### PR TITLE
fix: persist onboarding_completed for CLI-configured users on first chat_ready

### DIFF
--- a/api/onboarding.py
+++ b/api/onboarding.py
@@ -435,6 +435,15 @@ def get_onboarding_status() -> dict:
     config_exists = Path(_get_config_path()).exists()
     config_auto_completed = config_exists and bool(runtime.get("chat_ready"))
 
+    # Persist the flag so it survives future transient import failures (e.g. after
+    # a git branch switch in the hermes-agent repo).  Without this, a CLI-configured
+    # user who never ran the wizard has no onboarding_completed flag — any momentary
+    # imports_ok=False during restart makes chat_ready=False, config_auto_completed=False,
+    # and the wizard reappears with a broken dropdown that clobbers their config.
+    if config_auto_completed and not settings.get("onboarding_completed"):
+        save_settings({"onboarding_completed": True})
+        settings["onboarding_completed"] = True
+
     return {
         "completed": bool(settings.get("onboarding_completed")) or auto_completed or config_auto_completed,
         "settings": {


### PR DESCRIPTION
## Problem

Users who configured Hermes via the CLI (`hermes model` / `hermes auth`) and never ran the web UI onboarding wizard have no `onboarding_completed` flag in `settings.json`.

After switching a git branch in the hermes-agent repo, the server restarts. During that restart window, `verify_hermes_imports()` can return `imports_ok=False` because Python's module cache still holds stale objects from the previous branch. This causes the following chain:

```
imports_ok = False
  -> chat_ready = False
  -> config_auto_completed = False
  -> completed = False
  -> onboarding wizard appears
```

The wizard's provider dropdown only contains **openrouter / anthropic / openai / custom**. Non-standard providers like `bedrock` are not listed. The select element snaps to the first option (`openrouter`). When the user clicks through the wizard it POSTs to `/api/onboarding/setup` with `provider=openrouter`, which rewrites `config.yaml` and clobbers the user's actual provider and model settings.

## Root Cause

`config_auto_completed` is computed correctly on every request but never persisted. So each time `chat_ready` becomes momentarily `False` (import hiccup, restart, branch switch), the protection disappears and the wizard reappears with a destructive dropdown default.

## Fix

In `get_onboarding_status()` (`api/onboarding.py`), when `config_auto_completed` is `True` for the first time, immediately write `onboarding_completed: True` to `settings.json`:

```python
if config_auto_completed and not settings.get("onboarding_completed"):
    save_settings({"onboarding_completed": True})
    settings["onboarding_completed"] = True
```

After this runs once, the persisted flag guarantees `completed=True` on all future requests — including ones where imports are momentarily broken — so the wizard never reappears for existing CLI users.

## Impact

- No behaviour change for users who set up via the wizard (flag already persisted).
- CLI-configured users with any non-standard provider (bedrock, deepseek, xai, etc.) are protected from the wizard clobbering their config after a branch switch or server restart.
- One extra `settings.json` write the first time a qualifying user visits after this fix ships — negligible cost.
