### PR TITLE
fix(sessions): keep unread dots for background completions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,11 @@
 - **Background session completion unread dots** — sidebar unread dots no longer
   depend solely on `message_count` increasing after a stream finishes. Background
   `done` events now set an explicit unread-completion marker, including
-  session-switch races where the old session is no longer the user's intended
-  view, and the marker clears only when that session is opened. (`static/sessions.js`,
+  session-switch races and hidden/unfocused tabs where the old session is no
+  longer being viewed. Session-list polling also marks unread when a session the
+  page previously saw streaming later reports stopped, and the marker clears
+  only when that session is opened or the user returns to the active completed
+  session. (`static/sessions.js`,
   `static/messages.js`, `tests/test_issue856_background_completion_unread.py`)
 - **Auto-title generic fallback** — when the auxiliary title-generation call
   fails and the local fallback can only produce the generic label

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 ## [Unreleased]
 
 ### Fixed
+- **Background session completion unread dots** — sidebar unread dots no longer
+  depend solely on `message_count` increasing after a stream finishes. Background
+  `done` events now set an explicit unread-completion marker, including
+  session-switch races where the old session is no longer the user's intended
+  view, and the marker clears only when that session is opened. (`static/sessions.js`,
+  `static/messages.js`, `tests/test_issue856_background_completion_unread.py`)
 - **Auto-title generic fallback** — when the auxiliary title-generation call
   fails and the local fallback can only produce the generic label
   `Conversation topic`, the WebUI now keeps the existing provisional title

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,10 @@
   `done` events now set an explicit unread-completion marker, including
   session-switch races and hidden/unfocused tabs where the old session is no
   longer being viewed. Session-list polling also marks unread when a session the
-  page previously saw streaming later reports stopped, and the marker clears
-  only when that session is opened or the user returns to the active completed
-  session. (`static/sessions.js`,
+  page previously saw streaming later reports stopped, including local
+  `INFLIGHT`-only sidebar spinners and reconnect/settled-stream fallback paths.
+  The marker clears only when that session is opened or the user returns to the
+  active completed session. (`static/sessions.js`,
   `static/messages.js`, `tests/test_issue856_background_completion_unread.py`)
 - **Auto-title generic fallback** — when the auxiliary title-generation call
   fails and the local fallback can only produce the generic label

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,16 @@
   longer being viewed. Session-list polling also marks unread when a session the
   page previously saw streaming later reports stopped, including local
   `INFLIGHT`-only sidebar spinners, cache-rendered visible spinners, and
-  reconnect/settled-stream fallback paths. The marker clears only when that
-  session is opened or the user returns to the active completed session.
+  reconnect/settled-stream fallback paths. Long-running sessions also use a
+  per-session message snapshot fallback and a persisted observed-running marker
+  so a completed background turn still becomes unread if the original
+  SSE/in-memory streaming context was missed or lost during a reload.
+  The `done` event now also updates the sidebar cache immediately before the
+  completion cue plays, so the row flips from spinner to unread without waiting
+  for the next session-list refresh, including auto-compression paths where the
+  final session id differs from the stream's original id.
+  The marker clears only when that session is opened or the user returns to the
+  active completed session.
   (`static/sessions.js`,
   `static/messages.js`, `tests/test_issue856_background_completion_unread.py`)
 - **Auto-title generic fallback** — when the auxiliary title-generation call

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,10 @@
   session-switch races and hidden/unfocused tabs where the old session is no
   longer being viewed. Session-list polling also marks unread when a session the
   page previously saw streaming later reports stopped, including local
-  `INFLIGHT`-only sidebar spinners and reconnect/settled-stream fallback paths.
-  The marker clears only when that session is opened or the user returns to the
-  active completed session. (`static/sessions.js`,
+  `INFLIGHT`-only sidebar spinners, cache-rendered visible spinners, and
+  reconnect/settled-stream fallback paths. The marker clears only when that
+  session is opened or the user returns to the active completed session.
+  (`static/sessions.js`,
   `static/messages.js`, `tests/test_issue856_background_completion_unread.py`)
 - **Auto-title generic fallback** — when the auxiliary title-generation call
   fails and the local fallback can only produce the generic label

--- a/static/messages.js
+++ b/static/messages.js
@@ -4,6 +4,15 @@ function _markSessionViewed(sid, messageCount) {
   _setSessionViewedCount(sid, next);
 }
 
+function _isSessionActivelyViewed(sid) {
+  if(!sid || !S.session || S.session.session_id!==sid) return false;
+  // During session switching, S.session still points at the previous row until
+  // the next metadata request resolves. Treat that in-flight switch as
+  // background so a just-finished old stream still gets an unread marker.
+  if(typeof _loadingSessionId!=='undefined' && _loadingSessionId && _loadingSessionId!==sid) return false;
+  return true;
+}
+
 async function send(){
   const text=$('msg').value.trim();
   if(!text&&!S.pendingFiles.length)return;
@@ -741,17 +750,21 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         _smdEndParser();
       }
       const d=JSON.parse(e.data);
+      const isSessionViewed=_isSessionActivelyViewed(activeSid);
+      if(!isSessionViewed && typeof _markSessionCompletionUnread==='function'){
+        _markSessionCompletionUnread(activeSid, d.session&&d.session.message_count);
+      }
       delete INFLIGHT[activeSid];
       clearInflight();clearInflightState(activeSid);
       stopApprovalPolling();
       stopClarifyPolling();
       if(!_approvalSessionId || _approvalSessionId===activeSid) hideApprovalCard(true);
       if(!_clarifySessionId || _clarifySessionId===activeSid) hideClarifyCard(true);
-      if(S.session&&S.session.session_id===activeSid){
+      if(isSessionViewed){
         S.activeStreamId=null;
         const _cb=$('btnCancel');if(_cb)_cb.style.display='none';
       }
-      if(S.session&&S.session.session_id===activeSid){
+      if(isSessionViewed){
         // Capture previous session totals BEFORE overwriting S.session with the new
         // cumulative values from the done event. prevIn/prevOut are the totals as of
         // the start of this turn; curIn/curOut are the full post-turn totals — the

--- a/static/messages.js
+++ b/static/messages.js
@@ -4,14 +4,36 @@ function _markSessionViewed(sid, messageCount) {
   _setSessionViewedCount(sid, next);
 }
 
-function _isSessionActivelyViewed(sid) {
+function _isDocumentVisibleAndFocused() {
+  if(typeof document!=='undefined' && document.visibilityState && document.visibilityState!=='visible') return false;
+  if(typeof document!=='undefined' && typeof document.hasFocus==='function' && !document.hasFocus()) return false;
+  return true;
+}
+
+function _isSessionCurrentPane(sid) {
   if(!sid || !S.session || S.session.session_id!==sid) return false;
   // During session switching, S.session still points at the previous row until
-  // the next metadata request resolves. Treat that in-flight switch as
-  // background so a just-finished old stream still gets an unread marker.
+  // the next metadata request resolves. Do not let a just-finished old stream
+  // update the chat pane while the user is moving to another session.
   if(typeof _loadingSessionId!=='undefined' && _loadingSessionId && _loadingSessionId!==sid) return false;
   return true;
 }
+
+function _isSessionActivelyViewed(sid) {
+  if(!_isSessionCurrentPane(sid)) return false;
+  if(!_isDocumentVisibleAndFocused()) return false;
+  return true;
+}
+
+function _markActiveSessionViewedOnReturn() {
+  if(!_isDocumentVisibleAndFocused() || !S.session || !S.session.session_id) return;
+  _markSessionViewed(S.session.session_id, S.session.message_count || (S.messages&&S.messages.length) || 0);
+  if(typeof _clearSessionCompletionUnread==='function') _clearSessionCompletionUnread(S.session.session_id);
+  if(typeof renderSessionListFromCache==='function') renderSessionListFromCache();
+}
+
+document.addEventListener('visibilitychange', _markActiveSessionViewedOnReturn);
+window.addEventListener('focus', _markActiveSessionViewedOnReturn);
 
 async function send(){
   const text=$('msg').value.trim();
@@ -750,6 +772,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         _smdEndParser();
       }
       const d=JSON.parse(e.data);
+      const isActiveSession=_isSessionCurrentPane(activeSid);
       const isSessionViewed=_isSessionActivelyViewed(activeSid);
       if(!isSessionViewed && typeof _markSessionCompletionUnread==='function'){
         _markSessionCompletionUnread(activeSid, d.session&&d.session.message_count);
@@ -760,11 +783,11 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       stopClarifyPolling();
       if(!_approvalSessionId || _approvalSessionId===activeSid) hideApprovalCard(true);
       if(!_clarifySessionId || _clarifySessionId===activeSid) hideClarifyCard(true);
-      if(isSessionViewed){
+      if(isActiveSession){
         S.activeStreamId=null;
         const _cb=$('btnCancel');if(_cb)_cb.style.display='none';
       }
-      if(isSessionViewed){
+      if(isActiveSession){
         // Capture previous session totals BEFORE overwriting S.session with the new
         // cumulative values from the done event. prevIn/prevOut are the totals as of
         // the start of this turn; curIn/curOut are the full post-turn totals — the
@@ -819,7 +842,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         S.busy=false;
         // No-reply guard (#373): if agent returned nothing, show inline error
         if(!S.messages.some(m=>m.role==='assistant'&&String(m.content||'').trim())&&!assistantText){removeThinking();S.messages.push({role:'assistant',content:'**No response received.** Check your API key and model selection.'});}
-        _markSessionViewed(activeSid, d.session.message_count ?? S.messages.length);
+        if(isSessionViewed) _markSessionViewed(activeSid, d.session.message_count ?? S.messages.length);
         syncTopbar();renderMessages();loadDir('.');
       }
       _queueDrainSid=activeSid;renderSessionList();setBusy(false);setStatus('');

--- a/static/messages.js
+++ b/static/messages.js
@@ -774,11 +774,16 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       const d=JSON.parse(e.data);
       const isActiveSession=_isSessionCurrentPane(activeSid);
       const isSessionViewed=_isSessionActivelyViewed(activeSid);
+      const completedSession=d.session||{session_id:activeSid};
+      const completedSid=completedSession.session_id||activeSid;
       if(!isSessionViewed && typeof _markSessionCompletionUnread==='function'){
-        _markSessionCompletionUnread(activeSid, d.session&&d.session.message_count);
+        _markSessionCompletionUnread(completedSid, completedSession.message_count);
       }
       delete INFLIGHT[activeSid];
       clearInflight();clearInflightState(activeSid);
+      if(typeof _markSessionCompletedInList==='function'){
+        _markSessionCompletedInList(completedSession, activeSid);
+      }
       stopApprovalPolling();
       stopClarifyPolling();
       if(!_approvalSessionId || _approvalSessionId===activeSid) hideApprovalCard(true);
@@ -842,7 +847,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         S.busy=false;
         // No-reply guard (#373): if agent returned nothing, show inline error
         if(!S.messages.some(m=>m.role==='assistant'&&String(m.content||'').trim())&&!assistantText){removeThinking();S.messages.push({role:'assistant',content:'**No response received.** Check your API key and model selection.'});}
-        if(isSessionViewed) _markSessionViewed(activeSid, d.session.message_count ?? S.messages.length);
+        if(isSessionViewed) _markSessionViewed(completedSid, completedSession.message_count ?? S.messages.length);
         syncTopbar();renderMessages();loadDir('.');
       }
       _queueDrainSid=activeSid;renderSessionList();setBusy(false);setStatus('');
@@ -1050,8 +1055,9 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       if(!_approvalSessionId||_approvalSessionId===activeSid) hideApprovalCard(true);
       if(!_clarifySessionId||_clarifySessionId===activeSid) hideClarifyCard(true);
       const isSessionViewed=_isSessionActivelyViewed(activeSid);
+      const completedSid=session.session_id||activeSid;
       if(!isSessionViewed && typeof _markSessionCompletionUnread==='function'){
-        _markSessionCompletionUnread(activeSid, session.message_count);
+        _markSessionCompletionUnread(completedSid, session.message_count);
       }
       if(S.session&&S.session.session_id===activeSid){
         S.activeStreamId=null;const _cbe=$('btnCancel');if(_cbe)_cbe.style.display='none';
@@ -1068,7 +1074,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         }else{
           S.toolCalls=[];
         }
-        if(isSessionViewed) _markSessionViewed(activeSid, session.message_count ?? S.messages.length);
+        if(isSessionViewed) _markSessionViewed(completedSid, session.message_count ?? S.messages.length);
         syncTopbar();renderMessages();
       }
       _queueDrainSid=activeSid;renderSessionList();setBusy(false);setComposerStatus('');

--- a/static/messages.js
+++ b/static/messages.js
@@ -1049,6 +1049,10 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       _closeSource();
       if(!_approvalSessionId||_approvalSessionId===activeSid) hideApprovalCard(true);
       if(!_clarifySessionId||_clarifySessionId===activeSid) hideClarifyCard(true);
+      const isSessionViewed=_isSessionActivelyViewed(activeSid);
+      if(!isSessionViewed && typeof _markSessionCompletionUnread==='function'){
+        _markSessionCompletionUnread(activeSid, session.message_count);
+      }
       if(S.session&&S.session.session_id===activeSid){
         S.activeStreamId=null;const _cbe=$('btnCancel');if(_cbe)_cbe.style.display='none';
         clearLiveToolCards();if(!assistantText)removeThinking();
@@ -1064,7 +1068,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         }else{
           S.toolCalls=[];
         }
-        _markSessionViewed(activeSid, session.message_count ?? S.messages.length);
+        if(isSessionViewed) _markSessionViewed(activeSid, session.message_count ?? S.messages.length);
         syncTopbar();renderMessages();
       }
       _queueDrainSid=activeSid;renderSessionList();setBusy(false);setComposerStatus('');

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -19,6 +19,7 @@ const SESSION_VIEWED_COUNTS_KEY = 'hermes-session-viewed-counts';
 const SESSION_COMPLETION_UNREAD_KEY = 'hermes-session-completion-unread';
 let _sessionViewedCounts = null;
 let _sessionCompletionUnread = null;
+const _sessionStreamingById = new Map();
 
 function _getSessionViewedCounts() {
   if (_sessionViewedCounts !== null) return _sessionViewedCounts;
@@ -97,6 +98,33 @@ function _hasUnreadForSession(s) {
   }
   if (!Number.isFinite(s.message_count)) return false;
   return s.message_count > Number(counts[s.session_id] || 0);
+}
+
+function _isSessionActivelyViewedForList(sid) {
+  if (!sid || !S.session || S.session.session_id !== sid) return false;
+  if (typeof _loadingSessionId !== 'undefined' && _loadingSessionId && _loadingSessionId !== sid) return false;
+  if (typeof document !== 'undefined' && document.visibilityState && document.visibilityState !== 'visible') return false;
+  if (typeof document !== 'undefined' && typeof document.hasFocus === 'function' && !document.hasFocus()) return false;
+  return true;
+}
+
+function _markPollingCompletionUnreadTransitions(sessions) {
+  if (!Array.isArray(sessions)) return;
+  const seen = new Set();
+  for (const s of sessions) {
+    if (!s || !s.session_id) continue;
+    const sid = s.session_id;
+    seen.add(sid);
+    const wasStreaming = _sessionStreamingById.get(sid);
+    const isStreaming = Boolean(s.is_streaming);
+    if (wasStreaming === true && !isStreaming && !_isSessionActivelyViewedForList(sid)) {
+      _markSessionCompletionUnread(sid, s.message_count);
+    }
+    _sessionStreamingById.set(sid, isStreaming);
+  }
+  for (const sid of Array.from(_sessionStreamingById.keys())) {
+    if (!seen.has(sid)) _sessionStreamingById.delete(sid);
+  }
 }
 
 async function newSession(flash){
@@ -645,6 +673,7 @@ async function renderSessionList(){
     if (typeof sessData.server_tz === 'string') {
       _serverTz = sessData.server_tz;
     }
+    _markPollingCompletionUnreadTransitions(_allSessions);
     const isStreaming = _allSessions.some(s => Boolean(s && s.is_streaming));
     if (isStreaming) {
       startStreamingPoll();

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -17,9 +17,12 @@ let _loadingSessionId = null;
 
 const SESSION_VIEWED_COUNTS_KEY = 'hermes-session-viewed-counts';
 const SESSION_COMPLETION_UNREAD_KEY = 'hermes-session-completion-unread';
+const SESSION_OBSERVED_STREAMING_KEY = 'hermes-session-observed-streaming';
 let _sessionViewedCounts = null;
 let _sessionCompletionUnread = null;
+let _sessionObservedStreaming = null;
 const _sessionStreamingById = new Map();
+const _sessionListSnapshotById = new Map();
 
 function _getSessionViewedCounts() {
   if (_sessionViewedCounts !== null) return _sessionViewedCounts;
@@ -88,6 +91,44 @@ function _hasSessionCompletionUnread(sid) {
   return Object.prototype.hasOwnProperty.call(_getSessionCompletionUnread(), sid);
 }
 
+function _getSessionObservedStreaming() {
+  if (_sessionObservedStreaming !== null) return _sessionObservedStreaming;
+  try {
+    const parsed = JSON.parse(localStorage.getItem(SESSION_OBSERVED_STREAMING_KEY) || '{}');
+    _sessionObservedStreaming = parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {};
+  } catch (_){
+    _sessionObservedStreaming = {};
+  }
+  return _sessionObservedStreaming;
+}
+
+function _saveSessionObservedStreaming() {
+  try {
+    localStorage.setItem(SESSION_OBSERVED_STREAMING_KEY, JSON.stringify(_getSessionObservedStreaming()));
+  } catch (_){
+    // Ignore localStorage write failures.
+  }
+}
+
+function _rememberObservedStreamingSession(s) {
+  if (!s || !s.session_id) return;
+  const observed = _getSessionObservedStreaming();
+  observed[s.session_id] = {
+    message_count: Number(s.message_count || 0),
+    last_message_at: Number(s.last_message_at || 0),
+    observed_at: Date.now(),
+  };
+  _saveSessionObservedStreaming();
+}
+
+function _forgetObservedStreamingSession(sid) {
+  if (!sid) return;
+  const observed = _getSessionObservedStreaming();
+  if (!Object.prototype.hasOwnProperty.call(observed, sid)) return;
+  delete observed[sid];
+  _saveSessionObservedStreaming();
+}
+
 function _hasUnreadForSession(s) {
   if (!s || !s.session_id) return false;
   if (_hasSessionCompletionUnread(s.session_id)) return true;
@@ -124,6 +165,55 @@ function _isSessionEffectivelyStreaming(s) {
 function _rememberRenderedStreamingState(s, isStreaming) {
   if (!s || !s.session_id || !isStreaming) return;
   _sessionStreamingById.set(s.session_id, true);
+  _rememberObservedStreamingSession(s);
+}
+
+function _rememberRenderedSessionSnapshot(s) {
+  if (!s || !s.session_id) return;
+  const previous = _sessionListSnapshotById.get(s.session_id);
+  if (previous) return;
+  _sessionListSnapshotById.set(s.session_id, {
+    message_count: Number(s.message_count || 0),
+    last_message_at: Number(s.last_message_at || 0),
+  });
+}
+
+function _markSessionCompletedInList(session, previousSid = null) {
+  if (!session || !Array.isArray(_allSessions)) return;
+  const finalSid = session.session_id || previousSid;
+  if (!finalSid) return;
+  const idx = _allSessions.findIndex(s => s && (s.session_id === finalSid || s.session_id === previousSid));
+  if (idx < 0) return;
+  const {messages: _messages, tool_calls: _toolCalls, ...sessionMeta} = session;
+  const messageCount = Number(
+    session.message_count != null
+      ? session.message_count
+      : (Array.isArray(session.messages) ? session.messages.length : (_allSessions[idx].message_count || 0))
+  );
+  const lastMessageAt = Number(session.last_message_at || session.updated_at || _allSessions[idx].last_message_at || 0);
+  _allSessions[idx] = {
+    ..._allSessions[idx],
+    ...sessionMeta,
+    session_id: finalSid,
+    message_count: messageCount,
+    last_message_at: lastMessageAt,
+    active_stream_id: null,
+    pending_user_message: null,
+    pending_started_at: null,
+    is_streaming: false,
+  };
+  _sessionStreamingById.set(finalSid, false);
+  _forgetObservedStreamingSession(finalSid);
+  if (previousSid && previousSid !== finalSid) {
+    _sessionStreamingById.delete(previousSid);
+    _forgetObservedStreamingSession(previousSid);
+    _sessionListSnapshotById.delete(previousSid);
+  }
+  _sessionListSnapshotById.set(finalSid, {
+    message_count: messageCount,
+    last_message_at: lastMessageAt,
+  });
+  renderSessionListFromCache();
 }
 
 function _markPollingCompletionUnreadTransitions(sessions) {
@@ -135,13 +225,39 @@ function _markPollingCompletionUnreadTransitions(sessions) {
     seen.add(sid);
     const wasStreaming = _sessionStreamingById.get(sid);
     const isStreaming = _isSessionEffectivelyStreaming(s);
-    if (wasStreaming === true && !isStreaming && !_isSessionActivelyViewedForList(sid)) {
+    const previousSnapshot = _sessionListSnapshotById.get(sid);
+    const observedStreaming = _getSessionObservedStreaming()[sid];
+    const messageCount = Number(s.message_count || 0);
+    const lastMessageAt = Number(s.last_message_at || 0);
+    const completedObservedStream = wasStreaming === true && !isStreaming;
+    const completedWithNewMessages = Boolean(
+      (previousSnapshot || observedStreaming)
+      && !isStreaming
+      && (
+        messageCount > Number((previousSnapshot || observedStreaming).message_count || 0)
+        || lastMessageAt > Number((previousSnapshot || observedStreaming).last_message_at || 0)
+      )
+    );
+    const completedPersistedObservedStream = Boolean(observedStreaming && !isStreaming);
+    if ((completedObservedStream || completedPersistedObservedStream || completedWithNewMessages) && !_isSessionActivelyViewedForList(sid)) {
       _markSessionCompletionUnread(sid, s.message_count);
     }
     _sessionStreamingById.set(sid, isStreaming);
+    if (isStreaming) {
+      _rememberObservedStreamingSession(s);
+    } else {
+      _forgetObservedStreamingSession(sid);
+    }
+    _sessionListSnapshotById.set(sid, {
+      message_count: messageCount,
+      last_message_at: lastMessageAt,
+    });
   }
   for (const sid of Array.from(_sessionStreamingById.keys())) {
     if (!seen.has(sid)) _sessionStreamingById.delete(sid);
+  }
+  for (const sid of Array.from(_sessionListSnapshotById.keys())) {
+    if (!seen.has(sid)) _sessionListSnapshotById.delete(sid);
   }
 }
 
@@ -1123,6 +1239,7 @@ function renderSessionListFromCache(){
     const isActive=S.session&&s.session_id===S.session.session_id;
     const isStreaming=_isSessionEffectivelyStreaming(s);
     _rememberRenderedStreamingState(s, isStreaming);
+    _rememberRenderedSessionSnapshot(s);
     const hasUnread=_hasUnreadForSession(s)&&!isActive;
     el.className='session-item'+(isActive?' active':'')+(isActive&&S.session&&S.session._flash?' new-flash':'')+(s.archived?' archived':'')+(isStreaming?' streaming':'')+(hasUnread?' unread':'');
     if(isActive&&S.session&&S.session._flash)delete S.session._flash;

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -108,6 +108,19 @@ function _isSessionActivelyViewedForList(sid) {
   return true;
 }
 
+function _isSessionLocallyStreaming(s) {
+  if (!s || !s.session_id) return false;
+  const isActive = S.session && s.session_id === S.session.session_id;
+  return Boolean(
+    (isActive && S.busy)
+    || (typeof INFLIGHT === 'object' && INFLIGHT && INFLIGHT[s.session_id])
+  );
+}
+
+function _isSessionEffectivelyStreaming(s) {
+  return Boolean(s && (s.is_streaming || _isSessionLocallyStreaming(s)));
+}
+
 function _markPollingCompletionUnreadTransitions(sessions) {
   if (!Array.isArray(sessions)) return;
   const seen = new Set();
@@ -116,7 +129,7 @@ function _markPollingCompletionUnreadTransitions(sessions) {
     const sid = s.session_id;
     seen.add(sid);
     const wasStreaming = _sessionStreamingById.get(sid);
-    const isStreaming = Boolean(s.is_streaming);
+    const isStreaming = _isSessionEffectivelyStreaming(s);
     if (wasStreaming === true && !isStreaming && !_isSessionActivelyViewedForList(sid)) {
       _markSessionCompletionUnread(sid, s.message_count);
     }
@@ -1103,14 +1116,7 @@ function renderSessionListFromCache(){
   function _renderOneSession(s, isPinnedGroup=false){
     const el=document.createElement('div');
     const isActive=S.session&&s.session_id===S.session.session_id;
-    const isLocalStreaming=Boolean(
-      s.session_id
-      && (
-        (isActive&&S.busy)
-        || (typeof INFLIGHT==='object'&&INFLIGHT&&INFLIGHT[s.session_id])
-      )
-    );
-    const isStreaming=Boolean(s.is_streaming||isLocalStreaming);
+    const isStreaming=_isSessionEffectivelyStreaming(s);
     const hasUnread=_hasUnreadForSession(s)&&!isActive;
     el.className='session-item'+(isActive?' active':'')+(isActive&&S.session&&S.session._flash?' new-flash':'')+(s.archived?' archived':'')+(isStreaming?' streaming':'')+(hasUnread?' unread':'');
     if(isActive&&S.session&&S.session._flash)delete S.session._flash;

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -16,7 +16,9 @@ const ICONS={
 let _loadingSessionId = null;
 
 const SESSION_VIEWED_COUNTS_KEY = 'hermes-session-viewed-counts';
+const SESSION_COMPLETION_UNREAD_KEY = 'hermes-session-completion-unread';
 let _sessionViewedCounts = null;
+let _sessionCompletionUnread = null;
 
 function _getSessionViewedCounts() {
   if (_sessionViewedCounts !== null) return _sessionViewedCounts;
@@ -45,8 +47,49 @@ function _setSessionViewedCount(sid, messageCount = 0) {
   _saveSessionViewedCounts();
 }
 
+function _getSessionCompletionUnread() {
+  if (_sessionCompletionUnread !== null) return _sessionCompletionUnread;
+  try {
+    const parsed = JSON.parse(localStorage.getItem(SESSION_COMPLETION_UNREAD_KEY) || '{}');
+    _sessionCompletionUnread = parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {};
+  } catch (_){
+    _sessionCompletionUnread = {};
+  }
+  return _sessionCompletionUnread;
+}
+
+function _saveSessionCompletionUnread() {
+  try {
+    localStorage.setItem(SESSION_COMPLETION_UNREAD_KEY, JSON.stringify(_getSessionCompletionUnread()));
+  } catch (_){
+    // Ignore localStorage write failures.
+  }
+}
+
+function _markSessionCompletionUnread(sid, messageCount = 0) {
+  if (!sid) return;
+  const unread = _getSessionCompletionUnread();
+  const count = Number.isFinite(messageCount) ? Number(messageCount) : 0;
+  unread[sid] = {message_count: count, completed_at: Date.now()};
+  _saveSessionCompletionUnread();
+}
+
+function _clearSessionCompletionUnread(sid) {
+  if (!sid) return;
+  const unread = _getSessionCompletionUnread();
+  if (!Object.prototype.hasOwnProperty.call(unread, sid)) return;
+  delete unread[sid];
+  _saveSessionCompletionUnread();
+}
+
+function _hasSessionCompletionUnread(sid) {
+  if (!sid) return false;
+  return Object.prototype.hasOwnProperty.call(_getSessionCompletionUnread(), sid);
+}
+
 function _hasUnreadForSession(s) {
   if (!s || !s.session_id) return false;
+  if (_hasSessionCompletionUnread(s.session_id)) return true;
   const counts = _getSessionViewedCounts();
   if (!Object.prototype.hasOwnProperty.call(counts, s.session_id)) {
     _setSessionViewedCount(s.session_id, Number(s.message_count || 0));
@@ -147,6 +190,7 @@ async function loadSession(sid){
   S.session._modelResolutionDeferred=true;
   S.lastUsage={...(data.session.last_usage||{})};
   _setSessionViewedCount(S.session.session_id, Number(data.session.message_count || 0));
+  _clearSessionCompletionUnread(S.session.session_id);
   localStorage.setItem('hermes-webui-session',S.session.session_id);
 
   const activeStreamId=S.session.active_stream_id||null;

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -121,6 +121,11 @@ function _isSessionEffectivelyStreaming(s) {
   return Boolean(s && (s.is_streaming || _isSessionLocallyStreaming(s)));
 }
 
+function _rememberRenderedStreamingState(s, isStreaming) {
+  if (!s || !s.session_id || !isStreaming) return;
+  _sessionStreamingById.set(s.session_id, true);
+}
+
 function _markPollingCompletionUnreadTransitions(sessions) {
   if (!Array.isArray(sessions)) return;
   const seen = new Set();
@@ -1117,6 +1122,7 @@ function renderSessionListFromCache(){
     const el=document.createElement('div');
     const isActive=S.session&&s.session_id===S.session.session_id;
     const isStreaming=_isSessionEffectivelyStreaming(s);
+    _rememberRenderedStreamingState(s, isStreaming);
     const hasUnread=_hasUnreadForSession(s)&&!isActive;
     el.className='session-item'+(isActive?' active':'')+(isActive&&S.session&&S.session._flash?' new-flash':'')+(s.archived?' archived':'')+(isStreaming?' streaming':'')+(hasUnread?' unread':'');
     if(isActive&&S.session&&S.session._flash)delete S.session._flash;

--- a/tests/test_issue856_active_session_read_state.py
+++ b/tests/test_issue856_active_session_read_state.py
@@ -19,8 +19,10 @@ def test_done_path_marks_active_session_as_viewed():
     done_idx = MESSAGES_JS.find("source.addEventListener('done'")
     assert done_idx != -1, "done handler not found in messages.js"
     done_block = MESSAGES_JS[done_idx:MESSAGES_JS.find("source.addEventListener('stream_end'", done_idx)]
-    assert "_markSessionViewed(activeSid" in done_block, (
-        "done handler must mark the active session as viewed so unread dot does not linger"
+    assert "const completedSid=completedSession.session_id||activeSid;" in done_block
+    assert "_markSessionViewed(completedSid" in done_block, (
+        "done handler must mark the final active session id as viewed so unread dot "
+        "does not linger after compression rotates session_id"
     )
 
 
@@ -37,8 +39,9 @@ def test_restore_and_error_paths_mark_active_session_as_viewed():
     restore_idx = MESSAGES_JS.find("async function _restoreSettledSession()")
     assert restore_idx != -1, "_restoreSettledSession() not found in messages.js"
     restore_block = MESSAGES_JS[restore_idx:MESSAGES_JS.find("function _handleStreamError()", restore_idx)]
-    assert "_markSessionViewed(activeSid" in restore_block, (
-        "_restoreSettledSession() must mark the active session as viewed"
+    assert "const completedSid=session.session_id||activeSid;" in restore_block
+    assert "_markSessionViewed(completedSid" in restore_block, (
+        "_restoreSettledSession() must mark the final session id as viewed"
     )
 
     error_idx = MESSAGES_JS.find("function _handleStreamError()")

--- a/tests/test_issue856_background_completion_unread.py
+++ b/tests/test_issue856_background_completion_unread.py
@@ -137,6 +137,24 @@ def test_polling_transition_tracks_the_same_effective_streaming_state_as_sidebar
     )
 
 
+def test_cache_render_seeds_streaming_transition_state_for_visible_spinners():
+    remember_block = _sessions_function_block(
+        "_rememberRenderedStreamingState",
+        "_markPollingCompletionUnreadTransitions",
+    )
+    render_idx = SESSIONS_JS.find("function _renderOneSession")
+    assert render_idx != -1, "_renderOneSession not found"
+    render_block = SESSIONS_JS[render_idx:SESSIONS_JS.find("const hasUnread=", render_idx)]
+
+    assert "if (!s || !s.session_id || !isStreaming) return;" in remember_block
+    assert "_sessionStreamingById.set(s.session_id, true);" in remember_block
+    assert "const isStreaming=_isSessionEffectivelyStreaming(s);" in render_block
+    assert "_rememberRenderedStreamingState(s, isStreaming);" in render_block, (
+        "renderSessionListFromCache can display a spinner from local INFLIGHT "
+        "state before a full poll runs, so it must seed the transition map too"
+    )
+
+
 def test_active_done_marks_viewed_without_setting_unread_marker():
     done_block = _done_block()
     marker_idx = done_block.find("_markSessionCompletionUnread(activeSid")

--- a/tests/test_issue856_background_completion_unread.py
+++ b/tests/test_issue856_background_completion_unread.py
@@ -16,6 +16,14 @@ def _done_block() -> str:
     return MESSAGES_JS[start:end]
 
 
+def _sessions_function_block(name: str, next_name: str) -> str:
+    start = SESSIONS_JS.find(f"function {name}")
+    assert start != -1, f"{name} not found in sessions.js"
+    end = SESSIONS_JS.find(f"function {next_name}", start)
+    assert end != -1, f"{next_name} not found after {name}"
+    return SESSIONS_JS[start:end]
+
+
 def test_background_completion_unread_uses_explicit_marker_not_message_delta():
     """A background completion must stay unread even when message_count has no delta."""
     assert "SESSION_COMPLETION_UNREAD_KEY = 'hermes-session-completion-unread'" in SESSIONS_JS
@@ -44,25 +52,126 @@ def test_background_done_sets_marker_when_session_not_actively_viewed():
     assert "_markSessionCompletionUnread(activeSid, d.session&&d.session.message_count);" in done_block
 
 
+def test_polling_transition_marks_completion_unread_without_sse_done():
+    transition_block = _sessions_function_block(
+        "_markPollingCompletionUnreadTransitions",
+        "newSession",
+    )
+    render_idx = SESSIONS_JS.find("async function renderSessionList()")
+    assert render_idx != -1, "renderSessionList not found"
+    render_block = SESSIONS_JS[render_idx:SESSIONS_JS.find("// ── Gateway session SSE", render_idx)]
+
+    assert "const _sessionStreamingById = new Map();" in SESSIONS_JS
+    assert "const wasStreaming = _sessionStreamingById.get(sid);" in transition_block
+    assert "const isStreaming = Boolean(s.is_streaming);" in transition_block
+    assert "wasStreaming === true && !isStreaming" in transition_block, (
+        "polling fallback must only fire on an observed streaming -> stopped transition"
+    )
+    assert "_markSessionCompletionUnread(sid, s.message_count);" in transition_block
+    assert "_sessionStreamingById.set(sid, isStreaming);" in transition_block
+    assert "_markPollingCompletionUnreadTransitions(_allSessions);" in render_block
+
+
+def test_polling_transition_does_not_mark_historical_first_render():
+    transition_block = _sessions_function_block(
+        "_markPollingCompletionUnreadTransitions",
+        "newSession",
+    )
+
+    assert "wasStreaming === true && !isStreaming" in transition_block
+    assert "wasStreaming && !isStreaming" not in transition_block, (
+        "first-render undefined state must not be treated as a completed stream"
+    )
+    mark_idx = transition_block.find("_markSessionCompletionUnread(sid")
+    set_idx = transition_block.find("_sessionStreamingById.set(sid, isStreaming)")
+    assert mark_idx != -1 and set_idx != -1 and mark_idx < set_idx, (
+        "the current render should seed streaming state only after checking for "
+        "a prior observed streaming state"
+    )
+
+
+def test_polling_transition_skips_visible_focused_active_session():
+    helper_block = _sessions_function_block(
+        "_isSessionActivelyViewedForList",
+        "_markPollingCompletionUnreadTransitions",
+    )
+    transition_block = _sessions_function_block(
+        "_markPollingCompletionUnreadTransitions",
+        "newSession",
+    )
+
+    assert "S.session.session_id !== sid" in helper_block
+    assert "_loadingSessionId !== sid" in helper_block
+    assert "document.visibilityState !== 'visible'" in helper_block
+    assert "!document.hasFocus()" in helper_block
+    assert "!_isSessionActivelyViewedForList(sid)" in transition_block, (
+        "polling fallback must not create an unread marker for a session the "
+        "user is visibly and focusedly reading"
+    )
+
+
 def test_active_done_marks_viewed_without_setting_unread_marker():
     done_block = _done_block()
     marker_idx = done_block.find("_markSessionCompletionUnread(activeSid")
-    viewed_guard_idx = done_block.find("if(isSessionViewed){", marker_idx)
-    viewed_mark_idx = done_block.find("_markSessionViewed(activeSid", viewed_guard_idx)
+    active_guard_idx = done_block.find("if(isActiveSession){", marker_idx)
+    viewed_guard_idx = done_block.find("if(isSessionViewed) _markSessionViewed(activeSid", active_guard_idx)
 
     assert marker_idx != -1, "background completion marker call missing"
-    assert viewed_guard_idx != -1, "done handler must guard active-session UI updates"
-    assert viewed_mark_idx != -1, "active/current completion must still mark session viewed"
-    assert viewed_guard_idx < viewed_mark_idx, (
+    assert active_guard_idx != -1, "done handler must guard active-session UI updates"
+    assert viewed_guard_idx != -1, "active/current completion must still mark session viewed when visible/focused"
+    assert active_guard_idx < viewed_guard_idx, (
         "active-session viewed write must remain inside isSessionViewed guard so "
         "switch-away races cannot mark a background completion read"
     )
 
 
-def test_switching_away_counts_as_background_completion():
+def test_hidden_active_done_still_updates_current_pane_but_not_read_state():
+    done_block = _done_block()
+
+    active_const_idx = done_block.find("const isActiveSession=_isSessionCurrentPane(activeSid);")
+    viewed_const_idx = done_block.find("const isSessionViewed=_isSessionActivelyViewed(activeSid);")
+    active_guard_idx = done_block.find("if(isActiveSession){", viewed_const_idx)
+    session_update_idx = done_block.find("S.session=d.session", active_guard_idx)
+    render_idx = done_block.find("renderMessages()", active_guard_idx)
+    load_dir_idx = done_block.find("loadDir('.')", active_guard_idx)
+    mark_viewed_idx = done_block.find("if(isSessionViewed) _markSessionViewed(activeSid", active_guard_idx)
+
+    assert active_const_idx != -1, "done handler must compute active/current pane separately"
+    assert viewed_const_idx != -1, "done handler must still compute visible/focused read state"
+    assert active_const_idx < viewed_const_idx
+    assert session_update_idx != -1, "active hidden completion must still refresh S.session"
+    assert render_idx != -1, "active hidden completion must still render the final assistant response"
+    assert load_dir_idx != -1, "active hidden completion must keep normal active-session finalization"
+    assert mark_viewed_idx != -1, "read-state write must stay gated by visible/focused viewing"
+    assert session_update_idx < mark_viewed_idx < render_idx, (
+        "hidden active completion should update the pane, but only mark read when "
+        "isSessionViewed is true"
+    )
+
+
+def test_hidden_or_unfocused_active_session_counts_as_background_completion():
     helper_idx = MESSAGES_JS.find("function _isSessionActivelyViewed(sid)")
     assert helper_idx != -1, "_isSessionActivelyViewed helper missing"
-    helper_block = MESSAGES_JS[helper_idx:MESSAGES_JS.find("async function send()", helper_idx)]
+    helper_block = MESSAGES_JS[helper_idx:MESSAGES_JS.find("function _markActiveSessionViewedOnReturn", helper_idx)]
+
+    current_idx = MESSAGES_JS.find("function _isSessionCurrentPane(sid)")
+    assert current_idx != -1, "_isSessionCurrentPane helper missing"
+    assert "function _isDocumentVisibleAndFocused()" in MESSAGES_JS
+    assert "document.visibilityState" in MESSAGES_JS
+    assert "document.visibilityState!=='visible'" in MESSAGES_JS
+    assert "document.hasFocus" in MESSAGES_JS
+    assert "!document.hasFocus()" in MESSAGES_JS
+    assert "if(!_isSessionCurrentPane(sid)) return false;" in helper_block
+    assert "if(!_isDocumentVisibleAndFocused()) return false;" in helper_block, (
+        "active session completion must be treated as unread when the tab is "
+        "hidden or the window is unfocused"
+    )
+
+
+def test_switching_away_counts_as_background_completion():
+    helper_idx = MESSAGES_JS.find("function _isSessionCurrentPane(sid)")
+    assert helper_idx != -1, "_isSessionCurrentPane helper missing"
+    helper_block = MESSAGES_JS[helper_idx:MESSAGES_JS.find("function _isSessionActivelyViewed", helper_idx)]
 
     assert "S.session.session_id!==sid" in helper_block
     assert "_loadingSessionId" in helper_block
@@ -70,6 +179,22 @@ def test_switching_away_counts_as_background_completion():
         "if loadSession(B) is in flight while done(A) arrives, A must be treated "
         "as background even though S.session can still temporarily point at A"
     )
+
+
+def test_focus_visibility_return_marks_active_session_viewed_and_clears_marker():
+    return_idx = MESSAGES_JS.find("function _markActiveSessionViewedOnReturn()")
+    assert return_idx != -1, "_markActiveSessionViewedOnReturn helper missing"
+    return_block = MESSAGES_JS[return_idx:MESSAGES_JS.find("async function send()", return_idx)]
+
+    assert "if(!_isDocumentVisibleAndFocused() || !S.session || !S.session.session_id) return;" in return_block
+    assert "_markSessionViewed(S.session.session_id" in return_block
+    assert "_clearSessionCompletionUnread(S.session.session_id)" in return_block, (
+        "returning to a visible/focused tab must clear the explicit unread marker "
+        "for the active session the user is now viewing"
+    )
+    assert "renderSessionListFromCache()" in return_block
+    assert "document.addEventListener('visibilitychange', _markActiveSessionViewedOnReturn);" in MESSAGES_JS
+    assert "window.addEventListener('focus', _markActiveSessionViewedOnReturn);" in MESSAGES_JS
 
 
 def test_completion_unread_clears_only_when_session_is_opened():
@@ -94,7 +219,9 @@ def test_historical_sessions_are_not_marked_unread_on_list_render():
     """The explicit unread marker must be event-driven, not initialized by _hasUnreadForSession."""
     has_unread_idx = SESSIONS_JS.find("function _hasUnreadForSession(s)")
     assert has_unread_idx != -1
-    has_unread_block = SESSIONS_JS[has_unread_idx:SESSIONS_JS.find("async function newSession", has_unread_idx)]
+    has_unread_block = SESSIONS_JS[
+        has_unread_idx:SESSIONS_JS.find("function _isSessionActivelyViewedForList", has_unread_idx)
+    ]
 
     assert "_markSessionCompletionUnread" not in has_unread_block, (
         "rendering old historical sessions must not create completion-unread markers"

--- a/tests/test_issue856_background_completion_unread.py
+++ b/tests/test_issue856_background_completion_unread.py
@@ -48,8 +48,64 @@ def test_background_completion_unread_uses_explicit_marker_not_message_delta():
 def test_background_done_sets_marker_when_session_not_actively_viewed():
     done_block = _done_block()
     assert "const isSessionViewed=_isSessionActivelyViewed(activeSid);" in done_block
+    assert "const completedSession=d.session||{session_id:activeSid};" in done_block
+    assert "const completedSid=completedSession.session_id||activeSid;" in done_block
     assert "if(!isSessionViewed && typeof _markSessionCompletionUnread==='function')" in done_block
-    assert "_markSessionCompletionUnread(activeSid, d.session&&d.session.message_count);" in done_block
+    assert "_markSessionCompletionUnread(completedSid, completedSession.message_count);" in done_block
+
+
+def test_background_done_uses_rotated_session_id_for_completion_unread():
+    done_block = _done_block()
+
+    completed_sid_idx = done_block.find("const completedSid=completedSession.session_id||activeSid;")
+    marker_idx = done_block.find("_markSessionCompletionUnread(completedSid, completedSession.message_count);")
+    viewed_idx = done_block.find("_markSessionViewed(completedSid, completedSession.message_count")
+
+    assert completed_sid_idx != -1, "done handler must derive the final post-compression session id"
+    assert marker_idx != -1, "background completion marker must be stored on the final session id"
+    assert viewed_idx != -1, "visible completions must mark the final session id as read"
+    assert completed_sid_idx < marker_idx < viewed_idx, (
+        "context compression can rotate session_id before done; unread/read state must "
+        "attach to the visible final row, not the old SSE activeSid"
+    )
+
+
+def test_done_event_updates_sidebar_cache_immediately_after_completion_marker():
+    done_block = _done_block()
+
+    marker_idx = done_block.find("_markSessionCompletionUnread(completedSid")
+    delete_idx = done_block.find("delete INFLIGHT[activeSid];")
+    cache_idx = done_block.find("_markSessionCompletedInList(completedSession, activeSid);")
+    refresh_idx = done_block.find("renderSessionList();", cache_idx)
+    sound_idx = done_block.find("playNotificationSound();", cache_idx)
+
+    assert "function _markSessionCompletedInList(" in SESSIONS_JS
+    assert marker_idx != -1, "done handler must write the completion-unread marker first"
+    assert delete_idx != -1, "done handler must clear local INFLIGHT before rendering idle state"
+    assert cache_idx != -1, "done handler must update the sidebar cache immediately"
+    assert refresh_idx != -1 and sound_idx != -1
+    assert marker_idx < delete_idx < cache_idx < refresh_idx < sound_idx, (
+        "the sidebar should flip from spinner to dot from the done payload before "
+        "waiting for /api/sessions or playing the completion cue"
+    )
+
+
+def test_sidebar_cache_completion_handles_compression_session_rotation():
+    helper_block = _sessions_function_block(
+        "_markSessionCompletedInList",
+        "_markPollingCompletionUnreadTransitions",
+    )
+
+    assert "function _markSessionCompletedInList(session, previousSid = null)" in helper_block
+    assert "const finalSid = session.session_id || previousSid;" in helper_block
+    assert "s.session_id === finalSid || s.session_id === previousSid" in helper_block
+    assert "const {messages: _messages, tool_calls: _toolCalls, ...sessionMeta} = session;" in helper_block
+    assert "...sessionMeta" in helper_block
+    assert "session_id: finalSid" in helper_block
+    assert "_sessionStreamingById.set(finalSid, false);" in helper_block
+    assert "if (previousSid && previousSid !== finalSid)" in helper_block
+    assert "_sessionStreamingById.delete(previousSid);" in helper_block
+    assert "_sessionListSnapshotById.delete(previousSid);" in helper_block
 
 
 def test_polling_transition_marks_completion_unread_without_sse_done():
@@ -140,7 +196,7 @@ def test_polling_transition_tracks_the_same_effective_streaming_state_as_sidebar
 def test_cache_render_seeds_streaming_transition_state_for_visible_spinners():
     remember_block = _sessions_function_block(
         "_rememberRenderedStreamingState",
-        "_markPollingCompletionUnreadTransitions",
+        "_rememberRenderedSessionSnapshot",
     )
     render_idx = SESSIONS_JS.find("function _renderOneSession")
     assert render_idx != -1, "_renderOneSession not found"
@@ -155,11 +211,80 @@ def test_cache_render_seeds_streaming_transition_state_for_visible_spinners():
     )
 
 
+def test_polling_transition_marks_completion_when_long_running_stream_snapshot_advances():
+    transition_block = _sessions_function_block(
+        "_markPollingCompletionUnreadTransitions",
+        "newSession",
+    )
+    render_idx = SESSIONS_JS.find("function _renderOneSession")
+    assert render_idx != -1, "_renderOneSession not found"
+    render_block = SESSIONS_JS[render_idx:SESSIONS_JS.find("const hasUnread=", render_idx)]
+
+    assert "const _sessionListSnapshotById = new Map();" in SESSIONS_JS
+    assert "SESSION_OBSERVED_STREAMING_KEY = 'hermes-session-observed-streaming'" in SESSIONS_JS
+    assert "function _rememberObservedStreamingSession(" in SESSIONS_JS
+    assert "function _forgetObservedStreamingSession(" in SESSIONS_JS
+    assert "const previousSnapshot = _sessionListSnapshotById.get(sid);" in transition_block
+    assert "const observedStreaming = _getSessionObservedStreaming()[sid];" in transition_block
+    assert "const completedWithNewMessages = Boolean(" in transition_block
+    assert "(previousSnapshot || observedStreaming)" in transition_block
+    assert "messageCount > Number((previousSnapshot || observedStreaming).message_count || 0)" in transition_block
+    assert "lastMessageAt > Number((previousSnapshot || observedStreaming).last_message_at || 0)" in transition_block
+    assert "const completedPersistedObservedStream = Boolean(observedStreaming && !isStreaming);" in transition_block
+    assert "completedObservedStream || completedPersistedObservedStream || completedWithNewMessages" in transition_block
+    assert "_sessionListSnapshotById.set(sid, {" in transition_block
+    assert "_rememberRenderedSessionSnapshot(s);" in render_block, (
+        "a visible sidebar spinner can outlive the original SSE context for "
+        "long-running tasks, so rendered rows must seed the message snapshot "
+        "used by the polling fallback"
+    )
+
+
+def test_polling_snapshot_fallback_does_not_mark_first_seen_historical_sessions():
+    transition_block = _sessions_function_block(
+        "_markPollingCompletionUnreadTransitions",
+        "newSession",
+    )
+
+    prev_idx = transition_block.find("const previousSnapshot = _sessionListSnapshotById.get(sid);")
+    fallback_idx = transition_block.find("const completedWithNewMessages = Boolean(")
+    mark_idx = transition_block.find("_markSessionCompletionUnread(sid")
+    snapshot_set_idx = transition_block.find("_sessionListSnapshotById.set(sid, {")
+
+    assert prev_idx != -1 and fallback_idx != -1 and mark_idx != -1 and snapshot_set_idx != -1
+    assert "(previousSnapshot || observedStreaming)\n      && !isStreaming" in transition_block, (
+        "snapshot-delta fallback must require a previous in-memory or persisted "
+        "observation so old completed sessions do not become unread on first render"
+    )
+    assert prev_idx < fallback_idx < mark_idx < snapshot_set_idx, (
+        "the old snapshot must be checked before writing the current snapshot"
+    )
+
+
+def test_rendered_streaming_rows_persist_observation_across_reload():
+    remember_block = _sessions_function_block(
+        "_rememberRenderedStreamingState",
+        "_rememberRenderedSessionSnapshot",
+    )
+    transition_block = _sessions_function_block(
+        "_markPollingCompletionUnreadTransitions",
+        "newSession",
+    )
+
+    assert "_rememberObservedStreamingSession(s);" in remember_block, (
+        "visible spinner rows must persist an observed-running marker so long "
+        "tasks still become unread if the original SSE/in-memory state is lost"
+    )
+    assert "if (isStreaming) {" in transition_block
+    assert "_rememberObservedStreamingSession(s);" in transition_block
+    assert "} else {\n      _forgetObservedStreamingSession(sid);" in transition_block
+
+
 def test_active_done_marks_viewed_without_setting_unread_marker():
     done_block = _done_block()
-    marker_idx = done_block.find("_markSessionCompletionUnread(activeSid")
+    marker_idx = done_block.find("_markSessionCompletionUnread(completedSid")
     active_guard_idx = done_block.find("if(isActiveSession){", marker_idx)
-    viewed_guard_idx = done_block.find("if(isSessionViewed) _markSessionViewed(activeSid", active_guard_idx)
+    viewed_guard_idx = done_block.find("if(isSessionViewed) _markSessionViewed(completedSid", active_guard_idx)
 
     assert marker_idx != -1, "background completion marker call missing"
     assert active_guard_idx != -1, "done handler must guard active-session UI updates"
@@ -179,7 +304,7 @@ def test_hidden_active_done_still_updates_current_pane_but_not_read_state():
     session_update_idx = done_block.find("S.session=d.session", active_guard_idx)
     render_idx = done_block.find("renderMessages()", active_guard_idx)
     load_dir_idx = done_block.find("loadDir('.')", active_guard_idx)
-    mark_viewed_idx = done_block.find("if(isSessionViewed) _markSessionViewed(activeSid", active_guard_idx)
+    mark_viewed_idx = done_block.find("if(isSessionViewed) _markSessionViewed(completedSid", active_guard_idx)
 
     assert active_const_idx != -1, "done handler must compute active/current pane separately"
     assert viewed_const_idx != -1, "done handler must still compute visible/focused read state"
@@ -232,9 +357,10 @@ def test_restore_settled_background_stream_marks_completion_unread():
     restore_block = MESSAGES_JS[restore_idx:MESSAGES_JS.find("function _handleStreamError", restore_idx)]
 
     assert "const isSessionViewed=_isSessionActivelyViewed(activeSid);" in restore_block
+    assert "const completedSid=session.session_id||activeSid;" in restore_block
     assert "if(!isSessionViewed && typeof _markSessionCompletionUnread==='function')" in restore_block
-    assert "_markSessionCompletionUnread(activeSid, session.message_count);" in restore_block
-    assert "if(isSessionViewed) _markSessionViewed(activeSid" in restore_block, (
+    assert "_markSessionCompletionUnread(completedSid, session.message_count);" in restore_block
+    assert "if(isSessionViewed) _markSessionViewed(completedSid" in restore_block, (
         "restore-settled fallback must not mark a hidden/background completion read"
     )
 

--- a/tests/test_issue856_background_completion_unread.py
+++ b/tests/test_issue856_background_completion_unread.py
@@ -57,13 +57,18 @@ def test_polling_transition_marks_completion_unread_without_sse_done():
         "_markPollingCompletionUnreadTransitions",
         "newSession",
     )
+    effective_block = _sessions_function_block(
+        "_isSessionEffectivelyStreaming",
+        "_markPollingCompletionUnreadTransitions",
+    )
     render_idx = SESSIONS_JS.find("async function renderSessionList()")
     assert render_idx != -1, "renderSessionList not found"
     render_block = SESSIONS_JS[render_idx:SESSIONS_JS.find("// ── Gateway session SSE", render_idx)]
 
     assert "const _sessionStreamingById = new Map();" in SESSIONS_JS
     assert "const wasStreaming = _sessionStreamingById.get(sid);" in transition_block
-    assert "const isStreaming = Boolean(s.is_streaming);" in transition_block
+    assert "const isStreaming = _isSessionEffectivelyStreaming(s);" in transition_block
+    assert "s.is_streaming || _isSessionLocallyStreaming(s)" in effective_block
     assert "wasStreaming === true && !isStreaming" in transition_block, (
         "polling fallback must only fire on an observed streaming -> stopped transition"
     )
@@ -107,6 +112,28 @@ def test_polling_transition_skips_visible_focused_active_session():
     assert "!_isSessionActivelyViewedForList(sid)" in transition_block, (
         "polling fallback must not create an unread marker for a session the "
         "user is visibly and focusedly reading"
+    )
+
+
+def test_polling_transition_tracks_the_same_effective_streaming_state_as_sidebar():
+    local_block = _sessions_function_block(
+        "_isSessionLocallyStreaming",
+        "_isSessionEffectivelyStreaming",
+    )
+    effective_block = _sessions_function_block(
+        "_isSessionEffectivelyStreaming",
+        "_markPollingCompletionUnreadTransitions",
+    )
+    render_idx = SESSIONS_JS.find("function _renderOneSession")
+    assert render_idx != -1, "_renderOneSession not found"
+    render_block = SESSIONS_JS[render_idx:SESSIONS_JS.find("const hasUnread=", render_idx)]
+
+    assert "(isActive && S.busy)" in local_block
+    assert "INFLIGHT && INFLIGHT[s.session_id]" in local_block
+    assert "s.is_streaming || _isSessionLocallyStreaming(s)" in effective_block
+    assert "const isStreaming=_isSessionEffectivelyStreaming(s);" in render_block, (
+        "the row spinner and polling completion transition must use the same "
+        "effective streaming source, including local INFLIGHT-only streams"
     )
 
 
@@ -178,6 +205,19 @@ def test_switching_away_counts_as_background_completion():
     assert "_loadingSessionId!==sid" in helper_block, (
         "if loadSession(B) is in flight while done(A) arrives, A must be treated "
         "as background even though S.session can still temporarily point at A"
+    )
+
+
+def test_restore_settled_background_stream_marks_completion_unread():
+    restore_idx = MESSAGES_JS.find("async function _restoreSettledSession()")
+    assert restore_idx != -1, "_restoreSettledSession not found"
+    restore_block = MESSAGES_JS[restore_idx:MESSAGES_JS.find("function _handleStreamError", restore_idx)]
+
+    assert "const isSessionViewed=_isSessionActivelyViewed(activeSid);" in restore_block
+    assert "if(!isSessionViewed && typeof _markSessionCompletionUnread==='function')" in restore_block
+    assert "_markSessionCompletionUnread(activeSid, session.message_count);" in restore_block
+    assert "if(isSessionViewed) _markSessionViewed(activeSid" in restore_block, (
+        "restore-settled fallback must not mark a hidden/background completion read"
     )
 
 

--- a/tests/test_issue856_background_completion_unread.py
+++ b/tests/test_issue856_background_completion_unread.py
@@ -1,0 +1,104 @@
+"""Regression checks for #856 background completion unread markers."""
+
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parent.parent
+SESSIONS_JS = (REPO / "static" / "sessions.js").read_text(encoding="utf-8")
+MESSAGES_JS = (REPO / "static" / "messages.js").read_text(encoding="utf-8")
+
+
+def _done_block() -> str:
+    start = MESSAGES_JS.find("source.addEventListener('done'")
+    assert start != -1, "done handler not found in messages.js"
+    end = MESSAGES_JS.find("source.addEventListener('stream_end'", start)
+    assert end != -1, "stream_end handler not found after done handler"
+    return MESSAGES_JS[start:end]
+
+
+def test_background_completion_unread_uses_explicit_marker_not_message_delta():
+    """A background completion must stay unread even when message_count has no delta."""
+    assert "SESSION_COMPLETION_UNREAD_KEY = 'hermes-session-completion-unread'" in SESSIONS_JS
+    assert "function _markSessionCompletionUnread(" in SESSIONS_JS
+    assert "function _clearSessionCompletionUnread(" in SESSIONS_JS
+    assert "function _hasSessionCompletionUnread(" in SESSIONS_JS
+
+    has_unread_idx = SESSIONS_JS.find("function _hasUnreadForSession(s)")
+    assert has_unread_idx != -1, "_hasUnreadForSession not found"
+    has_unread_block = SESSIONS_JS[has_unread_idx:SESSIONS_JS.find("async function newSession", has_unread_idx)]
+
+    marker_idx = has_unread_block.find("_hasSessionCompletionUnread(s.session_id)")
+    count_idx = has_unread_block.find("s.message_count > Number")
+    assert marker_idx != -1, "_hasUnreadForSession must check explicit completion unread marker"
+    assert count_idx != -1, "_hasUnreadForSession must keep the existing message_count fallback"
+    assert marker_idx < count_idx, (
+        "explicit completion unread marker must be checked before message_count delta, "
+        "because completed streams can have viewed_count == message_count"
+    )
+
+
+def test_background_done_sets_marker_when_session_not_actively_viewed():
+    done_block = _done_block()
+    assert "const isSessionViewed=_isSessionActivelyViewed(activeSid);" in done_block
+    assert "if(!isSessionViewed && typeof _markSessionCompletionUnread==='function')" in done_block
+    assert "_markSessionCompletionUnread(activeSid, d.session&&d.session.message_count);" in done_block
+
+
+def test_active_done_marks_viewed_without_setting_unread_marker():
+    done_block = _done_block()
+    marker_idx = done_block.find("_markSessionCompletionUnread(activeSid")
+    viewed_guard_idx = done_block.find("if(isSessionViewed){", marker_idx)
+    viewed_mark_idx = done_block.find("_markSessionViewed(activeSid", viewed_guard_idx)
+
+    assert marker_idx != -1, "background completion marker call missing"
+    assert viewed_guard_idx != -1, "done handler must guard active-session UI updates"
+    assert viewed_mark_idx != -1, "active/current completion must still mark session viewed"
+    assert viewed_guard_idx < viewed_mark_idx, (
+        "active-session viewed write must remain inside isSessionViewed guard so "
+        "switch-away races cannot mark a background completion read"
+    )
+
+
+def test_switching_away_counts_as_background_completion():
+    helper_idx = MESSAGES_JS.find("function _isSessionActivelyViewed(sid)")
+    assert helper_idx != -1, "_isSessionActivelyViewed helper missing"
+    helper_block = MESSAGES_JS[helper_idx:MESSAGES_JS.find("async function send()", helper_idx)]
+
+    assert "S.session.session_id!==sid" in helper_block
+    assert "_loadingSessionId" in helper_block
+    assert "_loadingSessionId!==sid" in helper_block, (
+        "if loadSession(B) is in flight while done(A) arrives, A must be treated "
+        "as background even though S.session can still temporarily point at A"
+    )
+
+
+def test_completion_unread_clears_only_when_session_is_opened():
+    load_idx = SESSIONS_JS.find("async function loadSession(sid)")
+    assert load_idx != -1, "loadSession not found"
+    load_block = SESSIONS_JS[load_idx:SESSIONS_JS.find("function _resolveSessionModelForDisplaySoon", load_idx)]
+
+    stale_guard_idx = load_block.find("if (_loadingSessionId !== sid) return;")
+    clear_idx = load_block.find("_clearSessionCompletionUnread(S.session.session_id);")
+    set_viewed_idx = load_block.find("_setSessionViewedCount(S.session.session_id")
+
+    assert clear_idx != -1, "loadSession must clear explicit completion unread when the user opens the session"
+    assert stale_guard_idx != -1 and stale_guard_idx < clear_idx, (
+        "stale loadSession responses must not clear unread markers for sessions the user did not actually open"
+    )
+    assert set_viewed_idx != -1 and set_viewed_idx < clear_idx, (
+        "completion unread should clear at the same point the session is marked viewed"
+    )
+
+
+def test_historical_sessions_are_not_marked_unread_on_list_render():
+    """The explicit unread marker must be event-driven, not initialized by _hasUnreadForSession."""
+    has_unread_idx = SESSIONS_JS.find("function _hasUnreadForSession(s)")
+    assert has_unread_idx != -1
+    has_unread_block = SESSIONS_JS[has_unread_idx:SESSIONS_JS.find("async function newSession", has_unread_idx)]
+
+    assert "_markSessionCompletionUnread" not in has_unread_block, (
+        "rendering old historical sessions must not create completion-unread markers"
+    )
+    assert "_setSessionViewedCount(s.session_id, Number(s.message_count || 0));" in has_unread_block, (
+        "missing viewed-count baseline should still initialize as read for historical sessions"
+    )

--- a/tests/test_issue856_pinned_indicator_layout.py
+++ b/tests/test_issue856_pinned_indicator_layout.py
@@ -118,10 +118,11 @@ def test_timestamp_hidden_when_attention_state_is_present():
 def test_sidebar_uses_local_inflight_state_for_immediate_spinner():
     messages_js = (Path(__file__).resolve().parent.parent / "static" / "messages.js").read_text()
 
-    assert "const isLocalStreaming=Boolean(" in SESSIONS_JS
-    assert "(isActive&&S.busy)" in SESSIONS_JS
+    assert "function _isSessionLocallyStreaming(s)" in SESSIONS_JS
+    assert "(isActive && S.busy)" in SESSIONS_JS
     assert "INFLIGHT[s.session_id]" in SESSIONS_JS
-    assert "const isStreaming=Boolean(s.is_streaming||isLocalStreaming);" in SESSIONS_JS
+    assert "function _isSessionEffectivelyStreaming(s)" in SESSIONS_JS
+    assert "const isStreaming=_isSessionEffectivelyStreaming(s);" in SESSIONS_JS
     assert "if(typeof renderSessionListFromCache==='function') renderSessionListFromCache();" in messages_js
 
 


### PR DESCRIPTION
## Summary

Follow-up to #856 / #898 for the session attention indicators.

This fixes residual unread-dot regressions where a background session could show a spinner while running, finish, and then lose the spinner without turning into an unread dot.

The visible behavior is small, but the fix is not just a CSS/state toggle: the sidebar derives one user-facing attention state from several asynchronous sources that can disagree or disappear at different times.

## Why this was tricky

The unread dot looks like a tiny UI detail, but the underlying state has multiple completion paths:

- foreground SSE `done` for the currently attached stream
- `/api/sessions` polling for background sessions
- local `INFLIGHT` / `S.busy` sidebar spinners before the next poll catches up
- reconnect / settled-stream fallback paths when the normal SSE `done` path is missed
- auto-compression, where Hermes Agent can rotate the session id before the final `done` payload is emitted

The last case was the hardest residual bug from manual testing: long-running sessions often auto-compress. The frontend captured the original stream id/session id as `activeSid`, but the final `done` payload could contain a different `session.session_id`. If the unread marker is written to the old id, the sidebar renders the final row under the new id and the dot is invisible.

## Root Cause

The first implementation mostly depended on the SSE `done` event for the session that completed.

That missed real multi-session cases where the sidebar only observes a background session through polling:

- the page sees a session as running
- later polling sees it stopped
- the spinner disappears
- but no unread marker is created because no attached SSE `done` handler ran for that background session

After covering the basic backend `is_streaming: true -> false` path, manual multi-session testing exposed additional source-of-truth gaps:

- the visible spinner can come from local `INFLIGHT` / `S.busy`, not only backend `is_streaming`
- `renderSessionListFromCache()` can display a spinner before a full `/api/sessions` poll has seeded transition state
- reconnect / settled-stream fallback can finish a stream without a normal SSE `done`
- auto-compression can rotate the session id, so unread/read state must attach to the final visible session id, not only the old SSE `activeSid`

## What Changed

- Adds an explicit completion-unread marker so completed background streams do not rely only on `message_count` deltas.
- Adds a polling fallback in `renderSessionList()` that marks a session unread when the page previously observed it streaming and later observes it stopped.
- Tracks the same effective streaming state the sidebar renders, including local `INFLIGHT` / active busy state, not just backend `is_streaming`.
- Seeds transition state when `renderSessionListFromCache()` visibly renders a spinner, so cache-rendered local spinners are not missed.
- Persists observed-running state in localStorage so a long-running session can still become unread after reload/reconnect or lost in-memory transition state.
- Marks background completions unread in the reconnect/settled-stream fallback path.
- Handles auto-compression session-id rotation by writing unread/read markers to the final `session.session_id` from the completion payload.
- Updates the sidebar cache immediately from the final completion payload so the row can flip from spinner to dot before waiting for the next full sessions refresh.
- Keeps the sidebar cache compact by stripping full `messages` / `tool_calls` from the completion payload before merging it into the session-list cache.
- Avoids marking old historical sessions unread on first render by requiring a previously observed running state or snapshot advancement.
- Keeps visible/focused active sessions read, while hidden/unfocused active-session completions can still refresh the pane without being marked read.
- Clears the explicit completion marker when the user opens the session, or when the user returns to the active completed session.

## Verification

Automated:

- `node --check static/messages.js`
- `node --check static/sessions.js`
- `git diff --check`
- `pytest tests/test_issue856_background_completion_unread.py tests/test_issue856_session_streaming_state.py tests/test_issue856_active_session_read_state.py tests/test_issue856_pinned_indicator_layout.py tests/test_session_metadata_fast_path.py`
  - `41 passed`

GitHub checks:

- Python 3.11: pass
- Python 3.12: pass
- Python 3.13: pass

Manual:

- Reproduced multi-session background completion cases locally on `127.0.0.1:8787`.
- Confirmed a long-running `mv generator skill` session with auto-compression history could finish and show the unread dot.
- Confirmed current active sessions still do not keep a stale unread dot after completion.

## Scope

This is intentionally a narrow regression fix for the already-shipped session attention work.

It does not change indicator design, timestamp behavior, notification behavior, or broader session-list UX.
