### PR TITLE
v0.50.275 — /session/static/* MIME-type fix (PR #1505 by @rickchew)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Hermes Web UI -- Changelog
 
+## [v0.50.275] — 2026-05-03
+
+### Fixed (1 PR — first-time contributor)
+
+- **Static assets served correctly under `/session/*` routes** (#1505, first-time contributor @rickchew) — when the browser navigates to `/session/<id>`, it requests stylesheets and scripts relative to that URL (e.g. `GET /session/static/style.css`). The existing `/session/*` catch-all in `api/routes.py` `handle_get()` matched these requests first and returned the 114KB HTML index page with `Content-Type: text/html`, which strict-MIME browsers refuse to apply as a stylesheet (`X-Content-Type-Options: nosniff` is set). A clever inline `<base href>` injection in `static/index.html:17` papered over the visible breakage on most browsers — but Chrome's preload scanner had already fired off all 12 wrong-URL requests (~1.4MB wasted bandwidth per session-URL navigation), and any strict-MIME / CSP / sandboxed-loader path failed outright. Verified live on master before merge: `curl -si http://127.0.0.1:8787/session/static/style.css` returned `200 OK / Content-Type: text/html / 114563 bytes`. **Fix:** add a guard in `handle_get()` BEFORE the `/session/` catch-all that detects `/session/static/*`, strips the `/session` prefix, and delegates to `_serve_static()` (which carries its own `Path.resolve()+relative_to(static_root)` traversal sandbox). Whitelist `/session/static/*` in `check_auth()` to match the existing `/static/*` auth-exemption policy. Maintainer follow-ups absorbed in-release: dropped an unused `from urllib.parse import urlparse as _up` import the contributor accidentally left in their hunk, and added 5 regression tests in `tests/test_session_static_assets.py` pinning (1) `/session/static/style.css` returns `text/css`, (2) `/session/static/ui.js` returns `application/javascript`, (3) `/session/<id>` (no `/static/`) still serves the HTML index, (4) path-traversal `/session/static/../../etc/passwd` still 404s after the prefix strip, (5) `/session/static/*` matches `/static/*` auth policy while non-static `/session/<id>` still requires auth. Co-authored-by trailer preserves rickchew attribution.
+
+### Notes
+
+- 3918 → 3923 tests passing (+5 regression tests for #1505).
+- Pre-release Opus advisor pass: SHIP. Path-traversal sandbox holds for both literal `..` (Path.resolve+relative_to) and URL-encoded `%2e%2e` (urlparse leaves percent-escapes literal, file doesn't exist → 404). Auth-exemption breadth is benign because `_serve_static`'s sandbox 404s any escape attempt before bytes leak.
+- Closes #1505. No follow-up issues filed.
+
 ## [v0.50.274] — 2026-05-03
 
 ### Fixed (1 PR — three sub-bugs from #1420)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,7 +3,7 @@
 > Goal: Full 1:1 parity with the Hermes CLI experience via a clean dark web UI.
 > Everything you can do from the CLI terminal, you can do from this UI.
 >
-> Last updated: v0.50.274 (May 03, 2026) — 3918 tests collected
+> Last updated: v0.50.275 (May 03, 2026) — 3923 tests collected
 > Tests: `pytest tests/ --collect-only -q`
 > Source: <repo>/
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -1835,8 +1835,8 @@ Bridged CLI sessions:
 
 ---
 
-*Last updated: v0.50.274, May 03, 2026*
-*Total automated tests collected: 3918*
+*Last updated: v0.50.275, May 03, 2026*
+*Total automated tests collected: 3923*
 *Regression gate: tests/test_regressions.py*
 *Run: pytest tests/ -v --timeout=60*
 *Source: <repo>/*

--- a/api/auth.py
+++ b/api/auth.py
@@ -217,7 +217,7 @@ def check_auth(handler, parsed) -> bool:
     if not is_auth_enabled():
         return True
     # Public paths don't require auth
-    if parsed.path in PUBLIC_PATHS or parsed.path.startswith('/static/'):
+    if parsed.path in PUBLIC_PATHS or parsed.path.startswith('/static/') or parsed.path.startswith('/session/static/'):
         return True
     # Check session cookie
     cookie_val = parse_cookie(handler)

--- a/api/routes.py
+++ b/api/routes.py
@@ -1112,7 +1112,9 @@ def handle_get(handler, parsed) -> bool:
     """Handle all GET routes. Returns True if handled, False for 404."""
 
     if parsed.path.startswith("/session/static/"):
-        from urllib.parse import urlparse as _up
+        # Strip the leading "/session" so _serve_static() sees a path that
+        # starts with "/static/" (its required prefix). _serve_static enforces
+        # its own path-traversal sandbox via Path.resolve()+relative_to().
         stripped = parsed._replace(path=parsed.path[len("/session"):])
         return _serve_static(handler, stripped)
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -1111,6 +1111,11 @@ def _handle_insights(handler, parsed) -> bool:
 def handle_get(handler, parsed) -> bool:
     """Handle all GET routes. Returns True if handled, False for 404."""
 
+    if parsed.path.startswith("/session/static/"):
+        from urllib.parse import urlparse as _up
+        stripped = parsed._replace(path=parsed.path[len("/session"):])
+        return _serve_static(handler, stripped)
+
     if parsed.path in ("/", "/index.html") or parsed.path.startswith("/session/"):
         from urllib.parse import quote
         from api.updates import WEBUI_VERSION

--- a/tests/test_session_static_assets.py
+++ b/tests/test_session_static_assets.py
@@ -1,0 +1,131 @@
+"""Regression tests for PR #1505 — /session/static/* must serve static assets, not the HTML index.
+
+Bug shape (pre-fix):
+  Browsers visiting /session/<id> resolved relative `<link rel="stylesheet" href="static/style.css">`
+  references against `/session/`, producing requests like /session/static/style.css. The
+  catch-all `parsed.path.startswith("/session/")` matched FIRST and returned the HTML index
+  with Content-Type: text/html, which strict-MIME browsers refused to apply as a stylesheet.
+
+Fix: handle_get() now intercepts /session/static/* BEFORE the catch-all and delegates to
+_serve_static() with the /session prefix stripped. check_auth() also exempts /session/static/*
+from auth (same policy as /static/*).
+
+These tests pin both the routing fix AND the auth exemption so a future refactor of either
+path can't silently re-introduce the MIME-type bug.
+"""
+
+from types import SimpleNamespace
+from urllib.parse import urlparse
+
+
+class _FakeHandler:
+    def __init__(self):
+        self.status = None
+        self.sent_headers = []
+        self.body = bytearray()
+        self.wfile = self
+        self.headers = {}
+
+    def send_response(self, status):
+        self.status = status
+
+    def send_header(self, name, value):
+        self.sent_headers.append((name, value))
+
+    def end_headers(self):
+        pass
+
+    def write(self, data):
+        self.body.extend(data)
+
+    def header(self, name):
+        for key, value in self.sent_headers:
+            if key.lower() == name.lower():
+                return value
+        return None
+
+
+def test_session_static_css_returns_text_css_mime(monkeypatch):
+    """/session/<id>/static/style.css must return Content-Type: text/css, not text/html.
+
+    This is the exact failure mode PR #1505 fixes: strict-MIME browsers refuse to apply
+    a stylesheet served as text/html.
+    """
+    from api.routes import handle_get
+
+    handler = _FakeHandler()
+    parsed = urlparse("http://example.com/session/static/style.css")
+    assert handle_get(handler, parsed) is True
+    assert handler.status == 200
+    ct = handler.header("Content-Type") or ""
+    assert ct.startswith("text/css"), f"expected text/css, got {ct!r}"
+    # Sanity: real CSS bytes, not the 100KB HTML index page
+    assert b"<!doctype html>" not in handler.body[:200].lower()
+
+
+def test_session_static_js_returns_javascript_mime(monkeypatch):
+    """/session/<id>/static/ui.js must return application/javascript, not text/html."""
+    from api.routes import handle_get
+
+    handler = _FakeHandler()
+    parsed = urlparse("http://example.com/session/static/ui.js")
+    assert handle_get(handler, parsed) is True
+    assert handler.status == 200
+    ct = handler.header("Content-Type") or ""
+    assert ct.startswith("application/javascript"), f"expected application/javascript, got {ct!r}"
+
+
+def test_session_html_route_still_serves_index():
+    """Sibling regression: /session/<id> (no /static/) must still return the HTML index.
+
+    The new /session/static/ guard is positioned before the catch-all; this test ensures
+    the catch-all itself wasn't accidentally reordered or weakened.
+    """
+    from api.routes import handle_get
+
+    handler = _FakeHandler()
+    parsed = urlparse("http://example.com/session/abc123def456")
+    handle_get(handler, parsed)
+    assert handler.status == 200
+    ct = handler.header("Content-Type") or ""
+    assert ct.startswith("text/html"), f"expected text/html, got {ct!r}"
+    # And the body really is the HTML index, not a 404 stub
+    assert b"<!doctype html>" in bytes(handler.body[:200]).lower()
+
+
+def test_session_static_path_traversal_blocked():
+    """Path-traversal sandbox in _serve_static must still apply after the prefix strip.
+
+    /session/static/../../etc/passwd → strips to /static/../../etc/passwd → _serve_static
+    resolves and rejects via relative_to(static_root) → 404.
+    """
+    from api.routes import handle_get
+
+    handler = _FakeHandler()
+    parsed = urlparse("http://example.com/session/static/../../etc/passwd")
+    handle_get(handler, parsed)
+    assert handler.status == 404
+
+
+def test_session_static_auth_exemption(monkeypatch):
+    """/session/static/* must be auth-exempt (same policy as /static/*).
+
+    Without this exemption, anonymous browser navigation to /session/<id> would
+    302-redirect every stylesheet/script to /login, breaking the page even when
+    the HTML index itself loaded correctly.
+    """
+    monkeypatch.setenv("HERMES_WEBUI_PASSWORD", "test-password")
+
+    from api.auth import check_auth
+
+    # /session/static/* is public (matches /static/* policy)
+    handler = _FakeHandler()
+    assert check_auth(handler, SimpleNamespace(path="/session/static/style.css", query="")) is True
+
+    # Confirm the /static/ baseline still works (regression guard)
+    handler = _FakeHandler()
+    assert check_auth(handler, SimpleNamespace(path="/static/style.css", query="")) is True
+
+    # And confirm a non-static /session/* path still requires auth
+    handler = _FakeHandler()
+    assert check_auth(handler, SimpleNamespace(path="/session/abc123", query="")) is False


### PR DESCRIPTION
# Release v0.50.275 — `/session/static/*` MIME-type fix

Single-PR hotfix release. Brings in [#1505 by @rickchew](https://github.com/nesquena/hermes-webui/pull/1505) (first-time contributor 🎉) plus 3 maintainer follow-ups absorbed in-release per the auto-rebase + auto-fix policy.

## What

When the browser navigates to `/session/<id>`, it requests stylesheets and scripts relative to that URL — e.g. `GET /session/static/style.css`, `GET /session/static/ui.js`. The existing `/session/*` catch-all in `api/routes.py` `handle_get()` matched these requests **first** and returned the 114KB HTML index page with `Content-Type: text/html`, which strict-MIME browsers refuse to apply as a stylesheet:

> Refused to apply style from '.../session/static/style.css' because its MIME type ('text/html') is not a supported stylesheet MIME type, and strict MIME checking is enabled.

The clever inline `<base href>` injection in `static/index.html:17` papered over the visible breakage on most browsers — but Chrome's preload scanner had already fired off all 12 wrong-URL requests (~1.4MB wasted bandwidth per session-URL navigation), and any strict-MIME / CSP / sandboxed-loader path failed outright.

## Verified live on master before merge

```bash
$ curl -si http://127.0.0.1:8787/session/static/style.css | head -3
HTTP/1.0 200 OK
Content-Type: text/html; charset=utf-8
Content-Length: 114563
```

And via Chrome DevTools `performance.getEntriesByType('resource')` on a fresh load of `/session/<id>`:

```
12 of 12 static assets fetched as /session/static/*.{js,css}
each receiving the 114KB HTML response
```

## Fix

**`api/routes.py`** — guard placed BEFORE the `/session/*` catch-all:

```python
if parsed.path.startswith("/session/static/"):
    # Strip the leading "/session" so _serve_static() sees a path that
    # starts with "/static/" (its required prefix). _serve_static enforces
    # its own path-traversal sandbox via Path.resolve()+relative_to().
    stripped = parsed._replace(path=parsed.path[len("/session"):])
    return _serve_static(handler, stripped)
```

**`api/auth.py`** — whitelist `/session/static/*` alongside the existing `/static/*` exemption.

## Maintainer follow-ups absorbed in-release

1. **Dropped unused import** — `from urllib.parse import urlparse as _up` was left in the contributor's hunk and never referenced. `parsed._replace` is a `namedtuple` method on the existing object, no new import needed.
2. **Replaced with a comment** explaining the prefix-strip rationale and pointing at `_serve_static`'s existing path-traversal sandbox.
3. **Added 5 regression tests** (`tests/test_session_static_assets.py`) pinning:
   - `/session/static/style.css` → `text/css`
   - `/session/static/ui.js` → `application/javascript`
   - `/session/<id>` (no `/static/`) still returns the HTML index — guards against future refactors silently weakening the catch-all
   - Path-traversal `/session/static/../../etc/passwd` → 404 (sandbox holds after prefix-strip)
   - `/session/static/*` matches `/static/*` auth-exemption policy; non-static `/session/<id>` still requires auth

`Co-authored-by: Rick Chew` trailer preserves contributor attribution.

## Test count

3918 → **3923** passing (+5 regression tests). Full suite green locally.

## Pre-release Opus advisor pass

**Verdict: SHIP.** Verified:

1. **Path-traversal sandbox.** Both literal `..` (collapsed by `Path.resolve()` then rejected by `relative_to(static_root)`) and URL-encoded `%2e%2e` (urlparse doesn't decode percent-escapes, treated as literal directory name → file doesn't exist → 404) are properly handled. No additional decode-and-revalidate step needed.
2. **`parsed._replace(path=...)`** is a stable `namedtuple` API on `urllib.parse.ParseResult`, fine to use.
3. **Auth-exemption breadth** is benign — `_serve_static`'s sandbox 404s any escape attempt before bytes can leak; `check_auth` returning True means "no login wall in front of this 404", which is fine.

No MUST-FIX, no SHOULD-FIX, no follow-up issues filed.

## Diff

```
api/auth.py                         |   2 +-
api/routes.py                       |   7 ++
tests/test_session_static_assets.py | 131 ++++++++++++++++++++++++++++++++++++
CHANGELOG.md                        |  12 ++++
ROADMAP.md                          |   2 +-
TESTING.md                          |   4 +-
6 files changed, 153 insertions(+), 5 deletions(-)
```

## Branches & cleanup

- Closes #1505 (will be merged via this release rather than directly)
- Tag: `v0.50.275`
- Stage branch: `stage-275`
- Worktree: `/tmp/wt-1505` (cleaned up post-merge)
