### PR TITLE
fix(compress): prefer persisted reference handoff after completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,12 @@
 ### Added
 - **Searchable model picker** — the model dropdown now has a live search input at the top. Type any part of a model name or ID to filter the list instantly; provider group headers (Anthropic, OpenAI, OpenRouter, etc.) remain visible in filtered results. Includes a clear button, Escape-to-close support, and a "No models found" empty state. i18n strings added for English, Spanish, and zh-CN. (PR #659 by @mmartial)
 
+## [v0.50.88] — 2026-04-19
 
+### Fixed
+- **`/compress` now shows the full persisted reference handoff immediately after completion** — the immediate post-compression `Reference only` card previously preferred the short `summary.reference_message` payload, which could collapse the card down to a redundant 3-line summary even when the full compaction handoff had already been saved in session history. The UI now prefers the persisted compaction message from session state and only falls back to the short summary when no persisted handoff is available, so the immediate card matches the version seen after reload. (Refs #695)
+
+## [v0.50.85] — 2026-04-18
 
 ### Fixed
 - **`_provider_oauth_authenticated()` now respects the `hermes_home` parameter** — the function had a CLI fast path (`hermes_cli.auth.get_auth_status()`) that ignored the caller-supplied `hermes_home` and read from the real system home. On machines where `openai-codex` (or another OAuth provider) was genuinely authenticated, this caused three test assertions to return `True` instead of `False`, regardless of the isolated `tmp_path` the test passed in. Removed the CLI fast path; the function now reads exclusively from `hermes_home/auth.json`, which is both the correct scoped behavior and what the docstring described. No functional change for production (the auth.json path was already the complete fallback). (Fixes pre-existing test_sprint34 failures)
@@ -1641,4 +1646,3 @@ Critical regressions introduced during the server.py split, caught by users and 
 - **Regression test file added** (`tests/test_regressions.py`): 10 tests, one per introduced bug. These form a permanent regression gate so each class of error can never silently return.
 
 ---
-

--- a/static/commands.js
+++ b/static/commands.js
@@ -189,8 +189,11 @@ async function _runManualCompression(focusTopic){
     const summary=data&&data.summary;
     if(typeof setCompressionUi==='function'&&S.session){
       const referenceMsg=(S.messages||[]).find(m=>typeof _isContextCompactionMessage==='function'&&_isContextCompactionMessage(m));
+      const messageRef=referenceMsg?msgContent(referenceMsg)||String(referenceMsg.content||''):'';
       const summaryRef=summary&&typeof summary.reference_message==='string' ? String(summary.reference_message||'').trim() : '';
-      const referenceText=summaryRef || (referenceMsg?msgContent(referenceMsg)||String(referenceMsg.content||''):'');
+      // Prefer the persisted compaction handoff when it already exists in session state.
+      // The short summary fallback is only for environments where that message is unavailable.
+      const referenceText=messageRef || summaryRef;
       const effectiveFocus=(data&&data.focus_topic)||focusTopic||'';
       setCompressionUi({
         sessionId:S.session.session_id,

--- a/tests/test_sprint46.py
+++ b/tests/test_sprint46.py
@@ -155,3 +155,13 @@ def test_static_commands_js_registers_compress_alias(cleanup_test_sessions):
     assert "/api/session/compress" in src
     assert "cmdCompress" in src
     assert "cmdCompact" in src
+
+
+def test_static_commands_js_prefers_persisted_reference_message(cleanup_test_sessions):
+    from pathlib import Path
+
+    with open(Path(__file__).resolve().parents[1] / "static" / "commands.js", encoding="utf-8") as f:
+        src = f.read()
+
+    assert "const messageRef=referenceMsg?msgContent(referenceMsg)||String(referenceMsg.content||''):'';" in src
+    assert "const referenceText=messageRef || summaryRef;" in src


### PR DESCRIPTION
## Summary

This draft PR implements **Option A** from #695.

It fixes the immediate `/compress` UX inconsistency where the third card (`Context compaction / Reference only`) could show only the short 3-line `summary.reference_message` right after compression, while the same card showed the full handoff summary after reload.

The fix is intentionally minimal:
- prefer the persisted compaction message already present in session state
- only fall back to `summary.reference_message` if no persisted handoff message is available

That keeps the immediate post-compression card aligned with the persisted/reloaded card without changing the backend/session contract.

## What Changed

- `static/commands.js`
  - changed the completion-state reference-text priority to use the persisted compaction message first
  - kept `summary.reference_message` as a fallback only
- `tests/test_sprint46.py`
  - added a regression check locking in that priority
- `CHANGELOG.md`
  - added a short user-visible fix note

## Why This Is Draft

This is the smallest tactical fix for the inconsistency discussed in #695.

If the preferred direction is still to move to **Option B** (a proper backend/session contract for the reference card), this PR can either:
- be promoted as-is if Option A is accepted, or
- be replaced/expanded if the cleaner architectural approach is preferred

## Verification

- `node --check static/commands.js`
- `.venv_test/bin/pytest tests/test_sprint46.py -q`

## Issue

- Refs #695

## Tooling

- OpenAI Codex (GPT-5)
