### PR TITLE
Fix raw </pre> handling in response renderer

### DIFF
--- a/static/ui.js
+++ b/static/ui.js
@@ -813,15 +813,15 @@ function renderMd(raw){
   // Stash raw <pre> blocks so the inline <code> rewrite below does not run
   // inside them. Running that rewrite in <pre> content can introduce stray
   // backticks for multiline code and break subsequent code-box rendering.
-  const raw_pre_stash=[];
-  s=s.replace(/(<pre\b[^>]*>[\s\S]*?<\/pre>)/gi,m=>{raw_pre_stash.push(m);return `\x00R${raw_pre_stash.length-1}\x00`;});
+  const rawPreStash=[];
+  s=s.replace(/(<pre\b[^>]*>[\s\S]*?<\/pre>)/gi,m=>{rawPreStash.push(m);return `\x00R${rawPreStash.length-1}\x00`;});
   s=s.replace(/<strong>([\s\S]*?)<\/strong>/gi,(_,t)=>'**'+t+'**');
   s=s.replace(/<b>([\s\S]*?)<\/b>/gi,(_,t)=>'**'+t+'**');
   s=s.replace(/<em>([\s\S]*?)<\/em>/gi,(_,t)=>'*'+t+'*');
   s=s.replace(/<i>([\s\S]*?)<\/i>/gi,(_,t)=>'*'+t+'*');
   s=s.replace(/<code>([^<]*?)<\/code>/gi,(_,t)=>'`'+t+'`');
   s=s.replace(/<br\s*\/?>/gi,'\n');
-  s=s.replace(/\x00R(\d+)\x00/g,(_,i)=>raw_pre_stash[+i]);
+  s=s.replace(/\x00R(\d+)\x00/g,(_,i)=>rawPreStash[+i]);
   // Restore stashed code blocks
   s=s.replace(/\x00F(\d+)\x00/g,(_,i)=>fence_stash[+i]);
   // Mermaid blocks: render as diagram containers (processed after DOM insertion)

--- a/static/ui.js
+++ b/static/ui.js
@@ -810,12 +810,18 @@ function renderMd(raw){
   s=s.replace(/\\\\\((.+?)\\\\\)/g,(_,m)=>{math_stash.push({type:'inline',src:m});return '\x00M'+(math_stash.length-1)+'\x00';});
   s=s.replace(/\\\\\[(.+?)\\\\\]/gs,(_,m)=>{math_stash.push({type:'display',src:m});return '\x00M'+(math_stash.length-1)+'\x00';});
   // Safe tag → markdown equivalent (these produce the same output as **text** etc.)
+  // Stash raw <pre> blocks so the inline <code> rewrite below does not run
+  // inside them. Running that rewrite in <pre> content can introduce stray
+  // backticks for multiline code and break subsequent code-box rendering.
+  const raw_pre_stash=[];
+  s=s.replace(/(<pre\b[^>]*>[\s\S]*?<\/pre>)/gi,m=>{raw_pre_stash.push(m);return `\x00R${raw_pre_stash.length-1}\x00`;});
   s=s.replace(/<strong>([\s\S]*?)<\/strong>/gi,(_,t)=>'**'+t+'**');
   s=s.replace(/<b>([\s\S]*?)<\/b>/gi,(_,t)=>'**'+t+'**');
   s=s.replace(/<em>([\s\S]*?)<\/em>/gi,(_,t)=>'*'+t+'*');
   s=s.replace(/<i>([\s\S]*?)<\/i>/gi,(_,t)=>'*'+t+'*');
   s=s.replace(/<code>([^<]*?)<\/code>/gi,(_,t)=>'`'+t+'`');
   s=s.replace(/<br\s*\/?>/gi,'\n');
+  s=s.replace(/\x00R(\d+)\x00/g,(_,i)=>raw_pre_stash[+i]);
   // Restore stashed code blocks
   s=s.replace(/\x00F(\d+)\x00/g,(_,i)=>fence_stash[+i]);
   // Mermaid blocks: render as diagram containers (processed after DOM insertion)

--- a/tests/test_renderer_js_behaviour.py
+++ b/tests/test_renderer_js_behaviour.py
@@ -461,3 +461,30 @@ class TestBlockquoteEntityEncodedInput:
             f"Entity-encoded blockquote with fenced code must render: {out!r}"
         )
         assert "<pre>" in out, f"Fenced code inside entity-encoded blockquote must render: {out!r}"
+
+
+class TestRawPreCodePreservation:
+    """Raw <pre><code> HTML from model output should remain structurally intact."""
+
+    def test_multiline_pre_code_blocks_do_not_degrade_to_backticks(self, driver_path):
+        src = (
+            "<pre><code>line 1\n"
+            "line 2\n"
+            "</code></pre>\n\n"
+            "After paragraph.\n\n"
+            "<pre><code>line 3\n"
+            "line 4\n"
+            "</code></pre>\n\n"
+            "Done."
+        )
+        out = _render(driver_path, src)
+        assert out.count("<pre>") == 2 and out.count("</pre>") == 2, (
+            f"Expected two balanced <pre> blocks, got: {out!r}"
+        )
+        assert out.count("<code>") == 2 and out.count("</code>") == 2, (
+            f"Expected two balanced <code> blocks, got: {out!r}"
+        )
+        assert "`line 1" not in out and "line 2\n`</pre>" not in out, (
+            f"<code> content inside <pre> must not be rewritten to backticks: {out!r}"
+        )
+        assert "After paragraph." in out and "Done." in out


### PR DESCRIPTION
## Bug Description

Fixes response rendering where raw HTML code blocks could consume following content.

When model output included raw `<pre><code>...</code></pre>`, later message content could be rendered as if still inside a code box. This was especially visible when multiple code boxes appeared in one response.

## Root Cause

`renderMd()` in `static/ui.js` performs a safe inline-HTML normalization pass that rewrites `<code>...</code>` to markdown backticks.

That rewrite was applied globally, including inside raw `<pre>` blocks coming from model output. For multiline code inside `<pre><code>...</code></pre>`, this could degrade block structure (introducing stray backticks and malformed code-box boundaries), which then cascaded into subsequent content rendering incorrectly.

## Fix

Stash raw `<pre>...</pre>` blocks before the inline `<code>` normalization pass, then restore them immediately after.

```js
// Before
s = s.replace(/<code>([^<]*?)<\/code>/gi, (_, t) => '`' + t + '`');

// After
const rawPreStash = [];
s = s.replace(/(<pre\b[^>]*>[\s\S]*?<\/pre>)/gi, m => {
  rawPreStash.push(m);
  return `\x00R${rawPreStash.length - 1}\x00`;
});
s = s.replace(/<code>([^<]*?)<\/code>/gi, (_, t) => '`' + t + '`');
s = s.replace(/\x00R(\d+)\x00/g, (_, i) => rawPreStash[+i]);
```

This is a minimal, targeted change: only raw `<pre>` regions are protected from the inline `<code>` rewrite; the rest of the markdown pipeline remains unchanged.

## Files Changed

- `static/ui.js` — protect raw `<pre>` blocks during inline HTML normalization
- `tests/test_renderer_js_behaviour.py` — add regression test for multiple multiline raw `<pre><code>` blocks

## How to Verify

Send output that contains multiple raw HTML code blocks, e.g.:

> "Return two raw HTML code blocks using `<pre><code>...</code></pre>`, each multiline, with plain text between and after them."

**Before fix:** code-box boundaries could degrade and later content could appear inside a code box.
**After fix:** each code block stays balanced and plain text between/after blocks renders normally.

## Test Plan

- [x] Added regression test in `tests/test_renderer_js_behaviour.py` (`TestRawPreCodePreservation`)
- [x] Ran direct Node `renderMd` smoke verification for multiline raw `<pre><code>` blocks
- [x] Confirmed touched files have no lints
- [x] Full local `pytest` run

## Risk Assessment

Low — change scope is limited to stashing/restoring raw `<pre>` segments around one inline rewrite pass. No CSS/layout changes and no behavior changes for fenced markdown code blocks.