### PR TITLE
fix: correct Claude Haiku model ID from 3-5 to 4-5

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -296,7 +296,7 @@ _FALLBACK_MODELS = [
     {'provider': 'OpenAI',    'id': 'openai/o4-mini',                   'label': 'o4-mini'},
     {'provider': 'Anthropic', 'id': 'anthropic/claude-sonnet-4.6',      'label': 'Claude Sonnet 4.6'},
     {'provider': 'Anthropic', 'id': 'anthropic/claude-sonnet-4-5',      'label': 'Claude Sonnet 4.5'},
-    {'provider': 'Anthropic', 'id': 'anthropic/claude-haiku-3-5',       'label': 'Claude Haiku 3.5'},
+    {'provider': 'Anthropic', 'id': 'anthropic/claude-haiku-4-5',       'label': 'Claude Haiku 4.5'},
     {'provider': 'Other',     'id': 'google/gemini-2.5-pro',            'label': 'Gemini 2.5 Pro'},
     {'provider': 'Other',     'id': 'deepseek/deepseek-chat-v3-0324',   'label': 'DeepSeek V3'},
     {'provider': 'Other',     'id': 'meta-llama/llama-4-scout',         'label': 'Llama 4 Scout'},
@@ -318,7 +318,7 @@ _PROVIDER_MODELS = {
         {'id': 'claude-opus-4.6',    'label': 'Claude Opus 4.6'},
         {'id': 'claude-sonnet-4.6',  'label': 'Claude Sonnet 4.6'},
         {'id': 'claude-sonnet-4-5',  'label': 'Claude Sonnet 4.5'},
-        {'id': 'claude-haiku-3-5',   'label': 'Claude Haiku 3.5'},
+        {'id': 'claude-haiku-4-5',   'label': 'Claude Haiku 4.5'},
     ],
     'openai': [
         {'id': 'gpt-5.4-mini', 'label': 'GPT-5.4 Mini'},


### PR DESCRIPTION
## Summary
- Fixed incorrect model ID `claude-haiku-3-5` → `claude-haiku-4-5` in both `_PROVIDER_MODELS` and `_FALLBACK_MODELS`
- `claude-haiku-3-5` does not exist on Anthropic's API and returns HTTP 404
- The correct model is Claude Haiku 4.5 (`claude-haiku-4-5`)

## Test plan
- [x] Verified the Anthropic API returns 404 for `claude-haiku-3-5`
- [x] Confirmed `claude-haiku-4-5` resolves correctly after the fix
- [x] Tested end-to-end chat via the WebUI with the Anthropic provider

🤖 Generated with [Claude Code](https://claude.com/claude-code)