### PR TITLE
fix: guard finalizeThinkingCard with session ID check

### DIFF
--- a/static/ui.js
+++ b/static/ui.js
@@ -4273,6 +4273,12 @@ function _thinkingMarkup(text=''){
     : `<div class="thinking"><div class="dot"></div><div class="dot"></div><div class="dot"></div></div>`;
 }
 function finalizeThinkingCard(){
+  // Guard: only finalize thinking card if we're looking at the session that started it.
+  // Without this check, switching tabs while a stream is running causes finalizeThinkingCard
+  // to remove/modify the thinking card DOM of the wrong session — the card belongs to the
+  // stream that started it, not the session currently displayed.
+  const _guardTurn = $('liveAssistantTurn');
+  if(_guardTurn && S.session && _guardTurn.dataset.sessionId !== S.session.session_id) return;
   if(!isSimplifiedToolCalling()){
     const row=$('thinkingRow');
     if(!row) return;


### PR DESCRIPTION
Without this check, switching browser tabs while a stream is running causes finalizeThinkingCard() to operate on the wrong session's thinking card DOM, the card belongs to the stream that started it, not the session currently displayed in the tab. The guard ensures finalize only runs when the live assistant turn's session matches the current session.