### PR TITLE
fix(title): auto-title extraction for tool-heavy first turns — closes #639 (PR #640 integration)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Hermes Web UI -- Changelog
 
+## [v0.50.80] — 2026-04-17
+
+### Fixed
+- **Auto-title extraction: better handling of tool-heavy first turns** — `_first_exchange_snippets()` now prefers the first substantive assistant answer and skips empty / meta-reasoning tool-call preambles (e.g. "Let me check my memory first."), while still preserving agentic first-turn replies that carry both substantive text AND a `tool_calls` field. The whitespace-normalized provisional-title check prevents the background title update from skipping when the UI placeholder differs from the derived title only by whitespace. (Closes #639, PR #640 by @franksong2702)
+
 ## [v0.50.76] — 2026-04-17
 
 ### Fixed

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -124,16 +124,27 @@ def _message_text(value) -> str:
 
 
 def _first_exchange_snippets(messages):
-    """Return (first_user_text, first_assistant_text) snippets for title generation."""
+    """Return (first_user_text, first_assistant_text) snippets for title generation.
+
+    Prefer the first substantive assistant answer in the opening exchange,
+    skipping empty placeholders and assistant tool-call preambles.
+    """
     user_text = ''
     asst_text = ''
     for m in messages or []:
         if not isinstance(m, dict):
             continue
         role = m.get('role')
-        if role == 'user' and not user_text:
-            user_text = _message_text(m.get('content'))
-        elif role == 'assistant' and not asst_text:
+        if role == 'user':
+            candidate = _message_text(m.get('content'))
+            if not user_text and candidate:
+                user_text = candidate
+                continue
+            if user_text and candidate:
+                break
+        elif role == 'assistant' and user_text:
+            if m.get('tool_calls'):
+                continue
             candidate = _message_text(m.get('content'))
             if candidate:
                 asst_text = candidate
@@ -147,7 +158,11 @@ def _is_provisional_title(current_title: str, messages) -> bool:
     derived = title_from(messages, '') or ''
     if not derived:
         return False
-    return (str(current_title or '').strip() == derived[:64])
+    current = re.sub(r'\s+', ' ', str(current_title or '')).strip()
+    candidate = re.sub(r'\s+', ' ', str(derived[:64] or '')).strip()
+    if not current or not candidate:
+        return False
+    return current == candidate or candidate.startswith(current)
 
 
 def _title_prompts(user_text: str, assistant_text: str) -> tuple[str, list[str]]:

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -143,9 +143,14 @@ def _first_exchange_snippets(messages):
             if user_text and candidate:
                 break
         elif role == 'assistant' and user_text:
-            if m.get('tool_calls'):
-                continue
             candidate = _message_text(m.get('content'))
+            # Skip tool-call preambles *only* when content is empty or looks
+            # like meta-reasoning ("Let me check my memory first.", "The user
+            # is asking...", etc.). Assistant rows that carry tool_calls but
+            # also contain a substantive answer text are kept — those are
+            # agentic first-turn plans that are legitimate title candidates.
+            if m.get('tool_calls') and (not candidate or _looks_invalid_generated_title(candidate)):
+                continue
             if candidate:
                 asst_text = candidate
         if user_text and asst_text:

--- a/static/index.html
+++ b/static/index.html
@@ -561,7 +561,7 @@
                 <div class="settings-section-title">System</div>
                 <div class="settings-section-meta">Instance version and access controls.</div>
               </div>
-              <span class="settings-version-badge">v0.50.76</span>
+              <span class="settings-version-badge">v0.50.80</span>
             </div>
             <div class="settings-field" style="border-top:1px solid var(--border);padding-top:12px;margin-top:8px">
               <label for="settingsPassword" data-i18n="settings_label_password">Access Password</label>

--- a/tests/test_sprint41.py
+++ b/tests/test_sprint41.py
@@ -286,6 +286,96 @@ class TestIssue495TitleStreaming(unittest.TestCase):
             "Whitespace-normalized provisional titles should still be recognized",
         )
 
