### PR TITLE
Fix/cache AIAgent per session to fix Honcho injectionFrequency

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -1704,6 +1704,18 @@ AGENT_INSTANCES: dict = {}  # stream_id -> AIAgent instance for interrupt propag
 STREAM_PARTIAL_TEXT: dict = {}  # stream_id -> partial assistant text accumulated during streaming
 SERVER_START_TIME = time.time()
 
+# Agent cache: reuse AIAgent across messages in the same WebUI session so that
+# _user_turn_count survives between turns.  This mirrors the gateway's
+# _agent_cache pattern and is required for injectionFrequency: "first-turn".
+SESSION_AGENT_CACHE: dict = {}   # session_id -> (AIAgent, config_sig)
+SESSION_AGENT_CACHE_LOCK = threading.Lock()
+
+
+def _evict_session_agent(session_id: str) -> None:
+    """Remove a cached agent for a session (on delete, clear, or model switch)."""
+    with SESSION_AGENT_CACHE_LOCK:
+        SESSION_AGENT_CACHE.pop(session_id, None)
+
 # ── Thread-local env context ─────────────────────────────────────────────────
 _thread_ctx = threading.local()
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -1224,6 +1224,9 @@ def handle_post(handler, parsed) -> bool:
         # Delete from WebUI session store
         with LOCK:
             SESSIONS.pop(sid, None)
+        # Evict cached agent so turn count doesn't leak into a recycled session
+        from api.config import _evict_session_agent
+        _evict_session_agent(sid)
         try:
             p = (SESSION_DIR / f"{sid}.json").resolve()
             p.relative_to(SESSION_DIR.resolve())
@@ -1264,6 +1267,9 @@ def handle_post(handler, parsed) -> bool:
             s.tool_calls = []
             s.title = "Untitled"
             s.save()
