### PR TITLE
fix(panels): invalidate cron skill picker cache on form open

### DIFF
--- a/static/panels.js
+++ b/static/panels.js
@@ -97,10 +97,9 @@ function toggleCronForm(){
     _renderCronSkillTags();
     const search=$('cronFormSkillSearch');
     if(search)search.value='';
-    // Pre-fetch skills for the picker
-    if(!_cronSkillsCache){
-      api('/api/skills').then(d=>{_cronSkillsCache=d.skills||[];}).catch(()=>{});
-    }
+    // Always re-fetch skills to avoid stale cache
+    _cronSkillsCache=null;
+    api('/api/skills').then(d=>{_cronSkillsCache=d.skills||[];}).catch(()=>{});
     $('cronFormName').focus();
   }
 }


### PR DESCRIPTION
Closes #502

The skill picker in the cron job create/edit forms cached the skills list in `_cronSkillsCache` on first load and never invalidated it. If a skill was added or updated while the same page session was open, the picker continued showing the outdated list until a full page reload.

### Fix

Clear `_cronSkillsCache` and re-fetch from `/api/skills` every time the cron form is opened, instead of only fetching on the first load.

### Testing

1. Open Tasks panel → create cron job → note available skills
2. Switch to Skills panel → add a new skill
3. Return to Tasks panel → open cron form again
4. Skill picker now shows the updated list