### PR TITLE
fix(ui): clear stale tool-running dots when thinking tokens arrive

### DIFF
--- a/static/ui.js
+++ b/static/ui.js
@@ -2305,6 +2305,7 @@ function finalizeThinkingCard(){
   row.removeAttribute('data-thinking-active');
 }
 function appendThinking(text=''){
+  const oldWait=$('toolRunningRow'); if(oldWait) oldWait.remove();
   $('emptyState').style.display='none';
   let turn=$('liveAssistantTurn');
   if(!turn){
@@ -2322,7 +2323,8 @@ function appendThinking(text=''){
     // Insert after whichever comes last: a live assistant segment or a tool card.
     // This mirrors appendLiveToolCard's anchor logic so thinking always appears
     // in the right position in the interleaved sequence.
-    // Also skip #toolRunningRow (dots) — thinking should go before dots, not after.
+    // Note: toolRunningRow (dots) was already removed at the top of this function,
+    // so the filter clause below is purely defensive against stale DOM artifacts.
     const allChildren=Array.from(blocks.children);
     const anchor=allChildren.filter(el=>
       el.id!=='toolRunningRow' &&


### PR DESCRIPTION
## Thinking Path
* When a model sends thinking/reasoning tokens during an active tool call, `appendThinking()` is invoked to create or extend the thinking card in the chat.
* Before this fix, `appendThinking()` did not remove the `#toolRunningRow` element (the animated 3-dot "waiting" indicator). The dots remained visible behind or beside the newly created thinking card, producing a visual artifact.
* The existing anchor-scan filter already skipped `#toolRunningRow` when choosing an insertion point, but the element itself was left in the DOM.
* The correct behavior: when reasoning tokens arrive, the tool-running dots are conceptually stale — the model is no longer "waiting to start" — and should be removed before the thinking card is inserted.

## What Changed
* Added `const oldWait=$('toolRunningRow'); if(oldWait) oldWait.remove();` at the top of `appendThinking()` in `static/ui.js`, so stale dots are cleaned up before DOM manipulation begins.
* Updated the anchor-scan comment to document that `#toolRunningRow` is already removed at that point, making the filter clause purely defensive against stale DOM artifacts.

## Why It Matters
* Eliminates a visual glitch where the animated "..." dots persisted alongside or behind the thinking card.
* Makes the DOM state consistent: when thinking arrives, the waiting indicator is removed; no stale element lingers.
* The filter clause `el.id!=='toolRunningRow'` becomes a safety net rather than the primary cleanup — defense-in-depth.

## Verification
* The change is a single DOM removal at a well-defined entry point (`appendThinking`).
* No existing tests reference `#toolRunningRow` removal, so no regressions expected.
* Manual verification: trigger a model that emits thinking tokens while a tool call is in progress and confirm the dots disappear.

## Risks / Follow-ups
* If a model interleaves tool calls and thinking, each thinking invocation removes any existing `#toolRunningRow`. Since `toolRunningRow` is re-created by the tool-call rendering path when appropriate, this is safe — there is no scenario where the dots should persist past the arrival of thinking content.

## Model Used
* Discovery: Claude Opus 4.7
* Implementation: Kimi K2.6 + GLM-5.1