### PR TITLE
fix: improve update error messages when pull fails (fixes #223)

### DIFF
--- a/api/updates.py
+++ b/api/updates.py
@@ -148,6 +148,17 @@ def _apply_update_inner(target):
         branch = _detect_default_branch(path)
         compare_ref = f'origin/{branch}'
 
+    # Fetch before attempting pull, so the remote ref is current.
+    _, fetch_ok = _run_git(['fetch', 'origin', '--quiet'], path, timeout=15)
+    if not fetch_ok:
+        return {
+            'ok': False,
+            'message': (
+                'Could not reach the remote repository. '
+                'Check your internet connection and try again.'
+            ),
+        }
+
     # Check for dirty working tree
     status_out, _ = _run_git(['status', '--porcelain'], path)
     stashed = False
@@ -162,7 +173,31 @@ def _apply_update_inner(target):
     if not pull_ok:
         if stashed:
             _run_git(['stash', 'pop'], path)
-        return {'ok': False, 'message': f'Pull failed: {pull_out[:200]}'}
+
+        # Diagnose the most common failure modes and surface actionable messages.
+        pull_lower = pull_out.lower()
+        if 'not possible to fast-forward' in pull_lower or 'diverged' in pull_lower:
+            return {
+                'ok': False,
+                'message': (
+                    f'The local {target} repo has commits that are not on the remote '
+                    'branch, so a fast-forward update is not possible. '
+                    'Run: git -C ' + str(path) + ' fetch origin && '
+                    'git -C ' + str(path) + ' reset --hard ' + compare_ref
+                ),
+                'diverged': True,
+            }
+        if 'does not track' in pull_lower or 'no tracking information' in pull_lower:
+            return {
+                'ok': False,
+                'message': (
+                    f'The local {target} branch has no upstream tracking branch configured. '
+                    'Run: git -C ' + str(path) + ' branch --set-upstream-to=' + compare_ref
+                ),
+            }
+        # Generic fallback — include the raw git output for debugging.
+        detail = pull_out.strip()[:300] if pull_out.strip() else '(no output from git)'
+        return {'ok': False, 'message': f'Pull failed: {detail}'}
 
     # Pop stash if we stashed
     if stashed:


### PR DESCRIPTION
## Summary

Fixes #223 — "Update Now" shows a generic "Pull Failed" toast with no actionable guidance.

## Root cause

`_apply_update_inner()` in `api/updates.py` ran `git pull --ff-only` and, on failure, returned only the first 200 chars of git's raw stderr. Three common failure modes all produced the same opaque message:

1. **Diverged local history** — local repo has commits that aren't on the remote branch. `git pull --ff-only` exits with "Not possible to fast-forward, aborting." No guidance on how to recover.
2. **No upstream tracking branch** — brand-new local branch or branch created without `--track`. `git pull` exits with "no tracking information."
3. **Network failure** — couldn't reach origin. Previously indistinguishable from pull errors since no fetch was done up front.

## Changes (`api/updates.py`)

- **Explicit `git fetch` before pull** — if the fetch fails (network down, auth issue, etc.), returns `"Could not reach the remote repository. Check your internet connection and try again."` instead of a confusing pull error.
- **Diverged history detection** — checks for "not possible to fast-forward" / "diverged" in git output and returns a message with the exact `git reset --hard` command to recover.
- **Missing upstream detection** — checks for "no tracking information" / "does not track" and returns a message with the exact `git branch --set-upstream-to` command.
- **Generic fallback** — includes up to 300 chars of raw git output (up from 200) for any other case.

## Testing

- All 17 update-related tests pass.
- 454 total tests pass (1 pre-existing unrelated failure deselected).
