### PR TITLE
fix(renderer): preserve raw <pre> blocks during markdown rewrites (v0.50.228)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -357,6 +357,14 @@
   workspace subtree) and never enumerate blocked system roots. (`api/routes.py`,
   `api/workspace.py`, `static/panels.js`, `static/style.css`) (partial for #616)
 
+## [v0.50.228] — 2026-04-27
+
+### Fixed
+- **Raw `<pre>` blocks preserved in markdown renderer** — the inline `<code>` rewrite
+  pass in `renderMd()` no longer processes content inside raw `<pre>` blocks, preventing
+  multiline code blocks passed as HTML from being degraded to backtick-wrapped strings.
+  (`static/ui.js`, `tests/test_renderer_js_behaviour.py`) (#1150)
+
 ## [v0.50.227] — 2026-04-27
 
 ### Fixed

--- a/static/ui.js
+++ b/static/ui.js
@@ -813,15 +813,15 @@ function renderMd(raw){
   // Stash raw <pre> blocks so the inline <code> rewrite below does not run
   // inside them. Running that rewrite in <pre> content can introduce stray
   // backticks for multiline code and break subsequent code-box rendering.
-  const raw_pre_stash=[];
-  s=s.replace(/(<pre\b[^>]*>[\s\S]*?<\/pre>)/gi,m=>{raw_pre_stash.push(m);return `\x00R${raw_pre_stash.length-1}\x00`;});
+  const rawPreStash=[];
+  s=s.replace(/(<pre\b[^>]*>[\s\S]*?<\/pre>)/gi,m=>{rawPreStash.push(m);return `\x00R${rawPreStash.length-1}\x00`;});
   s=s.replace(/<strong>([\s\S]*?)<\/strong>/gi,(_,t)=>'**'+t+'**');
   s=s.replace(/<b>([\s\S]*?)<\/b>/gi,(_,t)=>'**'+t+'**');
   s=s.replace(/<em>([\s\S]*?)<\/em>/gi,(_,t)=>'*'+t+'*');
   s=s.replace(/<i>([\s\S]*?)<\/i>/gi,(_,t)=>'*'+t+'*');
   s=s.replace(/<code>([^<]*?)<\/code>/gi,(_,t)=>'`'+t+'`');
   s=s.replace(/<br\s*\/?>/gi,'\n');
-  s=s.replace(/\x00R(\d+)\x00/g,(_,i)=>raw_pre_stash[+i]);
+  s=s.replace(/\x00R(\d+)\x00/g,(_,i)=>rawPreStash[+i]);
   // Restore stashed code blocks
   s=s.replace(/\x00F(\d+)\x00/g,(_,i)=>fence_stash[+i]);
   // Mermaid blocks: render as diagram containers (processed after DOM insertion)

--- a/static/ui.js
+++ b/static/ui.js
@@ -810,12 +810,18 @@ function renderMd(raw){
   s=s.replace(/\\\\\((.+?)\\\\\)/g,(_,m)=>{math_stash.push({type:'inline',src:m});return '\x00M'+(math_stash.length-1)+'\x00';});
   s=s.replace(/\\\\\[(.+?)\\\\\]/gs,(_,m)=>{math_stash.push({type:'display',src:m});return '\x00M'+(math_stash.length-1)+'\x00';});
   // Safe tag → markdown equivalent (these produce the same output as **text** etc.)
+  // Stash raw <pre> blocks so the inline <code> rewrite below does not run
+  // inside them. Running that rewrite in <pre> content can introduce stray
+  // backticks for multiline code and break subsequent code-box rendering.
+  const raw_pre_stash=[];
+  s=s.replace(/(<pre\b[^>]*>[\s\S]*?<\/pre>)/gi,m=>{raw_pre_stash.push(m);return `\x00R${raw_pre_stash.length-1}\x00`;});
   s=s.replace(/<strong>([\s\S]*?)<\/strong>/gi,(_,t)=>'**'+t+'**');
   s=s.replace(/<b>([\s\S]*?)<\/b>/gi,(_,t)=>'**'+t+'**');
   s=s.replace(/<em>([\s\S]*?)<\/em>/gi,(_,t)=>'*'+t+'*');
   s=s.replace(/<i>([\s\S]*?)<\/i>/gi,(_,t)=>'*'+t+'*');
   s=s.replace(/<code>([^<]*?)<\/code>/gi,(_,t)=>'`'+t+'`');
   s=s.replace(/<br\s*\/?>/gi,'\n');
+  s=s.replace(/\x00R(\d+)\x00/g,(_,i)=>raw_pre_stash[+i]);
   // Restore stashed code blocks
   s=s.replace(/\x00F(\d+)\x00/g,(_,i)=>fence_stash[+i]);
   // Mermaid blocks: render as diagram containers (processed after DOM insertion)

--- a/tests/test_renderer_js_behaviour.py
+++ b/tests/test_renderer_js_behaviour.py
@@ -461,3 +461,30 @@ class TestBlockquoteEntityEncodedInput:
             f"Entity-encoded blockquote with fenced code must render: {out!r}"
         )
         assert "<pre>" in out, f"Fenced code inside entity-encoded blockquote must render: {out!r}"
+
+
+class TestRawPreCodePreservation:
+    """Raw <pre><code> HTML from model output should remain structurally intact."""
+
+    def test_multiline_pre_code_blocks_do_not_degrade_to_backticks(self, driver_path):
+        src = (
+            "<pre><code>line 1\n"
+            "line 2\n"
+            "</code></pre>\n\n"
+            "After paragraph.\n\n"
+            "<pre><code>line 3\n"
+            "line 4\n"
+            "</code></pre>\n\n"
+            "Done."
+        )
+        out = _render(driver_path, src)
+        assert out.count("<pre>") == 2 and out.count("</pre>") == 2, (
+            f"Expected two balanced <pre> blocks, got: {out!r}"
+        )
+        assert out.count("<code>") == 2 and out.count("</code>") == 2, (
+            f"Expected two balanced <code> blocks, got: {out!r}"
+        )
+        assert "`line 1" not in out and "line 2\n`</pre>" not in out, (
+            f"<code> content inside <pre> must not be rewritten to backticks: {out!r}"
+        )
+        assert "After paragraph." in out and "Done." in out


### PR DESCRIPTION
> **Attribution:** Original work by @bsgdigital (PR #1150). Integrated here.

## What this fixes

`renderMd()` in `static/ui.js` processes raw HTML from model output through a series of rewrites. One pass converts `<code>text</code>` to `` `text` `` (markdown inline code). That pass was running inside raw `<pre>` blocks, so multiline `<pre><code>` blocks from the model got their content rewritten to backtick strings — producing broken output like:

```
`line 1
line 2
`</pre>
```

## How it's fixed

6 lines: stash all `<pre>...</pre>` blocks behind `\x00R{n}\x00` tokens before the inline-code rewrite, restore them after. The token uses `\x00R` — no collision with existing `\x00F` (fence stash) or `\x00M` (math stash) tokens.

The regex `(<pre\b[^>]*>[\s\S]*?<\/pre>)` is non-greedy and case-insensitive, handles `<pre class="...">` variants correctly.

**Tests:** 1 new test class (`TestRawPreCodePreservation`) with 1 test covering the exact regression. Full suite: **2635 passing**.
