### PR TITLE
fix(tests): restore conftest default model in teardown — fixes CI ordering failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Hermes Web UI -- Changelog
 
+## [v0.50.123] — 2026-04-21
+
+### Fixed
+- **Default model change surfaced stale value after model-list TTL cache landed** — `set_hermes_default_model()` now explicitly invalidates `_available_models_cache` after `reload_config()`. The 60s TTL cache introduced in v0.50.121 (#780) only invalidates on config-file mtime change, but `reload_config()` resyncs `_cfg_mtime` before `get_available_models()` runs — so the mtime check never fires and the POST response (plus downstream reads within the TTL window) returned the previous model until the cache expired. Root cause of the `test_default_model_updates_hermes_config` CI flake as well. (#788)
+- **Test teardown restores conftest default deterministically** — `test_default_model_updates_hermes_config` now restores to the conftest-injected `TEST_DEFAULT_MODEL` (via `tests/_pytest_port.py`) instead of reading the pre-test value from `/api/models`, so teardown is stable regardless of ordering. Also updates `TESTING.md` automated-test count to 1578. (#788)
+
 ## [v0.50.122] — 2026-04-21
 
 ### Fixed

--- a/TESTING.md
+++ b/TESTING.md
@@ -8,7 +8,7 @@
 > Prerequisites: SSH tunnel is active on port 8787. Open http://localhost:8787 in browser.
 > Server health check: curl http://127.0.0.1:8787/health should return {"status":"ok"}.
 >
-> Automated coverage: 1353 tests collected via `pytest tests/ --collect-only -q`. Includes onboarding coverage for bootstrap/static wizard presence, real provider config persistence (`config.yaml` + `.env`), the `/api/onboarding/*` backend, the onboarding skip/existing-config guard, and CSS regression coverage for smooth thinking/tool card disclosure animation.
+> Automated coverage: 1578 tests collected via `pytest tests/ --collect-only -q`. Includes onboarding coverage for bootstrap/static wizard presence, real provider config persistence (`config.yaml` + `.env`), the `/api/onboarding/*` backend, the onboarding skip/existing-config guard, and CSS regression coverage for smooth thinking/tool card disclosure animation.
 > Run: `pytest tests/ -v --timeout=60`
 >
 > Local regression focus: verify that a previously closed workspace panel stays visually closed from first paint through boot completion on desktop refresh; there should be no brief open-then-close flash.

--- a/api/config.py
+++ b/api/config.py
@@ -800,6 +800,10 @@ def set_hermes_default_model(model_id: str) -> dict:
         _save_yaml_config_file(config_path, config_data)
     # Reload outside the lock — reload_config() acquires _cfg_lock itself.
     reload_config()
+    # reload_config() resyncs _cfg_mtime to the new file mtime, so the mtime
+    # check inside get_available_models() won't trigger invalidation. Drop
+    # the TTL cache explicitly so the next call recomputes with the new model.
+    invalidate_models_cache()
     return get_available_models()
 
 

--- a/tests/_pytest_port.py
+++ b/tests/_pytest_port.py
@@ -40,3 +40,7 @@ TEST_STATE_DIR = pathlib.Path(os.environ.get(
     'HERMES_WEBUI_TEST_STATE_DIR',
     str(_HERMES_HOME / _auto_state_dir_name(_REPO_ROOT))
 ))
+
+# Default model injected by conftest — tests that mutate the default model
+# must restore to this value so later tests see a consistent baseline.
+TEST_DEFAULT_MODEL = os.environ.get('HERMES_WEBUI_DEFAULT_MODEL', 'openai/gpt-5.4-mini')

--- a/tests/test_sprint12.py
+++ b/tests/test_sprint12.py
@@ -3,7 +3,7 @@ Sprint 12 Tests: settings panel, session pinning, session import, SSE reconnect.
 """
 import json, pathlib, urllib.error, urllib.request, urllib.parse
 
-from tests._pytest_port import BASE
+from tests._pytest_port import BASE, TEST_DEFAULT_MODEL
 
 
 def get(path):
@@ -40,8 +40,6 @@ def test_settings_get_returns_defaults():
 
 def test_default_model_updates_hermes_config():
     """POST /api/default-model updates the effective Hermes default model."""
-    original, _ = get("/api/models")
-    original_model = original.get("default_model") or ""
     try:
         d, status = post("/api/default-model", {"model": "anthropic/claude-sonnet-4.6"})
         assert status == 200
@@ -50,9 +48,9 @@ def test_default_model_updates_hermes_config():
         # Both should resolve to the same model (may differ in prefix normalization)
         assert 'claude-sonnet-4.6' in d2['default_model']
     finally:
-        # Always restore — regardless of test ordering or failures
-        if original_model:
-            post("/api/default-model", {"model": original_model})
+        # Always restore to the conftest-injected default so later tests see
+        # a consistent baseline regardless of test ordering.
+        post("/api/default-model", {"model": TEST_DEFAULT_MODEL})
 
 
 def test_settings_does_not_persist_default_model():


### PR DESCRIPTION
## Summary

CI has been failing on `test_default_model_updates_hermes_config` due to test ordering sensitivity. This fixes it.

## Root cause

`set_hermes_default_model()` writes `model.default` to `config.yaml` on disk. The test's `finally` block was restoring using `original_model` from `GET /api/models` — but `get_effective_default_model()` returns the *config.yaml* value when present, not the env var. So:

1. First run: `original_model = "gpt-5.4-mini"` (from env, config.yaml clean)
2. Test sets model → asserts → finally restores `gpt-5.4-mini` to config.yaml
3. Now config.yaml has `model.default = gpt-5.4-mini` persisted
4. Next test run (or different ordering): something else sets default-model before this test runs → `original_model` = that other model → restore bakes in the wrong value
5. Subsequent test that expects `gpt-5.4-mini` gets the wrong model

## Fix

- Expose `TEST_DEFAULT_MODEL` from `tests/_pytest_port.py` (reads `HERMES_WEBUI_DEFAULT_MODEL`, which conftest sets to `openai/gpt-5.4-mini`)
- In the `finally` block, always restore to `TEST_DEFAULT_MODEL` instead of the potentially stale `original_model`

This makes teardown deterministic regardless of test ordering.

## Also included

- `TESTING.md`: update automated test count from 1353 → 1578 (was stale)

## Testing

All 1578 tests pass locally. `test_sprint12.py` passes in isolation and in full suite.
