### PR TITLE
fix(docker): Install Open SSH client

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ RUN apt-get update -y --fix-missing --no-install-recommends \
     sudo \
     curl \
     rsync \
+    openssh-client \
     && apt-get upgrade -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
I use the ssh terminal backend with hermes, and hermes-webui didn't work with it because it was missing an ssh client. This change just adds the package to the docker image to resolve that.