### PR TITLE
fix: preserve and surface configured model badges

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -1231,12 +1231,13 @@ def _is_valid_models_cache(cache: object) -> bool:
     """Return True when a disk cache payload has the full /api/models shape."""
     if not isinstance(cache, dict):
         return False
-    if not {"active_provider", "default_model", "groups"}.issubset(cache):
+    if not {"active_provider", "default_model", "configured_model_badges", "groups"}.issubset(cache):
         return False
     active_provider = cache.get("active_provider")
     return (
         (active_provider is None or isinstance(active_provider, str))
         and isinstance(cache.get("default_model"), str)
+        and isinstance(cache.get("configured_model_badges"), dict)
         and isinstance(cache.get("groups"), list)
     )
 
@@ -1266,6 +1267,7 @@ def _save_models_cache_to_disk(cache: dict) -> None:
                 {
                     "active_provider": cache["active_provider"],
                     "default_model": cache["default_model"],
+                    "configured_model_badges": cache["configured_model_badges"],
                     "groups": cache["groups"],
                 },
                 f,
@@ -1410,6 +1412,88 @@ def get_available_models() -> dict:
         active_provider = None
         default_model = get_effective_default_model(cfg)
         groups = []
+
+        def _norm_model_id(model_id: str) -> str:
+            s = str(model_id or "").strip().lower()
+            if s.startswith("@") and ":" in s:
+                s = s.split(":", 1)[1]
+            if "/" in s:
+                s = s.split("/", 1)[1]
+            return s.replace("-", ".")
+
+        def _build_configured_model_badges() -> dict[str, dict[str, str]]:
+            configured_entries: list[dict[str, str]] = []
+            if active_provider and default_model:
+                configured_entries.append(
+                    {
+                        "provider": active_provider,
+                        "model": default_model,
+                        "role": "primary",
+                        "label": "Primary",
+                    }
+                )
+            fallback_cfg = cfg.get("fallback_providers", [])
+            if isinstance(fallback_cfg, list):
+                for idx, entry in enumerate(fallback_cfg, start=1):
+                    if not isinstance(entry, dict):
+                        continue
+                    provider = _resolve_provider_alias(entry.get("provider"))
+                    model = str(entry.get("model") or "").strip()
+                    if not provider or not model:
+                        continue
+                    configured_entries.append(
+                        {
+                            "provider": provider,
+                            "model": model,
+                            "role": "fallback",
+                            "label": f"Fallback {idx}",
+                        }
+                    )
+
+            option_ids = [m.get("id", "") for g in groups for m in g.get("models", []) if m.get("id")]
+            option_lookup = {str(opt_id): str(opt_id) for opt_id in option_ids}
+            norm_lookup: dict[str, list[str]] = {}
+            for opt_id in option_ids:
+                norm_lookup.setdefault(_norm_model_id(opt_id), []).append(opt_id)
+
+            badges: dict[str, dict[str, str]] = {}
+            for entry in configured_entries:
+                provider = entry["provider"]
+                model = entry["model"]
+                raw_candidates = []
+                for candidate in (
+                    model,
+                    f"{provider}/{model}",
+                    f"@{provider}:{model}",
+                ):
+                    if candidate and candidate not in raw_candidates:
+                        raw_candidates.append(candidate)
+
+                match_id = None
+                for candidate in raw_candidates:
+                    if candidate in option_lookup:
+                        match_id = option_lookup[candidate]
+                        break
+                if match_id is None:
+                    for candidate in raw_candidates:
+                        normalized = _norm_model_id(candidate)
+                        matches = norm_lookup.get(normalized, [])
+                        if not matches:
+                            continue
+                        provider_match = next(
+                            (m for m in matches if m.startswith(f"@{provider}:") or m.startswith(f"{provider}/")),
+                            None,
+                        )
+                        match_id = provider_match or matches[0]
+                        if match_id:
+                            break
+
+                badge_payload = {"role": entry["role"], "label": entry["label"], "provider": provider}
+                for candidate in raw_candidates:
+                    badges[candidate] = badge_payload
+                if match_id:
+                    badges[match_id] = badge_payload
+            return badges
 
         # 1. Read config.yaml model section
         cfg_base_url = ""  # must be defined before conditional blocks (#117)
@@ -1901,6 +1985,7 @@ def get_available_models() -> dict:
         return {
             "active_provider": active_provider,
             "default_model": default_model,
+            "configured_model_badges": _build_configured_model_badges(),
             "groups": groups,
         }
 

