### PR TITLE
fix: consolidate __CACHE_VERSION__ to __WEBUI_VERSION__ (#1509)

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -1188,7 +1188,7 @@ def handle_get(handler, parsed) -> bool:
             from api.updates import WEBUI_VERSION
             version_token = quote(WEBUI_VERSION, safe="")
             text = sw_path.read_text(encoding="utf-8").replace(
-                "__CACHE_VERSION__", version_token
+                "__WEBUI_VERSION__", version_token
             )
             data = text.encode("utf-8")
             handler.send_response(200)

--- a/static/sw.js
+++ b/static/sw.js
@@ -7,18 +7,18 @@
 
 // Cache version is injected by the server at request time (routes.py /sw.js handler).
 // Bumps automatically whenever the git commit changes — no manual edits needed.
-const CACHE_NAME = 'hermes-shell-__CACHE_VERSION__';
+const CACHE_NAME = 'hermes-shell-__WEBUI_VERSION__';
 
 // Static assets that form the app shell.
 //
-// Versioned assets (CSS + JS) include `?v=__CACHE_VERSION__` to match the
+// Versioned assets (CSS + JS) include `?v=__WEBUI_VERSION__` to match the
 // query string the page sends — see index.html. Without the version query
 // here, every cache lookup against `?v=...` URLs would miss and fall through
 // to network, defeating the pre-cache.
 //
 // Unversioned assets (`./`, manifest.json, favicons) are referenced from
 // index.html without a cache-bust query, so they stay unversioned here too.
-const VQ = '?v=__CACHE_VERSION__';
+const VQ = '?v=__WEBUI_VERSION__';
 const SHELL_ASSETS = [
   './',
   './static/style.css' + VQ,

--- a/tests/test_pwa_manifest_sw.py
+++ b/tests/test_pwa_manifest_sw.py
@@ -2,7 +2,7 @@
 
 Covers:
 - manifest.json is valid JSON with required PWA fields
-- sw.js has the `__CACHE_VERSION__` placeholder the server replaces at request time
+- sw.js has the `__WEBUI_VERSION__` placeholder the server replaces at request time
 - sw.js offline-fallback uses a resolved promise (not `caches.match() || fallback`
   which is broken — Promise objects are always truthy in `||` checks, so the
   fallback Response would never be used)
@@ -52,8 +52,8 @@ class TestManifest:
 class TestServiceWorker:
     def test_sw_has_cache_version_placeholder(self):
         src = SW.read_text(encoding="utf-8")
-        assert "__CACHE_VERSION__" in src, (
-            "sw.js must contain __CACHE_VERSION__ placeholder for the server "
+        assert "__WEBUI_VERSION__" in src, (
+            "sw.js must contain __WEBUI_VERSION__ placeholder for the server "
             "handler at /sw.js to replace with WEBUI_VERSION at request time"
         )
 
@@ -117,8 +117,8 @@ class TestPWARoutes:
         idx = src.find('"/sw.js"')
         assert idx != -1, "routes.py must handle /sw.js"
         block = src[idx:idx + 1000]
-        assert "__CACHE_VERSION__" in block, (
-            "sw.js route must replace __CACHE_VERSION__ with the current WEBUI_VERSION"
+        assert "__WEBUI_VERSION__" in block, (
+            "sw.js route must replace __WEBUI_VERSION__ with the current WEBUI_VERSION"
         )
         assert "WEBUI_VERSION" in block, (
             "sw.js route must import and use WEBUI_VERSION for cache busting"
@@ -185,7 +185,7 @@ class TestIndexHtmlIntegration:
 
     def test_sw_shell_assets_match_versioned_asset_urls(self):
         """The service worker's SHELL_ASSETS pre-cache list must use the same
-        `?v=__CACHE_VERSION__` suffix on JS+CSS that index.html sends, so that
+        `?v=__WEBUI_VERSION__` suffix on JS+CSS that index.html sends, so that
         the pre-cached entries actually serve when the page requests them.
 
         Without this, every `cache.match()` for a versioned asset URL (e.g.
@@ -208,13 +208,13 @@ class TestIndexHtmlIntegration:
             "terminal.js",
             "onboarding.js",
         ):
-            # Either inline `?v=__CACHE_VERSION__` or via the VQ constant
+            # Either inline `?v=__WEBUI_VERSION__` or via the VQ constant
             # produces a URL string the cache lookup can match.
-            has_inline = f"{asset}?v=__CACHE_VERSION__" in src
+            has_inline = f"{asset}?v=__WEBUI_VERSION__" in src
             has_concat = f"{asset}' + VQ" in src or f"{asset}\" + VQ" in src
             assert has_inline or has_concat, (
                 f"sw.js SHELL_ASSETS entry for {asset} must carry "
-                "?v=__CACHE_VERSION__ to match the URL the page requests"
+                "?v=__WEBUI_VERSION__ to match the URL the page requests"
             )
 
     def test_index_route_url_encodes_asset_version(self):


### PR DESCRIPTION
## Thinking Path

- `__CACHE_VERSION__` (in `static/sw.js`) and `__WEBUI_VERSION__` (in `static/index.html`) are functionally identical: both flow through `quote(WEBUI_VERSION, safe="")` at request time and produce the same token
- Two placeholder names exist for historical reasons — `index.html` and its versioning were added first, the SW was added later in a separate PR
- Having two names for the same value is a naming hygiene issue surfaced during the v0.50.276 release review
- This PR consolidates to a single canonical name: `__WEBUI_VERSION__`

## What Changed

| File | Change |
|------|--------|
| `static/sw.js` | `__CACHE_VERSION__` → `__WEBUI_VERSION__` in `CACHE_NAME`, `VQ` constant, and comment |
| `api/routes.py` | Substitution string updated to `__WEBUI_VERSION__` |
| `tests/test_pwa_manifest_sw.py` | All 9 assertions and docstrings updated to match |

## Why It Matters

- Eliminates confusion for contributors who see two different placeholder names and wonder if they're different values
- Single source of truth: `__WEBUI_VERSION__` is the canonical name used in `index.html` (the older, more widely referenced file)
- Makes the version injection path easier to trace across files

## Verification

- 19/19 PWA tests pass (`tests/test_pwa_manifest_sw.py`)
- `grep -rn "__CACHE_VERSION__"` across all `.py`, `.js`, `.html` files returns zero matches
- No behavior change: same `?v=vX.Y.Z` query strings on the same URLs, same cache-bust semantics

## Risks / Follow-ups

- **Risk:** None. Pure rename with no behavioral change. The substitution happens at request time, so the SW output is byte-identical.
- **Follow-up:** None needed. The consolidation is complete.

## Model Used

- xiaomi/mimo-v2.5-pro (via Xiaomi MiMo)
