### PR TITLE
Keep reasoning chip visible for None effort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- **Reasoning None chip visibility** — the composer reasoning chip now remains visible when reasoning effort is unset/default or explicitly set to `none`, showing `Default` or `None` instead of disappearing. (`static/ui.js`, `static/style.css`) Closes #1068
+
 ## v0.50.215 — 2026-04-26
 
 ### Added

--- a/static/style.css
+++ b/static/style.css
@@ -655,6 +655,7 @@
   .composer-workspace-label{min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
   .composer-reasoning-wrap{position:relative;flex:0 1 auto;min-width:0;}
   .composer-reasoning-chip{display:inline-flex;align-items:center;gap:8px;max-width:180px;padding:8px 10px 8px 12px;border-radius:999px;border:1px solid transparent;background-color:transparent;color:var(--muted);font-weight:500;cursor:pointer;transition:color .15s,background-color .15s,border-color .15s;}
+  .composer-reasoning-chip.inactive{opacity:.78;}
   .composer-reasoning-chip:hover{color:var(--text);background-color:var(--hover-bg);}
   .composer-reasoning-chip.active{color:var(--text);background:var(--accent-bg);border-color:var(--accent-bg);}
   .composer-reasoning-icon,.composer-reasoning-chevron{display:inline-flex;align-items:center;justify-content:center;flex-shrink:0;line-height:1;}

--- a/static/ui.js
+++ b/static/ui.js
@@ -432,15 +432,31 @@ window.addEventListener('resize',()=>{
 // ── Reasoning effort chip ────────────────────────────────────────────────────
 let _currentReasoningEffort=null;
 
+function _normalizeReasoningEffort(eff){
+  return String(eff||'').trim().toLowerCase();
+}
+
+function _formatReasoningEffortLabel(effort){
+  if(effort==='none') return 'None';
+  if(!effort) return 'Default';
+  return effort;
+}
+
 function _applyReasoningChip(eff){
-  _currentReasoningEffort=eff;
+  const effort=_normalizeReasoningEffort(eff);
+  _currentReasoningEffort=effort;
   const wrap=$('composerReasoningWrap');
   const label=$('composerReasoningLabel');
+  const chip=$('composerReasoningChip');
   if(!wrap||!label) return;
-  if(!eff||eff==='none'){wrap.style.display='none';return;}
   wrap.style.display='';
-  label.textContent=eff;
-  _highlightReasoningOption(eff);
+  label.textContent=_formatReasoningEffortLabel(effort);
+  if(chip){
+    const inactive=!effort||effort==='none';
+    chip.classList.toggle('inactive',inactive);
+    chip.title='Reasoning effort: '+_formatReasoningEffortLabel(effort);
+  }
+  _highlightReasoningOption(effort);
 }
 
 function fetchReasoningChip(){

--- a/tests/test_reasoning_chip_btw_fixes.py
+++ b/tests/test_reasoning_chip_btw_fixes.py
@@ -28,6 +28,7 @@ INDEX = (REPO / "static" / "index.html").read_text(encoding="utf-8")
 UI_JS = (REPO / "static" / "ui.js").read_text(encoding="utf-8")
 COMMANDS_JS = (REPO / "static" / "commands.js").read_text(encoding="utf-8")
 MESSAGES_JS = (REPO / "static" / "messages.js").read_text(encoding="utf-8")
+STYLE_CSS = (REPO / "static" / "style.css").read_text(encoding="utf-8")
 
 
 # ── #1 dropdown escapes composer-left ─────────────────────────────────────────
@@ -112,6 +113,57 @@ class TestReasoningChipIcon:
         assert "🧠" not in fn, (
             "_applyReasoningChip should not concatenate a 🧠 emoji into the label — "
             "the chip already has a monochrome SVG icon next to the label"
+        )
+
+
+# ── #1068 None/default reasoning chip stays visible ──────────────────────────
+
+
+class TestReasoningChipNoneState:
+    """Reasoning effort is a current setting like model selection.  Setting it
+    to None disables reasoning, but the chip must remain visible so users can
+    see and change the current level."""
+
+    def get_apply_reasoning_chip(self):
+        m = re.search(
+            r"function\s+_applyReasoningChip\b[\s\S]*?^}",
+            UI_JS,
+            re.MULTILINE,
+        )
+        assert m, "_applyReasoningChip not found in ui.js"
+        return m.group(0)
+
+    def test_none_and_default_do_not_hide_reasoning_chip(self):
+        fn = self.get_apply_reasoning_chip()
+        assert "wrap.style.display='';" in fn, (
+            "_applyReasoningChip must show the reasoning chip even for empty/"
+            "default or 'none' effort values"
+        )
+        assert "if(!eff" not in fn and "wrap.style.display='none'" not in fn, (
+            "_applyReasoningChip must not use a truthy guard that hides the "
+            "chip for the valid 'none' state"
+        )
+        assert "wrap.style.display='none'" not in fn, (
+            "the None/default reasoning state should be visible, not hidden"
+        )
+
+    def test_none_and_default_have_visible_labels(self):
+        assert "if(effort==='none') return 'None';" in UI_JS, (
+            "the disabled reasoning state must render a visible 'None' label"
+        )
+        assert "if(!effort) return 'Default';" in UI_JS, (
+            "the unset reasoning state must render a visible 'Default' label"
+        )
+
+    def test_none_and_default_are_visually_inactive_not_missing(self):
+        fn = self.get_apply_reasoning_chip()
+        assert "chip.classList.toggle('inactive',inactive)" in fn, (
+            "None/default should be shown with an inactive visual treatment "
+            "instead of removing the chip"
+        )
+        assert ".composer-reasoning-chip.inactive" in STYLE_CSS, (
+            "the inactive chip state needs a CSS rule so the visible None/"
+            "default state is intentionally muted"
         )
 
 

--- a/tests/test_reasoning_chip_js_behaviour.py
+++ b/tests/test_reasoning_chip_js_behaviour.py
@@ -1,0 +1,199 @@
+"""Behavioural tests that drive the actual `_applyReasoningChip()` from
+static/ui.js via node, not just a regex over the source.
+
+The static checks in test_reasoning_chip_btw_fixes.py confirm the *shape*
+of the function (no `display='none'`, the right toggle call exists, etc.)
+but they pass even if a runtime detail is wrong — e.g. if `inactive` were
+inverted, or `_normalizeReasoningEffort` mishandled whitespace, or the
+label fell through to a wrong value for an unknown input.
+
+This file pins the actual rendered output for every effort state so the
+chip's None/Default visibility cannot silently regress.
+"""
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent.resolve()
+UI_JS_PATH = REPO_ROOT / "static" / "ui.js"
+
+NODE = shutil.which("node")
+pytestmark = pytest.mark.skipif(NODE is None, reason="node not on PATH")
+
+
+_DRIVER_SRC = r"""
+const fs = require('fs');
+const src = fs.readFileSync(process.argv[2], 'utf8');
+
+function makeEl() {
+  return {
+    style: {},
+    classList: {
+      _set: new Set(),
+      add(c){this._set.add(c)},
+      remove(c){this._set.delete(c)},
+      toggle(c, on){
+        const want = on === undefined ? !this._set.has(c) : Boolean(on);
+        if (want) this._set.add(c); else this._set.delete(c);
+      },
+      contains(c){return this._set.has(c)},
+    },
+    dataset: {},
+    title: '',
+    textContent: '',
+    querySelectorAll(){return []},
+  };
+}
+
+const els = {
+  composerReasoningWrap: makeEl(),
+  composerReasoningLabel: makeEl(),
+  composerReasoningChip: makeEl(),
+  composerReasoningDropdown: makeEl(),
+};
+els.composerReasoningWrap.style.display = 'none'; // mirrors the HTML default
+
+global.window = {};
+global.document = {
+  createElement: () => makeEl(),
+  addEventListener: () => {},
+  querySelectorAll: () => [],
+  querySelector: () => null,
+};
+global.$ = id => els[id] || null;
+global.api = () => ({ then: () => ({ catch: () => {} }), catch: () => {} });
+
+function extractFunc(name) {
+  const re = new RegExp('function\\s+' + name + '\\s*\\(');
+  const start = src.search(re);
+  if (start < 0) throw new Error(name + ' not found');
+  let i = src.indexOf('{', start);
+  let depth = 1; i++;
+  while (depth > 0 && i < src.length) {
+    if (src[i] === '{') depth++;
+    else if (src[i] === '}') depth--;
+    i++;
+  }
+  return src.slice(start, i);
+}
+eval(extractFunc('_normalizeReasoningEffort'));
+eval(extractFunc('_formatReasoningEffortLabel'));
+eval(extractFunc('_highlightReasoningOption'));
+eval(extractFunc('_applyReasoningChip'));
+
+const input = JSON.parse(process.argv[3]);
+_applyReasoningChip(input);
+const result = {
+  display: els.composerReasoningWrap.style.display,
+  label:   els.composerReasoningLabel.textContent,
+  inactive: els.composerReasoningChip.classList.contains('inactive'),
+  title:   els.composerReasoningChip.title,
+};
+process.stdout.write(JSON.stringify(result));
+"""
+
+
+@pytest.fixture(scope="module")
+def driver_path(tmp_path_factory):
+    p = tmp_path_factory.mktemp("reasoning_driver") / "driver.js"
+    p.write_text(_DRIVER_SRC, encoding="utf-8")
+    return str(p)
+
+
+def _apply(driver_path, value):
+    """Run _applyReasoningChip(value) against the actual ui.js."""
+    import json as _json
+    result = subprocess.run(
+        [NODE, driver_path, str(UI_JS_PATH), _json.dumps(value)],
+        capture_output=True, text=True, timeout=10,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"node driver failed: {result.stderr}")
+    return _json.loads(result.stdout)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# The chip MUST stay visible for every effort state (issue #1068).  This used
+# to be hidden for !eff and 'none', and the source-regex tests in
+# test_reasoning_chip_btw_fixes.py verify the literal `display='none'` is gone
+# — but only a behavioural check confirms the wrap actually receives `''`.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestChipAlwaysVisible:
+
+    def test_empty_string_shows_chip_with_default_label(self, driver_path):
+        out = _apply(driver_path, "")
+        assert out["display"] == "", f"empty effort must show the chip: {out}"
+        assert out["label"] == "Default"
+        assert out["inactive"] is True
+
+    def test_null_shows_chip_with_default_label(self, driver_path):
+        out = _apply(driver_path, None)
+        assert out["display"] == ""
+        assert out["label"] == "Default"
+        assert out["inactive"] is True
+
+    def test_none_shows_chip_with_none_label(self, driver_path):
+        """The bug from #1068 — 'none' must NOT hide the chip."""
+        out = _apply(driver_path, "none")
+        assert out["display"] == "", (
+            f"'none' must show the chip (the regression that started #1068): {out}"
+        )
+        assert out["label"] == "None"
+        assert out["inactive"] is True
+
+    def test_low_shows_chip_active(self, driver_path):
+        out = _apply(driver_path, "low")
+        assert out["display"] == ""
+        assert out["label"] == "low"
+        assert out["inactive"] is False
+
+    def test_high_shows_chip_active(self, driver_path):
+        out = _apply(driver_path, "high")
+        assert out["display"] == ""
+        assert out["inactive"] is False
+
+
+class TestNormalizationEdgeCases:
+    """Pin the input-normalisation contract so it can't silently shift."""
+
+    def test_uppercase_normalises(self, driver_path):
+        # Even though the API and slash command use lowercase, defensive
+        # normalisation matters — copy/paste of an uppercase value or a
+        # mis-cased server response shouldn't break the chip.
+        out = _apply(driver_path, "NONE")
+        assert out["label"] == "None"
+        assert out["inactive"] is True
+
+    def test_whitespace_trimmed(self, driver_path):
+        out = _apply(driver_path, "  none  ")
+        assert out["label"] == "None"
+        assert out["inactive"] is True
+
+    def test_unknown_value_falls_through_visible(self, driver_path):
+        # Defensive: unknown effort still shows the chip rather than hiding.
+        out = _apply(driver_path, "banana")
+        assert out["display"] == ""
+        assert out["label"] == "banana"
+        assert out["inactive"] is False
+
+
+class TestTitleAttributeAccessibility:
+    """The chip's `title` is the hover tooltip and a screen-reader hint —
+    confirm it always carries the current state in human-readable form."""
+
+    def test_title_has_default_label_for_unset(self, driver_path):
+        out = _apply(driver_path, "")
+        assert out["title"] == "Reasoning effort: Default"
+
+    def test_title_has_none_label_for_none(self, driver_path):
+        out = _apply(driver_path, "none")
+        assert out["title"] == "Reasoning effort: None"
+
+    def test_title_has_active_label_for_high(self, driver_path):
+        out = _apply(driver_path, "high")
+        assert out["title"] == "Reasoning effort: high"


### PR DESCRIPTION
## Summary
- Keep the composer reasoning chip visible when the current effort is unset/default or explicitly `none`.
- Render visible labels for both inactive states: `Default` for unset config and `None` for disabled reasoning.
- Add an inactive visual treatment instead of removing the chip.

## Root Cause
`_applyReasoningChip()` treated falsy effort values and `none` as a signal to hide `#composerReasoningWrap`. That made `None` a valid saved state with no visible UI affordance to inspect or change it.

## Verification
- `node --check static/ui.js`
- `./.venv_test/bin/pytest tests/test_reasoning_chip_btw_fixes.py tests/test_reasoning_show_hide.py`
- `git diff --check`

Closes #1068
