### PR TITLE
Fix Hindsight dependency in Docker WebUI venv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 ## [Unreleased]
 
 ### Fixed
+- **Docker Hindsight memory provider dependency** — Docker startup now ensures
+  `hindsight-client` is installed in the WebUI container venv, even on fast
+  restarts where `/app/venv/.deps_installed` already exists. This lets
+  two-container WebUI deployments import Hermes Agent's Hindsight memory
+  provider without a manual container-side install. (`docker_init.bash`,
+  `tests/test_issue926_hindsight_docker_dependency.py`) Closes #926.
 
 ## v0.50.223 — 2026-04-26
 

--- a/docker_init.bash
+++ b/docker_init.bash
@@ -285,6 +285,19 @@ echo "";echo "== Activating hermes webui's virtual environment"
 source /app/venv/bin/activate || error_exit "Failed to activate hermeswebui virtual environment"
 test -x /app/venv/bin/python3
 
+ensure_hindsight_client_docker_dependency() {
+  # Keep this outside the .deps_installed fast-restart guard so existing
+  # two-container Docker venvs self-heal after this dependency was added.
+  _hindsight_client_requirement="hindsight-client>=0.4.22"
+  echo ""; echo "== Checking Hindsight memory provider dependency"
+  if uv pip show hindsight-client >/dev/null 2>&1; then
+    echo "-- hindsight-client already installed"
+  else
+    echo "-- Installing ${_hindsight_client_requirement} for Hindsight memory provider support"
+    uv pip install "${_hindsight_client_requirement}" --trusted-host pypi.org --trusted-host files.pythonhosted.org || error_exit "Failed to install hindsight-client"
+  fi
+}
+
 if [ -f /app/venv/.deps_installed ]; then
   echo ""; echo "== Dependencies already installed — skipping (fast restart)"
 else
@@ -322,6 +335,8 @@ else
   fi
   touch /app/venv/.deps_installed
 fi
+
+ensure_hindsight_client_docker_dependency
 
 echo ""; echo "== Running hermes-webui"
 cd /app; python server.py || error_exit "hermes-webui failed or exited with an error"

--- a/tests/test_issue926_hindsight_docker_dependency.py
+++ b/tests/test_issue926_hindsight_docker_dependency.py
@@ -1,0 +1,32 @@
+"""Regression tests for #926 Hindsight dependency in Docker WebUI venv."""
+import pathlib
+
+
+REPO_ROOT = pathlib.Path(__file__).parent.parent
+INIT_SH = (REPO_ROOT / "docker_init.bash").read_text(encoding="utf-8")
+REQUIREMENTS_TXT = (REPO_ROOT / "requirements.txt").read_text(encoding="utf-8")
+
+
+def test_926_docker_init_installs_hindsight_distribution():
+    """Docker init must install the PyPI distribution named hindsight-client."""
+    assert "uv pip show hindsight-client" in INIT_SH
+    assert '"hindsight-client>=0.4.22"' in INIT_SH
+    assert 'uv pip install "${_hindsight_client_requirement}"' in INIT_SH
+
+
+def test_926_hindsight_install_runs_after_fast_restart_guard():
+    """Existing Docker venvs with .deps_installed must still get hindsight-client."""
+    deps_guard_pos = INIT_SH.find("if [ -f /app/venv/.deps_installed ]; then")
+    assert deps_guard_pos != -1, ".deps_installed fast-restart guard not found"
+
+    expected_sequence = "\nfi\n\nensure_hindsight_client_docker_dependency\n"
+    call_after_guard_pos = INIT_SH.find(expected_sequence, deps_guard_pos)
+    assert call_after_guard_pos != -1, (
+        "hindsight-client install check must run outside the .deps_installed guard "
+        "so old Docker venvs self-heal on fast restart"
+    )
+
+
+def test_926_hindsight_dependency_stays_docker_specific():
+    """Local non-Docker bootstrap should not install optional memory clients."""
+    assert "hindsight-client" not in REQUIREMENTS_TXT


### PR DESCRIPTION
## Summary

Closes #926.

This fixes the two-container Docker setup where the WebUI process imports Hermes Agent code from a shared source volume, but runs in its own isolated `/app/venv`. Hindsight's Python client was available only when users manually installed it in the WebUI container, so the Hindsight memory provider could not import cleanly from WebUI Docker.

## Root Cause

The Hermes Agent container and Hermes WebUI container have separate Python environments. Installing Hermes Agent source with `[all]` into the WebUI venv does not currently install Hindsight: upstream Hermes Agent includes `honcho` in `[all]`, but does not include a Hindsight extra or `hindsight-client` there. The Hindsight plugin metadata declares `hindsight-client>=0.4.22`, and the PyPI distribution imports as `hindsight_client` / `hindsight_client_api`.

## Changes

- Add a Docker init check that installs `hindsight-client>=0.4.22` into the WebUI container venv when missing.
- Run that check outside the `/app/venv/.deps_installed` fast-restart guard so existing Docker venvs can self-heal after upgrading.
- Keep `requirements.txt` unchanged so local non-Docker startup does not gain optional external memory-provider dependencies.
- Add focused regression tests for the Docker-specific dependency path and fast-restart placement.
- Update the changelog.

## Verification

- `bash -n docker_init.bash`
- `uvx pytest tests/test_issue926_hindsight_docker_dependency.py tests/test_issue569_579.py -q` passed: 14 tests
- `git diff --check`
- Temporary venv install/import check confirmed `hindsight-client==0.5.4` exposes `hindsight_client` and `hindsight_client_api`
- Docker image build succeeded:
  - `docker build --build-arg HERMES_VERSION=hindsight-926-smoke -t hermes-webui:hindsight-926 .`
- Docker first-start smoke passed:
  - temporary container ran `/hermeswebui_init.bash`
  - init installed `hindsight-client==0.5.4`
  - `/app/venv/bin/python` imported `hindsight_client` and `hindsight_client_api`
- Docker fast-restart smoke passed:
  - manually uninstalled `hindsight-client` while preserving `/app/venv/.deps_installed`
  - restarted the same container
  - logs showed `Dependencies already installed — skipping (fast restart)` followed by `Installing hindsight-client>=0.4.22`
  - import succeeded again

## Not Run

- Full `docker compose -f docker-compose.two-container.yml up` with a live Hermes Agent container and mounted real agent source volume.
