### PR TITLE
Fix batch session actions and in-flight reload recovery

### DIFF
--- a/static/boot.js
+++ b/static/boot.js
@@ -1298,7 +1298,11 @@ function applyBotName(){
       // subsequent refresh will also run loadSession() → loadDir() → files stay visible.
       // Removing it here caused the file tree to go blank on the second refresh
       // because the "no saved session" path never calls loadDir (#workspace-files).
-      if(S.session && (S.session.message_count||0) === 0){
+      const _restoredInFlight = S.session && (
+        S.session.active_stream_id ||
+        S.session.pending_user_message
+      );
+      if(S.session && (S.session.message_count||0) === 0 && !_restoredInFlight){
         S.session=null; S.messages=[];
         S._bootReady=true;
         // Restore panel pref before syncing so the workspace panel stays visible

--- a/static/i18n.js
+++ b/static/i18n.js
@@ -7517,7 +7517,13 @@ function resolvePreferredLocale(primary, fallback) {
 function t(key, ...args) {
   const val = _locale[key] ?? LOCALES.en[key];
   if (val === undefined) return key;  // final fallback: return key itself
-  return typeof val === 'function' ? val(...args) : val;
+  if (typeof val === 'function') return val(...args);
+  if (args.length) {
+    return String(val).replace(/\{(\d+)\}/g, (match, idx) => (
+      Object.prototype.hasOwnProperty.call(args, idx) ? String(args[idx]) : match
+    ));
+  }
+  return val;
 }
 
 /**

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -753,13 +753,13 @@ function _renderBatchActionBar(){
   const bar=$('batchActionBar');if(!bar)return;
   bar.innerHTML='';bar.style.display=_selectedSessions.size>0?'flex':'none';
   const countBadge=document.createElement('span');countBadge.className='batch-count';
-  countBadge.textContent=String(t('session_selected_count')).replace('{0}',_selectedSessions.size);bar.appendChild(countBadge);
+  countBadge.textContent=t('session_selected_count',_selectedSessions.size);bar.appendChild(countBadge);
   // Archive
   const archiveBtn=document.createElement('button');archiveBtn.className='batch-action-btn';
   archiveBtn.textContent=t('session_batch_archive');
   archiveBtn.onclick=async()=>{
     const ids=[..._selectedSessions];
-    const ok=await showConfirmDialog({message:String(t('session_batch_archive_confirm')).replace('{0}',ids.length),confirmLabel:t('session_batch_archive'),danger:true});
+    const ok=await showConfirmDialog({message:t('session_batch_archive_confirm',ids.length),confirmLabel:t('session_batch_archive'),danger:true});
     if(!ok)return;
     try{await Promise.all(ids.map(sid=>api('/api/session/archive',{method:'POST',body:JSON.stringify({session_id:sid,archived:true})})));
       showToast(t('session_archived'));exitSessionSelectMode();await renderSessionList();
@@ -774,7 +774,7 @@ function _renderBatchActionBar(){
   deleteBtn.textContent=t('session_batch_delete');
   deleteBtn.onclick=async()=>{
     const ids=[..._selectedSessions];
-    const ok=await showConfirmDialog({message:String(t('session_batch_delete_confirm')).replace('{0}',ids.length),confirmLabel:t('delete_title'),danger:true});
+    const ok=await showConfirmDialog({message:t('session_batch_delete_confirm',ids.length),confirmLabel:t('delete_title'),danger:true});
     if(!ok)return;
     try{await Promise.all(ids.map(sid=>api('/api/session/delete',{method:'POST',body:JSON.stringify({session_id:sid})})));
       if(S.session&&ids.includes(S.session.session_id)){

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -722,6 +722,14 @@ function toggleSessionSelect(sid){
   const item=cb?cb.closest('.session-item'):null;
   if(item){item.classList.toggle('selected',_selectedSessions.has(sid));if(cb)cb.checked=_selectedSessions.has(sid);}
 }
+function setSessionSelected(sid, selected){
+  if(selected) _selectedSessions.add(sid);
+  else _selectedSessions.delete(sid);
+  _updateBatchActionBar();
+  const cb=document.querySelector('.session-select-cb[data-sid="'+sid+'"]');
+  const item=cb?cb.closest('.session-item'):null;
+  if(item){item.classList.toggle('selected',_selectedSessions.has(sid));if(cb)cb.checked=_selectedSessions.has(sid);}
+}
 function selectAllSessions(){
   _selectedSessions.clear();
   document.querySelectorAll('.session-select-cb').forEach(cb=>{
@@ -738,21 +746,20 @@ function deselectAllSessions(){
 function _updateBatchActionBar(){
   const bar=$('batchActionBar');if(!bar)return;
   const count=_selectedSessions.size;
-  bar.style.display=count>0?'':'none';
-  const badge=bar.querySelector('.batch-count');
-  if(badge) badge.textContent=t('session_selected_count',count);
+  if(count>0){_renderBatchActionBar();}
+  else{bar.style.display='none';}
 }
 function _renderBatchActionBar(){
   const bar=$('batchActionBar');if(!bar)return;
-  bar.innerHTML='';bar.style.display=_selectedSessions.size>0?'':'none';
+  bar.innerHTML='';bar.style.display=_selectedSessions.size>0?'flex':'none';
   const countBadge=document.createElement('span');countBadge.className='batch-count';
-  countBadge.textContent=t('session_selected_count',_selectedSessions.size);bar.appendChild(countBadge);
+  countBadge.textContent=String(t('session_selected_count')).replace('{0}',_selectedSessions.size);bar.appendChild(countBadge);
   // Archive
   const archiveBtn=document.createElement('button');archiveBtn.className='batch-action-btn';
   archiveBtn.textContent=t('session_batch_archive');
   archiveBtn.onclick=async()=>{
     const ids=[..._selectedSessions];
-    const ok=await showConfirmDialog({message:t('session_batch_archive_confirm',ids.length),confirmLabel:t('session_batch_archive'),danger:true});
+    const ok=await showConfirmDialog({message:String(t('session_batch_archive_confirm')).replace('{0}',ids.length),confirmLabel:t('session_batch_archive'),danger:true});
     if(!ok)return;
     try{await Promise.all(ids.map(sid=>api('/api/session/archive',{method:'POST',body:JSON.stringify({session_id:sid,archived:true})})));
       showToast(t('session_archived'));exitSessionSelectMode();await renderSessionList();
@@ -761,13 +768,13 @@ function _renderBatchActionBar(){
   // Move
   const moveBtn=document.createElement('button');moveBtn.className='batch-action-btn';
   moveBtn.textContent=t('session_batch_move');
-  moveBtn.onclick=()=>{_showBatchProjectPicker();};bar.appendChild(moveBtn);
+  moveBtn.onclick=(e)=>{e.stopPropagation();_showBatchProjectPicker();};bar.appendChild(moveBtn);
   // Delete
   const deleteBtn=document.createElement('button');deleteBtn.className='batch-action-btn batch-action-btn-danger';
   deleteBtn.textContent=t('session_batch_delete');
   deleteBtn.onclick=async()=>{
     const ids=[..._selectedSessions];
-    const ok=await showConfirmDialog({message:t('session_batch_delete_confirm',ids.length),confirmLabel:t('delete_title'),danger:true});
+    const ok=await showConfirmDialog({message:String(t('session_batch_delete_confirm')).replace('{0}',ids.length),confirmLabel:t('delete_title'),danger:true});
     if(!ok)return;
     try{await Promise.all(ids.map(sid=>api('/api/session/delete',{method:'POST',body:JSON.stringify({session_id:sid})})));
       if(S.session&&ids.includes(S.session.session_id)){
@@ -782,8 +789,9 @@ function _renderBatchActionBar(){
 }
 function _showBatchProjectPicker(){
   const ids=[..._selectedSessions];if(!ids.length)return;
-  document.querySelectorAll('.project-picker').forEach(p=>p.remove());
-  const picker=document.createElement('div');picker.className='project-picker';
+  const bar=$('batchActionBar');if(!bar)return;
+  bar.querySelectorAll('.batch-project-picker').forEach(p=>p.remove());
+  const picker=document.createElement('div');picker.className='project-picker batch-project-picker';
   const none=document.createElement('div');none.className='project-picker-item';none.textContent='No project';
   none.onclick=async()=>{picker.remove();
     try{await Promise.all(ids.map(sid=>api('/api/session/move',{method:'POST',body:JSON.stringify({session_id:sid,project_id:null})})));
@@ -801,7 +809,7 @@ function _showBatchProjectPicker(){
       }catch(e){showToast('Move failed: '+(e.message||e));}
     };picker.appendChild(item);
   }
-  document.body.appendChild(picker);picker.style.cssText='position:fixed;bottom:60px;left:50%;transform:translateX(-50%);z-index:999;';
+  bar.appendChild(picker);
   const close=(e)=>{if(!picker.contains(e.target)){picker.remove();document.removeEventListener('click',close);}};
   setTimeout(()=>document.addEventListener('click',close),0);
 }
@@ -1320,7 +1328,14 @@ function renderSessionListFromCache(){
   // real once the first message is sent. The server already filters them, but this
   // guard ensures a brand-new active session doesn't flash into the list while
   // _allSessions is stale from a prior render (#1171).
-  const withMessages=allMatched.filter(s=>(s.message_count||0)>0 || (activeSidForSidebar&&s.session_id===activeSidForSidebar) || (S.session&&s.session_id===S.session.session_id&&(S.session.message_count||0)>0));
+  const withMessages=allMatched.filter(s=>
+    (s.message_count||0)>0 ||
+    _isSessionEffectivelyStreaming(s) ||
+    !!s.active_stream_id ||
+    !!s.pending_user_message ||
+    (activeSidForSidebar&&s.session_id===activeSidForSidebar) ||
+    (S.session&&s.session_id===S.session.session_id&&(S.session.message_count||0)>0)
+  );
   // Filter by active profile (unless "All profiles" is toggled on)
   // Server backfills profile='default' for legacy sessions, so every session has a profile.
   // Show only sessions tagged to the active profile; 'All profiles' toggle overrides.
@@ -1364,8 +1379,9 @@ function renderSessionListFromCache(){
   }
   // Ensure batch action bar exists in DOM
   let batchBar=$('batchActionBar');
-  if(!batchBar){batchBar=document.createElement('div');batchBar.id='batchActionBar';batchBar.className='batch-action-bar';document.body.appendChild(batchBar);}
-  if(_sessionSelectMode&&_selectedSessions.size>0){batchBar.style.display='';_renderBatchActionBar();}
+  if(!batchBar){batchBar=document.createElement('div');batchBar.id='batchActionBar';batchBar.className='batch-action-bar';}
+  list.appendChild(batchBar);
+  if(_sessionSelectMode&&_selectedSessions.size>0){batchBar.style.display='flex';_renderBatchActionBar();}
   else{batchBar.style.display='none';}
   // Project filter bar (only when projects exist)
   if(_allProjects.length>0){
@@ -1557,8 +1573,11 @@ function renderSessionListFromCache(){
       const cbWrapper=document.createElement('label');cbWrapper.className='session-select-cb-wrapper';
       const cb=document.createElement('input');cb.type='checkbox';cb.className='session-select-cb';
       cb.dataset.sid=s.session_id;cb.checked=_selectedSessions.has(s.session_id);
-      cb.onchange=(e)=>{e.stopPropagation();toggleSessionSelect(s.session_id);};
+      cb.onchange=(e)=>{e.stopPropagation();setSessionSelected(s.session_id,cb.checked);};
       cb.onclick=(e)=>{e.stopPropagation();};
+      cb.onpointerup=(e)=>{e.stopPropagation();};
+      cbWrapper.onpointerup=(e)=>{e.stopPropagation();};
+      cbWrapper.onclick=(e)=>{e.stopPropagation();};
       cbWrapper.appendChild(cb);
       el.classList.toggle('selected',_selectedSessions.has(s.session_id));
       el.appendChild(cbWrapper);

--- a/static/style.css
+++ b/static/style.css
@@ -426,13 +426,12 @@
   .session-item.selected{background:var(--accent-bg);color:var(--accent-text);}
   .session-item.selected .session-title{color:var(--accent-text);}
   .session-item.selected .session-meta{color:var(--accent-text);opacity:.8;}
-  .batch-action-bar{display:none;position:fixed;bottom:0;left:0;right:0;z-index:998;background:var(--surface);border-top:1px solid var(--border2);box-shadow:0 -2px 12px rgba(0,0,0,.15);padding:10px 16px;align-items:center;gap:10px;font-size:13px;}
-  .batch-count{font-weight:600;color:var(--accent);margin-right:auto;white-space:nowrap;}
-  .batch-action-btn{border:1px solid var(--border);border-radius:8px;background:var(--surface);color:var(--text);cursor:pointer;padding:6px 14px;font-size:12px;font-weight:500;transition:background .12s,color .12s,border-color .12s;white-space:nowrap;}
+  .batch-action-bar{display:none;margin:0 10px 8px;padding:8px;border:1px solid var(--border);border-radius:10px;background:var(--surface);align-items:stretch;gap:6px;font-size:12px;flex-wrap:wrap;}
+  .batch-count{font-weight:600;color:var(--accent);width:100%;white-space:nowrap;}
+  .batch-action-btn{border:1px solid var(--border);border-radius:8px;background:var(--surface);color:var(--text);cursor:pointer;padding:6px 8px;font-size:12px;font-weight:500;transition:background .12s,color .12s,border-color .12s;white-space:nowrap;flex:1 1 auto;}
   .batch-action-btn:hover{background:var(--hover-bg);border-color:var(--border2);}
   .batch-action-btn-danger{color:var(--error,#e94560);border-color:var(--error,#e94560);}
   .batch-action-btn-danger:hover{background:rgba(233,69,96,.1);}
-  @media(hover:none){.batch-action-bar{padding-bottom:max(10px,env(safe-area-inset-bottom));}}
   .session-date-caret{font-size:9px;transition:transform .2s;flex-shrink:0;display:inline-block;transform:rotate(0deg);}
   .session-date-caret.collapsed{transform:rotate(-90deg);}
   .app-dialog-overlay{position:fixed;inset:0;background:rgba(7,12,19,.62);backdrop-filter:blur(6px);z-index:1100;display:none;align-items:center;justify-content:center;padding:24px;}
@@ -2400,6 +2399,7 @@ main.main.showing-profiles > #mainProfiles{display:flex;}
 .project-create-btn:hover{opacity:1;border-color:var(--blue);color:var(--blue);}
 .project-create-input{font-size:10px;padding:3px 8px;border-radius:12px;border:1px solid var(--accent-bg);background:var(--surface);color:var(--text);outline:none;min-width:40px;max-width:180px;width:auto;font-family:inherit;box-shadow:0 0 0 2px var(--accent-bg);}
 .project-picker{position:absolute;right:0;top:100%;background:var(--sidebar);border:1px solid var(--border2);border-radius:8px;padding:4px;z-index:30;min-width:160px;max-width:220px;width:max-content;box-shadow:0 4px 16px rgba(0,0,0,.3);}
+.batch-action-bar .batch-project-picker{position:static;right:auto;top:auto;min-width:100%;max-width:none;width:100%;box-shadow:none;margin-top:2px;background:var(--input-bg);}
 .project-picker-item{padding:5px 10px;font-size:11px;border-radius:6px;cursor:pointer;color:var(--muted);transition:all .1s;display:flex;align-items:center;gap:6px;}
 .project-picker-item:hover{background:rgba(255,255,255,.08);color:var(--text);}
 .project-picker-item.active{color:var(--blue);}

--- a/tests/test_session_batch_select.py
+++ b/tests/test_session_batch_select.py
@@ -93,12 +93,12 @@ def test_batch_action_bar_overrides_css_hidden_state():
         src = f.read()
     assert "if(count>0){_renderBatchActionBar();}" in src, \
         "Updating selected count must render action buttons, not just reveal an empty bar"
-    assert "String(t('session_selected_count')).replace('{0}',_selectedSessions.size)" in src, \
-        "Selected count must interpolate string-valued i18n labels"
-    assert "String(t('session_batch_archive_confirm')).replace('{0}',ids.length)" in src, \
-        "Batch archive confirmation must interpolate selected session count"
-    assert "String(t('session_batch_delete_confirm')).replace('{0}',ids.length)" in src, \
-        "Batch delete confirmation must interpolate selected session count"
+    assert "t('session_selected_count',_selectedSessions.size)" in src, \
+        "Selected count must pass the selected session count to i18n"
+    assert "t('session_batch_archive_confirm',ids.length)" in src, \
+        "Batch archive confirmation must pass selected session count to i18n"
+    assert "t('session_batch_delete_confirm',ids.length)" in src, \
+        "Batch delete confirmation must pass selected session count to i18n"
     assert "bar.innerHTML='';bar.style.display=_selectedSessions.size>0?'flex':'none'" in src, \
         "Rendering the action bar must explicitly show it when selections exist"
     assert "batchBar.style.display='flex'" in src, \
@@ -198,6 +198,16 @@ def test_batch_select_i18n_keys():
     for key in required_keys:
         count = src.count(f"{key}:")
         assert count >= 8, f"Key '{key}' found {count} times, expected >= 8 (one per locale) (one per locale)"
+
+
+def test_i18n_string_placeholder_interpolation_supported():
+    """String-valued translations with {0} placeholders should interpolate args."""
+    with open('static/i18n.js') as f:
+        src = f.read()
+    assert "String(val).replace(/\\{(\\d+)\\}/g" in src, \
+        "t() must interpolate {0}-style placeholders for string-valued translations"
+    assert "Object.prototype.hasOwnProperty.call(args, idx)" in src, \
+        "t() must preserve unknown placeholders instead of replacing with undefined"
 
 
 def test_batch_select_css_exists():

--- a/tests/test_session_batch_select.py
+++ b/tests/test_session_batch_select.py
@@ -48,6 +48,20 @@ def test_batch_select_intercepts_navigation():
         "Pointerup handler should call toggleSessionSelect in select mode"
 
 
+def test_batch_checkbox_sets_selection_without_row_double_toggle():
+    """Clicking the checkbox itself must not also trigger row-level toggling."""
+    with open('static/sessions.js') as f:
+        src = f.read()
+    assert 'function setSessionSelected(sid, selected)' in src, \
+        "Checkbox changes should set explicit state instead of toggling blindly"
+    assert 'cb.onchange=(e)=>{e.stopPropagation();setSessionSelected(s.session_id,cb.checked);};' in src, \
+        "Checkbox change must use its checked state"
+    assert 'cb.onpointerup=(e)=>{e.stopPropagation();};' in src, \
+        "Checkbox pointerup must not bubble to the row pointerup handler"
+    assert 'cbWrapper.onpointerup=(e)=>{e.stopPropagation();};' in src, \
+        "Checkbox wrapper pointerup must not bubble to the row pointerup handler"
+
+
 def test_batch_select_escape_handler():
     """Verify Escape key exits select mode."""
     with open('static/sessions.js') as f:
@@ -71,6 +85,86 @@ def test_batch_select_bar_element():
     assert 'batchActionBar' in src, "Missing batchActionBar element"
     assert 'batch-action-bar' in src, "Missing batch-action-bar CSS class"
     assert 'batch-action-btn' in src, "Missing batch-action-btn class"
+
+
+def test_batch_action_bar_overrides_css_hidden_state():
+    """Selected sessions must make the fixed action bar visible."""
+    with open('static/sessions.js') as f:
+        src = f.read()
+    assert "if(count>0){_renderBatchActionBar();}" in src, \
+        "Updating selected count must render action buttons, not just reveal an empty bar"
+    assert "String(t('session_selected_count')).replace('{0}',_selectedSessions.size)" in src, \
+        "Selected count must interpolate string-valued i18n labels"
+    assert "String(t('session_batch_archive_confirm')).replace('{0}',ids.length)" in src, \
+        "Batch archive confirmation must interpolate selected session count"
+    assert "String(t('session_batch_delete_confirm')).replace('{0}',ids.length)" in src, \
+        "Batch delete confirmation must interpolate selected session count"
+    assert "bar.innerHTML='';bar.style.display=_selectedSessions.size>0?'flex':'none'" in src, \
+        "Rendering the action bar must explicitly show it when selections exist"
+    assert "batchBar.style.display='flex'" in src, \
+        "Session list render must explicitly show the action bar in select mode"
+
+
+def test_batch_action_bar_is_sidebar_inline_not_global_footer():
+    """Batch actions should appear in the session list, not over the composer."""
+    with open('static/sessions.js') as f:
+        js = f.read()
+    with open('static/style.css') as f:
+        css = f.read()
+    assert "list.appendChild(batchBar)" in js, \
+        "Batch action bar should be rendered inside the session list"
+    assert "document.body.appendChild(batchBar)" not in js, \
+        "Batch action bar must not be mounted as a global footer"
+    assert ".batch-action-bar{display:none;margin:" in css, \
+        "Batch action bar should use inline sidebar spacing"
+    assert "position:fixed" not in css[css.find(".batch-action-bar{"):css.find(".batch-count{")], \
+        "Batch action bar must not be fixed to the bottom of the viewport"
+
+
+def test_batch_project_picker_is_anchored_to_batch_actions():
+    """Batch move project picker should open inside the sidebar action bar."""
+    with open('static/sessions.js') as f:
+        js = f.read()
+    with open('static/style.css') as f:
+        css = f.read()
+    assert "const bar=$('batchActionBar');if(!bar)return;" in js, \
+        "Batch project picker should anchor to the batch action bar"
+    assert "picker.className='project-picker batch-project-picker'" in js, \
+        "Batch project picker needs its own inline styling hook"
+    assert "bar.appendChild(picker)" in js, \
+        "Batch project picker should render inside the batch action bar"
+    assert "document.body.appendChild(picker);picker.style.cssText='position:fixed" not in js, \
+        "Batch project picker must not use the old global fixed placement"
+    assert ".batch-action-bar .batch-project-picker{position:static;" in css, \
+        "Batch project picker should override the shared absolute project picker style"
+    assert css.find(".project-picker{") < css.find(".batch-action-bar .batch-project-picker{"), \
+        "Batch project picker override must come after the shared project picker rule"
+
+
+def test_streaming_zero_message_sessions_stay_visible_after_reload():
+    """In-flight sessions may have zero saved messages during reload recovery."""
+    with open('static/sessions.js') as f:
+        src = f.read()
+    assert "_isSessionEffectivelyStreaming(s)" in src, \
+        "Streaming sessions must bypass the zero-message sidebar filter"
+    assert "!!s.active_stream_id" in src, \
+        "Sessions with persisted active stream IDs must remain visible after reload"
+    assert "!!s.pending_user_message" in src, \
+        "Sessions with pending user turns must remain visible after reload"
+
+
+def test_boot_does_not_drop_zero_message_inflight_session():
+    """Reloading /session/<id> during a running turn must keep the session open."""
+    with open('static/boot.js') as f:
+        src = f.read()
+    assert "const _restoredInFlight = S.session && (" in src, \
+        "Boot must detect restored in-flight sessions before ephemeral cleanup"
+    assert "S.session.active_stream_id" in src, \
+        "Boot must treat active stream IDs as real sessions"
+    assert "S.session.pending_user_message" in src, \
+        "Boot must treat pending user messages as real sessions"
+    assert "&& !_restoredInFlight" in src, \
+        "Zero-message cleanup must not run for in-flight sessions"
 
 
 def test_batch_select_i18n_keys():


### PR DESCRIPTION
## Summary

Fixes two WebUI session sidebar regressions:

- Batch select actions could render as an empty/global bottom bar, show literal `{0}` placeholders in confirmation text, or report `0` selected after clicking checkboxes because checkbox events could bubble into the row-level select toggle.
- Reloading `/session/<id>` during an in-flight turn could show the empty chat home even though the sidebar still showed the running zero-message session.

## Changes

- Render the batch action bar inline inside the session list instead of mounting it as a fixed global footer.
- Re-render batch action buttons when selection changes instead of only revealing an empty bar.
- Add string-valued `{0}` interpolation support to the shared `t()` i18n helper.
- Anchor the batch project picker inside the batch action bar and override the shared absolute picker styling.
- Prevent checkbox clicks from double-toggling through the row pointer handler.
- Keep zero-message sessions visible and loaded when they have `active_stream_id` or `pending_user_message` during reload recovery.

## Tests

- `uv run pytest tests/test_session_batch_select.py`
- Result: `18 passed in 1.02s`