### PR TITLE
fix: session list race condition (#1430) + read-only fs guard (#1470)

### DIFF
--- a/docker_init.bash
+++ b/docker_init.bash
@@ -188,8 +188,24 @@ if [ "A${whoami}" == "Ahermeswebuitoo" ]; then
   # We are altering the UID/GID of the hermeswebui user to the desired ones and restarting as that user
   # using usermod for the already create hermeswebui user, knowing it is not already in use
   # per usermod manual: "You must make certain that the named user is not executing any processes when this command is being executed"
-  sudo groupmod -o -g ${WANTED_GID} hermeswebui || error_exit "Failed to set GID of hermeswebui user"
-  sudo usermod -o -u ${WANTED_UID} hermeswebui || error_exit "Failed to set UID of hermeswebui user"
+  # Guard for read-only root filesystem (podman with read_only=true, issue #1470).
+  _readonly_root=false
+  if [ ! -w /etc/group ] || [ ! -w /etc/passwd ]; then
+    _readonly_root=true
+    echo "  !! Detected read-only root filesystem — /etc/group or /etc/passwd is not writable"
+  fi
+  if [ "A${_readonly_root}" == "Atrue" ]; then
+    _current_hermeswebui_gid=$(id -g hermeswebui 2>/dev/null || echo "")
+    _current_hermeswebui_uid=$(id -u hermeswebui 2>/dev/null || echo "")
+    if [ "A${_current_hermeswebui_gid}" == "A${WANTED_GID}" ] && [ "A${_current_hermeswebui_uid}" == "A${WANTED_UID}" ]; then
+      echo "  -- Skipping groupmod/usermod — hermeswebui already has UID ${WANTED_UID} GID ${WANTED_GID} and root fs is read-only"
+    else
+      error_exit "Cannot modify /etc/group or /etc/passwd (read-only root fs). Set UID=${_current_hermeswebui_uid} and GID=${_current_hermeswebui_gid} to match, or run without read_only=true. See issue #1470."
+    fi
+  else
+    sudo groupmod -o -g ${WANTED_GID} hermeswebui || error_exit "Failed to set GID of hermeswebui user"
+    sudo usermod -o -u ${WANTED_UID} hermeswebui || error_exit "Failed to set UID of hermeswebui user"
+  fi
   sudo chown -R ${WANTED_UID}:${WANTED_GID} /home/hermeswebui || error_exit "Failed to set owner of /home/hermeswebui"
   save_env /tmp/hermeswebuitoo_env.txt  
   # restart the script as hermeswebui set with the correct UID/GID this time

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1359,7 +1359,14 @@ window.addEventListener('resize',()=>{
   if(_sessionActionMenu && _sessionActionAnchor) _positionSessionActionMenu(_sessionActionAnchor);
 });
 
+// Generation counter to discard stale API responses (issue #1430).
+// Multiple callers (message send, rename, session switch) fire renderSessionList()
+// concurrently. Without this guard, a slower older response can overwrite _allSessions
+// with stale data, causing sessions to vanish from the sidebar.
+let _renderSessionListGen = 0;
+
 async function renderSessionList(){
+  const _gen = ++_renderSessionListGen;
   try{
     if(!($('sessionSearch').value||'').trim()) _contentSearchResults = [];
     const allProfilesQS = _showAllProfiles ? '?all_profiles=1' : '';
@@ -1367,6 +1374,8 @@ async function renderSessionList(){
       api('/api/sessions' + allProfilesQS),
       api('/api/projects' + allProfilesQS),
     ]);
+    // Discard stale response — a newer renderSessionList() call superseded us.
+    if (_gen !== _renderSessionListGen) return;
     // Server's other_profile_count tells us how many sessions exist outside the
     // active profile so the "Show N from other profiles" toggle can render
     // without a second round-trip. Stashed on the module for renderSessionListFromCache.


### PR DESCRIPTION
Closes #1430, Closes #1470

## Summary

Two targeted fixes for reported bugs:

### #1430 — Session list race condition

**Symptom:** Picking a conversation from a previous day makes today's sessions disappear from the sidebar.

**Root cause:** `renderSessionList()` in `static/sessions.js` had no staleness guard. Multiple callers (message send, rename, session switch) fire it concurrently without awaiting. If a slower older API response arrives after a newer one, it overwrites `_allSessions` with stale data — causing sessions to vanish.

**Fix:** Added a generation counter (`_renderSessionListGen`). Each call increments it before the `await`, then discards the response if a newer call has superseded it. This is the lightest-weight approach — no AbortController, no debounce, no state machine.

### #1470 — Read-only root filesystem guard (podman)

**Symptom:** `groupmod: cannot lock /etc/group` crash under podman with `read_only=true`.

**Root cause:** `docker_init.bash` unconditionally calls `groupmod`/`usermod` even when `/etc/group` and `/etc/passwd` are on a read-only filesystem.

**Fix:** Added a writability check for `/etc/group` and `/etc/passwd`:
- If read-only and UID/GID already match → skip gracefully with a log message
- If read-only and UID/GID don't match → clear error message suggesting the user set matching IDs or disable read_only mode

## Test plan

- [x] `node --check static/sessions.js` — syntax OK
- [x] `bash -n docker_init.bash` — syntax OK
- [ ] Manual: open WebUI, create 2+ sessions on different days, click between them rapidly — sessions should persist
- [ ] Manual: podman with `read_only=true` + matching UID/GID — container should start without error

🤖 AI-assisted via Hermes Agent