### PR TITLE
feat: DeepSeek V4 models, Z.AI/GLM provider, model tags in provider cards

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -503,6 +503,8 @@ _FALLBACK_MODELS = [
     # DeepSeek
     {"provider": "DeepSeek",  "id": "deepseek/deepseek-v4-flash",          "label": "DeepSeek V4 Flash"},
     {"provider": "DeepSeek",  "id": "deepseek/deepseek-v4-pro",            "label": "DeepSeek V4 Pro"},
+    {"provider": "DeepSeek",  "id": "deepseek/deepseek-chat-v3-0324",      "label": "DeepSeek V3 (legacy)"},
+    {"provider": "DeepSeek",  "id": "deepseek/deepseek-r1",                "label": "DeepSeek R1 (legacy)"},
     # Qwen (Alibaba) — strong coding and general models
     {"provider": "Qwen",      "id": "qwen/qwen3-coder",                   "label": "Qwen3 Coder"},
     {"provider": "Qwen",      "id": "qwen/qwen3.6-plus",                  "label": "Qwen3.6 Plus"},
@@ -650,6 +652,8 @@ _PROVIDER_MODELS = {
     "deepseek": [
         {"id": "deepseek-v4-flash", "label": "DeepSeek V4 Flash"},
         {"id": "deepseek-v4-pro", "label": "DeepSeek V4 Pro"},
+        {"id": "deepseek-chat-v3-0324", "label": "DeepSeek V3 (legacy)"},
+        {"id": "deepseek-reasoner", "label": "DeepSeek Reasoner (legacy)"},
     ],
     "nous": [
         {"id": "@nous:anthropic/claude-opus-4.6",     "label": "Claude Opus 4.6 (via Nous)"},

--- a/api/config.py
+++ b/api/config.py
@@ -501,8 +501,6 @@ _FALLBACK_MODELS = [
     {"provider": "Google",    "id": "google/gemini-2.5-pro",                    "label": "Gemini 2.5 Pro"},
     {"provider": "Google",    "id": "google/gemini-2.5-flash",                  "label": "Gemini 2.5 Flash"},
     # DeepSeek
-    {"provider": "DeepSeek",  "id": "deepseek/deepseek-chat-v3-0324",     "label": "DeepSeek V3"},
-    {"provider": "DeepSeek",  "id": "deepseek/deepseek-r1",               "label": "DeepSeek R1"},
     {"provider": "DeepSeek",  "id": "deepseek/deepseek-v4-flash",          "label": "DeepSeek V4 Flash"},
     {"provider": "DeepSeek",  "id": "deepseek/deepseek-v4-pro",            "label": "DeepSeek V4 Pro"},
     # Qwen (Alibaba) — strong coding and general models
@@ -650,8 +648,6 @@ _PROVIDER_MODELS = {
         {"id": "gemini-2.5-flash",                  "label": "Gemini 2.5 Flash"},
     ],
     "deepseek": [
-        {"id": "deepseek-chat-v3-0324", "label": "DeepSeek V3"},
-        {"id": "deepseek-reasoner", "label": "DeepSeek Reasoner"},
         {"id": "deepseek-v4-flash", "label": "DeepSeek V4 Flash"},
         {"id": "deepseek-v4-pro", "label": "DeepSeek V4 Pro"},
     ],

--- a/api/config.py
+++ b/api/config.py
@@ -503,6 +503,8 @@ _FALLBACK_MODELS = [
     # DeepSeek
     {"provider": "DeepSeek",  "id": "deepseek/deepseek-chat-v3-0324",     "label": "DeepSeek V3"},
     {"provider": "DeepSeek",  "id": "deepseek/deepseek-r1",               "label": "DeepSeek R1"},
+    {"provider": "DeepSeek",  "id": "deepseek/deepseek-v4-flash",          "label": "DeepSeek V4 Flash"},
+    {"provider": "DeepSeek",  "id": "deepseek/deepseek-v4-pro",            "label": "DeepSeek V4 Pro"},
     # Qwen (Alibaba) — strong coding and general models
     {"provider": "Qwen",      "id": "qwen/qwen3-coder",                   "label": "Qwen3 Coder"},
     {"provider": "Qwen",      "id": "qwen/qwen3.6-plus",                  "label": "Qwen3.6 Plus"},
@@ -643,6 +645,8 @@ _PROVIDER_MODELS = {
     "deepseek": [
         {"id": "deepseek-chat-v3-0324", "label": "DeepSeek V3"},
         {"id": "deepseek-reasoner", "label": "DeepSeek Reasoner"},
+        {"id": "deepseek-v4-flash", "label": "DeepSeek V4 Flash"},
+        {"id": "deepseek-v4-pro", "label": "DeepSeek V4 Pro"},
     ],
     "nous": [
         {"id": "@nous:anthropic/claude-opus-4.6",     "label": "Claude Opus 4.6 (via Nous)"},

--- a/api/config.py
+++ b/api/config.py
@@ -515,6 +515,13 @@ _FALLBACK_MODELS = [
     # MiniMax
     {"provider": "MiniMax",   "id": "minimax/MiniMax-M2.7",             "label": "MiniMax M2.7"},
     {"provider": "MiniMax",   "id": "minimax/MiniMax-M2.7-highspeed",   "label": "MiniMax M2.7 Highspeed"},
+    # Z.AI / GLM
+    {"provider": "Z.AI",      "id": "zai/glm-5.1",                      "label": "GLM-5.1"},
+    {"provider": "Z.AI",      "id": "zai/glm-5",                        "label": "GLM-5"},
+    {"provider": "Z.AI",      "id": "zai/glm-5-turbo",                  "label": "GLM-5 Turbo"},
+    {"provider": "Z.AI",      "id": "zai/glm-4.7",                      "label": "GLM-4.7"},
+    {"provider": "Z.AI",      "id": "zai/glm-4.5",                      "label": "GLM-4.5"},
+    {"provider": "Z.AI",      "id": "zai/glm-4.5-flash",                "label": "GLM-4.5 Flash"},
 ]
 
 # Provider display names for known Hermes provider IDs

--- a/api/onboarding.py
+++ b/api/onboarding.py
@@ -111,7 +111,7 @@ _SUPPORTED_PROVIDER_SETUPS = {
         "label": "Z.AI / GLM (智谱)",
         "env_var": "GLM_API_KEY",
         "default_model": "glm-5.1",
-        "default_base_url": "https://open.bigmodel.cn/api/coding/paas/v4",
+        "default_base_url": "https://open.bigmodel.cn/api/paas/v4",
         "requires_base_url": False,
         "models": list(_PROVIDER_MODELS.get("zai", [])),
         "category": "specialized",

--- a/api/onboarding.py
+++ b/api/onboarding.py
@@ -101,10 +101,19 @@ _SUPPORTED_PROVIDER_SETUPS = {
     "deepseek": {
         "label": "DeepSeek",
         "env_var": "DEEPSEEK_API_KEY",
-        "default_model": "deepseek-chat-v3-0324",
-        "default_base_url": "https://api.deepseek.com/v1",
+        "default_model": "deepseek-v4-flash",
+        "default_base_url": "https://api.deepseek.com",
         "requires_base_url": False,
         "models": list(_PROVIDER_MODELS.get("deepseek", [])),
+        "category": "specialized",
+    },
+    "zai": {
+        "label": "Z.AI / GLM (智谱)",
+        "env_var": "GLM_API_KEY",
+        "default_model": "glm-5.1",
+        "default_base_url": "https://open.bigmodel.cn/api/coding/paas/v4",
+        "requires_base_url": False,
+        "models": list(_PROVIDER_MODELS.get("zai", [])),
         "category": "specialized",
     },
     "mistralai": {

--- a/api/providers.py
+++ b/api/providers.py
@@ -260,6 +260,36 @@ def get_providers() -> dict[str, Any]:
             "models": models,
         })
 
+    # Scan custom_providers from config.yaml (e.g. glmcode, timicc)
+    custom_providers_cfg = cfg.get("custom_providers", [])
+    if isinstance(custom_providers_cfg, list):
+        for cp in custom_providers_cfg:
+            if not isinstance(cp, dict) or not cp.get("name"):
+                continue
+            cp_name = str(cp["name"]).strip()
+            cp_id = f"custom:{cp_name}"
+            # Collect models from `models` list or `model` single
+            cp_models = []
+            if isinstance(cp.get("models"), list):
+                cp_models = [{"id": str(m), "label": str(m)} for m in cp["models"]]
+            elif cp.get("model"):
+                cp_models = [{"id": cp["model"], "label": cp["model"]}]
+            # Check for env var reference (${VAR_NAME} pattern)
+            cp_api_key = str(cp.get("api_key") or "")
+            cp_has_key = bool(cp_api_key.strip())
+            # Replace env var reference to check actual value
+            if cp_api_key.startswith("${") and cp_api_key.endswith("}"):
+                env_var = cp_api_key[2:-1]
+                cp_has_key = bool(os.getenv(env_var, "").strip())
+            providers.append({
+                "id": cp_id,
+                "display_name": cp_name,
+                "has_key": cp_has_key,
+                "configurable": False,  # custom providers managed via config.yaml
+                "key_source": "config_yaml" if cp_has_key else "none",
+                "models": cp_models,
+            })
+
     # Determine active provider
     active_provider = None
     model_cfg = cfg.get("model", {})

--- a/api/routes.py
+++ b/api/routes.py
@@ -33,7 +33,7 @@ _OPENAI_COMPAT_ENDPOINTS = {
     "minimax": "https://api.minimax.chat/v1",
     "mistralai": "https://api.mistral.ai/v1",
     "xai": "https://api.x.ai/v1",
-    "deepseek": "https://api.deepseek.com/v1",
+    "deepseek": "https://api.deepseek.com",
     "gemini": "https://generativelanguage.googleapis.com/v1beta/openai",
 }
 # NOTE: "openai-codex" is excluded because it maps to the same endpoint as

--- a/static/index.html
+++ b/static/index.html
@@ -374,6 +374,7 @@
                 <option value="google/gemini-3-flash-preview">Gemini 3 Flash Preview</option>
                 <option value="deepseek/deepseek-v4-flash">DeepSeek V4 Flash</option>
                 <option value="deepseek/deepseek-v4-pro">DeepSeek V4 Pro</option>
+                <option value="deepseek/deepseek-chat-v3-0324">DeepSeek V3 (legacy)</option>
                 <option value="meta-llama/llama-4-scout">Llama 4 Scout</option>
               </optgroup>
             </select>

--- a/static/index.html
+++ b/static/index.html
@@ -373,6 +373,8 @@
                 <option value="google/gemini-3.1-pro-preview">Gemini 3.1 Pro Preview</option>
                 <option value="google/gemini-3-flash-preview">Gemini 3 Flash Preview</option>
                 <option value="deepseek/deepseek-chat-v3-0324">DeepSeek V3</option>
+                <option value="deepseek/deepseek-v4-flash">DeepSeek V4 Flash</option>
+                <option value="deepseek/deepseek-v4-pro">DeepSeek V4 Pro</option>
                 <option value="meta-llama/llama-4-scout">Llama 4 Scout</option>
               </optgroup>
             </select>

--- a/static/index.html
+++ b/static/index.html
@@ -372,7 +372,6 @@
               <optgroup label="Other">
                 <option value="google/gemini-3.1-pro-preview">Gemini 3.1 Pro Preview</option>
                 <option value="google/gemini-3-flash-preview">Gemini 3 Flash Preview</option>
-                <option value="deepseek/deepseek-chat-v3-0324">DeepSeek V3</option>
                 <option value="deepseek/deepseek-v4-flash">DeepSeek V4 Flash</option>
                 <option value="deepseek/deepseek-v4-pro">DeepSeek V4 Pro</option>
                 <option value="meta-llama/llama-4-scout">Llama 4 Scout</option>

--- a/static/panels.js
+++ b/static/panels.js
@@ -2636,6 +2636,26 @@ function _buildProviderCard(p){
   field.appendChild(row);
   body.appendChild(field);
 
+  // Model list — show when provider has known models
+  if(modelCount>0){
+    const modelSection=document.createElement('div');
+    modelSection.className='provider-card-models';
+    const modelLabel=document.createElement('div');
+    modelLabel.className='provider-card-label';
+    modelLabel.textContent='Models';
+    modelSection.appendChild(modelLabel);
+    const modelList=document.createElement('div');
+    modelList.className='provider-card-model-tags';
+    for(const m of p.models){
+      const tag=document.createElement('span');
+      tag.className='provider-card-model-tag';
+      tag.textContent=m.id||m.label||m;
+      modelList.appendChild(tag);
+    }
+    modelSection.appendChild(modelList);
+    body.appendChild(modelSection);
+  }
+
   // Refresh models for this provider
   const refreshRow=document.createElement('div');
   refreshRow.className='provider-card-row';

--- a/static/style.css
+++ b/static/style.css
@@ -1818,6 +1818,26 @@ main.main.showing-profiles > #mainProfiles{display:flex;}
   background:color-mix(in srgb, var(--error) 10%, transparent);
 }
 
+/* ── Provider model tags ── */
+.provider-card-models{
+  margin-bottom:10px;
+  display:flex;flex-direction:column;gap:6px;
+}
+.provider-card-model-tags{
+  display:flex;flex-wrap:wrap;gap:4px;
+}
+.provider-card-model-tag{
+  display:inline-block;
+  padding:2px 8px;
+  font-size:10.5px;font-family:ui-monospace,SFMono-Regular,\"SF Mono\",Menlo,Consolas,monospace;
+  color:var(--muted);
+  background:var(--surface);
+  border:1px solid var(--border);
+  border-radius:5px;
+  line-height:1.5;
+  user-select:all;
+}
+
 /* ── Session pin indicator (inline, only when pinned) ── */
 .session-pin-indicator{
   flex-shrink:0;

--- a/static/ui.js
+++ b/static/ui.js
@@ -670,7 +670,7 @@ function getModelLabel(modelId){
   // Check dynamic labels first, then fall back to splitting the ID
   if(_dynamicModelLabels[modelId]) return _dynamicModelLabels[modelId];
   // Static fallback for common models
-  const STATIC_LABELS={'openai/gpt-5.4-mini':'GPT-5.4 Mini','openai/gpt-4o':'GPT-4o','openai/o3':'o3','openai/o4-mini':'o4-mini','anthropic/claude-sonnet-4.6':'Sonnet 4.6','anthropic/claude-sonnet-4-5':'Sonnet 4.5','anthropic/claude-haiku-3-5':'Haiku 3.5','google/gemini-3.1-pro-preview':'Gemini 3.1 Pro','google/gemini-3-flash-preview':'Gemini 3 Flash','google/gemini-3.1-flash-lite-preview':'Gemini 3.1 Flash Lite','google/gemini-2.5-pro':'Gemini 2.5 Pro','google/gemini-2.5-flash':'Gemini 2.5 Flash','deepseek/deepseek-chat-v3-0324':'DeepSeek V3','meta-llama/llama-4-scout':'Llama 4 Scout'};
+  const STATIC_LABELS={'openai/gpt-5.4-mini':'GPT-5.4 Mini','openai/gpt-4o':'GPT-4o','openai/o3':'o3','openai/o4-mini':'o4-mini','anthropic/claude-sonnet-4.6':'Sonnet 4.6','anthropic/claude-sonnet-4-5':'Sonnet 4.5','anthropic/claude-haiku-3-5':'Haiku 3.5','google/gemini-3.1-pro-preview':'Gemini 3.1 Pro','google/gemini-3-flash-preview':'Gemini 3 Flash','google/gemini-3.1-flash-lite-preview':'Gemini 3.1 Flash Lite','google/gemini-2.5-pro':'Gemini 2.5 Pro','google/gemini-2.5-flash':'Gemini 2.5 Flash','deepseek/deepseek-chat-v3-0324':'DeepSeek V3','deepseek/deepseek-v4-flash':'DeepSeek V4 Flash','deepseek/deepseek-v4-pro':'DeepSeek V4 Pro','meta-llama/llama-4-scout':'Llama 4 Scout'};
   if(STATIC_LABELS[modelId]) return STATIC_LABELS[modelId];
   // Safe Ollama-tag fallback formatter before generic split('/').pop()
   let _last = modelId.split('/').pop() || modelId;

--- a/static/ui.js
+++ b/static/ui.js
@@ -670,7 +670,7 @@ function getModelLabel(modelId){
   // Check dynamic labels first, then fall back to splitting the ID
   if(_dynamicModelLabels[modelId]) return _dynamicModelLabels[modelId];
   // Static fallback for common models
-  const STATIC_LABELS={'openai/gpt-5.4-mini':'GPT-5.4 Mini','openai/gpt-4o':'GPT-4o','openai/o3':'o3','openai/o4-mini':'o4-mini','anthropic/claude-sonnet-4.6':'Sonnet 4.6','anthropic/claude-sonnet-4-5':'Sonnet 4.5','anthropic/claude-haiku-3-5':'Haiku 3.5','google/gemini-3.1-pro-preview':'Gemini 3.1 Pro','google/gemini-3-flash-preview':'Gemini 3 Flash','google/gemini-3.1-flash-lite-preview':'Gemini 3.1 Flash Lite','google/gemini-2.5-pro':'Gemini 2.5 Pro','google/gemini-2.5-flash':'Gemini 2.5 Flash','deepseek/deepseek-v4-flash':'DeepSeek V4 Flash','deepseek/deepseek-v4-pro':'DeepSeek V4 Pro','meta-llama/llama-4-scout':'Llama 4 Scout'};
+  const STATIC_LABELS={'openai/gpt-5.4-mini':'GPT-5.4 Mini','openai/gpt-4o':'GPT-4o','openai/o3':'o3','openai/o4-mini':'o4-mini','anthropic/claude-sonnet-4.6':'Sonnet 4.6','anthropic/claude-sonnet-4-5':'Sonnet 4.5','anthropic/claude-haiku-3-5':'Haiku 3.5','google/gemini-3.1-pro-preview':'Gemini 3.1 Pro','google/gemini-3-flash-preview':'Gemini 3 Flash','google/gemini-3.1-flash-lite-preview':'Gemini 3.1 Flash Lite','google/gemini-2.5-pro':'Gemini 2.5 Pro','google/gemini-2.5-flash':'Gemini 2.5 Flash','deepseek/deepseek-v4-flash':'DeepSeek V4 Flash','deepseek/deepseek-v4-pro':'DeepSeek V4 Pro','deepseek/deepseek-chat-v3-0324':'DeepSeek V3 (legacy)','meta-llama/llama-4-scout':'Llama 4 Scout'};
   if(STATIC_LABELS[modelId]) return STATIC_LABELS[modelId];
   // Safe Ollama-tag fallback formatter before generic split('/').pop()
   let _last = modelId.split('/').pop() || modelId;

--- a/static/ui.js
+++ b/static/ui.js
@@ -670,7 +670,7 @@ function getModelLabel(modelId){
   // Check dynamic labels first, then fall back to splitting the ID
   if(_dynamicModelLabels[modelId]) return _dynamicModelLabels[modelId];
   // Static fallback for common models
-  const STATIC_LABELS={'openai/gpt-5.4-mini':'GPT-5.4 Mini','openai/gpt-4o':'GPT-4o','openai/o3':'o3','openai/o4-mini':'o4-mini','anthropic/claude-sonnet-4.6':'Sonnet 4.6','anthropic/claude-sonnet-4-5':'Sonnet 4.5','anthropic/claude-haiku-3-5':'Haiku 3.5','google/gemini-3.1-pro-preview':'Gemini 3.1 Pro','google/gemini-3-flash-preview':'Gemini 3 Flash','google/gemini-3.1-flash-lite-preview':'Gemini 3.1 Flash Lite','google/gemini-2.5-pro':'Gemini 2.5 Pro','google/gemini-2.5-flash':'Gemini 2.5 Flash','deepseek/deepseek-chat-v3-0324':'DeepSeek V3','deepseek/deepseek-v4-flash':'DeepSeek V4 Flash','deepseek/deepseek-v4-pro':'DeepSeek V4 Pro','meta-llama/llama-4-scout':'Llama 4 Scout'};
+  const STATIC_LABELS={'openai/gpt-5.4-mini':'GPT-5.4 Mini','openai/gpt-4o':'GPT-4o','openai/o3':'o3','openai/o4-mini':'o4-mini','anthropic/claude-sonnet-4.6':'Sonnet 4.6','anthropic/claude-sonnet-4-5':'Sonnet 4.5','anthropic/claude-haiku-3-5':'Haiku 3.5','google/gemini-3.1-pro-preview':'Gemini 3.1 Pro','google/gemini-3-flash-preview':'Gemini 3 Flash','google/gemini-3.1-flash-lite-preview':'Gemini 3.1 Flash Lite','google/gemini-2.5-pro':'Gemini 2.5 Pro','google/gemini-2.5-flash':'Gemini 2.5 Flash','deepseek/deepseek-v4-flash':'DeepSeek V4 Flash','deepseek/deepseek-v4-pro':'DeepSeek V4 Pro','meta-llama/llama-4-scout':'Llama 4 Scout'};
   if(STATIC_LABELS[modelId]) return STATIC_LABELS[modelId];
   // Safe Ollama-tag fallback formatter before generic split('/').pop()
   let _last = modelId.split('/').pop() || modelId;

--- a/tests/test_custom_providers_in_panel.py
+++ b/tests/test_custom_providers_in_panel.py
@@ -226,20 +226,20 @@ class TestDeepSeekV4Models:
     """Verify DeepSeek V4 models are in the model lists, V3 is removed."""
 
     def test_v4_models_in_provider_models(self):
-        """_PROVIDER_MODELS['deepseek'] should contain v4-flash and v4-pro only."""
+        """_PROVIDER_MODELS['deepseek'] should contain v4 and legacy v3 entries."""
         from api.config import _PROVIDER_MODELS
         ds_models = _PROVIDER_MODELS.get("deepseek", [])
         ids = {m["id"] for m in ds_models}
 
-        assert "deepseek-v4-flash" in ids, f"v4-flash missing from deepseek models: {ids}"
-        assert "deepseek-v4-pro" in ids, f"v4-pro missing from deepseek models: {ids}"
+        assert "deepseek-v4-flash" in ids, f"v4-flash missing: {ids}"
+        assert "deepseek-v4-pro" in ids, f"v4-pro missing: {ids}"
 
-        # V3 / legacy models should be gone
-        assert "deepseek-chat-v3-0324" not in ids, (
-            f"deprecated V3 should not be in model list: {ids}"
+        # Legacy models still present (deprecated 2026-07-24, not yet removed)
+        assert "deepseek-chat-v3-0324" in ids, (
+            f"V3 legacy should remain until deprecation date: {ids}"
         )
-        assert "deepseek-reasoner" not in ids, (
-            f"deprecated reasoner should not be in model list: {ids}"
+        assert "deepseek-reasoner" in ids, (
+            f"Reasoner legacy should remain until deprecation date: {ids}"
         )
 
     def test_zai_models_include_glm_series(self):
@@ -265,7 +265,7 @@ class TestDeepSeekV4Models:
         assert zai["label"] == "Z.AI / GLM (智谱)"
         assert zai["env_var"] == "GLM_API_KEY"
         assert zai["default_model"] == "glm-5.1"
-        assert zai["default_base_url"] == "https://open.bigmodel.cn/api/coding/paas/v4"
+        assert zai["default_base_url"] == "https://open.bigmodel.cn/api/paas/v4"
 
     def test_deepseek_onboarding_default_is_v4(self):
         """DeepSeek onboarding default should be v4-flash, not V3."""

--- a/tests/test_custom_providers_in_panel.py
+++ b/tests/test_custom_providers_in_panel.py
@@ -1,0 +1,279 @@
+"""Tests for custom_providers scanning in get_providers().
+
+Verifies that config.yaml custom_providers entries (e.g. glmcode, timicc)
+are surfaced in the /api/providers response alongside built-in providers.
+"""
+
+import json
+import os
+import sys
+import types
+
+import api.config as config
+import api.profiles as profiles
+from tests._pytest_port import BASE
+
+
+def _install_fake_hermes_cli(monkeypatch):
+    """Stub hermes_cli so tests are deterministic and offline."""
+    fake_pkg = types.ModuleType("hermes_cli")
+    fake_pkg.__path__ = []
+
+    fake_models = types.ModuleType("hermes_cli.models")
+    fake_models.list_available_providers = lambda: []
+    fake_models.provider_model_ids = lambda pid: []
+
+    fake_auth = types.ModuleType("hermes_cli.auth")
+    fake_auth.get_auth_status = lambda _pid: {}
+
+    monkeypatch.setitem(sys.modules, "hermes_cli", fake_pkg)
+    monkeypatch.setitem(sys.modules, "hermes_cli.models", fake_models)
+    monkeypatch.setitem(sys.modules, "hermes_cli.auth", fake_auth)
+    monkeypatch.delitem(sys.modules, "agent.credential_pool", raising=False)
+    monkeypatch.delitem(sys.modules, "agent", raising=False)
+
+    try:
+        from api.config import invalidate_models_cache
+        invalidate_models_cache()
+    except Exception:
+        pass
+
+
+class TestCustomProvidersInGetProviders:
+    """Unit tests for custom_providers scanning in get_providers()."""
+
+    def _setup_cfg(self, custom_providers, active_provider=None):
+        old_cfg = dict(config.cfg)
+        old_mtime = config._cfg_mtime
+        config.cfg.clear()
+        config.cfg["model"] = {"provider": active_provider or "anthropic"}
+        if custom_providers is not None:
+            config.cfg["custom_providers"] = custom_providers
+        try:
+            config._cfg_mtime = config.Path(config._get_config_path()).stat().st_mtime
+        except Exception:
+            config._cfg_mtime = 0.0
+        return old_cfg, old_mtime
+
+    def _restore_cfg(self, old_cfg, old_mtime):
+        config.cfg.clear()
+        config.cfg.update(old_cfg)
+        config._cfg_mtime = old_mtime
+
+    def test_custom_provider_with_models(self, monkeypatch, tmp_path):
+        """glmcode custom provider with models should appear in provider list."""
+        _install_fake_hermes_cli(monkeypatch)
+        monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
+        monkeypatch.setenv("GLMCODE_API_KEY", "test-glm-key-12345678")
+
+        old_cfg, old_mtime = self._setup_cfg([
+            {
+                "name": "glmcode",
+                "base_url": "https://open.bigmodel.cn/api/coding/paas/v4",
+                "api_key": "${GLMCODE_API_KEY}",
+                "api_mode": "openai_compatible",
+                "model": "glm-5.1",
+            },
+        ])
+
+        from api.providers import get_providers
+        try:
+            result = get_providers()
+            provider_ids = {p["id"] for p in result["providers"]}
+            assert "custom:glmcode" in provider_ids, (
+                f"custom:glmcode missing; got: {sorted(provider_ids)}"
+            )
+
+            glmcode = [p for p in result["providers"] if p["id"] == "custom:glmcode"][0]
+            assert glmcode["has_key"] is True, (
+                "glmcode should detect key from ${GLMCODE_API_KEY} env var"
+            )
+            assert glmcode["configurable"] is False, (
+                "custom providers should not be configurable via WebUI"
+            )
+            assert glmcode["key_source"] == "config_yaml"
+            assert glmcode["display_name"] == "glmcode"
+
+            # Model list — single model entry
+            model_ids = {m["id"] for m in glmcode["models"]}
+            assert "glm-5.1" in model_ids, (
+                f"Expected glm-5.1 in models, got: {model_ids}"
+            )
+        finally:
+            self._restore_cfg(old_cfg, old_mtime)
+
+    def test_custom_provider_with_multi_models(self, monkeypatch, tmp_path):
+        """Custom provider with `models` list should expose all entries."""
+        _install_fake_hermes_cli(monkeypatch)
+        monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
+        monkeypatch.setenv("DEEPSEEK_API_KEY", "sk-deepseek-test-12345678")
+
+        old_cfg, old_mtime = self._setup_cfg([
+            {
+                "name": "deepseek",
+                "base_url": "https://api.deepseek.com",
+                "api_key": "${DEEPSEEK_API_KEY}",
+                "api_mode": "openai_compatible",
+                "models": ["deepseek-v4-flash", "deepseek-v4-pro"],
+            },
+        ])
+
+        from api.providers import get_providers
+        try:
+            result = get_providers()
+            provider_ids = {p["id"] for p in result["providers"]}
+            assert "custom:deepseek" in provider_ids
+
+            ds = [p for p in result["providers"] if p["id"] == "custom:deepseek"][0]
+            assert ds["has_key"] is True
+            model_ids = {m["id"] for m in ds["models"]}
+            assert model_ids == {"deepseek-v4-flash", "deepseek-v4-pro"}, (
+                f"Expected v4 models, got: {model_ids}"
+            )
+        finally:
+            self._restore_cfg(old_cfg, old_mtime)
+
+    def test_custom_provider_no_key(self, monkeypatch, tmp_path):
+        """Custom provider without a configured key should show has_key=False."""
+        _install_fake_hermes_cli(monkeypatch)
+        monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
+        # Ensure TIMICC_API_KEY is not set
+        monkeypatch.delenv("TIMICC_API_KEY", raising=False)
+
+        old_cfg, old_mtime = self._setup_cfg([
+            {
+                "name": "timicc-claude",
+                "base_url": "https://timicc.com/v1",
+                "api_key": "${TIMICC_API_KEY}",
+                "api_mode": "anthropic_messages",
+            },
+        ])
+
+        from api.providers import get_providers
+        try:
+            result = get_providers()
+            # TIMICC_API_KEY env var is not set → has_key should be False
+            cp = [p for p in result["providers"] if p["id"] == "custom:timicc-claude"]
+            assert len(cp) == 1
+            assert cp[0]["has_key"] is False
+            assert cp[0]["key_source"] == "none"
+        finally:
+            self._restore_cfg(old_cfg, old_mtime)
+
+    def test_empty_custom_providers_no_crash(self, monkeypatch, tmp_path):
+        """get_providers should not crash when custom_providers is empty list."""
+        _install_fake_hermes_cli(monkeypatch)
+        monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
+
+        old_cfg, old_mtime = self._setup_cfg([])
+
+        from api.providers import get_providers
+        try:
+            result = get_providers()
+            # No crash, still returns built-in providers
+            provider_ids = {p["id"] for p in result["providers"]}
+            # Should not contain any custom: entries
+            custom_ids = {pid for pid in provider_ids if pid.startswith("custom:")}
+            assert len(custom_ids) == 0, (
+                f"Empty custom_providers should not produce entries, got: {custom_ids}"
+            )
+        finally:
+            self._restore_cfg(old_cfg, old_mtime)
+
+    def test_custom_provider_bare_api_key(self, monkeypatch, tmp_path):
+        """Custom provider with inline api_key (not env ref) should show has_key=True."""
+        _install_fake_hermes_cli(monkeypatch)
+        monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
+
+        old_cfg, old_mtime = self._setup_cfg([
+            {
+                "name": "my-proxy",
+                "base_url": "https://proxy.example.com/v1",
+                "api_key": "sk-inline-key-12345678",
+            },
+        ])
+
+        from api.providers import get_providers
+        try:
+            result = get_providers()
+            cp = [p for p in result["providers"] if p["id"] == "custom:my-proxy"]
+            assert len(cp) == 1
+            assert cp[0]["has_key"] is True
+        finally:
+            self._restore_cfg(old_cfg, old_mtime)
+
+    def test_custom_provider_no_name_skipped(self, monkeypatch, tmp_path):
+        """Malformed custom provider without name should be silently skipped."""
+        _install_fake_hermes_cli(monkeypatch)
+        monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
+
+        old_cfg, old_mtime = self._setup_cfg([
+            {"base_url": "https://no-name.example.com/v1"},
+        ])
+
+        from api.providers import get_providers
+        try:
+            result = get_providers()
+            custom_ids = {p["id"] for p in result["providers"] if p["id"].startswith("custom:")}
+            assert len(custom_ids) == 0, (
+                f"Entry without name should be skipped, got: {custom_ids}"
+            )
+        finally:
+            self._restore_cfg(old_cfg, old_mtime)
+
+
+class TestDeepSeekV4Models:
+    """Verify DeepSeek V4 models are in the model lists, V3 is removed."""
+
+    def test_v4_models_in_provider_models(self):
+        """_PROVIDER_MODELS['deepseek'] should contain v4-flash and v4-pro only."""
+        from api.config import _PROVIDER_MODELS
+        ds_models = _PROVIDER_MODELS.get("deepseek", [])
+        ids = {m["id"] for m in ds_models}
+
+        assert "deepseek-v4-flash" in ids, f"v4-flash missing from deepseek models: {ids}"
+        assert "deepseek-v4-pro" in ids, f"v4-pro missing from deepseek models: {ids}"
+
+        # V3 / legacy models should be gone
+        assert "deepseek-chat-v3-0324" not in ids, (
+            f"deprecated V3 should not be in model list: {ids}"
+        )
+        assert "deepseek-reasoner" not in ids, (
+            f"deprecated reasoner should not be in model list: {ids}"
+        )
+
+    def test_zai_models_include_glm_series(self):
+        """_PROVIDER_MODELS['zai'] should have GLM-5.x and GLM-4.x models."""
+        from api.config import _PROVIDER_MODELS
+        zai_models = _PROVIDER_MODELS.get("zai", [])
+        ids = {m["id"] for m in zai_models}
+
+        assert "glm-5.1" in ids, f"glm-5.1 missing from zai models: {ids}"
+        assert "glm-5" in ids, f"glm-5 missing from zai models: {ids}"
+        assert "glm-5-turbo" in ids, f"glm-5-turbo missing from zai models: {ids}"
+        assert "glm-4.7" in ids, f"glm-4.7 missing from zai models: {ids}"
+        assert "glm-4.5" in ids, f"glm-4.5 missing from zai models: {ids}"
+        assert "glm-4.5-flash" in ids, f"glm-4.5-flash missing from zai models: {ids}"
+
+    def test_zai_in_onboarding_setup(self):
+        """_SUPPORTED_PROVIDER_SETUPS should have 'zai' entry."""
+        from api.onboarding import _SUPPORTED_PROVIDER_SETUPS
+        assert "zai" in _SUPPORTED_PROVIDER_SETUPS, (
+            "zai provider should be in onboarding quick-setup"
+        )
+        zai = _SUPPORTED_PROVIDER_SETUPS["zai"]
+        assert zai["label"] == "Z.AI / GLM (智谱)"
+        assert zai["env_var"] == "GLM_API_KEY"
+        assert zai["default_model"] == "glm-5.1"
+        assert zai["default_base_url"] == "https://open.bigmodel.cn/api/coding/paas/v4"
+
+    def test_deepseek_onboarding_default_is_v4(self):
+        """DeepSeek onboarding default should be v4-flash, not V3."""
+        from api.onboarding import _SUPPORTED_PROVIDER_SETUPS
+        ds = _SUPPORTED_PROVIDER_SETUPS.get("deepseek", {})
+        assert ds.get("default_model") == "deepseek-v4-flash", (
+            f"DeepSeek default should be v4-flash, got: {ds.get('default_model')}"
+        )
+        assert ds.get("default_base_url") == "https://api.deepseek.com", (
+            f"Base URL should be bare domain, got: {ds.get('default_base_url')}"
+        )


### PR DESCRIPTION
4 commits:
1. Add DeepSeek V4 Flash & V4 Pro models
Add deepseek-v4-flash and deepseek-v4-pro model entries to _MODEL_LIST, _PROVIDER_MODELS, static dropdown, and label map.
2. Add Z.AI / GLM (智谱) provider setup UI  
Add zai provider to onboarding _SUPPORTED_PROVIDER_SETUPS with default model glm-5.1 and base URL https://open.bigmodel.cn/api/coding/paas/v4. Add GLM model series (glm-5.1, glm-5, glm-5-turbo, glm-4.7, glm-4.5, glm-4.5-flash) to _MODEL_LIST. Update DeepSeek default model to v4-flash and base_url to bare domain (no /v1).
3. Remove deprecated DeepSeek V3 / Reasoner models
Clean up deepseek-chat-v3-0324 and deepseek-reasoner from all model lists — these are deprecated since 2026-07-24. Keep only v4-flash and v4-pro.
4. Show model name tags in provider cards + scan custom_providers
