### PR TITLE
perf: rAF-throttled token streaming for smoother rendering

### DIFF
--- a/static/messages.js
+++ b/static/messages.js
@@ -103,14 +103,25 @@ async function send(){
   // ── Shared SSE handler wiring (used for initial connection and reconnect) ──
   let _reconnectAttempted=false;
 
+  // rAF-throttled rendering: buffer tokens, render at most once per frame
+  let _renderPending=false;
+  function _scheduleRender(){
+    if(_renderPending) return;
+    _renderPending=true;
+    requestAnimationFrame(()=>{
+      _renderPending=false;
+      if(assistantBody) assistantBody.innerHTML=renderMd(assistantText);
+      scrollIfPinned();
+    });
+  }
+
   function _wireSSE(source){
     source.addEventListener('token',e=>{
       if(!S.session||S.session.session_id!==activeSid) return;
       const d=JSON.parse(e.data);
       assistantText+=d.text;
       ensureAssistantRow();
-      assistantBody.innerHTML=renderMd(assistantText);
-      scrollIfPinned();
+      _scheduleRender();
     });
 
     source.addEventListener('tool',e=>{


### PR DESCRIPTION
Token streaming now uses requestAnimationFrame to batch DOM writes. Instead of calling `renderMd()` on every single token event (~100/sec), multiple tokens arriving between frames are batched into one render (~60/sec at 60fps).

One small function added (`_scheduleRender()`), one line changed in the token handler. No behavior change -- just smoother rendering during heavy agentic output.

Inspired by PR #75 (@MartinNielsenDev).

Tests: 401 passed, 23 pre-existing failures, zero regressions.

Generated with [Claude Code](https://claude.com/claude-code)