+            # Evict cached agent — cleared session is a fresh conversation
+            from api.config import _evict_session_agent
+            _evict_session_agent(body["session_id"])
         return j(handler, {"ok": True, "session": s.compact()})
 
     if parsed.path == "/api/session/truncate":

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -1398,7 +1398,56 @@ def _run_agent_streaming(session_id, msg_text, model, workspace, stream_id, atta
             if 'gateway_session_key' in _agent_params:
                 _agent_kwargs['gateway_session_key'] = session_id
 
-            agent = _AIAgent(**_agent_kwargs)
+            # ── Agent cache: reuse across messages in the same session ──
+            # Mirrors gateway _agent_cache.  Keeps _user_turn_count alive so
+            # injectionFrequency: "first-turn" actually suppresses after turn 1.
+            if ephemeral:
+                agent = _AIAgent(**_agent_kwargs)
+                logger.debug('[webui] Created ephemeral agent for session %s', session_id)
+            else:
+                import hashlib as _hashlib
+                import json as _json
+                from api.config import SESSION_AGENT_CACHE, SESSION_AGENT_CACHE_LOCK
+                _sig_blob = _json.dumps([
+                    resolved_model or '',
+                    _hashlib.sha256((resolved_api_key or '').encode()).hexdigest()[:16],
+                    resolved_base_url or '',
+                    resolved_provider or '',
+                    sorted(_toolsets) if _toolsets else [],
+                ], sort_keys=True)
+                _agent_sig = _hashlib.sha256(_sig_blob.encode()).hexdigest()[:16]
+
+                agent = None
+                with SESSION_AGENT_CACHE_LOCK:
+                    _cached = SESSION_AGENT_CACHE.get(session_id)
+                    if _cached and _cached[1] == _agent_sig:
+                        agent = _cached[0]
+                        logger.debug('[webui] Reusing cached agent for session %s', session_id)
+
+                if agent is not None:
+                    # Refresh per-turn callbacks — these close over request-scoped
+                    # objects (put queue, cancel_event) that are new each request.
+                    agent.stream_delta_callback = _agent_kwargs.get('stream_delta_callback')
+                    agent.tool_progress_callback = _agent_kwargs.get('tool_progress_callback')
+                    if hasattr(agent, 'reasoning_callback'):
+                        agent.reasoning_callback = _agent_kwargs.get('reasoning_callback')
+                    if hasattr(agent, 'clarify_callback'):
+                        agent.clarify_callback = _agent_kwargs.get('clarify_callback')
+                    if _session_db is not None:
+                        agent._session_db = _session_db
+                    if hasattr(agent, '_api_call_count'):
+                        agent._api_call_count = 0
+                    # Reset interrupt state from a prior cancel so the reused
+                    # agent does not think it is still interrupted.
+                    if hasattr(agent, '_interrupted'):
+                        agent._interrupted = False
+                    if hasattr(agent, '_interrupt_message'):
+                        agent._interrupt_message = None
+                else:
+                    agent = _AIAgent(**_agent_kwargs)
+                    with SESSION_AGENT_CACHE_LOCK:
+                        SESSION_AGENT_CACHE[session_id] = (agent, _agent_sig)
+                    logger.debug('[webui] Created new agent for session %s', session_id)
 
             # Store agent instance for cancel/interrupt propagation
             with STREAMS_LOCK:
@@ -1648,6 +1697,13 @@ def _run_agent_streaming(session_id, msg_text, model, workspace, stream_id, atta
                     with SESSION_AGENT_LOCKS_LOCK:
                         SESSION_AGENT_LOCKS[new_sid] = _agent_lock
                         SESSION_AGENT_LOCKS.pop(old_sid, None)
+                    # Migrate cached agent to the new session ID so the turn
+                    # count survives context compression.
+                    from api.config import SESSION_AGENT_CACHE, SESSION_AGENT_CACHE_LOCK
+                    with SESSION_AGENT_CACHE_LOCK:
+                        _cached_entry = SESSION_AGENT_CACHE.pop(old_sid, None)
+                        if _cached_entry:
+                            SESSION_AGENT_CACHE[new_sid] = _cached_entry
                     if old_path.exists() and not new_path.exists():
                         try:
                             old_path.rename(new_path)


### PR DESCRIPTION
### Problem

The WebUI creates a fresh `AIAgent` on every chat message via `_run_agent_streaming()`. A fresh agent has `_user_turn_count = 0`, so `on_turn_start(1, ...)` fires every time. The Honcho plugin's guard:

```python
if self._injection_frequency == "first-turn" and self._turn_count > 1:
    return ""
```

...never triggers. Context is injected on every turn regardless of the `injectionFrequency` setting in `honcho.json`.

The gateway (`gateway/run.py`) already solved this with `_agent_cache`. The WebUI never adopted the pattern.

### Solution

Cache `AIAgent` instances per WebUI session, keyed by a config signature (model, API key hash, base URL, provider, toolsets). On cache hit, refresh per-turn callbacks (which close over request-scoped objects), reset interrupt state, and reuse the agent. On signature mismatch, create a fresh agent.

Ephemeral sessions (`/btw`, `/background`) bypass the cache entirely since they are deleted immediately after use.

When context compression rotates the session ID, the cache entry is migrated to the new ID so the turn count survives.

Evict cached agents on session delete and session clear to prevent stale turn counts from suppressing first-turn injection in new conversations.

### Files Changed

- **`api/config.py`** — Add `SESSION_AGENT_CACHE`, lock, and eviction helper
- **`api/streaming.py`** — Cache-check before `AIAgent` construction; interrupt state reset on reuse; ephemeral bypass; cache migration on session ID rotation
- **`api/routes.py`** — Evict on session delete and session clear

### Also Fixes

All turn-dependent Honcho features that were silently broken:
- `contextCadence` (minimum turns between context API calls)
- `dialecticCadence` (minimum turns between dialectic calls)
- `flush_min_turns` (observation flush threshold)