### PR TITLE
fix: allow Cmd/Ctrl+K new chat while a conversation is busy

### DIFF
--- a/static/boot.js
+++ b/static/boot.js
@@ -531,7 +531,12 @@ document.addEventListener('keydown',async e=>{
     // If the current session has no messages, just focus the composer rather than
     // creating another empty session that will clutter the sidebar list (#1171).
     if(S.session&&(S.session.message_count||0)===0){$('msg').focus();return;}
-    if(!S.busy){await newSession();await renderSessionList();closeMobileSidebar();$('msg').focus();}
+    // Cmd/Ctrl+K should always create a new conversation, even while the current
+    // one is still streaming. The old !S.busy guard meant users had to wait for
+    // a long generation to finish before they could start something new — exactly
+    // the moment they want to switch context. newSession() leaves the in-flight
+    // stream running on its own session; the user just gets a fresh blank one.
+    await newSession();await renderSessionList();closeMobileSidebar();$('msg').focus();
   }
   if(e.key==='Escape'){
     // Close onboarding overlay if open (skip/dismiss the wizard)

--- a/tests/test_mobile_layout.py
+++ b/tests/test_mobile_layout.py
@@ -157,9 +157,33 @@ def test_new_conversation_closes_mobile_sidebar():
 
     shortcut_line = next((ln for ln in boot_js.splitlines() if "e.key==='k'" in ln or "e.key === 'k'" in ln), "")
     assert shortcut_line, "Cmd/Ctrl+K new chat shortcut missing from static/boot.js"
-    shortcut_block = "\n".join(boot_js.splitlines()[boot_js.splitlines().index(shortcut_line):boot_js.splitlines().index(shortcut_line)+6])
+    shortcut_block = "\n".join(boot_js.splitlines()[boot_js.splitlines().index(shortcut_line):boot_js.splitlines().index(shortcut_line)+12])
     assert "closeMobileSidebar" in shortcut_block, \
         "Cmd/Ctrl+K new chat shortcut must closeMobileSidebar() after creating the new session"
+
+
+def test_new_conversation_shortcut_works_while_busy():
+    """Cmd/Ctrl+K should still create a new conversation while the current one is busy.
+
+    The previous behavior gated the shortcut on !S.busy, which meant users had
+    to wait for a long generation to finish before they could start something
+    new — the exact moment they want to switch context.
+    """
+    boot_js = (REPO / "static" / "boot.js").read_text(encoding="utf-8")
+    shortcut_line = next((ln for ln in boot_js.splitlines() if "e.key==='k'" in ln or "e.key === 'k'" in ln), "")
+    assert shortcut_line, "Cmd/Ctrl+K new chat shortcut missing from static/boot.js"
+    # Inspect the next 10 lines after the keybinding match — the gating block
+    # would live there if it had been kept.
+    idx = boot_js.splitlines().index(shortcut_line)
+    shortcut_block = "\n".join(boot_js.splitlines()[idx:idx + 10])
+    # Strip the existing message-count guard (which is unrelated and stays) so
+    # we only check for an S.busy gate on the newSession() call itself.
+    assert "if(!S.busy)" not in shortcut_block, (
+        "Cmd/Ctrl+K must not be blocked by the current session's busy state"
+    )
+    assert "if (!S.busy)" not in shortcut_block, (
+        "Cmd/Ctrl+K must not be blocked by the current session's busy state"
+    )
 
 
 # ── Viewport and scroll safety ────────────────────────────────────────────────


### PR DESCRIPTION
# fix: allow Cmd/Ctrl+K new chat while a conversation is busy

The Cmd/Ctrl+K shortcut for "new conversation" was gated on `!S.busy`, which meant users had to wait for an in-flight generation to finish before they could start a fresh conversation — exactly the moment they want to switch context (long generation running, user wants to ask something else in parallel).

## Salvaged from PR #1084

Lifted out of the contributor PR #1084 (@GeoffBao) as a focused, well-tested PR.

## What ships

### `static/boot.js`

```diff
   if((e.metaKey||e.ctrlKey)&&e.key==='k'){
     e.preventDefault();
     // If the current session has no messages, just focus the composer rather than
     // creating another empty session that will clutter the sidebar list (#1171).
     if(S.session&&(S.session.message_count||0)===0){$('msg').focus();return;}
-    if(!S.busy){await newSession();await renderSessionList();closeMobileSidebar();$('msg').focus();}
+    // Cmd/Ctrl+K should always create a new conversation, even while the current
+    // one is still streaming. The old !S.busy guard meant users had to wait for
+    // a long generation to finish before they could start something new — exactly
+    // the moment they want to switch context. newSession() leaves the in-flight
+    // stream running on its own session; the user just gets a fresh blank one.
+    await newSession();await renderSessionList();closeMobileSidebar();$('msg').focus();
   }
```

The existing `#1171` guard (don't stack empty sessions) is preserved. The in-flight stream continues running on its own session in the background; the user just gets a fresh blank session in the foreground.

## Tests

`tests/test_mobile_layout.py` — new `test_new_conversation_shortcut_works_while_busy` regression guard:

```python
def test_new_conversation_shortcut_works_while_busy():
    boot_js = (REPO / "static" / "boot.js").read_text(encoding="utf-8")
    shortcut_line = next(... e.key==='k' ...)
    idx = boot_js.splitlines().index(shortcut_line)
    shortcut_block = "\n".join(boot_js.splitlines()[idx:idx + 10])
    assert "if(!S.busy)" not in shortcut_block
    assert "if (!S.busy)" not in shortcut_block
```

Existing `test_new_conversation_closes_mobile_sidebar` widened from a 6-line to a 12-line scan window to accommodate the new comment block.

**Full suite: 3253 passed**, 2 skipped, 3 xpassed, 0 failures (was 3252; +1 new test).

## What's intentionally NOT included from #1084

The other changes in #1084 ship as separate sibling PRs:
- Sienna skin
- Stale-session 404 cleanup + structured api() errors
- Session title quality improvements

## Risk

Trivially low. One-line removal of a guard. The streaming session and the new session don't share state — they live independently in the agent's session store. The keybinding is desktop-only (mobile layouts don't typically have a Cmd/Ctrl key), so no mobile UX impact.

## Diff stats

```
 static/boot.js              |  7 ++++++-
 tests/test_mobile_layout.py | 26 +++++++++++++++++++++++++-
 2 files changed, 31 insertions(+), 2 deletions(-)
```

Closes part of #1084 once merged.
