### PR TITLE
fix(compress): prefer persisted reference handoff after completion — v0.50.90 (PR #699 by @franksong2702)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@
 ### Added
 - **Searchable model picker** — the model dropdown now has a live search input at the top. Type any part of a model name or ID to filter the list instantly; provider group headers (Anthropic, OpenAI, OpenRouter, etc.) remain visible in filtered results. Includes a clear button, Escape-to-close support, and a "No models found" empty state. i18n strings added for English, Spanish, and zh-CN. (PR #659 by @mmartial)
 
+## [v0.50.90] — 2026-04-19
+
+### Fixed
+- **`/compress` reference card now shows full handoff immediately after compression** — the context compaction card no longer shows only the short 3-line API summary right after `/compress` completes. The UI now prefers the persisted compaction message (full handoff) over the raw API response, matching what is shown after a page reload. (PR #699 by @franksong2702)
+
 ## [v0.50.89] — 2026-04-19
 
 ### Fixed

--- a/static/commands.js
+++ b/static/commands.js
@@ -189,8 +189,11 @@ async function _runManualCompression(focusTopic){
     const summary=data&&data.summary;
     if(typeof setCompressionUi==='function'&&S.session){
       const referenceMsg=(S.messages||[]).find(m=>typeof _isContextCompactionMessage==='function'&&_isContextCompactionMessage(m));
+      const messageRef=referenceMsg?msgContent(referenceMsg)||String(referenceMsg.content||''):'';
       const summaryRef=summary&&typeof summary.reference_message==='string' ? String(summary.reference_message||'').trim() : '';
-      const referenceText=summaryRef || (referenceMsg?msgContent(referenceMsg)||String(referenceMsg.content||''):'');
+      // Prefer the persisted compaction handoff when it already exists in session state.
+      // The short summary fallback is only for environments where that message is unavailable.
+      const referenceText=messageRef || summaryRef;
       const effectiveFocus=(data&&data.focus_topic)||focusTopic||'';
       setCompressionUi({
         sessionId:S.session.session_id,

--- a/tests/test_sprint46.py
+++ b/tests/test_sprint46.py
@@ -155,3 +155,13 @@ def test_static_commands_js_registers_compress_alias(cleanup_test_sessions):
     assert "/api/session/compress" in src
     assert "cmdCompress" in src
     assert "cmdCompact" in src
+
+
+def test_static_commands_js_prefers_persisted_reference_message(cleanup_test_sessions):
+    from pathlib import Path
+
+    with open(Path(__file__).resolve().parents[1] / "static" / "commands.js", encoding="utf-8") as f:
+        src = f.read()
+
+    assert "const messageRef=referenceMsg?msgContent(referenceMsg)||String(referenceMsg.content||''):'';" in src
+    assert "const referenceText=messageRef || summaryRef;" in src


### PR DESCRIPTION
Fixes the /compress reference card showing only a short 3-line summary immediately after compression. Now prefers the persisted compaction message (full handoff) over the raw API summary, matching what is shown after page reload. Closes #695.

(Squash-rebased version of PR #699 by @franksong2702 with corrected CHANGELOG position — v0.50.90)