--- a/static/index.html
+++ b/static/index.html
@@ -401,6 +401,7 @@
               <button class="composer-model-chip" id="composerModelChip" type="button" onclick="toggleModelDropdown()" title="Conversation model">
                 <span class="composer-model-icon" aria-hidden="true"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="4" width="16" height="16" rx="2"/><rect x="9" y="9" width="6" height="6"/><path d="M15 2v2"/><path d="M15 20v2"/><path d="M2 15h2"/><path d="M2 9h2"/><path d="M20 15h2"/><path d="M20 9h2"/><path d="M9 2v2"/><path d="M9 20v2"/></svg></span>
                 <span class="composer-model-label" id="composerModelLabel"></span>
+                <span class="composer-model-badge" id="composerModelBadge" hidden></span>
                 <span class="composer-model-chevron" aria-hidden="true"><svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg></span>
               </button>
               <select id="modelSelect" class="composer-model-select" title="Conversation model" aria-hidden="true" tabindex="-1">

--- a/static/style.css
+++ b/static/style.css
@@ -1053,7 +1053,11 @@
 .model-opt{padding:10px 14px;cursor:pointer;transition:background .12s;display:flex;flex-direction:column;gap:3px;align-items:flex-start;}
 .model-opt:hover{background:rgba(255,255,255,.07);}
 .model-opt.active{background:var(--accent-bg);}
+.model-opt-top{display:flex;align-items:center;gap:8px;flex-wrap:wrap;width:100%;}
 .model-opt-name{display:block;font-size:13px;color:var(--text);font-weight:500;line-height:1.25;}
