### PR TITLE
ci: add GitHub Actions workflow to run tests on PRs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,30 @@
+name: Tests
+
+on:
+  pull_request:
+    branches: [master]
+  push:
+    branches: [master]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.11', '3.12', '3.13']
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pyyaml>=6.0 pytest pytest-timeout
+
+      - name: Run tests
+        run: pytest tests/ -v --timeout=60


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that runs the pytest suite on every PR targeting master and on pushes to master
- Tests across Python 3.11, 3.12, and 3.13 on ubuntu-latest
- Agent-dependent tests auto-skip via existing conftest logic

## Test plan
- [ ] Merge and verify workflow appears in Actions tab
- [ ] Open a subsequent PR and confirm tests trigger automatically
- [ ] Verify agent-dependent tests show as skipped (not failed) in CI logs