### PR TITLE
fix(ui): workspace panel collapse priority + visible project color dot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Fixed
 
+- **Workspace panel header collapse priority** — as the right panel narrows, the git badge now disappears first, the "Workspace" label second, and the icon buttons survive the longest. Previously `.panel-header` used `justify-content:space-between` with no flex-shrink ratios, so all three children compressed simultaneously and the icon buttons (the actual primary controls) could disappear before the git badge (least-essential metadata). Fix: declare `.rightpanel` as a `container-type:inline-size` container, replace `space-between` with `gap` + `margin-left:auto` on `.panel-actions` (`flex-shrink:0`), and add `@container rightpanel` queries that crisply hide the git badge below 220px and the label below 160px. (`static/style.css`)
+- **Project color dot truncated** — the colored project marker on a session item used to be appended inside `.session-title`, which is `overflow:hidden;text-overflow:ellipsis`. Long titles clipped the dot off, hiding the project marker exactly when it was most needed. Fix: append the dot as a flex sibling of the title in `.session-title-row`, and move `.session-time` from `position:absolute` into the same flex flow with `margin-left:auto`. The dot now sits next to the timestamp and stays visible regardless of title length. The desktop `.session-item` padding-right at rest dropped from 86px (no longer needed for an absolute timestamp) to 8px; hover/streaming/unread/menu-open/focus-within keep 40px reserved for the absolute action button + attention indicator. (`static/sessions.js`, `static/style.css`)
+
 ## v0.50.219 — 2026-04-26
 
 ### Fixed

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -920,6 +920,21 @@ function renderSessionListFromCache(){
     ts.className='session-time'+(hasAttentionState?' is-hidden':'');
     ts.textContent=hasAttentionState?'':_formatRelativeSessionTime(tsMs);
     titleRow.appendChild(title);
+    // Project color dot: placed BETWEEN title and timestamp, not inside the
+    // title span. Inside the title span it would be clipped by the ellipsis
+    // truncation, becoming invisible exactly when the title is long enough
+    // to need the project marker. As a flex-flow sibling it stays visible
+    // regardless of title length and sits next to the timestamp on the right.
+    if(s.project_id){
+      const proj=_allProjects.find(p=>p.project_id===s.project_id);
+      if(proj){
+        const dot=document.createElement('span');
+        dot.className='session-project-dot';
+        dot.style.background=proj.color||'var(--blue)';
+        dot.title=proj.name;
+        titleRow.appendChild(dot);
+      }
+    }
     titleRow.appendChild(ts);
     sessionText.appendChild(titleRow);
     const density=(window._sidebarDensity==='detailed'?'detailed':'compact');
@@ -990,17 +1005,8 @@ function renderSessionListFromCache(){
       setTimeout(()=>{inp.focus();inp.select();},10);
     };
 
-    // Project indicator: colored dot appended after the title
-    if(s.project_id){
-      const proj=_allProjects.find(p=>p.project_id===s.project_id);
-      if(proj){
-        const dot=document.createElement('span');
-        dot.className='session-project-dot';
-        dot.style.background=proj.color||'var(--blue)';
-        dot.title=proj.name;
-        title.appendChild(dot);
-      }
-    }
+    // (Project dot is appended above, between title and timestamp, so it
+    // sits outside the truncating title span and stays visible.)
     el.appendChild(sessionText);
     const state=document.createElement('span');
     state.className='session-attention-indicator session-state-indicator'+(isStreaming?' is-streaming':(hasUnread?' is-unread':''));

--- a/static/style.css
+++ b/static/style.css
@@ -234,8 +234,16 @@
   .sidebar-search-icon{position:absolute;left:22px;top:50%;transform:translateY(-50%);width:14px;height:14px;color:var(--muted);opacity:.7;pointer-events:none;}
   /* Inline session title edit */
   .session-title-input{flex:1;background:var(--surface);border:1px solid var(--accent);border-radius:6px;color:var(--text);padding:3px 8px;font-size:13px;outline:none;min-width:0;box-shadow:0 0 0 2px var(--accent-bg-strong);font-family:inherit;}
-  .session-item{padding:8px 86px 8px 8px;margin-bottom:2px;border-radius:8px;cursor:pointer;font-size:13px;color:var(--muted);transition:background .15s,color .15s;display:flex;align-items:flex-start;gap:8px;min-width:0;position:relative;}
-  .session-item.streaming,.session-item.unread{padding-right:40px;}
+  /* padding-right was 86px to reserve space for the absolute-positioned
+     timestamp + action button (which appears on hover). Now that .session-time
+     lives in the flex flow of .session-title-row, the timestamp sits at the
+     row's right edge naturally, so no reservation is needed at rest. The
+     action button (.session-actions, position:absolute, 26x26 at right:6px)
+     and attention indicator (26x26 at right:6px) still need 40px reserved
+     when they're visible — covered by the hover / streaming / unread /
+     menu-open / focus-within rule below. */
+  .session-item{padding:8px 8px;margin-bottom:2px;border-radius:8px;cursor:pointer;font-size:13px;color:var(--muted);transition:background .15s,color .15s;display:flex;align-items:flex-start;gap:8px;min-width:0;position:relative;}
+  .session-item.streaming,.session-item.unread,.session-item:hover,.session-item:focus-within,.session-item.menu-open{padding-right:40px;}
   .session-item:hover{background:var(--hover-bg);color:var(--text);}
   .session-item.active{background:var(--accent-bg);color:var(--accent);}
   .session-item.streaming .session-title{color:var(--accent);}
@@ -274,12 +282,13 @@
     width:8px;
     height:8px;
   }
