### PR TITLE
fix(onboarding,providers): probe LM Studio /models + align env var with agent CLI (#1499 #1500)

### DIFF
--- a/api/onboarding.py
+++ b/api/onboarding.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import os
+import socket
+import urllib.error
+import urllib.request
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -71,7 +75,18 @@ _SUPPORTED_PROVIDER_SETUPS = {
     },
     "lmstudio": {
         "label": "LM Studio",
-        "env_var": "LMSTUDIO_API_KEY",
+        # Canonical env var matches the agent CLI runtime (hermes_cli/auth.py:182,
+        # api_key_env_vars=("LM_API_KEY",)).  Onboarding writes this name so the
+        # agent runtime actually picks up the key on the next chat — pre-#1499/#1500
+        # the WebUI wrote LMSTUDIO_API_KEY which the agent runtime ignored, masked
+        # in practice by the LMSTUDIO_NOAUTH_PLACEHOLDER fallback for keyless installs.
+        "env_var": "LM_API_KEY",
+        # Legacy env var written by older WebUI builds (≤ v0.50.272).  Detection
+        # paths (_provider_api_key_present here, _provider_has_key in providers.py)
+        # also read this name so existing users with the old key in their .env
+        # don't flip to "no key" in Settings → Providers after upgrading.
+        # Onboarding only writes the canonical name going forward.
+        "env_var_aliases": ["LMSTUDIO_API_KEY"],
         "default_model": "gpt-4o-mini",
         "default_base_url": "http://localhost:1234/v1",
         "requires_base_url": True,
@@ -228,6 +243,181 @@ def _normalize_base_url(base_url: str) -> str:
     return (base_url or "").strip().rstrip("/")
 
 
+# ── Provider endpoint probe (#1499) ─────────────────────────────────────────
+
+# Probe error codes — stable strings the frontend can switch on for inline
+# error rendering.  Add new codes only by extending this set; never reuse.
+PROBE_ERROR_CODES = (
+    "invalid_url",       # base_url failed urlparse / scheme / host check
+    "dns",               # hostname did not resolve
+    "connect_refused",   # TCP RST on connect (server not listening)
+    "timeout",           # exceeded probe timeout
+    "http_4xx",          # endpoint returned 4xx (auth required, wrong path, …)
+    "http_5xx",          # endpoint returned 5xx (server-side fault)
+    "parse",             # body not JSON or not the OpenAI /models shape
+    "unreachable",       # other network / SSL / unknown error
+)
+
+PROBE_TIMEOUT_SECONDS = 5.0
+# OpenAI /models response can list dozens of entries on Ollama / LM Studio.
+# 256 KB is more than enough for any realistic catalog and bounds the worst
+# case for a hostile / mis-pointed endpoint that streams forever.
+PROBE_MAX_BYTES = 256 * 1024
+
+
+def probe_provider_endpoint(
+    provider: str,
+    base_url: str,
+    api_key: str | None = None,
+    timeout: float = PROBE_TIMEOUT_SECONDS,
+) -> dict:
+    """Probe `<base_url>/models` for a self-hosted OpenAI-compatible provider.
+
+    Used by the onboarding wizard to validate the user's configured base URL
+    before persisting (#1499).  Distinguishes failure modes so the frontend
+    can render a precise inline error instead of a generic "could not save."
+
+    Returns one of:
+
+      {"ok": True, "models": [{"id": "...", "label": "..."}, ...]}
+      {"ok": False, "error": "<code>", "detail": "<human string>"}
+
+    Where ``<code>`` is one of ``PROBE_ERROR_CODES``.
+
+    The probe is a single HTTP GET — no retries.  The timeout is short by
+    design: the wizard runs the probe synchronously on the user's submit
+    click, and we'd rather report "timeout" quickly than block the UI for
+    the kernel default ~75s.
+
+    The probe response is NOT persisted.  This function returns model IDs
+    so the wizard can populate its dropdown, but ``apply_onboarding_setup``
+    only writes the user's typed selection — never auto-pinning a stale
+    list of models to ``config.yaml``.
+
+    SSRF: ``base_url`` is whatever the user typed in the onboarding form.
+    The wizard is gated behind authentication (post-onboarding, the user
+    has already authenticated to the WebUI), and the legitimate target is
+    a local LM Studio / Ollama / vLLM server, so we deliberately do not
+    block private-IP ranges — that would make the feature useless.  The
+    risk surface is "authenticated user crafts a probe to enumerate
+    internal HTTP services," which is a different threat model from
+    unauthenticated SSRF.
+    """
+    base_url = _normalize_base_url(base_url)
+    if not base_url:
+        return {"ok": False, "error": "invalid_url", "detail": "base_url is required"}
+
+    parsed = urlparse(base_url)
+    if parsed.scheme not in {"http", "https"}:
+        return {
+            "ok": False,
+            "error": "invalid_url",
+            "detail": "base_url must start with http:// or https://",
+        }
+    if not parsed.hostname:
+        return {"ok": False, "error": "invalid_url", "detail": "base_url has no host"}
+
+    # Build the probe URL.  OpenAI-compatible servers expose /v1/models or
+    # /models.  Most users supply a base URL ending in /v1, so we just append
+    # /models to whatever they typed.  Strip the trailing slash and append
+    # rather than urljoin to avoid eating the /v1 segment when there's no
+    # trailing slash.
+    probe_url = f"{base_url}/models"
+
+    headers = {
+        "Accept": "application/json",
+        "User-Agent": "hermes-webui-onboarding-probe",
+    }
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+
+    req = urllib.request.Request(probe_url, headers=headers, method="GET")
+
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            status = resp.status
+            body = resp.read(PROBE_MAX_BYTES + 1)
+    except urllib.error.HTTPError as exc:
+        # 4xx / 5xx with a body — categorize.
+        code = "http_4xx" if 400 <= exc.code < 500 else "http_5xx"
+        # Try to surface a useful detail (LM Studio sometimes returns text/plain).
+        try:
+            err_body = exc.read(2048).decode("utf-8", errors="replace").strip()
+        except Exception:
+            err_body = ""
+        detail = f"HTTP {exc.code}"
+        if err_body:
+            err_first = err_body.splitlines()[0][:200]
+            detail = f"{detail}: {err_first}"
+        return {"ok": False, "error": code, "detail": detail, "status": exc.code}
+    except urllib.error.URLError as exc:
+        # Distinguish DNS / connect-refused / timeout / generic.
+        reason = exc.reason
+        if isinstance(reason, socket.timeout) or "timed out" in str(reason).lower():
+            return {"ok": False, "error": "timeout", "detail": f"connection timed out after {timeout:g}s"}
+        if isinstance(reason, socket.gaierror):
+            return {
+                "ok": False,
+                "error": "dns",
+                "detail": f"could not resolve host '{parsed.hostname}'",
+            }
+        if isinstance(reason, ConnectionRefusedError) or "refused" in str(reason).lower():
+            port_hint = parsed.port or ("443" if parsed.scheme == "https" else "80")
+            return {
+                "ok": False,
+                "error": "connect_refused",
+                "detail": f"connection refused at {parsed.hostname}:{port_hint}",
+            }
+        return {"ok": False, "error": "unreachable", "detail": str(reason)[:200]}
+    except (TimeoutError, socket.timeout):
+        return {"ok": False, "error": "timeout", "detail": f"connection timed out after {timeout:g}s"}
+    except Exception as exc:  # pragma: no cover — defensive net
+        logger.debug("probe_provider_endpoint unexpected error", exc_info=True)
+        return {"ok": False, "error": "unreachable", "detail": str(exc)[:200]}
+
+    # If the response was huge, refuse to parse.  256 KB cap is generous;
+    # anything bigger is likely the user pointed us at the wrong service.
+    if len(body) > PROBE_MAX_BYTES:
+        return {
+            "ok": False,
+            "error": "parse",
+            "detail": f"response exceeded {PROBE_MAX_BYTES // 1024} KB cap",
+        }
+
+    try:
+        payload = json.loads(body.decode("utf-8", errors="replace"))
+    except (ValueError, UnicodeDecodeError) as exc:
+        return {
+            "ok": False,
+            "error": "parse",
+            "detail": f"response is not JSON ({exc.__class__.__name__})",
+        }
+
+    # Accept both the OpenAI shape (`{"data": [{"id": ...}, ...]}`) and the
+    # bare-list shape some self-hosted servers return (`[{"id": ...}, ...]`).
+    if isinstance(payload, dict) and isinstance(payload.get("data"), list):
+        entries = payload["data"]
+    elif isinstance(payload, list):
+        entries = payload
+    else:
+        return {
+            "ok": False,
+            "error": "parse",
+            "detail": "response is not in OpenAI /models shape (expected {'data': [...]} or [...])",
+        }
+
+    models = []
+    for entry in entries:
+        if isinstance(entry, dict) and entry.get("id"):
+            mid = str(entry["id"]).strip()
+            if mid:
+                models.append({"id": mid, "label": mid})
+        elif isinstance(entry, str) and entry.strip():
+            models.append({"id": entry.strip(), "label": entry.strip()})
+
+    return {"ok": True, "models": models, "status": status}
+
+
 def _extract_current_provider(cfg: dict) -> str:
     model_cfg = cfg.get("model", {})
     if isinstance(model_cfg, dict):
@@ -263,6 +453,15 @@ def _provider_api_key_present(
     env_var = _SUPPORTED_PROVIDER_SETUPS.get(provider, {}).get("env_var")
     if env_var and env_values.get(env_var):
         return True
+
+    # Legacy env-var aliases (read-only fallback for env vars renamed in past
+    # releases — e.g. lmstudio's LM_API_KEY canonical + LMSTUDIO_API_KEY legacy
+    # in #1500).  Canonical name is what onboarding writes going forward;
+    # aliases keep existing users' detection working without forcing an .env
+    # rewrite.
+    for alias in _SUPPORTED_PROVIDER_SETUPS.get(provider, {}).get("env_var_aliases", []) or []:
+        if alias and env_values.get(alias):
+            return True
 
     model_cfg = cfg.get("model", {})
     if isinstance(model_cfg, dict) and str(model_cfg.get("api_key") or "").strip():

--- a/api/onboarding.py
+++ b/api/onboarding.py
@@ -70,6 +70,10 @@ _SUPPORTED_PROVIDER_SETUPS = {
         "default_model": "qwen3:32b",
         "default_base_url": "http://localhost:11434/v1",
         "requires_base_url": True,
+        # Local Ollama runs keyless by default — only Ollama Cloud requires
+        # OLLAMA_API_KEY.  The wizard accepts an empty api_key for this
+        # provider; users with auth enabled can still type one.  See #1499.
+        "key_optional": True,
         "models": [],
         "category": "self_hosted",
     },
@@ -90,6 +94,11 @@ _SUPPORTED_PROVIDER_SETUPS = {
         "default_model": "gpt-4o-mini",
         "default_base_url": "http://localhost:1234/v1",
         "requires_base_url": True,
+        # Most LM Studio installs run keyless (LMSTUDIO_NOAUTH_PLACEHOLDER on the
+        # agent side handles this).  The wizard accepts an empty api_key; auth-
+        # enabled servers still need one but the user types it in the same field.
+        # See #1499 (third sub-bug from #1420).
+        "key_optional": True,
         "models": [],
         "category": "self_hosted",
     },
@@ -98,6 +107,11 @@ _SUPPORTED_PROVIDER_SETUPS = {
         "env_var": "OPENAI_API_KEY",
         "default_model": "gpt-4o-mini",
         "requires_base_url": True,
+        # Many self-hosted OpenAI-compatible servers (vLLM, llama-server,
+        # TabbyAPI, etc.) run keyless behind a private network.  The wizard
+        # accepts an empty api_key — auth-protected endpoints can still
+        # supply one.  See #1499.
+        "key_optional": True,
         "models": [],
         "category": "self_hosted",
     },
@@ -574,12 +588,30 @@ def _status_from_runtime(cfg: dict, imports_ok: bool) -> dict:
     provider_ready = False
 
     if provider_configured:
-        if provider == "custom":
-            provider_ready = bool(
-                base_url and _provider_api_key_present(provider, cfg, env_values)
-            )
-        elif provider in _SUPPORTED_PROVIDER_SETUPS:
-            provider_ready = _provider_api_key_present(provider, cfg, env_values)
+        meta = _SUPPORTED_PROVIDER_SETUPS.get(provider, {})
+        if provider in _SUPPORTED_PROVIDER_SETUPS:
+            # key_optional providers (lmstudio, ollama, custom) are ready as
+            # soon as the user has saved a provider+model+base_url; an api_key
+            # is allowed but not required.  The agent runtime substitutes a
+            # placeholder for keyless local servers (LMSTUDIO_NOAUTH_PLACEHOLDER
+            # for lmstudio, equivalent paths for ollama / custom).  See #1499
+            # third sub-bug from #1420.
+            if meta.get("key_optional"):
+                if meta.get("requires_base_url"):
+                    provider_ready = bool(base_url)
+                else:
+                    provider_ready = True
+            else:
+                # Standard wizard provider (openrouter, anthropic, openai, gemini,
+                # deepseek, zai, …) — needs an api_key.  Custom historically also
+                # took this branch, but is now key_optional via the meta flag.
+                if meta.get("requires_base_url"):
+                    provider_ready = bool(
+                        base_url
+                        and _provider_api_key_present(provider, cfg, env_values)
+                    )
+                else:
+                    provider_ready = _provider_api_key_present(provider, cfg, env_values)
         else:
             # Unknown provider — may be an OAuth flow (openai-codex, copilot, etc.)
             # OR an API-key provider not in the quick-setup list (minimax-cn, deepseek,
@@ -655,6 +687,10 @@ def _build_setup_catalog(cfg: dict) -> dict:
                 "default_model": meta["default_model"],
                 "default_base_url": meta.get("default_base_url") or "",
                 "requires_base_url": bool(meta.get("requires_base_url")),
+                # #1499 (third sub-bug from #1420) — providers that may run
+                # keyless (lmstudio, ollama, custom).  Frontend uses this to
+                # show a "(optional)" hint and allow Continue without a key.
+                "key_optional": bool(meta.get("key_optional")),
                 "models": list(meta.get("models", [])),
                 "category": meta.get("category", "easy_start"),
                 "quick": meta.get("quick", False),
@@ -842,7 +878,14 @@ def apply_onboarding_setup(body: dict) -> dict:
     env_values = _load_env_file(env_path)
 
     if not api_key and not _provider_api_key_present(provider, cfg, env_values):
-        raise ValueError(f"{provider_meta['env_var']} is required")
+        # Providers that may run keyless (lmstudio, ollama, custom — gated by
+        # `key_optional` in _SUPPORTED_PROVIDER_SETUPS) are allowed to onboard
+        # with no api_key.  The agent runtime substitutes a placeholder
+        # (LMSTUDIO_NOAUTH_PLACEHOLDER) for those, and the probe (#1499) gives
+        # the user immediate feedback if their server actually does require
+        # auth (http_4xx with status 401).  See #1499 third sub-bug from #1420.
+        if not provider_meta.get("key_optional"):
+            raise ValueError(f"{provider_meta['env_var']} is required")
 
     model_cfg = cfg.get("model", {})
     if not isinstance(model_cfg, dict):

--- a/api/onboarding.py
+++ b/api/onboarding.py
@@ -279,6 +279,29 @@ PROBE_TIMEOUT_SECONDS = 5.0
 PROBE_MAX_BYTES = 256 * 1024
 
 
+class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Refuse to follow HTTP redirects on the probe path.
+
+    `urllib.request.urlopen` follows redirects by default — without this
+    handler, a probe at `http://example.com/v1/models` could be redirected
+    to `http://internal-service:8080/admin`, surfacing internal HTTP services
+    to whatever the probe targets next.  The probe is already gated behind
+    WebUI auth and the local-network check, so the threat model is
+    "authenticated user enumerating internal services" — same as `curl`
+    from their browser DevTools.  Disabling redirects tightens defaults
+    without breaking any legitimate use case (a self-hosted /models endpoint
+    that 3xx-redirects is itself misconfigured).  Redirects surface to the
+    caller as `unreachable` (mapped from `HTTPError(3xx)` in the probe).
+    Reviewer-flagged in PR #1501 (#1499 + #1500).
+    """
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return None  # tell urllib to NOT follow; raises HTTPError(3xx) instead
+
+
+_PROBE_OPENER = urllib.request.build_opener(_NoRedirectHandler())
+
+
 def probe_provider_endpoint(
     provider: str,
     base_url: str,
@@ -348,11 +371,23 @@ def probe_provider_endpoint(
     req = urllib.request.Request(probe_url, headers=headers, method="GET")
 
     try:
-        with urllib.request.urlopen(req, timeout=timeout) as resp:
+        with _PROBE_OPENER.open(req, timeout=timeout) as resp:
             status = resp.status
             body = resp.read(PROBE_MAX_BYTES + 1)
     except urllib.error.HTTPError as exc:
-        # 4xx / 5xx with a body — categorize.
+        # 3xx / 4xx / 5xx with a body — categorize.  3xx happens when the
+        # endpoint redirects (we refuse to follow on the probe path — see
+        # _NoRedirectHandler).  Map to `unreachable` rather than introducing a
+        # new error code, since a self-hosted /models endpoint that 3xx-
+        # redirects is itself misconfigured.
+        if 300 <= exc.code < 400:
+            code = "unreachable"
+            detail = (
+                f"HTTP {exc.code} — endpoint returned a redirect "
+                f"(probe does not follow redirects).  Point base_url at the "
+                f"final URL directly."
+            )
+            return {"ok": False, "error": code, "detail": detail, "status": exc.code}
         code = "http_4xx" if 400 <= exc.code < 500 else "http_5xx"
         # Try to surface a useful detail (LM Studio sometimes returns text/plain).
         try:

--- a/api/providers.py
+++ b/api/providers.py
@@ -53,14 +53,29 @@ _PROVIDER_ENV_VAR: dict[str, str] = {
     # via providers.ollama.api_key in config.yaml — that path remains supported
     # by _provider_has_key().
     "ollama-cloud": "OLLAMA_API_KEY",
-    # NOTE: bare "lmstudio" maps to LMSTUDIO_API_KEY (no conflict — this env var is
-    # only consumed by the lmstudio runtime, not by ollama-cloud or any sibling).
-    # Without this entry, Settings → Providers would render LM Studio as
-    # has_key=False / configurable=False even when LMSTUDIO_API_KEY is set in
-    # ~/.hermes/.env (e.g. via a successful onboarding wizard run), and the user
-    # would have no UI surface to add or update the key.  See #1420.
-    "lmstudio": "LMSTUDIO_API_KEY",
+    # Bare "lmstudio" maps to LM_API_KEY — the canonical env var the agent CLI
+    # runtime reads (hermes_cli/auth.py:182, api_key_env_vars=("LM_API_KEY",)).
+    # Pre-#1499/#1500 the WebUI used LMSTUDIO_API_KEY here, which made Settings
+    # report keys correctly but the agent runtime ignored them — masked in
+    # practice by the LMSTUDIO_NOAUTH_PLACEHOLDER for keyless local installs.
+    # Aligning to LM_API_KEY makes a configured LM Studio key actually work
+    # for chat. The legacy LMSTUDIO_API_KEY name is read by `_provider_has_key`
+    # via _PROVIDER_ENV_VAR_ALIASES below so existing users don't see Settings
+    # flip to "no key" after upgrading.
+    "lmstudio": "LM_API_KEY",
     "nvidia": "NVIDIA_API_KEY",
+}
+
+# Read-only legacy env-var aliases.  When `_provider_has_key(pid)` looks up its
+# canonical env var name and finds nothing, it also checks any aliases listed
+# here.  Onboarding (api/onboarding.py:apply_onboarding_setup) only writes the
+# canonical name.  Use this for env vars that were renamed in a past release;
+# add an entry, ship for a few releases, then remove the alias once enough
+# users have upgraded.
+_PROVIDER_ENV_VAR_ALIASES: dict[str, tuple[str, ...]] = {
+    # #1500 — agent runtime reads LM_API_KEY (canonical), but WebUI builds
+    # ≤ v0.50.272 wrote LMSTUDIO_API_KEY into .env.  Keep reading both.
+    "lmstudio": ("LMSTUDIO_API_KEY",),
 }
 
 # Providers that use OAuth or token flows — their credentials are managed
@@ -218,6 +233,14 @@ def _provider_has_key(provider_id: str) -> bool:
             return True
         if os.getenv(env_var):
             return True
+        # Fall back to legacy env-var aliases (e.g. lmstudio's pre-#1500
+        # LMSTUDIO_API_KEY name) so existing users don't lose detection
+        # after an env-var rename.  See _PROVIDER_ENV_VAR_ALIASES.
+        for alias in _PROVIDER_ENV_VAR_ALIASES.get(provider_id, ()) or ():
+            if env_values.get(alias):
+                return True
+            if os.getenv(alias):
+                return True
 
     cfg = get_config()
     # Check model.api_key — only match if this provider is the active one.
@@ -324,7 +347,22 @@ def get_providers() -> dict[str, Any]:
                 elif os.getenv(env_var):
                     key_source = "env_var"
                 else:
-                    key_source = "config_yaml"
+                    # Canonical name not set; check legacy aliases (e.g. lmstudio's
+                    # pre-#1500 LMSTUDIO_API_KEY) so existing users see "env_file"
+                    # instead of being misreported as "config_yaml" when the key
+                    # actually lives in .env under the old name.
+                    aliased = False
+                    for alias in _PROVIDER_ENV_VAR_ALIASES.get(pid, ()) or ():
+                        if env_values.get(alias):
+                            key_source = "env_file"
+                            aliased = True
+                            break
+                        if os.getenv(alias):
+                            key_source = "env_var"
+                            aliased = True
+                            break
+                    if not aliased:
+                        key_source = "config_yaml"
             else:
                 key_source = "config_yaml"
         elif pid not in _PROVIDER_ENV_VAR:

--- a/api/routes.py
+++ b/api/routes.py
@@ -707,6 +707,7 @@ from api.onboarding import (
     apply_onboarding_setup,
     get_onboarding_status,
     complete_onboarding,
+    probe_provider_endpoint,
 )
 
 # Approval system (optional -- graceful fallback if agent not available)
@@ -2569,6 +2570,36 @@ def handle_post(handler, parsed) -> bool:
 
     if parsed.path == "/api/onboarding/complete":
         return j(handler, complete_onboarding())
+
+    if parsed.path == "/api/onboarding/probe":
+        # Probe a self-hosted provider endpoint (#1499).  Validates the
+        # configured base URL is reachable + parses /models, returns the
+        # model catalog so the wizard can populate its dropdown.
+        # Read-only: no config.yaml or .env writes happen here.  Same local-
+        # network gate as /api/onboarding/setup (also writing-adjacent in
+        # spirit because it carries an api_key the user typed).
+        from api.auth import is_auth_enabled
+        import os as _os
+        if not is_auth_enabled() and not _os.getenv("HERMES_WEBUI_ONBOARDING_OPEN"):
+            import ipaddress
+            try:
+                _xff = handler.headers.get("X-Forwarded-For", "").split(",")[0].strip()
+                _xri = handler.headers.get("X-Real-IP", "").strip()
+                _raw = handler.client_address[0]
+                _ip_str = _xff or _xri or _raw
+                addr = ipaddress.ip_address(_ip_str)
+                is_local = addr.is_loopback or addr.is_private
+            except ValueError:
+                is_local = False
+            if not is_local:
+                return bad(handler, "Onboarding probe is only available from local networks when auth is not enabled. To bypass this on a remote server, set HERMES_WEBUI_ONBOARDING_OPEN=1.", 403)
+        provider = str((body or {}).get("provider") or "").strip().lower()
+        base_url = str((body or {}).get("base_url") or "")
+        api_key = str((body or {}).get("api_key") or "").strip() or None
+        try:
+            return j(handler, probe_provider_endpoint(provider, base_url, api_key))
+        except Exception as e:
+            return bad(handler, f"probe failed: {e}", 500)
 
     # ── Session pin (POST) ──
     if parsed.path == "/api/session/pin":

--- a/static/i18n.js
+++ b/static/i18n.js
@@ -647,6 +647,19 @@ const LOCALES = {
     onboarding_error_choose_model: 'Choose a model before continuing.',
     onboarding_error_provider_required: 'Choose a setup mode before continuing.',
     onboarding_error_base_url_required: 'Base URL is required for custom endpoints.',
+    onboarding_probe_test_button: 'Test connection',
+    onboarding_probe_probing: 'Testing connection…',
+    onboarding_probe_ok: 'Connected. {n} model(s) available.',
+    onboarding_probe_error_generic: 'Could not reach the configured base URL.',
+    onboarding_probe_error_invalid_url: 'Base URL must start with http:// or https://.',
+    onboarding_probe_error_dns: 'Could not resolve the host. Check the URL or use the host\'s IP address.',
+    onboarding_probe_error_connect_refused: 'Connection refused — the server may not be running on that address. From inside Docker, try the host IP instead of localhost.',
+    onboarding_probe_error_timeout: 'The endpoint did not respond in time. Check that the server is running and the URL is correct.',
+    onboarding_probe_error_http_4xx: 'The endpoint returned a client error. Check authentication and the URL path (typically ends in /v1).',
+    onboarding_probe_error_http_5xx: 'The endpoint returned a server error. Check the LM Studio / Ollama server logs.',
+    onboarding_probe_error_parse: 'The endpoint did not return a model list in the expected shape. Verify the URL points to the OpenAI-compatible API root.',
+    onboarding_probe_error_unreachable: 'Could not reach the configured base URL.',
+    onboarding_error_probe_failed: 'Could not validate the configured base URL.',
     onboarding_error_workspace_required: 'Workspace is required.',
     onboarding_error_model_required: 'Model is required.',
     onboarding_complete: 'Onboarding complete',
@@ -1527,6 +1540,19 @@ const LOCALES = {
     onboarding_error_choose_model: '続行する前にモデルを選択してください。',
     onboarding_error_provider_required: '続行する前にセットアップモードを選択してください。',
     onboarding_error_base_url_required: 'カスタムエンドポイントにはベース URL が必要です。',
+    onboarding_probe_test_button: 'Test connection', // TODO: translate
+    onboarding_probe_probing: 'Testing connection…', // TODO: translate
+    onboarding_probe_ok: 'Connected. {n} model(s) available.', // TODO: translate
+    onboarding_probe_error_generic: 'Could not reach the configured base URL.', // TODO: translate
+    onboarding_probe_error_invalid_url: 'Base URL must start with http:// or https://.', // TODO: translate
+    onboarding_probe_error_dns: 'Could not resolve the host. Check the URL or use the host\'s IP address.', // TODO: translate
+    onboarding_probe_error_connect_refused: 'Connection refused — the server may not be running on that address. From inside Docker, try the host IP instead of localhost.', // TODO: translate
+    onboarding_probe_error_timeout: 'The endpoint did not respond in time. Check that the server is running and the URL is correct.', // TODO: translate
+    onboarding_probe_error_http_4xx: 'The endpoint returned a client error. Check authentication and the URL path (typically ends in /v1).', // TODO: translate
+    onboarding_probe_error_http_5xx: 'The endpoint returned a server error. Check the LM Studio / Ollama server logs.', // TODO: translate
+    onboarding_probe_error_parse: 'The endpoint did not return a model list in the expected shape. Verify the URL points to the OpenAI-compatible API root.', // TODO: translate
+    onboarding_probe_error_unreachable: 'Could not reach the configured base URL.', // TODO: translate
+    onboarding_error_probe_failed: 'Could not validate the configured base URL.', // TODO: translate
     onboarding_error_workspace_required: 'ワークスペースは必須です。',
     onboarding_error_model_required: 'モデルは必須です。',
     onboarding_complete: 'オンボーディング完了',
@@ -2214,6 +2240,19 @@ const LOCALES = {
     onboarding_error_choose_model: 'Выберите модель перед продолжением.',
     onboarding_error_provider_required: 'Выберите режим настройки перед продолжением.',
     onboarding_error_base_url_required: 'Для собственных endpoint-ов требуется базовый URL.',
+    onboarding_probe_test_button: 'Test connection', // TODO: translate
+    onboarding_probe_probing: 'Testing connection…', // TODO: translate
+    onboarding_probe_ok: 'Connected. {n} model(s) available.', // TODO: translate
+    onboarding_probe_error_generic: 'Could not reach the configured base URL.', // TODO: translate
+    onboarding_probe_error_invalid_url: 'Base URL must start with http:// or https://.', // TODO: translate
+    onboarding_probe_error_dns: 'Could not resolve the host. Check the URL or use the host\'s IP address.', // TODO: translate
+    onboarding_probe_error_connect_refused: 'Connection refused — the server may not be running on that address. From inside Docker, try the host IP instead of localhost.', // TODO: translate
+    onboarding_probe_error_timeout: 'The endpoint did not respond in time. Check that the server is running and the URL is correct.', // TODO: translate
+    onboarding_probe_error_http_4xx: 'The endpoint returned a client error. Check authentication and the URL path (typically ends in /v1).', // TODO: translate
+    onboarding_probe_error_http_5xx: 'The endpoint returned a server error. Check the LM Studio / Ollama server logs.', // TODO: translate
+    onboarding_probe_error_parse: 'The endpoint did not return a model list in the expected shape. Verify the URL points to the OpenAI-compatible API root.', // TODO: translate
+    onboarding_probe_error_unreachable: 'Could not reach the configured base URL.', // TODO: translate
+    onboarding_error_probe_failed: 'Could not validate the configured base URL.', // TODO: translate
     onboarding_error_workspace_required: 'Рабочее пространство обязательно.',
     onboarding_error_model_required: 'Модель обязательна.',
     onboarding_complete: 'Первичная настройка завершена',
@@ -3033,6 +3072,19 @@ const LOCALES = {
     onboarding_error_choose_model: 'Elige un modelo antes de continuar.',
     onboarding_error_provider_required: 'Elige un modo de configuración antes de continuar.',
     onboarding_error_base_url_required: 'La base URL es obligatoria para endpoints personalizados.',
+    onboarding_probe_test_button: 'Test connection', // TODO: translate
+    onboarding_probe_probing: 'Testing connection…', // TODO: translate
+    onboarding_probe_ok: 'Connected. {n} model(s) available.', // TODO: translate
+    onboarding_probe_error_generic: 'Could not reach the configured base URL.', // TODO: translate
+    onboarding_probe_error_invalid_url: 'Base URL must start with http:// or https://.', // TODO: translate
+    onboarding_probe_error_dns: 'Could not resolve the host. Check the URL or use the host\'s IP address.', // TODO: translate
+    onboarding_probe_error_connect_refused: 'Connection refused — the server may not be running on that address. From inside Docker, try the host IP instead of localhost.', // TODO: translate
+    onboarding_probe_error_timeout: 'The endpoint did not respond in time. Check that the server is running and the URL is correct.', // TODO: translate
+    onboarding_probe_error_http_4xx: 'The endpoint returned a client error. Check authentication and the URL path (typically ends in /v1).', // TODO: translate
+    onboarding_probe_error_http_5xx: 'The endpoint returned a server error. Check the LM Studio / Ollama server logs.', // TODO: translate
+    onboarding_probe_error_parse: 'The endpoint did not return a model list in the expected shape. Verify the URL points to the OpenAI-compatible API root.', // TODO: translate
+    onboarding_probe_error_unreachable: 'Could not reach the configured base URL.', // TODO: translate
+    onboarding_error_probe_failed: 'Could not validate the configured base URL.', // TODO: translate
     onboarding_error_workspace_required: 'El espacio de trabajo es obligatorio.',
     onboarding_error_model_required: 'El modelo es obligatorio.',
     onboarding_complete: 'Onboarding completado',
@@ -3986,6 +4038,19 @@ const LOCALES = {
     onboarding_error_choose_model: 'Bitte wählen Sie ein Modell.',
     onboarding_error_provider_required: 'Anbieter erforderlich.',
     onboarding_error_base_url_required: 'Base URL erforderlich.',
+    onboarding_probe_test_button: 'Test connection', // TODO: translate
+    onboarding_probe_probing: 'Testing connection…', // TODO: translate
+    onboarding_probe_ok: 'Connected. {n} model(s) available.', // TODO: translate
+    onboarding_probe_error_generic: 'Could not reach the configured base URL.', // TODO: translate
+    onboarding_probe_error_invalid_url: 'Base URL must start with http:// or https://.', // TODO: translate
+    onboarding_probe_error_dns: 'Could not resolve the host. Check the URL or use the host\'s IP address.', // TODO: translate
+    onboarding_probe_error_connect_refused: 'Connection refused — the server may not be running on that address. From inside Docker, try the host IP instead of localhost.', // TODO: translate
+    onboarding_probe_error_timeout: 'The endpoint did not respond in time. Check that the server is running and the URL is correct.', // TODO: translate
+    onboarding_probe_error_http_4xx: 'The endpoint returned a client error. Check authentication and the URL path (typically ends in /v1).', // TODO: translate
+    onboarding_probe_error_http_5xx: 'The endpoint returned a server error. Check the LM Studio / Ollama server logs.', // TODO: translate
+    onboarding_probe_error_parse: 'The endpoint did not return a model list in the expected shape. Verify the URL points to the OpenAI-compatible API root.', // TODO: translate
+    onboarding_probe_error_unreachable: 'Could not reach the configured base URL.', // TODO: translate
+    onboarding_error_probe_failed: 'Could not validate the configured base URL.', // TODO: translate
     onboarding_error_workspace_required: 'Arbeitsbereich erforderlich.',
     onboarding_error_model_required: 'Modell erforderlich.',
     onboarding_complete: 'Einrichtung abgeschlossen!',
@@ -4663,6 +4728,19 @@ const LOCALES = {
     onboarding_error_choose_model: '继续前请先选择模型。',
     onboarding_error_provider_required: '继续前请先选择设置模式。',
     onboarding_error_base_url_required: '自定义端点必须填写 Base URL。',
+    onboarding_probe_test_button: 'Test connection', // TODO: translate
+    onboarding_probe_probing: 'Testing connection…', // TODO: translate
+    onboarding_probe_ok: 'Connected. {n} model(s) available.', // TODO: translate
+    onboarding_probe_error_generic: 'Could not reach the configured base URL.', // TODO: translate
+    onboarding_probe_error_invalid_url: 'Base URL must start with http:// or https://.', // TODO: translate
+    onboarding_probe_error_dns: 'Could not resolve the host. Check the URL or use the host\'s IP address.', // TODO: translate
+    onboarding_probe_error_connect_refused: 'Connection refused — the server may not be running on that address. From inside Docker, try the host IP instead of localhost.', // TODO: translate
+    onboarding_probe_error_timeout: 'The endpoint did not respond in time. Check that the server is running and the URL is correct.', // TODO: translate
+    onboarding_probe_error_http_4xx: 'The endpoint returned a client error. Check authentication and the URL path (typically ends in /v1).', // TODO: translate
+    onboarding_probe_error_http_5xx: 'The endpoint returned a server error. Check the LM Studio / Ollama server logs.', // TODO: translate
+    onboarding_probe_error_parse: 'The endpoint did not return a model list in the expected shape. Verify the URL points to the OpenAI-compatible API root.', // TODO: translate
+    onboarding_probe_error_unreachable: 'Could not reach the configured base URL.', // TODO: translate
+    onboarding_error_probe_failed: 'Could not validate the configured base URL.', // TODO: translate
     onboarding_error_workspace_required: '必须填写工作区。',
     onboarding_error_model_required: '必须填写模型。',
     onboarding_complete: '引导完成',
@@ -5439,6 +5517,19 @@ const LOCALES = {
     onboarding_custom_model_placeholder: 'your_model_name',
     onboarding_env_file: '.env \u6a94\u6848\uff1a',
     onboarding_error_base_url_required: '\u81ea\u8a02\u7aef\u9ede\u9700\u8981\u57fa\u790e URL\u3002',
+    onboarding_probe_test_button: 'Test connection', // TODO: translate
+    onboarding_probe_probing: 'Testing connection…', // TODO: translate
+    onboarding_probe_ok: 'Connected. {n} model(s) available.', // TODO: translate
+    onboarding_probe_error_generic: 'Could not reach the configured base URL.', // TODO: translate
+    onboarding_probe_error_invalid_url: 'Base URL must start with http:// or https://.', // TODO: translate
+    onboarding_probe_error_dns: 'Could not resolve the host. Check the URL or use the host\'s IP address.', // TODO: translate
+    onboarding_probe_error_connect_refused: 'Connection refused — the server may not be running on that address. From inside Docker, try the host IP instead of localhost.', // TODO: translate
+    onboarding_probe_error_timeout: 'The endpoint did not respond in time. Check that the server is running and the URL is correct.', // TODO: translate
+    onboarding_probe_error_http_4xx: 'The endpoint returned a client error. Check authentication and the URL path (typically ends in /v1).', // TODO: translate
+    onboarding_probe_error_http_5xx: 'The endpoint returned a server error. Check the LM Studio / Ollama server logs.', // TODO: translate
+    onboarding_probe_error_parse: 'The endpoint did not return a model list in the expected shape. Verify the URL points to the OpenAI-compatible API root.', // TODO: translate
+    onboarding_probe_error_unreachable: 'Could not reach the configured base URL.', // TODO: translate
+    onboarding_error_probe_failed: 'Could not validate the configured base URL.', // TODO: translate
     onboarding_error_choose_model: '\u8acb\u5148\u9078\u64c7\u6a21\u578b\u518d\u7e7c\u7e8c\u3002',
     onboarding_error_choose_workspace: '\u8acb\u5148\u9078\u64c7\u5de5\u4f5c\u5340\u518d\u7e7c\u7e8c\u3002',
     onboarding_error_model_required: '\u9700\u8981\u6a21\u578b\u3002',
@@ -6466,6 +6557,19 @@ const LOCALES = {
     onboarding_error_choose_model: 'Escolha modelo antes de continuar.',
     onboarding_error_provider_required: 'Escolha modo de setup antes de continuar.',
     onboarding_error_base_url_required: 'Base URL é necessária para endpoints customizados.',
+    onboarding_probe_test_button: 'Test connection', // TODO: translate
+    onboarding_probe_probing: 'Testing connection…', // TODO: translate
+    onboarding_probe_ok: 'Connected. {n} model(s) available.', // TODO: translate
+    onboarding_probe_error_generic: 'Could not reach the configured base URL.', // TODO: translate
+    onboarding_probe_error_invalid_url: 'Base URL must start with http:// or https://.', // TODO: translate
+    onboarding_probe_error_dns: 'Could not resolve the host. Check the URL or use the host\'s IP address.', // TODO: translate
+    onboarding_probe_error_connect_refused: 'Connection refused — the server may not be running on that address. From inside Docker, try the host IP instead of localhost.', // TODO: translate
+    onboarding_probe_error_timeout: 'The endpoint did not respond in time. Check that the server is running and the URL is correct.', // TODO: translate
+    onboarding_probe_error_http_4xx: 'The endpoint returned a client error. Check authentication and the URL path (typically ends in /v1).', // TODO: translate
+    onboarding_probe_error_http_5xx: 'The endpoint returned a server error. Check the LM Studio / Ollama server logs.', // TODO: translate
+    onboarding_probe_error_parse: 'The endpoint did not return a model list in the expected shape. Verify the URL points to the OpenAI-compatible API root.', // TODO: translate
+    onboarding_probe_error_unreachable: 'Could not reach the configured base URL.', // TODO: translate
+    onboarding_error_probe_failed: 'Could not validate the configured base URL.', // TODO: translate
     onboarding_error_workspace_required: 'Workspace é necessário.',
     onboarding_error_model_required: 'Modelo é necessário.',
     onboarding_complete: 'Configuração completa',
@@ -7252,6 +7356,19 @@ const LOCALES = {
     onboarding_error_choose_model: 'Choose a model before continuing.',
     onboarding_error_provider_required: 'Choose a setup mode before continuing.',
     onboarding_error_base_url_required: 'Base URL is required for custom endpoints.',
+    onboarding_probe_test_button: 'Test connection', // TODO: translate
+    onboarding_probe_probing: 'Testing connection…', // TODO: translate
+    onboarding_probe_ok: 'Connected. {n} model(s) available.', // TODO: translate
+    onboarding_probe_error_generic: 'Could not reach the configured base URL.', // TODO: translate
+    onboarding_probe_error_invalid_url: 'Base URL must start with http:// or https://.', // TODO: translate
+    onboarding_probe_error_dns: 'Could not resolve the host. Check the URL or use the host\'s IP address.', // TODO: translate
+    onboarding_probe_error_connect_refused: 'Connection refused — the server may not be running on that address. From inside Docker, try the host IP instead of localhost.', // TODO: translate
+    onboarding_probe_error_timeout: 'The endpoint did not respond in time. Check that the server is running and the URL is correct.', // TODO: translate
+    onboarding_probe_error_http_4xx: 'The endpoint returned a client error. Check authentication and the URL path (typically ends in /v1).', // TODO: translate
+    onboarding_probe_error_http_5xx: 'The endpoint returned a server error. Check the LM Studio / Ollama server logs.', // TODO: translate
+    onboarding_probe_error_parse: 'The endpoint did not return a model list in the expected shape. Verify the URL points to the OpenAI-compatible API root.', // TODO: translate
+    onboarding_probe_error_unreachable: 'Could not reach the configured base URL.', // TODO: translate
+    onboarding_error_probe_failed: 'Could not validate the configured base URL.', // TODO: translate
     onboarding_error_workspace_required: 'Workspace is required.',
     onboarding_error_model_required: 'Model is required.',
     onboarding_complete: '설정 완료',

--- a/static/i18n.js
+++ b/static/i18n.js
@@ -622,6 +622,9 @@ const LOCALES = {
     provider_category_specialized: 'Specialized',
     onboarding_api_key_label: 'API key',
     onboarding_api_key_placeholder: 'Leave blank to keep an existing saved key',
+    onboarding_api_key_label_optional: 'API key (optional)',
+    onboarding_api_key_placeholder_optional: 'Leave blank for keyless servers',
+    onboarding_api_key_help_keyless: 'Most LM Studio / Ollama / vLLM installs run keyless — leave this blank if your server doesn\'t require authentication. Use the Test connection button to verify.',
     onboarding_api_key_help_prefix: 'Saved as a secret in your Hermes .env file using',
     onboarding_base_url_label: 'Base URL',
     onboarding_base_url_placeholder: 'https://your-endpoint.example/v1',
@@ -1515,6 +1518,9 @@ const LOCALES = {
     provider_category_specialized: '専門用途',
     onboarding_api_key_label: 'APIキー',
     onboarding_api_key_placeholder: '空欄で既存の保存済みキーを維持',
+    onboarding_api_key_label_optional: 'API key (optional)', // TODO: translate
+    onboarding_api_key_placeholder_optional: 'Leave blank for keyless servers', // TODO: translate
+    onboarding_api_key_help_keyless: 'Most LM Studio / Ollama / vLLM installs run keyless — leave this blank if your server doesn\'t require authentication. Use the Test connection button to verify.', // TODO: translate
     onboarding_api_key_help_prefix: 'Hermes の .env ファイルにシークレットとして保存されます — 使用変数:',
     onboarding_base_url_label: 'ベース URL',
     onboarding_base_url_placeholder: 'https://your-endpoint.example/v1',
@@ -2208,6 +2214,9 @@ const LOCALES = {
     provider_category_specialized: 'Специализированные',
     onboarding_api_key_label: 'Ключ API',
     onboarding_api_key_placeholder: 'Оставьте пустым, чтобы сохранить уже сохранённый ключ',
+    onboarding_api_key_label_optional: 'API key (optional)', // TODO: translate
+    onboarding_api_key_placeholder_optional: 'Leave blank for keyless servers', // TODO: translate
+    onboarding_api_key_help_keyless: 'Most LM Studio / Ollama / vLLM installs run keyless — leave this blank if your server doesn\'t require authentication. Use the Test connection button to verify.', // TODO: translate
     oauth_login_codex: 'Login with Codex (ChatGPT)', // TODO: translate
     oauth_codex_step1: 'Step 1: Visit this URL and enter the code', // TODO: translate
     oauth_codex_step2: 'Step 2: Enter this code on the page', // TODO: translate
@@ -3040,6 +3049,9 @@ const LOCALES = {
     provider_category_specialized: 'Especializados',
     onboarding_api_key_label: 'API key',
     onboarding_api_key_placeholder: 'Déjala en blanco para conservar una key ya guardada',
+    onboarding_api_key_label_optional: 'API key (optional)', // TODO: translate
+    onboarding_api_key_placeholder_optional: 'Leave blank for keyless servers', // TODO: translate
+    onboarding_api_key_help_keyless: 'Most LM Studio / Ollama / vLLM installs run keyless — leave this blank if your server doesn\'t require authentication. Use the Test connection button to verify.', // TODO: translate
     oauth_login_codex: 'Login with Codex (ChatGPT)', // TODO: translate
     oauth_codex_step1: 'Step 1: Visit this URL and enter the code', // TODO: translate
     oauth_codex_step2: 'Step 2: Enter this code on the page', // TODO: translate
@@ -4010,6 +4022,9 @@ const LOCALES = {
     provider_category_specialized: 'Spezialisiert',
     onboarding_api_key_label: 'API-Schlüssel',
     onboarding_api_key_placeholder: 'sk-…',
+    onboarding_api_key_label_optional: 'API key (optional)', // TODO: translate
+    onboarding_api_key_placeholder_optional: 'Leave blank for keyless servers', // TODO: translate
+    onboarding_api_key_help_keyless: 'Most LM Studio / Ollama / vLLM installs run keyless — leave this blank if your server doesn\'t require authentication. Use the Test connection button to verify.', // TODO: translate
     oauth_login_codex: 'Login with Codex (ChatGPT)', // TODO: translate
     oauth_codex_step1: 'Step 1: Visit this URL and enter the code', // TODO: translate
     oauth_codex_step2: 'Step 2: Enter this code on the page', // TODO: translate
@@ -4696,6 +4711,9 @@ const LOCALES = {
     provider_category_specialized: '专业服务',
     onboarding_api_key_label: 'API key',
     onboarding_api_key_placeholder: '留空可保留已保存的 key',
+    onboarding_api_key_label_optional: 'API key (optional)', // TODO: translate
+    onboarding_api_key_placeholder_optional: 'Leave blank for keyless servers', // TODO: translate
+    onboarding_api_key_help_keyless: 'Most LM Studio / Ollama / vLLM installs run keyless — leave this blank if your server doesn\'t require authentication. Use the Test connection button to verify.', // TODO: translate
     oauth_login_codex: 'Login with Codex (ChatGPT)', // TODO: translate
     oauth_codex_step1: 'Step 1: Visit this URL and enter the code', // TODO: translate
     oauth_codex_step2: 'Step 2: Enter this code on the page', // TODO: translate
@@ -5494,6 +5512,9 @@ const LOCALES = {
     onboarding_api_key_help_prefix: '\u900f\u904e\u4ee5\u4e0b\u65b9\u5f0f\u5132\u5b58\u70ba Hermes .env \u6a94\u6848\u4e2d\u7684\u6a5f\u5bc6',
     onboarding_api_key_label: 'API \u91d1\u9470',
     onboarding_api_key_placeholder: '\u7559\u7a7a\u4ee5\u4fdd\u7559\u5df2\u5132\u5b58\u7684\u91d1\u9470',
+    onboarding_api_key_label_optional: 'API key (optional)', // TODO: translate
+    onboarding_api_key_placeholder_optional: 'Leave blank for keyless servers', // TODO: translate
+    onboarding_api_key_help_keyless: 'Most LM Studio / Ollama / vLLM installs run keyless — leave this blank if your server doesn\'t require authentication. Use the Test connection button to verify.', // TODO: translate
     onboarding_back: '\u4e0a\u4e00\u6b65',
     onboarding_badge: '\u9996\u6b21\u57f7\u884c',
     onboarding_base_url_help: '\u7528\u65bc OpenAI \u76f8\u5bb9\u8def\u7531\u5668\u3001\u81ea\u67b6\u4f3a\u670d\u5668\u3001LiteLLM\u3001Ollama\u3001LM Studio\u3001vLLM \u7b49\u7aef\u9ede\u3002',
@@ -6532,6 +6553,9 @@ const LOCALES = {
     oauth_codex_error: 'OAuth login failed', // TODO: translate
     oauth_codex_expired: 'Code expired, please try again', // TODO: translate
     onboarding_api_key_placeholder: 'Deixe em branco para manter key existente',
+    onboarding_api_key_label_optional: 'API key (optional)', // TODO: translate
+    onboarding_api_key_placeholder_optional: 'Leave blank for keyless servers', // TODO: translate
+    onboarding_api_key_help_keyless: 'Most LM Studio / Ollama / vLLM installs run keyless — leave this blank if your server doesn\'t require authentication. Use the Test connection button to verify.', // TODO: translate
     onboarding_api_key_help_prefix: 'Salvo como segredo no .env do Hermes usando',
     onboarding_base_url_label: 'Base URL',
     onboarding_base_url_placeholder: 'https://seu-endpoint.exemplo/v1',
@@ -7331,6 +7355,9 @@ const LOCALES = {
     oauth_codex_error: 'OAuth login failed', // TODO: translate
     oauth_codex_expired: 'Code expired, please try again', // TODO: translate
     onboarding_api_key_placeholder: 'Leave blank to keep an existing saved key',
+    onboarding_api_key_label_optional: 'API key (optional)', // TODO: translate
+    onboarding_api_key_placeholder_optional: 'Leave blank for keyless servers', // TODO: translate
+    onboarding_api_key_help_keyless: 'Most LM Studio / Ollama / vLLM installs run keyless — leave this blank if your server doesn\'t require authentication. Use the Test connection button to verify.', // TODO: translate
     onboarding_api_key_help_prefix: 'Saved as a secret in your Hermes .env file using',
     onboarding_base_url_label: 'Base URL',
     onboarding_base_url_placeholder: 'https://your-endpoint.example/v1',

--- a/static/onboarding.js
+++ b/static/onboarding.js
@@ -185,6 +185,21 @@ function _renderOnboardingBaseUrlField(showBaseUrl){
   return `<label class="onboarding-field"><span>${t('onboarding_base_url_label')}</span><input id="onboardingBaseUrlInput" value="${esc(ONBOARDING.form.baseUrl||'')}" placeholder="${t('onboarding_base_url_placeholder')}" oninput="ONBOARDING.form.baseUrl=this.value;_scheduleOnboardingProbe()" onblur="_runOnboardingProbe()"></label><div class="onboarding-probe-row"><button type="button" class="onboarding-probe-btn" ${testBtnDisabled} onclick="_runOnboardingProbe({force:true})">${esc(testBtnLabel)}</button></div>${banner}`;
 }
 
+function _renderOnboardingApiKeyField(){
+  // Renders the API-key input.  For providers flagged `key_optional` in the
+  // setup catalog (lmstudio, ollama, custom — typically self-hosted servers
+  // that run keyless by default), the field shows an "(optional)" hint and
+  // empty input is accepted on Continue.  Pre-#1499-third-sub-bug-fix the
+  // wizard required a non-empty string here even for keyless installs, which
+  // forced users to type random gibberish to clear onboarding.
+  const provider=_getOnboardingSetupProvider(ONBOARDING.form.provider);
+  const keyOptional=!!(provider&&provider.key_optional);
+  const labelKey=keyOptional?'onboarding_api_key_label_optional':'onboarding_api_key_label';
+  const placeholderKey=keyOptional?'onboarding_api_key_placeholder_optional':'onboarding_api_key_placeholder';
+  const helpHtml=keyOptional?`<p class="onboarding-copy onboarding-api-key-help">${esc(t('onboarding_api_key_help_keyless')||'')}</p>`:'';
+  return `<label class="onboarding-field" id="onboardingApiKeyField"><span>${t(labelKey)}</span><input id="onboardingApiKeyInput" type="password" value="${esc(ONBOARDING.form.apiKey||'')}" placeholder="${t(placeholderKey)}" oninput="ONBOARDING.form.apiKey=this.value;_scheduleOnboardingProbe()"></label>${helpHtml}`;
+}
+
 function _getOnboardingSelectedModel(){
   return ONBOARDING.form.model||'';
 }
@@ -265,10 +280,7 @@ function _renderOnboardingBody(){
             <span>${t('onboarding_provider_label')}</span>
             <select id="onboardingProviderSelect" onchange="syncOnboardingProvider(this.value)">${groupedOptions}</select>
           </label>
-          <label class="onboarding-field" id="onboardingApiKeyField">
-            <span>${t('onboarding_api_key_label')}</span>
-            <input id="onboardingApiKeyInput" type="password" value="${esc(ONBOARDING.form.apiKey||'')}" placeholder="${t('onboarding_api_key_placeholder')}" oninput="ONBOARDING.form.apiKey=this.value">
-          </label>
+          ${_renderOnboardingApiKeyField()}
           ${_renderOnboardingBaseUrlField(showBaseUrl)}
           <p class="onboarding-copy">${keyHelp}</p>`;
       } else {
@@ -286,10 +298,7 @@ function _renderOnboardingBody(){
             <span>${t('onboarding_provider_label')}</span>
             <select id="onboardingProviderSelect" onchange="syncOnboardingProvider(this.value)">${groupedOptions}</select>
           </label>
-          <label class="onboarding-field" id="onboardingApiKeyField">
-            <span>${t('onboarding_api_key_label')}</span>
-            <input id="onboardingApiKeyInput" type="password" value="${esc(ONBOARDING.form.apiKey||'')}" placeholder="${t('onboarding_api_key_placeholder')}" oninput="ONBOARDING.form.apiKey=this.value">
-          </label>
+          ${_renderOnboardingApiKeyField()}
           ${_renderOnboardingBaseUrlField(showBaseUrl)}
           <p class="onboarding-copy">${keyHelp}</p>`;
       }
@@ -302,10 +311,7 @@ function _renderOnboardingBody(){
         <span>${t('onboarding_provider_label')}</span>
         <select id="onboardingProviderSelect" onchange="syncOnboardingProvider(this.value)">${groupedOptions}</select>
       </label>
-      <label class="onboarding-field">
-        <span>${t('onboarding_api_key_label')}</span>
-        <input id="onboardingApiKeyInput" type="password" value="${esc(ONBOARDING.form.apiKey||'')}" placeholder="${t('onboarding_api_key_placeholder')}" oninput="ONBOARDING.form.apiKey=this.value">
-      </label>
+      ${_renderOnboardingApiKeyField()}
       ${_renderOnboardingBaseUrlField(showBaseUrl)}
       <p class="onboarding-copy">${keyHelp}</p>
       <div class="onboarding-oauth-card" id="codexOAuthCard">

--- a/static/onboarding.js
+++ b/static/onboarding.js
@@ -1,4 +1,85 @@
-const ONBOARDING={status:null,step:0,steps:['system','setup','workspace','password','finish'],form:{provider:'openrouter',workspace:'',model:'',password:'',apiKey:'',baseUrl:''},active:false};
+const ONBOARDING={status:null,step:0,steps:['system','setup','workspace','password','finish'],form:{provider:'openrouter',workspace:'',model:'',password:'',apiKey:'',baseUrl:''},active:false,probe:{status:'idle',error:null,detail:'',models:null,probedKey:''}};
+
+// ── Onboarding base-URL probe (#1499) ───────────────────────────────────────
+// Probes <base_url>/models so the wizard can validate the configured endpoint
+// before persisting AND populate the model dropdown from the live catalog.
+// Probe state lives on ONBOARDING.probe; the dropdown render and the
+// nextOnboardingStep gate both consult it.
+
+let _onboardingProbeTimer=null;
+
+function _onboardingProbeKey(provider,baseUrl,apiKey){
+  return `${provider||''}|${(baseUrl||'').trim().replace(/\/+$/,'')}|${apiKey||''}`;
+}
+
+function _setOnboardingProbeState(patch){
+  ONBOARDING.probe={...ONBOARDING.probe,...patch};
+  // Re-render body so probe status / model dropdown reflect new state.
+  _renderOnboardingBody();
+}
+
+async function _runOnboardingProbe({force=false}={}){
+  const provider=ONBOARDING.form.provider;
+  const cat=_getOnboardingSetupProvider(provider);
+  if(!cat||!cat.requires_base_url){
+    _setOnboardingProbeState({status:'idle',error:null,detail:'',models:null,probedKey:''});
+    return ONBOARDING.probe;
+  }
+  const baseUrl=(ONBOARDING.form.baseUrl||'').trim();
+  if(!baseUrl){
+    _setOnboardingProbeState({status:'idle',error:null,detail:'',models:null,probedKey:''});
+    return ONBOARDING.probe;
+  }
+  const apiKey=(ONBOARDING.form.apiKey||'').trim();
+  const key=_onboardingProbeKey(provider,baseUrl,apiKey);
+  if(!force&&ONBOARDING.probe.probedKey===key&&ONBOARDING.probe.status!=='probing'){
+    return ONBOARDING.probe;
+  }
+  _setOnboardingProbeState({status:'probing',error:null,detail:'',probedKey:key});
+  try{
+    const res=await api('/api/onboarding/probe',{method:'POST',body:JSON.stringify({provider,base_url:baseUrl,api_key:apiKey||undefined})});
+    if(res&&res.ok){
+      _setOnboardingProbeState({status:'ok',error:null,detail:'',models:Array.isArray(res.models)?res.models:[],probedKey:key});
+      // If the user hasn't picked a model yet (or their pick is no longer in
+      // the list), default to the first probed model so Continue isn't blocked
+      // on an empty selection.
+      const stillPresent=ONBOARDING.form.model&&(res.models||[]).some(m=>m.id===ONBOARDING.form.model);
+      if(!stillPresent&&(res.models||[]).length>0){
+        ONBOARDING.form.model=res.models[0].id;
+        _renderOnboardingBody();
+      }
+    }else{
+      const err=(res&&res.error)||'unreachable';
+      const detail=(res&&res.detail)||'';
+      _setOnboardingProbeState({status:'error',error:err,detail,models:null,probedKey:key});
+    }
+  }catch(e){
+    _setOnboardingProbeState({status:'error',error:'unreachable',detail:(e&&e.message)||String(e),models:null,probedKey:key});
+  }
+  return ONBOARDING.probe;
+}
+
+function _scheduleOnboardingProbe(){
+  if(_onboardingProbeTimer)clearTimeout(_onboardingProbeTimer);
+  _onboardingProbeTimer=setTimeout(()=>{_runOnboardingProbe();},400);
+}
+
+function _onboardingProbeMessage(probe){
+  if(!probe||probe.status==='idle')return '';
+  if(probe.status==='probing')return t('onboarding_probe_probing')||'Testing connection…';
+  if(probe.status==='ok'){
+    const n=(probe.models||[]).length;
+    const tmpl=t('onboarding_probe_ok')||'Connected. {n} model(s) available.';
+    return tmpl.replace('{n}',String(n));
+  }
+  // status === 'error'
+  const errKey='onboarding_probe_error_'+probe.error;
+  const localized=t(errKey);
+  // i18n.js's `t()` returns the key itself when missing — fall back to a generic message.
+  const heading=(localized&&localized!==errKey)?localized:(t('onboarding_probe_error_generic')||'Could not reach the configured base URL.');
+  const detail=probe.detail?` (${probe.detail})`:'';
+  return heading+detail;
+}
 
 function _getOnboardingSetupProviders(){
   return (((ONBOARDING.status||{}).setup||{}).providers)||[];
@@ -75,7 +156,33 @@ function _getOnboardingWorkspaceChoices(){
 
 function _getOnboardingProviderModelChoices(){
   const provider=_getOnboardingSetupProvider(ONBOARDING.form.provider);
+  // Probe-discovered models (#1499) take precedence over the static catalog
+  // for providers with requires_base_url=True.  The catalog ships an empty
+  // list for self-hosted providers (lmstudio, ollama, custom) — without the
+  // probe the user had nothing to pick from.
+  if(provider&&provider.requires_base_url&&ONBOARDING.probe&&ONBOARDING.probe.status==='ok'&&Array.isArray(ONBOARDING.probe.models)&&ONBOARDING.probe.models.length){
+    return ONBOARDING.probe.models;
+  }
   return provider?(provider.models||[]):[];
+}
+
+function _renderOnboardingBaseUrlField(showBaseUrl){
+  // Renders the base_url input PLUS the probe status banner / Test button
+  // when the active provider has requires_base_url=True (#1499).  Returns
+  // the empty string when the active provider does not require a base URL,
+  // so the existing call sites can continue to template-interpolate this in
+  // place of the previous inline `<label …>` snippet.
+  if(!showBaseUrl)return '';
+  const probe=ONBOARDING.probe||{status:'idle'};
+  const msg=_onboardingProbeMessage(probe);
+  let banner='';
+  if(msg){
+    const cls={ok:'onboarding-probe-ok',probing:'onboarding-probe-probing',error:'onboarding-probe-error'}[probe.status]||'';
+    banner=`<p class="onboarding-copy onboarding-probe-banner ${cls}">${esc(msg)}</p>`;
+  }
+  const testBtnLabel=t('onboarding_probe_test_button')||'Test connection';
+  const testBtnDisabled=(probe.status==='probing')?'disabled':'';
+  return `<label class="onboarding-field"><span>${t('onboarding_base_url_label')}</span><input id="onboardingBaseUrlInput" value="${esc(ONBOARDING.form.baseUrl||'')}" placeholder="${t('onboarding_base_url_placeholder')}" oninput="ONBOARDING.form.baseUrl=this.value;_scheduleOnboardingProbe()" onblur="_runOnboardingProbe()"></label><div class="onboarding-probe-row"><button type="button" class="onboarding-probe-btn" ${testBtnDisabled} onclick="_runOnboardingProbe({force:true})">${esc(testBtnLabel)}</button></div>${banner}`;
 }
 
 function _getOnboardingSelectedModel(){
@@ -162,7 +269,7 @@ function _renderOnboardingBody(){
             <span>${t('onboarding_api_key_label')}</span>
             <input id="onboardingApiKeyInput" type="password" value="${esc(ONBOARDING.form.apiKey||'')}" placeholder="${t('onboarding_api_key_placeholder')}" oninput="ONBOARDING.form.apiKey=this.value">
           </label>
-          ${showBaseUrl?`<label class="onboarding-field"><span>${t('onboarding_base_url_label')}</span><input id="onboardingBaseUrlInput" value="${esc(ONBOARDING.form.baseUrl||'')}" placeholder="${t('onboarding_base_url_placeholder')}" oninput="ONBOARDING.form.baseUrl=this.value"></label>`:''}
+          ${_renderOnboardingBaseUrlField(showBaseUrl)}
           <p class="onboarding-copy">${keyHelp}</p>`;
       } else {
         _setOnboardingNotice(t('onboarding_notice_setup_required'),'warn');
@@ -183,7 +290,7 @@ function _renderOnboardingBody(){
             <span>${t('onboarding_api_key_label')}</span>
             <input id="onboardingApiKeyInput" type="password" value="${esc(ONBOARDING.form.apiKey||'')}" placeholder="${t('onboarding_api_key_placeholder')}" oninput="ONBOARDING.form.apiKey=this.value">
           </label>
-          ${showBaseUrl?`<label class="onboarding-field"><span>${t('onboarding_base_url_label')}</span><input id="onboardingBaseUrlInput" value="${esc(ONBOARDING.form.baseUrl||'')}" placeholder="${t('onboarding_base_url_placeholder')}" oninput="ONBOARDING.form.baseUrl=this.value"></label>`:''}
+          ${_renderOnboardingBaseUrlField(showBaseUrl)}
           <p class="onboarding-copy">${keyHelp}</p>`;
       }
       return;
@@ -199,7 +306,7 @@ function _renderOnboardingBody(){
         <span>${t('onboarding_api_key_label')}</span>
         <input id="onboardingApiKeyInput" type="password" value="${esc(ONBOARDING.form.apiKey||'')}" placeholder="${t('onboarding_api_key_placeholder')}" oninput="ONBOARDING.form.apiKey=this.value">
       </label>
-      ${showBaseUrl?`<label class="onboarding-field"><span>${t('onboarding_base_url_label')}</span><input id="onboardingBaseUrlInput" value="${esc(ONBOARDING.form.baseUrl||'')}" placeholder="${t('onboarding_base_url_placeholder')}" oninput="ONBOARDING.form.baseUrl=this.value"></label>`:''}
+      ${_renderOnboardingBaseUrlField(showBaseUrl)}
       <p class="onboarding-copy">${keyHelp}</p>
       <div class="onboarding-oauth-card" id="codexOAuthCard">
         <div class="onboarding-oauth-icon">🔑</div>
@@ -399,6 +506,23 @@ async function nextOnboardingStep(){
       ONBOARDING.form.baseUrl=(($('onboardingBaseUrlInput')||{}).value||ONBOARDING.form.baseUrl||'').trim();
       if(!ONBOARDING.form.provider) throw new Error(t('onboarding_error_provider_required'));
       if(ONBOARDING.form.provider==='custom' && !ONBOARDING.form.baseUrl) throw new Error(t('onboarding_error_base_url_required'));
+      // For self-hosted providers (requires_base_url=True), gate Continue on a
+      // successful probe of <base_url>/models — otherwise the wizard would
+      // happily persist an unreachable URL and finish in 200ms with no
+      // outbound HTTP, exactly the bug in #1499.  Run the probe synchronously
+      // here, then check status; the probe is idempotent & cached on
+      // (provider, baseUrl, apiKey) so this rarely triggers a second network
+      // call when the user already saw a green banner.
+      const cat=_getOnboardingSetupProvider(ONBOARDING.form.provider);
+      if(cat&&cat.requires_base_url){
+        if(!ONBOARDING.form.baseUrl) throw new Error(t('onboarding_error_base_url_required'));
+        await _runOnboardingProbe();
+        if(ONBOARDING.probe.status!=='ok'){
+          // Surface the same localized error string the inline banner shows.
+          const msg=_onboardingProbeMessage(ONBOARDING.probe)||t('onboarding_error_probe_failed')||'Could not reach the configured base URL.';
+          throw new Error(msg);
+        }
+      }
     }
     if(ONBOARDING.steps[ONBOARDING.step]==='workspace'){
       ONBOARDING.form.workspace=(($('onboardingWorkspaceInput')||{}).value||ONBOARDING.form.workspace||'').trim();

--- a/static/style.css
+++ b/static/style.css
@@ -497,6 +497,9 @@
   .onboarding-probe-banner.onboarding-probe-ok{border-color:#1f8a4f;color:#9ce0b4;background:rgba(31,138,79,.12);}
   .onboarding-probe-banner.onboarding-probe-probing{color:var(--muted);}
   .onboarding-probe-banner.onboarding-probe-error{border-color:#9c3a3a;color:#f5a3a3;background:rgba(156,58,58,.12);}
+  /* Onboarding api-key keyless hint (#1499 third sub-bug) — subtle muted text */
+  /* sized below the input so it reads as inline help, not a banner. */
+  .onboarding-api-key-help{margin:4px 0 0;font-size:11px;color:var(--muted);font-style:italic;}
   .onboarding-summary{display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:12px;}
   .onboarding-summary div{padding:14px;border-radius:14px;background:rgba(255,255,255,.03);border:1px solid var(--border);display:flex;flex-direction:column;gap:5px;}
   .onboarding-summary strong{font-size:12px;letter-spacing:.04em;text-transform:uppercase;color:var(--muted);}

--- a/static/style.css
+++ b/static/style.css
@@ -488,6 +488,15 @@
   .onboarding-field span{font-size:12px;font-weight:700;color:var(--text);}
   .onboarding-field input,.onboarding-field select{margin-bottom:0;padding:10px 12px;border-radius:10px;font-size:13px;background:var(--input-bg);border:1px solid var(--border2);color:var(--text);}
   .onboarding-copy{font-size:12px;color:var(--muted);line-height:1.7;}
+  /* Onboarding probe (#1499) — Test connection button + status banner */
+  .onboarding-probe-row{display:flex;justify-content:flex-end;margin-top:-2px;}
+  .onboarding-probe-btn{padding:6px 12px;font-size:12px;font-weight:600;border-radius:8px;background:var(--input-bg);border:1px solid var(--border2);color:var(--text);cursor:pointer;}
+  .onboarding-probe-btn:hover:not(:disabled){border-color:var(--accent);}
+  .onboarding-probe-btn:disabled{opacity:.55;cursor:wait;}
+  .onboarding-probe-banner{margin:6px 0 0;padding:8px 10px;border-radius:8px;border:1px solid var(--border2);background:var(--input-bg);}
+  .onboarding-probe-banner.onboarding-probe-ok{border-color:#1f8a4f;color:#9ce0b4;background:rgba(31,138,79,.12);}
+  .onboarding-probe-banner.onboarding-probe-probing{color:var(--muted);}
+  .onboarding-probe-banner.onboarding-probe-error{border-color:#9c3a3a;color:#f5a3a3;background:rgba(156,58,58,.12);}
   .onboarding-summary{display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:12px;}
   .onboarding-summary div{padding:14px;border-radius:14px;background:rgba(255,255,255,.03);border:1px solid var(--border);display:flex;flex-direction:column;gap:5px;}
   .onboarding-summary strong{font-size:12px;letter-spacing:.04em;text-transform:uppercase;color:var(--muted);}

--- a/tests/test_issue1420_lmstudio_provider_env_var.py
+++ b/tests/test_issue1420_lmstudio_provider_env_var.py
@@ -100,26 +100,43 @@ class TestIssue1420LMStudioProviderEnvVar:
     """
 
     def test_lmstudio_in_provider_env_var_dict(self):
-        """`_PROVIDER_ENV_VAR['lmstudio']` must equal `'LMSTUDIO_API_KEY'`."""
-        from api.providers import _PROVIDER_ENV_VAR
+        """`_PROVIDER_ENV_VAR['lmstudio']` must equal `'LM_API_KEY'` (canonical, agent-aligned).
+
+        The original #1420 fix used `'LMSTUDIO_API_KEY'`. After #1500 (cross-tool
+        env-var alignment with the agent CLI) the canonical name is `LM_API_KEY`,
+        and `LMSTUDIO_API_KEY` is preserved as a read-only legacy alias in
+        `_PROVIDER_ENV_VAR_ALIASES` so existing users don't lose detection.
+        """
+        from api.providers import _PROVIDER_ENV_VAR, _PROVIDER_ENV_VAR_ALIASES
         assert "lmstudio" in _PROVIDER_ENV_VAR, (
             "_PROVIDER_ENV_VAR is missing the 'lmstudio' entry — Settings → "
             "Providers will render LM Studio as has_key=False / "
-            "configurable=False even with LMSTUDIO_API_KEY set in .env. See #1420."
+            "configurable=False. See #1420."
         )
-        assert _PROVIDER_ENV_VAR["lmstudio"] == "LMSTUDIO_API_KEY", (
+        assert _PROVIDER_ENV_VAR["lmstudio"] == "LM_API_KEY", (
             f"_PROVIDER_ENV_VAR['lmstudio'] = {_PROVIDER_ENV_VAR['lmstudio']!r}, "
-            f"expected 'LMSTUDIO_API_KEY'. The onboarding wizard writes the "
-            f"key to LMSTUDIO_API_KEY in .env (api/onboarding.py:73-80) and "
-            f"the runtime in hermes_cli reads it under that name; the Settings "
-            f"detection path must look at the same name."
+            f"expected 'LM_API_KEY' to match the agent CLI's "
+            f"hermes_cli/auth.py:lmstudio.api_key_env_vars. See #1500."
+        )
+        # The legacy alias must still be registered so users with the pre-#1500
+        # env var don't lose detection on upgrade.
+        assert "lmstudio" in _PROVIDER_ENV_VAR_ALIASES, (
+            "_PROVIDER_ENV_VAR_ALIASES['lmstudio'] missing — pre-#1500 users "
+            "with LMSTUDIO_API_KEY in their .env will see Settings flip to "
+            "'no key' on upgrade.  Keep the alias for at least a few releases."
+        )
+        assert "LMSTUDIO_API_KEY" in _PROVIDER_ENV_VAR_ALIASES["lmstudio"], (
+            f"Expected 'LMSTUDIO_API_KEY' as a legacy alias for lmstudio, got "
+            f"{_PROVIDER_ENV_VAR_ALIASES['lmstudio']!r}."
         )
 
     def test_lmstudio_has_key_true_when_env_var_set(self, monkeypatch, tmp_path):
-        """LMSTUDIO_API_KEY in env should mark LM Studio configured in Settings."""
+        """`LM_API_KEY` in env should mark LM Studio configured in Settings (canonical, post-#1500)."""
         _install_fake_hermes_cli(monkeypatch)
         monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
-        monkeypatch.setenv("LMSTUDIO_API_KEY", "lm-studio")
+        monkeypatch.delenv("LMSTUDIO_API_KEY", raising=False)
+        monkeypatch.delenv("LM_API_KEY", raising=False)
+        monkeypatch.setenv("LM_API_KEY", "lm-studio")
 
         restore = _swap_in_test_config({"model": {"provider": "lmstudio"}})
         try:
@@ -160,6 +177,7 @@ class TestIssue1420LMStudioProviderEnvVar:
         _install_fake_hermes_cli(monkeypatch)
         monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
         monkeypatch.delenv("LMSTUDIO_API_KEY", raising=False)
+        monkeypatch.delenv("LM_API_KEY", raising=False)
 
         restore = _swap_in_test_config({
             "model": {"provider": "lmstudio"},
@@ -191,6 +209,7 @@ class TestIssue1420LMStudioProviderEnvVar:
         _install_fake_hermes_cli(monkeypatch)
         monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
         monkeypatch.delenv("LMSTUDIO_API_KEY", raising=False)
+        monkeypatch.delenv("LM_API_KEY", raising=False)
 
         restore = _swap_in_test_config({"model": {"provider": "lmstudio"}})
         try:
@@ -226,10 +245,12 @@ class TestIssue1420LMStudioProviderEnvVar:
             "GEMINI_API_KEY", "DEEPSEEK_API_KEY", "MINIMAX_API_KEY",
             "MINIMAX_CN_API_KEY", "MISTRAL_API_KEY", "XAI_API_KEY",
             "GLM_API_KEY", "KIMI_API_KEY", "OPENCODE_ZEN_API_KEY",
-            "OPENCODE_GO_API_KEY", "NVIDIA_API_KEY",
+            "OPENCODE_GO_API_KEY", "NVIDIA_API_KEY", "LMSTUDIO_API_KEY",
         ):
             monkeypatch.delenv(var, raising=False)
-        monkeypatch.setenv("LMSTUDIO_API_KEY", "lm-studio")
+        # Set the canonical post-#1500 env var; sibling providers must not
+        # cross-detect.
+        monkeypatch.setenv("LM_API_KEY", "lm-studio")
 
         restore = _swap_in_test_config({"model": {"provider": "lmstudio"}})
         try:
@@ -249,11 +270,11 @@ class TestIssue1420LMStudioProviderEnvVar:
                 if pid.startswith("custom"):
                     continue
                 assert entry["has_key"] is False, (
-                    f"LMSTUDIO_API_KEY in env caused {pid!r} to flip "
-                    f"has_key=True (cross-detection leak). Pre-fix this was "
-                    f"never an issue because lmstudio wasn't in "
-                    f"_PROVIDER_ENV_VAR at all; with the fix in place we have "
-                    f"to verify the new entry doesn't bleed into a sibling."
+                    f"LM_API_KEY in env caused {pid!r} to flip "
+                    f"has_key=True (cross-detection leak). LM_API_KEY is "
+                    f"unique to lmstudio in _PROVIDER_ENV_VAR; this test "
+                    f"future-proofs against a regression that adds it to "
+                    f"a sibling."
                 )
         finally:
             restore()

--- a/tests/test_issue1499_keyless_onboarding.py
+++ b/tests/test_issue1499_keyless_onboarding.py
@@ -1,0 +1,381 @@
+"""Regression: self-hosted providers accept empty api_key in onboarding (#1499 sub-bug 3).
+
+Pre-fix, ``apply_onboarding_setup`` rejected an empty ``api_key`` for every
+wizard provider with the error ``f"{env_var} is required"``. For LM Studio,
+Ollama, and Custom — which run keyless on most local installs — this forced
+users to type a placeholder string into the API key field just to clear the
+wizard. The ``LMSTUDIO_NOAUTH_PLACEHOLDER`` substitution at chat-time was the
+agent's workaround for the no-auth case, but the wizard side rejected the
+empty input first, so users never got that far without typing gibberish.
+
+The fix adds a ``key_optional: True`` flag to the affected providers in
+``_SUPPORTED_PROVIDER_SETUPS``. When that flag is set:
+
+  * ``apply_onboarding_setup`` skips the "key required" check.
+  * No write to ``.env`` happens for the empty-key case (no
+    ``LM_API_KEY=*** placeholder lying in the user's .env file`` either).
+  * ``_status_from_runtime`` reports ``provider_ready=True`` based on
+    ``base_url`` alone, so the wizard doesn't refire on the next page load
+    just because there's no api_key.
+  * The setup catalog exposes ``key_optional`` so the frontend can render
+    "(optional)" hint copy + accept empty submit.
+
+Symmetric tests verify the existing required-key path still rejects empty
+api_keys for cloud providers (openrouter, anthropic, openai), so this fix
+doesn't accidentally make every provider keyless.
+
+Reporters: @chwps, @AdoneyGalvan via #1420 → split into #1499.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+import api.config as config
+import api.profiles as profiles
+
+
+def _install_fake_hermes_cli(monkeypatch):
+    """Stub hermes_cli modules so tests are deterministic and offline.
+
+    Mirrors the helper in test_provider_management.py — kept inline so this
+    regression test stays self-contained.
+    """
+    fake_pkg = types.ModuleType("hermes_cli")
+    fake_pkg.__path__ = []
+    fake_models = types.ModuleType("hermes_cli.models")
+    fake_models.list_available_providers = lambda: []
+    fake_models.provider_model_ids = lambda pid: []
+    fake_auth = types.ModuleType("hermes_cli.auth")
+    fake_auth.get_auth_status = lambda _pid: {}
+    monkeypatch.setitem(sys.modules, "hermes_cli", fake_pkg)
+    monkeypatch.setitem(sys.modules, "hermes_cli.models", fake_models)
+    monkeypatch.setitem(sys.modules, "hermes_cli.auth", fake_auth)
+
+
+def _isolate_onboarding_writes(monkeypatch, tmp_path):
+    """Redirect every onboarding write target to ``tmp_path`` and clear
+    every relevant env var so the test starts from a known clean state.
+
+    Pattern from webui-onboarding-provider-readiness skill — without this,
+    tests that call ``apply_onboarding_setup`` directly write to the real
+    ``~/.hermes`` and clobber the developer's actual config.
+    """
+    from api import onboarding as ob
+    monkeypatch.setattr(ob, "_get_active_hermes_home", lambda: tmp_path)
+    cfg_path = tmp_path / "config.yaml"
+    monkeypatch.setattr(ob, "_get_config_path", lambda: cfg_path)
+    monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
+    monkeypatch.delenv("HERMES_WEBUI_SKIP_ONBOARDING", raising=False)
+    for var in (
+        "LM_API_KEY", "LMSTUDIO_API_KEY", "OLLAMA_API_KEY", "OPENAI_API_KEY",
+        "OPENROUTER_API_KEY", "ANTHROPIC_API_KEY", "GOOGLE_API_KEY",
+        "GH_TOKEN", "GITHUB_TOKEN",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    return cfg_path
+
+
+class TestKeyOptionalProviderSchema:
+    """The catalog declares which providers may run keyless."""
+
+    def test_lmstudio_is_key_optional(self):
+        from api.onboarding import _SUPPORTED_PROVIDER_SETUPS
+        assert _SUPPORTED_PROVIDER_SETUPS["lmstudio"].get("key_optional") is True, (
+            "lmstudio must declare key_optional=True so onboarding accepts an "
+            "empty api_key.  Pre-fix the wizard required users to type "
+            "gibberish to clear the form.  See #1499 (third sub-bug from #1420)."
+        )
+
+    def test_ollama_is_key_optional(self):
+        from api.onboarding import _SUPPORTED_PROVIDER_SETUPS
+        assert _SUPPORTED_PROVIDER_SETUPS["ollama"].get("key_optional") is True, (
+            "ollama must declare key_optional=True — local Ollama runs keyless "
+            "by default."
+        )
+
+    def test_custom_is_key_optional(self):
+        from api.onboarding import _SUPPORTED_PROVIDER_SETUPS
+        assert _SUPPORTED_PROVIDER_SETUPS["custom"].get("key_optional") is True, (
+            "custom must declare key_optional=True — many self-hosted "
+            "OpenAI-compatible servers (vLLM, llama-server, TabbyAPI) run "
+            "keyless behind a private network."
+        )
+
+    def test_cloud_providers_are_not_key_optional(self):
+        """Regression-defense: openrouter/anthropic/openai must STILL require a key."""
+        from api.onboarding import _SUPPORTED_PROVIDER_SETUPS
+        for pid in ("openrouter", "anthropic", "openai"):
+            assert not _SUPPORTED_PROVIDER_SETUPS[pid].get("key_optional"), (
+                f"{pid} must NOT be key_optional — cloud providers always need "
+                f"a real key.  This test catches an accidental flag flip."
+            )
+
+    def test_setup_catalog_exposes_key_optional_flag(self):
+        """Frontend reads `provider.key_optional` from the catalog."""
+        from api.onboarding import _build_setup_catalog
+        catalog = _build_setup_catalog({"model": {"provider": "lmstudio"}})
+        by_id = {p["id"]: p for p in catalog["providers"]}
+        assert by_id["lmstudio"]["key_optional"] is True
+        assert by_id["ollama"]["key_optional"] is True
+        assert by_id["custom"]["key_optional"] is True
+        assert by_id["openrouter"]["key_optional"] is False, (
+            "Catalog must expose key_optional=False for cloud providers so "
+            "the frontend doesn't accidentally label them optional."
+        )
+
+
+class TestKeylessOnboarding:
+    """``apply_onboarding_setup`` accepts empty api_key for key_optional providers."""
+
+    def test_lmstudio_empty_api_key_accepted(self, monkeypatch, tmp_path):
+        """Pre-fix this raised; post-fix it succeeds and writes no .env entry."""
+        _install_fake_hermes_cli(monkeypatch)
+        cfg_path = _isolate_onboarding_writes(monkeypatch, tmp_path)
+
+        from api import onboarding as ob
+        # Empty api_key — should NOT raise.
+        ob.apply_onboarding_setup({
+            "provider": "lmstudio",
+            "model": "qwen3-27b",
+            "base_url": "http://example.local:1234/v1",
+            "api_key": "",
+        })
+
+        # config.yaml gets written with provider/model/base_url
+        assert cfg_path.exists()
+        cfg_text = cfg_path.read_text(encoding="utf-8")
+        assert "provider: lmstudio" in cfg_text
+        assert "base_url: http://example.local:1234/v1" in cfg_text
+
+        # .env should NOT have an API_KEY entry — empty key means we don't
+        # write a placeholder into .env.
+        env_path = tmp_path / ".env"
+        if env_path.exists():
+            env_text = env_path.read_text(encoding="utf-8")
+            assert "LM_API_KEY=" not in env_text, (
+                f"Onboarding wrote LM_API_KEY to .env even though user "
+                f"submitted an empty api_key. .env contents:\n{env_text}"
+            )
+            assert "LMSTUDIO_API_KEY=" not in env_text
+
+    def test_ollama_empty_api_key_accepted(self, monkeypatch, tmp_path):
+        _install_fake_hermes_cli(monkeypatch)
+        _isolate_onboarding_writes(monkeypatch, tmp_path)
+
+        from api import onboarding as ob
+        ob.apply_onboarding_setup({
+            "provider": "ollama",
+            "model": "qwen3:32b",
+            "base_url": "http://localhost:11434/v1",
+            "api_key": "",
+        })
+        env_path = tmp_path / ".env"
+        if env_path.exists():
+            assert "OLLAMA_API_KEY=" not in env_path.read_text(encoding="utf-8")
+
+    def test_custom_empty_api_key_accepted(self, monkeypatch, tmp_path):
+        _install_fake_hermes_cli(monkeypatch)
+        _isolate_onboarding_writes(monkeypatch, tmp_path)
+
+        from api import onboarding as ob
+        ob.apply_onboarding_setup({
+            "provider": "custom",
+            "model": "gpt-4o-mini",
+            "base_url": "http://my-vllm.local/v1",
+            "api_key": "",
+        })
+        env_path = tmp_path / ".env"
+        if env_path.exists():
+            assert "OPENAI_API_KEY=" not in env_path.read_text(encoding="utf-8")
+
+    def test_openrouter_empty_api_key_still_rejected(self, monkeypatch, tmp_path):
+        """Cloud providers must still reject empty api_key (regression defense)."""
+        _install_fake_hermes_cli(monkeypatch)
+        _isolate_onboarding_writes(monkeypatch, tmp_path)
+
+        from api import onboarding as ob
+        with pytest.raises(ValueError, match="OPENROUTER_API_KEY is required"):
+            ob.apply_onboarding_setup({
+                "provider": "openrouter",
+                "model": "anthropic/claude-sonnet-4.6",
+                "base_url": "",
+                "api_key": "",
+            })
+
+    def test_anthropic_empty_api_key_still_rejected(self, monkeypatch, tmp_path):
+        _install_fake_hermes_cli(monkeypatch)
+        _isolate_onboarding_writes(monkeypatch, tmp_path)
+
+        from api import onboarding as ob
+        with pytest.raises(ValueError, match="ANTHROPIC_API_KEY is required"):
+            ob.apply_onboarding_setup({
+                "provider": "anthropic",
+                "model": "claude-sonnet-4.6",
+                "api_key": "",
+            })
+
+    def test_lmstudio_with_explicit_api_key_still_writes_env(self, monkeypatch, tmp_path):
+        """Auth-enabled LM Studio: user supplies a key, .env still gets written.
+
+        Regression-defense for the keyless path: when the user DOES supply a
+        key, we still write it under the canonical name (LM_API_KEY, post-#1500).
+        """
+        _install_fake_hermes_cli(monkeypatch)
+        _isolate_onboarding_writes(monkeypatch, tmp_path)
+
+        from api import onboarding as ob
+        ob.apply_onboarding_setup({
+            "provider": "lmstudio",
+            "model": "qwen3-27b",
+            "base_url": "http://example.local:1234/v1",
+            "api_key": "real-secret-token",
+        })
+        env_text = (tmp_path / ".env").read_text(encoding="utf-8")
+        assert "LM_API_KEY=" in env_text, (
+            f"Auth-enabled lmstudio user supplied an api_key but .env doesn't "
+            f"contain LM_API_KEY. Contents:\n{env_text}"
+        )
+
+
+class TestKeylessChatReady:
+    """``provider_ready`` and ``chat_ready`` are True for key_optional providers."""
+
+    def test_lmstudio_keyless_provider_ready_via_status_runtime(
+        self, monkeypatch, tmp_path,
+    ):
+        """``_status_from_runtime`` returns provider_ready=True with no api_key."""
+        _install_fake_hermes_cli(monkeypatch)
+        _isolate_onboarding_writes(monkeypatch, tmp_path)
+
+        from api import onboarding as ob
+        cfg = {
+            "model": {
+                "provider": "lmstudio",
+                "default": "qwen3-27b",
+                "base_url": "http://example.local:1234/v1",
+            },
+        }
+        status = ob._status_from_runtime(cfg, imports_ok=True)
+        assert status.get("provider_ready") is True, (
+            "lmstudio with base_url + model + NO api_key must be provider_ready=True. "
+            "Otherwise the wizard refires on every page load even though the "
+            "user finished setup. See #1499 third sub-bug from #1420."
+        )
+
+    def test_ollama_keyless_provider_ready_via_status_runtime(
+        self, monkeypatch, tmp_path,
+    ):
+        _install_fake_hermes_cli(monkeypatch)
+        _isolate_onboarding_writes(monkeypatch, tmp_path)
+
+        from api import onboarding as ob
+        cfg = {
+            "model": {
+                "provider": "ollama",
+                "default": "qwen3:32b",
+                "base_url": "http://localhost:11434/v1",
+            },
+        }
+        status = ob._status_from_runtime(cfg, imports_ok=True)
+        assert status.get("provider_ready") is True
+
+    def test_custom_keyless_provider_ready_requires_base_url(
+        self, monkeypatch, tmp_path,
+    ):
+        """custom is key_optional but still requires base_url."""
+        _install_fake_hermes_cli(monkeypatch)
+        _isolate_onboarding_writes(monkeypatch, tmp_path)
+
+        from api import onboarding as ob
+        # With base_url → ready
+        cfg_with = {
+            "model": {
+                "provider": "custom",
+                "default": "gpt-4o-mini",
+                "base_url": "http://my-vllm.local/v1",
+            },
+        }
+        assert ob._status_from_runtime(cfg_with, imports_ok=True).get("provider_ready") is True
+
+        # Without base_url → NOT ready (custom still requires it)
+        cfg_without = {
+            "model": {
+                "provider": "custom",
+                "default": "gpt-4o-mini",
+            },
+        }
+        assert ob._status_from_runtime(cfg_without, imports_ok=True).get("provider_ready") is False, (
+            "custom is key_optional but still requires base_url — this test "
+            "catches a regression where the requires_base_url check is "
+            "accidentally dropped for key_optional providers."
+        )
+
+    def test_openrouter_keyless_provider_ready_is_false(self, monkeypatch, tmp_path):
+        """Cloud provider with no key → provider_ready=False (regression defense)."""
+        _install_fake_hermes_cli(monkeypatch)
+        _isolate_onboarding_writes(monkeypatch, tmp_path)
+
+        from api import onboarding as ob
+        cfg = {
+            "model": {
+                "provider": "openrouter",
+                "default": "anthropic/claude-sonnet-4.6",
+            },
+        }
+        assert ob._status_from_runtime(cfg, imports_ok=True).get("provider_ready") is False, (
+            "openrouter with no api_key must NOT be provider_ready — that "
+            "would silently let the wizard finish without the user actually "
+            "entering a key."
+        )
+
+    def test_lmstudio_keyless_chat_ready_via_full_status(self, monkeypatch, tmp_path):
+        """End-to-end: get_onboarding_status reports chat_ready=True after keyless save."""
+        _install_fake_hermes_cli(monkeypatch)
+        cfg_path = _isolate_onboarding_writes(monkeypatch, tmp_path)
+
+        from api import onboarding as ob
+        ob.apply_onboarding_setup({
+            "provider": "lmstudio",
+            "model": "qwen3-27b",
+            "base_url": "http://example.local:1234/v1",
+            "api_key": "",
+        })
+
+        # Reload config so get_onboarding_status sees the just-written values.
+        # _swap_in_test_config-style — replicate just enough of that pattern.
+        old_cfg = dict(config.cfg)
+        old_mtime = config._cfg_mtime
+        config.cfg.clear()
+        try:
+            import yaml
+            config.cfg.update(yaml.safe_load(cfg_path.read_text(encoding="utf-8")) or {})
+        except Exception:
+            pass
+        try:
+            config._cfg_mtime = cfg_path.stat().st_mtime
+        except Exception:
+            config._cfg_mtime = 0.0
+
+        try:
+            status = ob.get_onboarding_status()
+            system = status.get("system", {})
+            assert system.get("provider_ready") is True, (
+                f"After saving lmstudio keyless config, provider_ready must be "
+                f"True. Got: provider_ready={system.get('provider_ready')!r}, "
+                f"chat_ready={system.get('chat_ready')!r}."
+            )
+            # chat_ready additionally requires _HERMES_FOUND + imports_ok which
+            # depend on the test environment; provider_ready is the bit this
+            # PR's fix actually controls.  But if hermes is importable, it
+            # should also be chat_ready.
+            if system.get("imports_ok"):
+                assert system.get("chat_ready") is True
+        finally:
+            config.cfg.clear()
+            config.cfg.update(old_cfg)
+            config._cfg_mtime = old_mtime

--- a/tests/test_issue1499_onboarding_probe.py
+++ b/tests/test_issue1499_onboarding_probe.py
@@ -1,0 +1,351 @@
+"""Regression: onboarding wizard probes <base_url>/models before persisting (#1499).
+
+Pre-#1499, `apply_onboarding_setup` accepted whatever `base_url` the user typed
+without ever fetching `<base_url>/models`. The wizard would finish in ~200ms
+with no outbound HTTP request, persist an unreachable URL silently, and leave
+the user with an empty model dropdown that they had to populate by hand-editing
+`config.yaml`.
+
+Reporters: @chwps's log timeline in #1420 was the smoking gun — onboarding
+submit completed in 239ms and there was no GET to `<HostIP>:1234/v1/models`
+anywhere in the WebUI container's outbound trace.
+
+The fix is the new `probe_provider_endpoint(provider, base_url, api_key)` in
+`api/onboarding.py` and the matching `POST /api/onboarding/probe` route. The
+frontend wizard runs the probe debounced on baseUrl input and blocking on
+Continue for any provider with `requires_base_url=True`.
+
+This file pins the backend probe contract (the function and the endpoint).
+The frontend wiring is exercised through manual reproduction during PR review;
+testing JS-side debounce behavior in pytest would add an outsized harness for
+the value.
+
+Each test mode covers exactly one error code from `PROBE_ERROR_CODES`, plus
+the success path with model-list parsing. The probe response is also asserted
+to NOT be persisted to config.yaml (the original wizard bug was that probe-
+discovered data was indistinguishable from user-entered data after persist).
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+import urllib.error
+import urllib.request
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import pytest
+
+from tests._pytest_port import BASE
+
+
+@pytest.fixture
+def mock_models_server():
+    """Spin up a tiny HTTP server with several /v1/models response variants."""
+    server_box: dict = {}
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):  # noqa: N802 — http.server convention
+            # /v1/models — happy path with OpenAI shape
+            if self.path == "/v1/models":
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(json.dumps({
+                    "data": [
+                        {"id": "qwen3-27b", "object": "model", "owned_by": "user"},
+                        {"id": "llama-3.3-70b", "object": "model", "owned_by": "user"},
+                    ]
+                }).encode())
+                return
+
+            # /barelist/models — bare list shape some self-hosted servers return
+            if self.path == "/barelist/models":
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(json.dumps([
+                    {"id": "alpha"}, {"id": "beta"},
+                ]).encode())
+                return
+
+            # /v1bad/models — 404 (wrong path)
+            if self.path == "/v1bad/models":
+                self.send_response(404)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(b'{"error": "not found"}')
+                return
+
+            # /v1/parse/models — 200 with non-JSON body
+            if self.path == "/v1/parse/models":
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(b"this is not json")
+                return
+
+            # /v1/wrongshape/models — 200 with JSON but not OpenAI shape
+            if self.path == "/v1/wrongshape/models":
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(b'{"unexpected": "shape"}')
+                return
+
+            # /v1/auth/models — 200 only with correct bearer token
+            if self.path == "/v1/auth/models":
+                auth = self.headers.get("Authorization", "")
+                if auth == "Bearer correct-token":
+                    self.send_response(200)
+                    self.send_header("Content-Type", "application/json")
+                    self.end_headers()
+                    self.wfile.write(b'{"data": [{"id": "auth-only"}]}')
+                else:
+                    self.send_response(401)
+                    self.end_headers()
+                    self.wfile.write(b"unauthorized")
+                return
+
+            # Default: 500
+            self.send_response(500)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(b'{"error": "boom"}')
+
+        def log_message(self, *args, **kwargs):  # noqa: N802 — suppress test noise
+            pass
+
+    httpd = HTTPServer(("127.0.0.1", 0), Handler)
+    server_box["port"] = httpd.server_address[1]
+    server_box["base"] = f"http://127.0.0.1:{server_box['port']}"
+    server_box["httpd"] = httpd
+
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    # Tiny sleep so the listening socket is observable when the test connects.
+    time.sleep(0.05)
+
+    yield server_box
+
+    httpd.shutdown()
+    httpd.server_close()
+
+
+class TestIssue1499OnboardingProbe:
+    # ── Direct unit tests on probe_provider_endpoint (no HTTP layer) ────────
+
+    def test_invalid_url_empty(self):
+        from api.onboarding import probe_provider_endpoint
+        r = probe_provider_endpoint("lmstudio", "")
+        assert r["ok"] is False
+        assert r["error"] == "invalid_url"
+
+    def test_invalid_url_bad_scheme(self):
+        from api.onboarding import probe_provider_endpoint
+        r = probe_provider_endpoint("lmstudio", "ftp://example.com:1234/v1")
+        assert r["ok"] is False
+        assert r["error"] == "invalid_url"
+
+    def test_invalid_url_no_host(self):
+        from api.onboarding import probe_provider_endpoint
+        r = probe_provider_endpoint("lmstudio", "http:///models")
+        assert r["ok"] is False
+        assert r["error"] == "invalid_url"
+
+    def test_dns_resolution_failure(self):
+        """Unresolvable hostname → error='dns'."""
+        from api.onboarding import probe_provider_endpoint
+        r = probe_provider_endpoint(
+            "lmstudio",
+            "http://this-host-definitely-does-not-exist-zxq987.invalid:1234/v1",
+            timeout=2.0,
+        )
+        assert r["ok"] is False
+        assert r["error"] == "dns", f"Expected dns error, got {r}"
+
+    def test_connect_refused(self):
+        """Connecting to a port nobody's listening on → error='connect_refused'."""
+        from api.onboarding import probe_provider_endpoint
+        # Port 1 is reserved tcpmux and on Linux/macOS dev boxes is universally
+        # not listening. If a future CI environment binds something there this
+        # will need updating, but no realistic CI binds port 1.
+        r = probe_provider_endpoint("lmstudio", "http://127.0.0.1:1/v1", timeout=2.0)
+        assert r["ok"] is False
+        assert r["error"] == "connect_refused", f"Expected connect_refused, got {r}"
+
+    def test_success_openai_shape(self, mock_models_server):
+        from api.onboarding import probe_provider_endpoint
+        r = probe_provider_endpoint("lmstudio", f"{mock_models_server['base']}/v1")
+        assert r["ok"] is True, f"Expected success, got {r}"
+        assert len(r["models"]) == 2
+        ids = [m["id"] for m in r["models"]]
+        assert "qwen3-27b" in ids
+        assert "llama-3.3-70b" in ids
+        for m in r["models"]:
+            assert m["id"] == m["label"], "label defaults to id when no separate label"
+
+    def test_success_bare_list_shape(self, mock_models_server):
+        """Some self-hosted servers return a bare list, not an OpenAI envelope."""
+        from api.onboarding import probe_provider_endpoint
+        r = probe_provider_endpoint("lmstudio", f"{mock_models_server['base']}/barelist")
+        assert r["ok"] is True, f"Expected success, got {r}"
+        ids = [m["id"] for m in r["models"]]
+        assert ids == ["alpha", "beta"]
+
+    def test_http_4xx(self, mock_models_server):
+        from api.onboarding import probe_provider_endpoint
+        r = probe_provider_endpoint("lmstudio", f"{mock_models_server['base']}/v1bad")
+        assert r["ok"] is False
+        assert r["error"] == "http_4xx"
+        assert r.get("status") == 404
+
+    def test_http_5xx(self, mock_models_server):
+        from api.onboarding import probe_provider_endpoint
+        r = probe_provider_endpoint("lmstudio", f"{mock_models_server['base']}/v1explode")
+        assert r["ok"] is False
+        assert r["error"] == "http_5xx"
+        assert r.get("status") == 500
+
+    def test_parse_non_json(self, mock_models_server):
+        from api.onboarding import probe_provider_endpoint
+        r = probe_provider_endpoint("lmstudio", f"{mock_models_server['base']}/v1/parse")
+        assert r["ok"] is False
+        assert r["error"] == "parse"
+        assert "JSON" in r["detail"] or "json" in r["detail"]
+
+    def test_parse_wrong_shape(self, mock_models_server):
+        """JSON body but not OpenAI /models shape → error='parse'."""
+        from api.onboarding import probe_provider_endpoint
+        r = probe_provider_endpoint("lmstudio", f"{mock_models_server['base']}/v1/wrongshape")
+        assert r["ok"] is False
+        assert r["error"] == "parse"
+        assert "OpenAI" in r["detail"] or "shape" in r["detail"]
+
+    def test_api_key_passes_authorization_header(self, mock_models_server):
+        """Probe sends api_key as Bearer when provided."""
+        from api.onboarding import probe_provider_endpoint
+
+        # Without key → 401 → http_4xx
+        r = probe_provider_endpoint("lmstudio", f"{mock_models_server['base']}/v1/auth")
+        assert r["error"] == "http_4xx"
+
+        # With wrong key → 401
+        r = probe_provider_endpoint(
+            "lmstudio",
+            f"{mock_models_server['base']}/v1/auth",
+            api_key="wrong-token",
+        )
+        assert r["error"] == "http_4xx"
+
+        # With correct key → success
+        r = probe_provider_endpoint(
+            "lmstudio",
+            f"{mock_models_server['base']}/v1/auth",
+            api_key="correct-token",
+        )
+        assert r["ok"] is True
+        assert [m["id"] for m in r["models"]] == ["auth-only"]
+
+    def test_probe_does_not_persist_to_config(self, mock_models_server, tmp_path, monkeypatch):
+        """Probe is read-only — must NOT touch config.yaml or .env.
+
+        Pre-fix the wizard would have happily auto-written the probed model
+        list into config.yaml, pinning a stale catalog. The probe path must
+        stay pure-read so that ``apply_onboarding_setup`` remains the single
+        write surface.
+        """
+        from api import onboarding as ob
+
+        # Redirect any potential write to tmp_path so we'd notice if the probe
+        # wrote anything by accident.
+        monkeypatch.setattr(ob, "_get_active_hermes_home", lambda: tmp_path)
+        cfg_path = tmp_path / "config.yaml"
+        monkeypatch.setattr(ob, "_get_config_path", lambda: cfg_path)
+
+        # Ensure neither file exists before the probe.
+        env_path = tmp_path / ".env"
+        assert not cfg_path.exists()
+        assert not env_path.exists()
+
+        ob.probe_provider_endpoint(
+            "lmstudio",
+            f"{mock_models_server['base']}/v1",
+            api_key="some-key",
+        )
+
+        assert not cfg_path.exists(), (
+            "probe_provider_endpoint must be read-only — it wrote to config.yaml"
+        )
+        assert not env_path.exists(), (
+            "probe_provider_endpoint must be read-only — it wrote to .env "
+            "(api_key would have leaked)"
+        )
+
+    def test_probe_error_codes_set_is_documented(self):
+        """The PROBE_ERROR_CODES tuple is the public contract for the frontend.
+
+        Every code returned by probe_provider_endpoint must be in this tuple
+        so frontend localization keys can mechanically derive from it.
+        """
+        from api.onboarding import PROBE_ERROR_CODES
+        # If you add a new error code, also add an i18n key
+        # `onboarding_probe_error_<code>` to all 9 locale blocks in
+        # static/i18n.js (search for `onboarding_probe_error_`).
+        expected = {
+            "invalid_url", "dns", "connect_refused", "timeout",
+            "http_4xx", "http_5xx", "parse", "unreachable",
+        }
+        assert set(PROBE_ERROR_CODES) == expected, (
+            f"PROBE_ERROR_CODES drift: got {set(PROBE_ERROR_CODES)}, "
+            f"expected {expected}. Update static/i18n.js if you intentionally "
+            f"changed this set."
+        )
+
+
+class TestIssue1499ProbeRouteEndToEnd:
+    """End-to-end smoke test for `POST /api/onboarding/probe`.
+
+    The route is a thin wrapper around `probe_provider_endpoint`; the unit
+    tests above cover the function logic exhaustively.  This class verifies
+    the wiring: route exists, parses JSON body, returns probe result as JSON.
+    """
+
+    def _post(self, body):
+        data = json.dumps(body).encode()
+        req = urllib.request.Request(
+            BASE + "/api/onboarding/probe",
+            data=data,
+            headers={"Content-Type": "application/json"},
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=10) as r:
+                return json.loads(r.read()), r.status
+        except urllib.error.HTTPError as e:
+            return json.loads(e.read()), e.code
+
+    def test_route_returns_invalid_url_for_empty_base(self):
+        body, status = self._post({"provider": "lmstudio", "base_url": ""})
+        assert status == 200
+        assert body["ok"] is False
+        assert body["error"] == "invalid_url"
+
+    def test_route_returns_success_against_mock(self, mock_models_server):
+        body, status = self._post({
+            "provider": "lmstudio",
+            "base_url": f"{mock_models_server['base']}/v1",
+        })
+        assert status == 200, f"unexpected status {status}: {body}"
+        assert body["ok"] is True
+        assert isinstance(body["models"], list)
+        assert any(m["id"] == "qwen3-27b" for m in body["models"])
+
+    def test_route_returns_dns_error_for_bad_host(self):
+        body, status = self._post({
+            "provider": "lmstudio",
+            "base_url": "http://this-host-definitely-does-not-exist-zxq987.invalid:1234/v1",
+        })
+        assert status == 200
+        assert body["ok"] is False
+        assert body["error"] == "dns"

--- a/tests/test_issue1499_onboarding_probe.py
+++ b/tests/test_issue1499_onboarding_probe.py
@@ -283,6 +283,64 @@ class TestIssue1499OnboardingProbe:
             "(api_key would have leaked)"
         )
 
+    def test_probe_does_not_follow_redirects(self):
+        """Probe refuses HTTP redirects — surfaces as `unreachable` with a 3xx hint.
+
+        SSRF defense-in-depth: an authenticated user typing a base URL that
+        redirects (intentionally or otherwise) should not have the probe
+        chase the redirect to internal services.  The auth + local-network
+        gate already restricts the practical attack surface, but tightening
+        the redirect default is cheap insurance.  Reviewer-flagged on PR #1501.
+        """
+        import json
+        import threading
+        import time
+        from http.server import BaseHTTPRequestHandler, HTTPServer
+
+        from api.onboarding import probe_provider_endpoint
+
+        class _RedirectHandler(BaseHTTPRequestHandler):
+            def do_GET(self):  # noqa: N802
+                if self.path == "/v1/models":
+                    self.send_response(302)
+                    self.send_header("Location", "/different-endpoint")
+                    self.end_headers()
+                    return
+                # If we accidentally follow the redirect, the test sees data
+                # and assertion fails.
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(json.dumps({"data": [{"id": "should-not-see"}]}).encode())
+
+            def log_message(self, *args, **kwargs):  # noqa: N802
+                pass
+
+        httpd = HTTPServer(("127.0.0.1", 0), _RedirectHandler)
+        port = httpd.server_address[1]
+        thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+        thread.start()
+        time.sleep(0.05)
+        try:
+            r = probe_provider_endpoint("lmstudio", f"http://127.0.0.1:{port}/v1")
+            assert r["ok"] is False, (
+                f"Probe followed a redirect — should have refused. Got {r!r}. "
+                f"_NoRedirectHandler is missing or broken."
+            )
+            assert r["error"] == "unreachable", (
+                f"3xx redirect should surface as 'unreachable', got {r['error']!r}"
+            )
+            assert r.get("status") == 302
+            # Detail must mention "redirect" so the user understands what
+            # happened — the localized error banner uses this string verbatim.
+            assert "redirect" in r["detail"].lower()
+            # Crucially, the probe must NOT have surfaced data from the
+            # redirect target (which our test handler returned for any other path).
+            assert "should-not-see" not in str(r)
+        finally:
+            httpd.shutdown()
+            httpd.server_close()
+
     def test_probe_error_codes_set_is_documented(self):
         """The PROBE_ERROR_CODES tuple is the public contract for the frontend.
 

--- a/tests/test_issue1500_lmstudio_env_var_alignment.py
+++ b/tests/test_issue1500_lmstudio_env_var_alignment.py
@@ -1,0 +1,199 @@
+"""Regression: webui aligns LM Studio env var with the agent CLI (#1500).
+
+Pre-#1500 the WebUI used `LMSTUDIO_API_KEY` everywhere — onboarding wrote it,
+Settings detection read it. The agent CLI runtime (hermes_cli/auth.py:182,
+api_key_env_vars=("LM_API_KEY",)) reads `LM_API_KEY`. So a user who configured
+auth on their LM Studio instance and entered the key in the WebUI got:
+
+  - Settings → Providers reporting has_key=True (because WebUI saw its own
+    LMSTUDIO_API_KEY)
+  - Agent runtime ignoring the key (because it reads LM_API_KEY)
+  - Chat falling back to LMSTUDIO_NOAUTH_PLACEHOLDER → 401 from the
+    auth-enabled LM Studio server
+
+Masked in practice for the no-auth majority. Real bug for anyone with
+auth enabled.
+
+This file pins the post-#1500 contract:
+
+  1. Onboarding writes the canonical `LM_API_KEY` (NOT `LMSTUDIO_API_KEY`).
+  2. Settings detection reads the canonical first.
+  3. Settings detection ALSO reads the legacy `LMSTUDIO_API_KEY` as a
+     read-only alias, so users with the old name in their .env don't see
+     Settings flip to "no key" on upgrade.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+
+import api.config as config
+import api.profiles as profiles
+
+
+def _install_fake_hermes_cli(monkeypatch):
+    """Stub hermes_cli modules so tests are deterministic and offline."""
+    fake_pkg = types.ModuleType("hermes_cli")
+    fake_pkg.__path__ = []
+    fake_models = types.ModuleType("hermes_cli.models")
+    fake_models.list_available_providers = lambda: []
+    fake_models.provider_model_ids = lambda pid: []
+    fake_auth = types.ModuleType("hermes_cli.auth")
+    fake_auth.get_auth_status = lambda _pid: {}
+    monkeypatch.setitem(sys.modules, "hermes_cli", fake_pkg)
+    monkeypatch.setitem(sys.modules, "hermes_cli.models", fake_models)
+    monkeypatch.setitem(sys.modules, "hermes_cli.auth", fake_auth)
+    monkeypatch.delitem(sys.modules, "agent.credential_pool", raising=False)
+    monkeypatch.delitem(sys.modules, "agent", raising=False)
+    try:
+        from api.config import invalidate_models_cache
+        invalidate_models_cache()
+    except Exception:
+        pass
+
+
+def _swap_in_test_config(extra_cfg):
+    old_cfg = dict(config.cfg)
+    old_mtime = config._cfg_mtime
+    config.cfg.clear()
+    config.cfg["model"] = {}
+    config.cfg.update(extra_cfg)
+    try:
+        config._cfg_mtime = config.Path(config._get_config_path()).stat().st_mtime
+    except Exception:
+        config._cfg_mtime = 0.0
+
+    def _restore():
+        config.cfg.clear()
+        config.cfg.update(old_cfg)
+        config._cfg_mtime = old_mtime
+
+    return _restore
+
+
+class TestIssue1500EnvVarAlignment:
+    def test_onboarding_supported_provider_setup_uses_lm_api_key(self):
+        """The wizard's lmstudio entry must declare the canonical env var name."""
+        from api.onboarding import _SUPPORTED_PROVIDER_SETUPS
+        assert "lmstudio" in _SUPPORTED_PROVIDER_SETUPS
+        meta = _SUPPORTED_PROVIDER_SETUPS["lmstudio"]
+        assert meta["env_var"] == "LM_API_KEY", (
+            f"Onboarding's lmstudio.env_var must be the canonical 'LM_API_KEY' "
+            f"(matching hermes_cli/auth.py:182 api_key_env_vars=('LM_API_KEY',)). "
+            f"Got {meta['env_var']!r}."
+        )
+        # Legacy alias preserved for read-only fallback.
+        aliases = list(meta.get("env_var_aliases") or [])
+        assert "LMSTUDIO_API_KEY" in aliases, (
+            f"Onboarding's lmstudio.env_var_aliases must include the legacy "
+            f"'LMSTUDIO_API_KEY' name so existing users' detection keeps "
+            f"working. Got aliases={aliases!r}."
+        )
+
+    def test_onboarding_writes_canonical_name_only(self, monkeypatch, tmp_path):
+        """`apply_onboarding_setup` must write LM_API_KEY (not LMSTUDIO_API_KEY)."""
+        _install_fake_hermes_cli(monkeypatch)
+
+        # Redirect every write target to the tmp_path so we don't touch the real
+        # ~/.hermes — pattern from webui-onboarding-provider-readiness skill.
+        from api import onboarding as ob
+        monkeypatch.setattr(ob, "_get_active_hermes_home", lambda: tmp_path)
+        cfg_path = tmp_path / "config.yaml"
+        monkeypatch.setattr(ob, "_get_config_path", lambda: cfg_path)
+        monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
+        monkeypatch.delenv("HERMES_WEBUI_SKIP_ONBOARDING", raising=False)
+        monkeypatch.delenv("LM_API_KEY", raising=False)
+        monkeypatch.delenv("LMSTUDIO_API_KEY", raising=False)
+
+        ob.apply_onboarding_setup({
+            "provider": "lmstudio",
+            "model": "qwen3-27b",
+            "base_url": "http://example.local:1234/v1",
+            "api_key": "fresh-canon",
+        })
+
+        env_path = tmp_path / ".env"
+        assert env_path.exists(), "onboarding must write .env"
+        env_text = env_path.read_text(encoding="utf-8")
+
+        assert "LM_API_KEY=" in env_text, (
+            f"Onboarding must write the canonical LM_API_KEY name. .env now reads:\n{env_text}"
+        )
+        assert "LMSTUDIO_API_KEY=" not in env_text, (
+            f"Onboarding must NOT write the legacy LMSTUDIO_API_KEY name "
+            f"(should only be canonical going forward). .env now reads:\n{env_text}"
+        )
+
+    def test_legacy_lmstudio_env_var_still_detected(self, monkeypatch, tmp_path):
+        """Pre-#1500 users with LMSTUDIO_API_KEY still see has_key=True after upgrade."""
+        _install_fake_hermes_cli(monkeypatch)
+        monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
+        monkeypatch.delenv("LM_API_KEY", raising=False)
+        monkeypatch.setenv("LMSTUDIO_API_KEY", "lm-studio-legacy")
+
+        restore = _swap_in_test_config({"model": {"provider": "lmstudio"}})
+        try:
+            from api.providers import get_providers
+            result = get_providers()
+            by_id = {p["id"]: p for p in result["providers"]}
+            assert by_id["lmstudio"]["has_key"] is True, (
+                "Pre-#1500 users with the legacy LMSTUDIO_API_KEY env var must "
+                "continue to see has_key=True after upgrade — that's the whole "
+                "point of the alias fallback in _PROVIDER_ENV_VAR_ALIASES."
+            )
+            assert by_id["lmstudio"]["key_source"] in {"env_file", "env_var"}, (
+                f"Legacy alias detection should report env_file / env_var as "
+                f"key_source (the key really IS in .env), got "
+                f"{by_id['lmstudio']['key_source']!r} — this is the post-#1500 "
+                f"key_source-via-alias path."
+            )
+        finally:
+            restore()
+
+    def test_canonical_takes_precedence_over_legacy(self, monkeypatch, tmp_path):
+        """When both env vars are set, canonical wins (rare migration edge)."""
+        _install_fake_hermes_cli(monkeypatch)
+        monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
+        monkeypatch.setenv("LM_API_KEY", "canonical-wins")
+        monkeypatch.setenv("LMSTUDIO_API_KEY", "legacy-loses")
+
+        restore = _swap_in_test_config({"model": {"provider": "lmstudio"}})
+        try:
+            from api.providers import get_providers, _provider_has_key
+            assert _provider_has_key("lmstudio") is True
+            # Both lead to has_key=True; the contract is that canonical is
+            # checked first (so it's definitely returning True and not just
+            # falling through to the alias).  We can't easily assert ordering
+            # from this layer, but the existence of both detection paths is
+            # captured by test_legacy_lmstudio_env_var_still_detected and
+            # test_lmstudio_has_key_true_when_env_var_set in the #1420 file.
+            result = get_providers()
+            by_id = {p["id"]: p for p in result["providers"]}
+            assert by_id["lmstudio"]["has_key"] is True
+            assert by_id["lmstudio"]["configurable"] is True
+        finally:
+            restore()
+
+    def test_provider_api_key_present_reads_aliases(self, monkeypatch, tmp_path):
+        """`_provider_api_key_present` (onboarding-side) reads aliases too.
+
+        The onboarding readiness pipeline (_status_from_runtime → chat_ready)
+        relies on this function.  If aliases aren't honored here, an upgrading
+        user gets a re-firing wizard even though their LM Studio is configured.
+        """
+        from api.onboarding import _provider_api_key_present
+        cfg = {"model": {"provider": "lmstudio"}}
+
+        # Only the legacy name set in .env values — onboarding must still see it.
+        env_values = {"LMSTUDIO_API_KEY": "x"}
+        assert _provider_api_key_present("lmstudio", cfg, env_values) is True
+
+        # Only the canonical name set — also detected.
+        env_values = {"LM_API_KEY": "x"}
+        assert _provider_api_key_present("lmstudio", cfg, env_values) is True
+
+        # Neither set — not detected.
+        env_values = {"OPENAI_API_KEY": "x"}
+        assert _provider_api_key_present("lmstudio", cfg, env_values) is False


### PR DESCRIPTION
## Summary

Three LM Studio onboarding bugs fixed together because they pile on top of each other in practice — fixing only one leaves the broken UX. Reporters @chwps and @AdoneyGalvan via #1420 → which was triaged into #1499 and #1500.

| Issue | What's wrong | What this PR does |
|---|---|---|
| **#1499 (a)** | Onboarding wizard never probes `<base_url>/models` — accepts unreachable URLs silently and finishes in 239ms with no outbound HTTP. Model dropdown stays empty. | New `POST /api/onboarding/probe` endpoint + frontend probe UI (debounced + blocking). |
| **#1499 (b) — third sub-bug** | Wizard rejected an empty api_key for `lmstudio`, `ollama`, `custom` even though most local installs run keyless. Users had to type random gibberish into a password field to clear the form. | New `key_optional` flag on the affected providers. Empty key accepted, no .env placeholder written, `provider_ready=True` based on base_url alone. Inline UX: label flips to "API key (optional)", help text explains it's optional. |
| **#1500** | webui writes `LMSTUDIO_API_KEY` to `.env`, but the agent CLI runtime reads `LM_API_KEY`. Auth-enabled LM Studio users get Settings reporting "configured" but agent runtime returning 401. | Canonical `env_var: "LM_API_KEY"` aligned with the agent, `LMSTUDIO_API_KEY` preserved as a read-only legacy alias for upgrading users. |

## Approach

### #1499 (a) — Probe before persist

```python
# api/onboarding.py
def probe_provider_endpoint(provider, base_url, api_key=None, timeout=5.0) -> dict:
    """Probe `<base_url>/models`. Returns {ok, models} on success;
    {ok: False, error: <code>, detail} on failure with stable codes
    the frontend can switch on."""
```

**Stable error codes:** `invalid_url`, `dns`, `connect_refused`, `timeout`, `http_4xx`, `http_5xx`, `parse`, `unreachable`. Each gets its own localized i18n key so the wizard can surface a precise hint (e.g. the `connect_refused` message tells Docker users to try the host IP instead of `localhost`).

**Read-only by design.** Probe responses populate the wizard's model dropdown but never get persisted — `apply_onboarding_setup` remains the single write surface.

**SSRF.** Deliberately does NOT block private-IP ranges. The wizard is gated behind WebUI auth and the legitimate target IS a local LM Studio / Ollama / vLLM server; blocking private IPs would make the feature useless. The route also reuses the same local-network gate as `/api/onboarding/setup` because the body carries an `api_key`.

**Stdlib only.** `urllib.request` + `socket` for the probe — no `httpx` dep added. 5s timeout, 256 KB response cap.

**Frontend wiring** in `static/onboarding.js`:
- New `ONBOARDING.probe` state object (`{status, error, detail, models, probedKey}`)
- `_runOnboardingProbe()` is idempotent + cached on `(provider, baseUrl, apiKey)` so repeat clicks don't re-fetch
- Debounced (400ms) on `oninput` of the base URL field; explicit "Test connection" button
- `nextOnboardingStep` blocks Continue at the setup step for any provider with `requires_base_url=True` until probe status is `ok`
- Probe-discovered models populate the wizard's model dropdown, replacing the (empty) catalog list

### #1499 (b) — Keyless setup for self-hosted providers

The cleanest UX is **make the field truly optional** rather than adding a "no-auth" checkbox or hidden auto-detection magic. The probe (#1499 (a)) makes this strictly safe: user leaves the key blank, hits Test connection, instantly sees either "Connected. N model(s) available." (success — keyless server is open) or `http_4xx` "401" (server requires auth — type a key). Same mental model as every other field: just hit Continue, the wizard tells you what's wrong if anything is.

**Backend:** `_SUPPORTED_PROVIDER_SETUPS` gains `key_optional: True` for `lmstudio`, `ollama`, `custom`:

```python
"lmstudio": {
    ...
    "env_var": "LM_API_KEY",
    "env_var_aliases": ["LMSTUDIO_API_KEY"],
    "requires_base_url": True,
    "key_optional": True,           # NEW — empty api_key accepted
    ...
},
```

`apply_onboarding_setup` skips the "{env_var} is required" check, doesn't write a placeholder to `.env`, and `_status_from_runtime` reports `provider_ready=True` based on `base_url` alone for these providers. Cloud providers (openrouter / anthropic / openai / gemini / deepseek / …) are unaffected — empty keys still rejected.

**Frontend:** `_renderOnboardingApiKeyField()` flips the label to **"API key (optional)"**, the placeholder to **"Leave blank for keyless servers"**, and renders an italic muted help paragraph below: *"Most LM Studio / Ollama / vLLM installs run keyless — leave this blank if your server doesn't require authentication. Use the Test connection button to verify."*

### #1500 — Env var alignment with agent CLI

The agent's source of truth is `hermes_cli/auth.py:177-183`:

```python
"lmstudio": ProviderConfig(
    id="lmstudio",
    api_key_env_vars=("LM_API_KEY",),
    base_url_env_var="LM_BASE_URL",
    ...
),
```

Picked **Option B** from the issue (defer to the agent — single source of truth). To avoid the migration cliff where existing users with `LMSTUDIO_API_KEY` in their `.env` would see Settings flip to "no key" on upgrade:

- Onboarding **writes** only the canonical `LM_API_KEY` going forward.
- Detection (both `_provider_api_key_present` in onboarding and `_provider_has_key` in providers) **reads** the canonical first, then falls through to legacy aliases declared in two new dicts (`env_var_aliases` and `_PROVIDER_ENV_VAR_ALIASES`).
- The alias mechanism is general — any future env-var rename gets the same gentle-migration path for free.

```yaml
# Migration matrix
| User has | Pre-fix | Post-fix |
|----------|---------|----------|
| Just LM_API_KEY (new install) | Settings: no key (wrong) | has_key=True, agent reads it ✓ |
| Just LMSTUDIO_API_KEY (existing) | Settings: has_key, agent reads nothing | has_key=True (via alias), but the agent runtime still reads LM_API_KEY — chat keeps failing the same way until the user re-onboards or hand-renames |
| Both | Settings: has_key | Settings: has_key (canonical wins), agent reads canonical |
```

Note on the middle row: existing users will continue to see "configured" in Settings but their auth-enabled LM Studio chat will keep failing the same way it did before this PR. The release notes will call out the one-time `.env` rename. Trade-off vs. silently rewriting the user's `.env` file at startup, which we want to avoid.

## Verified end-to-end on port 8789

Spun up an isolated test server with a mock LM Studio at `127.0.0.1:11234/v1/models` returning multiple model entries. Stepped through the onboarding wizard with three scenarios:

**1. Failure path (#1499 a):** with `base_url=http://127.0.0.1:1/v1`, the probe rendered:

> **Connection refused — the server may not be running on that address. From inside Docker, try the host IP instead of localhost.** *(connection refused at 127.0.0.1:1)*

Red banner. `nextOnboardingStep` correctly refused to advance.

**2. Keyless success path (#1499 b):** picked LM Studio, left api_key BLANK, set base_url to the mock:

- Field label correctly flipped to **"API key (optional)"**
- Placeholder showed **"Leave blank for keyless servers"**
- Italic muted help paragraph rendered below
- Probe returned green **"Connected. 2 model(s) available."**
- Wizard advanced through workspace + password steps and **completed without ever requiring a key**
- Final state: `config.yaml` written, **`.env` does not exist** (no placeholder), `chat_ready: true`, `state: ready`

**3. Cloud provider unchanged:** switched to Anthropic, label reverted to "API key", help text disappeared, behavior matches the pre-fix experience for cloud users.

The vision tool's analysis confirmed the visual hierarchy: subtle italic help reads as documentation, prominent green probe banner pops as status. Two distinct visual languages, no confusion between them.

## Tests

- **`tests/test_issue1499_onboarding_probe.py`** — 17 tests:
  - 3 invalid_url variants (empty / bad scheme / no host)
  - DNS resolution failure
  - Connect refused (port 1)
  - Success: OpenAI shape `{"data": [...]}`
  - Success: bare-list shape `[...]`
  - `http_4xx` (404)
  - `http_5xx` (500)
  - `parse`: non-JSON body
  - `parse`: JSON but wrong shape
  - api_key passes through as `Authorization: Bearer ...`
  - **Probe is read-only** — must not write to config.yaml or .env
  - PROBE_ERROR_CODES contract pin (regression catcher for new codes)
  - 3 end-to-end route-level smoke tests against the live server fixture

- **`tests/test_issue1499_keyless_onboarding.py`** — 16 tests in 3 classes:
  - `TestKeyOptionalProviderSchema` (5): lmstudio / ollama / custom declare `key_optional=True`; openrouter / anthropic / openai do NOT (regression defense); setup catalog exposes the flag.
  - `TestKeylessOnboarding` (6): empty api_key accepted for the 3 self-hosted providers (no `.env` write); empty api_key still rejected for openrouter / anthropic; explicit-key path still writes `.env` correctly.
  - `TestKeylessChatReady` (5): `provider_ready=True` for keyless lmstudio / ollama; custom requires base_url even when keyless; openrouter still requires a key for `provider_ready`; end-to-end `get_onboarding_status` reports `chat_ready=True` after keyless save.

- **`tests/test_issue1500_lmstudio_env_var_alignment.py`** — 5 tests:
  - Onboarding declares `LM_API_KEY` canonical + `LMSTUDIO_API_KEY` alias
  - Onboarding writes ONLY the canonical name (verified via .env file inspection)
  - Legacy `LMSTUDIO_API_KEY` still detected (no upgrade cliff)
  - Canonical takes precedence when both env vars are set
  - `_provider_api_key_present` reads aliases (onboarding-side detection symmetry)

- **`tests/test_issue1420_lmstudio_provider_env_var.py`** — 5 tests, updated for the new canonical name. Original #1420 regression tests still green.

```text
$ pytest tests/test_issue1499_onboarding_probe.py tests/test_issue1499_keyless_onboarding.py tests/test_issue1500_lmstudio_env_var_alignment.py tests/test_issue1420_lmstudio_provider_env_var.py -v
==== 43 passed in 9.50s ====

$ pytest tests/ -q
==== 3917 passed, 2 skipped, 3 xpassed, 0 failed in 96.55s ====
```

Suite delta: **3879 → 3917, +38 new tests.** Full pre-release gate green on local 3.11.

## Attribution

@chwps did the production diagnosis (config.yaml dump, log-timeline analysis showing zero outbound HTTP during onboarding, manual reproduction). @AdoneyGalvan provided the independent three-container Docker repro. Both get `Co-authored-by` trailers.

The keyless-setup polish (#1499 third sub-bug) was added during PR review when @nesquena flagged that requiring users to type random strings into a password field was unacceptable UX.

Closes #1499 (all three sub-bugs)
Closes #1500
