### PR TITLE
fix(streaming): use truthy-check for _pending_started_at fallback (closes #1595)

### DIFF
--- a/api/streaming.py
+++ b/api/streaming.py
@@ -2055,7 +2055,7 @@ def _run_agent_streaming(
             _pending_started_at = getattr(s, 'pending_started_at', None)
             # Normal chat-start sets pending_started_at before spawning this thread;
             # fallback to now only for recovered/legacy flows where that marker is absent.
-            _turn_started_at = _pending_started_at if _pending_started_at is not None else time.time()
+            _turn_started_at = _pending_started_at if _pending_started_at else time.time()
             _previous_messages = list(s.messages or [])
             _previous_context_messages = list(_session_context_messages(s))
             _pre_compression_count = getattr(

--- a/tests/test_turn_duration_display.py
+++ b/tests/test_turn_duration_display.py
@@ -21,10 +21,6 @@ def test_streaming_done_payload_includes_backend_turn_duration():
         "Turn duration should be measured from the persisted pending_started_at "
         "start time, not only from browser-local state."
     )
-    assert "if _pending_started_at is not None else time.time()" in STREAMING_PY, (
-        "The fallback should preserve explicit timestamp values and only use now "
-        "when pending_started_at is absent."
-    )
     assert "recovered/legacy flows" in STREAMING_PY, (
         "The missing-start fallback should be documented so it is not mistaken "
         "for the primary timing path."


### PR DESCRIPTION
## Summary

Two-character fix: change `is not None` to truthy check for `_pending_started_at` fallback in turn-duration calculation, so falsy values like `0` or empty string also fall back to `time.time()`.

Closes #1595

## Thinking Path

- #1592 added per-turn duration display in v0.50.290
- The fallback uses `is not None`, which treats `0` as a valid timestamp
- If `pending_started_at` is ever `0` (deserialization edge case, manual fixture, buggy migration), duration would display "Done in 56 years"
- Switching to truthy check uniformly handles `None`, `0`, and missing-attribute
- The contributor's own source-string test pinned the exact expression; dropped it since the behavioral tests still cover the contract

## What Changed

- `api/streaming.py:2058` — `is not None` → truthy check (2 chars)
- `tests/test_turn_duration_display.py` — dropped brittle source-string assertion that pinned the exact expression form

## Why It Matters

Prevents a hypothetical but real class of nonsensical duration display if `pending_started_at` is ever falsy (not just `None`). The fix is semantically equivalent for the normal code path where `pending_started_at` is always a positive epoch timestamp.

## Verification

```bash
# All streaming-related tests pass:
python -m pytest tests/test_turn_duration_display.py tests/test_streaming_max_tokens_quota.py tests/test_stale_stream_cleanup.py tests/test_stale_stream_pending_recovery.py -v
# 13 passed in 1.76s
```

## Risks / Follow-ups

- None. Behavioral change is limited to the `0`/empty-string edge case; normal flow (`pending_started_at` = positive epoch or `None`) is unaffected.
- The dropped source-string assertion was already noted as fragile in #1595 ("it broke twice in the v0.50.290 release pipeline alone").

## Model Used

None — human-authored.
