### PR TITLE
fix: broadcast SSE stream events to multiple tabs

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -14,6 +14,7 @@ import copy
 import json
 import logging
 import os
+import queue
 import sys
 import threading
 import time
@@ -2745,6 +2746,53 @@ _INDEX_HTML_PATH = REPO_ROOT / "static" / "index.html"
 LOCK = threading.Lock()
 SESSIONS_MAX = 100
 CHAT_LOCK = threading.Lock()
+
+
+class StreamChannel:
+    """Broadcast SSE events to every connected browser tab for a stream.
+
+    While no tab is connected, events are buffered so the first/reconnected
+    subscriber still receives the stream tail that arrived during the gap.
+    Once one or more subscribers are attached, new events are broadcast to all
+    of them instead of being consumed destructively by a single queue reader.
+    """
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        self._subscribers: list[queue.Queue] = []
+        self._offline_buffer: list[tuple[str, object]] = []
+
+    def subscribe(self) -> queue.Queue:
+        q: queue.Queue = queue.Queue()
+        with self._lock:
+            snapshot = list(self._offline_buffer)
+            self._subscribers.append(q)
+        for item in snapshot:
+            q.put_nowait(item)
+        return q
+
+    def unsubscribe(self, q: queue.Queue) -> None:
+        with self._lock:
+            try:
+                self._subscribers.remove(q)
+            except ValueError:
+                pass
+
+    def put_nowait(self, item: tuple[str, object]) -> None:
+        with self._lock:
+            subscribers = list(self._subscribers)
+            if not subscribers:
+                self._offline_buffer.append(item)
+                return
+            self._offline_buffer.clear()
+        for q in subscribers:
+            q.put_nowait(item)
+
+
+def create_stream_channel() -> StreamChannel:
+    return StreamChannel()
+
+
 STREAMS: dict = {}
 STREAMS_LOCK = threading.Lock()
 CANCEL_FLAGS: dict = {}

