### PR TITLE
fix: expand openai-codex model catalog to match DEFAULT_CODEX_MODELS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Hermes Web UI -- Changelog
 
+## [v0.50.28] fix: expand openai-codex model catalog to match DEFAULT_CODEX_MODELS
+
+`_PROVIDER_MODELS["openai-codex"]` only listed `codex-mini-latest`, so profiles using the `openai-codex` provider (e.g. a CodePath profile with `default: gpt-5.4`) showed only one entry in the model dropdown. Updated to mirror the agent's authoritative `DEFAULT_CODEX_MODELS` list: `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.3-codex`, `gpt-5.2-codex`, `gpt-5.1-codex-max`, `gpt-5.1-codex-mini`, `codex-mini-latest`. Added 2 regression tests.
+
+- 1029 tests total (up from 1027)
+
 ## [v0.50.27] feat: relative time labels in session sidebar (#394)
 
 - `static/sessions.js`: new `_sessionCalendarBoundaries()` (DST-safe via `new Date(y,m,d)` construction), `_localDayOrdinal()`, `_formatSessionDate()` (includes year for dates from prior years); `_formatRelativeSessionTime()` now uses calendar midnight boundaries consistent with `_sessionTimeBucketLabel()` — no more label/bucket mismatch; all relative time strings call `t()` for localization; meta row only appended when non-empty (removes redundant group-header fallback); dead `ONE_DAY` constant removed

--- a/api/config.py
+++ b/api/config.py
@@ -466,7 +466,13 @@ _PROVIDER_MODELS = {
         {"id": "o4-mini", "label": "o4-mini"},
     ],
     "openai-codex": [
-        {"id": "codex-mini-latest", "label": "Codex Mini"},
+        {"id": "gpt-5.4", "label": "GPT-5.4"},
+        {"id": "gpt-5.4-mini", "label": "GPT-5.4 Mini"},
+        {"id": "gpt-5.3-codex", "label": "GPT-5.3 Codex"},
+        {"id": "gpt-5.2-codex", "label": "GPT-5.2 Codex"},
+        {"id": "gpt-5.1-codex-max", "label": "GPT-5.1 Codex Max"},
+        {"id": "gpt-5.1-codex-mini", "label": "GPT-5.1 Codex Mini"},
+        {"id": "codex-mini-latest", "label": "Codex Mini (latest)"},
     ],
     "google": [
         {"id": "gemini-2.5-pro", "label": "Gemini 2.5 Pro"},

--- a/static/index.html
+++ b/static/index.html
@@ -535,7 +535,7 @@
                 <div class="settings-section-title">System</div>
                 <div class="settings-section-meta">Instance version and access controls.</div>
               </div>
-              <span class="settings-version-badge">v0.50.27</span>
+              <span class="settings-version-badge">v0.50.28</span>
             </div>
             <div class="settings-field" style="border-top:1px solid var(--border);padding-top:12px;margin-top:8px">
               <label for="settingsPassword" data-i18n="settings_label_password">Access Password</label>

--- a/tests/test_opencode_providers.py
+++ b/tests/test_opencode_providers.py
@@ -68,3 +68,19 @@ def test_opencode_zen_detected_via_env_key(monkeypatch):
 
 def test_opencode_go_detected_via_env_key(monkeypatch):
     _models_with_env_key(monkeypatch, "OPENCODE_GO_API_KEY", "OpenCode Go")
+
+
+def test_openai_codex_model_catalog_includes_gpt54():
+    """openai-codex catalog must include gpt-5.4 and the standard Codex lineup."""
+    assert "openai-codex" in config._PROVIDER_MODELS
+    ids = [m["id"] for m in config._PROVIDER_MODELS["openai-codex"]]
+    assert "gpt-5.4" in ids, f"gpt-5.4 missing from openai-codex catalog: {ids}"
+    assert "gpt-5.4-mini" in ids, f"gpt-5.4-mini missing from openai-codex catalog: {ids}"
+    assert "gpt-5.3-codex" in ids, f"gpt-5.3-codex missing from openai-codex catalog: {ids}"
+    assert "gpt-5.2-codex" in ids, f"gpt-5.2-codex missing from openai-codex catalog: {ids}"
+
+
+def test_openai_codex_display_name():
+    """openai-codex must have a human-readable display name."""
+    assert "openai-codex" in config._PROVIDER_DISPLAY
+    assert config._PROVIDER_DISPLAY["openai-codex"] == "OpenAI Codex"


### PR DESCRIPTION
## fix: expand openai-codex model catalog to match DEFAULT_CODEX_MODELS

**Root cause:** `_PROVIDER_MODELS["openai-codex"]` only contained `codex-mini-latest`. Profiles configured with `provider: openai-codex` and any other model (e.g. `default: gpt-5.4` in a CodePath profile) showed only one entry in the WebUI model dropdown — the saved default wouldn't appear in the list.

**Fix:** Expanded the catalog to match `DEFAULT_CODEX_MODELS` in the agent's `hermes_cli/codex_models.py` (the authoritative source):

| Model ID | Label |
|----------|-------|
| `gpt-5.4` | GPT-5.4 |
| `gpt-5.4-mini` | GPT-5.4 Mini |
| `gpt-5.3-codex` | GPT-5.3 Codex |
| `gpt-5.2-codex` | GPT-5.2 Codex |
| `gpt-5.1-codex-max` | GPT-5.1 Codex Max |
| `gpt-5.1-codex-mini` | GPT-5.1 Codex Mini |
| `codex-mini-latest` | Codex Mini (latest) |

**Tests:** 2 new regression tests in `test_opencode_providers.py`.

**Suite:** 1029 passed, 0 failed.