### PR TITLE
fix(css): overflow-wrap:anywhere on chat bubbles — prevents long URL bleed (#1080)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- **Long URL / unbreakable string overflow** — chat bubble boundaries no longer overflow when a message contains very long URLs, file paths, or base64 data. `overflow-wrap: anywhere` added to `.msg-body` and the user-bubble variant so continuous non-whitespace text wraps at the column edge instead of bleeding into adjacent layout areas. (`static/style.css`) Closes #1080
+
 
 ## v0.50.217 — 2026-04-26
 

--- a/static/style.css
+++ b/static/style.css
@@ -568,7 +568,7 @@
   .role-icon{width:22px;height:22px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:10px;font-weight:700;flex-shrink:0;}
   .role-icon.user{background:var(--accent-bg);color:var(--accent-text);border:1px solid var(--accent-bg-strong);}
   .role-icon.assistant{background:var(--accent-bg-strong);color:var(--accent-text);border:1px solid var(--accent-bg-strong);}
-  .msg-body{font-size:14px;line-height:1.75;color:var(--text);padding-left:30px;max-width:680px;}
+  .msg-body{font-size:14px;line-height:1.75;color:var(--text);padding-left:30px;max-width:680px;overflow-wrap:anywhere;}
   .msg-body p{margin-bottom:10px;}.msg-body p:last-child{margin-bottom:0;}
   .msg-body ul,.msg-body ol{margin:6px 0 10px 20px;}.msg-body li{margin-bottom:3px;}
   .msg-body h1,.msg-body h2,.msg-body h3{margin:16px 0 6px;font-weight:600;}
@@ -1969,6 +1969,7 @@ main.main.showing-profiles > #mainProfiles{display:flex;}
   padding-left: 14px;
   max-width: none;
   color: var(--user-bubble-text);
+  overflow-wrap: anywhere;
 }
 .msg-row[data-role="user"] .msg-body::selection,
 .msg-row[data-role="user"] .msg-body *::selection {


### PR DESCRIPTION
## Summary

Long unbreakable strings — URLs, file paths, base64 data — overflow chat bubble boundaries and bleed into adjacent layout areas. Two CSS lines fix it.

## Root cause

`static/style.css` had no `overflow-wrap` rule on `.msg-body` or the user-bubble variant. The browser's default is `overflow-wrap: normal`, which never breaks inside a word/token regardless of container width.

## Fix

Added `overflow-wrap: anywhere` to:
- `.msg-body` (line ~571) — assistant message bodies
- `.msg-row[data-role="user"] .msg-body` (line ~1963) — user message bubbles

`overflow-wrap: anywhere` is preferred over `break-all` because it only inserts breaks at non-break-opportunity points (i.e. only when the word genuinely cannot fit), preserving normal word-wrapping for regular prose.

## Testing

- 2442/2442 tests pass
- CSS-only change, no logic modified

Closes #1080