### PR TITLE
feat: /compress with focus topic in Web UI (replace /compact)

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,7 +436,7 @@ across 53 test files.
 
 ### Slash commands
 - Type `/` in the composer for autocomplete dropdown
-- Built-in: `/help`, `/clear`, `/model <name>`, `/workspace <name>`, `/new`, `/usage`, `/theme`, `/compact`
+- Built-in: `/help`, `/clear`, `/compress [focus topic]`, `/compact` (alias), `/model <name>`, `/workspace <name>`, `/new`, `/usage`, `/theme`
 - Arrow keys navigate, Tab/Enter select, Escape closes
 - Unrecognized commands pass through to the agent
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -30,6 +30,7 @@ from api.config import (
     CANCEL_FLAGS,
     SERVER_START_TIME,
     _resolve_cli_toolsets,
+    CLI_TOOLSETS,
     _INDEX_HTML_PATH,
     get_available_models,
     IMAGE_EXTS,

--- a/api/routes.py
+++ b/api/routes.py
@@ -902,6 +902,9 @@ def handle_post(handler, parsed) -> bool:
             handler, {"ok": True, "session": s.compact() | {"messages": s.messages}}
         )
 
+    if parsed.path == "/api/session/compress":
+        return _handle_session_compress(handler, body)
+
     if parsed.path == "/api/chat/start":
         return _handle_chat_start(handler, body)
 
@@ -2445,6 +2448,114 @@ def _handle_clarify_respond(handler, body):
         return bad(handler, "response is required")
     resolve_clarify(sid, response, resolve_all=False)
     return j(handler, {"ok": True, "response": response})
+
+
+def _handle_session_compress(handler, body):
+    try:
+        require(body, "session_id")
+    except ValueError as e:
+        return bad(handler, str(e))
+
+    sid = str(body.get("session_id") or "").strip()
+    if not sid:
+        return bad(handler, "session_id is required")
+
+    focus_topic = str(body.get("focus_topic") or body.get("topic") or "").strip() or None
+
+    try:
+        s = get_session(sid)
+    except KeyError:
+        return bad(handler, "Session not found", 404)
+
+    if getattr(s, "active_stream_id", None):
+        return bad(handler, "Session is still streaming; wait for the current turn to finish.", 409)
+
+    try:
+        from api.streaming import _sanitize_messages_for_api
+
+        messages = _sanitize_messages_for_api(s.messages)
+        if len(messages) < 4:
+            return bad(handler, "Not enough conversation to compress (need at least 4 messages).")
+
+        import api.config as _cfg
+        import hermes_cli.runtime_provider as _runtime_provider
+        import run_agent as _run_agent
+        from agent.manual_compression_feedback import summarize_manual_compression
+        from agent.model_metadata import estimate_messages_tokens_rough
+
+        resolved_model, resolved_provider, resolved_base_url = _cfg.resolve_model_provider(s.model)
+
+        resolved_api_key = None
+        try:
+            _rt = _runtime_provider.resolve_runtime_provider(requested=resolved_provider)
+            resolved_api_key = _rt.get("api_key")
+            if not resolved_provider:
+                resolved_provider = _rt.get("provider")
+            if not resolved_base_url:
+                resolved_base_url = _rt.get("base_url")
+        except Exception as _e:
+            logger.warning("resolve_runtime_provider failed for compression: %s", _e)
+
+        if not resolved_api_key:
+            return bad(handler, "No provider configured -- cannot compress.")
+
+        with _cfg._get_session_agent_lock(sid):
+            original_messages = list(messages)
+            approx_tokens = estimate_messages_tokens_rough(original_messages)
+
+            agent = _run_agent.AIAgent(
+                model=resolved_model,
+                provider=resolved_provider,
+                base_url=resolved_base_url,
+                api_key=resolved_api_key,
+                platform="cli",
+                quiet_mode=True,
+                enabled_toolsets=CLI_TOOLSETS,
+                session_id=sid,
+            )
+            compressed = agent.context_compressor.compress(
+                original_messages,
+                current_tokens=approx_tokens,
+                focus_topic=focus_topic,
+            )
+            new_tokens = estimate_messages_tokens_rough(compressed)
+            summary = summarize_manual_compression(
+                original_messages,
+                compressed,
+                approx_tokens,
+                new_tokens,
+            )
+
+            s.messages = compressed
+            s.tool_calls = []
+            s.active_stream_id = None
+            s.pending_user_message = None
+            s.pending_attachments = []
+            s.pending_started_at = None
+            s.save()
+
+        session_payload = redact_session_data(
+            s.compact() | {
+                "messages": s.messages,
+                "tool_calls": s.tool_calls,
+                "active_stream_id": s.active_stream_id,
+                "pending_user_message": s.pending_user_message,
+                "pending_attachments": s.pending_attachments,
+                "pending_started_at": s.pending_started_at,
+            }
+        )
+        return j(
+            handler,
+            {
+                "ok": True,
+                "session": session_payload,
+                "summary": summary,
+                "focus_topic": focus_topic,
+            },
+        )
+    except Exception as e:
+        logger.warning("Manual session compression failed: %s", e)
+        return bad(handler, f"Compression failed: {_sanitize_error(e)}")
 
 
 def _handle_skill_save(handler, body):

