### PR TITLE
Fix CLI session import fallback model default

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -4434,6 +4434,7 @@ def _handle_session_import_cli(handler, body):
     updated_at = None
     cli_title = None
     cli_source_tag = None
+    model = "unknown"
     for cs in get_cli_sessions():
         if cs["session_id"] == sid:
             profile = cs.get("profile")


### PR DESCRIPTION
Fixes a crash in CLI session import by defaulting model to 'unknown' when metadata is missing.

This avoids UnboundLocalError during POST /api/session/import_cli and allows CLI sessions without metadata to import successfully.