### PR TITLE
Fix: show top-level reasoning field in thinking card

### DIFF
--- a/static/ui.js
+++ b/static/ui.js
@@ -499,6 +499,10 @@ function renderMessages(){
       thinkingText=content.filter(p=>p&&(p.type==='thinking'||p.type==='reasoning')).map(p=>p.thinking||p.reasoning||p.text||'').join('\n');
       content=content.filter(p=>p&&p.type==='text').map(p=>p.text||p.content||'').join('\n');
     }
+    // Also check top-level reasoning field (Hermes format)
+    if(!thinkingText && m.reasoning){
+      thinkingText=m.reasoning;
+    }
     const isUser=m.role==='user';
     const isLastAssistant=!isUser&&vi===visWithIdx.length-1;
     // Render thinking card before the assistant message (collapsed by default)


### PR DESCRIPTION
## Problem
Hermes stores reasoning as a top-level message field (`m.reasoning`) instead of in content arrays like Claude (which uses `content: [{type: 'reasoning', reasoning: '...'}]`).

The WebUI thinking/reasoning card only checked for structured content arrays, so Hermes reasoning was never displayed.

## Fix
Added a fallback check for `m.reasoning` after the content array check in `renderMessages()`:

```javascript
// Also check top-level reasoning field (Hermes format)
if(!thinkingText && m.reasoning){
  thinkingText=m.reasoning;
}
```

This allows Hermes users to see the model's reasoning process in the WebUI.

## Testing
- Patch applied locally on hermes-ai.gaalman.org
- Reasoning cards now display correctly in WebUI