### PR TITLE
fix: recover WebUI-origin state.db sessions

### DIFF
--- a/api/agent_sessions.py
+++ b/api/agent_sessions.py
@@ -214,9 +214,9 @@ def read_importable_agent_session_rows(
     db_path: Path,
     limit: int = 200,
     log=None,
-    exclude_sources: tuple[str, ...] | None = ("cron",),
+    exclude_sources: tuple[str, ...] | None = ("cron", "webui"),
 ) -> list[dict]:
-    """Return non-WebUI agent sessions projected as importable conversations.
+    """Return agent sessions projected as importable conversations.
 
     Hermes Agent can create rows in ``state.db.sessions`` before a session has
     any messages, and long conversations can be split into compression-linked
@@ -256,7 +256,7 @@ def read_importable_agent_session_rows(
         ended_expr = _optional_col('ended_at', session_cols)
         end_reason_expr = _optional_col('end_reason', session_cols)
 
-        where_clauses = ["s.source IS NOT NULL", "s.source != 'webui'"]
+        where_clauses = ["s.source IS NOT NULL"]
         params: list[str] = []
         if exclude_sources:
             excluded = tuple(str(source) for source in exclude_sources if source)

--- a/tests/test_gateway_sync.py
+++ b/tests/test_gateway_sync.py
@@ -208,6 +208,41 @@ def test_gateway_sessions_appear_when_enabled():
         post('/api/settings', {'show_cli_sessions': False})
 
 
+def test_webui_state_db_session_without_sidecar_appears_when_agent_sessions_enabled():
+    """Regression: WebUI-origin rows in state.db can recover missing JSON sidecars."""
+    conn = _ensure_state_db()
+    sid = 'webui_state_only_001'
+    try:
+        _insert_agent_session_row(
+            conn,
+            session_id=sid,
+            source='webui',
+            title='Recovered WebUI Session',
+            model='openai/gpt-5',
+            messages=2,
+        )
+
+        post('/api/settings', {'show_cli_sessions': True})
+
+        data, status = get('/api/sessions')
+        assert status == 200
+        sessions = data.get('sessions', [])
+        recovered = [s for s in sessions if s.get('session_id') == sid]
+        assert len(recovered) == 1, (
+            "WebUI-origin sessions that exist in state.db but have no JSON sidecar "
+            "should be surfaced through the agent-session bridge for recovery."
+        )
+        assert recovered[0].get('source_tag') == 'webui'
+        assert recovered[0].get('is_cli_session') is True
+    finally:
+        try:
+            _remove_test_sessions(conn, sid)
+            conn.close()
+        except Exception:
+            pass
+        post('/api/settings', {'show_cli_sessions': False})
+
+
 def test_gateway_sessions_without_messages_are_hidden_from_sidebar():
     """Regression: empty agent session rows must not appear as broken sidebar entries."""
     conn = _ensure_state_db()


### PR DESCRIPTION
## Summary

Recover WebUI-origin sessions that are present in Hermes `state.db` but missing their WebUI JSON sidecar.

## Problem

When a WebUI-origin session exists in `state.db.sessions` / `state.db.messages` but no matching `~/.hermes/webui/sessions/<id>.json` sidecar exists, the WebUI cannot show it through the JSON-session path.

The agent-session bridge could recover it, but `read_importable_agent_session_rows()` hard-filtered `s.source != 'webui'` even when callers opted out of source exclusion. That leaves canonical SQLite messages present but invisible in `/api/sessions`.

This is another small slice of the #1471 session-recovery class, separate from stale runtime stream state (#1525).

## Change

- Make the default exclusion explicit: `(\"cron\", \"webui\")`.
- Remove the hard-coded `s.source != 'webui'` predicate so `exclude_sources=None` genuinely includes WebUI-origin rows.
- Add a regression test for a WebUI-origin state.db session with messages and no JSON sidecar.

## Tests

```bash
python -m py_compile api/agent_sessions.py tests/test_gateway_sync.py
python -m pytest \
  tests/test_gateway_sync.py::test_webui_state_db_session_without_sidecar_appears_when_agent_sessions_enabled \
  tests/test_gateway_sync.py::test_gateway_sessions_appear_when_enabled \
  tests/test_gateway_sync.py::test_gateway_sessions_without_messages_are_hidden_from_sidebar -q
# 3 passed
```

Refs #1471.
