### PR TITLE
fix: add explicit UTF-8 encoding to read_text() calls for Windows compatibility

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -198,7 +198,7 @@ def reload_config() -> None:
             import yaml as _yaml
 
             if config_path.exists():
-                loaded = _yaml.safe_load(config_path.read_text())
+                loaded = _yaml.safe_load(config_path.read_text(encoding="utf-8"))
                 if isinstance(loaded, dict):
                     _cfg_cache.update(loaded)
                     try:
@@ -770,7 +770,7 @@ def get_available_models() -> dict:
             try:
                 import json as _j
 
-                auth_store = _j.loads(auth_store_path.read_text())
+                auth_store = _j.loads(auth_store_path.read_text(encoding="utf-8"))
                 active_provider = auth_store.get("active_provider")
             except Exception:
                 logger.debug("Failed to load auth store from %s", auth_store_path)
@@ -818,7 +818,7 @@ def get_available_models() -> dict:
         env_keys = {}
         if hermes_env_path.exists():
             try:
-                for line in hermes_env_path.read_text().splitlines():
+                for line in hermes_env_path.read_text(encoding="utf-8").splitlines():
                     line = line.strip()
                     if line and not line.startswith("#") and "=" in line:
                         k, v = line.split("=", 1)

--- a/api/profiles.py
+++ b/api/profiles.py
@@ -75,7 +75,7 @@ def _read_active_profile_file() -> str:
     ap_file = _DEFAULT_HERMES_HOME / 'active_profile'
     if ap_file.exists():
         try:
-            name = ap_file.read_text().strip()
+            name = ap_file.read_text(encoding="utf-8").strip()
             if name:
                 return name
         except Exception:
@@ -142,7 +142,7 @@ def _reload_dotenv(home: Path):
         return
     try:
         loaded_keys: set[str] = set()
-        for line in env_path.read_text().splitlines():
+        for line in env_path.read_text(encoding="utf-8").splitlines():
             line = line.strip()
             if line and not line.startswith('#') and '=' in line:
                 k, v = line.split('=', 1)
@@ -344,7 +344,7 @@ def _write_endpoint_to_config(profile_dir: Path, base_url: str = None, api_key: 
     cfg = {}
     if config_path.exists():
         try:
-            loaded = _yaml.safe_load(config_path.read_text())
+            loaded = _yaml.safe_load(config_path.read_text(encoding="utf-8"))
             if isinstance(loaded, dict):
                 cfg = loaded
         except Exception:


### PR DESCRIPTION
## Summary

- Fix `Path.read_text()` calls missing `encoding="utf-8"` in `api/config.py` and `api/profiles.py`, which causes silent config loading failures on Windows systems with non-UTF-8 default locale (e.g. GBK on Chinese Windows, Shift_JIS on Japanese Windows)

## Problem

On Windows, `Path.read_text()` without an explicit encoding argument defaults to the system locale encoding (determined by `locale.getpreferredencoding()`), **not** UTF-8. 

The default Hermes `config.yaml` contains Unicode characters in personality definitions (e.g. `◕‿◕`, `★`, `♪`, CJK characters). When the system locale is GBK (Chinese), Shift_JIS (Japanese), or any non-UTF-8 encoding, reading these files raises a `UnicodeDecodeError`.

Because `reload_config()` catches all exceptions silently (`except Exception: logger.debug(...)`), the config dict ends up **empty**. This causes the WebUI to:
1. Think no provider/model is configured
2. Show the onboarding wizard on every launch
3. Appear disconnected from the CLI config — even though `hermes` CLI works perfectly with the same `config.yaml`

## Fix

Added `encoding="utf-8"` to all 6 `read_text()` calls that were missing it:

| File | Function | What it reads |
|---|---|---|
| `api/config.py` | `reload_config()` | `config.yaml` |
| `api/config.py` | `get_available_models()` | `auth.json` |
| `api/config.py` | `get_available_models()` | `.env` |
| `api/profiles.py` | `_read_active_profile_file()` | `active_profile` |
| `api/profiles.py` | `_reload_dotenv()` | `.env` |
| `api/profiles.py` | `_write_endpoint_to_config()` | `config.yaml` |

Note: `api/onboarding.py` already had `encoding="utf-8"` on all its `read_text()` calls, so it was not affected.

## Test plan

- [x] Tested on Windows 11 (Chinese locale, default encoding GBK) with a `config.yaml` containing Unicode personality strings
- [x] Verified `GET /api/onboarding/status` returns `completed: true` and `chat_ready: true` after fix
- [x] Verified `GET /health` returns `status: ok`
- [x] No impact on Linux/macOS (UTF-8 is already the default locale on those platforms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)