### PR TITLE
fix: merge WebUI agent thread env before setting

### DIFF
--- a/api/streaming.py
+++ b/api/streaming.py
@@ -68,6 +68,23 @@ _API_SAFE_MSG_KEYS = {'role', 'content', 'tool_calls', 'tool_call_id', 'name', '
 _NATIVE_IMAGE_MAX_BYTES = 20 * 1024 * 1024
 
 
+def _build_agent_thread_env(profile_runtime_env: dict | None, workspace: str, session_id: str, profile_home: str) -> dict:
+    """Build thread-local agent env with per-run values overriding profile defaults.
+
+    Profile runtime env may include TERMINAL_CWD from config.yaml. Passing it as
+    **kwargs alongside an explicit TERMINAL_CWD raises TypeError before the
+    agent starts, so merge into one dict first and let the active workspace win.
+    """
+    env = dict(profile_runtime_env or {})
+    env.update({
+        'TERMINAL_CWD': str(workspace),
+        'HERMES_EXEC_ASK': '1',
+        'HERMES_SESSION_KEY': session_id,
+        'HERMES_HOME': profile_home,
+    })
+    return env
+
+
 def _attachment_name(att) -> str:
     if isinstance(att, dict):
         return str(att.get('name') or att.get('filename') or att.get('path') or '').strip()
@@ -1419,13 +1436,13 @@ def _run_agent_streaming(session_id, msg_text, model, workspace, stream_id, atta
             _profile_home = os.environ.get('HERMES_HOME', '')
             _profile_runtime_env = {}
 
-        _set_thread_env(
-            **_profile_runtime_env,
-            TERMINAL_CWD=str(s.workspace),
-            HERMES_EXEC_ASK='1',
-            HERMES_SESSION_KEY=session_id,
-            HERMES_HOME=_profile_home,
+        _thread_env = _build_agent_thread_env(
+            _profile_runtime_env,
+            str(s.workspace),
+            session_id,
+            _profile_home,
         )
+        _set_thread_env(**_thread_env)
         # Still set process-level env as fallback for tools that bypass thread-local
         # Acquire lock only for the env mutation, then release before the agent runs.
         # The finally block re-acquires to restore — keeping critical sections short

--- a/tests/test_profile_terminal_env.py
+++ b/tests/test_profile_terminal_env.py
@@ -1,4 +1,5 @@
 import os
+import re
 from pathlib import Path
 
 import yaml
@@ -53,3 +54,40 @@ def test_streaming_applies_profile_runtime_env_to_agent_run():
     assert "_profile_runtime_env" in src
     assert "old_profile_env" in src
     assert "os.environ.update(_profile_runtime_env)" in src
+
+
+def test_streaming_thread_env_allows_profile_terminal_cwd_override():
+    src = Path("api/streaming.py").read_text(encoding="utf-8")
+
+    assert "def _build_agent_thread_env" in src
+    assert "_thread_env = _build_agent_thread_env(" in src
+    assert "_set_thread_env(**_thread_env)" in src
+    assert "_set_thread_env(\n            **_profile_runtime_env,\n            TERMINAL_CWD" not in src
+
+    match = re.search(
+        r"(def _build_agent_thread_env\(.*?\n)(?=\ndef |\nclass )",
+        src,
+        re.DOTALL,
+    )
+    assert match, "_build_agent_thread_env not found in api/streaming.py"
+    ns: dict = {}
+    exec(compile(match.group(1), "<streaming_extract>", "exec"), ns)
+
+    env = ns["_build_agent_thread_env"](
+        {
+            "TERMINAL_CWD": "/profile/config/cwd",
+            "HERMES_EXEC_ASK": "0",
+            "HERMES_SESSION_KEY": "old-session",
+            "HERMES_HOME": "/old/profile/home",
+            "TERMINAL_ENV": "ssh",
+        },
+        "/active/workspace",
+        "active-session",
+        "/active/profile/home",
+    )
+
+    assert env["TERMINAL_CWD"] == "/active/workspace"
+    assert env["HERMES_EXEC_ASK"] == "1"
+    assert env["HERMES_SESSION_KEY"] == "active-session"
+    assert env["HERMES_HOME"] == "/active/profile/home"
+    assert env["TERMINAL_ENV"] == "ssh"


### PR DESCRIPTION
## Summary
- merge profile runtime env and per-run WebUI env before calling _set_thread_env
- let active workspace override profile TERMINAL_CWD while preserving profile terminal settings
- add regression coverage for duplicate TERMINAL_CWD handling

## Test Plan
- ~/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_profile_terminal_env.py -q
- ~/.hermes/hermes-agent/venv/bin/python -m pytest -q