### PR TITLE
fix: inject full workspace path into agent context for uploaded files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 ### Fixed
 - **Reasoning chip now appears after the model chip** in the composer toolbar — model is a more fundamental choice and should be stable in position regardless of whether reasoning is active. Order: Profile → Workspace → Model → Reasoning. (`static/index.html`)
 
+## v0.50.206 — 2026-04-25
+
+### Fixed
+- **Uploaded files now resolve to their full workspace path in agent context** — drag-and-drop and paperclip file uploads were correctly saved to the workspace, but the agent received only the bare filename (e.g. `photo.jpg`) in the message context rather than an absolute path. The agent could not call `read_file` or `vision_analyze` without a full path. `uploadPendingFiles()` now returns `{name, path}` objects from the `/api/upload` response (`data.path` was always returned but never threaded through). The agent message uses the full path; all display surfaces (badges, session history, INFLIGHT state, POST body) continue showing only the bare filename. (`static/ui.js`, `static/messages.js`) Closes #996. [#997]
+
 ## v0.50.205 — 2026-04-24
 
 ### Fixed

--- a/static/messages.js
+++ b/static/messages.js
@@ -117,7 +117,7 @@ async function send(){
     }
     markInflight(activeSid, streamId);
     if(typeof saveInflightState==='function'){
-      saveInflightState(activeSid,{streamId,messages:INFLIGHT[activeSid].messages,uploaded,toolCalls:INFLIGHT[activeSid].toolCalls||[]});
+      saveInflightState(activeSid,{streamId,messages:INFLIGHT[activeSid].messages,uploaded:uploadedNames,toolCalls:INFLIGHT[activeSid].toolCalls||[]});
     }
     // Refresh session list so background streaming indicators appear immediately for the
     // session that was just started and any others that may already be running.
@@ -160,7 +160,7 @@ async function send(){
   }
 
   // Open SSE stream and render tokens live
-  attachLiveStream(activeSid, streamId, uploaded);
+  attachLiveStream(activeSid, streamId, uploadedNames);
 
 }
 
@@ -719,7 +719,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         }
         if(uploaded.length){
           const lastUser=[...S.messages].reverse().find(m=>m.role==='user');
-          if(lastUser)lastUser.attachments=uploadedNames;
+          if(lastUser)lastUser.attachments=uploaded;
         }
         clearLiveToolCards();
         S.busy=false;

--- a/static/messages.js
+++ b/static/messages.js
@@ -60,20 +60,22 @@ async function send(){
   try{uploaded=await uploadPendingFiles();}
   catch(e){if(!text){setComposerStatus(`Upload error: ${e.message}`);return;}}
 
+  const uploadedNames=uploaded.map(u=>u.name||u);
+  const uploadedPaths=uploaded.map(u=>u.path||u.name||u);
   let msgText=text;
-  if(uploaded.length&&!msgText)msgText=`I've uploaded ${uploaded.length} file(s): ${uploaded.join(', ')}`;
-  else if(uploaded.length)msgText=`${text}\n\n[Attached files: ${uploaded.join(', ')}]`;
+  if(uploaded.length&&!msgText)msgText=`I've uploaded ${uploaded.length} file(s): ${uploadedPaths.join(', ')}`;
+  else if(uploaded.length)msgText=`${text}\n\n[Attached files: ${uploadedPaths.join(', ')}]`;
   if(!msgText){setComposerStatus('Nothing to send');return;}
 
   $('msg').value='';autoResize();
-  const displayText=text||(uploaded.length?`Uploaded: ${uploaded.join(', ')}`:'(file upload)');
-  const userMsg={role:'user',content:displayText,attachments:uploaded.length?uploaded:undefined,_ts:Date.now()/1000};
+  const displayText=text||(uploaded.length?`Uploaded: ${uploadedNames.join(', ')}`:'(file upload)');
+  const userMsg={role:'user',content:displayText,attachments:uploaded.length?uploadedNames:undefined,_ts:Date.now()/1000};
   S.toolCalls=[];  // clear tool calls from previous turn
   clearLiveToolCards();  // clear any leftover live cards from last turn
   S.messages.push(userMsg);renderMessages();appendThinking();setBusy(true);
-  INFLIGHT[activeSid]={messages:[...S.messages],uploaded,toolCalls:[]};
+  INFLIGHT[activeSid]={messages:[...S.messages],uploaded:uploadedNames,toolCalls:[]};
   if(typeof saveInflightState==='function'){
-    saveInflightState(activeSid,{streamId:null,messages:INFLIGHT[activeSid].messages,uploaded,toolCalls:[]});
+    saveInflightState(activeSid,{streamId:null,messages:INFLIGHT[activeSid].messages,uploaded:uploadedNames,toolCalls:[]});
   }
   startApprovalPolling(activeSid);
   startClarifyPolling(activeSid);
@@ -100,7 +102,7 @@ async function send(){
     const startData=await api('/api/chat/start',{method:'POST',body:JSON.stringify({
       session_id:activeSid,message:msgText,
       model:S.session.model||$('modelSelect').value,workspace:S.session.workspace,
-      attachments:uploaded.length?uploaded:undefined
+      attachments:uploaded.length?uploadedNames:undefined
     })});
     if(startData.effective_model && S.session){
       S.session.model=startData.effective_model;
@@ -717,7 +719,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         }
         if(uploaded.length){
           const lastUser=[...S.messages].reverse().find(m=>m.role==='user');
-          if(lastUser)lastUser.attachments=uploaded;
+          if(lastUser)lastUser.attachments=uploadedNames;
         }
         clearLiveToolCards();
         S.busy=false;

--- a/static/ui.js
+++ b/static/ui.js
@@ -2790,7 +2790,7 @@ async function uploadPendingFiles(){
       if(!res.ok){const err=await res.text();throw new Error(err);}
       const data=await res.json();
       if(data.error)throw new Error(data.error);
-      names.push(data.filename);
+      names.push({name: data.filename, path: data.path});
     }catch(e){failures++;setStatus(`\u274c ${t('upload_failed')}${f.name} \u2014 ${e.message}`);}
     bar.style.width=`${Math.round((i+1)/total*100)}%`;
   }


### PR DESCRIPTION
## Summary

Fixes #996 — drag-and-drop (and paperclip) file uploads were saved correctly to the workspace, but the agent couldn't read them because only the bare filename was injected into the message context, not the full path.

## Root cause

`uploadPendingFiles()` in `ui.js` pushed `data.filename` (e.g. `photo.jpg`) to the result array. The message context built from that was:

```
[Attached files: photo.jpg]
```

The agent has no way to call `read_file` or `vision_analyze` with a bare filename — it needs an absolute path.

## Fix

`uploadPendingFiles()` now returns `{name, path}` objects. The agent message uses the full path; display labels (badges, INFLIGHT state, session history) continue showing only the bare filename.

**Before:**
```
[Attached files: gettyimages-108226626-612x612.jpg]
```

**After:**
```
[Attached files: /home/user/.hermes/workspaces/default/gettyimages-108226626-612x612.jpg]
```

The path is already returned by `/api/upload` as `data.path` — this fix just threads it through to the message context.

## Files changed

- `static/ui.js` — `uploadPendingFiles()` returns `{name, path}` instead of bare filename
- `static/messages.js` — uses `uploadedPaths` for agent `msgText`, `uploadedNames` for all display/storage

## Backwards compat

The `u.path||u.name||u` fallback pattern means this degrades gracefully if the server ever returns a filename-only response.

## Tests

2133 passed, 0 failures.

Reported by ET in Discord. Closes #996.
