### PR TITLE
feat(mobile): add Profiles button to bottom navigation

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -441,6 +441,14 @@
 </div>
 <div class="mobile-overlay" id="mobileOverlay" onclick="closeMobileSidebar();closeMobileFiles()"></div>
 <nav class="mobile-bottom-nav" id="mobileBottomNav">
+    <button class="mobile-nav-btn" id="btnMobileProfiles" onclick="toggleMobileSidebar(); switchPanel('profiles');" title="Profiles">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/>
+        <circle cx="12" cy="7" r="4"/>
+      </svg>
+      <span data-i18n="tab_profiles">Profiles</span>
+    </button>
+
   <button class="mobile-nav-btn active" data-panel="chat" onclick="mobileSwitchPanel('chat')">
     <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
     <span data-i18n="tab_chat">Chat</span>


### PR DESCRIPTION
Closes #264

On mobile the sidebar nav tabs are hidden and the bottom navigation is the primary way to reach panels. This adds a **Profiles** entry to the bottom bar that opens the sidebar and switches to the Profiles panel.