### PR TITLE
[security] fix(profiles): block path traversal in profile switch and delete flows

### DIFF
--- a/api/profiles.py
+++ b/api/profiles.py
@@ -176,7 +176,7 @@ def switch_profile(name: str) -> dict:
     if name == 'default':
         home = _DEFAULT_HERMES_HOME
     else:
-        home = _DEFAULT_HERMES_HOME / 'profiles' / name
+        home = _resolve_named_profile_home(name)
         if not home.is_dir():
             raise ValueError(f"Profile '{name}' does not exist.")
 
@@ -265,6 +265,24 @@ def _validate_profile_name(name: str):
             f"Invalid profile name {name!r}. "
             "Must match [a-z0-9][a-z0-9_-]{0,63}"
         )
+
+
+def _profiles_root() -> Path:
+    """Return the canonical root that contains named profiles."""
+    return (_DEFAULT_HERMES_HOME / 'profiles').resolve()
+
+
+def _resolve_named_profile_home(name: str) -> Path:
+    """Resolve a named profile to a directory under the profiles root.
+
+    Validates *name* as a logical profile identifier first, then resolves the
+    final filesystem path and enforces containment under ~/.hermes/profiles.
+    """
+    _validate_profile_name(name)
+    profiles_root = _profiles_root()
+    candidate = (profiles_root / name).resolve()
+    candidate.relative_to(profiles_root)
+    return candidate
 
 
 def _create_profile_fallback(name: str, clone_from: str = None,
@@ -385,6 +403,7 @@ def delete_profile_api(name: str) -> dict:
     """Delete a profile. Switches to default first if it's the active one."""
     if name == 'default':
         raise ValueError("Cannot delete the default profile.")
+    _validate_profile_name(name)
 
     # If deleting the active profile, switch to default first
     if _active_profile == name:
@@ -402,7 +421,7 @@ def delete_profile_api(name: str) -> dict:
     except ImportError:
         # Manual fallback: just remove the directory
         import shutil
-        profile_dir = _DEFAULT_HERMES_HOME / 'profiles' / name
+        profile_dir = _resolve_named_profile_home(name)
         if profile_dir.is_dir():
             shutil.rmtree(str(profile_dir))
         else:

--- a/api/routes.py
+++ b/api/routes.py
@@ -761,8 +761,10 @@ def handle_post(handler, parsed) -> bool:
         if not name:
             return bad(handler, "name is required")
         try:
-            from api.profiles import switch_profile
+            from api.profiles import switch_profile, _validate_profile_name
 
+            if name != 'default':
+                _validate_profile_name(name)
             result = switch_profile(name)
             return j(handler, result)
         except (ValueError, FileNotFoundError) as e:
@@ -809,8 +811,9 @@ def handle_post(handler, parsed) -> bool:
         if not name:
             return bad(handler, "name is required")
         try:
-            from api.profiles import delete_profile_api
+            from api.profiles import delete_profile_api, _validate_profile_name
 
+            _validate_profile_name(name)
             result = delete_profile_api(name)
             return j(handler, result)
         except (ValueError, FileNotFoundError) as e:

--- a/tests/test_profile_path_security.py
+++ b/tests/test_profile_path_security.py
@@ -1,0 +1,63 @@
+import importlib
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent.resolve()
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+def _reload_profiles_module(base_home: Path):
+    os.environ["HERMES_BASE_HOME"] = str(base_home)
+    os.environ["HERMES_HOME"] = str(base_home)
+
+    for name in ["api.config", "api.profiles"]:
+        if name in sys.modules:
+            del sys.modules[name]
+
+    profiles = importlib.import_module("api.profiles")
+    return profiles
+
+
+def test_switch_profile_rejects_path_traversal():
+    with tempfile.TemporaryDirectory() as td:
+        temp_root = Path(td)
+        base = temp_root / ".hermes"
+        (base / "profiles").mkdir(parents=True)
+        (temp_root / "escape-target").mkdir()
+
+        profiles = _reload_profiles_module(base)
+
+        with pytest.raises(ValueError):
+            profiles.switch_profile("../../escape-target")
+
+
+def test_delete_profile_rejects_path_traversal():
+    with tempfile.TemporaryDirectory() as td:
+        temp_root = Path(td)
+        base = temp_root / ".hermes"
+        (base / "profiles").mkdir(parents=True)
+        (temp_root / "escape-target").mkdir()
+
+        profiles = _reload_profiles_module(base)
+
+        with pytest.raises(ValueError):
+            profiles.delete_profile_api("../../escape-target")
+
+
+def test_switch_profile_allows_valid_profile_name():
+    with tempfile.TemporaryDirectory() as td:
+        temp_root = Path(td)
+        base = temp_root / ".hermes"
+        profile_dir = base / "profiles" / "demo"
+        profile_dir.mkdir(parents=True)
+
+        profiles = _reload_profiles_module(base)
+        result = profiles.switch_profile("demo")
+
+        assert result["active"] == "demo"
+        assert Path(os.environ["HERMES_HOME"]).resolve() == profile_dir.resolve()


### PR DESCRIPTION
## Summary

This PR hardens Web UI profile management by preventing profile names from escaping the intended `~/.hermes/profiles` root.

Before this change, profile switch and delete flows accepted a user-controlled profile name and joined it directly into a filesystem path. That allowed traversal-style names such as `../../escape-target` to resolve outside the profiles directory.

This patch validates profile identifiers consistently and enforces resolved-path containment under the profiles root for profile switch and delete operations.

## Security impact

Issue:
Profile path traversal in profile switch and delete flows

Impact:
Escape from the intended profiles root; repoint or operate on state outside `~/.hermes/profiles`

CVSS v3.1:
8.8 High

Vector:
`CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H`

## Root cause

- Profile names supplied by the client were treated like safe filesystem path components.
- The code joined `name` into `_DEFAULT_HERMES_HOME / 'profiles' / name` without enforcing final resolved containment under the profiles root.

## Fix

- Reuse strict profile-name validation for switch/delete flows.
- Resolve named profile paths before use.
- Enforce containment under `~/.hermes/profiles` before switching or deleting.
- Keep route-level validation and helper-level validation aligned for defense in depth.

## Files changed

- `api/profiles.py`
- `api/routes.py`
- `tests/test_profile_path_security.py`

## Test plan

Passed:
- `source /Users/lennon/.hermes/hermes-agent/venv/bin/activate && cd /Users/lennon/code/hermes-webui && python -m pytest tests/test_profile_path_security.py -q`

Added regression coverage for:
- traversal rejected in `switch_profile()`
- traversal rejected in `delete_profile_api()`
- valid profile names still switch correctly

Note:
- Running the full suite in this environment surfaced unrelated pre-existing failures in existing redaction and `/tmp`/`/private/tmp` workspace tests. Those failures are not caused by this patch.

## Scope

This is a narrow fix limited to profile-management path validation and containment. It does not change chat, streaming, or unrelated UI behavior.
