### PR TITLE
fix(pwa): redirect to /login client-side on 401 — fixes iOS PWA auth expiry (#1038)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
+- **iOS PWA auth redirect** — when an auth session expires, all API calls now detect the 401 and redirect to `/login` client-side instead of relying on a server-side 302. This fixes the iOS home-screen PWA getting permanently stuck on "Authentication required" with no way to re-authenticate without deleting and re-adding the PWA. (`static/workspace.js`, `static/ui.js`) [#1038]
 
 ## v0.50.207 — 2026-04-25
 

--- a/static/ui.js
+++ b/static/ui.js
@@ -9,6 +9,10 @@ const SESSION_QUEUES={};  // keyed by session_id for queued follow-up turns
 // single-threaded so only one done event fires at a time in practice.
 let _queueDrainSid=null;
 const $=id=>document.getElementById(id);
+// Redirect to /login when the server responds with 401 (auth session expired).
+// Handles iOS PWA standalone mode where a server-side 302→/login would break
+// out of the PWA shell into Safari instead of navigating within it.
+function _redirectIfUnauth(res){if(res&&res.status===401){window.location.href='/login';return true;}return false;}
 function _getSessionQueue(sid, create=false){
   if(!sid) return [];
   if(!SESSION_QUEUES[sid]&&create) SESSION_QUEUES[sid]=[];
@@ -87,7 +91,9 @@ async function populateModelDropdown(){
   const sel=$('modelSelect');
   if(!sel) return;
   try{
-    const data=await fetch(new URL('api/models',location.href).href,{credentials:'include'}).then(r=>r.json());
+    const _modelsRes=await fetch(new URL('api/models',location.href).href,{credentials:'include'});
+    if(_redirectIfUnauth(_modelsRes)) return;
+    const data=await _modelsRes.json();
     if(!data.groups||!data.groups.length) return; // keep HTML defaults
     // Store active provider globally so the send path can warn on mismatch
     window._activeProvider=data.active_provider||null;
@@ -191,7 +197,9 @@ async function _fetchLiveModels(provider, sel){
   try{
     const url=new URL('api/models/live',location.href);
     url.searchParams.set('provider',provider);
-    const data=await fetch(url.href,{credentials:'include'}).then(r=>r.json());
+    const _liveRes=await fetch(url.href,{credentials:'include'});
+    if(_redirectIfUnauth(_liveRes)) return;
+    const data=await _liveRes.json();
     if(!data.models||!data.models.length) return;
     _liveModelCache[provider]=data.models;
     const added=_addLiveModelsToSelect(provider,data.models,sel);
@@ -2829,6 +2837,7 @@ async function uploadPendingFiles(){
     fd.append('session_id',S.session.session_id);fd.append('file',f,f.name);
     try{
       const res=await fetch(new URL('api/upload',location.href).href,{method:'POST',credentials:'include',body:fd});
+      if(_redirectIfUnauth(res)) return;
       if(!res.ok){const err=await res.text();throw new Error(err);}
       const data=await res.json();
       if(data.error)throw new Error(data.error);

--- a/static/workspace.js
+++ b/static/workspace.js
@@ -4,6 +4,10 @@ async function api(path,opts={}){
   const url=new URL(rel,location.href);
   const res=await fetch(url.href,{credentials:'include',headers:{'Content-Type':'application/json'},...opts});
   if(!res.ok){
+    // 401 means the auth session expired. Redirect to /login so the user can
+    // re-authenticate. This is especially important for iOS PWA (standalone mode)
+    // where a server-side 302 → /login opens in Safari instead of within the PWA.
+    if(res.status===401){window.location.href='/login';return;}
     const text=await res.text();
     // Parse JSON error body and surface the human-readable message,
     // rather than showing raw JSON like {"error":"Profile 'x' does not exist."}

--- a/tests/test_1038_pwa_auth_redirect.py
+++ b/tests/test_1038_pwa_auth_redirect.py
@@ -1,0 +1,72 @@
+"""
+Tests for issue #1038 — iOS PWA auth-expiry redirect.
+
+When a 401 is returned by any API endpoint, the client-side JS should redirect
+to /login rather than showing a raw error toast. On iOS PWA standalone mode a
+server-side 302→/login breaks out of the PWA shell into Safari, so the fix is
+client-side: workspace.js api() intercepts 401 before throwing and calls
+window.location.href = '/login'.
+
+These are static regression tests that verify the JS source contains the
+correct guard patterns.
+"""
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).parent.parent
+
+
+def _workspace_js() -> str:
+    return (ROOT / "static" / "workspace.js").read_text(encoding="utf-8")
+
+
+def _ui_js() -> str:
+    return (ROOT / "static" / "ui.js").read_text(encoding="utf-8")
+
+
+class TestPWAAuthRedirect:
+    def test_workspace_js_has_401_redirect(self):
+        """api() in workspace.js must redirect to /login on 401."""
+        src = _workspace_js()
+        # Guard must appear inside the !res.ok block, before throwing
+        assert "res.status===401" in src, \
+            "workspace.js api() must check res.status===401"
+        assert "window.location.href='/login'" in src or \
+               'window.location.href="/login"' in src, \
+            "workspace.js api() must redirect to /login on 401"
+
+    def test_workspace_js_401_before_throw(self):
+        """The 401 redirect must come before the generic error throw."""
+        src = _workspace_js()
+        idx_401 = src.find("res.status===401")
+        idx_throw = src.find("throw new Error")
+        assert idx_401 != -1, "401 guard not found in workspace.js"
+        assert idx_throw != -1, "throw not found in workspace.js"
+        assert idx_401 < idx_throw, \
+            "401 redirect must appear before the generic throw in workspace.js"
+
+    def test_ui_js_has_redirect_helper(self):
+        """ui.js must define _redirectIfUnauth helper."""
+        src = _ui_js()
+        assert "_redirectIfUnauth" in src, \
+            "ui.js must define _redirectIfUnauth helper function"
+
+    def test_ui_js_models_fetch_uses_redirect(self):
+        """populateModelDropdown() must call _redirectIfUnauth on the api/models response."""
+        src = _ui_js()
+        # The helper must be called after the api/models fetch
+        assert "_redirectIfUnauth(_modelsRes)" in src, \
+            "populateModelDropdown() must check 401 on api/models fetch"
+
+    def test_ui_js_live_models_fetch_uses_redirect(self):
+        """loadLiveModels() must call _redirectIfUnauth on the api/models/live response."""
+        src = _ui_js()
+        assert "_redirectIfUnauth(_liveRes)" in src, \
+            "loadLiveModels() must check 401 on api/models/live fetch"
+
+    def test_ui_js_upload_fetch_uses_redirect(self):
+        """File upload must call _redirectIfUnauth on the api/upload response."""
+        src = _ui_js()
+        assert "_redirectIfUnauth(res)" in src, \
+            "upload fetch must call _redirectIfUnauth"


### PR DESCRIPTION
## Summary

Fixes #1038 — iOS home-screen PWA gets permanently stuck on "Authentication required" when the auth session expires, with no way to re-login.

## Root cause

When auth expires, the server sends a `302 → /login` redirect for page requests. In a normal browser this works correctly. But in iOS Safari PWA standalone mode (`navigator.standalone === true`), navigation to a different origin URL (`/login`) breaks out of the PWA shell and opens in Safari — leaving the PWA stuck on the error screen with no recovery path other than deleting and re-adding the PWA from Safari.

## Fix

Intercept 401 responses **client-side** before surfacing any error, and navigate to `/login` directly from JS. This keeps navigation within the PWA shell on iOS and also improves the session-expiry UX in regular browsers (instant redirect instead of a confusing error toast).

**`static/workspace.js` — `api()` wrapper:**
```js
if(res.status===401){window.location.href='/login';return;}
```

**`static/ui.js`:**
- Added `_redirectIfUnauth(res)` helper at the top
- Wired into all three direct `fetch()` calls that bypass `api()`: `api/models` (model dropdown), `api/models/live` (live model list), `api/upload` (file upload)

The SSE streaming path (`EventSource`) uses cookies and the `/api/chat/start` POST goes through `api()`, so it's covered by the workspace.js fix.

## Tests

6 static regression tests in `tests/test_1038_pwa_auth_redirect.py`:
- `workspace.js` has `res.status===401` guard + `window.location.href='/login'`
- 401 guard appears before the generic `throw` (order matters)
- `ui.js` defines `_redirectIfUnauth` helper
- `api/models`, `api/models/live`, `api/upload` fetches all call `_redirectIfUnauth`

**2175/2175 tests passing.**
