### PR TITLE
fix: two issues from post-merge review of PRs #82 and #83

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -219,8 +219,9 @@ def handle_get(handler, parsed):
         sid = qs.get('session_id', [''])[0]
         if not sid:
             return bad(handler, 'session_id required')
-        s = get_session(sid)
-        if not s:
+        try:
+            s = get_session(sid)
+        except KeyError:
             return bad(handler, 'Session not found', 404)
         from api.workspace import git_info_for_workspace
         info = git_info_for_workspace(Path(s.workspace))

--- a/static/style.css
+++ b/static/style.css
@@ -192,7 +192,7 @@
   /* Context usage indicator */
   .ctx-indicator{display:flex;align-items:center;gap:6px;padding:2px 4px;flex-shrink:1;min-width:0;}
   .ctx-bar-wrap{width:70px;height:5px;border-radius:3px;background:rgba(255,255,255,.08);overflow:hidden;flex-shrink:0;}
-  .ctx-bar{display:block;height:100%;border-radius:3px;transition:width .4s ease,background .4s ease;min-width:2px;background:var(--teal);}
+  .ctx-bar{display:block;height:100%;border-radius:3px;transition:width .4s ease,background .4s ease;min-width:2px;background:var(--blue);}
   .ctx-bar.ctx-mid{background:#e6a817;}
   .ctx-bar.ctx-high{background:#e05252;}
   .ctx-label{font-size:9px;color:var(--muted);white-space:nowrap;font-variant-numeric:tabular-nums;}


### PR DESCRIPTION
Post-merge review of the recent community PR batch found two small bugs:\n\n**1. /api/git-info returns 500 instead of 404 on bad session_id (PR #82)**\n`get_session(sid)` raises `KeyError` when the session doesn't exist -- it never returns `None`. The `if not s` check was unreachable. Wrapped in `try/except KeyError`.\n\n**2. .ctx-bar uses undefined --teal variable (PR #83)**\n`--teal` is not defined anywhere in the CSS. The context bar was rendering with no color (falling back to transparent). Replaced with `--blue` which is defined in `:root` and fits the palette.