### PR TITLE
fix(ci): Docker tag extraction for 2-part versions (v0.29)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,9 +40,8 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=match,pattern=v(.*),group=1
+            type=raw,value=latest
 
       # Build and push multi-arch image (amd64 + arm64)
       - name: Build and push Docker image


### PR DESCRIPTION
The `type=semver` pattern in `docker/metadata-action` requires 3-part versions (e.g. `v0.29.0`). Our tags use 2-part (`v0.29`), causing the metadata step to produce empty tags and the Docker build-push to fail.

Fix: use `type=match` with regex `v(.*)` to extract the version string directly, plus `type=raw,value=latest` unconditionally.

This fixes the failed release at https://github.com/nesquena/hermes-webui/actions/runs/23969230947