### PR TITLE
[Docker] Add the ability to run with the same user id/gid as the hermes installing user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get update -y --fix-missing --no-install-recommends \
     ca-certificates \
     sudo \
     curl \
+    rsync \
     && apt-get upgrade -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
@@ -35,10 +36,9 @@ ENV LC_ALL=C
 # Set environment variables
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
-    PYTHONPATH=/app \
     PYTHONIOENCODING=utf-8
 
-WORKDIR /app
+WORKDIR /apptoo
 
 # Every sudo group user does not need a password
 RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
@@ -55,38 +55,13 @@ RUN useradd -u 1024 -d /home/hermeswebui -g hermeswebui -s /bin/bash -m hermeswe
 RUN useradd -u 1025 -d /home/hermeswebuitoo -g hermeswebuitoo -s /bin/bash -m hermeswebuitoo \
     && usermod -G users hermeswebuitoo \
     && adduser hermeswebuitoo sudo
-RUN chown -R hermeswebuitoo:hermeswebuitoo /app
-
-USER hermeswebuitoo
-
-# Install uv
-# https://docs.astral.sh/uv/guides/integration/docker/#installing-uv
-RUN curl -LsSf https://astral.sh/uv/install.sh | sh
-ENV PATH="/home/hermeswebuitoo/.local/bin/:$PATH"
-ENV UV_PROJECT_ENVIRONMENT=venv
-
-# Verify that python3 and uv are installed
-RUN which python3 && python3 --version
-RUN which uv && uv --version
-
-COPY . /app
-RUN --mount=type=cache,target=/uv_cache,uid=1025,gid=1025,mode=0755 \
-    export UV_CACHE_DIR=/uv_cache \
-    && cd /app \
-    && uv venv venv \
-    && VIRTUAL_ENV=/app/venv uv pip install -r requirements.txt --trusted-host pypi.org --trusted-host files.pythonhosted.org \
-    && VIRTUAL_ENV=/app/venv uv pip install -U pip setuptools --trusted-host pypi.org --trusted-host files.pythonhosted.org \
-    && test -d /app/venv \
-    && test -f /app/venv/bin/activate \
-    && test -x /app/venv/bin/python3 \
-    && test -x /app/venv/bin/pip \
-    && VIRTUAL_ENV=/app/venv uv pip install uv \
-    && test -x /app/venv/bin/uv \
-    && unset UV_CACHE_DIR
+RUN chown -R hermeswebuitoo:hermeswebuitoo /apptoo
 
 USER root
 
 COPY --chmod=555 docker_init.bash /hermeswebui_init.bash
