### PR TITLE
fix: preserve user-renamed session titles (#300)

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -1543,7 +1543,9 @@ def _handle_chat_sync(handler, body):
             else:
                 os.environ["HERMES_SESSION_KEY"] = old_session_key
     s.messages = result.get("messages") or s.messages
-    s.title = title_from(s.messages, s.title)
+    # Only auto-generate title when still default; preserves user renames
+    if s.title == "Untitled":
+        s.title = title_from(s.messages, s.title)
     s.save()
     # Sync to state.db for /insights (opt-in setting)
     try:

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -334,7 +334,9 @@ def _run_agent_streaming(session_id, msg_text, model, workspace, stream_id, atta
             for _m in s.messages:
                 if isinstance(_m, dict) and not _m.get('timestamp') and not _m.get('_ts'):
                     _m['timestamp'] = int(_now)
-            s.title = title_from(s.messages, s.title)
+            # Only auto-generate title when still default; preserves user renames
+            if s.title == 'Untitled':
+                s.title = title_from(s.messages, s.title)
             # Read token/cost usage from the agent object (if available)
             input_tokens = getattr(agent, 'session_prompt_tokens', 0) or 0
             output_tokens = getattr(agent, 'session_completion_tokens', 0) or 0


### PR DESCRIPTION
## Summary

Guard `title_from()` with `s.title == 'Untitled'` check in both `streaming.py` and `routes.py` to avoid overwriting user-assigned titles after conversation turns.

## Fix

```python
# Before (in both files):
s.title = title_from(s.messages, s.title)

# After:
# Only auto-generate title when still default; preserves user renames
if s.title == 'Untitled':
    s.title = title_from(s.messages, s.title)
```

## Files changed

- `api/streaming.py` — streaming turn path (~line 337)
- `api/routes.py` — non-streaming / synchronous path (~line 1546)

## Root cause

`title_from()` was called unconditionally after every conversation turn, silently overwriting any user-assigned title. The guard ensures auto-generation only happens when the session still has the default title.

Fixes #300
