### PR TITLE
docs: fix sprint34 test count 19→21 in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Major UI overhaul by **[@aronprins](https://github.com/aronprins)** — the bigg
 ## [v0.49.4] Cancel stream cleanup guaranteed (PR #309, fixes #299)
 
 - **Reliable cancel cleanup** (closes #299): `cancelStream()` no longer depends on the SSE `cancel` event to clear busy state and status text. Previously, if the SSE connection was already closed when cancel fired, "Cancelling..." would linger indefinitely. Now `cancelStream()` clears `S.activeStreamId`, calls `setBusy(false)`, `setStatus('')`, and hides the cancel button directly after the cancel API request — regardless of SSE connection state. The SSE cancel handler still runs when the connection is alive (all operations are idempotent).
-  - 9 new tests in `tests/test_sprint36.py`; 740 tests total (up from 731)
+  - 9 new tests in `tests/test_sprint36.py`; 742 tests total (up from 733)
 
 ## [v0.49.3] Session title guard + breadcrumb nav + wider panel (PRs #301, #302)
 
@@ -33,7 +33,7 @@ Major UI overhaul by **[@aronprins](https://github.com/aronprins)** — the bigg
 - **Clickable breadcrumb navigation** (PR #302 by **[@franksong2702](https://github.com/franksong2702)** / closes #292): Workspace file preview now shows a clickable breadcrumb path bar. Each segment navigates directly to that directory level. Paths with spaces and special characters handled correctly. `clearPreview()` restores the directory breadcrumb on close.
 - **Wider right panel** (PR #302): `PANEL_MAX` raised from 500 to 1200 — right panel can now be dragged wider on ultrawide screens.
 - **Responsive message width** (PR #302): `.messages-inner` now scales up gracefully at 1400px (1100px max) and 1800px (1200px max) viewport widths instead of capping at 800px on all screen sizes.
-  - 12 new tests in `tests/test_sprint35.py`; 731 tests total (up from 719)
+  - 12 new tests in `tests/test_sprint35.py`; 733 tests total (up from 721)
 
 ## [v0.49.2] OAuth provider support in onboarding (issues #303, #304)
 
@@ -41,7 +41,7 @@ Major UI overhaul by **[@aronprins](https://github.com/aronprins)** — the bigg
   - New `_provider_oauth_authenticated()` helper in `api/onboarding.py` checks `hermes_cli.auth.get_auth_status()` first (authoritative), then falls back to parsing `~/.hermes/auth.json` directly for the known OAuth provider IDs (`openai-codex`, `copilot`, `copilot-acp`, `qwen-oauth`, `nous`).
   - `_status_from_runtime()` now has an `else` branch for providers not in `_SUPPORTED_PROVIDER_SETUPS`; OAuth-authenticated providers return `provider_ready=True` and `setup_state="ready"`.
   - The `provider_incomplete` status note no longer says "API key" for OAuth providers — it now says "Run 'hermes auth' or 'hermes model' in a terminal to complete setup."
-  - 19 new tests in `tests/test_sprint34.py`; 719 tests total (up from 700)
+  - 21 new tests in `tests/test_sprint34.py`; 721 tests total (up from 700)
 
 ## [v0.49.1] Docker docs + mobile Profiles button (PRs #291, #265)
 


### PR DESCRIPTION
Sprint34 has 21 tests (not 19 — two control center tests were added during PR #242 review). Cascades: 721→v0.49.2, 733→v0.49.3, 742→v0.49.4 (matches actual pytest count).