### PR TITLE
feat: inline diff/patch viewer (#483)

### DIFF
--- a/static/i18n.js
+++ b/static/i18n.js
@@ -27,6 +27,8 @@ const LOCALES = {
     copy_failed: 'Copy failed',
 
     diff_loading: 'Loading diff',
+    diff_error: 'Could not load patch file',
+    diff_too_large: 'Patch file too large to display inline',
     you: 'You',
     thinking: 'Thinking',
     expand_all: 'Expand all',
@@ -699,6 +701,8 @@ const LOCALES = {
     copy_failed: '\u041e\u0448\u0438\u0431\u043a\u0430 \u043a\u043e\u043f\u0438\u0440\u043e\u0432\u0430\u043d\u0438\u044f',
 
     diff_loading: 'Загрузка diff',
+    diff_error: 'Не удалось загрузить файл патча',
+    diff_too_large: 'Файл патча слишком большой для отображения',
     you: 'Вы',
     thinking: 'Думаю',
     expand_all: 'Развернуть всё',
@@ -1320,6 +1324,8 @@ const LOCALES = {
     copy_failed: 'Error al copiar',
 
     diff_loading: 'Cargando diff',
+    diff_error: 'No se pudo cargar el archivo de parche',
+    diff_too_large: 'Archivo de parche demasiado grande para mostrar',
     you: 'Tú',
     thinking: 'Pensando',
     expand_all: 'Expandir todo',
@@ -1933,6 +1939,8 @@ const LOCALES = {
     copy_failed: 'Kopieren fehlgeschlagen',
 
     diff_loading: 'Lade Diff',
+    diff_error: 'Patch-Datei konnte nicht geladen werden',
+    diff_too_large: 'Patch-Datei zu groß für Inline-Anzeige',
     you: 'Du',
     thinking: 'Nachdenken',
     expand_all: 'Alle ausklappen',
@@ -2320,6 +2328,8 @@ const LOCALES = {
     copy_failed: '\u590d\u5236\u5931\u8d25',
 
     diff_loading: '加载 diff',
+    diff_error: '无法加载 patch 文件',
+    diff_too_large: 'Patch 文件过大，无法内联显示',
     you: '\u4f60',
     thinking: '\u601d\u8003\u8fc7\u7a0b',
     expand_all: '\u5168\u90e8\u5c55\u5f00',
@@ -2931,6 +2941,8 @@ const LOCALES = {
     copy_failed: '\u8907\u88fd\u5931\u6557',
 
     diff_loading: '載入 diff',
+    diff_error: '無法載入 patch 檔案',
+    diff_too_large: 'Patch 檔案過大，無法內聯顯示',
     you: '\u4f60',
     thinking: '\u601d\u8003\u904e\u7a0b',
     expand_all: '\u5168\u90e8\u5c55\u958b',
@@ -3591,6 +3603,8 @@ const LOCALES = {
     copy_failed: '복사 실패',
 
     diff_loading: 'diff 불러오는 중',
+    diff_error: '패치 파일을 로드할 수 없습니다',
+    diff_too_large: '패치 파일이 너무 커서 인라인으로 표시할 수 없습니다',
     you: '나',
     thinking: '생각 중',
     expand_all: '모두 펼치기',

--- a/static/i18n.js
+++ b/static/i18n.js
@@ -25,6 +25,8 @@ const LOCALES = {
     copy: 'Copy',
     copied: 'Copied!',
     copy_failed: 'Copy failed',
+
+    diff_loading: 'Loading diff',
     you: 'You',
     thinking: 'Thinking',
     expand_all: 'Expand all',
@@ -695,6 +697,8 @@ const LOCALES = {
     copy: 'Копировать',
     copied: 'Скопировано!',
     copy_failed: '\u041e\u0448\u0438\u0431\u043a\u0430 \u043a\u043e\u043f\u0438\u0440\u043e\u0432\u0430\u043d\u0438\u044f',
+
+    diff_loading: 'Загрузка diff',
     you: 'Вы',
     thinking: 'Думаю',
     expand_all: 'Развернуть всё',
@@ -1314,6 +1318,8 @@ const LOCALES = {
     copy: 'Copiar',
     copied: '¡Copiado!',
     copy_failed: 'Error al copiar',
+
+    diff_loading: 'Cargando diff',
     you: 'Tú',
     thinking: 'Pensando',
     expand_all: 'Expandir todo',
@@ -1925,6 +1931,8 @@ const LOCALES = {
     copy: 'Kopieren',
     copied: 'Kopiert!',
     copy_failed: 'Kopieren fehlgeschlagen',
+
+    diff_loading: 'Lade Diff',
     you: 'Du',
     thinking: 'Nachdenken',
     expand_all: 'Alle ausklappen',
@@ -2310,6 +2318,8 @@ const LOCALES = {
     copy: '\u590d\u5236',
     copied: '\u5df2\u590d\u5236',
     copy_failed: '\u590d\u5236\u5931\u8d25',
+
+    diff_loading: '加载 diff',
     you: '\u4f60',
     thinking: '\u601d\u8003\u8fc7\u7a0b',
     expand_all: '\u5168\u90e8\u5c55\u5f00',
@@ -2919,6 +2929,8 @@ const LOCALES = {
     copy: '\u8907\u88fd',
     copied: '\u5df2\u8907\u88fd',
     copy_failed: '\u8907\u88fd\u5931\u6557',
+
+    diff_loading: '載入 diff',
     you: '\u4f60',
     thinking: '\u601d\u8003\u904e\u7a0b',
     expand_all: '\u5168\u90e8\u5c55\u958b',
@@ -3577,6 +3589,8 @@ const LOCALES = {
     copy: '복사',
     copied: '복사됨!',
     copy_failed: '복사 실패',
+
+    diff_loading: 'diff 불러오는 중',
     you: '나',
     thinking: '생각 중',
     expand_all: '모두 펼치기',

--- a/static/style.css
+++ b/static/style.css
@@ -603,6 +603,15 @@
   .pre-header{font-size:10px;font-weight:600;text-transform:uppercase;letter-spacing:.06em;color:var(--muted);padding:8px 16px 8px;background:var(--input-bg);border-radius:10px 10px 0 0;border:1px solid var(--border);border-bottom:1px solid var(--border);display:flex;align-items:center;gap:6px;}
   .pre-header::before{content:'';width:8px;height:8px;border-radius:50%;background:var(--muted);opacity:.4;}
   .pre-header+pre{border-radius:0 0 10px 10px;border-top:none;margin-top:0;}
+  /* Diff/patch viewer */
+  .diff-block{margin:0;counter-reset:diff-line;}
+  .diff-block .diff-line{display:block;padding:0 16px;min-height:1.4em;white-space:pre;}
+  .diff-block .diff-plus{background:rgba(34,197,94,.1);color:#22c55e;}
+  .diff-block .diff-minus{background:rgba(239,68,68,.1);color:#ef4444;}
+  .diff-block .diff-hunk{color:var(--muted);font-style:italic;background:rgba(99,102,241,.06);}
+  .diff-inline-load{color:var(--muted);font-size:13px;padding:8px 12px;border:1px dashed var(--border);border-radius:8px;margin:6px 0;}
+  .diff-inline{margin:6px 0;}
+  .diff-inline-error{color:#ef4444;font-size:13px;padding:8px 12px;border:1px solid rgba(239,68,68,.2);border-radius:8px;margin:6px 0;}
   .msg-body blockquote{border-left:3px solid var(--blue);padding-left:14px;color:var(--muted);font-style:italic;margin:10px 0;}
   .msg-body blockquote p{margin:0;}
   .msg-body a{color:var(--blue);text-decoration:underline;}

--- a/static/ui.js
+++ b/static/ui.js
@@ -845,7 +845,18 @@ function renderMd(raw){
       const code=m?m[2]:raw.replace(/^\n?/,'');
       const h=lang?`<div class="pre-header">${esc(lang)}</div>`:'';
       const langAttr=lang?` class="language-${esc(lang)}"`:'';
-      _preBlock_stash.push(`${h}<pre><code${langAttr}>${esc(code.replace(/\n$/,''))}</code></pre>`);
+      // For diff/patch blocks, wrap each line in a colored span
+      if(lang==='diff'||lang==='patch'){
+        const colored=esc(code.replace(/\n$/,'')).split('\n').map(line=>{
+          if(line.startsWith('@@')) return `<span class="diff-line diff-hunk">${line}</span>`;
+          if(line.startsWith('+')) return `<span class="diff-line diff-plus">${line}</span>`;
+          if(line.startsWith('-')) return `<span class="diff-line diff-minus">${line}</span>`;
+          return `<span class="diff-line">${line}</span>`;
+        }).join('\n');
+        _preBlock_stash.push(`${h}<pre class="diff-block"><code${langAttr}>${colored}</code></pre>`);
+      } else {
+        _preBlock_stash.push(`${h}<pre><code${langAttr}>${esc(code.replace(/\n$/,''))}</code></pre>`);
+      }
     }
     return '\x00P'+(_preBlock_stash.length-1)+'\x00';
   });
@@ -1130,6 +1141,10 @@ function renderMd(raw){
     }
     // Non-image local file — show download link with filename
     const fname=esc(ref.split('/').pop()||ref);
+    // .patch/.diff files → render inline as colored diff instead of download
+    if(/\.(patch|diff)$/i.test(ref)){
+      return `<div class="diff-inline-load" data-path="${esc(ref)}">${t('diff_loading')} ${fname}...</div>`;
+    }
     return `<a class="msg-media-link" href="${esc(apiUrl+'&download=1')}" download="${fname}">📎 ${fname}</a>`;
   });
   // ── End MEDIA restore ──────────────────────────────────────────────────────
@@ -2330,7 +2345,7 @@ function renderMessages(){
       inner.innerHTML=cached.html;
       _sessionHtmlCacheSid=sid;
       if(S.activeStreamId){scrollIfPinned();}else{scrollToBottom();}
-      requestAnimationFrame(()=>{highlightCode();addCopyButtons();renderMermaidBlocks();renderKatexBlocks();});
+      requestAnimationFrame(()=>{highlightCode();addCopyButtons();loadDiffInline();renderMermaidBlocks();renderKatexBlocks();});
       if(typeof loadTodos==='function'&&document.getElementById('panelTodos')&&document.getElementById('panelTodos').classList.contains('active')){loadTodos();}
       return;
     }
@@ -2721,7 +2736,7 @@ function renderMessages(){
     scrollToBottom();
   }
   // Apply syntax highlighting after DOM is built
-  requestAnimationFrame(()=>{highlightCode();addCopyButtons();renderMermaidBlocks();renderKatexBlocks();});
+  requestAnimationFrame(()=>{highlightCode();addCopyButtons();loadDiffInline();renderMermaidBlocks();renderKatexBlocks();});
   // Refresh todo panel if it's currently open
   if(typeof loadTodos==='function' && document.getElementById('panelTodos') && document.getElementById('panelTodos').classList.contains('active')){
     loadTodos();
@@ -3010,6 +3025,28 @@ function addCopyButtons(container){
 
 let _mermaidLoading=false;
 let _mermaidReady=false;
+
+function loadDiffInline(){
+  document.querySelectorAll('.diff-inline-load:not([data-loaded])').forEach(el=>{
+    el.setAttribute('data-loaded','1');
+    const path=el.dataset.path;
+    fetch('api/media?path='+encodeURIComponent(path))
+      .then(r=>{if(!r.ok) throw new Error(r.status);return r.text();})
+      .then(text=>{
+        const lines=text.split('\n').map(line=>{
+          const e=esc(line);
+          if(e.startsWith('@@')) return `<span class="diff-line diff-hunk">${e}</span>`;
+          if(e.startsWith('+')) return `<span class="diff-line diff-plus">${e}</span>`;
+          if(e.startsWith('-')) return `<span class="diff-line diff-minus">${e}</span>`;
+          return `<span class="diff-line">${e}</span>`;
+        }).join('\n');
+        el.outerHTML=`<div class="diff-inline"><div class="pre-header">${esc(path.split('/').pop())}</div><pre class="diff-block"><code>${lines}</code></pre></div>`;
+      })
+      .catch(()=>{
+        el.outerHTML=`<div class="diff-inline-error">${esc(path.split('/').pop())}</div>`;
+      });
+  });
+}
 
 function renderMermaidBlocks(){
   const blocks=document.querySelectorAll('.mermaid-block:not([data-rendered])');

--- a/static/ui.js
+++ b/static/ui.js
@@ -3027,12 +3027,17 @@ let _mermaidLoading=false;
 let _mermaidReady=false;
 
 function loadDiffInline(){
+  const DIFF_MAX_SIZE=512*1024; // 512 KB cap for inline diff rendering
   document.querySelectorAll('.diff-inline-load:not([data-loaded])').forEach(el=>{
     el.setAttribute('data-loaded','1');
     const path=el.dataset.path;
     fetch('api/media?path='+encodeURIComponent(path))
       .then(r=>{if(!r.ok) throw new Error(r.status);return r.text();})
       .then(text=>{
+        if(text.length>DIFF_MAX_SIZE){
+          el.outerHTML=`<div class="diff-inline-error">${esc(path.split('/').pop())}<br><span style="color:var(--muted);font-size:12px">${t('diff_too_large')}</span></div>`;
+          return;
+        }
         const lines=text.split('\n').map(line=>{
           const e=esc(line);
           if(e.startsWith('@@')) return `<span class="diff-line diff-hunk">${e}</span>`;
@@ -3043,7 +3048,7 @@ function loadDiffInline(){
         el.outerHTML=`<div class="diff-inline"><div class="pre-header">${esc(path.split('/').pop())}</div><pre class="diff-block"><code>${lines}</code></pre></div>`;
       })
       .catch(()=>{
-        el.outerHTML=`<div class="diff-inline-error">${esc(path.split('/').pop())}</div>`;
+        el.outerHTML=`<div class="diff-inline-error">${esc(path.split('/').pop())}<br><span style="color:var(--muted);font-size:12px">${t('diff_error')}</span></div>`;
       });
   });
 }

--- a/tests/test_issue483_inline_diff_viewer.py
+++ b/tests/test_issue483_inline_diff_viewer.py
@@ -1,0 +1,100 @@
+"""Tests for issue #483 — inline diff/patch viewer."""
+import pytest
+
+
+class TestFencedDiffRenderer:
+    """Fenced ```diff blocks should render with colored line spans."""
+
+    def test_diff_block_has_diff_block_class(self):
+        """diff blocks should get a 'diff-block' class on <pre>."""
+        with open("static/ui.js", "r", encoding="utf-8") as f:
+            content = f.read()
+        assert "diff-block" in content, "Missing diff-block class"
+        # Should be in the fenced block renderer
+        assert "pre class=\"diff-block\"" in content
+
+    def test_diff_lines_get_span_classes(self):
+        """Each diff line should be wrapped in a span with appropriate class."""
+        with open("static/ui.js", "r", encoding="utf-8") as f:
+            content = f.read()
+        assert "diff-line diff-plus" in content
+        assert "diff-line diff-minus" in content
+        assert "diff-line diff-hunk" in content
+
+    def test_diff_lang_detection(self):
+        """Both 'diff' and 'patch' language hints should trigger diff rendering."""
+        with open("static/ui.js", "r", encoding="utf-8") as f:
+            content = f.read()
+        assert "lang==='diff'||lang==='patch'" in content
+
+    def test_diff_line_escape(self):
+        """Diff lines must be HTML-escaped (using esc() function)."""
+        with open("static/ui.js", "r", encoding="utf-8") as f:
+            content = f.read()
+        # In the fenced diff block renderer, lines should be escaped
+        # Check the pattern: esc(code...).split('\\n').map
+        assert "esc(code.replace" in content
+
+
+class TestMediaDiffInline:
+    """MEDIA: .patch/.diff files should render inline instead of download."""
+
+    def test_patch_extension_detected(self):
+        """.patch and .diff extensions should trigger inline rendering."""
+        with open("static/ui.js", "r", encoding="utf-8") as f:
+            content = f.read()
+        assert "\\.(patch|diff)$" in content
+
+    def test_diff_inline_load_placeholder(self):
+        """Should emit a placeholder div while loading."""
+        with open("static/ui.js", "r", encoding="utf-8") as f:
+            content = f.read()
+        assert "diff-inline-load" in content
+        assert "data-path" in content
+
+    def test_loadDiffInline_function_exists(self):
+        """loadDiffInline() function should be defined."""
+        with open("static/ui.js", "r", encoding="utf-8") as f:
+            content = f.read()
+        assert "function loadDiffInline()" in content
+
+    def test_loadDiffInline_called_in_post_render(self):
+        """loadDiffInline() should be called in post-render (after addCopyButtons)."""
+        with open("static/ui.js", "r", encoding="utf-8") as f:
+            content = f.read()
+        count = content.count("loadDiffInline()")
+        assert count >= 2, f"loadDiffInline() called {count} times, expected >= 2 (cached + fresh render)"
+
+    def test_diff_inline_error_class(self):
+        """Should have error state class."""
+        with open("static/ui.js", "r", encoding="utf-8") as f:
+            content = f.read()
+        assert "diff-inline-error" in content
+
+
+class TestDiffCSS:
+    """CSS classes for diff coloring."""
+
+    def test_diff_css_classes_exist(self):
+        with open("static/style.css", "r", encoding="utf-8") as f:
+            content = f.read()
+        for cls in (".diff-block", ".diff-line", ".diff-plus", ".diff-minus",
+                    ".diff-hunk", ".diff-inline-load", ".diff-inline", ".diff-inline-error"):
+            assert cls in content, f"Missing CSS class: {cls}"
+
+    def test_diff_colors_are_present(self):
+        """Green for plus, red for minus should use rgba colors."""
+        with open("static/style.css", "r", encoding="utf-8") as f:
+            content = f.read()
+        assert "rgba(34,197,94" in content or "#22c55e" in content, "Missing green color for diff-plus"
+        assert "rgba(239,68,68" in content or "#ef4444" in content, "Missing red color for diff-minus"
+
+
+class TestDiffI18n:
+    """i18n keys for diff viewer."""
+
+    def test_diff_loading_key_in_all_locales(self):
+        with open("static/i18n.js", "r", encoding="utf-8") as f:
+            content = f.read()
+        count = content.count("diff_loading")
+        assert count == 7, f"diff_loading found {count} times, expected 7"


### PR DESCRIPTION
## Summary

Renders git diffs and patches with colored lines inside chat messages.

## Two surfaces

### 1. Fenced diff blocks
When the agent outputs a fenced code block with language hint `diff` or `patch`, each line is wrapped in a colored span:
- `-` lines: red background
- `+` lines: green background
- `@@` hunk headers: muted italic with subtle blue background
- Context lines: normal

### 2. MEDIA: .patch/.diff files
When the agent saves a `.patch` or `.diff` file and outputs `MEDIA:/path/to/file.patch`, the file content is fetched via `api/media?path=` and rendered inline with the same coloring. A placeholder is shown while loading; an error state is shown if the fetch fails.

## Changes
- `static/ui.js`: diff line coloring in fenced block renderer + `loadDiffInline()` async fetch + post-render integration
- `static/style.css`: diff-block, diff-line, diff-plus/minus/hunk CSS classes
- `static/i18n.js`: `diff_loading` key in all 7 locales

## Tests (12)
- 4 renderer tests (diff-block class, span classes, lang detection, HTML escaping)
- 5 MEDIA inline tests (extension detection, placeholder, function existence, post-render calls, error class)
- 2 CSS tests (class existence, color values)
- 1 i18n test (key parity across 7 locales)

All pass: 2848 passed (1 pre-existing failure in test_sprint31).

Closes #483