### PR TITLE
Add systemd user service launchers

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -115,6 +115,16 @@ Log file:
 - Server binds to 127.0.0.1:8787 (localhost only, not public internet)
 - Access from Mac: SSH tunnel: ssh -N -L 8787:127.0.0.1:8787 <user>@<your-server>
 - The server imports Hermes modules via sys.path.insert(0, parent_dir)
+- `start.sh` is a bootstrap entrypoint, not a service entrypoint. It execs
+  `bootstrap.py`, which launches `server.py` in a detached child session and
+  exits after health succeeds.
+- `systemd --user` should supervise the foreground server process directly via
+  `<repo>/scripts/run-systemd-user-service.sh` and
+  `<repo>/systemd/hermes-webui.service`.
+- A separate Hermes CLI dashboard unit is checked in at
+  `<repo>/systemd/hermes-dashboard.service`, using
+  `<repo>/scripts/run-hermes-dashboard-service.sh` to resolve `hermes`,
+  apply `--no-open`, and add `--insecure` automatically for non-loopback binds.
 
 Environment variables controlling behavior:
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,61 @@ Or keep using the shell launcher:
 ./start.sh
 ```
 
+For a long-running `systemd --user` service, do not point the unit at
+`start.sh`. `start.sh` runs `bootstrap.py`, and `bootstrap.py` intentionally
+spawns `server.py` into a separate background session before exiting. For
+systemd, use the checked-in foreground launcher instead. The checked-in unit
+expects this repo at `~/hermes-webui` by default and binds to `0.0.0.0`, so
+set `HERMES_WEBUI_PASSWORD` before exposing it beyond localhost:
+
+```bash
+chmod +x scripts/run-systemd-user-service.sh
+mkdir -p ~/.config/systemd/user
+cp systemd/hermes-webui.service ~/.config/systemd/user/
+systemctl --user daemon-reload
+systemctl --user enable --now hermes-webui.service
+```
+
+Useful follow-ups:
+
+```bash
+systemctl --user status hermes-webui.service
+journalctl --user -u hermes-webui.service -f
+curl http://127.0.0.1:8787/health
+```
+
+The service script sources `.env` from this repo automatically, so overrides
+like `HERMES_WEBUI_PORT`, `HERMES_WEBUI_HOST`, `HERMES_WEBUI_PASSWORD`,
+`HERMES_WEBUI_AGENT_DIR`, and `HERMES_WEBUI_PYTHON` continue to work.
+If this repo is cloned somewhere other than `~/hermes-webui`, edit the copied
+unit and set `HERMES_WEBUI_REPO` to the absolute repo path.
+
+If you also want the Hermes CLI dashboard under `systemd --user`, use the
+separate checked-in unit. Hermes requires `--insecure` for any non-localhost
+bind, so the wrapper adds that automatically when `HERMES_DASHBOARD_HOST` is
+not loopback. The dashboard unit also expects this repo at `~/hermes-webui`
+unless `HERMES_DASHBOARD_REPO` is changed in the copied unit:
+
+```bash
+chmod +x scripts/run-hermes-dashboard-service.sh
+mkdir -p ~/.config/systemd/user
+cp systemd/hermes-dashboard.service ~/.config/systemd/user/
+systemctl --user daemon-reload
+systemctl --user enable --now hermes-dashboard.service
+```
+
+Useful follow-ups:
+
+```bash
+systemctl --user status hermes-dashboard.service
+journalctl --user -u hermes-dashboard.service -f
+curl http://127.0.0.1:9119/
+```
+
+Supported overrides: `HERMES_DASHBOARD_BIN`, `HERMES_DASHBOARD_HOST`,
+`HERMES_DASHBOARD_PORT`, `HERMES_DASHBOARD_ALLOW_INSECURE`, and
+`HERMES_DASHBOARD_NODE_BIN`.
+
 The bootstrap will:
 
 1. Detect Hermes Agent and, if missing, attempt the official installer (`curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash`).
@@ -391,6 +446,9 @@ HERMES_WEBUI_PORT=8787 venv/bin/python /path/to/hermes-webui/server.py
 ```
 
 Note: use the agent venv Python (or any Python environment that has the Hermes agent dependencies installed). System Python will be missing `openai`, `httpx`, and other required packages.
