### PR TITLE
fix: remove phantom /sw.js from PUBLIC_PATHS whitelist

### DIFF
--- a/api/auth.py
+++ b/api/auth.py
@@ -22,7 +22,6 @@ PUBLIC_PATHS = frozenset({
     '/login', '/health', '/favicon.ico',
     '/api/auth/login', '/api/auth/status',
     '/manifest.json', '/manifest.webmanifest',
-    '/sw.js',
 })
 
 COOKIE_NAME = 'hermes_session'


### PR DESCRIPTION
Closes #1481

Remove `/sw.js` from PUBLIC_PATHS. The service worker is served via a dedicated route handler and does not need to be in the auth whitelist.