### PR TITLE
Polish forked session indicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Hermes Web UI -- Changelog
 
+## Unreleased
+
+### Fixed
+
+- **Forked session sidebar indicator is now recognizable and less noisy** (#1613) — replaced the permanent `⑂` OCR glyph with the existing `git-branch` SVG icon, made the indicator subtle until row hover/focus, changed the tooltip to prefer the parent session title with a truncated-id fallback, and removed the hidden click-to-parent behavior from the sidebar row. The `/branch` command and fork data model are unchanged.
+
 ## [v0.50.291] — 2026-05-04
 
 ### Fixed (1 PR — "What's new?" link 404 — closes #1579)

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1692,6 +1692,21 @@ function _sidebarLineageKeyForRow(s){
   return s._lineage_key||s._lineage_root_id||s.lineage_root_id||s.parent_session_id||s.session_id||null;
 }
 
+function _truncatedSessionId(sid){
+  sid=String(sid||'').trim();
+  if(!sid) return '';
+  if(sid.length<=16) return sid;
+  return sid.slice(0,12)+'...';
+}
+
+function _sessionTitleForForkParent(parentSid){
+  if(!parentSid||!Array.isArray(_allSessions)) return '';
+  const parent=_allSessions.find(item=>item&&item.session_id===parentSid);
+  const title=parent&&String(parent.title||'').trim();
+  if(!title||title==='Untitled') return '';
+  return title;
+}
+
 function _attachChildSessionsToSidebarRows(collapsedRows, rawSessions){
   const rows=(collapsedRows||[]).filter(s=>!_isChildSession(s)).map(s=>({...s}));
   const visibleBySid=new Map();
@@ -2069,13 +2084,9 @@ function renderSessionListFromCache(){
     if(s.parent_session_id){
       const branchInd=document.createElement('span');
       branchInd.className='session-branch-indicator';
-      branchInd.textContent='\u2442'; // ⑂
-      branchInd.title=(typeof t==='function'?t('forked_from'):'Forked from')+' '+s.parent_session_id;
-      branchInd.style.cursor='pointer';
-      branchInd.onclick=(e)=>{
-        e.stopPropagation();
-        if(typeof loadSession==='function') loadSession(s.parent_session_id);
-      };
+      branchInd.innerHTML=li('git-branch',12);
+      const parentLabel=_sessionTitleForForkParent(s.parent_session_id)||_truncatedSessionId(s.parent_session_id);
+      branchInd.title=(typeof t==='function'?t('forked_from'):'Forked from')+' '+parentLabel;
       titleRow.appendChild(branchInd);
     }
     const title=document.createElement('span');

--- a/static/style.css
+++ b/static/style.css
@@ -2448,6 +2448,29 @@ main.main.showing-profiles > #mainProfiles{display:flex;}
 }
 .session-pin-indicator svg{width:10px;height:10px;}
 
+/* ── Fork lineage indicator (inline, subtle until row focus/hover) ── */
+.session-branch-indicator{
+  flex-shrink:0;
+  width:12px;
+  height:12px;
+  color:var(--muted);
+  line-height:1;
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  opacity:.35;
+  pointer-events:none;
+  transition:opacity .15s ease,color .15s ease;
+}
+.session-branch-indicator svg{width:12px;height:12px;}
+.session-item:hover .session-branch-indicator,
+.session-item:focus-within .session-branch-indicator,
+.session-item.menu-open .session-branch-indicator{
+  opacity:.85;
+  color:var(--text);
+}
+.session-item.active .session-branch-indicator{color:var(--accent-text);}
+
 /* ── Cron alert badge ── */
 .cron-badge{position:absolute;top:2px;right:2px;background:#e53e3e;color:#fff;font-size:9px;font-weight:700;min-width:14px;height:14px;line-height:14px;text-align:center;border-radius:7px;padding:0 3px;}
 .cron-new-dot{width:7px;height:7px;border-radius:50%;background:var(--success,#22c55e);flex-shrink:0;animation:cron-dot-pulse 2s ease-in-out infinite;}

--- a/tests/test_465_session_branching.py
+++ b/tests/test_465_session_branching.py
@@ -6,7 +6,7 @@ Verifies:
   3. Frontend /branch slash command is registered
   4. forkFromMessage function exists in commands.js
   5. Fork button (git-branch icon) is rendered in ui.js message actions
-  6. Parent session indicator (⑂) is rendered in sessions.js sidebar
+  6. Parent session indicator uses a subtle git-branch icon in sessions.js sidebar
   7. i18n keys exist for all branch-related strings
   8. git-branch icon exists in icons.js
 """
@@ -228,12 +228,14 @@ def test_sidebar_parent_indicator():
         "sessions.js should check parent_session_id"
     assert 'session-branch-indicator' in src, \
         "Should have session-branch-indicator class"
-    assert '\\u2442' in src, \
-        "Should use ⑂ character for parent indicator"
+    assert "li('git-branch',12)" in src, \
+        "Sidebar parent indicator should use the git-branch icon"
+    assert '\\u2442' not in src, \
+        "Sidebar parent indicator should not use the opaque OCR double-backslash glyph"
 
 
-def test_parent_indicator_clickable():
-    """Verify parent indicator navigates to parent session on click."""
+def test_parent_indicator_not_clickable():
+    """Verify parent indicator is informational, not hidden navigation."""
     with open('static/sessions.js') as f:
         src = f.read()
     # Find the parent indicator block
@@ -243,8 +245,34 @@ def test_parent_indicator_clickable():
     )
     assert parent_block, "Could not find parent indicator block"
     block = parent_block.group(0)
-    assert 'loadSession(' in block, \
-        "Parent indicator should call loadSession on click"
+    assert 'loadSession(' not in block, \
+        "Parent indicator should not navigate to the parent from the sidebar"
+    assert 'onclick' not in block, \
+        "Parent indicator should not register a hidden click target"
+
+
+def test_parent_indicator_tooltip_uses_parent_title_fallback():
+    """Tooltip should prefer a parent title and only fall back to a short id."""
+    with open('static/sessions.js') as f:
+        src = f.read()
+    assert 'function _sessionTitleForForkParent' in src, \
+        "sessions.js should resolve a user-facing parent title"
+    assert 'function _truncatedSessionId' in src, \
+        "sessions.js should fall back to a truncated id, not raw session_id"
+    assert "_sessionTitleForForkParent(s.parent_session_id)||_truncatedSessionId(s.parent_session_id)" in src, \
+        "parent indicator tooltip must prefer title and fall back to truncated id"
+
+
+def test_parent_indicator_hover_only_style():
+    """The sidebar lineage indicator should be visually subdued until row hover/focus."""
+    with open('static/style.css') as f:
+        src = f.read()
+    assert '.session-branch-indicator' in src, \
+        "Missing session branch indicator CSS"
+    assert 'opacity:.35' in src, \
+        "Fork lineage indicator should be subdued at rest"
+    assert '.session-item:hover .session-branch-indicator' in src, \
+        "Fork lineage indicator should become visible on row hover"
 
 
 # ── Frontend: i18n keys ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes #1613.

This polishes the forked-session indicator in the sidebar so it is recognizable without adding permanent visual noise:

- replaces the opaque `⑂` glyph with the existing `git-branch` SVG icon
- keeps the indicator subtle at rest and makes it more visible on row hover/focus/active states
- updates the tooltip to prefer the parent session title, with a truncated session id fallback
- removes the hidden click-to-parent behavior from the sidebar row indicator

The underlying `/branch` command and fork data model are unchanged. This is only the sidebar affordance cleanup discussed in #1613.

## Verification

- `.venv_test/bin/pytest tests/test_465_session_branching.py`
- `node --check static/sessions.js`
- `git diff --check`
