### PR TITLE
Fix _normalizeConfiguredModelKey in frontend to match backend behavior

### DIFF
--- a/static/ui.js
+++ b/static/ui.js
@@ -520,7 +520,8 @@ function _selectedModelOption(){
 
 function _normalizeConfiguredModelKey(modelId){
   let s=String(modelId||'').trim().toLowerCase();
-  if(s.startsWith('@')&&s.includes(':')) s=s.substring(s.indexOf(':')+1);
+  // Strip @provider: prefix (e.g., @custom:jingdong:GLM-5 -> GLM-5)
+  if(s.startsWith('@')&&s.includes(':')) s=s.split(':').pop();
   if(s.includes('/')) s=s.split('/').pop();
   return s.replace(/-/g,'.');
 }
@@ -678,7 +679,13 @@ function renderModelDropdown(){
       for(const m of configuredModels){
         const row=document.createElement('div');
         row.className='model-opt'+(m.value===sel.value?' active':'');
-        const badgeHtml=m.badge?`<span class="model-opt-badge model-opt-badge--${esc(m.badge.role||'configured')}">${esc(m.badge.label||'Configured')}</span>`:'';
+        // Add provider info to badge label (e.g., "Primary (jingdong)")
+        let badgeLabel=m.badge?(m.badge.label||'Configured'):'';
+        if(m.badge&&m.badge.provider){
+          const providerName=m.badge.provider.replace(/^custom:/,'').split('/')[0];
+          badgeLabel+=` (${providerName})`;
+        }
+        const badgeHtml=m.badge?`<span class="model-opt-badge model-opt-badge--${esc(m.badge.role||'configured')}">${esc(badgeLabel)}</span>`:'';
         row.innerHTML=`<div class="model-opt-top"><span class="model-opt-name">${m.name}</span>${badgeHtml}</div><span class="model-opt-id">${m.id}</span>`;
         row.onclick=()=>selectModelFromDropdown(m.value);
         dd.appendChild(row);


### PR DESCRIPTION
## Summary
This PR fixes the same bug in the JavaScript frontend that was fixed in the Python backend in commit #d6164cd.

## Problem
The JavaScript `_normalizeConfiguredModelKey` function used `substring(indexOf(:)+1)` which only removes the first colon-separated segment, leaving provider names in the normalized model ID.

For example, `@custom:jingdong:GLM-5` became `jingdong:glm.5` instead of `glm.5`.

This caused:
- Duplicate Primary badges appearing in the model dropdown
- Configured model badge injection check failing for custom providers

## Solution
Replace `substring(indexOf(:)+1)` with `split(:).pop()` to match the Python backend behavior and strip all colon prefixes.

## Bonus
Added provider name to badge label for clarity (e.g., `"Primary (jingdong)"` instead of just `"Primary"`).

## Testing
- Verified model dropdown shows only one Primary badge
- Verified badge displays provider name correctly
- Tested with `@custom:jingdong:GLM-5` format model IDs

## Related
- Follow-up to commit d6164cd which fixed the same issue in Python backend