### PR TITLE
fix: approval pending check broken by stale has_pending import

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -64,14 +64,13 @@ from api.streaming import _sse, _run_agent_streaming, cancel_stream
 # Approval system (optional -- graceful fallback if agent not available)
 try:
     from tools.approval import (
-        has_pending, pop_pending, submit_pending,
+        submit_pending,
         approve_session, approve_permanent, save_permanent_allowlist,
         is_approved, _pending, _lock, _permanent_approved,
         resolve_gateway_approval,
     )
 except ImportError:
-    has_pending = lambda *a, **k: False
-    pop_pending = lambda *a, **k: None
+
     submit_pending = lambda *a, **k: None
     approve_session = lambda *a, **k: None
     approve_permanent = lambda *a, **k: None
@@ -969,10 +968,10 @@ def _handle_file_read(handler, parsed):
 
 def _handle_approval_pending(handler, parsed):
     sid = parse_qs(parsed.query).get('session_id', [''])[0]
-    if has_pending(sid):
-        with _lock:
-            p = dict(_pending.get(sid, {}))
-        return j(handler, {'pending': p})
+    with _lock:
+        p = _pending.get(sid)
+    if p:
+        return j(handler, {'pending': dict(p)})
     return j(handler, {'pending': None})
 
 


### PR DESCRIPTION
**Root cause:** `api/routes.py` imported `has_pending` and `pop_pending` from `tools.approval`, but the agent module renamed `has_pending` → `has_blocking_approval` (which checks the gateway queue, not the polling `_pending` dict) and removed `pop_pending`. The import fell through to the fallback lambdas:

```python
has_pending = lambda *a, **k: False   # always False — never sees pending entries
pop_pending = lambda *a, **k: None
```

So `GET /api/approval/pending` always returned `{"pending": null}` even after a successful `/api/approval/inject_test` call — making the approval UI show no pending entry for any session.

**Fix:** `_handle_approval_pending` now checks `_pending` directly under `_lock` (the same dict that `submit_pending` writes to). No named helper needed — it's a simple `_pending.get(sid)` lookup. Stale imports removed.

**Tests:** 555 passed, 16 skipped, 0 failed (previously 554 pass + 1 pre-existing failure).