### PR TITLE
feat(ui): refine desktop sidebar collapse behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Hermes Web UI -- Changelog
 
+## [v0.50.97] — 2026-04-19
+
+### Added
+- **Left sidebar can now be collapsed on desktop and reopened from the top bar** — the session/navigation sidebar now has a dedicated hide button, remembers its collapsed state across reloads, and exposes a matching top-bar toggle so narrow desktop layouts can reclaim more space without losing access to navigation. (Closes #431)
+
 ## [v0.50.96] — 2026-04-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [v0.50.97] — 2026-04-19
 
 ### Added
-- **Left sidebar can now be collapsed on desktop and reopened from the top bar** — the session/navigation sidebar now has a dedicated hide button, remembers its collapsed state across reloads, and exposes a matching top-bar toggle so narrow desktop layouts can reclaim more space without losing access to navigation. (Closes #431)
+- **Left sidebar desktop collapse now uses a cleaner pull-out interaction** — the hide control now lives inline with the sidebar icon row instead of taking its own header line, while the reopen control moves to the top-left of the chat header. When the desktop sidebar is collapsed, tapping that top-left control pulls the sidebar back out as an overlay and clicking the scrim closes it again, reusing the mobile-style interaction without wasting chat width. (Closes #431)
 
 ## [v0.50.96] — 2026-04-19
 

--- a/static/boot.js
+++ b/static/boot.js
@@ -16,9 +16,14 @@ async function cancelStream(){
 
 // ── Mobile navigation ──────────────────────────────────────────────────────
 let _workspacePanelMode='closed'; // 'closed' | 'browse' | 'preview'
+let _sidebarPanelMode=document.documentElement.dataset.sidebarPanel==='closed'?'closed':'open';
 
 function _isCompactWorkspaceViewport(){
   return window.matchMedia('(max-width: 900px)').matches;
+}
+
+function _isCompactSidebarViewport(){
+  return window.matchMedia('(max-width: 640px)').matches;
 }
 
 function _workspacePanelEls(){
@@ -126,19 +131,74 @@ function syncWorkspacePanelUI(){
   }
 }
 
+function _sidebarPanelEls(){
+  return {
+    layout: document.querySelector('.layout'),
+    sidebar: document.querySelector('.sidebar'),
+    toggleBtn: $('btnSidebarPanelToggle'),
+    collapseBtn: $('btnCollapseSidebar'),
+  };
+}
+
+function _setSidebarPanelMode(mode){
+  const {layout,sidebar}= _sidebarPanelEls();
+  if(!layout||!sidebar) return;
+  _sidebarPanelMode=mode==='closed'?'closed':'open';
+  document.documentElement.dataset.sidebarPanel=_sidebarPanelMode;
+  localStorage.setItem('hermes-webui-sidebar-panel', _sidebarPanelMode);
+  layout.classList.toggle('sidebar-collapsed', _sidebarPanelMode==='closed');
+  syncSidebarPanelUI();
+}
+
+function syncSidebarPanelUI(){
+  const {layout,sidebar,toggleBtn,collapseBtn}= _sidebarPanelEls();
+  if(!layout||!sidebar) return;
+  const isCompact=_isCompactSidebarViewport();
+  if(!isCompact) sidebar.classList.remove('mobile-open');
+  const isOpen=isCompact ? sidebar.classList.contains('mobile-open') : _sidebarPanelMode!=='closed';
+  layout.classList.toggle('sidebar-collapsed', !isCompact && _sidebarPanelMode==='closed');
+  if(toggleBtn){
+    toggleBtn.classList.toggle('active', isOpen);
+    toggleBtn.setAttribute('aria-pressed', isOpen?'true':'false');
+    toggleBtn.title=isOpen?'Hide sidebar':'Show sidebar';
+  }
+  if(collapseBtn){
+    collapseBtn.title=isCompact?'Close sidebar':'Hide sidebar';
+  }
+}
+
+function toggleSidebarPanel(force){
+  if(_isCompactSidebarViewport()){
+    toggleMobileSidebar();
+    return;
+  }
+  const currentlyOpen=_sidebarPanelMode!=='closed';
+  const nextOpen=typeof force==='boolean' ? force : !currentlyOpen;
+  _setSidebarPanelMode(nextOpen?'open':'closed');
+}
+
+function closeSidebarPanel(){
+  if(_isCompactSidebarViewport()){
+    closeMobileSidebar();
+    return;
+  }
+  _setSidebarPanelMode('closed');
+}
+
 function toggleMobileSidebar(){
   const sidebar=document.querySelector('.sidebar');
   const overlay=$('mobileOverlay');
   if(!sidebar)return;
   const isOpen=sidebar.classList.contains('mobile-open');
   if(isOpen){closeMobileSidebar();}
-  else{sidebar.classList.add('mobile-open');if(overlay)overlay.classList.add('visible');}
+  else{sidebar.classList.add('mobile-open');if(overlay)overlay.classList.add('visible');syncSidebarPanelUI();}
 }
 function closeMobileSidebar(){
   const sidebar=document.querySelector('.sidebar');
   const overlay=$('mobileOverlay');
   if(sidebar)sidebar.classList.remove('mobile-open');
   if(overlay)overlay.classList.remove('visible');
+  syncSidebarPanelUI();
 }
 function toggleMobileFiles(){
   toggleWorkspacePanel();
@@ -815,6 +875,8 @@ function applyBotName(){
   await loadWorkspaceList();
   await loadOnboardingWizard();
   _initResizePanels();
+  _setSidebarPanelMode(document.documentElement.dataset.sidebarPanel==='closed'?'closed':'open');
+  window.addEventListener('resize',syncSidebarPanelUI);
   // Workspace panel restore happens AFTER loadSession so we know if
   // the session has a workspace — prevents the snap-open-then-closed flash (#576).
   const saved=localStorage.getItem('hermes-webui-session');

--- a/static/boot.js
+++ b/static/boot.js
@@ -146,6 +146,7 @@ function _setSidebarPanelMode(mode){
   _sidebarPanelMode=mode==='closed'?'closed':'open';
   document.documentElement.dataset.sidebarPanel=_sidebarPanelMode;
   localStorage.setItem('hermes-webui-sidebar-panel', _sidebarPanelMode);
+  if(!_isCompactSidebarViewport()) sidebar.classList.remove('mobile-open');
   layout.classList.toggle('sidebar-collapsed', _sidebarPanelMode==='closed');
   syncSidebarPanelUI();
 }
@@ -158,18 +159,26 @@ function syncSidebarPanelUI(){
   const isOpen=isCompact ? sidebar.classList.contains('mobile-open') : _sidebarPanelMode!=='closed';
   layout.classList.toggle('sidebar-collapsed', !isCompact && _sidebarPanelMode==='closed');
   if(toggleBtn){
+    toggleBtn.hidden=!isCompact && _sidebarPanelMode!=='closed';
     toggleBtn.classList.toggle('active', isOpen);
     toggleBtn.setAttribute('aria-pressed', isOpen?'true':'false');
     toggleBtn.title=isOpen?'Hide sidebar':'Show sidebar';
+    toggleBtn.setAttribute('aria-label', isOpen?'Hide sidebar':'Show sidebar');
   }
   if(collapseBtn){
     collapseBtn.title=isCompact?'Close sidebar':'Hide sidebar';
+    collapseBtn.setAttribute('aria-label', isCompact?'Close sidebar':'Hide sidebar');
   }
 }
 
 function toggleSidebarPanel(force){
-  if(_isCompactSidebarViewport()){
-    toggleMobileSidebar();
+  const isCompact=_isCompactSidebarViewport();
+  const {sidebar}= _sidebarPanelEls();
+  if(!sidebar)return;
+  if(isCompact){
+    const nextOpen=typeof force==='boolean' ? force : !sidebar.classList.contains('mobile-open');
+    if(nextOpen) openSidebarOverlay();
+    else closeMobileSidebar();
     return;
   }
   const currentlyOpen=_sidebarPanelMode!=='closed';
@@ -178,6 +187,8 @@ function toggleSidebarPanel(force){
 }
 
 function closeSidebarPanel(){
+  const {sidebar}= _sidebarPanelEls();
+  if(!sidebar)return;
   if(_isCompactSidebarViewport()){
     closeMobileSidebar();
     return;
@@ -185,13 +196,21 @@ function closeSidebarPanel(){
   _setSidebarPanelMode('closed');
 }
 
-function toggleMobileSidebar(){
+function openSidebarOverlay(){
   const sidebar=document.querySelector('.sidebar');
   const overlay=$('mobileOverlay');
   if(!sidebar)return;
+  sidebar.classList.add('mobile-open');
+  if(overlay)overlay.classList.add('visible');
+  syncSidebarPanelUI();
+}
+
+function toggleMobileSidebar(){
+  const sidebar=document.querySelector('.sidebar');
+  if(!sidebar)return;
   const isOpen=sidebar.classList.contains('mobile-open');
   if(isOpen){closeMobileSidebar();}
-  else{sidebar.classList.add('mobile-open');if(overlay)overlay.classList.add('visible');syncSidebarPanelUI();}
+  else{openSidebarOverlay();}
 }
 function closeMobileSidebar(){
   const sidebar=document.querySelector('.sidebar');

--- a/static/index.html
+++ b/static/index.html
@@ -10,6 +10,7 @@
 <!-- base href enables subpath mount support; all static paths must stay relative (no leading slash) -->
 <script>(function(){var p=location.pathname.endsWith('/')?location.pathname:(location.pathname.replace(/\/[^\/]*$/,'/')||'/');document.write('<base href="'+location.origin+p+'">');})()</script>
 <script>(function(){var themes={light:1,dark:1,system:1},skins={default:1,ares:1,mono:1,slate:1,poseidon:1,sisyphus:1,charizard:1},legacy={slate:['dark','slate'],solarized:['dark','poseidon'],monokai:['dark','sisyphus'],nord:['dark','slate'],oled:['dark','default']},t=(localStorage.getItem('hermes-theme')||'dark').toLowerCase(),s=(localStorage.getItem('hermes-skin')||'').toLowerCase(),m=legacy[t],theme=m?m[0]:(themes[t]?t:'dark'),skin=skins[s]?s:(m?m[1]:'default');localStorage.setItem('hermes-theme',theme);localStorage.setItem('hermes-skin',skin);if(theme==='system')theme=window.matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light';if(theme==='dark')document.documentElement.classList.add('dark');if(skin!=='default')document.documentElement.dataset.skin=skin;})()</script>
+<script>(function(){try{document.documentElement.dataset.sidebarPanel=localStorage.getItem('hermes-webui-sidebar-panel')==='closed'?'closed':'open';}catch(e){document.documentElement.dataset.sidebarPanel='open';}})()</script>
 <script>(function(){try{document.documentElement.dataset.workspacePanel=localStorage.getItem('hermes-webui-workspace-panel')==='open'?'open':'closed';}catch(e){document.documentElement.dataset.workspacePanel='closed';}})()</script>
 <link rel="stylesheet" href="static/style.css">
   <!-- KaTeX math rendering CSS (loaded eagerly to prevent layout shift) -->
@@ -22,6 +23,11 @@
 <body>
 <div class="layout">
   <aside class="sidebar">
+    <div class="sidebar-panel-head">
+      <button class="panel-icon-btn" id="btnCollapseSidebar" type="button" onclick="toggleSidebarPanel(false)" title="Hide sidebar" aria-label="Hide sidebar">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="15 18 9 12 15 6"/></svg>
+      </button>
+    </div>
 
     <div class="sidebar-nav">
       <button class="nav-tab active" data-panel="chat" data-label="Chat" onclick="switchPanel('chat')" title="Chat" data-i18n-title="tab_chat"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg></button>
@@ -176,6 +182,7 @@
       </button>
       <div style="flex:1;min-width:0;overflow:hidden"><div class="topbar-title" id="topbarTitle">Hermes</div><div class="topbar-meta" id="topbarMeta" data-i18n="new_conversation">Start a new conversation</div></div>
       <div class="topbar-chips">
+        <button class="chip sidebar-toggle-btn" id="btnSidebarPanelToggle" onclick="toggleSidebarPanel()" title="Show sidebar" aria-pressed="true"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="3" width="18" height="18" rx="2"/><line x1="9" y1="3" x2="9" y2="21"/></svg><span class="sidebar-toggle-label">Sidebar</span></button>
         <button class="chip workspace-toggle-btn" id="btnWorkspacePanelToggle" onclick="toggleWorkspacePanel()" title="Show workspace panel" aria-pressed="false"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg><span class="workspace-toggle-label">Files</span></button>
       </div>
     </div>

--- a/static/index.html
+++ b/static/index.html
@@ -23,13 +23,10 @@
 <body>
 <div class="layout">
   <aside class="sidebar">
-    <div class="sidebar-panel-head">
-      <button class="panel-icon-btn" id="btnCollapseSidebar" type="button" onclick="toggleSidebarPanel(false)" title="Hide sidebar" aria-label="Hide sidebar">
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="15 18 9 12 15 6"/></svg>
-      </button>
-    </div>
-
     <div class="sidebar-nav">
+      <button class="sidebar-nav-toggle" id="btnCollapseSidebar" type="button" onclick="toggleSidebarPanel(false)" title="Hide sidebar" aria-label="Hide sidebar" data-label="Hide sidebar">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="15 18 9 12 15 6"/></svg>
+      </button>
       <button class="nav-tab active" data-panel="chat" data-label="Chat" onclick="switchPanel('chat')" title="Chat" data-i18n-title="tab_chat"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg></button>
       <button class="nav-tab" data-panel="tasks" data-label="Tasks" onclick="switchPanel('tasks')" title="Tasks" data-i18n-title="tab_tasks"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="4" width="18" height="18" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg></button>
       <button class="nav-tab" data-panel="skills" data-label="Skills" onclick="switchPanel('skills')" title="Skills" data-i18n-title="tab_skills"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 2L2 7l10 5 10-5-10-5z"/><path d="M2 17l10 5 10-5"/><path d="M2 12l10 5 10-5"/></svg></button>
@@ -177,13 +174,16 @@
   </aside>
   <main class="main">
     <div class="topbar">
-      <button class="mobile-hamburger" id="btnHamburger" onclick="toggleMobileSidebar()" title="Menu">
-        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
-      </button>
-      <div style="flex:1;min-width:0;overflow:hidden"><div class="topbar-title" id="topbarTitle">Hermes</div><div class="topbar-meta" id="topbarMeta" data-i18n="new_conversation">Start a new conversation</div></div>
-      <div class="topbar-chips">
-        <button class="chip sidebar-toggle-btn" id="btnSidebarPanelToggle" onclick="toggleSidebarPanel()" title="Show sidebar" aria-pressed="true"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="3" width="18" height="18" rx="2"/><line x1="9" y1="3" x2="9" y2="21"/></svg><span class="sidebar-toggle-label">Sidebar</span></button>
-        <button class="chip workspace-toggle-btn" id="btnWorkspacePanelToggle" onclick="toggleWorkspacePanel()" title="Show workspace panel" aria-pressed="false"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg><span class="workspace-toggle-label">Files</span></button>
+      <div class="topbar-inner">
+        <div class="topbar-heading">
+          <button class="topbar-sidebar-toggle" id="btnSidebarPanelToggle" onclick="toggleSidebarPanel()" title="Show sidebar" aria-pressed="true" aria-label="Show sidebar">
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+          </button>
+          <div class="topbar-copy"><div class="topbar-title" id="topbarTitle">Hermes</div><div class="topbar-meta" id="topbarMeta" data-i18n="new_conversation">Start a new conversation</div></div>
+        </div>
+        <div class="topbar-chips">
+          <button class="chip workspace-toggle-btn" id="btnWorkspacePanelToggle" onclick="toggleWorkspacePanel()" title="Show workspace panel" aria-pressed="false"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg><span class="workspace-toggle-label">Files</span></button>
+        </div>
       </div>
     </div>
     <div class="messages" id="messages">

--- a/static/style.css
+++ b/static/style.css
@@ -167,7 +167,6 @@
   .layout{display:flex;width:100%;height:100vh;height:100dvh;min-height:0;}
   .sidebar{width:300px;background:var(--sidebar);border-right:1px solid var(--border);display:flex;flex-direction:column;overflow:visible;flex-shrink:0;opacity:1;transform:translateX(0);transform-origin:left center;transition:width .24s cubic-bezier(.22,1,.36,1),opacity .18s ease,transform .24s cubic-bezier(.22,1,.36,1),border-color .24s ease;}
   .sidebar-header{padding:16px 18px 14px;border-bottom:1px solid var(--border);display:flex;align-items:center;gap:10px;}
-  .sidebar-panel-head{padding:8px 12px 0;display:flex;justify-content:flex-end;flex-shrink:0;}
   .logo{width:32px;height:32px;border-radius:9px;background:linear-gradient(145deg,var(--accent-hover),var(--accent));display:flex;align-items:center;justify-content:center;font-weight:800;font-size:14px;color:#fff;flex-shrink:0;box-shadow:0 2px 8px var(--accent-bg-strong);}
   .sidebar-header h1{font-size:15px;font-weight:600;}
   .sidebar-section{padding:14px 14px 8px;}
@@ -348,6 +347,9 @@
   .clarify-card.visible .clarify-question{padding-left:1px;}
   /* Sidebar navigation tabs */
   .sidebar-nav{display:flex;border-bottom:1px solid var(--border);flex-shrink:0;padding:6px 8px 0;gap:2px;}
+  .sidebar-nav-toggle{flex:0 0 auto;width:34px;padding:10px 0 8px;text-align:center;cursor:pointer;color:var(--muted);border:none;background:none;transition:color .15s,border-color .15s,background .15s;border-bottom:2px solid transparent;border-radius:10px 10px 0 0;white-space:nowrap;overflow:hidden;position:relative;display:flex;align-items:center;justify-content:center;}
+  .sidebar-nav-toggle:hover{color:var(--text);background:var(--hover-bg);}
+  .sidebar-nav-toggle:hover::after{content:attr(data-label);position:absolute;bottom:calc(100% + 8px);left:50%;transform:translateX(-50%);background:var(--surface);border:1px solid var(--accent-bg-strong);color:var(--accent-text);font-size:12px;font-weight:700;letter-spacing:.02em;padding:6px 12px;border-radius:8px;white-space:nowrap;pointer-events:none;z-index:50;box-shadow:0 4px 12px rgba(0,0,0,.3);}
   .nav-tab{flex:1;padding:10px 4px 8px;font-size:20px;text-align:center;cursor:pointer;color:var(--muted);border:none;background:none;transition:color .15s;border-bottom:2px solid transparent;white-space:nowrap;overflow:hidden;position:relative;display:flex;align-items:center;justify-content:center;}
   .nav-tab:hover{color:var(--text);}
   .nav-tab:hover::after{content:attr(data-label);position:absolute;bottom:calc(100% + 8px);left:50%;transform:translateX(-50%);background:var(--surface);border:1px solid var(--accent-bg-strong);color:var(--accent-text);font-size:12px;font-weight:700;letter-spacing:.02em;padding:6px 12px;border-radius:8px;white-space:nowrap;pointer-events:none;z-index:50;box-shadow:0 4px 12px rgba(0,0,0,.3);}
@@ -419,7 +421,14 @@
   .sm-btn:hover{background:rgba(255,255,255,0.09);color:var(--text);border-color:rgba(255,255,255,.15);}
   .sm-btn:disabled{opacity:.45;cursor:not-allowed;}
   .main{flex:1;display:flex;flex-direction:column;overflow:hidden;min-width:0;min-height:0;background:var(--main-bg);}
-  .topbar{padding:12px 20px;border-bottom:1px solid var(--border);background:var(--topbar-bg);backdrop-filter:blur(12px);display:flex;align-items:center;justify-content:space-between;flex-shrink:0;position:relative;z-index:10;}
+.topbar{padding:12px 20px;border-bottom:1px solid var(--border);background:var(--topbar-bg);backdrop-filter:blur(12px);flex-shrink:0;position:relative;z-index:10;}
+.topbar-inner{width:100%;margin:0;display:flex;align-items:flex-start;justify-content:space-between;gap:12px;}
+.topbar-heading{display:flex;align-items:flex-start;gap:10px;flex:1;min-width:0;max-width:var(--content-column-max);}
+  .topbar-copy{min-width:0;overflow:hidden;display:flex;flex-direction:column;}
+  .topbar-sidebar-toggle{display:none;align-items:center;justify-content:center;width:28px;height:28px;padding:0;border:none;background:none;color:var(--muted);cursor:pointer;border-radius:8px;flex-shrink:0;transition:background .15s,color .15s,opacity .15s;margin-top:1px;}
+  .topbar-sidebar-toggle:hover{background:var(--hover-bg);color:var(--text);}
+  .topbar-sidebar-toggle.active{color:var(--accent-text);}
+  .topbar-sidebar-toggle svg{display:block;}
   .topbar-title{font-size:15px;font-weight:600;letter-spacing:-.01em;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
   .topbar-meta{font-size:11px;color:var(--muted);margin-top:3px;opacity:.75;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
   .topbar-chips{display:flex;gap:6px;align-items:center;flex-shrink:0;}
@@ -434,9 +443,7 @@
   /* sticky-first-child: button is first child of .messages so its natural position is above viewport; sticky+bottom:16px pins it there when visible */
   .scroll-to-bottom-btn{position:sticky;bottom:16px;align-self:flex-end;margin-right:20px;width:32px;height:32px;border-radius:50%;border:1px solid var(--border2);background:var(--code-bg);color:var(--muted);font-size:16px;cursor:pointer;display:flex;align-items:center;justify-content:center;box-shadow:0 2px 8px rgba(0,0,0,.25);z-index:10;transition:color .12s,border-color .12s,background .12s;}
   .scroll-to-bottom-btn:hover{color:var(--text);border-color:var(--border);background:var(--hover-bg);}
-  .messages-inner{margin:0 auto;width:100%;padding:20px 24px 32px;display:flex;flex-direction:column;}
-  @media(min-width:1400px){.messages-inner{max-width:1100px;}}
-  @media(min-width:1800px){.messages-inner{max-width:1200px;}}
+.messages-inner{margin-left:0;margin-right:auto;width:100%;padding:20px 24px 32px;display:flex;flex-direction:column;max-width:var(--content-column-max);}
   .msg-row{padding:10px 0;}
   .msg-row+.msg-row{border-top:none;}
   /* Bubble layout (issue #336): opt-in chat-bubble look with user messages right-aligned
@@ -650,13 +657,16 @@
   ::-webkit-scrollbar-thumb{background:rgba(255,255,255,.1);border-radius:99px;transition:background .2s}
   ::-webkit-scrollbar-thumb:hover{background:rgba(255,255,255,.22)}
   /* ── Desktop: hide mobile-only elements ── */
-  .mobile-hamburger{display:none;}
   .mobile-files-btn{display:none!important;}
-  .mobile-overlay{display:none;}
+  .mobile-overlay{display:none;position:fixed;inset:0;background:rgba(0,0,0,.5);z-index:199;-webkit-tap-highlight-color:transparent;}
+  .mobile-overlay.visible{display:block;}
 
-  @media(min-width:641px){
+@media(min-width:641px){
+  .layout.sidebar-collapsed.workspace-panel-collapsed .messages-inner{margin-left:auto;margin-right:auto;}
   html[data-sidebar-panel="closed"] .sidebar{width:0 !important;opacity:0;transform:translateX(-14px);border-right-color:transparent;pointer-events:none;overflow:hidden;}
   .layout.sidebar-collapsed .sidebar{width:0 !important;opacity:0;transform:translateX(-14px);border-right-color:transparent;pointer-events:none;overflow:hidden;}
+  html[data-sidebar-panel="closed"] .topbar-sidebar-toggle,
+  .layout.sidebar-collapsed .topbar-sidebar-toggle{display:flex;}
   html[data-sidebar-panel="closed"] .sidebar .resize-handle,
   .layout.sidebar-collapsed .sidebar .resize-handle{display:none;}
 
@@ -677,15 +687,6 @@
       transition:left .25s ease;box-shadow:4px 0 24px rgba(0,0,0,.4);}
     .sidebar.mobile-open{left:0;}
     .sidebar .resize-handle{display:none;}
-    /* Hamburger button */
-    .mobile-hamburger{display:flex;align-items:center;justify-content:center;
-      background:none;border:none;color:var(--muted);cursor:pointer;padding:4px;
-      flex-shrink:0;-webkit-tap-highlight-color:transparent;}
-    .mobile-hamburger:hover{color:var(--text);}
-    /* Overlay backdrop */
-    .mobile-overlay{display:none;position:fixed;inset:0;background:rgba(0,0,0,.5);
-      z-index:199;-webkit-tap-highlight-color:transparent;}
-    .mobile-overlay.visible{display:block;}
     /* Files button in topbar */
     .workspace-toggle-btn,.mobile-files-btn{display:inline-flex!important;}
     /* Right panel: slide-over from right */
@@ -697,9 +698,12 @@
     /* Keep the Hermes control available at the bottom of the mobile sidebar */
     .sidebar-bottom{display:block;padding:10px;}
     /* Topbar adjustments */
-    .topbar{padding:8px 12px;gap:8px;}
+    .topbar{padding:8px 12px;}
+    .topbar-inner{gap:8px;align-items:center;max-width:none;}
+    .topbar-heading{gap:8px;align-items:center;}
     .topbar-title{font-size:14px;}
     .topbar-meta{display:none;}
+    .topbar-sidebar-toggle{display:flex;width:30px;height:30px;padding:4px;}
     .topbar-chips{flex-wrap:nowrap;gap:4px;overflow-x:auto;-webkit-overflow-scrolling:touch;}
     .topbar-chips .chip,.topbar-chips .ws-chip,.topbar-chips button{font-size:11px!important;padding:4px 8px!important;white-space:nowrap;}
     .settings-shell{grid-template-columns:1fr;gap:0;}
@@ -1553,6 +1557,7 @@ body.resizing{user-select:none;cursor:col-resize;}
 :root {
   --msg-rail: 0;
   --msg-max: 780px;
+  --content-column-max: var(--msg-max);
   --user-bubble-bg: var(--accent);
   --user-bubble-border: var(--accent-hover);
   --user-bubble-text: #fff;
@@ -1762,10 +1767,9 @@ body.bubble-layout .msg-row + .msg-row[data-role="user"] { border-top: none; pad
 }
 .msg-date-sep::before, .msg-date-sep::after { content: ''; flex: 1; height: 1px; background: var(--border); }
 
-/* ── Widths: collapse messages-inner to match content column ── */
-.messages-inner { max-width: var(--msg-max); }
-@media (min-width: 1400px) { .messages-inner { max-width: calc(var(--msg-max) + 40px); } }
-@media (min-width: 1800px) { .messages-inner { max-width: calc(var(--msg-max) + 80px); } }
+/* ── Widths: topbar title row and chat body share one content column ── */
+@media (min-width: 1400px) { :root { --content-column-max: calc(var(--msg-max) + 40px); } }
+@media (min-width: 1800px) { :root { --content-column-max: calc(var(--msg-max) + 80px); } }
 
 @media (max-width: 700px) {
   .msg-role { margin-bottom: 4px; }

--- a/static/style.css
+++ b/static/style.css
@@ -1770,6 +1770,8 @@ body.bubble-layout .msg-row + .msg-row[data-role="user"] { border-top: none; pad
 /* ── Widths: topbar title row and chat body share one content column ── */
 @media (min-width: 1400px) { :root { --content-column-max: calc(var(--msg-max) + 40px); } }
 @media (min-width: 1800px) { :root { --content-column-max: calc(var(--msg-max) + 80px); } }
+@media (min-width: 1400px) { .messages-inner { max-width: 1100px; } }
+@media (min-width: 1800px) { .messages-inner { max-width: 1200px; } }
 
 @media (max-width: 700px) {
   .msg-role { margin-bottom: 4px; }

--- a/static/style.css
+++ b/static/style.css
@@ -165,8 +165,9 @@
   body,header,footer,aside,nav,main,div,button,input,textarea,select{transition-property:background-color,border-color,color;transition-duration:.15s;transition-timing-function:ease;}
   body{background:var(--bg);color:var(--text);height:100vh;height:100dvh;overflow:hidden;display:flex;}
   .layout{display:flex;width:100%;height:100vh;height:100dvh;min-height:0;}
-  .sidebar{width:300px;background:var(--sidebar);border-right:1px solid var(--border);display:flex;flex-direction:column;overflow:visible;flex-shrink:0;}
+  .sidebar{width:300px;background:var(--sidebar);border-right:1px solid var(--border);display:flex;flex-direction:column;overflow:visible;flex-shrink:0;opacity:1;transform:translateX(0);transform-origin:left center;transition:width .24s cubic-bezier(.22,1,.36,1),opacity .18s ease,transform .24s cubic-bezier(.22,1,.36,1),border-color .24s ease;}
   .sidebar-header{padding:16px 18px 14px;border-bottom:1px solid var(--border);display:flex;align-items:center;gap:10px;}
+  .sidebar-panel-head{padding:8px 12px 0;display:flex;justify-content:flex-end;flex-shrink:0;}
   .logo{width:32px;height:32px;border-radius:9px;background:linear-gradient(145deg,var(--accent-hover),var(--accent));display:flex;align-items:center;justify-content:center;font-weight:800;font-size:14px;color:#fff;flex-shrink:0;box-shadow:0 2px 8px var(--accent-bg-strong);}
   .sidebar-header h1{font-size:15px;font-weight:600;}
   .sidebar-section{padding:14px 14px 8px;}
@@ -423,6 +424,8 @@
   .topbar-meta{font-size:11px;color:var(--muted);margin-top:3px;opacity:.75;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
   .topbar-chips{display:flex;gap:6px;align-items:center;flex-shrink:0;}
   .chip{font-size:11px;padding:4px 10px;border-radius:999px;background:rgba(255,255,255,0.05);border:1px solid var(--border2);color:var(--muted);font-weight:500;}
+  .sidebar-toggle-btn{display:inline-flex;align-items:center;gap:6px;cursor:pointer;}
+  .sidebar-toggle-btn.active{color:var(--accent-text);border-color:var(--accent-bg);background:var(--accent-bg);}
   .workspace-toggle-btn{display:inline-flex!important;align-items:center;gap:6px;cursor:pointer;}
   .workspace-toggle-btn.active{color:var(--accent-text);border-color:var(--accent-bg);background:var(--accent-bg);}
   .workspace-toggle-btn:disabled{opacity:.38;cursor:not-allowed;}
@@ -651,9 +654,14 @@
   .mobile-files-btn{display:none!important;}
   .mobile-overlay{display:none;}
 
-  @media(min-width:901px){
-    html[data-workspace-panel="closed"] .rightpanel{width:0 !important;opacity:0;transform:translateX(14px);border-left-color:transparent;pointer-events:none;}
-    .layout.workspace-panel-collapsed .rightpanel{width:0 !important;opacity:0;transform:translateX(14px);border-left-color:transparent;pointer-events:none;}
+  @media(min-width:641px){
+  html[data-sidebar-panel="closed"] .sidebar{width:0 !important;opacity:0;transform:translateX(-14px);border-right-color:transparent;pointer-events:none;overflow:hidden;}
+  .layout.sidebar-collapsed .sidebar{width:0 !important;opacity:0;transform:translateX(-14px);border-right-color:transparent;pointer-events:none;overflow:hidden;}
+  html[data-sidebar-panel="closed"] .sidebar .resize-handle,
+  .layout.sidebar-collapsed .sidebar .resize-handle{display:none;}
+
+  html[data-workspace-panel="closed"] .rightpanel{width:0 !important;opacity:0;transform:translateX(14px);border-left-color:transparent;pointer-events:none;}
+  .layout.workspace-panel-collapsed .rightpanel{width:0 !important;opacity:0;transform:translateX(14px);border-left-color:transparent;pointer-events:none;}
   }
 
   @media(max-width:900px){
@@ -759,6 +767,11 @@
     .onboarding-actions .sm-btn{width:100%;min-height:44px;}
     /* Login page responsive */
     .card{width:90vw;max-width:320px;padding:28px 24px;}
+  }
+
+  @media(max-width:640px){
+    .sidebar-panel-head{display:none;}
+    .sidebar-toggle-btn{display:none!important;}
   }
 
 

--- a/tests/test_sprint51.py
+++ b/tests/test_sprint51.py
@@ -1,0 +1,60 @@
+"""Tests for sprint 51 sidebar UX fixes.
+
+Covers:
+  - #431: left sidebar can collapse independently on desktop, with persisted
+          state and a visible way to reopen it.
+"""
+
+import pathlib
+
+
+REPO = pathlib.Path(__file__).parent.parent
+
+
+def read(rel):
+    return (REPO / rel).read_text()
+
+
+def test_sidebar_toggle_controls_exist_in_html():
+    src = read("static/index.html")
+    assert 'id="btnCollapseSidebar"' in src, (
+        "Sidebar needs an in-panel collapse button"
+    )
+    assert 'id="btnSidebarPanelToggle"' in src, (
+        "Topbar needs a visible sidebar toggle so desktop users can reopen the sidebar"
+    )
+
+
+def test_sidebar_state_bootstrapped_from_local_storage():
+    src = read("static/index.html")
+    assert "hermes-webui-sidebar-panel" in src, (
+        "Sidebar collapsed state should be restored from localStorage before CSS loads"
+    )
+    assert "document.documentElement.dataset.sidebarPanel" in src, (
+        "Initial sidebar state should be reflected on documentElement dataset"
+    )
+
+
+def test_boot_js_has_sidebar_panel_state_machine():
+    src = read("static/boot.js")
+    for needle in (
+        "let _sidebarPanelMode",
+        "function _setSidebarPanelMode(",
+        "function syncSidebarPanelUI(",
+        "function toggleSidebarPanel(",
+        "hermes-webui-sidebar-panel",
+    ):
+        assert needle in src, f"{needle} must exist in static/boot.js"
+
+
+def test_desktop_sidebar_collapsed_css_exists():
+    src = read("static/style.css")
+    assert 'html[data-sidebar-panel="closed"] .sidebar' in src, (
+        "Desktop collapsed sidebar CSS selector must exist"
+    )
+    assert ".layout.sidebar-collapsed .sidebar" in src, (
+        "Layout class should also be able to drive collapsed sidebar state"
+    )
+    assert ".sidebar-toggle-btn" in src, (
+        "Topbar sidebar toggle styling must exist"
+    )

--- a/tests/test_sprint51.py
+++ b/tests/test_sprint51.py
@@ -23,6 +23,18 @@ def test_sidebar_toggle_controls_exist_in_html():
     assert 'id="btnSidebarPanelToggle"' in src, (
         "Topbar needs a visible sidebar toggle so desktop users can reopen the sidebar"
     )
+    assert 'class="sidebar-nav-toggle"' in src, (
+        "The collapse affordance should live in the same visual row as the sidebar nav icons"
+    )
+    assert 'class="topbar-sidebar-toggle"' in src, (
+        "Desktop reopen control should live at the top-left, not in the right-side chip cluster"
+    )
+    assert 'class="topbar-heading"' in src, (
+        "Topbar title and sidebar toggle should share a dedicated alignment container"
+    )
+    assert 'class="topbar-inner"' in src, (
+        "Topbar content should live inside a shared content-width container"
+    )
 
 
 def test_sidebar_state_bootstrapped_from_local_storage():
@@ -42,6 +54,7 @@ def test_boot_js_has_sidebar_panel_state_machine():
         "function _setSidebarPanelMode(",
         "function syncSidebarPanelUI(",
         "function toggleSidebarPanel(",
+        "function openSidebarOverlay(",
         "hermes-webui-sidebar-panel",
     ):
         assert needle in src, f"{needle} must exist in static/boot.js"
@@ -55,6 +68,18 @@ def test_desktop_sidebar_collapsed_css_exists():
     assert ".layout.sidebar-collapsed .sidebar" in src, (
         "Layout class should also be able to drive collapsed sidebar state"
     )
-    assert ".sidebar-toggle-btn" in src, (
+    assert ".topbar-sidebar-toggle" in src, (
         "Topbar sidebar toggle styling must exist"
+    )
+    assert ".mobile-overlay.visible" in src, (
+        "Mobile overlay backdrop must still exist for the compact layout"
+    )
+    assert ".topbar-heading" in src, (
+        "Topbar heading layout must exist so the title and toggle align cleanly"
+    )
+    assert "--content-column-max" in src, (
+        "Topbar and message column should share one width variable"
+    )
+    assert ".layout.sidebar-collapsed.workspace-panel-collapsed .messages-inner" in src, (
+        "Only the fully collapsed desktop layout should recenter the chat column"
     )


### PR DESCRIPTION
## Thinking Path

- Hermes WebUI uses a three-panel layout, so collapsing the left sidebar needs to do more than hide a pane.
- The desktop interaction has to preserve clear spatial ownership: left-sidebar controls should stay on the left, and the title row should track the chat column cleanly.
- We first evaluated a more mobile-style pullout interaction, but on desktop that introduced the wrong visual model for reclaimed space.
- We then aligned the layout rules to the state-based behavior seen in NotebookLLM: the chat column can re-center only when both side panels are collapsed, while title and chat alignment should stay coherent when either panel is open.
- This PR refines the desktop sidebar collapse flow around that model so the collapsed and expanded states feel native instead of patched together.

## What Changed

- Moved the desktop collapse affordance into the same top icon row inside the left sidebar instead of giving it a separate header line.
- Removed the previous right-side desktop sidebar toggle treatment and kept the reopen affordance on the left, where it matches the controlled panel.
- Refined the desktop topbar structure so the title block and chat column share a consistent content-width model.
- Applied state-specific layout rules:
  - when both side panels are collapsed, the chat column recenters
  - when either side panel is open, the chat column left-aligns as the main reading column
  - in the fully collapsed state, the title block remains anchored left so reopening the sidebar feels like a natural pull-out from the edge
- Tightened the desktop hamburger alignment so it sits more cleanly on the title baseline.
- Updated regression coverage for the desktop sidebar collapse structure and state rules.
- Added a changelog entry.

## Why It Matters

This makes the desktop sidebar collapse behavior feel intentional instead of merely functional.

The important UX outcomes are:
- the left sidebar is always controlled from the left side
- collapsing the sidebar actually frees space in a way that feels coherent on desktop
- the title row no longer drifts into awkward positions across panel states
- the chat column behaves predictably across the four desktop layout states:
  - left closed / right closed: chat centered, title anchored left
  - left open / right closed: title and chat share the same left reading edge
  - left closed / right open: title and chat share the same left reading edge
  - left open / right open: title and chat share the same left reading edge

## Verification

- `node --check static/boot.js`
- `.venv_test/bin/pytest tests/test_sprint51.py -q`
  - result: `4 passed`
- Manual desktop validation:
  - collapse from the left icon row
  - reopen from the left-side hamburger
  - verify no desktop scrim/overlay remains
  - verify centered chat only when both panels are collapsed
  - verify title/chat alignment when either panel is open

## Risks / Follow-ups

- This PR intentionally focuses on desktop behavior. Mobile sidebar behavior is preserved.
- Before/after screenshots will be added in a follow-up comment.

## Model Used

- Provider: OpenAI
- Model: GPT-5.4
- Tooling: Codex desktop app with local shell, git, and targeted pytest verification

Closes #431
