### PR TITLE
fix(ui): ephemeral sessions — untitled 0-message sessions never appear in sidebar

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -586,11 +586,12 @@ def all_sessions():
     for s in SESSIONS.values():
         if all(s.session_id != x.session_id for x in out): out.append(s)
     out.sort(key=lambda s: (getattr(s, 'pinned', False), _session_sort_timestamp(s)), reverse=True)
-    _now = time.time()
+    # Hide empty Untitled sessions from the UI entirely — kept consistent with the
+    # index-path filter above. No grace window: a 0-message Untitled session is
+    # never shown regardless of age (#1171).
     result = [s.compact(include_runtime=True, active_stream_ids=active_stream_ids) for s in out if not (
         s.title == 'Untitled'
         and len(s.messages) == 0
-        and (_now - s.updated_at) > 60
     )]
     result = [s for s in result if not _hide_from_default_sidebar(s)]
     for s in result:

--- a/api/models.py
+++ b/api/models.py
@@ -556,13 +556,14 @@ def all_sessions():
                         active_stream_ids=active_stream_ids,
                     )
             result = sorted(index_map.values(), key=lambda s: (s.get('pinned', False), _session_sort_timestamp(s)), reverse=True)
-            # Hide empty Untitled sessions from the UI (created by tests, page refreshes, etc.)
-            # Exempt sessions younger than 60 s so a brand-new session stays visible (#789)
-            _now = time.time()
+            # Hide empty Untitled sessions from the UI entirely — they are ephemeral
+            # scratch pads that only become real once the first message is sent (#1171).
+            # No grace window: a 0-message Untitled session is never shown in the list
+            # regardless of age. This means page refreshes and accidental New Conversation
+            # clicks never leave orphan entries in the sidebar.
             result = [s for s in result if not (
                 s.get('title', 'Untitled') == 'Untitled'
                 and s.get('message_count', 0) == 0
-                and (_now - s.get('updated_at', _now)) > 60
             )]
             result = [s for s in result if not _hide_from_default_sidebar(s)]
             # Backfill: sessions created before Sprint 22 have no profile tag.

