### PR TITLE
Fix session list pending message payload

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -479,6 +479,7 @@ class Session:
             # Sessions without a fork must not leak None — see test_session_lineage_metadata_api.
             **({'parent_session_id': self.parent_session_id} if self.parent_session_id else {}),
             'active_stream_id': self.active_stream_id,
+            'pending_user_message': self.pending_user_message,
             'is_cli_session': self.is_cli_session,
             'source_tag': self.source_tag,
             'session_source': self.session_source,

--- a/static/i18n.js
+++ b/static/i18n.js
@@ -7519,6 +7519,7 @@ function t(key, ...args) {
   if (val === undefined) return key;  // final fallback: return key itself
   if (typeof val === 'function') return val(...args);
   if (args.length) {
+    // Locale strings can use numbered placeholders like {0} and {1}.
     return String(val).replace(/\{(\d+)\}/g, (match, idx) => (
       Object.prototype.hasOwnProperty.call(args, idx) ? String(args[idx]) : match
     ));

--- a/tests/test_issue856_session_streaming_state.py
+++ b/tests/test_issue856_session_streaming_state.py
@@ -47,9 +47,11 @@ def _make_session(session_id, stream_id=None, message_count=1):
 def test_all_sessions_marks_indexed_and_in_memory_streaming_sessions():
     """Session records from both index and in-memory cache should expose is_streaming."""
     s_disk = _make_session("disk_session", stream_id="stream-1")
+    s_disk.pending_user_message = "pending disk turn"
     s_disk.save()
 
     s_memory = _make_session("memory_session", stream_id="stream-2")
+    s_memory.pending_user_message = "pending memory turn"
     with models.LOCK:
         models.SESSIONS[s_memory.session_id] = s_memory
 
@@ -62,6 +64,8 @@ def test_all_sessions_marks_indexed_and_in_memory_streaming_sessions():
     assert by_sid["disk_session"]["is_streaming"] is True
     assert by_sid["memory_session"]["is_streaming"] is True
     assert by_sid["memory_session"]["active_stream_id"] == "stream-2"
+    assert by_sid["disk_session"]["pending_user_message"] == "pending disk turn"
+    assert by_sid["memory_session"]["pending_user_message"] == "pending memory turn"
 
 
 def test_all_sessions_marks_streaming_false_when_stream_is_not_active():


### PR DESCRIPTION
## Summary

Follow-up to merged PR #1473.

The frontend reload/sidebar recovery logic already checks both `active_stream_id` and `pending_user_message`, but the `/api/sessions` list payload still omitted `pending_user_message` from `Session.compact()`. That meant the sidebar filter could not reliably preserve zero-message in-flight sessions based on pending user text alone.

This patch:

- adds `pending_user_message` to the compact session payload used by `/api/sessions`
- extends the existing session streaming-state regression test to assert the field is present for both indexed and in-memory sessions
- adds the one-line `{0}` placeholder comment requested in review next to `t()` string interpolation

## Why this is separate

PR #1473 is already merged. This is the smallest follow-up patch to close the remaining backend payload gap identified in review.

## Tests

I was able to verify the code path and keep the patch minimal, but I could not run `tests/test_issue856_session_streaming_state.py` to completion inside the current local sandbox because `api.config` rejects the sandbox workspace during import-time default workspace resolution.

The added test is a direct extension of the existing backend regression coverage in `tests/test_issue856_session_streaming_state.py`.
