### PR TITLE
fix: install hermes-agent[honcho] extra in Docker init (fixes #553)

### DIFF
--- a/docker_init.bash
+++ b/docker_init.bash
@@ -235,7 +235,7 @@ else
   test -x /app/venv/bin/pip
 
   echo ""; echo "== Adding hermes-agent's pyproject.toml base dependencies to the virtual environment"
-  uv pip install /home/hermeswebui/.hermes/hermes-agent --trusted-host pypi.org --trusted-host files.pythonhosted.org || error_exit "Failed to install hermes-agent's requirements"
+  uv pip install "/home/hermeswebui/.hermes/hermes-agent[honcho]" --trusted-host pypi.org --trusted-host files.pythonhosted.org || error_exit "Failed to install hermes-agent's requirements"
   touch /app/venv/.deps_installed
 fi
 


### PR DESCRIPTION
Fixes #553.

`docker_init.bash` line 238 was calling:
```bash
uv pip install /home/hermeswebui/.hermes/hermes-agent
```

Changed to:
```bash
uv pip install "/home/hermeswebui/.hermes/hermes-agent[honcho]"
```

The `honcho` extra is declared as optional in hermes-agent's `pyproject.toml`. Without it, `honcho-ai` is never installed, causing all Honcho memory tools to fail with `"Honcho session could not be initialized."` on every fresh Docker build. One-line fix, no other changes.

1302/1302 tests pass.
