### PR TITLE
Speed up large session restore paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
+- **Large session switching and reload keep the API path lightweight** — `GET /api/session?messages=0` now parses only the JSON metadata before the `messages` array and skips cold model-catalog resolution while preserving the compact `message_count` from the session index. The frontend's lazy full-message fetch also passes `resolve_model=0`, avoiding a second cold model-catalog lookup on session switch, then refreshes display-model normalization asynchronously so provider-mismatch handling remains intact without blocking the switch. Hard reload no longer waits for the dynamic model catalog before restoring the saved session. Metadata-only loads no longer populate the full-session cache, preventing a compact session object from hiding the real message history on the next full load. (`api/models.py`, `api/routes.py`, `static/boot.js`, `static/sessions.js`, `static/ui.js`, `tests/test_session_index.py`, `tests/test_session_metadata_fast_path.py`)
 - **Reasoning chip now appears after the model chip** in the composer toolbar — model is a more fundamental choice and should be stable in position regardless of whether reasoning is active. Order: Profile → Workspace → Model → Reasoning. (`static/index.html`)
 
 ## v0.50.206 — 2026-04-25

--- a/api/models.py
+++ b/api/models.py
@@ -194,6 +194,87 @@ def _is_streaming_session(active_stream_id, active_stream_ids):
     return bool(active_stream_id and active_stream_id in active_stream_ids)
 
 
+def _find_top_level_json_key(text, key):
+    """Return the byte offset of a top-level JSON object key, if present."""
+    depth = 0
+    i = 0
+    n = len(text)
+    while i < n:
+        ch = text[i]
+        if ch == '"':
+            start = i
+            i += 1
+            escaped = False
+            chars = []
+            while i < n:
+                c = text[i]
+                if escaped:
+                    chars.append(c)
+                    escaped = False
+                elif c == '\\':
+                    escaped = True
+                elif c == '"':
+                    break
+                else:
+                    chars.append(c)
+                i += 1
+            if i >= n:
+                return None
+            if depth == 1 and ''.join(chars) == key:
+                j = i + 1
+                while j < n and text[j] in ' \t\r\n':
+                    j += 1
+                if j < n and text[j] == ':':
+                    return start
+        elif ch in '{[':
+            depth += 1
+        elif ch in '}]':
+            depth -= 1
+        i += 1
+    return None
+
+
+def _read_metadata_json_prefix(path, max_prefix_bytes=65536):
+    """Read only the metadata portion before the top-level messages array."""
+    buf = ''
+    with open(path, 'r', encoding='utf-8') as f:
+        while len(buf.encode('utf-8')) < max_prefix_bytes:
+            chunk = f.read(4096)
+            if not chunk:
+                return None
+            buf += chunk
+            messages_pos = _find_top_level_json_key(buf, 'messages')
+            if messages_pos is None:
+                continue
+            prefix = buf[:messages_pos].rstrip()
+            if prefix.endswith(','):
+                prefix = prefix[:-1].rstrip()
+            return f'{prefix}\n}}'
+    return None
+
+
+def _lookup_index_message_count(session_id):
+    """Return the indexed message count without loading the full session file."""
+    try:
+        entries = json.loads(SESSION_INDEX_FILE.read_text(encoding='utf-8'))
+    except Exception:
+        return None
+    if not isinstance(entries, list):
+        return None
+    for entry in entries:
+        if entry.get('session_id') != session_id:
+            continue
+        count = entry.get('message_count')
+        if isinstance(count, int) and count >= 0:
+            return count
+        try:
+            count = int(count)
+        except (TypeError, ValueError):
+            return None
+        return count if count >= 0 else None
+    return None
+
+
 class Session:
     def __init__(self, session_id: str=None, title: str='Untitled',
                  workspace=str(DEFAULT_WORKSPACE), model=DEFAULT_MODEL,
@@ -231,6 +312,7 @@ class Session:
         self.pending_started_at = pending_started_at
         self.compression_anchor_visible_idx = compression_anchor_visible_idx
         self.compression_anchor_message_key = compression_anchor_message_key
+        self._metadata_message_count = None
 
     @property
     def path(self):
@@ -255,7 +337,8 @@ class Session:
         meta['tool_calls'] = self.tool_calls
         # Fields not in METADATA_FIELDS (e.g. last_usage, message_count) go at the end
         extra = {k: v for k, v in self.__dict__.items()
-                 if k not in METADATA_FIELDS and k not in ('messages', 'tool_calls')}
+                 if k not in METADATA_FIELDS and k not in ('messages', 'tool_calls')
+                 and not k.startswith('_')}
         payload = json.dumps({**meta, **extra}, ensure_ascii=False, indent=2)
         tmp = self.path.with_suffix(f'.tmp.{os.getpid()}.{threading.current_thread().ident}')
         try:
