### PR TITLE
fix(security): add Content-Security-Policy and Permissions-Policy headers

### DIFF
--- a/api/helpers.py
+++ b/api/helpers.py
@@ -39,6 +39,16 @@ def _security_headers(handler):
     handler.send_header('X-Content-Type-Options', 'nosniff')
     handler.send_header('X-Frame-Options', 'DENY')
     handler.send_header('Referrer-Policy', 'same-origin')
+    handler.send_header(
+        'Content-Security-Policy',
+        "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; "
+        "img-src 'self' data:; font-src 'self' data:; connect-src 'self'; "
+        "base-uri 'self'; form-action 'self'"
+    )
+    handler.send_header(
+        'Permissions-Policy',
+        'camera=(), microphone=(), geolocation=()'
+    )
 
 
 def j(handler, payload, status: int=200) -> None:


### PR DESCRIPTION
## Summary

Adds `Content-Security-Policy` and `Permissions-Policy` headers to every response via `_security_headers()` in `api/helpers.py`.

## Why

CSP is standard defense-in-depth that was missing from the existing security headers. The server already sets `X-Content-Type-Options`, `X-Frame-Options`, and `Referrer-Policy` — this completes the header suite.

## CSP Policy

| Directive | Value | Rationale |
|---|---|---|
| `default-src` | `'self'` | Only same-origin resources |
| `script-src` | `'self'` | Block inline/remote script injection |
| `style-src` | `'self' 'unsafe-inline'` | Needed for theme switching |
| `img-src` | `'self' data:` | Workspace images + data URIs |
| `font-src` | `'self' data:` | Web fonts |
| `connect-src` | `'self'` | Fetch/XHR only to same origin |
| `base-uri` | `'self'` | Prevent `<base>` injection |
| `form-action` | `'self'` | Prevent form hijacking |

## Permissions-Policy

Disables `camera`, `microphone`, `geolocation` — none of which this app uses.

Fixes #193