### PR TITLE
feat(deepseek): add V4 Pro/Flash [1m] variants to model dropdown

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -679,8 +679,10 @@ _PROVIDER_MODELS = {
         {"id": "gemini-2.5-flash",                  "label": "Gemini 2.5 Flash"},
     ],
     "deepseek": [
-        {"id": "deepseek-v4-flash", "label": "DeepSeek V4 Flash"},
         {"id": "deepseek-v4-pro", "label": "DeepSeek V4 Pro"},
+        {"id": "deepseek-v4-pro[1m]", "label": "DeepSeek V4 Pro (1M)"},
+        {"id": "deepseek-v4-flash", "label": "DeepSeek V4 Flash"},
+        {"id": "deepseek-v4-flash[1m]", "label": "DeepSeek V4 Flash (1M)"},
         {"id": "deepseek-chat-v3-0324", "label": "DeepSeek V3 (legacy)"},
         {"id": "deepseek-reasoner", "label": "DeepSeek Reasoner (legacy)"},
     ],


### PR DESCRIPTION
## Summary

Add `deepseek-v4-pro[1m]` and `deepseek-v4-flash[1m]` (1M context window variants) to the DeepSeek provider model dropdown while keeping the existing V4 and legacy entries.

## Changes

- Added `deepseek-v4-pro[1m]` — DeepSeek V4 Pro (1M)
- Added `deepseek-v4-flash[1m]` — DeepSeek V4 Flash (1M)
- Reordered so V4 models appear first, legacy models at the bottom

## Related

- [hermes-agent#18509](https://github.com/NousResearch/hermes-agent/pull/18509)