### PR TITLE
feat: add "None" filter chip for sessions without project

### DIFF
--- a/static/sessions.js
+++ b/static/sessions.js
@@ -674,6 +674,7 @@ const _selectedSessions = new Set();  // selected session IDs
 let _allProjects = [];  // cached project list
 let _activeProject = null;  // project_id filter (null = show all)
 let _showAllProfiles = false;  // false = filter to active profile only
+let _showNoneProject = false;  // show sessions without any project
 let _sessionActionMenu = null;
 let _sessionActionAnchor = null;
 let _sessionActionSessionId = null;
@@ -1429,8 +1430,8 @@ function renderSessionListFromCache(){
   // Server backfills profile='default' for legacy sessions, so every session has a profile.
   // Show only sessions tagged to the active profile; 'All profiles' toggle overrides.
   const profileFiltered=_showAllProfiles?withMessages:withMessages.filter(s=>s.is_cli_session||s.profile===S.activeProfile);
-  // Filter by active project
-  const projectFiltered=_activeProject?profileFiltered.filter(s=>s.project_id===_activeProject):profileFiltered;
+  // Filter by project: "All" (null) shows all projects, "None" shows sessions without project, other project shows only that project
+  const projectFiltered=_activeProject?profileFiltered.filter(s=>s.project_id===_activeProject):(_showNoneProject?profileFiltered.filter(s=>!s.project_id):profileFiltered);
   // Filter archived unless toggle is on
   const sessionsRaw=_showArchived?projectFiltered:projectFiltered.filter(s=>!s.archived);
   const sessions=_attachChildSessionsToSidebarRows(_collapseSessionLineageForSidebar(sessionsRaw), sessionsRaw);
@@ -1462,10 +1463,17 @@ function renderSessionListFromCache(){
     bar.className='project-bar';
     // "All" chip
     const allChip=document.createElement('span');
-    allChip.className='project-chip'+(!_activeProject?' active':'');
+    allChip.className='project-chip'+(!_activeProject&&!_showNoneProject?' active':'');
     allChip.textContent='All';
-    allChip.onclick=()=>{_activeProject=null;renderSessionListFromCache();};
+    allChip.onclick=()=>{_activeProject=null;_showNoneProject=false;renderSessionListFromCache();};
     bar.appendChild(allChip);
+    // "None" chip (sessions without any project)
+    const noneChip=document.createElement('span');
+    noneChip.className='project-chip'+(_showNoneProject?' active':'');
+    noneChip.textContent='None';
+    noneChip.onclick=()=>{_activeProject=null;_showNoneProject=true;renderSessionListFromCache();};
+    noneChip.oncontextmenu=(e)=>{e.preventDefault();_showProjectContextMenu(e, null, noneChip);};
+    bar.appendChild(noneChip);
     // Project chips
     for(const p of _allProjects){
       const chip=document.createElement('span');


### PR DESCRIPTION
# Add "None" filter chip for sessions without project

## What Changed

Added a new "None" filter chip in the session list sidebar that displays only conversations not assigned to any project folder.

**File changes:**
- `static/sessions.js`: Added `_showNoneProject` flag and "None" chip UI element

## Why It Matters

Previously, there was no easy way to view sessions that weren't organized into projects. Users could only see:
- All sessions (when "All" chip was selected)
- Sessions within a specific project

Now users can also filter by "None" to see only unassigned/unorganized conversations, which is useful for:
- Finding recent conversations not yet organized
- Quick review of all active chats regardless of project
- Cleaning up the project view from unassigned sessions

## Implementation

**Chosen approach:** Added a simple boolean flag `_showNoneProject` to the existing filter state management system.

This approach was selected because:
- Minimal code changes (single new variable + filter logic update)
- Consistent with existing patterns (`_showArchived`, `_showAllProfiles`)
- No breaking changes to existing functionality
- Easy to test and maintain

**Alternative approach considered:** Refactoring `_showAllProfiles` from a boolean flag to a state object or constant enum. However, this would require more significant changes to multiple files and is unlikely to be necessary in the near future.

## Verification

1. Open session list sidebar
2. Click "None" chip (appears after "All" chip)
3. Verify only sessions without `project_id` are shown
4. Click "All" or any project chip — "None" filter should deactivate
5. Click "None" again — should re-enable the filter

## Risks / Follow-ups

- Context menu on "None" chip calls `_showProjectContextMenu` with `null` — should work since it handles null project gracefully
- No backend changes needed — filtering is done in frontend
- Existing project filtering logic remains unchanged — only adds a new filter state

---

*AI-assisted code generation: Qwen3.5*