### PR TITLE
[security] fix(sessions): validate session_id before deleting session files (#409)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Hermes Web UI -- Changelog
 
+## [v0.50.32] fix(sessions): validate session_id before deleting session files [SECURITY] (#409)
+
+`/api/session/delete` accepted arbitrary `session_id` values from the request body and built the delete path directly as `SESSION_DIR / f"{sid}.json"`. Because pathlib discards the prefix when `sid` is an absolute path, an attacker could supply `/tmp/victim` and cause the server to unlink `victim.json` outside the session store. Traversal-style values (`../../etc/target`) were also accepted. CVSS 8.1 High (AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:H/A:H).
+
+- `api/routes.py`: validate `session_id` against `[0-9a-z_]+` allowlist (covers `uuid4().hex[:12]` WebUI IDs and `YYYYMMDD_HHMMSS_hex` CLI IDs) before path construction; resolve candidate path and enforce `path.relative_to(SESSION_DIR)` containment before unlinking; only invalidate session index on successful deletion path, not on rejected requests
+- `tests/test_sprint3.py`: 2 new regression tests — absolute-path payload rejected and file preserved, traversal payload rejected and file preserved
+- Original PR by @Hinotoi-agent (cherry-picked; branch was 4 commits behind master)
+- 1041 tests total (up from 1039)
+
 ## [v0.50.31] fix: delegate all live model fetching to agent's provider_model_ids()
 
 `_handle_live_models()` in `api/routes.py` previously maintained its own per-provider fetch logic and returned `not_supported` for Anthropic, Google, and Gemini. Now it delegates entirely to the agent's `hermes_cli.models.provider_model_ids()` — the single authoritative resolver — and `_fetchLiveModels()` in `ui.js` no longer skips any provider.

--- a/api/routes.py
+++ b/api/routes.py
@@ -729,11 +729,6 @@ def handle_post(handler, parsed) -> bool:
         # Delete from WebUI session store
         with LOCK:
             SESSIONS.pop(sid, None)
-        # Invalidate session index before file deletion so deleted sessions do not reappear
-        try:
-            SESSION_INDEX_FILE.unlink(missing_ok=True)
-        except Exception:
-            logger.debug("Failed to unlink session index")
         try:
             p = (SESSION_DIR / f"{sid}.json").resolve()
             p.relative_to(SESSION_DIR.resolve())

--- a/api/routes.py
+++ b/api/routes.py
@@ -724,10 +724,21 @@ def handle_post(handler, parsed) -> bool:
         sid = body.get("session_id", "")
         if not sid:
             return bad(handler, "session_id is required")
+        if not all(c in '0123456789abcdefghijklmnopqrstuvwxyz_' for c in sid):
+            return bad(handler, "Invalid session_id", 400)
         # Delete from WebUI session store
         with LOCK:
             SESSIONS.pop(sid, None)
-        p = SESSION_DIR / f"{sid}.json"
+        # Invalidate session index before file deletion so deleted sessions do not reappear
+        try:
+            SESSION_INDEX_FILE.unlink(missing_ok=True)
+        except Exception:
+            logger.debug("Failed to unlink session index")
+        try:
+            p = (SESSION_DIR / f"{sid}.json").resolve()
+            p.relative_to(SESSION_DIR.resolve())
+        except Exception:
+            return bad(handler, "Invalid session_id", 400)
         try:
             p.unlink(missing_ok=True)
         except Exception:

--- a/static/index.html
+++ b/static/index.html
@@ -535,7 +535,7 @@
                 <div class="settings-section-title">System</div>
                 <div class="settings-section-meta">Instance version and access controls.</div>
               </div>
-              <span class="settings-version-badge">v0.50.31</span>
+              <span class="settings-version-badge">v0.50.32</span>
             </div>
             <div class="settings-field" style="border-top:1px solid var(--border);padding-top:12px;margin-top:8px">
               <label for="settingsPassword" data-i18n="settings_label_password">Access Password</label>

--- a/tests/test_sprint3.py
+++ b/tests/test_sprint3.py
@@ -114,6 +114,24 @@ def test_session_delete_requires_session_id():
     result, status = post("/api/session/delete", {})
     assert status == 400
 
+
+def test_session_delete_rejects_absolute_path_payload(tmp_path):
+    victim = tmp_path / "victim.json"
+    victim.write_text("TOPSECRET", encoding="utf-8")
+    result, status = post("/api/session/delete", {"session_id": str(victim.with_suffix(""))})
+    assert status == 400
+    assert victim.exists(), "absolute-path payload must not delete arbitrary files"
+
+
+def test_session_delete_rejects_traversal_payload(tmp_path):
+    victim = tmp_path / "outside.json"
+    victim.write_text("TOPSECRET", encoding="utf-8")
+    traversal = f"../../../../{victim.with_suffix('').as_posix().lstrip('/')}"
+    result, status = post("/api/session/delete", {"session_id": traversal})
+    assert status == 400
+    assert victim.exists(), "traversal payload must not delete arbitrary files"
+
+
 def test_chat_start_requires_session_id():
     result, status = post("/api/chat/start", {"message": "hello"})
     assert status == 400


### PR DESCRIPTION
## v0.50.32 — session_id path traversal fix [SECURITY]

Review of PR #409 by @Hinotoi-agent.

**The vulnerability is real.** `/api/session/delete` built the delete target as `SESSION_DIR / f"{sid}.json"` from untrusted input. Pathlib discards the prefix when `sid` is an absolute path, so `{"session_id": "/tmp/victim"}` caused `unlink()` to run on `/tmp/victim.json` outside the session store. Traversal-style values also worked. CVSS 8.1 High.

**What changed vs. the original PR:**
- Branch was 4 commits behind master (cherry-picked cleanly onto master)
- Removed a redundant `SESSION_INDEX_FILE.unlink()` that the PR added before the path validation check — it ran even on rejected requests and nuked the index cache unnecessarily. Moved to only fire on the success path (where it already existed)
- Otherwise the fix is taken as-is: allowlist validation + resolved-path containment

**Fix in one sentence:** `session_id` is now validated against `[0-9a-z_]+` (covers all real ID formats) and the resolved path must pass `path.relative_to(SESSION_DIR)` containment before `unlink()` runs.

**Tests:** 3 security regression tests pass, full suite 1041/0.

Closes #409.