### PR TITLE
fix(onboarding): non-standard provider/path cluster — agent dir discovery, wizard guard, session model (#1029)

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -91,6 +91,14 @@ def _discover_agent_dir() -> Path:
     # 6. ~/hermes-agent
     candidates.append(HOME / "hermes-agent")
 
+    # 7. XDG_DATA_HOME / hermes-agent  (e.g. ~/.local/share/hermes-agent)
+    xdg_data = Path(os.getenv("XDG_DATA_HOME", str(HOME / ".local" / "share")))
+    candidates.append(xdg_data.expanduser() / "hermes-agent")
+
+    # 8. System-wide install paths (e.g. /opt/hermes-agent, /usr/local/hermes-agent)
+    for sys_prefix in ("/opt", "/usr/local", "/usr/local/share"):
+        candidates.append(Path(sys_prefix) / "hermes-agent")
+
     for path in candidates:
         if path.exists() and (path / "run_agent.py").exists():
             return path.resolve()

--- a/api/onboarding.py
+++ b/api/onboarding.py
@@ -518,11 +518,33 @@ def get_onboarding_status() -> dict:
     auto_completed = skip_requested  # unconditional: operator says skip, we skip
 
     # Auto-complete for existing Hermes users: if config.yaml already exists
-    # AND the system is chat_ready, treat onboarding as done.  These users
-    # configured Hermes via the CLI before the Web UI existed; they must never
-    # be shown the first-run wizard — it would silently overwrite their config.
+    # AND the provider is configured (or the system is chat_ready), treat onboarding
+    # as done.  These users configured Hermes via the CLI before the Web UI existed;
+    # they must never be shown the first-run wizard — it would silently overwrite their
+    # config.  We use provider_configured (not chat_ready) so that users with
+    # non-wizard providers (ollama-cloud, deepseek, xai, kimi, etc.) are not forced
+    # through the wizard just because their provider doesn't have a detectable API key
+    # — the wizard cannot represent their provider and would overwrite their config
+    # with whichever wizard-supported provider they accidentally select.
     config_exists = Path(_get_config_path()).exists()
-    config_auto_completed = config_exists and bool(runtime.get("chat_ready"))
+
+    # For providers not in the wizard's quick-setup list (e.g. ollama-cloud, deepseek,
+    # xai, kimi-k2.6), the wizard can never help — it only knows how to configure
+    # openrouter/anthropic/openai/google/custom.  If such a user has a configured
+    # provider + model in config.yaml, showing the wizard would only confuse them
+    # (or worse, let them accidentally overwrite their config with gpt-5.4-mini).
+    _current_provider = str(
+        (cfg.get("model", {}) or {}).get("provider", "") if isinstance(cfg.get("model"), dict)
+        else ""
+    ).strip().lower()
+    _is_non_wizard_provider = bool(
+        _current_provider and _current_provider not in _SUPPORTED_PROVIDER_SETUPS
+    )
+
+    config_auto_completed = config_exists and (
+        bool(runtime.get("chat_ready"))
+        or (_is_non_wizard_provider and bool(runtime.get("provider_configured")))
+    )
 
     # Persist the flag so it survives future transient import failures (e.g. after
     # a git branch switch in the hermes-agent repo).  Without this, a CLI-configured

--- a/api/routes.py
+++ b/api/routes.py
@@ -232,7 +232,13 @@ def _resolve_compatible_session_model(model_id: str | None) -> tuple[str, bool]:
         return default_model, bool(default_model)
 
     active_provider = _normalize_provider_id(catalog.get("active_provider"))
-    if not active_provider:
+    # Also keep the raw active_provider slug for cross-provider detection with
+    # non-listed providers (ollama-cloud, deepseek, xai, etc.) that _normalize_provider_id
+    # returns "" for. If the raw provider is set but normalization returned "", we still
+    # want to detect that a session model from a known provider (e.g. openai/gpt-5.4-mini)
+    # is stale relative to this unknown active provider. (#1023)
+    raw_active_provider = str(catalog.get("active_provider") or "").strip().lower()
+    if not active_provider and not raw_active_provider:
         return model, False
 
     slash = model.find("/")
@@ -275,7 +281,12 @@ def _resolve_compatible_session_model(model_id: str | None) -> tuple[str, bool]:
 
     # Skip normalization for models on custom/openrouter namespaces — these are
     # user-controlled and should never be silently replaced.
-    if model_provider and model_provider not in {"", "custom", "openrouter"} and model_provider != active_provider and default_model:
+    # Also normalize when the model is from a known provider but the active provider
+    # is an unlisted one (e.g. ollama-cloud) — active_provider is "" in that case
+    # but raw_active_provider is set. If model_provider doesn't start with the raw
+    # active provider name, the session model is stale. (#1023)
+    _active_for_compare = active_provider or raw_active_provider
+    if model_provider and model_provider not in {"", "custom", "openrouter"} and model_provider != _active_for_compare and default_model:
         return default_model, True
     return model, False
 

--- a/static/onboarding.js
+++ b/static/onboarding.js
@@ -286,7 +286,7 @@ async function loadOnboardingWizard(){
     const current=((status.setup||{}).current)||{};
     ONBOARDING.form.provider=current.provider||'openrouter';
     ONBOARDING.form.workspace=(status.workspaces&&status.workspaces.last)||status.settings.default_workspace||'';
-    ONBOARDING.form.model=status.settings.default_model||current.model||'openai/gpt-5.4-mini';
+    ONBOARDING.form.model=status.settings.default_model||current.model||'';
     ONBOARDING.form.password='';
     ONBOARDING.form.apiKey='';
     ONBOARDING.form.baseUrl=current.base_url||'';

--- a/tests/test_issue572.py
+++ b/tests/test_issue572.py
@@ -192,10 +192,22 @@ class TestOnboardingStatusUnsupportedProvider:
             "config.yaml + chat_ready=True must auto-complete onboarding regardless of provider."
         )
 
-    def test_minimax_cn_not_ready_shows_wizard(self):
-        """minimax-cn + chat_ready=False → wizard fires so user can fix it."""
+    def test_minimax_cn_not_ready_skips_wizard(self):
+        """minimax-cn + chat_ready=False → wizard still skipped for non-wizard providers.
+
+        The onboarding wizard has no minimax-cn option — showing it would only confuse
+        the user or let them accidentally overwrite their config with an OpenAI/Anthropic
+        provider.  For any provider not in _SUPPORTED_PROVIDER_SETUPS, onboarding is
+        auto-completed as long as provider_configured is True, regardless of chat_ready.
+        Users on non-wizard providers with no API key should fix credentials via
+        Settings → Providers, not via the first-run wizard.  (#1020)
+        """
         result = self._make_status(chat_ready=False)
-        assert result["completed"] is False
+        assert result["completed"] is True, (
+            "Wizard fired for minimax-cn user with provider_configured=True! "
+            "Non-wizard providers must auto-complete onboarding because the wizard "
+            "cannot configure them and would silently overwrite their config."
+        )
 
     def test_current_is_oauth_set_for_unsupported_provider(self):
         """setup.current_is_oauth must be True for minimax-cn (not in quick-setup list)."""


### PR DESCRIPTION
Absorbed from @nesquena-hermes #1029. Fixes four related bugs breaking first-run for users with non-wizard providers (ollama-cloud, deepseek, xai, kimi-k2.6) or non-standard agent install paths (/opt/hermes-agent, /usr/local/hermes-agent). All tests pass.

Co-authored-by: nesquena <nesquena@gmail.com>