### PR TITLE
Fix unicode filenames in file download headers

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -1302,6 +1302,29 @@ def _handle_gateway_sse_stream(handler):
     return True
 
 
+def _content_disposition_value(disposition: str, filename: str) -> str:
+    """Build a latin-1-safe Content-Disposition value with RFC 5987 filename*."""
+    import urllib.parse as _up
+
+    safe_name = Path(filename).name.replace("\r", "").replace("\n", "")
+    ascii_fallback = "".join(
+        ch if 32 <= ord(ch) < 127 and ch not in {'"', '\\'} else "_"
+        for ch in safe_name
+    ).strip(" .")
+    if not ascii_fallback:
+        suffix = Path(safe_name).suffix
+        ascii_suffix = "".join(
+            ch if 32 <= ord(ch) < 127 and ch not in {'"', '\\'} else "_"
+            for ch in suffix
+        )
+        ascii_fallback = f"download{ascii_suffix}" if ascii_suffix else "download"
+    quoted_name = _up.quote(safe_name, safe="")
+    return (
+        f'{disposition}; filename="{ascii_fallback}"; '
+        f"filename*=UTF-8''{quoted_name}"
+    )
+
+
 def _handle_file_raw(handler, parsed):
     qs = parse_qs(parsed.query)
     sid = qs.get("session_id", [""])[0]
@@ -1319,9 +1342,6 @@ def _handle_file_raw(handler, parsed):
     ext = target.suffix.lower()
     mime = MIME_MAP.get(ext, "application/octet-stream")
     raw_bytes = target.read_bytes()
-    import urllib.parse as _up
-
-    safe_name = _up.quote(target.name, safe="")
     handler.send_response(200)
     handler.send_header("Content-Type", mime)
     handler.send_header("Content-Length", str(len(raw_bytes)))
@@ -1331,12 +1351,12 @@ def _handle_file_raw(handler, parsed):
     if force_download or mime in dangerous_types:
         handler.send_header(
             "Content-Disposition",
-            f"attachment; filename=\"{target.name}\"; filename*=UTF-8''{safe_name}",
+            _content_disposition_value("attachment", target.name),
         )
     else:
         handler.send_header(
             "Content-Disposition",
-            f"inline; filename=\"{target.name}\"; filename*=UTF-8''{safe_name}",
+            _content_disposition_value("inline", target.name),
         )
     handler.end_headers()
     handler.wfile.write(raw_bytes)

--- a/tests/test_sprint29.py
+++ b/tests/test_sprint29.py
@@ -21,6 +21,7 @@ import pathlib
 import sys
 import time
 import urllib.error
+import urllib.parse
 import urllib.request
 
 sys.path.insert(0, str(pathlib.Path(__file__).parent))
@@ -49,6 +50,12 @@ def post(path, body=None, headers=None):
             return json.loads(r.read()), r.status
     except urllib.error.HTTPError as e:
         return json.loads(e.read()), e.code
+
+
+def get_raw_with_headers(path):
+    req = urllib.request.Request(BASE + path)
+    with urllib.request.urlopen(req, timeout=10) as r:
+        return r.read(), dict(r.headers.items()), r.status
 
 
 # ── 1. CSRF Protection ─────────────────────────────────────────────────────
@@ -549,6 +556,52 @@ class TestContentDisposition:
         assert "application/xhtml+xml" in src
         assert "image/svg+xml" in src
         assert "dangerous_types" in src
+
+    def test_unicode_filename_download_header_is_latin1_safe(self, cleanup_test_sessions):
+        """Unicode filenames must not crash download responses."""
+        body, status = post("/api/session/new", {})
+        assert status == 200, body
+        sid = body["session"]["session_id"]
+        cleanup_test_sessions.append(sid)
+        ws = pathlib.Path(body["session"]["workspace"])
+        filename = "中文对照表.pdf"
+        pdf_bytes = b"%PDF-1.3\n1 0 obj\n<<>>\nendobj\ntrailer\n<<>>\n%%EOF\n"
+        (ws / filename).write_bytes(pdf_bytes)
+
+        encoded = urllib.parse.quote(filename)
+        raw, headers, raw_status = get_raw_with_headers(
+            f"/api/file/raw?session_id={sid}&path={encoded}&download=1"
+        )
+
+        assert raw_status == 200
+        assert raw == pdf_bytes
+        disp = headers["Content-Disposition"]
+        assert disp.startswith("attachment; ")
+        assert "filename*=UTF-8''" in disp
+        disp.encode("latin-1")
+
+    def test_unicode_filename_inline_header_is_latin1_safe(self, cleanup_test_sessions):
+        """Inline responses must also work for unicode filenames."""
+        body, status = post("/api/session/new", {})
+        assert status == 200, body
+        sid = body["session"]["session_id"]
+        cleanup_test_sessions.append(sid)
+        ws = pathlib.Path(body["session"]["workspace"])
+        filename = "预览.pdf"
+        pdf_bytes = b"%PDF-1.3\n1 0 obj\n<<>>\nendobj\ntrailer\n<<>>\n%%EOF\n"
+        (ws / filename).write_bytes(pdf_bytes)
+
+        encoded = urllib.parse.quote(filename)
+        raw, headers, raw_status = get_raw_with_headers(
+            f"/api/file/raw?session_id={sid}&path={encoded}"
+        )
+
+        assert raw_status == 200
+        assert raw == pdf_bytes
+        disp = headers["Content-Disposition"]
+        assert disp.startswith("inline; ")
+        assert "filename*=UTF-8''" in disp
+        disp.encode("latin-1")
 
 
 # ── 9. PBKDF2 Password Hashing ───────────────────────────────────────────


### PR DESCRIPTION
## Summary
- make `/api/file/raw` emit a latin-1-safe `Content-Disposition` header for non-ASCII filenames
- keep the UTF-8 filename in `filename*` while generating an ASCII fallback for the legacy `filename` parameter
- add regression coverage for both attachment and inline responses with Unicode filenames

## Problem
Clicking a workspace PDF whose filename contains Chinese characters currently fails. The server tries to send the raw Unicode filename in the `Content-Disposition` header, and Python's `http.server` raises `UnicodeEncodeError` because headers must be latin-1 encodable.

## Fix
This patch centralizes `Content-Disposition` generation in a helper that:
- strips CR/LF from the filename
- builds an ASCII fallback for `filename="..."`
- preserves the original UTF-8 filename via `filename*=`

This keeps downloads working for Unicode filenames without changing the existing inline vs attachment behavior.

## Tests
- `python -m pytest -q tests/test_sprint29.py -k "unicode_filename or dangerous_mime_types_set_complete"`
- `python -m pytest -q tests/test_sprint2.py -k "raw_endpoint_serves_png or raw_endpoint_serves_svg"`
