### PR TITLE
fix: exclude ambient gh-cli token from model dropdown provider detection

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -496,9 +496,20 @@ def get_available_models() -> dict:
     _hermes_auth_used = False
     try:
         from hermes_cli.models import list_available_providers as _lap
+        from hermes_cli.auth import get_auth_status as _gas
         for _p in _lap():
-            if _p.get('authenticated'):
-                detected_providers.add(_p['id'])
+            if not _p.get('authenticated'):
+                continue
+            # Exclude providers whose credential came from an ambient token
+            # (e.g. 'gh auth token' for Copilot on a machine with gh CLI auth).
+            # Only include providers with an explicit, dedicated credential.
+            try:
+                _src = _gas(_p['id']).get('key_source', '')
+                if _src == 'gh auth token':
+                    continue
+            except Exception:
+                pass
+            detected_providers.add(_p['id'])
         _hermes_auth_used = True
     except Exception:
         pass


### PR DESCRIPTION
`list_available_providers()` reports Copilot as "authenticated" on any machine with `gh` CLI auth, because `resolve_copilot_token()` falls back to `gh auth token` when no explicit `COPILOT_GITHUB_TOKEN`/`GITHUB_TOKEN` is set. This caused the model dropdown to show a GitHub Copilot group on machines that have never configured Copilot as a Hermes provider.

**Fix:** When iterating `list_available_providers()` results, call `get_auth_status(provider_id)` and skip any provider where `key_source == 'gh auth token'`. That source value is only returned when the credential came from the ambient `gh` CLI auth fallback — not from an explicitly configured token. All legitimately configured providers (Anthropic via `ANTHROPIC_TOKEN`, OpenRouter via credential pool, Copilot via explicit `GITHUB_TOKEN` in `.env`) have a different source value and pass through.

A provider with an explicit `GITHUB_TOKEN` in their `.env` (intentionally configuring Copilot) still shows correctly — only the ambient fallback path is excluded.

Tests: 466 passed. Generated with [Claude Code](https://claude.com/claude-code)
