### PR TITLE
fix(btw): harden _streamDone flag — defensive ordering + session guard + stream_end coverage

### DIFF
--- a/static/messages.js
+++ b/static/messages.js
@@ -1363,13 +1363,13 @@ function attachBtwStream(parentSid, streamId, question){
     if(ansEl) ansEl.innerHTML=renderMd(answer);
   });
   src.addEventListener('done',e=>{
-    src.close();
     _streamDone=true;
+    src.close();
     try{
       const d=JSON.parse(e.data);
       if(d.answer&&!answer) answer=d.answer;
     }catch(_){}
-    _ensureBtwRow();
+    if(S.session&&S.session.session_id===parentSid) _ensureBtwRow();
     if(btwRow&&btwRow.isConnected){
       const ansEl=btwRow.querySelector('.msg-btw-answer');
       if(ansEl) ansEl.innerHTML=renderMd(answer||t('btw_no_answer'));
@@ -1377,15 +1377,15 @@ function attachBtwStream(parentSid, streamId, question){
     showToast(t('btw_done'));
   });
   src.addEventListener('apperror',e=>{
-    src.close();
     _streamDone=true;
+    src.close();
     try{
       const d=JSON.parse(e.data);
       showToast(t('btw_failed')+(d.message||''));
     }catch(_){showToast(t('btw_failed'));}
     if(btwRow&&btwRow.isConnected) btwRow.remove();
   });
-  src.addEventListener('stream_end',()=>{src.close();});
+  src.addEventListener('stream_end',()=>{_streamDone=true;src.close();});
   src.onerror=()=>{src.close();if(!_streamDone&&btwRow&&btwRow.isConnected) btwRow.remove();};
 }
 

--- a/tests/test_reasoning_chip_btw_fixes.py
+++ b/tests/test_reasoning_chip_btw_fixes.py
@@ -201,6 +201,85 @@ class TestBtwStreamDoneGuard:
             "even if no token events arrived before done"
         )
 
+    def test_ensure_btw_row_gated_on_session_match(self):
+        """Regression for PR #935: _ensureBtwRow reads $('msgInner') — the
+        CURRENTLY-viewed session's container.  If the user switched sessions
+        during the /btw stream, creating a bubble here would put it in the
+        wrong session.  The done handler must guard on S.session.session_id
+        matching the parent sid before creating a new bubble.
+        """
+        fn = self.get_attach_btw()
+        done_block_m = re.search(
+            r"addEventListener\('done'[\s\S]*?(?=addEventListener\(')",
+            fn,
+        )
+        assert done_block_m
+        block = done_block_m.group(0)
+        # The _ensureBtwRow call must be guarded by a session-match check
+        assert ("S.session" in block and "parentSid" in block), (
+            "_ensureBtwRow() in the done handler must be gated on "
+            "S.session.session_id === parentSid — otherwise a user who "
+            "switched sessions during the /btw stream gets the answer "
+            "bubble injected into the wrong session's container"
+        )
+
+    def test_stream_done_set_before_close_in_done(self):
+        """Regression for PR #935 defensive ordering: _streamDone=true must be
+        set BEFORE src.close() in the done handler.  Setting it after works
+        today because EventSource.close() is synchronous per spec and doesn't
+        dispatch events, but the defensive-correct ordering is flag-first so
+        no future browser quirk or event-queue race can bypass the guard.
+        """
+        fn = self.get_attach_btw()
+        done_block_m = re.search(
+            r"addEventListener\('done'[\s\S]*?(?=addEventListener\(')",
+            fn,
+        )
+        assert done_block_m
+        block = done_block_m.group(0)
+        flag_pos = block.find("_streamDone=true")
+        close_pos = block.find("src.close()")
+        assert flag_pos > -1 and close_pos > -1
+        assert flag_pos < close_pos, (
+            "_streamDone=true must be set BEFORE src.close() in the done handler "
+            "so any event the browser fires during close() sees the flag already set"
+        )
+
+    def test_stream_done_set_before_close_in_apperror(self):
+        """Same defensive ordering as test_stream_done_set_before_close_in_done,
+        applied to the apperror handler."""
+        fn = self.get_attach_btw()
+        apperror_m = re.search(
+            r"addEventListener\('apperror'[\s\S]*?(?=addEventListener\(')",
+            fn,
+        )
+        assert apperror_m
+        block = apperror_m.group(0)
+        flag_pos = block.find("_streamDone=true")
+        close_pos = block.find("src.close()")
+        assert flag_pos > -1 and close_pos > -1, (
+            "apperror handler must both set _streamDone=true and call src.close()"
+        )
+        assert flag_pos < close_pos, (
+            "_streamDone=true must be set BEFORE src.close() in the apperror handler"
+        )
+
+    def test_stream_end_sets_stream_done(self):
+        """Regression for PR #935/#939/#942: stream_end handler must also set
+        _streamDone=true.  Today the ephemeral /btw path returns before emitting
+        stream_end so this is moot, but if the server emits stream_end as a
+        standalone terminator (e.g. for a non-ephemeral /btw variant), the
+        subsequent browser-fired onerror would wipe the bubble without the flag.
+        """
+        fn = self.get_attach_btw()
+        m = re.search(r"addEventListener\('stream_end'[\s\S]*?\}\s*\)", fn)
+        assert m, "stream_end handler not found"
+        block = m.group(0)
+        assert "_streamDone=true" in block or "_streamDone = true" in block, (
+            "stream_end handler must set _streamDone=true before closing the "
+            "connection — consistent with the done/apperror handlers"
+        )
+
 
 # ── #5 resize handler symmetry (non-blocking polish) ─────────────────────────
 


### PR DESCRIPTION
## Follow-up hardening of `_streamDone` flag from PR #934

Opus mentor review of PR #934 flagged three defensive improvements to the `_streamDone` flag introduced in `static/messages.js:attachBtwStream()`:

### Changes

**1. Set `_streamDone=true` before `src.close()` in `done` and `apperror` handlers**

The original code set the flag after `src.close()`. While `EventSource.close()` is synchronous and doesn't dispatch events per spec, the defensive-correct ordering is to mark the stream as done first, then tear down the connection — ensuring no possible re-ordering edge case in future browser revisions can bypass the guard.

**2. Guard `_ensureBtwRow()` in `done` handler with session ID check**

The `_ensureBtwRow()` call added in PR #934 reads `$('msgInner')` — the *currently viewed* session's message container. If the user switches sessions during a `/btw` stream, `btwRow.isConnected` goes false when `renderMessages()` clears the old container, but `done` would then create a new bubble in the *wrong* (now active) session.

Fix: only call `_ensureBtwRow()` if `S.session.session_id === parentSid` (the session that originated the `/btw` stream). If the user has switched away, the bubble is silently dropped — matching the pre-PR behavior for this edge case.

**3. Set `_streamDone=true` in `stream_end` handler**

`stream_end` is currently just `src.close()`. In the typical event ordering (`token → done → stream_end`) this is moot because `done` already set the flag. But if the server ever emits `stream_end` as a standalone terminator (without a preceding `done`), the subsequent `onerror` would still wipe the bubble. Setting `_streamDone=true` in `stream_end` makes the flag invariant: any clean close path sets it.

### Verification

- All 2103 tests pass
- Browser QA: all 12 checks pass (including 3 new Opus-specific checks)
