### PR TITLE
fix(css): prevent iOS auto-zoom on input focus (#1167)

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -2353,3 +2353,14 @@ main.main > .main-view:not([id="mainChat"]):not([id="mainSettings"]) .main-view-
   .queue-pill:hover{background:color-mix(in srgb,var(--hover-bg) 60%,var(--surface));}
   .queue-pill-count{color:var(--text);}
   .queue-pill-chevron{margin-left:auto;opacity:.5;}
+
+/* ── Mobile: prevent iOS auto-zoom on input focus ─────────────────────────
+   iOS Safari zooms in when a focused input/select has font-size < 16px.
+   This media query targets touch-primary devices (phones and tablets) and
+   bumps all interactive inputs to the minimum non-zoom threshold.
+   The textarea#msg composer is already 16px; the sidebar search, rename
+   inputs, settings selects, and dialog inputs are not.  (#1167)
+──────────────────────────────────────────────────────────────────────── */
+@media (hover:none) and (pointer:coarse){
+  input,textarea,select{font-size:max(16px,1em)!important;}
+}

--- a/tests/test_mobile_layout.py
+++ b/tests/test_mobile_layout.py
@@ -232,6 +232,30 @@ def test_composer_textarea_font_size_mobile():
         "Composer textarea must have font-size:16px at mobile widths to prevent iOS zoom-on-focus"
 
 
+def test_touch_device_inputs_meet_zoom_threshold():
+    """All input/textarea/select must clear iOS Safari's 16px zoom threshold
+    on touch-primary devices, not just the composer textarea (#1167).
+
+    This locks the global media-query floor so future per-element font-size
+    tweaks (sidebar search 13px, settings selects 12px, dialog inputs 14px,
+    onboarding fields 13px) cannot accidentally re-introduce auto-zoom.
+    """
+    # The hover:none + pointer:coarse pair is the canonical touch-primary
+    # detection (won't match desktop with mouse, won't match touch laptops
+    # that report hover:hover).
+    pattern = re.compile(
+        r'@media\s*\(hover:none\)\s*and\s*\(pointer:coarse\)\s*\{[^}]*'
+        r'input\s*,\s*textarea\s*,\s*select\s*\{[^}]*'
+        r'font-size:\s*max\(\s*16px',
+        re.DOTALL,
+    )
+    assert pattern.search(CSS), (
+        "style.css must contain a (hover:none) and (pointer:coarse) media "
+        "query that bumps input/textarea/select to font-size:max(16px,…) "
+        "so iOS Safari does not auto-zoom on focus (#1167)"
+    )
+
+
 
 # ── Sidebar tabs on mobile ───────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Fixes the mobile viewport zoom issue where tapping any input field (sidebar search, session rename, settings fields, selects) causes iOS Safari to zoom in and not reset after blur.

## Root cause

iOS Safari automatically zooms in when a focused `<input>`, `<textarea>`, or `<select>` has `font-size < 16px`. It doesn't un-zoom after blur. The `textarea#msg` composer was already `16px` and unaffected. The triggering elements were:

| Element | Current font-size |
|---|---|
| `.sidebar-search input` | 13px |
| `.session-title-input` (rename) | 13px |
| `select` (settings dropdowns) | 12px |
| `.app-dialog-input` | 14px |
| `.onboarding-field input/select` | 13px |

## Fix

One CSS media query at the end of `style.css` targeting touch-primary devices:

```css
@media (hover:none) and (pointer:coarse) {
  input, textarea, select { font-size: max(16px, 1em) !important; }
}
```

`(hover:none) and (pointer:coarse)` is the canonical way to target touch devices (phones, tablets) without affecting desktop browsers at any viewport width. `max(16px, 1em)` ensures the floor is met while respecting any larger user-configured font size.

## Testing

- 2644 tests passing.
- Manual: tap sidebar search on iPhone → no zoom. Tap rename input → no zoom. Tap settings select → no zoom.

Closes #1167
