### PR TITLE
fix(picker): Nous Portal featured-set cap + endpoint symmetry (closes #1567)

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -899,6 +899,122 @@ def _format_nous_label(mid: str) -> str:
     return f"{base} (via Nous)"
 
 
+# Soft cap on how many Nous Portal models surface in the picker dropdown.
+# Above this count, _build_nous_featured_set() trims the visible list to
+# ~_NOUS_FEATURED_TARGET entries; the full catalog is still returned to the
+# client under ``extra_models`` so /model autocomplete covers everything.
+# Caps reflect human scannability — a 25-row dropdown is the practical UX
+# ceiling, and per-vendor sampling at 15 keeps the flagship shape visible
+# without one vendor dominating.
+_NOUS_FEATURED_THRESHOLD = 25
+_NOUS_FEATURED_TARGET = 15
+
+# Vendor-prefix priority order for featured selection. Lower index = picked
+# earlier when sampling the live catalog. Reflects which vendors users have
+# historically reached for first via Nous Portal (driven by the curated
+# static list maintained in _PROVIDER_MODELS["nous"] and Discord feedback).
+_NOUS_VENDOR_PRIORITY = (
+    "anthropic", "openai", "google", "moonshotai", "z-ai",
+    "minimax", "qwen", "x-ai", "deepseek", "stepfun",
+    "xiaomi", "tencent", "nvidia", "arcee-ai",
+)
+
+
+def _build_nous_featured_set(
+    live_ids: list[str],
+    *,
+    selected_model_id: str | None = None,
+    target: int = _NOUS_FEATURED_TARGET,
+) -> tuple[list[str], list[str]]:
+    """Trim a Nous Portal catalog into a (featured, extras) split.
+
+    ``featured`` is what the picker dropdown renders. ``extras`` is everything
+    else — kept available so the slash-command `/model` autocomplete and the
+    ``_dynamicModelLabels`` map cover the full catalog.
+
+    Selection rules (in order, deterministic):
+
+    1. Always include the user's currently-selected model if it's in the
+       catalog (preserves selection stickiness — no orphan IDs in the
+       dropdown after a refresh).
+    2. Always include every entry from the curated static
+       ``_PROVIDER_MODELS["nous"]`` list whose id maps onto a live id —
+       those four are explicitly maintained as flagship picks.
+    3. Top up to ``target`` by walking ``_NOUS_VENDOR_PRIORITY`` round-robin
+       (one model per vendor each pass) so no vendor monopolises the slot
+       budget. Within a vendor, the original ``live_ids`` order is preserved
+       — that's the order Nous Portal returned, which approximates recency.
+
+    Returns ``(featured_ids, extras_ids)`` — both lists are subsets of
+    ``live_ids`` with disjoint membership and union equal to ``live_ids``.
+
+    For catalogs ≤ ``_NOUS_FEATURED_THRESHOLD`` entries the function is a
+    no-op: ``featured == live_ids``, ``extras == []``.
+    """
+    if not live_ids:
+        return [], []
+    if len(live_ids) <= _NOUS_FEATURED_THRESHOLD:
+        return list(live_ids), []
+
+    chosen: list[str] = []  # preserves insertion order
+    chosen_set: set[str] = set()
+
+    def _add(mid: str) -> None:
+        if mid and mid not in chosen_set:
+            chosen.append(mid)
+            chosen_set.add(mid)
+
+    # Rule 1: sticky selection. Strip "@nous:" prefix if present so we can
+    # match against the live id space (which is bare "vendor/model").
+    if selected_model_id:
+        sel = selected_model_id
+        if sel.startswith("@nous:"):
+            sel = sel[len("@nous:"):]
+        if sel in live_ids:
+            _add(sel)
+
+    # Rule 2: curated flagships. Extract the bare ids from the static list
+    # entries (which are stored as "@nous:vendor/model").
+    for static in _PROVIDER_MODELS.get("nous", []):
+        sid = static.get("id", "")
+        if sid.startswith("@nous:"):
+            sid = sid[len("@nous:"):]
+        if sid in live_ids:
+            _add(sid)
+
+    # Rule 3: vendor-priority round-robin top-up.
+    by_vendor: dict[str, list[str]] = {}
+    for mid in live_ids:
+        if mid in chosen_set:
+            continue
+        vendor = mid.split("/", 1)[0] if "/" in mid else ""
+        by_vendor.setdefault(vendor, []).append(mid)
+
+    # Walk vendors in priority order, then any leftover vendors alphabetically.
+    priority = list(_NOUS_VENDOR_PRIORITY)
+    leftover = sorted(v for v in by_vendor if v not in set(priority))
+    vendor_order = priority + leftover
+
+    # Round-robin: one model per vendor per pass until we hit the target or
+    # exhaust every bucket.
+    while len(chosen) < target:
+        added_this_pass = 0
+        for vendor in vendor_order:
+            if len(chosen) >= target:
+                break
+            bucket = by_vendor.get(vendor)
+            if not bucket:
+                continue
+            _add(bucket.pop(0))
+            added_this_pass += 1
+        if added_this_pass == 0:
+            break  # all buckets empty
+
+    # Anything not chosen becomes extras (full-catalog completion surface).
+    extras = [m for m in live_ids if m not in chosen_set]
+    return chosen, extras
+
+
 def _apply_provider_prefix(
     raw_models: list[dict],
     provider_id: str,
@@ -1767,6 +1883,22 @@ def get_available_models() -> dict:
                     logger.debug("Failed to get key source for provider %s", _p.get("id", "unknown"))
                 detected_providers.add(_p["id"])
             _hermes_auth_used = True
+
+            # Belt-and-braces: list_available_providers() is the primary signal
+            # for OAuth providers, but its `authenticated` field can disagree
+            # with `get_auth_status(<id>).logged_in` on some hermes_cli versions
+            # (the two fields are computed via different code paths). When the
+            # disagreement happens for Nous Portal, the Settings → Providers
+            # card renders the live catalog (because api/providers.py iterates
+            # all OAuth providers regardless of authentication state) but the
+            # picker dropdown comes up empty — a confusing asymmetry reported
+            # in #1567. Add Nous explicitly when get_auth_status agrees so the
+            # picker stays in sync with the providers card.
+            try:
+                if _gas("nous").get("logged_in"):
+                    detected_providers.add("nous")
+            except Exception:
+                logger.debug("Failed to check Nous Portal auth status")
         except Exception:
             logger.debug("Failed to detect auth providers from hermes")
 
@@ -2241,43 +2373,102 @@ def get_available_models() -> dict:
                             }
                         )
                 elif pid == "nous":
