### PR TITLE
Add kimi-k2.5 to Kimi / Moonshot provider model list

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -529,10 +529,11 @@ _PROVIDER_MODELS = {
         {"id": "glm-4.5-flash", "label": "GLM-4.5 Flash"},
     ],
     "kimi-coding": [
-        {"id": "moonshot-v1-8k", "label": "Moonshot v1 8k"},
+{"id": "moonshot-v1-8k", "label": "Moonshot v1 8k"},
         {"id": "moonshot-v1-32k", "label": "Moonshot v1 32k"},
         {"id": "moonshot-v1-128k", "label": "Moonshot v1 128k"},
         {"id": "kimi-latest", "label": "Kimi Latest"},
+        {"id": "kimi-k2.5", "label": "Kimi K2.5"}
     ],
     "minimax": [
         {"id": "MiniMax-M2.7", "label": "MiniMax M2.7"},


### PR DESCRIPTION
## Summary

This PR adds `kimi-k2.5` model to the Kimi / Moonshot provider in the web UI model selector.

## Changes
- Added `"kimi-k2.5"` to the `kimi-coding` provider model list in `api/config.py`

## Why this change
The hermes CLI already supports `kimi-k2.5`, but this model was missing in the web UI, making it unavailable for selection in Kimi / Moonshot provider group.

Thank you for creating and maintaining this amazing project! ❤️