### PR TITLE
feat (ui): add a sidebar running indicator for active sessions

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -172,6 +172,7 @@ class Session:
             'workspace': self.workspace,
             'model': self.model,
             'message_count': len(self.messages),
+            'active_stream_id': self.active_stream_id,
             'created_at': self.created_at,
             'updated_at': self.updated_at,
             'pinned': self.pinned,

--- a/static/messages.js
+++ b/static/messages.js
@@ -140,6 +140,7 @@ async function send(){
     if(!_clarifySessionId || _clarifySessionId===activeSid) hideClarifyCard(true);
     S.messages.push({role:'assistant',content:`**Error:** ${errMsg}`});
     renderMessages();setBusy(false);setComposerStatus(`Error: ${errMsg}`);
+    clearSidebarRunningState(activeSid, 0);
     return;
   }
 
@@ -156,6 +157,25 @@ function closeLiveStream(sessionId, streamId){
   if(streamId&&live.streamId!==streamId) return;
   try{live.source.close();}catch(_){ }
   delete LIVE_STREAMS[sessionId];
+}
+
+function clearSidebarRunningState(sessionId, delayMs=250){
+  if(!sessionId) return;
+  if(S.session&&S.session.session_id===sessionId&&S.session){
+    S.session.active_stream_id=null;
+  }
+  if(typeof _allSessions!=='undefined'&&Array.isArray(_allSessions)){
+    const row=_allSessions.find(s=>s&&s.session_id===sessionId);
+    if(row){
+      row.active_stream_id=null;
+      row.agent_running=false;
+    }
+  }
+  if(typeof renderSessionListFromCache==='function') renderSessionListFromCache();
+  else if(typeof renderSessionList==='function') renderSessionList();
+  if(typeof renderSessionList==='function'){
+    setTimeout(()=>{ try{ renderSessionList(); }catch(_){ } }, Math.max(0, Number(delayMs)||0));
+  }
 }
 
 function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
@@ -599,6 +619,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         catch(_){trackBackgroundError(activeSid,_errTitle,'Error');}
       }
       if(!S.session||!INFLIGHT[S.session.session_id]){setBusy(false);setComposerStatus('');}
+      clearSidebarRunningState(activeSid);
     });
 
     source.addEventListener('warning',e=>{
@@ -717,6 +738,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       }
     }
     if(!S.session||!INFLIGHT[S.session.session_id]){setBusy(false);setComposerStatus('');}
