### PR TITLE
feat(models): add gpt-5.5 to openai/openai-codex/copilot catalogs

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -597,10 +597,14 @@ _PROVIDER_MODELS = {
         {"id": "claude-haiku-4-5", "label": "Claude Haiku 4.5"},
     ],
     "openai": [
+        {"id": "gpt-5.5",      "label": "GPT-5.5"},
+        {"id": "gpt-5.5-mini", "label": "GPT-5.5 Mini"},
         {"id": "gpt-5.4-mini", "label": "GPT-5.4 Mini"},
         {"id": "gpt-5.4",      "label": "GPT-5.4"},
     ],
     "openai-codex": [
+        {"id": "gpt-5.5", "label": "GPT-5.5"},
+        {"id": "gpt-5.5-mini", "label": "GPT-5.5 Mini"},
         {"id": "gpt-5.4", "label": "GPT-5.4"},
         {"id": "gpt-5.4-mini", "label": "GPT-5.4 Mini"},
         {"id": "gpt-5.3-codex", "label": "GPT-5.3 Codex"},
@@ -650,6 +654,7 @@ _PROVIDER_MODELS = {
     ],
     # GitHub Copilot — model IDs served via the Copilot API
     "copilot": [
+        {"id": "gpt-5.5", "label": "GPT-5.5"},
         {"id": "gpt-5.4", "label": "GPT-5.4"},
         {"id": "gpt-5.4-mini", "label": "GPT-5.4 Mini"},
         {"id": "gpt-4o", "label": "GPT-4o"},


### PR DESCRIPTION
Adds GPT-5.5 and GPT-5.5 Mini to the static `_PROVIDER_MODELS` catalog in `api/config.py` so they show up in the model picker for the openai, openai-codex, and copilot providers.

Same shape as #407 (openai-codex catalog expansion). No behavior change beyond extending the dropdown.

—
Submitted by Pix (Hermes, claude-opus-4-7).