### PR TITLE
fix(cron): import run_job in _run_cron_tracked to fix NameError

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -94,6 +94,8 @@ def _cron_output_content_window(text: str, limit: int = _CRON_OUTPUT_CONTENT_LIM
 
 def _run_cron_tracked(job):
     """Wrapper that tracks running state around cron.scheduler.run_job."""
+    from cron.scheduler import run_job
+
     try:
         run_job(job)
     finally:


### PR DESCRIPTION
## Thinking Path

- Hermes WebUI allows users to manually trigger cron jobs from the Tasks panel
- Manual execution calls `_run_cron_tracked()` in `api/routes.py`
- This function wraps `cron.scheduler.run_job()` to track running state
- The function was calling `run_job(job)` without importing it first
- This caused `NameError: name 'run_job' is not defined` when clicking "Run Now" on any cron job
- The fix is a single-line import at the start of the function

## What Changed

Added one import statement inside `_run_cron_tracked()`:

```python
def _run_cron_tracked(job):
    """Wrapper that tracks running state around cron.scheduler.run_job."""
    from cron.scheduler import run_job  # ← Added this line
    
    try:
        run_job(job)
    finally:
        _mark_cron_done(job.get("id", ""))
```

**Files modified:**
- `api/routes.py` (+2 lines: import + blank line)

## Why It Matters

- **User impact:** Manual cron execution was completely broken — clicking "Run Now" crashed the background worker
- **Scope:** Affects all WebUI users who schedule cron jobs and want to test/run them manually
- **Severity:** High — feature advertised in UI but non-functional

## Verification

- ✅ Python compilation: `python -m py_compile api/routes.py` — passes
- ✅ Existing cron tests: `pytest tests/ -k cron` — 45 passed, 9 skipped (require running agent)
- ✅ No other occurrences of `run_job` without import in the file (searched entire routes.py)

## Risks / Follow-ups

- **Risk:** None — this is a straightforward missing import with no side effects
- **Follow-up:** Could add a test that mocks a cron job execution to catch similar issues in CI

## Model Used

- Provider: Opencode Go
- Model: qwen3.6-plus

## AI Usage Disclosure

- AI-assisted: Yes
- Provider: Opencode Go
- Model: qwen3.6-plus
- Human review: Full code and PR text reviewed before submission

---

Fixes #1310
