### PR TITLE
feat: agent-API gateway + CLI rename + full-width chat + status indicators (v0.50.229)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -357,6 +357,30 @@
   workspace subtree) and never enumerate blocked system roots. (`api/routes.py`,
   `api/workspace.py`, `static/panels.js`, `static/style.css`) (partial for #616)
 
+## [v0.50.229] — 2026-04-27
+
+### Added
+- **Agent-API gateway integration** — a new `gateway_provider.py` module allows the
+  WebUI to route completions through a locally-running hermes-agent gateway. Models are
+  identified by the `@gateway-{label}:{model}/{keyword}` convention. The gateway
+  model picker refreshes on dropdown open and streams status via SSE.
+  (`api/gateway_provider.py`, `api/config.py`, `api/routes.py`, `api/streaming.py`)
+
+### Fixed
+- **Sidebar rename for CLI/gateway sessions** — renaming a session imported from
+  `state.db` (agent/gateway source) now routes through `state_sync.rename_cli_session`
+  so the rename persists to both the WebUI JSON and the agent's SQLite store.
+  (`api/routes.py`, `api/state_sync.py`, `static/sessions.js`) (#1134)
+- **Model picker freshness on dropdown open** — the model list is re-fetched from the
+  gateway each time the dropdown opens, preventing stale model entries after provider
+  changes. (`static/sessions.js`)
+- **Full-width chat output container** — removes the historical 1100/1200px max-width
+  caps on the message column so it expands with the viewport.
+  (`static/ui.js`, `static/style.css`)
+- **Sidebar status indicators** — CLI busy dot, per-session accent colour, and gateway
+  connection dot are shown on session items when the agent is active.
+  (`static/sessions.js`, `static/style.css`, `static/index.html`)
+
 ## [v0.50.227] — 2026-04-27
 
 ### Fixed

--- a/api/agent_sessions.py
+++ b/api/agent_sessions.py
@@ -88,8 +88,7 @@ def _project_agent_session_rows(rows: list[dict]) -> list[dict]:
             continue
 
         merged = dict(row)
-        # Keep the chain head's visible identity (title, started_at), but
-        # point the row at the latest importable segment for navigation AND
+        # Point the row at the latest importable segment for navigation AND
         # surface the tip's recency so an actively-used chain bubbles to the
         # top of the sidebar by its true last activity. Without overriding
         # last_activity, a long-lived chain whose tip is being edited NOW
@@ -102,6 +101,10 @@ def _project_agent_session_rows(rows: list[dict]) -> list[dict]:
         ):
             if key in tip:
                 merged[key] = tip[key]
+        # Keep the chain head's visible identity (title, started_at).
+        # Renames flow to the lineage *root* via state_sync.rename_cli_session
+        # (it walks parent_session_id up the chain and updates the head),
+        # so head-prefer keeps working AND survives hard refresh.
         if not merged.get('title'):
             merged['title'] = tip.get('title')
         if not merged.get('source'):

--- a/api/config.py
+++ b/api/config.py
@@ -1243,6 +1243,41 @@ def _get_label_for_model(model_id: str, existing_groups: list) -> str:
     )
 
 
+def _is_gateway_group(grp: dict) -> bool:
+    """Recognise a gateway-provider group regardless of legacy naming.
+    Gateway provider ids/labels start with ``gateway`` (e.g. ``gateway-prod``)
+    or ``gw`` (legacy short form). Used to filter cached groups before
+    re-appending the fresh list from agent-api-gateway."""
+    if not isinstance(grp, dict):
+        return False
+    pid = (grp.get("provider") or grp.get("id") or "").lower()
+    return pid.startswith("gateway") or pid.startswith("gw-") or pid == "gw"
+
+
+def _attach_fresh_gateway_groups(result: dict) -> dict:
+    """Strip cached gateway groups from ``result`` and re-append fresh ones.
+
+    ``get_available_models()`` caches the heavy provider/credential discovery
+    for 24 h, but the gateway model list must reflect console-side changes
+    within seconds. We therefore keep gateway discovery OUTSIDE the cache
+    and re-attach it on every call. ``get_gateway_model_groups`` itself
+    has a short TTL (~30 s, see ``api.gateway_provider``) so this stays
+    cheap.
+
+    Always returns a deep copy of ``result`` with its ``groups`` rewritten;
+    callers must NOT mutate the returned dict back into the cache.
+    """
+    out = copy.deepcopy(result) if result else {"groups": []}
+    base_groups = [g for g in out.get("groups", []) if not _is_gateway_group(g)]
+    try:
+        from api.gateway_provider import get_gateway_model_groups
+        fresh = list(get_gateway_model_groups() or [])
+    except Exception:
+        fresh = []  # gateway unavailable — never crash the model picker
+    out["groups"] = base_groups + fresh
+    return out
+
+
 def get_available_models() -> dict:
     """
     Return available models grouped by provider.
@@ -1746,15 +1781,11 @@ def get_available_models() -> dict:
                         }
                     )
 
-        # Append gateway provider groups (agent-api-gateway integration).
-        # Kept inside the cold-path builder so the result is cached normally;
-        # if discovery is slow, the next request hits the cache instead of
-        # repeating the HTTP probe.
-        try:
-            from api.gateway_provider import get_gateway_model_groups
-            groups.extend(get_gateway_model_groups())
-        except Exception:
-            pass  # gateway module missing or discovery failed — never crash
+        # NOTE: gateway provider groups intentionally NOT appended here.
+        # They are appended OUTSIDE the cache (see _attach_fresh_gateway_groups)
+        # so console-side changes to the gateway propagate within seconds —
+        # otherwise a fresh model added to the gateway would be invisible
+        # to the WebUI for up to ``_AVAILABLE_MODELS_CACHE_TTL`` (24 h).
 
         return {
             "active_provider": active_provider,
@@ -1792,7 +1823,7 @@ def get_available_models() -> dict:
                 timeout=60
             )
             if _available_models_cache is not None and (time.monotonic() - _available_models_cache_ts) < _AVAILABLE_MODELS_CACHE_TTL:
-                return copy.deepcopy(_available_models_cache)
+                return _attach_fresh_gateway_groups(_available_models_cache)
 
         # Reload config if changed
         if _cfg_changed:
@@ -1803,14 +1834,14 @@ def get_available_models() -> dict:
         # Serve from memory cache if fresh
         now = time.monotonic()
         if _available_models_cache is not None and (now - _available_models_cache_ts) < _AVAILABLE_MODELS_CACHE_TTL:
-            return copy.deepcopy(_available_models_cache)
+            return _attach_fresh_gateway_groups(_available_models_cache)
 
         # Cold path: disk cache hit — use it (fast, no lock contention)
         if disk_groups is not None:
             _available_models_cache = disk_groups
             _available_models_cache_ts = now
             _save_models_cache_to_disk(disk_groups)
-            return copy.deepcopy(disk_groups)
+            return _attach_fresh_gateway_groups(disk_groups)
 
         # Cold path: full rebuild — only one thread reaches here at a time
         with _cache_build_cv:
@@ -1829,7 +1860,7 @@ def get_available_models() -> dict:
             _cache_build_in_progress = False
             _cache_build_cv.notify_all()
         _save_models_cache_to_disk(result)
-        return copy.deepcopy(result)
+        return _attach_fresh_gateway_groups(result)
 
 
 # ── Static file path ─────────────────────────────────────────────────────────

--- a/api/config.py
+++ b/api/config.py
@@ -1736,6 +1736,16 @@ def get_available_models() -> dict:
                         }
                     )
 
+        # Append gateway provider groups (agent-api-gateway integration).
+        # Kept inside the cold-path builder so the result is cached normally;
+        # if discovery is slow, the next request hits the cache instead of
+        # repeating the HTTP probe.
+        try:
+            from api.gateway_provider import get_gateway_model_groups
+            groups.extend(get_gateway_model_groups())
+        except Exception:
+            pass  # gateway module missing or discovery failed — never crash
+
         return {
             "active_provider": active_provider,
             "default_model": default_model,

--- a/api/config.py
+++ b/api/config.py
@@ -843,6 +843,16 @@ def resolve_model_provider(model_id: str) -> tuple:
 
     Returns (model, provider, base_url) where provider and base_url may be None.
     """
+    # Gateway models (@gateway-*:model/keyword) are handled by the gateway module
+    try:
+        from api.gateway_provider import is_gateway_model, resolve_gateway_model
+        if is_gateway_model(model_id or ""):
+            resolved = resolve_gateway_model(model_id)
+            if resolved:
+                return resolved["model"], resolved["provider"], resolved["base_url"]
+    except Exception:
+        pass  # gateway module missing — fall through to normal resolution
+
     config_provider = None
     config_base_url = None
     model_cfg = cfg.get("model", {})

--- a/api/config.py
+++ b/api/config.py
@@ -1814,6 +1814,7 @@ def get_available_models() -> dict:
     if _available_models_cache is None:
         disk_groups = _load_models_cache_from_disk()
 
+    _base_result = None  # resolved inside lock; gateway HTTP call happens outside
     with _available_models_cache_lock:
         # If another thread is already building, wait for its result instead
         # of re-entering the cold path (avoids duplicate 10s zai load_pool calls).
@@ -1823,44 +1824,51 @@ def get_available_models() -> dict:
                 timeout=60
             )
             if _available_models_cache is not None and (time.monotonic() - _available_models_cache_ts) < _AVAILABLE_MODELS_CACHE_TTL:
-                return _attach_fresh_gateway_groups(_available_models_cache)
+                _base_result = _available_models_cache
 
-        # Reload config if changed
-        if _cfg_changed:
-            reload_config()
-            _available_models_cache = None
-            _available_models_cache_ts = 0.0
+        if _base_result is None:
+            # Reload config if changed
+            if _cfg_changed:
+                reload_config()
+                _available_models_cache = None
+                _available_models_cache_ts = 0.0
 
-        # Serve from memory cache if fresh
-        now = time.monotonic()
-        if _available_models_cache is not None and (now - _available_models_cache_ts) < _AVAILABLE_MODELS_CACHE_TTL:
-            return _attach_fresh_gateway_groups(_available_models_cache)
+            # Serve from memory cache if fresh
+            now = time.monotonic()
+            if _available_models_cache is not None and (now - _available_models_cache_ts) < _AVAILABLE_MODELS_CACHE_TTL:
+                _base_result = _available_models_cache
 
-        # Cold path: disk cache hit — use it (fast, no lock contention)
-        if disk_groups is not None:
-            _available_models_cache = disk_groups
-            _available_models_cache_ts = now
-            _save_models_cache_to_disk(disk_groups)
-            return _attach_fresh_gateway_groups(disk_groups)
+        if _base_result is None:
+            # Cold path: disk cache hit — use it (fast, no lock contention)
+            if disk_groups is not None:
+                _available_models_cache = disk_groups
+                _available_models_cache_ts = now if 'now' in dir() else time.monotonic()
+                _save_models_cache_to_disk(disk_groups)
+                _base_result = disk_groups
 
-        # Cold path: full rebuild — only one thread reaches here at a time
-        with _cache_build_cv:
-            _cache_build_in_progress = True
-        try:
-            result = _build_available_models_uncached()
-        except Exception:
-            # Always reset the flag so waiting threads don't block for 60s
+        if _base_result is None:
+            # Cold path: full rebuild — only one thread reaches here at a time
             with _cache_build_cv:
+                _cache_build_in_progress = True
+            try:
+                result = _build_available_models_uncached()
+            except Exception:
+                # Always reset the flag so waiting threads don't block for 60s
+                with _cache_build_cv:
+                    _cache_build_in_progress = False
+                    _cache_build_cv.notify_all()
+                raise
+            with _cache_build_cv:
+                _available_models_cache = result
+                _available_models_cache_ts = time.monotonic()
                 _cache_build_in_progress = False
                 _cache_build_cv.notify_all()
-            raise
-        with _cache_build_cv:
-            _available_models_cache = result
-            _available_models_cache_ts = time.monotonic()
-            _cache_build_in_progress = False
-            _cache_build_cv.notify_all()
-        _save_models_cache_to_disk(result)
-        return _attach_fresh_gateway_groups(result)
+            _save_models_cache_to_disk(result)
+            _base_result = result
+
+    # _attach_fresh_gateway_groups runs OUTSIDE the cache lock to avoid
+    # holding the lock during HTTP calls to gateway instances (up to 5s each).
+    return _attach_fresh_gateway_groups(_base_result)
 
 
 # ── Static file path ─────────────────────────────────────────────────────────

--- a/api/gateway_provider.py
+++ b/api/gateway_provider.py
@@ -290,16 +290,11 @@ def resolve_gateway_model(model_id: str) -> Optional[Dict[str, str]]:
             cli_route = inst.get("cli", "cursor")
             break
 
-    # Embed keyword in URL path so no extra HTTP headers are needed.
-    # This avoids issues with AIAgent's codex_responses mode for GPT-5+ models
-    # rejecting extra_headers in request_overrides.
-    base_url = f"{gateway_url}/{cli_route}/v1/k/{keyword}"
+    base_url = f"{gateway_url}/{cli_route}/v1"
 
     # Use a prefixed model name (e.g. "gw:gpt-5.4") to prevent the AI agent
     # from auto-switching to the Responses API for GPT-5+ models.  The gateway
-    # proxies everything as chat completions regardless of the underlying model.
-    # The "gw:" prefix ensures _model_requires_responses_api("gw:gpt-5.4")
-    # returns False (doesn't start with "gpt-5").
+    # strips the "gw:" prefix and matches the real model name strictly.
     safe_model = f"gw:{model_name}"
 
     return {
@@ -307,5 +302,7 @@ def resolve_gateway_model(model_id: str) -> Optional[Dict[str, str]]:
         "provider": "openai",
         "base_url": base_url,
         "api_key": "agent-gateway-no-key-required",
-        "extra_headers": {},
+        "extra_headers": {
+            "x-instance-keyword": keyword,
+        },
     }

--- a/api/gateway_provider.py
+++ b/api/gateway_provider.py
@@ -306,3 +306,26 @@ def resolve_gateway_model(model_id: str) -> Optional[Dict[str, str]]:
             "x-instance-keyword": keyword,
         },
     }
+
+
+def get_gateway_instance_statuses() -> List[Dict[str, str]]:
+    """Return status of all gateway instances across all configured gateways.
+
+    Each entry: {label, keyword, model, cli, status}.
+    """
+    results: List[Dict[str, str]] = []
+    for cfg in _load_gateway_configs():
+        label = cfg.get("label", "local")
+        url = cfg.get("url", "")
+        if not url:
+            continue
+        instances = discover_instances(url, force_refresh=False)
+        for inst in instances:
+            results.append({
+                "label": label,
+                "keyword": inst.get("keyword", ""),
+                "model": inst.get("model", ""),
+                "cli": inst.get("cli", ""),
+                "status": inst.get("status", "unknown"),
+            })
+    return results

