### PR TITLE
fix: resolve duplicate TERMINAL_CWD in _set_thread_env call

### DIFF
--- a/api/streaming.py
+++ b/api/streaming.py
@@ -1419,6 +1419,9 @@ def _run_agent_streaming(session_id, msg_text, model, workspace, stream_id, atta
             _profile_home = os.environ.get('HERMES_HOME', '')
             _profile_runtime_env = {}
 
+        # Remove TERMINAL_CWD from profile env to avoid duplicate kwarg error
+        # (profile may have terminal.cwd set, and we explicitly pass s.workspace)
+        _profile_runtime_env.pop('TERMINAL_CWD', None)
         _set_thread_env(
             **_profile_runtime_env,
             TERMINAL_CWD=str(s.workspace),


### PR DESCRIPTION
## Problem

When `terminal.cwd` is configured in `config.yaml`, `get_profile_runtime_env()` includes `TERMINAL_CWD` in the returned dict. Then `streaming.py` explicitly passes `TERMINAL_CWD=str(s.workspace)`, causing:

```
TypeError: api.config._set_thread_env() got multiple values for keyword argument 'TERMINAL_CWD'
```

## Root Cause

`_profile_runtime_env` dict may contain `TERMINAL_CWD` from profile config (via `_TERMINAL_ENV_MAPPINGS['cwd'] = 'TERMINAL_CWD'`), which conflicts with the explicit `TERMINAL_CWD` parameter passed to `_set_thread_env()`.

## Solution

Remove `TERMINAL_CWD` from `_profile_runtime_env` before calling `_set_thread_env` to avoid the duplicate keyword argument error. This ensures the session's workspace path is always used.

## Testing

- Verified no TypeError in WebUI logs after fix
- Service starts and runs correctly  
- Streaming API works without errors