### PR TITLE
Polish session attention indicators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## [Unreleased]
 
 ### Fixed
+- **Session attention indicators now reuse the right-side actions slot** — streaming spinners and unread dots no longer sit before the session title. Running and unread rows hide the timestamp and show the attention indicator at the same right-side position as the three-dot actions button, which appears on hover/focus. This preserves the last-activity timestamp for idle/read sessions while avoiding title shifts and saving horizontal title space. (`static/sessions.js`, `static/style.css`)
+- **Session sidebar polish** — idle/read timestamps now align to the far right and hide on hover when the actions menu appears; date group carets now point down when expanded and right when collapsed; sessions inside the Pinned group no longer repeat the pinned-star icon on each row. (`static/sessions.js`, `static/style.css`)
+- **Session running indicators now appear immediately after send** — the sidebar now treats the active local busy session and local in-flight sessions as streaming while `/api/sessions` catches up, so the spinner no longer waits for the next 5-second streaming poll. (`static/messages.js`, `static/sessions.js`)
+- **Session sidebar dates now use the last message time** — sidebar sorting, grouping, and relative timestamps now prefer a derived `last_message_at` value instead of metadata-only `updated_at`, so changing session settings does not make an old conversation appear under Today. (`api/models.py`, `api/routes.py`, `static/sessions.js`)
 - **Reasoning chip now appears after the model chip** in the composer toolbar — model is a more fundamental choice and should be stable in position regardless of whether reasoning is active. Order: Profile → Workspace → Model → Reasoning. (`static/index.html`)
 
 ## v0.50.205 — 2026-04-24

--- a/api/models.py
+++ b/api/models.py
@@ -194,6 +194,34 @@ def _is_streaming_session(active_stream_id, active_stream_ids):
     return bool(active_stream_id and active_stream_id in active_stream_ids)
 
 
