### PR TITLE
fix: refresh model dropdowns when provider key is removed

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -2348,6 +2348,7 @@ def handle_post(handler, parsed) -> bool:
         result = remove_provider_key(provider_id)
         if not result.get("ok"):
             return bad(handler, result.get("error", "Unknown error"))
+        _clear_live_models_cache()
         return j(handler, result)
 
     if parsed.path == "/api/reasoning":

--- a/static/panels.js
+++ b/static/panels.js
@@ -3385,7 +3385,10 @@ async function _removeProviderKey(providerId){
     const res=await api('/api/providers/delete',{method:'POST',body:JSON.stringify({provider:providerId})});
     if(res.ok){
       showToast(res.provider+' key '+t('providers_key_removed').toLowerCase());
+      _clearLiveModelCache(providerId);
       await loadProvidersPanel(); // refresh list
+      if(typeof populateModelDropdown==='function') populateModelDropdown();
+      if(typeof renderModelDropdown==='function') renderModelDropdown();
     }else{
       showToast(res.error||'Failed to remove key');
       if(els.saveBtn){els.saveBtn.disabled=false;els.saveBtn.textContent=t('providers_save');}

--- a/static/ui.js
+++ b/static/ui.js
@@ -389,6 +389,15 @@ async function populateModelDropdown(){
 
 // Cache so we don't re-fetch on every page load
 const _liveModelCache={};
+
+/** Remove all cached model entries for a given provider. */
+function _clearLiveModelCache(providerId){
+  for(const key of Object.keys(_liveModelCache)){
+    if(key===providerId||key.startsWith(providerId+'/')){
+      delete _liveModelCache[key];
+    }
+  }
+}
 // Tracks providers for which a live-model fetch is in flight.
 // Used by syncTopbar() to defer model corrections until the fetch completes,
 // preventing premature fallback to the first static model (#1169).


### PR DESCRIPTION
Closes #1539

After removing a provider key, model dropdowns still showed stale models. Clears backend live models cache, frontend live model cache, and refreshes all model dropdowns on provider removal.