### PR TITLE
feat(#1097): drag & drop workspace files into chat composer

### DIFF
--- a/static/panels.js
+++ b/static/panels.js
@@ -2113,9 +2113,29 @@ async function loadMemory(force) {
 // Drag and drop
 const wrap=$('composerWrap');let dragCounter=0;
 document.addEventListener('dragover',e=>e.preventDefault());
-document.addEventListener('dragenter',e=>{e.preventDefault();if(e.dataTransfer.types.includes('Files')){dragCounter++;wrap.classList.add('drag-over');}});
+document.addEventListener('dragenter',e=>{e.preventDefault();if(e.dataTransfer.types.includes('Files')||e.dataTransfer.types.includes('application/ws-path')){dragCounter++;wrap.classList.add('drag-over');}});
 document.addEventListener('dragleave',e=>{dragCounter--;if(dragCounter<=0){dragCounter=0;wrap.classList.remove('drag-over');}});
-document.addEventListener('drop',e=>{e.preventDefault();dragCounter=0;wrap.classList.remove('drag-over');const files=Array.from(e.dataTransfer.files);if(files.length){addFiles(files);$('msg').focus();}});
+document.addEventListener('drop',e=>{
+  e.preventDefault();dragCounter=0;wrap.classList.remove('drag-over');
+  // Workspace file/folder drag → insert @path reference into composer
+  const wsPath=e.dataTransfer.getData('application/ws-path');
+  if(wsPath){
+    const msgEl=$('msg');
+    if(msgEl){
+      const start=msgEl.selectionStart;const end=msgEl.selectionEnd;
+      const val=msgEl.value;
+      const prefix=start>0&&!val[start-1].match(/\s/)?' ':'';
+      const insert=prefix+'@'+wsPath+' ';
+      msgEl.value=val.slice(0,start)+insert+val.slice(end);
+      msgEl.selectionStart=msgEl.selectionEnd=start+insert.length;
+      msgEl.focus();
+    }
+    return;
+  }
+  // OS file drag → attach files
+  const files=Array.from(e.dataTransfer.files);
+  if(files.length){addFiles(files);$('msg').focus();}
+});
 
 // ── Settings panel ───────────────────────────────────────────────────────────
 

--- a/static/ui.js
+++ b/static/ui.js
@@ -3028,6 +3028,8 @@ function _renderTreeItems(container, entries, depth){
   for(const item of entries){
     const el=document.createElement('div');el.className='file-item';
     el.style.paddingLeft=(8+depth*16)+'px';
+    el.setAttribute('draggable','true');
+    el.ondragstart=(e)=>{e.dataTransfer.setData('application/ws-path',item.path);e.dataTransfer.setData('application/ws-type',item.type);e.dataTransfer.effectAllowed='copy';};
 
     if(item.type==='dir'){
       // Toggle arrow for directories

--- a/tests/test_issue1097_workspace_drag_drop.py
+++ b/tests/test_issue1097_workspace_drag_drop.py
@@ -1,0 +1,87 @@
+"""Tests for #1097 — drag & drop workspace files into chat composer."""
+import re
+
+
+def _src(name: str) -> str:
+    with open(f"static/{name}") as f:
+        return f.read()
+
+
+class TestWorkspaceDragDrop:
+    """File tree items are draggable and composer accepts workspace drops."""
+
+    def test_renderTreeItems_makes_items_draggable(self):
+        """Each file-item must have draggable='true'."""
+        src = _src("ui.js")
+        assert "el.setAttribute('draggable','true')" in src, \
+            "_renderTreeItems must set draggable=true on each item"
+
+    def test_dragstart_stores_ws_path(self):
+        """dragstart must store 'application/ws-path' with item.path."""
+        src = _src("ui.js")
+        assert "application/ws-path" in src, \
+            "dragstart must setData with application/ws-path"
+        assert "item.path" in src, \
+            "dragstart must include item.path in data transfer"
+
+    def test_dragstart_stores_ws_type(self):
+        """dragstart must store 'application/ws-type' (file or dir)."""
+        src = _src("ui.js")
+        assert "application/ws-type" in src, \
+            "dragstart must setData with application/ws-type"
+
+    def test_dragstart_effectAllowed_copy(self):
+        """Drag effect must be 'copy' (not move — we insert a reference)."""
+        src = _src("ui.js")
+        assert "effectAllowed='copy'" in src, \
+            "dragstart must set effectAllowed to 'copy'"
+
+    def test_drop_handler_checks_ws_path(self):
+        """Global drop handler must check for application/ws-path first."""
+        src = _src("panels.js")
+        m = re.search(r"document\.addEventListener\('drop'", src)
+        assert m, "Global drop listener must exist"
+        after = src[m.start():m.start() + 2000]
+        assert "application/ws-path" in after, \
+            "Drop handler must check for workspace path data"
+
+    def test_workspace_drop_inserts_at_path(self):
+        """Workspace drop must insert @path into composer textarea."""
+        src = _src("panels.js")
+        m = re.search(r"document\.addEventListener\('drop'", src)
+        after = src[m.start():m.start() + 2000]
+        # Must insert @-prefixed path
+        assert "'@'+wsPath" in after or '"@"+wsPath' in after or "@"+"" in after, \
+            "Workspace drop must insert @-prefixed path into composer"
+        # Must position cursor after insert
+        assert "selectionStart" in after, \
+            "Drop handler must update cursor position"
+        # Must focus composer
+        assert "msgEl.focus()" in after or "$('msg').focus()" in after, \
+            "Drop handler must focus the composer textarea"
+
+    def test_workspace_drop_has_prefix_logic(self):
+        """Workspace drop should add space prefix if cursor is mid-word."""
+        src = _src("panels.js")
+        m = re.search(r"document\.addEventListener\('drop'", src)
+        after = src[m.start():m.start() + 2000]
+        assert "prefix" in after.lower(), \
+            "Drop handler should handle spacing between existing text and @path"
+
+    def test_dragenter_accepts_ws_path(self):
+        """dragenter must highlight composer for workspace drags too."""
+        src = _src("panels.js")
+        # Find dragenter listener
+        m = re.search(r"document\.addEventListener\('dragenter'", src)
+        assert m, "dragenter listener must exist"
+        after = src[m.start():m.start() + 300]
+        assert "application/ws-path" in after, \
+            "dragenter must also trigger for workspace drags (application/ws-path)"
+
+    def test_os_file_drop_still_works(self):
+        """OS file drag (dataTransfer.files) must still attach files."""
+        src = _src("panels.js")
+        m = re.search(r"document\.addEventListener\('drop'", src)
+        after = src[m.start():m.start() + 2000]
+        assert "addFiles(files)" in after, \
+            "OS file drop path (addFiles) must still work after workspace drop addition"


### PR DESCRIPTION
## Summary

Fixes #1097

Files and folders in the workspace file tree are now draggable. Dropping them into the composer inserts `@path` reference at cursor position. OS file drag-and-drop (attach files) still works.

## Changes

- **`static/ui.js`**: `_renderTreeItems()` sets `draggable='true'` + `dragstart` handler with `application/ws-path` and `application/ws-type` data transfer
- **`static/panels.js`**: Global drop handler checks for `application/ws-path` first. If present, inserts `@path` at cursor position with smart spacing (adds space if cursor is mid-word). Falls back to OS file attachment for regular file drops.
- **`tests/test_issue1097_workspace_drag_drop.py`**: 9 regression tests

## Behavior

| Source | Drop target | Action |
|--------|-------------|--------|
| Workspace file | Composer | Insert `@path/to/file` at cursor |
| Workspace folder | Composer | Insert `@path/to/folder` at cursor |
| OS file | Composer | Attach file (existing behavior) |

## Testing

```
9 passed
```