### PR TITLE
feat: per-session TPS indicator in sidebar

### DIFF
--- a/api/metering.py
+++ b/api/metering.py
@@ -45,8 +45,6 @@ from __future__ import annotations
 import threading
 import time
 from dataclasses import dataclass
-
-_HOUR_SECS = 3600.0   # rolling window for HIGH/LOW tracking
 _STALE_SECS = 60.0    # consider a session inactive after this
 
 
@@ -69,22 +67,17 @@ class _SessionMeter:
 class GlobalMeter:
     """Thread-safe global streaming meter.
 
-    Tracks per-session TPS, averages them for a global tps, and maintains a
-    60-minute rolling history of global tps snapshots for HIGH/LOW reporting.
+    Tracks per-session TPS and computes an average for the global tps.
     """
 
     __slots__ = (
         '_lock',
         '_sessions',        # stream_id -> _SessionMeter
-        '_readings',        # [(monotonic_ts, tps), ...] rolling 60-minute history
-        '_window_start',    # monotonic ts of current window
     )
 
     def __init__(self) -> None:
         self._lock = threading.Lock()
         self._sessions: dict[str, _SessionMeter] = {}
-        self._readings: list[tuple[float, float]] = []
-        self._window_start: float = time.monotonic()
 
     # ── Public API ────────────────────────────────────────────────────────────
 
@@ -133,7 +126,7 @@ class GlobalMeter:
         with self._lock:
             self._sessions.pop(stream_id, None)
 
-    def get_stats(self) -> dict:
+    def get_stats(self, stream_id: str | None = None) -> dict:
         now = time.monotonic()
         with self._lock:
             # Prune stale sessions
@@ -144,10 +137,6 @@ class GlobalMeter:
             for sid in stale:
                 self._sessions.pop(sid, None)
 
-            # Reset window if everything went stale
-            if not self._sessions:
-                self._window_start = now
-
             # Compute global tps: average of per-session TPS values
             active = [s for s in self._sessions.values() if s.first_token_ts > 0]
             if active:
@@ -155,27 +144,19 @@ class GlobalMeter:
             else:
                 global_tps = 0.0
 
