### PR TITLE
Add language indicator to Hermes-Wiki project card

### DIFF
--- a/community/index.html
+++ b/community/index.html
@@ -271,7 +271,7 @@
 
         <a href="https://github.com/cclank/Hermes-Wiki" target="_blank" rel="noopener" class="project-card">
           <div class="project-header">
-            <div class="project-name">Hermes-Wiki</div>
+            <div class="project-name">Hermes-Wiki <span style="font-weight: normal; font-size: 12px;">(Chinese / 中文)</span></div>
             <span class="project-stars"><svg viewBox="0 0 16 16"><path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25z"/></svg>191</span>
           </div>
           <div class="project-desc">Complete Hermes agent wiki with source code walkthroughs, architecture deep-dives, and LLM integration details.</div>


### PR DESCRIPTION

## Thinking Path

- The Hermes-Wiki link points to Chinese-only content with no language indicator
- Chinese speakers may miss it; non-Chinese speakers waste a click finding out they can't read it
- A bilingual label solves both problems at a glance

## What Changed

- Added `(Chinese / 中文)` label to the Hermes-Wiki project card

## Why It Matters

- Helps Chinese speakers find relevant content
- Saves non-Chinese speakers from clicking through to unreadable content

## Verification

- Confirmed label renders correctly and layout is unaffected

## Risks / Follow-ups

- None. Display-only change to a single card.

## Model Used

GLM 5.1 — translation and PR drafting only. Code change was human-authored.

## Screenshots:
<img width="600" height="619" alt="after" src="https://github.com/user-attachments/assets/15979c3d-227e-41b2-b442-22c97321e6aa" />
<img width="600" height="645" alt="before" src="https://github.com/user-attachments/assets/7c78347d-a4d8-4107-aa30-47bd2ec06ac5" />