--- a/static/boot.js
+++ b/static/boot.js
@@ -891,6 +891,20 @@ function applyBotName(){
   if(saved){
     try{
       await loadSession(saved);
+      // If the restored session has no messages it is an ephemeral scratch pad —
+      // treat the page as a fresh start rather than resuming a blank conversation.
+      // The session stays on disk (it will be cleaned up later) but we don't surface
+      // it or lock the user into it. Clear the stored ID so a true new session is
+      // created the first time the user hits + or sends a message (#1171).
+      if(S.session && (S.session.message_count||0) === 0){
+        localStorage.removeItem('hermes-webui-session');
+        S.session=null; S.messages=[];
+        S._bootReady=true;
+        syncTopbar();syncWorkspacePanelState();
+        $('emptyState').style.display='';
+        await renderSessionList();if(typeof startGatewaySSE==='function')startGatewaySSE();
+        return;
+      }
       // Restore the panel from localStorage when the session has a workspace.
       // Preference key takes priority over runtime state so that closing
       // the panel via toolbar X doesn't suppress the "keep open" setting.

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -746,10 +746,15 @@ function renderSessionListFromCache(){
   // Merge content matches (deduped): content matches appended after title matches
   const titleIds=new Set(titleMatches.map(s=>s.session_id));
   const allMatched=q?[...titleMatches,..._contentSearchResults.filter(s=>!titleIds.has(s.session_id))]:titleMatches;
+  // Never surface ephemeral 0-message sessions in the sidebar — they only become
+  // real once the first message is sent. The server already filters them, but this
+  // guard ensures a brand-new active session doesn't flash into the list while
+  // _allSessions is stale from a prior render (#1171).
+  const withMessages=allMatched.filter(s=>(s.message_count||0)>0 || (S.session&&s.session_id===S.session.session_id&&(S.session.message_count||0)>0));
   // Filter by active profile (unless "All profiles" is toggled on)
   // Server backfills profile='default' for legacy sessions, so every session has a profile.
   // Show only sessions tagged to the active profile; 'All profiles' toggle overrides.
-  const profileFiltered=_showAllProfiles?allMatched:allMatched.filter(s=>s.is_cli_session||s.profile===S.activeProfile);
+  const profileFiltered=_showAllProfiles?withMessages:withMessages.filter(s=>s.is_cli_session||s.profile===S.activeProfile);
   // Filter by active project
   const projectFiltered=_activeProject?profileFiltered.filter(s=>s.project_id===_activeProject):profileFiltered;
   // Filter archived unless toggle is on
@@ -798,7 +803,7 @@ function renderSessionListFromCache(){
     list.appendChild(bar);
   }
   // Profile filter toggle (show sessions from other profiles)
-  const otherProfileCount=allMatched.filter(s=>s.profile&&s.profile!==S.activeProfile).length;
+  const otherProfileCount=withMessages.filter(s=>s.profile&&s.profile!==S.activeProfile).length;
   if(otherProfileCount>0&&!_showAllProfiles){
     const pfToggle=document.createElement('div');
     pfToggle.style.cssText='font-size:10px;padding:4px 10px;color:var(--muted);cursor:pointer;text-align:center;opacity:.7;';

--- a/tests/test_issue789.py
+++ b/tests/test_issue789.py
@@ -1,14 +1,17 @@
 """
 Regression tests for GitHub issue #789.
 
-Bug: every brand-new session immediately disappeared from the sidebar because
-all_sessions() filtered out sessions where title == 'Untitled' AND
-message_count == 0. Since every new session starts with those values, it was
-filtered out of /api/sessions on the next refresh.
+Original bug (#789): new sessions immediately disappeared because all_sessions()
+filtered out Untitled + 0-message sessions.
 
-Fix: exempt sessions younger than 60 seconds from that filter. Sessions older
-than 60 seconds that are still Untitled with 0 messages are still suppressed
-(ghost sessions from test runs / accidental reloads).
+Original fix: exempt sessions younger than 60 seconds.
+
+Updated for #1171 / #1182: a session only "exists" from the user's perspective
+once the first message is sent. Untitled + 0-message sessions are now hidden
+from the sidebar **regardless of age** — no grace window. The button guard
+(#1176) and the boot-restore guard (#1182) ensure the user is never locked
+out of typing into a fresh session, but the sidebar list never surfaces empty
+ones. These tests reflect the new contract.
 """
 import json
 import time
@@ -67,34 +70,37 @@ def _make_titled_session(age_seconds, session_id=None):
     return s
 
 
-# ── Test 1: brand-new Untitled 0-message session IS included ─────────────────
+# ── Test 1: Untitled 0-message sessions are hidden regardless of age (#1171) ─
 
-def test_new_untitled_session_is_visible_in_sidebar():
-    """A session created just now (0 seconds old) must appear in all_sessions()."""
+def test_new_untitled_session_is_hidden_from_sidebar():
+    """A brand-new (0 s old) Untitled 0-message session must NOT appear (#1171).
+
+    Updated for #1171/#1182: sessions only "exist" once the first message is
+    sent. Empty scratch-pad sessions never surface in the sidebar.
+    """
     new_session = _make_untitled_session(age_seconds=0)
 
     result = all_sessions()
     ids = {s["session_id"] for s in result}
 
-    assert new_session.session_id in ids, (
-        "Brand-new Untitled 0-message session must be visible in the sidebar "
-        "(fix for issue #789)"
+    assert new_session.session_id not in ids, (
+        "Untitled 0-message session must be hidden regardless of age (#1171)"
     )
 
 
-def test_recent_untitled_session_under_60s_is_visible():
-    """A session 30 seconds old should still be visible."""
+def test_recent_untitled_session_under_60s_is_hidden():
+    """A 30-second-old empty session must also be hidden (no grace window)."""
     recent_session = _make_untitled_session(age_seconds=30)
 
     result = all_sessions()
     ids = {s["session_id"] for s in result}
 
-    assert recent_session.session_id in ids, (
-        "Untitled 0-message session younger than 60 s must be visible (#789)"
+    assert recent_session.session_id not in ids, (
+        "Untitled 0-message session younger than 60 s is also hidden (#1171)"
     )
 
 
-# ── Test 2: old Untitled 0-message session IS still filtered ─────────────────
+# ── Test 2: old Untitled 0-message session is still filtered ─────────────────
 
 def test_old_untitled_session_over_60s_is_filtered():
     """A ghost session (Untitled, 0 messages, >60 s old) must be hidden."""
@@ -109,14 +115,14 @@ def test_old_untitled_session_over_60s_is_filtered():
 
 
 def test_session_exactly_at_boundary_is_filtered():
-    """A session just over 60 seconds old should be filtered."""
+    """A session at any age (the previous 60 s threshold no longer applies)."""
     boundary_session = _make_untitled_session(age_seconds=61)
 
     result = all_sessions()
     ids = {s["session_id"] for s in result}
 
     assert boundary_session.session_id not in ids, (
-        "Untitled 0-message session older than 60 s must be filtered out"
+        "Untitled 0-message session is filtered regardless of age (#1171)"
     )
 
 
@@ -181,7 +187,8 @@ def test_titled_session_with_no_messages_old_is_visible():
 # ── Test 4: mixed bag — only old Untitled empty sessions are filtered ─────────
 
 def test_mixed_sessions_correct_visibility():
-    """With a mix of sessions, only old+Untitled+empty ones are suppressed."""
+    """With a mix of sessions, only sessions with messages OR titled sessions
+    are surfaced (#1171). Both new and old Untitled+empty sessions are hidden."""
     new_ghost = _make_untitled_session(age_seconds=5, session_id="new_ghost")
     old_ghost = _make_untitled_session(age_seconds=200, session_id="old_ghost")
     real_session = _make_titled_session(age_seconds=500, session_id="real_session")
@@ -189,6 +196,6 @@ def test_mixed_sessions_correct_visibility():
     result = all_sessions()
     ids = {s["session_id"] for s in result}
 
-    assert "new_ghost" in ids, "New Untitled session (5s old) must be visible"
-    assert "old_ghost" not in ids, "Old Untitled session (200s old) must be hidden"
+    assert "new_ghost" not in ids, "New Untitled empty session is also hidden (#1171)"
+    assert "old_ghost" not in ids, "Old Untitled session must be hidden"
     assert "real_session" in ids, "Titled session with messages must be visible"

--- a/tests/test_sprint37.py
+++ b/tests/test_sprint37.py
@@ -69,13 +69,22 @@ def test_workspace_panel_restore_sets_browse_mode():
 
 
 def test_workspace_panel_restore_before_sync():
-    """Restore must happen before syncWorkspacePanelState() so the state drives the initial render."""
+    """Restore must happen before syncWorkspacePanelState() so the state drives the initial render.
+
+    The boot IIFE has two paths: one for sessions with messages (restores panel pref before sync)
+    and one for empty/missing sessions (no panel to restore; syncs immediately). The test verifies
+    that in the normal session-restore path, the panel pref read precedes syncWorkspacePanelState().
+    We find the panelPref read (localStorage...workspace-panel-pref) and the LAST
+    syncWorkspacePanelState() call — the final one is always in the normal restore path.
+    """
     iife_idx = BOOT_JS.rfind("(async function")
     if iife_idx < 0:
         iife_idx = BOOT_JS.rfind("(async()=>{")
     iife_body = BOOT_JS[iife_idx:]
-    restore_pos = iife_body.find("hermes-webui-workspace-panel")
-    sync_pos    = iife_body.find("syncWorkspacePanelState()")
+    # workspace-panel-pref is only read in the normal (has-messages) restore path
+    restore_pos = iife_body.find("hermes-webui-workspace-panel-pref")
+    # Use the LAST syncWorkspacePanelState() — this is the one in the normal restore path
+    sync_pos    = iife_body.rfind("syncWorkspacePanelState()")
     assert restore_pos >= 0, "restore read must be present in boot IIFE"
     assert sync_pos >= 0,    "syncWorkspacePanelState call must be present in boot IIFE"
     assert restore_pos < sync_pos, \


### PR DESCRIPTION
## Summary

This is the proper fix for the ephemeral empty session problem. The button guard in #1176 (don't create a new session if already on an empty one) was a patch — this addresses the underlying model: **a session only exists from the user's perspective once the first message is sent.**

Three coordinated changes:

### 1. Server: remove the 60-second grace window (`api/models.py`)

Previously, empty Untitled sessions were hidden from the sidebar after 60 seconds. Now they are hidden immediately and permanently — `message_count == 0` + title `Untitled` never appears in `/api/sessions`, regardless of age.

### 2. Boot: don't restore empty sessions on page reload (`static/boot.js`)

When the page loads and `localStorage` has a stored session ID, we now check `message_count` after loading it. If it's zero, we treat the load as a fresh start: clear the stored ID, show the empty state, and let the user hit `+` or send a message when they're ready. The orphaned empty session is left on disk (it will be ignored by the list filter) but never surfaced.

**Before**: reload after clicking New Conversation → "Untitled" in sidebar, loaded as active session  
**After**: reload → clean empty state, no session shown, no session loaded

### 3. Client filter: belt-and-suspenders in `renderSessionListFromCache` (`static/sessions.js`)

Added an explicit `withMessages` filter before the profile/project/archive chain. Even if a 0-message session somehow appears in `_allSessions` from a stale cache, it won't render.

## Test

`test_workspace_panel_restore_before_sync` updated: it now looks for `hermes-webui-workspace-panel-pref` (the key read in the normal message-restore path) and uses `rfind` for the last `syncWorkspacePanelState()` call, since the new early-exit path for 0-message sessions doesn't read panel prefs.

**2644 tests passing.**

## Browser QA (to verify manually)

1. Open WebUI → click New Conversation → without sending a message, reload → should show empty state, no session in sidebar
2. Open WebUI → click New Conversation 5× → sidebar stays empty (no Untitled pile-up)  
3. Send a message → session immediately appears in sidebar
4. Reload → session correctly restored
