### PR TITLE
fix: clear stale WebUI stream state

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -233,6 +233,34 @@ from api.helpers import (
     _redact_text,
 )
 
+
+def _clear_stale_stream_state(session) -> bool:
+    """Clear persisted streaming flags when the in-memory stream no longer exists.
+
+    A server restart or worker crash can leave active_stream_id/pending_* in the
+    session JSON while STREAMS is empty. The frontend then keeps reconnecting to
+    a dead stream and shows a permanent running/thinking state.
+    """
+    stream_id = getattr(session, "active_stream_id", None)
+    if not stream_id:
+        return False
+    with STREAMS_LOCK:
+        stream_alive = stream_id in STREAMS
+    if stream_alive:
+        return False
+    session.active_stream_id = None
+    if hasattr(session, "pending_user_message"):
+        session.pending_user_message = None
+    if hasattr(session, "pending_attachments"):
+        session.pending_attachments = []
+    if hasattr(session, "pending_started_at"):
+        session.pending_started_at = None
+    try:
+        session.save()
+    except Exception:
+        pass
+    return True
+
 # ── CSRF: validate Origin/Referer on POST ────────────────────────────────────
 import re as _re
 
@@ -1309,6 +1337,7 @@ def handle_get(handler, parsed) -> bool:
         try:
             _t1 = _time.monotonic()
             s = get_session(sid, metadata_only=(not load_messages))
+            _clear_stale_stream_state(s)
             _t2 = _time.monotonic()
             effective_model = (
                 _resolve_effective_session_model_for_display(s)
@@ -1435,6 +1464,7 @@ def handle_get(handler, parsed) -> bool:
             return bad(handler, "Missing session_id")
         try:
             from api.session_ops import session_status
+            _clear_stale_stream_state(get_session(sid, metadata_only=True))
             return j(handler, session_status(sid))
         except KeyError:
             return bad(handler, "Session not found", 404)
@@ -4265,7 +4295,7 @@ def _handle_chat_start(handler, body):
                 status=409,
             )
         # Stale stream id from a previous run; clear and continue.