+    clearSidebarRunningState(activeSid);
   }
 
   (async()=>{

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -191,6 +191,14 @@ let _sessionActionMenu = null;
 let _sessionActionAnchor = null;
 let _sessionActionSessionId = null;
 
+function _sessionIsRunning(session){
+  const sid=session&&session.session_id;
+  if(!sid) return false;
+  if(!!INFLIGHT[sid]) return true;
+  if(S.session&&S.session.session_id===sid&&(S.busy||S.activeStreamId)) return true;
+  return !!(session.active_stream_id||session.agent_running);
+}
+
 function closeSessionActionMenu(){
   if(_sessionActionMenu){
     _sessionActionMenu.remove();
@@ -693,7 +701,8 @@ function renderSessionListFromCache(){
   function _renderOneSession(s){
     const el=document.createElement('div');
     const isActive=S.session&&s.session_id===S.session.session_id;
-    el.className='session-item'+(isActive?' active':'')+(isActive&&S.session&&S.session._flash?' new-flash':'')+(s.archived?' archived':'');
+    const isRunning=_sessionIsRunning(s);
+    el.className='session-item'+(isActive?' active':'')+(isRunning?' running':'')+(isActive&&S.session&&S.session._flash?' new-flash':'')+(s.archived?' archived':'');
     if(isActive&&S.session&&S.session._flash)delete S.session._flash;
     const rawTitle=s.title||'Untitled';
     const tags=(rawTitle.match(/#[\w-]+/g)||[]);
@@ -803,6 +812,14 @@ function renderSessionListFromCache(){
     // Single trigger button that opens a shared dropdown menu
     const actions=document.createElement('div');
     actions.className='session-actions';
+    if(isRunning){
+      const running=document.createElement('span');
+      running.className='session-running-indicator';
+      running.title='Conversation is running';
+      running.setAttribute('aria-label','Conversation is running');
+      running.innerHTML='<span class="session-running-spinner" aria-hidden="true"></span>';
+      actions.appendChild(running);
+    }
     const menuBtn=document.createElement('button');
     menuBtn.type='button';
     menuBtn.className='session-actions-trigger';

--- a/static/style.css
+++ b/static/style.css
@@ -227,14 +227,23 @@
   .session-text{flex:1;min-width:0;display:flex;flex-direction:column;gap:2px;overflow:hidden;}
   .session-title-row{display:flex;align-items:center;gap:6px;min-width:0;}
   .session-title{flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:var(--text);}
+  .session-running-indicator{position:absolute;inset:0;display:inline-flex;align-items:center;justify-content:center;color:var(--accent-text);opacity:0;pointer-events:none;transition:opacity .15s ease;}
+  .session-running-spinner{display:block;width:11px;height:11px;border-radius:50%;border:1.5px solid currentColor;border-right-color:transparent;animation:sessionSpin .85s linear infinite;}
   .session-item.active .session-title{color:var(--accent-text);}
   .session-meta{font-size:11px;color:var(--muted);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
   .session-item.active .session-meta{color:var(--accent-text);opacity:.8;}
+  .session-item.running .session-meta{padding-left:0;}
   .session-time{display:none;}
   /* ── Session action trigger + dropdown ── */
-  .session-actions{position:absolute;right:6px;top:50%;transform:translateY(-50%);display:flex;align-items:center;justify-content:center;opacity:0;pointer-events:none;transition:opacity .15s ease;}
+  .session-actions{position:absolute;right:6px;top:50%;transform:translateY(-50%);width:26px;height:26px;opacity:0;pointer-events:none;transition:opacity .15s ease;}
   .session-item:hover .session-actions,.session-item:focus-within .session-actions,.session-item.menu-open .session-actions{opacity:1;pointer-events:auto;}
-  .session-actions-trigger{width:26px;height:26px;border:1px solid transparent;border-radius:8px;background:transparent;color:var(--muted);cursor:pointer;padding:0;line-height:1;display:inline-flex;align-items:center;justify-content:center;transition:background .12s,color .12s,border-color .12s;}
+  .session-item.running .session-actions{opacity:1;pointer-events:none;}
+  .session-item.running:hover .session-actions,.session-item.running:focus-within .session-actions,.session-item.running.menu-open .session-actions{pointer-events:auto;}
+  .session-actions-trigger{position:absolute;inset:0;width:26px;height:26px;border:1px solid transparent;border-radius:8px;background:transparent;color:var(--muted);cursor:pointer;padding:0;line-height:1;display:inline-flex;align-items:center;justify-content:center;transition:background .12s,color .12s,border-color .12s;}
+  .session-item.running .session-actions-trigger{opacity:0;pointer-events:none;}
+  .session-item.running:hover .session-actions-trigger,.session-item.running:focus-within .session-actions-trigger,.session-item.running.menu-open .session-actions-trigger{opacity:1;pointer-events:auto;}
+  .session-item.running .session-running-indicator{opacity:.9;}
+  .session-item.running:hover .session-running-indicator,.session-item.running:focus-within .session-running-indicator,.session-item.running.menu-open .session-running-indicator{opacity:0;}
   .session-actions-trigger:hover{background:var(--hover-bg);color:var(--text);}
   .session-actions-trigger.active{background:var(--accent-bg);border-color:var(--accent-bg-strong);color:var(--text);}
   .session-actions-trigger svg{display:block;}
@@ -252,6 +261,7 @@
   /* Hide overlay during inline rename */
   .session-item:has(.session-title-input) .session-actions{display:none;}
   @keyframes newflash{0%{background:var(--accent-bg-strong);color:var(--accent);}100%{background:transparent;color:var(--muted);}}
+  @keyframes sessionSpin{to{transform:rotate(360deg);}}
   .session-item.new-flash{animation:newflash 1.4s ease-out forwards;}
   /* Collapsible date group headers */
   .session-date-header{display:flex;align-items:center;gap:5px;font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--muted);padding:8px 10px 4px;cursor:pointer;user-select:none;opacity:.8;transition:opacity .15s;}

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -489,6 +489,34 @@ def test_newSession_resets_busy_state_for_fresh_chat(cleanup_test_sessions):
     assert "updateQueueBadge(S.session.session_id);" in new_sess_body, \
         "newSession() must refresh the badge for the new session rather than leaving the old session's queue badge visible"
 
+def test_session_sidebar_running_indicator_uses_session_scoped_inflight_state(cleanup_test_sessions):
+    """Sidebar rows should show a live running indicator for busy sessions."""
+    src = (REPO_ROOT / "static/sessions.js").read_text()
+    css = (REPO_ROOT / "static/style.css").read_text()
+    assert "function _sessionIsRunning(session)" in src, \
+        "sessions.js should centralize the sidebar running-state check"
+    assert "INFLIGHT[sid]" in src and "S.activeStreamId" in src, \
+        "_sessionIsRunning should cover background in-flight sessions and the active stream"
+    assert "actions.appendChild(running);" in src, \
+        "session rows should place the running indicator in the actions slot"
+    assert ".session-running-spinner" in css and "@keyframes sessionSpin" in css, \
+        "style.css should include spinner styling for the sidebar running indicator"
+    assert ".session-item.running .session-actions-trigger" in css and ".session-item.running:hover .session-running-indicator" in css, \
+        "running rows should swap spinner and menu trigger on hover"
+    assert ".session-actions{position:absolute;right:6px;top:50%;transform:translateY(-50%);width:26px;height:26px;" in css, \
+        "session actions should reserve a single overlay slot on the far right"
+    assert ".session-running-indicator{position:absolute;inset:0;" in css and ".session-actions-trigger{position:absolute;inset:0;" in css, \
+        "spinner and menu trigger should overlap in the same slot rather than sit side by side"
+
+def test_sidebar_running_indicator_clears_on_error_paths(cleanup_test_sessions):
+    src = (REPO_ROOT / "static/messages.js").read_text()
+    assert "function clearSidebarRunningState(sessionId, delayMs=250)" in src, \
+        "messages.js should centralize sidebar running-state cleanup"
+    assert "row.active_stream_id=null;" in src and "row.agent_running=false;" in src, \
+        "sidebar cleanup should clear stale cached running flags"
+    assert src.count("clearSidebarRunningState(activeSid") >= 3, \
+        "all terminal error paths should clear the sidebar running state"
+
 
 def test_session_scoped_message_queue_frontend_wiring(cleanup_test_sessions):
     """R15bb: queued follow-ups must stay attached to their originating session.

--- a/tests/test_sprint10.py
+++ b/tests/test_sprint10.py
@@ -1,10 +1,10 @@
 """
 Sprint 10 Tests: server.py split, cancel endpoint, cron history, tool card polish.
 """
-import json, pathlib, urllib.error, urllib.request, urllib.parse
+import json, pathlib, urllib.error, urllib.request, urllib.parse, time, uuid
 REPO_ROOT = pathlib.Path(__file__).parent.parent.resolve()
 
-from tests._pytest_port import BASE
+from tests._pytest_port import BASE, TEST_STATE_DIR
 
 def get(path):
     with urllib.request.urlopen(BASE + path, timeout=10) as r:
@@ -29,6 +29,41 @@ def make_session(created_list):
     sid = d["session"]["session_id"]
     created_list.append(sid)
     return sid
+
+def _write_running_session(created_list):
+    sid = "streamlist_" + uuid.uuid4().hex[:8]
+    stream_id = "stream-test-" + uuid.uuid4().hex[:8]
+    created_list.append(sid)
+    now = time.time()
+    sessions_dir = TEST_STATE_DIR / "sessions"
+    sessions_dir.mkdir(parents=True, exist_ok=True)
+    (sessions_dir / f"{sid}.json").write_text(json.dumps({
+        "session_id": sid,
+        "title": "Running session",
+        "workspace": "/tmp",
+        "model": "openai/gpt-5.4-mini",
+        "messages": [{"role": "user", "content": "hello"}],
+        "created_at": now,
+        "updated_at": now,
+        "tool_calls": [],
+        "pinned": False,
+        "archived": False,
+        "project_id": None,
+        "profile": "default",
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "estimated_cost": None,
+        "personality": None,
+        "active_stream_id": stream_id,
+        "pending_user_message": "hello",
+        "pending_attachments": [],
+        "pending_started_at": now,
+    }), encoding="utf-8")
+    try:
+        (sessions_dir / "_index.json").unlink()
+    except FileNotFoundError:
+        pass
+    return sid, stream_id
 
 # ── server.py split: api/ modules served / importable ─────────────────────
 
@@ -137,3 +172,15 @@ def test_cancel_sse_event_handler_in_messages_js(cleanup_test_sessions):
 def test_active_stream_id_tracked(cleanup_test_sessions):
     src, _ = get_text("/static/messages.js")
     assert "S.activeStreamId" in src
+
+def test_sessions_list_exposes_active_stream_id_for_running_session(cleanup_test_sessions):
+    created = []
+    try:
+        sid, stream_id = _write_running_session(created)
+        data, status = get("/api/sessions")
+        assert status == 200
+        entry = next(sess for sess in data["sessions"] if sess["session_id"] == sid)
+        assert entry["active_stream_id"] == stream_id
+    finally:
+        for sid in created:
+            post("/api/session/delete", {"session_id": sid})


### PR DESCRIPTION
## Summary

This adds a running indicator to the session list in the left sidebar while a session is actively processing.

The indicator now:
- uses the same right-side action slot as the `...` menu
- shows a spinner while the session is running
- swaps back to the `...` trigger on hover/focus so the action menu remains accessible
- clears correctly on error paths instead of getting stuck in a running state

## What changed

- exposed `active_stream_id` in compact session payloads so the sidebar can reflect real running state
- added session-scoped running-state detection in the sidebar
- updated the sidebar CSS so the spinner overlays the actions slot instead of shifting the title layout
- fixed stale running indicators after repeated error cases by clearing cached sidebar running state on terminal error paths
- added tests for:
  - `/api/sessions` exposing `active_stream_id` for running sessions
  - sidebar running-indicator wiring and error-path cleanup

## Verification

Ran:
- `uv run --with pytest --with pytest-timeout pytest tests/test_sprint10.py::test_sessions_list_exposes_active_stream_id_for_running_session -q --timeout=60`
- `uv run --with pytest --with pytest-timeout pytest tests/test_regressions.py -k 'sidebar_running_indicator' -q --timeout=60`
- `uv run --with pytest --with pytest-timeout pytest tests/ -q --timeout=60`

Full suite result in this branch:
- `1887 passed`
- `46 skipped`
- `4 failed`

The remaining 4 failures appear to be pre-existing and unrelated:
- `tests/test_issue798.py::test_concurrent_new_sessions_get_correct_profiles`
- `tests/test_provider_management.py::TestSetProviderKey::test_set_key_writes_to_env_file`
- `tests/test_session_index.py::test_concurrent_saves_dont_lose_data`
- `tests/test_sprint46.py::test_session_compress_roundtrip`

## AI assistance

Provider: OpenAI  
Model: GPT-5 Codex  
Notable mode/tool use: Used as a coding agent in the local repository with terminal/tool access for code inspection, edits, git operations, and targeted test execution.