### PR TITLE
Fix legacy @provider session models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## [Unreleased]
 
 ### Fixed
+- **Legacy `@provider:model` session models** — persisted sessions with an
+  old explicit provider hint (for example `@copilot:gpt-5.5`) now pass through
+  the same stale-model compatibility recovery as slash-prefixed session models,
+  so they can continue after the active provider changes. (`api/routes.py`)
 
 ## v0.50.223 — 2026-04-26
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -216,6 +216,44 @@ def _normalize_provider_id(value: str | None) -> str:
     return "" 
 
 
+def _catalog_provider_id_sets(catalog: dict) -> tuple[set[str], set[str]]:
+    raw_provider_ids: set[str] = set()
+    normalized_provider_ids: set[str] = set()
+    for group in catalog.get("groups") or []:
+        raw = str(group.get("provider_id") or "").strip().lower()
+        if not raw:
+            continue
+        raw_provider_ids.add(raw)
+        normalized = _normalize_provider_id(raw)
+        if normalized:
+            normalized_provider_ids.add(normalized)
+    return raw_provider_ids, normalized_provider_ids
+
+
+def _catalog_has_provider(
+    provider_raw: str,
+    provider_normalized: str,
+    raw_provider_ids: set[str],
+    normalized_provider_ids: set[str],
+) -> bool:
+    return (
+        provider_raw in raw_provider_ids
+        or (provider_normalized and provider_normalized in raw_provider_ids)
+        or (provider_normalized and provider_normalized in normalized_provider_ids)
+    )
+
+
+def _model_matches_active_provider_family(
+    model: str,
+    active_provider: str,
+) -> bool:
+    model_lower = model.lower()
+    for bare_prefix in ("gpt", "claude", "gemini"):
+        if model_lower.startswith(bare_prefix):
+            return _normalize_provider_id(bare_prefix) == active_provider
+    return False
+
+
 def _resolve_compatible_session_model(model_id: str | None) -> tuple[str, bool]:
     """Return (effective_model, was_normalized) for persisted session models.
 
@@ -239,6 +277,37 @@ def _resolve_compatible_session_model(model_id: str | None) -> tuple[str, bool]:
     # is stale relative to this unknown active provider. (#1023)
     raw_active_provider = str(catalog.get("active_provider") or "").strip().lower()
     if not active_provider and not raw_active_provider:
+        return model, False
+
+    if model.startswith("@") and ":" in model:
+        provider_hint, bare_model = model[1:].split(":", 1)
+        provider_raw = provider_hint.strip().lower()
+        provider_normalized = _normalize_provider_id(provider_raw)
+        bare_model = bare_model.strip()
+        if not provider_raw or not bare_model:
+            return model, False
+
+        raw_provider_ids, normalized_provider_ids = _catalog_provider_id_sets(catalog)
+        hint_matches_active = (
+            provider_raw == raw_active_provider
+            or provider_raw == active_provider
+            or (provider_normalized and provider_normalized == active_provider)
+        )
+        if hint_matches_active:
+            return bare_model, True
+
+        if _catalog_has_provider(
+            provider_raw,
+            provider_normalized,
+            raw_provider_ids,
+            normalized_provider_ids,
+        ):
+            return model, False
+
+        if _model_matches_active_provider_family(bare_model, active_provider):
+            return bare_model, True
+        if default_model:
+            return default_model, True
         return model, False
 
     slash = model.find("/")

--- a/tests/test_provider_mismatch.py
+++ b/tests/test_provider_mismatch.py
@@ -336,6 +336,123 @@ def test_prefixed_google_session_model_normalizes_to_active_provider_default(mon
     assert effective == "gpt-5.4-mini"
 
 
+def test_legacy_at_provider_session_model_normalizes_when_provider_hidden(monkeypatch):
+    """Old @provider:model session values must not bypass stale-model recovery."""
+    import api.routes as routes
+
+    monkeypatch.setattr(
+        routes,
+        "get_available_models",
+        lambda: {
+            "active_provider": "openai-codex",
+            "default_model": "gpt-5.5",
+            "groups": [
+                {
+                    "provider": "OpenAI Codex",
+                    "provider_id": "openai-codex",
+                    "models": [{"id": "gpt-5.5", "label": "GPT-5.5"}],
+                },
+            ],
+        },
+    )
+
+    effective, changed = routes._resolve_compatible_session_model(
+        "@copilot:gpt-5.5"
+    )
+
+    assert changed is True
+    assert effective == "gpt-5.5"
+
+
+def test_active_at_provider_session_model_strips_redundant_hint(monkeypatch):
+    """@active-provider:model is an old persisted form; use the bare model now."""
+    import api.routes as routes
+
+    monkeypatch.setattr(
+        routes,
+        "get_available_models",
+        lambda: {
+            "active_provider": "openai-codex",
+            "default_model": "gpt-5.5",
+            "groups": [
+                {
+                    "provider": "OpenAI Codex",
+                    "provider_id": "openai-codex",
+                    "models": [{"id": "gpt-5.4-mini", "label": "GPT-5.4 Mini"}],
+                },
+            ],
+        },
+    )
+
+    effective, changed = routes._resolve_compatible_session_model(
+        "@openai-codex:gpt-5.4-mini"
+    )
+
+    assert changed is True
+    assert effective == "gpt-5.4-mini"
+
+
+def test_routable_non_active_at_provider_session_model_is_preserved(monkeypatch):
+    """Visible cross-provider dropdown selections must keep their provider hint."""
+    import api.routes as routes
+
+    monkeypatch.setattr(
+        routes,
+        "get_available_models",
+        lambda: {
+            "active_provider": "openai-codex",
+            "default_model": "gpt-5.5",
+            "groups": [
+                {
+                    "provider": "OpenAI Codex",
+                    "provider_id": "openai-codex",
+                    "models": [{"id": "gpt-5.5", "label": "GPT-5.5"}],
+                },
+                {
+                    "provider": "GitHub Copilot",
+                    "provider_id": "copilot",
+                    "models": [{"id": "@copilot:gpt-5.4", "label": "GPT-5.4"}],
+                },
+            ],
+        },
+    )
+
+    effective, changed = routes._resolve_compatible_session_model(
+        "@copilot:gpt-5.4"
+    )
+
+    assert changed is False
+    assert effective == "@copilot:gpt-5.4"
+
+
+def test_stale_at_provider_model_falls_back_when_family_mismatches(monkeypatch):
+    """Unroutable @provider:model should not invent a bare model for another family."""
+    import api.routes as routes
+
+    monkeypatch.setattr(
+        routes,
+        "get_available_models",
+        lambda: {
+            "active_provider": "openai-codex",
+            "default_model": "gpt-5.5",
+            "groups": [
+                {
+                    "provider": "OpenAI Codex",
+                    "provider_id": "openai-codex",
+                    "models": [{"id": "gpt-5.5", "label": "GPT-5.5"}],
+                },
+            ],
+        },
+    )
+
+    effective, changed = routes._resolve_compatible_session_model(
+        "@copilot:claude-opus-4.6"
+    )
+
+    assert changed is True
+    assert effective == "gpt-5.5"
+
+
 def test_google_active_provider_keeps_valid_gemini_session_model(monkeypatch):
     """A Google-configured session must keep its Gemini model."""
     import api.routes as routes


### PR DESCRIPTION
## Thinking Path

- Hermes WebUI keeps sessions usable across provider/model configuration changes.
- #1023 / #1029 already recover stale bare and slash-prefixed session models.
- A remaining legacy path is persisted `@provider:model` values from the model dropdown, such as `@copilot:gpt-5.5`.
- That format is valid for currently-routable cross-provider selections, so the fix cannot blindly strip every `@provider:` prefix.
- This PR extends the existing compatibility layer so stale/unroutable provider hints recover while still-routable explicit hints remain intact.

## What Changed

- Added `@provider:model` handling to `_resolve_compatible_session_model()`.
- Normalizes redundant active-provider hints to the bare model, for example `@openai-codex:gpt-5.4-mini` -> `gpt-5.4-mini`.
- Preserves still-routable non-active provider hints, for example visible Copilot dropdown selections.
- Recovers stale/unroutable hints to the current active provider family or default model.
- Added regression coverage for stale Copilot hints, active-provider hints, valid cross-provider hints, and family mismatch fallback.
- Added a changelog entry.

## Why It Matters

Older sessions can otherwise stay pinned to a provider that is no longer routable. In that state, a session can appear to send but never show an assistant reply until the stored model is manually edited. This keeps old sessions usable without a bulk migration or UI change.

Fixes #1128.
Refs #1023.
Refs #1029.

## Verification

- `python -m py_compile api/routes.py`
- `python -m pytest tests/test_provider_mismatch.py -k "session_model or provider_model or stale_at_provider or legacy_at_provider or active_at_provider or routable_non_active" -v`
- `python -m pytest tests/test_provider_mismatch.py tests/test_model_resolver.py tests/test_credential_pool_providers.py tests/test_issue895_894_nous_prefix.py -v`

## Risks / Follow-ups

- The fix is intentionally conservative: if a non-active provider hint is still visible/routable in the current catalog, it is preserved.
- This does not bulk-migrate historical session files. Existing write-path normalization persists only when a stale explicit model is encountered.
- No UI behavior changes, so no screenshots are included.

## Model Used

- Provider: OpenAI Codex
- Model: GPT-5.5
- Mode/tooling: local code inspection, shell tests, GitHub CLI
