### PR TITLE
fix: serve static assets correctly under /session/* routes

### DIFF
--- a/api/auth.py
+++ b/api/auth.py
@@ -217,7 +217,7 @@ def check_auth(handler, parsed) -> bool:
     if not is_auth_enabled():
         return True
     # Public paths don't require auth
-    if parsed.path in PUBLIC_PATHS or parsed.path.startswith('/static/'):
+    if parsed.path in PUBLIC_PATHS or parsed.path.startswith('/static/') or parsed.path.startswith('/session/static/'):
         return True
     # Check session cookie
     cookie_val = parse_cookie(handler)

--- a/api/routes.py
+++ b/api/routes.py
@@ -1111,6 +1111,11 @@ def _handle_insights(handler, parsed) -> bool:
 def handle_get(handler, parsed) -> bool:
     """Handle all GET routes. Returns True if handled, False for 404."""
 
+    if parsed.path.startswith("/session/static/"):
+        from urllib.parse import urlparse as _up
+        stripped = parsed._replace(path=parsed.path[len("/session"):])
+        return _serve_static(handler, stripped)
+
     if parsed.path in ("/", "/index.html") or parsed.path.startswith("/session/"):
         from urllib.parse import quote
         from api.updates import WEBUI_VERSION


### PR DESCRIPTION
## Problem

When the browser navigates to a session page at `/session/<id>`, it requests static assets relative to that URL — e.g. `GET /session/static/style.css`. The existing `/session/*` catch-all in `handle_get()` matched these requests first and returned the HTML index page with `Content-Type: text/html`. Browsers with strict MIME checking refused to apply the stylesheet, logging:

```
Refused to apply style from '.../session/static/style.css' because its MIME type
('text/html') is not a supported stylesheet MIME type, and strict MIME checking is enabled.
```

## Fix

**`api/routes.py`** — add a guard *before* the `/session/` catch-all that detects `/session/static/*` paths, strips the `/session` prefix, and delegates to `_serve_static()` so the correct `Content-Type` is returned.

**`api/auth.py`** — whitelist `/session/static/*` in `check_auth()` alongside the existing `/static/` exemption, so static assets on session pages bypass auth (same policy as `/static/`).

## Testing

```bash
curl -si http://127.0.0.1:8787/session/static/style.css | head -3
# HTTP/1.0 200 OK
# Content-Type: text/css; charset=utf-8
```
