### PR TITLE
Hide empty agent sessions from sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
+- **Show agent sessions now hides empty/unimportable agent rows** — `state.db` can contain cron/gateway/agent session rows before any messages are written. The sidebar previously showed those rows when "Show agent sessions" was enabled, but clicking them failed because there were no messages to import. The regular session list and gateway SSE watcher now share the same importable-agent-session filter. (`api/agent_sessions.py`, `api/models.py`, `api/gateway_watcher.py`, `tests/test_gateway_sync.py`)
 - **Reasoning chip now appears after the model chip** in the composer toolbar — model is a more fundamental choice and should be stable in position regardless of whether reasoning is active. Order: Profile → Workspace → Model → Reasoning. (`static/index.html`)
 
 ## v0.50.206 — 2026-04-25

--- a/api/agent_sessions.py
+++ b/api/agent_sessions.py
@@ -1,0 +1,55 @@
+"""Shared helpers for reading Hermes Agent sessions from state.db."""
+import logging
+import sqlite3
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def read_importable_agent_session_rows(db_path: Path, limit: int = 200, log=None) -> list[dict]:
+    """Return non-WebUI agent sessions that have readable message rows.
+
+    Hermes Agent can create rows in ``state.db.sessions`` before a session has
+    any messages. WebUI cannot import those rows, so both the regular
+    ``/api/sessions`` path and the gateway SSE watcher must filter them the
+    same way.
+    """
+    db_path = Path(db_path)
+    if not db_path.exists():
+        return []
+
+    log = log or logger
+    with sqlite3.connect(str(db_path)) as conn:
+        conn.row_factory = sqlite3.Row
+        cur = conn.cursor()
+
+        # Older Hermes Agent versions may not have source tracking. Without a
+        # source column we cannot safely distinguish WebUI rows from agent rows.
+        cur.execute("PRAGMA table_info(sessions)")
+        session_cols = {row[1] for row in cur.fetchall()}
+        if 'source' not in session_cols:
+            log.warning(
+                "agent session listing skipped: state.db at %s has no 'source' column "
+                "(older hermes-agent?). Agent sessions unavailable. "
+                "Upgrade hermes-agent to fix this.",
+                db_path,
+            )
+            return []
+
+        cur.execute(
+            """
+            SELECT s.id, s.title, s.model, s.message_count,
+                   s.started_at, s.source,
+                   COUNT(m.id) AS actual_message_count,
+                   MAX(m.timestamp) AS last_activity
+            FROM sessions s
+            LEFT JOIN messages m ON m.session_id = s.id
+            WHERE s.source IS NOT NULL AND s.source != 'webui'
+            GROUP BY s.id
+            HAVING COUNT(m.id) > 0
+            ORDER BY COALESCE(MAX(m.timestamp), s.started_at) DESC
+            LIMIT ?
+            """,
+            (int(limit),),
+        )
+        return [dict(row) for row in cur.fetchall()]

--- a/api/gateway_watcher.py
+++ b/api/gateway_watcher.py
@@ -13,12 +13,12 @@ import json
 import logging
 import os
 import queue
-import sqlite3
 import threading
 import time
 from pathlib import Path
 
 from api.config import HOME
+from api.agent_sessions import read_importable_agent_session_rows
 
 logger = logging.getLogger(__name__)
 
@@ -55,33 +55,18 @@ def _get_agent_sessions_from_db() -> list:
         return []
 
     try:
