### PR TITLE
Fix pytest state isolation for direct session saves

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,10 +57,18 @@ TEST_STATE_DIR = pathlib.Path(os.getenv(
 ))
 TEST_WORKSPACE = TEST_STATE_DIR / 'test-workspace'
 
-# Publish at module level so _pytest_port.py (imported at collection time)
-# and any test file using os.environ sees the right values immediately.
-os.environ.setdefault('HERMES_WEBUI_TEST_PORT', str(TEST_PORT))
-os.environ.setdefault('HERMES_WEBUI_TEST_STATE_DIR', str(TEST_STATE_DIR))
+# Publish at module level so api.config, _pytest_port.py, and any test module
+# importing stateful API code during collection see the isolated test paths.
+#
+# Direct assignment is intentional for production-risk paths: tests that import
+# api.config/api.models in the pytest process must never inherit the real
+# ~/.hermes state tree before the server subprocess fixture starts.
+os.environ['HERMES_WEBUI_TEST_PORT'] = str(TEST_PORT)
+os.environ['HERMES_WEBUI_TEST_STATE_DIR'] = str(TEST_STATE_DIR)
+os.environ['HERMES_WEBUI_STATE_DIR'] = str(TEST_STATE_DIR)
+os.environ['HERMES_WEBUI_DEFAULT_WORKSPACE'] = str(TEST_WORKSPACE)
+os.environ['HERMES_HOME'] = str(TEST_STATE_DIR)
+os.environ['HERMES_BASE_HOME'] = str(TEST_STATE_DIR)
 
 # ── Server script: always relative to repo root ───────────────────────────
 SERVER_SCRIPT = REPO_ROOT / 'server.py'

