### PR TITLE
fix: inject SessionDB into AIAgent for WebUI sessions (enables session_search)

### DIFF
--- a/api/streaming.py
+++ b/api/streaming.py
@@ -186,6 +186,14 @@ def _run_agent_streaming(session_id, msg_text, model, workspace, stream_id, atta
             _AIAgent = _get_ai_agent()
             if _AIAgent is None:
                 raise ImportError("AIAgent not available -- check that hermes-agent is on sys.path")
+
+            # Initialize SessionDB so session_search works in WebUI sessions
+            _session_db = None
+            try:
+                from hermes_state import SessionDB
+                _session_db = SessionDB()
+            except Exception as _db_err:
+                print(f"[webui] WARNING: SessionDB init failed — session_search will be unavailable: {_db_err}", flush=True)
             resolved_model, resolved_provider, resolved_base_url = resolve_model_provider(model)
 
             # Resolve API key via Hermes runtime provider (matches gateway behaviour).
@@ -235,6 +243,7 @@ def _run_agent_streaming(session_id, msg_text, model, workspace, stream_id, atta
                 enabled_toolsets=_toolsets,
                 fallback_model=_fallback_resolved,
                 session_id=session_id,
+                session_db=_session_db,
                 stream_delta_callback=on_token,
                 tool_progress_callback=on_tool,
             )


### PR DESCRIPTION
## Problem
The session_search tool always returns "Session database not available" when used from WebUI sessions. This means the agent cannot recall past conversations or search session history — a capability that works fine in CLI and gateway modes.

## Root Cause
The session_search tool requires a SessionDB instance passed via the session_db parameter on AIAgent.__init__(). Both the CLI path (cli.py) and gateway path (gateway/run.py) already initialize and inject SessionDB, but the WebUI streaming path (api/streaming.py) was missing this step.

The agent's _invoke_tool() method checks self._session_db — when it's None, it short-circuits with the error message without ever touching the database.

## Fix
Two changes in api/streaming.py:
1. Initialize SessionDB() before creating the AIAgent instance (with try/except so failures are non-fatal — just logs a warning)
2. Pass session_db=_session_db to the AIAgent() constructor

## Testing
Verified manually: after the fix, session_search successfully returns recent sessions with metadata (session_id, title, source, timestamps, preview) from the existing state.db (59 sessions, 2309 messages).