### PR TITLE
feat(clarify): SSE long-connection for real-time clarify notifications

### DIFF
--- a/api/clarify.py
+++ b/api/clarify.py
@@ -6,6 +6,7 @@ clarification string instead of an approval decision.
 
 from __future__ import annotations
 
+import queue
 import threading
 import time
 from typing import Optional
@@ -16,6 +17,9 @@ _lock = threading.Lock()
 _pending: dict[str, dict] = {}
 _gateway_queues: dict[str, list] = {}
 _gateway_notify_cbs: dict[str, object] = {}
+
+# ── SSE subscriber registry ─────────────────────────────────────────────
+_clarify_sse_subscribers: dict[str, list[queue.Queue]] = {}
 
 
 class _ClarifyEntry:
@@ -70,15 +74,46 @@ def _with_timeout_metadata(data: dict) -> dict:
     return item
 
 
+def _clarify_sse_notify(session_id: str, head: dict | None, total: int) -> None:
+    """Push a clarify event to all SSE subscribers for a session."""
+    payload = {"pending": dict(head) if head else None, "pending_count": total}
+    for q in _clarify_sse_subscribers.get(session_id, ()):
+        try:
+            q.put_nowait(payload)
+        except queue.Full:
+            pass  # drop if subscriber is slow
+
+
+def sse_subscribe(session_id: str) -> queue.Queue:
+    """Register a bounded Queue for SSE push to a given session."""
+    q: queue.Queue = queue.Queue(maxsize=16)
+    with _lock:
+        _clarify_sse_subscribers.setdefault(session_id, []).append(q)
+    return q
+
+
+def sse_unsubscribe(session_id: str, q: queue.Queue) -> None:
+    """Remove a subscriber Queue; clean up empty session entries."""
+    with _lock:
+        subs = _clarify_sse_subscribers.get(session_id)
+        if subs:
+            try:
+                subs.remove(q)
+            except ValueError:
+                pass
+            if not subs:
+                _clarify_sse_subscribers.pop(session_id, None)
+
+
 def submit_pending(session_key: str, data: dict) -> _ClarifyEntry:
     """Queue a pending clarify request and notify the UI callback if registered."""
     data = _with_timeout_metadata(data)
     with _lock:
-        queue = _gateway_queues.setdefault(session_key, [])
+        gw_queue = _gateway_queues.setdefault(session_key, [])
         # De-duplicate while unresolved: if the most recent pending clarify is
         # semantically identical, reuse it instead of stacking duplicates.
-        if queue:
-            last = queue[-1]
+        if gw_queue:
+            last = gw_queue[-1]
             if (
                 str(last.data.get("question", "")) == str(data.get("question", ""))
                 and list(last.data.get("choices_offered") or [])
@@ -87,7 +122,7 @@ def submit_pending(session_key: str, data: dict) -> _ClarifyEntry:
                 entry = last
                 cb = _gateway_notify_cbs.get(session_key)
                 # Keep _pending aligned to the oldest unresolved entry.
-                _pending[session_key] = queue[0].data
+                _pending[session_key] = gw_queue[0].data
                 if cb:
                     try:
                         cb(dict(entry.data))
@@ -96,9 +131,11 @@ def submit_pending(session_key: str, data: dict) -> _ClarifyEntry:
                 return entry
 
         entry = _ClarifyEntry(data)
-        queue.append(entry)
-        _pending[session_key] = queue[0].data
+        gw_queue.append(entry)
+        _pending[session_key] = gw_queue[0].data
         cb = _gateway_notify_cbs.get(session_key)
+        # Notify SSE subscribers from inside _lock for ordering guarantees.
+        _clarify_sse_notify(session_key, dict(gw_queue[0].data), len(gw_queue))
     if cb:
         try:
             cb(data)
@@ -125,15 +162,17 @@ def has_pending(session_key: str) -> bool:
 def resolve_clarify(session_key: str, response: str, resolve_all: bool = False) -> int:
     """Resolve the oldest pending clarify request for a session."""
     with _lock:
-        queue = _gateway_queues.get(session_key)
-        if not queue:
+        q = _gateway_queues.get(session_key)
+        if not q:
             _pending.pop(session_key, None)
             return 0
-        entries = list(queue) if resolve_all else [queue.pop(0)]
-        if queue:
-            _pending[session_key] = queue[0].data
+        entries = list(q) if resolve_all else [q.pop(0)]
+        if q:
+            _pending[session_key] = q[0].data
+            _clarify_sse_notify(session_key, dict(q[0].data), len(q))
         else:
             _clear_queue_locked(session_key)
+            _clarify_sse_notify(session_key, None, 0)
     count = 0
     for entry in entries:
         entry.result = response

--- a/api/routes.py
+++ b/api/routes.py
@@ -643,10 +643,13 @@ try:
         submit_pending as submit_clarify_pending,
         get_pending as get_clarify_pending,
         resolve_clarify,
+        sse_subscribe as clarify_sse_subscribe,
+        sse_unsubscribe as clarify_sse_unsubscribe,
     )
 except ImportError:
     submit_clarify_pending = lambda *a, **k: None
     get_clarify_pending = lambda *a, **k: None
