### PR TITLE
docs: v0.38.1 release notes + version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@
 
 ---
 
+## [v0.38.1] — 2026-04-06
+
+### Fixed
+- **Model selector duplicates** (#147, #151): When `config.yaml` sets `model.default` with a provider prefix (e.g. `anthropic/claude-opus-4.6`), the model dropdown no longer shows a duplicate entry alongside the existing bare-ID entry. The dedup check now normalizes both sides before comparing.
+- **Stale model labels** (#147, #151): Sessions created with models no longer in the current provider list now show `"ModelName (unavailable)"` in muted text with a tooltip, instead of appearing as a normal selectable option that would fail silently on send.
+
+---
+
+## [v0.38.0] — 2026-04-06
+
+### Fixed
+- **Multi-provider model routing (#138):** Non-default provider models now use `@provider:model` format. `resolve_model_provider()` routes them through `resolve_runtime_provider(requested=provider)` — no OpenRouter fallback for users with direct provider keys.
+- **Personalities from config.yaml (#139):** `/api/personalities` reads from `config.yaml` `agent.personalities` (the documented mechanism). Personality prompts pass via `agent.ephemeral_system_prompt`.
+- **Tool call cards survive page reload (#140):** Assistant messages with only `tool_use` content are no longer filtered from the render list, preserving anchor rows for tool card display.
+
+---
+
 ## [v0.37.0] /personality command, model prefix routing fix, tool card reload fix
 *April 6, 2026 | 465 tests*
 

--- a/static/index.html
+++ b/static/index.html
@@ -14,7 +14,7 @@
 <body>
 <div class="layout">
   <aside class="sidebar">
-    <div class="sidebar-header"><div class="logo">H</div><div><h1 style="margin:0;font-size:15px;font-weight:700;letter-spacing:-.01em">Hermes</h1><div style="font-size:10px;color:var(--muted);opacity:.8;margin-top:1px">v0.38.0</div></div></div>
+    <div class="sidebar-header"><div class="logo">H</div><div><h1 style="margin:0;font-size:15px;font-weight:700;letter-spacing:-.01em">Hermes</h1><div style="font-size:10px;color:var(--muted);opacity:.8;margin-top:1px">v0.38.1</div></div></div>
     <div class="sidebar-nav">
       <button class="nav-tab active" data-panel="chat" data-label="Chat" onclick="switchPanel('chat')" title="Chat">&#128172;</button>
       <button class="nav-tab" data-panel="tasks" data-label="Tasks" onclick="switchPanel('tasks')" title="Tasks">&#128197;</button>


### PR DESCRIPTION
Fixes both bugs reported in #147.

**Bug 1 — Stale/ghost model entries (ui.js)**

When a session was created with a model that's no longer in the current provider list, loading it appended the old model ID as a plain `<option>` that looked identical to working models. Users would select it and hit a silent routing failure.

Fix: the appended option now shows `"ModelName (unavailable)"` in muted color with a tooltip explaining it's a stale model from a prior session. The session value is still preserved (no behavior change on send), but the label makes clear the model isn't available.

**Bug 2 — Duplicate entry when `default_model` is prefixed (api/config.py)**

When `config.yaml` sets `model.default: anthropic/claude-opus-4.6`, the "ensure default appears in dropdown" logic compared the prefixed ID against a set of bare IDs and saw no match, injecting a second `anthropic/claude-opus-4.6` entry alongside the existing `claude-opus-4.6`. The Anthropic group would show the same model twice.

Fix: normalize both sides before comparing — strip the provider prefix so `anthropic/claude-opus-4.6` matches `claude-opus-4.6` already in the list. No injection happens; no duplicate.

Tests: 466 passed (1 new regression test for Bug 2). Fixes #147.

Generated with [Claude Code](https://claude.com/claude-code)
