### PR TITLE
fix: add bootstrap foreground mode for supervisors

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -68,6 +68,8 @@ DEFAULT_PORT = int(os.getenv("HERMES_WEBUI_PORT", "8787"))
 # Set HERMES_WEBUI_SKIP_ONBOARDING=1 to bypass the first-run wizard when
 # the environment is already fully configured (e.g. managed hosting).
 
+SUPERVISOR_ENV_VARS = ("LAUNCHD_SOCKET", "INVOCATION_ID", "NOTIFY_SOCKET")
+
 
 def info(msg: str) -> None:
     print(f"[bootstrap] {msg}", flush=True)
@@ -194,7 +196,12 @@ def open_browser(url: str) -> None:
         info(f"Could not open browser automatically: {exc}")
 
 
-def parse_args() -> argparse.Namespace:
+def supervisor_env_present(environ: dict[str, str] | None = None) -> bool:
+    environ = environ or os.environ
+    return any(environ.get(name) for name in SUPERVISOR_ENV_VARS)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Bootstrap Hermes Web UI onboarding.")
     parser.add_argument("port", nargs="?", type=int, default=DEFAULT_PORT)
     parser.add_argument("--host", default=DEFAULT_HOST)
@@ -208,7 +215,15 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Fail instead of attempting the official Hermes installer.",
     )
-    return parser.parse_args()
+    parser.add_argument(
+        "--foreground",
+        action="store_true",
+        help=(
+            "Run server.py in the current process for launchd/systemd-style "
+            "supervisors instead of spawning a detached child."
+        ),
+    )
+    return parser.parse_args(argv)
 
 
 def main() -> int:
@@ -239,6 +254,17 @@ def main() -> int:
         env["HERMES_WEBUI_AGENT_DIR"] = str(agent_dir)
 
     info(f"Starting Hermes Web UI on http://{args.host}:{args.port}")
