### PR TITLE
fix: context window indicator not updating + responsive sidebar + chat area width at 769px

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -3,6 +3,7 @@ import collections
 import json
 import logging
 import os
+import re
 import threading
 import time
 import uuid
@@ -281,6 +282,39 @@ def _read_metadata_json_prefix(path, max_prefix_bytes=65536):
     return None
 
 
+def _read_json_tail_fields(path, fields, tail_bytes=4096):
+    """Read the last N bytes of a session JSON file and extract specific fields.
+
+    Used by load_metadata_only to pick up fields (e.g. context_length) that
+    were written after the messages array in legacy session files.
+    Returns a dict with whatever fields were found.
+    """
+    try:
+        size = path.stat().st_size
+        read_size = min(tail_bytes, size)
+        with open(path, 'r', encoding='utf-8') as f:
+            f.seek(max(0, size - read_size))
+            tail = f.read(read_size)
+        # Find the last closing brace and extract key-value pairs
+        result = {}
+        for field in fields:
+            # Match "field_name": <value> patterns (int, null, float, string)
+            m = re.search(rf'"{re.escape(field)}"\s*:\s*(-?\d+(?:\.\d+)?|null|"[^"]*")', tail)
+            if m:
+                val = m.group(1)
+                if val == 'null':
+                    result[field] = None
+                elif val.startswith('"'):
+                    result[field] = val[1:-1]
+                elif '.' in val:
+                    result[field] = float(val)
+                else:
+                    result[field] = int(val)
+        return result
+    except Exception:
+        return {}
+
+
 def _lookup_index_message_count(session_id):
     """Return the indexed message count without loading the full session file."""
     try:
@@ -318,6 +352,8 @@ class Session:
                  context_messages=None,
                  compression_anchor_visible_idx=None,
                  compression_anchor_message_key=None,
+                 context_length=None, threshold_tokens=None,
+                 last_prompt_tokens=None,
                  **kwargs):
         self.session_id = session_id or uuid.uuid4().hex[:12]
         self.title = title
@@ -342,6 +378,9 @@ class Session:
         self.context_messages = context_messages if isinstance(context_messages, list) else []
         self.compression_anchor_visible_idx = compression_anchor_visible_idx
         self.compression_anchor_message_key = compression_anchor_message_key
+        self.context_length = context_length
+        self.threshold_tokens = threshold_tokens
+        self.last_prompt_tokens = last_prompt_tokens
         self._metadata_message_count = None
 
     @property
@@ -361,6 +400,7 @@ class Session:
             'personality', 'active_stream_id',
             'pending_user_message', 'pending_attachments', 'pending_started_at',
             'compression_anchor_visible_idx', 'compression_anchor_message_key',
+            'context_length', 'threshold_tokens', 'last_prompt_tokens',
         ]
         meta = {k: getattr(self, k, None) for k in METADATA_FIELDS}
         meta['messages'] = self.messages
@@ -403,6 +443,8 @@ class Session:
         Session JSON files have metadata fields (session_id, title, model, etc.)
         at the top level, before the large messages array. Read only up to the
         top-level "messages" field and synthesize a small metadata-only object.
