### PR TITLE
Preserve cron output response snippets

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -35,6 +35,8 @@ _CLIENT_DISCONNECT_ERRORS = (
 # Track job IDs currently being executed so the frontend can poll status.
 _RUNNING_CRON_JOBS: dict[str, float] = {}  # job_id → start_timestamp
 _RUNNING_CRON_LOCK = threading.Lock()
+_CRON_OUTPUT_CONTENT_LIMIT = 8000
+_CRON_OUTPUT_HEADER_CONTEXT = 200
 
 
 def _mark_cron_running(job_id: str):
@@ -54,6 +56,40 @@ def _is_cron_running(job_id: str) -> tuple[bool, float]:
         if t is None:
             return False, 0.0
         return True, time.time() - t
+
+
+def _cron_response_marker_index(text: str) -> int:
+    """Return the start index of a markdown Response heading, if present."""
+    candidates = []
+    for heading in ("## Response", "# Response"):
+        if text.startswith(heading):
+            candidates.append(0)
+        idx = text.find(f"\n{heading}")
+        if idx >= 0:
+            candidates.append(idx + 1)
+    return min(candidates) if candidates else -1
+
+
+def _cron_output_content_window(text: str, limit: int = _CRON_OUTPUT_CONTENT_LIMIT) -> str:
+    """Return a bounded cron output window that preserves useful response text.
+
+    Cron output files can contain large skill dumps in the Prompt section. The
+    UI already extracts ``## Response`` when present, so keep that section in
+    the API payload instead of blindly returning the first ``limit`` chars.
+    """
+    if limit <= 0:
+        return ""
+    if len(text) <= limit:
+        return text
+
+    response_idx = _cron_response_marker_index(text)
+    if response_idx >= 0:
+        header = text[:min(_CRON_OUTPUT_HEADER_CONTEXT, response_idx)].rstrip()
+        response = text[response_idx:].lstrip("\n")
+        content = f"{header}\n...\n{response}" if header else response
+        return content[:limit]
+
+    return text[-limit:]
 
 
 def _run_cron_tracked(job):
@@ -2886,7 +2922,7 @@ def _handle_cron_output(handler, parsed):
         for f in files:
             try:
                 txt = f.read_text(encoding="utf-8", errors="replace")
-                outputs.append({"filename": f.name, "content": txt[:8000]})
+                outputs.append({"filename": f.name, "content": _cron_output_content_window(txt)})
             except Exception:
                 logger.debug("Failed to read cron output file %s", f)
     return j(handler, {"job_id": job_id, "outputs": outputs})

--- a/tests/test_sprint10.py
+++ b/tests/test_sprint10.py
@@ -115,6 +115,40 @@ def test_cron_output_snippet_helper(cleanup_test_sessions):
     src, _ = get_text("/static/panels.js")
     assert "_cronOutputSnippet" in src
 
+
+def test_cron_output_window_preserves_response_after_large_prompt(cleanup_test_sessions):
+    """Large skill dumps before ## Response must not hide the useful output."""
+    from api.routes import _cron_output_content_window
+
+    content = (
+        "Job metadata\n"
+        "## Prompt\n"
+        + ("skill dump\n" * 1200)
+        + "user prompt\n"
+        "## Response\n"
+        "actual useful cron result\n"
+    )
+
+    window = _cron_output_content_window(content, limit=8000)
+
+    assert len(window) <= 8000
+    assert "## Response" in window
+    assert "actual useful cron result" in window
+    assert "Job metadata" in window
+
+
+def test_cron_output_window_without_response_uses_tail(cleanup_test_sessions):
+    """Without a response marker, keep the newest tail rather than old prompt text."""
+    from api.routes import _cron_output_content_window
+
+    content = "old prompt\n" + ("x" * 9000) + "tail result"
+
+    window = _cron_output_content_window(content, limit=8000)
+
+    assert len(window) == 8000
+    assert window.endswith("tail result")
+    assert "old prompt" not in window
+
 # ── Tool card polish ───────────────────────────────────────────────────────
 
 def test_tool_card_running_dot_in_css(cleanup_test_sessions):


### PR DESCRIPTION
## Summary

- fix `/api/crons/output` so the bounded payload preserves the `## Response` section when large skill/prompt content appears before it
- fall back to the file tail when no response marker exists, instead of always returning the oldest 8000 characters
- add regression coverage for both the large-prompt response-marker case and the no-marker tail fallback

Fixes #1295.

## Root cause

Cron output files can place a large `## Prompt` section before the actual `## Response`. The API returned `txt[:8000]`, so jobs with large skill dumps could lose the response marker and make the frontend snippet helper show prompt/skill metadata instead of the useful result.

## Verification

- `python3 -m py_compile api/routes.py tests/test_sprint10.py`
- `git diff --check`
- `.venv_test/bin/pytest tests/test_sprint10.py -q`
- `.venv_test/bin/pytest tests/test_sprint3.py tests/test_sprint10.py -q`
