### PR TITLE
fix(#1014): classify model-not-found errors with helpful message

### DIFF
--- a/api/streaming.py
+++ b/api/streaming.py
@@ -1660,6 +1660,13 @@ def _run_agent_streaming(session_id, msg_text, model, workspace, stream_id, atta
     except Exception as e:
         print('[webui] stream error:\n' + traceback.format_exc(), flush=True)
         err_str = str(e)
+        # Sanitize HTML from provider error responses — some providers return
+        # full HTML pages (e.g. nginx "404 page not found") instead of JSON errors.
+        # Strip HTML tags to avoid rendering raw markup in the chat message.
+        _stripped = re.sub(r'<[^>]+>', ' ', err_str)
+        _stripped = re.sub(r'\s+', ' ', _stripped).strip()
+        if _stripped != err_str:
+            err_str = _stripped
         _exc_lower = err_str.lower()
         # Classify before saving so the error message can be persisted to the session.
         # Check quota exhaustion first — OpenAI billing 429s use insufficient_quota which
@@ -1683,6 +1690,16 @@ def _run_agent_streaming(session_id, msg_text, model, workspace, stream_id, atta
             or 'invalid api key' in _exc_lower
             or 'no cookie auth credentials' in _exc_lower
         )
+        _exc_is_not_found = (
+            '404' in err_str
+            or 'not found' in _exc_lower
+            or 'does not exist' in _exc_lower
+            or 'model not found' in _exc_lower
+            or 'model_not_found' in _exc_lower
+            or 'invalid model' in _exc_lower
+            or 'does not match any known model' in _exc_lower
+            or 'unknown model' in _exc_lower
+        )
         if _exc_is_quota:
             _exc_label, _exc_type, _exc_hint = (
                 'Out of credits', 'quota_exhausted',
@@ -1698,6 +1715,12 @@ def _run_agent_streaming(session_id, msg_text, model, workspace, stream_id, atta
                 'Authentication error', 'auth_mismatch',
                 'The selected model may not be supported by your configured provider. '
                 'Run `hermes model` in your terminal to switch providers, then restart the WebUI.',
+            )
+        elif _exc_is_not_found:
+            _exc_label, _exc_type, _exc_hint = (
+                'Model not found', 'model_not_found',
+                'The selected model was not found by the provider. '
+                'Check the model ID in Settings or run `hermes model` to verify it exists for your provider.',
             )
         else:
             _exc_label, _exc_type, _exc_hint = 'Error', 'error', ''

--- a/static/i18n.js
+++ b/static/i18n.js
@@ -56,6 +56,7 @@ const LOCALES = {
     model_unavailable_title: 'This model is no longer in your current provider list',
     provider_mismatch_warning: (m,p)=>`"${m}" may not work with your configured provider (${p}). Send anyway, or run \`hermes model\` in your terminal to switch.`,
     provider_mismatch_label: 'Provider mismatch',
+    model_not_found_label: 'Model not found',
     model_custom_label: 'Custom model ID',
     model_custom_placeholder: 'e.g. openai/gpt-5.4',
     model_search_placeholder: 'Search models…',
@@ -652,6 +653,7 @@ const LOCALES = {
     provider_mismatch_warning: (m, p) =>
     `"${m}" может не работать с вашим настроенным провайдером (${p}). Всё равно отправить или запустите \`hermes model\` в терминале, чтобы переключиться.`,
     provider_mismatch_label: 'Несовпадение провайдера',
+    model_not_found_label: 'Модель не найдена',
     model_custom_label: 'Пользовательский ID модели',
     model_custom_placeholder: 'например, openai/gpt-5.4',
     cmd_help: 'Показать доступные команды',
@@ -1233,6 +1235,7 @@ const LOCALES = {
     model_unavailable_title: 'Este modelo ya no está en tu lista actual de proveedores',
     provider_mismatch_warning: (m,p)=>`"${m}" puede no funcionar con tu proveedor configurado (${p}). Envía de todas formas, o ejecuta \`hermes model\` en la terminal para cambiar.`,
     provider_mismatch_label: 'Proveedor incompatible',
+    model_not_found_label: 'Modelo no encontrado',
     model_custom_label: 'ID de modelo personalizado',
     model_custom_placeholder: 'p. ej. openai/gpt-5.4',
     model_search_placeholder: 'Buscar modelos…',
@@ -1773,6 +1776,7 @@ const LOCALES = {
     model_unavailable_title: 'Dieses Modell ist nicht mehr in Ihrer aktuellen Provider-Liste',
     provider_mismatch_warning: (m,p)=>`"${m}" funktioniert möglicherweise nicht mit Ihrem konfigurierten Provider (${p}). Trotzdem senden, oder \`hermes model\` im Terminal ausführen.`,
     provider_mismatch_label: 'Provider-Konflikt',
+    model_not_found_label: 'Modell nicht gefunden',
     // commands.js
     cmd_help: 'Verfügbare Befehle auflisten',
     cmd_clear: 'Konversationsverlauf löschen',
@@ -2097,6 +2101,7 @@ const LOCALES = {
     model_unavailable_title: '\u8fd9\u4e2a\u6a21\u578b\u5df2\u7ecf\u4e0d\u5728\u5f53\u524d provider \u5217\u8868\u4e2d',
     provider_mismatch_warning: (m,p)=>`\"${m}\" \u53ef\u80fd\u65e0\u6cd5\u5728\u5f53\u524d\u914d\u7f6e\u7684\u63d0\u4f9b\u5546 (${p}) \u4e0b\u5de5\u4f5c\u3002\u76f4\u63a5\u53d1\u9001\uff0c\u6216\u5728\u7ec8\u7aef\u8fd0\u884c \`hermes model\` \u5207\u6362\u3002`,
     provider_mismatch_label: '\u63d0\u4f9b\u5546\u4e0d\u5339\u914d',
+    model_not_found_label: '\u672a\u627e\u5230\u6a21\u578b',
     model_custom_label: '\u81ea\u5b9a\u4e49\u6a21\u578b ID',
     model_custom_placeholder: '\u4f8b\u5982 openai/gpt-5.4',
     model_search_placeholder: '\u641c\u7d22\u6a21\u578b\u2026',
@@ -2635,6 +2640,7 @@ const LOCALES = {
     model_unavailable_title: '\u6b64\u6a21\u578b\u5df2\u7d93\u4e0d\u5728\u7576\u524d provider \u5217\u8868\u4e2d',
     provider_mismatch_warning: (m,p)=>`\"${m}\" \u53ef\u80fd\u7121\u6cd5\u5728\u7576\u524d\u914d\u7f6e\u7684\u63d0\u4f9b\u8005 (${p}) \u4e0b\u904b\u4f5c\u3002\u5c1a\u9001\uff0c\u6216\u5728\u7d42\u7aef\u57f7\u884c \`hermes model\` \u5207\u63db\u3002`,
     provider_mismatch_label: '\u63d0\u4f9b\u8005\u4e0d\u76f8\u7b26',
+    model_not_found_label: '\u672a\u627e\u5230\u6a21\u578b',
     // commands.js
     cmd_help: '\u67e5\u770b\u53ef\u7528\u547d\u4ee4',
     cmd_clear: '\u6e05\u7a7a\u7576\u524d\u5c0d\u8a71\u8a0a\u606f',

--- a/static/messages.js
+++ b/static/messages.js
@@ -775,8 +775,9 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
           const isRateLimit=d.type==='rate_limit';
           const isQuotaExhausted=d.type==='quota_exhausted';
           const isAuthMismatch=d.type==='auth_mismatch';
+          const isModelNotFound=d.type==='model_not_found';
           const isNoResponse=d.type==='no_response';
-          const label=isQuotaExhausted?'Out of credits':isRateLimit?'Rate limit reached':isAuthMismatch?(typeof t==='function'?t('provider_mismatch_label'):'Provider mismatch'):isNoResponse?'No response received':'Error';
+          const label=isQuotaExhausted?'Out of credits':isRateLimit?'Rate limit reached':isAuthMismatch?(typeof t==='function'?t('provider_mismatch_label'):'Provider mismatch'):isModelNotFound?(typeof t==='function'?t('model_not_found_label'):'Model not found'):isNoResponse?'No response received':'Error';
           const hint=d.hint?`\n\n*${d.hint}*`:'';
           S.messages.push({role:'assistant',content:`**${label}:** ${d.message}${hint}`});
         }catch(_){

--- a/tests/test_issue1014_model_not_found.py
+++ b/tests/test_issue1014_model_not_found.py
@@ -1,0 +1,198 @@
+"""
+Tests for issue #1014 — model-not-found error classification.
+
+Covers:
+  1. streaming.py: 404/model-not-found errors detected and classified as 'model_not_found'
+  2. streaming.py: HTML tags stripped from provider error messages before classification
+  3. static/messages.js: apperror handler has model_not_found branch
+  4. static/i18n.js: model_not_found_label key present in all locales
+  5. streaming.py: model_not_found checked after auth but before generic error
+"""
+import pathlib
+import re
+
+REPO_ROOT = pathlib.Path(__file__).parent.parent.resolve()
+
+
+def _read(rel_path: str) -> str:
+    return (REPO_ROOT / rel_path).read_text(encoding="utf-8")
+
+
+# ── 1. streaming.py: model-not-found error detection ─────────────────────────
+
+class TestStreamingModelNotFoundDetection:
+    """streaming.py must classify 404/model-not-found errors as model_not_found."""
+
+    def test_model_not_found_type_defined_in_streaming(self):
+        """'model_not_found' type must be emitted for 404 errors."""
+        src = _read("api/streaming.py")
+        assert "model_not_found" in src, (
+            "model_not_found type not found in streaming.py — "
+            "404 errors will not be surfaced with a helpful message"
+        )
+
+    def test_is_not_found_flag_defined(self):
+        """_exc_is_not_found variable must exist in the exception handler."""
+        src = _read("api/streaming.py")
+        assert "_exc_is_not_found" in src, (
+            "_exc_is_not_found flag not found in streaming.py"
+        )
+
+    def test_not_found_detects_404(self):
+        """'404' must be part of the model-not-found detection logic."""
+        src = _read("api/streaming.py")
+        idx = src.find("_exc_is_not_found")
+        assert idx != -1, "_exc_is_not_found not found"
+        block = src[idx:idx + 600]
+        assert "'404'" in block or '"404"' in block, (
+            "'404' not in model-not-found detection block"
+        )
+
+    def test_not_found_detects_not_found_string(self):
+        """'not found' must be part of the detection logic."""
+        src = _read("api/streaming.py")
+        idx = src.find("_exc_is_not_found")
+        block = src[idx:idx + 600]
+        assert "not found" in block.lower(), (
+            "'not found' not in model-not-found detection block"
+        )
+
+    def test_not_found_detects_does_not_exist(self):
+        """'does not exist' must be part of the detection logic."""
+        src = _read("api/streaming.py")
+        idx = src.find("_exc_is_not_found")
+        block = src[idx:idx + 600]
+        assert "does not exist" in block.lower(), (
+            "'does not exist' not in model-not-found detection block"
+        )
+
+    def test_not_found_detects_invalid_model(self):
+        """'invalid model' must be part of the detection logic."""
+        src = _read("api/streaming.py")
+        idx = src.find("_exc_is_not_found")
+        block = src[idx:idx + 600]
+        assert "invalid model" in block.lower(), (
+            "'invalid model' not in model-not-found detection block"
+        )
+
+    def test_not_found_hint_mentions_settings(self):
+        """The model_not_found hint must mention Settings or hermes model."""
+        src = _read("api/streaming.py")
+        idx = src.find("model_not_found")
+        block = src[idx:idx + 500]
+        assert "Settings" in block or "hermes model" in block, (
+            "model_not_found hint must mention Settings or hermes model command"
+        )
+
+    def test_not_found_check_order_after_auth(self):
+        """model_not_found must be checked after auth_mismatch (auth first)."""
+        src = _read("api/streaming.py")
+        auth_idx = src.find("elif _exc_is_auth")
+        nf_idx = src.find("elif _exc_is_not_found")
+        assert auth_idx != -1, "_exc_is_auth not found"
+        assert nf_idx != -1, "_exc_is_not_found not found"
+        assert auth_idx < nf_idx, (
+            "auth_mismatch should be checked before model_not_found — "
+            "auth errors must not be mistaken for not-found errors"
+        )
+
+
+# ── 2. streaming.py: HTML sanitization ───────────────────────────────────────
+
+class TestStreamingHtmlSanitization:
+    """Provider error messages containing HTML must be stripped."""
+
+    def test_html_strip_before_classification(self):
+        """HTML tags must be stripped before error classification."""
+        src = _read("api/streaming.py")
+        # Find the HTML sanitization block in the exception handler
+        # It should appear before _exc_lower = err_str.lower()
+        sanitize_idx = src.find("re.sub(r'<[^>]+>'")
+        exc_lower_idx = src.find("_exc_lower = err_str.lower()")
+        assert sanitize_idx != -1, (
+            "HTML tag stripping (re.sub) not found in streaming.py exception handler"
+        )
+        assert exc_lower_idx != -1, "_exc_lower not found"
+        assert sanitize_idx < exc_lower_idx, (
+            "HTML sanitization must happen before error classification"
+        )
+
+    def test_whitespace_normalization(self):
+        """Stripped HTML must have whitespace collapsed."""
+        src = _read("api/streaming.py")
+        sanitize_idx = src.find("re.sub(r'<[^>]+>'")
+        block = src[sanitize_idx:sanitize_idx + 300]
+        assert r"\s+" in block, (
+            "Whitespace normalization (\\s+) not found after HTML strip"
+        )
+
+
+# ── 3. static/messages.js: apperror handler ──────────────────────────────────
+
+class TestApperrorModelNotFound:
+    """messages.js apperror handler must handle model_not_found type."""
+
+    def test_model_not_found_type_handled(self):
+        """apperror handler must check for type='model_not_found'."""
+        src = _read("static/messages.js")
+        assert "model_not_found" in src, (
+            "model_not_found type not handled in messages.js apperror handler"
+        )
+
+    def test_model_not_found_label(self):
+        """'Model not found' label must appear in the error handling."""
+        src = _read("static/messages.js")
+        assert "Model not found" in src, (
+            "'Model not found' label not found in messages.js"
+        )
+
+    def test_is_model_not_found_variable(self):
+        """isModelNotFound variable must be defined."""
+        src = _read("static/messages.js")
+        assert "isModelNotFound" in src, (
+            "isModelNotFound variable not found in messages.js apperror handler"
+        )
+
+
+# ── 4. static/i18n.js: all locales ───────────────────────────────────────────
+
+class TestI18nModelNotFound:
+    """All locales must have model_not_found_label."""
+
+    REQUIRED_KEY = "model_not_found_label"
+
+    def _locale_names(self, src: str) -> list:
+        pattern = re.compile(
+            r"^\s{2}(?:'(?P<quoted>[A-Za-z0-9-]+)'|(?P<plain>[A-Za-z0-9-]+))\s*:\s*\{",
+            re.MULTILINE,
+        )
+        names = []
+        for match in pattern.finditer(src):
+            names.append(match.group("quoted") or match.group("plain"))
+        return names
+
+    def _count_key(self, src: str, key: str) -> int:
+        return len(re.findall(r'\b' + re.escape(key) + r'\b', src))
+
+    def test_all_locales_have_model_not_found_label(self):
+        """model_not_found_label must appear in all locales."""
+        src = _read("static/i18n.js")
+        locale_count = len(self._locale_names(src))
+        count = self._count_key(src, self.REQUIRED_KEY)
+        assert count >= locale_count, (
+            f"model_not_found_label found {count} times, expected >= {locale_count} "
+            f"(one per locale)"
+        )
+
+    def test_english_label_is_plain_string(self):
+        """English model_not_found_label must be a plain string, not a function."""
+        src = _read("static/i18n.js")
+        en_start = src.find("\n  en: {")
+        es_start = src.find("\n  es: {")
+        en_block = src[en_start:es_start]
+        assert self.REQUIRED_KEY in en_block, "Key not in en block"
+        idx = en_block.find(self.REQUIRED_KEY)
+        line = en_block[idx:idx + 200]
+        assert "=>" not in line, (
+            "model_not_found_label should be a plain string, not an arrow function"
+        )


### PR DESCRIPTION
## Summary

Fixes #1014 — Qwen (and other) models returning 404 show a generic raw error instead of a helpful message.

### Problem

When a provider returns a 404 error (model not found), the WebUI currently:
1. Shows the raw error string (which may contain HTML like nginx's "404 page not found")
2. Falls through to the generic `'error'` type with no hint for the user

### Changes

**`api/streaming.py`**
- Added `_exc_is_not_found` classifier that detects: `404`, `not found`, `does not exist`, `model not found`, `invalid model`, `unknown model`, `does not match any known model`
- Added HTML sanitization: strips HTML tags from provider error messages before classification (some providers return full HTML pages instead of JSON)
- New error type: `'model_not_found'` with hint pointing to Settings / `hermes model`

**`static/messages.js`**
- Added `isModelNotFound` branch in the `apperror` handler with i18n label

**`static/i18n.js`**
- Added `model_not_found_label` in all 6 locales (en, es, de, ru, zh, zh-Hant)

### Error classification order

`quota` → `rate_limit` → `auth` → **`model_not_found`** (new) → `generic error`

### Tests

15 tests in `tests/test_issue1014_model_not_found.py`:
- 8 tests for streaming.py detection (patterns, order, hint)
- 2 tests for HTML sanitization
- 3 tests for messages.js frontend handler
- 2 tests for i18n locale coverage

All existing tests pass (52 provider mismatch + quota tests verified).

### Note

This fix improves error UX regardless of the specific provider the reporter was using. Even without more details from the reporter, users will now see:
> **Model not found:** [sanitized error message]
> *The selected model was not found by the provider. Check the model ID in Settings or run `hermes model` to verify it exists for your provider.*

Instead of raw HTML or a generic error.