### PR TITLE
fix(providers): add missing OpenCode Go models

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -748,13 +748,20 @@ _PROVIDER_MODELS = {
     ],
     # OpenCode Go — flat-rate models via opencode.ai/go ($10/month)
     "opencode-go": [
-        {"id": "glm-5.1", "label": "GLM-5.1"},
-        {"id": "glm-5", "label": "GLM-5"},
-        {"id": "kimi-k2.5", "label": "Kimi K2.5"},
-        {"id": "mimo-v2-pro", "label": "MiMo V2 Pro"},
-        {"id": "mimo-v2-omni", "label": "MiMo V2 Omni"},
-        {"id": "minimax-m2.7", "label": "MiniMax M2.7"},
-        {"id": "minimax-m2.5", "label": "MiniMax M2.5"},
+        {"id": "glm-5.1",          "label": "GLM-5.1"},
+        {"id": "glm-5",            "label": "GLM-5"},
+        {"id": "kimi-k2.5",        "label": "Kimi K2.5"},
+        {"id": "kimi-k2.6",        "label": "Kimi K2.6"},
+        {"id": "deepseek-v4-pro",  "label": "DeepSeek V4 Pro"},
+        {"id": "deepseek-v4-flash","label": "DeepSeek V4 Flash"},
+        {"id": "mimo-v2-pro",      "label": "MiMo V2 Pro"},
+        {"id": "mimo-v2-omni",     "label": "MiMo V2 Omni"},
+        {"id": "mimo-v2.5-pro",    "label": "MiMo V2.5 Pro"},
+        {"id": "mimo-v2.5",        "label": "MiMo V2.5"},
+        {"id": "minimax-m2.7",     "label": "MiniMax M2.7"},
+        {"id": "minimax-m2.5",     "label": "MiniMax M2.5"},
+        {"id": "qwen3.6-plus",     "label": "Qwen3.6 Plus"},
+        {"id": "qwen3.5-plus",     "label": "Qwen3.5 Plus"},
     ],
     # 'gemini' is the hermes_cli provider ID for Google AI Studio
     # Model IDs are bare — sent directly to:

--- a/tests/test_opencode_providers.py
+++ b/tests/test_opencode_providers.py
@@ -49,7 +49,18 @@ def test_opencode_go_in_provider_models():
     ids = [m["id"] for m in config._PROVIDER_MODELS["opencode-go"]]
     assert "glm-5.1" in ids
     assert "glm-5" in ids
+    assert "kimi-k2.5" in ids
+    assert "kimi-k2.6" in ids
+    assert "deepseek-v4-pro" in ids
+    assert "deepseek-v4-flash" in ids
     assert "mimo-v2-pro" in ids
+    assert "mimo-v2-omni" in ids
+    assert "mimo-v2.5-pro" in ids
+    assert "mimo-v2.5" in ids
+    assert "minimax-m2.7" in ids
+    assert "minimax-m2.5" in ids
+    assert "qwen3.6-plus" in ids
+    assert "qwen3.5-plus" in ids
 
 
 # ── Env-var fallback detection ────────────────────────────────────────


### PR DESCRIPTION
Adds 7 missing models to the OpenCode Go provider catalog, reported by @uzairansaruzi in #1269.

## Changes

- `api/config.py` — 7 new entries in `_PROVIDER_MODELS["opencode-go"]`:
  - `kimi-k2.6` / Kimi K2.6
  - `deepseek-v4-pro` / DeepSeek V4 Pro
  - `deepseek-v4-flash` / DeepSeek V4 Flash
  - `mimo-v2.5-pro` / MiMo V2.5 Pro
  - `mimo-v2.5` / MiMo V2.5
  - `qwen3.6-plus` / Qwen3.6 Plus
  - `qwen3.5-plus` / Qwen3.5 Plus
- `tests/test_opencode_providers.py` — updated `test_opencode_go_in_provider_models` to assert all 14 models are present

## Test results

3064 passed, 2 skipped — full suite clean.

Closes #1269