### PR TITLE
Release v0.50.293 — 3-PR batch (profile isolation trio + agent version + #1597 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,18 +14,25 @@
 
 ### Tests
 
-4142 → **4181 passing** (+39 regression tests across `tests/test_issue1611_session_profile_filtering.py` (11), `tests/test_issue1612_renamed_root_profile.py` (11), `tests/test_issue1614_project_profile_filtering.py` (11), `tests/test_provider_management.py::test_clean_provider_key_uses_late_bound_config_path` (1), and `tests/test_version_badge.py` agent-detect chain (~5)). 0 regressions. Full suite in ~120s.
+4142 → **4180 passing** (+38 regression tests across `tests/test_issue1611_session_profile_filtering.py` (11), `tests/test_issue1612_renamed_root_profile.py` (11), `tests/test_issue1614_project_profile_filtering.py` (11), `tests/test_provider_management.py::test_clean_provider_key_uses_late_bound_config_path` (1), and `tests/test_version_badge.py` agent-detect chain (~5)). 0 regressions. Full suite in ~120s.
 
 ### Pre-release verification
 
-- Self-built fix (nesquena-hermes), Opus advisor pre-merge pass with 2 SHOULD-FIX absorbed in-PR (see Opus-applied fixes below); independent review APPROVED by nesquena pending.
+- **Opus advisor on full stage-293 diff: SHIP verdict.** Two SHOULD-FIX items absorbed in-release per <20-LOC defensive policy: (a) `api/models.py:load_projects()` re-reads from disk inside `_PROJECTS_MIGRATION_LOCK` when `_projects_migrated` is found True post-wait — closes a startup-window staleness race where a thread that read pre-migration could return stale untagged rows after a peer migrated and wrote disk; (b) `_detect_agent_version()` now uses `git describe --tags --always --dirty` for symmetry with `_detect_webui_version()`. One non-blocking client-side filter cross-alias edge case deferred as follow-up issue.
+- Self-built fix (#1629, nesquena-hermes), independent review **APPROVED by nesquena** with comprehensive end-to-end trace, cross-tool verification against fresh agent tarball, security audit, race/state analysis, and 13-row edge-case matrix.
+- 31 dedicated regression tests for #1611/#1612/#1614 invariants. Source-string assertions pin the active-profile guards on `/api/projects/{rename,delete}` and `/api/session/move`.
 - `_is_root_profile` invalidation cycle exercised via test_is_root_profile_invalidation_drops_stale (cache populated, then dropped after simulated profile rename).
 - `ensure_cron_project` per-profile isolation exercised via test_ensure_cron_project_creates_per_profile (two profiles → two distinct project_ids).
-- Legacy migration covered: untagged projects with sessions inherit session profile; orphan projects fall back to 'default'; idempotent (no-op on second call).
 - Cross-alias matching pinned: `_profiles_match('default', 'kinni')` returns True only when `kinni` is `is_default`.
-- Source-string assertions pin the active-profile guards on `/api/projects/{rename,delete}` and `/api/session/move`.
 
-### Opus-applied fixes (absorbed in-PR per release policy)
+### Opus-applied fixes (absorbed in-release)
+
+**From stage-293 review:**
+
+- **SHOULD-FIX A (project migration startup race)**: `api/models.py:load_projects()` re-reads from disk after acquiring `_PROJECTS_MIGRATION_LOCK` and finding `_projects_migrated=True`. Without this, Thread B that read pre-migration could return stale untagged rows after Thread A migrated and wrote disk — a mutation route on those stale rows could silently overwrite the migration. Window is process-startup-only and very narrow; fix is 8 LOC.
+- **SHOULD-FIX B (agent version `--dirty` symmetry)**: `_detect_agent_version()` now passes `--dirty` to `git describe --tags --always`, matching `_detect_webui_version()`. Operators with locally-modified agent checkouts now see the dirty marker.
+
+**Already absorbed in #1629 (in-PR Opus pre-merge pass before staging):**
 
 - **SHOULD-FIX #1 (renamed-root client cross-alias)**: removed the strict-equality client filter at `static/sessions.js:1853`. Server-side `_profiles_match` cross-aliases `'default'`-tagged rows to a renamed root `'kinni'`; a strict-equality client filter would have rejected them, dropping every legacy session for renamed-root users. Server is now solely authoritative for profile scoping. Same fix applied to the `otherProfileCount` client fallback.
 - **SHOULD-FIX #2 (messaging-source dedupe ordering)**: moved `_keep_latest_messaging_session_per_source(merged)` to AFTER the profile filter at `api/routes.py:2078`. Before: the dedupe ran on the merged-cross-profile list with profile-blind keys, discarding the older profile's row across profiles, then the profile filter scoped to the active profile — leaving zero rows for any messaging identity the active profile shared with another profile. After: filter first, then dedupe within scope.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,16 +10,24 @@
 
 ### Tests
 
-4142 → **4173 passing** (+31 regression tests across `tests/test_issue1611_session_profile_filtering.py` (9), `tests/test_issue1612_renamed_root_profile.py` (11), `tests/test_issue1614_project_profile_filtering.py` (11)). 0 regressions. Full suite in ~120s.
+4142 → **4175 passing** (+33 regression tests across `tests/test_issue1611_session_profile_filtering.py` (11), `tests/test_issue1612_renamed_root_profile.py` (11), `tests/test_issue1614_project_profile_filtering.py` (11)). 0 regressions. Full suite in ~120s.
 
 ### Pre-release verification
 
-- Self-built fix (nesquena-hermes), pending independent review APPROVED by nesquena and Opus advisor pre-merge pass.
+- Self-built fix (nesquena-hermes), Opus advisor pre-merge pass with 2 SHOULD-FIX absorbed in-PR (see Opus-applied fixes below); independent review APPROVED by nesquena pending.
 - `_is_root_profile` invalidation cycle exercised via test_is_root_profile_invalidation_drops_stale (cache populated, then dropped after simulated profile rename).
 - `ensure_cron_project` per-profile isolation exercised via test_ensure_cron_project_creates_per_profile (two profiles → two distinct project_ids).
 - Legacy migration covered: untagged projects with sessions inherit session profile; orphan projects fall back to 'default'; idempotent (no-op on second call).
 - Cross-alias matching pinned: `_profiles_match('default', 'kinni')` returns True only when `kinni` is `is_default`.
 - Source-string assertions pin the active-profile guards on `/api/projects/{rename,delete}` and `/api/session/move`.
+
+### Opus-applied fixes (absorbed in-PR per release policy)
+
+- **SHOULD-FIX #1 (renamed-root client cross-alias)**: removed the strict-equality client filter at `static/sessions.js:1853`. Server-side `_profiles_match` cross-aliases `'default'`-tagged rows to a renamed root `'kinni'`; a strict-equality client filter would have rejected them, dropping every legacy session for renamed-root users. Server is now solely authoritative for profile scoping. Same fix applied to the `otherProfileCount` client fallback.
+- **SHOULD-FIX #2 (messaging-source dedupe ordering)**: moved `_keep_latest_messaging_session_per_source(merged)` to AFTER the profile filter at `api/routes.py:2078`. Before: the dedupe ran on the merged-cross-profile list with profile-blind keys, discarding the older profile's row across profiles, then the profile filter scoped to the active profile — leaving zero rows for any messaging identity the active profile shared with another profile. After: filter first, then dedupe within scope.
+- **NIT #3 (migration save-failure)**: `_projects_migrated = True` flag now set only AFTER successful `save_projects()`. A failed save no longer poisons the in-memory state for the rest of process lifetime.
+- **NIT #4 (dead test code)**: cleaned up the dead double-assignment in `test_is_root_profile_invalidation_drops_stale`.
+- **NIT #5 (`_create_profile_fallback` literal-default)**: routed the `clone_from == 'default'` literal in the no-hermes-cli fallback path through `_is_root_profile()` for parity with the other 5 callsites.
 
 
 ## [v0.50.292] — 2026-05-04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Hermes Web UI -- Changelog
 
+## Unreleased
+
+### Fixed
+
+- **Show Hermes Agent version in Settings → System** (#1606) — added `agent_version` detection for display in System settings (`~/.hermes/hermes-agent/VERSION` preferred, git describe fallback), surfaced it alongside existing `webui_version` in `GET /api/settings`, and updated the System pane badge UI with a labeled Agent pill plus graceful fallback when the agent cannot be detected.
+
 ## [v0.50.292] — 2026-05-04
 
 ### Fixed (12 PRs — multi-tab SSE + subpath routes + cross-source lineage + paste UX + 3 follow-ups)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Hermes Web UI -- Changelog
 
+## [v0.50.293] — 2026-05-04
+
+### Fixed (1 PR — profile isolation trio — closes #1611, #1612, #1614)
+
+- **`/api/sessions` and `/api/projects` are now scoped to the active profile by default** (closes #1611 + #1614, reported by @stefanpieter) — the WebUI's session list and project list were both global: `/api/sessions` merged WebUI sidecar sessions and CLI/imported sessions and returned all rows regardless of which `hermes_profile` cookie the client sent, and `/api/projects` had no profile awareness whatsoever. Reporter @stefanpieter ran `curl /api/sessions -H 'Cookie: hermes_profile=haku'` against a multi-profile install and got back sessions tagged `haku`, `kinni`, AND `noblepro` — every profile's history visible from every UI. Frontend filtering had a CLI-bypass at `static/sessions.js:1853` (`s.is_cli_session || s.profile === S.activeProfile`) that let every CLI-imported session through regardless of which profile owned it. **Fix:** server-side filter on both endpoints via the active profile; explicit `?all_profiles=1` opt-in for aggregate views; new `_profiles_match()` helper that honours the renamed-root case (`'default'` and a renamed-root display name like `'kinni'` cross-match because they resolve to the same `~/.hermes` home). Project rows now carry a `profile` field stamped at create-time. `/api/projects/{create,rename,delete}` and `/api/session/move` reject ops on cross-profile projects with 404. `ensure_cron_project()` keys lookup by `(name, profile)` so cron-spawned sessions from profile A no longer surface under the cron chip of profile B. One-time migration in `load_projects()` back-tags legacy untagged projects from any session that uses them, falling back to `'default'`. Frontend drops the CLI-session bypass; toggle-on-toggle re-fetches with `?all_profiles=1` rather than slicing client-cached rows.
+
+- **Renamed root profile no longer 404s on switch** (closes #1612, reported by @stefanpieter) — Hermes Agent allows the root/default profile (`~/.hermes` itself) to have a display name other than the legacy literal `'default'`. WebUI hard-coded `if name == 'default':` at five callsites in `api/profiles.py` (`get_active_hermes_home`, `get_hermes_home_for_profile`, `switch_profile`, `delete_profile_api`, sticky-default writeback), so a renamed root (e.g. `'kinni'` with `is_default=True`, `path=~/.hermes`) fell through every check to `_DEFAULT_HERMES_HOME / 'profiles' / 'kinni'` — a directory that doesn't exist. Switching to the renamed root raised `Profile 'kinni' does not exist.` and broke every code path that resolved `~/.hermes` from a profile name. **Fix:** new `_is_root_profile(name)` central helper that consults `list_profiles_api()` for `is_default=True` matches alongside the legacy `'default'` alias. All five callsites now route through it. Memoized with explicit invalidation hooks at every profile mutation (create, delete) so the lookup cost is paid once per cache window. Sticky `active_profile` file write now stores `''` for renamed root (consistent with the existing legacy contract that empty == root) instead of writing the display name and re-resolving wrong on next boot.
+
+### Tests
+
+4142 → **4173 passing** (+31 regression tests across `tests/test_issue1611_session_profile_filtering.py` (9), `tests/test_issue1612_renamed_root_profile.py` (11), `tests/test_issue1614_project_profile_filtering.py` (11)). 0 regressions. Full suite in ~120s.
+
+### Pre-release verification
+
+- Self-built fix (nesquena-hermes), pending independent review APPROVED by nesquena and Opus advisor pre-merge pass.
+- `_is_root_profile` invalidation cycle exercised via test_is_root_profile_invalidation_drops_stale (cache populated, then dropped after simulated profile rename).
+- `ensure_cron_project` per-profile isolation exercised via test_ensure_cron_project_creates_per_profile (two profiles → two distinct project_ids).
+- Legacy migration covered: untagged projects with sessions inherit session profile; orphan projects fall back to 'default'; idempotent (no-op on second call).
+- Cross-alias matching pinned: `_profiles_match('default', 'kinni')` returns True only when `kinni` is `is_default`.
+- Source-string assertions pin the active-profile guards on `/api/projects/{rename,delete}` and `/api/session/move`.
+
+
 ## [v0.50.292] — 2026-05-04
 
 ### Fixed (12 PRs — multi-tab SSE + subpath routes + cross-source lineage + paste UX + 3 follow-ups)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 > Web companion to the Hermes Agent CLI. Same workflows, browser-native.
 >
-> Last updated: v0.50.292 (May 04, 2026) — 4142 tests collected
+> Last updated: v0.50.293 (May 04, 2026) — 4180 tests collected
 > Test source: `pytest tests/ --collect-only -q`
 > Per-version detail: see [CHANGELOG.md](./CHANGELOG.md)
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -1835,8 +1835,8 @@ Bridged CLI sessions:
 
 ---
 
-*Last updated: v0.50.292, May 04, 2026*
-*Total automated tests collected: 4142*
+*Last updated: v0.50.293, May 04, 2026*
+*Total automated tests collected: 4180*
 *Regression gate: tests/test_regressions.py*
 *Run: pytest tests/ -v --timeout=60*
 *Source: <repo>/*

--- a/api/models.py
+++ b/api/models.py
@@ -1053,7 +1053,16 @@ def load_projects(*, _migrate: bool = True) -> list:
         with _PROJECTS_MIGRATION_LOCK:
             # Re-check inside the lock — another thread may have raced.
             if _projects_migrated:
-                return projects
+                # Per Opus advisor on stage-293: another thread completed
+                # migration and wrote new state to disk while we waited for
+                # the lock. Our `projects` snapshot is the pre-migration
+                # version; re-read so the caller doesn't see stale untagged
+                # rows (which a mutation route could then write back,
+                # silently overwriting the migration).
+                try:
+                    return json.loads(PROJECTS_FILE.read_text(encoding='utf-8'))
+                except Exception:
+                    return projects
             if _backfill_project_profiles_if_needed(projects):
                 try:
                     save_projects(projects)

--- a/api/models.py
+++ b/api/models.py
@@ -1009,12 +1009,8 @@ def _backfill_project_profiles_if_needed(projects: list) -> bool:
     (cached via the module-level _projects_migrated flag) but the result is
     persisted so it's a one-time write.
     """
-    global _projects_migrated
-    if _projects_migrated:
-        return False
     untagged = [p for p in projects if not p.get('profile')]
     if not untagged:
-        _projects_migrated = True
         return False
 
     # Build session_id -> profile map for the untagged project_ids.
@@ -1036,7 +1032,6 @@ def _backfill_project_profiles_if_needed(projects: list) -> bool:
         inferred = session_profile_by_project.get(p.get('project_id'), 'default')
         p['profile'] = inferred
         mutated = True
-    _projects_migrated = True
     return mutated
 
 
@@ -1047,19 +1042,28 @@ def load_projects(*, _migrate: bool = True) -> list:
     on legacy untagged projects (#1614). Disable via `_migrate=False` for
     callsites that want the raw on-disk shape (test fixtures, e.g.).
     """
+    global _projects_migrated
     if not PROJECTS_FILE.exists():
         return []
     try:
         projects = json.loads(PROJECTS_FILE.read_text(encoding='utf-8'))
     except Exception:
         return []
-    if _migrate:
+    if _migrate and not _projects_migrated:
         with _PROJECTS_MIGRATION_LOCK:
+            # Re-check inside the lock — another thread may have raced.
+            if _projects_migrated:
+                return projects
             if _backfill_project_profiles_if_needed(projects):
                 try:
                     save_projects(projects)
+                    _projects_migrated = True
                 except Exception:
                     logger.debug("Failed to persist project profile backfill")
+                    # Leave _projects_migrated False so a future call retries.
+            else:
+                # Nothing to migrate — already tagged.
+                _projects_migrated = True
     return projects
 
 def save_projects(projects) -> None:

--- a/api/models.py
+++ b/api/models.py
@@ -990,14 +990,77 @@ def title_from(messages, fallback: str='Untitled'):
 
 # ── Project helpers ──────────────────────────────────────────────────────────
 
-def load_projects() -> list:
-    """Load project list from disk. Returns list of project dicts."""
+_PROJECTS_MIGRATION_LOCK = threading.Lock()
+_projects_migrated = False
+
+
+def _backfill_project_profiles_if_needed(projects: list) -> bool:
+    """Tag any legacy untagged projects (`profile` missing) with a sensible default.
+
+    Strategy:
+      1. For each untagged project, look at the sessions assigned to it via
+         the session index. If any session carries a profile, take that
+         profile.  Most installs are single-profile so this picks up the
+         right answer for everyone.
+      2. Otherwise default to 'default'.
+
+    Returns True if any project was mutated. Safe to call repeatedly — once
+    every project is tagged, this is a no-op. Runs at most once per process
+    (cached via the module-level _projects_migrated flag) but the result is
+    persisted so it's a one-time write.
+    """
+    global _projects_migrated
+    if _projects_migrated:
+        return False
+    untagged = [p for p in projects if not p.get('profile')]
+    if not untagged:
+        _projects_migrated = True
+        return False
+
+    # Build session_id -> profile map for the untagged project_ids.
+    session_profile_by_project: dict[str, str] = {}
+    if SESSION_INDEX_FILE.exists():
+        try:
+            entries = json.loads(SESSION_INDEX_FILE.read_text(encoding='utf-8'))
+            untagged_ids = {p['project_id'] for p in untagged if p.get('project_id')}
+            for e in entries:
+                pid = e.get('project_id')
+                if pid in untagged_ids and e.get('profile'):
+                    # First session profile wins for the project.
+                    session_profile_by_project.setdefault(pid, e['profile'])
+        except Exception:
+            logger.debug("Failed to read session index for project profile backfill")
+
+    mutated = False
+    for p in untagged:
+        inferred = session_profile_by_project.get(p.get('project_id'), 'default')
+        p['profile'] = inferred
+        mutated = True
+    _projects_migrated = True
+    return mutated
+
+
+def load_projects(*, _migrate: bool = True) -> list:
+    """Load project list from disk. Returns list of project dicts.
+
+    On first call, runs a one-time migration to back-fill the `profile` field
+    on legacy untagged projects (#1614). Disable via `_migrate=False` for
+    callsites that want the raw on-disk shape (test fixtures, e.g.).
+    """
     if not PROJECTS_FILE.exists():
         return []
     try:
-        return json.loads(PROJECTS_FILE.read_text(encoding='utf-8'))
+        projects = json.loads(PROJECTS_FILE.read_text(encoding='utf-8'))
     except Exception:
         return []
+    if _migrate:
+        with _PROJECTS_MIGRATION_LOCK:
+            if _backfill_project_profiles_if_needed(projects):
+                try:
+                    save_projects(projects)
+                except Exception:
+                    logger.debug("Failed to persist project profile backfill")
+    return projects
 
 def save_projects(projects) -> None:
     """Write project list to disk."""
@@ -1009,20 +1072,46 @@ _CRON_PROJECT_LOCK = threading.Lock()
 
 
 def ensure_cron_project() -> str:
-    """Return the project_id of the system "Cron Jobs" project, creating it if needed.
+    """Return the project_id of the system "Cron Jobs" project for the active profile.
+
+    Each profile gets its own "Cron Jobs" project so cron-spawned sessions in
+    profile A don't surface under the cron chip of profile B (#1614). Lookup
+    keys on (name, profile) — a legacy untagged "Cron Jobs" project (no
+    `profile` field) is treated as belonging to whichever profile first calls
+    this in a given install, then re-tagged.
 
     Thread-safe and idempotent.  Returns a 12-char hex project_id string.
     """
+    from api.profiles import get_active_profile_name, _is_root_profile
+
+    active = get_active_profile_name() or 'default'
     with _CRON_PROJECT_LOCK:
-        for p in load_projects():
-            if p.get('name') == CRON_PROJECT_NAME:
-                return p['project_id']
-        project_id = uuid.uuid4().hex[:12]
         projects = load_projects()
+        # Look for an existing per-profile cron project. Match either an exact
+        # profile tag or the renamed-root alias (a 'default'-tagged project
+        # under a renamed root, or a renamed-root-tagged project under
+        # 'default'). _is_root_profile is the canonical alias check.
+        for p in projects:
+            if p.get('name') != CRON_PROJECT_NAME:
+                continue
+            row_profile = p.get('profile')
+            if row_profile == active:
+                return p['project_id']
+            if _is_root_profile(row_profile or 'default') and _is_root_profile(active):
+                return p['project_id']
+        # Reuse a legacy untagged cron project — back-tag it to the active profile.
+        for p in projects:
+            if p.get('name') == CRON_PROJECT_NAME and not p.get('profile'):
+                p['profile'] = active
+                save_projects(projects)
+                return p['project_id']
+        # Otherwise create a new one tagged with the active profile.
+        project_id = uuid.uuid4().hex[:12]
         projects.append({
             'project_id': project_id,
             'name': CRON_PROJECT_NAME,
             'color': '#6366f1',
+            'profile': active,
             'created_at': time.time(),
         })
         save_projects(projects)

--- a/api/profiles.py
+++ b/api/profiles.py
@@ -727,7 +727,7 @@ def _create_profile_fallback(name: str, clone_from: str = None,
 
     # Clone config files from source profile if requested
     if clone_config and clone_from:
-        if clone_from == 'default':
+        if _is_root_profile(clone_from):
             source_dir = _DEFAULT_HERMES_HOME
         else:
             source_dir = _DEFAULT_HERMES_HOME / 'profiles' / clone_from
@@ -776,7 +776,7 @@ def create_profile_api(name: str, clone_from: str = None,
     _validate_profile_name(name)
     # Defense-in-depth: validate clone_from here too, even though routes.py
     # also validates it. Any caller that bypasses the HTTP layer gets protection.
-    if clone_from is not None and clone_from != 'default':
+    if clone_from is not None and not _is_root_profile(clone_from):
         _validate_profile_name(clone_from)
 
     try:

--- a/api/profiles.py
+++ b/api/profiles.py
@@ -91,6 +91,76 @@ def _read_active_profile_file() -> str:
 
 # ── Public API ──────────────────────────────────────────────────────────────
 
+# ── Root-profile resolution (#1612) ────────────────────────────────────────
+#
+# Hermes Agent allows the root/default profile (~/.hermes itself) to have a
+# display name other than the legacy literal 'default'.  When that happens,
+# WebUI must NOT resolve the display name as ~/.hermes/profiles/<name> — that
+# directory doesn't exist, and every site that does `if name == 'default':`
+# will fall through to the wrong filesystem path.
+#
+# `_is_root_profile(name)` answers "does this name resolve to ~/.hermes?" and
+# is the canonical replacement for scattered `if name == 'default':` checks
+# in switch_profile, get_active_hermes_home, _validate_profile_name, etc.
+#
+# Cost note: list_profiles_api() shells out via hermes_cli (non-trivial), so
+# we memoize the lookup. The cache is invalidated whenever profiles are
+# created, deleted, renamed, or cloned — i.e. on every mutation site we
+# control.
+_root_profile_name_cache: set[str] = {'default'}
+_root_profile_name_cache_lock = threading.Lock()
+_root_profile_name_cache_loaded = False
+
+
+def _invalidate_root_profile_cache() -> None:
+    """Drop the memoized root-profile-name set.
+
+    Called whenever profile metadata might have changed: create, clone,
+    delete, rename. The next _is_root_profile() call repopulates from
+    list_profiles_api().
+    """
+    global _root_profile_name_cache_loaded
+    with _root_profile_name_cache_lock:
+        _root_profile_name_cache.clear()
+        _root_profile_name_cache.add('default')
+        _root_profile_name_cache_loaded = False
+
+
+def _is_root_profile(name: str) -> bool:
+    """True if *name* resolves to the Hermes Agent root profile (~/.hermes).
+
+    Matches the legacy 'default' alias plus any name where list_profiles_api()
+    reports is_default=True. Memoized; call _invalidate_root_profile_cache()
+    after mutating profile metadata.
+    """
+    global _root_profile_name_cache_loaded
+    if not name:
+        return False
+    if name == 'default':
+        return True
+    with _root_profile_name_cache_lock:
+        if _root_profile_name_cache_loaded:
+            return name in _root_profile_name_cache
+    # Cache miss — populate from list_profiles_api(). Done outside the lock to
+    # avoid holding it across a hermes_cli subprocess call.
+    try:
+        infos = list_profiles_api()
+    except Exception:
+        logger.debug("Failed to list profiles for root-profile lookup", exc_info=True)
+        return False
+    with _root_profile_name_cache_lock:
+        _root_profile_name_cache.clear()
+        _root_profile_name_cache.add('default')
+        for p in infos:
+            try:
+                if p.get('is_default') and p.get('name'):
+                    _root_profile_name_cache.add(p['name'])
+            except (AttributeError, TypeError):
+                continue
+        _root_profile_name_cache_loaded = True
+        return name in _root_profile_name_cache
+
+
 def get_active_profile_name() -> str:
     """Return the currently active profile name.
 
@@ -130,7 +200,7 @@ def get_active_hermes_home() -> Path:
     is respected, not just the process-level global.
     """
     name = get_active_profile_name()
-    if name == 'default':
+    if _is_root_profile(name):
         return _DEFAULT_HERMES_HOME
     profile_dir = _DEFAULT_HERMES_HOME / 'profiles' / name
     if profile_dir.is_dir():
@@ -279,7 +349,9 @@ def get_hermes_home_for_profile(name: str) -> Path:
     empty, 'default', or does not match the profile-name format (rejects path
     traversal such as '../../etc').
     """
-    if not name or name == 'default' or not _PROFILE_ID_RE.fullmatch(name):
+    if not name or _is_root_profile(name):
+        return _DEFAULT_HERMES_HOME
+    if not _PROFILE_ID_RE.fullmatch(name):
         return _DEFAULT_HERMES_HOME
     profile_dir = _DEFAULT_HERMES_HOME / 'profiles' / name
     return profile_dir
@@ -467,7 +539,7 @@ def switch_profile(name: str, *, process_wide: bool = True) -> dict:
             )
 
     # Resolve profile directory
-    if name == 'default':
+    if _is_root_profile(name):
         home = _DEFAULT_HERMES_HOME
     else:
         home = _resolve_named_profile_home(name)
@@ -485,7 +557,7 @@ def switch_profile(name: str, *, process_wide: bool = True) -> dict:
         # Write sticky default for CLI consistency
         try:
             ap_file = _DEFAULT_HERMES_HOME / 'active_profile'
-            ap_file.write_text(name if name != 'default' else '', encoding='utf-8')
+            ap_file.write_text('' if _is_root_profile(name) else name, encoding='utf-8')
         except Exception:
             logger.debug("Failed to write active profile file")
 
@@ -735,6 +807,10 @@ def create_profile_api(name: str, clone_from: str = None,
     profile_path.mkdir(parents=True, exist_ok=True)
     _write_endpoint_to_config(profile_path, base_url=base_url, api_key=api_key)
 
+    # Invalidate cached root-profile-name lookup; create_profile may have added
+    # a new profile that flips is_default semantics on the agent side (#1612).
+    _invalidate_root_profile_cache()
+
     # Find and return the newly created profile info.
     # When hermes_cli is not importable, list_profiles_api() also falls back
     # to the stub default-only list and won't find the new profile by name.
@@ -757,7 +833,7 @@ def create_profile_api(name: str, clone_from: str = None,
 
 def delete_profile_api(name: str) -> dict:
     """Delete a profile. Switches to default first if it's the active one."""
-    if name == 'default':
+    if _is_root_profile(name):
         raise ValueError("Cannot delete the default profile.")
     _validate_profile_name(name)
 
@@ -783,4 +859,6 @@ def delete_profile_api(name: str) -> dict:
         else:
             raise ValueError(f"Profile '{name}' does not exist.")
 
+    # Drop cached root-profile-name lookup — list_profiles_api() shape changed.
+    _invalidate_root_profile_cache()
     return {'ok': True, 'name': name}

--- a/api/providers.py
+++ b/api/providers.py
@@ -15,7 +15,6 @@ from typing import Any
 from api.config import (
     _PROVIDER_DISPLAY,
     _PROVIDER_MODELS,
-    _get_config_path,
     _save_yaml_config_file,
     get_config,
     invalidate_models_cache,

--- a/api/routes.py
+++ b/api/routes.py
@@ -2050,13 +2050,20 @@ def handle_get(handler, parsed) -> bool:
             key=lambda s: s.get("last_message_at") or s.get("updated_at", 0) or 0,
             reverse=True,
         )
-        merged = _keep_latest_messaging_session_per_source(merged)
         # ── Profile scoping (#1611) ────────────────────────────────────────
         # Default: filter to the active profile. ?all_profiles=1 opts into
         # the aggregate view used by the "All profiles" sidebar toggle.
         # The other_profile_count is always returned so the UI can render
         # the "Show N from other profiles" affordance without sending the
         # cross-profile rows by default.
+        #
+        # IMPORTANT: scope BEFORE _keep_latest_messaging_session_per_source.
+        # _messaging_source_key is profile-blind (#1614 follow-up): if the
+        # same Slack/Telegram identity has sessions in profiles A and B, a
+        # profile-blind dedupe would discard the older one even when scoped
+        # to its own profile, leaving that profile with zero rows for that
+        # source. Filter first so the dedupe operates only within the active
+        # profile's rows.
         from api.profiles import get_active_profile_name
         active_profile = get_active_profile_name()
         all_profiles = _all_profiles_query_flag(parsed)
@@ -2067,6 +2074,7 @@ def handle_get(handler, parsed) -> bool:
             scoped = [s for s in merged
                       if _profiles_match(s.get("profile"), active_profile)]
             other_profile_count = len(merged) - len(scoped)
+        scoped = _keep_latest_messaging_session_per_source(scoped)
         safe_merged = []
         for s in scoped:
             item = dict(s)

--- a/api/routes.py
+++ b/api/routes.py
@@ -1743,8 +1743,9 @@ def handle_get(handler, parsed) -> bool:
         # Inject the running version so the UI badge stays in sync with git tags
         # without any manual release step.
         try:
-            from api.updates import WEBUI_VERSION
+            from api.updates import AGENT_VERSION, WEBUI_VERSION
             settings["webui_version"] = WEBUI_VERSION
+            settings["agent_version"] = AGENT_VERSION
         except Exception:
             pass
         return j(handler, settings)

--- a/api/routes.py
+++ b/api/routes.py
@@ -53,6 +53,55 @@ _MESSAGING_SESSION_METADATA_LOCK = threading.Lock()
 _STALE_MESSAGING_END_REASONS = {"session_reset", "session_switch"}
 
 
+# ── Profile-scoped session/project filtering (#1611, #1614) ────────────────
+#
+# Sessions and projects are stored in the WebUI sidecar without per-row
+# isolation by default — they're tagged with a `profile` field but every
+# query saw all rows. The fix scopes both endpoints to the active profile
+# by default, with `?all_profiles=1` opting into aggregate mode.
+#
+# Renamed-root profile handling (#1612): a row tagged `profile='default'`
+# matches the active root regardless of the root's display name, and a row
+# tagged with the renamed-root display name (e.g. 'kinni') likewise matches
+# when the active profile is `'default'`. _is_root_profile() is the
+# canonical check.
+
+def _profiles_match(row_profile, active_profile) -> bool:
+    """Return True if a session/project row's profile matches the active profile.
+
+    Treats both the literal alias 'default' and any renamed-root display name
+    (per _is_root_profile) as equivalent, so legacy rows tagged 'default'
+    still surface when the user has renamed the root profile to e.g. 'kinni',
+    and vice versa.
+
+    A row with no profile (`None` or empty string) is treated as belonging to
+    the root profile — that's the convention used by the legacy backfill at
+    api/models.py::all_sessions, and matches the default seen in
+    `static/sessions.js` (`S.activeProfile||'default'`).
+    """
+    from api.profiles import _is_root_profile
+
+    row = row_profile or 'default'
+    active = active_profile or 'default'
+    if row == active:
+        return True
+    # Cross-alias the renamed root.
+    if _is_root_profile(row) and _is_root_profile(active):
+        return True
+    return False
+
+
+def _all_profiles_query_flag(parsed_url) -> bool:
+    """Return True if the request URL has `?all_profiles=1` (or true/yes).
+
+    Centralizes the opt-in parsing so /api/sessions and /api/projects use
+    the same shape. Accepts 1/true/yes (case-insensitive) for ergonomics.
+    """
+    qs = parse_qs(parsed_url.query)
+    raw = qs.get('all_profiles', [''])[0].strip().lower()
+    return raw in ('1', 'true', 'yes', 'on')
+
+
 def _normalize_messaging_source(raw_source) -> str:
     return str(raw_source or "").strip().lower()
 
@@ -2002,8 +2051,24 @@ def handle_get(handler, parsed) -> bool:
             reverse=True,
         )
         merged = _keep_latest_messaging_session_per_source(merged)
+        # ── Profile scoping (#1611) ────────────────────────────────────────
+        # Default: filter to the active profile. ?all_profiles=1 opts into
+        # the aggregate view used by the "All profiles" sidebar toggle.
+        # The other_profile_count is always returned so the UI can render
+        # the "Show N from other profiles" affordance without sending the
+        # cross-profile rows by default.
+        from api.profiles import get_active_profile_name
+        active_profile = get_active_profile_name()
+        all_profiles = _all_profiles_query_flag(parsed)
+        if all_profiles:
+            scoped = merged
+            other_profile_count = 0
+        else:
+            scoped = [s for s in merged
+                      if _profiles_match(s.get("profile"), active_profile)]
+            other_profile_count = len(merged) - len(scoped)
         safe_merged = []
-        for s in merged:
+        for s in scoped:
             item = dict(s)
             if isinstance(item.get("title"), str):
                 item["title"] = _redact_text(item["title"])
@@ -2011,12 +2076,32 @@ def handle_get(handler, parsed) -> bool:
         return j(handler, {
             "sessions": safe_merged,
             "cli_count": len(deduped_cli),
+            "all_profiles": all_profiles,
+            "active_profile": active_profile,
+            "other_profile_count": other_profile_count,
             "server_time": time.time(),
             "server_tz": time.strftime("%z"),
         })
 
     if parsed.path == "/api/projects":
-        return j(handler, {"projects": load_projects()})
+        # ── Profile scoping (#1614) ────────────────────────────────────────
+        # Default: filter to the active profile. ?all_profiles=1 returns the
+        # aggregate list so settings/admin UIs can still see everything.
+        from api.profiles import get_active_profile_name
+        active_profile = get_active_profile_name()
+        all_projects = load_projects()
+        all_profiles = _all_profiles_query_flag(parsed)
+        if all_profiles:
+            scoped = all_projects
+        else:
+            scoped = [p for p in all_projects
+                      if _profiles_match(p.get("profile"), active_profile)]
+        return j(handler, {
+            "projects": scoped,
+            "all_profiles": all_profiles,
+            "active_profile": active_profile,
+            "other_profile_count": len(all_projects) - len(scoped),
+        })
 
     if parsed.path == "/api/session/export":
         return _handle_session_export(handler, parsed)
@@ -3325,8 +3410,21 @@ def handle_post(handler, parsed) -> bool:
             s = get_session(body["session_id"])
         except KeyError:
             return bad(handler, "Session not found", 404)
+        # #1614: refuse moves into a project owned by another profile.
+        target_pid = body.get("project_id") or None
+        if target_pid:
+            from api.profiles import get_active_profile_name
+            active_profile = get_active_profile_name()
+            target = next(
+                (p for p in load_projects() if p["project_id"] == target_pid),
+                None,
+            )
+            if not target:
+                return bad(handler, "Project not found", 404)
+            if not _profiles_match(target.get("profile"), active_profile):
+                return bad(handler, "Project not found", 404)
         with _get_session_agent_lock(body["session_id"]):
-            s.project_id = body.get("project_id") or None
+            s.project_id = target_pid
             s.save()
         return j(handler, {"ok": True, "session": s.compact()})
 
@@ -3337,6 +3435,7 @@ def handle_post(handler, parsed) -> bool:
         except ValueError as e:
             return bad(handler, str(e))
         import re as _re
+        from api.profiles import get_active_profile_name
 
         name = body["name"].strip()[:128]
         if not name:
@@ -3349,6 +3448,7 @@ def handle_post(handler, parsed) -> bool:
             "project_id": uuid.uuid4().hex[:12],
             "name": name,
             "color": color,
+            "profile": get_active_profile_name() or 'default',
             "created_at": time.time(),
         }
         projects.append(proj)
@@ -3361,12 +3461,17 @@ def handle_post(handler, parsed) -> bool:
         except ValueError as e:
             return bad(handler, str(e))
         import re as _re
+        from api.profiles import get_active_profile_name
 
         projects = load_projects()
         proj = next(
             (p for p in projects if p["project_id"] == body["project_id"]), None
         )
         if not proj:
+            return bad(handler, "Project not found", 404)
+        # #1614: a project can only be renamed by the profile that owns it.
+        active_profile = get_active_profile_name()
+        if not _profiles_match(proj.get("profile"), active_profile):
             return bad(handler, "Project not found", 404)
         proj["name"] = body["name"].strip()[:128]
         if "color" in body:
@@ -3382,11 +3487,16 @@ def handle_post(handler, parsed) -> bool:
             require(body, "project_id")
         except ValueError as e:
             return bad(handler, str(e))
+        from api.profiles import get_active_profile_name
         projects = load_projects()
         proj = next(
             (p for p in projects if p["project_id"] == body["project_id"]), None
         )
         if not proj:
+            return bad(handler, "Project not found", 404)
+        # #1614: a project can only be deleted by the profile that owns it.
+        active_profile = get_active_profile_name()
+        if not _profiles_match(proj.get("profile"), active_profile):
             return bad(handler, "Project not found", 404)
         projects = [p for p in projects if p["project_id"] != body["project_id"]]
         save_projects(projects)

--- a/api/updates.py
+++ b/api/updates.py
@@ -135,7 +135,10 @@ def _detect_agent_version() -> str:
     # file is available (common in source checkouts and developer environments).
     if not Path(_AGENT_DIR).exists():
         return 'not detected'
-    out, ok = _run_git(['describe', '--tags', '--always'], _AGENT_DIR, timeout=3)
+    # Symmetric with _detect_webui_version() above — `--dirty` flags a
+    # locally-modified checkout so operators can see when their agent has
+    # uncommitted changes vs a clean tag. Per Opus advisor on stage-293.
+    out, ok = _run_git(['describe', '--tags', '--always', '--dirty'], _AGENT_DIR, timeout=3)
     if ok and out:
         return out
 

--- a/api/updates.py
+++ b/api/updates.py
@@ -117,8 +117,34 @@ def _detect_webui_version() -> str:
     return 'unknown'
 
 
+def _detect_agent_version() -> str:
+    """Detect the running Hermes Agent version for UI display."""
+    if _AGENT_DIR is None:
+        return 'not detected'
+
+    version_file = Path(_AGENT_DIR) / "VERSION"
+    try:
+        if version_file.exists():
+            text = version_file.read_text(encoding='utf-8').strip()
+            if text:
+                return text
+    except Exception:
+        pass
+
+    # Fallback: infer from git describe when the checkout exists but no VERSION
+    # file is available (common in source checkouts and developer environments).
+    if not Path(_AGENT_DIR).exists():
+        return 'not detected'
+    out, ok = _run_git(['describe', '--tags', '--always'], _AGENT_DIR, timeout=3)
+    if ok and out:
+        return out
+
+    return 'not detected'
+
+
 # Resolved once at import time — tags cannot change without a process restart.
 WEBUI_VERSION: str = _detect_webui_version()
+AGENT_VERSION: str = _detect_agent_version()
 
 
 def _split_remote_ref(ref):

--- a/static/index.html
+++ b/static/index.html
@@ -920,7 +920,8 @@
                 <div class="settings-section-meta" data-i18n="settings_section_system_meta">Instance version and access controls.</div>
               </div>
               <div id="checkUpdatesBlock">
-                <span class="settings-version-badge">—</span>
+                <span class="settings-version-badge" id="settings-webui-version-badge">WebUI: —</span>
+                <span class="settings-version-badge" id="settings-agent-version-badge">Agent: not detected</span>
                 <button class="btn-tiny" id="btnCheckUpdatesNow" onclick="checkUpdatesNow()" title="Check for updates now" data-i18n-title="settings_check_now"><svg id="checkUpdatesSpinner" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="spinner-xs" aria-hidden="true"><path d="M21 12a9 9 0 1 1-6.219-8.56"/><polyline points="21 3 21 9 15 9"/></svg><span id="checkUpdatesLabel" data-i18n="settings_check_now">Check now</span></button>
                 <span id="checkUpdatesStatus"></span>
               </div>

--- a/static/panels.js
+++ b/static/panels.js
@@ -3021,10 +3021,17 @@ function _retryPreferencesAutosave(){
 async function loadSettingsPanel(){
   try{
     const settings=await api('/api/settings');
-    // Populate the version badge from the server — keeps it in sync with git
+    // Populate the version badges from the server — keeps them in sync with git
     // tags automatically without any manual release step.
-    const vbadge=document.querySelector('.settings-version-badge');
-    if(vbadge && settings.webui_version) vbadge.textContent=settings.webui_version;
+    const webuiBadge = $('settings-webui-version-badge');
+    if(webuiBadge){
+      webuiBadge.textContent = `WebUI: ${settings.webui_version || 'not detected'}`;
+    }
+    const agentBadge = $('settings-agent-version-badge');
+    if(agentBadge){
+      const agentVersion = (settings.agent_version || 'not detected').toString().trim() || 'not detected';
+      agentBadge.textContent = `Agent: ${agentVersion}`;
+    }
     // Hydrate appearance controls first so a slow /api/models request
     // cannot overwrite an in-progress theme/skin selection.
     const themeSel=$('settingsTheme');

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1868,14 +1868,14 @@ function renderSessionListFromCache(){
     (activeSidForSidebar&&s.session_id===activeSidForSidebar) ||
     (S.session&&s.session_id===S.session.session_id&&(S.session.message_count||0)>0)
   );
-  // Filter by active profile (unless "All profiles" is toggled on).
-  // Server backfills profile='default' for legacy sessions, so every session has a profile.
-  // The server already scopes /api/sessions by the active profile by default (#1611),
-  // so this is a defense-in-depth client-side mirror — _showAllProfiles requests
-  // ?all_profiles=1 which short-circuits the server filter.
-  const profileFiltered=_showAllProfiles
-    ? withMessages
-    : withMessages.filter(s=>(s.profile||'default')===(S.activeProfile||'default'));
+  // The server is authoritative for profile scoping (#1611): it filters by
+  // active profile when no query param is set, and returns the aggregate when
+  // we send ?all_profiles=1. The renamed-root cross-alias (a row tagged
+  // 'default' matching active 'kinni' when kinni.is_default) lives server-side
+  // in _profiles_match, and a strict-equality client filter would reject those
+  // rows incorrectly. So we trust the wire data and skip the redundant client
+  // filter entirely.
+  const profileFiltered=withMessages;
   // Filter by active project. NO_PROJECT_FILTER sentinel asks for sessions
   // with no project_id; otherwise filter to the matching project_id, or
   // pass through when no filter is active.
@@ -1965,11 +1965,9 @@ function renderSessionListFromCache(){
   // Profile filter toggle (show sessions from other profiles).
   // Cross-profile rows live SERVER-SIDE behind ?all_profiles=1, so the toggle
   // must trigger a refetch — there's no client-cached aggregate to slice through.
-  // Falls back to client-side count if server didn't supply other_profile_count
-  // (e.g. older server build), to preserve UI affordance during partial rollouts.
-  const otherProfileCount = _otherProfileCount > 0
-    ? _otherProfileCount
-    : withMessages.filter(s=>(s.profile||'default')!==(S.activeProfile||'default')).length;
+  // The server is authoritative for the count (renamed-root cross-alias is
+  // server-side). A naive strict-equality client fallback would mis-count.
+  const otherProfileCount = _otherProfileCount;
   if(otherProfileCount>0&&!_showAllProfiles){
     const pfToggle=document.createElement('div');
     pfToggle.style.cssText='font-size:10px;padding:4px 10px;color:var(--muted);cursor:pointer;text-align:center;opacity:.7;';

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1028,6 +1028,7 @@ let _allProjects = [];  // cached project list
 const NO_PROJECT_FILTER = '__none__';
 let _activeProject = null;  // project_id filter (null = show all, NO_PROJECT_FILTER = unassigned only)
 let _showAllProfiles = false;  // false = filter to active profile only
+let _otherProfileCount = 0;       // count of sessions from other profiles (server-reported)
 let _sessionActionMenu = null;
 let _sessionActionAnchor = null;
 let _sessionActionSessionId = null;
@@ -1361,10 +1362,15 @@ window.addEventListener('resize',()=>{
 async function renderSessionList(){
   try{
     if(!($('sessionSearch').value||'').trim()) _contentSearchResults = [];
+    const allProfilesQS = _showAllProfiles ? '?all_profiles=1' : '';
     const [sessData, projData] = await Promise.all([
-      api('/api/sessions'),
-      api('/api/projects'),
+      api('/api/sessions' + allProfilesQS),
+      api('/api/projects' + allProfilesQS),
     ]);
+    // Server's other_profile_count tells us how many sessions exist outside the
+    // active profile so the "Show N from other profiles" toggle can render
+    // without a second round-trip. Stashed on the module for renderSessionListFromCache.
+    _otherProfileCount = sessData.other_profile_count || 0;
     _allSessions = sessData.sessions||[];
     _allProjects = projData.projects||[];
     // Capture server clock for clock-skew compensation (issue #1144).
@@ -1862,10 +1868,14 @@ function renderSessionListFromCache(){
     (activeSidForSidebar&&s.session_id===activeSidForSidebar) ||
     (S.session&&s.session_id===S.session.session_id&&(S.session.message_count||0)>0)
   );
-  // Filter by active profile (unless "All profiles" is toggled on)
+  // Filter by active profile (unless "All profiles" is toggled on).
   // Server backfills profile='default' for legacy sessions, so every session has a profile.
-  // Show only sessions tagged to the active profile; 'All profiles' toggle overrides.
-  const profileFiltered=_showAllProfiles?withMessages:withMessages.filter(s=>s.is_cli_session||s.profile===S.activeProfile);
+  // The server already scopes /api/sessions by the active profile by default (#1611),
+  // so this is a defense-in-depth client-side mirror — _showAllProfiles requests
+  // ?all_profiles=1 which short-circuits the server filter.
+  const profileFiltered=_showAllProfiles
+    ? withMessages
+    : withMessages.filter(s=>(s.profile||'default')===(S.activeProfile||'default'));
   // Filter by active project. NO_PROJECT_FILTER sentinel asks for sessions
   // with no project_id; otherwise filter to the matching project_id, or
   // pass through when no filter is active.
@@ -1952,19 +1962,25 @@ function renderSessionListFromCache(){
     bar.appendChild(addBtn);
     list.appendChild(bar);
   }
-  // Profile filter toggle (show sessions from other profiles)
-  const otherProfileCount=withMessages.filter(s=>s.profile&&s.profile!==S.activeProfile).length;
+  // Profile filter toggle (show sessions from other profiles).
+  // Cross-profile rows live SERVER-SIDE behind ?all_profiles=1, so the toggle
+  // must trigger a refetch — there's no client-cached aggregate to slice through.
+  // Falls back to client-side count if server didn't supply other_profile_count
+  // (e.g. older server build), to preserve UI affordance during partial rollouts.
+  const otherProfileCount = _otherProfileCount > 0
+    ? _otherProfileCount
+    : withMessages.filter(s=>(s.profile||'default')!==(S.activeProfile||'default')).length;
   if(otherProfileCount>0&&!_showAllProfiles){
     const pfToggle=document.createElement('div');
     pfToggle.style.cssText='font-size:10px;padding:4px 10px;color:var(--muted);cursor:pointer;text-align:center;opacity:.7;';
     pfToggle.textContent='Show '+otherProfileCount+' from other profiles';
-    pfToggle.onclick=()=>{_showAllProfiles=true;renderSessionListFromCache();};
+    pfToggle.onclick=()=>{_showAllProfiles=true;renderSessionList();};
     list.appendChild(pfToggle);
-  } else if(_showAllProfiles&&otherProfileCount>0){
+  } else if(_showAllProfiles){
     const pfToggle=document.createElement('div');
     pfToggle.style.cssText='font-size:10px;padding:4px 10px;color:var(--muted);cursor:pointer;text-align:center;opacity:.7;';
     pfToggle.textContent='Show active profile only';
-    pfToggle.onclick=()=>{_showAllProfiles=false;renderSessionListFromCache();};
+    pfToggle.onclick=()=>{_showAllProfiles=false;renderSessionList();};
     list.appendChild(pfToggle);
   }
   // Show/hide archived toggle if there are archived sessions

--- a/tests/test_issue1611_session_profile_filtering.py
+++ b/tests/test_issue1611_session_profile_filtering.py
@@ -102,9 +102,10 @@ def test_static_sessions_js_no_cli_session_bypass():
     """static/sessions.js must NOT filter via `s.is_cli_session || s.profile ===`.
 
     The original bypass let every CLI-imported session leak into the active-profile
-    sidebar regardless of which profile owned it. After #1611, the filter is
-    solely on `(s.profile||'default') === (S.activeProfile||'default')` — server
-    already scoped the wire data, this is defense-in-depth.
+    sidebar regardless of which profile owned it. After #1611 + the Opus pre-release
+    SHOULD-FIX, the client trusts the server's scoped wire data and does not
+    re-filter by profile at all (a strict-equality client filter would reject
+    the server's renamed-root cross-aliased rows).
     """
     from pathlib import Path
 
@@ -116,10 +117,6 @@ def test_static_sessions_js_no_cli_session_bypass():
     )
     assert "s.is_cli_session || s.profile === S.activeProfile" not in src, (
         "Old CLI-session bypass must be removed (#1611)"
-    )
-    # And the new shape is present
-    assert "(s.profile||'default')===(S.activeProfile||'default')" in src, (
-        "Expected the new active-profile-only filter shape"
     )
 
 
@@ -142,6 +139,69 @@ def test_static_sessions_js_uses_all_profiles_query_when_toggle_on():
     )
     assert "api('/api/projects' + allProfilesQS)" in src, (
         "Expected /api/projects fetch to use the variant query"
+    )
+
+
+# ── SHOULD-FIX #2: profile filter must run BEFORE messaging-source dedupe ──
+# Bug shape (Opus pre-release advisor): _messaging_source_key is profile-blind,
+# so if profiles A and B both have a session for the same Slack identity, a
+# profile-blind dedupe runs first and discards the older profile's row, then
+# the profile filter scopes — leaving the losing profile with zero rows for
+# that source.
+
+
+def test_keep_latest_messaging_runs_after_profile_filter():
+    """Source-string check: api/routes.py /api/sessions handler must call
+    _keep_latest_messaging_session_per_source AFTER the profile filter."""
+    from pathlib import Path
+
+    repo_root = Path(__file__).parent.parent
+    src = (repo_root / 'api' / 'routes.py').read_text(encoding='utf-8')
+
+    handler_idx = src.find('parsed.path == "/api/sessions":')
+    assert handler_idx > 0
+    next_handler = src.find('parsed.path == "/api/projects":', handler_idx)
+    block = src[handler_idx:next_handler]
+
+    filter_idx = block.find('_profiles_match(s.get("profile"), active_profile)')
+    dedupe_idx = block.find('_keep_latest_messaging_session_per_source(scoped)')
+    assert filter_idx > 0, "Profile filter not found in /api/sessions handler"
+    assert dedupe_idx > 0, "Messaging dedupe must run on the scoped list"
+    assert filter_idx < dedupe_idx, (
+        "Profile filter must run BEFORE messaging-source dedupe — running it "
+        "after lets the dedupe discard the active profile's row when both "
+        "profiles share a messaging identity (Opus pre-release SHOULD-FIX #2)"
+    )
+
+
+# ── SHOULD-FIX #1: client filter must NOT strict-equality-reject server cross-aliased rows ──
+
+
+def test_static_sessions_js_trusts_server_profile_scoping():
+    """After SHOULD-FIX #1, the client should NOT re-filter via strict equality.
+
+    Bug shape: server returns rows tagged 'default' to an active 'kinni' user
+    (when kinni is the renamed root) via _profiles_match cross-alias. A
+    naïve `(s.profile||'default')===(S.activeProfile||'default')` client filter
+    rejects them — user loses every legacy 'default'-tagged session.
+
+    Fix: drop the redundant client filter; trust the server."""
+    from pathlib import Path
+
+    repo_root = Path(__file__).parent.parent
+    src = (repo_root / 'static' / 'sessions.js').read_text(encoding='utf-8')
+
+    # The fragile client-side strict-equality filter must be gone.
+    forbidden = "withMessages.filter(s=>(s.profile||'default')===(S.activeProfile||'default'))"
+    assert forbidden not in src, (
+        "Client must not re-filter rows the server already cross-aliased "
+        "(Opus pre-release SHOULD-FIX #1)"
+    )
+
+    # And the count fallback that ran the same broken comparison must be gone too.
+    forbidden_count = "withMessages.filter(s=>(s.profile||'default')!==(S.activeProfile||'default')).length"
+    assert forbidden_count not in src, (
+        "Client otherProfileCount must come from server, not strict-equality fallback"
     )
 
 

--- a/tests/test_issue1611_session_profile_filtering.py
+++ b/tests/test_issue1611_session_profile_filtering.py
@@ -1,0 +1,156 @@
+"""Tests for issue #1611: /api/sessions must be scoped to the active profile.
+
+Reporter (@stefanpieter) saw multi-profile installs where querying
+/api/sessions with `Cookie: hermes_profile=haku` still returned sessions
+tagged to other profiles. Two bugs combined to produce this:
+  1. Server-side `/api/sessions` had no profile filter — it merged
+     WebUI sidecar sessions and CLI/imported sessions and returned the lot.
+  2. Frontend `static/sessions.js` filter let every CLI session bypass the
+     active-profile filter via `s.is_cli_session || s.profile === active`.
+
+This test file pins the server-side filter shape via api.routes._profiles_match
+(the helper used by the /api/sessions and /api/projects handlers) and the
+all_profiles=1 opt-in path. End-to-end HTTP-level tests live separately under
+tests/test_sessions_endpoint.py if/when added.
+"""
+
+from urllib.parse import urlparse
+
+import pytest
+
+
+# ── _profiles_match helper ─────────────────────────────────────────────────
+
+
+def test_profiles_match_exact():
+    """Same name on both sides matches."""
+    from api.routes import _profiles_match
+    assert _profiles_match('haku', 'haku') is True
+    assert _profiles_match('default', 'default') is True
+
+
+def test_profiles_match_distinct_named_profiles():
+    """Different named profiles do not cross-match."""
+    from api.routes import _profiles_match
+    assert _profiles_match('haku', 'kinni') is False
+    assert _profiles_match('noblepro', 'haku') is False
+
+
+def test_profiles_match_default_alias_treated_as_root(monkeypatch):
+    """A row tagged 'default' matches when the active profile is the renamed
+    root (e.g. 'kinni') and vice versa — both resolve to the same ~/.hermes
+    home, so they're the same profile from a user perspective."""
+    import api.profiles as p
+    from api.routes import _profiles_match
+
+    monkeypatch.setattr(p, 'list_profiles_api', lambda: [
+        {'name': 'kinni', 'is_default': True, 'path': str(p._DEFAULT_HERMES_HOME)},
+    ])
+    p._invalidate_root_profile_cache()
+
+    assert _profiles_match('default', 'kinni') is True
+    assert _profiles_match('kinni', 'default') is True
+    # And neither matches a true named profile
+    assert _profiles_match('default', 'haku') is False
+    assert _profiles_match('kinni', 'haku') is False
+
+
+def test_profiles_match_empty_row_treated_as_root():
+    """A row with no profile tag (None or empty string) is treated as root.
+
+    Backward compat with legacy sessions/projects that pre-date the profile
+    field. The all_sessions() backfill at api/models.py also sets profile
+    to 'default' for such rows.
+    """
+    from api.routes import _profiles_match
+    assert _profiles_match(None, 'default') is True
+    assert _profiles_match('', 'default') is True
+    assert _profiles_match(None, 'haku') is False
+
+
+def test_profiles_match_active_none_treated_as_default():
+    """If active profile resolves to None/empty (boot edge case), treat as 'default'."""
+    from api.routes import _profiles_match
+    assert _profiles_match('default', None) is True
+    assert _profiles_match('default', '') is True
+
+
+# ── _all_profiles_query_flag ───────────────────────────────────────────────
+
+
+def test_all_profiles_query_flag_true_values():
+    """1, true, yes, on (case-insensitive) all enable aggregate mode."""
+    from api.routes import _all_profiles_query_flag
+    for v in ('1', 'true', 'TRUE', 'yes', 'YES', 'on'):
+        u = urlparse(f'/api/sessions?all_profiles={v}')
+        assert _all_profiles_query_flag(u) is True, f"value {v!r} should be true"
+
+
+def test_all_profiles_query_flag_false_values():
+    """0, empty, garbage, missing — all default to scoped mode (False)."""
+    from api.routes import _all_profiles_query_flag
+    for path in ('/api/sessions', '/api/sessions?all_profiles=0',
+                 '/api/sessions?all_profiles=', '/api/sessions?all_profiles=lol'):
+        u = urlparse(path)
+        assert _all_profiles_query_flag(u) is False, f"path {path!r} should be false"
+
+
+# ── No client-side CLI bypass ──────────────────────────────────────────────
+
+
+def test_static_sessions_js_no_cli_session_bypass():
+    """static/sessions.js must NOT filter via `s.is_cli_session || s.profile ===`.
+
+    The original bypass let every CLI-imported session leak into the active-profile
+    sidebar regardless of which profile owned it. After #1611, the filter is
+    solely on `(s.profile||'default') === (S.activeProfile||'default')` — server
+    already scoped the wire data, this is defense-in-depth.
+    """
+    from pathlib import Path
+
+    repo_root = Path(__file__).parent.parent
+    src = (repo_root / 'static' / 'sessions.js').read_text(encoding='utf-8')
+
+    assert "s.is_cli_session||s.profile===S.activeProfile" not in src, (
+        "Old CLI-session bypass must be removed (#1611)"
+    )
+    assert "s.is_cli_session || s.profile === S.activeProfile" not in src, (
+        "Old CLI-session bypass must be removed (#1611)"
+    )
+    # And the new shape is present
+    assert "(s.profile||'default')===(S.activeProfile||'default')" in src, (
+        "Expected the new active-profile-only filter shape"
+    )
+
+
+def test_static_sessions_js_uses_all_profiles_query_when_toggle_on():
+    """Frontend must request /api/sessions?all_profiles=1 when _showAllProfiles is true.
+
+    Without this, flipping the toggle just re-renders client-cached rows that
+    may not contain cross-profile data (since the server scoped on first fetch).
+    """
+    from pathlib import Path
+
+    repo_root = Path(__file__).parent.parent
+    src = (repo_root / 'static' / 'sessions.js').read_text(encoding='utf-8')
+
+    assert "_showAllProfiles ? '?all_profiles=1' : ''" in src, (
+        "Expected fetch path to flip on the toggle state"
+    )
+    assert "api('/api/sessions' + allProfilesQS)" in src, (
+        "Expected /api/sessions fetch to use the variant query"
+    )
+    assert "api('/api/projects' + allProfilesQS)" in src, (
+        "Expected /api/projects fetch to use the variant query"
+    )
+
+
+# ── Cleanup ────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _invalidate_profile_cache():
+    import api.profiles as p
+    p._invalidate_root_profile_cache()
+    yield
+    p._invalidate_root_profile_cache()

--- a/tests/test_issue1612_renamed_root_profile.py
+++ b/tests/test_issue1612_renamed_root_profile.py
@@ -71,13 +71,10 @@ def test_is_root_profile_invalidation_drops_stale(monkeypatch):
     """Explicit invalidation forces re-query on next call."""
     import api.profiles as p
 
-    states = [
+    seq = [
         [{'name': 'kinni', 'is_default': True, 'path': '/tmp/.hermes'}],
         [{'name': 'noblepro', 'is_default': True, 'path': '/tmp/.hermes'}],
     ]
-    monkeypatch.setattr(p, 'list_profiles_api', lambda: states[len(states) - len([s for s in states])])
-    # Simpler: pop pattern
-    seq = list(states)
     monkeypatch.setattr(p, 'list_profiles_api', lambda: seq[0] if seq else [])
 
     p._invalidate_root_profile_cache()

--- a/tests/test_issue1612_renamed_root_profile.py
+++ b/tests/test_issue1612_renamed_root_profile.py
@@ -1,0 +1,230 @@
+"""Tests for issue #1612: renamed root profile must resolve to ~/.hermes,
+not ~/.hermes/profiles/<name>.
+
+A renamed root/default Hermes profile (`is_default=True` on the agent side
+but with a display name like `kinni`) was being treated as a named profile
+directory under `~/.hermes/profiles/kinni`, which doesn't exist. Every
+`if name == 'default':` site in api/profiles.py fell through to the wrong
+filesystem path with `Profile 'kinni' does not exist.`
+
+Fix: centralize the "is this the root?" check in `_is_root_profile(name)`
+and replace each scattered `if name == 'default':` with it.
+"""
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+# ── _is_root_profile core ───────────────────────────────────────────────────
+
+
+def test_is_root_profile_default_alias():
+    """Legacy 'default' literal always resolves as root, regardless of cache state."""
+    import api.profiles as p
+    p._invalidate_root_profile_cache()
+    assert p._is_root_profile('default') is True
+
+
+def test_is_root_profile_empty_or_none_is_false():
+    """Empty/None name is NOT root — caller code decides what to do."""
+    import api.profiles as p
+    assert p._is_root_profile('') is False
+    assert p._is_root_profile(None) is False
+
+
+def test_is_root_profile_renamed_root_via_list_profiles_api(monkeypatch):
+    """A profile name reported by list_profiles_api with is_default=True is treated as root."""
+    import api.profiles as p
+
+    monkeypatch.setattr(p, 'list_profiles_api', lambda: [
+        {'name': 'kinni', 'is_default': True, 'path': str(p._DEFAULT_HERMES_HOME)},
+        {'name': 'haku', 'is_default': False, 'path': '/tmp/profiles/haku'},
+    ])
+    p._invalidate_root_profile_cache()
+
+    assert p._is_root_profile('kinni') is True
+    assert p._is_root_profile('haku') is False
+    assert p._is_root_profile('default') is True
+
+
+def test_is_root_profile_caches_results(monkeypatch):
+    """Repeated calls don't re-invoke list_profiles_api — once-per-mutation memoization."""
+    import api.profiles as p
+
+    calls = {'n': 0}
+    def fake_list():
+        calls['n'] += 1
+        return [{'name': 'kinni', 'is_default': True, 'path': '/tmp/.hermes'}]
+    monkeypatch.setattr(p, 'list_profiles_api', fake_list)
+    p._invalidate_root_profile_cache()
+
+    p._is_root_profile('kinni')
+    p._is_root_profile('kinni')
+    p._is_root_profile('haku')
+    assert calls['n'] == 1, "Cache should be hit after first lookup"
+
+
+def test_is_root_profile_invalidation_drops_stale(monkeypatch):
+    """Explicit invalidation forces re-query on next call."""
+    import api.profiles as p
+
+    states = [
+        [{'name': 'kinni', 'is_default': True, 'path': '/tmp/.hermes'}],
+        [{'name': 'noblepro', 'is_default': True, 'path': '/tmp/.hermes'}],
+    ]
+    monkeypatch.setattr(p, 'list_profiles_api', lambda: states[len(states) - len([s for s in states])])
+    # Simpler: pop pattern
+    seq = list(states)
+    monkeypatch.setattr(p, 'list_profiles_api', lambda: seq[0] if seq else [])
+
+    p._invalidate_root_profile_cache()
+    assert p._is_root_profile('kinni') is True
+    assert p._is_root_profile('noblepro') is False
+
+    # Simulate rename — drop first state, second is now the truth
+    seq.pop(0)
+    p._invalidate_root_profile_cache()
+    assert p._is_root_profile('kinni') is False
+    assert p._is_root_profile('noblepro') is True
+
+
+def test_is_root_profile_handles_list_profiles_failure(monkeypatch):
+    """If list_profiles_api raises, fall back to literal-default-only — never raise."""
+    import api.profiles as p
+
+    def boom():
+        raise RuntimeError("hermes_cli explosion")
+    monkeypatch.setattr(p, 'list_profiles_api', boom)
+    p._invalidate_root_profile_cache()
+
+    # 'default' still works (handled before list_profiles_api call).
+    assert p._is_root_profile('default') is True
+    # Other names return False on failure.
+    assert p._is_root_profile('kinni') is False
+
+
+# ── get_active_hermes_home: returns _DEFAULT_HERMES_HOME for renamed root ──
+
+
+def test_get_active_hermes_home_returns_default_for_renamed_root(tmp_path, monkeypatch):
+    """The core bug: a renamed root profile must resolve to _DEFAULT_HERMES_HOME,
+    not _DEFAULT_HERMES_HOME / 'profiles' / <name>."""
+    import api.profiles as p
+
+    monkeypatch.setattr(p, '_DEFAULT_HERMES_HOME', tmp_path)
+    monkeypatch.setattr(p, 'list_profiles_api', lambda: [
+        {'name': 'kinni', 'is_default': True, 'path': str(tmp_path)},
+    ])
+    p._invalidate_root_profile_cache()
+    monkeypatch.setattr(p, '_active_profile', 'kinni')
+
+    result = p.get_active_hermes_home()
+    assert result == tmp_path, f"Expected {tmp_path}, got {result}"
+
+
+def test_get_active_hermes_home_returns_named_for_real_named_profile(tmp_path, monkeypatch):
+    """Backward compat: a real named (non-default) profile still resolves to profiles/<name>."""
+    import api.profiles as p
+
+    profile_dir = tmp_path / 'profiles' / 'haku'
+    profile_dir.mkdir(parents=True)
+    monkeypatch.setattr(p, '_DEFAULT_HERMES_HOME', tmp_path)
+    monkeypatch.setattr(p, 'list_profiles_api', lambda: [
+        {'name': 'kinni', 'is_default': True, 'path': str(tmp_path)},
+        {'name': 'haku', 'is_default': False, 'path': str(profile_dir)},
+    ])
+    p._invalidate_root_profile_cache()
+    monkeypatch.setattr(p, '_active_profile', 'haku')
+
+    result = p.get_active_hermes_home()
+    assert result == profile_dir
+
+
+# ── switch_profile: accepts renamed root display name ─────────────────────
+
+
+def test_switch_profile_resolution_renamed_root_picks_default_home(tmp_path, monkeypatch):
+    """switch_profile()'s resolution branch: a renamed root must select
+    _DEFAULT_HERMES_HOME, not raise 'Profile <name> does not exist.'
+
+    We don't drive switch_profile() end-to-end (it touches reload_config,
+    workspace resolution, env mutation, etc.); instead we exercise the
+    same resolve-or-raise structure that lives at the head of switch_profile.
+    """
+    import api.profiles as p
+
+    monkeypatch.setattr(p, '_DEFAULT_HERMES_HOME', tmp_path)
+    monkeypatch.setattr(p, 'list_profiles_api', lambda: [
+        {'name': 'kinni', 'is_default': True, 'path': str(tmp_path)},
+    ])
+    p._invalidate_root_profile_cache()
+
+    # Mirror switch_profile's resolution logic
+    name = 'kinni'
+    if p._is_root_profile(name):
+        home = p._DEFAULT_HERMES_HOME
+    else:
+        home = p._resolve_named_profile_home(name)
+        if not home.is_dir():
+            raise ValueError(f"Profile '{name}' does not exist.")
+    assert home == tmp_path
+
+    # Sanity: a TRULY missing profile still raises (backward compat)
+    with pytest.raises(ValueError, match="does not exist"):
+        name = 'phantom'
+        if p._is_root_profile(name):
+            home = p._DEFAULT_HERMES_HOME
+        else:
+            home = p._resolve_named_profile_home(name)
+            if not home.is_dir():
+                raise ValueError(f"Profile '{name}' does not exist.")
+
+
+def test_switch_profile_sticky_marker_renamed_root(tmp_path, monkeypatch):
+    """switch_profile writes '' (empty marker) to active_profile file when
+    switching to the root profile, regardless of its display name. This
+    means a subsequent boot reads '' → falls through to 'default' alias →
+    _is_root_profile('default') → resolves to _DEFAULT_HERMES_HOME, which
+    is the only correct location for the renamed-root case."""
+    import api.profiles as p
+
+    monkeypatch.setattr(p, '_DEFAULT_HERMES_HOME', tmp_path)
+    monkeypatch.setattr(p, 'list_profiles_api', lambda: [
+        {'name': 'kinni', 'is_default': True, 'path': str(tmp_path)},
+    ])
+    p._invalidate_root_profile_cache()
+
+    # Mirror the sticky-write line directly — guards that the new ternary
+    # uses _is_root_profile, not the literal-'default' compare.
+    written = '' if p._is_root_profile('kinni') else 'kinni'
+    assert written == ''
+    written2 = '' if p._is_root_profile('haku') else 'haku'
+    assert written2 == 'haku' 
+
+
+def test_delete_profile_blocks_renamed_root(tmp_path, monkeypatch):
+    """delete_profile_api on a renamed root must refuse, same as 'default'."""
+    import api.profiles as p
+
+    monkeypatch.setattr(p, '_DEFAULT_HERMES_HOME', tmp_path)
+    monkeypatch.setattr(p, 'list_profiles_api', lambda: [
+        {'name': 'kinni', 'is_default': True, 'path': str(tmp_path)},
+    ])
+    p._invalidate_root_profile_cache()
+
+    with pytest.raises(ValueError, match="Cannot delete the default profile"):
+        p.delete_profile_api('kinni')
+
+
+# ── Cleanup: invalidate cache between tests so they don't leak ─────────────
+
+
+@pytest.fixture(autouse=True)
+def _invalidate_cache_around_test():
+    import api.profiles as p
+    p._invalidate_root_profile_cache()
+    yield
+    p._invalidate_root_profile_cache()

--- a/tests/test_issue1614_project_profile_filtering.py
+++ b/tests/test_issue1614_project_profile_filtering.py
@@ -1,0 +1,293 @@
+"""Tests for issue #1614: /api/projects must be scoped to the active profile.
+
+Same shape as #1611 but for projects:
+  - Global PROJECTS_FILE returned to every profile.
+  - Project rows had no `profile` field.
+  - Mutation endpoints didn't validate profile ownership.
+  - ensure_cron_project() returned the same global Cron Jobs project across profiles.
+
+Fix:
+  - New `profile` field on project dicts (defaulted at create-time).
+  - /api/projects filters by active profile by default; ?all_profiles=1 opts in.
+  - Create/rename/delete/move endpoints reject ops on cross-profile projects.
+  - ensure_cron_project() keys lookup by (name, profile).
+  - One-time migration: untagged projects inherit profile from sessions, fall back to 'default'.
+"""
+
+import json
+import threading
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+# ── ensure_cron_project: per-profile ─────────────────────────────────────
+
+
+def test_ensure_cron_project_creates_per_profile(tmp_path, monkeypatch):
+    """Each distinct profile gets its own 'Cron Jobs' project_id."""
+    import api.config as cfg
+    import api.models as models
+    import api.profiles as profiles
+
+    projects_file = tmp_path / 'projects.json'
+    monkeypatch.setattr(cfg, 'PROJECTS_FILE', projects_file)
+    monkeypatch.setattr(models, 'PROJECTS_FILE', projects_file)
+    monkeypatch.setattr(models, '_projects_migrated', True)
+    monkeypatch.setattr(models, '_CRON_PROJECT_LOCK', threading.Lock())
+    profiles._invalidate_root_profile_cache()
+    monkeypatch.setattr(profiles, 'list_profiles_api', lambda: [])
+
+    monkeypatch.setattr(profiles, '_active_profile', 'haku')
+    pid_haku = models.ensure_cron_project()
+    monkeypatch.setattr(profiles, '_active_profile', 'kinni')
+    pid_kinni = models.ensure_cron_project()
+
+    assert pid_haku != pid_kinni, "Per-profile cron projects must have distinct ids"
+
+    # Verify on disk
+    saved = json.loads(projects_file.read_text())
+    cron_rows = [p for p in saved if p['name'] == 'Cron Jobs']
+    assert len(cron_rows) == 2
+    assert {r['profile'] for r in cron_rows} == {'haku', 'kinni'}
+
+
+def test_ensure_cron_project_idempotent_per_profile(tmp_path, monkeypatch):
+    """Repeated calls within the same profile return the same id."""
+    import api.config as cfg
+    import api.models as models
+    import api.profiles as profiles
+
+    projects_file = tmp_path / 'projects.json'
+    monkeypatch.setattr(cfg, 'PROJECTS_FILE', projects_file)
+    monkeypatch.setattr(models, 'PROJECTS_FILE', projects_file)
+    monkeypatch.setattr(models, '_projects_migrated', True)
+    monkeypatch.setattr(models, '_CRON_PROJECT_LOCK', threading.Lock())
+    profiles._invalidate_root_profile_cache()
+    monkeypatch.setattr(profiles, 'list_profiles_api', lambda: [])
+    monkeypatch.setattr(profiles, '_active_profile', 'haku')
+
+    pid1 = models.ensure_cron_project()
+    pid2 = models.ensure_cron_project()
+    assert pid1 == pid2
+
+
+def test_ensure_cron_project_back_tags_legacy_untagged(tmp_path, monkeypatch):
+    """A pre-existing 'Cron Jobs' project with no `profile` field is back-tagged
+    to whichever profile first calls ensure_cron_project(), then reused going forward."""
+    import api.config as cfg
+    import api.models as models
+    import api.profiles as profiles
+
+    projects_file = tmp_path / 'projects.json'
+    legacy_pid = 'legacy123abc'
+    projects_file.write_text(json.dumps([
+        {'project_id': legacy_pid, 'name': 'Cron Jobs', 'color': '#6366f1', 'created_at': 1.0}
+    ]))
+    monkeypatch.setattr(cfg, 'PROJECTS_FILE', projects_file)
+    monkeypatch.setattr(models, 'PROJECTS_FILE', projects_file)
+    monkeypatch.setattr(models, '_projects_migrated', True)  # skip the load_projects auto-migration
+    monkeypatch.setattr(models, '_CRON_PROJECT_LOCK', threading.Lock())
+    profiles._invalidate_root_profile_cache()
+    monkeypatch.setattr(profiles, 'list_profiles_api', lambda: [])
+    monkeypatch.setattr(profiles, '_active_profile', 'haku')
+
+    returned = models.ensure_cron_project()
+    assert returned == legacy_pid
+
+    saved = json.loads(projects_file.read_text())
+    assert saved[0]['profile'] == 'haku', "Legacy untagged cron project must be back-tagged"
+
+
+def test_ensure_cron_project_renamed_root_matches_default(tmp_path, monkeypatch):
+    """When the root profile has been renamed (e.g. 'kinni'), an existing cron
+    project tagged 'default' is reused — they're the same profile from the
+    user's perspective."""
+    import api.config as cfg
+    import api.models as models
+    import api.profiles as profiles
+
+    projects_file = tmp_path / 'projects.json'
+    pid = 'crondefault1'
+    projects_file.write_text(json.dumps([
+        {'project_id': pid, 'name': 'Cron Jobs', 'color': '#6366f1',
+         'profile': 'default', 'created_at': 1.0}
+    ]))
+    monkeypatch.setattr(cfg, 'PROJECTS_FILE', projects_file)
+    monkeypatch.setattr(models, 'PROJECTS_FILE', projects_file)
+    monkeypatch.setattr(models, '_projects_migrated', True)
+    monkeypatch.setattr(models, '_CRON_PROJECT_LOCK', threading.Lock())
+
+    monkeypatch.setattr(profiles, 'list_profiles_api', lambda: [
+        {'name': 'kinni', 'is_default': True, 'path': str(tmp_path)},
+    ])
+    profiles._invalidate_root_profile_cache()
+    monkeypatch.setattr(profiles, '_active_profile', 'kinni')
+
+    returned = models.ensure_cron_project()
+    assert returned == pid, "Renamed root must reuse the 'default'-tagged cron project"
+
+
+# ── load_projects migration ────────────────────────────────────────────────
+
+
+def test_load_projects_backfills_from_session_index(tmp_path, monkeypatch):
+    """Untagged projects pick up their profile from any session that uses them."""
+    import api.config as cfg
+    import api.models as models
+
+    projects_file = tmp_path / 'projects.json'
+    index_file = tmp_path / '_index.json'
+
+    projects_file.write_text(json.dumps([
+        {'project_id': 'abc111', 'name': 'My Project', 'created_at': 1.0},
+        {'project_id': 'def222', 'name': 'Other', 'created_at': 2.0},
+        {'project_id': 'tagged3', 'name': 'Already Tagged',
+         'profile': 'haku', 'created_at': 3.0},
+    ]))
+    index_file.write_text(json.dumps([
+        {'session_id': 's1', 'project_id': 'abc111', 'profile': 'haku', 'message_count': 1},
+        {'session_id': 's2', 'project_id': 'def222', 'profile': 'kinni', 'message_count': 2},
+        {'session_id': 's3', 'project_id': 'tagged3', 'profile': 'haku', 'message_count': 0},
+    ]))
+
+    monkeypatch.setattr(cfg, 'PROJECTS_FILE', projects_file)
+    monkeypatch.setattr(cfg, 'SESSION_INDEX_FILE', index_file)
+    monkeypatch.setattr(models, 'PROJECTS_FILE', projects_file)
+    monkeypatch.setattr(models, 'SESSION_INDEX_FILE', index_file)
+    monkeypatch.setattr(models, '_projects_migrated', False)
+    monkeypatch.setattr(models, '_PROJECTS_MIGRATION_LOCK', threading.Lock())
+
+    out = models.load_projects()
+    by_id = {p['project_id']: p for p in out}
+    assert by_id['abc111']['profile'] == 'haku', "abc111 had a haku session"
+    assert by_id['def222']['profile'] == 'kinni', "def222 had a kinni session"
+    assert by_id['tagged3']['profile'] == 'haku', "Already-tagged unchanged"
+
+    # Persisted to disk
+    saved = json.loads(projects_file.read_text())
+    saved_by_id = {p['project_id']: p for p in saved}
+    assert saved_by_id['abc111']['profile'] == 'haku'
+    assert saved_by_id['def222']['profile'] == 'kinni'
+
+
+def test_load_projects_backfills_to_default_when_no_sessions(tmp_path, monkeypatch):
+    """Untagged project with no session attribution falls back to 'default'."""
+    import api.config as cfg
+    import api.models as models
+
+    projects_file = tmp_path / 'projects.json'
+    projects_file.write_text(json.dumps([
+        {'project_id': 'orphan1', 'name': 'Orphan', 'created_at': 1.0},
+    ]))
+
+    monkeypatch.setattr(cfg, 'PROJECTS_FILE', projects_file)
+    # Index doesn't exist
+    monkeypatch.setattr(cfg, 'SESSION_INDEX_FILE', tmp_path / 'no-index.json')
+    monkeypatch.setattr(models, 'PROJECTS_FILE', projects_file)
+    monkeypatch.setattr(models, 'SESSION_INDEX_FILE', tmp_path / 'no-index.json')
+    monkeypatch.setattr(models, '_projects_migrated', False)
+    monkeypatch.setattr(models, '_PROJECTS_MIGRATION_LOCK', threading.Lock())
+
+    out = models.load_projects()
+    assert out[0]['profile'] == 'default'
+
+
+def test_load_projects_idempotent_after_first_migrate(tmp_path, monkeypatch):
+    """Once everything is tagged, subsequent calls don't re-write the file."""
+    import api.config as cfg
+    import api.models as models
+
+    projects_file = tmp_path / 'projects.json'
+    projects_file.write_text(json.dumps([
+        {'project_id': 'abc111', 'name': 'My Project',
+         'profile': 'haku', 'created_at': 1.0},
+    ]))
+    monkeypatch.setattr(cfg, 'PROJECTS_FILE', projects_file)
+    monkeypatch.setattr(models, 'PROJECTS_FILE', projects_file)
+    monkeypatch.setattr(models, '_projects_migrated', False)
+    monkeypatch.setattr(models, '_PROJECTS_MIGRATION_LOCK', threading.Lock())
+
+    mtime_before = projects_file.stat().st_mtime_ns
+    models.load_projects()
+    models.load_projects()
+    mtime_after = projects_file.stat().st_mtime_ns
+    assert mtime_before == mtime_after, "No-op when everything already tagged"
+
+
+# ── _profiles_match shape used by /api/projects ───────────────────────────
+
+
+def test_profile_field_on_project_dict_default_create(monkeypatch):
+    """A new project dict shape must include `profile` after create.
+
+    We can't full-stack-test the HTTP path without spinning up a server, so
+    instead we pin the file-level invariant: the create handler now stamps
+    `profile` on the created dict.
+    """
+    from pathlib import Path
+    src = (Path(__file__).parent.parent / 'api' / 'routes.py').read_text(encoding='utf-8')
+
+    # The create handler must now include get_active_profile_name() for the new dict
+    create_idx = src.find('"/api/projects/create"')
+    assert create_idx > 0
+    next_handler_idx = src.find('"/api/projects/rename"', create_idx)
+    create_block = src[create_idx:next_handler_idx]
+    assert '"profile": get_active_profile_name() or \'default\'' in create_block, (
+        "Project create must stamp the active profile (#1614)"
+    )
+
+
+def test_project_rename_rejects_cross_profile():
+    """Source-string check that rename's active-profile guard is in place."""
+    from pathlib import Path
+    src = (Path(__file__).parent.parent / 'api' / 'routes.py').read_text(encoding='utf-8')
+
+    rename_idx = src.find('"/api/projects/rename"')
+    assert rename_idx > 0
+    next_idx = src.find('"/api/projects/delete"', rename_idx)
+    rename_block = src[rename_idx:next_idx]
+    assert '_profiles_match(proj.get("profile"), active_profile)' in rename_block, (
+        "Rename must check active-profile ownership"
+    )
+
+
+def test_project_delete_rejects_cross_profile():
+    from pathlib import Path
+    src = (Path(__file__).parent.parent / 'api' / 'routes.py').read_text(encoding='utf-8')
+
+    delete_idx = src.find('"/api/projects/delete"')
+    assert delete_idx > 0
+    delete_block = src[delete_idx:delete_idx + 1500]
+    assert '_profiles_match(proj.get("profile"), active_profile)' in delete_block, (
+        "Delete must check active-profile ownership"
+    )
+
+
+def test_session_move_rejects_cross_profile_project():
+    """/api/session/move must refuse moves into a project from another profile."""
+    from pathlib import Path
+    src = (Path(__file__).parent.parent / 'api' / 'routes.py').read_text(encoding='utf-8')
+
+    move_idx = src.find('"/api/session/move"')
+    assert move_idx > 0
+    move_block = src[move_idx:move_idx + 2000]
+    assert '_profiles_match(target.get("profile"), active_profile)' in move_block, (
+        "session/move must check target project's active-profile ownership"
+    )
+
+
+# ── Cleanup ────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _reset_profile_state():
+    import api.profiles as profiles
+    import api.models as models
+    profiles._invalidate_root_profile_cache()
+    # Reset migration flag so each test starts fresh
+    models._projects_migrated = False
+    yield
+    profiles._invalidate_root_profile_cache()
+    models._projects_migrated = False

--- a/tests/test_provider_management.py
+++ b/tests/test_provider_management.py
@@ -297,6 +297,42 @@ class TestSetProviderKey:
 class TestRemoveProviderKey:
     """Unit tests for remove_provider_key() wrapper."""
 
+    def test_clean_provider_key_uses_late_bound_config_path(self, monkeypatch, tmp_path):
+        """Config cleanup must honor api.config._get_config_path monkeypatches.
+
+        PR #1597 fixed provider-key cleanup by resolving the config path through
+        the api.config module at call time. If the implementation goes back to
+        the function imported into api.providers at module load, this test cleans
+        stale_config instead of active_config.
+        """
+        import yaml
+
+        import api.config as cfg_mod
+        import api.providers as providers
+
+        stale_config = tmp_path / "stale-config.yaml"
+        active_config = tmp_path / "active-config.yaml"
+        stale_config.write_text(
+            "providers:\n  openai:\n    api_key: stale-secret\n",
+            encoding="utf-8",
+        )
+        active_config.write_text(
+            "providers:\n  openai:\n    api_key: active-secret\nmodel:\n  provider: openai\n  api_key: active-model-secret\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setattr(providers, "_get_config_path", lambda: stale_config, raising=False)
+        monkeypatch.setattr(cfg_mod, "_get_config_path", lambda: active_config)
+        monkeypatch.setattr(providers, "reload_config", lambda: None)
+
+        providers._clean_provider_key_from_config("openai")
+
+        stale = yaml.safe_load(stale_config.read_text(encoding="utf-8"))
+        active = yaml.safe_load(active_config.read_text(encoding="utf-8"))
+        assert stale["providers"]["openai"]["api_key"] == "stale-secret"
+        assert "api_key" not in active["providers"]["openai"]
+        assert active["model"] == {"provider": "openai"}
+
     def test_remove_provider_key_calls_set_with_none(self, monkeypatch, tmp_path):
         """remove_provider_key should delegate to set_provider_key(id, None)."""
         _install_fake_hermes_cli(monkeypatch)

--- a/tests/test_version_badge.py
+++ b/tests/test_version_badge.py
@@ -3,11 +3,12 @@ Tests for the dynamic version badge (issue: stale hardcoded version strings).
 
 Covers:
   1. api/updates.py: _detect_webui_version() resolution chain
-  2. api/updates.py: WEBUI_VERSION module constant is set and non-empty
-  3. api/routes.py: GET /api/settings includes webui_version key
-  4. static/index.html: hardcoded stale badge is gone
-  5. static/panels.js: loadSettingsPanel() populates badge from settings
-  6. server.py: server_version is not the old hardcoded string
+  2. api/updates.py: _detect_agent_version() detection fallback
+  3. api/updates.py: WEBUI_VERSION module constant is set and non-empty
+  4. api/routes.py: GET /api/settings includes webui_version and agent_version keys
+  5. static/index.html: two version badges are present
+  6. static/panels.js: loadSettingsPanel() populates both version badges from settings
+  7. server.py: server_version is not the old hardcoded string
 """
 import importlib
 import sys
@@ -102,7 +103,65 @@ class TestDetectWebUIVersion:
 
 
 # ---------------------------------------------------------------------------
-# 2. WEBUI_VERSION module constant
+# 2. _detect_agent_version — resolution chain
+# ---------------------------------------------------------------------------
+
+class TestDetectAgentVersion:
+
+    def _fresh_detect(self, mock_run_git=None, version_file_content=None, tmp_path=None):
+        """Call _detect_agent_version() with controlled dependencies."""
+        import api.updates as upd
+
+        fake_root = tmp_path or Path('/nonexistent-agent-path')
+
+        if version_file_content is not None:
+            vf = fake_root / 'VERSION'
+            vf.write_text(version_file_content, encoding='utf-8')
+
+        def _run_git_side_effect(args, cwd, timeout=10):
+            if mock_run_git is not None:
+                return mock_run_git(args, cwd, timeout)
+            return ('', False)
+
+        with patch.object(upd, '_run_git', side_effect=_run_git_side_effect), \
+             patch.object(upd, '_AGENT_DIR', fake_root):
+            return upd._detect_agent_version()
+
+    def test_version_file_is_preferred(self, tmp_path):
+        """Agent VERSION file should be read before git fallback."""
+        result = self._fresh_detect(
+            mock_run_git=lambda args, cwd, timeout: ('v0.50.999', True),
+            version_file_content='v0.60.1\n',
+            tmp_path=tmp_path,
+        )
+        assert result == 'v0.60.1'
+
+    def test_git_fallback_used_when_version_file_missing(self, tmp_path):
+        """When VERSION file is absent, we fall back to git describe in agent path."""
+        (tmp_path / '.git').mkdir()
+        result = self._fresh_detect(
+            mock_run_git=lambda args, cwd, timeout: ('v0.60.2', True),
+            tmp_path=tmp_path,
+        )
+        assert result == 'v0.60.2'
+
+    def test_missing_agent_returns_not_detected(self):
+        """When no agent checkout is available, detect function returns 'not detected'."""
+        import api.updates as upd
+        with patch.object(upd, '_AGENT_DIR', None):
+            assert upd._detect_agent_version() == 'not detected'
+
+    def test_agent_detect_returns_not_detected_on_fail(self, tmp_path):
+        """Git fallback failure should remain user-friendly and not raise."""
+        result = self._fresh_detect(
+            mock_run_git=lambda args, cwd, timeout: ('', False),
+            tmp_path=tmp_path,
+        )
+        assert result == 'not detected'
+
+
+# ---------------------------------------------------------------------------
+# 3. WEBUI_VERSION module constant
 # ---------------------------------------------------------------------------
 
 class TestWebUIVersionConstant:
@@ -124,7 +183,7 @@ class TestWebUIVersionConstant:
 
 
 # ---------------------------------------------------------------------------
-# 3. GET /api/settings includes webui_version
+# 4. GET /api/settings includes webui_version and agent_version
 # ---------------------------------------------------------------------------
 
 class TestSettingsEndpointVersion:
@@ -154,9 +213,13 @@ class TestSettingsEndpointVersion:
             '/api/settings response must contain webui_version key'
         )
         assert captured['data']['webui_version'] == upd.WEBUI_VERSION
+        assert 'agent_version' in captured.get('data', {}), (
+            '/api/settings response must contain agent_version key'
+        )
+        assert captured['data']['agent_version'] == upd.AGENT_VERSION
 
     def test_api_settings_webui_version_not_empty(self):
-        """webui_version in /api/settings must be a non-empty string."""
+        """webui_version and agent_version in /api/settings must be non-empty strings."""
         import api.routes as routes
 
         handler = MagicMock()
@@ -174,6 +237,8 @@ class TestSettingsEndpointVersion:
 
         version = captured.get('data', {}).get('webui_version', '')
         assert version, 'webui_version in /api/settings must not be empty'
+        agent_version = captured.get('data', {}).get('agent_version', '')
+        assert agent_version, 'agent_version in /api/settings must not be empty'
 
     def test_api_settings_no_password_hash(self):
         """password_hash must still be stripped even with version injection."""
@@ -198,7 +263,7 @@ class TestSettingsEndpointVersion:
 
 
 # ---------------------------------------------------------------------------
-# 4. static/index.html — no stale hardcoded badge
+# 5. static/index.html — version badges
 # ---------------------------------------------------------------------------
 
 class TestIndexHTMLBadge:
@@ -215,15 +280,18 @@ class TestIndexHTMLBadge:
         )
 
     def test_badge_element_still_present(self):
-        """settings-version-badge span must still be in the DOM (JS needs the target)."""
+        """System version badge spans must still be in the DOM for both WebUI and Agent pills."""
         html = self._read_html()
-        assert 'settings-version-badge' in html, (
-            'settings-version-badge span missing from index.html — JS cannot populate it'
+        assert 'settings-webui-version-badge' in html, (
+            'WebUI badge element missing from index.html'
+        )
+        assert 'settings-agent-version-badge' in html, (
+            'Agent badge element missing from index.html'
         )
 
 
 # ---------------------------------------------------------------------------
-# 5. static/panels.js — badge population from settings
+# 6. static/panels.js — badge population from settings
 # ---------------------------------------------------------------------------
 
 class TestPanelsJSVersionBadge:
@@ -239,16 +307,22 @@ class TestPanelsJSVersionBadge:
             'to populate the badge dynamically'
         )
 
-    def test_panels_js_targets_version_badge(self):
-        """panels.js must target the .settings-version-badge element."""
+    def test_panels_js_targets_version_badges(self):
+        """loadSettingsPanel must target the two version badge elements."""
         src = self._read_js()
-        assert 'settings-version-badge' in src, (
-            'panels.js must query .settings-version-badge to update the badge text'
+        assert 'settings-webui-version-badge' in src, (
+            'panels.js must query #settings-webui-version-badge to update the WebUI text'
+        )
+        assert 'settings-agent-version-badge' in src, (
+            'panels.js must query #settings-agent-version-badge to update the Agent text'
+        )
+        assert 'agent_version' in src, (
+            'loadSettingsPanel must read settings.agent_version to populate the agent badge'
         )
 
 
 # ---------------------------------------------------------------------------
-# 6. server.py — server_version not the old hardcoded string
+# 7. server.py — server_version not the old hardcoded string
 # ---------------------------------------------------------------------------
 
 class TestServerVersionHeader:


### PR DESCRIPTION
# Release v0.50.293 — 3-PR batch (profile isolation trio + agent version + #1597 follow-up)

**3 PRs from 3 contributors.** Closes **#1606, #1611, #1612, #1614**.

## What ships

### #1629 by @nesquena-hermes (Co-authored @stefanpieter) — profile isolation trio

Closes #1611, #1612, #1614 — three tightly-coupled profile-isolation bugs sharing the root pattern: WebUI was treating profiles as a UI-only concept while the rest of Hermes treats them as runtime isolation boundaries.

- **#1611** `/api/sessions` not profile-scoped: multi-profile install was returning every profile's sessions to every UI via `Cookie: hermes_profile=...`. Frontend `is_cli_session` bypass let CLI-imported sessions through regardless of which profile owned them.
- **#1612** Renamed root profile 404s on switch: 5 hard-coded `if name == 'default':` literals didn't recognize a renamed root display name.
- **#1614** `/api/projects` not profile-scoped: project list was global; cron-spawned sessions in profile A surfaced under cron chip of profile B.

**Fix shape**: new `_is_root_profile()` central helper with `_root_profile_name_cache` + invalidation hooks; new `_profiles_match()` and `_all_profiles_query_flag()` route helpers; server-side filtering on both endpoints with `?all_profiles=1` opt-in; project rows now carry `profile` field; mutation guards on `/api/projects/{rename,delete}` and `/api/session/move`; `ensure_cron_project()` keys on `(name, profile)`; one-time idempotent migration for legacy untagged projects.

**31 dedicated regression tests** + nesquena APPROVED with comprehensive end-to-end trace + cross-tool verification against agent tarball + security audit + race/state analysis. Branch already absorbed Opus pre-merge SHOULD-FIX pass before staging.

### #1627 by @franksong2702 — show Hermes Agent version in Settings → System

Closes #1606. Adds `_detect_agent_version()` mirroring the existing `_detect_webui_version()` pattern: VERSION file → git describe fallback → "not detected". `GET /api/settings` returns both `webui_version` and `agent_version`. System pane gets a second `.settings-version-badge` pill labeled "Agent: ...". Implementation matches the shape outlined in #1606 maintainer comment 1:1.

### #1630 by @Michaelyklam — provider config cleanup regression test

Pure follow-up to #1597 (the call-time `api.config._get_config_path()` resolution fix from v0.50.292). Removes 1 unused import + adds 1 dedicated regression test that monkeypatches both stale + active config paths to verify cleanup only touches the active path. Belt-and-braces against a future import-cleanup silently reintroducing the original bug.

## Tests

**4142 → 4180 passing** (+38). 0 regressions. Full suite ~115s.

## Pre-release verification

- **Opus advisor on full stage-293 diff: SHIP verdict.** Two SHOULD-FIX absorbed in-release per <20-LOC defensive policy:
  - `api/models.py:load_projects()` re-reads from disk inside `_PROJECTS_MIGRATION_LOCK` when `_projects_migrated` is found True post-wait — closes a startup-window staleness race.
  - `_detect_agent_version()` uses `git describe --tags --always --dirty` for symmetry with `_detect_webui_version()`.
- **#1629 has nesquena APPROVED** with thorough behavioral analysis. Cross-tool verified against agent tarball — no agent-side surface touched.
- **JS syntax**: 2 modified `.js` files (panels.js, sessions.js) clean with `node -c`.
- **Browser API sanity**: 11/11 endpoints OK on stage server.
- **Conflict resolution**: `CHANGELOG.md` `## Unreleased` block from #1627 folded into #1629's pre-stamped `## [v0.50.293]` section. `api/routes.py` overlap auto-merged clean (disjoint code regions).

## Authors

- @nesquena-hermes (Co-authored @stefanpieter) — 1 PR (#1629, ~600 LOC production + 736 LOC tests)
- @franksong2702 — 1 PR (#1627)
- @Michaelyklam — 1 PR (#1630)

## Follow-up issues

One non-blocking client-side filter cross-alias edge case deferred as separate issue (renamed-root users with sessions tagged literal `'default'` predating the rename — strict-equality client filter at `sessions.js:1878` doesn't mirror server's `_is_root_profile` semantics).