+    clarify_sse_subscribe = None
     resolve_clarify = lambda *a, **k: 0
 
 
@@ -1270,6 +1273,9 @@ def handle_get(handler, parsed) -> bool:
 
     if parsed.path == "/api/clarify/pending":
         return _handle_clarify_pending(handler, parsed)
+
+    if parsed.path == "/api/clarify/stream":
+        return _handle_clarify_sse_stream(handler, parsed)
 
     if parsed.path == "/api/clarify/inject_test":
         # Loopback-only: used by automated tests; blocked from any remote client
@@ -2877,6 +2883,61 @@ def _handle_clarify_pending(handler, parsed):
     if pending:
         return j(handler, {"pending": pending})
     return j(handler, {"pending": None})
+
+
+def _handle_clarify_sse_stream(handler, parsed):
+    """SSE endpoint for real-time clarify notifications.
+
+    Long-lived connection that pushes clarify events the moment they arrive,
+    replacing the 1.5s polling loop.  The frontend uses EventSource and falls
+    back to HTTP polling if the connection fails.
+    """
+    if clarify_sse_subscribe is None:
+        return bad(handler, "clarify SSE not available")
+
+    sid = parse_qs(parsed.query).get("session_id", [""])[0]
+    if not sid:
+        return bad(handler, "session_id is required")
+
+    # Subscribe AND snapshot atomically.  We import clarify's _lock so that
+    # subscribe and the snapshot read happen under the same mutex — same
+    # pattern as the approval SSE handler.
+    from api.clarify import _lock as _clarify_lock, _clarify_sse_subscribers as _clarify_subs
+    q = queue.Queue(maxsize=16)
+    initial_pending = None
+    initial_count = 0
+    with _clarify_lock:
+        _clarify_subs.setdefault(sid, []).append(q)
+        initial_pending = get_clarify_pending(sid)
+        initial_count = 1 if initial_pending else 0
+
+    handler.send_response(200)
+    handler.send_header('Content-Type', 'text/event-stream; charset=utf-8')
+    handler.send_header('Cache-Control', 'no-cache')
+    handler.send_header('X-Accel-Buffering', 'no')
+    handler.send_header('Connection', 'keep-alive')
+    handler.end_headers()
+
+    from api.streaming import _sse
+
+    # Push initial state immediately so the client doesn't miss anything.
+    _sse(handler, 'initial', {"pending": initial_pending, "pending_count": initial_count})
+
+    try:
+        while True:
+            try:
+                payload = q.get(timeout=30)
+            except queue.Empty:
+                handler.wfile.write(b': keepalive\n\n')
+                handler.wfile.flush()
+                continue
+            if payload is None:
+                break
+            _sse(handler, 'clarify', payload)
+    except _CLIENT_DISCONNECT_ERRORS:
+        pass
+    finally:
+        clarify_sse_unsubscribe(sid, q)
 
 
 def _handle_clarify_inject(handler, parsed):

--- a/static/messages.js
+++ b/static/messages.js
@@ -1668,10 +1668,56 @@ async function respondClarify(response) {
   } catch(e) { setStatus(t("clarify_responding") + " " + e.message); }
 }
 
