### PR TITLE
style(sidebar): add missing .session-branch-indicator CSS rule

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -2430,6 +2430,25 @@ main.main.showing-profiles > #mainProfiles{display:flex;}
 }
 .session-pin-indicator svg{width:10px;height:10px;}
 
+/* ── Session branch indicator (fork/branch, for branched sessions #465) ── */
+.session-branch-indicator{
+  flex-shrink:0;
+  color:var(--accent);
+  font-size:11px;
+  font-weight:600;
+  line-height:1;
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  margin:0 2px;
+  cursor:pointer;
+  user-select:none;
+  transition:opacity 0.2s;
+}
+.session-branch-indicator:hover{
+  opacity:0.7;
+}
+
 /* ── Cron alert badge ── */
 .cron-badge{position:absolute;top:2px;right:2px;background:#e53e3e;color:#fff;font-size:9px;font-weight:700;min-width:14px;height:14px;line-height:14px;text-align:center;border-radius:7px;padding:0 3px;}
 .cron-new-dot{width:7px;height:7px;border-radius:50%;background:var(--success,#22c55e);flex-shrink:0;animation:cron-dot-pulse 2s ease-in-out infinite;}


### PR DESCRIPTION
## Summary

The sidebar session **branch indicator** uses the `.session-branch-indicator` class in `static/sessions.js`, but the stylesheet has no matching rule. As a result the element falls back to generic sidebar-text styling, which causes:

- **No `flex-shrink` guard** — the indicator collapses when session names are long and pushes against the pin indicator beside it.
- **Inherited default text color** — indistinguishable from the session title on dark themes.
- **No font-size/weight tuning** — renders at body size next to smaller metadata text.
- **No cursor/hover affordance** — even though the click handler navigates to the parent session, the element gives no visual hint that it is interactive.

The recent upstream commit `dc7b142` ("fix: use correct Unicode codepoint for branch indicator") correctly swapped the glyph to `\u2442` (⑂, OCR FORK) but did not add the missing CSS rule.

## Change

Add a `.session-branch-indicator` rule block in `static/style.css`, mirroring the conventions of the adjacent `.session-pin-indicator`:

```css
.session-branch-indicator{
  flex-shrink:0;
  color:var(--accent);
  font-size:11px;
  font-weight:600;
  line-height:1;
  display:inline-flex;
  align-items:center;
  justify-content:center;
  margin:0 2px;
  cursor:pointer;
  user-select:none;
  transition:opacity 0.2s;
}
.session-branch-indicator:hover{
  opacity:0.7;
}
```

## Test plan

- [x] Manual: create a branched session, verify the indicator renders in the sidebar with the accent color.
- [x] Manual: hover + click still navigates to the parent session.
- [x] Existing tests (`tests/test_465_session_branching.py`) unchanged and still pass.

## Risk

Trivial. 19 lines of CSS, no JS/behavior change.

## Related

Feature #465 (parent session forking) — the class was defined in JS but never styled.
