### PR TITLE
fix: skill panel auto-open, thinking scroll, nav icon alignment, Safari zoom — closes #643 #638 #636 #630

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,14 @@
 ### Fixed
 - **Default model no longer shows as "(unavailable)" for non-OpenAI users** — changed the hardcoded fallback `DEFAULT_MODEL` from `openai/gpt-5.4-mini` to `""` (empty). When no default model is configured, the WebUI now defers to the active provider's own default instead of pre-selecting an OpenAI model that most providers don't have. Users who want a specific default can still set `HERMES_WEBUI_DEFAULT_MODEL` env var or pick a model in Preferences. (Closes #646)
 
+## [v0.50.80] — 2026-04-18
+
+### Fixed
+- **Clicking a skill no longer silently loads content into a hidden panel** — `openSkill()` now calls `ensureWorkspacePreviewVisible()` so the workspace panel auto-opens when you click a skill in the Skills tab. (Closes #643)
+- **Long thinking/reasoning traces now scroll instead of being clipped** — the thinking card body now uses `overflow-y: auto` when open, so long traces are fully readable. (Closes #638)
+- **Sidebar nav icon hit targets are now correctly aligned** — added `display:flex; align-items:center; justify-content:center` to `.nav-tab` so clicking the icon itself (not below it) activates the tab. (Closes #636)
+- **Safari iOS input auto-zoom fixed** — bumped `textarea#msg` base font-size from 14px to 16px, which prevents Safari from zooming the viewport on input focus (Safari zooms when font-size < 16px). Visual difference is negligible. (Closes #630)
+
 ## [v0.50.76] — 2026-04-17
 
 ### Fixed

--- a/static/index.html
+++ b/static/index.html
@@ -591,7 +591,7 @@
                 <div class="settings-section-title">System</div>
                 <div class="settings-section-meta">Instance version and access controls.</div>
               </div>
-              <span class="settings-version-badge">v0.50.79</span>
+              <span class="settings-version-badge">v0.50.80</span>
             </div>
             <div class="settings-field" style="border-top:1px solid var(--border);padding-top:12px;margin-top:8px">
               <label for="settingsPassword" data-i18n="settings_label_password">Access Password</label>

--- a/static/panels.js
+++ b/static/panels.js
@@ -405,6 +405,8 @@ async function openSkill(name, el) {
   // Highlight active skill
   document.querySelectorAll('.skill-item').forEach(e => e.classList.remove('active'));
   if (el) el.classList.add('active');
+  // Ensure the workspace panel is open so the skill content is actually visible (#643)
+  if (typeof ensureWorkspacePreviewVisible === 'function') ensureWorkspacePreviewVisible();
   try {
     const data = await api(`/api/skills/content?name=${encodeURIComponent(name)}`);
     // Show skill content in right panel preview

--- a/static/style.css
+++ b/static/style.css
@@ -347,7 +347,7 @@
   .clarify-card.visible .clarify-question{padding-left:1px;}
   /* Sidebar navigation tabs */
   .sidebar-nav{display:flex;border-bottom:1px solid var(--border);flex-shrink:0;padding:6px 8px 0;gap:2px;}
-  .nav-tab{flex:1;padding:10px 4px 8px;font-size:20px;text-align:center;cursor:pointer;color:var(--muted);border:none;background:none;transition:color .15s;border-bottom:2px solid transparent;white-space:nowrap;overflow:hidden;position:relative;}
+  .nav-tab{flex:1;padding:10px 4px 8px;font-size:20px;text-align:center;cursor:pointer;color:var(--muted);border:none;background:none;transition:color .15s;border-bottom:2px solid transparent;white-space:nowrap;overflow:hidden;position:relative;display:flex;align-items:center;justify-content:center;}
   .nav-tab:hover{color:var(--text);}
   .nav-tab:hover::after{content:attr(data-label);position:absolute;bottom:calc(100% + 8px);left:50%;transform:translateX(-50%);background:var(--surface);border:1px solid var(--accent-bg-strong);color:var(--accent-text);font-size:12px;font-weight:700;letter-spacing:.02em;padding:6px 12px;border-radius:8px;white-space:nowrap;pointer-events:none;z-index:50;box-shadow:0 4px 12px rgba(0,0,0,.3);}
   .nav-tab.active{color:var(--accent-text);}
@@ -509,7 +509,7 @@
   .attach-chip{display:flex;align-items:center;gap:5px;background:var(--accent-bg);border:1px solid var(--accent-bg-strong);border-radius:8px;padding:4px 10px;font-size:11px;font-weight:500;color:var(--accent-text);}
   .attach-chip button{background:none;border:none;color:var(--muted);cursor:pointer;font-size:13px;line-height:1;padding:0 0 0 3px;}
   .attach-chip button:hover{color:var(--accent);}
-  textarea#msg{width:100%;background:transparent;border:none;outline:none;color:var(--text);font-size:14px;line-height:1.65;padding:12px 16px 6px;resize:none;min-height:44px;max-height:200px;font-family:inherit;}
+  textarea#msg{width:100%;background:transparent;border:none;outline:none;color:var(--text);font-size:16px;line-height:1.65;padding:12px 16px 6px;resize:none;min-height:44px;max-height:200px;font-family:inherit;}
   textarea#msg::placeholder{color:var(--muted);}
   .composer-footer{display:flex;align-items:center;justify-content:space-between;gap:10px;padding:6px 10px 10px;position:relative;}
   .composer-left{display:flex;align-items:center;gap:4px;min-width:0;flex:1;overflow-x:auto;overflow-y:hidden;scrollbar-width:none;}
@@ -701,7 +701,7 @@
     .msg-role{font-size:12px;}
     .composer-wrap{padding:8px 10px 12px!important;}
     .composer-box{border-radius:12px;}
-    .composer-box textarea{font-size:16px;min-height:40px;}
+    .composer-box textarea{min-height:40px;}
     .composer-footer{padding:6px 8px 8px!important;gap:8px;}
     /* icon-only composer chips below 768px */
     .composer-profile-label,
@@ -1341,7 +1341,7 @@ body.bubble-layout .msg-row + .msg-row[data-role="user"] { border-top: none; pad
   border-top: 1px solid transparent;
   transition: max-height .22s ease, opacity .18s ease, padding .22s ease, border-top-color .22s ease;
 }
-.thinking-card.open .thinking-card-body { max-height: 260px; opacity: 1; padding: 8px 12px; border-top-color: var(--accent-bg-strong); }
+.thinking-card.open .thinking-card-body { max-height: 260px; overflow-y: auto; opacity: 1; padding: 8px 12px; border-top-color: var(--accent-bg-strong); }
 .thinking-card-body pre { font-family: 'SF Mono', ui-monospace, monospace; font-size: 11px; line-height: 1.6; color: var(--muted); white-space: pre-wrap; word-break: break-word; margin: 0; }
 
 /* ── Tool cards: tighter chrome to match quieter thinking card ── */


### PR DESCRIPTION
## Summary
Four small CSS/JS bug fixes, all self-contained with no logic changes.

Closes #643, #638, #636, #630

## Changes

**#643 — Skill click auto-opens workspace panel**
`openSkill()` in `static/panels.js` now calls `ensureWorkspacePreviewVisible()` before loading content. Previously, clicking a skill loaded the full content into a hidden panel with no feedback to the user.

**#638 — Long thinking traces now scroll**
Added `overflow-y: auto` to `.thinking-card.open .thinking-card-body` in `static/style.css`. Previously the card had a fixed max-height with `overflow: hidden`, cutting off long reasoning traces with no way to see the rest.

**#636 — Sidebar nav icon hit targets aligned**
Added `display:flex; align-items:center; justify-content:center` to `.nav-tab`. Previously the SVG icon was visually offset from the button's centre due to text-align alone, so clicking the icon itself did nothing — you had to click below it.

**#630 — Safari iOS auto-zoom on input focus**
Bumped `textarea#msg` base font-size from `14px` to `16px`. Safari zooms the viewport when focusing an input with `font-size < 16px` and doesn't reset on blur. The visual difference between 14px and 16px is imperceptible at normal reading distance. Removed the now-redundant mobile media query override.

## Testing
- 1369 tests passing (4 pre-existing failures in `test_sprint34.py::TestProviderOAuthAuthenticated` unrelated to these changes — confirmed identical failures on master before this branch)
- All changes are CSS/JS only — no Python logic affected
