### PR TITLE
fix(security): CSP script-src must include unsafe-inline for inline event handlers

### DIFF
--- a/api/helpers.py
+++ b/api/helpers.py
@@ -41,7 +41,9 @@ def _security_headers(handler):
     handler.send_header('Referrer-Policy', 'same-origin')
     handler.send_header(
         'Content-Security-Policy',
-        "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; "
+        "default-src 'self'; "
+        "script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; "
+        "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; "
         "img-src 'self' data:; font-src 'self' data:; connect-src 'self'; "
         "base-uri 'self'; form-action 'self'"
     )


### PR DESCRIPTION
**Bug found during full QA browser sanity check:** The CSP `script-src 'self'` policy introduced in PR #197 blocks all inline `onclick=` event handlers in `index.html`. The app has 55+ inline handlers (`toggleSettings()`, `switchPanel()`, `filterSessions()`, `clearConversation()`, etc.) — all are blocked, making the settings panel, sidebar navigation, and most interactive controls non-functional.

**Evidence from browser console:**
```
Executing inline event handler violates the following Content Security Policy directive 'script-src 'self''. Either the 'unsafe-inline' keyword, a hash ('sha256-...'), or a nonce ('nonce-...') is required.
```

**Fix:** Added `'unsafe-inline'` to `script-src`. This is consistent with `style-src` which already has `'unsafe-inline'` for the theme system. Using hash-based CSP would require computing and maintaining SHA256 for 55+ event handlers — not practical for this codebase.

Also restores `https://cdn.jsdelivr.net` to `script-src` and `style-src` (needed for Mermaid.js and Prism.js) which was dropped in the v0.42.1 commit.

564 tests passing.
