### PR TITLE
Per-turn cost display on each assistant message bubble (#503)

### DIFF
--- a/static/messages.js
+++ b/static/messages.js
@@ -759,7 +759,26 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         if(reasoningText&&lastAsst&&!lastAsst.reasoning) lastAsst.reasoning=reasoningText;
         // Stamp _ts on the last assistant message if it has no timestamp
         if(lastAsst&&!lastAsst._ts&&!lastAsst.timestamp) lastAsst._ts=Date.now()/1000;
-        if(d.usage){S.lastUsage=d.usage;_syncCtxIndicator(d.usage);}
+        if(d.usage){
+          S.lastUsage=d.usage;_syncCtxIndicator(d.usage);
+          // #503 — compute per-turn cost delta and attach to last assistant message
+          if(lastAsst){
+            const prevIn=S.session.input_tokens||0;
+            const prevOut=S.session.output_tokens||0;
+            const prevCost=S.session.estimated_cost||0;
+            const curIn=d.usage.input_tokens||0;
+            const curOut=d.usage.output_tokens||0;
+            const curCost=d.usage.estimated_cost||0;
+            // Only set delta if values actually increased (skip no-op turns)
+            if(curIn>prevIn||curOut>prevOut){
+              lastAsst._turnUsage={
+                input_tokens:Math.max(0,curIn-prevIn),
+                output_tokens:Math.max(0,curOut-prevOut),
+                estimated_cost:Math.max(0,curCost-prevCost),
+              };
+            }
+          }
+        }
         if(d.session.tool_calls&&d.session.tool_calls.length){
           S.toolCalls=d.session.tool_calls.map(tc=>({...tc,done:true}));
         } else {

--- a/static/messages.js
+++ b/static/messages.js
@@ -1,3 +1,6 @@
+// #503 — per-turn usage delta
+function _attachTurnUsage(m,u){if(!m||!u)return;const pi=S.session.input_tokens||0,po=S.session.output_tokens||0,pc=S.session.estimated_cost||0,ci=u.input_tokens||0,co=u.output_tokens||0,cc=u.estimated_cost||0;if(ci>pi||co>po)m._turnUsage={input_tokens:Math.max(0,ci-pi),output_tokens:Math.max(0,co-po),estimated_cost:Math.max(0,cc-pc)};}
+
 function _markSessionViewed(sid, messageCount) {
   if(typeof _setSessionViewedCount!=='function' || !sid) return;
   const next = Number.isFinite(messageCount) ? Number(messageCount) : 0;
@@ -753,31 +756,12 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       }
       if(S.session&&S.session.session_id===activeSid){
         S.session=d.session;S.messages=d.session.messages||[];
-        // Find the last assistant message once for both reasoning persistence and timestamp
         const lastAsst=[...S.messages].reverse().find(m=>m.role==='assistant');
         // Persist reasoning trace so thinking card survives page reload
         if(reasoningText&&lastAsst&&!lastAsst.reasoning) lastAsst.reasoning=reasoningText;
-        // Stamp _ts on the last assistant message if it has no timestamp
         if(lastAsst&&!lastAsst._ts&&!lastAsst.timestamp) lastAsst._ts=Date.now()/1000;
         if(d.usage){
-          S.lastUsage=d.usage;_syncCtxIndicator(d.usage);
-          // #503 — compute per-turn cost delta and attach to last assistant message
-          if(lastAsst){
-            const prevIn=S.session.input_tokens||0;
-            const prevOut=S.session.output_tokens||0;
-            const prevCost=S.session.estimated_cost||0;
-            const curIn=d.usage.input_tokens||0;
-            const curOut=d.usage.output_tokens||0;
-            const curCost=d.usage.estimated_cost||0;
-            // Only set delta if values actually increased (skip no-op turns)
-            if(curIn>prevIn||curOut>prevOut){
-              lastAsst._turnUsage={
-                input_tokens:Math.max(0,curIn-prevIn),
-                output_tokens:Math.max(0,curOut-prevOut),
-                estimated_cost:Math.max(0,curCost-prevCost),
-              };
-            }
-          }
+          S.lastUsage=d.usage;_syncCtxIndicator(d.usage);_attachTurnUsage(lastAsst,d.usage);
         }
         if(d.session.tool_calls&&d.session.tool_calls.length){
           S.toolCalls=d.session.tool_calls.map(tc=>({...tc,done:true}));

--- a/static/ui.js
+++ b/static/ui.js
@@ -2507,26 +2507,31 @@ function renderMessages(){
       if(anchorRow&&lastInsertedNode) anchorInsertAfter.set(anchorRow, lastInsertedNode);
     }
   }
-  // Render cumulative usage on the last assistant footer row (if enabled).
-  if(window._showTokenUsage&&S.session&&(S.session.input_tokens||S.session.output_tokens)){
-    const rows=inner.querySelectorAll('.assistant-turn');
-    let lastAssist=null;
-    for(let i=rows.length-1;i>=0;i--){lastAssist=rows[i];break;}
-    if(lastAssist){
-      const footerRows=lastAssist.querySelectorAll('.msg-foot');
+  // Render per-turn token usage on each assistant message that has it (#503).
+  // Replaces the old cumulative-total-on-last-bubble approach.
+  if(window._showTokenUsage){
+    const asstRows=inner.querySelectorAll('.assistant-turn');
+    let ai=0; // assistant-only index for DOM rows
+    for(let mi=0;mi<S.messages.length;mi++){
+      const msg=S.messages[mi];
+      if(msg.role!=='assistant'){continue;}
+      if(!msg._turnUsage){ai++;continue;}
+      if(ai>=asstRows.length) continue;
+      const row=asstRows[ai];
+      const footerRows=row.querySelectorAll('.msg-foot');
       const targetFoot=footerRows.length?footerRows[footerRows.length-1]:null;
-      if(targetFoot&&!targetFoot.querySelector('.msg-usage-inline')){
-        const usage=document.createElement('span');
-        usage.className='msg-usage-inline';
-        const inTok=S.session.input_tokens||0;
-        const outTok=S.session.output_tokens||0;
-        const cost=S.session.estimated_cost;
-        let text=`${_fmtTokens(inTok)} in · ${_fmtTokens(outTok)} out`;
-        if(cost) text+=` · ~$${cost<0.01?cost.toFixed(4):cost.toFixed(2)}`;
-        usage.textContent=text;
-        targetFoot.classList.add('msg-foot-with-usage');
-        targetFoot.insertBefore(usage, targetFoot.firstChild);
-      }
+      if(!targetFoot||targetFoot.querySelector('.msg-usage-inline')){ai++;continue;}
+      const usage=document.createElement('span');
+      usage.className='msg-usage-inline';
+      const inTok=msg._turnUsage.input_tokens||0;
+      const outTok=msg._turnUsage.output_tokens||0;
+      const cost=msg._turnUsage.estimated_cost;
+      let text=`${_fmtTokens(inTok)} in · ${_fmtTokens(outTok)} out`;
+      if(cost) text+=` · ~$${cost<0.01?cost.toFixed(4):cost.toFixed(2)}`;
+      usage.textContent=text;
+      targetFoot.classList.add('msg-foot-with-usage');
+      targetFoot.insertBefore(usage, targetFoot.firstChild);
+      ai++;
     }
   }
   // Only force-scroll when not actively streaming — mid-stream re-renders


### PR DESCRIPTION
## Thinking Path

Issue #503 identifies that the cost/token display attached to the last assistant message shows cumulative session totals (`S.session.input_tokens`, `S.session.output_tokens`). This means the number attached to message 5 is the total cost of the entire conversation, not just that turn — which reads as misleading.

The fix: compute a per-turn delta from the cumulative usage delivered in the `done` SSE event, store it on the message object, and render it individually on each assistant bubble.

## What Changed

### `static/messages.js`
- At the `done` SSE event handler, when `d.usage` arrives (cumulative totals), compute the delta vs the previous session totals (`S.session.input_tokens` etc.)
- Store the delta as `_turnUsage` on the last assistant message: `{input_tokens, output_tokens, estimated_cost}`
- Only sets `_turnUsage` if values actually increased (skips no-op turns)

### `static/ui.js`
- Replaced the "cumulative usage on last assistant bubble" block with a per-turn loop
- Iterates over `S.messages`, finds assistant messages with `_turnUsage`, and renders inline usage on each one's footer
- Uses a separate `ai` counter to correctly map message indices to `.assistant-turn` DOM rows (since user messages don't create assistant-turn rows)
- The context ring / composer footer still shows cumulative totals via `_syncCtxIndicator()` — no information is lost

### Backwards compatibility
- Messages loaded from old sessions won't have `_turnUsage` — they simply won't show inline usage, which is correct (we don't have per-turn data for them)
- The `_showTokenUsage` setting still gates the feature

Closes #503