### PR TITLE
Fix #1214: workspace refresh on profile switch and #1212: OAuth provider detection

### DIFF
--- a/api/providers.py
+++ b/api/providers.py
@@ -311,12 +311,17 @@ def get_providers() -> dict[str, Any]:
                     key_source = "config_yaml"
             else:
                 key_source = "config_yaml"
-        else:
-            # Fallback: provider may be authenticated via hermes auth even
-            # though it is not in the hardcoded _OAUTH_PROVIDERS set
-            # (e.g. Anthropic connected via OAuth).  Check live auth
-            # status so the Providers tab agrees with the model picker
-            # (#1212).
+        elif pid not in _PROVIDER_ENV_VAR:
+            # Fallback: provider is not a known API-key provider and not in
+            # the hardcoded _OAUTH_PROVIDERS set.  It may be a custom or
+            # newly-added OAuth provider (e.g. Anthropic connected via OAuth).
+            # Check live auth status so the Providers tab agrees with the
+            # model picker (#1212).
+            #
+            # IMPORTANT: we skip providers in _PROVIDER_ENV_VAR because they
+            # are pure API-key providers — calling get_auth_status() for every
+            # unconfigured API-key provider would add unnecessary latency
+            # (network round-trip per provider) on the Settings page.
             try:
                 from hermes_cli.auth import get_auth_status as _gas
                 status = _gas(pid)

--- a/api/providers.py
+++ b/api/providers.py
@@ -51,8 +51,10 @@ _PROVIDER_ENV_VAR: dict[str, str] = {
 # through the Hermes CLI, not via API keys.  The WebUI cannot set these.
 _OAUTH_PROVIDERS = frozenset({
     "copilot",
-    "openai-codex",
+    "copilot-acp",
     "nous",
+    "openai-codex",
+    "qwen-oauth",
 })
 
 # SECTION: Helper functions
@@ -309,6 +311,21 @@ def get_providers() -> dict[str, Any]:
                     key_source = "config_yaml"
             else:
                 key_source = "config_yaml"
+        else:
+            # Fallback: provider may be authenticated via hermes auth even
+            # though it is not in the hardcoded _OAUTH_PROVIDERS set
+            # (e.g. Anthropic connected via OAuth).  Check live auth
+            # status so the Providers tab agrees with the model picker
+            # (#1212).
+            try:
+                from hermes_cli.auth import get_auth_status as _gas
+                status = _gas(pid)
+                if isinstance(status, dict) and status.get("logged_in"):
+                    has_key = True
+                    key_source = status.get("key_source", "oauth")
+                    is_oauth = True
+            except Exception:
+                pass
 
         models = _PROVIDER_MODELS.get(pid, [])
         # Also include models from config.yaml providers section

--- a/static/panels.js
+++ b/static/panels.js
@@ -2099,6 +2099,9 @@ async function switchToProfile(name) {
       // No messages yet — just refresh the list and topbar in place
       await renderSessionList();
       syncTopbar();
+      // Refresh workspace file tree so the right panel shows the new
+      // profile's workspace, not the previous one (#1214).
+      if (S.session && S.session.workspace) loadDir('.');
       showToast(t('profile_switched', name));
     }
 


### PR DESCRIPTION
## Summary

Two small fixes for recent bugs:

### #1214 - Workspace panel stale after profile switch (empty session)
When switching profiles on a session with no messages yet, the workspace file tree panel kept showing files from the previous profile workspace.

Fix: Added loadDir('.') call in switchToProfile() Case B (S.messages.length === 0) so the workspace panel refreshes to show the new profile files.

### #1212 - OAuth providers show as unconfigured in Settings
Some OAuth/token-based providers were missing from the hardcoded _OAUTH_PROVIDERS set (copilot-acp, qwen-oauth). More importantly, providers authenticated via hermes auth (e.g. Anthropic via OAuth) that are not in the set were never detected.

Fix:
- Expanded _OAUTH_PROVIDERS with copilot-acp and qwen-oauth
- Added a fallback in get_providers() that calls get_auth_status() live for providers with no API key and not in the hardcoded set

## Test results
85 passed - provider + profile switch tests
JS syntax check: OK
Python compile: OK