--- a/api/gateway_provider.py
+++ b/api/gateway_provider.py
@@ -1,0 +1,303 @@
+"""
+Hermes Web UI -- Agent API Gateway provider integration.
+
+Discovers AI model instances from agent-api-gateway and integrates them
+into hermes-webui's model dropdown and routing system.
+
+This module is self-contained and communicates with the gateway exclusively
+via its HTTP admin API. No gateway source code is imported.
+
+Gateway model IDs use the format: @gateway-{label}:{model_name}/{keyword}
+This fits hermes-webui's existing @provider:model convention.
+
+Usage in config.yaml:
+    gateway_providers:
+      - label: local
+        url: http://localhost:3000
+      - label: remote
+        url: http://10.1.73.240:3000
+
+Environment variable overrides:
+    AGENT_GATEWAY_LOCAL_URL  — overrides the first gateway entry
+    AGENT_GATEWAY_REMOTE_URL — overrides the second gateway entry
+"""
+
+import logging
+import os
+import threading
+import time
+from typing import Any, Dict, List, Optional, Tuple
+from urllib.parse import urljoin
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Types
+# ---------------------------------------------------------------------------
+
+GatewayInstance = Dict[str, Any]
+
+# ---------------------------------------------------------------------------
+# Discovery cache (thread-safe, TTL-based)
+# ---------------------------------------------------------------------------
+
+_CACHE_LOCK = threading.Lock()
+_CACHE: Dict[str, Tuple[float, List[GatewayInstance]]] = {}
+DEFAULT_CACHE_TTL_S = 30
+
+
+def _cache_key(url: str) -> str:
+    return url.rstrip("/")
+
+
+def _read_cache(url: str, max_age_s: float = DEFAULT_CACHE_TTL_S) -> Optional[List[GatewayInstance]]:
+    key = _cache_key(url)
+    with _CACHE_LOCK:
+        entry = _CACHE.get(key)
+        if entry is None:
+            return None
+        fetched_at, instances = entry
+        if time.time() - fetched_at > max_age_s:
+            return None
+        return instances
+
+
+def _write_cache(url: str, instances: List[GatewayInstance]) -> None:
+    key = _cache_key(url)
+    with _CACHE_LOCK:
+        _CACHE[key] = (time.time(), instances)
+
+
+def clear_cache(url: Optional[str] = None) -> None:
+    """Clear discovery cache. If url is None, clears all entries."""
+    with _CACHE_LOCK:
+        if url is None:
+            _CACHE.clear()
+        else:
+            _CACHE.pop(_cache_key(url), None)
+
+
+# ---------------------------------------------------------------------------
+# HTTP discovery
+# ---------------------------------------------------------------------------
+
+def _fetch_instances(gateway_url: str, timeout_s: float = 5.0) -> List[GatewayInstance]:
+    """Fetch active instances from a gateway's admin API."""
+    import urllib.request
+    import urllib.error
+    import json as _json
+
+    admin_url = gateway_url.rstrip("/") + "/admin/instances"
+    req = urllib.request.Request(admin_url, headers={"Accept": "application/json"})
+    try:
+        with urllib.request.urlopen(req, timeout=timeout_s) as resp:
+            data = _json.loads(resp.read().decode("utf-8"))
+            if not isinstance(data, list):
+                return []
+            return data
+    except (urllib.error.URLError, OSError, ValueError) as exc:
+        logger.debug("gateway discovery failed for %s: %s", admin_url, exc)
+        return []
+
+
+def _filter_active(instances: List[GatewayInstance]) -> List[GatewayInstance]:
+    return [i for i in instances if i.get("status") in ("ready", "busy")]
+
+
+def discover_instances(
+    gateway_url: str,
+    *,
+    max_age_s: float = DEFAULT_CACHE_TTL_S,
+    force_refresh: bool = False,
+) -> List[GatewayInstance]:
+    """Return active gateway instances, using cache when possible."""
+    if not force_refresh:
+        cached = _read_cache(gateway_url, max_age_s)
+        if cached is not None:
+            return cached
+
+    raw = _fetch_instances(gateway_url)
+    active = _filter_active(raw)
+
+    if active:
+        _write_cache(gateway_url, active)
+        return active
+
+    # Fall back to last-known-good snapshot
+    stale = _read_cache(gateway_url, max_age_s=float("inf"))
+    return stale or active
+
+
+# ---------------------------------------------------------------------------
+# Model ID encoding / decoding
+# ---------------------------------------------------------------------------
+
+GATEWAY_PROVIDER_PREFIX = "gateway-"
+
+
+def build_model_id(label: str, model_name: str, keyword: str) -> str:
+    """Build a hermes-webui model ID: @gateway-{label}:{model_name}/{keyword}"""
+    return f"@{GATEWAY_PROVIDER_PREFIX}{label}:{model_name}/{keyword}"
+
+
+def parse_model_id(model_id: str) -> Optional[Dict[str, str]]:
+    """Parse a gateway model ID. Returns None if not a gateway model.
+
+    Returns dict with keys: label, model_name, keyword, provider_id
+    """
+    if not model_id.startswith("@" + GATEWAY_PROVIDER_PREFIX):
+        return None
+
+    # Strip leading @
+    rest = model_id[1:]
+    if ":" not in rest:
+        return None
+
+    provider_id, model_part = rest.split(":", 1)
+    label = provider_id[len(GATEWAY_PROVIDER_PREFIX):]
+
+    if "/" in model_part:
+        model_name, keyword = model_part.split("/", 1)
+    else:
+        model_name = model_part
+        keyword = ""
+
+    return {
+        "label": label,
+        "model_name": model_name,
+        "keyword": keyword,
+        "provider_id": provider_id,
+    }
+
+
+def is_gateway_model(model_id: str) -> bool:
+    return parse_model_id(model_id) is not None
+
+
+# ---------------------------------------------------------------------------
+# Config loading
+# ---------------------------------------------------------------------------
+
+def _load_gateway_configs() -> List[Dict[str, str]]:
+    """Load gateway provider configs from hermes config and env vars.
+
+    Returns list of dicts: [{"label": "local", "url": "http://..."}]
+    """
+    configs: List[Dict[str, str]] = []
+
+    # Try to read from hermes config.yaml
+    try:
+        from api.config import cfg
+        gw_list = cfg.get("gateway_providers", [])
+        if isinstance(gw_list, list):
+            for entry in gw_list:
+                if isinstance(entry, dict) and entry.get("url"):
+                    configs.append({
+                        "label": str(entry.get("label", f"gw{len(configs)}")),
+                        "url": str(entry["url"]).rstrip("/"),
+                    })
+    except Exception:
+        pass
+
+    # Env var overrides / additions
+    env_local = os.getenv("AGENT_GATEWAY_LOCAL_URL", "").strip()
+    env_remote = os.getenv("AGENT_GATEWAY_REMOTE_URL", "").strip()
+
+    if env_local:
+        if configs:
+            configs[0]["url"] = env_local
+        else:
+            configs.append({"label": "local", "url": env_local})
+
+    if env_remote:
+        if len(configs) > 1:
+            configs[1]["url"] = env_remote
+        else:
+            configs.append({"label": "remote", "url": env_remote})
+
+    return configs
+
+
+# ---------------------------------------------------------------------------
+# Public API for hermes-webui integration
+# ---------------------------------------------------------------------------
+
+def get_gateway_model_groups() -> List[Dict[str, Any]]:
+    """Return model groups for the hermes-webui dropdown.
+
+    Each group: {"provider": "gateway-local", "models": [{"id": ..., "label": ...}]}
+    """
+    configs = _load_gateway_configs()
+    groups = []
+
+    for gw in configs:
+        label = gw["label"]
+        url = gw["url"]
+        instances = discover_instances(url)
+
+        if not instances:
+            continue
+
+        models = []
+        for inst in instances:
+            model_name = inst.get("model", "unknown")
+            keyword = inst.get("keyword", "default")
+            cli = inst.get("cli", "cursor").upper()
+            mid = build_model_id(label, model_name, keyword)
+            display = f"{model_name} [{cli}:{keyword}]"
+            models.append({"id": mid, "label": display})
+
+        if models:
+            groups.append({
+                "provider": f"{GATEWAY_PROVIDER_PREFIX}{label}",
+                "models": models,
+            })
+
+    return groups
+
+
+def resolve_gateway_model(model_id: str) -> Optional[Dict[str, str]]:
+    """Resolve a gateway model ID to routing parameters.
+
+    Returns dict with: model, provider, base_url, api_key, headers
+    Or None if not a gateway model.
+    """
+    parsed = parse_model_id(model_id)
+    if parsed is None:
+        return None
+
+    label = parsed["label"]
+    model_name = parsed["model_name"]
+    keyword = parsed["keyword"]
+
+    # Find the gateway URL for this label
+    configs = _load_gateway_configs()
+    gateway_url = None
+    for gw in configs:
+        if gw["label"] == label:
+            gateway_url = gw["url"]
+            break
+
+    if not gateway_url:
+        logger.warning("no gateway config found for label=%s", label)
+        return None
+
+    # Look up the instance to determine CLI route
+    instances = discover_instances(gateway_url)
+    cli_route = "cursor"
+    for inst in instances:
+        if inst.get("model") == model_name and inst.get("keyword") == keyword:
+            cli_route = inst.get("cli", "cursor")
+            break
+
+    base_url = f"{gateway_url}/{cli_route}/v1"
+
+    return {
+        "model": model_name,
+        "provider": "openai",
+        "base_url": base_url,
+        "api_key": "agent-gateway-no-key-required",
+        "extra_headers": {
+            "x-instance-keyword": keyword,
+        },
+    }

