### PR TITLE
docs: v0.31 — update all markdown for Sprint 24 features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1098,4 +1098,4 @@ Three-panel layout: sessions sidebar, chat area, workspace panel.
 
 ---
 
-*Last updated: v0.30.1, April 4, 2026 | Tests: 424*
+*Last updated: v0.31, April 4, 2026 | Tests: 424*

--- a/README.md
+++ b/README.md
@@ -262,6 +262,8 @@ across 22 test files.
 - Code block copy button with "Copied!" feedback
 - Syntax highlighting via Prism.js (Python, JS, bash, JSON, SQL, and more)
 - Safe HTML rendering in AI responses (bold, italic, code converted to markdown)
+- rAF-throttled token streaming for smoother rendering during long responses
+- Context usage indicator in composer footer -- token count, cost, and fill bar (model-aware)
 
 ### Sessions
 - Create, rename, duplicate, delete, search by title and message content
@@ -269,7 +271,7 @@ across 22 test files.
 - Archive sessions (hide without deleting, toggle to show)
 - Session projects -- named groups with colors for organizing sessions
 - Session tags -- add #tag to titles for colored chips and click-to-filter
-- Grouped by Today / Yesterday / Earlier in the sidebar
+- Grouped by Today / Yesterday / Earlier in the sidebar (collapsible date groups)
 - Download as Markdown transcript, full JSON export, or import from JSON
 - Sessions persist across page reloads and SSH tunnel reconnects
 - Browser tab title reflects the active session name
@@ -283,6 +285,7 @@ across 22 test files.
 - Edit, create, delete, and rename files; create folders
 - Binary file download (auto-detected from server)
 - File preview auto-closes on directory navigation (with unsaved-edit guard)
+- Git detection -- branch name and dirty file count badge in workspace header
 - Right panel is drag-resizable
 - Syntax highlighted code preview (Prism.js)
 
@@ -347,26 +350,26 @@ across 22 test files.
 ## Architecture
 
 ```
-server.py               HTTP routing shell + auth middleware (~81 lines)
+server.py               HTTP routing shell + auth middleware (~83 lines)
 api/
   auth.py               Optional password authentication, signed cookies (~149 lines)
-  config.py             Discovery, globals, model detection, reloadable config (~702 lines)
+  config.py             Discovery, globals, model detection, reloadable config (~726 lines)
   helpers.py            HTTP helpers, security headers (~71 lines)
-  models.py             Session model + CRUD (~146 lines)
+  models.py             Session model + CRUD + CLI bridge (~338 lines)
   profiles.py           Profile state management, hermes_cli wrapper (~366 lines)
-  routes.py             All GET + POST route handlers (~1180 lines)
-  streaming.py          SSE engine, run_agent, cancel support (~272 lines)
+  routes.py             All GET + POST route handlers (~1314 lines)
+  streaming.py          SSE engine, run_agent, cancel support (~332 lines)
   upload.py             Multipart parser, file upload handler (~78 lines)
-  workspace.py          File ops, workspace helpers (~245 lines)
+  workspace.py          File ops, workspace helpers, git detection (~288 lines)
 static/
-  index.html            HTML template (~364 lines)
-  style.css             All CSS incl. mobile responsive (~670 lines)
-  ui.js                 DOM helpers, renderMd, tool cards, file tree (~1002 lines)
-  workspace.js          File preview, file ops (~191 lines)
-  sessions.js           Session CRUD, list rendering, search (~556 lines)
-  messages.js           send(), SSE handlers, approval, transcript (~337 lines)
-  panels.js             Cron, skills, memory, profiles, settings (~1030 lines)
-  commands.js           Slash command autocomplete (~156 lines)
+  index.html            HTML template (~388 lines)
+  style.css             All CSS incl. mobile responsive (~726 lines)
+  ui.js                 DOM helpers, renderMd, tool cards, context indicator (~1063 lines)
+  workspace.js          File preview, file ops, git badge (~247 lines)
+  sessions.js           Session CRUD, collapsible groups, search (~589 lines)
+  messages.js           send(), SSE handlers, rAF throttle (~352 lines)
+  panels.js             Cron, skills, memory, profiles, settings (~1146 lines)
+  commands.js           Slash command autocomplete (~170 lines)
   boot.js               Mobile nav, voice input, boot IIFE (~338 lines)
 tests/
   conftest.py           Isolated test server (port 8788)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,7 +3,7 @@
 > Goal: Full 1:1 parity with the Hermes CLI experience via a clean dark web UI.
 > Everything you can do from the CLI terminal, you can do from this UI.
 >
-> Last updated: v0.29 (April 4, 2026)
+> Last updated: v0.31 (April 4, 2026)
 > Tests: 424 total (401 passing, 23 pre-existing failures)
 > Source: <repo>/
 
@@ -194,9 +194,10 @@
 ### Advanced / Future
 - [ ] Subagent session tree -- show subagent hierarchy in sidebar with expand/collapse (PR #75)
 - [ ] Specialized tool card renderers -- diff viewer, terminal output, todo checklist views (PR #75)
-- [ ] Streaming performance -- requestAnimationFrame throttled token rendering for smoother output (PR #75)
-- [ ] Git integration modal -- branch, status, log, diff viewer in workspace panel (PR #75)
-- [ ] Collapsible date groups -- click Today/Yesterday/Earlier headers to collapse session groups (PR #75)
+- [x] Streaming performance -- rAF-throttled token rendering (Sprint 24, PR #81)
+- [x] Workspace git detection -- branch name and dirty status badge (Sprint 24, PR #82)
+- [x] Collapsible date groups -- click group headers to collapse (Sprint 24, PR #80)
+- [x] Context usage indicator -- token count and cost in composer footer (Sprint 24, PR #83)
 - [ ] LLM-generated session titles -- auto-title via small model instead of first-message substring (PR #75)
 - [ ] Workspace git detection -- show branch name, dirty status in workspace header (PR #75)
 - [ ] Clarify dialog -- agent can ask clarifying questions that block until user responds (PR #75)

--- a/SPRINTS.md
+++ b/SPRINTS.md
@@ -1,6 +1,6 @@
 # Hermes Web UI -- Forward Sprint Plan
 
-> Current state: v0.30.1 | 424 tests | Daily driver ready
+> Current state: v0.31 | 424 tests | Daily driver ready
 > This document plans the path from here to two targets:
 >
 > Target A: 1:1 feature parity with the Hermes CLI (everything you can do from the
@@ -898,5 +898,5 @@ genuinely differentiating for an open-source project
 ---
 
 *Last updated: April 4, 2026*
-*Current version: v0.30.1 | 424 tests*
+*Current version: v0.31 | 424 tests*
 *Next sprint: Sprint 24 (Web Polish + Bug Fix Pass)*


### PR DESCRIPTION
Update README, ROADMAP, SPRINTS, CHANGELOG to reflect Sprint 24 features (PRs #79-#83). Docs only.