### PR TITLE
security: redact credentials from API responses and fix credential file permissions

### DIFF
--- a/api/helpers.py
+++ b/api/helpers.py
@@ -2,6 +2,7 @@
 Hermes Web UI -- HTTP helper functions.
 """
 import json as _json
+import re as _re
 from pathlib import Path
 from api.config import IMAGE_EXTS, MD_EXTS
 
@@ -78,6 +79,88 @@ def t(handler, payload, status: int=200, content_type: str='text/plain; charset=
 
 
 MAX_BODY_BYTES = 20 * 1024 * 1024  # 20MB limit for non-upload POST bodies
+
+
+# ── Credential redaction ──────────────────────────────────────────────────────
+
+def _build_redact_fn():
+    """Return redact_sensitive_text from hermes-agent if available, else a fallback."""
+    try:
+        from agent.redact import redact_sensitive_text
+        return redact_sensitive_text
+    except ImportError:
+        pass
+
+    # Minimal fallback covering the most common credential prefixes
+    _CRED_RE = _re.compile(
+        r"(?<![A-Za-z0-9_-])("
+        r"sk-[A-Za-z0-9_-]{10,}"          # OpenAI / Anthropic / OpenRouter
+        r"|ghp_[A-Za-z0-9]{10,}"          # GitHub PAT (classic)
+        r"|github_pat_[A-Za-z0-9_]{10,}"  # GitHub PAT (fine-grained)
+        r"|gho_[A-Za-z0-9]{10,}"          # GitHub OAuth token
+        r"|ghu_[A-Za-z0-9]{10,}"          # GitHub user-to-server token
+        r"|ghs_[A-Za-z0-9]{10,}"          # GitHub server-to-server token
+        r"|ghr_[A-Za-z0-9]{10,}"          # GitHub refresh token
+        r"|AKIA[A-Z0-9]{16}"              # AWS Access Key ID
+        r"|xox[baprs]-[A-Za-z0-9-]{10,}" # Slack tokens
+        r"|hf_[A-Za-z0-9]{10,}"          # HuggingFace token
+        r"|SG\.[A-Za-z0-9_-]{10,}"       # SendGrid API key
+        r")(?![A-Za-z0-9_-])"
+    )
+    _AUTH_HDR_RE = _re.compile(r"(Authorization:\s*Bearer\s+)(\S+)", _re.IGNORECASE)
+    _ENV_RE = _re.compile(
+        r"([A-Z0-9_]{0,50}(?:API_?KEY|TOKEN|SECRET|PASSWORD|PASSWD|CREDENTIAL|AUTH)[A-Z0-9_]{0,50})"
+        r"\s*=\s*(['\"]?)(\S+)\2"
+    )
+    _PRIVKEY_RE = _re.compile(
+        r"-----BEGIN[A-Z ]*PRIVATE KEY-----[\s\S]*?-----END[A-Z ]*PRIVATE KEY-----"
+    )
+
+    def _mask(token: str) -> str:
+        return f"{token[:6]}...{token[-4:]}" if len(token) >= 18 else "***"
+
+    def _fallback_redact(text: str) -> str:
+        if not isinstance(text, str) or not text:
+            return text
+        text = _CRED_RE.sub(lambda m: _mask(m.group(1)), text)
+        text = _AUTH_HDR_RE.sub(lambda m: m.group(1) + _mask(m.group(2)), text)
+        text = _ENV_RE.sub(
+            lambda m: f"{m.group(1)}={m.group(2)}{_mask(m.group(3))}{m.group(2)}", text
+        )
+        text = _PRIVKEY_RE.sub("[REDACTED PRIVATE KEY]", text)
+        return text
+
+    return _fallback_redact
+
+
+_redact_text = _build_redact_fn()
+
+
+def _redact_value(v):
+    """Recursively redact credentials from strings, dicts, and lists."""
+    if isinstance(v, str):
+        return _redact_text(v)
+    if isinstance(v, dict):
+        return {k: _redact_value(val) for k, val in v.items()}
+    if isinstance(v, list):
+        return [_redact_value(item) for item in v]
+    return v
+
+
+def redact_session_data(session_dict: dict) -> dict:
+    """Redact credentials from message content and tool_call data before API response.
+
+    Applies to: messages[], tool_calls[], and title.
+    The underlying session file is not modified; redaction is response-layer only.
+    """
+    result = dict(session_dict)
+    if isinstance(result.get('title'), str):
+        result['title'] = _redact_text(result['title'])
+    if 'messages' in result:
+        result['messages'] = _redact_value(result['messages'])
+    if 'tool_calls' in result:
+        result['tool_calls'] = _redact_value(result['tool_calls'])
+    return result
 
 
 def read_body(handler) -> dict:

--- a/api/routes.py
+++ b/api/routes.py
@@ -20,7 +20,7 @@ from api.config import (
     IMAGE_EXTS, MD_EXTS, MIME_MAP, MAX_FILE_BYTES, MAX_UPLOAD_BYTES,
     CHAT_LOCK, load_settings, save_settings,
 )
-from api.helpers import require, bad, safe_resolve, j, t, read_body, _security_headers, _sanitize_error
+from api.helpers import require, bad, safe_resolve, j, t, read_body, _security_headers, _sanitize_error, redact_session_data, _redact_text
 
 # ── CSRF: validate Origin/Referer on POST ────────────────────────────────────
 import re as _re
@@ -203,10 +203,11 @@ def handle_get(handler, parsed) -> bool:
             return j(handler, {'error': 'session_id is required'}, status=400)
         try:
             s = get_session(sid)
-            return j(handler, {'session': s.compact() | {
+            raw = s.compact() | {
                 'messages': s.messages,
                 'tool_calls': getattr(s, 'tool_calls', []),
-            }})
+            }
+            return j(handler, {'session': redact_session_data(raw)})
         except KeyError:
             # Not a WebUI session -- try CLI store
             msgs = get_cli_session_messages(sid)
@@ -232,7 +233,7 @@ def handle_get(handler, parsed) -> bool:
                     'messages': msgs,
                     'tool_calls': [],
                 }
-                return j(handler, {'session': sess})
+                return j(handler, {'session': redact_session_data(sess)})
             return bad(handler, 'Session not found', 404)
 
     if parsed.path == '/api/sessions':
@@ -817,7 +818,8 @@ def _handle_session_export(handler, parsed):
     if not sid: return bad(handler, 'session_id is required')
     try: s = get_session(sid)
     except KeyError: return bad(handler, 'Session not found', 404)
-    payload = json.dumps(s.__dict__, ensure_ascii=False, indent=2)
+    safe = redact_session_data(s.__dict__)
+    payload = json.dumps(safe, ensure_ascii=False, indent=2)
     handler.send_response(200)
     handler.send_header('Content-Type', 'application/json; charset=utf-8')
     handler.send_header('Content-Disposition', f'attachment; filename="hermes-{sid}.json"')
@@ -1043,7 +1045,7 @@ def _handle_memory_read(handler):
     memory = mem_file.read_text(encoding='utf-8', errors='replace') if mem_file.exists() else ''
     user = user_file.read_text(encoding='utf-8', errors='replace') if user_file.exists() else ''
     return j(handler, {
-        'memory': memory, 'user': user,
+        'memory': _redact_text(memory), 'user': _redact_text(user),
         'memory_path': str(mem_file), 'user_path': str(user_file),
         'memory_mtime': mem_file.stat().st_mtime if mem_file.exists() else None,
         'user_mtime': user_file.stat().st_mtime if user_file.exists() else None,

--- a/api/startup.py
+++ b/api/startup.py
@@ -1,7 +1,35 @@
 """Hermes Web UI -- startup helpers."""
 from __future__ import annotations
-import os, subprocess, sys
+import os, stat, subprocess, sys
 from pathlib import Path
+
+# Credential files that should never be world-readable
+_SENSITIVE_FILES = (
+    '.env',
+    'google_token.json',
+    'google_client_secret.json',
+    '.signing_key',
+    'auth.json',
+)
+
+
+def fix_credential_permissions() -> None:
+    """Ensure sensitive files in HERMES_HOME are chmod 600 (owner-only)."""
+    hermes_home = Path(os.environ.get('HERMES_HOME', str(Path.home() / '.hermes')))
+    if not hermes_home.is_dir():
+        return
+    for name in _SENSITIVE_FILES:
+        fpath = hermes_home / name
+        if not fpath.exists():
+            continue
+        try:
+            current = stat.S_IMODE(fpath.stat().st_mode)
+            if current & 0o077:  # group or other bits set
+                fpath.chmod(0o600)
+                print(f'  [security] fixed permissions on {fpath.name} ({oct(current)} -> 0600)', flush=True)
+        except OSError:
+            pass  # best-effort; don't abort startup
+
 
 def _agent_dir() -> Path | None:
     hermes_home = Path(os.environ.get('HERMES_HOME', str(Path.home() / '.hermes')))

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -16,6 +16,7 @@ from api.config import (
     _get_session_agent_lock, _set_thread_env, _clear_thread_env,
     resolve_model_provider,
 )
+from api.helpers import redact_session_data
 
 # Global lock for os.environ writes. Per-session locks (_agent_lock) prevent
 # concurrent runs of the SAME session, but two DIFFERENT sessions can still
@@ -404,7 +405,8 @@ def _run_agent_streaming(session_id, msg_text, model, workspace, stream_id, atta
                 usage['context_length'] = getattr(_cc, 'context_length', 0) or 0
                 usage['threshold_tokens'] = getattr(_cc, 'threshold_tokens', 0) or 0
                 usage['last_prompt_tokens'] = getattr(_cc, 'last_prompt_tokens', 0) or 0
-            put('done', {'session': s.compact() | {'messages': s.messages, 'tool_calls': tool_calls}, 'usage': usage})
+            raw_session = s.compact() | {'messages': s.messages, 'tool_calls': tool_calls}
+            put('done', {'session': redact_session_data(raw_session), 'usage': usage})
         finally:
             # Unregister the gateway approval callback and unblock any threads
             # still waiting on approval (e.g. stream cancelled mid-approval).

--- a/server.py
+++ b/server.py
@@ -12,7 +12,7 @@ from api.auth import check_auth
 from api.config import HOST, PORT, STATE_DIR, SESSION_DIR, DEFAULT_WORKSPACE
 from api.helpers import j
 from api.routes import handle_get, handle_post
-from api.startup import auto_install_agent_deps
+from api.startup import auto_install_agent_deps, fix_credential_permissions
 
 
 class Handler(BaseHTTPRequestHandler):
@@ -63,6 +63,9 @@ def main() -> None:
 
     print_startup_config()
 
+    # Fix sensitive file permissions before doing anything else
+    fix_credential_permissions()
+
     # Security: warn if binding non-loopback without authentication
     from api.auth import is_auth_enabled
     if HOST not in ('127.0.0.1', '::1', 'localhost') and not is_auth_enabled():
@@ -70,6 +73,10 @@ def main() -> None:
         print(f'     Anyone on the network can access your filesystem and agent.', flush=True)
         print(f'     Set a password via Settings or HERMES_WEBUI_PASSWORD env var.', flush=True)
         print(f'     To suppress: bind to 127.0.0.1 or set a password.', flush=True)
+    elif not is_auth_enabled():
+        print(f'  [tip] No password set. Any process on this machine can read sessions', flush=True)
+        print(f'        and memory via the local API. Set HERMES_WEBUI_PASSWORD to', flush=True)
+        print(f'        enable authentication.', flush=True)
 
     ok, missing, errors = verify_hermes_imports()
     if not ok and _HERMES_FOUND:

--- a/tests/test_security_redaction.py
+++ b/tests/test_security_redaction.py
@@ -1,0 +1,301 @@
+"""
+Security tests: credential redaction in API responses.
+
+Verifies that credentials (GitHub PATs, API keys, etc.) are masked in:
+  - GET /api/session  (messages and tool_calls)
+  - GET /api/memory   (MEMORY.md and USER.md content)
+  - GET /api/session/export (downloaded JSON)
+  - SSE done event    (session payload in stream)
+
+Tests run against the isolated test test_server on port 8788.
+"""
+
+import json
+import pathlib
+import sys
+import urllib.request
+import urllib.error
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).parent.parent.parent))
+
+
+def _server_is_up(port: int = 8788) -> bool:
+    """Return True if the test server is accepting connections."""
+    try:
+        urllib.request.urlopen(f"http://127.0.0.1:{port}/health", timeout=2)
+        return True
+    except Exception:
+        return False
+
+
+_needs_server = pytest.mark.skipif(
+    not _server_is_up(),
+    reason="Test server not running on port 8788 — run start.sh first",
+)
+
+BASE = "http://127.0.0.1:8788"
+
+# Sample credentials that should be masked in every API response
+_FAKE_GITHUB_PAT = "ghp_TestFakeCredential1234567890ab"
+_FAKE_SK_KEY     = "sk-TestFakeOpenAIKey1234567890abcdef"
+_FAKE_HF_TOKEN   = "hf_TestFakeHuggingFaceToken12345"
+_FAKE_AWS_KEY    = "AKIATESTFAKEKEY12345"
+
+
+# ── HTTP helpers ──────────────────────────────────────────────────────────────
+
+def _get(path):
+    with urllib.request.urlopen(BASE + path, timeout=10) as r:
+        return json.loads(r.read())
+
+
+def _post(path, body=None):
+    data = json.dumps(body or {}).encode()
+    req = urllib.request.Request(
+        BASE + path, data=data,
+        headers={"Content-Type": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10) as r:
+            return json.loads(r.read()), r.status
+    except urllib.error.HTTPError as e:
+        return json.loads(e.read()), e.code
+
+
+def _get_raw(path):
+    """Return raw bytes (used for export endpoint)."""
+    with urllib.request.urlopen(BASE + path, timeout=10) as r:
+        return r.read()
+
+
+def _assert_no_plaintext_credentials(text: str, label: str = ""):
+    """Assert that none of the fake credential strings appear in text."""
+    for cred in (_FAKE_GITHUB_PAT, _FAKE_SK_KEY, _FAKE_HF_TOKEN, _FAKE_AWS_KEY):
+        assert cred not in text, (
+            f"{label}: credential '{cred[:12]}...' found in plaintext. "
+            "Redaction is not working."
+        )
+
+
+# ── helpers.py unit tests (import-level, no test_server needed) ───────────────────
+
+def test_redact_value_str():
+    """_redact_value masks a plaintext GitHub PAT in a string."""
+    from api.helpers import _redact_value
+    result = _redact_value(f"my token is {_FAKE_GITHUB_PAT} bye")
+    assert _FAKE_GITHUB_PAT not in result
+    assert "ghp_Te" in result  # prefix preserved
+
+
+def test_redact_value_dict():
+    """_redact_value recurses into dicts."""
+    from api.helpers import _redact_value
+    d = {"content": f"key={_FAKE_SK_KEY}", "role": "user"}
+    result = _redact_value(d)
+    assert _FAKE_SK_KEY not in result["content"]
+    assert result["role"] == "user"  # innocent values untouched
+
+
+def test_redact_value_list():
+    """_redact_value recurses into lists."""
+    from api.helpers import _redact_value
+    lst = [{"content": _FAKE_GITHUB_PAT}, {"content": "safe text"}]
+    result = _redact_value(lst)
+    assert _FAKE_GITHUB_PAT not in result[0]["content"]
+    assert result[1]["content"] == "safe text"
+
+
+def test_redact_session_data_messages():
+    """redact_session_data masks credentials in messages[]."""
+    from api.helpers import redact_session_data
+    session = {
+        "session_id": "abc123",
+        "title": f"my token {_FAKE_GITHUB_PAT}",
+        "messages": [
+            {"role": "user", "content": f"token: {_FAKE_GITHUB_PAT}"},
+            {"role": "assistant", "content": "sure"},
+        ],
+        "tool_calls": [
+            {"name": "terminal", "args": {"command": f"gh auth login --token {_FAKE_GITHUB_PAT}"},
+             "snippet": "ok"},
+        ],
+    }
+    result = redact_session_data(session)
+    dump = json.dumps(result)
+    _assert_no_plaintext_credentials(dump, "redact_session_data")
+    # Safe fields remain intact
+    assert result["session_id"] == "abc123"
+    assert result["messages"][1]["content"] == "sure"
+
+
+def test_redact_session_data_multiple_cred_types():
+    """redact_session_data handles sk-, ghp_, hf_, and AKIA keys."""
+    from api.helpers import redact_session_data
+    session = {
+        "title": "test",
+        "messages": [{"role": "user", "content": (
+            f"openai={_FAKE_SK_KEY} "
+            f"github={_FAKE_GITHUB_PAT} "
+            f"hf={_FAKE_HF_TOKEN} "
+            f"aws={_FAKE_AWS_KEY}"
+        )}],
+        "tool_calls": [],
+    }
+    result = redact_session_data(session)
+    dump = json.dumps(result)
+    _assert_no_plaintext_credentials(dump, "multi-type redaction")
+
+
+def test_redact_session_data_non_sensitive_unchanged():
+    """redact_session_data does not corrupt innocent content."""
+    from api.helpers import redact_session_data
+    session = {
+        "title": "Hello world",
+        "messages": [{"role": "user", "content": "What is 2+2?"}],
+        "tool_calls": [{"name": "terminal", "snippet": "4"}],
+    }
+    result = redact_session_data(session)
+    assert result["title"] == "Hello world"
+    assert result["messages"][0]["content"] == "What is 2+2?"
+    assert result["tool_calls"][0]["snippet"] == "4"
+
+
+# ── API-level tests (require running test server started by conftest.py) ─────
+# Run via `start.sh && pytest tests/test_security_redaction.py -v`
+
+def _create_session_with_credentials() -> str:
+    """Write a session file with credential-containing messages directly to disk.
+
+    Bypasses the server's in-memory cache so the GET endpoint is forced to read
+    from disk, exercising the redaction code path on load.
+    Uses TEST_STATE_DIR from conftest.py (the isolated test server state directory).
+    """
+    import time, uuid
+    try:
+        from conftest import TEST_STATE_DIR
+        sessions_dir = TEST_STATE_DIR / "sessions"
+    except ImportError:
+        from api.config import SESSION_DIR as sessions_dir
+    sessions_dir = pathlib.Path(sessions_dir)
+    sessions_dir.mkdir(parents=True, exist_ok=True)
+
+    # Use a unique session ID that is NOT in the server's LRU cache
+    sid = "sec_test_" + uuid.uuid4().hex[:8]
+    now = time.time()
+    session_file = sessions_dir / f"{sid}.json"
+    session_file.write_text(json.dumps({
+        "session_id": sid,
+        "title": f"session with {_FAKE_GITHUB_PAT}",
+        "workspace": "/tmp",
+        "model": "test",
+        "created_at": now,
+        "updated_at": now,
+        "pinned": False, "archived": False, "project_id": None,
+        "profile": "default", "input_tokens": 0, "output_tokens": 0,
+        "estimated_cost": None, "personality": None,
+        "messages": [
+            {"role": "user",      "content": f"my PAT is {_FAKE_GITHUB_PAT}"},
+            {"role": "assistant", "content": f"sk key is {_FAKE_SK_KEY}"},
+            {"role": "tool",      "content": "result ok", "name": "terminal"},
+        ],
+        "tool_calls": [
+            {"name": "terminal",
+             "args": {"command": f"gh auth login --token {_FAKE_GITHUB_PAT}"},
+             "snippet": "blocked"}
+        ],
+    }))
+    return sid
+
+
+@_needs_server
+def test_api_session_redacts_messages(test_server):
+    """GET /api/session must not return credentials in messages or tool_calls."""
+    sid = _create_session_with_credentials()
+    data = _get(f"/api/session?session_id={sid}")
+    dump = json.dumps(data)
+    _assert_no_plaintext_credentials(dump, "GET /api/session messages")
+    assert data["session"]["session_id"] == sid
+    assert len(data["session"]["messages"]) == 3
+
+
+@_needs_server
+def test_api_session_redacts_title(test_server):
+    """GET /api/session must not return a title containing a credential."""
+    sid = _create_session_with_credentials()
+    data = _get(f"/api/session?session_id={sid}")
+    assert _FAKE_GITHUB_PAT not in data["session"]["title"]
+
+
+@_needs_server
+def test_api_sessions_list_redacts_titles(test_server):
+    """GET /api/sessions must not return session titles containing credentials."""
+    _create_session_with_credentials()
+    data = _get("/api/sessions")
+    dump = json.dumps(data)
+    _assert_no_plaintext_credentials(dump, "GET /api/sessions titles")
+
+
+@_needs_server
+def test_api_session_export_redacts(test_server):
+    """GET /api/session/export must not include credentials in the download."""
+    sid = _create_session_with_credentials()
+    raw_bytes = _get_raw(f"/api/session/export?session_id={sid}")
+    text = raw_bytes.decode("utf-8")
+    _assert_no_plaintext_credentials(text, "GET /api/session/export")
+
+
+@_needs_server
+def test_api_memory_redacts_via_write_read(test_server):
+    """Credential written to MEMORY.md must be masked in GET /api/memory response."""
+    original = _get("/api/memory").get("memory", "")
+
+    cred_content = f"GitHub PAT: {_FAKE_GITHUB_PAT}\nNormal note: hello world"
+    data, status = _post("/api/memory/write", {"section": "memory", "content": cred_content})
+    assert status == 200, f"memory/write failed: {data}"
+
+    try:
+        read_back = _get("/api/memory")
+        dump = json.dumps(read_back)
+        _assert_no_plaintext_credentials(dump, "GET /api/memory")
+        assert "hello world" in read_back["memory"]   # non-sensitive content preserved
+    finally:
+        _post("/api/memory/write", {"section": "memory", "content": original})
+
+
+# ── startup: fix_credential_permissions ──────────────────────────────────────
+
+def test_fix_credential_permissions_corrects_loose_files(tmp_path, monkeypatch):
+    """fix_credential_permissions() tightens group/other read bits."""
+    import os
+    from api.startup import fix_credential_permissions
+
+    env_file = tmp_path / ".env"
+    env_file.write_text("SECRET=abc")
+    env_file.chmod(0o644)  # world-readable -- should be fixed
+
+    google_file = tmp_path / "google_token.json"
+    google_file.write_text("{}")
+    google_file.chmod(0o664)  # group-readable -- should be fixed
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    fix_credential_permissions()
+
+    import stat
+    assert stat.S_IMODE(env_file.stat().st_mode) == 0o600, ".env not fixed to 600"
+    assert stat.S_IMODE(google_file.stat().st_mode) == 0o600, "google_token.json not fixed to 600"
+
+
+def test_fix_credential_permissions_skips_correct_files(tmp_path, monkeypatch):
+    """fix_credential_permissions() does not alter already-strict files."""
+    env_file = tmp_path / ".env"
+    env_file.write_text("SECRET=abc")
+    env_file.chmod(0o600)
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from api.startup import fix_credential_permissions
+    fix_credential_permissions()
+
+    import stat
+    assert stat.S_IMODE(env_file.stat().st_mode) == 0o600


### PR DESCRIPTION
## Summary

During a security audit of a local Hermes deployment, the following issues were found and fixed:

- **GET /api/session** returned full message history and tool_call arguments in plaintext, including GitHub PATs and API keys the agent had handled
- **GET /api/memory** returned MEMORY.md content verbatim, including credentials stored by the agent's memory tool
- **SSE `done` event** (chat stream) also contained the full session payload with unredacted credentials
- **Credential files** (`google_token.json`, `google_client_secret.json`) had `664` permissions instead of `600`

All API endpoints have no authentication by default, making this exploitable by any process on the same machine (including a malicious browser tab).

## Changes

### `api/helpers.py` — new credential redaction utilities
- `_build_redact_fn()`: imports `redact_sensitive_text` from `agent.redact` (hermes-agent); falls back to built-in regex covering `ghp_`, `sk-`, `AKIA`, `hf_`, `SG.`, `xox*`, `Authorization: Bearer`, `KEY=value` env patterns, and PEM private key blocks
- `_redact_value()`: recursively redacts str / dict / list
- `redact_session_data()`: applies redaction to `messages[]`, `tool_calls[]`, and `title` — response-layer only, session files on disk are not modified

### `api/routes.py` — apply redaction in three endpoints
- `GET /api/session` — wraps full session payload with `redact_session_data()`
- `GET /api/session/export` — redacts before serving download
- `GET /api/memory` — applies `_redact_text()` to MEMORY.md and USER.md

### `api/streaming.py` — redact SSE done event
- The `done` event sends the complete session object; now wrapped with `redact_session_data()`

### `api/startup.py` — `fix_credential_permissions()`
- At startup: `chmod 600` any HERMES_HOME file in a known-sensitive list (`.env`, `google_token.json`, `google_client_secret.json`, `auth.json`, `.signing_key`) if it has group or world read bits set

### `server.py`
- Calls `fix_credential_permissions()` before accepting connections
- Adds a startup tip in localhost mode when no password is set, pointing to `HERMES_WEBUI_PASSWORD`

### `tests/test_security_redaction.py` — 13 new tests
- 8 unit tests (always run): `_redact_value`, `redact_session_data` across message content / tool args / multi-type / innocent-content-unchanged, `fix_credential_permissions` enforcement and no-op
- 5 integration tests (skipped unless test server on port 8788 is running via `start.sh`)

## Test plan

- [x] `pytest tests/test_security_redaction.py -v` — 8 unit tests pass, 5 skipped
- [ ] After `./start.sh`: all 13 tests pass
- [ ] `curl http://localhost:8787/api/memory` — credentials masked
- [ ] `curl "http://localhost:8787/api/session?session_id=<id>"` — `ghp_` tokens masked in messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)