+.model-opt-badge{display:inline-flex;align-items:center;justify-content:center;padding:2px 7px;border-radius:999px;font-size:10px;font-weight:700;letter-spacing:.02em;text-transform:uppercase;border:1px solid transparent;}
+.model-opt-badge--primary{background:rgba(50,184,198,.16);border-color:rgba(50,184,198,.32);color:#8fe7ef;}
+.model-opt-badge--fallback{background:rgba(255,184,77,.14);border-color:rgba(255,184,77,.28);color:#ffd18a;}
 .model-opt-id{display:block;font-size:10px;color:var(--muted);line-height:1.3;opacity:.72;word-break:break-word;}
 .model-custom-sep{padding-top:4px;border-top:1px solid var(--border);margin-top:4px;}
 .model-custom-row{display:flex;align-items:center;gap:6px;padding:6px 10px 8px;}

--- a/static/style.css
+++ b/static/style.css
@@ -747,10 +747,14 @@
   .reasoning-option:hover{background:rgba(255,255,255,.07);}
   .reasoning-option.selected{background:var(--accent-bg);}
   .composer-model-wrap{position:relative;flex:0 1 auto;min-width:0;}
-  .composer-model-chip{display:inline-flex;align-items:center;gap:8px;max-width:220px;padding:8px 10px 8px 12px;border-radius:999px;border:1px solid transparent;background-color:transparent;color:var(--muted);font-weight:500;cursor:pointer;transition:color .15s,background-color .15s,border-color .15s;}
+  .composer-model-chip{display:inline-flex;align-items:center;gap:8px;max-width:280px;padding:8px 10px 8px 12px;border-radius:999px;border:1px solid transparent;background-color:transparent;color:var(--muted);font-weight:500;cursor:pointer;transition:color .15s,background-color .15s,border-color .15s;}
   .composer-model-chip:hover{color:var(--text);background-color:var(--hover-bg);}
   .composer-model-chip.active{color:var(--text);background:var(--accent-bg);border-color:var(--accent-bg);}
   .composer-model-label{min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+  .composer-model-badge{display:inline-flex;align-items:center;justify-content:center;flex-shrink:0;padding:2px 7px;border-radius:999px;font-size:10px;font-weight:700;letter-spacing:.02em;text-transform:uppercase;border:1px solid transparent;}
+  .composer-model-badge[hidden]{display:none;}
+  .composer-model-badge--primary{background:rgba(50,184,198,.16);border-color:rgba(50,184,198,.32);color:#8fe7ef;}
+  .composer-model-badge--fallback{background:rgba(255,184,77,.14);border-color:rgba(255,184,77,.28);color:#ffd18a;}
   .composer-model-icon,.composer-model-chevron{display:inline-flex;align-items:center;justify-content:center;flex-shrink:0;line-height:1;}
   .composer-model-select{position:absolute!important;left:-9999px!important;width:1px!important;height:1px!important;opacity:0!important;pointer-events:none!important;}
   .composer-right{display:flex;gap:8px;align-items:center;flex-shrink:0;}

--- a/static/ui.js
+++ b/static/ui.js
@@ -92,6 +92,7 @@ const _ARCHIVE_EXTS=/\.(zip|tar|tar\.gz|tgz|tar\.bz2|tbz2|tar\.xz|txz)$/i;
 
 // Dynamic model labels -- populated by populateModelDropdown(), fallback to static map
 let _dynamicModelLabels={};
+window._configuredModelBadges=window._configuredModelBadges||{};
 
 // ── Smart model resolver ────────────────────────────────────────────────────
 // Finds the best matching option value in a <select> for a given model ID.
@@ -145,6 +146,7 @@ async function populateModelDropdown(){
     // Store default model so newSession() can apply it (#872).
     // Per-page-load — not synced across browser tabs.
     window._defaultModel=data.default_model||null;
+    window._configuredModelBadges=data.configured_model_badges||{};
     // Clear existing options
     sel.innerHTML='';
     _dynamicModelLabels={};
@@ -306,6 +308,24 @@ function _selectedModelOption(){
   return sel.options[sel.selectedIndex]||null;
 }
 
+function _normalizeConfiguredModelKey(modelId){
+  let s=String(modelId||'').trim().toLowerCase();
+  if(s.startsWith('@')&&s.includes(':')) s=s.substring(s.indexOf(':')+1);
+  if(s.includes('/')) s=s.split('/').pop();
+  return s.replace(/-/g,'.');
+}
+
+function _getConfiguredModelBadge(modelId,badgeMap){
+  const map=badgeMap||window._configuredModelBadges||{};
+  if(!modelId||!map) return null;
+  if(map[modelId]) return map[modelId];
+  const targetNorm=_normalizeConfiguredModelKey(modelId);
+  for(const [candidate,badge] of Object.entries(map)){
+    if(_normalizeConfiguredModelKey(candidate)===targetNorm) return badge;
+  }
+  return null;
+}
+
 function syncModelChip(){
   const sel=$('modelSelect');
   const chip=$('composerModelChip');
@@ -339,14 +359,15 @@ function renderModelDropdown(){
   if(!dd||!sel) return;
   // Store model data for filtering
   const _modelData=[];
+  const _badgeMap=window._configuredModelBadges||{};
   for(const child of Array.from(sel.children)){
     if(child.tagName==='OPTGROUP'){
       for(const opt of Array.from(child.children)){
-        _modelData.push({value:opt.value,name:esc(opt.textContent||getModelLabel(opt.value)),id:esc(opt.value),group:child.label||''});
+        _modelData.push({value:opt.value,name:esc(opt.textContent||getModelLabel(opt.value)),id:esc(opt.value),group:child.label||'',badge:_getConfiguredModelBadge(opt.value,_badgeMap)});
       }
     }
     if(child.tagName==='OPTION'){
-      _modelData.push({value:child.value,name:esc(child.textContent||getModelLabel(child.value)),id:esc(child.value),group:''});
+      _modelData.push({value:child.value,name:esc(child.textContent||getModelLabel(child.value)),id:esc(child.value),group:'',badge:_getConfiguredModelBadge(child.value,_badgeMap)});
     }
   }
   // Create search input FIRST before filterModels definition
@@ -398,7 +419,8 @@ function renderModelDropdown(){
         }
         const row=document.createElement('div');
         row.className='model-opt'+(m.value===sel.value?' active':'');
-        row.innerHTML=`<span class="model-opt-name">${m.name}</span><span class="model-opt-id">${m.id}</span>`;
+        const badgeHtml=m.badge?`<span class="model-opt-badge model-opt-badge--${esc(m.badge.role||'configured')}">${esc(m.badge.label||'Configured')}</span>`:'';
+        row.innerHTML=`<div class="model-opt-top"><span class="model-opt-name">${m.name}</span>${badgeHtml}</div><span class="model-opt-id">${m.id}</span>`;
         row.onclick=()=>selectModelFromDropdown(m.value);
         dd.appendChild(row);
       }

--- a/static/ui.js
+++ b/static/ui.js
@@ -330,12 +330,28 @@ function syncModelChip(){
   const sel=$('modelSelect');
   const chip=$('composerModelChip');
   const label=$('composerModelLabel');
+  const badgeEl=$('composerModelBadge');
   const dd=$('composerModelDropdown');
   if(!sel||!chip||!label) return;
   // Don't show a model label until boot has finished loading to prevent flash of wrong default
-  if(!S._bootReady){ label.textContent=''; chip.title='Conversation model'; return; }
+  if(!S._bootReady){
+    label.textContent='';
+    chip.title='Conversation model';
+    if(badgeEl){
+      badgeEl.textContent='';
+      badgeEl.hidden=true;
+      badgeEl.className='composer-model-badge';
+    }
+    return;
+  }
   const opt=_selectedModelOption();
   label.textContent=opt?opt.textContent:getModelLabel(sel.value||'');
+  const badge=_getConfiguredModelBadge(sel.value||'',window._configuredModelBadges||{});
+  if(badgeEl){
+    badgeEl.textContent=badge&&badge.label?badge.label:'';
+    badgeEl.hidden=!badgeEl.textContent;
+    badgeEl.className='composer-model-badge'+(badge&&badge.role?` composer-model-badge--${badge.role}`:'');
+  }
   chip.title=sel.value||'Conversation model';
   chip.classList.toggle('active',!!(dd&&dd.classList.contains('open')));
 }

--- a/tests/test_model_picker_badges.py
+++ b/tests/test_model_picker_badges.py
@@ -89,7 +89,11 @@ def test_get_available_models_cache_preserves_configured_model_badges(tmp_path, 
 
 
 def test_ui_renders_model_badges_from_api_payload():
-    js = (Path(__file__).resolve().parent.parent / "static" / "ui.js").read_text(encoding="utf-8")
+    root = Path(__file__).resolve().parent.parent
+    js = (root / "static" / "ui.js").read_text(encoding="utf-8")
+    html = (root / "static" / "index.html").read_text(encoding="utf-8")
+    css = (root / "static" / "style.css").read_text(encoding="utf-8")
+
     assert "window._configuredModelBadges=data.configured_model_badges||{};" in js, (
         "populateModelDropdown() deve guardar configured_model_badges do /api/models "
         "para que o dropdown reflita a cadeia configurada atual."
@@ -101,4 +105,19 @@ def test_ui_renders_model_badges_from_api_payload():
     assert "_getConfiguredModelBadge" in js, (
         "A UI precisa de um helper de matching resiliente para religar badges mesmo quando "
         "o update do catálogo mudar prefixos/formas do model ID."
+    )
+    assert 'id="composerModelBadge"' in html, (
+        "O chip principal do modelo precisa de um container dedicado para exibir o badge "
+        "do modelo selecionado fora do dropdown."
+    )
+    assert "composer-model-badge" in css, (
+        "O badge do chip principal precisa de estilo próprio para ficar visível ao lado "
+        "do nome do modelo selecionado."
+    )
+    assert "const badge=_getConfiguredModelBadge(sel.value||'',window._configuredModelBadges||{});" in js, (
+        "syncModelChip() deve buscar o badge configurado do modelo selecionado e projetá-lo "
+        "no chip principal da composer."
+    )
+    assert "badgeEl.textContent=badge&&badge.label?badge.label:'';" in js, (
+        "syncModelChip() deve preencher o texto do badge visível no chip principal quando houver metadata configurada."
     )

--- a/tests/test_model_picker_badges.py
+++ b/tests/test_model_picker_badges.py
@@ -1,0 +1,104 @@
+from pathlib import Path
+
+from api import config
+
+
+def _models_with_cfg(model_cfg=None, fallback_providers=None, custom_providers=None, active_provider=None):
+    old_cfg = config.cfg
+    old_mtime = config._cfg_mtime
+    old_cache = config._available_models_cache
+    old_cache_ts = config._available_models_cache_ts
+    try:
+        config._available_models_cache = None
+        config._available_models_cache_ts = 0.0
+        config._cfg_mtime = 0.0
+        config.cfg = {
+            "model": model_cfg or {"provider": "openai-codex", "default": "gpt-5.4"},
+            "fallback_providers": fallback_providers or [],
+            "providers": custom_providers or {},
+        }
+        if active_provider:
+            config.cfg["model"]["provider"] = active_provider
+        return config.get_available_models()
+    finally:
+        config.cfg = old_cfg
+        config._cfg_mtime = old_mtime
+        config._available_models_cache = old_cache
+        config._available_models_cache_ts = old_cache_ts
+
+
+def test_available_models_exposes_primary_and_fallback_badges():
+    result = _models_with_cfg(
+        model_cfg={"provider": "openai-codex", "default": "gpt-5.4"},
+        fallback_providers=[
+            {"provider": "copilot", "model": "gpt-4.1"},
+            {"provider": "anthropic", "model": "claude-haiku-4.5"},
+        ],
+    )
+
+    badges = result.get("configured_model_badges")
+    assert isinstance(badges, dict), (
+        "get_available_models() deve expor configured_model_badges para o frontend "
+        "marcar visualmente o dropdown com a cadeia primária + fallback configurada."
+    )
+    assert badges.get("@openai-codex:gpt-5.4", {}).get("role") == "primary"
+    assert badges.get("@openai-codex:gpt-5.4", {}).get("label") == "Primary"
+    assert badges.get("@copilot:gpt-4.1", {}).get("role") == "fallback"
+    assert badges.get("@copilot:gpt-4.1", {}).get("label") == "Fallback 1"
+    assert badges.get("anthropic/claude-haiku-4.5", {}).get("role") == "fallback"
+    assert badges.get("anthropic/claude-haiku-4.5", {}).get("label") == "Fallback 2"
+
+
+def test_get_available_models_cache_preserves_configured_model_badges(tmp_path, monkeypatch):
+    cache_path = tmp_path / "models_cache.json"
+    old_cfg = config.cfg
+    old_mtime = config._cfg_mtime
+    old_cache = config._available_models_cache
+    old_cache_ts = config._available_models_cache_ts
+    old_cache_path = config._models_cache_path
+    try:
+        monkeypatch.setattr(config, "_models_cache_path", cache_path)
+        config._available_models_cache = None
+        config._available_models_cache_ts = 0.0
+        config._cfg_mtime = 0.0
+        config.cfg = {
+            "model": {"provider": "openai-codex", "default": "gpt-5.4"},
+            "fallback_providers": [{"provider": "copilot", "model": "gpt-4.1"}],
+            "providers": {},
+        }
+
+        cold = config.get_available_models()
+        assert cold.get("configured_model_badges", {}).get("@copilot:gpt-4.1", {}).get("label") == "Fallback 1"
+
+        config._available_models_cache = None
+        config._available_models_cache_ts = 0.0
+        warm = config.get_available_models()
+
+        assert "configured_model_badges" in warm, (
+            "O cache persistido de /api/models não pode descartar configured_model_badges, "
+            "senão o deploy/servidor reiniciado perde as TAGS do dropdown mesmo com o código novo."
+        )
+        assert warm["configured_model_badges"].get("@copilot:gpt-4.1", {}).get("label") == "Fallback 1"
+    finally:
+        config.cfg = old_cfg
+        config._cfg_mtime = old_mtime
+        config._available_models_cache = old_cache
+        config._available_models_cache_ts = old_cache_ts
+        monkeypatch.setattr(config, "_models_cache_path", old_cache_path)
+
+
+
+def test_ui_renders_model_badges_from_api_payload():
+    js = (Path(__file__).resolve().parent.parent / "static" / "ui.js").read_text(encoding="utf-8")
+    assert "window._configuredModelBadges=data.configured_model_badges||{};" in js, (
+        "populateModelDropdown() deve guardar configured_model_badges do /api/models "
+        "para que o dropdown reflita a cadeia configurada atual."
+    )
+    assert "model-opt-badge" in js, (
+        "renderModelDropdown() deve renderizar um badge visual por modelo quando houver "
+        "metadata de primário/fallback no payload."
+    )
+    assert "_getConfiguredModelBadge" in js, (
+        "A UI precisa de um helper de matching resiliente para religar badges mesmo quando "
+        "o update do catálogo mudar prefixos/formas do model ID."
+    )


### PR DESCRIPTION
## Bug Description

Configured model badges were not stable across cached deploys, and the selected model chip did not surface the active badge outside the dropdown.

## Root Cause

The backend cache for `/api/models` did not persist `configured_model_badges`, so cached deploys could lose the configured chain metadata. Separately, the composer chip had no badge node and `syncModelChip()` did not project the selected model badge into the visible chip.

## Fix

- persist and validate `configured_model_badges` in cached `/api/models`
- keep the configured badge metadata wired through the UI payload
- render the configured badge directly on the selected model chip
- add regression coverage for cache persistence and chip rendering

## How to Verify

1. Load a config with PRIMARY / FALLBACK badges.
2. Confirm the selected model chip shows the configured badge next to the active model label.
3. Reload from cache and confirm the dropdown and chip still show the configured badges.

## Test Plan

- [x] `pytest tests/test_model_picker_badges.py -q`
- [x] Manual visual verification in local evidence page

## Risk Assessment

Low — isolated to model metadata caching and badge presentation in the picker UI.
