### PR TITLE
fix(cron,server): tighten worker broad-except and clean up socket dead code (closes #1578, #1583)

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -198,14 +198,10 @@ def _run_cron_tracked(job, profile_home=None):
     # (threads have no TLS, so get_active_hermes_home() can't resolve).
     ctx = None
     if profile_home is not None:
-        try:
-            from api.profiles import cron_profile_context_for_home
+        from api.profiles import cron_profile_context_for_home
 
-            ctx = cron_profile_context_for_home(profile_home)
-            ctx.__enter__()
-        except Exception:
-            logger.exception("Failed to pin profile %s for cron run", profile_home)
-            ctx = None
+        ctx = cron_profile_context_for_home(profile_home)
+        ctx.__enter__()
 
     try:
         success, output, final_response, error = run_job(job)

--- a/server.py
+++ b/server.py
@@ -27,19 +27,6 @@ class QuietHTTPServer(ThreadingHTTPServer):
     daemon_threads = True
     request_queue_size = 64
     
-    def server_bind(self):
-        """Set socket options to prevent TIME_WAIT and CLOSE-WAIT accumulation."""
-        # Enable address reuse to avoid "Address already in use" errors
-        self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        # Enable TCP keepalive to detect dead connections (Linux)
-        try:
-            self.socket.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 60)   # Start probing after 60s idle
-            self.socket.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, 10)  # Probe every 10s
-            self.socket.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPCNT, 3)     # Drop after 3 failed probes
-        except (OSError, AttributeError):
-            pass  # TCP_KEEP* may not be available on all platforms
-        super().server_bind()
-    
     def handle_error(self, request, client_address):
         """Override to suppress logging for common client disconnect errors."""
         exc_type, exc_value, _ = sys.exc_info()
@@ -63,19 +50,31 @@ class Handler(BaseHTTPRequestHandler):
     timeout = 30  # seconds — kills idle/incomplete connections to prevent thread exhaustion
     
     def setup(self):
-        """Set additional socket options for each connection."""
+        """Set socket options for each accepted connection."""
         super().setup()
-        # Enable TCP keepalive on the connection socket (not just server socket)
+        # TCP_NODELAY — universal, disables Nagle for HTTP latency
         try:
-            import socket
-            self.connection.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)  # Disable Nagle's algorithm
-            # Aggressive keepalive: start after 10s idle, probe every 5s, drop after 3 failures
-            self.connection.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 10)
-            self.connection.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, 5)
-            self.connection.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPCNT, 3)
+            self.connection.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+        except OSError:
+            pass
+        # SO_KEEPALIVE — universal master switch (must be set before timing params)
+        try:
             self.connection.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
-        except (OSError, AttributeError):
-            pass  # May not be available on all platforms
+        except OSError:
+            pass
+        # Per-platform timing parameters
+        if hasattr(socket, 'TCP_KEEPIDLE'):  # Linux
+            try:
+                self.connection.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 10)
+                self.connection.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, 5)
+                self.connection.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPCNT, 3)
+            except OSError:
+                pass
+        elif hasattr(socket, 'TCP_KEEPALIVE'):  # macOS
+            try:
+                self.connection.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPALIVE, 10)
+            except OSError:
+                pass
     _ver_suffix = WEBUI_VERSION.removeprefix('v')
     server_version = ('HermesWebUI/' + _ver_suffix) if _ver_suffix != 'unknown' else 'HermesWebUI'
     def log_message(self, fmt, *args): pass  # suppress default Apache-style log

--- a/tests/test_scheduled_jobs_profile_isolation.py
+++ b/tests/test_scheduled_jobs_profile_isolation.py
@@ -197,3 +197,33 @@ def test_cron_run_does_not_silently_swallow_profile_resolution_errors():
         "HERMES_HOME. Let the exception propagate (500 the request) rather "
         "than corrupt cross-profile state silently."
     )
+
+
+def test_cron_worker_does_not_silently_fall_back_on_profile_context_failure():
+    """_run_cron_tracked must NOT silently set ctx=None when
+    cron_profile_context_for_home(...).__enter__() raises.
+
+    A silent fallback in the worker thread would leave the job running
+    unpinned against process-global HERMES_HOME, silently corrupting
+    cross-profile state — the same class of bug as #1573. We'd rather
+    let the exception propagate and kill the worker thread than risk
+    that.
+
+    Source-level assertion to catch any future re-introduction of the
+    over-broad except clause around the context setup.
+    """
+    from pathlib import Path
+    src = (Path(__file__).resolve().parent.parent / "api" / "routes.py").read_text(encoding="utf-8")
+
+    idx = src.find("def _run_cron_tracked(job, profile_home=None):")
+    assert idx != -1, "_run_cron_tracked not found"
+    body = src[idx : idx + 2000]
+
+    # The profile-context setup must NOT be wrapped in try/except that
+    # silently falls back to ctx=None.
+    assert "except Exception" not in body[:body.find("run_job(job)")], (
+        "_run_cron_tracked silently falls back to ctx=None when "
+        "cron_profile_context_for_home(...).__enter__() raises. That leaves "
+        "the worker thread unpinned against process-global HERMES_HOME. "
+        "Let the exception propagate rather than corrupt cross-profile state."
+    )


### PR DESCRIPTION
## Summary

Two small cleanups: tighten worker-side broad-except in _run_cron_tracked (#1578) and clean up dead socket code in server.py (#1583).

### #1578
Remove try/except Exception wrapper around cron_profile_context_for_home.__enter__() in _run_cron_tracked. Add regression test.

### #1583
Delete QuietHTTPServer.server_bind() override (dead code). Restructure Handler.setup() with per-platform branches so SO_KEEPALIVE is always applied on macOS.