### PR TITLE
fix: restore mobile chat scrolling and drawer close

### DIFF
--- a/static/boot.js
+++ b/static/boot.js
@@ -257,7 +257,7 @@ $('btnAttach').onclick=()=>$('fileInput').click();
 })();
 window._micActive=window._micActive||false;
 $('fileInput').onchange=e=>{addFiles(Array.from(e.target.files));e.target.value='';};
-$('btnNewChat').onclick=async()=>{await newSession();await renderSessionList();$('msg').focus();};
+$('btnNewChat').onclick=async()=>{await newSession();await renderSessionList();closeMobileSidebar();$('msg').focus();};
 $('btnDownload').onclick=()=>{
   if(!S.session)return;
   const blob=new Blob([transcript()],{type:'text/markdown'});
@@ -374,7 +374,7 @@ document.addEventListener('keydown',async e=>{
   }
   if((e.metaKey||e.ctrlKey)&&e.key==='k'){
     e.preventDefault();
-    if(!S.busy){await newSession();await renderSessionList();$('msg').focus();}
+    if(!S.busy){await newSession();await renderSessionList();closeMobileSidebar();$('msg').focus();}
   }
   if(e.key==='Escape'){
     // Close settings overlay if open

--- a/static/style.css
+++ b/static/style.css
@@ -114,7 +114,7 @@
     --input-bg:rgba(255,255,255,.03);--hover-bg:rgba(255,255,255,.05);
   }
   body{background:var(--bg);color:var(--text);height:100vh;height:100dvh;overflow:hidden;display:flex;}
-  .layout{display:flex;width:100%;height:100vh;height:100dvh;}
+  .layout{display:flex;width:100%;height:100vh;height:100dvh;min-height:0;}
   .sidebar{width:300px;background:var(--sidebar);border-right:1px solid var(--border);display:flex;flex-direction:column;overflow:visible;flex-shrink:0;}
   .sidebar-header{padding:16px 18px 14px;border-bottom:1px solid var(--border);display:flex;align-items:center;gap:10px;}
   .logo{width:32px;height:32px;border-radius:9px;background:linear-gradient(145deg,#e8a030,var(--accent));display:flex;align-items:center;justify-content:center;font-weight:800;font-size:14px;color:#fff;flex-shrink:0;box-shadow:0 2px 8px rgba(233,69,96,.3);}
@@ -334,7 +334,7 @@
   .sm-btn{flex:1;padding:8px 0;border-radius:8px;font-size:11px;font-weight:500;background:var(--input-bg);border:1px solid var(--border);color:var(--muted);cursor:pointer;transition:all .15s;text-align:center;letter-spacing:.02em;}
   .sm-btn:hover{background:rgba(255,255,255,0.09);color:var(--text);border-color:rgba(255,255,255,.15);}
   .sm-btn:disabled{opacity:.45;cursor:not-allowed;}
-  .main{flex:1;display:flex;flex-direction:column;overflow:hidden;min-width:0;background:var(--main-bg);}
+  .main{flex:1;display:flex;flex-direction:column;overflow:hidden;min-width:0;min-height:0;background:var(--main-bg);}
   .topbar{padding:12px 20px;border-bottom:1px solid var(--border);background:var(--topbar-bg);backdrop-filter:blur(12px);display:flex;align-items:center;justify-content:space-between;flex-shrink:0;position:relative;z-index:10;}
   .topbar-title{font-size:15px;font-weight:600;letter-spacing:-.01em;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
   .topbar-meta{font-size:11px;color:var(--muted);margin-top:3px;opacity:.75;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
@@ -344,7 +344,7 @@
   .workspace-toggle-btn.active{color:var(--blue);border-color:rgba(124,185,255,.35);background:rgba(124,185,255,.1);}
   .workspace-toggle-btn:disabled{opacity:.38;cursor:not-allowed;}
   .chip.model{color:var(--blue);border-color:rgba(124,185,255,0.35);background:rgba(124,185,255,0.1);}
-  .messages{flex:1;overflow-y:auto;display:flex;flex-direction:column;min-height:0;position:relative;z-index:0;}
+  .messages{flex:1;overflow-y:auto;display:flex;flex-direction:column;min-height:0;position:relative;z-index:0;-webkit-overflow-scrolling:touch;touch-action:pan-y;overscroll-behavior-y:contain;}
   .messages-inner{margin:0 auto;width:100%;padding:20px 24px 32px;display:flex;flex-direction:column;}
   @media(min-width:1400px){.messages-inner{max-width:1100px;}}
   @media(min-width:1800px){.messages-inner{max-width:1200px;}}

--- a/tests/test_mobile_layout.py
+++ b/tests/test_mobile_layout.py
@@ -133,6 +133,21 @@ def test_toggle_mobile_files_js_defined():
         "toggleMobileFiles() must toggle mobile-open class on the right panel"
 
 
+def test_new_conversation_closes_mobile_sidebar():
+    """New conversation must close the mobile drawer so the chat pane is visible immediately."""
+    boot_js = (REPO / "static" / "boot.js").read_text(encoding="utf-8")
+    click_line = next((ln for ln in boot_js.splitlines() if "$('btnNewChat').onclick" in ln), "")
+    assert click_line, "btnNewChat onclick handler missing from static/boot.js"
+    assert "closeMobileSidebar" in click_line, \
+        "btnNewChat handler must closeMobileSidebar() after creating the new session"
+
+    shortcut_line = next((ln for ln in boot_js.splitlines() if "e.key==='k'" in ln or "e.key === 'k'" in ln), "")
+    assert shortcut_line, "Cmd/Ctrl+K new chat shortcut missing from static/boot.js"
+    shortcut_block = "\n".join(boot_js.splitlines()[boot_js.splitlines().index(shortcut_line):boot_js.splitlines().index(shortcut_line)+4])
+    assert "closeMobileSidebar" in shortcut_block, \
+        "Cmd/Ctrl+K new chat shortcut must closeMobileSidebar() after creating the new session"
+
+
 # ── Viewport and scroll safety ────────────────────────────────────────────────
 
 def test_body_overflow_hidden():
@@ -141,6 +156,32 @@ def test_body_overflow_hidden():
         "body rule missing from style.css"
     assert re.search(r'body\{[^}]*overflow:hidden', CSS), \
         "body must have overflow:hidden to prevent double scrollbars"
+
+
+def test_flex_parents_allow_message_scroller_to_shrink():
+    """The top-level flex containers must opt into min-height:0 so .messages can scroll on mobile.
+
+    Mobile Safari/Chrome can trap scroll when a flex child with overflow:auto sits inside
+    parents whose min-height remains auto. Both .layout and .main need min-height:0.
+    """
+    assert re.search(r'\.layout\{[^}]*min-height:0', CSS), \
+        ".layout must set min-height:0 so the chat column can shrink and scroll"
+    assert re.search(r'\.main\{[^}]*min-height:0', CSS), \
+        ".main must set min-height:0 so .messages remains scrollable while busy"
+
+
+def test_messages_touch_scrolling_hints_present():
+    """The messages scroller must advertise touch-friendly scrolling behavior.
+
+    On mobile browsers, momentum scrolling and explicit pan-y/overscroll behavior help
+    prevent the chat area from feeling locked while the app body itself stays overflow:hidden.
+    """
+    assert re.search(r'\.messages\{[^}]*-webkit-overflow-scrolling:\s*touch', CSS), \
+        ".messages must enable -webkit-overflow-scrolling:touch for mobile momentum scroll"
+    assert re.search(r'\.messages\{[^}]*touch-action:\s*pan-y', CSS), \
+        ".messages must set touch-action:pan-y so vertical swipe gestures scroll the transcript"
+    assert re.search(r'\.messages\{[^}]*overscroll-behavior-y:\s*contain', CSS), \
+        ".messages must contain vertical overscroll so the transcript keeps the gesture"
 
 
 def test_100dvh_viewport_height():


### PR DESCRIPTION
## Summary

Restores mobile chat scrolling and ensures starting a new conversation closes the mobile drawer so the transcript becomes visible immediately.

## Root cause

The mobile layout was missing a few flex/scroll hints needed for the chat transcript to remain scrollable inside the constrained mobile viewport. Separately, creating a new conversation from the sidebar closed neither the drawer button path nor the keyboard shortcut path consistently, leaving the chat view obscured after the action.

## What this changes

- adds the missing mobile flex/scroll CSS needed for the transcript column to shrink and scroll correctly on narrow viewports
- adds touch-scrolling hints to the message scroller for better mobile browser behavior
- closes the mobile sidebar after starting a new conversation from both the new-chat button and the Cmd/Ctrl+K shortcut path
- adds regression coverage for the mobile layout rules and the new-conversation drawer-close behavior

## Why this fits upstream

- fixes a clear mobile usability regression
- keeps the scope limited to mobile layout behavior and focused regression tests
- improves consistency between pointer and keyboard new-chat flows

## Verification

- [x] `source /home/jordan/.hermes/hermes-agent/venv/bin/activate && python -m pytest tests/test_mobile_layout.py -q`
  - result: `24 passed in 1.86s`

## Scope

- intentionally limited to `static/style.css`, `static/boot.js`, and `tests/test_mobile_layout.py`
- does not change desktop layout or unrelated session behavior
