### PR TITLE
fix(workspace): Allow /var/home workspaces (#1199)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -357,6 +357,15 @@
   workspace subtree) and never enumerate blocked system roots. (`api/routes.py`,
   `api/workspace.py`, `static/panels.js`, `static/style.css`) (partial for #616)
 
+## [v0.50.233] — 2026-04-28
+
+### Fixed
+- **Workspace trust for /var/home paths** — workspaces under `/var/home` (used by
+  systemd-homed on Fedora/RHEL) were incorrectly blocked because `_is_blocked_system_path`
+  flagged `/var` as a system root. The home-directory trust check in both
+  `resolve_trusted_workspace` and `validate_workspace_to_add` now correctly trusts any
+  path under `Path.home()` regardless of where the home directory lives on disk.
+  (`api/workspace.py`) (by @frap129, PR #1199)
 ## [v0.50.232] — 2026-04-28
 
 ### Fixed

--- a/api/workspace.py
+++ b/api/workspace.py
@@ -448,10 +448,8 @@ def resolve_trusted_workspace(path: str | Path | None = None) -> Path:
 
     # (A) Trusted if under the user's home directory — cross-platform via Path.home()
     # Must be checked before system roots to allow symlinks like /var/home.
-    # Guard: skip if HOME is / or is itself a blocked root (unusual container setups).
     _home = Path.home().resolve()
-    _home_is_sane = (_home != Path("/") and not _is_blocked_system_path(_home))
-    if _home_is_sane:
+    if _home != Path("/"):
         try:
             candidate.relative_to(_home)
             return candidate
@@ -508,6 +506,12 @@ def validate_workspace_to_add(path: str) -> Path:
         raise ValueError(f"Path does not exist: {candidate}")
     if not candidate.is_dir():
         raise ValueError(f"Path is not a directory: {candidate}")
+
+    # Home directory is always trusted regardless of where it lives on disk
+    # (e.g. /var/home/... on systemd-homed Fedora/RHEL).
+    _home = Path.home().resolve()
+    if _home != Path("/") and _is_within(candidate, _home):
+        return candidate
 
     # Block known system roots and their immediate children
     if _is_blocked_system_path(candidate):


### PR DESCRIPTION
Carries the code from **@frap129**'s PR #1199 (`fix(workspace): Allow /var/home workspaces`).

## What changed

On systemd-homed systems (Fedora/RHEL), the user home directory lives under `/var/home/<user>`. The old trust check in `resolve_trusted_workspace` guarded with `not _is_blocked_system_path(_home)` — which failed because `/var` is in the blocked roots list. This prevented any workspace under `/var/home` from being trusted, even though it's genuinely the user's own home directory.

**Two-part fix:**
1. `resolve_trusted_workspace`: remove the `_is_blocked_system_path(_home)` guard — trust any path under `Path.home()` as long as home isn't `/`.
2. `validate_workspace_to_add`: add a symmetric early-return for paths under `Path.home()` (was missing this check entirely).

The `/` guard is kept so we don't accidentally trust everything inside a broken container where `HOME=/`.

## Testing

2764 tests pass. Fixes the same regression that #1165 introduced.

Co-authored-by: Joe Maples <joe@maples.dev>
