### PR TITLE
fix: OpenRouter model routing regression + project input validation

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -343,12 +343,14 @@ def resolve_model_provider(model_id: str):
 
     if '/' in model_id:
         prefix, bare = model_id.split('/', 1)
-        # If prefix matches config provider, strip it
+        # If prefix matches config provider, strip it and use that provider directly
         if config_provider and prefix == config_provider:
             return bare, config_provider, config_base_url
-        # If prefix is a known direct-API provider, use it
-        # (base_url only applies when matching config provider)
-        if prefix in _PROVIDER_MODELS:
+        # If the config provider is openrouter (or unset/None), pass the full
+        # provider/model string through -- OpenRouter uses this as its model ID.
+        # Only strip the prefix and switch to a direct-API provider when the
+        # config is explicitly set to that direct provider.
+        if config_provider and config_provider != 'openrouter' and prefix in _PROVIDER_MODELS:
             return bare, prefix, None
 
     return model_id, config_provider, config_base_url

--- a/api/routes.py
+++ b/api/routes.py
@@ -140,7 +140,6 @@ def handle_get(handler, parsed):
 
     # ── Cron API (GET) ──
     if parsed.path == '/api/crons':
-        sys.path.insert(0, str(Path(__file__).parent.parent))
         from cron.jobs import list_jobs
         return j(handler, {'jobs': list_jobs(include_disabled=True)})
 
@@ -345,8 +344,14 @@ def handle_post(handler, parsed):
     if parsed.path == '/api/projects/create':
         try: require(body, 'name')
         except ValueError as e: return bad(handler, str(e))
+        import re as _re
+        name = body['name'].strip()[:128]
+        if not name: return bad(handler, 'name required')
+        color = body.get('color')
+        if color and not _re.match(r'^#[0-9a-fA-F]{3,8}$', color):
+            return bad(handler, 'Invalid color format')
         projects = load_projects()
-        proj = {'project_id': uuid.uuid4().hex[:12], 'name': body['name'], 'color': body.get('color'), 'created_at': time.time()}
+        proj = {'project_id': uuid.uuid4().hex[:12], 'name': name, 'color': color, 'created_at': time.time()}
         projects.append(proj)
         save_projects(projects)
         return j(handler, {'ok': True, 'project': proj})
@@ -354,11 +359,16 @@ def handle_post(handler, parsed):
     if parsed.path == '/api/projects/rename':
         try: require(body, 'project_id', 'name')
         except ValueError as e: return bad(handler, str(e))
+        import re as _re
         projects = load_projects()
         proj = next((p for p in projects if p['project_id'] == body['project_id']), None)
         if not proj: return bad(handler, 'Project not found', 404)
-        proj['name'] = body['name']
-        if 'color' in body: proj['color'] = body['color']
+        proj['name'] = body['name'].strip()[:128]
+        if 'color' in body:
+            color = body['color']
+            if color and not _re.match(r'^#[0-9a-fA-F]{3,8}$', color):
+                return bad(handler, 'Invalid color format')
+            proj['color'] = color
         save_projects(projects)
         return j(handler, {'ok': True, 'project': proj})
 
@@ -594,7 +604,6 @@ def _handle_cron_recent(handler, parsed):
     qs = parse_qs(parsed.query)
     since = float(qs.get('since', ['0'])[0])
     try:
-        sys.path.insert(0, str(Path(__file__).parent.parent))
         from cron.jobs import list_jobs
         jobs = list_jobs(include_disabled=True)
         completions = []


### PR DESCRIPTION
## Summary

Four fixes identified during a code review of the development branch.

### Fix 1 -- CRITICAL: Chat broken for all OpenRouter users

`resolve_model_provider()` was introduced in v0.16.2 to strip provider prefixes for direct-API providers. However it incorrectly treated OpenRouter model IDs like `openai/gpt-5.4-mini` as "use the OpenAI direct API", causing `AIAgent` to look for `OPENAI_API_KEY` (not configured for OpenRouter users), throw `RuntimeError`, and crash the stream thread before the SSE client connected. Every chat message returned "Connection lost" for anyone using OpenRouter as their provider.

**Fix:** Only strip prefix and route to direct-API when `config.provider` explicitly matches that provider. When `config.provider` is `openrouter` (or unset), pass the full `provider/model` string through unchanged -- which is exactly the format OpenRouter expects.

### Fix 2 -- Security: Project color field allows CSS injection

The `color` field in POST `/api/projects/create` and `/api/projects/rename` was stored without validation and set directly on `dot.style.background` in `sessions.js`. A direct API call with `color: "red; font-size:100px"` would inject arbitrary CSS properties.

**Fix:** Validate color matches `^#[0-9a-fA-F]{3,8}$` on the server; return 400 otherwise.

### Fix 3 -- Project name length limit

Project names had no server-side length cap. Added 128-char limit and rejection of names that are empty after stripping.

### Fix 4 -- Cleanup: Remove redundant sys.path.insert() calls

Two `sys.path.insert(0, ...)` calls before `from cron.jobs import` were redundant since the agent dir is already on sys.path via `api/config.py` at startup.

## Test plan

- [x] `pytest tests/` -- 214 passed, 23 pre-existing failures, 0 regressions

Generated with [Claude Code](https://claude.com/claude-code)
