### PR TITLE
fix(#1112): allow Google Fonts in CSP style-src and font-src

### DIFF
--- a/api/helpers.py
+++ b/api/helpers.py
@@ -44,8 +44,8 @@ def _security_headers(handler):
         'Content-Security-Policy',
         "default-src 'self' https://*.cloudflareaccess.com; "
         "script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://static.cloudflareinsights.com; "
-        "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; "
-        "img-src 'self' data: https: blob:; font-src 'self' data: https://cdn.jsdelivr.net; connect-src 'self'; "
+        "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://fonts.googleapis.com; "
+        "img-src 'self' data: https: blob:; font-src 'self' data: https://cdn.jsdelivr.net https://fonts.gstatic.com; connect-src 'self'; "
         "manifest-src 'self' https://*.cloudflareaccess.com; "
         "base-uri 'self'; form-action 'self'"
     )

--- a/tests/test_issue1112_csp_google_fonts.py
+++ b/tests/test_issue1112_csp_google_fonts.py
@@ -1,0 +1,49 @@
+"""Tests for #1112 — CSP allows Google Fonts stylesheet and font files."""
+import re
+
+
+def _helpers_src() -> str:
+    with open("api/helpers.py") as f:
+        return f.read()
+
+
+class TestCSPGoogleFonts:
+    """style-src and font-src must allow fonts.googleapis.com / fonts.gstatic.com."""
+
+    def test_style_src_includes_google_fonts(self):
+        """style-src must include https://fonts.googleapis.com for Google Fonts CSS."""
+        src = _helpers_src()
+        assert "https://fonts.googleapis.com" in src, \
+            "style-src must allow fonts.googleapis.com (Google Fonts stylesheets)"
+        # Must be in the style-src directive, not accidentally elsewhere
+        style_match = re.search(r"style-src\s+([^;]+);", src)
+        assert style_match, "style-src directive must exist"
+        assert "fonts.googleapis.com" in style_match.group(1), \
+            "fonts.googleapis.com must be in style-src directive"
+
+    def test_font_src_includes_fonts_gstatic(self):
+        """font-src must include https://fonts.gstatic.com for Google Font files."""
+        src = _helpers_src()
+        assert "https://fonts.gstatic.com" in src, \
+            "font-src must allow fonts.gstatic.com (Google Font WOFF2/WOFF files)"
+        # Must be in the font-src directive
+        font_match = re.search(r"font-src\s+([^;]+);", src)
+        assert font_match, "font-src directive must exist"
+        assert "fonts.gstatic.com" in font_match.group(1), \
+            "fonts.gstatic.com must be in font-src directive"
+
+    def test_existing_csp_directives_preserved(self):
+        """All pre-existing CSP directives must still be present after the fix."""
+        src = _helpers_src()
+        for directive in (
+            "default-src 'self'",
+            "script-src 'self' 'unsafe-inline'",
+            "style-src 'self' 'unsafe-inline'",
+            "img-src 'self' data:",
+            "font-src 'self' data:",
+            "connect-src 'self'",
+            "manifest-src 'self'",
+            "base-uri 'self'",
+            "form-action 'self'",
+        ):
+            assert directive in src, f"CSP must still contain: {directive}"


### PR DESCRIPTION
## Summary

Fixes #1112

Mermaid themes inject `@import` for `fonts.googleapis.com` at render time. The CSP `style-src` directive only allowed `cdn.jsdelivr.net`, so Google Fonts stylesheet requests were blocked with a CSP violation.

## Changes

- **`api/helpers.py`**: Added `https://fonts.googleapis.com` to `style-src` (Google Fonts CSS) and `https://fonts.gstatic.com` to `font-src` (Google Font WOFF2/WOFF files)
- **`tests/test_issue1112_csp_google_fonts.py`**: 3 regression tests

## Testing

```
9 passed — 3 new (CSP Google Fonts) + 3 existing (PWA manifest CSP) + 3 existing (Mermaid CSP font)
```