### PR TITLE
feat: add profile-aware cron panel

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -13,6 +13,7 @@ import sys
 import threading
 import time
 import uuid
+from contextlib import contextmanager
 from pathlib import Path
 from urllib.parse import parse_qs
 
@@ -37,22 +38,27 @@ _RUNNING_CRON_JOBS: dict[str, float] = {}  # job_id → start_timestamp
 _RUNNING_CRON_LOCK = threading.Lock()
 _CRON_OUTPUT_CONTENT_LIMIT = 8000
 _CRON_OUTPUT_HEADER_CONTEXT = 200
+_CRON_PROFILE_LOCK = threading.RLock()
 
 
-def _mark_cron_running(job_id: str):
+def _cron_run_key(job_id: str, profile: str | None = None) -> str:
+    return f"{profile}:{job_id}" if profile else job_id
+
+
+def _mark_cron_running(job_id: str, profile: str | None = None):
     with _RUNNING_CRON_LOCK:
-        _RUNNING_CRON_JOBS[job_id] = time.time()
+        _RUNNING_CRON_JOBS[_cron_run_key(job_id, profile)] = time.time()
 
 
-def _mark_cron_done(job_id: str):
+def _mark_cron_done(job_id: str, profile: str | None = None):
     with _RUNNING_CRON_LOCK:
-        _RUNNING_CRON_JOBS.pop(job_id, None)
+        _RUNNING_CRON_JOBS.pop(_cron_run_key(job_id, profile), None)
 
 
-def _is_cron_running(job_id: str) -> tuple[bool, float]:
+def _is_cron_running(job_id: str, profile: str | None = None) -> tuple[bool, float]:
     """Return (is_running, elapsed_seconds)."""
     with _RUNNING_CRON_LOCK:
-        t = _RUNNING_CRON_JOBS.get(job_id)
+        t = _RUNNING_CRON_JOBS.get(_cron_run_key(job_id, profile))
         if t is None:
             return False, 0.0
         return True, time.time() - t
