### PR TITLE
fix(ui): restrict edit to latest user message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Hermes Web UI -- Changelog
 
+## [v0.50.97] — 2026-04-20
+
+### Fixed
+- **Only the latest user message can be edited** — older user turns no longer show the pencil/edit affordance. This avoids implying that historical turns can be lightly edited when the actual action truncates the session and restarts the conversation from that point. (Closes #744)
+
 ## [v0.50.96] — 2026-04-19
 
 ### Added

--- a/static/ui.js
+++ b/static/ui.js
@@ -1409,6 +1409,13 @@ function renderMessages(){
     if(msgContent(m)||m.attachments?.length||(m.role==='assistant'&&(hasTc||hasTu||_messageHasReasoningPayload(m)))) visWithIdx.push({m,rawIdx});
     rawIdx++;
   }
+  let lastUserRawIdx=-1;
+  for(let i=visWithIdx.length-1;i>=0;i--){
+    if(visWithIdx[i].m&&visWithIdx[i].m.role==='user'){
+      lastUserRawIdx=visWithIdx[i].rawIdx;
+      break;
+    }
+  }
   const insertionAnchor=_compressionAnchorIndex(
     visWithIdx,
     compressionState ? compressionState.anchorMessageKey : sessionCompressionAnchorKey,
@@ -1471,7 +1478,8 @@ function renderMessages(){
       filesHtml=`<div class="msg-files">${m.attachments.map(f=>`<div class="msg-file-badge">${li('paperclip',12)} ${esc(f)}</div>`).join('')}</div>`;
     }
     const bodyHtml = isUser ? esc(String(content)).replace(/\n/g,'<br>') : renderMd(_stripXmlToolCallsDisplay(String(content)));
-    const editBtn  = isUser  ? `<button class="msg-action-btn" title="${t('edit_message')}" onclick="editMessage(this)">${li('pencil',13)}</button>` : '';
+    const isEditableUser=isUser&&rawIdx===lastUserRawIdx;
+    const editBtn  = isEditableUser ? `<button class="msg-action-btn" title="${t('edit_message')}" onclick="editMessage(this)">${li('pencil',13)}</button>` : '';
     const retryBtn = isLastAssistant ? `<button class="msg-action-btn" title="${t('regenerate')}" onclick="regenerateResponse(this)">${li('rotate-ccw',13)}</button>` : '';
     const copyBtn  = `<button class="msg-copy-btn msg-action-btn" title="${t('copy')}" onclick="copyMsg(this)">${li('copy',13)}</button>`;
     const tsVal=m._ts||m.timestamp;

--- a/tests/test_issue744.py
+++ b/tests/test_issue744.py
@@ -1,0 +1,9 @@
+import pathlib
+
+
+def test_only_latest_user_message_gets_edit_button():
+    src = pathlib.Path("static/ui.js").read_text(encoding="utf-8")
+    assert "let lastUserRawIdx=-1;" in src
+    assert "const isEditableUser=isUser&&rawIdx===lastUserRawIdx;" in src
+    assert "const editBtn  = isEditableUser ?" in src
+


### PR DESCRIPTION
## Summary
- restrict the edit pencil to the latest user message only
- keep older user messages read-only for low-risk actions like copy / timestamp
- add a regression test for the latest-user-only edit condition

Closes #744.

## Why
The current pencil affordance looks like a lightweight inline edit, but for older user messages the actual behavior is destructive: it truncates the session and restarts the conversation from that point.

This keeps the existing truncate + resend behavior for the latest user message, where that interaction is still understandable, and removes the misleading edit affordance from historical turns.

## Verification
- `node --check static/ui.js`
- `pytest tests/test_issue744.py -q`