-        with sqlite3.connect(str(db_path)) as conn:
-            conn.row_factory = sqlite3.Row
-            cur = conn.cursor()
-            cur.execute("""
-                SELECT s.id, s.title, s.model, s.message_count,
-                       s.started_at, s.source,
-                       MAX(m.timestamp) AS last_activity
-                FROM sessions s
-                LEFT JOIN messages m ON m.session_id = s.id
-                WHERE s.source IS NOT NULL AND s.source != 'webui'
-                GROUP BY s.id
-                HAVING COUNT(m.id) > 0
-                ORDER BY COALESCE(MAX(m.timestamp), s.started_at) DESC
-                LIMIT 200
-            """)
-            sessions = []
-            for row in cur.fetchall():
-                sessions.append({
-                    'session_id': row['id'],
-                    'title': row['title'] or 'Agent Session',
-                    'model': row['model'] or None,
-                    'message_count': row['message_count'] or 0,
-                    'created_at': row['started_at'],
-                    'updated_at': row['last_activity'] or row['started_at'],
-                    'source': row['source'] or 'cli',
-                })
-            return sessions
+        sessions = []
+        for row in read_importable_agent_session_rows(db_path, limit=200, log=logger):
+            sessions.append({
+                'session_id': row['id'],
+                'title': row['title'] or 'Agent Session',
+                'model': row['model'] or None,
+                'message_count': row['message_count'] or row['actual_message_count'] or 0,
+                'created_at': row['started_at'],
+                'updated_at': row['last_activity'] or row['started_at'],
+                'source': row['source'] or 'cli',
+            })
+        return sessions
     except Exception:
         return []
 

--- a/api/models.py
+++ b/api/models.py
@@ -15,6 +15,7 @@ from api.config import (
     get_effective_default_model,
 )
 from api.workspace import get_last_workspace
+from api.agent_sessions import read_importable_agent_session_rows
 
 logger = logging.getLogger(__name__)
 
@@ -528,16 +529,11 @@ def get_cli_sessions() -> list:
     """Read CLI sessions from the agent's SQLite store and return them as
     dicts in a format the WebUI sidebar can render alongside local sessions.
 
-    Returns empty list if the SQLite DB is missing, the sqlite3 module is
-    unavailable, or any error occurs -- the bridge is purely additive and never
-    crashes the WebUI.
+    Returns empty list if the SQLite DB is missing or any error occurs -- the
+    bridge is purely additive and never crashes the WebUI.
     """
     import os
     cli_sessions = []
-    try:
-        import sqlite3
-    except ImportError:
-        return cli_sessions
 
     # Use the active WebUI profile's HERMES_HOME to find state.db.
     # The active profile is determined by what the user has selected in the UI
@@ -566,59 +562,30 @@ def get_cli_sessions() -> list:
         _cli_profile = None  # older agent -- fall back to no profile
 
     try:
-        with sqlite3.connect(str(db_path)) as conn:
-            conn.row_factory = sqlite3.Row
-            cur = conn.cursor()
-            # Introspect schema to handle older hermes-agent versions that
-            # may not have a 'source' column. Without this check the query raises
-            # OperationalError which is silently swallowed, causing the empty-list bug.
-            cur.execute("PRAGMA table_info(sessions)")
-            _session_cols = {row[1] for row in cur.fetchall()}
-            if 'source' not in _session_cols:
-                import logging as _logging
-                _logging.getLogger(__name__).warning(
-                    "get_cli_sessions(): state.db at %s has no 'source' column "
-                    "(older hermes-agent?). CLI sessions unavailable. "
-                    "Upgrade hermes-agent to fix this.",
-                    db_path,
-                )
-                return cli_sessions
+        for row in read_importable_agent_session_rows(db_path, limit=200, log=logger):
+            sid = row['id']
+            raw_ts = row['last_activity'] or row['started_at']
+            # Prefer the CLI session's own profile from the DB; fall back to
+            # the active CLI profile so sidebar filtering works either way.
+            profile = _cli_profile  # CLI DB has no profile column; use active profile
 
