### PR TITLE
fix(title): strip markdown labels from auto-generated titles

### DIFF
--- a/api/streaming.py
+++ b/api/streaming.py
@@ -134,7 +134,9 @@ def _first_exchange_snippets(messages):
         if role == 'user' and not user_text:
             user_text = _message_text(m.get('content'))
         elif role == 'assistant' and not asst_text:
-            asst_text = _message_text(m.get('content'))
+            candidate = _message_text(m.get('content'))
+            if candidate:
+                asst_text = candidate
         if user_text and asst_text:
             break
     return user_text[:500], asst_text[:500]

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -76,8 +76,14 @@ def _strip_thinking_markup(text: str) -> str:
 def _sanitize_generated_title(text: str) -> str:
     """Sanitize LLM-generated title text before persisting to session."""
     s = _strip_thinking_markup(text or '')
+    s = re.sub(
+        r'^\s*(?:[*_`~]+\s*)?(?:session\s+title|title)\s*[:：]\s*(?:[*_`~]+\s*)?',
+        '',
+        s,
+        flags=re.IGNORECASE,
+    )
     s = re.sub(r'^\s*title\s*:\s*', '', s, flags=re.IGNORECASE)
-    s = s.strip(" \t\r\n\"'`")
+    s = s.strip(" \t\r\n\"'`*_~")
     s = re.sub(r'\s+', ' ', s).strip()
     # Guard against chain-of-thought leakage and meta-reasoning patterns.
     if _looks_invalid_generated_title(s):
@@ -149,6 +155,7 @@ def _title_prompts(user_text: str, assistant_text: str) -> tuple[str, list[str]]
             "Generate a short session title from this conversation start.\n"
             "Use BOTH the user's question and the assistant's visible answer.\n"
             "Return only the title text, 3-8 words, as a topic label.\n"
+            "Do not use markdown, bullets, labels, or prefixes like Session Title:.\n"
             "Do not output a full sentence.\n"
             "Do not output acknowledgements or completion phrases like OK, done, all set, 测试完成.\n"
             "Do not describe internal reasoning.\n"
@@ -159,6 +166,7 @@ def _title_prompts(user_text: str, assistant_text: str) -> tuple[str, list[str]]
             "Rewrite this conversation start as a concise noun-phrase title.\n"
             "Use the actual topic, not the task outcome.\n"
             "Return title text only.\n"
+            "Do not use markdown, bullets, labels, or prefixes like Session Title:.\n"
             "Never output acknowledgements, completion status, or meta commentary."
         ),
     ]

--- a/tests/test_title_sanitization.py
+++ b/tests/test_title_sanitization.py
@@ -1,6 +1,6 @@
 import unittest
 
-from api.streaming import _sanitize_generated_title
+from api.streaming import _first_exchange_snippets, _sanitize_generated_title
 
 
 class TestGeneratedTitleSanitization(unittest.TestCase):
@@ -20,4 +20,16 @@ class TestGeneratedTitleSanitization(unittest.TestCase):
         self.assertEqual(
             _sanitize_generated_title("**Clarifying Topic for Discussion**"),
             "Clarifying Topic for Discussion",
+        )
+
+    def test_first_exchange_skips_empty_assistant_tool_call_placeholder(self):
+        messages = [
+            {"role": "user", "content": "What time is it in San Francisco?"},
+            {"role": "assistant", "content": "", "tool_calls": [{"id": "call_1"}]},
+            {"role": "tool", "content": "tool output", "tool_call_id": "call_1"},
+            {"role": "assistant", "content": "It is 6:16 PM in San Francisco."},
+        ]
+        self.assertEqual(
+            _first_exchange_snippets(messages),
+            ("What time is it in San Francisco?", "It is 6:16 PM in San Francisco."),
         )

--- a/tests/test_title_sanitization.py
+++ b/tests/test_title_sanitization.py
@@ -1,0 +1,23 @@
+import unittest
+
+from api.streaming import _sanitize_generated_title
+
+
+class TestGeneratedTitleSanitization(unittest.TestCase):
+    def test_strips_session_title_markdown_prefix(self):
+        self.assertEqual(
+            _sanitize_generated_title("**Session Title:** Clarifying Topic for Discussion"),
+            "Clarifying Topic for Discussion",
+        )
+
+    def test_strips_plain_title_prefix(self):
+        self.assertEqual(
+            _sanitize_generated_title("Title: Clarifying Topic for Discussion"),
+            "Clarifying Topic for Discussion",
+        )
+
+    def test_strips_wrapping_markdown_emphasis(self):
+        self.assertEqual(
+            _sanitize_generated_title("**Clarifying Topic for Discussion**"),
+            "Clarifying Topic for Discussion",
+        )


### PR DESCRIPTION
## Summary

This is a follow-up hardening pass for the auto-summarized session titles work from PR #535.

We found that some generated titles could leak Markdown formatting or label prefixes into the persisted session title, e.g. `**Session Title:** Clarifying Topic for Discussion`. That was happening because the sanitizer was only stripping a narrow set of prefixes and quoting, while the title prompt did not explicitly forbid Markdown labels.

We also found a separate edge case where the first assistant message in a conversation can be an empty tool-call placeholder. In that case, the title generator could latch onto the empty assistant row instead of the first visible assistant answer, which makes title generation less reliable for tool-using conversations.

## What changed

- expand title sanitization to strip `Session Title:` / `Title:` label wrappers and Markdown emphasis
- tighten the title prompt to explicitly forbid Markdown, bullets, and label prefixes
- skip empty assistant placeholders when extracting the first exchange for title generation
- add regression tests for the markdown label case and the empty assistant placeholder case

## Why this is related to PR #535

PR #535 introduced the background auto-title flow itself. This PR keeps that design, but hardens the output handling so the generated title is still clean even when the model emits formatting or when the first assistant row is an empty tool-call placeholder.

In other words: PR #535 created the feature; this PR makes it robust.

## Validation

- `PYTHONPATH=/Users/xuefusong/hermes-webui /Users/xuefusong/.hermes/hermes-agent/.venv/bin/python -m unittest discover -s tests -p 'test_title_sanitization.py' -v`
- `PYTHONPATH=/Users/xuefusong/hermes-webui /Users/xuefusong/.hermes/hermes-agent/.venv/bin/python -m unittest discover -s tests -p 'test_sprint41.py' -v`
