### PR TITLE
Fix sidebar session rename first Enter revert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 ## [Unreleased]
 
 ### Fixed
+- **Sidebar session rename first Enter** — double-click inline rename now keeps
+  the session-list render guard active until `/api/session/rename` finishes, so
+  the first Enter cannot be overwritten by a stale refresh. Duplicate completion
+  paths are ignored, cache/active titles update after success, and failures
+  restore state with an error message. (`static/sessions.js`,
+  `tests/test_session_rename_lifecycle.py`) [#1153]
 - **Recurring cron jobs with no next run need attention** — the Tasks panel now
   distinguishes anomalous recurring jobs (`enabled=false`, `state=completed`,
   `next_run_at=null`) from ordinary off jobs, shows a warning with recovery

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -970,25 +970,49 @@ function renderSessionListFromCache(){
     const startRename=()=>{
       closeSessionActionMenu();
       _renamingSid = s.session_id;
+      const oldTitle=s.title||'Untitled';
       const inp=document.createElement('input');
       inp.className='session-title-input';
-      inp.value=s.title||'Untitled';
+      inp.value=oldTitle;
       ['click','mousedown','dblclick','pointerdown'].forEach(ev=>
         inp.addEventListener(ev, e2=>e2.stopPropagation())
       );
+      const applyTitle=(nextTitle, updateDom=true)=>{
+        if(updateDom) title.textContent=nextTitle;
+        s.title=nextTitle;
+        const cached=_allSessions.find(item=>item&&item.session_id===s.session_id);
+        if(cached) cached.title=nextTitle;
+        if(S.session&&S.session.session_id===s.session_id){S.session.title=nextTitle;syncTopbar();}
+      };
+      let finishDone=false;
       const finish=async(save)=>{
-        _renamingSid = null;
-        if(save){
-          const newTitle=inp.value.trim()||'Untitled';
-          title.textContent=newTitle;
-          s.title=newTitle;
-          if(S.session&&S.session.session_id===s.session_id){S.session.title=newTitle;syncTopbar();}
-          try{await api('/api/session/rename',{method:'POST',body:JSON.stringify({session_id:s.session_id,title:newTitle})});}
-          catch(err){setStatus('Rename failed: '+err.message);}
+        if(finishDone) return;
+        finishDone=true;
+        const releaseRename=()=>{
+          _renamingSid = null;
+          if(inp.isConnected) inp.replaceWith(title);
+          // Allow list re-renders again after DOM cleanup has completed.
+          setTimeout(()=>{ if(_renamingSid===null) renderSessionListFromCache(); },50);
+        };
+        if(!save){
+          applyTitle(oldTitle,false);
+          releaseRename();
+          return;
         }
-        inp.replaceWith(title);
-        // Allow list re-renders again after a short delay
-        setTimeout(()=>{ if(_renamingSid===null) renderSessionListFromCache(); },50);
+        const newTitle=inp.value.trim()||'Untitled';
+        try{
+          if(newTitle!==oldTitle){
+            await api('/api/session/rename',{method:'POST',body:JSON.stringify({session_id:s.session_id,title:newTitle})});
+          }
+          applyTitle(newTitle);
+        }catch(err){
+          applyTitle(oldTitle,false);
+          const msg='Rename failed: '+(err&&err.message?err.message:String(err));
+          setStatus(msg);
+          if(typeof showToast==='function') showToast(msg,3000,'error');
+        }finally{
+          releaseRename();
+        }
       };
       inp.onkeydown=e2=>{
         if(e2.key==='Enter'){

--- a/tests/test_session_rename_lifecycle.py
+++ b/tests/test_session_rename_lifecycle.py
@@ -1,0 +1,77 @@
+"""Structural regressions for sidebar session inline rename (#1153).
+
+The first Enter after double-click rename could appear to revert because the
+frontend cleared `_renamingSid` before `/api/session/rename` completed. That
+let normal session-list refreshes re-render stale cached data and destroy the
+input while the save was still in flight.
+"""
+
+import pathlib
+
+
+REPO = pathlib.Path(__file__).parent.parent
+SESSIONS_JS = (REPO / "static" / "sessions.js").read_text(encoding="utf-8")
+
+
+def _session_rename_block():
+    start = SESSIONS_JS.find("const startRename=()=>{")
+    assert start >= 0, "session inline rename startRename() block not found"
+    end = SESSIONS_JS.find("// (Project dot is appended above", start)
+    assert end > start, "session inline rename block end marker not found"
+    return SESSIONS_JS[start:end]
+
+
+def test_session_rename_finish_is_idempotent():
+    block = _session_rename_block()
+    assert "let finishDone=false;" in block, (
+        "session rename finish() must track completion so Enter, blur, Escape, "
+        "and delayed pointer paths cannot complete twice"
+    )
+    guard_pos = block.find("if(finishDone) return;")
+    set_pos = block.find("finishDone=true;")
+    assert guard_pos >= 0 and set_pos > guard_pos, (
+        "session rename finish() must return early after the first completion"
+    )
+
+
+def test_session_rename_guard_releases_after_save_path_completes():
+    block = _session_rename_block()
+    assert block.count("_renamingSid = null;") == 1, (
+        "_renamingSid must be cleared from one release helper only, not at the "
+        "top of finish() before the async rename save settles"
+    )
+    release_pos = block.find("const releaseRename=()=>{")
+    clear_pos = block.find("_renamingSid = null;")
+    assert release_pos >= 0 and clear_pos > release_pos, (
+        "_renamingSid should be cleared inside releaseRename(), after the "
+        "selected finish path has completed"
+    )
+    api_pos = block.find("await api('/api/session/rename'")
+    finally_pos = block.find("finally{")
+    release_call_pos = block.find("releaseRename();", finally_pos)
+    assert api_pos >= 0 and finally_pos > api_pos and release_call_pos > finally_pos, (
+        "save path must await /api/session/rename before releaseRename() clears "
+        "the render guard"
+    )
+
+
+def test_session_rename_success_updates_cache_and_active_session_title():
+    block = _session_rename_block()
+    assert "_allSessions.find(item=>item&&item.session_id===s.session_id)" in block
+    assert "if(cached) cached.title=nextTitle;" in block
+    assert "S.session.title=nextTitle;syncTopbar();" in block, (
+        "successful session rename must keep cached and active titles coherent"
+    )
+
+
+def test_session_rename_failure_restores_state_and_surfaces_error():
+    block = _session_rename_block()
+    catch_pos = block.find("}catch(err){")
+    assert catch_pos >= 0, "session rename save path must handle API failures"
+    catch_block = block[catch_pos:block.find("}finally{", catch_pos)]
+    assert "applyTitle(oldTitle,false);" in catch_block, (
+        "failed session rename must restore the cached/active title instead of "
+        "silently appearing successful"
+    )
+    assert "setStatus(msg);" in catch_block
+    assert "showToast(msg,3000,'error')" in catch_block


### PR DESCRIPTION
## Summary

Fixes #1153.

This PR makes sidebar inline session rename keep its render guard active until the save/cancel/failure path is complete. The first `Enter` commit can no longer be overwritten by a stale session-list refresh while `/api/session/rename` is still in flight.

## What changed

- Keeps `_renamingSid` active until rename completion cleanup runs.
- Makes the rename `finish()` path idempotent so `Enter`, `blur`, `Escape`, and delayed pointer paths cannot complete twice.
- Updates cached and active session titles only after a successful rename response.
- Restores the old title and surfaces an error if `/api/session/rename` fails.
- Adds focused structural regression coverage for the rename lifecycle.

## Regression coverage

The new regression checks lock the old failure mode at the frontend layer:

- the rename guard is released only from the completion helper
- the save path awaits `/api/session/rename` before releasing the guard
- success keeps cached and active session titles coherent
- failure restores title state and reports the error
- existing IME composition Enter behavior remains covered

## Verification

- `python -m pytest tests/test_ime_composition.py tests/test_session_rename_lifecycle.py -q`
- `node --check static/sessions.js`
- `git diff --check`