@@ -92,31 +98,143 @@ def _cron_output_content_window(text: str, limit: int = _CRON_OUTPUT_CONTENT_LIM
     return text[-limit:]
 
 
-def _run_cron_tracked(job):
+def _run_cron_tracked(job, profile: str | None = None, track_profile: str | None = None):
     """Wrapper that tracks running state around cron.scheduler.run_job."""
-    from cron.scheduler import run_job  # import here — runs inside a worker thread
-    from cron.jobs import mark_job_run, save_job_output
-
     job_id = job.get("id", "")
     try:
-        success, output, final_response, error = run_job(job)
-        save_job_output(job_id, output)
+        with _cron_profile_context(profile, include_scheduler=True):
+            from cron.scheduler import run_job  # import here — runs inside a worker thread
+            from cron.jobs import mark_job_run, save_job_output
 
-        # Match the scheduled cron path: an apparently successful run with no
-        # final response should not leave the job looking healthy.
-        if success and not final_response:
-            success = False
-            error = "Agent completed but produced empty response (model error, timeout, or misconfiguration)"
+            success, output, final_response, error = run_job(job)
+            save_job_output(job_id, output)
 
-        mark_job_run(job_id, success, error)
+            # Match the scheduled cron path: an apparently successful run with no
+            # final response should not leave the job looking healthy.
+            if success and not final_response:
+                success = False
+                error = "Agent completed but produced empty response (model error, timeout, or misconfiguration)"
+
+            mark_job_run(job_id, success, error)
     except Exception as e:
         logger.exception("Manual cron run failed for job %s", job_id)
         try:
-            mark_job_run(job_id, False, str(e))
+            with _cron_profile_context(profile):
+                from cron.jobs import mark_job_run
+
+                mark_job_run(job_id, False, str(e))
         except Exception:
             logger.debug("Failed to mark manual cron run failure for %s", job_id)
     finally:
-        _mark_cron_done(job_id)
+        _mark_cron_done(job_id, track_profile)
+
+
+def _active_cron_profile() -> str:
+    try:
+        from api.profiles import get_active_profile_name
+
+        return get_active_profile_name() or "default"
+    except Exception:
+        return "default"
+
+
+def _cron_profile_home(profile: str | None) -> tuple[str, Path]:
+    name = (profile or _active_cron_profile() or "default").strip() or "default"
+    try:
+        from api.profiles import get_hermes_home_for_profile
+
+        home = get_hermes_home_for_profile(name)
+        default_home = get_hermes_home_for_profile("default")
+    except Exception:
+        home = Path.home() / ".hermes"
+        default_home = home
+        name = "default"
+    if name != "default" and home == default_home:
+        # get_hermes_home_for_profile intentionally falls back for unknown or
+        # invalid names. Keep explicit requests from masquerading as a profile.
+        name = "default"
+    return name, home
+
+
+@contextmanager
+def _cron_profile_context(profile: str | None, *, include_scheduler: bool = False):
+    """Point cron module path globals at one profile for a single operation."""
+    name, home = _cron_profile_home(profile)
+    with _CRON_PROFILE_LOCK:
+        import cron.jobs as cron_jobs
+
+        jobs_state = {
+            "HERMES_DIR": cron_jobs.HERMES_DIR,
+            "CRON_DIR": cron_jobs.CRON_DIR,
+            "JOBS_FILE": cron_jobs.JOBS_FILE,
+            "OUTPUT_DIR": cron_jobs.OUTPUT_DIR,
+        }
+        scheduler = None
+        scheduler_state = {}
+
+        cron_dir = home / "cron"
+        cron_jobs.HERMES_DIR = home
+        cron_jobs.CRON_DIR = cron_dir
+        cron_jobs.JOBS_FILE = cron_dir / "jobs.json"
+        cron_jobs.OUTPUT_DIR = cron_dir / "output"
+        if include_scheduler:
+            try:
+                import cron.scheduler as scheduler
+
+                scheduler_state = {
+                    "_hermes_home": scheduler._hermes_home,
+                    "_LOCK_DIR": scheduler._LOCK_DIR,
+                    "_LOCK_FILE": scheduler._LOCK_FILE,
+                }
+            except Exception:
+                scheduler = None
+        if scheduler is not None:
+            scheduler._hermes_home = home
+            scheduler._LOCK_DIR = cron_dir
+            scheduler._LOCK_FILE = cron_dir / ".tick.lock"
+        try:
+            yield name, home
+        finally:
+            for key, value in jobs_state.items():
+                setattr(cron_jobs, key, value)
+            if scheduler is not None:
+                for key, value in scheduler_state.items():
+                    setattr(scheduler, key, value)
+
+
+def _cron_profiles_from_query(parsed) -> list[str]:
+    qs = parse_qs(parsed.query)
+    names = []
+    for raw_profiles in qs.get("profiles", []):
+        names.extend(p.strip() for p in raw_profiles.split(",") if p.strip())
+    for raw_profile in qs.get("profile", []):
+        names.extend(p.strip() for p in raw_profile.split(",") if p.strip())
+    if not names:
+        names.append(_active_cron_profile())
+    deduped = []
+    for name in names:
+        if name not in deduped:
+            deduped.append(name)
+    return deduped
+
+
+def _annotate_cron_job(job: dict, profile: str) -> dict:
+    annotated = dict(job)
+    annotated["profile"] = profile
+    return annotated
+
+
+def _list_cron_jobs_for_profiles(profiles: list[str]) -> list[dict]:
+    from cron.jobs import list_jobs
+
+    jobs = []
+    for requested in profiles:
+        with _cron_profile_context(requested) as (profile, _home):
+            jobs.extend(
+                _annotate_cron_job(job, profile)
+                for job in list_jobs(include_disabled=True)
+            )
+    return jobs
 
 _PROVIDER_ALIASES = {
     "claude": "anthropic",
@@ -1303,9 +1421,7 @@ def handle_get(handler, parsed) -> bool:
 
     # ── Cron API (GET) ──
     if parsed.path == "/api/crons":
-        from cron.jobs import list_jobs
-
-        return j(handler, {"jobs": list_jobs(include_disabled=True)})
+        return j(handler, {"jobs": _list_cron_jobs_for_profiles(_cron_profiles_from_query(parsed))})
 
     if parsed.path == "/api/crons/output":
         return _handle_cron_output(handler, parsed)
@@ -3192,33 +3308,37 @@ def _handle_live_models(handler, parsed):
 
 
 def _handle_cron_output(handler, parsed):
-    from cron.jobs import OUTPUT_DIR as CRON_OUT
-
     qs = parse_qs(parsed.query)
+    profile = qs.get("profile", [""])[0].strip() or None
     job_id = qs.get("job_id", [""])[0]
     limit = int(qs.get("limit", ["5"])[0])
     if not job_id:
         return j(handler, {"error": "job_id required"}, status=400)
-    out_dir = CRON_OUT / job_id
-    outputs = []
-    if out_dir.exists():
-        files = sorted(out_dir.glob("*.md"), reverse=True)[:limit]
-        for f in files:
-            try:
-                txt = f.read_text(encoding="utf-8", errors="replace")
-                outputs.append({"filename": f.name, "content": _cron_output_content_window(txt)})
-            except Exception:
-                logger.debug("Failed to read cron output file %s", f)
-    return j(handler, {"job_id": job_id, "outputs": outputs})
+    with _cron_profile_context(profile) as (resolved_profile, _home):
+        from cron.jobs import OUTPUT_DIR as CRON_OUT
+
+        out_dir = CRON_OUT / job_id
+        outputs = []
+        if out_dir.exists():
+            files = sorted(out_dir.glob("*.md"), reverse=True)[:limit]
+            for f in files:
+                try:
+                    txt = f.read_text(encoding="utf-8", errors="replace")
+                    outputs.append({"filename": f.name, "content": _cron_output_content_window(txt)})
+                except Exception:
+                    logger.debug("Failed to read cron output file %s", f)
+    return j(handler, {"job_id": job_id, "profile": resolved_profile, "outputs": outputs})
 
 
 def _handle_cron_status(handler, parsed):
     """Return running status for one or all cron jobs."""
     qs = parse_qs(parsed.query)
+    profile = qs.get("profile", [""])[0].strip() or None
     job_id = qs.get("job_id", [""])[0]
     if job_id:
-        running, elapsed = _is_cron_running(job_id)
-        return j(handler, {"job_id": job_id, "running": running, "elapsed": round(elapsed, 1)})
+        resolved_profile, _home = _cron_profile_home(profile)
+        running, elapsed = _is_cron_running(job_id, resolved_profile if profile else None)
+        return j(handler, {"job_id": job_id, "profile": resolved_profile, "running": running, "elapsed": round(elapsed, 1)})
     # Return status for all running jobs
     with _RUNNING_CRON_LOCK:
         all_running = {jid: round(time.time() - t, 1) for jid, t in _RUNNING_CRON_JOBS.items()}
@@ -3232,11 +3352,8 @@ def _handle_cron_recent(handler, parsed):
     qs = parse_qs(parsed.query)
     since = float(qs.get("since", ["0"])[0])
     try:
-        from cron.jobs import list_jobs
-
-        jobs = list_jobs(include_disabled=True)
         completions = []
-        for job in jobs:
+        for job in _list_cron_jobs_for_profiles(_cron_profiles_from_query(parsed)):
             last_run = job.get("last_run_at")
             if not last_run:
                 continue
@@ -3253,6 +3370,7 @@ def _handle_cron_recent(handler, parsed):
                 completions.append(
                     {
                         "job_id": job.get("id", ""),
+                        "profile": job.get("profile", "default"),
                         "name": job.get("name", "Unknown"),
                         "status": job.get("last_status", "unknown"),
                         "completed_at": ts,
@@ -3691,17 +3809,18 @@ def _handle_cron_create(handler, body):
     except ValueError as e:
         return bad(handler, str(e))
     try:
-        from cron.jobs import create_job
+        with _cron_profile_context(body.get("profile") or None) as (profile, _home):
+            from cron.jobs import create_job
 
-        job = create_job(
-            prompt=body["prompt"],
-            schedule=body["schedule"],
-            name=body.get("name") or None,
-            deliver=body.get("deliver") or "local",
-            skills=body.get("skills") or [],
-            model=body.get("model") or None,
-        )
-        return j(handler, {"ok": True, "job": job})
+            job = create_job(
+                prompt=body["prompt"],
+                schedule=body["schedule"],
+                name=body.get("name") or None,
+                deliver=body.get("deliver") or "local",
+                skills=body.get("skills") or [],
+                model=body.get("model") or None,
+            )
+        return j(handler, {"ok": True, "job": _annotate_cron_job(job, profile)})
     except Exception as e:
         return j(handler, {"error": str(e)}, status=400)
 
@@ -3711,13 +3830,14 @@ def _handle_cron_update(handler, body):
         require(body, "job_id")
     except ValueError as e:
         return bad(handler, str(e))
-    from cron.jobs import update_job
+    with _cron_profile_context(body.get("profile") or None) as (profile, _home):
+        from cron.jobs import update_job
 
-    updates = {k: v for k, v in body.items() if k != "job_id" and v is not None}
-    job = update_job(body["job_id"], updates)
+        updates = {k: v for k, v in body.items() if k not in ("job_id", "profile") and v is not None}
+        job = update_job(body["job_id"], updates)
     if not job:
         return bad(handler, "Job not found", 404)
-    return j(handler, {"ok": True, "job": job})
+    return j(handler, {"ok": True, "job": _annotate_cron_job(job, profile)})
 
 
 def _handle_cron_delete(handler, body):
@@ -3725,42 +3845,47 @@ def _handle_cron_delete(handler, body):
         require(body, "job_id")
     except ValueError as e:
         return bad(handler, str(e))
-    from cron.jobs import remove_job
+    with _cron_profile_context(body.get("profile") or None) as (profile, _home):
+        from cron.jobs import remove_job
 
-    ok = remove_job(body["job_id"])
+        ok = remove_job(body["job_id"])
     if not ok:
         return bad(handler, "Job not found", 404)
-    return j(handler, {"ok": True, "job_id": body["job_id"]})
+    return j(handler, {"ok": True, "job_id": body["job_id"], "profile": profile})
 
 
 def _handle_cron_run(handler, body):
     job_id = body.get("job_id", "")
     if not job_id:
         return bad(handler, "job_id required")
-    from cron.jobs import get_job
+    requested_profile = body.get("profile") or None
+    with _cron_profile_context(requested_profile) as (profile, _home):
+        from cron.jobs import get_job
 
-    job = get_job(job_id)
+        job = get_job(job_id)
     if not job:
         return bad(handler, "Job not found", 404)
     # Prevent double-run: reject if the job is already tracked as running
-    already_running, elapsed = _is_cron_running(job_id)
+    track_profile = profile if requested_profile else None
+    already_running, elapsed = _is_cron_running(job_id, track_profile)
     if already_running:
-        return j(handler, {"ok": False, "job_id": job_id, "status": "already_running",
+        return j(handler, {"ok": False, "job_id": job_id, "profile": profile, "status": "already_running",
                             "elapsed": round(elapsed, 1)})
-    _mark_cron_running(job_id)
-    threading.Thread(target=_run_cron_tracked, args=(job,), daemon=True).start()
-    return j(handler, {"ok": True, "job_id": job_id, "status": "running"})
+    _mark_cron_running(job_id, track_profile)
+    threading.Thread(target=_run_cron_tracked, args=(job, profile, track_profile), daemon=True).start()
+    return j(handler, {"ok": True, "job_id": job_id, "profile": profile, "status": "running"})
 
 
 def _handle_cron_pause(handler, body):
     job_id = body.get("job_id", "")
     if not job_id:
         return bad(handler, "job_id required")
-    from cron.jobs import pause_job
+    with _cron_profile_context(body.get("profile") or None) as (profile, _home):
+        from cron.jobs import pause_job
 
-    result = pause_job(job_id, reason=body.get("reason"))
+        result = pause_job(job_id, reason=body.get("reason"))
     if result:
-        return j(handler, {"ok": True, "job": result})
+        return j(handler, {"ok": True, "job": _annotate_cron_job(result, profile)})
     return bad(handler, "Job not found", 404)
 
 
@@ -3768,11 +3893,12 @@ def _handle_cron_resume(handler, body):
     job_id = body.get("job_id", "")
     if not job_id:
         return bad(handler, "job_id required")
-    from cron.jobs import resume_job
+    with _cron_profile_context(body.get("profile") or None) as (profile, _home):
+        from cron.jobs import resume_job
 
-    result = resume_job(job_id)
+        result = resume_job(job_id)
     if result:
-        return j(handler, {"ok": True, "job": result})
+        return j(handler, {"ok": True, "job": _annotate_cron_job(result, profile)})
     return bad(handler, "Job not found", 404)
 
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -163,11 +163,12 @@ def _cron_profile_context(profile: str | None, *, include_scheduler: bool = Fals
     with _CRON_PROFILE_LOCK:
         import cron.jobs as cron_jobs
 
+        missing = object()
         jobs_state = {
-            "HERMES_DIR": cron_jobs.HERMES_DIR,
-            "CRON_DIR": cron_jobs.CRON_DIR,
-            "JOBS_FILE": cron_jobs.JOBS_FILE,
-            "OUTPUT_DIR": cron_jobs.OUTPUT_DIR,
+            "HERMES_DIR": getattr(cron_jobs, "HERMES_DIR", missing),
+            "CRON_DIR": getattr(cron_jobs, "CRON_DIR", missing),
+            "JOBS_FILE": getattr(cron_jobs, "JOBS_FILE", missing),
+            "OUTPUT_DIR": getattr(cron_jobs, "OUTPUT_DIR", missing),
         }
         scheduler = None
         scheduler_state = {}
@@ -184,9 +185,9 @@ def _cron_profile_context(profile: str | None, *, include_scheduler: bool = Fals
                 import cron.scheduler as scheduler
 
                 scheduler_state = {
-                    "_hermes_home": scheduler._hermes_home,
-                    "_LOCK_DIR": scheduler._LOCK_DIR,
-                    "_LOCK_FILE": scheduler._LOCK_FILE,
+                    "_hermes_home": getattr(scheduler, "_hermes_home", missing),
+                    "_LOCK_DIR": getattr(scheduler, "_LOCK_DIR", missing),
+                    "_LOCK_FILE": getattr(scheduler, "_LOCK_FILE", missing),
                 }
             except Exception:
                 scheduler = None
@@ -194,7 +195,7 @@ def _cron_profile_context(profile: str | None, *, include_scheduler: bool = Fals
                 import hermes_state
 
                 hermes_state_state = {
-                    "DEFAULT_DB_PATH": hermes_state.DEFAULT_DB_PATH,
+                    "DEFAULT_DB_PATH": getattr(hermes_state, "DEFAULT_DB_PATH", missing),
                 }
             except Exception:
                 hermes_state = None
@@ -208,13 +209,31 @@ def _cron_profile_context(profile: str | None, *, include_scheduler: bool = Fals
             yield name, home
         finally:
             for key, value in jobs_state.items():
-                setattr(cron_jobs, key, value)
+                if value is missing:
+                    try:
+                        delattr(cron_jobs, key)
+                    except AttributeError:
+                        pass
+                else:
+                    setattr(cron_jobs, key, value)
             if scheduler is not None:
                 for key, value in scheduler_state.items():
-                    setattr(scheduler, key, value)
+                    if value is missing:
+                        try:
+                            delattr(scheduler, key)
+                        except AttributeError:
+                            pass
+                    else:
+                        setattr(scheduler, key, value)
             if hermes_state is not None:
                 for key, value in hermes_state_state.items():
-                    setattr(hermes_state, key, value)
+                    if value is missing:
+                        try:
+                            delattr(hermes_state, key)
+                        except AttributeError:
+                            pass
+                    else:
+                        setattr(hermes_state, key, value)
 
 
 def _cron_profiles_from_query(parsed) -> list[str]:

--- a/api/routes.py
+++ b/api/routes.py
@@ -171,6 +171,8 @@ def _cron_profile_context(profile: str | None, *, include_scheduler: bool = Fals
         }
         scheduler = None
         scheduler_state = {}
+        hermes_state = None
+        hermes_state_state = {}
 
         cron_dir = home / "cron"
         cron_jobs.HERMES_DIR = home
@@ -188,10 +190,20 @@ def _cron_profile_context(profile: str | None, *, include_scheduler: bool = Fals
                 }
             except Exception:
                 scheduler = None
+            try:
+                import hermes_state
+
+                hermes_state_state = {
+                    "DEFAULT_DB_PATH": hermes_state.DEFAULT_DB_PATH,
+                }
+            except Exception:
+                hermes_state = None
         if scheduler is not None:
             scheduler._hermes_home = home
             scheduler._LOCK_DIR = cron_dir
             scheduler._LOCK_FILE = cron_dir / ".tick.lock"
+        if hermes_state is not None:
+            hermes_state.DEFAULT_DB_PATH = home / "state.db"
         try:
             yield name, home
         finally:
@@ -200,6 +212,9 @@ def _cron_profile_context(profile: str | None, *, include_scheduler: bool = Fals
             if scheduler is not None:
                 for key, value in scheduler_state.items():
                     setattr(scheduler, key, value)
+            if hermes_state is not None:
+                for key, value in hermes_state_state.items():
+                    setattr(hermes_state, key, value)
 
 
 def _cron_profiles_from_query(parsed) -> list[str]:

--- a/static/index.html
+++ b/static/index.html
@@ -126,6 +126,7 @@
           <button class="panel-head-btn" onclick="openCronCreate()" title="New job" data-i18n-title="new_job" aria-label="New job"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg></button>
         </div>
       </div>
+      <div class="cron-profile-filter" id="cronProfileFilter"></div>
       <div class="cron-list" id="cronList"><div style="padding:12px;color:var(--muted);font-size:12px" data-i18n="loading">Loading...</div></div>
     </div>
     <!-- Skills panel -->

--- a/static/panels.js
+++ b/static/panels.js
@@ -5,6 +5,7 @@ let _cronList = null; // cached cron jobs (array)
 let _currentCronDetail = null; // full cron job object
 let _cronMode = 'empty'; // 'empty' | 'read' | 'create' | 'edit'
 let _cronPreFormDetail = null; // snapshot of prior selection when entering a form
+const CRON_VISIBLE_PROFILES_KEY = 'hermes-webui:cron:visible_profiles';
 let _currentWorkspaceDetail = null; // { path, name, is_default }
 let _workspaceMode = 'empty'; // 'empty' | 'read' | 'create' | 'edit'
 let _workspacePreFormDetail = null;
@@ -248,6 +249,7 @@ function _cronStatusMeta(job) {
 
 function _cronDiagnostics(job) {
   const fields = {
+    profile: job.profile || 'default',
     id: job.id,
     name: job.name || null,
     schedule: job.schedule || null,
@@ -265,6 +267,92 @@ function _cronDiagnostics(job) {
   return JSON.stringify(fields, null, 2);
 }
 
+function _readCronVisibleProfiles() {
+  try {
+    const raw = localStorage.getItem(CRON_VISIBLE_PROFILES_KEY);
+    const parsed = raw ? JSON.parse(raw) : null;
+    return Array.isArray(parsed) ? parsed.filter(Boolean).map(String) : [];
+  } catch(e) {
+    return [];
+  }
+}
+
+function _writeCronVisibleProfiles(names) {
+  try {
+    localStorage.setItem(CRON_VISIBLE_PROFILES_KEY, JSON.stringify(names || []));
+  } catch(e) {}
+}
+
+function _cronVisibleProfiles(profiles) {
+  const available = new Set((profiles || []).map(p => p.name));
+  const saved = _readCronVisibleProfiles().filter(name => !available.size || available.has(name));
+  if (saved.length) return saved;
+  const active = S.activeProfile || 'default';
+  if (!available.size || available.has(active)) return [active];
+  return ['default'];
+}
+
+function _cronProfileQuery(profiles) {
+  const names = _cronVisibleProfiles(profiles);
+  if (!names.length) return '';
+  const params = new URLSearchParams();
+  names.forEach(name => params.append('profile', name));
+  return `?${params.toString()}`;
+}
+
+function _renderCronProfileFilter(profiles) {
+  const wrap = $('cronProfileFilter');
+  if (!wrap) return;
+  if (!profiles || profiles.length <= 1) {
+    wrap.innerHTML = '';
+    wrap.style.display = 'none';
+    return;
+  }
+  wrap.style.display = '';
+  const selected = new Set(_cronVisibleProfiles(profiles));
+  const activeProfile = S.activeProfile || 'default';
+  const hasVisibleNonActive = [...selected].some(name => name !== activeProfile);
+  const buttons = profiles.map(p => {
+    const active = selected.has(p.name);
+    const gw = p.gateway_running ? '<span class="cron-profile-dot running"></span>' : '<span class="cron-profile-dot"></span>';
+    return `<button type="button" class="cron-profile-toggle${active ? ' active' : ''}" data-profile="${esc(p.name)}">${gw}<span>${esc(p.name)}</span></button>`;
+  }).join('');
+  const hint = hasVisibleNonActive
+    ? `<div class="cron-profile-hint">New jobs use active profile: <strong>${esc(activeProfile)}</strong></div>`
+    : '';
+  wrap.innerHTML = `<div class="cron-profile-buttons">${buttons}</div>${hint}`;
+  wrap.querySelectorAll('.cron-profile-toggle').forEach(btn => {
+    btn.onclick = async () => {
+      const name = btn.dataset.profile;
+      const next = new Set(_cronVisibleProfiles(profiles));
+      if (next.has(name)) next.delete(name);
+      else next.add(name);
+      _writeCronVisibleProfiles([...next]);
+      _clearCronDetail();
+      await loadCrons(true);
+    };
+  });
+}
+
+async function _loadCronProfilesForFilter() {
+  try {
+    const data = await api('/api/profiles');
+    _renderCronProfileFilter(data.profiles || []);
+    return data.profiles || [];
+  } catch(e) {
+    _renderCronProfileFilter([]);
+    return [];
+  }
+}
+
+function _cronJobProfile(job) {
+  return (job && job.profile) || 'default';
+}
+
+function _cronProfileBadge(job) {
+  return `<span class="cron-profile-label">[${esc(_cronJobProfile(job))}]</span>`;
+}
+
 async function loadCrons(animate) {
   const box = $('cronList');
   const refreshBtn = $('cronRefreshBtn');
@@ -273,7 +361,8 @@ async function loadCrons(animate) {
     refreshBtn.disabled = true;
   }
   try {
-    const data = await api('/api/crons');
+    const profiles = await _loadCronProfilesForFilter();
+    const data = await api('/api/crons' + _cronProfileQuery(profiles));
     _cronList = data.jobs || [];
     if (!_cronList.length) {
       box.innerHTML = `<div style="padding:16px;color:var(--muted);font-size:12px">${esc(t('cron_no_jobs'))}</div>`;
@@ -285,21 +374,23 @@ async function loadCrons(animate) {
       const item = document.createElement('div');
       item.className = 'cron-item';
       item.id = 'cron-' + job.id;
+      item.dataset.profile = _cronJobProfile(job);
       const status = _cronStatusMeta(job);
       const isNewRun = _cronNewJobIds.has(String(job.id));
       item.innerHTML = `
         <div class="cron-header">
           ${isNewRun ? '<span class="cron-new-dot" title="New run"></span>' : ''}
+          ${_cronProfileBadge(job)}
           <span class="cron-name" title="${esc(job.name)}">${esc(job.name)}</span>
           <span class="cron-status ${status.listClass}">${esc(status.label)}</span>
         </div>`;
-      item.onclick = () => openCronDetail(job.id, item);
-      if (_currentCronDetail && _currentCronDetail.id === job.id) item.classList.add('active');
+      item.onclick = () => openCronDetail(job.id, item, job.profile);
+      if (_currentCronDetail && _currentCronDetail.id === job.id && _cronJobProfile(_currentCronDetail) === _cronJobProfile(job)) item.classList.add('active');
       box.appendChild(item);
     }
     // Re-render current detail with fresh data if we have one and we're not in a form
     if (_currentCronDetail && _cronMode !== 'create' && _cronMode !== 'edit') {
-      const refreshed = _cronList.find(j => j.id === _currentCronDetail.id);
+      const refreshed = _cronList.find(j => j.id === _currentCronDetail.id && _cronJobProfile(j) === _cronJobProfile(_currentCronDetail));
       if (refreshed) _renderCronDetail(refreshed);
       else _clearCronDetail();
     }
@@ -320,6 +411,7 @@ function _renderCronDetail(job){
   if (!title || !body) return;
   title.textContent = job.name || job.schedule_display || '(unnamed)';
   const status = _cronStatusMeta(job);
+  const profile = _cronJobProfile(job);
   const nextRun = job.next_run_at ? new Date(job.next_run_at).toLocaleString() : t('not_available');
   const lastRun = job.last_run_at ? new Date(job.last_run_at).toLocaleString() : t('never');
   const schedule = job.schedule_display || (job.schedule && job.schedule.expression) || '';
@@ -346,6 +438,7 @@ function _renderCronDetail(job){
       ${attentionBanner}
       <div class="detail-card">
         <div class="detail-card-title">${esc(t('cron_status_active').replace(/./,c=>c.toUpperCase()))}</div>
+        <div class="detail-row"><div class="detail-row-label">Profile</div><div class="detail-row-value"><span class="detail-badge">${esc(profile)}</span></div></div>
         <div class="detail-row"><div class="detail-row-label">Status</div><div class="detail-row-value"><span class="detail-badge ${status.detailClass}">${esc(status.label)}</span></div></div>
         <div class="detail-row"><div class="detail-row-label">Schedule</div><div class="detail-row-value"><code>${esc(schedule)}</code></div></div>
         <div class="detail-row"><div class="detail-row-label">${esc(t('cron_next'))}</div><div class="detail-row-value">${esc(nextRun)}</div></div>
@@ -368,7 +461,7 @@ function _renderCronDetail(job){
   _cronMode = 'read';
   _setCronHeaderButtons('read', job);
   // Load runs asynchronously
-  _loadCronDetailRuns(job.id);
+  _loadCronDetailRuns(job.id, profile);
 }
 
 function _setCronHeaderButtons(mode, job) {
@@ -400,10 +493,11 @@ function _setCronHeaderButtons(mode, job) {
   }
 }
 
-async function _loadCronDetailRuns(jobId){
+async function _loadCronDetailRuns(jobId, profile){
   try {
-    const data = await api(`/api/crons/output?job_id=${encodeURIComponent(jobId)}&limit=20`);
-    if (!_currentCronDetail || _currentCronDetail.id !== jobId) return;
+    const profileParam = profile ? `&profile=${encodeURIComponent(profile)}` : '';
+    const data = await api(`/api/crons/output?job_id=${encodeURIComponent(jobId)}&limit=20${profileParam}`);
+    if (!_currentCronDetail || _currentCronDetail.id !== jobId || _cronJobProfile(_currentCronDetail) !== (profile || 'default')) return;
     const card = $('cronDetailRuns');
     if (!card) return;
     if (!data.outputs || !data.outputs.length) {
@@ -423,11 +517,13 @@ async function _loadCronDetailRuns(jobId){
   } catch(e) { /* ignore */ }
 }
 
-function openCronDetail(id, el){
-  const job = _cronList ? _cronList.find(j => j.id === id) : null;
+function openCronDetail(id, el, profile){
+  const job = _cronList ? _cronList.find(j => j.id === id && (!profile || _cronJobProfile(j) === profile)) : null;
   if (!job) return;
   document.querySelectorAll('.cron-item').forEach(e => e.classList.remove('active'));
-  const target = el || $('cron-' + id);
+  const target = el || (profile
+    ? document.querySelector(`.cron-item[data-profile="${CSS.escape(profile)}"][id="cron-${CSS.escape(id)}"]`)
+    : $('cron-' + id));
   if (target) target.classList.add('active');
   // Remove new-run dot from this job since user is now viewing it
   _clearCronUnreadForJob(id);
@@ -437,7 +533,7 @@ function openCronDetail(id, el){
   _editingCronId = null;
   _stopCronWatch();
   _renderCronDetail(job);
-  _checkCronWatchOnDetail(id);
+  _checkCronWatchOnDetail(id, _cronJobProfile(job));
 }
 
 function _clearCronDetail(){
@@ -453,9 +549,9 @@ function _clearCronDetail(){
   _setCronHeaderButtons('empty');
 }
 
-async function runCurrentCron(){ if (_currentCronDetail) await cronRun(_currentCronDetail.id); }
-async function pauseCurrentCron(){ if (_currentCronDetail) await cronPause(_currentCronDetail.id); }
-async function resumeCurrentCron(){ if (_currentCronDetail) await cronResume(_currentCronDetail.id); }
+async function runCurrentCron(){ if (_currentCronDetail) await cronRun(_currentCronDetail.id, _cronJobProfile(_currentCronDetail)); }
+async function pauseCurrentCron(){ if (_currentCronDetail) await cronPause(_currentCronDetail.id, _cronJobProfile(_currentCronDetail)); }
+async function resumeCurrentCron(){ if (_currentCronDetail) await cronResume(_currentCronDetail.id, _cronJobProfile(_currentCronDetail)); }
 async function copyCurrentCronDiagnostics(){
   if (!_currentCronDetail) return;
   try {
@@ -506,7 +602,7 @@ async function deleteCurrentCron(){
   const _ok = await showConfirmDialog({title:t('cron_delete_confirm_title'),message:t('cron_delete_confirm_message'),confirmLabel:t('delete_title'),danger:true,focusCancel:true});
   if(!_ok) return;
   try {
-    await api('/api/crons/delete', {method:'POST', body: JSON.stringify({job_id: id})});
+    await api('/api/crons/delete', {method:'POST', body: JSON.stringify({job_id: id, profile: _cronJobProfile(_currentCronDetail)})});
     showToast(t('cron_job_deleted'));
     _clearCronDetail();
     await loadCrons();
@@ -675,19 +771,20 @@ async function saveCronForm(){
   if(!prompt){errEl.textContent=t('cron_prompt_required');errEl.style.display='';return;}
   try{
     if (_editingCronId) {
-      const updates = {job_id: _editingCronId, schedule, prompt};
+      const updates = {job_id: _editingCronId, profile: _cronPreFormDetail ? _cronJobProfile(_cronPreFormDetail) : 'default', schedule, prompt};
       if (name) updates.name = name;
       await api('/api/crons/update', {method:'POST', body: JSON.stringify(updates)});
       const editedId = _editingCronId;
+      const editedProfile = updates.profile;
       _editingCronId = null;
       _cronPreFormDetail = null;
       showToast(t('cron_job_updated'));
       await loadCrons();
-      const job = _cronList && _cronList.find(j => j.id === editedId);
-      if (job) openCronDetail(editedId);
+      const job = _cronList && _cronList.find(j => j.id === editedId && _cronJobProfile(j) === editedProfile);
+      if (job) openCronDetail(editedId, null, editedProfile);
       return;
     }
-    const body={schedule,prompt,deliver};
+    const body={schedule,prompt,deliver,profile:S.activeProfile||'default'};
     if(_cronIsDuplicate) body.enabled=false;
     if(name)body.name=name;
     if(_cronSelectedSkills.length)body.skills=_cronSelectedSkills;
@@ -697,8 +794,12 @@ async function saveCronForm(){
     showToast(t('cron_job_created'));
     await loadCrons();
     const newId = res && (res.id || (res.job && res.job.id));
-    if (newId) openCronDetail(newId);
-    else if (_cronList && _cronList.length) openCronDetail(_cronList[_cronList.length - 1].id);
+    const newProfile = (res && res.job && res.job.profile) || body.profile;
+    if (newId) openCronDetail(newId, null, newProfile);
+    else if (_cronList && _cronList.length) {
+      const newest = _cronList[_cronList.length - 1];
+      openCronDetail(newest.id, null, _cronJobProfile(newest));
+    }
   }catch(e){
     errEl.textContent=t('error_prefix')+e.message;errEl.style.display='';
   }
@@ -721,21 +822,22 @@ let _cronWatchInterval = null;
 let _cronWatchStart = null;
 let _cronWatchTimerInterval = null;
 
-function _startCronWatch(jobId) {
+function _startCronWatch(jobId, profile) {
   _stopCronWatch();
   _cronWatchStart = Date.now();
   _cronWatchInterval = setInterval(async () => {
     try {
-      const data = await api(`/api/crons/status?job_id=${encodeURIComponent(jobId)}`);
+      const profileParam = profile ? `&profile=${encodeURIComponent(profile)}` : '';
+      const data = await api(`/api/crons/status?job_id=${encodeURIComponent(jobId)}${profileParam}`);
       if (!data.running) {
         _stopCronWatch();
-        if (_currentCronDetail && _currentCronDetail.id === jobId) {
-          _loadCronDetailRuns(jobId);
+        if (_currentCronDetail && _currentCronDetail.id === jobId && _cronJobProfile(_currentCronDetail) === (profile || 'default')) {
+          _loadCronDetailRuns(jobId, profile);
         }
         return;
       }
       // Still running — update elapsed
-      if (_currentCronDetail && _currentCronDetail.id === jobId) {
+      if (_currentCronDetail && _currentCronDetail.id === jobId && _cronJobProfile(_currentCronDetail) === (profile || 'default')) {
         const el = $('cronRunningIndicator');
         if (el) el.querySelector('.cron-watch-elapsed').textContent = _formatElapsed(data.elapsed);
       }
@@ -749,7 +851,7 @@ function _startCronWatch(jobId) {
     }
   }, 1000);
   // Inject running indicator into detail card
-  if (_currentCronDetail && _currentCronDetail.id === jobId) {
+  if (_currentCronDetail && _currentCronDetail.id === jobId && _cronJobProfile(_currentCronDetail) === (profile || 'default')) {
     _injectRunningIndicator();
   }
 }
@@ -779,34 +881,35 @@ function _formatElapsed(seconds) {
   return m + 'm ' + s + 's';
 }
 
-function _checkCronWatchOnDetail(jobId) {
+function _checkCronWatchOnDetail(jobId, profile) {
   // When opening a detail view, check if job is running
-  api(`/api/crons/status?job_id=${encodeURIComponent(jobId)}`).then(data => {
-    if (data.running && _currentCronDetail && _currentCronDetail.id === jobId) {
-      _startCronWatch(jobId);
+  const profileParam = profile ? `&profile=${encodeURIComponent(profile)}` : '';
+  api(`/api/crons/status?job_id=${encodeURIComponent(jobId)}${profileParam}`).then(data => {
+    if (data.running && _currentCronDetail && _currentCronDetail.id === jobId && _cronJobProfile(_currentCronDetail) === (profile || 'default')) {
+      _startCronWatch(jobId, profile);
     }
   }).catch(() => {});
 }
 
-async function cronRun(id) {
+async function cronRun(id, profile) {
   try {
-    await api('/api/crons/run', {method:'POST', body: JSON.stringify({job_id: id})});
+    await api('/api/crons/run', {method:'POST', body: JSON.stringify({job_id: id, profile})});
     showToast(t('cron_job_triggered'));
-    _startCronWatch(id);
+    _startCronWatch(id, profile);
   } catch(e) { showToast(t('failed_colon') + e.message, 4000); }
 }
 
-async function cronPause(id) {
+async function cronPause(id, profile) {
   try {
-    await api('/api/crons/pause', {method:'POST', body: JSON.stringify({job_id: id})});
+    await api('/api/crons/pause', {method:'POST', body: JSON.stringify({job_id: id, profile})});
     showToast(t('cron_job_paused'));
     await loadCrons();
   } catch(e) { showToast(t('failed_colon') + e.message, 4000); }
 }
 
-async function cronResume(id) {
+async function cronResume(id, profile) {
   try {
-    await api('/api/crons/resume', {method:'POST', body: JSON.stringify({job_id: id})});
+    await api('/api/crons/resume', {method:'POST', body: JSON.stringify({job_id: id, profile})});
     showToast(t('cron_job_resumed'));
     await loadCrons();
   } catch(e) { showToast(t('failed_colon') + e.message, 4000); }
@@ -3422,7 +3525,9 @@ function startCronPolling(){
   _cronPollTimer=setInterval(async()=>{
     if(document.hidden) return;  // don't poll when tab is in background
     try{
-      const data=await api(`/api/crons/recent?since=${_cronPollSince}`);
+      const profiles = await _loadCronProfilesForFilter();
+      const profileQuery = _cronProfileQuery(profiles);
+      const data=await api(`/api/crons/recent${profileQuery}${profileQuery ? '&' : '?'}since=${_cronPollSince}`);
       if(data.completions&&data.completions.length>0){
         for(const c of data.completions){
           showToast(t('cron_completion_status', c.name, c.status==='error' ? t('status_failed') : t('status_completed')),4000);

--- a/static/style.css
+++ b/static/style.css
@@ -620,9 +620,19 @@
   .panel-view.active{display:flex;}
   /* Cron panel */
   .cron-list{flex:1;overflow-y:auto;padding:8px;}
+  .cron-profile-filter{display:flex;flex-direction:column;gap:6px;padding:8px;border-bottom:1px solid var(--border);}
+  .cron-profile-buttons{display:flex;gap:6px;flex-wrap:wrap;min-width:0;}
+  .cron-profile-hint{font-size:11px;color:var(--muted);line-height:1.35;}
+  .cron-profile-toggle{display:inline-flex;align-items:center;gap:6px;min-width:0;max-width:100%;border:1px solid var(--border);background:rgba(255,255,255,.03);color:var(--muted);border-radius:8px;padding:5px 8px;font-size:11px;font-weight:600;cursor:pointer;}
+  .cron-profile-toggle span:last-child{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+  .cron-profile-toggle:hover{border-color:var(--border2);color:var(--text);}
+  .cron-profile-toggle.active{background:var(--accent-bg);border-color:var(--accent-bg-strong);color:var(--accent-text);}
+  .cron-profile-dot{width:7px;height:7px;border-radius:50%;background:rgba(255,255,255,.2);flex-shrink:0;}
+  .cron-profile-dot.running{background:#4caf50;box-shadow:0 0 4px rgba(76,175,80,.5);}
   .cron-item{width:100%;min-width:0;box-sizing:border-box;border-radius:10px;border:1px solid var(--border);margin-bottom:6px;overflow:hidden;transition:border-color .15s,background .15s;background:rgba(255,255,255,.02);cursor:pointer;}
   .cron-item:hover{border-color:var(--border2);}
   .cron-header{display:flex;align-items:center;gap:8px;padding:10px 12px;cursor:pointer;}
+  .cron-profile-label{font-size:10px;font-weight:700;color:var(--muted);flex-shrink:0;}
   .cron-name{flex:1;font-size:13px;color:var(--text);font-weight:500;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
   .cron-status{font-size:10px;font-weight:700;padding:2px 8px;border-radius:99px;flex-shrink:0;}
   .cron-status.active{background:rgba(34,197,94,.15);color:var(--success);}

--- a/tests/test_cron_profile_visibility.py
+++ b/tests/test_cron_profile_visibility.py
@@ -1,0 +1,62 @@
+import os
+import sys
+import types
+
+
+def test_cron_listing_reads_each_profile_without_mutating_env(tmp_path, monkeypatch):
+    import api.profiles as profiles
+    import api.routes as routes
+
+    default_home = tmp_path
+    cronbot_home = tmp_path / "profiles" / "cronbot"
+    cronbot_home.mkdir(parents=True)
+
+    monkeypatch.setattr(profiles, "_DEFAULT_HERMES_HOME", default_home)
+    monkeypatch.setattr(profiles, "_active_profile", "default")
+    monkeypatch.setattr(profiles._tls, "profile", None, raising=False)
+
+    cron_pkg = types.ModuleType("cron")
+    cron_pkg.__path__ = []
+    cron_jobs = types.ModuleType("cron.jobs")
+    cron_jobs.HERMES_DIR = default_home
+    cron_jobs.CRON_DIR = default_home / "cron"
+    cron_jobs.JOBS_FILE = default_home / "cron" / "jobs.json"
+    cron_jobs.OUTPUT_DIR = default_home / "cron" / "output"
+
+    def list_jobs(include_disabled=False):
+        return [{
+            "id": cron_jobs.HERMES_DIR.name or "default",
+            "name": f"job in {cron_jobs.HERMES_DIR}",
+            "prompt": "hello",
+            "enabled": True,
+            "schedule_display": "every 1h",
+        }]
+
+    cron_jobs.list_jobs = list_jobs
+    monkeypatch.setitem(sys.modules, "cron", cron_pkg)
+    monkeypatch.setitem(sys.modules, "cron.jobs", cron_jobs)
+    monkeypatch.delitem(sys.modules, "cron.scheduler", raising=False)
+    monkeypatch.setenv("HERMES_HOME", "/should/not/change")
+
+    jobs = routes._list_cron_jobs_for_profiles(["default", "cronbot"])
+
+    assert [job["profile"] for job in jobs] == ["default", "cronbot"]
+    assert str(default_home) in jobs[0]["name"]
+    assert str(cronbot_home) in jobs[1]["name"]
+    assert os.environ["HERMES_HOME"] == "/should/not/change"
+    assert cron_jobs.HERMES_DIR == default_home
+
+
+def test_cron_query_supports_profile_and_profiles_params():
+    from urllib.parse import urlparse
+    import api.routes as routes
+
+    single = routes._cron_profiles_from_query(urlparse("/api/crons?profile=cronbot"))
+    multi = routes._cron_profiles_from_query(urlparse("/api/crons?profiles=default,cronbot,default"))
+    repeated = routes._cron_profiles_from_query(urlparse("/api/crons?profile=default&profile=cronbot"))
+    combined = routes._cron_profiles_from_query(urlparse("/api/crons?profiles=default&profile=cronbot"))
+
+    assert single == ["cronbot"]
+    assert multi == ["default", "cronbot"]
+    assert repeated == ["default", "cronbot"]
+    assert combined == ["default", "cronbot"]

--- a/tests/test_cron_profile_visibility.py
+++ b/tests/test_cron_profile_visibility.py
@@ -1,6 +1,28 @@
 import os
+from pathlib import Path
 import sys
 import types
+
+REPO_ROOT = Path(__file__).parent.parent.resolve()
+
+
+def _read_static(path: str) -> str:
+    return (REPO_ROOT / path).read_text(encoding="utf-8")
+
+
+def _extract_js_function(src: str, name: str) -> str:
+    marker = f"function {name}("
+    idx = src.find(marker)
+    assert idx != -1, f"{name} not found"
+    depth = 0
+    for i, ch in enumerate(src[idx:], idx):
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return src[idx:i + 1]
+    raise AssertionError(f"Could not extract {name}")
 
 
 def test_cron_listing_reads_each_profile_without_mutating_env(tmp_path, monkeypatch):
@@ -47,6 +69,45 @@ def test_cron_listing_reads_each_profile_without_mutating_env(tmp_path, monkeypa
     assert cron_jobs.HERMES_DIR == default_home
 
 
+def test_cron_profile_context_scopes_agent_cron_paths_without_mutating_env(tmp_path, monkeypatch):
+    import api.profiles as profiles
+    import api.routes as routes
+
+    default_home = tmp_path
+    foo_home = tmp_path / "profiles" / "foo"
+    foo_home.mkdir(parents=True)
+
+    monkeypatch.setattr(profiles, "_DEFAULT_HERMES_HOME", default_home)
+    monkeypatch.setattr(profiles, "_active_profile", "default")
+    monkeypatch.setenv("HERMES_HOME", "/should/not/change")
+
+    cron_pkg = types.ModuleType("cron")
+    cron_pkg.__path__ = []
+    cron_jobs = types.ModuleType("cron.jobs")
+    cron_jobs.HERMES_DIR = default_home
+    cron_jobs.CRON_DIR = default_home / "cron"
+    cron_jobs.JOBS_FILE = default_home / "cron" / "jobs.json"
+    cron_jobs.OUTPUT_DIR = default_home / "cron" / "output"
+    cron_scheduler = types.ModuleType("cron.scheduler")
+    cron_scheduler._hermes_home = default_home
+    cron_scheduler._LOCK_DIR = default_home / "cron"
+    cron_scheduler._LOCK_FILE = default_home / "cron" / ".tick.lock"
+
+    monkeypatch.setitem(sys.modules, "cron", cron_pkg)
+    monkeypatch.setitem(sys.modules, "cron.jobs", cron_jobs)
+    monkeypatch.setitem(sys.modules, "cron.scheduler", cron_scheduler)
+
+    with routes._cron_profile_context("foo", include_scheduler=True):
+        assert cron_jobs.HERMES_DIR == foo_home
+        assert cron_jobs.OUTPUT_DIR == foo_home / "cron" / "output"
+        assert cron_scheduler._hermes_home == foo_home
+        assert os.environ["HERMES_HOME"] == "/should/not/change"
+
+    assert cron_jobs.HERMES_DIR == default_home
+    assert cron_scheduler._hermes_home == default_home
+    assert os.environ["HERMES_HOME"] == "/should/not/change"
+
+
 def test_cron_query_supports_profile_and_profiles_params():
     from urllib.parse import urlparse
     import api.routes as routes
@@ -60,3 +121,97 @@ def test_cron_query_supports_profile_and_profiles_params():
     assert multi == ["default", "cronbot"]
     assert repeated == ["default", "cronbot"]
     assert combined == ["default", "cronbot"]
+
+
+def test_cron_profile_jobs_and_cron_project_sessions_share_profile_scope(tmp_path, monkeypatch):
+    import api.models as models
+    import api.profiles as profiles
+    import api.routes as routes
+
+    default_home = tmp_path
+    foo_home = tmp_path / "profiles" / "foo"
+    foo_home.mkdir(parents=True)
+    (foo_home / "state.db").write_text("", encoding="utf-8")
+    cron_dir = foo_home / "cron"
+    cron_dir.mkdir()
+    (cron_dir / "jobs.json").write_text(
+        '{"jobs":[{"id":"foo-job","name":"Foo Cron","enabled":true}]}',
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(profiles, "_DEFAULT_HERMES_HOME", default_home)
+    monkeypatch.setattr(profiles, "_active_profile", "foo")
+    monkeypatch.setattr(profiles._tls, "profile", None, raising=False)
+    monkeypatch.setattr(models, "PROJECTS_FILE", tmp_path / "projects.json")
+    models.save_projects([])
+
+    cron_pkg = types.ModuleType("cron")
+    cron_pkg.__path__ = []
+    cron_jobs = types.ModuleType("cron.jobs")
+    cron_jobs.HERMES_DIR = default_home
+    cron_jobs.CRON_DIR = default_home / "cron"
+    cron_jobs.JOBS_FILE = default_home / "cron" / "jobs.json"
+    cron_jobs.OUTPUT_DIR = default_home / "cron" / "output"
+    cron_jobs.list_jobs = lambda include_disabled=False: [
+        {
+            "id": "foo-job",
+            "name": "Foo Cron",
+            "enabled": True,
+            "schedule_display": "every 1h",
+        }
+    ]
+    monkeypatch.setitem(sys.modules, "cron", cron_pkg)
+    monkeypatch.setitem(sys.modules, "cron.jobs", cron_jobs)
+
+    panel_jobs = routes._list_cron_jobs_for_profiles(["foo"])
+    assert panel_jobs == [
+        {
+            "id": "foo-job",
+            "name": "Foo Cron",
+            "enabled": True,
+            "schedule_display": "every 1h",
+            "profile": "foo",
+        }
+    ]
+
+    monkeypatch.setattr(
+        models,
+        "read_importable_agent_session_rows",
+        lambda db_path, **kwargs: [
+            {
+                "id": "cron_foo-job_123",
+                "last_activity": 20,
+                "started_at": 10,
+                "source": "cron",
+                "title": None,
+                "model": "test-model",
+                "message_count": 2,
+                "actual_message_count": 2,
+                "raw_source": "cron",
+                "session_source": "cron",
+                "source_label": "Cron",
+            }
+        ],
+    )
+
+    sidebar_sessions = models.get_cli_sessions()
+    assert len(sidebar_sessions) == 1
+    assert sidebar_sessions[0]["title"] == "Foo Cron"
+    assert sidebar_sessions[0]["profile"] == "foo"
+    assert sidebar_sessions[0]["project_id"] == models.ensure_cron_project()
+
+
+def test_visible_cron_profiles_fall_back_to_active_profile():
+    fn = _extract_js_function(_read_static("static/panels.js"), "_cronVisibleProfiles")
+
+    assert "const saved = _readCronVisibleProfiles()" in fn
+    assert "if (saved.length) return saved;" in fn
+    assert "const active = S.activeProfile || 'default';" in fn
+    assert "return [active];" in fn
+    assert "return ['default'];" in fn
+
+
+def test_chat_actions_still_use_active_profile():
+    commands = _read_static("static/commands.js")
+
+    assert commands.count("profile:S.activeProfile||'default'") >= 3

--- a/tests/test_cron_profile_visibility.py
+++ b/tests/test_cron_profile_visibility.py
@@ -92,19 +92,24 @@ def test_cron_profile_context_scopes_agent_cron_paths_without_mutating_env(tmp_p
     cron_scheduler._hermes_home = default_home
     cron_scheduler._LOCK_DIR = default_home / "cron"
     cron_scheduler._LOCK_FILE = default_home / "cron" / ".tick.lock"
+    hermes_state = types.ModuleType("hermes_state")
+    hermes_state.DEFAULT_DB_PATH = default_home / "state.db"
 
     monkeypatch.setitem(sys.modules, "cron", cron_pkg)
     monkeypatch.setitem(sys.modules, "cron.jobs", cron_jobs)
     monkeypatch.setitem(sys.modules, "cron.scheduler", cron_scheduler)
+    monkeypatch.setitem(sys.modules, "hermes_state", hermes_state)
 
     with routes._cron_profile_context("foo", include_scheduler=True):
         assert cron_jobs.HERMES_DIR == foo_home
         assert cron_jobs.OUTPUT_DIR == foo_home / "cron" / "output"
         assert cron_scheduler._hermes_home == foo_home
+        assert hermes_state.DEFAULT_DB_PATH == foo_home / "state.db"
         assert os.environ["HERMES_HOME"] == "/should/not/change"
 
     assert cron_jobs.HERMES_DIR == default_home
     assert cron_scheduler._hermes_home == default_home
+    assert hermes_state.DEFAULT_DB_PATH == default_home / "state.db"
     assert os.environ["HERMES_HOME"] == "/should/not/change"
 
 


### PR DESCRIPTION
## Summary
Adds profile-aware visibility support for the Scheduled Jobs panel.

This keeps the active profile behavior unchanged for chat/session actions, while adding a separate “visible profiles” concept for dashboard panels, starting with Scheduled Jobs.

This PR:
- adds profile-aware cron listing for `/api/crons`
- annotates returned cron jobs with `profile`
- routes cron detail/action endpoints through the job’s owning profile
- adds a Scheduled Jobs visible-profile selector
- persists visible profile selection in `localStorage`
- shows profile badges on cron rows/details
- creates new cron jobs under the active profile
- shows a UI hint when visible profiles include profiles other than the active one

## Active Profile vs Visible Profiles
- Active profile: used for new chats/actions and new cron creation.
- Visible profiles: controls which cron jobs appear in the Scheduled Jobs panel.

If no visible profiles are saved, the panel falls back to the active profile. Users with only the default profile should keep the same behavior as before.

## API Shape
The backend accepts:
- `GET /api/crons?profile=cronbot`
- `GET /api/crons?profile=default&profile=cronbot`
- `GET /api/crons?profiles=default,cronbot`

The UI uses repeated `profile=` params. The comma-separated `profiles=` form remains supported for compatibility and manual API checks.

Cron detail endpoints accept `profile`:
- `/api/crons/output`
- `/api/crons/recent`
- `/api/crons/status`

Cron action endpoints accept `profile` in the JSON body:
- create
- update
- delete
- run
- pause
- resume

## localStorage
Visible cron profiles are stored under:

`hermes-webui:cron:visible_profiles`

## Cron Jobs Project Note
Profile scope is independent from the v0.50.247 Cron Jobs project/session metadata.

`profile=` selects the Hermes profile home used for cron job storage and output lookup. It does not filter by project. Cron-created sessions should continue to be assigned to the Cron Jobs project through the existing session metadata path.

## Tests
- `python3 -m py_compile api/routes.py tests/test_cron_profile_visibility.py`
- `node --check static/panels.js`
- `python -m pytest tests/test_cron_profile_visibility.py tests/test_cron_run_job_import.py tests/test_sprint3.py::test_crons_list tests/test_sprint3.py::test_crons_list_has_required_fields tests/test_sprint3.py::test_crons_output_requires_job_id tests/test_sprint3.py::test_crons_run_nonexistent tests/test_sprint7.py::test_cron_update_unknown_job_404 tests/test_sprint7.py::test_cron_delete_unknown_404 tests/test_sprint10.py::test_crons_output_limit_param tests/test_cron_refresh_button_835.py tests/test_issue1140_cron_badge_per_job.py`

Local result: `27 passed`

## Previous questions / requests

- Ghost flash: profile switches clear the selected cron detail and stop the running watcher before reload, so a cronbot job should be hidden when only default is visible, not shown as a stale row.
- localStorage key: now namespaced as hermes-webui:cron:visible_profiles.
- now shows New jobs use active profile: <profile> when visible profiles include a non-active profile.
