### PR TITLE
v0.50.223: model picker, idle retry, drag-drop, CSP, clipboard copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@
 
 ### Fixed
 
+## v0.50.223 — 2026-04-26
+
+### Added
+- **Drag & drop workspace files into composer** — files and folders in the workspace file tree are now draggable; dropping them into the chat composer inserts an `@path` reference at the cursor with smart spacing. OS file drag-and-drop (attach files) still works as before. (`static/ui.js`, `static/panels.js`) [#1123 @bergeouss] Closes #1097
+- **Composer placeholder reflects active profile** — when a named profile is active (not `default`), the composer placeholder and title bar show the profile name (capitalised) instead of the global `bot_name`; falls back to `bot_name`/Hermes for the default profile. (`static/boot.js`, `static/panels.js`) [#1122 @bergeouss] Closes #1116
+
+### Fixed
+- **Copy buttons — clipboard-write Permissions-Policy** — added `clipboard-write=(self)` to the `Permissions-Policy` header so Firefox allows `navigator.clipboard.writeText()`. Extracted `_fallbackCopy()` with explicit `focus()` before `select()` and correct visible-but-hidden positioning (no more `-9999px` offscreen failure). (`api/helpers.py`, `static/ui.js`) [#1125 @bergeouss] Closes #1096
+- **Model picker shows all configured providers** — `XAI_API_KEY` and `MISTRAL_API_KEY` env vars now map to `x-ai` and `mistralai` respectively. Providers configured in `config.yaml` under `providers:` are also detected and shown in the model picker. (`api/config.py`) [#1126 @bergeouss] Partially closes #604
+- **api() retries on stale keep-alive after idle** — after a long idle period, `fetch()` throws a `TypeError` when the TCP connection has been dropped by a NAT or proxy timeout. `api()` in `workspace.js` now retries up to 3 times on `TypeError` only; 4xx/5xx HTTP errors and 401 redirects are not retried. (`static/workspace.js`) [#1121 @bergeouss] Closes #1118
+- **Google Fonts allowed in CSP** — Mermaid themes inject `@import url(fonts.googleapis.com)` at render time; the CSP `style-src` and `font-src` directives now include `fonts.googleapis.com` and `fonts.gstatic.com`. (`api/helpers.py`) [#1121 @bergeouss] Closes #1112
+
 ## v0.50.221 — 2026-04-26
 
 ### Fixed

--- a/api/config.py
+++ b/api/config.py
@@ -1413,6 +1413,8 @@ def get_available_models() -> dict:
                 "OPENCODE_GO_API_KEY",
                 "MINIMAX_API_KEY",
                 "MINIMAX_CN_API_KEY",
+                "XAI_API_KEY",
+                "MISTRAL_API_KEY",
             ):
                 val = os.getenv(k)
                 if val:
@@ -1435,10 +1437,23 @@ def get_available_models() -> dict:
                 detected_providers.add("minimax")
             if all_env.get("DEEPSEEK_API_KEY"):
                 detected_providers.add("deepseek")
+            if all_env.get("XAI_API_KEY"):
+                detected_providers.add("x-ai")
+            if all_env.get("MISTRAL_API_KEY"):
+                detected_providers.add("mistralai")
             if all_env.get("OPENCODE_ZEN_API_KEY"):
                 detected_providers.add("opencode-zen")
             if all_env.get("OPENCODE_GO_API_KEY"):
                 detected_providers.add("opencode-go")
+
+        # Also detect providers explicitly listed in config.yaml providers section.
+        # A user may configure a provider key via config.yaml providers.<name>.api_key
+        # without setting the corresponding env var. (#604)
+        _cfg_providers = cfg.get("providers", {})
+        if isinstance(_cfg_providers, dict):
+            for _pid_key in _cfg_providers:
+                if _pid_key in _PROVIDER_MODELS:
+                    detected_providers.add(_pid_key)
 
         # 4. Fetch models from custom endpoint if base_url is configured
         auto_detected_models = []

--- a/api/helpers.py
+++ b/api/helpers.py
@@ -51,7 +51,7 @@ def _security_headers(handler):
     )
     handler.send_header(
         'Permissions-Policy',
-        'camera=(), microphone=(self), geolocation=()'
+        'camera=(), microphone=(self), geolocation=(), clipboard-write=(self)'
     )
 
 

--- a/api/helpers.py
+++ b/api/helpers.py
@@ -44,8 +44,8 @@ def _security_headers(handler):
         'Content-Security-Policy',
         "default-src 'self' https://*.cloudflareaccess.com; "
         "script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://static.cloudflareinsights.com; "
-        "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; "
-        "img-src 'self' data: https: blob:; font-src 'self' data: https://cdn.jsdelivr.net; connect-src 'self'; "
+        "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://fonts.googleapis.com; "
+        "img-src 'self' data: https: blob:; font-src 'self' data: https://cdn.jsdelivr.net https://fonts.gstatic.com; connect-src 'self'; "
         "manifest-src 'self' https://*.cloudflareaccess.com; "
         "base-uri 'self'; form-action 'self'"
     )

--- a/static/boot.js
+++ b/static/boot.js
@@ -768,7 +768,15 @@ function _buildSkinPicker(activeSkin){
 }
 
 function applyBotName(){
-  const name=window._botName||'Hermes';
+  // Prefer profile name over global bot_name for personalised placeholder.
+  // If activeProfile is set and not 'default', use it (capitalised).
+  // Falls back to window._botName (global bot_name setting) or 'Hermes'.
+  let name;
+  if(S.activeProfile && S.activeProfile!=='default'){
+    name=S.activeProfile.charAt(0).toUpperCase()+S.activeProfile.slice(1);
+  }else{
+    name=window._botName||'Hermes';
+  }
   document.title=name;
   const sidebarH1=document.querySelector('.sidebar-header h1');
   if(sidebarH1) sidebarH1.textContent=name;

--- a/static/panels.js
+++ b/static/panels.js
@@ -2116,9 +2116,29 @@ async function loadMemory(force) {
 // Drag and drop
 const wrap=$('composerWrap');let dragCounter=0;
 document.addEventListener('dragover',e=>e.preventDefault());
-document.addEventListener('dragenter',e=>{e.preventDefault();if(e.dataTransfer.types.includes('Files')){dragCounter++;wrap.classList.add('drag-over');}});
+document.addEventListener('dragenter',e=>{e.preventDefault();if(e.dataTransfer.types.includes('Files')||e.dataTransfer.types.includes('application/ws-path')){dragCounter++;wrap.classList.add('drag-over');}});
 document.addEventListener('dragleave',e=>{dragCounter--;if(dragCounter<=0){dragCounter=0;wrap.classList.remove('drag-over');}});
-document.addEventListener('drop',e=>{e.preventDefault();dragCounter=0;wrap.classList.remove('drag-over');const files=Array.from(e.dataTransfer.files);if(files.length){addFiles(files);$('msg').focus();}});
+document.addEventListener('drop',e=>{
+  e.preventDefault();dragCounter=0;wrap.classList.remove('drag-over');
+  // Workspace file/folder drag → insert @path reference into composer
+  const wsPath=e.dataTransfer.getData('application/ws-path');
+  if(wsPath){
+    const msgEl=$('msg');
+    if(msgEl){
+      const start=msgEl.selectionStart;const end=msgEl.selectionEnd;
+      const val=msgEl.value;
+      const prefix=start>0&&!val[start-1].match(/\s/)?' ':'';
+      const insert=prefix+'@'+wsPath+' ';
+      msgEl.value=val.slice(0,start)+insert+val.slice(end);
+      msgEl.selectionStart=msgEl.selectionEnd=start+insert.length;
+      msgEl.focus();
+    }
+    return;
+  }
+  // OS file drag → attach files
+  const files=Array.from(e.dataTransfer.files);
+  if(files.length){addFiles(files);$('msg').focus();}
+});
 
 // ── Settings panel ───────────────────────────────────────────────────────────
 

--- a/static/panels.js
+++ b/static/panels.js
@@ -1981,6 +1981,9 @@ async function switchToProfile(name) {
     if (_currentPanel === 'profiles') await loadProfilesPanel();
     if (_currentPanel === 'workspaces') await loadWorkspacesPanel();
 
+    // Update composer placeholder and title bar to reflect profile name
+    if (typeof applyBotName === 'function') applyBotName();
+
   } catch (e) { showToast(t('switch_failed') + e.message); }
 }
 

--- a/static/ui.js
+++ b/static/ui.js
@@ -3028,6 +3028,8 @@ function _renderTreeItems(container, entries, depth){
   for(const item of entries){
     const el=document.createElement('div');el.className='file-item';
     el.style.paddingLeft=(8+depth*16)+'px';
+    el.setAttribute('draggable','true');
+    el.ondragstart=(e)=>{e.dataTransfer.setData('application/ws-path',item.path);e.dataTransfer.setData('application/ws-type',item.type);e.dataTransfer.effectAllowed='copy';};
 
     if(item.type==='dir'){
       // Toggle arrow for directories

--- a/static/ui.js
+++ b/static/ui.js
@@ -1528,12 +1528,19 @@ function showPromptDialog(opts={}){
 
 function _copyText(text){
   if(navigator.clipboard && window.isSecureContext){
-    return navigator.clipboard.writeText(text);
+    return navigator.clipboard.writeText(text).catch(()=>{
+      // Fallback if clipboard API fails (e.g. permissions)
+      return _fallbackCopy(text);
+    });
   }
+  return _fallbackCopy(text);
+}
+function _fallbackCopy(text){
   return new Promise((resolve,reject)=>{
     const ta=document.createElement('textarea');
-    ta.value=text;ta.style.cssText='position:fixed;left:-9999px;top:-9999px;opacity:0';
-    document.body.appendChild(ta);ta.select();
+    ta.value=text;ta.style.cssText='position:fixed;left:0;top:0;width:2em;height:2em;padding:0;border:none;outline:none;box-shadow:none;background:transparent;z-index:-1';
+    document.body.appendChild(ta);
+    ta.focus();ta.select();
     try{document.execCommand('copy');resolve();}
     catch(e){reject(e);}
     finally{document.body.removeChild(ta);}

--- a/static/workspace.js
+++ b/static/workspace.js
@@ -2,20 +2,35 @@ async function api(path,opts={}){
   // Strip leading slash so URL resolves relative to location.href (supports subpath mounts)
   const rel = path.startsWith('/') ? path.slice(1) : path;
   const url=new URL(rel,location.href);
-  const res=await fetch(url.href,{credentials:'include',headers:{'Content-Type':'application/json'},...opts});
-  if(!res.ok){
-    // 401 means the auth session expired. Redirect to /login so the user can
-    // re-authenticate. This is especially important for iOS PWA (standalone mode)
-    // where a server-side 302 → /login opens in Safari instead of within the PWA.
-    if(res.status===401){window.location.href='/login?next='+encodeURIComponent(window.location.pathname+window.location.search);return;}
-    const text=await res.text();
-    // Parse JSON error body and surface the human-readable message,
-    // rather than showing raw JSON like {"error":"Profile 'x' does not exist."}
-    try{const j=JSON.parse(text);throw new Error(j.error||j.message||text);}
-    catch(e){if(e instanceof SyntaxError)throw new Error(text);throw e;}
+  // Retry up to 2 times on network errors (e.g. stale keep-alive after long idle).
+  // Server errors (4xx/5xx) are NOT retried — only connection failures.
+  let lastErr;
+  for(let attempt=0;attempt<3;attempt++){
+    try{
+      const res=await fetch(url.href,{credentials:'include',headers:{'Content-Type':'application/json'},...opts});
+      if(!res.ok){
+        // 401 means the auth session expired. Redirect to /login so the user can
+        // re-authenticate. This is especially important for iOS PWA (standalone mode)
+        // where a server-side 302 → /login opens in Safari instead of within the PWA.
+        if(res.status===401){window.location.href='/login?next='+encodeURIComponent(window.location.pathname+window.location.search);return;}
+        const text=await res.text();
+        // Parse JSON error body and surface the human-readable message,
+        // rather than showing raw JSON like {"error":"Profile 'x' does not exist."}
+        try{const j=JSON.parse(text);throw new Error(j.error||j.message||text);}
+        catch(e){if(e instanceof SyntaxError)throw new Error(text);throw e;}
+      }
+      const ct=res.headers.get('content-type')||'';
+      return ct.includes('application/json')?res.json():res.text();
+    }catch(e){
+      lastErr=e;
+      // Only retry on network errors (TypeError from fetch), not on HTTP errors
+      // that were already thrown above. Re-throw 401 redirects immediately.
+      if(e.message&&/401/.test(e.message)) throw e;
+      if(attempt<2 && e instanceof TypeError) continue;
+      throw e;
+    }
   }
-  const ct=res.headers.get('content-type')||'';
-  return ct.includes('application/json')?res.json():res.text();
+  throw lastErr;
 }
 
 // Persist/restore expanded directory state per workspace in localStorage

--- a/tests/test_issue1096_copy_buttons.py
+++ b/tests/test_issue1096_copy_buttons.py
@@ -1,100 +1,103 @@
-"""Tests for #1096 — copy buttons work without HTTPS (execCommand fallback)."""
-import os
+"""Tests for #1096 — copy buttons work via Permissions-Policy + fallback."""
 import re
-import pytest
 
 
-# ── Helpers ─────────────────────────────────────────────────────────────────────
-
-def _read_js(name):
-    path = os.path.join('static', name)
-    with open(path) as f:
+def _src(name: str) -> str:
+    with open(f"static/{name}") as f:
         return f.read()
 
 
-def _read_i18n():
-    return _read_js('i18n.js')
+def _py_src() -> str:
+    with open("api/helpers.py") as f:
+        return f.read()
 
 
-def _read_ui():
-    return _read_js('ui.js')
+class TestClipboardPermissions:
+    """Permissions-Policy must allow clipboard-write for the origin."""
+
+    def test_permissions_policy_includes_clipboard_write(self):
+        """Permissions-Policy header must include clipboard-write=(self)."""
+        src = _py_src()
+        # Match the Permissions-Policy value string (may span lines)
+        m = re.search(r"Permissions-Policy',\s*'(.*?)'", src, re.DOTALL)
+        assert m, "Permissions-Policy header value must exist"
+        assert "clipboard-write=(self)" in m.group(1), \
+            "Permissions-Policy must include clipboard-write=(self)"
 
 
-# ── _copyText helper ────────────────────────────────────────────────────────────
+class TestCopyTextFunction:
+    """_copyText must use clipboard API with fallback to execCommand."""
 
-class TestCopyTextHelperExists:
-    """_copyText() helper must exist with secure context check + execCommand fallback."""
+    def test_copyText_uses_clipboard_api(self):
+        """_copyText must call navigator.clipboard.writeText."""
+        src = _src("ui.js")
+        assert "navigator.clipboard.writeText(text)" in src, \
+            "_copyText must use Clipboard API"
 
-    def test_function_exists(self):
-        ui = _read_ui()
-        assert 'function _copyText(' in ui, '_copyText helper missing from ui.js'
+    def test_copyText_has_fallback(self):
+        """_copyText must fall back to execCommand if clipboard API fails."""
+        src = _src("ui.js")
+        assert "function _fallbackCopy" in src, \
+            "Must have a separate _fallbackCopy function"
+        # Clipboard API call must .catch() to fallback
+        m = re.search(r"navigator\.clipboard\.writeText\(text\)", src)
+        assert m, "Must call clipboard API"
+        after = src[m.start():m.start() + 300]
+        assert "_fallbackCopy" in after, \
+            "clipboard.writeText must .catch() → _fallbackCopy"
 
-    def test_uses_secure_context_check(self):
-        ui = _read_ui()
-        assert 'isSecureContext' in ui, 'isSecureContext check missing — fallback wont trigger on HTTP'
+    def test_fallbackCopy_uses_execCommand(self):
+        """_fallbackCopy must use document.execCommand('copy')."""
+        src = _src("ui.js")
+        assert "document.execCommand('copy')" in src, \
+            "_fallbackCopy must use execCommand('copy')"
 
-    def test_uses_exec_command_fallback(self):
-        ui = _read_ui()
-        assert 'execCommand' in ui, 'execCommand fallback missing — copy fails on HTTP'
+    def test_fallbackCopy_focuses_textarea(self):
+        """_fallbackCopy must explicitly focus textarea before select()."""
+        src = _src("ui.js")
+        # Find _fallbackCopy function
+        m = re.search(r"function _fallbackCopy", src)
+        assert m, "_fallbackCopy function must exist"
+        fn = src[m.start():m.start() + 600]
+        assert "ta.focus()" in fn, \
+            "Must call .focus() on textarea before .select()"
 
+    def test_fallbackCopy_not_offscreen(self):
+        """_fallbackCopy textarea must NOT be positioned at -9999px (fails in some browsers)."""
+        src = _src("ui.js")
+        m = re.search(r"function _fallbackCopy", src)
+        fn = src[m.start():m.start() + 600]
+        assert "-9999" not in fn, \
+            "Textarea must not be positioned at -9999px (offscreen select fails)"
 
-# ── copyMsg() uses helper ──────────────────────────────────────────────────────
-
-class TestCopyMsgUsesHelper:
-
-    def test_copy_msg_exists(self):
-        ui = _read_ui()
-        assert 'function copyMsg(' in ui
-
-    def test_copy_msg_calls_helper_not_clipboard_directly(self):
-        """copyMsg must use _copyText, not navigator.clipboard.writeText."""
-        ui = _read_ui()
-        # Find copyMsg function body
-        m = re.search(r'function copyMsg\(', ui)
-        assert m, 'copyMsg function not found'
-        body = ui[m.start():m.start() + 600]
-        assert '_copyText(' in body, 'copyMsg must call _copyText helper'
-        assert 'navigator.clipboard.writeText' not in body, 'copyMsg must NOT call navigator.clipboard directly'
-
-    def test_copy_msg_has_i18n_error(self):
-        """Error message must use t() for i18n, not hardcoded string."""
-        ui = _read_ui()
-        m = re.search(r'function copyMsg\(', ui)
-        body = ui[m.start():m.start() + 600]
-        assert "t('copy_failed')" in body, 'copyMsg error must use t("copy_failed") not hardcoded string'
-
-
-# ── Code block copy uses helper ────────────────────────────────────────────────
-
-class TestCodeBlockCopyUsesHelper:
-
-    def test_add_copy_buttons_exists(self):
-        ui = _read_ui()
-        assert 'function addCopyButtons(' in ui
-
-    def test_code_copy_calls_helper(self):
-        """addCopyButtons must use _copyText, not navigator.clipboard directly."""
-        ui = _read_ui()
-        m = re.search(r'function addCopyButtons\(', ui)
-        assert m, 'addCopyButtons function not found'
-        body = ui[m.start():m.start() + 2000]
-        assert '_copyText(' in body, 'addCopyButtons must call _copyText helper'
-        assert 'navigator.clipboard.writeText' not in body, 'addCopyButtons must NOT call navigator.clipboard directly'
-
-    def test_code_copy_has_catch_handler(self):
-        """Code block copy must have .catch() — previously had none (silent failure)."""
-        ui = _read_ui()
-        m = re.search(r'function addCopyButtons\(', ui)
-        body = ui[m.start():m.start() + 2000]
-        assert '.catch(' in body, 'Code block copy button has no .catch() handler'
+    def test_copyMsg_copies_raw_text(self):
+        """copyMsg must extract text from data-raw-text attribute."""
+        src = _src("ui.js")
+        assert "closest('[data-raw-text]')" in src, \
+            "copyMsg must find nearest element with data-raw-text"
+        assert "dataset.rawText" in src, \
+            "copyMsg must read rawText from dataset"
 
 
-# ── i18n ────────────────────────────────────────────────────────────────────────
+class TestCodeCopyButton:
+    """Code block copy button must also use _copyText."""
+
+    def test_code_copy_uses_copyText(self):
+        """Code copy button onclick must call _copyText."""
+        src = _src("ui.js")
+        # Find addCopyButtons function
+        m = re.search(r"function addCopyButtons", src)
+        assert m, "addCopyButtons must exist"
+        fn = src[m.start():m.start() + 800]
+        assert "_copyText" in fn, \
+            "Code copy button must use _copyText function"
+        assert "codeEl.textContent" in fn, \
+            "Code copy must copy the code element's textContent"
 
 class TestCopyFailedI18n:
 
     def test_copy_failed_in_all_locales(self):
         """copy_failed key must exist in all locale blocks (currently 7 with Korean)."""
-        i18n = _read_i18n()
+        i18n = _src('i18n.js')
         count = i18n.count('copy_failed')
         assert count >= 6, f'Expected copy_failed in at least 6 locale blocks, found {count}'

--- a/tests/test_issue1097_workspace_drag_drop.py
+++ b/tests/test_issue1097_workspace_drag_drop.py
@@ -1,0 +1,87 @@
+"""Tests for #1097 — drag & drop workspace files into chat composer."""
+import re
+
+
+def _src(name: str) -> str:
+    with open(f"static/{name}") as f:
+        return f.read()
+
+
+class TestWorkspaceDragDrop:
+    """File tree items are draggable and composer accepts workspace drops."""
+
+    def test_renderTreeItems_makes_items_draggable(self):
+        """Each file-item must have draggable='true'."""
+        src = _src("ui.js")
+        assert "el.setAttribute('draggable','true')" in src, \
+            "_renderTreeItems must set draggable=true on each item"
+
+    def test_dragstart_stores_ws_path(self):
+        """dragstart must store 'application/ws-path' with item.path."""
+        src = _src("ui.js")
+        assert "application/ws-path" in src, \
+            "dragstart must setData with application/ws-path"
+        assert "item.path" in src, \
+            "dragstart must include item.path in data transfer"
+
+    def test_dragstart_stores_ws_type(self):
+        """dragstart must store 'application/ws-type' (file or dir)."""
+        src = _src("ui.js")
+        assert "application/ws-type" in src, \
+            "dragstart must setData with application/ws-type"
+
+    def test_dragstart_effectAllowed_copy(self):
+        """Drag effect must be 'copy' (not move — we insert a reference)."""
+        src = _src("ui.js")
+        assert "effectAllowed='copy'" in src, \
+            "dragstart must set effectAllowed to 'copy'"
+
+    def test_drop_handler_checks_ws_path(self):
+        """Global drop handler must check for application/ws-path first."""
+        src = _src("panels.js")
+        m = re.search(r"document\.addEventListener\('drop'", src)
+        assert m, "Global drop listener must exist"
+        after = src[m.start():m.start() + 2000]
+        assert "application/ws-path" in after, \
+            "Drop handler must check for workspace path data"
+
+    def test_workspace_drop_inserts_at_path(self):
+        """Workspace drop must insert @path into composer textarea."""
+        src = _src("panels.js")
+        m = re.search(r"document\.addEventListener\('drop'", src)
+        after = src[m.start():m.start() + 2000]
+        # Must insert @-prefixed path
+        assert "'@'+wsPath" in after or '"@"+wsPath' in after or "@"+"" in after, \
+            "Workspace drop must insert @-prefixed path into composer"
+        # Must position cursor after insert
+        assert "selectionStart" in after, \
+            "Drop handler must update cursor position"
+        # Must focus composer
+        assert "msgEl.focus()" in after or "$('msg').focus()" in after, \
+            "Drop handler must focus the composer textarea"
+
+    def test_workspace_drop_has_prefix_logic(self):
+        """Workspace drop should add space prefix if cursor is mid-word."""
+        src = _src("panels.js")
+        m = re.search(r"document\.addEventListener\('drop'", src)
+        after = src[m.start():m.start() + 2000]
+        assert "prefix" in after.lower(), \
+            "Drop handler should handle spacing between existing text and @path"
+
+    def test_dragenter_accepts_ws_path(self):
+        """dragenter must highlight composer for workspace drags too."""
+        src = _src("panels.js")
+        # Find dragenter listener
+        m = re.search(r"document\.addEventListener\('dragenter'", src)
+        assert m, "dragenter listener must exist"
+        after = src[m.start():m.start() + 300]
+        assert "application/ws-path" in after, \
+            "dragenter must also trigger for workspace drags (application/ws-path)"
+
+    def test_os_file_drop_still_works(self):
+        """OS file drag (dataTransfer.files) must still attach files."""
+        src = _src("panels.js")
+        m = re.search(r"document\.addEventListener\('drop'", src)
+        after = src[m.start():m.start() + 2000]
+        assert "addFiles(files)" in after, \
+            "OS file drop path (addFiles) must still work after workspace drop addition"

--- a/tests/test_issue1112_csp_google_fonts.py
+++ b/tests/test_issue1112_csp_google_fonts.py
@@ -1,0 +1,49 @@
+"""Tests for #1112 — CSP allows Google Fonts stylesheet and font files."""
+import re
+
+
+def _helpers_src() -> str:
+    with open("api/helpers.py") as f:
+        return f.read()
+
+
+class TestCSPGoogleFonts:
+    """style-src and font-src must allow fonts.googleapis.com / fonts.gstatic.com."""
+
+    def test_style_src_includes_google_fonts(self):
+        """style-src must include https://fonts.googleapis.com for Google Fonts CSS."""
+        src = _helpers_src()
+        assert "https://fonts.googleapis.com" in src, \
+            "style-src must allow fonts.googleapis.com (Google Fonts stylesheets)"
+        # Must be in the style-src directive, not accidentally elsewhere
+        style_match = re.search(r"style-src\s+([^;]+);", src)
+        assert style_match, "style-src directive must exist"
+        assert "fonts.googleapis.com" in style_match.group(1), \
+            "fonts.googleapis.com must be in style-src directive"
+
+    def test_font_src_includes_fonts_gstatic(self):
+        """font-src must include https://fonts.gstatic.com for Google Font files."""
+        src = _helpers_src()
+        assert "https://fonts.gstatic.com" in src, \
+            "font-src must allow fonts.gstatic.com (Google Font WOFF2/WOFF files)"
+        # Must be in the font-src directive
+        font_match = re.search(r"font-src\s+([^;]+);", src)
+        assert font_match, "font-src directive must exist"
+        assert "fonts.gstatic.com" in font_match.group(1), \
+            "fonts.gstatic.com must be in font-src directive"
+
+    def test_existing_csp_directives_preserved(self):
+        """All pre-existing CSP directives must still be present after the fix."""
+        src = _helpers_src()
+        for directive in (
+            "default-src 'self'",
+            "script-src 'self' 'unsafe-inline'",
+            "style-src 'self' 'unsafe-inline'",
+            "img-src 'self' data:",
+            "font-src 'self' data:",
+            "connect-src 'self'",
+            "manifest-src 'self'",
+            "base-uri 'self'",
+            "form-action 'self'",
+        ):
+            assert directive in src, f"CSP must still contain: {directive}"

--- a/tests/test_issue1116_composer_placeholder.py
+++ b/tests/test_issue1116_composer_placeholder.py
@@ -1,0 +1,60 @@
+"""Tests for #1116 — composer placeholder reflects active profile name."""
+import re
+
+
+def _src(name: str) -> str:
+    with open(f"static/{name}") as f:
+        return f.read()
+
+
+class TestComposerPlaceholderProfile:
+    """applyBotName() should use the profile name when activeProfile is set."""
+
+    def test_applyBotName_uses_profile_name(self):
+        """applyBotName must check S.activeProfile and prefer it over global bot_name."""
+        src = _src("boot.js")
+        assert "S.activeProfile" in src, \
+            "applyBotName must reference S.activeProfile"
+        # Should fall back to _botName when activeProfile is 'default'
+        assert "S.activeProfile!=='default'" in src, \
+            "applyBotName must skip 'default' profile (use bot_name instead)"
+
+    def test_applyBotName_capitalises_profile_name(self):
+        """Profile name should be capitalised (first letter uppercase)."""
+        src = _src("boot.js")
+        m = re.search(r'function applyBotName\(\)\{.*?\n\}', src, re.DOTALL)
+        assert m, "applyBotName function must exist"
+        body = m.group(0)
+        assert "charAt(0).toUpperCase()" in body, \
+            "applyBotName must capitalise first letter of profile name"
+
+    def test_applyBotName_falls_back_to_bot_name(self):
+        """When no active profile, must fall back to window._botName."""
+        src = _src("boot.js")
+        m = re.search(r'function applyBotName\(\)\{.*?\n\}', src, re.DOTALL)
+        assert m, "applyBotName function must exist"
+        body = m.group(0)
+        assert "window._botName||'Hermes'" in body, \
+            "applyBotName must fall back to window._botName or 'Hermes'"
+
+    def test_switchToProfile_calls_applyBotName(self):
+        """switchToProfile() must call applyBotName() after switching."""
+        src = _src("panels.js")
+        assert "function switchToProfile" in src, \
+            "switchToProfile function must exist"
+        # Find the function block (starts with 'async function switchToProfile')
+        m = re.search(r'async function switchToProfile\s*\(', src)
+        assert m, "switchToProfile must be an async function"
+        # Get everything after the function declaration (enough context)
+        after = src[m.start():m.start()+5000]
+        assert "applyBotName" in after, \
+            "switchToProfile must call applyBotName after profile switch"
+
+    def test_placeholder_uses_name_variable(self):
+        """The composer placeholder must use the resolved name variable."""
+        src = _src("boot.js")
+        m = re.search(r'function applyBotName\(\)\{.*?\n\}', src, re.DOTALL)
+        assert m, "applyBotName function must exist"
+        body = m.group(0)
+        assert re.search(r"msg\.placeholder\s*=\s*.*Message.*name", body), \
+            "applyBotName must set composer placeholder to 'Message <name>…'"

--- a/tests/test_issue1118_idle_session_retry.py
+++ b/tests/test_issue1118_idle_session_retry.py
@@ -1,0 +1,66 @@
+"""Tests for #1118 — api() retries on network errors (stale keep-alive after idle)."""
+import re
+
+
+def _src() -> str:
+    with open("static/workspace.js") as f:
+        return f.read()
+
+
+class TestApiRetryOnNetworkError:
+    """The api() function in workspace.js should retry on fetch TypeError (network failure)."""
+
+    def test_api_function_has_retry_loop(self):
+        """api() must contain a retry loop (for/while with attempt counter)."""
+        src = _src()
+        assert re.search(r'for\s*\(\s*let\s+\w+\s*=\s*0\s*;', src), \
+            "api() must have a for loop with attempt counter"
+
+    def test_api_retries_on_typeerror(self):
+        """api() must retry when fetch throws TypeError (network failure)."""
+        src = _src()
+        # Find the api function body
+        m = re.search(r'async function api\(path,opts.*?\n\}(?!\n[\s]*function)', src, re.DOTALL)
+        assert m, "api() function must exist"
+        body = m.group(0)
+        assert 'TypeError' in body, \
+            "api() must check for TypeError to detect network failures"
+        assert 'attempt' in body, \
+            "api() must track attempt count for retry logic"
+
+    def test_api_does_not_retry_http_errors(self):
+        """api() must NOT retry on HTTP error responses (4xx/5xx) — only network failures."""
+        src = _src()
+        m = re.search(r'async function api\(path,opts.*?\n\}(?!\n[\s]*function)', src, re.DOTALL)
+        assert m, "api() function must exist"
+        body = m.group(0)
+        # The retry should be in catch block (after res.ok check), not in the ok path
+        # HTTP errors throw Error (not TypeError), so only TypeError triggers retry
+        assert 'e instanceof TypeError' in body, \
+            "api() retry must be limited to TypeError (network errors), not all errors"
+
+    def test_api_max_3_attempts(self):
+        """api() must limit retries (max 3 attempts total = 1 initial + 2 retries)."""
+        src = _src()
+        m = re.search(r'async function api\(path,opts.*?\n\}(?!\n[\s]*function)', src, re.DOTALL)
+        assert m, "api() function must exist"
+        body = m.group(0)
+        # Should have attempt < 2 (0, 1, 2 = 3 attempts max)
+        assert re.search(r'attempt\s*<\s*2', body), \
+            "api() must limit to 3 attempts max (attempt < 2)"
+
+    def test_api_preserves_401_redirect(self):
+        """api() must still redirect to /login on 401 (auth expired)."""
+        src = _src()
+        assert "res.status===401" in src, \
+            "api() must still check for 401 status"
+        assert "/login?next=" in src, \
+            "api() must still redirect to /login on 401"
+
+    def test_api_preserves_error_parsing(self):
+        """api() must still parse JSON error bodies for non-200 responses."""
+        src = _src()
+        assert "JSON.parse(text)" in src, \
+            "api() must still parse JSON error responses"
+        assert "res.json()" in src, \
+            "api() must still parse JSON success responses"

--- a/tests/test_issue604_all_providers_model_picker.py
+++ b/tests/test_issue604_all_providers_model_picker.py
@@ -1,0 +1,106 @@
+"""Tests for #604 — model picker shows all configured providers."""
+import re
+
+
+def _src() -> str:
+    with open("api/config.py") as f:
+        return f.read()
+
+
+def _get_provider_models_keys() -> set:
+    """Extract top-level provider keys from _PROVIDER_MODELS dict."""
+    with open("api/config.py") as f:
+        lines = f.readlines()
+    keys = []
+    in_dict = False
+    for line in lines:
+        if "_PROVIDER_MODELS = {" in line:
+            in_dict = True
+            continue
+        if in_dict:
+            m = re.match(r'^    "([^"]+)":\s*\[', line)
+            if m:
+                keys.append(m.group(1))
+            if re.match(r'^\}', line):
+                break
+    return set(keys)
+
+
+_PROVIDER_MODELS_KEYS = _get_provider_models_keys()
+
+
+class TestProviderDetectionEnvVars:
+    """All known env vars should map to valid provider IDs."""
+
+    # Providers that exist but aren't in _PROVIDER_MODELS (use special handling)
+    _SPECIAL_PROVIDERS = {"openrouter", "ollama-cloud", "custom", "ollama", "lmstudio", "local"}
+
+    def test_xai_env_maps_to_xai_provider(self):
+        """XAI_API_KEY should add 'x-ai' (not 'xai')."""
+        src = _src()
+        assert re.search(r'XAI_API_KEY.*?add\("x-ai"\)', src, re.DOTALL), \
+            "XAI_API_KEY must map to provider 'x-ai'"
+
+    def test_mistral_env_maps_to_mistralai_provider(self):
+        """MISTRAL_API_KEY should add 'mistralai' (not 'mistral')."""
+        src = _src()
+        assert re.search(r'MISTRAL_API_KEY.*?add\("mistralai"\)', src, re.DOTALL), \
+            "MISTRAL_API_KEY must map to provider 'mistralai'"
+
+    def test_all_provider_env_vars_map_to_known_providers(self):
+        """Every detected_provider.add() call should reference a known provider."""
+        src = _src()
+        fn = re.search(r'def _build_available_models_uncached', src)
+        fn_block = src[fn.start():fn.start() + 10000]
+        adds = re.findall(r'detected_providers\.add\("([^"]+)"\)', fn_block)
+        unknown = [p for p in adds if p not in _PROVIDER_MODELS_KEYS and p not in self._SPECIAL_PROVIDERS]
+        assert not unknown, \
+            f"Unknown provider IDs in env var detection: {unknown}"
+
+
+class TestConfigProvidersDetection:
+    """Providers listed in config.yaml providers section should be detected."""
+
+    def test_cfg_providers_detection_exists(self):
+        """_build_available_models must scan cfg['providers'] for known providers."""
+        src = _src()
+        assert "cfg.get(\"providers\", {})" in src, \
+            "Must read cfg['providers']"
+        assert "_cfg_providers" in src, \
+            "Must use _cfg_providers variable"
+
+    def test_cfg_providers_only_adds_known(self):
+        """Only providers in _PROVIDER_MODELS should be added from config."""
+        src = _src()
+        # Find the config providers detection block
+        m = re.search(r'Also detect providers explicitly listed', src)
+        assert m, "Comment about config.yaml providers detection must exist"
+        block = src[m.start():m.start() + 500]
+        assert "_PROVIDER_MODELS" in block, \
+            "Config providers detection must check against _PROVIDER_MODELS"
+
+
+class TestProviderModelsCompleteness:
+    """Verify _PROVIDER_MODELS has expected providers."""
+
+    def test_has_anthropic(self):
+        assert "anthropic" in _PROVIDER_MODELS_KEYS
+
+    def test_has_openai(self):
+        assert "openai" in _PROVIDER_MODELS_KEYS
+
+    def test_has_google(self):
+        assert "google" in _PROVIDER_MODELS_KEYS
+
+    def test_has_deepseek(self):
+        assert "deepseek" in _PROVIDER_MODELS_KEYS
+
+    def test_has_xai(self):
+        assert "x-ai" in _PROVIDER_MODELS_KEYS
+
+    def test_has_mistralai(self):
+        assert "mistralai" in _PROVIDER_MODELS_KEYS
+
+    def test_has_openrouter(self):
+        # openrouter uses _FALLBACK_MODELS, not _PROVIDER_MODELS
+        pass  # intentionally no assertion


### PR DESCRIPTION
## v0.50.223 — 5 bugfix/feature PRs

Batch reviewed, fixed, and tested end-to-end on top of v0.50.222.

### Included PRs

| PR | Title | Author | Absorb fixes |
|----|-------|--------|--------------|
| #1126 | fix(#604): model picker shows all configured providers | @bergeouss | None |
| #1121 | fix(#1118): retry api() on network errors after long idle | @bergeouss | Includes #1112 CSP fix (stacked) |
| #1122 | feat(#1116): composer placeholder reflects active profile | @bergeouss | None |
| #1123 | feat(#1097): drag & drop workspace files into composer | @bergeouss | None |
| #1125 | fix(#1096): copy buttons + clipboard-write Permissions-Policy | @bergeouss | Conflict in test_issue1096_copy_buttons.py resolved (kept new comprehensive tests + preserved TestCopyFailedI18n locale regression) |

### Held PRs (not included)

- **#1124** (@JKJameson) — held with detailed comment: composer draft key name mismatch (`S._drafts` vs `S.composerDrafts`) + self-defeating save/delete in same function. Other changes in that PR (dblclick removal, auto-focus, background queue drain) are correct but kept together.
- **#1120** — closed, superseded by #1121.

### Gate results
- pytest: **2572 passed, 0 failed** (2538 baseline + 34 new)
- QA harness: pending (runs on approve + merge)

### What ships
- Model picker now surfaces xAI, Mistral, and any provider in `config.yaml providers:` section
- `api()` transparently retries on stale keep-alive connections (no more "Failed to load session" after idle)
- Google Fonts unblocked in CSP (needed for Mermaid themes)
- Composer placeholder shows active profile name (personalised UX)
- Workspace file tree items are draggable — drop to insert `@path` reference
- Copy buttons work in Firefox (clipboard-write Permissions-Policy) + robust fallback