--- a/tests/test_default_workspace_fallback.py
+++ b/tests/test_default_workspace_fallback.py
@@ -11,6 +11,7 @@ def test_resolve_default_workspace_falls_back_to_existing_home_work(monkeypatch,
 
     monkeypatch.setattr(config, "HOME", tmp_path)
     monkeypatch.setattr(config, "STATE_DIR", state_dir)
+    monkeypatch.delenv("HERMES_WEBUI_DEFAULT_WORKSPACE", raising=False)
 
     resolved = config.resolve_default_workspace("/definitely/not/usable")
 
@@ -28,6 +29,7 @@ def test_save_settings_rewrites_bad_default_workspace_to_fallback(monkeypatch, t
     monkeypatch.setattr(config, "STATE_DIR", state_dir)
     monkeypatch.setattr(config, "SETTINGS_FILE", settings_file)
     monkeypatch.setattr(config, "DEFAULT_WORKSPACE", preferred)
+    monkeypatch.delenv("HERMES_WEBUI_DEFAULT_WORKSPACE", raising=False)
 
     saved = config.save_settings({"default_workspace": "/definitely/not/usable"})
     on_disk = json.loads(settings_file.read_text(encoding="utf-8"))
@@ -41,6 +43,7 @@ def test_resolve_default_workspace_creates_home_workspace_when_missing(monkeypat
     state_dir = tmp_path / "state"
     monkeypatch.setattr(config, "HOME", tmp_path)
     monkeypatch.setattr(config, "STATE_DIR", state_dir)
+    monkeypatch.delenv("HERMES_WEBUI_DEFAULT_WORKSPACE", raising=False)
     # Neither ~/work nor ~/workspace exists yet
     resolved = config.resolve_default_workspace(None)
     assert resolved == (tmp_path / "workspace").resolve()
@@ -145,4 +148,3 @@ def test_env_var_wins_over_settings_json_on_startup(monkeypatch, tmp_path):
         f"Expected {env_ws.resolve()}, got {current_ws}. "
         "settings.json must not override HERMES_WEBUI_DEFAULT_WORKSPACE."
     )
-

--- a/tests/test_onboarding_existing_config.py
+++ b/tests/test_onboarding_existing_config.py
@@ -293,6 +293,15 @@ def _server_reachable() -> bool:
         return False
 
 
+def _flush_server_config_cache() -> None:
+    # GET /api/personalities always calls reload_config(), giving us a cheap
+    # way to flush cached provider state without restarting the test server.
+    try:
+        _http_get("/api/personalities")
+    except Exception:
+        pass
+
+
 # No collection-time skip guard — conftest.py starts the server via its
 # autouse session fixture BEFORE tests run.  A collection-time check always
 # sees no server and turns every test into a skip.  Server reachability is
@@ -313,19 +322,13 @@ class TestOnboardingGateIntegration:
         hermes_home = _server_hermes_home()
         for rel in ("config.yaml", ".env"):
             (hermes_home / rel).unlink(missing_ok=True)
+        _http_post("/api/settings", {"onboarding_completed": False})
+        _flush_server_config_cache()
         yield
         for rel in ("config.yaml", ".env"):
             (hermes_home / rel).unlink(missing_ok=True)
-        # Force the server to reload its in-memory config after file deletion.
-        # apply_onboarding_setup() calls reload_config() which caches provider
-        # state in the server process.  Deleting files on disk does not clear
-        # that cache — the next test would see provider_configured=True.
-        # GET /api/personalities always calls reload_config(), giving us a
-        # cheap way to flush the cache without a server restart.
-        try:
-            _http_get("/api/personalities")
-        except Exception:
-            pass
+        _http_post("/api/settings", {"onboarding_completed": False})
+        _flush_server_config_cache()
 
     def test_no_config_wizard_fires(self):
         """No config.yaml → completed=False."""

--- a/tests/test_pytest_state_isolation.py
+++ b/tests/test_pytest_state_isolation.py
@@ -1,0 +1,22 @@
+"""
+Regression tests for pytest-process state isolation.
+
+Some tests import api.config/api.models during collection and directly write
+sessions from the pytest process. conftest must publish the test state env vars
+before those imports, not only for the server subprocess.
+"""
+
+from pathlib import Path
+
+
+def test_api_config_uses_pytest_state_dir():
+    import api.config as config
+    from tests.conftest import TEST_STATE_DIR
+
+    test_state_dir = TEST_STATE_DIR.resolve()
+    production_state_dir = (Path.home() / ".hermes" / "webui").resolve()
+
+    assert config.STATE_DIR == test_state_dir
+    assert config.SESSION_DIR == test_state_dir / "sessions"
+    assert config.STATE_DIR != production_state_dir
+    assert production_state_dir not in config.SESSION_DIR.resolve().parents


### PR DESCRIPTION
## Thinking Path

`tests/test_sprint46.py` imports `api.config.SESSION_DIR` at collection time and then calls `Session.save()` directly from the pytest main process. Before this change, `tests/conftest.py` only passed `HERMES_WEBUI_STATE_DIR` to the test server subprocess, so `api.config.STATE_DIR` could fall back to the real `~/.hermes/webui` path in pytest itself.

## What Changed

- Publish pytest isolation env vars from `tests/conftest.py` at module import time, before test modules import `api.config` or `api.models`.
- Use direct assignment for production-risk paths so an inherited shell environment cannot leave pytest pointed at the real WebUI state directory.
- Add `tests/test_pytest_state_isolation.py` to lock the invariant that `api.config.STATE_DIR` and `SESSION_DIR` resolve under the isolated test state directory, not `~/.hermes/webui`.
- Update adjacent tests that intentionally exercise env-less workspace fallback or onboarding cleanup so they explicitly reset the pytest-level isolation state they depend on.

## Why It Matters

Tests that save sessions directly in-process can no longer create or update files in the real WebUI session store. The server subprocess isolation and pytest main-process isolation now agree on the same test state root.

## Verification

- `pytest tests/test_pytest_state_isolation.py tests/test_sprint46.py -q`
- `pytest tests/test_default_workspace_fallback.py -q`
- `pytest tests/test_onboarding_existing_config.py -q`
- `pytest tests/test_pytest_state_isolation.py tests/test_sprint46.py tests/test_default_workspace_fallback.py tests/test_onboarding_existing_config.py -q`
- Checked the existing `~/.hermes/webui/sessions/compress_test_001.json` sentinel before and after the run; size and mtime were unchanged.

## Risks / Follow-ups

- Low risk. The change is scoped to pytest configuration and a regression test.
- Some tests that intentionally override these env vars still need to use monkeypatch or module reload patterns, as they already do today.

## Model Used

GPT-5 Codex