+  /* Timestamp lives in the flex flow of .session-title-row (not absolute) so
+     the title's flex:1 bound stops at the timestamp's left edge and stops
+     running underneath it. margin-left:auto pushes it to the row's right
+     edge, keeping the visual position the user already expects. */
   .session-time{
     display:inline-flex;
-    position:absolute;
-    right:10px;
-    top:50%;
-    transform:translateY(-50%);
+    margin-left:auto;
     color:var(--muted);
     font-size:10px;
     white-space:nowrap;
@@ -713,11 +722,26 @@
   .upload-bar-wrap{display:none;height:3px;background:var(--hover-bg);border-radius:0 0 16px 16px;overflow:hidden;}
   .upload-bar-wrap.active{display:block;}
   .upload-bar{height:100%;background:linear-gradient(90deg,var(--accent),var(--accent-hover));width:0%;transition:width .3s ease;}
-  .rightpanel{width:300px;background:var(--sidebar);border-left:1px solid var(--border);display:flex;flex-direction:column;overflow:hidden;flex-shrink:0;min-width:0;opacity:1;transform:translateX(0);transform-origin:right center;transition:width .24s cubic-bezier(.22,1,.36,1),opacity .18s ease,transform .24s cubic-bezier(.22,1,.36,1),border-color .24s ease;}
-  .panel-header{padding:12px 16px;border-bottom:1px solid var(--border);font-size:11px;font-weight:600;color:var(--muted);text-transform:uppercase;letter-spacing:.1em;display:flex;align-items:center;justify-content:space-between;}
-  .git-badge{font-size:9px;font-weight:600;color:var(--muted);background:var(--hover-bg);padding:2px 7px;border-radius:4px;letter-spacing:.02em;margin-left:auto;margin-right:4px;white-space:nowrap;font-family:'SF Mono',ui-monospace,monospace;}
+  /* container-type/name lets descendants run @container queries against the
+     panel's width so the header can collapse less-essential elements as the
+     user resizes the panel narrower. */
+  .rightpanel{width:300px;background:var(--sidebar);border-left:1px solid var(--border);display:flex;flex-direction:column;overflow:hidden;flex-shrink:0;min-width:0;opacity:1;transform:translateX(0);transform-origin:right center;transition:width .24s cubic-bezier(.22,1,.36,1),opacity .18s ease,transform .24s cubic-bezier(.22,1,.36,1),border-color .24s ease;container-type:inline-size;container-name:rightpanel;}
+  /* Collapse priority as the panel narrows: git-badge first, then "Workspace"
+     label, never the icon buttons. flex-shrink ratios give graceful ellipsis;
+     @container queries below cut to display:none at hard breakpoints. */
+  .panel-header{padding:12px 16px;border-bottom:1px solid var(--border);font-size:11px;font-weight:600;color:var(--muted);text-transform:uppercase;letter-spacing:.1em;display:flex;align-items:center;gap:6px;overflow:hidden;}
+  .panel-header > span:first-child{white-space:nowrap;overflow:hidden;text-overflow:ellipsis;min-width:0;flex-shrink:2;}
+  .git-badge{font-size:9px;font-weight:600;color:var(--muted);background:var(--hover-bg);padding:2px 7px;border-radius:4px;letter-spacing:.02em;margin-left:auto;margin-right:4px;white-space:nowrap;font-family:'SF Mono',ui-monospace,monospace;flex-shrink:3;overflow:hidden;min-width:0;}
   .git-badge.dirty{color:var(--accent-text);background:var(--accent-bg);}
-  .panel-actions{display:flex;gap:4px;}
+  .panel-actions{display:flex;gap:4px;flex-shrink:0;margin-left:auto;}
+  /* Crisp display:none at narrow widths so the header doesn't show a sliver
+     of an ellipsised label or git badge — icons survive longest. */
+  @container rightpanel (max-width: 220px){
+    .git-badge{display:none !important;}
+  }
+  @container rightpanel (max-width: 160px){
+    .panel-header > span:first-child{display:none;}
+  }
   .mobile-close-btn{display:none;}
   .panel-icon-btn{width:24px;height:24px;background:none;border:none;color:var(--muted);cursor:pointer;border-radius:5px;font-size:13px;display:flex;align-items:center;justify-content:center;transition:all .15s;}
   .panel-icon-btn:hover{background:var(--hover-bg);color:var(--text);}
@@ -1831,7 +1855,9 @@ main.main.showing-profiles > #mainProfiles{display:flex;}
 .project-picker-item.active{color:var(--blue);}
 .project-picker-create{color:var(--blue);opacity:.7;border-top:1px solid var(--border2);margin-top:2px;padding-top:6px;}
 .project-picker-create:hover{opacity:1;background:var(--accent-bg);}
-.session-project-dot{width:6px;height:6px;border-radius:50%;flex-shrink:0;display:inline-block;margin-left:4px;vertical-align:middle;}
+/* Lives as a flex sibling in .session-title-row (between title and time);
+   the row's gap:6px handles spacing, no margin/vertical-align needed. */
+.session-project-dot{width:6px;height:6px;border-radius:50%;flex-shrink:0;display:inline-block;}
 
 /* ── Code copy button ── */
 .code-copy-btn{background:var(--hover-bg);border:1px solid var(--border2);border-radius:4px;color:var(--muted);font-size:11px;cursor:pointer;padding:2px 6px;transition:all .15s;line-height:1.3;}

--- a/tests/test_issue856_pinned_indicator_layout.py
+++ b/tests/test_issue856_pinned_indicator_layout.py
@@ -84,15 +84,25 @@ def test_timestamp_hidden_when_attention_state_is_present():
     assert "ts.className='session-time'+(hasAttentionState?' is-hidden':'');" in SESSIONS_JS
     assert "ts.textContent=hasAttentionState?'':_formatRelativeSessionTime(tsMs);" in SESSIONS_JS
     assert ".session-time.is-hidden{display:none;}" in STYLE_CSS
-    assert ".session-item{padding:8px 86px 8px 8px;" in STYLE_CSS
-    assert ".session-item.streaming,.session-item.unread{padding-right:40px;}" in STYLE_CSS
+    # padding-right was 86px when the timestamp was position:absolute. Now that
+    # the timestamp lives in the flex flow of .session-title-row, the rest
+    # state needs no right reservation; hover/streaming/unread/menu-open/
+    # focus-within all expand to 40px to make room for the absolute action
+    # button + attention indicator.
+    assert ".session-item{padding:8px 8px;" in STYLE_CSS
+    assert ".session-item.streaming,.session-item.unread,.session-item:hover,.session-item:focus-within,.session-item.menu-open{padding-right:40px;}" in STYLE_CSS
     assert ".session-item{min-height:44px;padding:10px 86px 10px 12px;}" in STYLE_CSS
+    # Timestamp now uses margin-left:auto inside the flex row instead of
+    # absolute positioning. This stops the title's flex:1 bound from running
+    # underneath the timestamp and lets the project dot sit beside it.
     session_time_block = STYLE_CSS[
         STYLE_CSS.find(".session-time{"):
         STYLE_CSS.find(".session-time.is-hidden")
     ]
-    assert "position:absolute;" in session_time_block
-    assert "right:10px;" in session_time_block
+    assert "position:absolute;" not in session_time_block, (
+        "Timestamp must live in flex flow (margin-left:auto), not absolute"
+    )
+    assert "margin-left:auto;" in session_time_block
     assert ".session-item:hover .session-time" in STYLE_CSS
     assert ".session-item.streaming:not(:hover):not(:focus-within):not(.menu-open) .session-actions" in STYLE_CSS
     assert ".session-item.unread:not(:hover):not(:focus-within):not(.menu-open) .session-actions" in STYLE_CSS

--- a/tests/test_workspace_panel_session_list.py
+++ b/tests/test_workspace_panel_session_list.py
@@ -1,0 +1,236 @@
+"""Regression tests for two related sidebar/panel UI fixes.
+
+1. Workspace panel header collapse priority — as the right panel narrows,
+   the git-badge must vanish first, the "Workspace" label second, and the
+   icon buttons last. Previously all three compressed simultaneously
+   because `.panel-header` used `justify-content:space-between` with no
+   flex-shrink ratios or container queries.
+
+2. Project color dot truncation — the dot used to be appended INSIDE the
+   `.session-title` span (which is `overflow:hidden;text-overflow:ellipsis`),
+   so the dot got clipped along with long titles. Fix moves the dot to a
+   flex sibling in `.session-title-row` between title and timestamp, and
+   moves `.session-time` from `position:absolute` to flex flow so the
+   title's `flex:1` bound stops at the timestamp's left edge.
+"""
+
+import pathlib
+
+REPO = pathlib.Path(__file__).parent.parent
+SESSIONS_JS = (REPO / "static" / "sessions.js").read_text(encoding="utf-8")
+STYLE_CSS = (REPO / "static" / "style.css").read_text(encoding="utf-8")
+
+
+# ── Bug 1: workspace panel header collapse priority ──────────────────────────
+
+
+class TestWorkspacePanelCollapsePriority:
+
+    def test_rightpanel_is_a_size_container(self):
+        """The right panel must declare itself as an inline-size container so
+        its descendants can run @container queries against the panel's width."""
+        # Look at the .rightpanel rule body
+        idx = STYLE_CSS.find(".rightpanel{")
+        assert idx >= 0, ".rightpanel rule not found"
+        rule = STYLE_CSS[idx: idx + 1200]
+        assert "container-type:inline-size" in rule, (
+            ".rightpanel must declare container-type:inline-size for the "
+            "header collapse-priority @container queries to work."
+        )
+        assert "container-name:rightpanel" in rule, (
+            ".rightpanel should be named 'rightpanel' so descendants can "
+            "scope @container queries explicitly."
+        )
+
+    def test_panel_header_no_longer_uses_space_between(self):
+        """`justify-content:space-between` was the root cause of the
+        simultaneous-shrink behaviour. The header now uses `gap` and
+        `margin-left:auto` on `.panel-actions` to push them right."""
+        idx = STYLE_CSS.find(".panel-header{")
+        rule = STYLE_CSS[idx: STYLE_CSS.find("}", idx) + 1]
+        assert "justify-content:space-between" not in rule, (
+            "panel-header still uses justify-content:space-between — that "
+            "compresses all three children simultaneously."
+        )
+        assert "gap:6px" in rule
+        assert "overflow:hidden" in rule
+
+    def test_panel_actions_pushed_right_and_never_shrinks(self):
+        """`.panel-actions` must have flex-shrink:0 and margin-left:auto so
+        the icon buttons stay visible no matter how narrow the panel gets,
+        and they sit at the right edge once `space-between` is removed."""
+        idx = STYLE_CSS.find(".panel-actions{")
+        rule = STYLE_CSS[idx: STYLE_CSS.find("}", idx)]
+        assert "flex-shrink:0" in rule, (
+            ".panel-actions must not shrink — icons are the priority."
+        )
+        assert "margin-left:auto" in rule, (
+            ".panel-actions must use margin-left:auto to push to the right "
+            "now that justify-content:space-between is gone."
+        )
+
+    def test_workspace_label_shrinks_with_ellipsis(self):
+        """The "Workspace" label (`panel-header > span:first-child`) must
+        shrink with ellipsis truncation rather than overflow uncontrollably."""
+        # Find the rule
+        sel = ".panel-header > span:first-child"
+        idx = STYLE_CSS.find(sel)
+        assert idx >= 0, f"Selector {sel!r} not found in style.css"
+        rule = STYLE_CSS[idx: STYLE_CSS.find("}", idx)]
+        assert "text-overflow:ellipsis" in rule
+        assert "min-width:0" in rule
+        assert "flex-shrink:2" in rule  # shrinks before icons (icons are 0)
+
+    def test_git_badge_shrinks_first(self):
+        """`.git-badge` must shrink faster than the label so it disappears
+        first as the panel narrows."""
+        idx = STYLE_CSS.find(".git-badge{")
+        rule = STYLE_CSS[idx: STYLE_CSS.find("}", idx)]
+        assert "flex-shrink:3" in rule, (
+            ".git-badge must have flex-shrink:3 so it shrinks before the "
+            "label (flex-shrink:2) and the icons (flex-shrink:0)."
+        )
+
+    def test_container_query_hides_git_badge_first(self):
+        """At narrow widths the git badge gets `display:none` BEFORE the
+        label is hidden — git badge first."""
+        # The container query block for hiding git badge
+        assert "@container rightpanel (max-width: 220px)" in STYLE_CSS, (
+            "Missing @container rule to hide .git-badge at narrow widths"
+        )
+        # Find the block and check git-badge is targeted
+        idx = STYLE_CSS.find("@container rightpanel (max-width: 220px)")
+        block = STYLE_CSS[idx: idx + 200]
+        assert ".git-badge{display:none" in block
+
+    def test_container_query_hides_label_at_narrower_width(self):
+        """The label hides at a NARROWER threshold than the git badge —
+        confirms collapse priority order."""
+        assert "@container rightpanel (max-width: 160px)" in STYLE_CSS
+        idx = STYLE_CSS.find("@container rightpanel (max-width: 160px)")
+        block = STYLE_CSS[idx: idx + 200]
+        assert ".panel-header > span:first-child{display:none" in block
+
+    def test_breakpoints_in_correct_order(self):
+        """Sanity: the git-badge breakpoint (220px) must be wider than the
+        label breakpoint (160px). Otherwise the label would vanish first."""
+        # Both queries exist — extract numeric thresholds
+        import re
+        matches = re.findall(
+            r"@container rightpanel \(max-width:\s*(\d+)px\)", STYLE_CSS
+        )
+        assert len(matches) >= 2
+        thresholds = [int(m) for m in matches]
+        # First threshold (git badge) must be larger than label threshold
+        assert thresholds[0] > thresholds[1], (
+            f"Git badge breakpoint ({thresholds[0]}px) must be wider than "
+            f"label breakpoint ({thresholds[1]}px) so git-badge hides first."
+        )
+
+
+# ── Bug 2: project color dot placement ───────────────────────────────────────
+
+
+class TestProjectDotPlacement:
+
+    def test_dot_appended_to_title_row_not_title(self):
+        """The project dot must be appended to `titleRow` (a flex sibling
+        of the title and timestamp), not to the title span (which truncates
+        with ellipsis and would clip the dot off long titles)."""
+        # Find _renderOneSession body
+        idx = SESSIONS_JS.find("function _renderOneSession(")
+        assert idx >= 0
+        body = SESSIONS_JS[idx: idx + 6000]
+        # Must append dot to titleRow
+        assert "titleRow.appendChild(dot)" in body, (
+            "Project dot must be appended to titleRow as a flex sibling, "
+            "not inside the truncating title span"
+        )
+        # Must NOT append dot to title (the truncating span)
+        assert "title.appendChild(dot)" not in body, (
+            "Old behaviour — dot inside title span gets clipped by the "
+            "ellipsis truncation. Dot must live in titleRow instead."
+        )
+
+    def test_dot_placed_between_title_and_timestamp(self):
+        """The dot is appended AFTER title.appendChild and BEFORE ts append
+        — that ordering puts the dot between the title and the timestamp
+        in the flex row."""
+        idx = SESSIONS_JS.find("function _renderOneSession(")
+        body = SESSIONS_JS[idx: idx + 6000]
+        title_pos = body.find("titleRow.appendChild(title);")
+        dot_pos = body.find("titleRow.appendChild(dot);")
+        ts_pos = body.find("titleRow.appendChild(ts);")
+        assert title_pos >= 0 and dot_pos >= 0 and ts_pos >= 0
+        assert title_pos < dot_pos < ts_pos, (
+            f"Order must be title → dot → ts in the title row "
+            f"(positions: {title_pos}, {dot_pos}, {ts_pos})"
+        )
+
+    def test_session_time_uses_flex_flow_not_absolute(self):
+        """`.session-time` must use margin-left:auto in flex flow, not
+        position:absolute. Without this the title's flex:1 runs underneath
+        the absolute-positioned timestamp and the dot has no anchor."""
+        # Get the bare .session-time rule (not .session-time.is-hidden, not
+        # .session-item:hover .session-time)
+        idx = STYLE_CSS.find(".session-time{")
+        rule = STYLE_CSS[idx: STYLE_CSS.find("}", idx)]
+        assert "position:absolute" not in rule, (
+            ".session-time must not be position:absolute — bug 2 requires "
+            "it to live in the flex flow of .session-title-row."
+        )
+        assert "margin-left:auto" in rule, (
+            ".session-time must use margin-left:auto to push to the right "
+            "edge of the flex row."
+        )
+
+    def test_session_project_dot_no_inline_block_baggage(self):
+        """`.session-project-dot` is now a flex sibling — the row's gap:6px
+        handles spacing, so the old `margin-left:4px` and
+        `vertical-align:middle` are unnecessary and only confuse layout."""
+        idx = STYLE_CSS.find(".session-project-dot{")
+        assert idx >= 0
+        rule = STYLE_CSS[idx: STYLE_CSS.find("}", idx)]
+        assert "margin-left:4px" not in rule, (
+            "Old margin-left:4px is unnecessary now — gap:6px on "
+            ".session-title-row handles spacing"
+        )
+        assert "vertical-align:middle" not in rule, (
+            "vertical-align is meaningless inside flex flow"
+        )
+        assert "flex-shrink:0" in rule, (
+            "Dot must not shrink (would disappear at narrow sidebar widths)"
+        )
+
+    def test_session_item_padding_at_rest_no_longer_reserves_86px(self):
+        """At rest (no hover, no streaming, no unread), the session item
+        no longer reserves 86px for the absolute timestamp — that space
+        was wasted now that the timestamp lives in flex flow."""
+        # Find the FIRST .session-item{ rule (the desktop one, not the
+        # mobile-touch override).
+        idx = STYLE_CSS.find(".session-item{padding:8px")
+        assert idx >= 0, "Could not find desktop .session-item padding rule"
+        rule = STYLE_CSS[idx: STYLE_CSS.find("}", idx)]
+        assert "padding:8px 8px" in rule, (
+            f"Expected 'padding:8px 8px' for at-rest session items, got: {rule!r}"
+        )
+        # The 86px reservation should still appear in the mobile override
+        # because mobile always shows the action button.
+        assert ".session-item{min-height:44px;padding:10px 86px 10px 12px;}" in STYLE_CSS
+
+    def test_session_item_expands_padding_on_hover_and_attention(self):
+        """When hover/focus/menu-open/streaming/unread shows the action
+        button or attention indicator, padding-right expands to 40px to
+        reserve space for them (they're position:absolute at right:6px,
+        26px wide → 32px footprint, 40px gives 8px breathing)."""
+        sel = (
+            ".session-item.streaming,.session-item.unread,"
+            ".session-item:hover,.session-item:focus-within,"
+            ".session-item.menu-open"
+        )
+        idx = STYLE_CSS.find(sel)
+        assert idx >= 0, (
+            f"Combined hover/streaming/unread padding rule not found"
+        )
+        rule = STYLE_CSS[idx: STYLE_CSS.find("}", idx)]
+        assert "padding-right:40px" in rule


### PR DESCRIPTION
## Summary

Two related sidebar/panel UI bugs from `workspace-panel-session-list-fixes.md`:

### Bug 1 — Workspace panel header has wrong collapse priority

As the right panel narrows, the icon buttons would disappear before the git badge ("MAIN · 18 ↑"). Backwards: the icons are the primary controls, the git badge is least-essential metadata.

**Root cause**: [`style.css:717`](static/style.css#L717) used `justify-content:space-between` with no flex-shrink ratios — all three children (Workspace label, git badge, icons) compressed simultaneously.

**Fix** ([static/style.css:716-737](static/style.css#L716-L737)):
- Declare `.rightpanel` as a `container-type:inline-size` container.
- Replace `justify-content:space-between` with `gap:6px` + `margin-left:auto` on `.panel-actions`.
- Flex-shrink ladder: `panel-actions` = 0 (never shrinks), label = 2, `.git-badge` = 3 (shrinks first).
- `@container rightpanel` queries crisply hide the git badge below 220px and the label below 160px.

### Bug 2 — Project color dot truncated, invisible on long titles

The colored project marker was appended **inside** the `.session-title` span (`overflow:hidden;text-overflow:ellipsis`), so the ellipsis clipped it off — invisible exactly when long titles needed the project marker most.

**Root cause**: dot was `title.appendChild(dot)` ([sessions.js:1001](static/sessions.js#L1001) pre-fix). Compounded by `.session-time` being `position:absolute`, so the title's `flex:1` ran underneath the timestamp with nowhere coherent to anchor the dot.

**Fix**:
- [`sessions.js:923-941`](static/sessions.js#L923-L941): append dot to `titleRow` between title and timestamp (flex sibling, not inside the truncating title span).
- [`style.css:281-292`](static/style.css#L281-L292): move `.session-time` from `position:absolute;right:10px` to `margin-left:auto` in the flex row.
- [`style.css:243`](static/style.css#L243): `.session-project-dot` drops `margin-left:4px/vertical-align:middle` (the row's `gap:6px` handles spacing).
- [`style.css:248-251`](static/style.css#L248-L251): `.session-item` padding-right at rest drops from 86px → 8px (no longer reserving space for an absolute timestamp); hover/streaming/unread/menu-open/focus-within reserve 40px for the absolute action button + attention indicator.

## Files changed

- `static/style.css` — collapse-priority rules + `@container` queries; `.session-time` flex flow; `.session-item` padding redesign; cleanup of `.session-project-dot`
- `static/sessions.js` — dot moved to `titleRow` in `_renderOneSession`
- `tests/test_workspace_panel_session_list.py` — 14 new tests
- `tests/test_issue856_pinned_indicator_layout.py` — updated to reflect new flex-flow timestamp + reduced rest-padding
- `CHANGELOG.md`

## Tests

14 new tests in [tests/test_workspace_panel_session_list.py](tests/test_workspace_panel_session_list.py), grouped:

**`TestWorkspacePanelCollapsePriority`** (8 tests):
- `.rightpanel` declares container-type/name
- `panel-header` no longer uses `space-between`
- `.panel-actions` has flex-shrink:0 + margin-left:auto
- Label uses ellipsis + flex-shrink:2
- Git badge uses flex-shrink:3 (shrinks first)
- Container query at 220px hides git badge
- Container query at 160px hides label
- Numeric ordering: 220 > 160 (git-badge breakpoint must be wider than label breakpoint, otherwise label vanishes first)

**`TestProjectDotPlacement`** (6 tests):
- Dot appended to `titleRow`, NOT to `title` span
- Dot is positioned between title and timestamp (`title < dot < ts`)
- `.session-time` uses margin-left:auto, no longer absolute
- `.session-project-dot` no longer carries `margin-left:4px` / `vertical-align:middle`
- Desktop `.session-item` padding-right at rest is `padding:8px 8px` (was 86px right)
- Hover/streaming/unread/menu-open/focus-within reserve 40px

Updated `test_issue856_pinned_indicator_layout.py::test_timestamp_hidden_when_attention_state_is_present` to assert the new flex-flow timestamp + reduced rest padding.

Full suite: **2433 passed**, 47 skipped, 0 PR-related failures.

## Test plan

- [ ] Drag right panel from 300px down to ~250px → all three header elements visible.
- [ ] Drag to ~200px → git badge disappears, "Workspace" + icons remain.
- [ ] Drag to ~150px → "Workspace" disappears, icons remain.
- [ ] Drag to minimum → only icons.
- [ ] Open a session list with a long-titled project session → colored dot visible at right edge next to timestamp.
- [ ] Hover that session → action button appears, no layout shift.
- [ ] Streaming/unread session → spinner/dot indicator appears at right; project dot still visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
