### PR TITLE
fix: remove redundant provider label concatenation in _deduplicate_model_ids

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -942,11 +942,6 @@ def _deduplicate_model_ids(groups: list[dict]) -> None:
             model = group["models"][mi]
             pid = group.get("provider_id", "")
             model["id"] = f"@{pid}:{original_id}"
-            provider_name = group.get("provider", pid)
-            if model.get("label") != original_id:
-                model["label"] = f"{model['label']} ({provider_name})"
-            else:
-                model["label"] = f"{original_id} ({provider_name})"
 
 
 def resolve_model_provider(model_id: str) -> tuple:


### PR DESCRIPTION
## Problem

When multiple providers expose models with the same name (e.g., DeepSeek V4 Flash is available from Xiaomi, Ollama, HuggingFace, etc.), the `_deduplicate_model_ids()` function appends the provider name to the model label for every duplicate found. This results in garbled labels like:

`Deepseek V4 Flash (Xiaomi) (Ollama) (HuggingFace) (Google-Gemini-Cli)`

The label should reflect the model's own metadata, not accumulate provider names.

## Root Cause

In `api/config.py`, the `_deduplicate_model_ids` function (around line 945) appends `(provider_name)` to `model["label"]` when deduplicating models with the same name. Since the function iterates across all provider groups and appends the label for every match, models exposed by many providers get increasingly garbled labels.

## Fix

Remove the label concatenation logic entirely. The ID deduplication (prefixing with `@provider_id:`) is preserved — it's the correct way to differentiate same-named models from different providers. The label should be left as-is from the model's own metadata.

### Before

```python
model["id"] = f"@{pid}:{original_id}"
provider_name = group.get("provider", pid)
if model.get("label") != original_id:
    model["label"] = f"{model['label']} ({provider_name})"
else:
    model["label"] = f"{original_id} ({provider_name})"
```

### After

```python
model["id"] = f"@{pid}:{original_id}"
```

## Testing

- Verified `/api/models` returns clean labels with no accumulated provider suffixes
- Model list in WebUI displays correctly with 11 clean provider groups
- No regression in model switching or provider routing