### PR TITLE
fix: preserve git remote names in update links

### DIFF
--- a/api/updates.py
+++ b/api/updates.py
@@ -207,9 +207,9 @@ def _check_repo(path, name):
     remote_url, _ = _run_git(['remote', 'get-url', 'origin'], path)
     # Convert SSH URLs (git@github.com:org/repo.git) to HTTPS
     if remote_url and remote_url.startswith('git@'):
-        remote_url = remote_url.replace(':', '/', 1).replace('git@', 'https://', 1).rstrip('.git')
-    elif remote_url:
-        remote_url = remote_url.rstrip('.git')
+        remote_url = remote_url.replace(':', '/', 1).replace('git@', 'https://', 1)
+    if remote_url and remote_url.endswith('.git'):
+        remote_url = remote_url[:-4]
 
     return {
         'name': name,

--- a/tests/test_update_banner_fixes.py
+++ b/tests/test_update_banner_fixes.py
@@ -28,6 +28,58 @@ def read(rel):
 
 # ── api/updates.py ────────────────────────────────────────────────────────────
 
+class TestUpdateChecker:
+    def test_repo_url_strips_only_dot_git_suffix(self, tmp_path, monkeypatch):
+        import api.updates as upd
+
+        (tmp_path / '.git').mkdir()
+
+        def fake_run(args, cwd, timeout=10):
+            if args[0] == 'fetch':
+                return '', True
+            if args[:2] == ['rev-parse', '--abbrev-ref']:
+                return 'origin/master', True
+            if args[:2] == ['rev-list', '--count']:
+                return '0', True
+            if args[0] == 'merge-base':
+                return 'abcdef1234567890', True
+            if args[:2] == ['rev-parse', '--short']:
+                return 'abcdef1', True
+            if args[:2] == ['remote', 'get-url']:
+                return 'https://github.com/nesquena/hermes-webui.git', True
+            return '', True
+
+        monkeypatch.setattr(upd, '_run_git', fake_run)
+        result = upd._check_repo(tmp_path, 'webui')
+
+        assert result['repo_url'] == 'https://github.com/nesquena/hermes-webui'
+
+    def test_repo_url_converts_ssh_and_strips_only_dot_git_suffix(self, tmp_path, monkeypatch):
+        import api.updates as upd
+
+        (tmp_path / '.git').mkdir()
+
+        def fake_run(args, cwd, timeout=10):
+            if args[0] == 'fetch':
+                return '', True
+            if args[:2] == ['rev-parse', '--abbrev-ref']:
+                return 'origin/main', True
+            if args[:2] == ['rev-list', '--count']:
+                return '0', True
+            if args[0] == 'merge-base':
+                return 'abcdef1234567890', True
+            if args[:2] == ['rev-parse', '--short']:
+                return 'abcdef1', True
+            if args[:2] == ['remote', 'get-url']:
+                return 'git@github.com:NousResearch/hermes-agent.git', True
+            return '', True
+
+        monkeypatch.setattr(upd, '_run_git', fake_run)
+        result = upd._check_repo(tmp_path, 'agent')
+
+        assert result['repo_url'] == 'https://github.com/NousResearch/hermes-agent'
+
+
 class TestConflictError:
     """#813 — conflict error must include flag + recovery command."""
 


### PR DESCRIPTION
Title: fix: preserve git remote names in update links

Summary:
- Replaces rstrip('.git') with exact .git suffix removal for update compare URLs.
- Fixes repository names ending with g/i/t or dot characters from being truncated, e.g. hermes-webui -> hermes-webu and hermes-agent -> hermes-agen.
- Covers HTTPS and SSH GitHub remote URLs.

Root cause:
str.rstrip('.git') removes any trailing character in the set {'.', 'g', 'i', 't'}, not the literal suffix '.git'.

Tests:
- python -m pytest tests/test_update_banner_fixes.py::TestUpdateChecker -q -o addopts=
