### PR TITLE
fix: add deep health diagnostics

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -3041,6 +3041,34 @@ STREAM_REASONING_TEXT: dict = {}  # stream_id -> reasoning trace accumulated dur
 STREAM_LIVE_TOOL_CALLS: dict = {}  # stream_id -> live tool calls accumulated during streaming (#1361 §B)
 SERVER_START_TIME = time.time()
 
+# Request-path liveness diagnostics (#1458 Bug #3).  Process supervisors can
+# see that the Python process is alive and the port is listening, but they need
+# a counter that advances only when the HTTP server actually accepts a request.
+_HTTP_REQUEST_HEARTBEAT_LOCK = threading.Lock()
+_HTTP_REQUEST_HEARTBEAT_COUNT = 0
+_HTTP_REQUEST_HEARTBEAT_LAST_AT = SERVER_START_TIME
+
+
+def record_http_request_heartbeat() -> None:
+    """Record that the HTTP accept/request path advanced once."""
+    global _HTTP_REQUEST_HEARTBEAT_COUNT, _HTTP_REQUEST_HEARTBEAT_LAST_AT
+    now = time.time()
+    with _HTTP_REQUEST_HEARTBEAT_LOCK:
+        _HTTP_REQUEST_HEARTBEAT_COUNT += 1
+        _HTTP_REQUEST_HEARTBEAT_LAST_AT = now
+
+
+def get_http_request_heartbeat() -> dict:
+    """Return request-path liveness counters safe for /health output."""
+    with _HTTP_REQUEST_HEARTBEAT_LOCK:
+        count = _HTTP_REQUEST_HEARTBEAT_COUNT
+        last_at = _HTTP_REQUEST_HEARTBEAT_LAST_AT
+    return {
+        "count": count,
+        "last_at": last_at,
+        "last_age_seconds": round(max(0.0, time.time() - last_at), 3),
+    }
+
 # Agent cache: reuse AIAgent across messages in the same WebUI session so that
 # _user_turn_count survives between turns.  This mirrors the gateway's
 # _agent_cache pattern and is required for injectionFrequency: "first-turn".

