### PR TITLE
docs: add CSS icon hotfix note to v0.47.0 CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
 ### Tests
 - **Mobile layout regression suite** (PR #254): 14 static tests in `tests/test_mobile_layout.py` that run on every QA pass. Covers: CSS breakpoints at 900px/640px, right panel slide-over, mobile overlay, bottom nav, files button, profile dropdown z-index, chip overflow, workspace close, `100dvh`, 44px touch targets, 16px textarea font. All pass against current and future master.
 
+**CSS hotfix (commit a2ae953, post-tag):** session action menu — icon now displays inline-left of text. The `.ws-opt` base class (`flex-direction:column`) was causing SVG icons to stack above the label. Fixed with 3 CSS rule overrides on `.session-action-opt`.
+
 **645 tests (up from 624 on v0.46.0 — +21 new tests)**
 
 ---


### PR DESCRIPTION
Documents the post-tag commit a2ae953 (session menu icon alignment fix) in the v0.47.0 CHANGELOG block for audit trail completeness. No code changes.