### PR TITLE
ci: multi-arch Docker builds + GitHub Releases on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,52 +5,48 @@ on:
     tags:
       - 'v*'
 
-permissions:
-  contents: write
-  packages: write
-
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
-
 jobs:
   release:
     runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
+    permissions:
+      contents: write   # required: create GitHub Release
+      packages: write   # required: push to ghcr.io
 
-      # Create GitHub Release from tag
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      # Create GitHub Release from tag with auto-generated notes
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@c062e08bd532815e2082a7e09ce9571a6592a176  # v2.2.1
         with:
           generate_release_notes: true
 
-      # Set up multi-arch build
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
+      # Set up multi-arch build (QEMU + Buildx)
+      - uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf  # v3.2.0
+      - uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349  # v3.7.1
 
-      # Log in to GHCR
+      # Log in to GitHub Container Registry
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567  # v3.3.0
         with:
-          registry: ${{ env.REGISTRY }}
+          registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Extract version tags (e.g. v0.19 -> 0.19, latest)
+      # Extract semver tags: e.g. v0.26 -> 0.26, 0.26 (major.minor), latest
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@369eb591f429131d6889c46b94e711f089e6ca96  # v5.6.1
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ghcr.io/${{ github.repository }}
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest,enable={{is_default_branch}}
 
-      # Build and push multi-arch image
+      # Build and push multi-arch image (amd64 + arm64)
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@ca877d9245fef47ef8e79a0c8ffc0a6d6b2e36a1  # v6.10.0
         with:
           context: .
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that triggers on tag push (`v*`) to:

1. **Create a GitHub Release** with auto-generated release notes (from commits since last tag)
2. **Build multi-arch Docker image** (linux/amd64 + linux/arm64) via QEMU
3. **Push to GHCR** at `ghcr.io/nesquena/hermes-webui` with semver tags (`0.19`, `0.19.0`, `latest`)
4. **Cache layers** via GitHub Actions cache for faster subsequent builds

Requested by @al-lac in #7.

### How it works

After merging, the next `git tag v0.X.Y && git push --tags` will:
- Create a release at https://github.com/nesquena/hermes-webui/releases
- Publish `ghcr.io/nesquena/hermes-webui:0.X.Y` and `:latest`

Users can then run:
```
docker pull ghcr.io/nesquena/hermes-webui:latest
```

### Files changed

| File | Change |
|------|--------|
| `.github/workflows/release.yml` | **NEW** -- 61 lines, single job |

## Test plan

- [ ] Merge PR, then create a test tag to trigger the workflow
- [ ] Verify GitHub Release is created with release notes
- [ ] Verify Docker image appears at https://github.com/nesquena/hermes-webui/pkgs/container/hermes-webui
- [ ] Verify multi-arch: `docker manifest inspect ghcr.io/nesquena/hermes-webui:latest` shows amd64 + arm64

Generated with [Claude Code](https://claude.com/claude-code)
