### PR TITLE
fix(projects): opaque context menu + auto-sizing rename input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Fixed
 
+- **Project context menu transparent background** — the right-click menu on project chips no longer bleeds the session list through it. Root cause: `_showProjectContextMenu` set `background: var(--panel)`, but `--panel` is not defined as a CSS custom property in this codebase, so the menu fell back to `transparent`. Fix: use `var(--surface)` (the same opaque variable used by `.session-action-menu` and other floating popovers). (`static/sessions.js`)
+- **Project rename input width** — the rename / new-project text field is no longer fixed at 100px regardless of content. Replaced the hard-coded `width:100px` on `.project-create-input` with `min-width:40px; max-width:180px; width:auto`, and added a `_resizeProjectInput()` helper that measures the current value with a hidden span and grows the field as the user types. Wired into both the rename flow (`_startProjectRename`) and the new-project flow (`_startProjectCreate`). (`static/style.css`, `static/sessions.js`)
+
 ## v0.50.218 — 2026-04-26
 
 ### Fixed

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1182,6 +1182,20 @@ function _showProjectPicker(session, anchorEl){
   setTimeout(()=>document.addEventListener('click',close),0);
 }
 
+// Resize a .project-create-input to fit its current value (or placeholder).
+// Bounded by the CSS min-width:40px / max-width:180px on the same class so
+// the input is never comically tiny nor wider than the project bar.
+// Uses a hidden span sized with the same font/padding to measure text width.
+function _resizeProjectInput(inp){
+  const sizer=document.createElement('span');
+  sizer.style.cssText='position:absolute;visibility:hidden;white-space:pre;font-size:10px;padding:0 8px;font-family:inherit;';
+  sizer.textContent=inp.value||inp.placeholder||' ';
+  document.body.appendChild(sizer);
+  const w=Math.min(180,Math.max(40,sizer.offsetWidth+2));
+  document.body.removeChild(sizer);
+  inp.style.width=w+'px';
+}
+
 function _startProjectCreate(bar, addBtn){
   const inp=document.createElement('input');
   inp.className='project-create-input';
@@ -1205,7 +1219,9 @@ function _startProjectCreate(bar, addBtn){
     if(e.key==='Escape'){e.preventDefault();finish(false);}
   };
   inp.onblur=()=>finish(false);
+  inp.addEventListener('input',()=>_resizeProjectInput(inp));
   addBtn.replaceWith(inp);
+  _resizeProjectInput(inp);
   setTimeout(()=>inp.focus(),10);
 }
 
@@ -1232,7 +1248,9 @@ function _startProjectRename(proj, chip){
   };
   inp.onblur=()=>finish(false);
   inp.onclick=(e)=>e.stopPropagation();
+  inp.addEventListener('input',()=>_resizeProjectInput(inp));
   chip.replaceWith(inp);
+  _resizeProjectInput(inp);
   setTimeout(()=>{inp.focus();inp.select();},10);
 }
 
