### PR TITLE
fix: resolve provider from config block, not just hostname (#1527, #1530)

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -645,6 +645,68 @@ def _resolve_provider_alias(name: str) -> str:
     return _PROVIDER_ALIASES.get(raw, name)
 
 
+def _normalize_base_url_for_compare(base_url: str) -> str:
+    raw = str(base_url or "").strip().rstrip("/")
+    if not raw:
+        return ""
+    parsed = urlparse(raw if "://" in raw else f"http://{raw}")
+    if parsed.scheme and parsed.netloc:
+        return parsed._replace(
+            scheme=parsed.scheme.lower(),
+            netloc=parsed.netloc.lower(),
+            path=(parsed.path or "").rstrip("/"),
+            params="",
+            query="",
+            fragment="",
+        ).geturl()
+    return raw.lower()
+
+
+def _configured_provider_for_base_url(
+    base_url: str,
+    config_data: dict,
+    active_provider: str | None = None,
+) -> str:
+    target = _normalize_base_url_for_compare(base_url)
+    if not target or not isinstance(config_data, dict):
+        return ""
+
+    model_cfg = config_data.get("model", {})
+    if isinstance(model_cfg, dict):
+        model_base_url = _normalize_base_url_for_compare(model_cfg.get("base_url", ""))
+        if model_base_url == target:
+            owner = str(active_provider or model_cfg.get("provider") or "").strip()
+            if owner:
+                return _resolve_provider_alias(owner)
+
+    providers_cfg = config_data.get("providers", {})
+    if isinstance(providers_cfg, dict):
+        for provider_key, provider_cfg in providers_cfg.items():
+            if not isinstance(provider_cfg, dict):
+                continue
+            provider_base_url = _normalize_base_url_for_compare(
+                provider_cfg.get("base_url", "")
+            )
+            if provider_base_url != target:
+                continue
+            owner = str(provider_cfg.get("provider") or provider_key or "").strip()
+            if owner:
+                return _resolve_provider_alias(owner)
+
+    return ""
+
+
+def _fallback_provider_for_base_url(base_url: str) -> str:
+    parsed = urlparse(base_url if "://" in base_url else f"http://{base_url}")
+    host = (parsed.netloc or parsed.path or "").lower()
+    hostname = (parsed.hostname or "").lower()
+    if "ollama" in host or hostname in {"127.0.0.1", "::1", "localhost"}:
+        return "ollama"
+    if "lmstudio" in host or "lm-studio" in host:
+        return "lmstudio"
+    return "custom"
+
+
 # Well-known models per provider (used to populate dropdown for direct API providers)
 _PROVIDER_MODELS = {
     "anthropic": [
@@ -1812,31 +1874,9 @@ def get_available_models() -> dict:
                 else:
                     endpoint_url = base_url.rstrip("/") + "/v1/models"
 
-                provider = "custom"
-                parsed = urlparse(base_url if "://" in base_url else f"http://{base_url}")
-                host = (parsed.netloc or parsed.path).lower()
-
-                if parsed.hostname:
-                    try:
-                        addr = ipaddress.ip_address(parsed.hostname)
-                        if addr.is_private or addr.is_loopback or addr.is_link_local:
-                            if "ollama" in host or "127.0.0.1" in host or "localhost" in host:
-                                provider = "ollama"
-                            elif "lmstudio" in host or "lm-studio" in host:
-                                provider = "lmstudio"
-                            else:
-                                # Unknown loopback/private endpoint: route through
-                                # the generic ``custom`` provider so the agent's
-                                # auxiliary client (compression, vision, web
-                                # extraction) takes the OpenAI-compat custom path
-                                # with ``no-key-required`` semantics. Writing
-                                # ``provider: local`` here used to break
-                                # compression mid-conversation because ``local``
-                                # is not a registered provider in
-                                # ``hermes_cli.auth.PROVIDER_REGISTRY`` — see #1384.
-                                provider = "custom"
-                    except ValueError:
-                        pass
+                provider = _configured_provider_for_base_url(base_url, cfg, active_provider)
+                if not provider:
+                    provider = _fallback_provider_for_base_url(base_url)
 
                 headers = {}
                 api_key = ""

--- a/tests/test_issue1384_local_provider.py
+++ b/tests/test_issue1384_local_provider.py
@@ -23,7 +23,6 @@ healed automatically:
    normalises through ``_resolve_provider_alias``.
 """
 
-import re
 from pathlib import Path
 
 import pytest
@@ -49,25 +48,12 @@ class TestAutoDetectWritesCustom:
         )
 
     def test_auto_detect_branch_uses_custom(self):
-        """The else-branch in the auto-detect block resolves to ``custom``."""
-        src = Path(cfg.__file__).read_text(encoding="utf-8")
-        # Find the auto-detect block (host-keyword classifier).
-        m = re.search(
-            r'if "ollama" in host or "127\.0\.0\.1" in host or "localhost" in host:\s*\n'
-            r'\s*provider = "ollama"\s*\n'
-            r'\s*elif "lmstudio" in host or "lm-studio" in host:\s*\n'
-            r'\s*provider = "lmstudio"\s*\n'
-            r'\s*else:',
-            src,
-        )
-        assert m, "Auto-detect host-classifier block not found in api/config.py"
-        # Find the next provider assignment after the else.
-        tail = src[m.end() : m.end() + 1500]
-        provider_assign = re.search(r'provider = "([a-z-]+)"', tail)
-        assert provider_assign, "No provider assignment found after auto-detect else"
-        assert provider_assign.group(1) == "custom", (
-            f"Auto-detect else branch must assign provider = \"custom\", "
-            f"got {provider_assign.group(1)!r}"
+        """Unknown private/LAN endpoints still resolve to ``custom``."""
+        provider = cfg._fallback_provider_for_base_url("http://192.168.1.10:8000/v1")
+        assert provider == "custom", (
+            f"Unknown private endpoints must resolve to \"custom\" so the "
+            f"agent's auxiliary client takes the no-key-required "
+            f"OpenAI-compat path; got {provider!r}"
         )
 
 

--- a/tests/test_issue1527_lmstudio_base_url_classification.py
+++ b/tests/test_issue1527_lmstudio_base_url_classification.py
@@ -1,0 +1,260 @@
+"""Regression tests for LM Studio base_url provider ownership (#1527)."""
+
+from __future__ import annotations
+
+import json
+import socket
+import sys
+import types
+from contextlib import contextmanager
+
+import api.config as config
+
+
+def _install_fake_hermes_cli(monkeypatch) -> None:
+    fake_pkg = types.ModuleType("hermes_cli")
+    fake_pkg.__path__ = []
+
+    fake_models = types.ModuleType("hermes_cli.models")
+    fake_models.list_available_providers = lambda: []
+    fake_models.provider_model_ids = lambda _pid: []
+
+    fake_auth = types.ModuleType("hermes_cli.auth")
+    fake_auth.get_auth_status = lambda _pid: {}
+
+    monkeypatch.setitem(sys.modules, "hermes_cli", fake_pkg)
+    monkeypatch.setitem(sys.modules, "hermes_cli.models", fake_models)
+    monkeypatch.setitem(sys.modules, "hermes_cli.auth", fake_auth)
+    monkeypatch.delitem(sys.modules, "agent.credential_pool", raising=False)
+    monkeypatch.delitem(sys.modules, "agent", raising=False)
+
+
+def _clear_provider_env(monkeypatch) -> None:
+    for key in (
+        "ANTHROPIC_API_KEY",
+        "API_KEY",
+        "DEEPSEEK_API_KEY",
+        "GEMINI_API_KEY",
+        "GLM_API_KEY",
+        "GOOGLE_API_KEY",
+        "HERMES_API_KEY",
+        "HERMES_OPENAI_API_KEY",
+        "KIMI_API_KEY",
+        "LOCAL_API_KEY",
+        "LM_API_KEY",
+        "LMSTUDIO_API_KEY",
+        "MINIMAX_API_KEY",
+        "MINIMAX_CN_API_KEY",
+        "MISTRAL_API_KEY",
+        "OPENCODE_GO_API_KEY",
+        "OPENCODE_ZEN_API_KEY",
+        "OPENAI_API_KEY",
+        "OPENROUTER_API_KEY",
+        "XAI_API_KEY",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+@contextmanager
+def _temp_config(monkeypatch, tmp_path, yaml_text: str):
+    old_cfg = dict(config.cfg)
+    old_mtime = config._cfg_mtime
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text(yaml_text, encoding="utf-8")
+    monkeypatch.setattr(config, "_get_config_path", lambda: cfg_path)
+    config.reload_config()
+    config.invalidate_models_cache()
+    try:
+        yield
+    finally:
+        config.cfg.clear()
+        config.cfg.update(old_cfg)
+        config._cfg_mtime = old_mtime
+        config.invalidate_models_cache()
+
+
+def _mock_models_endpoint(monkeypatch, model_id: str = "qwen3-27b") -> None:
+    class Response:
+        def read(self):
+            return json.dumps(
+                {"data": [{"id": model_id, "name": model_id}]}
+            ).encode("utf-8")
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    monkeypatch.setattr("urllib.request.urlopen", lambda *a, **k: Response())
+    monkeypatch.setattr(
+        "socket.getaddrinfo",
+        lambda *a, **k: [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("192.168.1.22", 0))],
+    )
+
+
+def _available_models(monkeypatch, tmp_path, yaml_text: str) -> dict:
+    _install_fake_hermes_cli(monkeypatch)
+    _clear_provider_env(monkeypatch)
+    _mock_models_endpoint(monkeypatch)
+    with _temp_config(monkeypatch, tmp_path, yaml_text):
+        return config.get_available_models()
+
+
+def _models_for_provider(result: dict, provider_id: str) -> list[str]:
+    for group in result["groups"]:
+        if group.get("provider_id") == provider_id:
+            return [model["id"] for model in group.get("models", [])]
+    return []
+
+
+def test_lmstudio_lan_ip_uses_configured_provider(monkeypatch, tmp_path):
+    result = _available_models(
+        monkeypatch,
+        tmp_path,
+        """
+model:
+  provider: lmstudio
+  default: qwen3-27b
+  base_url: http://192.168.1.22:1234/v1
+providers: {}
+""",
+    )
+
+    assert "qwen3-27b" in _models_for_provider(result, "lmstudio")
+    assert not _models_for_provider(result, "custom")
+
+
+def test_lmstudio_lan_ip_selection_resolves_to_configured_base_url(monkeypatch, tmp_path):
+    _install_fake_hermes_cli(monkeypatch)
+    _clear_provider_env(monkeypatch)
+    _mock_models_endpoint(monkeypatch, model_id="qwen3.6-35b-a3b@q6_k")
+    base_url = "http://192.168.1.22:1234/v1"
+
+    with _temp_config(
+        monkeypatch,
+        tmp_path,
+        f"""
+model:
+  provider: lmstudio
+  default: qwen3.6-35b-a3b@q6_k
+  base_url: {base_url}
+providers: {{}}
+""",
+    ):
+        result = config.get_available_models()
+        models = _models_for_provider(result, "lmstudio")
+        assert "qwen3.6-35b-a3b@q6_k" in models
+
+        selected = config.model_with_provider_context(models[0], "lmstudio")
+        model, provider, resolved_base_url = config.resolve_model_provider(selected)
+
+    assert model == "qwen3.6-35b-a3b@q6_k"
+    assert provider == "lmstudio"
+    assert resolved_base_url == base_url
+
+
+def test_lmstudio_tailscale_hostname_uses_configured_provider(monkeypatch, tmp_path):
+    result = _available_models(
+        monkeypatch,
+        tmp_path,
+        """
+model:
+  provider: lmstudio
+  default: qwen3-27b
+  base_url: http://my-mac.tailnet.ts.net:1234/v1
+providers: {}
+""",
+    )
+
+    assert "qwen3-27b" in _models_for_provider(result, "lmstudio")
+    assert not _models_for_provider(result, "custom")
+
+
+def test_lmstudio_reverse_proxy_uses_configured_provider(monkeypatch, tmp_path):
+    result = _available_models(
+        monkeypatch,
+        tmp_path,
+        """
+model:
+  provider: lmstudio
+  default: qwen3-27b
+  base_url: https://lm.internal.example.com/v1
+providers: {}
+""",
+    )
+
+    assert "qwen3-27b" in _models_for_provider(result, "lmstudio")
+    assert not _models_for_provider(result, "custom")
+
+
+def test_unclaimed_lan_ip_falls_back_to_custom(monkeypatch, tmp_path):
+    result = _available_models(
+        monkeypatch,
+        tmp_path,
+        """
+model:
+  default: qwen3-27b
+  base_url: http://192.168.1.22:1234/v1
+providers: {}
+""",
+    )
+
+    assert "qwen3-27b" in _models_for_provider(result, "custom")
+    assert not _models_for_provider(result, "lmstudio")
+
+
+def test_hostname_fallback_still_detects_lmstudio(monkeypatch, tmp_path):
+    result = _available_models(
+        monkeypatch,
+        tmp_path,
+        """
+model:
+  default: qwen3-27b
+  base_url: http://lmstudio.internal.example.com/v1
+providers: {}
+""",
+    )
+
+    assert "qwen3-27b" in _models_for_provider(result, "lmstudio")
+
+
+def test_localhost_fallback_still_detects_ollama(monkeypatch, tmp_path):
+    result = _available_models(
+        monkeypatch,
+        tmp_path,
+        """
+model:
+  default: llama3.2
+  base_url: http://localhost:11434/v1
+providers: {}
+""",
+    )
+
+    assert "qwen3-27b" in _models_for_provider(result, "ollama")
+
+
+def test_configured_provider_matches_each_base_url_not_global_active():
+    cfg = {
+        "model": {
+            "provider": "ollama",
+            "base_url": "http://127.0.0.1:11434/v1",
+        },
+        "providers": {
+            "ollama": {"base_url": "http://127.0.0.1:11434/v1"},
+            "lmstudio": {"base_url": "http://192.168.1.22:1234/v1"},
+        },
+    }
+
+    assert (
+        config._configured_provider_for_base_url(
+            "http://192.168.1.22:1234/v1", cfg, active_provider="ollama"
+        )
+        == "lmstudio"
+    )
+    assert (
+        config._configured_provider_for_base_url(
+            "http://127.0.0.1:11434/v1", cfg, active_provider="ollama"
+        )
+        == "ollama"
+    )


### PR DESCRIPTION
## Summary
- resolves model-discovery provider ownership from the config block that owns the base_url before falling back to hostname heuristics
- keeps unknown LAN/private endpoints on `custom` so #1384's no-key custom routing behavior stays intact
- adds #1527 regressions for LM Studio LAN IP, Tailscale/reverse-proxy hosts, hostname fallback, Ollama fallback, and the paired #1530 selection/base_url resolution path

## Tests
- `python -m pytest tests\test_issue1527_lmstudio_base_url_classification.py tests\test_issue1384_local_provider.py tests\test_model_resolver.py::test_custom_endpoint_uses_model_config_api_key_for_model_discovery -q`
- `python -m pytest tests\test_issue1420_lmstudio_provider_env_var.py tests\test_issue1500_lmstudio_env_var_alignment.py tests\test_issue1384_local_provider.py -q`
- `python -m py_compile api\config.py`

Local note: full `python -m pytest -q` on this Windows host reached 3828 passed before failing on unrelated environment/platform gates (OpenSSL config, symlink privileges, chmod/umask, macOS path assertions).

Closes #1527.
Closes #1530.