### PR TITLE
fix: keep profiles list populated on CLI errors

### DIFF
--- a/api/profiles.py
+++ b/api/profiles.py
@@ -316,28 +316,97 @@ def switch_profile(name: str, *, process_wide: bool = True) -> dict:
 
 
 def list_profiles_api() -> list:
-    """List all profiles with metadata, serialized for JSON response."""
+    """List all profiles with metadata, serialized for JSON response.
+
+    Prefer hermes_cli's richer profile metadata, but never let a CLI-side
+    parsing/runtime error blank the Profiles UI.  If listing via hermes_cli
+    fails, fall back to the on-disk profile directories so the page still has
+    selectable data.
+    """
     try:
         from hermes_cli.profiles import list_profiles
         infos = list_profiles()
     except ImportError:
-        # hermes_cli not available -- return just the default
-        return [_default_profile_dict()]
+        return _list_profiles_from_filesystem()
+    except Exception as exc:
+        logger.warning("hermes_cli list_profiles failed; using filesystem fallback: %s", exc)
+        return _list_profiles_from_filesystem()
 
     active = get_active_profile_name()
     result = []
-    for p in infos:
-        result.append({
-            'name': p.name,
-            'path': str(p.path),
-            'is_default': p.is_default,
-            'is_active': p.name == active,
-            'gateway_running': p.gateway_running,
-            'model': p.model,
-            'provider': p.provider,
-            'has_env': p.has_env,
-            'skill_count': p.skill_count,
-        })
+    try:
+        for p in infos:
+            name = getattr(p, 'name')
+            result.append({
+                'name': name,
+                'path': str(getattr(p, 'path')),
+                'is_default': bool(getattr(p, 'is_default', name == 'default')),
+                'is_active': name == active,
+                'gateway_running': bool(getattr(p, 'gateway_running', False)),
+                'model': getattr(p, 'model', None),
+                'provider': getattr(p, 'provider', None),
+                'has_env': bool(getattr(p, 'has_env', False)),
+                'skill_count': int(getattr(p, 'skill_count', 0) or 0),
+            })
+    except Exception as exc:
+        logger.warning("Failed to serialize hermes_cli profiles; using filesystem fallback: %s", exc)
+        return _list_profiles_from_filesystem()
+    return result
+
+
+def _read_profile_model_metadata(profile_dir: Path) -> tuple[str | None, str | None]:
+    """Best-effort model/provider extraction for fallback profile listing."""
+    config_path = profile_dir / 'config.yaml'
+    if not config_path.exists():
+        return None, None
+    try:
+        import yaml as _yaml
+        cfg = _yaml.safe_load(config_path.read_text(encoding='utf-8')) or {}
+    except Exception:
+        return None, None
+    if not isinstance(cfg, dict):
+        return None, None
+    model_cfg = cfg.get('model', {})
+    if isinstance(model_cfg, str):
+        return model_cfg, None
+    if isinstance(model_cfg, dict):
+        return model_cfg.get('default'), model_cfg.get('provider')
+    return None, None
+
+
+def _profile_dict_from_path(name: str, profile_dir: Path, *, is_default: bool) -> dict:
+    model, provider = _read_profile_model_metadata(profile_dir)
+    active = get_active_profile_name()
+    skills_dir = profile_dir / 'skills'
+    try:
+        skill_count = sum(1 for child in skills_dir.iterdir() if child.is_dir()) if skills_dir.is_dir() else 0
+    except Exception:
+        skill_count = 0
+    return {
+        'name': name,
+        'path': str(profile_dir),
+        'is_default': is_default,
+        'is_active': name == active,
+        'gateway_running': False,
+        'model': model,
+        'provider': provider,
+        'has_env': (profile_dir / '.env').exists(),
+        'skill_count': skill_count,
+    }
+
+
+def _list_profiles_from_filesystem() -> list:
+    """Fallback profile list based only on ~/.hermes/profiles directories."""
+    result = [_profile_dict_from_path('default', _DEFAULT_HERMES_HOME, is_default=True)]
+    profiles_root = _DEFAULT_HERMES_HOME / 'profiles'
+    if not profiles_root.is_dir():
+        return result
+    try:
+        profile_dirs = sorted(p for p in profiles_root.iterdir() if p.is_dir() and _PROFILE_ID_RE.fullmatch(p.name))
+    except Exception:
+        return result
+    for profile_dir in profile_dirs:
+        result.append(_profile_dict_from_path(profile_dir.name, profile_dir, is_default=False))
     return result
 
 

