### PR TITLE
fix(ci): stricter semver regex for Docker tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,14 +33,14 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Extract semver tags: e.g. v0.28 -> 0.28, latest
+      # Extract tags from the git ref (supports vX.Y and vX.Y.Z formats)
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
-            type=match,pattern=v(.*),group=1
+            type=match,pattern=v(\d+\.\d+(?:\.\d+)?),group=1
             type=raw,value=latest
 
       # Build and push multi-arch image (amd64 + arm64)


### PR DESCRIPTION
Replaces `v(.*)` with `v(\d+\.\d+(?:\.\d+)?)` — only matches real version numbers, not arbitrary strings. Keeps `latest` unconditional since all tag pushes are releases. Supersedes PR #52.