+    if args.foreground or supervisor_env_present(env):
+        reason = "--foreground" if args.foreground else "supervisor environment detected"
+        info(f"Foreground mode enabled ({reason}); replacing bootstrap with server.py")
+        os.chdir(str(agent_dir or REPO_ROOT))
+        os.execve(
+            python_exe,
+            [python_exe, str(REPO_ROOT / "server.py")],
+            env,
+        )
+        raise RuntimeError("os.execve returned unexpectedly")
+
     with log_path.open("ab") as log_file:
         proc = subprocess.Popen(
             [python_exe, str(REPO_ROOT / "server.py")],

--- a/tests/test_bootstrap_foreground.py
+++ b/tests/test_bootstrap_foreground.py
@@ -1,0 +1,92 @@
+"""Regression tests for supervisor-friendly bootstrap foreground mode."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+
+def test_parse_args_accepts_foreground_flag():
+    import bootstrap as bs
+
+    args = bs.parse_args(["--foreground", "--no-browser", "18888"])
+
+    assert args.foreground is True
+    assert args.no_browser is True
+    assert args.port == 18888
+
+
+def test_supervisor_env_present_detects_launchd_and_systemd():
+    import bootstrap as bs
+
+    assert bs.supervisor_env_present({}) is False
+    assert bs.supervisor_env_present({"LAUNCHD_SOCKET": "/tmp/launchd.sock"}) is True
+    assert bs.supervisor_env_present({"INVOCATION_ID": "systemd-unit"}) is True
+    assert bs.supervisor_env_present({"NOTIFY_SOCKET": "/run/notify"}) is True
+
+
+def test_foreground_replaces_bootstrap_without_popen(monkeypatch, tmp_path):
+    import bootstrap as bs
+
+    calls = {}
+
+    def fake_execve(executable, argv, env):
+        calls["execve"] = (executable, argv, env)
+        raise SystemExit(0)
+
+    def fail_popen(*_args, **_kwargs):
+        raise AssertionError("foreground mode must not spawn a detached child")
+
+    monkeypatch.setattr(sys, "argv", ["bootstrap.py", "--foreground", "--no-browser"])
+    monkeypatch.setenv("HERMES_WEBUI_STATE_DIR", str(tmp_path))
+    monkeypatch.setattr(bs, "ensure_supported_platform", lambda: None)
+    monkeypatch.setattr(bs, "discover_agent_dir", lambda: None)
+    monkeypatch.setattr(bs, "hermes_command_exists", lambda: True)
+    monkeypatch.setattr(bs, "discover_launcher_python", lambda _agent_dir: "python3")
+    monkeypatch.setattr(bs, "ensure_python_has_webui_deps", lambda _python: "/bin/python3")
+    monkeypatch.setattr(bs.subprocess, "Popen", fail_popen)
+    monkeypatch.setattr(bs, "wait_for_health", lambda _url: False)
+    monkeypatch.setattr(bs.os, "chdir", lambda path: calls.setdefault("chdir", path))
+    monkeypatch.setattr(bs.os, "execve", fake_execve)
+
+    with pytest.raises(SystemExit) as exc:
+        bs.main()
+
+    assert exc.value.code == 0
+    assert calls["chdir"] == str(bs.REPO_ROOT)
+    executable, argv, env = calls["execve"]
+    assert executable == "/bin/python3"
+    assert argv == ["/bin/python3", str(bs.REPO_ROOT / "server.py")]
+    assert env["HERMES_WEBUI_HOST"] == bs.DEFAULT_HOST
+    assert env["HERMES_WEBUI_PORT"] == str(bs.DEFAULT_PORT)
+    assert env["HERMES_WEBUI_STATE_DIR"] == str(tmp_path)
+
+
+def test_supervisor_env_triggers_foreground_without_flag(monkeypatch, tmp_path):
+    import bootstrap as bs
+
+    calls = {}
+
+    def fake_execve(executable, argv, env):
+        calls["execve"] = (executable, argv, env)
+        raise SystemExit(0)
+
+    monkeypatch.setattr(sys, "argv", ["bootstrap.py", "--no-browser"])
+    monkeypatch.setenv("HERMES_WEBUI_STATE_DIR", str(tmp_path))
+    monkeypatch.setenv("INVOCATION_ID", "unit-id")
+    monkeypatch.setattr(bs, "ensure_supported_platform", lambda: None)
+    monkeypatch.setattr(bs, "discover_agent_dir", lambda: None)
+    monkeypatch.setattr(bs, "hermes_command_exists", lambda: True)
+    monkeypatch.setattr(bs, "discover_launcher_python", lambda _agent_dir: "python3")
+    monkeypatch.setattr(bs, "ensure_python_has_webui_deps", lambda _python: "/bin/python3")
+    monkeypatch.setattr(bs.subprocess, "Popen", lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("Popen called")))
+    monkeypatch.setattr(bs.os, "chdir", lambda _path: None)
+    monkeypatch.setattr(bs.os, "execve", fake_execve)
+
+    with pytest.raises(SystemExit) as exc:
+        bs.main()
+
+    assert exc.value.code == 0
+    assert calls["execve"][2]["INVOCATION_ID"] == "unit-id"


### PR DESCRIPTION
Refs #1458 (Bug #1 only).

This adds a supervisor-friendly foreground path to `bootstrap.py`:

- new `--foreground` flag for launchd/systemd/run-it-under-a-supervisor usage
- auto-detects common supervisor env vars (`LAUNCHD_SOCKET`, `INVOCATION_ID`, `NOTIFY_SOCKET`)
- uses `os.execve()` to replace the bootstrap process with `server.py` instead of `Popen(..., start_new_session=True)` followed by parent exit
- keeps the existing detached child path unchanged for normal one-shot/interactive startup

`start.sh` already forwards `$@` to `bootstrap.py`, so `./start.sh --foreground` works without a shell wrapper change.

Validation:

```bash
python -m pytest tests/test_bootstrap_foreground.py tests/test_bootstrap_dotenv.py -q
# 20 passed

python -m py_compile bootstrap.py
```