### PR TITLE
fix: use pathlib in test_sprint34 static file opens (fixes path-dependent test failures)

### DIFF
--- a/tests/test_sprint34.py
+++ b/tests/test_sprint34.py
@@ -232,7 +232,7 @@ class TestOnboardingStatusApiOAuth:
 
 def test_control_center_resets_active_section_on_close():
     """Closing the control center must reset _settingsSection to 'conversation'."""
-    src = open('static/panels.js').read()
+    src = open(pathlib.Path(__file__).parent.parent / 'static' / 'panels.js').read()
     assert '_settingsSection' in src, '_settingsSection state variable missing from panels.js'
     assert "_settingsSection = 'conversation'" in src or "_settingsSection='conversation'" in src, \
         'Control center does not reset section to conversation on close'
@@ -240,7 +240,7 @@ def test_control_center_resets_active_section_on_close():
 
 def test_control_center_tab_highlight_on_open():
     """Opening the control center must use settings-tabs for section navigation."""
-    css = open('static/style.css').read()
+    css = open(pathlib.Path(__file__).parent.parent / 'static' / 'style.css').read()
     assert 'settings-tabs' in css, 'settings-tabs CSS class for control center tabs missing from style.css'
 
 


### PR DESCRIPTION
Two tests in `tests/test_sprint34.py` used bare relative `open('static/...')` calls which fail when pytest is invoked from any directory other than the repo root (e.g. from the hermes-agent venv directory).

**Root cause:** `test_control_center_resets_active_section_on_close` and `test_control_center_tab_highlight_on_open` used `open('static/panels.js')` and `open('static/style.css')` without resolving the path relative to the test file. Every other test in the suite that opens static files already uses `pathlib.Path(__file__).parent.parent` for this.

**Fix:** Replace both bare `open('static/...')` calls with `open(pathlib.Path(__file__).parent.parent / 'static' / '...')`. `pathlib` is already imported in this file.

**Result:** 813/813 tests pass regardless of the working directory pytest is invoked from.
