### PR TITLE
fix(tests): pin _cfg_mtime=0.0 in except so CI reload_config() guard works

### DIFF
--- a/tests/test_model_resolver.py
+++ b/tests/test_model_resolver.py
@@ -273,7 +273,10 @@ def _available_models_with_full_cfg(provider, default, base_url):
     try:
         _cfg._cfg_mtime = _cfg.Path(_cfg._get_config_path()).stat().st_mtime
     except Exception:
-        pass
+        # No config.yaml on this machine (e.g. CI); pin to 0.0 so the mtime check
+        # inside get_available_models() sees 0.0 == 0.0 and doesn't call reload_config(),
+        # which would overwrite the in-memory cfg we just set up.
+        _cfg._cfg_mtime = 0.0
     # Clear model-override env vars to prevent the real profile from leaking in
     _model_env_keys = ('HERMES_MODEL', 'OPENAI_MODEL', 'LLM_MODEL')
     _saved_env = {k: os.environ.pop(k, None) for k in _model_env_keys}
@@ -417,7 +420,9 @@ def test_custom_endpoint_uses_model_config_api_key_for_model_discovery(monkeypat
     try:
         _cfg._cfg_mtime = _cfg.Path(_cfg._get_config_path()).stat().st_mtime
     except Exception:
-        pass
+        # No config.yaml on this machine (e.g. CI); pin to 0.0 so the mtime check
+        # inside get_available_models() sees 0.0 == 0.0 and skips reload_config().
+        _cfg._cfg_mtime = 0.0
     _cfg.cfg.pop('providers', None)
 
     captured = {}


### PR DESCRIPTION
Root cause of persistent CI failure on `test_custom_endpoint_uses_model_config_api_key_for_model_discovery`:

The helper `_available_models_with_full_cfg` and the failing test itself both do:
```python
try:
    _cfg._cfg_mtime = stat().st_mtime
except Exception:
    pass  # ← leaves _cfg_mtime at stale value from a prior test
```

On CI (no `~/.hermes/config.yaml`), `stat()` raises `OSError`. `get_available_models()` then sees `_current_mtime=0.0 != _cfg_mtime=<stale from prior test>`, calls `reload_config()`, overwrites the test's in-memory `cfg`, `api_key` disappears, `urlopen` is never called, `captured['auth']` raises `KeyError`.

**Fix:** The `except` clause now sets `_cfg._cfg_mtime = 0.0` (matching what `get_available_models()` will see when `stat()` also fails), so the reload guard becomes a no-op and the test's `cfg` mutation survives. Same pattern already used correctly in `test_custom_provider_display_name.py` and `test_ttl_cache.py`.

Verified with `HERMES_CONFIG_PATH=/tmp/nonexistent` to reproduce the CI no-config condition locally. 1747/1747 full suite.