@@ -1240,7 +1258,11 @@ function _showProjectContextMenu(e, proj, chip){
   document.querySelectorAll('.project-ctx-menu').forEach(el=>el.remove());
   const menu=document.createElement('div');
   menu.className='project-ctx-menu';
-  menu.style.cssText='position:fixed;background:var(--panel);border:1px solid var(--border);border-radius:8px;padding:6px 0;z-index:9999;min-width:140px;box-shadow:0 4px 16px rgba(0,0,0,.35);';
+  // background: var(--surface) — fully-opaque theme variable (not var(--panel),
+  // which is undefined in this codebase and falls back to transparent, letting
+  // the session list show through the menu). Same variable used by
+  // .session-action-menu and other floating popovers.
+  menu.style.cssText='position:fixed;background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:6px 0;z-index:9999;min-width:140px;box-shadow:0 4px 16px rgba(0,0,0,.35);';
   menu.style.left=e.clientX+'px';
   menu.style.top=e.clientY+'px';
 

--- a/static/style.css
+++ b/static/style.css
@@ -1824,7 +1824,7 @@ main.main.showing-profiles > #mainProfiles{display:flex;}
 .project-chip .color-dot{width:6px;height:6px;border-radius:50%;display:inline-block;flex-shrink:0;}
 .project-create-btn{font-size:10px;padding:3px 6px;border-radius:12px;cursor:pointer;border:1px dashed var(--border2);background:none;color:var(--muted);opacity:.6;transition:all .15s;}
 .project-create-btn:hover{opacity:1;border-color:var(--blue);color:var(--blue);}
-.project-create-input{font-size:10px;padding:3px 8px;border-radius:12px;border:1px solid var(--accent-bg);background:var(--surface);color:var(--text);outline:none;width:100px;font-family:inherit;box-shadow:0 0 0 2px var(--accent-bg);}
+.project-create-input{font-size:10px;padding:3px 8px;border-radius:12px;border:1px solid var(--accent-bg);background:var(--surface);color:var(--text);outline:none;min-width:40px;max-width:180px;width:auto;font-family:inherit;box-shadow:0 0 0 2px var(--accent-bg);}
 .project-picker{position:absolute;right:0;top:100%;background:var(--sidebar);border:1px solid var(--border2);border-radius:8px;padding:4px;z-index:30;min-width:160px;max-width:220px;width:max-content;box-shadow:0 4px 16px rgba(0,0,0,.3);}
 .project-picker-item{padding:5px 10px;font-size:11px;border-radius:6px;cursor:pointer;color:var(--muted);transition:all .1s;display:flex;align-items:center;gap:6px;}
 .project-picker-item:hover{background:rgba(255,255,255,.08);color:var(--text);}

--- a/tests/test_project_chip_ui.py
+++ b/tests/test_project_chip_ui.py
@@ -1,0 +1,164 @@
+"""Regression tests for the project chip UI fixes (issue #1085).
+
+Two bugs:
+
+1. The right-click context menu opened by `_showProjectContextMenu` was styled
+   with `background: var(--panel)`, but `--panel` is NOT defined anywhere in
+   style.css.  CSS falls back to `transparent` for undefined variables, so the
+   menu appeared see-through and the session list bled through.  The fix
+   replaces `var(--panel)` with `var(--surface)` — the same opaque variable
+   used by `.session-action-menu` and other floating popovers.
+
+2. The `.project-create-input` (used for both rename and new-project creation)
+   had `width: 100px` hard-coded, so the field was always exactly 100px wide
+   regardless of the project name being edited.  Fix: bound the field with
+   `min-width: 40px` / `max-width: 180px` and `width: auto`, plus a
+   `_resizeProjectInput()` JS helper that measures the current value with a
+   hidden span and sets the pixel width accordingly.
+
+These are static-source tests — CSS/JS behaviour of a popover and an input
+sizer can't be exercised faithfully without a browser, but the patterns
+worth pinning are the variable names, the absence of the bad ones, and the
+presence of the resize helper at both call sites.
+"""
+
+import pathlib
+
+REPO = pathlib.Path(__file__).parent.parent
+SESSIONS_JS = (REPO / "static" / "sessions.js").read_text(encoding="utf-8")
+STYLE_CSS = (REPO / "static" / "style.css").read_text(encoding="utf-8")
+
+
+# ── Bug 1: context menu background ────────────────────────────────────────────
+
+
+class TestContextMenuBackground:
+
+    def test_panel_variable_not_defined_in_stylesheet(self):
+        """`--panel` is not defined as a CSS custom property anywhere — so
+        any rule using `var(--panel)` falls back to `transparent`, which is
+        the actual root cause of the menu bleed-through.  This test
+        documents that fact: if `--panel` is ever defined, the test will
+        need updating but the fix is still safer using `--surface`."""
+        # Match either ":root --panel:" or "--panel:" assignments; absence
+        # confirms the fallback-to-transparent failure mode.
+        assert "--panel:" not in STYLE_CSS, (
+            "If --panel is now defined, update this test, but the menu "
+            "should still use --surface for consistency with other popovers."
+        )
+
+    def test_context_menu_uses_surface_not_panel(self):
+        """`_showProjectContextMenu` must set the menu background to
+        `var(--surface)`, not `var(--panel)`."""
+        # Locate the menu construction
+        idx = SESSIONS_JS.find("project-ctx-menu")
+        assert idx >= 0, "project-ctx-menu className not found in sessions.js"
+        # Look at the surrounding 800 chars where the cssText is set
+        window = SESSIONS_JS[idx: idx + 1200]
+        assert "background:var(--surface)" in window, (
+            "Project context menu must use background:var(--surface) for an "
+            "opaque surface — var(--panel) is undefined and falls back to "
+            "transparent."
+        )
+        assert "background:var(--panel)" not in window, (
+            "Project context menu still uses background:var(--panel) — "
+            "this CSS variable is not defined and renders transparent."
+        )
+
+    def test_session_action_menu_also_uses_surface_for_consistency(self):
+        """Sanity check: the existing .session-action-menu (the analogous
+        right-click menu for session items) uses `var(--surface)` — so the
+        fix is consistent with the rest of the codebase."""
+        assert "session-action-menu" in STYLE_CSS
+        # Find the rule and confirm it uses --surface
+        idx = STYLE_CSS.find(".session-action-menu")
+        assert idx >= 0
+        rule = STYLE_CSS[idx: idx + 400]
+        assert "var(--surface)" in rule, (
+            ".session-action-menu should use var(--surface) — kept here as "
+            "the canonical reference for opaque popover surfaces."
+        )
+
+
+# ── Bug 2: project-create-input width ─────────────────────────────────────────
+
+
+class TestProjectCreateInputWidth:
+
+    def test_no_hardcoded_100px_width(self):
+        """The fixed `width: 100px` on .project-create-input is gone."""
+        idx = STYLE_CSS.find(".project-create-input{")
+        assert idx >= 0, ".project-create-input rule not found in style.css"
+        rule = STYLE_CSS[idx: idx + 400]
+        assert "width:100px" not in rule and "width: 100px" not in rule, (
+            "Fixed 100px width must be replaced with min-width/max-width/"
+            "width:auto so the input grows with its content."
+        )
+
+    def test_min_and_max_width_present(self):
+        """Both min-width and max-width must be set on .project-create-input."""
+        idx = STYLE_CSS.find(".project-create-input{")
+        rule = STYLE_CSS[idx: idx + 400]
+        assert "min-width:40px" in rule, (
+            f"min-width:40px not found in .project-create-input rule: {rule}"
+        )
+        assert "max-width:180px" in rule, (
+            f"max-width:180px not found in .project-create-input rule: {rule}"
+        )
+        assert "width:auto" in rule, (
+            f"width:auto not found in .project-create-input rule: {rule}"
+        )
+
+
+class TestResizeProjectInputHelper:
+    """The `_resizeProjectInput` helper must exist and be wired into both
+    rename and create call sites."""
+
+    def test_resize_helper_defined(self):
+        assert "function _resizeProjectInput(" in SESSIONS_JS, (
+            "_resizeProjectInput helper not found in sessions.js"
+        )
+
+    def test_resize_helper_uses_hidden_span(self):
+        """The standard pattern is to measure with a hidden absolute span
+        sharing the same font/padding as the input."""
+        idx = SESSIONS_JS.find("function _resizeProjectInput(")
+        assert idx >= 0
+        body = SESSIONS_JS[idx: idx + 800]
+        assert "position:absolute" in body and "visibility:hidden" in body, (
+            "_resizeProjectInput should use a hidden absolute span to "
+            "measure the value's rendered width."
+        )
+        assert "Math.min(180" in body, (
+            "max bound (180) not applied in _resizeProjectInput"
+        )
+        assert "Math.max(40" in body, (
+            "min bound (40) not applied in _resizeProjectInput"
+        )
+
+    def test_rename_calls_resize_helper(self):
+        """`_startProjectRename` must call `_resizeProjectInput` once on
+        creation and again on every input event."""
+        idx = SESSIONS_JS.find("function _startProjectRename(")
+        assert idx >= 0
+        body = SESSIONS_JS[idx: idx + 1200]
+        assert "_resizeProjectInput(inp)" in body, (
+            "_startProjectRename must call _resizeProjectInput so the "
+            "input width matches the existing project name."
+        )
+        # Wired into the input event so it grows as the user types
+        assert "addEventListener('input'" in body and "_resizeProjectInput" in body, (
+            "_startProjectRename must wire input events to _resizeProjectInput"
+        )
+
+    def test_create_calls_resize_helper(self):
+        """Same for `_startProjectCreate` (new-project entry field)."""
+        idx = SESSIONS_JS.find("function _startProjectCreate(")
+        assert idx >= 0
+        body = SESSIONS_JS[idx: idx + 1200]
+        assert "_resizeProjectInput(inp)" in body, (
+            "_startProjectCreate must call _resizeProjectInput on focus"
+        )
+        assert "addEventListener('input'" in body, (
+            "_startProjectCreate must wire input events to _resizeProjectInput"
+        )


### PR DESCRIPTION
## Summary

Two project-chip UI bugs from `project-ui-bugs.md` (both surfaced by recent project-chip work in #1082):

### Bug 1 — Context menu was transparent

The right-click context menu on a project chip showed the session list bleeding through. Root cause was a misdiagnosis in the bug report: it's not an opacity problem, it's that `var(--panel)` **isn't defined anywhere** in `static/style.css`. CSS falls back to `transparent` for undefined variables, so the menu had no background at all.

Fix: change the menu to `background: var(--surface)` — the variable [`.session-action-menu`](static/style.css#L298) and other floating popovers already use.

### Bug 2 — Rename/create input had a fixed 100px width

`.project-create-input` had `width: 100px` hard-coded, so a 3-letter project name got the same input width as a 20-letter one.

Fix:
- CSS: `width: 100px` → `min-width: 40px; max-width: 180px; width: auto;`
- JS: new `_resizeProjectInput()` helper that measures the current value with a hidden absolute-positioned span (same font/padding) and sets the pixel width inside the CSS bounds. Wired into both `_startProjectRename` (focus + every keystroke) and `_startProjectCreate` (same pattern).

## Files changed

- [`static/sessions.js`](static/sessions.js) — context menu uses `var(--surface)`; new `_resizeProjectInput` helper; both rename/create flows call it on creation and on `input` events
- [`static/style.css`](static/style.css) — `.project-create-input` width rule
- [`tests/test_project_chip_ui.py`](tests/test_project_chip_ui.py) — 9 new static-source tests (see below)
- `CHANGELOG.md`

## Tests

9 new tests in `tests/test_project_chip_ui.py`:

- **`test_panel_variable_not_defined_in_stylesheet`** — pins the actual root cause: `--panel` is not defined, so `var(--panel)` resolved to `transparent`. If `--panel` is ever added the test will need updating, but the menu should still use `--surface` for consistency.
- **`test_context_menu_uses_surface_not_panel`** — the cssText set in `_showProjectContextMenu` uses `var(--surface)` and not `var(--panel)`.
- **`test_session_action_menu_also_uses_surface_for_consistency`** — sanity-check that the existing session-action menu uses `--surface`, so this fix matches the codebase pattern.
- **`test_no_hardcoded_100px_width`** — fixed `width:100px` is gone.
- **`test_min_and_max_width_present`** — `min-width:40px`, `max-width:180px`, and `width:auto` all present in the rule.
- **`test_resize_helper_defined`** — `_resizeProjectInput()` exists in `sessions.js`.
- **`test_resize_helper_uses_hidden_span`** — uses `position:absolute;visibility:hidden` for measurement, with `Math.min(180,…)` and `Math.max(40,…)` clamps.
- **`test_rename_calls_resize_helper`** — `_startProjectRename` calls `_resizeProjectInput(inp)` and wires `input` events.
- **`test_create_calls_resize_helper`** — same for `_startProjectCreate`.

Full suite: **2419 passed**, 47 skipped, 0 PR-related failures.

## Test plan

- [ ] Right-click a project chip — context menu has a fully opaque background; nothing visible behind the Rename row, color swatches, divider, or Delete row.
- [ ] Verify both light and dark themes render the menu opaquely.
- [ ] Double-click a short project name (e.g. "Foo") — input is narrow.
- [ ] Double-click a long project name — input is wider, fits the name.
- [ ] Type more characters — input grows up to 180px, then stops growing and scrolls.
- [ ] Press `Esc` to cancel rename — chip restored, no broken state.
- [ ] Click `+` to create a new project — input opens at minimum width, grows as you type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
