### PR TITLE
fix: pre-install uv in Docker image + fix workspace dir permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,6 +69,10 @@ RUN rm -rf /var/lib/apt/lists/* /etc/apt/apt.conf.d/01proxy \
 
 USER hermeswebuitoo
 
+# Pre-install uv so the container doesn't need internet access at runtime.
+# The init script will skip the download when uv is already on PATH.
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+
 COPY . /apptoo
 
 # Default to binding all interfaces (required for container networking)

--- a/docker_init.bash
+++ b/docker_init.bash
@@ -187,7 +187,10 @@ rm -f $it || error_exit "Failed to delete test file in $HERMES_WEBUI_STATE_DIR"
 echo ""; echo "-- HERMES_WEBUI_DEFAULT_WORKSPACE: Default workspace directory shown on first launch"
 if [ -z "${HERMES_WEBUI_DEFAULT_WORKSPACE+x}" ]; then echo "HERMES_WEBUI_DEFAULT_WORKSPACE not set, setting to /workspace"; export HERMES_WEBUI_DEFAULT_WORKSPACE="/workspace"; fi;
 echo "-- HERMES_WEBUI_DEFAULT_WORKSPACE: $HERMES_WEBUI_DEFAULT_WORKSPACE"
-if [ ! -d "$HERMES_WEBUI_DEFAULT_WORKSPACE" ]; then mkdir -p $HERMES_WEBUI_DEFAULT_WORKSPACE || error_exit "Failed to create default workspace at $HERMES_WEBUI_DEFAULT_WORKSPACE"; fi
+# Use sudo for mkdir/chown — Docker may auto-create bind-mount directories as root,
+# leaving them unwritable by the hermeswebui user (#357).
+sudo mkdir -p "$HERMES_WEBUI_DEFAULT_WORKSPACE" || error_exit "Failed to create default workspace at $HERMES_WEBUI_DEFAULT_WORKSPACE"
+sudo chown hermeswebui:hermeswebui "$HERMES_WEBUI_DEFAULT_WORKSPACE" || error_exit "Failed to set owner of $HERMES_WEBUI_DEFAULT_WORKSPACE"
 if [ ! -d "$HERMES_WEBUI_DEFAULT_WORKSPACE" ]; then error_exit "HERMES_WEBUI_DEFAULT_WORKSPACE directory does not exist at $HERMES_WEBUI_DEFAULT_WORKSPACE"; fi
 it="$HERMES_WEBUI_DEFAULT_WORKSPACE/.testfile"; touch $it || error_exit "Failed to verify default workspace at $HERMES_WEBUI_DEFAULT_WORKSPACE"
 rm -f $it || error_exit "Failed to delete test file in $HERMES_WEBUI_DEFAULT_WORKSPACE"
@@ -195,8 +198,13 @@ rm -f $it || error_exit "Failed to delete test file in $HERMES_WEBUI_DEFAULT_WOR
 echo ""; echo "==================="
 echo ""; echo "== Installing uv and creating a new virtual environment for hermes-webui"
 
-curl -LsSf https://astral.sh/uv/install.sh | sh
 export PATH="/home/hermeswebui/.local/bin/:$PATH"
+if command -v uv &>/dev/null; then
+  echo "-- uv already installed ($(uv --version)), skipping download"
+else
+  echo "-- uv not found, downloading..."
+  curl -LsSf https://astral.sh/uv/install.sh | sh || error_exit "Failed to install uv — check network connectivity"
+fi
 export UV_PROJECT_ENVIRONMENT=venv
 
 export UV_CACHE_DIR=/uv_cache


### PR DESCRIPTION
## Summary
- **Pre-install `uv` at Docker build time** so the container starts without internet access. The init script now checks `command -v uv` and skips the download if already present.
- **Fix workspace directory permissions** by using `sudo mkdir -p` + `sudo chown` for the default workspace, matching the existing pattern for `/app`. Docker auto-creates bind-mount directories as root, leaving them unwritable by the hermeswebui user.

## Root cause
1. `docker_init.bash` line 198 runs `curl ... | sh` to install `uv` at every startup. If the container has no internet (corporate firewall, isolated network), this fails and the container exits.
2. Line 190 runs `mkdir -p` as the hermeswebui user, but Docker may have already created the mount point as root, causing a permission error.

## What changed
- `Dockerfile`: Added `RUN curl -LsSf https://astral.sh/uv/install.sh | sh` at build time (as hermeswebuitoo user)
- `docker_init.bash`: Skip uv download when already installed; use sudo for workspace mkdir/chown

## Test plan
- [x] `bash -n docker_init.bash` — syntax OK
- [x] `pytest tests/ --timeout=60 -q` — 815 passed, 48 skipped
- [ ] Docker build + startup in isolated network (manual verification)

Fixes #357

🤖 Generated with [Claude Code](https://claude.com/claude-code)