### PR TITLE
fix: render inline formatting in markdown table cells (#273)

### DIFF
--- a/static/ui.js
+++ b/static/ui.js
@@ -211,8 +211,8 @@ function renderMd(raw){
     if(rows.length<2)return block;
     const isSep=r=>/^\|[\s|:-]+\|$/.test(r.trim());
     if(!isSep(rows[1]))return block;
-    const parseRow=r=>r.trim().replace(/^\|/,'').replace(/\|$/,'').split('|').map(c=>`<td>${esc(c.trim())}</td>`).join('');
-    const parseHeader=r=>r.trim().replace(/^\|/,'').replace(/\|$/,'').split('|').map(c=>`<th>${esc(c.trim())}</th>`).join('');
+    const parseRow=r=>r.trim().replace(/^\|/,'').replace(/\|$/,'').split('|').map(c=>`<td>${inlineMd(c.trim())}</td>`).join('');
+    const parseHeader=r=>r.trim().replace(/^\|/,'').replace(/\|$/,'').split('|').map(c=>`<th>${inlineMd(c.trim())}</th>`).join('');
     const header=`<tr>${parseHeader(rows[0])}</tr>`;
     const body=rows.slice(2).map(r=>`<tr>${parseRow(r)}</tr>`).join('');
     return `<table><thead>${header}</thead><tbody>${body}</tbody></table>`;


### PR DESCRIPTION
Reviewed merge of PR #278 (fix: render inline formatting in markdown table cells).

PR was cut from pre-v0.48.0 master and contained stale-base noise that would have reverted the gateway session sync (PR #274), deleted `test_gateway_sync.py`, and rolled back docs to v0.47.1. Cherry-picked only the genuine fix commit (`a2ecdca`) onto current master.

**The fix:** `esc()` → `inlineMd()` in table cell `parseRow`/`parseHeader` in `static/ui.js` (2 lines). Allows `**bold**`, `*italic*`, `` `code` ``, `[links](url)` to render correctly in markdown table cells. Already used for list items and blockquotes.

**Security:** `inlineMd()` escapes all interpolated values via `esc()`, has a `SAFE_INLINE` allowlist, and the outer `SAFE_TAGS` pass at the end of `renderMd()` provides a second layer. XSS test confirmed: `<script>alert(1)</script>` in a table cell renders as `&lt;script&gt;...`.

**Tests:** 658/658 pass (no regressions). Browser QA confirmed inline formatting renders in table headers and cells.

Closes #273.