### PR TITLE
docs: v0.38.4 release notes + version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@
 
 ---
 
+## [v0.38.4] — 2026-04-06
+
+### Fixed
+- **Copilot false positive in model dropdown** (#158): `list_available_providers()` reported Copilot as available on any machine with `gh` CLI auth, because the Copilot token resolver falls back to `gh auth token`. The dropdown now skips any provider whose credential source is `'gh auth token'` — only explicit, dedicated credentials count. Users with `GITHUB_TOKEN` explicitly set in their `.env` still see Copilot correctly.
+
+---
+
 ## [v0.38.3] — 2026-04-06
 
 ### Fixed

--- a/static/index.html
+++ b/static/index.html
@@ -14,7 +14,7 @@
 <body>
 <div class="layout">
   <aside class="sidebar">
-    <div class="sidebar-header"><div class="logo">H</div><div><h1 style="margin:0;font-size:15px;font-weight:700;letter-spacing:-.01em">Hermes</h1><div style="font-size:10px;color:var(--muted);opacity:.8;margin-top:1px">v0.38.3</div></div></div>
+    <div class="sidebar-header"><div class="logo">H</div><div><h1 style="margin:0;font-size:15px;font-weight:700;letter-spacing:-.01em">Hermes</h1><div style="font-size:10px;color:var(--muted);opacity:.8;margin-top:1px">v0.38.4</div></div></div>
     <div class="sidebar-nav">
       <button class="nav-tab active" data-panel="chat" data-label="Chat" onclick="switchPanel('chat')" title="Chat">&#128172;</button>
       <button class="nav-tab" data-panel="tasks" data-label="Tasks" onclick="switchPanel('tasks')" title="Tasks">&#128197;</button>


### PR DESCRIPTION
`list_available_providers()` reports Copilot as "authenticated" on any machine with `gh` CLI auth, because `resolve_copilot_token()` falls back to `gh auth token` when no explicit `COPILOT_GITHUB_TOKEN`/`GITHUB_TOKEN` is set. This caused the model dropdown to show a GitHub Copilot group on machines that have never configured Copilot as a Hermes provider.

**Fix:** When iterating `list_available_providers()` results, call `get_auth_status(provider_id)` and skip any provider where `key_source == 'gh auth token'`. That source value is only returned when the credential came from the ambient `gh` CLI auth fallback — not from an explicitly configured token. All legitimately configured providers (Anthropic via `ANTHROPIC_TOKEN`, OpenRouter via credential pool, Copilot via explicit `GITHUB_TOKEN` in `.env`) have a different source value and pass through.

A provider with an explicit `GITHUB_TOKEN` in their `.env` (intentionally configuring Copilot) still shows correctly — only the ambient fallback path is excluded.

Tests: 466 passed. Generated with [Claude Code](https://claude.com/claude-code)