--- a/api/routes.py
+++ b/api/routes.py
@@ -332,6 +332,7 @@ from api.config import (
     get_reasoning_status,
     set_reasoning_display,
     set_reasoning_effort,
+    create_stream_channel,
 )
 from api.helpers import (
     require,
@@ -3649,9 +3650,10 @@ def _handle_list_dir(handler, parsed):
 
 def _handle_sse_stream(handler, parsed):
     stream_id = parse_qs(parsed.query).get("stream_id", [""])[0]
-    q = STREAMS.get(stream_id)
-    if q is None:
+    stream = STREAMS.get(stream_id)
+    if stream is None:
         return j(handler, {"error": "stream not found"}, status=404)
+    subscriber = stream.subscribe() if hasattr(stream, "subscribe") else stream
     handler.send_response(200)
     handler.send_header("Content-Type", "text/event-stream; charset=utf-8")
     handler.send_header("Cache-Control", "no-cache")
@@ -3661,7 +3663,7 @@ def _handle_sse_stream(handler, parsed):
     try:
         while True:
             try:
-                event, data = q.get(timeout=30)
+                event, data = subscriber.get(timeout=30)
             except queue.Empty:
                 handler.wfile.write(b": heartbeat\n\n")
                 handler.wfile.flush()
@@ -3671,6 +3673,12 @@ def _handle_sse_stream(handler, parsed):
                 break
     except _CLIENT_DISCONNECT_ERRORS:
         pass
+    finally:
+        if subscriber is not stream and hasattr(stream, "unsubscribe"):
+            try:
+                stream.unsubscribe(subscriber)
+            except Exception:
+                pass
     return True
 
 
@@ -4812,9 +4820,9 @@ def _handle_btw(handler, body):
     stream_id = uuid.uuid4().hex
     ephemeral.active_stream_id = stream_id
     ephemeral.save()
-    q = queue.Queue()
+    stream = create_stream_channel()
     with STREAMS_LOCK:
-        STREAMS[stream_id] = q
+        STREAMS[stream_id] = stream
     from api.background import track_btw
     track_btw(body["session_id"], ephemeral.session_id, stream_id, question)
     thr = threading.Thread(
@@ -4858,9 +4866,9 @@ def _handle_background(handler, body):
     stream_id = uuid.uuid4().hex
     bg.active_stream_id = stream_id
     bg.save()
-    q = queue.Queue()
+    stream = create_stream_channel()
     with STREAMS_LOCK:
-        STREAMS[stream_id] = q
+        STREAMS[stream_id] = stream
     task_id = uuid.uuid4().hex[:8]
     from api.background import track_background, complete_background
     parent_sid = body["session_id"]
@@ -4974,9 +4982,9 @@ def _handle_chat_start(handler, body):
         s.pending_started_at = time.time()
         s.save()
     set_last_workspace(workspace)
-    q = queue.Queue()
+    stream = create_stream_channel()
     with STREAMS_LOCK:
-        STREAMS[stream_id] = q
+        STREAMS[stream_id] = stream
     thr = threading.Thread(
         target=_run_agent_streaming,
         args=(s.session_id, msg, model, workspace, stream_id, attachments),

--- a/tests/test_issue_1584_multitab_sse.py
+++ b/tests/test_issue_1584_multitab_sse.py
@@ -1,0 +1,83 @@
+import io
+import threading
+from types import SimpleNamespace
+
+from api.config import STREAMS, STREAMS_LOCK, create_stream_channel
+from api.routes import _handle_sse_stream
+
+
+class _FakeHandler:
+    def __init__(self):
+        self.status = None
+        self.headers = []
+        self.wfile = io.BytesIO()
+
+    def send_response(self, status):
+        self.status = status
+
+    def send_header(self, key, value):
+        self.headers.append((key, value))
+
+    def end_headers(self):
+        return None
+
+
+def test_stream_channel_broadcasts_each_event_to_every_subscriber():
+    stream = create_stream_channel()
+    q1 = stream.subscribe()
+    q2 = stream.subscribe()
+
+    try:
+        stream.put_nowait(("token", {"text": "H"}))
+        stream.put_nowait(("token", {"text": "allo"}))
+        stream.put_nowait(("stream_end", {"status": "done"}))
+
+        assert q1.get(timeout=1) == ("token", {"text": "H"})
+        assert q1.get(timeout=1) == ("token", {"text": "allo"})
+        assert q1.get(timeout=1) == ("stream_end", {"status": "done"})
+
+        assert q2.get(timeout=1) == ("token", {"text": "H"})
+        assert q2.get(timeout=1) == ("token", {"text": "allo"})
+        assert q2.get(timeout=1) == ("stream_end", {"status": "done"})
+    finally:
+        stream.unsubscribe(q1)
+        stream.unsubscribe(q2)
+
+
+def test_same_stream_in_two_tabs_receives_identical_token_sequence():
+    stream_id = "multitab-stream"
+    stream = create_stream_channel()
+    with STREAMS_LOCK:
+        STREAMS[stream_id] = stream
+
+    handlers = [_FakeHandler(), _FakeHandler()]
+    threads = [
+        threading.Thread(
+            target=_handle_sse_stream,
+            args=(handler, SimpleNamespace(query=f"stream_id={stream_id}")),
+            daemon=True,
+        )
+        for handler in handlers
+    ]
+
+    try:
+        for thread in threads:
+            thread.start()
+
+        stream.put_nowait(("token", {"text": "H"}))
+        stream.put_nowait(("token", {"text": "allo"}))
+        stream.put_nowait(("stream_end", {"status": "done"}))
+
+        for thread in threads:
+            thread.join(timeout=1)
+            assert not thread.is_alive(), "every tab should finish the same SSE stream"
+
+        for handler in handlers:
+            payload = handler.wfile.getvalue().decode("utf-8")
+            assert handler.status == 200
+            assert '"text": "H"' in payload
+            assert '"text": "allo"' in payload
+            assert "event: stream_end" in payload
+    finally:
+        with STREAMS_LOCK:
+            STREAMS.pop(stream_id, None)


### PR DESCRIPTION
## Thinking Path

- Hermes WebUI relies on one SSE stream per active agent turn, but users can legitimately have the same session open in multiple browser tabs.
- Issue #1584 reported streamed text being split between tabs, e.g. one tab receiving `H` while another receives `allo`.
- The root cause is that every `/api/chat/stream` handler was reading destructively from the same `queue.Queue` stored in `STREAMS[stream_id]`.
- This PR fixes the stream transport itself rather than adding frontend guards, so every connected tab receives the same event sequence.
- The user-visible result is that multiple tabs on the same active session render the full response instead of competing for token chunks.

## What Changed

- Added a `StreamChannel` broadcast wrapper in `api/config.py` with per-subscriber queues and a small offline buffer for reconnect/first-subscriber gaps.
- Updated `api/routes.py:_handle_sse_stream()` so each EventSource connection subscribes to its own queue and unsubscribes on exit.
- Switched the chat, background, and `/btw` stream creation paths from raw `queue.Queue()` to `create_stream_channel()`.
- Added `tests/test_issue_1584_multitab_sse.py` covering:
  - direct fan-out to two subscribers;
  - two concurrent SSE handlers receiving the identical token + terminal event sequence.

Closes #1584.

## Why It Matters

Before this change, multiple browser tabs attached to the same active stream were competing consumers. `queue.Queue.get()` removes each token event, so only one tab could receive any given chunk. That made live responses appear split, incomplete, or stuck depending on timing.

Broadcasting the producer events into one queue per subscriber matches the expected SSE semantics: every open tab observing the same stream should see the same stream.

## Verification

```bash
/home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_issue_1584_multitab_sse.py -q
/home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_issue_1584_multitab_sse.py tests/test_inflight_stream_reuse.py tests/test_streaming_race_fix.py -q
git diff --check
/home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/ -q
env -u HERMES_CONFIG_PATH /home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_issue1094_provider_bugs.py::TestBug1094RemoveProviderKey tests/test_model_resolver.py::test_custom_endpoint_uses_model_config_api_key_for_model_discovery tests/test_onboarding_mvp.py::test_onboarding_status_defaults_incomplete tests/test_onboarding_mvp.py::test_onboarding_setup_openrouter_writes_real_config_and_env tests/test_onboarding_mvp.py::test_onboarding_setup_custom_endpoint_writes_runtime_files tests/test_onboarding_mvp.py::test_onboarding_setup_rejects_api_key_with_newline tests/test_sprint28.py::test_personalities_empty_when_none_exist -q
```

Result:

```text
tests/test_issue_1584_multitab_sse.py: 2 passed
targeted streaming regression set: 17 passed
git diff --check: passed
full suite: 4110 passed, 2 skipped, 3 xpassed, 1 warning, 8 subtests passed; 9 unrelated failures in provider/onboarding/personality tests
rerun of full-suite failures with HERMES_CONFIG_PATH unset: 8 passed, 2 remaining provider-key cleanup failures
```

Manual verification:

- Recreated the broken pre-fix behavior against the old raw queue: one simulated SSE tab consumed all events while the second tab stayed alive with empty output.
- Re-ran the same simulated two-tab stream after the fix: both handlers received `H`, `allo`, and `stream_end`, then exited cleanly.

UI media:

- Not applicable; this is a server-side streaming transport fix with no interface changes.

## Risks / Follow-ups

- The new transport keeps a small in-memory offline buffer while no subscribers are attached so reconnecting clients do not miss the stream tail. It is scoped to active streams and removed with the existing `STREAMS.pop(stream_id, None)` cleanup.
- Existing raw-queue behavior is still tolerated in `_handle_sse_stream()` for defensive compatibility, but all current stream creation paths now use `create_stream_channel()`.
- The full local suite has unrelated failures on this checkout in provider-key cleanup / onboarding / personality isolation tests; the new issue-specific tests and nearby streaming regression tests pass.

## Model Used

AI assisted.

- Provider: OpenAI Codex
- Model: `gpt-5.5`
- Notable tool use: terminal, git, gh CLI, pytest, file patching, GitHub REST/CLI inspection.
