### PR TITLE
fix(models): preserve /api/models cache metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## [Unreleased]
 
 ### Fixed
+- **Model catalog disk cache metadata** — `/api/models` disk-cache hits now
+  preserve `active_provider` and `default_model` alongside provider groups.
+  Legacy cache files that only contain `groups` are ignored and rebuilt, so
+  the frontend does not lose the configured provider/default-model source of
+  truth after restart. (`api/config.py`, `tests/test_model_cache_metadata.py`)
 - **Auto-title generic fallback** — when the auxiliary title-generation call
   fails and the local fallback can only produce the generic label
   `Conversation topic`, the WebUI now keeps the existing provisional title

--- a/api/config.py
+++ b/api/config.py
@@ -1120,15 +1120,29 @@ def _delete_models_cache_on_disk() -> None:
         pass  # already absent
 
 
+def _is_valid_models_cache(cache: object) -> bool:
+    """Return True when a disk cache payload has the full /api/models shape."""
+    if not isinstance(cache, dict):
+        return False
+    if not {"active_provider", "default_model", "groups"}.issubset(cache):
+        return False
+    active_provider = cache.get("active_provider")
+    return (
+        (active_provider is None or isinstance(active_provider, str))
+        and isinstance(cache.get("default_model"), str)
+        and isinstance(cache.get("groups"), list)
+    )
+
+
 def _load_models_cache_from_disk() -> dict | None:
-    """Load groups dict from disk cache if it exists and is valid."""
+    """Load /api/models cache from disk if it exists and has current metadata."""
     try:
         import json as _j
         if not _models_cache_path.exists():
             return None
         with open(_models_cache_path, encoding="utf-8") as f:
             cache = _j.load(f)
-        return cache if isinstance(cache, dict) and "groups" in cache else None
+        return cache if _is_valid_models_cache(cache) else None
     except Exception:
         return None
 
@@ -1136,10 +1150,19 @@ def _load_models_cache_from_disk() -> dict | None:
 def _save_models_cache_to_disk(cache: dict) -> None:
     """Save cache to disk so it survives server restarts."""
     try:
-        import time as _cache_time
+        if not _is_valid_models_cache(cache):
+            return
         tmp = str(_models_cache_path) + f".{os.getpid()}.tmp"
         with open(tmp, "w", encoding="utf-8") as f:
-            json.dump({"groups": cache.get("groups", [])}, f, indent=2)
+            json.dump(
+                {
+                    "active_provider": cache["active_provider"],
+                    "default_model": cache["default_model"],
+                    "groups": cache["groups"],
+                },
+                f,
+                indent=2,
+            )
         os.rename(tmp, str(_models_cache_path))
     except Exception:
         pass  # Non-fatal -- cache will rebuild on next call

--- a/api/config.py
+++ b/api/config.py
@@ -1138,6 +1138,7 @@ def _load_models_cache_from_disk() -> dict | None:
     """Load /api/models cache from disk if it exists and has current metadata."""
     try:
         import json as _j
+
         if not _models_cache_path.exists():
             return None
         with open(_models_cache_path, encoding="utf-8") as f:
@@ -1166,6 +1167,20 @@ def _save_models_cache_to_disk(cache: dict) -> None:
         os.rename(tmp, str(_models_cache_path))
     except Exception:
         pass  # Non-fatal -- cache will rebuild on next call
+
+
+def _get_fresh_memory_models_cache(now: float) -> dict | None:
+    """Return a valid fresh in-memory /api/models cache, or clear stale shapes."""
+    global _available_models_cache, _available_models_cache_ts
+    if _available_models_cache is None:
+        return None
+    if (now - _available_models_cache_ts) >= _AVAILABLE_MODELS_CACHE_TTL:
+        return None
+    if _is_valid_models_cache(_available_models_cache):
+        return copy.deepcopy(_available_models_cache)
+    _available_models_cache = None
+    _available_models_cache_ts = 0.0
+    return None
 
 
 def invalidate_models_cache():
@@ -1799,19 +1814,22 @@ def get_available_models() -> dict:
                 lambda: not _cache_build_in_progress and _available_models_cache is not None,
                 timeout=60
             )
-            if _available_models_cache is not None and (time.monotonic() - _available_models_cache_ts) < _AVAILABLE_MODELS_CACHE_TTL:
-                return copy.deepcopy(_available_models_cache)
+            cached = _get_fresh_memory_models_cache(time.monotonic())
+            if cached is not None:
+                return cached
 
         # Reload config if changed
         if _cfg_changed:
             reload_config()
             _available_models_cache = None
             _available_models_cache_ts = 0.0
+            disk_groups = None
 
         # Serve from memory cache if fresh
         now = time.monotonic()
