### PR TITLE
fix: YAML code blocks collapse newlines due to Prism token white-space (#1463)

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -735,6 +735,8 @@
   .msg-body pre code{background:none;padding:0;border-radius:0;color:var(--pre-text);font-size:13px;line-height:1.6;}
   /* Keep original theme background — prevent prism-tomorrow from overriding --code-bg */
   .msg-body pre[class*="language-"],.msg-body pre code[class*="language-"]{background:var(--code-bg) !important;}
+  /* Fix #1463: Prism YAML grammar collapses newlines inside token spans — force pre */
+  .msg-body pre code.language-yaml .token{white-space:pre !important;}
   .pre-header{font-size:10px;font-weight:600;text-transform:uppercase;letter-spacing:.06em;color:var(--muted);padding:8px 16px 8px;background:var(--input-bg);border-radius:10px 10px 0 0;border:1px solid var(--border);border-bottom:1px solid var(--border);display:flex;align-items:center;gap:6px;}
   .pre-header::before{content:'';width:8px;height:8px;border-radius:50%;background:var(--muted);opacity:.4;}
   .pre-header+pre{border-radius:0 0 10px 10px;border-top:none;margin-top:0;}
@@ -1128,6 +1130,8 @@
   .preview-md pre code{background:none;padding:0;color:var(--pre-text);font-size:11.5px;line-height:1.55;}
   /* Keep original theme background — prevent prism-tomorrow from overriding --code-bg */
   .preview-md pre[class*="language-"],.preview-md pre code[class*="language-"]{background:var(--code-bg) !important;}
+  /* Fix #1463: Prism YAML grammar collapses newlines inside token spans — force pre */
+  .preview-md pre code.language-yaml .token{white-space:pre !important;}
   .preview-md blockquote{border-left:3px solid var(--blue);padding-left:12px;color:var(--muted);font-style:italic;margin:8px 0;}
   .preview-md blockquote p{margin:0;}
   .preview-md strong{color:var(--strong);font-weight:600;}.preview-md em{color:var(--em);}


### PR DESCRIPTION
## Thinking Path

- Hermes WebUI renders markdown code blocks through a Prism.js syntax-highlighting pipeline
- The reporter (#1463) confirmed via DOM probes that `textContent` of YAML blocks preserves `\n` characters, ruling out the renderer pipeline
- Plain code blocks and `language-bash` blocks render correctly — only `language-yaml` is affected
- This points to Prism's YAML grammar, which wraps tokens in `<span>` elements where `white-space` defaults to `normal`, collapsing newlines into spaces
- The fix is pure CSS: force `white-space: pre` on token spans inside YAML code blocks

## What Changed

Added two CSS rules to `static/style.css`:

```css
.msg-body pre code.language-yaml .token{white-space:pre !important;}
.preview-md pre code.language-yaml .token{white-space:pre !important;}
```

Covers both the chat message area (`.msg-body`) and the markdown preview panel (`.preview-md`).

## Why It Matters

YAML is one of the most common code-block languages in this UI (config files, docker-compose, CI pipelines). Collapsed newlines make YAML blocks unreadable — the indentation structure that YAML depends on is lost.

## Verification

- Reporter's probe 1 confirmed `\n` present in DOM `textContent` → CSS fix is the correct layer
- Reporter's probe 2 confirmed plain code blocks and `language-bash` work → scoped to YAML token processing only
- The selector `.language-yaml .token` is specific enough to avoid side effects on other languages
- `!important` is necessary because Prism's bundled themes set `white-space` on token elements

## Risks / Follow-ups

- **Risk:** None. The selector is scoped to `language-yaml` only; other languages are unaffected.
- **Follow-up:** If Prism updates their YAML grammar to fix the underlying tokenizer issue, this rule becomes a harmless no-op.

## Model Used

- xiaomi/mimo-v2.5-pro (via Xiaomi MiMo)