+
+This direct foreground form is also what the `systemd/hermes-webui.service`
+unit uses, via `scripts/run-systemd-user-service.sh`.
 
 Health check:
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,6 +4,8 @@
 > Everything you can do from the CLI terminal, you can do from this UI.
 >
 > Last updated: v0.50.225 (April 26, 2026) — 2591 tests collected
+> Ops note: checked-in `systemd --user` units now cover both the Web UI server and the Hermes CLI dashboard launcher.
+> Local delta: enabling password from Settings keeps the current browser signed in; the former Assistant Reply Language enhancement has been removed; workspace panel closed-state now preloads in `<head>` so desktop first paint no longer flashes open before boot sync; thinking cards and tool call cards now animate both their carets and disclosure bodies smoothly on expand/collapse, and thinking cards now use the same bordered rounded panel chrome as tool cards with a gold palette.
 > Tests: 2107 collected (`pytest tests/ --collect-only -q`)
 > Source: <repo>/
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -7,6 +7,13 @@
 >
 > Prerequisites: SSH tunnel is active on port 8787. Open http://localhost:8787 in browser.
 > Server health check: curl http://127.0.0.1:8787/health should return {"status":"ok"}.
+> If started with `systemd --user`: `systemctl --user status hermes-webui.service`
+> and `journalctl --user -u hermes-webui.service -f` should show the server
+> running under `scripts/run-systemd-user-service.sh`.
+> If the Hermes CLI dashboard is also supervised by `systemd --user`, use
+> `systemctl --user status hermes-dashboard.service` and
+> `journalctl --user -u hermes-dashboard.service -f`, then verify
+> `curl http://127.0.0.1:9119/` responds.
 >
 > Automated coverage: 2591 tests collected via `pytest tests/ --collect-only -q`. Includes onboarding coverage for bootstrap/static wizard presence, real provider config persistence (`config.yaml` + `.env`), the `/api/onboarding/*` backend, the onboarding skip/existing-config guard, and CSS regression coverage for smooth thinking/tool card disclosure animation.
 > Run: `pytest tests/ -v --timeout=60`

--- a/scripts/run-hermes-dashboard-service.sh
+++ b/scripts/run-hermes-dashboard-service.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if [[ -f "${REPO_ROOT}/.env" ]]; then
+  set -a
+  # shellcheck source=/dev/null
+  source "${REPO_ROOT}/.env"
+  set +a
+fi
+
+if [[ -n "${HERMES_DASHBOARD_NODE_BIN:-}" ]]; then
+  export PATH="${HERMES_DASHBOARD_NODE_BIN}:${PATH}"
+elif [[ -x "${HOME}/.local/share/fnm/node-versions/v24.14.1/installation/bin/npm" ]]; then
+  export PATH="${HOME}/.local/share/fnm/node-versions/v24.14.1/installation/bin:${PATH}"
+fi
+
+resolve_hermes() {
+  local candidate
+
+  if [[ -n "${HERMES_DASHBOARD_BIN:-}" ]]; then
+    printf '%s\n' "${HERMES_DASHBOARD_BIN}"
+    return 0
+  fi
+
+  if command -v hermes >/dev/null 2>&1; then
+    command -v hermes
+    return 0
+  fi
+
+  for candidate in \
+    "${HOME}/.local/bin/hermes" \
+    "${HOME}/.hermes/hermes-agent/venv/bin/hermes"
+  do
+    if [[ -x "${candidate}" ]]; then
+      printf '%s\n' "${candidate}"
+      return 0
+    fi
+  done
+
+  echo "[XX] Could not find 'hermes' on PATH. Set HERMES_DASHBOARD_BIN." >&2
+  return 1
+}
+
+HERMES_BIN="$(resolve_hermes)"
+HOST="${HERMES_DASHBOARD_HOST:-0.0.0.0}"
+PORT="${HERMES_DASHBOARD_PORT:-9119}"
+ALLOW_INSECURE="${HERMES_DASHBOARD_ALLOW_INSECURE:-1}"
+
+args=(
+  dashboard
+  --no-open
+  --host "${HOST}"
+  --port "${PORT}"
+)
+
+case "${HOST}" in
+  127.0.0.1|localhost|::1)
+    ;;
+  *)
+    if [[ "${ALLOW_INSECURE}" != "1" ]]; then
+      echo "[XX] Refusing non-localhost bind without HERMES_DASHBOARD_ALLOW_INSECURE=1." >&2
+      exit 1
+    fi
+    args+=(--insecure)
+    ;;
+esac
+
+exec "${HERMES_BIN}" "${args[@]}"

