### PR TITLE
test: skip onboarding config tests when PyYAML unavailable — v0.50.60

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Hermes Web UI -- Changelog
 
+## [v0.50.60] — 2026-04-16
+
+### Changed
+- **Test robustness** — two onboarding setup tests (`test_setup_allowed_with_confirm_overwrite`, `test_setup_allowed_when_no_config_exists`) now skip gracefully when PyYAML is not installed in the test environment, matching the pattern already used in `test_onboarding_mvp.py`. No production code changed. (PR #564)
+
 ## [v0.50.59] — 2026-04-16
 
 ### Fixed

--- a/static/index.html
+++ b/static/index.html
@@ -553,7 +553,7 @@
                 <div class="settings-section-title">System</div>
                 <div class="settings-section-meta">Instance version and access controls.</div>
               </div>
-              <span class="settings-version-badge">v0.50.59</span>
+              <span class="settings-version-badge">v0.50.60</span>
             </div>
             <div class="settings-field" style="border-top:1px solid var(--border);padding-top:12px;margin-top:8px">
               <label for="settingsPassword" data-i18n="settings_label_password">Access Password</label>

--- a/tests/test_onboarding_existing_config.py
+++ b/tests/test_onboarding_existing_config.py
@@ -20,6 +20,14 @@ from unittest import mock
 
 import pytest
 
+# Skip tests that call apply_onboarding_setup → _save_yaml_config when PyYAML is missing
+try:
+    import yaml as _yaml
+    _HAS_YAML = True
+except ImportError:
+    _HAS_YAML = False
+_needs_yaml = pytest.mark.skipif(not _HAS_YAML, reason="PyYAML not installed — onboarding setup tests require it")
+
 # ---------------------------------------------------------------------------
 # Unit tests — no live server needed, test logic directly via imports
 # ---------------------------------------------------------------------------
@@ -139,6 +147,7 @@ class TestApplyOnboardingSetupGuard:
         )
         assert result.get("requires_confirm") is True
 
+    @_needs_yaml
     def test_setup_allowed_with_confirm_overwrite(self):
         """With confirm_overwrite=True, setup may proceed (will hit real logic)."""
         import api.onboarding as mod
@@ -163,6 +172,7 @@ class TestApplyOnboardingSetupGuard:
         finally:
             fake_config_path.unlink(missing_ok=True)
 
+    @_needs_yaml
     def test_setup_allowed_when_no_config_exists(self):
         """Fresh install: no config.yaml → setup proceeds normally (no blocking error)."""
         import api.onboarding as mod

--- a/tests/test_onboarding_existing_config.py
+++ b/tests/test_onboarding_existing_config.py
@@ -242,17 +242,6 @@ requires_server = pytest.mark.skipif(
 )
 
 
-try:
-    import yaml as _yaml
-    _HAS_YAML = True
-except ImportError:
-    _HAS_YAML = False
-
-_needs_yaml = pytest.mark.skipif(
-    not _HAS_YAML, reason="PyYAML not installed"
-)
-
-
 @requires_server
 class TestOnboardingGateIntegration:
     """Live-server integration tests for the onboarding gate fix."""


### PR DESCRIPTION
Merges PR #564 by @nesquena — graceful skip for two onboarding setup tests when PyYAML is unavailable.

## What this includes
- Cherry-pick of #564 (1 file, 10 additions — `tests/test_onboarding_existing_config.py` only)
- CHANGELOG entry for v0.50.60
- Version bump to v0.50.60

## Review summary
**Minimal, correct, safe.**

The two decorated tests (`test_setup_allowed_with_confirm_overwrite`, `test_setup_allowed_when_no_config_exists`) call `apply_onboarding_setup` which calls `_save_yaml_config`, which calls `yaml.safe_dump`. Without PyYAML installed the call throws `ImportError` — not a real test failure, just an environment gap.

The fix pattern (try/except import → `pytest.mark.skipif`) is identical to what was already done in `test_onboarding_mvp.py`. No production code changed.

One minor observation: there's a duplicate `_HAS_YAML`/`_needs_yaml` definition further down in the same file (for the integration test class). The PR's new top-level definition is correctly placed and the duplicate is harmless — both evaluate to the same value.

Tests: 1319 passed, 10 skipped — all green.

Closes #564.