### PR TITLE
fix(tests): add autouse cache-isolation fixture to all get_available_models test files

### DIFF
--- a/tests/test_custom_provider_display_name.py
+++ b/tests/test_custom_provider_display_name.py
@@ -5,7 +5,22 @@ When a custom_providers entry carries a `name` field (e.g. "Agent37"), the
 web UI model picker should show that name as the group header rather than the
 generic "Custom" label.
 """
+import pytest
 import api.config as config
+
+
+@pytest.fixture(autouse=True)
+def _isolate_models_cache():
+    """Invalidate the models TTL cache before and after every test in this file."""
+    try:
+        config.invalidate_models_cache()
+    except Exception:
+        pass
+    yield
+    try:
+        config.invalidate_models_cache()
+    except Exception:
+        pass
 
 
 def _models_with_cfg(model_cfg=None, custom_providers=None, active_provider=None):

--- a/tests/test_issue644.py
+++ b/tests/test_issue644.py
@@ -3,6 +3,20 @@ import pytest
 import api.config as _cfg
 
 
+@pytest.fixture(autouse=True)
+def _isolate_models_cache():
+    """Invalidate the models TTL cache before and after every test in this file."""
+    try:
+        _cfg.invalidate_models_cache()
+    except Exception:
+        pass
+    yield
+    try:
+        _cfg.invalidate_models_cache()
+    except Exception:
+        pass
+
+
 def _available_models_with_cfg(cfg_override):
     """Helper: temporarily patch config.cfg, call get_available_models(), restore."""
     old_cfg = dict(_cfg.cfg)

--- a/tests/test_minimax_provider.py
+++ b/tests/test_minimax_provider.py
@@ -8,7 +8,22 @@ Covers:
   - minimax/MiniMax-M2.7 (slash format) is routed via openrouter when active provider differs
 """
 import os
+import pytest
 import api.config as config
+
+
+@pytest.fixture(autouse=True)
+def _isolate_models_cache():
+    """Invalidate the models TTL cache before and after every test in this file."""
+    try:
+        config.invalidate_models_cache()
+    except Exception:
+        pass
+    yield
+    try:
+        config.invalidate_models_cache()
+    except Exception:
+        pass
 
 
 # ── Helper ────────────────────────────────────────────────────────────────────

--- a/tests/test_model_resolver.py
+++ b/tests/test_model_resolver.py
@@ -3,6 +3,7 @@ Tests for resolve_model_provider() model routing logic.
 Verifies that model IDs are correctly resolved to (model, provider, base_url)
 tuples for different provider configurations.
 """
+import pytest
 import api.config as config
 
 
@@ -159,6 +160,30 @@ def test_custom_provider_model_with_slash_routes_to_named_custom_provider():
 
 
 # ── get_available_models() @provider: hint behaviour ──────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _isolate_models_cache():
+    """Invalidate the models TTL cache before and after every test in this file.
+
+    Several helpers here mutate ``config.cfg`` in-memory and call
+    ``get_available_models()``.  Without this guard, a prior test that called
+    ``get_available_models()`` leaves a 60-second TTL cache entry; the next
+    test that mutates cfg and calls the function gets a cache hit instead of
+    running the function body, causing silently wrong results (e.g. the
+    ``test_custom_endpoint_uses_model_config_api_key_for_model_discovery``
+    ``KeyError: 'auth'`` on CI where ``urlopen`` is never reached).
+    """
+    try:
+        config.invalidate_models_cache()
+    except Exception:
+        pass
+    yield
+    try:
+        config.invalidate_models_cache()
+    except Exception:
+        pass
+
 
 def _available_models_with_provider(provider):
     """Helper: temporarily set active_provider in config."""

--- a/tests/test_opencode_providers.py
+++ b/tests/test_opencode_providers.py
@@ -6,7 +6,22 @@ env-var fallback detection.
 import os
 import sys
 import types
+import pytest
 import api.config as config
+
+
+@pytest.fixture(autouse=True)
+def _isolate_models_cache():
+    """Invalidate the models TTL cache before and after every test in this file."""
+    try:
+        config.invalidate_models_cache()
+    except Exception:
+        pass
+    yield
+    try:
+        config.invalidate_models_cache()
+    except Exception:
+        pass
 
 
 # ── Provider registration ─────────────────────────────────────────────


### PR DESCRIPTION
## What this fixes

`tests/test_model_resolver.py::test_custom_endpoint_uses_model_config_api_key_for_model_discovery` has been failing on CI (all 3 Python versions: 3.11, 3.12, 3.13) since the #817 merge.

**Root cause:** `get_available_models()` has a 60-second TTL cache. `test_byok_model_dropdown.py` (introduced in #817) calls it multiple times with monkeypatched `_get_config_path` pointing at tmp paths, populating the cache. When `test_model_resolver.py` runs afterward in the same pytest process (alphabetically: `b` before `m`), the cache TTL hasn't expired. `test_custom_endpoint_uses_model_config_api_key_for_model_discovery` mutates `_cfg.cfg` and calls `get_available_models()` — but gets a cache hit and returns early without ever reaching the `urlopen` mock. `captured` stays empty. `captured['auth']` raises `KeyError`.

The `test_byok_model_dropdown.py` already had this fixture, but it only protects tests within that file. The same problem exists in 4 other test files that also mutate `cfg` and call `get_available_models()`.

**Fix:** Add the same `autouse` `_isolate_models_cache` fixture to all 5 affected files:
- `tests/test_model_resolver.py`
- `tests/test_custom_provider_display_name.py`
- `tests/test_issue644.py`
- `tests/test_minimax_provider.py`
- `tests/test_opencode_providers.py`

Each fixture calls `config.invalidate_models_cache()` before and after every test, ensuring every test starts with a cold cache.

**Verified:** Running all 6 files together in alphabetical CI order — 51/51 pass including the previously-failing test. Full suite: 1747/1747, 0 failures. QA harness all green.
