### PR TITLE
fix: initialize cfg_base_url for custom providers

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -427,6 +427,7 @@ def get_available_models() -> dict:
 
     # 1. Read config.yaml model section
     model_cfg = cfg.get('model', {})
+    cfg_base_url = ''
     if isinstance(model_cfg, str):
         default_model = model_cfg
     elif isinstance(model_cfg, dict):


### PR DESCRIPTION
**Agent review — APPROVED ✅**

Reviewed full diff, repo health, and tests.

**What this does:** Fixes issue #117 by initializing `cfg_base_url` before the `model_cfg` conditional in `api/config.py`, so custom providers with a `base_url` can safely reach the model-fetching branch without an unbound-variable crash.

**Diff:** 1 file, 1 insertion, 0 deletions
**Security:** CLEAN
**Tests:** 433 passed, 0 failed
**Correctness:** Matches the issue report exactly. This is the minimal safe fix. No behavior changes outside model list discovery.

Safe to merge.
