### PR TITLE
feat(models): add gpt-5.5 and gpt-5.5-mini to model catalogs (#1041)

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -597,10 +597,14 @@ _PROVIDER_MODELS = {
         {"id": "claude-haiku-4-5", "label": "Claude Haiku 4.5"},
     ],
     "openai": [
+        {"id": "gpt-5.5",      "label": "GPT-5.5"},
+        {"id": "gpt-5.5-mini", "label": "GPT-5.5 Mini"},
         {"id": "gpt-5.4-mini", "label": "GPT-5.4 Mini"},
         {"id": "gpt-5.4",      "label": "GPT-5.4"},
     ],
     "openai-codex": [
+        {"id": "gpt-5.5", "label": "GPT-5.5"},
+        {"id": "gpt-5.5-mini", "label": "GPT-5.5 Mini"},
         {"id": "gpt-5.4", "label": "GPT-5.4"},
         {"id": "gpt-5.4-mini", "label": "GPT-5.4 Mini"},
         {"id": "gpt-5.3-codex", "label": "GPT-5.3 Codex"},
@@ -650,6 +654,7 @@ _PROVIDER_MODELS = {
     ],
     # GitHub Copilot — model IDs served via the Copilot API
     "copilot": [
+        {"id": "gpt-5.5", "label": "GPT-5.5"},
         {"id": "gpt-5.4", "label": "GPT-5.4"},
         {"id": "gpt-5.4-mini", "label": "GPT-5.4 Mini"},
         {"id": "gpt-4o", "label": "GPT-4o"},

--- a/api/config.py
+++ b/api/config.py
@@ -655,6 +655,7 @@ _PROVIDER_MODELS = {
     # GitHub Copilot — model IDs served via the Copilot API
     "copilot": [
         {"id": "gpt-5.5", "label": "GPT-5.5"},
+        {"id": "gpt-5.5-mini", "label": "GPT-5.5 Mini"},
         {"id": "gpt-5.4", "label": "GPT-5.4"},
         {"id": "gpt-5.4-mini", "label": "GPT-5.4 Mini"},
         {"id": "gpt-4o", "label": "GPT-4o"},


### PR DESCRIPTION
Absorbed from @aliceisjustplaying #1041. Adds gpt-5.5 and gpt-5.5-mini to openai, openai-codex, and copilot provider catalogs. Also adds gpt-5.5-mini to copilot (was missing from the original PR). All tests pass.

Co-authored-by: aliceisjustplaying <aliceisjustplaying@users.noreply.github.com>