--- a/static/i18n.js
+++ b/static/i18n.js
@@ -322,7 +322,7 @@ const LOCALES = {
     tab_skills: 'Skills',
     tab_memory: 'Memory',
     tab_workspaces: 'Spaces',
-    tab_profiles: 'Profiles',
+    tab_profiles: 'profiles : multi agents',
     tab_todos: 'Todos',
     tab_settings: 'Settings',
     new_conversation: 'New conversation',

--- a/static/index.html
+++ b/static/index.html
@@ -164,7 +164,7 @@
     <!-- Profiles panel -->
     <div class="panel-view" id="panelProfiles">
       <div class="panel-head">
-        <span data-i18n="tab_profiles">Agent profiles</span>
+        <span data-i18n="tab_profiles">profiles : multi agents</span>
         <div class="panel-head-actions">
           <button class="panel-head-btn" onclick="openProfileCreate()" title="New profile" data-i18n-title="new_profile" aria-label="New profile"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg></button>
         </div>

--- a/tests/test_profiles_list_resilience.py
+++ b/tests/test_profiles_list_resilience.py
@@ -1,0 +1,41 @@
+import sys
+import types
+from pathlib import Path
+
+
+def test_list_profiles_api_falls_back_to_filesystem_when_cli_listing_fails(monkeypatch, tmp_path):
+    """Profiles panel should still get data if hermes_cli list_profiles crashes."""
+    import api.profiles as profiles
+
+    base = tmp_path / ".hermes"
+    named = base / "profiles" / "coder"
+    named.mkdir(parents=True)
+    (named / "skills").mkdir()
+    (named / "config.yaml").write_text(
+        "model:\n  default: gpt-5.5\n  provider: openai-codex\n",
+        encoding="utf-8",
+    )
+    (base / ".env").write_text("OPENAI_API_KEY=test\n", encoding="utf-8")
+
+    fake_profiles_mod = types.ModuleType("hermes_cli.profiles")
+
+    def boom():
+        raise RuntimeError("bad profile config should not blank the UI list")
+
+    fake_profiles_mod.list_profiles = boom
+    monkeypatch.setitem(sys.modules, "hermes_cli.profiles", fake_profiles_mod)
+    monkeypatch.setattr(profiles, "_DEFAULT_HERMES_HOME", base)
+    monkeypatch.setattr(profiles, "_active_profile", "coder")
+
+    data = profiles.list_profiles_api()
+
+    assert [p["name"] for p in data] == ["default", "coder"]
+    coder = next(p for p in data if p["name"] == "coder")
+    assert coder["is_active"] is True
+    assert coder["model"] == "gpt-5.5"
+    assert coder["provider"] == "openai-codex"
+
+
+def test_profiles_menu_label_uses_requested_short_copy():
+    i18n = Path("static/i18n.js").read_text(encoding="utf-8")
+    assert "tab_profiles: 'profiles : multi agents'" in i18n


### PR DESCRIPTION
## Summary
- Add a filesystem fallback for /api/profiles when hermes_cli profile listing or serialization fails, so the Profiles page still receives list data.
- Preserve basic fallback metadata including active profile, model, provider, API-key presence, and skill count.
- Rename the English Profiles menu label to `profiles : multi agents` and update the static HTML fallback copy.

## Test Plan
- `python -m py_compile api/profiles.py`
- `HERMES_WEBUI_PYTHON=/Users/vincez/Documents/GitHub/hermes-agent/.venv/bin/python pytest tests/test_profiles_list_resilience.py tests/test_profile_path_security.py tests/test_profile_env_isolation.py -q`