### PR TITLE
Fix #1144: sync session timestamps with server clock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ docs/*
 # Local-only PR review harness: rendering drivers, sample bank, fixtures.
 # Used by Claude during deep reviews; never shared in the repo.
 .local-review/
+graphify-out/

--- a/api/routes.py
+++ b/api/routes.py
@@ -935,7 +935,12 @@ def handle_get(handler, parsed) -> bool:
             if isinstance(item.get("title"), str):
                 item["title"] = _redact_text(item["title"])
             safe_merged.append(item)
-        return j(handler, {"sessions": safe_merged, "cli_count": len(deduped_cli)})
+        return j(handler, {
+            "sessions": safe_merged,
+            "cli_count": len(deduped_cli),
+            "server_time": time.time(),
+            "server_tz": time.strftime("%z"),
+        })
 
     if parsed.path == "/api/projects":
         return j(handler, {"projects": load_projects()})

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -591,6 +591,16 @@ async function renderSessionList(){
     ]);
     _allSessions = sessData.sessions||[];
     _allProjects = projData.projects||[];
+    // Capture server clock for clock-skew compensation (issue #1144).
+    // server_time is epoch seconds from the server's time.time().
+    // _serverTimeDelta = client - server, so (Date.now() - _serverTimeDelta)
+    // gives an approximation of the current server time.
+    if (typeof sessData.server_time === 'number' && sessData.server_time > 0) {
+      _serverTimeDelta = Date.now() - (sessData.server_time * 1000);
+    }
+    if (typeof sessData.server_tz === 'string') {
+      _serverTz = sessData.server_tz;
+    }
     const isStreaming = _allSessions.some(s => Boolean(s && s.is_streaming));
     if (isStreaming) {
       startStreamingPoll();
@@ -735,6 +745,8 @@ function stopGatewaySSE(){
 
 let _searchDebounceTimer = null;
 let _contentSearchResults = [];  // results from /api/sessions/search content scan
+let _serverTimeDelta = 0;       // ms offset: client clock - server clock (for clock-skew compensation)
+let _serverTz = '';              // server timezone offset string (e.g. "+0800", "+0000", "-0500")
 
 function filterSessions(){
   // Immediate client-side title filter (no flicker)
@@ -758,12 +770,30 @@ function _sessionTimestampMs(session) {
   return Number.isFinite(raw) ? raw * 1000 : 0;
 }
 
+function _serverNowMs() {
+  // Compensate for clock skew between client and server (issue #1144).
+  // Returns an approximation of the current server time in ms.
+  return Date.now() - _serverTimeDelta;
+}
+
+function _serverTzOptions() {
+  // Build a timeZone option from _serverTz (e.g. "+0800" → "Etc/GMT-8").
+  // Falls back to undefined (uses browser timezone) if _serverTz is not set.
+  if (!_serverTz || _serverTz === '+0000' || _serverTz === '-0000') return undefined;
+  const m = _serverTz.match(/^([+-])(\d{2})(\d{2})$/);
+  if (!m) return undefined;
+  // IANA Etc/GMT uses inverted sign: UTC+8 → "Etc/GMT-8"
+  const sign = m[1] === '+' ? '-' : '+';
+  return { timeZone: `Etc/GMT${sign}${parseInt(m[2])}` };
+}
+
 function _localDayOrdinal(timestampMs) {
   const date = new Date(timestampMs);
   return Math.floor(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()) / 86400000);
 }
 
-function _sessionCalendarBoundaries(nowMs = Date.now()) {
+function _sessionCalendarBoundaries(nowMs) {
+  nowMs = nowMs || _serverNowMs();
   const now = new Date(nowMs);
   const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate());
   const startOfYesterday = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 1);
@@ -779,7 +809,8 @@ function _sessionCalendarBoundaries(nowMs = Date.now()) {
   };
 }
 
-function _formatSessionDate(timestampMs, nowMs = Date.now()) {
+function _formatSessionDate(timestampMs, nowMs) {
+  nowMs = nowMs || _serverNowMs();
   const date = new Date(timestampMs);
   const now = new Date(nowMs);
   const options = {month:'short', day:'numeric'};
@@ -787,8 +818,9 @@ function _formatSessionDate(timestampMs, nowMs = Date.now()) {
   return date.toLocaleDateString(undefined, options);
 }
 
-function _formatRelativeSessionTime(timestampMs, nowMs = Date.now()) {
+function _formatRelativeSessionTime(timestampMs, nowMs) {
   if (!timestampMs) return t('session_time_unknown');
+  nowMs = nowMs || _serverNowMs();
   const diffMs = Math.max(0, nowMs - timestampMs);
   const minute = 60 * 1000;
   const hour = 60 * minute;
@@ -809,8 +841,9 @@ function _formatRelativeSessionTime(timestampMs, nowMs = Date.now()) {
   return _formatSessionDate(timestampMs, nowMs);
 }
 
-function _sessionTimeBucketLabel(timestampMs, nowMs = Date.now()) {
+function _sessionTimeBucketLabel(timestampMs, nowMs) {
   if (!timestampMs) return t('session_time_bucket_older');
+  nowMs = nowMs || _serverNowMs();
   const {startOfToday, startOfYesterday, startOfWeek, startOfLastWeek} = _sessionCalendarBoundaries(nowMs);
   if (timestampMs >= startOfToday) return t('session_time_bucket_today');
   if (timestampMs >= startOfYesterday) return t('session_time_bucket_yesterday');
@@ -919,7 +952,7 @@ function renderSessionListFromCache(){
   const pinned=orderedSessions.filter(s=>s.pinned);
   const unpinned=orderedSessions.filter(s=>!s.pinned);
   // Date grouping: Pinned / Today / Yesterday / This week / Last week / Older
-  const now=Date.now();
+  const now=_serverNowMs();
   // Collapse state persisted in localStorage
   let _groupCollapsed={};
   try{_groupCollapsed=JSON.parse(localStorage.getItem('hermes-date-groups-collapsed')||'{}');}catch(e){}

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -778,13 +778,41 @@ function _serverNowMs() {
 
 function _serverTzOptions() {
   // Build a timeZone option from _serverTz (e.g. "+0800" → "Etc/GMT-8").
-  // Falls back to undefined (uses browser timezone) if _serverTz is not set.
+  // Falls back to undefined (uses browser timezone) when:
+  //   - _serverTz is not set or is UTC (no offset to apply)
+  //   - _serverTz is malformed
+  //   - _serverTz has a fractional-hour component (India +0530, Iran +0330,
+  //     Newfoundland -0330, Nepal +0545, etc.) — IANA Etc/GMT zones cannot
+  //     express half/quarter-hour offsets; use _formatInServerTz() instead
+  //     for correct fractional-offset formatting.
   if (!_serverTz || _serverTz === '+0000' || _serverTz === '-0000') return undefined;
   const m = _serverTz.match(/^([+-])(\d{2})(\d{2})$/);
   if (!m) return undefined;
+  if (m[3] !== '00') return undefined;  // fractional offset — caller must use _formatInServerTz
   // IANA Etc/GMT uses inverted sign: UTC+8 → "Etc/GMT-8"
   const sign = m[1] === '+' ? '-' : '+';
   return { timeZone: `Etc/GMT${sign}${parseInt(m[2])}` };
+}
+
+function _formatInServerTz(date, options) {
+  // Format `date` in the server's wall-clock timezone, including correct
+  // handling of fractional-hour offsets that Etc/GMT cannot express.
+  //
+  // Strategy: shift the timestamp by the server's offset, then format with
+  // timeZone:'UTC' so no further conversion is applied — the formatted
+  // output reads as the wall-clock time in the server's timezone.
+  //
+  // Falls back to plain `date.toLocaleString(undefined, options)` (browser
+  // timezone) when _serverTz is absent, UTC, or malformed.
+  if (!_serverTz || _serverTz === '+0000' || _serverTz === '-0000') {
+    return date.toLocaleString(undefined, options);
+  }
+  const m = _serverTz.match(/^([+-])(\d{2})(\d{2})$/);
+  if (!m) return date.toLocaleString(undefined, options);
+  const sign = m[1] === '+' ? 1 : -1;
+  const offsetMin = sign * (parseInt(m[2]) * 60 + parseInt(m[3]));
+  const adjusted = new Date(date.getTime() + offsetMin * 60 * 1000);
+  return adjusted.toLocaleString(undefined, { ...options, timeZone: 'UTC' });
 }
 
 function _localDayOrdinal(timestampMs) {

--- a/static/ui.js
+++ b/static/ui.js
@@ -2148,14 +2148,16 @@ function _formatMessageFooterTimestamp(tsVal){
   if(!tsVal) return '';
   const date=new Date(tsVal*1000);
   const now=new Date();
+  const tzOpts=(typeof _serverTzOptions==='function')?_serverTzOptions():undefined;
   if(_isSameLocalDay(date, now)){
-    return date.toLocaleTimeString([], {hour:'2-digit', minute:'2-digit'});
+    return date.toLocaleTimeString([], {hour:'2-digit', minute:'2-digit', ...tzOpts});
   }
   return date.toLocaleString([], {
     month:'short',
     day:'numeric',
     hour:'numeric',
     minute:'2-digit',
+    ...tzOpts,
   });
 }
 function _compressionStatusCardHtml({
@@ -2361,7 +2363,8 @@ function renderMessages(){
     const retryBtn = isLastAssistant ? `<button class="msg-action-btn" title="${t('regenerate')}" onclick="regenerateResponse(this)">${li('rotate-ccw',13)}</button>` : '';
     const copyBtn  = `<button class="msg-copy-btn msg-action-btn" title="${t('copy')}" onclick="copyMsg(this)">${li('copy',13)}</button>`;
     const tsVal=m._ts||m.timestamp;
-    const tsTitle=tsVal?new Date(tsVal*1000).toLocaleString():'';
+    const _tzo=(typeof _serverTzOptions==='function')?_serverTzOptions():undefined;
+    const tsTitle=tsVal?new Date(tsVal*1000).toLocaleString([],_tzo):'';
     const tsTime=_formatMessageFooterTimestamp(tsVal);
     const timeHtml = tsTime ? `<span class="msg-time" title="${esc(tsTitle)}">${tsTime}</span>` : '';
     const footHtml = `<div class="msg-foot">${timeHtml}<span class="msg-actions">${editBtn}${copyBtn}${retryBtn}</span></div>`;

--- a/static/ui.js
+++ b/static/ui.js
@@ -2148,17 +2148,16 @@ function _formatMessageFooterTimestamp(tsVal){
   if(!tsVal) return '';
   const date=new Date(tsVal*1000);
   const now=new Date();
-  const tzOpts=(typeof _serverTzOptions==='function')?_serverTzOptions():undefined;
+  // Use _formatInServerTz when available — it correctly handles fractional-hour
+  // offsets like India +0530 that Etc/GMT cannot express. Falls back to plain
+  // toLocaleString when sessions.js hasn't loaded yet.
+  const fmt=(typeof _formatInServerTz==='function')?_formatInServerTz:null;
   if(_isSameLocalDay(date, now)){
-    return date.toLocaleTimeString([], {hour:'2-digit', minute:'2-digit', ...tzOpts});
+    const opts={hour:'2-digit', minute:'2-digit'};
+    return fmt?fmt(date,opts):date.toLocaleTimeString([], opts);
   }
-  return date.toLocaleString([], {
-    month:'short',
-    day:'numeric',
-    hour:'numeric',
-    minute:'2-digit',
-    ...tzOpts,
-  });
+  const opts={month:'short', day:'numeric', hour:'numeric', minute:'2-digit'};
+  return fmt?fmt(date,opts):date.toLocaleString([], opts);
 }
 function _compressionStatusCardHtml({
   statusLabel,
@@ -2363,8 +2362,10 @@ function renderMessages(){
     const retryBtn = isLastAssistant ? `<button class="msg-action-btn" title="${t('regenerate')}" onclick="regenerateResponse(this)">${li('rotate-ccw',13)}</button>` : '';
     const copyBtn  = `<button class="msg-copy-btn msg-action-btn" title="${t('copy')}" onclick="copyMsg(this)">${li('copy',13)}</button>`;
     const tsVal=m._ts||m.timestamp;
-    const _tzo=(typeof _serverTzOptions==='function')?_serverTzOptions():undefined;
-    const tsTitle=tsVal?new Date(tsVal*1000).toLocaleString([],_tzo):'';
+    // _formatInServerTz handles fractional-hour offsets (India +0530 etc.)
+    // correctly via offset arithmetic; bare toLocaleString is the browser-tz fallback.
+    const _fmtSv=(typeof _formatInServerTz==='function')?_formatInServerTz:null;
+    const tsTitle=tsVal?(_fmtSv?_fmtSv(new Date(tsVal*1000),{}):new Date(tsVal*1000).toLocaleString()):'';
     const tsTime=_formatMessageFooterTimestamp(tsVal);
     const timeHtml = tsTime ? `<span class="msg-time" title="${esc(tsTitle)}">${tsTime}</span>` : '';
     const footHtml = `<div class="msg-foot">${timeHtml}<span class="msg-actions">${editBtn}${copyBtn}${retryBtn}</span></div>`;

--- a/tests/test_issue1144_session_time_sync.py
+++ b/tests/test_issue1144_session_time_sync.py
@@ -326,7 +326,7 @@ def _extract_is_same_local_day() -> str:
 
 
 def test_message_footer_timestamp_uses_server_tz():
-    """_formatMessageFooterTimestamp should use _serverTzOptions for display."""
+    """_formatMessageFooterTimestamp should use _formatInServerTz for display."""
     is_same_day_fn = _extract_is_same_local_day()
     fmt_fn = _extract_ui_function("_formatMessageFooterTimestamp")
     script = textwrap.dedent(
@@ -334,16 +334,22 @@ def test_message_footer_timestamp_uses_server_tz():
         process.env.TZ = 'America/New_York';
         let _serverTimeDelta = 0;
         let _serverTz = '+0800';
-        function _serverTzOptions() {{
-          if (!_serverTz || _serverTz === '+0000' || _serverTz === '-0000') return undefined;
+        // Stub _formatInServerTz with the same offset-arithmetic semantics
+        // as the real implementation in sessions.js.
+        function _formatInServerTz(date, options) {{
+          if (!_serverTz || _serverTz === '+0000' || _serverTz === '-0000') {{
+            return date.toLocaleString(undefined, options);
+          }}
           const m = _serverTz.match(/^([+-])(\\d{{2}})(\\d{{2}})$/);
-          if (!m) return undefined;
-          const sign = m[1] === '+' ? '-' : '+';
-          return {{ timeZone: `Etc/GMT${{sign}}${{parseInt(m[2])}}` }};
+          if (!m) return date.toLocaleString(undefined, options);
+          const sign = m[1] === '+' ? 1 : -1;
+          const offsetMin = sign * (parseInt(m[2]) * 60 + parseInt(m[3]));
+          const adjusted = new Date(date.getTime() + offsetMin * 60 * 1000);
+          return adjusted.toLocaleString(undefined, {{ ...options, timeZone: 'UTC' }});
         }}
         {is_same_day_fn}
         {fmt_fn}
-        // Timestamp for 2026-04-28 10:00:00 UTC = 18:00 UTC+8
+        // Timestamp for 2026-03-29 02:00:00 UTC = 10:00 in UTC+8
         const tsVal = 1774749600;
         const result = _formatMessageFooterTimestamp(tsVal);
         process.stdout.write(JSON.stringify({{ formatted: result }}));
@@ -351,9 +357,58 @@ def test_message_footer_timestamp_uses_server_tz():
     )
     proc = subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True)
     data = json.loads(proc.stdout)
-    # Should display in Etc/GMT-8 timezone (UTC+8), not America/New_York
-    # 2026-03-29 02:00 UTC = 10:00 AM in Etc/GMT-8
-    assert "10:00 AM" in data["formatted"]
+    # Should display in UTC+8, not America/New_York.
+    # 2026-03-29 02:00 UTC = 10:00 in UTC+8
+    assert "10:00 AM" in data["formatted"], (
+        f"Expected '10:00 AM' (UTC+8 wall-clock) in {data['formatted']!r}"
+    )
+
+
+def test_message_footer_timestamp_handles_fractional_offset():
+    """_formatMessageFooterTimestamp must correctly format in IST (+0530) and
+    other half-hour offsets — Etc/GMT can't express these but offset
+    arithmetic in _formatInServerTz handles them correctly. Affects ~1.5B
+    users in India, Iran, Newfoundland, Nepal, Sri Lanka, etc."""
+    is_same_day_fn = _extract_is_same_local_day()
+    fmt_fn = _extract_ui_function("_formatMessageFooterTimestamp")
+    script = textwrap.dedent(
+        f"""
+        process.env.TZ = 'UTC';
+        let _serverTimeDelta = 0;
+        let _serverTz = '+0530';  // India IST
+        function _formatInServerTz(date, options) {{
+          if (!_serverTz || _serverTz === '+0000' || _serverTz === '-0000') {{
+            return date.toLocaleString(undefined, options);
+          }}
+          const m = _serverTz.match(/^([+-])(\\d{{2}})(\\d{{2}})$/);
+          if (!m) return date.toLocaleString(undefined, options);
+          const sign = m[1] === '+' ? 1 : -1;
+          const offsetMin = sign * (parseInt(m[2]) * 60 + parseInt(m[3]));
+          const adjusted = new Date(date.getTime() + offsetMin * 60 * 1000);
+          return adjusted.toLocaleString(undefined, {{ ...options, timeZone: 'UTC' }});
+        }}
+        {is_same_day_fn}
+        {fmt_fn}
+        // 2026-03-29 02:00:00 UTC = 07:30 IST (UTC+5:30)
+        const tsVal = 1774749600;
+        const result = _formatMessageFooterTimestamp(tsVal);
+        process.stdout.write(JSON.stringify({{ formatted: result }}));
+        """
+    )
+    proc = subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True)
+    data = json.loads(proc.stdout)
+    # 2026-03-29 02:00 UTC = 07:30 IST. Old Etc/GMT-5 mapping would have shown 07:00.
+    # Accept either "07:30" or "7:30" (en-US uses hour:'numeric' for non-same-day).
+    formatted = data["formatted"]
+    assert "07:30" in formatted or "7:30" in formatted, (
+        f"Expected '7:30' (IST = UTC+5:30 wall-clock) in {formatted!r}; "
+        "Etc/GMT-5 path would show 7:00 — off by 30 min."
+    )
+    # And explicitly NOT the broken Etc/GMT-5 output (07:00 / 7:00 with 0 minutes).
+    assert ":00" not in formatted.split("M")[0], (
+        f"Output contains ':00' which would be the off-by-30-min Etc/GMT-5 result; "
+        f"got {formatted!r}"
+    )
 
 
 def test_message_footer_timestamp_falls_back_without_server_tz():
@@ -404,7 +459,34 @@ def test_sessions_js_uses_server_now_in_time_functions():
 
 
 def test_ui_js_message_timestamp_uses_server_tz():
-    """ui.js _formatMessageFooterTimestamp should reference _serverTzOptions."""
-    assert "_serverTzOptions" in UI_JS
-    # tsTitle in message rendering should also use it
-    assert "_tzo=" in UI_JS
+    """ui.js timestamp formatters should reference the server-tz helpers
+    so they pick up the server's wall-clock time (with correct fractional
+    offset handling) rather than always rendering in browser TZ."""
+    # _formatInServerTz is the canonical helper that handles both whole-hour
+    # and fractional offsets (e.g. India +0530). _serverTzOptions is the
+    # whole-hour fast path; either reference indicates server-tz awareness.
+    assert "_formatInServerTz" in UI_JS or "_serverTzOptions" in UI_JS, (
+        "ui.js must reference one of the server-tz helpers so message "
+        "timestamps render in the server's wall-clock time"
+    )
+
+
+def test_sessions_js_has_format_in_server_tz_helper():
+    """_formatInServerTz must exist and use offset arithmetic so fractional
+    offsets (India +0530, Iran +0330, etc.) format correctly."""
+    assert "function _formatInServerTz" in SESSIONS_JS, (
+        "_formatInServerTz must be defined to handle fractional-hour "
+        "offsets that Etc/GMT cannot express"
+    )
+    # Find the function body
+    start = SESSIONS_JS.find("function _formatInServerTz")
+    end = SESSIONS_JS.find("\n}", start) + 2
+    body = SESSIONS_JS[start:end]
+    # Offset arithmetic + timeZone:'UTC' is the correct strategy
+    assert "timeZone: 'UTC'" in body or 'timeZone: "UTC"' in body, (
+        "_formatInServerTz must format in UTC after applying the offset "
+        "via arithmetic — that's how fractional offsets work correctly"
+    )
+    assert "60 * 1000" in body or "* 60_000" in body, (
+        "_formatInServerTz must convert the offset minutes to milliseconds"
+    )

--- a/tests/test_issue1144_session_time_sync.py
+++ b/tests/test_issue1144_session_time_sync.py
@@ -1,0 +1,410 @@
+"""Regression tests for issue #1144 – session time sync with system time.
+
+Root cause: The WebUI used Date.now() (client-side clock) as the reference
+for all relative-time calculations ("2 hours ago", "Today", "Yesterday", etc.).
+If the server clock and client clock are out of sync (e.g. WSL clock drift,
+Docker container TZ mismatch), timestamps appear wrong.
+
+Fix: The /api/sessions response now includes ``server_time`` (epoch seconds)
+and ``server_tz`` (offset string like "+0800").  The JS computes
+``_serverTimeDelta = Date.now() - server_time * 1000`` once per session-list
+fetch, then every time helper uses ``_serverNowMs()`` (which returns
+``Date.now() - _serverTimeDelta``) instead of bare ``Date.now()``.
+"""
+
+import json
+import pathlib
+import subprocess
+import textwrap
+import time
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).parent.parent.resolve()
+SESSIONS_JS = (REPO_ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
+UI_JS = (REPO_ROOT / "static" / "ui.js").read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Backend: /api/sessions includes server_time and server_tz
+# ---------------------------------------------------------------------------
+
+def test_sessions_endpoint_includes_server_time_and_tz():
+    """GET /api/sessions must return server_time (float) and server_tz (str)."""
+    from tests._pytest_port import BASE
+    import urllib.request
+    with urllib.request.urlopen(BASE + "/api/sessions", timeout=10) as r:
+        data = json.loads(r.read())
+    assert "server_time" in data
+    assert "server_tz" in data
+    # server_time should be a recent epoch seconds value
+    assert isinstance(data["server_time"], float)
+    assert data["server_time"] > 1_700_000_000  # after 2023
+    # Should be close to time.time()
+    assert abs(data["server_time"] - time.time()) < 5
+    # server_tz should be an offset string
+    assert isinstance(data["server_tz"], str)
+    assert len(data["server_tz"]) == 5  # "+HHMM" or "-HHMM"
+
+
+def test_server_time_allows_clock_skew_compensation():
+    """server_time lets the client detect clock skew relative to the server."""
+    from tests._pytest_port import BASE
+    import urllib.request
+    before = time.time()
+    with urllib.request.urlopen(BASE + "/api/sessions", timeout=10) as r:
+        data = json.loads(r.read())
+    after = time.time()
+    server_time = data["server_time"]
+    # The server_time should be between our before and after timestamps
+    assert before <= server_time <= after
+
+
+# ---------------------------------------------------------------------------
+# JS: _serverNowMs compensates for clock skew
+# ---------------------------------------------------------------------------
+
+def _extract_function(source: str, name: str) -> str:
+    marker = f"function {name}"
+    start = source.index(marker)
+    brace_start = source.index("{", start)
+    depth = 0
+    for idx in range(brace_start, len(source)):
+        ch = source[idx]
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return source[start : idx + 1]
+    raise AssertionError(f"Could not extract {name}")
+
+
+def _run_time_case(script_body: str, tz: str = "UTC") -> dict:
+    """Extract time-related functions and run a script body via Node.js."""
+    functions = "\n\n".join(
+        _extract_function(SESSIONS_JS, name)
+        for name in (
+            "_sessionTimestampMs",
+            "_localDayOrdinal",
+            "_serverNowMs",
+            "_serverTzOptions",
+            "_sessionCalendarBoundaries",
+            "_formatSessionDate",
+            "_formatRelativeSessionTime",
+            "_sessionTimeBucketLabel",
+        )
+    )
+    script = textwrap.dedent(
+        f"""
+        process.env.TZ = '{tz}';
+        let _serverTimeDelta = 0;
+        let _serverTz = '';
+        const translations = {{
+          session_time_unknown: 'Unknown',
+          session_time_minutes_ago: (n) => `${{n}}m`,
+          session_time_hours_ago: (n) => `${{n}}h`,
+          session_time_days_ago: (n) => `${{n}}d`,
+          session_time_last_week: '1w',
+          session_time_bucket_today: 'Today',
+          session_time_bucket_yesterday: 'Yesterday',
+          session_time_bucket_this_week: 'This week',
+          session_time_bucket_last_week: 'Last week',
+          session_time_bucket_older: 'Older',
+        }};
+        function t(key, ...args) {{
+          const val = translations[key];
+          return typeof val === 'function' ? val(...args) : val;
+        }}
+        {functions}
+        {script_body}
+        """
+    )
+    proc = subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True)
+    return json.loads(proc.stdout)
+
+
+def test_server_now_ms_defaults_to_date_now_when_no_skew():
+    """Without skew, _serverNowMs() should equal Date.now()."""
+    result = _run_time_case(
+        """
+        const before = Date.now();
+        const serverNow = _serverNowMs();
+        const after = Date.now();
+        process.stdout.write(JSON.stringify({
+          serverNow,
+          closeToNow: serverNow >= before && serverNow <= after,
+        }));
+        """
+    )
+    assert result["closeToNow"] is True
+
+
+def test_server_now_ms_compensates_positive_skew():
+    """If server is behind client (skew > 0), _serverNowMs() subtracts the delta."""
+    result = _run_time_case(
+        """
+        // Simulate: client clock is 3600s (1 hour) ahead of server
+        _serverTimeDelta = 3600 * 1000;
+        const clientNow = Date.now();
+        const serverNow = _serverNowMs();
+        const diff = clientNow - serverNow;
+        process.stdout.write(JSON.stringify({
+          diffMs: diff,
+          isOneHour: diff === 3600000,
+        }));
+        """
+    )
+    assert result["isOneHour"] is True
+    assert result["diffMs"] == 3_600_000
+
+
+def test_server_now_ms_compensates_negative_skew():
+    """If server is ahead of client (skew < 0), _serverNowMs() adds the delta."""
+    result = _run_time_case(
+        """
+        // Simulate: client clock is 7200s (2 hours) behind server
+        _serverTimeDelta = -7200 * 1000;
+        const clientNow = Date.now();
+        const serverNow = _serverNowMs();
+        const diff = serverNow - clientNow;
+        process.stdout.write(JSON.stringify({
+          diffMs: diff,
+          isTwoHours: diff === 7200000,
+        }));
+        """
+    )
+    assert result["isTwoHours"] is True
+    assert result["diffMs"] == 7_200_000
+
+
+def test_relative_time_uses_server_clock():
+    """_formatRelativeSessionTime uses _serverNowMs() when nowMs is not passed."""
+    result = _run_time_case(
+        """
+        // Simulate server 8 hours behind client (common WSL scenario)
+        _serverTimeDelta = 8 * 3600 * 1000;
+        // Session created 5 minutes ago in server time
+        const serverNow = _serverNowMs();
+        const fiveMinAgo = serverNow - 5 * 60 * 1000;
+        process.stdout.write(JSON.stringify({
+          relative: _formatRelativeSessionTime(fiveMinAgo),
+          bucket: _sessionTimeBucketLabel(fiveMinAgo),
+        }));
+        """
+    )
+    # Without compensation, client thinks this session is 8h5m ago.
+    # With compensation, it correctly shows "5m".
+    assert result["relative"] == "5m"
+    assert result["bucket"] == "Today"
+
+
+def test_session_bucket_uses_server_clock():
+    """_sessionTimeBucketLabel uses _serverNowMs() for Today/Yesterday boundaries."""
+    result = _run_time_case(
+        """
+        // Simulate server 8 hours ahead of client
+        _serverTimeDelta = -8 * 3600 * 1000;
+        const serverNow = _serverNowMs();
+        // Session created 2 hours ago in server time → should be Today
+        const twoHoursAgo = serverNow - 2 * 3600 * 1000;
+        // Session created 26 hours ago → should be Yesterday
+        const yesterday = serverNow - 26 * 3600 * 1000;
+        process.stdout.write(JSON.stringify({
+          todayBucket: _sessionTimeBucketLabel(twoHoursAgo),
+          yesterdayBucket: _sessionTimeBucketLabel(yesterday),
+          todayRelative: _formatRelativeSessionTime(twoHoursAgo),
+        }));
+        """
+    )
+    assert result["todayBucket"] == "Today"
+    assert result["yesterdayBucket"] == "Yesterday"
+    assert result["todayRelative"] == "2h"
+
+
+def test_explicit_now_param_overrides_server_clock():
+    """Passing nowMs explicitly should still work (backward compat)."""
+    result = _run_time_case(
+        """
+        _serverTimeDelta = 8 * 3600 * 1000;  // large skew
+        const explicitNow = Date.UTC(2026, 3, 15, 14, 0, 0);
+        const twoHoursAgo = explicitNow - 2 * 3600 * 1000;
+        process.stdout.write(JSON.stringify({
+          relative: _formatRelativeSessionTime(twoHoursAgo, explicitNow),
+          bucket: _sessionTimeBucketLabel(twoHoursAgo, explicitNow),
+        }));
+        """
+    )
+    # Explicit now should be used, not server clock
+    assert result["relative"] == "2h"
+    assert result["bucket"] == "Today"
+
+
+# ---------------------------------------------------------------------------
+# JS: _serverTzOptions builds correct timeZone option
+# ---------------------------------------------------------------------------
+
+def test_server_tz_options_positive_offset():
+    result = _run_time_case(
+        """
+        _serverTz = '+0800';
+        const opts = _serverTzOptions();
+        process.stdout.write(JSON.stringify({
+          tz: opts ? opts.timeZone : null,
+        }));
+        """
+    )
+    assert result["tz"] == "Etc/GMT-8"
+
+
+def test_server_tz_options_negative_offset():
+    result = _run_time_case(
+        """
+        _serverTz = '-0500';
+        const opts = _serverTzOptions();
+        process.stdout.write(JSON.stringify({
+          tz: opts ? opts.timeZone : null,
+        }));
+        """
+    )
+    assert result["tz"] == "Etc/GMT+5"
+
+
+def test_server_tz_options_utc_returns_undefined():
+    result = _run_time_case(
+        """
+        _serverTz = '+0000';
+        const opts = _serverTzOptions();
+        process.stdout.write(JSON.stringify({
+          isUndefined: opts === undefined,
+          isNull: opts === null,
+          type: typeof opts,
+        }));
+        """
+    )
+    assert result["isUndefined"] is True
+    assert result["isNull"] is False
+    assert result["type"] == "undefined"
+
+
+def test_server_tz_options_empty_returns_undefined():
+    result = _run_time_case(
+        """
+        _serverTz = '';
+        const opts = _serverTzOptions();
+        process.stdout.write(JSON.stringify({
+          isUndefined: opts === undefined,
+        }));
+        """
+    )
+    assert result["isUndefined"] is True
+
+
+# ---------------------------------------------------------------------------
+# JS: _formatMessageFooterTimestamp uses server timezone
+# ---------------------------------------------------------------------------
+
+def _extract_ui_function(name: str) -> str:
+    return _extract_function(UI_JS, name)
+
+
+def _extract_is_same_local_day() -> str:
+    """Extract _isSameLocalDay from ui.js (helper used by _formatMessageFooterTimestamp)."""
+    marker = "function _isSameLocalDay("
+    start = UI_JS.index(marker)
+    brace_start = UI_JS.index("{", start)
+    depth = 0
+    for idx in range(brace_start, len(UI_JS)):
+        ch = UI_JS[idx]
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return UI_JS[start : idx + 1]
+    raise AssertionError("Could not extract _isSameLocalDay")
+
+
+def test_message_footer_timestamp_uses_server_tz():
+    """_formatMessageFooterTimestamp should use _serverTzOptions for display."""
+    is_same_day_fn = _extract_is_same_local_day()
+    fmt_fn = _extract_ui_function("_formatMessageFooterTimestamp")
+    script = textwrap.dedent(
+        f"""
+        process.env.TZ = 'America/New_York';
+        let _serverTimeDelta = 0;
+        let _serverTz = '+0800';
+        function _serverTzOptions() {{
+          if (!_serverTz || _serverTz === '+0000' || _serverTz === '-0000') return undefined;
+          const m = _serverTz.match(/^([+-])(\\d{{2}})(\\d{{2}})$/);
+          if (!m) return undefined;
+          const sign = m[1] === '+' ? '-' : '+';
+          return {{ timeZone: `Etc/GMT${{sign}}${{parseInt(m[2])}}` }};
+        }}
+        {is_same_day_fn}
+        {fmt_fn}
+        // Timestamp for 2026-04-28 10:00:00 UTC = 18:00 UTC+8
+        const tsVal = 1774749600;
+        const result = _formatMessageFooterTimestamp(tsVal);
+        process.stdout.write(JSON.stringify({{ formatted: result }}));
+        """
+    )
+    proc = subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True)
+    data = json.loads(proc.stdout)
+    # Should display in Etc/GMT-8 timezone (UTC+8), not America/New_York
+    # 2026-03-29 02:00 UTC = 10:00 AM in Etc/GMT-8
+    assert "10:00 AM" in data["formatted"]
+
+
+def test_message_footer_timestamp_falls_back_without_server_tz():
+    """Without _serverTzOptions, should use browser timezone (no crash)."""
+    is_same_day_fn = _extract_is_same_local_day()
+    fmt_fn = _extract_ui_function("_formatMessageFooterTimestamp")
+    script = textwrap.dedent(
+        f"""
+        process.env.TZ = 'UTC';
+        // _serverTzOptions is not defined — simulates sessions.js not loaded
+        let _serverTimeDelta = 0;
+        {is_same_day_fn}
+        {fmt_fn}
+        const tsVal = 1774749600;  // 2026-04-28 10:00 UTC
+        const result = _formatMessageFooterTimestamp(tsVal);
+        process.stdout.write(JSON.stringify({{ formatted: result, hasValue: result.length > 0 }}));
+        """
+    )
+    proc = subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True)
+    data = json.loads(proc.stdout)
+    assert data["hasValue"] is True
+
+
+# ---------------------------------------------------------------------------
+# JS: sessions.js contains the compensation variables and helpers
+# ---------------------------------------------------------------------------
+
+def test_sessions_js_has_server_time_compensation_vars():
+    assert "_serverTimeDelta" in SESSIONS_JS
+    assert "_serverTz" in SESSIONS_JS
+    assert "function _serverNowMs()" in SESSIONS_JS
+    assert "function _serverTzOptions()" in SESSIONS_JS
+
+
+def test_sessions_js_captures_server_time_on_fetch():
+    assert "sessData.server_time" in SESSIONS_JS
+    assert "sessData.server_tz" in SESSIONS_JS
+    assert "_serverTimeDelta = Date.now()" in SESSIONS_JS
+
+
+def test_sessions_js_uses_server_now_in_time_functions():
+    """All time formatting functions should use _serverNowMs() as default."""
+    assert "_serverNowMs()" in SESSIONS_JS
+    # Ensure the old pattern `Date.now()` is NOT the default in these functions
+    assert "nowMs = Date.now()" not in SESSIONS_JS
+    # _serverNowMs() should be used as fallback in time formatting functions
+    assert "nowMs || _serverNowMs()" in SESSIONS_JS
+
+
+def test_ui_js_message_timestamp_uses_server_tz():
+    """ui.js _formatMessageFooterTimestamp should reference _serverTzOptions."""
+    assert "_serverTzOptions" in UI_JS
+    # tsTitle in message rendering should also use it
+    assert "_tzo=" in UI_JS


### PR DESCRIPTION
## Thinking Path

**Root cause**: All relative-time calculations in the session sidebar ("2 hours ago", "Today", "Yesterday", etc.) used `Date.now()` (client-side clock) as reference. When the browser clock and server clock are out of sync — common with WSL clock drift, Docker containers running in UTC, or remote browser access — session timestamps appear wrong.

**Fix**: The `/api/sessions` response now includes `server_time` (epoch seconds) and `server_tz` (offset string like "+0800"). The JS computes a clock-skew delta once per session-list fetch and uses it to compensate all time calculations. Message footer timestamps also use the server's timezone when available.

## What Changed

### Backend (`api/routes.py`)
- `/api/sessions` now returns `server_time` (float, epoch seconds) and `server_tz` (string, UTC offset like "+0800")

### Session sidebar (`static/sessions.js`)
- New `_serverNowMs()` helper returns `Date.now() - _serverTimeDelta` (server-clock approximation)
- New `_serverTzOptions()` converts offset string to IANA `Etc/GMT-X` timezone
- `_formatRelativeSessionTime`, `_sessionCalendarBoundaries`, `_sessionTimeBucketLabel`, `_formatSessionDate` all default to `_serverNowMs()` instead of `Date.now()`
- `renderSessionListFromCache()` uses `_serverNowMs()` for date grouping
- Delta is recalculated on every session list fetch

### Message timestamps (`static/ui.js`)
- `_formatMessageFooterTimestamp` and `tsTitle` tooltip now use server timezone via `_serverTzOptions()`
- Graceful fallback to browser timezone when not available

### Backward compatible
- Explicit `nowMs` parameter still works (used by existing tests)
- Zero skew = identical behavior to before
- `"+0000"` or empty `_serverTz` falls back to browser timezone

### Tests (`tests/test_issue1144_session_time_sync.py`)
- 18 regression tests covering: backend response, skew compensation, timezone conversion, fallback

Fixes #1144