### PR TITLE
Fix selected text visibility in user message bubbles

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1581,6 +1581,8 @@ body.resizing{user-select:none;cursor:col-resize;}
   --user-bubble-border: var(--accent-hover);
   --user-bubble-text: #fff;
   --user-bubble-placeholder: rgba(255,255,255,.7);
+  --user-selection-bg: rgba(0,0,0,.22);
+  --user-selection-text: #fff;
 }
 /* Dark mode: keep user bubbles dark; skin remains a tint via border/fill. */
 :root.dark {
@@ -1588,6 +1590,8 @@ body.resizing{user-select:none;cursor:col-resize;}
   --user-bubble-border: var(--accent-bg-strong);
   --user-bubble-text: var(--text);
   --user-bubble-placeholder: var(--muted);
+  --user-selection-bg: rgba(255,255,255,.18);
+  --user-selection-text: var(--text);
 }
 
 /* Inline code: stop shouting orange; inherit strong text colour instead */
@@ -1644,6 +1648,16 @@ body.resizing{user-select:none;cursor:col-resize;}
   padding-left: 14px;
   max-width: none;
   color: var(--user-bubble-text);
+}
+.msg-row[data-role="user"] .msg-body::selection,
+.msg-row[data-role="user"] .msg-body *::selection {
+  background: var(--user-selection-bg);
+  color: var(--user-selection-text);
+}
+.msg-row[data-role="user"] .msg-body::-moz-selection,
+.msg-row[data-role="user"] .msg-body *::-moz-selection {
+  background: var(--user-selection-bg);
+  color: var(--user-selection-text);
 }
 .msg-row[data-role="user"] .msg-body code { color: var(--user-bubble-text); background: rgba(0,0,0,.1); }
 .msg-row[data-role="user"] .msg-body a { color: var(--user-bubble-text); text-decoration: underline; }

--- a/tests/test_bugbatch_apr2026.py
+++ b/tests/test_bugbatch_apr2026.py
@@ -76,6 +76,29 @@ def test_dark_user_bubbles_do_not_need_per_skin_text_hacks():
     )
 
 
+def test_user_bubbles_define_selection_tokens_for_both_modes():
+    """User bubbles need dedicated selection colors so selected text remains readable."""
+    assert "--user-selection-bg: rgba(0,0,0,.22);" in STYLE_CSS, (
+        "Light-mode user bubbles should define a darker selection fill for contrast"
+    )
+    assert "--user-selection-bg: rgba(255,255,255,.18);" in STYLE_CSS, (
+        "Dark-mode user bubbles should define a lighter selection fill for contrast"
+    )
+    assert "--user-selection-text: #fff;" in STYLE_CSS, (
+        "Light-mode user bubble selection should preserve readable text color"
+    )
+
+
+def test_user_bubble_selection_is_scoped_to_user_message_body():
+    """Selection override must apply only to user bubbles, including nested markdown nodes."""
+    assert '.msg-row[data-role="user"] .msg-body::selection,' in STYLE_CSS, (
+        "Missing selection override on the user message bubble"
+    )
+    assert '.msg-row[data-role="user"] .msg-body *::selection {' in STYLE_CSS, (
+        "Nested elements inside user messages must inherit the same selection colors"
+    )
+
+
 # ── #576: workspace panel snap fix ───────────────────────────────────────────
 
 def test_576_panel_restore_gated_on_workspace():


### PR DESCRIPTION
When selecting text inside a user message bubble, the selection highlight could blend into the bubble background, making it hard to see what text was actually selected.

This updates the user-message bubble selection styling so highlighted text stays clearly visible across light and dark appearance/theme combinations.

It applies only to user messages and adds regression coverage for the selection rules.