### PR TITLE
fix: remove PRIMARY chip badge + add Claude Opus 4.7 label

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -503,6 +503,7 @@ _FALLBACK_MODELS = [
     {"provider": "OpenAI",    "id": "openai/gpt-5.4-mini",                "label": "GPT-5.4 Mini"},
     {"provider": "OpenAI",    "id": "openai/gpt-5.4",                     "label": "GPT-5.4"},
     # Anthropic — 4.6 flagship + 4.5 generation
+    {"provider": "Anthropic", "id": "anthropic/claude-opus-4.7",          "label": "Claude Opus 4.7"},
     {"provider": "Anthropic", "id": "anthropic/claude-opus-4.6",          "label": "Claude Opus 4.6"},
     {"provider": "Anthropic", "id": "anthropic/claude-sonnet-4.6",        "label": "Claude Sonnet 4.6"},
     {"provider": "Anthropic", "id": "anthropic/claude-sonnet-4-5",        "label": "Claude Sonnet 4.5"},
@@ -641,6 +642,7 @@ def _resolve_provider_alias(name: str) -> str:
 # Well-known models per provider (used to populate dropdown for direct API providers)
 _PROVIDER_MODELS = {
     "anthropic": [
+        {"id": "claude-opus-4.7", "label": "Claude Opus 4.7"},
         {"id": "claude-opus-4.6", "label": "Claude Opus 4.6"},
         {"id": "claude-sonnet-4.6", "label": "Claude Sonnet 4.6"},
         {"id": "claude-sonnet-4-5", "label": "Claude Sonnet 4.5"},
@@ -738,6 +740,7 @@ _PROVIDER_MODELS = {
         {"id": "gpt-5", "label": "GPT-5"},
         {"id": "gpt-5-codex", "label": "GPT-5 Codex"},
         {"id": "gpt-5-nano", "label": "GPT-5 Nano"},
+        {"id": "claude-opus-4-7", "label": "Claude Opus 4.7"},
         {"id": "claude-opus-4-6", "label": "Claude Opus 4.6"},
         {"id": "claude-opus-4-5", "label": "Claude Opus 4.5"},
         {"id": "claude-opus-4-1", "label": "Claude Opus 4.1"},

--- a/static/index.html
+++ b/static/index.html
@@ -401,7 +401,6 @@
               <button class="composer-model-chip" id="composerModelChip" type="button" onclick="toggleModelDropdown()" title="Conversation model">
                 <span class="composer-model-icon" aria-hidden="true"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="4" width="16" height="16" rx="2"/><rect x="9" y="9" width="6" height="6"/><path d="M15 2v2"/><path d="M15 20v2"/><path d="M2 15h2"/><path d="M2 9h2"/><path d="M20 15h2"/><path d="M20 9h2"/><path d="M9 2v2"/><path d="M9 20v2"/></svg></span>
                 <span class="composer-model-label" id="composerModelLabel"></span>
-                <span class="composer-model-badge" id="composerModelBadge" hidden></span>
                 <span class="composer-model-chevron" aria-hidden="true"><svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg></span>
               </button>
               <select id="modelSelect" class="composer-model-select" title="Conversation model" aria-hidden="true" tabindex="-1">

--- a/static/style.css
+++ b/static/style.css
@@ -824,10 +824,6 @@
   .composer-model-chip:hover{color:var(--text);background-color:var(--hover-bg);}
   .composer-model-chip.active{color:var(--text);background:var(--accent-bg);border-color:var(--accent-bg);}
   .composer-model-label{min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
-  .composer-model-badge{display:inline-flex;align-items:center;justify-content:center;flex-shrink:0;padding:2px 7px;border-radius:999px;font-size:10px;font-weight:700;letter-spacing:.02em;text-transform:uppercase;border:1px solid transparent;}
-  .composer-model-badge[hidden]{display:none;}
-  .composer-model-badge--primary{background:rgba(50,184,198,.16);border-color:rgba(50,184,198,.32);color:#8fe7ef;}
-  .composer-model-badge--fallback{background:rgba(255,184,77,.14);border-color:rgba(255,184,77,.28);color:#ffd18a;}
   .composer-model-icon,.composer-model-chevron{display:inline-flex;align-items:center;justify-content:center;flex-shrink:0;line-height:1;}
   .composer-model-select{position:absolute!important;left:-9999px!important;width:1px!important;height:1px!important;opacity:0!important;pointer-events:none!important;}
   .composer-right{display:flex;gap:8px;align-items:center;flex-shrink:0;}

--- a/static/ui.js
+++ b/static/ui.js
@@ -425,28 +425,16 @@ function syncModelChip(){
   const sel=$('modelSelect');
   const chip=$('composerModelChip');
   const label=$('composerModelLabel');
-  const badgeEl=$('composerModelBadge');
   const dd=$('composerModelDropdown');
   if(!sel||!chip||!label) return;
   // Don't show a model label until boot has finished loading to prevent flash of wrong default
   if(!S._bootReady){
     label.textContent='';
     chip.title='Conversation model';
-    if(badgeEl){
-      badgeEl.textContent='';
-      badgeEl.hidden=true;
-      badgeEl.className='composer-model-badge';
-    }
     return;
   }
   const opt=_selectedModelOption();
   label.textContent=opt?opt.textContent:getModelLabel(sel.value||'');
-  const badge=_getConfiguredModelBadge(sel.value||'',window._configuredModelBadges||{});
-  if(badgeEl){
-    badgeEl.textContent=badge&&badge.label?badge.label:'';
-    badgeEl.hidden=!badgeEl.textContent;
-    badgeEl.className='composer-model-badge'+(badge&&badge.role?` composer-model-badge--${badge.role}`:'');
-  }
   chip.title=sel.value||'Conversation model';
   chip.classList.toggle('active',!!(dd&&dd.classList.contains('open')));
 }

--- a/tests/test_model_picker_badges.py
+++ b/tests/test_model_picker_badges.py
@@ -106,18 +106,17 @@ def test_ui_renders_model_badges_from_api_payload():
         "A UI precisa de um helper de matching resiliente para religar badges mesmo quando "
         "o update do catálogo mudar prefixos/formas do model ID."
     )
-    assert 'id="composerModelBadge"' in html, (
-        "O chip principal do modelo precisa de um container dedicado para exibir o badge "
-        "do modelo selecionado fora do dropdown."
+    # Chip-projected badge was removed in v0.50.243 (added too much width to the
+    # composer chip; signal value low since the model name is right next to it).
+    # Badges remain in the dropdown rows (model-opt-badge) for picker rows.
+    assert 'id="composerModelBadge"' not in html, (
+        "composer-model-badge chip projection was intentionally removed — "
+        "do not re-add it to the composer chip."
     )
-    assert "composer-model-badge" in css, (
-        "O badge do chip principal precisa de estilo próprio para ficar visível ao lado "
-        "do nome do modelo selecionado."
+    assert "composer-model-badge" not in css, (
+        "composer-model-badge CSS was intentionally removed alongside the chip span."
     )
-    assert "const badge=_getConfiguredModelBadge(sel.value||'',window._configuredModelBadges||{});" in js, (
-        "syncModelChip() deve buscar o badge configurado do modelo selecionado e projetá-lo "
-        "no chip principal da composer."
-    )
-    assert "badgeEl.textContent=badge&&badge.label?badge.label:'';" in js, (
-        "syncModelChip() deve preencher o texto do badge visível no chip principal quando houver metadata configurada."
+    assert "composerModelBadge" not in js, (
+        "syncModelChip() must not reference composerModelBadge — the chip-projected "
+        "badge was removed because it added too much width to the composer chip."
     )


### PR DESCRIPTION
## What

Two small fixes Nathan flagged in chat after using v0.50.241/242:

1. **Remove the `PRIMARY` badge from the composer model chip.** The chip-projected badge added in #1287 took up ≈30% of the chip width without adding signal — the model name is already right next to it. The dropdown rows still show the badges (where they actually help distinguish picker entries).
2. **Add Claude Opus 4.7 label entries.** When you pick `claude-opus-4-7` the dropdown was rendering "Claude Opus 4 **7**" (missing dot) because it had no entry in the static label table and was falling through to the generic dash-replace formatter. Every other Claude model in that table has an explicit entry; 4.7 just hadn't been added yet.

## Why

> "I feel like it adds too much extra width to the UI, and I think we need to remove that badge altogether. Also, I noticed that when I select clod opus 4 7, it is missing the dot, but all the other ones have a dot."

Direct user feedback. The chip badge was the wrong place for that signal — too loud, too wide, redundant with the model label sitting next to it. The dropdown remains a better home for it because rows there genuinely benefit from a primary/fallback distinguisher.

## Visual verification

Measured in-browser DOM:

| | Before | After |
|---|---|---|
| Chip width | 235px | 164px |
| Chip label text | "Claude Opus 4 7" | "Claude Opus 4.7" |
| Visible badge | "PRIMARY" pill | (none) |

That's 71px (≈30%) of horizontal real estate returned to the composer footer.

Dropdown rows are untouched — they still show `model-opt-badge` for primary/fallback rows.

## Changes

- `static/index.html` — drop `<span id="composerModelBadge">` from the composer chip
- `static/ui.js` — drop the `badgeEl` reads and writes from `syncModelChip()`. The dropdown rendering in `renderModelDropdown()` still calls `_getConfiguredModelBadge` and emits `model-opt-badge` rows; that path is untouched.
- `static/style.css` — drop the four `.composer-model-badge*` rules
- `api/config.py` — add 3 label entries for Opus 4.7:
  - `anthropic/claude-opus-4.7` in `_FALLBACK_MODELS` (OpenRouter-style id with dot)
  - `claude-opus-4.7` in `_PROVIDER_MODELS["anthropic"]` (bare id with dot)
  - `claude-opus-4-7` in the `_PROVIDER_MODELS["opencode-zen"]` bare-id static labels block (dashed form — what live Anthropic API responses return for this model)
- `tests/test_model_picker_badges.py` — flip the chip-badge presence assertions into absence assertions; add a symmetric `composerModelBadge not in js` guard so a future regression in `syncModelChip()` can't reintroduce the lookup silently.

The backend `_build_configured_model_badges()` helper and the `configured_model_badges` payload on `/api/models` are intentionally **preserved** — the dropdown rows still consume them.

## Tests

```
3252 passed, 2 skipped, 3 xpassed in 74s
```

Targeted tests:
```
tests/test_model_picker_badges.py     3 passed
tests/test_model_cache_metadata.py    8 passed
tests/test_issue1188_fuzzy_match.py   7 passed
```

## Risk

Low. Diff is 14 insertions / 29 deletions across 5 files, scoped to model picker UI rendering and one new label entry. No backend logic changes. Backend badge metadata stays in the payload for the dropdown to consume.

Independent advisory review by Claude Opus 4.7 (no blockers, one nit applied — symmetric JS test assertion).
