### PR TITLE
docs: sweep markdown for v0.36

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1269,3 +1269,6 @@ Three-panel layout: sessions sidebar, chat area, workspace panel.
 ---
 
 *Last updated: v0.36, April 5, 2026 | Tests: 433*
+
+### Markdown sweep
+- ROADMAP.md, TESTING.md, SPRINTS.md, README.md, and THEMES.md refreshed to match v0.36 and 433 tests.

--- a/README.md
+++ b/README.md
@@ -284,8 +284,8 @@ Or using the agent venv explicitly:
 ```
 
 Tests run against an isolated server on port 8788 with a separate state directory.
-Production data and real cron jobs are never touched. Current count: **424 tests**
-across 22 test files.
+Production data and real cron jobs are never touched. Current count: **433 tests**
+across 23 test files.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,7 +3,7 @@
 > Goal: Full 1:1 parity with the Hermes CLI experience via a clean dark web UI.
 > Everything you can do from the CLI terminal, you can do from this UI.
 >
-> Last updated: v0.35 (April 5, 2026)
+> Last updated: v0.36 (April 5, 2026)
 > Tests: 433 total (433 passing, 0 failures)
 > Source: <repo>/
 

--- a/SPRINTS.md
+++ b/SPRINTS.md
@@ -1159,3 +1159,4 @@ New test cases in `tests/test_sprint26.py`:
 *Current version: v0.36 | 433 tests*
 *Next sprint: Sprint 24 (Web Polish + Bug Fix Pass)*
 *Horizon sprint: Sprint 25 (macOS Desktop Application)*
+*Docs sweep policy: update markdown proactively during PR reviews and after significant releases*

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,7 +1,7 @@
 # Hermes Web UI: Browser Testing Plan
 
 > This document is for manual browser testing by you or by a Claude browser agent.
-> It covers user-facing features of the UI through Sprint 26 (v0.34.3).
+> It covers user-facing features of the UI through Sprint 26 (v0.36).
 > Each section is written as a step-by-step test procedure with expected outcomes.
 > A browser agent (e.g. Claude with Chrome access) can execute this plan directly.
 >
@@ -1708,7 +1708,7 @@ Each has automated API-level tests in `tests/test_sprint{N}.py`.
 
 ---
 
-*Last updated: Sprint 26 / v0.34.3, April 5, 2026*
+*Last updated: Sprint 26 / v0.36, April 5, 2026*
 *Total automated tests: 433 (433 passing, 0 failures)*
 *Regression gate: tests/test_regressions.py*
 *Run: pytest tests/ -v --timeout=60*

--- a/THEMES.md
+++ b/THEMES.md
@@ -1,6 +1,6 @@
 # Hermes Web UI — Themes
 
-Hermes Web UI supports pluggable color themes. Five themes ship built-in, and
+Hermes Web UI supports pluggable color themes. Six themes ship built-in, and
 you can create your own with pure CSS — no Python changes needed.
 
 ---


### PR DESCRIPTION
Docs-only sweep to keep the repo markdown current for v0.36 and 433 tests.

Updated:
- CHANGELOG.md
- ROADMAP.md
- TESTING.md
- SPRINTS.md
- README.md
- THEMES.md

Notes:
- ROADMAP now says v0.36
- README now says 433 tests / 23 files
- TESTING now says Sprint 26 / v0.36
- SPRINTS footer now includes docs sweep policy
- THEMES says six built-in themes
- CHANGELOG includes a short markdown sweep note
