### PR TITLE
feat(skills): collapsible category headers in Skills panel

### DIFF
--- a/static/panels.js
+++ b/static/panels.js
@@ -870,6 +870,23 @@ async function loadSkills() {
   } catch(e) { box.innerHTML = `<div style="padding:12px;color:var(--accent);font-size:12px">Error: ${esc(e.message)}</div>`; }
 }
 
+let _collapsedCats = new Set(); // persisted collapsed state across re-renders
+
+function _toggleCatCollapse(cat) {
+  if (_collapsedCats.has(cat)) _collapsedCats.delete(cat);
+  else _collapsedCats.add(cat);
+  // Toggle DOM without full re-render
+  document.querySelectorAll('.skills-category').forEach(sec => {
+    const header = sec.querySelector('.skills-cat-header');
+    if (header && header.dataset.cat === cat) {
+      const collapsed = _collapsedCats.has(cat);
+      sec.classList.toggle('collapsed', collapsed);
+      header.querySelector('.cat-chevron').style.transform = collapsed ? '' : 'rotate(90deg)';
+      sec.querySelectorAll('.skill-item').forEach(el => el.style.display = collapsed ? 'none' : '');
+    }
+  });
+}
+
 function renderSkills(skills) {
   const query = ($('skillsSearch').value || '').toLowerCase();
   const filtered = query ? skills.filter(s =>
@@ -888,12 +905,19 @@ function renderSkills(skills) {
   box.innerHTML = '';
   if (!filtered.length) { box.innerHTML = `<div style="padding:12px;color:var(--muted);font-size:12px">${esc(t('skills_no_match'))}</div>`; return; }
   for (const [cat, items] of Object.entries(cats).sort()) {
+    const collapsed = _collapsedCats.has(cat);
     const sec = document.createElement('div');
-    sec.className = 'skills-category';
-    sec.innerHTML = `<div class="skills-cat-header">${li('folder',12)} ${esc(cat)} <span style="opacity:.5">(${items.length})</span></div>`;
+    sec.className = 'skills-category' + (collapsed ? ' collapsed' : '');
+    const hdr = document.createElement('div');
+    hdr.className = 'skills-cat-header';
+    hdr.dataset.cat = cat;
+    hdr.innerHTML = `<span class="cat-chevron" style="display:inline-flex;transition:transform .15s;${collapsed ? '' : 'transform:rotate(90deg)'}">${li('chevron-right',12)}</span> ${esc(cat)} <span style="opacity:.5">(${items.length})</span>`;
+    hdr.onclick = () => _toggleCatCollapse(cat);
+    sec.appendChild(hdr);
     for (const skill of items.sort((a,b) => a.name.localeCompare(b.name))) {
       const el = document.createElement('div');
       el.className = 'skill-item';
+      el.style.display = collapsed ? 'none' : '';
       el.innerHTML = `<span class="skill-name">${esc(skill.name)}</span><span class="skill-desc">${esc(skill.description||'')}</span>`;
       el.onclick = () => openSkill(skill.name, el);
       sec.appendChild(el);

--- a/static/panels.js
+++ b/static/panels.js
@@ -866,6 +866,10 @@ async function loadSkills() {
   try {
     const data = await api('/api/skills');
     _skillsData = data.skills || [];
+    // Prune collapsed state to only keep categories present in fresh data,
+    // avoiding stale keys when categories are renamed or removed server-side.
+    const liveCats = new Set(_skillsData.map(s => s.category || '(general)'));
+    for (const c of _collapsedCats) { if (!liveCats.has(c)) _collapsedCats.delete(c); }
     renderSkills(_skillsData);
   } catch(e) { box.innerHTML = `<div style="padding:12px;color:var(--accent);font-size:12px">Error: ${esc(e.message)}</div>`; }
 }

--- a/static/style.css
+++ b/static/style.css
@@ -555,9 +555,10 @@
   /* Skills panel */
   .skills-list{flex:1;overflow-y:auto;padding:0 8px 8px;}
   .skills-category{margin-bottom:4px;}
-  .skills-cat-header{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--muted);padding:8px 6px 4px;cursor:pointer;display:flex;align-items:center;gap:4px;}
+  .skills-cat-header{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--muted);padding:8px 6px 4px;cursor:pointer;display:flex;align-items:center;gap:2px;user-select:none;}
   .skills-cat-header:hover{color:var(--text);}
-  .skill-item{width:100%;min-width:0;box-sizing:border-box;padding:8px 10px;border-radius:8px;cursor:pointer;font-size:12px;color:var(--muted);display:flex;align-items:flex-start;gap:6px;transition:all .12s;line-height:1.4;}
+  .cat-chevron{flex-shrink:0;width:12px;height:12px;}
+  .skill-item{width:100%;min-width:0;box-sizing:border-box;padding:8px 10px;border-radius:8px;cursor:pointer;font-size:12px;color:var(--muted);display:flex;align-items:flex-start;gap:6px;transition:all .12s;line-height:1.4;overflow:hidden;max-height:200px;opacity:1;}
   .skill-item:hover{background:var(--hover-bg);color:var(--text);}
   .skill-item.active{background:var(--accent-bg);color:var(--accent-text);}
   .skill-name{font-weight:500;flex-shrink:0;}

--- a/tests/test_skills_category_collapse.py
+++ b/tests/test_skills_category_collapse.py
@@ -1,0 +1,153 @@
+"""Tests for collapsible skill categories in the Skills panel.
+
+Validates that renderSkills() produces collapsible category headers
+with chevron toggles, click handlers, and persisted collapse state.
+"""
+import os
+import re
+import pytest
+
+
+def _readpanels():
+    with open(os.path.join('static', 'panels.js')) as f:
+        return f.read()
+
+
+def _readcss():
+    with open(os.path.join('static', 'style.css')) as f:
+        return f.read()
+
+
+# ── State variable ──────────────────────────────────────────────────────────
+
+class TestCollapseState:
+    """A Set must track collapsed categories across re-renders."""
+
+    def test_collapsed_cats_set_exists(self):
+        p = _readpanels()
+        assert '_collapsedCats' in p, '_collapsedCats Set must exist'
+        assert 'new Set()' in p, '_collapsedCats must be initialized as Set'
+
+    def test_toggle_function_exists(self):
+        p = _readpanels()
+        assert '_toggleCatCollapse' in p, '_toggleCatCollapse() function must exist'
+
+
+# ── renderSkills produces collapsible headers ──────────────────────────────
+
+class TestRenderSkillsCollapse:
+    """renderSkills() must render category headers with chevron icons and click handlers."""
+
+    def test_chevron_icon_used_instead_of_folder(self):
+        p = _readpanels()
+        idx = p.find('function renderSkills(')
+        body = p[idx:idx + 2000]
+        assert 'chevron-right' in body, 'Must use chevron-right icon instead of folder'
+        assert "li('folder'" not in body, 'Must not use folder icon anymore'
+
+    def test_cat_header_has_dataset_cat(self):
+        p = _readpanels()
+        idx = p.find('function renderSkills(')
+        body = p[idx:idx + 2000]
+        assert 'dataset.cat' in body, 'Header must store category in data-cat attribute'
+
+    def test_cat_header_has_click_handler(self):
+        p = _readpanels()
+        idx = p.find('function renderSkills(')
+        body = p[idx:idx + 2000]
+        assert 'hdr.onclick' in body or 'onclick' in body, 'Header must have onclick handler'
+
+    def test_collapsed_class_toggled(self):
+        p = _readpanels()
+        idx = p.find('function renderSkills(')
+        body = p[idx:idx + 2000]
+        assert 'collapsed' in body, 'Must apply collapsed class based on state'
+
+    def test_skill_items_hidden_when_collapsed(self):
+        p = _readpanels()
+        idx = p.find('function renderSkills(')
+        body = p[idx:idx + 2000]
+        assert "'none'" in body and "style.display" in body, 'Skill items must be hidden when category is collapsed'
+
+    def test_chevron_rotation_on_collapse(self):
+        p = _readpanels()
+        idx = p.find('function renderSkills(')
+        body = p[idx:idx + 2000]
+        assert 'rotate(90deg)' in body, 'Chevron must rotate 90deg when expanded'
+
+    def test_renderSkills_preserves_search_query(self):
+        """Search query must still be read and applied before grouping."""
+        p = _readpanels()
+        idx = p.find('function renderSkills(')
+        body = p[idx:idx + 500]
+        assert 'skillsSearch' in body, 'Must read search input value'
+        assert 'toLowerCase().includes(query)' in body, 'Must filter by name/description/category'
+
+
+# ── _toggleCatCollapse DOM manipulation ────────────────────────────────────
+
+class TestToggleCatCollapse:
+    """_toggleCatCollapse() must toggle DOM without full re-render."""
+
+    def test_toggles_set_membership(self):
+        p = _readpanels()
+        idx = p.find('function _toggleCatCollapse(')
+        body = p[idx:idx + 500]
+        assert '_collapsedCats.has(cat)' in body
+        assert '_collapsedCats.delete(cat)' in body
+        assert '_collapsedCats.add(cat)' in body
+
+    def test_queries_skills_category_elements(self):
+        p = _readpanels()
+        idx = p.find('function _toggleCatCollapse(')
+        body = p[idx:idx + 800]
+        assert '.skills-category' in body, 'Must query .skills-category elements'
+
+    def test_matches_by_dataset_cat(self):
+        p = _readpanels()
+        idx = p.find('function _toggleCatCollapse(')
+        body = p[idx:idx + 800]
+        assert 'header.dataset.cat === cat' in body or 'dataset.cat' in body, 'Must match category by data attribute'
+
+    def test_toggles_skill_item_display(self):
+        p = _readpanels()
+        idx = p.find('function _toggleCatCollapse(')
+        body = p[idx:idx + 800]
+        assert '.skill-item' in body, 'Must query .skill-item elements'
+        assert "display = collapsed ? 'none'" in body or "style.display" in body, 'Must toggle display property'
+
+    def test_toggles_chevron_rotation(self):
+        p = _readpanels()
+        idx = p.find('function _toggleCatCollapse(')
+        body = p[idx:idx + 800]
+        assert '.cat-chevron' in body, 'Must select chevron element'
+        assert 'rotate' in body, 'Must toggle rotation on chevron'
+
+
+# ── CSS ────────────────────────────────────────────────────────────────────
+
+class TestCSSClasses:
+    """CSS must support collapsible categories."""
+
+    def test_cat_chevron_class(self):
+        css = _readcss()
+        assert '.cat-chevron' in css, '.cat-chevron class must exist in CSS'
+
+    def test_cat_chevron_has_fixed_size(self):
+        css = _readcss()
+        m = re.search(r'\.cat-chevron\{[^}]+\}', css)
+        assert m, '.cat-chevron rule must exist'
+        assert 'width' in m.group(), 'Chevron must have fixed width'
+        assert 'flex-shrink' in m.group(), 'Chevron must not shrink'
+
+    def test_skills_cat_header_user_select_none(self):
+        css = _readcss()
+        m = re.search(r'\.skills-cat-header\{[^}]+\}', css)
+        assert m, '.skills-cat-header rule must exist'
+        assert 'user-select' in m.group(), 'Header must have user-select:none to prevent text selection on click'
+
+    def test_skills_cat_header_has_cursor_pointer(self):
+        css = _readcss()
+        m = re.search(r'\.skills-cat-header\{[^}]+\}', css)
+        assert m, '.skills-cat-header rule must exist'
+        assert 'cursor:pointer' in m.group(), 'Header must have cursor:pointer'


### PR DESCRIPTION
## Summary
Makes skill categories collapsible — click on a category header to toggle its content.

## Changes
- **Icon**: Replaced folder icon with chevron-right that rotates 90deg when expanded
- **Toggle**: Click on category header collapses/expands without full re-render (DOM manipulation only)
- **State**: Collapse state persisted in `_collapsedCats` Set — survives search filtering and re-renders
- **CSS**: Added `.cat-chevron` with fixed size, `user-select:none` on header to prevent text selection

## Files changed
- `static/panels.js` — `_collapsedCats` state, `_toggleCatCollapse()`, modified `renderSkills()`
- `static/style.css` — `.cat-chevron` class, `user-select:none`, adjusted header gap
- `tests/test_skills_category_collapse.py` — 18 tests

## Testing
18 new tests pass. All 3105 existing tests pass.

---
*Co-authored-by: Hermes AI Agent (bergeouss/hermes-webui fork)*