### PR TITLE
fix(renderer): suppress Mermaid Google Fonts CSP violation via fontFamily inherit (#1044)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
+- **Mermaid CSP font fix** — added `fontFamily: 'inherit'` and `fontSize: '14px'` to the mermaid `themeVariables` block so Mermaid no longer requests the Manrope font from `fonts.googleapis.com` at render time. Eliminates CSP `style-src` violations on every diagram render; diagram text now uses the page's own font stack. (`static/ui.js`) [#1044]
 
 ## v0.50.209 — 2026-04-25
 

--- a/static/ui.js
+++ b/static/ui.js
@@ -2682,6 +2682,7 @@ function renderMermaidBlocks(){
       script.onload=()=>{
         if(typeof mermaid!=='undefined'){
           mermaid.initialize({startOnLoad:false,theme:document.documentElement.classList.contains('dark')?'dark':'default',themeVariables:{
+            fontFamily:'inherit',fontSize:'14px',
             primaryColor:'#4a6fa5',primaryTextColor:'#e2e8f0',lineColor:'#718096',
             secondaryColor:'#2d3748',tertiaryColor:'#1a202c',primaryBorderColor:'#4a5568',
           }});

--- a/tests/test_1044_mermaid_csp_font.py
+++ b/tests/test_1044_mermaid_csp_font.py
@@ -1,0 +1,51 @@
+"""
+Tests for issue #1044 — Mermaid CSP font violation.
+
+Mermaid's built-in themes inject an @import for Google Fonts (Manrope) at
+render time, which is blocked by the CSP's style-src directive. Fix: pass
+fontFamily:'inherit' in themeVariables so Mermaid never requests an external
+font URL.
+"""
+
+from pathlib import Path
+
+ROOT = Path(__file__).parent.parent
+
+
+def _ui_js() -> str:
+    return (ROOT / "static" / "ui.js").read_text(encoding="utf-8")
+
+
+class TestMermaidCSPFont:
+    def test_mermaid_init_has_font_family_inherit(self):
+        """themeVariables in mermaid.initialize() must set fontFamily to 'inherit'."""
+        src = _ui_js()
+        assert "fontFamily:'inherit'" in src, (
+            "mermaid.initialize() themeVariables must set fontFamily:'inherit' "
+            "to suppress the Google Fonts (Manrope) import that violates CSP"
+        )
+
+    def test_mermaid_init_no_google_fonts_url(self):
+        """ui.js must not contain a hardcoded fonts.googleapis.com URL."""
+        src = _ui_js()
+        assert "fonts.googleapis.com" not in src, (
+            "ui.js must not reference fonts.googleapis.com — use fontFamily:'inherit'"
+        )
+
+    def test_mermaid_font_family_inside_theme_variables_block(self):
+        """fontFamily:'inherit' must be inside the themeVariables block of mermaid.initialize()."""
+        src = _ui_js()
+        init_idx = src.find("mermaid.initialize(")
+        assert init_idx != -1, "mermaid.initialize() call not found in ui.js"
+        # Find the themeVariables block after the initialize call
+        tv_idx = src.find("themeVariables", init_idx)
+        assert tv_idx != -1, "themeVariables not found inside mermaid.initialize()"
+        font_idx = src.find("fontFamily:'inherit'", tv_idx)
+        assert font_idx != -1, (
+            "fontFamily:'inherit' must appear inside themeVariables in mermaid.initialize()"
+        )
+        # The closing brace of themeVariables should come after fontFamily
+        close_brace = src.find("})", tv_idx)
+        assert font_idx < close_brace, (
+            "fontFamily:'inherit' must be inside the themeVariables block (before })"
+        )


### PR DESCRIPTION
## Summary

Fixes #1044 — mermaid diagram blocks trigger CSP `style-src` violations because Mermaid's built-in themes inject `@import url('https://fonts.googleapis.com/css2?family=Manrope...')` into generated SVGs at render time. The CSP only allows `cdn.jsdelivr.net`, so the request is blocked and the browser console fills with errors on any page containing a diagram.

## Root cause

`mermaid.initialize()` in `renderMermaidBlocks()` sets `theme: 'dark'` or `'default'` but does not override `fontFamily`. Both built-in Mermaid themes pull in Google Fonts (Manrope) by default.

## Fix

Add `fontFamily: 'inherit'` and `fontSize: '14px'` to the `themeVariables` block passed to `mermaid.initialize()`. This suppresses Mermaid's external font import entirely — the diagram text uses the page's existing font stack instead.

```js
mermaid.initialize({
  startOnLoad: false,
  theme: ...,
  themeVariables: {
    fontFamily: 'inherit',  // ← suppress Google Fonts import
    fontSize: '14px',
    primaryColor: '#4a6fa5',
    ...
  }
});
```

This is preferable to adding `fonts.googleapis.com` to the CSP — no new external network dependency, no font-load delay on first diagram, and diagram text matches the rest of the UI typography.

## Tests

3 static regression tests in `tests/test_1044_mermaid_csp_font.py`:
- `themeVariables` contains `fontFamily:'inherit'`
- `ui.js` does not contain any `fonts.googleapis.com` URL
- `fontFamily:'inherit'` appears inside the `themeVariables` block (not outside)

**2215/2215 tests passing.**
