### PR TITLE
fix(routing): strip provider prefix from model ID when custom base_url is configured

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -637,7 +637,10 @@ def resolve_model_provider(model_id: str) -> tuple:
         # just because the model name contains a slash (e.g. google/gemma-4-26b-a4b).
         # The user has explicitly pointed at a base_url, so trust their routing config.
         if config_base_url:
-            return model_id, config_provider, config_base_url
+            # Strip provider prefix (e.g. 'openai/gpt-5.4' -> 'gpt-5.4') so prefixed
+            # model IDs from previous sessions don't break custom endpoint routing.
+            bare_model = model_id.split('/', 1)[-1]
+            return bare_model, config_provider, config_base_url
         # If prefix does NOT match config provider, the user picked a cross-provider model
         # from the OpenRouter dropdown (e.g. config=anthropic but picked openai/gpt-5.4-mini).
         # In this case always route through openrouter with the full provider/model string.

--- a/tests/test_model_resolver.py
+++ b/tests/test_model_resolver.py
@@ -403,8 +403,10 @@ def test_custom_endpoint_slash_model_routes_to_custom_not_openrouter():
     assert base_url == 'http://127.0.0.1:1234/v1', (
         "Expected base_url 'http://127.0.0.1:1234/v1', got '{}'.".format(base_url)
     )
-    assert model == 'google/gemma-4-26b-a4b', (
-        "Model name should be preserved as-is, got '{}'.".format(model)
+    # Fix #433: provider prefix is now stripped for custom endpoints so stale
+    # prefixed model IDs from previous sessions do not break custom endpoint routing.
+    assert model == 'gemma-4-26b-a4b', (
+        "Model name prefix should be stripped for custom base_url endpoint, got '{}'.".format(model)
     )
 
     # --- openrouter with slash model name MUST still route to openrouter -----

--- a/tests/test_sprint40_ui_polish.py
+++ b/tests/test_sprint40_ui_polish.py
@@ -1,0 +1,72 @@
+"""
+Tests for issue #433 — stale provider-prefixed model IDs sent to custom endpoints.
+
+When a user configures a custom endpoint (config_base_url set) and previously
+had sessions with provider-prefixed model IDs (e.g. openai/gpt-5.4), the
+resolve_model_provider() function must strip the provider prefix so the bare
+model ID (gpt-5.4) is sent to the custom endpoint.
+"""
+import unittest
+from unittest.mock import patch
+import api.config as config
+
+
+class TestCustomEndpointModelStripping:
+    """Tests for fix #433: strip provider prefix when custom base_url is set."""
+
+    def _resolve(self, model_id, provider=None, base_url=None):
+        """Helper: set cfg directly (same pattern as test_model_resolver.py)."""
+        old_cfg = dict(config.cfg)
+        model_cfg = {}
+        if provider:
+            model_cfg['provider'] = provider
+        if base_url:
+            model_cfg['base_url'] = base_url
+        config.cfg['model'] = model_cfg
+        try:
+            return config.resolve_model_provider(model_id)
+        finally:
+            config.cfg.clear()
+            config.cfg.update(old_cfg)
+
+    def test_prefixed_model_stripped_for_custom_endpoint(self):
+        """Issue #433: 'openai/gpt-5.4' with custom base_url returns bare 'gpt-5.4'."""
+        model, provider, base_url = self._resolve(
+            'openai/gpt-5.4',
+            provider='custom',
+            base_url='http://my-proxy.local:8080/v1',
+        )
+        assert model == 'gpt-5.4', (
+            "Expected bare 'gpt-5.4' for custom endpoint, got '{}'."
+            " Stale provider-prefix must be stripped.".format(model)
+        )
+        assert base_url == 'http://my-proxy.local:8080/v1'
+        assert provider == 'custom'
+
+    def test_bare_model_unchanged_for_custom_endpoint(self):
+        """Bare model ID (no slash) must pass through untouched with custom base_url."""
+        model, provider, base_url = self._resolve(
+            'gpt-4o',
+            provider='custom',
+            base_url='http://my-proxy.local:8080/v1',
+        )
+        assert model == 'gpt-4o', (
+            "Bare model 'gpt-4o' should not be modified, got '{}'.".format(model)
+        )
+        assert base_url == 'http://my-proxy.local:8080/v1'
+        assert provider == 'custom'
+
+    def test_prefixed_model_kept_for_openrouter(self):
+        """When NO custom base_url (openrouter route), prefixed model must stay prefixed."""
+        model, provider, base_url = self._resolve(
+            'openai/gpt-5.4',
+            provider='anthropic',  # cross-provider pick triggers openrouter routing
+        )
+        # Cross-provider model with openrouter routing must keep full provider/model path
+        assert 'openai/gpt-5.4' in model or provider == 'openrouter', (
+            "Expected prefixed model or openrouter routing for non-custom endpoint, "
+            "got model='{}', provider='{}'.".format(model, provider)
+        )
+        assert base_url is None, (
+            "OpenRouter routing must not set a base_url, got '{}'.".format(base_url)
+        )


### PR DESCRIPTION
Fixes #433

**Root cause:** `resolve_model_provider()` in `api/config.py` returns the model ID verbatim when a custom `base_url` is configured. If the stored session model ID carries a provider prefix (e.g. `openai/gpt-5.4` from a previous OpenRouter session), that prefixed ID gets sent to the custom endpoint which only accepts bare IDs (e.g. `gpt-5.4`), breaking the request.

**Fix (Option A — minimal risk, confirmed with reporter @shaoxianbilly):** Strip any provider prefix with `model_id.split('/', 1)[-1]` before returning from the custom-endpoint branch. This is idempotent: if the ID has no slash, it returns unchanged.

**Changes:**
- `api/config.py` in `resolve_model_provider()`: `return model_id, ...` → `bare_model = model_id.split('/', 1)[-1]; return bare_model, ...` when `config_base_url` is set
- `tests/test_sprint40_ui_polish.py`: 3 new tests (prefixed stripped, bare unchanged, openrouter path unaffected)
- `tests/test_model_resolver.py`: updated 1 existing test whose assertion matched the old (wrong) behavior

1079 tests passing.
