### PR TITLE
fix: allow workspace path under /root

### DIFF
--- a/api/workspace.py
+++ b/api/workspace.py
@@ -243,7 +243,7 @@ def resolve_trusted_workspace(path: str | Path | None = None) -> Path:
     _BLOCKED_SYSTEM_ROOTS = {
         # Linux / macOS
         Path('/etc'), Path('/usr'), Path('/var'), Path('/bin'), Path('/sbin'),
-        Path('/boot'), Path('/proc'), Path('/sys'), Path('/dev'), Path('/root'),
+        Path('/boot'), Path('/proc'), Path('/sys'), Path('/dev'),
         Path('/lib'), Path('/lib64'), Path('/opt/homebrew'),
     }
 
@@ -265,7 +265,7 @@ def resolve_trusted_workspace(path: str | Path | None = None) -> Path:
         except ValueError as e:
             if "system directory" in str(e):
                 raise
-            # relative_to raised ValueError = candidate is NOT under blocked = safe
+            pass # Not under blocked, safe
 
     # (A) Trusted if under the user's home directory — cross-platform via Path.home()
     try:


### PR DESCRIPTION
## Description
When trying to set `/root/.hermes/webui/workspace` as the workspace path, the WebUI throws `ValueError: Path points to a system directory: /root/.hermes/webui/workspace`, preventing normal startup and usage.

## Cause
In `api/workspace.py`, the `_BLOCKED_SYSTEM_ROOTS` set strictly restricts access to `Path('/root')`. 
If the project is deployed under `/root`, all workspace directories will be intercepted by the relative path validation logic (`candidate.relative_to(blocked)`).

## Fix
Removed `Path('/root')` from the `_BLOCKED_SYSTEM_ROOTS` set.
This allows self-hosted users to safely create workspaces and run the application under the `/root` directory.