### PR TITLE
fix(docker): Install all dependencies for agent

### DIFF
--- a/docker_init.bash
+++ b/docker_init.bash
@@ -306,7 +306,7 @@ else
     fi
   done
   if [ -n "$_agent_src" ]; then
-    uv pip install "$_agent_src[honcho]" --trusted-host pypi.org --trusted-host files.pythonhosted.org || error_exit "Failed to install hermes-agent's requirements"
+    uv pip install "$_agent_src[all]" --trusted-host pypi.org --trusted-host files.pythonhosted.org || error_exit "Failed to install hermes-agent's requirements"
   else
     echo ""
     echo "!! WARNING: hermes-agent source not found."


### PR DESCRIPTION
This fix modifies the docker entrypoint script to install ALL features, not just honcho. Closes #896 and closes #628 