### PR TITLE
fix: show active session in sidebar immediately on creation

### DIFF
--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1224,7 +1224,9 @@ function renderSessionListFromCache(){
   // real once the first message is sent. The server already filters them, but this
   // guard ensures a brand-new active session doesn't flash into the list while
   // _allSessions is stale from a prior render (#1171).
-  const withMessages=allMatched.filter(s=>(s.message_count||0)>0 || (S.session&&s.session_id===S.session.session_id&&(S.session.message_count||0)>0));
+  // Always include the active session even with 0 messages so it appears immediately
+  // when created (fixes: new chat not visible until first message is sent).
+  const withMessages=allMatched.filter(s=>(s.message_count||0)>0 || (S.session&&s.session_id===S.session.session_id));
   // Filter by active profile (unless "All profiles" is toggled on)
   // Server backfills profile='default' for legacy sessions, so every session has a profile.
   // Show only sessions tagged to the active profile; 'All profiles' toggle overrides.


### PR DESCRIPTION
## Problem

Newly created sessions (0 messages) do not appear in the left sidebar until the first message is sent. The active session is invisible during that gap.

## Root cause

`renderSessionListFromCache()` filters out 0-message sessions with:

```js
const withMessages = allMatched.filter(
  s => (s.message_count || 0) > 0
    || (S.session && s.session_id === S.session.session_id && (S.session.message_count || 0) > 0)
);
```

The second clause excepts the active session but *still requires messages* — making the exception meaningless.

## Fix

Remove the `message_count > 0` guard from the active session exception so it always appears:

```js
const withMessages = allMatched.filter(
  s => (s.message_count || 0) > 0
    || (S.session && s.session_id === S.session.session_id)
);
```

## Verification

- Create a new chat → it now appears in the sidebar immediately
- No change to behavior for non-active sessions (0-message sessions still hidden as intended)
