### PR TITLE
fix(docker): use /home/hermes/.hermes for HERMES_HOME in two/three-container compose

### DIFF
--- a/docker-compose.three-container.yml
+++ b/docker-compose.three-container.yml
@@ -29,11 +29,11 @@ services:
       - "127.0.0.1:8642:8642"
     volumes:
       # Persist config, state, sessions, skills, memory across restarts
-      - hermes-home:/root/.hermes
+      - hermes-home:/home/hermes/.hermes
       # Expose agent source so the WebUI can install dependencies from it
       - hermes-agent-src:/opt/hermes
     environment:
-      - HERMES_HOME=/root/.hermes
+      - HERMES_HOME=/home/hermes/.hermes
       - HERMES_UID=${HERMES_UID:-10000}
       - HERMES_GID=${HERMES_GID:-10000}
     restart: unless-stopped
@@ -52,9 +52,9 @@ services:
     ports:
       - "127.0.0.1:9119:9119"
     volumes:
-      - hermes-home:/root/.hermes
+      - hermes-home:/home/hermes/.hermes
     environment:
-      - HERMES_HOME=/root/.hermes
+      - HERMES_HOME=/home/hermes/.hermes
       - HERMES_UID=${HERMES_UID:-10000}
       - HERMES_GID=${HERMES_GID:-10000}
       # Dashboard connects to the gateway for health/session data

--- a/docker-compose.two-container.yml
+++ b/docker-compose.two-container.yml
@@ -40,11 +40,11 @@ services:
       - "127.0.0.1:8642:8642"
     volumes:
       # Persist config, state, sessions, skills, memory across restarts
-      - hermes-home:/root/.hermes
+      - hermes-home:/home/hermes/.hermes
       # Expose agent source so the WebUI can install dependencies from it
       - hermes-agent-src:/opt/hermes
     environment:
-      - HERMES_HOME=/root/.hermes
+      - HERMES_HOME=/home/hermes/.hermes
     restart: unless-stopped
     networks:
       - hermes-net


### PR DESCRIPTION
Fixes the container crash reported in #967.

**Root cause:** Both compose files set `HERMES_HOME=/root/.hermes` and mount the `hermes-home` volume there. The `nousresearch/hermes-agent` image drops privileges from root to a `hermes` user via `gosu`. After the drop, `/root` is mode `700` so the re-executed entrypoint cannot create subdirectories under `/root/.hermes`.

**Fix:** mount `hermes-home` to `/home/hermes/.hermes` and update `HERMES_HOME` in both `docker-compose.two-container.yml` and `docker-compose.three-container.yml`.

Closes #967.