### PR TITLE
fix: _loadOlderMessages scroll position not preserved after loading older messages

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -772,6 +772,16 @@ def handle_get(handler, parsed) -> bool:
         load_messages = query.get("messages", ["1"])[0] != "0"
         resolve_model_default = "1" if load_messages else "0"
         resolve_model = query.get("resolve_model", [resolve_model_default])[0] != "0"
+        # ?msg_limit=N returns only the last N messages (tail window).
+        # Used by the frontend for fast session switching — avoids serialising
+        # and sending hundreds of messages when the user only sees the most
+        # recent exchange.  Older messages are loaded on-demand via scrolling.
+        _msg_limit = query.get("msg_limit", [None])[0]
+        msg_limit = int(_msg_limit) if _msg_limit else None
+        # ?msg_before=TS — only return messages with timestamp < TS (for
+        # scroll-to-top lazy loading).  Combined with msg_limit for paging.
+        _msg_before = query.get("msg_before", [None])[0]
+        msg_before = float(_msg_before) if _msg_before else None
         try:
             _t1 = _time.monotonic()
             s = get_session(sid, metadata_only=(not load_messages))
@@ -782,14 +792,34 @@ def handle_get(handler, parsed) -> bool:
                 else None
             )
             _t3 = _time.monotonic()
+            _all_msgs = s.messages if load_messages else []
+            if load_messages:
+                if msg_before is not None:
+                    # Scroll-to-top paging: return messages older than anchor
+                    _filtered = [
+                        m for m in _all_msgs
+                        if (m.get('_ts') or m.get('timestamp') or 0) < msg_before
+                    ]
+                    _truncated_msgs = _filtered[-msg_limit:] if msg_limit else _filtered
+                elif msg_limit and len(_all_msgs) > msg_limit:
+                    _truncated_msgs = _all_msgs[-msg_limit:]
+                else:
+                    _truncated_msgs = _all_msgs
+            else:
+                _truncated_msgs = _all_msgs
             raw = s.compact() | {
-                "messages": s.messages if load_messages else [],
+                "messages": _truncated_msgs,
                 "tool_calls": getattr(s, "tool_calls", []) if load_messages else [],
                 "active_stream_id": getattr(s, "active_stream_id", None),
                 "pending_user_message": getattr(s, "pending_user_message", None),
                 "pending_attachments": getattr(s, "pending_attachments", []) if load_messages else [],
                 "pending_started_at": getattr(s, "pending_started_at", None),
             }
+            # Signal to the frontend that older messages were omitted.
+            raw["_messages_truncated"] = (
+                load_messages and msg_limit is not None
+                and len(_all_msgs) > msg_limit
+            )
             _t4 = _time.monotonic()
             if effective_model:
                 raw["model"] = effective_model

--- a/api/routes.py
+++ b/api/routes.py
@@ -777,11 +777,18 @@ def handle_get(handler, parsed) -> bool:
         # and sending hundreds of messages when the user only sees the most
         # recent exchange.  Older messages are loaded on-demand via scrolling.
         _msg_limit = query.get("msg_limit", [None])[0]
-        msg_limit = int(_msg_limit) if _msg_limit else None
-        # ?msg_before=TS — only return messages with timestamp < TS (for
-        # scroll-to-top lazy loading).  Combined with msg_limit for paging.
+        try:
+            msg_limit = max(1, int(_msg_limit)) if _msg_limit else None
+        except (ValueError, TypeError):
+            msg_limit = None
+        # ?msg_before=N — 0-based index into the full message array.
+        # Returns messages before this index (for scroll-to-top lazy loading).
+        # Combined with msg_limit for paging.
         _msg_before = query.get("msg_before", [None])[0]
-        msg_before = float(_msg_before) if _msg_before else None
+        try:
+            msg_before = int(_msg_before) if _msg_before else None
+        except (ValueError, TypeError):
+            msg_before = None
         try:
             _t1 = _time.monotonic()
             s = get_session(sid, metadata_only=(not load_messages))
@@ -795,12 +802,14 @@ def handle_get(handler, parsed) -> bool:
             _all_msgs = s.messages if load_messages else []
             if load_messages:
                 if msg_before is not None:
-                    # Scroll-to-top paging: return messages older than anchor
-                    _filtered = [
-                        m for m in _all_msgs
-                        if (m.get('_ts') or m.get('timestamp') or 0) < msg_before
-                    ]
-                    _truncated_msgs = _filtered[-msg_limit:] if msg_limit else _filtered
+                    # Scroll-to-top paging: msg_before is a 0-based index into
+                    # the full message list. Return the msg_limit messages that
+                    # appear *before* this index (i.e. older messages).
+                    # Using index instead of timestamp avoids issues with
+                    # duplicate/missing timestamps.
+                    _before_idx = max(0, min(int(msg_before), len(_all_msgs)))
+                    _slice = _all_msgs[:_before_idx]
+                    _truncated_msgs = _slice[-msg_limit:] if msg_limit else _slice
                 elif msg_limit and len(_all_msgs) > msg_limit:
                     _truncated_msgs = _all_msgs[-msg_limit:]
                 else:
@@ -816,10 +825,20 @@ def handle_get(handler, parsed) -> bool:
                 "pending_started_at": getattr(s, "pending_started_at", None),
             }
             # Signal to the frontend that older messages were omitted.
-            raw["_messages_truncated"] = (
-                load_messages and msg_limit is not None
-                and len(_all_msgs) > msg_limit
-            )
+            # For msg_before paging, compare against the filtered set,
+            # not the full list — otherwise we signal truncation even when
+            # all older messages were returned.
+            if msg_before is not None:
+                _truncated = load_messages and msg_limit is not None and len(_slice) > msg_limit
+            else:
+                _truncated = load_messages and msg_limit is not None and len(_all_msgs) > msg_limit
+            raw["_messages_truncated"] = _truncated
+            # Index of the first returned message in the full message array.
+            # Frontend uses this as cursor for scroll-to-top paging.
+            if msg_before is not None:
+                raw["_messages_offset"] = max(0, _before_idx - len(_truncated_msgs))
+            else:
+                raw["_messages_offset"] = max(0, len(_all_msgs) - len(_truncated_msgs))
             _t4 = _time.monotonic()
             if effective_model:
                 raw["model"] = effective_model

--- a/api/workspace.py
+++ b/api/workspace.py
@@ -516,22 +516,36 @@ def git_info_for_workspace(workspace: Path) -> dict:
     branch = _run_git(['rev-parse', '--abbrev-ref', 'HEAD'], workspace)
     if branch is None:
         return None
-    # Status counts
-    status_out = _run_git(['status', '--porcelain'], workspace) or ''
-    lines = [l for l in status_out.splitlines() if l]
-    # git status --porcelain: XY format where X=index, Y=worktree
-    modified = sum(1 for l in lines if len(l) >= 2 and (l[0] in 'MAR' or l[1] in 'MAR'))
-    untracked = sum(1 for l in lines if l.startswith('??'))
-    dirty = len(lines)
-    # Ahead/behind
-    ahead = _run_git(['rev-list', '--count', '@{u}..HEAD'], workspace)
-    behind = _run_git(['rev-list', '--count', 'HEAD..@{u}'], workspace)
+    # Run the remaining git commands in parallel via threads — they are
+    # independent subprocess calls and together can take 50-200ms when run
+    # serially.  Threading is safe here because each call blocks only on the
+    # subprocess pipe, not on the GIL.
+    import concurrent.futures
+    def _ahead():
+        r = _run_git(['rev-list', '--count', '@{u}..HEAD'], workspace)
+        return int(r) if r and r.isdigit() else 0
+    def _behind():
+        r = _run_git(['rev-list', '--count', 'HEAD..@{u}'], workspace)
+        return int(r) if r and r.isdigit() else 0
+    def _status():
+        out = _run_git(['status', '--porcelain'], workspace) or ''
+        lines = [l for l in out.splitlines() if l]
+        modified = sum(1 for l in lines if len(l) >= 2 and (l[0] in 'MAR' or l[1] in 'MAR'))
+        untracked = sum(1 for l in lines if l.startswith('??'))
+        return len(lines), modified, untracked
+    with concurrent.futures.ThreadPoolExecutor(max_workers=3) as pool:
+        f_status = pool.submit(_status)
+        f_ahead  = pool.submit(_ahead)
+        f_behind = pool.submit(_behind)
+        dirty, modified, untracked = f_status.result()
+        ahead  = f_ahead.result()
+        behind = f_behind.result()
     return {
         'branch': branch,
         'dirty': dirty,
         'modified': modified,
         'untracked': untracked,
-        'ahead': int(ahead) if ahead and ahead.isdigit() else 0,
-        'behind': int(behind) if behind and behind.isdigit() else 0,
+        'ahead': ahead,
+        'behind': behind,
         'is_git': True,
     }

