### PR TITLE
docs(testing): update automated test count to 1777

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -8,7 +8,7 @@
 > Prerequisites: SSH tunnel is active on port 8787. Open http://localhost:8787 in browser.
 > Server health check: curl http://127.0.0.1:8787/health should return {"status":"ok"}.
 >
-> Automated coverage: 1578 tests collected via `pytest tests/ --collect-only -q`. Includes onboarding coverage for bootstrap/static wizard presence, real provider config persistence (`config.yaml` + `.env`), the `/api/onboarding/*` backend, the onboarding skip/existing-config guard, and CSS regression coverage for smooth thinking/tool card disclosure animation.
+> Automated coverage: 1777 tests collected via `pytest tests/ --collect-only -q`. Includes onboarding coverage for bootstrap/static wizard presence, real provider config persistence (`config.yaml` + `.env`), the `/api/onboarding/*` backend, the onboarding skip/existing-config guard, and CSS regression coverage for smooth thinking/tool card disclosure animation.
 > Run: `pytest tests/ -v --timeout=60`
 >
 > Local regression focus: verify that a previously closed workspace panel stays visually closed from first paint through boot completion on desktop refresh; there should be no brief open-then-close flash.
@@ -1783,7 +1783,7 @@ Bridged CLI sessions:
 ---
 
 *Last updated: v0.50.91, April 19, 2026*
-*Total automated tests collected: 1688*
+*Total automated tests collected: 1777*
 *Regression gate: tests/test_regressions.py*
 *Run: pytest tests/ -v --timeout=60*
 *Source: <repo>/*


### PR DESCRIPTION
docs(testing): update automated test count to 1777

TESTING.md had two stale references to old test counts (1578 and 1688).
The current suite is 1777 tests as of v0.50.139.

Updated:
- Header blurb: 1578 → 1777
- Footer total: 1688 → 1777

Docs-only, no code changes.
