### PR TITLE
Show Hermes Agent version in Settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Hermes Web UI -- Changelog
 
+## Unreleased
+
+### Fixed
+
+- **Show Hermes Agent version in Settings → System** (#1606) — added `agent_version` detection for display in System settings (`~/.hermes/hermes-agent/VERSION` preferred, git describe fallback), surfaced it alongside existing `webui_version` in `GET /api/settings`, and updated the System pane badge UI with a labeled Agent pill plus graceful fallback when the agent cannot be detected.
+
 ## [v0.50.292] — 2026-05-04
 
 ### Fixed (12 PRs — multi-tab SSE + subpath routes + cross-source lineage + paste UX + 3 follow-ups)

--- a/api/routes.py
+++ b/api/routes.py
@@ -1743,8 +1743,9 @@ def handle_get(handler, parsed) -> bool:
         # Inject the running version so the UI badge stays in sync with git tags
         # without any manual release step.
         try:
-            from api.updates import WEBUI_VERSION
+            from api.updates import AGENT_VERSION, WEBUI_VERSION
             settings["webui_version"] = WEBUI_VERSION
+            settings["agent_version"] = AGENT_VERSION
         except Exception:
             pass
         return j(handler, settings)

--- a/api/updates.py
+++ b/api/updates.py
@@ -117,8 +117,34 @@ def _detect_webui_version() -> str:
     return 'unknown'
 
 
+def _detect_agent_version() -> str:
+    """Detect the running Hermes Agent version for UI display."""
+    if _AGENT_DIR is None:
+        return 'not detected'
+
+    version_file = Path(_AGENT_DIR) / "VERSION"
+    try:
+        if version_file.exists():
+            text = version_file.read_text(encoding='utf-8').strip()
+            if text:
+                return text
+    except Exception:
+        pass
+
+    # Fallback: infer from git describe when the checkout exists but no VERSION
+    # file is available (common in source checkouts and developer environments).
+    if not Path(_AGENT_DIR).exists():
+        return 'not detected'
+    out, ok = _run_git(['describe', '--tags', '--always'], _AGENT_DIR, timeout=3)
+    if ok and out:
+        return out
+
+    return 'not detected'
+
+
 # Resolved once at import time — tags cannot change without a process restart.
 WEBUI_VERSION: str = _detect_webui_version()
+AGENT_VERSION: str = _detect_agent_version()
 
 
 def _split_remote_ref(ref):

--- a/static/index.html
+++ b/static/index.html
@@ -920,7 +920,8 @@
                 <div class="settings-section-meta" data-i18n="settings_section_system_meta">Instance version and access controls.</div>
               </div>
               <div id="checkUpdatesBlock">
-                <span class="settings-version-badge">—</span>
+                <span class="settings-version-badge" id="settings-webui-version-badge">WebUI: —</span>
+                <span class="settings-version-badge" id="settings-agent-version-badge">Agent: not detected</span>
                 <button class="btn-tiny" id="btnCheckUpdatesNow" onclick="checkUpdatesNow()" title="Check for updates now" data-i18n-title="settings_check_now"><svg id="checkUpdatesSpinner" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="spinner-xs" aria-hidden="true"><path d="M21 12a9 9 0 1 1-6.219-8.56"/><polyline points="21 3 21 9 15 9"/></svg><span id="checkUpdatesLabel" data-i18n="settings_check_now">Check now</span></button>
                 <span id="checkUpdatesStatus"></span>
               </div>

--- a/static/panels.js
+++ b/static/panels.js
@@ -3021,10 +3021,17 @@ function _retryPreferencesAutosave(){
 async function loadSettingsPanel(){
   try{
     const settings=await api('/api/settings');
-    // Populate the version badge from the server — keeps it in sync with git
+    // Populate the version badges from the server — keeps them in sync with git
     // tags automatically without any manual release step.
-    const vbadge=document.querySelector('.settings-version-badge');
-    if(vbadge && settings.webui_version) vbadge.textContent=settings.webui_version;
+    const webuiBadge = $('settings-webui-version-badge');
+    if(webuiBadge){
+      webuiBadge.textContent = `WebUI: ${settings.webui_version || 'not detected'}`;
+    }
+    const agentBadge = $('settings-agent-version-badge');
+    if(agentBadge){
+      const agentVersion = (settings.agent_version || 'not detected').toString().trim() || 'not detected';
+      agentBadge.textContent = `Agent: ${agentVersion}`;
+    }
     // Hydrate appearance controls first so a slow /api/models request
     // cannot overwrite an in-progress theme/skin selection.
     const themeSel=$('settingsTheme');

--- a/tests/test_version_badge.py
+++ b/tests/test_version_badge.py
@@ -3,11 +3,12 @@ Tests for the dynamic version badge (issue: stale hardcoded version strings).
 
 Covers:
   1. api/updates.py: _detect_webui_version() resolution chain
-  2. api/updates.py: WEBUI_VERSION module constant is set and non-empty
-  3. api/routes.py: GET /api/settings includes webui_version key
-  4. static/index.html: hardcoded stale badge is gone
-  5. static/panels.js: loadSettingsPanel() populates badge from settings
-  6. server.py: server_version is not the old hardcoded string
+  2. api/updates.py: _detect_agent_version() detection fallback
+  3. api/updates.py: WEBUI_VERSION module constant is set and non-empty
+  4. api/routes.py: GET /api/settings includes webui_version and agent_version keys
+  5. static/index.html: two version badges are present
+  6. static/panels.js: loadSettingsPanel() populates both version badges from settings
+  7. server.py: server_version is not the old hardcoded string
 """
 import importlib
 import sys
@@ -102,7 +103,65 @@ class TestDetectWebUIVersion:
 
 
 # ---------------------------------------------------------------------------
-# 2. WEBUI_VERSION module constant
+# 2. _detect_agent_version — resolution chain
+# ---------------------------------------------------------------------------
+
+class TestDetectAgentVersion:
+
+    def _fresh_detect(self, mock_run_git=None, version_file_content=None, tmp_path=None):
+        """Call _detect_agent_version() with controlled dependencies."""
+        import api.updates as upd
+
+        fake_root = tmp_path or Path('/nonexistent-agent-path')
+
+        if version_file_content is not None:
+            vf = fake_root / 'VERSION'
+            vf.write_text(version_file_content, encoding='utf-8')
+
+        def _run_git_side_effect(args, cwd, timeout=10):
+            if mock_run_git is not None:
+                return mock_run_git(args, cwd, timeout)
+            return ('', False)
+
+        with patch.object(upd, '_run_git', side_effect=_run_git_side_effect), \
+             patch.object(upd, '_AGENT_DIR', fake_root):
+            return upd._detect_agent_version()
+
+    def test_version_file_is_preferred(self, tmp_path):
+        """Agent VERSION file should be read before git fallback."""
+        result = self._fresh_detect(
+            mock_run_git=lambda args, cwd, timeout: ('v0.50.999', True),
+            version_file_content='v0.60.1\n',
+            tmp_path=tmp_path,
+        )
+        assert result == 'v0.60.1'
+
+    def test_git_fallback_used_when_version_file_missing(self, tmp_path):
+        """When VERSION file is absent, we fall back to git describe in agent path."""
+        (tmp_path / '.git').mkdir()
+        result = self._fresh_detect(
+            mock_run_git=lambda args, cwd, timeout: ('v0.60.2', True),
+            tmp_path=tmp_path,
+        )
+        assert result == 'v0.60.2'
+
+    def test_missing_agent_returns_not_detected(self):
+        """When no agent checkout is available, detect function returns 'not detected'."""
+        import api.updates as upd
+        with patch.object(upd, '_AGENT_DIR', None):
+            assert upd._detect_agent_version() == 'not detected'
+
+    def test_agent_detect_returns_not_detected_on_fail(self, tmp_path):
+        """Git fallback failure should remain user-friendly and not raise."""
+        result = self._fresh_detect(
+            mock_run_git=lambda args, cwd, timeout: ('', False),
+            tmp_path=tmp_path,
+        )
+        assert result == 'not detected'
+
+
+# ---------------------------------------------------------------------------
+# 3. WEBUI_VERSION module constant
 # ---------------------------------------------------------------------------
 
 class TestWebUIVersionConstant:
@@ -124,7 +183,7 @@ class TestWebUIVersionConstant:
 
 
 # ---------------------------------------------------------------------------
-# 3. GET /api/settings includes webui_version
+# 4. GET /api/settings includes webui_version and agent_version
 # ---------------------------------------------------------------------------
 
 class TestSettingsEndpointVersion:
@@ -154,9 +213,13 @@ class TestSettingsEndpointVersion:
             '/api/settings response must contain webui_version key'
         )
         assert captured['data']['webui_version'] == upd.WEBUI_VERSION
+        assert 'agent_version' in captured.get('data', {}), (
+            '/api/settings response must contain agent_version key'
+        )
+        assert captured['data']['agent_version'] == upd.AGENT_VERSION
 
     def test_api_settings_webui_version_not_empty(self):
-        """webui_version in /api/settings must be a non-empty string."""
+        """webui_version and agent_version in /api/settings must be non-empty strings."""
         import api.routes as routes
 
         handler = MagicMock()
@@ -174,6 +237,8 @@ class TestSettingsEndpointVersion:
 
         version = captured.get('data', {}).get('webui_version', '')
         assert version, 'webui_version in /api/settings must not be empty'
+        agent_version = captured.get('data', {}).get('agent_version', '')
+        assert agent_version, 'agent_version in /api/settings must not be empty'
 
     def test_api_settings_no_password_hash(self):
         """password_hash must still be stripped even with version injection."""
@@ -198,7 +263,7 @@ class TestSettingsEndpointVersion:
 
 
 # ---------------------------------------------------------------------------
-# 4. static/index.html — no stale hardcoded badge
+# 5. static/index.html — version badges
 # ---------------------------------------------------------------------------
 
 class TestIndexHTMLBadge:
@@ -215,15 +280,18 @@ class TestIndexHTMLBadge:
         )
 
     def test_badge_element_still_present(self):
-        """settings-version-badge span must still be in the DOM (JS needs the target)."""
+        """System version badge spans must still be in the DOM for both WebUI and Agent pills."""
         html = self._read_html()
-        assert 'settings-version-badge' in html, (
-            'settings-version-badge span missing from index.html — JS cannot populate it'
+        assert 'settings-webui-version-badge' in html, (
+            'WebUI badge element missing from index.html'
+        )
+        assert 'settings-agent-version-badge' in html, (
+            'Agent badge element missing from index.html'
         )
 
 
 # ---------------------------------------------------------------------------
-# 5. static/panels.js — badge population from settings
+# 6. static/panels.js — badge population from settings
 # ---------------------------------------------------------------------------
 
 class TestPanelsJSVersionBadge:
@@ -239,16 +307,22 @@ class TestPanelsJSVersionBadge:
             'to populate the badge dynamically'
         )
 
-    def test_panels_js_targets_version_badge(self):
-        """panels.js must target the .settings-version-badge element."""
+    def test_panels_js_targets_version_badges(self):
+        """loadSettingsPanel must target the two version badge elements."""
         src = self._read_js()
-        assert 'settings-version-badge' in src, (
-            'panels.js must query .settings-version-badge to update the badge text'
+        assert 'settings-webui-version-badge' in src, (
+            'panels.js must query #settings-webui-version-badge to update the WebUI text'
+        )
+        assert 'settings-agent-version-badge' in src, (
+            'panels.js must query #settings-agent-version-badge to update the Agent text'
+        )
+        assert 'agent_version' in src, (
+            'loadSettingsPanel must read settings.agent_version to populate the agent badge'
         )
 
 
 # ---------------------------------------------------------------------------
-# 6. server.py — server_version not the old hardcoded string
+# 7. server.py — server_version not the old hardcoded string
 # ---------------------------------------------------------------------------
 
 class TestServerVersionHeader:


### PR DESCRIPTION
## Thinking Path

Settings already shows the WebUI version from `GET /api/settings`, but there was no equivalent Hermes Agent version in the System section. The lowest-risk shape is to mirror the existing WebUI version path: detect the agent version server-side, expose it in the settings payload, and render it as a second System badge.

Closes #1606.

## What Changed

- Added Hermes Agent version detection in `api/updates.py`.
  - Prefer the agent `VERSION` file when present.
  - Fall back to `git describe --tags --always` from the detected agent checkout.
  - Return `not detected` when Hermes Agent is unavailable or cannot be resolved.
- Added `agent_version` to `GET /api/settings` alongside `webui_version`.
- Updated Settings → System to show separate `WebUI` and `Agent` version pills.
- Extended version-badge regression coverage for the agent detection chain, settings payload, and frontend badge targets.

## Why It Matters

Users can now confirm both moving parts from the WebUI: the WebUI version and the underlying Hermes Agent version. That matters when diagnosing parity issues, install drift, or cases where WebUI is updated but the agent checkout is not.

## Verification

- `python -m py_compile api/updates.py api/routes.py`
- `node --check static/panels.js`
- `pytest tests/test_version_badge.py -q`

## Risks / Follow-ups

- The version is resolved at server import time, matching the existing `WEBUI_VERSION` pattern. If the agent checkout changes while the server is running, the badge updates after restart.
- This PR only displays the detected version; it does not change update or install behavior.

## Model Used

- `gpt-5.3-codex-spark` worker implementation
- GPT-5 coordinator review and PR gate
