### PR TITLE
feat: add GLM-5.1 to Z.AI model list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@
 
 ---
 
+## [v0.17.2] Model Update
+*April 2, 2026*
+
+### Enhancements
+- **GLM-5.1 added to Z.AI model list.** New model available in the dropdown
+  for Z.AI provider users. (Fixes #17)
+
+---
+
 ## [v0.17.1] Security + Bug Fixes
 *April 2, 2026 | 237 tests*
 

--- a/api/config.py
+++ b/api/config.py
@@ -297,6 +297,7 @@ _PROVIDER_MODELS = {
         {'id': 'gemini-2.5-pro',    'label': 'Gemini 2.5 Pro (via Nous)'},
     ],
     'zai': [
+        {'id': 'glm-5.1',            'label': 'GLM-5.1'},
         {'id': 'glm-5',              'label': 'GLM-5'},
         {'id': 'glm-5-turbo',        'label': 'GLM-5 Turbo'},
         {'id': 'glm-4.7',            'label': 'GLM-4.7'},


### PR DESCRIPTION
## Summary
- Adds `glm-5.1` to the hardcoded Z.AI provider model list in `api/config.py`
- Updates CHANGELOG with v0.17.2 entry

Fixes #17

## Test plan
- [ ] Verify GLM-5.1 appears in the model dropdown when Z.AI provider is configured
- [ ] Verify existing GLM models still appear and are selectable

🤖 Generated with [Claude Code](https://claude.com/claude-code)