### PR TITLE
fix: invalidate cron skills cache after skill save operations

### DIFF
--- a/static/panels.js
+++ b/static/panels.js
@@ -485,6 +485,7 @@ async function submitSkillSave() {
     await api('/api/skills/save', {method:'POST', body: JSON.stringify({name, category: category||undefined, content})});
     showToast(_editingSkillName ? t('skill_updated') : t('skill_created'));
     _skillsData = null;
+    _cronSkillsCache = null;
     toggleSkillForm();
     await loadSkills();
   } catch(e) { errEl.textContent = t('error_prefix') + e.message; errEl.style.display = ''; }


### PR DESCRIPTION
Fixes #502

The skill picker in the cron job forms caches the skills list in `_cronSkillsCache` on first load, but the cache is never invalidated when skills are added, renamed, or deleted.

**Change:** Set `_cronSkillsCache = null` after a successful skill save (in `submitSkillSave()`), so the next time the cron form is opened it re-fetches the current skills list from `/api/skills`.

**Before:** After adding/deleting a skill, the cron skill picker showed stale data until full page reload.
**After:** The picker reflects the current skills list on next form open.

**Test:** 
1. Open Tasks panel → create cron form → observe skills list
2. Switch to Skills panel → add or delete a skill
3. Return to Tasks panel → open cron form again → skills list should be updated