### PR TITLE
fix(panels): invalidate cron skill cache after skill write operations

### DIFF
--- a/static/panels.js
+++ b/static/panels.js
@@ -485,6 +485,7 @@ async function submitSkillSave() {
     await api('/api/skills/save', {method:'POST', body: JSON.stringify({name, category: category||undefined, content})});
     showToast(_editingSkillName ? t('skill_updated') : t('skill_created'));
     _skillsData = null;
+    _cronSkillsCache = null;
     toggleSkillForm();
     await loadSkills();
   } catch(e) { errEl.textContent = t('error_prefix') + e.message; errEl.style.display = ''; }


### PR DESCRIPTION
Fixes #502

## Thinking Path
- Hermes WebUI provides a cron job form with a skill picker
- The skill list is fetched once and cached in `_cronSkillsCache`
- The cache was never invalidated after skill save/delete operations
- Users who added or renamed skills saw stale data in the cron picker

## What Changed
- Added `_cronSkillsCache = null` in `submitSkillSave()`, right after the existing `_skillsData = null` invalidation
- The next time the cron form opens, it re-fetches the current skill list from the API

## Verification
1. Open Tasks panel, start creating a cron job — note the skill list
2. Switch to Skills panel, add a new skill
3. Return to Tasks panel, open cron form again — skill list now reflects the change
4. No full page reload needed

## Risks / Follow-ups
- If a skill delete API is added later, it should also clear `_cronSkillsCache`
- No other code paths set the cache, so this single invalidation point is sufficient

## Model Used
None — human-authored