### PR TITLE
test: cover provider config cleanup path

### DIFF
--- a/api/providers.py
+++ b/api/providers.py
@@ -15,7 +15,6 @@ from typing import Any
 from api.config import (
     _PROVIDER_DISPLAY,
     _PROVIDER_MODELS,
-    _get_config_path,
     _save_yaml_config_file,
     get_config,
     invalidate_models_cache,

--- a/tests/test_provider_management.py
+++ b/tests/test_provider_management.py
@@ -297,6 +297,42 @@ class TestSetProviderKey:
 class TestRemoveProviderKey:
     """Unit tests for remove_provider_key() wrapper."""
 
+    def test_clean_provider_key_uses_late_bound_config_path(self, monkeypatch, tmp_path):
+        """Config cleanup must honor api.config._get_config_path monkeypatches.
+
+        PR #1597 fixed provider-key cleanup by resolving the config path through
+        the api.config module at call time. If the implementation goes back to
+        the function imported into api.providers at module load, this test cleans
+        stale_config instead of active_config.
+        """
+        import yaml
+
+        import api.config as cfg_mod
+        import api.providers as providers
+
+        stale_config = tmp_path / "stale-config.yaml"
+        active_config = tmp_path / "active-config.yaml"
+        stale_config.write_text(
+            "providers:\n  openai:\n    api_key: stale-secret\n",
+            encoding="utf-8",
+        )
+        active_config.write_text(
+            "providers:\n  openai:\n    api_key: active-secret\nmodel:\n  provider: openai\n  api_key: active-model-secret\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setattr(providers, "_get_config_path", lambda: stale_config, raising=False)
+        monkeypatch.setattr(cfg_mod, "_get_config_path", lambda: active_config)
+        monkeypatch.setattr(providers, "reload_config", lambda: None)
+
+        providers._clean_provider_key_from_config("openai")
+
+        stale = yaml.safe_load(stale_config.read_text(encoding="utf-8"))
+        active = yaml.safe_load(active_config.read_text(encoding="utf-8"))
+        assert stale["providers"]["openai"]["api_key"] == "stale-secret"
+        assert "api_key" not in active["providers"]["openai"]
+        assert active["model"] == {"provider": "openai"}
+
     def test_remove_provider_key_calls_set_with_none(self, monkeypatch, tmp_path):
         """remove_provider_key should delegate to set_provider_key(id, None)."""
         _install_fake_hermes_cli(monkeypatch)


### PR DESCRIPTION
## Thinking Path

- PR #1597 fixed pytest config isolation and also adjusted provider-key cleanup to resolve `api.config._get_config_path()` at call time.
- The reviewer correctly noted that the runtime cleanup path needed its own explicit regression coverage.
- This follow-up keeps the runtime behavior unchanged and pins the late-binding contract so a future import cleanup does not silently reintroduce stale config-path cleanup.
- I also removed the now-unused `_get_config_path` import from `api.providers` so the intended path ownership is clearer.

## What Changed

- Added a provider-management regression test that sets a stale `api.providers._get_config_path` and a live `api.config._get_config_path`, then verifies cleanup only touches the live module-resolved config path.
- Removed the unused `_get_config_path` import from `api/providers.py`.

## Why It Matters

Provider key removal is safety-sensitive because it edits config files. The test now proves `_clean_provider_key_from_config()` follows the active config module path resolver instead of a stale imported function reference.

## Verification

```bash
/home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_provider_management.py::TestRemoveProviderKey tests/test_pytest_config_isolation.py -q
/home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_provider_management.py tests/test_pytest_config_isolation.py -q
git diff --check
```

Result:

```text
3 passed in 1.55s
20 passed in 2.04s
git diff --check passed
```

UI media:

- Not applicable; this PR is test/runtime cleanup only.

## Risks / Follow-ups

- Low risk: the only product-code change removes an unused import; the runtime late-binding behavior already exists on `master`.
- This is a direct follow-up to the reviewer note on #1597 rather than a user-visible feature.

## Model Used

AI assisted.

- Provider: OpenAI Codex
- Model: `gpt-5.5`
- Notable tool use: terminal, git, pytest, GitHub CLI, repository skill/context review