+    def test_title_snippet_keeps_tool_call_with_substantive_text(self):
+        """An assistant row with tool_calls AND a substantive answer text
+        must still be used as the first-exchange snippet — it's not a
+        preamble, it's an agentic first-turn plan."""
+        from api.streaming import _first_exchange_snippets
+
+        user_msg = {
+            "role": "user",
+            "content": "Can you schedule a reminder for the Q3 kickoff meeting?",
+        }
+        # Assistant row with both a real answer AND a tool_call
+        agentic_asst = {
+            "role": "assistant",
+            "content": "I'll schedule the Q3 kickoff reminder for next Monday at 9am.",
+            "tool_calls": [
+                {
+                    "id": "call-1",
+                    "function": {
+                        "name": "cronjob",
+                        "arguments": '{"action":"create","when":"mon 9am"}',
+                    },
+                }
+            ],
+        }
+
+        user_text, assistant_text = _first_exchange_snippets([user_msg, agentic_asst])
+
+        self.assertEqual(user_text, user_msg["content"][:500])
+        self.assertEqual(
+            assistant_text,
+            agentic_asst["content"][:500],
+            "Substantive answer text on a tool_call row must be preserved",
+        )
+
+    def test_title_snippet_skips_tool_call_preamble_only_rows(self):
+        """Tool-call rows whose content is empty or meta-reasoning preamble
+        ('Let me check my memory first.') must still be skipped — those are
+        orchestration scaffolding, not title material."""
+        from api.streaming import _first_exchange_snippets
+
+        user_msg = {
+            "role": "user",
+            "content": "Summarize my notes from last week.",
+        }
+        empty_preamble = {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call-1",
+                    "function": {
+                        "name": "memory",
+                        "arguments": '{"action":"search"}',
+                    },
+                }
+            ],
+        }
+        meta_preamble = {
+            "role": "assistant",
+            "content": "Let me check my memory first.",
+            "tool_calls": [
+                {
+                    "id": "call-2",
+                    "function": {
+                        "name": "memory",
+                        "arguments": '{"action":"search","q":"last week"}',
+                    },
+                }
+            ],
+        }
+        tool_result = {
+            "role": "tool",
+            "tool_call_id": "call-2",
+            "content": '{"result":"background info"}',
+        }
+        final_asst = {
+            "role": "assistant",
+            "content": "Here's a summary of your notes from last week.",
+        }
+
+        _, assistant_text = _first_exchange_snippets(
+            [user_msg, empty_preamble, meta_preamble, tool_result, final_asst]
+        )
+
+        self.assertEqual(
+            assistant_text,
+            final_asst["content"][:500],
+            "Empty and meta-reasoning preamble rows must be skipped",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_sprint41.py
+++ b/tests/test_sprint41.py
@@ -213,6 +213,65 @@ class TestIssue495TitleStreaming(unittest.TestCase):
             "messages.js should close SSE connection on stream_end (not immediately on done)",
         )
 
+    def test_title_snippet_uses_visible_assistant_reply_after_tools(self):
+        """Tool-heavy opening turns should use the final visible assistant reply."""
+        from api.streaming import _first_exchange_snippets
+
+        user_msg = {
+            "role": "user",
+            "content": "Please look up the earlier context and then summarize it.",
+        }
+        preamble_asst = {
+            "role": "assistant",
+            "content": "Let me check my memory first.",
+            "tool_calls": [
+                {
+                    "id": "call-1",
+                    "function": {
+                        "name": "memory",
+                        "arguments": '{"action":"search"}',
+                    },
+                }
+            ],
+        }
+        tool_result = {
+            "role": "tool",
+            "tool_call_id": "call-1",
+            "content": '{"result":"background info"}',
+        }
+        final_asst = {
+            "role": "assistant",
+            "content": "Here is the substantive answer after the tool work.",
+        }
+
+        user_text, assistant_text = _first_exchange_snippets(
+            [user_msg, preamble_asst, tool_result, final_asst]
+        )
+
+        self.assertEqual(user_text, user_msg["content"][:500])
+        self.assertEqual(assistant_text, final_asst["content"][:500])
+
+    def test_provisional_title_detection_ignores_whitespace_noise(self):
+        """Temporary first-message titles should still match with whitespace normalization."""
+        from api.streaming import _is_provisional_title, title_from
+
+        messages = [
+            {
+                "role": "user",
+                "content": "过去两个礼拜发生了一些事情。最重要的一点就是我加入了一个 Hermes Web UI 的项目。\n\n因为我开始使用 Hermes 这个 agent 以后，就逐渐不再使用 OpenClaw了。",
+            },
+            {"role": "assistant", "content": "Sure, let me help."},
+        ]
+
+        derived = title_from(messages, "")
+        current = derived[:63]  # Simulate the provisional title the UI writes immediately.
+
+        self.assertNotEqual(current, derived[:64])
+        self.assertTrue(
+            _is_provisional_title(current, messages),
+            "Whitespace-normalized provisional titles should still be recognized",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_sprint41.py
+++ b/tests/test_sprint41.py
@@ -251,6 +251,20 @@ class TestIssue495TitleStreaming(unittest.TestCase):
         self.assertEqual(user_text, user_msg["content"][:500])
         self.assertEqual(assistant_text, final_asst["content"][:500])
 
+    def test_title_snippet_keeps_short_substantive_assistant_reply(self):
+        """Short but real assistant answers should still be eligible for titles."""
+        from api.streaming import _first_exchange_snippets
+
+        messages = [
+            {"role": "user", "content": "Can you help me rename this session?"},
+            {"role": "assistant", "content": "Sure."},
+        ]
+
+        user_text, assistant_text = _first_exchange_snippets(messages)
+
+        self.assertEqual(user_text, "Can you help me rename this session?")
+        self.assertEqual(assistant_text, "Sure.")
+
     def test_provisional_title_detection_ignores_whitespace_noise(self):
         """Temporary first-message titles should still match with whitespace normalization."""
         from api.streaming import _is_provisional_title, title_from


### PR DESCRIPTION
Integration branch for PR #640 by @franksong2702, rebased on current master (v0.50.80) with CHANGELOG and version badge updated to v0.50.81.

Original PR: #640
Independent review: @nesquena confirmed fixes in commits a553b2b + a0ca9fe.

Closes #639.