### PR TITLE
fix(cron): import run_job in _run_cron_tracked to fix NameError

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -94,6 +94,7 @@ def _cron_output_content_window(text: str, limit: int = _CRON_OUTPUT_CONTENT_LIM
 
 def _run_cron_tracked(job):
     """Wrapper that tracks running state around cron.scheduler.run_job."""
+    from cron.scheduler import run_job
     try:
         run_job(job)
     finally:


### PR DESCRIPTION
## Description

Fixes #1310: Manual cron job execution crashes with `NameError: name 'run_job' is not defined`.

The `_run_cron_tracked()` function calls `run_job(job)` but `run_job` was never imported. The function is defined at line 95 in `api/routes.py`, but `run_job` is only imported locally inside `_handle_cron_run()` (line 3503).

## Fix

Added `from cron.scheduler import run_job` at the top of `_run_cron_tracked()` function body, matching the existing import pattern used elsewhere in the file.

## Related

- Fixes #1310
- Same issue potentially addressed by #1312 and #1317 (unmerged)