### PR TITLE
fix(settings): show selected state on theme/skin/font-size picker cards

### DIFF
--- a/static/boot.js
+++ b/static/boot.js
@@ -710,17 +710,17 @@ function _pickSkin(name){
 
 function _syncThemePicker(active){
   document.querySelectorAll('#themePickerGrid .theme-pick-btn').forEach(btn=>{
-    const sel=btn.dataset.themeVal===active;
-    btn.style.borderColor=sel?'var(--accent)':'var(--border2)';
-    btn.style.boxShadow=sel?'0 0 0 1px var(--accent-bg-strong)':'none';
+    btn.classList.toggle('active',btn.dataset.themeVal===active);
+    btn.style.borderColor='';
+    btn.style.boxShadow='';
   });
 }
 
 function _syncSkinPicker(active){
   document.querySelectorAll('#skinPickerGrid .skin-pick-btn').forEach(btn=>{
-    const sel=btn.dataset.skinVal===active;
-    btn.style.borderColor=sel?'var(--accent)':'var(--border2)';
-    btn.style.boxShadow=sel?'0 0 0 1px var(--accent-bg-strong)':'none';
+    btn.classList.toggle('active',btn.dataset.skinVal===active);
+    btn.style.borderColor='';
+    btn.style.boxShadow='';
   });
 }
 
@@ -743,9 +743,9 @@ function _pickFontSize(size){
 
 function _syncFontSizePicker(active){
   document.querySelectorAll('#fontSizePickerGrid .font-size-pick-btn').forEach(btn=>{
-    const sel=btn.dataset.fontSizeVal===(active||'default');
-    btn.style.borderColor=sel?'var(--accent)':'var(--border2)';
-    btn.style.boxShadow=sel?'0 0 0 1px var(--accent-bg-strong)':'none';
+    btn.classList.toggle('active',btn.dataset.fontSizeVal===(active||'default'));
+    btn.style.borderColor='';
+    btn.style.boxShadow='';
   });
 }
 

--- a/static/style.css
+++ b/static/style.css
@@ -1661,6 +1661,10 @@ main.main.showing-profiles > #mainProfiles{display:flex;}
 #mainSettings .theme-pick-btn:hover,
 #mainSettings .skin-pick-btn:hover,
 #mainSettings .font-size-pick-btn:hover{border-color:var(--accent-bg-strong)!important;background:var(--surface)!important;}
+/* Active/selected state for picker cards — must use !important to beat the base border-color:var(--border)!important rule above */
+#mainSettings .theme-pick-btn.active,
+#mainSettings .skin-pick-btn.active,
+#mainSettings .font-size-pick-btn.active{border-color:var(--accent)!important;box-shadow:0 0 0 1px var(--accent-bg-strong)!important;background:var(--surface)!important;}
 
 /* Responsive: tighten canvas on small screens. */
 @media (max-width: 768px){

--- a/tests/test_1057_settings_picker_active_state.py
+++ b/tests/test_1057_settings_picker_active_state.py
@@ -1,0 +1,84 @@
+"""Regression tests for settings picker active-state highlighting.
+
+The theme, skin, and font-size pickers in the Appearance settings tab must show
+the currently-selected option with a visible accent border. This was broken because
+the CSS rule used !important on border-color:var(--border) which overrode the inline
+style that _syncThemePicker/etc. set. Fixed by moving to .active CSS class + !important
+override on the active state.
+
+Issue: #1057
+"""
+from pathlib import Path
+
+BOOT_JS = (Path(__file__).parent.parent / "static" / "boot.js").read_text(encoding="utf-8")
+STYLE_CSS = (Path(__file__).parent.parent / "static" / "style.css").read_text(encoding="utf-8")
+
+
+class TestSettingsPickerActiveState:
+    """The selected picker card must be visually distinct via the .active class."""
+
+    def test_theme_picker_uses_active_class(self):
+        """_syncThemePicker must toggle .active class, not set inline borderColor."""
+        idx = BOOT_JS.find("function _syncThemePicker(")
+        assert idx >= 0, "_syncThemePicker function not found in boot.js"
+        body = BOOT_JS[idx:idx + 300]
+        assert "classList.toggle" in body, (
+            "_syncThemePicker must use classList.toggle('active', ...) — "
+            "inline style.borderColor is overridden by !important CSS rules"
+        )
+        # Confirm no accent/border2 color values set inline (clearing with '' is OK)
+        assert "var(--accent)" not in body and "var(--border2)" not in body, (
+            "_syncThemePicker must not set var(--accent) or var(--border2) inline — "
+            "those are overridden by !important CSS rules"
+        )
+
+    def test_font_size_picker_uses_active_class(self):
+        """_syncFontSizePicker must toggle .active class."""
+        idx = BOOT_JS.find("function _syncFontSizePicker(")
+        assert idx >= 0, "_syncFontSizePicker function not found in boot.js"
+        body = BOOT_JS[idx:idx + 300]
+        assert "classList.toggle" in body, (
+            "_syncFontSizePicker must use classList.toggle('active', ...)"
+        )
+        assert "var(--accent)" not in body and "var(--border2)" not in body, (
+            "_syncFontSizePicker must not set var(--accent) or var(--border2) inline"
+        )
+
+    def test_skin_picker_uses_active_class(self):
+        """_syncSkinPicker must toggle .active class."""
+        idx = BOOT_JS.find("function _syncSkinPicker(")
+        assert idx >= 0, "_syncSkinPicker function not found in boot.js"
+        body = BOOT_JS[idx:idx + 300]
+        assert "classList.toggle" in body, (
+            "_syncSkinPicker must use classList.toggle('active', ...)"
+        )
+        assert "var(--accent)" not in body and "var(--border2)" not in body, (
+            "_syncSkinPicker must not set var(--accent) or var(--border2) inline"
+        )
+
+    def test_css_active_rule_beats_base_rule(self):
+        """CSS must have a .active rule with !important that overrides the base border-color rule."""
+        assert ".theme-pick-btn.active" in STYLE_CSS, (
+            "style.css must have a .theme-pick-btn.active rule"
+        )
+        assert ".font-size-pick-btn.active" in STYLE_CSS, (
+            "style.css must have a .font-size-pick-btn.active rule"
+        )
+        assert ".skin-pick-btn.active" in STYLE_CSS, (
+            "style.css must have a .skin-pick-btn.active rule"
+        )
+        # The active rule must use !important to beat the base !important rule
+        idx = STYLE_CSS.find(".theme-pick-btn.active")
+        rule = STYLE_CSS[idx:idx + 200]
+        assert "!important" in rule, (
+            ".theme-pick-btn.active must use !important to override "
+            "the base border-color:var(--border)!important rule"
+        )
+
+    def test_active_rule_uses_accent_color(self):
+        """The .active rule must apply the accent color to make selection visible."""
+        idx = STYLE_CSS.find(".theme-pick-btn.active")
+        rule = STYLE_CSS[idx:idx + 200]
+        assert "var(--accent)" in rule, (
+            ".theme-pick-btn.active must set border-color to var(--accent)"
+        )

--- a/tests/test_1059_settings_picker_active_state.py
+++ b/tests/test_1059_settings_picker_active_state.py
@@ -6,7 +6,7 @@ the CSS rule used !important on border-color:var(--border) which overrode the in
 style that _syncThemePicker/etc. set. Fixed by moving to .active CSS class + !important
 override on the active state.
 
-Issue: #1057
+Issue: #1059 (settings picker active state)
 """
 from pathlib import Path
 


### PR DESCRIPTION
## Summary

Fixes the selected-state highlighting on the theme, skin, and font-size picker cards in Settings → Appearance.

## Root cause

`_syncThemePicker()` (and its siblings for skin/font size) indicated the active selection by setting `btn.style.borderColor = 'var(--accent)'` as an inline style. However, the stylesheet has:

```css
#mainSettings .theme-pick-btn { border-color: var(--border) !important; }
```

CSS `!important` declarations override inline styles — so the active accent color was always overridden by the base rule and the cards looked identical whether selected or not.

## Fix

1. **`static/style.css`** — added a `.active` variant rule that uses `!important` to beat the base:
   ```css
   #mainSettings .theme-pick-btn.active,
   #mainSettings .skin-pick-btn.active,
   #mainSettings .font-size-pick-btn.active {
     border-color: var(--accent) !important;
     box-shadow: 0 0 0 1px var(--accent-bg-strong) !important;
     background: var(--surface) !important;
   }
   ```

2. **`static/boot.js`** — `_syncThemePicker`, `_syncSkinPicker`, `_syncFontSizePicker` now toggle the `.active` class instead of setting inline color values, and clear any stale inline styles.

5 regression tests added in `tests/test_1059_settings_picker_active_state.py`.