### PR TITLE
fix(csp): allow external https images in img-src — closes #608

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Hermes Web UI -- Changelog
 
+## [v0.50.76] — 2026-04-17
+
+### Fixed
+- **CSP blocked external images in chat** — `img-src` in the Content Security Policy was restricted to `'self'` and `data:`, causing the browser to block any external image URLs (e.g. from Wikipedia, GitHub, or other HTTPS sources) that the agent rendered in a response. Expanded to `img-src 'self' data: https: blob:` so external images load correctly. (Closes #608)
+
 ## [v0.50.75] — 2026-04-17
 
 ### Fixed

--- a/api/helpers.py
+++ b/api/helpers.py
@@ -45,7 +45,7 @@ def _security_headers(handler):
         "default-src 'self'; "
         "script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; "
         "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; "
-        "img-src 'self' data:; font-src 'self' data: https://cdn.jsdelivr.net; connect-src 'self'; "
+        "img-src 'self' data: https: blob:; font-src 'self' data: https://cdn.jsdelivr.net; connect-src 'self'; "
         "base-uri 'self'; form-action 'self'"
     )
     handler.send_header(

--- a/static/index.html
+++ b/static/index.html
@@ -561,7 +561,7 @@
                 <div class="settings-section-title">System</div>
                 <div class="settings-section-meta">Instance version and access controls.</div>
               </div>
-              <span class="settings-version-badge">v0.50.75</span>
+              <span class="settings-version-badge">v0.50.76</span>
             </div>
             <div class="settings-field" style="border-top:1px solid var(--border);padding-top:12px;margin-top:8px">
               <label for="settingsPassword" data-i18n="settings_label_password">Access Password</label>


### PR DESCRIPTION
## Problem

The app's Content Security Policy set `img-src 'self' data:`, which caused browsers to block any external image URLs rendered in chat responses (e.g. images from Wikipedia, GitHub, or any HTTPS source). The user would see the image tag in the response but the browser would silently block the load with a CSP violation.

Diagnosed via browser DevTools network tab — multiple CSP-blocked requests to `upload.wikimedia.org` confirmed the source.

Closes #608

## Change

In `api/helpers.py`, expand `img-src` from:
```
img-src 'self' data:;
```
to:
```
img-src 'self' data: https: blob:;
```

- `https:` allows any external image over HTTPS (the common case for agent-rendered images)
- `blob:` allows locally generated object URLs (e.g. canvas exports, future media features)
- `'self'` and `data:` preserved as before

## Testing

- 1373 tests passing, 0 skipped
- One-line change to CSP header only — no logic changes

## Note

This fix addresses external HTTPS image URLs in responses. The separate issue of workspace-served images using `localhost` instead of the real server IP (for remote access scenarios) is a distinct problem and tracked separately in #608.
