### PR TITLE
fix: default STATE_DIR to ~/.hermes/webui

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -31,7 +31,7 @@ PORT = int(os.getenv('HERMES_WEBUI_PORT', '8787'))
 # ── State directory (env-overridable, never inside repo) ──────────────────────
 STATE_DIR = Path(os.getenv(
     'HERMES_WEBUI_STATE_DIR',
-    str(HOME / '.hermes' / 'webui-mvp')
+    str(HOME / '.hermes' / 'webui')
 )).expanduser().resolve()
 
 SESSION_DIR           = STATE_DIR / 'sessions'


### PR DESCRIPTION
The previous default was `~/.hermes/webui-mvp` — an internal development repo name that leaks implementation details and is meaningless to anyone deploying the public repo.

Changed to `~/.hermes/webui`, a clean generic default appropriate for any deployment.

The env var `HERMES_WEBUI_STATE_DIR` continues to override this for anyone running multiple instances side by side.