### PR TITLE
fix(btw): set _streamDone=true before src.close() — defensive ordering in /btw stream handlers

### DIFF
--- a/static/messages.js
+++ b/static/messages.js
@@ -1363,8 +1363,8 @@ function attachBtwStream(parentSid, streamId, question){
     if(ansEl) ansEl.innerHTML=renderMd(answer);
   });
   src.addEventListener('done',e=>{
-    src.close();
     _streamDone=true;
+    src.close();
     try{
       const d=JSON.parse(e.data);
       if(d.answer&&!answer) answer=d.answer;
@@ -1377,8 +1377,8 @@ function attachBtwStream(parentSid, streamId, question){
     showToast(t('btw_done'));
   });
   src.addEventListener('apperror',e=>{
-    src.close();
     _streamDone=true;
+    src.close();
     try{
       const d=JSON.parse(e.data);
       showToast(t('btw_failed')+(d.message||''));


### PR DESCRIPTION
## Defensive ordering: `_streamDone=true` before `src.close()` in /btw stream handlers

Tiny defensive hygiene fix in `attachBtwStream` (static/messages.js), flagged during the Opus mentor review of PR #934.

**Before:** `src.close()` first, then `_streamDone=true`
**After:** `_streamDone=true` first, then `src.close()`

Same change in both the `done` handler and the `apperror` handler.

### Is there an observable bug today?

No. Per the EventSource spec, `close()` only sets readyState to CLOSED and suppresses reconnect attempts - it does NOT dispatch error. So onerror cannot fire between src.close() and _streamDone=true in any current browser.

### Why bother?

- Spec-defensive: if any future engine fires a synchronous error on close(), the flag will already be set, and onerror will not remove the rendered /btw answer
- Footgun elimination: the existing ordering is a latent pattern that could silently break if the event model changes
- Two-line change, zero behavioral risk

### Files changed

- static/messages.js - 2 lines reordered (done handler + apperror handler)

Full test suite: 2093 passed, 0 failed
