### PR TITLE
fix: hide cron agent sessions from sidebar by default

### DIFF
--- a/api/agent_sessions.py
+++ b/api/agent_sessions.py
@@ -118,7 +118,12 @@ def _project_agent_session_rows(rows: list[dict]) -> list[dict]:
     return projected
 
 
-def read_importable_agent_session_rows(db_path: Path, limit: int = 200, log=None) -> list[dict]:
+def read_importable_agent_session_rows(
+    db_path: Path,
+    limit: int = 200,
+    log=None,
+    exclude_sources: tuple[str, ...] | None = ("cron",),
+) -> list[dict]:
     """Return non-WebUI agent sessions projected as importable conversations.
 
     Hermes Agent can create rows in ``state.db.sessions`` before a session has
@@ -126,6 +131,12 @@ def read_importable_agent_session_rows(db_path: Path, limit: int = 200, log=None
     rows. WebUI cannot import empty rows and should not show compression
     segments as separate conversations, so both the regular ``/api/sessions``
     path and the gateway SSE watcher use this shared projection.
+
+    By default, omit background/internal sources such as ``cron`` from the WebUI
+    sidebar. This mirrors Hermes Agent CLI's session-list behaviour: interactive
+    views should stay focused on user-facing conversations, while callers that
+    need a source-specific diagnostic view can opt out by passing
+    ``exclude_sources=None``.
     """
     db_path = Path(db_path)
     if not db_path.exists():
@@ -153,6 +164,15 @@ def read_importable_agent_session_rows(db_path: Path, limit: int = 200, log=None
         ended_expr = _optional_col('ended_at', session_cols)
         end_reason_expr = _optional_col('end_reason', session_cols)
 
+        where_clauses = ["s.source IS NOT NULL", "s.source != 'webui'"]
+        params: list[str] = []
+        if exclude_sources:
+            excluded = tuple(str(source) for source in exclude_sources if source)
+            if excluded:
+                placeholders = ", ".join("?" for _ in excluded)
+                where_clauses.append(f"s.source NOT IN ({placeholders})")
+                params.extend(excluded)
+
         cur.execute(
             f"""
             SELECT s.id, s.title, s.model, s.message_count,
@@ -164,10 +184,11 @@ def read_importable_agent_session_rows(db_path: Path, limit: int = 200, log=None
                    MAX(m.timestamp) AS last_activity
             FROM sessions s
             LEFT JOIN messages m ON m.session_id = s.id
-            WHERE s.source IS NOT NULL AND s.source != 'webui'
+            WHERE {' AND '.join(where_clauses)}
             GROUP BY s.id
             ORDER BY COALESCE(MAX(m.timestamp), s.started_at) DESC
             """,
+            params,
         )
         projected = _project_agent_session_rows([dict(row) for row in cur.fetchall()])
         if limit is None:

--- a/api/models.py
+++ b/api/models.py
@@ -513,6 +513,13 @@ def new_session(workspace=None, model=None, profile=None):
     s.save()
     return s
 
+def _hide_from_default_sidebar(session: dict) -> bool:
+    """Return True for internal/background sessions hidden from the default list."""
+    sid = str(session.get('session_id') or '')
+    source = session.get('source_tag') or session.get('source')
+    return source == 'cron' or sid.startswith('cron_')
+
+
 def all_sessions():
     active_stream_ids = _active_stream_ids()
     # Phase C: try index first for O(1) read; fall back to full scan
@@ -557,6 +564,7 @@ def all_sessions():
                 and s.get('message_count', 0) == 0
                 and (_now - s.get('updated_at', _now)) > 60
             )]
+            result = [s for s in result if not _hide_from_default_sidebar(s)]
             # Backfill: sessions created before Sprint 22 have no profile tag.
             # Attribute them to 'default' so the client profile filter works correctly.
             for s in result:
@@ -583,6 +591,7 @@ def all_sessions():
         and len(s.messages) == 0
         and (_now - s.updated_at) > 60
     )]
+    result = [s for s in result if not _hide_from_default_sidebar(s)]
     for s in result:
         if not s.get('profile'):
             s['profile'] = 'default'

--- a/tests/test_gateway_sync.py
+++ b/tests/test_gateway_sync.py
@@ -669,6 +669,26 @@ def test_gateway_session_has_correct_metadata():
         post('/api/settings', {'show_cli_sessions': False})
 
 
+def test_imported_cron_sessions_hidden_from_sidebar_by_default(cleanup_test_sessions):
+    """Cron sessions already imported into the WebUI store should stay hidden from the sidebar."""
+    from api.models import Session
+
+    sid = 'cron_imported_20260427'
+    cleanup_test_sessions.append(sid)
+    s = Session(
+        session_id=sid,
+        title='Hourly Cron Import',
+        messages=[{'role': 'user', 'content': 'run hourly job', 'timestamp': time.time()}],
+        model='openai/gpt-5',
+    )
+    s.is_cli_session = True
+    s.save(touch_updated_at=False)
+
+    data, status = get('/api/sessions')
+    assert status == 200
+    assert sid not in {session.get('session_id') for session in data.get('sessions', [])}
+
+
 def test_cron_sessions_hidden_from_sidebar_by_default():
     """Cron-run sessions are background/internal and should not appear in the default sidebar list."""
     conn = _ensure_state_db()