-            cur.execute("""
-                SELECT s.id, s.title, s.model, s.message_count,
-                       s.started_at, s.source,
-                       MAX(m.timestamp) AS last_activity
-                FROM sessions s
-                LEFT JOIN messages m ON m.session_id = s.id
-                WHERE s.source IS NOT NULL AND s.source != 'webui'
-                GROUP BY s.id
-                ORDER BY COALESCE(MAX(m.timestamp), s.started_at) DESC
-                LIMIT 200
-            """)
-            for row in cur.fetchall():
-                sid = row['id']
-                raw_ts = row['last_activity'] or row['started_at']
-                # Prefer the CLI session's own profile from the DB; fall back to
-                # the active CLI profile so sidebar filtering works either way.
-                profile = _cli_profile  # CLI DB has no profile column; use active profile
-
-                _source = row['source'] or 'cli'
-                _display_title = row['title'] or f'{_source.title()} Session'
-                cli_sessions.append({
-                    'session_id': sid,
-                    'title': _display_title,
-                    'workspace': str(get_last_workspace()),
-                    'model': row['model'] or None,
-                    'message_count': row['message_count'] or 0,
-                    'created_at': row['started_at'],
-                    'updated_at': raw_ts,
-                    'pinned': False,
-                    'archived': False,
-                    'project_id': None,
-                    'profile': profile,
-                    'source_tag': _source,
-                    'is_cli_session': True,
-                })
+            _source = row['source'] or 'cli'
+            _display_title = row['title'] or f'{_source.title()} Session'
+            cli_sessions.append({
+                'session_id': sid,
+                'title': _display_title,
+                'workspace': str(get_last_workspace()),
+                'model': row['model'] or None,
+                'message_count': row['message_count'] or row['actual_message_count'] or 0,
+                'created_at': row['started_at'],
+                'updated_at': raw_ts,
+                'pinned': False,
+                'archived': False,
+                'project_id': None,
+                'profile': profile,
+                'source_tag': _source,
+                'is_cli_session': True,
+            })
     except Exception as _cli_err:
         # DB schema changed, locked, or corrupted -- log warning so admins can diagnose.
         # Still degrade gracefully (don't crash the WebUI).

--- a/tests/test_gateway_sync.py
+++ b/tests/test_gateway_sync.py
@@ -156,6 +156,79 @@ def test_gateway_sessions_appear_when_enabled():
         post('/api/settings', {'show_cli_sessions': False})
 
 
+def test_gateway_sessions_without_messages_are_hidden_from_sidebar():
+    """Regression: empty agent session rows must not appear as broken sidebar entries."""
+    conn = _ensure_state_db()
+    empty_sid = 'gw_empty_no_messages_001'
+    try:
+        conn.execute(
+            "INSERT OR REPLACE INTO sessions (id, source, title, model, started_at, message_count) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (empty_sid, 'cron', 'Cron Session', 'openai/gpt-5', time.time(), 0),
+        )
+        conn.execute("DELETE FROM messages WHERE session_id = ?", (empty_sid,))
+        conn.commit()
+
+        post('/api/settings', {'show_cli_sessions': True})
+
+        data, status = get('/api/sessions')
+        assert status == 200
+        sessions = data.get('sessions', [])
+        assert empty_sid not in {s.get('session_id') for s in sessions}, (
+            "Agent sessions with no readable message rows should be filtered before "
+            "they reach the sidebar; otherwise clicking them fails during import."
+        )
+    finally:
+        try:
+            _remove_test_sessions(conn, empty_sid)
+            conn.close()
+        except Exception:
+            pass
+        post('/api/settings', {'show_cli_sessions': False})
+
+
+def test_gateway_watcher_hides_sessions_without_messages(monkeypatch):
+    """Regression: SSE watcher must use the same importable-agent filter."""
+    conn = _ensure_state_db()
+    empty_sid = 'gw_empty_watcher_001'
+    live_sid = 'gw_live_watcher_001'
+    try:
+        conn.execute(
+            "INSERT OR REPLACE INTO sessions (id, source, title, model, started_at, message_count) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (empty_sid, 'cron', 'Empty Cron Session', 'openai/gpt-5', time.time(), 0),
+        )
+        conn.execute("DELETE FROM messages WHERE session_id = ?", (empty_sid,))
+        _insert_gateway_session(
+            conn,
+            session_id=live_sid,
+            source='cron',
+            title='Live Cron Session',
+            message_count=0,
+        )
+
+        import api.gateway_watcher as gateway_watcher
+
+        monkeypatch.setattr(gateway_watcher, '_get_state_db_path', _get_state_db_path)
+
+        sessions = gateway_watcher._get_agent_sessions_from_db()
+        ids = {s.get('session_id') for s in sessions}
+        live = next((s for s in sessions if s.get('session_id') == live_sid), None)
+
+        assert empty_sid not in ids
+        assert live is not None
+        assert live.get('message_count') == 2, (
+            "Watcher should fall back to actual message rows when stored "
+            "message_count is zero, matching the sidebar route."
+        )
+    finally:
+        try:
+            _remove_test_sessions(conn, empty_sid, live_sid)
+            conn.close()
+        except Exception:
+            pass
+
+
 def test_gateway_sessions_excluded_when_disabled():
     """Gateway sessions are NOT returned when show_cli_sessions is off."""
     conn = _ensure_state_db()

