### PR TITLE
fix(btw): use correct SSE endpoint /api/chat/stream

### DIFF
--- a/static/messages.js
+++ b/static/messages.js
@@ -1329,7 +1329,7 @@ function sendBrowserNotification(title,body){
 
 function attachBtwStream(parentSid, streamId, question){
   if(!parentSid||!streamId) return;
-  const src=new EventSource('/api/stream?stream_id='+encodeURIComponent(streamId));
+  const src=new EventSource('/api/chat/stream?stream_id='+encodeURIComponent(streamId));
   let answer='';
   let btwRow=null;
   let _streamDone=false;


### PR DESCRIPTION
## Summary

- Fixes the `/btw` command being completely non-functional — `attachBtwStream()` connected to `/api/stream` (404) instead of `/api/chat/stream`

## Details

Issue #945 identified two bugs. This PR fixes Bug 1 (critical):

- **Bug 1 (fixed):** `static/messages.js` line 1332 opened `EventSource` at `/api/stream` but the server SSE handler is at `/api/chat/stream` (`routes.py` line 884). Every `/btw` request got an immediate 404.

- **Bug 2 (not a bug):** The issue also reported "no token streaming in ephemeral path." However, inspecting `api/streaming.py`, the `on_token` callback (line 1043) fires `put('token', ...)` during the agent run — this fires for **all** runs including ephemeral. The `stream_delta_callback=on_token` is wired at line 1221, well before the ephemeral branch at line 1344. So token-level streaming already works for `/btw`; the only issue was the 404 URL preventing any events from reaching the client.

Closes #945

🤖 Generated with [Claude Code](https://claude.com/claude-code)