### PR TITLE
fix(ui): active session title uses var(--gold) instead of hardcoded color

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -172,7 +172,7 @@
   .session-text{flex:1;min-width:0;display:flex;flex-direction:column;gap:2px;overflow:hidden;}
   .session-title-row{display:flex;align-items:flex-start;gap:8px;min-width:0;}
   .session-title{flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:var(--text);}
-  .session-item.active .session-title{color:#e8a030;}
+  .session-item.active .session-title{color:var(--gold);}
   .session-time{flex-shrink:0;font-size:11px;line-height:1.4;color:var(--muted);text-transform:lowercase;}
   .session-meta{font-size:11px;line-height:1.35;color:var(--muted);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
   /* ── Session action trigger + dropdown ── */

--- a/tests/test_sprint40_ui_polish.py
+++ b/tests/test_sprint40_ui_polish.py
@@ -1,0 +1,51 @@
+"""
+Sprint 40 UI Polish Tests: Active session title uses CSS theme variable (issue #440).
+
+Covers:
+- .session-item.active .session-title uses var(--gold) instead of hardcoded #e8a030
+- The hardcoded amber color #e8a030 is NOT present in the active session title rule
+"""
+import pathlib
+import re
+import unittest
+
+REPO_ROOT = pathlib.Path(__file__).parent.parent
+STYLE_CSS = (REPO_ROOT / "static" / "style.css").read_text()
+
+
+class TestActiveSessionTitleThemeColor(unittest.TestCase):
+
+    def test_active_session_title_uses_theme_variable(self):
+        """
+        .session-item.active .session-title must use var(--gold) not a hardcoded hex.
+        The light-theme override line (data-theme="light") is allowed to keep its own
+        hardcoded color; we only check the base/dark rule.
+        """
+        # Find all lines that match the active session title selector
+        lines = STYLE_CSS.splitlines()
+        base_rule_lines = [
+            line for line in lines
+            if ".session-item.active .session-title" in line
+            and 'data-theme="light"' not in line
+        ]
+
+        self.assertTrue(
+            len(base_rule_lines) >= 1,
+            "Could not find .session-item.active .session-title base rule in style.css"
+        )
+
+        for line in base_rule_lines:
+            self.assertIn(
+                "var(--gold)",
+                line,
+                f"Expected var(--gold) in active session title rule, got: {line.strip()}"
+            )
+            self.assertNotIn(
+                "#e8a030",
+                line,
+                f"Hardcoded #e8a030 must be removed from active session title rule: {line.strip()}"
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #440

**Root cause:** `static/style.css` line 175 hardcoded `#e8a030` (amber/orange) as the active session title color. This color only looks intentional in the default Dark theme — in Light, Slate, Nord, Monokai, Solarized, and OLED themes it's jarring and inconsistent.

**Fix:** Replace `#e8a030` with `var(--gold)`, which is already defined per-theme across all 7 theme blocks in `style.css`.

**Changes:**
- `static/style.css` line 175: `color:#e8a030` → `color:var(--gold)`
- `tests/test_sprint40_ui_polish.py`: 1 new test asserting `var(--gold)` is used

1079 tests passing.
