### PR TITLE
fix: context window indicator shows 100% when context_length is missing from SSE payload

### DIFF
--- a/api/streaming.py
+++ b/api/streaming.py
@@ -2241,6 +2241,28 @@ def _run_agent_streaming(session_id, msg_text, model, workspace, stream_id, atta
                 usage['context_length'] = getattr(_cc, 'context_length', 0) or 0
                 usage['threshold_tokens'] = getattr(_cc, 'threshold_tokens', 0) or 0
                 usage['last_prompt_tokens'] = getattr(_cc, 'last_prompt_tokens', 0) or 0
+            # Fallback: when the compressor is absent or reports context_length=0,
+            # resolve the model's context window from metadata so the UI indicator
+            # shows the correct percentage rather than overflowing against the 128K
+            # JS default.  Mirrors the session-save fallback above (lines ~2205-2217).
+            if not usage.get('context_length'):
+                try:
+                    from agent.model_metadata import get_model_context_length as _get_cl
+                    _fb_cl = _get_cl(
+                        getattr(agent, 'model', resolved_model or '') or '',
+                        getattr(agent, 'base_url', '') or '',
+                    )
+                    if _fb_cl:
+                        usage['context_length'] = _fb_cl
+                except Exception:
+                    pass
+            # Fallback: when last_prompt_tokens is missing (no compressor), use the
+            # session-persisted value rather than letting the frontend fall back to
+            # the cumulative input_tokens counter, which overflows for long sessions.
+            if not usage.get('last_prompt_tokens'):
+                _sess_lpt = getattr(s, 'last_prompt_tokens', 0) or 0
+                if _sess_lpt:
+                    usage['last_prompt_tokens'] = _sess_lpt
             # (reasoning trace already attached + saved above, before s.save())
             # Leftover-steer delivery: if a /steer was queued (via
             # api/chat/steer) but the agent finished its turn before

--- a/static/messages.js
+++ b/static/messages.js
@@ -141,6 +141,10 @@ async function send(){
   let uploaded=[];
   try{uploaded=await uploadPendingFiles();}
   catch(e){if(!text){setComposerStatus(`Upload error: ${e.message}`);return;}}
+  // Clear the uploading status now that upload is done — if we don't clear here
+  // it stays visible for the entire duration of the agent stream, since
+  // setComposerStatus('') is only called in setBusy(false), not setBusy(true).
+  setComposerStatus('');
 
   const uploadedNames=uploaded.map(u=>u.name||u);
   const uploadedPaths=uploaded.map(u=>u&&u.is_image?(u.name||u.filename||u):(u.path||u.name||u));

--- a/static/ui.js
+++ b/static/ui.js
@@ -864,7 +864,9 @@ function _syncCtxIndicator(usage){
   }
   if(wrap) wrap.style.display='';
   const hasPromptTok=!!promptTok;
-  const pct=hasPromptTok?Math.min(100,Math.round((promptTok/ctxWindow)*100)):0;
+  const rawPct=hasPromptTok?Math.round((promptTok/ctxWindow)*100):0;
+  const pct=Math.min(100,rawPct);
+  const overflowed=rawPct>100;
   const ring=$('ctxRingValue');
   const center=$('ctxPercent');
   const usageLine=$('ctxTooltipUsage');
@@ -908,7 +910,7 @@ function _syncCtxIndicator(usage){
   if(!hasExplicitCtx&&hasPromptTok) label+=' (est. 128K)';
   if(cost) label+=` \u00b7 $${cost<0.01?cost.toFixed(4):cost.toFixed(2)}`;
   el.setAttribute('aria-label',label);
-  if(usageLine) usageLine.textContent=hasPromptTok?`${pct}% used (${Math.max(0,100-pct)}% left)`:`${_fmtTokens(totalTok)} tokens used`;
+  if(usageLine) usageLine.textContent=hasPromptTok?(overflowed?`${rawPct}% used (context exceeded)`:`${pct}% used (${100-pct}% left)`):`${_fmtTokens(totalTok)} tokens used`;
   if(tokensLine) tokensLine.textContent=hasPromptTok?`${_fmtTokens(promptTok)} / ${_fmtTokens(ctxWindow)} tokens used`:`In: ${_fmtTokens(usage.input_tokens||0)} \u00b7 Out: ${_fmtTokens(usage.output_tokens||0)}`;
   const threshold=usage.threshold_tokens||0;
   if(thresholdLine){


### PR DESCRIPTION
## Summary

The context window indicator shows **100% / 0% left** for long sessions even when the model has a large context window (e.g. 1M tokens for claude-sonnet-4.6).

## Root cause

The live SSE `usage` payload that populates the indicator was missing a fallback for `context_length` when the context compressor was absent or reported 0. The frontend then fell back to the 128K JS default (131,072 tokens). For sessions whose **cumulative** `input_tokens` exceeded 131K, the indicator computed `>100%` and capped it at 100%, displaying `100% used (0% left)`.

The session-save path (lines ~2205–2217 in `streaming.py`) already had a `get_model_context_length()` fallback, but the live SSE payload block had none.

Separately, when `last_prompt_tokens` was missing (no compressor), the frontend fell back to the cumulative `input_tokens` counter rather than the actual last-request prompt size, compounding the overflow.

## Changes

**`api/streaming.py`**
- After reading `context_length` from the compressor, fall back to `get_model_context_length()` when the value is still 0. Mirrors the existing session-save fallback.
- When `last_prompt_tokens` is missing from the compressor, fall back to `s.last_prompt_tokens` (the session-persisted value) to avoid using the cumulative counter as a proxy.

**`static/ui.js`**
- Track `rawPct` separately from the clamped `pct`.
- When `rawPct > 100`, show `N% used (context exceeded)` instead of the misleading `100% used (0% left)`.

## Reproduction

Use a large-context model (e.g. `claude-sonnet-4.6` via OpenRouter, 1M context window) without auto-compress enabled. After the session's cumulative token count exceeds 128K, the indicator shows 100% even though the model still has ~875K tokens available.

## Tests

All 28 context-related tests and 161 streaming/usage/ctx tests pass.
