### PR TITLE
fix: compare compression_count against per-turn snapshot to stop repeated banner

### DIFF
--- a/api/streaming.py
+++ b/api/streaming.py
@@ -1883,6 +1883,10 @@ def _run_agent_streaming(session_id, msg_text, model, workspace, stream_id, atta
                 agent.ephemeral_system_prompt = _personality_prompt
             _previous_messages = list(s.messages or [])
             _previous_context_messages = list(_session_context_messages(s))
+            _pre_compression_count = getattr(
+                getattr(agent, 'context_compressor', None),
+                'compression_count', 0,
+            )
 
             # ── Periodic checkpoint during streaming (Issue #765) ──
             # The agent works on an internal copy of s.messages during run_conversation()
@@ -2107,7 +2111,7 @@ def _run_agent_streaming(session_id, msg_text, model, workspace, stream_id, atta
                 # Also detect compression via the result dict or compressor state
                 if not _compressed:
                     _compressor = getattr(agent, 'context_compressor', None)
-                    if _compressor and getattr(_compressor, 'compression_count', 0) > 0:
+                    if _compressor and getattr(_compressor, 'compression_count', 0) > _pre_compression_count:
                         _compressed = True
                 # Notify the frontend that compression happened
                 if _compressed:


### PR DESCRIPTION
### Problem

After context compression fires once in a session, the "Context auto-compressed" banner repeats on **every subsequent turn** for the rest of the session.

The compression detection in `_run_agent_streaming()` has two paths:

1. **Session ID comparison** — checks if the agent's session ID changed during the turn (compression rotates the ID). Works correctly: fires once on the compression turn, then stops because the frontend adopts the new ID.

2. **`compression_count` fallback** — checks `getattr(compressor, 'compression_count', 0) > 0`. This is a cumulative counter that only increments. Once compression fires, it is permanently above zero, so this path evaluates to `True` on every subsequent turn.

Path 1 is correct. Path 2 is always a false positive after the first compression event.

### Fix

Snapshot `compression_count` before `run_conversation()` starts. After the turn, compare against the snapshot (`> _pre_compression_count`) instead of zero (`> 0`). The fallback path is preserved for cases where the session ID comparison might not detect compression, but it now only fires when the count actually increased during the current turn.

### Files Changed

- **`api/streaming.py`** — Add pre-turn snapshot of `compression_count`; change fallback comparison from `> 0` to `> _pre_compression_count`

### Testing

1. Start a conversation long enough to trigger context compression
2. Verify the "Context auto-compressed" banner appears once on the compression turn
3. Continue the conversation for several more turns
4. Verify the banner does **not** repeat on subsequent turns
5. Continue until compression fires a second time
6. Verify the banner appears again (once) on the second compression turn