@@ -288,10 +371,9 @@ class Session:
         """Load only the compact metadata fields, skipping the messages array.
 
         Session JSON files have metadata fields (session_id, title, model, etc.)
-        at the top level, before the large messages array. We read only the
-        first ~1KB — enough to capture all compact() fields — then parse just
-        that prefix. Falls back to load() if the prefix doesn't contain enough
-        fields or if the file is unexpectedly small.
+        at the top level, before the large messages array. Read only up to the
+        top-level "messages" field and synthesize a small metadata-only object.
+        Falls back to load() for legacy or unexpected file layouts.
         """
         if not sid or not all(c in '0123456789abcdefghijklmnopqrstuvwxyz_' for c in sid):
             return None
@@ -299,26 +381,18 @@ class Session:
         if not p.exists():
             return None
         try:
-            # Read just the first 1 KB — metadata comes before messages array
-            with open(p, 'r', encoding='utf-8') as f:
-                prefix = f.read(1024)
+            prefix = _read_metadata_json_prefix(p)
             if not prefix:
                 return cls.load(sid)
             parsed = json.loads(prefix)
-            # Verify we got the essential fields.
-            # With metadata-first save() ordering, messages appears at byte ~567.
-            # For sessions <= ~512 bytes total the entire messages array fits in the
-            # first 1 KB and we get a valid list. For larger sessions json.loads
-            # fails on the truncated buffer (unterminated string), so we fall back
-            # to full load. The one exception is a truncation inside a string value
-            # that happens to produce valid JSON with a truncated string — guard
-            # against that by requiring messages to be a list.
             needed = {'session_id', 'title', 'created_at', 'updated_at'}
             if not needed.issubset(parsed.keys()):
                 return cls.load(sid)
-            if not isinstance(parsed.get('messages'), list):
-                return cls.load(sid)
-            return cls(**parsed)
+            parsed['messages'] = []
+            parsed['tool_calls'] = []
+            session = cls(**parsed)
+            session._metadata_message_count = _lookup_index_message_count(sid)
+            return session
         except Exception:
             # Corrupt prefix or decode error — fall back to full load
             return cls.load(sid)
@@ -330,7 +404,11 @@ class Session:
             'title': self.title,
             'workspace': self.workspace,
             'model': self.model,
-            'message_count': len(self.messages),
+            'message_count': (
+                self._metadata_message_count
+                if self._metadata_message_count is not None
+                else len(self.messages)
+            ),
             'created_at': self.created_at,
             'updated_at': self.updated_at,
             'pinned': self.pinned,
@@ -352,9 +430,10 @@ class Session:
 def get_session(sid, metadata_only=False):
     """Load a session, optionally with metadata only (skipping the messages array).
 
-    When metadata_only=True the session is still cached so the full load on the
-    next access is fast. Use this when you only need compact() metadata and not
-    the actual message history (e.g., for fast sidebar switching).
+    Metadata-only loads intentionally do not populate the full-session cache.
+    Otherwise a later full load could return a compact object with an empty
+    messages list. Use this when you only need compact() metadata and not the
+    actual message history (e.g., for fast sidebar switching).
     """
     with LOCK:
         if sid in SESSIONS:
@@ -362,6 +441,8 @@ def get_session(sid, metadata_only=False):
             return SESSIONS[sid]
     if metadata_only:
         s = Session.load_metadata_only(sid)
+        if s:
+            return s
     else:
         s = Session.load(sid)
     if s:

--- a/api/routes.py
+++ b/api/routes.py
@@ -680,19 +680,26 @@ def handle_get(handler, parsed) -> bool:
         import time as _time
         _t0 = _time.monotonic()
         _debug_slow = os.environ.get("HERMES_DEBUG_SLOW", "")
-        sid = parse_qs(parsed.query).get("session_id", [""])[0]
+        query = parse_qs(parsed.query)
+        sid = query.get("session_id", [""])[0]
         if not sid:
             return j(handler, {"error": "session_id is required"}, status=400)
         # ?messages=0 skips the message payload for fast session switching.
         # The frontend uses this when switching conversations in the sidebar
         # (only needs metadata). The full message array is loaded lazily
         # via ?messages=1 when the message panel opens.
