### PR TITLE
fix: sync workspace chip immediately on chat switch + searchable sorted dropdown

### DIFF
--- a/static/i18n.js
+++ b/static/i18n.js
@@ -120,6 +120,8 @@ const LOCALES = {
     model_search_placeholder: 'Search models…',
     model_search_no_results: 'No models found',
     model_group_configured: 'Configured',
+    ws_search_placeholder: 'Search workspaces…',
+    ws_no_results: 'No workspaces found',
     model_scope_advisory: 'Applies to this conversation from your next message.',
     model_scope_toast: 'Applies to this conversation from your next message.',
     // commands.js
@@ -998,6 +1000,8 @@ const LOCALES = {
     model_search_placeholder: 'モデルを検索…',
     model_search_no_results: 'モデルが見つかりません',
     model_group_configured: '設定済み',
+    ws_search_placeholder: 'ワークスペースを検索…',
+    ws_no_results: 'ワークスペースが見つかりません',
     model_scope_advisory: '次回のメッセージからこの会話に適用されます。',
     model_scope_toast: '次回のメッセージからこの会話に適用されます。',
     // commands.js
@@ -1922,6 +1926,8 @@ const LOCALES = {
     focus_label: 'Фокус',
     model_search_no_results: 'Модели не найдены',
     model_group_configured: 'Настроенные',
+    ws_search_placeholder: 'Поиск рабочих пространств…',
+    ws_no_results: 'Рабочие пространства не найдены',
     model_search_placeholder: 'Поиск моделей…',
     model_scope_advisory: 'Применяется к этой беседе со следующего сообщения.',
     session_toolsets: 'Session Toolsets', // TODO: translate
@@ -2670,6 +2676,8 @@ const LOCALES = {
     model_search_placeholder: 'Buscar modelos…',
     model_search_no_results: 'No se encontraron modelos',
     model_group_configured: 'Configurados',
+    ws_search_placeholder: 'Buscar espacios de trabajo…',
+    ws_no_results: 'No se encontraron espacios de trabajo',
     session_toolsets: 'Session Toolsets', // TODO: translate
     session_toolsets_desc: 'Restrict available tools for this session (blank = use global config)', // TODO: translate
     session_toolsets_global: 'Global (default)', // TODO: translate
@@ -3875,6 +3883,8 @@ const LOCALES = {
     model_search_placeholder: 'Modelle suchen…',
     model_search_no_results: 'Keine Modelle gefunden',
     model_group_configured: 'Konfiguriert',
+    ws_search_placeholder: 'Arbeitsbereiche suchen…',
+    ws_no_results: 'Keine Arbeitsbereiche gefunden',
     session_toolsets: 'Session Toolsets', // TODO: translate
     session_toolsets_desc: 'Restrict available tools for this session (blank = use global config)', // TODO: translate
     session_toolsets_global: 'Global (default)', // TODO: translate
@@ -4298,6 +4308,8 @@ const LOCALES = {
     model_search_placeholder: '\u641c\u7d22\u6a21\u578b\u2026',
     model_search_no_results: '\u672a\u627e\u5230\u6a21\u578b',
     model_group_configured: '已配置',
+    ws_search_placeholder: '搜索工作区…',
+    ws_no_results: '未找到工作区',
     session_toolsets: 'Session Toolsets', // TODO: translate
     session_toolsets_desc: 'Restrict available tools for this session (blank = use global config)', // TODO: translate
     session_toolsets_global: 'Global (default)', // TODO: translate
@@ -5532,6 +5544,8 @@ const LOCALES = {
     model_custom_placeholder: '\u4f8b\u5982 openai/gpt-5.4',
     model_search_no_results: '\u627e\u4e0d\u5230\u6a21\u578b',
     model_group_configured: '已設定',
+    ws_search_placeholder: '搜尋工作區…',
+    ws_no_results: '找不到工作區',
     model_search_placeholder: '\u641c\u5c0b\u6a21\u578b\u2026',
     session_toolsets: 'Session Toolsets', // TODO: translate
     session_toolsets_desc: 'Restrict available tools for this session (blank = use global config)', // TODO: translate
@@ -6011,6 +6025,8 @@ const LOCALES = {
     session_toolsets_failed: 'Failed to update toolsets: ', // TODO: translate
     model_search_no_results: 'Nenhum modelo encontrado',
     model_group_configured: 'Configurados',
+    ws_search_placeholder: 'Buscar espaços de trabalho…',
+    ws_no_results: 'Nenhum espaço de trabalho encontrado',
     // commands.js
     cmd_clear: 'Limpar mensagens da conversa',
     cmd_compress: 'Comprimir manualmente o contexto (uso: /compress [tópico])',
@@ -6768,6 +6784,8 @@ const LOCALES = {
     session_toolsets_failed: 'Failed to update toolsets: ', // TODO: translate
     model_search_no_results: 'No models found',
     model_group_configured: '구성됨',
+    ws_search_placeholder: '워크스페이스 검색…',
+    ws_no_results: '워크스페이스를 찾을 수 없습니다',
     model_scope_advisory: '다음 메시지부터 이 대화에 적용됩니다.',
     model_scope_toast: '다음 메시지부터 이 대화에 적용됩니다.',
     // commands.js

--- a/static/panels.js
+++ b/static/panels.js
@@ -1647,13 +1647,63 @@ function _positionProfileDropdown(){
 function renderWorkspaceDropdownInto(dd, workspaces, currentWs){
   if(!dd)return;
   dd.innerHTML='';
-  for(const w of workspaces){
-    const opt=document.createElement('div');
-    opt.className='ws-opt'+(w.path===currentWs?' active':'');
-    opt.innerHTML=`<span class="ws-opt-name">${esc(w.name)}</span><span class="ws-opt-path">${esc(w.path)}</span>`;
-    opt.onclick=()=>switchToWorkspace(w.path,w.name);
-    dd.appendChild(opt);
+
+  // ── Search row ──────────────────────────────────────────────────────────
+  const searchRow=document.createElement('div');
+  searchRow.className='ws-search-row';
+  searchRow.innerHTML=`<input class="ws-search-input" type="text" placeholder="${esc(t('ws_search_placeholder')||'Search workspaces…')}" spellcheck="false" autocomplete="off"><button class="ws-search-clear" title="Clear search">${li('x',10)}</button>`;
+  const si=searchRow.querySelector('.ws-search-input');
+  const sc=searchRow.querySelector('.ws-search-clear');
+  dd.appendChild(searchRow);
+
+  // ── Workspace list ──────────────────────────────────────────────────────
+  // Sort alphabetically by name (case-insensitive) before rendering.
+  const sorted=[...workspaces].sort((a,b)=>(a.name||'').localeCompare(b.name||''));
+  const listContainer=document.createElement('div');
+  listContainer.className='ws-list-container';
+  dd.appendChild(listContainer);
+
+  // Pre-create noResults element so filterWs can reference it safely from the start.
+  const noResults=document.createElement('div');
+  noResults.className='ws-no-results';
+  noResults.textContent=t('ws_no_results')||'No workspaces found';
+  noResults.style.display='none';
+
+  function filterWs(term){
+    term=(term||'').trim().toLowerCase();
+    let visible=0;
+    const opts=listContainer.querySelectorAll('.ws-opt');
+    for(const opt of opts){
+      const name=(opt.dataset.name||'').toLowerCase();
+      const path=(opt.dataset.path||'').toLowerCase();
+      const show=!term||name.includes(term)||path.includes(term);
+      opt.style.display=show?'':'none';
+      if(show) visible++;
+    }
+    noResults.style.display=visible?'':'none';
   }
+
+  function renderList(){
+    listContainer.innerHTML='';
+    for(const w of sorted){
+      const opt=document.createElement('div');
+      opt.className='ws-opt'+(w.path===currentWs?' active':'');
+      opt.dataset.name=w.name||'';
+      opt.dataset.path=w.path||'';
+      opt.innerHTML=`<span class="ws-opt-name">${esc(w.name)}</span><span class="ws-opt-path">${esc(w.path)}</span>`;
+      opt.onclick=()=>switchToWorkspace(w.path,w.name);
+      listContainer.appendChild(opt);
+    }
+    listContainer.appendChild(noResults);
+  }
+
+  renderList();
+  filterWs('');
+
+  si.addEventListener('input',()=>{ filterWs(si.value); });
+  sc.addEventListener('click',()=>{ si.value=''; filterWs(''); si.focus(); });
+
+  // ── Footer actions ────────────────────────────────────────────────────────
   dd.appendChild(document.createElement('div')).className='ws-divider';
   dd.appendChild(_renderWorkspaceAction(
     t('workspace_choose_path'),

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -380,6 +380,9 @@ async function loadSession(sid){
   S.session=data.session;
   S.session._modelResolutionDeferred=true;
   S.lastUsage={...(data.session.last_usage||{})};
+  // Sync workspace display immediately so the chip label reflects the new session's workspace
+  // before any async message-loading begins (mirrors how model is handled).
+  if(typeof syncTopbar==='function') syncTopbar();
   _setSessionViewedCount(S.session.session_id, Number(data.session.message_count || 0));
   _clearSessionCompletionUnread(S.session.session_id);
   localStorage.setItem('hermes-webui-session',S.session.session_id);

--- a/static/style.css
+++ b/static/style.css
@@ -1401,6 +1401,13 @@
 .ws-divider{height:1px;background:var(--border);margin:4px 0;}
 .ws-manage{color:var(--muted);font-size:12px;}
 .ws-opt-action{display:flex;flex-direction:row;align-items:center;gap:8px;}
+.ws-search-row{display:flex;align-items:center;gap:6px;padding:8px 10px 10px;}
+.ws-search-input{flex:1;background:var(--code-bg);border:1px solid var(--border2);border-radius:6px;color:var(--text);padding:6px 8px;font-size:12px;outline:none;font-family:inherit;min-width:0;}
+.ws-search-input:focus{border-color:var(--accent);}
+.ws-search-clear{flex-shrink:0;width:22px;height:22px;border:1px solid var(--border2);border-radius:50%;background:transparent;color:var(--muted);cursor:pointer;display:inline-flex;align-items:center;justify-content:center;transition:color .12s,border-color .12s;font-size:10px;}
+.ws-search-clear:hover{color:var(--text);border-color:var(--border);}
+.ws-list-container{overflow-y:auto;max-height:260px;}
+.ws-no-results{padding:12px 14px;text-align:center;color:var(--muted);font-size:12px;}
 .ws-opt-icon{display:inline-flex;align-items:center;justify-content:center;opacity:.82;flex-shrink:0;}
 .ws-opt-meta{font-size:11px;color:var(--muted);}
 /* ── Workspace management panel ── */


### PR DESCRIPTION
Fixes the workspace display lagging behind after switching chats, and adds alphabetical sort + search to the workspace dropdown.

- sessions.js: Call syncTopbar() immediately after S.session = data.session in loadSession() so the workspace chip label reflects the correct session workspace before async message-loading begins
- panels.js: Rewrite renderWorkspaceDropdownInto() to sort workspaces alphabetically by name (localeCompare) and add a search input that filters by name or path in real-time; clear button resets filter; "No workspaces found" shown when nothing matches
- style.css: Add .ws-search-row/.ws-search-input/.ws-search-clear/.ws-no-results styles matching the model dropdown aesthetic
- api/workspace.py: Sort load_workspaces() output by name before returning so the backend enforces consistent alphabetical order