### PR TITLE
docs: v0.50.21 release — version badge

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -528,7 +528,7 @@
                 <div class="settings-section-title">System</div>
                 <div class="settings-section-meta">Instance version and access controls.</div>
               </div>
-              <span class="settings-version-badge">v0.50.20</span>
+              <span class="settings-version-badge">v0.50.21</span>
             </div>
             <div class="settings-field" style="border-top:1px solid var(--border);padding-top:12px;margin-top:8px">
               <label for="settingsPassword" data-i18n="settings_label_password">Access Password</label>


### PR DESCRIPTION
Version badge bump to v0.50.21 (live reasoning + reload recovery with durable localStorage state, PR #367).