### PR TITLE
v0.50.212: model cache perf (~30s→~1ms), session switch UX, cache isolation fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## [Unreleased]
 
+## v0.50.212 — 2026-04-26
+
+### Performance
+- **Model list ~1ms on restart** — `get_available_models()` now writes to a disk cache at `/dev/shm` on every cold rebuild and reads it back on restart, eliminating the ~30s Z.AI endpoint-probe delay on every server start. TTL raised from 60s to 24h. (`api/config.py`) [#1060 @JKJameson]
+- **Thundering-herd prevention** — RLock + `_cache_build_in_progress` flag ensures only one thread runs the cold rebuild while others wait on a Condition variable instead of triggering duplicate 10s provider calls. (`api/config.py`) [#1060 @JKJameson]
+- **Credential pool cache** — `load_pool()` results cached per provider (24h TTL) to avoid repeated expensive auth-store reads on every model list refresh. (`api/config.py`) [#1060 @JKJameson]
+
+### Fixed
+- **Stale SSE blocking** — switching sessions now discards in-flight SSE tokens from the previous session before attaching the new one; no cross-session token bleed. (`static/sessions.js`) [#1060 @JKJameson]
+- **Pending files cleared after send** — ghost attachments no longer appear in the composer tray after sending. (`static/sessions.js`) [#1060 @JKJameson]
+- **Textarea focus on session switch** — message input automatically focused after switching sessions. (`static/sessions.js`) [#1060 @JKJameson]
+- **Instant click for inactive sessions** — no loading spinner blocking fast repeated session switches. (`static/sessions.js`) [#1060 @JKJameson]
+- **Double-click titlebar to rename** — session title can be renamed by double-clicking the active session in the sidebar. (`static/sessions.js`) [#1060 @JKJameson]
+- **Draft persistence across switches** — composer draft saved/restored when switching sessions. (`static/panels.js`) [#1060 @JKJameson]
+- **user-select:none on session titles** — prevents accidental text selection on double-click. (`static/style.css`) [#1060 @JKJameson]
+- **Cache disk-delete in invalidate_models_cache()** — `invalidate_models_cache()` now also removes the on-disk snapshot so test isolation is preserved and stale cached data is never served after invalidation. (`api/config.py`)
+- **_cache_build_in_progress reset on exception** — rebuild exceptions no longer leave the flag stuck, which would block waiting threads for 60s. (`api/config.py`)
+
 ## v0.50.211 — 2026-04-25
 
 ### Changed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,7 +3,7 @@
 > Goal: Full 1:1 parity with the Hermes CLI experience via a clean dark web UI.
 > Everything you can do from the CLI terminal, you can do from this UI.
 >
-> Last updated: v0.50.211 (April 25, 2026) — 2276 tests collected
+> Last updated: v0.50.212 (April 26, 2026) — 2281 tests collected
 > Tests: 2107 collected (`pytest tests/ --collect-only -q`)
 > Source: <repo>/
 

--- a/api/config.py
+++ b/api/config.py
@@ -1088,7 +1088,7 @@ _available_models_cache: dict | None = None
 _available_models_cache_ts: float = 0.0
 _AVAILABLE_MODELS_CACHE_TTL: float = 86400.0  # 24 hours
 _available_models_cache_lock = threading.RLock()  # must be RLock: cold path refactoring moved slow work inside this lock, requiring re-entry
-_cache_build_cv = threading.Condition()  # signaled when _available_models_cache is set from a cold path
+_cache_build_cv = threading.Condition(_available_models_cache_lock)  # shares underlying RLock so notify_all() is safe inside with _available_models_cache_lock
 _cache_build_in_progress = False  # True while a cold path is actively building
 
 # Cache for credential pool results -- calling load_pool() per-provider per-server

--- a/api/config.py
+++ b/api/config.py
@@ -1152,6 +1152,11 @@ def invalidate_models_cache():
         _available_models_cache_ts = 0.0
         _cache_build_in_progress = False
         _cache_build_cv.notify_all()
+        # Clear the credential pool cache too. The cache key is provider_id
+        # only, so without this, tests (and live provider key edits) see a
+        # stale CredentialPool from a prior auth_store payload — the test_
+        # credential_pool_providers suite was hitting this directly.
+        _CREDENTIAL_POOL_CACHE.clear()
 
 
 def invalidate_provider_models_cache(provider_id: str):

--- a/api/config.py
+++ b/api/config.py
@@ -1224,6 +1224,14 @@ def get_available_models() -> dict:
     }
     """
     global _cache_build_in_progress, _available_models_cache, _available_models_cache_ts, _cache_build_cv
+    # Config mtime check — must come before any config reads.
+    # (Test #585 verifies _current_mtime appears before active_provider = None)
+    try:
+        _current_mtime = Path(_get_config_path()).stat().st_mtime
+    except OSError:
+        _current_mtime = 0.0
+    if _current_mtime != _cfg_mtime:
+        reload_config()
     # ── COLD PATH helper ─────────────────────────────────────────────────────
     # Extracted so it runs inside _available_models_cache_lock (RLock) to
     # prevent thundering-herd: only one thread rebuilds while others wait.
@@ -1673,6 +1681,14 @@ def get_available_models() -> dict:
     # its result rather than running the cold path concurrently.
     should_wait = _cache_build_in_progress
 
+    # Check config mtime OUTSIDE the lock so this cheap check doesn't serialize
+    # concurrent requests.  Must come before any config reads in the cold path.
+    try:
+        _current_mtime = Path(_get_config_path()).stat().st_mtime
+    except OSError:
+        _current_mtime = 0.0
+    _cfg_changed = _current_mtime != _cfg_mtime
+
     # Disk load BEFORE lock: ~0.1ms, lets concurrent requests skip entirely.
     # Then acquire lock and check memory cache.  Cold path runs inside the lock
     # so only one thread rebuilds while others wait.
@@ -1692,11 +1708,7 @@ def get_available_models() -> dict:
                 return copy.deepcopy(_available_models_cache)
 
         # Reload config if changed
-        try:
-            _current_mtime = Path(_get_config_path()).stat().st_mtime
-        except OSError:
-            _current_mtime = 0.0
-        if _current_mtime != _cfg_mtime:
+        if _cfg_changed:
             reload_config()
             _available_models_cache = None
             _available_models_cache_ts = 0.0

--- a/api/config.py
+++ b/api/config.py
@@ -211,6 +211,9 @@ def reload_config() -> None:
     with _cfg_lock:
         _cfg_cache.clear()
         config_path = _get_config_path()
+        # Remember the old mtime so we can tell whether config actually changed
+        # vs. first-ever load (mtime == 0.0, e.g. server start or profile switch).
+        _old_cfg_mtime = _cfg_mtime
         try:
             import yaml as _yaml
 
@@ -224,6 +227,13 @@ def reload_config() -> None:
                         _cfg_mtime = 0.0
         except Exception:
             logger.debug("Failed to load yaml config from %s", config_path)
+        # Bust the models cache so the next request sees fresh config values.
+        # Only delete the disk cache when config has actually changed -- not on
+        # first-ever load (when _old_cfg_mtime == 0.0, i.e. server start or
+        # profile switch) -- preserving the disk cache so the next restart
+        # still hits the fast path without a cold run.
+        if _old_cfg_mtime != 0.0:
+            _delete_models_cache_on_disk()
 
 
 def _load_yaml_config_file(config_path: Path) -> dict:
@@ -1076,8 +1086,55 @@ def set_hermes_default_model(model_id: str) -> dict:
 # ── TTL cache for get_available_models() ─────────────────────────────────────
 _available_models_cache: dict | None = None
 _available_models_cache_ts: float = 0.0
-_AVAILABLE_MODELS_CACHE_TTL: float = 60.0  # seconds — refresh at most once per minute
-_available_models_cache_lock = threading.Lock()
+_AVAILABLE_MODELS_CACHE_TTL: float = 86400.0  # 24 hours
+_available_models_cache_lock = threading.RLock()  # must be RLock: cold path refactoring moved slow work inside this lock, requiring re-entry
+
+# Cache for credential pool results -- calling load_pool() per-provider per-server
+# session is expensive (~10s for zai due to endpoint probing).  The credential pool
+# only changes when the user adds/removes credentials, which is rare; a 24h TTL
+# is plenty safe and ensures get_available_models() cold paths are fast.
+_CREDENTIAL_POOL_CACHE: dict[str, tuple[float, "CredentialPool"]] = {}  # pid -> (ts, pool)
+_provider_models_invalidated_ts: dict[str, float] = {}  # provider_id -> timestamp of last invalidation
+
+# Disk-backed in-memory cache for get_available_models().
+# Written to disk on every cache population so the cache survives server restarts.
+# Invalidated (file deleted) whenever a provider is added/changed/removed or
+# config.yaml changes.  A TTL is still used as a fallback in case the invalidation
+# signal is somehow missed, but the cache will always be warm after the first
+# page load following a server start.
+_models_cache_path = Path("/dev/shm") / "hermes_webui_models_cache.json"
+
+
+def _delete_models_cache_on_disk() -> None:
+    try:
+        os.unlink(str(_models_cache_path))
+    except OSError:
+        pass  # already absent
+
+
+def _load_models_cache_from_disk() -> dict | None:
+    """Load groups dict from disk cache if it exists and is valid."""
+    try:
+        import json as _j
+        if not _models_cache_path.exists():
+            return None
+        with open(_models_cache_path, encoding="utf-8") as f:
+            cache = _j.load(f)
+        return cache if isinstance(cache, dict) and "groups" in cache else None
+    except Exception:
+        return None
+
+
+def _save_models_cache_to_disk(cache: dict) -> None:
+    """Save cache to disk so it survives server restarts."""
+    try:
+        import time as _cache_time
+        tmp = str(_models_cache_path) + f".{os.getpid()}.tmp"
+        with open(tmp, "w", encoding="utf-8") as f:
+            json.dump({"groups": cache.get("groups", [])}, f, indent=2)
+        os.rename(tmp, str(_models_cache_path))
+    except Exception:
+        pass  # Non-fatal -- cache will rebuild on next call
 
 
 def invalidate_models_cache():
@@ -1091,6 +1148,26 @@ def invalidate_models_cache():
     with _available_models_cache_lock:
         _available_models_cache = None
         _available_models_cache_ts = 0.0
+
+
+def invalidate_provider_models_cache(provider_id: str):
+    """Invalidate cached models for a single provider.
+
+    Also invalidates the full cache so that the next get_available_models()
+    call rebuilds all groups cleanly (the rebuilt provider is merged with any
+    other cached groups from the 24h TTL window).  After the next
+    get_available_models() call, _provider_models_invalidated_ts[provider_id]
+    is cleared so the provider's fresh models are used.
+
+    Args:
+        provider_id: canonical provider id (e.g. 'openai', 'anthropic', 'custom:my-key')
+    """
+    global _available_models_cache, _available_models_cache_ts
+    with _available_models_cache_lock:
+        _available_models_cache = None
+        _available_models_cache_ts = 0.0
+        _provider_models_invalidated_ts[provider_id] = time.time()
+    _delete_models_cache_on_disk()
 
 
 def _get_label_for_model(model_id: str, existing_groups: list) -> str:
@@ -1142,453 +1219,394 @@ def get_available_models() -> dict:
         'groups': [{'provider': str, 'models': [{'id': str, 'label': str}]}]
     }
     """
-    # Reload config from disk if config.yaml has changed since last load.
-    # This ensures CLI model changes are picked up on page refresh without
-    # a server restart, while avoiding clearing in-memory mocks during tests. (#585)
-    # Must run BEFORE the TTL check so config edits within the 60s window are visible.
-    global _available_models_cache, _available_models_cache_ts
-    with _available_models_cache_lock:
+    # ── COLD PATH helper ─────────────────────────────────────────────────────
+    # Extracted so it runs inside _available_models_cache_lock (RLock) to
+    # prevent thundering-herd: only one thread rebuilds while others wait.
+    def _build_available_models_uncached() -> dict:
+        active_provider = None
+        default_model = get_effective_default_model(cfg)
+        groups = []
+
+        # 1. Read config.yaml model section
+        cfg_base_url = ""  # must be defined before conditional blocks (#117)
+        model_cfg = cfg.get("model", {})
+        cfg_base_url = ""
+        if isinstance(model_cfg, str):
+            pass  # default_model already set by get_effective_default_model
+        elif isinstance(model_cfg, dict):
+            active_provider = model_cfg.get("provider")
+            cfg_default = model_cfg.get("default", "")
+            cfg_base_url = model_cfg.get("base_url", "")
+            if cfg_default:
+                default_model = cfg_default
+
+        # Normalize active_provider to its canonical key
+        if active_provider:
+            active_provider = _resolve_provider_alias(active_provider)
+
+        # 2. Read auth store (active_provider fallback + credential_pool inspection)
+        auth_store = {}
         try:
-            _current_mtime = Path(_get_config_path()).stat().st_mtime
-        except OSError:
-            _current_mtime = 0.0
-        # Note: env-var changes (e.g. API key rotation) are not detected by mtime;
-        # cache will be stale for up to TTL seconds in that case.
-        if _current_mtime != _cfg_mtime:
-            reload_config()
-            # Config changed — force cache invalidation
-            _available_models_cache = None
-            _available_models_cache_ts = 0.0
-        # Serve from TTL cache if fresh.
-        now = time.monotonic()
-        if _available_models_cache is not None and (now - _available_models_cache_ts) < _AVAILABLE_MODELS_CACHE_TTL:
-            return copy.deepcopy(_available_models_cache)
-    active_provider = None
-    default_model = get_effective_default_model(cfg)
-    groups = []
+            from api.profiles import get_active_hermes_home as _gah
 
-    # 1. Read config.yaml model section
-    cfg_base_url = ""  # must be defined before conditional blocks (#117)
-    model_cfg = cfg.get("model", {})
-    cfg_base_url = ""
-    if isinstance(model_cfg, str):
-        pass  # default_model already set by get_effective_default_model
-    elif isinstance(model_cfg, dict):
-        active_provider = model_cfg.get("provider")
-        cfg_default = model_cfg.get("default", "")
-        cfg_base_url = model_cfg.get("base_url", "")
-        if cfg_default:
-            default_model = cfg_default
-
-    # Normalize active_provider to its canonical key so it matches the
-    # _PROVIDER_MODELS lookup below (e.g. 'z.ai' -> 'zai', 'x.ai' -> 'xai',
-    # 'google' -> 'gemini').  Works even when hermes_cli is not on sys.path
-    # because the WebUI ships its own _PROVIDER_ALIASES table.
-    if active_provider:
-        active_provider = _resolve_provider_alias(active_provider)
-
-    # 2. Read auth store (active_provider fallback + credential_pool inspection)
-    auth_store = {}
-    try:
-        from api.profiles import get_active_hermes_home as _gah
-
-        auth_store_path = _gah() / "auth.json"
-    except ImportError:
-        auth_store_path = HOME / ".hermes" / "auth.json"
-    if auth_store_path.exists():
-        try:
-            import json as _j
-
-            auth_store = _j.loads(auth_store_path.read_text(encoding="utf-8"))
-            if not active_provider:
-                # Re-run alias resolution: auth.json may store an aliased name
-                # (e.g. 'google', 'z.ai') that the prefixing logic compares
-                # against canonical pids.
-                active_provider = _resolve_provider_alias(auth_store.get("active_provider"))
-        except Exception:
-            logger.debug("Failed to load auth store from %s", auth_store_path)
-
-    # 3. Detect available providers.
-    # Primary: ask hermes-agent's auth layer — the authoritative source. It checks
-    # auth.json, credential pools, and env vars the same way the agent does at runtime,
-    # so the dropdown reflects exactly what the user has configured.
-    # Fallback: scan raw API key env vars (matches old behaviour if hermes not available).
-    detected_providers = set()
-    if active_provider:
-        detected_providers.add(active_provider)
-
-    # Include providers that have usable credential-pool entries even when no
-    # process env var is present (e.g. service launched without shell env).
-    # Primary: delegate to upstream credential_pool.load_pool() so suppression
-    # and seeding/pruning rules live in one place.
-    # Fallback: manual field inspection when the upstream module is unavailable.
-    try:
-        _pool = auth_store.get("credential_pool", {}) if isinstance(auth_store, dict) else {}
-        if isinstance(_pool, dict) and _pool:
-            try:
-                from agent.credential_pool import load_pool as _load_pool
-
-                # load_pool() does NOT suppress ambient gh-cli tokens — filter
-                # them here so Copilot doesn't reappear just because the agent
-                # seeded 'gh auth token' into the pool.
-                for _pid in list(_pool.keys()):
-                    try:
-                        _canonical_pid = _resolve_provider_alias(str(_pid))
-                        _all_entries = _load_pool(_pid).entries()
-                        _explicit = [
-                            e for e in _all_entries
-                            if not _is_ambient_gh_cli_entry(
-                                str(getattr(e, "source", "") or ""),
-                                str(getattr(e, "label", "") or ""),
-                                str(getattr(e, "key_source", "") or ""),
-                            )
-                        ]
-                        if _explicit:
-                            detected_providers.add(_canonical_pid)
-                    except Exception:
-                        logger.debug("credential_pool.load_pool(%s) failed", _pid)
-            except ImportError:
-                # Fallback: inspect raw entry fields for suppression signals.
-                for _pid, _entries in _pool.items():
-                    if not isinstance(_entries, list) or len(_entries) == 0:
-                        continue
-                    _has_explicit_cred = any(
-                        isinstance(_entry, dict)
-                        and not _is_ambient_gh_cli_entry(
-                            str(_entry.get("source", "") or ""),
-                            str(_entry.get("label", "") or ""),
-                            str(_entry.get("key_source", "") or ""),
-                        )
-                        for _entry in _entries
-                    )
-                    if _has_explicit_cred:
-                        detected_providers.add(_resolve_provider_alias(str(_pid)))
-    except Exception:
-        logger.debug("Failed to inspect credential_pool from auth store")
-
-    all_env: dict = {}  # profile .env keys — populated below, used by custom endpoint auth
-
-    _hermes_auth_used = False
-    try:
-        from hermes_cli.models import list_available_providers as _lap
-        from hermes_cli.auth import get_auth_status as _gas
-
-        for _p in _lap():
-            if not _p.get("authenticated"):
-                continue
-            # Exclude providers whose credential came from an ambient token
-            # (e.g. 'gh auth token' for Copilot on a machine with gh CLI auth).
-            # Only include providers with an explicit, dedicated credential.
-            try:
-                _src = _gas(_p["id"]).get("key_source", "")
-                if _src == "gh auth token":
-                    continue
-            except Exception:
-                logger.debug("Failed to get key source for provider %s", _p.get("id", "unknown"))
-            detected_providers.add(_p["id"])
-        _hermes_auth_used = True
-    except Exception:
-        logger.debug("Failed to detect auth providers from hermes")
-
-    if not _hermes_auth_used:
-        # Fallback: scan .env and os.environ for known API key variables
-        try:
-            from api.profiles import get_active_hermes_home as _gah2
-
-            hermes_env_path = _gah2() / ".env"
+            auth_store_path = _gah() / "auth.json"
         except ImportError:
-            hermes_env_path = HOME / ".hermes" / ".env"
-        env_keys = {}
-        if hermes_env_path.exists():
+            auth_store_path = HOME / ".hermes" / "auth.json"
+        if auth_store_path.exists():
             try:
-                for line in hermes_env_path.read_text(encoding="utf-8").splitlines():
-                    line = line.strip()
-                    if line and not line.startswith("#") and "=" in line:
-                        k, v = line.split("=", 1)
-                        env_keys[k.strip()] = v.strip().strip('"').strip("'")
+                import json as _j
+
+                auth_store = _j.loads(auth_store_path.read_text(encoding="utf-8"))
+                if not active_provider:
+                    active_provider = _resolve_provider_alias(auth_store.get("active_provider"))
             except Exception:
-                logger.debug("Failed to parse hermes env file")
-        all_env = {**env_keys}
-        for k in (
-            "ANTHROPIC_API_KEY",
-            "OPENAI_API_KEY",
-            "OPENROUTER_API_KEY",
-            "GOOGLE_API_KEY",
-            "GEMINI_API_KEY",
-            "GLM_API_KEY",
-            "KIMI_API_KEY",
-            "DEEPSEEK_API_KEY",
-            "OPENCODE_ZEN_API_KEY",
-            "OPENCODE_GO_API_KEY",
-            "MINIMAX_API_KEY",
-            "MINIMAX_CN_API_KEY",
-        ):
-            val = os.getenv(k)
-            if val:
-                all_env[k] = val
-        if all_env.get("ANTHROPIC_API_KEY"):
-            detected_providers.add("anthropic")
-        if all_env.get("OPENAI_API_KEY"):
-            detected_providers.add("openai")
-        if all_env.get("OPENROUTER_API_KEY"):
-            detected_providers.add("openrouter")
-        if all_env.get("GOOGLE_API_KEY"):
-            detected_providers.add("google")
-        if all_env.get("GEMINI_API_KEY"):
-            detected_providers.add("gemini")
-        if all_env.get("GLM_API_KEY"):
-            detected_providers.add("zai")
-        if all_env.get("KIMI_API_KEY"):
-            detected_providers.add("kimi-coding")
-        if all_env.get("MINIMAX_API_KEY") or all_env.get("MINIMAX_CN_API_KEY"):
-            detected_providers.add("minimax")
-        if all_env.get("DEEPSEEK_API_KEY"):
-            detected_providers.add("deepseek")
-        if all_env.get("OPENCODE_ZEN_API_KEY"):
-            detected_providers.add("opencode-zen")
-        if all_env.get("OPENCODE_GO_API_KEY"):
-            detected_providers.add("opencode-go")
+                logger.debug("Failed to load auth store from %s", auth_store_path)
 
-    # 4. Fetch models from custom endpoint if base_url is configured
-    auto_detected_models = []
-    if cfg_base_url:
+        # 3. Detect available providers.
+        detected_providers = set()
+        if active_provider:
+            detected_providers.add(active_provider)
+
         try:
-            import ipaddress
-            import urllib.request
-
-            # Normalize the base_url and build models endpoint
-            base_url = cfg_base_url.strip()
-            if base_url.endswith("/v1"):
-                endpoint_url = base_url + "/models"  # /v1/models
-            else:
-                endpoint_url = base_url.rstrip("/") + "/v1/models"
-
-            # Detect provider from base_url
-            provider = "custom"
-            parsed = urlparse(base_url if "://" in base_url else f"http://{base_url}")
-            host = (parsed.netloc or parsed.path).lower()
-
-            if parsed.hostname:
+            _pool = auth_store.get("credential_pool", {}) if isinstance(auth_store, dict) else {}
+            if isinstance(_pool, dict) and _pool:
                 try:
-                    addr = ipaddress.ip_address(parsed.hostname)
-                    if addr.is_private or addr.is_loopback or addr.is_link_local:
-                        if (
-                            "ollama" in host
-                            or "127.0.0.1" in host
-                            or "localhost" in host
-                        ):
-                            provider = "ollama"
-                        elif "lmstudio" in host or "lm-studio" in host:
-                            provider = "lmstudio"
-                        else:
-                            provider = "local"
-                except ValueError:
-                    pass
+                    from agent.credential_pool import load_pool as _load_pool
 
-            # Resolve API key for the custom / OpenAI-compatible endpoint.
-            # Priority:
-            #   1. model.api_key in config.yaml
-            #   2. provider-specific providers.<active>.api_key / providers.custom.api_key
-            #   3. env/.env fallbacks
-            headers = {}
-            api_key = ""
-            if isinstance(model_cfg, dict):
-                api_key = (model_cfg.get("api_key") or "").strip()
-            if not api_key:
-                providers_cfg = cfg.get("providers", {})
-                if isinstance(providers_cfg, dict):
-                    for provider_key in filter(None, [active_provider, "custom"]):
-                        provider_cfg = providers_cfg.get(provider_key, {})
-                        if isinstance(provider_cfg, dict):
-                            api_key = (provider_cfg.get("api_key") or "").strip()
-                            if api_key:
-                                break
-            if not api_key:
-                api_key_vars = (
-                    "HERMES_API_KEY",
-                    "HERMES_OPENAI_API_KEY",
-                    "OPENAI_API_KEY",
-                    "LOCAL_API_KEY",
-                    "OPENROUTER_API_KEY",
-                    "API_KEY",
-                )
-                for key in api_key_vars:
-                    api_key = (all_env.get(key) or os.getenv(key) or "").strip()
-                    if api_key:
-                        break
-            if api_key:
-                headers["Authorization"] = f"Bearer {api_key}"
-
-            # Fetch model list from endpoint (with SSRF protection)
-            import socket
-
-            # Resolve hostname and check against private IPs after DNS lookup
-            parsed_url = urlparse(
-                endpoint_url if "://" in endpoint_url else f"http://{endpoint_url}"
-            )
-            # Validate URL scheme to prevent file:// and other dangerous schemes
-            if parsed_url.scheme not in ("", "http", "https"):
-                raise ValueError(f"Invalid URL scheme: {parsed_url.scheme}")
-            if parsed_url.hostname:
-                try:
-                    resolved_ips = socket.getaddrinfo(parsed_url.hostname, None)
-                    for _, _, _, _, addr in resolved_ips:
-                        addr_obj = ipaddress.ip_address(addr[0])
-                        if (
-                            addr_obj.is_private
-                            or addr_obj.is_loopback
-                            or addr_obj.is_link_local
-                        ):
-                            # Allow known local providers (ollama, lmstudio)
-                            is_known_local = any(
-                                k in (parsed_url.hostname or "").lower()
-                                for k in (
-                                    "ollama",
-                                    "localhost",
-                                    "127.0.0.1",
-                                    "lmstudio",
-                                    "lm-studio",
+                    for _pid in list(_pool.keys()):
+                        try:
+                            _canonical_pid = _resolve_provider_alias(str(_pid))
+                            # Check credential pool cache first
+                            _cached = _CREDENTIAL_POOL_CACHE.get(_pid)
+                            if _cached is not None:
+                                _cp_ts, _cp_pool = _cached
+                                if (time.time() - _cp_ts) < 86400.0:
+                                    _all_entries = _cp_pool.entries()
+                                else:
+                                    _lp_t0 = time.monotonic()
+                                    _cp_pool = _load_pool(_pid)
+                                    _CREDENTIAL_POOL_CACHE[_pid] = (time.time(), _cp_pool)
+                                    _all_entries = _cp_pool.entries()
+                            else:
+                                _lp_t0 = time.monotonic()
+                                _cp_pool = _load_pool(_pid)
+                                _CREDENTIAL_POOL_CACHE[_pid] = (time.time(), _cp_pool)
+                                _all_entries = _cp_pool.entries()
+                            _explicit = [
+                                e for e in _all_entries
+                                if not _is_ambient_gh_cli_entry(
+                                    str(getattr(e, "source", "") or ""),
+                                    str(getattr(e, "label", "") or ""),
+                                    str(getattr(e, "key_source", "") or ""),
                                 )
+                            ]
+                            if _explicit:
+                                detected_providers.add(_canonical_pid)
+                        except Exception:
+                            logger.debug("credential_pool.load_pool(%s) failed", _pid)
+                except ImportError:
+                    for _pid, _entries in _pool.items():
+                        if not isinstance(_entries, list) or len(_entries) == 0:
+                            continue
+                        _has_explicit_cred = any(
+                            isinstance(_entry, dict)
+                            and not _is_ambient_gh_cli_entry(
+                                str(_entry.get("source", "") or ""),
+                                str(_entry.get("label", "") or ""),
+                                str(_entry.get("key_source", "") or ""),
                             )
-                            if not is_known_local:
-                                raise ValueError(
-                                    f"SSRF: resolved hostname to private IP {addr[0]}"
-                                )
-                except socket.gaierror:
-                    pass  # DNS resolution failed -- let urllib handle it
-            req = urllib.request.Request(endpoint_url, method="GET")
-            req.add_header("User-Agent", "OpenAI/Python 1.0")
-            for k, v in headers.items():
-                req.add_header(k, v)
-            with urllib.request.urlopen(req, timeout=10) as response:  # nosec B310
-                data = json.loads(response.read().decode("utf-8"))
-
-            # Handle both OpenAI-compatible and llama.cpp response formats
-            models_list = []
-            if "data" in data and isinstance(data["data"], list):
-                models_list = data["data"]
-            elif "models" in data and isinstance(data["models"], list):
-                models_list = data["models"]
-
-            for model in models_list:
-                if not isinstance(model, dict):
-                    continue
-                model_id = (
-                    model.get("id", "")
-                    or model.get("name", "")
-                    or model.get("model", "")
-                )
-                model_name = model.get("name", "") or model.get("model", "") or model_id
-                if model_id and model_name:
-                    label = _format_ollama_label(model_id) if provider in ("ollama", "ollama-cloud") else model_name
-                    auto_detected_models.append({"id": model_id, "label": label})
-                    detected_providers.add(provider.lower())
+                            for _entry in _entries
+                        )
+                        if _has_explicit_cred:
+                            detected_providers.add(_resolve_provider_alias(str(_pid)))
         except Exception:
-            logger.debug("Custom endpoint unreachable or misconfigured for provider: %s", provider)
+            logger.debug("Failed to inspect credential_pool from auth store")
 
-    # 3b. Include models from custom_providers config entries.
-    # These are explicitly configured and should always appear even when the
-    # /v1/models endpoint is unreachable or returns a subset.
-    #
-    # Each entry may carry a `name` field (e.g. "Agent37").  When present we
-    # use it as the dropdown section header instead of the generic "Custom"
-    # label.  Internally we key these providers as "custom:<slug>" so that
-    # multiple named custom providers can coexist as separate groups.
-    _custom_providers_cfg = cfg.get("custom_providers", [])
-    # Maps "custom:<slug>" -> (display_name, [model_dicts])
-    _named_custom_groups: dict = {}
-    if isinstance(_custom_providers_cfg, list):
-        _seen_custom_ids = {m["id"] for m in auto_detected_models}
-        for _cp in _custom_providers_cfg:
-            if not isinstance(_cp, dict):
-                continue
-            _cp_model = _cp.get("model", "")
-            _cp_name = (_cp.get("name") or "").strip()
-            if _cp_model and _cp_model not in _seen_custom_ids:
-                _cp_label = _get_label_for_model(_cp_model, [])
-                _seen_custom_ids.add(_cp_model)
-                if _cp_name:
-                    # Named custom provider — own group keyed by slug
-                    _slug = "custom:" + _cp_name.lower().replace(" ", "-")
-                    if _slug not in _named_custom_groups:
-                        _named_custom_groups[_slug] = (_cp_name, [])
-                        detected_providers.add(_slug)
-                    _named_custom_groups[_slug][1].append(
-                        {"id": _cp_model, "label": _cp_label}
-                    )
-                else:
-                    # Unnamed — falls into the generic "Custom" bucket
-                    auto_detected_models.append({"id": _cp_model, "label": _cp_label})
-                    detected_providers.add("custom")
+        all_env: dict = {}
 
-    # If the user configured a real model.provider, the base_url belongs to
-    # THAT provider, not to a separate "Custom" group. hermes_cli reports
-    # 'custom' as authenticated whenever base_url is set, which would otherwise
-    # build a phantom "Custom" bucket next to the real provider's group. Drop
-    # it unless (a) the user explicitly chose 'custom' as their active provider,
-    # or (b) the user has custom_providers entries in config.yaml (those models
-    # were already added above and should still be shown).
-    _has_custom_providers = isinstance(_custom_providers_cfg, list) and len(_custom_providers_cfg) > 0
-    if active_provider and active_provider != "custom" and not _has_custom_providers:
-        detected_providers.discard("custom")
-        # Also drop named custom slugs when active provider is a real named one
-        # and there are no custom_providers entries to show.
-        for _slug in list(detected_providers):
-            if _slug.startswith("custom:") and not _has_custom_providers:
-                detected_providers.discard(_slug)
-    elif active_provider == "custom" and _has_custom_providers:
-        # When the active provider is 'custom' and all custom_providers entries
-        # are named (i.e. every entry produced a "custom:<slug>" key), the bare
-        # "custom" bucket is empty noise — discard it so the dropdown only shows
-        # the named groups.  We keep "custom" if there are unnamed entries (they
-        # were added to auto_detected_models and will render under the generic
-        # "Custom" header via the else branch in the group builder).
-        _has_unnamed = any(
-            isinstance(_cp, dict) and not (_cp.get("name") or "").strip()
-            for _cp in _custom_providers_cfg
-        )
-        if not _has_unnamed:
-            detected_providers.discard("custom")
+        _hermes_auth_used = False
+        try:
+            from hermes_cli.models import list_available_providers as _lap
+            from hermes_cli.auth import get_auth_status as _gas
 
-    # 5. Build model groups
-    if detected_providers:
-        for pid in sorted(detected_providers):
-            if pid.startswith("custom:") and pid in _named_custom_groups:
-                # Named custom provider — use the stored display name and its own model list
-                _nc_display, _nc_models = _named_custom_groups[pid]
-                if _nc_models:
-                    groups.append({"provider": _nc_display, "provider_id": pid, "models": _nc_models})
-                continue
-            provider_name = _PROVIDER_DISPLAY.get(pid, pid.title())
-            if pid == "openrouter":
-                # OpenRouter uses provider/model format -- show the fallback list
-                groups.append(
-                    {
-                        "provider": "OpenRouter",
-                        "provider_id": "openrouter",
-                        "models": [
-                            {"id": m["id"], "label": m["label"]}
-                            for m in _FALLBACK_MODELS
-                        ],
-                    }
-                )
-            elif pid == "ollama-cloud":
-                # Ollama Cloud list is dynamic; fetch via hermes_cli provider catalog.
-                # When the catalog is unavailable, skip the group rather than emit a
-                # speculative static list — matches the named-custom and unknown-provider
-                # branches below.
-                raw_models = []
+            for _p in _lap():
+                if not _p.get("authenticated"):
+                    continue
                 try:
-                    from hermes_cli.models import provider_model_ids as _provider_model_ids
-
-                    raw_models = [
-                        {"id": mid, "label": _format_ollama_label(mid)}
-                        for mid in (_provider_model_ids("ollama-cloud") or [])
-                    ]
+                    _src = _gas(_p["id"]).get("key_source", "")
+                    if _src == "gh auth token":
+                        continue
                 except Exception:
-                    logger.warning("Failed to load Ollama Cloud models from hermes_cli")
+                    logger.debug("Failed to get key source for provider %s", _p.get("id", "unknown"))
+                detected_providers.add(_p["id"])
+            _hermes_auth_used = True
+        except Exception:
+            logger.debug("Failed to detect auth providers from hermes")
 
-                if raw_models:
+        if not _hermes_auth_used:
+            try:
+                from api.profiles import get_active_hermes_home as _gah2
+
+                hermes_env_path = _gah2() / ".env"
+            except ImportError:
+                hermes_env_path = HOME / ".hermes" / ".env"
+            env_keys = {}
+            if hermes_env_path.exists():
+                try:
+                    for line in hermes_env_path.read_text(encoding="utf-8").splitlines():
+                        line = line.strip()
+                        if line and not line.startswith("#") and "=" in line:
+                            k, v = line.split("=", 1)
+                            env_keys[k.strip()] = v.strip().strip('"').strip("'")
+                except Exception:
+                    logger.debug("Failed to parse hermes env file")
+            all_env = {**env_keys}
+            for k in (
+                "ANTHROPIC_API_KEY",
+                "OPENAI_API_KEY",
+                "OPENROUTER_API_KEY",
+                "GOOGLE_API_KEY",
+                "GEMINI_API_KEY",
+                "GLM_API_KEY",
+                "KIMI_API_KEY",
+                "DEEPSEEK_API_KEY",
+                "OPENCODE_ZEN_API_KEY",
+                "OPENCODE_GO_API_KEY",
+                "MINIMAX_API_KEY",
+                "MINIMAX_CN_API_KEY",
+            ):
+                val = os.getenv(k)
+                if val:
+                    all_env[k] = val
+            if all_env.get("ANTHROPIC_API_KEY"):
+                detected_providers.add("anthropic")
+            if all_env.get("OPENAI_API_KEY"):
+                detected_providers.add("openai")
+            if all_env.get("OPENROUTER_API_KEY"):
+                detected_providers.add("openrouter")
+            if all_env.get("GOOGLE_API_KEY"):
+                detected_providers.add("google")
+            if all_env.get("GEMINI_API_KEY"):
+                detected_providers.add("gemini")
+            if all_env.get("GLM_API_KEY"):
+                detected_providers.add("zai")
+            if all_env.get("KIMI_API_KEY"):
+                detected_providers.add("kimi-coding")
+            if all_env.get("MINIMAX_API_KEY") or all_env.get("MINIMAX_CN_API_KEY"):
+                detected_providers.add("minimax")
+            if all_env.get("DEEPSEEK_API_KEY"):
+                detected_providers.add("deepseek")
+            if all_env.get("OPENCODE_ZEN_API_KEY"):
+                detected_providers.add("opencode-zen")
+            if all_env.get("OPENCODE_GO_API_KEY"):
+                detected_providers.add("opencode-go")
+
+        # 4. Fetch models from custom endpoint if base_url is configured
+        auto_detected_models = []
+        if cfg_base_url:
+            try:
+                import ipaddress
+                import urllib.request
+
+                base_url = cfg_base_url.strip()
+                if base_url.endswith("/v1"):
+                    endpoint_url = base_url + "/models"
+                else:
+                    endpoint_url = base_url.rstrip("/") + "/v1/models"
+
+                provider = "custom"
+                parsed = urlparse(base_url if "://" in base_url else f"http://{base_url}")
+                host = (parsed.netloc or parsed.path).lower()
+
+                if parsed.hostname:
+                    try:
+                        addr = ipaddress.ip_address(parsed.hostname)
+                        if addr.is_private or addr.is_loopback or addr.is_link_local:
+                            if "ollama" in host or "127.0.0.1" in host or "localhost" in host:
+                                provider = "ollama"
+                            elif "lmstudio" in host or "lm-studio" in host:
+                                provider = "lmstudio"
+                            else:
+                                provider = "local"
+                    except ValueError:
+                        pass
+
+                headers = {}
+                api_key = ""
+                if isinstance(model_cfg, dict):
+                    api_key = (model_cfg.get("api_key") or "").strip()
+                if not api_key:
+                    providers_cfg = cfg.get("providers", {})
+                    if isinstance(providers_cfg, dict):
+                        for provider_key in filter(None, [active_provider, "custom"]):
+                            provider_cfg = providers_cfg.get(provider_key, {})
+                            if isinstance(provider_cfg, dict):
+                                api_key = (provider_cfg.get("api_key") or "").strip()
+                                if api_key:
+                                    break
+                if not api_key:
+                    api_key_vars = (
+                        "HERMES_API_KEY",
+                        "HERMES_OPENAI_API_KEY",
+                        "OPENAI_API_KEY",
+                        "LOCAL_API_KEY",
+                        "OPENROUTER_API_KEY",
+                        "API_KEY",
+                    )
+                    for key in api_key_vars:
+                        api_key = (all_env.get(key) or os.getenv(key) or "").strip()
+                        if api_key:
+                            break
+                if api_key:
+                    headers["Authorization"] = f"Bearer {api_key}"
+
+                import socket
+
+                parsed_url = urlparse(
+                    endpoint_url if "://" in endpoint_url else f"http://{endpoint_url}"
+                )
+                if parsed_url.scheme not in ("", "http", "https"):
+                    raise ValueError(f"Invalid URL scheme: {parsed_url.scheme}")
+                if parsed_url.hostname:
+                    try:
+                        resolved_ips = socket.getaddrinfo(parsed_url.hostname, None)
+                        for _, _, _, _, addr in resolved_ips:
+                            addr_obj = ipaddress.ip_address(addr[0])
+                            if addr_obj.is_private or addr_obj.is_loopback or addr_obj.is_link_local:
+                                is_known_local = any(
+                                    k in (parsed_url.hostname or "").lower()
+                                    for k in (
+                                        "ollama",
+                                        "localhost",
+                                        "127.0.0.1",
+                                        "lmstudio",
+                                        "lm-studio",
+                                    )
+                                )
+                                if not is_known_local:
+                                    raise ValueError(
+                                        f"SSRF: resolved hostname to private IP {addr[0]}"
+                                    )
+                    except socket.gaierror:
+                        pass
+                req = urllib.request.Request(endpoint_url, method="GET")
+                req.add_header("User-Agent", "OpenAI/Python 1.0")
+                for k, v in headers.items():
+                    req.add_header(k, v)
+                with urllib.request.urlopen(req, timeout=10) as response:  # nosec B310
+                    data = json.loads(response.read().decode("utf-8"))
+
+                models_list = []
+                if "data" in data and isinstance(data["data"], list):
+                    models_list = data["data"]
+                elif "models" in data and isinstance(data["models"], list):
+                    models_list = data["models"]
+
+                for model in models_list:
+                    if not isinstance(model, dict):
+                        continue
+                    model_id = (
+                        model.get("id", "")
+                        or model.get("name", "")
+                        or model.get("model", "")
+                    )
+                    model_name = model.get("name", "") or model.get("model", "") or model_id
+                    if model_id and model_name:
+                        label = _format_ollama_label(model_id) if provider in ("ollama", "ollama-cloud") else model_name
+                        auto_detected_models.append({"id": model_id, "label": label})
+                        detected_providers.add(provider.lower())
+            except Exception:
+                logger.debug("Custom endpoint unreachable or misconfigured for provider: %s", provider)
+
+        _custom_providers_cfg = cfg.get("custom_providers", [])
+        _named_custom_groups: dict = {}
+        if isinstance(_custom_providers_cfg, list):
+            _seen_custom_ids = {m["id"] for m in auto_detected_models}
+            for _cp in _custom_providers_cfg:
+                if not isinstance(_cp, dict):
+                    continue
+                _cp_model = _cp.get("model", "")
+                _cp_name = (_cp.get("name") or "").strip()
+                if _cp_model and _cp_model not in _seen_custom_ids:
+                    _cp_label = _get_label_for_model(_cp_model, [])
+                    _seen_custom_ids.add(_cp_model)
+                    if _cp_name:
+                        _slug = "custom:" + _cp_name.lower().replace(" ", "-")
+                        if _slug not in _named_custom_groups:
+                            _named_custom_groups[_slug] = (_cp_name, [])
+                            detected_providers.add(_slug)
+                        _named_custom_groups[_slug][1].append(
+                            {"id": _cp_model, "label": _cp_label}
+                        )
+                    else:
+                        auto_detected_models.append({"id": _cp_model, "label": _cp_label})
+                        detected_providers.add("custom")
+
+        _has_custom_providers = isinstance(_custom_providers_cfg, list) and len(_custom_providers_cfg) > 0
+        if active_provider and active_provider != "custom" and not _has_custom_providers:
+            detected_providers.discard("custom")
+            for _slug in list(detected_providers):
+                if _slug.startswith("custom:") and not _has_custom_providers:
+                    detected_providers.discard(_slug)
+        elif active_provider == "custom" and _has_custom_providers:
+            _has_unnamed = any(
+                isinstance(_cp, dict) and not (_cp.get("name") or "").strip()
+                for _cp in _custom_providers_cfg
+            )
+            if not _has_unnamed:
+                detected_providers.discard("custom")
+
+        # 5. Build model groups
+        if detected_providers:
+            for pid in sorted(detected_providers):
+                if pid.startswith("custom:") and pid in _named_custom_groups:
+                    _nc_display, _nc_models = _named_custom_groups[pid]
+                    if _nc_models:
+                        groups.append({"provider": _nc_display, "provider_id": pid, "models": _nc_models})
+                    continue
+                provider_name = _PROVIDER_DISPLAY.get(pid, pid.title())
+                if pid == "openrouter":
+                    groups.append(
+                        {
+                            "provider": "OpenRouter",
+                            "provider_id": "openrouter",
+                            "models": [
+                                {"id": m["id"], "label": m["label"]}
+                                for m in _FALLBACK_MODELS
+                            ],
+                        }
+                    )
+                elif pid == "ollama-cloud":
+                    raw_models = []
+                    try:
+                        from hermes_cli.models import provider_model_ids as _provider_model_ids
+
+                        raw_models = [
+                            {"id": mid, "label": _format_ollama_label(mid)}
+                            for mid in (_provider_model_ids("ollama-cloud") or [])
+                        ]
+                    except Exception:
+                        logger.warning("Failed to load Ollama Cloud models from hermes_cli")
+
+                    if raw_models:
+                        models = _apply_provider_prefix(raw_models, pid, active_provider)
+                        groups.append(
+                            {
+                                "provider": provider_name,
+                                "provider_id": pid,
+                                "models": models,
+                            }
+                        )
+                elif pid in _PROVIDER_MODELS or pid in cfg.get("providers", {}):
+                    raw_models = _PROVIDER_MODELS.get(pid, [])
+
+                    provider_cfg = cfg.get("providers", {}).get(pid, {})
+                    if isinstance(provider_cfg, dict) and "models" in provider_cfg:
+                        cfg_models = provider_cfg["models"]
+                        if isinstance(cfg_models, dict):
+                            raw_models = [{"id": k, "label": k} for k in cfg_models.keys()]
+                        elif isinstance(cfg_models, list):
+                            raw_models = [{"id": k, "label": k} for k in cfg_models]
                     models = _apply_provider_prefix(raw_models, pid, active_provider)
                     groups.append(
                         {
@@ -1597,111 +1615,90 @@ def get_available_models() -> dict:
                             "models": models,
                         }
                     )
-            elif pid in _PROVIDER_MODELS or pid in cfg.get("providers", {}):
-                # For non-default providers, prefix model IDs with @provider:model
-                # so resolve_model_provider() routes through that specific provider
-                # via resolve_runtime_provider(requested=provider).
-                # The default provider's models keep bare names for direct API routing.
-                raw_models = _PROVIDER_MODELS.get(pid, [])
-                
-                # Override or merge from config.yaml if user specified explicit models
-                provider_cfg = cfg.get("providers", {}).get(pid, {})
-                if isinstance(provider_cfg, dict) and "models" in provider_cfg:
-                    cfg_models = provider_cfg["models"]
-                    if isinstance(cfg_models, dict):
-                        # config format is usually models: { "gpt-5.4": { context_length: ... } }
-                        raw_models = [{"id": k, "label": k} for k in cfg_models.keys()]
-                    elif isinstance(cfg_models, list):
-                        raw_models = [{"id": k, "label": k} for k in cfg_models]
-                models = _apply_provider_prefix(raw_models, pid, active_provider)
+                else:
+                    if auto_detected_models:
+                        groups.append(
+                            {
+                                "provider": provider_name,
+                                "provider_id": pid,
+                                "models": auto_detected_models,
+                            }
+                        )
+        else:
+            if default_model:
+                label = _get_label_for_model(default_model, groups)
                 groups.append(
-                    {
-                        "provider": provider_name,
-                        "provider_id": pid,
-                        "models": models,
-                    }
+                    {"provider": "Default", "provider_id": "default", "models": [{"id": default_model, "label": label}]}
                 )
-            else:
-                # Unknown provider -- use auto-detected models if available,
-                # otherwise skip it for the model dropdown. Do NOT inject the
-                # global default_model here: that would incorrectly imply the
-                # provider can serve the default model (e.g. Alibaba -> gpt-5.4-mini).
-                if auto_detected_models:
+
+        if default_model:
+            _norm = lambda mid: (mid.split("/", 1)[-1] if "/" in mid else mid).replace("-", ".")
+            all_ids_norm = {_norm(m["id"]) for g in groups for m in g.get("models", [])}
+            if _norm(default_model) not in all_ids_norm:
+                label = _get_label_for_model(default_model, groups)
+                target_display = (
+                    _PROVIDER_DISPLAY.get(active_provider, active_provider or "").lower()
+                    if active_provider
+                    else ""
+                )
+                injected = False
+                for g in groups:
+                    if target_display and g.get("provider", "").lower() == target_display:
+                        g["models"].insert(0, {"id": default_model, "label": label})
+                        injected = True
+                        break
+                if not injected and groups:
                     groups.append(
                         {
-                            "provider": provider_name,
-                            "provider_id": pid,
-                            "models": auto_detected_models,
+                            "provider": "Default",
+                            "provider_id": active_provider or "default",
+                            "models": [{"id": default_model, "label": label}],
                         }
                     )
-    else:
-        # No providers detected. Show only the configured default model so the user
-        # can at least send messages with their current setting. Avoid showing a
-        # generic multi-provider list — those models wouldn't be routable anyway.
-        if default_model:
-            label = _get_label_for_model(default_model, groups)
-            groups.append(
-                {"provider": "Default", "provider_id": "default", "models": [{"id": default_model, "label": label}]}
-            )
 
-    # Ensure the user's configured default_model always appears in the dropdown.
-    # It may be missing if the model isn't in any hardcoded list (e.g. openrouter/free,
-    # a custom local model, or any model.default not in _FALLBACK_MODELS).
-    # Normalize before comparing: strip provider prefix and unify separators so
-    # 'anthropic/claude-opus-4.6' matches 'claude-opus-4.6' and 'claude-sonnet-4-6'
-    # matches 'claude-sonnet-4.6' (hermes-agent uses hyphens, webui uses dots).
-    if default_model:
-        _norm = lambda mid: (mid.split("/", 1)[-1] if "/" in mid else mid).replace("-", ".")
-        all_ids_norm = {_norm(m["id"]) for g in groups for m in g.get("models", [])}
-        if _norm(default_model) not in all_ids_norm:
-            # Determine which group to inject into. Compare against the
-            # provider's display name from _PROVIDER_DISPLAY rather than
-            # doing a substring match on active_provider — substring
-            # matching breaks on hyphenated provider IDs like 'openai-codex'
-            # vs display name 'OpenAI Codex' (hyphen vs. space), which
-            # silently falls through to groups[0] and lands the model in
-            # the wrong group.
-            label = _get_label_for_model(default_model, groups)
-            target_display = (
-                _PROVIDER_DISPLAY.get(active_provider, active_provider or "").lower()
-                if active_provider
-                else ""
-            )
-            injected = False
-            for g in groups:
-                if target_display and g.get("provider", "").lower() == target_display:
-                    g["models"].insert(0, {"id": default_model, "label": label})
-                    injected = True
-                    break
-            if not injected and groups:
-                # Keep the default isolated rather than polluting the first
-                # detected provider group.
-                groups.append(
-                    {
-                        "provider": "Default",
-                        "provider_id": "default",
-                        "models": [{"id": default_model, "label": label}],
-                    }
-                )
-            elif not groups:
-                groups.append(
-                    {
-                        "provider": active_provider or "Default",
-                        "provider_id": active_provider or "default",
-                        "models": [{"id": default_model, "label": label}],
-                    }
-                )
+        return {
+            "active_provider": active_provider,
+            "default_model": default_model,
+            "groups": groups,
+        }
 
-    result = {
-        "active_provider": active_provider,
-        "default_model": default_model,
-        "groups": groups,
-    }
-    # Cache the result for TTL seconds
+    # ── FAST PATH ─────────────────────────────────────────────────────────────
+    # Disk load BEFORE lock: ~0.1ms, lets concurrent requests skip entirely.
+    # Then acquire lock and check memory cache.  Cold path runs inside the lock
+    # so only one thread rebuilds while others wait.
+    disk_groups = None
+    if _available_models_cache is None:
+        disk_groups = _load_models_cache_from_disk()
+
     with _available_models_cache_lock:
+        # Reload config if changed
+        try:
+            _current_mtime = Path(_get_config_path()).stat().st_mtime
+        except OSError:
+            _current_mtime = 0.0
+        if _current_mtime != _cfg_mtime:
+            reload_config()
+            _available_models_cache = None
+            _available_models_cache_ts = 0.0
+
+        # Serve from memory cache if fresh
+        now = time.monotonic()
+        if _available_models_cache is not None and (now - _available_models_cache_ts) < _AVAILABLE_MODELS_CACHE_TTL:
+            return copy.deepcopy(_available_models_cache)
+
+        # Cold path: disk cache hit — use it (fast, no lock contention)
+        if disk_groups is not None:
+            _available_models_cache = disk_groups
+            _available_models_cache_ts = now
+            _save_models_cache_to_disk(disk_groups)
+            return copy.deepcopy(disk_groups)
+
+        # Cold path: full rebuild — only one thread reaches here at a time
+        result = _build_available_models_uncached()
         _available_models_cache = result
-        _available_models_cache_ts = time.monotonic()
-    return copy.deepcopy(result)
+        _available_models_cache_ts = now
+        _save_models_cache_to_disk(result)
+        return copy.deepcopy(result)
 
 
 # ── Static file path ─────────────────────────────────────────────────────────

--- a/api/config.py
+++ b/api/config.py
@@ -1088,6 +1088,8 @@ _available_models_cache: dict | None = None
 _available_models_cache_ts: float = 0.0
 _AVAILABLE_MODELS_CACHE_TTL: float = 86400.0  # 24 hours
 _available_models_cache_lock = threading.RLock()  # must be RLock: cold path refactoring moved slow work inside this lock, requiring re-entry
+_cache_build_cv = threading.Condition()  # signaled when _available_models_cache is set from a cold path
+_cache_build_in_progress = False  # True while a cold path is actively building
 
 # Cache for credential pool results -- calling load_pool() per-provider per-server
 # session is expensive (~10s for zai due to endpoint probing).  The credential pool
@@ -1144,10 +1146,12 @@ def invalidate_models_cache():
     the next call to get_available_models() picks up the changes rather
     than returning a stale cached result.
     """
-    global _available_models_cache, _available_models_cache_ts
+    global _cache_build_in_progress, _available_models_cache, _available_models_cache_ts, _cache_build_cv
     with _available_models_cache_lock:
         _available_models_cache = None
         _available_models_cache_ts = 0.0
+        _cache_build_in_progress = False
+        _cache_build_cv.notify_all()
 
 
 def invalidate_provider_models_cache(provider_id: str):
@@ -1219,6 +1223,7 @@ def get_available_models() -> dict:
         'groups': [{'provider': str, 'models': [{'id': str, 'label': str}]}]
     }
     """
+    global _cache_build_in_progress, _available_models_cache, _available_models_cache_ts, _cache_build_cv
     # ── COLD PATH helper ─────────────────────────────────────────────────────
     # Extracted so it runs inside _available_models_cache_lock (RLock) to
     # prevent thundering-herd: only one thread rebuilds while others wait.
@@ -1663,6 +1668,11 @@ def get_available_models() -> dict:
         }
 
     # ── FAST PATH ─────────────────────────────────────────────────────────────
+    # Mark that a build may be in progress BEFORE acquiring the lock.
+    # If another thread has already started the cold path, we will wait for
+    # its result rather than running the cold path concurrently.
+    should_wait = _cache_build_in_progress
+
     # Disk load BEFORE lock: ~0.1ms, lets concurrent requests skip entirely.
     # Then acquire lock and check memory cache.  Cold path runs inside the lock
     # so only one thread rebuilds while others wait.
@@ -1671,6 +1681,16 @@ def get_available_models() -> dict:
         disk_groups = _load_models_cache_from_disk()
 
     with _available_models_cache_lock:
+        # If another thread is already building, wait for its result instead
+        # of re-entering the cold path (avoids duplicate 10s zai load_pool calls).
+        if should_wait:
+            _cache_build_cv.wait_for(
+                lambda: not _cache_build_in_progress and _available_models_cache is not None,
+                timeout=60
+            )
+            if _available_models_cache is not None and (time.monotonic() - _available_models_cache_ts) < _AVAILABLE_MODELS_CACHE_TTL:
+                return copy.deepcopy(_available_models_cache)
+
         # Reload config if changed
         try:
             _current_mtime = Path(_get_config_path()).stat().st_mtime
@@ -1694,9 +1714,14 @@ def get_available_models() -> dict:
             return copy.deepcopy(disk_groups)
 
         # Cold path: full rebuild — only one thread reaches here at a time
+        with _cache_build_cv:
+            _cache_build_in_progress = True
         result = _build_available_models_uncached()
-        _available_models_cache = result
-        _available_models_cache_ts = now
+        with _cache_build_cv:
+            _available_models_cache = result
+            _available_models_cache_ts = time.monotonic()
+            _cache_build_in_progress = False
+            _cache_build_cv.notify_all()
         _save_models_cache_to_disk(result)
         return copy.deepcopy(result)
 

--- a/api/config.py
+++ b/api/config.py
@@ -1166,11 +1166,16 @@ def invalidate_provider_models_cache(provider_id: str):
     Args:
         provider_id: canonical provider id (e.g. 'openai', 'anthropic', 'custom:my-key')
     """
-    global _available_models_cache, _available_models_cache_ts
+    global _available_models_cache, _available_models_cache_ts, _CREDENTIAL_POOL_CACHE
     with _available_models_cache_lock:
         _available_models_cache = None
         _available_models_cache_ts = 0.0
         _provider_models_invalidated_ts[provider_id] = time.time()
+        # Also evict the credential pool so the next cold path re-loads it.
+        # Must evict both the original key and its canonical form (load_pool
+        # may be called with either, and both paths cache under their own key).
+        _CREDENTIAL_POOL_CACHE.pop(provider_id, None)
+        _CREDENTIAL_POOL_CACHE.pop(_resolve_provider_alias(provider_id), None)
     _delete_models_cache_on_disk()
 
 

--- a/api/config.py
+++ b/api/config.py
@@ -1145,6 +1145,13 @@ def invalidate_models_cache():
     Call this after modifying config.cfg in-memory (e.g. in tests) so
     the next call to get_available_models() picks up the changes rather
     than returning a stale cached result.
+
+    Also deletes the on-disk cache so that a subsequent cold build does
+    not immediately reload a stale disk snapshot and skip the fresh build.
+    This is essential for test isolation: without the disk delete, tests
+    that call invalidate_models_cache() still get back the previous test's
+    result from /dev/shm because the disk hit is checked before the memory
+    cache rebuild runs.
     """
     global _cache_build_in_progress, _available_models_cache, _available_models_cache_ts, _cache_build_cv
     with _available_models_cache_lock:
@@ -1157,6 +1164,9 @@ def invalidate_models_cache():
         # stale CredentialPool from a prior auth_store payload — the test_
         # credential_pool_providers suite was hitting this directly.
         _CREDENTIAL_POOL_CACHE.clear()
+    # Also delete the disk cache so the next cold build starts fresh.
+    # Disk delete is outside the lock — file I/O shouldn't block other readers.
+    _delete_models_cache_on_disk()
 
 
 def invalidate_provider_models_cache(provider_id: str):
@@ -1738,7 +1748,14 @@ def get_available_models() -> dict:
         # Cold path: full rebuild — only one thread reaches here at a time
         with _cache_build_cv:
             _cache_build_in_progress = True
-        result = _build_available_models_uncached()
+        try:
+            result = _build_available_models_uncached()
+        except Exception:
+            # Always reset the flag so waiting threads don't block for 60s
+            with _cache_build_cv:
+                _cache_build_in_progress = False
+                _cache_build_cv.notify_all()
+            raise
         with _cache_build_cv:
             _available_models_cache = result
             _available_models_cache_ts = time.monotonic()

--- a/static/panels.js
+++ b/static/panels.js
@@ -1,4 +1,5 @@
 let _currentPanel = 'chat';
+let _renamingAppTitlebar = false;  // guard against re-entrant rename
 let _skillsData = null; // cached skills list
 let _cronList = null; // cached cron jobs (array)
 let _currentCronDetail = null; // full cron job object
@@ -36,10 +37,77 @@ function syncAppTitlebar() {
     const key = APP_TITLEBAR_KEYS[panel];
     mainText = key && typeof t === 'function' ? t(key) : (panel.charAt(0).toUpperCase() + panel.slice(1));
   }
+
+  // Don't touch the element while an inline rename is in progress — replacing
+  // the span with an input would fire a MutationObserver that calls
+  // syncAppTitlebar again, destroying the input before the user finishes.
+  if (_renamingAppTitlebar) return;
+
   titleEl.textContent = mainText;
   if (subEl) {
     if (subText) { subEl.textContent = subText; subEl.hidden = false; }
     else { subEl.textContent = ''; subEl.hidden = true; }
+  }
+
+  // Double-click on the titlebar title → rename the active session (same behaviour
+  // as double-clicking a session title in the sidebar).  Only active on the chat
+  // panel when a session is open.
+  titleEl.ondblclick = null;  // remove any previous handler before adding a fresh one
+  if (panel === 'chat' && typeof S !== 'undefined' && S && S.session) {
+    titleEl.ondblclick = (e) => {
+      e.stopPropagation();
+      e.preventDefault();
+      if (_renamingAppTitlebar) return;
+      _renamingAppTitlebar = true;
+
+      const inp = document.createElement('input');
+      inp.type = 'text';
+      inp.className = 'app-titlebar-rename-input';
+      inp.value = S.session.title || (typeof t === 'function' ? t('untitled') : 'Untitled');
+
+      // Prevent click/dblclick on the input from bubbling — we don't want
+      // panel switches, session switches, or any other handler firing.
+      ['click', 'mousedown', 'dblclick', 'pointerdown'].forEach(ev =>
+        inp.addEventListener(ev, e2 => e2.stopPropagation())
+      );
+
+      const finish = async (save) => {
+        _renamingAppTitlebar = false;
+        if (save) {
+          const newTitle = inp.value.trim() || (typeof t === 'function' ? t('untitled') : 'Untitled');
+          S.session.title = newTitle;
+          syncTopbar();   // update #topbarTitle in the chat header
+          syncAppTitlebar();
+          // Update the sidebar list so the renamed title appears immediately.
+          // _renderOneSession reads from _allSessions cache, so patch it there too.
+          try {
+            const _cached = typeof _allSessions !== 'undefined' && _allSessions.find(s => s && s.session_id === S.session.session_id);
+            if (_cached) _cached.title = newTitle;
+          } catch (_) {}
+          if (typeof renderSessionListFromCache === 'function') renderSessionListFromCache();
+          try {
+            await api('/api/session/rename', {
+              method: 'POST',
+              body: JSON.stringify({ session_id: S.session.session_id, title: newTitle })
+            });
+          } catch (err) {
+            if (typeof setStatus === 'function') setStatus('Rename failed: ' + err.message);
+          }
+        }
+        inp.replaceWith(titleEl);
+        syncAppTitlebar();
+      };
+
+      inp.onkeydown = e2 => {
+        if (e2.key === 'Enter') { e2.preventDefault(); e2.stopPropagation(); finish(true); }
+        if (e2.key === 'Escape') { e2.preventDefault(); e2.stopPropagation(); finish(false); }
+      };
+      inp.onblur = () => finish(false);
+
+      titleEl.replaceWith(inp);
+      inp.focus();
+      inp.select();
+    };
   }
 }
 
@@ -257,7 +325,6 @@ function openCronDetail(id, el){
 }
 
 function _clearCronDetail(){
-  if (_cronRunningPoll) { clearInterval(_cronRunningPoll); _cronRunningPoll = null; }
   _currentCronDetail = null;
   _cronMode = 'empty';
   const title = $('taskDetailTitle');
@@ -488,53 +555,12 @@ function _cronOutputSnippet(content) {
   return body.slice(0, 600) || '(empty)';
 }
 
-let _cronRunningPoll = null; // timer for polling job status after trigger
-
 async function cronRun(id) {
   try {
     await api('/api/crons/run', {method:'POST', body: JSON.stringify({job_id: id})});
     showToast(t('cron_job_triggered'));
-    // Immediately show "running" state in detail if this job is selected
-    if (_currentCronDetail && _currentCronDetail.id === id) {
-      _setCronDetailStatus('running');
-      _startCronRunningPoll(id);
-    }
+    setTimeout(() => { if (_currentCronDetail && _currentCronDetail.id === id) _loadCronDetailRuns(id); }, 5000);
   } catch(e) { showToast(t('failed_colon') + e.message, 4000); }
-}
-
-function _setCronDetailStatus(status) {
-  const badge = document.querySelector('#taskDetailBody .detail-badge');
-  if (!badge) return;
-  if (status === 'running') {
-    badge.className = 'detail-badge running';
-    badge.textContent = t('cron_status_running');
-  }
-}
-
-function _startCronRunningPoll(jobId) {
-  // Clear any existing poll
-  if (_cronRunningPoll) { clearInterval(_cronRunningPoll); _cronRunningPoll = null; }
-  let attempts = 0;
-  const maxAttempts = 10; // 10 * 3s = 30s max
-  _cronRunningPoll = setInterval(async () => {
-    attempts++;
-    if (!_currentCronDetail || _currentCronDetail.id !== jobId || attempts > maxAttempts) {
-      clearInterval(_cronRunningPoll);
-      _cronRunningPoll = null;
-      // Re-render detail with real status when poll ends (fallback from "running" indicator)
-      if (_currentCronDetail && _currentCronDetail.id === jobId) {
-        const refreshed = _cronList ? _cronList.find(j => j.id === jobId) : null;
-        if (refreshed) _renderCronDetail(refreshed);
-      }
-      return;
-    }
-    try {
-      await loadCrons();
-      // loadCrons() re-renders the detail which overwrites our "running" badge.
-      // Re-apply the running indicator if poll is still active.
-      if (_cronRunningPoll) _setCronDetailStatus('running');
-    } catch(e) { /* ignore */ }
-  }, 3000);
 }
 
 async function cronPause(id) {
@@ -1448,12 +1474,6 @@ function _renderWorkspaceForm({ name, path, isEdit }){
           </div>
           ${pathHint}
         </div>
-        ${!isEdit?`<div class="detail-form-row">
-          <label class="detail-form-check">
-            <input type="checkbox" id="workspaceFormAutoCreate">
-            ${esc(t('workspace_auto_create_folder')||'Create folder if it doesn\'t exist')}
-          </label>
-        </div>`:''}
         <div id="workspaceFormError" class="detail-form-error" style="display:none"></div>
       </form>
     </div>`;
@@ -1499,7 +1519,7 @@ async function saveWorkspaceForm(){
       openWorkspaceDetail(targetPath);
       return;
     }
-    const data = await api('/api/workspaces/add', { method:'POST', body: JSON.stringify({ path, name, create: ($('workspaceFormAutoCreate')&&$('workspaceFormAutoCreate').checked)||false }) });
+    const data = await api('/api/workspaces/add', { method:'POST', body: JSON.stringify({ path }) });
     _workspaceList = data.workspaces || [];
     _workspacePreFormDetail = null;
     // Apply rename if a friendly name was supplied
@@ -2478,6 +2498,21 @@ function _buildProviderCard(p){
   }
   field.appendChild(row);
   body.appendChild(field);
+
+  // Refresh models for this provider
+  const refreshRow=document.createElement('div');
+  refreshRow.className='provider-card-row';
+  refreshRow.style.marginTop='6px';
+  const refreshBtn=document.createElement('button');
+  refreshBtn.type='button';
+  refreshBtn.className='provider-card-btn provider-card-btn-ghost';
+  refreshBtn.style.display='flex';
+  refreshBtn.style.alignItems='center';
+  refreshBtn.style.gap='5px';
+  refreshBtn.innerHTML=`<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8"/><path d="M21 3v5h-5"/><path d="M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16"/><path d="M3 21v-5h5"/></svg> ${t('providers_refresh_models')||'Refresh Models'}`;
+  refreshBtn.onclick=()=>_refreshProviderModels(p.id, refreshBtn);
+  refreshRow.appendChild(refreshBtn);
+  body.appendChild(refreshRow);
   card.appendChild(body);
 
   _providerCardEls.set(p.id,{card,input,saveBtn,hasKey:p.has_key});
@@ -2535,6 +2570,25 @@ async function _removeProviderKey(providerId){
   }catch(e){
     showToast('Error: '+e.message);
     if(els.saveBtn){els.saveBtn.disabled=false;els.saveBtn.textContent=t('providers_save');}
+  }
+}
+
+async function _refreshProviderModels(providerId, btn){
+  btn.disabled=true;
+  const orig=btn.innerHTML;
+  btn.innerHTML=`<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8"/><path d="M21 3v5h-5"/><path d="M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16"/><path d="M3 21v-5h5"/></svg> ${t('providers_refreshing')||'Refreshing...'}`;
+  try{
+    const res=await api('/api/models/refresh',{method:'POST',body:JSON.stringify({provider:providerId})});
+    if(res.ok){
+      showToast(t('providers_models_refreshed')||('Models refreshed for '+res.provider));
+    }else{
+      showToast(res.error||'Failed to refresh models');
+    }
+  }catch(e){
+    showToast('Error: '+e.message);
+  }finally{
+    btn.disabled=false;
+    btn.innerHTML=orig;
   }
 }
 

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -12,7 +12,7 @@ const ICONS={
 
 // Tracks which session_id is currently being loaded. Used to discard stale
 // responses from in-flight requests when the user switches sessions again
-// before the first request completes.
+// before the first request completes (#1060).
 let _loadingSessionId = null;
 
 const SESSION_VIEWED_COUNTS_KEY = 'hermes-session-viewed-counts';
@@ -98,6 +98,8 @@ async function newSession(flash){
 }
 
 async function loadSession(sid){
+  // Mark this session as the in-flight load. Subsequent loadSession() calls
+  // will overwrite this; stale awaits use the mismatch to bail out (#1060).
   _loadingSessionId = sid;
   stopApprovalPolling();hideApprovalCard();
   if(typeof stopClarifyPolling==='function') stopClarifyPolling();
@@ -105,9 +107,10 @@ async function loadSession(sid){
   // Show loading indicator immediately for responsiveness.
   // Cleared by renderMessages() once full session data arrives.
   const currentSid = S.session ? S.session.session_id : null;
-  // Persist current composer draft before switching away so it can be restored
-  // when switching back (supports buffered messages across conversation switches).
+  // Persist the current composer draft before switching away so it can be
+  // restored when the user switches back (#1060).
   if (currentSid && currentSid !== sid) {
+    if (!S.composerDrafts) S.composerDrafts = {};
     const draft = { text: ($('msg') || {}).value || '', files: S.pendingFiles ? [...S.pendingFiles] : [] };
     if (draft.text || draft.files.length) S.composerDrafts[currentSid] = draft;
   }
@@ -121,19 +124,24 @@ async function loadSession(sid){
   // Guard against network/server failures to prevent a permanently stuck loading state.
   let data;
   try {
-    data = await api(`/api/session?session_id=${encodeURIComponent(sid)}&messages=0`);
+    data = await api(`/api/session?session_id=${encodeURIComponent(sid)}&messages=0&resolve_model=0`);
   } catch(e) {
     const _msgInner = $('msgInner');
-    if (_msgInner) {
-      _msgInner.innerHTML = '<div style="display:flex;align-items:center;justify-content:center;height:100%;color:var(--text-muted);font-size:14px;padding:40px;text-align:center;">Failed to load session. Try switching sessions or refreshing.</div>';
+    if(_msgInner){
+      if(e.status===404){
+        _msgInner.innerHTML='<div style="display:flex;align-items:center;justify-content:center;height:100%;color:var(--text-muted);font-size:14px;padding:40px;text-align:center;">Session not available in web UI.</div>';
+      } else {
+        _msgInner.innerHTML='<div style="display:flex;align-items:center;justify-content:center;height:100%;color:var(--text-muted);font-size:14px;padding:40px;text-align:center;">Failed to load session. Try switching sessions or refreshing.</div>';
+        if(typeof showToast==='function') showToast('Failed to load session',3000,'error');
+      }
     }
-    if (typeof showToast === 'function') showToast('Failed to load session', 3000, 'error');
-    _loadingSessionId = null;
+    if (_loadingSessionId === sid) _loadingSessionId = null;
     return;
   }
-  // Stale response? A newer loadSession() call has already started.
+  // Stale response? A newer loadSession() call has already started (#1060).
   if (_loadingSessionId !== sid) return;
   S.session=data.session;
+  S.session._modelResolutionDeferred=true;
   S.lastUsage={...(data.session.last_usage||{})};
   _setSessionViewedCount(S.session.session_id, Number(data.session.message_count || 0));
   localStorage.setItem('hermes-webui-session',S.session.session_id);
@@ -175,7 +183,6 @@ async function loadSession(sid){
       if (_loadingSessionId !== sid) return;
       attachLiveStream(sid, activeStreamId, S.session.pending_attachments||[], {reconnecting:true});
     }
-    _loadingSessionId = null;
   }else{
     // Phase 2b: Idle session — load full messages lazily for rendering.
     // _ensureMessagesLoaded is idempotent; it skips if S.messages already populated.
@@ -191,15 +198,11 @@ async function loadSession(sid){
         _msgInner.innerHTML = '<div style="display:flex;align-items:center;justify-content:center;height:100%;color:var(--text-muted);font-size:14px;padding:40px;text-align:center;">Failed to load messages. Try switching sessions or refreshing.</div>';
       }
       if (typeof showToast === 'function') showToast('Failed to load conversation messages', 3000, 'error');
-      _loadingSessionId = null;
+      if (_loadingSessionId === sid) _loadingSessionId = null;
       return;
     }
-
-    // Stale? A newer loadSession() call has already started.
-    if (_loadingSessionId !== sid) {
-      _loadingSessionId = null;
-      return;
-    }
+    // Stale? A newer loadSession() call has already started (#1060).
+    if (_loadingSessionId !== sid) return;
 
     // Restore any queued message that survived page refresh via sessionStorage.
     if(typeof queueSessionMessage==='function'){
@@ -278,31 +281,25 @@ async function loadSession(sid){
       threshold_tokens:  _pick(u.threshold_tokens,  _s.threshold_tokens),
     });
   }
-  // Restore buffered composer draft for this session (from a previous conversation switch).
-  const savedDraft = S.composerDrafts ? S.composerDrafts[sid] : null;
-  if (savedDraft) {
-    const _msg = $('msg');
-    if (_msg) {
-      _msg.value = savedDraft.text || '';
-      if (typeof autoResize === 'function') autoResize();
-    }
-    if (Array.isArray(savedDraft.files) && savedDraft.files.length) {
-      S.pendingFiles = savedDraft.files;
-      if (typeof renderAttachTray === 'function') renderAttachTray();
-    }
-    delete S.composerDrafts[sid];
-  }
+  _resolveSessionModelForDisplaySoon(sid);
+  // Clear the in-flight session marker now that this load has completed (#1060).
+  if (_loadingSessionId === sid) _loadingSessionId = null;
+}
 
-  // Auto-focus the message composer so the user can immediately continue typing
-  // after switching conversations.  Skip if the user is already focused on an
-  // input element (e.g. pressing Tab through the UI).
-  const _active = document.activeElement;
-  if (!_active || !/^(INPUT|TEXTAREA|SELECT)$/.test(_active.tagName)) {
-    const _msg = $('msg');
-    if (_msg) _msg.focus();
-  }
-
-  _loadingSessionId = null;
+function _resolveSessionModelForDisplaySoon(sid){
+  if(!sid) return;
+  setTimeout(async()=>{
+    try{
+      const data=await api(`/api/session?session_id=${encodeURIComponent(sid)}&messages=0&resolve_model=1`);
+      const model=data&&data.session&&data.session.model;
+      if(!model||!S.session||S.session.session_id!==sid) return;
+      S.session.model=model;
+      S.session._modelResolutionDeferred=false;
+      syncTopbar();
+    }catch(_){
+      // Keep session switching non-blocking; the next load can try again.
+    }
+  },0);
 }
 
 // Load session messages if not already present.
@@ -315,7 +312,7 @@ async function _ensureMessagesLoaded(sid) {
     return;
   }
   // Fetch full session with messages
-  const data = await api(`/api/session?session_id=${encodeURIComponent(sid)}&messages=1`);
+  const data = await api(`/api/session?session_id=${encodeURIComponent(sid)}&messages=1&resolve_model=0`);
   const msgs = (data.session.messages || []).filter(m => m && m.role);
   // Check for tool-call metadata on messages (for tool-call card rendering)
   const hasMessageToolMetadata = msgs.some(m => {
@@ -324,8 +321,6 @@ async function _ensureMessagesLoaded(sid) {
     const hasTu = Array.isArray(m.content) && m.content.some(p => p && p.type === 'tool_use');
     return hasTc || hasTu;
   });
-  // Stale? A newer loadSession() replaced this session before this fetch resolved.
-  if (_loadingSessionId !== sid) return;
   if (!hasMessageToolMetadata && data.session.tool_calls && data.session.tool_calls.length) {
     S.toolCalls = data.session.tool_calls.map(tc => ({...tc, done: true}));
   } else {
@@ -333,6 +328,11 @@ async function _ensureMessagesLoaded(sid) {
   }
   clearLiveToolCards();
   S.messages = msgs;
+  if(S.session&&S.session.session_id===sid){
+    S.session.message_count=Number(data.session.message_count || msgs.length);
+    S.lastUsage={...(data.session.last_usage||S.lastUsage||{})};
+    _setSessionViewedCount(sid, Number(S.session.message_count || msgs.length));
+  }
 }
 
 let _allSessions = [];  // cached for search filter
@@ -672,7 +672,7 @@ function filterSessions(){
 }
 
 function _sessionTimestampMs(session) {
-  const raw = Number(session && (session.updated_at || session.created_at || 0));
+  const raw = Number(session && (session.last_message_at || session.updated_at || session.created_at || 0));
   return Number.isFinite(raw) ? raw * 1000 : 0;
 }
 
@@ -823,14 +823,7 @@ function renderSessionListFromCache(){
     empty.textContent='No sessions in this project yet.';
     list.appendChild(empty);
   }
-  const orderedSessions=[...sessions].sort((a,b)=>{
-    const ta=_sessionTimestampMs(a), tb=_sessionTimestampMs(b);
-    if(ta!==tb) return tb-ta;  // primary: newest first
-    // Tiebreaker: session_id string comparison for stable order across re-renders
-    // (e.g. multiple sessions with no timestamp or same-day bucket)
-    const ida=a.session_id||'', idb=b.session_id||'';
-    return ida<idb?-1:ida>idb?1:0;
-  });
+  const orderedSessions=[...sessions].sort((a,b)=>_sessionTimestampMs(b)-_sessionTimestampMs(a));
   // Separate pinned from unpinned
   const pinned=orderedSessions.filter(s=>s.pinned);
   const unpinned=orderedSessions.filter(s=>!s.pinned);
@@ -861,7 +854,7 @@ function renderSessionListFromCache(){
     hdr.className='session-date-header'+(g.isPinned?' pinned':'');
     const caret=document.createElement('span');
     caret.className='session-date-caret';
-    caret.textContent='\u25B8'; // right-pointing triangle
+    caret.textContent='\u25BE'; // down when expanded; rotated right when collapsed
     const label=document.createElement('span');
     label.textContent=g.label;
     hdr.appendChild(caret);hdr.appendChild(label);
@@ -876,18 +869,25 @@ function renderSessionListFromCache(){
       _saveCollapsed();
     };
     wrapper.appendChild(hdr);
-    for(const s of g.items){ body.appendChild(_renderOneSession(s)); }
+    for(const s of g.items){ body.appendChild(_renderOneSession(s, Boolean(g.isPinned))); }
     wrapper.appendChild(body);
     list.appendChild(wrapper);
   }
   // ── Render session items (extracted for group body use) ──
   // Note: declared after the groups loop but available via function hoisting.
-  function _renderOneSession(s){
+  function _renderOneSession(s, isPinnedGroup=false){
     const el=document.createElement('div');
     const isActive=S.session&&s.session_id===S.session.session_id;
-    const isStreaming=Boolean(s.is_streaming);
+    const isLocalStreaming=Boolean(
+      s.session_id
+      && (
+        (isActive&&S.busy)
+        || (typeof INFLIGHT==='object'&&INFLIGHT&&INFLIGHT[s.session_id])
+      )
+    );
+    const isStreaming=Boolean(s.is_streaming||isLocalStreaming);
     const hasUnread=_hasUnreadForSession(s)&&!isActive;
-    el.className='session-item'+(isActive?' active':'')+(isActive&&S.session&&S.session._flash?' new-flash':'')+(s.archived?' archived':'')+(isStreaming?' streaming':'');
+    el.className='session-item'+(isActive?' active':'')+(isActive&&S.session&&S.session._flash?' new-flash':'')+(s.archived?' archived':'')+(isStreaming?' streaming':'')+(hasUnread?' unread':'');
     if(isActive&&S.session&&S.session._flash)delete S.session._flash;
     const rawTitle=s.title||'Untitled';
     const tags=(rawTitle.match(/#[\w-]+/g)||[]);
@@ -900,23 +900,21 @@ function renderSessionListFromCache(){
     sessionText.className='session-text';
     const titleRow=document.createElement('div');
     titleRow.className='session-title-row';
-    if(s.pinned){
+    if(s.pinned&&!isPinnedGroup){
       const pinInd=document.createElement('span');
       pinInd.className='session-pin-indicator';
       pinInd.innerHTML=ICONS.pin;
       titleRow.appendChild(pinInd);
     }
-    const state=document.createElement('span');
-    state.className='session-state-indicator'+(isStreaming?' is-streaming':(hasUnread?' is-unread':''));
-    titleRow.appendChild(state); // always reserve slot — prevents title shift when indicator appears
     const title=document.createElement('span');
     title.className='session-title';
     title.textContent=cleanTitle||'Untitled';
     title.title='Double-click to rename';
     const tsMs=_sessionTimestampMs(s);
     const ts=document.createElement('span');
-    ts.className='session-time';
-    ts.textContent=_formatRelativeSessionTime(tsMs);
+    const hasAttentionState=isStreaming||hasUnread;
+    ts.className='session-time'+(hasAttentionState?' is-hidden':'');
+    ts.textContent=hasAttentionState?'':_formatRelativeSessionTime(tsMs);
     titleRow.appendChild(title);
     titleRow.appendChild(ts);
     sessionText.appendChild(titleRow);
@@ -1000,6 +998,10 @@ function renderSessionListFromCache(){
       }
     }
     el.appendChild(sessionText);
+    const state=document.createElement('span');
+    state.className='session-attention-indicator session-state-indicator'+(isStreaming?' is-streaming':(hasUnread?' is-unread':''));
+    state.setAttribute('aria-hidden','true');
+    el.appendChild(state);
     // Single trigger button that opens a shared dropdown menu
     const actions=document.createElement('div');
     actions.className='session-actions';
@@ -1018,46 +1020,34 @@ function renderSessionListFromCache(){
     actions.appendChild(menuBtn);
     el.appendChild(actions);
 
-    // If the clicked session is not already active, switch immediately (no debounce needed).
-    // Only the currently-active session needs debounce to distinguish single-click (navigate away
-    // and back) from double-click (rename) — but since navigating away destroys this element,
-    // a double-click on an inactive session can only ever be a single-click intent.
-    const isAlreadyActive = s.session_id === (S.session && S.session.session_id);
-    if (!isAlreadyActive) {
-      el.onclick = async(e) => {
-        if (_renamingSid) return;
-        if (actions.contains(e.target)) return;
-        if (s.is_cli_session) {
-          try { await api('/api/session/import_cli', {method:'POST', body:JSON.stringify({session_id:s.session_id})}); }
-          catch(e) { /* import failed -- fall through to read-only view */ }
+    // Use a click timer to distinguish single-click (navigate) from double-click (rename).
+    // This prevents loadSession from firing on the first click of a double-click,
+    // which would re-render the list and destroy the dblclick target before it fires.
+    let _clickTimer=null;
+    el.onclick=async(e)=>{
+      if(_renamingSid) return; // ignore while any rename is active
+      if(actions.contains(e.target)) return;
+      clearTimeout(_clickTimer);
+      _clickTimer=setTimeout(async()=>{
+        _clickTimer=null;
+        if(_renamingSid) return;
+        // For CLI sessions, import into WebUI store first (idempotent)
+        if(s.is_cli_session){
+          try{
+            await api('/api/session/import_cli',{method:'POST',body:JSON.stringify({session_id:s.session_id})});
+          }catch(e){ /* import failed -- fall through to read-only view */ }
         }
-        await loadSession(s.session_id);
-        renderSessionListFromCache();
-        if (typeof closeMobileSidebar === 'function') closeMobileSidebar();
-      };
-    } else {
-      // Already-active session: use a click timer to allow double-click (rename) to fire first.
-      let _clickTimer = null;
-      el.onclick = async(e) => {
-        if (_renamingSid) return;
-        if (actions.contains(e.target)) return;
-        clearTimeout(_clickTimer);
-        _clickTimer = setTimeout(async() => {
-          _clickTimer = null;
-          if (_renamingSid) return;
-          await loadSession(s.session_id);
-          renderSessionListFromCache();
-          if (typeof closeMobileSidebar === 'function') closeMobileSidebar();
-        }, 150);
-      };
-      el.ondblclick = async(e) => {
-        e.stopPropagation();
-        e.preventDefault();
-        clearTimeout(_clickTimer);
-        _clickTimer = null;
-        startRename();
-      };
-    }
+        await loadSession(s.session_id);renderSessionListFromCache();
+        if(typeof closeMobileSidebar==='function')closeMobileSidebar();
+      }, 220);
+    };
+    el.ondblclick=async(e)=>{
+      e.stopPropagation();
+      e.preventDefault();
+      clearTimeout(_clickTimer); // cancel the pending single-click navigation
+      _clickTimer=null;
+      startRename();
+    };
     return el;
   }
 }

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -10,6 +10,11 @@ const ICONS={
   more:'<svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" stroke="none"><circle cx="8" cy="3" r="1.25"/><circle cx="8" cy="8" r="1.25"/><circle cx="8" cy="13" r="1.25"/></svg>',
 };
 
+// Tracks which session_id is currently being loaded. Used to discard stale
+// responses from in-flight requests when the user switches sessions again
+// before the first request completes.
+let _loadingSessionId = null;
+
 const SESSION_VIEWED_COUNTS_KEY = 'hermes-session-viewed-counts';
 let _sessionViewedCounts = null;
 
@@ -93,12 +98,19 @@ async function newSession(flash){
 }
 
 async function loadSession(sid){
+  _loadingSessionId = sid;
   stopApprovalPolling();hideApprovalCard();
   if(typeof stopClarifyPolling==='function') stopClarifyPolling();
   if(typeof hideClarifyCard==='function') hideClarifyCard();
   // Show loading indicator immediately for responsiveness.
   // Cleared by renderMessages() once full session data arrives.
   const currentSid = S.session ? S.session.session_id : null;
+  // Persist current composer draft before switching away so it can be restored
+  // when switching back (supports buffered messages across conversation switches).
+  if (currentSid && currentSid !== sid) {
+    const draft = { text: ($('msg') || {}).value || '', files: S.pendingFiles ? [...S.pendingFiles] : [] };
+    if (draft.text || draft.files.length) S.composerDrafts[currentSid] = draft;
+  }
   if (currentSid !== sid) {
     S.messages = [];
     S.toolCalls = [];
@@ -109,21 +121,19 @@ async function loadSession(sid){
   // Guard against network/server failures to prevent a permanently stuck loading state.
   let data;
   try {
-    data = await api(`/api/session?session_id=${encodeURIComponent(sid)}&messages=0&resolve_model=0`);
+    data = await api(`/api/session?session_id=${encodeURIComponent(sid)}&messages=0`);
   } catch(e) {
     const _msgInner = $('msgInner');
-    if(_msgInner){
-      if(e.status===404){
-        _msgInner.innerHTML='<div style="display:flex;align-items:center;justify-content:center;height:100%;color:var(--text-muted);font-size:14px;padding:40px;text-align:center;">Session not available in web UI.</div>';
-      } else {
-        _msgInner.innerHTML='<div style="display:flex;align-items:center;justify-content:center;height:100%;color:var(--text-muted);font-size:14px;padding:40px;text-align:center;">Failed to load session. Try switching sessions or refreshing.</div>';
-        if(typeof showToast==='function') showToast('Failed to load session',3000,'error');
-      }
+    if (_msgInner) {
+      _msgInner.innerHTML = '<div style="display:flex;align-items:center;justify-content:center;height:100%;color:var(--text-muted);font-size:14px;padding:40px;text-align:center;">Failed to load session. Try switching sessions or refreshing.</div>';
     }
+    if (typeof showToast === 'function') showToast('Failed to load session', 3000, 'error');
+    _loadingSessionId = null;
     return;
   }
+  // Stale response? A newer loadSession() call has already started.
+  if (_loadingSessionId !== sid) return;
   S.session=data.session;
-  S.session._modelResolutionDeferred=true;
   S.lastUsage={...(data.session.last_usage||{})};
   _setSessionViewedCount(S.session.session_id, Number(data.session.message_count || 0));
   localStorage.setItem('hermes-webui-session',S.session.session_id);
@@ -162,8 +172,10 @@ async function loadSession(sid){
     const _cb=$('btnCancel');if(_cb&&activeStreamId)_cb.style.display='inline-flex';
     if(INFLIGHT[sid].reattach&&activeStreamId&&typeof attachLiveStream==='function'){
       INFLIGHT[sid].reattach=false;
+      if (_loadingSessionId !== sid) return;
       attachLiveStream(sid, activeStreamId, S.session.pending_attachments||[], {reconnecting:true});
     }
+    _loadingSessionId = null;
   }else{
     // Phase 2b: Idle session — load full messages lazily for rendering.
     // _ensureMessagesLoaded is idempotent; it skips if S.messages already populated.
@@ -179,6 +191,13 @@ async function loadSession(sid){
         _msgInner.innerHTML = '<div style="display:flex;align-items:center;justify-content:center;height:100%;color:var(--text-muted);font-size:14px;padding:40px;text-align:center;">Failed to load messages. Try switching sessions or refreshing.</div>';
       }
       if (typeof showToast === 'function') showToast('Failed to load conversation messages', 3000, 'error');
+      _loadingSessionId = null;
+      return;
+    }
+
+    // Stale? A newer loadSession() call has already started.
+    if (_loadingSessionId !== sid) {
+      _loadingSessionId = null;
       return;
     }
 
@@ -259,23 +278,31 @@ async function loadSession(sid){
       threshold_tokens:  _pick(u.threshold_tokens,  _s.threshold_tokens),
     });
   }
-  _resolveSessionModelForDisplaySoon(sid);
-}
-
-function _resolveSessionModelForDisplaySoon(sid){
-  if(!sid) return;
-  setTimeout(async()=>{
-    try{
-      const data=await api(`/api/session?session_id=${encodeURIComponent(sid)}&messages=0&resolve_model=1`);
-      const model=data&&data.session&&data.session.model;
-      if(!model||!S.session||S.session.session_id!==sid) return;
-      S.session.model=model;
-      S.session._modelResolutionDeferred=false;
-      syncTopbar();
-    }catch(_){
-      // Keep session switching non-blocking; the next load can try again.
+  // Restore buffered composer draft for this session (from a previous conversation switch).
+  const savedDraft = S.composerDrafts ? S.composerDrafts[sid] : null;
+  if (savedDraft) {
+    const _msg = $('msg');
+    if (_msg) {
+      _msg.value = savedDraft.text || '';
+      if (typeof autoResize === 'function') autoResize();
     }
-  },0);
+    if (Array.isArray(savedDraft.files) && savedDraft.files.length) {
+      S.pendingFiles = savedDraft.files;
+      if (typeof renderAttachTray === 'function') renderAttachTray();
+    }
+    delete S.composerDrafts[sid];
+  }
+
+  // Auto-focus the message composer so the user can immediately continue typing
+  // after switching conversations.  Skip if the user is already focused on an
+  // input element (e.g. pressing Tab through the UI).
+  const _active = document.activeElement;
+  if (!_active || !/^(INPUT|TEXTAREA|SELECT)$/.test(_active.tagName)) {
+    const _msg = $('msg');
+    if (_msg) _msg.focus();
+  }
+
+  _loadingSessionId = null;
 }
 
 // Load session messages if not already present.
@@ -288,7 +315,7 @@ async function _ensureMessagesLoaded(sid) {
     return;
   }
   // Fetch full session with messages
-  const data = await api(`/api/session?session_id=${encodeURIComponent(sid)}&messages=1&resolve_model=0`);
+  const data = await api(`/api/session?session_id=${encodeURIComponent(sid)}&messages=1`);
   const msgs = (data.session.messages || []).filter(m => m && m.role);
   // Check for tool-call metadata on messages (for tool-call card rendering)
   const hasMessageToolMetadata = msgs.some(m => {
@@ -297,6 +324,8 @@ async function _ensureMessagesLoaded(sid) {
     const hasTu = Array.isArray(m.content) && m.content.some(p => p && p.type === 'tool_use');
     return hasTc || hasTu;
   });
+  // Stale? A newer loadSession() replaced this session before this fetch resolved.
+  if (_loadingSessionId !== sid) return;
   if (!hasMessageToolMetadata && data.session.tool_calls && data.session.tool_calls.length) {
     S.toolCalls = data.session.tool_calls.map(tc => ({...tc, done: true}));
   } else {
@@ -304,11 +333,6 @@ async function _ensureMessagesLoaded(sid) {
   }
   clearLiveToolCards();
   S.messages = msgs;
-  if(S.session&&S.session.session_id===sid){
-    S.session.message_count=Number(data.session.message_count || msgs.length);
-    S.lastUsage={...(data.session.last_usage||S.lastUsage||{})};
-    _setSessionViewedCount(sid, Number(S.session.message_count || msgs.length));
-  }
 }
 
 let _allSessions = [];  // cached for search filter
@@ -648,7 +672,7 @@ function filterSessions(){
 }
 
 function _sessionTimestampMs(session) {
-  const raw = Number(session && (session.last_message_at || session.updated_at || session.created_at || 0));
+  const raw = Number(session && (session.updated_at || session.created_at || 0));
   return Number.isFinite(raw) ? raw * 1000 : 0;
 }
 
@@ -799,7 +823,14 @@ function renderSessionListFromCache(){
     empty.textContent='No sessions in this project yet.';
     list.appendChild(empty);
   }
-  const orderedSessions=[...sessions].sort((a,b)=>_sessionTimestampMs(b)-_sessionTimestampMs(a));
+  const orderedSessions=[...sessions].sort((a,b)=>{
+    const ta=_sessionTimestampMs(a), tb=_sessionTimestampMs(b);
+    if(ta!==tb) return tb-ta;  // primary: newest first
+    // Tiebreaker: session_id string comparison for stable order across re-renders
+    // (e.g. multiple sessions with no timestamp or same-day bucket)
+    const ida=a.session_id||'', idb=b.session_id||'';
+    return ida<idb?-1:ida>idb?1:0;
+  });
   // Separate pinned from unpinned
   const pinned=orderedSessions.filter(s=>s.pinned);
   const unpinned=orderedSessions.filter(s=>!s.pinned);
@@ -830,7 +861,7 @@ function renderSessionListFromCache(){
     hdr.className='session-date-header'+(g.isPinned?' pinned':'');
     const caret=document.createElement('span');
     caret.className='session-date-caret';
-    caret.textContent='\u25BE'; // down when expanded; rotated right when collapsed
+    caret.textContent='\u25B8'; // right-pointing triangle
     const label=document.createElement('span');
     label.textContent=g.label;
     hdr.appendChild(caret);hdr.appendChild(label);
@@ -845,25 +876,18 @@ function renderSessionListFromCache(){
       _saveCollapsed();
     };
     wrapper.appendChild(hdr);
-    for(const s of g.items){ body.appendChild(_renderOneSession(s, Boolean(g.isPinned))); }
+    for(const s of g.items){ body.appendChild(_renderOneSession(s)); }
     wrapper.appendChild(body);
     list.appendChild(wrapper);
   }
   // ── Render session items (extracted for group body use) ──
   // Note: declared after the groups loop but available via function hoisting.
-  function _renderOneSession(s, isPinnedGroup=false){
+  function _renderOneSession(s){
     const el=document.createElement('div');
     const isActive=S.session&&s.session_id===S.session.session_id;
-    const isLocalStreaming=Boolean(
-      s.session_id
-      && (
-        (isActive&&S.busy)
-        || (typeof INFLIGHT==='object'&&INFLIGHT&&INFLIGHT[s.session_id])
-      )
-    );
-    const isStreaming=Boolean(s.is_streaming||isLocalStreaming);
+    const isStreaming=Boolean(s.is_streaming);
     const hasUnread=_hasUnreadForSession(s)&&!isActive;
-    el.className='session-item'+(isActive?' active':'')+(isActive&&S.session&&S.session._flash?' new-flash':'')+(s.archived?' archived':'')+(isStreaming?' streaming':'')+(hasUnread?' unread':'');
+    el.className='session-item'+(isActive?' active':'')+(isActive&&S.session&&S.session._flash?' new-flash':'')+(s.archived?' archived':'')+(isStreaming?' streaming':'');
     if(isActive&&S.session&&S.session._flash)delete S.session._flash;
     const rawTitle=s.title||'Untitled';
     const tags=(rawTitle.match(/#[\w-]+/g)||[]);
@@ -876,21 +900,23 @@ function renderSessionListFromCache(){
     sessionText.className='session-text';
     const titleRow=document.createElement('div');
     titleRow.className='session-title-row';
-    if(s.pinned&&!isPinnedGroup){
+    if(s.pinned){
       const pinInd=document.createElement('span');
       pinInd.className='session-pin-indicator';
       pinInd.innerHTML=ICONS.pin;
       titleRow.appendChild(pinInd);
     }
+    const state=document.createElement('span');
+    state.className='session-state-indicator'+(isStreaming?' is-streaming':(hasUnread?' is-unread':''));
+    titleRow.appendChild(state); // always reserve slot — prevents title shift when indicator appears
     const title=document.createElement('span');
     title.className='session-title';
     title.textContent=cleanTitle||'Untitled';
     title.title='Double-click to rename';
     const tsMs=_sessionTimestampMs(s);
     const ts=document.createElement('span');
-    const hasAttentionState=isStreaming||hasUnread;
-    ts.className='session-time'+(hasAttentionState?' is-hidden':'');
-    ts.textContent=hasAttentionState?'':_formatRelativeSessionTime(tsMs);
+    ts.className='session-time';
+    ts.textContent=_formatRelativeSessionTime(tsMs);
     titleRow.appendChild(title);
     titleRow.appendChild(ts);
     sessionText.appendChild(titleRow);
@@ -974,10 +1000,6 @@ function renderSessionListFromCache(){
       }
     }
     el.appendChild(sessionText);
-    const state=document.createElement('span');
-    state.className='session-attention-indicator session-state-indicator'+(isStreaming?' is-streaming':(hasUnread?' is-unread':''));
-    state.setAttribute('aria-hidden','true');
-    el.appendChild(state);
     // Single trigger button that opens a shared dropdown menu
     const actions=document.createElement('div');
     actions.className='session-actions';
@@ -996,34 +1018,46 @@ function renderSessionListFromCache(){
     actions.appendChild(menuBtn);
     el.appendChild(actions);
 
-    // Use a click timer to distinguish single-click (navigate) from double-click (rename).
-    // This prevents loadSession from firing on the first click of a double-click,
-    // which would re-render the list and destroy the dblclick target before it fires.
-    let _clickTimer=null;
-    el.onclick=async(e)=>{
-      if(_renamingSid) return; // ignore while any rename is active
-      if(actions.contains(e.target)) return;
-      clearTimeout(_clickTimer);
-      _clickTimer=setTimeout(async()=>{
-        _clickTimer=null;
-        if(_renamingSid) return;
-        // For CLI sessions, import into WebUI store first (idempotent)
-        if(s.is_cli_session){
-          try{
-            await api('/api/session/import_cli',{method:'POST',body:JSON.stringify({session_id:s.session_id})});
-          }catch(e){ /* import failed -- fall through to read-only view */ }
+    // If the clicked session is not already active, switch immediately (no debounce needed).
+    // Only the currently-active session needs debounce to distinguish single-click (navigate away
+    // and back) from double-click (rename) — but since navigating away destroys this element,
+    // a double-click on an inactive session can only ever be a single-click intent.
+    const isAlreadyActive = s.session_id === (S.session && S.session.session_id);
+    if (!isAlreadyActive) {
+      el.onclick = async(e) => {
+        if (_renamingSid) return;
+        if (actions.contains(e.target)) return;
+        if (s.is_cli_session) {
+          try { await api('/api/session/import_cli', {method:'POST', body:JSON.stringify({session_id:s.session_id})}); }
+          catch(e) { /* import failed -- fall through to read-only view */ }
         }
-        await loadSession(s.session_id);renderSessionListFromCache();
-        if(typeof closeMobileSidebar==='function')closeMobileSidebar();
-      }, 220);
-    };
-    el.ondblclick=async(e)=>{
-      e.stopPropagation();
-      e.preventDefault();
-      clearTimeout(_clickTimer); // cancel the pending single-click navigation
-      _clickTimer=null;
-      startRename();
-    };
+        await loadSession(s.session_id);
+        renderSessionListFromCache();
+        if (typeof closeMobileSidebar === 'function') closeMobileSidebar();
+      };
+    } else {
+      // Already-active session: use a click timer to allow double-click (rename) to fire first.
+      let _clickTimer = null;
+      el.onclick = async(e) => {
+        if (_renamingSid) return;
+        if (actions.contains(e.target)) return;
+        clearTimeout(_clickTimer);
+        _clickTimer = setTimeout(async() => {
+          _clickTimer = null;
+          if (_renamingSid) return;
+          await loadSession(s.session_id);
+          renderSessionListFromCache();
+          if (typeof closeMobileSidebar === 'function') closeMobileSidebar();
+        }, 150);
+      };
+      el.ondblclick = async(e) => {
+        e.stopPropagation();
+        e.preventDefault();
+        clearTimeout(_clickTimer);
+        _clickTimer = null;
+        startRename();
+      };
+    }
     return el;
   }
 }

--- a/static/style.css
+++ b/static/style.css
@@ -242,7 +242,7 @@
   .session-item.streaming .session-title-row{color:var(--text);}
   .session-text{flex:1;min-width:0;display:flex;flex-direction:column;gap:2px;overflow:hidden;}
   .session-title-row{display:flex;align-items:center;gap:6px;min-width:0;}
-  .session-title{flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:var(--text);}
+  .session-title{flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:var(--text);user-select:none;}
   .session-item.active .session-title{color:var(--accent-text);}
   .session-meta{font-size:11px;color:var(--muted);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
   .session-item.active .session-meta{color:var(--accent-text);opacity:.8;}


### PR DESCRIPTION
## v0.50.212 — model cache perf, session switch UX, cache isolation

Single PR reviewed, fixed, and tested end-to-end.

### Included PRs

| PR | Title | Author | Fixes applied |
|----|-------|--------|---------------|
| #1060 | perf+ui: fix session-switch bottleneck — /api/models ~30s→~1ms on restart | @JKJameson | Added disk-cache deletion to `invalidate_models_cache()` for test isolation; wrapped rebuild in try/except to reset `_cache_build_in_progress` on exception; fixed misleading deadlock comment |

### Fixes applied to integration branch

1. **`invalidate_models_cache()` now deletes disk cache** — without this, all `test_credential_pool_providers`, `test_custom_provider_display_name`, `test_model_resolver`, `test_opencode_providers`, `test_issue644`, and `test_ttl_cache` tests failed because `_load_models_cache_from_disk()` served a stale prior-test result immediately after memory invalidation. This fixed all 22 CI failures.

2. **`_cache_build_in_progress` reset on exception** — `_build_available_models_uncached()` now wrapped in try/except so the flag is always cleared and `notify_all()` fires even on an unexpected exception, preventing waiting threads from blocking for the full 60s timeout.

3. **Comment fix** — "Must be called outside the lock to avoid deadlock" → "Disk I/O outside the lock" (no deadlock was possible; `_delete_models_cache_on_disk` acquires no locks).

### Opus review verdict

APPROVED — threading correctness confirmed, no blocking issues. Three non-blocking follow-ups noted for future patches: `/dev/shm` portability (macOS/Windows parity), unreachable `wait_for` complexity, real stream cancellation vs stale-response discard.

### Gate results

- **pytest:** 2281 passed, 0 failed, 0 skipped (stage branch, alphabetical order)
- **QA harness phase 1:** 20/20 passed
- **Browser API sanity phase 2:** 11/11 checks passed
