### PR TITLE
fix: trust custom provider base_url in SSRF validation

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -1524,6 +1524,11 @@ def get_available_models() -> dict:
                 # Build set of hostnames from custom_providers config — these are
                 # user-explicitly configured endpoints and should not be blocked by SSRF.
                 _ssrf_trusted_hosts: set[str] = set()
+                # Also trust the base_url from model config (explicitly configured by user)
+                if cfg_base_url:
+                    _base_parsed = urlparse(cfg_base_url if "://" in cfg_base_url else f"http://{cfg_base_url}")
+                    if _base_parsed.hostname:
+                        _ssrf_trusted_hosts.add(_base_parsed.hostname.lower())
                 _custom_providers_cfg = cfg.get("custom_providers", [])
                 if isinstance(_custom_providers_cfg, list):
                     for _cp in _custom_providers_cfg:


### PR DESCRIPTION
## Problem
When using custom providers with private IPs (like AxonHub on internal networks with IPv6 addresses), the SSRF protection incorrectly blocks API calls to the user's own configured endpoint.

This causes silent failures for:
- `/api/models` endpoint (returns empty list)
- `/v1/*` API calls to custom endpoints

## Root Cause
The SSRF protection in `api/config.py` builds a trusted hosts list from hardcoded providers and environment variables, but does not include the user-configured `model.base_url` from `config.yaml`.

When `base_url` points to a private IP (e.g., `fc03:1136:...` IPv6), the request is blocked by SSRF protection.

## Solution
Automatically add the `model.base_url` hostname to the SSRF trusted hosts list, since it's explicitly configured by the user in `config.yaml`.

## Changes
- Modified `api/config.py` to parse `model.base_url` and add its hostname to `_ssrf_trusted_hosts`
- Uses `urlparse` to safely extract hostname from the configured URL

## Testing
- Verified `/api/models` now returns the full model list when using custom providers with private IPs
- Confirmed SSRF protection still works for non-configured private IPs