### PR TITLE
fix(#1095): render pasted/dragged images as inline preview instead of paperclip badge

### DIFF
--- a/static/ui.js
+++ b/static/ui.js
@@ -2235,7 +2235,14 @@ function renderMessages(){
     const isLastAssistant=!isUser&&vi===visWithIdx.length-1;
     let filesHtml='';
     if(m.attachments&&m.attachments.length){
-      filesHtml=`<div class="msg-files">${m.attachments.map(f=>`<div class="msg-file-badge">${li('paperclip',12)} ${esc(f)}</div>`).join('')}</div>`;
+      filesHtml=`<div class="msg-files">${m.attachments.map(f=>{
+        const fname=f.split('/').pop()||f;
+        if(_IMAGE_EXTS.test(fname)){
+          const imgUrl='api/media?path='+encodeURIComponent(f);
+          return `<img class="msg-media-img" src="${esc(imgUrl)}" alt="${esc(fname)}" loading="lazy" onclick="this.classList.toggle('msg-media-img--full')">`;
+        }
+        return `<div class="msg-file-badge">${li('paperclip',12)} ${esc(fname)}</div>`;
+      }).join('')}</div>`;
     }
     const bodyHtml = isUser ? esc(String(content)).replace(/\n/g,'<br>') : renderMd(_stripXmlToolCallsDisplay(String(content)));
     const isEditableUser=isUser&&rawIdx===lastUserRawIdx;

--- a/tests/test_issue1095_pasted_images.py
+++ b/tests/test_issue1095_pasted_images.py
@@ -1,0 +1,52 @@
+"""Tests for #1095 — pasted images render as inline previews, not paperclip badges."""
+import os
+import re
+import pytest
+
+
+def _read_js(name):
+    with open(os.path.join('static', name)) as f:
+        return f.read()
+
+
+class TestAttachmentImageRendering:
+    """User message attachments with image extensions should render as <img>, not paperclip badges."""
+
+    def test_attachments_block_uses_image_check(self):
+        ui = _read_js('ui.js')
+        # Find the attachments rendering block
+        assert 'm.attachments' in ui
+        # Must check file extension before rendering
+        assert '_IMAGE_EXTS.test(' in ui, '_IMAGE_EXTS not used in attachment rendering'
+
+    def test_image_attachments_use_img_tag(self):
+        """Image attachments should produce <img> with api/media?path=, not paperclip badge."""
+        ui = _read_js('ui.js')
+        # Find the attachments section
+        m = re.search(r"m\.attachments&&m\.attachments\.length", ui)
+        assert m, 'attachments rendering block not found'
+        body = ui[m.start():m.start() + 1000]
+        # Should have img tag with api/media
+        assert 'msg-media-img' in body, 'attachments must render images with msg-media-img class'
+        assert 'api/media?path=' in body, 'image attachments must use api/media endpoint'
+
+    def test_non_image_attachments_keep_paperclip(self):
+        """Non-image attachments must still show paperclip badge."""
+        ui = _read_js('ui.js')
+        m = re.search(r"m\.attachments&&m\.attachments\.length", ui)
+        body = ui[m.start():m.start() + 1000]
+        assert "msg-file-badge" in body, 'non-image attachments must still use paperclip badge'
+
+    def test_image_click_to_full(self):
+        """Inline image attachments should support click-to-fullscreen (toggle class)."""
+        ui = _read_js('ui.js')
+        m = re.search(r"m\.attachments&&m\.attachments\.length", ui)
+        body = ui[m.start():m.start() + 1000]
+        assert "msg-media-img--full" in body, 'image attachments should toggle full-screen on click'
+
+    def test_uses_filename_not_full_path(self):
+        """Non-image badge should display filename, not full path."""
+        ui = _read_js('ui.js')
+        m = re.search(r"m\.attachments&&m\.attachments\.length", ui)
+        body = ui[m.start():m.start() + 1000]
+        assert ".split('/').pop()" in body, 'should extract filename from path for display'


### PR DESCRIPTION
## Thinking Path
- User message attachments are always rendered as paperclip + filename badges (line 2251 in ui.js)
- The MEDIA token rendering path (for agent-generated images) already has inline image support via `api/media?path=` + `_IMAGE_EXTS` check
- Pasted/dragged images are stored as attachments (not MEDIA tokens) — they bypass the inline rendering entirely
- Fix: check attachment extension against `_IMAGE_EXTS` — render images as `<img>` with click-to-fullscreen, non-images keep paperclip badge

## What Changed
- **`static/ui.js`**: Attachment rendering now checks file extension against `_IMAGE_EXTS`. Image attachments render as `<img class="msg-media-img">` with `api/media?path=` endpoint, lazy loading, and click-to-fullscreen toggle. Non-image attachments still show paperclip badge with filename (extracted from full path).

## Why It Matters
Pasted/dragged images in the chat composer showed as `📎 image.png` instead of an actual image preview. The underlying file was accessible to the agent, but users couldn't see what they uploaded. This is a fundamental UX gap for image-heavy workflows (screenshots, diagrams, photos).

## Verification
- `pytest tests/test_issue1095_pasted_images.py -v` — 5/5 pass
- Inline image rendering uses same `msg-media-img` class and `api/media` endpoint as agent-generated MEDIA tokens — consistent styling
- Non-image attachments unchanged (paperclip + filename badge)

## Risks / Follow-ups
- Large images may slow chat scrolling — mitigated by `loading="lazy"`
- Very long file paths in attachments now show only filename (improvement, not risk)

## Model Used
- Provider: zai
- Model: glm-5-turbo
- Tools: Hermes Agent

Closes #1095