--- a/api/gateway_provider.py
+++ b/api/gateway_provider.py
@@ -86,7 +86,11 @@ def _fetch_instances(gateway_url: str, timeout_s: float = 5.0) -> List[GatewayIn
     import urllib.request
     import urllib.error
     import json as _json
+    from urllib.parse import urlparse as _urlparse
 
+    if _urlparse(gateway_url).scheme not in ("http", "https"):
+        logger.debug("gateway_provider: rejecting non-http(s) URL: %s", gateway_url)
+        return []
     admin_url = gateway_url.rstrip("/") + "/admin/instances"
     req = urllib.request.Request(admin_url, headers={"Accept": "application/json"})
     try:
@@ -145,6 +149,8 @@ def parse_model_id(model_id: str) -> Optional[Dict[str, str]]:
 
     Returns dict with keys: label, model_name, keyword, provider_id
     """
+    if not model_id:
+        return None
     if not model_id.startswith("@" + GATEWAY_PROVIDER_PREFIX):
         return None
 

--- a/api/gateway_provider.py
+++ b/api/gateway_provider.py
@@ -290,14 +290,22 @@ def resolve_gateway_model(model_id: str) -> Optional[Dict[str, str]]:
             cli_route = inst.get("cli", "cursor")
             break
 
-    base_url = f"{gateway_url}/{cli_route}/v1"
+    # Embed keyword in URL path so no extra HTTP headers are needed.
+    # This avoids issues with AIAgent's codex_responses mode for GPT-5+ models
+    # rejecting extra_headers in request_overrides.
+    base_url = f"{gateway_url}/{cli_route}/v1/k/{keyword}"
+
+    # Use a prefixed model name (e.g. "gw:gpt-5.4") to prevent the AI agent
+    # from auto-switching to the Responses API for GPT-5+ models.  The gateway
+    # proxies everything as chat completions regardless of the underlying model.
+    # The "gw:" prefix ensures _model_requires_responses_api("gw:gpt-5.4")
+    # returns False (doesn't start with "gpt-5").
+    safe_model = f"gw:{model_name}"
 
     return {
-        "model": model_name,
+        "model": safe_model,
         "provider": "openai",
         "base_url": base_url,
         "api_key": "agent-gateway-no-key-required",
-        "extra_headers": {
-            "x-instance-keyword": keyword,
-        },
+        "extra_headers": {},
     }

--- a/api/routes.py
+++ b/api/routes.py
@@ -1231,13 +1231,47 @@ def handle_post(handler, parsed) -> bool:
             require(body, "session_id", "title")
         except ValueError as e:
             return bad(handler, str(e))
+        new_title = str(body["title"]).strip()[:80] or "Untitled"
+        sid = body["session_id"]
         try:
-            s = get_session(body["session_id"])
+            s = get_session(sid)
         except KeyError:
-            return bad(handler, "Session not found", 404)
+            # Not a WebUI-owned session — try CLI/agent sessions in state.db.
+            # This keeps double-click rename in the sidebar working uniformly
+            # across WebUI sessions and CLI/gateway sessions.
+            try:
+                from api.state_sync import rename_cli_session
+            except Exception:
+                return bad(handler, "Session not found", 404)
+            try:
+                ok = rename_cli_session(sid, new_title)
+            except ValueError as e:
+                # Title uniqueness conflict from SessionDB.set_session_title
+                return bad(handler, str(e), 409)
+            if not ok:
+                return bad(handler, "Session not found", 404)
+            return j(handler, {"session": {
+                "session_id": sid,
+                "title": new_title,
+                "is_cli_session": True,
+            }})
         with _get_session_agent_lock(body["session_id"]):
-            s.title = str(body["title"]).strip()[:80] or "Untitled"
+            s.title = new_title
             s.save()
+        # Mirror to state.db so /insights and CLI sidebar listings stay in sync
+        try:
+            from api.state_sync import sync_session_usage
+            sync_session_usage(
+                session_id=sid,
+                input_tokens=int(getattr(s, "input_tokens", 0) or 0),
+                output_tokens=int(getattr(s, "output_tokens", 0) or 0),
+                estimated_cost=getattr(s, "estimated_cost", None),
+                model=getattr(s, "model", None),
+                title=new_title,
+                message_count=len(s.messages),
+            )
+        except Exception:
+            pass  # state.db sync is best-effort
         return j(handler, {"session": s.compact()})
 
     if parsed.path == "/api/personality/set":

--- a/api/routes.py
+++ b/api/routes.py
@@ -725,6 +725,13 @@ def handle_get(handler, parsed) -> bool:
     if parsed.path == "/api/models":
         return j(handler, get_available_models())
 
+    if parsed.path == "/api/gateway-status":
+        try:
+            from api.gateway_provider import get_gateway_instance_statuses
+            return j(handler, get_gateway_instance_statuses())
+        except Exception:
+            return j(handler, [])
+
     if parsed.path == "/api/models/live":
         return _handle_live_models(handler, parsed)
 

--- a/api/state_sync.py
+++ b/api/state_sync.py
@@ -116,3 +116,73 @@ def sync_session_usage(session_id: str, input_tokens: int=0, output_tokens: int=
             db.close()
         except Exception:
             logger.debug("Failed to close state.db")
+
+
+def rename_cli_session(session_id: str, title: str) -> bool:
+    """Rename a CLI / agent / gateway-imported session in state.db.
+
+    Used by /api/session/rename when the session is not owned by the WebUI
+    (no JSON file in SESSION_DIR). Returns True if the row existed and was
+    updated, False if the session_id was not found, or raises ValueError
+    on title-uniqueness conflicts (mirrors SessionDB.set_session_title).
+
+    Implementation note: we try SessionDB.set_session_title first because it
+    enforces title sanitization and uniqueness. If SessionDB cannot be opened
+    (e.g. the on-disk state.db schema doesn't match the installed
+    hermes_state version), we fall back to a defensive raw SQL UPDATE so the
+    WebUI rename feature still works in degraded environments.
+    """
+    # Resolve the state.db path the same way _get_state_db does
+    try:
+        from api.profiles import get_active_hermes_home
+        hermes_home = Path(get_active_hermes_home()).expanduser().resolve()
+    except Exception:
+        hermes_home = Path(os.getenv('HERMES_HOME', str(Path.home() / '.hermes')))
+    db_path = hermes_home / 'state.db'
+    if not db_path.exists():
+        return False
+
+    # Path 1: preferred — go through SessionDB so sanitization / uniqueness apply.
+    db = _get_state_db()
+    if db is not None:
+        try:
+            return bool(db.set_session_title(session_id, title))
+        except ValueError:
+            raise
+        except Exception:
+            pass  # fall through to the raw-SQL fallback
+        finally:
+            try:
+                db.close()
+            except Exception:
+                pass
+
+    # Path 2: defensive raw SQL fallback — used when SessionDB schema migration
+    # fails (e.g. older state.db missing columns that the installed hermes_state
+    # version expects).  Cap title length the same way the WebUI does.
+    import sqlite3
+    safe_title = (title or "").strip()[:80] or "Untitled"
+    try:
+        conn = sqlite3.connect(str(db_path), timeout=5)
+        try:
+            # Uniqueness check (mirrors SessionDB.set_session_title behaviour)
+            conflict = conn.execute(
+                "SELECT id FROM sessions WHERE title = ? AND id != ?",
+                (safe_title, session_id),
+            ).fetchone()
+            if conflict:
+                raise ValueError(
+                    f"Title {safe_title!r} is already in use by session {conflict[0]}"
+                )
+            cursor = conn.execute(
+                "UPDATE sessions SET title = ? WHERE id = ?",
+                (safe_title, session_id),
+            )
+            conn.commit()
+            return cursor.rowcount > 0
+        finally:
+            conn.close()
+    except ValueError:
+        raise
+    except Exception:
+        return False

--- a/api/state_sync.py
+++ b/api/state_sync.py
@@ -118,6 +118,61 @@ def sync_session_usage(session_id: str, input_tokens: int=0, output_tokens: int=
             logger.debug("Failed to close state.db")
 
 
+def _sanitize_title(title: str) -> str:
+    """Mirror SessionDB.set_session_title sanitization and the WebUI cap."""
+    return (title or "").strip()[:80] or "Untitled"
+
+
+def _resolve_lineage_root(db_path: Path, session_id: str) -> str:
+    """Walk parent_session_id upward to find the lineage root.
+
+    Renames target the chain head so the projection (which prefers the
+    head's title) shows the new name. Stops at the first row whose
+    ``parent_session_id`` is NULL or unknown, or when the parent's
+    ``end_reason`` isn't ``compression`` (only compression chains are
+    considered the same logical conversation). Returns ``session_id``
+    unchanged on any error.
+    """
+    import sqlite3
+    try:
+        conn = sqlite3.connect(str(db_path), timeout=5)
+    except Exception:
+        return session_id
+    try:
+        cur = conn.execute("PRAGMA table_info(sessions)")
+        cols = {row[1] for row in cur.fetchall()}
+        if 'parent_session_id' not in cols:
+            return session_id
+        current = session_id
+        seen = {current}
+        for _ in range(64):
+            row = conn.execute(
+                "SELECT parent_session_id, end_reason FROM sessions WHERE id = ?",
+                (current,),
+            ).fetchone()
+            if not row:
+                return current
+            parent_id = row[0]
+            if not parent_id or parent_id in seen:
+                return current
+            parent_row = conn.execute(
+                "SELECT end_reason FROM sessions WHERE id = ?",
+                (parent_id,),
+            ).fetchone()
+            if not parent_row or parent_row[0] != 'compression':
+                return current
+            current = parent_id
+            seen.add(current)
+        return current
+    except Exception:
+        return session_id
+    finally:
+        try:
+            conn.close()
+        except Exception:
+            pass
+
+
 def rename_cli_session(session_id: str, title: str) -> bool:
     """Rename a CLI / agent / gateway-imported session in state.db.
 
@@ -126,11 +181,18 @@ def rename_cli_session(session_id: str, title: str) -> bool:
     updated, False if the session_id was not found, or raises ValueError
     on title-uniqueness conflicts (mirrors SessionDB.set_session_title).
 
-    Implementation note: we try SessionDB.set_session_title first because it
-    enforces title sanitization and uniqueness. If SessionDB cannot be opened
-    (e.g. the on-disk state.db schema doesn't match the installed
-    hermes_state version), we fall back to a defensive raw SQL UPDATE so the
-    WebUI rename feature still works in degraded environments.
+    Note on compression chains
+    --------------------------
+    The sidebar projection (``api.agent_sessions._project_agent_session_rows``)
+    collapses a compression chain into a single row that uses the *tip*'s
+    session_id for navigation but the chain *head*'s title for visible
+    identity. So the rename must hit the head — otherwise the new name
+    would never appear after a hard refresh. We walk ``parent_session_id``
+    upward from the supplied id (only across compression boundaries) and
+    update the lineage root. Updating just one row keeps us compatible
+    with ``hermes_state``'s ``UNIQUE INDEX … ON sessions(title) WHERE
+    title IS NOT NULL`` — the auto-generated ``#N`` titles on the
+    intermediate / tip rows stay distinct.
     """
     # Resolve the state.db path the same way _get_state_db does
     try:
@@ -142,47 +204,53 @@ def rename_cli_session(session_id: str, title: str) -> bool:
     if not db_path.exists():
         return False
 
-    # Path 1: preferred — go through SessionDB so sanitization / uniqueness apply.
-    db = _get_state_db()
-    if db is not None:
+    safe_title = _sanitize_title(title)
+
+    # Walk to the lineage root so the projection (head-prefer title)
+    # surfaces the new name on the next refresh.
+    target_id = _resolve_lineage_root(db_path, session_id)
+
+    # Path 1: hand the canonical update to SessionDB so it can do its
+    # own bookkeeping (event emission, cache invalidation, uniqueness
+    # validation, etc.) when the agent's hermes_state package is installed.
+    sdb = _get_state_db()
+    if sdb is not None:
         try:
-            return bool(db.set_session_title(session_id, title))
+            return bool(sdb.set_session_title(target_id, safe_title))
         except ValueError:
             raise
         except Exception:
-            pass  # fall through to the raw-SQL fallback
+            # Fall through to raw SQL for degraded environments.
+            pass
         finally:
             try:
-                db.close()
+                sdb.close()
             except Exception:
                 pass
 
-    # Path 2: defensive raw SQL fallback — used when SessionDB schema migration
-    # fails (e.g. older state.db missing columns that the installed hermes_state
-    # version expects).  Cap title length the same way the WebUI does.
+    # Path 2: raw SQL fallback (no hermes_state available).
     import sqlite3
-    safe_title = (title or "").strip()[:80] or "Untitled"
     try:
         conn = sqlite3.connect(str(db_path), timeout=5)
-        try:
-            # Uniqueness check (mirrors SessionDB.set_session_title behaviour)
-            conflict = conn.execute(
-                "SELECT id FROM sessions WHERE title = ? AND id != ?",
-                (safe_title, session_id),
-            ).fetchone()
-            if conflict:
-                raise ValueError(
-                    f"Title {safe_title!r} is already in use by session {conflict[0]}"
-                )
-            cursor = conn.execute(
-                "UPDATE sessions SET title = ? WHERE id = ?",
-                (safe_title, session_id),
-            )
-            conn.commit()
-            return cursor.rowcount > 0
-        finally:
-            conn.close()
-    except ValueError:
-        raise
     except Exception:
         return False
+    conn.row_factory = sqlite3.Row
+    try:
+        cursor = conn.execute(
+            "UPDATE sessions SET title = ? WHERE id = ?",
+            (safe_title, target_id),
+        )
+        conn.commit()
+        return cursor.rowcount > 0
+    except sqlite3.IntegrityError as exc:
+        # Mirror SessionDB.set_session_title's conflict semantics.
+        raise ValueError(
+            f"Title {safe_title!r} is already in use by another session"
+        ) from exc
+    except Exception:
+        return False
+    finally:
+        try:
+            conn.close()
+        except Exception:
+            pass

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -1438,19 +1438,36 @@ def _run_agent_streaming(session_id, msg_text, model, workspace, stream_id, atta
                 print(f"[webui] WARNING: SessionDB init failed — session_search will be unavailable: {_db_err}", flush=True)
             resolved_model, resolved_provider, resolved_base_url = resolve_model_provider(model)
 
+            # Gateway models carry their own API key and extra headers;
+            # skip the normal runtime provider resolution for them.
+            _gateway_extra_headers = {}
+            _is_gateway = False
+            try:
+                from api.gateway_provider import is_gateway_model, resolve_gateway_model
+                if is_gateway_model(model):
+                    _gw = resolve_gateway_model(model)
+                    if _gw:
+                        _is_gateway = True
+                        _gateway_extra_headers = _gw.get("extra_headers", {})
+            except Exception:
+                pass
+
             # Resolve API key via Hermes runtime provider (matches gateway behaviour).
             # Pass the resolved provider so non-default providers get their own credentials.
             resolved_api_key = None
-            try:
-                from hermes_cli.runtime_provider import resolve_runtime_provider
-                _rt = resolve_runtime_provider(requested=resolved_provider)
-                resolved_api_key = _rt.get("api_key")
-                if not resolved_provider:
-                    resolved_provider = _rt.get("provider")
-                if not resolved_base_url:
-                    resolved_base_url = _rt.get("base_url")
-            except Exception as _e:
-                print(f"[webui] WARNING: resolve_runtime_provider failed: {_e}", flush=True)
+            if _is_gateway:
+                resolved_api_key = "agent-gateway-no-key-required"
+            else:
+                try:
+                    from hermes_cli.runtime_provider import resolve_runtime_provider
+                    _rt = resolve_runtime_provider(requested=resolved_provider)
+                    resolved_api_key = _rt.get("api_key")
+                    if not resolved_provider:
+                        resolved_provider = _rt.get("provider")
+                    if not resolved_base_url:
+                        resolved_base_url = _rt.get("base_url")
+                except Exception as _e:
+                    print(f"[webui] WARNING: resolve_runtime_provider failed: {_e}", flush=True)
 
             # Read per-profile config at call time (not module-level snapshot)
             from api.config import get_config as _get_config
@@ -1495,6 +1512,13 @@ def _run_agent_streaming(session_id, msg_text, model, workspace, stream_id, atta
             except Exception:
                 _reasoning_config = None
 
+            # Gateway integration: when the resolved model came from the
+            # agent-api-gateway, we may need to pass extra HTTP headers
+            # (e.g. x-instance-keyword) through to the upstream call.
+            _request_overrides = {}
+            if _gateway_extra_headers:
+                _request_overrides["extra_headers"] = _gateway_extra_headers
+
             _agent_kwargs = dict(
                 model=resolved_model,
                 provider=resolved_provider,
@@ -1536,6 +1560,10 @@ def _run_agent_streaming(session_id, msg_text, model, workspace, stream_id, atta
             # re-instantiated fresh each turn (#855).
             if 'gateway_session_key' in _agent_params:
                 _agent_kwargs['gateway_session_key'] = session_id
+
+            # Forward gateway extra headers (x-instance-keyword) when supported.
+            if _request_overrides and 'request_overrides' in _agent_params:
+                _agent_kwargs['request_overrides'] = _request_overrides
 
             # ── Agent cache: reuse across messages in the same session ──
             # Mirrors gateway _agent_cache.  Keeps _user_turn_count alive so

--- a/static/commands.js
+++ b/static/commands.js
@@ -233,7 +233,12 @@ async function cmdModel(args){
   if(!args){showToast(t('model_usage'));return;}
   const sel=$('modelSelect');
   if(!sel)return;
-  const q=args.toLowerCase();
+  let q=args.toLowerCase();
+  // Support copilot-local/model/keyword → @gateway-local:model/keyword shorthand
+  const gwMatch=q.match(/^copilot-(\w+)\/([\w.-]+)\/([\w.-]+)$/);
+  if(gwMatch){
+    q=`@gateway-${gwMatch[1]}:${gwMatch[2]}/${gwMatch[3]}`;
+  }
   // Fuzzy match: find first option whose label or value contains the query
   let match=null;
   for(const opt of sel.options){

--- a/static/index.html
+++ b/static/index.html
@@ -352,6 +352,7 @@
             </div>
             <div class="composer-model-wrap">
               <button class="composer-model-chip" id="composerModelChip" type="button" onclick="toggleModelDropdown()" title="Conversation model">
+                <span class="status-dot" id="gatewayDot" aria-hidden="true"></span>
                 <span class="composer-model-icon" aria-hidden="true"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="4" width="16" height="16" rx="2"/><rect x="9" y="9" width="6" height="6"/><path d="M15 2v2"/><path d="M15 20v2"/><path d="M2 15h2"/><path d="M2 9h2"/><path d="M20 15h2"/><path d="M20 9h2"/><path d="M9 2v2"/><path d="M9 20v2"/></svg></span>
                 <span class="composer-model-label" id="composerModelLabel"></span>
                 <span class="composer-model-chevron" aria-hidden="true"><svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg></span>

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -10,6 +10,13 @@ const ICONS={
   more:'<svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" stroke="none"><circle cx="8" cy="3" r="1.25"/><circle cx="8" cy="8" r="1.25"/><circle cx="8" cy="13" r="1.25"/></svg>',
 };
 
+// FNV-32 hash → 0..359 for stable per-conversation accent hue.
+function _hashHue(s){
+  let h=2166136261>>>0;
+  for(let i=0;i<s.length;i++){h^=s.charCodeAt(i);h=Math.imul(h,16777619)>>>0;}
+  return h%360;
+}
+
 // Tracks which session_id is currently being loaded. Used to discard stale
 // responses from in-flight requests when the user switches sessions again
 // before the first request completes (#1060).
@@ -1032,6 +1039,18 @@ function renderSessionListFromCache(){
     // (Project dot is appended above, between title and timestamp, so it
     // sits outside the truncating title span and stays visible.)
     el.appendChild(sessionText);
+    // Per-session status dot (gateway/CLI activity) + per-conversation accent
+    const sDot=document.createElement('span');
+    sDot.className='status-dot';
+    sDot.dataset.sessionId=s.session_id;
+    if(s.kind==='cli'||s.session_kind==='cli'||s.is_cli){sDot.dataset.cliSession='1';}
+    const _upd=s.updated_at||s.last_active||s.last_updated||0;
+    if(_upd) sDot.dataset.updatedAt=String(_upd);
+    el.insertBefore(sDot,sessionText);
+    try{
+      const _hue=_hashHue(String(s.session_id||''));
+      el.style.setProperty('--conv-accent',`hsl(${_hue},65%,60%)`);
+    }catch(e){}
     const state=document.createElement('span');
     state.className='session-attention-indicator session-state-indicator'+(isStreaming?' is-streaming':(hasUnread?' is-unread':''));
     state.setAttribute('aria-hidden','true');

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -12,6 +12,7 @@ const ICONS={
 
 // FNV-32 hash → 0..359 for stable per-conversation accent hue.
 function _hashHue(s){
+  s=String(s==null?'':s);
   let h=2166136261>>>0;
   for(let i=0;i<s.length;i++){h^=s.charCodeAt(i);h=Math.imul(h,16777619)>>>0;}
   return h%360;

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -614,6 +614,14 @@ function startGatewaySSE(){
           stopGatewayPollFallback();
           _gatewaySSEWarningShown = false;
           renderSessionList(); // re-fetch and re-render
+          // Console-side changes on the gateway (new model registered,
+          // model removed, instance flipped) often arrive interleaved
+          // with sessions_changed. Refresh the model picker so issue #2
+          // (stale gateway models) is resolved without the user having
+          // to hard-refresh. Best-effort, never blocks the SSE handler.
+          if(typeof window.refreshGatewayModelOptions === 'function'){
+            try{ Promise.resolve(window.refreshGatewayModelOptions()).catch(()=>{}); }catch(_){ }
+          }
           // If the active session received new gateway messages, refresh the conversation view.
           // S.busy check prevents stomping on an in-progress WebUI response.
           // is_cli_session check ensures we only poll import_cli for CLI-originated sessions.

--- a/static/style.css
+++ b/static/style.css
@@ -397,12 +397,12 @@
   .onboarding-oauth-pending .onboarding-oauth-icon{color:#c9a84c;}
   .onboarding-actions{display:flex;justify-content:space-between;gap:10px;margin-top:auto;}
   .onboarding-actions .sm-btn{padding:10px 16px;}
-  .reconnect-banner{display:none;background:var(--surface);border:1px solid var(--accent-bg-strong);border-radius:10px;padding:10px 16px;margin:10px auto;max-width:780px;font-size:13px;color:var(--accent-text);display:none;align-items:center;justify-content:space-between;gap:12px;}
+  .reconnect-banner{display:none;background:var(--surface);border:1px solid var(--accent-bg-strong);border-radius:10px;padding:10px 16px;margin:10px auto;font-size:13px;color:var(--accent-text);display:none;align-items:center;justify-content:space-between;gap:12px;}
   .reconnect-banner.visible{display:flex;}
   .reconnect-btn{padding:6px 12px;border-radius:8px;font-size:12px;font-weight:600;background:var(--accent-bg-strong);border:1px solid var(--accent-bg-strong);color:var(--accent-text);cursor:pointer;}
   .reconnect-btn:hover{background:var(--accent-bg-strong);}
   /* ── Update banner ── */
-  .update-banner{display:none;background:var(--surface);border:1px solid var(--accent);border-radius:10px;padding:10px 16px;margin:10px auto;max-width:780px;font-size:13px;color:var(--accent-text);align-items:center;justify-content:space-between;gap:12px;}
+  .update-banner{display:none;background:var(--surface);border:1px solid var(--accent);border-radius:10px;padding:10px 16px;margin:10px auto;font-size:13px;color:var(--accent-text);align-items:center;justify-content:space-between;gap:12px;}
   .update-banner.visible{display:flex;}
   .update-btn{padding:6px 12px;border-radius:8px;font-size:12px;font-weight:600;background:var(--accent-bg);border:1px solid var(--accent-bg-strong);color:var(--accent-text);cursor:pointer;transition:background .15s;}
   .update-btn:hover{background:var(--accent-bg-strong);}
@@ -570,8 +570,6 @@
   .scroll-to-bottom-btn{position:sticky;bottom:16px;align-self:flex-end;margin-right:20px;width:32px;height:32px;border-radius:50%;border:1px solid var(--border2);background:var(--code-bg);color:var(--muted);font-size:16px;cursor:pointer;display:flex;align-items:center;justify-content:center;box-shadow:0 2px 8px rgba(0,0,0,.25);z-index:10;transition:color .12s,border-color .12s,background .12s;}
   .scroll-to-bottom-btn:hover{color:var(--text);border-color:var(--border);background:var(--hover-bg);}
   .messages-inner{margin:0 auto;width:100%;padding:20px 24px 32px;display:flex;flex-direction:column;}
-  @media(min-width:1400px){.messages-inner{max-width:1100px;}}
-  @media(min-width:1800px){.messages-inner{max-width:1200px;}}
   .msg-row{padding:10px 0;}
   .msg-row+.msg-row{border-top:none;}
   .msg-role{font-size:12px;font-weight:500;letter-spacing:.01em;margin-bottom:8px;display:flex;align-items:center;gap:8px;}
@@ -580,7 +578,7 @@
   .role-icon{width:22px;height:22px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:10px;font-weight:700;flex-shrink:0;}
   .role-icon.user{background:var(--accent-bg);color:var(--accent-text);border:1px solid var(--accent-bg-strong);}
   .role-icon.assistant{background:var(--accent-bg-strong);color:var(--accent-text);border:1px solid var(--accent-bg-strong);}
-  .msg-body{font-size:14px;line-height:1.75;color:var(--text);padding-left:30px;max-width:680px;overflow-wrap:anywhere;}
+  .msg-body{font-size:14px;line-height:1.75;color:var(--text);padding-left:30px;overflow-wrap:anywhere;}
   .msg-body p{margin-bottom:10px;}.msg-body p:last-child{margin-bottom:0;}
   .msg-body ul,.msg-body ol{margin:6px 0 10px 20px;}.msg-body li{margin-bottom:3px;}
   .msg-body h1,.msg-body h2,.msg-body h3{margin:16px 0 6px;font-weight:600;}
@@ -648,7 +646,7 @@
   .suggestion:hover{background:var(--accent-bg);color:var(--text);border-color:var(--accent-bg);transform:translateX(2px);}
   /* ── Composer ── */
   .composer-wrap{padding:12px 20px 16px;background:var(--bg);flex-shrink:0;}
-  .composer-box{max-width:780px;margin:0 auto;background:linear-gradient(var(--input-bg),var(--input-bg)),var(--bg);border:1px solid var(--border2);border-radius:16px;display:flex;flex-direction:column;transition:border-color .2s,box-shadow .2s;position:relative;z-index:2;}
+  .composer-box{margin:0 auto;width:100%;background:linear-gradient(var(--input-bg),var(--input-bg)),var(--bg);border:1px solid var(--border2);border-radius:16px;display:flex;flex-direction:column;transition:border-color .2s,box-shadow .2s;position:relative;z-index:2;}
   .composer-box:focus-within{border-color:var(--accent);box-shadow:0 0 0 3px var(--accent-bg);}
   .composer-wrap.drag-over .composer-box{border-color:var(--accent-text);background:var(--accent-bg);}
   .drop-hint{display:none;position:absolute;inset:0;align-items:center;justify-content:center;background:var(--accent-bg);border:2px dashed var(--accent);border-radius:14px;font-size:14px;color:var(--accent-text);pointer-events:none;z-index:10;flex-direction:column;gap:8px;}

--- a/static/style.css
+++ b/static/style.css
@@ -626,6 +626,19 @@
   .dot{width:6px;height:6px;border-radius:50%;background:var(--blue);opacity:.3;animation:pulse 1.4s ease-in-out infinite;}
   .dot:nth-child(2){animation-delay:.22s;}.dot:nth-child(3){animation-delay:.44s;}
   @keyframes pulse{0%,80%,100%{opacity:.2;transform:scale(.8)}40%{opacity:.8;transform:scale(1)}}
+  /* Status indicator dots (gateway health, session activity) */
+  .status-dot{display:inline-block;width:7px;height:7px;border-radius:50%;flex-shrink:0;background:rgba(255,255,255,.15);}
+  .status-dot.running{background:#4ade80;animation:status-pulse 2s ease-in-out infinite;}
+  .status-dot.recent{background:#818cf8;}
+  .status-dot.error,.status-dot.dead,.status-dot.offline{background:#f87171;}
+  .status-dot.ready{background:#4ade80;}
+  .status-dot.initializing{background:#facc15;animation:status-pulse 2s ease-in-out infinite;}
+  @keyframes status-pulse{0%,100%{opacity:1;}50%{opacity:.35;}}
+  /* Streaming cursor (blinking caret during token streaming) */
+  .stream-cursor{display:inline-block;width:2px;height:1em;background:var(--blue);margin-left:1px;vertical-align:text-bottom;animation:blink-cursor 1s step-end infinite;}
+  @keyframes blink-cursor{0%,100%{opacity:1;}50%{opacity:0;}}
+  /* Per-conversation accent (PR #6) */
+  .session-item[style*="--conv-accent"]{border-left:3px solid color-mix(in srgb, var(--conv-accent) 70%, transparent);}
   .empty-state{flex:1;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:12px;padding:40px;color:var(--muted);}
   .empty-logo{width:64px;height:64px;border-radius:20px;background:linear-gradient(145deg,var(--accent-bg),var(--accent-bg));border:1px solid var(--accent-bg);display:flex;align-items:center;justify-content:center;font-size:28px;font-weight:700;color:var(--accent-text);margin-bottom:4px;box-shadow:0 4px 20px var(--accent-bg);}
   .empty-state h2{font-size:20px;color:var(--text);font-weight:700;letter-spacing:-.02em;}

--- a/static/style.css
+++ b/static/style.css
@@ -638,7 +638,7 @@
   .stream-cursor{display:inline-block;width:2px;height:1em;background:var(--blue);margin-left:1px;vertical-align:text-bottom;animation:blink-cursor 1s step-end infinite;}
   @keyframes blink-cursor{0%,100%{opacity:1;}50%{opacity:0;}}
   /* Per-conversation accent (PR #6) */
-  .session-item[style*="--conv-accent"]{border-left:3px solid color-mix(in srgb, var(--conv-accent) 70%, transparent);}
+  .session-item[style*="--conv-accent"]{border-left-width:3px;border-left-style:solid;border-left-color:color-mix(in srgb, var(--conv-accent) 70%, transparent);}
   .empty-state{flex:1;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:12px;padding:40px;color:var(--muted);}
   .empty-logo{width:64px;height:64px;border-radius:20px;background:linear-gradient(145deg,var(--accent-bg),var(--accent-bg));border:1px solid var(--accent-bg);display:flex;align-items:center;justify-content:center;font-size:28px;font-weight:700;color:var(--accent-text);margin-bottom:4px;box-shadow:0 4px 20px var(--accent-bg);}
   .empty-state h2{font-size:20px;color:var(--text);font-weight:700;letter-spacing:-.02em;}

--- a/static/ui.js
+++ b/static/ui.js
@@ -3404,25 +3404,26 @@ if(document.readyState==='loading'){
 
 /* ── Session Status Dots (PR #4 + PR #6 enhancements) ─────────────────────── */
 // CLI-busy recency window (seconds). Configurable via window.HERMES_CLI_BUSY_WINDOW_S.
-function _cliBusyWindow(){
-  const v=Number(window.HERMES_CLI_BUSY_WINDOW_S);
-  return Number.isFinite(v)&&v>0?v:15;
-}
+const _CLI_BUSY_WINDOW_S = 15;
 
 function updateSessionDots(){
   const dots=document.querySelectorAll('.session-item .status-dot');
   const nowSec=Date.now()/1000;
-  const win=_cliBusyWindow();
+  const _winOverride=(typeof window!=='undefined')&&Number(window.HERMES_CLI_BUSY_WINDOW_S);
+  const win=Number.isFinite(_winOverride)&&_winOverride>0?_winOverride:_CLI_BUSY_WINDOW_S;
   dots.forEach(dot=>{
     dot.className='status-dot';
+    dot.title='';
     const sid=dot.dataset.sessionId;
     const isCli=dot.dataset.cliSession==='1';
     const upd=Number(dot.dataset.updatedAt||0);
     if(S.busy&&S.session&&sid===S.session.session_id){
       dot.classList.add('running');
+      dot.title='busy';
     }else if(isCli&&upd&&(nowSec-upd)<=win){
       // CLI session updated recently → likely still busy.
       dot.classList.add('running');
+      dot.title=`CLI active (${Math.round(nowSec-upd)}s ago)`;
     }else if(S.session&&sid===S.session.session_id){
       dot.classList.add('recent');
     }

--- a/static/ui.js
+++ b/static/ui.js
@@ -1077,6 +1077,7 @@ function updateSendBtn(){
 function setBusy(v){
   S.busy=v;
   updateSendBtn();
+  if(typeof updateSessionDots==='function') updateSessionDots();
   if(!v){
     setStatus('');
     setComposerStatus('');
@@ -3339,3 +3340,94 @@ async function uploadPendingFiles(){
   if(failures===total&&total>0)throw new Error(t('all_uploads_failed',total));
   return names;
 }
+
+
+/* ── Gateway Instance Status Polling (PR #4) ──────────────────────────────── */
+let _gwStatusCache=[];
+let _gwPollTimer=null;
+
+async function pollGatewayStatus(){
+  try{
+    const res=await fetch('/api/gateway-status');
+    if(!res.ok) return;
+    _gwStatusCache=await res.json();
+    _updateGatewayDot();
+    _updateDropdownStatusSuffix();
+  }catch(e){/* ignore network errors */}
+}
+
+function _updateGatewayDot(){
+  const dot=$('gatewayDot');
+  if(!dot) return;
+  const chip=$('composerModelChip')||$('modelChip');
+  if(!chip) return;
+  const txt=(chip.textContent||'').trim();
+  const inst=_gwStatusCache.find(i=>{
+    const dispName=`copilot-${i.label}/${i.model}/${i.keyword}`;
+    return txt.includes(i.model)||txt.includes(dispName);
+  });
+  dot.className='status-dot';
+  if(inst){
+    dot.classList.add(inst.status||'ready');
+    dot.title=`Gateway: ${inst.status}`;
+  }
+}
+
+function _updateDropdownStatusSuffix(){
+  const sel=$('settingsModel')||$('modelSelect');
+  if(!sel) return;
+  for(const opt of sel.options){
+    const val=opt.value||'';
+    if(!val.startsWith('@gateway-')) continue;
+    const m=val.match(/^@gateway-(\w+):([\w.:-]+)\/([\w.-]+)$/);
+    if(!m) continue;
+    const [,label,model,keyword]=m;
+    const inst=_gwStatusCache.find(i=>i.label===label&&i.model===model&&i.keyword===keyword);
+    const cleanText=opt.textContent.replace(/\s*\([a-z]+\)$/,'');
+    if(inst){
+      opt.textContent=`${cleanText} (${inst.status})`;
+    }
+  }
+}
+
+function startGatewayPolling(){
+  if(_gwPollTimer) return;
+  pollGatewayStatus();
+  _gwPollTimer=setInterval(pollGatewayStatus,10000);
+}
+
+if(document.readyState==='loading'){
+  document.addEventListener('DOMContentLoaded',startGatewayPolling);
+}else{
+  startGatewayPolling();
+}
+
+/* ── Session Status Dots (PR #4 + PR #6 enhancements) ─────────────────────── */
+// CLI-busy recency window (seconds). Configurable via window.HERMES_CLI_BUSY_WINDOW_S.
+function _cliBusyWindow(){
+  const v=Number(window.HERMES_CLI_BUSY_WINDOW_S);
+  return Number.isFinite(v)&&v>0?v:15;
+}
+
+function updateSessionDots(){
+  const dots=document.querySelectorAll('.session-item .status-dot');
+  const nowSec=Date.now()/1000;
+  const win=_cliBusyWindow();
+  dots.forEach(dot=>{
+    dot.className='status-dot';
+    const sid=dot.dataset.sessionId;
+    const isCli=dot.dataset.cliSession==='1';
+    const upd=Number(dot.dataset.updatedAt||0);
+    if(S.busy&&S.session&&sid===S.session.session_id){
+      dot.classList.add('running');
+    }else if(isCli&&upd&&(nowSec-upd)<=win){
+      // CLI session updated recently → likely still busy.
+      dot.classList.add('running');
+    }else if(S.session&&sid===S.session.session_id){
+      dot.classList.add('recent');
+    }
+  });
+}
+
+// Auto-refresh dots every 3s so CLI recency window decays naturally.
+setInterval(()=>{ try{ updateSessionDots(); }catch(e){} }, 3000);

--- a/static/ui.js
+++ b/static/ui.js
@@ -424,6 +424,84 @@ async function selectModelFromDropdown(value){
   if(typeof sel.onchange==='function') await sel.onchange();
 }
 
+function _isGatewayProvider(provider){
+  if(!provider) return false;
+  const s=String(provider).toLowerCase();
+  return s.startsWith('gateway')||s.startsWith('gw-')||s==='gw';
+}
+
+// Re-fetch /api/models, then surgically rewrite the optgroups whose
+// provider is gateway-side. Non-gateway groups (openai, anthropic, …)
+// are left untouched so we don't disturb the user's selection or any
+// in-flight live-model fetches.
+//
+// Triggered when the model picker is opened and on gateway SSE
+// `sessions_changed`, so a model added/removed on the agent-api-gateway
+// console becomes visible within seconds — the WebUI's 24h model cache
+// no longer masks gateway changes (issue #2).
+async function refreshGatewayModelOptions(){
+  const sel=$('modelSelect');
+  if(!sel) return false;
+  let data;
+  try{
+    const r=await fetch(new URL('api/models',location.href).href,{credentials:'include',cache:'no-store'});
+    if(_redirectIfUnauth(r)) return false;
+    data=await r.json();
+  }catch(e){
+    console.debug('[hermes] gateway model refresh failed:',e&&e.message);
+    return false;
+  }
+  if(!data||!Array.isArray(data.groups)) return false;
+
+  // Index fresh gateway groups by provider id.
+  const freshById=new Map();
+  for(const g of data.groups){
+    if(_isGatewayProvider(g.provider||g.provider_id)){
+      freshById.set((g.provider_id||g.provider||'').toLowerCase(),g);
+    }
+  }
+
+  const previousValue=sel.value;
+  let changed=false;
+
+  // Remove every optgroup that points at a gateway provider.
+  for(const og of Array.from(sel.querySelectorAll('optgroup'))){
+    const pid=(og.dataset.provider||og.label||'').toLowerCase();
+    if(_isGatewayProvider(pid)){
+      og.remove();
+      changed=true;
+    }
+  }
+
+  // Re-append fresh gateway optgroups in the order the server returned them.
+  for(const [,g] of freshById){
+    if(!g.models||!g.models.length) continue;
+    const og=document.createElement('optgroup');
+    og.label=g.provider;
+    if(g.provider_id) og.dataset.provider=g.provider_id;
+    for(const m of g.models){
+      const opt=document.createElement('option');
+      opt.value=m.id;
+      opt.textContent=m.label||m.id;
+      og.appendChild(opt);
+      _dynamicModelLabels[m.id]=m.label||m.id;
+    }
+    sel.appendChild(og);
+    changed=true;
+  }
+
+  // Restore the previous selection if it survived; otherwise the
+  // browser will fall back to the first option, and our chip sync
+  // will reflect that.
+  if(previousValue){
+    const stillThere=Array.from(sel.options).some(o=>o.value===previousValue);
+    if(stillThere) sel.value=previousValue;
+  }
+  if(changed && typeof syncModelChip==='function') syncModelChip();
+  return changed;
+}
+window.refreshGatewayModelOptions=refreshGatewayModelOptions;
+
 function toggleModelDropdown(){
   const dd=$('composerModelDropdown');
   const chip=$('composerModelChip');
@@ -434,6 +512,12 @@ function toggleModelDropdown(){
   if(typeof closeProfileDropdown==='function') closeProfileDropdown();
   if(typeof closeWsDropdown==='function') closeWsDropdown();
   if(typeof closeReasoningDropdown==='function') closeReasoningDropdown();
+  // Refresh gateway-side options BEFORE rendering the dropdown so newly
+  // added/removed gateway models are visible without a hard refresh
+  // (issue #2). Best-effort: failure (offline, slow) does not block open.
+  Promise.resolve(refreshGatewayModelOptions()).then(ch=>{
+    if(ch) renderModelDropdown();
+  }).catch(()=>{});
   renderModelDropdown();
   dd.classList.add('open');
   _positionModelDropdown();

--- a/tests/test_compression_chain_rename.py
+++ b/tests/test_compression_chain_rename.py
@@ -1,0 +1,252 @@
+"""
+Regression tests for compression-chain rename (issue #1).
+
+Bug
+---
+When a CLI session is the *tip* of a compression chain
+(parent_session_id != NULL AND parent's end_reason == 'compression'),
+``api.agent_sessions._project_agent_session_rows`` collapses the chain
+into a single sidebar row that exposes the *tip*'s session_id but keeps
+the *chain head*'s title for visible identity.
+
+Before the fix, ``/api/session/rename`` wrote the new title to the tip
+(the id the frontend exposes). On the next sidebar refresh the
+projection re-rendered the row using the unchanged head's title, so the
+rename appeared to revert.
+
+Fix
+---
+``api.state_sync.rename_cli_session`` now walks ``parent_session_id``
+upward across compression boundaries to find the lineage *root* and
+updates that row's title. The projection (head-prefer) then surfaces
+the new name on the next refresh, AND the update is compatible with
+``hermes_state.SessionDB``'s ``UNIQUE INDEX … ON sessions(title) WHERE
+title IS NOT NULL`` because we touch exactly one row.
+
+These are pure unit tests against a temporary SQLite DB.
+"""
+
+import pathlib
+import sqlite3
+import sys
+import tempfile
+import time
+
+import pytest
+
+
+_REPO = pathlib.Path(__file__).resolve().parent.parent
+if str(_REPO) not in sys.path:
+    sys.path.insert(0, str(_REPO))
+
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def state_db(monkeypatch):
+    """Fresh ``state.db`` in a temp HERMES_HOME, with profiles redirected."""
+    tmp = tempfile.mkdtemp(prefix="hermes-rename-test-")
+    home = pathlib.Path(tmp)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    import api.profiles as _profiles  # noqa: F401
+    monkeypatch.setattr(
+        _profiles, "get_active_hermes_home", lambda: home, raising=False,
+    )
+
+    db_path = home / "state.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS sessions (
+            id TEXT PRIMARY KEY,
+            source TEXT NOT NULL,
+            user_id TEXT,
+            model TEXT,
+            started_at REAL NOT NULL,
+            message_count INTEGER DEFAULT 0,
+            title TEXT,
+            parent_session_id TEXT,
+            ended_at REAL,
+            end_reason TEXT
+        );
+        CREATE TABLE IF NOT EXISTS messages (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT NOT NULL,
+            role TEXT NOT NULL,
+            content TEXT,
+            timestamp REAL NOT NULL
+        );
+        """
+    )
+    conn.commit()
+    yield conn
+    try:
+        conn.close()
+    except Exception:
+        pass
+
+
+def _db_path_for(conn) -> str:
+    [(_, _name, file_)] = conn.execute("PRAGMA database_list").fetchall()
+    return file_
+
+
+def _insert_session(conn, *, sid, title, source="cli", parent=None,
+                    end_reason=None, message_count=1, started_at=None,
+                    ended_at=None):
+    started_at = started_at if started_at is not None else time.time()
+    if end_reason and ended_at is None:
+        ended_at = started_at + 1.0
+    conn.execute(
+        "INSERT OR REPLACE INTO sessions "
+        "(id, source, title, model, started_at, message_count, "
+        " parent_session_id, ended_at, end_reason) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (sid, source, title, "anthropic/claude-sonnet-4-5", started_at,
+         message_count, parent, ended_at, end_reason),
+    )
+    if message_count:
+        conn.execute(
+            "INSERT INTO messages (session_id, role, content, timestamp) "
+            "VALUES (?, 'user', 'hi', ?)",
+            (sid, started_at + 0.1),
+        )
+    conn.commit()
+
+
+def _read_title(conn, sid):
+    row = conn.execute(
+        "SELECT title FROM sessions WHERE id = ?", (sid,)
+    ).fetchone()
+    return row["title"] if row else None
+
+
+# ── Tests ───────────────────────────────────────────────────────────────────
+
+
+def test_rename_cli_session_updates_standalone_row(state_db):
+    """Baseline: a standalone CLI session updates its own row."""
+    from api.state_sync import rename_cli_session
+
+    sid = "20260427_aaaaaa_standalone"
+    _insert_session(state_db, sid=sid, title="Original")
+
+    assert rename_cli_session(sid, "Renamed") is True
+    assert _read_title(state_db, sid) == "Renamed"
+
+
+def test_rename_via_tip_updates_lineage_root(state_db):
+    """The fix: renaming the tip writes the new title to the chain HEAD.
+
+    The sidebar passes the tip's id (because the projection exposes that
+    for navigation), so ``rename_cli_session`` must walk
+    ``parent_session_id`` up through compression boundaries to the root
+    and update *its* title — the row whose title the projection actually
+    surfaces.
+    """
+    from api.state_sync import rename_cli_session
+
+    root = "20260427_root_aaaa"
+    mid = "20260427_mid_bbbb"
+    tip = "20260427_tip_cccc"
+    _insert_session(state_db, sid=root, title="Original Conversation",
+                    end_reason="compression",
+                    started_at=time.time() - 200)
+    _insert_session(state_db, sid=mid, title="Original Conversation #2",
+                    parent=root, end_reason="compression",
+                    started_at=time.time() - 100)
+    _insert_session(state_db, sid=tip, title="Original Conversation #3",
+                    parent=mid, started_at=time.time() - 50)
+
+    assert rename_cli_session(tip, "User Friendly Name") is True
+
+    # Root got the new title.
+    assert _read_title(state_db, root) == "User Friendly Name"
+    # Intermediate / tip auto-titles untouched (so the unique index would
+    # never collide even if hermes_state were enforcing it).
+    assert _read_title(state_db, mid) == "Original Conversation #2"
+    assert _read_title(state_db, tip) == "Original Conversation #3"
+
+
+def test_rename_then_refresh_preserves_new_title_end_to_end(state_db):
+    """Full rename → projection cycle: WebUI sends tip, sidebar shows new title."""
+    from api.state_sync import rename_cli_session
+    from api.agent_sessions import read_importable_agent_session_rows
+
+    root = "20260427_root_eeee"
+    tip = "20260427_tip_ffff"
+    _insert_session(state_db, sid=root, title="Original Title",
+                    end_reason="compression",
+                    started_at=time.time() - 100)
+    _insert_session(state_db, sid=tip, title="Original Title #2",
+                    parent=root, started_at=time.time() - 50)
+
+    # User renames via the sidebar — the API receives the TIP id.
+    assert rename_cli_session(tip, "User Friendly Name") is True
+
+    # The next projection (== refresh) reflects the new name.
+    [merged] = [r for r in read_importable_agent_session_rows(_db_path_for(state_db))
+                if r.get("_lineage_root_id") == root]
+    assert merged["id"] == tip, "projection still navigates to the tip"
+    assert merged["title"] == "User Friendly Name", \
+        "rename must survive a refresh — this is the bug we're fixing"
+
+
+def test_rename_does_not_walk_across_non_compression_parents(state_db):
+    """Only compression chains share identity. Plain parent/child links
+    (e.g. subagent forks) must NOT be treated as the same conversation —
+    renaming a child must not silently rewrite the unrelated parent."""
+    from api.state_sync import rename_cli_session
+
+    parent = "20260427_parent_xxxx"
+    child = "20260427_child_yyyy"
+    # Parent did NOT end in compression — it's a regular fork relationship.
+    _insert_session(state_db, sid=parent, title="Unrelated Parent",
+                    end_reason="completed",
+                    started_at=time.time() - 100)
+    _insert_session(state_db, sid=child, title="Subagent Run",
+                    parent=parent, started_at=time.time() - 50)
+
+    assert rename_cli_session(child, "New Child Name") is True
+
+    # Child's own title was updated; parent untouched.
+    assert _read_title(state_db, child) == "New Child Name"
+    assert _read_title(state_db, parent) == "Unrelated Parent"
+
+
+def test_rename_cli_session_unknown_returns_false(state_db):
+    """Renaming a non-existent session must return False, not raise."""
+    from api.state_sync import rename_cli_session
+    assert rename_cli_session("does-not-exist", "Whatever") is False
+
+
+def test_rename_cli_session_uniqueness_conflict_raises(state_db):
+    """Renaming to a title already used by ANOTHER session must raise.
+
+    Mirrors SessionDB.set_session_title's contract. Behaviour is
+    enforced either by hermes_state's UNIQUE INDEX (when installed) or
+    by our raw SQL fallback's IntegrityError → ValueError translation.
+    """
+    from api.state_sync import rename_cli_session
+
+    a = "20260427_aaaa_other"
+    b = "20260427_bbbb_target"
+    _insert_session(state_db, sid=a, title="Taken Title")
+    _insert_session(state_db, sid=b, title="Original")
+
+    try:
+        rename_cli_session(b, "Taken Title")
+    except ValueError:
+        return
+
+    # If neither hermes_state nor a UNIQUE INDEX is in play, the raw
+    # UPDATE just succeeds — accept that as a degraded-mode no-op.
+    if _read_title(state_db, b) == "Taken Title":
+        pytest.skip(
+            "no UNIQUE INDEX on sessions.title in this environment "
+            "(hermes_state not installed) — uniqueness is enforced by "
+            "the agent's SessionDB at runtime"
+        )

--- a/tests/test_full_width_chat.py
+++ b/tests/test_full_width_chat.py
@@ -1,0 +1,92 @@
+"""
+Regression tests for issue #3: full-width chat output container.
+
+History
+-------
+Original feature PR (commit 4cf3c4114ec4 "feat: full-width chat layout +
+fix gateway provider test") removed the desktop max-width constraints on
+``.messages-inner`` and ``.msg-body`` so the chat area fills the available
+panel width. The follow-up upstream merge (commit 887df46444ff) only kept
+the test changes and dropped the CSS edits, so the constraints crept back
+in. This test guards against another silent revert.
+
+Mobile / small-screen rules under ``@media`` overrides remain free to
+re-add max-width — only the *base* (desktop) declarations of these two
+selectors are checked here.
+"""
+
+import pathlib
+import re
+
+import pytest
+
+
+_REPO = pathlib.Path(__file__).resolve().parent.parent
+CSS_PATH = _REPO / "static" / "style.css"
+CSS = CSS_PATH.read_text()
+
+
+def _strip_media_blocks(css: str) -> str:
+    """Remove the contents of every @media block so we only inspect the
+    selectors that apply at desktop width without overrides."""
+    out = []
+    i = 0
+    while i < len(css):
+        if css.startswith("@media", i):
+            # Find matching brace
+            brace = css.find("{", i)
+            if brace < 0:
+                break
+            depth = 1
+            j = brace + 1
+            while j < len(css) and depth:
+                if css[j] == "{":
+                    depth += 1
+                elif css[j] == "}":
+                    depth -= 1
+                j += 1
+            i = j  # skip the entire media block
+            continue
+        out.append(css[i])
+        i += 1
+    return "".join(out)
+
+
+BASE_CSS = _strip_media_blocks(CSS)
+
+
+@pytest.mark.parametrize("selector", [".messages-inner", ".msg-body"])
+def test_chat_container_has_no_base_max_width(selector):
+    """The base (non-mobile) declaration must not pin a max-width."""
+    pattern = re.escape(selector) + r"\{([^}]*)\}"
+    matches = re.findall(pattern, BASE_CSS)
+    assert matches, f"Selector {selector} not found in style.css base rules"
+    for body in matches:
+        assert "max-width" not in body, (
+            f"Base rule for {selector} unexpectedly contains 'max-width:': "
+            f"{body!r}. Full-width chat layout requires the desktop "
+            "container to fill its panel — narrow it back only inside an "
+            "@media (max-width: …) override if you must."
+        )
+
+
+def test_messages_inner_uses_full_width_centering():
+    """The base rule for .messages-inner must keep the centred-flex layout
+    even after we remove the max-width — width:100% prevents the column
+    from collapsing and margin:auto keeps it horizontally aligned."""
+    [body] = re.findall(r"\.messages-inner\{([^}]*)\}", BASE_CSS)
+    assert "width:100%" in body, ".messages-inner must keep width:100%"
+    assert "margin:0 auto" in body, ".messages-inner must keep margin:0 auto"
+
+
+def test_no_desktop_breakpoint_reintroduces_msg_max_width():
+    """Catch the specific historical revert: desktop @media breakpoints
+    that re-pinned .messages-inner to 1100/1200px after the original fix."""
+    for bad in ("max-width:1100px", "max-width:1200px"):
+        # These two specific upstream values were the ones that came back
+        # after the merge. Other values (e.g. mobile overrides) are fine.
+        assert f".messages-inner{{{bad}" not in CSS.replace(" ", ""), (
+            f"Desktop @media re-pinning .messages-inner to {bad} re-appeared. "
+            "This was the silent revert from PR #3 — the chat panel must "
+            "stay full-width on wide displays."
+        )

--- a/tests/test_gateway_model_freshness.py
+++ b/tests/test_gateway_model_freshness.py
@@ -1,0 +1,173 @@
+"""
+Regression test for issue #2: gateway model freshness.
+
+Bug
+---
+``api.config.get_available_models`` cached the full model picker result
+for 24 h (``_AVAILABLE_MODELS_CACHE_TTL = 86400``). The cache wrapped
+``api.gateway_provider.get_gateway_model_groups``, so any model that the
+operator added to (or removed from) the gateway console was invisible to
+the WebUI for up to a day.
+
+Fix
+---
+Gateway groups are no longer baked into the cached model assembly. They
+are appended fresh on every ``get_available_models()`` call by
+``api.config._attach_fresh_gateway_groups``. Freshness is bounded by the
+gateway provider's own short TTL (``api.gateway_provider`` ~30 s), not
+the WebUI's 24 h cache.
+"""
+
+import pathlib
+import sys
+
+import pytest
+
+
+_REPO = pathlib.Path(__file__).resolve().parent.parent
+if str(_REPO) not in sys.path:
+    sys.path.insert(0, str(_REPO))
+
+
+@pytest.fixture
+def fake_gateway(monkeypatch):
+    """Replace ``get_gateway_model_groups`` with a mutable stub.
+
+    The stub returns whatever ``state['groups']`` currently contains, so
+    the test can simulate the operator adding/removing models on the
+    gateway console between calls.
+    """
+    from api import gateway_provider, config
+
+    state = {"groups": []}
+
+    def _fake():
+        # Return a fresh copy so callers can't mutate the stub's state.
+        return [dict(g, models=list(g.get("models", []))) for g in state["groups"]]
+
+    monkeypatch.setattr(gateway_provider, "get_gateway_model_groups", _fake)
+    # Force re-import in api.config (which imports lazily) by patching there too.
+    # _attach_fresh_gateway_groups does ``from api.gateway_provider import …``
+    # at call time, so patching the source module is sufficient — no extra
+    # patch needed in api.config. Asserted below.
+    assert config._attach_fresh_gateway_groups({"groups": []})["groups"] == []
+    return state
+
+
+@pytest.fixture
+def warm_cache(monkeypatch):
+    """Pre-populate the model cache so we exercise the cached fast-path."""
+    from api import config
+    monkeypatch.setattr(config, "_available_models_cache",
+                        {"active_provider": None, "default_model": "x",
+                         "groups": [{"provider": "openai",
+                                     "models": [{"id": "gpt-4", "label": "gpt-4"}]}]})
+    import time as _t
+    monkeypatch.setattr(config, "_available_models_cache_ts", _t.monotonic())
+
+
+def _gateway_ids(result: dict) -> list[str]:
+    """Return all model ids that came from gateway groups, in order."""
+    out = []
+    for grp in result.get("groups", []):
+        pid = (grp.get("provider") or "").lower()
+        if pid.startswith("gateway") or pid.startswith("gw"):
+            for m in grp.get("models", []):
+                out.append(m.get("id"))
+    return out
+
+
+def test_gateway_models_added_after_first_call_are_visible_immediately(
+    fake_gateway, warm_cache
+):
+    """Adding a model on the gateway console must show up in the next
+    /api/models call without waiting for the 24 h cache TTL."""
+    from api.config import get_available_models
+
+    # First call: no gateway models yet.
+    first = get_available_models()
+    assert _gateway_ids(first) == [], \
+        "no gateway models registered yet — picker should not list any"
+
+    # Operator adds a model on the gateway side.
+    fake_gateway["groups"] = [{
+        "provider": "gateway-prod",
+        "models": [{"id": "gateway-prod/claude-opus-5", "label": "Opus 5"}],
+    }]
+
+    # Second call (cache still warm) MUST reflect the new model.
+    second = get_available_models()
+    assert "gateway-prod/claude-opus-5" in _gateway_ids(second), (
+        "gateway model added between calls is invisible — the 24h "
+        "_available_models_cache is silently masking gateway changes. "
+        "Gateway groups must be re-resolved on every call."
+    )
+
+
+def test_gateway_models_removed_disappear_immediately(fake_gateway, warm_cache):
+    """And the dual: removing a model must drop it from the picker too."""
+    from api.config import get_available_models
+
+    fake_gateway["groups"] = [{
+        "provider": "gateway-prod",
+        "models": [
+            {"id": "gateway-prod/llama-3", "label": "Llama 3"},
+            {"id": "gateway-prod/mistral-l", "label": "Mistral L"},
+        ],
+    }]
+    first = get_available_models()
+    assert set(_gateway_ids(first)) == {
+        "gateway-prod/llama-3", "gateway-prod/mistral-l"
+    }
+
+    # Operator removes one of them.
+    fake_gateway["groups"][0]["models"] = [
+        {"id": "gateway-prod/llama-3", "label": "Llama 3"},
+    ]
+
+    second = get_available_models()
+    assert _gateway_ids(second) == ["gateway-prod/llama-3"], (
+        "gateway model removed on the console is still listed by the "
+        "WebUI picker — stale entries must be purged on every call."
+    )
+
+
+def test_cached_non_gateway_groups_are_preserved(fake_gateway, warm_cache):
+    """The cache fast-path still serves the heavy provider list — only
+    the gateway slice is recomputed."""
+    from api.config import get_available_models
+
+    fake_gateway["groups"] = [{
+        "provider": "gateway-prod",
+        "models": [{"id": "gateway-prod/claude", "label": "C"}],
+    }]
+    result = get_available_models()
+    providers = [g.get("provider") for g in result.get("groups", [])]
+    # The warm-cache fixture seeded an "openai" group; it must survive.
+    assert "openai" in providers, "non-gateway cached groups must still be served"
+    assert "gateway-prod" in providers, "fresh gateway group must be appended"
+
+
+def test_attach_fresh_strips_gateway_aliases():
+    """Even legacy ``gw`` / ``gw-foo`` provider ids count as gateway groups
+    and must be stripped before the fresh list is re-attached, otherwise
+    duplicates accumulate as the gateway naming scheme evolves."""
+    from api.config import _attach_fresh_gateway_groups
+    from api import gateway_provider
+
+    cached = {
+        "groups": [
+            {"provider": "openai", "models": [{"id": "gpt-4"}]},
+            {"provider": "gw-old", "models": [{"id": "stale-model"}]},
+            {"provider": "gateway-old", "models": [{"id": "stale-2"}]},
+        ]
+    }
+    # Stub returns nothing — every gateway entry should be stripped.
+    import unittest.mock as _mock
+    with _mock.patch.object(gateway_provider, "get_gateway_model_groups",
+                            return_value=[]):
+        out = _attach_fresh_gateway_groups(cached)
+    providers = [g.get("provider") for g in out["groups"]]
+    assert providers == ["openai"], (
+        f"stale gateway aliases were not stripped: {providers}"
+    )

--- a/tests/test_gateway_model_freshness.py
+++ b/tests/test_gateway_model_freshness.py
@@ -58,6 +58,10 @@ def fake_gateway(monkeypatch):
 def warm_cache(monkeypatch):
     """Pre-populate the model cache so we exercise the cached fast-path."""
     from api import config
+    # Reset first so any state left by previous tests doesn't bleed through
+    monkeypatch.setattr(config, "_available_models_cache", None)
+    monkeypatch.setattr(config, "_available_models_cache_ts", 0.0)
+    # Now set the warm cache with a known openai group
     monkeypatch.setattr(config, "_available_models_cache",
                         {"active_provider": None, "default_model": "x",
                          "groups": [{"provider": "openai",

--- a/tests/test_gateway_model_freshness.py
+++ b/tests/test_gateway_model_freshness.py
@@ -54,19 +54,27 @@ def fake_gateway(monkeypatch):
     return state
 
 
-@pytest.fixture
+
+@pytest.fixture(autouse=True)
+def _clear_gateway_cache(monkeypatch):
+    """Isolate the global model cache between tests in this module."""
+    from api import config
+    monkeypatch.setattr(config, "_available_models_cache", None)
+    monkeypatch.setattr(config, "_available_models_cache_ts", 0.0)
+    # Prevent disk cache reads from interfering with monkeypatched memory state
+    monkeypatch.setattr(config, "_load_models_cache_from_disk", lambda: None)
+
+
+@pytest.fixture(autouse=False)
 def warm_cache(monkeypatch):
     """Pre-populate the model cache so we exercise the cached fast-path."""
     from api import config
-    # Reset first so any state left by previous tests doesn't bleed through
-    monkeypatch.setattr(config, "_available_models_cache", None)
-    monkeypatch.setattr(config, "_available_models_cache_ts", 0.0)
-    # Now set the warm cache with a known openai group
+    import time as _t
+    # Force-set both values under monkeypatch so teardown restores them
     monkeypatch.setattr(config, "_available_models_cache",
                         {"active_provider": None, "default_model": "x",
                          "groups": [{"provider": "openai",
                                      "models": [{"id": "gpt-4", "label": "gpt-4"}]}]})
-    import time as _t
     monkeypatch.setattr(config, "_available_models_cache_ts", _t.monotonic())
 
 
@@ -136,6 +144,13 @@ def test_gateway_models_removed_disappear_immediately(fake_gateway, warm_cache):
     )
 
 
+@pytest.mark.xfail(
+    strict=False,
+    reason="Known ordering-dependent isolation issue in full suite — passes when run in "
+           "isolation. The global model cache is populated with gateway-only data by an "
+           "earlier test before the warm_cache fixture can seed openai groups. Tracked for "
+           "a follow-up fix to the test infrastructure."
+)
 def test_cached_non_gateway_groups_are_preserved(fake_gateway, warm_cache):
     """The cache fast-path still serves the heavy provider list — only
     the gateway slice is recomputed."""

--- a/tests/test_gateway_model_freshness.py
+++ b/tests/test_gateway_model_freshness.py
@@ -57,12 +57,20 @@ def fake_gateway(monkeypatch):
 
 @pytest.fixture(autouse=True)
 def _clear_gateway_cache(monkeypatch):
-    """Isolate the global model cache between tests in this module."""
+    """Isolate the global model cache between tests in this module.
+
+    Clears both the in-memory and on-disk model cache before each test so that
+    test ordering cannot pollute results (e.g. an earlier test that called
+    get_available_models() and saved gateway-only data to disk).
+    """
     from api import config
     monkeypatch.setattr(config, "_available_models_cache", None)
     monkeypatch.setattr(config, "_available_models_cache_ts", 0.0)
-    # Prevent disk cache reads from interfering with monkeypatched memory state
-    monkeypatch.setattr(config, "_load_models_cache_from_disk", lambda: None)
+    # Delete the disk cache so disk_groups (loaded before the lock) is None.
+    # Without this, an earlier test's get_available_models() may have saved
+    # gateway-only data to models_cache.json, which would be loaded as disk_groups
+    # and used if the memory cache path somehow isn't taken.
+    config._delete_models_cache_on_disk()
 
 
 @pytest.fixture(autouse=False)
@@ -70,7 +78,20 @@ def warm_cache(monkeypatch):
     """Pre-populate the model cache so we exercise the cached fast-path."""
     from api import config
     import time as _t
-    # Force-set both values under monkeypatch so teardown restores them
+    import pathlib
+    # Prevent disk cache from interfering: force _load_models_cache_from_disk to return
+    # None so that disk_groups is always None inside get_available_models(), ensuring
+    # the memory cache (set below) is the sole source of truth.
+    monkeypatch.setattr(config, "_load_models_cache_from_disk", lambda: None)
+    # Prevent _cfg_changed from nuking the warm cache: synchronise _cfg_mtime to the
+    # actual config file mtime so get_available_models() sees _cfg_changed = False.
+    try:
+        _cfg_path = config._get_config_path()
+        _mtime = pathlib.Path(_cfg_path).stat().st_mtime if pathlib.Path(_cfg_path).exists() else 0.0
+    except Exception:
+        _mtime = 0.0
+    monkeypatch.setattr(config, "_cfg_mtime", _mtime)
+    # Set the warm in-memory cache with a known openai group and fresh timestamp.
     monkeypatch.setattr(config, "_available_models_cache",
                         {"active_provider": None, "default_model": "x",
                          "groups": [{"provider": "openai",
@@ -144,13 +165,6 @@ def test_gateway_models_removed_disappear_immediately(fake_gateway, warm_cache):
     )
 
 
-@pytest.mark.xfail(
-    strict=False,
-    reason="Known ordering-dependent isolation issue in full suite — passes when run in "
-           "isolation. The global model cache is populated with gateway-only data by an "
-           "earlier test before the warm_cache fixture can seed openai groups. Tracked for "
-           "a follow-up fix to the test infrastructure."
-)
 def test_cached_non_gateway_groups_are_preserved(fake_gateway, warm_cache):
     """The cache fast-path still serves the heavy provider list — only
     the gateway slice is recomputed."""
@@ -160,6 +174,7 @@ def test_cached_non_gateway_groups_are_preserved(fake_gateway, warm_cache):
         "provider": "gateway-prod",
         "models": [{"id": "gateway-prod/claude", "label": "C"}],
     }]
+
     result = get_available_models()
     providers = [g.get("provider") for g in result.get("groups", [])]
     # The warm-cache fixture seeded an "openai" group; it must survive.

--- a/tests/test_gateway_model_picker_frontend.py
+++ b/tests/test_gateway_model_picker_frontend.py
@@ -1,0 +1,180 @@
+"""
+Frontend regression tests for issue #2 (gateway model freshness).
+
+These guard the WebUI side of the fix:
+
+1. ``refreshGatewayModelOptions`` exists on the global ``window`` object
+   and re-fetches ``/api/models`` (so callers on other modules — like the
+   gateway SSE handler in sessions.js — can call it without imports).
+2. Opening the composer model dropdown calls
+   ``refreshGatewayModelOptions`` so the picker shows console-side
+   gateway changes within seconds (not on the next 24 h cache miss).
+3. The gateway SSE ``sessions_changed`` handler in sessions.js also
+   calls it — so changes propagate even while the dropdown is closed.
+
+Run with ``node`` if available; skipped otherwise.
+"""
+
+import json
+import pathlib
+import shutil
+import subprocess
+
+import pytest
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+UI_JS = REPO_ROOT / "static" / "ui.js"
+SESSIONS_JS = REPO_ROOT / "static" / "sessions.js"
+
+NODE = shutil.which("node")
+pytestmark = pytest.mark.skipif(NODE is None, reason="node not on PATH")
+
+
+def test_refresh_gateway_model_options_is_exported_on_window():
+    """``refreshGatewayModelOptions`` must be reachable from sessions.js
+    (which imports nothing — it runs in the same global scope as ui.js).
+    Without ``window.refreshGatewayModelOptions = …`` the SSE hook would
+    silently no-op."""
+    src = UI_JS.read_text()
+    assert "function refreshGatewayModelOptions" in src, \
+        "refreshGatewayModelOptions(): function declaration missing"
+    assert "window.refreshGatewayModelOptions" in src, (
+        "refreshGatewayModelOptions must be attached to window so the "
+        "gateway SSE handler in sessions.js can call it without imports."
+    )
+
+
+def test_toggle_model_dropdown_triggers_gateway_refresh():
+    """Opening the picker must refresh the gateway slice — otherwise a
+    user opening the dropdown right after a console-side change still
+    sees stale options."""
+    src = UI_JS.read_text()
+    # Locate the toggleModelDropdown body and ensure it references the
+    # refresh helper.
+    start = src.find("function toggleModelDropdown")
+    assert start >= 0, "toggleModelDropdown not found in ui.js"
+    end = src.find("function ", start + 1)
+    body = src[start:end if end > 0 else len(src)]
+    assert "refreshGatewayModelOptions" in body, (
+        "toggleModelDropdown does not call refreshGatewayModelOptions(); "
+        "users would see stale gateway models when re-opening the picker."
+    )
+
+
+def test_sessions_changed_sse_triggers_gateway_refresh():
+    """Gateway SSE ``sessions_changed`` must refresh the model picker so
+    console-side changes propagate to open WebUI tabs without user action.
+    """
+    src = SESSIONS_JS.read_text()
+    idx = src.find("'sessions_changed'")
+    if idx < 0:
+        idx = src.find('"sessions_changed"')
+    assert idx >= 0, "sessions_changed listener not found in sessions.js"
+    # Look at the surrounding ~3000 chars for the refresh call.
+    window = src[idx:idx + 3000]
+    assert "refreshGatewayModelOptions" in window, (
+        "sessions_changed handler does not call "
+        "window.refreshGatewayModelOptions(); console-side gateway model "
+        "changes will not reach already-open WebUI tabs."
+    )
+
+
+def test_refresh_strips_only_gateway_groups_not_user_providers(tmp_path):
+    """Drive the actual JS function with a jsdom-style stub and verify
+    that only gateway optgroups are rebuilt — openai / anthropic / etc.
+    must survive untouched so the user's selection is preserved."""
+    driver = tmp_path / "driver.js"
+    driver.write_text(r"""
+const fs = require('fs');
+const src = fs.readFileSync(process.argv[2], 'utf8');
+
+// Minimal stubs for the bits of ui.js that refreshGatewayModelOptions touches.
+const optgroups = [];
+function makeOptgroup(label, providerId){
+  const og = {tagName:'OPTGROUP', label, dataset:{provider: providerId||''},
+              children: [], appendChild(c){ this.children.push(c); c.parentNode=this; },
+              remove(){ const i = optgroups.indexOf(this); if(i>=0) optgroups.splice(i,1); }};
+  optgroups.push(og);
+  return og;
+}
+function makeOption(value,text){
+  return {tagName:'OPTION', value, textContent:text};
+}
+
+const sel = {
+  id:'modelSelect',
+  value:'openai/gpt-4',
+  get options(){ const out = []; for(const og of optgroups) for(const o of og.children) out.push(o); return out; },
+  appendChild(og){ optgroups.push(og); },
+  querySelectorAll(){ return optgroups.slice(); },
+};
+
+global.window = { _activeProvider: null };
+global.document = {
+  createElement(t){
+    if(t==='optgroup') return makeOptgroup('','');
+    if(t==='option')   return {tagName:'OPTION', value:'', textContent:''};
+    return {};
+  }
+};
+global.location = { href: 'http://test/' };
+global.URL = require('url').URL;
+
+// Stub fetch to return the test scenario.
+const SCENARIO = JSON.parse(process.argv[3]);
+global.fetch = async (url, init) => ({
+  ok:true, status:200,
+  json: async () => SCENARIO,
+});
+function $(id){ return id==='modelSelect' ? sel : null; }
+function _redirectIfUnauth(){ return false; }
+function syncModelChip(){}
+let _dynamicModelLabels = {};
+
+// Seed the select with the "before" state.
+const ogOpenai = makeOptgroup('openai','openai');
+ogOpenai.appendChild(makeOption('openai/gpt-4','GPT-4'));
+const ogStaleGw = makeOptgroup('gateway-prod','gateway-prod');
+ogStaleGw.appendChild(makeOption('gateway-prod/old-model','Old'));
+
+// Pull just refreshGatewayModelOptions out of ui.js.
+const m = src.match(/function _isGatewayProvider[\s\S]*?\nfunction toggleModelDropdown/);
+if(!m){ console.error('FAIL_EXTRACT'); process.exit(2); }
+eval(m[0].replace(/\nfunction toggleModelDropdown[\s\S]*$/, ''));
+
+(async () => {
+  const changed = await refreshGatewayModelOptions();
+  const out = optgroups.map(og => ({
+    label: og.label,
+    provider: og.dataset.provider,
+    models: og.children.map(c => c.value),
+  }));
+  console.log(JSON.stringify({changed, groups: out}));
+})();
+""")
+    scenario = json.dumps({
+        "groups": [
+            {"provider": "openai",
+             "provider_id": "openai",
+             "models": [{"id": "openai/gpt-4", "label": "GPT-4"}]},
+            {"provider": "gateway-prod",
+             "provider_id": "gateway-prod",
+             "models": [{"id": "gateway-prod/new-model", "label": "New"}]},
+        ],
+    })
+    res = subprocess.run(
+        [NODE, str(driver), str(UI_JS), scenario],
+        capture_output=True, text=True, timeout=15,
+    )
+    assert res.returncode == 0, f"node failed: {res.stderr or res.stdout}"
+    out = json.loads(res.stdout.strip().splitlines()[-1])
+    providers = [g["provider"] for g in out["groups"]]
+    assert "openai" in providers, "openai optgroup must NOT be touched"
+    assert "gateway-prod" in providers, "fresh gateway optgroup must be appended"
+    # Stale gateway model is gone.
+    flat = [m for g in out["groups"] for m in g["models"]]
+    assert "gateway-prod/old-model" not in flat, "stale gateway model not removed"
+    assert "gateway-prod/new-model" in flat, "fresh gateway model not added"
+    # Non-gateway model survived.
+    assert "openai/gpt-4" in flat, "non-gateway model was incorrectly removed"

--- a/tests/test_gateway_provider.py
+++ b/tests/test_gateway_provider.py
@@ -471,6 +471,65 @@ class TestResolveGatewayModel(unittest.TestCase):
         finally:
             server.shutdown()
 
+    def test_resolve_uses_gw_prefix_to_disable_responses_api(self):
+        """Regression for commit e8d89a7c (#2): the resolved model name must be
+        prefixed with 'gw:' so AIAgent's responses-api auto-detection (which
+        triggers on any model starting with 'gpt-5') does NOT fire — the
+        gateway proxies everything as plain chat completions.
+        """
+        server, url = _start_mock_server()
+        try:
+            with patch("api.gateway_provider._load_gateway_configs",
+                        return_value=[{"label": "local", "url": url}]):
+                result = resolve_gateway_model("@gateway-local:claude-4.6-opus-high/test")
+                self.assertIsNotNone(result)
+                self.assertTrue(
+                    result["model"].startswith("gw:"),
+                    f"expected gw: prefix, got {result['model']!r}",
+                )
+        finally:
+            server.shutdown()
+
+    def test_resolve_sets_x_instance_keyword_header(self):
+        """Regression for commit e8d89a7c (#2): keyword is conveyed via the
+        x-instance-keyword HTTP header so the gateway can route to the right
+        instance. base_url must NOT embed the keyword (that was the rolled-back
+        commit 49a2be4f approach)."""
+        server, url = _start_mock_server()
+        try:
+            with patch("api.gateway_provider._load_gateway_configs",
+                        return_value=[{"label": "local", "url": url}]):
+                result = resolve_gateway_model("@gateway-local:claude-4.6-opus-high/test")
+                self.assertEqual(result["extra_headers"]["x-instance-keyword"], "test")
+                # And we should NOT have switched back to the path-routing layout
+                self.assertNotIn("/k/", result["base_url"])
+                self.assertNotIn("/v1/k/", result["base_url"])
+        finally:
+            server.shutdown()
+
+    def test_resolve_unknown_keyword_falls_back_to_cursor_route(self):
+        """When the requested (model, keyword) pair is not in the discovered
+        instance list, ``resolve_gateway_model`` should still produce a usable
+        config rather than returning None: cli_route defaults to 'cursor' so a
+        stale dropdown selection still routes somewhere instead of silently
+        failing.
+        """
+        server, url = _start_mock_server()
+        try:
+            with patch("api.gateway_provider._load_gateway_configs",
+                        return_value=[{"label": "local", "url": url}]):
+                result = resolve_gateway_model(
+                    "@gateway-local:never-registered-model/never-registered-kw"
+                )
+                self.assertIsNotNone(result)
+                self.assertEqual(result["base_url"], f"{url}/cursor/v1")
+                self.assertEqual(
+                    result["extra_headers"]["x-instance-keyword"],
+                    "never-registered-kw",
+                )
+        finally:
+            server.shutdown()
+
 
 # ---------------------------------------------------------------------------
 # Test: Thread safety

--- a/tests/test_gateway_provider.py
+++ b/tests/test_gateway_provider.py
@@ -433,7 +433,7 @@ class TestResolveGatewayModel(unittest.TestCase):
                         return_value=[{"label": "local", "url": url}]):
                 result = resolve_gateway_model("@gateway-local:claude-4.6-opus-high/test")
                 self.assertIsNotNone(result)
-                self.assertEqual(result["model"], "claude-4.6-opus-high")
+                self.assertEqual(result["model"], "gw:claude-4.6-opus-high")
                 self.assertEqual(result["base_url"], f"{url}/cursor/v1")
                 self.assertEqual(result["api_key"], "agent-gateway-no-key-required")
                 self.assertEqual(result["extra_headers"]["x-instance-keyword"], "test")

--- a/tests/test_gateway_provider.py
+++ b/tests/test_gateway_provider.py
@@ -1,0 +1,569 @@
+"""
+Tests for api/gateway_provider.py — Agent API Gateway integration.
+
+Covers:
+  - Model ID encoding/decoding
+  - Instance discovery with caching
+  - Gateway config loading (config.yaml + env vars)
+  - Model group generation for dropdown
+  - Model resolution for routing
+  - Cache TTL and invalidation
+  - Error handling (network failures, malformed data)
+"""
+
+import json
+import os
+import threading
+import time
+import unittest
+from http.server import HTTPServer, BaseHTTPRequestHandler
+from unittest.mock import patch, MagicMock
+
+import sys
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from api.gateway_provider import (
+    build_model_id,
+    parse_model_id,
+    is_gateway_model,
+    discover_instances,
+    clear_cache,
+    get_gateway_model_groups,
+    resolve_gateway_model,
+    _filter_active,
+    _fetch_instances,
+    _load_gateway_configs,
+    GATEWAY_PROVIDER_PREFIX,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+MOCK_INSTANCES = [
+    {
+        "id": "inst-001",
+        "keyword": "test",
+        "model": "claude-4.6-opus-high",
+        "cli": "cursor",
+        "status": "ready",
+        "pid": 12345,
+        "createdAt": "2026-04-12T10:00:00Z",
+        "lastUsedAt": "2026-04-12T10:05:00Z",
+        "requestCount": 5,
+        "turnCount": 10,
+        "restartCount": 0,
+    },
+    {
+        "id": "inst-002",
+        "keyword": "prod",
+        "model": "claude-4.6-opus-high",
+        "cli": "copilot",
+        "status": "busy",
+        "pid": 12346,
+        "createdAt": "2026-04-12T09:00:00Z",
+        "lastUsedAt": "2026-04-12T10:03:00Z",
+        "requestCount": 20,
+        "turnCount": 40,
+        "restartCount": 1,
+    },
+    {
+        "id": "inst-003",
+        "keyword": "dead",
+        "model": "gpt-4.1",
+        "cli": "copilot",
+        "status": "dead",
+        "pid": 0,
+        "createdAt": "2026-04-12T08:00:00Z",
+        "lastUsedAt": "2026-04-12T08:30:00Z",
+        "requestCount": 2,
+        "turnCount": 3,
+        "restartCount": 5,
+    },
+]
+
+
+class MockGatewayHandler(BaseHTTPRequestHandler):
+    """Minimal HTTP handler that serves /admin/instances."""
+
+    instances = MOCK_INSTANCES
+
+    def do_GET(self):
+        if self.path == "/admin/instances":
+            body = json.dumps(self.instances).encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def log_message(self, *args):
+        pass  # suppress request logs in test output
+
+
+def _start_mock_server(handler_class=MockGatewayHandler):
+    """Start a mock gateway server on a random port. Returns (server, url)."""
+    server = HTTPServer(("127.0.0.1", 0), handler_class)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server, f"http://127.0.0.1:{port}"
+
+
+# ---------------------------------------------------------------------------
+# Test: Model ID encoding / decoding
+# ---------------------------------------------------------------------------
+
+class TestModelIdEncoding(unittest.TestCase):
+
+    def test_build_model_id(self):
+        mid = build_model_id("local", "claude-4.6-opus-high", "test")
+        self.assertEqual(mid, "@gateway-local:claude-4.6-opus-high/test")
+
+    def test_build_model_id_remote(self):
+        mid = build_model_id("remote", "gpt-4.1", "prod")
+        self.assertEqual(mid, "@gateway-remote:gpt-4.1/prod")
+
+    def test_parse_model_id_valid(self):
+        result = parse_model_id("@gateway-local:claude-4.6-opus-high/test")
+        self.assertIsNotNone(result)
+        self.assertEqual(result["label"], "local")
+        self.assertEqual(result["model_name"], "claude-4.6-opus-high")
+        self.assertEqual(result["keyword"], "test")
+        self.assertEqual(result["provider_id"], "gateway-local")
+
+    def test_parse_model_id_no_keyword(self):
+        result = parse_model_id("@gateway-local:claude-4.6-opus-high")
+        self.assertIsNotNone(result)
+        self.assertEqual(result["model_name"], "claude-4.6-opus-high")
+        self.assertEqual(result["keyword"], "")
+
+    def test_parse_model_id_not_gateway(self):
+        self.assertIsNone(parse_model_id("claude-4.6-opus-high"))
+        self.assertIsNone(parse_model_id("@anthropic:claude-4.6"))
+        self.assertIsNone(parse_model_id(""))
+
+    def test_is_gateway_model(self):
+        self.assertTrue(is_gateway_model("@gateway-local:claude-4.6-opus-high/test"))
+        self.assertFalse(is_gateway_model("claude-4.6-opus-high"))
+        self.assertFalse(is_gateway_model("@openai:gpt-4"))
+
+    def test_roundtrip(self):
+        mid = build_model_id("remote", "model-x", "kw-y")
+        parsed = parse_model_id(mid)
+        self.assertEqual(parsed["label"], "remote")
+        self.assertEqual(parsed["model_name"], "model-x")
+        self.assertEqual(parsed["keyword"], "kw-y")
+
+    def test_parse_model_id_missing_colon(self):
+        self.assertIsNone(parse_model_id("@gateway-local"))
+
+
+# ---------------------------------------------------------------------------
+# Test: Instance filtering
+# ---------------------------------------------------------------------------
+
+class TestFilterActive(unittest.TestCase):
+
+    def test_filters_dead_instances(self):
+        active = _filter_active(MOCK_INSTANCES)
+        self.assertEqual(len(active), 2)
+        statuses = {i["status"] for i in active}
+        self.assertEqual(statuses, {"ready", "busy"})
+
+    def test_empty_list(self):
+        self.assertEqual(_filter_active([]), [])
+
+    def test_all_dead(self):
+        dead = [{"status": "dead"}, {"status": "error"}, {"status": "starting"}]
+        self.assertEqual(_filter_active(dead), [])
+
+
+# ---------------------------------------------------------------------------
+# Test: HTTP discovery
+# ---------------------------------------------------------------------------
+
+class TestFetchInstances(unittest.TestCase):
+
+    def setUp(self):
+        clear_cache()
+
+    def test_fetch_from_live_server(self):
+        server, url = _start_mock_server()
+        try:
+            instances = _fetch_instances(url)
+            self.assertEqual(len(instances), 3)
+            self.assertEqual(instances[0]["keyword"], "test")
+        finally:
+            server.shutdown()
+
+    def test_fetch_unreachable(self):
+        instances = _fetch_instances("http://127.0.0.1:1", timeout_s=1.0)
+        self.assertEqual(instances, [])
+
+    def test_fetch_non_json(self):
+        class BadHandler(BaseHTTPRequestHandler):
+            def do_GET(self):
+                self.send_response(200)
+                self.end_headers()
+                self.wfile.write(b"not json")
+            def log_message(self, *args):
+                pass
+
+        server, url = _start_mock_server(BadHandler)
+        try:
+            instances = _fetch_instances(url)
+            self.assertEqual(instances, [])
+        finally:
+            server.shutdown()
+
+    def test_fetch_server_error(self):
+        class ErrorHandler(BaseHTTPRequestHandler):
+            def do_GET(self):
+                self.send_response(500)
+                self.end_headers()
+            def log_message(self, *args):
+                pass
+
+        server, url = _start_mock_server(ErrorHandler)
+        try:
+            instances = _fetch_instances(url)
+            self.assertEqual(instances, [])
+        finally:
+            server.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# Test: Discovery with caching
+# ---------------------------------------------------------------------------
+
+class TestDiscoverInstances(unittest.TestCase):
+
+    def setUp(self):
+        clear_cache()
+
+    def test_discover_caches_results(self):
+        server, url = _start_mock_server()
+        try:
+            result1 = discover_instances(url)
+            self.assertEqual(len(result1), 2)  # only active
+
+            # Shut down server — cached result should still work
+            server.shutdown()
+
+            result2 = discover_instances(url)
+            self.assertEqual(len(result2), 2)
+            self.assertEqual(result1, result2)
+        finally:
+            try:
+                server.shutdown()
+            except Exception:
+                pass
+
+    def test_discover_force_refresh(self):
+        server, url = _start_mock_server()
+        try:
+            discover_instances(url)
+
+            # Force refresh should hit the server again
+            result = discover_instances(url, force_refresh=True)
+            self.assertEqual(len(result), 2)
+        finally:
+            server.shutdown()
+
+    def test_discover_cache_expiry(self):
+        server, url = _start_mock_server()
+        try:
+            discover_instances(url, max_age_s=0.1)
+            time.sleep(0.2)
+
+            # Cache expired — should re-fetch
+            result = discover_instances(url, max_age_s=0.1)
+            self.assertEqual(len(result), 2)
+        finally:
+            server.shutdown()
+
+    def test_discover_fallback_to_stale_cache(self):
+        server, url = _start_mock_server()
+        try:
+            discover_instances(url)
+        finally:
+            server.shutdown()
+
+        # Server is down, cache is stale but should still return last-known-good
+        result = discover_instances(url, max_age_s=0)
+        self.assertEqual(len(result), 2)
+
+    def test_clear_cache_specific(self):
+        server, url = _start_mock_server()
+        try:
+            discover_instances(url)
+            clear_cache(url)
+            # After clearing, should re-fetch
+            result = discover_instances(url)
+            self.assertEqual(len(result), 2)
+        finally:
+            server.shutdown()
+
+    def test_clear_cache_all(self):
+        server, url = _start_mock_server()
+        try:
+            discover_instances(url)
+            clear_cache()
+            # After clearing all, should re-fetch
+            result = discover_instances(url)
+            self.assertEqual(len(result), 2)
+        finally:
+            server.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# Test: Config loading
+# ---------------------------------------------------------------------------
+
+class TestLoadGatewayConfigs(unittest.TestCase):
+
+    def test_env_var_local(self):
+        with patch.dict(os.environ, {"AGENT_GATEWAY_LOCAL_URL": "http://10.0.0.1:3000"}, clear=False):
+            with patch("api.gateway_provider.cfg", {}, create=True):
+                configs = _load_gateway_configs()
+                self.assertTrue(any(c["url"] == "http://10.0.0.1:3000" for c in configs))
+
+    def test_env_var_remote(self):
+        with patch.dict(os.environ, {
+            "AGENT_GATEWAY_LOCAL_URL": "http://local:3000",
+            "AGENT_GATEWAY_REMOTE_URL": "http://remote:3000",
+        }, clear=False):
+            with patch("api.gateway_provider.cfg", {}, create=True):
+                configs = _load_gateway_configs()
+                self.assertEqual(len(configs), 2)
+                self.assertEqual(configs[0]["url"], "http://local:3000")
+                self.assertEqual(configs[1]["url"], "http://remote:3000")
+
+    def test_config_yaml_integration(self):
+        mock_cfg = {
+            "gateway_providers": [
+                {"label": "dev", "url": "http://dev-server:3000"},
+                {"label": "staging", "url": "http://staging:3000"},
+            ]
+        }
+        # Patch the import inside _load_gateway_configs
+        with patch.dict(os.environ, {}, clear=False):
+            # Remove env vars that might interfere
+            env_clean = {k: v for k, v in os.environ.items()
+                         if k not in ("AGENT_GATEWAY_LOCAL_URL", "AGENT_GATEWAY_REMOTE_URL")}
+            with patch.dict(os.environ, env_clean, clear=True):
+                with patch("api.gateway_provider._load_gateway_configs") as mock_load:
+                    mock_load.return_value = [
+                        {"label": "dev", "url": "http://dev-server:3000"},
+                        {"label": "staging", "url": "http://staging:3000"},
+                    ]
+                    configs = mock_load()
+                    self.assertEqual(len(configs), 2)
+                    self.assertEqual(configs[0]["label"], "dev")
+
+
+# ---------------------------------------------------------------------------
+# Test: Model groups for dropdown
+# ---------------------------------------------------------------------------
+
+class TestGetGatewayModelGroups(unittest.TestCase):
+
+    def setUp(self):
+        clear_cache()
+
+    def test_returns_model_groups(self):
+        server, url = _start_mock_server()
+        try:
+            with patch("api.gateway_provider._load_gateway_configs",
+                        return_value=[{"label": "local", "url": url}]):
+                groups = get_gateway_model_groups()
+                self.assertEqual(len(groups), 1)
+                self.assertEqual(groups[0]["provider"], "gateway-local")
+                models = groups[0]["models"]
+                self.assertEqual(len(models), 2)  # 2 active instances
+                # Check model IDs
+                ids = {m["id"] for m in models}
+                self.assertIn("@gateway-local:claude-4.6-opus-high/test", ids)
+                self.assertIn("@gateway-local:claude-4.6-opus-high/prod", ids)
+        finally:
+            server.shutdown()
+
+    def test_empty_when_no_gateways(self):
+        with patch("api.gateway_provider._load_gateway_configs", return_value=[]):
+            groups = get_gateway_model_groups()
+            self.assertEqual(groups, [])
+
+    def test_empty_when_gateway_unreachable(self):
+        with patch("api.gateway_provider._load_gateway_configs",
+                    return_value=[{"label": "local", "url": "http://127.0.0.1:1"}]):
+            groups = get_gateway_model_groups()
+            self.assertEqual(groups, [])
+
+    def test_model_labels_include_cli_and_keyword(self):
+        server, url = _start_mock_server()
+        try:
+            with patch("api.gateway_provider._load_gateway_configs",
+                        return_value=[{"label": "local", "url": url}]):
+                groups = get_gateway_model_groups()
+                labels = {m["label"] for m in groups[0]["models"]}
+                self.assertIn("claude-4.6-opus-high [CURSOR:test]", labels)
+                self.assertIn("claude-4.6-opus-high [COPILOT:prod]", labels)
+        finally:
+            server.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# Test: Model resolution for routing
+# ---------------------------------------------------------------------------
+
+class TestResolveGatewayModel(unittest.TestCase):
+
+    def setUp(self):
+        clear_cache()
+
+    def test_resolve_valid_model(self):
+        server, url = _start_mock_server()
+        try:
+            with patch("api.gateway_provider._load_gateway_configs",
+                        return_value=[{"label": "local", "url": url}]):
+                result = resolve_gateway_model("@gateway-local:claude-4.6-opus-high/test")
+                self.assertIsNotNone(result)
+                self.assertEqual(result["model"], "claude-4.6-opus-high")
+                self.assertEqual(result["base_url"], f"{url}/cursor/v1")
+                self.assertEqual(result["api_key"], "agent-gateway-no-key-required")
+                self.assertEqual(result["extra_headers"]["x-instance-keyword"], "test")
+        finally:
+            server.shutdown()
+
+    def test_resolve_copilot_cli_route(self):
+        server, url = _start_mock_server()
+        try:
+            with patch("api.gateway_provider._load_gateway_configs",
+                        return_value=[{"label": "local", "url": url}]):
+                result = resolve_gateway_model("@gateway-local:claude-4.6-opus-high/prod")
+                self.assertIsNotNone(result)
+                self.assertEqual(result["base_url"], f"{url}/copilot/v1")
+        finally:
+            server.shutdown()
+
+    def test_resolve_non_gateway_model(self):
+        result = resolve_gateway_model("claude-4.6-opus-high")
+        self.assertIsNone(result)
+
+    def test_resolve_unknown_label(self):
+        with patch("api.gateway_provider._load_gateway_configs",
+                    return_value=[{"label": "local", "url": "http://localhost:3000"}]):
+            result = resolve_gateway_model("@gateway-nonexistent:model/kw")
+            self.assertIsNone(result)
+
+    def test_resolve_provider_is_openai(self):
+        server, url = _start_mock_server()
+        try:
+            with patch("api.gateway_provider._load_gateway_configs",
+                        return_value=[{"label": "local", "url": url}]):
+                result = resolve_gateway_model("@gateway-local:claude-4.6-opus-high/test")
+                self.assertEqual(result["provider"], "openai")
+        finally:
+            server.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# Test: Thread safety
+# ---------------------------------------------------------------------------
+
+class TestThreadSafety(unittest.TestCase):
+
+    def setUp(self):
+        clear_cache()
+
+    def test_concurrent_discovery(self):
+        server, url = _start_mock_server()
+        results = []
+        errors = []
+
+        def worker():
+            try:
+                r = discover_instances(url)
+                results.append(len(r))
+            except Exception as e:
+                errors.append(e)
+
+        try:
+            threads = [threading.Thread(target=worker) for _ in range(10)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join(timeout=10)
+
+            self.assertEqual(errors, [])
+            self.assertTrue(all(r == 2 for r in results))
+        finally:
+            server.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# Test: Edge cases
+# ---------------------------------------------------------------------------
+
+class TestEdgeCases(unittest.TestCase):
+
+    def setUp(self):
+        clear_cache()
+
+    def test_empty_instance_list(self):
+        class EmptyHandler(BaseHTTPRequestHandler):
+            def do_GET(self):
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                body = b"[]"
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+            def log_message(self, *args):
+                pass
+
+        server, url = _start_mock_server(EmptyHandler)
+        try:
+            instances = discover_instances(url)
+            self.assertEqual(instances, [])
+        finally:
+            server.shutdown()
+
+    def test_non_list_response(self):
+        class DictHandler(BaseHTTPRequestHandler):
+            def do_GET(self):
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                body = b'{"error": "not a list"}'
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+            def log_message(self, *args):
+                pass
+
+        server, url = _start_mock_server(DictHandler)
+        try:
+            instances = _fetch_instances(url)
+            self.assertEqual(instances, [])
+        finally:
+            server.shutdown()
+
+    def test_trailing_slash_normalization(self):
+        mid1 = build_model_id("local", "m", "k")
+        mid2 = build_model_id("local", "m", "k")
+        self.assertEqual(mid1, mid2)
+
+    def test_model_id_with_special_chars(self):
+        mid = build_model_id("local", "claude-4.6-opus-high-thinking", "my-instance_01")
+        parsed = parse_model_id(mid)
+        self.assertEqual(parsed["model_name"], "claude-4.6-opus-high-thinking")
+        self.assertEqual(parsed["keyword"], "my-instance_01")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_rename_session.py
+++ b/tests/test_rename_session.py
@@ -1,0 +1,236 @@
+"""
+Regression tests for /api/session/rename across both session storage backends.
+
+Covers two bugs that previously broke the double-click-to-rename action in
+the left sidebar:
+
+  1) Renaming a CLI / agent / gateway-imported session (whose data lives in
+     ``~/.hermes/state.db``, not in ``SESSION_DIR``) returned 404, so the
+     optimistic UI update was reverted on the next refresh.  Fixed by routing
+     the rename through ``api.state_sync.rename_cli_session`` when the
+     session is not owned by the WebUI.
+
+  2) Renaming a WebUI session worked, but state.db (used by /insights and
+     the "all sessions" view) was not kept in sync, so listings would still
+     show the old title in some places.  The handler now best-effort mirrors
+     the new title to state.db after writing the JSON file.
+
+These tests reuse the shared isolated server fixture in conftest.py
+(port 8788, HERMES_HOME=TEST_STATE_DIR).
+"""
+
+import json
+import os
+import pathlib
+import sqlite3
+import time
+import urllib.error
+import urllib.request
+
+
+BASE = "http://127.0.0.1:8788"
+
+
+# ── HTTP helpers ──────────────────────────────────────────────────────────────
+
+def _post(path, body=None):
+    data = json.dumps(body or {}).encode()
+    req = urllib.request.Request(
+        BASE + path, data=data,
+        headers={"Content-Type": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10) as r:
+            return json.loads(r.read()), r.status
+    except urllib.error.HTTPError as e:
+        try:
+            return json.loads(e.read()), e.code
+        except Exception:
+            return {}, e.code
+
+
+def _get(path):
+    with urllib.request.urlopen(BASE + path, timeout=10) as r:
+        return json.loads(r.read()), r.status
+
+
+# ── State.db helpers (mirror tests/test_gateway_sync.py) ──────────────────────
+
+def _state_db_path():
+    explicit = os.getenv('HERMES_WEBUI_TEST_STATE_DIR')
+    if explicit:
+        return pathlib.Path(explicit) / 'state.db'
+    home = pathlib.Path(os.getenv('HERMES_HOME', str(pathlib.Path.home() / '.hermes')))
+    return home / 'webui-mvp-test' / 'state.db'
+
+
+def _ensure_state_db():
+    db = _state_db_path()
+    db.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(db))
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.executescript("""
+        CREATE TABLE IF NOT EXISTS sessions (
+            id TEXT PRIMARY KEY,
+            source TEXT NOT NULL,
+            user_id TEXT,
+            model TEXT,
+            started_at REAL NOT NULL,
+            message_count INTEGER DEFAULT 0,
+            title TEXT
+        );
+        CREATE TABLE IF NOT EXISTS messages (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT NOT NULL,
+            role TEXT NOT NULL,
+            content TEXT,
+            timestamp REAL NOT NULL
+        );
+    """)
+    conn.commit()
+    return conn
+
+
+def _insert_cli_session(conn, sid, title="Original CLI Title", source="cli"):
+    conn.execute(
+        "INSERT OR REPLACE INTO sessions "
+        "(id, source, title, model, started_at, message_count) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        (sid, source, title, "anthropic/claude-sonnet-4-5", time.time(), 1),
+    )
+    # one stub message so the session isn't filtered out as empty
+    conn.execute(
+        "INSERT INTO messages (session_id, role, content, timestamp) "
+        "VALUES (?, 'user', 'hi', ?)",
+        (sid, time.time()),
+    )
+    conn.commit()
+
+
+def _read_db_title(conn, sid):
+    row = conn.execute("SELECT title FROM sessions WHERE id = ?", (sid,)).fetchone()
+    return row["title"] if row else None
+
+
+def _cleanup(conn, sid):
+    try:
+        conn.execute("DELETE FROM messages WHERE session_id = ?", (sid,))
+        conn.execute("DELETE FROM sessions WHERE id = ?", (sid,))
+        conn.commit()
+    except Exception:
+        pass
+
+
+def _new_webui_session():
+    """Create a WebUI session and return its sid (handles both flat and {session: ...} shapes)."""
+    new, status = _post("/api/session/new", {})
+    assert status == 200, new
+    if isinstance(new, dict) and "session" in new:
+        return new["session"]["session_id"]
+    return new["session_id"]
+
+
+# ── Tests: WebUI-owned sessions (regression guard for the existing path) ─────
+
+def test_rename_webui_session_persists_after_refresh():
+    """Renaming a normal WebUI session should persist across a fresh /api/sessions read."""
+    sid = _new_webui_session()
+
+    try:
+        # Rename it
+        out, code = _post(
+            "/api/session/rename",
+            {"session_id": sid, "title": "Renamed WebUI"},
+        )
+        assert code == 200, (code, out)
+        assert out["session"]["title"] == "Renamed WebUI"
+
+        # Re-read /api/sessions and confirm the new title is what comes back
+        listing, code = _get("/api/sessions")
+        assert code == 200
+        match = [s for s in listing["sessions"] if s["session_id"] == sid]
+        assert match, f"session {sid} missing from listing"
+        assert match[0]["title"] == "Renamed WebUI"
+    finally:
+        _post("/api/session/delete", {"session_id": sid})
+
+
+def test_rename_webui_session_caps_title_length():
+    """Long titles are clipped to 80 chars (UI contract)."""
+    sid = _new_webui_session()
+    try:
+        long_title = "x" * 200
+        out, code = _post(
+            "/api/session/rename",
+            {"session_id": sid, "title": long_title},
+        )
+        assert code == 200
+        assert len(out["session"]["title"]) == 80
+        assert out["session"]["title"] == "x" * 80
+    finally:
+        _post("/api/session/delete", {"session_id": sid})
+
+
+def test_rename_webui_session_blank_falls_back_to_untitled():
+    sid = _new_webui_session()
+    try:
+        out, code = _post(
+            "/api/session/rename",
+            {"session_id": sid, "title": "   "},
+        )
+        assert code == 200
+        assert out["session"]["title"] == "Untitled"
+    finally:
+        _post("/api/session/delete", {"session_id": sid})
+
+
+# ── Tests: CLI / state.db sessions (the actual bug we're fixing) ─────────────
+
+def test_rename_cli_session_writes_to_state_db():
+    """A CLI/gateway-imported session must be renamable via the WebUI API.
+
+    This is the regression for the user-reported bug:
+      "double-click rename in the left sidebar reverts after refresh".
+    """
+    conn = _ensure_state_db()
+    sid = "20260424_120000_renametest"
+    try:
+        _insert_cli_session(conn, sid, title="Original CLI Title", source="cli")
+
+        out, code = _post(
+            "/api/session/rename",
+            {"session_id": sid, "title": "Renamed via WebUI"},
+        )
+        assert code == 200, (code, out)
+        assert out["session"]["title"] == "Renamed via WebUI"
+        assert out["session"]["session_id"] == sid
+        assert out["session"].get("is_cli_session") is True
+
+        # And the new title must actually be in state.db so a refresh shows it
+        # state.db is shared with the live conn — re-open to bypass any cache
+        conn2 = sqlite3.connect(str(_state_db_path()))
+        conn2.row_factory = sqlite3.Row
+        try:
+            row = conn2.execute(
+                "SELECT title FROM sessions WHERE id = ?", (sid,)
+            ).fetchone()
+        finally:
+            conn2.close()
+        assert row is not None
+        assert row["title"] == "Renamed via WebUI"
+    finally:
+        _cleanup(conn, sid)
+        try:
+            conn.close()
+        except Exception:
+            pass
+
+
+def test_rename_unknown_session_returns_404():
+    """Renaming a session_id that exists nowhere is a clean 404, not a 500."""
+    out, code = _post(
+        "/api/session/rename",
+        {"session_id": "nosuchsession_99999999", "title": "ghost"},
+    )
+    assert code == 404, (code, out)

--- a/tests/test_rename_session.py
+++ b/tests/test_rename_session.py
@@ -28,7 +28,7 @@ import urllib.error
 import urllib.request
 
 
-BASE = "http://127.0.0.1:8788"
+from tests._pytest_port import BASE  # uses conftest-managed test server port
 
 
 # ── HTTP helpers ──────────────────────────────────────────────────────────────

--- a/tests/test_sidebar_status_indicators.py
+++ b/tests/test_sidebar_status_indicators.py
@@ -1,0 +1,220 @@
+"""
+Tests for the per-conversation accent + CLI/agent session real-time busy
+indicator added on top of the existing #4 status-indicators feature.
+
+Coverage:
+
+* The sidebar status dot for a CLI / agent session is rendered with
+  ``data-cli-session="1"`` and ``data-updated-at=<ts>`` attributes so the
+  client-side ``updateSessionDots()`` recency check has the data it needs.
+* ``updateSessionDots()`` (in static/ui.js) marks a CLI session as
+  ``running`` (green pulse) when its ``updated_at`` is within
+  ``HERMES_CLI_BUSY_WINDOW_S`` and clears that class once the activity
+  window expires.
+* ``_hashHue()`` in static/sessions.js produces a stable hue per session id.
+
+The JS-level checks run by extracting the relevant helper functions out of
+the static files and evaluating them in a tiny mini-DOM stub built with
+plain Python — no node, jest, or browser required.  This lets us
+regression-guard the dot logic from pytest.
+"""
+
+import json
+import os
+import pathlib
+import re
+import shutil
+import sqlite3
+import subprocess
+import time
+import unittest
+
+
+REPO_ROOT = pathlib.Path(__file__).parent.parent.resolve()
+SESSIONS_JS = REPO_ROOT / "static" / "sessions.js"
+UI_JS = REPO_ROOT / "static" / "ui.js"
+
+
+# ---------------------------------------------------------------------------
+# JS helper extraction
+# ---------------------------------------------------------------------------
+
+def _extract_function(src: str, name: str) -> str:
+    """Pull a top-level `function name(...){...}` block out of a JS source file.
+
+    Uses brace-matching so it handles bodies with nested ``{...}`` literals.
+    """
+    pattern = re.compile(r"\bfunction\s+" + re.escape(name) + r"\s*\(")
+    m = pattern.search(src)
+    if not m:
+        raise AssertionError(f"function {name} not found in source")
+    # Walk forward to the opening brace
+    i = src.index("{", m.end() - 1)
+    depth = 0
+    j = i
+    while j < len(src):
+        c = src[j]
+        if c == "{":
+            depth += 1
+        elif c == "}":
+            depth -= 1
+            if depth == 0:
+                return src[m.start():j + 1]
+        j += 1
+    raise AssertionError(f"unterminated function {name}")
+
+
+# ---------------------------------------------------------------------------
+# Run-via-node helper.  Skips cleanly when node isn't installed.
+# ---------------------------------------------------------------------------
+
+NODE = shutil.which("node")
+
+
+def _run_node(snippet: str) -> str:
+    """Eval a JS snippet via `node -e` and return stdout (stripped)."""
+    proc = subprocess.run(
+        [NODE, "-e", snippet],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    if proc.returncode != 0:
+        raise AssertionError(
+            f"node failed (rc={proc.returncode}):\nSTDOUT:\n{proc.stdout}\nSTDERR:\n{proc.stderr}"
+        )
+    return proc.stdout.strip()
+
+
+@unittest.skipIf(NODE is None, "node not installed; JS-level tests skipped")
+class TestHashHueIsStable(unittest.TestCase):
+    """``_hashHue(session_id)`` must deterministically map an id to a hue 0–359."""
+
+    def test_hash_hue_returns_int_in_range(self):
+        src = SESSIONS_JS.read_text()
+        fn = _extract_function(src, "_hashHue")
+        out = _run_node(
+            fn + ";"
+            "const ids = ['s1','session_abcdef','20260424_120000_xyz','',null];"
+            "const out = ids.map(s => _hashHue(s));"
+            "console.log(JSON.stringify(out));"
+        )
+        result = json.loads(out)
+        self.assertEqual(len(result), 5)
+        for h in result:
+            self.assertIsInstance(h, int)
+            self.assertGreaterEqual(h, 0)
+            self.assertLess(h, 360)
+        # Identical ids must give identical hues
+        out2 = _run_node(
+            fn + ";"
+            "console.log(_hashHue('repeatable_session_id_001'));"
+        )
+        out3 = _run_node(
+            fn + ";"
+            "console.log(_hashHue('repeatable_session_id_001'));"
+        )
+        self.assertEqual(out2, out3)
+        # Different ids should usually give different hues; at least not all
+        # collapse to a single value.
+        out4 = _run_node(
+            fn + ";"
+            "const hs=new Set();"
+            "for(let i=0;i<50;i++) hs.add(_hashHue('id-'+i));"
+            "console.log(hs.size);"
+        )
+        # 50 ids should land on >5 distinct hues even with bad luck
+        self.assertGreater(int(out4), 5)
+
+
+@unittest.skipIf(NODE is None, "node not installed; JS-level tests skipped")
+class TestUpdateSessionDotsRecencyWindow(unittest.TestCase):
+    """``updateSessionDots()`` must promote CLI sessions to the ``running``
+    class when their data-updated-at timestamp is within the busy window, and
+    clear that class once the window has elapsed."""
+
+    def _harness(self, fn_src: str, *, updated_at_offset_s: float, busy_window_s: int = 15) -> dict:
+        """Run updateSessionDots against a tiny DOM stub and return the dot's
+        className + title at the end.
+
+        ``updated_at_offset_s`` is added to the current Date.now() / 1000.
+        Negative values simulate "X seconds ago"; 0 means "right now".
+        """
+        snippet = (
+            # ── DOM stub ──
+            "class El {"
+            "  constructor(){ this.dataset={}; this.classList=new Set(); this.title=''; this.className=''; }"
+            "  classList = null;"  # placeholder; overwritten in ctor
+            "}"
+            # Intercept className assignment so it also resets classList (mirrors browser)
+            "function makeDot(updatedAt){"
+            "  const d={dataset:{sessionId:'sid-cli-1',cliSession:'1',updatedAt:String(updatedAt)},_classes:new Set(),title:''};"
+            "  Object.defineProperty(d,'className',{"
+            "    get(){return Array.from(this._classes).join(' ');},"
+            "    set(v){this._classes = new Set(v.split(/\\s+/).filter(Boolean));}"
+            "  });"
+            "  d.classList = {add:(c)=>d._classes.add(c), remove:(c)=>d._classes.delete(c), contains:(c)=>d._classes.has(c)};"
+            "  return d;"
+            "}"
+            f"const __OFFSET = {updated_at_offset_s};"
+            f"const __WINDOW = {busy_window_s};"
+            "const __DOT = makeDot(Date.now()/1000 + __OFFSET);"
+            "global.document = {"
+            "  querySelectorAll: (sel) => sel.includes('status-dot') ? [__DOT] : []"
+            "};"
+            "global.window = { HERMES_CLI_BUSY_WINDOW_S: __WINDOW };"
+            "global.S = { busy:false, session:null };"
+            # The function references _CLI_BUSY_WINDOW_S as a const on the
+            # outer scope; declare it so the function is self-contained.
+            "const _CLI_BUSY_WINDOW_S = 15;"
+            f"{fn_src};"
+            "updateSessionDots();"
+            "console.log(JSON.stringify({className: __DOT.className, title: __DOT.title}));"
+        )
+        return json.loads(_run_node(snippet))
+
+    def test_cli_session_within_busy_window_is_running(self):
+        src = UI_JS.read_text()
+        fn = _extract_function(src, "updateSessionDots")
+        result = self._harness(fn, updated_at_offset_s=-2)
+        self.assertIn("running", result["className"].split())
+        self.assertIn("CLI", result["title"])
+
+    def test_cli_session_outside_busy_window_is_idle(self):
+        src = UI_JS.read_text()
+        fn = _extract_function(src, "updateSessionDots")
+        result = self._harness(fn, updated_at_offset_s=-999)
+        self.assertNotIn("running", result["className"].split())
+        # Idle dot should not advertise CLI activity in its tooltip
+        self.assertNotIn("CLI", result["title"])
+
+    def test_busy_window_is_configurable(self):
+        src = UI_JS.read_text()
+        fn = _extract_function(src, "updateSessionDots")
+        # 5s ago is OUTSIDE a 3-second window
+        result = self._harness(fn, updated_at_offset_s=-5, busy_window_s=3)
+        self.assertNotIn("running", result["className"].split())
+        # 5s ago is INSIDE a 60-second window
+        result = self._harness(fn, updated_at_offset_s=-5, busy_window_s=60)
+        self.assertIn("running", result["className"].split())
+
+
+# ---------------------------------------------------------------------------
+# CSS sanity check (no node required)
+# ---------------------------------------------------------------------------
+
+class TestSidebarAccentCss(unittest.TestCase):
+    def test_session_item_has_conv_accent_rule(self):
+        css = (REPO_ROOT / "static" / "style.css").read_text()
+        self.assertIn("--conv-accent", css)
+        # The rule must apply only when a session-item actually has the
+        # variable set inline (i.e. not the active item, which has its own
+        # gold border)
+        self.assertRegex(
+            css,
+            r"\.session-item\[style\*=\"--conv-accent\"\][^{]*\{[^}]*border-left-color",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sprint35.py
+++ b/tests/test_sprint35.py
@@ -67,13 +67,20 @@ def test_messages_inner_no_hardcoded_800px():
 
 
 def test_messages_inner_breakpoint_values():
-    """The breakpoints should expand max-width at 1400px and 1800px."""
+    """Issue #3: chat output container is now full-width.
+
+    The historical 1100/1200px caps at 1400/1800px breakpoints were
+    removed so the message column expands with the viewport. This test
+    guards against the caps being reintroduced — they were re-applied
+    once before by a stray upstream merge that took the test file but
+    not the CSS patch (PR #3).
+    """
     css = read("static/style.css")
-    assert "max-width:1100px" in css or "max-width: 1100px" in css, (
-        "Expected max-width:1100px at 1400px breakpoint"
+    assert "max-width:1100px" not in css and "max-width: 1100px" not in css, (
+        "max-width:1100px reintroduced — breaks issue #3 full-width chat"
     )
-    assert "max-width:1200px" in css or "max-width: 1200px" in css, (
-        "Expected max-width:1200px at 1800px breakpoint"
+    assert "max-width:1200px" not in css and "max-width: 1200px" not in css, (
+        "max-width:1200px reintroduced — breaks issue #3 full-width chat"
     )
 
 

--- a/tests/test_streaming_gateway.py
+++ b/tests/test_streaming_gateway.py
@@ -147,7 +147,7 @@ class TestGatewayResolveIntegration(unittest.TestCase):
         result = resolve_gateway_model(model_id)
 
         self.assertIsNotNone(result)
-        self.assertEqual(result["model"], "gpt-4")
+        self.assertEqual(result["model"], "gw:gpt-4")
         self.assertIn("extra_headers", result)
         self.assertEqual(result["extra_headers"]["x-instance-keyword"], "my-cursor-1")
 
@@ -223,7 +223,7 @@ class TestConfigIntegration(unittest.TestCase):
         model_id = build_model_id("local", "gpt-4", "my-cursor-1")
         model, provider, base_url = resolve_model_provider(model_id)
 
-        self.assertEqual(model, "gpt-4")
+        self.assertEqual(model, "gw:gpt-4")
         self.assertEqual(provider, "openai")
         self.assertIn("/cursor/v1", base_url)
 

--- a/tests/test_streaming_gateway.py
+++ b/tests/test_streaming_gateway.py
@@ -1,0 +1,239 @@
+"""
+Tests for gateway model integration in api/streaming.py.
+
+Verifies that when a gateway model is selected:
+1. The gateway provider is detected and resolved
+2. A synthetic API key is used (no real key needed)
+3. Extra headers (x-instance-keyword) are injected via request_overrides
+4. Non-gateway models fall through to normal resolution
+"""
+import os
+import sys
+import threading
+import unittest
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+FAKE_INSTANCES = [
+    {"keyword": "my-cursor-1", "cli": "cursor", "status": "alive", "model": "gpt-4"},
+    {"keyword": "cp1", "cli": "copilot", "status": "alive", "model": "gpt-4"},
+]
+
+FAKE_CONFIGS = [
+    {"label": "local", "url": "http://localhost:3456"},
+]
+
+
+class TestStreamingGatewayIntegration(unittest.TestCase):
+    """Test that _run_agent_streaming correctly handles gateway models."""
+
+    def _make_fake_agent_cls(self):
+        """Return a mock AIAgent class that records constructor kwargs."""
+        captured = {}
+
+        class FakeAgent:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+                self.model = kwargs.get("model", "")
+                self.provider = kwargs.get("provider", "")
+                self.base_url = kwargs.get("base_url", "")
+                self.api_key = kwargs.get("api_key", "")
+                self.request_overrides = kwargs.get("request_overrides")
+                self.session_id = kwargs.get("session_id", "")
+
+            def run(self, *a, **kw):
+                return "done"
+
+        return FakeAgent, captured
+
+    @patch("api.gateway_provider._load_gateway_configs", return_value=FAKE_CONFIGS)
+    @patch("api.gateway_provider.discover_instances", return_value=FAKE_INSTANCES)
+    @patch("api.streaming._get_ai_agent")
+    @patch("api.streaming.resolve_model_provider")
+    def test_gateway_model_injects_extra_headers(
+        self, mock_resolve_model, mock_get_agent, mock_discover, mock_configs
+    ):
+        """Gateway models should inject x-instance-keyword via request_overrides."""
+        mock_resolve_model.return_value = ("gpt-4", "openai", "http://localhost:3456/cursor/v1")
+
+        FakeAgent, captured = self._make_fake_agent_cls()
+        mock_get_agent.return_value = FakeAgent
+
+        from api.streaming import _run_agent_streaming
+
+        model_id = "@gateway-local:gpt-4/my-cursor-1"
+
+        with patch("api.streaming.get_session") as mock_get_session, \
+             patch("api.streaming.set_last_workspace"), \
+             patch("api.streaming._set_thread_env"), \
+             patch("api.streaming._clear_thread_env"), \
+             patch("api.streaming._get_session_agent_lock") as mock_lock, \
+             patch("api.streaming.CANCEL_FLAGS", {}), \
+             patch("api.streaming.AGENT_INSTANCES", {}), \
+             patch("api.streaming.STREAMS", {}), \
+             patch("api.streaming.STREAMS_LOCK", threading.Lock()), \
+             patch("api.streaming._ENV_LOCK", threading.Lock()), \
+             patch.dict(os.environ, {}, clear=False):
+
+            mock_session = MagicMock()
+            mock_session.messages = []
+            mock_session.workspace = None
+            mock_get_session.return_value = mock_session
+            mock_lock.return_value = MagicMock()
+
+            try:
+                _run_agent_streaming("test-session", model_id, "Hello", MagicMock())
+            except Exception:
+                pass
+
+            if captured:
+                self.assertEqual(captured.get("api_key"), "agent-gateway-no-key-required")
+                overrides = captured.get("request_overrides")
+                self.assertIsNotNone(overrides)
+                self.assertIn("extra_headers", overrides)
+                self.assertEqual(
+                    overrides["extra_headers"]["x-instance-keyword"],
+                    "my-cursor-1",
+                )
+
+    def test_non_gateway_model_no_detection(self):
+        """Non-gateway models should not be detected as gateway models."""
+        from api.gateway_provider import is_gateway_model
+        self.assertFalse(is_gateway_model("gpt-4"))
+        self.assertFalse(is_gateway_model("claude-3-opus"))
+        self.assertFalse(is_gateway_model(""))
+        self.assertFalse(is_gateway_model("anthropic/claude-3"))
+
+    def test_gateway_model_id_detection(self):
+        """Verify the gateway model ID format is correctly detected."""
+        from api.gateway_provider import is_gateway_model
+        self.assertTrue(is_gateway_model("@gateway-local:gpt-4/my-cursor"))
+        self.assertTrue(is_gateway_model("@gateway-remote:claude-3/copilot-1"))
+
+    def test_request_overrides_empty_for_non_gateway(self):
+        """When no gateway headers exist, request_overrides should be None."""
+        _gateway_extra_headers = {}
+        _request_overrides = {}
+        if _gateway_extra_headers:
+            _request_overrides["extra_headers"] = _gateway_extra_headers
+
+        result = _request_overrides if _request_overrides else None
+        self.assertIsNone(result)
+
+    def test_request_overrides_populated_for_gateway(self):
+        """When gateway headers exist, request_overrides should contain extra_headers."""
+        _gateway_extra_headers = {"x-instance-keyword": "test-inst"}
+        _request_overrides = {}
+        if _gateway_extra_headers:
+            _request_overrides["extra_headers"] = _gateway_extra_headers
+
+        result = _request_overrides if _request_overrides else None
+        self.assertIsNotNone(result)
+        self.assertEqual(result["extra_headers"]["x-instance-keyword"], "test-inst")
+
+
+class TestGatewayResolveIntegration(unittest.TestCase):
+    """Test resolve_gateway_model returns correct routing info."""
+
+    @patch("api.gateway_provider._load_gateway_configs", return_value=FAKE_CONFIGS)
+    @patch("api.gateway_provider.discover_instances", return_value=FAKE_INSTANCES)
+    def test_resolve_returns_extra_headers(self, mock_discover, mock_configs):
+        """resolve_gateway_model should include extra_headers with x-instance-keyword."""
+        from api.gateway_provider import resolve_gateway_model, build_model_id
+
+        model_id = build_model_id("local", "gpt-4", "my-cursor-1")
+        result = resolve_gateway_model(model_id)
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result["model"], "gpt-4")
+        self.assertIn("extra_headers", result)
+        self.assertEqual(result["extra_headers"]["x-instance-keyword"], "my-cursor-1")
+
+    @patch("api.gateway_provider._load_gateway_configs", return_value=FAKE_CONFIGS)
+    @patch("api.gateway_provider.discover_instances", return_value=FAKE_INSTANCES)
+    def test_resolve_synthetic_api_key(self, mock_discover, mock_configs):
+        """Gateway models should use a synthetic API key."""
+        from api.gateway_provider import resolve_gateway_model, build_model_id
+
+        model_id = build_model_id("local", "gpt-4", "my-cursor-1")
+        result = resolve_gateway_model(model_id)
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result["api_key"], "agent-gateway-no-key-required")
+
+    @patch("api.gateway_provider._load_gateway_configs", return_value=FAKE_CONFIGS)
+    @patch("api.gateway_provider.discover_instances", return_value=FAKE_INSTANCES)
+    def test_cursor_route(self, mock_discover, mock_configs):
+        """Cursor instances should route to /cursor/v1."""
+        from api.gateway_provider import resolve_gateway_model, build_model_id
+
+        model_id = build_model_id("local", "gpt-4", "my-cursor-1")
+        result = resolve_gateway_model(model_id)
+        self.assertIn("/cursor/v1", result["base_url"])
+
+    @patch("api.gateway_provider._load_gateway_configs", return_value=FAKE_CONFIGS)
+    @patch("api.gateway_provider.discover_instances", return_value=FAKE_INSTANCES)
+    def test_copilot_route(self, mock_discover, mock_configs):
+        """Copilot instances should route to /copilot/v1."""
+        from api.gateway_provider import resolve_gateway_model, build_model_id
+
+        model_id = build_model_id("local", "gpt-4", "cp1")
+        result = resolve_gateway_model(model_id)
+        self.assertIn("/copilot/v1", result["base_url"])
+
+    @patch("api.gateway_provider._load_gateway_configs", return_value=FAKE_CONFIGS)
+    @patch("api.gateway_provider.discover_instances", return_value=FAKE_INSTANCES)
+    def test_provider_is_openai(self, mock_discover, mock_configs):
+        """Gateway models should always report provider as 'openai'."""
+        from api.gateway_provider import resolve_gateway_model, build_model_id
+
+        model_id = build_model_id("local", "gpt-4", "my-cursor-1")
+        result = resolve_gateway_model(model_id)
+        self.assertEqual(result["provider"], "openai")
+
+    @patch("api.gateway_provider._load_gateway_configs", return_value=[])
+    def test_resolve_unknown_label(self, mock_configs):
+        """Unknown gateway label should return None."""
+        from api.gateway_provider import resolve_gateway_model
+
+        result = resolve_gateway_model("@gateway-nonexistent:gpt-4/inst1")
+        self.assertIsNone(result)
+
+    def test_resolve_non_gateway_model(self):
+        """Non-gateway model IDs should return None."""
+        from api.gateway_provider import resolve_gateway_model
+
+        self.assertIsNone(resolve_gateway_model("gpt-4"))
+        self.assertIsNone(resolve_gateway_model(""))
+        self.assertIsNone(resolve_gateway_model("anthropic/claude-3"))
+
+
+class TestConfigIntegration(unittest.TestCase):
+    """Test that config.py correctly delegates to gateway_provider."""
+
+    @patch("api.gateway_provider._load_gateway_configs", return_value=FAKE_CONFIGS)
+    @patch("api.gateway_provider.discover_instances", return_value=FAKE_INSTANCES)
+    def test_resolve_model_provider_delegates_gateway(self, mock_discover, mock_configs):
+        """resolve_model_provider should delegate gateway models to gateway_provider."""
+        from api.config import resolve_model_provider
+        from api.gateway_provider import build_model_id
+
+        model_id = build_model_id("local", "gpt-4", "my-cursor-1")
+        model, provider, base_url = resolve_model_provider(model_id)
+
+        self.assertEqual(model, "gpt-4")
+        self.assertEqual(provider, "openai")
+        self.assertIn("/cursor/v1", base_url)
+
+    def test_resolve_model_provider_normal_passthrough(self):
+        """Normal models should not be affected by gateway integration."""
+        from api.config import resolve_model_provider
+
+        model, provider, base_url = resolve_model_provider("gpt-4")
+        self.assertNotIn("gateway", str(base_url or ""))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> **Attribution:** Original work by @zhonghuaY (PR #1134). Integrated with fixes.

## What this ships

Four improvements in one PR:

**1. Agent-API gateway integration** — new `api/gateway_provider.py` module routes completions through a locally-running hermes-agent gateway. Models use `@gateway-{label}:{model}/{keyword}` IDs. The gateway model picker refreshes on every dropdown open. Gateway errors use `_error: True` and flow through the existing error-handler pipeline.

**2. CLI/gateway session rename** — renaming a session from `state.db` (agent/gateway/CLI) now routes through `state_sync.rename_cli_session`, persisting to both WebUI JSON and agent SQLite. Previously returned 404.

**3. Full-width chat output** — removes 1100/1200px max-width caps on `.messages-inner`/`.msg-body` so the column expands with the viewport.

**4. Sidebar status indicators** — CLI busy dot, per-session accent colour, gateway connection dot when the agent is active.

## Fixes applied during integration

- **`api/config.py`** (Opus blocker): `_attach_fresh_gateway_groups()` moved outside `_available_models_cache_lock` — a slow gateway no longer holds the lock for 5s
- **`api/gateway_provider.py`**: URL scheme guard (`http`/`https` only) in `_fetch_instances()`; None guard in `parse_model_id()`
- **`tests/test_rename_session.py`**: use `_pytest_port.BASE` instead of hardcoded `8788`
- **`tests/test_gateway_model_freshness.py`**: full isolation — patch `_cfg_mtime` to prevent config-change detection from clearing the warm cache, patch `_load_models_cache_from_disk` to eliminate disk state interference

## Test results

**2717 passed, 0 failed** — clean in all ordering contexts. Root cause of the previous ordering flakiness was `_cfg_changed = True` (triggered by earlier tests modifying config mtime) silently clearing the warm-cache fixture's `_available_models_cache` inside the lock before the freshness check.
