### PR TITLE
docs: fix stale 433 test counts to 440

### DIFF
--- a/SPRINTS.md
+++ b/SPRINTS.md
@@ -1164,7 +1164,7 @@ New test cases in `tests/test_sprint26.py`:
 ---
 
 *Last updated: April 5, 2026*
-*Current version: v0.36 | 433 tests*
+*Current version: v0.36.2 | 440 tests*
 *Next sprint: Sprint 24 (Web Polish + Bug Fix Pass)*
 *Horizon sprint: Sprint 25 (macOS Desktop Application)*
 *Docs sweep policy: update markdown proactively during PR reviews and after significant releases*

--- a/TESTING.md
+++ b/TESTING.md
@@ -8,7 +8,7 @@
 > Prerequisites: SSH tunnel is active on port 8786. Open http://localhost:8786 in browser.
 > Server health check: curl http://127.0.0.1:8786/health should return {"status":"ok"}.
 >
-> Automated tests: 433 total (433 passing, 0 failures)
+> Automated tests: 440 total (440 passing, 0 failures)
 > Run: `pytest tests/ -v --timeout=60`
 
 ---


### PR DESCRIPTION
Docs-only. No code changes.

Reviewer subagent caught two stale test counts not updated when v0.36.2 bumped to 440 tests:
- TESTING.md header (line 11): 433 → 440
- SPRINTS.md footer: v0.36 | 433 → v0.36.2 | 440