+var _clarifyEventSource = null;
+var _clarifyFallbackTimer = null;
+var _clarifyHealthTimer = null;
+
 function startClarifyPolling(sid) {
   stopClarifyPolling();
   _clarifyMissingEndpointWarned = false;
-  _clarifyPollTimer = setInterval(async () => {
+
+  // SSE primary path: long-lived connection pushes events instantly.
+  try {
+    _clarifyEventSource = new EventSource('/api/clarify/stream?session_id=' + encodeURIComponent(sid));
+  } catch(e) {
+    _startClarifyFallbackPoll(sid);
+    return;
+  }
+
+  _clarifyEventSource.addEventListener('initial', function(ev) {
+    try {
+      var d = JSON.parse(ev.data);
+      if (d.pending) { d.pending._session_id = sid; showClarifyCard(d.pending); }
+      else { hideClarifyCard(false, 'expired'); }
+    } catch(e) {}
+  });
+
+  _clarifyEventSource.addEventListener('clarify', function(ev) {
+    try {
+      var d = JSON.parse(ev.data);
+      if (d.pending) { d.pending._session_id = sid; showClarifyCard(d.pending); }
+      else { hideClarifyCard(false, 'expired'); }
+    } catch(e) {}
+  });
+
+  _clarifyEventSource.onerror = function() {
+    stopClarifyPolling();
+    _startClarifyFallbackPoll(sid);
+  };
+
+  // Health timer: if no event received in 60s, reconnect.
+  _clarifyHealthTimer = setInterval(function() {
+    if (_clarifyEventSource) {
+      try { _clarifyEventSource.close(); } catch(_){}
+      _clarifyEventSource = null;
+    }
+    clearInterval(_clarifyHealthTimer); _clarifyHealthTimer = null;
+    startClarifyPolling(sid);
+  }, 60000);
+}
+
+function _startClarifyFallbackPoll(sid) {
+  _clarifyFallbackTimer = setInterval(async () => {
     if (!S.session || S.session.session_id !== sid) {
       stopClarifyPolling(); hideClarifyCard(true, 'session'); return;
     }
@@ -1689,13 +1735,14 @@ function startClarifyPolling(sid) {
         }
         stopClarifyPolling();
       }
-      // Ignore transient poll errors; SSE clarify event still provides a fast path.
     }
-  }, 1500);
+  }, 3000);
 }
 
 function stopClarifyPolling() {
-  if (_clarifyPollTimer) { clearInterval(_clarifyPollTimer); _clarifyPollTimer = null; }
+  if (_clarifyEventSource) { try { _clarifyEventSource.close(); } catch(_){} _clarifyEventSource = null; }
+  if (_clarifyFallbackTimer) { clearInterval(_clarifyFallbackTimer); _clarifyFallbackTimer = null; }
+  if (_clarifyHealthTimer) { clearInterval(_clarifyHealthTimer); _clarifyHealthTimer = null; }
 }
 
 // ── Notifications and Sound ──────────────────────────────────────────────────

