### PR TITLE
fix #1154: prevent fenced code content from leaking into markdown passes

### DIFF
--- a/static/ui.js
+++ b/static/ui.js
@@ -813,10 +813,32 @@ function renderMd(raw){
   // Only runs OUTSIDE fenced code blocks and backtick spans (stash + restore).
   // Unsafe tags (anything not in the allowlist) are left as-is and will be
   // HTML-escaped by esc() when they reach an innerHTML assignment -- no XSS risk.
-  // Fence stash: protect code blocks and backtick spans from all further processing
-  // Must run BEFORE math_stash so $..$ inside code spans is not extracted as math
+  // Fence stash: protect code blocks and backtick spans from all further processing.
+  // Must run BEFORE math_stash so $..$ inside code spans is not extracted as math.
+  // Split into fenced blocks (\x00P — kept stashed until after all markdown passes)
+  // and inline backtick spans (\x00F — restored before bold/italic so **`code`** works).
+  // Fenced blocks are converted to <pre><code> here so their content is HTML-escaped
+  // and never exposed to list/heading/table regexes that could corrupt the layout.
+  // Fixes #1154: diff/patch lines inside fenced blocks (e.g. + added, - removed)
+  // were matching the unordered-list regex and injecting <ul>/<li> inside <pre>,
+  // breaking </pre> closure and corrupting all subsequent message rendering.
+  const _preBlock_stash=[];
   const fence_stash=[];
-  s=s.replace(/(```[\s\S]*?```|`[^`\n]+`)/g,m=>{fence_stash.push(m);return '\x00F'+(fence_stash.length-1)+'\x00';});
+  s=s.replace(/```([\s\S]*?)```/g,(_,raw)=>{
+    const m=raw.match(/^(\w[\w+-]*)\n?([\s\S]*)$/);
+    if(m&&m[1].trim().toLowerCase()==='mermaid'){
+      const id='mermaid-'+Math.random().toString(36).slice(2,10);
+      _preBlock_stash.push(`<div class="mermaid-block" data-mermaid-id="${id}">${esc(m[2].trim())}</div>`);
+    } else {
+      const lang=m?(m[1]||'').trim().toLowerCase():'';
+      const code=m?m[2]:raw.replace(/^\n?/,'');
+      const h=lang?`<div class="pre-header">${esc(lang)}</div>`:'';
+      const langAttr=lang?` class="language-${esc(lang)}"`:'';
+      _preBlock_stash.push(`${h}<pre><code${langAttr}>${esc(code.replace(/\n$/,''))}</code></pre>`);
+    }
+    return '\x00P'+(_preBlock_stash.length-1)+'\x00';
+  });
+  s=s.replace(/`([^`\n]+)`/g,(_,c)=>{fence_stash.push('<code>'+esc(c)+'</code>');return '\x00F'+(fence_stash.length-1)+'\x00';});
   // Math stash: protect $$..$$ and $..$ from markdown processing
   // Runs AFTER fence_stash so backtick code spans protect their dollar-sign contents
   const math_stash=[];
@@ -841,20 +863,9 @@ function renderMd(raw){
   s=s.replace(/<code>([^<]*?)<\/code>/gi,(_,t)=>'`'+t+'`');
   s=s.replace(/<br\s*\/?>/gi,'\n');
   s=s.replace(/\x00R(\d+)\x00/g,(_,i)=>rawPreStash[+i]);
-  // Restore stashed code blocks
+  // Inline backtick spans: restore <code> tags produced in the stash callback above.
+  // Must happen BEFORE bold/italic so **`code`** → <strong><code>code</code></strong>.
   s=s.replace(/\x00F(\d+)\x00/g,(_,i)=>fence_stash[+i]);
-  // Mermaid blocks: render as diagram containers (processed after DOM insertion)
-  s=s.replace(/```mermaid\n?([\s\S]*?)```/g,(_,code)=>{
-    const id='mermaid-'+Math.random().toString(36).slice(2,10);
-    return `<div class="mermaid-block" data-mermaid-id="${id}">${esc(code.trim())}</div>`;
-  });
-  s=s.replace(/```([\w+-]*)\n?([\s\S]*?)```/g,(_,lang,code)=>{
-    const normalizedLang=(lang||'').trim().toLowerCase();
-    const h=normalizedLang?`<div class="pre-header">${esc(normalizedLang)}</div>`:'';
-    const langAttr=normalizedLang?` class="language-${esc(normalizedLang)}"`:'';
-    return `${h}<pre><code${langAttr}>${esc(code.replace(/\n$/,''))}</code></pre>`;
-  });
-  s=s.replace(/`([^`\n]+)`/g,(_,c)=>`<code>${esc(c)}</code>`);
   // inlineMd: process bold/italic/code/links within a single line of text.
   // Used inside list items and blockquotes where the text may already contain
   // HTML from the pre-pass → bold pipeline, so we cannot call esc() directly.
@@ -984,6 +995,11 @@ function renderMd(raw){
     }
     return `<span class="katex-inline" data-katex="inline">${esc(item.src)}</span>`;
   });
+  // Restore fenced block stash (\x00P) → <pre><code> HTML.
+  // Happens AFTER all markdown passes (lists, headings, tables, etc.) so
+  // diff/patch content inside code blocks is never misinterpreted as markdown.
+  // The _pre_stash below then protects these blocks from paragraph splitting.
+  s=s.replace(/\x00P(\d+)\x00/g,(_,i)=>_preBlock_stash[+i]);
   // Stash rendered <pre> blocks (with optional pre-header div) and mermaid/katex
   // divs before paragraph splitting so \n inside code blocks is never replaced
   // with <br>. Token \x00E (next free after B D F G L M C O A).

--- a/tests/test_issue1154_fenced_code_leak.py
+++ b/tests/test_issue1154_fenced_code_leak.py
@@ -1,0 +1,189 @@
+"""
+Regression tests for #1154 — fenced code block content leaking into
+markdown passes and corrupting subsequent message rendering.
+
+Root cause: fenced code blocks were rendered to <pre><code> early in
+the pipeline, BEFORE list/heading/table regexes ran. Lines inside
+code blocks that looked like markdown (e.g. `- removed`, `+ added`
+in diff blocks) were matched by those regexes, injecting <ul>/<li>
+HTML inside <pre>, breaking </pre> closure and corrupting layout.
+
+Fix: fenced blocks are converted to <pre><code> HTML inside the stash
+callback and kept as \\x00P tokens until AFTER all markdown passes.
+"""
+import re
+import shutil
+
+import pytest
+
+REPO_ROOT = __import__("pathlib").Path(__file__).parent.parent.resolve()
+UI_JS_PATH = REPO_ROOT / "static" / "ui.js"
+NODE = shutil.which("node")
+
+pytestmark = pytest.mark.skipif(NODE is None, reason="node not on PATH")
+
+_DRIVER_SRC = r"""
+const fs = require('fs');
+const src = fs.readFileSync(process.argv[2], 'utf8');
+global.window = {};
+global.document = { createElement: () => ({ innerHTML: '', textContent: '' }) };
+const esc = s => String(s ?? '').replace(/[&<>\"']/g, c => (
+  {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
+
+function extractFunc(name) {
+  const re = new RegExp('function\\s+' + name + '\\s*\\(');
+  const start = src.search(re);
+  if (start < 0) throw new Error(name + ' not found');
+  let i = src.indexOf('{', start);
+  let depth = 1; i++;
+  while (depth > 0 && i < src.length) {
+    if (src[i] === '{') depth++;
+    else if (src[i] === '}') depth--;
+    i++;
+  }
+  return src.slice(start, i);
+}
+eval(extractFunc('renderMd'));
+
+let buf = '';
+process.stdin.on('data', c => { buf += c; });
+process.stdin.on('end', () => { process.stdout.write(renderMd(buf)); });
+"""
+
+
+@pytest.fixture(scope="module")
+def driver_path(tmp_path_factory):
+    p = tmp_path_factory.mktemp("renderer_driver") / "driver.js"
+    p.write_text(_DRIVER_SRC, encoding="utf-8")
+    return str(p)
+
+
+def _render(driver_path, markdown: str) -> str:
+    import subprocess
+    result = subprocess.run(
+        [NODE, driver_path, str(UI_JS_PATH)],
+        input=markdown, capture_output=True, text=True, timeout=10,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"node driver failed: {result.stderr}")
+    return result.stdout
+
+
+class TestFencedCodeBlockIsolation:
+    """Content inside fenced code blocks must never be interpreted as markdown."""
+
+    def test_diff_block_plus_minus_lines_not_treated_as_list(self, driver_path):
+        html = _render(driver_path,
+            "before\n\n```diff\n- removed line\n+ added line\n```\nafter")
+        pre = _extract_pre(html)
+        assert pre is not None, "Expected a <pre> block"
+        assert "<ul>" not in pre, "List HTML must not appear inside <pre>"
+        assert "<li>" not in pre, "List items must not appear inside <pre>"
+        assert "- removed line" in pre
+        assert "+ added line" in pre
+        assert html.count("<pre") == html.count("</pre>"), \
+            "Every <pre> must have a matching </pre>"
+
+    def test_bash_block_asterisk_lines_not_treated_as_list(self, driver_path):
+        html = _render(driver_path,
+            "```bash\n* not a list item\n* another one\n```")
+        pre = _extract_pre(html)
+        assert pre is not None
+        assert "<ul>" not in pre
+        assert "<li>" not in pre
+
+    def test_markdown_block_heading_not_treated_as_h1(self, driver_path):
+        html = _render(driver_path,
+            "```markdown\n# Not a heading\n## Also not\n```")
+        pre = _extract_pre(html)
+        assert pre is not None
+        assert "<h1>" not in pre
+        assert "<h2>" not in pre
+        assert "# Not a heading" in pre
+
+    def test_markdown_block_bold_not_treated_as_strong(self, driver_path):
+        html = _render(driver_path, "```text\n**not bold**\n```")
+        pre = _extract_pre(html)
+        assert pre is not None
+        assert "<strong>" not in pre
+        assert "**not bold**" in pre
+
+    def test_content_after_code_block_renders_normally(self, driver_path):
+        html = _render(driver_path,
+            "```diff\n- old\n+ new\n```\n\n"
+            "# Real Heading\n\n- real list item\n\n**bold text**")
+        assert "<h1>Real Heading</h1>" in html
+        assert "<ul>" in html
+        assert "<strong>bold text</strong>" in html
+        pre = _extract_pre(html)
+        assert "<ul>" not in pre
+
+    def test_no_escaped_pre_closing_tag(self, driver_path):
+        html = _render(driver_path,
+            "```diff\n- old line\n+ new line\n```\n\nAfter the block")
+        assert "&lt;/pre&gt;" not in html, \
+            "Escaped </pre> indicates broken HTML nesting"
+
+    def test_code_block_without_language(self, driver_path):
+        html = _render(driver_path,
+            "```\n- item\n+ item\n```\n\n- real list")
+        pre = _extract_pre(html)
+        assert pre is not None
+        assert "<ul>" not in pre
+        assert html.count("<pre") == html.count("</pre>")
+
+    def test_inline_backtick_still_works(self, driver_path):
+        html = _render(driver_path, "Some **`code`** here")
+        assert "<strong><code>code</code></strong>" in html
+
+    def test_inline_backtick_inside_bold(self, driver_path):
+        html = _render(driver_path,
+            "Text with `inline code` and **bold**")
+        assert "<code>inline code</code>" in html
+        assert "<strong>bold</strong>" in html
+
+    def test_large_diff_output_no_corruption(self, driver_path):
+        diff_lines = "\n".join(
+            f"- old_line_{i}" if i % 2 == 0 else f"+ new_line_{i}"
+            for i in range(50)
+        )
+        html = _render(driver_path,
+            f"```diff\n{diff_lines}\n```\n\nSummary after diff")
+        pre = _extract_pre(html)
+        assert pre is not None
+        assert "<ul>" not in pre
+        assert "<li>" not in pre
+        assert html.count("<pre") == html.count("</pre>")
+        assert "Summary after diff" in html
+
+    def test_mixed_fenced_and_inline_code(self, driver_path):
+        html = _render(driver_path,
+            "Use `rm -rf` to delete:\n\n"
+            "```bash\nrm -rf /tmp/stuff\n```\n\nDone.")
+        assert "<code>rm -rf</code>" in html
+        pre = _extract_pre(html)
+        assert pre is not None
+        assert "rm -rf /tmp/stuff" in pre
+
+
+class TestFencedBlockPreHeaderPreserved:
+    """Pre-header div (language label) must still be generated."""
+
+    def test_language_header_present(self, driver_path):
+        html = _render(driver_path,
+            "```python\ndef hello():\n    pass\n```")
+        assert '<div class="pre-header">python</div>' in html
+
+    def test_no_language_no_header(self, driver_path):
+        html = _render(driver_path, "```\nsome code\n```")
+        assert "pre-header" not in html
+
+    def test_language_class_on_code_tag(self, driver_path):
+        html = _render(driver_path,
+            "```javascript\nconsole.log('hi')\n```")
+        assert 'class="language-javascript"' in html
+
+
+def _extract_pre(html):
+    m = re.search(r"<pre[^>]*>[\s\S]*?</pre>", html)
+    return m.group(0) if m else None

--- a/tests/test_issue347.py
+++ b/tests/test_issue347.py
@@ -176,7 +176,7 @@ def test_fence_stash_before_math_stash():
 def test_fence_stash_populated_before_math_stash():
     """The fence_stash s.replace call must appear before any math_stash s.replace calls."""
     # Find the s.replace call that populates each stash
-    fence_replace_pos = UI_JS.find("fence_stash.push(m)")
+    fence_replace_pos = UI_JS.find("fence_stash.push(")
     math_replace_pos = UI_JS.find("math_stash.push(")
     assert fence_replace_pos != -1, "fence_stash population call not found"
     assert math_replace_pos != -1, "math_stash population call not found"

--- a/tests/test_issue_code_syntax_highlight.py
+++ b/tests/test_issue_code_syntax_highlight.py
@@ -10,14 +10,15 @@ def _read_ui_js() -> str:
 
 def test_fenced_code_blocks_add_prism_language_class():
     js = _read_ui_js()
-    assert 'class="language-${esc(normalizedLang)}"' in js, (
+    assert 'class="language-${esc(lang)}"' in js, (
         "Fenced code blocks should add Prism language-* classes so syntax highlighting works"
     )
 
-
 def test_fenced_code_blocks_keep_existing_pre_header_layout():
     js = _read_ui_js()
-    assert 'return `${h}<pre><code${langAttr}>${esc(code.replace(/\\n$/,' in js, (
+    # The fenced code rendering was moved into the stash callback (#1154 fix).
+    # The template string now uses `lang` instead of `normalizedLang`.
+    assert '${h}<pre><code${langAttr}>${esc(code.replace(/\\n$/,' in js, (
         "The syntax-highlight fix should preserve the existing fenced code block layout"
     )
     assert '<div class="code-block">' not in js, (


### PR DESCRIPTION
## Thinking Path

**Problem:** When the LLM produces large tool outputs containing fenced code blocks (especially `diff` or `bash` blocks), the WebUI rendering corrupts subsequent messages. Diff hunks (`-` / `+` lines) are misinterpreted as markdown list items, injecting `<ul><li>` tags inside `<pre><code>` blocks, which breaks the `</pre>` closing tag and corrupts all following message content.

**Root cause:** In `renderMd()`, fenced code blocks were rendered to `<pre><code>` HTML early — right after the fence stash restore — then exposed to subsequent markdown passes (lists, headings, tables, etc.). The list regex `^(?:  )?[-*+] .+` (multiline flag) would match lines inside `<pre><code>` blocks that happen to start with `-` or `+` (diff hunks, bash prompts), injecting HTML inside the code block.

**Fix:** Split the fence stash into two phases:
1. **Inline backticks (`\x00F`):** transformed to `<code>` tags in the stash callback, restored before bold/italic passes (unchanged behavior)
2. **Fenced blocks (`\x00P`):** transformed to `<pre><code>` HTML inside the stash callback, **kept stashed until after ALL markdown passes**, then restored just before `_pre_stash`

This ensures diff/patch/list content inside fenced code blocks is never misinterpreted as markdown, regardless of code block size or content.

Compatible with upstream's `rawPreStash` (\x00R) which protects existing `<pre>` blocks from streaming HTML.

## What Changed

- **`static/ui.js`**: Split fence stash into fenced blocks (\x00P) and inline backticks (\x00F); fenced blocks stay stashed through all markdown passes
- **`tests/test_issue1154_fenced_code_leak.py`**: 14 new regression tests covering diff blocks, bash prompts, list markers, inline backticks, and headings after fenced blocks
- **`tests/test_issue347.py`**: Updated static analysis to match refactored stash code structure
- **`tests/test_issue_code_syntax_highlight.py`**: Updated static analysis for renamed variables in stash callback

**All 2667 tests pass** (1 known upstream failure: `test_sprint31`)

Fixes #1154