### PR TITLE
Collapse agent session compression chains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- **Show agent sessions now collapses compression continuation chains** — long Hermes Agent conversations can rotate through many `parent_session_id` segments during context compression, which made one Weixin/Cron/CLI conversation appear as many sidebar rows. Agent-session listing now projects compression chains to a single logical sidebar entry, preserves the chain head as the visible representative, points import/current state at the latest importable segment, keeps non-compression parent/child relationships unchanged, filters empty chains, and applies the sidebar limit after projection. (`api/agent_sessions.py`, `tests/test_gateway_sync.py`)
+
 ## v0.50.215 — 2026-04-26
 
 ### Added
@@ -54,51 +57,6 @@
 
 ### Fixed
 - **Settings picker active state** — theme, skin, and font-size picker cards in Settings → Appearance now correctly highlight the selected option. Root cause: the base CSS rule used `!important` on `border-color`, overriding the inline style set by `_syncThemePicker()` and siblings. Fix moves to an `.active` class with its own `!important` rule. (`static/style.css`, `static/boot.js`) [#1059]
-
-## v0.50.210 — 2026-04-25
-
-### Added
-- **gpt-5.5 and gpt-5.5-mini in model picker** — available for openai, openai-codex, and copilot providers. (`api/config.py`) [#1052 @aliceisjustplaying]
-- **Login redirects back to original URL after re-login** — the iOS PWA auth redirect now passes `?next=` with the current path; `login.js` honors it via a `_safeNextPath()` helper that guards against open-redirect (rejects `//`, backslash, and non-path-absolute inputs). (`static/login.js`, `static/ui.js`, `static/workspace.js`) [#1053]
-
-### Fixed
-- **Non-standard provider first-run experience** — agent dir discovery now searches XDG_DATA_HOME, `/opt`, `/usr/local` paths; onboarding wizard auto-completes for non-wizard providers (ollama-cloud, deepseek, xai, kimi-k2.6) with `provider_configured=True`; wizard model field no longer hardcodes `gpt-5.4-mini` literal; session model resolver correctly handles unlisted active providers. (`api/config.py`, `api/onboarding.py`, `api/routes.py`) Closes #1019–#1023 [#1049]
-- **Cron session titles in sidebar** — cron-launched sessions now display the human-friendly job name (from `~/.hermes/cron/jobs.json`) instead of a generic "Cron Session" label. (`api/models.py`, `api/routes.py`) [#1050 @waldmanz]
-- **AIAgent reused per session — fixes Honcho first-turn injection** — `AIAgent` is now cached per `session_id` so the agent's turn counter increments correctly across messages. Cache is evicted on session delete/clear. (`api/config.py`, `api/routes.py`, `api/streaming.py`) Closes #1039 [#1051 @qxxaa]
-- **Mermaid Google Fonts CSP violation suppressed** — `fontFamily:'inherit'` in Mermaid themeVariables prevents `@import url('fonts.googleapis.com')` from being injected into diagram SVGs. (`static/ui.js`) Closes #1044 [#1054]
-- **bfcache layout and dropdown restore** — `pageshow+event.persisted` handler re-syncs topbar, workspace panel, session list, and gateway SSE; also closes open composer dropdowns frozen by bfcache. `_initResizePanels()` removed from pageshow (bfcache preserves listeners). (`static/boot.js`) Closes #1045 [#1055]
-
-## v0.50.209 — 2026-04-25
-
-### Added
-- **Codex-style message queue flyout** — messages typed while a stream is running now appear as a flyout card above the composer (same pattern as approval/clarify cards). Supports drag-to-reorder, inline edit, per-item model badge, Combine/Clear actions, and a collapsed pill outside the composer. Per-session DOM isolation via `_queueRenderKeys[sid]`/`_queueCollapsed[sid]` prevents cross-session bleed. Titlebar `#appTitlebarSub` chip shows live queue count. (`static/ui.js`, `static/messages.js`, `static/style.css`, `static/i18n.js`, `static/index.html`) Closes #965 [#1040 @24601]
-- **Inline HTML preview in workspace panel** — `.html` and `.htm` files now render as live sandboxed iframes (`sandbox="allow-scripts"`, no `allow-same-origin`) in the workspace file browser. A `?inline=1` parameter on `/api/file/raw` bypasses the usual attachment disposition; the server adds `Content-Security-Policy: sandbox allow-scripts` on inline HTML responses to prevent XSS when the URL is opened directly in a browser tab. (`static/workspace.js`, `api/routes.py`, `static/index.html`) Closes #779 [#1035 @bergeouss]
-- **Provider categories in setup wizard** — the onboarding provider dropdown groups 10 providers into Easy Start / Open & Self-hosted / Specialized with `<optgroup>` sections. Includes Google Gemini, DeepSeek, Mistral, and xAI/Grok with correct current model defaults. (`api/onboarding.py`, `static/onboarding.js`) Closes #603 [#1036 @bergeouss]
-
-### Fixed
-- **Manual "Check for Updates" button in System settings** — users can now trigger an update check immediately instead of waiting for the periodic background fetch. Error messages are sanitized before display. (`static/panels.js`, `static/index.html`, `static/style.css`) Closes #785 [#1033 @bergeouss]
-- **"Keep workspace panel open" toggle in Appearance settings** — adds a persistent preference so the workspace panel opens automatically on each session if preferred. The toolbar X no longer clears the preference. (`static/panels.js`, `static/boot.js`) Closes #999 [#1034 @bergeouss]
-
-### Changed
-- **CSP allowlist for Cloudflare Access deployments** — `default-src` and `manifest-src` now include `https://*.cloudflareaccess.com`, and `script-src` now includes `https://static.cloudflareinsights.com`. This unblocks Agent37-style deployments running behind Cloudflare Access without affecting vanilla self-hosters (the new origins are unreachable in non-Cloudflare environments). (`api/helpers.py`) [#1040 follow-up]
-
-## v0.50.207 — 2026-04-25
-
-### Added
-- **Live TPS stat in header** — a monospace chip in the titlebar shows tokens per second during streaming, with HIGH watermark from the past hour. Emitted via SSE at 1 Hz during active streams; hidden when idle. (`api/metering.py`, `api/streaming.py`, `static/messages.js`, `static/style.css`) [#1005 @JKJameson]
-
-### Fixed
-- **Stale SSE events no longer pollute the new session's DOM on session switch** — `appendThinking()` and `appendLiveToolCard()` now guard against events from a prior session's stream arriving after the user has switched sessions. Thinking card also auto-scrolls to top on completion so the response is immediately visible. (`static/ui.js`) [#1006 @JKJameson]
-- **Show agent sessions no longer shows empty/unimportable rows** — `state.db` can contain agent session rows before any messages are written. The sidebar now filters those out consistently across both the regular `/api/sessions` path and the gateway SSE watcher. (`api/agent_sessions.py`, `api/gateway_watcher.py`, `api/models.py`) [#1009 @franksong2702]
-- **Three orphaned i18n keys removed from language dropdown** — `cmd_status`, `memory_saved`, and `profile_delete_title` were placed outside any locale block in `static/i18n.js`, causing them to appear as invalid language options. (`static/i18n.js`) [#1010 @bergeouss]
-- **Cron panel UX polish** — Resume button SVG now uses a ▶| icon to distinguish it from Run; toast overlap fixed with `z-index` on the header; running-state badge with spinner shows during active jobs; `_cronRunningPoll` clears correctly on panel close. (`static/panels.js`, `static/index.html`, `static/style.css`, `static/i18n.js`) [#1011 @bergeouss]
-- **Create Folder and Add as Space from the browser** — users can now create directories and immediately register them as workspace spaces without SSH access; server validates paths against blocked roots before `mkdir`. (`api/routes.py`, `static/ui.js`, `static/panels.js`, `static/i18n.js`) [#1018 @bergeouss]
-- **Model-not-found errors now show a helpful message** — when a provider returns a 404 (e.g. Qwen model not available), the error is classified and a user-friendly hint appears instead of a raw HTML page. All 6 locales covered. (`api/streaming.py`, `static/messages.js`, `static/i18n.js`) [#1022 @bergeouss]
-- **Session attention indicators moved to right-side actions slot** — streaming spinners and unread dots no longer sit before the session title, avoiding title shifts. Running/unread rows hide the timestamp; idle/read rows keep right-aligned timestamps. Date group carets now point down/right correctly. Pinned group no longer repeats the star icon per row. (`static/sessions.js`, `static/style.css`) [#1024 @franksong2702]
-- **Session sidebar dates now use the last real message time** — sorting, grouping, and relative timestamps prefer `last_message_at` derived from the last non-tool message instead of metadata-only `updated_at`, so changing session settings doesn't move old conversations to Today. (`api/models.py`, `api/routes.py`) [#1024 @franksong2702]
-- **Running indicators appear immediately after send** — the sidebar now treats the active local busy session and local in-flight sessions as streaming while `/api/sessions` catches up. (`static/messages.js`, `static/sessions.js`) [#1024 @franksong2702]
-- **Large session switching and reload no longer block on cold model-catalog resolution** — `GET /api/session?messages=0` now parses only the JSON metadata prefix; metadata-only loads skip the full-session LRU cache; the frontend lazy fetch passes `resolve_model=0`; hard reload no longer waits for `populateModelDropdown()`. (`api/models.py`, `api/routes.py`, `static/boot.js`, `static/sessions.js`, `static/ui.js`) [#1025 @franksong2702]
-- **Auto title generation hardened for reasoning models** — title generation now uses a 512-token reasoning-safe budget, retries once with 1024 tokens on empty content or `finish_reason: length`, and preserves the underlying failure reason in `title_status` when falling back to a local summary. (`api/streaming.py`) [#1026 @franksong2702]
 
 ## v0.50.206 — 2026-04-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,51 @@
 ### Fixed
 - **Settings picker active state** — theme, skin, and font-size picker cards in Settings → Appearance now correctly highlight the selected option. Root cause: the base CSS rule used `!important` on `border-color`, overriding the inline style set by `_syncThemePicker()` and siblings. Fix moves to an `.active` class with its own `!important` rule. (`static/style.css`, `static/boot.js`) [#1059]
 
+## v0.50.210 — 2026-04-25
+
+### Added
+- **gpt-5.5 and gpt-5.5-mini in model picker** — available for openai, openai-codex, and copilot providers. (`api/config.py`) [#1052 @aliceisjustplaying]
+- **Login redirects back to original URL after re-login** — the iOS PWA auth redirect now passes `?next=` with the current path; `login.js` honors it via a `_safeNextPath()` helper that guards against open-redirect (rejects `//`, backslash, and non-path-absolute inputs). (`static/login.js`, `static/ui.js`, `static/workspace.js`) [#1053]
+
+### Fixed
+- **Non-standard provider first-run experience** — agent dir discovery now searches XDG_DATA_HOME, `/opt`, `/usr/local` paths; onboarding wizard auto-completes for non-wizard providers (ollama-cloud, deepseek, xai, kimi-k2.6) with `provider_configured=True`; wizard model field no longer hardcodes `gpt-5.4-mini` literal; session model resolver correctly handles unlisted active providers. (`api/config.py`, `api/onboarding.py`, `api/routes.py`) Closes #1019–#1023 [#1049]
+- **Cron session titles in sidebar** — cron-launched sessions now display the human-friendly job name (from `~/.hermes/cron/jobs.json`) instead of a generic "Cron Session" label. (`api/models.py`, `api/routes.py`) [#1050 @waldmanz]
+- **AIAgent reused per session — fixes Honcho first-turn injection** — `AIAgent` is now cached per `session_id` so the agent's turn counter increments correctly across messages. Cache is evicted on session delete/clear. (`api/config.py`, `api/routes.py`, `api/streaming.py`) Closes #1039 [#1051 @qxxaa]
+- **Mermaid Google Fonts CSP violation suppressed** — `fontFamily:'inherit'` in Mermaid themeVariables prevents `@import url('fonts.googleapis.com')` from being injected into diagram SVGs. (`static/ui.js`) Closes #1044 [#1054]
+- **bfcache layout and dropdown restore** — `pageshow+event.persisted` handler re-syncs topbar, workspace panel, session list, and gateway SSE; also closes open composer dropdowns frozen by bfcache. `_initResizePanels()` removed from pageshow (bfcache preserves listeners). (`static/boot.js`) Closes #1045 [#1055]
+
+## v0.50.209 — 2026-04-25
+
+### Added
+- **Codex-style message queue flyout** — messages typed while a stream is running now appear as a flyout card above the composer (same pattern as approval/clarify cards). Supports drag-to-reorder, inline edit, per-item model badge, Combine/Clear actions, and a collapsed pill outside the composer. Per-session DOM isolation via `_queueRenderKeys[sid]`/`_queueCollapsed[sid]` prevents cross-session bleed. Titlebar `#appTitlebarSub` chip shows live queue count. (`static/ui.js`, `static/messages.js`, `static/style.css`, `static/i18n.js`, `static/index.html`) Closes #965 [#1040 @24601]
+- **Inline HTML preview in workspace panel** — `.html` and `.htm` files now render as live sandboxed iframes (`sandbox="allow-scripts"`, no `allow-same-origin`) in the workspace file browser. A `?inline=1` parameter on `/api/file/raw` bypasses the usual attachment disposition; the server adds `Content-Security-Policy: sandbox allow-scripts` on inline HTML responses to prevent XSS when the URL is opened directly in a browser tab. (`static/workspace.js`, `api/routes.py`, `static/index.html`) Closes #779 [#1035 @bergeouss]
+- **Provider categories in setup wizard** — the onboarding provider dropdown groups 10 providers into Easy Start / Open & Self-hosted / Specialized with `<optgroup>` sections. Includes Google Gemini, DeepSeek, Mistral, and xAI/Grok with correct current model defaults. (`api/onboarding.py`, `static/onboarding.js`) Closes #603 [#1036 @bergeouss]
+
+### Fixed
+- **Manual "Check for Updates" button in System settings** — users can now trigger an update check immediately instead of waiting for the periodic background fetch. Error messages are sanitized before display. (`static/panels.js`, `static/index.html`, `static/style.css`) Closes #785 [#1033 @bergeouss]
+- **"Keep workspace panel open" toggle in Appearance settings** — adds a persistent preference so the workspace panel opens automatically on each session if preferred. The toolbar X no longer clears the preference. (`static/panels.js`, `static/boot.js`) Closes #999 [#1034 @bergeouss]
+
+### Changed
+- **CSP allowlist for Cloudflare Access deployments** — `default-src` and `manifest-src` now include `https://*.cloudflareaccess.com`, and `script-src` now includes `https://static.cloudflareinsights.com`. This unblocks Agent37-style deployments running behind Cloudflare Access without affecting vanilla self-hosters (the new origins are unreachable in non-Cloudflare environments). (`api/helpers.py`) [#1040 follow-up]
+
+## v0.50.207 — 2026-04-25
+
+### Added
+- **Live TPS stat in header** — a monospace chip in the titlebar shows tokens per second during streaming, with HIGH watermark from the past hour. Emitted via SSE at 1 Hz during active streams; hidden when idle. (`api/metering.py`, `api/streaming.py`, `static/messages.js`, `static/style.css`) [#1005 @JKJameson]
+
+### Fixed
+- **Stale SSE events no longer pollute the new session's DOM on session switch** — `appendThinking()` and `appendLiveToolCard()` now guard against events from a prior session's stream arriving after the user has switched sessions. Thinking card also auto-scrolls to top on completion so the response is immediately visible. (`static/ui.js`) [#1006 @JKJameson]
+- **Show agent sessions no longer shows empty/unimportable rows** — `state.db` can contain agent session rows before any messages are written. The sidebar now filters those out consistently across both the regular `/api/sessions` path and the gateway SSE watcher. (`api/agent_sessions.py`, `api/gateway_watcher.py`, `api/models.py`) [#1009 @franksong2702]
+- **Three orphaned i18n keys removed from language dropdown** — `cmd_status`, `memory_saved`, and `profile_delete_title` were placed outside any locale block in `static/i18n.js`, causing them to appear as invalid language options. (`static/i18n.js`) [#1010 @bergeouss]
+- **Cron panel UX polish** — Resume button SVG now uses a ▶| icon to distinguish it from Run; toast overlap fixed with `z-index` on the header; running-state badge with spinner shows during active jobs; `_cronRunningPoll` clears correctly on panel close. (`static/panels.js`, `static/index.html`, `static/style.css`, `static/i18n.js`) [#1011 @bergeouss]
+- **Create Folder and Add as Space from the browser** — users can now create directories and immediately register them as workspace spaces without SSH access; server validates paths against blocked roots before `mkdir`. (`api/routes.py`, `static/ui.js`, `static/panels.js`, `static/i18n.js`) [#1018 @bergeouss]
+- **Model-not-found errors now show a helpful message** — when a provider returns a 404 (e.g. Qwen model not available), the error is classified and a user-friendly hint appears instead of a raw HTML page. All 6 locales covered. (`api/streaming.py`, `static/messages.js`, `static/i18n.js`) [#1022 @bergeouss]
+- **Session attention indicators moved to right-side actions slot** — streaming spinners and unread dots no longer sit before the session title, avoiding title shifts. Running/unread rows hide the timestamp; idle/read rows keep right-aligned timestamps. Date group carets now point down/right correctly. Pinned group no longer repeats the star icon per row. (`static/sessions.js`, `static/style.css`) [#1024 @franksong2702]
+- **Session sidebar dates now use the last real message time** — sorting, grouping, and relative timestamps prefer `last_message_at` derived from the last non-tool message instead of metadata-only `updated_at`, so changing session settings doesn't move old conversations to Today. (`api/models.py`, `api/routes.py`) [#1024 @franksong2702]
+- **Running indicators appear immediately after send** — the sidebar now treats the active local busy session and local in-flight sessions as streaming while `/api/sessions` catches up. (`static/messages.js`, `static/sessions.js`) [#1024 @franksong2702]
+- **Large session switching and reload no longer block on cold model-catalog resolution** — `GET /api/session?messages=0` now parses only the JSON metadata prefix; metadata-only loads skip the full-session LRU cache; the frontend lazy fetch passes `resolve_model=0`; hard reload no longer waits for `populateModelDropdown()`. (`api/models.py`, `api/routes.py`, `static/boot.js`, `static/sessions.js`, `static/ui.js`) [#1025 @franksong2702]
+- **Auto title generation hardened for reasoning models** — title generation now uses a 512-token reasoning-safe budget, retries once with 1024 tokens on empty content or `finish_reason: length`, and preserves the underlying failure reason in `title_status` when falling back to a local summary. (`api/streaming.py`) [#1026 @franksong2702]
+
 ## v0.50.206 — 2026-04-25
 
 ### Fixed

--- a/api/agent_sessions.py
+++ b/api/agent_sessions.py
@@ -88,12 +88,17 @@ def _project_agent_session_rows(rows: list[dict]) -> list[dict]:
             continue
 
         merged = dict(row)
-        # Keep the chain head's visible metadata, but point the row at the
-        # latest importable segment. That avoids rewriting history in the
-        # sidebar while still continuing from the compressed current state.
+        # Keep the chain head's visible identity (title, started_at), but
+        # point the row at the latest importable segment for navigation AND
+        # surface the tip's recency so an actively-used chain bubbles to the
+        # top of the sidebar by its true last activity. Without overriding
+        # last_activity, a long-lived chain whose tip is being edited NOW
+        # would sort by the root's old timestamp and fall below recently
+        # touched standalone sessions — exactly the inverse of what a user
+        # expects from "Show agent sessions" sorted by activity.
         for key in (
             'id', 'model', 'message_count', 'actual_message_count',
-            'ended_at', 'end_reason',
+            'ended_at', 'end_reason', 'last_activity',
         ):
             if key in tip:
                 merged[key] = tip[key]

--- a/api/agent_sessions.py
+++ b/api/agent_sessions.py
@@ -6,13 +6,121 @@ from pathlib import Path
 logger = logging.getLogger(__name__)
 
 
+def _optional_col(name: str, columns: set[str], fallback: str = "NULL") -> str:
+    return f"s.{name}" if name in columns else f"{fallback} AS {name}"
+
+
+def _is_compression_continuation(parent: dict | None, child: dict) -> bool:
+    """Mirror Hermes Agent's compression-child guard.
+
+    A child is a continuation only when the parent ended because of compression
+    and the child started after that compression boundary. Plain parent/child
+    relationships are left alone for future subagent-tree work.
+    """
+    if not parent:
+        return False
+    if parent.get('end_reason') != 'compression':
+        return False
+    ended_at = parent.get('ended_at')
+    if ended_at is None:
+        return False
+    try:
+        return float(child.get('started_at') or 0) >= float(ended_at)
+    except (TypeError, ValueError):
+        return False
+
+
+def _project_agent_session_rows(rows: list[dict]) -> list[dict]:
+    """Collapse compression chains into one logical sidebar row.
+
+    The visible conversation should still look like the original chain head
+    (title and timestamps), while importing should use the latest importable
+    segment so the user continues from the current compressed state.
+    """
+    rows_by_id = {row['id']: row for row in rows}
+    children_by_parent: dict[str, list[dict]] = {}
+    continuation_child_ids = set()
+
+    for row in rows:
+        parent_id = row.get('parent_session_id')
+        if not parent_id:
+            continue
+        children_by_parent.setdefault(parent_id, []).append(row)
+        if _is_compression_continuation(rows_by_id.get(parent_id), row):
+            continuation_child_ids.add(row['id'])
+
+    for children in children_by_parent.values():
+        children.sort(key=lambda row: row.get('started_at') or 0, reverse=True)
+
+    def compression_tip(row: dict) -> tuple[dict | None, int]:
+        current = row
+        seen = {row['id']}
+        latest_importable = row if (row.get('actual_message_count') or 0) > 0 else None
+        segment_count = 1
+        for _ in range(len(rows_by_id) + 1):
+            candidates = [
+                child for child in children_by_parent.get(current['id'], [])
+                if child['id'] not in seen and _is_compression_continuation(current, child)
+            ]
+            if not candidates:
+                return latest_importable, segment_count
+            current = candidates[0]
+            seen.add(current['id'])
+            segment_count += 1
+            if (current.get('actual_message_count') or 0) > 0:
+                latest_importable = current
+        return latest_importable, segment_count
+
+    projected = []
+    for row in rows:
+        if row['id'] in continuation_child_ids:
+            continue
+
+        segment_count = 1
+        tip = row
+        if row.get('end_reason') == 'compression':
+            tip, segment_count = compression_tip(row)
+        if not tip or (tip.get('actual_message_count') or 0) <= 0:
+            continue
+
+        if tip is row:
+            projected.append(dict(row))
+            continue
+
+        merged = dict(row)
+        # Keep the chain head's visible metadata, but point the row at the
+        # latest importable segment. That avoids rewriting history in the
+        # sidebar while still continuing from the compressed current state.
+        for key in (
+            'id', 'model', 'message_count', 'actual_message_count',
+            'ended_at', 'end_reason',
+        ):
+            if key in tip:
+                merged[key] = tip[key]
+        if not merged.get('title'):
+            merged['title'] = tip.get('title')
+        if not merged.get('source'):
+            merged['source'] = tip.get('source')
+        merged['_lineage_root_id'] = row['id']
+        merged['_lineage_tip_id'] = tip['id']
+        merged['_compression_segment_count'] = segment_count
+        projected.append(merged)
+
+    projected.sort(
+        key=lambda row: row.get('last_activity') or row.get('started_at') or 0,
+        reverse=True,
+    )
+    return projected
+
+
 def read_importable_agent_session_rows(db_path: Path, limit: int = 200, log=None) -> list[dict]:
-    """Return non-WebUI agent sessions that have readable message rows.
+    """Return non-WebUI agent sessions projected as importable conversations.
 
     Hermes Agent can create rows in ``state.db.sessions`` before a session has
-    any messages. WebUI cannot import those rows, so both the regular
-    ``/api/sessions`` path and the gateway SSE watcher must filter them the
-    same way.
+    any messages, and long conversations can be split into compression-linked
+    rows. WebUI cannot import empty rows and should not show compression
+    segments as separate conversations, so both the regular ``/api/sessions``
+    path and the gateway SSE watcher use this shared projection.
     """
     db_path = Path(db_path)
     if not db_path.exists():
@@ -36,20 +144,27 @@ def read_importable_agent_session_rows(db_path: Path, limit: int = 200, log=None
             )
             return []
 
+        parent_expr = _optional_col('parent_session_id', session_cols)
+        ended_expr = _optional_col('ended_at', session_cols)
+        end_reason_expr = _optional_col('end_reason', session_cols)
+
         cur.execute(
-            """
+            f"""
             SELECT s.id, s.title, s.model, s.message_count,
                    s.started_at, s.source,
+                   {parent_expr},
+                   {ended_expr},
+                   {end_reason_expr},
                    COUNT(m.id) AS actual_message_count,
                    MAX(m.timestamp) AS last_activity
             FROM sessions s
             LEFT JOIN messages m ON m.session_id = s.id
             WHERE s.source IS NOT NULL AND s.source != 'webui'
             GROUP BY s.id
-            HAVING COUNT(m.id) > 0
             ORDER BY COALESCE(MAX(m.timestamp), s.started_at) DESC
-            LIMIT ?
             """,
-            (int(limit),),
         )
-        return [dict(row) for row in cur.fetchall()]
+        projected = _project_agent_session_rows([dict(row) for row in cur.fetchall()])
+        if limit is None:
+            return projected
+        return projected[:max(0, int(limit))]

--- a/tests/test_gateway_sync.py
+++ b/tests/test_gateway_sync.py
@@ -327,8 +327,12 @@ def test_compression_chain_collapses_to_latest_tip_in_sidebar():
         assert tip is not None
         assert tip.get('title') == 'Magazine Style PPT Skill'
         assert tip.get('message_count') == 2
+        # created_at = the chain head's started_at (preserves original conversation date)
         assert abs(tip.get('created_at') - t0) < 0.01
-        assert abs(tip.get('updated_at') - (t0 + 2)) < 0.01
+        # updated_at = the tip's last message timestamp so the sidebar entry
+        # bubbles to the top by true recency, not by the root's stale activity.
+        # tip messages are at t0+201 and t0+202, so last_activity = t0 + 202.
+        assert abs(tip.get('updated_at') - (t0 + 202)) < 0.01
 
         from api.agent_sessions import read_importable_agent_session_rows
 
@@ -511,6 +515,108 @@ def test_agent_session_limit_applies_after_compression_projection():
     finally:
         try:
             _remove_test_sessions(conn, *(chain_ids + [standalone_id]))
+            conn.close()
+        except Exception:
+            pass
+
+
+def test_compression_chain_bubbles_to_top_by_tip_activity():
+    """An actively-used compression chain must surface in the sidebar by its
+    TIP's last activity, not by the (stale) root's last activity.
+
+    Without overriding ``last_activity`` from the tip, a long-running chain
+    whose tip is being actively edited NOW would sort by the root's old
+    timestamp and fall below recently touched standalone sessions — the
+    inverse of what users expect from "Show agent sessions" sorted by
+    recency. This regression test pins the override.
+    """
+    conn = _ensure_state_db()
+    ids_to_remove = ('bubble_root_001', 'bubble_tip_001', 'bubble_standalone_001')
+    now = time.time()
+    # Root started long ago; tip is being edited "now" (very recent message)
+    root_started = now - 30 * 86400
+    root_ended = now - 28 * 86400
+    tip_started = root_ended + 1
+    tip_latest_msg = now - 5  # 5 seconds ago — most recent activity in the DB
+    # A standalone session active 2 days ago — older than tip, much newer
+    # than the root. Without the fix, the chain row sorts by ROOT's age and
+    # standalone wins; with the fix, the chain wins.
+    standalone_msg = now - 2 * 86400
+    try:
+        _insert_agent_session_row(
+            conn,
+            'bubble_root_001',
+            title='Bubble Root',
+            started_at=root_started,
+            ended_at=root_ended,
+            end_reason='compression',
+            messages=2,
+        )
+        # Override message timestamps so root's last_activity is genuinely old.
+        conn.execute("DELETE FROM messages WHERE session_id = 'bubble_root_001'")
+        conn.execute(
+            "INSERT INTO messages (session_id, role, content, timestamp) VALUES (?, ?, ?, ?)",
+            ('bubble_root_001', 'user', 'old root msg', root_started + 60),
+        )
+        _insert_agent_session_row(
+            conn,
+            'bubble_tip_001',
+            title='Bubble Tip',
+            started_at=tip_started,
+            parent_session_id='bubble_root_001',
+            messages=1,
+        )
+        conn.execute("DELETE FROM messages WHERE session_id = 'bubble_tip_001'")
+        conn.execute(
+            "INSERT INTO messages (session_id, role, content, timestamp) VALUES (?, ?, ?, ?)",
+            ('bubble_tip_001', 'user', 'fresh tip msg', tip_latest_msg),
+        )
+        _insert_agent_session_row(
+            conn,
+            'bubble_standalone_001',
+            title='Bubble Standalone',
+            started_at=now - 2 * 86400 - 60,
+            messages=1,
+        )
+        conn.execute("DELETE FROM messages WHERE session_id = 'bubble_standalone_001'")
+        conn.execute(
+            "INSERT INTO messages (session_id, role, content, timestamp) VALUES (?, ?, ?, ?)",
+            ('bubble_standalone_001', 'user', 'standalone msg', standalone_msg),
+        )
+        conn.commit()
+
+        from api.agent_sessions import read_importable_agent_session_rows
+
+        rows = read_importable_agent_session_rows(_get_state_db_path(), limit=200)
+        ids = [row.get('id') for row in rows]
+        # Filter out unrelated rows from the shared DB
+        ids = [i for i in ids if i in ('bubble_root_001', 'bubble_tip_001', 'bubble_standalone_001')]
+
+        assert 'bubble_tip_001' in ids, (
+            f"Compression tip must appear in projected output. ids={ids}"
+        )
+        assert 'bubble_root_001' not in ids, (
+            "Compression root row must be hidden once the tip is the active row."
+        )
+
+        tip_pos = ids.index('bubble_tip_001')
+        standalone_pos = ids.index('bubble_standalone_001') if 'bubble_standalone_001' in ids else -1
+        assert standalone_pos == -1 or tip_pos < standalone_pos, (
+            f"Active compression tip (last msg 5s ago) must sort BEFORE standalone "
+            f"session (last msg 2d ago). Got order: {ids}. "
+            f"This indicates merged.last_activity is the root's stale value, "
+            f"not the tip's recent value."
+        )
+
+        tip_row = next(r for r in rows if r['id'] == 'bubble_tip_001')
+        assert abs(tip_row['last_activity'] - tip_latest_msg) < 0.01, (
+            f"Projected tip's last_activity must equal the tip's most recent "
+            f"message timestamp ({tip_latest_msg}), not the root's "
+            f"({root_started + 60}). Got: {tip_row['last_activity']}"
+        )
+    finally:
+        try:
+            _remove_test_sessions(conn, *ids_to_remove)
             conn.close()
         except Exception:
             pass

--- a/tests/test_gateway_sync.py
+++ b/tests/test_gateway_sync.py
@@ -86,6 +86,14 @@ def _ensure_state_db():
             timestamp REAL NOT NULL
         );
     """)
+    for column, ddl in (
+        ('parent_session_id', 'ALTER TABLE sessions ADD COLUMN parent_session_id TEXT'),
+        ('ended_at', 'ALTER TABLE sessions ADD COLUMN ended_at REAL'),
+        ('end_reason', 'ALTER TABLE sessions ADD COLUMN end_reason TEXT'),
+    ):
+        existing = {row[1] for row in conn.execute("PRAGMA table_info(sessions)").fetchall()}
+        if column not in existing:
+            conn.execute(ddl)
     conn.commit()
     return conn
 
@@ -110,6 +118,50 @@ def _insert_gateway_session(conn, session_id='20260401_120000_abcdefgh', source=
         "INSERT INTO messages (session_id, role, content, timestamp) VALUES (?, 'assistant', ?, ?)",
         (session_id, 'Hi there!', (started_at or time.time()) + 1)
     )
+    conn.commit()
+
+
+def _insert_agent_session_row(
+    conn,
+    session_id,
+    source='weixin',
+    title='Agent Session',
+    model='openai/gpt-5',
+    started_at=None,
+    parent_session_id=None,
+    ended_at=None,
+    end_reason=None,
+    messages=1,
+):
+    """Insert an agent session row with optional compression lineage."""
+    started_at = started_at or time.time()
+    conn.execute(
+        "INSERT OR REPLACE INTO sessions "
+        "(id, source, title, model, started_at, message_count, parent_session_id, ended_at, end_reason) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            session_id,
+            source,
+            title,
+            model,
+            started_at,
+            messages,
+            parent_session_id,
+            ended_at,
+            end_reason,
+        ),
+    )
+    conn.execute("DELETE FROM messages WHERE session_id = ?", (session_id,))
+    for i in range(messages):
+        conn.execute(
+            "INSERT INTO messages (session_id, role, content, timestamp) VALUES (?, ?, ?, ?)",
+            (
+                session_id,
+                'user' if i % 2 == 0 else 'assistant',
+                f'{title} message {i + 1}',
+                started_at + i,
+            ),
+        )
     conn.commit()
 
 
@@ -224,6 +276,241 @@ def test_gateway_watcher_hides_sessions_without_messages(monkeypatch):
     finally:
         try:
             _remove_test_sessions(conn, empty_sid, live_sid)
+            conn.close()
+        except Exception:
+            pass
+
+
+def test_compression_chain_collapses_to_latest_tip_in_sidebar():
+    """Show one logical agent conversation for a compression continuation chain."""
+    conn = _ensure_state_db()
+    ids_to_remove = ('chain_root_001', 'chain_empty_mid_001', 'chain_tip_001')
+    t0 = time.time() - 600
+    try:
+        _insert_agent_session_row(
+            conn,
+            'chain_root_001',
+            title='Magazine Style PPT Skill',
+            started_at=t0,
+            ended_at=t0 + 100,
+            end_reason='compression',
+            messages=3,
+        )
+        _insert_agent_session_row(
+            conn,
+            'chain_empty_mid_001',
+            title='Magazine Style PPT Skill #2',
+            started_at=t0 + 101,
+            parent_session_id='chain_root_001',
+            ended_at=t0 + 200,
+            end_reason='compression',
+            messages=0,
+        )
+        _insert_agent_session_row(
+            conn,
+            'chain_tip_001',
+            title='Magazine Style PPT Skill #3',
+            started_at=t0 + 201,
+            parent_session_id='chain_empty_mid_001',
+            messages=2,
+        )
+
+        post('/api/settings', {'show_cli_sessions': True})
+        data, status = get('/api/sessions')
+        assert status == 200
+        ids = {s.get('session_id') for s in data.get('sessions', [])}
+        tip = next((s for s in data.get('sessions', []) if s.get('session_id') == 'chain_tip_001'), None)
+
+        assert 'chain_tip_001' in ids
+        assert 'chain_root_001' not in ids
+        assert 'chain_empty_mid_001' not in ids
+        assert tip is not None
+        assert tip.get('title') == 'Magazine Style PPT Skill'
+        assert tip.get('message_count') == 2
+        assert abs(tip.get('created_at') - t0) < 0.01
+        assert abs(tip.get('updated_at') - (t0 + 2)) < 0.01
+
+        from api.agent_sessions import read_importable_agent_session_rows
+
+        rows = read_importable_agent_session_rows(_get_state_db_path(), limit=None)
+        projected_tip = next((row for row in rows if row.get('id') == 'chain_tip_001'), None)
+        assert projected_tip is not None
+        assert projected_tip.get('title') == 'Magazine Style PPT Skill'
+        assert projected_tip.get('_lineage_root_id') == 'chain_root_001'
+        assert projected_tip.get('_lineage_tip_id') == 'chain_tip_001'
+        assert projected_tip.get('_compression_segment_count') == 3
+    finally:
+        try:
+            _remove_test_sessions(conn, *ids_to_remove)
+            conn.close()
+        except Exception:
+            pass
+        post('/api/settings', {'show_cli_sessions': False})
+
+
+def test_compression_chain_with_empty_latest_tip_falls_back_to_latest_importable_segment():
+    """Empty latest tips should not make the whole conversation disappear."""
+    conn = _ensure_state_db()
+    ids_to_remove = ('empty_tip_root_001', 'empty_tip_001')
+    t0 = time.time() - 500
+    try:
+        _insert_agent_session_row(
+            conn,
+            'empty_tip_root_001',
+            title='Long Conversation',
+            started_at=t0,
+            ended_at=t0 + 100,
+            end_reason='compression',
+            messages=2,
+        )
+        _insert_agent_session_row(
+            conn,
+            'empty_tip_001',
+            title='Long Conversation #2',
+            started_at=t0 + 101,
+            parent_session_id='empty_tip_root_001',
+            messages=0,
+        )
+
+        post('/api/settings', {'show_cli_sessions': True})
+        data, status = get('/api/sessions')
+        assert status == 200
+        ids = {s.get('session_id') for s in data.get('sessions', [])}
+
+        assert 'empty_tip_root_001' in ids
+        assert 'empty_tip_001' not in ids
+        root = next((s for s in data.get('sessions', []) if s.get('session_id') == 'empty_tip_root_001'), None)
+        assert root and root.get('title') == 'Long Conversation'
+    finally:
+        try:
+            _remove_test_sessions(conn, *ids_to_remove)
+            conn.close()
+        except Exception:
+            pass
+        post('/api/settings', {'show_cli_sessions': False})
+
+
+def test_compression_chain_with_all_empty_segments_is_hidden():
+    """A compression chain with no importable segment should not appear."""
+    conn = _ensure_state_db()
+    ids_to_remove = ('all_empty_root_001', 'all_empty_tip_001')
+    t0 = time.time() - 450
+    try:
+        _insert_agent_session_row(
+            conn,
+            'all_empty_root_001',
+            title='Empty Long Conversation',
+            started_at=t0,
+            ended_at=t0 + 100,
+            end_reason='compression',
+            messages=0,
+        )
+        _insert_agent_session_row(
+            conn,
+            'all_empty_tip_001',
+            title='Empty Long Conversation #2',
+            started_at=t0 + 101,
+            parent_session_id='all_empty_root_001',
+            messages=0,
+        )
+
+        post('/api/settings', {'show_cli_sessions': True})
+        data, status = get('/api/sessions')
+        assert status == 200
+        ids = {s.get('session_id') for s in data.get('sessions', [])}
+
+        assert 'all_empty_root_001' not in ids
+        assert 'all_empty_tip_001' not in ids
+    finally:
+        try:
+            _remove_test_sessions(conn, *ids_to_remove)
+            conn.close()
+        except Exception:
+            pass
+        post('/api/settings', {'show_cli_sessions': False})
+
+
+def test_non_compression_child_is_not_collapsed_into_parent():
+    """Parent/child relationships that are not compression continuations stay flat."""
+    conn = _ensure_state_db()
+    ids_to_remove = ('branch_parent_001', 'branch_child_001')
+    t0 = time.time() - 400
+    try:
+        _insert_agent_session_row(
+            conn,
+            'branch_parent_001',
+            title='Branch Parent',
+            started_at=t0,
+            ended_at=t0 + 100,
+            end_reason='branched',
+            messages=2,
+        )
+        _insert_agent_session_row(
+            conn,
+            'branch_child_001',
+            title='Branch Child',
+            started_at=t0 + 101,
+            parent_session_id='branch_parent_001',
+            messages=2,
+        )
+
+        from api.agent_sessions import read_importable_agent_session_rows
+
+        rows = read_importable_agent_session_rows(_get_state_db_path(), limit=None)
+        ids = {row.get('id') for row in rows}
+
+        assert 'branch_parent_001' in ids
+        assert 'branch_child_001' in ids
+    finally:
+        try:
+            _remove_test_sessions(conn, *ids_to_remove)
+            conn.close()
+        except Exception:
+            pass
+
+
+def test_agent_session_limit_applies_after_compression_projection():
+    """A long raw chain should count as one logical sidebar row before limiting."""
+    conn = _ensure_state_db()
+    chain_ids = [f'limit_chain_{i:03d}' for i in range(8)]
+    standalone_id = 'limit_standalone_001'
+    t0 = time.time() - 300
+    try:
+        for i, sid in enumerate(chain_ids):
+            _insert_agent_session_row(
+                conn,
+                sid,
+                title=f'Limit Chain #{i + 1}',
+                started_at=t0 + i,
+                parent_session_id=chain_ids[i - 1] if i else None,
+                ended_at=t0 + i + 0.5 if i < len(chain_ids) - 1 else None,
+                end_reason='compression' if i < len(chain_ids) - 1 else None,
+                messages=1,
+            )
+        _insert_agent_session_row(
+            conn,
+            standalone_id,
+            title='Limit Standalone',
+            started_at=t0 + 20,
+            messages=1,
+        )
+
+        from api.agent_sessions import read_importable_agent_session_rows
+
+        rows = read_importable_agent_session_rows(_get_state_db_path(), limit=2)
+        ids = [row.get('id') for row in rows]
+
+        assert len(rows) == 2
+        assert chain_ids[-1] in ids
+        assert standalone_id in ids
+        assert not any(sid in ids for sid in chain_ids[:-1])
+        chain = next(row for row in rows if row.get('id') == chain_ids[-1])
+        assert chain.get('title') == 'Limit Chain #1'
+        assert chain.get('_lineage_root_id') == chain_ids[0]
+        assert chain.get('_compression_segment_count') == len(chain_ids)
+    finally:
+        try:
+            _remove_test_sessions(conn, *(chain_ids + [standalone_id]))
             conn.close()
         except Exception:
             pass


### PR DESCRIPTION
## Summary

This refreshes #1012 on current `master` now that #1009 has landed.

It fixes the remaining concrete `Show agent sessions` correctness issue from #1004: Hermes Agent can split one long CLI / Weixin / Telegram / Cron conversation into multiple `state.db.sessions` rows during context compression, and WebUI was flattening those raw backend segments into separate sidebar rows.

## Implementation

- Adds a shared `api/agent_sessions.py` projection layer for both `/api/sessions` and the gateway SSE watcher.
- Mirrors Hermes Agent's compression-continuation guard:
  - parent `end_reason == 'compression'`
  - parent has `ended_at`
  - child `started_at >= parent.ended_at`
- Skips continuation child rows so a compression chain surfaces as one logical sidebar entry.
- Preserves the chain head as the visible representative, including title and timestamps, so WebUI does not silently rewrite the user's historical conversation metadata.
- Points the row's import/current-state identity at the latest importable segment, so clicking the entry continues from the compressed current state rather than an old segment.
- Filters chains with no importable message rows.
- Keeps non-compression parent/child relationships flat, so this does not overlap #494 / future subagent-tree UI work.
- Applies the sidebar limit after projection, so one long compression chain cannot crowd out other real conversations before the list is collapsed.

## Scope

This PR addresses the technical compression-chain projection layer from #1004.

It intentionally does not solve the broader product/UX question of how every external source should appear in the main chat sidebar. That source-aware IA discussion is tracked separately in #1013.

Non-goals:

- no subagent tree UI (#494)
- no bidirectional Weixin / Telegram / WebUI sync
- no source-aware filtering or grouping IA
- no concatenated fake WebUI transcript across every historical compression segment

## Verification

```bash
python3 -m py_compile api/agent_sessions.py api/models.py api/gateway_watcher.py tests/test_gateway_sync.py
git diff --check
.venv_test/bin/pytest tests/test_gateway_sync.py tests/test_issue634.py tests/test_cron_session_title.py -q
```

Results:

```text
38 passed
```

Refs #1004.
