### PR TITLE
fix(ui): dark-mode user bubbles use subtle tint + thinking card collapsible — v0.50.111

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Hermes Web UI -- Changelog
 
+## [v0.50.111] — 2026-04-20
+
+### Fixed
+- **Dark-mode user bubbles no longer use a glaring bright accent fill** — `:root.dark` now overrides `--user-bubble-bg`/`--user-bubble-border` to `var(--accent-bg-strong)` (a 15% tint), keeping the bubble visually subdued in dark skins. The 6 per-skin `--user-bubble-text` hacks are removed; text color falls back to `var(--text)`. Edit-area box-shadow now uses the shared `--focus-ring` token. (credit: @aronprins)
+- **Thinking card header is now collapsible** — the main `_thinkingMarkup()` function now includes `onclick` toggle and the chevron affordance, matching the compression reference card pattern. The header has `display:flex` for proper icon/label/chevron alignment.
+
 ## [v0.50.110] — 2026-04-20
 
 ### Fixed

--- a/static/style.css
+++ b/static/style.css
@@ -1543,17 +1543,15 @@ body.resizing{user-select:none;cursor:col-resize;}
   --user-bubble-bg: var(--accent);
   --user-bubble-border: var(--accent-hover);
   --user-bubble-text: #fff;
+  --user-bubble-placeholder: rgba(255,255,255,.7);
 }
-/* Dark mode: bright accents need dark text for contrast */
+/* Dark mode: keep user bubbles dark; skin remains a tint via border/fill. */
 :root.dark {
-  --user-bubble-text: #1a1a2a;
+  --user-bubble-bg: var(--accent-bg-strong);
+  --user-bubble-border: var(--accent-bg-strong);
+  --user-bubble-text: var(--text);
+  --user-bubble-placeholder: var(--muted);
 }