-            # Prune readings older than 1 hour
-            cutoff = now - _HOUR_SECS
-            self._readings = [(ts, v) for ts, v in self._readings if ts > cutoff]
-
-            # Only record this snapshot for HIGH/LOW if there is active work.
-            # This prevents idle periods from flooding the history and keeps
-            # HIGH/LOW meaningful for the past hour of actual throughput.
-            if global_tps > 0:
-                self._readings.append((now, global_tps))
-
-            # HIGH/LOW from the past hour (skip near-zero idle readings)
-            active_readings = [v for _, v in self._readings if v >= 1.0]
-            high = max(active_readings) if active_readings else 0.0
-            low = min(active_readings) if active_readings else 0.0
-
-            return {
+            result = {
                 'tps': round(global_tps, 1),
-                'high': round(high, 1),
-                'low': round(low, 1),
                 'active': len(self._sessions),
             }
+
+            # When called with a stream_id, include that session's own TPS so the
+            # SSE metering event can update the correct per-conversation indicator.
+            if stream_id is not None:
+                s = self._sessions.get(stream_id)
+                if s is not None and s.first_token_ts > 0:
+                    result['session_tps'] = round(s.tps(), 1)
+
+            return result
 
 
 # ── Module-level singleton ─────────────────────────────────────────────────────

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -1306,8 +1306,9 @@ def _run_agent_streaming(session_id, msg_text, model, workspace, stream_id, atta
                 if now - _metering_last_emit[0] < 0.1:
                     return
                 _metering_last_emit[0] = now
-                stats = meter().get_stats()
-                stats['session_id'] = stream_id
+                stats = meter().get_stats(stream_id)
+                stats['session_id'] = session_id
+                stats['stream_id'] = stream_id
                 put('metering', stats)
 
             def on_token(text):
@@ -1321,7 +1322,7 @@ def _run_agent_streaming(session_id, msg_text, model, workspace, stream_id, atta
                 put('token', {'text': text})
                 # Update global throughput meter
                 meter().record_token(stream_id, len(STREAM_PARTIAL_TEXT[stream_id]))
-                _emit_metering()
+                _emit_metering()  # must follow record_token so first_token_ts is set
 
             def on_reasoning(text):
                 nonlocal _reasoning_text
@@ -1331,7 +1332,7 @@ def _run_agent_streaming(session_id, msg_text, model, workspace, stream_id, atta
                 put('reasoning', {'text': str(text)})
                 # Track reasoning tokens in the meter so TPS reflects all AI output
                 meter().record_reasoning(stream_id, len(_reasoning_text))
-                _emit_metering()
+                _emit_metering()  # must follow record_reasoning so first_token_ts is set
 
             # Pre-initialise the activity counter here so on_tool (which
             # closes over it) never captures an unbound name even if this
@@ -1362,7 +1363,7 @@ def _run_agent_streaming(session_id, msg_text, model, workspace, stream_id, atta
                         _reasoning_text += str(reason_text)
                         put('reasoning', {'text': str(reason_text)})
                         meter().record_reasoning(stream_id, len(_reasoning_text))
-                        _emit_metering()
+                        _emit_metering()  # must follow record_reasoning so first_token_ts is set
                     return
 
                 args_snap = {}

--- a/static/index.html
+++ b/static/index.html
@@ -18,7 +18,7 @@
 <script>(function(){var themes={light:1,dark:1,system:1},skins={default:1,ares:1,mono:1,slate:1,poseidon:1,sisyphus:1,charizard:1},legacy={slate:['dark','slate'],solarized:['dark','poseidon'],monokai:['dark','sisyphus'],nord:['dark','slate'],oled:['dark','default']},t=(localStorage.getItem('hermes-theme')||'dark').toLowerCase(),s=(localStorage.getItem('hermes-skin')||'').toLowerCase(),m=legacy[t],theme=m?m[0]:(themes[t]?t:'dark'),skin=skins[s]?s:(m?m[1]:'default');localStorage.setItem('hermes-theme',theme);localStorage.setItem('hermes-skin',skin);if(theme==='system')theme=window.matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light';if(theme==='dark')document.documentElement.classList.add('dark');if(skin!=='default')document.documentElement.dataset.skin=skin;})()</script>
 <script>(function(){var fs=localStorage.getItem('hermes-font-size');if(fs&&fs!=='default')document.documentElement.dataset.fontSize=fs;})()</script>
 <script>(function(){try{document.documentElement.dataset.workspacePanel=localStorage.getItem('hermes-webui-workspace-panel')==='open'?'open':'closed';}catch(e){document.documentElement.dataset.workspacePanel='closed';}})()</script>
-<link rel="stylesheet" href="static/style.css">
+<link rel="stylesheet" href="static/style.css?v=25">
   <!-- KaTeX math rendering CSS (loaded eagerly to prevent layout shift) -->
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.22/dist/katex.min.css" integrity="sha384-5TcZemv2l/9On385z///+d7MSYlvIEw9FuZTIdZ14vJLqWphw7e7ZPuOiCHJcFCP" crossorigin="anonymous">
   <!-- streaming-markdown: incremental DOM-building markdown parser for live streams -->
@@ -69,7 +69,6 @@
     </span>
     <span class="app-titlebar-title" id="appTitlebarTitle">Hermes</span>
     <span class="app-titlebar-sub" id="appTitlebarSub" hidden></span>
-    <div class="tps-chip" id="tpsStat" title="Tokens per second / minute">0.0 t/s · 0.0 high</div>
   </div>
   <div class="app-titlebar-spacer" aria-hidden="true"></div>
 </header>
@@ -815,9 +814,9 @@
 <script src="static/icons.js" defer></script>
 <script src="static/ui.js" defer></script>
 <script src="static/workspace.js" defer></script>
-<script src="static/sessions.js" defer></script>
+<script src="static/sessions.js?v=18" defer></script>
 <script src="static/commands.js" defer></script>
-<script src="static/messages.js" defer></script>
+<script src="static/messages.js?v=6" defer></script>
 <script src="static/panels.js" defer></script>
 <script src="static/onboarding.js" defer></script>
 <script src="static/boot.js" defer></script>

--- a/static/messages.js
+++ b/static/messages.js
@@ -225,6 +225,10 @@ function closeLiveStream(sessionId, streamId){
 function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
   if(!activeSid||!streamId) return;
   const reconnecting=!!options.reconnecting;
+  // _meteringSid: the session_id that the sidebar items use as data-session-id.
+  // The metering SSE event carries stream_id as its 'session_id' field,
+  // so we need this local copy to route t/s updates to the right sidebar row.
+  const _meteringSid = activeSid;
   closeLiveStream(activeSid);
   if(!INFLIGHT[activeSid]) INFLIGHT[activeSid]={messages:[...S.messages],uploaded:[...uploaded],toolCalls:[]};
   else {
@@ -825,17 +829,20 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     });
 
     source.addEventListener('metering',e=>{
-      // TPS + HIGH/LOW stats for the header chip — emitted at 1 Hz during a stream,
-      // silenced entirely when no sessions are active (ticker exits when idle).
+      // Rolling 5-second average tps per session — maintained by _updateSessionTpsLabel.
+      // d.session_tps is the per-session TPS (from meter().get_stats(stream_id));
+      // d.tps is the global average across all active sessions.
       try{
         const d=JSON.parse(e.data||'{}');
-        const el=$('tpsStat');
-        if(!el) return;
-        const tps=typeof d.tps==='number'?d.tps.toFixed(1):'0.0';
-        const high=typeof d.high==='number' && d.high>=0?d.high.toFixed(1)+' high':'—';
-        const low=typeof d.low==='number' && d.low>=0?d.low.toFixed(1)+' low':'';
-        el.textContent=`${tps} t/s · ${high}${low?' · '+low:''}`;
-      }catch(_){}
+        if(!d.session_id){ return; }
+        // Use per-session TPS; fall back to global tps if not present.
+        const rawTps = (typeof d.session_tps === 'number' && d.session_tps > 0)
+          ? d.session_tps
+          : (typeof d.tps === 'number' ? d.tps : null);
+        // Use d.session_id directly — the backend now sends the actual session_id,
+        // not stream_id (they differ for resumed/continued sessions).
+        _updateSessionTpsLabel(d.session_id, rawTps);
+      }catch(err){}
     });
 
     source.addEventListener('apperror',e=>{

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -594,6 +594,8 @@ let _sessionTimeRefreshTimer = null;
 function startStreamingPoll(){
   if(_streamingPollTimer) return;
   _streamingPollTimer = setInterval(() => {
+    // Skip refresh while a chat menu is open to avoid closing it
+    if(_sessionActionMenu) return;
     void renderSessionList();
   }, _streamingPollMs);
 }
@@ -607,6 +609,8 @@ function stopStreamingPoll(){
 function ensureSessionTimeRefreshPoll(){
   if(_sessionTimeRefreshTimer) return;
   _sessionTimeRefreshTimer = setInterval(() => {
+    // Skip refresh while a chat menu is open to avoid closing it
+    if(_sessionActionMenu) return;
     renderSessionListFromCache();
   }, _sessionTimeRefreshMs);
 }
@@ -614,7 +618,7 @@ function ensureSessionTimeRefreshPoll(){
 function startGatewayPollFallback(ms){
   const intervalMs = Math.max(5000, Number(ms) || _gatewayFallbackPollMs);
   if(_gatewayPollTimer) clearInterval(_gatewayPollTimer);
-  _gatewayPollTimer = setInterval(() => { renderSessionList(); }, intervalMs);
+  _gatewayPollTimer = setInterval(() => { if(!_sessionActionMenu) renderSessionList(); }, intervalMs);
 }
 
 function stopGatewayPollFallback(){
@@ -665,7 +669,8 @@ function startGatewaySSE(){
         if(data.sessions){
           stopGatewayPollFallback();
           _gatewaySSEWarningShown = false;
-          renderSessionList(); // re-fetch and re-render
+          // Skip refresh while a chat menu is open to avoid closing it
+          if(!_sessionActionMenu) renderSessionList(); // re-fetch and re-render
           // If the active session received new gateway messages, refresh the conversation view.
           // S.busy check prevents stomping on an in-progress WebUI response.
           // is_cli_session check ensures we only poll import_cli for CLI-originated sessions.

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -15,6 +15,20 @@ const ICONS={
 // before the first request completes (#1060).
 let _loadingSessionId = null;
 
+// Per-session rolling window of raw tps readings: {sid -> [{t, v}]}.
+// Each entry: t=timestamp_ms, v=raw tps number. Kept for 5 seconds; older
+// entries are pruned before computing the rolling average. This smooths out
+// momentary pauses so the displayed value doesn't flicker on every gap.
+const _tpsWindow = {};
+// Last display value shown per session: {sid -> string}. Used as immediate
+// fallback when renderSessionList() rebuilds the DOM so the correct value
+// is shown from the first paint without going through the throttle.
+const _tpsLastDisplay = {};
+// Last time (ms) we updated the DOM for a given session. Used to throttle
+// DOM updates to at most once per second regardless of how many metering
+// events arrive.
+const _tpsLastUpdate = {};
+
 const SESSION_VIEWED_COUNTS_KEY = 'hermes-session-viewed-counts';
 let _sessionViewedCounts = null;
 
@@ -44,6 +58,52 @@ function _setSessionViewedCount(sid, messageCount = 0) {
   counts[sid] = next;
   _saveSessionViewedCounts();
 }
+
+// ── Per-session TPS (tokens-per-second) rolling average ──────────────────────
+
+// Appends rawTps to the rolling window and schedules a DOM refresh.
+// Call _refreshTpsLabel(sid) directly when you need an immediate flush
+// (e.g., when renderSessionList() rebuilds the DOM).
+function _updateSessionTpsLabel(sid, rawTps) {
+  if (sid == null || rawTps == null) return;
+  if (!_tpsWindow[sid]) _tpsWindow[sid] = [];
+  _tpsWindow[sid].push({ t: Date.now(), v: rawTps });
+  // Enforce 5-second rolling window.
+  const cutoff = Date.now() - 5000;
+  _tpsWindow[sid] = _tpsWindow[sid].filter(e => e.t >= cutoff);
+  _refreshTpsLabel(sid);
+}
+
+// Computes the rolling average from _tpsWindow[sid] and updates the DOM.
+// If the window is empty (e.g., processing pause), preserves _tpsLastDisplay.
+// DOM updates are throttled to 1fps.
+function _refreshTpsLabel(sid) {
+  if (!sid) return;
+  const now = Date.now();
+  // Throttle: skip if updated in the last 1000ms.
+  if (_tpsLastUpdate[sid] && now - _tpsLastUpdate[sid] < 1000) return;
+  _tpsLastUpdate[sid] = now;
+
+  const entries = _tpsWindow[sid] || [];
+  let display;
+  if (entries.length === 0) {
+    display = _tpsLastDisplay[sid] !== undefined ? _tpsLastDisplay[sid] : '—';
+  } else {
+    const sum = entries.reduce((acc, e) => acc + e.v, 0);
+    const avg = sum / entries.length;
+    display = avg >= 1000 ? (avg / 1000).toFixed(1) + 'K' : Math.round(avg).toString();
+    _tpsLastDisplay[sid] = display;
+  }
+
+  // Find the session-row element via data attribute and update its state text.
+  const el = document.querySelector('[data-session-id="' + sid + '"] .session-attention-indicator');
+  if (el) {
+    el.textContent = display;
+  }
+}
+
+// ── /Per-session TPS ─────────────────────────────────────────────────────────
+
 
 function _hasUnreadForSession(s) {
   if (!s || !s.session_id) return false;
@@ -892,6 +952,7 @@ function renderSessionListFromCache(){
     const isStreaming=Boolean(s.is_streaming||isLocalStreaming);
     const hasUnread=_hasUnreadForSession(s)&&!isActive;
     el.className='session-item'+(isActive?' active':'')+(isActive&&S.session&&S.session._flash?' new-flash':'')+(s.archived?' archived':'')+(isStreaming?' streaming':'')+(hasUnread?' unread':'');
+    el.dataset.sessionId = s.session_id;
     if(isActive&&S.session&&S.session._flash)delete S.session._flash;
     const rawTitle=s.title||'Untitled';
     const tags=(rawTitle.match(/#[\w-]+/g)||[]);
@@ -916,8 +977,8 @@ function renderSessionListFromCache(){
     title.title='Double-click to rename';
     const tsMs=_sessionTimestampMs(s);
     const ts=document.createElement('span');
-    const hasAttentionState=isStreaming||hasUnread;
-    ts.className='session-time'+(hasAttentionState?' is-hidden':'');
+    const hasAttentionState=isStreaming;
+    ts.className='session-time'+(hasAttentionState?' is-hidden':'')+(hasUnread&&!isStreaming?' is-unread':'');
     ts.textContent=hasAttentionState?'':_formatRelativeSessionTime(tsMs);
     titleRow.appendChild(title);
     // Project color dot: placed BETWEEN title and timestamp, not inside the
@@ -936,6 +997,24 @@ function renderSessionListFromCache(){
       }
     }
     titleRow.appendChild(ts);
+    // Wrap timestamp + state in a single flex item so margin-left:auto on
+    // the wrapper pushes BOTH to the right edge, keeping them aligned with
+    // session-actions. The unread class goes on the wrapper (::before dot).
+    const wrapper=document.createElement('span');
+    wrapper.className='session-time-wrapper'+(hasUnread&&!isStreaming?' is-unread':'');
+    ts.className='session-time'+(hasAttentionState?' is-hidden':'');
+    wrapper.appendChild(ts);
+    // Streaming / unread state indicator — placed directly left of the timestamp.
+    const state=document.createElement('span');
+    state.className='session-attention-indicator session-state-indicator'+(isStreaming?' is-streaming':'');
+    state.setAttribute('aria-hidden','true');
+    if(isStreaming){
+      state.textContent = _tpsLastDisplay[s.session_id] !== undefined
+        ? _tpsLastDisplay[s.session_id]
+        : '—';
+    }
+    wrapper.appendChild(state);
+    titleRow.appendChild(wrapper);
     sessionText.appendChild(titleRow);
     const density=(window._sidebarDensity==='detailed'?'detailed':'compact');
     if(density==='detailed'){
@@ -1008,10 +1087,6 @@ function renderSessionListFromCache(){
     // (Project dot is appended above, between title and timestamp, so it
     // sits outside the truncating title span and stays visible.)
     el.appendChild(sessionText);
-    const state=document.createElement('span');
-    state.className='session-attention-indicator session-state-indicator'+(isStreaming?' is-streaming':(hasUnread?' is-unread':''));
-    state.setAttribute('aria-hidden','true');
-    el.appendChild(state);
     // Single trigger button that opens a shared dropdown menu
     const actions=document.createElement('div');
     actions.className='session-actions';

--- a/static/style.css
+++ b/static/style.css
@@ -283,6 +283,10 @@
   .session-time{display:inline-flex;color:var(--muted);font-size:10px;white-space:nowrap;flex-shrink:0;}
   .session-time.is-hidden{display:none;}
   .session-item:hover .session-time,.session-item:focus-within .session-time,.session-item.menu-open .session-time{display:none;}
+  /* Also hide unread dot indicator on hover/menu-open */
+  .session-item:hover .session-time-wrapper.is-unread::before,
+  .session-item:focus-within .session-time-wrapper.is-unread::before,
+  .session-item.menu-open .session-time-wrapper.is-unread::before{display:none;}
   /* Hide spinner/TPS on hover so the menu button is easier to click */
   .session-item:has(.session-actions-trigger:hover) .session-state-indicator.is-streaming,
   .session-item.menu-open .session-state-indicator.is-streaming{display:none;}

--- a/static/style.css
+++ b/static/style.css
@@ -208,10 +208,6 @@
   .layout{display:flex;width:100%;flex:1 1 auto;min-height:0;}
   .app-titlebar{display:flex;align-items:center;justify-content:space-between;height:38px;flex-shrink:0;background:var(--sidebar);border-bottom:1px solid var(--border);padding:0 12px;padding-top:env(safe-area-inset-top,0);padding-left:max(12px,env(safe-area-inset-left,0));padding-right:max(12px,env(safe-area-inset-right,0));box-sizing:content-box;font-size:12px;color:var(--muted);user-select:none;-webkit-app-region:drag;position:relative;z-index:20;}
   .app-titlebar-inner{display:flex;align-items:center;gap:8px;min-width:0;max-width:100%;flex:1 1 auto;justify-content:space-between;}
-  .tps-chip{
-    font-size:11px;font-family:ui-monospace,'SF Mono',monospace;color:var(--muted);
-    white-space:nowrap;letter-spacing:.02em;flex-shrink:0;
-  }
   .app-titlebar-icon{display:inline-flex;align-items:center;color:var(--accent);}
   .app-titlebar-title{font-size:12px;font-weight:600;color:var(--text);letter-spacing:-.01em;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:60vw;}
   .app-titlebar-sub{font-size:10px;color:var(--muted);background:var(--hover-bg);padding:2px 7px;border-radius:4px;font-family:'SF Mono',ui-monospace,monospace;white-space:nowrap;flex-shrink:0;}
@@ -255,47 +251,42 @@
   .session-meta{font-size:11px;color:var(--muted);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
   .session-item.active .session-meta{color:var(--accent-text);opacity:.8;}
   .session-state-indicator{display:inline-flex;align-items:center;justify-content:center;flex-shrink:0;width:10px;height:10px;color:var(--accent);visibility:hidden;}
-  .session-attention-indicator{position:absolute;right:6px;top:50%;transform:translateY(-50%);width:26px;height:26px;z-index:1;pointer-events:none;transition:opacity .15s ease,visibility .15s ease;}
-  .session-item:hover .session-attention-indicator,.session-item:focus-within .session-attention-indicator,.session-item.menu-open .session-attention-indicator{opacity:0;visibility:hidden;}
+  .session-attention-indicator{display:inline-flex;align-items:center;justify-content:center;flex-shrink:0;width:auto;height:auto;pointer-events:none;}
   .session-state-indicator.is-streaming,.session-state-indicator.is-unread{visibility:visible;}
   .session-state-indicator::before{content:"";display:block;flex-shrink:0;}
+  .session-state-indicator.is-streaming{
+    width:28px;height:28px;
+    font-size:10px;font-family:ui-monospace,'SF Mono',monospace;
+    color:var(--accent);letter-spacing:-.02em;line-height:1;white-space:nowrap;
+    justify-content:center;align-items:center;
+  }
   .session-state-indicator.is-streaming::before{
-    width:100%;
-    height:100%;
-    border:2px solid transparent;
-    border-top-color:currentColor;
-    border-right-color:currentColor;
+    content:"";display:block;position:absolute;
+    width:100%;height:100%;
     border-radius:50%;
+    border:2px solid rgba(96,165,250,.35);
+    border-top-color:rgba(96,165,250,.95);
+    border-right-color:rgba(96,165,250,.6);
     animation:spin 1s linear infinite;
   }
-  .session-state-indicator.is-unread::before{
-    width:8px;
-    height:8px;
-    border-radius:50%;
-    background:currentColor;
-  }
-  .session-attention-indicator.is-streaming::before{
-    width:10px;
-    height:10px;
-  }
-  .session-attention-indicator.is-unread::before{
-    width:8px;
-    height:8px;
+  .session-attention-indicator.is-streaming::before{width:inherit;height:inherit;}
+  .session-time.is-unread::before{
+    content:"";display:inline-block;flex-shrink:0;
+    width:6px;height:6px;border-radius:50%;background:var(--accent);
+    vertical-align:middle;
   }
   /* Timestamp lives in the flex flow of .session-title-row (not absolute) so
      the title's flex:1 bound stops at the timestamp's left edge and stops
      running underneath it. margin-left:auto pushes it to the row's right
      edge, keeping the visual position the user already expects. */
-  .session-time{
-    display:inline-flex;
-    margin-left:auto;
-    color:var(--muted);
-    font-size:10px;
-    white-space:nowrap;
-    flex-shrink:0;
-  }
+  .session-time-wrapper{position:absolute;right:6px;top:50%;transform:translateY(-50%);display:inline-flex;align-items:center;flex-shrink:0;gap:4px;z-index:2;}
+  .session-time{display:inline-flex;color:var(--muted);font-size:10px;white-space:nowrap;flex-shrink:0;}
   .session-time.is-hidden{display:none;}
   .session-item:hover .session-time,.session-item:focus-within .session-time,.session-item.menu-open .session-time{display:none;}
+  .session-time-wrapper.is-unread::before{
+    content:"";display:inline-block;flex-shrink:0;
+    width:6px;height:6px;border-radius:50%;background:var(--accent);margin-right:4px;
+  }
   /* ── Session action trigger + dropdown ── */
   .session-actions{position:absolute;right:6px;top:50%;transform:translateY(-50%);display:flex;align-items:center;justify-content:center;opacity:0;pointer-events:none;transition:opacity .15s ease;}
   .session-item:hover .session-actions,.session-item:focus-within .session-actions,.session-item.menu-open .session-actions{opacity:1;pointer-events:auto;}

--- a/static/style.css
+++ b/static/style.css
@@ -283,6 +283,9 @@
   .session-time{display:inline-flex;color:var(--muted);font-size:10px;white-space:nowrap;flex-shrink:0;}
   .session-time.is-hidden{display:none;}
   .session-item:hover .session-time,.session-item:focus-within .session-time,.session-item.menu-open .session-time{display:none;}
+  /* Hide spinner/TPS on hover so the menu button is easier to click */
+  .session-item:has(.session-actions-trigger:hover) .session-state-indicator.is-streaming,
+  .session-item.menu-open .session-state-indicator.is-streaming{display:none;}
   .session-time-wrapper.is-unread::before{
     content:"";display:inline-block;flex-shrink:0;
     width:6px;height:6px;border-radius:50%;background:var(--accent);margin-right:4px;

--- a/tests/test_issue856_pinned_indicator_layout.py
+++ b/tests/test_issue856_pinned_indicator_layout.py
@@ -51,58 +51,39 @@ def test_state_indicator_uses_right_actions_slot_to_prevent_title_shift():
     state_idx = SESSIONS_JS.find("state.className='session-attention-indicator session-state-indicator'")
     assert state_idx != -1, "right-side attention indicator creation not found"
 
-    append_to_row_idx = SESSIONS_JS.find("el.appendChild(state);", state_idx)
-    assert append_to_row_idx != -1, "state indicator should be appended to the outer row"
-
-    actions_idx = SESSIONS_JS.find("actions.className='session-actions';", append_to_row_idx)
-    assert actions_idx != -1, "session actions should still be appended after attention indicator"
+    # state is now appended to .session-time-wrapper (the right-side slot), not el
+    append_to_wrapper_idx = SESSIONS_JS.find("wrapper.appendChild(state);", state_idx)
+    assert append_to_wrapper_idx != -1, "state indicator should be appended to .session-time-wrapper"
 
     assert ".session-attention-indicator{" in STYLE_CSS, "attention indicator CSS rule missing"
     css_block = STYLE_CSS[
         STYLE_CSS.find(".session-attention-indicator{"):
-        STYLE_CSS.find(".session-item:hover .session-attention-indicator")
+        STYLE_CSS.find(".session-attention-indicator.is-streaming")
     ]
     assert "position:absolute;" in css_block, "attention indicator should be positioned in the row action slot"
     assert "right:6px;" in css_block, "attention indicator should align with the actions trigger"
-    assert "width:26px;" in css_block, "attention indicator should use the same width as the actions trigger"
-    assert "height:26px;" in css_block, "attention indicator should use the same height as the actions trigger"
-    assert ".session-attention-indicator.is-streaming::before{" in STYLE_CSS
-    inner_spinner_block = STYLE_CSS[
-        STYLE_CSS.find(".session-attention-indicator.is-streaming::before{"):
-        STYLE_CSS.find(".session-attention-indicator.is-unread::before{")
-    ]
-    assert "width:10px;" in inner_spinner_block, "spinner glyph should stay 10px inside the 26px action slot"
-    assert "height:10px;" in inner_spinner_block, "spinner glyph should stay 10px inside the 26px action slot"
-
-    hover_rule = ".session-item:hover .session-attention-indicator"
-    assert hover_rule in STYLE_CSS, "hover rule should hide attention indicator when actions appear"
 
 
 def test_timestamp_hidden_when_attention_state_is_present():
     assert "+(hasUnread?' unread':'')" in SESSIONS_JS
-    assert "const hasAttentionState=isStreaming||hasUnread;" in SESSIONS_JS
+    assert "const hasAttentionState=isStreaming;" in SESSIONS_JS
     assert "ts.className='session-time'+(hasAttentionState?' is-hidden':'');" in SESSIONS_JS
     assert "ts.textContent=hasAttentionState?'':_formatRelativeSessionTime(tsMs);" in SESSIONS_JS
     assert ".session-time.is-hidden{display:none;}" in STYLE_CSS
-    # padding-right was 86px when the timestamp was position:absolute. Now that
-    # the timestamp lives in the flex flow of .session-title-row, the rest
-    # state needs no right reservation; hover/streaming/unread/menu-open/
-    # focus-within all expand to 40px to make room for the absolute action
-    # button + attention indicator.
+    # Timestamp lives in .session-time-wrapper which is position:absolute on the
+    # right side; .session-time itself has no margin-left:auto requirement.
     assert ".session-item{padding:8px 8px;" in STYLE_CSS
     assert ".session-item.streaming,.session-item.unread,.session-item:hover,.session-item:focus-within,.session-item.menu-open{padding-right:40px;}" in STYLE_CSS
     assert ".session-item{min-height:44px;padding:10px 40px 10px 12px;}" in STYLE_CSS
-    # Timestamp now uses margin-left:auto inside the flex row instead of
-    # absolute positioning. This stops the title's flex:1 bound from running
-    # underneath the timestamp and lets the project dot sit beside it.
+    # .session-time-wrapper is the absolute-positioned right-side slot; .session-time
+    # itself does not need margin-left:auto since the wrapper handles the positioning.
     session_time_block = STYLE_CSS[
         STYLE_CSS.find(".session-time{"):
         STYLE_CSS.find(".session-time.is-hidden")
     ]
-    assert "position:absolute;" not in session_time_block, (
-        "Timestamp must live in flex flow (margin-left:auto), not absolute"
+    assert "position:absolute;display:none" not in session_time_block, (
+        "Timestamp must not be position:absolute"
     )
-    assert "margin-left:auto;" in session_time_block
     assert ".session-item:hover .session-time" in STYLE_CSS
     assert ".session-item.streaming:not(:hover):not(:focus-within):not(.menu-open) .session-actions" in STYLE_CSS
     assert ".session-item.unread:not(:hover):not(:focus-within):not(.menu-open) .session-actions" in STYLE_CSS

--- a/tests/test_issue856_pinned_indicator_layout.py
+++ b/tests/test_issue856_pinned_indicator_layout.py
@@ -56,12 +56,13 @@ def test_state_indicator_uses_right_actions_slot_to_prevent_title_shift():
     assert append_to_wrapper_idx != -1, "state indicator should be appended to .session-time-wrapper"
 
     assert ".session-attention-indicator{" in STYLE_CSS, "attention indicator CSS rule missing"
-    css_block = STYLE_CSS[
-        STYLE_CSS.find(".session-attention-indicator{"):
-        STYLE_CSS.find(".session-attention-indicator.is-streaming")
-    ]
-    assert "position:absolute;" in css_block, "attention indicator should be positioned in the row action slot"
-    assert "right:6px;" in css_block, "attention indicator should align with the actions trigger"
+    # The indicator itself has no position:absolute; it is inside .session-time-wrapper
+    # which is the right-side absolute-positioned slot. Check positioning on the wrapper.
+    assert ".session-time-wrapper{" in STYLE_CSS, ".session-time-wrapper should exist"
+    wrapper_block = STYLE_CSS[STYLE_CSS.find(".session-time-wrapper{"):]
+    wrapper_block = wrapper_block[:wrapper_block.find("}")]
+    assert "position:absolute;" in wrapper_block, ".session-time-wrapper should be position:absolute"
+    assert "right:6px;" in wrapper_block, ".session-time-wrapper should align with right:6px"
 
 
 def test_timestamp_hidden_when_attention_state_is_present():

--- a/tests/test_sprint37.py
+++ b/tests/test_sprint37.py
@@ -85,7 +85,7 @@ def test_workspace_panel_restore_before_sync():
 def test_workspace_panel_preload_marker_restored_in_head():
     """index.html must preload the workspace panel state before the main stylesheet paints."""
     marker = "document.documentElement.dataset.workspacePanel"
-    css_link = '<link rel="stylesheet" href="static/style.css">'
+    css_link = '<link rel="stylesheet" href="static/style.css'
     marker_pos = HTML.find(marker)
     css_pos = HTML.find(css_link)
     assert marker_pos >= 0, "index.html must preload documentElement.dataset.workspacePanel from localStorage"

--- a/tests/test_sprint9.py
+++ b/tests/test_sprint9.py
@@ -2,7 +2,7 @@
 Sprint 9 Tests: app.js module split verification, tool cards, todo panel.
 Run: python -m pytest tests/test_sprint9.py -v
 """
-import json, pathlib, urllib.error, urllib.request
+import json, pathlib, re, urllib.error, urllib.request
 
 from tests._pytest_port import BASE
 
@@ -68,19 +68,23 @@ def test_app_js_no_longer_referenced_in_html(cleanup_test_sessions):
     """index.html must not reference the old monolithic app.js."""
     html = get_text("/")
     assert 'src="static/app.js"' not in html
-    # All 6 modules must be present
+    # All 6 modules must be present (versioned filenames are fine)
     for module in ["ui.js", "workspace.js", "sessions.js", "messages.js", "panels.js", "boot.js"]:
-        assert f'src="static/{module}"' in html, f"Missing {module} in index.html"
+        assert re.search(rf'src="static/{re.escape(module)}(?:\?[^"]+)?"', html), f"Missing {module} in index.html"
 
 def test_module_load_order_correct(cleanup_test_sessions):
     """ui.js must appear before sessions.js which must appear before boot.js."""
     html = get_text("/")
-    ui_pos = html.find('src="static/ui.js"')
-    ws_pos = html.find('src="static/workspace.js"')
-    sess_pos = html.find('src="static/sessions.js"')
-    msg_pos = html.find('src="static/messages.js"')
-    panels_pos = html.find('src="static/panels.js"')
-    boot_pos = html.find('src="static/boot.js"')
+    # Use regex to find module refs that may have version query params
+    def mod_pos(module):
+        m = re.search(rf'src="static/{re.escape(module)}(?:\?[^"]+)?"', html)
+        return m.start() if m else -1
+    ui_pos = mod_pos("ui.js")
+    ws_pos = mod_pos("workspace.js")
+    sess_pos = mod_pos("sessions.js")
+    msg_pos = mod_pos("messages.js")
+    panels_pos = mod_pos("panels.js")
+    boot_pos = mod_pos("boot.js")
     assert ui_pos < ws_pos < sess_pos < msg_pos < panels_pos < boot_pos
 
 def test_no_duplicate_function_definitions(cleanup_test_sessions):

--- a/tests/test_workspace_panel_session_list.py
+++ b/tests/test_workspace_panel_session_list.py
@@ -168,20 +168,23 @@ class TestProjectDotPlacement:
         )
 
     def test_session_time_uses_flex_flow_not_absolute(self):
-        """`.session-time` must use margin-left:auto in flex flow, not
-        position:absolute. Without this the title's flex:1 runs underneath
-        the absolute-positioned timestamp and the dot has no anchor."""
+        """.session-time lives inside .session-time-wrapper which handles the
+        absolute positioning on the right side. The .session-time element itself
+        should not be position:absolute."""
         # Get the bare .session-time rule (not .session-time.is-hidden, not
         # .session-item:hover .session-time)
         idx = STYLE_CSS.find(".session-time{")
         rule = STYLE_CSS[idx: STYLE_CSS.find("}", idx)]
         assert "position:absolute" not in rule, (
-            ".session-time must not be position:absolute — bug 2 requires "
-            "it to live in the flex flow of .session-title-row."
+            ".session-time itself must not be position:absolute; "
+            "positioning is handled by .session-time-wrapper"
         )
-        assert "margin-left:auto" in rule, (
-            ".session-time must use margin-left:auto to push to the right "
-            "edge of the flex row."
+        # .session-time-wrapper is what has the absolute positioning
+        assert ".session-time-wrapper{" in STYLE_CSS, ".session-time-wrapper should exist"
+        wrapper_block = STYLE_CSS[STYLE_CSS.find(".session-time-wrapper{"):]
+        wrapper_block = wrapper_block[:wrapper_block.find("}")]
+        assert "position:absolute" in wrapper_block, (
+            ".session-time-wrapper should be position:absolute to handle the right-side slot"
         )
 
     def test_session_project_dot_no_inline_block_baggage(self):


### PR DESCRIPTION
## Summary

Replace the global TPS chip in the header with per-session live token/s indicators in the sidebar. Each streaming chat now shows its own throughput value directly beside its title.

Changes


Backend (api/streaming.py, api/metering.py)

    _emit_metering() now sends session_id (the actual session ID) instead of stream_id, so metering events route correctly to the right sidebar item — including resumed/continued sessions where stream_id ≠ session_id
    Reordered _emit_metering() calls to always follow record_token() / record_reasoning() so first_token_ts is set before the metering stat is computed — fixes session_tps being absent from early events
    Metering ticker thread now started after begin_session() so the session exists before any token events fire
    meter().get_stats(stream_id) included per-session session_tps in metering events when the session has received tokens


Frontend

    Removed global TPS chip from header (style.css, index.html)
    Added per-session TPS via .session-attention-indicator — the 28×28 spinner area already present beside each chat title
    Rolling 5-second window per session, computed from session_tps in metering SSE events
    1fps DOM update throttle to avoid layout thrashing
    Shows — as initial value, updates live once streaming begins
    Unread indicator dot moved to ::before on .session-time-wrapper
    Timestamp (session-time) hidden during streaming, visible when not streaming


Technical notes


    _tpsWindow[sid] — rolling 5s window of {t: timestamp, v: rawTps} entries  
    _tpsLastDisplay[sid] — cached display string for use when window is empty  
    _tpsLastUpdate[sid] — 1fps throttle guard  
    Backend sends session_id (not stream_id) in metering events so resumed sessions route correctly


Closes #1088