+
+RUN touch /.within_container
 
 # Remove APT proxy configuration and clean up APT downloaded files
 RUN rm -rf /var/lib/apt/lists/* /etc/apt/apt.conf.d/01proxy \
@@ -94,12 +69,11 @@ RUN rm -rf /var/lib/apt/lists/* /etc/apt/apt.conf.d/01proxy \
 
 USER hermeswebuitoo
 
+COPY . /apptoo
+
 # Default to binding all interfaces (required for container networking)
 ENV HERMES_WEBUI_HOST=0.0.0.0
 ENV HERMES_WEBUI_PORT=8787
-
-# State directory (mount as volume for persistence)
-ENV HERMES_WEBUI_STATE_DIR=/data
 
 EXPOSE 8787
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,6 +69,7 @@ RUN rm -rf /var/lib/apt/lists/* /etc/apt/apt.conf.d/01proxy \
 
 USER hermeswebuitoo
 
+# Staging dir for ownership transfer
 COPY . /apptoo
 
 # Default to binding all interfaces (required for container networking)

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,13 +3,96 @@ FROM python:3.12-slim
 LABEL maintainer="nesquena"
 LABEL description="Hermes Web UI — browser interface for Hermes Agent"
 
+# Install system packages
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Make use of apt-cacher-ng if available
+RUN if [ "A${BUILD_APT_PROXY:-}" != "A" ]; then \
+        echo "Using APT proxy: ${BUILD_APT_PROXY}"; \
+        printf 'Acquire::http::Proxy "%s";\n' "$BUILD_APT_PROXY" > /etc/apt/apt.conf.d/01proxy; \
+    fi \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates wget gnupg \
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get clean
+
+RUN apt-get update -y --fix-missing --no-install-recommends \
+    && apt-get install -y --no-install-recommends \
+    apt-utils \
+    locales \
+    ca-certificates \
+    sudo \
+    curl \
+    && apt-get upgrade -y \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# UTF-8
+RUN localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+ENV LANG=en_US.utf8
+ENV LC_ALL=C
+
+# Set environment variables
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PYTHONPATH=/app \
+    PYTHONIOENCODING=utf-8
+
 WORKDIR /app
 
-# Copy source
-COPY . /app
+# Every sudo group user does not need a password
+RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
-# Install Python dependencies
-RUN pip install --no-cache-dir -r requirements.txt
+# Create a new group for the hermeswebui and hermeswebuitoo users
+RUN groupadd -g 1024 hermeswebui \ 
+    && groupadd -g 1025 hermeswebuitoo
+
+# The hermeswebui (resp. hermeswebuitoo) user will have UID 1024 (resp. 1025), 
+# be part of the hermeswebui (resp. hermeswebuitoo) and users groups and be sudo capable (passwordless) 
+RUN useradd -u 1024 -d /home/hermeswebui -g hermeswebui -s /bin/bash -m hermeswebui \
+    && usermod -G users hermeswebui \
+    && adduser hermeswebui sudo
+RUN useradd -u 1025 -d /home/hermeswebuitoo -g hermeswebuitoo -s /bin/bash -m hermeswebuitoo \
+    && usermod -G users hermeswebuitoo \
+    && adduser hermeswebuitoo sudo
+RUN chown -R hermeswebuitoo:hermeswebuitoo /app
+
+USER hermeswebuitoo
+
+# Install uv
+# https://docs.astral.sh/uv/guides/integration/docker/#installing-uv
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+ENV PATH="/home/hermeswebuitoo/.local/bin/:$PATH"
+ENV UV_PROJECT_ENVIRONMENT=venv
+
+# Verify that python3 and uv are installed
+RUN which python3 && python3 --version
+RUN which uv && uv --version
+
+COPY . /app
+RUN --mount=type=cache,target=/uv_cache,uid=1025,gid=1025,mode=0755 \
+    export UV_CACHE_DIR=/uv_cache \
+    && cd /app \
+    && uv venv venv \
+    && VIRTUAL_ENV=/app/venv uv pip install -r requirements.txt --trusted-host pypi.org --trusted-host files.pythonhosted.org \
+    && VIRTUAL_ENV=/app/venv uv pip install -U pip setuptools --trusted-host pypi.org --trusted-host files.pythonhosted.org \
+    && test -d /app/venv \
+    && test -f /app/venv/bin/activate \
+    && test -x /app/venv/bin/python3 \
+    && test -x /app/venv/bin/pip \
+    && VIRTUAL_ENV=/app/venv uv pip install uv \
+    && test -x /app/venv/bin/uv \
+    && unset UV_CACHE_DIR
+
+USER root
+
+COPY --chmod=555 docker_init.bash /hermeswebui_init.bash
+
+# Remove APT proxy configuration and clean up APT downloaded files
+RUN rm -rf /var/lib/apt/lists/* /etc/apt/apt.conf.d/01proxy \
+    && apt-get clean
+
+USER hermeswebuitoo
 
 # Default to binding all interfaces (required for container networking)
 ENV HERMES_WEBUI_HOST=0.0.0.0
@@ -20,4 +103,5 @@ ENV HERMES_WEBUI_STATE_DIR=/data
 
 EXPOSE 8787
 
-CMD ["python", "server.py"]
+CMD ["/hermeswebui_init.bash"]
+

--- a/README.md
+++ b/README.md
@@ -122,20 +122,23 @@ That is it! The script will:
 
 **Pre-built images** (amd64 + arm64) are published to GHCR on every release:
 
-Make sure the `HERMES_WEBUI_STATE_DIR` and `HERMES_WEBUI_DEFAULT_WORKSPACE` folder exist with the UID/GID of the owner of the `.hermes` folder.
+Make sure the `HERMES_WEBUI_STATE_DIR` (by default `~/.hermes/webui-mvp`, as detailed in the `.env.example` file) folder exist with the UID/GID of the owner of the `.hermes` folder. 
+The container will also mount your configured "workspace" (also from the example .env.example) as `/workspace`. adapt the location as needed.
+
 
 ```bash
 docker pull ghcr.io/nesquena/hermes-webui:latest
 docker run -d \
 -e WANTED_UID=`id -u` -e WANTED_GID=`id -g` \
 -v ~/.hermes:/home/hermeswebui/.hermes -e HERMES_WEBUI_STATE_DIR=/home/hermeswebui/.hermes/webui-mvp \
--v ~/workspace:/workspace -e HERMES_WEBUI_DEFAULT_WORKSPACE=/workspace \
+-v ~/workspace:/workspace \
 -p 8787:8787 ghcr.io/nesquena/hermes-webui:latest
 ```
 
 Or run with Docker Compose (recommended):
 
 ```bash
+# Check the docker-compose.yml and make sure to adapt as needed, at minimum WANTED_UID/WANTED_GID
 docker compose up -d
 ```
 
@@ -146,7 +149,7 @@ docker build -t hermes-webui .
 docker run -d \
 -e WANTED_UID=`id -u` -e WANTED_GID=`id -g` \
 -v ~/.hermes:/home/hermeswebui/.hermes -e HERMES_WEBUI_STATE_DIR=/home/hermeswebui/.hermes/webui-mvp \
--v ~/workspace:/workspace -e HERMES_WEBUI_DEFAULT_WORKSPACE=/workspace \
+-v ~/workspace:/workspace \
 -p 8787:8787 hermes-webui
 ```
 
@@ -158,7 +161,7 @@ To enable password protection:
 docker run -d \
 -e WANTED_UID=`id -u` -e WANTED_GID=`id -g` \
 -v ~/.hermes:/home/hermeswebui/.hermes -e HERMES_WEBUI_STATE_DIR=/home/hermeswebui/.hermes/webui-mvp \
--v ~/workspace:/workspace -e HERMES_WEBUI_DEFAULT_WORKSPACE=/workspace \
+-v ~/workspace:/workspace \
 -p 8787:8787 -e HERMES_WEBUI_PASSWORD=your-secret ghcr.io/nesquena/hermes-webui:latest
 ```
 

--- a/README.md
+++ b/README.md
@@ -122,9 +122,15 @@ That is it! The script will:
 
 **Pre-built images** (amd64 + arm64) are published to GHCR on every release:
 
+Make sure the `HERMES_WEBUI_STATE_DIR` and `HERMES_WEBUI_DEFAULT_WORKSPACE` folder exist with the UID/GID of the owner of the `.hermes` folder.
+
 ```bash
 docker pull ghcr.io/nesquena/hermes-webui:latest
-docker run -d -p 8787:8787 -v ~/.hermes:/root/.hermes ghcr.io/nesquena/hermes-webui:latest
+docker run -d \
+-e WANTED_UID=`id -u` -e WANTED_GID=`id -g` \
+-v ~/.hermes:/home/hermeswebui/.hermes -e HERMES_WEBUI_STATE_DIR=/home/hermeswebui/.hermes/webui-mvp \
+-v ~/workspace:/workspace -e HERMES_WEBUI_DEFAULT_WORKSPACE=/workspace \
+-p 8787:8787 ghcr.io/nesquena/hermes-webui:latest
 ```
 
 Or run with Docker Compose (recommended):
@@ -137,7 +143,11 @@ Or build locally:
 
 ```bash
 docker build -t hermes-webui .
-docker run -d -p 8787:8787 -v ~/.hermes:/root/.hermes hermes-webui
+docker run -d \
+-e WANTED_UID=`id -u` -e WANTED_GID=`id -g` \
+-v ~/.hermes:/home/hermeswebui/.hermes -e HERMES_WEBUI_STATE_DIR=/home/hermeswebui/.hermes/webui-mvp \
+-v ~/workspace:/workspace -e HERMES_WEBUI_DEFAULT_WORKSPACE=/workspace \
+-p 8787:8787 hermes-webui
 ```
 
 Open http://localhost:8787 in your browser.
@@ -145,10 +155,12 @@ Open http://localhost:8787 in your browser.
 To enable password protection:
 
 ```bash
-docker run -d -p 8787:8787 -e HERMES_WEBUI_PASSWORD=your-secret -v ~/.hermes:/root/.hermes ghcr.io/nesquena/hermes-webui:latest
+docker run -d \
+-e WANTED_UID=`id -u` -e WANTED_GID=`id -g` \
+-v ~/.hermes:/home/hermeswebui/.hermes -e HERMES_WEBUI_STATE_DIR=/home/hermeswebui/.hermes/webui-mvp \
+-v ~/workspace:/workspace -e HERMES_WEBUI_DEFAULT_WORKSPACE=/workspace \
+-p 8787:8787 -e HERMES_WEBUI_PASSWORD=your-secret ghcr.io/nesquena/hermes-webui:latest
 ```
-
-Session data persists in a named volume (`hermes-data`) across restarts.
 
 > **Note:** By default, Docker Compose binds to `127.0.0.1` (localhost only).
 > To expose on a network, change the port to `"8787:8787"` in `docker-compose.yml`

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -28,6 +28,23 @@ try:
     from run_agent import AIAgent
 except ImportError:
     AIAgent = None
+
+def _get_ai_agent():
+    """Return AIAgent class, retrying the import if the initial attempt failed.
+
+    auto_install_agent_deps() in server.py may install missing packages after
+    this module is first imported (common in Docker with a volume-mounted agent).
+    Re-attempting the import here picks up the newly installed packages without
+    requiring a server restart.
+    """
+    global AIAgent
+    if AIAgent is None:
+        try:
+            from run_agent import AIAgent as _cls  # noqa: PLC0415
+            AIAgent = _cls
+        except ImportError:
+            pass
+    return AIAgent
 from api.models import get_session, title_from
 from api.workspace import set_last_workspace
 
@@ -111,15 +128,15 @@ def _run_agent_streaming(session_id, msg_text, model, workspace, stream_id, atta
         # The finally block re-acquires to restore — keeping critical sections short
         # and preventing a deadlock where the restore would re-enter the same lock.
         with _ENV_LOCK:
-          old_cwd = os.environ.get('TERMINAL_CWD')
-          old_exec_ask = os.environ.get('HERMES_EXEC_ASK')
-          old_session_key = os.environ.get('HERMES_SESSION_KEY')
-          old_hermes_home = os.environ.get('HERMES_HOME')
-          os.environ['TERMINAL_CWD'] = str(s.workspace)
-          os.environ['HERMES_EXEC_ASK'] = '1'
-          os.environ['HERMES_SESSION_KEY'] = session_id
-          if _profile_home:
-              os.environ['HERMES_HOME'] = _profile_home
+            old_cwd = os.environ.get('TERMINAL_CWD')
+            old_exec_ask = os.environ.get('HERMES_EXEC_ASK')
+            old_session_key = os.environ.get('HERMES_SESSION_KEY')
+            old_hermes_home = os.environ.get('HERMES_HOME')
+            os.environ['TERMINAL_CWD'] = str(s.workspace)
+            os.environ['HERMES_EXEC_ASK'] = '1'
+            os.environ['HERMES_SESSION_KEY'] = session_id
+            if _profile_home:
+                os.environ['HERMES_HOME'] = _profile_home
         # Lock released — agent runs without holding it
         # Register a gateway-style notify callback so the approval system can
         # push the `approval` SSE event the moment a dangerous command is
@@ -165,7 +182,8 @@ def _run_agent_streaming(session_id, msg_text, model, workspace, stream_id, atta
                 except ImportError:
                     pass
 
-            if AIAgent is None:
+            _AIAgent = _get_ai_agent()
+            if _AIAgent is None:
                 raise ImportError("AIAgent not available -- check that hermes-agent is on sys.path")
             resolved_model, resolved_provider, resolved_base_url = resolve_model_provider(model)
 
@@ -206,7 +224,7 @@ def _run_agent_streaming(session_id, msg_text, model, workspace, stream_id, atta
             else:
                 _fallback_resolved = None
 
-            agent = AIAgent(
+            agent = _AIAgent(
                 model=resolved_model,
                 provider=resolved_provider,
                 base_url=resolved_base_url,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,8 @@ services:
   hermes-webui:
     build: .
     ports:
-#      - "127.0.0.1:8787:8787"
-      - "8787:8787"
+      - "127.0.0.1:8787:8787"
+#      - "8787:8787"
     volumes:
       # Mount hermes home for agent features and profile management
       - ${HERMES_HOME:-${HOME}/.hermes}:/home/hermeswebui/.hermes

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,19 +4,25 @@ services:
   hermes-webui:
     build: .
     ports:
-      - "127.0.0.1:8787:8787"
+#      - "127.0.0.1:8787:8787"
+      - "8787:8787"
     volumes:
-      # Persist session data, settings, and projects across restarts
-      - hermes-data:/data
+      - ./hermeswebui:/data
       # Mount hermes home for agent features and profile management
-      - ${HERMES_HOME:-${HOME}/.hermes}:/root/.hermes
+      - ${HERMES_HOME:-${HOME}/.hermes}:/home/hermeswebui/.hermes
+      # Default workspace directory shown on first launch
+      - ${HERMES_HOME:-${HOME}}/workspace:/workspace
     environment:
+      - WANTED_UID=1000
+      - WANTED_GID=1000
+      # Required: bind address and port
       - HERMES_WEBUI_HOST=0.0.0.0
       - HERMES_WEBUI_PORT=8787
-      - HERMES_WEBUI_STATE_DIR=/data
+      # Where to store sessions, workspaces, and other state (default: ~/.hermes/webui-mvp)
+      - HERMES_WEBUI_STATE_DIR=/home/hermeswebui/.hermes/webui-mvp
+      # Default workspace directory shown on first launch
+      - HERMES_WEBUI_DEFAULT_WORKSPACE=/workspace
       # Optional: set a password for remote access
       # - HERMES_WEBUI_PASSWORD=your-secret-password
     restart: unless-stopped
 
-volumes:
-  hermes-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   hermes-webui:
     build: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,6 @@ services:
 #      - "127.0.0.1:8787:8787"
       - "8787:8787"
     volumes:
-      - ./hermeswebui:/data
       # Mount hermes home for agent features and profile management
       - ${HERMES_HOME:-${HOME}/.hermes}:/home/hermeswebui/.hermes
       # Default workspace directory shown on first launch

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,6 @@ services:
       # Modify the UID and GID to match your user; docker compose starts as root by default, but the container will drop privileges to the specified UID/GID
       - WANTED_UID=${UID:-1000}
       - WANTED_GID=${GID:-1000}
-      - WANTED_GID=1000
       # Required: bind address and port
       - HERMES_WEBUI_HOST=0.0.0.0
       - HERMES_WEBUI_PORT=8787

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,15 +4,19 @@ services:
   hermes-webui:
     build: .
     ports:
+    # select only one; use 127.0.0.1 version to expose to localhost only
       - "127.0.0.1:8787:8787"
 #      - "8787:8787"
     volumes:
+      # Within the containe the tool expects to find the .hermes location at /home/hermeswebui/.hermes, so we mount it there; this allows you to manage agent profiles and other features that rely on the .hermes directory from your host machine, make sure to adapt the path if your HERMES_HOME is different
       # Mount hermes home for agent features and profile management
       - ${HERMES_HOME:-${HOME}/.hermes}:/home/hermeswebui/.hermes
-      # Default workspace directory shown on first launch
+      # Your workspace directory shown on first launch (adapt if yours is different, the container will use the mounted /workspace)
       - ${HERMES_HOME:-${HOME}}/workspace:/workspace
     environment:
-      - WANTED_UID=1000
+      # Modify the UID and GID to match your user; docker compose starts as root by default, but the container will drop privileges to the specified UID/GID
+      - WANTED_UID=${UID:-1000}
+      - WANTED_GID=${GID:-1000}
       - WANTED_GID=1000
       # Required: bind address and port
       - HERMES_WEBUI_HOST=0.0.0.0
@@ -20,7 +24,7 @@ services:
       # Where to store sessions, workspaces, and other state (default: ~/.hermes/webui-mvp)
       - HERMES_WEBUI_STATE_DIR=/home/hermeswebui/.hermes/webui-mvp
       # Default workspace directory shown on first launch
-      - HERMES_WEBUI_DEFAULT_WORKSPACE=/workspace
+#      - HERMES_WEBUI_DEFAULT_WORKSPACE=/workspace
       # Optional: set a password for remote access
       # - HERMES_WEBUI_PASSWORD=your-secret-password
     restart: unless-stopped

--- a/docker_init.bash
+++ b/docker_init.bash
@@ -164,8 +164,13 @@ if [ -f $it ]; then
   load_env $it true
 fi
 
-echo ""; echo "-- Making sure /app is owned by the hermeswebui user to avoid permission issues when running the server and installing packages"
-sudo chown -R ${WANTED_UID}:${WANTED_GID} /app || error_exit "Failed to set owner of /app to hermeswebui user"
+##
+echo ""; echo "-- Making sure /app is owned by the hermeswebui user to avoid permission issues when running the server "
+sudo mkdir -p /app || error_exit "Failed to create /app directory"
+sudo chown hermeswebui:hermeswebui /app || error_exit "Failed to set owner of /app to hermeswebui user"
+sudo rsync -av --chown=hermeswebui:hermeswebui /apptoo/ /app/ || error_exit "Failed to sync /apptoo to /app with correct ownership"
+it=/app/.testfile; touch $it || error_exit "Failed to verify /app directory"
+rm -f $it || error_exit "Failed to delete test file in /app"
 
 ######## Environment variables (consume AFTER the load_env)
 
@@ -176,17 +181,48 @@ if [ -z "${HERMES_WEBUI_STATE_DIR+x}" ]; then error_exit "HERMES_WEBUI_STATE_DIR
 echo "-- HERMES_WEBUI_STATE_DIR: $HERMES_WEBUI_STATE_DIR"
 if [ ! -d "$HERMES_WEBUI_STATE_DIR" ]; then mkdir -p $HERMES_WEBUI_STATE_DIR || error_exit "Failed to create state directory at $HERMES_WEBUI_STATE_DIR"; fi
 if [ ! -d "$HERMES_WEBUI_STATE_DIR" ]; then error_exit "HERMES_WEBUI_STATE_DIR directory does not exist at $HERMES_WEBUI_STATE_DIR"; fi
-touch $HERMES_WEBUI_STATE_DIR/.testfile || error_exit "Failed to verify state directory at $HERMES_WEBUI_STATE_DIR"
-rm -f $HERMES_WEBUI_STATE_DIR/.testfile || error_exit "Failed to delete test file in $HERMES_WEBUI_STATE_DIR"
+it="$HERMES_WEBUI_STATE_DIR/.testfile"; touch $it || error_exit "Failed to verify state directory at $HERMES_WEBUI_STATE_DIR"
+rm -f $it || error_exit "Failed to delete test file in $HERMES_WEBUI_STATE_DIR"
 
 echo ""; echo "-- HERMES_WEBUI_DEFAULT_WORKSPACE: Default workspace directory shown on first launch"
-if [ -z "${HERMES_WEBUI_DEFAULT_WORKSPACE+x}" ]; then error_exit "HERMES_WEBUI_DEFAULT_WORKSPACE not set"; fi; 
+if [ -z "${HERMES_WEBUI_DEFAULT_WORKSPACE+x}" ]; then echo "HERMES_WEBUI_DEFAULT_WORKSPACE not set, setting to /workspace"; export HERMES_WEBUI_DEFAULT_WORKSPACE="/workspace"; fi;
 echo "-- HERMES_WEBUI_DEFAULT_WORKSPACE: $HERMES_WEBUI_DEFAULT_WORKSPACE"
-touch $HERMES_WEBUI_DEFAULT_WORKSPACE/.testfile || error_exit "Failed to verify default workspace at $HERMES_WEBUI_DEFAULT_WORKSPACE"
-rm -f $HERMES_WEBUI_DEFAULT_WORKSPACE/.testfile || error_exit "Failed to delete test file in $HERMES_WEBUI_DEFAULT_WORKSPACE"
+if [ ! -d "$HERMES_WEBUI_DEFAULT_WORKSPACE" ]; then mkdir -p $HERMES_WEBUI_DEFAULT_WORKSPACE || error_exit "Failed to create default workspace at $HERMES_WEBUI_DEFAULT_WORKSPACE"; fi
+if [ ! -d "$HERMES_WEBUI_DEFAULT_WORKSPACE" ]; then error_exit "HERMES_WEBUI_DEFAULT_WORKSPACE directory does not exist at $HERMES_WEBUI_DEFAULT_WORKSPACE"; fi
+it="$HERMES_WEBUI_DEFAULT_WORKSPACE/.testfile"; touch $it || error_exit "Failed to verify default workspace at $HERMES_WEBUI_DEFAULT_WORKSPACE"
+rm -f $it || error_exit "Failed to delete test file in $HERMES_WEBUI_DEFAULT_WORKSPACE"
 
 echo ""; echo "==================="
-echo "== Running hermes-webui"
-cd /app; source /app/venv/bin/activate; python server.py ${CLI_ARGS} || error_exit "hermes-webui failed or exited with an error"
+echo ""; echo "== Installing uv and creating a new virtual environment for hermes-webui"
 
+curl -LsSf https://astral.sh/uv/install.sh | sh
+export PATH="/home/hermeswebui/.local/bin/:$PATH"
+export UV_PROJECT_ENVIRONMENT=venv
+
+export UV_CACHE_DIR=/uv_cache
+sudo mkdir -p ${UV_CACHE_DIR} || error_exit "Failed to create /uv_cache directory"
+sudo chown hermeswebui:hermeswebui ${UV_CACHE_DIR} || error_exit "Failed to set owner of ${UV_CACHE_DIR} to hermeswebui user"
+
+cd /app
+uv venv venv
+export VIRTUAL_ENV=/app/venv
+test -d /app/venv
+test -f /app/venv/bin/activate
+
+echo "";echo "== Activating hermes webui's virtual environment"
+source /app/venv/bin/activate || error_exit "Failed to activate hermeswebui virtual environment"
+test -x /app/venv/bin/python3
+
+echo ""; echo "== Installing hermes-webui dependencies"
+uv pip install -r requirements.txt --trusted-host pypi.org --trusted-host files.pythonhosted.org
+uv pip install -U pip setuptools --trusted-host pypi.org --trusted-host files.pythonhosted.org
+test -x /app/venv/bin/pip
+
+echo ""; echo "== Adding hermes-agent's pyproject.toml base dependencies to the virtual environment"
+uv pip install /home/hermeswebui/.hermes/hermes-agent --trusted-host pypi.org --trusted-host files.pythonhosted.org || error_exit "Failed to install hermes-agent's requirements"
+
+echo ""; echo "== Running hermes-webui"
+cd /app; python server.py || error_exit "hermes-webui failed or exited with an error"
+
+# we should never be here because the server should be running indefinitely, but if we are, we exit safely
 ok_exit "Clean exit"

--- a/docker_init.bash
+++ b/docker_init.bash
@@ -1,0 +1,192 @@
+#!/bin/bash
+
+set -e
+
+error_exit() {
+  echo -n "!! ERROR: "
+  echo $*
+  echo "!! Exiting script (ID: $$)"
+  exit 1
+}
+
+ok_exit() {
+  echo $*
+  echo "++ Exiting script (ID: $$)"
+  exit 0
+}
+
+## Environment variables loaded when passing environment variables from user to user
+# Ignore list: variables to ignore when loading environment variables from user to user
+export ENV_IGNORELIST="HOME PWD USER SHLVL TERM OLDPWD SHELL _ SUDO_COMMAND HOSTNAME LOGNAME MAIL SUDO_GID SUDO_UID SUDO_USER CHECK_NV_CUDNN_VERSION VIRTUAL_ENV VIRTUAL_ENV_PROMPT ENV_IGNORELIST ENV_OBFUSCATE_PART"
+# Obfuscate part: part of the key to obfuscate when loading environment variables from user to user, ex: HF_TOKEN, ...
+export ENV_OBFUSCATE_PART="TOKEN API KEY"
+
+# Check for ENV_IGNORELIST and ENV_OBFUSCATE_PART
+if [ -z "${ENV_IGNORELIST+x}" ]; then error_exit "ENV_IGNORELIST not set"; fi
+if [ -z "${ENV_OBFUSCATE_PART+x}" ]; then error_exit "ENV_OBFUSCATE_PART not set"; fi
+
+whoami=`whoami`
+script_dir=$(dirname $0)
+script_name=$(basename $0)
+echo ""; echo ""
+echo "======================================"
+echo "=================== Starting script (ID: $$)"
+echo "== Running ${script_name} in ${script_dir} as ${whoami}"
+script_fullname=$0
+echo "  - script_fullname: ${script_fullname}"
+ignore_value="VALUE_TO_IGNORE"
+
+# everyone can read our files by default
+umask 0022
+
+# Write a world-writeable file (preferably inside /tmp -- ie within the container)
+write_worldtmpfile() {
+  tmpfile=$1
+  if [ -z "${tmpfile}" ]; then error_exit "write_worldfile: missing argument"; fi
+  if [ -f $tmpfile ]; then rm -f $tmpfile; fi
+  echo -n $2 > ${tmpfile}
+  chmod 777 ${tmpfile}
+}
+
+itdir=/tmp/hermeswebui_init
+if [ ! -d $itdir ]; then mkdir $itdir; chmod 777 $itdir; fi
+if [ ! -d $itdir ]; then error_exit "Failed to create $itdir"; fi
+
+# Set user and group id
+# logic: if not set and file exists, use file value, else use default. Create file for persistence when the container is re-run
+# reasoning: needed when using docker compose as the file will exist in the stopped container, and changing the value from environment variables or configuration file must be propagated from hermeswebuitoo to hermeswebuitoo transition (those values are the only ones loaded before the environment variables dump file are loaded)
+it=$itdir/hermeswebui_user_uid
+if [ -z "${WANTED_UID+x}" ]; then
+  if [ -f $it ]; then WANTED_UID=$(cat $it); fi
+fi
+WANTED_UID=${WANTED_UID:-1024}
+write_worldtmpfile $it "$WANTED_UID"
+echo "-- WANTED_UID: \"${WANTED_UID}\""
+
+it=$itdir/hermeswebui_user_gid
+if [ -z "${WANTED_GID+x}" ]; then
+  if [ -f $it ]; then WANTED_GID=$(cat $it); fi
+fi
+WANTED_GID=${WANTED_GID:-1024}
+write_worldtmpfile $it "$WANTED_GID"
+echo "-- WANTED_GID: \"${WANTED_GID}\""
+
+echo "== Most Environment variables set"
+
+# Check user id and group id
+new_gid=`id -g`
+new_uid=`id -u`
+echo "== user ($whoami)"
+echo "  uid: $new_uid / WANTED_UID: $WANTED_UID"
+echo "  gid: $new_gid / WANTED_GID: $WANTED_GID"
+
+save_env() {
+  tosave=$1
+  echo "-- Saving environment variables to $tosave"
+  env | sort > "$tosave"
+}
+
+load_env() {
+  tocheck=$1
+  overwrite_if_different=$2
+  ignore_list="${ENV_IGNORELIST}"
+  obfuscate_part="${ENV_OBFUSCATE_PART}"
+  if [ -f "$tocheck" ]; then
+    echo "-- Loading environment variables from $tocheck (overwrite existing: $overwrite_if_different) (ignorelist: $ignore_list) (obfuscate: $obfuscate_part)"
+    while IFS='=' read -r key value; do
+      doit=false
+      # checking if the key is in the ignorelist
+      for i in $ignore_list; do
+        if [[ "A$key" ==  "A$i" ]]; then doit=ignore; break; fi
+      done
+      if [[ "A$doit" == "Aignore" ]]; then continue; fi
+      rvalue=$value
+      # checking if part of the key is in the obfuscate list
+      doobs=false
+      for i in $obfuscate_part; do
+        if [[ "A$key" == *"$i"* ]]; then doobs=obfuscate; break; fi
+      done
+      if [[ "A$doobs" == "Aobfuscate" ]]; then rvalue="**OBFUSCATED**"; fi
+
+      if [ -z "${!key}" ]; then
+        echo "  ++ Setting environment variable $key [$rvalue]"
+        doit=true
+      elif [ "A$overwrite_if_different" == "Atrue" ]; then
+        cvalue="${!key}"
+        if [[ "A${doobs}" == "Aobfuscate" ]]; then cvalue="**OBFUSCATED**"; fi
+        if [[ "A${!key}" != "A${value}" ]]; then
+          echo "  @@ Overwriting environment variable $key [$cvalue] -> [$rvalue]"
+          doit=true
+        else
+          echo "  == Environment variable $key [$rvalue] already set and value is unchanged"
+        fi
+      fi
+      if [[ "A$doit" == "Atrue" ]]; then
+        export "$key=$value"
+      fi
+    done < "$tocheck"
+  fi
+}
+
+# hermeswebuitoo is a specfiic user not existing by default on ubuntu, we can check its whomai
+if [ "A${whoami}" == "Ahermeswebuitoo" ]; then 
+  echo "-- Running as hermeswebuitoo, will switch hermeswebui to the desired UID/GID"
+  # The script is started as hermeswebuitoo -- UID/GID 1025/1025
+
+  # We are altering the UID/GID of the hermeswebui user to the desired ones and restarting as that user
+  # using usermod for the already create hermeswebui user, knowing it is not already in use
+  # per usermod manual: "You must make certain that the named user is not executing any processes when this command is being executed"
+  sudo groupmod -o -g ${WANTED_GID} hermeswebui || error_exit "Failed to set GID of hermeswebui user"
+  sudo usermod -o -u ${WANTED_UID} hermeswebui || error_exit "Failed to set UID of hermeswebui user"
+  sudo chown -R ${WANTED_UID}:${WANTED_GID} /home/hermeswebui || error_exit "Failed to set owner of /home/hermeswebui"
+  save_env /tmp/hermeswebuitoo_env.txt  
+  # restart the script as hermeswebui set with the correct UID/GID this time
+  echo "-- Restarting as hermeswebui user with UID ${WANTED_UID} GID ${WANTED_GID}"
+  sudo su hermeswebui $script_fullname || error_exit "subscript failed"
+  ok_exit "Clean exit"
+fi
+
+# If we are here, the script is started as another user than hermeswebuitoo
+# because the whoami value for the hermeswebui user can be any existing user, we can not check against it
+# instead we check if the UID/GID are the expected ones
+if [ "$WANTED_GID" != "$new_gid" ]; then error_exit "hermeswebui MUST be running as UID ${WANTED_UID} GID ${WANTED_GID}, current UID ${new_uid} GID ${new_gid}"; fi
+if [ "$WANTED_UID" != "$new_uid" ]; then error_exit "hermeswebui MUST be running as UID ${WANTED_UID} GID ${WANTED_GID}, current UID ${new_uid} GID ${new_gid}"; fi
+
+########## 'hermeswebui' specific section below
+
+# We are therefore running as hermeswebui
+echo ""; echo "== Running as hermeswebui"
+
+# Load environment variables one by one if they do not exist from /tmp/hermeswebuitoo_env.txt
+it=/tmp/hermeswebuitoo_env.txt
+if [ -f $it ]; then
+  echo "-- Loading not already set environment variables from $it"
+  load_env $it true
+fi
+
+echo ""; echo "-- Making sure /app is owned by the hermeswebui user to avoid permission issues when running the server and installing packages"
+sudo chown -R ${WANTED_UID}:${WANTED_GID} /app || error_exit "Failed to set owner of /app to hermeswebui user"
+
+######## Environment variables (consume AFTER the load_env)
+
+echo ""; echo "== Checking required environment variables for hermes-webui"
+
+echo ""; echo "-- HERMES_WEBUI_VERSION: Where to store sessions, workspaces, and other state (default: ~/.hermes/webui-mvp)"
+if [ -z "${HERMES_WEBUI_STATE_DIR+x}" ]; then error_exit "HERMES_WEBUI_STATE_DIR not set"; fi; 
+echo "-- HERMES_WEBUI_STATE_DIR: $HERMES_WEBUI_STATE_DIR"
+if [ ! -d "$HERMES_WEBUI_STATE_DIR" ]; then mkdir -p $HERMES_WEBUI_STATE_DIR || error_exit "Failed to create state directory at $HERMES_WEBUI_STATE_DIR"; fi
+if [ ! -d "$HERMES_WEBUI_STATE_DIR" ]; then error_exit "HERMES_WEBUI_STATE_DIR directory does not exist at $HERMES_WEBUI_STATE_DIR"; fi
+touch $HERMES_WEBUI_STATE_DIR/.testfile || error_exit "Failed to verify state directory at $HERMES_WEBUI_STATE_DIR"
+rm -f $HERMES_WEBUI_STATE_DIR/.testfile || error_exit "Failed to delete test file in $HERMES_WEBUI_STATE_DIR"
+
+echo ""; echo "-- HERMES_WEBUI_DEFAULT_WORKSPACE: Default workspace directory shown on first launch"
+if [ -z "${HERMES_WEBUI_DEFAULT_WORKSPACE+x}" ]; then error_exit "HERMES_WEBUI_DEFAULT_WORKSPACE not set"; fi; 
+echo "-- HERMES_WEBUI_DEFAULT_WORKSPACE: $HERMES_WEBUI_DEFAULT_WORKSPACE"
+touch $HERMES_WEBUI_DEFAULT_WORKSPACE/.testfile || error_exit "Failed to verify default workspace at $HERMES_WEBUI_DEFAULT_WORKSPACE"
+rm -f $HERMES_WEBUI_DEFAULT_WORKSPACE/.testfile || error_exit "Failed to delete test file in $HERMES_WEBUI_DEFAULT_WORKSPACE"
+
+echo ""; echo "==================="
+echo "== Running hermes-webui"
+cd /app; source /app/venv/bin/activate; python server.py ${CLI_ARGS} || error_exit "hermes-webui failed or exited with an error"
+
+ok_exit "Clean exit"

--- a/docker_init.bash
+++ b/docker_init.bash
@@ -193,7 +193,7 @@ it="$HERMES_WEBUI_DEFAULT_WORKSPACE/.testfile"; touch $it || error_exit "Failed 
 rm -f $it || error_exit "Failed to delete test file in $HERMES_WEBUI_DEFAULT_WORKSPACE"
 
 echo ""; echo "==================="
-echo ""; echo "== Installing uv and creating a new virtual environment for hermes-webui"
+echo ""; echo "== Installing uv asa as hermeswebui and creating a new virtual environment for hermes-webui"
 
 curl -LsSf https://astral.sh/uv/install.sh | sh
 export PATH="/home/hermeswebui/.local/bin/:$PATH"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@
 # The server uses only stdlib + pyyaml.
 # All heavy ML/agent deps live in the Hermes agent venv.
 pyyaml>=6.0
-openai

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@
 # The server uses only stdlib + pyyaml.
 # All heavy ML/agent deps live in the Hermes agent venv.
 pyyaml>=6.0
+openai

--- a/server.py
+++ b/server.py
@@ -63,6 +63,17 @@ def main() -> None:
 
     print_startup_config()
 
+    within_container = False
+    # Check for the "/.within_container" file to determine if we're running inside a container; this file is created in the Dockerfile
+    try:
+        with open('/.within_container', 'r') as f:
+            within_container = True
+    except FileNotFoundError:
+        pass
+
+    if within_container:
+        print('[ok] Running within container.', flush=True)
+
     # Security: warn if binding non-loopback without authentication
     from api.auth import is_auth_enabled
     if HOST not in ('127.0.0.1', '::1', 'localhost') and not is_auth_enabled():
@@ -70,6 +81,8 @@ def main() -> None:
         print(f'     Anyone on the network can access your filesystem and agent.', flush=True)
         print(f'     Set a password via Settings or HERMES_WEBUI_PASSWORD env var.', flush=True)
         print(f'     To suppress: bind to 127.0.0.1 or set a password.', flush=True)
+        if within_container:
+            print(f'     Note: You are running within a container, must bind to 0.0.0.0 to publish the port.', flush=True)
 
     ok, missing, errors = verify_hermes_imports()
     if not ok and _HERMES_FOUND:
@@ -108,7 +121,7 @@ def main() -> None:
             scheme = 'http'
 
     print(f'  Hermes Web UI listening on {scheme}://{HOST}:{PORT}', flush=True)
-    if HOST == '127.0.0.1':
+    if HOST == '127.0.0.1' or within_container:
         print(f'  Remote access: ssh -N -L {PORT}:127.0.0.1:{PORT} <user>@<your-server>', flush=True)
     print(f'  Then open:     {scheme}://localhost:{PORT}', flush=True)
     print('', flush=True)


### PR DESCRIPTION
Using as a non-root user (with `sudo` privileges if needed) installation of hermes-agent, this PR will allow the files in `.hermes` to not be created/modified by the `root` user (the default user of the container).

This PR proposes using a `hermeswebui` user within the container; that user's UID/GID can be configured via the `WANTED_UID` and `WANTED_GID` environment variables to match the user who owns the `.hermes` folder.
I updated the `README.md` to reflect the change and explain its use case.

The `docker_init.bash` file contains most of the user-switching logic.

This is the same technique I have used successfully in the ComfyUI project I am maintaining.

I tested functionality using:

```bash
docker compose up --build
[...]
[+] up 2/2
 ✔ Image hermes-webui-hermes-webui       Built                                                                                                                                           0.9s
 ✔ Container hermes-webui-hermes-webui-1 Recreated                                                                                                                                       0.6s
Attaching to hermes-webui-1
hermes-webui-1  |
hermes-webui-1  |
hermes-webui-1  | ======================================
hermes-webui-1  | =================== Starting script (ID: 1)
hermes-webui-1  | == Running hermeswebui_init.bash in / as hermeswebuitoo
hermes-webui-1  |   - script_fullname: /hermeswebui_init.bash
hermes-webui-1  | -- WANTED_UID: "1000"
hermes-webui-1  | -- WANTED_GID: "1000"
hermes-webui-1  | == Most Environment variables set
hermes-webui-1  | == user (hermeswebuitoo)
hermes-webui-1  |   uid: 1025 / WANTED_UID: 1000
hermes-webui-1  |   gid: 1025 / WANTED_GID: 1000
hermes-webui-1  | -- Running as hermeswebuitoo, will switch hermeswebui to the desired UID/GID
hermes-webui-1  | -- Saving environment variables to /tmp/hermeswebuitoo_env.txt
hermes-webui-1  | -- Restarting as hermeswebui user with UID 1000 GID 1000
hermes-webui-1  |
hermes-webui-1  |
hermes-webui-1  | ======================================
hermes-webui-1  | =================== Starting script (ID: 38)
hermes-webui-1  | == Running hermeswebui_init.bash in / as hermeswebui
hermes-webui-1  |   - script_fullname: /hermeswebui_init.bash
hermes-webui-1  | -- WANTED_UID: "1000"
hermes-webui-1  | -- WANTED_GID: "1000"
hermes-webui-1  | == Most Environment variables set
hermes-webui-1  | == user (hermeswebui)
hermes-webui-1  |   uid: 1000 / WANTED_UID: 1000
hermes-webui-1  |   gid: 1000 / WANTED_GID: 1000
hermes-webui-1  |
hermes-webui-1  | == Running as hermeswebui
hermes-webui-1  | -- Loading not already set environment variables from /tmp/hermeswebuitoo_env.txt
hermes-webui-1  | -- Loading environment variables from /tmp/hermeswebuitoo_env.txt (overwrite existing: true) (ignorelist: HOME PWD USER SHLVL TERM OLDPWD SHELL _ SUDO_COMMAND HOSTNAME LOGNAME MAIL SUDO_GID SUDO_UID SUDO_USER CHECK_NV_CUDNN_VERSION VIRTUAL_ENV VIRTUAL_ENV_PROMPT ENV_IGNORELIST ENV_OBFUSCATE_PART) (obfuscate: TOKEN API KEY)
hermes-webui-1  |   ++ Setting environment variable DEBIAN_FRONTEND [noninteractive]
hermes-webui-1  |   ++ Setting environment variable GPG_KEY [**OBFUSCATED**]
hermes-webui-1  |   ++ Setting environment variable HERMES_WEBUI_DEFAULT_WORKSPACE [/workspace]
hermes-webui-1  |   ++ Setting environment variable HERMES_WEBUI_HOST [0.0.0.0]
hermes-webui-1  |   ++ Setting environment variable HERMES_WEBUI_PORT [8787]
hermes-webui-1  |   ++ Setting environment variable HERMES_WEBUI_STATE_DIR [/home/hermeswebui/.hermes/webui-mvp]
hermes-webui-1  |   == Environment variable LANG [en_US.utf8] already set and value is unchanged
hermes-webui-1  |   == Environment variable LC_ALL [C] already set and value is unchanged
hermes-webui-1  |   @@ Overwriting environment variable PATH [/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin] -> [/home/hermeswebuitoo/.local/bin/:/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin]
hermes-webui-1  |   ++ Setting environment variable PYTHONDONTWRITEBYTECODE [1]
hermes-webui-1  |   ++ Setting environment variable PYTHONIOENCODING [utf-8]
hermes-webui-1  |   ++ Setting environment variable PYTHONPATH [/app]
hermes-webui-1  |   ++ Setting environment variable PYTHONUNBUFFERED [1]
hermes-webui-1  |   ++ Setting environment variable PYTHON_SHA256 [c08bc65a81971c1dd5783182826503369466c7e67374d1646519adf05207b684]
hermes-webui-1  |   ++ Setting environment variable PYTHON_VERSION [3.12.13]
hermes-webui-1  |   ++ Setting environment variable UV_PROJECT_ENVIRONMENT [venv]
hermes-webui-1  |   == Environment variable WANTED_GID [1000] already set and value is unchanged
hermes-webui-1  |   == Environment variable WANTED_UID [1000] already set and value is unchanged
hermes-webui-1  |
hermes-webui-1  | -- Making sure /app is owned by the hermeswebui user to avoid permission issues when running the server and installing packages
hermes-webui-1  |
hermes-webui-1  | == Checking required environment variables for hermes-webui
hermes-webui-1  |
hermes-webui-1  | -- HERMES_WEBUI_VERSION: Where to store sessions, workspaces, and other state (default: ~/.hermes/webui-mvp)
hermes-webui-1  | -- HERMES_WEBUI_STATE_DIR: /home/hermeswebui/.hermes/webui-mvp
hermes-webui-1  |
hermes-webui-1  | -- HERMES_WEBUI_DEFAULT_WORKSPACE: Default workspace directory shown on first launch
hermes-webui-1  | -- HERMES_WEBUI_DEFAULT_WORKSPACE: /workspace
hermes-webui-1  |
hermes-webui-1  | ===================
hermes-webui-1  | == Running hermes-webui
hermes-webui-1  |
hermes-webui-1  |   Hermes Web UI -- startup config
hermes-webui-1  |   --------------------------------
hermes-webui-1  |   repo root   : /app
hermes-webui-1  |   agent dir   : /home/hermeswebui/.hermes/hermes-agent  [ok]
hermes-webui-1  |   python      : /app/venv/bin/python3
hermes-webui-1  |   state dir   : /home/hermeswebui/.hermes/webui-mvp
hermes-webui-1  |   workspace   : /workspace
hermes-webui-1  |   host:port   : 0.0.0.0:8787
hermes-webui-1  |   config file : /home/hermeswebui/.hermes/config.yaml  (found)
hermes-webui-1  |
hermes-webui-1  | [!!] WARNING: Binding to 0.0.0.0 with NO PASSWORD SET.
hermes-webui-1  |      Anyone on the network can access your filesystem and agent.
hermes-webui-1  |      Set a password via Settings or HERMES_WEBUI_PASSWORD env var.
hermes-webui-1  |      To suppress: bind to 127.0.0.1 or set a password.
hermes-webui-1  | [!!] Warning: Hermes agent found but missing modules: ['run_agent']
hermes-webui-1  |      run_agent: ModuleNotFoundError: No module named 'fire'
hermes-webui-1  |      Attempting to install missing dependencies from agent requirements.txt...
hermes-webui-1  |      Installing from /home/hermeswebui/.hermes/hermes-agent/requirements.txt ...
hermes-webui-1  | [ok] pip install completed.
hermes-webui-1  | [ok] Agent dependencies installed successfully.
hermes-webui-1  |   Hermes Web UI listening on http://0.0.0.0:8787
hermes-webui-1  |   Then open:     http://localhost:8787
```
