### PR TITLE
fix: block self-update restart during active streams

### DIFF
--- a/api/updates.py
+++ b/api/updates.py
@@ -13,7 +13,7 @@ import threading
 import time
 from pathlib import Path
 
-from api.config import REPO_ROOT
+from api.config import REPO_ROOT, STREAMS, STREAMS_LOCK
 
 # Lazy -- may be None if agent not found
 try:
@@ -26,6 +26,32 @@ _cache_lock = threading.Lock()
 _check_in_progress = False
 _apply_lock = threading.Lock()   # prevents concurrent stash/pull/pop on same repo
 CACHE_TTL = 1800  # 30 minutes
+
+
+def _active_stream_count() -> int:
+    """Return the current in-memory chat stream count.
+
+    Self-update schedules an in-process re-exec after git pull/reset.  That is
+    restart-equivalent for live streams, even when systemd does not see a unit
+    restart.  Refuse update/force-update while a stream exists so a browser
+    update click cannot recreate the pending-message loss class fixed in #1543.
+    """
+    with STREAMS_LOCK:
+        return len(STREAMS)
+
+
+def _restart_blocked_response(target: str, active_streams: int) -> dict:
+    plural = "s" if active_streams != 1 else ""
+    return {
+        'ok': False,
+        'message': (
+            f'Cannot update {target} while {active_streams} active chat stream{plural} '
+            'is running. Wait for the response to finish, then retry the update.'
+        ),
+        'target': target,
+        'restart_blocked': True,
+        'active_streams': active_streams,
+    }
 
 
 def _run_git(args, cwd, timeout=10):
@@ -249,6 +275,10 @@ def apply_force_update(target: str) -> dict:
     response with ``conflict: True`` or ``diverged: True`` and the user
     has confirmed they want to discard local changes.
     """
+    active_streams = _active_stream_count()
+    if active_streams:
+        return _restart_blocked_response(target, active_streams)
+
     if not _apply_lock.acquire(blocking=False):
         return {'ok': False, 'message': 'Update already in progress'}
     try:
@@ -299,6 +329,10 @@ def apply_force_update(target: str) -> dict:
 
 def apply_update(target):
     """Stash, pull --ff-only, pop for the given target repo."""
+    active_streams = _active_stream_count()
+    if active_streams:
+        return _restart_blocked_response(target, active_streams)
+
     if not _apply_lock.acquire(blocking=False):
         return {'ok': False, 'message': 'Update already in progress'}
     try:

--- a/tests/test_update_banner_fixes.py
+++ b/tests/test_update_banner_fixes.py
@@ -117,6 +117,66 @@ class TestScheduleRestart:
         assert execv_called, "_schedule_restart must eventually call os.execv"
 
 
+class TestApplyUpdateRestartSafety:
+    """Self-update must not re-exec while chat streams are active."""
+
+    def test_apply_update_refuses_when_stream_active(self, tmp_path, monkeypatch):
+        import queue
+        import api.updates as upd
+        from api.config import STREAMS, STREAMS_LOCK
+
+        (tmp_path / '.git').mkdir()
+        monkeypatch.setattr(upd, 'REPO_ROOT', tmp_path)
+        monkeypatch.setattr(upd, '_AGENT_DIR', tmp_path)
+        called = []
+        monkeypatch.setattr(upd, '_run_git', lambda *a, **k: (called.append(a) or ('', True)))
+        monkeypatch.setattr(upd, '_schedule_restart', lambda delay=2.0: (_ for _ in ()).throw(AssertionError('must not restart')))
+
+        with STREAMS_LOCK:
+            old = dict(STREAMS)
+            STREAMS.clear()
+            STREAMS['stream_active'] = queue.Queue()
+        try:
+            result = upd.apply_update('webui')
+        finally:
+            with STREAMS_LOCK:
+                STREAMS.clear()
+                STREAMS.update(old)
+
+        assert result['ok'] is False
+        assert result.get('active_streams') == 1
+        assert result.get('restart_blocked') is True
+        assert 'active chat stream' in result['message']
+        assert called == []
+
+    def test_force_update_refuses_when_stream_active(self, tmp_path, monkeypatch):
+        import queue
+        import api.updates as upd
+        from api.config import STREAMS, STREAMS_LOCK
+
+        (tmp_path / '.git').mkdir()
+        monkeypatch.setattr(upd, 'REPO_ROOT', tmp_path)
+        monkeypatch.setattr(upd, '_AGENT_DIR', tmp_path)
+        monkeypatch.setattr(upd, '_run_git', lambda *a, **k: (_ for _ in ()).throw(AssertionError('must not run git')))
+        monkeypatch.setattr(upd, '_schedule_restart', lambda delay=2.0: (_ for _ in ()).throw(AssertionError('must not restart')))
+
+        with STREAMS_LOCK:
+            old = dict(STREAMS)
+            STREAMS.clear()
+            STREAMS['stream_active'] = queue.Queue()
+        try:
+            result = upd.apply_force_update('agent')
+        finally:
+            with STREAMS_LOCK:
+                STREAMS.clear()
+                STREAMS.update(old)
+
+        assert result['ok'] is False
+        assert result.get('active_streams') == 1
+        assert result.get('restart_blocked') is True
+        assert 'active chat stream' in result['message']
+
+
 class TestSuccessfulUpdateReturnsRestartScheduled:
     """#814 — successful apply_update must return restart_scheduled: True."""
 


### PR DESCRIPTION
## Summary
- Block WebUI self-update and force-update while chat streams are active
- Return a structured `restart_blocked` response with the active stream count
- Add regression coverage for both `apply_update()` and `apply_force_update()`

## Problem
The WebUI self-update path schedules an in-process restart via `os.execv()` after applying updates. That restart-equivalent path is independent of systemd, so external restart guards do not protect active chat streams when a browser user clicks the update button.

If a self-update happens while a response is streaming, the process can be replaced while in-memory stream state is still active. This reintroduces the same failure class as the stale-stream/pending-message recovery work: active turns can be interrupted by a restart path that does not know about live streams.

## Change
Before starting either update path, count active streams under `STREAMS_LOCK`. If any stream is active, refuse the update before running git commands or scheduling restart.

## Test Plan
- `uv run --with pytest --with fastapi --with starlette --with pydantic python -m pytest tests/test_update_banner_fixes.py -q`
- Result: `31 passed`

## Notes
This is intentionally narrow: it only guards the restart-equivalent self-update endpoints. It does not change the existing successful update behavior when no stream is active.
