### PR TITLE
Filter low-value CLI agent sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Hermes Web UI -- Changelog
 
+## Unreleased
+
+### Fixed
+
+- **Show Agent Sessions: keep CLI imports meaningful and conservative** — source-normalized CLI sessions are now filtered before sidebar display so empty/default one-off CLI rows no longer flood the session list, while titled sessions and compression-lineage sessions remain visible. CLI-origin session menus now use the same conservative external-session action set as messaging imports: pin, move, and archive remain available, while duplicate/delete are hidden to avoid implying WebUI owns the original Hermes Agent CLI history. This is the CLI-focused follow-up slice for #1013 after the messaging-channel handoff work.
+
 ## [v0.50.297] — 2026-05-04
 
 ### Fixed (3 PRs — closes #1658; refs #1458, #1652)
@@ -48,7 +54,6 @@
 ### Note on closed-as-superseded
 
 PR #1656 (also @Michaelyklam) was closed as superseded by #1657. Both target #1458 Bug #3, both add accept-loop heartbeat + `/health?deep=1` + 503-on-degraded. #1657 adds beyond #1656: state.db connectivity check, projects state check, FD soft-limit raise, and `docs/supervisor.md` watchdog recipe. Same author iterated; the second PR was the keeper.
-
 ## [v0.50.296] — 2026-05-04
 
 ### Fixed (3 PRs — closes #1406, #1617; refs #1362)
@@ -313,7 +318,6 @@ Two stale source-string assertions were broken by #1591's compact() and messages
 - **PR rebase verified** (REBASE-DEFAULT rule): #1586/#1590/#1591/#1592 all on current master (bf7bc6b4 = v0.50.289), zero commits behind. #1464 was 124 commits behind (forked at v0.50.275); rebased cleanly onto master.
 - **Auto-fix on #1464:** ternary inversion + regression test, with `Co-authored-by: Josh Jameson` preserved.
 - **Auto-fix on stage:** widened source-string anchors in two pre-existing brittle tests broken by #1591's structural changes.
-
 
 ## [v0.50.289] — 2026-05-03
 

--- a/api/agent_sessions.py
+++ b/api/agent_sessions.py
@@ -14,6 +14,9 @@ MESSAGING_SOURCES = {
     'weixin',
 }
 
