### PR TITLE
fix(composer): raise approval card z-index above queue flyout

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -401,7 +401,7 @@
   .composer-flyout{position:relative;height:0;z-index:1;}
   /* ── Approval card ── */
   .approval-card{position:absolute;left:0;right:0;bottom:-24px;max-width:var(--msg-max);margin:0 auto;padding:0 20px;box-sizing:border-box;width:100%;overflow:hidden;pointer-events:none;}
-  .approval-card.visible{pointer-events:auto;}
+  .approval-card.visible{pointer-events:auto;z-index:3;}
   .approval-inner{background:var(--surface);backdrop-filter:blur(8px);border:1px solid var(--accent-bg-strong);border-radius:14px;padding:16px 18px 40px;transform:translateY(100%);opacity:0;transition:transform .4s cubic-bezier(.32,.72,.16,1),opacity .25s ease;}
   .approval-card.visible .approval-inner{transform:translateY(0);opacity:1;}
   .approval-header{display:flex;align-items:center;gap:8px;margin-bottom:10px;font-size:13px;font-weight:600;color:var(--error);}

--- a/tests/test_approval_card_layering.py
+++ b/tests/test_approval_card_layering.py
@@ -1,0 +1,40 @@
+"""
+Regression test for PR #1071: approval card must render above the queue flyout.
+
+Both `.approval-card` and `.queue-card` are siblings inside `.composer-flyout`
+and share the same absolute positioning slot just above the composer. When
+both are visible at the same time (queue flyout open + tool approval card
+sliding up) the approval card MUST win the stacking order so its security-
+relevant Allow / Deny buttons stay clickable.
+
+The old CSS had `.queue-card { z-index: 2 }` and no z-index on
+`.approval-card.visible`, so the queue card painted on top and blocked the
+approval buttons. The fix raises `.approval-card.visible` to z-index 3.
+
+This test pins the invariant: approval-card.visible z-index must be strictly
+greater than queue-card z-index.
+"""
+import re
+from pathlib import Path
+
+CSS = Path("static/style.css").read_text(encoding="utf-8")
+
+
+def _z_index_of(selector_regex: str) -> int | None:
+    m = re.search(selector_regex + r"\s*\{[^}]*z-index:(\d+)", CSS)
+    return int(m.group(1)) if m else None
+
+
+def test_approval_card_visible_outranks_queue_card():
+    queue_z = _z_index_of(r"\.queue-card")
+    approval_visible_z = _z_index_of(r"\.approval-card\.visible")
+    assert queue_z is not None, ".queue-card must declare a z-index"
+    assert approval_visible_z is not None, (
+        ".approval-card.visible must declare a z-index — without it, the approval "
+        "buttons get covered by the queue flyout (PR #1071)"
+    )
+    assert approval_visible_z > queue_z, (
+        f".approval-card.visible z-index ({approval_visible_z}) must be strictly "
+        f"greater than .queue-card z-index ({queue_z}) so approval buttons "
+        f"remain clickable when both flyouts are open."
+    )


### PR DESCRIPTION
## Bug

When a message is queued (queue flyout visible) at the same time as a tool approval card appears, the queue flyout renders on top of the approval card — making the **Allow once / Allow session / Always allow / Deny** buttons difficult or impossible to click.

## Root cause

`.queue-card` has `z-index: 2`. `.approval-card.visible` had no explicit z-index, so it lost to the queue card in stacking order.

```css
/* before */
.approval-card.visible { pointer-events: auto; }          /* no z-index → loses to queue-card */
.queue-card            { ... z-index: 2; }                /* wins */
```

## Fix

One line — add `z-index: 3` to `.approval-card.visible`:

```css
.approval-card.visible { pointer-events: auto; z-index: 3; }
```

No JS changes needed. Approval is a blocking, security-relevant interaction and must always render above passive UI elements like the queue flyout.

## Test result

Full suite: 2319 passed, 0 failed.
