### PR TITLE
fix: UI polish -- image error, CLI badge overlap, dropdown z-index

### DIFF
--- a/static/boot.js
+++ b/static/boot.js
@@ -169,7 +169,7 @@ $('importFileInput').onchange=async(e)=>{
 // btnRefreshFiles is now panel-icon-btn in header (see HTML)
 function clearPreview(){
   const pa=$('previewArea');if(pa)pa.classList.remove('visible');
-  const pi=$('previewImg');if(pi)pi.src='';
+  const pi=$('previewImg');if(pi){pi.onerror=null;pi.src='';}
   const pm=$('previewMd');if(pm)pm.innerHTML='';
   const pc=$('previewCode');if(pc)pc.textContent='';
   const pp=$('previewPathText');if(pp)pp.textContent='';

--- a/static/style.css
+++ b/static/style.css
@@ -129,7 +129,7 @@
   .topbar-chips{display:flex;gap:6px;align-items:center;flex-shrink:0;}
   .chip{font-size:11px;padding:4px 10px;border-radius:999px;background:rgba(255,255,255,0.05);border:1px solid rgba(255,255,255,.1);color:var(--muted);font-weight:500;}
   .chip.model{color:var(--blue);border-color:rgba(124,185,255,0.35);background:rgba(124,185,255,0.1);}
-  .messages{flex:1;overflow-y:auto;display:flex;flex-direction:column;min-height:0;}
+  .messages{flex:1;overflow-y:auto;display:flex;flex-direction:column;min-height:0;position:relative;z-index:0;}
   .messages-inner{max-width:800px;margin:0 auto;width:100%;padding:20px 24px 32px;display:flex;flex-direction:column;}
   .msg-row{padding:10px 0;}
   .msg-row+.msg-row{border-top:none;}
@@ -692,6 +692,7 @@ body.resizing{user-select:none;cursor:col-resize;}
 /* ── CLI session items in sidebar ── */
 .session-item.cli-session {
   border-left-color: var(--gold);
+  padding-right: 36px; /* make room for session-actions overlay */
 }
 .session-item.cli-session::after {
   content: 'cli';
@@ -701,6 +702,7 @@ body.resizing{user-select:none;cursor:col-resize;}
   letter-spacing: .04em;
   color: var(--gold);
   opacity: .5;
-  margin-left: 4px;
+  margin-left: auto;
   flex-shrink: 0;
+  pointer-events: none; /* don't block clicks on session-actions beneath */
 }


### PR DESCRIPTION
## Summary

Three UI glitches fixed in 2 files (5 lines changed).

### 1. Image preview "Could not load image" error (closes #68)
**Bug:** After viewing an image in the workspace panel, clicking refresh or sending a message triggered a persistent "Could not load image" error banner.
**Root cause:** `clearPreview()` set `previewImg.src = ''` which fired the stale `onerror` handler from the previous image load.
**Fix:** Null out `onerror` before clearing `src` in `boot.js:172`.

### 2. CLI session badge covers delete button (closes #69)
**Bug:** Sessions labeled "CLI" had the badge overlapping the hover-revealed delete/action buttons, making them unreachable.
**Root cause:** The `::after` pseudo-element for the "cli" label occupied the same flex position as the `.session-actions` absolute overlay.
**Fix:** Add `padding-right: 36px` to `.cli-session`, use `margin-left: auto` to push badge right, add `pointer-events: none` so clicks pass through to actions beneath.

### 3. Tool cards visible through profile dropdown
**Bug:** When the profile picker dropdown was open, tool call cards in the chat area rendered on top of it.
**Root cause:** The `.messages` container had no stacking context, so its children could compete with the profile dropdown (z-index: 200).
**Fix:** Add `position: relative; z-index: 0` to `.messages` to establish a stacking context.

### Files changed

| File | Lines | Fix |
|------|-------|-----|
| `static/boot.js` | 1 | onerror null before src clear |
| `static/style.css` | 4 | CLI badge padding + pointer-events, messages z-index |

## Test plan

- [ ] Open an image in workspace, click refresh -- no error banner
- [ ] Enable "Show CLI sessions", hover a CLI session -- delete button reachable
- [ ] Open profile dropdown while tool cards are visible -- dropdown renders on top
- [ ] Full suite: 401 passed, 23 failed (pre-existing), zero regressions

Generated with [Claude Code](https://claude.com/claude-code)