+CLI_MIN_UNTITLED_MESSAGE_COUNT = 6
+CLI_MIN_UNTITLED_USER_MESSAGE_COUNT = 2
+
 SOURCE_LABELS = {
     'api_server': 'API',
     'cli': 'CLI',
@@ -69,6 +72,115 @@ def _with_normalized_source(row: dict) -> dict:
 
 def _optional_col(name: str, columns: set[str], fallback: str = "NULL") -> str:
     return f"s.{name}" if name in columns else f"{fallback} AS {name}"
+
+
+def _safe_lower(value) -> str:
+    return str(value or "").strip().lower()
+
+
+def _normalize_source_name(value: object) -> str:
+    source = _safe_lower(value)
+    if not source:
+        return ""
+    if source.endswith(" session"):
+        source = source[:-len(" session")].strip()
+    return source
+
+
+def _looks_like_default_cli_title(row: dict) -> bool:
+    """Return True when a CLI row looks like framework-generated metadata."""
+    title = _safe_lower(row.get("title"))
+    if not title or title == "untitled":
+        return True
+    if title in {"cli", "cli session"}:
+        return True
+
+    source_candidates = {
+        _normalize_source_name(row.get("source")),
+        _normalize_source_name(row.get("session_source")),
+        _normalize_source_name(row.get("source_tag")),
+        _normalize_source_name(row.get("raw_source")),
+        _normalize_source_name(row.get("source_label")),
+    }
+    source_candidates.discard("")
+    source_candidates.add("cli")
+    return any(title == f"{candidate} session" for candidate in source_candidates)
+
+
+def _as_positive_int(value) -> int:
+    try:
+        return max(0, int(float(value)))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _count_user_turns(row: dict) -> int:
+    user_turns = row.get("actual_user_message_count")
+    if user_turns is None:
+        user_turns = row.get("user_message_count")
+    if user_turns is None:
+        messages = row.get("messages") or []
+        if isinstance(messages, list):
+            return sum(
+                1
+                for msg in messages
+                if _safe_lower(msg.get("role") if isinstance(msg, dict) else msg) == "user"
+            )
+        return 0
+    return _as_positive_int(user_turns)
+
+
+def _has_cli_lineage(row: dict) -> bool:
+    segment_count = _as_positive_int(row.get("_compression_segment_count"))
+    return segment_count > 1 or bool(row.get("_lineage_root_id"))
+
+
+def is_cli_session_row(row: dict) -> bool:
+    """Return True for rows that should be treated as CLI-imported sessions."""
+    if not isinstance(row, dict):
+        return False
+    source = _safe_lower(row.get("session_source"))
+    if source == "messaging":
+        return False
+    if source == "cli":
+        return True
+    source_tag = _safe_lower(row.get("source_tag"))
+    raw_source = _safe_lower(row.get("raw_source"))
+    source_name = _safe_lower(row.get("source"))
+    source_label = _safe_lower(row.get("source_label"))
+    if source_tag == "cli" or raw_source == "cli" or source_name == "cli" or source_label == "cli":
+        return True
+
+    # Legacy imported CLI rows may only be marked as CLI in sidebar metadata.
+    # Keep this conservative to avoid treating messaging sessions as CLI.
+    return bool(
+        row.get("is_cli_session")
+        and source not in MESSAGING_SOURCES
+        and source_tag not in MESSAGING_SOURCES
+        and raw_source not in MESSAGING_SOURCES
+        and source_name not in MESSAGING_SOURCES
+        and _looks_like_default_cli_title(row)
+    )
+
+
+def is_cli_session_row_visible(row: dict) -> bool:
+    """Return whether a CLI-related row should remain visible in the sidebar."""
+    if not isinstance(row, dict):
+        return False
+    if not is_cli_session_row(row):
+        return True
+
+    message_count = _as_positive_int(row.get("actual_message_count") or row.get("message_count"))
+    if message_count <= 0:
+        return False
+
+    if _has_cli_lineage(row):
+        return True
+
+    if not _looks_like_default_cli_title(row):
+        return True
+
+    return _count_user_turns(row) >= CLI_MIN_UNTITLED_USER_MESSAGE_COUNT
 
 
 def _is_continuation_session(parent: dict | None, child: dict | None) -> bool:
@@ -301,6 +413,7 @@ def read_importable_agent_session_rows(
                    {ended_expr},
                    {end_reason_expr},
                    COUNT(m.id) AS actual_message_count,
+                   COUNT(CASE WHEN LOWER(m.role) = 'user' THEN 1 END) AS actual_user_message_count,
                    MAX(m.timestamp) AS last_activity
             FROM sessions s
             LEFT JOIN messages m ON m.session_id = s.id
@@ -312,6 +425,7 @@ def read_importable_agent_session_rows(
         )
         projected = _project_agent_session_rows([dict(row) for row in cur.fetchall()])
         projected = [_with_normalized_source(row) for row in projected]
+        projected = [row for row in projected if is_cli_session_row_visible(row)]
         if limit is None:
             return projected
         return projected[:max(0, int(limit))]

--- a/api/agent_sessions.py
+++ b/api/agent_sessions.py
@@ -313,7 +313,7 @@ def _project_agent_session_rows(rows: list[dict]) -> list[dict]:
         # touched standalone sessions — exactly the inverse of what a user
         # expects from "Show agent sessions" sorted by activity.
         for key in (
-            'id', 'model', 'message_count', 'actual_message_count',
+            'id', 'model', 'message_count', 'actual_message_count', 'actual_user_message_count',
             'ended_at', 'end_reason', 'last_activity',
         ):
             if key in tip:
@@ -367,6 +367,8 @@ def read_importable_agent_session_rows(
         # source column we cannot safely distinguish WebUI rows from agent rows.
         cur.execute("PRAGMA table_info(sessions)")
         session_cols = {row[1] for row in cur.fetchall()}
+        cur.execute("PRAGMA table_info(messages)")
+        message_cols = {row[1] for row in cur.fetchall()}
         if 'source' not in session_cols:
             log.warning(
                 "agent session listing skipped: state.db at %s has no 'source' column "
@@ -387,6 +389,11 @@ def read_importable_agent_session_rows(
         origin_chat_id_expr = _optional_col('origin_chat_id', session_cols)
         origin_user_id_expr = _optional_col('origin_user_id', session_cols)
         platform_expr = _optional_col('platform', session_cols)
+        user_message_count_expr = (
+            "COUNT(CASE WHEN LOWER(m.role) = 'user' THEN 1 END)"
+            if 'role' in message_cols
+            else "COUNT(m.id)"
+        )
 
         where_clauses = ["s.source IS NOT NULL"]
         params: list[str] = []
@@ -413,7 +420,7 @@ def read_importable_agent_session_rows(
                    {ended_expr},
                    {end_reason_expr},
                    COUNT(m.id) AS actual_message_count,
-                   COUNT(CASE WHEN LOWER(m.role) = 'user' THEN 1 END) AS actual_user_message_count,
+                   {user_message_count_expr} AS actual_user_message_count,
                    MAX(m.timestamp) AS last_activity
             FROM sessions s
             LEFT JOIN messages m ON m.session_id = s.id

--- a/api/models.py
+++ b/api/models.py
@@ -224,6 +224,12 @@ def _last_message_timestamp(messages):
     return None
 
 
+def _message_role(message):
+    if not isinstance(message, dict):
+        return ''
+    return str(message.get('role', '')).strip().lower()
+
+
 def _find_top_level_json_key(text, key):
     """Return the byte offset of a top-level JSON object key, if present."""
     depth = 0
@@ -536,11 +542,6 @@ class Session:
         last_message_at = _last_message_timestamp(self.messages) or self.updated_at
         if has_pending_user_message and self.pending_started_at:
             last_message_at = self.pending_started_at
-
-        def _role(message):
-            if not isinstance(message, dict):
-                return ""
-            return str(message.get('role', '')).strip().lower()
         return {
             'session_id': self.session_id,
             'title': self.title,
@@ -558,9 +559,6 @@ class Session:
             'input_tokens': self.input_tokens,
             'output_tokens': self.output_tokens,
             'estimated_cost': self.estimated_cost,
-            'user_message_count': sum(
-                1 for message in self.messages if _role(message) == 'user'
-            ) if isinstance(self.messages, list) else 0,
             'personality': self.personality,
             'compression_anchor_visible_idx': self.compression_anchor_visible_idx,
             'compression_anchor_message_key': self.compression_anchor_message_key,
@@ -570,6 +568,9 @@ class Session:
             # Only emit 'parent_session_id' when set (the /branch fork link, #1342).
             # Sessions without a fork must not leak None — see test_session_lineage_metadata_api.
             **({'parent_session_id': self.parent_session_id} if self.parent_session_id else {}),
+            'user_message_count': sum(
+                1 for message in self.messages if _message_role(message) == 'user'
+            ) if isinstance(self.messages, list) else 0,
             'active_stream_id': self.active_stream_id,
             'pending_user_message': self.pending_user_message,
             'has_pending_user_message': has_pending_user_message,

--- a/api/models.py
+++ b/api/models.py
@@ -19,6 +19,7 @@ from api.workspace import get_last_workspace
 from api.agent_sessions import read_importable_agent_session_rows, read_session_lineage_metadata
 
 logger = logging.getLogger(__name__)
+CLI_VISIBLE_SESSION_LIMIT = 20
 
 # ---------------------------------------------------------------------------
 # Stale temp-file cleanup
@@ -535,6 +536,11 @@ class Session:
         last_message_at = _last_message_timestamp(self.messages) or self.updated_at
         if has_pending_user_message and self.pending_started_at:
             last_message_at = self.pending_started_at
+
+        def _role(message):
+            if not isinstance(message, dict):
+                return ""
+            return str(message.get('role', '')).strip().lower()
         return {
             'session_id': self.session_id,
             'title': self.title,
@@ -552,6 +558,9 @@ class Session:
             'input_tokens': self.input_tokens,
             'output_tokens': self.output_tokens,
             'estimated_cost': self.estimated_cost,
+            'user_message_count': sum(
+                1 for message in self.messages if _role(message) == 'user'
+            ) if isinstance(self.messages, list) else 0,
             'personality': self.personality,
             'compression_anchor_visible_idx': self.compression_anchor_visible_idx,
             'compression_anchor_message_key': self.compression_anchor_message_key,
@@ -1277,7 +1286,12 @@ def get_cli_sessions() -> list:
         return _cron_pid_cache[0]
 
     try:
-        for row in read_importable_agent_session_rows(db_path, limit=200, log=logger, exclude_sources=None):
+        for row in read_importable_agent_session_rows(
+            db_path,
+            limit=CLI_VISIBLE_SESSION_LIMIT,
+            log=logger,
+            exclude_sources=None,
+        ):
             sid = row['id']
             raw_ts = row['last_activity'] or row['started_at']
             # Prefer the CLI session's own profile from the DB; fall back to
@@ -1343,6 +1357,7 @@ def get_cli_sessions() -> list:
                 '_parent_lineage_root_id': row.get('_parent_lineage_root_id'),
                 'end_reason': row.get('end_reason'),
                 'actual_message_count': row.get('actual_message_count'),
+                'user_message_count': row.get('actual_user_message_count'),
                 '_lineage_root_id': row.get('_lineage_root_id'),
                 '_lineage_tip_id': row.get('_lineage_tip_id'),
                 '_compression_segment_count': row.get('_compression_segment_count'),

--- a/api/routes.py
+++ b/api/routes.py
@@ -22,7 +22,11 @@ import re
 from pathlib import Path
 from contextlib import closing
 from urllib.parse import parse_qs
-from api.agent_sessions import MESSAGING_SOURCES
+from api.agent_sessions import (
+    MESSAGING_SOURCES,
+    is_cli_session_row,
+    is_cli_session_row_visible,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -1118,6 +1122,44 @@ def _session_sort_timestamp(session: dict) -> float:
     ) or 0.0
 
 
+def _is_cli_session_for_settings(session: dict) -> bool:
+    """Return True for importable CLI sessions that are safe to classify for settings."""
+    if not isinstance(session, dict):
+        return False
+    if is_cli_session_row(session):
+        return True
+
+    # Fallback for legacy local copies that had weak/empty metadata:
+    # keep this conservative so messaging sessions do not collapse incorrectly.
+    if not session.get("is_cli_session"):
+        return False
+    source = str(session.get("source") or "").strip().lower()
+    if source in MESSAGING_SOURCES:
+        return False
+    title = str(session.get("title") or "").strip().lower()
+    return title in ("", "untitled", "cli", "cli session") or title.endswith(" session") and (
+        not source or source == "cli"
+    )
+
+
+CLI_VISIBLE_SESSION_CAP = 20
+
+
+def _cap_recent_cli_sessions(sessions: list[dict], cli_cap: int = CLI_VISIBLE_SESSION_CAP) -> list[dict]:
+    """Keep only the most recent CLI-visible sessions after filtering."""
+    if cli_cap <= 0:
+        return sessions
+    kept = []
+    cli_seen = 0
+    for session in sessions:
+        if _is_cli_session_for_settings(session):
+            cli_seen += 1
+            if cli_seen > cli_cap:
+                continue
+        kept.append(session)
+    return kept
+
+
 def _merge_cli_sidebar_metadata(ui_session: dict, cli_meta: dict) -> dict:
     """Merge source-of-truth CLI metadata into a sidebar session row.
 
@@ -2166,7 +2208,8 @@ def handle_get(handler, parsed) -> bool:
     if parsed.path == "/api/sessions":
         webui_sessions = all_sessions()
         settings = load_settings()
-        if settings.get("show_cli_sessions"):
+        show_cli_sessions = bool(settings.get("show_cli_sessions"))
+        if show_cli_sessions:
             cli = get_cli_sessions()
             cli_by_id = {s["session_id"]: s for s in cli}
             for s in webui_sessions:
@@ -2181,12 +2224,14 @@ def handle_get(handler, parsed) -> bool:
                     for key in ("source_tag", "raw_source", "session_source", "source_label"):
                         if not s.get(key) and meta.get(key):
                             s[key] = meta[key]
+            # Apply the same CLI visibility semantics to imported local copies so
+            # low-value imported artifacts do not leak into the sidebar.
+            webui_sessions = [s for s in webui_sessions if is_cli_session_row_visible(s)]
             webui_ids = {s["session_id"] for s in webui_sessions}
             from api.models import _hide_from_default_sidebar as _cron_hide
-            deduped_cli = [s for s in cli
-                           if s["session_id"] not in webui_ids
-                           and not _cron_hide(s)]
+            deduped_cli = [s for s in cli if s["session_id"] not in webui_ids and is_cli_session_row_visible(s) and not _cron_hide(s)]
         else:
+            webui_sessions = [s for s in webui_sessions if not _is_cli_session_for_settings(s)]
             deduped_cli = []
         merged = webui_sessions + deduped_cli
         merged.sort(
@@ -2218,6 +2263,8 @@ def handle_get(handler, parsed) -> bool:
                       if _profiles_match(s.get("profile"), active_profile)]
             other_profile_count = len(merged) - len(scoped)
         scoped = _keep_latest_messaging_session_per_source(scoped)
+        if show_cli_sessions:
+            scoped = _cap_recent_cli_sessions(scoped, cli_cap=CLI_VISIBLE_SESSION_CAP)
         safe_merged = []
         for s in scoped:
             item = dict(s)

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -576,6 +576,24 @@ function _isMessagingSession(session) {
   return _MESSAGING_RAW_SOURCES.has(raw);
 }
 
+function _isCliSession(session) {
+  if (!session) return false;
+  // session_source is set by upstream normalization for CLI sessions as 'cli'
+  if (session.session_source === 'cli') return true;
+  // Legacy payloads often use raw/source tags to convey the source.
+  const raw = (
+    session.raw_source
+    || session.source_tag
+    || session.source
+    || session.source_label
+    || ''
+  ).toLowerCase();
+  if (raw === 'cli') return true;
+  // If messaging-like, don't classify as legacy CLI even when is_cli_session is true.
+  if (_isMessagingSession(session)) return false;
+  return session.is_cli_session === true;
+}
+
 function _normalizeMessageForCliImportComparison(message) {
   if (!message || typeof message !== 'object') return message;
   const clone = { ...message };
@@ -1262,6 +1280,8 @@ function _openSessionActionMenu(session, anchorEl){
   }
   closeSessionActionMenu();
   const isMessagingSession = _isMessagingSession(session);
+  const isCliSession = _isCliSession(session);
+  const isExternalSession = isMessagingSession || isCliSession;
   const menu=document.createElement('div');
   menu.className='session-action-menu open';
   menu.appendChild(_buildSessionAction(
@@ -1304,7 +1324,7 @@ function _openSessionActionMenu(session, anchorEl){
       }catch(err){showToast(t('session_archive_failed')+err.message);}
     }
   ));
-  if(!isMessagingSession){
+  if(!isExternalSession){
     _appendSessionDuplicateAction(menu, session);
   }
   if(session.active_stream_id){
@@ -1319,7 +1339,7 @@ function _openSessionActionMenu(session, anchorEl){
       }
     ));
   }
-  if(!isMessagingSession){
+  if(!isExternalSession){
     menu.appendChild(_buildSessionAction(
       t('session_delete'),
       t('session_delete_desc'),

--- a/tests/test_1466_sidebar_cancel_clarify.py
+++ b/tests/test_1466_sidebar_cancel_clarify.py
@@ -52,3 +52,27 @@ class TestSidebarCancelAction:
         )
         assert "hideClarifyCard(true" in body
         assert "hideApprovalCard(true" in body
+
+    def test_cli_session_helper_identifies_cli_origin(self):
+        """CLI sessions should be treated as external-only for destructive action gating."""
+        body = _function_body(SESSIONS_JS, "_isCliSession", 900)
+        assert "function _isCliSession(session) {" in body
+        assert "session.session_source === 'cli'" in body
+        assert "session.raw_source" in body
+        assert "session.source_tag" in body
+        assert "session.source" in body
+        assert "session.source_label" in body
+        assert "if (_isMessagingSession(session)) return false;" in body
+        assert "return session.is_cli_session === true;" in body
+
+    def test_cli_sessions_hide_duplicate_and_delete_in_action_menu(self):
+        """Session action menu should hide duplicate/delete for CLI-origin sessions."""
+        body = _function_body(SESSIONS_JS, "_openSessionActionMenu", 3600)
+        assert "const isCliSession = _isCliSession(session);" in body
+        assert "const isExternalSession = isMessagingSession || isCliSession;" in body
+        assert "if(!isExternalSession)" in body
+        # duplicate/delete should both be gated by the same external-session check
+        first = body.find("_appendSessionDuplicateAction")
+        second = body.find("t('session_delete')")
+        assert first > 0 and second > 0, "menu actions should still include duplicate/delete nodes"
+        assert first < second, "duplicate action should render before delete action"

--- a/tests/test_cron_session_title.py
+++ b/tests/test_cron_session_title.py
@@ -142,6 +142,16 @@ def test_non_cron_sessions_unaffected(fake_hermes_home):
     _make_state_db(fake_hermes_home / "state.db", [
         ("cron_cd65df6fc1a8_xx", None, "cli"),
     ])
+    # PR #1587 hides one-off default-titled CLI rows. Keep this fixture visible
+    # so the test remains focused on the cron-name guard rather than sidebar
+    # filtering.
+    conn = sqlite3.connect(str(fake_hermes_home / "state.db"))
+    conn.execute(
+        "INSERT INTO messages (session_id, timestamp) VALUES (?, ?)",
+        ("cron_cd65df6fc1a8_xx", 1700000002.0),
+    )
+    conn.commit()
+    conn.close()
 
     sessions = models.get_cli_sessions()
 

--- a/tests/test_gateway_sync.py
+++ b/tests/test_gateway_sync.py
@@ -508,6 +508,51 @@ def test_compression_chain_with_all_empty_segments_is_hidden():
         post('/api/settings', {'show_cli_sessions': False})
 
 
+def test_default_title_cli_compression_chain_is_kept_by_lineage():
+    """Default-titled CLI compression chains are meaningful even with a short tip."""
+    conn = _ensure_state_db()
+    ids_to_remove = ('cli_default_compress_root_001', 'cli_default_compress_tip_001')
+    t0 = time.time() - 430
+    try:
+        _insert_agent_session_row(
+            conn,
+            'cli_default_compress_root_001',
+            source='cli',
+            title='Cli Session',
+            started_at=t0,
+            ended_at=t0 + 100,
+            end_reason='compression',
+            messages=1,
+        )
+        _insert_agent_session_row(
+            conn,
+            'cli_default_compress_tip_001',
+            source='cli',
+            title='Cli Session',
+            started_at=t0 + 101,
+            parent_session_id='cli_default_compress_root_001',
+            messages=1,
+        )
+
+        post('/api/settings', {'show_cli_sessions': True})
+        data, status = get('/api/sessions')
+        assert status == 200
+        ids = {s.get('session_id') for s in data.get('sessions', [])}
+
+        assert 'cli_default_compress_tip_001' in ids
+        assert 'cli_default_compress_root_001' not in ids
+        tip = next(s for s in data.get('sessions', []) if s.get('session_id') == 'cli_default_compress_tip_001')
+        assert tip.get('_compression_segment_count') == 2
+        assert tip.get('_lineage_root_id') == 'cli_default_compress_root_001'
+    finally:
+        try:
+            _remove_test_sessions(conn, *ids_to_remove)
+            conn.close()
+        except Exception:
+            pass
+        post('/api/settings', {'show_cli_sessions': False})
+
+
 def test_non_compression_child_is_not_collapsed_into_parent():
     """Parent/child relationships that are not compression continuations stay flat."""
     conn = _ensure_state_db()


### PR DESCRIPTION
## Thinking Path

- #1013 is about making `Show Agent Sessions` useful rather than noisy.
- The earlier source-normalization and messaging-channel handoff slices made Weixin/Telegram/other channel sessions safer to show.
- CLI sessions have a different product shape: users often do not title them, one-off test runs are common, and WebUI should not imply that it owns the original Hermes Agent CLI history.
- The bug was that WebUI treated every importable CLI row as sidebar-worthy, then exposed full WebUI clone/delete actions once the row appeared.
- This PR keeps meaningful CLI sessions visible while filtering obvious low-value/default one-off rows, and makes CLI-origin menus conservative.

Refs #1013.

## What Changed

- Added source-aware CLI visibility rules for importable agent sessions:
  - hide empty CLI rows
  - hide default/untitled CLI rows with fewer than 2 user turns
  - keep explicitly titled CLI sessions
  - keep compression-lineage CLI sessions, because they represent long-running conversations
- Apply the CLI visible cap after filtering, so low-value rows do not consume the window.
- Preserve the messaging-channel projection that shipped after #1404, so Weixin/Telegram sessions remain deduplicated by their current channel rules.
- Treat true CLI-origin sessions as external/imported sessions in the sidebar action menu:
  - keep pin, move, archive/restore
  - hide duplicate/delete
- Add user-turn counts to compact session payloads so the filtering rule is based on actual user turns instead of raw assistant/tool/internal message count.
- Hardened compatibility with older `messages` table fixtures that do not have a `role` column, so the CLI projection degrades to message-count based filtering instead of failing the whole list.
- Added a short changelog entry for the user-visible behavior change.

## PR2 Cross-check

This PR is intentionally built on top of the messaging-channel handoff work from #1404. It does not reimplement or weaken that layer:

- Messaging sessions still bypass the new CLI visibility filter because `session_source == "messaging"` is explicitly treated as non-CLI.
- Weixin/Telegram dedup still happens through the existing messaging identity projection, so distinct chats stay separate while stale continuation/reset segments remain hidden.
- The #1404 refresh/compaction safeguards remain in place: messaging state.db metadata wins over stale local snapshots, import refresh only extends safe prefixes, and shorter/stale refresh payloads do not overwrite active transcripts.
- CLI compression chains are preserved by this PR's own filter because compression-lineage CLI sessions are treated as meaningful even when their generated title is still `Cli Session`. This is now covered by `test_default_title_cli_compression_chain_is_kept_by_lineage`.

## CLI Compression Boundary

WebUI does not try to distinguish whether a CLI continuation came from auto-compression or a manual `/compress` action. At this layer, both are handled through the same Hermes Agent `state.db` lineage contract: `parent_session_id` plus `end_reason='compression'` or `cli_close`.

When that lineage exists, this PR collapses the chain into one logical sidebar row and points import/navigation at the latest importable tip segment, so the user continues from the current compressed context instead of reopening the stale root segment.

If a future Hermes Agent path creates a compressed continuation without recording that lineage metadata, WebUI cannot infer the chain safely from title/time alone. That would need to be fixed at the Hermes Agent/source-of-truth layer rather than guessed in this sidebar filter.

## Why It Matters

- Opening `Show Agent Sessions` should not flood the sidebar with old one-off CLI experiments.
- Meaningful CLI conversations still remain available for import and continuation.
- The menu now avoids destructive or misleading actions for sessions whose source of truth is outside WebUI.
- This keeps the PR focused on correctness and safety. CLI default-title polish, such as derived display titles, should be handled as a separate follow-up instead of keeping #1013 open indefinitely.

## Verification

- `python -m py_compile api/agent_sessions.py api/models.py api/routes.py tests/test_gateway_sync.py tests/test_session_lineage_collapse.py tests/test_1466_sidebar_cancel_clarify.py tests/test_cron_session_title.py tests/test_465_session_branching.py`
- `node --check static/sessions.js`
- `pytest -q tests/test_gateway_sync.py tests/test_session_lineage_collapse.py tests/test_1466_sidebar_cancel_clarify.py` -> `59 passed`
- `pytest -q tests/test_cron_session_title.py tests/test_465_session_branching.py` -> `26 passed`
- `git diff --check`
- Manual validation on a real local WebUI state:
  - `Weixin Session`: 1 visible
  - `Telegram Session`: 2 visible
  - `Cli Session`: 3 visible
  - CLI-origin menu hides duplicate/delete and keeps conservative actions

## Risks / Follow-ups

- This does not rename or retitle default CLI sessions. Multiple meaningful CLI sessions may still appear as `Cli Session`; a deterministic derived display-title polish can be a separate follow-up.
- This does not implement real-time two-client synchronization between Hermes CLI and WebUI.
- This does not delete or mutate hidden Hermes Agent CLI history; it only changes WebUI sidebar projection.

## Model Used

- OpenAI GPT-5.5 via Codex coordinator.
- OpenAI `gpt-5.3-codex-spark` worker for the focused implementation pass.
