### PR TITLE
fix: align .env.example state dir default with bootstrap.py

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,7 +16,7 @@
 # HERMES_WEBUI_PORT=8787
 
 # Where to store sessions, workspaces, and other state (default: ~/.hermes/webui-mvp)
-# HERMES_WEBUI_STATE_DIR=~/.hermes/webui-mvp
+# HERMES_WEBUI_STATE_DIR=~/.hermes/webui
 
 # Default workspace directory shown on first launch
 # HERMES_WEBUI_DEFAULT_WORKSPACE=~/workspace


### PR DESCRIPTION
## Description

The `.env.example` file references `HERMES_WEBUI_STATE_DIR=~/.hermes/webui-mvp`, but `bootstrap.py` defaults to `~/.hermes/webui` and `docker-compose.yml` also uses `~/.hermes/webui`.

This inconsistency can confuse users following the example config — the state dir they set in `.env` won't match what the rest of the codebase expects by default.

## Changes

- Updated `HERMES_WEBUI_STATE_DIR` comment in `.env.example` from `~/.hermes/webui-mvp` → `~/.hermes/webui` to match the actual default used by `bootstrap.py` and `docker-compose.yml`.