-                    # Nous Portal exposes a curated catalog (~30 models, currently)
-                    # via inference-api.nousresearch.com. Like ollama-cloud, we
+                    # Nous Portal exposes a curated catalog (~30 models on most
+                    # accounts, up to several hundred for enterprise tiers) via
+                    # inference-api.nousresearch.com. Like ollama-cloud, we
                     # live-fetch through hermes_cli.models.provider_model_ids()
                     # rather than relying on the static four-entry list, which
-                    # chronically drifts out of date (#1538). Fall back to the
-                    # static list when hermes_cli is unavailable (test envs,
-                    # package mismatches) so the picker is never empty.
+                    # chronically drifts out of date (#1538).
+                    #
+                    # When the catalog exceeds _NOUS_FEATURED_THRESHOLD (~25)
+                    # the picker dropdown gets a curated subset to stay
+                    # scannable — the full list is still returned under
+                    # "extra_models" for the slash-command autocomplete and
+                    # the dynamic-label map (#1567). The optgroup label is
+                    # decorated with the truncation count so users know more
+                    # exists.
                     raw_models = []
+                    extra_models: list[dict] = []
+                    truncated_label_suffix = ""
+                    live_fetch_failed = False
                     try:
                         from hermes_cli.models import provider_model_ids as _provider_model_ids
 
                         live_ids = _provider_model_ids("nous") or []
-                        raw_models = [
-                            # Prefix every live id with "@nous:" so routing matches
-                            # the explicit-provider-hint branch of resolve_model_provider
-                            # (same convention as the curated static list — see
-                            # tests/test_nous_portal_routing.py for the invariant).
-                            {"id": f"@nous:{mid}", "label": _format_nous_label(mid)}
-                            for mid in live_ids
-                        ]
                     except Exception:
                         logger.warning("Failed to load Nous Portal models from hermes_cli")
+                        live_ids = []
+                        live_fetch_failed = True
 
-                    if not raw_models:
-                        # Static fallback: deepcopy so dedup/prefix mutation
-                        # below does not bleed into the module-level catalog.
+                    if live_ids:
+                        # Sticky-selection signal: prefer the explicitly-active
+                        # model from cfg["model"]["model"] (what the user is
+                        # currently using) over cfg["model"]["default"] (the
+                        # configured default suggestion). Falls back to the
+                        # latter so first-load before any selection still works.
+                        _model_cfg = cfg.get("model", {})
+                        _selected = (
+                            (isinstance(_model_cfg, dict) and _model_cfg.get("model"))
+                            or default_model
+                            or None
+                        )
+                        featured_ids, extras_ids = _build_nous_featured_set(
+                            live_ids,
+                            selected_model_id=_selected,
+                        )
+                        # Prefix every live id with "@nous:" so routing matches
+                        # the explicit-provider-hint branch of resolve_model_provider
+                        # (same convention as the curated static list — see
+                        # tests/test_nous_portal_routing.py for the invariant).
+                        raw_models = [
+                            {"id": f"@nous:{mid}", "label": _format_nous_label(mid)}
+                            for mid in featured_ids
+                        ]
+                        extra_models = [
+                            {"id": f"@nous:{mid}", "label": _format_nous_label(mid)}
+                            for mid in extras_ids
+                        ]
+                        if extras_ids:
+                            # Show "(15 of 397)" so the user understands the picker
+                            # is showing a featured subset, not a broken short list.
+                            truncated_label_suffix = (
+                                f" ({len(featured_ids)} of {len(live_ids)})"
+                            )
+                    elif not live_fetch_failed:
+                        # Live-fetch returned an empty list AND did not raise —
+                        # the user is gated as authenticated by detection above
+                        # but the catalog endpoint replied with no models.
+                        # Showing the static 4-entry curated list here would
+                        # contradict the providers card (which always shows
+                        # the live catalog) — exactly the asymmetry #1567
+                        # reports. Omit the Nous group entirely; the providers
+                        # card already tells the truth, and a transient empty
+                        # response will self-heal on the next cache rebuild.
+                        logger.warning(
+                            "Nous Portal authenticated but live-fetch returned empty — "
+                            "omitting from picker (will retry on next cache rebuild)"
+                        )
+                    else:
+                        # hermes_cli unavailable / raised — fall back to the
+                        # curated 4-entry static list so the picker is never
+                        # empty in this degraded state. This matches pre-#1538
+                        # behaviour for environments without hermes_cli (test
+                        # envs, package mismatches, isolated WebUI builds).
                         raw_models = copy.deepcopy(_PROVIDER_MODELS.get("nous", []))
 
                     if raw_models:
                         models = _apply_provider_prefix(raw_models, pid, active_provider)
-                        groups.append(
-                            {
-                                "provider": provider_name,
-                                "provider_id": pid,
-                                "models": models,
-                            }
-                        )
+                        # Apply the same prefix transform to extras so /model
+                        # autocomplete sees consistent IDs across the two lists.
+                        extras = _apply_provider_prefix(extra_models, pid, active_provider) if extra_models else []
+                        group_entry = {
+                            "provider": provider_name + truncated_label_suffix,
+                            "provider_id": pid,
+                            "models": models,
+                        }
+                        if extras:
+                            group_entry["extra_models"] = extras
+                        groups.append(group_entry)
                 elif pid in _PROVIDER_MODELS or pid in cfg.get("providers", {}):
                     raw_models = copy.deepcopy(_PROVIDER_MODELS.get(pid, []))
                     detected_models = auto_detected_models_by_provider.get(pid, [])

--- a/api/providers.py
+++ b/api/providers.py
@@ -392,10 +392,19 @@ def get_providers() -> dict[str, Any]:
                     pass
 
         models = list(_PROVIDER_MODELS.get(pid, []))
+        models_total = len(models)
         # Nous Portal: prefer the live catalog so the providers card matches
         # the dropdown picker (#1538). Same fallback shape as the static-only
         # case below — when hermes_cli is unavailable or its lookup raises,
         # we keep the four-entry curated list.
+        #
+        # On large-tier accounts (#1567 reporter Deor saw 396 entries), we
+        # render the same featured subset the picker uses so the providers
+        # card body doesn't become a 396-pill wall. The full count is still
+        # reported via models_total — surfaced in the header line as
+        # "396 models · OAuth" by static/panels.js — so the user knows the
+        # complete catalog is reachable (via /model autocomplete or a future
+        # "show all" disclosure if added).
         if pid == "nous":
             try:
                 from hermes_cli.models import provider_model_ids as _provider_model_ids
@@ -403,12 +412,14 @@ def get_providers() -> dict[str, Any]:
                 live_ids = _provider_model_ids("nous") or []
                 if live_ids:
                     # Lazy-import to avoid circular dep with api.config.
