### PR TITLE
chore: CHANGELOG + v0.50.66 version badge (post-merge for PR #582)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Hermes Web UI -- Changelog
 
+## [v0.50.66] — 2026-04-16
+
+### Fixed
+- **WebUI agent now receives full runtime route from provider resolver** — previously `api_mode`, `acp_command`, `acp_args`, and `credential_pool` were not forwarded into `AIAgent.__init__()` in the WebUI streaming path. Users switching between Codex accounts or using credential pools found the switch worked in the CLI but not the WebUI. The fix passes all four fields from the resolved runtime into the agent constructor. (PR #582 by @suinia)
+
 ## [v0.50.65] — 2026-04-16
 
 ### Fixed

--- a/static/index.html
+++ b/static/index.html
@@ -553,7 +553,7 @@
                 <div class="settings-section-title">System</div>
                 <div class="settings-section-meta">Instance version and access controls.</div>
               </div>
-              <span class="settings-version-badge">v0.50.65</span>
+              <span class="settings-version-badge">v0.50.66</span>
             </div>
             <div class="settings-field" style="border-top:1px solid var(--border);padding-top:12px;margin-top:8px">
               <label for="settingsPassword" data-i18n="settings_label_password">Access Password</label>


### PR DESCRIPTION
Post-merge follow-up for PR #582. Adds CHANGELOG entry and bumps version badge to v0.50.66. No logic changes. Admin merging immediately.