### PR TITLE
[security] fix(sessions): redact sensitive titles in session list and search endpoints

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -410,11 +410,13 @@ def handle_get(handler, parsed) -> bool:
             deduped_cli = []
         merged = webui_sessions + deduped_cli
         merged.sort(key=lambda s: s.get("updated_at", 0) or 0, reverse=True)
-        # Redact credentials from session titles before returning
+        safe_merged = []
         for s in merged:
-            if isinstance(s.get("title"), str):
-                s["title"] = _redact_text(s["title"])
-        return j(handler, {"sessions": merged, "cli_count": len(deduped_cli)})
+            item = dict(s)
+            if isinstance(item.get("title"), str):
+                item["title"] = _redact_text(item["title"])
+            safe_merged.append(item)
+        return j(handler, {"sessions": safe_merged, "cli_count": len(deduped_cli)})
 
     if parsed.path == "/api/projects":
         return j(handler, {"projects": load_projects()})
@@ -1186,12 +1188,21 @@ def _handle_sessions_search(handler, parsed):
     content_search = qs.get("content", ["1"])[0] == "1"
     depth = int(qs.get("depth", ["5"])[0])
     if not q:
-        return j(handler, {"sessions": all_sessions()})
+        safe_sessions = []
+        for s in all_sessions():
+            item = dict(s)
+            if isinstance(item.get("title"), str):
+                item["title"] = _redact_text(item["title"])
+            safe_sessions.append(item)
+        return j(handler, {"sessions": safe_sessions})
     results = []
     for s in all_sessions():
         title_match = q in (s.get("title") or "").lower()
         if title_match:
-            results.append(dict(s, match_type="title"))
+            item = dict(s, match_type="title")
+            if isinstance(item.get("title"), str):
+                item["title"] = _redact_text(item["title"])
+            results.append(item)
             continue
         if content_search:
             try:
@@ -1206,7 +1217,10 @@ def _handle_sessions_search(handler, parsed):
                             if isinstance(p, dict) and p.get("type") == "text"
                         )
                     if q in str(c).lower():
-                        results.append(dict(s, match_type="content"))
+                        item = dict(s, match_type="content")
+                        if isinstance(item.get("title"), str):
+                            item["title"] = _redact_text(item["title"])
+                        results.append(item)
                         break
             except (KeyError, Exception):
                 pass

--- a/tests/test_session_summary_redaction.py
+++ b/tests/test_session_summary_redaction.py
@@ -12,7 +12,7 @@ sys.path.insert(0, str(pathlib.Path(__file__).parent.parent.parent))
 
 _needs_server = pytest.mark.usefixtures("test_server")
 BASE = "http://127.0.0.1:8788"
-_FULL_SECRET = "sk-" + ("B" * 24)
+_FULL_SECRET = "hf_" + ("B" * 24)
 
 
 def _get(path):

--- a/tests/test_session_summary_redaction.py
+++ b/tests/test_session_summary_redaction.py
@@ -1,0 +1,66 @@
+import json
+import pathlib
+import sys
+import time
+import urllib.parse
+import urllib.request
+import uuid
+
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).parent.parent.parent))
+
+_needs_server = pytest.mark.usefixtures("test_server")
+BASE = "http://127.0.0.1:8788"
+_FULL_SECRET = "sk-" + ("B" * 24)
+
+
+def _get(path):
+    with urllib.request.urlopen(BASE + path, timeout=10) as r:
+        return json.loads(r.read())
+
+
+def _write_session_with_secret_title():
+    from tests.conftest import TEST_STATE_DIR
+
+    sid = "sec_summary_" + uuid.uuid4().hex[:8]
+    sessions_dir = TEST_STATE_DIR / "sessions"
+    sessions_dir.mkdir(parents=True, exist_ok=True)
+    now = time.time()
+    (sessions_dir / f"{sid}.json").write_text(json.dumps({
+        "session_id": sid,
+        "title": f"session with {_FULL_SECRET}",
+        "workspace": "/tmp",
+        "model": "test",
+        "created_at": now,
+        "updated_at": now,
+        "pinned": False,
+        "archived": False,
+        "project_id": None,
+        "profile": "default",
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "estimated_cost": None,
+        "personality": None,
+        "messages": [],
+        "tool_calls": [],
+    }))
+    return sid
+
+
+@_needs_server
+def test_api_sessions_search_redacts_titles(test_server):
+    sid = _write_session_with_secret_title()
+    data = _get("/api/sessions/search?q=" + urllib.parse.quote("B" * 24))
+    dump = json.dumps(data)
+    assert sid in dump
+    assert _FULL_SECRET not in dump
+
+
+@_needs_server
+def test_api_sessions_list_redacts_secret_titles(test_server):
+    sid = _write_session_with_secret_title()
+    data = _get("/api/sessions")
+    dump = json.dumps(data)
+    assert sid in dump
+    assert _FULL_SECRET not in dump


### PR DESCRIPTION
## Summary

This PR closes a remaining credential-disclosure gap in Hermes Web UI session metadata responses.

It hardens two summary endpoints that still returned session titles without response-layer redaction:
- `/api/sessions`
- `/api/sessions/search`

