### PR TITLE
fix: bypass service worker cache for subpath API routes

### DIFF
--- a/static/sw.js
+++ b/static/sw.js
@@ -64,11 +64,15 @@ self.addEventListener('fetch', (event) => {
   // Never intercept cross-origin requests
   if (url.origin !== self.location.origin) return;
 
-  // API and streaming endpoints — always go to network
+  // API and streaming endpoints — always go to network.
+  // The WebUI may be mounted under a subpath such as /hermes/, so API
+  // requests can look like /hermes/api/sessions rather than /api/sessions.
   if (
     url.pathname.startsWith('/api/') ||
+    url.pathname.includes('/api/') ||
     url.pathname.includes('/stream') ||
-    url.pathname.startsWith('/health')
+    url.pathname.startsWith('/health') ||
+    url.pathname.includes('/health')
   ) {
     return; // let browser handle normally
   }

--- a/tests/test_service_worker_api_cache.py
+++ b/tests/test_service_worker_api_cache.py
@@ -1,0 +1,31 @@
+"""Regression tests for service worker API cache exclusion under subpath mounts.
+
+The WebUI can be served at /hermes/. In that deployment API requests look like
+/hermes/api/sessions, not /api/sessions. The service worker must treat those as
+network-only; otherwise cache-first handling can serve a stale sidebar session
+list until the browser cache/service-worker cache is cleared.
+"""
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SW_SRC = (ROOT / "static" / "sw.js").read_text(encoding="utf-8")
+
+
+def test_service_worker_excludes_subpath_mounted_api_routes_from_cache():
+    assert "url.pathname.includes('/api/')" in SW_SRC, (
+        "service worker must bypass cache for subpath-mounted API routes like "
+        "/hermes/api/sessions, not only root-mounted /api/*"
+    )
+
+
+def test_service_worker_excludes_subpath_mounted_health_routes_from_cache():
+    assert "url.pathname.includes('/health')" in SW_SRC, (
+        "service worker must bypass cache for subpath-mounted health routes like "
+        "/hermes/health, not only root-mounted /health"
+    )
+
+
+def test_service_worker_documents_api_routes_are_never_cached():
+    assert "API and streaming endpoints" in SW_SRC
+    assert "always go to network" in SW_SRC


### PR DESCRIPTION
## Thinking Path

- Hermes WebUI should keep the browser state in sync with server-side sessions, especially after creating a new chat.
- The sidebar gets its chat list from `/api/sessions`, so that endpoint must always reflect current server state.
- The service worker was correctly avoiding cache for root-mounted API routes like `/api/*` and `/health`.
- When the app is deployed under `/hermes/`, those same requests become `/hermes/api/*` and `/hermes/health`.
- Those subpath requests did not match the service-worker API bypass check and could fall through to cache-first behavior.
- This PR fixes the cache bypass so subpath-mounted API/session requests are network-only, which keeps the sidebar list fresh after new chat creation.

## What Changed

- Updated `static/sw.js` so API/health requests are treated as network-only when Hermes WebUI is mounted under a path prefix:
  - `/api/...`
  - `/health`
  - `/hermes/api/...`
  - `/hermes/health`
- Added regression coverage in `tests/test_service_worker_api_cache.py` for subpath API cache exclusion.

## Why It Matters

Without this fix, creating a new chat can succeed server-side while the sidebar still shows a stale cached session list in the browser. Users then have to refresh or clear cache to see the chat they just created, which makes the WebUI feel unreliable even though the backend already created the session correctly.

This keeps session list reads fresh while preserving the service worker's static-asset caching behavior.

## Verification

Manual verification:

- Confirmed locally in the deployed WebUI that new chats appear in the sidebar immediately without clearing browser cache.

Automated verification:

```bash
/home/michael/.hermes/hermes-agent/venv/bin/python -m pytest \
  tests/test_service_worker_api_cache.py \
  tests/test_empty_session_no_disk_write.py -q

git diff --check origin/master...HEAD
```

Result:

```text
10 passed
```

## Risks / Follow-ups

- Low risk: the change is limited to service-worker route classification for API/health requests.
- Static assets remain cache-first; only dynamic API/health routes bypass the cache.
- If additional deployment prefixes are introduced later, the service-worker API detection should stay prefix-aware rather than checking only one hard-coded mount path.

## Model Used

AI assisted.

- Provider: OpenAI via Hermes Agent
- Model: `gpt-5.5`
- Notable tool use: terminal/git/gh CLI for repository inspection and PR updates; file tools for drafting PR body text.