### PR TITLE
fix: batch v0.50.231 — macOS symlink bypass, workspace panel, fenced code leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -357,6 +357,28 @@
   workspace subtree) and never enumerate blocked system roots. (`api/routes.py`,
   `api/workspace.py`, `static/panels.js`, `static/style.css`) (partial for #616)
 
+## [v0.50.231] — 2026-04-28
+
+### Fixed
+- **macOS `/etc` symlink bypass in workspace blocked-roots** — on macOS, `/etc`, `/var`, and
+  `/tmp` are symlinks to `/private/etc` etc. `_workspace_blocked_roots()` now materialises both
+  the literal and `Path.resolve()` forms of every blocked root, and a new `_is_blocked_system_path()`
+  helper applies the check with `/var/folders` and `/var/tmp` carve-outs so pytest `tmp_path_factory`
+  paths and other legitimate per-user tmp dirs remain registerable as workspaces.
+  (`api/workspace.py`, `api/routes.py`) (#1186)
+- **Workspace panel stuck closed after empty-session reload** — a regression from #1182: when a
+  user had the workspace panel open and reloaded the page on an empty/new session, the panel was
+  force-closed and the toggle disabled. `syncWorkspacePanelState()` now only force-closes in
+  `'preview'` mode (which requires a session); `'browse'` mode renders the panel chrome with a
+  no-workspace placeholder. Both boot paths restore the user's localStorage panel preference before
+  the sync call. (`static/boot.js`) (#1187)
+- **Fenced code content leaking into markdown passes** — large tool outputs with diff/patch/log
+  content (lines starting with `-`, `+`, `*`, `#` inside code blocks) were having `<ul>/<li>/<h>` tags
+  injected by the list/heading regexes, breaking `</pre>` closure and corrupting subsequent message
+  rendering. The fix keeps fenced blocks stashed as `\x00P<n>\x00` tokens through ALL markdown
+  passes and restores them AFTER lists/headings/tables, so those regexes never see the rendered HTML.
+  (`static/ui.js`) (#1154, @bergeouss)
+
 ## [v0.50.230] — 2026-04-27
 
 ### Fixed

--- a/api/routes.py
+++ b/api/routes.py
@@ -409,6 +409,7 @@ from api.workspace import (
     safe_resolve_ws,
     resolve_trusted_workspace,
     validate_workspace_to_add,
+    _is_blocked_system_path,
     _workspace_blocked_roots,
 )
 from api.upload import handle_upload, handle_transcribe
@@ -3204,13 +3205,12 @@ def _handle_workspace_add(handler, body):
         return bad(handler, "path is required")
     # Validate the path is NOT a blocked system root BEFORE any filesystem mutation.
     # This prevents creating orphan directories on rejected paths (#782 review).
+    # _is_blocked_system_path honours user-tmp carve-outs (e.g. /var/folders on
+    # macOS) so pytest's tmp_path_factory paths and other legit user-tmp dirs
+    # still register cleanly.
     candidate = Path(path_str).expanduser().resolve()
-    for blocked in _workspace_blocked_roots():
-        try:
-            candidate.relative_to(blocked)
-            return bad(handler, f"Path points to a system directory: {candidate}")
-        except ValueError:
-            pass
+    if _is_blocked_system_path(candidate):
+        return bad(handler, f"Path points to a system directory: {candidate}")
     # Now safe to create the directory if requested
     if auto_create:
         try:

--- a/api/workspace.py
+++ b/api/workspace.py
@@ -220,22 +220,82 @@ def set_last_workspace(path: str) -> None:
         logger.debug("Failed to set last workspace")
 
 
+def _safe_resolve(p: Path) -> Path:
+    """Path.resolve() that never raises — falls back to the input path on error."""
+    try:
+        return p.resolve()
+    except (OSError, RuntimeError):
+        return p
+
+
+# Per-user temp directories that sit nominally under a "system" prefix but are
+# actually user-writable scratch space.  Workspaces registered here (e.g. by
+# pytest's ``tmp_path_factory`` on macOS, which uses ``/var/folders/<hash>/T/``)
+# must remain accepted even though their parent (``/var``) is blocked.  These
+# carve-outs apply to BOTH workspace registration and runtime file ops so a
+# symlink target inside the carve-out is also reachable.
+_USER_TMP_PREFIXES: tuple[Path, ...] = (
+    Path('/var/folders'),         # macOS per-user tmp (literal form)
+    Path('/private/var/folders'),  # macOS per-user tmp (resolved form)
+    Path('/var/tmp'),               # Linux/macOS system-wide tmp (user-writable)
+    Path('/private/var/tmp'),       # macOS resolved form
+)
+
+
 def _workspace_blocked_roots() -> tuple[Path, ...]:
-    return (
+    """System roots that must never be accepted as workspace candidates.
+
+    Returns both the literal path and its symlink-resolved canonical form,
+    deduped.  This matters on macOS where ``/etc``, ``/var``, and ``/tmp``
+    are symlinks to ``/private/etc`` etc.  Without the resolved forms,
+    callers that pass a ``.resolve()``-d candidate (every caller does)
+    would compare ``/private/etc`` against literal ``Path('/etc')`` and the
+    ``relative_to`` check would miss — letting ``/etc`` through as a
+    registered workspace on macOS.
+
+    Carve-outs for legitimate user-tmp paths nominally under these roots
+    (e.g. ``/var/folders/.../T/`` on macOS) are handled by
+    :func:`_is_blocked_system_path`, not by exclusion from this list.
+    """
+    _raw = (
         # Linux / macOS
-        Path('/etc'),
-        Path('/usr'),
-        Path('/var'),
-        Path('/bin'),
-        Path('/sbin'),
-        Path('/boot'),
-        Path('/proc'),
-        Path('/sys'),
-        Path('/dev'),
-        Path('/lib'),
-        Path('/lib64'),
-        Path('/opt/homebrew'),
+        '/etc',
+        '/usr',
+        '/var',
+        '/bin',
+        '/sbin',
+        '/boot',
+        '/proc',
+        '/sys',
+        '/dev',
+        '/lib',
+        '/lib64',
+        '/opt/homebrew',
     )
+    _seen: set[Path] = set()
+    _out: list[Path] = []
+    for _p in _raw:
+        for _form in (Path(_p), _safe_resolve(Path(_p))):
+            if _form not in _seen:
+                _seen.add(_form)
+                _out.append(_form)
+    return tuple(_out)
+
+
+def _is_blocked_system_path(candidate: Path) -> bool:
+    """Return True if *candidate* falls under a blocked system root.
+
+    Honours :data:`_USER_TMP_PREFIXES` carve-outs so per-user tmp directories
+    nominally under ``/var`` (``/var/folders`` on macOS, ``/var/tmp`` on
+    Linux/macOS) remain valid workspace candidates and reachable file targets.
+    """
+    for tmp in _USER_TMP_PREFIXES:
+        if _is_within(candidate, tmp):
+            return False
+    for blocked in _workspace_blocked_roots():
+        if _is_within(candidate, blocked):
+            return True
+    return False
 
 
 def _is_within(path: Path, root: Path) -> bool:
@@ -258,7 +318,7 @@ def _trusted_workspace_roots() -> list[Path]:
             return
         if not p.exists() or not p.is_dir():
             return
-        if any(_is_within(p, blocked) for blocked in _workspace_blocked_roots()):
+        if _is_blocked_system_path(p):
             return
         if p not in roots:
             roots.append(p)
@@ -390,8 +450,7 @@ def resolve_trusted_workspace(path: str | Path | None = None) -> Path:
     # Must be checked before system roots to allow symlinks like /var/home.
     # Guard: skip if HOME is / or is itself a blocked root (unusual container setups).
     _home = Path.home().resolve()
-    _home_is_sane = (_home != Path("/") and
-                     not any(_is_within(_home, b) for b in _workspace_blocked_roots()))
+    _home_is_sane = (_home != Path("/") and not _is_blocked_system_path(_home))
     if _home_is_sane:
         try:
             candidate.relative_to(_home)
@@ -400,14 +459,8 @@ def resolve_trusted_workspace(path: str | Path | None = None) -> Path:
             pass
 
     # Block known system roots and their children
-    for blocked in _workspace_blocked_roots():
-        try:
-            candidate.relative_to(blocked)
-            raise ValueError(f"Path points to a system directory: {candidate}")
-        except ValueError as e:
-            if "system directory" in str(e):
-                raise
-            # relative_to raised ValueError = candidate is NOT under blocked = safe
+    if _is_blocked_system_path(candidate):
+        raise ValueError(f"Path points to a system directory: {candidate}")
 
     # (B) Trusted if already in the saved workspace list — covers non-home installs
     try:
@@ -457,13 +510,8 @@ def validate_workspace_to_add(path: str) -> Path:
         raise ValueError(f"Path is not a directory: {candidate}")
 
     # Block known system roots and their immediate children
-    for blocked in _workspace_blocked_roots():
-        try:
-            candidate.relative_to(blocked)
-            raise ValueError(f"Path points to a system directory: {candidate}")
-        except ValueError as e:
-            if "system directory" in str(e):
-                raise
+    if _is_blocked_system_path(candidate):
+        raise ValueError(f"Path points to a system directory: {candidate}")
 
     return candidate
 
@@ -494,13 +542,8 @@ def safe_resolve_ws(root: Path, requested: str) -> Path:
     # Even if the user placed the symlink intentionally, prevent reads from
     # /etc, /proc, /sys, /dev and other blocked roots (LLM agents can call
     # read_file_content via tool calls, not just human users).
-    for blocked in _workspace_blocked_roots():
-        try:
-            resolved.relative_to(blocked)
-            raise ValueError(f"Path traversal blocked (system dir): {requested}")
-        except ValueError as _e:
-            if "system dir" in str(_e):
-                raise
+    if _is_blocked_system_path(resolved):
+        raise ValueError(f"Path traversal blocked (system dir): {requested}")
     return resolved
 
 
@@ -530,15 +573,7 @@ def list_dir(workspace: Path, rel: str='.'):
             except ValueError:
                 pass
             # Block symlinks that resolve to system directories.
-            _sym_blocked = False
-            for _blocked in _workspace_blocked_roots():
-                try:
-                    link_target.relative_to(_blocked)
-                    _sym_blocked = True
-                    break
-                except ValueError:
-                    pass
-            if _sym_blocked:
+            if _is_blocked_system_path(link_target):
                 continue
             is_dir = link_target.is_dir()
             # Keep the display path relative to workspace (don't follow the link)

--- a/static/boot.js
+++ b/static/boot.js
@@ -62,14 +62,19 @@ function syncWorkspacePanelState(){
     return;
   }
   if(!S.session){
-    _setWorkspacePanelMode('closed');
+    // No active session — if the panel was explicitly opened (browse mode), keep it
+    // open so the workspace pane doesn't vanish on a fresh-page or empty-session boot.
+    // The file tree will show the "no workspace" placeholder naturally via renderFileTree().
+    // Only force-close if the mode is 'preview' (file preview without a session is invalid).
+    if(_workspacePanelMode==='preview') _setWorkspacePanelMode('closed');
+    else syncWorkspacePanelUI();
     return;
   }
   _setWorkspacePanelMode(_workspacePanelMode==='preview'?'closed':_workspacePanelMode);
 }
 
 function openWorkspacePanel(mode='browse'){
-  if(mode==='browse'&&!S.session&&!_hasWorkspacePreviewVisible())return;
+  if(mode==='browse'&&!S.session&&!_hasWorkspacePreviewVisible()&&!S._profileDefaultWorkspace)return;
   if(mode==='preview'&&_workspacePanelMode==='browse'){
     syncWorkspacePanelUI();
     return;
@@ -101,7 +106,7 @@ function syncWorkspacePanelUI(){
   const mobileOpen=panel.classList.contains('mobile-open');
   const isCompact=_isCompactWorkspaceViewport();
   const isOpen=isCompact?mobileOpen:desktopOpen;
-  const canBrowse=!!S.session||_hasWorkspacePreviewVisible();
+  const canBrowse=!!S.session||_hasWorkspacePreviewVisible()||!!(S._profileDefaultWorkspace);
   const hasPreview=_hasWorkspacePreviewVisible();
   if(toggleBtn){
     toggleBtn.classList.toggle('active',isOpen);
@@ -900,6 +905,11 @@ function applyBotName(){
         localStorage.removeItem('hermes-webui-session');
         S.session=null; S.messages=[];
         S._bootReady=true;
+        // Restore panel pref before syncing so the workspace panel stays visible
+        // even though there is no active session (#workspace-persist).
+        const _ephPanelPref=localStorage.getItem('hermes-webui-workspace-panel-pref')==='open'
+          || localStorage.getItem('hermes-webui-workspace-panel')==='open';
+        if(_ephPanelPref) _workspacePanelMode='browse';
         syncTopbar();syncWorkspacePanelState();
         $('emptyState').style.display='';
         await renderSessionList();if(typeof startGatewaySSE==='function')startGatewaySSE();
@@ -920,6 +930,11 @@ function applyBotName(){
   // no saved session - show empty state, wait for user to hit +
   S._bootReady=true;
   syncTopbar();
+  // Restore panel pref so the workspace panel stays visible on a fresh load if the
+  // user had it open during their last session (#workspace-persist).
+  const _freshPanelPref=localStorage.getItem('hermes-webui-workspace-panel-pref')==='open'
+    || localStorage.getItem('hermes-webui-workspace-panel')==='open';
+  if(_freshPanelPref) _workspacePanelMode='browse';
   syncWorkspacePanelState();
   $('emptyState').style.display='';
   await renderSessionList();

--- a/static/ui.js
+++ b/static/ui.js
@@ -813,10 +813,32 @@ function renderMd(raw){
   // Only runs OUTSIDE fenced code blocks and backtick spans (stash + restore).
   // Unsafe tags (anything not in the allowlist) are left as-is and will be
   // HTML-escaped by esc() when they reach an innerHTML assignment -- no XSS risk.
-  // Fence stash: protect code blocks and backtick spans from all further processing
-  // Must run BEFORE math_stash so $..$ inside code spans is not extracted as math
+  // Fence stash: protect code blocks and backtick spans from all further processing.
+  // Must run BEFORE math_stash so $..$ inside code spans is not extracted as math.
+  // Split into fenced blocks (\x00P — kept stashed until after all markdown passes)
+  // and inline backtick spans (\x00F — restored before bold/italic so **`code`** works).
+  // Fenced blocks are converted to <pre><code> here so their content is HTML-escaped
+  // and never exposed to list/heading/table regexes that could corrupt the layout.
+  // Fixes #1154: diff/patch lines inside fenced blocks (e.g. + added, - removed)
+  // were matching the unordered-list regex and injecting <ul>/<li> inside <pre>,
+  // breaking </pre> closure and corrupting all subsequent message rendering.
+  const _preBlock_stash=[];
   const fence_stash=[];
-  s=s.replace(/(```[\s\S]*?```|`[^`\n]+`)/g,m=>{fence_stash.push(m);return '\x00F'+(fence_stash.length-1)+'\x00';});
+  s=s.replace(/```([\s\S]*?)```/g,(_,raw)=>{
+    const m=raw.match(/^(\w[\w+-]*)\n?([\s\S]*)$/);
+    if(m&&m[1].trim().toLowerCase()==='mermaid'){
+      const id='mermaid-'+Math.random().toString(36).slice(2,10);
+      _preBlock_stash.push(`<div class="mermaid-block" data-mermaid-id="${id}">${esc(m[2].trim())}</div>`);
+    } else {
+      const lang=m?(m[1]||'').trim().toLowerCase():'';
+      const code=m?m[2]:raw.replace(/^\n?/,'');
+      const h=lang?`<div class="pre-header">${esc(lang)}</div>`:'';
+      const langAttr=lang?` class="language-${esc(lang)}"`:'';
+      _preBlock_stash.push(`${h}<pre><code${langAttr}>${esc(code.replace(/\n$/,''))}</code></pre>`);
+    }
+    return '\x00P'+(_preBlock_stash.length-1)+'\x00';
+  });
+  s=s.replace(/`([^`\n]+)`/g,(_,c)=>{fence_stash.push('<code>'+esc(c)+'</code>');return '\x00F'+(fence_stash.length-1)+'\x00';});
   // Math stash: protect $$..$$ and $..$ from markdown processing
   // Runs AFTER fence_stash so backtick code spans protect their dollar-sign contents
   const math_stash=[];
@@ -841,20 +863,9 @@ function renderMd(raw){
   s=s.replace(/<code>([^<]*?)<\/code>/gi,(_,t)=>'`'+t+'`');
   s=s.replace(/<br\s*\/?>/gi,'\n');
   s=s.replace(/\x00R(\d+)\x00/g,(_,i)=>rawPreStash[+i]);
-  // Restore stashed code blocks
+  // Inline backtick spans: restore <code> tags produced in the stash callback above.
+  // Must happen BEFORE bold/italic so **`code`** → <strong><code>code</code></strong>.
   s=s.replace(/\x00F(\d+)\x00/g,(_,i)=>fence_stash[+i]);
-  // Mermaid blocks: render as diagram containers (processed after DOM insertion)
-  s=s.replace(/```mermaid\n?([\s\S]*?)```/g,(_,code)=>{
-    const id='mermaid-'+Math.random().toString(36).slice(2,10);
-    return `<div class="mermaid-block" data-mermaid-id="${id}">${esc(code.trim())}</div>`;
-  });
-  s=s.replace(/```([\w+-]*)\n?([\s\S]*?)```/g,(_,lang,code)=>{
-    const normalizedLang=(lang||'').trim().toLowerCase();
-    const h=normalizedLang?`<div class="pre-header">${esc(normalizedLang)}</div>`:'';
-    const langAttr=normalizedLang?` class="language-${esc(normalizedLang)}"`:'';
-    return `${h}<pre><code${langAttr}>${esc(code.replace(/\n$/,''))}</code></pre>`;
-  });
-  s=s.replace(/`([^`\n]+)`/g,(_,c)=>`<code>${esc(c)}</code>`);
   // inlineMd: process bold/italic/code/links within a single line of text.
   // Used inside list items and blockquotes where the text may already contain
   // HTML from the pre-pass → bold pipeline, so we cannot call esc() directly.
@@ -984,6 +995,11 @@ function renderMd(raw){
     }
     return `<span class="katex-inline" data-katex="inline">${esc(item.src)}</span>`;
   });
+  // Restore fenced block stash (\x00P) → <pre><code> HTML.
+  // Happens AFTER all markdown passes (lists, headings, tables, etc.) so
+  // diff/patch content inside code blocks is never misinterpreted as markdown.
+  // The _pre_stash below then protects these blocks from paragraph splitting.
+  s=s.replace(/\x00P(\d+)\x00/g,(_,i)=>_preBlock_stash[+i]);
   // Stash rendered <pre> blocks (with optional pre-header div) and mermaid/katex
   // divs before paragraph splitting so \n inside code blocks is never replaced
   // with <br>. Token \x00E (next free after B D F G L M C O A).

--- a/tests/test_batch_fixes.py
+++ b/tests/test_batch_fixes.py
@@ -30,10 +30,16 @@ class TestRootWorkspaceUnblocked:
         )
 
     def test_etc_still_blocked(self):
-        """Sanity: other dangerous paths remain blocked."""
+        """Sanity: other dangerous paths remain blocked.
+
+        After the macOS symlink fix, blocked roots are listed as bare strings
+        in a tuple and ``_workspace_blocked_roots()`` materialises both the
+        literal and resolved-canonical Path forms.  Assert the source still
+        names ``/etc`` and ``/proc`` as blocked roots.
+        """
         src = read("api/workspace.py")
-        assert "Path('/etc')" in src
-        assert "Path('/proc')" in src
+        assert "'/etc'" in src or 'Path("/etc")' in src or "Path('/etc')" in src
+        assert "'/proc'" in src or 'Path("/proc")' in src or "Path('/proc')" in src
 
     def test_split_guard_present(self):
         src = read("api/streaming.py")

--- a/tests/test_issue1154_fenced_code_leak.py
+++ b/tests/test_issue1154_fenced_code_leak.py
@@ -1,0 +1,189 @@
+"""
+Regression tests for #1154 — fenced code block content leaking into
+markdown passes and corrupting subsequent message rendering.
+
+Root cause: fenced code blocks were rendered to <pre><code> early in
+the pipeline, BEFORE list/heading/table regexes ran. Lines inside
+code blocks that looked like markdown (e.g. `- removed`, `+ added`
+in diff blocks) were matched by those regexes, injecting <ul>/<li>
+HTML inside <pre>, breaking </pre> closure and corrupting layout.
+
+Fix: fenced blocks are converted to <pre><code> HTML inside the stash
+callback and kept as \\x00P tokens until AFTER all markdown passes.
+"""
+import re
+import shutil
+
+import pytest
+
+REPO_ROOT = __import__("pathlib").Path(__file__).parent.parent.resolve()
+UI_JS_PATH = REPO_ROOT / "static" / "ui.js"
+NODE = shutil.which("node")
+
+pytestmark = pytest.mark.skipif(NODE is None, reason="node not on PATH")
+
+_DRIVER_SRC = r"""
+const fs = require('fs');
+const src = fs.readFileSync(process.argv[2], 'utf8');
+global.window = {};
+global.document = { createElement: () => ({ innerHTML: '', textContent: '' }) };
+const esc = s => String(s ?? '').replace(/[&<>\"']/g, c => (
+  {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
+
+function extractFunc(name) {
+  const re = new RegExp('function\\s+' + name + '\\s*\\(');
+  const start = src.search(re);
+  if (start < 0) throw new Error(name + ' not found');
+  let i = src.indexOf('{', start);
+  let depth = 1; i++;
+  while (depth > 0 && i < src.length) {
+    if (src[i] === '{') depth++;
+    else if (src[i] === '}') depth--;
+    i++;
+  }
+  return src.slice(start, i);
+}
+eval(extractFunc('renderMd'));
+
+let buf = '';
+process.stdin.on('data', c => { buf += c; });
+process.stdin.on('end', () => { process.stdout.write(renderMd(buf)); });
+"""
+
+
+@pytest.fixture(scope="module")
+def driver_path(tmp_path_factory):
+    p = tmp_path_factory.mktemp("renderer_driver") / "driver.js"
+    p.write_text(_DRIVER_SRC, encoding="utf-8")
+    return str(p)
+
+
+def _render(driver_path, markdown: str) -> str:
+    import subprocess
+    result = subprocess.run(
+        [NODE, driver_path, str(UI_JS_PATH)],
+        input=markdown, capture_output=True, text=True, timeout=10,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"node driver failed: {result.stderr}")
+    return result.stdout
+
+
+class TestFencedCodeBlockIsolation:
+    """Content inside fenced code blocks must never be interpreted as markdown."""
+
+    def test_diff_block_plus_minus_lines_not_treated_as_list(self, driver_path):
+        html = _render(driver_path,
+            "before\n\n```diff\n- removed line\n+ added line\n```\nafter")
+        pre = _extract_pre(html)
+        assert pre is not None, "Expected a <pre> block"
+        assert "<ul>" not in pre, "List HTML must not appear inside <pre>"
+        assert "<li>" not in pre, "List items must not appear inside <pre>"
+        assert "- removed line" in pre
+        assert "+ added line" in pre
+        assert html.count("<pre") == html.count("</pre>"), \
+            "Every <pre> must have a matching </pre>"
+
+    def test_bash_block_asterisk_lines_not_treated_as_list(self, driver_path):
+        html = _render(driver_path,
+            "```bash\n* not a list item\n* another one\n```")
+        pre = _extract_pre(html)
+        assert pre is not None
+        assert "<ul>" not in pre
+        assert "<li>" not in pre
+
+    def test_markdown_block_heading_not_treated_as_h1(self, driver_path):
+        html = _render(driver_path,
+            "```markdown\n# Not a heading\n## Also not\n```")
+        pre = _extract_pre(html)
+        assert pre is not None
+        assert "<h1>" not in pre
+        assert "<h2>" not in pre
+        assert "# Not a heading" in pre
+
+    def test_markdown_block_bold_not_treated_as_strong(self, driver_path):
+        html = _render(driver_path, "```text\n**not bold**\n```")
+        pre = _extract_pre(html)
+        assert pre is not None
+        assert "<strong>" not in pre
+        assert "**not bold**" in pre
+
+    def test_content_after_code_block_renders_normally(self, driver_path):
+        html = _render(driver_path,
+            "```diff\n- old\n+ new\n```\n\n"
+            "# Real Heading\n\n- real list item\n\n**bold text**")
+        assert "<h1>Real Heading</h1>" in html
+        assert "<ul>" in html
+        assert "<strong>bold text</strong>" in html
+        pre = _extract_pre(html)
+        assert "<ul>" not in pre
+
+    def test_no_escaped_pre_closing_tag(self, driver_path):
+        html = _render(driver_path,
+            "```diff\n- old line\n+ new line\n```\n\nAfter the block")
+        assert "&lt;/pre&gt;" not in html, \
+            "Escaped </pre> indicates broken HTML nesting"
+
+    def test_code_block_without_language(self, driver_path):
+        html = _render(driver_path,
+            "```\n- item\n+ item\n```\n\n- real list")
+        pre = _extract_pre(html)
+        assert pre is not None
+        assert "<ul>" not in pre
+        assert html.count("<pre") == html.count("</pre>")
+
+    def test_inline_backtick_still_works(self, driver_path):
+        html = _render(driver_path, "Some **`code`** here")
+        assert "<strong><code>code</code></strong>" in html
+
+    def test_inline_backtick_inside_bold(self, driver_path):
+        html = _render(driver_path,
+            "Text with `inline code` and **bold**")
+        assert "<code>inline code</code>" in html
+        assert "<strong>bold</strong>" in html
+
+    def test_large_diff_output_no_corruption(self, driver_path):
+        diff_lines = "\n".join(
+            f"- old_line_{i}" if i % 2 == 0 else f"+ new_line_{i}"
+            for i in range(50)
+        )
+        html = _render(driver_path,
+            f"```diff\n{diff_lines}\n```\n\nSummary after diff")
+        pre = _extract_pre(html)
+        assert pre is not None
+        assert "<ul>" not in pre
+        assert "<li>" not in pre
+        assert html.count("<pre") == html.count("</pre>")
+        assert "Summary after diff" in html
+
+    def test_mixed_fenced_and_inline_code(self, driver_path):
+        html = _render(driver_path,
+            "Use `rm -rf` to delete:\n\n"
+            "```bash\nrm -rf /tmp/stuff\n```\n\nDone.")
+        assert "<code>rm -rf</code>" in html
+        pre = _extract_pre(html)
+        assert pre is not None
+        assert "rm -rf /tmp/stuff" in pre
+
+
+class TestFencedBlockPreHeaderPreserved:
+    """Pre-header div (language label) must still be generated."""
+
+    def test_language_header_present(self, driver_path):
+        html = _render(driver_path,
+            "```python\ndef hello():\n    pass\n```")
+        assert '<div class="pre-header">python</div>' in html
+
+    def test_no_language_no_header(self, driver_path):
+        html = _render(driver_path, "```\nsome code\n```")
+        assert "pre-header" not in html
+
+    def test_language_class_on_code_tag(self, driver_path):
+        html = _render(driver_path,
+            "```javascript\nconsole.log('hi')\n```")
+        assert 'class="language-javascript"' in html
+
+
+def _extract_pre(html):
+    m = re.search(r"<pre[^>]*>[\s\S]*?</pre>", html)
+    return m.group(0) if m else None

--- a/tests/test_issue347.py
+++ b/tests/test_issue347.py
@@ -176,7 +176,7 @@ def test_fence_stash_before_math_stash():
 def test_fence_stash_populated_before_math_stash():
     """The fence_stash s.replace call must appear before any math_stash s.replace calls."""
     # Find the s.replace call that populates each stash
-    fence_replace_pos = UI_JS.find("fence_stash.push(m)")
+    fence_replace_pos = UI_JS.find("fence_stash.push(")
     math_replace_pos = UI_JS.find("math_stash.push(")
     assert fence_replace_pos != -1, "fence_stash population call not found"
     assert math_replace_pos != -1, "math_stash population call not found"

--- a/tests/test_issue_code_syntax_highlight.py
+++ b/tests/test_issue_code_syntax_highlight.py
@@ -10,14 +10,15 @@ def _read_ui_js() -> str:
 
 def test_fenced_code_blocks_add_prism_language_class():
     js = _read_ui_js()
-    assert 'class="language-${esc(normalizedLang)}"' in js, (
+    assert 'class="language-${esc(lang)}"' in js, (
         "Fenced code blocks should add Prism language-* classes so syntax highlighting works"
     )
 
-
 def test_fenced_code_blocks_keep_existing_pre_header_layout():
     js = _read_ui_js()
-    assert 'return `${h}<pre><code${langAttr}>${esc(code.replace(/\\n$/,' in js, (
+    # The fenced code rendering was moved into the stash callback (#1154 fix).
+    # The template string now uses `lang` instead of `normalizedLang`.
+    assert '${h}<pre><code${langAttr}>${esc(code.replace(/\\n$/,' in js, (
         "The syntax-highlight fix should preserve the existing fenced code block layout"
     )
     assert '<div class="code-block">' not in js, (

--- a/tests/test_workspace_blank_page_fix.py
+++ b/tests/test_workspace_blank_page_fix.py
@@ -59,14 +59,15 @@ class TestBootJsProfileDefaultWorkspace:
         """The settings block (lines ~758-800 in boot.js) must set
         S._profileDefaultWorkspace from the /api/settings response."""
         src = read('static/boot.js')
-        # Find the settings fetch and the _profileDefaultWorkspace assignment
-        # and confirm both are in the same settings-read block (within ~50 lines)
-        ws_idx = src.find('_profileDefaultWorkspace')
+        # Find the settings fetch and the _profileDefaultWorkspace ASSIGNMENT
+        # (the if(s.default_workspace) line, not usages elsewhere in the file)
         settings_idx = src.find("await api('/api/settings')")
-        assert ws_idx != -1, "_profileDefaultWorkspace not found in boot.js"
         assert settings_idx != -1, "await api('/api/settings') not found in boot.js"
-        # Both must be within 300 chars of each other (same block)
-        assert abs(ws_idx - settings_idx) < 1000, (
+        # Find the assignment specifically — it uses 's.default_workspace'
+        ws_assign_idx = src.find('S._profileDefaultWorkspace=s.default_workspace')
+        assert ws_assign_idx != -1, "S._profileDefaultWorkspace assignment not found in boot.js"
+        # The assignment must be in the same settings-fetch block (within a few hundred chars)
+        assert abs(ws_assign_idx - settings_idx) < 1000, (
             "S._profileDefaultWorkspace must be set in the same settings-fetch block"
         )
 

--- a/tests/test_workspace_blocked_roots_macos.py
+++ b/tests/test_workspace_blocked_roots_macos.py
@@ -1,0 +1,137 @@
+"""
+Regression tests for the macOS symlink leg of the workspace blocked-roots check.
+
+On macOS, ``/etc``, ``/var``, and ``/tmp`` are symlinks to ``/private/etc``,
+``/private/var``, and ``/private/tmp``.  ``Path('/etc').resolve()`` returns
+``/private/etc`` — so a literal-only blocked-roots set would miss the
+resolved candidate and let the user register ``/etc`` as a workspace.
+
+Conversely, ``/private/var/folders/<hash>/T/`` is the per-user tmp tree
+(this is where pytest's ``tmp_path_factory`` writes), and must remain a
+valid workspace candidate even though it lives nominally under ``/var``.
+
+These tests run on every platform — on Linux all the macOS-aliased paths
+are no-ops because ``Path('/etc').resolve() == Path('/etc')``, but the
+Linux-side invariants (``/etc`` blocked, ``/tmp`` allowed) are also locked.
+"""
+from pathlib import Path
+
+import pytest
+
+from api.workspace import (
+    _USER_TMP_PREFIXES,
+    _is_blocked_system_path,
+    _workspace_blocked_roots,
+)
+
+
+# ── Blocked-roots set includes both literal and resolved forms ──────────────
+
+
+class TestBlockedRootsCanonicalisation:
+    def test_etc_literal_in_blocked_roots(self):
+        assert Path('/etc') in _workspace_blocked_roots()
+
+    def test_etc_resolved_in_blocked_roots(self):
+        """``/etc.resolve()`` is ``/private/etc`` on macOS; same path on Linux.
+        Either way the resolved form must appear in the set so a candidate
+        that crossed a symlink during ``.resolve()`` still matches."""
+        resolved = Path('/etc').resolve()
+        assert resolved in _workspace_blocked_roots()
+
+    def test_var_literal_and_resolved_in_blocked_roots(self):
+        assert Path('/var') in _workspace_blocked_roots()
+        assert Path('/var').resolve() in _workspace_blocked_roots()
+
+
+# ── /etc is rejected on both Linux and macOS ────────────────────────────────
+
+
+class TestEtcAlwaysBlocked:
+    def test_etc_resolved_form_blocked(self):
+        """The path-after-resolve form (``/private/etc`` on macOS, ``/etc`` on
+        Linux) must be blocked."""
+        assert _is_blocked_system_path(Path('/etc').resolve())
+
+    def test_etc_subpath_blocked(self):
+        assert _is_blocked_system_path(Path('/etc/hostname').resolve())
+
+    def test_private_etc_explicit_blocked(self):
+        """Even if the user writes ``/private/etc`` directly (knowing the
+        macOS layout), it must still be blocked."""
+        assert _is_blocked_system_path(Path('/private/etc'))
+
+
+# ── /var is selectively blocked (system parts) but tmp carve-outs work ──────
+
+
+class TestVarSystemBlockedButUserTmpAllowed:
+    def test_var_log_blocked(self):
+        """``/private/var/log`` would have been a macOS-only security gap
+        before this fix — it resolved through the ``/var`` symlink and
+        didn't match the literal blocked root."""
+        assert _is_blocked_system_path(Path('/var/log').resolve())
+
+    def test_private_var_log_blocked(self):
+        assert _is_blocked_system_path(Path('/private/var/log'))
+
+    def test_var_folders_user_tmp_allowed(self):
+        """macOS per-user tmp under /var/folders/<hash>/T/ — pytest's
+        tmp_path_factory writes here. Must remain registerable."""
+        # This path may not actually exist; the carve-out is path-shape based.
+        candidate = Path('/var/folders/abc/T/some-test-dir')
+        assert not _is_blocked_system_path(candidate)
+
+    def test_private_var_folders_user_tmp_allowed(self):
+        candidate = Path('/private/var/folders/abc/T/some-test-dir')
+        assert not _is_blocked_system_path(candidate)
+
+    def test_var_tmp_user_writable_allowed(self):
+        """``/var/tmp`` is system-wide user-writable tmp on Linux/macOS.
+        Carved out so users can register tmp dirs there."""
+        assert not _is_blocked_system_path(Path('/var/tmp/my-workspace'))
+        assert not _is_blocked_system_path(Path('/private/var/tmp/my-workspace'))
+
+
+# ── Carve-out invariants ───────────────────────────────────────────────────
+
+
+class TestUserTmpPrefixes:
+    def test_var_folders_in_carveouts(self):
+        assert Path('/var/folders') in _USER_TMP_PREFIXES
+        assert Path('/private/var/folders') in _USER_TMP_PREFIXES
+
+    def test_var_tmp_in_carveouts(self):
+        assert Path('/var/tmp') in _USER_TMP_PREFIXES
+        assert Path('/private/var/tmp') in _USER_TMP_PREFIXES
+
+    def test_carveouts_only_loosen_var_subtree(self):
+        """Carve-outs must not let /etc or other strict roots through."""
+        for tmp in _USER_TMP_PREFIXES:
+            # tmp paths are under /var or /private/var, never under /etc, /usr, /bin, etc.
+            assert str(tmp).startswith('/var/') or str(tmp).startswith('/private/var/')
+
+
+# ── Other roots: literal == resolved on both platforms ─────────────────────
+
+
+class TestNonSymlinkRootsUnchanged:
+    @pytest.mark.parametrize("root", [
+        '/usr', '/bin', '/sbin', '/proc', '/sys', '/dev', '/lib', '/opt/homebrew',
+    ])
+    def test_root_blocked(self, root):
+        # Whether or not the root exists, the literal form must be blocked.
+        assert _is_blocked_system_path(Path(root))
+        # And the resolved form (almost always equal to literal for these).
+        assert _is_blocked_system_path(Path(root).resolve())
+
+    @pytest.mark.parametrize("subpath", [
+        '/usr/local/bin/something',
+        '/proc/self/maps',
+        '/sys/class/net',
+        '/dev/null',
+    ])
+    def test_subpath_blocked(self, subpath):
+        # Use Path() not .resolve() — we want to assert the shape-based block,
+        # not test whether the path actually exists on the test runner.
+        assert _is_blocked_system_path(Path(subpath))

--- a/tests/test_workspace_blocked_roots_macos.py
+++ b/tests/test_workspace_blocked_roots_macos.py
@@ -10,10 +10,14 @@ Conversely, ``/private/var/folders/<hash>/T/`` is the per-user tmp tree
 (this is where pytest's ``tmp_path_factory`` writes), and must remain a
 valid workspace candidate even though it lives nominally under ``/var``.
 
-These tests run on every platform — on Linux all the macOS-aliased paths
-are no-ops because ``Path('/etc').resolve() == Path('/etc')``, but the
-Linux-side invariants (``/etc`` blocked, ``/tmp`` allowed) are also locked.
+The ``TestEtcAlwaysBlocked`` and ``TestVarSystemBlockedButUserTmpAllowed``
+classes contain checks that depend on the macOS layout (where ``/etc``
+resolves to ``/private/etc``); those tests are skipped on Linux where
+``/etc.resolve() == /etc`` and the ``/private/*`` aliases simply don't exist.
+The cross-platform invariants (``/etc`` literal blocked, ``/tmp`` allowed,
+non-symlink roots blocked) run on every platform.
 """
+import sys
 from pathlib import Path
 
 import pytest
@@ -23,6 +27,10 @@ from api.workspace import (
     _is_blocked_system_path,
     _workspace_blocked_roots,
 )
+
+
+_IS_MACOS = sys.platform == 'darwin'
+_macos_only = pytest.mark.skipif(not _IS_MACOS, reason="macOS-specific symlink layout")
 
 
 # ── Blocked-roots set includes both literal and resolved forms ──────────────
@@ -56,9 +64,12 @@ class TestEtcAlwaysBlocked:
     def test_etc_subpath_blocked(self):
         assert _is_blocked_system_path(Path('/etc/hostname').resolve())
 
+    @_macos_only
     def test_private_etc_explicit_blocked(self):
         """Even if the user writes ``/private/etc`` directly (knowing the
-        macOS layout), it must still be blocked."""
+        macOS layout), it must still be blocked.  Skipped on Linux —
+        ``/private/etc`` doesn't exist there and ``Path('/etc').resolve()``
+        is ``/etc`` so the resolved-form aliasing is a no-op."""
         assert _is_blocked_system_path(Path('/private/etc'))
 
 
@@ -72,7 +83,11 @@ class TestVarSystemBlockedButUserTmpAllowed:
         didn't match the literal blocked root."""
         assert _is_blocked_system_path(Path('/var/log').resolve())
 
+    @_macos_only
     def test_private_var_log_blocked(self):
+        """Skipped on Linux: ``/private/var/log`` isn't an alias for
+        ``/var/log`` there; ``Path('/var').resolve() == /var`` so no
+        ``/private/var`` ever lands in the blocked set."""
         assert _is_blocked_system_path(Path('/private/var/log'))
 
     def test_var_folders_user_tmp_allowed(self):

--- a/tests/test_workspace_panel_persists_on_empty_boot.py
+++ b/tests/test_workspace_panel_persists_on_empty_boot.py
@@ -1,0 +1,138 @@
+"""
+Regression tests for the workspace panel persisting across page reload on
+empty-session and no-session boot paths.
+
+Two boot paths previously dropped the workspace panel even when the user had
+explicitly opened it before reloading:
+
+  1. Ephemeral-session guard added in #1182: when the restored session has
+     0 messages, boot clears localStorage and shows the empty state. This
+     path was calling ``syncWorkspacePanelState()`` without first restoring
+     ``_workspacePanelMode`` from localStorage.
+  2. No-saved-session path: a fresh page load with no localStorage session
+     also went straight to ``syncWorkspacePanelState()`` without restoring
+     the panel preference.
+
+Both paths force-closed the panel because ``syncWorkspacePanelState()``
+unconditionally set ``_workspacePanelMode='closed'`` whenever ``S.session``
+was null — even when the user's preference was 'open'.
+
+Fix verified by these tests:
+
+  - ``syncWorkspacePanelState`` checks ``_workspacePanelMode==='preview'``
+    BEFORE force-closing, so 'browse' mode is preserved without a session.
+  - Both boot paths read the panel pref from localStorage and set
+    ``_workspacePanelMode='browse'`` before calling sync.
+  - ``canBrowse`` and ``openWorkspacePanel()`` include
+    ``S._profileDefaultWorkspace`` so the toggle stays enabled.
+"""
+import pathlib
+
+REPO = pathlib.Path(__file__).parent.parent
+BOOT_JS = (REPO / "static" / "boot.js").read_text(encoding="utf-8")
+
+
+# ── 1. syncWorkspacePanelState preserves browse mode without a session ──────
+
+
+class TestSyncStateNoSession:
+    def test_preview_mode_without_session_force_closes(self):
+        """A 'preview' panel needs file content from a session — close it
+        when there's no session."""
+        idx = BOOT_JS.find("function syncWorkspacePanelState()")
+        body = BOOT_JS[idx:idx + 800]
+        assert "_workspacePanelMode==='preview'" in body, (
+            "syncWorkspacePanelState must check _workspacePanelMode==='preview' "
+            "before force-closing on no-session boot"
+        )
+        assert "_setWorkspacePanelMode('closed')" in body, (
+            "syncWorkspacePanelState still must close 'preview' mode without a session"
+        )
+
+    def test_browse_mode_calls_sync_ui_instead_of_force_close(self):
+        """For 'browse' mode without a session, syncWorkspacePanelUI() should
+        run so the panel renders its 'no workspace' or default-workspace state
+        rather than being force-closed."""
+        idx = BOOT_JS.find("function syncWorkspacePanelState()")
+        body = BOOT_JS[idx:idx + 800]
+        # The else branch (browse / closed mode without session) calls UI sync
+        assert "syncWorkspacePanelUI()" in body, (
+            "syncWorkspacePanelState must call syncWorkspacePanelUI() in the "
+            "no-session, non-preview branch so 'browse' mode is preserved"
+        )
+
+
+# ── 2. Both boot paths restore panelPref before sync ────────────────────────
+
+
+class TestBootPathsRestorePanelPref:
+    PREF_PATTERN = "hermes-webui-workspace-panel-pref"
+
+    def test_ephemeral_path_restores_panel_pref(self):
+        """The empty-session guard (#1182) must read panelPref before
+        calling syncWorkspacePanelState()."""
+        # Find the ephemeral guard — it's marked by message_count===0 check
+        eph_idx = BOOT_JS.find("(S.session.message_count||0) === 0")
+        assert eph_idx > 0, "Empty-session guard not found in boot IIFE"
+        # The next syncWorkspacePanelState() call after this point is in the ephemeral path
+        sync_idx = BOOT_JS.find("syncWorkspacePanelState()", eph_idx)
+        assert sync_idx > 0, "syncWorkspacePanelState call not found in ephemeral path"
+        # panelPref must be read between the guard and the sync call
+        block = BOOT_JS[eph_idx:sync_idx]
+        assert self.PREF_PATTERN in block, (
+            "Ephemeral-session boot path must read 'hermes-webui-workspace-panel-pref' "
+            "from localStorage before calling syncWorkspacePanelState()"
+        )
+        assert "_workspacePanelMode='browse'" in block or "_workspacePanelMode = 'browse'" in block, (
+            "Ephemeral-session path must set _workspacePanelMode='browse' "
+            "when the pref is 'open'"
+        )
+
+    def test_no_session_path_restores_panel_pref(self):
+        """The fresh-load (no localStorage session) path must read panelPref
+        before calling syncWorkspacePanelState()."""
+        # Find the comment marker that precedes the no-session path
+        marker = "no saved session"
+        m_idx = BOOT_JS.find(marker)
+        assert m_idx > 0, "no-saved-session path not found"
+        # syncWorkspacePanelState should appear shortly after
+        sync_idx = BOOT_JS.find("syncWorkspacePanelState()", m_idx)
+        assert sync_idx > 0, "syncWorkspacePanelState() not found after no-saved-session marker"
+        block = BOOT_JS[m_idx:sync_idx]
+        assert self.PREF_PATTERN in block, (
+            "No-saved-session boot path must read 'hermes-webui-workspace-panel-pref' "
+            "before calling syncWorkspacePanelState()"
+        )
+        assert "_workspacePanelMode='browse'" in block or "_workspacePanelMode = 'browse'" in block, (
+            "No-saved-session path must set _workspacePanelMode='browse' "
+            "when the pref is 'open'"
+        )
+
+
+# ── 3. Toggle button stays enabled when profile default workspace exists ────
+
+
+class TestToggleStaysEnabledWithProfileWorkspace:
+    def test_can_browse_includes_profile_default_workspace(self):
+        """The toggle button's enabled state (canBrowse) must be true when
+        S._profileDefaultWorkspace is set, even with no active session."""
+        idx = BOOT_JS.find("const canBrowse=")
+        assert idx > 0, "canBrowse declaration not found in syncWorkspacePanelUI"
+        line = BOOT_JS[idx:idx + 200].split("\n", 1)[0]
+        assert "_profileDefaultWorkspace" in line, (
+            "canBrowse must include S._profileDefaultWorkspace so the toggle "
+            "button stays enabled when a profile workspace is configured"
+        )
+
+    def test_open_workspace_panel_allows_browse_with_profile_workspace(self):
+        """openWorkspacePanel('browse') must not return early when
+        S._profileDefaultWorkspace is set, otherwise clicking the toggle
+        won't open the panel even though canBrowse said it should."""
+        idx = BOOT_JS.find("function openWorkspacePanel(")
+        body = BOOT_JS[idx:idx + 600]
+        # The early-return guard should include the profile-workspace check
+        assert "_profileDefaultWorkspace" in body, (
+            "openWorkspacePanel must include S._profileDefaultWorkspace in its "
+            "early-return guard so users can open the panel via the toggle "
+            "button when a profile workspace is configured"
+        )


### PR DESCRIPTION
Batch release v0.50.231 — 3 fixes.

## PRs included

| PR | Author | Fix |
|---|---|---|
| #1186 | @nesquena (Claude Code) | macOS `/etc` symlink bypass in workspace blocked-roots |
| #1187 | @nesquena-hermes | Workspace panel stuck closed after empty-session reload |
| #1190 | @bergeouss | Fenced code content leaking into markdown passes (#1154) |

All three PRs were independently reviewed and approved by @nesquena.

## Test results

**2729 passed, 2 skipped** (2 macOS-only tests correctly skipped on Linux). Browser QA: **21/21**.

## Key fix notes

**#1186:** `_workspace_blocked_roots()` now returns both literal and `Path.resolve()` forms of each blocked root. macOS symlinks (`/etc → /private/etc`) previously let a resolved candidate slip past the literal check. New `_is_blocked_system_path()` helper with `/var/folders` and `/var/tmp` carve-outs for pytest temp dirs.

**#1187:** Regression from #1182 — `syncWorkspacePanelState()` force-closed on any no-session state. Now only closes in `'preview'` mode. Both boot paths restore localStorage panel pref before sync.

**#1190:** Fenced code blocks are now stashed as `\x00P<n>\x00` tokens through ALL markdown passes (list/heading/table regexes), restored at the very end. Previously, diff hunks and markdown headings inside code blocks triggered those regexes, injecting `<ul>/<li>/<h>` tags that broke `</pre>` closure.
