### PR TITLE
fix(btw): stream_end sets _streamDone=true before closing SSE connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 ### Fixed
 - **Reasoning chip now appears after the model chip** in the composer toolbar — model is a more fundamental choice and should be stable in position regardless of whether reasoning is active. Order: Profile → Workspace → Model → Reasoning. (`static/index.html`)
 
+## v0.50.185 — 2026-04-24
+
+### Fixed
+- **`/btw` `stream_end` now sets `_streamDone`** — defense-in-depth improvement per Opus code review: the `stream_end` SSE handler now sets `_streamDone=true` before closing the connection, guarding against any server flow that emits `stream_end` without a preceding `done`/`apperror` event. (`static/messages.js`)
+
 ## v0.50.184 — 2026-04-24
 
 ### Fixed

--- a/static/messages.js
+++ b/static/messages.js
@@ -1385,7 +1385,7 @@ function attachBtwStream(parentSid, streamId, question){
     }catch(_){showToast(t('btw_failed'));}
     if(btwRow&&btwRow.isConnected) btwRow.remove();
   });
-  src.addEventListener('stream_end',()=>{src.close();});
+  src.addEventListener('stream_end',()=>{_streamDone=true;src.close();});
   src.onerror=()=>{src.close();if(!_streamDone&&btwRow&&btwRow.isConnected) btwRow.remove();};
 }
 


### PR DESCRIPTION
## fix(btw): `stream_end` sets `_streamDone=true` before closing SSE connection

**Defense-in-depth improvement from Opus code review of PR #934.**

### What changed

`static/messages.js` — the `stream_end` event handler in `attachBtwStream()`:

**Before:**
```js
src.addEventListener('stream_end', () => { src.close(); });
```

**After:**
```js
src.addEventListener('stream_end', () => { _streamDone = true; src.close(); });
```

### Why

PR #934 added a `_streamDone` flag to prevent `onerror` from removing the `/btw` answer bubble when the server cleanly closes the SSE connection. The flag is set in `done` and `apperror` handlers. However, Opus's review of #934 noted that if the server ever emits `stream_end` without a preceding `done`/`apperror` event (or if those events arrive in an unexpected order), `_streamDone` would still be `false` when `onerror` fires — wiping the rendered bubble.

Setting `_streamDone=true` in `stream_end` closes this gap. One-line fix, zero risk.

### Testing

2103 tests passing (all existing + the 10 regression tests added in #934 for the btw/reasoning fixes).

Closes no issue — this is a follow-up hardening of the fix already shipped in v0.50.184.
