### PR TITLE
fix(streaming): use truthy-check for _pending_started_at fallback (closes #1595)

### DIFF
--- a/api/streaming.py
+++ b/api/streaming.py
@@ -2054,8 +2054,10 @@ def _run_agent_streaming(
                 agent.ephemeral_system_prompt = _personality_prompt
             _pending_started_at = getattr(s, 'pending_started_at', None)
             # Normal chat-start sets pending_started_at before spawning this thread;
-            # fallback to now only for recovered/legacy flows where that marker is absent.
-            _turn_started_at = _pending_started_at if _pending_started_at is not None else time.time()
+            # fallback to now only for recovered/legacy flows where that marker is absent
+            # or has been zeroed out (e.g. via a buggy migration / manual file edit).
+            # Truthy-check covers None, missing-attr, and 0 uniformly.
+            _turn_started_at = _pending_started_at if _pending_started_at else time.time()
             _previous_messages = list(s.messages or [])
             _previous_context_messages = list(_session_context_messages(s))
             _pre_compression_count = getattr(

--- a/tests/test_turn_duration_display.py
+++ b/tests/test_turn_duration_display.py
@@ -21,10 +21,6 @@ def test_streaming_done_payload_includes_backend_turn_duration():
         "Turn duration should be measured from the persisted pending_started_at "
         "start time, not only from browser-local state."
     )
-    assert "if _pending_started_at is not None else time.time()" in STREAMING_PY, (
-        "The fallback should preserve explicit timestamp values and only use now "
-        "when pending_started_at is absent."
-    )
     assert "recovered/legacy flows" in STREAMING_PY, (
         "The missing-start fallback should be documented so it is not mistaken "
         "for the primary timing path."


### PR DESCRIPTION
## Summary

Tightens the per-turn duration fallback at `api/streaming.py:2058` from `is not None` to a truthy check, so `None`, missing-attr, and an explicit `0` all uniformly fall back to `time.time()`.

## Why

If `pending_started_at` were ever `0` (buggy migration, manual fixture edit, future field-reset path), the duration calc would compute `time.time() - 0` ≈ wall-clock-since-epoch and render "Done in 56 years 4 months …".

In practice `pending_started_at` is always set via `int(time.time())` so this is hardening, not a live-bug fix — exactly the framing in #1595.

## Change

```diff
- _turn_started_at = _pending_started_at if _pending_started_at is not None else time.time()
+ _turn_started_at = _pending_started_at if _pending_started_at else time.time()
```

Also dropped the brittle source-string assertion in `tests/test_turn_duration_display.py` that pinned the literal expression. The behavioural test `test_done_handler_persists_duration_on_last_assistant_message` already proves the duration field flows through; the source-string pin broke twice during the v0.50.290 release pipeline (Opus tightening + maintainer revert).

This is option (a) from the issue's suggested fix.

## Tests

```
$ pytest tests/test_turn_duration_display.py -v
...                                                                       [100%]
============================== 3 passed in 2.10s ===============================
```

Plus all streaming-adjacent tests (`test_streaming_race_fix.py`, `test_streaming_session_sidebar.py`, `test_stale_stream_pending_recovery.py`, `test_issue765_streaming_persistence.py`) — 47 passed. Full suite: 4076 passed.

(5 unrelated failures pre-existing on `master` locally — workspace path-validation tests where `tmp_path` resolves inside `$HOME` so the "outside home" assertion never fires; not introduced by this PR.)

## Closes

Closes #1595