### PR TITLE
fix: add missing workspace volume to two-container compose (#326)

### DIFF
--- a/docker-compose.two-container.yml
+++ b/docker-compose.two-container.yml
@@ -39,6 +39,9 @@ services:
       #   uv pip install /home/hermeswebui/.hermes/hermes-agent
       # which installs the agent and all its Python dependencies.
       - hermes-agent-src:/home/hermeswebui/.hermes/hermes-agent
+      # Workspace directory — browse and edit files from the WebUI.
+      # Adapt the host path to your project directory.
+      - ~/workspace:/workspace
     environment:
       - HERMES_WEBUI_HOST=0.0.0.0
       - HERMES_WEBUI_PORT=8787


### PR DESCRIPTION
The two-container Docker Compose was missing the `~/workspace:/workspace` volume mount. Without it, the workspace directory inside the container is ephemeral and users can't browse their actual project files.

The single-container compose already had this mount — this brings the two-container variant to parity.

One file, 3 lines added. Fixes #326.

Generated with [Claude Code](https://claude.com/claude-code)