-        s.active_stream_id = None
+        _clear_stale_stream_state(s)
     stream_id = uuid.uuid4().hex
     with _get_session_agent_lock(s.session_id):
         s.workspace = workspace

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -387,6 +387,15 @@ async function loadSession(sid){
   _setActiveSessionUrl(S.session.session_id);
 
   const activeStreamId=S.session.active_stream_id||null;
+  // If the server says the session is idle, discard any browser-side inflight
+  // cache left behind by a crashed/restarted stream. Otherwise the UI can keep
+  // showing a permanent thinking/running state even though active_streams=0.
+  if(!activeStreamId&&INFLIGHT[sid]){
+    delete INFLIGHT[sid];
+    if(typeof clearInflightState==='function') clearInflightState(sid);
+    S.activeStreamId=null;
+    S.busy=false;
+  }
 
   // Phase 2a: If session is streaming, restore from INFLIGHT cache before
   // loading full messages (INFLIGHT state is self-contained and sufficient).

--- a/static/sw.js
+++ b/static/sw.js
@@ -7,7 +7,7 @@
 
 // Cache version is injected by the server at request time (routes.py /sw.js handler).
 // Bumps automatically whenever the git commit changes — no manual edits needed.
-const CACHE_NAME = 'hermes-shell-__CACHE_VERSION__';
+const CACHE_NAME = 'hermes-shell-__CACHE_VERSION__-stale-stream-cleanup1';
 
 // Static assets that form the app shell.
 //

--- a/tests/test_stale_stream_cleanup.py
+++ b/tests/test_stale_stream_cleanup.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+ROUTES_SRC = (REPO / "api" / "routes.py").read_text(encoding="utf-8")
+SESSIONS_SRC = (REPO / "static" / "sessions.js").read_text(encoding="utf-8")
+SW_SRC = (REPO / "static" / "sw.js").read_text(encoding="utf-8")
+
+
+def test_stale_stream_cleanup_helper_exists():
+    assert "def _clear_stale_stream_state(session)" in ROUTES_SRC
+    assert "stream_id in STREAMS" in ROUTES_SRC
+    assert "session.active_stream_id = None" in ROUTES_SRC
+    assert "session.pending_user_message = None" in ROUTES_SRC
+    assert "session.pending_attachments = []" in ROUTES_SRC
+    assert "session.pending_started_at = None" in ROUTES_SRC
+    assert "session.save()" in ROUTES_SRC
+
+
+def test_session_load_clears_stale_stream_before_response():
+    load_pos = ROUTES_SRC.index("s = get_session(sid, metadata_only=(not load_messages))")
+    cleanup_pos = ROUTES_SRC.index("_clear_stale_stream_state(s)", load_pos)
+    response_pos = ROUTES_SRC.index('"active_stream_id": getattr(s, "active_stream_id", None)', cleanup_pos)
+    assert load_pos < cleanup_pos < response_pos
+
+
+def test_chat_start_clears_stale_pending_state_not_only_active_id():
+    stale_comment_pos = ROUTES_SRC.index("# Stale stream id from a previous run; clear and continue.")
+    cleanup_pos = ROUTES_SRC.index("_clear_stale_stream_state(s)", stale_comment_pos)
+    stream_id_pos = ROUTES_SRC.index("stream_id = uuid.uuid4().hex", cleanup_pos)
+    assert stale_comment_pos < cleanup_pos < stream_id_pos
+
+
+def test_frontend_drops_inflight_cache_when_server_session_is_idle():
+    marker = "If the server says the session is idle, discard any browser-side inflight"
+    marker_pos = SESSIONS_SRC.index(marker)
+    window = SESSIONS_SRC[marker_pos:marker_pos + 500]
+    assert "if(!activeStreamId&&INFLIGHT[sid])" in window
+    assert "delete INFLIGHT[sid]" in window
+    assert "clearInflightState" in window
+    assert "S.busy=false" in window
+
+
+def test_service_worker_cache_bumped_for_frontend_fix_delivery():
+    assert "stale-stream-cleanup1" in SW_SRC


### PR DESCRIPTION
# PR 1: fix: clear stale WebUI stream state

Target repo: `nesquena/hermes-webui`
Base: `master`
Local branch: `/home/manfred/.hermes/workspace/webui-prs/stale-stream-cleanup` (`fix/stale-stream-state-cleanup`)
Patch: `0001-fix-clear-stale-WebUI-stream-state.patch`
Related issue: #1471

## Summary

This PR prevents WebUI sessions from getting stuck when persisted stream state outlives the actual in-memory stream.

It adds backend stale-stream cleanup and frontend in-flight cache invalidation when the server reports the session as idle.

## Problem

A session JSON can retain `active_stream_id` and pending fields after a stream failure, provider exception, or server restart. The server has no live stream, but the frontend keeps trying to restore one.

Observed failure mode:

- `/health` reports `active_streams: 0`
- session JSON still has a dead `active_stream_id`
- `pending_user_message`, `pending_attachments`, and `pending_started_at` can remain set
- browser-side `INFLIGHT[sid]` can keep the UI busy even when the backend reports idle

## Changes

- Add `_clear_stale_stream_state(session)`
- Clear stale:
  - `active_stream_id`
  - `pending_user_message`
  - `pending_attachments`
  - `pending_started_at`
- Run cleanup before session metadata/status is returned
- Run cleanup before starting a new turn after stale stream-id conflict
- Clear browser-side `INFLIGHT[sid]` if server says session is idle
- Bump service-worker cache to deliver the frontend fix
- Add regression tests

## Test plan

```bash
python -m py_compile api/routes.py
python -m pytest tests/test_stale_stream_cleanup.py -q
```

Local result:

```text
5 passed
```

## Notes

This does not implement WAL/partial-token crash recovery. It only removes stale runtime stream state so the UI does not reconnect to a stream that cannot exist anymore.

Fixes #1471 for the stale-runtime-state portion.
