### PR TITLE
fix: sync subsequent gateway messages to WebUI conversation view

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -2817,9 +2817,13 @@ def _handle_session_import_cli(handler, body):
 
     sid = str(body["session_id"])
 
-    # Check if already imported — idempotent
+    # Check if already imported — refresh messages from CLI store if new ones arrived
     existing = Session.load(sid)
     if existing:
+        fresh_msgs = get_cli_session_messages(sid)
+        if fresh_msgs and len(fresh_msgs) > len(existing.messages):
+            existing.messages = fresh_msgs
+            existing.save(touch_updated_at=False)
         return j(
             handler,
             {

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -331,6 +331,25 @@ function startGatewaySSE(){
         const data = JSON.parse(ev.data);
         if(data.sessions){
           renderSessionList(); // re-fetch and re-render
+          // If the active session received new gateway messages, refresh the conversation view.
+          // We check S.busy so we don't stomp on an in-progress WebUI response.
+          if(S.session && !S.busy){
+            const changedIds = new Set((data.sessions||[]).map(s=>s.session_id));
+            if(changedIds.has(S.session.session_id)){
+              api('/api/session/import_cli',{method:'POST',body:JSON.stringify({session_id:S.session.session_id})})
+                .then(res=>{
+                  if(res && res.session && Array.isArray(res.session.messages)){
+                    const prev = S.messages.length;
+                    S.messages = res.session.messages.filter(m=>m&&m.role);
+                    if(S.messages.length !== prev){
+                      renderMessages();
+                      if(typeof highlightCode==='function') highlightCode();
+                    }
+                  }
+                })
+                .catch(()=>{ /* ignore — next poll will retry */ });
+            }
+          }
         }
       }catch(e){ /* ignore parse errors */ }
     });


### PR DESCRIPTION
When a session was already imported from the CLI/gateway store, the
  `/api/session/import_cli` endpoint returned stale WebUI JSON without
  checking state.db for newer messages. Additionally, the `sessions_changed`
  SSE handler in the frontend only refreshed the sidebar session list but
  never re-rendered the active conversation view.

 ## Root causes:
  - Backend: `_handle_session_import_cli` did an early return with cached
    data on re-calls, so new Slack/gateway messages were never merged into
    the WebUI JSON file.
  - Frontend: `startGatewaySSE()` sessions_changed handler called
    renderSessionList() only, skipping conversation view refresh.

 ## Fixes:
  - api/routes.py: Re-fetch messages from state.db when session already
    exists; update and save JSON when state.db has more messages than the
    cached version.
  - static/sessions.js: After a sessions_changed event, call import_cli
    for the currently-displayed session and invoke renderMessages() if new
    messages arrived. Guard with !S.busy to avoid stomping on an
    in-progress WebUI response.

  Only the first Slack mention was visible in the WebUI before this fix;
  subsequent messages in the same session now sync correctly.