### PR TITLE
fix: show update branches in banner labels

### DIFF
--- a/static/panels.js
+++ b/static/panels.js
@@ -3606,8 +3606,13 @@ async function checkUpdatesNow(){
       if(status){status.textContent=t('settings_updates_disabled');status.style.color='var(--muted)';}
     } else {
       const parts=[];
-      if(data.webui&&data.webui.behind>0) parts.push('WebUI: '+data.webui.behind);
-      if(data.agent&&data.agent.behind>0) parts.push('Agent: '+data.agent.behind);
+      const formatUpdatePart=(typeof _formatUpdateTargetStatus==='function')
+        ? _formatUpdateTargetStatus
+        : ((label,info)=>info&&info.behind>0?label+': '+info.behind:null);
+      const webuiPart=formatUpdatePart('WebUI',data.webui);
+      const agentPart=formatUpdatePart('Agent',data.agent);
+      if(webuiPart) parts.push(webuiPart);
+      if(agentPart) parts.push(agentPart);
       if(parts.length){
         if(status){status.textContent=t('settings_updates_available').replace('{count}',parts.join(', '));status.style.color='var(--accent)';}
         // Also trigger the update banner

--- a/static/ui.js
+++ b/static/ui.js
@@ -2844,10 +2844,17 @@ async function refreshSession() {
   } catch(e) { setStatus('Refresh failed: ' + e.message); }
 }
 // ── Update banner ──
+function _formatUpdateTargetStatus(label,info){
+  if(!info||!(info.behind>0)) return null;
+  const branch=info.branch?` (${info.branch})`:'';
+  return `${label}${branch}: ${info.behind} update${info.behind>1?'s':''}`;
+}
 function _showUpdateBanner(data){
   const parts=[];
-  if(data.webui&&data.webui.behind>0) parts.push(`WebUI: ${data.webui.behind} update${data.webui.behind>1?'s':''}`);
-  if(data.agent&&data.agent.behind>0) parts.push(`Agent: ${data.agent.behind} update${data.agent.behind>1?'s':''}`);
+  const webuiPart=_formatUpdateTargetStatus('WebUI',data.webui);
+  const agentPart=_formatUpdateTargetStatus('Agent',data.agent);
+  if(webuiPart) parts.push(webuiPart);
+  if(agentPart) parts.push(agentPart);
   if(!parts.length)return;
   const msg=$('updateMsg');
   if(msg) msg.textContent='\u2B06 '+parts.join(', ')+' available';

--- a/tests/test_update_banner_fixes.py
+++ b/tests/test_update_banner_fixes.py
@@ -396,6 +396,24 @@ class TestUiJsUpdateBanner:
         )
 
 
+class TestUpdateBannerUx:
+    def test_update_banner_includes_repo_branch_labels(self):
+        src = read('static/ui.js')
+        assert 'function _formatUpdateTargetStatus' in src
+        assert 'info.branch' in src
+        assert "_formatUpdateTargetStatus('WebUI',data.webui)" in src
+        assert "_formatUpdateTargetStatus('Agent',data.agent)" in src
+
+    def test_settings_update_check_uses_same_repo_branch_formatter(self):
+        src = read('static/panels.js')
+        m = re.search(r'async function checkUpdatesNow\b.*?\n\}', src, re.DOTALL)
+        assert m, "checkUpdatesNow() not found"
+        fn = m.group(0)
+        assert '_formatUpdateTargetStatus' in fn
+        assert "formatUpdatePart('WebUI',data.webui)" in fn
+        assert "formatUpdatePart('Agent',data.agent)" in fn
+
+
 # ── static/index.html ─────────────────────────────────────────────────────────
 
 class TestIndexHtmlBanner:


### PR DESCRIPTION
Summary:
- Shows the tracked branch/ref next to each update target in the update banner and Settings update check.
- Makes mixed states clearer, e.g. WebUI can be up to date on origin/master while Agent is behind origin/main.
- Reuses one formatter for WebUI and Agent labels with a safe fallback in Settings.

Why:
When only the Agent repo is behind origin/main, the generic banner can be misread as the WebUI itself being behind main. Including the branch/ref removes that ambiguity.

Tests:
- python -m pytest tests/test_update_banner_fixes.py::TestUpdateBannerUx tests/test_update_banner_fixes.py::TestIndexHtmlBanner -q -o addopts=
