### PR TITLE
[codex] Use Hermes config as default model source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Hermes Web UI -- Changelog
 
+## [v0.50.112] — 2026-04-20
+
+### Fixed
+- **Default model now follows Hermes config instead of a separate WebUI setting** — the Settings modal and onboarding flow no longer persist `default_model` into `~/.hermes/webui/settings.json`. The effective default model now comes from Hermes `config.yaml` and model updates write back there, so saving unrelated WebUI preferences can no longer overwrite the runtime model fallback used by new sessions. This keeps the browser UI aligned with Hermes CLI / gateway defaults and avoids split-brain model state. (Fixes #761)
+
 ## [v0.50.111] — 2026-04-20
 
 ### Fixed

--- a/api/config.py
+++ b/api/config.py
@@ -209,6 +209,35 @@ def reload_config() -> None:
             logger.debug("Failed to load yaml config from %s", config_path)
 
 
+def _load_yaml_config_file(config_path: Path) -> dict:
+    try:
+        import yaml as _yaml
+    except ImportError:
+        return {}
+
+    if not config_path.exists():
+        return {}
+    try:
+        loaded = _yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        return loaded if isinstance(loaded, dict) else {}
+    except Exception:
+        logger.debug("Failed to parse yaml config from %s", config_path)
+        return {}
+
+
+def _save_yaml_config_file(config_path: Path, config_data: dict) -> None:
+    try:
+        import yaml as _yaml
+    except ImportError as exc:
+        raise RuntimeError("PyYAML is required to write Hermes config.yaml") from exc
+
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(
+        _yaml.safe_dump(config_data, sort_keys=False, allow_unicode=True),
+        encoding="utf-8",
+    )
+
+
 # Initial load
 reload_config()
 cfg = _cfg_cache  # alias for backward compat with existing references
@@ -710,6 +739,64 @@ def resolve_model_provider(model_id: str) -> tuple:
     return model_id, config_provider, config_base_url
 
 
+def get_effective_default_model(config_data: dict | None = None) -> str:
+    """Resolve the effective Hermes default model from config, then env overrides."""
+    active_cfg = config_data if config_data is not None else cfg
+    default_model = DEFAULT_MODEL
+
+    model_cfg = active_cfg.get("model", {})
+    if isinstance(model_cfg, str):
+        default_model = model_cfg.strip()
+    elif isinstance(model_cfg, dict):
+        cfg_default = str(model_cfg.get("default") or "").strip()
+        if cfg_default:
+            default_model = cfg_default
+
+    env_model = (
+        os.getenv("HERMES_MODEL") or os.getenv("OPENAI_MODEL") or os.getenv("LLM_MODEL")
+    )
+    if env_model:
+        default_model = env_model.strip()
+    return default_model
+
+
+def set_hermes_default_model(model_id: str) -> dict:
+    """Persist the Hermes default model in config.yaml and reload runtime config."""
+    selected_model = str(model_id or "").strip()
+    if not selected_model:
+        raise ValueError("model is required")
+
+    config_path = _get_config_path()
+    config_data = _load_yaml_config_file(config_path)
+    model_cfg = config_data.get("model", {})
+    if not isinstance(model_cfg, dict):
+        model_cfg = {}
+
+    previous_provider = str(model_cfg.get("provider") or "").strip()
+    resolved_model, resolved_provider, resolved_base_url = resolve_model_provider(
+        selected_model
+    )
+    persisted_model = str(resolved_model or selected_model).strip()
+    persisted_provider = str(resolved_provider or previous_provider or "").strip()
+
+    model_cfg["default"] = persisted_model
+    if persisted_provider:
+        model_cfg["provider"] = persisted_provider
+
+    if resolved_base_url:
+        model_cfg["base_url"] = str(resolved_base_url).strip().rstrip("/")
+    elif persisted_provider != previous_provider:
+        if persisted_provider == "openai":
+            model_cfg["base_url"] = "https://api.openai.com/v1"
+        elif not persisted_provider.startswith("custom:"):
+            model_cfg.pop("base_url", None)
+
+    config_data["model"] = model_cfg
+    _save_yaml_config_file(config_path, config_data)
+    reload_config()
+    return get_available_models()
+
+
 def get_available_models() -> dict:
     """
     Return available models grouped by provider.
@@ -736,7 +823,7 @@ def get_available_models() -> dict:
     if _current_mtime != _cfg_mtime:
         reload_config()
     active_provider = None
-    default_model = DEFAULT_MODEL
+    default_model = get_effective_default_model(cfg)
     groups = []
 
     # 1. Read config.yaml model section
@@ -752,14 +839,7 @@ def get_available_models() -> dict:
         if cfg_default:
             default_model = cfg_default
 
-    # 2. Also check env vars for model override
-    env_model = (
-        os.getenv("HERMES_MODEL") or os.getenv("OPENAI_MODEL") or os.getenv("LLM_MODEL")
-    )
-    if env_model:
-        default_model = env_model.strip()
-
-    # 3. Try to read auth store for active provider (if hermes is installed)
+    # 2. Try to read auth store for active provider (if hermes is installed)
     if not active_provider:
         try:
             from api.profiles import get_active_hermes_home as _gah
@@ -1258,7 +1338,7 @@ _SETTINGS_DEFAULTS = {
     "bubble_layout": False,  # right-aligned user / left-aligned assistant chat bubbles
     "password_hash": None,  # PBKDF2-HMAC-SHA256 hash; None = auth disabled
 }
-_SETTINGS_LEGACY_DROP_KEYS = {"assistant_language"}
+_SETTINGS_LEGACY_DROP_KEYS = {"assistant_language", "default_model"}
 _SETTINGS_THEME_VALUES = {"light", "dark", "system"}
 _SETTINGS_SKIN_VALUES = {
     "default",
@@ -1345,10 +1425,14 @@ def load_settings() -> dict:
         stored.get("theme") if isinstance(stored, dict) else settings.get("theme"),
         stored.get("skin") if isinstance(stored, dict) else settings.get("skin"),
     )
+    settings["default_model"] = get_effective_default_model()
     return settings
 
 
-_SETTINGS_ALLOWED_KEYS = set(_SETTINGS_DEFAULTS.keys()) - {"password_hash"}
+_SETTINGS_ALLOWED_KEYS = set(_SETTINGS_DEFAULTS.keys()) - {
+    "password_hash",
+    "default_model",
+}
 _SETTINGS_ENUM_VALUES = {
     "send_key": {"enter", "ctrl+enter"},
 }
@@ -1418,16 +1502,16 @@ def save_settings(settings: dict) -> dict:
     current["default_workspace"] = str(
         resolve_default_workspace(current.get("default_workspace"))
     )
+    persisted = {k: v for k, v in current.items() if k != "default_model"}
     SETTINGS_FILE.write_text(
-        json.dumps(current, ensure_ascii=False, indent=2),
+        json.dumps(persisted, ensure_ascii=False, indent=2),
         encoding="utf-8",
     )
     # Update runtime defaults so new sessions use them immediately
-    global DEFAULT_MODEL, DEFAULT_WORKSPACE
-    if "default_model" in current:
-        DEFAULT_MODEL = current["default_model"]
+    global DEFAULT_WORKSPACE
     if "default_workspace" in current:
         DEFAULT_WORKSPACE = resolve_default_workspace(current["default_workspace"])
+    current["default_model"] = get_effective_default_model()
     return current
 
 
@@ -1442,14 +1526,13 @@ try:
 except OSError:
     _settings_file_exists = False
 if _settings_file_exists:
-    if _startup_settings.get("default_model"):
-        DEFAULT_MODEL = _startup_settings["default_model"]
     if not os.getenv("HERMES_WEBUI_DEFAULT_WORKSPACE"):
         DEFAULT_WORKSPACE = resolve_default_workspace(
             _startup_settings.get("default_workspace")
         )
     if _startup_settings.get("default_workspace") != str(DEFAULT_WORKSPACE):
         _startup_settings["default_workspace"] = str(DEFAULT_WORKSPACE)
+        _startup_settings.pop("default_model", None)
         try:
             SETTINGS_FILE.write_text(
                 json.dumps(_startup_settings, ensure_ascii=False, indent=2),

--- a/api/models.py
+++ b/api/models.py
@@ -8,10 +8,10 @@ import time
 import uuid
 from pathlib import Path
 
-import api.config as _cfg
 from api.config import (
     SESSION_DIR, SESSION_INDEX_FILE, SESSIONS, SESSIONS_MAX,
-    LOCK, DEFAULT_WORKSPACE, DEFAULT_MODEL, PROJECTS_FILE, HOME
+    LOCK, DEFAULT_WORKSPACE, DEFAULT_MODEL, PROJECTS_FILE, HOME,
+    get_effective_default_model,
 )
 from api.workspace import get_last_workspace
 
@@ -134,13 +134,18 @@ def get_session(sid):
     raise KeyError(sid)
 
 def new_session(workspace=None, model=None):
-    # Use _cfg.DEFAULT_MODEL (not the import-time snapshot) so save_settings() changes take effect
+    # Use the live config-derived default so Hermes config changes apply without restart.
     try:
         from api.profiles import get_active_profile_name
         _profile = get_active_profile_name()
     except ImportError:
         _profile = None
-    s = Session(workspace=workspace or get_last_workspace(), model=model or _cfg.DEFAULT_MODEL, profile=_profile)
+    effective_model = model or get_effective_default_model()
+    s = Session(
+        workspace=workspace or get_last_workspace(),
+        model=effective_model,
+        profile=_profile,
+    )
     with LOCK:
         SESSIONS[s.session_id] = s
         SESSIONS.move_to_end(s.session_id)

--- a/api/routes.py
+++ b/api/routes.py
@@ -47,6 +47,7 @@ from api.config import (
     CHAT_LOCK,
     load_settings,
     save_settings,
+    set_hermes_default_model,
 )
 from api.helpers import (
     require,
@@ -880,6 +881,14 @@ def handle_post(handler, parsed) -> bool:
             return bad(handler, str(e))
         s = new_session(workspace=workspace, model=body.get("model"))
         return j(handler, {"session": s.compact() | {"messages": s.messages}})
+
+    if parsed.path == "/api/default-model":
+        try:
+            return j(handler, set_hermes_default_model(body.get("model")))
+        except ValueError as e:
+            return bad(handler, str(e))
+        except RuntimeError as e:
+            return bad(handler, str(e), 500)
 
     if parsed.path == "/api/sessions/cleanup":
         return _handle_sessions_cleanup(handler, body, zero_only=False)

--- a/static/onboarding.js
+++ b/static/onboarding.js
@@ -321,7 +321,7 @@ async function _saveOnboardingDefaults(){
   if(!known){
     await api('/api/workspaces/add',{method:'POST',body:JSON.stringify({path:workspace})});
   }
-  const body={default_workspace:workspace,default_model:model};
+  const body={default_workspace:workspace};
   if(password) body._set_password=password;
   const saved=await api('/api/settings',{method:'POST',body:JSON.stringify(body)});
   if(ONBOARDING.status){

--- a/static/panels.js
+++ b/static/panels.js
@@ -1075,6 +1075,7 @@ document.addEventListener('drop',e=>{e.preventDefault();dragCounter=0;wrap.class
 let _settingsDirty = false;
 let _settingsThemeOnOpen = null; // track theme at open time for discard revert
 let _settingsSkinOnOpen = null; // track skin at open time for discard revert
+let _settingsHermesDefaultModelOnOpen = '';
 let _settingsSection = 'conversation';
 
 function switchSettingsSection(name){
@@ -1232,8 +1233,9 @@ async function loadSettingsPanel(){
           }
           modelSel.appendChild(og);
         }
+        _settingsHermesDefaultModelOnOpen=models.default_model||'';
+        modelSel.value=_settingsHermesDefaultModelOnOpen;
       }catch(e){}
-      modelSel.value=settings.default_model||'';
       modelSel.addEventListener('change',_markSettingsDirty,{once:false});
     }
     // Send key preference
@@ -1314,6 +1316,7 @@ function _applySavedSettingsUi(saved, body, opts){
   _settingsSkinOnOpen=skin||'default';
   const bar=$('settingsUnsavedBar');
   if(bar) bar.style.display='none';
+  _settingsHermesDefaultModelOnOpen=body.default_model||_settingsHermesDefaultModelOnOpen||'';
   renderMessages();
   if(typeof syncTopbar==='function') syncTopbar();
   if(typeof renderSessionList==='function') renderSessionList();
@@ -1321,6 +1324,7 @@ function _applySavedSettingsUi(saved, body, opts){
 
 async function saveSettings(andClose){
   const model=($('settingsModel')||{}).value;
+  const modelChanged=(model||'')!==(_settingsHermesDefaultModelOnOpen||'');
   const sendKey=($('settingsSendKey')||{}).value;
   const showTokenUsage=!!($('settingsShowTokenUsage')||{}).checked;
   const showCliSessions=!!($('settingsShowCliSessions')||{}).checked;
@@ -1329,7 +1333,6 @@ async function saveSettings(andClose){
   const skin=($('settingsSkin')||{}).value||'default';
   const language=($('settingsLanguage')||{}).value||'en';
   const body={};
-  if(model) body.default_model=model;
 
   if(sendKey) body.send_key=sendKey;
   body.theme=theme;
@@ -1349,6 +1352,10 @@ async function saveSettings(andClose){
   if(pw && pw.trim()){
     try{
       const saved=await api('/api/settings',{method:'POST',body:JSON.stringify({...body,_set_password:pw.trim()})});
+      if(modelChanged && model){
+        await api('/api/default-model',{method:'POST',body:JSON.stringify({model})});
+        body.default_model=model;
+      }
       _applySavedSettingsUi(saved, body, {sendKey,showTokenUsage,showCliSessions,theme,skin,language});
       showToast(t(saved.auth_just_enabled?'settings_saved_pw':'settings_saved_pw_updated'));
       _hideSettingsPanel();
@@ -1357,6 +1364,10 @@ async function saveSettings(andClose){
   }
   try{
     const saved=await api('/api/settings',{method:'POST',body:JSON.stringify(body)});
+    if(modelChanged && model){
+      await api('/api/default-model',{method:'POST',body:JSON.stringify({model})});
+      body.default_model=model;
+    }
     _applySavedSettingsUi(saved, body, {sendKey,showTokenUsage,showCliSessions,theme,skin,language});
     showToast(t('settings_saved'));
     _hideSettingsPanel();

--- a/tests/test_sprint12.py
+++ b/tests/test_sprint12.py
@@ -38,27 +38,26 @@ def test_settings_get_returns_defaults():
     assert 'default_model' in d
     assert 'default_workspace' in d
 
-def test_settings_post_persists():
-    """POST /api/settings saves and returns merged settings."""
-    d, status = post("/api/settings", {"default_model": "test/model-123"})
+def test_default_model_updates_hermes_config():
+    """POST /api/default-model updates the effective Hermes default model."""
+    original, _ = get("/api/models")
+    original_model = original["default_model"]
+    d, status = post("/api/default-model", {"model": "anthropic/claude-sonnet-4.6"})
     assert status == 200
-    assert d['default_model'] == 'test/model-123'
-    # Verify it persisted
+    assert d['default_model'].endswith('claude-sonnet-4.6')
     d2, _ = get("/api/settings")
-    assert d2['default_model'] == 'test/model-123'
-    # Restore
-    post("/api/settings", {"default_model": "openai/gpt-5.4-mini"})
+    assert d2['default_model'] == d['default_model']
+    post("/api/default-model", {"model": original_model})
 
 def test_settings_partial_update():
     """POST /api/settings with partial data doesn't clobber other fields."""
     d1, _ = get("/api/settings")
     original_ws = d1['default_workspace']
-    post("/api/settings", {"default_model": "anthropic/claude-sonnet-4.6"})
+    post("/api/settings", {"send_key": "ctrl+enter"})
     d2, _ = get("/api/settings")
-    assert d2['default_model'] == 'anthropic/claude-sonnet-4.6'
+    assert d2['send_key'] == 'ctrl+enter'
     assert d2['default_workspace'] == original_ws
-    # Restore
-    post("/api/settings", {"default_model": "openai/gpt-5.4-mini"})
+    post("/api/settings", {"send_key": "enter"})
 
 
 # ── Session Pinning ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Thinking Path
- Hermes WebUI should reflect Hermes runtime configuration instead of maintaining a second persistent default-model state.
- The bug was that the Settings modal and onboarding flow persisted `default_model` into `~/.hermes/webui/settings.json`, while Hermes itself resolves its runtime default from `config.yaml`.
- That split-brain state let unrelated WebUI settings saves change the fallback model used by new WebUI sessions, diverging from Hermes CLI / gateway defaults.
- This PR removes WebUI ownership of the persisted default model and makes Hermes config the single source of truth.
- The result is that changing unrelated WebUI preferences no longer rewrites the effective default model, and the browser UI stays aligned with Hermes itself.

## What Changed
- Added a dedicated backend path to persist the default model into Hermes `config.yaml` and reload the runtime model catalog from that source.
- Stopped persisting `default_model` in WebUI `settings.json`; `load_settings()` now exposes the effective Hermes default model for compatibility, but `save_settings()` no longer stores or mutates it.
- Updated the Settings modal to load the default model from `/api/models` and save model changes through the new Hermes-config endpoint.
- Updated onboarding to stop posting `default_model` into `/api/settings`.
- Updated session creation to use the live Hermes-config-derived default model.
- Added a changelog entry and adjusted regression coverage around the new default-model flow.
- No visual UI change, so there are no before/after screenshots.

## Why It Matters
- Removes the duplicate persisted source of truth for the default model.
- Keeps WebUI, Hermes CLI, and Hermes gateway aligned on the same default model.
- Prevents unrelated WebUI settings saves from silently changing model fallback behavior.
- Reduces the chance of provider/auth mismatches caused by stale or conflicting WebUI-owned defaults.

## Verification
- `python3 -m py_compile api/config.py api/routes.py api/models.py`
- `python3 -m pytest tests/test_sprint12.py tests/test_sprint19.py tests/test_sprint26.py -q`
- `python3 -m pytest tests/ -v`
  - Result: `1474 passed, 46 skipped, 1 warning in 41.36s`

## Risks / Follow-ups
- This changes persistence ownership for `default_model`, so existing stale `default_model` values in `~/.hermes/webui/settings.json` are now ignored rather than migrated.
- I did not add UI screenshots because the behavior change does not alter the rendered interface.
- This PR does not address separate stale in-memory gateway override state inside Hermes itself; it only fixes the WebUI-side source-of-truth problem.

## Model Used
- Provider: OpenAI
- Model: Codex desktop agent (the exact underlying GPT-5 model identifier is not exposed in-session)
- Notable mode/tool use: local git, `gh`, `apply_patch`, targeted verification plus full `pytest tests/ -v`

## AI Usage Disclosure
- Provider: OpenAI
- Exact model name or ID: Codex desktop agent (exact underlying model ID not exposed in-session)
- Notable mode or tool use that mattered: local repo inspection, patch application, full local test run, GitHub CLI for branch push and PR creation

Refs #761
