### PR TITLE
docs: fix stale test count in README (791 → 802)

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ Or using the agent venv explicitly:
 ```
 
 Tests run against an isolated server on port 8788 with a separate state directory.
-Production data and real cron jobs are never touched. Current count: **791 tests**
+Production data and real cron jobs are never touched. Current count: **802 tests**
 across 51 test files.
 
 ---
@@ -488,7 +488,7 @@ static/
   boot.js               Mobile nav, voice input, boot IIFE (~524 lines)
 tests/
   conftest.py           Isolated test server (port 8788)
-  51 test files          791 test functions
+  51 test files          802 test functions
 Dockerfile              python:3.12-slim container image
 docker-compose.yml      Compose with named volume and optional auth
 .github/workflows/      CI: multi-arch Docker build + GitHub Release on tag


### PR DESCRIPTION
Two lines in README.md still showed `791 test functions` after the v0.50.10 release (which added 11 tests, bringing the total to 802). Both the running-tests section (line 342) and the architecture block (line 491) are now corrected.