### PR TITLE
fix(title): do not persist generic fallback titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 ## [Unreleased]
 
 ### Fixed
+- **Auto-title generic fallback** — when the auxiliary title-generation call
+  fails and the local fallback can only produce the generic label
+  `Conversation topic`, the WebUI now keeps the existing provisional title
+  instead of persisting the generic placeholder as a generated title. The
+  `title_status` diagnostic still preserves the underlying LLM failure reason.
+  (`api/streaming.py`, `tests/test_title_aux_routing.py`) Closes #1155.
 - **Recurring cron jobs with no next run need attention** — the Tasks panel now
   distinguishes anomalous recurring jobs (`enabled=false`, `state=completed`,
   `next_run_at=null`) from ordinary off jobs, shows a warning with recovery

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -703,6 +703,11 @@ def _fallback_title_from_exchange(user_text: str, assistant_text: str) -> Option
     return 'Conversation topic'
 
 
+def _is_generic_fallback_title(title: str) -> bool:
+    """Return True for low-information fallback labels that should not be persisted."""
+    return str(title or '').strip().lower() in {'conversation topic'}
+
+
 def _run_background_title_update(session_id: str, user_text: str, assistant_text: str, placeholder_title: str, put_event, agent=None):
     """Generate and publish a better title after `done`, then end the stream."""
     try:
@@ -737,10 +742,13 @@ def _run_background_title_update(session_id: str, user_text: str, assistant_text
                 next_title, llm_status, raw_preview = _generate_llm_session_title_for_agent(agent, user_text, assistant_text)
         source = llm_status
         if not next_title:
-            next_title = _fallback_title_from_exchange(user_text, assistant_text)
-            if next_title:
+            fallback_title = _fallback_title_from_exchange(user_text, assistant_text)
+            if fallback_title and not _is_generic_fallback_title(fallback_title):
                 logger.debug("Using local fallback for session title generation")
+                next_title = fallback_title
                 source = 'fallback'
+            elif fallback_title:
+                logger.debug("Skipping generic local fallback for session title generation: %r", fallback_title)
         fallback_reason = (
             f'local_summary:{llm_status}'
             if source == 'fallback' and llm_status

--- a/tests/test_title_aux_routing.py
+++ b/tests/test_title_aux_routing.py
@@ -269,6 +269,48 @@ class TestReasoningModelTitleGeneration(unittest.TestCase):
         self.assertEqual(title_status[0]['status'], 'fallback')
         self.assertEqual(title_status[0]['reason'], 'local_summary:llm_length_aux')
 
+    @patch('api.streaming._aux_title_configured', return_value=True)
+    @patch('api.streaming._generate_llm_session_title_via_aux')
+    @patch('api.streaming.get_session')
+    def test_generic_fallback_title_is_not_persisted(
+        self, mock_get_session, mock_aux_title, mock_configured,
+    ):
+        """A generic local fallback is worse than the provisional first-message title."""
+        from api.streaming import _run_background_title_update
+
+        provisional_title = '\u5e2e\u6211\u53bb\u627e\u4e00\u672c\u300a\u7ea2\u697c\u68a6\u300b\u7535\u5b50\u4e66'
+        first_user_text = provisional_title + '\u3002'
+        mock_session = MagicMock()
+        mock_session.title = provisional_title
+        mock_session.llm_title_generated = False
+        mock_session.messages = [
+            {'role': 'user', 'content': first_user_text},
+            {'role': 'assistant', 'content': ''},
+        ]
+        mock_get_session.return_value = mock_session
+        mock_aux_title.return_value = (None, 'llm_error_aux', '')
+        events = []
+
+        _run_background_title_update(
+            session_id='generic-title-session',
+            user_text=first_user_text,
+            assistant_text='',
+            placeholder_title=provisional_title,
+            put_event=lambda event_type, data: events.append((event_type, data)),
+            agent=None,
+        )
+
+        title_events = [data for event_type, data in events if event_type == 'title']
+        title_status = [data for event_type, data in events if event_type == 'title_status']
+        self.assertEqual(title_events, [])
+        self.assertTrue(title_status)
+        self.assertEqual(title_status[0]['status'], 'skipped')
+        self.assertEqual(title_status[0]['reason'], 'llm_error_aux')
+        self.assertEqual(title_status[0]['title'], provisional_title)
+        self.assertEqual(mock_session.title, provisional_title)
+        self.assertFalse(mock_session.llm_title_generated)
+        mock_session.save.assert_not_called()
+
 
 class TestAuxTitleTimeoutEdgeCases(unittest.TestCase):
     """Comment 4: _aux_title_timeout must reject zero, negative, and non-numeric values."""


### PR DESCRIPTION
## Summary

Fixes #1155.

When title generation falls back after an auxiliary LLM failure, the local fallback can produce the generic placeholder `Conversation topic`. Persisting that as the generated title is worse than keeping the existing provisional title because it adds no useful session-list signal.

This PR keeps the existing title when the local fallback is generic, while preserving the underlying `title_status` diagnostic reason such as `llm_error_aux`.

## Changes

- Adds a small generic-fallback guard for low-information local title labels.
- Skips persisting `Conversation topic` as `s.title`.
- Avoids setting `llm_title_generated = True` when no meaningful title was generated.
- Keeps the existing provisional title and emits `title_status: skipped` with the original LLM failure reason.
- Adds regression coverage for the non-Latin / low-confidence fallback path.

## Why this layer

The provider failure is still useful diagnostic information, but the fallback persistence decision lives in `api/streaming.py` where the title update is committed. This avoids changing provider routing, title SSE rendering, or session-list display behavior.

## Verification

- `python -m pytest tests/test_title_aux_routing.py tests/test_title_sanitization.py tests/test_1058_adaptive_title_refresh.py tests/test_issues_853_857.py -q`
- `python -m py_compile api/streaming.py`
- `git diff --check`
