### PR TITLE
fix(sessions): return None instead of unknown for missing gateway session model

### DIFF
--- a/api/gateway_watcher.py
+++ b/api/gateway_watcher.py
@@ -75,7 +75,7 @@ def _get_agent_sessions_from_db() -> list:
                 sessions.append({
                     'session_id': row['id'],
                     'title': row['title'] or 'Agent Session',
-                    'model': row['model'] or 'unknown',
+                    'model': row['model'] or None,
                     'message_count': row['message_count'] or 0,
                     'created_at': row['started_at'],
                     'updated_at': row['last_activity'] or row['started_at'],

--- a/api/models.py
+++ b/api/models.py
@@ -309,7 +309,7 @@ def get_cli_sessions() -> list:
                     'session_id': sid,
                     'title': _display_title,
                     'workspace': str(get_last_workspace()),
-                    'model': row['model'] or 'unknown',
+                    'model': row['model'] or None,
                     'message_count': row['message_count'] or 0,
                     'created_at': row['started_at'],
                     'updated_at': raw_ts,

--- a/tests/test_sprint40_ui_polish.py
+++ b/tests/test_sprint40_ui_polish.py
@@ -1,0 +1,57 @@
+"""
+Tests for UI polish fixes - Issue #443
+Gateway session null model should return None not 'unknown'.
+"""
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+class TestGatewaySessionNullModel(unittest.TestCase):
+    """Verify that api/models.py and api/gateway_watcher.py do not
+    fall back to the string 'unknown' for missing model values."""
+
+    def test_gateway_session_null_model_returns_none_not_unknown(self):
+        """api/models.py must not use `or 'unknown'` for the model field
+        so that a NULL model in state.db is returned as None (falsy) to
+        the frontend rather than the truthy string 'unknown'."""
+        models_src = (REPO_ROOT / "api" / "models.py").read_text()
+        # Ensure the old fallback pattern is gone
+        self.assertNotIn(
+            "'model': row['model'] or 'unknown'",
+            models_src,
+            "api/models.py must not use `or 'unknown'` for the model field "
+            "(fixes #443: gateway sessions showed 'telegram · unknown')",
+        )
+
+    def test_gateway_watcher_null_model_returns_none_not_unknown(self):
+        """api/gateway_watcher.py must not use `or 'unknown'` for the model
+        field so that a NULL model in state.db is returned as None (falsy)."""
+        gw_src = (REPO_ROOT / "api" / "gateway_watcher.py").read_text()
+        self.assertNotIn(
+            "'model': row['model'] or 'unknown'",
+            gw_src,
+            "api/gateway_watcher.py must not use `or 'unknown'` for the model "
+            "field (fixes #443: gateway sessions showed 'telegram · unknown')",
+        )
+
+    def test_gateway_session_model_uses_none_fallback(self):
+        """Both source files must use `row['model'] or None` (explicit None
+        fallback) for the model field assignment."""
+        models_src = (REPO_ROOT / "api" / "models.py").read_text()
+        gw_src = (REPO_ROOT / "api" / "gateway_watcher.py").read_text()
+        self.assertIn(
+            "'model': row['model'] or None,",
+            models_src,
+            "api/models.py should assign `row['model'] or None` for the model field",
+        )
+        self.assertIn(
+            "'model': row['model'] or None,",
+            gw_src,
+            "api/gateway_watcher.py should assign `row['model'] or None` for the model field",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #443

**Root cause:** `api/models.py` and `api/gateway_watcher.py` both fall back to the string `'unknown'` when `state.db` has `NULL` in the model column for a gateway session. The frontend guard `if(s.model)` is truthy for the string `'unknown'`, so `telegram · unknown` appears in the subtitle.

**Fix:** Return `None` instead of `'unknown'` in both files. The existing frontend guard correctly omits `None` model values.

**Changes:**
- `api/models.py` line 312: `row['model'] or 'unknown'` → `row['model'] or None`
- `api/gateway_watcher.py` line 78: same change
- `tests/test_sprint40_ui_polish.py`: 3 new tests

1079 tests passing.
