### PR TITLE
fix: pass api_key to AIAgent for non-Anthropic /anthropic providers

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -888,8 +888,21 @@ def _handle_chat_sync(handler, body):
         with CHAT_LOCK:
             from api.config import resolve_model_provider
             _model, _provider, _base_url = resolve_model_provider(s.model)
+            # Resolve API key via Hermes runtime provider (matches gateway behaviour)
+            _api_key = None
+            try:
+                from hermes_cli.runtime_provider import resolve_runtime_provider
+                _rt = resolve_runtime_provider()
+                _api_key = _rt.get("api_key")
+                # Also use runtime provider/base_url if the webui config didn't resolve them
+                if not _provider:
+                    _provider = _rt.get("provider")
+                if not _base_url:
+                    _base_url = _rt.get("base_url")
+            except Exception as _e:
+                print(f"[webui] WARNING: resolve_runtime_provider failed: {_e}", flush=True)
             agent = AIAgent(model=_model, provider=_provider, base_url=_base_url,
-                           platform='cli', quiet_mode=True,
+                           api_key=_api_key, platform='cli', quiet_mode=True,
                            enabled_toolsets=CLI_TOOLSETS, session_id=s.session_id)
             workspace_ctx = f"[Workspace: {s.workspace}]\n"
             workspace_system_msg = (

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -113,6 +113,19 @@ def _run_agent_streaming(session_id, msg_text, model, workspace, stream_id, atta
                 raise ImportError("AIAgent not available -- check that hermes-agent is on sys.path")
             resolved_model, resolved_provider, resolved_base_url = resolve_model_provider(model)
 
+            # Resolve API key via Hermes runtime provider (matches gateway behaviour)
+            resolved_api_key = None
+            try:
+                from hermes_cli.runtime_provider import resolve_runtime_provider
+                _rt = resolve_runtime_provider()
+                resolved_api_key = _rt.get("api_key")
+                if not resolved_provider:
+                    resolved_provider = _rt.get("provider")
+                if not resolved_base_url:
+                    resolved_base_url = _rt.get("base_url")
+            except Exception as _e:
+                print(f"[webui] WARNING: resolve_runtime_provider failed: {_e}", flush=True)
+
             # Read per-profile config at call time (not module-level snapshot)
             from api.config import get_config as _get_config
             _cfg = _get_config()
@@ -140,6 +153,7 @@ def _run_agent_streaming(session_id, msg_text, model, workspace, stream_id, atta
                 model=resolved_model,
                 provider=resolved_provider,
                 base_url=resolved_base_url,
+                api_key=resolved_api_key,
                 platform='cli',
                 quiet_mode=True,
                 enabled_toolsets=_toolsets,


### PR DESCRIPTION
## Summary

Fixes #77.

When a user's Hermes config uses a non-Anthropic provider whose base URL ends in `/anthropic` (e.g. MiniMax at `https://api.minimax.io/anthropic`), the WebUI fails silently with `APIConnectionError: Connection error` on every chat request, while the `hermes` CLI and messaging gateway work correctly with the same config.

## Root cause

Both `api/routes.py` and `api/streaming.py` constructed `AIAgent` using only `(model, provider, base_url)` from `resolve_model_provider()` and never passed `api_key`.

In `run_agent.py`, when the base URL ends in `/anthropic`, `AIAgent` uses the `anthropic_messages` adapter. It only falls back to `ANTHROPIC_TOKEN` when `provider == "anthropic"` — a safety check to avoid leaking Anthropic credentials to third-party endpoints. For MiniMax (and similar), the effective key becomes `""`, and the auth failure surfaces as a generic "Connection error" after three retries.

The CLI and gateway resolve the key via `hermes_cli.runtime_provider.resolve_runtime_provider()`, which reads `MINIMAX_API_KEY` (and similar) from `~/.hermes/.env`. This patch does the same before creating the `AIAgent` in both chat paths.

## Changes

- `api/streaming.py`: resolve `api_key` via `resolve_runtime_provider()` and pass it to `AIAgent()`.  Also fill in `provider` / `base_url` from the runtime provider when the webui config didn't resolve them.
- `api/routes.py`: same fix for the non-streaming chat path.

Both changes wrap the import/call in `try/except` so a missing `hermes_cli` (non-Hermes installs, alternate backends) still allows the webui to fall through to its existing behaviour.

## Testing

Verified locally with a MiniMax config (provider `minimax`, base_url `https://api.minimax.io/anthropic`, `MINIMAX_API_KEY` in `~/.hermes/.env`):

- **Before:** every message produced three retried `APIConnectionError: Connection error` entries in the webui log, no response to the user.
- **After:** chat works immediately, same as the CLI and gateway.

Existing Anthropic / OpenRouter configs are unaffected because:
- Native Anthropic still resolves its token inside `AIAgent` via `resolve_anthropic_token()`.
- OpenRouter clients already pass their own auth; `resolve_runtime_provider()` returns the same values `resolve_model_provider()` would have returned when no key needs to be overridden.