### PR TITLE
fix: stale test count in ROADMAP.md header (499 -> 604)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,7 +4,7 @@
 > Everything you can do from the CLI terminal, you can do from this UI.
 >
 > Last updated: v0.45.0 (April 10, 2026) — 604 tests, 604 passing
-> Tests: 499 total (499 passing, 0 failures)
+> Tests: 604 total (604 passing, 0 failures)
 > Source: <repo>/
 
 ---


### PR DESCRIPTION
ROADMAP.md header had two test-count lines that disagreed. Line 6 was correctly updated to 604 during the v0.45.0 docs pass, but line 7 still read `> Tests: 499 total (499 passing, 0 failures)` — a leftover from the Sprint 29 era. One-line fix.
