### PR TITLE
fix: reuse inflight session stream

### DIFF
--- a/static/messages.js
+++ b/static/messages.js
@@ -283,12 +283,19 @@ function closeLiveStream(sessionId, streamId){
 function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
   if(!activeSid||!streamId) return;
   const reconnecting=!!options.reconnecting;
-  closeLiveStream(activeSid);
   if(!INFLIGHT[activeSid]) INFLIGHT[activeSid]={messages:[...S.messages],uploaded:[...uploaded],toolCalls:[]};
   else {
     if(uploaded.length) INFLIGHT[activeSid].uploaded=[...uploaded];
     if(!Array.isArray(INFLIGHT[activeSid].toolCalls)) INFLIGHT[activeSid].toolCalls=[];
   }
+  const existingLive=LIVE_STREAMS[activeSid];
+  if(
+    existingLive&&existingLive.streamId===streamId&&existingLive.source&&
+    (typeof EventSource==='undefined'||existingLive.source.readyState!==EventSource.CLOSED)
+  ){
+    return;
+  }
+  closeLiveStream(activeSid);
 
   let assistantText='';
   let reasoningText='';

--- a/static/messages.js
+++ b/static/messages.js
@@ -291,6 +291,8 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
   const existingLive=LIVE_STREAMS[activeSid];
   if(
     existingLive&&existingLive.streamId===streamId&&existingLive.source&&
+    // A same-stream transport can be reused unless the browser has already
+    // marked it closed; closed streams must still fall through to reopen.
     (typeof EventSource==='undefined'||existingLive.source.readyState!==EventSource.CLOSED)
   ){
     return;

--- a/tests/test_inflight_stream_reuse.py
+++ b/tests/test_inflight_stream_reuse.py
@@ -35,7 +35,7 @@ def test_attach_live_stream_reuses_existing_same_stream_transport():
     therefore reuse the existing transport.
     """
     body = _function_body(MESSAGES_JS, "attachLiveStream")
-    close_pos = body.find("closeLiveStream(activeSid)")
+    close_pos = body.find("\n  closeLiveStream(activeSid);\n")
     reuse_pos = body.find("const existingLive=LIVE_STREAMS[activeSid]")
     assert reuse_pos != -1, "attachLiveStream() should check for an existing live stream"
     assert close_pos != -1, "attachLiveStream() should still close stale/different streams"
@@ -43,6 +43,32 @@ def test_attach_live_stream_reuses_existing_same_stream_transport():
     assert "existingLive.streamId===streamId" in body
     assert "existingLive.source.readyState!==EventSource.CLOSED" in body
     assert "return" in body[reuse_pos:close_pos]
+
+
+def test_attach_live_stream_updates_uploads_before_same_stream_reuse():
+    """Reusing transport must not skip per-session uploaded attachment state."""
+    body = _function_body(MESSAGES_JS, "attachLiveStream")
+    upload_pos = body.find("if(uploaded.length) INFLIGHT[activeSid].uploaded=[...uploaded]")
+    reuse_pos = body.find("const existingLive=LIVE_STREAMS[activeSid]")
+    close_pos = body.find("\n  closeLiveStream(activeSid);\n")
+    assert upload_pos != -1
+    assert reuse_pos != -1
+    assert close_pos != -1
+    assert upload_pos < reuse_pos < close_pos
+
+
+def test_attach_live_stream_different_stream_still_reopens_transport():
+    """A new stream id for the same session must not reuse the old transport."""
+    body = _function_body(MESSAGES_JS, "attachLiveStream")
+    reuse_pos = body.find("const existingLive=LIVE_STREAMS[activeSid]")
+    close_pos = body.find("\n  closeLiveStream(activeSid);\n")
+    assert reuse_pos != -1
+    assert close_pos != -1
+    reuse_block = body[reuse_pos:close_pos]
+    assert "existingLive.streamId===streamId" in reuse_block
+    assert "existingLive.streamId!==streamId" not in reuse_block
+    assert "return" in reuse_block
+    assert reuse_pos < close_pos
 
 
 def test_load_session_reattach_path_uses_attach_live_stream_for_running_sessions():

--- a/tests/test_inflight_stream_reuse.py
+++ b/tests/test_inflight_stream_reuse.py
@@ -1,0 +1,56 @@
+"""Regression tests for preserving live streams across session switches."""
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+MESSAGES_JS = (REPO_ROOT / "static" / "messages.js").read_text(encoding="utf-8")
+SESSIONS_JS = (REPO_ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
+
+
+def _function_body(src: str, name: str) -> str:
+    marker = f"function {name}("
+    start = src.find(marker)
+    assert start != -1, f"{name}() not found"
+    brace = src.find("){", start)
+    assert brace != -1, f"{name}() body not found"
+    brace += 1
+    depth = 1
+    i = brace + 1
+    while i < len(src) and depth:
+        if src[i] == "{":
+            depth += 1
+        elif src[i] == "}":
+            depth -= 1
+        i += 1
+    assert depth == 0, f"{name}() body did not close"
+    return src[brace + 1 : i - 1]
+
+
+def test_attach_live_stream_reuses_existing_same_stream_transport():
+    """Returning to a running session must not tear down its same SSE stream.
+
+    The server-side stream queue is not a replay log. If a sidebar switch back
+    to the running session closes and reopens the same EventSource, there is a
+    narrow window where stream events can be consumed by the old transport but
+    no longer represented in the pane/cache. The same session/stream pair should
+    therefore reuse the existing transport.
+    """
+    body = _function_body(MESSAGES_JS, "attachLiveStream")
+    close_pos = body.find("closeLiveStream(activeSid)")
+    reuse_pos = body.find("const existingLive=LIVE_STREAMS[activeSid]")
+    assert reuse_pos != -1, "attachLiveStream() should check for an existing live stream"
+    assert close_pos != -1, "attachLiveStream() should still close stale/different streams"
+    assert reuse_pos < close_pos, "same-stream reuse must run before closeLiveStream(activeSid)"
+    assert "existingLive.streamId===streamId" in body
+    assert "existingLive.source.readyState!==EventSource.CLOSED" in body
+    assert "return" in body[reuse_pos:close_pos]
+
+
+def test_load_session_reattach_path_uses_attach_live_stream_for_running_sessions():
+    """The session switch-back path should still route through attachLiveStream()."""
+    body = _function_body(SESSIONS_JS, "loadSession")
+    active_pos = body.find("const activeStreamId=S.session.active_stream_id||null")
+    reattach_pos = body.find("attachLiveStream(sid, activeStreamId")
+    assert active_pos != -1
+    assert reattach_pos != -1
+    assert active_pos < reattach_pos
+    assert "{reconnecting:true}" in body[reattach_pos : reattach_pos + 200]


### PR DESCRIPTION
## Thinking Path

- Hermes WebUI supports long-running chat turns.
- Users may switch away from a running session and later return to it.
- The active pane and the running session are different concepts.
- Returning to the same running session should not tear down the existing SSE transport for that same session/stream pair.
- This PR keeps that transport alive when `attachLiveStream()` is called again for the same active stream.

## What Changed

- `attachLiveStream()` now checks `LIVE_STREAMS[session_id]` before closing an existing stream.
- If the existing live stream has the same `streamId` and is not closed, the function reuses it instead of closing/reopening the `EventSource`.
- The `INFLIGHT[session_id]` state is still initialized/updated before the reuse check so session switch-back can restore the active pane's running state.
- Added a regression test that pins the same-stream reuse invariant and the existing `loadSession()` reattach path.

## Why It Matters

SSE stream events are not a replay log. Tearing down and reopening the same running stream during sidebar navigation creates a small timing window where events can be consumed by the old transport but not reflected back into the current pane/cache.

This is the first small step in improving reliability for in-flight session switching. It follows the direction in #1466: keep the currently viewed pane separate from per-session runtime state.

## Verification

```bash
node --check static/messages.js static/sessions.js
python -m py_compile api/routes.py api/models.py api/agent_sessions.py
pytest tests/test_inflight_stream_reuse.py tests/test_issue660.py tests/test_session_cross_tab_sync.py -q
```

Result:

```text
21 passed
```

Also checked the added diff for accidental non-ASCII text:

```text
non_ascii_added_lines=0
```

## Risks / Follow-ups

- This intentionally does not centralize all per-session runtime state.
- Follow-ups from #1466 should cover per-session inflight cleanup, approval/clarify state, and background completion/sidebar refresh.
- If a browser reports an existing `EventSource` as closed, the old close/reopen path is still used.

## Model Used

OpenAI GPT-5.5 via Hermes Agent.

Refs #1466
