### PR TITLE
fix(renderer): line-anchor fence regex to prevent mid-line ``` corruption (#1438)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Hermes Web UI -- Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- **Markdown renderer: triple backticks mid-line corrupted downstream rendering** (#1438) —
+  The fence regex `/```([\s\S]*?)```/g` had no line anchoring. A literal triple backtick
+  appearing inside a code block's content (e.g. a regex pattern with ``` in a lookbehind,
+  a script that documents fences, embedded markdown-in-markdown) terminated the outer
+  fence at the wrong place. The leaked tail then went through bold/italic/inline-code
+  passes, eating `*` characters as italic markers and producing literal `</strong>` tags
+  in the rendered output. Reported by **Cygnus** (Discord, May 1 2026), relayed by
+  @AvidFuturist.
+
+  **Fix:** anchor all 3 fence regexes per CommonMark §4.5 — opening fence must start a
+  line (with up to 3 spaces of indent), closing fence must also start a line. Pattern:
+  `(^|\n)[ ]{0,3}\`\`\`(?:([\s\S]*?)\n)?[ ]{0,3}\`\`\`(?=\n|$)`. The `(?:...\n)?` group
+  keeps empty fences (`` ```\n``` ``) working. Patched sites:
+
+  - `static/ui.js:1559` — `renderMd()` fenced-block stash (the assistant-message renderer)
+  - `static/ui.js:66` — `_renderUserFencedBlocks()` (user-message renderer)
+  - `static/ui.js:2599` — `_stripForTTS()` (TTS speech pre-strip)
+
+  Plus the Python mirror in `tests/test_sprint16.py`. Triple backticks in the middle of
+  a line are now treated as literal text (CommonMark-conformant) and no longer break out
+  of code blocks. 20 regression tests in `tests/test_issue1438_fence_anchoring.py` cover
+  Cygnus's exact repro, inline `` ``` `` in paragraphs, partial/streaming fences, empty
+  fences, indented fences (3-space ✓, 4-space ✗), language tags, two adjacent blocks,
+  and source-level guards on all 3 patched sites.
+
 ## [v0.50.263] — 2026-05-02
 
 ### Fixed

