### PR TITLE
docs: v0.38.3 release notes + version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@
 
 ---
 
+## [v0.38.3] — 2026-04-06
+
+### Fixed
+- **Model dropdown shows only configured providers** (#155): Provider detection now uses `hermes_cli.models.list_available_providers()` — the same auth check the Hermes agent uses at runtime — instead of scanning raw API key env vars. The dropdown now reflects exactly what the user has configured (auth.json, credential pools, OAuth flows like Copilot). When no providers are detected, shows only the configured default model rather than a full generic list. Added `copilot` and `gemini` to the curated model lists. Falls back to env var scanning for standalone installs without hermes-agent.
+
+---
+
 ## [v0.38.2] — 2026-04-06
 
 ### Fixed

--- a/static/index.html
+++ b/static/index.html
@@ -14,7 +14,7 @@
 <body>
 <div class="layout">
   <aside class="sidebar">
-    <div class="sidebar-header"><div class="logo">H</div><div><h1 style="margin:0;font-size:15px;font-weight:700;letter-spacing:-.01em">Hermes</h1><div style="font-size:10px;color:var(--muted);opacity:.8;margin-top:1px">v0.38.2</div></div></div>
+    <div class="sidebar-header"><div class="logo">H</div><div><h1 style="margin:0;font-size:15px;font-weight:700;letter-spacing:-.01em">Hermes</h1><div style="font-size:10px;color:var(--muted);opacity:.8;margin-top:1px">v0.38.3</div></div></div>
     <div class="sidebar-nav">
       <button class="nav-tab active" data-panel="chat" data-label="Chat" onclick="switchPanel('chat')" title="Chat">&#128172;</button>
       <button class="nav-tab" data-panel="tasks" data-label="Tasks" onclick="switchPanel('tasks')" title="Tasks">&#128197;</button>


### PR DESCRIPTION
The model dropdown was built by scanning raw API key env vars (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, etc.) and showing hardcoded model lists for whatever keys were found. When no keys were detected, it showed the full `_FALLBACK_MODELS` list — all providers regardless of configuration.

This meant users saw models they couldn't use, and users who had providers configured through Hermes's auth layer (credential pools, `auth.json`, OAuth flows like Copilot) might not see those providers at all if the raw env var wasn't set.

**What changed:**

Provider detection now uses `hermes_cli.models.list_available_providers()` — the same auth check the Hermes agent itself uses at runtime. It checks `auth.json`, credential pools, and env vars through the same path as `resolve_runtime_provider()`. The dropdown reflects exactly what the user has configured, not what API key env vars happen to exist.

The old env-var scanning is kept as a fallback for installs where hermes-agent modules aren't importable (standalone WebUI without a full Hermes install).

**No-providers fallback** changed from showing all `_FALLBACK_MODELS` (wrong) to showing only the configured `default_model` (correct — at minimum the user can send messages with whatever they have set).

**Added to `_PROVIDER_MODELS`:** `copilot` (GitHub Copilot) and `gemini` (Google AI Studio via `hermes_cli` provider ID), which `list_available_providers()` now returns and were missing from the webui's curated model list.

**Your scenario** (Anthropic + OpenRouter both configured) now works correctly: you see two separate groups with the Anthropic-specific models under Anthropic and the full OR model list under OpenRouter, and nothing else.

Tests: 466 passed. Generated with [Claude Code](https://claude.com/claude-code)
