### PR TITLE
fix(markdown): stash code blocks with attributes and multiline content

### DIFF
--- a/static/ui.js
+++ b/static/ui.js
@@ -630,7 +630,7 @@ function renderMd(raw){
   // Stash <code> tags from the backtick pass above so the outer bold/italic
   // regexes don't esc() their content (e.g. **`code`** → <strong><code>code</code></strong>)
   const _ob_stash=[];
-  s=s.replace(/(<code>[^<]*<\/code>)/g,m=>{_ob_stash.push(m);return `\x00O${_ob_stash.length-1}\x00`;});
+  s=s.replace(/(<code\b[^>]*>[\s\S]*?<\/code>)/g,m=>{_ob_stash.push(m);return `\x00O${_ob_stash.length-1}\x00`;});
   s=s.replace(/\*\*\*(.+?)\*\*\*/g,(_,t)=>`<strong><em>${esc(t)}</em></strong>`);
   s=s.replace(/\*\*(.+?)\*\*/g,(_,t)=>`<strong>${esc(t)}</strong>`);
   s=s.replace(/\*([^*\n]+)\*/g,(_,t)=>`<em>${esc(t)}</em>`);


### PR DESCRIPTION
## Thinking Path

- Hermes WebUI renders Markdown in the browser via a custom `renderMd()` function in `ui.js`
- The engine uses a "stash" mechanism to protect `<code>` blocks from bold/italic/paragraph processing
- The stash regex `(<code>[^<]*</code>)` had two failure modes: it couldn't match `<code>` tags with attributes (e.g. `<code class="language-sql">`), and `[^<]*` couldn't capture multiline content
- Code blocks with language tags leaked into the bold/italic pipeline, corrupting SQL/C# comments into `<strong><em>` tags and producing `&lt;` artifacts
- This PR fixes the regex to handle both attributes and multiline content
- The benefit is correct rendering of all fenced code blocks regardless of language tag or content

## What Changed

- **`static/ui.js:630`** — Updated the `_ob_stash` regex from `(<code>[^<]*<\/code>)` to `(<code\b[^>]*>[\s\S]*?<\/code>)`

One line, one file.

## Why It Matters

Any fenced code block with a language identifier (e.g. ` ```sql `) was getting corrupted. SQL headers like `/****** Object: ... ******/` were rendered as bold+italic HTML, and angle brackets inside code became visible `&lt;` entities. This affects copy-paste integrity for SQL, C#, and any language using multi-line comments.

## Verification

Manual test — input this Markdown:
~~~markdown
```sql
/****** Object: StoredProcedure [dbo].[Proc_Name] Script Date: 2023... ******/
SET ANSI_NULLS ON
GO
```
~~~

**Before:** Header stars rendered as `<strong><em>`, `&lt;` artifacts visible.
**After:** Code block renders as-is, content fully preserved.

Also verified:
- Inline `` `code` `` still works (no attributes, single-line — matched by both patterns)
- ` ``` ` blocks without language tag still work (no attributes)
- ` ```python `, ` ```js `, etc. all stash correctly now

## Risks / Follow-ups

- Low risk — the new pattern is a strict superset of the old one for well-formed `<code>` tags
- Non-greedy `[\s\S]*?` is safe here because `<\/code>` is not a substring that appears inside code block content (it would have been escaped by the earlier backtick→`<code>` pass)
- No new dependencies, no framework changes, preserves the no-build-step constraint

## AI Usage Disclosure

- **Provider:** Anthropic (via Claude Code CLI)
- **Model:** GLM 5.1 (primary), Claude Opus 4.7 (co-author attribution)
- **Tool use:** File editing, Git, GitHub CLI
- **PAI framework** used for session management

Closes #890

🤖 Generated with [Claude Code](https://claude.com/claude-code)