### PR TITLE
Fix SSE disconnect leaks and resilient boot session list

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -18,6 +18,19 @@ from urllib.parse import parse_qs
 
 logger = logging.getLogger(__name__)
 
+# Treat stalled/closed HTTP clients as normal disconnects.  Long-lived SSE
+# connections often end this way when a browser tab sleeps, a phone switches
+# networks, or Tailscale leaves the socket half-closed.  If these bubble to the
+# request handler, the server logs 500s and can leave CLOSE-WAIT sockets around
+# until the OS-level timeout fires.
+_CLIENT_DISCONNECT_ERRORS = (
+    BrokenPipeError,
+    ConnectionResetError,
+    ConnectionAbortedError,
+    TimeoutError,
+    OSError,
+)
+
 # ── Cron run tracking ────────────────────────────────────────────────────────
 # Track job IDs currently being executed so the frontend can poll status.
 _RUNNING_CRON_JOBS: dict[str, float] = {}  # job_id → start_timestamp
@@ -2190,7 +2203,7 @@ def _handle_sse_stream(handler, parsed):
             _sse(handler, event, data)
             if event in ("stream_end", "error", "cancel"):
                 break
-    except (BrokenPipeError, ConnectionResetError):
+    except _CLIENT_DISCONNECT_ERRORS:
         pass
     return True
 
@@ -2392,7 +2405,7 @@ def _handle_gateway_sse_stream(handler, parsed):
             if event_data is None:
                 break  # watcher is stopping
             _sse(handler, event_data.get('type', 'sessions_changed'), event_data)
-    except (BrokenPipeError, ConnectionResetError, ConnectionAbortedError):
+    except _CLIENT_DISCONNECT_ERRORS:
         pass
     finally:
         watcher.unsubscribe(q)

--- a/server.py
+++ b/server.py
@@ -24,20 +24,22 @@ from api.updates import WEBUI_VERSION
 
 class QuietHTTPServer(ThreadingHTTPServer):
     """Custom HTTP server that silently handles common network errors."""
+    daemon_threads = True
+    request_queue_size = 64
     
     def handle_error(self, request, client_address):
         """Override to suppress logging for common client disconnect errors."""
         exc_type, exc_value, _ = sys.exc_info()
         
         # Silently ignore common connection errors caused by client disconnects
-        if exc_type in (ConnectionResetError, BrokenPipeError, ConnectionAbortedError):
+        if exc_type in (ConnectionResetError, BrokenPipeError, ConnectionAbortedError, TimeoutError):
             return
         
         # Also handle socket errors that indicate client disconnect
-        if exc_type is socket.error:
+        if issubclass(exc_type, OSError):
             # errno 54 is Connection reset by peer on macOS/BSD
             # errno 104 is Connection reset by peer on Linux
-            if exc_value.errno in (54, 104, 32):  # ECONNRESET, EPIPE
+            if getattr(exc_value, 'errno', None) in (32, 54, 104, 110):  # EPIPE, ECONNRESET, ETIMEDOUT
                 return
         
         # For other errors, use default logging

--- a/static/boot.js
+++ b/static/boot.js
@@ -879,9 +879,12 @@ function applyBotName(){
     if(S.session) syncTopbar();
   }).catch(()=>{});
   window._modelDropdownReady=_modelDropdownReady;
-  // Pre-load workspace list so sidebar name is correct from first render
+  // Pre-load workspace list so sidebar name is correct from first render.
+  // Render the session list before restoring the saved conversation so a stale
+  // saved-session/client-side boot error cannot leave the sidebar empty forever.
   await loadWorkspaceList();
   await loadOnboardingWizard();
+  await renderSessionList();
   _initResizePanels();
   // Workspace panel restore happens AFTER loadSession so we know if
   // the session has a workspace — prevents the snap-open-then-closed flash (#576).
@@ -941,7 +944,14 @@ function applyBotName(){
   await renderSessionList();
   // Start real-time gateway session sync if setting is enabled
   if(typeof startGatewaySSE==='function') startGatewaySSE();
-})();
+})().catch(e=>{
+  console.error('[hermes] boot failed', e);
+  try{S._bootReady=true;}catch(_){}
+  try{syncTopbar();}catch(_){}
+  try{syncWorkspacePanelState();}catch(_){}
+  try{$('emptyState').style.display='';}catch(_){}
+  try{if(typeof renderSessionList==='function') void renderSessionList();}catch(_){}
+});
 
 // Fix #822 (bfcache path): when the browser restores the page from the
 // back-forward cache, the async boot IIFE above does NOT re-run, but the

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -938,6 +938,10 @@ function startGatewaySSE(){
       }catch(e){ /* ignore parse errors */ }
     });
     _gatewaySSE.onerror = () => {
+      if(_gatewaySSE){
+        _gatewaySSE.close();
+        _gatewaySSE = null;
+      }
       void probeGatewaySSEStatus();
     };
   }catch(e){


### PR DESCRIPTION
## Summary
- Treat stalled/closed SSE clients as normal disconnects, including TimeoutError/OSError
- Close gateway EventSource on error before probing fallback to avoid reconnect churn
- Increase WebUI listen backlog and daemonize handler threads
- Render the session list before saved-session restore and add a boot catch fallback so stale client-side boot failures cannot leave conversations invisible

## Test Plan
- python3 -m py_compile server.py api/routes.py
- node --check static/boot.js
- node --check static/sessions.js
- git diff --check
- Restarted local WebUI on :7860 and verified /health and /api/sessions responsiveness

Note: pytest is unavailable in this runtime (/root/hermes-agent/venv/bin/python3: No module named pytest).