### PR TITLE
fix: move models disk cache from /dev/shm to STATE_DIR for per-instance isolation

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -1104,7 +1104,11 @@ _provider_models_invalidated_ts: dict[str, float] = {}  # provider_id -> timesta
 # config.yaml changes.  A TTL is still used as a fallback in case the invalidation
 # signal is somehow missed, but the cache will always be warm after the first
 # page load following a server start.
-_models_cache_path = Path("/dev/shm") / "hermes_webui_models_cache.json"
+# Cache file lives inside STATE_DIR so each server instance (different
+# HERMES_WEBUI_STATE_DIR / port) has its own file and test runs never
+# pollute the production server's cache. Also works on macOS and Windows
+# where /dev/shm does not exist.
+_models_cache_path = STATE_DIR / "models_cache.json"
 
 
 def _delete_models_cache_on_disk() -> None:
@@ -1150,7 +1154,7 @@ def invalidate_models_cache():
     not immediately reload a stale disk snapshot and skip the fresh build.
     This is essential for test isolation: without the disk delete, tests
     that call invalidate_models_cache() still get back the previous test's
-    result from /dev/shm because the disk hit is checked before the memory
+    result from the disk cache because the disk hit is checked before the memory
     cache rebuild runs.
     """
     global _cache_build_in_progress, _available_models_cache, _available_models_cache_ts, _cache_build_cv


### PR DESCRIPTION
## Problem

Using `/dev/shm` for the models disk cache caused cross-instance pollution: any server started on a different port (QA harness on 8789, test runs, staging) writes its own provider set to the shared file. The production server on 8787 then loads it on next restart and shows only whatever providers the test environment had configured — in practice, just OpenRouter with a test model.

This hit immediately after merging #1060: the stage sanity server (port 8789, minimal config) wrote its OpenRouter-only snapshot to `/dev/shm/hermes_webui_models_cache.json`, and the next restart of the production server read it instead of doing a fresh build.

## Fix

Move the cache file from `/dev/shm/hermes_webui_models_cache.json` to `STATE_DIR / "models_cache.json"`.

Each server instance already has its own `STATE_DIR` (pinned via `HERMES_WEBUI_STATE_DIR` in `.env`), so isolation is automatic — no port-based or UID-based filename needed. Cache still survives server restarts (STATE_DIR is persistent). Also fixes macOS and Windows where `/dev/shm` doesn't exist, which was the other concern noted in the #1060 Opus review.

**Override note:** Nathan authorized direct merge without waiting for independent review cycle — simple one-line path change, full test suite passes (2281/2281).
