### PR TITLE
fix: start.sh state dir default webui-mvp -> webui

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -198,7 +198,7 @@ hdr "Starting Hermes Web UI..."
 
 LOG="/tmp/hermes-webui-${PORT}.log"
 export HERMES_WEBUI_HOST="${HERMES_WEBUI_HOST:-127.0.0.1}"
-export HERMES_WEBUI_STATE_DIR="${HERMES_WEBUI_STATE_DIR:-${HERMES_HOME}/webui-mvp}"
+export HERMES_WEBUI_STATE_DIR="${HERMES_WEBUI_STATE_DIR:-${HERMES_HOME}/webui}"
 
 nohup "${PYTHON}" "${REPO_ROOT}/server.py" \
     > "${LOG}" 2>&1 &


### PR DESCRIPTION
Companion fix to PR #72. `start.sh` line 201 still had the old `webui-mvp` hardcoded default. Changed to `webui` to match `api/config.py`.\n\nAll three places that define a default state dir now consistently use `~/.hermes/webui`:\n- `api/config.py` (fixed in #72)\n- `start.sh` (this PR)\n- `Dockerfile` / `docker-compose.yml` (already correct -- uses `/data`)