### PR TITLE
fix(oauth): honor cancel during Codex device-token exchange (follow-up to #1652)

### DIFF
--- a/api/oauth.py
+++ b/api/oauth.py
@@ -347,6 +347,13 @@ def _run_codex_oauth_worker(flow_id: str) -> None:
             if not authorization_code or not code_verifier:
                 raise RuntimeError("Device auth response missing authorization_code or code_verifier")
             tokens = _exchange_codex_authorization(authorization_code, code_verifier)
+            # Re-check status under lock before persisting: a cancel/expire that
+            # raced with the device-token + token-exchange network calls must
+            # win, so we don't persist credentials the user explicitly aborted.
+            with _OAUTH_FLOWS_LOCK:
+                current = _OAUTH_FLOWS.get(flow_id)
+                if not current or current.get("status") != "pending":
+                    return
             _persist_codex_credentials(Path(live["hermes_home"]), tokens)
             _set_flow_status(flow_id, "success")
             return

--- a/tests/test_issue1362_codex_oauth_onboarding.py
+++ b/tests/test_issue1362_codex_oauth_onboarding.py
@@ -111,6 +111,60 @@ def test_cancel_marks_flow_cancelled_and_poll_stops(tmp_path):
     assert polled["status"] == "cancelled"
 
 
+def test_cancel_during_token_exchange_does_not_persist_credentials(monkeypatch, tmp_path):
+    """Cancel arriving while the worker is mid-network-call must win.
+
+    Without the post-exchange status re-check, the worker would proceed to
+    persist credentials to auth.json AND override the cancelled status with
+    "success" — silently storing tokens the user explicitly aborted.
+    """
+    import threading
+    import api.oauth as oauth
+
+    oauth._OAUTH_FLOWS.clear()
+
+    poll_started = threading.Event()
+    poll_continue = threading.Event()
+
+    def _slow_poll(device_auth_id, user_code):
+        poll_started.set()
+        assert poll_continue.wait(timeout=5)
+        return {"authorization_code": "auth-code", "code_verifier": "verifier"}
+
+    def _exchange(authorization_code, code_verifier):
+        return {"access_token": "ACCESS", "refresh_token": "REFRESH"}
+
+    monkeypatch.setattr(oauth, "_poll_codex_authorization", _slow_poll)
+    monkeypatch.setattr(oauth, "_exchange_codex_authorization", _exchange)
+
+    flow_id = "race-flow"
+    oauth._OAUTH_FLOWS[flow_id] = {
+        "provider": "openai-codex",
+        "status": "pending",
+        "device_auth_id": "device-secret",
+        "user_code": "ABCD-EFGH",
+        "expires_at": time.time() + 600,
+        "poll_interval_seconds": 1,
+        "hermes_home": str(tmp_path),
+        "created_at": time.time(),
+        "updated_at": time.time(),
+    }
+
+    worker = threading.Thread(target=oauth._run_codex_oauth_worker, args=(flow_id,), daemon=True)
+    worker.start()
+    assert poll_started.wait(timeout=5)
+
+    oauth.cancel_onboarding_oauth_flow({"flow_id": flow_id})
+    assert oauth._OAUTH_FLOWS[flow_id]["status"] == "cancelled"
+
+    poll_continue.set()
+    worker.join(timeout=5)
+    assert not worker.is_alive()
+
+    assert oauth._OAUTH_FLOWS[flow_id]["status"] == "cancelled"
+    assert not (tmp_path / "auth.json").exists()
+
+
 def test_expired_flow_reports_expired_and_drops_sensitive_lifecycle(tmp_path):
     import api.oauth as oauth
 


### PR DESCRIPTION
## Summary

Follow-on fix for [PR #1652](https://github.com/nesquena/hermes-webui/pull/1652) (Codex OAuth onboarding flow, refs #1362). Fixes a cancel-vs-worker race where a `POST /api/onboarding/oauth/cancel` request that arrived while the worker was mid-network-call would be silently overridden: credentials would still get persisted to `auth.json` and the flow status would flip from `cancelled` to `success`.

## The race

1. User clicks **Cancel** → server sets `flow.status = "cancelled"` and drops sensitive lifecycle fields under `_OAUTH_FLOWS_LOCK`.
2. Worker is mid-`_poll_codex_authorization` / `_exchange_codex_authorization` using the `live` snapshot it captured *before* the cancel.
3. Worker calls `_persist_codex_credentials(...)` — `auth.json` gets written.
4. Worker calls `_set_flow_status(flow_id, "success")` — overwrites the cancelled status.

Net effect: the user's explicit cancel is ignored, credentials get persisted, and the UI reports success.

## Behavioural harness — pre/post fix

Reproduced deterministically with a `threading.Event`-gated stub of the network calls:

```
[BEFORE FIX]
  AFTER CANCEL  → flow status: cancelled
  AFTER WORKER  → flow status: success
  AUTH FILE EXISTS: True
  CREDENTIALS PERSISTED DESPITE CANCEL

[AFTER FIX]
  AFTER CANCEL  → flow status: cancelled
  AFTER WORKER  → flow status: cancelled
  AUTH FILE EXISTS: False
```

## The fix

Re-check `_OAUTH_FLOWS[flow_id].status` under the lock immediately *after* `_exchange_codex_authorization` returns and *before* writing auth.json. If the status is no longer `pending`, the worker exits cleanly — no persistence, no status overwrite.

```python
with _OAUTH_FLOWS_LOCK:
    current = _OAUTH_FLOWS.get(flow_id)
    if not current or current.get("status") != "pending":
        return
_persist_codex_credentials(Path(live["hermes_home"]), tokens)
_set_flow_status(flow_id, "success")
```

The check is intentionally *post-network-call*: putting it earlier wouldn't catch the race window we actually hit (cancel during the in-flight exchange).

## Severity

UX inconsistency, not a security bug. The credentials that get persisted *are* tokens the user authorized in their browser — so the leak isn't an unauthorized credential write. But the cancel button stops doing what it says, which violates the design intent of #1650's server-owned lifecycle.

## Cross-tool trace

Verified against fresh `hermes-agent` tarball:
- `credential_pool["openai-codex"]` entry shape unchanged: `auth_type=oauth`, `source=manual:device_code`, `priority=0`, `base_url=https://chatgpt.com/backend-api/codex`.
- Compatible with `agent.credential_pool.load_pool("openai-codex")` and the agent CLI's `_save_codex_tokens` legacy fallback path (`hermes_cli/auth.py:3580-3608`).
- Same race exists in `hermes_cli/web_server.py:_codex_device_code_worker` — out of scope for this webui fix; the agent's web_server flow is a separate code path.

## Test plan

- [x] New regression `test_cancel_during_token_exchange_does_not_persist_credentials` drives a real worker thread against `threading.Event`-gated stubs of `_poll_codex_authorization` and `_exchange_codex_authorization`. The cancel arrives while the worker is parked in the slow poll; the test asserts the worker exits with `cancelled` status and no `auth.json` file is created.
- [x] All 10 tests in `tests/test_issue1362_codex_oauth_onboarding.py` pass.
- [x] Full suite: **4230 passed, 57 skipped, 3 xpassed, 0 failed in 33.82s**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)