### PR TITLE
fix: deduplicate model dropdown + update README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 ---
 
 
+## [v0.50.8] Model dropdown deduplication — hyphen vs dot separator fix (PR #332)
+
+- **Model dropdown no longer shows duplicates for hyphen-format configs** (e.g. `claude-sonnet-4-6` from hermes-agent config): The server-side normalization in `api/config.py` now unifies hyphens and dots when checking whether the default model is already in the dropdown. Previously, `claude-sonnet-4-6` (hermes-agent format) and `claude-sonnet-4.6` (WebUI list format) were treated as different models, causing the same model to appear twice — once as a raw unlabelled entry and once with the correct display name. The raw entry is now suppressed and the labelled one is selected as default.
+- **README updated**: test count corrected to 791 / 51 files; all module line counts updated to current values; `onboarding.py`, `state_sync.py`, `updates.py` added to the architecture listing.
+
 ## [v0.50.7] OAuth provider onboarding path — Codex/Copilot no longer blocks setup (PR #331, fixes #329 bug 2)
 
 - **OAuth providers now have a proper onboarding path** (closes bug 2): Users with `openai-codex`, `copilot`, `qwen-oauth`, or any other OAuth-authenticated provider now see a clear confirmation card instead of an unusable API key input form.

--- a/README.md
+++ b/README.md
@@ -339,8 +339,8 @@ Or using the agent venv explicitly:
 ```
 
 Tests run against an isolated server on port 8788 with a separate state directory.
-Production data and real cron jobs are never touched. Current count: **433 tests**
-across 23 test files.
+Production data and real cron jobs are never touched. Current count: **782 tests**
+across 51 test files.
 
 ---
 
@@ -462,31 +462,33 @@ across 23 test files.
 ## Architecture
 
 ```
-server.py               HTTP routing shell + auth middleware (~83 lines)
+server.py               HTTP routing shell + auth middleware (~91 lines)
 api/
-  auth.py               Optional password authentication, signed cookies (~149 lines)
-  config.py             Discovery, globals, model detection, reloadable config (~726 lines)
-  helpers.py            HTTP helpers, security headers (~71 lines)
-  models.py             Session model + CRUD + CLI bridge (~338 lines)
+  auth.py               Optional password authentication, signed cookies (~193 lines)
+  config.py             Discovery, globals, model detection, reloadable config (~852 lines)
+  helpers.py            HTTP helpers, security headers (~80 lines)
+  models.py             Session model + CRUD + CLI bridge (~374 lines)
+  onboarding.py         OAuth provider onboarding flow (~35 lines)
   profiles.py           Profile state management, hermes_cli wrapper (~366 lines)
-  routes.py             All GET + POST route handlers (~1314 lines)
-  streaming.py          SSE engine, run_agent, cancel support (~332 lines)
-  upload.py             Multipart parser, file upload handler (~78 lines)
+  routes.py             All GET + POST route handlers (~1463 lines)
+  state_sync.py         /insights sync — message_count to state.db (~113 lines)
+  streaming.py          SSE engine, run_agent, cancel support (~438 lines)
+  updates.py            Self-update check and release notes (~164 lines)
+  upload.py             Multipart parser, file upload handler (~82 lines)
   workspace.py          File ops, workspace helpers, git detection (~288 lines)
 static/
-  index.html            HTML template (~600 lines)
-  style.css             All CSS incl. mobile responsive, themes (~855 lines)
-  ui.js                 DOM helpers, renderMd, tool cards, context ring (~1090 lines)
+  index.html            HTML template (~423 lines)
+  style.css             All CSS incl. mobile responsive, themes (~838 lines)
+  ui.js                 DOM helpers, renderMd, tool cards, context indicator (~1166 lines)
   workspace.js          File preview, file ops, git badge (~247 lines)
-  sessions.js           Session CRUD, ⋯ dropdown, collapsible groups, search (~600 lines)
-  messages.js           send(), SSE handlers, rAF throttle (~352 lines)
-  panels.js             Cron, skills, memory, profiles, control center (~1200 lines)
-  commands.js           Slash command autocomplete (~170 lines)
-  boot.js               Mobile nav, workspace state machine, composer chips, boot IIFE (~420 lines)
+  sessions.js           Session CRUD, collapsible groups, search (~589 lines)
+  messages.js           send(), SSE handlers, rAF throttle (~364 lines)
+  panels.js             Cron, skills, memory, profiles, settings (~1207 lines)
+  commands.js           Slash command autocomplete (~228 lines)
+  boot.js               Mobile nav, voice input, boot IIFE (~359 lines)
 tests/
   conftest.py           Isolated test server (port 8788)
-  test_sprint{1-36}.py  36 test files, 742 test functions
-  test_regressions.py   Permanent regression gate
+  51 test files          782 test functions
 Dockerfile              python:3.12-slim container image
 docker-compose.yml      Compose with named volume and optional auth
 .github/workflows/      CI: multi-arch Docker build + GitHub Release on tag

--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ Or using the agent venv explicitly:
 ```
 
 Tests run against an isolated server on port 8788 with a separate state directory.
-Production data and real cron jobs are never touched. Current count: **782 tests**
+Production data and real cron jobs are never touched. Current count: **791 tests**
 across 51 test files.
 
 ---
@@ -462,33 +462,33 @@ across 51 test files.
 ## Architecture
 
 ```
-server.py               HTTP routing shell + auth middleware (~91 lines)
+server.py               HTTP routing shell + auth middleware (~154 lines)
 api/
