### PR TITLE
fix(ui): show toast when model is switched during active session

### DIFF
--- a/static/ui.js
+++ b/static/ui.js
@@ -272,6 +272,11 @@ async function selectModelFromDropdown(value){
   sel.value=value;
   syncModelChip();
   closeModelDropdown();
+  // Notify user that model changes take effect in new conversations
+  // when switching during an active session with messages
+  if(S.session && S.messages && S.messages.length > 0) {
+    showToast('Model change takes effect in your next conversation', 4000);
+  }
   if(typeof sel.onchange==='function') await sel.onchange();
 }
 


### PR DESCRIPTION
Fixes #419

When a user switches the model via the dropdown during an active chat session,
the UI now shows a toast notification: "Model change takes effect in your
next conversation". This prevents confusion about which model is processing
messages.

**Changes:**
- In `selectModelFromDropdown()`, check if `S.session` exists with messages
  after model selection
- If so, call `showToast()` to inform the user

**Verification:**
1. Open a chat session and send a message
2. Switch the model via the dropdown while the session is active
3. Confirm the toast appears: "Model change takes effect in your next conversation"
4. Verify no toast appears when switching models before any messages are sent