### PR TITLE
fix(ui): show toast when model is switched during active session

### DIFF
--- a/static/ui.js
+++ b/static/ui.js
@@ -271,6 +271,10 @@ async function selectModelFromDropdown(value){
   }
   sel.value=value;
   syncModelChip();
+  // Warn user if model is changed mid-session (model takes effect next turn)
+  if(S.session && S.messages && S.messages.length > 0){
+    showToast('Model change takes effect in your next conversation', 3500);
+  }
   closeModelDropdown();
   if(typeof sel.onchange==='function') await sel.onchange();
 }


### PR DESCRIPTION
## Fixes #419

When a user switches the model via the WebUI during an active chat session, the UI now shows a toast notification: "Model change takes effect in your next conversation". This prevents confusion about which model is processing messages.

### Changes
- In , check if  exists with messages after model selection
- If so, call  to inform the user the model change takes effect on the next conversation

### Verification
1. Open a chat session and send a message
2. Switch the model via the dropdown while the session is active
3. Confirm the toast appears: "Model change takes effect in your next conversation"
4. Verify no toast appears when switching models before any messages are sent