### PR TITLE
feat: YOLO mode toggle — skip all approvals per session (#467)

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -432,6 +432,9 @@ try:
         _lock,
         _permanent_approved,
         resolve_gateway_approval,
+        enable_session_yolo,
+        disable_session_yolo,
+        is_session_yolo_enabled,
     )
 except ImportError:
     _submit_pending_raw = lambda *a, **k: None
@@ -440,6 +443,9 @@ except ImportError:
     save_permanent_allowlist = lambda *a, **k: None
     is_approved = lambda *a, **k: True
     resolve_gateway_approval = lambda *a, **k: 0
+    enable_session_yolo = lambda *a, **k: None
+    disable_session_yolo = lambda *a, **k: None
+    is_session_yolo_enabled = lambda *a, **k: False
     _pending = {}
     _lock = threading.Lock()
     _permanent_approved = set()
@@ -845,6 +851,12 @@ def handle_get(handler, parsed) -> bool:
             return j(handler, session_status(sid))
         except KeyError:
             return bad(handler, "Session not found", 404)
+
+    if parsed.path == "/api/session/yolo":
+        sid = parse_qs(parsed.query).get("session_id", [""])[0]
+        if not sid:
+            return bad(handler, "Missing session_id")
+        return j(handler, {"yolo_enabled": is_session_yolo_enabled(sid)})
 
     if parsed.path == "/api/session/usage":
         sid = parse_qs(parsed.query).get("session_id", [""])[0]
@@ -1401,6 +1413,31 @@ def handle_post(handler, parsed) -> bool:
             return bad(handler, "Session not found", 404)
         except ValueError as e:
             return j(handler, {"error": str(e)})
+
+    # ── YOLO mode toggle (POST) ──
+    # Session-scoped only — never persistent, never global across sessions.
+    # Fixes #467
+    if parsed.path == "/api/session/yolo":
+        try:
+            require(body, "session_id")
+        except ValueError as e:
+            return bad(handler, str(e))
+        sid = body["session_id"]
+        enabled = bool(body.get("enabled", True))
+        if enabled:
+            enable_session_yolo(sid)
+            # Also resolve any pending approvals for this session so the
+            # agent doesn't stay stuck waiting on an already-dismissed card.
+            try:
+                from tools.approval import _pending as _p, _lock as _l
+                with _l:
+                    _p.pop(sid, None)
+            except Exception:
+                pass
+            resolve_gateway_approval(sid, "once", resolve_all=True)
+        else:
+            disable_session_yolo(sid)
+        return j(handler, {"ok": True, "yolo_enabled": enabled})
 
     if parsed.path == "/api/btw":
         return _handle_btw(handler, body)

--- a/api/routes.py
+++ b/api/routes.py
@@ -1415,7 +1415,12 @@ def handle_post(handler, parsed) -> bool:
             return j(handler, {"error": str(e)})
 
     # ── YOLO mode toggle (POST) ──
-    # Session-scoped only — never persistent, never global across sessions.
+    # Session-scoped only — stored in-memory on the server side.
+    # Important lifecycle notes:
+    #   • Page reload: state PERSISTS (frontend re-fetches via GET endpoint)
+    #   • Cross-tab: state is SHARED (same server-side flag per session)
+    #   • Server restart: state is LOST (in-memory only)
+    #   • Cross-session: isolated (each session has its own flag)
     # Fixes #467
     if parsed.path == "/api/session/yolo":
         try:

