### PR TITLE
fix: avoid duplicate terminal cwd in stream env

### DIFF
--- a/api/streaming.py
+++ b/api/streaming.py
@@ -35,6 +35,24 @@ from api.metering import meter
 # save/restore around the entire agent run.
 _ENV_LOCK = threading.Lock()
 
+
+def _build_agent_thread_env(profile_runtime_env, workspace, session_id, profile_home):
+    """Build thread-local env for an agent run.
+
+    Profile runtime env can include TERMINAL_CWD from config.yaml or .env, but
+    WebUI runs should execute from the session workspace. Merge into one dict so
+    explicit WebUI values override profile/global values without passing duplicate
+    keyword arguments to _set_thread_env().
+    """
+    env = dict(profile_runtime_env or {})
+    env.update({
+        'TERMINAL_CWD': str(workspace),
+        'HERMES_EXEC_ASK': '1',
+        'HERMES_SESSION_KEY': session_id,
+        'HERMES_HOME': profile_home,
+    })
+    return env
+
 # Lazy import to avoid circular deps -- hermes-agent is on sys.path via api/config.py
 try:
     from run_agent import AIAgent
@@ -1419,13 +1437,13 @@ def _run_agent_streaming(session_id, msg_text, model, workspace, stream_id, atta
             _profile_home = os.environ.get('HERMES_HOME', '')
             _profile_runtime_env = {}
 
-        _set_thread_env(
-            **_profile_runtime_env,
-            TERMINAL_CWD=str(s.workspace),
-            HERMES_EXEC_ASK='1',
-            HERMES_SESSION_KEY=session_id,
-            HERMES_HOME=_profile_home,
+        _thread_env = _build_agent_thread_env(
+            _profile_runtime_env,
+            workspace=s.workspace,
+            session_id=session_id,
+            profile_home=_profile_home,
         )
+        _set_thread_env(**_thread_env)
         # Still set process-level env as fallback for tools that bypass thread-local
         # Acquire lock only for the env mutation, then release before the agent runs.
         # The finally block re-acquires to restore — keeping critical sections short

--- a/tests/test_profile_terminal_env.py
+++ b/tests/test_profile_terminal_env.py
@@ -1,4 +1,5 @@
 import os
+import re
 from pathlib import Path
 
 import yaml
@@ -53,3 +54,34 @@ def test_streaming_applies_profile_runtime_env_to_agent_run():
     assert "_profile_runtime_env" in src
     assert "old_profile_env" in src
     assert "os.environ.update(_profile_runtime_env)" in src
+
+
+def test_streaming_thread_env_workspace_overrides_profile_terminal_cwd():
+    src = Path("api/streaming.py").read_text(encoding="utf-8")
+    match = re.search(
+        r"(def _build_agent_thread_env\(.*?)\n(?=\ndef |\nclass )",
+        src,
+        re.DOTALL,
+    )
+    assert match, "_build_agent_thread_env not found in api/streaming.py"
+
+    ns: dict = {}
+    exec(compile(match.group(1), "<streaming_extract>", "exec"), ns)
+    build_env = ns["_build_agent_thread_env"]
+
+    env = build_env(
+        {
+            "TERMINAL_ENV": "local",
+            "TERMINAL_CWD": "/profile/cwd",
+            "HERMES_HOME": "/profile/home-from-env",
+        },
+        workspace="/workspace/session",
+        session_id="session-123",
+        profile_home="/profile/home",
+    )
+
+    assert env["TERMINAL_ENV"] == "local"
+    assert env["TERMINAL_CWD"] == "/workspace/session"
+    assert env["HERMES_EXEC_ASK"] == "1"
+    assert env["HERMES_SESSION_KEY"] == "session-123"
+    assert env["HERMES_HOME"] == "/profile/home"


### PR DESCRIPTION
## Thinking Path
- Hermes WebUI applies per-profile runtime env before starting a streaming agent run.
- Profile env can already contain `TERMINAL_CWD` from `terminal.cwd` or `.env`.
- The streaming path also passed the session workspace as `TERMINAL_CWD` in the same `_set_thread_env(...)` call.
- Python rejects duplicate keyword arguments before the agent starts, so affected WebUI sessions fail immediately.
- This PR merges the thread-local env into one dict with the session workspace taking precedence.

## What Changed
- Added `_build_agent_thread_env(...)` to centralize WebUI agent thread env composition.
- Updated streaming startup to call `_set_thread_env(**_thread_env)` with a deduplicated env dict.
- Added a regression test covering profile-provided `TERMINAL_CWD` being overridden by the session workspace.

## Why It Matters
- Fixes WebUI crashes like `api.config._set_thread_env() got multiple values for keyword argument 'TERMINAL_CWD'`.
- Preserves profile terminal settings while keeping WebUI runs scoped to the selected workspace.

## Verification
- RED: `/home/ubuntu/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_profile_terminal_env.py::test_streaming_thread_env_workspace_overrides_profile_terminal_cwd -q` failed before the implementation because `_build_agent_thread_env` was missing.
- GREEN: `/home/ubuntu/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_profile_terminal_env.py -q` -> 3 passed.
- Full suite: `/home/ubuntu/.hermes/hermes-agent/venv/bin/python -m pytest tests/ -v` -> 3065 passed, 2 skipped, 3 xpassed, 1 warning, 8 subtests passed.
- Note: the contributing guide command with `--timeout=60` could not run in this local venv because the pytest-timeout plugin is not installed, so I ran the same suite without that option.

## Risks / Follow-ups
- Low risk: the change only deduplicates thread-local env construction for streaming agent runs.
- Existing process-level env fallback behavior is left unchanged.
