### PR TITLE
fix: custom endpoint URL, custom_providers in dropdown, .env key resolution (#138 follow-up)

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -492,6 +492,7 @@ def get_available_models() -> dict:
     detected_providers = set()
     if active_provider:
         detected_providers.add(active_provider)
+    all_env: dict = {}  # profile .env keys — populated below, used by custom endpoint auth
 
     _hermes_auth_used = False
     try:
@@ -564,9 +565,9 @@ def get_available_models() -> dict:
             # Normalize the base_url and build models endpoint
             base_url = cfg_base_url.strip()
             if base_url.endswith('/v1'):
-                endpoint_url = base_url[:-3] + '/models'
+                endpoint_url = base_url + '/models'  # /v1/models
             else:
-                endpoint_url = base_url + '/v1/models'
+                endpoint_url = base_url.rstrip('/') + '/v1/models'
 
             # Detect provider from base_url
             provider = 'custom'
@@ -586,12 +587,12 @@ def get_available_models() -> dict:
                 except ValueError:
                     pass
 
-            # Resolve API key from environment
+            # Resolve API key from environment (check profile .env keys too)
             headers = {}
             api_key_vars = ('HERMES_API_KEY', 'HERMES_OPENAI_API_KEY', 'OPENAI_API_KEY',
                             'LOCAL_API_KEY', 'OPENROUTER_API_KEY', 'API_KEY')
             for key in api_key_vars:
-                api_key = os.getenv(key)
+                api_key = all_env.get(key) or os.getenv(key)
                 if api_key:
                     headers['Authorization'] = f'Bearer {api_key}'
                     break
@@ -620,6 +621,22 @@ def get_available_models() -> dict:
                     detected_providers.add(provider.lower())
         except Exception:
             pass  # custom endpoint unreachable or misconfigured -- fail silently
+
+    # 3b. Include models from custom_providers config entries.
+    # These are explicitly configured and should always appear even when the
+    # /v1/models endpoint is unreachable or returns a subset.
+    _custom_providers_cfg = cfg.get('custom_providers', [])
+    if isinstance(_custom_providers_cfg, list):
+        _seen_custom_ids = {m['id'] for m in auto_detected_models}
+        for _cp in _custom_providers_cfg:
+            if not isinstance(_cp, dict):
+                continue
+            _cp_model = _cp.get('model', '')
+            if _cp_model and _cp_model not in _seen_custom_ids:
+                _cp_label = _cp_model.split('/')[-1] if '/' in _cp_model else _cp_model
+                auto_detected_models.append({'id': _cp_model, 'label': _cp_label})
+                _seen_custom_ids.add(_cp_model)
+                detected_providers.add('custom')
 
     # 5. Build model groups
     if detected_providers:


### PR DESCRIPTION
Three fixes for custom endpoint model visibility, originally contributed in #157 by @hannesss81 (follow-up to #138). That PR was branched from v0.38.2 and would have reverted the v0.38.3/v0.38.4 provider-auth work, so the fixes are applied cleanly here on current master instead. PR #157 is closed in favour of this one.

**Bug 1 — URL construction (#157):** When `base_url` ends in `/v1`, the models endpoint was incorrectly constructed as `http://host/models` instead of `http://host/v1/models`. The old code stripped the `/v1` suffix before appending `/models`.

```python
# Before (wrong): strips /v1
endpoint_url = base_url[:-3] + '/models'  # http://host/models

# After (correct): appends /models to the existing /v1
endpoint_url = base_url + '/models'       # http://host/v1/models
```

**Bug 2 — `custom_providers` not in dropdown (#157):** `config.yaml` `custom_providers` entries (e.g. Ollama model aliases, Azure model overrides) were never added to the dropdown — only models auto-fetched from the `/v1/models` endpoint appeared. Now reads `custom_providers` from config and includes any entries not already in the auto-detected list.

**Bug 3 — API key from .env not used for custom endpoints (#157):** The custom endpoint auth code only checked `os.getenv()`. Keys defined in `~/.hermes/.env` (loaded at server startup) were already in `all_env` but not consulted. Now checks `all_env` first, falls back to `os.getenv`.

Tests: 466 passed. Closes #157. Fixes #138 (remaining gap).

Generated with [Claude Code](https://claude.com/claude-code)
