### PR TITLE
fix: persist manual cron run results

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -95,10 +95,28 @@ def _cron_output_content_window(text: str, limit: int = _CRON_OUTPUT_CONTENT_LIM
 def _run_cron_tracked(job):
     """Wrapper that tracks running state around cron.scheduler.run_job."""
     from cron.scheduler import run_job  # import here — runs inside a worker thread
+    from cron.jobs import mark_job_run, save_job_output
+
+    job_id = job.get("id", "")
     try:
-        run_job(job)
+        success, output, final_response, error = run_job(job)
+        save_job_output(job_id, output)
+
+        # Match the scheduled cron path: an apparently successful run with no
+        # final response should not leave the job looking healthy.
+        if success and not final_response:
+            success = False
+            error = "Agent completed but produced empty response (model error, timeout, or misconfiguration)"
+
+        mark_job_run(job_id, success, error)
+    except Exception as e:
+        logger.exception("Manual cron run failed for job %s", job_id)
+        try:
+            mark_job_run(job_id, False, str(e))
+        except Exception:
+            logger.debug("Failed to mark manual cron run failure for %s", job_id)
     finally:
-        _mark_cron_done(job.get("id", ""))
+        _mark_cron_done(job_id)
 
 _PROVIDER_ALIASES = {
     "claude": "anthropic",

--- a/tests/test_cron_manual_run_persistence.py
+++ b/tests/test_cron_manual_run_persistence.py
@@ -1,0 +1,69 @@
+"""Regression tests for manual WebUI cron runs."""
+
+import sys
+import types
+
+
+def test_manual_cron_run_saves_output_and_marks_job(monkeypatch):
+    import api.routes as routes
+
+    calls = []
+
+    cron_pkg = types.ModuleType("cron")
+    cron_pkg.__path__ = []
+
+    cron_jobs = types.ModuleType("cron.jobs")
+    cron_jobs.save_job_output = lambda job_id, output: calls.append(
+        ("save", job_id, output)
+    )
+    cron_jobs.mark_job_run = lambda job_id, success, error=None: calls.append(
+        ("mark", job_id, success, error)
+    )
+
+    cron_scheduler = types.ModuleType("cron.scheduler")
+    cron_scheduler.run_job = lambda job: (True, "manual output", "done", None)
+
+    monkeypatch.setitem(sys.modules, "cron", cron_pkg)
+    monkeypatch.setitem(sys.modules, "cron.jobs", cron_jobs)
+    monkeypatch.setitem(sys.modules, "cron.scheduler", cron_scheduler)
+
+    routes._mark_cron_running("job123")
+    routes._run_cron_tracked({"id": "job123"})
+
+    assert calls == [
+        ("save", "job123", "manual output"),
+        ("mark", "job123", True, None),
+    ]
+    assert routes._is_cron_running("job123") == (False, 0.0)
+
+
+def test_manual_cron_run_marks_empty_response_as_failure(monkeypatch):
+    import api.routes as routes
+
+    calls = []
+
+    cron_pkg = types.ModuleType("cron")
+    cron_pkg.__path__ = []
+
+    cron_jobs = types.ModuleType("cron.jobs")
+    cron_jobs.save_job_output = lambda job_id, output: calls.append(
+        ("save", job_id, output)
+    )
+    cron_jobs.mark_job_run = lambda job_id, success, error=None: calls.append(
+        ("mark", job_id, success, error)
+    )
+
+    cron_scheduler = types.ModuleType("cron.scheduler")
+    cron_scheduler.run_job = lambda job: (True, "manual output", "", None)
+
+    monkeypatch.setitem(sys.modules, "cron", cron_pkg)
+    monkeypatch.setitem(sys.modules, "cron.jobs", cron_jobs)
+    monkeypatch.setitem(sys.modules, "cron.scheduler", cron_scheduler)
+
+    routes._mark_cron_running("job-empty")
+    routes._run_cron_tracked({"id": "job-empty"})
+
+    assert calls[0] == ("save", "job-empty", "manual output")
+    assert calls[1][0:3] == ("mark", "job-empty", False)
+    assert "empty response" in calls[1][3]
+    assert routes._is_cron_running("job-empty") == (False, 0.0)


### PR DESCRIPTION
## Summary
Fixes manual WebUI cron runs so they persist results the same way scheduled cron ticks do.

Manual runs previously called `cron.scheduler.run_job(job)` and then only cleared the in-memory running flag. That meant output could be dropped and job metadata like `last_run_at` / `last_status` was not updated after a manual run.

This PR:
- saves manual-run output with `save_job_output`
- marks manual runs complete with `mark_job_run`
- records manual-run failures in job metadata
- keeps `_run_cron_tracked` self-contained for worker-thread execution
- adds a regression test for manual-run persistence

## Cron Jobs Project Note
This does not change project scoping or filtering.

Manual runs still execute through `cron.scheduler.run_job`, so the v0.50.247 Cron Jobs project/session metadata behavior remains independent of this fix. This patch only persists cron output and job run metadata.

## Tests
- `python3 -m py_compile api/routes.py tests/test_cron_manual_run_persistence.py`
- `python -m pytest tests/test_cron_manual_run_persistence.py tests/test_cron_run_job_import.py tests/test_sprint3.py::test_crons_run_nonexistent tests/test_sprint10.py::test_crons_output_limit_param`

result: `7 passed`
