### PR TITLE
fix: do not build phantom "Custom" group when active provider is set

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -654,6 +654,14 @@ def get_available_models() -> dict:
                 _seen_custom_ids.add(_cp_model)
                 detected_providers.add('custom')
 
+    # If the user configured a real model.provider, the base_url belongs to
+    # THAT provider, not to a separate "Custom" group. hermes_cli reports
+    # 'custom' as authenticated whenever base_url is set, which would otherwise
+    # build a phantom "Custom" bucket next to the real provider's group. Drop
+    # it unless the user explicitly chose 'custom' as their active provider.
+    if active_provider and active_provider != 'custom':
+        detected_providers.discard('custom')
+
     # 5. Build model groups
     if detected_providers:
         for pid in sorted(detected_providers):
@@ -715,11 +723,21 @@ def get_available_models() -> dict:
         _norm = lambda mid: mid.split('/', 1)[-1] if '/' in mid else mid
         all_ids_norm = {_norm(m['id']) for g in groups for m in g.get('models', [])}
         if _norm(default_model) not in all_ids_norm:
-            # Determine which group to inject into
+            # Determine which group to inject into. Compare against the
+            # provider's display name from _PROVIDER_DISPLAY rather than
+            # doing a substring match on active_provider — substring
+            # matching breaks on hyphenated provider IDs like 'openai-codex'
+            # vs display name 'OpenAI Codex' (hyphen vs. space), which
+            # silently falls through to groups[0] and lands the model in
+            # the wrong group.
             label = default_model.split('/')[-1] if '/' in default_model else default_model
+            target_display = (
+                _PROVIDER_DISPLAY.get(active_provider, active_provider or '').lower()
+                if active_provider else ''
+            )
             injected = False
             for g in groups:
-                if active_provider and active_provider.lower() in g.get('provider', '').lower():
+                if target_display and g.get('provider', '').lower() == target_display:
                     g['models'].insert(0, {'id': default_model, 'label': label})
                     injected = True
                     break

--- a/tests/test_model_resolver.py
+++ b/tests/test_model_resolver.py
@@ -202,3 +202,96 @@ def test_default_provider_models_not_prefixed():
             assert bare_id in returned_ids, (
                 f"_PROVIDER_MODELS entry '{bare_id}' is missing from the Anthropic group"
             )
+
+
+# ── get_available_models(): phantom "Custom" group regression ─────────────
+#
+# When the user has model.provider set to a real provider (e.g. openai-codex)
+# AND a model.base_url set, hermes_cli reports the 'custom' pseudo-provider as
+# authenticated. The WebUI picker must NOT build a separate "Custom" group in
+# that case — the base_url belongs to the active provider.
+
+def _available_models_with_full_cfg(provider, default, base_url):
+    """Helper: set model.provider, model.default, model.base_url at once."""
+    import api.config as _cfg
+    old_cfg = dict(_cfg.cfg)
+    _cfg.cfg['model'] = {
+        'provider': provider,
+        'default': default,
+        'base_url': base_url,
+    }
+    try:
+        return _cfg.get_available_models()
+    finally:
+        _cfg.cfg.clear()
+        _cfg.cfg.update(old_cfg)
+
+
+def test_no_phantom_custom_group_when_active_provider_is_set(monkeypatch):
+    """Issue: with provider=openai-codex + base_url set, gpt-5.4 was landing
+    under a phantom "Custom" group instead of the "OpenAI Codex" group."""
+    import sys, types
+
+    # Force hermes_cli to report both the real provider and the phantom
+    # 'custom' as authenticated, simulating what list_available_providers()
+    # returns when base_url is configured.
+    fake_mod = types.ModuleType('hermes_cli.models')
+    fake_mod.list_available_providers = lambda: [
+        {'id': 'openai-codex', 'authenticated': True},
+        {'id': 'custom',       'authenticated': True},
+    ]
+    fake_auth = types.ModuleType('hermes_cli.auth')
+    fake_auth.get_auth_status = lambda pid: {'key_source': 'env'}
+    monkeypatch.setitem(sys.modules, 'hermes_cli.models', fake_mod)
+    monkeypatch.setitem(sys.modules, 'hermes_cli.auth', fake_auth)
+
+    result = _available_models_with_full_cfg(
+        provider='openai-codex',
+        default='gpt-5.4',
+        base_url='https://chatgpt.com/backend-api/codex',
+    )
+    group_names = [g['provider'] for g in result['groups']]
+    assert 'Custom' not in group_names, (
+        f"Phantom 'Custom' group present; full groups: {group_names}"
+    )
+
+
+def test_default_model_lands_under_active_provider_group(monkeypatch):
+    """The configured default_model must appear under the active provider's
+    display group, even when the model isn't in _PROVIDER_MODELS[provider]
+    AND the active provider isn't the alphabetical first detected provider.
+
+    Regression guard for a hyphen-vs-space bug in the "ensure default_model
+    appears" post-pass: the substring check `active_provider.lower() in
+    g.get('provider', '').lower()` was failing for 'openai-codex' vs
+    display name 'OpenAI Codex' (hyphen vs. space), silently falling back
+    to groups[0] — which, when another provider sorted earlier
+    alphabetically (e.g. 'anthropic'), placed gpt-5.4 in the WRONG group.
+    """
+    import sys, types
+    fake_mod = types.ModuleType('hermes_cli.models')
+    fake_mod.list_available_providers = lambda: [
+        {'id': 'anthropic',    'authenticated': True},  # sorts before openai-codex
+        {'id': 'openai-codex', 'authenticated': True},
+        {'id': 'custom',       'authenticated': True},
+    ]
+    fake_auth = types.ModuleType('hermes_cli.auth')
+    fake_auth.get_auth_status = lambda pid: {'key_source': 'env'}
+    monkeypatch.setitem(sys.modules, 'hermes_cli.models', fake_mod)
+    monkeypatch.setitem(sys.modules, 'hermes_cli.auth', fake_auth)
+
+    result = _available_models_with_full_cfg(
+        provider='openai-codex',
+        default='gpt-5.4',
+        base_url='https://chatgpt.com/backend-api/codex',
+    )
+    groups = {g['provider']: [m['id'] for m in g['models']] for g in result['groups']}
+    assert 'OpenAI Codex' in groups, f"OpenAI Codex group missing: {list(groups)}"
+    assert 'gpt-5.4' in groups['OpenAI Codex'], (
+        f"gpt-5.4 not in OpenAI Codex group; contents: {groups['OpenAI Codex']}"
+    )
+    # And crucially, it must NOT have landed in the alphabetically-first
+    # group (Anthropic) via the fallback path.
+    assert 'gpt-5.4' not in groups.get('Anthropic', []), (
+        f"gpt-5.4 leaked into Anthropic group via fallback: {groups.get('Anthropic')}"
+    )


