### PR TITLE
docs: v0.40.1 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@
 ---
 
 
+## [v0.40.1] — 2026-04-09
+
+### Bug Fixes
+- **Default locale on first install** (PR #185): A fresh install would start in
+  English based on the server default, but `loadLocale()` could resurrect a
+  stale or unsupported locale code from `localStorage`. Now `loadLocale()` falls
+  back to English when there is no saved code or the saved code is not in the
+  LOCALES bundle. `setLocale()` also stores the resolved code, so an unknown
+  input never persists to storage.
+
+---
+
 ## [v0.40.0] — 2026-04-09
 
 ### Features

--- a/static/index.html
+++ b/static/index.html
@@ -14,7 +14,7 @@
 <body>
 <div class="layout">
   <aside class="sidebar">
-    <div class="sidebar-header"><div class="logo">H</div><div><h1 style="margin:0;font-size:15px;font-weight:700;letter-spacing:-.01em">Hermes</h1><div style="font-size:10px;color:var(--muted);opacity:.8;margin-top:1px">v0.40.0</div></div></div>
+    <div class="sidebar-header"><div class="logo">H</div><div><h1 style="margin:0;font-size:15px;font-weight:700;letter-spacing:-.01em">Hermes</h1><div style="font-size:10px;color:var(--muted);opacity:.8;margin-top:1px">v0.40.1</div></div></div>
     <div class="sidebar-nav">
       <button class="nav-tab active" data-panel="chat" data-label="Chat" onclick="switchPanel('chat')" title="Chat">&#128172;</button>
       <button class="nav-tab" data-panel="tasks" data-label="Tasks" onclick="switchPanel('tasks')" title="Tasks">&#128197;</button>


### PR DESCRIPTION
Bumps version to v0.40.1 and adds CHANGELOG entry for PR #185 (default locale fix).

**Change:** `loadLocale()` now falls back to English when localStorage has no key or an unknown key. `setLocale()` stores the resolved code. Server-side default was already `en`; this closes the browser boot gap.

**Tests:** 499 passed. 4 browser locale scenarios verified (fresh install, stale unknown code, valid zh code, unknown code via setLocale).