### PR TITLE
docs: v0.50.15 release — version badge

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -528,7 +528,7 @@
                 <div class="settings-section-title">System</div>
                 <div class="settings-section-meta">Instance version and access controls.</div>
               </div>
-              <span class="settings-version-badge">v0.50.12</span>
+              <span class="settings-version-badge">v0.50.15</span>
             </div>
             <div class="settings-field" style="border-top:1px solid var(--border);padding-top:12px;margin-top:8px">
               <label for="settingsPassword" data-i18n="settings_label_password">Access Password</label>


### PR DESCRIPTION
Version badge bump to v0.50.15.

Covers three PRs merged since v0.50.12:
- #356: inject SessionDB for session_search in WebUI sessions
- #354: bandit security fixes (B310/B324/B110) + QuietHTTPServer
- #352: KaTeX math rendering for LaTeX in chat + workspace previews