### PR TITLE
fix: move login JS into external file, remove inline handlers (fixes #222)

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -130,29 +130,14 @@ button:hover{background:rgba(124,185,255,.25)}
   <div class="logo">{{BOT_NAME_INITIAL}}</div>
   <h1>{{BOT_NAME}}</h1>
   <p class="sub">{{LOGIN_SUBTITLE}}</p>
-  <form onsubmit="doLogin(event);return false">
-    <input type="password" id="pw" placeholder="{{LOGIN_PLACEHOLDER}}" autofocus
-           onkeydown="if(event.key==='Enter'){doLogin(event);event.preventDefault();}">
+  <form id="login-form" data-invalid-pw="{{LOGIN_INVALID_PW}}" data-conn-failed="{{LOGIN_CONN_FAILED}}">
+    <input type="password" id="pw" placeholder="{{LOGIN_PLACEHOLDER}}" autofocus>
     <button type="submit">{{LOGIN_BTN}}</button>
   </form>
   <div class="err" id="err"></div>
 </div>
-<script>
-async function doLogin(e){
-  e.preventDefault();
-  const pw=document.getElementById('pw').value;
-  const err=document.getElementById('err');
-  err.style.display='none';
-  try{
-    const res=await fetch('/api/auth/login',{method:'POST',
-      headers:{'Content-Type':'application/json'},
-      body:JSON.stringify({password:pw}),credentials:'include'});
-    const data=await res.json();
-    if(res.ok&&data.ok){window.location.href='/';}
-    else{err.textContent=data.error||'{{LOGIN_INVALID_PW}}';err.style.display='block';}
-  }catch(ex){err.textContent='{{LOGIN_CONN_FAILED}}';err.style.display='block';}
-}
-</script></body></html>'''
+<script src="/static/login.js"></script>
+</body></html>'''
 
 # ── GET routes ────────────────────────────────────────────────────────────────
 
@@ -177,8 +162,8 @@ def handle_get(handler, parsed) -> bool:
             .replace('{{LOGIN_SUBTITLE}}', _html.escape(_login_strings['subtitle']))
             .replace('{{LOGIN_PLACEHOLDER}}', _html.escape(_login_strings['placeholder']))
             .replace('{{LOGIN_BTN}}', _html.escape(_login_strings['btn']))
-            .replace('{{LOGIN_INVALID_PW}}', _login_strings['invalid_pw'].replace('\\','\\\\').replace("'","\\'"))
-            .replace('{{LOGIN_CONN_FAILED}}', _login_strings['conn_failed'].replace('\\','\\\\').replace("'","\\'"))
+            .replace('{{LOGIN_INVALID_PW}}', _html.escape(_login_strings['invalid_pw']))
+            .replace('{{LOGIN_CONN_FAILED}}', _html.escape(_login_strings['conn_failed']))
         )
         return t(handler, _page, content_type='text/html; charset=utf-8')
 

--- a/static/login.js
+++ b/static/login.js
@@ -1,0 +1,54 @@
+/* Login page — external script, no inline handlers.
+ * Loaded by the /login route. Reads data attributes from the form for
+ * i18n strings so the server does not need to inject JS literals.
+ */
+document.addEventListener('DOMContentLoaded', function () {
+  var form = document.getElementById('login-form');
+  var input = document.getElementById('pw');
+
+  if (!form || !input) return;
+
+  var invalidPw = form.getAttribute('data-invalid-pw') || 'Invalid password';
+  var connFailed = form.getAttribute('data-conn-failed') || 'Connection failed';
+
+  function showErr(msg) {
+    var err = document.getElementById('err');
+    if (err) { err.textContent = msg; err.style.display = 'block'; }
+  }
+
+  function hideErr() {
+    var err = document.getElementById('err');
+    if (err) { err.style.display = 'none'; }
+  }
+
+  async function doLogin(e) {
+    e.preventDefault();
+    var pw = input.value;
+    hideErr();
+    try {
+      var res = await fetch('/api/auth/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ password: pw }),
+        credentials: 'include',
+      });
+      var data = await res.json();
+      if (res.ok && data.ok) {
+        window.location.href = '/';
+      } else {
+        showErr(data.error || invalidPw);
+      }
+    } catch (ex) {
+      showErr(connFailed);
+    }
+  }
+
+  form.addEventListener('submit', doLogin);
+
+  input.addEventListener('keydown', function (e) {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      doLogin(e);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #222 — login page fails silently when CSP `script-src` does not include `'unsafe-inline'`.

The login page (`/login`) had inline event handler attributes (`onsubmit`, `onkeydown`) and an inline `<script>` block. These are blocked by a strict `script-src 'self'` CSP directive, causing the login button and Enter key to silently do nothing for users with password auth enabled.

## Changes

- **`static/login.js`** (new file): contains `doLogin()` and the Enter key listener, attached via `addEventListener` on `DOMContentLoaded`. No inline handlers needed.
- **`api/routes.py`**: removes the inline `<script>` block and `onsubmit`/`onkeydown` attributes from the login page template. The form now has `id="login-form"` and carries i18n strings as `data-invalid-pw` / `data-conn-failed` HTML attributes (properly HTML-escaped via `_html.escape()`) rather than injected JS string literals.
- `/static/` is already a public path in `auth.py`, so `login.js` is served without authentication.

## Why this approach

- No `unsafe-hashes` or `'unsafe-inline'` needed — the fix works with any `script-src 'self'` policy.
- The hash-based workaround from the issue report is fragile: any whitespace change to the inline code silently breaks login again. External files are versioned and served by the same static handler as all other JS.
- Consistent with how the rest of the app (boot.js, messages.js, etc.) structures its JavaScript.

## Testing

- All 436 tests pass (excluding one pre-existing unrelated failure in `test_approval_submit_and_respond`).
- All 5 existing auth tests pass.
- Login page renders correctly; `login.js` is accessible at `/static/login.js` without auth.
