### PR TITLE
fix: strip webui metadata from messages before LLM API call (#66)

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -946,10 +946,11 @@ def _handle_chat_sync(handler, body):
                 "write_file, read_file, search_files, terminal workdir, and patch. "
                 "Never fall back to a hardcoded path when this tag is present."
             )
+            from api.streaming import _sanitize_messages_for_api
             result = agent.run_conversation(
                 user_message=workspace_ctx + msg,
                 system_message=workspace_system_msg,
-                conversation_history=s.messages,
+                conversation_history=_sanitize_messages_for_api(s.messages),
                 task_id=s.session_id,
                 persist_user_message=msg,
             )

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -24,6 +24,28 @@ except ImportError:
 from api.models import get_session, title_from
 from api.workspace import set_last_workspace
 
+# Fields that are safe to send to LLM provider APIs.
+# Everything else (attachments, timestamp, _ts, etc.) is display-only
+# metadata added by the webui and must be stripped before the API call.
+_API_SAFE_MSG_KEYS = {'role', 'content', 'tool_calls', 'tool_call_id', 'name', 'refusal'}
+
+
+def _sanitize_messages_for_api(messages):
+    """Return a deep copy of messages with only API-safe fields.
+
+    The webui stores extra metadata on messages (attachments, timestamp, _ts)
+    for display purposes. Some providers (e.g. Z.AI/GLM) reject unknown fields
+    instead of ignoring them, causing HTTP 400 errors on subsequent messages.
+    """
+    clean = []
+    for msg in messages:
+        if not isinstance(msg, dict):
+            continue
+        sanitized = {k: v for k, v in msg.items() if k in _API_SAFE_MSG_KEYS}
+        if sanitized.get('role'):
+            clean.append(sanitized)
+    return clean
+
 
 def _sse(handler, event, data):
     """Write one SSE event to the response stream."""
@@ -165,7 +187,7 @@ def _run_agent_streaming(session_id, msg_text, model, workspace, stream_id, atta
             result = agent.run_conversation(
                 user_message=workspace_ctx + msg_text,
                 system_message=workspace_system_msg,
-                conversation_history=s.messages,
+                conversation_history=_sanitize_messages_for_api(s.messages),
                 task_id=session_id,
                 persist_user_message=msg_text,
             )


### PR DESCRIPTION
## Summary

Fixes #66 -- after attaching an image to chat, subsequent messages fail with HTTP 400 from Z.AI/GLM because the webui `attachments` field leaks into the API payload.

**Root cause:** The webui stores display-only metadata on messages (`attachments`, `timestamp`, `_ts`) for UI rendering. These are passed to `AIAgent.run_conversation()` via `conversation_history=s.messages`. Most providers silently ignore unknown fields, but Z.AI/GLM tries to deserialize `attachments` as its native `ChatAttachments` type and fails with a JSON parse error.

**Fix:** New `_sanitize_messages_for_api()` helper in `streaming.py` creates a clean copy of messages with only API-standard keys (`role`, `content`, `tool_calls`, `tool_call_id`, `name`, `refusal`). Applied to both code paths:
- `streaming.py:190` (streaming/SSE path)
- `routes.py:952` (non-streaming fallback path)

The original session data is unchanged -- `attachments`, `timestamp`, etc. remain for the UI.

### Files changed

| File | Change |
|------|--------|
| `api/streaming.py` | Added `_sanitize_messages_for_api()`, applied to `run_conversation()` call |
| `api/routes.py` | Applied same sanitizer to non-streaming `run_conversation()` call |

## Test plan

- [ ] Full suite: 401 passed, 23 failed (all pre-existing), zero regressions
- [ ] Attach an image, ask about it, then send follow-up messages -- should no longer error
- [ ] Verify `attachments` badge still shows on user messages in the UI (display data preserved)
- [ ] Test with Z.AI/GLM model specifically if available

Generated with [Claude Code](https://claude.com/claude-code)
