### PR TITLE
fix(projects): project chip rename + color picker via right-click context menu (#1078)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Fixed
+- **Project chip rename now works** — double-clicking a project chip now reliably triggers the rename input. Root cause: `onclick` was calling `renderSessionListFromCache()` which destroyed the chip DOM node before `ondblclick` could fire. Fixed with a 220ms `_clickTimer` delay on `onclick` (same pattern used by session items), so a double-click cancels the single-click and invokes rename instead. (`static/sessions.js`) Closes #1078
+
+### Added
+- **Project color picker** — right-clicking a project chip now shows a context menu with Rename, a row of color swatches (the 8 `PROJECT_COLORS`), and Delete. Selecting a swatch updates the project color via the existing `/api/projects/rename` endpoint (which already supports an optional `color` field). (`static/sessions.js`) Closes #1078
+
 
 ## v0.50.217 — 2026-04-26
 

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -779,9 +779,13 @@ function renderSessionListFromCache(){
       const nameSpan=document.createElement('span');
       nameSpan.textContent=p.name;
       chip.appendChild(nameSpan);
-      chip.onclick=()=>{_activeProject=p.project_id;renderSessionListFromCache();};
-      chip.ondblclick=(e)=>{e.stopPropagation();_startProjectRename(p,chip);};
-      chip.oncontextmenu=(e)=>{e.preventDefault();_confirmDeleteProject(p);};
+      let _pClickTimer=null;
+      chip.onclick=(e)=>{
+        clearTimeout(_pClickTimer);
+        _pClickTimer=setTimeout(()=>{_pClickTimer=null;_activeProject=p.project_id;renderSessionListFromCache();},220);
+      };
+      chip.ondblclick=(e)=>{e.stopPropagation();clearTimeout(_pClickTimer);_pClickTimer=null;_startProjectRename(p,chip);};
+      chip.oncontextmenu=(e)=>{e.preventDefault();_showProjectContextMenu(e,p,chip);};
       bar.appendChild(chip);
     }
     // Create button
@@ -1230,6 +1234,57 @@ function _startProjectRename(proj, chip){
   inp.onclick=(e)=>e.stopPropagation();
   chip.replaceWith(inp);
   setTimeout(()=>{inp.focus();inp.select();},10);
+}
+
+function _showProjectContextMenu(e, proj, chip){
+  document.querySelectorAll('.project-ctx-menu').forEach(el=>el.remove());
+  const menu=document.createElement('div');
+  menu.className='project-ctx-menu';
+  menu.style.cssText='position:fixed;background:var(--panel);border:1px solid var(--border);border-radius:8px;padding:6px 0;z-index:9999;min-width:140px;box-shadow:0 4px 16px rgba(0,0,0,.35);';
+  menu.style.left=e.clientX+'px';
+  menu.style.top=e.clientY+'px';
+
+  // Rename option
+  const renameItem=document.createElement('div');
+  renameItem.textContent='Rename';
+  renameItem.style.cssText='padding:7px 14px;cursor:pointer;font-size:13px;color:var(--text);';
+  renameItem.onmouseenter=()=>renameItem.style.background='var(--hover)';
+  renameItem.onmouseleave=()=>renameItem.style.background='';
+  renameItem.onclick=()=>{menu.remove();_startProjectRename(proj,chip);};
+  menu.appendChild(renameItem);
+
+  // Color picker row
+  const colorRow=document.createElement('div');
+  colorRow.style.cssText='display:flex;gap:5px;padding:7px 14px;align-items:center;';
+  PROJECT_COLORS.forEach(hex=>{
+    const dot=document.createElement('span');
+    dot.style.cssText=`width:16px;height:16px;border-radius:50%;background:${hex};cursor:pointer;display:inline-block;flex-shrink:0;`;
+    if(hex===(proj.color||'')) dot.style.outline='2px solid var(--text)';
+    dot.onclick=async()=>{
+      menu.remove();
+      await api('/api/projects/rename',{method:'POST',body:JSON.stringify({project_id:proj.project_id,name:proj.name,color:hex})});
+      await renderSessionList();
+      showToast('Color updated');
+    };
+    colorRow.appendChild(dot);
+  });
+  menu.appendChild(colorRow);
+
+  // Divider + Delete
+  const sep=document.createElement('hr');
+  sep.style.cssText='border:none;border-top:1px solid var(--border);margin:4px 0;';
+  menu.appendChild(sep);
+  const delItem=document.createElement('div');
+  delItem.textContent='Delete';
+  delItem.style.cssText='padding:7px 14px;cursor:pointer;font-size:13px;color:var(--error,#e94560);';
+  delItem.onmouseenter=()=>delItem.style.background='var(--hover)';
+  delItem.onmouseleave=()=>delItem.style.background='';
+  delItem.onclick=()=>{menu.remove();_confirmDeleteProject(proj);};
+  menu.appendChild(delItem);
+
+  document.body.appendChild(menu);
+  const dismiss=()=>{menu.remove();document.removeEventListener('click',dismiss);};
+  setTimeout(()=>document.addEventListener('click',dismiss),0);
 }
 
 async function _confirmDeleteProject(proj){


### PR DESCRIPTION
## Summary

Two UX gaps in project chips fixed:

1. **Rename never triggered** — `ondblclick` was wired up but dead. The `onclick` handler called `renderSessionListFromCache()` which destroyed the chip DOM node before the `dblclick` event could fire, so `_startProjectRename()` was never reached.

2. **No way to change a project color after creation** — colors were permanently assigned at creation time with no UI to change them.

## Fix

**Rename (sessions.js ~782):**  
Added a 220ms `_pClickTimer` delay on `onclick` — the same `_clickTimer` pattern already used by session items (~1026). A double-click cancels the pending single-click and invokes rename instead.

**Color picker (new `_showProjectContextMenu`):**  
Changed `chip.oncontextmenu` from calling `_confirmDeleteProject` directly to opening a small context menu with:
- **Rename** — calls `_startProjectRename`
- **Color swatches** — 8 dots from `PROJECT_COLORS`; clicking one POSTs to `/api/projects/rename` with the `color` field (already supported by the API)
- **Delete** — calls `_confirmDeleteProject` as before

The context menu auto-dismisses on any outside click.

## Changes

- `static/sessions.js` — click-timer guard + context menu function (~65 lines)
- `CHANGELOG.md`

## Testing

- 2442/2442 tests pass (CSS/JS-only change)
- Verify: create a project, double-click chip → rename input appears; right-click chip → color picker menu appears

Closes #1078