### PR TITLE
v0.50.285 — same-day hotfix: session recovery actually fires now (closes #1558 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Hermes Web UI -- Changelog
 
+## [v0.50.285] — 2026-05-03
+
+### Fixed (1 PR — same-day hotfix-of-hotfix)
+
+- **Session recovery scanner crashes on `_index.json` (silent no-op in production)** (closes #1558 follow-up) — v0.50.284's startup self-heal (`api/session_recovery.py:recover_all_sessions_on_startup`) crashed on the very first `*.json` it scanned in the production session directory. The session dir contains an `_index.json` file whose top-level shape is a **list** (the index of session metadata dicts), not a dict. `_msg_count()` did `data.get('messages')` which raises `AttributeError: 'list' object has no attribute 'get'`. The broad `except Exception` in `server.py`'s startup hook swallowed the error and printed `[recovery] startup recovery failed: 'list' object has no attribute 'get'`, so the recovery silently no-op'd for every user — defeating the entire purpose of the v0.50.284 startup self-heal. Verified live on the production server immediately after the v0.50.284 deploy: log line confirmed the failure, no recovery attempted. **Fix:** (1) `_msg_count()` now guards `if not isinstance(data, dict): return -1` so non-dict-shaped JSON files return the harmless "unknown count" sentinel instead of raising. (2) The scanner skips any file whose name starts with `_` (the existing project convention for non-session metadata files like `_index.json`). (3) The scanner now wraps `recover_session(path)` in `try/except Exception` so a single malformed file can't break recovery for the rest. 2 new regression tests in `tests/test_metadata_save_wipe_1558.py`: `test_recover_all_sessions_on_startup_skips_non_session_index_json` and `test_msg_count_returns_neg1_for_non_dict_top_level`. Net effect: any user wiped between v0.50.279 and v0.50.284 deploys whose session left a `.bak` will now get auto-recovered on first launch of v0.50.285, as v0.50.284's release notes promised.
+
+### Tests
+
+4026 → **4028 passing** (+2 from the 2 new regression tests). 0 regressions. Full suite in 114s.
+
+### Pre-release verification
+
+- All 8 tests in `tests/test_metadata_save_wipe_1558.py` pass (6 original + 2 new regression).
+- Live verification on production server: pre-fix log line `[recovery] startup recovery failed: 'list' object has no attribute 'get'`. Post-fix expected log: `[recovery] Restored N/M sessions from .bak (see #1558).` (or empty scan if no `.bak` files).
+- Pre-release Opus advisor pass on the hotfix.
+
+### Why this needed a same-day v0.50.285 vs being deferred
+
+v0.50.284 promised that "the first server start after deploying v0.50.285 will auto-restore any session that was wiped between deploys." That promise was broken by the `_index.json` shape mismatch — the recovery silently never fired. Affected users (the original reporter on v0.50.282 with the 1000+ message session that disappeared) would have had `<sid>.json.bak` files on disk but those files would never be processed. Same-day hotfix restores the promise.
+
+
 ## [v0.50.284] — 2026-05-03
 
 ### Fixed (2 PRs — P0 streaming hotfix batch — closes #1533, #1558)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 
 ### Why this needed a same-day v0.50.285 vs being deferred
 
-v0.50.284 promised that "the first server start after deploying v0.50.285 will auto-restore any session that was wiped between deploys." That promise was broken by the `_index.json` shape mismatch — the recovery silently never fired. Affected users (the original reporter on v0.50.282 with the 1000+ message session that disappeared) would have had `<sid>.json.bak` files on disk but those files would never be processed. Same-day hotfix restores the promise.
+v0.50.284 promised that "the first server start after deploying v0.50.284 will auto-restore any session that was wiped between deploys." That promise was broken in production by the `_index.json` shape mismatch — the recovery silently never fired. Affected users (the original reporter on v0.50.282 with the 1000+ message session that disappeared) had `<sid>.json.bak` files on disk but those files would never be processed. Same-day hotfix restores the promise.
 
 
 ## [v0.50.284] — 2026-05-03

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 > Web companion to the Hermes Agent CLI. Same workflows, browser-native.
 >
-> Last updated: v0.50.284 (May 03, 2026) — 4026 tests collected
+> Last updated: v0.50.285 (May 03, 2026) — 4028 tests collected
 > Test source: `pytest tests/ --collect-only -q`
 > Per-version detail: see [CHANGELOG.md](./CHANGELOG.md)
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -1835,8 +1835,8 @@ Bridged CLI sessions:
 
 ---
 
-*Last updated: v0.50.284, May 03, 2026*
-*Total automated tests collected: 4026*
+*Last updated: v0.50.285, May 03, 2026*
+*Total automated tests collected: 4028*
 *Regression gate: tests/test_regressions.py*
 *Run: pytest tests/ -v --timeout=60*
 *Source: <repo>/*

--- a/api/session_recovery.py
+++ b/api/session_recovery.py
@@ -31,10 +31,21 @@ logger = logging.getLogger(__name__)
 
 
 def _msg_count(p: Path) -> int:
-    """Return the number of messages in a session JSON file, or -1 on read/parse error."""
+    """Return the number of messages in a session JSON file, or -1 on read/parse error.
+
+    Returns -1 for any non-session-shape file:
+    - File can't be read (OSError)
+    - Top-level isn't valid JSON or is invalid (JSONDecodeError, ValueError)
+    - Top-level isn't a dict (AttributeError on .get) — e.g. ``_index.json``
+      which is a top-level list of session metadata, not a session itself.
+      The startup recovery scanner globs ``*.json`` and would otherwise
+      crash on the first non-dict file it encounters.
+    """
     try:
         data = json.loads(p.read_text(encoding='utf-8'))
     except (OSError, json.JSONDecodeError, ValueError):
+        return -1
+    if not isinstance(data, dict):
         return -1
     msgs = data.get('messages')
     return len(msgs) if isinstance(msgs, list) else -1
@@ -117,8 +128,25 @@ def recover_all_sessions_on_startup(session_dir: Path) -> dict:
     restored = 0
     details: list[dict] = []
     for path in session_dir.glob('*.json'):
+        # Skip non-session JSON files in the same dir:
+        # - ``_index.json`` is a top-level list of session metadata
+        # - any other underscore-prefixed file is convention-marked as
+        #   non-session (matching the existing _index.json pattern)
+        # - dated-format files (``YYYYMMDD_HHMMSS_*.json``) are gateway
+        #   transcripts with their own shape
+        if path.name.startswith('_'):
+            continue
         scanned += 1
-        result = recover_session(path)
+        try:
+            result = recover_session(path)
+        except Exception as exc:
+            # Defensive: a malformed session file shouldn't break recovery
+            # for the rest. Log and continue.
+            logger.warning(
+                "recover_all_sessions_on_startup: skipped %s due to %s: %s",
+                path.name, type(exc).__name__, exc,
+            )
+            continue
         if result.get("restored"):
             restored += 1
             details.append(result)

--- a/api/session_recovery.py
+++ b/api/session_recovery.py
@@ -130,10 +130,9 @@ def recover_all_sessions_on_startup(session_dir: Path) -> dict:
     for path in session_dir.glob('*.json'):
         # Skip non-session JSON files in the same dir:
         # - ``_index.json`` is a top-level list of session metadata
-        # - any other underscore-prefixed file is convention-marked as
-        #   non-session (matching the existing _index.json pattern)
-        # - dated-format files (``YYYYMMDD_HHMMSS_*.json``) are gateway
-        #   transcripts with their own shape
+        # - any future non-session JSON marked with the ``_`` convention is
+        #   skipped automatically (project convention for system files in
+        #   directories that otherwise hold user data)
         if path.name.startswith('_'):
             continue
         scanned += 1

--- a/tests/test_metadata_save_wipe_1558.py
+++ b/tests/test_metadata_save_wipe_1558.py
@@ -215,3 +215,47 @@ def test_recover_all_sessions_on_startup_is_idempotent_no_op_on_clean_state(temp
 
     live_after = (temp_session_dir / f"{sid}.json").read_text(encoding="utf-8")
     assert live_before == live_after
+
+
+def test_recover_all_sessions_on_startup_skips_non_session_index_json(temp_session_dir):
+    """Regression for v0.50.284 startup: ``_index.json`` is a top-level list
+    (not a dict), and the recovery scanner globs ``*.json``. Without the
+    underscore-prefix skip + ``isinstance(data, dict)`` guard in ``_msg_count``,
+    the very first iteration crashed with ``AttributeError: 'list' object has
+    no attribute 'get'`` and the broad ``except Exception`` in server.py
+    swallowed the error, so recovery silently no-op'd in production.
+    """
+    # Simulate the production session dir: 1 valid session + _index.json
+    sid = _make_session_on_disk(temp_session_dir, n_msgs=1000)
+    # _index.json is the index file shape — a top-level list of metadata dicts
+    index_path = temp_session_dir / "_index.json"
+    index_path.write_text(
+        json.dumps([
+            {"session_id": sid, "title": "Test", "updated_at": 1.0},
+            {"session_id": "other", "title": "Other", "updated_at": 2.0},
+        ]),
+        encoding="utf-8",
+    )
+
+    from api.session_recovery import recover_all_sessions_on_startup
+    # Before the fix, this raised AttributeError; the broad except in server.py
+    # swallowed it and printed [recovery] startup recovery failed: 'list'
+    # object has no attribute 'get'. Now the scanner skips _index.json
+    # entirely (underscore-prefix convention) and continues scanning real
+    # session files.
+    result = recover_all_sessions_on_startup(temp_session_dir)
+    assert result["restored"] == 0
+    # The 1 valid session was scanned; _index.json was skipped (not counted)
+    assert result["scanned"] == 1, (
+        f"_index.json must be skipped, scanned should be 1, got {result['scanned']}"
+    )
+
+
+def test_msg_count_returns_neg1_for_non_dict_top_level(temp_session_dir):
+    """``_msg_count`` must not raise on a JSON file whose top-level is a list."""
+    from api.session_recovery import _msg_count
+    list_shaped = temp_session_dir / "_index.json"
+    list_shaped.write_text(json.dumps([{"session_id": "x"}]), encoding="utf-8")
+    # Pre-fix: AttributeError. Post-fix: -1.
+    assert _msg_count(list_shaped) == -1
+


### PR DESCRIPTION
# v0.50.285 — same-day hotfix to v0.50.284 (session recovery actually fires now)

**Severity:** P1 hotfix-of-hotfix. Recommend deploy as soon as CI clears.

v0.50.284 promised that the startup self-heal would auto-restore any session wiped between v0.50.279 and v0.50.284 deploys. **That promise was broken in production** — the recovery scanner crashed on the first JSON file it processed, the broad `except Exception` in server.py swallowed the error, and recovery silently no-op'd for every user.

Verified live on the production server immediately after v0.50.284 deploy:

```
[recovery] startup recovery failed: 'list' object has no attribute 'get'
```

## Root cause

The production session directory contains `_index.json` whose top-level shape is a **list** (the index of session metadata dicts), not a dict. `_msg_count()` in `api/session_recovery.py` did `data.get('messages')` which raises `AttributeError` on a list. The first `*.json` the scanner globbed was `_index.json` → AttributeError → caught by server.py's broad `except Exception` → printed the warning above and returned. Recovery silently never fired.

## Fix — three small defensive changes (98 LOC total)

### Change 1: `_msg_count()` non-dict guard
```python
+    if not isinstance(data, dict):
+        return -1
     msgs = data.get('messages')
```

### Change 2: Skip underscore-prefixed files in scanner
```python
     for path in session_dir.glob('*.json'):
+        if path.name.startswith('_'):
+            continue
         scanned += 1
```

`_index.json` follows the existing convention for non-session metadata files in the session dir. Future additions like `_workspaces.json` would be skipped automatically.

### Change 3: Per-file exception isolation
```python
+        try:
+            result = recover_session(path)
+        except Exception as exc:
+            logger.warning("recover_all_sessions_on_startup: skipped %s due to %s: %s",
+                           path.name, type(exc).__name__, exc)
+            continue
```

Defensive: a single malformed session file shouldn't break recovery for the rest.

## Tests

- `test_recover_all_sessions_on_startup_skips_non_session_index_json` — simulates the production session dir (1 valid session + `_index.json` with the actual list-of-dicts shape), asserts the scanner returns `scanned=1, restored=0`.
- `test_msg_count_returns_neg1_for_non_dict_top_level` — direct unit test of `_msg_count()` against a list-shaped JSON file. Pre-fix: AttributeError. Post-fix: -1.

4026 → **4028 passing**. All 8 tests in `tests/test_metadata_save_wipe_1558.py` pass (6 original v0.50.284 + 2 new regression).

## Net effect

Any user wiped between v0.50.279 and v0.50.284 deploys whose session left a `.bak` shadow on disk will now get auto-recovered on first launch of v0.50.285, **as v0.50.284's release notes promised**.

The original reporter on v0.50.282 with the 1000+ message session that disappeared will see their conversation restored automatically when their server restarts on v0.50.285 (assuming the buggy v0.50.282 save left a `.bak` — which it did, every save shrunk messages).

## Reviews

- Pre-release Opus advisor pass.
- Per maintainer directive: no independent review needed for this hotfix-of-hotfix; CI green + Opus pass is sufficient.

## Closes

- Closes #1558 (follow-up — the original P0 was closed by v0.50.284 but the recovery half didn't actually run in production, so the issue technically wasn't resolved end-to-end).

## Deploy note

Restart the server on first launch of v0.50.285. Watch for the log line:

```
[recovery] Restored N/M sessions from .bak (see #1558).
```

If `N > 0`, those users had their messages restored. If `N == 0`, no `.bak` shadows were found (clean state — no recovery needed).
