### PR TITLE
fix: render streaming markdown on subpath mounts

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -28,7 +28,7 @@
   <!-- ES module imports do not support the integrity= attribute (W3C limitation);    -->
   <!-- version is pinned in the vendored file path; hash documented above for audit. -->
   <script type="module">
-    import * as smd from '/static/vendor/smd.min.js';
+    import * as smd from './static/vendor/smd.min.js';
     // SRI verification happens at the ES module level via importmap or SW; pinning version in URL.
     // sha384 of smd.min.js @0.2.15: sha384-T6r95ocN9t3W8tUK2Fa6FPaO7bJryyjyW0WCalrUnpgtm2qXr5xcN4vwPYEJ6vHa
     window.smd = smd;

--- a/static/messages.js
+++ b/static/messages.js
@@ -640,9 +640,12 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
           _smdWrite(displayText);
         } else {
           // Fallback: smd not loaded yet, reconnect session, or smd unavailable — use renderMd
-          assistantBody.innerHTML = (segmentStart===0
+          // for every live segment. Without this, the first segment inserts raw
+          // parsed.displayText and users see unformatted markdown until done.
+          const fallbackText = segmentStart===0
             ? parsed.displayText
-            : renderMd ? renderMd(assistantText.slice(segmentStart)) : assistantText.slice(segmentStart)) || '';
+            : _stripXmlToolCalls(assistantText.slice(segmentStart));
+          assistantBody.innerHTML = renderMd ? renderMd(fallbackText) : esc(fallbackText);
         }
       }
       scrollIfPinned();

--- a/tests/test_streaming_markdown.py
+++ b/tests/test_streaming_markdown.py
@@ -107,6 +107,19 @@ class TestIndexHtmlSmdScript:
             "streaming-markdown must be loaded with type=\"module\" (it is an ES module)"
         )
 
+    def test_smd_vendor_import_is_mount_agnostic(self):
+        assert "static/vendor/smd.min.js" in INDEX_HTML, (
+            "index.html must load the vendored streaming-markdown module"
+        )
+        assert "from '/static/vendor/smd.min.js'" not in INDEX_HTML, (
+            "streaming-markdown import must not be root-absolute; root-absolute "
+            "static paths break subpath deployments such as /hermes/"
+        )
+        assert 'from "/static/vendor/smd.min.js"' not in INDEX_HTML, (
+            "streaming-markdown import must not be root-absolute; root-absolute "
+            "static paths break subpath deployments such as /hermes/"
+        )
+
 
 # ── 2. Closure variable declarations ─────────────────────────────────────────
 
@@ -268,6 +281,17 @@ class TestScheduleRenderSmdPath:
         fn = self.get_fn()
         assert fn and "renderMd" in fn, (
             "renderMd fallback must still exist in _scheduleRender when smd unavailable"
+        )
+
+    def test_fallback_formats_first_segment_with_render_md(self):
+        fn = self.get_fn()
+        assert fn, "_scheduleRender not found"
+        assert "const fallbackText" in fn, (
+            "_scheduleRender fallback should choose the visible segment text once"
+        )
+        assert "renderMd(fallbackText)" in fn, (
+            "When smd is unavailable, the first live segment must still be "
+            "formatted with renderMd instead of inserting raw parsed.displayText"
         )
 
     def test_smd_new_parser_called_lazily(self):


### PR DESCRIPTION
## Thinking Path

- Hermes WebUI supports live assistant streaming over SSE, with final messages rendered through the full markdown pipeline after `done`.
- The live renderer already uses the vendored `streaming-markdown` parser, but the module import was root-absolute (`/static/...`).
- Root-absolute static paths work for root-mounted deployments, but fail under reverse-proxy subpaths such as `/hermes/`, so `window.smd` never loads there.
- When `window.smd` is unavailable, the fallback path also inserted the first live segment as raw `parsed.displayText`, which leaves markdown visible until final render.
- This PR makes the import mount-agnostic and makes the fallback format every live segment through `renderMd()`.

## What Changed

- Changed the vendored `streaming-markdown` ES module import from `/static/vendor/smd.min.js` to `./static/vendor/smd.min.js` so it resolves correctly at `/`, `/hermes/`, or any other subpath mount.
- Updated the live-stream fallback in `static/messages.js` to compute a `fallbackText` and pass it through `renderMd(fallbackText)` for the first segment as well as post-tool segments.
- Added static regressions in `tests/test_streaming_markdown.py` for:
  - mount-agnostic `smd` imports
  - fallback formatting of the first live assistant segment

## Why It Matters

Users should see markdown formatting as responses stream in, not a messy raw markdown transcript until the assistant turn completes. This also keeps self-hosted/reverse-proxied deployments portable without requiring a hard-coded base path.

## Verification

- `python -m pytest tests/test_streaming_markdown.py -q` → `52 passed`
- `python -m pytest tests/test_streaming_markdown.py tests/test_service_worker_api_cache.py tests/test_sprint19.py tests/test_ui_tool_call_cleanup.py -q` → `86 passed`
- `git diff --check` → clean

UI media: not attached. This is a streaming-path behavior fix; the regression is covered by source-level tests rather than a static before/after screenshot.

## Risks / Follow-ups

- `streaming-markdown` live output remains an intermediate rendering path; final saved messages still render through the canonical `renderMd()` pipeline on `done`.
- The fallback now calls `esc(fallbackText)` only if `renderMd` is unavailable, preserving safe plain-text behavior for that unusual path.

## Model Used

- Provider: OpenAI Codex
- Model: `gpt-5.5`
- Tool use: Hermes Agent file editing, terminal test runs, git/GitHub CLI workflow
