### PR TITLE
docs: add remaining contributors — Argonaut790, indigokarasu, zenc-cp (complete to 33)

### DIFF
--- a/README.md
+++ b/README.md
@@ -609,6 +609,15 @@ Fixed `api_key` not being passed to `AIAgent` for non-Anthropic `/anthropic` pro
 **[@mangodxd](https://github.com/mangodxd)** — Type hints cleanup (PR #115)
 Added missing type hints across 10 files and corrected 9 inaccurate existing ones — the kind of maintenance work that makes the codebase easier to reason about.
 
+**[@Argonaut790](https://github.com/Argonaut790)** — HTML entity decode + Traditional Chinese locale (PR #239)
+Fixed double-escaping of HTML entities in `renderMd()` — LLM output containing `&lt;code&gt;` was being escaped a second time, rendering as literal text instead of the intended markdown. The same PR also completed the Simplified Chinese translation (40+ missing keys) and added a full Traditional Chinese (`zh-Hant`) locale.
+
+**[@indigokarasu](https://github.com/indigokarasu)** — Visual redesign proposal: icon rail + design token system + 7 themes (PR #213)
+A CSS-only redesign of the full UI — proper design tokens (`--bg-primary`, `--text-info`, spacing scale), an icon rail sidebar replacing the emoji tab strip, consistent form cards, breadcrumb nav, and 7 built-in themes as custom properties. The PR didn't merge as-is but directly shaped the design language and theme architecture that shipped in v0.50.0.
+
+**[@zenc-cp](https://github.com/zenc-cp)** — Anti-hallucination guard for ReAct loop (PR #133)
+Added a streaming token buffer and post-run message scrub to `streaming.py` to detect and strip fake tool execution JSON that weaker models write inline instead of calling tools properly. A three-layer approach: ephemeral anti-hallucination prompt, live token filtering, and session history cleanup. The pattern influenced later streaming.py improvements.
+
 ---
 
 Want to contribute? See [ARCHITECTURE.md](ARCHITECTURE.md) for the codebase layout and [TESTING.md](TESTING.md) for how to run the test suite. The best contributions are focused, well-tested, and solve a real problem — exactly what every person on this list did.


### PR DESCRIPTION
Adds the three remaining external contributors not yet in the README.

**@Argonaut790** (#239) — HTML entity decode fix + Traditional Chinese locale
- The entity decode fix (double-escaping of `&lt;code&gt;` in renderMd) shipped in v0.46.0
- PR also completed Simplified Chinese (40+ missing keys) and added full `zh-Hant` locale

**@indigokarasu** (#213) — Visual redesign: icon rail + design token system + 7 themes
- CSS-only redesign proposal — 3268 additions, zero JS changes
- Didn't merge as-is but the design token system and theme architecture directly shaped what shipped in v0.50.0

**@zenc-cp** (#133) — Anti-hallucination guard for ReAct loop
- Three-layer approach: ephemeral system prompt, streaming token buffer, post-run message scrub
- Addresses weaker models writing fake tool execution JSON inline

README now has **33 contributors** covering the full project history from PRs #3–#378.