### PR TITLE
v0.50.219: project chip context menu + input auto-sizing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@
 
 ### Fixed
 
-- **Project context menu transparent background** — the right-click menu on project chips no longer bleeds the session list through it. Root cause: `_showProjectContextMenu` set `background: var(--panel)`, but `--panel` is not defined as a CSS custom property in this codebase, so the menu fell back to `transparent`. Fix: use `var(--surface)` (the same opaque variable used by `.session-action-menu` and other floating popovers). (`static/sessions.js`)
-- **Project rename input width** — the rename / new-project text field is no longer fixed at 100px regardless of content. Replaced the hard-coded `width:100px` on `.project-create-input` with `min-width:40px; max-width:180px; width:auto`, and added a `_resizeProjectInput()` helper that measures the current value with a hidden span and grows the field as the user types. Wired into both the rename flow (`_startProjectRename`) and the new-project flow (`_startProjectCreate`). (`static/style.css`, `static/sessions.js`)
+## v0.50.219 — 2026-04-26
 
+### Fixed
+- **Project context menu transparent background** — the right-click menu on project chips no longer bleeds the session list through it. `_showProjectContextMenu` was using `background: var(--panel)`, but `--panel` is not defined in this codebase — CSS fell back to `transparent`. Fix: use `var(--surface)` (same opaque variable used by `.session-action-menu` and other floating popovers). (`static/sessions.js`) [#1086]
+- **Project rename / create input auto-sizing** — the rename and new-project input is no longer fixed at 100px. CSS changed to `min-width:40px; max-width:180px; width:auto`. New `_resizeProjectInput()` helper measures the current value via a hidden span (font properties read from `getComputedStyle`) and updates the pixel width as the user types. Wired into both `_startProjectRename` and `_startProjectCreate`. (`static/sessions.js`, `static/style.css`) [#1086]
 ## v0.50.218 — 2026-04-26
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Fixed
 
+- **Project context menu transparent background** — the right-click menu on project chips no longer bleeds the session list through it. Root cause: `_showProjectContextMenu` set `background: var(--panel)`, but `--panel` is not defined as a CSS custom property in this codebase, so the menu fell back to `transparent`. Fix: use `var(--surface)` (the same opaque variable used by `.session-action-menu` and other floating popovers). (`static/sessions.js`)
+- **Project rename input width** — the rename / new-project text field is no longer fixed at 100px regardless of content. Replaced the hard-coded `width:100px` on `.project-create-input` with `min-width:40px; max-width:180px; width:auto`, and added a `_resizeProjectInput()` helper that measures the current value with a hidden span and grows the field as the user types. Wired into both the rename flow (`_startProjectRename`) and the new-project flow (`_startProjectCreate`). (`static/style.css`, `static/sessions.js`)
+
 ## v0.50.218 — 2026-04-26
 
 ### Fixed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,7 +3,7 @@
 > Goal: Full 1:1 parity with the Hermes CLI experience via a clean dark web UI.
 > Everything you can do from the CLI terminal, you can do from this UI.
 >
-> Last updated: v0.50.218 (April 26, 2026) — 2458 tests collected
+> Last updated: v0.50.219 (April 26, 2026) — 2467 tests collected
 > Tests: 2107 collected (`pytest tests/ --collect-only -q`)
 > Source: <repo>/
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -8,7 +8,7 @@
 > Prerequisites: SSH tunnel is active on port 8787. Open http://localhost:8787 in browser.
 > Server health check: curl http://127.0.0.1:8787/health should return {"status":"ok"}.
 >
-> Automated coverage: 2458 tests collected via `pytest tests/ --collect-only -q`. Includes onboarding coverage for bootstrap/static wizard presence, real provider config persistence (`config.yaml` + `.env`), the `/api/onboarding/*` backend, the onboarding skip/existing-config guard, and CSS regression coverage for smooth thinking/tool card disclosure animation.
+> Automated coverage: 2467 tests collected via `pytest tests/ --collect-only -q`. Includes onboarding coverage for bootstrap/static wizard presence, real provider config persistence (`config.yaml` + `.env`), the `/api/onboarding/*` backend, the onboarding skip/existing-config guard, and CSS regression coverage for smooth thinking/tool card disclosure animation.
 > Run: `pytest tests/ -v --timeout=60`
 >
 > Local regression focus: verify that a previously closed workspace panel stays visually closed from first paint through boot completion on desktop refresh; there should be no brief open-then-close flash.

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1182,6 +1182,20 @@ function _showProjectPicker(session, anchorEl){
   setTimeout(()=>document.addEventListener('click',close),0);
 }
 
+// Resize a .project-create-input to fit its current value (or placeholder).
+// Bounded by the CSS min-width:40px / max-width:180px on the same class so
+// the input is never comically tiny nor wider than the project bar.
+// Uses a hidden span sized with the same font/padding to measure text width.
+function _resizeProjectInput(inp){
+  const sizer=document.createElement('span');
+  sizer.style.cssText='position:absolute;visibility:hidden;white-space:pre;font-size:10px;padding:0 8px;font-family:inherit;';
+  sizer.textContent=inp.value||inp.placeholder||' ';
+  document.body.appendChild(sizer);
+  const w=Math.min(180,Math.max(40,sizer.offsetWidth+2));
+  document.body.removeChild(sizer);
+  inp.style.width=w+'px';
+}
+
 function _startProjectCreate(bar, addBtn){
   const inp=document.createElement('input');
   inp.className='project-create-input';
@@ -1205,7 +1219,9 @@ function _startProjectCreate(bar, addBtn){
     if(e.key==='Escape'){e.preventDefault();finish(false);}
   };
   inp.onblur=()=>finish(false);
+  inp.addEventListener('input',()=>_resizeProjectInput(inp));
   addBtn.replaceWith(inp);
+  _resizeProjectInput(inp);
   setTimeout(()=>inp.focus(),10);
 }
 
@@ -1232,7 +1248,9 @@ function _startProjectRename(proj, chip){
   };
   inp.onblur=()=>finish(false);
   inp.onclick=(e)=>e.stopPropagation();
+  inp.addEventListener('input',()=>_resizeProjectInput(inp));
   chip.replaceWith(inp);
+  _resizeProjectInput(inp);
   setTimeout(()=>{inp.focus();inp.select();},10);
 }
 
@@ -1240,7 +1258,11 @@ function _showProjectContextMenu(e, proj, chip){
   document.querySelectorAll('.project-ctx-menu').forEach(el=>el.remove());
   const menu=document.createElement('div');
   menu.className='project-ctx-menu';
-  menu.style.cssText='position:fixed;background:var(--panel);border:1px solid var(--border);border-radius:8px;padding:6px 0;z-index:9999;min-width:140px;box-shadow:0 4px 16px rgba(0,0,0,.35);';
+  // background: var(--surface) — fully-opaque theme variable (not var(--panel),
+  // which is undefined in this codebase and falls back to transparent, letting
+  // the session list show through the menu). Same variable used by
+  // .session-action-menu and other floating popovers.
+  menu.style.cssText='position:fixed;background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:6px 0;z-index:9999;min-width:140px;box-shadow:0 4px 16px rgba(0,0,0,.35);';
   menu.style.left=e.clientX+'px';
   menu.style.top=e.clientY+'px';
 

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1188,7 +1188,13 @@ function _showProjectPicker(session, anchorEl){
 // Uses a hidden span sized with the same font/padding to measure text width.
 function _resizeProjectInput(inp){
   const sizer=document.createElement('span');
-  sizer.style.cssText='position:absolute;visibility:hidden;white-space:pre;font-size:10px;padding:0 8px;font-family:inherit;';
+  const cs=getComputedStyle(inp);
+  // Read font from the live element so the sizer stays calibrated if CSS changes.
+  // Horizontal padding only (0 vertical) — we're measuring width, not height.
+  sizer.style.cssText='position:absolute;visibility:hidden;white-space:pre;';
+  sizer.style.fontSize=cs.fontSize;
+  sizer.style.fontFamily=cs.fontFamily;
+  sizer.style.padding='0 '+cs.paddingRight;
   sizer.textContent=inp.value||inp.placeholder||' ';
   document.body.appendChild(sizer);
   const w=Math.min(180,Math.max(40,sizer.offsetWidth+2));

--- a/static/style.css
+++ b/static/style.css
@@ -1824,7 +1824,7 @@ main.main.showing-profiles > #mainProfiles{display:flex;}
 .project-chip .color-dot{width:6px;height:6px;border-radius:50%;display:inline-block;flex-shrink:0;}
 .project-create-btn{font-size:10px;padding:3px 6px;border-radius:12px;cursor:pointer;border:1px dashed var(--border2);background:none;color:var(--muted);opacity:.6;transition:all .15s;}
 .project-create-btn:hover{opacity:1;border-color:var(--blue);color:var(--blue);}
-.project-create-input{font-size:10px;padding:3px 8px;border-radius:12px;border:1px solid var(--accent-bg);background:var(--surface);color:var(--text);outline:none;width:100px;font-family:inherit;box-shadow:0 0 0 2px var(--accent-bg);}
+.project-create-input{font-size:10px;padding:3px 8px;border-radius:12px;border:1px solid var(--accent-bg);background:var(--surface);color:var(--text);outline:none;min-width:40px;max-width:180px;width:auto;font-family:inherit;box-shadow:0 0 0 2px var(--accent-bg);}
 .project-picker{position:absolute;right:0;top:100%;background:var(--sidebar);border:1px solid var(--border2);border-radius:8px;padding:4px;z-index:30;min-width:160px;max-width:220px;width:max-content;box-shadow:0 4px 16px rgba(0,0,0,.3);}
 .project-picker-item{padding:5px 10px;font-size:11px;border-radius:6px;cursor:pointer;color:var(--muted);transition:all .1s;display:flex;align-items:center;gap:6px;}
 .project-picker-item:hover{background:rgba(255,255,255,.08);color:var(--text);}

--- a/tests/test_project_chip_ui.py
+++ b/tests/test_project_chip_ui.py
@@ -121,13 +121,17 @@ class TestResizeProjectInputHelper:
 
     def test_resize_helper_uses_hidden_span(self):
         """The standard pattern is to measure with a hidden absolute span
-        sharing the same font/padding as the input."""
+        sharing the same font/padding as the input. Font and family are read
+        via getComputedStyle so the sizer stays calibrated if CSS changes."""
         idx = SESSIONS_JS.find("function _resizeProjectInput(")
         assert idx >= 0
-        body = SESSIONS_JS[idx: idx + 800]
+        body = SESSIONS_JS[idx: idx + 900]
         assert "position:absolute" in body and "visibility:hidden" in body, (
             "_resizeProjectInput should use a hidden absolute span to "
             "measure the value's rendered width."
+        )
+        assert "getComputedStyle(inp)" in body, (
+            "_resizeProjectInput should use getComputedStyle to read font "            "properties so the sizer stays calibrated if CSS changes."
         )
         assert "Math.min(180" in body, (
             "max bound (180) not applied in _resizeProjectInput"

--- a/tests/test_project_chip_ui.py
+++ b/tests/test_project_chip_ui.py
@@ -1,0 +1,164 @@
+"""Regression tests for the project chip UI fixes (issue #1085).
+
+Two bugs:
+
+1. The right-click context menu opened by `_showProjectContextMenu` was styled
+   with `background: var(--panel)`, but `--panel` is NOT defined anywhere in
+   style.css.  CSS falls back to `transparent` for undefined variables, so the
+   menu appeared see-through and the session list bled through.  The fix
+   replaces `var(--panel)` with `var(--surface)` — the same opaque variable
+   used by `.session-action-menu` and other floating popovers.
+
+2. The `.project-create-input` (used for both rename and new-project creation)
+   had `width: 100px` hard-coded, so the field was always exactly 100px wide
+   regardless of the project name being edited.  Fix: bound the field with
+   `min-width: 40px` / `max-width: 180px` and `width: auto`, plus a
+   `_resizeProjectInput()` JS helper that measures the current value with a
+   hidden span and sets the pixel width accordingly.
+
+These are static-source tests — CSS/JS behaviour of a popover and an input
+sizer can't be exercised faithfully without a browser, but the patterns
+worth pinning are the variable names, the absence of the bad ones, and the
+presence of the resize helper at both call sites.
+"""
+
+import pathlib
+
+REPO = pathlib.Path(__file__).parent.parent
+SESSIONS_JS = (REPO / "static" / "sessions.js").read_text(encoding="utf-8")
+STYLE_CSS = (REPO / "static" / "style.css").read_text(encoding="utf-8")
+
+
+# ── Bug 1: context menu background ────────────────────────────────────────────
+
+
+class TestContextMenuBackground:
+
+    def test_panel_variable_not_defined_in_stylesheet(self):
+        """`--panel` is not defined as a CSS custom property anywhere — so
+        any rule using `var(--panel)` falls back to `transparent`, which is
+        the actual root cause of the menu bleed-through.  This test
+        documents that fact: if `--panel` is ever defined, the test will
+        need updating but the fix is still safer using `--surface`."""
+        # Match either ":root --panel:" or "--panel:" assignments; absence
+        # confirms the fallback-to-transparent failure mode.
+        assert "--panel:" not in STYLE_CSS, (
+            "If --panel is now defined, update this test, but the menu "
+            "should still use --surface for consistency with other popovers."
+        )
+
+    def test_context_menu_uses_surface_not_panel(self):
+        """`_showProjectContextMenu` must set the menu background to
+        `var(--surface)`, not `var(--panel)`."""
+        # Locate the menu construction
+        idx = SESSIONS_JS.find("project-ctx-menu")
+        assert idx >= 0, "project-ctx-menu className not found in sessions.js"
+        # Look at the surrounding 800 chars where the cssText is set
+        window = SESSIONS_JS[idx: idx + 1200]
+        assert "background:var(--surface)" in window, (
+            "Project context menu must use background:var(--surface) for an "
+            "opaque surface — var(--panel) is undefined and falls back to "
+            "transparent."
+        )
+        assert "background:var(--panel)" not in window, (
+            "Project context menu still uses background:var(--panel) — "
+            "this CSS variable is not defined and renders transparent."
+        )
+
+    def test_session_action_menu_also_uses_surface_for_consistency(self):
+        """Sanity check: the existing .session-action-menu (the analogous
+        right-click menu for session items) uses `var(--surface)` — so the
+        fix is consistent with the rest of the codebase."""
+        assert "session-action-menu" in STYLE_CSS
+        # Find the rule and confirm it uses --surface
+        idx = STYLE_CSS.find(".session-action-menu")
+        assert idx >= 0
+        rule = STYLE_CSS[idx: idx + 400]
+        assert "var(--surface)" in rule, (
+            ".session-action-menu should use var(--surface) — kept here as "
+            "the canonical reference for opaque popover surfaces."
+        )
+
+
+# ── Bug 2: project-create-input width ─────────────────────────────────────────
+
+
+class TestProjectCreateInputWidth:
+
+    def test_no_hardcoded_100px_width(self):
+        """The fixed `width: 100px` on .project-create-input is gone."""
+        idx = STYLE_CSS.find(".project-create-input{")
+        assert idx >= 0, ".project-create-input rule not found in style.css"
+        rule = STYLE_CSS[idx: idx + 400]
+        assert "width:100px" not in rule and "width: 100px" not in rule, (
+            "Fixed 100px width must be replaced with min-width/max-width/"
+            "width:auto so the input grows with its content."
+        )
+
+    def test_min_and_max_width_present(self):
+        """Both min-width and max-width must be set on .project-create-input."""
+        idx = STYLE_CSS.find(".project-create-input{")
+        rule = STYLE_CSS[idx: idx + 400]
+        assert "min-width:40px" in rule, (
+            f"min-width:40px not found in .project-create-input rule: {rule}"
+        )
+        assert "max-width:180px" in rule, (
+            f"max-width:180px not found in .project-create-input rule: {rule}"
+        )
+        assert "width:auto" in rule, (
+            f"width:auto not found in .project-create-input rule: {rule}"
+        )
+
+
+class TestResizeProjectInputHelper:
+    """The `_resizeProjectInput` helper must exist and be wired into both
+    rename and create call sites."""
+
+    def test_resize_helper_defined(self):
+        assert "function _resizeProjectInput(" in SESSIONS_JS, (
+            "_resizeProjectInput helper not found in sessions.js"
+        )
+
+    def test_resize_helper_uses_hidden_span(self):
+        """The standard pattern is to measure with a hidden absolute span
+        sharing the same font/padding as the input."""
+        idx = SESSIONS_JS.find("function _resizeProjectInput(")
+        assert idx >= 0
+        body = SESSIONS_JS[idx: idx + 800]
+        assert "position:absolute" in body and "visibility:hidden" in body, (
+            "_resizeProjectInput should use a hidden absolute span to "
+            "measure the value's rendered width."
+        )
+        assert "Math.min(180" in body, (
+            "max bound (180) not applied in _resizeProjectInput"
+        )
+        assert "Math.max(40" in body, (
+            "min bound (40) not applied in _resizeProjectInput"
+        )
+
+    def test_rename_calls_resize_helper(self):
+        """`_startProjectRename` must call `_resizeProjectInput` once on
+        creation and again on every input event."""
+        idx = SESSIONS_JS.find("function _startProjectRename(")
+        assert idx >= 0
+        body = SESSIONS_JS[idx: idx + 1200]
+        assert "_resizeProjectInput(inp)" in body, (
+            "_startProjectRename must call _resizeProjectInput so the "
+            "input width matches the existing project name."
+        )
+        # Wired into the input event so it grows as the user types
+        assert "addEventListener('input'" in body and "_resizeProjectInput" in body, (
+            "_startProjectRename must wire input events to _resizeProjectInput"
+        )
+
+    def test_create_calls_resize_helper(self):
+        """Same for `_startProjectCreate` (new-project entry field)."""
+        idx = SESSIONS_JS.find("function _startProjectCreate(")
+        assert idx >= 0
+        body = SESSIONS_JS[idx: idx + 1200]
+        assert "_resizeProjectInput(inp)" in body, (
+            "_startProjectCreate must call _resizeProjectInput on focus"
+        )
+        assert "addEventListener('input'" in body, (
+            "_startProjectCreate must wire input events to _resizeProjectInput"
+        )


### PR DESCRIPTION
## v0.50.219 — project chip context menu + input sizing

Single PR reviewed, Opus-approved, tested end-to-end.

### Included PR
| PR | Title | Author | Fixes applied |
|----|-------|--------|---------------|
| #1086 | fix(projects): opaque context menu + auto-sizing rename input | @nesquena | getComputedStyle in sizer span |

### What ships
- **Context menu opaque** — `var(--panel)` (undefined → transparent) → `var(--surface)`
- **Input auto-sizes** — `width:100px` → `min-width:40px; max-width:180px; width:auto` + `_resizeProjectInput()` helper using `getComputedStyle` for font properties

### Gate results
- pytest: **2467 passed, 0 failed** (9 new tests)
- QA harness regression: 11/11 passed
- Browser API sanity (port 8789): 11/11 passed
- Opus independent review: **APPROVE — no blockers**
