### PR TITLE
perf: add defer to all local script tags for faster page load

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -730,15 +730,15 @@
   </div>
 </div>
 <div class="toast" id="toast"></div>
-<script src="static/i18n.js"></script>
-<script src="static/icons.js"></script>
-<script src="static/ui.js"></script>
-<script src="static/workspace.js"></script>
-<script src="static/sessions.js"></script>
-<script src="static/commands.js"></script>
-<script src="static/messages.js"></script>
-<script src="static/panels.js"></script>
-<script src="static/onboarding.js"></script>
-<script src="static/boot.js"></script>
+<script src="static/i18n.js" defer></script>
+<script src="static/icons.js" defer></script>
+<script src="static/ui.js" defer></script>
+<script src="static/workspace.js" defer></script>
+<script src="static/sessions.js" defer></script>
+<script src="static/commands.js" defer></script>
+<script src="static/messages.js" defer></script>
+<script src="static/panels.js" defer></script>
+<script src="static/onboarding.js" defer></script>
+<script src="static/boot.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Add `defer` attribute to all 10 local `<script>` tags in `index.html`. This allows the browser to download scripts in parallel during HTML parsing instead of blocking DOM construction sequentially.

## Before

All scripts loaded synchronously — each one blocked HTML parsing:

```html
<script src="static/i18n.js"></script>
<script src="static/icons.js"></script>
...
```

This caused 10 sequential HTTP requests to the Python HTTP server, with DOM construction paused between each. Total ~560KB of JS blocked page rendering. The sidebar session list could not render until all scripts finished loading, causing a noticeable delay before past conversations appeared.

## After

```html
<script src="static/i18n.js" defer></script>
<script src="static/icons.js" defer></script>
...
```

Scripts download in parallel during HTML parsing and execute in order after the DOM is ready. Execution order is preserved (`defer` guarantees order), and all scripts run after HTML parsing completes (before `DOMContentLoaded`), so `document.querySelector` and other DOM-dependent calls work correctly.

## Verification

- Page loads with 0 console errors
- All UI panels functional (chat, tasks, skills, memory, profiles, settings)
- Session list populates correctly
- Slash commands, voice input, workspace browser all work

## Testing

Manual verification — existing test suite covers functional behavior without asserting on script loading strategy.