### PR TITLE
fix: onboarding API-key input loses focus when probe completes (#1503)

### DIFF
--- a/static/onboarding.js
+++ b/static/onboarding.js
@@ -197,7 +197,7 @@ function _renderOnboardingApiKeyField(){
   const labelKey=keyOptional?'onboarding_api_key_label_optional':'onboarding_api_key_label';
   const placeholderKey=keyOptional?'onboarding_api_key_placeholder_optional':'onboarding_api_key_placeholder';
   const helpHtml=keyOptional?`<p class="onboarding-copy onboarding-api-key-help">${esc(t('onboarding_api_key_help_keyless')||'')}</p>`:'';
-  return `<label class="onboarding-field" id="onboardingApiKeyField"><span>${t(labelKey)}</span><input id="onboardingApiKeyInput" type="password" value="${esc(ONBOARDING.form.apiKey||'')}" placeholder="${t(placeholderKey)}" oninput="ONBOARDING.form.apiKey=this.value;_scheduleOnboardingProbe()"></label>${helpHtml}`;
+  return `<label class="onboarding-field" id="onboardingApiKeyField"><span>${t(labelKey)}</span><input id="onboardingApiKeyInput" type="password" value="${esc(ONBOARDING.form.apiKey||'')}" placeholder="${t(placeholderKey)}" oninput="ONBOARDING.form.apiKey=this.value" onblur="_runOnboardingProbe()"></label>${helpHtml}`;
 }
 
 function _getOnboardingSelectedModel(){


### PR DESCRIPTION
## Thinking Path

- The onboarding wizard's API-key input has `oninput="_scheduleOnboardingProbe()"` which fires a 400ms-debounced probe on every keystroke
- When the probe completes, `_setOnboardingProbeState()` calls `_renderOnboardingBody()` which rebuilds the entire form DOM
- This destroys the `<input>` element the user is typing into — focus and cursor position are lost
- On localhost the probe completes in ~5-50ms so the bug window is narrow; on slow networks (VPN, corporate proxy, cold-start vLLM) the re-render routinely lands between keystrokes
- The password field is where impact is felt most — users type long secrets character by character
- Fix: remove `_scheduleOnboardingProbe()` from the api-key input's `oninput` handler (Option A from the issue). Add `onblur="_runOnboardingProbe()"` so the probe fires when the user tabs away

## What Changed

`static/onboarding.js` — line 200, one line change:

- **Before:** `oninput="ONBOARDING.form.apiKey=this.value;_scheduleOnboardingProbe()"`
- **After:** `oninput="ONBOARDING.form.apiKey=this.value" onblur="_runOnboardingProbe()"`

## Why It Matters

- The API-key field is a `type="password"` input where users paste or type long secrets
- Losing focus mid-typing is disorienting — "I was typing my key and the field stopped responding"
- The probe still fires via: (a) `onblur` when user tabs away, (b) "Test connection" button click, (c) `nextOnboardingStep()` before Continue
- The inline probe banner may not show "401 → key required" until Continue is clicked, but `nextOnboardingStep` gates on probe success so the flow is still correct

## Verification

- `_scheduleOnboardingProbe()` is only removed from the api-key input — the baseUrl input (line 185) still has it, which is acceptable UX
- `_runOnboardingProbe()` on `onblur` ensures the probe fires before the user reaches the Continue button
- `nextOnboardingStep()` (line 525) runs `_runOnboardingProbe()` synchronously before allowing Continue — no flow breakage
- 25/25 tests pass

## Risks / Follow-ups

- **Risk:** If a user pastes a key and clicks Continue without first blurring the field, the inline probe banner won't show the result until Continue is clicked. This is acceptable — `nextOnboardingStep` handles it.
- **Follow-up:** Option B from the issue (targeted DOM update instead of full re-render) is the proper architectural fix but is ~30-50 LOC. This PR is the 1-line mitigation.

## Model Used

- xiaomi/mimo-v2.5-pro (via Xiaomi MiMo)
