### PR TITLE
docs: v0.38.2 release notes + version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@
 
 ---
 
+## [v0.38.2] — 2026-04-06
+
+### Fixed
+- **Tool cards actually render on page reload** (#140, #153): PR #149 fixed the wrong filter — it updated `vis` but not `visWithIdx` (the loop that actually creates DOM rows), so anchor rows were never inserted. This PR fixes `visWithIdx`. Additionally, `streaming.py`'s `assistant_msg_idx` builder previously only scanned Anthropic content-array format and produced `idx=-1` for all OpenAI-format tool calls (the format used in saved sessions); it now handles both. As a final fallback, `renderMessages()` now builds tool card data directly from per-message `tool_calls` arrays when `S.toolCalls` is empty, covering historical sessions that predate session-level tool tracking.
+
+---
+
 ## [v0.38.1] — 2026-04-06
 
 ### Fixed

--- a/static/index.html
+++ b/static/index.html
@@ -14,7 +14,7 @@
 <body>
 <div class="layout">
   <aside class="sidebar">
-    <div class="sidebar-header"><div class="logo">H</div><div><h1 style="margin:0;font-size:15px;font-weight:700;letter-spacing:-.01em">Hermes</h1><div style="font-size:10px;color:var(--muted);opacity:.8;margin-top:1px">v0.38.1</div></div></div>
+    <div class="sidebar-header"><div class="logo">H</div><div><h1 style="margin:0;font-size:15px;font-weight:700;letter-spacing:-.01em">Hermes</h1><div style="font-size:10px;color:var(--muted);opacity:.8;margin-top:1px">v0.38.2</div></div></div>
     <div class="sidebar-nav">
       <button class="nav-tab active" data-panel="chat" data-label="Chat" onclick="switchPanel('chat')" title="Chat">&#128172;</button>
       <button class="nav-tab" data-panel="tasks" data-label="Tasks" onclick="switchPanel('tasks')" title="Tasks">&#128197;</button>


### PR DESCRIPTION
PR #149 kept tool_use-only assistant messages in the `vis` filter list but the **actual DOM row rendering loop** (`visWithIdx`) used a separate filter that didn't include that fix — so no anchor rows were created and tool cards still didn't appear on reload.

Additionally, the session-level `S.toolCalls` that `renderMessages()` reads is empty for the majority of sessions: either they predate session-level tool tracking, or `streaming.py`'s `assistant_msg_idx` builder only handled Anthropic's content-array format and produced `idx=-1` for every OpenAI-format tool call (the format actually used in saved sessions).

**What this PR fixes:**

**`api/streaming.py`** — `assistant_msg_idx` builder now handles both formats:
- Anthropic: `content` array with `type=tool_use` blocks (existing path, now also sets `pending_asst_idx`)
- OpenAI: `tool_calls` as a top-level field on the assistant message (new path)

Previously most tool calls got `assistant_msg_idx: -1` because the code only scanned Anthropic-format content.

**`static/ui.js`** — Two changes to `renderMessages()`:

1. `visWithIdx` (the loop that creates DOM rows) now includes assistant messages that have a top-level `tool_calls` array or Anthropic `tool_use` content blocks, even if their text is empty. These rows are the DOM anchors the card-insertion code looks up via `data-msg-idx`.

2. Fallback: when `S.toolCalls` is empty (common for historical sessions), `renderMessages()` builds a display list from per-message `tool_calls` arrays before attempting card insertion. This is the approach the original reporter described — "check each assistant message for a tool_calls array."

Fixes #140.

Generated with [Claude Code](https://claude.com/claude-code)
