### PR TITLE
chore: CHANGELOG + v0.50.64 badge + Today-bucket test (post-merge follow-up for #584)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Hermes Web UI -- Changelog
 
+## [v0.50.64] — 2026-04-16
+
+### Changed
+- **Sidebar session items decluttered** — the meta row under every session title (message count, model slug, and source-tag badge) has been removed. Each session now renders as a single line: title + relative-time bucket headers. The visible session count at a typical viewport height roughly doubles. The `source_tag` field is still populated on the session object and available for a future tooltip or filter facet. `[SYSTEM:]`-prefixed gateway titles fall back to `"Session"` rather than leaking system-prompt content. Removes `_formatSourceTag()`, `.session-meta`, `cli-session`, `[data-source=…]`, `_SOURCE_DISPLAY`, and the associated CSS badge rules. (PR #584 by @aronprins)
+
 ## [v0.50.63] — 2026-04-16
 
 ### Fixed

--- a/static/index.html
+++ b/static/index.html
@@ -553,7 +553,7 @@
                 <div class="settings-section-title">System</div>
                 <div class="settings-section-meta">Instance version and access controls.</div>
               </div>
-              <span class="settings-version-badge">v0.50.63</span>
+              <span class="settings-version-badge">v0.50.64</span>
             </div>
             <div class="settings-field" style="border-top:1px solid var(--border);padding-top:12px;margin-top:8px">
               <label for="settingsPassword" data-i18n="settings_label_password">Access Password</label>

--- a/tests/test_session_sidebar_relative_time.py
+++ b/tests/test_session_sidebar_relative_time.py
@@ -104,6 +104,22 @@ def test_relative_time_uses_calendar_boundaries_and_year_for_old_sessions():
     assert "2024" in result["oldDate"]
 
 
+def test_relative_time_today_bucket():
+    """Session from 2 hours ago should bucket as 'Today'."""
+    result = _run_session_time_case(
+        """
+        const now = Date.UTC(2026, 3, 15, 14, 0, 0);
+        const twoHoursAgo = now - 2 * 60 * 60 * 1000;
+        process.stdout.write(JSON.stringify({
+          relative: _formatRelativeSessionTime(twoHoursAgo, now),
+          bucket: _sessionTimeBucketLabel(twoHoursAgo, now),
+        }));
+        """
+    )
+    assert result["relative"] == "2 hours ago"
+    assert result["bucket"] == "Today"
+
+
 def test_relative_time_handles_just_now_and_dst_safe_yesterday_boundary():
     result = _run_session_time_case(
         """


### PR DESCRIPTION
Post-merge follow-up for PR #584.

The contributor PR was merged but the CHANGELOG, version badge, and a new test were on a separate branch that didn't get squashed into the merge commit. This PR adds them directly.

**Changes:**
- CHANGELOG entry for v0.50.64 (sidebar declutter)
- Version badge bumped from v0.50.63 → v0.50.64 in index.html  
- `test_relative_time_today_bucket` added to test_session_sidebar_relative_time.py — closes the minor coverage gap flagged in code review (no explicit Today-bucket runtime assertion existed)

**Tests:** 1315 passed, 10 skipped — no regressions.
