### PR TITLE
fix: model dropdown missing custom/configured models (#116, #117)

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -426,6 +426,7 @@ def get_available_models() -> dict:
     groups = []
 
     # 1. Read config.yaml model section
+    cfg_base_url = ''  # must be defined before conditional blocks (#117)
     model_cfg = cfg.get('model', {})
     if isinstance(model_cfg, str):
         default_model = model_cfg
@@ -605,6 +606,25 @@ def get_available_models() -> dict:
             )
         for provider_name, models in by_provider.items():
             groups.append({'provider': provider_name, 'models': models})
+
+    # Ensure the user's configured default_model always appears in the dropdown.
+    # It may be missing if the model isn't in any hardcoded list (e.g. openrouter/free,
+    # a custom local model, or any model.default not in _FALLBACK_MODELS).
+    if default_model:
+        all_ids = {m['id'] for g in groups for m in g.get('models', [])}
+        if default_model not in all_ids:
+            # Determine which group to inject into
+            label = default_model.split('/')[-1] if '/' in default_model else default_model
+            injected = False
+            for g in groups:
+                if active_provider and active_provider.lower() in g.get('provider', '').lower():
+                    g['models'].insert(0, {'id': default_model, 'label': label})
+                    injected = True
+                    break
+            if not injected and groups:
+                groups[0]['models'].insert(0, {'id': default_model, 'label': label})
+            elif not groups:
+                groups.append({'provider': active_provider or 'Default', 'models': [{'id': default_model, 'label': label}]})
 
     return {
         'active_provider': active_provider,


### PR DESCRIPTION
Fixes two related bugs where the user's configured model didn't appear in the dropdown.

**Bug 1 (#117):** `cfg_base_url` was defined inside a conditional block but referenced unconditionally, causing a `NameError` when using custom providers with `base_url`. Fix: initialize before the conditional.

**Bug 2 (#116):** The OpenRouter branch substituted the hardcoded fallback list without checking if the user's `model.default` was present. Models like `openrouter/free` or custom local models were invisible in the dropdown. Fix: after building all groups, inject the configured `default_model` at the top of its provider group if it's missing.

One file changed (`api/config.py`), 20 lines added. Tests: 409 passed, 24 skipped, zero failures.

Generated with [Claude Code](https://claude.com/claude-code)