### PR TITLE
fix: correct message ordering after task cancellation

### DIFF
--- a/api/streaming.py
+++ b/api/streaming.py
@@ -1666,6 +1666,11 @@ def cancel_stream(stream_id: str) -> bool:
             _cs.pending_user_message = None
             _cs.pending_attachments = []
             _cs.pending_started_at = None
+            # Add cancel message to session messages so client sees consistent state
+            _cs.messages.append({
+                'role': 'assistant',
+                'content': '*Task cancelled.*'
+            })
             _cs.save()
         except Exception:
             logger.debug("Failed to clear session state on cancel for %s", _cancel_session_id)

--- a/static/messages.js
+++ b/static/messages.js
@@ -653,10 +653,26 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       if(S.session&&S.session.session_id===activeSid){
         S.activeStreamId=null;const _cbc=$('btnCancel');if(_cbc)_cbc.style.display='none';
       }
-      if(S.session&&S.session.session_id===activeSid){
-        clearLiveToolCards();if(!assistantText)removeThinking();
-        S.messages.push({role:'assistant',content:'*Task cancelled.*'});renderMessages();
-      }
+      // Fetch latest session from server to get accurate message list (includes cancel status)
+      // This ensures messages stay in sync with server, fixing race condition where local
+      // "*Task cancelled.*" message gets lost when done event overwrites S.messages
+      (async()=>{
+        try{
+          const data=await api(`/api/session?session_id=${encodeURIComponent(activeSid)}`);
+          if(data&&data.session&&S.session&&S.session.session_id===activeSid){
+            S.session=data.session;
+            S.messages=(data.session.messages||[]).filter(m=>m&&m.role);
+            clearLiveToolCards();if(!assistantText)removeThinking();
+            renderMessages();
+          }
+        }catch(_){
+          // Fallback to local cancel message if API fails
+          if(S.session&&S.session.session_id===activeSid){
+            clearLiveToolCards();if(!assistantText)removeThinking();
+            S.messages.push({role:'assistant',content:'*Task cancelled.*'});renderMessages();
+          }
+        }
+      })();
       renderSessionList();
       if(!S.session||!INFLIGHT[S.session.session_id]){setBusy(false);setComposerStatus('');}
     });


### PR DESCRIPTION
## Summary

This PR fixes a message ordering issue where new response messages appear above the "task cancelled" message instead of at the bottom after cancelling an ongoing task.

## What changed

- **Frontend (static/messages.js)**: Changed cancel event handler to fetch server messages via /api/session (same as done event)
- **Backend (api/streaming.py)**: Added "*Task cancelled.*" message to session.messages when cancel occurs

## Root cause

1. **cancel event**: Frontend locally added "*Task cancelled.*" message without syncing to server
2. **done event**: Server returns complete session.messages list, frontend replaces all local messages
3. Since cancel-added message wasn't saved to server, when done event fires, server's message list doesn't include it, causing wrong message order

## Verification

1. Send a message, wait for response
2. Click cancel button during response
3. Send another new message
4. Confirm new response appears at the bottom correctly
