### PR TITLE
fix: preserve imported session source metadata

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -347,6 +347,10 @@ class Session:
         self.context_length = context_length
         self.threshold_tokens = threshold_tokens
         self.last_prompt_tokens = last_prompt_tokens
+        self.is_cli_session = bool(kwargs.get('is_cli_session', False))
+        self.source_tag = kwargs.get('source_tag')
+        self.session_source = kwargs.get('session_source')
+        self.source_label = kwargs.get('source_label')
         self._metadata_message_count = None
 
     @property
@@ -367,6 +371,7 @@ class Session:
             'pending_user_message', 'pending_attachments', 'pending_started_at',
             'compression_anchor_visible_idx', 'compression_anchor_message_key',
             'context_length', 'threshold_tokens', 'last_prompt_tokens',
+            'is_cli_session', 'source_tag', 'session_source', 'source_label',
         ]
         meta = {k: getattr(self, k, None) for k in METADATA_FIELDS}
         meta['messages'] = self.messages
@@ -462,6 +467,10 @@ class Session:
             'threshold_tokens': self.threshold_tokens,
             'last_prompt_tokens': self.last_prompt_tokens,
             'active_stream_id': self.active_stream_id,
+            'is_cli_session': self.is_cli_session,
+            'source_tag': self.source_tag,
+            'session_source': self.session_source,
+            'source_label': self.source_label,
             'is_streaming': _is_streaming_session(
                 self.active_stream_id, active_stream_ids
             ) if include_runtime else False,

--- a/tests/test_gateway_sync.py
+++ b/tests/test_gateway_sync.py
@@ -724,6 +724,33 @@ def test_gateway_watcher_uses_normalized_source_metadata(monkeypatch):
             pass
 
 
+def test_imported_cli_session_metadata_survives_compact(cleanup_test_sessions):
+    """Imported agent sessions should remain distinguishable in compact sidebar payloads."""
+    from api.models import Session
+
+    sid = 'gw_imported_metadata_001'
+    cleanup_test_sessions.append(sid)
+    s = Session(
+        session_id=sid,
+        title='Imported Telegram Chat',
+        messages=[{'role': 'user', 'content': 'hello from telegram', 'timestamp': time.time()}],
+        model='openai/gpt-5',
+    )
+    s.is_cli_session = True
+    s.source_tag = 'telegram'
+    s.session_source = 'messaging'
+    s.source_label = 'Telegram'
+    s.save(touch_updated_at=False)
+
+    loaded = Session.load_metadata_only(sid)
+    compact = loaded.compact()
+
+    assert compact['is_cli_session'] is True
+    assert compact['source_tag'] == 'telegram'
+    assert compact['session_source'] == 'messaging'
+    assert compact['source_label'] == 'Telegram'
+
+
 def test_imported_cron_sessions_hidden_from_sidebar_by_default(cleanup_test_sessions):
     """Cron sessions already imported into the WebUI store should stay hidden from the sidebar."""
     from api.models import Session


### PR DESCRIPTION
## Thinking Path
- Hermes WebUI sidebar sessions can include imported Hermes Agent / gateway sessions.
- Those imported sessions need source metadata so the UI and server can distinguish them from native WebUI sessions.
- `Session.load_metadata_only().compact()` was dropping those fields, so sidebar payloads lost that provenance.
- This PR preserves the existing safe source fields in the session metadata path and adds a regression test.

## What Changed
- Store imported-session metadata (`is_cli_session`, `source_tag`, `session_source`, `source_label`) in the fast metadata section of session JSON.
- Include the same fields in `Session.compact()` output.
- Add a regression test covering save → metadata-only load → compact.

## Why It Matters
Imported CLI / gateway sessions remain distinguishable in sidebar/API payloads, which prevents later session-list behavior from treating imported projections as ordinary WebUI sessions.

## Verification
- `pytest tests/test_gateway_sync.py::test_imported_cli_session_metadata_survives_compact tests/test_gateway_sync.py::test_imported_cron_sessions_hidden_from_sidebar_by_default -q`

## Risks / Follow-ups
- Low risk: this only persists/exposes already-used metadata fields and does not change message storage.
- Follow-up PRs can build on this metadata for lineage grouping and cross-tab active-session synchronization.

## Model Used
AI-assisted: OpenAI Codex GPT-5.5 via Hermes Agent tools.
