### PR TITLE
fix(ui): defer live-model-fetch race that silently overwrites session model

### DIFF
--- a/static/ui.js
+++ b/static/ui.js
@@ -165,6 +165,10 @@ async function populateModelDropdown(){
 
 // Cache so we don't re-fetch on every page load
 const _liveModelCache={};
+// Tracks providers for which a live-model fetch is in flight.
+// Used by syncTopbar() to defer model corrections until the fetch completes,
+// preventing premature fallback to the first static model (#1169).
+const _liveModelFetchPending=new Set();
 
 function _addLiveModelsToSelect(provider, models, sel){
   if(!provider||!models||!models.length||!sel) return 0;
@@ -215,6 +219,14 @@ function _addLiveModelsToSelect(provider, models, sel){
     added++;
   }
   if(added>0 && currentVal) _applyModelToDropdown(currentVal, sel);
+  // After live models are added, re-apply the session's model in case it was
+  // absent from the static list and syncTopbar() fired before the live fetch
+  // completed (#1169). This ensures the session model wins over any premature
+  // fallback that may have set sel.value to the first available option.
+  if(S.session && S.session.model && sel.id==='modelSelect'){
+    const reapplied=_applyModelToDropdown(S.session.model, sel);
+    if(reapplied && typeof syncModelChip==='function') syncModelChip();
+  }
   return added;
 }
 
@@ -226,6 +238,7 @@ async function _fetchLiveModels(provider, sel){
     if(added>0 && typeof syncModelChip==='function') syncModelChip();
     return;
   }
+  _liveModelFetchPending.add(provider);
   try{
     const url=new URL('api/models/live',location.href);
     url.searchParams.set('provider',provider);
@@ -241,6 +254,8 @@ async function _fetchLiveModels(provider, sel){
     }
   }catch(e){
     console.debug('[hermes] Live model fetch failed for',provider,e.message);
+  }finally{
+    _liveModelFetchPending.delete(provider);
   }
 }
 
@@ -1832,21 +1847,30 @@ function syncTopbar(){
     // first available model so stale values don't pollute the picker (#829).
     if(!applied && currentModel){
       const deferModelCorrection=Boolean(S.session._modelResolutionDeferred);
-      // Stale session model not in the current provider catalog — reset to the
-      // first available model rather than injecting an "(unavailable)" option
-      // that visually appears under the wrong provider group (#829).
-      const modelSel=$('modelSelect');
-      const first=modelSel&&modelSel.querySelector('optgroup > option, option');
-      if(first){
-        modelSel.value=first.value;
-        if(!deferModelCorrection){
-          S.session.model=first.value;
-          // Persist the correction so the session doesn't re-inject on next load.
-          fetch(new URL('api/session/update',location.href).href,{
-            method:'POST',credentials:'include',
-            headers:{'Content-Type':'application/json'},
-            body:JSON.stringify({session_id:S.session.id||S.session.session_id,model:first.value})
-          }).catch(()=>{});
+      // Also defer if a live model fetch is still in flight — the model may be
+      // in the list once the fetch completes. Persisting now would corrupt the
+      // session with the wrong model before live models arrive (#1169).
+      const liveStillPending=window._activeProvider&&_liveModelFetchPending.has(window._activeProvider);
+      if(liveStillPending){
+        // Live fetch in flight — don't touch sel.value or S.session.model yet.
+        // _addLiveModelsToSelect() will re-apply S.session.model once done (#1169).
+      } else {
+        // Stale session model not in the current provider catalog — reset to the
+        // first available model rather than injecting an "(unavailable)" option
+        // that visually appears under the wrong provider group (#829).
+        const modelSel=$('modelSelect');
+        const first=modelSel&&modelSel.querySelector('optgroup > option, option');
+        if(first){
+          modelSel.value=first.value;
+          if(!deferModelCorrection){
+            S.session.model=first.value;
+            // Persist the correction so the session doesn't re-inject on next load.
+            fetch(new URL('api/session/update',location.href).href,{
+              method:'POST',credentials:'include',
+              headers:{'Content-Type':'application/json'},
+              body:JSON.stringify({session_id:S.session.id||S.session.session_id,model:first.value})
+            }).catch(()=>{});
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary

Fixes a race condition where loading any session with a Nous-routed (or other live-only) model silently overwrites the session's model on disk with the first static model in the dropdown — typically `@nous:anthropic/claude-opus-4.6`. Reported with Kimi K2.6 (`moonshotai/kimi-k2`) but affects any model not present in the static 4-item list.

## Root cause

The bug is a timing race between two async operations:

1. `_resolveSessionModelForDisplaySoon()` schedules a `setTimeout(..., 0)` that clears `_modelResolutionDeferred` and calls `syncTopbar()`.
2. `syncTopbar()` calls `_applyModelToDropdown(sessionModel, sel)`. If the model is absent from the dropdown **and** `_modelResolutionDeferred` is already `false`, it immediately sets `sel.value = first.value` (e.g. Opus 4.6) and persists that wrong model via `POST /api/session/update`.
3. `_fetchLiveModels()` runs in parallel — it takes 100–500ms to fetch the live model list from the provider API. By the time it completes and adds Kimi to the dropdown, the session model on disk has already been corrupted.

The existing `_modelResolutionDeferred` flag was designed to protect against this, but it only defers until `GET /api/session?resolve_model=1` returns — it doesn't account for the live model fetch still being in flight.

## Fix

Two changes:

1. **`_liveModelFetchPending` set** — tracks which providers have a live fetch in flight. `_fetchLiveModels()` adds the provider to the set before the fetch and removes it in a `finally` block. When `syncTopbar()` detects a model is missing, it checks this set: if the active provider's fetch is pending, the fallback logic is skipped entirely (no `sel.value` override, no disk write).

2. **Re-apply in `_addLiveModelsToSelect()`** — after inserting newly fetched models, re-apply `S.session.model` if it is now resolvable. This ensures the correct model is applied even if `syncTopbar()` already ran and briefly showed the wrong model in the chip.

## Testing

- All 2634 tests pass.
- Manual: configure a Nous profile with `model.default: moonshotai/kimi-k2` → load any session → model chip shows Kimi throughout; no incorrect model persisted.

Closes #1169
