### PR TITLE
fix(ui): workspace files stay visible on repeated blank-page reloads

### DIFF
--- a/static/boot.js
+++ b/static/boot.js
@@ -898,11 +898,12 @@ function applyBotName(){
       await loadSession(saved);
       // If the restored session has no messages it is an ephemeral scratch pad —
       // treat the page as a fresh start rather than resuming a blank conversation.
-      // The session stays on disk (it will be cleaned up later) but we don't surface
-      // it or lock the user into it. Clear the stored ID so a true new session is
-      // created the first time the user hits + or sends a message (#1171).
+      // loadSession() already ran, so loadDir() has populated the workspace file tree.
+      // Do NOT remove the session ID from localStorage — keeping it means every
+      // subsequent refresh will also run loadSession() → loadDir() → files stay visible.
+      // Removing it here caused the file tree to go blank on the second refresh
+      // because the "no saved session" path never calls loadDir (#workspace-files).
       if(S.session && (S.session.message_count||0) === 0){
-        localStorage.removeItem('hermes-webui-session');
         S.session=null; S.messages=[];
         S._bootReady=true;
         // Restore panel pref before syncing so the workspace panel stays visible

--- a/tests/test_workspace_files_persist_on_empty_reload.py
+++ b/tests/test_workspace_files_persist_on_empty_reload.py
@@ -1,0 +1,78 @@
+"""
+Regression test for #workspace-files: workspace file tree must stay
+visible across REPEATED blank-page reloads (not just the first one).
+
+Bug shape: PR #1182's ephemeral guard removed the stored session ID from
+localStorage when it detected a 0-message session. That made the FIRST
+refresh work (loadSession → loadDir → files render, then guard fires and
+clears the key), but the SECOND refresh fell into the "no saved session"
+boot path which never calls loadDir() — file tree went blank.
+
+Fix: keep the session ID in localStorage. Every refresh runs the same
+path:
+  loadSession() → loadDir() populates the workspace
+  → ephemeral guard fires → S.session=null in memory only
+  → workspace panel stays open with files visible
+
+The session ID persisting in localStorage is harmless — server-side
+``all_sessions()`` filters Untitled+0-message sessions so no phantom
+sidebar entry appears, and ``newSession()`` overwrites the key when the
+user actually creates a real session.
+"""
+import pathlib
+import re
+
+REPO = pathlib.Path(__file__).parent.parent
+BOOT_JS = (REPO / "static" / "boot.js").read_text(encoding="utf-8")
+
+
+def test_ephemeral_guard_does_not_remove_session_localstorage_key():
+    """The empty-session guard block must NOT call
+    localStorage.removeItem('hermes-webui-session') — that's exactly what
+    breaks the second refresh."""
+    # Find the guard block (message_count===0 check)
+    guard_idx = BOOT_JS.find("(S.session.message_count||0) === 0")
+    assert guard_idx > 0, "Empty-session guard block not found in boot IIFE"
+    # The block runs until 'return;' that exits the IIFE early
+    block_end = BOOT_JS.find("return;", guard_idx)
+    assert block_end > guard_idx
+    block = BOOT_JS[guard_idx:block_end]
+    assert "removeItem('hermes-webui-session')" not in block, (
+        "The empty-session guard must NOT remove 'hermes-webui-session' from "
+        "localStorage. Removing it sends the next refresh into the no-saved-"
+        "session boot path which never calls loadDir(), leaving the workspace "
+        "file tree permanently blank (#workspace-files)."
+    )
+    assert 'removeItem("hermes-webui-session")' not in block, (
+        "Same as above (double-quoted form)."
+    )
+
+
+def test_ephemeral_guard_still_clears_in_memory_session_state():
+    """The guard MUST still clear ``S.session`` and ``S.messages`` in memory
+    so the user isn't locked into an empty conversation. Only the
+    localStorage cleanup is what was removed."""
+    guard_idx = BOOT_JS.find("(S.session.message_count||0) === 0")
+    block_end = BOOT_JS.find("return;", guard_idx)
+    block = BOOT_JS[guard_idx:block_end]
+    # Both in-memory clears must remain
+    assert re.search(r"S\.session\s*=\s*null", block), (
+        "Empty-session guard must still set S.session=null so the empty "
+        "scratch-pad is not surfaced as the active conversation"
+    )
+    assert re.search(r"S\.messages\s*=\s*\[\]", block), (
+        "Empty-session guard must still reset S.messages=[]"
+    )
+
+
+def test_ephemeral_guard_still_restores_panel_pref():
+    """PR #1187's panel-pref restore must still happen in the same block —
+    that's how the workspace panel stays visible on the empty-session
+    refresh path."""
+    guard_idx = BOOT_JS.find("(S.session.message_count||0) === 0")
+    block_end = BOOT_JS.find("return;", guard_idx)
+    block = BOOT_JS[guard_idx:block_end]
+    assert "hermes-webui-workspace-panel-pref" in block, (
+        "Empty-session guard must still read 'hermes-webui-workspace-panel-pref' "
+        "from localStorage to keep the panel open across refreshes (#1187)"
+    )


### PR DESCRIPTION
## Summary

Fixes a secondary bug left after PR #1187: the workspace file tree goes blank on the **second** refresh of an empty new conversation, even though the first refresh works fine.

## Root cause

The ephemeral guard (added in the ephemeral-sessions PR) called `localStorage.removeItem('hermes-webui-session')` after detecting a 0-message session. This made the key absent on the next page load, sending the boot sequence into the "no saved session" path — which never calls `loadDir()`.

Exact sequence with the bug:

| Event | localStorage key | loadDir called? | Files visible? |
|---|---|---|---|
| Click + (new session) | `session_A_id` | ✅ (by newSession) | ✅ |
| **Refresh 1** | `session_A_id` → **removed** by guard | ✅ (by loadSession) | ✅ |
| **Refresh 2** | `null` → "no saved session" path | ❌ never called | ❌ blank |
| Refresh 3, 4… | `null` | ❌ | ❌ still blank |

## Fix

Remove the `localStorage.removeItem()` call. The session ID stays in localStorage so every blank-page refresh takes the same path:

```
loadSession() → loadDir() → files populate DOM
→ ephemeral guard fires → S.session = null in memory
→ workspace panel stays open, files visible
```

The session ID remaining in localStorage is safe:
- Ephemeral guard still fires on every refresh → `S.session` cleared from memory → no active session context
- Session stays invisible in the sidebar (server-side `/api/sessions` filter removes Untitled+0-msg entries)
- No "Untitled" entry accumulates — the server filter was already handling that before the localStorage removal was added
- When the user sends their first message, `newSession()` creates a real session and overwrites the localStorage key normally

## Testing

2729 tests passing. Manual sequence verified:
1. Click New Conversation
2. Refresh → workspace panel open, files visible ✅
3. Refresh again → workspace panel open, files still visible ✅
4. Refresh N more times → always shows files ✅
5. Send a message → new session created, sidebar entry appears ✅