-:root.dark[data-skin="ares"] { --user-bubble-text: #1a1a2a; }
-:root.dark[data-skin="mono"] { --user-bubble-text: #1a1a2a; }
-:root.dark[data-skin="slate"] { --user-bubble-text: #0f172a; }
-:root.dark[data-skin="poseidon"] { --user-bubble-text: #0a1628; }
-:root.dark[data-skin="sisyphus"] { --user-bubble-text: #1a1a2a; }
-:root.dark[data-skin="charizard"] { --user-bubble-text: #1a1a2a; }
 
 /* Inline code: stop shouting orange; inherit strong text colour instead */
 .msg-body code { color: var(--strong); background: var(--code-inline-bg); font-size: 12.5px; }
@@ -1613,8 +1611,8 @@ body.resizing{user-select:none;cursor:col-resize;}
 .msg-row[data-role="user"] .msg-body code { color: var(--user-bubble-text); background: rgba(0,0,0,.1); }
 .msg-row[data-role="user"] .msg-body a { color: var(--user-bubble-text); text-decoration: underline; }
 .msg-row[data-role="user"] .msg-files { padding-left: 0; margin-left: 0; justify-content: flex-end; }
-.msg-row[data-role="user"][data-editing="1"] .msg-edit-area { background: var(--user-bubble-bg); border-color: var(--user-bubble-border); color: var(--user-bubble-text); box-shadow: 0 0 0 3px rgba(255,255,255,.15); }
-.msg-row[data-role="user"][data-editing="1"] .msg-edit-area::placeholder { color: rgba(255,255,255,.5); }
+.msg-row[data-role="user"][data-editing="1"] .msg-edit-area { background: var(--user-bubble-bg); border-color: var(--user-bubble-border); color: var(--user-bubble-text); box-shadow: 0 0 0 3px var(--focus-ring); }
+.msg-row[data-role="user"][data-editing="1"] .msg-edit-area::placeholder { color: var(--user-bubble-placeholder); }
 
 /* Bubble-layout mode: user-card stays intact, just drop the rail margin.
    (:has() form matches the existing bubble-layout rule's specificity so this

--- a/static/style.css
+++ b/static/style.css
@@ -1716,7 +1716,7 @@ body.bubble-layout .msg-row + .msg-row[data-role="user"] { border-top: none; pad
   border-color: var(--accent-hover);
   background: var(--accent-bg);
 }
-.thinking-card-header { padding: 5px 10px; color: var(--accent-text); font-size: 12px; font-weight: 600; opacity: .85; }
+.thinking-card-header { display:flex; align-items:center; gap:8px; padding: 5px 10px; color: var(--accent-text); font-size: 12px; font-weight: 600; opacity: .85; }
 .thinking-card-header:hover { opacity: 1; }
 .thinking-card-icon { opacity: .7; }
 .thinking-card-body {

--- a/static/ui.js
+++ b/static/ui.js
@@ -2096,7 +2096,7 @@ function renderKatexBlocks(){
 
 function _thinkingMarkup(text=''){
   return (text&&String(text).trim())
-    ? `<div class="thinking-card open"><div class="thinking-card-header"><span class="thinking-card-icon">${li('lightbulb',14)}</span><span class="thinking-card-label">${t('thinking')}</span></div><div class="thinking-card-body"><pre>${esc(String(text).trim())}</pre></div></div>`
+    ? `<div class="thinking-card open"><div class="thinking-card-header" onclick="this.parentElement.classList.toggle('open')"><span class="thinking-card-icon">${li('lightbulb',14)}</span><span class="thinking-card-label">${t('thinking')}</span><span class="thinking-card-toggle">${li('chevron-right',12)}</span></div><div class="thinking-card-body"><pre>${esc(String(text).trim())}</pre></div></div>`
     : `<div class="thinking"><div class="dot"></div><div class="dot"></div><div class="dot"></div></div>`;
 }
 function finalizeThinkingCard(){

--- a/tests/test_bugbatch_apr2026.py
+++ b/tests/test_bugbatch_apr2026.py
@@ -54,6 +54,28 @@ def test_594_file_rename_input_has_light_mode_override():
     )
 
 
+# ── dark-mode user bubble semantics ──────────────────────────────────────────
+
+def test_dark_user_bubbles_use_dark_tinted_surface():
+    """Dark mode should keep user bubbles dark, with skin only tinting the bubble."""
+    assert "--user-bubble-bg: var(--accent-bg-strong);" in STYLE_CSS, (
+        "Dark mode user bubbles should use the dark accent tint, not the full bright accent fill"
+    )
+    assert "--user-bubble-border: var(--accent-bg-strong);" in STYLE_CSS, (
+        "Dark mode user bubble borders should match the quieter thinking-card border intensity"
+    )
+    assert "--user-bubble-text: var(--text);" in STYLE_CSS, (
+        "Dark mode user bubble text should inherit the theme text color"
+    )
+
+
+def test_dark_user_bubbles_do_not_need_per_skin_text_hacks():
+    """Dark-mode user bubble contrast should not rely on per-skin text overrides."""
+    assert re.search(r':root\.dark\[data-skin="[^"]+"\]\s*\{\s*--user-bubble-text:', STYLE_CSS) is None, (
+        "Dark-mode user bubble contrast should come from shared theme tokens, not per-skin text hacks"
+    )
+
+
 # ── #576: workspace panel snap fix ───────────────────────────────────────────
 
 def test_576_panel_restore_gated_on_workspace():

--- a/tests/test_ui_card_animation.py
+++ b/tests/test_ui_card_animation.py
@@ -23,6 +23,7 @@ def test_tool_card_detail_uses_transitionable_collapsed_state():
 
 def test_thinking_card_toggle_and_body_use_animation_friendly_state():
     assert ".thinking-card-toggle{margin-left:auto;font-size:10px;display:inline-flex;" in COMPACT_CSS
+    assert ".thinking-card-header{display:flex;align-items:center;gap:8px;" in COMPACT_CSS
     # Body uses div default (display:block); canonical rule lives in the
     # consolidated block. Open state caps at 260px (intentional "quieter" sizing).
     assert ".thinking-card-body{max-height:0;opacity:0;overflow:hidden;" in COMPACT_CSS
@@ -35,6 +36,7 @@ def test_thinking_card_toggle_and_body_use_animation_friendly_state():
 def test_tool_card_toggle_uses_same_chevron_icon_markup_as_thinking_card():
     assert "<span class=\"thinking-card-toggle\">${li('chevron-right',12)}</span>" in UI_JS
     assert "<span class=\"tool-card-toggle\">${li('chevron-right',12)}</span>" in UI_JS
+    assert "<div class=\"thinking-card open\"><div class=\"thinking-card-header\" onclick=\"this.parentElement.classList.toggle('open')\"><span class=\"thinking-card-icon\">" in UI_JS
 
 
 def test_thinking_card_uses_panel_chrome_with_gold_palette():


### PR DESCRIPTION
## Summary

Rebased on behalf of @aronprins from fork branch `codex/dark-user-bubbles`. Two asset-only commits (PR screenshot add/remove) were dropped; the two code commits are applied cleanly on top of current master (v0.50.110).

### What changed

**Dark-mode user bubbles** (`static/style.css`):
- `:root.dark` now overrides `--user-bubble-bg`/`--user-bubble-border` to `var(--accent-bg-strong)` (a 15% opacity tint) — keeps the bubble visually subdued in dark skins instead of a glaring bright accent fill
- Removes 6 per-skin `--user-bubble-text` hacks (ares, mono, slate, poseidon, sisyphus, charizard); text falls back to `var(--text)` which is already correct in dark mode
- Adds `--user-bubble-placeholder` token; edit-area box-shadow now uses `--focus-ring` instead of hardcoded `rgba(255,255,255,.15)`

**Thinking card collapsibility** (`static/ui.js` + `static/style.css`):
- `_thinkingMarkup()` now includes `onclick` toggle and chevron affordance, matching the compression reference card pattern
- `.thinking-card-header` gets `display:flex; gap:8px` for proper icon/label/chevron alignment

**Tests**: 2 new in `test_bugbatch_apr2026.py` (dark bubble token contract + no-per-skin-hack assertion), 2 updated in `test_ui_card_animation.py` (flex header layout + onclick pattern).

1520 passed. QA 20/20. Browser verified: dark mode bubble uses subtle tint, thinking card toggles correctly.

(credit: @aronprins)
