### PR TITLE
chore: v0.50.184 release notes (CHANGELOG)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## v0.50.184 — 2026-04-24
+
 ### Fixed
 - **Reasoning chip dropdown now opens correctly** — the dropdown was placed inside `.composer-left` which has `overflow-y: hidden`, clipping the upward-opening menu entirely. Moved `#composerReasoningDropdown` outside to sit alongside the model/profile/workspace dropdowns and added `_positionReasoningDropdown()` for consistent chip-aligned positioning. Z-index raised to 200 to match other composer dropdowns. (`static/index.html`, `static/style.css`, `static/ui.js`)
 - **Reasoning chip icon is now a monochrome SVG** — replaced the `🧠` emoji in the label with a `stroke="currentColor"` brain-outline SVG matching the style of all other composer chips. (`static/index.html`, `static/ui.js`)


### PR DESCRIPTION
Converts the `[Unreleased]` CHANGELOG entries (from PRs #932 + #934) into the versioned `v0.50.184` release entry.

This is a chore-only PR with no logic changes — just documentation update.

2103 tests still passing.
