### PR TITLE
fix(btw): _streamDone in stream_end + align /reasoning toast prefix

### DIFF
--- a/static/commands.js
+++ b/static/commands.js
@@ -654,7 +654,7 @@ function cmdReasoning(args){
     api('/api/reasoning',{method:'POST',body:JSON.stringify({effort:arg})})
       .then(function(st){
         const eff=(st && st.reasoning_effort)||arg;
-        showToast('Reasoning effort set to '+eff+' (saved; applies to next turn)');
+        showToast(BRAIN+' Reasoning effort: '+eff+' (saved; applies to next turn)');
         if(typeof _applyReasoningChip==='function') _applyReasoningChip(eff);
       })
       .catch(function(e){

--- a/static/messages.js
+++ b/static/messages.js
@@ -1385,7 +1385,7 @@ function attachBtwStream(parentSid, streamId, question){
     }catch(_){showToast(t('btw_failed'));}
     if(btwRow&&btwRow.isConnected) btwRow.remove();
   });
-  src.addEventListener('stream_end',()=>{src.close();});
+  src.addEventListener('stream_end',()=>{_streamDone=true;src.close();});
   src.onerror=()=>{src.close();if(!_streamDone&&btwRow&&btwRow.isConnected) btwRow.remove();};
 }
 


### PR DESCRIPTION
## Advisory fixes from Opus mentor review of PR #934

Two small improvements identified during the Opus mentor review of PR #934. Neither is blocking, but both are correctness improvements.

### Fix 1 — `_streamDone=true` in `stream_end` handler (`static/messages.js`)

**Why:** Defensive symmetry. The `_streamDone` flag introduced in PR #934 is set in `done` and `apperror` handlers. Opus noted that the `stream_end` handler does not set it, which is currently harmless (the ephemeral `/btw` path in `api/streaming.py` returns before emitting `stream_end`). However if someone later adds `stream_end` emission to the ephemeral branch, or this helper is reused for non-ephemeral streams, the guard would silently regress. Setting the flag here is consistent with all other completion paths.

**Change:** `src.addEventListener('stream_end',()=>{src.close();})` → `src.addEventListener('stream_end',()=>{_streamDone=true;src.close();})`

### Fix 2 — `/reasoning` success toast uses `BRAIN` prefix (`static/commands.js`)

**Why:** The failure toast already used `BRAIN + ' Failed to set effort…'`. The success toast used a bare string without the prefix, making the two branches visually inconsistent.

**Change:** `showToast('Reasoning effort set to …')` → `showToast(BRAIN+' Reasoning effort: …')`

---

No Python changes. Tests pass (2093).
