### PR TITLE
docs: fix stale port 8786 in TESTING.md prerequisites

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -5,8 +5,8 @@
 > Each section is written as a step-by-step test procedure with expected outcomes.
 > A browser agent (e.g. Claude with Chrome access) can execute this plan directly.
 >
-> Prerequisites: SSH tunnel is active on port 8786. Open http://localhost:8786 in browser.
-> Server health check: curl http://127.0.0.1:8786/health should return {"status":"ok"}.
+> Prerequisites: SSH tunnel is active on port 8787. Open http://localhost:8787 in browser.
+> Server health check: curl http://127.0.0.1:8787/health should return {"status":"ok"}.
 >
 > Automated tests: 700 total (700 passing, 0 skipped, 0 known failures). Includes onboarding coverage for bootstrap/static wizard presence, real provider config persistence (`config.yaml` + `.env`), and the `/api/onboarding/*` backend.
 > Run: `pytest tests/ -v --timeout=60`


### PR DESCRIPTION
The TESTING.md prerequisites header still referenced port 8786, which was retired in April 2026.

The live server has always run on port 8787 (the `start.sh` default). This fixes the stale reference.

**Change:** Two lines in the prerequisites block — `8786` → `8787`.
