### PR TITLE
feat: add OLED theme for true black displays

### DIFF
--- a/THEMES.md
+++ b/THEMES.md
@@ -1,6 +1,6 @@
 # Hermes Web UI — Themes
 
-Hermes Web UI supports pluggable color themes. Six themes ship built-in, and
+Hermes Web UI supports pluggable color themes. Seven themes ship built-in, and
 you can create your own with pure CSS — no Python changes needed.
 
 ---
@@ -27,6 +27,7 @@ preview is instant — the UI updates as you click through options.
 | **Solarized Dark** | Ethan Schoonover's classic dark palette. Teal background, warm accents. |
 | **Monokai** | Warm dark theme inspired by the Monokai editor scheme. Green/pink accents. |
 | **Nord** | Arctic blue-gray palette from the Nord color system. Calm and minimal. |
+| **OLED** | True black (#000) backgrounds for OLED displays. Minimizes glow and burn-in risk. |
 | **Custom themes** | Any string accepted by `settings.json`, `POST /api/settings`, and `/theme` if added to the picker/command list. Pure CSS variables only. |
 
 ---

--- a/static/commands.js
+++ b/static/commands.js
@@ -10,7 +10,7 @@ const COMMANDS=[
   {name:'workspace', desc:'Switch workspace by name',            fn:cmdWorkspace, arg:'name'},
   {name:'new',       desc:'Start a new chat session',            fn:cmdNew},
   {name:'usage',     desc:'Toggle token usage display on/off',   fn:cmdUsage},
-  {name:'theme',     desc:'Switch theme (dark/light/slate/solarized/monokai/nord)', fn:cmdTheme, arg:'name'},
+  {name:'theme',     desc:'Switch theme (dark/light/slate/solarized/monokai/nord/oled)', fn:cmdTheme, arg:'name'},
   {name:'personality', desc:'Switch agent personality', fn:cmdPersonality, arg:'name'},
 ];
 
@@ -125,7 +125,7 @@ async function cmdUsage(){
 }
 
 async function cmdTheme(args){
-  const themes=['dark','light','slate','solarized','monokai','nord'];
+  const themes=['dark','light','slate','solarized','monokai','nord','oled'];
   if(!args||!themes.includes(args.toLowerCase())){
     showToast('Usage: /theme '+themes.join('|'));
     return;

--- a/static/index.html
+++ b/static/index.html
@@ -342,6 +342,7 @@
           <option value="solarized">Solarized Dark</option>
           <option value="monokai">Monokai</option>
           <option value="nord">Nord</option>
+          <option value="oled">OLED</option>
         </select>
       </div>
       <div class="settings-field">

--- a/static/style.css
+++ b/static/style.css
@@ -107,6 +107,7 @@
     --surface:#0a0a0a;--topbar-bg:rgba(0,0,0,.98);--main-bg:rgba(0,0,0,0.5);
     --focus-ring:rgba(108,180,255,.3);--focus-glow:rgba(108,180,255,.06);
     --strong:#ffffff;--em:#c0c0d0;--code-text:#e8b86d;--code-inline-bg:rgba(255,255,255,.06);--pre-text:#d0d0d8;
+    --input-bg:rgba(255,255,255,.03);--hover-bg:rgba(255,255,255,.05);
   }
   body{background:var(--bg);color:var(--text);height:100vh;height:100dvh;overflow:hidden;display:flex;}
   .layout{display:flex;width:100%;height:100vh;height:100dvh;}

--- a/static/style.css
+++ b/static/style.css
@@ -100,6 +100,14 @@
     --focus-ring:rgba(129,161,193,.35);--focus-glow:rgba(129,161,193,.08);
     --strong:#eceff4;--em:#b8c0cc;--code-text:#a3be8c;--code-inline-bg:rgba(0,0,0,.2);--pre-text:#d8dee9;
   }
+  /* ── OLED theme ── */
+  :root[data-theme="oled"]{
+    --bg:#000000;--sidebar:#000000;--border:rgba(255,255,255,0.06);--border2:rgba(255,255,255,0.12);
+    --text:#e0e0e0;--muted:#777777;--accent:#ff3b5c;--blue:#6cb4ff;--gold:#d4a74a;--code-bg:#080808;
+    --surface:#0a0a0a;--topbar-bg:rgba(0,0,0,.98);--main-bg:rgba(0,0,0,0.5);
+    --focus-ring:rgba(108,180,255,.3);--focus-glow:rgba(108,180,255,.06);
+    --strong:#ffffff;--em:#c0c0d0;--code-text:#e8b86d;--code-inline-bg:rgba(255,255,255,.06);--pre-text:#d0d0d8;
+  }
   body{background:var(--bg);color:var(--text);height:100vh;height:100dvh;overflow:hidden;display:flex;}
   .layout{display:flex;width:100%;height:100vh;height:100dvh;}
   .sidebar{width:300px;background:var(--sidebar);border-right:1px solid var(--border);display:flex;flex-direction:column;overflow:visible;flex-shrink:0;}


### PR DESCRIPTION
## What
Adds an **OLED theme** option optimized for true black displays.

## Changes
- `static/style.css` — OLED theme CSS variables (pure #000 backgrounds, low-opacity borders, warm accents to reduce burn-in risk)
- `static/index.html` — Added OLED option to the theme dropdown
- `static/commands.js` — Registered `oled` in the theme registry and `/theme oled` command

## Why
Existing dark themes use dark grays which glow on OLED panels. This theme uses true black (#000) backgrounds with minimal-opacity borders to maximize contrast and minimize OLED burn-in.

## Testing
- `/theme oled` in chat works
- Theme dropdown in settings works
- No regressions in existing themes