### PR TITLE
fix(sessions): use cron job name as session title when available (#1032)

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -691,7 +691,25 @@ def get_cli_sessions() -> list:
             profile = _cli_profile  # CLI DB has no profile column; use active profile
 
             _source = row['source'] or 'cli'
-            _display_title = row['title'] or f'{_source.title()} Session'
+            _title = row['title']
+            if not _title and _source == 'cron' and sid.startswith('cron_'):
+                # Extract job_id from session ID (cron_{job_id}_{timestamp})
+                # and look up the human-friendly job name from jobs.json
+                parts = sid.split('_')
+                if len(parts) >= 3:
+                    _job_id = parts[1]
+                    try:
+                        _jobs_path = hermes_home / 'cron' / 'jobs.json'
+                        if _jobs_path.exists():
+                            import json as _json
+                            _jobs_data = _json.loads(_jobs_path.read_text())
+                            for _j in _jobs_data.get('jobs', []):
+                                if _j.get('id') == _job_id:
+                                    _title = _j.get('name') or _title
+                                    break
+                    except Exception:
+                        pass  # degrade gracefully
+            _display_title = _title or f'{_source.title()} Session'
             cli_sessions.append({
                 'session_id': sid,
                 'title': _display_title,
@@ -707,75 +725,6 @@ def get_cli_sessions() -> list:
                 'source_tag': _source,
                 'is_cli_session': True,
             })
-        with sqlite3.connect(str(db_path)) as conn:
-            conn.row_factory = sqlite3.Row
-            cur = conn.cursor()
-            # Introspect schema to handle older hermes-agent versions that
-            # may not have a 'source' column. Without this check the query raises
-            # OperationalError which is silently swallowed, causing the empty-list bug.
-            cur.execute("PRAGMA table_info(sessions)")
-            _session_cols = {row[1] for row in cur.fetchall()}
-            if 'source' not in _session_cols:
-                import logging as _logging
-                _logging.getLogger(__name__).warning(
-                    "get_cli_sessions(): state.db at %s has no 'source' column "
-                    "(older hermes-agent?). CLI sessions unavailable. "
-                    "Upgrade hermes-agent to fix this.",
-                    db_path,
-                )
-                return cli_sessions
-            cur.execute("""
-                SELECT s.id, s.title, s.model, s.message_count,
-                       s.started_at, s.source,
-                       MAX(m.timestamp) AS last_activity
-                FROM sessions s
-                LEFT JOIN messages m ON m.session_id = s.id
-                WHERE s.source IS NOT NULL AND s.source != 'webui'
-                GROUP BY s.id
-                ORDER BY COALESCE(MAX(m.timestamp), s.started_at) DESC
-                LIMIT 200
-            """)
-            for row in cur.fetchall():
-                sid = row['id']
-                raw_ts = row['last_activity'] or row['started_at']
-                # Prefer the CLI session's own profile from the DB; fall back to
-                # the active CLI profile so sidebar filtering works either way.
-                profile = _cli_profile  # CLI DB has no profile column; use active profile
-                _source = row['source'] or 'cli'
-                _title = row['title']
-                if not _title and _source == 'cron' and sid.startswith('cron_'):
-                    # Extract job_id from session ID (cron_{job_id}_{timestamp})
-                    # and look up the human-friendly job name from jobs.json
-                    parts = sid.split('_')
-                    if len(parts) >= 3:
-                        _job_id = parts[1]
-                        try:
-                            _jobs_path = hermes_home / 'cron' / 'jobs.json'
-                            if _jobs_path.exists():
-                                import json as _json
-                                _jobs_data = _json.loads(_jobs_path.read_text())
-                                for _j in _jobs_data.get('jobs', []):
-                                    if _j.get('id') == _job_id:
-                                        _title = _j.get('name') or _title
-                                        break
-                        except Exception:
-                            pass  # degrade gracefully
-                _display_title = _title or f'{_source.title()} Session'
-                cli_sessions.append({
-                    'session_id': sid,
-                    'title': _display_title,
-                    'workspace': str(get_last_workspace()),
-                    'model': row['model'] or None,
-                    'message_count': row['message_count'] or 0,
-                    'created_at': row['started_at'],
-                    'updated_at': raw_ts,
-                    'pinned': False,
-                    'archived': False,
-                    'project_id': None,
-                    'profile': profile,
-                    'source_tag': _source,
-                    'is_cli_session': True,
-                })
     except Exception as _cli_err:
         # DB schema changed, locked, or corrupted -- log warning so admins can diagnose.
         # Still degrade gracefully (don't crash the WebUI).

--- a/api/models.py
+++ b/api/models.py
@@ -707,6 +707,75 @@ def get_cli_sessions() -> list:
                 'source_tag': _source,
                 'is_cli_session': True,
             })
