### PR TITLE
feat: breadcrumb nav + wider panel + responsive msg width (#292)

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -1543,7 +1543,9 @@ def _handle_chat_sync(handler, body):
             else:
                 os.environ["HERMES_SESSION_KEY"] = old_session_key
     s.messages = result.get("messages") or s.messages
-    s.title = title_from(s.messages, s.title)
+    # Only auto-generate title when still default; preserves user renames
+    if s.title == "Untitled":
+        s.title = title_from(s.messages, s.title)
     s.save()
     # Sync to state.db for /insights (opt-in setting)
     try:

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -334,7 +334,9 @@ def _run_agent_streaming(session_id, msg_text, model, workspace, stream_id, atta
             for _m in s.messages:
                 if isinstance(_m, dict) and not _m.get('timestamp') and not _m.get('_ts'):
                     _m['timestamp'] = int(_now)
-            s.title = title_from(s.messages, s.title)
+            # Only auto-generate title when still default; preserves user renames
+            if s.title == 'Untitled':
+                s.title = title_from(s.messages, s.title)
             # Read token/cost usage from the agent object (if available)
             input_tokens = getattr(agent, 'session_prompt_tokens', 0) or 0
             output_tokens = getattr(agent, 'session_completion_tokens', 0) or 0

--- a/static/boot.js
+++ b/static/boot.js
@@ -4,7 +4,7 @@ async function cancelStream(){
   try{
     await fetch(new URL(`/api/chat/cancel?stream_id=${encodeURIComponent(streamId)}`,location.origin).href,{credentials:'include'});
     const btn=$('btnCancel');if(btn)btn.style.display='none';
-    // Don't set status here - let the SSE cancel event handle UI cleanup
+    setStatus(t('cancelling'));
   }catch(e){setStatus(t('cancel_failed')+e.message);}
 }
 
@@ -21,37 +21,12 @@ function closeMobileSidebar(){
   const sidebar=document.querySelector('.sidebar');
   const overlay=$('mobileOverlay');
   if(sidebar)sidebar.classList.remove('mobile-open');
-  // only hide overlay if right panel is also closed
-  const panel=document.querySelector('.rightpanel');
-  if(!panel||!panel.classList.contains('mobile-open')){
-    if(overlay)overlay.classList.remove('visible');
-  }
+  if(overlay)overlay.classList.remove('visible');
 }
 function toggleMobileFiles(){
   const panel=document.querySelector('.rightpanel');
-  const overlay=$('mobileOverlay');
   if(!panel)return;
-  if(panel.classList.contains('mobile-open')){
-    panel.classList.remove('mobile-open');
-    // only hide overlay if left sidebar is also closed
-    const sidebar=document.querySelector('.sidebar');
-    if(!sidebar||!sidebar.classList.contains('mobile-open')){
-      if(overlay)overlay.classList.remove('visible');
-    }
-  } else {
-    panel.classList.add('mobile-open');
-    if(overlay)overlay.classList.add('visible');
-  }
-}
-function closeMobileFiles(){
-  const panel=document.querySelector('.rightpanel');
-  const overlay=$('mobileOverlay');
-  if(panel)panel.classList.remove('mobile-open');
-  // only hide overlay if left sidebar is also closed
-  const sidebar=document.querySelector('.sidebar');
-  if(!sidebar||!sidebar.classList.contains('mobile-open')){
-    if(overlay)overlay.classList.remove('visible');
-  }
+  panel.classList.toggle('mobile-open');
 }
 function mobileSwitchPanel(name){
   // Switch the panel content view
@@ -200,6 +175,8 @@ function clearPreview(){
   const pp=$('previewPathText');if(pp)pp.textContent='';
   const ft=$('fileTree');if(ft)ft.style.display='';
   _previewCurrentPath='';_previewCurrentMode='';_previewDirty=false;
+  // Restore directory breadcrumb after closing file preview
+  if(typeof renderBreadcrumb==='function') renderBreadcrumb();
 }
 $('btnClearPreview').onclick=clearPreview;
 // workspacePath click handler removed -- use topbar workspace chip dropdown instead
@@ -209,11 +186,6 @@ $('modelSelect').onchange=async()=>{
   localStorage.setItem('hermes-webui-model', selectedModel);
   await api('/api/session/update',{method:'POST',body:JSON.stringify({session_id:S.session.session_id,workspace:S.session.workspace,model:selectedModel})});
   S.session.model=selectedModel;syncTopbar();
-  // Warn if selected model belongs to a different provider than what Hermes is configured for
-  if(typeof _checkProviderMismatch==='function'){
-    const warn=_checkProviderMismatch(selectedModel);
-    if(warn&&typeof showToast==='function') showToast(warn,4000);
-  }
 };
 $('msg').addEventListener('input',()=>{
   autoResize();
@@ -302,7 +274,7 @@ document.querySelectorAll('.suggestion').forEach(btn=>{
 // ── Resizable panels ──────────────────────────────────────────────────────
 (function(){
   const SIDEBAR_MIN=180, SIDEBAR_MAX=420;
-  const PANEL_MIN=180,   PANEL_MAX=500;
+  const PANEL_MIN=180,   PANEL_MAX=1200;
 
   function initResize(handleId, targetEl, edge, minW, maxW, storageKey){
     const handle = $(handleId);
@@ -387,17 +359,14 @@ function applyBotName(){
   }
   // Pre-load workspace list so sidebar name is correct from first render
   await loadWorkspaceList();
-  await loadOnboardingWizard();
   _initResizePanels();
   const saved=localStorage.getItem('hermes-webui-session');
   if(saved){
-    try{await loadSession(saved);await renderSessionList();if(typeof startGatewaySSE==='function')startGatewaySSE();await checkInflightOnBoot(saved);return;}
+    try{await loadSession(saved);await renderSessionList();await checkInflightOnBoot(saved);return;}
     catch(e){localStorage.removeItem('hermes-webui-session');}
   }
   // no saved session - show empty state, wait for user to hit +
   $('emptyState').style.display='';
   await renderSessionList();
-  // Start real-time gateway session sync if setting is enabled
-  if(typeof startGatewaySSE==='function') startGatewaySSE();
 })();
 

--- a/static/style.css
+++ b/static/style.css
@@ -33,7 +33,7 @@
   /* ── Light theme: sidebar, roles, chips, active states ── */
   :root[data-theme="light"] .session-item{color:#5a544a;}
   :root[data-theme="light"] .session-item:hover{background:rgba(0,0,0,.06);color:#2c2825;}
-  :root[data-theme="light"] .session-item.active{background:rgba(45,111,163,.1);color:#1a5a8a;}
+  :root[data-theme="light"] .session-item.active{background:rgba(45,111,163,.1);color:#1a5a8a;border-left-color:#2d6fa3;}
   :root[data-theme="light"] .session-item.active .session-actions{background:linear-gradient(to right,transparent,rgba(228,224,216,.95) 12px);}
   :root[data-theme="light"] .session-pin-indicator{color:#996b15;}
   :root[data-theme="light"] .session-date-header.pinned{color:#996b15;}
@@ -129,24 +129,15 @@
   .session-item:hover{background:var(--hover-bg);color:var(--text);}
   .session-item.active{background:rgba(232,160,48,0.12);color:#e8a030;border-left:2px solid #e8a030;padding-left:8px;}
   .session-title{flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
-  /* ── Session action trigger + dropdown (⋯ menu) ── */
-  .session-actions{position:absolute;right:6px;top:50%;transform:translateY(-50%);display:flex;align-items:center;justify-content:center;opacity:0;pointer-events:none;transition:opacity .15s ease;}
-  .session-item:hover .session-actions,.session-item:focus-within .session-actions,.session-item.menu-open .session-actions{opacity:1;pointer-events:auto;}
-  .session-actions-trigger{width:26px;height:26px;border:1px solid transparent;border-radius:8px;background:transparent;color:var(--muted);cursor:pointer;padding:0;line-height:1;display:inline-flex;align-items:center;justify-content:center;transition:background .12s,color .12s,border-color .12s;}
-  .session-actions-trigger:hover{background:var(--hover-bg);color:var(--text);}
-  .session-actions-trigger.active{background:rgba(124,185,255,.1);border-color:rgba(124,185,255,.2);color:var(--text);}
-  .session-actions-trigger svg{display:block;}
-  .session-action-menu{display:block;position:fixed;left:0;top:0;right:auto;bottom:auto;min-width:220px;max-width:min(280px,calc(100vw - 16px));background:var(--surface);border:1px solid var(--border2);border-radius:10px;box-shadow:0 -4px 24px rgba(0,0,0,.4);z-index:999;overflow:hidden;max-height:320px;overflow-y:auto;}
-  .session-action-menu.open{display:block;}
-  .session-action-opt{width:100%;background:none;border:none;text-align:left;font:inherit;color:var(--text);flex-direction:row!important;gap:0!important;padding:0!important;}
-  .session-action-opt .ws-opt-action{display:flex;flex-direction:row;align-items:center;gap:10px;width:100%;padding:10px 14px;}
-  .session-action-opt .ws-opt-icon{color:var(--muted);transition:color .12s,opacity .12s;flex-shrink:0;display:flex;align-items:center;width:16px;}
-  .session-action-opt:hover .ws-opt-icon{color:var(--text);opacity:1;}
-  .session-action-copy{display:flex;flex-direction:column;gap:2px;min-width:0;}
-  .session-action-meta{font-size:11px;color:var(--muted);line-height:1.3;white-space:normal;opacity:.72;}
-  .session-action-opt.is-active{background:rgba(124,185,255,.1);}
-  .session-action-opt.danger:hover{background:rgba(233,69,96,.08);}
-  .session-action-opt.danger .ws-opt-icon,.session-action-opt.danger .ws-opt-name{color:var(--accent);}
+  /* ── Session action button overlay ── */
+  .session-actions{position:absolute;right:0;top:0;bottom:0;display:flex;align-items:center;gap:2px;padding:0 6px 0 16px;background:linear-gradient(to right,transparent,var(--sidebar) 12px);opacity:0;pointer-events:none;transition:opacity .15s ease;border-radius:0 8px 8px 0;}
+  .session-item:hover .session-actions{opacity:1;pointer-events:auto;}
+  .session-item.active .session-actions{background:linear-gradient(to right,transparent,rgba(30,22,8,.95) 12px);}
+  .session-actions button{background:none;border:none;color:var(--muted);cursor:pointer;padding:2px 3px;line-height:1;transition:color .12s;display:flex;align-items:center;}
+  .session-actions button:hover{color:var(--text);}
+  .session-actions .act-trash:hover{color:var(--accent);}
+  .session-actions .act-pin.pinned{color:#f5c542;}
+  .session-actions .act-pin.pinned:hover{color:#d4a017;}
   /* Hide overlay during inline rename */
   .session-item:has(.session-title-input) .session-actions{display:none;}
   @keyframes newflash{0%{background:rgba(124,185,255,0.22);color:var(--blue);}100%{background:transparent;color:var(--muted);}}
@@ -157,65 +148,8 @@
   .session-date-header.pinned{color:#f5c542;}
   .session-date-caret{font-size:9px;transition:transform .2s;flex-shrink:0;display:inline-block;}
   .session-date-caret.collapsed{transform:rotate(-90deg);}
-
-  /* ── Shared app dialogs (replace native confirm/prompt) ── */
-  .app-dialog-overlay{position:fixed;inset:0;background:rgba(7,12,19,.62);backdrop-filter:blur(6px);z-index:1100;display:none;align-items:center;justify-content:center;padding:24px;}
-  .app-dialog{width:min(460px,100%);background:linear-gradient(180deg,rgba(21,31,45,.98),rgba(13,20,31,.98));border:1px solid rgba(124,185,255,.2);border-radius:18px;box-shadow:0 18px 60px rgba(0,0,0,.45);padding:18px 18px 16px;color:var(--text);}
-  .app-dialog-header{display:flex;align-items:flex-start;justify-content:space-between;gap:12px;margin-bottom:10px;}
-  .app-dialog-title{font-size:16px;font-weight:700;letter-spacing:.01em;color:var(--text);}
-  .app-dialog-close{display:inline-flex;align-items:center;justify-content:center;width:32px;height:32px;border:none;border-radius:10px;background:rgba(255,255,255,.04);color:var(--muted);cursor:pointer;transition:background .15s,color .15s;}
-  .app-dialog-close:hover{background:rgba(255,255,255,.09);color:var(--text);}
-  .app-dialog-desc{font-size:13px;line-height:1.6;color:var(--muted);white-space:pre-wrap;}
-  .app-dialog-input{width:100%;margin-top:14px;padding:11px 12px;background:rgba(255,255,255,.04);border:1px solid var(--border2);border-radius:10px;color:var(--text);font-size:14px;outline:none;box-sizing:border-box;}
-  .app-dialog-input:focus{border-color:rgba(124,185,255,.55);box-shadow:0 0 0 3px rgba(124,185,255,.12);}
-  .app-dialog-actions{display:flex;justify-content:flex-end;gap:10px;margin-top:18px;flex-wrap:wrap;}
-  .app-dialog-btn{display:inline-flex;align-items:center;justify-content:center;min-width:104px;padding:10px 14px;border-radius:10px;border:1px solid var(--border2);background:rgba(255,255,255,.05);color:var(--text);font-size:13px;font-weight:600;cursor:pointer;transition:transform .15s,background .15s,border-color .15s;}
-  .app-dialog-btn:hover{transform:translateY(-1px);background:rgba(255,255,255,.1);}
-  .app-dialog-btn.confirm{border-color:rgba(124,185,255,.45);background:rgba(124,185,255,.14);color:var(--blue);}
-  .app-dialog-btn.confirm:hover{background:rgba(124,185,255,.22);border-color:rgba(124,185,255,.65);}
-  .app-dialog-btn.confirm.danger{border-color:rgba(233,69,96,.4);background:rgba(233,69,96,.14);color:var(--accent);}
-  .app-dialog-btn.confirm.danger:hover{background:rgba(233,69,96,.22);border-color:rgba(233,69,96,.58);}
-  .app-dialog-btn:focus-visible,.app-dialog-close:focus-visible{outline:2px solid rgba(124,185,255,.85);outline-offset:2px;}
   .toast{position:fixed;bottom:24px;left:50%;transform:translateX(-50%);background:var(--surface);backdrop-filter:blur(12px);border:1px solid rgba(124,185,255,0.25);color:var(--text);font-size:13px;padding:10px 20px;border-radius:12px;pointer-events:none;opacity:0;transition:opacity .2s,transform .2s;z-index:100;box-shadow:0 4px 20px rgba(0,0,0,.3);letter-spacing:.01em;}
   .toast.show{opacity:1;transform:translateX(-50%) translateY(-2px);}
-  .onboarding-overlay{position:fixed;inset:0;z-index:1050;background:rgba(7,12,19,.78);backdrop-filter:blur(8px);display:none;align-items:center;justify-content:center;padding:24px;}
-  .onboarding-card{width:min(980px,100%);max-height:min(760px,94vh);overflow:auto;border:1px solid rgba(124,185,255,.16);border-radius:24px;background:linear-gradient(180deg,rgba(20,30,44,.98),rgba(11,17,27,.98));box-shadow:0 24px 80px rgba(0,0,0,.45);}
-  .onboarding-shell{display:grid;grid-template-columns:minmax(240px,300px) minmax(0,1fr);}
-  .onboarding-sidebar{padding:28px 24px;border-right:1px solid var(--border);background:linear-gradient(180deg,rgba(124,185,255,.08),rgba(124,185,255,.02));}
-  .onboarding-sidebar h2{font-size:26px;line-height:1.15;margin-top:10px;margin-bottom:12px;letter-spacing:-.03em;}
-  .onboarding-badge{display:inline-flex;padding:4px 10px;border-radius:999px;font-size:10px;font-weight:800;letter-spacing:.12em;background:rgba(124,185,255,.14);color:var(--blue);}
-  .onboarding-sidebar p{font-size:13px;color:var(--muted);line-height:1.7;}
-  .onboarding-steps{display:flex;flex-direction:column;gap:10px;margin-top:24px;}
-  .onboarding-step{display:flex;gap:12px;align-items:flex-start;padding:10px 12px;border-radius:14px;border:1px solid transparent;background:rgba(255,255,255,.02);}
-  .onboarding-step.active{border-color:rgba(124,185,255,.25);background:rgba(124,185,255,.08);}
-  .onboarding-step.done{background:rgba(201,168,76,.08);}
-  .onboarding-step-index{width:24px;height:24px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:11px;font-weight:700;background:rgba(255,255,255,.08);color:var(--text);flex-shrink:0;}
-  .onboarding-step.done .onboarding-step-index{background:rgba(201,168,76,.16);color:var(--gold);}
-  .onboarding-step.active .onboarding-step-index{background:rgba(124,185,255,.18);color:var(--blue);}
-  .onboarding-step-title{font-size:13px;font-weight:700;color:var(--text);}
-  .onboarding-step-desc{font-size:11px;color:var(--muted);margin-top:2px;line-height:1.5;}
-  .onboarding-main{padding:28px 28px 24px;display:flex;flex-direction:column;gap:18px;min-width:0;}
-  .onboarding-status{display:none;padding:12px 14px;border-radius:12px;font-size:13px;line-height:1.6;border:1px solid var(--border2);background:rgba(255,255,255,.04);}
-  .onboarding-status.info{color:var(--text);}
-  .onboarding-status.success{color:var(--blue);border-color:rgba(124,185,255,.3);background:rgba(124,185,255,.08);}
-  .onboarding-status.warn{color:var(--gold);border-color:rgba(201,168,76,.28);background:rgba(201,168,76,.08);}
-  .onboarding-body{display:flex;flex-direction:column;gap:16px;}
-  .onboarding-panel-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:12px;}
-  .onboarding-check{padding:14px;border-radius:14px;border:1px solid var(--border);background:rgba(255,255,255,.03);display:flex;flex-direction:column;gap:5px;}
-  .onboarding-check strong{font-size:13px;color:var(--text);}
-  .onboarding-check span{font-size:12px;color:var(--muted);line-height:1.5;}
-  .onboarding-check.ok{border-color:rgba(124,185,255,.28);background:rgba(124,185,255,.08);}
-  .onboarding-check.warn{border-color:rgba(201,168,76,.25);background:rgba(201,168,76,.08);}
-  .onboarding-field{display:flex;flex-direction:column;gap:6px;}
-  .onboarding-field span{font-size:12px;font-weight:700;color:var(--text);}
-  .onboarding-field input,.onboarding-field select{margin-bottom:0;padding:10px 12px;border-radius:10px;font-size:13px;background:var(--input-bg);border:1px solid var(--border2);color:var(--text);}
-  .onboarding-copy{font-size:12px;color:var(--muted);line-height:1.7;}
-  .onboarding-summary{display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:12px;}
-  .onboarding-summary div{padding:14px;border-radius:14px;background:rgba(255,255,255,.03);border:1px solid var(--border);display:flex;flex-direction:column;gap:5px;}
-  .onboarding-summary strong{font-size:12px;letter-spacing:.04em;text-transform:uppercase;color:var(--muted);}
-  .onboarding-summary span{font-size:13px;color:var(--text);word-break:break-word;}
-  .onboarding-actions{display:flex;justify-content:space-between;gap:10px;margin-top:auto;}
-  .onboarding-actions .sm-btn{padding:10px 16px;}
   .reconnect-banner{display:none;background:var(--surface);border:1px solid rgba(201,168,76,0.4);border-radius:10px;padding:10px 16px;margin:10px auto;max-width:780px;font-size:13px;color:var(--gold);display:none;align-items:center;justify-content:space-between;gap:12px;}
   .reconnect-banner.visible{display:flex;}
   .reconnect-btn{padding:5px 12px;border-radius:7px;font-size:12px;font-weight:600;background:rgba(201,168,76,0.15);border:1px solid rgba(201,168,76,0.4);color:var(--gold);cursor:pointer;}
@@ -322,7 +256,9 @@
   .chip{font-size:11px;padding:4px 10px;border-radius:999px;background:rgba(255,255,255,0.05);border:1px solid var(--border2);color:var(--muted);font-weight:500;}
   .chip.model{color:var(--blue);border-color:rgba(124,185,255,0.35);background:rgba(124,185,255,0.1);}
   .messages{flex:1;overflow-y:auto;display:flex;flex-direction:column;min-height:0;position:relative;z-index:0;}
-  .messages-inner{max-width:800px;margin:0 auto;width:100%;padding:20px 24px 32px;display:flex;flex-direction:column;}
+  .messages-inner{margin:0 auto;width:100%;padding:20px 24px 32px;display:flex;flex-direction:column;}
+  @media(min-width:1400px){.messages-inner{max-width:1100px;}}
+  @media(min-width:1800px){.messages-inner{max-width:1200px;}}
   .msg-row{padding:10px 0;}
   .msg-row+.msg-row{border-top:none;}
   .msg-role{font-size:12px;font-weight:500;letter-spacing:.01em;margin-bottom:8px;display:flex;align-items:center;gap:8px;}
@@ -408,7 +344,6 @@
   .panel-actions{display:flex;gap:4px;}
   .panel-icon-btn{width:24px;height:24px;background:none;border:none;color:var(--muted);cursor:pointer;border-radius:5px;font-size:13px;display:flex;align-items:center;justify-content:center;transition:all .15s;}
   .panel-icon-btn:hover{background:rgba(255,255,255,.08);color:var(--text);}
-  .mobile-close-btn{display:none;}
   /* File row actions (shown on hover) */
   /* file-item-actions removed: delete button is now a flex child */
   .file-action-btn{width:20px;height:20px;background:rgba(0,0,0,.4);border:none;border-radius:4px;color:var(--muted);cursor:pointer;font-size:11px;display:flex;align-items:center;justify-content:center;}
@@ -538,26 +473,12 @@
     .approval-btns{gap:6px;}
     .approval-btn{padding:8px 12px;font-size:12px;min-height:44px;}
     .approval-kbd{display:none;}
-    .app-dialog-overlay{padding:12px;}
-    .app-dialog{width:100%;padding:16px 16px 14px;border-radius:16px;}
-    .app-dialog-actions{flex-direction:column-reverse;align-items:stretch;}
-    .app-dialog-btn{width:100%;min-height:44px;}
     /* Tool cards */
     .tool-card{margin-left:0!important;font-size:12px;}
     /* Settings modal */
     .settings-panel{width:95vw;max-width:95vw;min-height:min(580px,88vh);max-height:92vh;}
-    .onboarding-overlay{padding:12px;}
-    .onboarding-shell{grid-template-columns:1fr;}
-    .onboarding-sidebar{border-right:none;border-bottom:1px solid var(--border);padding:22px 18px;}
-    .onboarding-main{padding:20px 18px 18px;}
-    .onboarding-actions{flex-direction:column-reverse;}
-    .onboarding-actions .sm-btn{width:100%;min-height:44px;}
     /* Login page responsive */
     .card{width:90vw;max-width:320px;padding:28px 24px;}
-    /* Workspace panel mobile close button */
-    .mobile-close-btn{display:inline-flex;}
-    /* Profile dropdown — escape overflow-x:auto clipping context */
-    .profile-dropdown{position:fixed;top:56px;right:8px;left:auto;max-width:calc(100vw - 16px);}
   }
 
 /* ── Workspace dropdown (topbar) ── */
@@ -906,13 +827,13 @@ body.resizing{user-select:none;cursor:col-resize;}
 
 .bg-error-banner{background:rgba(229,62,62,.15);border:1px solid rgba(229,62,62,.3);color:#fca5a5;padding:8px 16px;font-size:12px;display:flex;align-items:center;justify-content:space-between;gap:12px;border-radius:0;}
 
-/* ── CLI / Agent session items in sidebar ── */
+/* ── CLI session items in sidebar ── */
 .session-item.cli-session {
   border-left-color: var(--gold);
-  padding-right: 40px; /* make room for the session actions trigger */
+  padding-right: 36px; /* make room for session-actions overlay */
 }
 .session-item.cli-session::after {
-  content: attr(data-source);
+  content: 'cli';
   font-size: 9px;
   font-weight: 600;
   text-transform: uppercase;
@@ -926,10 +847,3 @@ body.resizing{user-select:none;cursor:col-resize;}
 .session-item.cli-session:hover::after {
   display: none; /* hide badge on hover so session-actions icons are fully reachable */
 }
-/* Source-specific colors for gateway sessions */
-.session-item.cli-session[data-source="telegram"] { border-left-color: #0088cc; }
-.session-item.cli-session[data-source="telegram"]::after { color: #0088cc; }
-.session-item.cli-session[data-source="discord"] { border-left-color: #5865F2; }
-.session-item.cli-session[data-source="discord"]::after { color: #5865F2; }
-.session-item.cli-session[data-source="slack"] { border-left-color: #4A154B; }
-.session-item.cli-session[data-source="slack"]::after { color: #4A154B; }

--- a/static/ui.js
+++ b/static/ui.js
@@ -45,8 +45,6 @@ async function populateModelDropdown(){
   try{
     const data=await fetch(new URL('/api/models',location.origin).href,{credentials:'include'}).then(r=>r.json());
     if(!data.groups||!data.groups.length) return; // keep HTML defaults
-    // Store active provider globally so the send path can warn on mismatch
-    window._activeProvider=data.active_provider||null;
     // Clear existing options
     sel.innerHTML='';
     _dynamicModelLabels={};
@@ -70,32 +68,6 @@ async function populateModelDropdown(){
     // API unavailable -- keep the hardcoded HTML options as fallback
     console.warn('Failed to load models from server:',e.message);
   }
-}
-
-/**
- * Check if the given model ID belongs to a different provider than the one
- * currently configured in Hermes. Returns a warning string if mismatched,
- * or null if the selection looks compatible.
- *
- * Provider detection is intentionally loose — we compare the model's slash
- * prefix (e.g. "openai/" from "openai/gpt-4o") against the active provider
- * name. Custom/local endpoints report active_provider='custom' or the
- * base_url hostname and we skip the check to avoid false positives.
- */
-function _checkProviderMismatch(modelId){
-  const ap=(window._activeProvider||'').toLowerCase();
-  if(!ap||ap==='custom'||ap==='openrouter') return null; // can't reliably check
-  const slash=modelId.indexOf('/');
-  if(slash<0) return null; // bare model name, no provider prefix
-  const modelProvider=modelId.substring(0,slash).toLowerCase();
-  // Normalise common aliases
-  const aliases={'claude':'anthropic','gpt':'openai','gemini':'google'};
-  const norm=p=>aliases[p]||p;
-  if(norm(modelProvider)!==norm(ap)){
-    return (window.t?window.t('provider_mismatch_warning',modelId,ap):
-      `"${modelId}" may not work with your configured provider (${ap}). Send anyway or run \`hermes model\` to switch.`);
-  }
-  return null;
 }
 
 // ── Scroll pinning ──────────────────────────────────────────────────────────
@@ -163,10 +135,6 @@ function getModelLabel(modelId){
 
 function renderMd(raw){
   let s=raw||'';
-  // Pre-pass: decode HTML entities first so markdown processing works correctly.
-  // This prevents double-escaping when LLM outputs entities like &lt; &gt; &amp;
-  const decode=s=>s.replace(/&lt;/g,'<').replace(/&gt;/g,'>').replace(/&amp;/g,'&').replace(/&quot;/g,'"').replace(/&#39;/g,"'");
-  s=decode(s);
   // Pre-pass: convert safe inline HTML tags the model may emit into their
   // markdown equivalents so the pipeline can render them correctly.
   // Only runs OUTSIDE fenced code blocks and backtick spans (stash + restore).
@@ -323,148 +291,6 @@ function updateQueueBadge(){
   }
 }
 function showToast(msg,ms){const el=$('toast');el.textContent=msg;el.classList.add('show');clearTimeout(el._t);el._t=setTimeout(()=>el.classList.remove('show'),ms||2800);}
-
-// ── Shared app dialogs ───────────────────────────────────────────────────────
-// showConfirmDialog(opts) and showPromptDialog(opts) replace browser-native dialog calls
-// throughout the UI. Both return Promises and support: title, message, confirmLabel,
-// cancelLabel, danger (confirm only), placeholder/value/inputType (prompt only).
-
-const APP_DIALOG={resolve:null,kind:null,lastFocus:null};
-let _appDialogBound=false;
-
-function _isAppDialogOpen(){
-  const overlay=$('appDialogOverlay');
-  return !!(overlay&&overlay.style.display!=='none');
-}
-
-function _getAppDialogFocusable(){
-  return [$('appDialogInput'), $('appDialogCancel'), $('appDialogConfirm'), $('appDialogClose')]
-    .filter(el=>el&&el.style.display!=='none'&&!el.disabled);
-}
-
-function _finishAppDialog(result, restoreFocus=true){
-  const overlay=$('appDialogOverlay');
-  const dialog=$('appDialog');
-  const input=$('appDialogInput');
-  const confirmBtn=$('appDialogConfirm');
-  const resolve=APP_DIALOG.resolve;
-  const lastFocus=APP_DIALOG.lastFocus;
-  APP_DIALOG.resolve=null;
-  APP_DIALOG.kind=null;
-  APP_DIALOG.lastFocus=null;
-  if(overlay){overlay.style.display='none';overlay.setAttribute('aria-hidden','true');}
-  if(dialog) dialog.setAttribute('role','dialog');
-  if(input){input.value='';input.style.display='none';input.placeholder='';}
-  if(confirmBtn){confirmBtn.classList.remove('danger');confirmBtn.textContent=t('dialog_confirm_btn');}
-  if(restoreFocus&&lastFocus&&typeof lastFocus.focus==='function'){setTimeout(()=>lastFocus.focus(),0);}
-  if(resolve) resolve(result);
-}
-
-function _ensureAppDialogBindings(){
-  if(_appDialogBound) return;
-  _appDialogBound=true;
-  const overlay=$('appDialogOverlay');
-  const cancelBtn=$('appDialogCancel');
-  const confirmBtn=$('appDialogConfirm');
-  const closeBtn=$('appDialogClose');
-  if(overlay){
-    overlay.addEventListener('click',e=>{
-      if(e.target===overlay) _finishAppDialog(APP_DIALOG.kind==='prompt'?null:false);
-    });
-  }
-  if(cancelBtn) cancelBtn.addEventListener('click',()=>_finishAppDialog(APP_DIALOG.kind==='prompt'?null:false));
-  if(closeBtn)  closeBtn.addEventListener('click',()=>_finishAppDialog(APP_DIALOG.kind==='prompt'?null:false));
-  if(confirmBtn){
-    confirmBtn.addEventListener('click',()=>{
-      if(APP_DIALOG.kind==='prompt'){
-        const input=$('appDialogInput');
-        _finishAppDialog(input?input.value:null);
-      }else{
-        _finishAppDialog(true);
-      }
-    });
-  }
-  document.addEventListener('keydown',e=>{
-    if(!_isAppDialogOpen()) return;
-    if(e.key==='Escape'){
-      e.preventDefault();
-      _finishAppDialog(APP_DIALOG.kind==='prompt'?null:false);
-      return;
-    }
-    if(e.key==='Enter'){
-      const target=e.target;
-      const isTextarea=target&&target.tagName==='TEXTAREA';
-      if(!isTextarea){
-        e.preventDefault();
-        if(target===cancelBtn||target===closeBtn){
-          _finishAppDialog(APP_DIALOG.kind==='prompt'?null:false);
-        }else if(APP_DIALOG.kind==='prompt'){
-          const input=$('appDialogInput');
-          _finishAppDialog(input?input.value:null);
-        }else{
-          _finishAppDialog(true);
-        }
-      }
-      return;
-    }
-    if(e.key==='Tab'){
-      const nodes=_getAppDialogFocusable();
-      if(!nodes.length) return;
-      const idx=nodes.indexOf(document.activeElement);
-      let nextIdx=idx;
-      if(e.shiftKey){nextIdx=idx<=0?nodes.length-1:idx-1;}
-      else{nextIdx=idx===-1||idx===nodes.length-1?0:idx+1;}
-      e.preventDefault();
-      nodes[nextIdx].focus();
-    }
-  }, true);
-}
-
-function showConfirmDialog(opts={}){
-  _ensureAppDialogBindings();
-  if(APP_DIALOG.resolve) _finishAppDialog(false,false);
-  const overlay=$('appDialogOverlay'),dialog=$('appDialog'),title=$('appDialogTitle'),
-    desc=$('appDialogDesc'),input=$('appDialogInput'),cancelBtn=$('appDialogCancel'),confirmBtn=$('appDialogConfirm');
-  APP_DIALOG.resolve=null;APP_DIALOG.kind='confirm';APP_DIALOG.lastFocus=document.activeElement;
-  if(title) title.textContent=opts.title||t('dialog_confirm_title');
-  if(desc) desc.textContent=opts.message||'';
-  if(input){input.style.display='none';input.value='';}
-  if(cancelBtn) cancelBtn.textContent=opts.cancelLabel||t('cancel');
-  if(confirmBtn){
-    confirmBtn.textContent=opts.confirmLabel||t('dialog_confirm_btn');
-    confirmBtn.classList.toggle('danger',!!opts.danger);
-  }
-  if(dialog) dialog.setAttribute('role',opts.danger?'alertdialog':'dialog');
-  if(overlay){overlay.style.display='flex';overlay.setAttribute('aria-hidden','false');}
-  return new Promise(resolve=>{
-    APP_DIALOG.resolve=resolve;
-    setTimeout(()=>((opts.focusCancel?cancelBtn:confirmBtn)||confirmBtn||cancelBtn).focus(),0);
-  });
-}
-
-function showPromptDialog(opts={}){
-  _ensureAppDialogBindings();
-  if(APP_DIALOG.resolve) _finishAppDialog(null,false);
-  const overlay=$('appDialogOverlay'),dialog=$('appDialog'),title=$('appDialogTitle'),
-    desc=$('appDialogDesc'),input=$('appDialogInput'),cancelBtn=$('appDialogCancel'),confirmBtn=$('appDialogConfirm');
-  APP_DIALOG.resolve=null;APP_DIALOG.kind='prompt';APP_DIALOG.lastFocus=document.activeElement;
-  if(title) title.textContent=opts.title||t('dialog_prompt_title');
-  if(desc) desc.textContent=opts.message||'';
-  if(input){
-    input.type=opts.inputType||'text';input.style.display='';
-    input.value=opts.value||'';input.placeholder=opts.placeholder||'';
-    input.autocomplete='off';input.spellcheck=false;
-  }
-  if(cancelBtn) cancelBtn.textContent=opts.cancelLabel||t('cancel');
-  if(confirmBtn){confirmBtn.textContent=opts.confirmLabel||t('create');confirmBtn.classList.remove('danger');}
-  if(dialog) dialog.setAttribute('role','dialog');
-  if(overlay){overlay.style.display='flex';overlay.setAttribute('aria-hidden','false');}
-  return new Promise(resolve=>{
-    APP_DIALOG.resolve=resolve;
-    setTimeout(()=>{if(input&&input.style.display!=='none')input.focus();else if(confirmBtn)confirmBtn.focus();},0);
-  });
-}
-
 
 function copyMsg(btn){
   const row=btn.closest('.msg-row');
@@ -1295,8 +1121,7 @@ function _renderTreeItems(container, entries, depth){
 
 async function deleteWorkspaceFile(relPath, name){
   if(!S.session)return;
-  const _delFile=await showConfirmDialog({title:t('delete_confirm',name),message:'',confirmLabel:'Delete',danger:true,focusCancel:true});
-  if(!_delFile) return;
+  if(!confirm(t('delete_confirm',name)))return;
   try{
     await api('/api/file/delete',{method:'POST',body:JSON.stringify({session_id:S.session.session_id,path:relPath})});
     showToast(t('deleted')+name);
@@ -1308,7 +1133,7 @@ async function deleteWorkspaceFile(relPath, name){
 
 async function promptNewFile(){
   if(!S.session)return;
-  const name=await showPromptDialog({title:t('new_file_prompt'),placeholder:'filename.txt',confirmLabel:t('create')});
+  const name=prompt(t('new_file_prompt'),'');
   if(!name||!name.trim())return;
   const relPath=S.currentDir==='.'?name.trim():(S.currentDir+'/'+name.trim());
   try{
@@ -1321,7 +1146,7 @@ async function promptNewFile(){
 
 async function promptNewFolder(){
   if(!S.session)return;
-  const name=await showPromptDialog({title:t('new_folder_prompt'),placeholder:'folder-name',confirmLabel:t('create')});
+  const name=prompt(t('new_folder_prompt'),'');
   if(!name||!name.trim())return;
   const relPath=S.currentDir==='.'?name.trim():(S.currentDir+'/'+name.trim());
   try{

--- a/static/workspace.js
+++ b/static/workspace.js
@@ -54,7 +54,7 @@ async function loadDir(path){
     }
     if(typeof clearPreview==='function'){
       if(typeof _previewDirty!=='undefined'&&_previewDirty){
-        showConfirmDialog({title:t('unsaved_confirm'),message:'',confirmLabel:'Discard',danger:true,focusCancel:true}).then(ok=>{if(ok)clearPreview();});
+        if(confirm(t('unsaved_confirm')))clearPreview();
       }else{
         clearPreview();
       }
@@ -200,6 +200,7 @@ async function openFile(path){
   $('fileTree').style.display='none';
 
   _previewCurrentPath = path;
+  renderFileBreadcrumb(path);
   if(IMAGE_EXTS.has(ext)){
     // Image: load via raw endpoint, show as <img>
     showPreview('image');
@@ -245,3 +246,41 @@ function downloadFile(path){
   showToast(t('downloading',filename),2000);
 }
 
+
+// ── Render breadcrumb for file preview mode ──────────────────────────────────
+function renderFileBreadcrumb(filePath) {
+  const bar = $('breadcrumbBar');
+  if (!bar) return;
+  bar.style.display = 'flex';
+  const upBtn = $('btnUpDir');
+  if (upBtn) upBtn.style.display = '';
+
+  bar.innerHTML = '';
+  // Root
+  const root = document.createElement('span');
+  root.className = 'breadcrumb-seg breadcrumb-link';
+  root.textContent = '~';
+  root.onclick = () => { clearPreview(); loadDir('.'); };
+  bar.appendChild(root);
+
+  const parts = filePath.split('/');
+  let accumulated = '';
+  for (let i = 0; i < parts.length; i++) {
+    const sep = document.createElement('span');
+    sep.className = 'breadcrumb-sep';
+    sep.textContent = '/';
+    bar.appendChild(sep);
+
+    accumulated += (accumulated ? '/' : '') + parts[i];
+    const seg = document.createElement('span');
+    seg.textContent = parts[i];
+    if (i < parts.length - 1) {
+      seg.className = 'breadcrumb-seg breadcrumb-link';
+      const target = accumulated;
+      seg.onclick = () => { clearPreview(); loadDir(target); };
+    } else {
+      seg.className = 'breadcrumb-seg breadcrumb-current';
+    }
+    bar.appendChild(seg);
+  }
+}


### PR DESCRIPTION
## Summary

Implements three UX improvements from #292:

1. **Clickable breadcrumb navigation** in workspace file preview — click any path segment to navigate directly
2. **PANEL_MAX raised from 500 to 1200** — enables wider right panel on ultrawide screens
3. **Responsive `.messages-inner` max-width** — scales up gracefully on large screens while preserving readability

## Changes

### static/boot.js
- `PANEL_MAX`: 500 → 1200

### static/style.css
- Added responsive breakpoints for `.messages-inner`:
  - `@media(min-width:1400px)` → `max-width:1100px`
  - `@media(min-width:1800px)` → `max-width:1200px`
- `.msg-body` already has its own 680px cap, so line width stays readable

### static/ui.js + workspace.js
- Clickable breadcrumb path bar in workspace preview
- Each path segment is clickable to navigate to that directory level
- Handles paths with spaces and special characters

## Owner feedback

Addressed in this PR:
- ✅ Viewport-based `@media` breakpoints (not container-based)
- ✅ `.msg-body` inner cap preserved for readability
- ✅ Spaces/special chars in breadcrumb paths handled

Fixes #292
