### PR TITLE
fix: merge profile runtime env for streaming sessions

### DIFF
--- a/api/streaming.py
+++ b/api/streaming.py
@@ -41,6 +41,27 @@ try:
 except ImportError:
     AIAgent = None
 
+
+def _build_agent_runtime_env(
+    profile_runtime_env: dict[str, str] | None,
+    *,
+    workspace: str,
+    session_id: str,
+    hermes_home: str,
+) -> dict[str, str]:
+    """Merge profile runtime env with per-session overrides.
+
+    A profile may define TERMINAL_CWD, but a WebUI chat run must always execute
+    in the session workspace. Returning a single merged mapping avoids passing
+    duplicate kwargs to _set_thread_env(**env).
+    """
+    env = dict(profile_runtime_env or {})
+    env["TERMINAL_CWD"] = str(workspace)
+    env["HERMES_EXEC_ASK"] = "1"
+    env["HERMES_SESSION_KEY"] = session_id
+    env["HERMES_HOME"] = hermes_home
+    return env
+
 def _get_ai_agent():
     """Return AIAgent class, retrying the import if the initial attempt failed.
 
@@ -1419,13 +1440,13 @@ def _run_agent_streaming(session_id, msg_text, model, workspace, stream_id, atta
             _profile_home = os.environ.get('HERMES_HOME', '')
             _profile_runtime_env = {}
 
-        _set_thread_env(
-            **_profile_runtime_env,
-            TERMINAL_CWD=str(s.workspace),
-            HERMES_EXEC_ASK='1',
-            HERMES_SESSION_KEY=session_id,
-            HERMES_HOME=_profile_home,
+        _runtime_env = _build_agent_runtime_env(
+            _profile_runtime_env,
+            workspace=str(s.workspace),
+            session_id=session_id,
+            hermes_home=_profile_home,
         )
+        _set_thread_env(**_runtime_env)
         # Still set process-level env as fallback for tools that bypass thread-local
         # Acquire lock only for the env mutation, then release before the agent runs.
         # The finally block re-acquires to restore — keeping critical sections short

--- a/tests/test_profile_terminal_env.py
+++ b/tests/test_profile_terminal_env.py
@@ -46,6 +46,29 @@ def test_profile_runtime_env_includes_terminal_config_and_dotenv(tmp_path):
     assert env["HERMES_MAX_ITERATIONS"] == "90"
 
 
+def test_streaming_runtime_env_merges_without_duplicate_terminal_cwd():
+    from api.streaming import _build_agent_runtime_env
+
+    env = _build_agent_runtime_env(
+        {
+            "TERMINAL_ENV": "ssh",
+            "TERMINAL_CWD": "/profile/cwd",
+            "TERMINAL_TIMEOUT": "60",
+        },
+        workspace="/session/workspace",
+        session_id="sess-123",
+        hermes_home="/tmp/hermes-home",
+    )
+
+    assert env["TERMINAL_ENV"] == "ssh"
+    assert env["TERMINAL_TIMEOUT"] == "60"
+    assert env["TERMINAL_CWD"] == "/session/workspace"
+    assert env["HERMES_EXEC_ASK"] == "1"
+    assert env["HERMES_SESSION_KEY"] == "sess-123"
+    assert env["HERMES_HOME"] == "/tmp/hermes-home"
+    assert list(env).count("TERMINAL_CWD") == 1
+
+
 def test_streaming_applies_profile_runtime_env_to_agent_run():
     src = Path("api/streaming.py").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Bug Description

Streaming WebUI sessions could inherit profile runtime environment values in a way that collided with the per-session workspace override for `TERMINAL_CWD`.

## Root Cause

`_run_agent_streaming()` expanded the profile runtime env and also passed `TERMINAL_CWD` explicitly into `_set_thread_env(...)`, which creates duplicate keyword assignment risk and makes the session workspace override fragile.

## Fix

- add `_build_agent_runtime_env()` to merge profile env with WebUI session overrides in one mapping
- force the active session workspace to win over any profile-level `TERMINAL_CWD`
- add regression coverage for the merged env contract

## How to Verify

1. Configure a profile runtime env with `TERMINAL_CWD` set to a different path.
2. Start a WebUI streaming session.
3. Confirm the agent runs in the session workspace and preserves the other profile runtime env values.

## Test Plan

- [x] `pytest tests/test_profile_terminal_env.py::test_streaming_runtime_env_merges_without_duplicate_terminal_cwd -v`
- [x] `pytest tests/test_profile_terminal_env.py::test_streaming_applies_profile_runtime_env_to_agent_run -v`

## Risk Assessment

Low — isolated to runtime env assembly for streaming sessions.
