### PR TITLE
docs: fix v0.19 test count (294→318), add Sprint 17 Tests section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 ---
 
 ## [v0.19] Sprint 17 -- Workspace Polish + Slash Commands + Settings
-*April 3, 2026 | 294 tests*
+*April 3, 2026 | 318 tests*
 
 ### Features
 - **Workspace breadcrumb navigation.** Clicking into subdirectories now shows a
@@ -28,8 +28,14 @@
 ### Architecture
 - New `static/commands.js` module (7th JS module): command registry, parser,
   autocomplete dropdown, and built-in command handlers.
-- `send_key` added to `_SETTINGS_DEFAULTS` in `api/config.py` with enum validation.
+- `send_key` added to `_SETTINGS_DEFAULTS` in `api/config.py` with enum validation
+  (`_SETTINGS_ENUM_VALUES` rejects unknown values server-side).
 - `S.currentDir` state tracking added to `ui.js` for workspace navigation.
+
+### Tests
+- 6 new tests in `test_sprint17.py`: send_key default, round-trip save with
+  cleanup, invalid value rejection, unknown key ignored, commands.js served,
+  workspace root listing. Total: **318 passed**.
 
 ---
 

--- a/SPRINTS.md
+++ b/SPRINTS.md
@@ -1,6 +1,6 @@
 # Hermes Web UI -- Forward Sprint Plan
 
-> Current state: v0.19 | 294 tests | Daily driver ready
+> Current state: v0.19 | 318 tests | Daily driver ready
 > This document plans the path from here to two targets:
 >
 > Target A: 1:1 feature parity with the Hermes CLI (everything you can do from the
@@ -317,7 +317,7 @@ handler for slash command autocomplete.
 - Voice input via Whisper
 - Workspace tree/accordion view (full implementation of Issue #22)
 
-**Tests:** 5 new. Total: 294.
+**Tests:** 6 new (test_sprint17.py). Total: 318.
 **Hermes CLI parity impact:** Low (slash commands add convenience)
 **Claude parity impact:** Medium (workspace nav, slash commands match Claude UX)
 
@@ -504,5 +504,5 @@ address.
 ---
 
 *Last updated: April 3, 2026*
-*Current version: v0.19 | 294 tests*
+*Current version: v0.19 | 318 tests*
 *Next sprint: Sprint 18 (Voice + Multimodal Input)*


### PR DESCRIPTION
## Summary

Corrects the test count in CHANGELOG.md and SPRINTS.md for v0.19 / Sprint 17.

### Problem
The Sprint 17 commit message said "5 new tests, total 294" but:
- test_sprint17.py has **6 tests** (not 5)
- The cumulative total is **318** (not 294)

The doc pass (PR #31) carried forward the wrong count from the commit message.

### Changes
- CHANGELOG.md: `294 tests` → `318 tests` in v0.19 header
- CHANGELOG.md: Added **Tests** section to v0.19 entry listing what the 6 tests cover
- CHANGELOG.md: Notes `_SETTINGS_ENUM_VALUES` server-side validation for send_key
- SPRINTS.md: `294 tests` → `318 tests` in Sprint 17 entry and footer
- SPRINTS.md: `5 new` → `6 new (test_sprint17.py)`

### No code changes
Docs only. All 318 tests pass.