### PR TITLE
fix(bfcache): restore layout and close dropdowns on tab restore (#1048)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
+- **bfcache layout restore** — extended the `pageshow` handler in `boot.js` to re-run `syncTopbar`, `syncWorkspacePanelState`, `_initResizePanels`, and `startGatewaySSE` when `event.persisted === true`. Fixes the broken layout (oversized search icon, stale rail) that appeared on tab restore / browser session restore without a hard refresh. (#822 session-search fix preserved.) (`static/boot.js`) [#1045]
 
 ## v0.50.209 — 2026-04-25
 

--- a/static/boot.js
+++ b/static/boot.js
@@ -906,6 +906,12 @@ window.addEventListener('pageshow', (event) => {
   if (!event.persisted) return;  // fresh loads are handled by the IIFE above
   const _srch = document.getElementById('sessionSearch');
   if (_srch) _srch.value = '';
+  // Close any dropdowns/popovers that were open when the user navigated away.
+  // bfcache freezes DOM state, so a dropdown left open remains open on restore.
+  if (typeof closeModelDropdown === 'function') try { closeModelDropdown(); } catch (_) {}
+  if (typeof closeReasoningDropdown === 'function') try { closeReasoningDropdown(); } catch (_) {}
+  if (typeof closeWsDropdown === 'function') try { closeWsDropdown(); } catch (_) {}
+  if (typeof closeProfileDropdown === 'function') try { closeProfileDropdown(); } catch (_) {}
   // Re-synchronise layout chrome that the boot IIFE sets up but bfcache
   // doesn't re-run. Each call is guarded so missing helpers degrade silently.
   if (typeof syncTopbar === 'function') try { syncTopbar(); } catch (_) {}

--- a/static/boot.js
+++ b/static/boot.js
@@ -916,7 +916,6 @@ window.addEventListener('pageshow', (event) => {
   // doesn't re-run. Each call is guarded so missing helpers degrade silently.
   if (typeof syncTopbar === 'function') try { syncTopbar(); } catch (_) {}
   if (typeof syncWorkspacePanelState === 'function') try { syncWorkspacePanelState(); } catch (_) {}
-  if (typeof _initResizePanels === 'function') try { _initResizePanels(); } catch (_) {}
   if (typeof renderSessionListFromCache === 'function') {
     try { renderSessionListFromCache(); } catch (_) {}
   }

--- a/static/boot.js
+++ b/static/boot.js
@@ -898,13 +898,22 @@ function applyBotName(){
 // back-forward cache, the async boot IIFE above does NOT re-run, but the
 // DOM — including any stale value in #sessionSearch — IS restored.  A
 // prior search string would silently hide all sessions via the filter in
-// renderSessionListFromCache().  Clear the field and re-render whenever
-// the page is restored from cache (`event.persisted === true`).
+// renderSessionListFromCache().  Clear the field and re-run the full layout
+// sync whenever the page is restored from cache (`event.persisted === true`).
+// Fix #1045: also re-run topbar/workspace/panel state so the rail and layout
+// chrome aren't left in the stale bfcache snapshot.
 window.addEventListener('pageshow', (event) => {
   if (!event.persisted) return;  // fresh loads are handled by the IIFE above
   const _srch = document.getElementById('sessionSearch');
   if (_srch) _srch.value = '';
+  // Re-synchronise layout chrome that the boot IIFE sets up but bfcache
+  // doesn't re-run. Each call is guarded so missing helpers degrade silently.
+  if (typeof syncTopbar === 'function') try { syncTopbar(); } catch (_) {}
+  if (typeof syncWorkspacePanelState === 'function') try { syncWorkspacePanelState(); } catch (_) {}
+  if (typeof _initResizePanels === 'function') try { _initResizePanels(); } catch (_) {}
   if (typeof renderSessionListFromCache === 'function') {
     try { renderSessionListFromCache(); } catch (_) {}
   }
+  // Restart the gateway SSE watcher — the persisted connection is dead after bfcache
+  if (typeof startGatewaySSE === 'function') try { startGatewaySSE(); } catch (_) {}
 });

--- a/tests/test_1045_bfcache_layout_restore.py
+++ b/tests/test_1045_bfcache_layout_restore.py
@@ -41,14 +41,6 @@ class TestBfcacheLayoutRestore:
             "pageshow handler must call syncWorkspacePanelState() on bfcache restore"
         )
 
-    def test_pageshow_calls_init_resize_panels(self):
-        """pageshow handler must call _initResizePanels()."""
-        src = _boot_js()
-        ps_idx = src.find("window.addEventListener('pageshow'")
-        handler_body = src[ps_idx:ps_idx + 1600]
-        assert "_initResizePanels" in handler_body, (
-            "pageshow handler must call _initResizePanels() to restore panel resize state"
-        )
 
     def test_pageshow_calls_start_gateway_sse(self):
         """pageshow handler must call startGatewaySSE() to reconnect the dead SSE connection."""
@@ -77,13 +69,24 @@ class TestBfcacheLayoutRestore:
             "pageshow handler must still call renderSessionListFromCache() (regression: #822 fix)"
         )
 
+    def test_pageshow_does_not_call_init_resize_panels(self):
+        """pageshow handler must NOT call _initResizePanels() — bfcache
+        preserves event listeners so re-attaching them stacks duplicates."""
+        src = _boot_js()
+        ps_idx = src.find("window.addEventListener('pageshow'")
+        handler_body = src[ps_idx:ps_idx + 1600]
+        assert "_initResizePanels" not in handler_body, (
+            "pageshow handler must not call _initResizePanels() — it stacks "
+            "duplicate mousedown listeners on every bfcache restore"
+        )
+
     def test_new_calls_are_guarded_with_typeof(self):
         """New calls in the pageshow handler must be typeof-guarded for safe degradation."""
         src = _boot_js()
         ps_idx = src.find("window.addEventListener('pageshow'")
         handler_body = src[ps_idx:ps_idx + 1600]
         # Each of the new calls must be guarded
-        for fn in ("syncTopbar", "syncWorkspacePanelState", "_initResizePanels", "startGatewaySSE",
+        for fn in ("syncTopbar", "syncWorkspacePanelState", "startGatewaySSE",
                    "closeModelDropdown", "closeReasoningDropdown", "closeWsDropdown", "closeProfileDropdown"):
             assert f"typeof {fn} === 'function'" in handler_body, (
                 f"{fn}() call in pageshow handler must be guarded with typeof === 'function'"

--- a/tests/test_1045_bfcache_layout_restore.py
+++ b/tests/test_1045_bfcache_layout_restore.py
@@ -27,7 +27,7 @@ class TestBfcacheLayoutRestore:
         # Find the pageshow listener block
         ps_idx = src.find("window.addEventListener('pageshow'")
         assert ps_idx != -1, "pageshow listener not found in boot.js"
-        handler_body = src[ps_idx:ps_idx + 1200]
+        handler_body = src[ps_idx:ps_idx + 1600]
         assert "syncTopbar" in handler_body, (
             "pageshow handler must call syncTopbar() to restore topbar state after bfcache"
         )
@@ -36,7 +36,7 @@ class TestBfcacheLayoutRestore:
         """pageshow handler must call syncWorkspacePanelState()."""
         src = _boot_js()
         ps_idx = src.find("window.addEventListener('pageshow'")
-        handler_body = src[ps_idx:ps_idx + 1200]
+        handler_body = src[ps_idx:ps_idx + 1600]
         assert "syncWorkspacePanelState" in handler_body, (
             "pageshow handler must call syncWorkspacePanelState() on bfcache restore"
         )
@@ -45,7 +45,7 @@ class TestBfcacheLayoutRestore:
         """pageshow handler must call _initResizePanels()."""
         src = _boot_js()
         ps_idx = src.find("window.addEventListener('pageshow'")
-        handler_body = src[ps_idx:ps_idx + 1200]
+        handler_body = src[ps_idx:ps_idx + 1600]
         assert "_initResizePanels" in handler_body, (
             "pageshow handler must call _initResizePanels() to restore panel resize state"
         )
@@ -54,7 +54,7 @@ class TestBfcacheLayoutRestore:
         """pageshow handler must call startGatewaySSE() to reconnect the dead SSE connection."""
         src = _boot_js()
         ps_idx = src.find("window.addEventListener('pageshow'")
-        handler_body = src[ps_idx:ps_idx + 1200]
+        handler_body = src[ps_idx:ps_idx + 1600]
         assert "startGatewaySSE" in handler_body, (
             "pageshow handler must restart gateway SSE (bfcache-persisted connections are dead)"
         )
@@ -63,7 +63,7 @@ class TestBfcacheLayoutRestore:
         """pageshow handler must still clear #sessionSearch (original #822 fix preserved)."""
         src = _boot_js()
         ps_idx = src.find("window.addEventListener('pageshow'")
-        handler_body = src[ps_idx:ps_idx + 1200]
+        handler_body = src[ps_idx:ps_idx + 1600]
         assert "sessionSearch" in handler_body, (
             "pageshow handler must still clear #sessionSearch (regression: #822 fix must be preserved)"
         )
@@ -72,7 +72,7 @@ class TestBfcacheLayoutRestore:
         """pageshow handler must still call renderSessionListFromCache()."""
         src = _boot_js()
         ps_idx = src.find("window.addEventListener('pageshow'")
-        handler_body = src[ps_idx:ps_idx + 1200]
+        handler_body = src[ps_idx:ps_idx + 1600]
         assert "renderSessionListFromCache" in handler_body, (
             "pageshow handler must still call renderSessionListFromCache() (regression: #822 fix)"
         )
@@ -81,9 +81,33 @@ class TestBfcacheLayoutRestore:
         """New calls in the pageshow handler must be typeof-guarded for safe degradation."""
         src = _boot_js()
         ps_idx = src.find("window.addEventListener('pageshow'")
-        handler_body = src[ps_idx:ps_idx + 1200]
-        # Each of the three new calls must be guarded
-        for fn in ("syncTopbar", "syncWorkspacePanelState", "_initResizePanels", "startGatewaySSE"):
+        handler_body = src[ps_idx:ps_idx + 1600]
+        # Each of the new calls must be guarded
+        for fn in ("syncTopbar", "syncWorkspacePanelState", "_initResizePanels", "startGatewaySSE",
+                   "closeModelDropdown", "closeReasoningDropdown", "closeWsDropdown", "closeProfileDropdown"):
             assert f"typeof {fn} === 'function'" in handler_body, (
                 f"{fn}() call in pageshow handler must be guarded with typeof === 'function'"
             )
+
+    def test_pageshow_closes_all_dropdowns(self):
+        """pageshow handler must close all known dropdowns to reset frozen bfcache popover state."""
+        src = _boot_js()
+        ps_idx = src.find("window.addEventListener('pageshow'")
+        handler_body = src[ps_idx:ps_idx + 1600]
+        for fn in ("closeModelDropdown", "closeReasoningDropdown", "closeWsDropdown", "closeProfileDropdown"):
+            assert fn in handler_body, (
+                f"pageshow handler must call {fn}() to dismiss any dropdown left open by bfcache"
+            )
+
+    def test_dropdowns_closed_before_layout_sync(self):
+        """Dropdown closes must come before layout sync calls (clean state first)."""
+        src = _boot_js()
+        ps_idx = src.find("window.addEventListener('pageshow'")
+        handler_body = src[ps_idx:ps_idx + 1600]
+        close_idx = handler_body.find("closeModelDropdown")
+        sync_idx = handler_body.find("syncTopbar")
+        assert close_idx != -1 and sync_idx != -1, "Both close and sync calls must be present"
+        assert close_idx < sync_idx, (
+            "Dropdown close calls must appear before layout sync calls in the pageshow handler"
+        )
+

--- a/tests/test_1045_bfcache_layout_restore.py
+++ b/tests/test_1045_bfcache_layout_restore.py
@@ -1,0 +1,89 @@
+"""
+Tests for issue #1045 — bfcache layout broken on tab restore.
+
+When the browser restores a page from bfcache (event.persisted === true),
+the async boot IIFE does not re-run. The existing pageshow handler (added for
+#822) only cleared the session search field and re-rendered the session list.
+This left the rail, topbar, workspace panel, and resize handles in the stale
+bfcache DOM state, producing a broken layout.
+
+Fix: extend the pageshow handler to also call syncTopbar, syncWorkspacePanelState,
+_initResizePanels, and startGatewaySSE — all guarded so missing helpers degrade.
+"""
+
+from pathlib import Path
+
+ROOT = Path(__file__).parent.parent
+
+
+def _boot_js() -> str:
+    return (ROOT / "static" / "boot.js").read_text(encoding="utf-8")
+
+
+class TestBfcacheLayoutRestore:
+    def test_pageshow_calls_sync_topbar(self):
+        """pageshow handler must call syncTopbar() on bfcache restore."""
+        src = _boot_js()
+        # Find the pageshow listener block
+        ps_idx = src.find("window.addEventListener('pageshow'")
+        assert ps_idx != -1, "pageshow listener not found in boot.js"
+        handler_body = src[ps_idx:ps_idx + 1200]
+        assert "syncTopbar" in handler_body, (
+            "pageshow handler must call syncTopbar() to restore topbar state after bfcache"
+        )
+
+    def test_pageshow_calls_sync_workspace_panel_state(self):
+        """pageshow handler must call syncWorkspacePanelState()."""
+        src = _boot_js()
+        ps_idx = src.find("window.addEventListener('pageshow'")
+        handler_body = src[ps_idx:ps_idx + 1200]
+        assert "syncWorkspacePanelState" in handler_body, (
+            "pageshow handler must call syncWorkspacePanelState() on bfcache restore"
+        )
+
+    def test_pageshow_calls_init_resize_panels(self):
+        """pageshow handler must call _initResizePanels()."""
+        src = _boot_js()
+        ps_idx = src.find("window.addEventListener('pageshow'")
+        handler_body = src[ps_idx:ps_idx + 1200]
+        assert "_initResizePanels" in handler_body, (
+            "pageshow handler must call _initResizePanels() to restore panel resize state"
+        )
+
+    def test_pageshow_calls_start_gateway_sse(self):
+        """pageshow handler must call startGatewaySSE() to reconnect the dead SSE connection."""
+        src = _boot_js()
+        ps_idx = src.find("window.addEventListener('pageshow'")
+        handler_body = src[ps_idx:ps_idx + 1200]
+        assert "startGatewaySSE" in handler_body, (
+            "pageshow handler must restart gateway SSE (bfcache-persisted connections are dead)"
+        )
+
+    def test_pageshow_still_clears_session_search(self):
+        """pageshow handler must still clear #sessionSearch (original #822 fix preserved)."""
+        src = _boot_js()
+        ps_idx = src.find("window.addEventListener('pageshow'")
+        handler_body = src[ps_idx:ps_idx + 1200]
+        assert "sessionSearch" in handler_body, (
+            "pageshow handler must still clear #sessionSearch (regression: #822 fix must be preserved)"
+        )
+
+    def test_pageshow_still_calls_render_session_list_from_cache(self):
+        """pageshow handler must still call renderSessionListFromCache()."""
+        src = _boot_js()
+        ps_idx = src.find("window.addEventListener('pageshow'")
+        handler_body = src[ps_idx:ps_idx + 1200]
+        assert "renderSessionListFromCache" in handler_body, (
+            "pageshow handler must still call renderSessionListFromCache() (regression: #822 fix)"
+        )
+
+    def test_new_calls_are_guarded_with_typeof(self):
+        """New calls in the pageshow handler must be typeof-guarded for safe degradation."""
+        src = _boot_js()
+        ps_idx = src.find("window.addEventListener('pageshow'")
+        handler_body = src[ps_idx:ps_idx + 1200]
+        # Each of the three new calls must be guarded
+        for fn in ("syncTopbar", "syncWorkspacePanelState", "_initResizePanels", "startGatewaySSE"):
+            assert f"typeof {fn} === 'function'" in handler_body, (
+                f"{fn}() call in pageshow handler must be guarded with typeof === 'function'"
+            )


### PR DESCRIPTION
Absorbed from @nesquena-hermes #1048. pageshow+event.persisted handler re-syncs topbar, workspace panel, and gateway SSE on bfcache restore. Also closes open composer dropdowns frozen by bfcache. Removed _initResizePanels() call (bfcache preserves JS listeners — re-attaching would stack duplicates). All tests pass.

Co-authored-by: nesquena <nesquena@gmail.com>