### PR TITLE
fix: add Docker HEALTHCHECK to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -92,5 +92,8 @@ ENV HERMES_WEBUI_PORT=8787
 
 EXPOSE 8787
 
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD curl -f http://localhost:8787/health || exit 1
+
 CMD ["/hermeswebui_init.bash"]
 


### PR DESCRIPTION
## Description

The Dockerfile was missing a `HEALTHCHECK` instruction, which means Docker and Docker Compose can't automatically detect when the container is healthy.

The `/health` endpoint already exists and returns `{"status": "ok"}`, so this is a straightforward addition.

## Changes

Added `HEALTHCHECK` instruction to Dockerfile:
```dockerfile
HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
  CMD curl -f http://localhost:8787/health || exit 1
```

This enables:
- `docker ps` shows healthy/unhealthy status
- Docker Compose `depends_on` with `condition: service_healthy` works
- Orchestration tools (K8s, Swarm) can use native health probes