### PR TITLE
docs: correct v0.50.38 test count to 1075 in TESTING.md + CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ locale routing updated in `api/routes.py` (`_resolve_login_locale_key()` helper)
 strings in `panels.js` cron UI extracted to i18n keys. 3 new test files:
 `test_chinese_locale.py`, `test_language_precedence.py`, `test_login_locale.py`.
 
-- Total tests: 1073 (was 1063)
+- Total tests: 1075 (was 1063)
 
 ## [v0.50.37] fix(onboarding): skip wizard when Hermes is already configured
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -8,7 +8,7 @@
 > Prerequisites: SSH tunnel is active on port 8787. Open http://localhost:8787 in browser.
 > Server health check: curl http://127.0.0.1:8787/health should return {"status":"ok"}.
 >
-> Automated tests: 1073 total (1073 passing, 0 known failures). Includes onboarding coverage for bootstrap/static wizard presence, real provider config persistence (`config.yaml` + `.env`), the `/api/onboarding/*` backend, and the onboarding skip/existing-config guard.
+> Automated tests: 1075 total (1075 passing, 0 known failures). Includes onboarding coverage for bootstrap/static wizard presence, real provider config persistence (`config.yaml` + `.env`), the `/api/onboarding/*` backend, and the onboarding skip/existing-config guard.
 > Run: `pytest tests/ -v --timeout=60`
 
 ---


### PR DESCRIPTION
Minor: v0.50.38 landed with 1075 tests (not 1073 as written in the release). Corrects both TESTING.md and the CHANGELOG entry.