### PR TITLE
fix(server): add 30s connection timeout to prevent slow-client thread exhaustion

### DIFF
--- a/server.py
+++ b/server.py
@@ -15,6 +15,7 @@ from api.routes import handle_get, handle_post
 
 
 class Handler(BaseHTTPRequestHandler):
+    timeout = 30  # seconds — kills idle/incomplete connections to prevent thread exhaustion
     server_version = 'HermesWebUI/0.2'
     def log_message(self, fmt, *args): pass  # suppress default Apache-style log
 


### PR DESCRIPTION
## Summary

Adds a 30-second read timeout to the HTTP handler by setting `timeout = 30` on the `Handler` class. Python `BaseHTTPRequestHandler.setup()` calls `self.request.settimeout(self.timeout)`, which causes `rfile.read()` to raise `socket.timeout` after the configured duration on idle or slow connections.

## Why

The `ThreadingHTTPServer` spawns one thread per connection. With no timeout:
- A slow-client (Slowloris) attack can exhaust all threads
- Hung connections from crashed clients hold threads open forever  
- No upper bound on thread count under sustained abuse

## The Fix

One line in `server.py`:
```python
class Handler(BaseHTTPRequestHandler):
    timeout = 30  # seconds
```

This is the standard Python stdlib approach — no new dependencies, no architectural change.

Fixes #194