### PR TITLE
fix: make hermes-agent source optional in Docker startup

### DIFF
--- a/docker_init.bash
+++ b/docker_init.bash
@@ -235,7 +235,17 @@ else
   test -x /app/venv/bin/pip
 
   echo ""; echo "== Adding hermes-agent's pyproject.toml base dependencies to the virtual environment"
-  uv pip install "/home/hermeswebui/.hermes/hermes-agent[honcho]" --trusted-host pypi.org --trusted-host files.pythonhosted.org || error_exit "Failed to install hermes-agent's requirements"
+  if [ -d "/home/hermeswebui/.hermes/hermes-agent" ] && [ -f "/home/hermeswebui/.hermes/hermes-agent/pyproject.toml" ]; then
+    uv pip install "/home/hermeswebui/.hermes/hermes-agent[honcho]" --trusted-host pypi.org --trusted-host files.pythonhosted.org || error_exit "Failed to install hermes-agent's requirements"
+  else
+    echo ""
+    echo "!! WARNING: hermes-agent source not found at /home/hermeswebui/.hermes/hermes-agent"
+    echo "!! The WebUI will start with reduced functionality (no model auto-detection,"
+    echo "!! no personality routing, no CLI session imports)."
+    echo "!! To fix: mount the agent source volume into the container. See:"
+    echo "!!   https://github.com/nesquena/hermes-webui/blob/master/docker-compose.two-container.yml"
+    echo ""
+  fi
   touch /app/venv/.deps_installed
 fi
 


### PR DESCRIPTION
## Summary
- The Docker init script now **warns instead of hard-exiting** when the hermes-agent source directory is not mounted
- Checks for both the directory and `pyproject.toml` before attempting `uv pip install`
- Prints a clear message explaining what's missing, what functionality is reduced, and links to the two-container compose file

## Root cause
`docker_init.bash` line 238 runs `uv pip install /home/hermeswebui/.hermes/hermes-agent || error_exit ...` which fatally exits the container when the agent source isn't mounted. Users running manual `docker run` commands (without the two-container compose file) hit this immediately.

The WebUI already has `try/except` fallbacks throughout the codebase for when hermes-agent is not importable (model detection, personality routing, CLI sessions, etc.), so a hard exit is unnecessary.

## What changed
- `docker_init.bash`: Check if agent source directory + pyproject.toml exist before installing. If missing, print a warning with reduced-functionality notice and a link to docs, then continue startup.

## Test plan
- [x] `bash -n docker_init.bash` — syntax OK
- [x] `pytest tests/ --timeout=60 -q` — 1261 passed, 60 skipped
- [ ] Docker startup without agent source mount (manual verification)

Fixes #570

🤖 Generated with [Claude Code](https://claude.com/claude-code)