### PR TITLE
fix: preserve clarify drafts on timeout

### DIFF
--- a/api/clarify.py
+++ b/api/clarify.py
@@ -7,9 +7,11 @@ clarification string instead of an approval decision.
 from __future__ import annotations
 
 import threading
+import time
 from typing import Optional
 
 
+DEFAULT_TIMEOUT_SECONDS = 120
 _lock = threading.Lock()
 _pending: dict[str, dict] = {}
 _gateway_queues: dict[str, list] = {}
@@ -57,8 +59,20 @@ def clear_pending(session_key: str) -> int:
     return len(entries)
 
 
+def _with_timeout_metadata(data: dict) -> dict:
+    item = dict(data or {})
+    requested_at = float(item.get("requested_at") or time.time())
+    timeout_seconds = int(item.get("timeout_seconds") or DEFAULT_TIMEOUT_SECONDS)
+    expires_at = float(item.get("expires_at") or requested_at + timeout_seconds)
+    item["requested_at"] = requested_at
+    item["timeout_seconds"] = timeout_seconds
+    item["expires_at"] = expires_at
+    return item
+
+
 def submit_pending(session_key: str, data: dict) -> _ClarifyEntry:
     """Queue a pending clarify request and notify the UI callback if registered."""
+    data = _with_timeout_metadata(data)
     with _lock:
         queue = _gateway_queues.setdefault(session_key, [])
         # De-duplicate while unresolved: if the most recent pending clarify is

--- a/static/index.html
+++ b/static/index.html
@@ -297,6 +297,7 @@
           <div class="clarify-header">
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 17h.01"/><path d="M9.09 9a3 3 0 1 1 5.82 1c0 2-3 2-3 4"/><circle cx="12" cy="12" r="10"/></svg>
             <span id="clarifyHeading" data-i18n="clarify_heading">Clarification needed</span>
+            <span class="clarify-countdown" id="clarifyCountdown"></span>
           </div>
           <div class="clarify-question" id="clarifyQuestion"></div>
           <div class="clarify-choices" id="clarifyChoices"></div>

--- a/static/messages.js
+++ b/static/messages.js
@@ -973,7 +973,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       source.close();
       delete INFLIGHT[activeSid];clearInflight();clearInflightState(activeSid);stopApprovalPolling();stopClarifyPolling();
       if(!_approvalSessionId||_approvalSessionId===activeSid) hideApprovalCard(true);
-      if(!_clarifySessionId||_clarifySessionId===activeSid) hideClarifyCard(true, 'terminal');
+      if(!_clarifySessionId||_clarifySessionId===activeSid) hideClarifyCard(true, 'cancelled');
       if(S.session&&S.session.session_id===activeSid){
         S.activeStreamId=null;const _cbc=$('btnCancel');if(_cbc)_cbc.style.display='none';
       }