-  auth.py               Optional password authentication, signed cookies (~193 lines)
-  config.py             Discovery, globals, model detection, reloadable config (~852 lines)
-  helpers.py            HTTP helpers, security headers (~80 lines)
-  models.py             Session model + CRUD + CLI bridge (~374 lines)
-  onboarding.py         OAuth provider onboarding flow (~35 lines)
-  profiles.py           Profile state management, hermes_cli wrapper (~366 lines)
-  routes.py             All GET + POST route handlers (~1463 lines)
+  auth.py               Optional password authentication, signed cookies (~201 lines)
+  config.py             Discovery, globals, model detection, reloadable config (~1110 lines)
+  helpers.py            HTTP helpers, security headers (~175 lines)
+  models.py             Session model + CRUD + CLI bridge (~377 lines)
+  onboarding.py         First-run onboarding wizard, OAuth provider support (~507 lines)
+  profiles.py           Profile state management, hermes_cli wrapper (~411 lines)
+  routes.py             All GET + POST route handlers (~1996 lines)
   state_sync.py         /insights sync — message_count to state.db (~113 lines)
-  streaming.py          SSE engine, run_agent, cancel support (~438 lines)
-  updates.py            Self-update check and release notes (~164 lines)
+  streaming.py          SSE engine, run_agent, cancel support (~545 lines)
+  updates.py            Self-update check and release notes (~257 lines)
   upload.py             Multipart parser, file upload handler (~82 lines)
   workspace.py          File ops, workspace helpers, git detection (~288 lines)
 static/
-  index.html            HTML template (~423 lines)
-  style.css             All CSS incl. mobile responsive, themes (~838 lines)
-  ui.js                 DOM helpers, renderMd, tool cards, context indicator (~1166 lines)
-  workspace.js          File preview, file ops, git badge (~247 lines)
-  sessions.js           Session CRUD, collapsible groups, search (~589 lines)
-  messages.js           send(), SSE handlers, rAF throttle (~364 lines)
-  panels.js             Cron, skills, memory, profiles, settings (~1207 lines)
-  commands.js           Slash command autocomplete (~228 lines)
-  boot.js               Mobile nav, voice input, boot IIFE (~359 lines)
+  index.html            HTML template (~600 lines)
+  style.css             All CSS incl. mobile responsive, themes (~1050 lines)
+  ui.js                 DOM helpers, renderMd, tool cards, context indicator (~1496 lines)
+  workspace.js          File preview, file ops, git badge (~286 lines)
+  sessions.js           Session CRUD, collapsible groups, search (~752 lines)
+  messages.js           send(), SSE handlers, rAF throttle (~487 lines)
+  panels.js             Cron, skills, memory, profiles, settings (~1438 lines)
+  commands.js           Slash command autocomplete (~267 lines)
+  boot.js               Mobile nav, voice input, boot IIFE (~524 lines)
 tests/
   conftest.py           Isolated test server (port 8788)
-  51 test files          782 test functions
+  51 test files          791 test functions
 Dockerfile              python:3.12-slim container image
 docker-compose.yml      Compose with named volume and optional auth
 .github/workflows/      CI: multi-arch Docker build + GitHub Release on tag

--- a/api/config.py
+++ b/api/config.py
@@ -913,10 +913,11 @@ def get_available_models() -> dict:
     # Ensure the user's configured default_model always appears in the dropdown.
     # It may be missing if the model isn't in any hardcoded list (e.g. openrouter/free,
     # a custom local model, or any model.default not in _FALLBACK_MODELS).
-    # Normalize before comparing: strip provider prefix so 'anthropic/claude-opus-4.6'
-    # matches 'claude-opus-4.6' already in the list and avoids a duplicate entry.
+    # Normalize before comparing: strip provider prefix and unify separators so
+    # 'anthropic/claude-opus-4.6' matches 'claude-opus-4.6' and 'claude-sonnet-4-6'
+    # matches 'claude-sonnet-4.6' (hermes-agent uses hyphens, webui uses dots).
     if default_model:
-        _norm = lambda mid: mid.split("/", 1)[-1] if "/" in mid else mid
+        _norm = lambda mid: (mid.split("/", 1)[-1] if "/" in mid else mid).replace("-", ".")
         all_ids_norm = {_norm(m["id"]) for g in groups for m in g.get("models", [])}
         if _norm(default_model) not in all_ids_norm:
             # Determine which group to inject into. Compare against the

--- a/static/index.html
+++ b/static/index.html
@@ -526,7 +526,7 @@
                 <div class="settings-section-title">System</div>
                 <div class="settings-section-meta">Instance version and access controls.</div>
               </div>
-              <span class="settings-version-badge">v0.50.7</span>
+              <span class="settings-version-badge">v0.50.8</span>
             </div>
             <div class="settings-field" style="border-top:1px solid var(--border);padding-top:12px;margin-top:8px">
               <label for="settingsPassword" data-i18n="settings_label_password">Access Password</label>


### PR DESCRIPTION
## Summary

Two changes:

### Model dropdown deduplication
When `default_model` in config uses hyphens (`claude-sonnet-4-6`, hermes-agent format) and the webui hardcoded list uses dots (`claude-sonnet-4.6`), the "ensure default_model appears" logic failed to match them as the same model and injected a duplicate entry. The normalization now also replaces hyphens with dots when comparing.

**Root cause:** `_norm` lambda on line 919 of config.py only stripped the provider prefix (`anthropic/`) but did not unify `-` vs `.` separators. The frontend already had this fuzzy matching in `_findModelInDropdown()` but the backend did not.

### README updates
- Test count: 433 -> 782 tests, 23 -> 51 test files
- Architecture line counts updated to match current source
- Added missing api modules: `state_sync.py`, `updates.py`, `onboarding.py`

## Test plan
- [ ] Configure hermes-agent with `claude-sonnet-4-6` as default model, verify it appears only once in dropdown
- [ ] Verify all existing models still appear correctly

Generated with [Claude Code](https://claude.com/claude-code)