### PR TITLE
Harden auto title generation for reasoning models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
+- **Auto title generation is more robust for reasoning models** — title generation now uses a reasoning-safe completion budget, retries empty-content/length responses once with a larger budget, and preserves the underlying LLM failure reason in `title_status` when falling back to a local summary. This keeps the existing `auxiliary.title_generation` cheaper-model path intact while preventing reasoning-heavy models from silently falling back to first-message titles. (`api/streaming.py`, `tests/test_title_aux_routing.py`) Refs #869.
 - **Reasoning chip now appears after the model chip** in the composer toolbar — model is a more fundamental choice and should be stable in position regardless of whether reasoning is active. Order: Profile → Workspace → Model → Reasoning. (`static/index.html`)
 
 ## v0.50.206 — 2026-04-25

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -292,9 +292,71 @@ def _aux_title_timeout(default: float = 15.0) -> float:
         return default
 
 def _title_completion_budget(provider: str = '', model: str = '', base_url: str = '') -> int:
-    if _is_minimax_route(provider, model, base_url):
-        return 384
-    return 160
+    # Title generation is a small auxiliary task, but reasoning models may
+    # spend a surprising amount of the completion budget before emitting final
+    # content.  Keep the budget high enough for MiniMax/Kimi-style reasoning
+    # responses without making title generation depend on provider-specific
+    # one-off branches.
+    return 512
+
+
+def _title_retry_completion_budget(provider: str = '', model: str = '', base_url: str = '') -> int:
+    return max(1024, _title_completion_budget(provider, model, base_url) * 2)
+
+
+def _title_retry_status(status: str) -> bool:
+    return status in {
+        'llm_length',
+        'llm_length_aux',
+        'llm_empty_reasoning',
+        'llm_empty_reasoning_aux',
+    }
+
+
+def _safe_obj_value(obj, key: str):
+    if obj is None:
+        return None
+    if isinstance(obj, dict):
+        return obj.get(key)
+    value = getattr(obj, key, None)
+    # Missing MagicMock attrs stringify as mock reprs and look truthy.  Treat
+    # them as absent so tests model real provider objects accurately.
+    if value.__class__.__module__.startswith('unittest.mock'):
+        return None
+    return value
+
+
+def _safe_text_value(value) -> str:
+    if value is None:
+        return ''
+    if value.__class__.__module__.startswith('unittest.mock'):
+        return ''
+    return str(value or '').strip()
+
+
+def _extract_title_response(resp, *, aux: bool = False) -> tuple[str, str]:
+    """Return (content, empty_status) from an OpenAI-compatible response."""
+    suffix = '_aux' if aux else ''
+    try:
+        choices = _safe_obj_value(resp, 'choices') or []
+        choice = choices[0] if choices else None
+        message = _safe_obj_value(choice, 'message')
+        content = _safe_text_value(_safe_obj_value(message, 'content'))
+        if content:
+            return content, ''
+        finish_reason = _safe_text_value(_safe_obj_value(choice, 'finish_reason')).lower()
+        reasoning = (
+            _safe_text_value(_safe_obj_value(message, 'reasoning'))
+            or _safe_text_value(_safe_obj_value(message, 'reasoning_content'))
+            or _safe_text_value(_safe_obj_value(message, 'thinking'))
+        )
+        if finish_reason == 'length':
+            return '', f'llm_length{suffix}'
+        if reasoning:
+            return '', f'llm_empty_reasoning{suffix}'
+        return '', f'llm_empty{suffix}'
+    except Exception:
+        return '', f'llm_empty{suffix}'
 
 
 def generate_title_raw_via_aux(
@@ -308,41 +370,43 @@ def generate_title_raw_via_aux(
     if not user_text or not assistant_text:
         return None, 'missing_exchange'
     qa, prompts = _title_prompts(user_text, assistant_text)
-    max_tokens = _title_completion_budget(provider, model, base_url)
+    base_max_tokens = _title_completion_budget(provider, model, base_url)
     reasoning_extra = {"reasoning": {"enabled": False}}
     if _is_minimax_route(provider, model, base_url):
         reasoning_extra["reasoning_split"] = True
     try:
         _timeout = _aux_title_timeout()
         from agent.auxiliary_client import call_llm
+        last_status = 'llm_error_aux'
         for idx, prompt in enumerate(prompts):
             messages = [
                 {"role": "system", "content": prompt},
                 {"role": "user", "content": qa},
             ]
+            budgets = [base_max_tokens]
             try:
-                resp = call_llm(
-                    task='title_generation',
-                    provider=provider or None,
-                    model=model or None,
-                    base_url=base_url or None,
-                    messages=messages,
-                    max_tokens=max_tokens,
-                    temperature=0.2,
-                    timeout=_timeout,
-                    extra_body=reasoning_extra,
-                )
-                raw = ''
-                try:
-                    raw = resp.choices[0].message.content or ''
-                except Exception:
-                    raw = ''
-                raw = str(raw or '').strip()
-                if raw:
-                    return raw, ('llm_aux' if idx == 0 else 'llm_aux_retry')
+                for budget_idx, max_tokens in enumerate(budgets):
+                    resp = call_llm(
+                        task='title_generation',
+                        provider=provider or None,
+                        model=model or None,
+                        base_url=base_url or None,
+                        messages=messages,
+                        max_tokens=max_tokens,
+                        temperature=0.2,
+                        timeout=_timeout,
+                        extra_body=reasoning_extra,
+                    )
+                    raw, empty_status = _extract_title_response(resp, aux=True)
+                    if raw:
+                        return raw, ('llm_aux' if idx == 0 and budget_idx == 0 else 'llm_aux_retry')
+                    last_status = empty_status or 'llm_empty_aux'
+                    if budget_idx == 0 and _title_retry_status(last_status):
+                        budgets.append(_title_retry_completion_budget(provider, model, base_url))
             except Exception as e:
+                last_status = 'llm_error_aux'
                 logger.debug("Aux title generation attempt %s failed: %s", idx + 1, e)
-        return None, 'llm_error_aux'
+        return None, last_status
     except Exception as e:
         logger.debug("Aux title generation failed: %s", e)
         return None, 'llm_error_aux'
@@ -356,7 +420,7 @@ def generate_title_raw_via_agent(agent, user_text: str, assistant_text: str) -> 
         return None, 'missing_agent'
 
     qa, prompts = _title_prompts(user_text, assistant_text)
-    max_tokens = _title_completion_budget(
+    base_max_tokens = _title_completion_budget(
         getattr(agent, 'provider', ''),
         getattr(agent, 'model', ''),
         getattr(agent, 'base_url', ''),
@@ -370,57 +434,70 @@ def generate_title_raw_via_agent(agent, user_text: str, assistant_text: str) -> 
                 {"role": "system", "content": prompt},
                 {"role": "user", "content": qa},
             ]
+            budgets = [base_max_tokens]
             try:
-                raw = ""
-                if getattr(agent, 'api_mode', '') == 'codex_responses':
-                    codex_kwargs = agent._build_api_kwargs(api_messages)
-                    codex_kwargs.pop('tools', None)
-                    if 'max_output_tokens' in codex_kwargs:
-                        codex_kwargs['max_output_tokens'] = max_tokens
-                    resp = agent._run_codex_stream(codex_kwargs)
-                    assistant_message, _ = agent._normalize_codex_response(resp)
-                    raw = (assistant_message.content or '') if assistant_message else ''
-                elif getattr(agent, 'api_mode', '') == 'anthropic_messages':
-                    from agent.anthropic_adapter import build_anthropic_kwargs, normalize_anthropic_response
-                    ant_kwargs = build_anthropic_kwargs(
-                        model=agent.model,
-                        messages=api_messages,
-                        tools=None,
-                        max_tokens=max_tokens,
-                        reasoning_config=disabled_reasoning,
-                        is_oauth=getattr(agent, '_is_anthropic_oauth', False),
-                        preserve_dots=agent._anthropic_preserve_dots(),
-                        base_url=getattr(agent, '_anthropic_base_url', None),
-                    )
-                    resp = agent._anthropic_messages_create(ant_kwargs)
-                    assistant_message, _ = normalize_anthropic_response(
-                        resp, strip_tool_prefix=getattr(agent, '_is_anthropic_oauth', False)
-                    )
-                    raw = (assistant_message.content or '') if assistant_message else ''
-                else:
-                    api_kwargs = agent._build_api_kwargs(api_messages)
-                    api_kwargs.pop('tools', None)
-                    api_kwargs['temperature'] = 0.1
-                    api_kwargs['timeout'] = 15.0
-                    if _is_minimax_route(getattr(agent, 'provider', ''), getattr(agent, 'model', ''), getattr(agent, 'base_url', '')):
-                        extra_body = dict(api_kwargs.get('extra_body') or {})
-                        extra_body['reasoning_split'] = True
-                        api_kwargs['extra_body'] = extra_body
-                    if 'max_completion_tokens' in api_kwargs:
-                        api_kwargs['max_completion_tokens'] = max_tokens
+                last_status = 'llm_empty'
+                for budget_idx, max_tokens in enumerate(budgets):
+                    raw = ""
+                    empty_status = ''
+                    if getattr(agent, 'api_mode', '') == 'codex_responses':
+                        codex_kwargs = agent._build_api_kwargs(api_messages)
+                        codex_kwargs.pop('tools', None)
+                        if 'max_output_tokens' in codex_kwargs:
+                            codex_kwargs['max_output_tokens'] = max_tokens
+                        resp = agent._run_codex_stream(codex_kwargs)
+                        assistant_message, _ = agent._normalize_codex_response(resp)
+                        raw = (assistant_message.content or '') if assistant_message else ''
+                        if not raw:
+                            empty_status = 'llm_empty'
+                    elif getattr(agent, 'api_mode', '') == 'anthropic_messages':
+                        from agent.anthropic_adapter import build_anthropic_kwargs, normalize_anthropic_response
+                        ant_kwargs = build_anthropic_kwargs(
+                            model=agent.model,
+                            messages=api_messages,
+                            tools=None,
+                            max_tokens=max_tokens,
+                            reasoning_config=disabled_reasoning,
+                            is_oauth=getattr(agent, '_is_anthropic_oauth', False),
+                            preserve_dots=agent._anthropic_preserve_dots(),
+                            base_url=getattr(agent, '_anthropic_base_url', None),
+                        )
+                        resp = agent._anthropic_messages_create(ant_kwargs)
+                        assistant_message, _ = normalize_anthropic_response(
+                            resp, strip_tool_prefix=getattr(agent, '_is_anthropic_oauth', False)
+                        )
+                        raw = (assistant_message.content or '') if assistant_message else ''
+                        if not raw:
+                            empty_status = 'llm_empty'
                     else:
-                        api_kwargs['max_tokens'] = max_tokens
-                    resp = agent._ensure_primary_openai_client(reason='title_generation').chat.completions.create(
-                        **api_kwargs,
-                    )
-                    try:
-                        raw = resp.choices[0].message.content or ""
-                    except Exception:
-                        raw = ""
-                raw = str(raw or '').strip()
-                if raw:
-                    return raw, ('llm' if idx == 0 else 'llm_retry')
+                        api_kwargs = agent._build_api_kwargs(api_messages)
+                        api_kwargs.pop('tools', None)
+                        api_kwargs['temperature'] = 0.1
+                        api_kwargs['timeout'] = 15.0
+                        if _is_minimax_route(getattr(agent, 'provider', ''), getattr(agent, 'model', ''), getattr(agent, 'base_url', '')):
+                            extra_body = dict(api_kwargs.get('extra_body') or {})
+                            extra_body['reasoning_split'] = True
+                            api_kwargs['extra_body'] = extra_body
+                        if 'max_completion_tokens' in api_kwargs:
+                            api_kwargs['max_completion_tokens'] = max_tokens
+                        else:
+                            api_kwargs['max_tokens'] = max_tokens
+                        resp = agent._ensure_primary_openai_client(reason='title_generation').chat.completions.create(
+                            **api_kwargs,
+                        )
+                        raw, empty_status = _extract_title_response(resp)
+                    raw = str(raw or '').strip()
+                    if raw:
+                        return raw, ('llm' if idx == 0 and budget_idx == 0 else 'llm_retry')
+                    last_status = empty_status or 'llm_empty'
+                    if budget_idx == 0 and _title_retry_status(last_status):
+                        budgets.append(_title_retry_completion_budget(
+                            getattr(agent, 'provider', ''),
+                            getattr(agent, 'model', ''),
+                            getattr(agent, 'base_url', ''),
+                        ))
             except Exception as e:
+                last_status = 'llm_error'
                 logger.debug(
                     "Agent title generation attempt %s failed: provider=%s model=%s error=%s",
                     idx + 1,
@@ -428,7 +505,7 @@ def generate_title_raw_via_agent(agent, user_text: str, assistant_text: str) -> 
                     getattr(agent, 'model', None),
                     e,
                 )
-        return None, 'llm_error'
+        return None, last_status
     except Exception as e:
         logger.debug("Agent title generation failed: %s", e)
         return None, 'llm_error'
@@ -611,6 +688,11 @@ def _run_background_title_update(session_id: str, user_text: str, assistant_text
             if next_title:
                 logger.debug("Using local fallback for session title generation")
                 source = 'fallback'
+        fallback_reason = (
+            f'local_summary:{llm_status}'
+            if source == 'fallback' and llm_status
+            else 'local_summary'
+        )
         wrote_title = False
         effective_title = current
         if next_title:
@@ -638,7 +720,7 @@ def _run_background_title_update(session_id: str, user_text: str, assistant_text
 
         if wrote_title:
             if source == 'fallback':
-                _put_title_status(put_event, session_id, source, 'local_summary', effective_title, raw_preview)
+                _put_title_status(put_event, session_id, source, fallback_reason, effective_title, raw_preview)
             else:
                 _put_title_status(put_event, session_id, source, llm_status, effective_title, raw_preview)
             put_event('title', {'session_id': session_id, 'title': effective_title})

--- a/tests/test_title_aux_routing.py
+++ b/tests/test_title_aux_routing.py
@@ -72,9 +72,14 @@ class TestGenerateTitleRawViaAuxTimeout(unittest.TestCase):
     def _run_with_config(self, tg_config, expected_timeout):
         from api.streaming import generate_title_raw_via_aux
 
-        mock_resp = MagicMock()
-        mock_resp.choices = [MagicMock()]
-        mock_resp.choices[0].message.content = 'Test Title'
+        mock_resp = types.SimpleNamespace(
+            choices=[
+                types.SimpleNamespace(
+                    message=types.SimpleNamespace(content='Test Title'),
+                    finish_reason='stop',
+                )
+            ]
+        )
 
         captured = {}
 
@@ -116,6 +121,153 @@ class TestGenerateTitleRawViaAuxTimeout(unittest.TestCase):
             {'provider': '', 'model': 'gpt-4o', 'base_url': '', 'timeout': None},
             15.0,
         )
+
+
+class TestReasoningModelTitleGeneration(unittest.TestCase):
+    """Regression coverage for reasoning models that spend output budget on reasoning."""
+
+    def test_title_budget_defaults_to_reasoning_safe_value(self):
+        """Title generation should not use a tiny output cap that starves final content."""
+        from api.streaming import _title_completion_budget, _title_retry_completion_budget
+
+        self.assertEqual(_title_completion_budget(), 512)
+        self.assertEqual(_title_retry_completion_budget(), 1024)
+
+    def test_aux_retries_empty_reasoning_length_response_with_larger_budget(self):
+        """If a reasoning model returns empty content at finish_reason=length, retry once."""
+        from api.streaming import generate_title_raw_via_aux
+
+        responses = [
+            {
+                'choices': [
+                    {
+                        'message': {'content': '', 'reasoning': 'long hidden reasoning'},
+                        'finish_reason': 'length',
+                    }
+                ]
+            },
+            {'choices': [{'message': {'content': 'Useful Session Title'}, 'finish_reason': 'stop'}]},
+        ]
+        captured_budgets = []
+
+        def fake_call_llm(**kwargs):
+            captured_budgets.append(kwargs.get('max_tokens'))
+            return responses.pop(0)
+
+        with _patch_tg_config({'provider': 'ollama', 'model': 'kimi-k2.6', 'base_url': 'https://ollama.com/v1'}):
+            with patch('agent.auxiliary_client.call_llm', side_effect=fake_call_llm, create=True):
+                result, status = generate_title_raw_via_aux(
+                    user_text='Hey nur ein kurzer Test',
+                    assistant_text='Alles klar, ich helfe dir dabei.',
+                )
+
+        self.assertEqual(result, 'Useful Session Title')
+        self.assertEqual(status, 'llm_aux_retry')
+        self.assertEqual(captured_budgets, [512, 1024])
+
+    def test_aux_returns_specific_status_when_reasoning_retry_still_empty(self):
+        """Diagnostics should expose the provider failure mode instead of generic llm_error_aux."""
+        from api.streaming import generate_title_raw_via_aux
+
+        def empty_length_response(**kwargs):
+            return {
+                'choices': [
+                    {
+                        'message': {'content': '', 'reasoning': 'still reasoning'},
+                        'finish_reason': 'length',
+                    }
+                ]
+            }
+
+        with _patch_tg_config({'provider': 'ollama', 'model': 'kimi-k2.6', 'base_url': 'https://ollama.com/v1'}):
+            with patch('agent.auxiliary_client.call_llm', side_effect=empty_length_response, create=True):
+                result, status = generate_title_raw_via_aux(
+                    user_text='Hey nur ein kurzer Test',
+                    assistant_text='Alles klar, ich helfe dir dabei.',
+                )
+
+        self.assertIsNone(result)
+        self.assertEqual(status, 'llm_length_aux')
+
+    def test_agent_route_retries_empty_reasoning_length_response(self):
+        """The active-agent route should get the same reasoning-model retry path as aux."""
+        from api.streaming import generate_title_raw_via_agent
+
+        responses = [
+            {
+                'choices': [
+                    {
+                        'message': {'content': '', 'reasoning': 'long hidden reasoning'},
+                        'finish_reason': 'length',
+                    }
+                ]
+            },
+            {'choices': [{'message': {'content': 'Agent Session Title'}, 'finish_reason': 'stop'}]},
+        ]
+        captured_budgets = []
+
+        def fake_create(**kwargs):
+            captured_budgets.append(kwargs.get('max_tokens') or kwargs.get('max_completion_tokens'))
+            return responses.pop(0)
+
+        client = types.SimpleNamespace(
+            chat=types.SimpleNamespace(
+                completions=types.SimpleNamespace(create=fake_create)
+            )
+        )
+        agent = MagicMock()
+        agent.api_mode = 'openai'
+        agent.provider = 'ollama'
+        agent.model = 'kimi-k2.6'
+        agent.base_url = 'https://ollama.com/v1'
+        agent.reasoning_config = None
+        agent._build_api_kwargs.return_value = {}
+        agent._ensure_primary_openai_client.return_value = client
+
+        result, status = generate_title_raw_via_agent(
+            agent,
+            user_text='Hey nur ein kurzer Test',
+            assistant_text='Alles klar, ich helfe dir dabei.',
+        )
+
+        self.assertEqual(result, 'Agent Session Title')
+        self.assertEqual(status, 'llm_retry')
+        self.assertEqual(captured_budgets, [512, 1024])
+        self.assertIsNone(agent.reasoning_config)
+
+    @patch('api.streaming._aux_title_configured', return_value=True)
+    @patch('api.streaming._generate_llm_session_title_via_aux')
+    @patch('api.streaming.get_session')
+    def test_fallback_title_status_keeps_underlying_llm_reason(
+        self, mock_get_session, mock_aux_title, mock_configured,
+    ):
+        """Local fallback should not hide that the LLM failed because it hit length."""
+        from api.streaming import _run_background_title_update
+
+        mock_session = MagicMock()
+        mock_session.title = 'Untitled'
+        mock_session.llm_title_generated = False
+        mock_session.messages = [
+            {'role': 'user', 'content': 'Hey nur ein kurzer Test'},
+            {'role': 'assistant', 'content': 'Alles klar, ich helfe dir dabei.'},
+        ]
+        mock_get_session.return_value = mock_session
+        mock_aux_title.return_value = (None, 'llm_length_aux', '')
+        events = []
+
+        _run_background_title_update(
+            session_id='reasoning-title-session',
+            user_text='Hey nur ein kurzer Test',
+            assistant_text='Alles klar, ich helfe dir dabei.',
+            placeholder_title='Untitled',
+            put_event=lambda event_type, data: events.append((event_type, data)),
+            agent=None,
+        )
+
+        title_status = [data for event_type, data in events if event_type == 'title_status']
+        self.assertTrue(title_status)
+        self.assertEqual(title_status[0]['status'], 'fallback')
+        self.assertEqual(title_status[0]['reason'], 'local_summary:llm_length_aux')
 
 
 class TestAuxTitleTimeoutEdgeCases(unittest.TestCase):


### PR DESCRIPTION
## Attribution

This is a fresh PR carrying the exact code from **@franksong2702's** original PR #1002, which was closed when the repo briefly blocked new PRs. Full credit to Frank for the work.

Original PR: https://github.com/nesquena/hermes-webui/pull/1002

---

## Summary

This fixes the concrete first-exchange title-generation failure discussed in #869 for reasoning-style models such as Ollama Cloud `kimi-k2.6`.

The root cause is not title quality. It is an output-budget / response-shape mismatch: reasoning models can spend the completion budget in `reasoning` and return empty `content` with `finish_reason: length`, so Hermes falls back to the first-message local summary.

## Changes

- Raises the title-generation completion budget to a reasoning-safe `512` tokens.
- Retries once with `1024` tokens when the response is empty because of `finish_reason: length` or reasoning-only output.
- Applies the same retry policy to both routes:
  - configured `auxiliary.title_generation` route
  - active-agent fallback route
- Preserves MiniMax `reasoning_split` as a provider-specific enhancement, but no longer treats MiniMax as the only reasoning-model case.
- Improves diagnostics: when local fallback is used, `title_status` now preserves the underlying reason, e.g. `local_summary:llm_length_aux`.
- Keeps the existing `auxiliary.title_generation` path intact so users can still route title generation to a cheaper/faster dedicated model.

## Scope

This PR targets the bug side of #869: provisional first-message titles not being replaced after the first assistant reply when title generation returns empty content.

It does not implement continuous title re-summarization as the conversation evolves. That remains a separate feature/design scope.

## Verification

- `python3 -m py_compile api/streaming.py`
- `pytest tests/test_title_aux_routing.py -q`
- `pytest tests/test_sprint41.py tests/test_title_sanitization.py tests/test_issues_853_857.py tests/test_title_aux_routing.py -q`
