### PR TITLE
fix: periodic session persistence during streaming (#765)

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -121,14 +121,15 @@ class Session:
     def path(self):
         return SESSION_DIR / f'{self.session_id}.json'
 
-    def save(self, touch_updated_at: bool = True) -> None:
+    def save(self, touch_updated_at: bool = True, skip_index: bool = False) -> None:
         if touch_updated_at:
             self.updated_at = time.time()
         self.path.write_text(
             json.dumps(self.__dict__, ensure_ascii=False, indent=2),
             encoding='utf-8',
         )
-        _write_session_index(updates=[self])
+        if not skip_index:
+            _write_session_index(updates=[self])
 
     @classmethod
     def load(cls, sid):

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -1174,6 +1174,30 @@ def _run_agent_streaming(session_id, msg_text, model, workspace, stream_id, atta
             if _personality_prompt:
                 agent.ephemeral_system_prompt = _personality_prompt
             _previous_messages = list(s.messages or [])
+            # ── Periodic checkpoint during streaming (Issue #765) ──
+            # Saves session to disk every 15 seconds so that messages are
+            # not lost if the server restarts mid-task.  The session index
+            # rebuild is skipped for performance; the final s.save() at task
+            # completion handles the full persist + index update.
+            _checkpoint_stop = threading.Event()
+            _checkpoint_msg_count = [len(s.messages or [])]
+
+            def _periodic_checkpoint():
+                while not _checkpoint_stop.wait(15):
+                    try:
+                        _cur = len(s.messages or [])
+                        if _cur > _checkpoint_msg_count[0]:
+                            s.save(skip_index=True)
+                            _checkpoint_msg_count[0] = _cur
+                    except Exception:
+                        pass
+
+            _ckpt_thread = threading.Thread(
+                target=_periodic_checkpoint, daemon=True,
+                name=f"ckpt-{session_id[:8]}",
+            )
+            _ckpt_thread.start()
+
             result = agent.run_conversation(
                 user_message=workspace_ctx + msg_text,
                 system_message=workspace_system_msg,
@@ -1495,6 +1519,11 @@ def _run_agent_streaming(session_id, msg_text, model, workspace, stream_id, atta
             _apperror_payload['hint'] = _exc_hint
         put('apperror', _apperror_payload)
     finally:
+        # Stop periodic checkpoint thread if it was started (Issue #765)
+        try:
+            _checkpoint_stop.set()
+        except Exception:
+            pass
         _clear_thread_env()  # TD1: always clear thread-local context
         with STREAMS_LOCK:
             STREAMS.pop(stream_id, None)

--- a/tests/test_issue765_streaming_persistence.py
+++ b/tests/test_issue765_streaming_persistence.py
@@ -1,0 +1,222 @@
+"""
+Tests for periodic session persistence during streaming (Issue #765).
+
+Validates:
+  - Session.save(skip_index=True) writes the JSON file but skips the index rebuild
+  - The periodic checkpoint timer fires during a simulated long-running task
+  - Messages accumulated during streaming are persisted to disk before completion
+"""
+import json
+import os
+import threading
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+import api.models as models
+from api.models import Session
+
+
+@pytest.fixture(autouse=True)
+def _isolate_session_dir(tmp_path, monkeypatch):
+    """Redirect SESSION_DIR and SESSION_INDEX_FILE to a temp directory."""
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    index_file = session_dir / "_index.json"
+
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", index_file)
+
+    models.SESSIONS.clear()
+    yield session_dir, index_file
+    models.SESSIONS.clear()
+
+
+def _make_session(session_id="abc123", messages=None):
+    """Helper to create a Session with a known ID."""
+    return Session(
+        session_id=session_id,
+        title="Test Session",
+        messages=messages or [{"role": "user", "content": "hello"}],
+    )
+
+
+class TestSaveSkipIndex:
+    """Tests for the skip_index parameter on Session.save()."""
+
+    def test_save_writes_json_file(self, tmp_path):
+        """save() always writes the session JSON file, regardless of skip_index."""
+        s = _make_session("s1")
+        s.save()
+        assert (s.path).exists()
+        data = json.loads(s.path.read_text())
+        assert data["session_id"] == "s1"
+        assert len(data["messages"]) == 1
+
+    def test_save_with_skip_index_writes_json(self):
+        """save(skip_index=True) still writes the session JSON file."""
+        s = _make_session("s2")
+        s.save(skip_index=True)
+        assert s.path.exists()
+        data = json.loads(s.path.read_text())
+        assert data["session_id"] == "s2"
+
+    def test_save_with_skip_index_skips_index_rebuild(self):
+        """save(skip_index=True) does NOT create or update the session index."""
+        s = _make_session("s3")
+        s.save(skip_index=True)
+        index = models.SESSION_INDEX_FILE
+        # Index should NOT exist after a skip_index save
+        assert not index.exists(), "Index file should not be created with skip_index=True"
+
+    def test_save_without_skip_index_creates_index(self):
+        """save() (default) DOES create the session index."""
+        s = _make_session("s4")
+        s.save()
+        index = models.SESSION_INDEX_FILE
+        assert index.exists(), "Index file should be created by default save()"
+        data = json.loads(index.read_text())
+        sids = [e["session_id"] for e in data]
+        assert "s4" in sids
+
+    def test_skip_index_then_full_save_updates_index(self):
+        """After skip_index saves, a full save() correctly builds the index."""
+        s = _make_session("s5")
+        # First save: skip index (like periodic checkpoint)
+        s.messages.append({"role": "assistant", "content": "hi there"})
+        s.save(skip_index=True)
+        assert not models.SESSION_INDEX_FILE.exists()
+
+        # Second save: full persist (like final save on task completion)
+        s.messages.append({"role": "user", "content": "thanks"})
+        s.save()
+        assert models.SESSION_INDEX_FILE.exists()
+        data = json.loads(s.path.read_text())
+        assert len(data["messages"]) == 3  # user + assistant + user
+
+
+class TestPeriodicCheckpoint:
+    """Tests for the periodic checkpoint mechanism during streaming."""
+
+    def test_checkpoint_timer_persists_new_messages(self):
+        """The periodic checkpoint timer saves messages as they accumulate."""
+        s = _make_session("ckpt1", messages=[{"role": "user", "content": "hello"}])
+
+        stop_event = threading.Event()
+        msg_count = [len(s.messages)]
+
+        def periodic_checkpoint():
+            """Mimics the _periodic_checkpoint closure from streaming.py."""
+            while not stop_event.wait(0.2):  # 200ms interval for fast test
+                try:
+                    cur = len(s.messages)
+                    if cur > msg_count[0]:
+                        s.save(skip_index=True)
+                        msg_count[0] = cur
+                except Exception:
+                    pass
+
+        t = threading.Thread(target=periodic_checkpoint, daemon=True)
+        t.start()
+
+        # Simulate agent adding messages over time
+        time.sleep(0.3)  # Let timer fire once
+        s.messages.append({"role": "assistant", "content": "partial response 1"})
+        time.sleep(0.3)  # Let timer fire again
+        s.messages.append({"role": "assistant", "content": "partial response 2"})
+        time.sleep(0.3)  # Let timer fire again
+
+        stop_event.set()
+        t.join(timeout=2)
+
+        # Verify: the session file on disk has all messages
+        data = json.loads(s.path.read_text())
+        assert len(data["messages"]) == 3  # user + 2 assistant messages
+        assert data["messages"][1]["content"] == "partial response 1"
+        assert data["messages"][2]["content"] == "partial response 2"
+
+    def test_checkpoint_timer_does_not_save_unchanged_session(self):
+        """The periodic checkpoint skips save when no new messages were added."""
+        s = _make_session("ckpt2", messages=[{"role": "user", "content": "hello"}])
+        s.save()  # Ensure file exists on disk
+
+        stop_event = threading.Event()
+        msg_count = [len(s.messages)]
+        save_count = [0]
+
+        def periodic_checkpoint():
+            while not stop_event.wait(0.1):
+                try:
+                    cur = len(s.messages)
+                    if cur > msg_count[0]:
+                        s.save(skip_index=True)
+                        msg_count[0] = cur
+                        save_count[0] += 1
+                except Exception:
+                    pass
+
+        t = threading.Thread(target=periodic_checkpoint, daemon=True)
+        t.start()
+        time.sleep(0.5)  # Timer fires ~5 times, but no new messages
+        stop_event.set()
+        t.join(timeout=2)
+
+        assert save_count[0] == 0, "Should not save when messages haven't changed"
+
+    def test_checkpoint_timer_stops_on_signal(self):
+        """The checkpoint thread exits cleanly when the stop event is set."""
+        s = _make_session("ckpt3")
+        stop_event = threading.Event()
+        iterations = [0]
+
+        def periodic_checkpoint():
+            while not stop_event.wait(0.05):
+                iterations[0] += 1
+
+        t = threading.Thread(target=periodic_checkpoint, daemon=True)
+        t.start()
+        time.sleep(0.2)
+        stop_event.set()
+        t.join(timeout=1)
+
+        # Thread should have stopped; iterations should be bounded
+        assert t.is_alive() is False
+
+    def test_messages_survive_simulated_restart(self):
+        """Messages saved by periodic checkpoint survive a 'process restart'.
+
+        Simulates: agent adds messages → checkpoint saves → session object
+        is discarded (simulating restart) → session reloaded from disk.
+        """
+        s = _make_session("survive1", messages=[{"role": "user", "content": "do stuff"}])
+        s.save()  # Initial save
+
+        # Simulate agent streaming: add messages
+        s.messages.append({"role": "assistant", "content": "I'll help with that"})
+        s.messages.append({"role": "assistant", "content": "Let me search for info"})
+        s.messages.append({"role": "tool", "content": "search results here"})
+        # Periodic checkpoint saves this state
+        s.save(skip_index=True)
+
+        # Simulate server restart: discard in-memory session, reload from disk
+        del s
+        models.SESSIONS.clear()
+
+        reloaded = Session.load("survive1")
+        assert reloaded is not None
+        assert len(reloaded.messages) == 4  # user + assistant + assistant + tool
+        assert reloaded.messages[1]["content"] == "I'll help with that"
+        assert reloaded.messages[3]["content"] == "search results here"
+
+    def test_skip_index_save_with_touch_updated_at_false(self):
+        """save(skip_index=True, touch_updated_at=False) only writes JSON."""
+        s = _make_session("touch1")
+        original_updated_at = s.updated_at
+        time.sleep(0.05)
+        s.save(skip_index=True, touch_updated_at=False)
+        data = json.loads(s.path.read_text())
+        # updated_at should be the original value (not touched)
+        assert data["updated_at"] == original_updated_at
+        assert not models.SESSION_INDEX_FILE.exists()


### PR DESCRIPTION
## Thinking Path
- Issue #765: messages lost when server restarts during streaming
- Root cause: `s.save()` only called after `run_conversation()` completes
- Solution: periodic checkpoint timer saves session every 15s during agent execution
- Index rebuild is skipped during checkpoints for performance; final `s.save()` handles it

## What Changed
- `api/models.py`: Added `skip_index` parameter to `Session.save()` — when `True`, writes the session JSON file but skips the expensive `_write_session_index()` call
- `api/streaming.py`: Launches a daemon thread before `agent.run_conversation()` that saves the session every 15 seconds if new messages were added. Thread is stopped in the outer `finally` block
- `tests/test_issue765_streaming_persistence.py`: 10 new tests covering both the `skip_index` parameter and the periodic checkpoint mechanism

## Why It Matters
Users running long tasks (multi-step research, coding) who experience a server restart (crash, service restart, manual restart) will no longer lose all accumulated messages. Worst case: up to 15 seconds of messages lost instead of the entire conversation.

## Verification
- `pytest tests/test_issue765_streaming_persistence.py -v` — 10/10 pass
- `pytest tests/ -v` (excluding pre-existing failures) — 1623+ pass, no new regressions
- `python3 -m py_compile api/models.py && python3 -m py_compile api/streaming.py` — syntax OK

## Risks / Follow-ups
- **Thread safety**: `s.messages` is read by the checkpoint thread while the agent thread appends to it. CPython GIL makes list operations atomic, so the worst case is a partially-updated message list — still better than losing everything
- **Performance**: Only writes the session JSON (no index rebuild). For sessions with very large message histories, JSON serialization every 15s adds minor I/O
- **Follow-up options**: tool-call checkpoints (save after each tool call for finer granularity), stream resumption UI (detect incomplete sessions on startup)

## Model Used
- Provider: zai
- Model: glm-5-turbo
- Tools: Hermes Agent (terminal, patch, file tools)

Closes #765