### PR TITLE
fix(ui): workspace panel persists across reload on empty-session boot

### DIFF
--- a/static/boot.js
+++ b/static/boot.js
@@ -62,14 +62,19 @@ function syncWorkspacePanelState(){
     return;
   }
   if(!S.session){
-    _setWorkspacePanelMode('closed');
+    // No active session — if the panel was explicitly opened (browse mode), keep it
+    // open so the workspace pane doesn't vanish on a fresh-page or empty-session boot.
+    // The file tree will show the "no workspace" placeholder naturally via renderFileTree().
+    // Only force-close if the mode is 'preview' (file preview without a session is invalid).
+    if(_workspacePanelMode==='preview') _setWorkspacePanelMode('closed');
+    else syncWorkspacePanelUI();
     return;
   }
   _setWorkspacePanelMode(_workspacePanelMode==='preview'?'closed':_workspacePanelMode);
 }
 
 function openWorkspacePanel(mode='browse'){
-  if(mode==='browse'&&!S.session&&!_hasWorkspacePreviewVisible())return;
+  if(mode==='browse'&&!S.session&&!_hasWorkspacePreviewVisible()&&!S._profileDefaultWorkspace)return;
   if(mode==='preview'&&_workspacePanelMode==='browse'){
     syncWorkspacePanelUI();
     return;
@@ -101,7 +106,7 @@ function syncWorkspacePanelUI(){
   const mobileOpen=panel.classList.contains('mobile-open');
   const isCompact=_isCompactWorkspaceViewport();
   const isOpen=isCompact?mobileOpen:desktopOpen;
-  const canBrowse=!!S.session||_hasWorkspacePreviewVisible();
+  const canBrowse=!!S.session||_hasWorkspacePreviewVisible()||!!(S._profileDefaultWorkspace);
   const hasPreview=_hasWorkspacePreviewVisible();
   if(toggleBtn){
     toggleBtn.classList.toggle('active',isOpen);
@@ -900,6 +905,11 @@ function applyBotName(){
         localStorage.removeItem('hermes-webui-session');
         S.session=null; S.messages=[];
         S._bootReady=true;
+        // Restore panel pref before syncing so the workspace panel stays visible
+        // even though there is no active session (#workspace-persist).
+        const _ephPanelPref=localStorage.getItem('hermes-webui-workspace-panel-pref')==='open'
+          || localStorage.getItem('hermes-webui-workspace-panel')==='open';
+        if(_ephPanelPref) _workspacePanelMode='browse';
         syncTopbar();syncWorkspacePanelState();
         $('emptyState').style.display='';
         await renderSessionList();if(typeof startGatewaySSE==='function')startGatewaySSE();
@@ -920,6 +930,11 @@ function applyBotName(){
   // no saved session - show empty state, wait for user to hit +
   S._bootReady=true;
   syncTopbar();
+  // Restore panel pref so the workspace panel stays visible on a fresh load if the
+  // user had it open during their last session (#workspace-persist).
+  const _freshPanelPref=localStorage.getItem('hermes-webui-workspace-panel-pref')==='open'
+    || localStorage.getItem('hermes-webui-workspace-panel')==='open';
+  if(_freshPanelPref) _workspacePanelMode='browse';
   syncWorkspacePanelState();
   $('emptyState').style.display='';
   await renderSessionList();

--- a/tests/test_workspace_blank_page_fix.py
+++ b/tests/test_workspace_blank_page_fix.py
@@ -59,14 +59,15 @@ class TestBootJsProfileDefaultWorkspace:
         """The settings block (lines ~758-800 in boot.js) must set
         S._profileDefaultWorkspace from the /api/settings response."""
         src = read('static/boot.js')
-        # Find the settings fetch and the _profileDefaultWorkspace assignment
-        # and confirm both are in the same settings-read block (within ~50 lines)
-        ws_idx = src.find('_profileDefaultWorkspace')
+        # Find the settings fetch and the _profileDefaultWorkspace ASSIGNMENT
+        # (the if(s.default_workspace) line, not usages elsewhere in the file)
         settings_idx = src.find("await api('/api/settings')")
-        assert ws_idx != -1, "_profileDefaultWorkspace not found in boot.js"
         assert settings_idx != -1, "await api('/api/settings') not found in boot.js"
-        # Both must be within 300 chars of each other (same block)
-        assert abs(ws_idx - settings_idx) < 1000, (
+        # Find the assignment specifically — it uses 's.default_workspace'
+        ws_assign_idx = src.find('S._profileDefaultWorkspace=s.default_workspace')
+        assert ws_assign_idx != -1, "S._profileDefaultWorkspace assignment not found in boot.js"
+        # The assignment must be in the same settings-fetch block (within a few hundred chars)
+        assert abs(ws_assign_idx - settings_idx) < 1000, (
             "S._profileDefaultWorkspace must be set in the same settings-fetch block"
         )
 

--- a/tests/test_workspace_panel_persists_on_empty_boot.py
+++ b/tests/test_workspace_panel_persists_on_empty_boot.py
@@ -1,0 +1,138 @@
+"""
+Regression tests for the workspace panel persisting across page reload on
+empty-session and no-session boot paths.
+
+Two boot paths previously dropped the workspace panel even when the user had
+explicitly opened it before reloading:
+
+  1. Ephemeral-session guard added in #1182: when the restored session has
+     0 messages, boot clears localStorage and shows the empty state. This
+     path was calling ``syncWorkspacePanelState()`` without first restoring
+     ``_workspacePanelMode`` from localStorage.
+  2. No-saved-session path: a fresh page load with no localStorage session
+     also went straight to ``syncWorkspacePanelState()`` without restoring
+     the panel preference.
+
+Both paths force-closed the panel because ``syncWorkspacePanelState()``
+unconditionally set ``_workspacePanelMode='closed'`` whenever ``S.session``
+was null — even when the user's preference was 'open'.
+
+Fix verified by these tests:
+
+  - ``syncWorkspacePanelState`` checks ``_workspacePanelMode==='preview'``
+    BEFORE force-closing, so 'browse' mode is preserved without a session.
+  - Both boot paths read the panel pref from localStorage and set
+    ``_workspacePanelMode='browse'`` before calling sync.
+  - ``canBrowse`` and ``openWorkspacePanel()`` include
+    ``S._profileDefaultWorkspace`` so the toggle stays enabled.
+"""
+import pathlib
+
+REPO = pathlib.Path(__file__).parent.parent
+BOOT_JS = (REPO / "static" / "boot.js").read_text(encoding="utf-8")
+
+
+# ── 1. syncWorkspacePanelState preserves browse mode without a session ──────
+
+
+class TestSyncStateNoSession:
+    def test_preview_mode_without_session_force_closes(self):
+        """A 'preview' panel needs file content from a session — close it
+        when there's no session."""
+        idx = BOOT_JS.find("function syncWorkspacePanelState()")
+        body = BOOT_JS[idx:idx + 800]
+        assert "_workspacePanelMode==='preview'" in body, (
+            "syncWorkspacePanelState must check _workspacePanelMode==='preview' "
+            "before force-closing on no-session boot"
+        )
+        assert "_setWorkspacePanelMode('closed')" in body, (
+            "syncWorkspacePanelState still must close 'preview' mode without a session"
+        )
+
+    def test_browse_mode_calls_sync_ui_instead_of_force_close(self):
+        """For 'browse' mode without a session, syncWorkspacePanelUI() should
+        run so the panel renders its 'no workspace' or default-workspace state
+        rather than being force-closed."""
+        idx = BOOT_JS.find("function syncWorkspacePanelState()")
+        body = BOOT_JS[idx:idx + 800]
+        # The else branch (browse / closed mode without session) calls UI sync
+        assert "syncWorkspacePanelUI()" in body, (
+            "syncWorkspacePanelState must call syncWorkspacePanelUI() in the "
+            "no-session, non-preview branch so 'browse' mode is preserved"
+        )
+
+
+# ── 2. Both boot paths restore panelPref before sync ────────────────────────
+
+
+class TestBootPathsRestorePanelPref:
+    PREF_PATTERN = "hermes-webui-workspace-panel-pref"
+
+    def test_ephemeral_path_restores_panel_pref(self):
+        """The empty-session guard (#1182) must read panelPref before
+        calling syncWorkspacePanelState()."""
+        # Find the ephemeral guard — it's marked by message_count===0 check
+        eph_idx = BOOT_JS.find("(S.session.message_count||0) === 0")
+        assert eph_idx > 0, "Empty-session guard not found in boot IIFE"
+        # The next syncWorkspacePanelState() call after this point is in the ephemeral path
+        sync_idx = BOOT_JS.find("syncWorkspacePanelState()", eph_idx)
+        assert sync_idx > 0, "syncWorkspacePanelState call not found in ephemeral path"
+        # panelPref must be read between the guard and the sync call
+        block = BOOT_JS[eph_idx:sync_idx]
+        assert self.PREF_PATTERN in block, (
+            "Ephemeral-session boot path must read 'hermes-webui-workspace-panel-pref' "
+            "from localStorage before calling syncWorkspacePanelState()"
+        )
+        assert "_workspacePanelMode='browse'" in block or "_workspacePanelMode = 'browse'" in block, (
+            "Ephemeral-session path must set _workspacePanelMode='browse' "
+            "when the pref is 'open'"
+        )
+
+    def test_no_session_path_restores_panel_pref(self):
+        """The fresh-load (no localStorage session) path must read panelPref
+        before calling syncWorkspacePanelState()."""
+        # Find the comment marker that precedes the no-session path
+        marker = "no saved session"
+        m_idx = BOOT_JS.find(marker)
+        assert m_idx > 0, "no-saved-session path not found"
+        # syncWorkspacePanelState should appear shortly after
+        sync_idx = BOOT_JS.find("syncWorkspacePanelState()", m_idx)
+        assert sync_idx > 0, "syncWorkspacePanelState() not found after no-saved-session marker"
+        block = BOOT_JS[m_idx:sync_idx]
+        assert self.PREF_PATTERN in block, (
+            "No-saved-session boot path must read 'hermes-webui-workspace-panel-pref' "
+            "before calling syncWorkspacePanelState()"
+        )
+        assert "_workspacePanelMode='browse'" in block or "_workspacePanelMode = 'browse'" in block, (
+            "No-saved-session path must set _workspacePanelMode='browse' "
+            "when the pref is 'open'"
+        )
+
+
+# ── 3. Toggle button stays enabled when profile default workspace exists ────
+
+
+class TestToggleStaysEnabledWithProfileWorkspace:
+    def test_can_browse_includes_profile_default_workspace(self):
+        """The toggle button's enabled state (canBrowse) must be true when
+        S._profileDefaultWorkspace is set, even with no active session."""
+        idx = BOOT_JS.find("const canBrowse=")
+        assert idx > 0, "canBrowse declaration not found in syncWorkspacePanelUI"
+        line = BOOT_JS[idx:idx + 200].split("\n", 1)[0]
+        assert "_profileDefaultWorkspace" in line, (
+            "canBrowse must include S._profileDefaultWorkspace so the toggle "
+            "button stays enabled when a profile workspace is configured"
+        )
+
+    def test_open_workspace_panel_allows_browse_with_profile_workspace(self):
+        """openWorkspacePanel('browse') must not return early when
+        S._profileDefaultWorkspace is set, otherwise clicking the toggle
+        won't open the panel even though canBrowse said it should."""
+        idx = BOOT_JS.find("function openWorkspacePanel(")
+        body = BOOT_JS[idx:idx + 600]
+        # The early-return guard should include the profile-workspace check
+        assert "_profileDefaultWorkspace" in body, (
+            "openWorkspacePanel must include S._profileDefaultWorkspace in its "
+            "early-return guard so users can open the panel via the toggle "
+            "button when a profile workspace is configured"
+        )


### PR DESCRIPTION
## Summary

Fixes a bug where the workspace panel closes and stays stuck closed after:
- Refreshing the page after clicking New Conversation (with no messages sent)
- Any page load where no session is stored in localStorage

After the bug triggers, the workspace toggle button is disabled and clicking it shows the "no workspace" icon. The only recovery is clicking a past conversation with a workspace. This was especially jarring because the workspace had been working fine before the refresh.

## Root cause

Three issues in `boot.js` working together:

**1. `syncWorkspacePanelState()` always closed the panel with no session:**
```js
if(!S.session){
  _setWorkspacePanelMode('closed');  // always, regardless of pref
  return;
}
```

**2. The ephemeral-session path (refresh after empty New Conversation) didn't restore `panelPref` before calling sync:**
```js
// Our PR #1182 added this path — correctly clears the empty session on reload,
// but missed restoring the workspace panel preference first.
S.session = null; S.messages = [];
syncTopbar(); syncWorkspacePanelState();  // ← _workspacePanelMode still 'closed', gets force-closed
```

**3. Same omission in the no-saved-session path** (fresh load, no localStorage ID).

The session-restore path (loading an existing conversation) already did this correctly — it sets `_workspacePanelMode='browse'` from `panelPref` before calling `syncWorkspacePanelState()`. The two new-session paths simply didn't.

## Fix

Four targeted changes, all in `static/boot.js`:

**1. `syncWorkspacePanelState()`** — when `S.session` is null and mode is already `browse`, call `syncWorkspacePanelUI()` instead of force-closing. Only `preview` mode (which requires a session to fetch file content) gets closed:
```js
if(!S.session){
  if(_workspacePanelMode==='preview') _setWorkspacePanelMode('closed');
  else syncWorkspacePanelUI();  // keep browse mode alive
  return;
}
```

**2 & 3. Ephemeral + no-session boot paths** — read `panelPref` from localStorage and apply it before calling `syncWorkspacePanelState()`, exactly matching the session-restore path.

**4. `canBrowse` / `openWorkspacePanel()`** — include `S._profileDefaultWorkspace` so the toggle button stays enabled and clickable when a profile workspace is configured.

## Affected scenarios

| Scenario | Before | After |
|---|---|---|
| Reload after empty New Conversation | Panel closes, button disabled | Panel stays open ✅ |
| First-ever load with pref='open' | Panel closed | Panel opens ✅ |
| Reload after session with workspace | ✅ worked | ✅ still works |
| Clicking past conversation | ✅ worked | ✅ still works |

## Testing

- 2685 tests passing
- Test updated: `test_boot_sets_profile_default_workspace_in_settings_block` now finds the specific assignment expression rather than any usage of the identifier
