### PR TITLE
feat: custom wallpaper background with brightness adjustment

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -1759,7 +1759,7 @@ Each has automated API-level tests in `tests/test_sprint{N}.py`.
 - [ ] Brightness change without Save → close panel via Discard → reverts
 - [ ] Brightness change with Save → close + reopen panel → slider stays at saved value
 - [ ] Page reload → wallpaper + brightness persist
-- [ ] Upload 6MB+ file → toast "too large", original wallpaper unchanged
+- [ ] Upload 11MB+ file → centered modal alert "too large (max 10MB)" appears (NOT a corner toast); original wallpaper unchanged
 - [ ] Rename `.svg` to `.jpg` and upload → toast "must be JPEG/PNG/WebP" (backend magic-byte check)
 - [ ] Upload new image → old image file replaced (`ls ~/.hermes/webui/wallpaper-*` shows only one)
 - [ ] Click Remove → wallpaper disappears, theme color returns

--- a/TESTING.md
+++ b/TESTING.md
@@ -1749,6 +1749,25 @@ Each has automated API-level tests in `tests/test_sprint{N}.py`.
 
 ---
 
+## Wallpaper (manual checklist)
+
+- [ ] Settings panel shows Wallpaper section under Theme dropdown
+- [ ] Upload JPEG → wallpaper visible immediately, brightness defaults 60%
+- [ ] Upload PNG → works
+- [ ] Upload WebP → works
+- [ ] Drag brightness slider to 30% → live dimming (no Save needed)
+- [ ] Brightness change without Save → close panel via Discard → reverts
+- [ ] Brightness change with Save → close + reopen panel → slider stays at saved value
+- [ ] Page reload → wallpaper + brightness persist
+- [ ] Upload 6MB+ file → toast "too large", original wallpaper unchanged
+- [ ] Rename `.svg` to `.jpg` and upload → toast "must be JPEG/PNG/WebP" (backend magic-byte check)
+- [ ] Upload new image → old image file replaced (`ls ~/.hermes/webui/wallpaper-*` shows only one)
+- [ ] Click Remove → wallpaper disappears, theme color returns
+- [ ] Switch theme (dark → light → slate, etc.) → wallpaper unchanged; theme color is visible fallback when no wallpaper
+- [ ] DevTools Network tab: second `/api/wallpaper?v=<hash>` request hits browser cache (Status 200 from disk cache)
+
+---
+
 *Last updated: v0.50.44, April 16, 2026*
 *Total automated tests collected: 1353*
 *Regression gate: tests/test_regressions.py*

--- a/api/config.py
+++ b/api/config.py
@@ -344,6 +344,7 @@ def verify_hermes_imports() -> tuple:
 # ── Limits ───────────────────────────────────────────────────────────────────
 MAX_FILE_BYTES = 200_000
 MAX_UPLOAD_BYTES = 20 * 1024 * 1024
+MAX_WALLPAPER_BYTES = 5_000_000  # 5MB cap for /api/wallpaper uploads
 
 # ── File type maps ───────────────────────────────────────────────────────────
 IMAGE_EXTS = {".png", ".jpg", ".jpeg", ".gif", ".svg", ".webp", ".ico", ".bmp"}
@@ -1224,6 +1225,7 @@ _SETTINGS_DEFAULTS = {
     "sound_enabled": False,  # play notification sound when assistant finishes
     "notifications_enabled": False,  # browser notification when tab is in background
     "bubble_layout": False,  # right-aligned user / left-aligned assistant chat bubbles
+    "wallpaper_file": None,  # filename of current wallpaper in STATE_DIR; None = no wallpaper
     "password_hash": None,  # PBKDF2-HMAC-SHA256 hash; None = auth disabled
 }
 _SETTINGS_LEGACY_DROP_KEYS = {"assistant_language"}

--- a/api/config.py
+++ b/api/config.py
@@ -344,7 +344,7 @@ def verify_hermes_imports() -> tuple:
 # ── Limits ───────────────────────────────────────────────────────────────────
 MAX_FILE_BYTES = 200_000
 MAX_UPLOAD_BYTES = 20 * 1024 * 1024
-MAX_WALLPAPER_BYTES = 5_000_000  # 5MB cap for /api/wallpaper uploads
+MAX_WALLPAPER_BYTES = 10_000_000  # 10MB cap for /api/wallpaper uploads
 
 # ── File type maps ───────────────────────────────────────────────────────────
 IMAGE_EXTS = {".png", ".jpg", ".jpeg", ".gif", ".svg", ".webp", ".ico", ".bmp"}

--- a/api/config.py
+++ b/api/config.py
@@ -1226,6 +1226,7 @@ _SETTINGS_DEFAULTS = {
     "notifications_enabled": False,  # browser notification when tab is in background
     "bubble_layout": False,  # right-aligned user / left-aligned assistant chat bubbles
     "wallpaper_file": None,  # filename of current wallpaper in STATE_DIR; None = no wallpaper
+    "wallpaper_brightness": 0.6,  # CSS filter brightness multiplier applied to wallpaper [0.1, 1.5]
     "password_hash": None,  # PBKDF2-HMAC-SHA256 hash; None = auth disabled
 }
 _SETTINGS_LEGACY_DROP_KEYS = {"assistant_language"}
@@ -1261,6 +1262,10 @@ _SETTINGS_ALLOWED_KEYS = set(_SETTINGS_DEFAULTS.keys()) - {"password_hash"}
 _SETTINGS_ENUM_VALUES = {
     "send_key": {"enter", "ctrl+enter"},
 }
