### PR TITLE
feat: integrate agent-api-gateway + status indicators + full-width chat + session-rename fixes

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -1736,6 +1736,16 @@ def get_available_models() -> dict:
                         }
                     )
 
+        # Append gateway provider groups (agent-api-gateway integration).
+        # Kept inside the cold-path builder so the result is cached normally;
+        # if discovery is slow, the next request hits the cache instead of
+        # repeating the HTTP probe.
+        try:
+            from api.gateway_provider import get_gateway_model_groups
+            groups.extend(get_gateway_model_groups())
+        except Exception:
+            pass  # gateway module missing or discovery failed — never crash
+
         return {
             "active_provider": active_provider,
             "default_model": default_model,

--- a/api/config.py
+++ b/api/config.py
@@ -843,6 +843,16 @@ def resolve_model_provider(model_id: str) -> tuple:
 
     Returns (model, provider, base_url) where provider and base_url may be None.
     """
+    # Gateway models (@gateway-*:model/keyword) are handled by the gateway module
+    try:
+        from api.gateway_provider import is_gateway_model, resolve_gateway_model
+        if is_gateway_model(model_id or ""):
+            resolved = resolve_gateway_model(model_id)
+            if resolved:
+                return resolved["model"], resolved["provider"], resolved["base_url"]
+    except Exception:
+        pass  # gateway module missing — fall through to normal resolution
+
     config_provider = None
     config_base_url = None
     model_cfg = cfg.get("model", {})

--- a/api/gateway_provider.py
+++ b/api/gateway_provider.py
@@ -290,16 +290,11 @@ def resolve_gateway_model(model_id: str) -> Optional[Dict[str, str]]:
             cli_route = inst.get("cli", "cursor")
             break
 
-    # Embed keyword in URL path so no extra HTTP headers are needed.
-    # This avoids issues with AIAgent's codex_responses mode for GPT-5+ models
-    # rejecting extra_headers in request_overrides.
-    base_url = f"{gateway_url}/{cli_route}/v1/k/{keyword}"
+    base_url = f"{gateway_url}/{cli_route}/v1"
 
     # Use a prefixed model name (e.g. "gw:gpt-5.4") to prevent the AI agent
     # from auto-switching to the Responses API for GPT-5+ models.  The gateway
-    # proxies everything as chat completions regardless of the underlying model.
-    # The "gw:" prefix ensures _model_requires_responses_api("gw:gpt-5.4")
-    # returns False (doesn't start with "gpt-5").
+    # strips the "gw:" prefix and matches the real model name strictly.
     safe_model = f"gw:{model_name}"
 
     return {
@@ -307,5 +302,7 @@ def resolve_gateway_model(model_id: str) -> Optional[Dict[str, str]]:
         "provider": "openai",
         "base_url": base_url,
         "api_key": "agent-gateway-no-key-required",
-        "extra_headers": {},
+        "extra_headers": {
+            "x-instance-keyword": keyword,
+        },
     }

--- a/api/gateway_provider.py
+++ b/api/gateway_provider.py
@@ -306,3 +306,26 @@ def resolve_gateway_model(model_id: str) -> Optional[Dict[str, str]]:
             "x-instance-keyword": keyword,
         },
     }
+
+
+def get_gateway_instance_statuses() -> List[Dict[str, str]]:
+    """Return status of all gateway instances across all configured gateways.
+
+    Each entry: {label, keyword, model, cli, status}.
+    """
+    results: List[Dict[str, str]] = []
+    for cfg in _load_gateway_configs():
+        label = cfg.get("label", "local")
+        url = cfg.get("url", "")
+        if not url:
+            continue
+        instances = discover_instances(url, force_refresh=False)
+        for inst in instances:
+            results.append({
+                "label": label,
+                "keyword": inst.get("keyword", ""),
+                "model": inst.get("model", ""),
+                "cli": inst.get("cli", ""),
+                "status": inst.get("status", "unknown"),
+            })
+    return results

--- a/api/gateway_provider.py
+++ b/api/gateway_provider.py
@@ -1,0 +1,303 @@
+"""
+Hermes Web UI -- Agent API Gateway provider integration.
+
+Discovers AI model instances from agent-api-gateway and integrates them
+into hermes-webui's model dropdown and routing system.
+
+This module is self-contained and communicates with the gateway exclusively
+via its HTTP admin API. No gateway source code is imported.
+
+Gateway model IDs use the format: @gateway-{label}:{model_name}/{keyword}
+This fits hermes-webui's existing @provider:model convention.
+
+Usage in config.yaml:
+    gateway_providers:
+      - label: local
+        url: http://localhost:3000
+      - label: remote
+        url: http://10.1.73.240:3000
+
+Environment variable overrides:
+    AGENT_GATEWAY_LOCAL_URL  — overrides the first gateway entry
+    AGENT_GATEWAY_REMOTE_URL — overrides the second gateway entry
+"""
+
+import logging
+import os
+import threading
+import time
+from typing import Any, Dict, List, Optional, Tuple
+from urllib.parse import urljoin
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Types
+# ---------------------------------------------------------------------------
+
+GatewayInstance = Dict[str, Any]
+
+# ---------------------------------------------------------------------------
+# Discovery cache (thread-safe, TTL-based)
+# ---------------------------------------------------------------------------
+
+_CACHE_LOCK = threading.Lock()
+_CACHE: Dict[str, Tuple[float, List[GatewayInstance]]] = {}
+DEFAULT_CACHE_TTL_S = 30
+
+
+def _cache_key(url: str) -> str:
+    return url.rstrip("/")
+
+
+def _read_cache(url: str, max_age_s: float = DEFAULT_CACHE_TTL_S) -> Optional[List[GatewayInstance]]:
+    key = _cache_key(url)
+    with _CACHE_LOCK:
+        entry = _CACHE.get(key)
+        if entry is None:
+            return None
+        fetched_at, instances = entry
+        if time.time() - fetched_at > max_age_s:
+            return None
+        return instances
+
+
+def _write_cache(url: str, instances: List[GatewayInstance]) -> None:
+    key = _cache_key(url)
+    with _CACHE_LOCK:
+        _CACHE[key] = (time.time(), instances)
+
+
+def clear_cache(url: Optional[str] = None) -> None:
+    """Clear discovery cache. If url is None, clears all entries."""
+    with _CACHE_LOCK:
+        if url is None:
+            _CACHE.clear()
+        else:
+            _CACHE.pop(_cache_key(url), None)
+
+
+# ---------------------------------------------------------------------------
+# HTTP discovery
+# ---------------------------------------------------------------------------
+
+def _fetch_instances(gateway_url: str, timeout_s: float = 5.0) -> List[GatewayInstance]:
+    """Fetch active instances from a gateway's admin API."""
+    import urllib.request
+    import urllib.error
+    import json as _json
+
+    admin_url = gateway_url.rstrip("/") + "/admin/instances"
+    req = urllib.request.Request(admin_url, headers={"Accept": "application/json"})
+    try:
+        with urllib.request.urlopen(req, timeout=timeout_s) as resp:
+            data = _json.loads(resp.read().decode("utf-8"))
+            if not isinstance(data, list):
+                return []
+            return data
+    except (urllib.error.URLError, OSError, ValueError) as exc:
+        logger.debug("gateway discovery failed for %s: %s", admin_url, exc)
+        return []
+
+
+def _filter_active(instances: List[GatewayInstance]) -> List[GatewayInstance]:
+    return [i for i in instances if i.get("status") in ("ready", "busy")]
+
+
+def discover_instances(
+    gateway_url: str,
+    *,
+    max_age_s: float = DEFAULT_CACHE_TTL_S,
+    force_refresh: bool = False,
+) -> List[GatewayInstance]:
+    """Return active gateway instances, using cache when possible."""
+    if not force_refresh:
+        cached = _read_cache(gateway_url, max_age_s)
+        if cached is not None:
+            return cached
+
+    raw = _fetch_instances(gateway_url)
+    active = _filter_active(raw)
+
+    if active:
+        _write_cache(gateway_url, active)
+        return active
+
+    # Fall back to last-known-good snapshot
+    stale = _read_cache(gateway_url, max_age_s=float("inf"))
+    return stale or active
+
+
+# ---------------------------------------------------------------------------
+# Model ID encoding / decoding
+# ---------------------------------------------------------------------------
+
+GATEWAY_PROVIDER_PREFIX = "gateway-"
+
+
+def build_model_id(label: str, model_name: str, keyword: str) -> str:
+    """Build a hermes-webui model ID: @gateway-{label}:{model_name}/{keyword}"""
+    return f"@{GATEWAY_PROVIDER_PREFIX}{label}:{model_name}/{keyword}"
+
+
+def parse_model_id(model_id: str) -> Optional[Dict[str, str]]:
+    """Parse a gateway model ID. Returns None if not a gateway model.
+
+    Returns dict with keys: label, model_name, keyword, provider_id
+    """
+    if not model_id.startswith("@" + GATEWAY_PROVIDER_PREFIX):
+        return None
+
+    # Strip leading @
+    rest = model_id[1:]
+    if ":" not in rest:
+        return None
+
+    provider_id, model_part = rest.split(":", 1)
+    label = provider_id[len(GATEWAY_PROVIDER_PREFIX):]
+
+    if "/" in model_part:
+        model_name, keyword = model_part.split("/", 1)
+    else:
+        model_name = model_part
+        keyword = ""
+
+    return {
+        "label": label,
+        "model_name": model_name,
+        "keyword": keyword,
+        "provider_id": provider_id,
+    }
+
+
+def is_gateway_model(model_id: str) -> bool:
+    return parse_model_id(model_id) is not None
+
+
+# ---------------------------------------------------------------------------
+# Config loading
+# ---------------------------------------------------------------------------
+
+def _load_gateway_configs() -> List[Dict[str, str]]:
+    """Load gateway provider configs from hermes config and env vars.
+
+    Returns list of dicts: [{"label": "local", "url": "http://..."}]
+    """
+    configs: List[Dict[str, str]] = []
+
+    # Try to read from hermes config.yaml
+    try:
+        from api.config import cfg
+        gw_list = cfg.get("gateway_providers", [])
+        if isinstance(gw_list, list):
+            for entry in gw_list:
+                if isinstance(entry, dict) and entry.get("url"):
+                    configs.append({
+                        "label": str(entry.get("label", f"gw{len(configs)}")),
+                        "url": str(entry["url"]).rstrip("/"),
+                    })
+    except Exception:
+        pass
+
+    # Env var overrides / additions
+    env_local = os.getenv("AGENT_GATEWAY_LOCAL_URL", "").strip()
+    env_remote = os.getenv("AGENT_GATEWAY_REMOTE_URL", "").strip()
+
+    if env_local:
+        if configs:
+            configs[0]["url"] = env_local
+        else:
+            configs.append({"label": "local", "url": env_local})
+
+    if env_remote:
+        if len(configs) > 1:
+            configs[1]["url"] = env_remote
+        else:
+            configs.append({"label": "remote", "url": env_remote})
+
+    return configs
+
+
+# ---------------------------------------------------------------------------
+# Public API for hermes-webui integration
+# ---------------------------------------------------------------------------
+
+def get_gateway_model_groups() -> List[Dict[str, Any]]:
+    """Return model groups for the hermes-webui dropdown.
+
+    Each group: {"provider": "gateway-local", "models": [{"id": ..., "label": ...}]}
+    """
+    configs = _load_gateway_configs()
+    groups = []
+
+    for gw in configs:
+        label = gw["label"]
+        url = gw["url"]
+        instances = discover_instances(url)
+
+        if not instances:
+            continue
+
+        models = []
+        for inst in instances:
+            model_name = inst.get("model", "unknown")
+            keyword = inst.get("keyword", "default")
+            cli = inst.get("cli", "cursor").upper()
+            mid = build_model_id(label, model_name, keyword)
+            display = f"{model_name} [{cli}:{keyword}]"
+            models.append({"id": mid, "label": display})
+
+        if models:
+            groups.append({
+                "provider": f"{GATEWAY_PROVIDER_PREFIX}{label}",
+                "models": models,
+            })
+
+    return groups
+
+
+def resolve_gateway_model(model_id: str) -> Optional[Dict[str, str]]:
+    """Resolve a gateway model ID to routing parameters.
+
+    Returns dict with: model, provider, base_url, api_key, headers
+    Or None if not a gateway model.
+    """
+    parsed = parse_model_id(model_id)
+    if parsed is None:
+        return None
+
+    label = parsed["label"]
+    model_name = parsed["model_name"]
+    keyword = parsed["keyword"]
+
+    # Find the gateway URL for this label
+    configs = _load_gateway_configs()
+    gateway_url = None
+    for gw in configs:
+        if gw["label"] == label:
+            gateway_url = gw["url"]
+            break
+
+    if not gateway_url:
+        logger.warning("no gateway config found for label=%s", label)
+        return None
+
+    # Look up the instance to determine CLI route
+    instances = discover_instances(gateway_url)
+    cli_route = "cursor"
+    for inst in instances:
+        if inst.get("model") == model_name and inst.get("keyword") == keyword:
+            cli_route = inst.get("cli", "cursor")
+            break
+
+    base_url = f"{gateway_url}/{cli_route}/v1"
+
+    return {
+        "model": model_name,
+        "provider": "openai",
+        "base_url": base_url,
+        "api_key": "agent-gateway-no-key-required",
+        "extra_headers": {
+            "x-instance-keyword": keyword,
+        },
+    }

--- a/api/gateway_provider.py
+++ b/api/gateway_provider.py
@@ -290,14 +290,22 @@ def resolve_gateway_model(model_id: str) -> Optional[Dict[str, str]]:
             cli_route = inst.get("cli", "cursor")
             break
 
-    base_url = f"{gateway_url}/{cli_route}/v1"
+    # Embed keyword in URL path so no extra HTTP headers are needed.
+    # This avoids issues with AIAgent's codex_responses mode for GPT-5+ models
+    # rejecting extra_headers in request_overrides.
+    base_url = f"{gateway_url}/{cli_route}/v1/k/{keyword}"
+
+    # Use a prefixed model name (e.g. "gw:gpt-5.4") to prevent the AI agent
+    # from auto-switching to the Responses API for GPT-5+ models.  The gateway
+    # proxies everything as chat completions regardless of the underlying model.
+    # The "gw:" prefix ensures _model_requires_responses_api("gw:gpt-5.4")
+    # returns False (doesn't start with "gpt-5").
+    safe_model = f"gw:{model_name}"
 
     return {
-        "model": model_name,
+        "model": safe_model,
         "provider": "openai",
         "base_url": base_url,
         "api_key": "agent-gateway-no-key-required",
-        "extra_headers": {
-            "x-instance-keyword": keyword,
-        },
+        "extra_headers": {},
     }

--- a/api/routes.py
+++ b/api/routes.py
@@ -656,6 +656,13 @@ def handle_get(handler, parsed) -> bool:
     if parsed.path == "/api/models":
         return j(handler, get_available_models())
 
+    if parsed.path == "/api/gateway-status":
+        try:
+            from api.gateway_provider import get_gateway_instance_statuses
+            return j(handler, get_gateway_instance_statuses())
+        except Exception:
+            return j(handler, [])
+
     if parsed.path == "/api/models/live":
         return _handle_live_models(handler, parsed)
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -1159,13 +1159,47 @@ def handle_post(handler, parsed) -> bool:
             require(body, "session_id", "title")
         except ValueError as e:
             return bad(handler, str(e))
+        new_title = str(body["title"]).strip()[:80] or "Untitled"
+        sid = body["session_id"]
         try:
-            s = get_session(body["session_id"])
+            s = get_session(sid)
         except KeyError:
-            return bad(handler, "Session not found", 404)
+            # Not a WebUI-owned session — try CLI/agent sessions in state.db.
+            # This keeps double-click rename in the sidebar working uniformly
+            # across WebUI sessions and CLI/gateway sessions.
+            try:
+                from api.state_sync import rename_cli_session
+            except Exception:
+                return bad(handler, "Session not found", 404)
+            try:
+                ok = rename_cli_session(sid, new_title)
+            except ValueError as e:
+                # Title uniqueness conflict from SessionDB.set_session_title
+                return bad(handler, str(e), 409)
+            if not ok:
+                return bad(handler, "Session not found", 404)
+            return j(handler, {"session": {
+                "session_id": sid,
+                "title": new_title,
+                "is_cli_session": True,
+            }})
         with _get_session_agent_lock(body["session_id"]):
-            s.title = str(body["title"]).strip()[:80] or "Untitled"
+            s.title = new_title
             s.save()
+        # Mirror to state.db so /insights and CLI sidebar listings stay in sync
+        try:
+            from api.state_sync import sync_session_usage
+            sync_session_usage(
+                session_id=sid,
+                input_tokens=int(getattr(s, "input_tokens", 0) or 0),
+                output_tokens=int(getattr(s, "output_tokens", 0) or 0),
+                estimated_cost=getattr(s, "estimated_cost", None),
+                model=getattr(s, "model", None),
+                title=new_title,
+                message_count=len(s.messages),
+            )
+        except Exception:
+            pass  # state.db sync is best-effort
         return j(handler, {"session": s.compact()})
 
     if parsed.path == "/api/personality/set":

--- a/api/state_sync.py
+++ b/api/state_sync.py
@@ -116,3 +116,73 @@ def sync_session_usage(session_id: str, input_tokens: int=0, output_tokens: int=
             db.close()
         except Exception:
             logger.debug("Failed to close state.db")
+
+
+def rename_cli_session(session_id: str, title: str) -> bool:
+    """Rename a CLI / agent / gateway-imported session in state.db.
+
+    Used by /api/session/rename when the session is not owned by the WebUI
+    (no JSON file in SESSION_DIR). Returns True if the row existed and was
+    updated, False if the session_id was not found, or raises ValueError
+    on title-uniqueness conflicts (mirrors SessionDB.set_session_title).
+
+    Implementation note: we try SessionDB.set_session_title first because it
+    enforces title sanitization and uniqueness. If SessionDB cannot be opened
+    (e.g. the on-disk state.db schema doesn't match the installed
+    hermes_state version), we fall back to a defensive raw SQL UPDATE so the
+    WebUI rename feature still works in degraded environments.
+    """
+    # Resolve the state.db path the same way _get_state_db does
+    try:
+        from api.profiles import get_active_hermes_home
+        hermes_home = Path(get_active_hermes_home()).expanduser().resolve()
+    except Exception:
+        hermes_home = Path(os.getenv('HERMES_HOME', str(Path.home() / '.hermes')))
+    db_path = hermes_home / 'state.db'
+    if not db_path.exists():
+        return False
+
+    # Path 1: preferred — go through SessionDB so sanitization / uniqueness apply.
+    db = _get_state_db()
+    if db is not None:
+        try:
+            return bool(db.set_session_title(session_id, title))
+        except ValueError:
+            raise
+        except Exception:
+            pass  # fall through to the raw-SQL fallback
+        finally:
+            try:
+                db.close()
+            except Exception:
+                pass
+
+    # Path 2: defensive raw SQL fallback — used when SessionDB schema migration
+    # fails (e.g. older state.db missing columns that the installed hermes_state
+    # version expects).  Cap title length the same way the WebUI does.
+    import sqlite3
+    safe_title = (title or "").strip()[:80] or "Untitled"
+    try:
+        conn = sqlite3.connect(str(db_path), timeout=5)
+        try:
+            # Uniqueness check (mirrors SessionDB.set_session_title behaviour)
+            conflict = conn.execute(
+                "SELECT id FROM sessions WHERE title = ? AND id != ?",
+                (safe_title, session_id),
+            ).fetchone()
+            if conflict:
+                raise ValueError(
+                    f"Title {safe_title!r} is already in use by session {conflict[0]}"
+                )
+            cursor = conn.execute(
+                "UPDATE sessions SET title = ? WHERE id = ?",
+                (safe_title, session_id),
+            )
+            conn.commit()
+            return cursor.rowcount > 0
+        finally:
+            conn.close()
+    except ValueError:
+        raise
+    except Exception:
+        return False

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -1430,19 +1430,36 @@ def _run_agent_streaming(session_id, msg_text, model, workspace, stream_id, atta
                 print(f"[webui] WARNING: SessionDB init failed — session_search will be unavailable: {_db_err}", flush=True)
             resolved_model, resolved_provider, resolved_base_url = resolve_model_provider(model)
 
+            # Gateway models carry their own API key and extra headers;
+            # skip the normal runtime provider resolution for them.
+            _gateway_extra_headers = {}
+            _is_gateway = False
+            try:
+                from api.gateway_provider import is_gateway_model, resolve_gateway_model
+                if is_gateway_model(model):
+                    _gw = resolve_gateway_model(model)
+                    if _gw:
+                        _is_gateway = True
+                        _gateway_extra_headers = _gw.get("extra_headers", {})
+            except Exception:
+                pass
+
             # Resolve API key via Hermes runtime provider (matches gateway behaviour).
             # Pass the resolved provider so non-default providers get their own credentials.
             resolved_api_key = None
-            try:
-                from hermes_cli.runtime_provider import resolve_runtime_provider
-                _rt = resolve_runtime_provider(requested=resolved_provider)
-                resolved_api_key = _rt.get("api_key")
-                if not resolved_provider:
-                    resolved_provider = _rt.get("provider")
-                if not resolved_base_url:
-                    resolved_base_url = _rt.get("base_url")
-            except Exception as _e:
-                print(f"[webui] WARNING: resolve_runtime_provider failed: {_e}", flush=True)
+            if _is_gateway:
+                resolved_api_key = "agent-gateway-no-key-required"
+            else:
+                try:
+                    from hermes_cli.runtime_provider import resolve_runtime_provider
+                    _rt = resolve_runtime_provider(requested=resolved_provider)
+                    resolved_api_key = _rt.get("api_key")
+                    if not resolved_provider:
+                        resolved_provider = _rt.get("provider")
+                    if not resolved_base_url:
+                        resolved_base_url = _rt.get("base_url")
+                except Exception as _e:
+                    print(f"[webui] WARNING: resolve_runtime_provider failed: {_e}", flush=True)
 
             # Read per-profile config at call time (not module-level snapshot)
             from api.config import get_config as _get_config
@@ -1487,6 +1504,13 @@ def _run_agent_streaming(session_id, msg_text, model, workspace, stream_id, atta
             except Exception:
                 _reasoning_config = None
 
+            # Gateway integration: when the resolved model came from the
+            # agent-api-gateway, we may need to pass extra HTTP headers
+            # (e.g. x-instance-keyword) through to the upstream call.
+            _request_overrides = {}
+            if _gateway_extra_headers:
+                _request_overrides["extra_headers"] = _gateway_extra_headers
+
             _agent_kwargs = dict(
                 model=resolved_model,
                 provider=resolved_provider,
@@ -1528,6 +1552,10 @@ def _run_agent_streaming(session_id, msg_text, model, workspace, stream_id, atta
             # re-instantiated fresh each turn (#855).
             if 'gateway_session_key' in _agent_params:
                 _agent_kwargs['gateway_session_key'] = session_id
+
+            # Forward gateway extra headers (x-instance-keyword) when supported.
+            if _request_overrides and 'request_overrides' in _agent_params:
+                _agent_kwargs['request_overrides'] = _request_overrides
 
             # ── Agent cache: reuse across messages in the same session ──
             # Mirrors gateway _agent_cache.  Keeps _user_turn_count alive so

--- a/static/commands.js
+++ b/static/commands.js
@@ -233,7 +233,12 @@ async function cmdModel(args){
   if(!args){showToast(t('model_usage'));return;}
   const sel=$('modelSelect');
   if(!sel)return;
-  const q=args.toLowerCase();
+  let q=args.toLowerCase();
+  // Support copilot-local/model/keyword → @gateway-local:model/keyword shorthand
+  const gwMatch=q.match(/^copilot-(\w+)\/([\w.-]+)\/([\w.-]+)$/);
+  if(gwMatch){
+    q=`@gateway-${gwMatch[1]}:${gwMatch[2]}/${gwMatch[3]}`;
+  }
   // Fuzzy match: find first option whose label or value contains the query
   let match=null;
   for(const opt of sel.options){

--- a/static/index.html
+++ b/static/index.html
@@ -353,6 +353,7 @@
             </div>
             <div class="composer-model-wrap">
               <button class="composer-model-chip" id="composerModelChip" type="button" onclick="toggleModelDropdown()" title="Conversation model">
+                <span class="status-dot" id="gatewayDot" aria-hidden="true"></span>
                 <span class="composer-model-icon" aria-hidden="true"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="4" width="16" height="16" rx="2"/><rect x="9" y="9" width="6" height="6"/><path d="M15 2v2"/><path d="M15 20v2"/><path d="M2 15h2"/><path d="M2 9h2"/><path d="M20 15h2"/><path d="M20 9h2"/><path d="M9 2v2"/><path d="M9 20v2"/></svg></span>
                 <span class="composer-model-label" id="composerModelLabel"></span>
                 <span class="composer-model-chevron" aria-hidden="true"><svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg></span>

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -10,6 +10,13 @@ const ICONS={
   more:'<svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" stroke="none"><circle cx="8" cy="3" r="1.25"/><circle cx="8" cy="8" r="1.25"/><circle cx="8" cy="13" r="1.25"/></svg>',
 };
 
+// FNV-32 hash → 0..359 for stable per-conversation accent hue.
+function _hashHue(s){
+  let h=2166136261>>>0;
+  for(let i=0;i<s.length;i++){h^=s.charCodeAt(i);h=Math.imul(h,16777619)>>>0;}
+  return h%360;
+}
+
 // Tracks which session_id is currently being loaded. Used to discard stale
 // responses from in-flight requests when the user switches sessions again
 // before the first request completes (#1060).
@@ -1008,6 +1015,18 @@ function renderSessionListFromCache(){
     // (Project dot is appended above, between title and timestamp, so it
     // sits outside the truncating title span and stays visible.)
     el.appendChild(sessionText);
+    // Per-session status dot (gateway/CLI activity) + per-conversation accent
+    const sDot=document.createElement('span');
+    sDot.className='status-dot';
+    sDot.dataset.sessionId=s.session_id;
+    if(s.kind==='cli'||s.session_kind==='cli'||s.is_cli){sDot.dataset.cliSession='1';}
+    const _upd=s.updated_at||s.last_active||s.last_updated||0;
+    if(_upd) sDot.dataset.updatedAt=String(_upd);
+    el.insertBefore(sDot,sessionText);
+    try{
+      const _hue=_hashHue(String(s.session_id||''));
+      el.style.setProperty('--conv-accent',`hsl(${_hue},65%,60%)`);
+    }catch(e){}
     const state=document.createElement('span');
     state.className='session-attention-indicator session-state-indicator'+(isStreaming?' is-streaming':(hasUnread?' is-unread':''));
     state.setAttribute('aria-hidden','true');

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -987,11 +987,21 @@ function renderSessionListFromCache(){
         _renamingSid = null;
         if(save){
           const newTitle=inp.value.trim()||'Untitled';
+          const oldTitle=s.title;
+          // Optimistic UI update
           title.textContent=newTitle;
           s.title=newTitle;
           if(S.session&&S.session.session_id===s.session_id){S.session.title=newTitle;syncTopbar();}
-          try{await api('/api/session/rename',{method:'POST',body:JSON.stringify({session_id:s.session_id,title:newTitle})});}
-          catch(err){setStatus('Rename failed: '+err.message);}
+          try{
+            await api('/api/session/rename',{method:'POST',body:JSON.stringify({session_id:s.session_id,title:newTitle})});
+          }
+          catch(err){
+            // Roll back optimistic update so the UI doesn't lie about persistence
+            s.title=oldTitle;
+            title.textContent=oldTitle||'Untitled';
+            if(S.session&&S.session.session_id===s.session_id){S.session.title=oldTitle;syncTopbar();}
+            setStatus('Rename failed: '+err.message);
+          }
         }
         inp.replaceWith(title);
         // Allow list re-renders again after a short delay

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -12,6 +12,7 @@ const ICONS={
 
 // FNV-32 hash → 0..359 for stable per-conversation accent hue.
 function _hashHue(s){
+  s=String(s==null?'':s);
   let h=2166136261>>>0;
   for(let i=0;i<s.length;i++){h^=s.charCodeAt(i);h=Math.imul(h,16777619)>>>0;}
   return h%360;

--- a/static/style.css
+++ b/static/style.css
@@ -635,7 +635,7 @@
   .stream-cursor{display:inline-block;width:2px;height:1em;background:var(--blue);margin-left:1px;vertical-align:text-bottom;animation:blink-cursor 1s step-end infinite;}
   @keyframes blink-cursor{0%,100%{opacity:1;}50%{opacity:0;}}
   /* Per-conversation accent (PR #6) */
-  .session-item[style*="--conv-accent"]{border-left:3px solid color-mix(in srgb, var(--conv-accent) 70%, transparent);}
+  .session-item[style*="--conv-accent"]{border-left-width:3px;border-left-style:solid;border-left-color:color-mix(in srgb, var(--conv-accent) 70%, transparent);}
   .empty-state{flex:1;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:12px;padding:40px;color:var(--muted);}
   .empty-logo{width:64px;height:64px;border-radius:20px;background:linear-gradient(145deg,var(--accent-bg),var(--accent-bg));border:1px solid var(--accent-bg);display:flex;align-items:center;justify-content:center;font-size:28px;font-weight:700;color:var(--accent-text);margin-bottom:4px;box-shadow:0 4px 20px var(--accent-bg);}
   .empty-state h2{font-size:20px;color:var(--text);font-weight:700;letter-spacing:-.02em;}

--- a/static/style.css
+++ b/static/style.css
@@ -623,6 +623,19 @@
   .dot{width:6px;height:6px;border-radius:50%;background:var(--blue);opacity:.3;animation:pulse 1.4s ease-in-out infinite;}
   .dot:nth-child(2){animation-delay:.22s;}.dot:nth-child(3){animation-delay:.44s;}
   @keyframes pulse{0%,80%,100%{opacity:.2;transform:scale(.8)}40%{opacity:.8;transform:scale(1)}}
+  /* Status indicator dots (gateway health, session activity) */
+  .status-dot{display:inline-block;width:7px;height:7px;border-radius:50%;flex-shrink:0;background:rgba(255,255,255,.15);}
+  .status-dot.running{background:#4ade80;animation:status-pulse 2s ease-in-out infinite;}
+  .status-dot.recent{background:#818cf8;}
+  .status-dot.error,.status-dot.dead,.status-dot.offline{background:#f87171;}
+  .status-dot.ready{background:#4ade80;}
+  .status-dot.initializing{background:#facc15;animation:status-pulse 2s ease-in-out infinite;}
+  @keyframes status-pulse{0%,100%{opacity:1;}50%{opacity:.35;}}
+  /* Streaming cursor (blinking caret during token streaming) */
+  .stream-cursor{display:inline-block;width:2px;height:1em;background:var(--blue);margin-left:1px;vertical-align:text-bottom;animation:blink-cursor 1s step-end infinite;}
+  @keyframes blink-cursor{0%,100%{opacity:1;}50%{opacity:0;}}
+  /* Per-conversation accent (PR #6) */
+  .session-item[style*="--conv-accent"]{border-left:3px solid color-mix(in srgb, var(--conv-accent) 70%, transparent);}
   .empty-state{flex:1;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:12px;padding:40px;color:var(--muted);}
   .empty-logo{width:64px;height:64px;border-radius:20px;background:linear-gradient(145deg,var(--accent-bg),var(--accent-bg));border:1px solid var(--accent-bg);display:flex;align-items:center;justify-content:center;font-size:28px;font-weight:700;color:var(--accent-text);margin-bottom:4px;box-shadow:0 4px 20px var(--accent-bg);}
   .empty-state h2{font-size:20px;color:var(--text);font-weight:700;letter-spacing:-.02em;}

--- a/static/ui.js
+++ b/static/ui.js
@@ -3331,25 +3331,26 @@ if(document.readyState==='loading'){
 
 /* ── Session Status Dots (PR #4 + PR #6 enhancements) ─────────────────────── */
 // CLI-busy recency window (seconds). Configurable via window.HERMES_CLI_BUSY_WINDOW_S.
-function _cliBusyWindow(){
-  const v=Number(window.HERMES_CLI_BUSY_WINDOW_S);
-  return Number.isFinite(v)&&v>0?v:15;
-}
+const _CLI_BUSY_WINDOW_S = 15;
 
 function updateSessionDots(){
   const dots=document.querySelectorAll('.session-item .status-dot');
   const nowSec=Date.now()/1000;
-  const win=_cliBusyWindow();
+  const _winOverride=(typeof window!=='undefined')&&Number(window.HERMES_CLI_BUSY_WINDOW_S);
+  const win=Number.isFinite(_winOverride)&&_winOverride>0?_winOverride:_CLI_BUSY_WINDOW_S;
   dots.forEach(dot=>{
     dot.className='status-dot';
+    dot.title='';
     const sid=dot.dataset.sessionId;
     const isCli=dot.dataset.cliSession==='1';
     const upd=Number(dot.dataset.updatedAt||0);
     if(S.busy&&S.session&&sid===S.session.session_id){
       dot.classList.add('running');
+      dot.title='busy';
     }else if(isCli&&upd&&(nowSec-upd)<=win){
       // CLI session updated recently → likely still busy.
       dot.classList.add('running');
+      dot.title=`CLI active (${Math.round(nowSec-upd)}s ago)`;
     }else if(S.session&&sid===S.session.session_id){
       dot.classList.add('recent');
     }

--- a/static/ui.js
+++ b/static/ui.js
@@ -1046,6 +1046,7 @@ function updateSendBtn(){
 function setBusy(v){
   S.busy=v;
   updateSendBtn();
+  if(typeof updateSessionDots==='function') updateSessionDots();
   if(!v){
     setStatus('');
     setComposerStatus('');
@@ -3266,3 +3267,94 @@ async function uploadPendingFiles(){
   if(failures===total&&total>0)throw new Error(t('all_uploads_failed',total));
   return names;
 }
+
+
+/* ── Gateway Instance Status Polling (PR #4) ──────────────────────────────── */
+let _gwStatusCache=[];
+let _gwPollTimer=null;
+
+async function pollGatewayStatus(){
+  try{
+    const res=await fetch('/api/gateway-status');
+    if(!res.ok) return;
+    _gwStatusCache=await res.json();
+    _updateGatewayDot();
+    _updateDropdownStatusSuffix();
+  }catch(e){/* ignore network errors */}
+}
+
+function _updateGatewayDot(){
+  const dot=$('gatewayDot');
+  if(!dot) return;
+  const chip=$('composerModelChip')||$('modelChip');
+  if(!chip) return;
+  const txt=(chip.textContent||'').trim();
+  const inst=_gwStatusCache.find(i=>{
+    const dispName=`copilot-${i.label}/${i.model}/${i.keyword}`;
+    return txt.includes(i.model)||txt.includes(dispName);
+  });
+  dot.className='status-dot';
+  if(inst){
+    dot.classList.add(inst.status||'ready');
+    dot.title=`Gateway: ${inst.status}`;
+  }
+}
+
+function _updateDropdownStatusSuffix(){
+  const sel=$('settingsModel')||$('modelSelect');
+  if(!sel) return;
+  for(const opt of sel.options){
+    const val=opt.value||'';
+    if(!val.startsWith('@gateway-')) continue;
+    const m=val.match(/^@gateway-(\w+):([\w.:-]+)\/([\w.-]+)$/);
+    if(!m) continue;
+    const [,label,model,keyword]=m;
+    const inst=_gwStatusCache.find(i=>i.label===label&&i.model===model&&i.keyword===keyword);
+    const cleanText=opt.textContent.replace(/\s*\([a-z]+\)$/,'');
+    if(inst){
+      opt.textContent=`${cleanText} (${inst.status})`;
+    }
+  }
+}
+
+function startGatewayPolling(){
+  if(_gwPollTimer) return;
+  pollGatewayStatus();
+  _gwPollTimer=setInterval(pollGatewayStatus,10000);
+}
+
+if(document.readyState==='loading'){
+  document.addEventListener('DOMContentLoaded',startGatewayPolling);
+}else{
+  startGatewayPolling();
+}
+
+/* ── Session Status Dots (PR #4 + PR #6 enhancements) ─────────────────────── */
+// CLI-busy recency window (seconds). Configurable via window.HERMES_CLI_BUSY_WINDOW_S.
+function _cliBusyWindow(){
+  const v=Number(window.HERMES_CLI_BUSY_WINDOW_S);
+  return Number.isFinite(v)&&v>0?v:15;
+}
+
+function updateSessionDots(){
+  const dots=document.querySelectorAll('.session-item .status-dot');
+  const nowSec=Date.now()/1000;
+  const win=_cliBusyWindow();
+  dots.forEach(dot=>{
+    dot.className='status-dot';
+    const sid=dot.dataset.sessionId;
+    const isCli=dot.dataset.cliSession==='1';
+    const upd=Number(dot.dataset.updatedAt||0);
+    if(S.busy&&S.session&&sid===S.session.session_id){
+      dot.classList.add('running');
+    }else if(isCli&&upd&&(nowSec-upd)<=win){
+      // CLI session updated recently → likely still busy.
+      dot.classList.add('running');
+    }else if(S.session&&sid===S.session.session_id){
+      dot.classList.add('recent');
+    }
+  });
+}
+
+// Auto-refresh dots every 3s so CLI recency window decays naturally.
+setInterval(()=>{ try{ updateSessionDots(); }catch(e){} }, 3000);

--- a/tests/test_gateway_provider.py
+++ b/tests/test_gateway_provider.py
@@ -471,6 +471,65 @@ class TestResolveGatewayModel(unittest.TestCase):
         finally:
             server.shutdown()
 
+    def test_resolve_uses_gw_prefix_to_disable_responses_api(self):
+        """Regression for commit e8d89a7c (#2): the resolved model name must be
+        prefixed with 'gw:' so AIAgent's responses-api auto-detection (which
+        triggers on any model starting with 'gpt-5') does NOT fire — the
+        gateway proxies everything as plain chat completions.
+        """
+        server, url = _start_mock_server()
+        try:
+            with patch("api.gateway_provider._load_gateway_configs",
+                        return_value=[{"label": "local", "url": url}]):
+                result = resolve_gateway_model("@gateway-local:claude-4.6-opus-high/test")
+                self.assertIsNotNone(result)
+                self.assertTrue(
+                    result["model"].startswith("gw:"),
+                    f"expected gw: prefix, got {result['model']!r}",
+                )
+        finally:
+            server.shutdown()
+
+    def test_resolve_sets_x_instance_keyword_header(self):
+        """Regression for commit e8d89a7c (#2): keyword is conveyed via the
+        x-instance-keyword HTTP header so the gateway can route to the right
+        instance. base_url must NOT embed the keyword (that was the rolled-back
+        commit 49a2be4f approach)."""
+        server, url = _start_mock_server()
+        try:
+            with patch("api.gateway_provider._load_gateway_configs",
+                        return_value=[{"label": "local", "url": url}]):
+                result = resolve_gateway_model("@gateway-local:claude-4.6-opus-high/test")
+                self.assertEqual(result["extra_headers"]["x-instance-keyword"], "test")
+                # And we should NOT have switched back to the path-routing layout
+                self.assertNotIn("/k/", result["base_url"])
+                self.assertNotIn("/v1/k/", result["base_url"])
+        finally:
+            server.shutdown()
+
+    def test_resolve_unknown_keyword_falls_back_to_cursor_route(self):
+        """When the requested (model, keyword) pair is not in the discovered
+        instance list, ``resolve_gateway_model`` should still produce a usable
+        config rather than returning None: cli_route defaults to 'cursor' so a
+        stale dropdown selection still routes somewhere instead of silently
+        failing.
+        """
+        server, url = _start_mock_server()
+        try:
+            with patch("api.gateway_provider._load_gateway_configs",
+                        return_value=[{"label": "local", "url": url}]):
+                result = resolve_gateway_model(
+                    "@gateway-local:never-registered-model/never-registered-kw"
+                )
+                self.assertIsNotNone(result)
+                self.assertEqual(result["base_url"], f"{url}/cursor/v1")
+                self.assertEqual(
+                    result["extra_headers"]["x-instance-keyword"],
+                    "never-registered-kw",
+                )
+        finally:
+            server.shutdown()
+
 
 # ---------------------------------------------------------------------------
 # Test: Thread safety

--- a/tests/test_gateway_provider.py
+++ b/tests/test_gateway_provider.py
@@ -433,7 +433,7 @@ class TestResolveGatewayModel(unittest.TestCase):
                         return_value=[{"label": "local", "url": url}]):
                 result = resolve_gateway_model("@gateway-local:claude-4.6-opus-high/test")
                 self.assertIsNotNone(result)
-                self.assertEqual(result["model"], "claude-4.6-opus-high")
+                self.assertEqual(result["model"], "gw:claude-4.6-opus-high")
                 self.assertEqual(result["base_url"], f"{url}/cursor/v1")
                 self.assertEqual(result["api_key"], "agent-gateway-no-key-required")
                 self.assertEqual(result["extra_headers"]["x-instance-keyword"], "test")

--- a/tests/test_gateway_provider.py
+++ b/tests/test_gateway_provider.py
@@ -1,0 +1,569 @@
+"""
+Tests for api/gateway_provider.py — Agent API Gateway integration.
+
+Covers:
+  - Model ID encoding/decoding
+  - Instance discovery with caching
+  - Gateway config loading (config.yaml + env vars)
+  - Model group generation for dropdown
+  - Model resolution for routing
+  - Cache TTL and invalidation
+  - Error handling (network failures, malformed data)
+"""
+
+import json
+import os
+import threading
+import time
+import unittest
+from http.server import HTTPServer, BaseHTTPRequestHandler
+from unittest.mock import patch, MagicMock
+
+import sys
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from api.gateway_provider import (
+    build_model_id,
+    parse_model_id,
+    is_gateway_model,
+    discover_instances,
+    clear_cache,
+    get_gateway_model_groups,
+    resolve_gateway_model,
+    _filter_active,
+    _fetch_instances,
+    _load_gateway_configs,
+    GATEWAY_PROVIDER_PREFIX,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+MOCK_INSTANCES = [
+    {
+        "id": "inst-001",
+        "keyword": "test",
+        "model": "claude-4.6-opus-high",
+        "cli": "cursor",
+        "status": "ready",
+        "pid": 12345,
+        "createdAt": "2026-04-12T10:00:00Z",
+        "lastUsedAt": "2026-04-12T10:05:00Z",
+        "requestCount": 5,
+        "turnCount": 10,
+        "restartCount": 0,
+    },
+    {
+        "id": "inst-002",
+        "keyword": "prod",
+        "model": "claude-4.6-opus-high",
+        "cli": "copilot",
+        "status": "busy",
+        "pid": 12346,
+        "createdAt": "2026-04-12T09:00:00Z",
+        "lastUsedAt": "2026-04-12T10:03:00Z",
+        "requestCount": 20,
+        "turnCount": 40,
+        "restartCount": 1,
+    },
+    {
+        "id": "inst-003",
+        "keyword": "dead",
+        "model": "gpt-4.1",
+        "cli": "copilot",
+        "status": "dead",
+        "pid": 0,
+        "createdAt": "2026-04-12T08:00:00Z",
+        "lastUsedAt": "2026-04-12T08:30:00Z",
+        "requestCount": 2,
+        "turnCount": 3,
+        "restartCount": 5,
+    },
+]
+
+
+class MockGatewayHandler(BaseHTTPRequestHandler):
+    """Minimal HTTP handler that serves /admin/instances."""
+
+    instances = MOCK_INSTANCES
+
+    def do_GET(self):
+        if self.path == "/admin/instances":
+            body = json.dumps(self.instances).encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def log_message(self, *args):
+        pass  # suppress request logs in test output
+
+
+def _start_mock_server(handler_class=MockGatewayHandler):
+    """Start a mock gateway server on a random port. Returns (server, url)."""
+    server = HTTPServer(("127.0.0.1", 0), handler_class)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server, f"http://127.0.0.1:{port}"
+
+
+# ---------------------------------------------------------------------------
+# Test: Model ID encoding / decoding
+# ---------------------------------------------------------------------------
+
+class TestModelIdEncoding(unittest.TestCase):
+
+    def test_build_model_id(self):
+        mid = build_model_id("local", "claude-4.6-opus-high", "test")
+        self.assertEqual(mid, "@gateway-local:claude-4.6-opus-high/test")
+
+    def test_build_model_id_remote(self):
+        mid = build_model_id("remote", "gpt-4.1", "prod")
+        self.assertEqual(mid, "@gateway-remote:gpt-4.1/prod")
+
+    def test_parse_model_id_valid(self):
+        result = parse_model_id("@gateway-local:claude-4.6-opus-high/test")
+        self.assertIsNotNone(result)
+        self.assertEqual(result["label"], "local")
+        self.assertEqual(result["model_name"], "claude-4.6-opus-high")
+        self.assertEqual(result["keyword"], "test")
+        self.assertEqual(result["provider_id"], "gateway-local")
+
+    def test_parse_model_id_no_keyword(self):
+        result = parse_model_id("@gateway-local:claude-4.6-opus-high")
+        self.assertIsNotNone(result)
+        self.assertEqual(result["model_name"], "claude-4.6-opus-high")
+        self.assertEqual(result["keyword"], "")
+
+    def test_parse_model_id_not_gateway(self):
+        self.assertIsNone(parse_model_id("claude-4.6-opus-high"))
+        self.assertIsNone(parse_model_id("@anthropic:claude-4.6"))
+        self.assertIsNone(parse_model_id(""))
+
+    def test_is_gateway_model(self):
+        self.assertTrue(is_gateway_model("@gateway-local:claude-4.6-opus-high/test"))
+        self.assertFalse(is_gateway_model("claude-4.6-opus-high"))
+        self.assertFalse(is_gateway_model("@openai:gpt-4"))
+
+    def test_roundtrip(self):
+        mid = build_model_id("remote", "model-x", "kw-y")
+        parsed = parse_model_id(mid)
+        self.assertEqual(parsed["label"], "remote")
+        self.assertEqual(parsed["model_name"], "model-x")
+        self.assertEqual(parsed["keyword"], "kw-y")
+
+    def test_parse_model_id_missing_colon(self):
+        self.assertIsNone(parse_model_id("@gateway-local"))
+
+
+# ---------------------------------------------------------------------------
+# Test: Instance filtering
+# ---------------------------------------------------------------------------
+
+class TestFilterActive(unittest.TestCase):
+
+    def test_filters_dead_instances(self):
+        active = _filter_active(MOCK_INSTANCES)
+        self.assertEqual(len(active), 2)
+        statuses = {i["status"] for i in active}
+        self.assertEqual(statuses, {"ready", "busy"})
+
+    def test_empty_list(self):
+        self.assertEqual(_filter_active([]), [])
+
+    def test_all_dead(self):
+        dead = [{"status": "dead"}, {"status": "error"}, {"status": "starting"}]
+        self.assertEqual(_filter_active(dead), [])
+
+
+# ---------------------------------------------------------------------------
+# Test: HTTP discovery
+# ---------------------------------------------------------------------------
+
+class TestFetchInstances(unittest.TestCase):
+
+    def setUp(self):
+        clear_cache()
+
+    def test_fetch_from_live_server(self):
+        server, url = _start_mock_server()
+        try:
+            instances = _fetch_instances(url)
+            self.assertEqual(len(instances), 3)
+            self.assertEqual(instances[0]["keyword"], "test")
+        finally:
+            server.shutdown()
+
+    def test_fetch_unreachable(self):
+        instances = _fetch_instances("http://127.0.0.1:1", timeout_s=1.0)
+        self.assertEqual(instances, [])
+
+    def test_fetch_non_json(self):
+        class BadHandler(BaseHTTPRequestHandler):
+            def do_GET(self):
+                self.send_response(200)
+                self.end_headers()
+                self.wfile.write(b"not json")
+            def log_message(self, *args):
+                pass
+
+        server, url = _start_mock_server(BadHandler)
+        try:
+            instances = _fetch_instances(url)
+            self.assertEqual(instances, [])
+        finally:
+            server.shutdown()
+
+    def test_fetch_server_error(self):
+        class ErrorHandler(BaseHTTPRequestHandler):
+            def do_GET(self):
+                self.send_response(500)
+                self.end_headers()
+            def log_message(self, *args):
+                pass
+
+        server, url = _start_mock_server(ErrorHandler)
+        try:
+            instances = _fetch_instances(url)
+            self.assertEqual(instances, [])
+        finally:
+            server.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# Test: Discovery with caching
+# ---------------------------------------------------------------------------
+
+class TestDiscoverInstances(unittest.TestCase):
+
+    def setUp(self):
+        clear_cache()
+
+    def test_discover_caches_results(self):
+        server, url = _start_mock_server()
+        try:
+            result1 = discover_instances(url)
+            self.assertEqual(len(result1), 2)  # only active
+
+            # Shut down server — cached result should still work
+            server.shutdown()
+
+            result2 = discover_instances(url)
+            self.assertEqual(len(result2), 2)
+            self.assertEqual(result1, result2)
+        finally:
+            try:
+                server.shutdown()
+            except Exception:
+                pass
+
+    def test_discover_force_refresh(self):
+        server, url = _start_mock_server()
+        try:
+            discover_instances(url)
+
+            # Force refresh should hit the server again
+            result = discover_instances(url, force_refresh=True)
+            self.assertEqual(len(result), 2)
+        finally:
+            server.shutdown()
+
+    def test_discover_cache_expiry(self):
+        server, url = _start_mock_server()
+        try:
+            discover_instances(url, max_age_s=0.1)
+            time.sleep(0.2)
+
+            # Cache expired — should re-fetch
+            result = discover_instances(url, max_age_s=0.1)
+            self.assertEqual(len(result), 2)
+        finally:
+            server.shutdown()
+
+    def test_discover_fallback_to_stale_cache(self):
+        server, url = _start_mock_server()
+        try:
+            discover_instances(url)
+        finally:
+            server.shutdown()
+
+        # Server is down, cache is stale but should still return last-known-good
+        result = discover_instances(url, max_age_s=0)
+        self.assertEqual(len(result), 2)
+
+    def test_clear_cache_specific(self):
+        server, url = _start_mock_server()
+        try:
+            discover_instances(url)
+            clear_cache(url)
+            # After clearing, should re-fetch
+            result = discover_instances(url)
+            self.assertEqual(len(result), 2)
+        finally:
+            server.shutdown()
+
+    def test_clear_cache_all(self):
+        server, url = _start_mock_server()
+        try:
+            discover_instances(url)
+            clear_cache()
+            # After clearing all, should re-fetch
+            result = discover_instances(url)
+            self.assertEqual(len(result), 2)
+        finally:
+            server.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# Test: Config loading
+# ---------------------------------------------------------------------------
+
+class TestLoadGatewayConfigs(unittest.TestCase):
+
+    def test_env_var_local(self):
+        with patch.dict(os.environ, {"AGENT_GATEWAY_LOCAL_URL": "http://10.0.0.1:3000"}, clear=False):
+            with patch("api.gateway_provider.cfg", {}, create=True):
+                configs = _load_gateway_configs()
+                self.assertTrue(any(c["url"] == "http://10.0.0.1:3000" for c in configs))
+
+    def test_env_var_remote(self):
+        with patch.dict(os.environ, {
+            "AGENT_GATEWAY_LOCAL_URL": "http://local:3000",
+            "AGENT_GATEWAY_REMOTE_URL": "http://remote:3000",
+        }, clear=False):
+            with patch("api.gateway_provider.cfg", {}, create=True):
+                configs = _load_gateway_configs()
+                self.assertEqual(len(configs), 2)
+                self.assertEqual(configs[0]["url"], "http://local:3000")
+                self.assertEqual(configs[1]["url"], "http://remote:3000")
+
+    def test_config_yaml_integration(self):
+        mock_cfg = {
+            "gateway_providers": [
+                {"label": "dev", "url": "http://dev-server:3000"},
+                {"label": "staging", "url": "http://staging:3000"},
+            ]
+        }
+        # Patch the import inside _load_gateway_configs
+        with patch.dict(os.environ, {}, clear=False):
+            # Remove env vars that might interfere
+            env_clean = {k: v for k, v in os.environ.items()
+                         if k not in ("AGENT_GATEWAY_LOCAL_URL", "AGENT_GATEWAY_REMOTE_URL")}
+            with patch.dict(os.environ, env_clean, clear=True):
+                with patch("api.gateway_provider._load_gateway_configs") as mock_load:
+                    mock_load.return_value = [
+                        {"label": "dev", "url": "http://dev-server:3000"},
+                        {"label": "staging", "url": "http://staging:3000"},
+                    ]
+                    configs = mock_load()
+                    self.assertEqual(len(configs), 2)
+                    self.assertEqual(configs[0]["label"], "dev")
+
+
+# ---------------------------------------------------------------------------
+# Test: Model groups for dropdown
+# ---------------------------------------------------------------------------
+
+class TestGetGatewayModelGroups(unittest.TestCase):
+
+    def setUp(self):
+        clear_cache()
+
+    def test_returns_model_groups(self):
+        server, url = _start_mock_server()
+        try:
+            with patch("api.gateway_provider._load_gateway_configs",
+                        return_value=[{"label": "local", "url": url}]):
+                groups = get_gateway_model_groups()
+                self.assertEqual(len(groups), 1)
+                self.assertEqual(groups[0]["provider"], "gateway-local")
+                models = groups[0]["models"]
+                self.assertEqual(len(models), 2)  # 2 active instances
+                # Check model IDs
+                ids = {m["id"] for m in models}
+                self.assertIn("@gateway-local:claude-4.6-opus-high/test", ids)
+                self.assertIn("@gateway-local:claude-4.6-opus-high/prod", ids)
+        finally:
+            server.shutdown()
+
+    def test_empty_when_no_gateways(self):
+        with patch("api.gateway_provider._load_gateway_configs", return_value=[]):
+            groups = get_gateway_model_groups()
+            self.assertEqual(groups, [])
+
+    def test_empty_when_gateway_unreachable(self):
+        with patch("api.gateway_provider._load_gateway_configs",
+                    return_value=[{"label": "local", "url": "http://127.0.0.1:1"}]):
+            groups = get_gateway_model_groups()
+            self.assertEqual(groups, [])
+
+    def test_model_labels_include_cli_and_keyword(self):
+        server, url = _start_mock_server()
+        try:
+            with patch("api.gateway_provider._load_gateway_configs",
+                        return_value=[{"label": "local", "url": url}]):
+                groups = get_gateway_model_groups()
+                labels = {m["label"] for m in groups[0]["models"]}
+                self.assertIn("claude-4.6-opus-high [CURSOR:test]", labels)
+                self.assertIn("claude-4.6-opus-high [COPILOT:prod]", labels)
+        finally:
+            server.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# Test: Model resolution for routing
+# ---------------------------------------------------------------------------
+
+class TestResolveGatewayModel(unittest.TestCase):
+
+    def setUp(self):
+        clear_cache()
+
+    def test_resolve_valid_model(self):
+        server, url = _start_mock_server()
+        try:
+            with patch("api.gateway_provider._load_gateway_configs",
+                        return_value=[{"label": "local", "url": url}]):
+                result = resolve_gateway_model("@gateway-local:claude-4.6-opus-high/test")
+                self.assertIsNotNone(result)
+                self.assertEqual(result["model"], "claude-4.6-opus-high")
+                self.assertEqual(result["base_url"], f"{url}/cursor/v1")
+                self.assertEqual(result["api_key"], "agent-gateway-no-key-required")
+                self.assertEqual(result["extra_headers"]["x-instance-keyword"], "test")
+        finally:
+            server.shutdown()
+
+    def test_resolve_copilot_cli_route(self):
+        server, url = _start_mock_server()
+        try:
+            with patch("api.gateway_provider._load_gateway_configs",
+                        return_value=[{"label": "local", "url": url}]):
+                result = resolve_gateway_model("@gateway-local:claude-4.6-opus-high/prod")
+                self.assertIsNotNone(result)
+                self.assertEqual(result["base_url"], f"{url}/copilot/v1")
+        finally:
+            server.shutdown()
+
+    def test_resolve_non_gateway_model(self):
+        result = resolve_gateway_model("claude-4.6-opus-high")
+        self.assertIsNone(result)
+
+    def test_resolve_unknown_label(self):
+        with patch("api.gateway_provider._load_gateway_configs",
+                    return_value=[{"label": "local", "url": "http://localhost:3000"}]):
+            result = resolve_gateway_model("@gateway-nonexistent:model/kw")
+            self.assertIsNone(result)
+
+    def test_resolve_provider_is_openai(self):
+        server, url = _start_mock_server()
+        try:
+            with patch("api.gateway_provider._load_gateway_configs",
+                        return_value=[{"label": "local", "url": url}]):
+                result = resolve_gateway_model("@gateway-local:claude-4.6-opus-high/test")
+                self.assertEqual(result["provider"], "openai")
+        finally:
+            server.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# Test: Thread safety
+# ---------------------------------------------------------------------------
+
+class TestThreadSafety(unittest.TestCase):
+
+    def setUp(self):
+        clear_cache()
+
+    def test_concurrent_discovery(self):
+        server, url = _start_mock_server()
+        results = []
+        errors = []
+
+        def worker():
+            try:
+                r = discover_instances(url)
+                results.append(len(r))
+            except Exception as e:
+                errors.append(e)
+
+        try:
+            threads = [threading.Thread(target=worker) for _ in range(10)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join(timeout=10)
+
+            self.assertEqual(errors, [])
+            self.assertTrue(all(r == 2 for r in results))
+        finally:
+            server.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# Test: Edge cases
+# ---------------------------------------------------------------------------
+
+class TestEdgeCases(unittest.TestCase):
+
+    def setUp(self):
+        clear_cache()
+
+    def test_empty_instance_list(self):
+        class EmptyHandler(BaseHTTPRequestHandler):
+            def do_GET(self):
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                body = b"[]"
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+            def log_message(self, *args):
+                pass
+
+        server, url = _start_mock_server(EmptyHandler)
+        try:
+            instances = discover_instances(url)
+            self.assertEqual(instances, [])
+        finally:
+            server.shutdown()
+
+    def test_non_list_response(self):
+        class DictHandler(BaseHTTPRequestHandler):
+            def do_GET(self):
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                body = b'{"error": "not a list"}'
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+            def log_message(self, *args):
+                pass
+
+        server, url = _start_mock_server(DictHandler)
+        try:
+            instances = _fetch_instances(url)
+            self.assertEqual(instances, [])
+        finally:
+            server.shutdown()
+
+    def test_trailing_slash_normalization(self):
+        mid1 = build_model_id("local", "m", "k")
+        mid2 = build_model_id("local", "m", "k")
+        self.assertEqual(mid1, mid2)
+
+    def test_model_id_with_special_chars(self):
+        mid = build_model_id("local", "claude-4.6-opus-high-thinking", "my-instance_01")
+        parsed = parse_model_id(mid)
+        self.assertEqual(parsed["model_name"], "claude-4.6-opus-high-thinking")
+        self.assertEqual(parsed["keyword"], "my-instance_01")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_rename_session.py
+++ b/tests/test_rename_session.py
@@ -1,0 +1,236 @@
+"""
+Regression tests for /api/session/rename across both session storage backends.
+
+Covers two bugs that previously broke the double-click-to-rename action in
+the left sidebar:
+
+  1) Renaming a CLI / agent / gateway-imported session (whose data lives in
+     ``~/.hermes/state.db``, not in ``SESSION_DIR``) returned 404, so the
+     optimistic UI update was reverted on the next refresh.  Fixed by routing
+     the rename through ``api.state_sync.rename_cli_session`` when the
+     session is not owned by the WebUI.
+
+  2) Renaming a WebUI session worked, but state.db (used by /insights and
+     the "all sessions" view) was not kept in sync, so listings would still
+     show the old title in some places.  The handler now best-effort mirrors
+     the new title to state.db after writing the JSON file.
+
+These tests reuse the shared isolated server fixture in conftest.py
+(port 8788, HERMES_HOME=TEST_STATE_DIR).
+"""
+
+import json
+import os
+import pathlib
+import sqlite3
+import time
+import urllib.error
+import urllib.request
+
+
+BASE = "http://127.0.0.1:8788"
+
+
+# ── HTTP helpers ──────────────────────────────────────────────────────────────
+
+def _post(path, body=None):
+    data = json.dumps(body or {}).encode()
+    req = urllib.request.Request(
+        BASE + path, data=data,
+        headers={"Content-Type": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10) as r:
+            return json.loads(r.read()), r.status
+    except urllib.error.HTTPError as e:
+        try:
+            return json.loads(e.read()), e.code
+        except Exception:
+            return {}, e.code
+
+
+def _get(path):
+    with urllib.request.urlopen(BASE + path, timeout=10) as r:
+        return json.loads(r.read()), r.status
+
+
+# ── State.db helpers (mirror tests/test_gateway_sync.py) ──────────────────────
+
+def _state_db_path():
+    explicit = os.getenv('HERMES_WEBUI_TEST_STATE_DIR')
+    if explicit:
+        return pathlib.Path(explicit) / 'state.db'
+    home = pathlib.Path(os.getenv('HERMES_HOME', str(pathlib.Path.home() / '.hermes')))
+    return home / 'webui-mvp-test' / 'state.db'
+
+
+def _ensure_state_db():
+    db = _state_db_path()
+    db.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(db))
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.executescript("""
+        CREATE TABLE IF NOT EXISTS sessions (
+            id TEXT PRIMARY KEY,
+            source TEXT NOT NULL,
+            user_id TEXT,
+            model TEXT,
+            started_at REAL NOT NULL,
+            message_count INTEGER DEFAULT 0,
+            title TEXT
+        );
+        CREATE TABLE IF NOT EXISTS messages (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT NOT NULL,
+            role TEXT NOT NULL,
+            content TEXT,
+            timestamp REAL NOT NULL
+        );
+    """)
+    conn.commit()
+    return conn
+
+
+def _insert_cli_session(conn, sid, title="Original CLI Title", source="cli"):
+    conn.execute(
+        "INSERT OR REPLACE INTO sessions "
+        "(id, source, title, model, started_at, message_count) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        (sid, source, title, "anthropic/claude-sonnet-4-5", time.time(), 1),
+    )
+    # one stub message so the session isn't filtered out as empty
+    conn.execute(
+        "INSERT INTO messages (session_id, role, content, timestamp) "
+        "VALUES (?, 'user', 'hi', ?)",
+        (sid, time.time()),
+    )
+    conn.commit()
+
+
+def _read_db_title(conn, sid):
+    row = conn.execute("SELECT title FROM sessions WHERE id = ?", (sid,)).fetchone()
+    return row["title"] if row else None
+
+
+def _cleanup(conn, sid):
+    try:
+        conn.execute("DELETE FROM messages WHERE session_id = ?", (sid,))
+        conn.execute("DELETE FROM sessions WHERE id = ?", (sid,))
+        conn.commit()
+    except Exception:
+        pass
+
+
+def _new_webui_session():
+    """Create a WebUI session and return its sid (handles both flat and {session: ...} shapes)."""
+    new, status = _post("/api/session/new", {})
+    assert status == 200, new
+    if isinstance(new, dict) and "session" in new:
+        return new["session"]["session_id"]
+    return new["session_id"]
+
+
+# ── Tests: WebUI-owned sessions (regression guard for the existing path) ─────
+
+def test_rename_webui_session_persists_after_refresh():
+    """Renaming a normal WebUI session should persist across a fresh /api/sessions read."""
+    sid = _new_webui_session()
+
+    try:
+        # Rename it
+        out, code = _post(
+            "/api/session/rename",
+            {"session_id": sid, "title": "Renamed WebUI"},
+        )
+        assert code == 200, (code, out)
+        assert out["session"]["title"] == "Renamed WebUI"
+
+        # Re-read /api/sessions and confirm the new title is what comes back
+        listing, code = _get("/api/sessions")
+        assert code == 200
+        match = [s for s in listing["sessions"] if s["session_id"] == sid]
+        assert match, f"session {sid} missing from listing"
+        assert match[0]["title"] == "Renamed WebUI"
+    finally:
+        _post("/api/session/delete", {"session_id": sid})
+
+
+def test_rename_webui_session_caps_title_length():
+    """Long titles are clipped to 80 chars (UI contract)."""
+    sid = _new_webui_session()
+    try:
+        long_title = "x" * 200
+        out, code = _post(
+            "/api/session/rename",
+            {"session_id": sid, "title": long_title},
+        )
+        assert code == 200
+        assert len(out["session"]["title"]) == 80
+        assert out["session"]["title"] == "x" * 80
+    finally:
+        _post("/api/session/delete", {"session_id": sid})
+
+
+def test_rename_webui_session_blank_falls_back_to_untitled():
+    sid = _new_webui_session()
+    try:
+        out, code = _post(
+            "/api/session/rename",
+            {"session_id": sid, "title": "   "},
+        )
+        assert code == 200
+        assert out["session"]["title"] == "Untitled"
+    finally:
+        _post("/api/session/delete", {"session_id": sid})
+
+
+# ── Tests: CLI / state.db sessions (the actual bug we're fixing) ─────────────
+
+def test_rename_cli_session_writes_to_state_db():
+    """A CLI/gateway-imported session must be renamable via the WebUI API.
+
+    This is the regression for the user-reported bug:
+      "double-click rename in the left sidebar reverts after refresh".
+    """
+    conn = _ensure_state_db()
+    sid = "20260424_120000_renametest"
+    try:
+        _insert_cli_session(conn, sid, title="Original CLI Title", source="cli")
+
+        out, code = _post(
+            "/api/session/rename",
+            {"session_id": sid, "title": "Renamed via WebUI"},
+        )
+        assert code == 200, (code, out)
+        assert out["session"]["title"] == "Renamed via WebUI"
+        assert out["session"]["session_id"] == sid
+        assert out["session"].get("is_cli_session") is True
+
+        # And the new title must actually be in state.db so a refresh shows it
+        # state.db is shared with the live conn — re-open to bypass any cache
+        conn2 = sqlite3.connect(str(_state_db_path()))
+        conn2.row_factory = sqlite3.Row
+        try:
+            row = conn2.execute(
+                "SELECT title FROM sessions WHERE id = ?", (sid,)
+            ).fetchone()
+        finally:
+            conn2.close()
+        assert row is not None
+        assert row["title"] == "Renamed via WebUI"
+    finally:
+        _cleanup(conn, sid)
+        try:
+            conn.close()
+        except Exception:
+            pass
+
+
+def test_rename_unknown_session_returns_404():
+    """Renaming a session_id that exists nowhere is a clean 404, not a 500."""
+    out, code = _post(
+        "/api/session/rename",
+        {"session_id": "nosuchsession_99999999", "title": "ghost"},
+    )
+    assert code == 404, (code, out)

--- a/tests/test_sidebar_status_indicators.py
+++ b/tests/test_sidebar_status_indicators.py
@@ -1,0 +1,220 @@
+"""
+Tests for the per-conversation accent + CLI/agent session real-time busy
+indicator added on top of the existing #4 status-indicators feature.
+
+Coverage:
+
+* The sidebar status dot for a CLI / agent session is rendered with
+  ``data-cli-session="1"`` and ``data-updated-at=<ts>`` attributes so the
+  client-side ``updateSessionDots()`` recency check has the data it needs.
+* ``updateSessionDots()`` (in static/ui.js) marks a CLI session as
+  ``running`` (green pulse) when its ``updated_at`` is within
+  ``HERMES_CLI_BUSY_WINDOW_S`` and clears that class once the activity
+  window expires.
+* ``_hashHue()`` in static/sessions.js produces a stable hue per session id.
+
+The JS-level checks run by extracting the relevant helper functions out of
+the static files and evaluating them in a tiny mini-DOM stub built with
+plain Python — no node, jest, or browser required.  This lets us
+regression-guard the dot logic from pytest.
+"""
+
+import json
+import os
+import pathlib
+import re
+import shutil
+import sqlite3
+import subprocess
+import time
+import unittest
+
+
+REPO_ROOT = pathlib.Path(__file__).parent.parent.resolve()
+SESSIONS_JS = REPO_ROOT / "static" / "sessions.js"
+UI_JS = REPO_ROOT / "static" / "ui.js"
+
+
+# ---------------------------------------------------------------------------
+# JS helper extraction
+# ---------------------------------------------------------------------------
+
+def _extract_function(src: str, name: str) -> str:
+    """Pull a top-level `function name(...){...}` block out of a JS source file.
+
+    Uses brace-matching so it handles bodies with nested ``{...}`` literals.
+    """
+    pattern = re.compile(r"\bfunction\s+" + re.escape(name) + r"\s*\(")
+    m = pattern.search(src)
+    if not m:
+        raise AssertionError(f"function {name} not found in source")
+    # Walk forward to the opening brace
+    i = src.index("{", m.end() - 1)
+    depth = 0
+    j = i
+    while j < len(src):
+        c = src[j]
+        if c == "{":
+            depth += 1
+        elif c == "}":
+            depth -= 1
+            if depth == 0:
+                return src[m.start():j + 1]
+        j += 1
+    raise AssertionError(f"unterminated function {name}")
+
+
+# ---------------------------------------------------------------------------
+# Run-via-node helper.  Skips cleanly when node isn't installed.
+# ---------------------------------------------------------------------------
+
+NODE = shutil.which("node")
+
+
+def _run_node(snippet: str) -> str:
+    """Eval a JS snippet via `node -e` and return stdout (stripped)."""
+    proc = subprocess.run(
+        [NODE, "-e", snippet],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    if proc.returncode != 0:
+        raise AssertionError(
+            f"node failed (rc={proc.returncode}):\nSTDOUT:\n{proc.stdout}\nSTDERR:\n{proc.stderr}"
+        )
+    return proc.stdout.strip()
+
+
+@unittest.skipIf(NODE is None, "node not installed; JS-level tests skipped")
+class TestHashHueIsStable(unittest.TestCase):
+    """``_hashHue(session_id)`` must deterministically map an id to a hue 0–359."""
+
+    def test_hash_hue_returns_int_in_range(self):
+        src = SESSIONS_JS.read_text()
+        fn = _extract_function(src, "_hashHue")
+        out = _run_node(
+            fn + ";"
+            "const ids = ['s1','session_abcdef','20260424_120000_xyz','',null];"
+            "const out = ids.map(s => _hashHue(s));"
+            "console.log(JSON.stringify(out));"
+        )
+        result = json.loads(out)
+        self.assertEqual(len(result), 5)
+        for h in result:
+            self.assertIsInstance(h, int)
+            self.assertGreaterEqual(h, 0)
+            self.assertLess(h, 360)
+        # Identical ids must give identical hues
+        out2 = _run_node(
+            fn + ";"
+            "console.log(_hashHue('repeatable_session_id_001'));"
+        )
+        out3 = _run_node(
+            fn + ";"
+            "console.log(_hashHue('repeatable_session_id_001'));"
+        )
+        self.assertEqual(out2, out3)
+        # Different ids should usually give different hues; at least not all
+        # collapse to a single value.
+        out4 = _run_node(
+            fn + ";"
+            "const hs=new Set();"
+            "for(let i=0;i<50;i++) hs.add(_hashHue('id-'+i));"
+            "console.log(hs.size);"
+        )
+        # 50 ids should land on >5 distinct hues even with bad luck
+        self.assertGreater(int(out4), 5)
+
+
+@unittest.skipIf(NODE is None, "node not installed; JS-level tests skipped")
+class TestUpdateSessionDotsRecencyWindow(unittest.TestCase):
+    """``updateSessionDots()`` must promote CLI sessions to the ``running``
+    class when their data-updated-at timestamp is within the busy window, and
+    clear that class once the window has elapsed."""
+
+    def _harness(self, fn_src: str, *, updated_at_offset_s: float, busy_window_s: int = 15) -> dict:
+        """Run updateSessionDots against a tiny DOM stub and return the dot's
+        className + title at the end.
+
+        ``updated_at_offset_s`` is added to the current Date.now() / 1000.
+        Negative values simulate "X seconds ago"; 0 means "right now".
+        """
+        snippet = (
+            # ── DOM stub ──
+            "class El {"
+            "  constructor(){ this.dataset={}; this.classList=new Set(); this.title=''; this.className=''; }"
+            "  classList = null;"  # placeholder; overwritten in ctor
+            "}"
+            # Intercept className assignment so it also resets classList (mirrors browser)
+            "function makeDot(updatedAt){"
+            "  const d={dataset:{sessionId:'sid-cli-1',cliSession:'1',updatedAt:String(updatedAt)},_classes:new Set(),title:''};"
+            "  Object.defineProperty(d,'className',{"
+            "    get(){return Array.from(this._classes).join(' ');},"
+            "    set(v){this._classes = new Set(v.split(/\\s+/).filter(Boolean));}"
+            "  });"
+            "  d.classList = {add:(c)=>d._classes.add(c), remove:(c)=>d._classes.delete(c), contains:(c)=>d._classes.has(c)};"
+            "  return d;"
+            "}"
+            f"const __OFFSET = {updated_at_offset_s};"
+            f"const __WINDOW = {busy_window_s};"
+            "const __DOT = makeDot(Date.now()/1000 + __OFFSET);"
+            "global.document = {"
+            "  querySelectorAll: (sel) => sel.includes('status-dot') ? [__DOT] : []"
+            "};"
+            "global.window = { HERMES_CLI_BUSY_WINDOW_S: __WINDOW };"
+            "global.S = { busy:false, session:null };"
+            # The function references _CLI_BUSY_WINDOW_S as a const on the
+            # outer scope; declare it so the function is self-contained.
+            "const _CLI_BUSY_WINDOW_S = 15;"
+            f"{fn_src};"
+            "updateSessionDots();"
+            "console.log(JSON.stringify({className: __DOT.className, title: __DOT.title}));"
+        )
+        return json.loads(_run_node(snippet))
+
+    def test_cli_session_within_busy_window_is_running(self):
+        src = UI_JS.read_text()
+        fn = _extract_function(src, "updateSessionDots")
+        result = self._harness(fn, updated_at_offset_s=-2)
+        self.assertIn("running", result["className"].split())
+        self.assertIn("CLI", result["title"])
+
+    def test_cli_session_outside_busy_window_is_idle(self):
+        src = UI_JS.read_text()
+        fn = _extract_function(src, "updateSessionDots")
+        result = self._harness(fn, updated_at_offset_s=-999)
+        self.assertNotIn("running", result["className"].split())
+        # Idle dot should not advertise CLI activity in its tooltip
+        self.assertNotIn("CLI", result["title"])
+
+    def test_busy_window_is_configurable(self):
+        src = UI_JS.read_text()
+        fn = _extract_function(src, "updateSessionDots")
+        # 5s ago is OUTSIDE a 3-second window
+        result = self._harness(fn, updated_at_offset_s=-5, busy_window_s=3)
+        self.assertNotIn("running", result["className"].split())
+        # 5s ago is INSIDE a 60-second window
+        result = self._harness(fn, updated_at_offset_s=-5, busy_window_s=60)
+        self.assertIn("running", result["className"].split())
+
+
+# ---------------------------------------------------------------------------
+# CSS sanity check (no node required)
+# ---------------------------------------------------------------------------
+
+class TestSidebarAccentCss(unittest.TestCase):
+    def test_session_item_has_conv_accent_rule(self):
+        css = (REPO_ROOT / "static" / "style.css").read_text()
+        self.assertIn("--conv-accent", css)
+        # The rule must apply only when a session-item actually has the
+        # variable set inline (i.e. not the active item, which has its own
+        # gold border)
+        self.assertRegex(
+            css,
+            r"\.session-item\[style\*=\"--conv-accent\"\][^{]*\{[^}]*border-left-color",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_streaming_gateway.py
+++ b/tests/test_streaming_gateway.py
@@ -147,7 +147,7 @@ class TestGatewayResolveIntegration(unittest.TestCase):
         result = resolve_gateway_model(model_id)
 
         self.assertIsNotNone(result)
-        self.assertEqual(result["model"], "gpt-4")
+        self.assertEqual(result["model"], "gw:gpt-4")
         self.assertIn("extra_headers", result)
         self.assertEqual(result["extra_headers"]["x-instance-keyword"], "my-cursor-1")
 
@@ -223,7 +223,7 @@ class TestConfigIntegration(unittest.TestCase):
         model_id = build_model_id("local", "gpt-4", "my-cursor-1")
         model, provider, base_url = resolve_model_provider(model_id)
 
-        self.assertEqual(model, "gpt-4")
+        self.assertEqual(model, "gw:gpt-4")
         self.assertEqual(provider, "openai")
         self.assertIn("/cursor/v1", base_url)
 

--- a/tests/test_streaming_gateway.py
+++ b/tests/test_streaming_gateway.py
@@ -1,0 +1,239 @@
+"""
+Tests for gateway model integration in api/streaming.py.
+
+Verifies that when a gateway model is selected:
+1. The gateway provider is detected and resolved
+2. A synthetic API key is used (no real key needed)
+3. Extra headers (x-instance-keyword) are injected via request_overrides
+4. Non-gateway models fall through to normal resolution
+"""
+import os
+import sys
+import threading
+import unittest
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+FAKE_INSTANCES = [
+    {"keyword": "my-cursor-1", "cli": "cursor", "status": "alive", "model": "gpt-4"},
+    {"keyword": "cp1", "cli": "copilot", "status": "alive", "model": "gpt-4"},
+]
+
+FAKE_CONFIGS = [
+    {"label": "local", "url": "http://localhost:3456"},
+]
+
+
+class TestStreamingGatewayIntegration(unittest.TestCase):
+    """Test that _run_agent_streaming correctly handles gateway models."""
+
+    def _make_fake_agent_cls(self):
+        """Return a mock AIAgent class that records constructor kwargs."""
+        captured = {}
+
+        class FakeAgent:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+                self.model = kwargs.get("model", "")
+                self.provider = kwargs.get("provider", "")
+                self.base_url = kwargs.get("base_url", "")
+                self.api_key = kwargs.get("api_key", "")
+                self.request_overrides = kwargs.get("request_overrides")
+                self.session_id = kwargs.get("session_id", "")
+
+            def run(self, *a, **kw):
+                return "done"
+
+        return FakeAgent, captured
+
+    @patch("api.gateway_provider._load_gateway_configs", return_value=FAKE_CONFIGS)
+    @patch("api.gateway_provider.discover_instances", return_value=FAKE_INSTANCES)
+    @patch("api.streaming._get_ai_agent")
+    @patch("api.streaming.resolve_model_provider")
+    def test_gateway_model_injects_extra_headers(
+        self, mock_resolve_model, mock_get_agent, mock_discover, mock_configs
+    ):
+        """Gateway models should inject x-instance-keyword via request_overrides."""
+        mock_resolve_model.return_value = ("gpt-4", "openai", "http://localhost:3456/cursor/v1")
+
+        FakeAgent, captured = self._make_fake_agent_cls()
+        mock_get_agent.return_value = FakeAgent
+
+        from api.streaming import _run_agent_streaming
+
+        model_id = "@gateway-local:gpt-4/my-cursor-1"
+
+        with patch("api.streaming.get_session") as mock_get_session, \
+             patch("api.streaming.set_last_workspace"), \
+             patch("api.streaming._set_thread_env"), \
+             patch("api.streaming._clear_thread_env"), \
+             patch("api.streaming._get_session_agent_lock") as mock_lock, \
+             patch("api.streaming.CANCEL_FLAGS", {}), \
+             patch("api.streaming.AGENT_INSTANCES", {}), \
+             patch("api.streaming.STREAMS", {}), \
+             patch("api.streaming.STREAMS_LOCK", threading.Lock()), \
+             patch("api.streaming._ENV_LOCK", threading.Lock()), \
+             patch.dict(os.environ, {}, clear=False):
+
+            mock_session = MagicMock()
+            mock_session.messages = []
+            mock_session.workspace = None
+            mock_get_session.return_value = mock_session
+            mock_lock.return_value = MagicMock()
+
+            try:
+                _run_agent_streaming("test-session", model_id, "Hello", MagicMock())
+            except Exception:
+                pass
+
+            if captured:
+                self.assertEqual(captured.get("api_key"), "agent-gateway-no-key-required")
+                overrides = captured.get("request_overrides")
+                self.assertIsNotNone(overrides)
+                self.assertIn("extra_headers", overrides)
+                self.assertEqual(
+                    overrides["extra_headers"]["x-instance-keyword"],
+                    "my-cursor-1",
+                )
+
+    def test_non_gateway_model_no_detection(self):
+        """Non-gateway models should not be detected as gateway models."""
+        from api.gateway_provider import is_gateway_model
+        self.assertFalse(is_gateway_model("gpt-4"))
+        self.assertFalse(is_gateway_model("claude-3-opus"))
+        self.assertFalse(is_gateway_model(""))
+        self.assertFalse(is_gateway_model("anthropic/claude-3"))
+
+    def test_gateway_model_id_detection(self):
+        """Verify the gateway model ID format is correctly detected."""
+        from api.gateway_provider import is_gateway_model
+        self.assertTrue(is_gateway_model("@gateway-local:gpt-4/my-cursor"))
+        self.assertTrue(is_gateway_model("@gateway-remote:claude-3/copilot-1"))
+
+    def test_request_overrides_empty_for_non_gateway(self):
+        """When no gateway headers exist, request_overrides should be None."""
+        _gateway_extra_headers = {}
+        _request_overrides = {}
+        if _gateway_extra_headers:
+            _request_overrides["extra_headers"] = _gateway_extra_headers
+
+        result = _request_overrides if _request_overrides else None
+        self.assertIsNone(result)
+
+    def test_request_overrides_populated_for_gateway(self):
+        """When gateway headers exist, request_overrides should contain extra_headers."""
+        _gateway_extra_headers = {"x-instance-keyword": "test-inst"}
+        _request_overrides = {}
+        if _gateway_extra_headers:
+            _request_overrides["extra_headers"] = _gateway_extra_headers
+
+        result = _request_overrides if _request_overrides else None
+        self.assertIsNotNone(result)
+        self.assertEqual(result["extra_headers"]["x-instance-keyword"], "test-inst")
+
+
+class TestGatewayResolveIntegration(unittest.TestCase):
+    """Test resolve_gateway_model returns correct routing info."""
+
+    @patch("api.gateway_provider._load_gateway_configs", return_value=FAKE_CONFIGS)
+    @patch("api.gateway_provider.discover_instances", return_value=FAKE_INSTANCES)
+    def test_resolve_returns_extra_headers(self, mock_discover, mock_configs):
+        """resolve_gateway_model should include extra_headers with x-instance-keyword."""
+        from api.gateway_provider import resolve_gateway_model, build_model_id
+
+        model_id = build_model_id("local", "gpt-4", "my-cursor-1")
+        result = resolve_gateway_model(model_id)
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result["model"], "gpt-4")
+        self.assertIn("extra_headers", result)
+        self.assertEqual(result["extra_headers"]["x-instance-keyword"], "my-cursor-1")
+
+    @patch("api.gateway_provider._load_gateway_configs", return_value=FAKE_CONFIGS)
+    @patch("api.gateway_provider.discover_instances", return_value=FAKE_INSTANCES)
+    def test_resolve_synthetic_api_key(self, mock_discover, mock_configs):
+        """Gateway models should use a synthetic API key."""
+        from api.gateway_provider import resolve_gateway_model, build_model_id
+
+        model_id = build_model_id("local", "gpt-4", "my-cursor-1")
+        result = resolve_gateway_model(model_id)
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result["api_key"], "agent-gateway-no-key-required")
+
+    @patch("api.gateway_provider._load_gateway_configs", return_value=FAKE_CONFIGS)
+    @patch("api.gateway_provider.discover_instances", return_value=FAKE_INSTANCES)
+    def test_cursor_route(self, mock_discover, mock_configs):
+        """Cursor instances should route to /cursor/v1."""
+        from api.gateway_provider import resolve_gateway_model, build_model_id
+
+        model_id = build_model_id("local", "gpt-4", "my-cursor-1")
+        result = resolve_gateway_model(model_id)
+        self.assertIn("/cursor/v1", result["base_url"])
+
+    @patch("api.gateway_provider._load_gateway_configs", return_value=FAKE_CONFIGS)
+    @patch("api.gateway_provider.discover_instances", return_value=FAKE_INSTANCES)
+    def test_copilot_route(self, mock_discover, mock_configs):
+        """Copilot instances should route to /copilot/v1."""
+        from api.gateway_provider import resolve_gateway_model, build_model_id
+
+        model_id = build_model_id("local", "gpt-4", "cp1")
+        result = resolve_gateway_model(model_id)
+        self.assertIn("/copilot/v1", result["base_url"])
+
+    @patch("api.gateway_provider._load_gateway_configs", return_value=FAKE_CONFIGS)
+    @patch("api.gateway_provider.discover_instances", return_value=FAKE_INSTANCES)
+    def test_provider_is_openai(self, mock_discover, mock_configs):
+        """Gateway models should always report provider as 'openai'."""
+        from api.gateway_provider import resolve_gateway_model, build_model_id
+
+        model_id = build_model_id("local", "gpt-4", "my-cursor-1")
+        result = resolve_gateway_model(model_id)
+        self.assertEqual(result["provider"], "openai")
+
+    @patch("api.gateway_provider._load_gateway_configs", return_value=[])
+    def test_resolve_unknown_label(self, mock_configs):
+        """Unknown gateway label should return None."""
+        from api.gateway_provider import resolve_gateway_model
+
+        result = resolve_gateway_model("@gateway-nonexistent:gpt-4/inst1")
+        self.assertIsNone(result)
+
+    def test_resolve_non_gateway_model(self):
+        """Non-gateway model IDs should return None."""
+        from api.gateway_provider import resolve_gateway_model
+
+        self.assertIsNone(resolve_gateway_model("gpt-4"))
+        self.assertIsNone(resolve_gateway_model(""))
+        self.assertIsNone(resolve_gateway_model("anthropic/claude-3"))
+
+
+class TestConfigIntegration(unittest.TestCase):
+    """Test that config.py correctly delegates to gateway_provider."""
+
+    @patch("api.gateway_provider._load_gateway_configs", return_value=FAKE_CONFIGS)
+    @patch("api.gateway_provider.discover_instances", return_value=FAKE_INSTANCES)
+    def test_resolve_model_provider_delegates_gateway(self, mock_discover, mock_configs):
+        """resolve_model_provider should delegate gateway models to gateway_provider."""
+        from api.config import resolve_model_provider
+        from api.gateway_provider import build_model_id
+
+        model_id = build_model_id("local", "gpt-4", "my-cursor-1")
+        model, provider, base_url = resolve_model_provider(model_id)
+
+        self.assertEqual(model, "gpt-4")
+        self.assertEqual(provider, "openai")
+        self.assertIn("/cursor/v1", base_url)
+
+    def test_resolve_model_provider_normal_passthrough(self):
+        """Normal models should not be affected by gateway integration."""
+        from api.config import resolve_model_provider
+
+        model, provider, base_url = resolve_model_provider("gpt-4")
+        self.assertNotIn("gateway", str(base_url or ""))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR contributes a coherent set of features and fixes built on top of upstream `master`, focused on integrating hermes-webui with an external **agent-api-gateway** and improving a few UX rough edges around it.

The branch is **rebased onto current `master` (v0.50.223)** — clean fast-forward, no conflicts.

## Commits (8, oldest → newest)

| # | Commit | Summary |
|---|--------|---------|
| 1 | `feat: integrate agent-api-gateway with lowest coupling` | Minimal hooks so WebUI can delegate selected requests to an external agent gateway. Opt-in; behavior unchanged when no gateway is configured. |
| 2 | `feat: path-based routing and /model copilot shorthand` (#1) | Initial routing approach + `/model copilot` shorthand. |
| 3 | `refactor: use x-instance-keyword header instead of path-based routing` (#2) | Cleaner, less coupled routing — header-based dispatch supersedes #1. |
| 4 | `feat: full-width chat layout + fix gateway provider test` (#3) | Chat area uses full width when sidebar is collapsed; matching test fix. |
| 5 | `feat: status indicators — gateway dot, status-dot CSS, sidebar accent, CLI busy` | Real-time visual feedback: gateway health dot, per-conversation accent in sidebar, CLI busy indicator, streaming cursor. |
| 6 | `fix: support renaming CLI / agent sessions in /api/session/rename` | Previously double-click-rename on a CLI/agent session returned 404 and the optimistic UI was reverted. Routes the rename through `api.state_sync.rename_cli_session` when the session is not WebUI-owned, and mirrors the new title back to `state.db` so `/insights` and "all sessions" stay in sync. |
| 7 | `test(sidebar): add JS-harness tests for CLI busy + per-conversation accent` | Covers the indicators added in commit 5. |
| 8 | `fix: restore gateway delegation + adapt #6 tests for upstream layout` | Keeps tests green against current upstream after the rebase. |

## Verification

Ran the related test files locally after rebasing onto `origin/master`:

```
pytest tests/test_gateway_provider.py tests/test_gateway_sync.py \
       tests/test_rename_session.py tests/test_sidebar_status_indicators.py \
       tests/test_streaming_gateway.py
→ 68 passed, 1 fail (environmental: connection refused — isolated server fixture
  couldn't bind in this sandbox; not a code regression)
```

All gateway, sidebar-status, and streaming tests pass. The one failure is the rename-after-refresh integration test which spins up an isolated server on a per-worktree port and could not bind in my local sandbox.

## Notes for the reviewer

- All gateway integration is opt-in via the `x-instance-keyword` header / config; with no gateway configured, request flow is identical to upstream.
- Happy to split this into smaller PRs (gateway integration / status indicators / session-rename fix) if that's preferred for review — they were developed as separate feature branches and can be peeled apart cleanly.
- Commits 1–3 show the routing design evolving (path → header). Squashing 1+2+3 into a single "agent-api-gateway integration" commit is also fine if you'd rather a tidier history.