--- a/static/messages.js
+++ b/static/messages.js
@@ -1368,8 +1368,10 @@ function _updateClarifyCountdown() {
 }
 
 function _startClarifyCountdown(pending) {
+  const expiresAt = _clarifyExpiryMs(pending);
+  if (_clarifyCountdownTimer && _clarifyExpiresAt === expiresAt) return;
   _clearClarifyCountdownTimer();
-  _clarifyExpiresAt = _clarifyExpiryMs(pending);
+  _clarifyExpiresAt = expiresAt;
   if (!_clarifyExpiresAt) return;
   _updateClarifyCountdown();
   _clarifyCountdownTimer = setInterval(_updateClarifyCountdown, 1000);

--- a/static/messages.js
+++ b/static/messages.js
@@ -202,7 +202,7 @@ async function send(){
     stopClarifyPolling();
     // Only hide approval card if it belongs to the session that just finished
     if(!_approvalSessionId || _approvalSessionId===activeSid) hideApprovalCard(true);removeThinking();
-    if(!_clarifySessionId || _clarifySessionId===activeSid) hideClarifyCard(true);
+    if(!_clarifySessionId || _clarifySessionId===activeSid) hideClarifyCard(true, 'terminal');
     S.messages.push({role:'assistant',content:`**Error:** ${errMsg}`});
     _queueDrainSid=activeSid;renderMessages();setBusy(false);setComposerStatus(`Error: ${errMsg}`);
     return;
@@ -747,7 +747,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       stopApprovalPolling();
       stopClarifyPolling();
       if(!_approvalSessionId || _approvalSessionId===activeSid) hideApprovalCard(true);
-      if(!_clarifySessionId || _clarifySessionId===activeSid) hideClarifyCard(true);
+      if(!_clarifySessionId || _clarifySessionId===activeSid) hideClarifyCard(true, 'terminal');
       if(S.session&&S.session.session_id===activeSid){
         S.activeStreamId=null;
         const _cb=$('btnCancel');if(_cb)_cb.style.display='none';
@@ -895,7 +895,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       source.close();
       delete INFLIGHT[activeSid];clearInflight();clearInflightState(activeSid);stopApprovalPolling();stopClarifyPolling();
       if(!_approvalSessionId||_approvalSessionId===activeSid) hideApprovalCard(true);
-      if(!_clarifySessionId||_clarifySessionId===activeSid) hideClarifyCard(true);
+      if(!_clarifySessionId||_clarifySessionId===activeSid) hideClarifyCard(true, 'terminal');
       if(S.session&&S.session.session_id===activeSid){
         S.activeStreamId=null;const _cbe=$('btnCancel');if(_cbe)_cbe.style.display='none';
         clearLiveToolCards();if(!assistantText)removeThinking();
@@ -973,7 +973,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       source.close();
       delete INFLIGHT[activeSid];clearInflight();clearInflightState(activeSid);stopApprovalPolling();stopClarifyPolling();
       if(!_approvalSessionId||_approvalSessionId===activeSid) hideApprovalCard(true);
-      if(!_clarifySessionId||_clarifySessionId===activeSid) hideClarifyCard(true);
+      if(!_clarifySessionId||_clarifySessionId===activeSid) hideClarifyCard(true, 'terminal');
       if(S.session&&S.session.session_id===activeSid){
         S.activeStreamId=null;const _cbc=$('btnCancel');if(_cbc)_cbc.style.display='none';
       }
@@ -1013,7 +1013,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       delete INFLIGHT[activeSid];clearInflight();clearInflightState(activeSid);stopApprovalPolling();stopClarifyPolling();
       _closeSource();
       if(!_approvalSessionId||_approvalSessionId===activeSid) hideApprovalCard(true);
-      if(!_clarifySessionId||_clarifySessionId===activeSid) hideClarifyCard(true);
+      if(!_clarifySessionId||_clarifySessionId===activeSid) hideClarifyCard(true, 'terminal');
       if(S.session&&S.session.session_id===activeSid){
         S.activeStreamId=null;const _cbe=$('btnCancel');if(_cbe)_cbe.style.display='none';
         clearLiveToolCards();if(!assistantText)removeThinking();
@@ -1049,7 +1049,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     delete INFLIGHT[activeSid];clearInflight();clearInflightState(activeSid);stopApprovalPolling();stopClarifyPolling();
     _closeSource();
     if(!_approvalSessionId||_approvalSessionId===activeSid) hideApprovalCard(true);
-    if(!_clarifySessionId||_clarifySessionId===activeSid) hideClarifyCard(true);
+    if(!_clarifySessionId||_clarifySessionId===activeSid) hideClarifyCard(true, 'terminal');
     if(S.session&&S.session.session_id===activeSid){
       S.activeStreamId=null;const _cbe=$('btnCancel');if(_cbe)_cbe.style.display='none';
       clearLiveToolCards();if(!assistantText)removeThinking();
@@ -1077,7 +1077,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
           stopApprovalPolling();
           stopClarifyPolling();
           if(!_approvalSessionId||_approvalSessionId===activeSid) hideApprovalCard(true);
-          if(!_clarifySessionId||_clarifySessionId===activeSid) hideClarifyCard(true);
+          if(!_clarifySessionId||_clarifySessionId===activeSid) hideClarifyCard(true, 'terminal');
           if(S.session&&S.session.session_id===activeSid){
             S.activeStreamId=null;
             const _cbe=$('btnCancel');if(_cbe)_cbe.style.display='none';
@@ -1290,6 +1290,8 @@ let _clarifyVisibleSince = 0;
 let _clarifySignature = '';
 let _clarifySessionId = null;
 let _clarifyMissingEndpointWarned = false;
+let _clarifyCountdownTimer = null;
+let _clarifyExpiresAt = 0;
 const CLARIFY_MIN_VISIBLE_MS = 30000;
 
 function _ensureClarifyCardDom() {
@@ -1308,6 +1310,7 @@ function _ensureClarifyCardDom() {
       <div class="clarify-header">
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 17h.01"/><path d="M9.09 9a3 3 0 1 1 5.82 1c0 2-3 2-3 4"/><circle cx="12" cy="12" r="10"/></svg>
         <span id="clarifyHeading" data-i18n="clarify_heading">Clarification needed</span>
+        <span class="clarify-countdown" id="clarifyCountdown"></span>
       </div>
       <div class="clarify-question" id="clarifyQuestion"></div>
       <div class="clarify-choices" id="clarifyChoices"></div>
@@ -1332,13 +1335,84 @@ function _clearClarifyHideTimer() {
   }
 }
 
+function _clearClarifyCountdownTimer() {
+  if (_clarifyCountdownTimer) {
+    clearInterval(_clarifyCountdownTimer);
+    _clarifyCountdownTimer = null;
+  }
+  _clarifyExpiresAt = 0;
+  const countdown = $("clarifyCountdown");
+  if (countdown) {
+    countdown.textContent = "";
+    countdown.classList.remove("urgent");
+  }
+}
+
+function _clarifyExpiryMs(pending) {
+  const expiresAt = Number(pending && pending.expires_at);
+  if (Number.isFinite(expiresAt) && expiresAt > 0) return expiresAt * 1000;
+  const requestedAt = Number(pending && pending.requested_at);
+  const timeoutSeconds = Number(pending && pending.timeout_seconds);
+  if (Number.isFinite(requestedAt) && Number.isFinite(timeoutSeconds)) {
+    return (requestedAt + timeoutSeconds) * 1000;
+  }
+  return 0;
+}
+
+function _updateClarifyCountdown() {
+  const countdown = $("clarifyCountdown");
+  if (!countdown || !_clarifyExpiresAt) return;
+  const remaining = Math.max(0, Math.ceil((_clarifyExpiresAt - Date.now()) / 1000));
+  countdown.textContent = `${remaining}s`;
+  countdown.classList.toggle("urgent", remaining <= 10);
+}
+
+function _startClarifyCountdown(pending) {
+  _clearClarifyCountdownTimer();
+  _clarifyExpiresAt = _clarifyExpiryMs(pending);
+  if (!_clarifyExpiresAt) return;
+  _updateClarifyCountdown();
+  _clarifyCountdownTimer = setInterval(_updateClarifyCountdown, 1000);
+}
+
+function _stashClarifyDraft(reason) {
+  if (reason !== "expired" && reason !== "terminal") return false;
+  const input = $("clarifyInput");
+  const draft = String((input && input.value) || "").trim();
+  if (!draft) return false;
+  const sid = _clarifySessionId || (S.session && S.session.session_id) || "unknown";
+  const key = `hermes-clarify-draft-${sid}-${_clarifySignature || "unknown"}`;
+  try {
+    sessionStorage.setItem(key, JSON.stringify({
+      draft,
+      reason,
+      saved_at: Date.now(),
+    }));
+  } catch (_) {}
+  const composer = $('msg');
+  if (composer) {
+    const current = String(composer.value || "");
+    composer.value = current.trim() ? `${current.replace(/\s+$/, "")}\n\n${draft}` : draft;
+    if (typeof autoResize === "function") autoResize();
+    if (typeof updateSendBtn === "function") updateSendBtn();
+  }
+  const notice = reason === "expired"
+    ? "Clarification timed out. Your draft was kept in the composer."
+    : "Clarification closed. Your draft was kept in the composer.";
+  if (typeof setComposerStatus === "function") setComposerStatus(notice);
+  else if (typeof setStatus === "function") setStatus(notice);
+  if (typeof showToast === "function") showToast(notice, 5000);
+  return true;
+}
+
 function _resetClarifyCardState() {
   _clearClarifyHideTimer();
+  _clearClarifyCountdownTimer();
   _clarifyVisibleSince = 0;
   _clarifySignature = '';
 }
 
-function hideClarifyCard(force=false) {
+function hideClarifyCard(force=false, reason="dismissed") {
   const card = $("clarifyCard");
   if (!card) {
     _clarifySessionId = null;
@@ -1346,7 +1420,7 @@ function hideClarifyCard(force=false) {
     if (typeof unlockComposerForClarify === "function") unlockComposerForClarify();
     return;
   }
-  if (!force && _clarifyVisibleSince) {
+  if (!force && reason !== "expired" && _clarifyVisibleSince) {
     const remaining = CLARIFY_MIN_VISIBLE_MS - (Date.now() - _clarifyVisibleSince);
     if (remaining > 0) {
       const scheduledSignature = _clarifySignature;
@@ -1354,11 +1428,12 @@ function hideClarifyCard(force=false) {
       _clarifyHideTimer = setTimeout(() => {
         _clarifyHideTimer = null;
         if (_clarifySignature !== scheduledSignature) return;
-        hideClarifyCard(true);
+        hideClarifyCard(true, reason);
       }, remaining);
       return;
     }
   }
+  _stashClarifyDraft(reason);
   _clarifySessionId = null;
   _resetClarifyCardState();
   card.classList.remove("visible");
@@ -1409,6 +1484,7 @@ function showClarifyCard(pending) {
   const sameClarify = card.classList.contains("visible") && _clarifySignature === sig;
   _clarifySessionId = pending._session_id || (S.session && S.session.session_id) || null;
   _clarifySignature = sig;
+  _startClarifyCountdown(pending);
   if (!sameClarify) {
     _clarifyVisibleSince = Date.now();
     _clearClarifyHideTimer();
@@ -1488,7 +1564,7 @@ async function respondClarify(response) {
   }
   _clarifySessionId = null;
   _clarifySetControlsDisabled(true, true);
-  hideClarifyCard(true);
+  hideClarifyCard(true, 'sent');
   try {
     await api("/api/clarify/respond", {
       method: "POST",
@@ -1502,12 +1578,12 @@ function startClarifyPolling(sid) {
   _clarifyMissingEndpointWarned = false;
   _clarifyPollTimer = setInterval(async () => {
     if (!S.session || S.session.session_id !== sid) {
-      stopClarifyPolling(); hideClarifyCard(true); return;
+      stopClarifyPolling(); hideClarifyCard(true, 'session'); return;
     }
     try {
       const data = await api("/api/clarify/pending?session_id=" + encodeURIComponent(sid));
       if (data.pending) { data.pending._session_id=sid; showClarifyCard(data.pending); }
-      else { hideClarifyCard(); }
+      else { hideClarifyCard(false, 'expired'); }
     } catch(e) {
       const msg = String((e && e.message) || "");
       if (!_clarifyMissingEndpointWarned && /(^|\b)(404|not found)(\b|$)/i.test(msg)) {

--- a/static/style.css
+++ b/static/style.css
@@ -472,6 +472,8 @@
   .clarify-card.visible .clarify-inner{transform:translateY(0);opacity:1;}
   .clarify-inner{background:var(--surface);backdrop-filter:blur(8px);border:1px solid var(--accent-bg-strong);border-radius:12px;padding:12px 14px 36px;box-shadow:0 1px 0 rgba(255,255,255,.02) inset;}
   .clarify-header{display:flex;align-items:center;gap:8px;margin-bottom:10px;font-size:12px;font-weight:700;color:var(--blue);letter-spacing:.01em;}
+  .clarify-countdown{margin-left:auto;min-width:42px;text-align:right;color:var(--muted);font-variant-numeric:tabular-nums;font-weight:700;}
+  .clarify-countdown.urgent{color:var(--error);}
   .clarify-question{font-size:14px;color:var(--text);line-height:1.7;white-space:pre-wrap;margin-bottom:12px;}
   .clarify-choices{display:flex;flex-direction:column;gap:8px;margin-bottom:12px;}
   .clarify-choice{display:flex;align-items:flex-start;gap:10px;width:100%;padding:11px 14px;border-radius:12px;font-size:13px;font-weight:600;border:1px solid var(--accent-bg-strong);background:var(--accent-bg);color:var(--accent-text);cursor:pointer;transition:all .15s;white-space:normal;text-align:left;box-shadow:0 1px 0 rgba(255,255,255,.03) inset;}

--- a/static/style.css
+++ b/static/style.css
@@ -473,7 +473,7 @@
   .clarify-inner{background:var(--surface);backdrop-filter:blur(8px);border:1px solid var(--accent-bg-strong);border-radius:12px;padding:12px 14px 36px;box-shadow:0 1px 0 rgba(255,255,255,.02) inset;}
   .clarify-header{display:flex;align-items:center;gap:8px;margin-bottom:10px;font-size:12px;font-weight:700;color:var(--blue);letter-spacing:.01em;}
   .clarify-countdown{margin-left:auto;min-width:42px;text-align:right;color:var(--muted);font-variant-numeric:tabular-nums;font-weight:700;}
-  .clarify-countdown.urgent{color:var(--error);}
+  .clarify-countdown.urgent{color:var(--error);box-shadow:inset 0 -2px 0 var(--error);border-radius:2px;}
   .clarify-question{font-size:14px;color:var(--text);line-height:1.7;white-space:pre-wrap;margin-bottom:12px;}
   .clarify-choices{display:flex;flex-direction:column;gap:8px;margin-bottom:12px;}
   .clarify-choice{display:flex;align-items:flex-start;gap:10px;width:100%;padding:11px 14px;border-radius:12px;font-size:13px;font-weight:600;border:1px solid var(--accent-bg-strong);background:var(--accent-bg);color:var(--accent-text);cursor:pointer;transition:all .15s;white-space:normal;text-align:left;box-shadow:0 1px 0 rgba(255,255,255,.03) inset;}

--- a/tests/test_clarify_unblock.py
+++ b/tests/test_clarify_unblock.py
@@ -1,13 +1,14 @@
 """Tests for clarify prompt unblocking and HTTP endpoints."""
 
 import json
-import threading
 import uuid
 import urllib.request
 import urllib.error
 import urllib.parse
 
 import pytest
+
+from tests._pytest_port import BASE
 
 try:
     from api.clarify import (
@@ -29,8 +30,6 @@ pytestmark = pytest.mark.skipif(
     not CLARIFY_AVAILABLE,
     reason="api.clarify not available in this environment",
 )
-
-from tests._pytest_port import BASE
 
 
 def get(path):
@@ -95,9 +94,24 @@ class TestClarifyUnblocking:
         sid = f"unit-submit-{uuid.uuid4().hex[:8]}"
         data = {"question": "Pick", "choices_offered": ["one", "two"], "session_id": sid}
         entry = submit_pending(sid, data)
-        assert entry.data == data
+        assert entry.data["question"] == data["question"]
+        assert entry.data["choices_offered"] == data["choices_offered"]
+        assert entry.data["session_id"] == data["session_id"]
         with _lock:
             assert sid in _gateway_queues
+
+        clear_pending(sid)
+
+    def test_submit_pending_adds_timeout_metadata(self):
+        sid = f"unit-timeout-{uuid.uuid4().hex[:8]}"
+        entry = submit_pending(sid, {"question": "Wait", "choices_offered": []})
+
+        assert isinstance(entry.data["requested_at"], (int, float))
+        assert entry.data["timeout_seconds"] == 120
+        assert entry.data["expires_at"] == pytest.approx(
+            entry.data["requested_at"] + 120,
+            abs=0.1,
+        )
 
         clear_pending(sid)
 

--- a/tests/test_sprint30.py
+++ b/tests/test_sprint30.py
@@ -12,12 +12,11 @@ Tests for:
 """
 
 import json
+import pathlib
 import re
 import urllib.request
 import urllib.error
 import urllib.parse
-
-import pytest
 
 from tests._pytest_port import BASE
 
@@ -44,8 +43,6 @@ def read(path):
     with open(path, encoding="utf-8") as f:
         return f.read()
 
-
-import pathlib
 REPO = pathlib.Path(__file__).parent.parent
 
 
@@ -518,6 +515,9 @@ class TestClarifyCardTimerLogic:
     def _get_js(self):
         return pathlib.Path(__file__).parent.parent / 'static' / 'messages.js'
 
+    def _get_html(self):
+        return pathlib.Path(__file__).parent.parent / 'static' / 'index.html'
+
     def test_clarify_min_visible_ms_constant_present(self):
         src = self._get_js().read_text()
         assert 'CLARIFY_MIN_VISIBLE_MS' in src
@@ -529,6 +529,7 @@ class TestClarifyCardTimerLogic:
     def test_hide_clarify_card_has_force_parameter(self):
         src = self._get_js().read_text()
         assert 'hideClarifyCard(force=false)' in src or \
+               'hideClarifyCard(force=false, reason=' in src or \
                'hideClarifyCard(force = false)' in src, \
             'hideClarifyCard must have force=false default parameter'
 
@@ -548,6 +549,25 @@ class TestClarifyCardTimerLogic:
         src = self._get_js().read_text()
         assert '_clarifySignature' in src
 
+    def test_clarify_countdown_element_present(self):
+        html = self._get_html().read_text()
+        assert 'id="clarifyCountdown"' in html, \
+            'clarify card must include a countdown element so users see timeout risk'
+
+    def test_clarify_countdown_uses_pending_expiry(self):
+        src = self._get_js().read_text()
+        assert '_clarifyCountdownTimer' in src
+        assert 'function _startClarifyCountdown' in src
+        assert 'expires_at' in src, \
+            'clarify countdown must use expires_at from the pending payload'
+
+    def test_hide_clarify_card_can_preserve_draft(self):
+        src = self._get_js().read_text()
+        assert 'function _stashClarifyDraft' in src
+        assert 'sessionStorage.setItem' in src
+        assert "$('msg')" in src, \
+            'clarify timeout should keep the typed draft visible in the composer'
+
     def test_respond_clarify_calls_hide_with_force(self):
         src = self._get_js().read_text()
         import re
@@ -555,14 +575,15 @@ class TestClarifyCardTimerLogic:
                       src, re.DOTALL)
         assert m, 'respondClarify function not found'
         body = m.group(0)
-        assert 'hideClarifyCard(true)' in body, \
+        assert 'hideClarifyCard(true' in body, \
             'respondClarify must call hideClarifyCard(true) so card hides immediately after user clicks'
+        assert "'sent'" in body, \
+            'respondClarify must mark user-submitted hides so drafts are not re-stashed'
 
     def test_clarify_poll_loop_uses_no_force(self):
         src = self._get_js().read_text()
-        assert 'else { hideClarifyCard(); }' in src or \
-               'else {hideClarifyCard();}' in src or \
-               'else { hideClarifyCard() }' in src, \
+        assert "else { hideClarifyCard(false, 'expired'); }" in src or \
+               "else {hideClarifyCard(false,'expired');}" in src, \
             'Clarify poll loop should hide without force=true'
 
     def test_show_clarify_card_signature_dedup(self):

--- a/tests/test_sprint30.py
+++ b/tests/test_sprint30.py
@@ -518,6 +518,9 @@ class TestClarifyCardTimerLogic:
     def _get_html(self):
         return pathlib.Path(__file__).parent.parent / 'static' / 'index.html'
 
+    def _get_css(self):
+        return pathlib.Path(__file__).parent.parent / 'static' / 'style.css'
+
     def test_clarify_min_visible_ms_constant_present(self):
         src = self._get_js().read_text()
         assert 'CLARIFY_MIN_VISIBLE_MS' in src
@@ -567,6 +570,34 @@ class TestClarifyCardTimerLogic:
         assert 'sessionStorage.setItem' in src
         assert "$('msg')" in src, \
             'clarify timeout should keep the typed draft visible in the composer'
+
+    def test_clarify_draft_appends_to_existing_composer_text(self):
+        src = self._get_js().read_text()
+        m = re.search(r'function _stashClarifyDraft.*?(?=\nfunction |\nasync function |\Z)',
+                      src, re.DOTALL)
+        assert m, '_stashClarifyDraft function not found'
+        body = m.group(0)
+        assert 'current.replace(/\\s+$/, "")' in body, \
+            'preserved clarify drafts must append after existing composer text instead of replacing it'
+        assert '\\n\\n${draft}' in body, \
+            'preserved clarify drafts should be separated from existing composer text'
+
+    def test_cancel_stream_does_not_preserve_clarify_draft(self):
+        src = self._get_js().read_text()
+        m = re.search(r"source\.addEventListener\('cancel'.*?\n    \}\);",
+                      src, re.DOTALL)
+        assert m, 'cancel event handler not found'
+        body = m.group(0)
+        assert "hideClarifyCard(true, 'cancelled')" in body, \
+            'explicit stream cancel must not use the timeout/terminal draft preservation path'
+
+    def test_clarify_urgent_countdown_has_non_color_cue(self):
+        css = self._get_css().read_text()
+        m = re.search(r'\.clarify-countdown\.urgent\{([^}]*)\}', css)
+        assert m, 'urgent clarify countdown style missing'
+        body = m.group(1)
+        assert any(prop in body for prop in ('box-shadow', 'outline', 'border', 'text-decoration')), \
+            'urgent countdown styling must include a non-color visual cue'
 
     def test_respond_clarify_calls_hide_with_force(self):
         src = self._get_js().read_text()

--- a/tests/test_sprint30.py
+++ b/tests/test_sprint30.py
@@ -564,6 +564,20 @@ class TestClarifyCardTimerLogic:
         assert 'expires_at' in src, \
             'clarify countdown must use expires_at from the pending payload'
 
+    def test_clarify_countdown_does_not_restart_for_same_expiry(self):
+        src = self._get_js().read_text()
+        m = re.search(r'function _startClarifyCountdown.*?(?=\nfunction |\nasync function |\Z)',
+                      src, re.DOTALL)
+        assert m, '_startClarifyCountdown function not found'
+        body = m.group(0)
+        assert 'const expiresAt = _clarifyExpiryMs(pending)' in body, \
+            'countdown start should compute the next expiry before clearing the existing timer'
+        assert '_clarifyCountdownTimer && _clarifyExpiresAt === expiresAt' in body, \
+            'same pending clarify poll updates must not restart the countdown interval'
+        assert body.index('_clarifyCountdownTimer && _clarifyExpiresAt === expiresAt') < \
+               body.index('_clearClarifyCountdownTimer()'), \
+            'same-expiry guard must run before clearing the current interval'
+
     def test_hide_clarify_card_can_preserve_draft(self):
         src = self._get_js().read_text()
         assert 'function _stashClarifyDraft' in src


### PR DESCRIPTION
## Thinking Path

- Hermes WebUI exposes Hermes Agent clarify prompts in the browser.
- Some clarify prompts ask for open-ended idea descriptions, which can take longer than the default timeout while the user is still typing.
- Before this change, the WebUI did not show the timeout deadline, and when the pending clarify prompt disappeared, the typed draft was cleared from the clarify input.
- This made it easy for users to lose meaningful long-form input without understanding why.
- This PR keeps the existing timeout behavior, but makes the timeout visible and preserves unsent draft text when the prompt expires or closes.

## What Changed

- Added timeout metadata to pending clarify payloads:
  - `requested_at`
  - `timeout_seconds`
  - `expires_at`
- Added a countdown indicator to the clarify card so users can see how much time remains.
- Added urgent countdown styling for the final seconds before expiration.
- Preserved unsent clarify draft text by moving it into the main composer when the clarify prompt expires or closes before submission.
- Avoided preserving already-submitted clarify text.
- Added regression coverage for clarify timeout metadata, countdown rendering, and draft preservation behavior.

## Why It Matters

Open-ended clarify prompts are often used for higher-value input, such as describing an idea or clarifying intent. Losing that draft after a hidden timeout is frustrating and can interrupt the user's thought process.

With this change, users can see the timeout risk before it happens, and their typed draft remains available in the main composer if the clarify prompt expires.

## Screenshots

Before: clarify prompt had no visible timeout.

After: clarify prompt shows a visible countdown.

<img width="869" height="767" alt="1" src="https://github.com/user-attachments/assets/aa218f85-ea4c-41a0-823f-ba596fcaf139" />


<img width="837" height="772" alt="2" src="https://github.com/user-attachments/assets/9c48158a-626a-48dd-b000-4bb0504eb5e4" />

After timeout/close: unsent clarify draft is preserved in the main composer.

<img width="867" height="775" alt="3" src="https://github.com/user-attachments/assets/8be92f9d-b0fb-41be-bde5-9ed5299a3fde" />


<img width="858" height="773" alt="4" src="https://github.com/user-attachments/assets/828dc463-9d37-48e0-925d-5d50ccd22128" />


## Verification

- `uv run --with pytest pytest tests/test_clarify_unblock.py tests/test_sprint30.py -q`
- `uv run --with ruff ruff check api/clarify.py tests/test_clarify_unblock.py tests/test_sprint30.py`
- `git --no-pager diff --check`
- Manual browser check on a Linux-hosted Hermes WebUI instance:
  - injected a test clarify prompt
  - verified countdown display
  - typed an unsent draft
  - resolved/closed the prompt
  - verified the draft moved into the main composer

## Risks / Follow-ups

- Full `pytest tests/ -v --timeout=60` has not been run yet.
- This PR keeps the existing 120-second clarify timeout; it does not make the timeout configurable.
- Clarify responses still use a single-line input. A future improvement could use a textarea for open-ended prompts.

## Model Used

Provider: OpenAI  
Model: GPT-5 via Codex desktop  
Notable tool use: local shell, SSH deployment to a Linux test host, Git, targeted pytest/ruff verification
