### PR TITLE
fix: harden _accepts_gzip + update stale test assertions post-#959

### DIFF
--- a/api/helpers.py
+++ b/api/helpers.py
@@ -57,7 +57,10 @@ def _security_headers(handler):
 
 def _accepts_gzip(handler) -> bool:
     """Check if the client accepts gzip encoding."""
-    ae = handler.headers.get('Accept-Encoding', '')
+    headers = getattr(handler, 'headers', None)
+    if not headers:
+        return False
+    ae = headers.get('Accept-Encoding', '')
     return 'gzip' in ae
 
 

--- a/tests/test_issue401.py
+++ b/tests/test_issue401.py
@@ -28,8 +28,10 @@ def test_loadsession_preserves_tool_rows():
 
 def test_loadsession_uses_session_toolcalls_only_as_fallback():
     """Session summaries are the fallback, not the primary reload source."""
-    assert "if(!hasMessageToolMetadata&&data.session.tool_calls&&data.session.tool_calls.length)" in SESSIONS_JS
-    assert "S.toolCalls=(data.session.tool_calls||[]).map(tc=>({...tc,done:true}));" in SESSIONS_JS
+    assert ("if(!hasMessageToolMetadata&&data.session.tool_calls&&data.session.tool_calls.length)" in SESSIONS_JS or
+            "if (!hasMessageToolMetadata && data.session.tool_calls && data.session.tool_calls.length)" in SESSIONS_JS)
+    assert ("S.toolCalls=(data.session.tool_calls||[]).map(tc=>({...tc,done:true}));" in SESSIONS_JS or
+            "S.toolCalls = data.session.tool_calls.map(tc => ({...tc, done: true}));" in SESSIONS_JS)
     assert "S.toolCalls=[];" in SESSIONS_JS
 
 

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -531,7 +531,8 @@ def test_reload_path_restores_pending_message_and_reattaches_live_stream(cleanup
     assert 'pending_user_message' in ui_src
     assert 'function attachLiveStream' in messages_src
     assert 'const pendingMsg=typeof getPendingSessionMessage' in sessions_src
-    assert 'const activeStreamId=data.session.active_stream_id||null;' in sessions_src
+    assert ('const activeStreamId=data.session.active_stream_id||null;' in sessions_src or
+            'const activeStreamId=S.session.active_stream_id||null;' in sessions_src)
     assert 'attachLiveStream(sid, activeStreamId' in sessions_src
     assert 'if (S.activeStreamId && S.activeStreamId === streamId) return;' in ui_src
 


### PR DESCRIPTION
Hotfix for test failures introduced when merging #959 (fast conversation switching). Fixes `_accepts_gzip` AttributeError in test harness and updates two stale static-analysis assertions whose target strings changed when #959 reformatted `sessions.js`.