### PR TITLE
fix: eagerly release session lock in cancel_stream() (#653)

### DIFF
--- a/api/streaming.py
+++ b/api/streaming.py
@@ -1426,7 +1426,14 @@ def _run_agent_streaming(session_id, msg_text, model, workspace, stream_id, atta
 
 
 def cancel_stream(stream_id: str) -> bool:
-    """Signal an in-flight stream to cancel. Returns True if the stream existed."""
+    """Signal an in-flight stream to cancel. Returns True if the stream existed.
+
+    Eagerly releases the session lock (pops STREAMS, clears active_stream_id)
+    so that new /api/chat/start requests succeed immediately after cancel,
+    even if the agent thread is still blocked in a C-level syscall.
+    The worker thread's eventual STREAMS.pop() in the finally block is a
+    no-op (dict.pop with default None), so there is no double-pop risk.
+    """
     with STREAMS_LOCK:
         if stream_id not in STREAMS:
             return False
@@ -1471,4 +1478,28 @@ def cancel_stream(stream_id: str) -> bool:
                 q.put_nowait(('cancel', {'message': 'Cancelled by user'}))
             except Exception:
                 logger.debug("Failed to put cancel event to queue")
+
+        # --- Eager session lock release (fixes #653) ---
+        # Pop stream state so the 409 guard in routes.py sees the session
+        # as idle and allows new /api/chat/start requests.  The worker
+        # thread's finally-block already uses .pop(key, None), so a
+        # double-pop here is safe (no-op).
+        STREAMS.pop(stream_id, None)
+        CANCEL_FLAGS.pop(stream_id, None)
+        AGENT_INSTANCES.pop(stream_id, None)
+
+        # Also clear the session's active_stream_id so the next request
+        # doesn't hit the stale-id fallback path either.
+        _session_id = getattr(agent, 'session_id', None) if agent else None
+        if _session_id:
+            try:
+                s = get_session(_session_id)
+                s.active_stream_id = None
+                s.pending_user_message = None
+                s.pending_attachments = []
+                s.pending_started_at = None
+                s.save()
+            except Exception:
+                logger.debug("Failed to clear session lock on cancel for %s", _session_id)
+
     return True

--- a/tests/test_sprint51.py
+++ b/tests/test_sprint51.py
@@ -1,0 +1,171 @@
+"""
+Test plan for the #653 fix (eager session lock release in cancel_stream).
+
+These tests verify that after cancel_stream() is called:
+1. STREAMS is popped (so the 409 guard passes)
+2. CANCEL_FLAGS is popped
+3. AGENT_INSTANCES is popped
+4. Session active_stream_id is cleared (when agent is available)
+5. Session pending fields are cleared (when agent is available)
+
+All tests are isolated and clean up after themselves.
+"""
+
+import pytest
+import queue
+import threading
+from unittest.mock import Mock, patch, MagicMock
+
+from api.streaming import cancel_stream
+from api.config import AGENT_INSTANCES, STREAMS, STREAMS_LOCK, CANCEL_FLAGS
+
+
+class TestCancelStreamEagerRelease:
+    """Test suite for #653: eager session lock release on cancel."""
+
+    def setup_method(self):
+        """Clean up before each test."""
+        AGENT_INSTANCES.clear()
+        STREAMS.clear()
+        CANCEL_FLAGS.clear()
+
+    def teardown_method(self):
+        """Clean up after each test."""
+        AGENT_INSTANCES.clear()
+        STREAMS.clear()
+        CANCEL_FLAGS.clear()
+
+    def test_cancel_pops_stream_from_streams_dict(self):
+        """After cancel, stream_id should no longer be in STREAMS."""
+        stream_id = "test_eager_pop"
+        q = queue.Queue()
+        STREAMS[stream_id] = q
+        CANCEL_FLAGS[stream_id] = threading.Event()
+
+        result = cancel_stream(stream_id)
+
+        assert result is True
+        assert stream_id not in STREAMS, \
+            "cancel_stream() should eagerly pop from STREAMS to release the session lock"
+
+    def test_cancel_pops_cancel_flags(self):
+        """After cancel, stream_id should no longer be in CANCEL_FLAGS."""
+        stream_id = "test_eager_flags"
+        STREAMS[stream_id] = queue.Queue()
+        CANCEL_FLAGS[stream_id] = threading.Event()
+
+        cancel_stream(stream_id)
+
+        assert stream_id not in CANCEL_FLAGS, \
+            "cancel_stream() should eagerly pop from CANCEL_FLAGS"
+
+    def test_cancel_pops_agent_instances(self):
+        """After cancel, stream_id should no longer be in AGENT_INSTANCES."""
+        stream_id = "test_eager_agent"
+        mock_agent = Mock()
+        mock_agent.interrupt = Mock()
+        STREAMS[stream_id] = queue.Queue()
+        CANCEL_FLAGS[stream_id] = threading.Event()
+        AGENT_INSTANCES[stream_id] = mock_agent
+
+        cancel_stream(stream_id)
+
+        assert stream_id not in AGENT_INSTANCES, \
+            "cancel_stream() should eagerly pop from AGENT_INSTANCES"
+
+    def test_cancel_clears_session_active_stream_id(self):
+        """After cancel, session.active_stream_id should be None."""
+        stream_id = "test_session_clear"
+        session_id = "sess_abc123"
+        mock_agent = Mock()
+        mock_agent.interrupt = Mock()
+        mock_agent.session_id = session_id
+
+        mock_session = Mock()
+        mock_session.active_stream_id = stream_id
+        mock_session.pending_user_message = "hello"
+        mock_session.pending_attachments = ["file.txt"]
+        mock_session.pending_started_at = 1234567890.0
+
+        STREAMS[stream_id] = queue.Queue()
+        CANCEL_FLAGS[stream_id] = threading.Event()
+        AGENT_INSTANCES[stream_id] = mock_agent
+
+        with patch('api.streaming.get_session', return_value=mock_session):
+            cancel_stream(stream_id)
+
+        assert mock_session.active_stream_id is None, \
+            "cancel_stream() should clear session.active_stream_id"
+        assert mock_session.pending_user_message is None, \
+            "cancel_stream() should clear session.pending_user_message"
+        assert mock_session.pending_attachments == [], \
+            "cancel_stream() should clear session.pending_attachments"
+        assert mock_session.pending_started_at is None, \
+            "cancel_stream() should clear session.pending_started_at"
+        mock_session.save.assert_called_once()
+
+    def test_cancel_without_agent_still_pops_streams(self):
+        """Cancel should pop STREAMS even when no agent instance exists."""
+        stream_id = "test_no_agent"
+        STREAMS[stream_id] = queue.Queue()
+        CANCEL_FLAGS[stream_id] = threading.Event()
+        # No AGENT_INSTANCES entry
+
+        cancel_stream(stream_id)
+
+        assert stream_id not in STREAMS, \
+            "cancel_stream() should pop STREAMS even without agent instance"
+        assert stream_id not in CANCEL_FLAGS
+
+    def test_cancel_sentinel_still_queued(self):
+        """Cancel sentinel should still be queued before popping STREAMS."""
+        stream_id = "test_sentinel"
+        q = queue.Queue()
+        STREAMS[stream_id] = q
+        CANCEL_FLAGS[stream_id] = threading.Event()
+
+        cancel_stream(stream_id)
+
+        # The cancel sentinel should have been queued before the pop
+        assert not q.empty()
+        event_type, data = q.get_nowait()
+        assert event_type == 'cancel'
+        assert data['message'] == 'Cancelled by user'
+
+    def test_double_cancel_is_safe(self):
+        """Calling cancel_stream() twice should not raise."""
+        stream_id = "test_double"
+        mock_agent = Mock()
+        mock_agent.interrupt = Mock()
+        mock_agent.session_id = "sess_xyz"
+
+        STREAMS[stream_id] = queue.Queue()
+        CANCEL_FLAGS[stream_id] = threading.Event()
+        AGENT_INSTANCES[stream_id] = mock_agent
+
+        # First cancel
+        result1 = cancel_stream(stream_id)
+        assert result1 is True
+        assert stream_id not in STREAMS
+
+        # Second cancel (stream already popped)
+        result2 = cancel_stream(stream_id)
+        assert result2 is False
+
+    def test_cancel_handle_get_session_failure(self):
+        """Cancel should not raise even if get_session fails."""
+        stream_id = "test_session_fail"
+        mock_agent = Mock()
+        mock_agent.interrupt = Mock()
+        mock_agent.session_id = "sess_nonexistent"
+
+        STREAMS[stream_id] = queue.Queue()
+        CANCEL_FLAGS[stream_id] = threading.Event()
+        AGENT_INSTANCES[stream_id] = mock_agent
+
+        with patch('api.streaming.get_session', side_effect=KeyError("Session not found")):
+            # Should not raise
+            result = cancel_stream(stream_id)
+
+        assert result is True
+        assert stream_id not in STREAMS


### PR DESCRIPTION
## Thinking Path

- Hermes WebUI aims for near 1:1 parity with the Hermes CLI in a browser
- Long-running chat turns rely on SSE streaming and session recovery
- When the agent encounters a bad tool call (malformed SQL, syntax error in bash eval), it may enter an internal retry loop that blocks the streaming thread indefinitely
- The cancel path (`/api/chat/cancel` → `cancel_stream()`) signals the agent and puts a cancel sentinel in the queue, but does **not** release the session lock (`STREAMS`, `active_stream_id`)
- Because the session lock is never released, all subsequent `/api/chat/start` requests hit the 409 "session already has an active stream" guard in `routes.py` — making the session permanently stuck
- This PR fixes `cancel_stream()` to eagerly pop stream state and clear the session lock after signalling cancel, so new requests succeed immediately even if the agent thread is still blocked

## What Changed

- **`api/streaming.py`** — `cancel_stream()`: added eager session lock release (~20 lines)
  - Pops `STREAMS[stream_id]` after cancel sentinel is queued
  - Pops `CANCEL_FLAGS[stream_id]` and `AGENT_INSTANCES[stream_id]`
  - Clears `s.active_stream_id`, `s.pending_user_message`, `s.pending_attachments`, `s.pending_started_at` on the session (when agent instance is available)
  - All `.pop()` calls use `default=None`, so the worker thread's eventual cleanup in the `finally` block is a safe no-op (no double-pop risk)

- **`tests/test_sprint51.py`** — new test suite (8 tests)
  - Verifies STREAMS is popped after cancel (409 guard passes)
  - Verifies CANCEL_FLAGS is popped
  - Verifies AGENT_INSTANCES is popped
  - Verifies session lock fields are cleared when agent is available
  - Verifies cancel works without agent instance
  - Verifies cancel sentinel is queued before cleanup
  - Verifies double-cancel is idempotent
  - Verifies get_session failures don't break cancel

## Why It Matters

A hung session with no recovery path is a critical UX bug. Users have to restart the WebUI server to recover. This fix makes the cancel button actually work as a recovery mechanism — after clicking cancel, users can immediately send a new message without needing to create a new session or restart the server.

## Verification

- Syntax check: `python -m py_compile api/streaming.py` ✅
- All existing `STREAMS[stream_id] = queue.Queue()` patterns remain unchanged (no structural changes to STREAMS)
- The 409 guard in `routes.py` (line 2162-2163) checks `current_stream_id in STREAMS` — after our pop, this returns False → guard passes ✅
- The worker thread's `finally` block (line 1415-1417) uses `.pop(key, None)` — safe no-op after our eager pop ✅
- New unit tests in `tests/test_sprint51.py` cover all eager release paths
- No changes to `routes.py`, `api/config.py`, or any frontend files

## Risks / Follow-ups

**Risks:**
- The eager pop means the SSE client may receive the cancel sentinel and then see the stream disappear from `/api/chat/stream/status` — this is acceptable because the client already handles stream termination on cancel
- If the agent thread eventually unblocks after cancel, its `finally` block operations become no-ops — no side effects

**Follow-ups (not in this PR):**
- A watchdog thread that scans `STREAMS` for stale entries (streams running >N minutes) and force-releases the session lock — handles cases where the user closes the browser without clicking cancel
- A per-session tool-call retry limit to prevent the agent from entering infinite retry loops (agent-side fix)

## Model Used

- Provider: zai
- Model: glm-5-turbo
- Tools: Hermes Agent (terminal, file tools, GitHub API via urllib)

Closes #653