### PR TITLE
fix: unskip 16 approval tests — remove stale has_pending/pop_pending imports

### DIFF
--- a/tests/test_approval_unblock.py
+++ b/tests/test_approval_unblock.py
@@ -27,9 +27,11 @@ try:
         _lock,
         _ApprovalEntry,
         submit_pending,
-        has_pending,
-        pop_pending,
     )
+    # has_pending and pop_pending were removed from tools.approval when the
+    # agent renamed has_pending -> has_blocking_approval (gateway queue check)
+    # and removed the polling-mode pop_pending. Routes now check _pending
+    # directly. These symbols are no longer part of the public API.
     APPROVAL_AVAILABLE = True
 except ImportError:
     APPROVAL_AVAILABLE = False


### PR DESCRIPTION
The entire `test_approval_unblock.py` file was skipping because the module-level import included `has_pending` and `pop_pending`, which the agent module removed when renaming to `has_blocking_approval` and dropping the polling-mode API.

Neither symbol was used in any test body — they were only in the import block. Removing them unblocks the `APPROVAL_AVAILABLE` guard and all 16 tests run and pass.

**Before:** 595 collected, 579 passed, 16 skipped, 0 failed
**After:** 595 collected, 595 passed, 0 skipped, 0 failed