### PR TITLE
v0.50.267 — 7 contributor PRs (model ID normalization, navigation, sessions, batch actions) + Opus follow-up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Hermes Web UI -- Changelog
 
+## [v0.50.267] — 2026-05-02
+
+### Fixed (contributor PR batch — 7 PRs)
+
+- **`_norm_model_id` strips multi-segment provider prefixes** (#1454, by @happy5318) — `s.split(':', 1)[1]` only stripped the first colon-separated segment, leaving `jingdong:GLM-5` un-normalized for `@custom:jingdong:GLM-5`-style IDs. Now uses `s.split(':')[-1]` (with a trailing-empty fallback to preserve distinct ids on malformed input). Same fix applied to the `/` branch. (`api/config.py`)
+- **Frontend `_normalizeConfiguredModelKey` matches backend** (#1474, by @happy5318) — the JavaScript helper had the same one-segment-only bug as the Python helper. Mirror fix + trailing-empty fallback. Plus surface the configured-model provider name in the model dropdown badge (e.g. "Primary (jingdong)"). (`static/ui.js`)
+- **`pushState` instead of `replaceState` for chat navigation** (#1461, by @JKJameson) — switching between chats wrote to the same browser-history entry, so the back button could not return to a prior chat. Now each chat-switch creates a new history entry. One-line change. (`static/sessions.js`)
+- **Session rename: ondblclick handler + loading guard** (#1465, by @AlexeyDsov) — adds a native `ondblclick` handler as a fallback to the existing manual click-counter (which can miss double-taps when the click-delay racing setTimeout fires between pointerups), plus a guard preventing rename while the session is still loading. (`static/sessions.js`)
+- **Reuse in-flight session stream on switch-back** (#1467, by @dso2ng) — `attachLiveStream()` now reuses the existing EventSource transport when (sessionId, streamId) match and the browser hasn't marked it CLOSED, instead of always tearing down and reopening. The server-side stream queue is not a replay log, so the close-and-reopen window dropped events that landed during the gap. 4 regression tests pin the invariants. (`static/messages.js`, `tests/test_inflight_stream_reuse.py`)
+- **Handle 401 redirect gracefully in loadSession flow** (#1460, by @joaompfp) — when `api()` redirects to `/login` after the auth session expires (e.g. server restart), it returns `undefined`. Five callsites in `loadSession` / `_ensureMessagesLoaded` / `_loadOlderMessages` / `_ensureAllMessagesLoaded` / `_positionModelDropdown` now defensively check for undefined data and bail without state mutation. (`static/sessions.js`, `static/ui.js`)
+- **Batch session actions + in-flight reload recovery** (#1473, by @Thanatos-Z) — fixed three regressions: (1) batch action bar rendered as an empty/global bottom bar with literal `{0}` placeholders because i18n placeholder substitution only ran for arrow-function values — `t()` now substitutes `{N}` placeholders at runtime for non-function values when args are passed; (2) batch project-picker dropped onto `document.body` orphaned itself on list re-render — now scoped to the action bar; (3) sessions with `active_stream_id` or `pending_user_message` set but `message_count=0` (mid-restore from in-flight reload) were filtered out of the sidebar — filter widened. 6 regression tests. (`static/boot.js`, `static/i18n.js`, `static/sessions.js`, `static/style.css`, `tests/test_session_batch_select.py`)
+
+### Defensive hardening (Opus pre-release follow-up)
+
+- **`_norm_model_id` trailing-empty fallback** — Opus advisor flagged a `SHOULD-FIX` edge case in #1454/#1474: malformed configured-model IDs ending in a colon or slash (`@custom:foo:bar:` or `provider/model/`) would `split('...')[-1]` to an empty string, collapsing distinct IDs to the same key in the configured-model badge filter. Both backend (`api/config.py:1513`) and frontend (`static/ui.js:524`) helpers now fall back to the original input when the last segment is empty (`parts[-1] or s` / `last || s`). 5 regression tests pin the guard, the clean multi-segment fix, and the frontend mirror. (`api/config.py`, `static/ui.js`, `tests/test_norm_model_id_trailing_empty_guard.py`)
+
 ## [v0.50.266] — 2026-05-02
 
 ### Fixed (i18n parity)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,7 +3,7 @@
 > Goal: Full 1:1 parity with the Hermes CLI experience via a clean dark web UI.
 > Everything you can do from the CLI terminal, you can do from this UI.
 >
-> Last updated: v0.50.266 (May 2, 2026) — 3753 tests collected
+> Last updated: v0.50.267 (May 02, 2026) — 3776 tests collected
 > Tests: `pytest tests/ --collect-only -q`
 > Source: <repo>/
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -1835,8 +1835,8 @@ Bridged CLI sessions:
 
 ---
 
-*Last updated: v0.50.266, May 2, 2026*
-*Total automated tests collected: 3753*
+*Last updated: v0.50.267, May 02, 2026*
+*Total automated tests collected: 3776*
 *Regression gate: tests/test_regressions.py*
 *Run: pytest tests/ -v --timeout=60*
 *Source: <repo>/*

--- a/api/config.py
+++ b/api/config.py
@@ -1506,10 +1506,13 @@ def get_available_models() -> dict:
 
         def _norm_model_id(model_id: str) -> str:
             s = str(model_id or "").strip().lower()
+            # Strip @provider: prefix (e.g., @custom:jingdong:GLM-5 -> GLM-5)
             if s.startswith("@") and ":" in s:
-                s = s.split(":", 1)[1]
+                # Split on all colons and take the last part
+                s = s.split(":")[-1]
+            # Strip provider/model prefix (e.g., custom:jingdong/GLM-5 -> GLM-5)
             if "/" in s:
-                s = s.split("/", 1)[1]
+                s = s.split("/")[-1]
             return s.replace("-", ".")
 
         def _build_configured_model_badges() -> dict[str, dict[str, str]]:
@@ -2079,9 +2082,8 @@ def get_available_models() -> dict:
                 )
 
         if default_model:
-            _norm = lambda mid: (mid.split("/", 1)[-1] if "/" in mid else mid).replace("-", ".")
-            all_ids_norm = {_norm(m["id"]) for g in groups for m in g.get("models", [])}
-            if _norm(default_model) not in all_ids_norm:
+            all_ids_norm = {_norm_model_id(m["id"]) for g in groups for m in g.get("models", [])}
+            if _norm_model_id(default_model) not in all_ids_norm:
                 label = _get_label_for_model(default_model, groups)
                 target_display = (
                     _PROVIDER_DISPLAY.get(active_provider, active_provider or "").lower()

--- a/api/config.py
+++ b/api/config.py
@@ -1506,13 +1506,17 @@ def get_available_models() -> dict:
 
         def _norm_model_id(model_id: str) -> str:
             s = str(model_id or "").strip().lower()
-            # Strip @provider: prefix (e.g., @custom:jingdong:GLM-5 -> GLM-5)
+            # Strip @provider: prefix (e.g., @custom:jingdong:GLM-5 -> GLM-5).
+            # Defensive: if the last segment is empty (trailing colon, malformed
+            # config), keep the original to avoid collapsing distinct IDs to ''.
             if s.startswith("@") and ":" in s:
-                # Split on all colons and take the last part
-                s = s.split(":")[-1]
-            # Strip provider/model prefix (e.g., custom:jingdong/GLM-5 -> GLM-5)
+                parts = s.split(":")
+                s = parts[-1] or s
+            # Strip provider/model prefix (e.g., custom:jingdong/GLM-5 -> GLM-5).
+            # Same trailing-empty guard.
             if "/" in s:
-                s = s.split("/")[-1]
+                parts = s.split("/")
+                s = parts[-1] or s
             return s.replace("-", ".")
 
         def _build_configured_model_badges() -> dict[str, dict[str, str]]:

--- a/static/boot.js
+++ b/static/boot.js
@@ -1298,7 +1298,11 @@ function applyBotName(){
       // subsequent refresh will also run loadSession() → loadDir() → files stay visible.
       // Removing it here caused the file tree to go blank on the second refresh
       // because the "no saved session" path never calls loadDir (#workspace-files).
-      if(S.session && (S.session.message_count||0) === 0){
+      const _restoredInFlight = S.session && (
+        S.session.active_stream_id ||
+        S.session.pending_user_message
+      );
+      if(S.session && (S.session.message_count||0) === 0 && !_restoredInFlight){
         S.session=null; S.messages=[];
         S._bootReady=true;
         // Restore panel pref before syncing so the workspace panel stays visible

--- a/static/i18n.js
+++ b/static/i18n.js
@@ -7517,7 +7517,13 @@ function resolvePreferredLocale(primary, fallback) {
 function t(key, ...args) {
   const val = _locale[key] ?? LOCALES.en[key];
   if (val === undefined) return key;  // final fallback: return key itself
-  return typeof val === 'function' ? val(...args) : val;
+  if (typeof val === 'function') return val(...args);
+  if (args.length) {
+    return String(val).replace(/\{(\d+)\}/g, (match, idx) => (
+      Object.prototype.hasOwnProperty.call(args, idx) ? String(args[idx]) : match
+    ));
+  }
+  return val;
 }
 
 /**

--- a/static/messages.js
+++ b/static/messages.js
@@ -283,12 +283,19 @@ function closeLiveStream(sessionId, streamId){
 function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
   if(!activeSid||!streamId) return;
   const reconnecting=!!options.reconnecting;
-  closeLiveStream(activeSid);
   if(!INFLIGHT[activeSid]) INFLIGHT[activeSid]={messages:[...S.messages],uploaded:[...uploaded],toolCalls:[]};
   else {
     if(uploaded.length) INFLIGHT[activeSid].uploaded=[...uploaded];
     if(!Array.isArray(INFLIGHT[activeSid].toolCalls)) INFLIGHT[activeSid].toolCalls=[];
   }
+  const existingLive=LIVE_STREAMS[activeSid];
+  if(
+    existingLive&&existingLive.streamId===streamId&&existingLive.source&&
+    (typeof EventSource==='undefined'||existingLive.source.readyState!==EventSource.CLOSED)
+  ){
+    return;
+  }
+  closeLiveStream(activeSid);
 
   let assistantText='';
   let reasoningText='';

--- a/static/messages.js
+++ b/static/messages.js
@@ -291,6 +291,8 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
   const existingLive=LIVE_STREAMS[activeSid];
   if(
     existingLive&&existingLive.streamId===streamId&&existingLive.source&&
+    // A same-stream transport can be reused unless the browser has already
+    // marked it closed; closed streams must still fall through to reopen.
     (typeof EventSource==='undefined'||existingLive.source.readyState!==EventSource.CLOSED)
   ){
     return;

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -753,13 +753,13 @@ function _renderBatchActionBar(){
   const bar=$('batchActionBar');if(!bar)return;
   bar.innerHTML='';bar.style.display=_selectedSessions.size>0?'flex':'none';
   const countBadge=document.createElement('span');countBadge.className='batch-count';
-  countBadge.textContent=String(t('session_selected_count')).replace('{0}',_selectedSessions.size);bar.appendChild(countBadge);
+  countBadge.textContent=t('session_selected_count',_selectedSessions.size);bar.appendChild(countBadge);
   // Archive
   const archiveBtn=document.createElement('button');archiveBtn.className='batch-action-btn';
   archiveBtn.textContent=t('session_batch_archive');
   archiveBtn.onclick=async()=>{
     const ids=[..._selectedSessions];
-    const ok=await showConfirmDialog({message:String(t('session_batch_archive_confirm')).replace('{0}',ids.length),confirmLabel:t('session_batch_archive'),danger:true});
+    const ok=await showConfirmDialog({message:t('session_batch_archive_confirm',ids.length),confirmLabel:t('session_batch_archive'),danger:true});
     if(!ok)return;
     try{await Promise.all(ids.map(sid=>api('/api/session/archive',{method:'POST',body:JSON.stringify({session_id:sid,archived:true})})));
       showToast(t('session_archived'));exitSessionSelectMode();await renderSessionList();
@@ -774,7 +774,7 @@ function _renderBatchActionBar(){
   deleteBtn.textContent=t('session_batch_delete');
   deleteBtn.onclick=async()=>{
     const ids=[..._selectedSessions];
-    const ok=await showConfirmDialog({message:String(t('session_batch_delete_confirm')).replace('{0}',ids.length),confirmLabel:t('delete_title'),danger:true});
+    const ok=await showConfirmDialog({message:t('session_batch_delete_confirm',ids.length),confirmLabel:t('delete_title'),danger:true});
     if(!ok)return;
     try{await Promise.all(ids.map(sid=>api('/api/session/delete',{method:'POST',body:JSON.stringify({session_id:sid})})));
       if(S.session&&ids.includes(S.session.session_id)){

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -369,6 +369,12 @@ async function loadSession(sid){
     if (_loadingSessionId === sid) _loadingSessionId = null;
     return;
   }
+  // Guard: api() may have redirected (401) and returned undefined; in that case
+  // the browser is already navigating away, so abort the rest of this flow.
+  if (!data) {
+    if (_loadingSessionId === sid) _loadingSessionId = null;
+    return;
+  }
   // Stale response? A newer loadSession() call has already started (#1060).
   if (_loadingSessionId !== sid) return;
   S.session=data.session;
@@ -561,6 +567,8 @@ async function _ensureMessagesLoaded(sid) {
   }
   // Fetch session messages with a tail window for fast initial load.
   const data = await api(`/api/session?session_id=${encodeURIComponent(sid)}&messages=1&resolve_model=0&msg_limit=${_INITIAL_MSG_LIMIT}`);
+  // Guard: api() may have redirected (401) and returned undefined.
+  if (!data || !data.session) return;
   _messagesTruncated = !!data.session._messages_truncated;
   _oldestIdx = data.session._messages_offset || 0;
   const msgs = (data.session.messages || []).filter(m => m && m.role);
@@ -601,7 +609,8 @@ async function _loadOlderMessages() {
   _loadingOlder = true;
   try {
     const data = await api(`/api/session?session_id=${encodeURIComponent(sid)}&messages=1&resolve_model=0&msg_before=${_oldestIdx}&msg_limit=${_INITIAL_MSG_LIMIT}`);
-    // Cancellation guards:
+    // Guard: api() may have redirected (401) and returned undefined.
+    if (!data || !data.session) { _loadingOlder = false; return; }
     //  - response shape sane
     //  - the active session is still the one we issued the request for.
     //    Compare against S.session.session_id, NOT _loadingSessionId — the
@@ -646,6 +655,8 @@ async function _ensureAllMessagesLoaded() {
   if (!_messagesTruncated || !S.session) return;
   const sid = S.session.session_id;
   const data = await api(`/api/session?session_id=${encodeURIComponent(sid)}&messages=1&resolve_model=0`);
+  // Guard: api() may have redirected (401) and returned undefined.
+  if (!data || !data.session) return;
   const msgs = (data.session.messages || []).filter(m => m && m.role);
   S.messages = msgs;
   _messagesTruncated = false;

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -697,7 +697,7 @@ function _setActiveSessionUrl(sid){
   if(typeof window==='undefined'||!window.history||!sid) return;
   const next=_sessionUrlForSid(sid);
   if(next && next!==(window.location.pathname+window.location.search+window.location.hash)){
-    window.history.replaceState({session_id:sid},'',next);
+    window.history.pushState({session_id:sid},'',next);
   }
 }
 

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1644,6 +1644,9 @@ function renderSessionListFromCache(){
 
     // Rename: called directly when we confirm it's a double-click
     const startRename=()=>{
+      // Guard: prevent renaming if session is currently being loaded
+      if (_loadingSessionId && _loadingSessionId !== s.session_id) return;
+
       closeSessionActionMenu();
       _renamingSid = s.session_id;
       const oldTitle=s.title||'Untitled';
@@ -1795,6 +1798,16 @@ function renderSessionListFromCache(){
         await loadSession(s.session_id);renderSessionListFromCache();
         if(typeof closeMobileSidebar==='function')closeMobileSidebar();
       }, delay);
+    };
+    // Add ondblclick for more reliable double-click detection
+    el.ondblclick=(e)=>{
+      if(e.pointerType==='mouse' && e.button!==0) return;
+      if(_renamingSid) return;
+      if(actions.contains(e.target)) return;
+      if(_sessionSelectMode){e.stopPropagation();toggleSessionSelect(s.session_id);return;}
+      // Guard: prevent renaming if session is currently being loaded
+      if (_loadingSessionId && _loadingSessionId !== s.session_id) return;
+      startRename();
     };
     return el;
   }

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -722,6 +722,14 @@ function toggleSessionSelect(sid){
   const item=cb?cb.closest('.session-item'):null;
   if(item){item.classList.toggle('selected',_selectedSessions.has(sid));if(cb)cb.checked=_selectedSessions.has(sid);}
 }
+function setSessionSelected(sid, selected){
+  if(selected) _selectedSessions.add(sid);
+  else _selectedSessions.delete(sid);
+  _updateBatchActionBar();
+  const cb=document.querySelector('.session-select-cb[data-sid="'+sid+'"]');
+  const item=cb?cb.closest('.session-item'):null;
+  if(item){item.classList.toggle('selected',_selectedSessions.has(sid));if(cb)cb.checked=_selectedSessions.has(sid);}
+}
 function selectAllSessions(){
   _selectedSessions.clear();
   document.querySelectorAll('.session-select-cb').forEach(cb=>{
@@ -738,21 +746,20 @@ function deselectAllSessions(){
 function _updateBatchActionBar(){
   const bar=$('batchActionBar');if(!bar)return;
   const count=_selectedSessions.size;
-  bar.style.display=count>0?'':'none';
-  const badge=bar.querySelector('.batch-count');
-  if(badge) badge.textContent=t('session_selected_count',count);
+  if(count>0){_renderBatchActionBar();}
+  else{bar.style.display='none';}
 }
 function _renderBatchActionBar(){
   const bar=$('batchActionBar');if(!bar)return;
-  bar.innerHTML='';bar.style.display=_selectedSessions.size>0?'':'none';
+  bar.innerHTML='';bar.style.display=_selectedSessions.size>0?'flex':'none';
   const countBadge=document.createElement('span');countBadge.className='batch-count';
-  countBadge.textContent=t('session_selected_count',_selectedSessions.size);bar.appendChild(countBadge);
+  countBadge.textContent=String(t('session_selected_count')).replace('{0}',_selectedSessions.size);bar.appendChild(countBadge);
   // Archive
   const archiveBtn=document.createElement('button');archiveBtn.className='batch-action-btn';
   archiveBtn.textContent=t('session_batch_archive');
   archiveBtn.onclick=async()=>{
     const ids=[..._selectedSessions];
-    const ok=await showConfirmDialog({message:t('session_batch_archive_confirm',ids.length),confirmLabel:t('session_batch_archive'),danger:true});
+    const ok=await showConfirmDialog({message:String(t('session_batch_archive_confirm')).replace('{0}',ids.length),confirmLabel:t('session_batch_archive'),danger:true});
     if(!ok)return;
     try{await Promise.all(ids.map(sid=>api('/api/session/archive',{method:'POST',body:JSON.stringify({session_id:sid,archived:true})})));
       showToast(t('session_archived'));exitSessionSelectMode();await renderSessionList();
@@ -761,13 +768,13 @@ function _renderBatchActionBar(){
   // Move
   const moveBtn=document.createElement('button');moveBtn.className='batch-action-btn';
   moveBtn.textContent=t('session_batch_move');
-  moveBtn.onclick=()=>{_showBatchProjectPicker();};bar.appendChild(moveBtn);
+  moveBtn.onclick=(e)=>{e.stopPropagation();_showBatchProjectPicker();};bar.appendChild(moveBtn);
   // Delete
   const deleteBtn=document.createElement('button');deleteBtn.className='batch-action-btn batch-action-btn-danger';
   deleteBtn.textContent=t('session_batch_delete');
   deleteBtn.onclick=async()=>{
     const ids=[..._selectedSessions];
-    const ok=await showConfirmDialog({message:t('session_batch_delete_confirm',ids.length),confirmLabel:t('delete_title'),danger:true});
+    const ok=await showConfirmDialog({message:String(t('session_batch_delete_confirm')).replace('{0}',ids.length),confirmLabel:t('delete_title'),danger:true});
     if(!ok)return;
     try{await Promise.all(ids.map(sid=>api('/api/session/delete',{method:'POST',body:JSON.stringify({session_id:sid})})));
       if(S.session&&ids.includes(S.session.session_id)){
@@ -782,8 +789,9 @@ function _renderBatchActionBar(){
 }
 function _showBatchProjectPicker(){
   const ids=[..._selectedSessions];if(!ids.length)return;
-  document.querySelectorAll('.project-picker').forEach(p=>p.remove());
-  const picker=document.createElement('div');picker.className='project-picker';
+  const bar=$('batchActionBar');if(!bar)return;
+  bar.querySelectorAll('.batch-project-picker').forEach(p=>p.remove());
+  const picker=document.createElement('div');picker.className='project-picker batch-project-picker';
   const none=document.createElement('div');none.className='project-picker-item';none.textContent='No project';
   none.onclick=async()=>{picker.remove();
     try{await Promise.all(ids.map(sid=>api('/api/session/move',{method:'POST',body:JSON.stringify({session_id:sid,project_id:null})})));
@@ -801,7 +809,7 @@ function _showBatchProjectPicker(){
       }catch(e){showToast('Move failed: '+(e.message||e));}
     };picker.appendChild(item);
   }
-  document.body.appendChild(picker);picker.style.cssText='position:fixed;bottom:60px;left:50%;transform:translateX(-50%);z-index:999;';
+  bar.appendChild(picker);
   const close=(e)=>{if(!picker.contains(e.target)){picker.remove();document.removeEventListener('click',close);}};
   setTimeout(()=>document.addEventListener('click',close),0);
 }
@@ -1320,7 +1328,14 @@ function renderSessionListFromCache(){
   // real once the first message is sent. The server already filters them, but this
   // guard ensures a brand-new active session doesn't flash into the list while
   // _allSessions is stale from a prior render (#1171).
-  const withMessages=allMatched.filter(s=>(s.message_count||0)>0 || (activeSidForSidebar&&s.session_id===activeSidForSidebar) || (S.session&&s.session_id===S.session.session_id&&(S.session.message_count||0)>0));
+  const withMessages=allMatched.filter(s=>
+    (s.message_count||0)>0 ||
+    _isSessionEffectivelyStreaming(s) ||
+    !!s.active_stream_id ||
+    !!s.pending_user_message ||
+    (activeSidForSidebar&&s.session_id===activeSidForSidebar) ||
+    (S.session&&s.session_id===S.session.session_id&&(S.session.message_count||0)>0)
+  );
   // Filter by active profile (unless "All profiles" is toggled on)
   // Server backfills profile='default' for legacy sessions, so every session has a profile.
   // Show only sessions tagged to the active profile; 'All profiles' toggle overrides.
@@ -1364,8 +1379,9 @@ function renderSessionListFromCache(){
   }
   // Ensure batch action bar exists in DOM
   let batchBar=$('batchActionBar');
-  if(!batchBar){batchBar=document.createElement('div');batchBar.id='batchActionBar';batchBar.className='batch-action-bar';document.body.appendChild(batchBar);}
-  if(_sessionSelectMode&&_selectedSessions.size>0){batchBar.style.display='';_renderBatchActionBar();}
+  if(!batchBar){batchBar=document.createElement('div');batchBar.id='batchActionBar';batchBar.className='batch-action-bar';}
+  list.appendChild(batchBar);
+  if(_sessionSelectMode&&_selectedSessions.size>0){batchBar.style.display='flex';_renderBatchActionBar();}
   else{batchBar.style.display='none';}
   // Project filter bar (only when projects exist)
   if(_allProjects.length>0){
@@ -1557,8 +1573,11 @@ function renderSessionListFromCache(){
       const cbWrapper=document.createElement('label');cbWrapper.className='session-select-cb-wrapper';
       const cb=document.createElement('input');cb.type='checkbox';cb.className='session-select-cb';
       cb.dataset.sid=s.session_id;cb.checked=_selectedSessions.has(s.session_id);
-      cb.onchange=(e)=>{e.stopPropagation();toggleSessionSelect(s.session_id);};
+      cb.onchange=(e)=>{e.stopPropagation();setSessionSelected(s.session_id,cb.checked);};
       cb.onclick=(e)=>{e.stopPropagation();};
+      cb.onpointerup=(e)=>{e.stopPropagation();};
+      cbWrapper.onpointerup=(e)=>{e.stopPropagation();};
+      cbWrapper.onclick=(e)=>{e.stopPropagation();};
       cbWrapper.appendChild(cb);
       el.classList.toggle('selected',_selectedSessions.has(s.session_id));
       el.appendChild(cbWrapper);

--- a/static/style.css
+++ b/static/style.css
@@ -426,13 +426,12 @@
   .session-item.selected{background:var(--accent-bg);color:var(--accent-text);}
   .session-item.selected .session-title{color:var(--accent-text);}
   .session-item.selected .session-meta{color:var(--accent-text);opacity:.8;}
-  .batch-action-bar{display:none;position:fixed;bottom:0;left:0;right:0;z-index:998;background:var(--surface);border-top:1px solid var(--border2);box-shadow:0 -2px 12px rgba(0,0,0,.15);padding:10px 16px;align-items:center;gap:10px;font-size:13px;}
-  .batch-count{font-weight:600;color:var(--accent);margin-right:auto;white-space:nowrap;}
-  .batch-action-btn{border:1px solid var(--border);border-radius:8px;background:var(--surface);color:var(--text);cursor:pointer;padding:6px 14px;font-size:12px;font-weight:500;transition:background .12s,color .12s,border-color .12s;white-space:nowrap;}
+  .batch-action-bar{display:none;margin:0 10px 8px;padding:8px;border:1px solid var(--border);border-radius:10px;background:var(--surface);align-items:stretch;gap:6px;font-size:12px;flex-wrap:wrap;}
+  .batch-count{font-weight:600;color:var(--accent);width:100%;white-space:nowrap;}
+  .batch-action-btn{border:1px solid var(--border);border-radius:8px;background:var(--surface);color:var(--text);cursor:pointer;padding:6px 8px;font-size:12px;font-weight:500;transition:background .12s,color .12s,border-color .12s;white-space:nowrap;flex:1 1 auto;}
   .batch-action-btn:hover{background:var(--hover-bg);border-color:var(--border2);}
   .batch-action-btn-danger{color:var(--error,#e94560);border-color:var(--error,#e94560);}
   .batch-action-btn-danger:hover{background:rgba(233,69,96,.1);}
-  @media(hover:none){.batch-action-bar{padding-bottom:max(10px,env(safe-area-inset-bottom));}}
   .session-date-caret{font-size:9px;transition:transform .2s;flex-shrink:0;display:inline-block;transform:rotate(0deg);}
   .session-date-caret.collapsed{transform:rotate(-90deg);}
   .app-dialog-overlay{position:fixed;inset:0;background:rgba(7,12,19,.62);backdrop-filter:blur(6px);z-index:1100;display:none;align-items:center;justify-content:center;padding:24px;}
@@ -2400,6 +2399,7 @@ main.main.showing-profiles > #mainProfiles{display:flex;}
 .project-create-btn:hover{opacity:1;border-color:var(--blue);color:var(--blue);}
 .project-create-input{font-size:10px;padding:3px 8px;border-radius:12px;border:1px solid var(--accent-bg);background:var(--surface);color:var(--text);outline:none;min-width:40px;max-width:180px;width:auto;font-family:inherit;box-shadow:0 0 0 2px var(--accent-bg);}
 .project-picker{position:absolute;right:0;top:100%;background:var(--sidebar);border:1px solid var(--border2);border-radius:8px;padding:4px;z-index:30;min-width:160px;max-width:220px;width:max-content;box-shadow:0 4px 16px rgba(0,0,0,.3);}
+.batch-action-bar .batch-project-picker{position:static;right:auto;top:auto;min-width:100%;max-width:none;width:100%;box-shadow:none;margin-top:2px;background:var(--input-bg);}
 .project-picker-item{padding:5px 10px;font-size:11px;border-radius:6px;cursor:pointer;color:var(--muted);transition:all .1s;display:flex;align-items:center;gap:6px;}
 .project-picker-item:hover{background:rgba(255,255,255,.08);color:var(--text);}
 .project-picker-item.active{color:var(--blue);}

--- a/static/ui.js
+++ b/static/ui.js
@@ -574,9 +574,10 @@ function _positionModelDropdown(){
   const chip=$('composerModelChip');
   const mobileAction=$('composerMobileModelAction');
   const footer=document.querySelector('.composer-footer');
-  if(!dd||!chip||!footer) return;
+  if(!dd||!footer) return;
   const panel=$('composerMobileConfigPanel');
-  const anchor=(panel&&panel.classList.contains('open')&&mobileAction)?mobileAction:chip;
+  const anchor=(panel&&panel.classList.contains('open')&&mobileAction)?mobileAction:(chip&&chip.offsetParent?chip:mobileAction);
+  if(!anchor) return;
   const chipRect=anchor.getBoundingClientRect();
   const footerRect=footer.getBoundingClientRect();
   let left=chipRect.left-footerRect.left;

--- a/static/ui.js
+++ b/static/ui.js
@@ -520,9 +520,11 @@ function _selectedModelOption(){
 
 function _normalizeConfiguredModelKey(modelId){
   let s=String(modelId||'').trim().toLowerCase();
-  // Strip @provider: prefix (e.g., @custom:jingdong:GLM-5 -> GLM-5)
-  if(s.startsWith('@')&&s.includes(':')) s=s.split(':').pop();
-  if(s.includes('/')) s=s.split('/').pop();
+  // Strip @provider: prefix (e.g., @custom:jingdong:GLM-5 -> GLM-5).
+  // Defensive: trailing-colon / trailing-slash falls back to the original key
+  // so malformed configs don't collapse distinct ids to '' (matches backend _norm_model_id).
+  if(s.startsWith('@')&&s.includes(':')){const last=s.split(':').pop();s=last||s;}
+  if(s.includes('/')){const last=s.split('/').pop();s=last||s;}
   return s.replace(/-/g,'.');
 }
 

--- a/static/ui.js
+++ b/static/ui.js
@@ -520,7 +520,8 @@ function _selectedModelOption(){
 
 function _normalizeConfiguredModelKey(modelId){
   let s=String(modelId||'').trim().toLowerCase();
-  if(s.startsWith('@')&&s.includes(':')) s=s.substring(s.indexOf(':')+1);
+  // Strip @provider: prefix (e.g., @custom:jingdong:GLM-5 -> GLM-5)
+  if(s.startsWith('@')&&s.includes(':')) s=s.split(':').pop();
   if(s.includes('/')) s=s.split('/').pop();
   return s.replace(/-/g,'.');
 }
@@ -678,7 +679,13 @@ function renderModelDropdown(){
       for(const m of configuredModels){
         const row=document.createElement('div');
         row.className='model-opt'+(m.value===sel.value?' active':'');
-        const badgeHtml=m.badge?`<span class="model-opt-badge model-opt-badge--${esc(m.badge.role||'configured')}">${esc(m.badge.label||'Configured')}</span>`:'';
+        // Add provider info to badge label (e.g., "Primary (jingdong)")
+        let badgeLabel=m.badge?(m.badge.label||'Configured'):'';
+        if(m.badge&&m.badge.provider){
+          const providerName=m.badge.provider.replace(/^custom:/,'').split('/')[0];
+          badgeLabel+=` (${providerName})`;
+        }
+        const badgeHtml=m.badge?`<span class="model-opt-badge model-opt-badge--${esc(m.badge.role||'configured')}">${esc(badgeLabel)}</span>`:'';
         row.innerHTML=`<div class="model-opt-top"><span class="model-opt-name">${m.name}</span>${badgeHtml}</div><span class="model-opt-id">${m.id}</span>`;
         row.onclick=()=>selectModelFromDropdown(m.value);
         dd.appendChild(row);

--- a/tests/test_inflight_stream_reuse.py
+++ b/tests/test_inflight_stream_reuse.py
@@ -35,7 +35,7 @@ def test_attach_live_stream_reuses_existing_same_stream_transport():
     therefore reuse the existing transport.
     """
     body = _function_body(MESSAGES_JS, "attachLiveStream")
-    close_pos = body.find("closeLiveStream(activeSid)")
+    close_pos = body.find("\n  closeLiveStream(activeSid);\n")
     reuse_pos = body.find("const existingLive=LIVE_STREAMS[activeSid]")
     assert reuse_pos != -1, "attachLiveStream() should check for an existing live stream"
     assert close_pos != -1, "attachLiveStream() should still close stale/different streams"
@@ -43,6 +43,32 @@ def test_attach_live_stream_reuses_existing_same_stream_transport():
     assert "existingLive.streamId===streamId" in body
     assert "existingLive.source.readyState!==EventSource.CLOSED" in body
     assert "return" in body[reuse_pos:close_pos]
+
+
+def test_attach_live_stream_updates_uploads_before_same_stream_reuse():
+    """Reusing transport must not skip per-session uploaded attachment state."""
+    body = _function_body(MESSAGES_JS, "attachLiveStream")
+    upload_pos = body.find("if(uploaded.length) INFLIGHT[activeSid].uploaded=[...uploaded]")
+    reuse_pos = body.find("const existingLive=LIVE_STREAMS[activeSid]")
+    close_pos = body.find("\n  closeLiveStream(activeSid);\n")
+    assert upload_pos != -1
+    assert reuse_pos != -1
+    assert close_pos != -1
+    assert upload_pos < reuse_pos < close_pos
+
+
+def test_attach_live_stream_different_stream_still_reopens_transport():
+    """A new stream id for the same session must not reuse the old transport."""
+    body = _function_body(MESSAGES_JS, "attachLiveStream")
+    reuse_pos = body.find("const existingLive=LIVE_STREAMS[activeSid]")
+    close_pos = body.find("\n  closeLiveStream(activeSid);\n")
+    assert reuse_pos != -1
+    assert close_pos != -1
+    reuse_block = body[reuse_pos:close_pos]
+    assert "existingLive.streamId===streamId" in reuse_block
+    assert "existingLive.streamId!==streamId" not in reuse_block
+    assert "return" in reuse_block
+    assert reuse_pos < close_pos
 
 
 def test_load_session_reattach_path_uses_attach_live_stream_for_running_sessions():

--- a/tests/test_inflight_stream_reuse.py
+++ b/tests/test_inflight_stream_reuse.py
@@ -1,0 +1,56 @@
+"""Regression tests for preserving live streams across session switches."""
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+MESSAGES_JS = (REPO_ROOT / "static" / "messages.js").read_text(encoding="utf-8")
+SESSIONS_JS = (REPO_ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
+
+
+def _function_body(src: str, name: str) -> str:
+    marker = f"function {name}("
+    start = src.find(marker)
+    assert start != -1, f"{name}() not found"
+    brace = src.find("){", start)
+    assert brace != -1, f"{name}() body not found"
+    brace += 1
+    depth = 1
+    i = brace + 1
+    while i < len(src) and depth:
+        if src[i] == "{":
+            depth += 1
+        elif src[i] == "}":
+            depth -= 1
+        i += 1
+    assert depth == 0, f"{name}() body did not close"
+    return src[brace + 1 : i - 1]
+
+
+def test_attach_live_stream_reuses_existing_same_stream_transport():
+    """Returning to a running session must not tear down its same SSE stream.
+
+    The server-side stream queue is not a replay log. If a sidebar switch back
+    to the running session closes and reopens the same EventSource, there is a
+    narrow window where stream events can be consumed by the old transport but
+    no longer represented in the pane/cache. The same session/stream pair should
+    therefore reuse the existing transport.
+    """
+    body = _function_body(MESSAGES_JS, "attachLiveStream")
+    close_pos = body.find("closeLiveStream(activeSid)")
+    reuse_pos = body.find("const existingLive=LIVE_STREAMS[activeSid]")
+    assert reuse_pos != -1, "attachLiveStream() should check for an existing live stream"
+    assert close_pos != -1, "attachLiveStream() should still close stale/different streams"
+    assert reuse_pos < close_pos, "same-stream reuse must run before closeLiveStream(activeSid)"
+    assert "existingLive.streamId===streamId" in body
+    assert "existingLive.source.readyState!==EventSource.CLOSED" in body
+    assert "return" in body[reuse_pos:close_pos]
+
+
+def test_load_session_reattach_path_uses_attach_live_stream_for_running_sessions():
+    """The session switch-back path should still route through attachLiveStream()."""
+    body = _function_body(SESSIONS_JS, "loadSession")
+    active_pos = body.find("const activeStreamId=S.session.active_stream_id||null")
+    reattach_pos = body.find("attachLiveStream(sid, activeStreamId")
+    assert active_pos != -1
+    assert reattach_pos != -1
+    assert active_pos < reattach_pos
+    assert "{reconnecting:true}" in body[reattach_pos : reattach_pos + 200]

--- a/tests/test_norm_model_id_trailing_empty_guard.py
+++ b/tests/test_norm_model_id_trailing_empty_guard.py
@@ -1,0 +1,80 @@
+"""Opus pre-release follow-up for stage-267:
+
+#1454/#1474 split(':')[-1] trailing-empty guard — when a malformed configured model id
+has a trailing colon (e.g. `@custom:foo:bar:`), the new normalization would collapse
+two distinct ids to the empty string. Defensive `parts[-1] or s` falls back to the
+original input so distinct ids stay distinct in the configured-model badge filter.
+
+Mirrors:
+  api/config.py        _norm_model_id
+  static/ui.js         _normalizeConfiguredModelKey
+"""
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+CONFIG_PY = (REPO_ROOT / "api" / "config.py").read_text(encoding="utf-8")
+UI_JS = (REPO_ROOT / "static" / "ui.js").read_text(encoding="utf-8")
+
+
+def _exec_norm():
+    """Re-execute the _norm_model_id closure body via a synthetic def, returning the function."""
+    # Extract source between `def _norm_model_id(model_id: str) -> str:` and the next `def _build_configured_model_badges`
+    start_marker = "def _norm_model_id(model_id: str) -> str:"
+    end_marker = "def _build_configured_model_badges"
+    s = CONFIG_PY.find(start_marker)
+    e = CONFIG_PY.find(end_marker, s)
+    assert s != -1 and e != -1
+    body = CONFIG_PY[s:e]
+    # Dedent (it's nested 8 spaces inside a function)
+    lines = body.splitlines()
+    # Find first non-blank line indent
+    indent = None
+    for ln in lines:
+        if ln.strip():
+            indent = len(ln) - len(ln.lstrip())
+            break
+    dedented = "\n".join(ln[indent:] if len(ln) >= indent else ln for ln in lines)
+    ns = {}
+    exec(dedented, ns)
+    return ns["_norm_model_id"]
+
+
+def test_norm_model_id_trailing_colon_keeps_original():
+    """Malformed @provider: ids with trailing colon must not collapse to empty."""
+    norm = _exec_norm()
+    # Trailing colon — last split segment is empty, must fall back to original
+    out = norm("@custom:foo:bar:")
+    assert out, f"trailing-colon collapsed to empty: {out!r}"
+
+
+def test_norm_model_id_clean_multi_segment_strips_correctly():
+    """Clean @custom:vendor:model still strips to last segment (the new fix's purpose)."""
+    norm = _exec_norm()
+    assert norm("@custom:jingdong:GLM-5") == "glm.5"
+
+
+def test_norm_model_id_trailing_slash_keeps_original():
+    """Same guard on the / branch — trailing slash must not collapse to empty."""
+    norm = _exec_norm()
+    out = norm("custom/jingdong/")
+    assert out, f"trailing-slash collapsed to empty: {out!r}"
+
+
+def test_norm_model_id_simple_inputs_unchanged():
+    """Sanity: simple inputs round-trip as before."""
+    norm = _exec_norm()
+    assert norm("gpt-4") == "gpt.4"
+    assert norm("provider/model-name") == "model.name"
+    assert norm("") == ""
+    assert norm(None) == ""
+
+
+def test_ui_js_mirror_has_trailing_empty_guard():
+    """Frontend _normalizeConfiguredModelKey must mirror the backend guard."""
+    # The new pattern uses `const last=s.split(':').pop();s=last||s;`
+    assert "s.split(':').pop()" in UI_JS, "ui.js no longer uses split-pop pattern"
+    # Look for the `||s` fallback specifically
+    snippet = UI_JS[UI_JS.find("function _normalizeConfiguredModelKey"):UI_JS.find("function _normalizeConfiguredModelKey") + 600]
+    assert "last||s" in snippet, "ui.js missing trailing-empty guard `||s` fallback"
+    # And mirror on / branch
+    assert snippet.count("last||s") >= 2, "ui.js trailing-empty guard not mirrored on slash branch"

--- a/tests/test_session_batch_select.py
+++ b/tests/test_session_batch_select.py
@@ -93,12 +93,12 @@ def test_batch_action_bar_overrides_css_hidden_state():
         src = f.read()
     assert "if(count>0){_renderBatchActionBar();}" in src, \
         "Updating selected count must render action buttons, not just reveal an empty bar"
-    assert "String(t('session_selected_count')).replace('{0}',_selectedSessions.size)" in src, \
-        "Selected count must interpolate string-valued i18n labels"
-    assert "String(t('session_batch_archive_confirm')).replace('{0}',ids.length)" in src, \
-        "Batch archive confirmation must interpolate selected session count"
-    assert "String(t('session_batch_delete_confirm')).replace('{0}',ids.length)" in src, \
-        "Batch delete confirmation must interpolate selected session count"
+    assert "t('session_selected_count',_selectedSessions.size)" in src, \
+        "Selected count must pass the selected session count to i18n"
+    assert "t('session_batch_archive_confirm',ids.length)" in src, \
+        "Batch archive confirmation must pass selected session count to i18n"
+    assert "t('session_batch_delete_confirm',ids.length)" in src, \
+        "Batch delete confirmation must pass selected session count to i18n"
     assert "bar.innerHTML='';bar.style.display=_selectedSessions.size>0?'flex':'none'" in src, \
         "Rendering the action bar must explicitly show it when selections exist"
     assert "batchBar.style.display='flex'" in src, \
@@ -198,6 +198,16 @@ def test_batch_select_i18n_keys():
     for key in required_keys:
         count = src.count(f"{key}:")
         assert count >= 8, f"Key '{key}' found {count} times, expected >= 8 (one per locale) (one per locale)"
+
+
+def test_i18n_string_placeholder_interpolation_supported():
+    """String-valued translations with {0} placeholders should interpolate args."""
+    with open('static/i18n.js') as f:
+        src = f.read()
+    assert "String(val).replace(/\\{(\\d+)\\}/g" in src, \
+        "t() must interpolate {0}-style placeholders for string-valued translations"
+    assert "Object.prototype.hasOwnProperty.call(args, idx)" in src, \
+        "t() must preserve unknown placeholders instead of replacing with undefined"
 
 
 def test_batch_select_css_exists():

--- a/tests/test_session_batch_select.py
+++ b/tests/test_session_batch_select.py
@@ -48,6 +48,20 @@ def test_batch_select_intercepts_navigation():
         "Pointerup handler should call toggleSessionSelect in select mode"
 
 
+def test_batch_checkbox_sets_selection_without_row_double_toggle():
+    """Clicking the checkbox itself must not also trigger row-level toggling."""
+    with open('static/sessions.js') as f:
+        src = f.read()
+    assert 'function setSessionSelected(sid, selected)' in src, \
+        "Checkbox changes should set explicit state instead of toggling blindly"
+    assert 'cb.onchange=(e)=>{e.stopPropagation();setSessionSelected(s.session_id,cb.checked);};' in src, \
+        "Checkbox change must use its checked state"
+    assert 'cb.onpointerup=(e)=>{e.stopPropagation();};' in src, \
+        "Checkbox pointerup must not bubble to the row pointerup handler"
+    assert 'cbWrapper.onpointerup=(e)=>{e.stopPropagation();};' in src, \
+        "Checkbox wrapper pointerup must not bubble to the row pointerup handler"
+
+
 def test_batch_select_escape_handler():
     """Verify Escape key exits select mode."""
     with open('static/sessions.js') as f:
@@ -71,6 +85,86 @@ def test_batch_select_bar_element():
     assert 'batchActionBar' in src, "Missing batchActionBar element"
     assert 'batch-action-bar' in src, "Missing batch-action-bar CSS class"
     assert 'batch-action-btn' in src, "Missing batch-action-btn class"
+
+
+def test_batch_action_bar_overrides_css_hidden_state():
+    """Selected sessions must make the fixed action bar visible."""
+    with open('static/sessions.js') as f:
+        src = f.read()
+    assert "if(count>0){_renderBatchActionBar();}" in src, \
+        "Updating selected count must render action buttons, not just reveal an empty bar"
+    assert "String(t('session_selected_count')).replace('{0}',_selectedSessions.size)" in src, \
+        "Selected count must interpolate string-valued i18n labels"
+    assert "String(t('session_batch_archive_confirm')).replace('{0}',ids.length)" in src, \
+        "Batch archive confirmation must interpolate selected session count"
+    assert "String(t('session_batch_delete_confirm')).replace('{0}',ids.length)" in src, \
+        "Batch delete confirmation must interpolate selected session count"
+    assert "bar.innerHTML='';bar.style.display=_selectedSessions.size>0?'flex':'none'" in src, \
+        "Rendering the action bar must explicitly show it when selections exist"
+    assert "batchBar.style.display='flex'" in src, \
+        "Session list render must explicitly show the action bar in select mode"
+
+
+def test_batch_action_bar_is_sidebar_inline_not_global_footer():
+    """Batch actions should appear in the session list, not over the composer."""
+    with open('static/sessions.js') as f:
+        js = f.read()
+    with open('static/style.css') as f:
+        css = f.read()
+    assert "list.appendChild(batchBar)" in js, \
+        "Batch action bar should be rendered inside the session list"
+    assert "document.body.appendChild(batchBar)" not in js, \
+        "Batch action bar must not be mounted as a global footer"
+    assert ".batch-action-bar{display:none;margin:" in css, \
+        "Batch action bar should use inline sidebar spacing"
+    assert "position:fixed" not in css[css.find(".batch-action-bar{"):css.find(".batch-count{")], \
+        "Batch action bar must not be fixed to the bottom of the viewport"
+
+
+def test_batch_project_picker_is_anchored_to_batch_actions():
+    """Batch move project picker should open inside the sidebar action bar."""
+    with open('static/sessions.js') as f:
+        js = f.read()
+    with open('static/style.css') as f:
+        css = f.read()
+    assert "const bar=$('batchActionBar');if(!bar)return;" in js, \
+        "Batch project picker should anchor to the batch action bar"
+    assert "picker.className='project-picker batch-project-picker'" in js, \
+        "Batch project picker needs its own inline styling hook"
+    assert "bar.appendChild(picker)" in js, \
+        "Batch project picker should render inside the batch action bar"
+    assert "document.body.appendChild(picker);picker.style.cssText='position:fixed" not in js, \
+        "Batch project picker must not use the old global fixed placement"
+    assert ".batch-action-bar .batch-project-picker{position:static;" in css, \
+        "Batch project picker should override the shared absolute project picker style"
+    assert css.find(".project-picker{") < css.find(".batch-action-bar .batch-project-picker{"), \
+        "Batch project picker override must come after the shared project picker rule"
+
+
+def test_streaming_zero_message_sessions_stay_visible_after_reload():
+    """In-flight sessions may have zero saved messages during reload recovery."""
+    with open('static/sessions.js') as f:
+        src = f.read()
+    assert "_isSessionEffectivelyStreaming(s)" in src, \
+        "Streaming sessions must bypass the zero-message sidebar filter"
+    assert "!!s.active_stream_id" in src, \
+        "Sessions with persisted active stream IDs must remain visible after reload"
+    assert "!!s.pending_user_message" in src, \
+        "Sessions with pending user turns must remain visible after reload"
+
+
+def test_boot_does_not_drop_zero_message_inflight_session():
+    """Reloading /session/<id> during a running turn must keep the session open."""
+    with open('static/boot.js') as f:
+        src = f.read()
+    assert "const _restoredInFlight = S.session && (" in src, \
+        "Boot must detect restored in-flight sessions before ephemeral cleanup"
+    assert "S.session.active_stream_id" in src, \
+        "Boot must treat active stream IDs as real sessions"
+    assert "S.session.pending_user_message" in src, \
+        "Boot must treat pending user messages as real sessions"
+    assert "&& !_restoredInFlight" in src, \
+        "Zero-message cleanup must not run for in-flight sessions"
 
 
 def test_batch_select_i18n_keys():


### PR DESCRIPTION
# v0.50.267 — 7 contributor PRs + Opus pre-release follow-up

Batch release of 7 contributor PRs (all green CI, all individually reviewed) plus 1 Opus advisor SHOULD-FIX defensive hardening.

## Constituent PRs (all closing on merge)

| PR | Author | Files | LOC | Summary |
|---|---|---|---|---|
| #1454 | @happy5318 | 1 | +7/-5 | `_norm_model_id` strips multi-segment provider prefixes |
| #1474 | @happy5318 | 1 | +9/-2 | Frontend `_normalizeConfiguredModelKey` parity + dropdown badge provider name |
| #1461 | @JKJameson | 1 | +1/-1 | `pushState` instead of `replaceState` for chat navigation |
| #1465 | @AlexeyDsov | 1 | +13/-0 | Session rename: `ondblclick` handler + loading guard |
| #1467 | @dso2ng | 2 | +92/-1 | Reuse in-flight session stream on switch-back (no event-loss window) |
| #1460 | @joaompfp | 2 | +15/-3 | Handle 401 redirect gracefully in `loadSession` flow (5 callsites) |
| #1473 | @Thanatos-Z | 5 | +151/-18 | Batch session actions + in-flight reload recovery + `t()` runtime placeholder substitution |

## Opus pre-release follow-up

Opus advisor flagged a `SHOULD-FIX` edge case in #1454/#1474: malformed configured-model IDs ending in a colon or slash (`@custom:foo:bar:` or `provider/model/`) would `split('...')[-1]` to an empty string, collapsing distinct IDs to the same key in the configured-model badge filter. Both backend (`api/config.py:1513`) and frontend (`static/ui.js:524`) helpers now fall back to the original input when the last segment is empty (`parts[-1] or s` / `last || s`). 5 regression tests in `tests/test_norm_model_id_trailing_empty_guard.py`.

Verdict from Opus: **MUST-FIX: none. SHOULD-FIX: this trailing-colon guard (now applied). OK as-is: other 6 PRs.**

## Test results

- **pytest tests/**: 3776 passed, 2 skipped, 3 xpassed (was 3760 before stage; +16 net: +11 from PR-bundled tests, +5 from Opus follow-up)
- **QA harness** (`bash ~/WebUI/scripts/run-browser-tests.sh`): 20/20 passed, all browser API sanity checks PASS on isolated port 8789
- **Mergeable**: clean against master at 4e0dce9 (current `master` HEAD)

## Diffstat (excluding tests)

```
 api/config.py      |  16 ++++++++++------
 static/boot.js     |   6 +++++-
 static/i18n.js     |   8 +++++++-
 static/messages.js |  11 ++++++++++-
 static/sessions.js |  71 ++++++++++++++++++++++++++++++++++++++++++++++++++---
 static/style.css   |   8 ++++----
 static/ui.js       |  20 +++++++++++++-----
 7 files changed, 121 insertions(+), 19 deletions(-)
```

## Release pipeline

1. ✅ Phase 0 fit-assessment (May 2026 policy) — all 7 PRs cleared
2. ✅ All 7 PRs merged into `stage-267` cleanly with `--no-ff` (preserves attribution)
3. ✅ Full pytest suite green (3776 passed)
4. ✅ QA harness green
5. ✅ Opus advisor review on stage diff (MUST-FIX: none; SHOULD-FIX applied)
6. ✅ Docs stamped: CHANGELOG.md / ROADMAP.md / TESTING.md
7. ⏳ This PR — CI 3.11/3.12/3.13
8. ⏳ Merge → tag v0.50.267 → restart on port 8787 → close constituent PRs + linked issues

## Closes

Closes #1454, #1474, #1461, #1465, #1467, #1460, #1473 on merge.
