### PR TITLE
fix(ui+api): render user code blocks + save sessions to profile dirs

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -344,6 +344,13 @@ class Session:
 
     @property
     def path(self):
+        # Fix #1195: use profile-specific sessions directory when profile is set.
+        if self.profile:
+            try:
+                from api.profiles import _resolve_named_profile_home
+                return _resolve_named_profile_home(self.profile) / 'sessions' / f'{self.session_id}.json'
+            except (ImportError, NameError):
+                pass
         return SESSION_DIR / f'{self.session_id}.json'
 
     def save(self, touch_updated_at: bool = True, skip_index: bool = False) -> None:

--- a/static/ui.js
+++ b/static/ui.js
@@ -2463,7 +2463,17 @@ function renderMessages(){
         return `<div class="msg-file-badge">${li('paperclip',12)} ${esc(fname)}</div>`;
       }).join('')}</div>`;
     }
-    const bodyHtml = isUser ? esc(String(content)).replace(/\n/g,'<br>') : renderMd(_stripXmlToolCallsDisplay(String(content)));
+    const _renderUserContent = (content) => {
+        const escaped = esc(String(content));
+        // Check if content contains fenced code block markers
+        if (/^```/m.test(escaped)) {
+            // renderMd will process the markdown code blocks and escape any raw HTML
+            return renderMd(escaped);
+        }
+        // Default: plain text with <br> for line breaks
+        return escaped.replace(/\n/g, '<br>');
+    };
+    const bodyHtml = isUser ? _renderUserContent(content) : renderMd(_stripXmlToolCallsDisplay(String(content)));
     const isEditableUser=isUser&&rawIdx===lastUserRawIdx;
     const editBtn  = isEditableUser ? `<button class="msg-action-btn" title="${t('edit_message')}" onclick="editMessage(this)">${li('pencil',13)}</button>` : '';
     const undoBtn  = isLastAssistant ? `<button class="msg-action-btn" title="${t('undo_exchange')}" onclick="undoLastExchange()">${li('undo',13)}</button>` : '';


### PR DESCRIPTION
## Summary

This PR fixes two issues in Hermes WebUI:

### Fix #1325: Render fenced code blocks in user message bubbles
User-authored fenced code blocks (e.g. ```yaml) were displayed as plain escaped text. Now rendered via `renderMd()` for syntax highlighting, while still sanitizing for XSS safety.

### Fix #1195: Save sessions to profile-specific directories
Sessions were always saved to the global `SESSION_DIR` regardless of which profile was active. Now uses profile-specific directory via `_resolve_named_profile_home()` when the session has a profile set, ensuring sessions for different agents stay in their respective profile directories.

## Changes
- `static/ui.js`: Add `_renderUserContent()` helper
- `api/models.py`: Update `Session.path` property to use profile-specific directory

## AI Disclosure
AI-generated: Yes (qwen3.6-plus via OpenCode Go)

Fixes #1325
Fixes #1195