--- a/static/commands.js
+++ b/static/commands.js
@@ -5,6 +5,7 @@
 const COMMANDS=[
   {name:'help',      desc:t('cmd_help'),             fn:cmdHelp},
   {name:'clear',     desc:t('cmd_clear'),         fn:cmdClear},
+  {name:'compress',  desc:t('cmd_compact'),       fn:cmdCompress, arg:'focus topic'},
   {name:'compact',   desc:t('cmd_compact'),       fn:cmdCompact},
   {name:'model',     desc:t('cmd_model'),  fn:cmdModel,     arg:'model_name'},
   {name:'workspace', desc:t('cmd_workspace'),            fn:cmdWorkspace, arg:'name'},
@@ -98,13 +99,42 @@ async function cmdNew(){
   showToast(t('new_session'));
 }
 
-function cmdCompact(){
-  // Send as a regular message to the agent -- the agent's run_conversation
-  // preflight will detect the high token count and trigger _compress_context.
-  // We send a user message so it appears in the conversation.
-  $('msg').value='Please compress and summarize the conversation context to free up space.';
-  send();
-  showToast(t('compressing'));
+async function _runManualCompression(focusTopic){
+  if(!S.session){showToast(t('no_active_session'));return;}
+  try{
+    const body={session_id:S.session.session_id};
+    if(focusTopic) body.focus_topic=focusTopic;
+    const data=await api('/api/session/compress',{method:'POST',body:JSON.stringify(body)});
+    if(data&&data.session){
+      const currentSid=S.session&&S.session.session_id;
+      if(data.session.session_id&&data.session.session_id!==currentSid){
+        await loadSession(data.session.session_id);
+      }else{
+        S.session=data.session;
+        S.messages=data.session.messages||[];
+        S.toolCalls=data.session.tool_calls||[];
+        clearLiveToolCards();
+        localStorage.setItem('hermes-webui-session',S.session.session_id);
+        syncTopbar();
+        renderMessages();
+        await renderSessionList();
+        updateQueueBadge(S.session.session_id);
+      }
+    }
+    const summary=data&&data.summary;
+    if(summary&&summary.headline) showToast(summary.headline);
+    else showToast(t('compressing'));
+  }catch(e){
+    showToast('Compression failed: '+e.message);
+  }
+}
+
+async function cmdCompress(args){
+  await _runManualCompression((args||'').trim());
+}
+
+async function cmdCompact(args){
+  await _runManualCompression((args||'').trim());
 }
 
 async function cmdUsage(){

--- a/tests/test_sprint46.py
+++ b/tests/test_sprint46.py
@@ -1,0 +1,151 @@
+"""
+Sprint 46 Tests: manual session compression with optional focus topic.
+"""
+
+import contextlib
+import io
+import json
+import sys
+import types
+
+from api.models import Session
+from api.config import SESSION_DIR
+from api.routes import _handle_session_compress
+from tests._pytest_port import BASE
+
+
+class _FakeHandler:
+    def __init__(self):
+        self.wfile = io.BytesIO()
+        self.status = None
+        self.sent_headers = {}
+
+    def send_response(self, status):
+        self.status = status
+
+    def send_header(self, key, value):
+        self.sent_headers[key] = value
+
+    def end_headers(self):
+        pass
+
+    def payload(self):
+        return json.loads(self.wfile.getvalue().decode("utf-8"))
+
+
+class _FakeCompressor:
+    def __init__(self):
+        self.calls = []
+
+    def compress(self, messages, current_tokens=None, focus_topic=None):
+        self.calls.append(
+            {
+                "messages": list(messages),
+                "current_tokens": current_tokens,
+                "focus_topic": focus_topic,
+            }
+        )
+        if len(messages) >= 2:
+            return [messages[0], messages[-1]]
+        return list(messages)
+
+
+class _FakeAgent:
+    last_instance = None
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.context_compressor = _FakeCompressor()
+        _FakeAgent.last_instance = self
+
+
+def _make_session(messages=None):
+    SESSION_DIR.mkdir(parents=True, exist_ok=True)
+    messages = messages or [
+        {"role": "user", "content": "one"},
+        {"role": "assistant", "content": "two"},
+        {"role": "user", "content": "three"},
+        {"role": "assistant", "content": "four"},
+    ]
+    s = Session(
+        session_id="compress_test_001",
+        title="Untitled",
+        workspace="/tmp/hermes-webui-test",
+        model="openai/gpt-5.4-mini",
+        messages=messages,
+    )
+    s.save(touch_updated_at=False)
+    return s.session_id
+
+
+def test_session_compress_requires_session_id(cleanup_test_sessions):
+    handler = _FakeHandler()
+    _handle_session_compress(handler, {})
+    assert handler.status == 400
+    assert handler.payload()["error"] == "Missing required field(s): session_id"
+
+
+def test_session_compress_roundtrip(monkeypatch, cleanup_test_sessions):
+    created = cleanup_test_sessions
+    sid = _make_session()
+    created.append(sid)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = _FakeAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    import api.config as _cfg
+    fake_runtime_provider = types.ModuleType("hermes_cli.runtime_provider")
+    fake_runtime_provider.resolve_runtime_provider = lambda requested=None: {
+        "api_key": "fake-key",
+        "provider": requested or "openai",
+        "base_url": "https://api.openai.com/v1",
+    }
+    monkeypatch.setitem(sys.modules, "hermes_cli.runtime_provider", fake_runtime_provider)
+    import hermes_cli.runtime_provider as _rtp
+
+    monkeypatch.setattr(
+        _cfg,
+        "resolve_model_provider",
+        lambda model: ("openai/gpt-5.4-mini", "openai", "https://api.openai.com/v1"),
+    )
+    monkeypatch.setattr(
+        _cfg,
+        "_get_session_agent_lock",
+        lambda sid: contextlib.nullcontext(),
+    )
+    monkeypatch.setattr(
+        _rtp,
+        "resolve_runtime_provider",
+        lambda requested=None: {
+            "api_key": "fake-key",
+            "provider": requested or "openai",
+            "base_url": "https://api.openai.com/v1",
+        },
+    )
+
+    handler = _FakeHandler()
+    _handle_session_compress(handler, {"session_id": sid, "focus_topic": "database schema"})
+
+    assert handler.status == 200
+    payload = handler.payload()
+    assert payload["ok"] is True
+    assert payload["focus_topic"] == "database schema"
+    assert payload["summary"]["headline"] == "Compressed: 4 → 2 messages"
+    assert payload["session"]["session_id"] == sid
+    assert payload["session"]["messages"] == [
+        {"role": "user", "content": "one"},
+        {"role": "assistant", "content": "four"},
+    ]
+    assert _FakeAgent.last_instance is not None
+    assert _FakeAgent.last_instance.context_compressor.calls[0]["focus_topic"] == "database schema"
+
+
+def test_static_commands_js_registers_compress_alias(cleanup_test_sessions):
+    with open("/Users/xuefusong/hermes-webui/static/commands.js", encoding="utf-8") as f:
+        src = f.read()
+    assert "name:'compress'" in src
+    assert "name:'compact'" in src
+    assert "/api/session/compress" in src
+    assert "cmdCompress" in src
+    assert "cmdCompact" in src


### PR DESCRIPTION
## Summary

Add a canonical `/compress [focus topic]` slash command to the Web UI, matching the CLI's focused compression flow while keeping `/compact` as a backwards-compatible alias. The direct implementation uses `POST /api/session/compress` so the UI can compress the current session without sending a fake user message into the history.

## What changed

- add `/compress [focus topic]` as the primary slash command
- keep `/compact` as an alias for compatibility
- add `POST /api/session/compress` to compress the active session directly
- propagate an optional focus topic into the agent's compression flow
- update the slash-command help text in the README
- add regression coverage for the manual compression endpoint and slash-command wiring

## Validation

- `tests/test_sprint46.py`
- targeted run: `3 passed`

Fixes #469
