### PR TITLE
[codex] fix profile terminal env keyword collision

### DIFF
--- a/api/streaming.py
+++ b/api/streaming.py
@@ -68,6 +68,22 @@ _API_SAFE_MSG_KEYS = {'role', 'content', 'tool_calls', 'tool_call_id', 'name', '
 _NATIVE_IMAGE_MAX_BYTES = 20 * 1024 * 1024
 
 
+def _build_agent_run_env(
+    profile_runtime_env: dict,
+    workspace: str,
+    session_id: str,
+    hermes_home: str,
+) -> dict:
+    env = dict(profile_runtime_env)
+    env.update({
+        'TERMINAL_CWD': workspace,
+        'HERMES_EXEC_ASK': '1',
+        'HERMES_SESSION_KEY': session_id,
+        'HERMES_HOME': hermes_home,
+    })
+    return env
+
+
 def _attachment_name(att) -> str:
     if isinstance(att, dict):
         return str(att.get('name') or att.get('filename') or att.get('path') or '').strip()
@@ -1419,13 +1435,13 @@ def _run_agent_streaming(session_id, msg_text, model, workspace, stream_id, atta
             _profile_home = os.environ.get('HERMES_HOME', '')
             _profile_runtime_env = {}
 
-        _set_thread_env(
-            **_profile_runtime_env,
-            TERMINAL_CWD=str(s.workspace),
-            HERMES_EXEC_ASK='1',
-            HERMES_SESSION_KEY=session_id,
-            HERMES_HOME=_profile_home,
+        _agent_run_env = _build_agent_run_env(
+            _profile_runtime_env,
+            str(s.workspace),
+            session_id,
+            _profile_home,
         )
+        _set_thread_env(**_agent_run_env)
         # Still set process-level env as fallback for tools that bypass thread-local
         # Acquire lock only for the env mutation, then release before the agent runs.
         # The finally block re-acquires to restore — keeping critical sections short

--- a/tests/test_profile_terminal_env.py
+++ b/tests/test_profile_terminal_env.py
@@ -51,5 +51,30 @@ def test_streaming_applies_profile_runtime_env_to_agent_run():
 
     assert "get_profile_runtime_env" in src
     assert "_profile_runtime_env" in src
+    assert "_set_thread_env(**_agent_run_env)" in src
     assert "old_profile_env" in src
     assert "os.environ.update(_profile_runtime_env)" in src
+
+
+def test_agent_run_env_overrides_profile_terminal_cwd_without_kwarg_collision():
+    from api.config import _clear_thread_env, _set_thread_env
+    from api.streaming import _build_agent_run_env
+
+    env = _build_agent_run_env(
+        {
+            "TERMINAL_CWD": "/profile/default/cwd",
+            "HERMES_HOME": "/profile/env/home",
+            "HERMES_MAX_ITERATIONS": "90",
+        },
+        "/session/workspace",
+        "session-123",
+        "/profile/home",
+    )
+
+    assert env["TERMINAL_CWD"] == "/session/workspace"
+    assert env["HERMES_HOME"] == "/profile/home"
+    assert env["HERMES_SESSION_KEY"] == "session-123"
+    assert env["HERMES_MAX_ITERATIONS"] == "90"
+
+    _set_thread_env(**env)
+    _clear_thread_env()


### PR DESCRIPTION
## Summary
- merge profile runtime env before calling `_set_thread_env`
- let the session workspace override `terminal.cwd` without passing duplicate `TERMINAL_CWD` kwargs
- add regression coverage for profile terminal cwd collisions

## Root cause
`get_profile_runtime_env()` maps `terminal.cwd` from `config.yaml` to `TERMINAL_CWD`. The streaming path then expanded that dict and also passed `TERMINAL_CWD=str(s.workspace)` explicitly into `_set_thread_env()`, which raises `TypeError: got multiple values for keyword argument 'TERMINAL_CWD'` before the agent starts.

## Validation
- `/home/lost9999/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_profile_terminal_env.py -q`
