### PR TITLE
docs: fix test count in v0.30 CHANGELOG (424 not 426)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 ---
 
 ## [v0.30] CLI Session Bridge (Community: @thadreber-web)
-*April 4, 2026 | 426 tests*
+*April 4, 2026 | 424 tests*
 
 ### Features
 - **CLI session bridge.** The WebUI now reads sessions from the hermes-agent's


### PR DESCRIPTION
One-line fix: CHANGELOG v0.30 entry said 426 tests, actual count is 424. No code changes.