-                    from api.config import _format_nous_label
+                    from api.config import _format_nous_label, _build_nous_featured_set
 
+                    featured_ids, _extras = _build_nous_featured_set(live_ids)
                     models = [
                         {"id": f"@nous:{mid}", "label": _format_nous_label(mid)}
-                        for mid in live_ids
+                        for mid in featured_ids
                     ]
+                    models_total = len(live_ids)
             except Exception:
                 logger.debug("Failed to load Nous Portal models from hermes_cli")
         # Also include models from config.yaml providers section
@@ -420,6 +431,13 @@ def get_providers() -> dict[str, Any]:
                     models = models + [{"id": k, "label": k} for k in cfg_models.keys()]
                 elif isinstance(cfg_models, list):
                     models = models + [{"id": k, "label": k} for k in cfg_models]
+                # Recompute models_total when config.yaml contributes additional
+                # entries on top of the live/static catalog. For non-Nous
+                # providers models_total still equals len(models); for Nous
+                # we keep the live count (which already includes any models
+                # surfaced in the curated featured slice).
+                if pid != "nous":
+                    models_total = len(models)
 
         providers.append({
             "id": pid,
@@ -430,6 +448,14 @@ def get_providers() -> dict[str, Any]:
             "key_source": key_source,
             "auth_error": auth_error,
             "models": models,
+            # models_total reflects the complete catalog size (e.g. 396 for
+            # an enterprise Nous Portal account), even when "models" is
+            # trimmed to a featured subset for UI scannability. The frontend
+            # uses this for the header text "396 models · OAuth" so users
+            # know the full catalog exists and is reachable via the slash
+            # command. For providers that don't trim, models_total ==
+            # len(models) and the frontend behaves identically to before.
+            "models_total": models_total,
         })
 
     # Scan custom_providers from config.yaml (e.g. glmcode, timicc)

--- a/api/routes.py
+++ b/api/routes.py
@@ -4416,6 +4416,23 @@ def _handle_live_models(handler, parsed):
         if not ids:
             return _finish({"provider": provider, "models": [], "count": 0})
 
+        # For Nous Portal, apply the same featured-set cap that
+        # /api/models uses so background enrichment via _fetchLiveModels()
+        # doesn't undo the dropdown trim — otherwise a 397-model catalog
+        # would still flood the picker after the initial render finished
+        # the cap. The full list is returned via the main /api/models
+        # endpoint's extra_models field for /model autocomplete; the live
+        # endpoint is purely a dropdown-enrichment surface, so it should
+        # match the dropdown's visibility budget. (#1567)
+        if provider == "nous":
+            try:
+                from api.config import _build_nous_featured_set
+                _default_model = (cfg.get("model", {}) or {}).get("model") if isinstance(cfg.get("model"), dict) else None
+                _featured, _ = _build_nous_featured_set(ids, selected_model_id=_default_model)
+                ids = _featured
+            except Exception:
+                logger.debug("Failed to apply Nous featured-set cap for /api/models/live")
+
         # Normalise to {id, label} — provider_model_ids() returns plain string IDs.
         # For ollama-cloud use the shared Ollama formatter (handles `:variant` suffix).
         # For all other providers use a simpler hyphen-split capitaliser.

--- a/static/commands.js
+++ b/static/commands.js
@@ -136,6 +136,15 @@ async function _loadSlashModelSubArgs(force=false){
           const id=_normalizeSlashSubArg(model&&model.id);
           if(id) values.push(id);
         }
+        // Include extra_models (the catalog tail that doesn't render as
+        // <option> entries when the picker is capped) so /model autocomplete
+        // covers the full catalog. The trimming is purely a dropdown
+        // scannability concern — the slash command exists precisely so
+        // power users can reach any model by typing its name. #1567.
+        for(const model of (group&&group.extra_models)||[]){
+          const id=_normalizeSlashSubArg(model&&model.id);
+          if(id) values.push(id);
+        }
       }
       const deduped=Array.from(new Set(values)).sort((a,b)=>a.localeCompare(b));
       _slashModelCache=deduped;

