### PR TITLE
fix: avoid duplicate profile env keys

### DIFF
--- a/api/streaming.py
+++ b/api/streaming.py
@@ -1419,8 +1419,12 @@ def _run_agent_streaming(session_id, msg_text, model, workspace, stream_id, atta
             _profile_home = os.environ.get('HERMES_HOME', '')
             _profile_runtime_env = {}
 
+        _profile_runtime_env_for_run = dict(_profile_runtime_env)
+        for _explicit_env_key in ('TERMINAL_CWD', 'HERMES_EXEC_ASK', 'HERMES_SESSION_KEY', 'HERMES_HOME'):
+            _profile_runtime_env_for_run.pop(_explicit_env_key, None)
+
         _set_thread_env(
-            **_profile_runtime_env,
+            **_profile_runtime_env_for_run,
             TERMINAL_CWD=str(s.workspace),
             HERMES_EXEC_ASK='1',
             HERMES_SESSION_KEY=session_id,
@@ -1431,12 +1435,12 @@ def _run_agent_streaming(session_id, msg_text, model, workspace, stream_id, atta
         # The finally block re-acquires to restore — keeping critical sections short
         # and preventing a deadlock where the restore would re-enter the same lock.
         with _ENV_LOCK:
-            old_profile_env = {key: os.environ.get(key) for key in _profile_runtime_env}
+            old_profile_env = {key: os.environ.get(key) for key in _profile_runtime_env_for_run}
             old_cwd = os.environ.get('TERMINAL_CWD')
             old_exec_ask = os.environ.get('HERMES_EXEC_ASK')
             old_session_key = os.environ.get('HERMES_SESSION_KEY')
             old_hermes_home = os.environ.get('HERMES_HOME')
-            os.environ.update(_profile_runtime_env)
+            os.environ.update(_profile_runtime_env_for_run)
             os.environ['TERMINAL_CWD'] = str(s.workspace)
             os.environ['HERMES_EXEC_ASK'] = '1'
             os.environ['HERMES_SESSION_KEY'] = session_id

--- a/tests/test_profile_terminal_env.py
+++ b/tests/test_profile_terminal_env.py
@@ -52,4 +52,13 @@ def test_streaming_applies_profile_runtime_env_to_agent_run():
     assert "get_profile_runtime_env" in src
     assert "_profile_runtime_env" in src
     assert "old_profile_env" in src
-    assert "os.environ.update(_profile_runtime_env)" in src
+    assert "os.environ.update(_profile_runtime_env_for_run)" in src
+
+
+def test_streaming_removes_explicit_thread_env_keys_from_profile_runtime_env():
+    src = Path("api/streaming.py").read_text(encoding="utf-8")
+
+    assert "_profile_runtime_env_for_run = dict(_profile_runtime_env)" in src
+    assert "for _explicit_env_key in ('TERMINAL_CWD', 'HERMES_EXEC_ASK', 'HERMES_SESSION_KEY', 'HERMES_HOME'):" in src
+    assert "_profile_runtime_env_for_run.pop(_explicit_env_key, None)" in src
+    assert "**_profile_runtime_env_for_run," in src


### PR DESCRIPTION
## Thinking Path

- WebUI profile runtime env loading should allow users to configure terminal defaults without breaking chat startup.
- A profile with `terminal.cwd` produces `TERMINAL_CWD` in `_profile_runtime_env`, while streaming also sets `TERMINAL_CWD` explicitly from the active session workspace.
- Passing both through `_set_thread_env(**_profile_runtime_env, TERMINAL_CWD=...)` raises `TypeError: got multiple values for keyword argument 'TERMINAL_CWD'` before the agent can start.
- This PR keeps profile-provided runtime env values, but removes the WebUI-owned per-turn keys before applying the stream context.
- The fix is intentionally narrow: only the env merge site and regression coverage are changed.

## What Changed

- Filters WebUI-owned keys out of profile runtime env before calling `_set_thread_env(...)`:
  - `TERMINAL_CWD`
  - `HERMES_EXEC_ASK`
  - `HERMES_SESSION_KEY`
  - `HERMES_HOME`
- Uses the filtered env dict consistently for thread-local env, saved prior env values, and process-level fallback env updates.
- Adds regression coverage asserting the stream runner filters explicit env keys before merging profile runtime env.

## Why It Matters

Users with terminal settings in `config.yaml` should still be able to start WebUI chats. Without this fix, a normal `terminal.cwd` setting can make every streamed chat fail immediately with a duplicate keyword argument error.

## Verification

```bash
/home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_profile_terminal_env.py -q
git diff --check --cached
/home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/ -q
```

Result:

```text
tests/test_profile_terminal_env.py: 3 passed
Full suite: 3065 passed, 2 skipped, 3 xpassed, 1 warning, 8 subtests passed in 349.19s (0:05:49)
git diff --check --cached: clean
```

Manual verification, if applicable:

- Reproduced the failure mode locally from a WebUI config where `terminal.cwd` maps to `TERMINAL_CWD` while streaming also sets the active session workspace.
- Verified the live WebUI health endpoint after applying the same fix in Michael's deployment.

UI media, if applicable:

- Not applicable; this is backend streaming/env handling with no UI visual change.

## Risks / Follow-ups

- This preserves existing behavior where WebUI owns per-turn workspace/session env keys. If users expect profile `terminal.cwd` to override the active WebUI workspace, that remains intentionally unsupported for streamed turns.
- Longer-term, explicit env/context passing would be safer than mixing thread-local env with process-level fallback env.

## Model Used

AI assisted.

- Provider: OpenAI Codex
- Model: `gpt-5.5`
- Notable tool use: terminal, git, pytest, GitHub CLI, file patching
