### PR TITLE
fix: sync active session across tabs

### DIFF
--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1605,6 +1605,22 @@ function renderSessionListFromCache(){
   }
 }
 
+async function _handleActiveSessionStorageEvent(e){
+  if(!e || e.key !== 'hermes-webui-session') return;
+  const sid = e.newValue;
+  if(!sid || (S.session && S.session.session_id === sid)) return;
+  if(S.busy){
+    if(typeof showToast==='function') showToast('Active session changed in another tab. Finish the current turn before switching.',3000);
+    return;
+  }
+  await loadSession(sid);
+  renderSessionListFromCache();
+}
+
+if(typeof window!=='undefined'){
+  window.addEventListener('storage', (e) => { void _handleActiveSessionStorageEvent(e); });
+}
+
 async function deleteSession(sid){
   const ok=await showConfirmDialog({
     message:'Delete this conversation?',

--- a/tests/test_session_cross_tab_sync.py
+++ b/tests/test_session_cross_tab_sync.py
@@ -1,0 +1,16 @@
+"""Regression tests for cross-tab active session synchronization."""
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent.resolve()
+SESSIONS_JS = (REPO_ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
+
+
+def test_sessions_js_listens_for_active_session_storage_changes():
+    assert "addEventListener('storage'" in SESSIONS_JS or 'addEventListener("storage"' in SESSIONS_JS
+    assert "hermes-webui-session" in SESSIONS_JS
+    assert "_handleActiveSessionStorageEvent" in SESSIONS_JS
+
+
+def test_storage_sync_does_not_switch_while_busy():
+    marker = "if(S.busy)"
+    assert marker in SESSIONS_JS, "cross-tab storage sync must not switch sessions during an active turn"


### PR DESCRIPTION
## Thinking Path
- Multiple browser tabs can keep different in-memory active sessions while sharing the same `localStorage` active-session key.
- When one tab switches sessions, another idle tab should notice before the next send/load action keeps using stale state.
- The safe behavior is to follow the changed active-session key only when the current tab is idle.

## What Changed
- Add a `storage` event listener for the `hermes-webui-session` key.
- Idle tabs load the new active session and re-render the sidebar cache.
- Busy tabs do not auto-switch during an active turn; they show a short toast instead.
- Add regression tests pinning the listener and busy guard.

## Why It Matters
This reduces accidental writes into stale sessions when users switch between browser tabs while using the same Hermes WebUI instance.

## Verification
- `pytest tests/test_session_cross_tab_sync.py tests/test_sprint9.py::test_sessions_js_served -q`

## Risks / Follow-ups
- This intentionally ignores removal/empty values and does not interrupt active turns.
- A later UI pass could add a persistent banner for busy-tab conflicts instead of a toast.

## Model Used
AI-assisted: OpenAI Codex GPT-5.5 via Hermes Agent tools.