--- a/api/workspace.py
+++ b/api/workspace.py
@@ -11,6 +11,7 @@ import json
 import logging
 import os
 import subprocess
+import concurrent.futures
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -520,7 +521,6 @@ def git_info_for_workspace(workspace: Path) -> dict:
     # independent subprocess calls and together can take 50-200ms when run
     # serially.  Threading is safe here because each call blocks only on the
     # subprocess pipe, not on the GIL.
-    import concurrent.futures
     def _ahead():
         r = _run_git(['rev-list', '--count', '@{u}..HEAD'], workspace)
         return int(r) if r and r.isdigit() else 0

--- a/static/commands.js
+++ b/static/commands.js
@@ -284,6 +284,7 @@ async function _runManualCompression(focusTopic){
       S.session=live.session;
       S.messages=live.session.messages||[];
       S.toolCalls=live.session.tool_calls||[];
+      if(typeof _messagesTruncated!=='undefined') _messagesTruncated=false;
     }catch(preflightErr){
       if(typeof clearCompressionUi==='function') clearCompressionUi();
       if(typeof _setCompressionSessionLock==='function') _setCompressionSessionLock(null);
@@ -682,7 +683,7 @@ async function cmdRetry(){
     if(r&&r.error){showToast(r.error);return;}
     if(!S.session||S.session.session_id!==activeSid)return;
     const data=await api('/api/session?session_id='+encodeURIComponent(activeSid));
-    if(data&&data.session){S.messages=data.session.messages||[];S.toolCalls=[];if(typeof clearLiveToolCards==='function')clearLiveToolCards();renderMessages();}
+    if(data&&data.session){S.messages=data.session.messages||[];S.toolCalls=[];if(typeof clearLiveToolCards==='function')clearLiveToolCards();if(typeof _messagesTruncated!=='undefined')_messagesTruncated=false;renderMessages();}
     $('msg').value=r.last_user_text||'';if(typeof autoResize==='function')autoResize();await send();
   }catch(e){showToast(t('retry_failed')+e.message);}
 }
@@ -695,7 +696,7 @@ async function cmdUndo(){
     if(r&&r.error){showToast(r.error);return;}
     if(!S.session||S.session.session_id!==activeSid)return;
     const data=await api('/api/session?session_id='+encodeURIComponent(activeSid));
-    if(data&&data.session){S.messages=data.session.messages||[];S.toolCalls=[];if(typeof clearLiveToolCards==='function')clearLiveToolCards();renderMessages();}
+    if(data&&data.session){S.messages=data.session.messages||[];S.toolCalls=[];if(typeof clearLiveToolCards==='function')clearLiveToolCards();if(typeof _messagesTruncated!=='undefined')_messagesTruncated=false;renderMessages();}
     showToast(`↩ ${t('undid_n_messages')} ${r.removed_count} ${t('undid_messages_suffix')}`);
   }catch(e){showToast(t('undo_failed')+e.message);}
 }

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -374,17 +374,23 @@ async function _loadOlderMessages() {
     const olderMsgs = (data.session.messages || []).filter(m => m && m.role);
     if (!olderMsgs.length) { _messagesTruncated = false; return; }
     // Prepend older messages
-    const inner = $('msgInner');
-    const prevScrollH = inner ? inner.scrollHeight : 0;
+    // Use $('messages') — the scrollable container (#msgInner is not scrollable).
+    const container = $('messages');
+    const prevScrollH = container ? container.scrollHeight : 0;
     S.messages = [...olderMsgs, ...S.messages];
     _messagesTruncated = !!data.session._messages_truncated;
     _oldestIdx = data.session._messages_offset || 0;
     renderMessages();
-    // Restore scroll position so the user stays at the same message
-    if (inner) {
-      const newScrollH = inner.scrollHeight;
-      inner.scrollTop = newScrollH - prevScrollH;
+    // Restore scroll position so the user stays at the same message.
+    // renderMessages() calls scrollToBottom() at the end, so we must
+    // counter-scroll to where the user was before loading older messages.
+    if (container) {
+      const newScrollH = container.scrollHeight;
+      container.scrollTop = newScrollH - prevScrollH;
     }
+    // renderMessages() called scrollToBottom() which set _scrollPinned=true.
+    // We just restored the user's scroll position, so mark as not pinned.
+    _scrollPinned = false;
   } catch(e) {
     console.warn('_loadOlderMessages failed:', e);
   } finally {

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -263,7 +263,12 @@ async function loadSession(sid){
       setStatus('');
       setComposerStatus('');
       updateQueueBadge(sid);
-      syncTopbar();renderMessages();highlightCode();loadDir('.');
+      syncTopbar();renderMessages();
+      // Kick off loadDir first (issues network requests), then highlight code.
+      // The fetch is dispatched before the CPU-bound Prism pass begins.
+      const _dirP=loadDir('.');
+      highlightCode();
+      await _dirP;
     }
   }
 

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -117,6 +117,7 @@ async function loadSession(sid){
   if (currentSid !== sid) {
     S.messages = [];
     S.toolCalls = [];
+    _messagesTruncated = false;
     const _msgInner = $('msgInner');
     if (_msgInner) _msgInner.innerHTML = '<div style="display:flex;align-items:center;justify-content:center;height:100%;color:var(--text-muted);font-size:14px;padding:40px;text-align:center;">Loading conversation...</div>';
   }
@@ -307,17 +308,27 @@ function _resolveSessionModelForDisplaySoon(sid){
   },0);
 }
 
+// Tracks whether the current session has older messages that were not
+// loaded during the initial paginated fetch (msg_limit window).
+// When true, scrolling to the top triggers _loadOlderMessages().
+let _messagesTruncated = false;
+
 // Load session messages if not already present.
 // Called after loadSession fetches metadata (messages=0).
 // Idempotent: if messages are already in S.messages, resolves immediately.
 // Handles streaming sessions specially: restores from INFLIGHT cache or API.
