### PR TITLE
fix: YAML newline collapse (#1463) + consolidate version placeholders (#1509)

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -915,7 +915,7 @@ def handle_get(handler, parsed) -> bool:
             from api.updates import WEBUI_VERSION
             version_token = quote(WEBUI_VERSION, safe="")
             text = sw_path.read_text(encoding="utf-8").replace(
-                "__CACHE_VERSION__", version_token
+                "__WEBUI_VERSION__", version_token
             )
             data = text.encode("utf-8")
             handler.send_response(200)

--- a/static/style.css
+++ b/static/style.css
@@ -714,6 +714,8 @@
   .msg-body pre code{background:none;padding:0;border-radius:0;color:var(--pre-text);font-size:13px;line-height:1.6;}
   /* Keep original theme background — prevent prism-tomorrow from overriding --code-bg */
   .msg-body pre[class*="language-"],.msg-body pre code[class*="language-"]{background:var(--code-bg) !important;}
+  /* Fix #1463: Prism YAML grammar collapses newlines inside token spans — force pre */
+  .msg-body pre code.language-yaml .token{white-space:pre !important;}
   .pre-header{font-size:10px;font-weight:600;text-transform:uppercase;letter-spacing:.06em;color:var(--muted);padding:8px 16px 8px;background:var(--input-bg);border-radius:10px 10px 0 0;border:1px solid var(--border);border-bottom:1px solid var(--border);display:flex;align-items:center;gap:6px;}
   .pre-header::before{content:'';width:8px;height:8px;border-radius:50%;background:var(--muted);opacity:.4;}
   .pre-header+pre{border-radius:0 0 10px 10px;border-top:none;margin-top:0;}
@@ -1069,6 +1071,8 @@
   .preview-md pre code{background:none;padding:0;color:var(--pre-text);font-size:11.5px;line-height:1.55;}
   /* Keep original theme background — prevent prism-tomorrow from overriding --code-bg */
   .preview-md pre[class*="language-"],.preview-md pre code[class*="language-"]{background:var(--code-bg) !important;}
+  /* Fix #1463: Prism YAML grammar collapses newlines inside token spans — force pre */
+  .preview-md pre code.language-yaml .token{white-space:pre !important;}
   .preview-md blockquote{border-left:3px solid var(--blue);padding-left:12px;color:var(--muted);font-style:italic;margin:8px 0;}
   .preview-md blockquote p{margin:0;}
   .preview-md strong{color:var(--strong);font-weight:600;}.preview-md em{color:var(--em);}

--- a/static/sw.js
+++ b/static/sw.js
@@ -7,7 +7,7 @@
 
 // Cache version is injected by the server at request time (routes.py /sw.js handler).
 // Bumps automatically whenever the git commit changes — no manual edits needed.
-const CACHE_NAME = 'hermes-shell-__CACHE_VERSION__';
+const CACHE_NAME = 'hermes-shell-__WEBUI_VERSION__';
 
 // Static assets that form the app shell
 const SHELL_ASSETS = [

--- a/tests/test_pwa_manifest_sw.py
+++ b/tests/test_pwa_manifest_sw.py
@@ -2,7 +2,7 @@
 
 Covers:
 - manifest.json is valid JSON with required PWA fields
-- sw.js has the `__CACHE_VERSION__` placeholder the server replaces at request time
+- sw.js has the `__WEBUI_VERSION__` placeholder the server replaces at request time
 - sw.js offline-fallback uses a resolved promise (not `caches.match() || fallback`
   which is broken — Promise objects are always truthy in `||` checks, so the
   fallback Response would never be used)
@@ -52,8 +52,8 @@ class TestManifest:
 class TestServiceWorker:
     def test_sw_has_cache_version_placeholder(self):
         src = SW.read_text(encoding="utf-8")
-        assert "__CACHE_VERSION__" in src, (
-            "sw.js must contain __CACHE_VERSION__ placeholder for the server "
+        assert "__WEBUI_VERSION__" in src, (
+            "sw.js must contain __WEBUI_VERSION__ placeholder for the server "
             "handler at /sw.js to replace with WEBUI_VERSION at request time"
         )
 
@@ -117,8 +117,8 @@ class TestPWARoutes:
         idx = src.find('"/sw.js"')
         assert idx != -1, "routes.py must handle /sw.js"
         block = src[idx:idx + 1000]
-        assert "__CACHE_VERSION__" in block, (
-            "sw.js route must replace __CACHE_VERSION__ with the current WEBUI_VERSION"
+        assert "__WEBUI_VERSION__" in block, (
+            "sw.js route must replace __WEBUI_VERSION__ with the current WEBUI_VERSION"
         )
         assert "WEBUI_VERSION" in block, (
             "sw.js route must import and use WEBUI_VERSION for cache busting"


### PR DESCRIPTION
## Summary

Two small fixes bundled into one PR:

### 1. Fix YAML newline collapse (#1463)

Prism's YAML grammar wraps tokens in `<span>` elements where `white-space` defaults to `normal`, collapsing `\n` characters into spaces. The DOM textContent is correct — confirmed by reporter's probe — so the bug is purely CSS.

**Fix:** Add `white-space: pre !important` to `.token` elements inside `language-yaml` code blocks, for both `.msg-body` and `.preview-md` contexts.

### 2. Consolidate version placeholders (#1509)

`__CACHE_VERSION__` (sw.js) and `__WEBUI_VERSION__` (index.html) are functionally identical — both resolve to `quote(WEBUI_VERSION, safe="")` at request time. Two names exist for historical reasons.

**Fix:** Rename `__CACHE_VERSION__` → `__WEBUI_VERSION__` in `static/sw.js`, `api/routes.py`, and `tests/test_pwa_manifest_sw.py`. Single canonical name, no behavior change.

## Changes

| File | Change |
|------|--------|
| `static/style.css` | +2 CSS rules (`.msg-body` + `.preview-md`) forcing `white-space: pre` on YAML tokens |
| `static/sw.js` | `__CACHE_VERSION__` → `__WEBUI_VERSION__` |
| `api/routes.py` | Substitution string updated to match |
| `tests/test_pwa_manifest_sw.py` | Assertions updated for consolidated placeholder |

## Tests

- 16/16 PWA tests pass
- 6/6 Korean locale tests pass (pre-existing)
- No regressions