--- a/tests/test_clarify_sse.py
+++ b/tests/test_clarify_sse.py
@@ -1,0 +1,238 @@
+"""Tests for clarify SSE long-connection (mirrors test_approval_sse.py structure).
+
+Covers:
+  - Static analysis of backend and frontend code
+  - Unit tests for subscribe/unsubscribe/notify lifecycle
+  - Concurrency safety of subscriber registry
+"""
+
+import os
+import queue
+import threading
+import textwrap
+
+import pytest
+
+# ── Paths ────────────────────────────────────────────────────────────────────
+_ROUTES = os.path.join(os.path.dirname(__file__), "..", "api", "routes.py")
+_CLARIFY = os.path.join(os.path.dirname(__file__), "..", "api", "clarify.py")
+_MESSAGES = os.path.join(os.path.dirname(__file__), "..", "static", "messages.js")
+
+
+def _read(path):
+    with open(path) as f:
+        return f.read()
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# 1. Static analysis — verify code structure without importing the server
+# ══════════════════════════════════════════════════════════════════════════════
+@pytest.mark.parametrize("marker", [
+    "_clarify_sse_subscribers",
+    "def sse_subscribe",
+    "def sse_unsubscribe",
+    "_clarify_sse_notify",
+])
+class TestClarifySSEBackendMarkers:
+    def test_clarify_module_has_marker(self, marker):
+        src = _read(_CLARIFY)
+        assert marker in src, f"api/clarify.py missing: {marker}"
+
+
+class TestClarifySSEBackendCode:
+    def test_submit_pending_calls_notify(self):
+        src = _read(_CLARIFY)
+        assert "_clarify_sse_notify(" in src, (
+            "submit_pending should call _clarify_sse_notify inside _lock"
+        )
+
+    def test_resolve_clarify_calls_notify(self):
+        src = _read(_CLARIFY)
+        # Count occurrences — resolve should notify on both branches
+        assert src.count("_clarify_sse_notify(") >= 2, (
+            "resolve_clarify should call _clarify_sse_notify for both queue-has-more and empty cases"
+        )
+
+
+class TestClarifySSERoutesCode:
+    def test_route_registered(self):
+        src = _read(_ROUTES)
+        assert '"/api/clarify/stream"' in src, "Missing /api/clarify/stream route"
+
+    def test_handler_function_exists(self):
+        src = _read(_ROUTES)
+        assert "def _handle_clarify_sse_stream(" in src
+
+    def test_imports_sse_subscribe(self):
+        src = _read(_ROUTES)
+        assert "clarify_sse_subscribe" in src
+
+    def test_imports_sse_unsubscribe(self):
+        src = _read(_ROUTES)
+        assert "clarify_sse_unsubscribe" in src
+
+
+class TestClarifySSEFrontendCode:
+    @pytest.fixture(autouse=True)
+    def _load_js(self):
+        self.js = _read(_MESSAGES)
+
+    def test_uses_event_source(self):
+        assert "new EventSource" in self.js
+        assert "/api/clarify/stream" in self.js
+
+    def test_frontend_listens_initial_event(self):
+        assert "'initial'" in self.js or '"initial"' in self.js
+
+    def test_frontend_listens_clarify_event(self):
+        assert "'clarify'" in self.js or '"clarify"' in self.js
+
+    def test_frontend_has_fallback_poll(self):
+        assert "_startClarifyFallbackPoll" in self.js or "clarifyFallbackTimer" in self.js
+
+    def test_frontend_fallback_interval_3s(self):
+        # Fallback poll interval should be 3000ms
+        assert "3000" in self.js
+
+    def test_frontend_stop_closes_event_source(self):
+        assert "_clarifyEventSource" in self.js
+        assert ".close()" in self.js
+
+    def test_frontend_has_health_timer(self):
+        assert "_clarifyHealthTimer" in self.js
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# 2. Unit tests — import clarify module directly
+# ══════════════════════════════════════════════════════════════════════════════
+@pytest.fixture()
+def clarify_mod():
+    """Import api.clarify fresh (module-level state is shared)."""
+    from api import clarify
+    return clarify
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_subscribers(clarify_mod):
+    """Clear SSE subscribers between tests to avoid leakage."""
+    yield
+    clarify_mod._clarify_sse_subscribers.clear()
+
+
+class TestClarifySSEUnit:
+    def test_subscribe_returns_queue(self, clarify_mod):
+        q = clarify_mod.sse_subscribe("s1")
+        assert isinstance(q, queue.Queue)
+        assert q.maxsize == 16
+
+    def test_unsubscribe_removes_queue(self, clarify_mod):
+        q = clarify_mod.sse_subscribe("s1")
+        clarify_mod.sse_unsubscribe("s1", q)
+        assert "s1" not in clarify_mod._clarify_sse_subscribers
+
+    def test_unsubscribe_cleans_empty_session(self, clarify_mod):
+        q = clarify_mod.sse_subscribe("s1")
+        clarify_mod.sse_unsubscribe("s1", q)
+        assert "s1" not in clarify_mod._clarify_sse_subscribers
+
+    def test_unsubscribe_unknown_queue_no_error(self, clarify_mod):
+        q = queue.Queue()
+        clarify_mod.sse_unsubscribe("s1", q)  # should not raise
+
+    def test_multiple_subscribers_same_session(self, clarify_mod):
+        q1 = clarify_mod.sse_subscribe("s1")
+        q2 = clarify_mod.sse_subscribe("s1")
+        assert len(clarify_mod._clarify_sse_subscribers["s1"]) == 2
+        clarify_mod.sse_unsubscribe("s1", q1)
+        assert len(clarify_mod._clarify_sse_subscribers["s1"]) == 1
+
+    def test_notify_delivers_to_all_subscribers(self, clarify_mod):
+        q1 = clarify_mod.sse_subscribe("s1")
+        q2 = clarify_mod.sse_subscribe("s1")
+        clarify_mod._clarify_sse_notify("s1", {"question": "test?"}, 1)
+        assert q1.get(timeout=1)["pending"]["question"] == "test?"
+        assert q2.get(timeout=1)["pending"]["question"] == "test?"
+
+    def test_cross_session_isolation(self, clarify_mod):
+        q1 = clarify_mod.sse_subscribe("s1")
+        q2 = clarify_mod.sse_subscribe("s2")
+        clarify_mod._clarify_sse_notify("s1", {"question": "q1"}, 1)
+        assert q1.get(timeout=1)["pending"]["question"] == "q1"
+        assert q2.empty()
+
+    def test_queue_overflow_drops_silently(self, clarify_mod):
+        q = clarify_mod.sse_subscribe("s1")
+        for i in range(20):  # maxsize=16
+            clarify_mod._clarify_sse_notify("s1", {"q": i}, i + 1)
+        # Should not raise; some messages dropped
+        count = 0
+        while not q.empty():
+            q.get_nowait()
+            count += 1
+        assert count <= 16
+
+    def test_submit_pending_triggers_notify(self, clarify_mod):
+        q = clarify_mod.sse_subscribe("s1")
+        clarify_mod.submit_pending("s1", {"question": "hello?", "choices_offered": []})
+        payload = q.get(timeout=1)
+        assert payload["pending"] is not None
+        assert payload["pending"]["question"] == "hello?"
+        assert payload["pending_count"] == 1
+
+    def test_unsubscribe_mid_notify_safe(self, clarify_mod):
+        q1 = clarify_mod.sse_subscribe("s1")
+        q2 = clarify_mod.sse_subscribe("s1")
+        clarify_mod.sse_unsubscribe("s1", q2)
+        clarify_mod._clarify_sse_notify("s1", {"question": "safe?"}, 1)
+        assert q1.get(timeout=1)["pending"]["question"] == "safe?"
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# 3. Concurrency tests
+# ══════════════════════════════════════════════════════════════════════════════
+class TestClarifySSEConcurrency:
+    def test_concurrent_subscribe_unsubscribe(self, clarify_mod):
+        errors = []
+
+        def worker():
+            try:
+                for _ in range(50):
+                    q = clarify_mod.sse_subscribe("s1")
+                    clarify_mod.sse_unsubscribe("s1", q)
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=worker) for _ in range(4)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=5)
+        assert not errors
+
+    def test_concurrent_notify_and_subscribe(self, clarify_mod):
+        received = []
+        lock = threading.Lock()
+        q = clarify_mod.sse_subscribe("s1")
+
+        def notifier():
+            for i in range(20):
+                clarify_mod._clarify_sse_notify("s1", {"q": i}, i + 1)
+
+        def subscriber():
+            for _ in range(20):
+                q2 = clarify_mod.sse_subscribe("s1")
+                clarify_mod.sse_unsubscribe("s1", q2)
+
+        t1 = threading.Thread(target=notifier)
+        t2 = threading.Thread(target=subscriber)
+        t1.start()
+        t2.start()
+        t1.join(timeout=5)
+        t2.join(timeout=5)
+        # Just verify no crash — some events may have been dropped
+        while not q.empty():
+            payload = q.get_nowait()
+            with lock:
+                received.append(payload)
+        # Should have received at least some events
+        assert len(received) > 0