+def _session_sort_timestamp(session):
+    if isinstance(session, dict):
+        return session.get('last_message_at') or session.get('updated_at') or 0
+    return _last_message_timestamp(getattr(session, 'messages', None)) or getattr(session, 'updated_at', 0) or 0
+
+
+def _message_timestamp(message):
+    if not isinstance(message, dict):
+        return None
+    raw = message.get('_ts') or message.get('timestamp')
+    try:
+        return float(raw) if raw is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _last_message_timestamp(messages):
+    if not isinstance(messages, list):
+        return None
+    for message in reversed(messages):
+        if isinstance(message, dict) and message.get('role') == 'tool':
+            continue
+        ts = _message_timestamp(message)
+        if ts:
+            return ts
+    return None
+
+
 class Session:
     def __init__(self, session_id: str=None, title: str='Untitled',
                  workspace=str(DEFAULT_WORKSPACE), model=DEFAULT_MODEL,
@@ -325,6 +353,7 @@ class Session:
 
     def compact(self, include_runtime=False, active_stream_ids=None) -> dict:
         active_stream_ids = active_stream_ids if active_stream_ids is not None else set()
+        last_message_at = _last_message_timestamp(self.messages) or self.updated_at
         return {
             'session_id': self.session_id,
             'title': self.title,
@@ -333,6 +362,7 @@ class Session:
             'message_count': len(self.messages),
             'created_at': self.created_at,
             'updated_at': self.updated_at,
+            'last_message_at': last_message_at,
             'pinned': self.pinned,
             'archived': self.archived,
             'project_id': self.project_id,
@@ -413,6 +443,11 @@ def all_sessions():
                 s for s in index
                 if _index_entry_exists(s.get('session_id'))
             ]
+            for i, s in enumerate(index):
+                if 'last_message_at' not in s:
+                    full = Session.load(s.get('session_id'))
+                    if full:
+                        index[i] = full.compact()
             for s in index:
                 s['is_streaming'] = _is_streaming_session(
                     s.get('active_stream_id'),
@@ -426,7 +461,7 @@ def all_sessions():
                         include_runtime=True,
                         active_stream_ids=active_stream_ids,
                     )
-            result = sorted(index_map.values(), key=lambda s: (s.get('pinned', False), s['updated_at']), reverse=True)
+            result = sorted(index_map.values(), key=lambda s: (s.get('pinned', False), _session_sort_timestamp(s)), reverse=True)
             # Hide empty Untitled sessions from the UI (created by tests, page refreshes, etc.)
             # Exempt sessions younger than 60 s so a brand-new session stays visible (#789)
             _now = time.time()
@@ -454,7 +489,7 @@ def all_sessions():
             logger.debug("Failed to load session from %s", p)
     for s in SESSIONS.values():
         if all(s.session_id != x.session_id for x in out): out.append(s)
-    out.sort(key=lambda s: (getattr(s, 'pinned', False), s.updated_at), reverse=True)
+    out.sort(key=lambda s: (getattr(s, 'pinned', False), _session_sort_timestamp(s)), reverse=True)
     _now = time.time()
     result = [s.compact(include_runtime=True, active_stream_ids=active_stream_ids) for s in out if not (
         s.title == 'Untitled'
@@ -612,6 +647,7 @@ def get_cli_sessions() -> list:
                     'message_count': row['message_count'] or 0,
                     'created_at': row['started_at'],
                     'updated_at': raw_ts,
+                    'last_message_at': raw_ts,
                     'pinned': False,
                     'archived': False,
                     'project_id': None,

--- a/api/routes.py
+++ b/api/routes.py
@@ -735,6 +735,8 @@ def handle_get(handler, parsed) -> bool:
                     "message_count": len(msgs),
                     "created_at": (cli_meta or {}).get("created_at", 0),
                     "updated_at": (cli_meta or {}).get("updated_at", 0),
+                    "last_message_at": (cli_meta or {}).get("last_message_at")
+                    or (cli_meta or {}).get("updated_at", 0),
                     "pinned": False,
                     "archived": False,
                     "project_id": None,
@@ -783,7 +785,10 @@ def handle_get(handler, parsed) -> bool:
         else:
             deduped_cli = []
         merged = webui_sessions + deduped_cli
-        merged.sort(key=lambda s: s.get("updated_at", 0) or 0, reverse=True)
+        merged.sort(
+            key=lambda s: s.get("last_message_at") or s.get("updated_at", 0) or 0,
+            reverse=True,
+        )
         safe_merged = []
         for s in merged:
             item = dict(s)

--- a/static/messages.js
+++ b/static/messages.js
@@ -75,6 +75,7 @@ async function send(){
   if(typeof saveInflightState==='function'){
     saveInflightState(activeSid,{streamId:null,messages:INFLIGHT[activeSid].messages,uploaded,toolCalls:[]});
   }
+  if(typeof renderSessionListFromCache==='function') renderSessionListFromCache();
   startApprovalPolling(activeSid);
   startClarifyPolling(activeSid);
   S.activeStreamId = null;  // will be set after stream starts

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -621,7 +621,7 @@ function filterSessions(){
 }
 
 function _sessionTimestampMs(session) {
-  const raw = Number(session && (session.updated_at || session.created_at || 0));
+  const raw = Number(session && (session.last_message_at || session.updated_at || session.created_at || 0));
   return Number.isFinite(raw) ? raw * 1000 : 0;
 }
 
@@ -803,7 +803,7 @@ function renderSessionListFromCache(){
     hdr.className='session-date-header'+(g.isPinned?' pinned':'');
     const caret=document.createElement('span');
     caret.className='session-date-caret';
-    caret.textContent='\u25B8'; // right-pointing triangle
+    caret.textContent='\u25BE'; // down when expanded; rotated right when collapsed
     const label=document.createElement('span');
     label.textContent=g.label;
     hdr.appendChild(caret);hdr.appendChild(label);
@@ -818,18 +818,25 @@ function renderSessionListFromCache(){
       _saveCollapsed();
     };
     wrapper.appendChild(hdr);
-    for(const s of g.items){ body.appendChild(_renderOneSession(s)); }
+    for(const s of g.items){ body.appendChild(_renderOneSession(s, Boolean(g.isPinned))); }
     wrapper.appendChild(body);
     list.appendChild(wrapper);
   }
   // ── Render session items (extracted for group body use) ──
   // Note: declared after the groups loop but available via function hoisting.
-  function _renderOneSession(s){
+  function _renderOneSession(s, isPinnedGroup=false){
     const el=document.createElement('div');
     const isActive=S.session&&s.session_id===S.session.session_id;
-    const isStreaming=Boolean(s.is_streaming);
+    const isLocalStreaming=Boolean(
+      s.session_id
+      && (
+        (isActive&&S.busy)
+        || (typeof INFLIGHT==='object'&&INFLIGHT&&INFLIGHT[s.session_id])
+      )
+    );
+    const isStreaming=Boolean(s.is_streaming||isLocalStreaming);
     const hasUnread=_hasUnreadForSession(s)&&!isActive;
-    el.className='session-item'+(isActive?' active':'')+(isActive&&S.session&&S.session._flash?' new-flash':'')+(s.archived?' archived':'')+(isStreaming?' streaming':'');
+    el.className='session-item'+(isActive?' active':'')+(isActive&&S.session&&S.session._flash?' new-flash':'')+(s.archived?' archived':'')+(isStreaming?' streaming':'')+(hasUnread?' unread':'');
     if(isActive&&S.session&&S.session._flash)delete S.session._flash;
     const rawTitle=s.title||'Untitled';
     const tags=(rawTitle.match(/#[\w-]+/g)||[]);
@@ -842,23 +849,21 @@ function renderSessionListFromCache(){
     sessionText.className='session-text';
     const titleRow=document.createElement('div');
     titleRow.className='session-title-row';
-    if(s.pinned){
+    if(s.pinned&&!isPinnedGroup){
       const pinInd=document.createElement('span');
       pinInd.className='session-pin-indicator';
       pinInd.innerHTML=ICONS.pin;
       titleRow.appendChild(pinInd);
     }
-    const state=document.createElement('span');
-    state.className='session-state-indicator'+(isStreaming?' is-streaming':(hasUnread?' is-unread':''));
-    titleRow.appendChild(state); // always reserve slot — prevents title shift when indicator appears
     const title=document.createElement('span');
     title.className='session-title';
     title.textContent=cleanTitle||'Untitled';
     title.title='Double-click to rename';
     const tsMs=_sessionTimestampMs(s);
     const ts=document.createElement('span');
-    ts.className='session-time';
-    ts.textContent=_formatRelativeSessionTime(tsMs);
+    const hasAttentionState=isStreaming||hasUnread;
+    ts.className='session-time'+(hasAttentionState?' is-hidden':'');
+    ts.textContent=hasAttentionState?'':_formatRelativeSessionTime(tsMs);
     titleRow.appendChild(title);
     titleRow.appendChild(ts);
     sessionText.appendChild(titleRow);
@@ -942,6 +947,10 @@ function renderSessionListFromCache(){
       }
     }
     el.appendChild(sessionText);
+    const state=document.createElement('span');
+    state.className='session-attention-indicator session-state-indicator'+(isStreaming?' is-streaming':(hasUnread?' is-unread':''));
+    state.setAttribute('aria-hidden','true');
+    el.appendChild(state);
     // Single trigger button that opens a shared dropdown menu
     const actions=document.createElement('div');
     actions.className='session-actions';

--- a/static/style.css
+++ b/static/style.css
@@ -230,7 +230,8 @@
   .sidebar-search-icon{position:absolute;left:22px;top:50%;transform:translateY(-50%);width:14px;height:14px;color:var(--muted);opacity:.7;pointer-events:none;}
   /* Inline session title edit */
   .session-title-input{flex:1;background:var(--surface);border:1px solid var(--accent);border-radius:6px;color:var(--text);padding:3px 8px;font-size:13px;outline:none;min-width:0;box-shadow:0 0 0 2px var(--accent-bg-strong);font-family:inherit;}
-  .session-item{padding:8px 40px 8px 8px;margin-bottom:2px;border-radius:8px;cursor:pointer;font-size:13px;color:var(--muted);transition:background .15s,color .15s;display:flex;align-items:flex-start;gap:8px;min-width:0;position:relative;}
+  .session-item{padding:8px 86px 8px 8px;margin-bottom:2px;border-radius:8px;cursor:pointer;font-size:13px;color:var(--muted);transition:background .15s,color .15s;display:flex;align-items:flex-start;gap:8px;min-width:0;position:relative;}
+  .session-item.streaming,.session-item.unread{padding-right:40px;}
   .session-item:hover{background:var(--hover-bg);color:var(--text);}
   .session-item.active{background:var(--accent-bg);color:var(--accent);}
   .session-item.streaming .session-title{color:var(--accent);}
@@ -242,6 +243,8 @@
   .session-meta{font-size:11px;color:var(--muted);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
   .session-item.active .session-meta{color:var(--accent-text);opacity:.8;}
   .session-state-indicator{display:inline-flex;align-items:center;justify-content:center;flex-shrink:0;width:10px;height:10px;color:var(--accent);visibility:hidden;}
+  .session-attention-indicator{position:absolute;right:6px;top:50%;transform:translateY(-50%);width:26px;height:26px;z-index:1;pointer-events:none;transition:opacity .15s ease,visibility .15s ease;}
+  .session-item:hover .session-attention-indicator,.session-item:focus-within .session-attention-indicator,.session-item.menu-open .session-attention-indicator{opacity:0;visibility:hidden;}
   .session-state-indicator.is-streaming,.session-state-indicator.is-unread{visibility:visible;}
   .session-state-indicator::before{content:"";display:block;flex-shrink:0;}
   .session-state-indicator.is-streaming::before{
@@ -259,17 +262,31 @@
     border-radius:50%;
     background:currentColor;
   }
+  .session-attention-indicator.is-streaming::before{
+    width:10px;
+    height:10px;
+  }
+  .session-attention-indicator.is-unread::before{
+    width:8px;
+    height:8px;
+  }
   .session-time{
     display:inline-flex;
-    margin-left:auto;
+    position:absolute;
+    right:10px;
+    top:50%;
+    transform:translateY(-50%);
     color:var(--muted);
     font-size:10px;
     white-space:nowrap;
     flex-shrink:0;
   }
+  .session-time.is-hidden{display:none;}
+  .session-item:hover .session-time,.session-item:focus-within .session-time,.session-item.menu-open .session-time{display:none;}
   /* ── Session action trigger + dropdown ── */
   .session-actions{position:absolute;right:6px;top:50%;transform:translateY(-50%);display:flex;align-items:center;justify-content:center;opacity:0;pointer-events:none;transition:opacity .15s ease;}
   .session-item:hover .session-actions,.session-item:focus-within .session-actions,.session-item.menu-open .session-actions{opacity:1;pointer-events:auto;}
+  .session-item.streaming:not(:hover):not(:focus-within):not(.menu-open) .session-actions,.session-item.unread:not(:hover):not(:focus-within):not(.menu-open) .session-actions{opacity:0;pointer-events:none;}
   .session-actions-trigger{width:26px;height:26px;border:1px solid transparent;border-radius:8px;background:transparent;color:var(--muted);cursor:pointer;padding:0;line-height:1;display:inline-flex;align-items:center;justify-content:center;transition:background .12s,color .12s,border-color .12s;}
   .session-actions-trigger:hover{background:var(--hover-bg);color:var(--text);}
   .session-actions-trigger.active{background:var(--accent-bg);border-color:var(--accent-bg-strong);color:var(--text);}
@@ -294,7 +311,7 @@
   .session-date-header{display:flex;align-items:center;gap:5px;font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--muted);padding:8px 10px 4px;cursor:pointer;user-select:none;opacity:.8;transition:opacity .15s;}
   .session-date-header:hover{opacity:1;}
   .session-date-header.pinned{color:var(--accent);}
-  .session-date-caret{font-size:9px;transition:transform .2s;flex-shrink:0;display:inline-block;}
+  .session-date-caret{font-size:9px;transition:transform .2s;flex-shrink:0;display:inline-block;transform:rotate(0deg);}
   .session-date-caret.collapsed{transform:rotate(-90deg);}
   .app-dialog-overlay{position:fixed;inset:0;background:rgba(7,12,19,.62);backdrop-filter:blur(6px);z-index:1100;display:none;align-items:center;justify-content:center;padding:24px;}
   .app-dialog{width:min(460px,100%);background:linear-gradient(180deg,rgba(21,31,45,.98),rgba(13,20,31,.98));border:1px solid var(--accent-bg-strong);border-radius:18px;box-shadow:0 18px 60px rgba(0,0,0,.45);padding:18px 18px 16px;color:var(--text);}
@@ -812,7 +829,8 @@
     .ctx-tooltip{right:-4px;min-width:190px;max-width:220px;}
     /* Touch targets — minimum 44px */
     .icon-btn,.mic-btn{min-width:44px;min-height:44px;}
-    .session-item{min-height:44px;padding:10px 40px 10px 12px;}
+    .session-item{min-height:44px;padding:10px 86px 10px 12px;}
+    .session-item.streaming,.session-item.unread{padding-right:40px;}
     .session-actions{opacity:1;pointer-events:auto;}
     /* Empty state */
     .empty-state h2{font-size:18px;}

--- a/tests/test_issue856_pinned_indicator_layout.py
+++ b/tests/test_issue856_pinned_indicator_layout.py
@@ -11,6 +11,10 @@ def test_pinned_indicator_renders_inside_title_row():
     title_row_idx = SESSIONS_JS.find("titleRow.className='session-title-row';")
     assert title_row_idx != -1, "session title row construction not found"
 
+    assert "body.appendChild(_renderOneSession(s, Boolean(g.isPinned)))" in SESSIONS_JS
+    assert "function _renderOneSession(s, isPinnedGroup=false)" in SESSIONS_JS
+    assert "if(s.pinned&&!isPinnedGroup){" in SESSIONS_JS
+
     pin_idx = SESSIONS_JS.find("pinInd.className='session-pin-indicator';", title_row_idx)
     assert pin_idx != -1, "pinned indicator creation not found after title row"
 
@@ -32,25 +36,87 @@ def test_pinned_indicator_uses_fixed_indicator_box():
     assert "justify-content:center;" in css_block, "pin indicator should center the star inside its box"
 
 
-def test_state_indicator_always_appended_to_prevent_layout_shift():
-    """State span is always added to the DOM (visibility:hidden when inactive) to prevent
-    titles shifting left/right when the spinner or unread dot appears/disappears."""
+def test_state_indicator_uses_right_actions_slot_to_prevent_title_shift():
+    """State span reuses the right-side action slot so the title start position
+    does not shift when the spinner or unread dot appears/disappears."""
     title_row_idx = SESSIONS_JS.find("titleRow.className='session-title-row';")
     assert title_row_idx != -1, "title row construction not found"
 
-    # state span must be appended unconditionally (no surrounding if-check)
-    append_idx = SESSIONS_JS.find("titleRow.appendChild(state);", title_row_idx)
-    assert append_idx != -1, "state span must always be appended to titleRow"
-
-    # Verify CSS uses visibility:hidden to reserve the slot
-    assert "session-state-indicator{" in STYLE_CSS, "session-state-indicator CSS rule missing"
-    base_block_start = STYLE_CSS.find("session-state-indicator{")
-    base_block_end = STYLE_CSS.find("}", base_block_start)
-    base_block = STYLE_CSS[base_block_start:base_block_end]
-    assert "visibility:hidden;" in base_block, (
-        "session-state-indicator should default to visibility:hidden so it reserves slot "
-        "without being visible — prevents title layout shift on state changes"
+    title_row_append_idx = SESSIONS_JS.find("titleRow.appendChild(state);", title_row_idx)
+    assert title_row_append_idx == -1, (
+        "state indicator should not be inserted before the title; it should reuse "
+        "the right-side actions slot to avoid title shift"
     )
+
+    state_idx = SESSIONS_JS.find("state.className='session-attention-indicator session-state-indicator'")
+    assert state_idx != -1, "right-side attention indicator creation not found"
+
+    append_to_row_idx = SESSIONS_JS.find("el.appendChild(state);", state_idx)
+    assert append_to_row_idx != -1, "state indicator should be appended to the outer row"
+
+    actions_idx = SESSIONS_JS.find("actions.className='session-actions';", append_to_row_idx)
+    assert actions_idx != -1, "session actions should still be appended after attention indicator"
+
+    assert ".session-attention-indicator{" in STYLE_CSS, "attention indicator CSS rule missing"
+    css_block = STYLE_CSS[
+        STYLE_CSS.find(".session-attention-indicator{"):
+        STYLE_CSS.find(".session-item:hover .session-attention-indicator")
+    ]
+    assert "position:absolute;" in css_block, "attention indicator should be positioned in the row action slot"
+    assert "right:6px;" in css_block, "attention indicator should align with the actions trigger"
+    assert "width:26px;" in css_block, "attention indicator should use the same width as the actions trigger"
+    assert "height:26px;" in css_block, "attention indicator should use the same height as the actions trigger"
+    assert ".session-attention-indicator.is-streaming::before{" in STYLE_CSS
+    inner_spinner_block = STYLE_CSS[
+        STYLE_CSS.find(".session-attention-indicator.is-streaming::before{"):
+        STYLE_CSS.find(".session-attention-indicator.is-unread::before{")
+    ]
+    assert "width:10px;" in inner_spinner_block, "spinner glyph should stay 10px inside the 26px action slot"
+    assert "height:10px;" in inner_spinner_block, "spinner glyph should stay 10px inside the 26px action slot"
+
+    hover_rule = ".session-item:hover .session-attention-indicator"
+    assert hover_rule in STYLE_CSS, "hover rule should hide attention indicator when actions appear"
+
+
+def test_timestamp_hidden_when_attention_state_is_present():
+    assert "+(hasUnread?' unread':'')" in SESSIONS_JS
+    assert "const hasAttentionState=isStreaming||hasUnread;" in SESSIONS_JS
+    assert "ts.className='session-time'+(hasAttentionState?' is-hidden':'');" in SESSIONS_JS
+    assert "ts.textContent=hasAttentionState?'':_formatRelativeSessionTime(tsMs);" in SESSIONS_JS
+    assert ".session-time.is-hidden{display:none;}" in STYLE_CSS
+    assert ".session-item{padding:8px 86px 8px 8px;" in STYLE_CSS
+    assert ".session-item.streaming,.session-item.unread{padding-right:40px;}" in STYLE_CSS
+    assert ".session-item{min-height:44px;padding:10px 86px 10px 12px;}" in STYLE_CSS
+    session_time_block = STYLE_CSS[
+        STYLE_CSS.find(".session-time{"):
+        STYLE_CSS.find(".session-time.is-hidden")
+    ]
+    assert "position:absolute;" in session_time_block
+    assert "right:10px;" in session_time_block
+    assert ".session-item:hover .session-time" in STYLE_CSS
+    assert ".session-item.streaming:not(:hover):not(:focus-within):not(.menu-open) .session-actions" in STYLE_CSS
+    assert ".session-item.unread:not(:hover):not(:focus-within):not(.menu-open) .session-actions" in STYLE_CSS
+
+
+def test_sidebar_uses_local_inflight_state_for_immediate_spinner():
+    messages_js = (Path(__file__).resolve().parent.parent / "static" / "messages.js").read_text()
+
+    assert "const isLocalStreaming=Boolean(" in SESSIONS_JS
+    assert "(isActive&&S.busy)" in SESSIONS_JS
+    assert "INFLIGHT[s.session_id]" in SESSIONS_JS
+    assert "const isStreaming=Boolean(s.is_streaming||isLocalStreaming);" in SESSIONS_JS
+    assert "if(typeof renderSessionListFromCache==='function') renderSessionListFromCache();" in messages_js
+
+
+def test_date_group_caret_expanded_down_collapsed_right():
+    assert "caret.textContent='\\u25BE';" in SESSIONS_JS
+    assert ".session-date-caret{" in STYLE_CSS
+    caret_block = STYLE_CSS[
+        STYLE_CSS.find(".session-date-caret{"):
+        STYLE_CSS.find(".session-date-caret.collapsed")
+    ]
+    assert "transform:rotate(0deg);" in caret_block
+    assert ".session-date-caret.collapsed{transform:rotate(-90deg);}" in STYLE_CSS
 
 
 def test_apperror_path_calls_render_session_list():

--- a/tests/test_session_index.py
+++ b/tests/test_session_index.py
@@ -65,6 +65,56 @@ def _read_index(index_file):
     return json.loads(index_file.read_text(encoding="utf-8"))
 
 
+def test_compact_exposes_last_message_at_from_message_timestamp():
+    s = Session(
+        session_id="sess_time",
+        title="Time",
+        updated_at=300.0,
+        messages=[
+            {"role": "user", "content": "old", "_ts": 100.0},
+            {"role": "tool", "content": "ignore", "timestamp": 400.0},
+            {"role": "assistant", "content": "latest", "timestamp": 200.0},
+        ],
+    )
+
+    compact = s.compact()
+
+    assert compact["updated_at"] == 300.0
+    assert compact["last_message_at"] == 200.0
+
+
+def test_all_sessions_backfills_last_message_at_for_legacy_index_rows():
+    index_file = models.SESSION_INDEX_FILE
+    s = Session(
+        session_id="sess_legacy_index",
+        title="Legacy Index",
+        updated_at=300.0,
+        messages=[{"role": "assistant", "content": "reply", "_ts": 100.0}],
+    )
+    s.path.write_text(json.dumps(s.__dict__, ensure_ascii=False, indent=2), encoding="utf-8")
+    _write_index_file(
+        index_file,
+        [
+            {
+                "session_id": s.session_id,
+                "title": s.title,
+                "updated_at": s.updated_at,
+                "workspace": s.workspace,
+                "model": s.model,
+                "message_count": 1,
+                "created_at": s.created_at,
+                "pinned": False,
+                "archived": False,
+            }
+        ],
+    )
+
+    rows = models.all_sessions()
+
+    assert rows[0]["session_id"] == s.session_id
+    assert rows[0]["last_message_at"] == 100.0
+
+
 # ── 6. test_incremental_patch_correctness ─────────────────────────────────
 
 def test_incremental_patch_correctness():

--- a/tests/test_session_sidebar_relative_time.py
+++ b/tests/test_session_sidebar_relative_time.py
@@ -29,6 +29,7 @@ def _run_session_time_case(script_body: str) -> dict:
     functions = "\n\n".join(
         _extract_function(SESSIONS_JS, name)
         for name in (
+            "_sessionTimestampMs",
             "_localDayOrdinal",
             "_sessionCalendarBoundaries",
             "_formatSessionDate",
@@ -65,6 +66,7 @@ def _run_session_time_case(script_body: str) -> dict:
 
 
 def test_session_sidebar_js_has_dynamic_relative_time_helpers():
+    assert "function _sessionTimestampMs" in SESSIONS_JS
     assert "function _sessionCalendarBoundaries" in SESSIONS_JS
     assert "function _formatRelativeSessionTime" in SESSIONS_JS
     assert "function _sessionTimeBucketLabel" in SESSIONS_JS
@@ -84,6 +86,22 @@ def test_session_sidebar_renders_relative_time_and_meta_rows():
     assert ".session-item.active .session-title" in STYLE_CSS
     assert "|| _sessionTimeBucketLabel" not in SESSIONS_JS
     assert "const ONE_DAY=86400000;" not in SESSIONS_JS
+
+
+def test_session_timestamp_prefers_last_message_at_over_metadata_updated_at():
+    result = _run_session_time_case(
+        """
+        const session = {
+          created_at: 1776441348,
+          updated_at: 1777086443,
+          last_message_at: 1776441972,
+        };
+        process.stdout.write(JSON.stringify({
+          timestampMs: _sessionTimestampMs(session),
+        }));
+        """
+    )
+    assert result["timestampMs"] == 1776441972 * 1000
 
 
 def test_relative_time_uses_calendar_boundaries_and_year_for_old_sessions():


### PR DESCRIPTION
## Summary

This is a follow-up polish pass for the session attention work from #856 / #898.

It does four things:

- moves the running spinner and unread dot into the right-side actions/accessory slot instead of inserting them before the session title
- hides the timestamp while a session is running or unread, while keeping idle/read timestamps aligned to the far right
- fixes sidebar date group affordances so expanded groups point down and collapsed groups point right
- removes duplicate per-row pinned stars inside the Pinned group

It also fixes two related behavior issues found during manual testing:

- running indicators now appear immediately after sending a message by using local busy / in-flight state while `/api/sessions` catches up, instead of waiting for the next 5-second streaming poll
- sidebar sorting/grouping/timestamps now prefer `last_message_at`, derived from the latest real message timestamp, so metadata-only saves do not make older conversations appear under Today

Credit to @pavolbiely for the UX suggestion in https://github.com/nesquena/hermes-webui/pull/886#issuecomment-4304717404 about using the right-side action slot for the loading indicator to avoid title shifting.

## Screenshots

Screenshots are ready to attach before marking this ready for review:

- Light theme: running spinner in the right slot
<img width="365" height="332" alt="截屏2026-04-25 12 00 15" src="https://github.com/user-attachments/assets/1d602190-992b-4364-97a9-d023778689da" />

- Light theme: unread dot in the right slot
<img width="376" height="347" alt="截屏2026-04-25 12 00 41" src="https://github.com/user-attachments/assets/cea76fa3-67ec-41c8-b5fc-edb348c417aa" />


- Light theme: collapsed group caret / pinned group cleanup
<img width="376" height="432" alt="截屏2026-04-25 12 01 50" src="https://github.com/user-attachments/assets/31994a07-0b47-46db-9dff-96790164f41d" />
<img width="382" height="370" alt="截屏2026-04-25 12 01 58" src="https://github.com/user-attachments/assets/dff5ee68-7881-4115-bf12-a2200943f6cd" />


- Dark theme: spinner and unread dot contrast check
<img width="374" height="371" alt="截屏2026-04-25 12 08 04" src="https://github.com/user-attachments/assets/a5051bb7-6ed0-4601-b391-e7317886b175" />

## Verification

- `node --check static/sessions.js`
- `node --check static/messages.js`
- `pytest tests/test_issue856_pinned_indicator_layout.py tests/test_session_sidebar_relative_time.py tests/test_session_index.py -q`

Manual validation on local WebUI:

- running spinner appears immediately after send
- unread dot appears in the same right-side slot
- running/unread rows hide timestamps
- idle/read rows keep right-aligned timestamps
- Pinned group no longer repeats the pinned star on each row
- collapsed/expanded group carets point in the expected directions
- old sessions whose metadata `updated_at` was touched are grouped by last real message time instead
