### PR TITLE
fix: show first-turn chats in sidebar immediately

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -524,20 +524,27 @@ class Session:
 
     def compact(self, include_runtime=False, active_stream_ids=None) -> dict:
         active_stream_ids = active_stream_ids if active_stream_ids is not None else set()
+        has_pending_user_message = bool(self.pending_user_message)
+        message_count = (
+            self._metadata_message_count
+            if self._metadata_message_count is not None
+            else len(self.messages)
+        )
+        if has_pending_user_message:
+            message_count = max(message_count, 1)
+        last_message_at = _last_message_timestamp(self.messages) or self.updated_at
+        if has_pending_user_message and self.pending_started_at:
+            last_message_at = self.pending_started_at
         return {
             'session_id': self.session_id,
             'title': self.title,
             'workspace': self.workspace,
             'model': self.model,
             'model_provider': self.model_provider,
-            'message_count': (
-                self._metadata_message_count
-                if self._metadata_message_count is not None
-                else len(self.messages)
-            ),
+            'message_count': message_count,
             'created_at': self.created_at,
             'updated_at': self.updated_at,
-            'last_message_at': _last_message_timestamp(self.messages) or self.updated_at,
+            'last_message_at': last_message_at,
             'pinned': self.pinned,
             'archived': self.archived,
             'project_id': self.project_id,
@@ -556,6 +563,7 @@ class Session:
             **({'parent_session_id': self.parent_session_id} if self.parent_session_id else {}),
             'active_stream_id': self.active_stream_id,
             'pending_user_message': self.pending_user_message,
+            'has_pending_user_message': has_pending_user_message,
             'is_cli_session': self.is_cli_session,
             'source_tag': self.source_tag,
             'raw_source': self.raw_source,
@@ -926,6 +934,7 @@ def all_sessions():
                 s.get('title', 'Untitled') == 'Untitled'
                 and s.get('message_count', 0) == 0
                 and not s.get('active_stream_id')
+                and not s.get('has_pending_user_message')
             )]
             result = [s for s in result if not _hide_from_default_sidebar(s)]
             # Backfill: sessions created before Sprint 22 have no profile tag.

