### PR TITLE
fix: NameError on logger in custom endpoint model discovery

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -510,8 +510,8 @@ def get_available_models() -> dict:
                 if model_id and model_name:
                     auto_detected_models.append({'id': model_id, 'label': model_name})
                     detected_providers.add(provider.lower())
-        except Exception as e:
-            logger.debug(f"Failed to fetch models from custom endpoint: {e}")
+        except Exception:
+            pass  # custom endpoint unreachable or misconfigured -- fail silently
 
     # 5. Build model groups
     if detected_providers:


### PR DESCRIPTION
## Summary
- Fixes a `NameError` crash when custom endpoint model fetching fails — `logger` was never imported in `config.py`
- Replaces `logger.debug(...)` with a silent `pass` since this is expected behavior (endpoint unreachable or misconfigured)

Bug introduced in PR #18 (model discovery feature).

## Test plan
- [ ] Configure an invalid `base_url` in config.yaml, verify no crash on startup
- [ ] Valid `base_url` still discovers models correctly

Generated with [Claude Code](https://claude.com/claude-code)