### PR TITLE
fix: avoid duplicate header copy buttons

### DIFF
--- a/static/ui.js
+++ b/static/ui.js
@@ -3712,7 +3712,8 @@ function addCopyButtons(container){
   if(!el) return;
   el.querySelectorAll('pre > code').forEach(codeEl=>{
     const pre=codeEl.parentElement;
-    if(pre.querySelector('.code-copy-btn')) return;
+    const header=pre.previousElementSibling;
+    if(pre.querySelector('.code-copy-btn')||(header&&header.classList.contains('pre-header')&&header.querySelector('.code-copy-btn'))) return;
     const btn=document.createElement('button');
     btn.className='code-copy-btn';
     btn.textContent=t('copy');
@@ -3723,7 +3724,6 @@ function addCopyButtons(container){
         setTimeout(()=>{btn.textContent=t('copy');},1500);
       }).catch(()=>{btn.textContent=t('copy_failed');setTimeout(()=>{btn.textContent=t('copy');},1500);});
     };
-    const header=pre.previousElementSibling;
     if(header&&header.classList.contains('pre-header')){
       header.style.display='flex';
       header.style.justifyContent='space-between';

--- a/tests/test_issue1096_copy_buttons.py
+++ b/tests/test_issue1096_copy_buttons.py
@@ -88,11 +88,27 @@ class TestCodeCopyButton:
         # Find addCopyButtons function
         m = re.search(r"function addCopyButtons", src)
         assert m, "addCopyButtons must exist"
-        fn = src[m.start():m.start() + 800]
+        fn = src[m.start():m.start() + 1000]
         assert "_copyText" in fn, \
             "Code copy button must use _copyText function"
         assert "codeEl.textContent" in fn, \
             "Code copy must copy the code element's textContent"
+
+    def test_code_copy_button_is_idempotent_for_header_blocks(self):
+        """Repeated post-render passes must not append duplicate header buttons.
+
+        addCopyButtons() can be called multiple times after render/cache/streaming
+        updates.  For fenced blocks with a language header, the copy button is
+        appended to the sibling .pre-header, not inside <pre>, so the duplicate
+        guard must check the header as well as the <pre>.
+        """
+        src = _src("ui.js")
+        m = re.search(r"function addCopyButtons", src)
+        assert m, "addCopyButtons must exist"
+        fn = src[m.start():m.start() + 1200]
+        assert "const header=pre.previousElementSibling;" in fn
+        assert "header.querySelector('.code-copy-btn')" in fn
+        assert fn.index("header.querySelector('.code-copy-btn')") < fn.index("document.createElement('button')")
 
 class TestCopyFailedI18n:
 


### PR DESCRIPTION
## Thinking Path
- Hermes WebUI renders fenced code blocks through repeated post-render passes during normal chat updates.
- For code blocks with a language header, the copy button is appended to the sibling `.pre-header`, not inside the `<pre>` element.
- The existing duplicate guard only checked inside `<pre>`, so repeated `addCopyButtons()` calls could append duplicate header copy buttons.
- This PR makes the guard check the header before creating a new button.

## What Changed
- Detect an existing `.code-copy-btn` in the `.pre-header` sibling before creating a new copy button.
- Keep the existing no-header behavior unchanged.
- Added a regression test that verifies the header guard runs before `document.createElement('button')`.

## Why It Matters
- Prevents duplicate copy buttons on language-header code blocks after repeated render/cache/streaming update passes.
- Keeps the fix small and localized to the existing vanilla JS helper.

## Verification
- `python -m pytest tests/test_issue1096_copy_buttons.py -q`
- Result: `10 passed`

## Risks / Follow-ups
- Low risk; the change only broadens the idempotency guard before creating a copy button.
- No layout changes beyond preventing duplicate buttons.

## Model Used
- AI-assisted with OpenAI GPT-5.5 via Hermes Agent, using local git/pytest/GitHub CLI tooling.
