### PR TITLE
docs: add community feature ideas from PR #75 to roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -192,8 +192,17 @@
 - [x] Multi-profile support — create, switch, delete profiles (Sprint 22, Issue #28)
 
 ### Advanced / Future
+- [ ] Subagent session tree -- show subagent hierarchy in sidebar with expand/collapse (PR #75)
+- [ ] Specialized tool card renderers -- diff viewer, terminal output, todo checklist views (PR #75)
+- [ ] Streaming performance -- requestAnimationFrame throttled token rendering for smoother output (PR #75)
+- [ ] Git integration modal -- branch, status, log, diff viewer in workspace panel (PR #75)
+- [ ] Collapsible date groups -- click Today/Yesterday/Earlier headers to collapse session groups (PR #75)
+- [ ] LLM-generated session titles -- auto-title via small model instead of first-message substring (PR #75)
+- [ ] Workspace git detection -- show branch name, dirty status in workspace header (PR #75)
+- [ ] Clarify dialog -- agent can ask clarifying questions that block until user responds (PR #75)
+- [ ] Gateway approval polling -- support blocking approvals from messaging gateway (PR #75)
+- [ ] Unified session storage -- SessionDB shared between webui and CLI (PR #75)
 - [ ] TTS playback of responses (deferred)
-- [ ] Subagent delegation cards (deferred)
 - [x] Background task cancel (activity bar Cancel button)
 - [ ] Code execution cell (deferred)
 - [ ] Desktop application (deferred)


### PR DESCRIPTION
Extracted new feature ideas from @MartinNielsenDev's PR #75 and added them to the Advanced/Future section. These are features we don't currently have that are worth building ourselves even if PR #75 doesn't land as-is.

**New roadmap items (all from PR #75):**
- Subagent session tree (sidebar hierarchy)
- Specialized tool card renderers (diff/terminal/todo)
- rAF-throttled streaming performance
- Git integration modal
- Collapsible date groups in session list
- LLM-generated session titles
- Workspace git detection
- Clarify dialog (blocking agent questions)
- Gateway approval polling
- Unified session storage (SessionDB)

Skipped: theme/icon changes (aesthetic), Telegram indicator (niche).

Generated with [Claude Code](https://claude.com/claude-code)