--- a/tests/test_issue634.py
+++ b/tests/test_issue634.py
@@ -14,7 +14,10 @@ import pathlib
 import re
 
 MODELS_PY = pathlib.Path(__file__).parent.parent / 'api' / 'models.py'
+AGENT_SESSIONS_PY = pathlib.Path(__file__).parent.parent / 'api' / 'agent_sessions.py'
 src = MODELS_PY.read_text(encoding='utf-8')
+agent_src = AGENT_SESSIONS_PY.read_text(encoding='utf-8')
+combined_src = src + "\n" + agent_src
 
 
 class TestCliSessionsErrorSurface:
@@ -22,16 +25,16 @@ class TestCliSessionsErrorSurface:
 
     def test_schema_introspection_present(self):
         """The function must check for the 'source' column before querying."""
-        assert "PRAGMA table_info(sessions)" in src
+        assert "PRAGMA table_info(sessions)" in combined_src
 
     def test_missing_source_column_logs_warning(self):
         """If 'source' column is absent, a warning is logged."""
         # The warning message must mention the missing column and how to fix it
-        assert "no 'source' column" in src or "has no 'source' column" in src
+        assert "no 'source' column" in combined_src or "has no 'source' column" in combined_src
 
     def test_missing_source_column_suggests_upgrade(self):
         """Warning message must suggest upgrading hermes-agent."""
-        assert "Upgrade hermes-agent" in src or "upgrade hermes-agent" in src.lower()
+        assert "Upgrade hermes-agent" in combined_src or "upgrade hermes-agent" in combined_src.lower()
 
     def test_exception_path_logs_warning(self):
         """The except clause must call logger.warning, not silently pass."""
@@ -67,8 +70,8 @@ class TestCliSessionsErrorSurface:
 
     def test_source_column_check_before_sql_query(self):
         """Schema check must happen before the main SQL SELECT."""
-        pragma_pos = src.find("PRAGMA table_info(sessions)")
-        select_pos = src.find("SELECT s.id, s.title, s.model")
+        pragma_pos = agent_src.find("PRAGMA table_info(sessions)")
+        select_pos = agent_src.find("SELECT s.id, s.title, s.model")
         assert pragma_pos != -1, "PRAGMA check not found"
         assert select_pos != -1, "SELECT query not found"
         assert pragma_pos < select_pos, \


### PR DESCRIPTION
## Summary

This is PR 1 for #1004.

It fixes the concrete empty-row failure mode in `Show agent sessions`: Hermes `state.db` can contain non-WebUI session rows before any messages are written. WebUI previously listed those rows, but clicking/importing them failed because there were no readable messages.

Changes:

- add a shared `read_importable_agent_session_rows()` helper for non-WebUI agent session rows
- filter out agent sessions with zero readable message rows
- use the same filter from both `/api/sessions` and the gateway SSE watcher
- fall back to the actual message row count when stored `message_count` is zero
- preserve the old missing-`source` diagnostic path for older Hermes Agent state DBs

## Scope

This intentionally does not collapse compression continuation chains yet. Real agent sessions with messages may still appear as separate rows, including repeated-looking titles such as `Magazine Style PPT Skill #...`.

That remaining behavior belongs to the follow-up PR for compression-chain projection described in #1004.

## Verification

```bash
python3 -m py_compile api/agent_sessions.py api/models.py api/gateway_watcher.py
git diff --check
.venv_test/bin/pytest tests/test_gateway_sync.py tests/test_issue634.py tests/test_sprint40_ui_polish.py tests/test_sprint43.py -q
```

Result:

```text
59 passed, 8 subtests passed
```

Also smoke-tested the real `state.db` reader against the current local Hermes state and confirmed `empty_visible=0`.

Refs #1004.
