### PR TITLE
fix: hot-apply compact tool activity setting

### DIFF
--- a/static/panels.js
+++ b/static/panels.js
@@ -2932,7 +2932,12 @@ function _schedulePreferencesAutosave(){
 
 async function _autosavePreferencesSettings(payload){
   try{
-    await api('/api/settings',{method:'POST',body:JSON.stringify(payload)});
+    const saved=await api('/api/settings',{method:'POST',body:JSON.stringify(payload)});
+    if(payload&&payload.simplified_tool_calling!==undefined){
+      window._simplifiedToolCalling=(saved&&saved.simplified_tool_calling!==false);
+      if(typeof clearMessageRenderCache==='function') clearMessageRenderCache();
+      if(typeof renderMessages==='function') renderMessages();
+    }
     _settingsPreferencesAutosaveRetryPayload=null;
     _setPreferencesAutosaveStatus('saved');
     // Only clear the global dirty flag and hide the unsaved-changes bar when

--- a/tests/test_ui_tool_call_cleanup.py
+++ b/tests/test_ui_tool_call_cleanup.py
@@ -82,6 +82,19 @@ class TestToolCallGroupingStatic:
             "Settings panel should load and save the simplified_tool_calling setting."
         )
 
+    def test_simplified_tool_calling_autosave_hot_applies_renderer_mode(self):
+        panels = (REPO / "static" / "panels.js").read_text(encoding="utf-8")
+        fn = _function_body(panels, "_autosavePreferencesSettings")
+        assert "window._simplifiedToolCalling" in fn, (
+            "Autosaving Compact tool activity should update the live renderer flag immediately."
+        )
+        assert "clearMessageRenderCache()" in fn, (
+            "Autosaving Compact tool activity should invalidate cached transcript HTML."
+        )
+        assert "renderMessages()" in fn, (
+            "Autosaving Compact tool activity should rebuild the visible transcript without a refresh."
+        )
+
     def test_render_messages_gates_settled_activity_grouping(self):
         fn = _function_body(UI_JS, "renderMessages")
         helper = _function_body(UI_JS, "ensureActivityGroup")


### PR DESCRIPTION
## Thinking Path

- Hermes WebUI settings should take effect in the current tab without requiring a browser refresh.
- Compact tool activity changes the assistant-turn render path, so persisting the checkbox is not enough by itself.
- The autosave preferences path saved `simplified_tool_calling` but did not update the live renderer flag or invalidate cached transcript HTML.
- This PR keeps the fix small: hot-apply only the compact tool activity setting after autosave returns the saved server value.
- Users can toggle compact/verbose activity rendering and immediately see the existing transcript rerender in the selected mode.

## What Changed

- Updated `static/panels.js` so preferences autosave captures the saved settings response.
- When `simplified_tool_calling` is part of the autosaved payload, the open tab now updates `window._simplifiedToolCalling`, clears the message render cache, and rerenders messages immediately.
- Added a focused regression test in `tests/test_ui_tool_call_cleanup.py` proving the autosave path hot-applies the renderer mode.

## Why It Matters

A settings checkbox that silently waits for a refresh feels broken. Compact tool activity is especially noticeable because it changes transcript structure, not just a stored preference. Hot-applying the runtime flag and rerendering keeps settings behavior consistent with user expectations: save/toggle means visible now.

## Verification

```bash
/home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_ui_tool_call_cleanup.py::TestToolCallGroupingStatic::test_simplified_tool_calling_autosave_hot_applies_renderer_mode -q
/home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_ui_tool_call_cleanup.py tests/test_simplified_tool_calling_setting.py tests/test_1003_preferences_autosave.py -q
node --check static/panels.js
git diff --check
```

Result:

```text
1 passed
24 passed
node --check static/panels.js passed
git diff --check passed
```

UI media, if applicable:

- Not attached. This is a tiny interaction-path fix with source-level regression coverage; reviewers may still want a short before/after clip showing the toggle rerendering without refresh.

## Risks / Follow-ups

- This rerenders the visible transcript when the Compact tool activity checkbox autosaves. That is intentional, but active streaming edge cases may need separate live-stream-specific polish if reviewers want toggles to transform in-flight partial rows too.
- Other settings should follow the same persist → update runtime state → invalidate cache → rerender affected UI pattern where applicable.

## Model Used

AI assisted.

- Provider: OpenAI Codex
- Model: `gpt-5.5`
- Notable tool use: Hermes file tools, terminal/git, pytest, node syntax check, GitHub CLI
