### PR TITLE
fix: live-fetch Nous Portal model catalog instead of hardcoded 4 models

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -2109,6 +2109,29 @@ def get_available_models() -> dict:
                                 "models": models,
                             }
                         )
+                elif pid == "nous":
+                    raw_models = []
+                    try:
+                        from hermes_cli.models import provider_model_ids as _provider_model_ids
+
+                        raw_models = [
+                            {"id": f"@nous:{mid}", "label": mid}
+                            for mid in (_provider_model_ids("nous") or [])
+                        ]
+                    except Exception:
+                        logger.warning("Failed to load Nous Portal models from hermes_cli")
+
+                    if not raw_models:
+                        raw_models = copy.deepcopy(_PROVIDER_MODELS.get("nous", []))
+
+                    models = _apply_provider_prefix(raw_models, pid, active_provider)
+                    groups.append(
+                        {
+                            "provider": provider_name,
+                            "provider_id": pid,
+                            "models": models,
+                        }
+                    )
                 elif pid in _PROVIDER_MODELS or pid in cfg.get("providers", {}):
                     raw_models = copy.deepcopy(_PROVIDER_MODELS.get(pid, []))
                     detected_models = auto_detected_models_by_provider.get(pid, [])

--- a/api/routes.py
+++ b/api/routes.py
@@ -2348,6 +2348,7 @@ def handle_post(handler, parsed) -> bool:
         result = remove_provider_key(provider_id)
         if not result.get("ok"):
             return bad(handler, result.get("error", "Unknown error"))
+        _clear_live_models_cache()
         return j(handler, result)
 
     if parsed.path == "/api/reasoning":

--- a/static/panels.js
+++ b/static/panels.js
@@ -3385,7 +3385,10 @@ async function _removeProviderKey(providerId){
     const res=await api('/api/providers/delete',{method:'POST',body:JSON.stringify({provider:providerId})});
     if(res.ok){
       showToast(res.provider+' key '+t('providers_key_removed').toLowerCase());
+      _clearLiveModelCache(providerId);
       await loadProvidersPanel(); // refresh list
+      if(typeof populateModelDropdown==='function') populateModelDropdown();
+      if(typeof renderModelDropdown==='function') renderModelDropdown();
     }else{
       showToast(res.error||'Failed to remove key');
       if(els.saveBtn){els.saveBtn.disabled=false;els.saveBtn.textContent=t('providers_save');}

--- a/static/ui.js
+++ b/static/ui.js
@@ -389,6 +389,15 @@ async function populateModelDropdown(){
 
 // Cache so we don't re-fetch on every page load
 const _liveModelCache={};
+
+/** Remove all cached model entries for a given provider. */
+function _clearLiveModelCache(providerId){
+  for(const key of Object.keys(_liveModelCache)){
+    if(key===providerId||key.startsWith(providerId+'/')){
+      delete _liveModelCache[key];
+    }
+  }
+}
 // Tracks providers for which a live-model fetch is in flight.
 // Used by syncTopbar() to defer model corrections until the fetch completes,
 // preventing premature fallback to the first static model (#1169).


### PR DESCRIPTION
Closes #1538

Nous Portal model picker only showed 4 hardcoded models. Now dynamically fetches the full catalog (~30 models) via hermes_cli, mirroring the ollama-cloud pattern. Falls back to hardcoded list on error.