### PR TITLE
fix: thinking card no longer mirrors main response during streaming (closes #852)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Hermes Web UI -- Changelog
 
+## [v0.50.154] — 2026-04-22
+
+### Fixed
+- **Thinking card no longer mirrors main response** — removed early return in `_streamDisplay()` that bypassed think-block stripping when `reasoningText` was populated. (`static/messages.js`) (closes #852)
+
 ## [v0.50.153] — 2026-04-22
 
 ### Fixed

--- a/static/messages.js
+++ b/static/messages.js
@@ -279,7 +279,10 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
   }
   function _streamDisplay(){
     const raw=_stripXmlToolCalls(assistantText);
-    if(reasoningText) return raw;
+    // Always run think-block stripping even when reasoningText is populated.
+    // Some providers emit reasoning content via on_reasoning AND wrap it in
+    // <think> tags in the token stream — the early-return caused the thinking
+    // card and main response to show identical content (closes #852).
     for(const {open,close} of _thinkPairs){
       // Trim leading whitespace before checking for the open tag — some models
       // (e.g. MiniMax) emit newlines before <think>.

--- a/tests/test_issue852_thinking_card_mirror.py
+++ b/tests/test_issue852_thinking_card_mirror.py
@@ -1,0 +1,58 @@
+"""Regression tests for #852 — thinking card must not mirror the main response.
+
+The `_streamDisplay()` function in messages.js had an early return
+`if(reasoningText) return raw` that bypassed think-block stripping when
+the reasoning SSE event had populated `reasoningText`. Providers that emit
+reasoning via BOTH `on_reasoning` AND `<think>` tags in the token stream
+then showed identical content in the thinking card and the main response.
+"""
+import os
+import re
+
+
+_SRC = os.path.join(os.path.dirname(__file__), "..")
+
+
+def _read(name):
+    return open(os.path.join(_SRC, name), encoding="utf-8").read()
+
+
+class TestStreamDisplayStripsThinkBlocksAlways:
+
+    def test_early_return_on_reasoning_text_is_gone(self):
+        """Regression guard: the bypass that caused the thinking card to
+        mirror the main response must stay removed."""
+        js = _read("static/messages.js")
+        m = re.search(r'function _streamDisplay\(\)\{.*?\n  \}', js, re.DOTALL)
+        assert m, "_streamDisplay not found"
+        fn = m.group(0)
+        assert "if(reasoningText) return raw" not in fn, (
+            "The early-return `if(reasoningText) return raw;` must remain "
+            "removed (#852) — it caused the thinking card to mirror the main "
+            "response when providers emit <think> tags AND reasoning SSE events."
+        )
+
+    def test_think_pair_stripping_still_runs(self):
+        """The `_thinkPairs` stripping loop must still be present so the
+        fix actually strips think blocks."""
+        js = _read("static/messages.js")
+        m = re.search(r'function _streamDisplay\(\)\{.*?\n  \}', js, re.DOTALL)
+        assert m
+        fn = m.group(0)
+        assert "_thinkPairs" in fn, (
+            "_streamDisplay must iterate _thinkPairs to strip think blocks"
+        )
+        assert "trimmed.startsWith(open)" in fn, (
+            "the think-block stripping must check for the open tag"
+        )
+
+    def test_still_handles_incomplete_think_tag_partial_prefix(self):
+        """Existing behaviour preserved: partial `<thi`, `<think` prefixes
+        must still be suppressed so users don't see them mid-stream."""
+        js = _read("static/messages.js")
+        m = re.search(r'function _streamDisplay\(\)\{.*?\n  \}', js, re.DOTALL)
+        assert m
+        fn = m.group(0)
+        assert "open.startsWith(trimmed)" in fn, (
+            "Partial-tag suppression must still be present"
+        )


### PR DESCRIPTION
## Summary

Fixes #852 — the thinking card and main response area were showing identical content during streaming with Nous-hosted reasoning models.

## Root cause

`_streamDisplay()` in `static/messages.js` had this early return at line 282:

```js
if(reasoningText) return raw;
```

When `reasoningText` was non-empty (reasoning SSE events arrived), the function returned `assistantText` **raw** — bypassing the `_thinkPairs` stripping loop. If the provider also emits `<think>…</think>` tags inside the token stream (double-emission), `assistantText` contained the think-block content and it rendered verbatim in the response body. The thinking card received the same content from `reasoningText`. Both panels showed identical text.

## Fix

Remove the early return. The `_thinkPairs` stripping loop now runs unconditionally. For models that don't use `<think>` tags in their token stream, this is a no-op (the loop finds no match and returns `raw` unchanged). For models that do, the think block is stripped before rendering.

**Verified by Opus analysis** — the `_thinkPairs` patterns already cover all three wrapper styles (`<think>`, `<|channel|>thought`, `<|turn|>thinking`) and already applied correctly on the non-reasoning path today.

## Testing

- `node --check static/messages.js` — OK
- 1854 tests passing; 4 remaining failures are pre-existing ordering-sensitive flaky tests confirmed on master

Closes #852.