### PR TITLE
fix: show custom_providers models regardless of active provider (#515)

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -949,8 +949,11 @@ def get_available_models() -> dict:
     # THAT provider, not to a separate "Custom" group. hermes_cli reports
     # 'custom' as authenticated whenever base_url is set, which would otherwise
     # build a phantom "Custom" bucket next to the real provider's group. Drop
-    # it unless the user explicitly chose 'custom' as their active provider.
-    if active_provider and active_provider != "custom":
+    # it unless (a) the user explicitly chose 'custom' as their active provider,
+    # or (b) the user has custom_providers entries in config.yaml (those models
+    # were already added above and should still be shown).
+    _has_custom_providers = isinstance(_custom_providers_cfg, list) and len(_custom_providers_cfg) > 0
+    if active_provider and active_provider != "custom" and not _has_custom_providers:
         detected_providers.discard("custom")
 
     # 5. Build model groups


### PR DESCRIPTION
## Summary

Custom models from `custom_providers` in config.yaml are now visible in the model
dropdown regardless of which provider is currently active.

## Root Cause

In `api/config.py`, the `detected_providers.discard('custom')` call at line 954
was unconditional — it fired whenever `active_provider` was not `'custom'`,
even when the user had explicitly configured `custom_providers` in config.yaml.

## Fix

Only discard `'custom'` from `detected_providers` if there are no `custom_providers`
entries in config.yaml:

```python
_has_custom_providers = isinstance(_custom_providers_cfg, list) and len(_custom_providers_cfg) > 0
if active_provider and active_provider != 'custom' and not _has_custom_providers:
    detected_providers.discard('custom')
```

## Verification

1. Configure `custom_providers` in config.yaml with a local/custom endpoint
2. Set active provider to something other than 'custom' (e.g. openai, opencode-go)
3. Open the WebUI model dropdown
4. Confirm custom models appear alongside other providers' models

Fixes #515