--- a/scripts/run-systemd-user-service.sh
+++ b/scripts/run-systemd-user-service.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if [[ -f "${REPO_ROOT}/.env" ]]; then
+  set -a
+  # shellcheck source=/dev/null
+  source "${REPO_ROOT}/.env"
+  set +a
+fi
+
+find_agent_dir() {
+  local home_dir hermes_home candidate
+  home_dir="${HOME}"
+  hermes_home="${HERMES_HOME:-${home_dir}/.hermes}"
+
+  for candidate in \
+    "${HERMES_WEBUI_AGENT_DIR:-}" \
+    "${hermes_home}/hermes-agent" \
+    "${REPO_ROOT}/../hermes-agent" \
+    "${home_dir}/.hermes/hermes-agent" \
+    "${home_dir}/hermes-agent"
+  do
+    [[ -n "${candidate}" ]] || continue
+    if [[ -f "${candidate}/run_agent.py" ]]; then
+      printf '%s\n' "${candidate}"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+resolve_python() {
+  local candidate agent_dir
+
+  if [[ -n "${HERMES_WEBUI_PYTHON:-}" ]]; then
+    printf '%s\n' "${HERMES_WEBUI_PYTHON}"
+    return 0
+  fi
+
+  candidate="${REPO_ROOT}/.venv/bin/python"
+  if [[ -x "${candidate}" ]]; then
+    printf '%s\n' "${candidate}"
+    return 0
+  fi
+
+  if agent_dir="$(find_agent_dir)"; then
+    candidate="${agent_dir}/venv/bin/python"
+    if [[ -x "${candidate}" ]]; then
+      printf '%s\n' "${candidate}"
+      return 0
+    fi
+  fi
+
+  if command -v python3 >/dev/null 2>&1; then
+    command -v python3
+    return 0
+  fi
+
+  if command -v python >/dev/null 2>&1; then
+    command -v python
+    return 0
+  fi
+
+  echo "[XX] Could not find a Python interpreter for Hermes Web UI." >&2
+  return 1
+}
+
+PYTHON="$(resolve_python)"
+
+export HERMES_WEBUI_HOST="${HERMES_WEBUI_HOST:-0.0.0.0}"
+export HERMES_WEBUI_PORT="${HERMES_WEBUI_PORT:-8787}"
+export HERMES_WEBUI_STATE_DIR="${HERMES_WEBUI_STATE_DIR:-${HOME}/.hermes/webui-mvp}"
+
+cd "${REPO_ROOT}"
+exec "${PYTHON}" "${REPO_ROOT}/server.py"

--- a/systemd/hermes-dashboard.service
+++ b/systemd/hermes-dashboard.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Hermes Dashboard
+After=network.target
+
+[Service]
+Type=simple
+Environment=HERMES_DASHBOARD_REPO=%h/hermes-webui
+Environment=HERMES_DASHBOARD_HOST=0.0.0.0
+ExecStart=/usr/bin/env bash -lc 'cd "$HERMES_DASHBOARD_REPO" && exec ./scripts/run-hermes-dashboard-service.sh'
+Restart=on-failure
+RestartSec=3
+
+[Install]
+WantedBy=default.target

--- a/systemd/hermes-webui.service
+++ b/systemd/hermes-webui.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Hermes Web UI
+After=default.target
+
+[Service]
+Type=simple
+Environment=HERMES_WEBUI_REPO=%h/hermes-webui
+Environment=HERMES_WEBUI_HOST=0.0.0.0
+ExecStart=/usr/bin/env bash -lc 'cd "$HERMES_WEBUI_REPO" && exec ./scripts/run-systemd-user-service.sh'
+Restart=on-failure
+RestartSec=3
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
Adds systemd --user service support for running the Web UI and Hermes CLI dashboard as foreground supervised processes.\n\nIncluded changes:\n- Add foreground launcher scripts for the Web UI and dashboard\n- Add user service unit examples with repo path overrides\n- Document systemd setup, status checks, and dashboard verification\n- Note the foreground server architecture in docs\n\nValidation:\n- git diff --check