### PR TITLE
Security: Auto-install executes untrusted Python package code from environment-controlled path

### DIFF
--- a/api/startup.py
+++ b/api/startup.py
@@ -41,10 +41,33 @@ def _agent_dir() -> Path | None:
             return p.resolve()
     return None
 
+
+def _trusted_agent_dir(agent_dir: Path) -> bool:
+    hermes_home = Path(os.environ.get('HERMES_HOME', str(Path.home() / '.hermes'))).expanduser()
+    try:
+        expected = (hermes_home / 'hermes-agent').resolve()
+        if agent_dir.resolve() != expected:
+            return False
+        st = agent_dir.stat()
+        if stat.S_IMODE(st.st_mode) & 0o022:
+            return False
+        if hasattr(os, 'getuid') and st.st_uid != os.getuid():
+            return False
+        return True
+    except OSError:
+        return False
+
 def auto_install_agent_deps() -> bool:
+    enabled = os.environ.get('HERMES_WEBUI_AUTO_INSTALL', '').strip().lower() in ('1', 'true', 'yes')
+    if not enabled:
+        print('[!!] Auto-install skipped: disabled by default.', flush=True)
+        return False
     agent_dir = _agent_dir()
     if agent_dir is None:
         print('[!!] Auto-install skipped: agent directory not found.', flush=True)
+        return False
+    if not _trusted_agent_dir(agent_dir):
+        print('[!!] Auto-install skipped: untrusted agent directory.', flush=True)
         return False
     req_file = agent_dir / 'requirements.txt'
     pyproject = agent_dir / 'pyproject.toml'


### PR DESCRIPTION
## Summary

Security: Auto-install executes untrusted Python package code from environment-controlled path

## Problem

**Severity**: `High` | **File**: `api/startup.py:L44`

The startup helper automatically runs `pip install` against `requirements.txt` or the project directory found via `HERMES_WEBUI_AGENT_DIR` (or `$HERMES_HOME/hermes-agent`). Installing from a local directory/project can execute arbitrary code (build backends, setup hooks, dependency scripts). If an attacker can influence this path or write to that directory, this becomes a code-execution vector during startup.

## Solution

Disable auto-install by default and gate it behind an explicit admin-only flag. Validate the target directory is trusted (owner check, not world/group writable, canonical allowlisted path). Prefer pinned, hash-verified dependencies (`--require-hashes`) and avoid installing directly from mutable local project paths.

## Changes

- `api/startup.py` (modified)