### PR TITLE
feat: add desktop microphone transcription fallback

### DIFF
--- a/api/helpers.py
+++ b/api/helpers.py
@@ -50,7 +50,7 @@ def _security_headers(handler):
     )
     handler.send_header(
         'Permissions-Policy',
-        'camera=(), microphone=(), geolocation=()'
+        'camera=(), microphone=(self), geolocation=()'
     )
 
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -181,7 +181,7 @@ from api.workspace import (
     read_file_content,
     safe_resolve_ws,
 )
-from api.upload import handle_upload
+from api.upload import handle_upload, handle_transcribe
 from api.streaming import _sse, _run_agent_streaming, cancel_stream
 from api.onboarding import (
     apply_onboarding_setup,
@@ -629,6 +629,9 @@ def handle_post(handler, parsed) -> bool:
 
     if parsed.path == "/api/upload":
         return handle_upload(handler)
+
+    if parsed.path == "/api/transcribe":
+        return handle_transcribe(handler)
 
     body = read_body(handler)
 

--- a/api/upload.py
+++ b/api/upload.py
@@ -3,6 +3,7 @@ Hermes Web UI -- File upload: multipart parser and upload handler.
 """
 import re as _re
 import email.parser
+import tempfile
 from pathlib import Path
 
 from api.config import MAX_UPLOAD_BYTES
@@ -50,8 +51,15 @@ def parse_multipart(rfile, content_type, content_length) -> tuple:
     return fields, files
 
 
+def _sanitize_upload_name(filename: str) -> str:
+    safe_name = _re.sub(r'[^\w.\-]', '_', Path(filename).name)[:200]
+    if not safe_name or safe_name.strip('.') == '':
+        raise ValueError('Invalid filename')
+    return safe_name
+
+
 def handle_upload(handler):
-    import re as _re, traceback as _tb
+    import traceback as _tb
     try:
         content_type = handler.headers.get('Content-Type', '')
         content_length = int(handler.headers.get('Content-Length', 0) or 0)
@@ -69,14 +77,55 @@ def handle_upload(handler):
         except KeyError:
             return j(handler, {'error': 'Session not found'}, status=404)
         workspace = Path(s.workspace)
-        safe_name = _re.sub(r'[^\w.\-]', '_', Path(filename).name)[:200]
-        # Reject names that are purely dots (path traversal: ".." survives regex)
-        if not safe_name or safe_name.strip('.') == '':
-            return j(handler, {'error': 'Invalid filename'}, status=400)
-        # Verify the resolved path stays within the workspace
+        safe_name = _sanitize_upload_name(filename)
         dest = safe_resolve_ws(workspace, safe_name)
         dest.write_bytes(file_bytes)
         return j(handler, {'filename': safe_name, 'path': str(dest), 'size': dest.stat().st_size})
-    except Exception as e:
+    except ValueError as e:
+        return j(handler, {'error': str(e)}, status=400)
+    except Exception:
         print('[webui] upload error: ' + _tb.format_exc(), flush=True)
         return j(handler, {'error': 'Upload failed'}, status=500)
+
+
+def handle_transcribe(handler):
+    import traceback as _tb
+    temp_path = None
+    try:
+        content_type = handler.headers.get('Content-Type', '')
+        content_length = int(handler.headers.get('Content-Length', 0) or 0)
+        if content_length > MAX_UPLOAD_BYTES:
+            return j(handler, {'error': f'File too large (max {MAX_UPLOAD_BYTES//1024//1024}MB)'}, status=413)
+        fields, files = parse_multipart(handler.rfile, content_type, content_length)
+        if 'file' not in files:
+            return j(handler, {'error': 'No file field in request'}, status=400)
+        filename, file_bytes = files['file']
+        if not filename:
+            return j(handler, {'error': 'No filename in upload'}, status=400)
+        safe_name = _sanitize_upload_name(filename)
+        suffix = Path(safe_name).suffix or '.webm'
+        with tempfile.NamedTemporaryFile(prefix='webui-stt-', suffix=suffix, delete=False) as tmp:
+            temp_path = tmp.name
+            tmp.write(file_bytes)
+        try:
+            from tools.transcription_tools import transcribe_audio
+        except ImportError:
+            return j(handler, {'error': 'Speech-to-text is unavailable on this server'}, status=503)
+        result = transcribe_audio(temp_path)
+        if not result.get('success'):
+            msg = str(result.get('error') or 'Transcription failed')
+            status = 503 if 'unavailable' in msg.lower() or 'not configured' in msg.lower() else 400
+            return j(handler, {'error': msg}, status=status)
+        transcript = str(result.get('transcript') or '').strip()
+        return j(handler, {'ok': True, 'transcript': transcript})
+    except ValueError as e:
+        return j(handler, {'error': str(e)}, status=400)
+    except Exception:
+        print('[webui] transcribe error: ' + _tb.format_exc(), flush=True)
+        return j(handler, {'error': 'Transcription failed'}, status=500)
+    finally:
+        if temp_path:
+            try:
+                Path(temp_path).unlink(missing_ok=True)
+            except Exception:
+                pass

--- a/static/boot.js
+++ b/static/boot.js
@@ -172,24 +172,32 @@ function mobileSwitchPanel(name){
   });
 }
 
-$('btnSend').onclick=()=>{if(window._micActive)_stopMic();send();};
+$('btnSend').onclick=()=>{
+  if(window._micActive){
+    window._micPendingSend=true;
+    _stopMic();
+    return;
+  }
+  send();
+};
 $('btnAttach').onclick=()=>$('fileInput').click();
 
-// ── Voice input (Web Speech API) ─────────────────────────────────────────
+// ── Voice input (Web Speech API + MediaRecorder fallback) ───────────────────
 (function(){
   const SpeechRecognition=window.SpeechRecognition||window.webkitSpeechRecognition;
-  if(!SpeechRecognition) return; // Browser unsupported — mic button stays hidden
+  const _canRecordAudio=!!(navigator.mediaDevices&&navigator.mediaDevices.getUserMedia&&window.MediaRecorder);
+  if(!SpeechRecognition&&!_canRecordAudio) return; // Browser unsupported — mic button stays hidden
 
   const btn=$('btnMic');
   const status=$('micStatus');
   const ta=$('msg');
-  btn.style.display=''; // Show button — browser supports speech
+  const statusText=status?status.querySelector('.status-text'):null;
+  btn.style.display=''; // Show button — browser supports speech recognition or recording fallback
 
-  const recognition=new SpeechRecognition();
-  recognition.continuous=false;
-  recognition.interimResults=true;
-  recognition.lang=(typeof _locale!=='undefined'&&_locale._speech)||'en-US';
-
+  let recognition=SpeechRecognition?new SpeechRecognition():null;
+  let mediaRecorder=null;
+  let mediaStream=null;
+  let audioChunks=[];
   let _finalText='';
   let _prefix='';
 
@@ -197,65 +205,160 @@ $('btnAttach').onclick=()=>$('fileInput').click();
     window._micActive=on;
     btn.classList.toggle('recording',on);
     status.style.display=on?'':'none';
+    if(statusText) statusText.textContent=on?'Listening':'Listening';
     if(!on){ _finalText=''; _prefix=''; }
   }
 
-  recognition.onstart=()=>{ _finalText=''; };
-
-  recognition.onresult=(event)=>{
-    let interim='';
-    let final=_finalText;
-    for(let i=event.resultIndex;i<event.results.length;i++){
-      const t=event.results[i][0].transcript;
-      if(event.results[i].isFinal){ final+=t; _finalText=final; }
-      else{ interim+=t; }
-    }
-    // Append to whatever was already in the textarea before mic started
-    ta.value=_prefix+(final||interim);
-    autoResize();
-  };
-
-  recognition.onend=()=>{
-    // Commit: prefix + final transcription; trim trailing space if prefix was non-empty
-    const committed=_finalText
+  function _commitTranscript(text){
+    const clean=(text||'').trim();
+    const committed=clean
       ? (_prefix&&!_prefix.endsWith(' ')&&!_prefix.endsWith('\n')
-          ? _prefix+' '+_finalText.trimStart()
-          : _prefix+_finalText)
-      : ta.value; // no speech detected — leave whatever is there
-    _setRecording(false);
+          ? _prefix+' '+clean.trimStart()
+          : _prefix+clean)
+      : ta.value;
     ta.value=committed;
     autoResize();
-  };
+    if(window._micPendingSend){
+      window._micPendingSend=false;
+      send();
+    }
+  }
 
-  recognition.onerror=(event)=>{
-    _setRecording(false);
-    const msgs={
-      'not-allowed':t('mic_denied'),
-      'no-speech':t('mic_no_speech'),
-      'network':t('mic_network'),
-    };
-    showToast(msgs[event.error]||t('mic_error')+event.error);
-  };
+  async function _transcribeBlob(blob){
+    const ext=(blob.type&&blob.type.includes('ogg'))?'ogg':'webm';
+    const form=new FormData();
+    form.append('file',new File([blob],`voice-input.${ext}`,{type:blob.type||`audio/${ext}`}));
+    setComposerStatus('Transcribing…');
+    try{
+      const res=await fetch('/api/transcribe',{method:'POST',body:form});
+      const data=await res.json().catch(()=>({}));
+      if(!res.ok) throw new Error(data.error||'Transcription failed');
+      _commitTranscript(data.transcript||'');
+    }catch(err){
+      window._micPendingSend=false;
+      showToast(err.message||t('mic_network'));
+    }finally{
+      setComposerStatus('');
+    }
+  }
+
+  function _stopTracks(){
+    if(mediaStream){
+      mediaStream.getTracks().forEach(track=>track.stop());
+      mediaStream=null;
+    }
+  }
 
   function _stopMic(){
-    if(window._micActive){ recognition.stop(); }
+    if(!window._micActive) return;
+    if(recognition){
+      recognition.stop();
+      return;
+    }
+    if(mediaRecorder&&mediaRecorder.state!=='inactive'){
+      mediaRecorder.stop();
+      return;
+    }
+    _setRecording(false);
+    _stopTracks();
   }
   window._stopMic=_stopMic; // expose for send-guard above
 
-  btn.onclick=()=>{
+  if(recognition){
+    recognition.continuous=false;
+    recognition.interimResults=true;
+    recognition.lang=(typeof _locale!=='undefined'&&_locale._speech)||'en-US';
+
+    recognition.onstart=()=>{ _finalText=''; };
+
+    recognition.onresult=(event)=>{
+      let interim='';
+      let final=_finalText;
+      for(let i=event.resultIndex;i<event.results.length;i++){
+        const t=event.results[i][0].transcript;
+        if(event.results[i].isFinal){ final+=t; _finalText=final; }
+        else{ interim+=t; }
+      }
+      ta.value=_prefix+(final||interim);
+      autoResize();
+    };
+
+    recognition.onend=()=>{
+      const committed=_finalText
+        ? (_prefix&&!_prefix.endsWith(' ')&&!_prefix.endsWith('\n')
+            ? _prefix+' '+_finalText.trimStart()
+            : _prefix+_finalText)
+        : ta.value;
+      _setRecording(false);
+      ta.value=committed;
+      autoResize();
+      if(window._micPendingSend){
+        window._micPendingSend=false;
+        send();
+      }
+    };
+
+    recognition.onerror=(event)=>{
+      _setRecording(false);
+      window._micPendingSend=false;
+      const msgs={
+        'not-allowed':t('mic_denied'),
+        'no-speech':t('mic_no_speech'),
+        'network':t('mic_network'),
+      };
+      showToast(msgs[event.error]||t('mic_error')+event.error);
+    };
+  }
+
+  btn.onclick=async()=>{
     if(window._micActive){
-      recognition.stop();
-      // _setRecording(false) will be called by onend
-    } else {
-      _finalText='';
-      // Snapshot existing textarea content so we append rather than replace
-      _prefix=ta.value;
+      _stopMic();
+      return;
+    }
+    _finalText='';
+    _prefix=ta.value;
+    if(recognition){
       recognition.start();
       _setRecording(true);
+      return;
+    }
+    if(!_canRecordAudio){
+      showToast(t('mic_network'));
+      return;
+    }
+    try{
+      mediaStream=await navigator.mediaDevices.getUserMedia({audio:true});
+      const preferredTypes=['audio/webm;codecs=opus','audio/webm','audio/ogg;codecs=opus','audio/ogg'];
+      const mimeType=preferredTypes.find(type=>window.MediaRecorder.isTypeSupported?.(type))||'';
+      mediaRecorder=new MediaRecorder(mediaStream,mimeType?{mimeType}:undefined);
+      audioChunks=[];
+      mediaRecorder.ondataavailable=e=>{if(e.data&&e.data.size)audioChunks.push(e.data);};
+      mediaRecorder.onerror=()=>{
+        _setRecording(false);
+        window._micPendingSend=false;
+        _stopTracks();
+        showToast(t('mic_network'));
+      };
+      mediaRecorder.onstop=async()=>{
+        const blob=new Blob(audioChunks,{type:mediaRecorder.mimeType||mimeType||'audio/webm'});
+        _setRecording(false);
+        _stopTracks();
+        if(blob.size){ await _transcribeBlob(blob); }
+        else if(window._micPendingSend){
+          window._micPendingSend=false;
+        }
+      };
+      mediaRecorder.start();
+      _setRecording(true);
+    }catch(err){
+      window._micPendingSend=false;
+      _stopTracks();
+      showToast(t('mic_denied'));
     }
   };
 })();
 window._micActive=window._micActive||false;
+window._micPendingSend=window._micPendingSend||false;
 $('fileInput').onchange=e=>{addFiles(Array.from(e.target.files));e.target.value='';};
 $('btnNewChat').onclick=async()=>{await newSession();await renderSessionList();$('msg').focus();};
 $('btnDownload').onclick=()=>{

--- a/tests/test_sprint19.py
+++ b/tests/test_sprint19.py
@@ -80,6 +80,16 @@ def test_security_headers_on_health():
     assert headers.get("X-Content-Type-Options") == "nosniff"
 
 
+def test_permissions_policy_does_not_disable_microphone():
+    """Permissions-Policy must not hard-disable microphone access for same-origin voice input."""
+    _, status, headers = get("/health")
+    assert status == 200
+    policy = headers.get("Permissions-Policy", "")
+    assert policy, "Permissions-Policy header missing"
+    assert "microphone=()" not in policy, \
+        "Permissions-Policy must not block microphone access or desktop/mobile voice input cannot work"
+
+
 def test_cache_control_no_store():
     """API responses should have Cache-Control: no-store."""
     d, status, headers = get("/api/sessions")

--- a/tests/test_sprint20.py
+++ b/tests/test_sprint20.py
@@ -8,6 +8,7 @@ the browser with no server-side component.
 import re
 import urllib.request
 import json
+import pathlib
 
 BASE = "http://127.0.0.1:8788"
 
@@ -315,15 +316,31 @@ def test_boot_js_iife_guard():
     assert '(function(){' in js or '(function () {' in js
 
 
-def test_boot_js_browser_unsupported_return():
-    """boot.js must bail out (return) early when SpeechRecognition is unavailable."""
+def test_boot_js_browser_unsupported_guard_uses_fallback_capabilities():
+    """boot.js must keep the mic available when either speech recognition OR recorder capture exists."""
     js, _ = get_text("/static/boot.js")
-    # The IIFE should have an early return when SpeechRecognition is falsy
-    assert 'if(!SpeechRecognition)' in js or 'if (!SpeechRecognition)' in js
+    assert 'navigator.mediaDevices' in js
+    assert 'getUserMedia' in js
+    assert 'MediaRecorder' in js
+    assert '_canRecordAudio' in js or 'canRecordAudio' in js, \
+        "boot.js should compute a recorder fallback instead of bailing only on SpeechRecognition"
 
 
-def test_boot_js_shows_mic_button_when_supported():
-    """boot.js must set display='' on btnMic when SpeechRecognition is available."""
+def test_boot_js_media_recorder_fallback_posts_to_transcribe_api():
+    """Desktop fallback must send recorded audio to /api/transcribe for transcription."""
+    js, _ = get_text("/static/boot.js")
+    assert '/api/transcribe' in js
+    assert 'fetch(' in js
+
+
+def test_routes_define_transcribe_endpoint():
+    """Server routes must expose /api/transcribe for MediaRecorder fallback uploads."""
+    routes = pathlib.Path(__file__).parent.parent.joinpath("api/routes.py").read_text(encoding="utf-8")
+    assert '"/api/transcribe"' in routes
+
+
+def test_boot_js_shows_mic_button_when_any_voice_path_is_supported():
+    """boot.js must reveal btnMic when speech recognition or recorder fallback is available."""
     js, _ = get_text("/static/boot.js")
     assert "btn.style.display=''" in js or 'btn.style.display = ""' in js
 

--- a/tests/test_voice_transcribe_endpoint.py
+++ b/tests/test_voice_transcribe_endpoint.py
@@ -1,0 +1,87 @@
+import io
+import json
+import sys
+import types
+
+from api.upload import handle_transcribe
+
+
+def _multipart_body(fields=None, files=None, boundary=b"voiceboundary"):
+    fields = fields or {}
+    files = files or {}
+    body = b""
+    for name, value in fields.items():
+        body += b"--" + boundary + b"\r\n"
+        body += f'Content-Disposition: form-data; name="{name}"\r\n\r\n'.encode()
+        body += str(value).encode() + b"\r\n"
+    for name, (filename, data, content_type) in files.items():
+        body += b"--" + boundary + b"\r\n"
+        body += (
+            f'Content-Disposition: form-data; name="{name}"; filename="{filename}"\r\n'
+            f'Content-Type: {content_type}\r\n\r\n'
+        ).encode()
+        body += data + b"\r\n"
+    body += b"--" + boundary + b"--\r\n"
+    return body, f"multipart/form-data; boundary={boundary.decode()}"
+
+
+class _FakeHandler:
+    def __init__(self, body: bytes, content_type: str):
+        self.rfile = io.BytesIO(body)
+        self.wfile = io.BytesIO()
+        self.headers = {
+            "Content-Type": content_type,
+            "Content-Length": str(len(body)),
+        }
+        self.status = None
+        self.sent_headers = {}
+
+    def send_response(self, status):
+        self.status = status
+
+    def send_header(self, key, value):
+        self.sent_headers[key] = value
+
+    def end_headers(self):
+        pass
+
+    def payload(self):
+        return json.loads(self.wfile.getvalue().decode("utf-8"))
+
+
+def test_handle_transcribe_requires_file_field():
+    body, content_type = _multipart_body(fields={"note": "missing file"})
+    handler = _FakeHandler(body, content_type)
+    handle_transcribe(handler)
+    assert handler.status == 400
+    assert handler.payload()["error"] == "No file field in request"
+
+
+def test_handle_transcribe_returns_transcript(monkeypatch):
+    fake_mod = types.ModuleType("tools.transcription_tools")
+    fake_mod.transcribe_audio = lambda path: {"success": True, "transcript": "hello from audio"}
+    monkeypatch.setitem(sys.modules, "tools.transcription_tools", fake_mod)
+
+    body, content_type = _multipart_body(
+        files={"file": ("voice.webm", b"RIFFfakeaudio", "audio/webm")}
+    )
+    handler = _FakeHandler(body, content_type)
+    handle_transcribe(handler)
+
+    assert handler.status == 200
+    assert handler.payload() == {"ok": True, "transcript": "hello from audio"}
+
+
+def test_handle_transcribe_surfaces_provider_error(monkeypatch):
+    fake_mod = types.ModuleType("tools.transcription_tools")
+    fake_mod.transcribe_audio = lambda path: {"success": False, "error": "STT not configured"}
+    monkeypatch.setitem(sys.modules, "tools.transcription_tools", fake_mod)
+
+    body, content_type = _multipart_body(
+        files={"file": ("voice.webm", b"RIFFfakeaudio", "audio/webm")}
+    )
+    handler = _FakeHandler(body, content_type)
+    handle_transcribe(handler)
+
+    assert handler.status == 503
+    assert handler.payload()["error"] == "STT not configured"


### PR DESCRIPTION
## Summary

Adds a desktop microphone transcription fallback so the WebUI mic button still works in browsers that can record audio but do not support the Web Speech API.

## Root cause

The browser mic path depended on `SpeechRecognition` / `webkitSpeechRecognition`. On desktops and browsers where those APIs are unavailable, the UI could not fall back to recorded audio even when `getUserMedia` and `MediaRecorder` were available and the server already had speech-to-text support.

## What this changes

- keeps the mic button available when browser speech recognition is missing but audio recording is available
- adds a `MediaRecorder` fallback that captures microphone audio and posts it to a new `/api/transcribe` endpoint
- adds `handle_transcribe()` on the server side, reusing the existing transcription tool path and returning clear 4xx/5xx/503 errors when transcription is unavailable or invalid
- factors filename sanitization into a shared helper used by both upload and transcription handling
- updates the send-button flow so stopping a live recording can commit transcription before sending
- adds focused coverage for the new transcription endpoint and related regression checks

## Why this fits upstream

- broadens microphone support across desktop/browser combinations without changing the primary speech-recognition path
- reuses existing server transcription capability rather than introducing a separate STT stack
- adds direct coverage for success and failure cases on the new endpoint

## Verification

- [x] `source /home/jordan/.hermes/hermes-agent/venv/bin/activate && python -m pytest tests/test_voice_transcribe_endpoint.py tests/test_sprint19.py tests/test_sprint20.py -q`
  - result: `68 passed in 2.11s`

## Scope

- intentionally limited to the browser mic flow, upload/transcription handler, and focused regression tests
- does not change unrelated chat/session/sidebar behavior
