### PR TITLE
fix(i18n): remove 3 orphaned locale keys leaking into language dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
+- **Language dropdown no longer shows invalid i18n key entries** — three Traditional Chinese translation keys (`cmd_status`, `memory_saved`, `profile_delete_title`) were placed outside any locale block in `static/i18n.js`, between the closing `}` of the `en` block and the opening `ru: {`. Since `panels.js` iterates `Object.entries(LOCALES)` to populate the language `<select>`, these orphaned keys appeared as invalid language options. Fixed by removing the duplicate orphaned entries — the correct translations already exist inside the `zh-Hant` locale block. (`static/i18n.js`) Closes #1008.
 - **Reasoning chip now appears after the model chip** in the composer toolbar — model is a more fundamental choice and should be stable in position regardless of whether reasoning is active. Order: Profile → Workspace → Model → Reasoning. (`static/index.html`)
 
 ## v0.50.206 — 2026-04-25

--- a/static/i18n.js
+++ b/static/i18n.js
@@ -605,9 +605,6 @@ const LOCALES = {
     profile_api_key_label: 'API key',
   },
 
-    cmd_status: '\u986f\u793a\u6703\u8a71\u8cc7\u8a0a',
-    memory_saved: '\u8a18\u61b6\u5df2\u5132\u5b58',
-    profile_delete_title: '\u522a\u9664\u6b64\u8a2d\u5b9a\u6a94',
   ru: {
     _lang: 'ru',
     _label: 'Русский',


### PR DESCRIPTION
## Summary

Fix the language dropdown in **Settings > Preferences** showing three invalid entries: `cmd_status`, `memory_saved`, and `profile_delete_title`.

## Root cause

In `static/i18n.js`, three Traditional Chinese translation keys were placed *outside* any locale block — between the closing `}` of the `en` block and the opening `ru: {`:

```js
  },  // ← en block closes here

    cmd_status: '顯示會話資訊',       // ← orphaned — not inside any locale
    memory_saved: '記憶已儲存',
    profile_delete_title: '刪除此設定檔',
  ru: {
```

`panels.js` populates the language `<select>` by iterating `Object.entries(LOCALES)`. These orphaned keys became top-level properties of the `LOCALES` object, so they appeared as selectable language options named `cmd_status`, `memory_saved`, and `profile_delete_title`.

## Fix

Remove the three orphaned lines. The correct Traditional Chinese translations for all three keys already exist inside the `zh-Hant` locale block (intact, untouched by this PR).

## Changes

- `static/i18n.js` — remove 3 orphaned lines (net: −3 lines)
- `CHANGELOG.md` — entry added

## Testing

- 2133/2133 tests pass
- Language dropdown no longer shows invalid entries after fix

Closes #1008
