### PR TITLE
feat: add MiniMax M2.7 to fallback model list and fix env var detection

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -300,6 +300,8 @@ _FALLBACK_MODELS = [
     {'provider': 'Other',     'id': 'google/gemini-2.5-pro',            'label': 'Gemini 2.5 Pro'},
     {'provider': 'Other',     'id': 'deepseek/deepseek-chat-v3-0324',   'label': 'DeepSeek V3'},
     {'provider': 'Other',     'id': 'meta-llama/llama-4-scout',         'label': 'Llama 4 Scout'},
+    {'provider': 'MiniMax',   'id': 'minimax/MiniMax-M2.7',             'label': 'MiniMax M2.7'},
+    {'provider': 'MiniMax',   'id': 'minimax/MiniMax-M2.7-highspeed',   'label': 'MiniMax M2.7 Highspeed'},
 ]
 
 # Provider display names for known Hermes provider IDs
@@ -534,7 +536,8 @@ def get_available_models() -> dict:
                 pass
         all_env = {**env_keys}
         for k in ('ANTHROPIC_API_KEY', 'OPENAI_API_KEY', 'OPENROUTER_API_KEY',
-                  'GOOGLE_API_KEY', 'GLM_API_KEY', 'KIMI_API_KEY', 'DEEPSEEK_API_KEY'):
+                  'GOOGLE_API_KEY', 'GLM_API_KEY', 'KIMI_API_KEY', 'DEEPSEEK_API_KEY',
+                  'MINIMAX_API_KEY', 'MINIMAX_CN_API_KEY'):
             val = os.getenv(k)
             if val:
                 all_env[k] = val

--- a/tests/test_minimax_provider.py
+++ b/tests/test_minimax_provider.py
@@ -1,0 +1,148 @@
+"""
+Tests for MiniMax provider support in the model/provider discovery layer.
+
+Covers:
+  - MiniMax models appear in the fallback model list
+  - MINIMAX_API_KEY env var is scanned and detected from os.environ
+  - @minimax: provider hint routing works correctly
+  - minimax/MiniMax-M2.7 (slash format) is routed via openrouter when active provider differs
+"""
+import os
+import api.config as config
+
+
+# ── Helper ────────────────────────────────────────────────────────────────────
+
+def _resolve_with_config(model_id, provider=None, base_url=None):
+    old_cfg = dict(config.cfg)
+    model_cfg = {}
+    if provider:
+        model_cfg['provider'] = provider
+    if base_url:
+        model_cfg['base_url'] = base_url
+    config.cfg['model'] = model_cfg if model_cfg else {}
+    try:
+        return config.resolve_model_provider(model_id)
+    finally:
+        config.cfg.clear()
+        config.cfg.update(old_cfg)
+
+
+# ── Fallback model list ───────────────────────────────────────────────────────
+
+def test_minimax_m2_7_in_fallback_models():
+    """MiniMax-M2.7 must appear in the hardcoded fallback model list."""
+    ids = [m['id'] for m in config._FALLBACK_MODELS]
+    assert 'minimax/MiniMax-M2.7' in ids, (
+        f"minimax/MiniMax-M2.7 missing from _FALLBACK_MODELS. Found: {ids}"
+    )
+
+
+def test_minimax_m2_7_highspeed_in_fallback_models():
+    """MiniMax-M2.7-highspeed must appear in the hardcoded fallback model list."""
+    ids = [m['id'] for m in config._FALLBACK_MODELS]
+    assert 'minimax/MiniMax-M2.7-highspeed' in ids, (
+        f"minimax/MiniMax-M2.7-highspeed missing from _FALLBACK_MODELS. Found: {ids}"
+    )
+
+
+def test_minimax_fallback_provider_label():
+    """MiniMax fallback entries must use 'MiniMax' as the provider label."""
+    minimax_entries = [m for m in config._FALLBACK_MODELS if 'minimax' in m['id'].lower()]
+    assert minimax_entries, "No MiniMax entries found in _FALLBACK_MODELS"
+    for entry in minimax_entries:
+        assert entry['provider'] == 'MiniMax', (
+            f"Expected provider='MiniMax', got '{entry['provider']}' for {entry['id']}"
+        )
+
+
+# ── _PROVIDER_MODELS ──────────────────────────────────────────────────────────
+
+def test_minimax_provider_models_has_m2_7():
+    """_PROVIDER_MODELS['minimax'] must include MiniMax-M2.7."""
+    models = config._PROVIDER_MODELS.get('minimax', [])
+    ids = [m['id'] for m in models]
+    assert 'MiniMax-M2.7' in ids, (
+        f"MiniMax-M2.7 missing from _PROVIDER_MODELS['minimax']. Found: {ids}"
+    )
+
+
+def test_minimax_provider_models_has_highspeed():
+    """_PROVIDER_MODELS['minimax'] must include MiniMax-M2.7-highspeed."""
+    models = config._PROVIDER_MODELS.get('minimax', [])
+    ids = [m['id'] for m in models]
+    assert 'MiniMax-M2.7-highspeed' in ids, (
+        f"MiniMax-M2.7-highspeed missing from _PROVIDER_MODELS['minimax']. Found: {ids}"
+    )
+
+
+# ── MINIMAX_API_KEY env var detection ─────────────────────────────────────────
+
+def test_minimax_api_key_in_env_scan_tuple():
+    """MINIMAX_API_KEY must be included in the env var scan performed by
+    get_available_models(), so users who export MINIMAX_API_KEY see the
+    MiniMax provider in the dropdown without editing ~/.hermes/.env."""
+    import inspect, ast, textwrap
+    src = inspect.getsource(config.get_available_models)
+    assert 'MINIMAX_API_KEY' in src, (
+        "MINIMAX_API_KEY not found in get_available_models() source — "
+        "it must be added to the env var scan tuple so os.environ is checked."
+    )
+
+
+def test_minimax_cn_api_key_in_env_scan_tuple():
+    """MINIMAX_CN_API_KEY must also be scanned (mainland China API key variant)."""
+    import inspect
+    src = inspect.getsource(config.get_available_models)
+    assert 'MINIMAX_CN_API_KEY' in src, (
+        "MINIMAX_CN_API_KEY not found in get_available_models() source."
+    )
+
+
+def test_minimax_detected_from_os_environ(monkeypatch):
+    """Setting MINIMAX_API_KEY in os.environ triggers minimax provider detection."""
+    monkeypatch.setenv('MINIMAX_API_KEY', 'test-key-from-env')
+    old_cfg = dict(config.cfg)
+    # Clear model config so the env-var fallback path is exercised
+    config.cfg['model'] = {}
+    try:
+        result = config.get_available_models()
+        provider_names = [g['provider'] for g in result['groups']]
+        assert 'MiniMax' in provider_names, (
+            f"MiniMax not detected when MINIMAX_API_KEY is set in os.environ. "
+            f"Active provider groups: {provider_names}"
+        )
+    finally:
+        config.cfg.clear()
+        config.cfg.update(old_cfg)
+
+
+# ── Model routing ─────────────────────────────────────────────────────────────
+
+def test_provider_hint_minimax_m2_7():
+    """@minimax:MiniMax-M2.7 routes to minimax provider with bare model name."""
+    model, provider, base_url = _resolve_with_config(
+        '@minimax:MiniMax-M2.7', provider='anthropic',
+    )
+    assert model == 'MiniMax-M2.7'
+    assert provider == 'minimax'
+    assert base_url is None
+
+
+def test_provider_hint_minimax_highspeed():
+    """@minimax:MiniMax-M2.7-highspeed routes to minimax provider."""
+    model, provider, base_url = _resolve_with_config(
+        '@minimax:MiniMax-M2.7-highspeed', provider='openai',
+    )
+    assert model == 'MiniMax-M2.7-highspeed'
+    assert provider == 'minimax'
+
+
+def test_minimax_slash_format_routes_openrouter_when_not_active():
+    """minimax/MiniMax-M2.7 (slash format) routes via openrouter when active
+    provider is anthropic (cross-provider routing)."""
+    model, provider, base_url = _resolve_with_config(
+        'minimax/MiniMax-M2.7', provider='anthropic',
+    )
+    assert model == 'minimax/MiniMax-M2.7'
+    assert provider == 'openrouter'


