### PR TITLE
fix: use pushState instead of replaceState for chat navigation

### DIFF
--- a/static/sessions.js
+++ b/static/sessions.js
@@ -697,7 +697,7 @@ function _setActiveSessionUrl(sid){
   if(typeof window==='undefined'||!window.history||!sid) return;
   const next=_sessionUrlForSid(sid);
   if(next && next!==(window.location.pathname+window.location.search+window.location.hash)){
-    window.history.replaceState({session_id:sid},'',next);
+    window.history.pushState({session_id:sid},'',next);
   }
 }
 


### PR DESCRIPTION
Session switching used history.replaceState, which overwrites the current browser history entry instead of creating a new one. Navigating chat A then chat B produced a history stack with only one entry, causing the browser Back button to skip over chat A entirely.

This change switches _setActiveSessionUrl to pushState so each chat visit adds a proper history entry. Browser Back/Forward now correctly steps through every chat in navigation order.

The URL (/session/<sid>) was already the primary session-restore mechanism on boot and on popstate — this aligns the navigation-time behavior with the restore behavior.