### PR TITLE
fix: improve mobile touch responsiveness for session list items

### DIFF
--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1030,16 +1030,31 @@ function renderSessionListFromCache(){
     actions.appendChild(menuBtn);
     el.appendChild(actions);
 
-    // Use a click timer to distinguish single-click (navigate) from double-click (rename).
-    // This prevents loadSession from firing on the first click of a double-click,
-    // which would re-render the list and destroy the dblclick target before it fires.
-    let _clickTimer=null;
-    el.onclick=async(e)=>{
-      if(_renamingSid) return; // ignore while any rename is active
+    // Use pointerup + manual double-tap detection instead of onclick/ondblclick.
+    // onclick/ondblclick are unreliable on touch devices (iPad Safari especially):
+    // hover-triggered layout shifts, ghost clicks, and 300ms delay all break
+    // single-tap navigation. pointerup fires immediately on both mouse & touch.
+    let _lastTapTime=0;
+    let _tapTimer=null;
+    el.onpointerup=(e)=>{
+      if(_renamingSid) return;
       if(actions.contains(e.target)) return;
-      clearTimeout(_clickTimer);
-      _clickTimer=setTimeout(async()=>{
-        _clickTimer=null;
+      const now=Date.now();
+      if(now-_lastTapTime<350){
+        // Double-tap: rename
+        clearTimeout(_tapTimer);
+        _tapTimer=null;
+        _lastTapTime=0;
+        startRename();
+        return;
+      }
+      _lastTapTime=now;
+      // Single tap: wait to ensure it's not the first of a double-tap,
+      // then navigate
+      clearTimeout(_tapTimer);
+      _tapTimer=setTimeout(async()=>{
+        _tapTimer=null;
+        _lastTapTime=0;
         if(_renamingSid) return;
         // For CLI sessions, import into WebUI store first (idempotent)
         if(s.is_cli_session){
@@ -1049,14 +1064,7 @@ function renderSessionListFromCache(){
         }
         await loadSession(s.session_id);renderSessionListFromCache();
         if(typeof closeMobileSidebar==='function')closeMobileSidebar();
-      }, 220);
-    };
-    el.ondblclick=async(e)=>{
-      e.stopPropagation();
-      e.preventDefault();
-      clearTimeout(_clickTimer); // cancel the pending single-click navigation
-      _clickTimer=null;
-      startRename();
+      }, 300);
     };
     return el;
   }

--- a/static/style.css
+++ b/static/style.css
@@ -242,8 +242,8 @@
      and attention indicator (26x26 at right:6px) still need 40px reserved
      when they're visible — covered by the hover / streaming / unread /
      menu-open / focus-within rule below. */
-  .session-item{padding:8px 8px;margin-bottom:2px;border-radius:8px;cursor:pointer;font-size:13px;color:var(--muted);transition:background .15s,color .15s;display:flex;align-items:flex-start;gap:8px;min-width:0;position:relative;}
-  .session-item.streaming,.session-item.unread,.session-item:hover,.session-item:focus-within,.session-item.menu-open{padding-right:40px;}
+  .session-item{padding:8px 8px;margin-bottom:2px;border-radius:8px;cursor:pointer;font-size:13px;color:var(--muted);transition:background .15s,color .15s;display:flex;align-items:flex-start;gap:8px;min-width:0;position:relative;touch-action:manipulation;-webkit-tap-highlight-color:transparent;}
+  .session-item.streaming,.session-item.unread,.session-item:focus-within,.session-item.menu-open{padding-right:40px;}
   .session-item:hover{background:var(--hover-bg);color:var(--text);}
   .session-item.active{background:var(--accent-bg);color:var(--accent);}
   .session-item.streaming .session-title{color:var(--accent);}


### PR DESCRIPTION
## Problem

On iPad and other touch devices, tapping a session in the left sidebar doesn't navigate. Symptoms:

- **First tap**: only a style change (background highlight), no navigation
- **Second tap**: sometimes works, depending on where you tap
- **Double tap**: triggers rename instead of navigation

The root cause is two-fold:

### 1. CSS layout shift on :hover disrupts click targeting
When `.session-item` is hovered, `padding-right` changes from 8px to 40px. On iPad, touch immediately activates `:hover`, causing the element to reflow *during* the tap. The subsequent `click` event lands on `.session-actions` (the actions button that just became visible), which has `e.stopPropagation()`, so the navigation click never fires.

### 2. onclick/ondblclick are mouse-centric
The old `onclick + setTimeout(220ms) + ondblclick` pattern works on desktop but is unreliable on touch. iPad Safari's click-to-dblclick synthesis has timing quirks that make single-tap navigation inconsistent.

## Fix

- **CSS**: Remove `:hover` from the `padding-right: 40px` rule — hover only changes `background` and `color` now, no layout shift
- **CSS**: Add `touch-action: manipulation` and `-webkit-tap-highlight-color: transparent` to `.session-item` — eliminates the 300ms tap delay and disables double-tap zoom
- **JS**: Replace `onclick`/`ondblclick` with `onpointerup` + manual double-tap detection (350ms window). `pointerup` fires immediately on both mouse and touch, with no delay or ghost-click issues

## Files changed

- `static/style.css` — 2 lines changed
- `static/sessions.js` — replaced click/dblclick with pointerup handler