### PR TITLE
feat: opt-in state.db sync for /insights visibility (#92)

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -652,6 +652,7 @@ _SETTINGS_DEFAULTS = {
     'send_key': 'enter',  # 'enter' or 'ctrl+enter'
     'show_token_usage': False,  # show input/output token badge below assistant messages
     'show_cli_sessions': False,  # merge CLI sessions from state.db into the sidebar
+    'sync_to_insights': False,  # mirror WebUI token usage to state.db for /insights
     'password_hash': None,  # SHA-256 hash; None = auth disabled
 }
 
@@ -671,7 +672,7 @@ _SETTINGS_ALLOWED_KEYS = set(_SETTINGS_DEFAULTS.keys()) - {'password_hash'}
 _SETTINGS_ENUM_VALUES = {
     'send_key': {'enter', 'ctrl+enter'},
 }
-_SETTINGS_BOOL_KEYS = {'show_token_usage', 'show_cli_sessions'}
+_SETTINGS_BOOL_KEYS = {'show_token_usage', 'show_cli_sessions', 'sync_to_insights'}
 
 def save_settings(settings: dict) -> dict:
     """Save settings to disk. Returns the merged settings. Ignores unknown keys."""

--- a/api/routes.py
+++ b/api/routes.py
@@ -995,6 +995,20 @@ def _handle_chat_sync(handler, body):
         else: os.environ['HERMES_SESSION_KEY'] = old_session_key
     s.messages = result.get('messages') or s.messages
     s.title = title_from(s.messages, s.title); s.save()
+    # Sync to state.db for /insights (opt-in setting)
+    try:
+        if load_settings().get('sync_to_insights'):
+            from api.state_sync import sync_session_usage
+            sync_session_usage(
+                session_id=s.session_id,
+                input_tokens=s.input_tokens or 0,
+                output_tokens=s.output_tokens or 0,
+                estimated_cost=s.estimated_cost,
+                model=s.model,
+                title=s.title,
+            )
+    except Exception:
+        pass
     return j(handler, {
         'answer': result.get('final_response') or '',
         'status': 'done' if result.get('completed', True) else 'partial',

--- a/api/state_sync.py
+++ b/api/state_sync.py
@@ -1,0 +1,93 @@
+"""
+Hermes Web UI -- Optional state.db sync bridge.
+
+Mirrors WebUI session metadata (token usage, title, model) into the
+hermes-agent state.db so that /insights, session lists, and cost
+tracking include WebUI activity.
+
+This is opt-in via the 'sync_to_insights' setting (default: off).
+All operations are wrapped in try/except -- if state.db is unavailable,
+locked, or the schema doesn't match, the WebUI continues normally.
+
+The bridge uses absolute token counts (not deltas) because the WebUI
+Session object already accumulates totals across turns. This avoids
+any double-counting risk.
+"""
+import os
+from pathlib import Path
+
+
+def _get_state_db():
+    """Get a HermesState instance for the active profile's state.db.
+    Returns None if hermes_state is not importable or DB is unavailable.
+    """
+    try:
+        from hermes_state import HermesState
+    except ImportError:
+        return None
+
+    try:
+        from api.profiles import get_active_hermes_home
+        hermes_home = Path(get_active_hermes_home()).expanduser().resolve()
+    except Exception:
+        hermes_home = Path(os.getenv('HERMES_HOME', str(Path.home() / '.hermes')))
+
+    db_path = hermes_home / 'state.db'
+    if not db_path.exists():
+        return None
+
+    try:
+        return HermesState(str(db_path))
+    except Exception:
+        return None
+
+
+def sync_session_start(session_id, model=None):
+    """Register a WebUI session in state.db (idempotent).
+    Called when a session's first message is sent.
+    """
+    try:
+        db = _get_state_db()
+        if not db:
+            return
+        db.ensure_session(
+            session_id=session_id,
+            source='webui',
+            model=model,
+        )
+    except Exception:
+        pass  # never crash the WebUI for sync failures
+
+
+def sync_session_usage(session_id, input_tokens=0, output_tokens=0,
+                       estimated_cost=None, model=None, title=None):
+    """Update token usage and title for a WebUI session in state.db.
+    Called after each turn completes. Uses absolute=True to set totals
+    (the WebUI Session already accumulates across turns).
+    """
+    try:
+        db = _get_state_db()
+        if not db:
+            return
+        # Ensure session exists first (idempotent)
+        db.ensure_session(session_id=session_id, source='webui', model=model)
+        # Set absolute token counts
+        db.update_token_counts(
+            session_id=session_id,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            estimated_cost_usd=estimated_cost,
+            model=model,
+            absolute=True,
+        )
+        # Update title if we have one
+        if title:
+            try:
+                db._execute_write(
+                    "UPDATE sessions SET title = ? WHERE id = ?",
+                    (title, session_id),
+                )
+            except Exception:
+                pass
+    except Exception:
+        pass  # never crash the WebUI for sync failures

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -309,6 +309,21 @@ def _run_agent_streaming(session_id, msg_text, model, workspace, stream_id, atta
                             m['attachments'] = attachments
                             break
             s.save()
+            # Sync to state.db for /insights (opt-in setting)
+            try:
+                from api.config import load_settings as _load_settings
+                if _load_settings().get('sync_to_insights'):
+                    from api.state_sync import sync_session_usage
+                    sync_session_usage(
+                        session_id=s.session_id,
+                        input_tokens=s.input_tokens or 0,
+                        output_tokens=s.output_tokens or 0,
+                        estimated_cost=s.estimated_cost,
+                        model=model,
+                        title=s.title,
+                    )
+            except Exception:
+                pass  # never crash the stream for sync failures
             usage = {'input_tokens': input_tokens, 'output_tokens': output_tokens, 'estimated_cost': estimated_cost}
             # Include context window data from the agent's compressor for the UI indicator
             _cc = getattr(agent, 'context_compressor', None)

--- a/static/index.html
+++ b/static/index.html
@@ -343,6 +343,13 @@
         </label>
         <div style="font-size:11px;color:var(--muted);margin-top:4px">Merges sessions from the Hermes CLI (state.db) into the session list. Click a CLI session to import it and continue the conversation.</div>
       </div>
+      <div class="settings-field">
+        <label style="display:flex;align-items:center;gap:8px;cursor:pointer">
+          <input type="checkbox" id="settingsSyncInsights" style="width:15px;height:15px;accent-color:var(--accent)">
+          Sync usage to /insights
+        </label>
+        <div style="font-size:11px;color:var(--muted);margin-top:4px">Mirrors WebUI token usage to state.db so <code>hermes /insights</code> includes browser session data. Off by default.</div>
+      </div>
       <div class="settings-field" style="border-top:1px solid var(--border);padding-top:12px;margin-top:8px">
         <label for="settingsPassword">Access Password</label>
         <div style="font-size:11px;color:var(--muted);margin-bottom:6px">Enter a new password to set or change it. Leave blank to keep current setting.</div>

--- a/static/panels.js
+++ b/static/panels.js
@@ -962,6 +962,8 @@ async function loadSettingsPanel(){
     if(showUsageCb) showUsageCb.checked=!!settings.show_token_usage;
     const showCliCb=$('settingsShowCliSessions');
     if(showCliCb) showCliCb.checked=!!settings.show_cli_sessions;
+    const syncCb=$('settingsSyncInsights');
+    if(syncCb) syncCb.checked=!!settings.sync_to_insights;
     // Password field: always blank (we don't send hash back)
     const pwField=$('settingsPassword');
     if(pwField) pwField.value='';
@@ -992,6 +994,7 @@ async function saveSettings(){
   if(sendKey) body.send_key=sendKey;
   body.show_token_usage=showTokenUsage;
   body.show_cli_sessions=showCliSessions;
+  body.sync_to_insights=!!($('settingsSyncInsights')||{}).checked;
   // Password: only act if the field has content; blank = leave auth unchanged
   if(pw && pw.trim()){
     try{


### PR DESCRIPTION
## Summary

Fixes #92 -- WebUI sessions are invisible to `hermes /insights` because the WebUI calls `AIAgent.run_conversation()` directly, bypassing the gateway that normally writes to state.db.

### Approach

New **opt-in setting** "Sync usage to /insights" (default: **off**). When enabled, after each turn completes the WebUI mirrors session metadata (tokens, cost, model, title) into state.db so `/insights` includes browser session data.

### Why default off?

- Writing to state.db while CLI/gateway also writes could cause WAL lock contention
- Some users may not want WebUI sessions polluting their `/insights` stats
- It's a one-way mirror (WebUI -> state.db), not full bidirectional sync

### Components

| File | Change |
|------|--------|
| `api/state_sync.py` | **NEW** -- bridge module: `sync_session_usage()` using `ensure_session()` + `update_token_counts(absolute=True)` |
| `api/config.py` | `sync_to_insights` boolean setting added to defaults |
| `api/streaming.py` | Calls `sync_session_usage()` after `s.save()` (streaming path) |
| `api/routes.py` | Same for non-streaming chat path |
| `static/index.html` | Checkbox in Settings panel |
| `static/panels.js` | Load/save the checkbox state |

### Safety

- All sync operations wrapped in try/except -- WebUI never crashes for sync failures
- Uses `absolute=True` on `update_token_counts()` -- the WebUI Session already accumulates totals, so no double-counting risk
- `ensure_session()` is idempotent (INSERT OR IGNORE)
- If `hermes_state` module is not importable or state.db doesn't exist, sync silently no-ops

## Test plan

- [ ] 400 passed, 24 skipped, zero failures
- [ ] Enable "Sync usage to /insights" in Settings
- [ ] Send a message, then run `hermes /insights` -- should show the WebUI session
- [ ] Disable the setting, send another message -- `/insights` should not update
- [ ] With hermes-agent not installed: setting enabled but sync silently skips

Generated with [Claude Code](https://claude.com/claude-code)