--- a/static/ui.js
+++ b/static/ui.js
@@ -62,8 +62,10 @@ function _renderUserFencedBlocks(text){
   const stash=[];
   let s=String(text||'');
   // Extract fenced code blocks → stash, replace with null-token placeholder
-  s=s.replace(/```([a-zA-Z0-9_+-]*)\n([\s\S]*?)```/g,(_,lang,code)=>{
+  // CommonMark line-anchored fence (fixes #1438): inner ``` inside content no longer truncates the block.
+  s=s.replace(/(^|\n)[ ]{0,3}```([a-zA-Z0-9_+-]*)\n(?:([\s\S]*?)\n)?[ ]{0,3}```(?=\n|$)/g,(_,lead,lang,code)=>{
     lang=(lang||'').trim().toLowerCase();
+    code=code||'';
     // Remove one trailing newline if present (the fence consumes its own)
     if(code.endsWith('\n')) code=code.slice(0,-1);
     const h=lang?`<div class="pre-header">${esc(lang)}</div>`:'';
@@ -79,7 +81,7 @@ function _renderUserFencedBlocks(text){
     } else {
       stash.push(`${h}<pre><code${langAttr}>${esc(code)}</code></pre>`);
     }
-    return '\x00UF'+(stash.length-1)+'\x00';
+    return lead+'\x00UF'+(stash.length-1)+'\x00';
   });
   // Escape remaining plain text and convert newlines to <br>
   s=esc(s).replace(/\n/g,'<br>');
@@ -1549,7 +1551,12 @@ function renderMd(raw){
   // breaking </pre> closure and corrupting all subsequent message rendering.
   const _preBlock_stash=[];
   const fence_stash=[];
-  s=s.replace(/```([\s\S]*?)```/g,(_,raw)=>{
+  // CommonMark §4.5: opening fence must start a line (with up to 3 spaces of indent)
+  // and closing fence must also start a line. Without line anchoring, a literal ``` inside
+  // a code block (e.g. a regex pattern with ``` in a lookbehind, a script that documents
+  // fences) terminates the outer block at the wrong place, leaking content into the
+  // markdown stream where bold/italic/inline-code passes corrupt it. Fixes #1438.
+  s=s.replace(/(^|\n)[ ]{0,3}```(?:([\s\S]*?)\n)?[ ]{0,3}```(?=\n|$)/g,(_,lead,raw)=>{
     const m=raw.match(/^(\w[\w+-]*)\n?([\s\S]*)$/);
     const lang=m?(m[1]||'').trim().toLowerCase():'';
     const code=m?m[2]:raw.replace(/^\n?/,'');
@@ -1595,7 +1602,7 @@ function renderMd(raw){
         _preBlock_stash.push(`${h}<pre><code${langAttr}>${esc(code.replace(/\n$/,''))}</code></pre>`);
       }
     }
-    return '\x00P'+(_preBlock_stash.length-1)+'\x00';
+    return lead+'\x00P'+(_preBlock_stash.length-1)+'\x00';
   });
   s=s.replace(/`([^`\n]+)`/g,(_,c)=>{fence_stash.push('<code>'+esc(c)+'</code>');return '\x00F'+(fence_stash.length-1)+'\x00';});
   // Math stash: protect $$..$$ and $..$ from markdown processing
@@ -2588,8 +2595,8 @@ function copyMsg(btn){
 // ── TTS: Text-to-Speech via Web Speech API (#499) ──
 // Strips markdown, code blocks, and MEDIA: paths for clean speech output.
 function _stripForTTS(text){
-  // Remove code blocks entirely (```)
-  text=text.replace(/```[\s\S]*?```/g,' ');
+  // Remove code blocks entirely (```) — line-anchored to match #1438 fix
+  text=text.replace(/(^|\n)[ ]{0,3}```(?:[\s\S]*?\n)?[ ]{0,3}```(?=\n|$)/g,' ');
   // Remove inline code
   text=text.replace(/`[^`]+`/g,' ');
   // Strip bold/italic

--- a/tests/test_issue1438_fence_anchoring.py
+++ b/tests/test_issue1438_fence_anchoring.py
@@ -1,0 +1,281 @@
+"""Regression tests for #1438 — triple backticks mid-line should not terminate fences.
+
+Bug shape (issue #1438): the fence regex `/```([\\s\\S]*?)```/g` had no line
+anchoring. A literal triple backtick inside a code-block content (e.g. a regex
+pattern with ``` in a lookbehind) terminated the outer fence at the wrong place.
+The leaked tail then went through bold/italic/inline-code passes, eating `*`
+characters and leaking literal `</strong>` tags into the rendered output.
+
+Reported by Cygnus (Discord, May 1 2026), relayed by @AvidFuturist.
+
+Fix: anchor the fence regex per CommonMark §4.5 — opening fence must start a
+line (with up to 3 spaces of indent), closing fence must also start a line.
+
+Sites patched:
+  static/ui.js:1557  — renderMd() fenced-block stash
+  static/ui.js:74    — _renderUserFencedBlocks() (user message renderer)
+  static/ui.js:2597  — _stripForTTS() (TTS pre-strip)
+  tests/test_sprint16.py — Python mirror (two regexes to keep in sync)
+
+Note on the Python mirror: it does not implement `_ob_stash` (which protects
+`<code>` from outer bold/italic) or `_pre_stash` (which protects `<pre>` from
+paragraph-wrap). So mirror output may show extra `<em>` inside `<pre>` blocks
+or `<pre>` wrapped in `<p>`. These are mirror-only artifacts; the actual JS
+pipeline produces clean output. Tests below focus on the structural property
+that the fence regex captures the correct extent — the part that's identical
+in both implementations.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from tests.test_sprint16 import render_md  # Python mirror of renderMd()
+
+
+UI_JS = (Path(__file__).resolve().parent.parent / "static" / "ui.js").read_text()
+
+
+def _strip_pre_blocks(out: str) -> str:
+    """Remove all <pre>...</pre> blocks for assertions about the surrounding text."""
+    return re.sub(r"<pre[\s\S]*?</pre>", "", out)
+
+
+# ── 1. THE BUG: Cygnus's exact repro ──────────────────────────────────────────
+
+
+def test_inner_triple_backtick_inside_regex_does_not_terminate_outer_fence():
+    """Cygnus's exact input — a regex literal with ``` in a lookbehind."""
+    text = (
+        "Here's the regex:\n\n"
+        "```regex\n"
+        "(?<!\\n)(?<!(?:^|\\n)[ \\t]*(?:```[^\\n]*|%%[ \\t]*(?:\\n|$)))\n"
+        "```\n\n"
+        "uses **bold** for emphasis."
+    )
+    out = render_md(text)
+
+    # ── Structural property: exactly one fence captured the right extent.
+    assert out.count("<pre>") == 1, f"expected 1 <pre>, got {out.count('<pre>')}"
+    assert out.count("</pre>") == 1
+
+    # ── The inner ``` is preserved as literal text inside the code block.
+    #    Before the fix, the `</code></pre>` would appear MID-content and the
+    #    inner ``` would NOT survive (the regex ate it as a delimiter).
+    pre_block = re.search(r"<pre[\s\S]*?</pre>", out)
+    assert pre_block, "no <pre> block found"
+    assert "```[^" in pre_block.group(0), (
+        "inner triple backtick should be preserved as literal inside the code block"
+    )
+    assert "%%" in pre_block.group(0), "tail of regex must survive inside code block"
+
+    # ── No orphaned ``` outside any <pre> block.
+    #    Before the fix, the trailing ``` (which used to be a closing fence)
+    #    leaked into the surrounding markdown stream as literal text.
+    outside = _strip_pre_blocks(out)
+    assert "```" not in outside, f"orphaned ``` leaked outside <pre>: {outside!r}"
+
+    # ── Bold renders correctly AFTER the fence.
+    assert "<strong>bold</strong>" in out, "bold must survive intact"
+    # Strong tags balanced.
+    assert out.count("<strong>") == out.count("</strong>")
+
+
+# ── 2. Inline triple-backtick in running text must NOT open a fence ────────────
+
+
+def test_inline_triple_backtick_in_paragraph_does_not_open_fence():
+    """A ``` in the middle of a sentence must not be treated as a fence opener."""
+    text = "Plain text with ``` in the middle of a sentence."
+    out = render_md(text)
+    assert "<pre>" not in out
+    # The literal ``` survives somewhere in the rendered output.
+    assert "```" in out
+
+
+def test_three_backticks_at_end_of_sentence_no_fence():
+    """``` immediately after text on the same line — not a fence."""
+    text = "End with``` not a fence"
+    out = render_md(text)
+    assert "<pre>" not in out
+
+
+def test_unmatched_partial_fence_does_not_eat_message():
+    """Partial/streaming input with no closing fence — must not match anything.
+
+    Before the fix, an inner ``` could pair with itself and produce a bogus <pre>.
+    With anchoring, no match occurs and content stays as plain text.
+    """
+    text = "```python\nincomplete code, no close yet"
+    out = render_md(text)
+    assert "<pre>" not in out
+    assert "incomplete code" in out
+
+
+# ── 3. Existing happy paths must keep working ─────────────────────────────────
+
+
+def test_simple_python_fence_renders():
+    text = "```python\nprint('hi')\n```"
+    out = render_md(text)
+    assert "<pre>" in out
+    # esc() may HTML-encode quotes; either form is fine.
+    assert "print(&#x27;hi&#x27;)" in out or "print('hi')" in out
+    # Language tag preserved.
+    assert 'class="pre-header">python' in out
+
+
+def test_fence_after_paragraph_no_blank_line_required():
+    """CommonMark allows a fence directly after text — `\\n` is enough."""
+    text = "Some text\n```\nx = 1\n```"
+    out = render_md(text)
+    assert "<pre>" in out
+    assert "x = 1" in out
+
+
+def test_fence_at_end_of_input_no_trailing_newline():
+    """Closing fence at the very end of input (no newline after)."""
+    text = "Intro\n\n```\nfoo\n```"
+    out = render_md(text)
+    assert out.count("<pre>") == 1
+    assert "foo" in out
+
+
+def test_two_adjacent_fenced_blocks_render_independently():
+    text = "```\nA\n```\n\n```\nB\n```"
+    out = render_md(text)
+    assert out.count("<pre>") == 2
+    assert "A" in out and "B" in out
+
+
+def test_three_space_indented_fence_still_recognised():
+    """CommonMark allows up to 3 spaces of indent on fence lines."""
+    text = "   ```\nfoo\n   ```"
+    out = render_md(text)
+    assert "<pre>" in out
+    assert "foo" in out
+
+
+def test_four_space_indent_is_not_a_fence():
+    """4+ spaces is an indented code block in CommonMark, not a fence.
+
+    With the line-anchored regex, this no longer matches the fence regex, so
+    no <pre> with bogus content. We don't implement strict CommonMark
+    indented-code-block behaviour — just verify we don't false-positive.
+    """
+    text = "    ```py\n    foo\n    ```"
+    out = render_md(text)
+    assert "<pre>" not in out
+
+
+# ── 4. Bold/italic/inline-code outside a fence still work after the fix ───────
+
+
+def test_bold_after_fence_renders_correctly():
+    text = "```\ncode\n```\n\nThen **bold** text."
+    out = render_md(text)
+    assert "<pre>" in out
+    assert "<strong>bold</strong>" in out
+
+
+def test_italic_after_fence_renders_correctly():
+    text = "```\ncode\n```\n\nThen *italic* text."
+    out = render_md(text)
+    assert "<pre>" in out
+    assert "<em>italic</em>" in out
+
+
+def test_inline_code_after_fence():
+    text = "```\nblock\n```\n\nThen `inline` code."
+    out = render_md(text)
+    assert "<pre>" in out
+    assert "<code>inline</code>" in out
+
+
+# ── 5. SOURCE-LEVEL guards (catch regression of any of the 3 patched sites) ───
+
+
+def test_renderMd_fence_regex_is_line_anchored():
+    """The fence regex in renderMd must include `(^|\\n)` opener and `(?=\\n|$)` closer.
+
+    Pattern: (^|\\n)[ ]{0,3}```(?:([\\s\\S]*?)\\n)?[ ]{0,3}```(?=\\n|$)
+    The `(?:...\\n)?` makes the body optional so empty fences (```\\n```) still match.
+    """
+    assert re.search(
+        r"s=s\.replace\(/\(\^\|\\n\)\[ \]\{0,3\}```\(\?:\(\[\\s\\S\]\*\?\)\\n\)\?\[ \]\{0,3\}```\(\?=\\n\|\$\)/g",
+        UI_JS,
+    ), "renderMd fence regex is not line-anchored — regression of #1438"
+
+
+def test_renderUserFencedBlocks_fence_regex_is_line_anchored():
+    """The fence regex in _renderUserFencedBlocks must also be line-anchored."""
+    assert re.search(
+        r"s=s\.replace\(/\(\^\|\\n\)\[ \]\{0,3\}```\(\[a-zA-Z0-9_\+\-\]\*\)\\n\(\?:\(\[\\s\\S\]\*\?\)\\n\)\?\[ \]\{0,3\}```\(\?=\\n\|\$\)/g",
+        UI_JS,
+    ), "_renderUserFencedBlocks fence regex is not line-anchored — regression of #1438"
+
+
+def test_stripForTTS_fence_regex_is_line_anchored():
+    """_stripForTTS must use the line-anchored fence regex too."""
+    assert re.search(
+        r"text=text\.replace\(/\(\^\|\\n\)\[ \]\{0,3\}```\(\?:\[\\s\\S\]\*\?\\n\)\?\[ \]\{0,3\}```\(\?=\\n\|\$\)/g",
+        UI_JS,
+    ), "_stripForTTS fence regex is not line-anchored — regression of #1438"
+
+
+def test_renderMd_callback_prefixes_lead():
+    """Without `lead+`, the leading newline gets stripped and paragraphs above
+    bleed into the <pre> after fence stash restore.
+    """
+    assert "return lead+'\\x00P'+(_preBlock_stash.length-1)+'\\x00';" in UI_JS, (
+        "renderMd fence callback must return lead+stashtoken to preserve newlines"
+    )
+
+
+def test_renderUserFencedBlocks_callback_prefixes_lead():
+    assert "return lead+'\\x00UF'+(stash.length-1)+'\\x00';" in UI_JS, (
+        "_renderUserFencedBlocks callback must return lead+stashtoken to preserve newlines"
+    )
+
+
+def test_no_unanchored_fence_regex_remains_in_render_paths():
+    """Belt-and-suspenders: assert the OLD vulnerable patterns are gone from
+    the three render/strip paths. (Documenting the regex literal is fragile;
+    we just verify the bare unanchored form isn't present in the patched
+    sites as a literal substring.)
+    """
+    # The exact OLD vulnerable forms that this PR replaces.
+    old_render_md = "s=s.replace(/```([\\s\\S]*?)```/g,(_,raw)=>{"
+    old_user_fenced = "s=s.replace(/```([a-zA-Z0-9_+-]*)\\n([\\s\\S]*?)```/g,(_,lang,code)=>{"
+    old_tts_strip = "text=text.replace(/```[\\s\\S]*?```/g,' ');"
+    assert old_render_md not in UI_JS, "old unanchored renderMd fence regex still present"
+    assert old_user_fenced not in UI_JS, "old unanchored _renderUserFencedBlocks regex still present"
+    assert old_tts_strip not in UI_JS, "old unanchored _stripForTTS regex still present"
+
+
+# ── 6. Diff/patch fence with inner ``` in content ─────────────────────────────
+
+
+def test_diff_fence_with_inner_backticks_in_content():
+    """Diff/patch blocks where a content line contains ``` mid-line — the inner
+    ``` must not be treated as a close fence.
+
+    Verified at the source level: the JS regex requires the close fence to be
+    on its own line (preceded by `\\n`), so a mid-line ``` cannot match.
+    The Python mirror doesn't implement diff/patch styling or _preBlock_stash
+    so we don't assert against its output here.
+    """
+    # Source-level: the renderMd fence regex requires `\n[ ]{0,3}\`\`\`(?=\n|$)`
+    # for the close fence — a mid-line ``` cannot match.
+    # Three sites must all use this pattern.
+    # Pattern explanation: ui.js source contains literal backslash-n in regex literals
+    # (ONE backslash + 'n'). In a Python raw string, r"\\n" compiles to a regex pattern
+    # matching ONE literal backslash followed by 'n'.
+    matches = re.findall(r"```\(\?=\\n\|\$\)", UI_JS)
+    assert len(matches) >= 3, (
+        f"all 3 fence sites (renderMd, _renderUserFencedBlocks, _stripForTTS) "
+        f"must have line-anchored close fence; found {len(matches)} occurrences"
+    )

--- a/tests/test_sprint16.py
+++ b/tests/test_sprint16.py
@@ -61,7 +61,8 @@ def render_md(raw):
         fence_stash.append(m.group())
         return "\x00F" + str(len(fence_stash) - 1) + "\x00"
 
-    s = re.sub(r"(```[\s\S]*?```|`[^`\n]+`)", stash, s)
+    # Fence regex line-anchored to match JS fix for #1438 (allows empty fence)
+    s = re.sub(r"(?:^|\n)[ ]{0,3}```(?:[\s\S]*?\n)?[ ]{0,3}```(?=\n|$)|`[^`\n]+`", stash, s)
     s = re.sub(r"<strong>([\s\S]*?)</strong>", lambda m: "**" + m.group(1) + "**", s, flags=re.I)
     s = re.sub(r"<b>([\s\S]*?)</b>",           lambda m: "**" + m.group(1) + "**", s, flags=re.I)
     s = re.sub(r"<em>([\s\S]*?)</em>",          lambda m: "*"  + m.group(1) + "*",  s, flags=re.I)
@@ -72,10 +73,11 @@ def render_md(raw):
 
     # Fenced code blocks
     def fenced(m):
-        lang, code = m.group(1), m.group(2).rstrip("\n")
+        lang, code = m.group(1), (m.group(2) or "").rstrip("\n")
         h = f'<div class="pre-header">{esc(lang)}</div>' if lang else ""
         return h + "<pre><code>" + esc(code) + "</code></pre>"
-    s = re.sub(r"```([\w+-]*)\n?([\s\S]*?)```", fenced, s)
+    # Fenced code blocks (line-anchored, fixes #1438; allows empty fence)
+    s = re.sub(r"(?:^|\n)[ ]{0,3}```([\w+-]*)\n(?:([\s\S]*?)\n)?[ ]{0,3}```(?=\n|$)", fenced, s)
     s = re.sub(r"`([^`\n]+)`", lambda m: "<code>" + esc(m.group(1)) + "</code>", s)
 
     # Inline formatting (top-level, outside list items)


### PR DESCRIPTION
## Summary

Fixes #1438 — triple backticks mid-line corrupted downstream markdown rendering. Reported by **Cygnus** (Discord, May 1 2026), relayed by @AvidFuturist with screenshots showing eaten `*` quantifiers and literal `</strong>` leaks.

## Root cause

The fence regex `/```([\s\S]*?)```/g` had no line anchoring. A literal triple backtick inside a code block's content — e.g. a regex pattern with ` ``` ` in a lookbehind, a script that documents fences, embedded markdown-in-markdown — terminated the outer fence at the wrong place. The leaked tail went through the bold/italic/inline-code passes, where:

- `**`/`*` got consumed as bold/italic markers, eating literal `*` characters
- `<strong>` HTML conversion left stray `</strong>` literal tags visible
- Single backticks formed unbalanced spans, splitting words
- Whole sentences appeared inside the wrong code block (or no code block at all)

## Fix

Anchor the fence regex per **CommonMark §4.5**: opening fence must start a line (with up to 3 spaces of indent), closing fence must also start a line. The same fix applied at all 3 sites where fence regex appears:

| Site | File:Line | Function | Purpose |
|---|---|---|---|
| 1 | `static/ui.js:1559` | `renderMd()` | Assistant message renderer (the main bug) |
| 2 | `static/ui.js:66` | `_renderUserFencedBlocks()` | User message renderer |
| 3 | `static/ui.js:2599` | `_stripForTTS()` | Pre-strip before text-to-speech |

Plus the Python mirror in `tests/test_sprint16.py` (the test driver).

**Final pattern:**
```
(^|\n)[ ]{0,3}```(?:([\s\S]*?)\n)?[ ]{0,3}```(?=\n|$)
```

The `(?:...\n)?` non-capturing group makes the body optional so empty fences (`` ```\n``` ``) still match. The `lead` group (`^|\n`) is prefixed back to the stash-token return so paragraphs above don't bleed into the `<pre>` block.

## Empirical verification

Live browser test on Cygnus's exact input, before and after — DevTools console:

**Before (v0.50.263):**
```
<p>Here's the regex:</p><div class="pre-header">regex</div><pre><code class="language-regex">(?<!\n)(?<!(?:^|\n)[ \t]*(?:</code></pre>
[^\n]<em>|%%[ \t]</em>(?:\n|$)))
```
↑ `<pre>` truncated mid-content, `*` consumed as `<em>`, trailing ``` orphaned in paragraph.

**After (this PR):**
```
<p>Here's the regex:</p><div class="pre-header">regex</div><pre><code class="language-regex">(?<!\n)(?<!(?:^|\n)[ \t]*(?:```[^\n]*|%%[ \t]*(?:\n|$)))</code></pre><p>uses <strong>bold</strong> for emphasis.</p>
```
↑ Single intact `<pre>`, inner ``` preserved as literal, regex `*` quantifier survives, bold renders correctly after the fence.

## 8-scenario behavioral matrix (live JS)

| Scenario | `<pre>` count | `<strong>` balanced | Orphan ` ``` ` outside `<pre>` |
|---|:---:|:---:|:---:|
| Cygnus regex repro | 1 | ✅ | ❌ (none) |
| Empty fence (`` ```\n``` ``) | 1 | ✅ | ❌ |
| Empty fence with lang | 1 | ✅ | ❌ |
| Inline ``` mid-paragraph | 0 | ✅ | ✅ (literal text) |
| Two adjacent blocks | 2 | ✅ | ❌ |
| Diff with inner ``` | 1 | ✅ | ❌ |
| Partial fence (streaming) | 0 | ✅ | ✅ (literal) |
| Fence with language tag | 1 | ✅ | ❌ |

## Edge cases verified

- ✅ Existing fences not preceded by a blank line (CommonMark allows this)
- ✅ Language tags preserved (`` ```python ``)
- ✅ Mermaid blocks, diff/patch blocks, JSON/YAML tree-views — all live in same callback, unaffected
- ✅ Up to 3 spaces of indent allowed (CommonMark indent rule)
- ✅ 4-space indent does NOT match (would be indented code block in strict CommonMark; we just don't false-positive)
- ✅ Empty fences (`` ```\n``` ``) — non-capturing optional group preserves this
- ✅ Streaming partial input (no closing fence yet) — no false `<pre>` emitted
- ✅ Trailing whitespace handled by `(?=\n|$)` lookahead

## Tests

20 new regression tests in `tests/test_issue1438_fence_anchoring.py`:
- Cygnus's exact repro (structural + balance properties)
- Inline triple-backtick in paragraph (must not open fence)
- 3-back-tick at end of sentence
- Partial/streaming fence (no close yet — must not match)
- Simple python fence, fence after paragraph, fence at EOF, two adjacent blocks
- 3-space indent allowed, 4-space rejected
- Bold/italic/inline-code after fence
- Source-level regex guards on all 3 patched sites
- `lead+` prefix invariant on both renderMd and _renderUserFencedBlocks
- No-unanchored-form-remains check (catches partial regression)
- Diff/patch fence with inline ``` in content (source-level)

**Full pytest:** 3678 passed (+20), 2 skipped, 3 xpassed, 0 failures.
**Browser sanity (run-browser-tests.sh):** all 20 + 11 API checks green (verified locally).

## Stats

- **Files**: 4 (`static/ui.js`, `tests/test_sprint16.py`, `tests/test_issue1438_fence_anchoring.py`, `CHANGELOG.md`)
- **Diff**: +328/-9
- **Sites patched**: 3 (renderMd, _renderUserFencedBlocks, _stripForTTS) + Python mirror
- **Test count**: 3658 → 3678 (+20)

## Severity

**P1.** Hits any assistant message that emits triple backticks inside a code block — regex patterns with fence-like syntax, scripts that document fences, embedded markdown-in-markdown, code-about-code. Most LLM responses about markdown, regex parsers, or shell tooling will trigger this. Cygnus's report is the second time this kind of cascade has been observed (different shape than the diff/patch list-injection bug fixed in PR #1190 / v0.50.231).

## Reported by

**Cygnus** (please ping in replies) in Discord, relayed by @AvidFuturist (May 1 2026 18:58 PT).

Closes #1438
