### PR TITLE
fix(ui): close 641-767px rail/hamburger breakpoint gap

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -439,7 +439,7 @@
   .rail .nav-tab{flex:0 0 auto;padding:0;font-size:inherit;border-bottom:none;overflow:visible;}
   .rail .nav-tab:hover::after{content:none;}
   .rail .nav-tab.active::before{content:'';position:absolute;left:-6px;top:50%;bottom:auto;transform:translateY(-50%);width:3px;height:16px;background:var(--accent);border-radius:0 2px 2px 0;}
-  @media(min-width:768px){.rail{display:flex;}.sidebar > .sidebar-nav{display:none;}}
+  @media(min-width:641px){.rail{display:flex;}.sidebar > .sidebar-nav{display:none;}}
   /* Sidebar navigation tabs */
   .sidebar-nav{display:flex;border-bottom:1px solid var(--border);flex-shrink:0;padding:6px 8px 0;gap:2px;}
   .nav-tab{flex:1;padding:10px 4px 8px;font-size:20px;text-align:center;cursor:pointer;color:var(--muted);border:none;background:none;transition:color .15s;border-bottom:2px solid transparent;white-space:nowrap;overflow:hidden;position:relative;display:flex;align-items:center;justify-content:center;}


### PR DESCRIPTION
Follow-on polish from #899 (three-column layout).

## Change

At 641–767px the layout was in an awkward gap: the hamburger was hidden (only shows at ≤640px) and the rail was also hidden (only shows at ≥768px). The sidebar stayed as a persistent panel with sidebar-nav tabs visible, so navigation still worked — but the rail was absent for no good reason.

**Fix:** move the rail breakpoint from `min-width:768px` to `min-width:641px`. The mobile slide-in behavior (sidebar position:fixed, hamburger toggle, overlay scrim) stays at ≤640px only — no change to mobile UX.

## Before / after

| Viewport | Before | After |
|----------|--------|-------|
| ≤640px | Mobile (hamburger + slide-in) | Unchanged |
| 641–767px | No rail, no hamburger — sidebar-nav only | **Rail visible** + sidebar-nav |
| ≥768px | Rail visible, sidebar-nav hidden | Unchanged |

## Testing

- CSS change only (1 line)
- JS syntax: clean
- 35 regression tests pass (settings navigation + sprint34)
