### PR TITLE
Assign new sessions to active project filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Hermes Web UI -- Changelog
 
+## Unreleased
+
+### Fixed
+
+- **Project-filter-aware session creation** (#1468) — when creating a new conversation, `/api/session/new` now receives `project_id` derived from the current sidebar project filter (`_activeProject`) so filtered project views create conversations in that same project by default. The all-projects state (`_activeProject === null`) and unassigned view (`NO_PROJECT_FILTER`) now pass `null`, preventing accidental project assignment. Archived-only visibility does not override an active project filter.
+
 ## [v0.50.292] — 2026-05-04
 
 ### Fixed (12 PRs — multi-tab SSE + subpath routes + cross-source lineage + paste UX + 3 follow-ups)

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -287,13 +287,14 @@ async function newSession(flash){
   const newModelState=(canQualify&&typeof _modelStateForSelect==='function')
     ? _modelStateForSelect(modelSel,selectedDefaultModel)
     : {model:selectedDefaultModel,model_provider:null};
+  const activeProjectId=_activeProject===NO_PROJECT_FILTER ? null : _activeProject;
   const reqBody={
     model:newModelState.model,
     model_provider:newModelState.model_provider||null,
     workspace:inheritWs,
     profile:S.activeProfile||'default',
+    project_id:activeProjectId||null,
   };
-  if(_activeProject&&_activeProject!==NO_PROJECT_FILTER) reqBody.project_id=_activeProject;
   const data=await api('/api/session/new',{method:'POST',body:JSON.stringify(reqBody)});
   S.session=data.session;S.messages=data.session.messages||[];
   S.lastUsage={...(data.session.last_usage||{})};

--- a/tests/test_issue1468_project_filter_new_session.py
+++ b/tests/test_issue1468_project_filter_new_session.py
@@ -1,0 +1,34 @@
+"""Regression test for #1468: new conversations in filtered project sidebar."""
+
+from pathlib import Path
+import re
+
+REPO_ROOT = Path(__file__).parent.parent
+SESSIONS_JS = (REPO_ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
+
+
+def _new_session_block() -> str:
+    """Return the source block for `newSession()` only."""
+    start = SESSIONS_JS.find("async function newSession(")
+    assert start >= 0, "newSession() not found in sessions.js"
+    next_fn = SESSIONS_JS.find("async function ", start + 10)
+    return SESSIONS_JS[start:next_fn if next_fn >= 0 else None]
+
+
+def test_new_session_post_payload_includes_project_id_with_sentinel_safe_fallback():
+    """newSession() must send project_id and map NO_PROJECT_FILTER to null."""
+    block = _new_session_block()
+    assert "activeProjectId=_activeProject===NO_PROJECT_FILTER ? null : _activeProject" in block, (
+        "newSession() should normalize NO_PROJECT_FILTER to null before building request body"
+    )
+    assert re.search(r"project_id:\s*activeProjectId\s*\|\|\s*null", block), (
+        "newSession() should always include project_id in the request and pass null for the "
+        "all-projects/unassigned cases"
+    )
+    assert "_showArchived?null" not in block, (
+        "archived-only visibility should not override an active project filter during creation"
+    )
+    # Guard against the old accidental behavior of setting only when truthy.
+    assert "if(_activeProject&&_activeProject!==NO_PROJECT_FILTER) reqBody.project_id" not in block, (
+        "newSession() should no longer guard project_id behind a truthy check"
+    )


### PR DESCRIPTION
## Thinking Path

When a user is already viewing a project-filtered sidebar, creating a new conversation should keep that conversation in the visible project context. The backend already accepts `project_id` on session creation, so the correct layer is the frontend `newSession()` request payload.

Closes #1468.

## What Changed

- Updated `static/sessions.js:newSession()` to always include `project_id` in the `/api/session/new` payload.
- Derives `project_id` from the active project filter:
  - real project filter → that project id
  - all-projects view → `null`
  - unassigned filter sentinel → `null`
- Leaves workspace, profile, and model inheritance unchanged.
- Added a focused regression test for the request-payload contract.

## Why It Matters

Project filtering now behaves like a creation context, not just a read-only view. A new conversation created while looking at a project stays in that project instead of disappearing from the current filtered list.

## Verification

- `node --check static/sessions.js`
- `pytest tests/test_issue1468_project_filter_new_session.py tests/test_sidebar_unassigned_filter.py -q`

## Risks / Follow-ups

- This PR intentionally does not add a Settings opt-out. If users want project filtering to remain view-only, that can be handled as a separate preference.
- Archived visibility does not override a real active project filter; archive state remains a visibility filter rather than a project assignment rule.

## Model Used

- `gpt-5.3-codex-spark` worker implementation
- GPT-5 coordinator review and PR gate
