### PR TITLE
fix: macOS auto-scroll momentum race (#1360) + custom:* provider model list (#1619)

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -2329,6 +2329,11 @@ def get_available_models() -> dict:
             for pid in sorted(detected_providers):
                 if pid.startswith("custom:") and pid in _named_custom_groups:
                     _nc_display, _nc_models = _named_custom_groups[pid]
+                    # If all named-group models were deduped (already auto-detected
+                    # from base_url /v1/models), fall back to auto-detected models
+                    # instead of silently dropping the group (issue #1619).
+                    if not _nc_models:
+                        _nc_models = auto_detected_models_by_provider.get(pid, [])
                     if _nc_models:
                         groups.append({"provider": _nc_display, "provider_id": pid, "models": _nc_models})
                     continue

--- a/api/routes.py
+++ b/api/routes.py
@@ -4509,11 +4509,12 @@ def _handle_live_models(handler, parsed):
             ids = []
 
         if not ids:
-            # For 'custom' provider, provider_model_ids() returns [] because
-            # 'custom' isn't a real endpoint.  Fall back to the custom_providers
-            # entries from config.yaml so the live-model enrichment step can
-            # add any models that weren't already in the static list.
-            if provider == "custom":
+            # For 'custom' and 'custom:*' providers, provider_model_ids()
+            # returns [] because they aren't real hermes_cli endpoints.
+            # Fall back to the custom_providers entries from config.yaml so
+            # the live-model enrichment step can add any models that weren't
+            # already in the static list (issue #1619).
+            if provider == "custom" or provider.startswith("custom:"):
                 try:
                     _cp_entries = cfg.get("custom_providers", [])
                     if isinstance(_cp_entries, list):
@@ -4525,8 +4526,8 @@ def _handle_live_models(handler, parsed):
                 except Exception:
                     pass
             
-            # If still no ids, try fetching from model.base_url directly (OpenAI-compat endpoint)
-            if not ids and provider == "custom":
+            # If still no ids, try fetching from base_url directly (OpenAI-compat endpoint)
+            if not ids and (provider == "custom" or provider.startswith("custom:")):
                 _base_url = cfg.get("model", {}).get("base_url")
                 _api_key = cfg.get("model", {}).get("api_key")
                 if _base_url and _api_key:

--- a/static/ui.js
+++ b/static/ui.js
@@ -1191,21 +1191,35 @@ window.addEventListener('resize',function(){
 // Uses a guard flag to avoid the race where programmatic scrolls (from
 // scrollIfPinned / scrollToBottom) re-set _scrollPinned=true, overriding
 // the user's explicit scroll-up.  Fixes #1469 / #1360.
+// rAF-debounced scroll listener (issue #1360): on macOS WKWebView, trackpad
+// momentum scrolling fires scroll events that interleave with the
+// _programmaticScroll setTimeout(0) guard. A mid-momentum scroll event can
+// either get swallowed (_programmaticScroll still true) or falsely report
+// nearBottom (momentum hasn't settled). rAF defers the nearBottom check to
+// the next paint frame when the browser's scroll position has settled.
+// A hysteresis counter requires two consecutive near-bottom samples before
+// re-pinning, preventing accidental re-pin during initial deceleration.
 let _scrollPinned=true;
 let _programmaticScroll=false;
+let _nearBottomCount=0;
 (function(){
   const el=document.getElementById('messages');
   if(!el) return;
+  let _scrollRaf=0;
   el.addEventListener('scroll',()=>{
     if(_programmaticScroll) return; // ignore scrolls we triggered ourselves
-    const nearBottom=el.scrollHeight-el.scrollTop-el.clientHeight<250;
-    _scrollPinned=nearBottom;
-    const btn=$('scrollToBottomBtn');
-    if(btn) btn.style.display=_scrollPinned?'none':'flex';
-    // Load older messages when scrolled near the top
-    if(el.scrollTop<80 && typeof _messagesTruncated!=='undefined' && _messagesTruncated && typeof _loadOlderMessages==='function'){
-      _loadOlderMessages();
-    }
+    cancelAnimationFrame(_scrollRaf);
+    _scrollRaf=requestAnimationFrame(()=>{
+      const nearBottom=el.scrollHeight-el.scrollTop-el.clientHeight<250;
+      _nearBottomCount=nearBottom?_nearBottomCount+1:0;
+      _scrollPinned=_nearBottomCount>=2;
+      const btn=$('scrollToBottomBtn');
+      if(btn) btn.style.display=_scrollPinned?'none':'flex';
+      // Load older messages when scrolled near the top
+      if(el.scrollTop<80 && typeof _messagesTruncated!=='undefined' && _messagesTruncated && typeof _loadOlderMessages==='function'){
+        _loadOlderMessages();
+      }
+    });
   });
 })();
 function _fmtTokens(n){if(!n||n<0)return'0';if(n>=1e6)return(n/1e6).toFixed(1)+'M';if(n>=1e3)return(n/1e3).toFixed(1)+'k';return String(n);}

--- a/tests/test_issue677.py
+++ b/tests/test_issue677.py
@@ -120,7 +120,9 @@ class TestScrollPinningFix:
         """Scroll listener must hide the button when user is near the bottom (#677)."""
         scroll_listener_start = UI_JS.find("el.addEventListener('scroll'")
         assert scroll_listener_start != -1, "scroll event listener not found"
-        listener_block = UI_JS[scroll_listener_start:scroll_listener_start + 300]
+        # After #1360 fix, the nearBottom + btn logic lives inside an rAF
+        # callback — extend search window to cover the full listener block.
+        listener_block = UI_JS[scroll_listener_start:scroll_listener_start + 600]
         assert "scrollToBottomBtn" in listener_block, (
             "Scroll listener must show/hide scrollToBottomBtn based on _scrollPinned (#677)"
         )


### PR DESCRIPTION
Closes #1360, Closes #1619

## Summary

Two targeted bug fixes.

### #1360 — Auto-scroll overrides user position on macOS (WKWebView)

**Symptom:** During streaming, scrolling up on a trackpad on macOS causes the viewport to snap back to the bottom.

**Root cause:** The `_programmaticScroll` setTimeout(0) guard races with WKWebView momentum scrolling. Mid-momentum scroll events either get swallowed or falsely report nearBottom, keeping _scrollPinned=true.

**Fix:** rAF-debounce the scroll listener + hysteresis counter requiring 2 consecutive near-bottom samples before re-pinning.

### #1619 — Model switching does not work for custom:* providers

**Symptom:** Using a custom:* provider via custom_providers in config.yaml, the model dropdown only shows the default model.

**Root cause:** (1) Dedup in config.py eats all named-group models when they overlap with auto-detected ones, and the continue silently drops auto-detected models. (2) Live enrichment endpoint only handled bare custom, not custom:* slugs.

**Fix:** (1) config.py: fall back to auto_detected_models when named group is empty after dedup. (2) routes.py: extend /api/models/live to handle custom:* slugs.

## Test plan

- [x] Python syntax OK (config.py, routes.py)
- [x] JS syntax OK (ui.js)
- [ ] Manual: macOS trackpad scroll during streaming stays pinned
- [ ] Manual: custom:* provider shows all models in dropdown

AI-assisted via Hermes Agent