### PR TITLE
fix: preserve slash model IDs for custom endpoints (fixes #548) — v0.50.53

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Hermes Web UI -- Changelog
 
+## [v0.50.53] — 2026-04-15
+
+### Fixed
+- **Custom endpoint slash model IDs** — model IDs with vendor prefixes that are intrinsic (e.g. `zai-org/GLM-5.1` on DeepInfra) are now preserved when routing to a custom `base_url` endpoint. Previously, all prefixed IDs were stripped, causing `model_not_found` errors on providers that require the full vendor/model format. Known provider namespaces (`openai/`, `google/`, `anthropic/`, etc.) are still stripped as before. (Fixes #548, PR #549 by @eba8)
+
 ## [v0.50.52] — 2026-04-15
 
 ### Fixed

--- a/api/config.py
+++ b/api/config.py
@@ -637,14 +637,14 @@ def resolve_model_provider(model_id: str) -> tuple:
         # just because the model name contains a slash (e.g. google/gemma-4-26b-a4b).
         # The user has explicitly pointed at a base_url, so trust their routing config.
         if config_base_url:
-            # For explicit custom endpoints, preserve full slash-bearing model IDs
-            # (e.g. "zai-org/GLM-5.1" on DeepInfra). Stripping the prefix causes
-            # model_not_found on providers that require vendor/model format.
-            if (config_provider or "").strip().lower() == "custom":
-                return model_id, config_provider, config_base_url
-            # Non-custom providers with a base_url override can still use bare IDs.
-            bare_model = model_id.split('/', 1)[-1]
-            return bare_model, config_provider, config_base_url
+            # Only strip the provider prefix when it's a known provider namespace
+            # (e.g. "openai/gpt-5.4" → "gpt-5.4" for a custom OpenAI-compatible proxy).
+            # Unknown prefixes (e.g. "zai-org/GLM-5.1" on DeepInfra) are intrinsic to
+            # the model ID and must be preserved — stripping them causes model_not_found.
+            if prefix in _PROVIDER_MODELS:
+                return bare, config_provider, config_base_url
+            # Unknown prefix (not a named provider) — pass full model_id through.
+            return model_id, config_provider, config_base_url
         # If prefix does NOT match config provider, the user picked a cross-provider model
         # from the OpenRouter dropdown (e.g. config=anthropic but picked openai/gpt-5.4-mini).
         # In this case always route through openrouter with the full provider/model string.

--- a/api/config.py
+++ b/api/config.py
@@ -637,8 +637,12 @@ def resolve_model_provider(model_id: str) -> tuple:
         # just because the model name contains a slash (e.g. google/gemma-4-26b-a4b).
         # The user has explicitly pointed at a base_url, so trust their routing config.
         if config_base_url:
-            # Strip provider prefix (e.g. 'openai/gpt-5.4' -> 'gpt-5.4') so prefixed
-            # model IDs from previous sessions don't break custom endpoint routing.
+            # For explicit custom endpoints, preserve full slash-bearing model IDs
+            # (e.g. "zai-org/GLM-5.1" on DeepInfra). Stripping the prefix causes
+            # model_not_found on providers that require vendor/model format.
+            if (config_provider or "").strip().lower() == "custom":
+                return model_id, config_provider, config_base_url
+            # Non-custom providers with a base_url override can still use bare IDs.
             bare_model = model_id.split('/', 1)[-1]
             return bare_model, config_provider, config_base_url
         # If prefix does NOT match config provider, the user picked a cross-provider model

--- a/static/index.html
+++ b/static/index.html
@@ -553,7 +553,7 @@
                 <div class="settings-section-title">System</div>
                 <div class="settings-section-meta">Instance version and access controls.</div>
               </div>
-              <span class="settings-version-badge">v0.50.52</span>
+              <span class="settings-version-badge">v0.50.53</span>
             </div>
             <div class="settings-field" style="border-top:1px solid var(--border);padding-top:12px;margin-top:8px">
               <label for="settingsPassword" data-i18n="settings_label_password">Access Password</label>


### PR DESCRIPTION
## fix: preserve slash model IDs for custom endpoints — v0.50.53

Contributor PR #549 by @eba8. Reviewed, regression fixed, 1302/1302 tests pass.

The PR needed one adjustment: the original guard (`config_provider == "custom"`) was too broad and broke two existing tests from issue #433. Fixed to use `prefix in _PROVIDER_MODELS` instead — strips known provider namespaces (openai/, google/) but preserves unknown prefixes like `zai-org/` that are intrinsic to the model ID.

Closes #548.