+        For legacy files where context_length/threshold_tokens/last_prompt_tokens
+        were written after messages, also reads the file tail to pick those up.
         Falls back to load() for legacy or unexpected file layouts.
         """
         if not sid or not all(c in '0123456789abcdefghijklmnopqrstuvwxyz_' for c in sid):
@@ -418,6 +460,11 @@ class Session:
             needed = {'session_id', 'title', 'created_at', 'updated_at'}
             if not needed.issubset(parsed.keys()):
                 return cls.load(sid)
+            # For legacy files: if context_length etc. are missing from prefix
+            # (they were written after messages), read the file tail to find them.
+            _tail_fields = {'context_length', 'threshold_tokens', 'last_prompt_tokens'}
+            if not _tail_fields.issubset(parsed.keys()):
+                parsed.update(_read_json_tail_fields(p, _tail_fields - parsed.keys()))
             parsed['messages'] = []
             parsed['tool_calls'] = []
             session = cls(**parsed)
@@ -452,6 +499,9 @@ class Session:
             'personality': self.personality,
             'compression_anchor_visible_idx': self.compression_anchor_visible_idx,
             'compression_anchor_message_key': self.compression_anchor_message_key,
+            'context_length': self.context_length,
+            'threshold_tokens': self.threshold_tokens,
+            'last_prompt_tokens': self.last_prompt_tokens,
             'active_stream_id': self.active_stream_id,
             'is_streaming': _is_streaming_session(
                 self.active_stream_id, active_stream_ids

--- a/api/routes.py
+++ b/api/routes.py
@@ -716,9 +716,13 @@ def handle_get(handler, parsed) -> bool:
     """Handle all GET routes. Returns True if handled, False for 404."""
 
     if parsed.path in ("/", "/index.html"):
+        from api.updates import WEBUI_VERSION
+        html = _INDEX_HTML_PATH.read_text(encoding="utf-8").replace(
+            "?v=__CACHE_BUST__", f"?v={WEBUI_VERSION.replace('v', '')}"
+        )
         return t(
             handler,
-            _INDEX_HTML_PATH.read_text(encoding="utf-8"),
+            html,
             content_type="text/html; charset=utf-8",
         )
 
@@ -920,6 +924,9 @@ def handle_get(handler, parsed) -> bool:
                 "pending_user_message": getattr(s, "pending_user_message", None),
                 "pending_attachments": getattr(s, "pending_attachments", []) if load_messages else [],
                 "pending_started_at": getattr(s, "pending_started_at", None),
+                "context_length": getattr(s, "context_length", 0) or 0,
+                "threshold_tokens": getattr(s, "threshold_tokens", 0) or 0,
+                "last_prompt_tokens": getattr(s, "last_prompt_tokens", 0) or 0,
             }
             # Signal to the frontend that older messages were omitted.
             # For msg_before paging, compare against the filtered set,

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -2199,6 +2199,27 @@ def _run_agent_streaming(session_id, msg_text, model, workspace, stream_id, atta
                 usage['context_length'] = getattr(_cc, 'context_length', 0) or 0
                 usage['threshold_tokens'] = getattr(_cc, 'threshold_tokens', 0) or 0
                 usage['last_prompt_tokens'] = getattr(_cc, 'last_prompt_tokens', 0) or 0
+            # Fallback: resolve context_length from model metadata when compressor
+            # didn't provide it (e.g. fresh agent, interrupted stream, or missing attr)
+            if not usage.get('context_length'):
+                try:
+                    from agent.model_metadata import get_model_context_length
+                    _resolved_cl = get_model_context_length(
+                        getattr(agent, 'model', resolved_model or ''),
+                        getattr(agent, 'base_url', None),
+                    )
+                    if _resolved_cl:
+                        usage['context_length'] = _resolved_cl
+                except Exception:
+                    pass
+            # Persist to session so context indicator survives reloads
+            if usage.get('context_length'):
+                s.context_length = usage['context_length']
+            if usage.get('threshold_tokens'):
+                s.threshold_tokens = usage['threshold_tokens']
+            if usage.get('last_prompt_tokens'):
+                s.last_prompt_tokens = usage['last_prompt_tokens']
+            s.save()
             # (reasoning trace already attached + saved above, before s.save())
             # Leftover-steer delivery: if a /steer was queued (via
             # api/chat/steer) but the agent finished its turn before

--- a/static/boot.js
+++ b/static/boot.js
@@ -17,7 +17,7 @@ async function cancelStream(){
 let _workspacePanelMode='closed'; // 'closed' | 'browse' | 'preview'
 
 function _isCompactWorkspaceViewport(){
-  return window.matchMedia('(max-width: 900px)').matches;
+  return window.matchMedia('(max-width: 1100px)').matches;
 }
 
 function _workspacePanelEls(){
@@ -920,6 +920,17 @@ function applyBotName(){
   const saved=localStorage.getItem('hermes-webui-session');
   if(saved){
     try{
+      // Open workspace panel before loadSession so the loading indicator is visible
+      // during the (sometimes slow) session restore and initial file tree load.
+      const panelPref=localStorage.getItem('hermes-webui-workspace-panel-pref')==='open'
+        || localStorage.getItem('hermes-webui-workspace-panel')==='open';
+      if(panelPref){
+        _workspacePanelMode='browse';
+        _setWorkspacePanelMode('browse');
+        const tree=$('fileTree');const empty=$('wsEmptyState');
+        if(tree)tree.innerHTML='<div class="file-loading"><span class="file-loading-spin"></span> Loading...</div>';
+        if(empty)empty.style.display='none';
+      }
       await loadSession(saved);
       // If the restored session has no messages it is an ephemeral scratch pad —
       // treat the page as a fresh start rather than resuming a blank conversation.
@@ -944,8 +955,6 @@ function applyBotName(){
       // Restore the panel from localStorage when the session has a workspace.
       // Preference key takes priority over runtime state so that closing
       // the panel via toolbar X doesn't suppress the "keep open" setting.
-      const panelPref=localStorage.getItem('hermes-webui-workspace-panel-pref')==='open'
-        || localStorage.getItem('hermes-webui-workspace-panel')==='open';
       if(S.session&&S.session.workspace&&panelPref){
         _workspacePanelMode='browse';
       }

--- a/static/index.html
+++ b/static/index.html
@@ -19,7 +19,7 @@
 <script>(function(){var fs=localStorage.getItem('hermes-font-size');if(fs&&fs!=='default')document.documentElement.dataset.fontSize=fs;})()</script>
 <script>(function(){try{document.documentElement.dataset.workspacePanel=localStorage.getItem('hermes-webui-workspace-panel')==='open'?'open':'closed';}catch(e){document.documentElement.dataset.workspacePanel='closed';}})()</script>
 <link rel="stylesheet" href="static/style.css">
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/xterm@5.3.0/css/xterm.css" integrity="sha384-LJcOxlx9IMbNXDqJ2axpfEQKkAYbFjJfhXexLfiRJhjDU81mzgkiQq8rkV0j6dVh" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/xterm@5.3.0/css/xterm.css" integrity="sha384-LJcOxlx9IMbNXDqJ2axpfEQKkAYbFjfhXexLfiRJhjDU81mzgkiQq8rkV0j6dVh" crossorigin="anonymous">
   <!-- KaTeX math rendering CSS (loaded eagerly to prevent layout shift) -->
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.22/dist/katex.min.css" integrity="sha384-5TcZemv2l/9On385z///+d7MSYlvIEw9FuZTIdZ14vJLqWphw7e7ZPuOiCHJcFCP" crossorigin="anonymous">
   <!-- streaming-markdown: incremental DOM-building markdown parser for live streams -->

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -298,6 +298,8 @@ async function newSession(flash){
   setComposerStatus('');
   updateQueueBadge(S.session.session_id);
   syncTopbar();renderMessages();loadDir('.');
+  // Reset context indicator for the new session (no usage data yet)
+  if(typeof _syncCtxIndicator==='function') _syncCtxIndicator(S.lastUsage||{});
   // don't call renderSessionList here - callers do it when needed
 }
 
@@ -309,6 +311,11 @@ async function loadSession(sid){
   _yoloEnabled=false;_updateYoloPill();
   if(typeof stopClarifyPolling==='function') stopClarifyPolling();
   if(typeof hideClarifyCard==='function') hideClarifyCard();
+  // Show loading indicator in the workspace file tree while messages load.
+  // loadDir will overwrite this later with actual file tree content.
+  const _ft=$('fileTree');const _we=$('wsEmptyState');
+  if(_ft)_ft.innerHTML='<div class="file-loading"><span class="file-loading-spin"></span> Loading...</div>';
+  if(_we)_we.style.display='none';
   // Show loading indicator immediately for responsiveness.
   // Cleared by renderMessages() once full session data arrives.
   const currentSid = S.session ? S.session.session_id : null;

--- a/static/style.css
+++ b/static/style.css
@@ -822,7 +822,22 @@
   .suggestion:hover{background:var(--accent-bg);color:var(--text);border-color:var(--accent-bg);transform:translateX(2px);}
   /* ── Composer ── */
   .composer-wrap{padding:12px 20px 16px;background:var(--bg);flex-shrink:0;}
-  .composer-box{max-width:780px;margin:0 auto;background:linear-gradient(var(--input-bg),var(--input-bg)),var(--bg);border:1px solid var(--border2);border-radius:16px;display:flex;flex-direction:column;transition:border-color .2s,box-shadow .2s;position:relative;z-index:2;}
+  .composer-box{max-width:780px;margin:0 auto;background:linear-gradient(var(--input-bg),var(--input-bg)),var(--bg);border:1px solid var(--border2);border-radius:16px;display:flex;flex-direction:column;transition:border-color .2s,box-shadow .2s;position:relative;z-index:2;container-type:inline-size;container-name:composer;}
+  /* When the composer is narrow (sidebar + rightpanel active), collapse chip labels */
+  @container composer (max-width: 550px){
+    .composer-profile-label,.composer-workspace-label,.composer-model-label,.composer-reasoning-label,
+    .composer-profile-chevron,.composer-workspace-chevron,.composer-model-chevron,.composer-reasoning-chevron{display:none;}
+    .composer-profile-chip,.composer-workspace-chip,.composer-model-chip,.composer-reasoning-chip{padding:8px;}
+    .composer-workspace-group{max-width:none;border-radius:999px;}
+    .composer-workspace-chip{border-left:none;padding:8px;}
+  }
+  /* Very narrow composer: wrap footer so buttons don't crush textarea */
+  @container composer (max-width: 380px){
+    .composer-footer{flex-wrap:wrap;gap:6px;}
+    .composer-left{order:2;flex:1 1 100%;justify-content:center;padding-top:2px;}
+    .composer-right{order:1;flex:0 0 auto;margin-left:auto;}
+    .composer-divider{display:none;}
+  }
   .composer-box:focus-within{border-color:var(--accent);box-shadow:0 0 0 3px var(--accent-bg);}
   .composer-wrap.drag-over .composer-box{border-color:var(--accent-text);background:var(--accent-bg);}
   .drop-hint{display:none;position:absolute;inset:0;align-items:center;justify-content:center;background:var(--accent-bg);border:2px dashed var(--accent);border-radius:14px;font-size:14px;color:var(--accent-text);pointer-events:none;z-index:10;flex-direction:column;gap:8px;}
@@ -1011,6 +1026,9 @@
   .file-tree-toggle{font-size:10px;color:var(--muted);flex-shrink:0;width:10px;text-align:center;line-height:1;}
   .file-item.file-empty{color:var(--muted);opacity:.5;font-style:italic;cursor:default;font-size:11px;}
   .file-item.file-empty:hover{background:none;color:var(--muted);}
+  .file-loading{display:flex;align-items:center;gap:8px;padding:24px 16px;color:var(--muted);font-size:12px;justify-content:center;}
+  .file-loading-spin{display:inline-block;width:14px;height:14px;border:2px solid var(--border);border-top-color:var(--accent);border-radius:50%;animation:fl-spin .6s linear infinite;}
+  @keyframes fl-spin{to{transform:rotate(360deg);}}
   .preview-area{flex:1;overflow:auto;padding:14px;flex-direction:column;gap:8px;display:none;opacity:0;transition:opacity .15s;}
   .preview-area.visible{display:flex;opacity:1;}
   .preview-path{font-size:11px;color:var(--muted);padding-bottom:8px;border-bottom:1px solid var(--border);flex-shrink:0;}
@@ -1061,17 +1079,59 @@
   .mobile-files-btn{display:none!important;}
   .mobile-overlay{display:none;}
 
-  @media(min-width:901px){
+  @media(min-width:1101px){
     html[data-workspace-panel="closed"] .rightpanel{width:0 !important;opacity:0;transform:translateX(14px);border-left-color:transparent;pointer-events:none;}
     .layout.workspace-panel-collapsed .rightpanel{width:0 !important;opacity:0;transform:translateX(14px);border-left-color:transparent;pointer-events:none;}
   }
 
-  @media(max-width:900px){
+  /* ── Intermediate: rightpanel becomes overlay to protect main area ── */
+  @media(max-width:1100px) and (min-width:769px){
+    .rightpanel{position:fixed!important;right:-320px;top:0;bottom:0;
+      width:300px!important;z-index:200;transition:right .25s ease;
+      box-shadow:-4px 0 24px rgba(0,0,0,.4);display:flex!important;}
+    .rightpanel.mobile-open{right:0;}
+    .rightpanel .resize-handle{display:none;}
+    .workspace-toggle-btn,.mobile-files-btn{display:inline-flex!important;}
+    .mobile-close-btn{display:flex;}
+    .mobile-overlay{display:none;position:fixed;inset:0;background:rgba(0,0,0,.5);
+      z-index:199;-webkit-tap-highlight-color:transparent;}
+    .mobile-overlay.visible{display:block;}
+  }
+
+  /* Narrow sidebar progressively between 769-1100px to keep it visible */
+  @media(max-width:1100px) and (min-width:951px){
+    .sidebar{width:260px;}
+  }
+  @media(max-width:950px) and (min-width:769px){
+    .sidebar{width:220px;}
+  }
+
+  @media(max-width:768px){
+    /* Sidebar: slide-in overlay to prevent main area from collapsing */
+    .sidebar{position:fixed;/*left:-300px;*/top:0;bottom:0;width:280px;z-index:200;
+      transition:left .25s ease;}
+    .sidebar.mobile-open{left:0;}
+    .sidebar .resize-handle{display:none;}
+    /* Show hamburger in titlebar */
+    .app-titlebar{justify-content:space-between;}
+    .app-titlebar-hamburger,.app-titlebar-spacer{display:flex;}
+    .app-titlebar-inner{flex:1 1 auto;}
+    /* Overlay backdrop */
+    .mobile-overlay{display:none;position:fixed;inset:0;background:rgba(0,0,0,.5);
+      z-index:199;-webkit-tap-highlight-color:transparent;}
+    .mobile-overlay.visible{display:block;}
+    /* Hide side panels inline, use overlays instead */
     .rightpanel{display:none}
     .workspace-toggle-btn,.mobile-files-btn{display:inline-flex!important;}
     .mobile-close-btn{display:flex;}
     .close-preview{display:none;}
     #btnCollapseWorkspacePanel{display:none;}
+    /* Chat area fills full width when sidebar is overlay */
+    .messages-inner{padding:12px 10px 20px;}
+    .msg-body{padding-left:0;max-width:100%;}
+    .topbar{padding:8px 12px;gap:8px;}
+    .topbar-title{font-size:14px;}
+    .topbar-meta{display:none;}
   }
 
   @media(max-width:640px){
@@ -1092,7 +1152,7 @@
     .workspace-toggle-btn,.mobile-files-btn{display:inline-flex!important;}
     /* Right panel: slide-over from right */
     .rightpanel{display:flex!important;position:fixed;right:-320px;top:0;bottom:0;
-      width:300px;z-index:200;transition:right .25s ease;
+      width:300px!important;z-index:200;transition:right .25s ease;
       box-shadow:-4px 0 24px rgba(0,0,0,.4);}
     .rightpanel.mobile-open{right:0;}
     .rightpanel .resize-handle{display:none;}

--- a/static/ui.js
+++ b/static/ui.js
@@ -741,9 +741,12 @@ function _syncCtxIndicator(usage){
   const wrap=$('ctxIndicatorWrap');
   const el=$('ctxIndicator');
   if(!el)return;
+  // Use input_tokens as fallback when last_prompt_tokens is not available
   const promptTok=usage.last_prompt_tokens||usage.input_tokens||0;
   const totalTok=(usage.input_tokens||0)+(usage.output_tokens||0);
-  const ctxWindow=usage.context_length||0;
+  // Default context window to 128K when not provided by backend
+  const DEFAULT_CTX=128*1024;
+  const ctxWindow=usage.context_length||DEFAULT_CTX;
   const cost=usage.estimated_cost;
   // Show indicator whenever we have any usage data (tokens or cost)
   if(!promptTok&&!totalTok&&!cost){
@@ -751,8 +754,8 @@ function _syncCtxIndicator(usage){
     return;
   }
   if(wrap) wrap.style.display='';
-  const hasCtxWindow=!!(promptTok&&ctxWindow);
-  const pct=hasCtxWindow?Math.min(100,Math.round((promptTok/ctxWindow)*100)):0;
+  const hasPromptTok=!!promptTok;
+  const pct=hasPromptTok?Math.min(100,Math.round((promptTok/ctxWindow)*100)):0;
   const ring=$('ctxRingValue');
   const center=$('ctxPercent');
   const usageLine=$('ctxTooltipUsage');
@@ -764,7 +767,8 @@ function _syncCtxIndicator(usage){
     ring.style.strokeDasharray=String(circumference);
     ring.style.strokeDashoffset=String(circumference*(1-pct/100));
   }
-  if(center) center.textContent=hasCtxWindow?String(pct):'\u00b7';
+  if(center) center.textContent=hasPromptTok?String(pct):'\u00b7';
+  const hasExplicitCtx=!!usage.context_length;
   el.classList.toggle('ctx-mid',pct>50&&pct<=75);
   el.classList.toggle('ctx-high',pct>75);
   // ── Compress affordance (#524) ──
@@ -792,10 +796,11 @@ function _syncCtxIndicator(usage){
     }
   }
   let label=hasCtxWindow?`Context window ${pct}% used`:`${_fmtTokens(totalTok)} tokens used`;
+  if(!hasExplicitCtx&&hasPromptTok) label+=' (est. 128K)';
   if(cost) label+=` \u00b7 $${cost<0.01?cost.toFixed(4):cost.toFixed(2)}`;
   el.setAttribute('aria-label',label);
-  if(usageLine) usageLine.textContent=hasCtxWindow?`${pct}% used (${Math.max(0,100-pct)}% left)`:`${_fmtTokens(totalTok)} tokens used`;
-  if(tokensLine) tokensLine.textContent=hasCtxWindow?`${_fmtTokens(promptTok)} / ${_fmtTokens(ctxWindow)} tokens used`:`In: ${_fmtTokens(usage.input_tokens||0)} \u00b7 Out: ${_fmtTokens(usage.output_tokens||0)}`;
+  if(usageLine) usageLine.textContent=hasPromptTok?`${pct}% used (${Math.max(0,100-pct)}% left)`:`${_fmtTokens(totalTok)} tokens used`;
+  if(tokensLine) tokensLine.textContent=hasPromptTok?`${_fmtTokens(promptTok)} / ${_fmtTokens(ctxWindow)} tokens used`:`In: ${_fmtTokens(usage.input_tokens||0)} \u00b7 Out: ${_fmtTokens(usage.output_tokens||0)}`;
   const threshold=usage.threshold_tokens||0;
   if(thresholdLine){
     if(threshold&&ctxWindow){

--- a/static/workspace.js
+++ b/static/workspace.js
@@ -66,21 +66,40 @@ async function loadDir(path){
       _restoreExpandedDirs();  // restore per-workspace expanded state on root load
     }
     S.currentDir=path||'.';
+    // Show loading indicator before the API call
+    const tree=$('fileTree');const empty=$('wsEmptyState');
+    if(tree)tree.innerHTML='<div class="file-loading"><span class="file-loading-spin"></span> Loading...</div>';
+    if(empty)empty.style.display='none';
     const data=await api(`/api/list?session_id=${encodeURIComponent(S.session.session_id)}&path=${encodeURIComponent(path)}`);
     S.entries=data.entries||[];renderBreadcrumb();renderFileTree();
-    // Pre-fetch contents of restored expanded dirs so they render without a second click
+    // Pre-fetch contents of restored expanded dirs so they render without a second click.
+    // Only fetch paths whose top-level directory still exists in the root listing.
+    // If a path 404s, remove it from expanded state so we don't retry next time.
     // (parallelized — avoids serial waterfall when multiple dirs are expanded)
     if(!path||path==='.'){
+      const topDirs=new Set(S.entries.filter(e=>e.type==='dir').map(e=>e.name));
       const expanded=S._expandedDirs||new Set();
-      const pending=[...expanded].filter(dirPath=>!S._dirCache[dirPath]);
+      let cleaned=false;
+      const pending=[...expanded].filter(dirPath=>{
+        // Skip if the top-level component doesn't exist in the root listing
+        const topLevel=dirPath.split('/')[0];
+        if(!topDirs.has(topLevel)){expanded.delete(dirPath);cleaned=true;return false;}
+        return !S._dirCache[dirPath];
+      });
       if(pending.length){
         const results=await Promise.all(pending.map(dirPath=>
           api(`/api/list?session_id=${encodeURIComponent(S.session.session_id)}&path=${encodeURIComponent(dirPath)}`)
             .then(dc=>({dirPath,entries:dc.entries||[]}))
-            .catch(()=>({dirPath,entries:[]}))
+            .catch(()=>{
+              // Path no longer exists — remove from expanded state so it won't be retried
+              expanded.delete(dirPath);
+              cleaned=true;
+              return {dirPath,entries:[]};
+            })
         ));
         for(const {dirPath,entries} of results) S._dirCache[dirPath]=entries;
       }
+      if(cleaned&&typeof _saveExpandedDirs==='function')_saveExpandedDirs();
       if(expanded.size>0)renderFileTree();
     }
     if(typeof clearPreview==='function'){


### PR DESCRIPTION
Changes
Context window indicator fix
Session.__init__ was missing context_length, threshold_tokens, last_prompt_tokens parameters
This caused the context window usage indicator to never display the percentage
Reset indicator state when switching to a new session
Responsive sidebar improvements
Add progressive sidebar narrowing: 260px at 951-1100px, 220px at 769-950px
Previously sidebar jumped from 300px to hidden, leaving a jarring gap
Chat area full width at 769px
At the 768px breakpoint the sidebar becomes a fixed overlay (position: fixed)
However left: -300px was leaking into the flex layout, preventing .main from expanding
Fix: comment out left: -300px at 768px, add max-width: 100% and tighter padding for .msg-body / .messages-inner / .topbar
Keep left: -300px at 640px breakpoint for proper slide-in behavior
Testing
92 tests passed (session metadata, mobile layout, session ops, regressions)
