### PR TITLE
fix: restore custom model list discovery with config api key

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -613,15 +613,33 @@ def get_available_models() -> dict:
                 except ValueError:
                     pass
 
-            # Resolve API key from environment (check profile .env keys too)
+            # Resolve API key for the custom / OpenAI-compatible endpoint.
+            # Priority:
+            #   1. model.api_key in config.yaml
+            #   2. provider-specific providers.<active>.api_key / providers.custom.api_key
+            #   3. env/.env fallbacks
             headers = {}
-            api_key_vars = ('HERMES_API_KEY', 'HERMES_OPENAI_API_KEY', 'OPENAI_API_KEY',
-                            'LOCAL_API_KEY', 'OPENROUTER_API_KEY', 'API_KEY')
-            for key in api_key_vars:
-                api_key = all_env.get(key) or os.getenv(key)
-                if api_key:
-                    headers['Authorization'] = f'Bearer {api_key}'
-                    break
+            api_key = ''
+            if isinstance(model_cfg, dict):
+                api_key = (model_cfg.get('api_key') or '').strip()
+            if not api_key:
+                providers_cfg = cfg.get('providers', {})
+                if isinstance(providers_cfg, dict):
+                    for provider_key in filter(None, [active_provider, 'custom']):
+                        provider_cfg = providers_cfg.get(provider_key, {})
+                        if isinstance(provider_cfg, dict):
+                            api_key = (provider_cfg.get('api_key') or '').strip()
+                            if api_key:
+                                break
+            if not api_key:
+                api_key_vars = ('HERMES_API_KEY', 'HERMES_OPENAI_API_KEY', 'OPENAI_API_KEY',
+                                'LOCAL_API_KEY', 'OPENROUTER_API_KEY', 'API_KEY')
+                for key in api_key_vars:
+                    api_key = (all_env.get(key) or os.getenv(key) or '').strip()
+                    if api_key:
+                        break
+            if api_key:
+                headers['Authorization'] = f'Bearer {api_key}'
 
             # Fetch model list from endpoint (with SSRF protection)
             import socket
@@ -641,6 +659,7 @@ def get_available_models() -> dict:
                 except socket.gaierror:
                     pass  # DNS resolution failed -- let urllib handle it
             req = urllib.request.Request(endpoint_url, method='GET')
+            req.add_header('User-Agent', 'OpenAI/Python 1.0')
             for k, v in headers.items():
                 req.add_header(k, v)
             with urllib.request.urlopen(req, timeout=10) as response:

--- a/tests/test_model_resolver.py
+++ b/tests/test_model_resolver.py
@@ -326,3 +326,55 @@ def test_default_model_lands_under_active_provider_group(monkeypatch):
     assert 'gpt-5.4' not in groups.get('Anthropic', []), (
         f"gpt-5.4 leaked into Anthropic group via fallback: {groups.get('Anthropic')}"
     )
+
+
+def test_custom_endpoint_uses_model_config_api_key_for_model_discovery(monkeypatch):
+    """Custom endpoint model discovery must use model.api_key from config.yaml,
+    not only environment variables, otherwise the dropdown collapses to the
+    default model when /v1/models requires auth."""
+    import json as _json
+    import api.config as _cfg
+
+    old_cfg = dict(_cfg.cfg)
+    _cfg.cfg['model'] = {
+        'provider': 'custom',
+        'default': 'gpt-5.4',
+        'base_url': 'https://example.test/v1',
+        'api_key': 'sk-test-model-key',
+    }
+    _cfg.cfg.pop('providers', None)
+
+    captured = {}
+
+    class _Resp:
+        def read(self):
+            return _json.dumps({'data': [{'id': 'gpt-5.2', 'name': 'GPT-5.2'}]}).encode('utf-8')
+        def __enter__(self):
+            return self
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    def _fake_urlopen(req, timeout=10):
+        captured['auth'] = req.get_header('Authorization')
+        captured['ua'] = req.get_header('User-agent')
+        return _Resp()
+
+    monkeypatch.setattr('urllib.request.urlopen', _fake_urlopen)
+    monkeypatch.setattr('socket.getaddrinfo', lambda *a, **k: [])
+    monkeypatch.delenv('OPENAI_API_KEY', raising=False)
+    monkeypatch.delenv('HERMES_API_KEY', raising=False)
+    monkeypatch.delenv('HERMES_OPENAI_API_KEY', raising=False)
+    monkeypatch.delenv('LOCAL_API_KEY', raising=False)
+    monkeypatch.delenv('OPENROUTER_API_KEY', raising=False)
+    monkeypatch.delenv('API_KEY', raising=False)
+    try:
+        result = _cfg.get_available_models()
+    finally:
+        _cfg.cfg.clear()
+        _cfg.cfg.update(old_cfg)
+
+    assert captured['auth'] == 'Bearer sk-test-model-key'
+    assert captured['ua'] == 'OpenAI/Python 1.0'
+    groups = {g['provider']: [m['id'] for m in g['models']] for g in result['groups']}
+    assert 'Custom' in groups
+    assert 'gpt-5.2' in groups['Custom']


### PR DESCRIPTION
## Summary
- use `model.api_key` / `providers.<active>.api_key` / `providers.custom.api_key` when fetching models from OpenAI-compatible custom endpoints
- keep env vars only as fallback
- add a regression test covering authenticated `/v1/models` discovery and the OpenAI-style user-agent

## Problem
Custom providers configured only in `config.yaml` could chat normally, but the Web UI model picker called `/v1/models` without auth and silently fell back to showing only the default model.

## Testing
- `python3 -m py_compile api/config.py tests/test_model_resolver.py`
- added regression test in `tests/test_model_resolver.py`
