### PR TITLE
fix: test_send_pop_in keyframe parser found wrong @keyframes block

### DIFF
--- a/tests/test_sprint20b.py
+++ b/tests/test_sprint20b.py
@@ -178,12 +178,12 @@ def test_send_pop_in_keyframes_defined():
     assert '@keyframes' in css
 
 
-def test_send_pop_in_uses_scale():
-    """send-pop-in keyframe must animate from a scaled-down state."""
-    css, _ = get_text("/static/style.css")
-    kf_idx = css.find('send-pop-in')
-    kf_start = css.rfind('@keyframes', 0, kf_idx)
-    # Find matching closing brace (simple scan)
+def _extract_keyframe(css, name):
+    """Extract the full @keyframes block for the given animation name."""
+    # Find '@keyframes <name>' directly (forward search) to avoid hitting
+    # an earlier keyframe when multiple are defined on the same line.
+    kf_start = css.find('@keyframes ' + name)
+    assert kf_start != -1, f"@keyframes {name} not found in CSS"
     depth = 0
     kf_end = kf_start
     for i, ch in enumerate(css[kf_start:], kf_start):
@@ -194,26 +194,20 @@ def test_send_pop_in_uses_scale():
             if depth == 0:
                 kf_end = i
                 break
-    kf_rule = css[kf_start:kf_end]
+    return css[kf_start:kf_end]
+
+
+def test_send_pop_in_uses_scale():
+    """send-pop-in keyframe must animate from a scaled-down state."""
+    css, _ = get_text("/static/style.css")
+    kf_rule = _extract_keyframe(css, 'send-pop-in')
     assert 'scale' in kf_rule
 
 
 def test_send_pop_in_uses_opacity():
     """send-pop-in keyframe must fade in (opacity transition)."""
     css, _ = get_text("/static/style.css")
-    kf_idx = css.find('send-pop-in')
-    kf_start = css.rfind('@keyframes', 0, kf_idx)
-    depth = 0
-    kf_end = kf_start
-    for i, ch in enumerate(css[kf_start:], kf_start):
-        if ch == '{':
-            depth += 1
-        elif ch == '}':
-            depth -= 1
-            if depth == 0:
-                kf_end = i
-                break
-    kf_rule = css[kf_start:kf_end]
+    kf_rule = _extract_keyframe(css, 'send-pop-in')
     assert 'opacity' in kf_rule
 
 


### PR DESCRIPTION
Two tests introduced with the send button polish PR were failing:

- test_send_pop_in_uses_scale
- test_send_pop_in_uses_opacity

Root cause: both tests used `css.rfind('@keyframes', 0, kf_idx)` to
locate the `send-pop-in` keyframe block. But since mic-pulse and
send-pop-in are both defined on the same minified CSS line, rfind landed
on `@keyframes mic-pulse` (which comes first) instead of
`@keyframes send-pop-in` — so the assertions checked the wrong block.

Fix: replace rfind with a direct `css.find('@keyframes send-pop-in')`
via a shared `_extract_keyframe(css, name)` helper. Forward search,
no ambiguity regardless of declaration order.

415 passed, 0 failed.