### PR TITLE
fix(login): session TTL, redirect-back, and connectivity retry

### DIFF
--- a/api/auth.py
+++ b/api/auth.py
@@ -24,7 +24,7 @@ PUBLIC_PATHS = frozenset({
 })
 
 COOKIE_NAME = 'hermes_session'
-SESSION_TTL = 86400  # 24 hours
+SESSION_TTL = 86400 * 30  # 30 days
 
 _SESSIONS_FILE = STATE_DIR / '.sessions.json'
 
@@ -229,7 +229,12 @@ def check_auth(handler, parsed) -> bool:
         handler.wfile.write(b'{"error":"Authentication required"}')
     else:
         handler.send_response(302)
-        handler.send_header('Location', '/login')
+        # Pass the original path as ?next= so login.js redirects back after auth.
+        import urllib.parse as _urlparse
+        _next = _urlparse.quote(parsed.path or '/', safe='/:@!$&\'()*+,;=')
+        if parsed.query:
+            _next += '?' + parsed.query
+        handler.send_header('Location', '/login?next=' + _urlparse.quote(_next, safe='/:@!$&\'()*+,;=?'))
         handler.end_headers()
     return False
 

--- a/static/login.js
+++ b/static/login.js
@@ -70,18 +70,41 @@ document.addEventListener('DOMContentLoaded', function () {
   // On page load, probe the server so we can distinguish "can't reach server"
   // (Tailscale off, wrong network) from "session expired / need to log in".
   // Uses /health — a public endpoint, no auth required.
+  // If unreachable, retries every 3 s and auto-reloads once the server is back.
   (function checkConnectivity() {
-    fetch('health', { method: 'GET', credentials: 'omit' })
-      .then(function (r) {
-        if (!r.ok) showErr(connFailed + ' (server error ' + r.status + ')');
-      })
-      .catch(function () {
-        showErr('Cannot reach server — check your VPN / Tailscale connection.');
-        // Disable the form so the user doesn't waste time trying a password
-        // that will never reach the server.
-        if (input) input.disabled = true;
-        var btn = form.querySelector('button');
-        if (btn) btn.disabled = true;
-      });
+    var retryTimer = null;
+
+    function setFormDisabled(disabled) {
+      if (input) input.disabled = disabled;
+      var btn = form.querySelector('button');
+      if (btn) btn.disabled = disabled;
+    }
+
+    function probe() {
+      fetch('health', { method: 'GET', credentials: 'omit' })
+        .then(function (r) {
+          if (r.ok) {
+            // Server is reachable — if we were in retry mode, reload so the
+            // page reflects the correct auth state (expired session, etc.).
+            if (retryTimer !== null) {
+              clearTimeout(retryTimer);
+              retryTimer = null;
+              window.location.reload();
+            }
+          } else {
+            showErr(connFailed + ' (server error ' + r.status + ')');
+          }
+        })
+        .catch(function () {
+          showErr('Cannot reach server — check your VPN / Tailscale connection.');
+          setFormDisabled(true);
+          // Keep retrying so the page auto-recovers once the network is back.
+          if (retryTimer === null) {
+            retryTimer = setInterval(probe, 3000);
+          }
+        });
+    }
+
+    probe();
   })();
 });

--- a/static/login.js
+++ b/static/login.js
@@ -66,4 +66,22 @@ document.addEventListener('DOMContentLoaded', function () {
       doLogin(e);
     }
   });
+
+  // On page load, probe the server so we can distinguish "can't reach server"
+  // (Tailscale off, wrong network) from "session expired / need to log in".
+  // Uses /health — a public endpoint, no auth required.
+  (function checkConnectivity() {
+    fetch('health', { method: 'GET', credentials: 'omit' })
+      .then(function (r) {
+        if (!r.ok) showErr(connFailed + ' (server error ' + r.status + ')');
+      })
+      .catch(function () {
+        showErr('Cannot reach server — check your VPN / Tailscale connection.');
+        // Disable the form so the user doesn't waste time trying a password
+        // that will never reach the server.
+        if (input) input.disabled = true;
+        var btn = form.querySelector('button');
+        if (btn) btn.disabled = true;
+      });
+  })();
 });


### PR DESCRIPTION
## Summary

Three stability fixes for the login page and session handling.

### 1. Session TTL extended: 24h → 30 days (`api/auth.py`)
Users were being kicked out after 24 hours of inactivity. Extended to 30 days to match typical browser session expectations.

### 2. Login page redirects back after session expiry (`api/auth.py`)
When a session expires and the user is redirected to `/login`, the server now passes `?next=/` so that after a successful login the user lands back at their original page instead of being left on `/login`.

### 3. Connectivity probe with auto-retry on login page (`static/login.js`)
Addresses a confusing UX issue: when the server is unreachable (e.g. VPN/Tailscale not running), the user would see a cryptic "session not found" or blank error instead of a helpful message.

Now on login page load:
- Probes `/health` immediately
- If unreachable: shows "Cannot reach server — check your VPN / Tailscale connection." and disables the form
- Retries every 3 seconds automatically
- Auto-reloads the page once the server becomes reachable again

No new dependencies. All changes are backwards-compatible.