+# Float-range validators: key -> (min, max) inclusive.
+_SETTINGS_FLOAT_RANGES = {
+    "wallpaper_brightness": (0.1, 1.5),
+}
 _SETTINGS_BOOL_KEYS = {
     "onboarding_completed",
     "show_token_usage",
@@ -1274,49 +1279,61 @@ _SETTINGS_BOOL_KEYS = {
 # Language codes are validated as short alphanumeric BCP-47-like tags (e.g. 'en', 'zh', 'fr')
 _SETTINGS_LANG_RE = __import__("re").compile(r"^[a-zA-Z]{2,10}(-[a-zA-Z0-9]{2,8})?$")
 
+_SETTINGS_WRITE_LOCK = threading.Lock()
+
 
 def save_settings(settings: dict) -> dict:
     """Save settings to disk. Returns the merged settings. Ignores unknown keys."""
-    current = load_settings()
-    # Handle _set_password: hash and store as password_hash
-    raw_pw = settings.pop("_set_password", None)
-    if raw_pw and isinstance(raw_pw, str) and raw_pw.strip():
-        # Use PBKDF2 from auth module (600k iterations) -- never raw SHA-256
-        from api.auth import _hash_password
+    with _SETTINGS_WRITE_LOCK:
+        current = load_settings()
+        # Handle _set_password: hash and store as password_hash
+        raw_pw = settings.pop("_set_password", None)
+        if raw_pw and isinstance(raw_pw, str) and raw_pw.strip():
+            # Use PBKDF2 from auth module (600k iterations) -- never raw SHA-256
+            from api.auth import _hash_password
 
-        current["password_hash"] = _hash_password(raw_pw.strip())
-    # Handle _clear_password: explicitly disable auth
-    if settings.pop("_clear_password", False):
-        current["password_hash"] = None
-    for k, v in settings.items():
-        if k in _SETTINGS_ALLOWED_KEYS:
-            # Validate enum-constrained keys
-            if k in _SETTINGS_ENUM_VALUES and v not in _SETTINGS_ENUM_VALUES[k]:
-                continue
-            # Validate language codes (BCP-47-like: 'en', 'zh', 'fr', 'zh-CN')
-            if k == "language" and (
-                not isinstance(v, str) or not _SETTINGS_LANG_RE.match(v)
-            ):
-                continue
-            # Coerce bool keys
-            if k in _SETTINGS_BOOL_KEYS:
-                v = bool(v)
-            current[k] = v
+            current["password_hash"] = _hash_password(raw_pw.strip())
+        # Handle _clear_password: explicitly disable auth
+        if settings.pop("_clear_password", False):
+            current["password_hash"] = None
+        for k, v in settings.items():
+            if k in _SETTINGS_ALLOWED_KEYS:
+                # Validate enum-constrained keys
+                if k in _SETTINGS_ENUM_VALUES and v not in _SETTINGS_ENUM_VALUES[k]:
+                    continue
+                # Validate float-range-constrained keys
+                if k in _SETTINGS_FLOAT_RANGES:
+                    lo, hi = _SETTINGS_FLOAT_RANGES[k]
+                    # bool is a subclass of int -- exclude it explicitly so True (=1.0) doesn't sneak in
+                    if not isinstance(v, (int, float)) or isinstance(v, bool):
+                        continue
+                    if not (lo <= v <= hi):
+                        continue
+                    v = float(v)
+                # Validate language codes (BCP-47-like: 'en', 'zh', 'fr', 'zh-CN')
+                if k == "language" and (
+                    not isinstance(v, str) or not _SETTINGS_LANG_RE.match(v)
+                ):
+                    continue
+                # Coerce bool keys
+                if k in _SETTINGS_BOOL_KEYS:
+                    v = bool(v)
+                current[k] = v
 
-    current["default_workspace"] = str(
-        resolve_default_workspace(current.get("default_workspace"))
-    )
-    SETTINGS_FILE.write_text(
-        json.dumps(current, ensure_ascii=False, indent=2),
-        encoding="utf-8",
-    )
-    # Update runtime defaults so new sessions use them immediately
-    global DEFAULT_MODEL, DEFAULT_WORKSPACE
-    if "default_model" in current:
-        DEFAULT_MODEL = current["default_model"]
-    if "default_workspace" in current:
-        DEFAULT_WORKSPACE = resolve_default_workspace(current["default_workspace"])
-    return current
+        current["default_workspace"] = str(
+            resolve_default_workspace(current.get("default_workspace"))
+        )
+        SETTINGS_FILE.write_text(
+            json.dumps(current, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+        # Update runtime defaults so new sessions use them immediately
+        global DEFAULT_MODEL, DEFAULT_WORKSPACE
+        if "default_model" in current:
+            DEFAULT_MODEL = current["default_model"]
+        if "default_workspace" in current:
+            DEFAULT_WORKSPACE = resolve_default_workspace(current["default_workspace"])
+        return current
 
 
 # Apply saved settings on startup (override env-derived defaults)

--- a/api/config.py
+++ b/api/config.py
@@ -1278,6 +1278,10 @@ _SETTINGS_BOOL_KEYS = {
 }
 # Language codes are validated as short alphanumeric BCP-47-like tags (e.g. 'en', 'zh', 'fr')
 _SETTINGS_LANG_RE = __import__("re").compile(r"^[a-zA-Z]{2,10}(-[a-zA-Z0-9]{2,8})?$")
+# wallpaper_file must match the exact format save_wallpaper() writes:
+# wallpaper-<8 hex chars>.{jpg,png,webp}.  Anchored ^...$ to prevent
+# any path-segment or absolute-path injection via /api/settings.
+_SETTINGS_WALLPAPER_FILE_RE = __import__("re").compile(r"^wallpaper-[0-9a-f]{8}\.(jpg|png|webp)$")
 
 _SETTINGS_WRITE_LOCK = threading.Lock()
 
@@ -1313,6 +1317,17 @@ def save_settings(settings: dict) -> dict:
                 # Validate language codes (BCP-47-like: 'en', 'zh', 'fr', 'zh-CN')
                 if k == "language" and (
                     not isinstance(v, str) or not _SETTINGS_LANG_RE.match(v)
+                ):
+                    continue
+                # Validate wallpaper_file: must be None, or the exact filename
+                # format that save_wallpaper() writes (wallpaper-<8 hex>.{jpg,png,webp}).
+                # Without this guard, a malicious POST /api/settings can store an
+                # arbitrary path/filename and read any image-readable file on disk
+                # via GET /api/wallpaper. (The magic-byte sniff in read_wallpaper
+                # blocks non-image files, but legit images outside STATE_DIR would
+                # otherwise leak.)
+                if k == "wallpaper_file" and v is not None and (
+                    not isinstance(v, str) or not _SETTINGS_WALLPAPER_FILE_RE.match(v)
                 ):
                     continue
                 # Coerce bool keys

--- a/api/routes.py
+++ b/api/routes.py
@@ -636,6 +636,44 @@ def handle_get(handler, parsed) -> bool:
     if parsed.path == "/api/media":
         return _handle_media(handler, parsed)
 
+    if parsed.path == "/api/wallpaper":
+        from api.wallpaper import read_wallpaper
+        try:
+            raw, mime, etag = read_wallpaper()
+        except FileNotFoundError as e:
+            return bad(handler, str(e), 404)
+        handler.send_response(200)
+        handler.send_header("Content-Type", mime)
+        handler.send_header("Content-Length", str(len(raw)))
+        handler.send_header("Cache-Control", "public, max-age=31536000, immutable")
+        handler.send_header("ETag", f'"{etag}"')
+        handler.end_headers()
+        handler.wfile.write(raw)
+        return
+
+    if parsed.path == "/api/wallpaper/info":
+        from api.wallpaper import get_wallpaper_path, read_wallpaper
+        settings = load_settings()
+        path = get_wallpaper_path()
+        if path is None:
+            return j(handler, {
+                "has_wallpaper": False,
+                "brightness": float(settings.get("wallpaper_brightness", 0.6)),
+                "mime": None,
+                "file": None,
+            })
+        try:
+            _raw, mime, etag = read_wallpaper()
+        except FileNotFoundError:
+            mime = None
+            etag = None
+        return j(handler, {
+            "has_wallpaper": True,
+            "brightness": float(settings.get("wallpaper_brightness", 0.6)),
+            "mime": mime,
+            "file": settings.get("wallpaper_file"),
+        })
+
     if parsed.path == "/api/file/raw":
         return _handle_file_raw(handler, parsed)
 
@@ -756,6 +794,45 @@ def handle_post(handler, parsed) -> bool:
 
     if parsed.path == "/api/transcribe":
         return handle_transcribe(handler)
+
+    if parsed.path == "/api/wallpaper":
+        from api.config import MAX_WALLPAPER_BYTES
+        from api.wallpaper import save_wallpaper
+        # Pre-check Content-Length so we don't read a huge body into memory
+        try:
+            content_length = int(handler.headers.get("Content-Length", 0))
+        except (TypeError, ValueError):
+            return bad(handler, "Content-Length required", 400)
+        if content_length <= 0:
+            return bad(handler, "Empty body", 400)
+        if content_length > MAX_WALLPAPER_BYTES:
+            # Drain the request body in chunks so the client doesn't get
+            # a broken-pipe error before it can read our 413 response.
+            remaining = content_length
+            while remaining > 0:
+                chunk = handler.rfile.read(min(remaining, 65536))
+                if not chunk:
+                    break
+                remaining -= len(chunk)
+            return bad(
+                handler,
+                f"wallpaper file too large (max {MAX_WALLPAPER_BYTES // 1_000_000}MB)",
+                413,
+            )
+        raw_body = handler.rfile.read(content_length)
+        try:
+            result = save_wallpaper(raw_body)
+        except ValueError as e:
+            # ValueError covers magic-byte and size violations (defensive size check)
+            msg = str(e)
+            code = 413 if "too large" in msg else 400
+            return bad(handler, msg, code)
+        return j(handler, {"ok": True, **result})
+
+    if parsed.path == "/api/wallpaper/delete":
+        from api.wallpaper import delete_wallpaper
+        delete_wallpaper()
+        return j(handler, {"ok": True})
 
     body = read_body(handler)
 

--- a/api/wallpaper.py
+++ b/api/wallpaper.py
@@ -1,0 +1,135 @@
+"""Wallpaper storage and serving.
+
+Stores a single user-uploaded image at STATE_DIR/wallpaper-<hash>.{ext}.
+The path is recorded in settings.json under 'wallpaper_file'. Magic-byte
+validation rejects anything that isn't a true JPEG/PNG/WebP, regardless
+of the client-supplied Content-Type.
+
+Public API:
+  save_wallpaper(raw_body) -> {'file': filename}
+  delete_wallpaper() -> None
+  get_wallpaper_path() -> Path | None
+  read_wallpaper() -> (bytes, mime, etag)
+"""
+from __future__ import annotations
+
+import hashlib
+import logging
+from pathlib import Path
+from typing import Tuple
+
+from api.config import MAX_WALLPAPER_BYTES, STATE_DIR
+from api.config import load_settings, save_settings
+
+logger = logging.getLogger(__name__)
+
+
+# Magic-byte signatures. WebP requires the offset-8 'WEBP' check;
+# 'RIFF' alone matches AVI / WAV containers.
+_JPEG_MAGIC = b'\xff\xd8\xff'
+_PNG_MAGIC = b'\x89PNG\r\n\x1a\n'
+
+# (extension, mime) per detected format
+_FORMATS = {
+    'jpeg': ('.jpg', 'image/jpeg'),
+    'png': ('.png', 'image/png'),
+    'webp': ('.webp', 'image/webp'),
+}
+
+
+def _sniff(raw: bytes) -> str | None:
+    """Return 'jpeg' | 'png' | 'webp' | None based on magic bytes.
+
+    Does not trust client Content-Type. Bytes 8..11 == 'WEBP' is required
+    for WebP detection (RIFF prefix alone is ambiguous with AVI/WAV).
+    """
+    if raw[:3] == _JPEG_MAGIC:
+        return 'jpeg'
+    if raw[:8] == _PNG_MAGIC:
+        return 'png'
+    if len(raw) >= 12 and raw[:4] == b'RIFF' and raw[8:12] == b'WEBP':
+        return 'webp'
+    return None
+
+
+def save_wallpaper(raw_body: bytes) -> dict:
+    """Validate, hash, and persist a wallpaper. Replaces the previous one.
+
+    Raises ValueError on size cap or magic-byte failure.
+    """
+    if len(raw_body) > MAX_WALLPAPER_BYTES:
+        raise ValueError(
+            f'wallpaper file too large (max {MAX_WALLPAPER_BYTES // 1_000_000}MB)'
+        )
+
+    fmt = _sniff(raw_body)
+    if fmt is None:
+        raise ValueError('wallpaper must be JPEG, PNG, or WebP')
+
+    ext, _mime = _FORMATS[fmt]
+    digest = hashlib.sha1(raw_body).hexdigest()[:8]
+    filename = f'wallpaper-{digest}{ext}'
+
+    # Single-slot replacement: remove any existing wallpaper file(s) first.
+    _purge_old_files()
+
+    target = STATE_DIR / filename
+    target.write_bytes(raw_body)
+
+    save_settings({'wallpaper_file': filename})
+
+    return {'file': filename}
+
+
+def delete_wallpaper() -> None:
+    """Remove the current wallpaper file and clear settings reference.
+
+    Idempotent: safe to call when no wallpaper is set.
+    """
+    _purge_old_files()
+    save_settings({'wallpaper_file': None})
+
+
+def get_wallpaper_path() -> Path | None:
+    """Return the current wallpaper file path, or None if not set / missing."""
+    settings = load_settings()
+    name = settings.get('wallpaper_file')
+    if not name:
+        return None
+    path = STATE_DIR / name
+    return path if path.exists() else None
+
+
+def read_wallpaper() -> Tuple[bytes, str, str]:
+    """Read the current wallpaper. Returns (bytes, mime, etag).
+
+    Raises FileNotFoundError if no wallpaper is set.
+    """
+    path = get_wallpaper_path()
+    if path is None:
+        raise FileNotFoundError('no wallpaper set')
+
+    raw = path.read_bytes()
+    fmt = _sniff(raw)
+    if fmt is None:
+        # Should be impossible if the file got through save_wallpaper, but
+        # defend against a manually-edited settings.json pointing at junk.
+        raise FileNotFoundError('wallpaper file is not a recognized image')
+    _ext, mime = _FORMATS[fmt]
+
+    # The hash in the filename is the etag (filename includes sha1[:8]).
+    etag = path.stem.removeprefix('wallpaper-')
+    return raw, mime, etag
+
+
+def _purge_old_files() -> None:
+    """Remove any wallpaper-*.{jpg,png,webp} files in STATE_DIR.
+
+    Used on upload (replace old before writing new) and on delete.
+    """
+    for pattern in ('wallpaper-*.jpg', 'wallpaper-*.png', 'wallpaper-*.webp'):
+        for p in STATE_DIR.glob(pattern):
+            try:
+                p.unlink()
+            except OSError as e:
+                logger.warning('failed to unlink old wallpaper %s: %s', p, e)

--- a/static/boot.js
+++ b/static/boot.js
@@ -673,6 +673,8 @@ function applyBotName(){
   if(profileLabel) profileLabel.textContent=S.activeProfile||'default';
   // Fetch available models from server and populate dropdown dynamically
   await populateModelDropdown();
+  // Apply wallpaper background (decorative — no await, slow load is fine)
+  if(typeof applyWallpaper === 'function') applyWallpaper();
   // Restore last-used model preference
   const savedModel=localStorage.getItem('hermes-webui-model');
   if(savedModel && $('modelSelect')){

--- a/static/i18n.js
+++ b/static/i18n.js
@@ -96,7 +96,7 @@ const LOCALES = {
     // wallpaper.js
     wallpaper_uploaded: 'Wallpaper applied',
     wallpaper_removed: 'Wallpaper removed',
-    wallpaper_size_too_large: 'Wallpaper file is too large (max 5MB).',
+    wallpaper_size_too_large: 'Wallpaper file is too large (max 10MB).',
     wallpaper_invalid_format: 'Wallpaper must be JPEG, PNG, or WebP.',
     wallpaper_label: 'Wallpaper',
     wallpaper_upload: 'Upload image',
@@ -519,7 +519,7 @@ const LOCALES = {
     // wallpaper.js
     wallpaper_uploaded: 'Fondo aplicado',
     wallpaper_removed: 'Fondo eliminado',
-    wallpaper_size_too_large: 'El archivo es demasiado grande (máx. 5 MB).',
+    wallpaper_size_too_large: 'El archivo es demasiado grande (máx. 10 MB).',
     wallpaper_invalid_format: 'El fondo debe ser JPEG, PNG o WebP.',
     wallpaper_label: 'Fondo',
     wallpaper_upload: 'Subir imagen',
@@ -932,7 +932,7 @@ const LOCALES = {
     // wallpaper.js
     wallpaper_uploaded: 'Hintergrund angewendet',
     wallpaper_removed: 'Hintergrund entfernt',
-    wallpaper_size_too_large: 'Die Datei ist zu groß (max. 5 MB).',
+    wallpaper_size_too_large: 'Die Datei ist zu groß (max. 10 MB).',
     wallpaper_invalid_format: 'Hintergrund muss JPEG, PNG oder WebP sein.',
     wallpaper_label: 'Hintergrund',
     wallpaper_upload: 'Bild hochladen',
@@ -1153,7 +1153,7 @@ const LOCALES = {
     // wallpaper.js
     wallpaper_uploaded: '壁纸已应用',
     wallpaper_removed: '壁纸已移除',
-    wallpaper_size_too_large: '壁纸文件过大（最大 5MB）。',
+    wallpaper_size_too_large: '壁纸文件过大（最大 10MB）。',
     wallpaper_invalid_format: '壁纸必须是 JPEG、PNG 或 WebP。',
     wallpaper_label: '壁纸',
     wallpaper_upload: '上传图片',
@@ -1565,7 +1565,7 @@ const LOCALES = {
     // wallpaper.js
     wallpaper_uploaded: '桌布已套用',
     wallpaper_removed: '桌布已移除',
-    wallpaper_size_too_large: '桌布檔案過大（最大 5MB）。',
+    wallpaper_size_too_large: '桌布檔案過大（最大 10MB）。',
     wallpaper_invalid_format: '桌布必須為 JPEG、PNG 或 WebP。',
     wallpaper_label: '桌布',
     wallpaper_upload: '上傳圖片',

--- a/static/i18n.js
+++ b/static/i18n.js
@@ -93,6 +93,15 @@ const LOCALES = {
     personality_cleared: 'Personality cleared',
     personality_set: 'Personality: ',
     failed_colon: 'Failed: ',
+    // wallpaper.js
+    wallpaper_uploaded: 'Wallpaper applied',
+    wallpaper_removed: 'Wallpaper removed',
+    wallpaper_size_too_large: 'Wallpaper file is too large (max 5MB).',
+    wallpaper_invalid_format: 'Wallpaper must be JPEG, PNG, or WebP.',
+    wallpaper_label: 'Wallpaper',
+    wallpaper_upload: 'Upload image',
+    wallpaper_remove: 'Remove',
+    wallpaper_brightness_label: 'Brightness',
     // ui.js
     no_workspace: 'No workspace',
     dialog_confirm_title: 'Confirm action',
@@ -507,6 +516,15 @@ const LOCALES = {
     personality_cleared: 'Personalidad borrada',
     personality_set: 'Personalidad: ',
     failed_colon: 'Error: ',
+    // wallpaper.js
+    wallpaper_uploaded: 'Fondo aplicado',
+    wallpaper_removed: 'Fondo eliminado',
+    wallpaper_size_too_large: 'El archivo es demasiado grande (máx. 5 MB).',
+    wallpaper_invalid_format: 'El fondo debe ser JPEG, PNG o WebP.',
+    wallpaper_label: 'Fondo',
+    wallpaper_upload: 'Subir imagen',
+    wallpaper_remove: 'Quitar',
+    wallpaper_brightness_label: 'Brillo',
     // ui.js
     no_workspace: 'Sin espacio de trabajo',
     // workspace.js
@@ -911,6 +929,15 @@ const LOCALES = {
     personality_cleared: 'Persönlichkeit gelöscht',
     personality_set: 'Persönlichkeit: ',
     failed_colon: 'Fehlgeschlagen: ',
+    // wallpaper.js
+    wallpaper_uploaded: 'Hintergrund angewendet',
+    wallpaper_removed: 'Hintergrund entfernt',
+    wallpaper_size_too_large: 'Die Datei ist zu groß (max. 5 MB).',
+    wallpaper_invalid_format: 'Hintergrund muss JPEG, PNG oder WebP sein.',
+    wallpaper_label: 'Hintergrund',
+    wallpaper_upload: 'Bild hochladen',
+    wallpaper_remove: 'Entfernen',
+    wallpaper_brightness_label: 'Helligkeit',
     // ui.js
     no_workspace: 'Kein Workspace',
     dialog_confirm_title: 'Aktion bestätigen',
@@ -1123,6 +1150,15 @@ const LOCALES = {
     personality_cleared: '\u4eba\u8bbe\u5df2\u6e05\u7a7a',
     personality_set: '\u5f53\u524d\u4eba\u8bbe\uff1a',
     failed_colon: '\u5931\u8d25\uff1a',
+    // wallpaper.js
+    wallpaper_uploaded: '壁纸已应用',
+    wallpaper_removed: '壁纸已移除',
+    wallpaper_size_too_large: '壁纸文件过大（最大 5MB）。',
+    wallpaper_invalid_format: '壁纸必须是 JPEG、PNG 或 WebP。',
+    wallpaper_label: '壁纸',
+    wallpaper_upload: '上传图片',
+    wallpaper_remove: '移除',
+    wallpaper_brightness_label: '亮度',
     // ui.js
     no_workspace: '\u672a\u9009\u62e9\u5de5\u4f5c\u533a',
     dialog_confirm_title: '\u786e\u8ba4\u64cd\u4f5c',
@@ -1526,6 +1562,15 @@ const LOCALES = {
     personality_cleared: '\u4eba\u8a2d\u5df2\u6e05\u7a7a',
     personality_set: '\u7576\u524d\u4eba\u8a2d\uff1a',
     failed_colon: '\u5931\u6557\uff1a',
+    // wallpaper.js
+    wallpaper_uploaded: '桌布已套用',
+    wallpaper_removed: '桌布已移除',
+    wallpaper_size_too_large: '桌布檔案過大（最大 5MB）。',
+    wallpaper_invalid_format: '桌布必須為 JPEG、PNG 或 WebP。',
+    wallpaper_label: '桌布',
+    wallpaper_upload: '上傳圖片',
+    wallpaper_remove: '移除',
+    wallpaper_brightness_label: '亮度',
     // ui.js
     no_workspace: '\u672a\u9078\u64c7\u5de5\u4f5c\u5340',
     // workspace.js

--- a/static/index.html
+++ b/static/index.html
@@ -498,6 +498,10 @@
             </div>
             <div class="settings-field">
               <label data-i18n="wallpaper_label">Wallpaper</label>
+              <div id="settingsWallpaperPreviewWrap" style="display:none;margin-bottom:10px;">
+                <div id="settingsWallpaperPreview" style="width:100%;height:120px;border-radius:8px;border:1px solid var(--border2);background-size:cover;background-position:center;background-repeat:no-repeat;background-color:rgba(255,255,255,.04);"></div>
+                <div id="settingsWallpaperFilename" style="font-size:11px;color:var(--muted);margin-top:4px;text-align:center;font-family:monospace;"></div>
+              </div>
               <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
                 <input type="file" id="settingsWallpaperFile" accept="image/jpeg,image/png,image/webp" style="flex:1;font-size:12px;color:var(--text);">
                 <button type="button" id="settingsWallpaperRemove" data-i18n="wallpaper_remove" style="padding:6px 10px;border-radius:6px;border:1px solid var(--border2);background:rgba(255,255,255,.06);color:var(--text);cursor:pointer;font-size:12px;">Remove</button>

--- a/static/index.html
+++ b/static/index.html
@@ -20,6 +20,7 @@
   <script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/plugins/autoloader/prism-autoloader.min.js" integrity="sha384-Uq05+JLko69eOiPr39ta9bh7kld5PKZoU+fF7g0EXTAriEollhZ+DrN8Q/Oi8J2Q" crossorigin="anonymous" defer></script>
 </head>
 <body>
+<div id="wallpaper"></div>
 <div class="layout">
   <aside class="sidebar">
 

--- a/static/index.html
+++ b/static/index.html
@@ -497,6 +497,17 @@
               </select>
             </div>
             <div class="settings-field">
+              <label data-i18n="wallpaper_label">Wallpaper</label>
+              <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
+                <input type="file" id="settingsWallpaperFile" accept="image/jpeg,image/png,image/webp" style="flex:1;font-size:12px;color:var(--text);">
+                <button type="button" id="settingsWallpaperRemove" data-i18n="wallpaper_remove" style="padding:6px 10px;border-radius:6px;border:1px solid var(--border2);background:rgba(255,255,255,.06);color:var(--text);cursor:pointer;font-size:12px;">Remove</button>
+              </div>
+              <div style="margin-top:10px;">
+                <label for="settingsWallpaperBrightness" data-i18n="wallpaper_brightness_label" style="font-size:12px;color:var(--muted);">Brightness</label>
+                <input type="range" id="settingsWallpaperBrightness" min="10" max="150" step="5" value="60" style="width:100%;margin-top:4px;">
+              </div>
+            </div>
+            <div class="settings-field">
               <label for="settingsLanguage" data-i18n="settings_label_language">Language</label>
               <select id="settingsLanguage" style="width:100%;padding:8px;background:var(--code-bg);color:var(--text);border:1px solid var(--border2);border-radius:6px"></select>
             </div>

--- a/static/index.html
+++ b/static/index.html
@@ -605,6 +605,7 @@
 <script src="static/messages.js"></script>
 <script src="static/panels.js"></script>
 <script src="static/onboarding.js"></script>
+<script src="static/wallpaper.js"></script>
 <script src="static/boot.js"></script>
 </body>
 </html>

--- a/static/panels.js
+++ b/static/panels.js
@@ -1225,6 +1225,8 @@ async function loadSettingsPanel(){
     // Theme preference
     const themeSel=$('settingsTheme');
     if(themeSel){themeSel.value=settings.theme||'dark';themeSel.addEventListener('change',_markSettingsDirty,{once:false});}
+    // Refresh wallpaper preview (panel may open after applyWallpaper has already run)
+    if(typeof applyWallpaper === 'function') applyWallpaper();
     // Wallpaper brightness slider — load value from settings + capture for Discard
     const wpBrightSlider = $('settingsWallpaperBrightness');
     if(wpBrightSlider){

--- a/static/panels.js
+++ b/static/panels.js
@@ -1160,14 +1160,33 @@ function _revertSettingsPreview(){
   }
 }
 
-// Show the "Unsaved changes" bar inside the settings panel
+// Show the "Unsaved changes" bar inside the settings panel.
+// The bar uses position:sticky so it stays visible regardless of how
+// far the user has scrolled inside the settings body. We also scroll
+// it into view + briefly flash on (re)show so a click-to-close after
+// changes feels responsive (root cause of "X has no reaction" UX bug
+// when user scrolled below the bar).
 function _showSettingsUnsavedBar(){
   let bar = $('settingsUnsavedBar');
-  if(bar){ bar.style.display=''; return; }
+  const flash = () => {
+    if(!bar) return;
+    bar.style.transition = 'box-shadow .25s, transform .25s';
+    bar.style.boxShadow = '0 0 0 3px rgba(233,69,96,.55)';
+    bar.style.transform = 'scale(1.02)';
+    setTimeout(() => {
+      if(!bar) return;
+      bar.style.boxShadow = '';
+      bar.style.transform = '';
+    }, 250);
+    if(typeof bar.scrollIntoView === 'function'){
+      bar.scrollIntoView({behavior: 'smooth', block: 'nearest'});
+    }
+  };
+  if(bar){ bar.style.display=''; flash(); return; }
   // Create it
   bar = document.createElement('div');
   bar.id = 'settingsUnsavedBar';
-  bar.style.cssText = 'display:flex;align-items:center;justify-content:space-between;gap:8px;background:rgba(233,69,96,.12);border:1px solid rgba(233,69,96,.3);border-radius:8px;padding:10px 14px;margin:0 0 12px;font-size:13px;';
+  bar.style.cssText = 'position:sticky;top:0;z-index:5;display:flex;align-items:center;justify-content:space-between;gap:8px;background:rgba(233,69,96,.18);backdrop-filter:blur(6px);border:1px solid rgba(233,69,96,.45);border-radius:8px;padding:10px 14px;margin:0 0 12px;font-size:13px;';
   bar.innerHTML = `<span style="color:var(--text)">${esc(t('settings_unsaved_changes'))}</span>`
     + '<span style="display:flex;gap:8px">'
     + `<button onclick="_discardSettings()" style="padding:5px 12px;border-radius:6px;border:1px solid var(--border2);background:rgba(255,255,255,.06);color:var(--muted);cursor:pointer;font-size:12px;font-weight:600">${esc(t('discard'))}</button>`
@@ -1175,6 +1194,7 @@ function _showSettingsUnsavedBar(){
     + '</span>';
   const body = document.querySelector('.settings-main') || document.querySelector('.settings-body') || document.querySelector('.settings-panel');
   if(body) body.prepend(bar);
+  flash();
 }
 
 function _discardSettings(){

--- a/static/panels.js
+++ b/static/panels.js
@@ -1068,6 +1068,7 @@ document.addEventListener('drop',e=>{e.preventDefault();dragCounter=0;wrap.class
 
 let _settingsDirty = false;
 let _settingsThemeOnOpen = null; // track theme at open time for discard revert
+let _settingsBrightnessOnOpen = null; // track brightness at open time for discard revert
 let _settingsSection = 'conversation';
 
 function switchSettingsSection(name){
@@ -1154,6 +1155,9 @@ function _revertSettingsPreview(){
     if(typeof _applyTheme==='function') _applyTheme(_settingsThemeOnOpen);
     else document.documentElement.dataset.theme = _settingsThemeOnOpen;
   }
+  if(_settingsBrightnessOnOpen !== null && typeof setBrightness === 'function'){
+    setBrightness(_settingsBrightnessOnOpen * 100);  // setBrightness expects percent
+  }
 }
 
 // Show the "Unsaved changes" bar inside the settings panel
@@ -1221,6 +1225,38 @@ async function loadSettingsPanel(){
     // Theme preference
     const themeSel=$('settingsTheme');
     if(themeSel){themeSel.value=settings.theme||'dark';themeSel.addEventListener('change',_markSettingsDirty,{once:false});}
+    // Wallpaper brightness slider — load value from settings + capture for Discard
+    const wpBrightSlider = $('settingsWallpaperBrightness');
+    if(wpBrightSlider){
+      const dec = (typeof settings.wallpaper_brightness === 'number') ? settings.wallpaper_brightness : 0.6;
+      wpBrightSlider.value = String(Math.round(dec * 100));
+      // Capture the at-open value so Discard can revert the live CSS variable
+      _settingsBrightnessOnOpen = dec;
+      wpBrightSlider.addEventListener('input', (e) => {
+        const pct = parseInt(e.target.value, 10);
+        if(typeof setBrightness === 'function') setBrightness(pct);
+        _markSettingsDirty();
+      });
+    }
+    // Wallpaper file picker — upload immediately on change (not save-gated)
+    const wpFile = $('settingsWallpaperFile');
+    if(wpFile){
+      wpFile.addEventListener('change', async (e) => {
+        const file = e.target.files && e.target.files[0];
+        if(file && typeof uploadWallpaper === 'function'){
+          await uploadWallpaper(file);
+          // Reset the input so re-selecting the same file fires another change event
+          e.target.value = '';
+        }
+      });
+    }
+    // Wallpaper remove button — also immediate (not save-gated)
+    const wpRemove = $('settingsWallpaperRemove');
+    if(wpRemove){
+      wpRemove.onclick = async () => {
+        if(typeof removeWallpaper === 'function') await removeWallpaper();
+      };
+    }
     // Language preference — populate from LOCALES bundle
     const langSel=$('settingsLanguage');
     if(langSel){
@@ -1324,6 +1360,14 @@ async function saveSettings(andClose){
   document.body.classList.toggle('bubble-layout', body.bubble_layout);
   const botName=(($('settingsBotName')||{}).value||'').trim();
   body.bot_name=botName||'Hermes';
+  // Wallpaper brightness: convert slider percent (10..150) back to decimal (0.1..1.5)
+  const wpBrightSlider = $('settingsWallpaperBrightness');
+  if(wpBrightSlider){
+    const pct = parseInt(wpBrightSlider.value, 10);
+    if(!isNaN(pct)){
+      body.wallpaper_brightness = Math.max(0.1, Math.min(1.5, pct / 100));
+    }
+  }
   // Password: only act if the field has content; blank = leave auth unchanged
   if(pw && pw.trim()){
     try{

--- a/static/style.css
+++ b/static/style.css
@@ -175,7 +175,8 @@
     --strong:#ffffff;--em:#c0c0d0;--code-text:#e8b86d;--code-inline-bg:rgba(255,255,255,.06);--pre-text:#d0d0d8;
     --input-bg:rgba(255,255,255,.03);--hover-bg:rgba(255,255,255,.05);
   }
-  body{background:var(--bg);color:var(--text);height:100vh;height:100dvh;overflow:hidden;display:flex;}
+  html{background:var(--bg);height:100%;}
+  body{background:transparent;color:var(--text);height:100vh;height:100dvh;overflow:hidden;display:flex;}
   .layout{display:flex;width:100%;height:100vh;height:100dvh;min-height:0;}
   .sidebar{width:300px;background:var(--sidebar);border-right:1px solid var(--border);display:flex;flex-direction:column;overflow:visible;flex-shrink:0;}
   .sidebar-header{padding:16px 18px 14px;border-bottom:1px solid var(--border);display:flex;align-items:center;gap:10px;}
@@ -1410,3 +1411,20 @@ body.bubble-layout .msg-row + .msg-row[data-role="user"] { border-top: none; pad
   .msg-row[data-role="user"] .msg-body { padding: 8px 12px; }
   .msg-row[data-error="1"] .msg-body { padding: 8px 12px; }
 }
+/* ── Wallpaper layer ─────────────────────────────────────────────────────
+   Fixed full-viewport background image, sits behind body content via
+   z-index:-1 (only visible because body has background:transparent).
+   Theme color from html{background:var(--bg)} is the fallback when no
+   wallpaper is set (data-active absent → display:none). */
+#wallpaper{
+  position:fixed;
+  inset:0;
+  z-index:-1;
+  background-size:cover;
+  background-position:center;
+  background-repeat:no-repeat;
+  filter:brightness(var(--wallpaper-brightness,1));
+  pointer-events:none;
+  display:none;
+}
+#wallpaper[data-active]{display:block;}

--- a/static/style.css
+++ b/static/style.css
@@ -511,7 +511,7 @@
   .suggestion{padding:12px 14px;background:var(--input-bg);border:1px solid var(--border);border-radius:10px;font-size:13px;color:var(--muted);cursor:pointer;transition:all .15s;text-align:left;}
   .suggestion:hover{background:rgba(124,185,255,0.07);color:var(--text);border-color:rgba(124,185,255,.3);transform:translateX(2px);}
   /* ── Composer ── */
-  .composer-wrap{padding:12px 20px 16px;background:var(--bg);flex-shrink:0;}
+  .composer-wrap{padding:12px 20px 16px;background:transparent;flex-shrink:0;}
   .composer-box{max-width:780px;margin:0 auto;background:linear-gradient(var(--input-bg),var(--input-bg)),var(--bg);border:1px solid var(--border2);border-radius:16px;display:flex;flex-direction:column;transition:border-color .2s,box-shadow .2s;position:relative;z-index:2;}
   .composer-box:focus-within{border-color:rgba(124,185,255,0.5);box-shadow:0 0 0 3px rgba(124,185,255,0.08);}
   .composer-wrap.drag-over .composer-box{border-color:var(--blue);background:rgba(124,185,255,0.06);}

--- a/static/wallpaper.js
+++ b/static/wallpaper.js
@@ -14,7 +14,7 @@
 const _WALLPAPER_ALLOWED_TYPES = new Set([
   'image/jpeg', 'image/png', 'image/webp',
 ]);
-const _WALLPAPER_MAX_BYTES = 5_000_000;
+const _WALLPAPER_MAX_BYTES = 10_000_000;
 
 async function applyWallpaper(){
   let info;
@@ -55,7 +55,7 @@ async function uploadWallpaper(file){
     return;
   }
   if(file.size > _WALLPAPER_MAX_BYTES){
-    showToast(t('wallpaper_size_too_large'));
+    showCenterAlert(t('wallpaper_size_too_large'));
     return;
   }
   try{
@@ -69,7 +69,13 @@ async function uploadWallpaper(file){
     if(!res.ok){
       let msg;
       try{ msg = (await res.json()).error; }catch(_){ msg = await res.text(); }
-      showToast(msg || ('Upload failed: ' + res.status));
+      // Backend rejects oversize with HTTP 413; surface in the prominent
+      // center alert so users notice immediately, not a corner toast.
+      if(res.status === 413){
+        showCenterAlert(msg || t('wallpaper_size_too_large'));
+      }else{
+        showToast(msg || ('Upload failed: ' + res.status));
+      }
       return;
     }
     await applyWallpaper();
@@ -93,4 +99,71 @@ function setBrightness(percent){
   // Slider is 10..150; CSS variable expects 0.1..1.5.
   const decimal = Math.max(0.1, Math.min(1.5, percent / 100));
   document.documentElement.style.setProperty('--wallpaper-brightness', String(decimal));
+}
+
+// ── Center alert ───────────────────────────────────────────────────────────
+// Prominent center-of-screen modal for important warnings (e.g. file too
+// large) where a corner toast is too easy to miss. Auto-dismisses after
+// 4s and on click/Escape. Uses inline styles so it works without CSS edits
+// and doesn't depend on theme variables (always visible regardless of bg).
+function showCenterAlert(msg){
+  // Remove any existing alert before showing a new one
+  const existing = document.getElementById('wallpaperCenterAlert');
+  if(existing) existing.remove();
+
+  const overlay = document.createElement('div');
+  overlay.id = 'wallpaperCenterAlert';
+  overlay.style.cssText = [
+    'position:fixed', 'inset:0', 'z-index:99999',
+    'display:flex', 'align-items:center', 'justify-content:center',
+    'background:rgba(0,0,0,0.45)', 'backdrop-filter:blur(2px)',
+    'animation:fadeIn 0.15s ease-out',
+  ].join(';');
+
+  const card = document.createElement('div');
+  card.style.cssText = [
+    'max-width:420px', 'min-width:280px',
+    'padding:24px 28px', 'border-radius:12px',
+    'background:#2a1f2e', 'color:#fff',
+    'border:1px solid rgba(233,69,96,0.55)',
+    'box-shadow:0 10px 40px rgba(0,0,0,0.5)',
+    'font-size:15px', 'line-height:1.5',
+    'text-align:center',
+  ].join(';');
+
+  const icon = document.createElement('div');
+  icon.textContent = '⚠️';
+  icon.style.cssText = 'font-size:36px;margin-bottom:8px;';
+  card.appendChild(icon);
+
+  const text = document.createElement('div');
+  text.textContent = msg;
+  text.style.cssText = 'margin-bottom:14px;color:#f0e0e0;';
+  card.appendChild(text);
+
+  const btn = document.createElement('button');
+  btn.textContent = 'OK';
+  btn.style.cssText = [
+    'padding:7px 20px', 'border-radius:6px', 'border:none',
+    'background:rgba(233,69,96,0.85)', 'color:#fff',
+    'cursor:pointer', 'font-size:14px', 'font-weight:600',
+  ].join(';');
+  card.appendChild(btn);
+
+  overlay.appendChild(card);
+
+  function dismiss(){
+    overlay.remove();
+    document.removeEventListener('keydown', onKey);
+  }
+  function onKey(e){
+    if(e.key === 'Escape' || e.key === 'Enter') dismiss();
+  }
+  overlay.onclick = (e) => { if(e.target === overlay) dismiss(); };
+  btn.onclick = dismiss;
+  document.addEventListener('keydown', onKey);
+
+  document.body.appendChild(overlay);
+  // Auto-dismiss after 4s in case user walks away
+  setTimeout(() => { if(document.body.contains(overlay)) dismiss(); }, 4000);
 }

--- a/static/wallpaper.js
+++ b/static/wallpaper.js
@@ -35,15 +35,35 @@ async function applyWallpaper(){
     root.style.setProperty('--wallpaper-brightness', String(info.brightness));
   }
 
+  let imageUrl = '';
   if(info.has_wallpaper && info.file){
     // ?v=<hash> for cache busting -- file name itself includes the hash but
     // browsers may key cache by URL, so the query string is belt-and-suspenders.
     const hash = info.file.replace(/^wallpaper-/, '').replace(/\.[a-z]+$/, '');
-    div.style.backgroundImage = `url("/api/wallpaper?v=${encodeURIComponent(hash)}")`;
+    imageUrl = `/api/wallpaper?v=${encodeURIComponent(hash)}`;
+    div.style.backgroundImage = `url("${imageUrl}")`;
     div.setAttribute('data-active', '');
   }else{
     div.style.backgroundImage = '';
     div.removeAttribute('data-active');
+  }
+  // Mirror to settings-panel preview if present (panel may not be open).
+  _updateWallpaperPreview(imageUrl, info.file);
+}
+
+function _updateWallpaperPreview(imageUrl, filename){
+  const wrap = document.getElementById('settingsWallpaperPreviewWrap');
+  const preview = document.getElementById('settingsWallpaperPreview');
+  const nameEl = document.getElementById('settingsWallpaperFilename');
+  if(!wrap || !preview) return;
+  if(imageUrl){
+    preview.style.backgroundImage = `url("${imageUrl}")`;
+    if(nameEl) nameEl.textContent = filename || '';
+    wrap.style.display = '';
+  }else{
+    preview.style.backgroundImage = '';
+    if(nameEl) nameEl.textContent = '';
+    wrap.style.display = 'none';
   }
 }
 

--- a/static/wallpaper.js
+++ b/static/wallpaper.js
@@ -1,0 +1,96 @@
+// ── Wallpaper ──────────────────────────────────────────────────────────────
+// Applies a custom user-uploaded background image and brightness adjustment.
+// Storage is server-side at ~/.hermes/webui/wallpaper-<hash>.{ext}; brightness
+// is a CSS variable on :root, persisted in settings.json.
+//
+// Public API:
+//   applyWallpaper()           — boot + post-upload: read /api/wallpaper/info
+//                                and update DOM (wallpaper div + brightness var)
+//   uploadWallpaper(file)      — POST raw bytes to /api/wallpaper
+//   removeWallpaper()          — POST /api/wallpaper/delete + clear DOM
+//   setBrightness(percent)     — update --wallpaper-brightness CSS var
+//                                (does NOT persist; persistence is via Save in panel)
+
+const _WALLPAPER_ALLOWED_TYPES = new Set([
+  'image/jpeg', 'image/png', 'image/webp',
+]);
+const _WALLPAPER_MAX_BYTES = 5_000_000;
+
+async function applyWallpaper(){
+  let info;
+  try{
+    info = await api('/api/wallpaper/info');
+  }catch(e){
+    // Silent failure on boot -- user just sees theme color (fallback).
+    console.warn('applyWallpaper failed', e);
+    return;
+  }
+  const root = document.documentElement;
+  const div = document.getElementById('wallpaper');
+  if(!div) return;
+
+  // Brightness applies regardless of whether a wallpaper is set (no-op if
+  // no wallpaper, but the CSS var should still be in sync with settings).
+  if(typeof info.brightness === 'number'){
+    root.style.setProperty('--wallpaper-brightness', String(info.brightness));
+  }
+
+  if(info.has_wallpaper && info.file){
+    // ?v=<hash> for cache busting -- file name itself includes the hash but
+    // browsers may key cache by URL, so the query string is belt-and-suspenders.
+    const hash = info.file.replace(/^wallpaper-/, '').replace(/\.[a-z]+$/, '');
+    div.style.backgroundImage = `url("/api/wallpaper?v=${encodeURIComponent(hash)}")`;
+    div.setAttribute('data-active', '');
+  }else{
+    div.style.backgroundImage = '';
+    div.removeAttribute('data-active');
+  }
+}
+
+async function uploadWallpaper(file){
+  if(!file) return;
+  // Local pre-check: type + size
+  if(!_WALLPAPER_ALLOWED_TYPES.has(file.type)){
+    showToast(t('wallpaper_invalid_format'));
+    return;
+  }
+  if(file.size > _WALLPAPER_MAX_BYTES){
+    showToast(t('wallpaper_size_too_large'));
+    return;
+  }
+  try{
+    const buf = await file.arrayBuffer();
+    const res = await fetch('/api/wallpaper', {
+      method: 'POST',
+      credentials: 'include',
+      headers: {'Content-Type': file.type},
+      body: buf,
+    });
+    if(!res.ok){
+      let msg;
+      try{ msg = (await res.json()).error; }catch(_){ msg = await res.text(); }
+      showToast(msg || ('Upload failed: ' + res.status));
+      return;
+    }
+    await applyWallpaper();
+    showToast(t('wallpaper_uploaded'));
+  }catch(e){
+    showToast(t('failed_colon') + e.message);
+  }
+}
+
+async function removeWallpaper(){
+  try{
+    await api('/api/wallpaper/delete', {method:'POST', body:JSON.stringify({})});
+    await applyWallpaper();  // refreshes div to inactive state
+    showToast(t('wallpaper_removed'));
+  }catch(e){
+    showToast(t('failed_colon') + e.message);
+  }
+}
+
+function setBrightness(percent){
+  // Slider is 10..150; CSS variable expects 0.1..1.5.
+  const decimal = Math.max(0.1, Math.min(1.5, percent / 100));
+  document.documentElement.style.setProperty('--wallpaper-brightness', String(decimal));
+}

--- a/tests/test_wallpaper.py
+++ b/tests/test_wallpaper.py
@@ -122,3 +122,110 @@ def test_delete_wallpaper_when_unset_is_noop(isolated_state):
     from api.wallpaper import delete_wallpaper, get_wallpaper_path
     delete_wallpaper()  # must not raise
     assert get_wallpaper_path() is None
+
+
+# ── HTTP-level tests (against the test subprocess server) ──────────────────
+
+import urllib.request
+import urllib.error
+
+from tests.conftest import TEST_BASE, _post
+
+
+def _post_raw(path, body, mime):
+    """POST raw bytes (not JSON / not multipart) with the given Content-Type."""
+    req = urllib.request.Request(
+        TEST_BASE + path,
+        data=body,
+        headers={'Content-Type': mime},
+        method='POST',
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10) as r:
+            return r.status, json.loads(r.read())
+    except urllib.error.HTTPError as e:
+        try:
+            return e.code, json.loads(e.read())
+        except Exception:
+            return e.code, {}
+
+
+def _get_raw(path):
+    """GET raw bytes; returns (status, headers, body_bytes)."""
+    try:
+        with urllib.request.urlopen(TEST_BASE + path, timeout=10) as r:
+            return r.status, dict(r.headers), r.read()
+    except urllib.error.HTTPError as e:
+        return e.code, dict(e.headers), e.read()
+
+
+def _cleanup_wallpaper():
+    """Remove wallpaper via API after each HTTP test."""
+    try:
+        _post(TEST_BASE, '/api/wallpaper/delete', {})
+    except Exception:
+        pass
+
+
+def test_http_post_wallpaper_jpeg_happy_path():
+    status, body = _post_raw('/api/wallpaper', _JPEG_BYTES, 'image/jpeg')
+    try:
+        assert status == 200
+        assert body['ok'] is True
+        assert body['file'].startswith('wallpaper-') and body['file'].endswith('.jpg')
+
+        # GET /info should reflect new wallpaper
+        info_status, _hdrs, info_body = _get_raw('/api/wallpaper/info')
+        assert info_status == 200
+        info = json.loads(info_body)
+        assert info['has_wallpaper'] is True
+        assert info['mime'] == 'image/jpeg'
+    finally:
+        _cleanup_wallpaper()
+
+
+def test_http_get_wallpaper_returns_bytes_with_cache_headers():
+    _post_raw('/api/wallpaper', _PNG_BYTES, 'image/png')
+    try:
+        status, headers, body = _get_raw('/api/wallpaper')
+        assert status == 200
+        assert body == _PNG_BYTES
+        assert headers.get('Content-Type') == 'image/png'
+        cc = headers.get('Cache-Control', '')
+        assert 'immutable' in cc
+        assert 'max-age=' in cc
+        assert headers.get('ETag')  # any non-empty etag is fine
+    finally:
+        _cleanup_wallpaper()
+
+
+def test_http_get_wallpaper_404_when_unset():
+    _cleanup_wallpaper()  # ensure clean state
+    status, _hdrs, body_bytes = _get_raw('/api/wallpaper')
+    assert status == 404
+    assert json.loads(body_bytes)['error']  # any error message present
+
+
+def test_http_post_wallpaper_rejects_oversize():
+    from api.config import MAX_WALLPAPER_BYTES
+    oversize = _JPEG_BYTES + b'\x00' * (MAX_WALLPAPER_BYTES + 1)
+    status, body = _post_raw('/api/wallpaper', oversize, 'image/jpeg')
+    assert status == 413
+    assert 'too large' in body['error']
+
+
+def test_http_post_wallpaper_rejects_bad_magic():
+    # Fake jpeg Content-Type, but body is HTML
+    status, body = _post_raw('/api/wallpaper', _HTML_BYTES, 'image/jpeg')
+    assert status == 400
+    assert 'JPEG, PNG, or WebP' in body['error']
+
+
+def test_http_delete_wallpaper_clears_file_and_settings():
+    _post_raw('/api/wallpaper', _WEBP_BYTES, 'image/webp')
+    # Use POST /api/wallpaper/delete (DELETE method may not be supported)
+    resp = _post(TEST_BASE, '/api/wallpaper/delete', {})
+    assert resp.get('ok') is True
+    info_status, _hdrs, info_body = _get_raw('/api/wallpaper/info')
+    info = json.loads(info_body)
+    assert info['has_wallpaper'] is False

--- a/tests/test_wallpaper.py
+++ b/tests/test_wallpaper.py
@@ -1,0 +1,124 @@
+"""Unit and HTTP tests for the wallpaper feature.
+
+Chunk 1 tests run api.wallpaper functions directly using the test-process's
+own STATE_DIR isolation (we monkeypatch api.config to point STATE_DIR at
+a tmp_path). Later tests in Chunk 2 hit the live test subprocess server
+via HTTP.
+"""
+import hashlib
+import importlib
+import json
+import pathlib
+
+import pytest
+
+
+# Minimal valid file headers / bodies for each accepted format.
+# These are big enough for magic-byte sniffing and small enough to stay
+# under any size limits. Real images would be much larger but we don't
+# need a decode-able image -- just one whose magic bytes pass.
+_JPEG_BYTES = b'\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01\x01\x00\x00\x01\x00\x01\x00\x00' + b'\x00' * 100
+_PNG_BYTES = b'\x89PNG\r\n\x1a\n' + b'\x00' * 100
+_WEBP_BYTES = b'RIFF\x80\x00\x00\x00WEBP' + b'\x00' * 100  # 4 + 4 (size) + 4 + payload
+_SVG_BYTES = b'<?xml version="1.0"?><svg xmlns="http://www.w3.org/2000/svg"></svg>'
+_HTML_BYTES = b'<!DOCTYPE html><html></html>'
+
+
+@pytest.fixture
+def isolated_state(tmp_path, monkeypatch):
+    """Point STATE_DIR + SETTINGS_FILE to tmp_path so tests don't touch real state.
+
+    api.config reads SETTINGS_FILE at module level for some default-loading
+    code, but save_settings() / load_settings() re-read it each call, so
+    monkeypatching the module attribute works for all the call sites we use.
+    """
+    import api.config
+    monkeypatch.setattr(api.config, 'STATE_DIR', tmp_path)
+    monkeypatch.setattr(api.config, 'SETTINGS_FILE', tmp_path / 'settings.json')
+    # Force-reload api.wallpaper so its module-level imports of STATE_DIR
+    # pick up the patched value.
+    import api.wallpaper
+    importlib.reload(api.wallpaper)
+    try:
+        yield tmp_path
+    finally:
+        # Restore api.wallpaper's STATE_DIR binding to the real one so a
+        # future in-process test that doesn't use this fixture won't write
+        # into a deleted tmp_path.
+        importlib.reload(api.wallpaper)
+
+
+def test_save_wallpaper_jpeg_writes_file_and_settings(isolated_state):
+    from api.wallpaper import save_wallpaper, get_wallpaper_path
+    from api.config import load_settings
+
+    result = save_wallpaper(_JPEG_BYTES)
+    assert result['file'].startswith('wallpaper-')
+    assert result['file'].endswith('.jpg')
+
+    # File on disk
+    path = get_wallpaper_path()
+    assert path is not None
+    assert path.exists()
+    assert path.read_bytes() == _JPEG_BYTES
+
+    # settings.json updated
+    settings = load_settings()
+    assert settings['wallpaper_file'] == result['file']
+
+
+def test_save_wallpaper_png_and_webp(isolated_state):
+    from api.wallpaper import save_wallpaper
+
+    r1 = save_wallpaper(_PNG_BYTES)
+    assert r1['file'].endswith('.png')
+
+    r2 = save_wallpaper(_WEBP_BYTES)
+    assert r2['file'].endswith('.webp')
+
+
+def test_save_wallpaper_rejects_svg_and_html(isolated_state):
+    from api.wallpaper import save_wallpaper
+    with pytest.raises(ValueError, match='must be JPEG, PNG, or WebP'):
+        save_wallpaper(_SVG_BYTES)
+    with pytest.raises(ValueError, match='must be JPEG, PNG, or WebP'):
+        save_wallpaper(_HTML_BYTES)
+
+
+def test_save_wallpaper_rejects_oversize(isolated_state):
+    from api.wallpaper import save_wallpaper
+    from api.config import MAX_WALLPAPER_BYTES
+    oversize = _JPEG_BYTES + b'\x00' * (MAX_WALLPAPER_BYTES + 1)
+    with pytest.raises(ValueError, match='too large'):
+        save_wallpaper(oversize)
+
+
+def test_save_wallpaper_replaces_old_file(isolated_state):
+    """Uploading a second wallpaper deletes the first; only one file remains."""
+    from api.wallpaper import save_wallpaper
+
+    r1 = save_wallpaper(_JPEG_BYTES)
+    r2 = save_wallpaper(_PNG_BYTES + b'\xde\xad')  # different bytes -> different hash
+
+    files = sorted(p.name for p in isolated_state.glob('wallpaper-*'))
+    assert files == [r2['file']]
+    assert r2['file'] != r1['file']
+
+
+def test_delete_wallpaper_clears_file_and_settings(isolated_state):
+    from api.wallpaper import save_wallpaper, delete_wallpaper, get_wallpaper_path
+    from api.config import load_settings
+
+    save_wallpaper(_JPEG_BYTES)
+    delete_wallpaper()
+
+    assert get_wallpaper_path() is None
+    assert load_settings()['wallpaper_file'] is None
+    assert list(isolated_state.glob('wallpaper-*')) == []
+
+
+def test_delete_wallpaper_when_unset_is_noop(isolated_state):
+    """Calling delete with no wallpaper present is safe."""
+    from api.wallpaper import delete_wallpaper, get_wallpaper_path
+    delete_wallpaper()  # must not raise
+    assert get_wallpaper_path() is None

--- a/tests/test_wallpaper.py
+++ b/tests/test_wallpaper.py
@@ -229,3 +229,82 @@ def test_http_delete_wallpaper_clears_file_and_settings():
     info_status, _hdrs, info_body = _get_raw('/api/wallpaper/info')
     info = json.loads(info_body)
     assert info['has_wallpaper'] is False
+
+
+# ── settings: wallpaper_brightness ─────────────────────────────────────────
+
+def test_settings_brightness_default_and_save():
+    """save_settings accepts a valid brightness in range [0.1, 1.5]."""
+    resp = _post(TEST_BASE, '/api/settings', {'wallpaper_brightness': 0.5})
+    # /api/settings returns the merged settings as the full object
+    assert resp.get('wallpaper_brightness') == 0.5
+
+    # /info should reflect the new brightness
+    info_status, _hdrs, info_body = _get_raw('/api/wallpaper/info')
+    assert json.loads(info_body)['brightness'] == 0.5
+
+    # Reset for other tests
+    _post(TEST_BASE, '/api/settings', {'wallpaper_brightness': 0.6})
+
+
+def test_settings_brightness_out_of_range_silently_ignored():
+    """Out-of-range values are silently kept-as-old (existing webui convention)."""
+    _post(TEST_BASE, '/api/settings', {'wallpaper_brightness': 0.5})
+    # Try out-of-range
+    _post(TEST_BASE, '/api/settings', {'wallpaper_brightness': 2.0})
+    # Should still be 0.5
+    info_status, _hdrs, info_body = _get_raw('/api/wallpaper/info')
+    assert json.loads(info_body)['brightness'] == 0.5
+
+    # Wrong type (string) also ignored
+    _post(TEST_BASE, '/api/settings', {'wallpaper_brightness': 'foo'})
+    info_status, _hdrs, info_body = _get_raw('/api/wallpaper/info')
+    assert json.loads(info_body)['brightness'] == 0.5
+
+    # Reset
+    _post(TEST_BASE, '/api/settings', {'wallpaper_brightness': 0.6})
+
+
+def test_concurrent_settings_writes_dont_lose_fields():
+    """Two simultaneous /api/settings writes (one for theme, one for brightness)
+    must both persist. Without the write lock the second-to-finish would clobber
+    the other's just-loaded copy.
+    """
+    import threading
+
+    # Pin known starting state
+    _post(TEST_BASE, '/api/settings', {'theme': 'dark', 'wallpaper_brightness': 0.6})
+
+    errors = []
+
+    def write_theme():
+        try:
+            _post(TEST_BASE, '/api/settings', {'theme': 'light'})
+        except Exception as e:
+            errors.append(('theme', e))
+
+    def write_brightness():
+        try:
+            _post(TEST_BASE, '/api/settings', {'wallpaper_brightness': 0.4})
+        except Exception as e:
+            errors.append(('brightness', e))
+
+    # Fire both nearly simultaneously
+    t1 = threading.Thread(target=write_theme)
+    t2 = threading.Thread(target=write_brightness)
+    t1.start(); t2.start()
+    t1.join(); t2.join()
+    assert errors == []
+
+    # Both fields must have stuck
+    info_status, _hdrs, info_body = _get_raw('/api/wallpaper/info')
+    assert json.loads(info_body)['brightness'] == 0.4
+
+    # Re-fetch full settings via the existing GET to verify theme too
+    settings_status, _hdrs, settings_body = _get_raw('/api/settings')
+    settings = json.loads(settings_body)
+    assert settings['theme'] == 'light'
+    assert settings['wallpaper_brightness'] == 0.4
+
+    # Reset
+    _post(TEST_BASE, '/api/settings', {'theme': 'dark', 'wallpaper_brightness': 0.6})

--- a/tests/test_wallpaper.py
+++ b/tests/test_wallpaper.py
@@ -124,6 +124,63 @@ def test_delete_wallpaper_when_unset_is_noop(isolated_state):
     assert get_wallpaper_path() is None
 
 
+def test_save_settings_rejects_arbitrary_wallpaper_file_path(isolated_state, monkeypatch):
+    """save_settings() must reject wallpaper_file values that don't match the
+    'wallpaper-<8 hex>.{jpg,png,webp}' format save_wallpaper() writes.
+
+    Without this guard, a malicious POST /api/settings with
+    {"wallpaper_file": "/etc/passwd"} or {"wallpaper_file": "../../foo.jpg"}
+    would persist, and GET /api/wallpaper would happily serve any image
+    file readable by the webui process from anywhere on disk.
+    """
+    import api.config as config
+
+    # Pre-set a valid wallpaper_file to verify it's preserved when an
+    # invalid value is rejected (rejection should mean "leave as-is",
+    # not "wipe the field").
+    config.save_settings({"wallpaper_file": "wallpaper-deadbeef.jpg"})
+    assert config.load_settings()["wallpaper_file"] == "wallpaper-deadbeef.jpg"
+
+    bad_inputs = [
+        "/etc/passwd",                  # absolute system path
+        "../../etc/passwd",             # relative traversal
+        "../wallpaper-deadbeef.jpg",    # one-up-then-valid-name
+        "wallpaper-deadbeef.svg",       # disallowed extension
+        "wallpaper-DEADBEEF.jpg",       # wrong case (regex is lowercase-only)
+        "wallpaper-12345.jpg",          # wrong digest length (5 chars)
+        "wallpaper-deadbeefcafe.jpg",   # too-long digest
+        "wallpaper-deadbeef.jpg.gz",    # extension suffix
+        "myown.jpg",                    # not a wallpaper-* prefix
+        "",                             # empty string
+        123,                            # wrong type entirely
+        {"file": "x"},                  # dict
+    ]
+
+    for bad in bad_inputs:
+        config.save_settings({"wallpaper_file": bad})
+        assert config.load_settings()["wallpaper_file"] == "wallpaper-deadbeef.jpg", (
+            f"Invalid wallpaper_file value {bad!r} silently overwrote settings"
+        )
+
+    # Setting None must clear the field — "no wallpaper" is a valid state.
+    config.save_settings({"wallpaper_file": None})
+    assert config.load_settings()["wallpaper_file"] is None
+
+
+def test_save_settings_accepts_valid_wallpaper_file(isolated_state):
+    """The format save_wallpaper() actually writes must round-trip cleanly."""
+    import api.config as config
+
+    valid = "wallpaper-a1b2c3d4.png"
+    config.save_settings({"wallpaper_file": valid})
+    assert config.load_settings()["wallpaper_file"] == valid
+
+    for ext in ("jpg", "png", "webp"):
+        name = f"wallpaper-deadbeef.{ext}"
+        config.save_settings({"wallpaper_file": name})
+        assert config.load_settings()["wallpaper_file"] == name
+
+
 # ── HTTP-level tests (against the test subprocess server) ──────────────────
 
 import urllib.request


### PR DESCRIPTION
## Summary
- **Upload a custom background image** (JPEG / PNG / WebP, ≤ 10MB) from Settings → Theme → Wallpaper. Image fills the entire viewport behind all UI.
- **Brightness slider** (10–150%) with live CSS-variable preview; persisted in `settings.json` via the existing `/api/settings` POST flow.
- **Thumbnail preview** in the settings panel so users see what's currently set, with a **Remove** button to revert to the theme color.
- **Strict magic-byte validation** — rejects `.svg` / HTML / mis-tagged containers regardless of client `Content-Type`. WebP requires both `RIFF` prefix AND `WEBP` at offset 8 (catches mis-tagged AVI/WAV).
- **Centered modal alert** (not a corner toast) when uploading > 10MB, so the failure is unmissable.
- Single-slot file replacement: uploading a new image deletes the old one (via glob + unlink) before writing.
- Bonus: closes a pre-existing race in `save_settings` by adding `_SETTINGS_WRITE_LOCK` (covered by a dedicated concurrent-write test).

## Architecture notes
- Image stored at `~/.hermes/webui/wallpaper-<sha1[:8]>.{ext}`; filename hash doubles as cache buster (`Cache-Control: public, max-age=31536000, immutable`).
- Frontend uses a dedicated `<div id="wallpaper">` at `position:fixed; z-index:-1` with `filter: brightness(var(--wallpaper-brightness))`.
- **CSS change**: moves `background:var(--bg)` from `body` to `html`, sets `body{background:transparent}`. Theme color is the bottom-most fallback layer; semi-transparent chrome (`.main`, `.topbar`, `.composer-wrap`) composites the wallpaper through.
- Backend: 4 routes (`POST /api/wallpaper`, `POST /api/wallpaper/delete`, `GET /api/wallpaper`, `GET /api/wallpaper/info`) in 1 new module `api/wallpaper.py`.
- POST uses raw bytes with file's MIME as `Content-Type` — simpler than multipart for a single-file upload, no coupling to existing `parse_multipart` helper.

## Test plan
- [x] **16 new pytest cases** in `tests/test_wallpaper.py`: 7 unit (storage module + magic-byte) + 6 HTTP (endpoints + cache headers + error responses) + 3 settings (brightness range validator + concurrent write race)
- [x] Full webui suite: 1337 passed, 0 new regressions (2 pre-existing `test_model_resolver` failures unrelated)
- [x] Playwright end-to-end: 21/21 — boot with no wallpaper, upload + apply, brightness CSS variable + clamping, cache headers, magic-byte rejection, remove, settings UI presence
- [x] Manual checklist added to `TESTING.md` under "Wallpaper" (14 items)
- [x] Smoke-tested in browser: upload JPEG/PNG/WebP, drag brightness slider, refresh persistence, magic-byte rejection, theme switching with wallpaper present, thumbnail preview shows current file

## Notes for reviewer
- 9 focused commits, each independently reviewable. The `body{background}` → `html{background}` swap is its own commit (`7a22ab5`) for easy bisect if any visual regression appears.
- `_SETTINGS_WRITE_LOCK` (`20abf8d`) closes a load-merge-write race that affected ALL settings POSTs, not just wallpaper. Marked as bonus fix in the commit message.
- New i18n keys added to all 5 supported locales (en, zh, es, de, zh-Hant). Verified by existing locale-parity tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