--- a/tests/test_gateway_sync.py
+++ b/tests/test_gateway_sync.py
@@ -248,14 +248,14 @@ def test_gateway_watcher_hides_sessions_without_messages(monkeypatch):
         conn.execute(
             "INSERT OR REPLACE INTO sessions (id, source, title, model, started_at, message_count) "
             "VALUES (?, ?, ?, ?, ?, ?)",
-            (empty_sid, 'cron', 'Empty Cron Session', 'openai/gpt-5', time.time(), 0),
+            (empty_sid, 'telegram', 'Empty Telegram Session', 'openai/gpt-5', time.time(), 0),
         )
         conn.execute("DELETE FROM messages WHERE session_id = ?", (empty_sid,))
         _insert_gateway_session(
             conn,
             session_id=live_sid,
-            source='cron',
-            title='Live Cron Session',
+            source='telegram',
+            title='Live Telegram Session',
             message_count=0,
         )
 
@@ -667,6 +667,55 @@ def test_gateway_session_has_correct_metadata():
         except Exception:
             pass
         post('/api/settings', {'show_cli_sessions': False})
+
+
+def test_cron_sessions_hidden_from_sidebar_by_default():
+    """Cron-run sessions are background/internal and should not appear in the default sidebar list."""
+    conn = _ensure_state_db()
+    try:
+        _insert_gateway_session(conn, session_id='cron_job123_20260427', source='cron', title='Nightly Cleanup')
+        _insert_gateway_session(conn, session_id='gw_noncron_001', source='telegram', title='Visible Chat')
+
+        post('/api/settings', {'show_cli_sessions': True})
+
+        data, status = get('/api/sessions')
+        assert status == 200
+        sessions = data.get('sessions', [])
+        ids = {s['session_id'] for s in sessions}
+        assert 'gw_noncron_001' in ids, "Non-cron agent session should still appear"
+        assert 'cron_job123_20260427' not in ids, "Cron session should be hidden by default"
+    finally:
+        try:
+            _remove_test_sessions(conn, 'cron_job123_20260427', 'gw_noncron_001')
+            conn.close()
+        except Exception:
+            pass
+        post('/api/settings', {'show_cli_sessions': False})
+
+
+def test_importable_agent_rows_can_opt_into_cron_source():
+    """Diagnostic callers can opt out of the default cron exclusion explicitly."""
+    conn = _ensure_state_db()
+    try:
+        _insert_agent_session_row(conn, session_id='cron_diag_20260427', source='cron', title='Cron Diagnostic')
+
+        from api.agent_sessions import read_importable_agent_session_rows
+
+        default_rows = read_importable_agent_session_rows(_get_state_db_path(), limit=None)
+        assert 'cron_diag_20260427' not in {row.get('id') for row in default_rows}
+
+        diagnostic_rows = read_importable_agent_session_rows(
+            _get_state_db_path(),
+            limit=None,
+            exclude_sources=None,
+        )
+        assert 'cron_diag_20260427' in {row.get('id') for row in diagnostic_rows}
+    finally:
+        try:
+            _remove_test_sessions(conn, 'cron_diag_20260427')
+            conn.close()
+        except Exception:
+            pass
 
 
 def test_gateway_session_has_message_count():


### PR DESCRIPTION
## Thinking Path

- Hermes WebUI's sidebar acts as the default interactive conversation picker.
- Hermes Agent cron jobs also write session rows into `state.db`.
- When "Show CLI sessions in sidebar" is enabled, those cron-run sessions can appear alongside user-facing conversations.
- Cron sessions are useful for diagnostics, but they are background/internal runs and usually should not clutter the default sidebar.
- Hermes CLI already treats cron sessions as hidden from normal interactive session browsing unless explicitly requested.
- This PR applies the same default-hiding concept to WebUI's agent-session projection while keeping an explicit opt-out path for diagnostic callers.

## What Changed

- Added an `exclude_sources` option to `read_importable_agent_session_rows()`.
- Defaulted `exclude_sources` to `("cron",)` so cron sessions are omitted from the default WebUI sidebar session list.
- Kept `exclude_sources=None` as an opt-out for callers that need to inspect all agent sessions, including cron runs.
- Added regression coverage for:
  - `/api/sessions` hiding cron sessions by default while still showing non-cron agent sessions.
  - `read_importable_agent_session_rows(..., exclude_sources=None)` still being able to return cron sessions.
- Updated an existing watcher test fixture to use a non-cron source now that cron is intentionally hidden by default.

## Why It Matters

This keeps the WebUI sidebar focused on user-facing conversations and prevents scheduled/background jobs from crowding out interactive sessions. It also aligns WebUI behavior with Hermes Agent CLI session browsing semantics.

## Verification

```bash
$HOME/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_gateway_sync.py -q
```

Result:

```text
29 passed
```

## Risks / Follow-ups

- This changes the default visibility of cron sessions in the WebUI sidebar when CLI/agent sessions are enabled.
- Cron sessions are not deleted; they remain in `state.db` for diagnostics.
- WebUI does not currently expose a source-specific session filter. If maintainers want UI-level inspection later, the new `exclude_sources=None` opt-out gives a backend path for that.

## Model Used

AI-assisted.

- Provider: OpenAI Codex / Hermes Agent
- Model: gpt-5.5
- Notable tooling: local repository inspection, patching, pytest verification
