### PR TITLE
feat(themes): add System (auto) prefers-color-scheme support (#504)

### DIFF
--- a/static/boot.js
+++ b/static/boot.js
@@ -581,6 +581,20 @@ function applyBotName(){
   if(msg) msg.placeholder='Message '+name+'\u2026';
 }
 
+function _applyTheme(theme){
+  if(theme==='system'){
+    theme=window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light';
+  }
+  document.documentElement.dataset.theme=theme;
+  return theme;
+}
+// Listen for OS theme changes when system is selected
+const _savedTheme=localStorage.getItem('hermes-theme');
+if(_savedTheme==='system'){
+  window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change',(e)=>{
+    document.documentElement.dataset.theme=e.matches?'dark':'light';
+  });
+}
 (async()=>{
   // Load send key preference
   let _bootSettings={};
@@ -594,7 +608,7 @@ function applyBotName(){
     window._notificationsEnabled=!!s.notifications_enabled;
     window._botName=s.bot_name||'Hermes';
     const _theme=s.theme||'dark';
-    document.documentElement.dataset.theme=_theme;
+    _applyTheme(_theme);
     localStorage.setItem('hermes-theme',_theme);
     document.body.classList.toggle('bubble-layout',!!s.bubble_layout);
     if(typeof setLocale==='function'){

--- a/static/commands.js
+++ b/static/commands.js
@@ -121,13 +121,13 @@ async function cmdUsage(){
 }
 
 async function cmdTheme(args){
-  const themes=['dark','light','slate','solarized','monokai','nord','oled'];
+  const themes=['system','dark','light','slate','solarized','monokai','nord','oled'];
   if(!args||!themes.includes(args.toLowerCase())){
     showToast(t('theme_usage')+themes.join('|'));
     return;
   }
   const themeName=args.toLowerCase();
-  document.documentElement.dataset.theme=themeName;
+  _applyTheme(themeName);
   localStorage.setItem('hermes-theme',themeName);
   try{await api('/api/settings',{method:'POST',body:JSON.stringify({theme:themeName})});}catch(e){}
   // Update settings dropdown if panel is open

--- a/static/index.html
+++ b/static/index.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Hermes</title>
-<script>(function(){var t=localStorage.getItem('hermes-theme');if(t&&t!=='dark')document.documentElement.dataset.theme=t;})()</script>
+<script>(function(){var t=localStorage.getItem('hermes-theme');var s=t==='system'?window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light':t;if(s&&s!=='dark')document.documentElement.dataset.theme=s;})()</script>
 <link rel="stylesheet" href="/static/style.css">
   <!-- KaTeX math rendering CSS (loaded eagerly to prevent layout shift) -->
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.22/dist/katex.min.css" integrity="sha384-5TcZemv2l/9On385z///+d7MSYlvIEw9FuZTIdZ14vJLqWphw7e7ZPuOiCHJcFCP" crossorigin="anonymous">
@@ -460,7 +460,8 @@
             </div>
             <div class="settings-field">
               <label for="settingsTheme" data-i18n="settings_label_theme">Theme</label>
-              <select id="settingsTheme" style="width:100%;padding:8px;background:var(--code-bg);color:var(--text);border:1px solid var(--border2);border-radius:6px" onchange="document.documentElement.dataset.theme=this.value;localStorage.setItem('hermes-theme',this.value)">
+              <select id="settingsTheme" style="width:100%;padding:8px;background:var(--code-bg);color:var(--text);border:1px solid var(--border2);border-radius:6px" onchange="_applyTheme(this.value);localStorage.setItem('hermes-theme',this.value)">
+                <option value="system">System (auto)</option>
                 <option value="dark">Dark (default)</option>
                 <option value="light">Light</option>
                 <option value="slate">Slate (charcoal)</option>

--- a/static/panels.js
+++ b/static/panels.js
@@ -1289,6 +1289,15 @@ function _applySavedSettingsUi(saved, body, opts){
     if(showCliSessions) startGatewaySSE();
     else if(typeof stopGatewaySSE==='function') stopGatewaySSE();
   }
+  // Resolve 'system' to actual dark/light before applying
+  _applyTheme(theme);
+  // Re-apply system change listener if system is selected
+  if(theme==='system'){
+    const mq=window.matchMedia('(prefers-color-scheme: dark)');
+    const handler=(e)=>{ document.documentElement.dataset.theme=e.matches?'dark':'light'; };
+    mq.removeEventListener('change', handler);
+    mq.addEventListener('change', handler);
+  }
   _setSettingsAuthButtonsVisible(!!saved.auth_enabled);
   _settingsDirty=false;
   _settingsThemeOnOpen=theme;


### PR DESCRIPTION
## Summary

Add a **System (auto)** theme option that automatically follows the OS `prefers-color-scheme` media query. When the OS setting changes (e.g. dark mode at sunset), the UI follows without a page reload.

## Changes

### 1. `static/index.html`
- Inline flicker-prevention script now resolves `system` to `dark`/`light` via `matchMedia` before setting the dataset theme
- Added `System (auto)` as the first entry in the theme picker
- Changed `onchange` from direct DOM assignment to `_applyTheme(this.value)`

### 2. `static/boot.js`
- Added `_applyTheme(theme)` helper that resolves `system` via `matchMedia` then sets `dataset.theme`
- Registers a `change` listener on `matchMedia` when saved theme is `system`
- Updated boot theme init to use `_applyTheme(_theme)`

### 3. `static/panels.js`
- `_applySavedSettingsUi` calls `_applyTheme(theme)` to resolve `system` before applying
- Re-registers OS change listener if `system` is selected

### 4. `static/commands.js`
- Added `system` to valid themes for `/theme` command
- `/theme system` uses `_applyTheme(themeName)`

## How It Works

When user selects **System (auto)**:
1. `localStorage` and server store value `"system"`
2. `_applyTheme('system')` resolves to `dark` or `light` via `matchMedia`
3. On OS change, the listener fires and updates DOM directly
4. The Settings dropdown shows currently active resolved mode

Fixes #504