### PR TITLE
fix: fold cron sessions in sidebar

### DIFF
--- a/static/sessions.js
+++ b/static/sessions.js
@@ -341,6 +341,11 @@ let _showArchived = false;  // toggle to show archived sessions
 let _allProjects = [];  // cached project list
 let _activeProject = null;  // project_id filter (null = show all)
 let _showAllProfiles = false;  // false = filter to active profile only
+let _cronSessionsCollapsed = true;  // fold noisy scheduled-task sessions in sidebar
+try{
+  const storedCronCollapse=localStorage.getItem('hermes-cron-sessions-collapsed');
+  if(storedCronCollapse!==null) _cronSessionsCollapsed = storedCronCollapse !== 'false';
+}catch(e){}
 let _sessionActionMenu = null;
 let _sessionActionAnchor = null;
 let _sessionActionSessionId = null;
@@ -676,6 +681,40 @@ function _sessionTimestampMs(session) {
   return Number.isFinite(raw) ? raw * 1000 : 0;
 }
 
+function _isCronSession(session) {
+  if(!session) return false;
+  const title=String(session.title||'').trim();
+  return title==='Cron Session' || title.startsWith('[SYSTEM: You are running as a scheduled cron job.');
+}
+
+function _saveCronSessionsCollapsed(){
+  try{localStorage.setItem('hermes-cron-sessions-collapsed', _cronSessionsCollapsed?'true':'false');}catch(e){}
+}
+
+function _renderCronSessionsToggle(cronSessions, initiallyCollapsed, onToggle){
+  const row=document.createElement('div');
+  row.className='cron-sessions-toggle';
+  const caret=document.createElement('span');
+  caret.className='session-date-caret'+(initiallyCollapsed?' collapsed':'');
+  caret.textContent='\u25B8';
+  const label=document.createElement('span');
+  label.className='cron-sessions-toggle-label';
+  label.textContent='Cron Sessions';
+  const count=document.createElement('span');
+  count.className='cron-sessions-toggle-count';
+  count.textContent=String(cronSessions.length);
+  row.appendChild(caret);
+  row.appendChild(label);
+  row.appendChild(count);
+  row.title=initiallyCollapsed?'展开定时任务会话':'折叠定时任务会话';
+  row.onclick=(e)=>{
+    e.preventDefault();
+    e.stopPropagation();
+    onToggle(row, caret);
+  };
+  return row;
+}
+
 function _localDayOrdinal(timestampMs) {
   const date = new Date(timestampMs);
   return Math.floor(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()) / 86400000);
@@ -873,7 +912,31 @@ function renderSessionListFromCache(){
       _saveCollapsed();
     };
     wrapper.appendChild(hdr);
-    for(const s of g.items){ body.appendChild(_renderOneSession(s, Boolean(g.isPinned))); }
+    const isPinnedGroup=Boolean(g.isPinned);
+    const cronItems=g.items.filter(_isCronSession);
+    const nonCronItems=g.items.filter(s=>!_isCronSession(s));
+    for(const s of nonCronItems){ body.appendChild(_renderOneSession(s, isPinnedGroup)); }
+    if(cronItems.length===1){
+      body.appendChild(_renderOneSession(cronItems[0], isPinnedGroup));
+    }else if(cronItems.length>1){
+      const activeCron=!!(S.session&&cronItems.some(s=>s.session_id===S.session.session_id));
+      const qActive=!!q;
+      const initiallyCollapsed=cronItems.length>1 && _cronSessionsCollapsed && !activeCron && !qActive;
+      const cronBody=document.createElement('div');
+      cronBody.className='cron-sessions-body';
+      if(initiallyCollapsed) cronBody.style.display='none';
+      const toggle=_renderCronSessionsToggle(cronItems, initiallyCollapsed, (row, caret)=>{
+        const isCollapsed=cronBody.style.display==='none';
+        cronBody.style.display=isCollapsed?'':'none';
+        caret.classList.toggle('collapsed',!isCollapsed);
+        row.title=isCollapsed?'折叠定时任务会话':'展开定时任务会话';
+        _cronSessionsCollapsed=!isCollapsed;
+        _saveCronSessionsCollapsed();
+      });
+      body.appendChild(toggle);
+      for(const s of cronItems){ cronBody.appendChild(_renderOneSession(s, isPinnedGroup)); }
+      body.appendChild(cronBody);
+    }
     wrapper.appendChild(body);
     list.appendChild(wrapper);
   }

--- a/static/style.css
+++ b/static/style.css
@@ -332,6 +332,11 @@
   .session-date-header.pinned{color:var(--accent);}
   .session-date-caret{font-size:9px;transition:transform .2s;flex-shrink:0;display:inline-block;transform:rotate(0deg);}
   .session-date-caret.collapsed{transform:rotate(-90deg);}
+  .cron-sessions-toggle{display:flex;align-items:center;gap:6px;margin:2px 4px 4px;padding:7px 10px;border-radius:8px;color:var(--muted);font-size:12px;cursor:pointer;user-select:none;background:rgba(255,255,255,.025);border:1px solid transparent;transition:background .15s,border-color .15s,color .15s;}
+  .cron-sessions-toggle:hover{background:var(--hover-bg);border-color:var(--border2);color:var(--text);}
+  .cron-sessions-toggle-label{font-weight:600;flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+  .cron-sessions-toggle-count{font-size:10px;color:var(--muted);border:1px solid var(--border2);border-radius:999px;padding:1px 6px;background:rgba(255,255,255,.035);}
+  .cron-sessions-body{padding-left:8px;border-left:1px dashed var(--border2);margin-left:12px;}
   .app-dialog-overlay{position:fixed;inset:0;background:rgba(7,12,19,.62);backdrop-filter:blur(6px);z-index:1100;display:none;align-items:center;justify-content:center;padding:24px;}
   .app-dialog{width:min(460px,100%);background:linear-gradient(180deg,rgba(21,31,45,.98),rgba(13,20,31,.98));border:1px solid var(--accent-bg-strong);border-radius:18px;box-shadow:0 18px 60px rgba(0,0,0,.45);padding:18px 18px 16px;color:var(--text);}
   .app-dialog-header{display:flex;align-items:flex-start;justify-content:space-between;gap:12px;margin-bottom:10px;}


### PR DESCRIPTION
## Summary
- Fold repeated cron-generated sessions in the sidebar behind a single `Cron Sessions` row with a count badge.
- Persist the cron fold/expand preference in `localStorage`.
- Auto-expand cron sessions while searching or when the active session is a cron session, so individual entries remain discoverable.

## Test Plan
- `node --check static/sessions.js`
- Manually verified in the WebUI that repeated cron sessions render as one folded `Cron Sessions` group instead of flooding the sidebar.

## Notes
This is a display-only change; it does not delete or merge any session history.
