### PR TITLE
fix: prevent infinite recursion from symlink cycles in workspace file…

### DIFF
--- a/api/workspace.py
+++ b/api/workspace.py
@@ -461,24 +461,86 @@ def validate_workspace_to_add(path: str) -> Path:
     return candidate
 
 def safe_resolve_ws(root: Path, requested: str) -> Path:
-    """Resolve a relative path inside a workspace root, raising ValueError on traversal."""
-    resolved = (root / requested).resolve()
-    resolved.relative_to(root.resolve())
-    return resolved
+    """Resolve a relative path inside a workspace root, raising ValueError on traversal.
+
+    Symlinks whose *unresolved* path is within the workspace root are allowed —
+    the user placed them there intentionally.  Only raw ``..`` traversal outside
+    the root is blocked.
+    """
+    import os
+    unresolved = root / requested
+    resolved = unresolved.resolve()
+    # Fast path: resolved path is inside root (covers most cases)
+    try:
+        resolved.relative_to(root.resolve())
+        return resolved
+    except ValueError:
+        pass
+    # Symlink path: normalize '..' (without following symlinks) and check
+    # os.path.normpath collapses '..' but does NOT follow symlinks.
+    norm = Path(os.path.normpath(str(unresolved)))
+    try:
+        norm.relative_to(root)
+        return resolved
+    except ValueError:
+        raise ValueError(f"Path traversal blocked: {requested}")
 
 
 def list_dir(workspace: Path, rel: str='.'):
     target = safe_resolve_ws(workspace, rel)
     if not target.is_dir():
         raise FileNotFoundError(f"Not a directory: {rel}")
+    ws_resolved = workspace.resolve()
     entries = []
-    for item in sorted(target.iterdir(), key=lambda p: (p.is_file(), p.name.lower())):
-        entries.append({
-            'name': item.name,
-            'path': str(item.relative_to(workspace)),
-            'type': 'dir' if item.is_dir() else 'file',
-            'size': item.stat().st_size if item.is_file() else None,
-        })
+    for item in sorted(target.iterdir(), key=lambda p: (not p.is_symlink(), p.is_file(), p.name.lower())):
+        if item.is_symlink():
+            # Resolve the symlink target and check if it stays within workspace
+            try:
+                link_target = item.resolve()
+            except OSError:
+                continue
+            # Cycle detection: skip if symlink points back to current dir,
+            # workspace root, or any ancestor of current dir.
+            # This must run REGARDLESS of whether target is inside workspace.
+            if (link_target == target.resolve() or link_target == target
+                    or link_target == ws_resolved):
+                continue
+            try:
+                target.resolve().relative_to(link_target)
+                # target is under link_target — link_target is an ancestor → cycle
+                continue
+            except ValueError:
+                pass
+            is_dir = link_target.is_dir()
+            # Keep the display path relative to workspace (don't follow the link)
+            display_path = str(Path(item.name))
+            if rel and rel != '.':
+                display_path = rel + '/' + display_path
+            entry = {
+                'name': item.name,
+                'path': display_path,
+                'type': 'symlink',
+                'target': str(link_target),
+                'is_dir': is_dir,
+            }
+            if not is_dir:
+                try:
+                    entry['size'] = link_target.stat().st_size
+                except OSError:
+                    entry['size'] = None
+            entries.append(entry)
+        else:
+            # Use rel-based path so entries under symlink targets (outside
+            # the workspace root) still get a valid workspace-relative path.
+            entry_path = item.name
+            if rel and rel != '.':
+                entry_path = rel + '/' + item.name
+            entries.append({
+                'name': item.name,
+                'path': entry_path,
+                'type': 'dir' if item.is_dir() else 'file',
+                'size': item.stat().st_size if item.is_file() else None,
+            })
         if len(entries) >= 200:
             break
     return entries

