### PR TITLE
Hide composer-footer toolsets chip (cramped layout, refs #1431)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 ### Changed
-- **Composer footer: hide session-toolsets chip temporarily** — the per-session toolsets restriction chip (introduced in #493) made the composer footer too cramped on narrow widths once it was sharing space with model, reasoning, profile, and context indicators. Hidden via `_applyToolsetsChip()` setting `display:none` on the wrap; the underlying state and `/api/session/toolsets` endpoint still work, so any cron job or scripted client that relies on `enabled_toolsets` continues unaffected. To be revisited when the footer layout is redesigned (#1430). (`static/ui.js`)
+- **Composer footer: hide session-toolsets chip temporarily** — the per-session toolsets restriction chip (introduced in #493) made the composer footer too cramped on narrow widths once it was sharing space with model, reasoning, profile, and context indicators. Hidden via `_applyToolsetsChip()` setting `display:none` on the wrap; the underlying state and `/api/session/toolsets` endpoint still work, so any cron job or scripted client that relies on `enabled_toolsets` continues unaffected. To be revisited when the footer layout is redesigned (#1431). (`static/ui.js`)
 
 ## [v0.50.260] — 2026-05-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Changed
+- **Composer footer: hide session-toolsets chip temporarily** — the per-session toolsets restriction chip (introduced in #493) made the composer footer too cramped on narrow widths once it was sharing space with model, reasoning, profile, and context indicators. Hidden via `_applyToolsetsChip()` setting `display:none` on the wrap; the underlying state and `/api/session/toolsets` endpoint still work, so any cron job or scripted client that relies on `enabled_toolsets` continues unaffected. To be revisited when the footer layout is redesigned (#1430). (`static/ui.js`)
+
 ## [v0.50.260] — 2026-05-01
 
 ### Fixed

--- a/static/ui.js
+++ b/static/ui.js
@@ -928,7 +928,7 @@ function _applyToolsetsChip(toolsets) {
   const label = $('composerToolsetsLabel');
   const chip = $('composerToolsetsChip');
   if (!wrap || !label) return;
-  // Temporarily hidden — composer footer is too cramped (#1430). State is still
+  // Temporarily hidden — composer footer is too cramped (#1431). State is still
   // tracked so /api/session/toolsets continues to work; just the chip UI is hidden
   // until we redesign the footer layout.
   wrap.style.display = 'none';

--- a/static/ui.js
+++ b/static/ui.js
@@ -928,7 +928,10 @@ function _applyToolsetsChip(toolsets) {
   const label = $('composerToolsetsLabel');
   const chip = $('composerToolsetsChip');
   if (!wrap || !label) return;
-  wrap.style.display = '';
+  // Temporarily hidden — composer footer is too cramped (#1430). State is still
+  // tracked so /api/session/toolsets continues to work; just the chip UI is hidden
+  // until we redesign the footer layout.
+  wrap.style.display = 'none';
   const hasCustom = Array.isArray(toolsets) && toolsets.length > 0;
   if (hasCustom) {
     label.textContent = toolsets.join(', ');


### PR DESCRIPTION
### Why

The composer footer was getting too cramped — the session-toolsets chip ("Global (default)") was overlapping the context-usage ring and squeezing the send button. Screenshot in original bug report:

> Right now, it's making everything feel really cramped.

### What

One-line change in `_applyToolsetsChip()`: instead of `wrap.style.display = ''` (visible), it now sets `'none'`. The chip introduced in #493 is hidden in the footer. Underlying state and the `/api/session/toolsets` endpoint still work — anyone passing `enabled_toolsets` programmatically (cron jobs, ACP clients, scripted callers) is unaffected.

This is explicitly a "punt for now" — issue #1431 tracks the proper redesign of footer layout / where to surface session-level tool restriction.

### Diff

```diff
function _applyToolsetsChip(toolsets) {
  _currentSessionToolsets = toolsets;
  const wrap = $('composerToolsetsWrap');
  const label = $('composerToolsetsLabel');
  const chip = $('composerToolsetsChip');
  if (!wrap || !label) return;
- wrap.style.display = '';
+ // Temporarily hidden — composer footer is too cramped (#1431). State is still
+ // tracked so /api/session/toolsets continues to work; just the chip UI is hidden
+ // until we redesign the footer layout.
+ wrap.style.display = 'none';
  ...
}
```

### Verification

- `pytest tests/` — 3627 passed, 2 skipped, 3 xpassed (full suite, ignoring browser smoke)
- Visual check: composer footer no longer shows the wrench/"Global (default)" chip; model + reasoning + profile + context-ring + send button now have breathing room

### Restoring locally

If anyone needs the chip back temporarily:

```js
document.getElementById('composerToolsetsWrap').style.display = '';
```

### Risk

Minimal. State still tracks; only the visual entry point is hidden. No backend changes, no test changes, no schema changes.

Closes nothing yet — issue #1431 stays open until the redesign lands.
