### PR TITLE
fix: add Save Settings button to System pane (#1139)

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -735,6 +735,7 @@
             </div>
             <button class="sm-btn" id="btnDisableAuth" onclick="disableAuth()" style="margin-top:6px;width:100%;padding:8px;font-weight:600;color:#e8a030;border-color:rgba(232,160,48,.3);display:none" data-i18n="disable_auth">Disable Auth</button>
             <button class="sm-btn" id="btnSignOut" onclick="signOut()" style="margin-top:6px;width:100%;padding:8px;font-weight:600;color:var(--accent);border-color:rgba(233,69,96,.3);display:none" data-i18n="sign_out">Sign Out</button>
+            <button class="sm-btn" onclick="saveSettings()" style="margin-top:12px;width:100%;padding:8px;font-weight:600" data-i18n="settings_save_btn">Save Settings</button>
           </div>
       </div>
     </div>

--- a/tests/test_issue1139_password_remote.py
+++ b/tests/test_issue1139_password_remote.py
@@ -1,0 +1,79 @@
+"""Tests for issue #1139 — Password change/remove broken remotely.
+
+Root cause: the System settings pane (settingsPaneSystem) had no Save Settings button.
+Users in Settings > System could type a new password but had no way to submit it.
+Disable Auth and Sign Out buttons existed but Save was missing.
+"""
+
+import pytest
+
+
+def test_system_pane_has_save_button():
+    """The System settings pane must include a Save Settings button."""
+    with open('static/index.html') as f:
+        html = f.read()
+
+    # Find the System pane block (last pane, so search until parent close)
+    start = html.index('id="settingsPaneSystem"')
+    # The parent container closes after all panes
+    end_marker = '</div>\n      </div>\n    </div>'  # pane + panes container + settings panel
+    end = html.index(end_marker, start) + len(end_marker)
+    pane_block = html[start:end]
+
+    assert 'saveSettings()' in pane_block, \
+        'System pane must contain a Save Settings button (onclick="saveSettings()")'
+
+
+def test_system_pane_has_password_field_and_auth_buttons():
+    """System pane should have password field, Disable Auth, and Sign Out buttons."""
+    with open('static/index.html') as f:
+        html = f.read()
+
+    start = html.index('id="settingsPaneSystem"')
+    end_marker = '</div>\n      </div>\n    </div>'
+    end = html.index(end_marker, start) + len(end_marker)
+    pane_block = html[start:end]
+
+    assert 'settingsPassword' in pane_block, 'Password field missing from System pane'
+    assert 'btnDisableAuth' in pane_block, 'Disable Auth button missing from System pane'
+    assert 'btnSignOut' in pane_block, 'Sign Out button missing from System pane'
+
+
+def test_save_settings_sends_password():
+    """saveSettings() must read settingsPassword and send _set_password."""
+    with open('static/panels.js') as f:
+        src = f.read()
+
+    assert 'settingsPassword' in src, 'saveSettings should read settingsPassword'
+    assert '_set_password' in src, 'saveSettings should send _set_password key'
+
+
+def test_disable_auth_sends_clear_password():
+    """disableAuth() must send _clear_password: true."""
+    with open('static/panels.js') as f:
+        src = f.read()
+
+    assert '_clear_password:true' in src, 'disableAuth should send _clear_password: true'
+
+
+def test_all_settings_panes_have_save_button():
+    """All settings panes that have user-editable fields should have a Save button."""
+    with open('static/index.html') as f:
+        html = f.read()
+
+    import re
+    # Find all settings panes
+    panes = re.findall(
+        r'<div class="settings-pane" id="(settingsPane\w+)"[^>]*>(.*?)</div>\s*</div>',
+        html, re.DOTALL
+    )
+
+    for pane_id, pane_html in panes:
+        # Providers pane doesn't need a Save button (has per-provider save)
+        if pane_id == 'settingsPaneProviders':
+            continue
+        # Check if pane has any input fields (not just buttons)
+        has_inputs = bool(re.search(r'<input|<select|<textarea', pane_html))
+        if has_inputs:
+            assert 'saveSettings()' in pane_html, \
+                f'{pane_id} has input fields but no Save Settings button'


### PR DESCRIPTION
## Thinking Path
- Issue #1139: password change/remove silently fails in Settings > System when accessed remotely
- Root cause: System settings pane (`settingsPaneSystem`) had no Save Settings button
- The password field, Disable Auth, and Sign Out buttons were present, but no Save
- Save Settings button only existed in Appearance and Preferences panes
- Users typed a new password but had no way to submit it — the action "silently" did nothing

## What Changed
- `static/index.html`: Added Save Settings button to System pane (after Disable Auth / Sign Out buttons)
- `tests/test_issue1139_password_remote.py`: 5 tests verifying System pane has Save, password field, auth buttons, and that all panes with inputs have Save

## Why It Matters
Users with password auth enabled (common for remote access) could not change or remove their password through the UI. This is a basic account maintenance operation that was completely blocked.

## Verification
- `pytest tests/test_issue1139_password_remote.py -v` — 5/5 pass
- HTML structure: Save button now present in System pane alongside existing auth buttons

## Risks / Follow-ups
- Minimal risk — single HTML button addition, same pattern as existing Save buttons
- Could add a "current password" confirmation step for password changes (separate enhancement)

## Model Used
- Provider: zai
- Model: glm-5-turbo
- Tools: Hermes Agent