### PR TITLE
docs: v0.49.0 final — test count 697, add #287 and #289 entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 ---
 
 
-## [v0.49.0] First-run onboarding wizard (PR #285)
+## [v0.49.0] First-run onboarding wizard + self-update hardening (PRs #285, #287, #289)
 
 - **One-shot bootstrap and first-run setup wizard** (PR #285): New users are greeted with a guided onboarding overlay on first load. The wizard checks system status, configures a provider (OpenRouter, Anthropic, OpenAI, or custom OpenAI-compatible endpoint), sets a workspace and optional password, and marks setup as complete — all without leaving the browser.
   - `bootstrap.py`: one-shot CLI bootstrap that writes `~/.hermes/config.yaml` and `~/.hermes/.env` from flags; idempotent and safe to re-run
@@ -17,6 +17,16 @@
   - `static/boot.js`: on load, fetches `/api/onboarding/status` and opens wizard when `completed=false`
   - Wizard does NOT show when `onboarding_completed=true` in settings
   - 14 new tests in `tests/test_onboarding.py`; 693 tests total (up from 679)
+
+- **Self-update git pull diagnostics** (PR #287): Fixes multiple failure modes in the WebUI self-update flow when the repo has a non-trivial git state.
+  - `_run_git()` now returns stderr on failure (stdout fallback, then exit-code message) — users see actionable git errors instead of empty strings
+  - New `_split_remote_ref()` helper splits `origin/master` into `('origin', 'master')` before `git pull --ff-only` — fixes silent failures where git misinterpreted the combined string as a repository name
+  - `--untracked-files=no` added to `git status --porcelain` — prevents spurious stash failures in repos with untracked files
+  - Early merge-conflict detection via porcelain status codes before attempting pull
+  - 4 new unit tests in `tests/test_updates.py`
+
+- **Skip flaky redaction test in agent-less environments** (PR #289): `test_api_sessions_list_redacts_titles` added to the CI skip list for environments without hermes-agent installed. Test still runs with the full agent; security coverage preserved by 6 pure-unit tests and 2 other API-level redaction tests.
+  - 697 tests total (up from 693)
 
 ## [v0.48.2] Provider/model mismatch warning (PR #283, fixes #266)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,9 +3,9 @@
 > Goal: Full 1:1 parity with the Hermes CLI experience via a clean dark web UI.
 > Everything you can do from the CLI terminal, you can do from this UI.
 >
-> Last updated: v0.49.0 (April 12, 2026) — 693 tests, 693 passing
+> Last updated: v0.49.0 (April 12, 2026) — 697 tests, 697 passing
 > Onboarding MVP now writes real Hermes provider config from the Web UI for OpenRouter, Anthropic, OpenAI, and custom OpenAI-compatible endpoints.
-> Tests: 693 total (693 passing, 0 failures)
+> Tests: 697 total (697 passing, 0 failures)
 > Source: <repo>/
 
 ---
@@ -49,7 +49,7 @@
 | v0.48.0 | Gateway session sync | Real-time Telegram/Discord/Slack sessions in sidebar via SSE + DB polling (#274 @bergeouss); +10 tests | 658 |
 | v0.48.1 | Table inline formatting | `inlineMd()` in table cells — **bold**, *italic*, `code`, links render correctly (PR #278); 0 new tests | 658 |
 | v0.48.2 | Provider mismatch warning | Toast warning + auth_mismatch error type for provider/model mismatches (#283, fixes #266); +21 tests | 679 |
-| v0.49.0 | First-run onboarding wizard | One-shot bootstrap + guided setup wizard; provider config persisted to config.yaml + .env; OpenRouter/Anthropic/OpenAI/Custom; wizard hidden after completion (#285); +14 tests | 693 |
+| v0.49.0 | First-run onboarding wizard + self-update hardening | One-shot bootstrap + guided setup wizard; provider config persisted to config.yaml + .env; OpenRouter/Anthropic/OpenAI/Custom; wizard hidden after completion (#285); self-update stderr/split-ref/conflict fixes (#287); skip flaky redaction test (#289); +18 tests | 697 |
 | v0.32 | Auto-compaction handling | Compression detection, /compact command, real context window indicator | 424 |
 | v0.33 | /insights sync | Opt-in state.db sync so `hermes /insights` includes WebUI sessions | 424 |
 | v0.34 | Sprint 26 — Pluggable themes | Dark, Light, Slate, Solarized, Monokai, Nord; settings unsaved-changes guard; /theme command | 433 |

--- a/SPRINTS.md
+++ b/SPRINTS.md
@@ -1164,7 +1164,7 @@ New test cases in `tests/test_sprint26.py`:
 ---
 
 *Last updated: April 12, 2026*
-*Current version: v0.49.0 | 693 tests*
+*Current version: v0.49.0 | 697 tests*
 *Next sprint: Sprint 24 (Web Polish + Bug Fix Pass)*
 *Horizon sprint: Sprint 25 (macOS Desktop Application)*
 *Docs sweep policy: update markdown proactively during PR reviews and after significant releases*

--- a/TESTING.md
+++ b/TESTING.md
@@ -8,7 +8,7 @@
 > Prerequisites: SSH tunnel is active on port 8786. Open http://localhost:8786 in browser.
 > Server health check: curl http://127.0.0.1:8786/health should return {"status":"ok"}.
 >
-> Automated tests: 693 total (693 passing, 0 skipped, 0 known failures). Includes onboarding coverage for bootstrap/static wizard presence, real provider config persistence (`config.yaml` + `.env`), and the `/api/onboarding/*` backend.
+> Automated tests: 697 total (697 passing, 0 skipped, 0 known failures). Includes onboarding coverage for bootstrap/static wizard presence, real provider config persistence (`config.yaml` + `.env`), and the `/api/onboarding/*` backend.
 > Run: `pytest tests/ -v --timeout=60`
 
 ---


### PR DESCRIPTION
Final docs update for v0.49.0 — corrects test count to 697 and adds CHANGELOG entries for all three PRs that landed in this release.

- Correct test count in ROADMAP.md, TESTING.md, SPRINTS.md: 693 → 697
- Update CHANGELOG.md: add entries for PR #287 (self-update diagnostics) and PR #289 (skip flaky test)
- Update ROADMAP.md sprint table row for v0.49.0 to reflect all three PRs
