### PR TITLE
fix: add missing openai and httpx to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@
 # The server uses only stdlib + pyyaml.
 # All heavy ML/agent deps live in the Hermes agent venv.
 pyyaml>=6.0
+openai>=1.0
+httpx>=0.25


### PR DESCRIPTION
## Summary

When the WebUI's Python venv lacks the `openai` package, running a chat that hits an API error causes the server to hang indefinitely.

## Root Cause

`api/streaming.py` delegates chat execution to `hermes-agent`'s `AIAgent`. When `AIAgent` raises an `anthropic.BadRequestError` (e.g. "context window exceeds limit"), its internal exception handler tries to import `openai.APIError`:

```python
# run_agent.py ~line 7040
from openai import APIError as _APIError
if isinstance(e, _APIError) and not getattr(e, "status_code", None):
    ...
```

If `openai` is not installed in the WebUI's venv, this `import` raises `ModuleNotFoundError` as an **unhandled exception inside a daemon thread**. The orphaned thread exits while holding the global `_ENV_LOCK` (a `threading.Lock` in `api/streaming.py`). All subsequent HTTP requests block forever waiting for that lock.

## Fix

Add `openai>=1.0` and `httpx>=0.25` to `requirements.txt`. Both packages are already imported by the WebUI streaming code or its dependency chain; they just weren't declared.

```diff
 # Hermes Web UI -- minimal Python dependencies
 # The server uses only stdlib + pyyaml.
 # All heavy ML/agent deps live in the Hermes agent venv.
 pyyaml>=6.0
+openai>=1.0
+httpx>=0.25
```

## Testing

1. Install the WebUI in a fresh venv **without** `openai`
2. Send a chat message that triggers an API error (e.g. context window overflow)
3. Observe: server hangs on all subsequent requests
4. Apply fix (`pip install openai httpx`), restart server
5. Observe: server continues responding normally after API errors

## Related

- `hermes-agent` issue: `from openai import APIError` in exception handler is not guarded by a try/except, so any `ModuleNotFoundError` propagates unhandled