### PR TITLE
fix: load provider models from config.yaml in webui

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -855,12 +855,22 @@ def get_available_models() -> dict:
                         ],
                     }
                 )
-            elif pid in _PROVIDER_MODELS:
+            elif pid in _PROVIDER_MODELS or pid in cfg.get("providers", {}):
                 # For non-default providers, prefix model IDs with @provider:model
                 # so resolve_model_provider() routes through that specific provider
                 # via resolve_runtime_provider(requested=provider).
                 # The default provider's models keep bare names for direct API routing.
-                raw_models = _PROVIDER_MODELS[pid]
+                raw_models = _PROVIDER_MODELS.get(pid, [])
+                
+                # Override or merge from config.yaml if user specified explicit models
+                provider_cfg = cfg.get("providers", {}).get(pid, {})
+                if isinstance(provider_cfg, dict) and "models" in provider_cfg:
+                    cfg_models = provider_cfg["models"]
+                    if isinstance(cfg_models, dict):
+                        # config format is usually models: { "gpt-5.4": { context_length: ... } }
+                        raw_models = [{"id": k, "label": k} for k in cfg_models.keys()]
+                    elif isinstance(cfg_models, list):
+                        raw_models = [{"id": k, "label": k} for k in cfg_models]
                 _active = (active_provider or "").lower()
                 if _active and pid != _active:
                     models = []


### PR DESCRIPTION
When a provider has custom models configured in config.yaml, the Web UI previously ignored them and always displayed the hardcoded _PROVIDER_MODELS fallback list for known providers. This patch merges or overrides the hardcoded models with the explicitly configured ones from config.yaml.