### PR DESCRIPTION
Replaces the 1.5s HTTP polling loop for clarify with a Server-Sent Events endpoint at \`/api/clarify/stream\` that pushes clarify events to the browser instantly.

## What changed

- **Backend**: SSE subscribe/unsubscribe/notify lifecycle in \`api/clarify.py\`
  - \`sse_subscribe(session_id)\` — register a bounded Queue for a session
  - \`sse_unsubscribe(session_id, queue)\` — cleanup on disconnect
  - \`_clarify_sse_notify(session_id, head, total)\` — push event to all subscribers
  - \`submit_pending()\` calls \`_clarify_sse_notify()\` inside \`_lock\` for ordering guarantees
  - \`resolve_clarify()\` calls \`_clarify_sse_notify()\` after pop (surfaces trailing clarifies)
- **New route**: \`GET /api/clarify/stream?session_id=\`
  - Atomic subscribe + initial snapshot under \`clarify._lock\`
  - 30s keepalive comments, \`_CLIENT_DISCONNECT_ERRORS\` handling
- **Frontend**: \`startClarifyPolling()\` in \`static/messages.js\`
  - EventSource SSE as primary transport
  - Automatic fallback to 3s HTTP polling on SSE error
  - Health timer detects stale connections (60s reconnect)
- **29 new tests** (static analysis + unit + concurrency)

Follows the same SSE pattern as the approval stream (#1350), including the notify-ordering and head-fidelity fixes from \`e68f74a\`.

## Testing

All 75 SSE-related tests pass (42 approval + 29 clarify + 4 regression):
- \`tests/test_approval_sse.py\` — 42 passed
- \`tests/test_clarify_sse.py\` — 29 passed
- \`tests/test_pr1350_sse_notify_correctness.py\` — 4 passed