### PR TITLE
Fix two-container Docker setup path confusion (#858)

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,13 @@ This starts both containers with shared volumes:
 - **`hermes-agent-src`** — the agent's source code, mounted into the WebUI
   container so it can install the agent's Python dependencies at startup
 
+> **Volume type:** The compose files use named Docker volumes by default.
+> If you prefer bind mounts to an existing directory (e.g. for sharing state
+> with an agent container you already run), both containers must mount the
+> same host path — the agent writes to `/root/.hermes`, the WebUI reads from
+> `/home/hermeswebui/.hermes`. See `docker-compose.two-container.yml` for
+> a bind-mount example.
+
 The WebUI's init script automatically installs hermes-agent and all its
 dependencies (openai, anthropic, etc.) into its own Python environment on
 first boot. Subsequent restarts reuse the installed packages.

--- a/docker-compose.three-container.yml
+++ b/docker-compose.three-container.yml
@@ -13,6 +13,12 @@
 #
 # All three share the same hermes-home volume so config, sessions,
 # skills, and memory are consistent across all surfaces.
+#
+# NOTE ON VOLUMES:
+#   This file uses named Docker volumes (hermes-home, hermes-agent-src) which
+#   work out of the box. If you prefer bind mounts (e.g. to an existing directory),
+#   see the two-container compose file for a bind-mount example.
+#   When using bind mounts, ALL containers must mount the same host path.
 
 services:
   hermes-agent:

--- a/docker-compose.two-container.yml
+++ b/docker-compose.two-container.yml
@@ -10,6 +10,23 @@
 # The agent container runs the gateway (CLI, Telegram, cron, etc.).
 # The WebUI container serves the browser interface on port 8787.
 # Both share ~/.hermes for config, sessions, and state.
+#
+# NOTE ON VOLUMES:
+#   This file uses named Docker volumes (hermes-home, hermes-agent-src) which
+#   work out of the box. If you prefer bind mounts (e.g. to an existing directory),
+#   replace the named volumes at the bottom. Example for hermes-agent-src:
+#
+#     hermes-agent-src:
+#       driver: local
+#       driver_opts:
+#         type: none
+#         o: bind
+#         device: /opt/hermes-agent
+#
+#   When using bind mounts, BOTH containers must mount the same host path.
+#   The agent exposes source at /opt/hermes, the WebUI reads it from
+#   /home/hermeswebui/.hermes/hermes-agent — as long as both point to the
+#   same host directory, the paths align correctly.
 
 services:
   hermes-agent:

--- a/docker_init.bash
+++ b/docker_init.bash
@@ -294,14 +294,29 @@ else
   test -x /app/venv/bin/pip
 
   echo ""; echo "== Adding hermes-agent's pyproject.toml base dependencies to the virtual environment"
-  if [ -d "/home/hermeswebui/.hermes/hermes-agent" ] && [ -f "/home/hermeswebui/.hermes/hermes-agent/pyproject.toml" ]; then
-    uv pip install "/home/hermeswebui/.hermes/hermes-agent[honcho]" --trusted-host pypi.org --trusted-host files.pythonhosted.org || error_exit "Failed to install hermes-agent's requirements"
+  _agent_paths=(
+    "/home/hermeswebui/.hermes/hermes-agent"
+    "/opt/hermes"
+  )
+  _agent_src=""
+  for _p in "${_agent_paths[@]}"; do
+    if [ -d "$_p" ] && [ -f "$_p/pyproject.toml" ]; then
+      _agent_src="$_p"
+      break
+    fi
+  done
+  if [ -n "$_agent_src" ]; then
+    uv pip install "$_agent_src[honcho]" --trusted-host pypi.org --trusted-host files.pythonhosted.org || error_exit "Failed to install hermes-agent's requirements"
   else
     echo ""
-    echo "!! WARNING: hermes-agent source not found at /home/hermeswebui/.hermes/hermes-agent"
+    echo "!! WARNING: hermes-agent source not found."
+    echo "!!   Looked in: ${_agent_paths[0]}"
+    echo "!!              ${_agent_paths[1]}"
     echo "!! The WebUI will start with reduced functionality (no model auto-detection,"
     echo "!! no personality routing, no CLI session imports)."
-    echo "!! To fix: mount the agent source volume into the container. See:"
+    echo "!! To fix: mount the agent source volume into the container:"
+    echo "!!   -v /path/to/hermes-agent:/home/hermeswebui/.hermes/hermes-agent"
+    echo "!! Or see the two-container compose example:"
     echo "!!   https://github.com/nesquena/hermes-webui/blob/master/docker-compose.two-container.yml"
     echo ""
   fi


### PR DESCRIPTION
## Thinking Path

- Hermes WebUI supports running agent + webui as separate Docker containers via compose files
- Users deploying with custom agent images or bind mounts hit confusing errors when agent source isn't found
- The `docker_init.bash` only probed one path (`/home/hermeswebui/.hermes/hermes-agent`) and the warning was generic — no actionable fix
- The compose files used named volumes without explaining how to switch to bind mounts
- This PR improves agent source discovery and adds volume documentation so users can self-serve

## What Changed

- **`docker_init.bash`** — Added `/opt/hermes` as a fallback agent source probe path (uses an array for easy extension). Improved the not-found warning to list both paths checked and show a concrete `-v` mount example.
- **`docker-compose.two-container.yml`** — Added header comments explaining named vs bind volumes with a concrete bind-mount YAML example for `hermes-agent-src`.
- **`docker-compose.three-container.yml`** — Added a briefer note pointing to the two-container file for bind-mount details.
- **`README.md`** — Added a note in the two-container section explaining the volume type distinction and path mapping between containers.

## Why It Matters

Fixes #858. Users running the agent in a separate container (especially with non-standard images or bind mounts) currently get a generic "source not found" warning with no guidance on how to fix it. The `/opt/hermes` fallback covers the standard two-container compose volume topology, and the improved error messages + documentation cover non-standard setups.

## Verification

- No Python code changed — only bash init script, YAML comments, and README docs
- `pytest tests/` is not applicable (no test files cover Docker compose or init scripts)
- Verified: compose files remain backward-compatible (same volume names, ports, services)
- Verified: the `_agent_paths` array pattern matches existing probe patterns in `docker_init.bash` (UID/GID auto-detect at lines 67-121)

## Risks / Follow-ups

- Minimal risk: purely additive changes to error messages and comments
- The `/opt/hermes` fallback only fires when the primary path fails — no behavioral change for existing working setups
- Future: consider unifying the three agent directory discovery implementations (bash `_agent_paths`, Python `_agent_dir()`, Python `_discover_agent_dir()`) — but that's a separate concern

## AI Usage Disclosure

- **Provider:** Anthropic
- **Model:** Claude Opus 4.7 (`claude-opus-4-7`)
- **Mode:** PAI Algorithm v3.7.0 (structured workflow with simplify review)