### PR TITLE
fix: merge profile runtime env before thread env setup

### DIFF
--- a/api/streaming.py
+++ b/api/streaming.py
@@ -1419,13 +1419,14 @@ def _run_agent_streaming(session_id, msg_text, model, workspace, stream_id, atta
             _profile_home = os.environ.get('HERMES_HOME', '')
             _profile_runtime_env = {}
 
-        _set_thread_env(
-            **_profile_runtime_env,
-            TERMINAL_CWD=str(s.workspace),
-            HERMES_EXEC_ASK='1',
-            HERMES_SESSION_KEY=session_id,
-            HERMES_HOME=_profile_home,
-        )
+        _thread_env = dict(_profile_runtime_env)
+        _thread_env.update({
+            'TERMINAL_CWD': str(s.workspace),
+            'HERMES_EXEC_ASK': '1',
+            'HERMES_SESSION_KEY': session_id,
+            'HERMES_HOME': _profile_home,
+        })
+        _set_thread_env(**_thread_env)
         # Still set process-level env as fallback for tools that bypass thread-local
         # Acquire lock only for the env mutation, then release before the agent runs.
         # The finally block re-acquires to restore — keeping critical sections short

--- a/tests/test_profile_terminal_env.py
+++ b/tests/test_profile_terminal_env.py
@@ -53,3 +53,6 @@ def test_streaming_applies_profile_runtime_env_to_agent_run():
     assert "_profile_runtime_env" in src
     assert "old_profile_env" in src
     assert "os.environ.update(_profile_runtime_env)" in src
+    assert "_thread_env = dict(_profile_runtime_env)" in src
+    assert "_set_thread_env(**_thread_env)" in src
+    assert "**_profile_runtime_env,\n            TERMINAL_CWD=str(s.workspace)" not in src


### PR DESCRIPTION
## Summary
- Avoid passing duplicate `TERMINAL_CWD` into `_set_thread_env()` when profile runtime env already contains terminal cwd from profile config
- Merge profile runtime env with per-session overrides before calling `_set_thread_env(**...)`
- Add a regression assertion to keep the duplicate-kwargs pattern from returning

## Why
PR #1245 was shipped via v0.50.238 / PR #1259, but the merged code can still hit `TypeError: got multiple values for keyword argument 'TERMINAL_CWD'` when a profile defines `terminal.cwd` and the streaming run also passes the session workspace as `TERMINAL_CWD`.

## Test Plan
- `$HOME/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_profile_terminal_env.py tests/test_profile_switch_1200.py tests/test_gateway_sync.py -q`