--- a/static/messages.js
+++ b/static/messages.js
@@ -177,6 +177,8 @@ async function send(){
   S.toolCalls=[];  // clear tool calls from previous turn
   clearLiveToolCards();  // clear any leftover live cards from last turn
   S.messages.push(userMsg);renderMessages();appendThinking();setBusy(true);
+  // First optimistic pass: make the local user turn visible before /api/chat/start
+  // can save pending state on the server.
   if(typeof upsertActiveSessionForLocalTurn==='function'){
     upsertActiveSessionForLocalTurn({title:displayText.slice(0,64),messageCount:S.messages.length,timestampMs:Date.now()});
   }
@@ -202,6 +204,8 @@ async function send(){
       session_id:activeSid, title:provisionalTitle
     })}).catch(()=>{});  // fire-and-forget, server refines on done
     if(typeof upsertActiveSessionForLocalTurn==='function'){
+      // Second optimistic pass: carry the provisional title into the cached row
+      // without re-fetching /api/sessions before pending state exists server-side.
       upsertActiveSessionForLocalTurn({title:provisionalTitle,messageCount:S.messages.length,timestampMs:Date.now()});
     }else if(typeof renderSessionListFromCache==='function') renderSessionListFromCache();
   } else if(typeof upsertActiveSessionForLocalTurn==='function'){
@@ -239,6 +243,8 @@ async function send(){
       S.session.active_stream_id = streamId;
     }
     if(typeof upsertActiveSessionForLocalTurn==='function'){
+      // Third optimistic pass: stream_id is now known, so the row can reconcile
+      // against real active-stream metadata before the background refresh lands.
       upsertActiveSessionForLocalTurn({title:S.session&&S.session.title||displayText.slice(0,64),messageCount:S.messages.length,timestampMs:Date.now()});
     }
     markInflight(activeSid, streamId);
@@ -279,6 +285,9 @@ async function send(){
     if(!_clarifySessionId || _clarifySessionId===activeSid) hideClarifyCard(true, 'terminal');
     S.messages.push({role:'assistant',content:`**Error:** ${errMsg}`});
     _queueDrainSid=activeSid;renderMessages();setBusy(false);setComposerStatus(`Error: ${errMsg}`);
+    if(typeof clearOptimisticSessionStreaming==='function') clearOptimisticSessionStreaming(activeSid);
+    // Reconcile with server truth after immediately clearing the optimistic spinner.
+    if(typeof renderSessionList==='function') void renderSessionList();
     return;
   }
 

--- a/static/messages.js
+++ b/static/messages.js
@@ -177,6 +177,9 @@ async function send(){
   S.toolCalls=[];  // clear tool calls from previous turn
   clearLiveToolCards();  // clear any leftover live cards from last turn
   S.messages.push(userMsg);renderMessages();appendThinking();setBusy(true);
+  if(typeof upsertActiveSessionForLocalTurn==='function'){
+    upsertActiveSessionForLocalTurn({title:displayText.slice(0,64),messageCount:S.messages.length,timestampMs:Date.now()});
+  }
   INFLIGHT[activeSid]={messages:[...S.messages],uploaded:uploadedNames,toolCalls:[]};
   if(typeof saveInflightState==='function'){
     saveInflightState(activeSid,{streamId:null,messages:INFLIGHT[activeSid].messages,uploaded:uploadedNames,toolCalls:[]});
@@ -193,13 +196,18 @@ async function send(){
     const provisionalTitle=displayText.slice(0,64);
     S.session.title=provisionalTitle;
     syncTopbar();
-    // Persist it and refresh the sidebar now -- don't wait for done
+    // Persist it in the background; keep the optimistic sidebar cache as the
+    // immediate source of truth until /api/chat/start saves pending state.
     api('/api/session/rename',{method:'POST',body:JSON.stringify({
       session_id:activeSid, title:provisionalTitle
     })}).catch(()=>{});  // fire-and-forget, server refines on done
-    renderSessionList();  // session appears in sidebar immediately
+    if(typeof upsertActiveSessionForLocalTurn==='function'){
+      upsertActiveSessionForLocalTurn({title:provisionalTitle,messageCount:S.messages.length,timestampMs:Date.now()});
+    }else if(typeof renderSessionListFromCache==='function') renderSessionListFromCache();
+  } else if(typeof upsertActiveSessionForLocalTurn==='function'){
+    upsertActiveSessionForLocalTurn({title:S.session&&S.session.title||displayText.slice(0,64),messageCount:S.messages.length,timestampMs:Date.now()});
   } else {
-    renderSessionList();  // ensure it's visible even if already titled
+    renderSessionListFromCache();  // ensure it's visible even if already titled
   }
 
   // Start the agent via POST, get a stream_id back
@@ -229,6 +237,9 @@ async function send(){
     S.activeStreamId = streamId;
     if(S.session&&S.session.session_id===activeSid){
       S.session.active_stream_id = streamId;
+    }
+    if(typeof upsertActiveSessionForLocalTurn==='function'){
+      upsertActiveSessionForLocalTurn({title:S.session&&S.session.title||displayText.slice(0,64),messageCount:S.messages.length,timestampMs:Date.now()});
     }
     markInflight(activeSid, streamId);
     if(typeof saveInflightState==='function'){

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1768,6 +1768,34 @@ function _activeSessionIdForSidebar(){
   return null;
 }
 
+function upsertActiveSessionForLocalTurn({title='', messageCount=0, timestampMs=Date.now()}={}){
+  if(!S.session||!S.session.session_id) return;
+  const sid=S.session.session_id;
+  const nowSec=Math.floor((Number(timestampMs)||Date.now())/1000);
+  const localCount=Array.isArray(S.messages)?S.messages.length:0;
+  const count=Math.max(Number(S.session.message_count||0),Number(messageCount||0),localCount,1);
+  S.session.message_count=count;
+  S.session.last_message_at=nowSec;
+  S.session.updated_at=nowSec;
+  if((S.session.title==='Untitled'||!S.session.title)&&title){
+    S.session.title=title;
+  }
+  const existingIdx=_allSessions.findIndex(s=>s&&s.session_id===sid);
+  const row={
+    ...S.session,
+    session_id:sid,
+    title:S.session.title||title||'New chat',
+    message_count:count,
+    last_message_at:nowSec,
+    updated_at:nowSec,
+    profile:S.session.profile||S.activeProfile||'default',
+    is_streaming:true,
+  };
+  if(existingIdx>=0) _allSessions[existingIdx]={..._allSessions[existingIdx],...row};
+  else _allSessions.unshift(row);
+  renderSessionListFromCache();
+}
+
 function renderSessionListFromCache(){
   // Don't re-render while user is actively renaming a session (would destroy the input)
   if(_renamingSid) return;

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1796,6 +1796,32 @@ function upsertActiveSessionForLocalTurn({title='', messageCount=0, timestampMs=
   renderSessionListFromCache();
 }
 
+function clearOptimisticSessionStreaming(sid){
+  sid=sid||(S.session&&S.session.session_id)||'';
+  if(!sid) return;
+  if(S.session&&S.session.session_id===sid){
+    S.session.active_stream_id=null;
+    S.activeStreamId=null;
+  }
+  if(Array.isArray(_allSessions)){
+    const idx=_allSessions.findIndex(s=>s&&s.session_id===sid);
+    if(idx>=0){
+      _allSessions[idx]={
+        ..._allSessions[idx],
+        active_stream_id:null,
+        pending_user_message:null,
+        pending_started_at:null,
+        is_streaming:false,
+      };
+    }
+  }
+  if(typeof _sessionStreamingById!=='undefined'&&_sessionStreamingById&&typeof _sessionStreamingById.set==='function'){
+    _sessionStreamingById.set(sid,false);
+  }
+  if(typeof _forgetObservedStreamingSession==='function') _forgetObservedStreamingSession(sid);
+  renderSessionListFromCache();
+}
+
 function renderSessionListFromCache(){
   // Don't re-render while user is actively renaming a session (would destroy the input)
   if(_renamingSid) return;

--- a/tests/test_sidebar_first_turn_visibility.py
+++ b/tests/test_sidebar_first_turn_visibility.py
@@ -1,0 +1,69 @@
+"""Regressions for first-turn sessions appearing in the sidebar immediately."""
+
+import pathlib
+
+REPO = pathlib.Path(__file__).parent.parent
+
+
+def read(rel: str) -> str:
+    return (REPO / rel).read_text(encoding="utf-8")
+
+
+class TestSidebarFirstTurnVisibility:
+    def test_messages_send_optimistically_upserts_active_sidebar_row(self):
+        src = read("static/messages.js")
+        assert "upsertActiveSessionForLocalTurn" in src, (
+            "send() must optimistically upsert the active session into the sidebar "
+            "as soon as the local user message is pushed."
+        )
+        push_idx = src.index("S.messages.push(userMsg);renderMessages();appendThinking();setBusy(true);")
+        helper_idx = src.index("upsertActiveSessionForLocalTurn", push_idx)
+        start_idx = src.index("api('/api/chat/start'", push_idx)
+        assert helper_idx < start_idx, (
+            "The sidebar row must be rendered before /api/chat/start returns so "
+            "tool calls are reachable while the first agent turn is still running."
+        )
+        pre_start = src[helper_idx:start_idx]
+        assert "renderSessionList();" not in pre_start, (
+            "Do not re-fetch /api/sessions before /api/chat/start saves pending state; "
+            "that race can overwrite the optimistic first-turn row with an empty list."
+        )
+
+    def test_sessions_js_has_local_turn_upsert_helper(self):
+        src = read("static/sessions.js")
+        assert "function upsertActiveSessionForLocalTurn" in src
+        start = src.index("function upsertActiveSessionForLocalTurn")
+        end = src.index("function renderSessionListFromCache", start)
+        body = src[start:end]
+        assert "_allSessions.unshift" in body or "_allSessions.splice" in body, (
+            "Helper must add a missing active session to the cached sidebar list."
+        )
+        assert "S.session.message_count" in body and "S.messages.length" in body, (
+            "Helper must treat the locally pushed user message as a real sidebar message."
+        )
+        assert "is_streaming:true" in body.replace(" ", ""), (
+            "Optimistic row should render as streaming until the backend reconciles."
+        )
+
+    def test_backend_compact_counts_pending_first_turn_as_visible(self):
+        src = read("api/models.py")
+        compact = src[src.index("def compact"):src.index("def _get_profile_home")]
+        assert "has_pending_user_message" in compact and "pending_user_message" in compact, (
+            "Session.compact() must account for pending_user_message in sidebar metadata."
+        )
+        assert "message_count = max(message_count, 1)" in compact, (
+            "Pending first user turn should make message_count non-zero for /api/sessions."
+        )
+        assert "pending_started_at" in compact and "last_message_at" in compact, (
+            "Pending first user turn should sort by pending_started_at in the sidebar."
+        )
+
+    def test_backend_index_filter_keeps_pending_first_turn_sessions(self):
+        src = read("api/models.py")
+        index_filter_start = src.index("# Hide empty Untitled sessions from the UI entirely")
+        index_filter_end = src.index("result = [s for s in result if not _hide_from_default_sidebar", index_filter_start)
+        index_filter = src[index_filter_start:index_filter_end]
+        assert "has_pending_user_message" in index_filter, (
+            "The index-path empty-session filter must exempt pending first-turn sessions, "
+            "matching the full-scan fallback."
+        )

--- a/tests/test_sidebar_first_turn_visibility.py
+++ b/tests/test_sidebar_first_turn_visibility.py
@@ -45,6 +45,36 @@ class TestSidebarFirstTurnVisibility:
             "Optimistic row should render as streaming until the backend reconciles."
         )
 
+    def test_messages_comments_document_why_each_optimistic_upsert_stays_separate(self):
+        src = read("static/messages.js")
+        assert "First optimistic pass" in src and "before /api/chat/start" in src
+        assert "Second optimistic pass" in src and "provisional title" in src
+        assert "Third optimistic pass" in src and "stream_id is now known" in src
+
+    def test_chat_start_failure_clears_optimistic_streaming_state(self):
+        messages = read("static/messages.js")
+        catch_start = messages.index("}catch(e){", messages.index("api('/api/chat/start'"))
+        failure_start = messages.index("S.messages.push({role:'assistant',content:`**Error:** ${errMsg}`});", catch_start)
+        catch_body = messages[failure_start:messages.index("return;", failure_start)]
+        assert "setBusy(false)" in catch_body, "chat/start failure must leave the active pane idle"
+        assert "clearOptimisticSessionStreaming(activeSid)" in catch_body, (
+            "If /api/chat/start fails after the optimistic sidebar upsert, the cached row "
+            "must drop its streaming spinner immediately instead of waiting for polling."
+        )
+        assert "void renderSessionList()" in catch_body, (
+            "After clearing the optimistic spinner locally, fetch /api/sessions to reconcile "
+            "with whatever the server persisted before failing."
+        )
+
+        sessions = read("static/sessions.js")
+        assert "function clearOptimisticSessionStreaming" in sessions
+        clear_start = sessions.index("function clearOptimisticSessionStreaming")
+        clear_end = sessions.index("function renderSessionListFromCache", clear_start)
+        clear_body = sessions[clear_start:clear_end]
+        assert "is_streaming:false" in clear_body.replace(" ", "")
+        assert "active_stream_id:null" in clear_body.replace(" ", "")
+        assert "_sessionStreamingById.set(sid,false)" in clear_body.replace(" ", "")
+
     def test_backend_compact_counts_pending_first_turn_as_visible(self):
         src = read("api/models.py")
         compact = src[src.index("def compact"):src.index("def _get_profile_home")]


### PR DESCRIPTION
## Thinking Path

- Hermes WebUI treats empty `Untitled` sessions as ephemeral so accidental blank chats do not clutter the sidebar.
- A first user message should promote that session into a real, visible conversation immediately, before the model produces an assistant response.
- The bug was a race between the local first-message render and `/api/sessions`: the client could re-fetch stale zero-message metadata before `/api/chat/start` saved pending state, hiding the row until the assistant turn completed.
- This PR keeps the fix small: add an optimistic sidebar upsert for the active local turn, avoid the pre-start session-list re-fetch race, and make pending first turns count as visible in compact server metadata.
- The result is that users can switch into a just-started conversation and inspect live tool calls even before the agent has responded.

## What Changed

- Added `upsertActiveSessionForLocalTurn()` in `static/sessions.js` to insert/update the active session in the cached sidebar list as soon as the local user message is pushed.
- Updated `static/messages.js` to call that helper before `/api/chat/start`, and to avoid re-fetching `/api/sessions` before the backend has persisted pending state.
- Updated `api/models.py` compact metadata so `pending_user_message` makes `message_count` non-zero and sorts by `pending_started_at` while the first turn is pending.
- Added `tests/test_sidebar_first_turn_visibility.py` regression coverage for the client optimistic path, the fetch-race guard, and pending first-turn server metadata.

## Why It Matters

Long-running first turns can emit tool calls before the assistant response is complete. If the new conversation is hidden from the sidebar during that window, users cannot reliably navigate back to the active run or observe its tool activity. Showing the row immediately preserves the existing no-ghost-chat behavior while making active work visible as soon as the user submits a message.

## Verification

```bash
/home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_sidebar_first_turn_visibility.py -q
git diff --check
```

Result:

```text
4 passed in 1.37s
git diff --check passed
```

Manual verification:

- Started an isolated local server from this PR worktree on `127.0.0.1:18790` with a temporary state dir.
- Patched `window.api` in the browser so `/api/chat/start` stayed pending and no assistant response could arrive.
- Sent a first message and verified the sidebar immediately showed the new active row with `message_count: 1` and `session-item active streaming` while only the user message existed.
- Checked the browser console after the interaction: no console messages or JS errors.

UI media:

- Browser evidence was captured locally, but media still needs to be attached through the GitHub UI before maintainer review.

## Risks / Follow-ups

- `Session.compact()` already includes `pending_user_message` in this branch; this PR adds a boolean `has_pending_user_message` for safer filtering/sorting without changing that existing field.
- The optimistic row is reconciled by the normal `/api/sessions` refresh after `/api/chat/start` returns, so the main risk is stale local display if the start request fails. Existing error handling still renders the failed turn and clears busy state.

## Model Used

AI assisted.

- Provider: OpenAI Codex
- Model: `gpt-5.5`
- Notable tool use: terminal/git/pytest, isolated Hermes WebUI server, browser QA with an intercepted pending `/api/chat/start` request.
