### PR TITLE
fix(streaming): pass agent.reasoning_effort into WebUI agents (salvages #1531)

### DIFF
--- a/api/streaming.py
+++ b/api/streaming.py
@@ -1817,7 +1817,7 @@ def _run_agent_streaming(
             # the key is absent or invalid, pass None → agent uses its default.
             try:
                 from api.config import parse_reasoning_effort as _parse_reff
-                _effort_cfg = _cfg.cfg.get('agent', {}) if isinstance(_cfg.cfg, dict) else {}
+                _effort_cfg = _cfg.get('agent', {}) if isinstance(_cfg, dict) else {}
                 _effort_raw = _effort_cfg.get('reasoning_effort') if isinstance(_effort_cfg, dict) else None
                 _reasoning_config = _parse_reff(_effort_raw)
             except Exception:
@@ -1885,6 +1885,7 @@ def _run_agent_streaming(
                     _max_tokens_cfg or '',
                     _fallback_resolved or {},
                     sorted(_toolsets) if _toolsets else [],
+                    _reasoning_config or {},
                 ], sort_keys=True)
                 _agent_sig = _hashlib.sha256(_sig_blob.encode()).hexdigest()[:16]
 

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -608,6 +608,38 @@ def test_streaming_bridge_accepts_current_tool_progress_callback_signature(clean
         "streaming.py must emit live tool completion SSE events"
 
 
+def test_streaming_reads_reasoning_effort_from_config_dict(cleanup_test_sessions):
+    """R17b: WebUI must read agent.reasoning_effort from the dict returned by get_config().
+
+    `get_config()` returns a plain dict (not a wrapper exposing `.cfg`).  The
+    pre-fix line `_cfg.cfg.get('agent', {})` raised AttributeError that the
+    surrounding try/except swallowed, so `_reasoning_config` was always None
+    regardless of what `/reasoning <level>` had been set to.  This static
+    source assertion pins the fix because the runtime symptom is silent.
+    """
+    src = (REPO_ROOT / "api/streaming.py").read_text()
+    assert "_cfg.cfg" not in src, \
+        "get_config() returns a dict; accessing _cfg.cfg drops reasoning_config to None"
+    assert "_cfg.get('agent', {})" in src or '_cfg.get("agent", {})' in src, \
+        "streaming.py must read agent.reasoning_effort via the config dict"
+
+
+def test_streaming_agent_cache_signature_includes_reasoning_config(cleanup_test_sessions):
+    """R17c: changing reasoning effort mid-session must rebuild the cached per-session agent.
+
+    Without `_reasoning_config` participating in `_sig_blob`, the cache key
+    matches the old entry and the operator's `/reasoning xhigh` change has
+    no effect on the live session.
+    """
+    src = (REPO_ROOT / "api/streaming.py").read_text()
+    start = src.find("_sig_blob = _json.dumps")
+    end = src.find("_agent_sig", start)
+    assert start >= 0 and end > start, "agent cache signature block not found"
+    sig_block = src[start:end]
+    assert "_reasoning_config" in sig_block, \
+        "agent cache signature must include reasoning_config so xhigh/medium changes take effect"
+
+
 def test_messages_js_supports_live_reasoning_and_tool_completion(cleanup_test_sessions):
     """R18: messages.js must render live reasoning and react to tool completion events.
     Without these handlers, the operator only sees generic Thinking… or nothing


### PR DESCRIPTION
## Summary

Surgical bug fix spliced from [#1531](https://github.com/nesquena/hermes-webui/pull/1531) by [@Asunfly](https://github.com/Asunfly): take Change-1 only (the actual `_cfg.cfg` → `_cfg` fix + cache-signature inclusion) and skip Change-2 (auxiliary title-route `extra_body` refactor) which is a separate scope concern. `Co-authored-by: Asunfly` on the merge commit preserves attribution.

## Why a separate PR vs merging #1531

#1531 originally was the Change-1 fix only and was approved on May 03 13:34. It was force-pushed at 15:31 to add Change-2 (`generate_title_raw_via_aux` no longer hardcodes `reasoning.enabled=False`). The intent of Change-2 is reasonable (let operator-configured `extra_body.reasoning` from `_get_auxiliary_task_config('title_generation')` flow through), but:

- It changes a different surface (auxiliary title route) and a different code path than the PR title and summary describe.
- The class of operator most affected (reasoning-route users on auxiliary tasks) overlaps with #1524 and won't necessarily see the PR title and connect the dots.
- Pre-Change-2, the WebUI defended against accidental reasoning on the title hot path. Post-Change-2, operators who selected a reasoning-capable auxiliary title model (xAI/Anthropic reasoning routes, OpenAI o-series, Grok-4 reasoning) without explicitly setting `reasoning.enabled=False` in the task config will reason on every new conversation's title — potentially noticeable cost / latency for free-tier reasoning routes in particular.

Splicing Change-1 into a focused PR ships the bug fix today and gives Change-2 its own short reviewable diff if @Asunfly wants to re-open it.

## What this PR ships

Two surgical fixes in `api/streaming.py`:

| Site | Pre-fix | Post-fix | Effect |
|---|---|---|---|
| Line 1820 | `_cfg.cfg.get('agent', {})` | `_cfg.get('agent', {})` | `get_config()` returns a plain dict, not a wrapper exposing `.cfg`. Pre-fix raised `AttributeError` swallowed by the surrounding `try/except`, so `_reasoning_config` was always `None`. |
| Line 1888 | (absent) | `_reasoning_config or {}` added to `_sig_blob` | Switching `/reasoning <level>` mid-session must rebuild the cached per-session agent. Without this, the cache key matches the old entry. |

Smoking gun verification: `api/streaming.py:1959` (a few hundred lines below in the same function) already correctly used `_cfg.get(...)` — the same `_cfg` was being read two different ways in one file.

## Tests

Two static-source assertion regression tests in `tests/test_regressions.py`:

- `test_streaming_reads_reasoning_effort_from_config_dict` (R17b) — pins `_cfg.cfg` from coming back. Static source assertion is the right shape for this regression because the runtime symptom is silent (operators get the agent's default effort regardless of what `/api/reasoning` was set to).
- `test_streaming_agent_cache_signature_includes_reasoning_config` (R17c) — pins `_reasoning_config` in `_sig_blob`.

## What is NOT in this PR

- The `generate_title_raw_via_aux` extra_body refactor (Change-2 from #1531).
- The `test_does_not_override_configured_reasoning_extra_body` test (guards Change-2).

If @Asunfly wants Change-2 to land, please re-open it as a focused PR with the title-extra_body change + that test, with a one-line justification of the reasoning-capable-aux-route trade-off. I'd merge that separately.

## Diff

```
api/streaming.py            |  3 ++-
tests/test_regressions.py   | 32 ++++++++++++++++++++++++++++++++
2 files changed, 34 insertions(+), 1 deletion(-)
```

## Closes

- Closes #1531 (the Change-1 portion ships here; Change-2 can be re-opened as its own PR if desired)
