### PR TITLE
fix(ui): show toast when model is switched during active session (#517)

### DIFF
--- a/static/boot.js
+++ b/static/boot.js
@@ -415,6 +415,10 @@ $('modelSelect').onchange=async()=>{
   S.session.model=selectedModel;
   if(typeof syncModelChip==='function') syncModelChip();
   syncTopbar();
+  // Show toast if switching model during active session (issue #517)
+  if(S.session && S.session.messages && S.session.messages.length > 0){
+    if(typeof showToast==='function') showToast('Model change takes effect in your next conversation', 3000);
+  }
   // Warn if selected model belongs to a different provider than what Hermes is configured for
   if(typeof _checkProviderMismatch==='function'){
     const warn=_checkProviderMismatch(selectedModel);


### PR DESCRIPTION
## Summary

When a user switches the model via the WebUI during an active chat session,
the UI now shows a toast notification: "Model change takes effect in your next conversation".

## Changes

In `static/boot.js`, added a check inside `modelSelect.onchange`:

```javascript
if (S.session && S.session.messages && S.session.messages.length > 0) {
  showToast('Model change takes effect in your next conversation', 3000);
}
```

This fires after the model is saved to the session but only when there are
already messages in the conversation — indicating an active session.

## Verification

1. Open a chat session and send a message
2. Switch the model via the dropdown while the session is active
3. Confirm the toast appears: "Model change takes effect in your next conversation"
4. Verify no toast appears when switching models before any messages are sent

Fixes #517