### PR TITLE
fix: retry SSE reconnect up to 3 times with exponential backoff

### DIFF
--- a/static/messages.js
+++ b/static/messages.js
@@ -377,7 +377,9 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
   }
 
   // ── Shared SSE handler wiring (used for initial connection and reconnect) ──
-  let _reconnectAttempted=false;
+  let _reconnectAttempts=0;
+  const _RECONNECT_MAX=3;
+  const _RECONNECT_DELAYS=[1500,3000,6000];
   let _terminalStateReached=false;
 
   // Bug A fix (#631): track whether the stream has been finalized so any rAF
@@ -984,9 +986,10 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         _closeSource();
         return;
       }
-      // Attempt one reconnect if the stream is still active server-side
-      if(!_reconnectAttempted && streamId){
-        _reconnectAttempted=true;
+      // Retry up to _RECONNECT_MAX times with exponential backoff before giving up
+      if(_reconnectAttempts < _RECONNECT_MAX && streamId){
+        const attempt=_reconnectAttempts++;
+        const delay=_RECONNECT_DELAYS[attempt]||6000;
         setComposerStatus('Reconnecting…');
         setTimeout(async()=>{
           try{
@@ -999,7 +1002,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
           }catch(_){}
           if(await _restoreSettledSession()) return;
           _handleStreamError();
-        },1500);
+        },delay);
         return;
       }
       if(await _restoreSettledSession()) return;


### PR DESCRIPTION
## Problem

Users occasionally see **\"Connection lost\"** in the chat UI during an active agent run. After reloading the page the chat resumes normally — the backend stream was never interrupted, only the frontend SSE connection dropped.

**Root cause:** `_reconnectAttempted` was a boolean. On SSE `error`, the frontend waited 1500 ms and opened a new `EventSource`. If that new connection also emitted `error` (common when the network is still stabilising — e.g. Tailscale/VPN hiccup, brief WiFi drop), `_reconnectAttempted` was already `true` so the code fell straight through to `_handleStreamError()` → \"Connection lost\", even though `/api/chat/stream/status` would have returned `active: true`.

## Fix

Replace the boolean flag with a counter and retry up to **3 times** with exponential backoff:

| Attempt | Delay |
|---------|-------|
| 1 | 1 500 ms |
| 2 | 3 000 ms |
| 3 | 6 000 ms |

Each attempt re-checks `/api/chat/stream/status` before opening a new `EventSource`. Only after all three attempts fail is `_handleStreamError()` called.

## Why this is safe

- The backend already sends `: heartbeat` every 30 s, so the stream stays alive server-side through any transient network gap.
- The retry loop exits immediately on `_terminalStateReached` or `_streamFinalized`, so cancelled/completed streams are unaffected.
- No behaviour change for intentional disconnects or actual backend failures.

## Reproduction

1. Start a long-running agent task (>30 s)
2. Briefly interrupt the client network (disable/re-enable WiFi, Tailscale reconnect, etc.)
3. **Before fix:** \"Connection lost\" appears; reload is required
4. **After fix:** UI shows \"Reconnecting…\" briefly, then \"Reconnected\" — no interruption visible to the user