### PR TITLE
fix(workspace): add .html/.htm to MIME_MAP so HTML preview renders correctly

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -442,6 +442,8 @@ MIME_MAP = {
     ".bmp": "image/bmp",
     ".pdf": "application/pdf",
     ".json": "application/json",
+    ".html": "text/html",
+    ".htm": "text/html",
     ".xls": "application/vnd.ms-excel",
     ".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
     ".doc": "application/msword",

--- a/tests/test_779_html_preview.py
+++ b/tests/test_779_html_preview.py
@@ -62,6 +62,19 @@ def test_sandbox_allows_scripts_only():
         )
 
 
+def test_mime_map_includes_html_and_htm():
+    """MIME_MAP must map .html/.htm to text/html — without this, _handle_file_raw
+    falls back to application/octet-stream and browsers refuse to render the
+    response inside the preview iframe (issue #779 follow-up: PR #1070)."""
+    from api.config import MIME_MAP
+    assert MIME_MAP.get(".html") == "text/html", (
+        "MIME_MAP['.html'] must be 'text/html' for the workspace HTML preview iframe"
+    )
+    assert MIME_MAP.get(".htm") == "text/html", (
+        "MIME_MAP['.htm'] must be 'text/html' for the workspace HTML preview iframe"
+    )
+
+
 def test_inline_html_response_sets_csp_sandbox():
     """Defense-in-depth: ?inline=1 HTML responses must set Content-Security-Policy:
     sandbox so the same origin isolation applies even when the URL is opened


### PR DESCRIPTION
## Bug

HTML file preview in the workspace panel shows a blank white iframe when clicking `.html` or `.htm` files.

## Root cause

`MIME_MAP` in `api/config.py` had no entry for `.html` or `.htm`. The server fell back to `Content-Type: application/octet-stream`, which browsers refuse to render as HTML inside an iframe.

The rest of the pipeline was already correct:
- The iframe exists in `static/index.html`  
- `openFile()` in `static/workspace.js` correctly routes `.html` files to `showPreview('html')`  
- `_handle_file_raw()` in `api/routes.py` correctly sets `Content-Security-Policy: sandbox allow-scripts` when `?inline=1` is present  

None of that matters if the MIME type is wrong.

## Fix

Two lines added to `MIME_MAP` in `api/config.py`:

```python
".html": "text/html",
".htm":  "text/html",
```

No JS or template changes needed.

## Test result

Full suite: 2319 passed, 0 failed.
