### PR TITLE
fix(ui): add Prism syntax highlighting with light + dark theme token colors

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -77,6 +77,42 @@
   :root[data-theme="light"] .profile-opt:hover{background:rgba(0,0,0,.05);}
   :root[data-theme="light"] .profile-opt.active{background:rgba(45,111,163,.06);}
   :root[data-theme="light"] .profile-chip{color:#7a5a90!important;}
+  /* ── Light theme: Prism syntax token overrides (prism-tomorrow is dark-only) ── */
+  :root[data-theme="light"] .token.comment,
+  :root[data-theme="light"] .token.prolog,
+  :root[data-theme="light"] .token.doctype,
+  :root[data-theme="light"] .token.cdata{color:#7a7060;font-style:italic;}
+  :root[data-theme="light"] .token.punctuation{color:#5a4e44;}
+  :root[data-theme="light"] .token.namespace{opacity:.8;}
+  :root[data-theme="light"] .token.property,
+  :root[data-theme="light"] .token.tag,
+  :root[data-theme="light"] .token.boolean,
+  :root[data-theme="light"] .token.number,
+  :root[data-theme="light"] .token.constant,
+  :root[data-theme="light"] .token.symbol,
+  :root[data-theme="light"] .token.deleted{color:#a0290a;}
+  :root[data-theme="light"] .token.selector,
+  :root[data-theme="light"] .token.attr-name,
+  :root[data-theme="light"] .token.string,
+  :root[data-theme="light"] .token.char,
+  :root[data-theme="light"] .token.builtin,
+  :root[data-theme="light"] .token.inserted{color:#276b30;}
+  :root[data-theme="light"] .token.operator,
+  :root[data-theme="light"] .token.entity,
+  :root[data-theme="light"] .token.url,
+  :root[data-theme="light"] .language-css .token.string,
+  :root[data-theme="light"] .style .token.string{color:#5a3e8a;}
+  :root[data-theme="light"] .token.atrule,
+  :root[data-theme="light"] .token.attr-value,
+  :root[data-theme="light"] .token.keyword{color:#2d6fa3;}
+  :root[data-theme="light"] .token.function,
+  :root[data-theme="light"] .token.class-name{color:#7a3a00;}
+  :root[data-theme="light"] .token.regex,
+  :root[data-theme="light"] .token.important,
+  :root[data-theme="light"] .token.variable{color:#8a4a00;}
+  :root[data-theme="light"] .token.important,
+  :root[data-theme="light"] .token.bold{font-weight:bold;}
+  :root[data-theme="light"] .token.italic{font-style:italic;}
   :root[data-theme="light"] .nav-tab:hover::after{background:var(--surface);border-color:rgba(45,111,163,.25);color:#2d6fa3;}
   :root[data-theme="light"] .cron-status.disabled{background:rgba(0,0,0,.05);}
   :root[data-theme="light"] .cron-btn{background:rgba(0,0,0,.04);}
@@ -382,6 +418,8 @@
   .msg-body code{font-family:"SF Mono","Fira Code",ui-monospace,monospace;font-size:12.5px;background:var(--code-inline-bg);padding:1px 5px;border-radius:4px;color:var(--code-text);}
   .msg-body pre{background:var(--code-bg);border:1px solid var(--border);border-radius:10px;padding:14px 16px;overflow-x:auto;margin:10px 0;}
   .msg-body pre code{background:none;padding:0;border-radius:0;color:var(--pre-text);font-size:13px;line-height:1.6;}
+  /* Keep original theme background — prevent prism-tomorrow from overriding --code-bg */
+  .msg-body pre[class*="language-"],.msg-body pre code[class*="language-"]{background:var(--code-bg) !important;}
   .pre-header{font-size:10px;font-weight:600;text-transform:uppercase;letter-spacing:.06em;color:var(--muted);padding:8px 16px 8px;background:var(--input-bg);border-radius:10px 10px 0 0;border:1px solid var(--border);border-bottom:1px solid var(--border);display:flex;align-items:center;gap:6px;}
   .pre-header::before{content:'';width:8px;height:8px;border-radius:50%;background:var(--muted);opacity:.4;}
   .pre-header+pre{border-radius:0 0 10px 10px;border-top:none;margin-top:0;}
@@ -536,6 +574,8 @@
   .preview-md code{font-family:"SF Mono",ui-monospace,monospace;font-size:11.5px;background:var(--code-inline-bg);padding:1px 5px;border-radius:4px;color:var(--code-text);}
   .preview-md pre{background:var(--code-bg);border:1px solid var(--border);border-radius:8px;padding:10px 12px;overflow-x:auto;margin:8px 0;}
   .preview-md pre code{background:none;padding:0;color:var(--pre-text);font-size:11.5px;line-height:1.55;}
+  /* Keep original theme background — prevent prism-tomorrow from overriding --code-bg */
+  .preview-md pre[class*="language-"],.preview-md pre code[class*="language-"]{background:var(--code-bg) !important;}
   .preview-md blockquote{border-left:3px solid var(--blue);padding-left:12px;color:var(--muted);font-style:italic;margin:8px 0;}
   .preview-md strong{color:var(--strong);font-weight:600;}.preview-md em{color:var(--em);}
   .preview-md a{color:var(--blue);text-decoration:underline;}

--- a/static/ui.js
+++ b/static/ui.js
@@ -411,7 +411,12 @@ function renderMd(raw){
     const id='mermaid-'+Math.random().toString(36).slice(2,10);
     return `<div class="mermaid-block" data-mermaid-id="${id}">${esc(code.trim())}</div>`;
   });
-  s=s.replace(/```([\w+-]*)\n?([\s\S]*?)```/g,(_,lang,code)=>{const h=lang?`<div class="pre-header">${esc(lang)}</div>`:'';return `${h}<pre><code>${esc(code.replace(/\n$/,''))}</code></pre>`;});
+  s=s.replace(/```([\w+-]*)\n?([\s\S]*?)```/g,(_,lang,code)=>{
+    const normalizedLang=(lang||'').trim().toLowerCase();
+    const h=normalizedLang?`<div class="pre-header">${esc(normalizedLang)}</div>`:'';
+    const langAttr=normalizedLang?` class="language-${esc(normalizedLang)}"`:'';
+    return `${h}<pre><code${langAttr}>${esc(code.replace(/\n$/,''))}</code></pre>`;
+  });
   s=s.replace(/`([^`\n]+)`/g,(_,c)=>`<code>${esc(c)}</code>`);
   // inlineMd: process bold/italic/code/links within a single line of text.
   // Used inside list items and blockquotes where the text may already contain

--- a/tests/test_issue_code_syntax_highlight.py
+++ b/tests/test_issue_code_syntax_highlight.py
@@ -1,0 +1,25 @@
+"""Regression tests for fenced code block syntax highlighting."""
+from pathlib import Path
+
+UI_JS = Path(__file__).resolve().parent.parent / "static" / "ui.js"
+
+
+def _read_ui_js() -> str:
+    return UI_JS.read_text()
+
+
+def test_fenced_code_blocks_add_prism_language_class():
+    js = _read_ui_js()
+    assert 'class="language-${esc(normalizedLang)}"' in js, (
+        "Fenced code blocks should add Prism language-* classes so syntax highlighting works"
+    )
+
+
+def test_fenced_code_blocks_keep_existing_pre_header_layout():
+    js = _read_ui_js()
+    assert 'return `${h}<pre><code${langAttr}>${esc(code.replace(/\\n$/,' in js, (
+        "The syntax-highlight fix should preserve the existing fenced code block layout"
+    )
+    assert '<div class="code-block">' not in js, (
+        "This fix should not introduce a new wrapper around fenced code blocks"
+    )


### PR DESCRIPTION
## Problem

Two related issues:

1. **No syntax highlighting at all** — `renderMd()` in `ui.js` emitted `<code>` elements with no `class` attribute. Prism's autoloader requires `class="language-*"` to detect the language and apply highlighting. Without it, every code block was rendered as plain unstyled text — in both dark *and* light themes.

2. **Light theme tokens invisible** — `prism-tomorrow` is a dark-only theme. Its `.token` colors are near-white / light, designed for dark code backgrounds. In light mode the code background is `#ddd8d0` (warm tan), making any tokens that did appear nearly invisible.

## Changes

### `static/ui.js`
Rewrote the fenced code block handler in `renderMd()` to normalise the language tag and emit the Prism-required `class="language-*"` attribute:

```
Before: <pre><code>...</code></pre>
After:  <pre><code class="language-python">...</code></pre>
```

This enables Prism's autoloader to detect, load, and apply syntax highlighting in **all themes** (dark and light).

### `static/style.css`
Added a complete set of `.token` color overrides scoped to `:root[data-theme="light"]` so every token type renders with strong contrast against the light background:

| Token | Color | Role |
|---|---|---|
| `comment` / `cdata` | `#7a7060` warm grey, italic | Muted but readable |
| `punctuation` | `#5a4e44` dark warm brown | Structural |
| `number` / `boolean` / `tag` | `#a0290a` dark brick red | Literals & tags |
| `string` / `selector` | `#276b30` forest green | String values |
| `operator` / `url` | `#5a3e8a` dark purple | Operators |
| `keyword` / `attr-value` | `#2d6fa3` theme blue | Keywords |
| `function` / `class-name` | `#7a3a00` dark amber | Callables |
| `variable` / `regex` | `#8a4a00` warm brown | Variables |

Dark, dim, solarized, monokai, nord, and terminal themes are **unaffected** — `prism-tomorrow`'s existing palette already works for those.

### `tests/test_issue_code_syntax_highlight.py`
Regression tests asserting:
- Fenced code blocks emit `language-*` class attributes
- Existing pre-header layout is preserved
- No extra wrapper divs are introduced