### PR TITLE
docs: fix stale TESTING.md footer (v0.36/440 -> v0.46.0/624)

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -1708,8 +1708,8 @@ Each has automated API-level tests in `tests/test_sprint{N}.py`.
 
 ---
 
-*Last updated: Sprint 26 / v0.36, April 5, 2026*
-*Total automated tests: 440 (440 passing, 0 failures)*
+*Last updated: v0.46.0, April 11, 2026*
+*Total automated tests: 624 (624 passing, 0 failures)*
 *Regression gate: tests/test_regressions.py*
 *Run: pytest tests/ -v --timeout=60*
 *Source: <repo>/*


### PR DESCRIPTION
Fix stale footer at end of TESTING.md that was missed during v0.46.0 release docs update.

The header (line 11) was correctly updated to 624 tests / v0.46.0, but the document-ending footer block still read Sprint 26 / v0.36 / 440 tests.

No code changes — documentation only.
