### PR TITLE
fix: table borders in chat + URL autolink edge cases (#341, #342)

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -369,6 +369,10 @@
   .msg-body blockquote{border-left:3px solid var(--blue);padding-left:14px;color:var(--muted);font-style:italic;margin:10px 0;}
   .msg-body a{color:var(--blue);text-decoration:underline;}
   .msg-body hr{border:none;border-top:1px solid var(--border);margin:14px 0;}
+  .msg-body table{border-collapse:collapse;width:100%;margin:8px 0;font-size:12px;overflow-x:auto;display:block;}
+  .msg-body th{background:rgba(255,255,255,.07);padding:6px 10px;text-align:left;font-weight:600;border:1px solid var(--border2);}
+  .msg-body td{padding:5px 10px;border:1px solid rgba(255,255,255,.06);}
+  .msg-body tr:nth-child(even){background:rgba(255,255,255,.03);}
   .msg-files{display:flex;flex-wrap:wrap;gap:6px;padding-left:30px;margin-bottom:10px;}
   .msg-file-badge{display:flex;align-items:center;gap:5px;background:rgba(124,185,255,0.1);border:1px solid rgba(124,185,255,0.25);border-radius:6px;padding:4px 9px;font-size:12px;color:var(--blue);}
   .thinking{display:flex;align-items:center;gap:5px;color:var(--muted);font-size:13px;padding-left:30px;}

--- a/static/ui.js
+++ b/static/ui.js
@@ -383,6 +383,8 @@ function renderMd(raw){
   // <div class="..."> (mermaid/pre-header). Everything else is untrusted input.
   const SAFE_TAGS=/^<\/?(strong|em|code|pre|h[1-6]|ul|ol|li|table|thead|tbody|tr|th|td|hr|blockquote|p|br|a|div)([\s>]|$)/i;
   s=s.replace(/<\/?[a-z][^>]*>/gi,tag=>SAFE_TAGS.test(tag)?tag:esc(tag));
+  // Autolink: convert plain URLs to clickable links (but not inside existing <a> or markdown [label](url))
+  s=s.replace(/(?!<a\s)[^>\n]*(https?:\/\/[^\s<>"')\]]+)(?![^<]*<\/a>)/g,(_, url)=>`<a href="${esc(url)}" target="_blank" rel="noopener">${esc(url)}</a>`);
   const parts=s.split(/\n{2,}/);
   s=parts.map(p=>{p=p.trim();if(!p)return '';if(/^<(h[1-6]|ul|ol|pre|hr|blockquote)/.test(p))return p;return `<p>${p.replace(/\n/g,'<br>')}</p>`;}).join('\n');
   return s;

--- a/static/ui.js
+++ b/static/ui.js
@@ -384,7 +384,16 @@ function renderMd(raw){
   const SAFE_TAGS=/^<\/?(strong|em|code|pre|h[1-6]|ul|ol|li|table|thead|tbody|tr|th|td|hr|blockquote|p|br|a|div)([\s>]|$)/i;
   s=s.replace(/<\/?[a-z][^>]*>/gi,tag=>SAFE_TAGS.test(tag)?tag:esc(tag));
   // Autolink: convert plain URLs to clickable links (but not inside existing <a> or markdown [label](url))
-  s=s.replace(/(?!<a\s)[^>\n]*(https?:\/\/[^\s<>"')\]]+)(?![^<]*<\/a>)/g,(_, url)=>`<a href="${esc(url)}" target="_blank" rel="noopener">${esc(url)}</a>`);
+  // First, temporarily remove code blocks to avoid linking URLs inside them
+  const codeBlocks=[], inlineCode=[];
+  s=s.replace(/(<code[^>]*>[\s\S]*?<\/code>)/g,(_,c)=>{inlineCode.push(c);return`\x00CODE${inlineCode.length-1}\x00`;});
+  // Strip trailing punctuation (.,;:!?) that commonly follows URLs but shouldn't be part of them
+  s=s.replace(/(?!<a\s)[^>\n]*(https?:\/\/[^\s<>"'\)\]]+)(?![^<]*<\/a>)/g,(_, url)=>{
+    url=url.replace(/[.,;:!?)+]+$/,''); // strip trailing punctuation
+    return`<a href="${esc(url)}" target="_blank" rel="noopener">${esc(url)}</a>`;
+  });
+  // Restore code blocks
+  inlineCode.forEach((c,i)=>s=s.replace(`\x00CODE${i}\x00`,c));
   const parts=s.split(/\n{2,}/);
   s=parts.map(p=>{p=p.trim();if(!p)return '';if(/^<(h[1-6]|ul|ol|pre|hr|blockquote)/.test(p))return p;return `<p>${p.replace(/\n/g,'<br>')}</p>`;}).join('\n');
   return s;


### PR DESCRIPTION
## Summary

Two fixes in one PR:

### Fix 1: Table border styles in chat messages (#341)
Add missing table border styles to `.msg-body` class in chat messages, fixing borderless tables that were unreadable.
- Add `border-collapse`, `width`, `margin`, `font-size` to `.msg-body table`
- Add header row styling with `border2` CSS variable for proper theming
- Add zebra striping for row readability
- Add `overflow-x: auto` + `display: block` for wide table scrolling on narrow screens

### Fix 2: URL autolink edge cases (#342)
Follow-up fix for #342 - the original autolink implementation had two edge cases:
1. **Trailing punctuation**: URLs followed by `.`, `,`, `;`, `:`, `!`, `?` had the punctuation incorrectly captured as part of the URL
2. **Code blocks**: URLs inside `<code>...</code>` were being auto-linked, but they should display as literal text

## Testing

| Input | Before | After |
|-------|--------|-------|
| `https://example.com.` | URL includes trailing dot | Dot stripped |
| `<code>https://example.com</code>` | URL was linked | Not linked |

Based on owner feedback in #342.

Closes #341, Closes #342