--- a/static/panels.js
+++ b/static/panels.js
@@ -3233,7 +3233,13 @@ function _buildProviderCard(p){
   // Use the is_oauth flag from the backend — it reflects _OAUTH_PROVIDERS in providers.py.
   // key_source can be 'oauth' (hermes auth), 'config_yaml' (token in config.yaml), or 'none'.
   const isOauth=p.is_oauth===true;
-  const modelCount=Array.isArray(p.models)?p.models.length:0;
+  // models_total reflects the complete catalog (e.g. 396 for a large-tier
+  // Nous Portal account). The "models" array may be trimmed to a featured
+  // subset for UI scannability — fall back to its length only when the
+  // server didn't supply models_total (older builds, custom providers).
+  const modelCount=Number.isFinite(p.models_total)
+    ? p.models_total
+    : (Array.isArray(p.models) ? p.models.length : 0);
   const sourceLabel=p.key_source==='oauth'
     ? t('providers_status_oauth')
     : p.key_source==='config_yaml'
@@ -3334,11 +3340,27 @@ function _buildProviderCard(p){
     modelSection.appendChild(modelLabel);
     const modelList=document.createElement('div');
     modelList.className='provider-card-model-tags';
-    for(const m of p.models){
+    const renderedModels=Array.isArray(p.models)?p.models:[];
+    for(const m of renderedModels){
       const tag=document.createElement('span');
       tag.className='provider-card-model-tag';
       tag.textContent=m.id||m.label||m;
       modelList.appendChild(tag);
+    }
+    // When the rendered list is a strict subset of the total catalog (Nous
+    // Portal large-tier accounts hit this with ~400-model catalogs), show
+    // a "+N more" trailing pill so the user knows the picker is intentionally
+    // capped — and they can still reach the full catalog via the /model
+    // slash command (its autocomplete consumes the un-trimmed list from
+    // /api/models's extra_models field). #1567.
+    const totalCount=Number.isFinite(p.models_total)?p.models_total:renderedModels.length;
+    const hiddenCount=Math.max(0, totalCount - renderedModels.length);
+    if(hiddenCount>0){
+      const more=document.createElement('span');
+      more.className='provider-card-model-tag provider-card-model-tag-more';
+      more.textContent='+'+hiddenCount+' more';
+      more.title='The /model slash command can autocomplete every model in this provider\'s catalog.';
+      modelList.appendChild(more);
     }
     modelSection.appendChild(modelList);
     body.appendChild(modelSection);

--- a/static/style.css
+++ b/static/style.css
@@ -2416,6 +2416,16 @@ main.main.showing-profiles > #mainProfiles{display:flex;}
   line-height:1.5;
   user-select:all;
 }
+/* "+N more" disclosure pill — appended when a provider's catalog is trimmed
+   for UI scannability (#1567 — Nous Portal large-tier accounts ship 100s of
+   models). Visually distinct from a real model tag so users don't think it's
+   a model id; muted dashed border, italic, no user-select. */
+.provider-card-model-tag-more{
+  font-style:italic;
+  border-style:dashed;
+  user-select:none;
+  cursor:help;
+}
 
 /* ── Session pin indicator (inline, only when pinned) ── */
 .session-pin-indicator{

--- a/static/ui.js
+++ b/static/ui.js
@@ -370,6 +370,17 @@ async function populateModelDropdown(){
         og.appendChild(opt);
         _dynamicModelLabels[m.id]=m.label;
       }
+      // Hydrate the label map from extra_models too (the catalog tail that
+      // doesn't render as <option> entries when the picker is capped — see
+      // _build_nous_featured_set in api/config.py for the rationale). This
+      // keeps a model selected from the slash-command autocomplete or a
+      // persisted-localStorage value renderable with its proper label
+      // instead of falling back to the bare ID. #1567.
+      if(Array.isArray(g.extra_models)){
+        for(const m of g.extra_models){
+          if(m && m.id) _dynamicModelLabels[m.id]=m.label||m.id;
+        }
+      }
       sel.appendChild(og);
     }
     // Set default model from server if no localStorage preference

--- a/tests/test_issue1567_nous_picker_capacity_and_symmetry.py
+++ b/tests/test_issue1567_nous_picker_capacity_and_symmetry.py
@@ -1,0 +1,555 @@
+"""Regression tests for #1567 — Nous Portal picker capacity + endpoint symmetry.
+
+Two issues addressed in one PR:
+
+1. **Endpoint disagreement (the bug):** The Settings → Providers card and the
+   model picker dropdown returned different Nous catalogs because their
+   detection paths differ. ``api/providers.py:get_providers`` iterates ALL
+   OAuth providers regardless of `list_available_providers().authenticated`.
+   ``api/config.py:_build_available_models_uncached`` only includes providers
+   in ``detected_providers``, which is gated on
+   ``list_available_providers().authenticated``. On some hermes_cli versions
+   that flag disagrees with ``get_auth_status(<id>).logged_in``. Result: the
+   providers card shows the live catalog (e.g. 396 models) and the picker
+   shows nothing or the stale 4-entry static fallback.
+
+2. **UX cap (the design concern):** Even with the disagreement fixed, dumping
+   a 397-model dropdown into the picker would be unusable. We cap the
+   dropdown at ~15 featured entries (deterministic vendor-priority sample,
+   sticky for the user's currently-selected model) and return the full
+   catalog under ``extra_models`` so /model autocomplete and the dynamic
+   label map still cover everything.
+
+Tests in this file pin both invariants.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import api.config as config
+import api.profiles as profiles
+
+
+# Big catalog matches the shape of an enterprise Nous Portal account.
+# Volume distribution mirrors what we saw on Nathan's machine (~30 models)
+# extrapolated up to ~400 with the same vendor mix Deor reported.
+_BIG_CATALOG_VENDORS = {
+    "anthropic": 8, "openai": 30, "google": 12, "moonshotai": 5, "z-ai": 15,
+    "minimax": 10, "qwen": 80, "x-ai": 8, "deepseek": 20, "stepfun": 10,
+    "xiaomi": 6, "tencent": 12, "nvidia": 25, "arcee-ai": 8,
+    "meta-llama": 50, "mistralai": 40, "cohere": 25, "databricks": 15, "lambda-ai": 18,
+}
+
+
+def _build_big_catalog() -> list[str]:
+    out = []
+    for v, n in _BIG_CATALOG_VENDORS.items():
+        for i in range(n):
+            out.append(f"{v}/model-{v}-{i:02d}")
+    return out
+
+
+def _install_fake_hermes_cli(
+    monkeypatch,
+    *,
+    nous_ids: list[str] | None = None,
+    raise_on_lookup: bool = False,
+    list_authenticated: bool = True,
+    auth_status_logged_in: bool = True,
+):
+    """Install fake ``hermes_cli`` modules with controllable Nous behavior.
+
+    The two flags ``list_authenticated`` and ``auth_status_logged_in`` model
+    the divergence between ``hermes_cli.models.list_available_providers()``
+    and ``hermes_cli.auth.get_auth_status()`` that #1567 calls out as a
+    real-world pattern on some hermes_cli versions.
+    """
+    fake_pkg = types.ModuleType("hermes_cli")
+    fake_pkg.__path__ = []
+
+    fake_models = types.ModuleType("hermes_cli.models")
+    fake_models.list_available_providers = lambda: [
+        {"id": "nous", "label": "Nous Portal", "aliases": [], "authenticated": list_authenticated},
+    ]
+    if raise_on_lookup:
+        def _raise(_pid):
+            raise RuntimeError("simulated hermes_cli failure")
+        fake_models.provider_model_ids = _raise
+    else:
+        ids = list(nous_ids) if nous_ids is not None else []
+        fake_models.provider_model_ids = lambda pid: ids if pid == "nous" else []
+
+    fake_auth = types.ModuleType("hermes_cli.auth")
+
+    def _get_auth_status(pid):
+        if pid == "nous":
+            return {"logged_in": auth_status_logged_in, "key_source": "oauth"}
+        return {}
+
+    fake_auth.get_auth_status = _get_auth_status
+
+    monkeypatch.setitem(sys.modules, "hermes_cli", fake_pkg)
+    monkeypatch.setitem(sys.modules, "hermes_cli.models", fake_models)
+    monkeypatch.setitem(sys.modules, "hermes_cli.auth", fake_auth)
+    monkeypatch.delitem(sys.modules, "agent.credential_pool", raising=False)
+    monkeypatch.delitem(sys.modules, "agent", raising=False)
+
+    config.invalidate_models_cache()
+
+
+def _swap_in_test_config(extra_cfg):
+    old_cfg = dict(config.cfg)
+    old_mtime = config._cfg_mtime
+    config.cfg.clear()
+    config.cfg["model"] = {}
+    config.cfg.update(extra_cfg)
+    try:
+        config._cfg_mtime = config.Path(config._get_config_path()).stat().st_mtime
+    except Exception:
+        config._cfg_mtime = 0.0
+
+    def _restore():
+        config.cfg.clear()
+        config.cfg.update(old_cfg)
+        config._cfg_mtime = old_mtime
+
+    return _restore
+
+
+def _scrub_provider_env(monkeypatch):
+    """Drop every provider env var so detection doesn't leak unrelated keys."""
+    for var in (
+        "ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GOOGLE_API_KEY", "GEMINI_API_KEY",
+        "DEEPSEEK_API_KEY", "XAI_API_KEY", "GROQ_API_KEY",
+        "MISTRAL_API_KEY", "OPENROUTER_API_KEY",
+        "OLLAMA_CLOUD_API_KEY", "OLLAMA_API_KEY",
+        "GLM_API_KEY", "KIMI_API_KEY", "MOONSHOT_API_KEY",
+        "MINIMAX_API_KEY", "MINIMAX_CN_API_KEY",
+        "OPENCODE_ZEN_API_KEY", "OPENCODE_GO_API_KEY",
+        "NOUS_API_KEY", "NVIDIA_API_KEY", "LM_API_KEY", "LMSTUDIO_API_KEY",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+# ────────────────────────────────────────────────────────────────────────
+# Section 1 — _build_nous_featured_set helper invariants
+# ────────────────────────────────────────────────────────────────────────
+
+
+class TestBuildNousFeaturedSet:
+    """Unit tests for the deterministic featured-vs-extras split helper."""
+
+    def test_small_catalog_is_no_op(self):
+        from api.config import _build_nous_featured_set, _NOUS_FEATURED_THRESHOLD
+        # 20 entries — below the threshold, helper should return the input
+        # untouched and an empty extras list.
+        catalog = [f"vendor/model-{i:02d}" for i in range(20)]
+        assert len(catalog) <= _NOUS_FEATURED_THRESHOLD
+        featured, extras = _build_nous_featured_set(catalog)
+        assert featured == catalog
+        assert extras == []
+
+    def test_large_catalog_is_capped_to_target(self):
+        from api.config import _build_nous_featured_set, _NOUS_FEATURED_TARGET
+        catalog = _build_big_catalog()
+        assert len(catalog) > 100, "test fixture should produce a large catalog"
+        featured, extras = _build_nous_featured_set(catalog)
+        assert len(featured) == _NOUS_FEATURED_TARGET, (
+            f"Large catalog should produce exactly _NOUS_FEATURED_TARGET "
+            f"featured entries, got {len(featured)}."
+        )
+        assert len(extras) == len(catalog) - _NOUS_FEATURED_TARGET
+
+    def test_featured_and_extras_are_disjoint_and_complete(self):
+        from api.config import _build_nous_featured_set
+        catalog = _build_big_catalog()
+        featured, extras = _build_nous_featured_set(catalog)
+        assert set(featured) & set(extras) == set(), (
+            "featured and extras must be disjoint — every model belongs to "
+            "exactly one bucket."
+        )
+        assert set(featured) | set(extras) == set(catalog), (
+            "featured ∪ extras must equal the input catalog — no model "
+            "should be silently dropped."
+        )
+
+    def test_priority_vendors_get_picked_first(self):
+        from api.config import _build_nous_featured_set, _NOUS_VENDOR_PRIORITY
+        catalog = _build_big_catalog()
+        featured, _ = _build_nous_featured_set(catalog)
+        # Every priority vendor with ≥1 entry in the catalog must appear in
+        # featured (round-robin guarantee until we hit the slot budget).
+        featured_vendors = {m.split("/", 1)[0] for m in featured}
+        for v in _NOUS_VENDOR_PRIORITY:
+            if v in _BIG_CATALOG_VENDORS:
+                assert v in featured_vendors, (
+                    f"Priority vendor {v!r} missing from featured set — "
+                    f"round-robin guarantee violated."
+                )
+
+    def test_sticky_selection_is_preserved(self):
+        from api.config import _build_nous_featured_set
+        catalog = _build_big_catalog()
+        # Pick a model from a leftover (non-priority) vendor that wouldn't
+        # normally make the featured cut.
+        sticky = "lambda-ai/model-lambda-ai-15"
+        assert sticky in catalog
+        featured, extras = _build_nous_featured_set(catalog, selected_model_id=sticky)
+        assert sticky in featured, (
+            f"Sticky-selected model {sticky!r} must appear in featured — "
+            f"otherwise the user's choice gets orphaned out of the dropdown "
+            f"after a refresh."
+        )
+        assert sticky not in extras
+
+    def test_sticky_selection_handles_at_nous_prefix(self):
+        from api.config import _build_nous_featured_set
+        catalog = _build_big_catalog()
+        # The frontend stores selections as @nous:vendor/model — helper must
+        # strip the prefix to match against the bare-id catalog.
+        sticky_with_prefix = "@nous:lambda-ai/model-lambda-ai-15"
+        bare = "lambda-ai/model-lambda-ai-15"
+        featured, _ = _build_nous_featured_set(catalog, selected_model_id=sticky_with_prefix)
+        assert bare in featured
+
+    def test_curated_static_flagships_are_preserved(self):
+        from api.config import _build_nous_featured_set, _PROVIDER_MODELS
+        # Build a catalog that contains all the curated static IDs so the
+        # rule-2 path fires.
+        static_ids = []
+        for entry in _PROVIDER_MODELS.get("nous", []):
+            sid = entry["id"]
+            if sid.startswith("@nous:"):
+                sid = sid[len("@nous:"):]
+            static_ids.append(sid)
+        catalog = static_ids + [f"filler-vendor/filler-{i:03d}" for i in range(100)]
+        featured, _ = _build_nous_featured_set(catalog)
+        for sid in static_ids:
+            assert sid in featured, (
+                f"Curated static flagship {sid!r} dropped from featured set."
+            )
+
+    def test_empty_catalog_returns_empty(self):
+        from api.config import _build_nous_featured_set
+        f, e = _build_nous_featured_set([])
+        assert f == [] and e == []
+
+    def test_deterministic_across_calls(self):
+        from api.config import _build_nous_featured_set
+        catalog = _build_big_catalog()
+        f1, e1 = _build_nous_featured_set(catalog)
+        f2, e2 = _build_nous_featured_set(catalog)
+        assert f1 == f2 and e1 == e2, (
+            "Featured set must be deterministic — random/seeded selection "
+            "would cause cache thrash and dropdown flicker on every reload."
+        )
+
+
+# ────────────────────────────────────────────────────────────────────────
+# Section 2 — End-to-end /api/models behaviour with the cap applied
+# ────────────────────────────────────────────────────────────────────────
+
+
+class TestApiModelsLargeCatalog:
+    """Wired-up test exercising the dispatch branch at config.py:2243."""
+
+    def test_picker_caps_large_catalog_and_exposes_extras(self, monkeypatch, tmp_path):
+        _scrub_provider_env(monkeypatch)
+        catalog = _build_big_catalog()
+        _install_fake_hermes_cli(monkeypatch, nous_ids=catalog)
+        monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
+
+        restore = _swap_in_test_config({"model": {"provider": "nous"}})
+        try:
+            data = config.get_available_models()
+            nous_groups = [g for g in data["groups"] if g["provider_id"] == "nous"]
+            assert len(nous_groups) == 1
+            grp = nous_groups[0]
+            from api.config import _NOUS_FEATURED_TARGET
+            assert len(grp["models"]) == _NOUS_FEATURED_TARGET, (
+                f"Picker should render {_NOUS_FEATURED_TARGET} featured entries "
+                f"on a {len(catalog)}-model catalog, got {len(grp['models'])}."
+            )
+            assert "extra_models" in grp, (
+                "Capped Nous group must include 'extra_models' so /model "
+                "autocomplete and the label map cover the full catalog."
+            )
+            assert len(grp["extra_models"]) == len(catalog) - _NOUS_FEATURED_TARGET
+            # Optgroup label is decorated with the truncation count so the user
+            # knows the dropdown is intentionally trimmed.
+            assert f"{_NOUS_FEATURED_TARGET} of {len(catalog)}" in grp["provider"], (
+                f"Provider label should include '({_NOUS_FEATURED_TARGET} of "
+                f"{len(catalog)})' for capped catalogs, got {grp['provider']!r}."
+            )
+        finally:
+            restore()
+
+    def test_picker_does_not_cap_small_catalog(self, monkeypatch, tmp_path):
+        _scrub_provider_env(monkeypatch)
+        # 20 models — below threshold, should pass through with no extras.
+        small_catalog = [f"vendor-{i % 4}/model-{i:02d}" for i in range(20)]
+        _install_fake_hermes_cli(monkeypatch, nous_ids=small_catalog)
+        monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
+
+        restore = _swap_in_test_config({"model": {"provider": "nous"}})
+        try:
+            data = config.get_available_models()
+            grp = next(g for g in data["groups"] if g["provider_id"] == "nous")
+            assert len(grp["models"]) == 20
+            assert "extra_models" not in grp or grp["extra_models"] == []
+            assert "of " not in grp["provider"], (
+                "Optgroup label should NOT include a truncation count when no "
+                "trimming happened, got " + repr(grp["provider"])
+            )
+        finally:
+            restore()
+
+
+# ────────────────────────────────────────────────────────────────────────
+# Section 3 — Auth-detection symmetry (#1567 part 1)
+# ────────────────────────────────────────────────────────────────────────
+
+
+class TestNousDetectionSymmetry:
+    """The picker must include Nous whenever the providers card would —
+    fixes the asymmetric-detection bug at the heart of #1567."""
+
+    def test_picker_includes_nous_when_get_auth_status_logged_in(self, monkeypatch, tmp_path):
+        """list_available_providers() reports authenticated=False but
+        get_auth_status('nous').logged_in=True. Picker must still show Nous."""
+        _scrub_provider_env(monkeypatch)
+        catalog = ["anthropic/claude-opus-4.7", "openai/gpt-5.5"]
+        _install_fake_hermes_cli(
+            monkeypatch,
+            nous_ids=catalog,
+            list_authenticated=False,  # primary detection path says NO
+            auth_status_logged_in=True,  # secondary detection path says YES
+        )
+        monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
+
+        restore = _swap_in_test_config({"model": {"provider": "nous"}})
+        try:
+            data = config.get_available_models()
+            nous_groups = [g for g in data["groups"] if g["provider_id"] == "nous"]
+            assert nous_groups, (
+                "Picker must include Nous group when get_auth_status reports "
+                "logged_in=True, even if list_available_providers disagrees. "
+                "This is the asymmetric-detection bug from #1567."
+            )
+            assert len(nous_groups[0]["models"]) == 2
+        finally:
+            restore()
+
+    def test_picker_omits_nous_when_both_auth_signals_false(self, monkeypatch, tmp_path):
+        """When neither signal reports authenticated, Nous should NOT appear.
+        Previously the static 4-entry list could leak in via the fallback path
+        even for unauthenticated users — that fallback is now scoped to the
+        hermes_cli-unavailable case only."""
+        _scrub_provider_env(monkeypatch)
+        _install_fake_hermes_cli(
+            monkeypatch,
+            nous_ids=[],  # no live catalog (also no auth)
+            list_authenticated=False,
+            auth_status_logged_in=False,
+        )
+        monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
+
+        restore = _swap_in_test_config({"model": {"provider": "anthropic"}})
+        try:
+            # Active provider is anthropic, not nous — so detected_providers
+            # only includes nous if the new auth-symmetry check fires.
+            data = config.get_available_models()
+            nous_groups = [g for g in data["groups"] if g["provider_id"] == "nous"]
+            assert not nous_groups, (
+                "Nous must NOT appear in picker when neither auth signal "
+                "reports authenticated. Got: " + str(nous_groups)
+            )
+        finally:
+            restore()
+
+
+# ────────────────────────────────────────────────────────────────────────
+# Section 4 — Live-fetch-empty handling (#1567 part 2)
+# ────────────────────────────────────────────────────────────────────────
+
+
+class TestNousLiveFetchEmpty:
+    """When authenticated but live-fetch returns [] (transient hermes_cli
+    state, OAuth refresh in flight), DON'T fall back to the stale 4-entry
+    static list — that creates the providers-card-vs-picker disagreement
+    that #1567 reports. Omit the group entirely instead."""
+
+    def test_authenticated_empty_catalog_omits_nous_group(self, monkeypatch, tmp_path):
+        _scrub_provider_env(monkeypatch)
+        _install_fake_hermes_cli(
+            monkeypatch,
+            nous_ids=[],  # live-fetch returns empty list (no exception)
+            auth_status_logged_in=True,  # but user IS authenticated
+        )
+        monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
+
+        restore = _swap_in_test_config({"model": {"provider": "nous"}})
+        try:
+            data = config.get_available_models()
+            nous_groups = [g for g in data["groups"] if g["provider_id"] == "nous"]
+            assert not nous_groups, (
+                "Authenticated user with empty live-fetch should NOT see "
+                "the stale 4-entry static list — that's exactly the "
+                "providers-card-vs-picker disagreement #1567 reports. "
+                "Omit the Nous group entirely; it'll re-populate on the "
+                "next cache rebuild when the live-fetch returns something."
+            )
+        finally:
+            restore()
+
+    def test_hermes_cli_unavailable_falls_back_to_static_4(self, monkeypatch, tmp_path):
+        """When hermes_cli is unavailable (raises) — distinct from returning [] —
+        we DO fall back to the static 4-entry list so the picker isn't empty
+        in that degraded environment. This preserves pre-#1538 behavior for
+        test envs without hermes_cli."""
+        _scrub_provider_env(monkeypatch)
+        _install_fake_hermes_cli(
+            monkeypatch,
+            raise_on_lookup=True,
+            auth_status_logged_in=True,
+        )
+        monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
+
+        restore = _swap_in_test_config({"model": {"provider": "nous"}})
+        try:
+            data = config.get_available_models()
+            nous_groups = [g for g in data["groups"] if g["provider_id"] == "nous"]
+            assert nous_groups, (
+                "When hermes_cli raises, Nous group MUST still appear with "
+                "the curated static fallback so the picker isn't empty in "
+                "test envs that lack the agent package."
+            )
+            assert len(nous_groups[0]["models"]) == 4, (
+                "Static fallback should expose the curated 4-entry list "
+                "from _PROVIDER_MODELS['nous']."
+            )
+        finally:
+            restore()
+
+
+# ────────────────────────────────────────────────────────────────────────
+# Section 5 — Providers card ↔ picker symmetry
+# ────────────────────────────────────────────────────────────────────────
+
+
+class TestProvidersCardPickerSymmetry:
+    """Both endpoints must report the same featured set + total count for
+    Nous Portal. This is the load-bearing invariant that ends the visual
+    disagreement #1567 reports."""
+
+    def test_providers_card_and_picker_agree_on_featured_set(self, monkeypatch, tmp_path):
+        _scrub_provider_env(monkeypatch)
+        catalog = _build_big_catalog()
+        _install_fake_hermes_cli(monkeypatch, nous_ids=catalog)
+        monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
+
+        restore = _swap_in_test_config({"model": {"provider": "nous"}})
+        try:
+            from api.providers import get_providers
+            from api.config import _NOUS_FEATURED_TARGET
+
+            providers = {p["id"]: p for p in get_providers()["providers"]}
+            picker = config.get_available_models()
+            picker_nous = next(g for g in picker["groups"] if g["provider_id"] == "nous")
+
+            card = providers["nous"]
+            # Both render exactly _NOUS_FEATURED_TARGET visible models.
+            assert len(card["models"]) == _NOUS_FEATURED_TARGET
+            assert len(picker_nous["models"]) == _NOUS_FEATURED_TARGET
+
+            # Both report the full catalog size somewhere.
+            assert card["models_total"] == len(catalog), (
+                f"Providers card models_total should match live catalog size, "
+                f"got {card['models_total']} vs catalog {len(catalog)}."
+            )
+            picker_total = len(picker_nous.get("models", [])) + len(
+                picker_nous.get("extra_models", [])
+            )
+            assert picker_total == len(catalog), (
+                f"Picker featured + extras must equal live catalog size, "
+                f"got {picker_total} vs {len(catalog)}."
+            )
+
+            # And they pick THE SAME featured set (not e.g. one's first-15
+            # and another's last-15).
+            card_ids = [m["id"] for m in card["models"]]
+            picker_ids = [m["id"] for m in picker_nous["models"]]
+            assert card_ids == picker_ids, (
+                f"Providers card and picker must show the SAME featured "
+                f"set so users see consistent labels in both places. "
+                f"Card: {card_ids}\nPicker: {picker_ids}"
+            )
+        finally:
+            restore()
+
+
+# ────────────────────────────────────────────────────────────────────────
+# Section 6 — Frontend contract (static-source assertions)
+# ────────────────────────────────────────────────────────────────────────
+
+
+class TestFrontendExtrasContract:
+    """Pin the JS-side contract: dropdown reads `models`, slash command and
+    label map ALSO read `extra_models`. Without this, a model from the
+    catalog tail gets a bare-ID label or is invisible to /model autocomplete."""
+
+    def test_ui_js_hydrates_dynamic_labels_from_extra_models(self):
+        from pathlib import Path
+        src = (Path(__file__).resolve().parent.parent / "static" / "ui.js").read_text(encoding="utf-8")
+        # Find the populateModelDropdown function and check it consumes
+        # extra_models. Use a windowed substring search so the test stays
+        # robust against minor refactors of surrounding code.
+        idx = src.find("async function populateModelDropdown")
+        assert idx != -1
+        body = src[idx : idx + 3000]
+        assert "extra_models" in body, (
+            "populateModelDropdown must hydrate _dynamicModelLabels from "
+            "g.extra_models so a model selected outside the featured set "
+            "still gets a proper label. Without this, /model audio-lines "
+            "→ 'audio-lines' bare-ID display. (#1567)"
+        )
+
+    def test_commands_js_loads_slash_args_from_extra_models(self):
+        from pathlib import Path
+        src = (Path(__file__).resolve().parent.parent / "static" / "commands.js").read_text(encoding="utf-8")
+        idx = src.find("async function _loadSlashModelSubArgs")
+        assert idx != -1
+        body = src[idx : idx + 1500]
+        assert "extra_models" in body, (
+            "_loadSlashModelSubArgs must iterate group.extra_models so /model "
+            "autocomplete covers the full catalog, not just the dropdown's "
+            "featured subset. The slash command exists precisely so power "
+            "users can reach any model by typing its name. (#1567)"
+        )
+
+    def test_panels_js_uses_models_total_for_count(self):
+        from pathlib import Path
+        src = (Path(__file__).resolve().parent.parent / "static" / "panels.js").read_text(encoding="utf-8")
+        idx = src.find("function _buildProviderCard")
+        assert idx != -1
+        body = src[idx : idx + 1500]
+        assert "models_total" in body, (
+            "Provider card header should use p.models_total (full catalog "
+            "size) for the count, not p.models.length (which is now the "
+            "trimmed featured-set size). Without this, the header text says "
+            "'15 models' instead of '396 models' for capped catalogs. (#1567)"
+        )
+
+    def test_panels_js_renders_more_disclosure_pill(self):
+        from pathlib import Path
+        src = (Path(__file__).resolve().parent.parent / "static" / "panels.js").read_text(encoding="utf-8")
+        # The "+N more" disclosure must reference the difference between
+        # rendered count and total count somewhere in the providers-card
+        # rendering path.
+        assert "provider-card-model-tag-more" in src, (
+            "Provider card must render a '+N more' disclosure pill when "
+            "len(models) < models_total, so users know the dropdown is "
+            "intentionally capped and the rest is reachable via /model."
+        )


### PR DESCRIPTION
# fix(picker): Nous Portal featured-set cap + endpoint symmetry

Closes #1567 — reported by Deor in Discord (May 03 2026 14:15 PT, relayed by @AvidFuturist).

## Two related bugs in one PR

### #1567 — Endpoint disagreement (the bug)

The Settings → Providers card showed `"Nous Portal — 396 models · OAuth"` while the in-conversation model picker dropdown listed only the four hardcoded curated entries (Claude Opus 4.6, Claude Sonnet 4.6, GPT-5.4 Mini, Gemini 3.1 Pro Preview).

**Two structural causes:**

1. **Asymmetric auth detection.** `api/providers.py:get_providers` iterates ALL OAuth providers regardless of authentication state and unconditionally live-fetches the catalog. `api/config.py:_build_available_models_uncached` only iterates providers in `detected_providers`, gated on `hermes_cli.models.list_available_providers().authenticated`. That flag can disagree with `hermes_cli.auth.get_auth_status(<id>).logged_in` on some hermes_cli versions — they're computed via different code paths in the agent. When the disagreement happens for Nous, the picker silently falls through to the curated 4-entry static list while the providers card keeps showing the live catalog.

2. **Stale-fallback poisoning.** The Nous live-fetch branch fell back to the same curated 4-entry static list when `provider_model_ids("nous")` returned an empty list (transient hermes_cli failure, OAuth refresh in flight, cache miss). This actively contradicts the providers card instead of self-healing.

### UX cap (the design concern flagged on triage)

Even with the disagreement fixed, dumping a 397-model catalog into a flat dropdown is unusable. We trim the visible picker to a curated ~15-entry featured set when the catalog exceeds 25 models, and surface the rest under a new `extra_models` field so power users still reach everything via the slash command.

## Fix design

### Featured selection rules (deterministic)

Same algorithm runs in both `/api/models` and `/api/models/live` so background enrichment via `_fetchLiveModels()` doesn't undo the trim:

1. **Sticky selection.** Always include the user's currently-selected model (no orphan IDs in the dropdown after a refresh).
2. **Curated flagships.** Always include every entry from the curated static `_PROVIDER_MODELS["nous"]` list whose id maps onto a live id.
3. **Vendor round-robin.** Top up to 15 by walking `_NOUS_VENDOR_PRIORITY` round-robin (one model per vendor each pass) so no vendor monopolises the slot budget. Within a vendor, original `live_ids` order preserved (approximates Nous Portal's recency ordering).

### Disclosure pattern

- **Optgroup label** in the dropdown: `"Nous Portal (15 of 397)"` so the user knows it's intentionally trimmed
- **`extra_models` field** on the API: catalog tail returned alongside `models`
- **`/model` slash command** consumes both: full-catalog autocomplete
- **`_dynamicModelLabels` map** hydrates from both: a model selected outside the featured slice still renders with its proper label
- **Providers card** uses new `models_total` field for header text (`"397 models · OAuth"`) and renders a small `+N more` disclosure pill at the end of the rendered pill list (only fires for non-OAuth providers — OAuth cards never expand pills)

### Live-fetch-empty path

When authenticated AND live-fetch returns `[]` (no exception, just empty), **omit the Nous group entirely** rather than falling back to stale-4. The providers card already tells the truth, and the next cache rebuild will heal the picker. Keep the static fallback only when `hermes_cli` is unavailable / raises (test envs, package mismatches).

### Detection symmetry

Add an explicit `get_auth_status("nous").logged_in` check after the existing `list_available_providers()` loop in `_build_available_models_uncached`. Belt-and-braces — the picker now includes Nous whenever the providers card would.

## Files

| File | Change |
|---|---|
| `api/config.py` | New `_build_nous_featured_set()` + 3 module constants; rewritten Nous branch with featured cap, symmetric detection, smarter empty-fetch handling |
| `api/providers.py` | Featured cap + new `models_total` field |
| `api/routes.py` | `/api/models/live` applies same featured cap so background backfill doesn't undo dropdown trim |
| `static/ui.js` | `populateModelDropdown` hydrates `_dynamicModelLabels` from `extra_models` |
| `static/commands.js` | `_loadSlashModelSubArgs` iterates `extra_models` so /model autocomplete covers full catalog |
| `static/panels.js` | Header count uses `models_total`; trailing "+N more" disclosure pill |
| `static/style.css` | `.provider-card-model-tag-more` rule (italic, dashed border, no select) |

## Tests

20 new tests in `tests/test_issue1567_nous_picker_capacity_and_symmetry.py`:

- `TestBuildNousFeaturedSet` (8): unit tests on the selection helper — small-catalog no-op, large-catalog cap to target, disjoint+complete invariants, priority-vendor round-robin guarantee, sticky selection with/without `@nous:` prefix, curated-flagship preservation, empty handling, determinism
- `TestApiModelsLargeCatalog` (2): end-to-end cap behavior on a synthetic 397-model catalog vs a 20-model catalog
- `TestNousDetectionSymmetry` (2): picker includes Nous when `get_auth_status` agrees but `list_available_providers` disagrees; picker omits Nous when both disagree
- `TestNousLiveFetchEmpty` (2): authenticated+empty-fetch omits the group; hermes_cli unavailable still falls back to static-4
- `TestProvidersCardPickerSymmetry` (1): both endpoints return the same featured-set IDs + total catalog count
- `TestFrontendExtrasContract` (4): static-source assertions pinning the JS contracts for `extra_models`, `models_total`, and the disclosure pill

## Verification

**4073 pytest passed** (was 4053 → 4073, +20 from this PR), 2 skipped, 3 xpassed, 0 failures.

**Live on port 8789** (30-model Nous catalog):

```
$ curl -s http://127.0.0.1:8789/api/models | jq '.groups[] | select(.provider_id=="nous") | {provider, model_count: (.models | length), extras: (.extra_models | length)}'
{ "provider": "Nous Portal (15 of 30)", "model_count": 15, "extras": 15 }

$ curl -s http://127.0.0.1:8789/api/providers | jq '.providers[] | select(.id=="nous") | {models_total, model_count: (.models | length)}'
{ "models_total": 30, "model_count": 15 }
```

Browser:
```js
> document.getElementById('modelSelect').options.length
15
> Object.keys(_dynamicModelLabels).length
30  // 15 featured + 15 extras — full catalog still labeled
```

Sticky selection works: with `model: "@nous:anthropic/claude-opus-4.7"` configured, Claude Opus 4.7 sits at index 4 in the featured slice (rule 1 — pinned in even though it would have lost the round-robin budget to Sonnet 4.6 + Sonnet 4.5 etc. in tied position).

## Reporter

Deor (Discord #report-bugs, May 03 2026 14:15 PT). Relayed by @AvidFuturist.