-        load_messages = parse_qs(parsed.query).get("messages", ["1"])[0] != "0"
+        load_messages = query.get("messages", ["1"])[0] != "0"
+        resolve_model_default = "1" if load_messages else "0"
+        resolve_model = query.get("resolve_model", [resolve_model_default])[0] != "0"
         try:
             _t1 = _time.monotonic()
             s = get_session(sid, metadata_only=(not load_messages))
             _t2 = _time.monotonic()
-            effective_model = _resolve_effective_session_model_for_display(s)
+            effective_model = (
+                _resolve_effective_session_model_for_display(s)
+                if resolve_model
+                else None
+            )
             _t3 = _time.monotonic()
             raw = s.compact() | {
                 "messages": s.messages if load_messages else [],

--- a/static/boot.js
+++ b/static/boot.js
@@ -793,6 +793,7 @@ function applyBotName(){
     window._showThinking=s.show_thinking!==false;
     window._sidebarDensity=(s.sidebar_density==='detailed'?'detailed':'compact');
     window._botName=s.bot_name||'Hermes';
+    if(s.default_model) window._defaultModel=s.default_model;
     // Persist default workspace so the blank new-chat page can show it
     // and workspace actions (New file/folder) work before the first session (#804).
     if(s.default_workspace) S._profileDefaultWorkspace=s.default_workspace;
@@ -840,16 +841,20 @@ function applyBotName(){
   // Update profile chip label immediately
   const profileLabel=$('profileChipLabel');
   if(profileLabel) profileLabel.textContent=S.activeProfile||'default';
-  // Fetch available models from server and populate dropdown dynamically
-  await populateModelDropdown();
-  // Restore last-used model preference
-  const savedModel=localStorage.getItem('hermes-webui-model');
-  if(savedModel && $('modelSelect')){
-    $('modelSelect').value=savedModel;
-    // If the value didn't take (model not in list), clear the bad pref
-    if($('modelSelect').value!==savedModel) localStorage.removeItem('hermes-webui-model');
-    else if(typeof syncModelChip==='function') syncModelChip();
-  }
+  // Fetch available models without blocking session restore. The static HTML
+  // options are enough for first paint; the dynamic provider list can settle
+  // after the saved session is visible.
+  const _modelDropdownReady=populateModelDropdown().then(()=>{
+    const savedModel=localStorage.getItem('hermes-webui-model');
+    if(savedModel && $('modelSelect')){
+      $('modelSelect').value=savedModel;
+      // If the value didn't take (model not in list), clear the bad pref
+      if($('modelSelect').value!==savedModel) localStorage.removeItem('hermes-webui-model');
+      else if(typeof syncModelChip==='function') syncModelChip();
+    }
+    if(S.session) syncTopbar();
+  }).catch(()=>{});
+  window._modelDropdownReady=_modelDropdownReady;
   // Pre-load workspace list so sidebar name is correct from first render
   await loadWorkspaceList();
   await loadOnboardingWizard();

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -109,7 +109,7 @@ async function loadSession(sid){
   // Guard against network/server failures to prevent a permanently stuck loading state.
   let data;
   try {
-    data = await api(`/api/session?session_id=${encodeURIComponent(sid)}&messages=0`);
+    data = await api(`/api/session?session_id=${encodeURIComponent(sid)}&messages=0&resolve_model=0`);
   } catch(e) {
     const _msgInner = $('msgInner');
     if (_msgInner) {
@@ -119,6 +119,7 @@ async function loadSession(sid){
     return;
   }
   S.session=data.session;
+  S.session._modelResolutionDeferred=true;
   S.lastUsage={...(data.session.last_usage||{})};
   _setSessionViewedCount(S.session.session_id, Number(data.session.message_count || 0));
   localStorage.setItem('hermes-webui-session',S.session.session_id);
@@ -254,6 +255,23 @@ async function loadSession(sid){
       threshold_tokens:  _pick(u.threshold_tokens,  _s.threshold_tokens),
     });
   }
+  _resolveSessionModelForDisplaySoon(sid);
+}
+
+function _resolveSessionModelForDisplaySoon(sid){
+  if(!sid) return;
+  setTimeout(async()=>{
+    try{
+      const data=await api(`/api/session?session_id=${encodeURIComponent(sid)}&messages=0&resolve_model=1`);
+      const model=data&&data.session&&data.session.model;
+      if(!model||!S.session||S.session.session_id!==sid) return;
+      S.session.model=model;
+      S.session._modelResolutionDeferred=false;
+      syncTopbar();
+    }catch(_){
+      // Keep session switching non-blocking; the next load can try again.
+    }
+  },0);
 }
 
 // Load session messages if not already present.
@@ -266,7 +284,7 @@ async function _ensureMessagesLoaded(sid) {
     return;
   }
   // Fetch full session with messages
-  const data = await api(`/api/session?session_id=${encodeURIComponent(sid)}&messages=1`);
+  const data = await api(`/api/session?session_id=${encodeURIComponent(sid)}&messages=1&resolve_model=0`);
   const msgs = (data.session.messages || []).filter(m => m && m.role);
   // Check for tool-call metadata on messages (for tool-call card rendering)
   const hasMessageToolMetadata = msgs.some(m => {
@@ -282,6 +300,11 @@ async function _ensureMessagesLoaded(sid) {
   }
   clearLiveToolCards();
   S.messages = msgs;
+  if(S.session&&S.session.session_id===sid){
+    S.session.message_count=Number(data.session.message_count || msgs.length);
+    S.lastUsage={...(data.session.last_usage||S.lastUsage||{})};
+    _setSessionViewedCount(sid, Number(S.session.message_count || msgs.length));
+  }
 }
 
 let _allSessions = [];  // cached for search filter

--- a/static/ui.js
+++ b/static/ui.js
@@ -1428,6 +1428,7 @@ function syncTopbar(){
     // If the model isn't in the current provider list, silently reset to the
     // first available model so stale values don't pollute the picker (#829).
     if(!applied && currentModel){
+      const deferModelCorrection=Boolean(S.session._modelResolutionDeferred);
       // Stale session model not in the current provider catalog — reset to the
       // first available model rather than injecting an "(unavailable)" option
       // that visually appears under the wrong provider group (#829).
@@ -1435,13 +1436,15 @@ function syncTopbar(){
       const first=modelSel&&modelSel.querySelector('optgroup > option, option');
       if(first){
         modelSel.value=first.value;
-        S.session.model=first.value;
-        // Persist the correction so the session doesn't re-inject on next load.
-        fetch(new URL('api/session/update',location.href).href,{
-          method:'POST',credentials:'include',
-          headers:{'Content-Type':'application/json'},
-          body:JSON.stringify({session_id:S.session.id||S.session.session_id,model:first.value})
-        }).catch(()=>{});
+        if(!deferModelCorrection){
+          S.session.model=first.value;
+          // Persist the correction so the session doesn't re-inject on next load.
+          fetch(new URL('api/session/update',location.href).href,{
+            method:'POST',credentials:'include',
+            headers:{'Content-Type':'application/json'},
+            body:JSON.stringify({session_id:S.session.id||S.session.session_id,model:first.value})
+          }).catch(()=>{});
+        }
       }
     }
   }

--- a/tests/test_session_index.py
+++ b/tests/test_session_index.py
@@ -178,6 +178,61 @@ def test_incremental_update_prunes_stale_entries():
     assert "ghost_sid" not in ids, "stale entry with no backing file must be pruned"
 
 
+def test_load_metadata_only_does_not_parse_large_message_body():
+    """Large sessions must keep the metadata-only path cheap."""
+    s = Session(
+        session_id="sess_large",
+        title="Large Session",
+        messages=[{"role": "assistant", "content": "x" * 200_000}],
+        tool_calls=[{"id": "tool_1", "name": "read_file", "result": "y" * 10_000}],
+        input_tokens=123,
+        output_tokens=45,
+    )
+    s.save()
+
+    with patch.object(Session, "load", side_effect=AssertionError("full load should not run")):
+        meta = Session.load_metadata_only("sess_large")
+
+    assert meta is not None
+    assert meta.session_id == "sess_large"
+    assert meta.title == "Large Session"
+    assert meta.input_tokens == 123
+    assert meta.output_tokens == 45
+    assert meta.messages == []
+    assert meta.tool_calls == []
+    assert meta.compact()["message_count"] == 1
+
+
+def test_metadata_only_get_session_does_not_poison_full_session_cache():
+    s = Session(
+        session_id="sess_cache",
+        title="Cache Guard",
+        messages=[{"role": "user", "content": "hi"}],
+    )
+    s.save(skip_index=True)
+
+    meta = models.get_session("sess_cache", metadata_only=True)
+    assert meta.messages == []
+    assert "sess_cache" not in models.SESSIONS
+
+    full = models.get_session("sess_cache")
+    assert full.messages == [{"role": "user", "content": "hi"}]
+    assert models.SESSIONS["sess_cache"] is full
+
+
+def test_session_save_does_not_persist_metadata_message_count_hint():
+    s = Session(
+        session_id="sess_private_hint",
+        title="Private Hint",
+        messages=[{"role": "user", "content": "hi"}],
+    )
+    s._metadata_message_count = 10
+    s.save(skip_index=True)
+
+    payload = json.loads(s.path.read_text(encoding="utf-8"))
+    assert "_metadata_message_count" not in payload
+
+
 # ── 8. test_first_call_full_rebuild ──────────────────────────────────────
 
 def test_first_call_full_rebuild():

--- a/tests/test_session_metadata_fast_path.py
+++ b/tests/test_session_metadata_fast_path.py
@@ -1,0 +1,51 @@
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_messages_zero_skips_effective_model_resolution():
+    src = (ROOT / "api" / "routes.py").read_text(encoding="utf-8")
+
+    assert re.search(
+        r"effective_model\s*=\s*\(\s*"
+        r"_resolve_effective_session_model_for_display\(s\)\s*"
+        r"if resolve_model\s*else None\s*\)",
+        src,
+    ), "messages=0 metadata requests must not resolve the model catalog"
+    assert 'resolve_model_default = "1" if load_messages else "0"' in src
+
+
+def test_full_message_load_updates_viewed_count_after_metadata_fast_path():
+    src = (ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
+
+    assert "_setSessionViewedCount(S.session.session_id, Number(data.session.message_count || 0));" in src
+    assert "_setSessionViewedCount(sid, Number(S.session.message_count || msgs.length));" in src
+
+
+def test_lazy_message_load_skips_model_resolution():
+    src = (ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
+
+    assert "messages=1&resolve_model=0" in src
+
+
+def test_session_switch_defers_model_resolution_without_blocking():
+    src = (ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
+    ui = (ROOT / "static" / "ui.js").read_text(encoding="utf-8")
+
+    assert "messages=0&resolve_model=0" in src
+    assert "function _resolveSessionModelForDisplaySoon" in src
+    assert "messages=0&resolve_model=1" in src
+    assert "_modelResolutionDeferred=true" in src
+    assert "deferModelCorrection" in ui
+    assert "if(!deferModelCorrection)" in ui
+
+
+def test_boot_does_not_block_session_restore_on_model_catalog():
+    src = (ROOT / "static" / "boot.js").read_text(encoding="utf-8")
+
+    assert "if(s.default_model) window._defaultModel=s.default_model;" in src
+    assert "const _modelDropdownReady=populateModelDropdown().then" in src
+    assert "window._modelDropdownReady=_modelDropdownReady" in src
+    assert "await populateModelDropdown()" not in src


### PR DESCRIPTION
## Attribution

This is a fresh PR carrying the exact code from **@franksong2702's** original PR #1001, which was closed when the repo briefly blocked new PRs. Full credit to Frank for the work.

Original PR: https://github.com/nesquena/hermes-webui/pull/1001

---

## Summary

This PR keeps large-session switching and hard reload from blocking on cold model-catalog resolution.

The main changes are:

- `GET /api/session?messages=0` now parses only the JSON metadata before the `messages` array instead of falling back to a full session load for large files.
- Metadata-only session loads no longer populate the full-session LRU cache, so a compact session object cannot hide the real message history on the next full load.
- Compact `message_count` is preserved from the session index, so the metadata response stays semantically correct.
- The frontend lazy message fetch uses `resolve_model=0` to avoid a second cold model-catalog lookup during session restore.
- Display-model normalization still runs, but asynchronously, so provider-mismatch behavior remains intact without blocking the switch.
- Hard reload no longer waits for `populateModelDropdown()` before restoring the saved session.
- `default_model` is initialized from `/api/settings`, so creating a new conversation remains correct even before the dynamic model dropdown finishes loading.

## Why

Large sessions could feel slow when switching or hard-refreshing because the read path still did work unrelated to rendering the conversation:

- metadata-only loads could fall back to parsing the full session JSON
- `/api/session` could trigger model catalog resolution
- boot waited for `/api/models`, which can be slow on a cold provider/model catalog

This keeps the session restore path focused on restoring the session first, while slower model catalog work settles in the background.

## Verification

- `python3 -m py_compile api/models.py api/routes.py`
- `pytest tests/test_session_index.py tests/test_session_metadata_fast_path.py tests/test_issue856_active_session_read_state.py tests/test_provider_mismatch.py tests/test_issues_907_908_909_model_dropdown.py tests/test_profile_default_workspace_823.py -q`

Local timing check on a large session:

- saved session metadata: ~3.7ms
- saved session full lazy payload: ~35.3ms
- `/api/models`: ~8.4s cold path, now background-only and no longer blocking saved session restore
