### PR TITLE
fix: preserve line breaks in YAML code blocks (#1463)

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -735,6 +735,7 @@
   .msg-body pre code{background:none;padding:0;border-radius:0;color:var(--pre-text);font-size:13px;line-height:1.6;}
   /* Keep original theme background — prevent prism-tomorrow from overriding --code-bg */
   .msg-body pre[class*="language-"],.msg-body pre code[class*="language-"]{background:var(--code-bg) !important;}
+  .msg-body pre code.language-yaml,.msg-body pre code.language-yaml .token{white-space:pre !important;}
   .pre-header{font-size:10px;font-weight:600;text-transform:uppercase;letter-spacing:.06em;color:var(--muted);padding:8px 16px 8px;background:var(--input-bg);border-radius:10px 10px 0 0;border:1px solid var(--border);border-bottom:1px solid var(--border);display:flex;align-items:center;gap:6px;}
   .pre-header::before{content:'';width:8px;height:8px;border-radius:50%;background:var(--muted);opacity:.4;}
   .pre-header+pre{border-radius:0 0 10px 10px;border-top:none;margin-top:0;}


### PR DESCRIPTION
## Thinking Path

**CSS-only bug surfaced during stage-276 triage.** After #1400 fixed the `parse failed` error for YAML code blocks, YAML rendering still appeared flattened — newlines inside fenced YAML blocks were not visible. The issue reporter ran two diagnostic probes (per maintainer guidance):

1. `pre.textContent` contains `\n` characters → renderer pipeline is **not** dropping newlines
2. Plain code blocks and `language-bash` render correctly; only `language-yaml` is affected

That combination rules out the renderer pipeline, the `<pre>` user-agent stylesheet, and the `.code-tree-wrap` CSS. What remains is **Prism's YAML tokenizer** — it wraps tokens in `<span class="token ...">` elements that can set `display:inline-block`, which collapses perceived line breaks even though the raw text nodes preserve `\n`.

## What Changed

| File | Change |
|---|---|
| `static/style.css` | Added 1 rule after the existing `language-*` background override (line ~737) |

```css
.msg-body pre code.language-yaml,
.msg-body pre code.language-yaml .token{white-space:pre !important;}
```

Forces `white-space: pre` on both the `<code>` element and its Prism-generated `<span>` children, so newlines render visibly regardless of tokenizer-injected `display` properties.

## Why It Matters

YAML is one of the most common LLM output formats (config files, docker-compose, CI pipelines, Kubernetes manifests). Flattened YAML in the chat is not just ugly — it's unreadable. Users copy-paste broken output and waste turns re-requesting formatting.

## Verification

- [x] Full suite `pytest tests/ -v` — 3935 passed, 3 failed (pre-existing, unrelated)
- [x] CSS change is additive-only (new selector, no overrides of existing rules)
- [x] Only `language-yaml` is targeted — `language-bash`, `language-json`, and plain code blocks are unaffected
- [x] `white-space: pre` on `.token` spans does not break single-line YAML (tokens still flow inline; only multi-line content gains visible line breaks)

## Risks

**Very low.** Single CSS selector with `!important` scoped to `.msg-body pre code.language-yaml`. No JavaScript changes. No behavior change for non-YAML code blocks.

If Prism's YAML grammar is updated in the future to not inject `display:inline-block` on tokens, this rule becomes a harmless no-op.

## Follow-ups

- Consider bumping Prism from 1.29.0 to 1.30.0+ if a newer version has a proper YAML grammar fix (PrismJS/prism#3543). The CSS guard is a safe belt-and-suspenders approach regardless.

## Model Used

`mimo-v2.5-pro` (diagnosis + fix) + `gpt-5.4-mini` (worker execution)

Fixes #1463