### PR DESCRIPTION
## Summary

When `model.provider` is a real provider (e.g. `openai-codex`) and `model.base_url` is configured, `hermes_cli.models.list_available_providers()` reports `'custom'` as an authenticated provider because the `base_url` makes the "custom endpoint" path available. The WebUI model picker was then building a separate **"Custom"** group for it and parking the configured `default_model` there, while the configured provider's group (e.g. **"OpenAI Codex"**) listed only its hardcoded `_PROVIDER_MODELS` entries. The TUI does not have this problem because it treats `model.provider` + `model.default` as a single source of truth.

### Repro (real config)

```yaml
model:
  default: gpt-5.4
  provider: openai-codex
  base_url: https://chatgpt.com/backend-api/codex
```

Before this patch, `/api/models` returns:

```
Custom:        gpt-5.4
OpenAI Codex:  codex-mini-latest
OpenRouter:    … fallback list …
```

After:

```
OpenAI Codex:  gpt-5.4, codex-mini-latest
OpenRouter:    … fallback list …
```

### What the patch does

Two small edits in `api/config.py` inside `get_available_models()`:

1. **Suppress the phantom `custom` detected provider** when `active_provider` is set and isn't `custom` itself — the `base_url` belongs to the active provider, not a separate bucket.
2. **Replace the substring-based default-model injection check** with an exact match against `_PROVIDER_DISPLAY`. The previous check `active_provider.lower() in g.get('provider', '').lower()` silently returned `False` for hyphenated provider IDs vs. space-separated display names (`'openai-codex' in 'openai codex'` is `False`), falling through to `groups[0]` and landing the model in the alphabetical first group.

Two regression tests added in `tests/test_model_resolver.py`. The second one mocks three authenticated providers (`anthropic`, `openai-codex`, `custom`) specifically so that `anthropic` sorts before `openai-codex` — this catches the fallback-to-groups[0] bug that a two-provider mock would miss.

## ⚠️ Important: authorship and review

This patch was written by **Claude Opus 4.6** (Anthropic) during an investigation session. I (the GitHub user opening this PR) am **not a confident-enough Python developer to vouch for the correctness of the change myself**. The AI agent traced the bug, reproduced it via `get_available_models()` directly, and proposed this fix — but **I can't independently verify edge cases**.

**I'd appreciate if maintainers could review the code carefully** before merging, especially:
- Whether discarding `'custom'` from `detected_providers` could affect users whose config legitimately wants a standalone Custom group (e.g. `model.provider: custom` with a local Ollama endpoint — the `active_provider != 'custom'` guard is meant to preserve this, but please double-check).
- Whether the `_PROVIDER_DISPLAY`-based injection match covers every provider ID in `_PROVIDER_DISPLAY` without breaking the existing `test_no_duplicate_when_default_model_is_prefixed` and similar tests.
- Whether the regression tests' `monkeypatch.setitem(sys.modules, …)` approach is idiomatic for this codebase, or if you'd prefer a different stubbing style.

Happy to iterate on the approach — just let me know what changes you'd like.

## Test plan

- [x] `pytest tests/test_model_resolver.py -v` passes (16/16, including the two new tests)
- [x] `pytest tests/ -q` passes (508 passed, 41 skipped — the skipped tests all require hermes-agent which isn't in the test env)
- [x] Manual verification against a live WebUI on the reporter's server: `gpt-5.4` now appears under "OpenAI Codex" in the composer model dropdown, with no phantom "Custom" group.

🤖 Patch generated with [Claude Code](https://claude.com/claude-code) (Opus 4.6)