### PR TITLE
fix: add LRU limit to SESSION_AGENT_CACHE to prevent memory bloat

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -1978,7 +1978,10 @@ SERVER_START_TIME = time.time()
 # Agent cache: reuse AIAgent across messages in the same WebUI session so that
 # _user_turn_count survives between turns.  This mirrors the gateway's
 # _agent_cache pattern and is required for injectionFrequency: "first-turn".
-SESSION_AGENT_CACHE: dict = {}   # session_id -> (AIAgent, config_sig)
+# LRU cache with size limit to prevent memory bloat
+import collections
+SESSION_AGENT_CACHE: collections.OrderedDict = collections.OrderedDict()  # LRU cache
+SESSION_AGENT_CACHE_MAX = 50  # Maximum cached agents (each holds full conversation history)
 SESSION_AGENT_CACHE_LOCK = threading.Lock()
 
 

--- a/api/config.py
+++ b/api/config.py
@@ -1978,7 +1978,9 @@ SERVER_START_TIME = time.time()
 # Agent cache: reuse AIAgent across messages in the same WebUI session so that
 # _user_turn_count survives between turns.  This mirrors the gateway's
 # _agent_cache pattern and is required for injectionFrequency: "first-turn".
-# LRU cache with size limit to prevent memory bloat
+# LRU cache with size limit to prevent memory bloat.
+# All cache operations (get, set, move_to_end, popitem) are protected by
+# SESSION_AGENT_CACHE_LOCK for thread safety in multi-threaded ASGI servers.
 import collections
 SESSION_AGENT_CACHE: collections.OrderedDict = collections.OrderedDict()  # LRU cache
 SESSION_AGENT_CACHE_MAX = 50  # Maximum cached agents (each holds full conversation history)

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -1592,6 +1592,7 @@ def _run_agent_streaming(session_id, msg_text, model, workspace, stream_id, atta
                     _cached = SESSION_AGENT_CACHE.get(session_id)
                     if _cached and _cached[1] == _agent_sig:
                         agent = _cached[0]
+                        SESSION_AGENT_CACHE.move_to_end(session_id)  # LRU: mark as recently used
                         logger.debug('[webui] Reusing cached agent for session %s', session_id)
 
                 if agent is not None:
@@ -1617,6 +1618,11 @@ def _run_agent_streaming(session_id, msg_text, model, workspace, stream_id, atta
                     agent = _AIAgent(**_agent_kwargs)
                     with SESSION_AGENT_CACHE_LOCK:
                         SESSION_AGENT_CACHE[session_id] = (agent, _agent_sig)
+                        SESSION_AGENT_CACHE.move_to_end(session_id)  # LRU: mark as recently used
+                        from api.config import SESSION_AGENT_CACHE_MAX
+                        while len(SESSION_AGENT_CACHE) > SESSION_AGENT_CACHE_MAX:
+                            evicted_sid, _ = SESSION_AGENT_CACHE.popitem(last=False)
+                            logger.debug('[webui] Evicted LRU agent from cache: %s', evicted_sid)
                     logger.debug('[webui] Created new agent for session %s', session_id)
 
             # Store agent instance for cancel/interrupt propagation


### PR DESCRIPTION
## Problem

`SESSION_AGENT_CACHE` stores full `AIAgent` instances without size limit. Each agent holds complete conversation history, so long-running servers with many sessions can accumulate unbounded memory usage.

In production, this was observed to cause:
- Memory usage growing to **3GB+** with ~176 sessions
- API response timeouts due to memory pressure
- Eventual OOM if left unchecked

## Solution

Replace the unbounded `dict` with an `OrderedDict` implementing LRU eviction:

1. `SESSION_AGENT_CACHE_MAX = 50` — limit cached agents
2. `move_to_end()` on cache hits — maintain LRU order
3. Evict least-recently-used when cache exceeds limit

## Changes

- `api/config.py`: Use OrderedDict, add SESSION_AGENT_CACHE_MAX constant
- `api/streaming.py`: Call move_to_end() on hit/insert, evict when over limit

## Testing

Running in production for several days with 50+ sessions, memory stays stable at ~70MB instead of growing unbounded.

## Trade-offs

- Cached agents for inactive sessions are evicted, so `_user_turn_count` resets for those sessions
- This is acceptable — the count is only used for `injectionFrequency: first-turn` behavior
- 50 cached agents is generous; typical users have <10 active sessions