### PR TITLE
fix: align agent UID/GID with webui in compose files (#1399)

### DIFF
--- a/docker-compose.three-container.yml
+++ b/docker-compose.three-container.yml
@@ -34,8 +34,10 @@ services:
       - hermes-agent-src:/opt/hermes
     environment:
       - HERMES_HOME=/home/hermes/.hermes
-      - HERMES_UID=${HERMES_UID:-10000}
-      - HERMES_GID=${HERMES_GID:-10000}
+      # Align UID/GID across containers sharing the hermes-home volume.
+      # Defaults to 1000 to match WANTED_UID/WANTED_GID in the webui service.
+      - HERMES_UID=${UID:-1000}
+      - HERMES_GID=${GID:-1000}
     restart: unless-stopped
     deploy:
       resources:
@@ -55,8 +57,10 @@ services:
       - hermes-home:/home/hermes/.hermes
     environment:
       - HERMES_HOME=/home/hermes/.hermes
-      - HERMES_UID=${HERMES_UID:-10000}
-      - HERMES_GID=${HERMES_GID:-10000}
+      # Align UID/GID across containers sharing the hermes-home volume.
+      # Defaults to 1000 to match WANTED_UID/WANTED_GID in the webui service.
+      - HERMES_UID=${UID:-1000}
+      - HERMES_GID=${GID:-1000}
       # Dashboard connects to the gateway for health/session data
       - GATEWAY_HEALTH_URL=http://hermes-agent:8642
     depends_on:

--- a/docker-compose.two-container.yml
+++ b/docker-compose.two-container.yml
@@ -45,6 +45,10 @@ services:
       - hermes-agent-src:/opt/hermes
     environment:
       - HERMES_HOME=/home/hermes/.hermes
+      # Align UID/GID across containers sharing the hermes-home volume.
+      # Defaults to 1000 to match WANTED_UID/WANTED_GID in the webui service.
+      - HERMES_UID=${UID:-1000}
+      - HERMES_GID=${GID:-1000}
     restart: unless-stopped
     networks:
       - hermes-net


### PR DESCRIPTION
## Problem

Both `docker-compose.two-container.yml` and `docker-compose.three-container.yml` have a UID mismatch between containers sharing the `hermes-home` volume:

| Container | UID |
|-----------|-----|
| hermes-agent | 10000 (image default) |
| hermes-dashboard | 10000 (image default) |
| hermes-webui | 1000 (WANTED_UID default) |

Files written by the agent (UID 10000) cannot be read by the webui (UID 1000), causing `Permission denied`.

## Bug Reproduction

**Test 1 — two-container (named volumes):**
```
Agent UID:  10000    writes OK (files owned by 10000:10000)
WebUI UID:  1000     reads → Permission denied
```

**Test 2 — three-container (named volumes):**
```
Agent UID:      10000    writes OK
Dashboard UID:  10000
WebUI UID:      1000     reads → Permission denied
```

## Fix

- **docker-compose.two-container.yml**: Add `HERMES_UID` / `HERMES_GID` (was missing entirely). Defaults to `${UID:-1000}` to match the webui.
- **docker-compose.three-container.yml**: Change default from `${HERMES_UID:-10000}` to `${UID:-1000}` to match the webui.

The agent image entrypoint already supports `usermod` remapping when these variables are set.

## Verification (after fix)

**Two-container:**
```
Agent UID:  1000 ✓    writes OK
WebUI UID:  1000 ✓    reads OK
Gateway:    Running ✓
```

**Three-container:**
```
Agent UID:      1000 ✓    writes OK
Dashboard UID:  1000 ✓    reads OK
WebUI UID:      1000 ✓    reads OK
Gateway:        Running ✓
Dashboard HTTP: 200 ✓
```

Fixes #1399