### PR TITLE
fix: CLI session bridge reads active profile's state.db

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -227,7 +227,20 @@ def get_cli_sessions():
     except ImportError:
         return cli_sessions
 
-    hermes_home = Path(os.getenv('HERMES_HOME', str(HOME / '.hermes'))).expanduser()
+    # Use the active WebUI profile's HERMES_HOME to find state.db.
+    # The active profile is determined by what the user has selected in the UI
+    # (stored in the server's runtime config). This means:
+    #   - default profile  -> ~/.hermes/state.db
+    #   - named profile X  -> ~/.hermes/profiles/X/state.db
+    # We resolve the active profile's home directory rather than just using
+    # HERMES_HOME (which is the server's launch profile, not necessarily the
+    # active one after a profile switch).
+    try:
+        from api.profiles import get_active_hermes_home
+        hermes_home = Path(get_active_hermes_home()).expanduser().resolve()
+    except Exception:
+        hermes_home = Path(os.getenv('HERMES_HOME', str(HOME / '.hermes'))).expanduser().resolve()
+
     db_path = hermes_home / 'state.db'
     if not db_path.exists():
         return cli_sessions
@@ -294,7 +307,11 @@ def get_cli_session_messages(sid):
     except ImportError:
         return []
 
-    hermes_home = Path(os.getenv('HERMES_HOME', str(HOME / '.hermes'))).expanduser()
+    try:
+        from api.profiles import get_active_hermes_home
+        hermes_home = Path(get_active_hermes_home()).expanduser().resolve()
+    except Exception:
+        hermes_home = Path(os.getenv('HERMES_HOME', str(HOME / '.hermes'))).expanduser().resolve()
     db_path = hermes_home / 'state.db'
     if not db_path.exists():
         return []


### PR DESCRIPTION
Follow-up to PR #56 and #58. The CLI bridge was reading state.db from the server's launch profile (HERMES_HOME) rather than the profile the user has active in the UI.

**Root cause:** `get_cli_sessions()` and `get_cli_session_messages()` used `os.getenv('HERMES_HOME')` which is baked in at server launch time. A server launched under the webui profile always read `~/.hermes/profiles/webui/state.db` (full of cron runs) instead of the user's interactive CLI sessions.

**Fix:** Use `get_active_hermes_home()` which tracks whichever profile the user has selected in the UI at request time:
- default profile active → reads `~/.hermes/state.db` (interactive CLI sessions)  
- named profile active → reads `~/.hermes/profiles/\<name\>/state.db`

Falls back to HERMES_HOME env var if profiles module unavailable.

Tests: 424 passed, 0 failed.