+// msg_limit (default 30): only fetch the last N messages for fast switching.
+// Older messages are loaded on-demand via _loadOlderMessages().
+const _INITIAL_MSG_LIMIT = 30;
+
 async function _ensureMessagesLoaded(sid) {
   // Already have messages? (e.g. from INFLIGHT restore path, already set)
   if (S.messages && S.messages.length > 0 && S.messages[0] && S.messages[0].role) {
     return;
   }
-  // Fetch full session with messages
-  const data = await api(`/api/session?session_id=${encodeURIComponent(sid)}&messages=1&resolve_model=0`);
+  // Fetch session messages with a tail window for fast initial load.
+  const data = await api(`/api/session?session_id=${encodeURIComponent(sid)}&messages=1&resolve_model=0&msg_limit=${_INITIAL_MSG_LIMIT}`);
+  _messagesTruncated = !!data.session._messages_truncated;
   const msgs = (data.session.messages || []).filter(m => m && m.role);
   // Check for tool-call metadata on messages (for tool-call card rendering)
   const hasMessageToolMetadata = msgs.some(m => {
@@ -337,6 +348,55 @@ async function _ensureMessagesLoaded(sid) {
     S.session.message_count=Number(data.session.message_count || msgs.length);
     S.lastUsage={...(data.session.last_usage||S.lastUsage||{})};
     _setSessionViewedCount(sid, Number(S.session.message_count || msgs.length));
+  }
+}
+
+// Load older messages when the user scrolls to the top of the conversation.
+// Prepends them to S.messages and re-renders, preserving scroll position.
+let _loadingOlder = false;
+async function _loadOlderMessages() {
+  if (_loadingOlder) return;
+  const sid = S.session ? S.session.session_id : null;
+  if (!sid || !S.messages.length) return;
+  // Use the _ts or timestamp of the oldest loaded message as a cursor.
+  // We ask for messages older than the first one we have.
+  const oldestMsg = S.messages[0];
+  const anchorTs = (oldestMsg._ts || oldestMsg.timestamp || 0);
+  _loadingOlder = true;
+  try {
+    const data = await api(`/api/session?session_id=${encodeURIComponent(sid)}&messages=1&resolve_model=0&msg_before=${encodeURIComponent(String(anchorTs))}&msg_limit=${_INITIAL_MSG_LIMIT}`);
+    if (!data || !data.session || _loadingSessionId !== null && _loadingSessionId !== sid) return;
+    const olderMsgs = (data.session.messages || []).filter(m => m && m.role);
+    if (!olderMsgs.length) { _messagesTruncated = false; return; }
+    // Prepend older messages
+    const inner = $('msgInner');
+    const prevScrollH = inner ? inner.scrollHeight : 0;
+    S.messages = [...olderMsgs, ...S.messages];
+    _messagesTruncated = !!data.session._messages_truncated;
+    renderMessages();
+    // Restore scroll position so the user stays at the same message
+    if (inner) {
+      const newScrollH = inner.scrollHeight;
+      inner.scrollTop = newScrollH - prevScrollH;
+    }
+  } catch(e) {
+    console.warn('_loadOlderMessages failed:', e);
+  } finally {
+    _loadingOlder = false;
+  }
+}
+
+// Ensure the full message history is loaded (for undo, export, etc).
+// If the session was loaded with msg_limit, this fetches all messages.
+async function _ensureAllMessagesLoaded() {
+  if (!_messagesTruncated || !S.session) return;
+  const sid = S.session.session_id;
+  const data = await api(`/api/session?session_id=${encodeURIComponent(sid)}&messages=1&resolve_model=0`);
+  const msgs = (data.session.messages || []).filter(m => m && m.role);
+  S.messages = msgs;
+  _messagesTruncated = false;
+  if(S.session && S.session.session_id === sid){
+    S.session.message_count = Number(data.session.message_count || msgs.length);
   }
 }
 

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -119,6 +119,7 @@ async function loadSession(sid){
     S.toolCalls = [];
     _messagesTruncated = false;
     _oldestIdx = 0;
+    _loadingOlder = false;
     const _msgInner = $('msgInner');
     if (_msgInner) _msgInner.innerHTML = '<div style="display:flex;align-items:center;justify-content:center;height:100%;color:var(--text-muted);font-size:14px;padding:40px;text-align:center;">Loading conversation...</div>';
   }
@@ -387,6 +388,9 @@ async function _loadOlderMessages() {
   } catch(e) {
     console.warn('_loadOlderMessages failed:', e);
   } finally {
+    // Always clear the loading lock. If the user switched sessions while
+    // this request was in flight, loadSession() already set _loadingOlder=false
+    // (see line ~122), so this is a harmless double-reset.
     _loadingOlder = false;
   }
 }

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -118,6 +118,7 @@ async function loadSession(sid){
     S.messages = [];
     S.toolCalls = [];
     _messagesTruncated = false;
+    _oldestIdx = 0;
     const _msgInner = $('msgInner');
     if (_msgInner) _msgInner.innerHTML = '<div style="display:flex;align-items:center;justify-content:center;height:100%;color:var(--text-muted);font-size:14px;padding:40px;text-align:center;">Loading conversation...</div>';
   }
@@ -329,6 +330,7 @@ async function _ensureMessagesLoaded(sid) {
   // Fetch session messages with a tail window for fast initial load.
   const data = await api(`/api/session?session_id=${encodeURIComponent(sid)}&messages=1&resolve_model=0&msg_limit=${_INITIAL_MSG_LIMIT}`);
   _messagesTruncated = !!data.session._messages_truncated;
+  _oldestIdx = data.session._messages_offset || 0;
   const msgs = (data.session.messages || []).filter(m => m && m.role);
   // Check for tool-call metadata on messages (for tool-call card rendering)
   const hasMessageToolMetadata = msgs.some(m => {
@@ -354,18 +356,20 @@ async function _ensureMessagesLoaded(sid) {
 // Load older messages when the user scrolls to the top of the conversation.
 // Prepends them to S.messages and re-renders, preserving scroll position.
 let _loadingOlder = false;
+// _oldestIdx tracks the index (in the server's full message array) of the
+// oldest message currently loaded in S.messages. Starts at 0 when all
+// messages are loaded, or > 0 when truncated by msg_limit.
+let _oldestIdx = 0;
+
 async function _loadOlderMessages() {
-  if (_loadingOlder) return;
+  if (_loadingOlder || !_messagesTruncated) return;
   const sid = S.session ? S.session.session_id : null;
   if (!sid || !S.messages.length) return;
-  // Use the _ts or timestamp of the oldest loaded message as a cursor.
-  // We ask for messages older than the first one we have.
-  const oldestMsg = S.messages[0];
-  const anchorTs = (oldestMsg._ts || oldestMsg.timestamp || 0);
+  if (_oldestIdx <= 0) { _messagesTruncated = false; return; }
   _loadingOlder = true;
   try {
-    const data = await api(`/api/session?session_id=${encodeURIComponent(sid)}&messages=1&resolve_model=0&msg_before=${encodeURIComponent(String(anchorTs))}&msg_limit=${_INITIAL_MSG_LIMIT}`);
-    if (!data || !data.session || _loadingSessionId !== null && _loadingSessionId !== sid) return;
+    const data = await api(`/api/session?session_id=${encodeURIComponent(sid)}&messages=1&resolve_model=0&msg_before=${_oldestIdx}&msg_limit=${_INITIAL_MSG_LIMIT}`);
+    if (!data || !data.session || (_loadingSessionId !== null && _loadingSessionId !== sid)) return;
     const olderMsgs = (data.session.messages || []).filter(m => m && m.role);
     if (!olderMsgs.length) { _messagesTruncated = false; return; }
     // Prepend older messages
@@ -373,6 +377,7 @@ async function _loadOlderMessages() {
     const prevScrollH = inner ? inner.scrollHeight : 0;
     S.messages = [...olderMsgs, ...S.messages];
     _messagesTruncated = !!data.session._messages_truncated;
+    _oldestIdx = data.session._messages_offset || 0;
     renderMessages();
     // Restore scroll position so the user stays at the same message
     if (inner) {

--- a/static/ui.js
+++ b/static/ui.js
@@ -574,6 +574,10 @@ let _scrollPinned=true;
     _scrollPinned=nearBottom;
     const btn=$('scrollToBottomBtn');
     if(btn) btn.style.display=_scrollPinned?'none':'flex';
+    // Load older messages when scrolled near the top
+    if(el.scrollTop<80 && typeof _messagesTruncated!=='undefined' && _messagesTruncated && typeof _loadOlderMessages==='function'){
+      _loadOlderMessages();
+    }
   });
 })();
 function _fmtTokens(n){if(!n||n<0)return'0';if(n>=1e6)return(n/1e6).toFixed(1)+'M';if(n>=1e3)return(n/1e3).toFixed(1)+'k';return String(n);}
@@ -2205,6 +2209,16 @@ function renderMessages(){
   });
   $('emptyState').style.display=vis.length?'none':'';
   inner.innerHTML='';
+  // Show "load older" indicator when older messages are available
+  if(typeof _messagesTruncated!=='undefined' && _messagesTruncated && S.messages.length>0){
+    const indicator=document.createElement('div');
+    indicator.id='loadOlderIndicator';
+    indicator.className='msg-date-sep';
+    indicator.style.cssText='cursor:pointer;color:var(--blue);font-size:13px;padding:10px 0;text-align:center;';
+    indicator.textContent='↑ Scroll up or click to load older messages';
+    indicator.onclick=()=>{if(typeof _loadOlderMessages==='function') _loadOlderMessages();};
+    inner.appendChild(indicator);
+  }
   const compressionNode=compressionState?_compressionCardsNode(compressionState):null;
   const referenceMessage=S.messages.find(m=>_isContextCompactionMessage(m));
   const referenceText=referenceMessage?msgContent(referenceMessage)||String(referenceMessage.content||''):'';

--- a/static/workspace.js
+++ b/static/workspace.js
@@ -64,7 +64,7 @@ async function loadDir(path){
     // Pre-fetch contents of restored expanded dirs so they render without a second click
     // (parallelized — avoids serial waterfall when multiple dirs are expanded)
     if(!path||path==='.'){
-      const expanded=S._expandedDirs||[];
+      const expanded=S._expandedDirs||new Set();
       const pending=[...expanded].filter(dirPath=>!S._dirCache[dirPath]);
       if(pending.length){
         const results=await Promise.all(pending.map(dirPath=>

--- a/static/workspace.js
+++ b/static/workspace.js
@@ -62,16 +62,19 @@ async function loadDir(path){
     const data=await api(`/api/list?session_id=${encodeURIComponent(S.session.session_id)}&path=${encodeURIComponent(path)}`);
     S.entries=data.entries||[];renderBreadcrumb();renderFileTree();
     // Pre-fetch contents of restored expanded dirs so they render without a second click
+    // (parallelized — avoids serial waterfall when multiple dirs are expanded)
     if(!path||path==='.'){
-      for(const dirPath of (S._expandedDirs||[])){
-        if(!S._dirCache[dirPath]){
-          try{
-            const dc=await api(`/api/list?session_id=${encodeURIComponent(S.session.session_id)}&path=${encodeURIComponent(dirPath)}`);
-            S._dirCache[dirPath]=dc.entries||[];
-          }catch(e2){S._dirCache[dirPath]=[];}
-        }
+      const expanded=S._expandedDirs||[];
+      const pending=[...expanded].filter(dirPath=>!S._dirCache[dirPath]);
+      if(pending.length){
+        const results=await Promise.all(pending.map(dirPath=>
+          api(`/api/list?session_id=${encodeURIComponent(S.session.session_id)}&path=${encodeURIComponent(dirPath)}`)
+            .then(dc=>({dirPath,entries:dc.entries||[]}))
+            .catch(()=>({dirPath,entries:[]}))
+        ));
+        for(const {dirPath,entries} of results) S._dirCache[dirPath]=entries;
       }
-      if(S._expandedDirs&&S._expandedDirs.size>0)renderFileTree();
+      if(expanded.size>0)renderFileTree();
     }
     if(typeof clearPreview==='function'){
       if(typeof _previewDirty!=='undefined'&&_previewDirty){

--- a/tests/test_parallel_session_switch.py
+++ b/tests/test_parallel_session_switch.py
@@ -5,7 +5,7 @@ Four optimizations to reduce session-switch latency:
 1. loadDir expanded-dir pre-fetch uses Promise.all (workspace.js)
 2. loadSession idle path overlaps loadDir with highlightCode (sessions.js)
 3. git_info_for_workspace runs git subprocesses in parallel (workspace.py)
-4. Message pagination: msg_limit tail-window + msg_before cursor (routes.py + sessions.js)
+4. Message pagination: msg_limit tail-window + msg_before index cursor (routes.py + sessions.js)
 """
 
 import pathlib
@@ -27,7 +27,6 @@ class TestLoadDirParallelPrefetch:
     instead of a serial for-await loop to avoid N sequential roundtrips."""
 
     def test_loaddir_uses_promise_all_for_expanded_dirs(self):
-        # Find the expanded-dir pre-fetch block inside loadDir
         marker = "Pre-fetch contents of restored expanded dirs"
         idx = WORKSPACE_JS.find(marker)
         assert idx >= 0, "Expanded-dir pre-fetch comment not found in workspace.js"
@@ -43,11 +42,20 @@ class TestLoadDirParallelPrefetch:
         idx = WORKSPACE_JS.find(marker)
         assert idx >= 0
         block = WORKSPACE_JS[idx : idx + 800]
-        # The old serial pattern was: for(const dirPath of ...){ ... await api(...); ... }
-        # The new parallel pattern uses .map() inside Promise.all instead.
         assert "for(const dirPath of (S._expandedDirs" not in block, (
             "loadDir still has a serial for-await loop for expanded dirs — "
             "should use Promise.all with .map() instead."
+        )
+
+    def test_expanded_dirs_fallback_is_set(self):
+        """S._expandedDirs||fallback must produce a Set, not an Array."""
+        marker = "Pre-fetch contents of restored expanded dirs"
+        idx = WORKSPACE_JS.find(marker)
+        assert idx >= 0
+        block = WORKSPACE_JS[idx : idx + 800]
+        assert "S._expandedDirs||new Set()" in block, (
+            "Expanded dirs fallback must be 'new Set()' not '[]' — "
+            "arrays have no .size property."
         )
 
 
@@ -60,8 +68,6 @@ class TestLoadSessionIdleOverlap:
     Prism.js pass."""
 
     def test_idle_path_starts_loaddir_before_highlightcode(self):
-        # Find the idle (non-streaming) else branch in loadSession
-        # Pattern: S.busy=false ... loadDir before highlightCode
         idle_marker = "S.busy=false"
         positions = []
         start = 0
@@ -72,7 +78,6 @@ class TestLoadSessionIdleOverlap:
             positions.append(idx)
             start = idx + 1
 
-        # There should be an idle path that calls both loadDir and highlightCode
         found = False
         for pos in positions:
             block = SESSIONS_JS[pos : pos + 600]
@@ -80,15 +85,12 @@ class TestLoadSessionIdleOverlap:
             has_loaddir = "loadDir('.')" in block
             if has_highlight and has_loaddir:
                 found = True
-                # loadDir must appear BEFORE highlightCode in source order
-                # (or at least be started before highlightCode runs)
                 loaddir_idx = block.find("loadDir(")
                 highlight_idx = block.find("highlightCode()")
                 assert loaddir_idx < highlight_idx, (
                     "In the idle path, loadDir() should be started before "
                     "highlightCode() so the network request is dispatched first."
                 )
-                # There should be an await for the loadDir promise
                 assert "await" in block and "_dirP" in block, (
                     "loadDir() result should be stored and awaited after "
                     "highlightCode() completes."
@@ -109,16 +111,13 @@ class TestGitInfoParallel:
     to reduce wall-clock time."""
 
     def test_uses_thread_pool(self):
-        from api.workspace import git_info_for_workspace
-
         source = pathlib.Path(__file__).parent.parent / "api" / "workspace.py"
         src = source.read_text()
         fn = src[src.find("def git_info_for_workspace") :]
         fn = fn[: fn.find("\ndef ")]
 
-        assert "concurrent.futures" in fn, (
-            "git_info_for_workspace should use concurrent.futures "
-            "for parallel subprocess execution."
+        assert "concurrent.futures" in src, (
+            "concurrent.futures should be imported at the module level."
         )
         assert "ThreadPoolExecutor" in fn, (
             "git_info_for_workspace should use ThreadPoolExecutor "
@@ -127,20 +126,13 @@ class TestGitInfoParallel:
 
     def test_git_commands_run_concurrently(self, tmp_path):
         """Proof that status/ahead/behind git commands execute in parallel,
-        not sequentially. Uses threading.Barrier to verify overlap.
-
-        rev-parse runs first (serial), then status + 2x rev-list run in parallel.
-        If they were serial, all 4 would finish sequentially.
-        If parallel, the 3 post-rev-parse commands overlap.
-        """
+        not sequentially. Uses threading.Barrier to verify overlap."""
         from api.workspace import git_info_for_workspace
         import api.workspace as ws_mod
 
         git_dir = tmp_path / ".git"
         git_dir.mkdir()
 
-        # Barrier for the 3 parallel commands (status, ahead, behind).
-        # rev-parse runs first and is NOT part of the barrier.
         barrier = threading.Barrier(3, timeout=5)
         call_count = {"n": 0}
         started_times = []
@@ -148,7 +140,6 @@ class TestGitInfoParallel:
         def fake_git(args, cwd, timeout=3):
             if args[0] == "rev-parse":
                 return "main"
-            # These three (status, rev-list ahead, rev-list behind) run in parallel
             call_count["n"] += 1
             started_times.append(time.monotonic())
             barrier.wait(timeout=2)
@@ -162,26 +153,16 @@ class TestGitInfoParallel:
         assert result is not None
         assert result["is_git"] is True
         assert result["branch"] == "main"
-
-        # All three parallel commands must have been called
         assert call_count["n"] == 3, (
             f"Expected 3 parallel git calls, got {call_count['n']}"
         )
-
-        # If parallel, all three start within a narrow window.
-        # If serial, each waits 0.1s+ before the next starts.
         assert started_times[-1] - started_times[0] < 0.15, (
             f"Git commands started too far apart ({started_times[-1]-started_times[0]:.3f}s), "
-            f"suggesting serial execution. Expected parallel start within 0.15s."
+            f"suggesting serial execution."
         )
 
     def test_parallel_faster_than_serial(self, tmp_path):
-        """Wall-clock time for parallel execution should be ~1/3 of serial.
-
-        Each mocked git command sleeps 0.1s.
-        Serial: 3 * 0.1s = 0.3s minimum.
-        Parallel: 0.1s + overhead.
-        """
+        """Wall-clock time for parallel execution should be ~1/3 of serial."""
         from api.workspace import git_info_for_workspace
         import api.workspace as ws_mod
 
@@ -203,8 +184,6 @@ class TestGitInfoParallel:
 
         assert result is not None
         assert result["is_git"] is True
-        # 3 commands * 0.1s each = 0.3s if serial.
-        # Parallel should be ~0.1s. Allow generous margin.
         assert elapsed < 0.25, (
             f"git_info_for_workspace took {elapsed:.3f}s — expected < 0.25s "
             f"with parallel execution (serial baseline is ~0.3s)."
@@ -243,13 +222,11 @@ class TestMessagePaginationBackend:
         session.compression_anchor_visible_idx = None
         session.compression_anchor_message_key = None
         session._metadata_message_count = None
-        # Generate messages with timestamps
         session.messages = [
-            {"role": "user" if i % 3 == 0 else "assistant", "content": f"Message {i}", "_ts": 1000 + i}
+            {"role": "user" if i % 3 == 0 else "assistant", "content": f"Message {i}"}
             for i in range(n_msgs)
         ]
         session.tool_calls = []
-        # compact() returns a dict
         session.compact.return_value = {
             "session_id": "test_session_123",
             "title": "Test Session",
@@ -276,11 +253,6 @@ class TestMessagePaginationBackend:
 
     def test_msg_limit_returns_tail(self):
         """msg_limit=10 should return the last 10 messages of a 100-msg session."""
-        import json
-        from urllib.parse import urlencode
-        from http.server import BaseHTTPRequestHandler
-
-        # Simulate the logic from routes.py /api/session handler
         session = self._make_session(100)
         all_msgs = session.messages
         msg_limit = 10
@@ -291,68 +263,92 @@ class TestMessagePaginationBackend:
         assert truncated[-1]["content"] == "Message 99"
 
     def test_msg_limit_larger_than_total(self):
-        """msg_limit larger than total messages returns all messages, no truncation."""
+        """msg_limit larger than total messages returns all messages."""
         session = self._make_session(50)
         all_msgs = session.messages
         msg_limit = 100
 
         truncated = all_msgs[-msg_limit:]
         assert len(truncated) == 50
-        # Not truncated
         assert len(all_msgs) <= msg_limit
 
-    def test_msg_before_filters_by_timestamp(self):
-        """msg_before=1050 should only return messages with _ts < 1050."""
+    def test_msg_before_index_based_slicing(self):
+        """msg_before=50 returns messages[:50] then tail window."""
         session = self._make_session(100)
         all_msgs = session.messages
-        msg_before = 1050.0
+        msg_before = 50
+        msg_limit = 30
 
-        filtered = [
-            m for m in all_msgs
-            if (m.get('_ts') or m.get('timestamp') or 0) < msg_before
-        ]
-        # Messages with _ts 1000..1049 (indices 0..49)
-        assert len(filtered) == 50
-        assert filtered[0]["_ts"] == 1000
-        assert filtered[-1]["_ts"] == 1049
+        _slice = all_msgs[:msg_before]
+        truncated = _slice[-msg_limit:]
+        assert len(truncated) == 30
+        assert truncated[0]["content"] == "Message 20"
+        assert truncated[-1]["content"] == "Message 49"
 
-    def test_msg_before_with_limit(self):
-        """msg_before=1050 & msg_limit=10 returns last 10 of messages < ts 1050."""
+    def test_msg_before_zero_returns_empty(self):
+        """msg_before=0 means no older messages exist — returns empty."""
         session = self._make_session(100)
         all_msgs = session.messages
-        msg_before = 1050.0
-        msg_limit = 10
+        msg_before = 0
 
-        filtered = [
-            m for m in all_msgs
-            if (m.get('_ts') or m.get('timestamp') or 0) < msg_before
-        ]
-        truncated = filtered[-msg_limit:]
-        assert len(truncated) == 10
-        assert truncated[0]["_ts"] == 1040
-        assert truncated[-1]["_ts"] == 1049
+        _slice = all_msgs[:msg_before]
+        assert len(_slice) == 0
+
+    def test_msg_before_equal_total(self):
+        """msg_before=100 returns all 100, tail-30 gives messages 70-99."""
+        session = self._make_session(100)
+        all_msgs = session.messages
+        msg_before = 100
+        msg_limit = 30
+
+        _slice = all_msgs[:msg_before]
+        truncated = _slice[-msg_limit:]
+        assert len(truncated) == 30
+        assert truncated[0]["content"] == "Message 70"
 
     def test_truncation_flag(self):
         """_messages_truncated must be True when messages were omitted."""
         session = self._make_session(100)
         msg_limit = 30
-
         is_truncated = len(session.messages) > msg_limit
         assert is_truncated is True
 
-        # Small session should not be truncated
         small = self._make_session(10)
         is_truncated_small = len(small.messages) > msg_limit
         assert is_truncated_small is False
 
-    def test_no_limit_returns_all(self):
-        """Without msg_limit, all messages are returned."""
+    def test_truncation_flag_with_msg_before(self):
+        """When msg_before filters to fewer than msg_limit, truncation is False."""
         session = self._make_session(100)
+        msg_before = 10
+        msg_limit = 30
+
+        _slice = session.messages[:msg_before]
+        _truncated = len(_slice) > msg_limit
+        assert _truncated is False  # 10 < 30, no truncation
+
+    def test_messages_offset_initial_load(self):
+        """_messages_offset = index of first returned message in full array."""
+        session = self._make_session(100)
+        msg_limit = 30
         all_msgs = session.messages
 
-        # No limit: return all
-        truncated = all_msgs  # no slicing
-        assert len(truncated) == 100
+        truncated = all_msgs[-msg_limit:]
+        offset = len(all_msgs) - len(truncated)
+        assert offset == 70
+        assert truncated[0]["content"] == "Message 70"
+
+    def test_messages_offset_with_msg_before(self):
+        """_messages_offset for msg_before=50, msg_limit=30."""
+        session = self._make_session(100)
+        msg_before = 50
+        msg_limit = 30
+
+        _slice = session.messages[:msg_before]
+        truncated = _slice[-msg_limit:]
+        offset = msg_before - len(truncated)
+        assert offset == 20
+        assert truncated[0]["content"] == "Message 20"
 
     def test_payload_size_reduction(self):
         """Quantify the payload reduction: 100 msgs → 30 msgs = ~70% smaller."""
@@ -364,9 +360,21 @@ class TestMessagePaginationBackend:
 
         reduction = 1 - len(tail_json) / len(all_json)
         assert reduction > 0.6, (
-            f"Expected >60% payload reduction, got {reduction*100:.0f}%. "
-            f"100 msgs: {len(all_json)} bytes, 30 msgs: {len(tail_json)} bytes"
+            f"Expected >60% payload reduction, got {reduction*100:.0f}%."
         )
+
+    def test_msg_before_bounds_clamping(self):
+        """msg_before beyond array length should be clamped."""
+        session = self._make_session(100)
+        all_msgs = session.messages
+
+        # msg_before = 999 → clamped to 100
+        _before_idx = max(0, min(999, len(all_msgs)))
+        assert _before_idx == 100
+
+        # msg_before = -5 → clamped to 0
+        _before_idx = max(0, min(-5, len(all_msgs)))
+        assert _before_idx == 0
 
 
 class TestMessagePaginationFrontend:
@@ -388,49 +396,53 @@ class TestMessagePaginationFrontend:
 
     def test_truncation_tracking(self):
         """_messagesTruncated must be set from the server response."""
-        assert "_messagesTruncated" in SESSIONS_JS, (
-            "sessions.js must track _messagesTruncated state"
+        assert "_messagesTruncated" in SESSIONS_JS
+        assert "_messages_truncated" in SESSIONS_JS
+
+    def test_oldest_idx_tracking(self):
+        """_oldestIdx must be tracked for index-based cursor paging."""
+        assert "_oldestIdx" in SESSIONS_JS, (
+            "sessions.js must track _oldestIdx for index-based cursor paging"
         )
-        assert "_messages_truncated" in SESSIONS_JS, (
-            "sessions.js must read _messages_truncated from server response"
+        assert "_messages_offset" in SESSIONS_JS, (
+            "sessions.js must read _messages_offset from server response"
         )
 
     def test_load_older_messages_function_exists(self):
         """_loadOlderMessages must be defined for scroll-to-top loading."""
-        assert "async function _loadOlderMessages" in SESSIONS_JS, (
-            "_loadOlderMessages function must be defined for lazy loading older messages"
-        )
-        assert "msg_before=" in SESSIONS_JS, (
-            "_loadOlderMessages must use msg_before parameter for cursor-based paging"
+        assert "async function _loadOlderMessages" in SESSIONS_JS
+
+    def test_load_older_uses_index_cursor(self):
+        """_loadOlderMessages must pass msg_before as integer index, not timestamp."""
+        fn_start = SESSIONS_JS.find("async function _loadOlderMessages")
+        fn_end = SESSIONS_JS.find("\n}", fn_start) + 2
+        fn_body = SESSIONS_JS[fn_start:fn_end]
+
+        assert "msg_before=${_oldestIdx}" in fn_body, (
+            "_loadOlderMessages should use _oldestIdx (integer) as msg_before cursor"
         )
 
     def test_ensure_all_messages_function_exists(self):
         """_ensureAllMessagesLoaded must exist for operations needing full history."""
-        assert "async function _ensureAllMessagesLoaded" in SESSIONS_JS, (
-            "_ensureAllMessagesLoaded function must exist for operations that "
-            "need the full message history (undo, export, etc.)"
-        )
+        assert "async function _ensureAllMessagesLoaded" in SESSIONS_JS
 
     def test_scroll_to_top_triggers_loading(self):
         """Scroll event handler must trigger _loadOlderMessages near top."""
         UI_JS = (REPO / "static" / "ui.js").read_text(encoding="utf-8")
 
-        # Find the scroll listener on #messages element
-        scroll_marker = "el.scrollTop<80"
-        assert scroll_marker in UI_JS, (
-            "Scroll handler must check scrollTop<80 to trigger older message loading"
-        )
-        assert "_loadOlderMessages" in UI_JS, (
-            "ui.js scroll handler must call _loadOlderMessages"
-        )
+        assert "el.scrollTop<80" in UI_JS
+        assert "_loadOlderMessages" in UI_JS
 
     def test_load_older_indicator_in_render(self):
         """renderMessages must show a 'load older' indicator when truncated."""
         UI_JS = (REPO / "static" / "ui.js").read_text(encoding="utf-8")
 
-        assert "loadOlderIndicator" in UI_JS, (
-            "renderMessages must create a loadOlderIndicator when older messages exist"
-        )
-        assert "load older messages" in UI_JS.lower(), (
-            "Load older indicator must have visible text for the user"
+        assert "loadOlderIndicator" in UI_JS
+
+    def test_oldest_idx_reset_on_session_switch(self):
+        """_oldestIdx must be reset to 0 on session switch."""
+        # Find the loadSession reset block
+        idx = SESSIONS_JS.find("_messagesTruncated = false;\n    _oldestIdx = 0;")
+        assert idx >= 0, (
+            "_oldestIdx must be reset to 0 alongside _messagesTruncated on session switch"
         )

--- a/tests/test_parallel_session_switch.py
+++ b/tests/test_parallel_session_switch.py
@@ -1,20 +1,22 @@
-"""Tests for session-switch parallelization (PR: perf/parallelize-session-switch).
+"""Tests for session-switch performance optimizations.
 
-Three optimizations to reduce session-switch latency:
+Four optimizations to reduce session-switch latency:
 
 1. loadDir expanded-dir pre-fetch uses Promise.all (workspace.js)
 2. loadSession idle path overlaps loadDir with highlightCode (sessions.js)
 3. git_info_for_workspace runs git subprocesses in parallel (workspace.py)
+4. Message pagination: msg_limit tail-window + msg_before cursor (routes.py + sessions.js)
 """
 
 import pathlib
 import threading
 import time
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 REPO = pathlib.Path(__file__).parent.parent
 SESSIONS_JS = (REPO / "static" / "sessions.js").read_text(encoding="utf-8")
 WORKSPACE_JS = (REPO / "static" / "workspace.js").read_text(encoding="utf-8")
+ROUTES_PY = (REPO / "api" / "routes.py").read_text(encoding="utf-8")
 
 
 # ── 1. workspace.js: expanded-dir pre-fetch is parallelized ─────────────────
@@ -206,4 +208,229 @@ class TestGitInfoParallel:
         assert elapsed < 0.25, (
             f"git_info_for_workspace took {elapsed:.3f}s — expected < 0.25s "
             f"with parallel execution (serial baseline is ~0.3s)."
+        )
+
+
+# ── 4. Message pagination (msg_limit + msg_before) ─────────────────────────
+
+
+class TestMessagePaginationBackend:
+    """Backend /api/session must support msg_limit and msg_before parameters
+    to return only the last N messages, reducing payload size for fast
+    session switching."""
+
+    def _make_session(self, n_msgs=100):
+        """Create a mock session with n_msgs messages."""
+        session = MagicMock()
+        session.session_id = "test_session_123"
+        session.title = "Test Session"
+        session.workspace = "/tmp/test"
+        session.model = "test-model"
+        session.created_at = 1000000
+        session.updated_at = 2000000
+        session.pinned = False
+        session.archived = False
+        session.project_id = None
+        session.profile = None
+        session.input_tokens = 0
+        session.output_tokens = 0
+        session.estimated_cost = None
+        session.personality = None
+        session.active_stream_id = None
+        session.pending_user_message = None
+        session.pending_attachments = []
+        session.pending_started_at = None
+        session.compression_anchor_visible_idx = None
+        session.compression_anchor_message_key = None
+        session._metadata_message_count = None
+        # Generate messages with timestamps
+        session.messages = [
+            {"role": "user" if i % 3 == 0 else "assistant", "content": f"Message {i}", "_ts": 1000 + i}
+            for i in range(n_msgs)
+        ]
+        session.tool_calls = []
+        # compact() returns a dict
+        session.compact.return_value = {
+            "session_id": "test_session_123",
+            "title": "Test Session",
+            "workspace": "/tmp/test",
+            "model": "test-model",
+            "message_count": n_msgs,
+            "created_at": 1000000,
+            "updated_at": 2000000,
+            "last_message_at": 2000000,
+            "pinned": False,
+            "archived": False,
+            "project_id": None,
+            "profile": None,
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "estimated_cost": None,
+            "personality": None,
+            "compression_anchor_visible_idx": None,
+            "compression_anchor_message_key": None,
+            "active_stream_id": None,
+            "is_streaming": False,
+        }
+        return session
+
+    def test_msg_limit_returns_tail(self):
+        """msg_limit=10 should return the last 10 messages of a 100-msg session."""
+        import json
+        from urllib.parse import urlencode
+        from http.server import BaseHTTPRequestHandler
+
+        # Simulate the logic from routes.py /api/session handler
+        session = self._make_session(100)
+        all_msgs = session.messages
+        msg_limit = 10
+
+        truncated = all_msgs[-msg_limit:]
+        assert len(truncated) == 10
+        assert truncated[0]["content"] == "Message 90"
+        assert truncated[-1]["content"] == "Message 99"
+
+    def test_msg_limit_larger_than_total(self):
+        """msg_limit larger than total messages returns all messages, no truncation."""
+        session = self._make_session(50)
+        all_msgs = session.messages
+        msg_limit = 100
+
+        truncated = all_msgs[-msg_limit:]
+        assert len(truncated) == 50
+        # Not truncated
+        assert len(all_msgs) <= msg_limit
+
+    def test_msg_before_filters_by_timestamp(self):
+        """msg_before=1050 should only return messages with _ts < 1050."""
+        session = self._make_session(100)
+        all_msgs = session.messages
+        msg_before = 1050.0
+
+        filtered = [
+            m for m in all_msgs
+            if (m.get('_ts') or m.get('timestamp') or 0) < msg_before
+        ]
+        # Messages with _ts 1000..1049 (indices 0..49)
+        assert len(filtered) == 50
+        assert filtered[0]["_ts"] == 1000
+        assert filtered[-1]["_ts"] == 1049
+
+    def test_msg_before_with_limit(self):
+        """msg_before=1050 & msg_limit=10 returns last 10 of messages < ts 1050."""
+        session = self._make_session(100)
+        all_msgs = session.messages
+        msg_before = 1050.0
+        msg_limit = 10
+
+        filtered = [
+            m for m in all_msgs
+            if (m.get('_ts') or m.get('timestamp') or 0) < msg_before
+        ]
+        truncated = filtered[-msg_limit:]
+        assert len(truncated) == 10
+        assert truncated[0]["_ts"] == 1040
+        assert truncated[-1]["_ts"] == 1049
+
+    def test_truncation_flag(self):
+        """_messages_truncated must be True when messages were omitted."""
+        session = self._make_session(100)
+        msg_limit = 30
+
+        is_truncated = len(session.messages) > msg_limit
+        assert is_truncated is True
+
+        # Small session should not be truncated
+        small = self._make_session(10)
+        is_truncated_small = len(small.messages) > msg_limit
+        assert is_truncated_small is False
+
+    def test_no_limit_returns_all(self):
+        """Without msg_limit, all messages are returned."""
+        session = self._make_session(100)
+        all_msgs = session.messages
+
+        # No limit: return all
+        truncated = all_msgs  # no slicing
+        assert len(truncated) == 100
+
+    def test_payload_size_reduction(self):
+        """Quantify the payload reduction: 100 msgs → 30 msgs = ~70% smaller."""
+        import json
+
+        session = self._make_session(100)
+        all_json = json.dumps(session.messages)
+        tail_json = json.dumps(session.messages[-30:])
+
+        reduction = 1 - len(tail_json) / len(all_json)
+        assert reduction > 0.6, (
+            f"Expected >60% payload reduction, got {reduction*100:.0f}%. "
+            f"100 msgs: {len(all_json)} bytes, 30 msgs: {len(tail_json)} bytes"
+        )
+
+
+class TestMessagePaginationFrontend:
+    """Frontend sessions.js must use msg_limit for initial load and expose
+    _loadOlderMessages for scroll-to-top lazy loading."""
+
+    def test_ensure_messages_uses_msg_limit(self):
+        """_ensureMessagesLoaded must send msg_limit parameter."""
+        fn_start = SESSIONS_JS.find("async function _ensureMessagesLoaded")
+        fn_end = SESSIONS_JS.find("\n}", fn_start) + 2
+        fn_body = SESSIONS_JS[fn_start:fn_end]
+
+        assert "msg_limit=" in fn_body, (
+            "_ensureMessagesLoaded should include msg_limit parameter in the API call"
+        )
+        assert "_INITIAL_MSG_LIMIT" in fn_body, (
+            "_ensureMessagesLoaded should use _INITIAL_MSG_LIMIT constant"
+        )
+
+    def test_truncation_tracking(self):
+        """_messagesTruncated must be set from the server response."""
+        assert "_messagesTruncated" in SESSIONS_JS, (
+            "sessions.js must track _messagesTruncated state"
+        )
+        assert "_messages_truncated" in SESSIONS_JS, (
+            "sessions.js must read _messages_truncated from server response"
+        )
+
+    def test_load_older_messages_function_exists(self):
+        """_loadOlderMessages must be defined for scroll-to-top loading."""
+        assert "async function _loadOlderMessages" in SESSIONS_JS, (
+            "_loadOlderMessages function must be defined for lazy loading older messages"
+        )
+        assert "msg_before=" in SESSIONS_JS, (
+            "_loadOlderMessages must use msg_before parameter for cursor-based paging"
+        )
+
+    def test_ensure_all_messages_function_exists(self):
+        """_ensureAllMessagesLoaded must exist for operations needing full history."""
+        assert "async function _ensureAllMessagesLoaded" in SESSIONS_JS, (
+            "_ensureAllMessagesLoaded function must exist for operations that "
+            "need the full message history (undo, export, etc.)"
+        )
+
+    def test_scroll_to_top_triggers_loading(self):
+        """Scroll event handler must trigger _loadOlderMessages near top."""
+        UI_JS = (REPO / "static" / "ui.js").read_text(encoding="utf-8")
+
+        # Find the scroll listener on #messages element
+        scroll_marker = "el.scrollTop<80"
+        assert scroll_marker in UI_JS, (
+            "Scroll handler must check scrollTop<80 to trigger older message loading"
+        )
+        assert "_loadOlderMessages" in UI_JS, (
+            "ui.js scroll handler must call _loadOlderMessages"
+        )
+
+    def test_load_older_indicator_in_render(self):
+        """renderMessages must show a 'load older' indicator when truncated."""
+        UI_JS = (REPO / "static" / "ui.js").read_text(encoding="utf-8")
+
+        assert "loadOlderIndicator" in UI_JS, (
+            "renderMessages must create a loadOlderIndicator when older messages exist"
+        )
+        assert "load older messages" in UI_JS.lower(), (
+            "Load older indicator must have visible text for the user"
         )

--- a/tests/test_parallel_session_switch.py
+++ b/tests/test_parallel_session_switch.py
@@ -1,0 +1,209 @@
+"""Tests for session-switch parallelization (PR: perf/parallelize-session-switch).
+
+Three optimizations to reduce session-switch latency:
+
+1. loadDir expanded-dir pre-fetch uses Promise.all (workspace.js)
+2. loadSession idle path overlaps loadDir with highlightCode (sessions.js)
+3. git_info_for_workspace runs git subprocesses in parallel (workspace.py)
+"""
+
+import pathlib
+import threading
+import time
+from unittest.mock import patch
+
+REPO = pathlib.Path(__file__).parent.parent
+SESSIONS_JS = (REPO / "static" / "sessions.js").read_text(encoding="utf-8")
+WORKSPACE_JS = (REPO / "static" / "workspace.js").read_text(encoding="utf-8")
+
+
+# ── 1. workspace.js: expanded-dir pre-fetch is parallelized ─────────────────
+
+
+class TestLoadDirParallelPrefetch:
+    """The expanded-dir pre-fetch inside loadDir() must use Promise.all()
+    instead of a serial for-await loop to avoid N sequential roundtrips."""
+
+    def test_loaddir_uses_promise_all_for_expanded_dirs(self):
+        # Find the expanded-dir pre-fetch block inside loadDir
+        marker = "Pre-fetch contents of restored expanded dirs"
+        idx = WORKSPACE_JS.find(marker)
+        assert idx >= 0, "Expanded-dir pre-fetch comment not found in workspace.js"
+
+        block = WORKSPACE_JS[idx : idx + 800]
+        assert "Promise.all" in block, (
+            "loadDir expanded-dir pre-fetch should use Promise.all() for "
+            "parallel fetching, not a serial for-await loop."
+        )
+
+    def test_loaddir_no_serial_for_await_in_prefetch(self):
+        marker = "Pre-fetch contents of restored expanded dirs"
+        idx = WORKSPACE_JS.find(marker)
+        assert idx >= 0
+        block = WORKSPACE_JS[idx : idx + 800]
+        # The old serial pattern was: for(const dirPath of ...){ ... await api(...); ... }
+        # The new parallel pattern uses .map() inside Promise.all instead.
+        assert "for(const dirPath of (S._expandedDirs" not in block, (
+            "loadDir still has a serial for-await loop for expanded dirs — "
+            "should use Promise.all with .map() instead."
+        )
+
+
+# ── 2. sessions.js: loadSession idle path overlaps loadDir and highlightCode ─
+
+
+class TestLoadSessionIdleOverlap:
+    """The idle path in loadSession() must start loadDir() before running
+    highlightCode() so the network request is in-flight during the CPU-bound
+    Prism.js pass."""
+
+    def test_idle_path_starts_loaddir_before_highlightcode(self):
+        # Find the idle (non-streaming) else branch in loadSession
+        # Pattern: S.busy=false ... loadDir before highlightCode
+        idle_marker = "S.busy=false"
+        positions = []
+        start = 0
+        while True:
+            idx = SESSIONS_JS.find(idle_marker, start)
+            if idx < 0:
+                break
+            positions.append(idx)
+            start = idx + 1
+
+        # There should be an idle path that calls both loadDir and highlightCode
+        found = False
+        for pos in positions:
+            block = SESSIONS_JS[pos : pos + 600]
+            has_highlight = "highlightCode()" in block
+            has_loaddir = "loadDir('.')" in block
+            if has_highlight and has_loaddir:
+                found = True
+                # loadDir must appear BEFORE highlightCode in source order
+                # (or at least be started before highlightCode runs)
+                loaddir_idx = block.find("loadDir(")
+                highlight_idx = block.find("highlightCode()")
+                assert loaddir_idx < highlight_idx, (
+                    "In the idle path, loadDir() should be started before "
+                    "highlightCode() so the network request is dispatched first."
+                )
+                # There should be an await for the loadDir promise
+                assert "await" in block and "_dirP" in block, (
+                    "loadDir() result should be stored and awaited after "
+                    "highlightCode() completes."
+                )
+                break
+
+        assert found, (
+            "Could not find the idle path in loadSession that calls both "
+            "loadDir and highlightCode."
+        )
+
+
+# ── 3. workspace.py: git_info_for_workspace is parallelized ────────────────
+
+
+class TestGitInfoParallel:
+    """git_info_for_workspace() must run git subprocess calls in parallel
+    to reduce wall-clock time."""
+
+    def test_uses_thread_pool(self):
+        from api.workspace import git_info_for_workspace
+
+        source = pathlib.Path(__file__).parent.parent / "api" / "workspace.py"
+        src = source.read_text()
+        fn = src[src.find("def git_info_for_workspace") :]
+        fn = fn[: fn.find("\ndef ")]
+
+        assert "concurrent.futures" in fn, (
+            "git_info_for_workspace should use concurrent.futures "
+            "for parallel subprocess execution."
+        )
+        assert "ThreadPoolExecutor" in fn, (
+            "git_info_for_workspace should use ThreadPoolExecutor "
+            "to run git commands in parallel."
+        )
+
+    def test_git_commands_run_concurrently(self, tmp_path):
+        """Proof that status/ahead/behind git commands execute in parallel,
+        not sequentially. Uses threading.Barrier to verify overlap.
+
+        rev-parse runs first (serial), then status + 2x rev-list run in parallel.
+        If they were serial, all 4 would finish sequentially.
+        If parallel, the 3 post-rev-parse commands overlap.
+        """
+        from api.workspace import git_info_for_workspace
+        import api.workspace as ws_mod
+
+        git_dir = tmp_path / ".git"
+        git_dir.mkdir()
+
+        # Barrier for the 3 parallel commands (status, ahead, behind).
+        # rev-parse runs first and is NOT part of the barrier.
+        barrier = threading.Barrier(3, timeout=5)
+        call_count = {"n": 0}
+        started_times = []
+
+        def fake_git(args, cwd, timeout=3):
+            if args[0] == "rev-parse":
+                return "main"
+            # These three (status, rev-list ahead, rev-list behind) run in parallel
+            call_count["n"] += 1
+            started_times.append(time.monotonic())
+            barrier.wait(timeout=2)
+            if args[0] == "status":
+                return ""
+            return "0"
+
+        with patch.object(ws_mod, "_run_git", side_effect=fake_git):
+            result = git_info_for_workspace(tmp_path)
+
+        assert result is not None
+        assert result["is_git"] is True
+        assert result["branch"] == "main"
+
+        # All three parallel commands must have been called
+        assert call_count["n"] == 3, (
+            f"Expected 3 parallel git calls, got {call_count['n']}"
+        )
+
+        # If parallel, all three start within a narrow window.
+        # If serial, each waits 0.1s+ before the next starts.
+        assert started_times[-1] - started_times[0] < 0.15, (
+            f"Git commands started too far apart ({started_times[-1]-started_times[0]:.3f}s), "
+            f"suggesting serial execution. Expected parallel start within 0.15s."
+        )
+
+    def test_parallel_faster_than_serial(self, tmp_path):
+        """Wall-clock time for parallel execution should be ~1/3 of serial.
+
+        Each mocked git command sleeps 0.1s.
+        Serial: 3 * 0.1s = 0.3s minimum.
+        Parallel: 0.1s + overhead.
+        """
+        from api.workspace import git_info_for_workspace
+        import api.workspace as ws_mod
+
+        git_dir = tmp_path / ".git"
+        git_dir.mkdir()
+
+        def slow_git(args, cwd, timeout=3):
+            if args[0] == "rev-parse":
+                return "main"
+            time.sleep(0.1)
+            if args[0] == "status":
+                return ""
+            return "0"
+
+        with patch.object(ws_mod, "_run_git", side_effect=slow_git):
+            t0 = time.monotonic()
+            result = git_info_for_workspace(tmp_path)
+            elapsed = time.monotonic() - t0
+
+        assert result is not None
+        assert result["is_git"] is True
+        # 3 commands * 0.1s each = 0.3s if serial.
+        # Parallel should be ~0.1s. Allow generous margin.
+        assert elapsed < 0.25, (
+            f"git_info_for_workspace took {elapsed:.3f}s — expected < 0.25s "
+            f"with parallel execution (serial baseline is ~0.3s)."
+        )

--- a/tests/test_parallel_session_switch.py
+++ b/tests/test_parallel_session_switch.py
@@ -446,3 +446,89 @@ class TestMessagePaginationFrontend:
         assert idx >= 0, (
             "_oldestIdx must be reset to 0 alongside _messagesTruncated on session switch"
         )
+
+
+# ── 5. Session-switch cancellation safety ───────────────────────────────────
+
+
+class TestSessionSwitchCancellation:
+    """When the user switches sessions while _loadOlderMessages is in-flight,
+    the stale response must NOT land on the new session's message array.
+
+    Guarards in place:
+    - _loadOlderMessages captures `sid` at entry, checks _loadingSessionId
+      after await (line ~373)
+    - loadSession resets _loadingOlder, _messagesTruncated, _oldestIdx
+      on session switch (line ~120-122)
+    """
+
+    def test_load_older_checks_loading_session_id(self):
+        """_loadOlderMessages must check _loadingSessionId after await."""
+        fn_start = SESSIONS_JS.find("async function _loadOlderMessages")
+        fn_end = SESSIONS_JS.find("\n}", fn_start) + 2
+        fn_body = SESSIONS_JS[fn_start:fn_end]
+
+        assert "_loadingSessionId" in fn_body, (
+            "_loadOlderMessages must check _loadingSessionId after the API "
+            "call returns to detect session-switch race conditions."
+        )
+        # The guard should be: if _loadingSessionId !== null && _loadingSessionId !== sid
+        assert "_loadingSessionId !== null" in fn_body or "_loadingSessionId!==null" in fn_body, (
+            "_loadOlderMessages should bail out if a new session load started "
+            "while the older-messages request was in flight."
+        )
+
+    def test_loading_older_reset_on_session_switch(self):
+        """loadSession must reset _loadingOlder when switching sessions."""
+        # Find the reset block in loadSession
+        marker = "_messagesTruncated = false;\n    _oldestIdx = 0;\n    _loadingOlder = false;"
+        idx = SESSIONS_JS.find(marker)
+        assert idx >= 0, (
+            "loadSession must reset _loadingOlder=false on session switch "
+            "to prevent a stale _loadOlderMessages lock from blocking the "
+            "new session's scroll-to-top loading."
+        )
+
+    def test_stale_cannot_mutate_messages(self):
+        """Verify the guard prevents S.messages mutation.
+
+        The guard `if (_loadingSessionId !== null && _loadingSessionId !== sid) return`
+        runs BEFORE `S.messages = [...olderMsgs, ...S.messages]`.
+        If the session changed, we return early — no mutation.
+        """
+        fn_start = SESSIONS_JS.find("async function _loadOlderMessages")
+        fn_end = SESSIONS_JS.find("\n}", fn_start) + 2
+        fn_body = SESSIONS_JS[fn_start:fn_end]
+
+        # Guard must appear before S.messages mutation
+        guard_idx = fn_body.find("_loadingSessionId")
+        mutation_idx = fn_body.find("S.messages = [...olderMsgs")
+        assert guard_idx >= 0 and mutation_idx >= 0 and guard_idx < mutation_idx, (
+            "The _loadingSessionId guard must appear BEFORE the S.messages "
+            "mutation to prevent stale data from landing on the wrong session."
+        )
+
+    def test_messages_truncated_reset_on_switch(self):
+        """loadSession must reset _messagesTruncated on session switch."""
+        marker = "_messagesTruncated = false;\n    _oldestIdx = 0;\n    _loadingOlder = false;"
+        idx = SESSIONS_JS.find(marker)
+        assert idx >= 0, (
+            "_messagesTruncated must be reset to false on session switch "
+            "to prevent the scroll-to-top handler from trying to load "
+            "older messages from the previous session."
+        )
+
+    def test_oldest_idx_reset_prevents_wrong_cursor(self):
+        """_oldestIdx=0 after switch prevents passing stale cursor to API."""
+        # If _oldestIdx carried over from session A (e.g. _oldestIdx=70),
+        # and session B only has 10 messages, msg_before=70 would return empty.
+        # Resetting to 0 ensures session B starts fresh.
+        fn_start = SESSIONS_JS.find("async function _loadOlderMessages")
+        fn_end = SESSIONS_JS.find("\n}", fn_start) + 2
+        fn_body = SESSIONS_JS[fn_start:fn_end]
+
+        # _loadOlderMessages checks _oldestIdx <= 0 early and exits
+        assert "_oldestIdx <= 0" in fn_body, (
+            "_loadOlderMessages should bail out if _oldestIdx <= 0, "
+            "which is the reset value after session switch."
+        )


### PR DESCRIPTION
Explanation:

When _loadOlderMessages() prepended older messages to the conversation, the viewport snapped to the bottom instead of staying where the user was — making it impossible to read older messages by scrolling up.

Two bugs compounding:

Wrong scrollable container. The code used $('msgInner') for scrollHeight/scrollTop, but #msgInner has no overflow-y — it's just a flex column inside the DOM tree. The actual scrollable container is #messages (.messages{overflow-y:auto}). Setting .scrollTop on msgInner was silently ignored because the element never scrolls.
renderMessages() overrides scroll position. At the end of renderMessages() (ui.js:2552), the existing code unconditionally calls scrollToBottom(), which scrolls #messages to the bottom and sets _scrollPinned=true. Since bug #1 made the scroll-restore logic a no-op, the page landed at the bottom every time.
Fix:

Changed scroll restore target from $('msgInner') to $('messages') (the real scrollable container).
Reset _scrollPinned = false after restoring the user's position, so scrollToBottom() doesn't re-fire on next tick