--- a/static/commands.js
+++ b/static/commands.js
@@ -28,6 +28,7 @@ const COMMANDS=[
   {name:'status',    desc:t('cmd_status'),   fn:cmdStatus},
   {name:'voice',     desc:t('cmd_voice'),    fn:cmdVoice,     noEcho:true},
   {name:'reasoning', desc:t('cmd_reasoning'), fn:cmdReasoning, arg:'show|hide|none|minimal|low|medium|high|xhigh', subArgs:['show','hide','none','minimal','low','medium','high','xhigh'], noEcho:true},
+  {name:'yolo', desc:t('cmd_yolo'), fn:cmdYolo, noEcho:true},
 ];
 
 const SLASH_SUBARG_SOURCES={
@@ -794,6 +795,31 @@ function cmdVoice(){
   if(mic&&mic.style.display!=='none'&&!mic.disabled){try{mic.click();return;}catch(_){}}
   showToast(t('cmd_voice_use_mic'));
 }
+
+// ── YOLO mode toggle ──
+// Session-scoped: skips all approval prompts for the current session.
+// Toggles on/off; state is not persisted across page reloads.
+async function cmdYolo(){
+  const sid=S.session&&S.session.session_id;
+  if(!sid){showToast(t('yolo_no_session'));return;}
+  try{
+    // Check current state first to toggle
+    const status=await api('/api/session/yolo?session_id='+encodeURIComponent(sid));
+    const enable=!status.yolo_enabled;
+    await api('/api/session/yolo',{
+      method:'POST',
+      body:JSON.stringify({session_id:sid,enabled:enable}),
+    });
+    _yoloEnabled=enable;
+    _updateYoloPill();
+    showToast(enable?t('yolo_enabled'):t('yolo_disabled'));
+    if(enable){
+      // Dismiss any visible approval card
+      hideApprovalCard(true);
+    }
+  }catch(e){showToast('YOLO: '+e.message);}
+}
+
 let _skillCommandCache=[];
 let _skillCommandLoadPromise=null;
 let _skillCommandCacheReady=false;

--- a/static/i18n.js
+++ b/static/i18n.js
@@ -655,7 +655,15 @@ const LOCALES = {
     // profile form
     profile_name_label: 'Name',
     profile_base_url_label: 'Base URL',
-    profile_api_key_label: 'API key',
+    profile_api_key_label: 'API key',,
+    cmd_yolo: 'Toggle YOLO mode (skip approvals)',
+    yolo_no_session: 'No active session',
+    yolo_enabled: '⚡ YOLO mode ON — approvals skipped this session',
+    yolo_disabled: 'YOLO mode OFF',
+    yolo_pill_label: 'YOLO',
+    yolo_pill_title_active: 'YOLO mode active — click to disable',
+    approval_skip_all: '⚡ Skip all this session',
+    approval_skip_all_title: 'Skip all approval prompts for this session'
   },
 
   ru: {
@@ -1122,7 +1130,15 @@ const LOCALES = {
       : (mod10 >= 2 && mod10 <= 4 && (mod100 < 10 || mod100 >= 20)
         ? 'навыка'
         : 'навыков');
-    return `${count} ${word}`;
+    return `${count} ${word}`;,
+    cmd_yolo: 'Переключить YOLO режим (без подтверждений)',
+    yolo_no_session: 'Нет активного сеанса',
+    yolo_enabled: '⚡ YOLO режим ВКЛ — подтверждения пропущены',
+    yolo_disabled: 'YOLO режим ВЫКЛ',
+    yolo_pill_label: 'YOLO',
+    yolo_pill_title_active: 'YOLO режим активен — нажмите для отключения',
+    approval_skip_all: '⚡ Пропустить все в этом сеансе',
+    approval_skip_all_title: 'Пропустить все запросы подтверждения в этом сеансе'
   },
     profile_use: 'Использовать',
     profile_switch_title: 'Переключиться на этот профиль',
@@ -1847,7 +1863,15 @@ const LOCALES = {
     settings_tab_appearance: 'Appearance',
     settings_tab_conversation: 'Conversation',
     settings_tab_preferences: 'Preferences',
-    settings_tab_system: 'System',
+    settings_tab_system: 'System',,
+    cmd_yolo: 'Alternar modo YOLO (omitir aprobaciones)',
+    yolo_no_session: 'Sin sesión activa',
+    yolo_enabled: '⚡ Modo YOLO ON — aprobaciones omitidas en esta sesión',
+    yolo_disabled: 'Modo YOLO OFF',
+    yolo_pill_label: 'YOLO',
+    yolo_pill_title_active: 'Modo YOLO activo — clic para desactivar',
+    approval_skip_all: '⚡ Omitir todo en esta sesión',
+    approval_skip_all_title: 'Omitir todas las aprobaciones en esta sesión'
   },
 
   de: {
@@ -2215,7 +2239,15 @@ const LOCALES = {
     settings_tab_conversation: 'Conversation',
     settings_tab_preferences: 'Preferences',
     settings_tab_system: 'System',
-},
+    cmd_yolo: 'YOLO-Modus umschalten',
+    yolo_no_session: 'Keine aktive Sitzung',
+    yolo_enabled: '⚡ YOLO-Modus AN — Genehmigungen übersprungen',
+    yolo_disabled: 'YOLO-Modus AUS',
+    yolo_pill_label: 'YOLO',
+    yolo_pill_title_active: 'YOLO-Modus aktiv — Klicken zum Deaktivieren',
+    approval_skip_all: '⚡ Alle in dieser Sitzung überspringen',
+    approval_skip_all_title: 'Alle Genehmigungsanfragen in dieser Sitzung überspringen'
+  },
 
   zh: {
     _lang: 'zh',
@@ -3444,7 +3476,23 @@ const LOCALES = {
     usage_personality_none: '\u7121',
     usage_settings_tip: '\u6ce8\u610f\uff1a\u8cbb\u7528\u70ba\u9810\u4f30\u503c\u3002',
     usage_total: '\u7e3d Token \u6578',
-    usage_unknown: '\u672a\u77e5',
+    usage_unknown: '\u672a\u77e5',,
+    cmd_yolo: 'YOLO-Modus umschalten (Genehmigungen überspringen)',
+    yolo_no_session: 'Keine aktive Sitzung',
+    yolo_enabled: '⚡ YOLO-Modus AN — Genehmigungen übersprungen',
+    yolo_disabled: 'YOLO-Modus AUS',
+    yolo_pill_label: 'YOLO',
+    yolo_pill_title_active: 'YOLO-Modus aktiv — klicken zum Deaktivieren',
+    approval_skip_all: '⚡ Alle in dieser Sitzung überspringen',
+    approval_skip_all_title: 'Alle Genehmigungsaufforderungen in dieser Sitzung überspringen',
+    cmd_yolo: '切换 YOLO 模式（跳过审批）',
+    yolo_no_session: '无活跃会话',
+    yolo_enabled: '⚡ YOLO 模式已开启 — 本次会话跳过审批',
+    yolo_disabled: 'YOLO 模式已关闭',
+    yolo_pill_label: 'YOLO',
+    yolo_pill_title_active: 'YOLO 模式已激活 — 点击关闭',
+    approval_skip_all: '⚡ 本次会话全部跳过',
+    approval_skip_all_title: '跳过本次会话的所有审批提示'
   },
 
   ko: {
@@ -4090,6 +4138,14 @@ const LOCALES = {
     profile_name_label: 'Name',
     profile_base_url_label: 'Base URL',
     profile_api_key_label: 'API key',
+    cmd_yolo: 'YOLO 모드 전환',
+    yolo_no_session: '활성 세션 없음',
+    yolo_enabled: '⚡ YOLO 모드 켜짐 — 이 세션에서 승인 건너뜀',
+    yolo_disabled: 'YOLO 모드 꺼짐',
+    yolo_pill_label: 'YOLO',
+    yolo_pill_title_active: 'YOLO 모드 활성 — 클릭하여 비활성화',
+    approval_skip_all: '⚡ 이 세션에서 모두 건너뛰기',
+    approval_skip_all_title: '이 세션의 모든 승인 요청 건너뛰기'
   }
 };
 

--- a/static/i18n.js
+++ b/static/i18n.js
@@ -655,7 +655,7 @@ const LOCALES = {
     // profile form
     profile_name_label: 'Name',
     profile_base_url_label: 'Base URL',
-    profile_api_key_label: 'API key',,
+    profile_api_key_label: 'API key',
     cmd_yolo: 'Toggle YOLO mode (skip approvals)',
     yolo_no_session: 'No active session',
     yolo_enabled: '⚡ YOLO mode ON — approvals skipped this session',
@@ -665,7 +665,6 @@ const LOCALES = {
     approval_skip_all: '⚡ Skip all this session',
     approval_skip_all_title: 'Skip all approval prompts for this session'
   },
-
   ru: {
     _lang: 'ru',
     _label: 'Русский',
@@ -1130,15 +1129,7 @@ const LOCALES = {
       : (mod10 >= 2 && mod10 <= 4 && (mod100 < 10 || mod100 >= 20)
         ? 'навыка'
         : 'навыков');
-    return `${count} ${word}`;,
-    cmd_yolo: 'Переключить YOLO режим (без подтверждений)',
-    yolo_no_session: 'Нет активного сеанса',
-    yolo_enabled: '⚡ YOLO режим ВКЛ — подтверждения пропущены',
-    yolo_disabled: 'YOLO режим ВЫКЛ',
-    yolo_pill_label: 'YOLO',
-    yolo_pill_title_active: 'YOLO режим активен — нажмите для отключения',
-    approval_skip_all: '⚡ Пропустить все в этом сеансе',
-    approval_skip_all_title: 'Пропустить все запросы подтверждения в этом сеансе'
+    return `${count} ${word}`;
   },
     profile_use: 'Использовать',
     profile_switch_title: 'Переключиться на этот профиль',
@@ -1271,8 +1262,15 @@ const LOCALES = {
     settings_tab_conversation: 'Conversation',
     settings_tab_preferences: 'Preferences',
     settings_tab_system: 'System',
+    cmd_yolo: 'Переключить YOLO режим (без подтверждений)',
+    yolo_no_session: 'Нет активного сеанса',
+    yolo_enabled: '⚡ YOLO режим ВКЛ — подтверждения пропущены',
+    yolo_disabled: 'YOLO режим ВЫКЛ',
+    yolo_pill_label: 'YOLO',
+    yolo_pill_title_active: 'YOLO режим активен — нажмите для отключения',
+    approval_skip_all: '⚡ Пропустить все в этом сеансе',
+    approval_skip_all_title: 'Пропустить все запросы подтверждения в этом сеансе'
   },
-
   es: {
     _lang: 'es',
     _label: 'Español',
@@ -1863,17 +1861,16 @@ const LOCALES = {
     settings_tab_appearance: 'Appearance',
     settings_tab_conversation: 'Conversation',
     settings_tab_preferences: 'Preferences',
-    settings_tab_system: 'System',,
-    cmd_yolo: 'Alternar modo YOLO (omitir aprobaciones)',
-    yolo_no_session: 'Sin sesión activa',
-    yolo_enabled: '⚡ Modo YOLO ON — aprobaciones omitidas en esta sesión',
-    yolo_disabled: 'Modo YOLO OFF',
+    settings_tab_system: 'System',
+    cmd_yolo: 'Alternar modo YOLO (saltar aprobaciones)',
+    yolo_no_session: 'No hay sesión activa',
+    yolo_enabled: '⚡ Modo YOLO activado — aprobaciones omitidas',
+    yolo_disabled: 'Modo YOLO desactivado',
     yolo_pill_label: 'YOLO',
-    yolo_pill_title_active: 'Modo YOLO activo — clic para desactivar',
-    approval_skip_all: '⚡ Omitir todo en esta sesión',
-    approval_skip_all_title: 'Omitir todas las aprobaciones en esta sesión'
+    yolo_pill_title_active: 'Modo YOLO activo — haz clic para desactivar',
+    approval_skip_all: '⚡ Saltar todo en esta sesión',
+    approval_skip_all_title: 'Saltar todas las solicitudes de aprobación en esta sesión'
   },
-
   de: {
     _lang: 'de',
     _label: 'Deutsch',
@@ -2247,8 +2244,7 @@ const LOCALES = {
     yolo_pill_title_active: 'YOLO-Modus aktiv — Klicken zum Deaktivieren',
     approval_skip_all: '⚡ Alle in dieser Sitzung überspringen',
     approval_skip_all_title: 'Alle Genehmigungsanfragen in dieser Sitzung überspringen'
-  },
-
+},
   zh: {
     _lang: 'zh',
     _label: '\u7b80\u4f53\u4e2d\u6587',
@@ -2837,6 +2833,14 @@ const LOCALES = {
     settings_tab_conversation: 'Conversation',
     settings_tab_preferences: 'Preferences',
     settings_tab_system: 'System',
+    cmd_yolo: 'YOLO 模式切换',
+    yolo_no_session: '无活动会话',
+    yolo_enabled: '⚡ YOLO 模式已开启 — 将跳过所有审批',
+    yolo_disabled: 'YOLO 模式已关闭',
+    yolo_pill_label: 'YOLO',
+    yolo_pill_title_active: 'YOLO 模式激活 — 点击关闭',
+    approval_skip_all: '⚡ 本次会话全部跳过',
+    approval_skip_all_title: '跳过本次会话的所有审批提示'
 },
 
   // Traditional Chinese (zh-Hant)
@@ -3476,25 +3480,16 @@ const LOCALES = {
     usage_personality_none: '\u7121',
     usage_settings_tip: '\u6ce8\u610f\uff1a\u8cbb\u7528\u70ba\u9810\u4f30\u503c\u3002',
     usage_total: '\u7e3d Token \u6578',
-    usage_unknown: '\u672a\u77e5',,
-    cmd_yolo: 'YOLO-Modus umschalten (Genehmigungen überspringen)',
-    yolo_no_session: 'Keine aktive Sitzung',
-    yolo_enabled: '⚡ YOLO-Modus AN — Genehmigungen übersprungen',
-    yolo_disabled: 'YOLO-Modus AUS',
+    usage_unknown: '\u672a\u77e5',
+    cmd_yolo: 'YOLO 模式切換',
+    yolo_no_session: '無活動工作階段',
+    yolo_enabled: '⚡ YOLO 模式已開啟 — 將跳過所有審批',
+    yolo_disabled: 'YOLO 模式已關閉',
     yolo_pill_label: 'YOLO',
-    yolo_pill_title_active: 'YOLO-Modus aktiv — klicken zum Deaktivieren',
-    approval_skip_all: '⚡ Alle in dieser Sitzung überspringen',
-    approval_skip_all_title: 'Alle Genehmigungsaufforderungen in dieser Sitzung überspringen',
-    cmd_yolo: '切换 YOLO 模式（跳过审批）',
-    yolo_no_session: '无活跃会话',
-    yolo_enabled: '⚡ YOLO 模式已开启 — 本次会话跳过审批',
-    yolo_disabled: 'YOLO 模式已关闭',
-    yolo_pill_label: 'YOLO',
-    yolo_pill_title_active: 'YOLO 模式已激活 — 点击关闭',
-    approval_skip_all: '⚡ 本次会话全部跳过',
-    approval_skip_all_title: '跳过本次会话的所有审批提示'
+    yolo_pill_title_active: 'YOLO 模式激活 — 點擊關閉',
+    approval_skip_all: '⚡ 本次工作階段全部跳過',
+    approval_skip_all_title: '跳過本次工作階段的所有審批提示'
   },
-
   ko: {
     _lang: 'ko',
     _label: 'Korean (한국어)',

--- a/static/i18n.js
+++ b/static/i18n.js
@@ -665,6 +665,7 @@ const LOCALES = {
     approval_skip_all: '⚡ Skip all this session',
     approval_skip_all_title: 'Skip all approval prompts for this session'
   },
+
   ru: {
     _lang: 'ru',
     _label: 'Русский',
@@ -1271,6 +1272,7 @@ const LOCALES = {
     approval_skip_all: '⚡ Пропустить все в этом сеансе',
     approval_skip_all_title: 'Пропустить все запросы подтверждения в этом сеансе'
   },
+
   es: {
     _lang: 'es',
     _label: 'Español',
@@ -1871,6 +1873,7 @@ const LOCALES = {
     approval_skip_all: '⚡ Saltar todo en esta sesión',
     approval_skip_all_title: 'Saltar todas las solicitudes de aprobación en esta sesión'
   },
+
   de: {
     _lang: 'de',
     _label: 'Deutsch',
@@ -2245,6 +2248,7 @@ const LOCALES = {
     approval_skip_all: '⚡ Alle in dieser Sitzung überspringen',
     approval_skip_all_title: 'Alle Genehmigungsanfragen in dieser Sitzung überspringen'
 },
+
   zh: {
     _lang: 'zh',
     _label: '\u7b80\u4f53\u4e2d\u6587',
@@ -3490,6 +3494,7 @@ const LOCALES = {
     approval_skip_all: '⚡ 本次工作階段全部跳過',
     approval_skip_all_title: '跳過本次工作階段的所有審批提示'
   },
+
   ko: {
     _lang: 'ko',
     _label: 'Korean (한국어)',

--- a/static/index.html
+++ b/static/index.html
@@ -286,6 +286,9 @@
               <span class="approval-btn-label" data-i18n="approval_btn_deny">Deny</span>
             </button>
           </div>
+          <button class="approval-skip-all" id="approvalSkipAll" onclick="toggleYoloFromApproval()" title="Skip all approvals this session" data-i18n-title="approval_skip_all_title">
+            <span data-i18n="approval_skip_all">⚡ Skip all this session</span>
+          </button>
         </div>
       </div>
       <div class="clarify-card" id="clarifyCard" role="dialog" aria-labelledby="clarifyHeading" aria-describedby="clarifyQuestion clarifyHint">
@@ -332,6 +335,10 @@
               </svg>
             </button>
             <div class="composer-divider" aria-hidden="true"></div>
+            <button class="yolo-pill" id="yoloPill" type="button" onclick="cmdYolo()" style="display:none" title="YOLO mode — click to disable" data-i18n-title="yolo_pill_title_active">
+              <span class="yolo-pill-icon" aria-hidden="true">⚡</span>
+              <span class="yolo-pill-label" data-i18n="yolo_pill_label">YOLO</span>
+            </button>
             <div id="profileChipWrap" class="composer-profile-wrap">
               <button class="composer-profile-chip profile-chip" id="profileChip" type="button" onclick="toggleProfileDropdown()" title="Switch profile">
                 <span class="composer-profile-icon" aria-hidden="true"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg></span>

--- a/static/index.html
+++ b/static/index.html
@@ -285,10 +285,11 @@
               <span class="approval-btn-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg></span>
               <span class="approval-btn-label" data-i18n="approval_btn_deny">Deny</span>
             </button>
+            <button class="approval-btn yolo" id="approvalSkipAll" onclick="toggleYoloFromApproval()" title="Skip all approvals this session" data-i18n-title="approval_skip_all_title">
+              <span class="approval-btn-icon" aria-hidden="true">⚡</span>
+              <span class="approval-btn-label" data-i18n="approval_skip_all">Skip all</span>
+            </button>
           </div>
-          <button class="approval-skip-all" id="approvalSkipAll" onclick="toggleYoloFromApproval()" title="Skip all approvals this session" data-i18n-title="approval_skip_all_title">
-            <span data-i18n="approval_skip_all">⚡ Skip all this session</span>
-          </button>
         </div>
       </div>
       <div class="clarify-card" id="clarifyCard" role="dialog" aria-labelledby="clarifyHeading" aria-describedby="clarifyQuestion clarifyHint">

--- a/static/messages.js
+++ b/static/messages.js
@@ -127,6 +127,7 @@ async function send(){
   if(typeof renderSessionListFromCache==='function') renderSessionListFromCache();
   startApprovalPolling(activeSid);
   startClarifyPolling(activeSid);
+  _fetchYoloState(activeSid);  // sync YOLO pill with backend state
   S.activeStreamId = null;  // will be set after stream starts
 
   // Set provisional title from user message immediately so session appears
@@ -1069,6 +1070,44 @@ function transcript(){
 
 function autoResize(){const el=$('msg');el.style.height='auto';el.style.height=Math.min(el.scrollHeight,200)+'px';updateSendBtn();}
 
+
+// ── YOLO mode state ──
+// Session-scoped; resets on page reload (intentional — not persisted).
+let _yoloEnabled = false;
+
+async function _fetchYoloState(sid) {
+  try {
+    const data = await api('/api/session/yolo?session_id=' + encodeURIComponent(sid));
+    _yoloEnabled = !!data.yolo_enabled;
+    _updateYoloPill();
+  } catch (_) { /* ignore */ }
+}
+
+function _updateYoloPill() {
+  const pill = $('yoloPill');
+  if (!pill) return;
+  pill.style.display = _yoloEnabled ? '' : 'none';
+  if (_yoloEnabled) {
+    pill.title = t('yolo_pill_title_active');
+    pill.setAttribute('data-i18n-title', 'yolo_pill_title_active');
+  }
+  if (typeof applyLocaleToDOM === 'function') applyLocaleToDOM();
+}
+
+async function toggleYoloFromApproval() {
+  const sid = S.session && S.session.session_id;
+  if (!sid) return;
+  try {
+    await api('/api/session/yolo', {
+      method: 'POST',
+      body: JSON.stringify({ session_id: sid, enabled: true }),
+    });
+    _yoloEnabled = true;
+    _updateYoloPill();
+    hideApprovalCard(true);
+    showToast(t('yolo_enabled'));
+  } catch (e) { showToast('YOLO: ' + e.message); }
+}
 
 // ── Approval polling ──
 let _approvalPollTimer = null;

--- a/static/messages.js
+++ b/static/messages.js
@@ -1072,7 +1072,14 @@ function autoResize(){const el=$('msg');el.style.height='auto';el.style.height=M
 
 
 // ── YOLO mode state ──
-// Session-scoped; resets on page reload (intentional — not persisted).
+// Session-scoped; stored server-side in memory (tools/approval.py).
+// Lifecycle:
+//   • Page reload: state PERSISTS — _fetchYoloState() re-syncs from backend.
+//   • Cross-tab: state is SHARED — enabling YOLO in Tab A affects Tab B for
+//     the same session (both poll the same server-side flag).
+//   • Server restart: state is LOST — in-memory only, not persisted to disk.
+//   • Session switch: state resets — loadSession() clears _yoloEnabled and
+//     fetches the new session's state.
 let _yoloEnabled = false;
 
 async function _fetchYoloState(sid) {

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -102,6 +102,7 @@ async function loadSession(sid){
   // will overwrite this; stale awaits use the mismatch to bail out (#1060).
   _loadingSessionId = sid;
   stopApprovalPolling();hideApprovalCard();
+  _yoloEnabled=false;_updateYoloPill();
   if(typeof stopClarifyPolling==='function') stopClarifyPolling();
   if(typeof hideClarifyCard==='function') hideClarifyCard();
   // Show loading indicator immediately for responsiveness.
@@ -176,6 +177,7 @@ async function loadSession(sid){
     setBusy(true);setComposerStatus('');
     startApprovalPolling(sid);
     if(typeof startClarifyPolling==='function') startClarifyPolling(sid);
+    if(typeof _fetchYoloState==='function') _fetchYoloState(sid);
     S.activeStreamId=activeStreamId;
     const _cb=$('btnCancel');if(_cb&&activeStreamId)_cb.style.display='inline-flex';
     if(INFLIGHT[sid].reattach&&activeStreamId&&typeof attachLiveStream==='function'){
@@ -253,6 +255,7 @@ async function loadSession(sid){
       updateQueueBadge(sid);
       startApprovalPolling(sid);
       if(typeof startClarifyPolling==='function') startClarifyPolling(sid);
+      if(typeof _fetchYoloState==='function') _fetchYoloState(sid);
       if(typeof attachLiveStream==='function') attachLiveStream(sid, activeStreamId, S.session.pending_attachments||[], {reconnecting:true});
       else if(typeof watchInflightSession==='function') watchInflightSession(sid, activeStreamId);
     }else{

--- a/static/style.css
+++ b/static/style.css
@@ -423,9 +423,9 @@
   .approval-btn:hover{background:rgba(255,255,255,0.12);transform:translateY(-1px);box-shadow:0 2px 8px rgba(0,0,0,0.2);}
   .approval-btn:active{transform:translateY(0);box-shadow:none;}
   .approval-btn:disabled{opacity:.5;cursor:not-allowed;transform:none;}
-  /* ── YOLO skip-all link inside approval card ── */
-  .approval-skip-all{display:block;margin-top:10px;padding:0;background:none;border:none;color:var(--muted);font-size:11px;cursor:pointer;text-align:center;transition:color .15s;white-space:nowrap;}
-  .approval-skip-all:hover{color:var(--warning,#f59e0b);}
+  /* ── YOLO skip-all button (approval-btn variant) ── */
+  .approval-btn.yolo{background:rgba(245,158,11,0.12);border-color:rgba(245,158,11,0.3);color:#f59e0b;}
+  .approval-btn.yolo:hover{background:rgba(245,158,11,0.22);border-color:rgba(245,158,11,0.5);color:#fbbf24;}
   /* ── YOLO pill in composer footer ── */
   .yolo-pill{display:inline-flex;align-items:center;gap:4px;padding:3px 10px;border-radius:999px;font-size:11px;font-weight:700;letter-spacing:.04em;text-transform:uppercase;background:rgba(245,158,11,0.15);color:#f59e0b;border:1px solid rgba(245,158,11,0.35);cursor:pointer;transition:all .15s;line-height:1.4;white-space:nowrap;}
   .yolo-pill:hover{background:rgba(245,158,11,0.25);border-color:rgba(245,158,11,0.5);transform:translateY(-1px);}

--- a/static/style.css
+++ b/static/style.css
@@ -423,6 +423,15 @@
   .approval-btn:hover{background:rgba(255,255,255,0.12);transform:translateY(-1px);box-shadow:0 2px 8px rgba(0,0,0,0.2);}
   .approval-btn:active{transform:translateY(0);box-shadow:none;}
   .approval-btn:disabled{opacity:.5;cursor:not-allowed;transform:none;}
+  /* ── YOLO skip-all link inside approval card ── */
+  .approval-skip-all{display:block;margin-top:10px;padding:0;background:none;border:none;color:var(--muted);font-size:11px;cursor:pointer;text-align:center;transition:color .15s;white-space:nowrap;}
+  .approval-skip-all:hover{color:var(--warning,#f59e0b);}
+  /* ── YOLO pill in composer footer ── */
+  .yolo-pill{display:inline-flex;align-items:center;gap:4px;padding:3px 10px;border-radius:999px;font-size:11px;font-weight:700;letter-spacing:.04em;text-transform:uppercase;background:rgba(245,158,11,0.15);color:#f59e0b;border:1px solid rgba(245,158,11,0.35);cursor:pointer;transition:all .15s;line-height:1.4;white-space:nowrap;}
+  .yolo-pill:hover{background:rgba(245,158,11,0.25);border-color:rgba(245,158,11,0.5);transform:translateY(-1px);}
+  .yolo-pill:active{transform:translateY(0);}
+  .yolo-pill-icon{font-size:12px;}
+  .yolo-pill-label{font-size:10px;}
   /* ── Queue flyout (same slide-up pattern as approval-card) ── */
   .queue-card{position:absolute;left:0;right:0;bottom:0;max-width:var(--msg-max);margin:0 auto;padding:0 20px;box-sizing:border-box;width:100%;overflow:hidden;pointer-events:none;z-index:2;}
   .queue-card.visible{pointer-events:auto;}

--- a/tests/test_issue467_yolo_mode_toggle.py
+++ b/tests/test_issue467_yolo_mode_toggle.py
@@ -15,6 +15,8 @@ import json
 import pathlib
 import pytest
 
+from tests.conftest import requires_agent_modules
+
 TEST_BASE = f"http://127.0.0.1:{os.environ.get('HERMES_WEBUI_TEST_PORT', '8788')}"
 
 
@@ -52,8 +54,16 @@ def _post(path, body=None, expect_ok=True):
 
 # ── Backend endpoint tests ──
 
+@requires_agent_modules
 class TestYoloEndpointGet:
-    """GET /api/session/yolo should return yolo_enabled state."""
+    """GET /api/session/yolo should return yolo_enabled state.
+
+    Agent-dependent: the endpoint reads from ``tools.approval._session_yolo``
+    in the hermes-agent process. When the agent isn't installed, routes.py
+    falls back to a no-op lambda that always returns ``False`` regardless of
+    POST state — every assertion here would either silently false-pass or
+    flake. Skip cleanly when modules aren't importable.
+    """
 
     def test_yolo_get_returns_false_by_default(self):
         """A fresh session should not have YOLO enabled."""
@@ -68,8 +78,17 @@ class TestYoloEndpointGet:
         assert resp is not None
 
 
+@requires_agent_modules
 class TestYoloEndpointPost:
-    """POST /api/session/yolo should toggle YOLO for a session."""
+    """POST /api/session/yolo should toggle YOLO for a session.
+
+    Agent-dependent: the endpoint writes to ``tools.approval._session_yolo``
+    in the hermes-agent process. Without the agent, routes.py falls back to
+    a no-op lambda; the response shape ``{"yolo_enabled": <input>}`` echoes
+    the request body, so naive POST-only tests false-pass. The
+    ``test_yolo_post_persists_within_session`` test catches this by reading
+    state back via GET — it only succeeds when the agent is wired.
+    """
 
     def test_yolo_post_enable(self):
         """Enabling YOLO returns ok=True and yolo_enabled=True."""

--- a/tests/test_issue467_yolo_mode_toggle.py
+++ b/tests/test_issue467_yolo_mode_toggle.py
@@ -1,0 +1,209 @@
+"""Tests for YOLO mode toggle in Web UI (Issue #467).
+
+Covers:
+- GET /api/session/yolo — query YOLO state for a session
+- POST /api/session/yolo — enable/disable YOLO for a session
+- /yolo slash command registration in commands.js
+- YOLO pill HTML element presence in index.html
+- Skip-all button presence in approval card
+- CSS classes for .yolo-pill and .approval-skip-all
+- i18n keys present in all 6 locales
+"""
+import os
+import re
+import json
+import pathlib
+import pytest
+
+TEST_BASE = f"http://127.0.0.1:{os.environ.get('HERMES_WEBUI_TEST_PORT', '8788')}"
+
+
+def _get(path, expect_ok=True):
+    import urllib.request, urllib.error
+    try:
+        with urllib.request.urlopen(TEST_BASE + path, timeout=10) as r:
+            return json.loads(r.read())
+    except urllib.error.HTTPError as e:
+        try:
+            body = json.loads(e.read())
+        except Exception:
+            body = {}
+        if expect_ok:
+            return body
+        return body
+
+
+def _post(path, body=None, expect_ok=True):
+    import urllib.request, urllib.error
+    data = json.dumps(body or {}).encode()
+    req = urllib.request.Request(
+        TEST_BASE + path, data=data, headers={"Content-Type": "application/json"}
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10) as r:
+            return json.loads(r.read())
+    except urllib.error.HTTPError as e:
+        try:
+            body = json.loads(e.read())
+        except Exception:
+            body = {}
+        return body
+
+
+# ── Backend endpoint tests ──
+
+class TestYoloEndpointGet:
+    """GET /api/session/yolo should return yolo_enabled state."""
+
+    def test_yolo_get_returns_false_by_default(self):
+        """A fresh session should not have YOLO enabled."""
+        data = _get("/api/session/yolo?session_id=test-yolo-fresh-001")
+        assert data is not None
+        assert data.get("yolo_enabled") is False
+
+    def test_yolo_get_requires_session_id(self):
+        """Missing session_id returns an error response."""
+        resp = _get("/api/session/yolo?session_id=")
+        # Empty session_id may return 400 or empty response
+        assert resp is not None
+
+
+class TestYoloEndpointPost:
+    """POST /api/session/yolo should toggle YOLO for a session."""
+
+    def test_yolo_post_enable(self):
+        """Enabling YOLO returns ok=True and yolo_enabled=True."""
+        sid = "test-yolo-enable-001"
+        data = _post("/api/session/yolo", {"session_id": sid, "enabled": True})
+        assert data.get("ok") is True
+        assert data.get("yolo_enabled") is True
+
+    def test_yolo_post_disable(self):
+        """Disabling YOLO returns ok=True and yolo_enabled=False."""
+        sid = "test-yolo-disable-001"
+        _post("/api/session/yolo", {"session_id": sid, "enabled": True})
+        data = _post("/api/session/yolo", {"session_id": sid, "enabled": False})
+        assert data.get("ok") is True
+        assert data.get("yolo_enabled") is False
+
+    def test_yolo_post_persists_within_session(self):
+        """After enabling, GET should reflect the enabled state."""
+        sid = "test-yolo-persist-001"
+        _post("/api/session/yolo", {"session_id": sid, "enabled": True})
+        data = _get(f"/api/session/yolo?session_id={sid}")
+        assert data.get("yolo_enabled") is True
+
+    def test_yolo_post_cross_session_isolation(self):
+        """Enabling YOLO for one session doesn't affect another."""
+        sid_a = "test-yolo-iso-a"
+        sid_b = "test-yolo-iso-b"
+        _post("/api/session/yolo", {"session_id": sid_a, "enabled": True})
+        data = _get(f"/api/session/yolo?session_id={sid_b}")
+        assert data.get("yolo_enabled") is False
+
+    def test_yolo_post_defaults_to_enabled(self):
+        """POST without 'enabled' key defaults to True."""
+        sid = "test-yolo-default-001"
+        data = _post("/api/session/yolo", {"session_id": sid})
+        assert data.get("yolo_enabled") is True
+
+
+# ── Frontend JS tests (static file analysis — no server needed) ──
+
+class TestYoloCommandRegistration:
+    """/yolo slash command should be registered in commands.js."""
+
+    @pytest.fixture(scope="class")
+    def commands_js(self):
+        with open("static/commands.js", "r") as f:
+            return f.read()
+
+    def test_yolo_command_in_array(self, commands_js):
+        assert "'yolo'" in commands_js or '"yolo"' in commands_js
+
+    def test_yolo_uses_cmdYolo(self, commands_js):
+        assert "cmdYolo" in commands_js
+
+    def test_cmdYolo_function_exists(self, commands_js):
+        assert re.search(r"function\s+cmdYolo\s*\(", commands_js)
+
+    def test_cmdYolo_calls_yolo_endpoint(self, commands_js):
+        assert "/api/session/yolo" in commands_js
+
+
+class TestYoloPillHTML:
+    """YOLO pill element should exist in index.html."""
+
+    @pytest.fixture(scope="class")
+    def index_html(self):
+        with open("static/index.html", "r") as f:
+            return f.read()
+
+    def test_yolo_pill_element_exists(self, index_html):
+        assert 'id="yoloPill"' in index_html
+
+    def test_yolo_pill_has_onclick(self, index_html):
+        assert 'onclick="cmdYolo()"' in index_html
+
+    def test_yolo_pill_hidden_by_default(self, index_html):
+        pill_match = re.search(r'<button[^>]*id="yoloPill"[^>]*>', index_html)
+        assert pill_match
+        assert "display:none" in pill_match.group(0)
+
+    def test_skip_all_button_exists(self, index_html):
+        assert 'id="approvalSkipAll"' in index_html
+
+
+class TestYoloCSS:
+    """YOLO-related CSS classes should exist."""
+
+    @pytest.fixture(scope="class")
+    def style_css(self):
+        with open("static/style.css", "r") as f:
+            return f.read()
+
+    def test_yolo_pill_class(self, style_css):
+        assert ".yolo-pill{" in style_css or ".yolo-pill {" in style_css
+
+    def test_yolo_pill_uses_amber(self, style_css):
+        assert "#f59e0b" in style_css
+
+    def test_approval_skip_all_class(self, style_css):
+        assert ".approval-skip-all{" in style_css or ".approval-skip-all {" in style_css
+
+
+class TestYoloI18n:
+    """YOLO-related i18n keys should exist in all 6 locales."""
+
+    REQUIRED_KEYS = [
+        "cmd_yolo",
+        "yolo_no_session",
+        "yolo_enabled",
+        "yolo_disabled",
+        "yolo_pill_label",
+        "yolo_pill_title_active",
+        "approval_skip_all",
+        "approval_skip_all_title",
+    ]
+
+    LOCALES = ["en", "ru", "es", "de", "zh", "ko"]
+
+    @pytest.fixture(scope="class")
+    def i18n_js(self):
+        with open("static/i18n.js", "r") as f:
+            return f.read()
+
+    @pytest.mark.parametrize("locale", LOCALES)
+    def test_locale_has_all_yolo_keys(self, i18n_js, locale):
+        pattern = rf"\s{locale}:\s*\{{"
+        match = re.search(pattern, i18n_js)
+        assert match, f"Locale '{locale}' not found in i18n.js"
+        start = match.end()
+        next_locale = re.search(r"\n  \w{2}:\s*\{", i18n_js[start:])
+        if next_locale:
+            block = i18n_js[start:start + next_locale.start()]
+        else:
+            block = i18n_js[start:]
+
+        for key in self.REQUIRED_KEYS:
+            assert key in block, f"Key '{key}' missing in locale '{locale}'"

--- a/tests/test_issue467_yolo_mode_toggle.py
+++ b/tests/test_issue467_yolo_mode_toggle.py
@@ -6,7 +6,7 @@ Covers:
 - /yolo slash command registration in commands.js
 - YOLO pill HTML element presence in index.html
 - Skip-all button presence in approval card
-- CSS classes for .yolo-pill and .approval-skip-all
+- CSS classes for .yolo-pill and .approval-btn.yolo
 - i18n keys present in all 6 locales
 """
 import os
@@ -169,7 +169,7 @@ class TestYoloCSS:
         assert "#f59e0b" in style_css
 
     def test_approval_skip_all_class(self, style_css):
-        assert ".approval-skip-all{" in style_css or ".approval-skip-all {" in style_css
+        assert ".approval-btn.yolo{" in style_css or ".approval-btn.yolo {" in style_css
 
 
 class TestYoloI18n:


### PR DESCRIPTION
## Thinking Path

Issue #467 requests a YOLO mode that lets users skip all approval prompts for the current session. The backend already had the plumbing (`enable_session_yolo`, `disable_session_yolo`, `is_session_yolo_enabled` in `tools/approval.py`) — this PR wires it up on the frontend with three entry points:

1. **`/yolo` slash command** — typed in the composer, toggles YOLO on/off for the active session
2. **"⚡ Skip all this session" button** — appears on every approval card, enables YOLO AND approves the current pending action
3. **YOLO pill indicator** — shows in the composer footer when YOLO is active, click to toggle off

### YOLO State Lifecycle

The state is session-scoped and **stored server-side in memory** (not in localStorage or sessionStorage):

| Scenario | Behavior |
|----------|----------|
| **Page reload** | ✅ State **persists** — the frontend re-fetches via `_fetchYoloState()` on session load |
| **Cross-tab** | ⚠️ State is **shared** — enabling YOLO in Tab A affects Tab B for the same session (both poll the same server-side flag) |
| **Server restart** | 🔄 State is **lost** — in-memory only, not persisted to disk |
| **Session switch** | ✅ State resets — `loadSession()` clears `_yoloEnabled` and fetches the new session state |
| **Cross-session** | ✅ Isolated — each session has its own YOLO flag |

This is intentional: the server-side approach avoids localStorage sync issues and ensures consistency across page reloads. The cross-tab sharing is an acceptable trade-off since YOLO is a per-session power-user feature that the user explicitly enables.

## What Changed

- **`api/routes.py`**: Added `POST /api/session/yolo` endpoint (toggle enable/disable with pending approval resolution) + `yolo_enabled` field in `GET /api/session/status`
- **`static/commands.js`**: Added `/yolo` command entry + `cmdYolo()` function
- **`static/index.html`**: Added skip-all button on approval card + YOLO pill in composer footer
- **`static/messages.js`**: Added YOLO state management (`_yoloEnabled`, `_fetchYoloState()`, `_updateYoloPill()`, `toggleYoloFromApproval()`) + state fetch after `startApprovalPolling` in sendMessage
- **`static/sessions.js`**: Added `_fetchYoloState()` calls at all `startApprovalPolling` call sites + reset on `loadSession()`
- **`static/style.css`**: Added `.yolo-pill` (amber pill) and `.approval-skip-all` (link-style) CSS
- **`static/i18n.js`**: Added 8 YOLO-related keys for all 6 locales (en, ru, es, de, zh-Hant, ko)
- **`tests/test_issue467_yolo_mode_toggle.py`**: 24 tests — endpoint GET/POST, slash command registration, HTML elements, CSS classes, i18n coverage

### i18n Duplicate Key Verification

All 8 YOLO-specific keys (`cmd_yolo`, `yolo_no_session`, `yolo_enabled`, `yolo_disabled`, `yolo_pill_label`, `yolo_pill_title_active`, `approval_skip_all`, `approval_skip_all_title`) are present **exactly once** in each of the 6 locales (en, ru, es, de, zh-Hant, ko). Verified via automated grep — no YOLO key duplicates exist.

Note: there are pre-existing duplicate keys in `ru` and `zh-Hant` locale blocks (e.g., `failed`, `http`, `https`, `settings_label_model`, etc.) that are **unrelated** to this PR. These pre-date this change and should be addressed in a separate cleanup PR.

Closes #467