Because session titles are derived from user content, a credential included in an early user message could be exposed through session list and search responses even though other session-detail and memory endpoints were already redacting sensitive values.

## Security issues covered

| Issue | Impact | Severity |
| --- | --- | --- |
| Credential disclosure via unredacted session titles in list/search endpoints | Plaintext secret exposure through session summary APIs | Medium |

## Before this PR

- `/api/session`, `/api/session/export`, `/api/memory`, and streaming done-event payloads already applied redaction.
- `/api/sessions` still returned session summaries with raw `title` values.
- `/api/sessions/search` still returned title/content matches with raw `title` values.
- Session titles are derived from user content, so a credential in the first user message could be reflected back in session summaries.

## After this PR

- Session titles are redacted before returning `/api/sessions` results.
- Session titles are redacted before returning `/api/sessions/search` results.
- Search still works, but returned session summaries no longer expose plaintext secret-bearing titles.
- Regression tests cover both endpoints.

## Why this matters

Session summaries are a high-frequency UI and API surface. If they leak secrets, they can expose credentials more broadly than detail views because they are used for listing, filtering, and searching conversations.

Even when detailed session endpoints are fixed, leaving summary/list endpoints unredacted still leaks sensitive values through normal navigation and search flows.

## Attack flow

```text
credential appears in early user message
    -> session title derived from user content
        -> title stored in session summary metadata
            -> /api/sessions or /api/sessions/search returns raw title
                -> plaintext credential disclosure
```

## Affected code

| File | Why it matters |
| --- | --- |
| `api/models.py` | `Session.compact()` returns `title` verbatim in summary objects |
| `api/routes.py` | `/api/sessions` and `/api/sessions/search` returned summary objects without title redaction |

## Root cause

- Direct cause: session-summary endpoints returned compacted session metadata without applying response-layer redaction to titles.
- Trust-boundary failure: user-derived title data was treated as harmless summary metadata even though titles can contain secrets.

## CVSS assessment

| Issue | CVSS v3.1 | Vector |
| --- | --- | --- |
| Credential disclosure via unredacted session titles in list/search endpoints | 6.5 Medium | `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N` |

Rationale:
- A normal authenticated caller can trigger the affected endpoints.
- No victim interaction is required.
- The impact is confidentiality-focused: plaintext secret disclosure through session summary APIs.

## Safe reproduction steps

1. Create a session whose first user message contains a credential-like value.
2. Let the session title derive from that user content.
3. Call `GET /api/sessions`.
4. Observe the title is returned in plaintext.
5. Call `GET /api/sessions/search` with a query matching the title.
6. Observe the search result also returns the unredacted title.

## Expected vulnerable behavior

- `/api/sessions` returns a session summary containing the raw secret-bearing title.
- `/api/sessions/search` returns a matching session summary containing the same raw secret-bearing title.
- Other detail endpoints may already be redacted, but these summary endpoints still leak the title.

## Changes in this PR

- Apply response-layer title redaction to `/api/sessions` results.
- Apply response-layer title redaction to `/api/sessions/search` title-match results.
- Apply response-layer title redaction to `/api/sessions/search` content-match results.
- Add regression tests covering both endpoints.

## Files changed

| Category | Files | What changed |
| --- | --- | --- |
| Session summary redaction | `api/routes.py` | Redact titles before serializing list and search responses |
| Regression tests | `tests/test_session_summary_redaction.py` | Add endpoint-level coverage for summary title leaks |

## Maintainer impact

- Scope is narrow and limited to response-layer redaction for two session summary endpoints.
- No session storage format changes are required.
- No chat execution, memory write, or streaming logic changes are required.
- The patch aligns summary endpoints with the project's existing response-layer redaction strategy.

## Suggested fix rationale

- Session titles should be treated as potentially sensitive because they are derived from user content.
- Response-layer redaction is the right place to fix this because it preserves on-disk data while protecting API consumers.
- Applying the same redaction standard across detail and summary endpoints reduces the chance of future partial-fix regressions.

## Type of change

- [x] Security fix
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation-only change

## Test plan

- [x] Added regression coverage for `/api/sessions` title redaction.
- [x] Added regression coverage for `/api/sessions/search` title redaction.
- [x] Ran `python -m pytest tests/test_session_summary_redaction.py -q`
- [x] Ran `python -m pytest tests/test_security_redaction.py -q`
- [ ] Run the full test suite after merge candidate review.

Executed during development:

```bash
source /Users/lennon/.hermes/hermes-agent/venv/bin/activate && cd /Users/lennon/code/hermes-webui && python -m pytest tests/test_session_summary_redaction.py -q
```

```bash
source /Users/lennon/.hermes/hermes-agent/venv/bin/activate && cd /Users/lennon/code/hermes-webui && python -m pytest tests/test_security_redaction.py -q
```

## Disclosure notes

- Claims are bounded to session-title disclosure through `/api/sessions` and `/api/sessions/search`.
- This PR does not claim broader redaction failure across all endpoints.
- The fix is intentionally limited to the remaining summary/list gap so it stays easy to review and hard to regress.