--- a/tests/test_symlink_cycle_detection.py
+++ b/tests/test_symlink_cycle_detection.py
@@ -1,0 +1,153 @@
+"""
+Tests for symlink cycle detection in workspace file browser.
+
+When a workspace contains symlinks (especially to directories outside the
+workspace root), the directory listing must terminate without infinite
+recursion.  Covers:
+
+- External symlink dirs (e.g. ln -s /some/path ~/workspace/link)
+- Self-referencing symlink (ln -s . ~/workspace/loop)
+- Ancestor symlink (ln -s .. ~/workspace/up)
+- Symlink entries carry correct type / is_dir / target fields
+- Browsing into a symlink directory via workspace-relative path works
+"""
+import json
+import os
+import pathlib
+import urllib.request
+import urllib.error
+import tempfile
+
+from tests._pytest_port import BASE
+
+
+def get(path):
+    url = BASE + path
+    with urllib.request.urlopen(url, timeout=10) as r:
+        return json.loads(r.read())
+
+
+def post(path, body=None):
+    url = BASE + path
+    data = json.dumps(body or {}).encode()
+    req = urllib.request.Request(url, data=data,
+          headers={"Content-Type": "application/json"})
+    try:
+        with urllib.request.urlopen(req, timeout=10) as r:
+            return json.loads(r.read()), r.status
+    except urllib.error.HTTPError as e:
+        return json.loads(e.read()), e.code
+
+
+def make_session(created_list, ws=None):
+    body = {}
+    if ws:
+        body["workspace"] = str(ws)
+    d, _ = post("/api/session/new", body)
+    sid = d["session"]["session_id"]
+    created_list.append(sid)
+    return sid, pathlib.Path(d["session"]["workspace"])
+
+
+class TestSymlinkCycleDetection:
+    """Symlink cycle detection in list_dir / safe_resolve_ws."""
+
+    def test_external_symlink_listed_as_symlink(self, cleanup_test_sessions, tmp_path_factory):
+        """External symlink dir should appear with type='symlink', is_dir=True."""
+        ws = tmp_path_factory.mktemp("ws")
+        target = tmp_path_factory.mktemp("target")
+        (target / "file.txt").write_text("hello")
+        link = ws / "ext"
+        link.symlink_to(target)
+
+        sid, _ = make_session(cleanup_test_sessions, ws)
+        listing = get(f"/api/list?session_id={sid}&path=.")
+        entries = listing["entries"]
+        ext = [e for e in entries if e["name"] == "ext"]
+        assert len(ext) == 1
+        assert ext[0]["type"] == "symlink"
+        assert ext[0]["is_dir"] is True
+        assert ext[0]["target"] == str(target)
+
+    def test_external_symlink_browsable(self, cleanup_test_sessions, tmp_path_factory):
+        """Listing inside an external symlink dir returns its contents."""
+        ws = tmp_path_factory.mktemp("ws")
+        target = tmp_path_factory.mktemp("target")
+        (target / "inner.txt").write_text("data")
+        (ws / "ext").symlink_to(target)
+
+        sid, _ = make_session(cleanup_test_sessions, ws)
+        listing = get(f"/api/list?session_id={sid}&path=ext")
+        entries = listing["entries"]
+        names = [e["name"] for e in entries]
+        assert "inner.txt" in names
+
+    def test_self_referencing_symlink_filtered(self, cleanup_test_sessions, tmp_path_factory):
+        """Symlink pointing to the workspace root itself must be filtered out."""
+        ws = tmp_path_factory.mktemp("ws")
+        (ws / "file.txt").write_text("data")
+        (ws / "loop").symlink_to(ws)
+
+        sid, _ = make_session(cleanup_test_sessions, ws)
+        listing = get(f"/api/list?session_id={sid}&path=.")
+        names = [e["name"] for e in listing["entries"]]
+        assert "loop" not in names, "Self-referencing symlink should be filtered"
+
+    def test_ancestor_symlink_filtered(self, cleanup_test_sessions, tmp_path_factory):
+        """Symlink pointing to a parent of the workspace must be filtered out."""
+        parent = tmp_path_factory.mktemp("parent")
+        ws = parent / "workspace"
+        ws.mkdir()
+        (ws / "file.txt").write_text("data")
+        # Symlink pointing to parent dir (ancestor of workspace)
+        (ws / "up").symlink_to(parent)
+
+        sid, _ = make_session(cleanup_test_sessions, ws)
+        listing = get(f"/api/list?session_id={sid}&path=.")
+        names = [e["name"] for e in listing["entries"]]
+        assert "up" not in names, "Ancestor symlink should be filtered"
+
+    def test_symlink_cycle_in_subdir(self, cleanup_test_sessions, tmp_path_factory):
+        """Symlink cycle inside a symlink target's subtree must not recurse."""
+        ws = tmp_path_factory.mktemp("ws")
+        target = tmp_path_factory.mktemp("target")
+        (target / "subdir").mkdir()
+        # Create a symlink inside target that points back to workspace
+        (target / "subdir" / "back").symlink_to(ws)
+        (ws / "ext").symlink_to(target)
+
+        sid, _ = make_session(cleanup_test_sessions, ws)
+        # List root — should show ext but not recurse
+        listing = get(f"/api/list?session_id={sid}&path=.")
+        names = [e["name"] for e in listing["entries"]]
+        assert "ext" in names
+
+        # List inside ext/subdir — 'back' should be filtered
+        listing2 = get(f"/api/list?session_id={sid}&path=ext/subdir")
+        names2 = [e["name"] for e in listing2["entries"]]
+        assert "back" not in names2, "Cycle symlink inside external target should be filtered"
+
+    def test_symlink_file_entry(self, cleanup_test_sessions, tmp_path_factory):
+        """Symlink to a file should have is_dir=False and include size."""
+        ws = tmp_path_factory.mktemp("ws")
+        real = tmp_path_factory.mktemp("real")
+        (real / "data.txt").write_text("hello world")
+        (ws / "link.txt").symlink_to(real / "data.txt")
+
+        sid, _ = make_session(cleanup_test_sessions, ws)
+        listing = get(f"/api/list?session_id={sid}&path=.")
+        link = [e for e in listing["entries"] if e["name"] == "link.txt"]
+        assert len(link) == 1
+        assert link[0]["type"] == "symlink"
+        assert link[0]["is_dir"] is False
+        assert link[0]["size"] == 11  # len("hello world")
+
+    def test_path_traversal_still_blocked(self, cleanup_test_sessions, tmp_path_factory):
+        """Raw .. traversal must still be blocked even with symlink support."""
+        ws = tmp_path_factory.mktemp("ws")
+        sid, _ = make_session(cleanup_test_sessions, ws)
+        try:
+            get(f"/api/list?session_id={sid}&path=../../../etc")
+            assert False, "Path traversal should be blocked"
+        except urllib.error.HTTPError as e:
+            assert e.code in (400, 404, 500)


### PR DESCRIPTION
… tree

When workspace contains symlinks pointing outside the workspace root (e.g. ln -s /root/obsidian ~/workspace/obsidian), the directory listing could recurse infinitely if the symlink target contains a symlink back to the workspace or its ancestors.

The original cycle detection only ran when the symlink target was inside the workspace root, missing the common case of external symlinks.

Changes:
- Move cycle detection outside the workspace-relative check so it runs for all symlinks regardless of target location
- Skip symlinks that point to the workspace root, the current directory, or any ancestor of the current directory
- Properly type symlink entries with 'type: symlink' and 'is_dir' field so the frontend can render them correctly (folder icon + expand arrow)
- Maintain workspace-relative paths for entries inside symlink targets so navigation continues to work across the workspace boundary