### PR TITLE
fix: persist context window usage to session after streaming

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -318,6 +318,8 @@ class Session:
                  context_messages=None,
                  compression_anchor_visible_idx=None,
                  compression_anchor_message_key=None,
+                 context_length=None, threshold_tokens=None,
+                 last_prompt_tokens=None,
                  **kwargs):
         self.session_id = session_id or uuid.uuid4().hex[:12]
         self.title = title
@@ -342,6 +344,9 @@ class Session:
         self.context_messages = context_messages if isinstance(context_messages, list) else []
         self.compression_anchor_visible_idx = compression_anchor_visible_idx
         self.compression_anchor_message_key = compression_anchor_message_key
+        self.context_length = context_length
+        self.threshold_tokens = threshold_tokens
+        self.last_prompt_tokens = last_prompt_tokens
         self._metadata_message_count = None
 
     @property
@@ -361,6 +366,7 @@ class Session:
             'personality', 'active_stream_id',
             'pending_user_message', 'pending_attachments', 'pending_started_at',
             'compression_anchor_visible_idx', 'compression_anchor_message_key',
+            'context_length', 'threshold_tokens', 'last_prompt_tokens',
         ]
         meta = {k: getattr(self, k, None) for k in METADATA_FIELDS}
         meta['messages'] = self.messages
@@ -452,6 +458,9 @@ class Session:
             'personality': self.personality,
             'compression_anchor_visible_idx': self.compression_anchor_visible_idx,
             'compression_anchor_message_key': self.compression_anchor_message_key,
+            'context_length': self.context_length,
+            'threshold_tokens': self.threshold_tokens,
+            'last_prompt_tokens': self.last_prompt_tokens,
             'active_stream_id': self.active_stream_id,
             'is_streaming': _is_streaming_session(
                 self.active_stream_id, active_stream_ids

--- a/api/routes.py
+++ b/api/routes.py
@@ -920,6 +920,9 @@ def handle_get(handler, parsed) -> bool:
                 "pending_user_message": getattr(s, "pending_user_message", None),
                 "pending_attachments": getattr(s, "pending_attachments", []) if load_messages else [],
                 "pending_started_at": getattr(s, "pending_started_at", None),
+                "context_length": getattr(s, "context_length", 0) or 0,
+                "threshold_tokens": getattr(s, "threshold_tokens", 0) or 0,
+                "last_prompt_tokens": getattr(s, "last_prompt_tokens", 0) or 0,
             }
             # Signal to the frontend that older messages were omitted.
             # For msg_before paging, compare against the filtered set,

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -2199,6 +2199,27 @@ def _run_agent_streaming(session_id, msg_text, model, workspace, stream_id, atta
                 usage['context_length'] = getattr(_cc, 'context_length', 0) or 0
                 usage['threshold_tokens'] = getattr(_cc, 'threshold_tokens', 0) or 0
                 usage['last_prompt_tokens'] = getattr(_cc, 'last_prompt_tokens', 0) or 0
+            # Fallback: resolve context_length from model metadata when compressor
+            # didn't provide it (e.g. fresh agent, interrupted stream, or missing attr)
+            if not usage.get('context_length'):
+                try:
+                    from agent.model_metadata import get_model_context_length
+                    _resolved_cl = get_model_context_length(
+                        getattr(agent, 'model', resolved_model or ''),
+                        getattr(agent, 'base_url', None),
+                    )
+                    if _resolved_cl:
+                        usage['context_length'] = _resolved_cl
+                except Exception:
+                    pass
+            # Persist to session so context indicator survives reloads
+            if usage.get('context_length'):
+                s.context_length = usage['context_length']
+            if usage.get('threshold_tokens'):
+                s.threshold_tokens = usage['threshold_tokens']
+            if usage.get('last_prompt_tokens'):
+                s.last_prompt_tokens = usage['last_prompt_tokens']
+            s.save()
             # (reasoning trace already attached + saved above, before s.save())
             # Leftover-steer delivery: if a /steer was queued (via
             # api/chat/steer) but the agent finished its turn before


### PR DESCRIPTION
## Summary

Split out from the original context-indicator-responsive-sidebar PR per review feedback.

When a stream finishes, context window data (context_length, threshold_tokens, last_prompt_tokens) was only sent via SSE but never written to the session file. On page reload the indicator showed 0%.

## Changes

- **Fallback**: if the compressor didn't report `context_length`, resolve it from `agent.model_metadata.get_model_context_length()` — covers fresh agents, interrupted streams, or agents without a compressor
- **Persist**: write the three fields to the Session object and call `s.save()` once at stream completion

## Dependencies

**Depends on PR A** (jasonjcwu/fix/session-context-fields) — the Session model must accept these fields first.

## Write amplification note

`s.save()` runs once per completed stream turn in the `done` path, not on every periodic checkpoint. No additional saves are added to the checkpoint cycle.

## What this PR does NOT include

- ❌ No `_read_json_tail_fields` regex — legacy file handling will be a separate migration PR
- ❌ No frontend/CSS/streaming checkpoint changes