### PR TITLE
fix: per-job cron completion indicator — badge persists until job is viewed (#1140)

### DIFF
--- a/static/panels.js
+++ b/static/panels.js
@@ -279,8 +279,10 @@ async function loadCrons(animate) {
       item.className = 'cron-item';
       item.id = 'cron-' + job.id;
       const status = _cronStatusMeta(job);
+      const isNewRun = _cronNewJobIds.has(String(job.id));
       item.innerHTML = `
         <div class="cron-header">
+          ${isNewRun ? '<span class="cron-new-dot" title="New run"></span>' : ''}
           <span class="cron-name" title="${esc(job.name)}">${esc(job.name)}</span>
           <span class="cron-status ${status.listClass}">${esc(status.label)}</span>
         </div>`;
@@ -349,7 +351,7 @@ function _renderCronDetail(job){
         <div class="detail-card-title">Prompt</div>
         <div class="detail-prompt">${esc(job.prompt || '')}</div>
       </div>
-      <div class="detail-card" id="cronDetailRuns">
+      <div class="detail-card ${_cronNewJobIds.has(String(job.id)) ? 'has-new-run' : ''}" id="cronDetailRuns">
         <div class="detail-card-title">${esc(t('cron_last_output'))}</div>
         <div style="color:var(--muted);font-size:12px">${esc(t('loading'))}</div>
       </div>
@@ -419,6 +421,10 @@ function openCronDetail(id, el){
   document.querySelectorAll('.cron-item').forEach(e => e.classList.remove('active'));
   const target = el || $('cron-' + id);
   if (target) target.classList.add('active');
+  // Remove new-run dot from this job since user is now viewing it
+  _clearCronUnreadForJob(id);
+  const dot = target && target.querySelector('.cron-new-dot');
+  if (dot) dot.remove();
   _cronPreFormDetail = null;
   _editingCronId = null;
   _renderCronDetail(job);
@@ -2919,6 +2925,7 @@ async function disableAuth(){
 let _cronPollSince=Date.now()/1000;  // track from page load
 let _cronPollTimer=null;
 let _cronUnreadCount=0;
+const _cronNewJobIds=new Set();  // track which job IDs had new completions (unread)
 
 // Auto-refresh the cron list when a job is created from chat or any external source.
 // The chat path dispatches this event when the agent response mentions cron creation.
@@ -2936,6 +2943,7 @@ function startCronPolling(){
         for(const c of data.completions){
           showToast(t('cron_completion_status', c.name, c.status==='error' ? t('status_failed') : t('status_completed')),4000);
           _cronPollSince=Math.max(_cronPollSince,c.completed_at);
+          if(c.job_id) _cronNewJobIds.add(String(c.job_id));
         }
         _cronUnreadCount+=data.completions.length;
         updateCronBadge();
@@ -2962,12 +2970,18 @@ function updateCronBadge(){
   }
 }
 
-// Clear cron badge when Tasks tab is opened
+// Clear cron badge only when all unread jobs have been viewed (not on panel open)
+function _clearCronUnreadForJob(jobId){
+  const id=String(jobId);
+  if(_cronNewJobIds.has(id)){
+    _cronNewJobIds.delete(id);
+    _cronUnreadCount=Math.max(0, _cronUnreadCount-1);
+    updateCronBadge();
+  }
+}
+
 const _origSwitchPanel=switchPanel;
-switchPanel=async function(name){
-  if(name==='tasks'){_cronUnreadCount=0;updateCronBadge();}
-  return _origSwitchPanel(name);
-};
+switchPanel=async function(name){ return _origSwitchPanel(name); };
 
 // Start polling on page load
 startCronPolling();

--- a/static/style.css
+++ b/static/style.css
@@ -1833,6 +1833,9 @@ main.main.showing-profiles > #mainProfiles{display:flex;}
 
 /* ── Cron alert badge ── */
 .cron-badge{position:absolute;top:2px;right:2px;background:#e53e3e;color:#fff;font-size:9px;font-weight:700;min-width:14px;height:14px;line-height:14px;text-align:center;border-radius:7px;padding:0 3px;}
+.cron-new-dot{width:7px;height:7px;border-radius:50%;background:var(--success,#22c55e);flex-shrink:0;animation:cron-dot-pulse 2s ease-in-out infinite;}
+@keyframes cron-dot-pulse{0%,100%{opacity:1;}50%{opacity:.4;}}
+.has-new-run{border-color:var(--success,#22c55e)!important;box-shadow:0 0 0 1px var(--success,#22c55e);}
 
 /* ── Background error banner ── */
 /* ── Archived sessions ── */

--- a/tests/test_issue1140_cron_badge_per_job.py
+++ b/tests/test_issue1140_cron_badge_per_job.py
@@ -1,0 +1,94 @@
+"""Tests for issue #1140 — Cron completion badge per-job indicator.
+
+Verifies that:
+1. _cronNewJobIds tracks job IDs with new completions
+2. loadCrons() renders a dot indicator for new-run jobs
+3. openCronDetail() clears the unread state for the viewed job
+4. Badge only clears when all unread jobs are viewed (not on panel open)
+5. _renderCronDetail() adds has-new-run class to Last Output card
+"""
+
+import pytest
+
+# ── Static file tests (no server needed) ──
+
+def test_cron_new_job_ids_tracking_in_panels_js():
+    """panels.js should declare _cronNewJobIds Set and populate it in startCronPolling."""
+    with open('static/panels.js') as f:
+        src = f.read()
+
+    # _cronNewJobIds declared as Set
+    assert '_cronNewJobIds' in src, '_cronNewJobIds not found in panels.js'
+    assert 'new Set()' in src, '_cronNewJobIds should be initialized as Set()'
+
+    # In startCronPolling, job IDs are added to the set
+    assert '_cronNewJobIds.add(String(c.job_id))' in src, \
+        'startCronPolling should add job_id to _cronNewJobIds'
+
+
+def test_cron_dot_indicator_rendered_in_load_crons():
+    """loadCrons() should render a .cron-new-dot for jobs in _cronNewJobIds."""
+    with open('static/panels.js') as f:
+        src = f.read()
+
+    # Dot indicator in cron-item rendering
+    assert 'cron-new-dot' in src, 'cron-new-dot class not found'
+    assert "_cronNewJobIds.has(String(job.id))" in src, \
+        'loadCrons should check _cronNewJobIds for each job'
+
+
+def test_open_cron_detail_clears_unread():
+    """openCronDetail() should mark job as read and remove the dot."""
+    with open('static/panels.js') as f:
+        src = f.read()
+
+    # _clearCronUnreadForJob called in openCronDetail
+    assert '_clearCronUnreadForJob' in src, \
+        '_clearCronUnreadForJob function not found'
+    # Dot removal in openCronDetail
+    assert "target.querySelector('.cron-new-dot')" in src, \
+        'openCronDetail should remove the dot element'
+
+
+def test_clear_cron_unread_for_job_function():
+    """_clearCronUnreadForJob should delete from set and decrement count."""
+    with open('static/panels.js') as f:
+        src = f.read()
+
+    assert 'def' not in src.lower() or True  # JS function, not Python
+    # Check function implementation
+    assert '_cronNewJobIds.delete(id)' in src, \
+        '_clearCronUnreadForJob should delete from _cronNewJobIds'
+    assert '_cronUnreadCount=Math.max(0' in src, \
+        '_clearCronUnreadForJob should decrement _cronUnreadCount'
+
+
+def test_switch_panel_no_longer_clears_badge():
+    """switchPanel override should NOT clear badge on tasks panel open."""
+    with open('static/panels.js') as f:
+        src = f.read()
+
+    # The old pattern "if(name==='tasks'){_cronUnreadCount=0" should NOT exist
+    assert "if(name==='tasks'){_cronUnreadCount=0" not in src, \
+        'switchPanel should NOT clear _cronUnreadCount on tasks open'
+
+
+def test_has_new_run_class_in_render_detail():
+    """_renderCronDetail() should add has-new-run class to Last Output card."""
+    with open('static/panels.js') as f:
+        src = f.read()
+
+    # Check has-new-run class in the cronDetailRuns div
+    assert 'has-new-run' in src, 'has-new-run class not found'
+
+
+def test_cron_css_classes_exist():
+    """style.css should contain .cron-new-dot and .has-new-run styles."""
+    with open('static/style.css') as f:
+        src = f.read()
+
+    assert '.cron-new-dot{' in src, '.cron-new-dot CSS rule not found'
+    assert '.has-new-run{' in src, '.has-new-run CSS rule not found'
+    assert 'cron-dot-pulse' in src, 'cron-dot-pulse animation not found'
+
+


### PR DESCRIPTION
## Thinking Path
- Issue #1140: cron completion badge clears on panel open with no way to identify which job ran
- Root cause: `_cronUnreadCount` resets to 0 on `switchPanel('tasks')` before user views any job
- No per-job tracking of which specific jobs had completions
- Fix: track unread job IDs in a `Set`, render per-job dots, clear only when user views the job

## What Changed
- `static/panels.js`: Added `_cronNewJobIds` Set, `_clearCronUnreadForJob()` helper
- `static/panels.js`: `startCronPolling()` populates `_cronNewJobIds` alongside count
- `static/panels.js`: `loadCrons()` renders `.cron-new-dot` on unread job rows
- `static/panels.js`: `openCronDetail()` marks job as read and removes dot
- `static/panels.js`: `_renderCronDetail()` adds `.has-new-run` class to Last Output card
- `static/panels.js`: `switchPanel` override no longer resets count on tasks open
- `static/style.css`: Added `.cron-new-dot` (pulsing green dot) and `.has-new-run` (green border) styles
- `tests/test_issue1140_cron_badge_per_job.py`: 7 static-file tests verifying JS/CSS changes

## Why It Matters
Users with multiple cron jobs currently get a notification badge but can't tell which job completed. They must manually check each job's Last Output. This fix provides per-job visual indicators that persist until viewed.

## Verification
- `pytest tests/test_issue1140_cron_badge_per_job.py -v` — 7/7 pass
- Syntax check: `python -m py_compile static/panels.js` — N/A (JS file)
- CSS validation: no syntax errors

## Risks / Follow-ups
- `_cronNewJobIds` is client-side only — state resets on page reload. Could persist to `sessionStorage` if desired.
- Pulse animation may need reduced-motion media query for accessibility.

## Model Used
- Provider: zai
- Model: glm-5-turbo
- Tools: Hermes Agent