### PR TITLE
fix(cron): bust _cronSkillsCache after skill save (#502)

### DIFF
--- a/static/panels.js
+++ b/static/panels.js
@@ -483,6 +483,7 @@ async function submitSkillSave() {
   if (!content.trim()) { errEl.textContent = t('content_required'); errEl.style.display = ''; return; }
   try {
     await api('/api/skills/save', {method:'POST', body: JSON.stringify({name, category: category||undefined, content})});
+    _cronSkillsCache = null;
     showToast(_editingSkillName ? t('skill_updated') : t('skill_created'));
     _skillsData = null;
     toggleSkillForm();


### PR DESCRIPTION
## Summary

After a skill is created or updated via the Skills panel, the cron form skill picker cache is now invalidated by setting . This forces the next cron form open to re-fetch the current skill list instead of showing a stale list.

## Root Cause

 was set once on first access and never cleared, even after skills were modified.

## Fix

Added  after the  call in .

Fixes #502