### PR DESCRIPTION
## Thinking Path

- Hermes WebUI already has MiniMax support via `_PROVIDER_MODELS['minimax']` and `_PROVIDER_DISPLAY['minimax']`
- However, MiniMax models are absent from `_FALLBACK_MODELS`, so they never appear in the model dropdown for users without a dedicated MiniMax provider config
- Additionally, `MINIMAX_API_KEY` is checked in `get_available_models()` but is never added to `all_env` from `os.environ` — the env var scan tuple only read it from `~/.hermes/.env`, not from the shell environment
- This PR closes both gaps so MiniMax M2.7 works out-of-the-box

## What Changed

**`api/config.py`**
- Added `minimax/MiniMax-M2.7` and `minimax/MiniMax-M2.7-highspeed` to `_FALLBACK_MODELS` so both models appear in the dropdown when the user has no specific Hermes provider configured (same pattern as DeepSeek, Gemini, Llama entries)
- Added `MINIMAX_API_KEY` and `MINIMAX_CN_API_KEY` to the `os.environ` scan tuple inside `get_available_models()` — previously setting these keys in the environment had no effect because only keys in the explicit tuple were ever read from `os.environ`; the downstream `all_env.get('MINIMAX_API_KEY')` check on line 553 was therefore unreachable via env vars

**`tests/test_minimax_provider.py`** (new file, 11 tests)
- Fallback model list contains M2.7 and M2.7-highspeed with correct labels
- `_PROVIDER_MODELS['minimax']` has both models
- `MINIMAX_API_KEY` and `MINIMAX_CN_API_KEY` are present in the env var scan
- Setting `MINIMAX_API_KEY` in `os.environ` triggers MiniMax provider detection
- `@minimax:MiniMax-M2.7` provider-hint routing works correctly
- `minimax/MiniMax-M2.7` (slash format) routes via OpenRouter when a different provider is active

## Why It Matters

Users who set `MINIMAX_API_KEY` in their shell environment (e.g. Docker deployments, CI) currently see no MiniMax models in the dropdown. This fix makes MiniMax M2.7 a first-class option alongside OpenAI, Anthropic, and other providers in the fallback list, and ensures the API key is properly detected from `os.environ`.

## Verification

```
pytest tests/test_minimax_provider.py tests/test_model_resolver.py -v
# 25 passed
pytest tests/ -v --timeout=60
# 517 passed, 41 skipped (agent-dependent tests skipped without hermes-agent)
```

## Risks / Follow-ups

- Minimal risk: changes are additive (new list entries + one tuple expansion)
- No existing tests affected

## Model Used

Provider: Anthropic  
Model: claude-sonnet-4-6  
Mode: Claude Code (agentic)