### PR TITLE
fix: session action menu icon aligned left of text (not above it)

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -138,9 +138,9 @@
   .session-actions-trigger svg{display:block;}
   .session-action-menu{display:block;position:fixed;left:0;top:0;right:auto;bottom:auto;min-width:220px;max-width:min(280px,calc(100vw - 16px));background:var(--surface);border:1px solid var(--border2);border-radius:10px;box-shadow:0 -4px 24px rgba(0,0,0,.4);z-index:999;overflow:hidden;max-height:320px;overflow-y:auto;}
   .session-action-menu.open{display:block;}
-  .session-action-opt{width:100%;background:none;border:none;text-align:left;font:inherit;color:var(--text);}
-  .session-action-opt .ws-opt-action{width:100%;align-items:flex-start;}
-  .session-action-opt .ws-opt-icon{color:var(--muted);transition:color .12s,opacity .12s;}
+  .session-action-opt{width:100%;background:none;border:none;text-align:left;font:inherit;color:var(--text);flex-direction:row!important;gap:0!important;padding:0!important;}
+  .session-action-opt .ws-opt-action{display:flex;flex-direction:row;align-items:center;gap:10px;width:100%;padding:10px 14px;}
+  .session-action-opt .ws-opt-icon{color:var(--muted);transition:color .12s,opacity .12s;flex-shrink:0;display:flex;align-items:center;width:16px;}
   .session-action-opt:hover .ws-opt-icon{color:var(--text);opacity:1;}
   .session-action-copy{display:flex;flex-direction:column;gap:2px;min-width:0;}
   .session-action-meta{font-size:11px;color:var(--muted);line-height:1.3;white-space:normal;opacity:.72;}


### PR DESCRIPTION
## Summary

One-line CSS fix: session action menu items now show the icon **to the left of** the label and subtitle text, instead of stacked above them.

## Root cause

The `.ws-opt` base class (shared with workspace dropdown items) uses `flex-direction:column`. The `.session-action-opt .ws-opt-action` override only set `align-items:flex-start` but never overrode the flex direction or added `display:flex` to the inner action span. Result: icon stacked above text.

## Fix (3 lines changed in `style.css`)

1. `.session-action-opt` — override `flex-direction:row` and remove inherited padding (moved to inner span)
2. `.session-action-opt .ws-opt-action` — `display:flex; flex-direction:row; align-items:center; gap:10px; padding:10px 14px`
3. `.session-action-opt .ws-opt-icon` — `flex-shrink:0; display:flex; align-items:center; width:16px`

## Before / After

**Before:** icon above text (stacked vertically)  
**After:** icon left of text (inline row, icon vertically centered)

## Tests

645 passed, 0 failed (CSS-only change, all static tests pass).  
Browser verified: all 5 menu items render correctly, delete item in red, zero JS console errors.
