### PR TITLE
fix(#1106): iterate custom_providers[].models dict keys for dropdown population

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -1564,22 +1564,34 @@ def get_available_models() -> dict:
             for _cp in _custom_providers_cfg:
                 if not isinstance(_cp, dict):
                     continue
-                _cp_model = _cp.get("model", "")
                 _cp_name = (_cp.get("name") or "").strip()
-                if _cp_model and _cp_model not in _seen_custom_ids:
-                    _cp_label = _get_label_for_model(_cp_model, [])
-                    _seen_custom_ids.add(_cp_model)
-                    if _cp_name:
-                        _slug = "custom:" + _cp_name.lower().replace(" ", "-")
-                        if _slug not in _named_custom_groups:
-                            _named_custom_groups[_slug] = (_cp_name, [])
+                _slug = ("custom:" + _cp_name.lower().replace(" ", "-")) if _cp_name else None
+
+                # Collect model IDs: singular "model" field first, then "models" dict keys
+                _cp_model_ids: list[str] = []
+                _cp_model = _cp.get("model", "")
+                if _cp_model:
+                    _cp_model_ids.append(_cp_model)
+                _cp_models_dict = _cp.get("models")
+                if isinstance(_cp_models_dict, dict):
+                    for _m_id in _cp_models_dict:
+                        if isinstance(_m_id, str) and _m_id.strip() and _m_id not in _cp_model_ids:
+                            _cp_model_ids.append(_m_id.strip())
+
+                for _cp_model in _cp_model_ids:
+                    if _cp_model and _cp_model not in _seen_custom_ids:
+                        _cp_label = _get_label_for_model(_cp_model, [])
+                        _seen_custom_ids.add(_cp_model)
+                        if _slug:
+                            if _slug not in _named_custom_groups:
+                                _named_custom_groups[_slug] = (_cp_name, [])
                             detected_providers.add(_slug)
-                        _named_custom_groups[_slug][1].append(
-                            {"id": _cp_model, "label": _cp_label}
-                        )
-                    else:
-                        auto_detected_models.append({"id": _cp_model, "label": _cp_label})
-                        detected_providers.add("custom")
+                            _named_custom_groups[_slug][1].append(
+                                {"id": _cp_model, "label": _cp_label}
+                            )
+                        else:
+                            auto_detected_models.append({"id": _cp_model, "label": _cp_label})
+                            detected_providers.add("custom")
 
         _has_custom_providers = isinstance(_custom_providers_cfg, list) and len(_custom_providers_cfg) > 0
         if active_provider and active_provider != "custom" and not _has_custom_providers:

--- a/tests/test_issue1106_custom_providers_models.py
+++ b/tests/test_issue1106_custom_providers_models.py
@@ -1,0 +1,198 @@
+"""Tests for #1106 — custom_providers[].models dict keys populate model dropdown."""
+import pytest
+import api.config as config
+
+
+def _reset():
+    try:
+        config.invalidate_models_cache()
+    except Exception:
+        pass
+
+
+def _models_with_cfg(model_cfg=None, custom_providers=None, active_provider=None):
+    """Temporarily patch config.cfg, call get_available_models(), restore.
+
+    Also pins _cfg_mtime to prevent reload_config() from overwriting patches.
+    """
+    old_cfg = dict(config.cfg)
+    old_mtime = config._cfg_mtime
+    config.cfg.clear()
+    if model_cfg:
+        config.cfg["model"] = model_cfg
+    if custom_providers is not None:
+        config.cfg["custom_providers"] = custom_providers
+    try:
+        config._cfg_mtime = config.Path(config._get_config_path()).stat().st_mtime
+    except Exception:
+        config._cfg_mtime = 0.0
+    try:
+        return config.get_available_models()
+    finally:
+        config.cfg.clear()
+        config.cfg.update(old_cfg)
+        config._cfg_mtime = old_mtime
+
+
+def _all_model_ids(result):
+    """Extract all model IDs from all groups."""
+    ids = []
+    for g in result.get("groups", []):
+        for m in g.get("models", []):
+            ids.append(m["id"])
+    return ids
+
+
+def _group_for(result, provider_name):
+    """Get a group by provider name."""
+    for g in result.get("groups", []):
+        if g.get("provider") == provider_name:
+            return g
+    return None
+
+
+class TestCustomProvidersModelsDict:
+    """custom_providers entries with a 'models' dict should populate all keys in the dropdown."""
+
+    def test_models_dict_keys_appear_in_dropdown(self):
+        """Each key in custom_providers[].models should appear as a selectable model."""
+        result = _models_with_cfg(
+            model_cfg={"provider": "custom"},
+            custom_providers=[
+                {
+                    "name": "Llama-swap",
+                    "base_url": "http://llama-swap:8880/v1",
+                    "model": "unsloth-qwen3.6-35b-a3b",
+                    "models": {
+                        "unsloth-qwen3.6-35b-a3b": {"context_length": 262144},
+                        "gemma4-26b": {},
+                        "qwen3.5-27b": {},
+                        "qwen3-coder-30b": {},
+                    },
+                }
+            ],
+        )
+        ids = _all_model_ids(result)
+        for expected in ["unsloth-qwen3.6-35b-a3b", "gemma4-26b", "qwen3.5-27b", "qwen3-coder-30b"]:
+            assert expected in ids, f"Expected '{expected}' in model IDs, got {ids}"
+
+    def test_models_dict_without_model_field_still_works(self):
+        """If only 'models' dict is present (no singular 'model'), all dict keys should appear."""
+        result = _models_with_cfg(
+            model_cfg={"provider": "custom"},
+            custom_providers=[
+                {
+                    "name": "Local-LLM",
+                    "base_url": "http://localhost:8080/v1",
+                    "models": {
+                        "llama-3-8b": {},
+                        "mistral-7b": {},
+                    },
+                }
+            ],
+        )
+        ids = _all_model_ids(result)
+        assert "llama-3-8b" in ids
+        assert "mistral-7b" in ids
+
+    def test_no_duplicates_when_model_and_models_overlap(self):
+        """If 'model' value also appears in 'models' dict, it should not be duplicated."""
+        result = _models_with_cfg(
+            model_cfg={"provider": "custom"},
+            custom_providers=[
+                {
+                    "name": "MyServer",
+                    "base_url": "http://myserver:8000/v1",
+                    "model": "base-model",
+                    "models": {
+                        "base-model": {},
+                        "other-model": {},
+                    },
+                }
+            ],
+        )
+        ids = _all_model_ids(result)
+        assert ids.count("base-model") == 1, f"'base-model' should appear exactly once, got {ids.count('base-model')}"
+        assert "other-model" in ids
+
+    def test_unnamed_provider_models_dict_works(self):
+        """custom_providers without 'name' should still populate 'Custom' group."""
+        result = _models_with_cfg(
+            model_cfg={"provider": "custom"},
+            custom_providers=[
+                {
+                    "model": "my-model",
+                    "models": {
+                        "extra-model-a": {},
+                        "extra-model-b": {},
+                    },
+                }
+            ],
+        )
+        ids = _all_model_ids(result)
+        for expected in ["my-model", "extra-model-a", "extra-model-b"]:
+            assert expected in ids, f"Expected '{expected}' in model IDs, got {ids}"
+
+    def test_empty_models_dict_is_ignored(self):
+        """An empty 'models' dict should not break anything."""
+        result = _models_with_cfg(
+            model_cfg={"provider": "custom"},
+            custom_providers=[
+                {
+                    "name": "TestServer",
+                    "model": "only-model",
+                    "models": {},
+                }
+            ],
+        )
+        ids = _all_model_ids(result)
+        assert "only-model" in ids
+
+    def test_non_string_models_keys_are_skipped(self):
+        """Non-string keys in models dict should be silently skipped."""
+        result = _models_with_cfg(
+            model_cfg={"provider": "custom"},
+            custom_providers=[
+                {
+                    "name": "TestServer",
+                    "model": "valid-model",
+                    "models": {
+                        "another-valid": {},
+                        123: {},  # non-string key
+                        None: {},  # non-string key
+                    },
+                }
+            ],
+        )
+        ids = _all_model_ids(result)
+        assert "valid-model" in ids
+        assert "another-valid" in ids
+
+    def test_multiple_custom_providers_each_keep_models_separate(self):
+        """Multiple named custom_providers should each have their own models."""
+        result = _models_with_cfg(
+            model_cfg={"provider": "custom"},
+            custom_providers=[
+                {
+                    "name": "Server-A",
+                    "model": "model-a1",
+                    "models": {"model-a2": {}},
+                },
+                {
+                    "name": "Server-B",
+                    "model": "model-b1",
+                    "models": {"model-b2": {}},
+                },
+            ],
+        )
+        group_a = _group_for(result, "Server-A")
+        group_b = _group_for(result, "Server-B")
+        assert group_a is not None, "Server-A group missing"
+        assert group_b is not None, "Server-B group missing"
+        ids_a = [m["id"] for m in group_a["models"]]
+        ids_b = [m["id"] for m in group_b["models"]]
+        assert "model-a1" in ids_a and "model-a2" in ids_a
+        assert "model-b1" in ids_b and "model-b2" in ids_b
+        # No cross-contamination
+        assert "model-b1" not in ids_a
+        assert "model-a1" not in ids_b


### PR DESCRIPTION
## Thinking Path
- `custom_providers[].models` dict (YAML key-value) is parsed but never iterated for dropdown population
- Only the singular `model` field was read → users with multiple models in `models` dict see only one
- This compounds with SSRF false positives (#1105): when auto-detect is blocked, `custom_providers` is the only fallback but only picks up one model
- Fix: after reading `model` field, also iterate `models` dict keys and add each as a selectable model

## What Changed
- **`api/config.py`**: `_build_available_models_uncached()` now collects model IDs from both `model` (singular) and `models` (dict) fields in `custom_providers` entries. Dict keys are deduplicated against the singular `model` field. Non-string keys are silently skipped.
- **`tests/test_issue1106_custom_providers_models.py`**: 7 regression tests covering dict iteration, no duplicates, overlap handling, empty dict, non-string keys, unnamed providers, and multiple named providers.

## Why It Matters
Users with local inference servers (llama.cpp, llama-swap, vLLM, TabbyAPI) list their models in `custom_providers[].models` in config.yaml. Currently only one model appears in the dropdown. After this fix, all models from the dict are available for selection.

## Verification
- `pytest tests/test_issue1106_custom_providers_models.py -v` — 7/7 pass
- `pytest tests/test_custom_provider_display_name.py tests/test_model_resolver.py -v` — 26/27 pass (1 pre-existing failure)
- Syntax check: `py_compile api/config.py` — OK

## Risks / Follow-ups
- `models` dict values (metadata like `context_length`) are not yet used — could power context length display in dropdown in a future PR
- Relates to #1105 (SSRF false positive) — when both are fixed, local model servers will fully work

## Model Used
- Provider: zai
- Model: glm-5-turbo
- Tools: Hermes Agent

Closes #1106