### PR TITLE
Fix _norm_model_id to properly strip provider prefixes

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -1506,10 +1506,13 @@ def get_available_models() -> dict:
 
         def _norm_model_id(model_id: str) -> str:
             s = str(model_id or "").strip().lower()
+            # Strip @provider: prefix (e.g., @custom:jingdong:GLM-5 -> GLM-5)
             if s.startswith("@") and ":" in s:
-                s = s.split(":", 1)[1]
+                # Split on all colons and take the last part
+                s = s.split(":")[-1]
+            # Strip provider/model prefix (e.g., custom:jingdong/GLM-5 -> GLM-5)
             if "/" in s:
-                s = s.split("/", 1)[1]
+                s = s.split("/")[-1]
             return s.replace("-", ".")
 
         def _build_configured_model_badges() -> dict[str, dict[str, str]]:
@@ -2079,9 +2082,8 @@ def get_available_models() -> dict:
                 )
 
         if default_model:
-            _norm = lambda mid: (mid.split("/", 1)[-1] if "/" in mid else mid).replace("-", ".")
-            all_ids_norm = {_norm(m["id"]) for g in groups for m in g.get("models", [])}
-            if _norm(default_model) not in all_ids_norm:
+            all_ids_norm = {_norm_model_id(m["id"]) for g in groups for m in g.get("models", [])}
+            if _norm_model_id(default_model) not in all_ids_norm:
                 label = _get_label_for_model(default_model, groups)
                 target_display = (
                     _PROVIDER_DISPLAY.get(active_provider, active_provider or "").lower()


### PR DESCRIPTION
## Summary

Fixes #1453 

The `_norm_model_id` function was using `split(':', 1)[1]` which only removed the first colon-separated segment, leaving provider names in the normalized model ID.

## Problem

For `@custom:jingdong:GLM-5`:
- **Before**: `jingdong:glm.5` (incorrect)
- **After**: `glm.5` (correct)

This caused the default model injection check to fail, resulting in a duplicate "Default" group being added to the model list.

## Changes

1. `_norm_model_id`: Use `split(':')[-1]` to get the last segment after all colons
2. `_norm_model_id`: Use `split('/')[-1]` consistently for slash-separated paths
3. Default model check: Replace local `_norm` lambda with `_norm_model_id` function call

## Testing

- All 20 existing tests in `tests/test_model_resolver.py` pass
- Verified fix with custom provider configuration

## Before

Model dropdown would show:
```
jingdong:
  @custom:jingdong:GLM-5
Default:
  GLM-5  <-- Duplicate!
```

## After

Model dropdown correctly shows:
```
jingdong:
  @custom:jingdong:GLM-5
```