### PR TITLE
Fix IME composition Enter sending message prematurely (East Asian input)

### DIFF
--- a/static/boot.js
+++ b/static/boot.js
@@ -793,6 +793,15 @@ $('msg').addEventListener('input',()=>{
     hideCmdDropdown();
   }
 });
+// Track IME composition for East Asian input. Safari fires the committing
+// keydown AFTER compositionend with isComposing=false, so we also keep a
+// manual flag and reset it on the next tick to swallow that trailing Enter.
+let _imeComposing=false;
+(()=>{const _c=$('msg');if(!_c)return;
+  _c.addEventListener('compositionstart',()=>{_imeComposing=true;});
+  _c.addEventListener('compositionend',()=>{setTimeout(()=>{_imeComposing=false;},0);});
+})();
+function _isImeEnter(e){return e.isComposing||e.keyCode===229||_imeComposing;}
 $('msg').addEventListener('keydown',e=>{
   // Autocomplete navigation when dropdown is open
   const dd=$('cmdDropdown');
@@ -803,7 +812,7 @@ $('msg').addEventListener('keydown',e=>{
     if(e.key==='Tab'){e.preventDefault();selectCmdDropdownItem();return;}
     if(e.key==='Escape'){e.preventDefault();hideCmdDropdown();return;}
     if(e.key==='Enter'&&!e.shiftKey){
-      if(e.isComposing){return;}
+      if(_isImeEnter(e)){return;}
       e.preventDefault();
       selectCmdDropdownItem();
       return;
@@ -815,7 +824,7 @@ $('msg').addEventListener('keydown',e=>{
   // The 'ctrl+enter' setting also uses this behavior (Enter = newline).
   // Users can override in Settings by explicitly choosing 'enter' mode.
   if(e.key==='Enter'){
-    if(e.isComposing){return;}
+    if(_isImeEnter(e)){return;}
     const _mobileDefault=matchMedia('(pointer:coarse)').matches&&window._sendKey==='enter';
     if(window._sendKey==='ctrl+enter'||_mobileDefault){
       if(e.ctrlKey||e.metaKey){e.preventDefault();send();}

--- a/tests/test_ime_composition.py
+++ b/tests/test_ime_composition.py
@@ -17,17 +17,46 @@ def _ime_guarded_enter_pattern(event_var_pattern, require_no_shift=False):
     )
 
 
+def _ime_helper_enter_pattern(event_var_pattern, require_no_shift=False):
+    """Match Enter handlers guarded by the _isImeEnter() helper."""
+    no_shift = rf"\s*&&\s*!\s*{event_var_pattern}\.shiftKey" if require_no_shift else ""
+    return (
+        rf"if\s*\(\s*{event_var_pattern}\.key\s*===\s*'Enter'{no_shift}\s*\)\s*\{{\s*"
+        rf"if\s*\(\s*_isImeEnter\s*\(\s*{event_var_pattern}\s*\)\s*\)\s*"
+        rf"(?:\{{\s*return\s*;?\s*\}}|return\s*;?)"
+    )
+
+
+def test_boot_js_ime_helper_is_defined():
+    """_isImeEnter must combine isComposing, keyCode===229, and the manual flag."""
+    # Extract the function body to scope all assertions within it.
+    fn_body_match = re.search(
+        r"function\s+_isImeEnter\s*\(\s*e\s*\)\s*\{([^}]*)\}",
+        BOOT_JS,
+    )
+    assert fn_body_match, "_isImeEnter helper must be defined in static/boot.js"
+    fn_body = fn_body_match.group(1)
+    assert re.search(r"e\.isComposing", fn_body), \
+        "_isImeEnter must check e.isComposing in static/boot.js"
+    assert re.search(r"keyCode\s*===\s*229", fn_body), \
+        "_isImeEnter must check keyCode===229 in static/boot.js"
+    assert re.search(r"_imeComposing", fn_body), \
+        "_isImeEnter must check the manual _imeComposing flag in static/boot.js"
+
+
 def test_boot_chat_enter_send_respects_ime_composition():
+    # Chat composer Enter handler: guarded by _isImeEnter()
     assert re.search(
-        _ime_guarded_enter_pattern("e"),
+        _ime_helper_enter_pattern("e"),
         BOOT_JS,
         re.DOTALL,
-    ), "Chat composer Enter handler must ignore IME composition Enter in static/boot.js"
+    ), "Chat composer Enter handler must ignore IME composition Enter via _isImeEnter() in static/boot.js"
+    # Command dropdown Enter handler: guarded by _isImeEnter() with !shiftKey
     assert re.search(
-        _ime_guarded_enter_pattern("e", require_no_shift=True),
+        _ime_helper_enter_pattern("e", require_no_shift=True),
         BOOT_JS,
         re.DOTALL,
-    ), "Command dropdown Enter handler must ignore IME composition Enter in static/boot.js"
+    ), "Command dropdown Enter handler must ignore IME composition Enter via _isImeEnter() in static/boot.js"
 
 
 def test_ui_enter_submit_paths_respect_ime_composition():


### PR DESCRIPTION
## Problem

When using East Asian IMEs (Japanese, Chinese, Korean), pressing **Enter** to confirm an IME composition candidate sends the message instead of just accepting the conversion. This makes the composer effectively unusable for native input — the user has to copy/paste from another app.

## Root cause

`static/boot.js` already guards on `e.isComposing` in the `#msg` keydown handler. That works on Chrome/Firefox, where `keydown` for the committing Enter fires *before* `compositionend`. **It fails on Safari**, where the committing `keydown` fires *after* `compositionend` with `isComposing=false`, so the Enter slips through.

## Fix

Three guards instead of one:

1. `e.isComposing` — covers Chrome/Firefox (existing behavior).
2. `e.keyCode === 229` — covers IME virtual key on broader browser/IME combos.
3. A manual `_imeComposing` flag set on `compositionstart` and reset on the *next tick* after `compositionend` — covers the Safari race.

Combined into one `_isImeEnter(e)` helper used in both the autocomplete-dropdown Enter path and the send Enter path.

## Test plan

- [ ] macOS Safari + Japanese IME (Hiragana): type かんじ, hit Enter to commit kanji selection — message does NOT send.
- [ ] macOS Chrome + Japanese IME: same.
- [ ] macOS Safari + Chinese (Pinyin): type a syllable, hit Enter to pick candidate — message does NOT send.
- [ ] Korean IME: confirm composition with Enter — message does NOT send.
- [ ] Plain English: Enter still sends (per send-key preference); Shift+Enter still inserts newline.
- [ ] Slash-command dropdown open: IME Enter doesn't trigger autocomplete; non-IME Enter still selects.

## Notes

Verified the fix is small (11 insertions / 2 deletions, single file) and additive — no behavior change for non-IME users.

🤖 Co-authored with [Claude Code](https://claude.com/claude-code)