--- a/api/routes.py
+++ b/api/routes.py
@@ -363,6 +363,7 @@ def _clear_live_models_cache() -> None:
 from api.config import (
     STATE_DIR,
     SESSION_DIR,
+    SESSION_INDEX_FILE,
     DEFAULT_WORKSPACE,
     DEFAULT_MODEL,
     SESSIONS,
@@ -393,6 +394,7 @@ from api.config import (
     set_reasoning_effort,
     create_stream_channel,
     get_webui_session_save_mode,
+    get_http_request_heartbeat,
 )
 from api.helpers import (
     require,
@@ -1658,6 +1660,84 @@ def _handle_insights(handler, parsed) -> bool:
 # ── GET routes ────────────────────────────────────────────────────────────────
 
 
+def _read_active_streams_bounded(timeout_seconds: float = 0.1) -> dict:
+    """Read STREAMS under a bounded lock attempt for deep health probes.
+
+    A wedged STREAMS_LOCK should make /health?deep=1 fail fast with useful
+    diagnostics instead of causing the watchdog probe itself to hang.
+    """
+    started = time.monotonic()
+    acquired = STREAMS_LOCK.acquire(timeout=timeout_seconds)
+    wait_ms = round((time.monotonic() - started) * 1000, 3)
+    if not acquired:
+        return {
+            "ok": False,
+            "acquired": False,
+            "active_streams": None,
+            "wait_ms": wait_ms,
+            "error": "STREAMS_LOCK acquisition timed out",
+        }
+    try:
+        return {
+            "ok": True,
+            "acquired": True,
+            "active_streams": len(STREAMS),
+            "wait_ms": wait_ms,
+        }
+    finally:
+        STREAMS_LOCK.release()
+
+
+def _session_store_health() -> dict:
+    """Exercise the session-store path without exposing session contents."""
+    result = {
+        "ok": True,
+        "path_exists": SESSION_DIR.exists(),
+        "index_exists": SESSION_INDEX_FILE.exists(),
+        "index_readable": None,
+        "session_file_count": 0,
+    }
+    try:
+        if not result["path_exists"]:
+            raise FileNotFoundError(str(SESSION_DIR))
+        result["session_file_count"] = sum(
+            1 for p in SESSION_DIR.glob("*.json") if not p.name.startswith("_")
+        )
+        if result["index_exists"]:
+            json.loads(SESSION_INDEX_FILE.read_text(encoding="utf-8") or "[]")
+            result["index_readable"] = True
+        else:
+            result["index_readable"] = False
+    except Exception as exc:
+        result["ok"] = False
+        result["error"] = type(exc).__name__
+    return result
+
+
+def _health_payload(*, deep: bool = False) -> tuple[dict, int]:
+    streams = _read_active_streams_bounded(timeout_seconds=0.1)
+    payload = {
+        "status": "ok" if streams["ok"] else "degraded",
+        "sessions": len(SESSIONS),
+        "active_streams": streams["active_streams"],
+        "uptime_seconds": round(time.time() - SERVER_START_TIME, 1),
+        "request_heartbeat": get_http_request_heartbeat(),
+    }
+    status = 200 if streams["ok"] else 503
+
+    if deep:
+        session_store = _session_store_health()
+        payload["deep"] = True
+        payload["diagnostics"] = {
+            "session_store": session_store,
+            "streams_lock": streams,
+        }
+        if not session_store["ok"]:
+            payload["status"] = "degraded"
+            status = 503
+    return payload, status
+
+
 def handle_get(handler, parsed) -> bool:
     """Handle all GET routes. Returns True if handled, False for 404."""
 
@@ -1776,17 +1856,10 @@ def handle_get(handler, parsed) -> bool:
         return _handle_insights(handler, parsed)
 
     if parsed.path == "/health":
-        with STREAMS_LOCK:
-            n_streams = len(STREAMS)
-        return j(
-            handler,
-            {
-                "status": "ok",
-                "sessions": len(SESSIONS),
-                "active_streams": n_streams,
-                "uptime_seconds": round(time.time() - SERVER_START_TIME, 1),
-            },
-        )
+        query = parse_qs(parsed.query)
+        deep = str(query.get("deep", [""])[0]).strip().lower() in ("1", "true", "yes", "on")
+        payload, status = _health_payload(deep=deep)
+        return j(handler, payload, status=status)
 
     if parsed.path == "/api/models":
         return j(handler, get_available_models())

--- a/server.py
+++ b/server.py
@@ -14,7 +14,14 @@ from urllib.parse import urlparse
 logger = logging.getLogger(__name__)
 
 from api.auth import check_auth
-from api.config import HOST, PORT, STATE_DIR, SESSION_DIR, DEFAULT_WORKSPACE
+from api.config import (
+    HOST,
+    PORT,
+    STATE_DIR,
+    SESSION_DIR,
+    DEFAULT_WORKSPACE,
+    record_http_request_heartbeat,
+)
 from api.helpers import j, get_profile_cookie
 from api.profiles import set_request_profile, clear_request_profile
 from api.routes import handle_get, handle_post
@@ -26,7 +33,14 @@ class QuietHTTPServer(ThreadingHTTPServer):
     """Custom HTTP server that silently handles common network errors."""
     daemon_threads = True
     request_queue_size = 64
-    
+
+    def _handle_request_noblock(self):
+        # Issue #1458 Bug #3: expose an accept/request heartbeat so watchdogs
+        # can tell whether request handling is still advancing, not merely
+        # whether the process is alive and the socket is listening.
+        record_http_request_heartbeat()
+        return super()._handle_request_noblock()
+
     def handle_error(self, request, client_address):
         """Override to suppress logging for common client disconnect errors."""
         exc_type, exc_value, _ = sys.exc_info()

--- a/tests/test_issue1458_health_diagnostics.py
+++ b/tests/test_issue1458_health_diagnostics.py
@@ -1,0 +1,68 @@
+"""
+Regression coverage for issue #1458 Bug #3 diagnostics.
+
+The residual HTTP-unhealthy wedge can leave the process alive and the port
+listening while request handling no longer advances. /health must expose enough
+cheap diagnostics for a watchdog to distinguish process liveness from request
+path liveness, and /health?deep=1 must exercise a little more of the request
+path without hanging forever on shared locks.
+"""
+import json
+import urllib.request
+
+from tests._pytest_port import BASE
+
+
+def _get(path):
+    with urllib.request.urlopen(BASE + path, timeout=10) as r:
+        return json.loads(r.read()), r.status
+
+
+def test_health_exposes_request_heartbeat_counter(cleanup_test_sessions):
+    first, status = _get("/health")
+    assert status == 200
+    assert first["status"] == "ok"
+    heartbeat = first["request_heartbeat"]
+    assert isinstance(heartbeat["count"], int)
+    assert heartbeat["count"] >= 1
+    assert isinstance(heartbeat["last_at"], float)
+    assert heartbeat["last_age_seconds"] >= 0
+
+    second, status = _get("/health")
+    assert status == 200
+    assert second["request_heartbeat"]["count"] > heartbeat["count"]
+
+
+def test_deep_health_exercises_session_store_and_stream_lock(cleanup_test_sessions):
+    data, status = _get("/health?deep=1")
+    assert status == 200
+    assert data["status"] == "ok"
+    assert data["deep"] is True
+
+    session_store = data["diagnostics"]["session_store"]
+    assert session_store["ok"] is True
+    assert session_store["path_exists"] is True
+    assert isinstance(session_store["session_file_count"], int)
+    assert "index_readable" in session_store
+
+    streams_lock = data["diagnostics"]["streams_lock"]
+    assert streams_lock["ok"] is True
+    assert streams_lock["acquired"] is True
+    assert streams_lock["active_streams"] == data["active_streams"]
+    assert streams_lock["wait_ms"] >= 0
+
+
+def test_deep_health_stream_lock_probe_is_bounded(cleanup_test_sessions):
+    from api import config as cfg
+    from api.routes import _read_active_streams_bounded
+
+    assert cfg.STREAMS_LOCK.acquire(blocking=False)
+    try:
+        result = _read_active_streams_bounded(timeout_seconds=0.01)
+    finally:
+        cfg.STREAMS_LOCK.release()
+
+    assert result["ok"] is False
+    assert result["acquired"] is False
+    assert result["active_streams"] is None
+    assert result["wait_ms"] < 250


### PR DESCRIPTION
## Thinking Path

- Issue #1458 is now narrowed to the residual Bug #3 class: a WebUI process can be alive and port-listening while real HTTP handling is unhealthy.
- The fixed bootstrap and SQLite FD-leak paths are intentionally out of scope; this PR adds diagnostics rather than claiming to solve every possible residual wedge.
- A watchdog needs two signals that process liveness cannot provide: whether the request path is still advancing, and whether shared health-adjacent resources can be touched without hanging.
- The smallest useful hardening slice is to expose an accept/request heartbeat in `/health` and add `/health?deep=1` for bounded session-store and stream-lock checks.
- The benefit is better production diagnostics and safer supervisor/watchdog decisions for the remaining HTTP-unhealthy wedge hypotheses.

## What Changed

- Added request-path heartbeat counters in `api.config` and increment them from `QuietHTTPServer._handle_request_noblock()`.
- Updated `/health` to include `request_heartbeat` and to read `STREAMS_LOCK` with a bounded acquisition instead of an unbounded `with STREAMS_LOCK` block.
- Added `/health?deep=1` diagnostics that exercise the session-store path without exposing session contents and report bounded stream-lock probe details.
- Added regression coverage in `tests/test_issue1458_health_diagnostics.py` for heartbeat advancement, deep session-store/stream-lock diagnostics, and bounded lock timeout behavior.

Refs #1458.

## Why It Matters

The residual #1458 failure mode is specifically about process supervisors seeing a live process and open socket even though HTTP requests are not successfully completing. These diagnostics give watchdogs and operators a cheap way to distinguish “process exists” from “request handling is still advancing,” and a deeper probe that can fail fast when shared session/stream state is unhealthy.

## Verification

```bash
env -u HERMES_CONFIG_PATH /home/michael/.hermes/hermes-agent/venv/bin/python -m pytest --rootdir=. -n 0 tests/test_issue1458_health_diagnostics.py -q
env -u HERMES_CONFIG_PATH /home/michael/.hermes/hermes-agent/venv/bin/python -m pytest --rootdir=. -n 0 tests/test_issue1458_health_diagnostics.py tests/test_sprint10.py::test_health_still_works -q
git diff --check
env -u HERMES_CONFIG_PATH /home/michael/.hermes/hermes-agent/venv/bin/python -m pytest --rootdir=. -n 0 tests/ -q
HERMES_WEBUI_TEST_PORT=28768 HERMES_WEBUI_TEST_STATE_DIR=/tmp/hermes-webui-pytest-28768 env -u HERMES_CONFIG_PATH /home/michael/.hermes/hermes-agent/venv/bin/python -m pytest --rootdir=. -n 0 tests/test_issue1458_health_diagnostics.py tests/test_sprint10.py::test_health_still_works -q
```

Result:

```text
tests/test_issue1458_health_diagnostics.py: 3 passed in 1.57s
issue1458 diagnostics + existing shallow health test: 4 passed in 1.63s
git diff --check: passed
full local suite: 4285 passed, 2 skipped, 2 deselected, 3 xpassed, 8 subtests passed in 566.00s
final targeted rerun on explicit clean test port/state: 4 passed in 1.57s
GitHub Actions: Tests passed on Python 3.11, 3.12, and 3.13
```

Manual verification, if applicable:

- No browser/UI flow changed; no screenshots needed.

UI media, if applicable:

- Not applicable — server health JSON only.

## Risks / Follow-ups

- This is diagnostic hardening, not proof that every residual RST+LISTEN mechanism is fixed.
- `/health` now exposes a heartbeat timestamp/count and uses a bounded stream-lock read; if `STREAMS_LOCK` is wedged it reports degraded instead of hanging indefinitely.
- `session_store` diagnostics intentionally return counts/booleans/error class only, not session contents or local paths.
- A later local full-suite rerun was invalidated by the test harness deleting the disposable worktree while pytest was running; the PR branch itself is clean and GitHub Actions is green.

## Model Used

AI assisted.

- Provider: openai-codex
- Model: `gpt-5.5`
- Notable tool use: Hermes Kanban worker, terminal/git/gh, pytest, source inspection