### PR TITLE
fix: prevent Enter from sending while IME composition is active

### DIFF
--- a/static/boot.js
+++ b/static/boot.js
@@ -454,6 +454,7 @@ $('msg').addEventListener('keydown',e=>{
   // The 'ctrl+enter' setting also uses this behavior (Enter = newline).
   // Users can override in Settings by explicitly choosing 'enter' mode.
   if(e.key==='Enter'){
+    if(e.isComposing){return;}
     const _mobileDefault=matchMedia('(pointer:coarse)').matches&&window._sendKey==='enter';
     if(window._sendKey==='ctrl+enter'||_mobileDefault){
       if(e.ctrlKey||e.metaKey){e.preventDefault();send();}


### PR DESCRIPTION
## Summary
- guard the chat textarea Enter handler with `e.isComposing`
- let IME users commit composition text without accidentally sending

## Test Plan
- manually verified the change is limited to `static/boot.js`
- confirmed the Enter send path is unchanged once composition ends

Closes #531