### PR TITLE
fix: tool call cards persist across page reload (#140)

### DIFF
--- a/static/ui.js
+++ b/static/ui.js
@@ -465,6 +465,9 @@ function renderMessages(){
   const inner=$('msgInner');
   const vis=S.messages.filter(m=>{
     if(!m||!m.role||m.role==='tool')return false;
+    // Keep assistant messages with tool_use content even if they have no text,
+    // so tool cards can be anchored to their DOM rows on page reload (#140).
+    if(m.role==='assistant'&&Array.isArray(m.content)&&m.content.some(p=>p&&p.type==='tool_use'))return true;
     return msgContent(m)||m.attachments?.length;
   });
   $('emptyState').style.display=vis.length?'none':'';


### PR DESCRIPTION
Tool cards vanished on page refresh because assistant messages containing only `tool_use` blocks (no text) were filtered from the render list. Since tool cards anchor to DOM rows via `data-msg-idx`, the anchor was missing.

**Fix:** Keep assistant messages in the render list when they contain `tool_use` blocks, even with no text content. 3 lines added to the filter in `renderMessages()`.

Tests: 441 passed, 24 skipped, zero failures. Fixes #140.

Generated with [Claude Code](https://claude.com/claude-code)