### PR TITLE
feat: auto-assign project when filtering by project on new session

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -713,7 +713,7 @@ def get_session(sid, metadata_only=False):
         return s
     raise KeyError(sid)
 
-def new_session(workspace=None, model=None, profile=None, model_provider=None):
+def new_session(workspace=None, model=None, profile=None, model_provider=None, project_id=None):
     """Create a new in-memory session.
 
     The session lives in the SESSIONS dict only — no disk write happens until
@@ -749,6 +749,7 @@ def new_session(workspace=None, model=None, profile=None, model_provider=None):
         model=effective_model,
         model_provider=model_provider,
         profile=profile,
+        project_id=project_id,
     )
     with LOCK:
         SESSIONS[s.session_id] = s

--- a/api/routes.py
+++ b/api/routes.py
@@ -2253,6 +2253,7 @@ def handle_post(handler, parsed) -> bool:
             model=model,
             model_provider=model_provider,
             profile=body.get("profile") or None,
+            project_id=body.get("project_id") or None,
         )
         return j(handler, {"session": s.compact() | {"messages": s.messages}})
 

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -287,12 +287,14 @@ async function newSession(flash){
   const newModelState=(canQualify&&typeof _modelStateForSelect==='function')
     ? _modelStateForSelect(modelSel,selectedDefaultModel)
     : {model:selectedDefaultModel,model_provider:null};
-  const data=await api('/api/session/new',{method:'POST',body:JSON.stringify({
+  const reqBody={
     model:newModelState.model,
     model_provider:newModelState.model_provider||null,
     workspace:inheritWs,
     profile:S.activeProfile||'default',
-  })});
+  };
+  if(_activeProject&&_activeProject!==NO_PROJECT_FILTER) reqBody.project_id=_activeProject;
+  const data=await api('/api/session/new',{method:'POST',body:JSON.stringify(reqBody)});
   S.session=data.session;S.messages=data.session.messages||[];
   S.lastUsage={...(data.session.last_usage||{})};
   if(flash)S.session._flash=true;


### PR DESCRIPTION
Closes #1468

When filtering by a project, new conversations now auto-assign to that project. Passes project_id from active filter through frontend, API route, and session model.