### PR TITLE
fix: preserve imported session timestamps

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -74,8 +74,9 @@ class Session:
     def path(self):
         return SESSION_DIR / f'{self.session_id}.json'
 
-    def save(self) -> None:
-        self.updated_at = time.time()
+    def save(self, touch_updated_at: bool = True) -> None:
+        if touch_updated_at:
+            self.updated_at = time.time()
         self.path.write_text(
             json.dumps(self.__dict__, ensure_ascii=False, indent=2),
             encoding='utf-8',
@@ -211,7 +212,15 @@ def save_projects(projects) -> None:
     PROJECTS_FILE.write_text(json.dumps(projects, ensure_ascii=False, indent=2), encoding='utf-8')
 
 
-def import_cli_session(session_id: str, title: str, messages, model: str='unknown', profile=None):
+def import_cli_session(
+    session_id: str,
+    title: str,
+    messages,
+    model: str='unknown',
+    profile=None,
+    created_at=None,
+    updated_at=None,
+):
     """Create a new WebUI session populated with CLI messages.
     Returns the Session object.
     """
@@ -222,8 +231,10 @@ def import_cli_session(session_id: str, title: str, messages, model: str='unknow
         model=model,
         messages=messages,
         profile=profile,
+        created_at=created_at,
+        updated_at=updated_at,
     )
-    s.save()
+    s.save(touch_updated_at=False)
     return s
 
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -2209,18 +2209,30 @@ def _handle_session_import_cli(handler, body):
     title = title_from(msgs, "CLI Session")
     model = "unknown"
 
-    # Get profile and model from CLI session metadata
+    # Get profile, model, and timestamps from CLI session metadata
     profile = None
+    created_at = None
+    updated_at = None
     for cs in get_cli_sessions():
         if cs["session_id"] == sid:
             profile = cs.get("profile")
             model = cs.get("model", "unknown")
+            created_at = cs.get("created_at")
+            updated_at = cs.get("updated_at")
             break
 
-    s = import_cli_session(sid, title, msgs, model, profile=profile)
+    s = import_cli_session(
+        sid,
+        title,
+        msgs,
+        model,
+        profile=profile,
+        created_at=created_at,
+        updated_at=updated_at,
+    )
     s.is_cli_session = True
     s._cli_origin = sid
-    s.save()
+    s.save(touch_updated_at=False)
     return j(
         handler,
         {

--- a/tests/test_gateway_sync.py
+++ b/tests/test_gateway_sync.py
@@ -275,6 +275,59 @@ def test_gateway_session_messages_readable():
         post('/api/settings', {'show_cli_sessions': False})
 
 
+def test_importing_older_gateway_session_preserves_original_timestamps_and_order():
+    """Importing an older gateway session should not bump it above newer WebUI sessions."""
+    conn = _ensure_state_db()
+    older_started_at = time.time() - 1800
+    imported_sid = 'gw_import_old_001'
+    newer_webui_sid = None
+    try:
+        newer_webui, status = post('/api/session/new', {'model': 'openai/gpt-5'})
+        assert status == 200, newer_webui
+        newer_webui_sid = newer_webui['session']['session_id']
+
+        rename, rename_status = post(
+            '/api/session/rename',
+            {'session_id': newer_webui_sid, 'title': 'Newer WebUI Session'},
+        )
+        assert rename_status == 200, rename
+
+        _insert_gateway_session(
+            conn,
+            session_id=imported_sid,
+            source='discord',
+            title='Older imported gateway session',
+            started_at=older_started_at,
+        )
+        post('/api/settings', {'show_cli_sessions': True})
+
+        imported, imported_status = post('/api/session/import_cli', {'session_id': imported_sid})
+        assert imported_status == 200, imported
+        imported_session = imported['session']
+        assert abs(imported_session['created_at'] - older_started_at) < 2, imported_session
+        assert abs(imported_session['updated_at'] - older_started_at) < 5, imported_session
+
+        sessions_payload, sessions_status = get('/api/sessions')
+        assert sessions_status == 200, sessions_payload
+        ordered_ids = [item['session_id'] for item in sessions_payload.get('sessions', [])]
+        assert newer_webui_sid in ordered_ids, ordered_ids
+        assert imported_sid in ordered_ids, ordered_ids
+        assert ordered_ids.index(newer_webui_sid) < ordered_ids.index(imported_sid), ordered_ids
+    finally:
+        try:
+            _remove_test_sessions(conn, imported_sid)
+            conn.close()
+        except Exception:
+            pass
+        if newer_webui_sid:
+            try:
+                post('/api/session/delete', {'session_id': newer_webui_sid})
+            except Exception:
+                pass
+        post('/api/settings', {'show_cli_sessions': False})
+
+
+
 def test_gateway_sse_stream_endpoint_exists():
     """GET /api/sessions/gateway/stream returns a response (200 or 200-range)."""
     # The SSE endpoint requires show_cli_sessions to be enabled


### PR DESCRIPTION
## Summary

Preserves original CLI/gateway session timestamps when importing them into the WebUI so historical sessions keep their correct chronological position instead of jumping to the top as if they were newly active.

## Root cause

`import_cli_session()` always saved imported sessions with a fresh `updated_at` timestamp, and the import route saved the session again immediately after import. That rewrote imported recency metadata and made older sessions appear newer than existing WebUI conversations.

## What this changes

- lets `Session.save()` preserve the existing `updated_at` value when needed instead of always touching it
- extends `import_cli_session()` to accept `created_at` and `updated_at` from CLI session metadata
- updates the CLI import route to pass those timestamps through the import path and avoid re-touching them after marking the imported session as CLI-backed
- adds a regression test covering the user-visible failure mode: importing an older gateway session should keep it below a newer WebUI session in `/api/sessions`

## Why this fits upstream

- fixes incorrect ordering for mixed WebUI + imported histories
- preserves source-of-truth timestamps instead of mutating imported metadata
- adds direct regression coverage for a user-visible ordering bug

## Verification

- [x] `source /home/jordan/.hermes/hermes-agent/venv/bin/activate && python -m pytest tests/test_gateway_sync.py -k older_gateway_session_preserves_original_timestamps_and_order -q`
  - result: `1 passed, 10 deselected in 1.89s`

## Scope

- intentionally limited to `api/models.py`, `api/routes.py`, and `tests/test_gateway_sync.py`
- does not change session sorting rules beyond preserving imported metadata correctly
