### PR TITLE
feat(#1116): composer placeholder reflects active profile name

### DIFF
--- a/static/boot.js
+++ b/static/boot.js
@@ -769,7 +769,15 @@ function _buildSkinPicker(activeSkin){
 }
 
 function applyBotName(){
-  const name=window._botName||'Hermes';
+  // Prefer profile name over global bot_name for personalised placeholder.
+  // If activeProfile is set and not 'default', use it (capitalised).
+  // Falls back to window._botName (global bot_name setting) or 'Hermes'.
+  let name;
+  if(S.activeProfile && S.activeProfile!=='default'){
+    name=S.activeProfile.charAt(0).toUpperCase()+S.activeProfile.slice(1);
+  }else{
+    name=window._botName||'Hermes';
+  }
   document.title=name;
   const sidebarH1=document.querySelector('.sidebar-header h1');
   if(sidebarH1) sidebarH1.textContent=name;

--- a/static/panels.js
+++ b/static/panels.js
@@ -1981,6 +1981,9 @@ async function switchToProfile(name) {
     if (_currentPanel === 'profiles') await loadProfilesPanel();
     if (_currentPanel === 'workspaces') await loadWorkspacesPanel();
 
+    // Update composer placeholder and title bar to reflect profile name
+    if (typeof applyBotName === 'function') applyBotName();
+
   } catch (e) { showToast(t('switch_failed') + e.message); }
 }
 

--- a/tests/test_issue1116_composer_placeholder.py
+++ b/tests/test_issue1116_composer_placeholder.py
@@ -1,0 +1,60 @@
+"""Tests for #1116 — composer placeholder reflects active profile name."""
+import re
+
+
+def _src(name: str) -> str:
+    with open(f"static/{name}") as f:
+        return f.read()
+
+
+class TestComposerPlaceholderProfile:
+    """applyBotName() should use the profile name when activeProfile is set."""
+
+    def test_applyBotName_uses_profile_name(self):
+        """applyBotName must check S.activeProfile and prefer it over global bot_name."""
+        src = _src("boot.js")
+        assert "S.activeProfile" in src, \
+            "applyBotName must reference S.activeProfile"
+        # Should fall back to _botName when activeProfile is 'default'
+        assert "S.activeProfile!=='default'" in src, \
+            "applyBotName must skip 'default' profile (use bot_name instead)"
+
+    def test_applyBotName_capitalises_profile_name(self):
+        """Profile name should be capitalised (first letter uppercase)."""
+        src = _src("boot.js")
+        m = re.search(r'function applyBotName\(\)\{.*?\n\}', src, re.DOTALL)
+        assert m, "applyBotName function must exist"
+        body = m.group(0)
+        assert "charAt(0).toUpperCase()" in body, \
+            "applyBotName must capitalise first letter of profile name"
+
+    def test_applyBotName_falls_back_to_bot_name(self):
+        """When no active profile, must fall back to window._botName."""
+        src = _src("boot.js")
+        m = re.search(r'function applyBotName\(\)\{.*?\n\}', src, re.DOTALL)
+        assert m, "applyBotName function must exist"
+        body = m.group(0)
+        assert "window._botName||'Hermes'" in body, \
+            "applyBotName must fall back to window._botName or 'Hermes'"
+
+    def test_switchToProfile_calls_applyBotName(self):
+        """switchToProfile() must call applyBotName() after switching."""
+        src = _src("panels.js")
+        assert "function switchToProfile" in src, \
+            "switchToProfile function must exist"
+        # Find the function block (starts with 'async function switchToProfile')
+        m = re.search(r'async function switchToProfile\s*\(', src)
+        assert m, "switchToProfile must be an async function"
+        # Get everything after the function declaration (enough context)
+        after = src[m.start():m.start()+5000]
+        assert "applyBotName" in after, \
+            "switchToProfile must call applyBotName after profile switch"
+
+    def test_placeholder_uses_name_variable(self):
+        """The composer placeholder must use the resolved name variable."""
+        src = _src("boot.js")
+        m = re.search(r'function applyBotName\(\)\{.*?\n\}', src, re.DOTALL)
+        assert m, "applyBotName function must exist"
+        body = m.group(0)
+        assert re.search(r"msg\.placeholder\s*=\s*.*Message.*name", body), \
+            "applyBotName must set composer placeholder to 'Message <name>…'"


### PR DESCRIPTION
## Summary

Fixes #1116

When a named profile is active (not `'default'`), the composer placeholder and title bar show the profile name (capitalised) instead of the global `bot_name`. Falls back to `bot_name`/`'Hermes'` for the default profile.

## Changes

- **`static/boot.js`**: `applyBotName()` now checks `S.activeProfile` — if set and not `'default'`, uses the capitalised profile name. Falls back to `window._botName` otherwise.
- **`static/panels.js`**: `switchToProfile()` calls `applyBotName()` after profile switch to update placeholder/title/sidebar/logo.
- **`tests/test_issue1116_composer_placeholder.py`**: 5 regression tests

## Testing

```
5 passed
```