+        with sqlite3.connect(str(db_path)) as conn:
+            conn.row_factory = sqlite3.Row
+            cur = conn.cursor()
+            # Introspect schema to handle older hermes-agent versions that
+            # may not have a 'source' column. Without this check the query raises
+            # OperationalError which is silently swallowed, causing the empty-list bug.
+            cur.execute("PRAGMA table_info(sessions)")
+            _session_cols = {row[1] for row in cur.fetchall()}
+            if 'source' not in _session_cols:
+                import logging as _logging
+                _logging.getLogger(__name__).warning(
+                    "get_cli_sessions(): state.db at %s has no 'source' column "
+                    "(older hermes-agent?). CLI sessions unavailable. "
+                    "Upgrade hermes-agent to fix this.",
+                    db_path,
+                )
+                return cli_sessions
+            cur.execute("""
+                SELECT s.id, s.title, s.model, s.message_count,
+                       s.started_at, s.source,
+                       MAX(m.timestamp) AS last_activity
+                FROM sessions s
+                LEFT JOIN messages m ON m.session_id = s.id
+                WHERE s.source IS NOT NULL AND s.source != 'webui'
+                GROUP BY s.id
+                ORDER BY COALESCE(MAX(m.timestamp), s.started_at) DESC
+                LIMIT 200
+            """)
+            for row in cur.fetchall():
+                sid = row['id']
+                raw_ts = row['last_activity'] or row['started_at']
+                # Prefer the CLI session's own profile from the DB; fall back to
+                # the active CLI profile so sidebar filtering works either way.
+                profile = _cli_profile  # CLI DB has no profile column; use active profile
+                _source = row['source'] or 'cli'
+                _title = row['title']
+                if not _title and _source == 'cron' and sid.startswith('cron_'):
+                    # Extract job_id from session ID (cron_{job_id}_{timestamp})
+                    # and look up the human-friendly job name from jobs.json
+                    parts = sid.split('_')
+                    if len(parts) >= 3:
+                        _job_id = parts[1]
+                        try:
+                            _jobs_path = hermes_home / 'cron' / 'jobs.json'
+                            if _jobs_path.exists():
+                                import json as _json
+                                _jobs_data = _json.loads(_jobs_path.read_text())
+                                for _j in _jobs_data.get('jobs', []):
+                                    if _j.get('id') == _job_id:
+                                        _title = _j.get('name') or _title
+                                        break
+                        except Exception:
+                            pass  # degrade gracefully
+                _display_title = _title or f'{_source.title()} Session'
+                cli_sessions.append({
+                    'session_id': sid,
+                    'title': _display_title,
+                    'workspace': str(get_last_workspace()),
+                    'model': row['model'] or None,
+                    'message_count': row['message_count'] or 0,
+                    'created_at': row['started_at'],
+                    'updated_at': raw_ts,
+                    'pinned': False,
+                    'archived': False,
+                    'project_id': None,
+                    'profile': profile,
+                    'source_tag': _source,
+                    'is_cli_session': True,
+                })
     except Exception as _cli_err:
         # DB schema changed, locked, or corrupted -- log warning so admins can diagnose.
         # Still degrade gracefully (don't crash the WebUI).

--- a/api/routes.py
+++ b/api/routes.py
@@ -3552,21 +3552,22 @@ def _handle_session_import_cli(handler, body):
     if not msgs:
         return bad(handler, "Session not found in CLI store", 404)
 
-    # Derive title from first user message
-    title = title_from(msgs, "CLI Session")
-    model = "unknown"
-
-    # Get profile, model, and timestamps from CLI session metadata
+    # Get profile, model, timestamps, and title from CLI session metadata
     profile = None
     created_at = None
     updated_at = None
+    cli_title = None
     for cs in get_cli_sessions():
         if cs["session_id"] == sid:
             profile = cs.get("profile")
             model = cs.get("model", "unknown")
             created_at = cs.get("created_at")
             updated_at = cs.get("updated_at")
+            cli_title = cs.get("title")
             break
