### PR TITLE
feat: add What's new? link to update banner

### DIFF
--- a/api/updates.py
+++ b/api/updates.py
@@ -150,12 +150,21 @@ def _check_repo(path, name):
     current, _ = _run_git(['rev-parse', '--short', 'HEAD'], path)
     latest, _ = _run_git(['rev-parse', '--short', compare_ref], path)
 
+    # Get repo URL for "What's new?" link
+    remote_url, _ = _run_git(['remote', 'get-url', 'origin'], path)
+    # Convert SSH URLs (git@github.com:org/repo.git) to HTTPS
+    if remote_url and remote_url.startswith('git@'):
+        remote_url = remote_url.replace(':', '/', 1).replace('git@', 'https://', 1).rstrip('.git')
+    elif remote_url:
+        remote_url = remote_url.rstrip('.git')
+
     return {
         'name': name,
         'behind': behind,
         'current_sha': current,
         'latest_sha': latest,
         'branch': compare_ref,
+        'repo_url': remote_url,
     }
 
 

--- a/static/index.html
+++ b/static/index.html
@@ -260,6 +260,7 @@
     <div class="update-banner" id="updateBanner">
       <div style="display:flex;flex-direction:column;flex:1;min-width:0">
         <span id="updateMsg"></span>
+        <a id="updateWhatsNew" href="#" target="_blank" rel="noopener" style="font-size:11px;color:var(--accent);text-decoration:underline;display:none;margin-left:8px;white-space:nowrap">What's new?</a>
         <div id="updateError" style="display:none;font-size:12px;color:var(--error,#e05);margin-top:4px;word-break:break-word"></div>
       </div>
       <div style="display:flex;gap:8px;flex-shrink:0;flex-wrap:wrap">

--- a/static/ui.js
+++ b/static/ui.js
@@ -2832,6 +2832,17 @@ function _showUpdateBanner(data){
   const banner=$('updateBanner');
   if(banner) banner.classList.add('visible');
   window._updateData=data;
+  // Wire up "What's new?" link
+  const link=$('updateWhatsNew');
+  if(link && data.webui){
+    const repoUrl=data.webui.repo_url;
+    const curSha=data.webui.current_sha;
+    const newSha=data.webui.latest_sha;
+    if(repoUrl && curSha && newSha){
+      link.href=repoUrl+'/compare/'+curSha+'...'+newSha;
+      link.style.display='inline';
+    }
+  }
 }
 function dismissUpdate(){
   const b=$('updateBanner');if(b)b.classList.remove('visible');


### PR DESCRIPTION
Closes #1512

Adds a 'What's new?' link to the update banner that opens the GitHub compare page for the commit range.