### PR TITLE
docs: v0.33 release notes and version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@
 
 ---
 
+## [v0.33] /insights Sync + state.db Bridge Fix
+*April 5, 2026 | 424 tests*
+
+### Features
+- **Opt-in `/insights` sync.** New "Sync usage to /insights" setting (default: off). When enabled, after each turn the WebUI mirrors session token usage, cost, model, and title into `state.db` so `hermes /insights` includes browser session activity. (#92, #93)
+
+### Bug Fixes
+- **state_sync.py correctness fixes.** Three bugs in the initial implementation caught during code review: wrong class name (`HermesState` → `SessionDB`), wrong constructor argument type (`str` → `Path`), wrong title update method (`_execute_write` with bad signature → `set_session_title`). Also fixed a SQLite connection leak (persistent connection opened per call, never closed). (#95)
+
+---
+
 ## [v0.32] Auto-Compaction Handling + /compact Command (Issue #90)
 *April 5, 2026 | 424 tests*
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,7 +3,7 @@
 > Goal: Full 1:1 parity with the Hermes CLI experience via a clean dark web UI.
 > Everything you can do from the CLI terminal, you can do from this UI.
 >
-> Last updated: v0.31.2 (April 5, 2026)
+> Last updated: v0.33 (April 5, 2026)
 > Tests: 424 total (424 passing, 0 failures)
 > Source: <repo>/
 

--- a/SPRINTS.md
+++ b/SPRINTS.md
@@ -898,5 +898,5 @@ genuinely differentiating for an open-source project
 ---
 
 *Last updated: April 5, 2026*
-*Current version: v0.32 | 424 tests*
+*Current version: v0.33 | 424 tests*
 *Next sprint: Sprint 24 (Web Polish + Bug Fix Pass)*

--- a/static/index.html
+++ b/static/index.html
@@ -13,7 +13,7 @@
 <body>
 <div class="layout">
   <aside class="sidebar">
-    <div class="sidebar-header"><div class="logo">H</div><div><h1 style="margin:0;font-size:15px;font-weight:700;letter-spacing:-.01em">Hermes</h1><div style="font-size:10px;color:var(--muted);opacity:.8;margin-top:1px">v0.32</div></div></div>
+    <div class="sidebar-header"><div class="logo">H</div><div><h1 style="margin:0;font-size:15px;font-weight:700;letter-spacing:-.01em">Hermes</h1><div style="font-size:10px;color:var(--muted);opacity:.8;margin-top:1px">v0.33</div></div></div>
     <div class="sidebar-nav">
       <button class="nav-tab active" data-panel="chat" data-label="Chat" onclick="switchPanel('chat')" title="Chat">&#128172;</button>
       <button class="nav-tab" data-panel="tasks" data-label="Tasks" onclick="switchPanel('tasks')" title="Tasks">&#128197;</button>


### PR DESCRIPTION
Post-merge docs for PR #93 + fix #95 (/insights sync feature + state_sync.py correctness fixes).

- CHANGELOG.md: add v0.33 entry
- ROADMAP.md: update version/date
- SPRINTS.md: update current version
- static/index.html: bump sidebar label to v0.33

No code changes. 424 tests pass.
