### PR TITLE
fix(ci): use standard version tags for GitHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,30 +13,30 @@ jobs:
       packages: write   # required: push to ghcr.io
 
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: actions/checkout@v4
 
       # Create GitHub Release from tag with auto-generated notes
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@c062e08bd532815e2082a7e09ce9571a6592a176  # v2.2.1
+        uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
 
       # Set up multi-arch build (QEMU + Buildx)
-      - uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf  # v3.2.0
-      - uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349  # v3.7.1
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
 
       # Log in to GitHub Container Registry
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567  # v3.3.0
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Extract semver tags: e.g. v0.26 -> 0.26, 0.26 (major.minor), latest
+      # Extract semver tags: e.g. v0.28 -> 0.28, latest
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@369eb591f429131d6889c46b94e711f089e6ca96  # v5.6.1
+        uses: docker/metadata-action@v5
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
@@ -46,7 +46,7 @@ jobs:
 
       # Build and push multi-arch image (amd64 + arm64)
       - name: Build and push Docker image
-        uses: docker/build-push-action@ca877d9245fef47ef8e79a0c8ffc0a6d6b2e36a1  # v6.10.0
+        uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
The SHA-pinned versions from the security hardening commit referenced non-existent commit hashes, causing the v0.28 workflow to fail with `unable to resolve action`. Switches to standard major version tags (`v4`, `v3`, `v2`, `v6`, `v5`) which are the recommended approach for well-known actions.

After merge, we need to push a new tag (v0.28.1) to re-trigger the pipeline.

Generated with [Claude Code](https://claude.com/claude-code)