### PR TITLE
feat: add compact tool activity setting

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,173 @@
+---
+version: alpha
+name: Hermes Calm Console
+description: "A restrained agent control surface: conversational content first, tool traces as quiet metadata, minimal chrome."
+colors:
+  primary: "#EAE0D5"
+  secondary: "#C6AC8F"
+  tertiary: "#C6AC8F"
+  neutral: "#0A0908"
+  surface: "#22333B"
+  surfaceSubtle: "#11100E"
+  borderSubtle: "#3B4A50"
+  ink: "#0A0908"
+  success: "#86C08B"
+  warning: "#E0B15D"
+  error: "#F87171"
+typography:
+  body-md:
+    fontFamily: "Georgia, Times New Roman, serif"
+    fontSize: 15px
+    fontWeight: 400
+    lineHeight: 1.68
+  body-sm:
+    fontFamily: "-apple-system, BlinkMacSystemFont, Segoe UI, Inter, system-ui, sans-serif"
+    fontSize: 12px
+    fontWeight: 400
+    lineHeight: 1.45
+  user-message:
+    fontFamily: "-apple-system, BlinkMacSystemFont, Segoe UI, Inter, system-ui, sans-serif"
+    fontSize: 14px
+    fontWeight: 400
+    lineHeight: 1.55
+  mono-xs:
+    fontFamily: "SF Mono, ui-monospace, monospace"
+    fontSize: 11px
+    fontWeight: 500
+    lineHeight: 1.55
+rounded:
+  sm: 4px
+  md: 8px
+  lg: 12px
+  pill: 999px
+spacing:
+  xs: 4px
+  sm: 8px
+  md: 12px
+  lg: 16px
+components:
+  app-shell:
+    backgroundColor: "{colors.neutral}"
+    textColor: "{colors.primary}"
+    rounded: "{rounded.sm}"
+    padding: 16px
+  panel:
+    backgroundColor: "{colors.surface}"
+    textColor: "{colors.primary}"
+    rounded: "{rounded.lg}"
+    padding: 16px
+  border-line:
+    backgroundColor: "{colors.borderSubtle}"
+    textColor: "{colors.primary}"
+    rounded: "{rounded.sm}"
+    padding: 4px
+  state-success:
+    backgroundColor: "{colors.success}"
+    textColor: "{colors.ink}"
+    rounded: "{rounded.sm}"
+    padding: 4px
+  state-warning:
+    backgroundColor: "{colors.warning}"
+    textColor: "{colors.ink}"
+    rounded: "{rounded.sm}"
+    padding: 4px
+  state-error:
+    backgroundColor: "{colors.error}"
+    textColor: "{colors.ink}"
+    rounded: "{rounded.sm}"
+    padding: 4px
+  tool-call-group:
+    backgroundColor: "{colors.neutral}"
+    textColor: "{colors.secondary}"
+    rounded: "{rounded.md}"
+    padding: 4px
+  tool-card:
+    backgroundColor: "{colors.surfaceSubtle}"
+    textColor: "{colors.secondary}"
+    rounded: "{rounded.md}"
+    padding: 8px
+  user-message:
+    backgroundColor: "{colors.tertiary}"
+    textColor: "{colors.ink}"
+    rounded: "{rounded.lg}"
+    padding: 12px
+---
+
+## Overview
+
+Hermes WebUI should feel like a calm developer console, not a demo page assembled from colorful cards. The primary artifact is the conversation. Tool calls, thinking traces, context compaction records, token usage, and runtime status are useful, but they are transcript metadata and should sit below the visual priority of user and assistant prose.
+
+The desired direction is Linear/Vercel precision with a little Claude-style conversational warmth: quiet surfaces, clear spacing, restrained accent use, and progressive disclosure for debugging detail.
+
+## Colors
+
+- **Primary (#EAE0D5):** main text on dark surfaces. The warm parchment should feel readable and grounded, not like bright white terminal text.
+- **Secondary/Tertiary (#C6AC8F):** metadata and restrained accent. Use sparingly for active state, focus, user bubbles, and quiet emphasis.
+- **Neutral (#0A0908):** app background and ink. This gives the WebUI depth without returning to the previous navy/gold theme.
+- **Surface (#22333B):** panels, sidebar, and stronger interactive surfaces. It should carry the structure while the conversation remains primary.
+- **Light surfaces (#EAE0D5 / #F4EEE7):** light mode uses the palette's parchment as the field and a slightly lifted derived surface for panels.
+- **Semantic colors:** success/warning/error/info are state colors only, not decorative palette choices.
+
+## Typography
+
+Use Claude-like split typography: assistant prose gets an editorial serif stack (Georgia as the available substitute for Anthropic Serif), while user bubbles and functional UI stay in a crisp sans stack. This keeps the bot voice calmer and more readable without making controls feel bookish. Use monospace only for code, file paths, commands, tool names, and compact metadata. Avoid making whole cards feel like terminal output unless they actually are logs.
+
+Scale should stay tight: 11px metadata, 12px labels, 14px body, 16–18px headings. Do not proliferate 10px/10.5px/12.5px one-offs unless there is a real layout constraint.
+
+## Layout
+
+Conversation rhythm:
+
+1. User message — right aligned, compact bubble.
+2. Assistant content — left aligned, prose-first, no heavy bubble.
+3. Tool/thinking/context traces — quiet disclosure rows inside the assistant turn.
+4. Raw logs/details — hidden until explicitly expanded.
+
+Metadata should not break the reading flow. A turn that used ten tools should read as one assistant turn with one compact `Used 10 tools` disclosure, not ten content cards.
+
+## Elevation & Depth
+
+Use almost no shadows in the transcript. Shadows are reserved for popovers, dropdowns, modal dialogs, and floating controls. Cards inside chat should use either a subtle border or a subtle tint, not both aggressively.
+
+## Shapes
+
+- Rows/list items: `4–8px` radius.
+- Cards/panels: `8–12px` radius.
+- Pills: only true chips/badges use `999px`.
+- Avoid stacks of nested rounded rectangles. If a card contains another card, one of them is probably unnecessary.
+
+## Components
+
+### Tool/thinking activity group
+
+Collapsed by default in settled history and during live runs. Summary line uses one disclosure for internals, e.g. `Activity: thinking + 4 tools · read_file, patch, terminal`. Expanding reveals thinking and individual tool cards together. Thinking and tools should not create separate transcript rows unless there is an error or approval state that needs attention.
+
+### Tool card
+
+A tool card is a debug event row, not a chat message. Show icon, name, short target/preview, and status. Arguments and result snippets stay behind expansion. Result snippets should be truncated; full logs belong behind “show more”.
+
+### Thinking/context cards
+
+Same visual family as tool-call metadata. They should be quieter than assistant prose and should not use bright tinted full cards unless the user expands them.
+
+### Composer
+
+The composer is the command surface. Keep it legible and focused: modest radius, subtle border, transparent inactive chips, no theatrical hover scaling.
+
+## Do's and Don'ts
+
+Do:
+
+- Collapse noisy agent internals by default.
+- Use one accent color at a time.
+- Prefer neutral borders and restrained surfaces.
+- Make debug traces accessible and inspectable without making them visually dominant.
+- Add stable class/data hooks for future visual regression tests.
+
+Don't:
+
+- Render every tool call as a first-class chat card.
+- Mix gold, cyan, purple, orange, red, and green as decorative colors in the same viewport.
+- Add new hardcoded radius/color values when a token exists.
+- Use shadows, gradients, and hover transforms for routine controls.
+- Hide important error or approval states; those are allowed to be prominent because they require action.

--- a/api/config.py
+++ b/api/config.py
@@ -2061,7 +2061,7 @@ _SETTINGS_DEFAULTS = {
     "show_cli_sessions": False,  # merge CLI sessions from state.db into the sidebar
     "sync_to_insights": False,  # mirror WebUI token usage to state.db for /insights
     "check_for_updates": True,  # check if webui/agent repos are behind upstream
-    "theme": "dark",  # light | dark | system
+    "theme": "dark",  # light | dark | system | calm
     "skin": "default",  # accent color skin: default | ares | mono | slate | poseidon | sisyphus | charizard
     "language": "en",  # UI locale code; must match a key in static/i18n.js LOCALES
     "bot_name": os.getenv(
@@ -2070,13 +2070,14 @@ _SETTINGS_DEFAULTS = {
     "sound_enabled": False,  # play notification sound when assistant finishes
     "notifications_enabled": False,  # browser notification when tab is in background
     "show_thinking": True,  # show/hide thinking/reasoning blocks in chat view
+    "simplified_tool_calling": True,  # group tools/thinking into one quiet activity disclosure
     "sidebar_density": "compact",  # compact | detailed
     "auto_title_refresh_every": "0",  # adaptive title refresh: 0=off, 5/10/20=every N exchanges
     "busy_input_mode": "queue",  # behavior when sending while agent is running: queue | interrupt | steer
     "password_hash": None,  # PBKDF2-HMAC-SHA256 hash; None = auth disabled
 }
 _SETTINGS_LEGACY_DROP_KEYS = {"assistant_language", "bubble_layout", "default_model"}
-_SETTINGS_THEME_VALUES = {"light", "dark", "system"}
+_SETTINGS_THEME_VALUES = {"light", "dark", "system", "calm"}
 _SETTINGS_SKIN_VALUES = {
     "default",
     "ares",
@@ -2185,6 +2186,7 @@ _SETTINGS_BOOL_KEYS = {
     "sound_enabled",
     "notifications_enabled",
     "show_thinking",
+    "simplified_tool_calling",
 }
 # Language codes are validated as short alphanumeric BCP-47-like tags (e.g. 'en', 'zh', 'fr')
 _SETTINGS_LANG_RE = __import__("re").compile(r"^[a-zA-Z]{2,10}(-[a-zA-Z0-9]{2,8})?$")

--- a/static/boot.js
+++ b/static/boot.js
@@ -624,6 +624,12 @@ window.addEventListener('resize',()=>{
 })();
 
 // ── Appearance helpers (theme = light/dark/system, skin = accent color) ──────
+const _THEMES=[
+  {name:'Light', value:'light', colors:['#FEFCF7','#FAF7F0','#B8860B']},
+  {name:'Dark', value:'dark', colors:['#0D0D1A','#141425','#FFD700']},
+  {name:'System', value:'system', colors:['#FEFCF7','#0D0D1A','#B8860B']},
+  {name:'Calm', value:'calm', colors:['#C6AC8F','#EAE0D5','#22333B']},
+];
 const _SKINS=[
   {name:'Default',  colors:['#FFD700','#FFBF00','#CD7F32']},
   {name:'Ares',     colors:['#FF4444','#CC3333','#992222']},
@@ -633,7 +639,7 @@ const _SKINS=[
   {name:'Sisyphus', colors:['#A78BFA','#8B5CF6','#7C3AED']},
   {name:'Charizard',colors:['#FB923C','#F97316','#EA580C']},
 ];
-const _VALID_THEMES=new Set(['system','dark','light']);
+const _VALID_THEMES=new Set((_THEMES||[]).map(t=>t.value));
 const _VALID_SKINS=new Set((_SKINS||[]).map(s=>s.name.toLowerCase()));
 const _LEGACY_THEME_MAP={
   slate:{theme:'dark',skin:'slate'},
@@ -668,6 +674,7 @@ function _setResolvedTheme(isDark){
 
 function _applyTheme(name){
   const normalized=_normalizeAppearance(name,'default');
+  delete document.documentElement.dataset.theme;
   if(_systemThemeMq&&_onSystemThemeChange){
     _systemThemeMq.removeEventListener('change',_onSystemThemeChange);
     _systemThemeMq=null;
@@ -678,6 +685,11 @@ function _applyTheme(name){
     _onSystemThemeChange=()=>_setResolvedTheme(_systemThemeMq.matches);
     _setResolvedTheme(_systemThemeMq.matches);
     _systemThemeMq.addEventListener('change',_onSystemThemeChange);
+    return;
+  }
+  if(normalized.theme==='calm'){
+    document.documentElement.dataset.theme='calm';
+    _setResolvedTheme(true);
     return;
   }
   _setResolvedTheme(normalized.theme==='dark');
@@ -813,6 +825,7 @@ function applyBotName(){
     window._soundEnabled=!!s.sound_enabled;
     window._notificationsEnabled=!!s.notifications_enabled;
     window._showThinking=s.show_thinking!==false;
+    window._simplifiedToolCalling=s.simplified_tool_calling!==false;
     window._sidebarDensity=(s.sidebar_density==='detailed'?'detailed':'compact');
     window._busyInputMode=(s.busy_input_mode||'queue');
     window._botName=s.bot_name||'Hermes';
@@ -840,6 +853,7 @@ function applyBotName(){
     window._soundEnabled=false;
     window._notificationsEnabled=false;
     window._showThinking=true;
+    window._simplifiedToolCalling=true;
     window._sidebarDensity='compact';
     window._busyInputMode='queue';
     window._botName='Hermes';

--- a/static/index.html
+++ b/static/index.html
@@ -592,7 +592,7 @@
             </div>
             <div class="settings-field">
               <label data-i18n="settings_label_theme">Theme</label>
-              <div id="themePickerGrid" style="display:grid;grid-template-columns:repeat(3,1fr);gap:8px;margin-top:4px">
+              <div id="themePickerGrid" style="display:grid;grid-template-columns:repeat(4,1fr);gap:8px;margin-top:4px">
                 <button type="button" data-theme-val="light" onclick="_pickTheme('light')" class="theme-pick-btn" style="border:1px solid var(--border2);border-radius:10px;padding:10px 8px;text-align:center;cursor:pointer;background:none;transition:all .15s">
                   <div style="width:100%;height:40px;border-radius:6px;background:#fff;border:1px solid rgba(0,0,0,.12);margin-bottom:6px;display:flex;align-items:center;justify-content:center">
                     <svg width="16" height="16" fill="none" stroke="#999" stroke-width="2" viewBox="0 0 24 24"><circle cx="12" cy="12" r="5"/><path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/></svg>
@@ -610,6 +610,12 @@
                     <svg width="16" height="16" fill="none" stroke="#888" stroke-width="2" viewBox="0 0 24 24"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg>
                   </div>
                   <span style="font-size:12px;font-weight:500;color:var(--text)">System</span>
+                </button>
+                <button type="button" data-theme-val="calm" onclick="_pickTheme('calm')" class="theme-pick-btn" style="border:1px solid var(--border2);border-radius:10px;padding:10px 8px;text-align:center;cursor:pointer;background:none;transition:all .15s">
+                  <div style="width:100%;height:40px;border-radius:6px;background:linear-gradient(135deg,#0A0908,#22333B 55%,#C6AC8F);border:1px solid rgba(198,172,143,.35);margin-bottom:6px;display:flex;align-items:center;justify-content:center">
+                    <svg width="16" height="16" fill="none" stroke="#EAE0D5" stroke-width="2" viewBox="0 0 24 24"><path d="M4 19h16"/><path d="M6 15l4-8 4 8"/><path d="M8 12h4"/><path d="M17 7v8"/></svg>
+                  </div>
+                  <span style="font-size:12px;font-weight:500;color:var(--text)">Calm</span>
                 </button>
               </div>
               <input type="hidden" id="settingsTheme" value="dark">
@@ -696,6 +702,13 @@
                 <span data-i18n="settings_label_token_usage">Show token usage after responses</span>
               </label>
               <div style="font-size:11px;color:var(--muted);margin-top:4px" data-i18n="settings_desc_token_usage">Displays input/output token count below each assistant reply. Also toggled with <code>/usage</code>.</div>
+            </div>
+            <div class="settings-field">
+              <label style="display:flex;align-items:center;gap:8px;cursor:pointer">
+                <input type="checkbox" id="settingsSimplifiedToolCalling" style="width:15px;height:15px;accent-color:var(--accent)">
+                <span>Compact tool activity</span>
+              </label>
+              <div style="font-size:11px;color:var(--muted);margin-top:4px">Group thinking and tool calls into one collapsed activity section per assistant turn.</div>
             </div>
             <div class="settings-field">
               <label for="settingsSidebarDensity" data-i18n="settings_label_sidebar_density">Sidebar density</label>

--- a/static/panels.js
+++ b/static/panels.js
@@ -2677,6 +2677,8 @@ async function loadSettingsPanel(){
     }
     const showUsageCb=$('settingsShowTokenUsage');
     if(showUsageCb){showUsageCb.checked=!!settings.show_token_usage;showUsageCb.addEventListener('change',_markSettingsDirty,{once:false});}
+    const simplifiedToolCb=$('settingsSimplifiedToolCalling');
+    if(simplifiedToolCb){simplifiedToolCb.checked=settings.simplified_tool_calling!==false;simplifiedToolCb.addEventListener('change',_markSettingsDirty,{once:false});}
     const showCliCb=$('settingsShowCliSessions');
     if(showCliCb){showCliCb.checked=!!settings.show_cli_sessions;showCliCb.addEventListener('change',_markSettingsDirty,{once:false});}
     const syncCb=$('settingsSyncInsights');
@@ -2979,6 +2981,7 @@ function _applySavedSettingsUi(saved, body, opts){
   window._soundEnabled=body.sound_enabled;
   window._notificationsEnabled=body.notifications_enabled;
   window._showThinking=body.show_thinking!==false;
+  window._simplifiedToolCalling=body.simplified_tool_calling!==false;
   window._sidebarDensity=sidebarDensity==='detailed'?'detailed':'compact';
   window._busyInputMode=body.busy_input_mode||'queue';
   window._botName=body.bot_name||'Hermes';
@@ -2999,6 +3002,7 @@ function _applySavedSettingsUi(saved, body, opts){
   _settingsHermesDefaultModelOnOpen=body.default_model||_settingsHermesDefaultModelOnOpen||'';
   // Sync window._defaultModel so newSession() uses the just-saved default without a reload (#908).
   if(body.default_model) window._defaultModel=body.default_model;
+  if(typeof clearMessageRenderCache==='function') clearMessageRenderCache();
   renderMessages();
   if(typeof syncTopbar==='function') syncTopbar();
   if(typeof renderSessionList==='function') renderSessionList();
@@ -3070,6 +3074,7 @@ async function saveSettings(andClose){
   body.skin=skin;
   body.language=language;
   body.show_token_usage=showTokenUsage;
+  body.simplified_tool_calling=!!($('settingsSimplifiedToolCalling')||{}).checked;
   body.show_cli_sessions=showCliSessions;
   body.sync_to_insights=!!($('settingsSyncInsights')||{}).checked;
   body.check_for_updates=!!($('settingsCheckUpdates')||{}).checked;

--- a/static/style.css
+++ b/static/style.css
@@ -9,7 +9,14 @@
     --strong:#0F0D08;--em:#5C5344;--code-text:#8b4513;--code-inline-bg:rgba(0,0,0,.06);--pre-text:#1A1610;
     --accent-hover:#996F08;--accent-bg:rgba(184,134,11,0.08);--accent-bg-strong:rgba(184,134,11,0.15);--accent-text:#8B6508;
     --error:#C62828;--success:#3D8B40;--warning:#E68A00;--info:#0288A8;
-    font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",system-ui,sans-serif;font-size:14px;line-height:1.6;
+    --radius-sm:4px;--radius-md:8px;--radius-card:8px;--radius-lg:12px;--radius-pill:999px;
+    --space-1:4px;--space-2:8px;--space-3:12px;--space-4:16px;
+    --font-size-xs:11px;--font-size-sm:12px;--font-size-md:14px;
+    --font-ui:-apple-system,BlinkMacSystemFont,"Segoe UI",Inter,system-ui,sans-serif;
+    --font-assistant:Georgia,"Times New Roman",serif;
+    --surface-subtle:rgba(0,0,0,.025);--surface-subtle-hover:rgba(0,0,0,.045);
+    --border-subtle:rgba(0,0,0,.08);--border-muted:rgba(0,0,0,.12);
+    font-family:var(--font-ui);font-size:14px;line-height:1.6;
   }
   /* ── Font size modifiers ── */
   /* ── Font size preference: scale key UI text elements ── */
@@ -69,6 +76,33 @@
     --strong:#fff;--em:#C0C0C0;--code-text:#f0c27f;--code-inline-bg:rgba(0,0,0,.35);--pre-text:#e2e8f0;
     --accent-hover:#FFBF00;--accent-bg:rgba(255,215,0,0.08);--accent-bg-strong:rgba(255,215,0,0.15);--accent-text:#FFD700;
     --error:#EF5350;--success:#4CAF50;--warning:#FFA726;--info:#4DD0E1;
+    --surface-subtle:rgba(255,255,255,.025);--surface-subtle-hover:rgba(255,255,255,.045);
+    --border-subtle:rgba(255,255,255,.075);--border-muted:rgba(255,255,255,.12);
+  }
+  /* ── Custom Theme: Calm Console (Coolors earth/slate palette) ── */
+  :root[data-theme="calm"] {
+    --bg:#EAE0D5;--sidebar:#F4EEE7;--border:#C6AC8F;--border2:rgba(10,9,8,0.13);
+    --text:#0A0908;--muted:#5B4B3B;--accent:#22333B;--blue:#22333B;--gold:#C6AC8F;--code-bg:#D8C8B7;
+    --surface:#F4EEE7;--topbar-bg:rgba(244,238,231,.96);--main-bg:rgba(234,224,213,0.72);
+    --focus-ring:rgba(34,51,59,.28);--focus-glow:rgba(34,51,59,.08);
+    --input-bg:rgba(10,9,8,.035);--hover-bg:rgba(10,9,8,.055);
+    --strong:#0A0908;--em:#3B3028;--code-text:#22333B;--code-inline-bg:rgba(10,9,8,.06);--pre-text:#0A0908;
+    --accent-hover:#0A0908;--accent-bg:rgba(34,51,59,0.08);--accent-bg-strong:rgba(34,51,59,0.15);--accent-text:#22333B;
+    --error:#B42318;--success:#2F6B3F;--warning:#8A5A18;--info:#22333B;
+    --surface-subtle:rgba(10,9,8,.025);--surface-subtle-hover:rgba(10,9,8,.045);
+    --border-subtle:rgba(10,9,8,.08);--border-muted:rgba(10,9,8,.12);
+  }
+  :root.dark[data-theme="calm"] {
+    --bg:#0A0908;--sidebar:#22333B;--border:#3B4A50;--border2:rgba(234,224,213,0.16);
+    --text:#EAE0D5;--muted:#C6AC8F;--accent:#C6AC8F;--blue:#C6AC8F;--gold:#C6AC8F;--code-bg:#11100E;
+    --surface:#22333B;--topbar-bg:rgba(34,51,59,.96);--main-bg:rgba(10,9,8,0.72);
+    --focus-ring:rgba(198,172,143,.28);--focus-glow:rgba(198,172,143,.08);
+    --input-bg:rgba(234,224,213,.035);--hover-bg:rgba(234,224,213,.055);
+    --strong:#F7F0E8;--em:#D8C6B2;--code-text:#C6AC8F;--code-inline-bg:rgba(234,224,213,.07);--pre-text:#EAE0D5;
+    --accent-hover:#EAE0D5;--accent-bg:rgba(198,172,143,0.08);--accent-bg-strong:rgba(198,172,143,0.14);--accent-text:#C6AC8F;
+    --error:#F87171;--success:#86C08B;--warning:#E0B15D;--info:#C6AC8F;
+    --surface-subtle:rgba(234,224,213,.025);--surface-subtle-hover:rgba(234,224,213,.045);
+    --border-subtle:rgba(234,224,213,.075);--border-muted:rgba(234,224,213,.12);
   }
   /* ── Skin: Default (gold — matches base) ── */
   /* No overrides needed — :root and .dark already use gold accent */
@@ -120,8 +154,8 @@
   :root:not(.dark) ::selection{background:var(--accent-bg-strong);}
   :root:not(.dark) *{scrollbar-color:rgba(0,0,0,.15) transparent;}
   /* ── Light mode: sidebar, roles, chips, active states ── */
-  :root:not(.dark) .session-item{color:#5a544a;}
-  :root:not(.dark) .session-item:hover{background:rgba(0,0,0,.06);color:#2c2825;}
+  :root:not(.dark) .session-item{color:var(--muted);}
+  :root:not(.dark) .session-item:hover{background:var(--hover-bg);color:var(--text);}
   :root:not(.dark) .session-item.active{background:var(--accent-bg);color:var(--accent-text);}
   :root:not(.dark) .session-item.active .session-title{color:var(--accent-text);}
   :root:not(.dark) .session-pin-indicator{color:var(--accent-text);}
@@ -130,11 +164,11 @@
   :root:not(.dark) .session-item.menu-open .session-actions-trigger{background:var(--accent-bg);border-color:var(--accent-bg-strong);color:var(--accent-text);}
   :root:not(.dark) .session-action-opt.is-active{background:var(--accent-bg);}
   :root:not(.dark) .msg-role.user{color:var(--accent-text);}
-  :root:not(.dark) .msg-role.assistant{color:#8a6520;}
+  :root:not(.dark) .msg-role.assistant{color:var(--muted);}
   :root:not(.dark) .role-icon.user{background:var(--accent-bg);color:var(--accent-text);border-color:var(--accent-bg-strong);}
-  :root:not(.dark) .role-icon.assistant{background:rgba(138,101,32,.12);color:#8a6520;border-color:rgba(138,101,32,.25);}
+  :root:not(.dark) .role-icon.assistant{background:var(--surface);color:var(--muted);border-color:var(--border);}
   :root:not(.dark) .project-chip{border-color:rgba(0,0,0,.12);background:rgba(0,0,0,.04);}
-  :root:not(.dark) .project-chip:hover{background:rgba(0,0,0,.08);color:#2c2825;}
+  :root:not(.dark) .project-chip:hover{background:var(--hover-bg);color:var(--text);}
   :root:not(.dark) .project-chip.active{background:var(--accent-bg);color:var(--accent-text);border-color:var(--accent-bg-strong);}
   :root:not(.dark) .chip{border-color:rgba(0,0,0,.1);background:rgba(0,0,0,.04);}
   :root:not(.dark) .chip.model{color:var(--accent-text);border-color:var(--accent-bg-strong);background:var(--accent-bg);}
@@ -162,7 +196,7 @@
   :root:not(.dark) .preview-md td{border-color:rgba(0,0,0,.08);}
   :root:not(.dark) .msg-body td{border-color:rgba(0,0,0,.08);}
   :root:not(.dark) .preview-badge.code{background:rgba(0,0,0,.05);}
-  :root:not(.dark) .ctx-ring-center{background:var(--bg);color:#5a544a;}
+  :root:not(.dark) .ctx-ring-center{background:var(--bg);color:var(--muted);}
   :root:not(.dark) .ctx-ring-track{stroke:rgba(0,0,0,.12);}
   :root:not(.dark) .ws-opt:hover{background:rgba(0,0,0,.05);}
   :root:not(.dark) .ws-row:hover{background:rgba(0,0,0,.04);}
@@ -1339,22 +1373,32 @@ body.resizing{user-select:none;cursor:col-resize;}
 .skill-linked-file{display:block;font-size:12px;padding:3px 6px;border-radius:4px;cursor:pointer;color:var(--blue);text-decoration:none;}
 .skill-linked-file:hover{background:var(--hover-bg);}
 .tool-card-row{margin:0;padding:1px 0;}
-.tool-card{background:rgba(255,255,255,.03);border:1px solid rgba(255,255,255,.07);border-radius:6px;margin:2px 0 2px 40px;overflow:hidden;transition:border-color .15s;}
-.tool-card:hover{border-color:rgba(255,255,255,.12);}
+.tool-call-group{margin:4px 0 4px var(--msg-rail);max-width:var(--msg-max);border-left:1px solid var(--border-subtle);}
+.tool-call-group-summary{width:100%;display:flex;align-items:center;gap:var(--space-2);padding:var(--space-1) var(--space-3);border:0;background:transparent;color:var(--muted);cursor:pointer;text-align:left;font:inherit;font-size:var(--font-size-xs);line-height:1.4;border-radius:var(--radius-card);}
+.tool-call-group-summary:hover{background:var(--surface-subtle-hover);color:var(--text);}
+.tool-call-group-label{font-weight:600;color:var(--muted);}
+.tool-call-group-list{opacity:.72;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+.tool-call-group-count{margin-left:auto;opacity:.56;font-variant-numeric:tabular-nums;}
+.tool-call-group-chevron{opacity:.45;display:inline-flex;transition:transform .16s ease;}
+.tool-call-group:not(.tool-call-group-collapsed) .tool-call-group-chevron{transform:rotate(90deg);}
+.tool-call-group-body{display:block;padding-left:var(--space-3);}
+.tool-call-group.tool-call-group-collapsed .tool-call-group-body{display:none;}
+.tool-card{background:var(--surface-subtle);border:1px solid var(--border-subtle);border-radius:var(--radius-card);margin:2px 0;overflow:hidden;transition:border-color .15s,background-color .15s;}
+.tool-card:hover{border-color:var(--border-muted);background:var(--surface-subtle-hover);}
 .tool-card-running{border-color:var(--accent-bg-strong);background:var(--accent-bg);}
-.tool-card-header{display:flex;align-items:center;gap:8px;padding:4px 10px;cursor:pointer;user-select:none;}
-.tool-card-icon{font-size:13px;flex-shrink:0;opacity:.8;}
-.tool-card-name{font-size:12px;font-weight:600;color:var(--muted);font-family:'SF Mono',ui-monospace,monospace;flex-shrink:0;}
-.tool-card-preview{font-size:11px;color:var(--muted);opacity:.6;flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
-.tool-card-toggle{font-size:10px;color:var(--muted);opacity:.5;flex-shrink:0;display:inline-flex;align-items:center;justify-content:center;transform-origin:center;transition:transform .18s ease;will-change:transform;}
+.tool-card-header{display:flex;align-items:center;gap:var(--space-2);padding:var(--space-1) var(--space-3);cursor:pointer;user-select:none;}
+.tool-card-icon{font-size:13px;flex-shrink:0;opacity:.65;}
+.tool-card-name{font-size:var(--font-size-xs);font-weight:600;color:var(--muted);font-family:'SF Mono',ui-monospace,monospace;flex-shrink:0;}
+.tool-card-preview{font-size:var(--font-size-xs);color:var(--muted);opacity:.62;flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+.tool-card-toggle{font-size:10px;color:var(--muted);opacity:.45;flex-shrink:0;display:inline-flex;align-items:center;justify-content:center;transform-origin:center;transition:transform .18s ease;will-change:transform;}
 .tool-card.open .tool-card-toggle{transform:rotate(90deg);}
-.tool-card-detail{display:block;max-height:0;opacity:0;overflow:hidden;border-top:1px solid transparent;padding:0 12px;transition:max-height .22s ease,opacity .18s ease,padding .22s ease,border-top-color .22s ease;}
-.tool-card.open .tool-card-detail{max-height:600px;opacity:1;padding:8px 12px;border-top-color:rgba(255,255,255,.06);overflow:auto;}
+.tool-card-detail{display:block;max-height:0;opacity:0;overflow:hidden;border-top:1px solid transparent;padding:0 var(--space-3);transition:max-height .22s ease,opacity .18s ease,padding .22s ease,border-top-color .22s ease;}
+.tool-card.open .tool-card-detail{max-height:600px;opacity:1;padding:var(--space-2) var(--space-3);border-top-color:var(--border-subtle);overflow:auto;}
 .tool-card-args{margin-bottom:6px;}
-.tool-card-args div{font-size:11px;line-height:1.6;}
-.tool-arg-key{color:var(--blue);font-family:'SF Mono',ui-monospace,monospace;font-size:11px;}
-.tool-arg-val{color:var(--muted);font-family:'SF Mono',ui-monospace,monospace;font-size:11px;word-break:break-all;}
-.tool-card-result pre{font-size:11px;color:var(--muted);font-family:'SF Mono',ui-monospace,monospace;white-space:pre-wrap;word-break:break-word;max-height:360px;overflow-y:auto;margin:0;line-height:1.55;}
+.tool-card-args div{font-size:var(--font-size-xs);line-height:1.6;}
+.tool-arg-key{color:var(--blue);font-family:'SF Mono',ui-monospace,monospace;font-size:var(--font-size-xs);}
+.tool-arg-val{color:var(--muted);font-family:'SF Mono',ui-monospace,monospace;font-size:var(--font-size-xs);word-break:break-all;}
+.tool-card-result pre{font-size:var(--font-size-xs);color:var(--muted);font-family:'SF Mono',ui-monospace,monospace;white-space:pre-wrap;word-break:break-word;max-height:240px;overflow-y:auto;margin:0;line-height:1.55;}
 
 /* ── Manual compression cards (transient transcript-local feedback) ── */
 .live-compression-cards{
@@ -1931,7 +1975,7 @@ main.main.showing-profiles > #mainProfiles{display:flex;}
   border-color:var(--accent);
   color:#fff;
 }
-:root.dark .provider-card-btn-primary{color:#0D0D1A;}
+:root.dark .provider-card-btn-primary{color:#0A0908;}
 .provider-card-btn-primary:hover:not(:disabled){
   background:var(--accent-hover);
   border-color:var(--accent-hover);
@@ -2113,6 +2157,11 @@ main.main.showing-profiles > #mainProfiles{display:flex;}
 /* ── Unified indent rail — every child of a turn lines up on --msg-rail ── */
 .msg-row { padding: 12px 0; }
 .msg-body { padding-left: var(--msg-rail); padding-top: 8px; max-width: var(--msg-max); }
+.assistant-turn .msg-body { font-family: var(--font-assistant); font-size: 15px; line-height: 1.68; letter-spacing: .003em; }
+.assistant-turn .msg-body code,
+.assistant-turn .msg-body pre,
+.assistant-turn .msg-body table { font-family: 'SF Mono', ui-monospace, monospace; }
+.msg-row[data-role="user"] .msg-body { font-family: var(--font-ui); }
 .msg-body:empty { display: none; }
 .assistant-turn { width: 100%; }
 .assistant-turn-blocks { display: flex; flex-direction: column; }
@@ -2134,6 +2183,9 @@ main.main.showing-profiles > #mainProfiles{display:flex;}
 .msg-usage { padding-left: var(--msg-rail); opacity: 1; margin-top: 6px; font-size: 11px; }
 .tool-card { margin-left: var(--msg-rail); max-width: var(--msg-max); }
 .thinking-card { margin-left: var(--msg-rail); max-width: var(--msg-max); }
+.agent-activity-group .tool-card,
+.agent-activity-group .thinking-card { margin-left: 0; max-width: none; }
+.agent-activity-thinking { margin: 2px 0; }
 .tool-cards-toggle { margin-left: var(--msg-rail); }
 .msg-row[data-editing="1"] { width: 100%; }
 .msg-row[data-editing="1"] .msg-edit-area,

--- a/static/ui.js
+++ b/static/ui.js
@@ -2024,6 +2024,7 @@ async function forceUpdate(btn){
 // blind setTimeout(reload, 2500) that race-lost against slow hardware or
 // reverse proxies that 502 immediately when the upstream socket closes (#874).
 async function _waitForServerThenReload(opts){
+  // Polls the /health endpoint; implementation uses a relative URL so subpath mounts keep working.
   opts=opts||{};
   const interval=opts.interval||500;
   const maxMs=opts.maxMs||15000;
@@ -2223,6 +2224,36 @@ function _assistantTurnBlocks(turn){
 function _thinkingCardHtml(text){
   const clean=_sanitizeThinkingDisplayText(text);
   return `<div class="thinking-card"><div class="thinking-card-header" onclick="this.parentElement.classList.toggle('open')"><span class="thinking-card-icon">${li('lightbulb',14)}</span><span class="thinking-card-label">${t('thinking')}</span><span class="thinking-card-toggle">${li('chevron-right',12)}</span></div><div class="thinking-card-body"><pre>${esc(clean)}</pre></div></div>`;
+}
+function isSimplifiedToolCalling(){
+  return window._simplifiedToolCalling!==false;
+}
+function _thinkingActivityNode(text){
+  const row=document.createElement('div');
+  row.className='agent-activity-thinking';
+  row.innerHTML=_thinkingCardHtml(text);
+  return row;
+}
+function ensureActivityGroup(inner, opts){
+  opts=opts||{};
+  if(!inner) return null;
+  const live=!!opts.live;
+  const selector=live?'.tool-call-group[data-live-tool-call-group="1"]':'.tool-call-group[data-agent-activity-group="1"]';
+  let group=inner.querySelector(selector);
+  if(!group){
+    group=document.createElement('div');
+    const collapsed=opts.collapsed!==false;
+    group.className='tool-call-group agent-activity-group'+(collapsed?' tool-call-group-collapsed':'');
+    group.setAttribute('data-tool-call-group','1');
+    group.setAttribute('data-agent-activity-group','1');
+    if(live) group.setAttribute('data-live-tool-call-group','1');
+    group.innerHTML=`<button type="button" class="tool-call-group-summary" aria-expanded="${collapsed?'false':'true'}" onclick="const g=this.closest('.tool-call-group');const c=g.classList.toggle('tool-call-group-collapsed');this.setAttribute('aria-expanded',String(!c));"><span class="tool-call-group-chevron">${li('chevron-right',12)}</span><span class="tool-call-group-label">Activity</span><span class="tool-call-group-list">tools / thinking</span><span class="tool-call-group-count">0</span></button><div class="tool-call-group-body"></div>`;
+    const anchor=opts.anchor||null;
+    if(anchor&&anchor.parentElement===inner) anchor.insertAdjacentElement('afterend', group);
+    else inner.appendChild(group);
+  }
+  _syncToolCallGroupSummary(group);
+  return group;
 }
 function _compressionStateForCurrentSession(){
   const state=window._compressionUi;
@@ -2488,6 +2519,10 @@ function renderCompressionUi(){
 // for the common read-only back-navigation case; not suitable as a general cache.
 const _sessionHtmlCache=new Map();
 let _sessionHtmlCacheSid=null; // session_id currently rendered in the DOM
+function clearMessageRenderCache(){
+  _sessionHtmlCache.clear();
+  _sessionHtmlCacheSid=null;
+}
 
 function renderMessages(){
   const inner=$('msgInner');
@@ -2578,6 +2613,7 @@ function renderMessages(){
   let _prevSepKey=null;
   let currentAssistantTurn=null;
   const assistantSegments=new Map();
+  const assistantThinking=new Map();
   const userRows=new Map();
   for(let vi=0;vi<visWithIdx.length;vi++){
     const {m,rawIdx}=visWithIdx[vi];
@@ -2695,11 +2731,14 @@ function renderMessages(){
       seg.setAttribute('data-live-assistant','1');
     }
     if(_ERR_MSG_RE.test(String(content||'').trim())) seg.dataset.error='1';
-    if(thinkingText&&window._showThinking!==false) seg.insertAdjacentHTML('beforeend', _thinkingCardHtml(thinkingText));
+    if(thinkingText&&window._showThinking!==false){
+      if(isSimplifiedToolCalling()) assistantThinking.set(rawIdx, thinkingText);
+      else seg.insertAdjacentHTML('beforeend', _thinkingCardHtml(thinkingText));
+    }
     const hasVisibleBody=!!(String(content||'').trim()||filesHtml);
     if(hasVisibleBody){
       seg.insertAdjacentHTML('beforeend', `${filesHtml}<div class="msg-body">${bodyHtml}</div>${footHtml}`);
-    }else if(!thinkingText){
+    }else if(!(thinkingText&&window._showThinking!==false&&!isSimplifiedToolCalling())){
       seg.classList.add('assistant-segment-anchor');
     }
     _assistantTurnBlocks(currentAssistantTurn).appendChild(seg);
@@ -2813,53 +2852,78 @@ function renderMessages(){
     });
     if(derived.length) S.toolCalls=derived;
   }
-  if(!S.busy && S.toolCalls && S.toolCalls.length){
-    inner.querySelectorAll('.tool-card-row:not([data-compression-card])').forEach(el=>el.remove());
+  if(!S.busy){
+    inner.querySelectorAll('.tool-call-group:not([data-compression-card]),.tool-card-row:not([data-compression-card])').forEach(el=>el.remove());
     const byAssistant = {};
-    for(const tc of S.toolCalls){
+    for(const tc of (S.toolCalls||[])){
       const key = tc.assistant_msg_idx !== undefined ? tc.assistant_msg_idx : -1;
       if(!byAssistant[key]) byAssistant[key] = [];
       byAssistant[key].push(tc);
     }
     const assistantIdxs=[...assistantSegments.keys()].sort((a,b)=>a-b);
     const anchorInsertAfter = new Map();
-    for(const [key, cards] of Object.entries(byAssistant)){
-      const aIdx = parseInt(key);
-      let anchorRow=assistantSegments.get(aIdx)||null;
-      if(!anchorRow&&assistantIdxs.length){
-        const fallbackIdx=[...assistantIdxs].reverse().find(idx=>idx<=aIdx);
-        anchorRow=fallbackIdx!==undefined?assistantSegments.get(fallbackIdx):assistantSegments.get(assistantIdxs[assistantIdxs.length-1]);
+    if(isSimplifiedToolCalling()){
+      const activityIdxs=[...new Set([...Object.keys(byAssistant).map(k=>parseInt(k)), ...assistantThinking.keys()])].sort((a,b)=>a-b);
+      for(const aIdx of activityIdxs){
+        const cards=byAssistant[aIdx]||[];
+        let anchorRow=assistantSegments.get(aIdx)||null;
+        if(!anchorRow&&assistantIdxs.length){
+          const fallbackIdx=[...assistantIdxs].reverse().find(idx=>idx<=aIdx);
+          anchorRow=fallbackIdx!==undefined?assistantSegments.get(fallbackIdx):assistantSegments.get(assistantIdxs[assistantIdxs.length-1]);
+        }
+        if(!anchorRow) continue;
+        const anchorParent=anchorRow.parentElement;
+        const insertAfterNode = anchorInsertAfter.get(anchorRow) || anchorRow;
+        const group=ensureActivityGroup(anchorParent,{collapsed:true,anchor:insertAfterNode});
+        const body=group&&group.querySelector('.tool-call-group-body');
+        if(!body) continue;
+        const thinkingText=assistantThinking.get(aIdx);
+        if(thinkingText) body.appendChild(_thinkingActivityNode(thinkingText));
+        for(const tc of cards){
+          body.appendChild(buildToolCard(tc));
+        }
+        _syncToolCallGroupSummary(group);
+        if(anchorRow) anchorInsertAfter.set(anchorRow, group);
       }
-      if(!anchorRow) continue;
-      const anchorParent=anchorRow.parentElement;
-      const frag=document.createDocumentFragment();
-      let lastInsertedNode=null;
-      for(const tc of cards){
-        const card=buildToolCard(tc);
-        frag.appendChild(card);
-        lastInsertedNode=card;
+    }else if(S.toolCalls && S.toolCalls.length){
+      for(const [key, cards] of Object.entries(byAssistant)){
+        const aIdx = parseInt(key);
+        let anchorRow=assistantSegments.get(aIdx)||null;
+        if(!anchorRow&&assistantIdxs.length){
+          const fallbackIdx=[...assistantIdxs].reverse().find(idx=>idx<=aIdx);
+          anchorRow=fallbackIdx!==undefined?assistantSegments.get(fallbackIdx):assistantSegments.get(assistantIdxs[assistantIdxs.length-1]);
+        }
+        if(!anchorRow) continue;
+        const anchorParent=anchorRow.parentElement;
+        const frag=document.createDocumentFragment();
+        let lastInsertedNode=null;
+        for(const tc of cards){
+          const card=buildToolCard(tc);
+          frag.appendChild(card);
+          lastInsertedNode=card;
+        }
+        // Add expand/collapse toggle for groups with 2+ cards
+        if(cards.length>=2){
+          const toggle=document.createElement('div');
+          toggle.className='tool-cards-toggle';
+          // Collect card elements before they get moved to DOM
+          const cardEls=Array.from(frag.querySelectorAll('.tool-card'));
+          const expandBtn=document.createElement('button');
+          expandBtn.textContent=t('expand_all');
+          expandBtn.onclick=()=>cardEls.forEach(c=>c.classList.add('open'));
+          const collapseBtn=document.createElement('button');
+          collapseBtn.textContent=t('collapse_all');
+          collapseBtn.onclick=()=>cardEls.forEach(c=>c.classList.remove('open'));
+          toggle.appendChild(expandBtn);
+          toggle.appendChild(collapseBtn);
+          frag.insertBefore(toggle,frag.firstChild);
+        }
+        const insertAfterNode = anchorInsertAfter.get(anchorRow) || anchorRow;
+        const refNode = insertAfterNode ? insertAfterNode.nextSibling : null;
+        if(refNode) anchorParent.insertBefore(frag,refNode);
+        else anchorParent.appendChild(frag);
+        if(anchorRow&&lastInsertedNode) anchorInsertAfter.set(anchorRow, lastInsertedNode);
       }
-      // Add expand/collapse toggle for groups with 2+ cards
-      if(cards.length>=2){
-        const toggle=document.createElement('div');
-        toggle.className='tool-cards-toggle';
-        // Collect card elements before they get moved to DOM
-        const cardEls=Array.from(frag.querySelectorAll('.tool-card'));
-        const expandBtn=document.createElement('button');
-        expandBtn.textContent=t('expand_all');
-        expandBtn.onclick=()=>cardEls.forEach(c=>c.classList.add('open'));
-        const collapseBtn=document.createElement('button');
-        collapseBtn.textContent=t('collapse_all');
-        collapseBtn.onclick=()=>cardEls.forEach(c=>c.classList.remove('open'));
-        toggle.appendChild(expandBtn);
-        toggle.appendChild(collapseBtn);
-        frag.insertBefore(toggle,frag.firstChild);
-      }
-      const insertAfterNode = anchorInsertAfter.get(anchorRow) || anchorRow;
-      const refNode = insertAfterNode ? insertAfterNode.nextSibling : null;
-      if(refNode) anchorParent.insertBefore(frag,refNode);
-      else anchorParent.appendChild(frag);
-      if(anchorRow&&lastInsertedNode) anchorInsertAfter.set(anchorRow, lastInsertedNode);
     }
   }
   // Render per-turn token usage on each assistant message that has it (#503).
@@ -2916,6 +2980,12 @@ function renderMessages(){
   }
 }
 
+function _toolDisplayName(tc){
+  const name=(tc&&tc.name)||'tool';
+  if(name==='subagent_progress') return 'Subagent';
+  if(name==='delegate_task') return 'Delegate task';
+  return name;
+}
 function toolIcon(name){
   const icons={
     terminal:        li('terminal'),
@@ -2960,9 +3030,7 @@ function buildToolCard(tc){
   const isDelegation=tc.name==='delegate_task';
   const cardClass='tool-card'+(tc.done===false?' tool-card-running':'')+(isSubagent?' tool-card-subagent':'');
   // Clean up legacy subagent prefixes since the Lucide icon already shows it
-  let displayName=tc.name;
-  if(isSubagent) displayName='Subagent';
-  if(isDelegation) displayName='Delegate task';
+  let displayName=_toolDisplayName(tc);
   let previewText=tc.preview||displaySnippet||'';
   if(isSubagent) previewText=previewText.replace(/^(?:\u{1F500}|↳)\s*/u,'');
   row.innerHTML=`
@@ -2987,6 +3055,33 @@ function buildToolCard(tc){
   return row;
 }
 
+function _syncToolCallGroupSummary(group){
+  if(!group) return;
+  const cards=Array.from(group.querySelectorAll('.tool-card-row .tool-card'));
+  const toolCount=cards.length;
+  const thinkingCount=group.querySelectorAll('.agent-activity-thinking .thinking-card').length;
+  const names=cards.map(card=>{
+    const el=card.querySelector('.tool-card-name');
+    return el?String(el.textContent||'').trim():'';
+  }).filter(Boolean);
+  const uniqueNames=[...new Set(names)];
+  const label=group.querySelector('.tool-call-group-label');
+  const list=group.querySelector('.tool-call-group-list');
+  const badge=group.querySelector('.tool-call-group-count');
+  const parts=[];
+  if(thinkingCount) parts.push('thinking');
+  if(uniqueNames.length) parts.push(uniqueNames.slice(0,5).join(', ')+(uniqueNames.length>5?'…':''));
+  const total=toolCount+thinkingCount;
+  if(label){
+    if(thinkingCount&&toolCount) label.textContent=`Activity: thinking + ${toolCount} tool${toolCount===1?'':'s'}`;
+    else if(thinkingCount) label.textContent='Activity: thinking';
+    else if(toolCount) label.textContent=`Activity: ${toolCount} tool${toolCount===1?'':'s'}`;
+    else label.textContent='Activity';
+  }
+  if(list) list.textContent=parts.join(' · ')||'tools / thinking';
+  if(badge) badge.textContent=String(total);
+}
+
 // ── Live tool card helpers (called during SSE streaming) ──
 // Live cards are inserted INLINE inside #msgInner (tagged with data-live-tid)
 // so the streaming layout matches the settled layout produced by renderMessages
@@ -3000,52 +3095,76 @@ function appendLiveToolCard(tc){
   if(!S.session||!S.activeStreamId) return;
   let turn=$('liveAssistantTurn');
   if(!turn){
-    appendThinking();
-    turn=$('liveAssistantTurn');
+    turn=_createAssistantTurn();
+    turn.id='liveAssistantTurn';
+    $('msgInner').appendChild(turn);
   }
   const inner=_assistantTurnBlocks(turn);
   if(!inner) return;
   const tid=tc.tid||'';
+  if(!isSimplifiedToolCalling()){
+    // Update existing card in place (tool_complete after tool_start)
+    if(tid){
+      const existing=inner.querySelector(`.tool-card-row[data-live-tid="${CSS.escape(tid)}"]`);
+      if(existing){
+        const replacement=buildToolCard(tc);
+        replacement.dataset.liveTid=tid;
+        existing.replaceWith(replacement);
+        // Keep #toolRunningRow alive — dots stay until text starts streaming
+        // or the next tool fires (which replaces them). Removing here caused
+        // a gap between tool completion and the first text token arriving.
+        return;
+      }
+    }
+    const row=buildToolCard(tc);
+    if(tid) row.dataset.liveTid=tid;
+    // Insert after whichever comes last: the current live assistant segment or
+    // the last tool card. This handles both cases:
+    //   text → tool1 → tool2  (no text between tools: anchor is card1)
+    //   text1 → tool1 → text2 → tool2  (text between tools: anchor is text2)
+    const children=Array.from(inner.children);
+    // Include .thinking-card-row so tool cards land AFTER a finalized thinking
+    // card, not between the text segment and thinking.
+    const anchor=children.filter(el=>el.matches('[data-live-assistant="1"],.tool-card-row,.thinking-card-row')).pop();
+    if(anchor) anchor.insertAdjacentElement('afterend', row);
+    else inner.appendChild(row);
+    // Add a 3-dot waiting indicator below the tool card so there's visual
+    // feedback while the tool is running. Removed when text starts streaming
+    // (ensureAssistantRow) or when tool_complete fires.
+    const oldWait=$('toolRunningRow');if(oldWait)oldWait.remove();
+    const waitRow=document.createElement('div');
+    waitRow.id='toolRunningRow';
+    waitRow.className='assistant-segment';
+    waitRow.innerHTML='<div class="thinking"><div class="dot"></div><div class="dot"></div><div class="dot"></div></div>';
+    row.insertAdjacentElement('afterend', waitRow);
+    if(typeof scrollIfPinned==='function') scrollIfPinned();
+    return;
+  }
+  const children=Array.from(inner.children);
+  const anchor=children.filter(el=>el.matches('[data-live-assistant="1"],.tool-call-group,.tool-card-row,.agent-activity-thinking')).pop();
+  const group=ensureActivityGroup(inner,{live:true,collapsed:false,anchor});
+  const body=group.querySelector('.tool-call-group-body');
   // Update existing card in place (tool_complete after tool_start)
   if(tid){
-    const existing=inner.querySelector(`.tool-card-row[data-live-tid="${CSS.escape(tid)}"]`);
+    const existing=body.querySelector(`.tool-card-row[data-live-tid="${CSS.escape(tid)}"]`);
     if(existing){
       const replacement=buildToolCard(tc);
       replacement.dataset.liveTid=tid;
       existing.replaceWith(replacement);
-      // Keep #toolRunningRow alive — dots stay until text starts streaming
-      // or the next tool fires (which replaces them). Removing here caused
-      // a gap between tool completion and the first text token arriving.
+      _syncToolCallGroupSummary(group);
       return;
     }
   }
   const row=buildToolCard(tc);
   if(tid) row.dataset.liveTid=tid;
-  // Insert after whichever comes last: the current live assistant segment or
-  // the last tool card. This handles both cases:
-  //   text → tool1 → tool2  (no text between tools: anchor is card1)
-  //   text1 → tool1 → text2 → tool2  (text between tools: anchor is text2)
-  const children=Array.from(inner.children);
-  // Include .thinking-card-row so tool cards land AFTER a finalized thinking
-  // card, not between the text segment and thinking.
-  const anchor=children.filter(el=>el.matches('[data-live-assistant="1"],.tool-card-row,.thinking-card-row')).pop();
-  if(anchor) anchor.insertAdjacentElement('afterend', row);
-  else inner.appendChild(row);
-  // Add a 3-dot waiting indicator below the tool card so there's visual
-  // feedback while the tool is running. Removed when text starts streaming
-  // (ensureAssistantRow) or when tool_complete fires.
-  const oldWait=$('toolRunningRow');if(oldWait)oldWait.remove();
-  const waitRow=document.createElement('div');
-  waitRow.id='toolRunningRow';
-  waitRow.className='assistant-segment';
-  waitRow.innerHTML='<div class="thinking"><div class="dot"></div><div class="dot"></div><div class="dot"></div></div>';
-  row.insertAdjacentElement('afterend', waitRow);
+  body.appendChild(row);
+  _syncToolCallGroupSummary(group);
   if(typeof scrollIfPinned==='function') scrollIfPinned();
 }
 
 function clearLiveToolCards(){
   const inner=_assistantTurnBlocks($('liveAssistantTurn'));
-  if(inner) inner.querySelectorAll('.tool-card-row[data-live-tid]').forEach(el=>el.remove());
+  if(inner) inner.querySelectorAll('.tool-call-group[data-live-tool-call-group],.tool-card-row[data-live-tid]').forEach(el=>el.remove());
   // Legacy #liveToolCards container cleanup — kept for safety in case any
   // leftover cards were inserted there before this refactor took effect.
   const container=$('liveToolCards');
@@ -3434,30 +3553,44 @@ function renderKatexBlocks(){
 
 function _thinkingMarkup(text=''){
   const clean=_sanitizeThinkingDisplayText(text);
+  const openClass=isSimplifiedToolCalling()?'':' open';
   return (clean&&String(clean).trim())
-    ? `<div class="thinking-card open"><div class="thinking-card-header" onclick="this.parentElement.classList.toggle('open')"><span class="thinking-card-icon">${li('lightbulb',14)}</span><span class="thinking-card-label">${t('thinking')}</span><span class="thinking-card-toggle">${li('chevron-right',12)}</span></div><div class="thinking-card-body"><pre>${esc(String(clean).trim())}</pre></div></div>`
+    ? `<div class="thinking-card${openClass}"><div class="thinking-card-header" onclick="this.parentElement.classList.toggle('open')"><span class="thinking-card-icon">${li('lightbulb',14)}</span><span class="thinking-card-label">${t('thinking')}</span><span class="thinking-card-toggle">${li('chevron-right',12)}</span></div><div class="thinking-card-body"><pre>${esc(String(clean).trim())}</pre></div></div>`
     : `<div class="thinking"><div class="dot"></div><div class="dot"></div><div class="dot"></div></div>`;
 }
 function finalizeThinkingCard(){
-  const row=$('thinkingRow');
-  if(!row) return;
-  // If the row is still just a spinner (no thinking content rendered),
-  // remove it entirely — it's the initial waiting dots.
-  const hasContent=row.querySelector('.thinking-card') || row.classList.contains('thinking-card-row');
-  if(!hasContent && row.getAttribute('data-thinking-active')==='1'){
-    row.remove();
+  if(!isSimplifiedToolCalling()){
+    const row=$('thinkingRow');
+    if(!row) return;
+    // If the row is still just a spinner (no thinking content rendered),
+    // remove it entirely — it's the initial waiting dots.
+    const hasContent=row.querySelector('.thinking-card') || row.classList.contains('thinking-card-row');
+    if(!hasContent && row.getAttribute('data-thinking-active')==='1'){
+      row.remove();
+      return;
+    }
+    // If the user was watching (scroll pinned = at bottom), scroll the thinking
+    // card back to the top so the completed response is visible underneath without
+    // the thinking content blocking it. If they scrolled up to read history,
+    // leave their scroll position intact.
+    if(_scrollPinned){
+      const body=row&&row.querySelector('.thinking-card-body');
+      if(body) body.scrollTop=0;
+    }
+    row.removeAttribute('id');
+    row.removeAttribute('data-thinking-active');
     return;
   }
-  // If the user was watching (scroll pinned = at bottom), scroll the thinking
-  // card back to the top so the completed response is visible underneath without
-  // the thinking content blocking it. If they scrolled up to read history,
-  // leave their scroll position intact.
-  if(_scrollPinned){
-    const body=row&&row.querySelector('.thinking-card-body');
-    if(body) body.scrollTop=0;
+  const turn=$('liveAssistantTurn');
+  const group=turn&&turn.querySelector('.tool-call-group[data-live-tool-call-group="1"]');
+  if(group){
+    group.classList.add('tool-call-group-collapsed');
+    const summary=group.querySelector('.tool-call-group-summary');
+    if(summary) summary.setAttribute('aria-expanded','false');
+    const active=group.querySelector('.agent-activity-thinking[data-thinking-active="1"]');
+    if(active) active.removeAttribute('data-thinking-active');
+    _syncToolCallGroupSummary(group);
   }
-  row.removeAttribute('id');
-  row.removeAttribute('data-thinking-active');
 }
 function appendThinking(text=''){
   // Guard: ignore if session was switched during an async SSE stream.
@@ -3472,40 +3605,81 @@ function appendThinking(text=''){
     $('msgInner').appendChild(turn);
   }
   const blocks=_assistantTurnBlocks(turn);
-  let row=$('thinkingRow');
+  if(!blocks) return;
+  if(!isSimplifiedToolCalling()){
+    let row=$('thinkingRow');
+    if(!row){
+      row=document.createElement('div');
+      row.className='assistant-segment';
+      row.id='thinkingRow';
+      row.setAttribute('data-thinking-active','1');
+      // Insert after whichever comes last: a live assistant segment or a tool card.
+      // This mirrors appendLiveToolCard's anchor logic so thinking always appears
+      // in the right position in the interleaved sequence.
+      // Also skip #toolRunningRow (dots) — thinking should go before dots, not after.
+      const allChildren=Array.from(blocks.children);
+      const anchor=allChildren.filter(el=>
+        el.id!=='toolRunningRow' &&
+        el.matches('[data-live-assistant="1"],.tool-card-row')
+      ).pop();
+      if(anchor) anchor.insertAdjacentElement('afterend', row);
+      else blocks.appendChild(row);
+    }
+    row.className=(text&&String(text).trim())?'assistant-segment thinking-card-row':'assistant-segment';
+    row.innerHTML=_thinkingMarkup(text);
+    scrollIfPinned();
+    // Auto-scroll the thinking card body to bottom if the user is watching
+    // (scroll pinned). If the user scrolled up to read history, leave it alone.
+    if(_scrollPinned){
+      const body=row&&row.querySelector('.thinking-card-body');
+      if(body) body.scrollTop=body.scrollHeight;
+    }
+    return;
+  }
+  if(!String(text||'').trim()){
+    scrollIfPinned();
+    return;
+  }
+  const allChildren=Array.from(blocks.children);
+  const anchor=allChildren.filter(el=>
+    el.id!=='toolRunningRow' &&
+    el.matches('[data-live-assistant="1"],.tool-call-group,.tool-card-row,.agent-activity-thinking')
+  ).pop();
+  const group=ensureActivityGroup(blocks,{live:true,collapsed:true,anchor});
+  const body=group&&group.querySelector('.tool-call-group-body');
+  if(!body) return;
+  let row=body.querySelector('.agent-activity-thinking[data-thinking-active="1"]');
   if(!row){
     row=document.createElement('div');
-    row.className='assistant-segment';
-    row.id='thinkingRow';
+    row.className='agent-activity-thinking';
     row.setAttribute('data-thinking-active','1');
-    // Insert after whichever comes last: a live assistant segment or a tool card.
-    // This mirrors appendLiveToolCard's anchor logic so thinking always appears
-    // in the right position in the interleaved sequence.
-    // Also skip #toolRunningRow (dots) — thinking should go before dots, not after.
-    const allChildren=Array.from(blocks.children);
-    const anchor=allChildren.filter(el=>
-      el.id!=='toolRunningRow' &&
-      el.matches('[data-live-assistant="1"],.tool-card-row')
-    ).pop();
-    if(anchor) anchor.insertAdjacentElement('afterend', row);
-    else blocks.appendChild(row);
+    body.insertBefore(row, body.firstChild);
   }
-  row.className=(text&&String(text).trim())?'assistant-segment thinking-card-row':'assistant-segment';
   row.innerHTML=_thinkingMarkup(text);
+  _syncToolCallGroupSummary(group);
   scrollIfPinned();
-  // Auto-scroll the thinking card body to bottom if the user is watching
-  // (scroll pinned). If the user scrolled up to read history, leave it alone.
   if(_scrollPinned){
-    const body=row&&row.querySelector('.thinking-card-body');
-    if(body) body.scrollTop=body.scrollHeight;
+    const thinkingBody=row&&row.querySelector('.thinking-card-body');
+    if(thinkingBody) thinkingBody.scrollTop=thinkingBody.scrollHeight;
   }
 }
 function updateThinking(text=''){appendThinking(text);}
 function removeThinking(){
-  const el=$('thinkingRow');
-  if(el) el.remove();
+  if(!isSimplifiedToolCalling()){
+    const el=$('thinkingRow');
+    if(el) el.remove();
+    const turn=$('liveAssistantTurn');
+    const blocks=_assistantTurnBlocks(turn);
+    if(turn&&blocks&&!blocks.children.length) turn.remove();
+    return;
+  }
   const turn=$('liveAssistantTurn');
   const blocks=_assistantTurnBlocks(turn);
+  if(blocks) blocks.querySelectorAll('.agent-activity-thinking').forEach(el=>el.remove());
+  if(blocks) blocks.querySelectorAll('.tool-call-group[data-agent-activity-group="1"]').forEach(group=>{
+    _syncToolCallGroupSummary(group);
+    if(!group.querySelector('.tool-card-row,.agent-activity-thinking')) group.remove();
+  });
   if(turn&&blocks&&!blocks.children.length) turn.remove();
 }
 

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -665,13 +665,15 @@ def test_ui_js_keeps_reasoning_only_assistant_messages_visible(cleanup_test_sess
 
 
 def test_ui_js_does_not_hide_anchor_segments_that_contain_thinking(cleanup_test_sessions):
-    """R19c2: assistant anchor segments that contain a thinking card must remain
-    visible; only truly empty tool-call anchor segments should be hidden.
+    """R19c2/R19c3: reasoning-only messages must remain visible through the
+    shared collapsed activity dropdown, even when the anchor segment has no prose.
     """
     src = (REPO_ROOT / "static" / "ui.js").read_text()
     compact = src.replace(' ', '').replace('\n', '')
-    assert "}elseif(!thinkingText){" in compact, \
-        "renderMessages must only hide assistant anchor segments when they have no thinking content"
+    assert "assistantThinking.set(rawIdx,thinkingText)" in compact, \
+        "renderMessages must preserve reasoning text before hiding empty anchor segments"
+    assert "_thinkingActivityNode(thinkingText)" in src, \
+        "thinking-only assistant content should render inside the shared activity dropdown"
 
 
 def test_messages_js_live_assistant_segment_reuses_live_turn_wrapper(cleanup_test_sessions):

--- a/tests/test_simplified_tool_calling_setting.py
+++ b/tests/test_simplified_tool_calling_setting.py
@@ -1,0 +1,29 @@
+"""Regression tests for the Simplified tool calling setting."""
+
+import importlib
+import json
+
+
+def test_simplified_tool_calling_defaults_enabled_and_round_trips(monkeypatch, tmp_path):
+    import api.config as config
+
+    settings_path = tmp_path / "settings.json"
+    monkeypatch.setattr(config, "SETTINGS_FILE", settings_path)
+
+    loaded = config.load_settings()
+    assert loaded["simplified_tool_calling"] is True
+
+    saved = config.save_settings({"simplified_tool_calling": False})
+    assert saved["simplified_tool_calling"] is False
+    assert json.loads(settings_path.read_text(encoding="utf-8"))["simplified_tool_calling"] is False
+
+    saved = config.save_settings({"simplified_tool_calling": True})
+    assert saved["simplified_tool_calling"] is True
+
+
+def test_simplified_tool_calling_is_a_valid_boolean_setting():
+    import api.config as config
+
+    assert "simplified_tool_calling" in config._SETTINGS_DEFAULTS
+    assert "simplified_tool_calling" in config._SETTINGS_BOOL_KEYS
+    assert "simplified_tool_calling" in config._SETTINGS_ALLOWED_KEYS

--- a/tests/test_sprint49.py
+++ b/tests/test_sprint49.py
@@ -41,8 +41,11 @@ def test_timestamp_footer_stays_on_visible_response_segments():
     assert 'seg.insertAdjacentHTML(\'beforeend\', `${filesHtml}<div class="msg-body">${bodyHtml}</div>${footHtml}`);' in UI_JS, (
         "Footer timestamp should stay attached to visible response segments"
     )
-    assert "else if(!thinkingText){" in UI_JS, (
-        "Thinking-only assistant segments should still avoid rendering a footer"
+    assert "assistantThinking.set(rawIdx, thinkingText);" in UI_JS, (
+        "Thinking-only assistant segments should preserve thinking for the shared activity dropdown without rendering a footer"
+    )
+    assert "seg.classList.add('assistant-segment-anchor');" in UI_JS, (
+        "Empty assistant anchor segments should stay footerless while anchoring activity metadata"
     )
 
 

--- a/tests/test_ui_card_animation.py
+++ b/tests/test_ui_card_animation.py
@@ -41,7 +41,7 @@ def test_thinking_card_toggle_and_body_use_animation_friendly_state():
 def test_tool_card_toggle_uses_same_chevron_icon_markup_as_thinking_card():
     assert "<span class=\"thinking-card-toggle\">${li('chevron-right',12)}</span>" in UI_JS
     assert "<span class=\"tool-card-toggle\">${li('chevron-right',12)}</span>" in UI_JS
-    assert "<div class=\"thinking-card open\"><div class=\"thinking-card-header\" onclick=\"this.parentElement.classList.toggle('open')\"><span class=\"thinking-card-icon\">" in UI_JS
+    assert "<div class=\"thinking-card\"><div class=\"thinking-card-header\" onclick=\"this.parentElement.classList.toggle('open')\"><span class=\"thinking-card-icon\">" in UI_JS
 
 
 def test_thinking_card_uses_panel_chrome_with_gold_palette():

--- a/tests/test_ui_tool_call_cleanup.py
+++ b/tests/test_ui_tool_call_cleanup.py
@@ -1,0 +1,279 @@
+"""Static UI tests for quieter tool-call rendering and shared design tokens.
+
+These tests intentionally follow the repo's existing pytest style: read static
+source files, isolate the relevant function/rule, and assert implementation
+invariants before changing the UI.
+"""
+import pathlib
+import re
+
+REPO = pathlib.Path(__file__).parent.parent
+UI_JS = (REPO / "static" / "ui.js").read_text(encoding="utf-8")
+BOOT_JS = (REPO / "static" / "boot.js").read_text(encoding="utf-8")
+CSS = (REPO / "static" / "style.css").read_text(encoding="utf-8")
+
+
+def _function_body(src: str, name: str) -> str:
+    match = re.search(rf"function\s+{re.escape(name)}\s*\(", src)
+    assert match, f"{name}() not found"
+    brace = src.find("{", match.end())
+    assert brace != -1, f"{name}() has no body"
+    depth = 1
+    i = brace + 1
+    in_string = None
+    escaped = False
+    in_line_comment = False
+    in_block_comment = False
+    while i < len(src) and depth:
+        ch = src[i]
+        nxt = src[i + 1] if i + 1 < len(src) else ""
+        if in_line_comment:
+            if ch == "\n":
+                in_line_comment = False
+            i += 1
+            continue
+        if in_block_comment:
+            if ch == "*" and nxt == "/":
+                in_block_comment = False
+                i += 2
+                continue
+            i += 1
+            continue
+        if in_string:
+            if escaped:
+                escaped = False
+            elif ch == "\\":
+                escaped = True
+            elif ch == in_string:
+                in_string = None
+            i += 1
+            continue
+        if ch == "/" and nxt == "/":
+            in_line_comment = True
+            i += 2
+            continue
+        if ch == "/" and nxt == "*":
+            in_block_comment = True
+            i += 2
+            continue
+        if ch in "'\"`":
+            in_string = ch
+            i += 1
+            continue
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+        i += 1
+    assert depth == 0, f"{name}() body did not close"
+    return src[brace + 1:i - 1]
+
+
+class TestToolCallGroupingStatic:
+    def test_simplified_tool_calling_setting_is_wired_through_frontend(self):
+        assert "settingsSimplifiedToolCalling" in (REPO / "static" / "index.html").read_text(encoding="utf-8"), (
+            "Settings should expose a Compact tool activity checkbox."
+        )
+        assert "window._simplifiedToolCalling" in (REPO / "static" / "boot.js").read_text(encoding="utf-8"), (
+            "Boot should hydrate simplified_tool_calling into a runtime flag."
+        )
+        panels = (REPO / "static" / "panels.js").read_text(encoding="utf-8")
+        assert "settingsSimplifiedToolCalling" in panels and "simplified_tool_calling" in panels, (
+            "Settings panel should load and save the simplified_tool_calling setting."
+        )
+
+    def test_render_messages_gates_settled_activity_grouping(self):
+        fn = _function_body(UI_JS, "renderMessages")
+        helper = _function_body(UI_JS, "ensureActivityGroup")
+        assert "isSimplifiedToolCalling()" in fn, (
+            "Settled tool/thinking grouping should be gated by the Compact tool activity toggle."
+        )
+        assert "tool-cards-toggle" in fn, (
+            "The non-simplified path should preserve the upstream loose tool-card controls."
+        )
+        assert "data-tool-call-group" in helper, (
+            "Tool-call groups need a stable data-tool-call-group attribute for CSS and tests."
+        )
+        assert re.search(r"cards\.length|toolCount|toolCalls\.length|group\.length", fn + helper), (
+            "The simplified group header should derive its summary/count from the number of tool calls."
+        )
+
+    def test_tool_call_groups_default_collapsed_with_summary_visible(self):
+        fn = _function_body(UI_JS, "renderMessages")
+        helper = _function_body(UI_JS, "ensureActivityGroup")
+        assert "tool-call-group-collapsed" in fn or "collapsed" in fn, (
+            "Historical tool-call groups should default to a collapsed state."
+        )
+        assert "tool-call-group-summary" in helper, (
+            "Collapsed groups must expose a visible summary/header row."
+        )
+        assert "tool-call-group-body" in helper, (
+            "Tool-card detail rows should live inside a group body that can be "
+            "expanded/collapsed."
+        )
+        assert "aria-expanded" in helper, (
+            "The expand/collapse control must expose aria-expanded."
+        )
+
+    def test_live_tool_cards_use_grouping_only_when_simplified(self):
+        live_fn = _function_body(UI_JS, "appendLiveToolCard")
+        settled_fn = _function_body(UI_JS, "renderMessages")
+        assert "isSimplifiedToolCalling()" in live_fn, (
+            "Live streaming tool cards should branch on the Compact tool activity toggle."
+        )
+        assert "ensureActivityGroup" in live_fn, (
+            "Compact live tool rendering should use the grouped activity container."
+        )
+        assert "toolRunningRow" in live_fn, (
+            "The non-simplified live tool path should preserve the upstream running-dots row."
+        )
+        assert "buildToolCard" in live_fn and "buildToolCard" in settled_fn, (
+            "Live and settled tool rendering should share buildToolCard() for consistent markup."
+        )
+        assert "data-live-tid" in live_fn, (
+            "Live grouping must preserve data-live-tid so tool_start/tool_complete updates still replace the correct card."
+        )
+
+    def test_tools_and_thinking_share_one_collapsed_activity_dropdown(self):
+        ui_min = re.sub(r"\s+", "", UI_JS)
+        assert "functionensureActivityGroup(" in ui_min, (
+            "Tool calls and thinking should share one agent-activity disclosure helper."
+        )
+        assert "data-agent-activity-group" in UI_JS, (
+            "The shared tools/thinking disclosure needs a stable data-agent-activity-group hook."
+        )
+        assert "agent-activity-thinking" in UI_JS, (
+            "Thinking content should be nested inside the shared activity dropdown, not rendered separately."
+        )
+        render_fn = _function_body(UI_JS, "renderMessages")
+        assert "isSimplifiedToolCalling()" in render_fn and "assistantThinking.set(rawIdx, thinkingText)" in render_fn, (
+            "Settled thinking should move into the shared activity dropdown only when Compact tool activity is enabled."
+        )
+        assert "seg.insertAdjacentHTML('beforeend', _thinkingCardHtml(thinkingText))" in render_fn, (
+            "The non-simplified path should preserve standalone settled thinking cards."
+        )
+
+    def test_live_thinking_uses_shared_activity_dropdown_only_when_simplified(self):
+        live_thinking_fn = _function_body(UI_JS, "appendThinking")
+        assert "isSimplifiedToolCalling()" in live_thinking_fn, (
+            "Live thinking should branch on the Compact tool activity toggle."
+        )
+        assert "ensureActivityGroup" in live_thinking_fn, (
+            "Compact live thinking should be inserted into the shared activity dropdown."
+        )
+        assert "thinkingRow" in live_thinking_fn, (
+            "The non-simplified live thinking path should preserve the upstream #thinkingRow card."
+        )
+
+
+class TestToolCardDesignTokens:
+    def test_root_defines_shared_layout_design_tokens(self):
+        for token in (
+            "--radius-sm",
+            "--radius-md",
+            "--radius-card",
+            "--space-1",
+            "--space-2",
+            "--space-3",
+            "--font-size-xs",
+            "--font-size-sm",
+            "--surface-subtle",
+            "--border-subtle",
+        ):
+            assert token in CSS, f"Missing design token {token} in style.css"
+
+    def test_base_dark_palette_restores_upstream_gold_tokens(self):
+        css_min = re.sub(r"\s+", "", CSS)
+        expected_tokens = (
+            "--bg:#0D0D1A",
+            "--sidebar:#141425",
+            "--border:#2A2A45",
+            "--text:#FFF8DC",
+            "--muted:#C0C0C0",
+            "--accent:#FFD700",
+            "--surface:#1A1A2E",
+            "--topbar-bg:rgba(20,20,37,.98)",
+        )
+        for token in expected_tokens:
+            assert token in css_min, f"Base dark palette token missing: {token}"
+
+    def test_base_light_palette_restores_upstream_gold_tokens(self):
+        css_min = re.sub(r"\s+", "", CSS)
+        expected_tokens = (
+            "--bg:#FEFCF7",
+            "--sidebar:#FAF7F0",
+            "--border:#E0D8C8",
+            "--text:#1A1610",
+            "--muted:#5C5344",
+            "--accent:#B8860B",
+            "--surface:#F3EEE3",
+        )
+        for token in expected_tokens:
+            assert token in css_min, f"Base light palette token missing: {token}"
+
+    def test_calm_console_palette_is_gated_as_custom_theme_not_base(self):
+        css_min = re.sub(r"\s+", "", CSS)
+        assert ':root.dark[data-theme="calm"]' in css_min, (
+            "Coolors calm palette should be gated behind the custom calm theme."
+        )
+        for token in (
+            "--bg:#0A0908",
+            "--sidebar:#22333B",
+            "--text:#EAE0D5",
+            "--muted:#C6AC8F",
+            "--accent:#C6AC8F",
+        ):
+            assert token in css_min, f"Calm custom theme token missing: {token}"
+
+    def test_default_skin_preview_stays_upstream_and_calm_theme_preview_is_separate(self):
+        boot_min = re.sub(r"\s+", "", BOOT_JS)
+        assert "{name:'Default',colors:['#FFD700','#FFBF00','#CD7F32']}" in boot_min, (
+            "The Default skin swatch should stay aligned with the upstream gold base."
+        )
+        assert "{name:'Calm'," in boot_min and "colors:['#C6AC8F','#EAE0D5','#22333B']" in boot_min, (
+            "The Coolors palette should be exposed as a separate custom Calm theme preview."
+        )
+
+    def test_claude_like_message_typography_splits_user_and_assistant_fonts(self):
+        css_min = re.sub(r"\s+", "", CSS)
+        assert "--font-ui:" in css_min and "--font-assistant:" in css_min, (
+            "Typography should define separate UI/user and assistant font tokens."
+        )
+        assert ".assistant-turn.msg-body{font-family:var(--font-assistant)" in css_min or ".assistant-turn.msg-body" in css_min.replace(" .", "."), (
+            "Assistant prose should use the Claude-like editorial serif stack."
+        )
+        assert ".msg-row[data-role=\"user\"].msg-body{font-family:var(--font-ui)" in css_min, (
+            "User bubbles should keep the sans/UI stack, matching Claude's split typography."
+        )
+        assert "Georgia" in CSS and "system-ui" in CSS, (
+            "Claude-like fallback stacks should include Georgia for assistant prose and system-ui for UI/user text."
+        )
+
+    def test_tool_card_css_uses_design_tokens_for_chrome(self):
+        css_min = re.sub(r"\s+", "", CSS)
+        assert ".tool-card{" in css_min, ".tool-card rule missing"
+        assert "border-radius:var(--radius-card)" in css_min, (
+            ".tool-card border radius should use --radius-card, not hardcoded px."
+        )
+        assert "background:var(--surface-subtle)" in css_min, (
+            ".tool-card background should use --surface-subtle."
+        )
+        assert "border:1pxsolidvar(--border-subtle)" in css_min, (
+            ".tool-card border should use --border-subtle."
+        )
+
+    def test_tool_card_header_and_text_use_spacing_and_font_tokens(self):
+        css_min = re.sub(r"\s+", "", CSS)
+        assert ".tool-card-header{" in css_min, ".tool-card-header rule missing"
+        assert "gap:var(--space-2)" in css_min, (
+            ".tool-card-header gap should use --space-2."
+        )
+        assert "padding:var(--space-1)var(--space-3)" in css_min, (
+            ".tool-card-header padding should use spacing tokens."
+        )
+        assert ".tool-card-name{" in css_min and "font-size:var(--font-size-xs)" in css_min, (
+            ".tool-card-name should use --font-size-xs."
+        )
+        assert ".tool-card-preview{" in css_min and "font-size:var(--font-size-xs)" in css_min, (
+            ".tool-card-preview should use --font-size-xs."
+        )


### PR DESCRIPTION
## Thinking Path

- Hermes WebUI is a chat-first interface, so long agent runs should remain easy to scan.
- Tool calls and thinking blocks are useful for transparency, but they can dominate the transcript when every internal step is shown as a full visible row.
- The goal is not to remove that detail; it is to make it less visually noisy by default while keeping the details inspectable.
- A settings toggle is the safest shape because users who prefer the existing verbose display can turn the compact treatment off.
- This PR adds **Compact tool activity** as an opt-out setting, keeping the compact grouped view enabled by default and preserving the original loose tool/thinking rendering path behind the toggle.

## What Changed

- Added a new boolean setting, `simplified_tool_calling`, displayed in Settings as **Compact tool activity**.
- Hydrates the frontend runtime flag as `window._simplifiedToolCalling` from `/api/settings`.
- Updates `static/ui.js` so assistant turn rendering branches between:
  - compact grouped activity disclosure; and
  - verbose/original-style standalone thinking and loose tool cards.
- Clears the message render cache after settings save so existing chat markup updates immediately when the setting changes.
- Adds tests for:
  - default setting behavior;
  - settings round-trip persistence;
  - frontend wiring;
  - compact and verbose rendering paths.
- Includes related UI/design token updates needed for the compact activity presentation.

## Why It Matters

Long-running agent conversations can produce many tool calls. Showing every internal step expanded into the main transcript creates visual clutter and makes the actual conversation harder to follow.

**Compact tool activity** gives users a quieter default: each assistant turn can summarize internal activity behind one disclosure such as “Activity: thinking + 4 tools.” The details are still available, but they no longer compete with the conversation by default.

Users who want the more verbose transcript can disable the setting and keep the previous standalone thinking/tool-call view.

## Verification

```bash
/home/michael/.hermes/hermes-agent/venv/bin/python -m pytest \
  tests/test_ui_tool_call_cleanup.py \
  tests/test_simplified_tool_calling_setting.py \
  tests/test_regressions.py \
  tests/test_sprint49.py \
  tests/test_ui_card_animation.py -q

node --check static/ui.js
node --check static/boot.js
node --check static/panels.js
git diff --check origin/master...HEAD
```

Result:

```text
75 passed in 6.82s
```

Manual verification:

- Confirmed the Settings checkbox is present as **Compact tool activity**.
- Confirmed compact mode groups thinking/tool activity into a single per-turn disclosure.
- Confirmed disabling the setting restores standalone thinking/tool-card rendering.
- Confirmed toggling the setting re-renders existing messages after settings save.

UI media:

- This PR changes visible UI/UX. Before/after screenshots or a short video should be attached before maintainer review if GitHub does not already show uploaded media in the conversation.

## Risks / Follow-ups

- Rendering logic now supports two display modes, so future tool/thinking UI changes should keep both compact and verbose paths covered.
- The setting key is intentionally named `simplified_tool_calling` internally even though the user-facing label is **Compact tool activity**.
- The PR includes related visual/design-token files in addition to the settings/rendering changes; if reviewers want an even tighter diff, the visual polish can be split out.

## Model Used

AI assisted.

- Provider: OpenAI via Hermes Agent
- Model: `gpt-5.5`
- Notable tool use: terminal/git/gh CLI for branch and PR work; Python/pytest and Node syntax checks for verification; file tools for code and test edits.