### PR TITLE
fix: Honcho per-session uses stable session ID across WebUI turns (closes #855)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Hermes Web UI -- Changelog
 
+## [v0.50.155] — 2026-04-22
+
+### Fixed
+- **Honcho per-session memory uses stable session ID across WebUI turns** — `api/streaming.py` now passes `gateway_session_key=session_id` to `AIAgent` (defensive, same pattern as `api_mode`/`credential_pool`). Without this, Honcho's `per-session` strategy created a new Honcho session on each streaming request. (`api/streaming.py`) (closes #855)
+
 ## [v0.50.154] — 2026-04-22
 
 ### Fixed

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -1155,6 +1155,12 @@ def _run_agent_streaming(session_id, msg_text, model, workspace, stream_id, atta
                 _agent_kwargs['acp_args'] = _rt.get('args')
             if 'credential_pool' in _agent_params:
                 _agent_kwargs['credential_pool'] = _rt.get('credential_pool')
+            # Pin Honcho memory sessions to the stable WebUI session ID.
+            # Without this, 'per-session' Honcho strategy creates a new Honcho
+            # session on every streaming request because HonchoSessionManager is
+            # re-instantiated fresh each turn (#855).
+            if 'gateway_session_key' in _agent_params:
+                _agent_kwargs['gateway_session_key'] = session_id
 
             agent = _AIAgent(**_agent_kwargs)
 


### PR DESCRIPTION
## Summary

Fixes #855 — Honcho `per-session` memory strategy was creating a new Honcho session for every WebUI message instead of one per chat.

## Root cause

`api/streaming.py` creates a fresh `AIAgent` instance on each streaming request. When Honcho's `per-session` strategy uses `session_id` as the Honcho session key, it works correctly in CLI use (one invocation = one Honcho session). In the WebUI, the same `session_id` is stable per chat, but `HonchoSessionManager` is re-instantiated from scratch each turn with an empty `_sessions_cache`, so every turn triggers a new Honcho session lookup.

The fix: pass `gateway_session_key=session_id` to `AIAgent`. This parameter bypasses all strategy-based resolution in the Honcho client and pins to the stable WebUI session ID directly. It's already used by the gateway runner for the same reason.

## Change

One line added to `_agent_kwargs` assembly in `api/streaming.py`, using the same defensive `'gateway_session_key' in _agent_params` guard already used for `api_mode`, `acp_command`, and `credential_pool` — safe on older agent builds.

## Testing

- `python3 -c "import ast; ast.parse(open('api/streaming.py').read())"` — OK
- 1854 tests passing; 4 pre-existing ordering-sensitive failures confirmed on master

Closes #855.