### PR TITLE
fix: load custom models for known providers from config

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -1452,7 +1452,7 @@ def get_available_models() -> dict:
         _cfg_providers = cfg.get("providers", {})
         if isinstance(_cfg_providers, dict):
             for _pid_key in _cfg_providers:
-                if _pid_key in _PROVIDER_MODELS:
+                if _pid_key in _PROVIDER_MODELS or _pid_key in cfg.get("providers", {}):
                     detected_providers.add(_pid_key)
 
         # 4. Fetch models from custom endpoint if base_url is configured
@@ -1678,7 +1678,7 @@ def get_available_models() -> dict:
                             }
                         )
                 elif pid in _PROVIDER_MODELS or pid in cfg.get("providers", {}):
-                    raw_models = _PROVIDER_MODELS.get(pid, [])
+                    raw_models = copy.deepcopy(_PROVIDER_MODELS.get(pid, []))
 
                     provider_cfg = cfg.get("providers", {}).get(pid, {})
                     if isinstance(provider_cfg, dict) and "models" in provider_cfg:


### PR DESCRIPTION
## Description
The WebUI currently ignores custom models defined in `config.yaml` when using a known provider (e.g., `openai`). 

## Problem
In `api/config.py`, when resolving available models:
1. It loops over the configured providers but checks `if _pid_key in _PROVIDER_MODELS`, skipping known providers that have custom configurations.
2. Even if the config branch is hit, `raw_models` accesses `_PROVIDER_MODELS.get(pid, [])` directly by reference. This causes subsequent model updates to modify the global default models dictionary, leading to unexpected behavior and duplication in the WebUI selector.

## Solution
1. Updated the discovery loop to also include providers found in `cfg.get('providers', {})`.
2. Wrapped the default model array in `copy.deepcopy()` when extracting from `_PROVIDER_MODELS` to prevent mutation of the global dictionary when custom models are appended.

This allows users to configure custom models for standard providers like `openai` via their `config.yaml` and correctly see them in the WebUI.

Tested locally and confirmed the UI properly merges standard + custom OpenAI models.