### PR TITLE
fix(ui): tool card output truncated at 220 chars and cannot scroll

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1233,12 +1233,12 @@ body.resizing{user-select:none;cursor:col-resize;}
 .tool-card-toggle{font-size:10px;color:var(--muted);opacity:.5;flex-shrink:0;display:inline-flex;align-items:center;justify-content:center;transform-origin:center;transition:transform .18s ease;will-change:transform;}
 .tool-card.open .tool-card-toggle{transform:rotate(90deg);}
 .tool-card-detail{display:block;max-height:0;opacity:0;overflow:hidden;border-top:1px solid transparent;padding:0 12px;transition:max-height .22s ease,opacity .18s ease,padding .22s ease,border-top-color .22s ease;}
-.tool-card.open .tool-card-detail{max-height:520px;opacity:1;padding:8px 12px;border-top-color:rgba(255,255,255,.06);}
+.tool-card.open .tool-card-detail{max-height:600px;opacity:1;padding:8px 12px;border-top-color:rgba(255,255,255,.06);overflow:auto;}
 .tool-card-args{margin-bottom:6px;}
 .tool-card-args div{font-size:11px;line-height:1.6;}
 .tool-arg-key{color:var(--blue);font-family:'SF Mono',ui-monospace,monospace;font-size:11px;}
 .tool-arg-val{color:var(--muted);font-family:'SF Mono',ui-monospace,monospace;font-size:11px;word-break:break-all;}
-.tool-card-result pre{font-size:11px;color:var(--muted);font-family:'SF Mono',ui-monospace,monospace;white-space:pre-wrap;word-break:break-word;max-height:180px;overflow-y:auto;margin:0;line-height:1.55;}
+.tool-card-result pre{font-size:11px;color:var(--muted);font-family:'SF Mono',ui-monospace,monospace;white-space:pre-wrap;word-break:break-word;max-height:360px;overflow-y:auto;margin:0;line-height:1.55;}
 
 /* ── Manual compression cards (transient transcript-local feedback) ── */
 .live-compression-cards{

--- a/static/ui.js
+++ b/static/ui.js
@@ -2614,9 +2614,9 @@ function buildToolCard(tc){
   let displaySnippet='';
   if(tc.snippet){
     const s=tc.snippet;
-    if(s.length<=220){displaySnippet=s;}
+    if(s.length<=800){displaySnippet=s;}
     else{
-      const cutoff=s.slice(0,220);
+      const cutoff=s.slice(0,800);
       const lastBreak=Math.max(cutoff.lastIndexOf('. '),cutoff.lastIndexOf('\n'),cutoff.lastIndexOf('; '));
       displaySnippet=lastBreak>80?s.slice(0,lastBreak+1):cutoff;
     }

--- a/tests/test_ui_card_animation.py
+++ b/tests/test_ui_card_animation.py
@@ -16,7 +16,12 @@ def test_tool_card_toggle_uses_transformable_layout_and_transition():
 def test_tool_card_detail_uses_transitionable_collapsed_state():
     assert ".tool-card-detail{display:block;max-height:0;opacity:0;overflow:hidden;" in COMPACT_CSS
     assert re.search(
-        r"\.tool-card\.open\s+\.tool-card-detail\s*\{[^}]*max-height:\s*520px;[^}]*opacity:\s*1;",
+        r"\.tool-card\.open\s+\.tool-card-detail\s*\{[^}]*max-height:\s*600px;[^}]*opacity:\s*1;",
+        STYLE_CSS,
+    )
+    # Open state must set overflow to auto so the inner <pre> scroll is not clipped (#1170).
+    assert re.search(
+        r"\.tool-card\.open\s+\.tool-card-detail\s*\{[^}]*overflow:\s*auto;",
         STYLE_CSS,
     )
 


### PR DESCRIPTION
## Summary

Fixes two issues with tool card output readability.

### Issue A: 220-char JS truncation was too aggressive

Tool call results were cut off at 220 characters — often in the middle of a stack trace, file path, or JSON value. Raised the threshold to 800 characters so most realistic tool outputs display in full without needing to click "Show more".

### Issue B: `overflow:hidden` on the parent blocked inner scroll

`.tool-card-detail` had `overflow:hidden` in both closed and open states. This is correct for the CSS `max-height` collapse animation (closed state), but in the open state it clips all children — including the `<pre>` inside `.tool-card-result`, which had `overflow-y:auto` but could never actually render a scrollbar.

Fix: add `overflow:auto` to `.tool-card.open .tool-card-detail`. The hidden state is preserved for the collapse animation; only the open state gains a scroll container.

Also raised:
- Inner `<pre>` max-height: `180px → 360px` (~20 lines, enough for most tool outputs without scrolling)
- Outer card cap: `520px → 600px`

## Testing

- All 2634 tests pass (test for CSS animation state updated to match new heights and assert `overflow:auto` on open state).
- Manual: expand a tool card with a long `read_file` or `terminal` result → content is scrollable.

Closes #1170
