### PR TITLE
fix: collapse sidebar session lineage rows

### DIFF
--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1211,6 +1211,28 @@ function _sessionTimeBucketLabel(timestampMs, nowMs) {
   return t('session_time_bucket_older');
 }
 
+function _sessionLineageKey(s){
+  if(!s||!s.session_id) return null;
+  return s._lineage_root_id || s.lineage_root_id || s.parent_session_id || null;
+}
+
+function _collapseSessionLineageForSidebar(sessions){
+  const result=[];
+  const groups=new Map();
+  for(const s of sessions||[]){
+    const key=_sessionLineageKey(s);
+    if(!key){result.push(s);continue;}
+    if(!groups.has(key)) groups.set(key,[]);
+    groups.get(key).push(s);
+  }
+  for(const items of groups.values()){
+    if(items.length<=1){result.push(items[0]);continue;}
+    const chosen=[...items].sort((a,b)=>_sessionTimestampMs(b)-_sessionTimestampMs(a))[0];
+    result.push({...chosen,_lineage_collapsed_count:items.length});
+  }
+  return result;
+}
+
 function renderSessionListFromCache(){
   // Don't re-render while user is actively renaming a session (would destroy the input)
   if(_renamingSid) return;
@@ -1232,7 +1254,8 @@ function renderSessionListFromCache(){
   // Filter by active project
   const projectFiltered=_activeProject?profileFiltered.filter(s=>s.project_id===_activeProject):profileFiltered;
   // Filter archived unless toggle is on
-  const sessions=_showArchived?projectFiltered:projectFiltered.filter(s=>!s.archived);
+  const sessionsRaw=_showArchived?projectFiltered:projectFiltered.filter(s=>!s.archived);
+  const sessions=_collapseSessionLineageForSidebar(sessionsRaw);
   const archivedCount=projectFiltered.filter(s=>s.archived).length;
   const list=$('sessionList');list.innerHTML='';
   // Batch select bar (when in select mode)

--- a/tests/test_session_lineage_collapse.py
+++ b/tests/test_session_lineage_collapse.py
@@ -1,0 +1,60 @@
+"""Regression tests for sidebar lineage collapse helpers."""
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent.resolve()
+SESSIONS_JS_PATH = REPO_ROOT / "static" / "sessions.js"
+NODE = shutil.which("node")
+
+pytestmark = pytest.mark.skipif(NODE is None, reason="node not on PATH")
+
+
+def _run_node(source: str) -> str:
+    result = subprocess.run(
+        [NODE, "-e", source],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr)
+    return result.stdout.strip()
+
+
+def test_sidebar_lineage_collapse_keeps_latest_tip_and_counts_segments():
+    js = SESSIONS_JS_PATH.read_text(encoding="utf-8")
+    source = f"""
+const src = {js!r};
+function extractFunc(name) {{
+  const re = new RegExp('function\\\\s+' + name + '\\\\s*\\\\(');
+  const start = src.search(re);
+  if (start < 0) throw new Error(name + ' not found');
+  let i = src.indexOf('{{', start);
+  let depth = 1; i++;
+  while (depth > 0 && i < src.length) {{
+    if (src[i] === '{{') depth++;
+    else if (src[i] === '}}') depth--;
+    i++;
+  }}
+  return src.slice(start, i);
+}}
+eval(extractFunc('_sessionTimestampMs'));
+eval(extractFunc('_sessionLineageKey'));
+eval(extractFunc('_collapseSessionLineageForSidebar'));
+const sessions = [
+  {{session_id:'root', title:'Hermes WebUI', message_count:10, updated_at:10, last_message_at:10, _lineage_root_id:'root', _lineage_tip_id:'root'}},
+  {{session_id:'tip', title:'Hermes WebUI', message_count:20, updated_at:20, last_message_at:20, _lineage_root_id:'root', _lineage_tip_id:'tip'}},
+  {{session_id:'solo', title:'Other', message_count:5, updated_at:15, last_message_at:15}},
+];
+const collapsed = _collapseSessionLineageForSidebar(sessions);
+console.log(JSON.stringify(collapsed));
+"""
+    collapsed = _run_node(source)
+    assert '"session_id":"tip"' in collapsed
+    assert '"session_id":"root"' not in collapsed
+    assert '"_lineage_collapsed_count":2' in collapsed
+    assert '"session_id":"solo"' in collapsed


### PR DESCRIPTION
## Thinking Path
- Long Hermes sessions can be represented as compression lineage segments.
- The sidebar should not flatten multiple rows from the same lineage when the API payload already provides lineage metadata.
- A small client-side collapse keeps the latest visible tip while preserving the underlying session data.

## What Changed
- Add a pure sidebar helper that groups sessions by lineage root metadata.
- Keep only the most recently active item for each lineage group in the visible sidebar list.
- Preserve a `_lineage_collapsed_count` marker on the visible row for future UI affordances.
- Add a node-backed regression test for the helper behavior.

## Why It Matters
Users no longer see every known segment of a compression lineage as a separate top-level conversation when lineage metadata is present. This is non-destructive: no session JSON or messages are merged, deleted, or rewritten.

## Verification
- `pytest tests/test_session_lineage_collapse.py tests/test_sprint9.py::test_sessions_js_served -q`

## Risks / Follow-ups
- This only collapses rows when lineage metadata is present in the session payload.
- Future follow-ups can add an explicit expand affordance or richer lineage detail UI.

## Model Used
AI-assisted: OpenAI Codex GPT-5.5 via Hermes Agent tools.
