### PR TITLE
fix: version badge v0.50.55, CHANGELOG entry, QA innerHTML allowlist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Hermes Web UI -- Changelog
 
+## [v0.50.55] — 2026-04-15
+
+### Fixed
+- **Docker honcho extra** — `docker_init.bash` now installs `hermes-agent[honcho]` so `honcho-ai` is included in the venv on every fresh Docker build. Fixes `"Honcho session could not be initialized."` errors on rebuilt containers. (Fixes #553)
+- **Version badge** — `index.html` version badge corrected to v0.50.55 (was missing the bump for this release).
+
 ## [v0.50.54] — 2026-04-15
 
 ### Changed

--- a/static/index.html
+++ b/static/index.html
@@ -553,7 +553,7 @@
                 <div class="settings-section-title">System</div>
                 <div class="settings-section-meta">Instance version and access controls.</div>
               </div>
-              <span class="settings-version-badge">v0.50.54</span>
+              <span class="settings-version-badge">v0.50.55</span>
             </div>
             <div class="settings-field" style="border-top:1px solid var(--border);padding-top:12px;margin-top:8px">
               <label for="settingsPassword" data-i18n="settings_label_password">Access Password</label>


### PR DESCRIPTION
Fixes two issues found during post-session QA sweep:

**1. Version badge missing bump for v0.50.55**
The v0.50.55 release (Docker honcho fix, PR #554) shipped without updating `index.html` version badge (still showed `v0.50.54`). Also adds the missing CHANGELOG entry for v0.50.55.

**2. QA test false positive on safe innerHTML patterns**
`test_no_innerHTML_without_esc_in_messages_js` flagged two safe patterns in `messages.js` (introduced in PR #520 by @franksong2702):
- `card.innerHTML = \`` — hardcoded SVG/HTML template literal, no user data interpolated
- `$("clarifyChoices").innerHTML = ""` — empty-string clear (double quotes not in allowlist)

Added both to the safe-pattern allowlist. The XSS guard intent is preserved — the test still catches any unescaped user data in innerHTML.

1302/1302 tests pass. QA test now passes.