-        if _available_models_cache is not None and (now - _available_models_cache_ts) < _AVAILABLE_MODELS_CACHE_TTL:
-            return copy.deepcopy(_available_models_cache)
+        cached = _get_fresh_memory_models_cache(now)
+        if cached is not None:
+            return cached
 
         # Cold path: disk cache hit — use it (fast, no lock contention)
         if disk_groups is not None:

--- a/tests/test_model_cache_metadata.py
+++ b/tests/test_model_cache_metadata.py
@@ -1,6 +1,7 @@
 """Regression tests for /api/models disk cache metadata."""
 
 import json
+import time
 
 import api.config as config
 
@@ -54,6 +55,116 @@ def test_load_models_cache_from_disk_rejects_legacy_groups_only_cache(tmp_path, 
     )
 
     assert config._load_models_cache_from_disk() is None
+
+
+def test_load_models_cache_from_disk_rejects_partial_metadata_cache(
+    tmp_path,
+    monkeypatch,
+):
+    cache_path = tmp_path / "models_cache.json"
+    monkeypatch.setattr(config, "_models_cache_path", cache_path)
+
+    valid_payload = {
+        "active_provider": "openai",
+        "default_model": "gpt-5.4-mini",
+        "groups": [
+            {
+                "provider": "OpenAI",
+                "provider_id": "openai",
+                "models": [{"id": "gpt-5.4-mini", "label": "GPT 5.4 Mini"}],
+            }
+        ],
+    }
+
+    invalid_payloads = [
+        {key: value for key, value in valid_payload.items() if key != "active_provider"},
+        {key: value for key, value in valid_payload.items() if key != "default_model"},
+        {key: value for key, value in valid_payload.items() if key != "groups"},
+        {**valid_payload, "active_provider": 123},
+        {**valid_payload, "default_model": None},
+        {**valid_payload, "groups": {}},
+    ]
+
+    for payload in invalid_payloads:
+        cache_path.write_text(json.dumps(payload), encoding="utf-8")
+        assert config._load_models_cache_from_disk() is None
+
+
+def test_get_available_models_ignores_invalid_ttl_memory_cache(monkeypatch):
+    _reset_memory_cache()
+
+    stale_cache = {
+        "groups": [
+            {
+                "provider": "Stale",
+                "provider_id": "stale",
+                "models": [{"id": "stale-model", "label": "Stale Model"}],
+            }
+        ]
+    }
+
+    saved_mtime = config._cfg_mtime
+    try:
+        with config._available_models_cache_lock:
+            config._available_models_cache = stale_cache
+            config._available_models_cache_ts = time.monotonic()
+
+        try:
+            config._cfg_mtime = config.Path(config._get_config_path()).stat().st_mtime
+        except OSError:
+            config._cfg_mtime = 0.0
+
+        result = config.get_available_models()
+    finally:
+        config._cfg_mtime = saved_mtime
+        _reset_memory_cache()
+
+    assert "active_provider" in result
+    assert "default_model" in result
+    assert "groups" in result
+    assert not any(group.get("provider") == "Stale" for group in result["groups"])
+
+
+def test_get_available_models_does_not_use_disk_cache_after_config_mtime_change(
+    tmp_path,
+    monkeypatch,
+):
+    cache_path = tmp_path / "models_cache.json"
+    monkeypatch.setattr(config, "_models_cache_path", cache_path)
+    cache_path.write_text(
+        json.dumps(
+            {
+                "active_provider": "stale-provider",
+                "default_model": "stale-model",
+                "groups": [
+                    {
+                        "provider": "Stale",
+                        "provider_id": "stale",
+                        "models": [{"id": "stale-model", "label": "Stale Model"}],
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    _reset_memory_cache()
+
+    saved_mtime = config._cfg_mtime
+    try:
+        config._cfg_mtime = -1.0
+        result = config.get_available_models()
+    finally:
+        config._cfg_mtime = saved_mtime
+        _reset_memory_cache()
+
+    assert result["active_provider"] != "stale-provider"
+    assert result["default_model"] != "stale-model"
+    assert not any(group.get("provider") == "Stale" for group in result["groups"])
+
+    written = json.loads(cache_path.read_text(encoding="utf-8"))
+    assert written["active_provider"] != "stale-provider"
+    assert written["default_model"] != "stale-model"
+    assert not any(group.get("provider") == "Stale" for group in written["groups"])
 
 
 def test_get_available_models_ignores_legacy_disk_cache_and_rebuilds(

--- a/tests/test_model_cache_metadata.py
+++ b/tests/test_model_cache_metadata.py
@@ -1,0 +1,101 @@
+"""Regression tests for /api/models disk cache metadata."""
+
+import json
+
+import api.config as config
+
+
+def _reset_memory_cache() -> None:
+    with config._available_models_cache_lock:
+        config._available_models_cache = None
+        config._available_models_cache_ts = 0.0
+        config._cache_build_in_progress = False
+        config._cache_build_cv.notify_all()
+
+
+def test_save_models_cache_to_disk_preserves_response_metadata(tmp_path, monkeypatch):
+    cache_path = tmp_path / "models_cache.json"
+    monkeypatch.setattr(config, "_models_cache_path", cache_path)
+
+    payload = {
+        "active_provider": "openai",
+        "default_model": "gpt-5.4-mini",
+        "groups": [
+            {
+                "provider": "OpenAI",
+                "provider_id": "openai",
+                "models": [{"id": "gpt-5.4-mini", "label": "GPT 5.4 Mini"}],
+            }
+        ],
+    }
+
+    config._save_models_cache_to_disk(payload)
+
+    assert json.loads(cache_path.read_text(encoding="utf-8")) == payload
+    assert config._load_models_cache_from_disk() == payload
+
+
+def test_load_models_cache_from_disk_rejects_legacy_groups_only_cache(tmp_path, monkeypatch):
+    cache_path = tmp_path / "models_cache.json"
+    monkeypatch.setattr(config, "_models_cache_path", cache_path)
+    cache_path.write_text(
+        json.dumps(
+            {
+                "groups": [
+                    {
+                        "provider": "Legacy",
+                        "provider_id": "legacy",
+                        "models": [{"id": "legacy-model", "label": "Legacy Model"}],
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert config._load_models_cache_from_disk() is None
+
+
+def test_get_available_models_ignores_legacy_disk_cache_and_rebuilds(
+    tmp_path,
+    monkeypatch,
+):
+    cache_path = tmp_path / "models_cache.json"
+    monkeypatch.setattr(config, "_models_cache_path", cache_path)
+    cache_path.write_text(
+        json.dumps(
+            {
+                "groups": [
+                    {
+                        "provider": "Legacy",
+                        "provider_id": "legacy",
+                        "models": [{"id": "legacy-model", "label": "Legacy Model"}],
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    _reset_memory_cache()
+
+    saved_mtime = config._cfg_mtime
+    try:
+        try:
+            config._cfg_mtime = config.Path(config._get_config_path()).stat().st_mtime
+        except OSError:
+            config._cfg_mtime = 0.0
+
+        result = config.get_available_models()
+    finally:
+        config._cfg_mtime = saved_mtime
+        _reset_memory_cache()
+
+    assert "active_provider" in result
+    assert "default_model" in result
+    assert "groups" in result
+    assert not any(group.get("provider") == "Legacy" for group in result["groups"])
+
+    written = json.loads(cache_path.read_text(encoding="utf-8"))
+    assert "active_provider" in written
+    assert "default_model" in written
+    assert "groups" in written


### PR DESCRIPTION
## Thinking Path

- Hermes WebUI uses `/api/models` as more than a display list: the frontend reads it for provider identity, the configured default model, live-model enrichment, and model mismatch checks.
- The cold model catalog build returns the full shape: `active_provider`, `default_model`, and `groups`.
- The disk cache only persisted `groups`, and the load path accepted any cache with `groups` as valid.
- That meant a disk-cache hit could serve an incomplete `/api/models` payload even though `config.yaml`, `/api/settings`, and `/api/providers` still had the correct provider/default-model state.
- This PR fixes the cache schema at the backend source-of-truth layer so cached model catalogs keep the metadata the frontend depends on.

## What Changed

- Added validation for the `/api/models` disk-cache payload shape.
- Disk cache is now valid only when it includes:
  - `active_provider`
  - `default_model`
  - `groups`
- Legacy `groups`-only cache files are rejected and rebuilt instead of being served.
- The cache write path now preserves the full metadata payload instead of writing only `groups`.
- Added focused regression coverage for:
  - preserving metadata when saving cache
  - rejecting legacy `groups`-only cache files
  - rebuilding through `get_available_models()` instead of returning the legacy cache
- Added an Unreleased changelog entry.

## Why It Matters

Without this metadata, the frontend can lose the configured model/provider source of truth and fall back to weaker state such as the current dropdown value, stale localStorage, or static picker ordering.

This is intentionally a small reliability fix. It does not redesign the model picker or provider settings; it makes the existing `/api/models` contract stable across restarts and disk-cache hits.

## Verification

- `python -m pytest tests/test_model_cache_metadata.py`
- `python -m pytest tests/test_sprint11.py tests/test_ttl_cache.py tests/test_profile_switch_1200.py`
- `python -m py_compile api/config.py`
- `git diff --check`

## Risks / Follow-ups

- This does not address duplicate model IDs across providers; that is covered by #1228 / #1231.
- This does not add dynamic Hermes Agent-backed model discovery for providers missing from WebUI's static catalog; that is discussed in #1236.
- External config-file changes versus disk-cache freshness remain a broader source-of-truth topic, but this PR keeps scope limited to the confirmed metadata-loss bug.

## Model Used

OpenAI Codex, GPT-5. AI-assisted implementation with a delegated worker sub-agent, followed by coordinator review and verification.
