### PR TITLE
fix: show custom_providers models regardless of active provider

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -949,9 +949,11 @@ def get_available_models() -> dict:
     # THAT provider, not to a separate "Custom" group. hermes_cli reports
     # 'custom' as authenticated whenever base_url is set, which would otherwise
     # build a phantom "Custom" bucket next to the real provider's group. Drop
-    # it unless the user explicitly chose 'custom' as their active provider.
+    # it unless the user explicitly chose 'custom' as their active provider
+    # OR has custom_providers configured (they want those models visible).
     if active_provider and active_provider != "custom":
-        detected_providers.discard("custom")
+        if not _custom_providers_cfg:
+            detected_providers.discard("custom")
 
     # 5. Build model groups
     if detected_providers:


### PR DESCRIPTION
When custom_providers are configured in config.yaml but the active provider is something else (e.g., opencode-go), the models were being hidden. This fix ensures custom models are always visible when custom_providers are explicitly configured.

**Changes:**
- Only discard 'custom' from detected_providers if no custom_providers are configured
- This allows users to see their custom local models alongside other providers

Fixes: custom models not appearing in dropdown when using another provider