+
+    # Use the CLI session title if available (e.g., cron job name), otherwise derive from messages
+    title = cli_title or title_from(msgs, "CLI Session")
 
     s = import_cli_session(
         sid,

--- a/tests/test_cron_session_title.py
+++ b/tests/test_cron_session_title.py
@@ -32,6 +32,7 @@ def _make_state_db(path, sessions):
     """)
     conn.execute("""
         CREATE TABLE messages (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
             session_id TEXT,
             timestamp REAL
         )

--- a/tests/test_cron_session_title.py
+++ b/tests/test_cron_session_title.py
@@ -1,0 +1,147 @@
+"""Tests for cron session title fallback in get_cli_sessions().
+
+When a CLI session originates from cron and has no title in state.db, the
+WebUI sidebar should display the human-friendly job name from cron/jobs.json
+instead of a generic "Cron Session" label.
+
+Session ID format produced by hermes-agent: cron_<job_id>_<YYYYMMDD>_<HHMMSS>
+"""
+import json
+import sqlite3
+
+import pytest
+
+import api.models as models
+
+
+def _make_state_db(path, sessions):
+    """Create a state.db with the schema get_cli_sessions() expects.
+
+    `sessions` is a list of (id, title, source) tuples.
+    """
+    conn = sqlite3.connect(str(path))
+    conn.execute("""
+        CREATE TABLE sessions (
+            id TEXT PRIMARY KEY,
+            title TEXT,
+            model TEXT,
+            message_count INTEGER,
+            started_at REAL,
+            source TEXT
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE messages (
+            session_id TEXT,
+            timestamp REAL
+        )
+    """)
+    for sid, title, source in sessions:
+        conn.execute(
+            "INSERT INTO sessions (id, title, model, message_count, started_at, source) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (sid, title, "gpt-x", 1, 1700000000.0, source),
+        )
+        conn.execute(
+            "INSERT INTO messages (session_id, timestamp) VALUES (?, ?)",
+            (sid, 1700000001.0),
+        )
+    conn.commit()
+    conn.close()
+
+
+def _write_jobs_json(hermes_home, jobs):
+    """Write cron/jobs.json with the given jobs list."""
+    cron_dir = hermes_home / "cron"
+    cron_dir.mkdir(parents=True, exist_ok=True)
+    (cron_dir / "jobs.json").write_text(
+        json.dumps({"jobs": jobs}), encoding="utf-8"
+    )
+
+
+@pytest.fixture
+def fake_hermes_home(tmp_path, monkeypatch):
+    """Point get_cli_sessions() at a temporary HERMES_HOME and disable
+    profile lookups so the test runs hermetically."""
+    home = tmp_path / "hermes"
+    home.mkdir()
+
+    # Both profile helpers are imported lazily inside get_cli_sessions(),
+    # so patching the api.profiles module reaches them.
+    import api.profiles as profiles
+    monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: home)
+    monkeypatch.setattr(profiles, "get_active_profile_name", lambda: None)
+
+    return home
+
+
+def test_cron_session_uses_job_name_when_title_missing(fake_hermes_home):
+    """A cron session with no title should display the friendly job name."""
+    _write_jobs_json(fake_hermes_home, [
+        {"id": "cd65df6fc1a8", "name": "wiki-auto-ingest"},
+    ])
+    _make_state_db(fake_hermes_home / "state.db", [
+        ("cron_cd65df6fc1a8_20260417_191049", None, "cron"),
+    ])
+
+    sessions = models.get_cli_sessions()
+
+    assert len(sessions) == 1
+    assert sessions[0]["title"] == "wiki-auto-ingest"
+
+
+def test_cron_session_falls_back_when_jobs_json_missing(fake_hermes_home):
+    """No jobs.json should not crash; title falls back to 'Cron Session'."""
+    _make_state_db(fake_hermes_home / "state.db", [
+        ("cron_abc123_20260417_191049", None, "cron"),
+    ])
+
+    sessions = models.get_cli_sessions()
+
+    assert sessions[0]["title"] == "Cron Session"
+
+
+def test_cron_session_falls_back_when_job_id_not_in_jobs_json(fake_hermes_home):
+    """Stale session whose job has been deleted falls back gracefully."""
+    _write_jobs_json(fake_hermes_home, [
+        {"id": "different_job", "name": "Some Other Job"},
+    ])
+    _make_state_db(fake_hermes_home / "state.db", [
+        ("cron_orphan_20260417_191049", None, "cron"),
+    ])
+
+    sessions = models.get_cli_sessions()
+
+    assert sessions[0]["title"] == "Cron Session"
+
+
+def test_explicit_title_is_preserved(fake_hermes_home):
+    """If state.db already has a title, the cron job lookup should not
+    override it."""
+    _write_jobs_json(fake_hermes_home, [
+        {"id": "cd65df6fc1a8", "name": "wiki-auto-ingest"},
+    ])
+    _make_state_db(fake_hermes_home / "state.db", [
+        ("cron_cd65df6fc1a8_20260417_191049", "User-edited title", "cron"),
+    ])
+
+    sessions = models.get_cli_sessions()
+
+    assert sessions[0]["title"] == "User-edited title"
+
+
+def test_non_cron_sessions_unaffected(fake_hermes_home):
+    """The cron-name lookup must not run for cli-source sessions, so the
+    generic 'Cli Session' fallback still applies when title is empty."""
+    _write_jobs_json(fake_hermes_home, [
+        {"id": "cd65df6fc1a8", "name": "wiki-auto-ingest"},
+    ])
+    # A 'cli' session whose ID coincidentally starts with 'cron_' must not
+    # pick up the job name — the source check guards against this.
+    _make_state_db(fake_hermes_home / "state.db", [
+        ("cron_cd65df6fc1a8_xx", None, "cli"),
+    ])
+
+    sessions = models.get_cli_sessions()
+
+    assert sessions[0]["title"] == "Cli Session"


### PR DESCRIPTION
Absorbed from @waldmanz #1032. Cron-launched CLI sessions now show the human-friendly job name (from cron/jobs.json) in the sidebar instead of a generic 'Cron Session' label. Best-effort with silent fallback. All tests pass.

Co-authored-by: waldmanz <waldmanz@users.noreply.github.com>