### PR TITLE
fix(bootstrap): discover .venv layout in agent_dir (closes #938)

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -113,7 +113,7 @@ def discover_launcher_python(agent_dir: Path | None) -> str:
     if env_python:
         return env_python
     if agent_dir:
-        for rel in ("venv/bin/python", "venv/Scripts/python.exe"):
+        for rel in ("venv/bin/python", "venv/Scripts/python.exe", ".venv/bin/python", ".venv/Scripts/python.exe"):
             candidate = agent_dir / rel
             if candidate.exists():
                 return str(candidate)


### PR DESCRIPTION
## Problem

`discover_launcher_python` only searched for `venv/bin/python` and `venv/Scripts/python.exe` inside `agent_dir`. When hermes-agent uses a `.venv/` layout (with a leading dot), discovery fell through to the webui's own `.venv`, which lacks hermes-agent on `sys.path`. This caused the launcher to silently use the wrong Python interpreter.

## Fix

Added `.venv/bin/python` and `.venv/Scripts/python.exe` to the search list for `agent_dir`, so both `venv/` and `.venv/` layouts are checked before falling back.

```python
# Before
for rel in ("venv/bin/python", "venv/Scripts/python.exe"):

# After
for rel in ("venv/bin/python", "venv/Scripts/python.exe", ".venv/bin/python", ".venv/Scripts/python.exe"):
```

## Testing

All 2103 tests pass.

Closes #938
