### PR TITLE
fix: normalize named profile base homes

### DIFF
--- a/api/profiles.py
+++ b/api/profiles.py
@@ -37,6 +37,13 @@ _loaded_profile_env_keys: set[str] = set()
 # process-global _active_profile.
 _tls = threading.local()
 
+def _unwrap_profile_home_to_base(home: Path) -> Path:
+    """Return the base Hermes home when *home* is already a named profile dir."""
+    if home.parent.name == 'profiles':
+        return home.parent.parent
+    return home
+
+
 def _resolve_base_hermes_home() -> Path:
     """Return the BASE ~/.hermes directory — the root that contains profiles/.
 
@@ -56,20 +63,22 @@ def _resolve_base_hermes_home() -> Path:
     reading it here would make _DEFAULT_HERMES_HOME point to that subdir,
     causing switch_profile('webui') to look for
     /home/user/.hermes/profiles/webui/profiles/webui — which doesn't exist.
+
+    HERMES_BASE_HOME normally points at the base home already, but isolated
+    single-profile WebUI deployments can provide /base/profiles/<name> there as
+    well.  Normalize both env vars through the same helper so active-profile
+    and per-request resolution share one base-root contract (#749).
     """
     # Explicit override for tests or unusual setups
     base_override = os.getenv('HERMES_BASE_HOME', '').strip()
     if base_override:
-        return Path(base_override).expanduser()
+        return _unwrap_profile_home_to_base(Path(base_override).expanduser())
 
     hermes_home = os.getenv('HERMES_HOME', '').strip()
     if hermes_home:
         p = Path(hermes_home).expanduser()
         # If HERMES_HOME points to a profiles/ subdir, walk up two levels to the base
-        if p.parent.name == 'profiles':
-            return p.parent.parent
-        # Otherwise trust it (e.g. test isolation sets HERMES_HOME to TEST_STATE_DIR)
-        return p
+        return _unwrap_profile_home_to_base(p)
 
     return Path.home() / '.hermes'
 
@@ -193,19 +202,29 @@ def clear_request_profile() -> None:
     _tls.profile = None
 
 
+def _resolve_profile_home_for_name(name: str) -> Path:
+    """Resolve a logical profile name to its Hermes home path.
+
+    Root/default aliases resolve to _DEFAULT_HERMES_HOME.  Valid named profiles
+    resolve to _DEFAULT_HERMES_HOME/profiles/<name> even when the directory has
+    not been created yet; the agent layer may create it on first use.  Invalid
+    names fall back to the base home so traversal-shaped cookie values cannot
+    influence filesystem paths.
+    """
+    if not name or _is_root_profile(name):
+        return _DEFAULT_HERMES_HOME
+    if not _PROFILE_ID_RE.fullmatch(name):
+        return _DEFAULT_HERMES_HOME
+    return _resolve_named_profile_home(name)
+
+
 def get_active_hermes_home() -> Path:
     """Return the HERMES_HOME path for the currently active profile.
 
     Uses get_active_profile_name() so per-request TLS context (issue #798)
     is respected, not just the process-level global.
     """
-    name = get_active_profile_name()
-    if _is_root_profile(name):
-        return _DEFAULT_HERMES_HOME
-    profile_dir = _DEFAULT_HERMES_HOME / 'profiles' / name
-    if profile_dir.is_dir():
-        return profile_dir
-    return _DEFAULT_HERMES_HOME
+    return _resolve_profile_home_for_name(get_active_profile_name())
 
 
 
@@ -393,12 +412,7 @@ def get_hermes_home_for_profile(name: str) -> Path:
     empty, 'default', or does not match the profile-name format (rejects path
     traversal such as '../../etc').
     """
-    if not name or _is_root_profile(name):
-        return _DEFAULT_HERMES_HOME
-    if not _PROFILE_ID_RE.fullmatch(name):
-        return _DEFAULT_HERMES_HOME
-    profile_dir = _DEFAULT_HERMES_HOME / 'profiles' / name
-    return profile_dir
+    return _resolve_profile_home_for_name(name)
 
 
 _TERMINAL_ENV_MAPPINGS = {

--- a/tests/test_issue798.py
+++ b/tests/test_issue798.py
@@ -9,7 +9,9 @@ get_hermes_home_for_profile() resolves a HERMES_HOME path from a name without
 touching os.environ or module-level state.
 """
 
+import json
 import os
+import subprocess
 import sys
 import threading
 from pathlib import Path
@@ -69,6 +71,96 @@ def test_get_hermes_home_for_profile_does_not_mutate_globals():
     assert os.environ.get('HERMES_HOME') == before_hermes_home, (
         "get_hermes_home_for_profile() must not mutate os.environ['HERMES_HOME']"
     )
+
+
+def _run_profile_resolution_probe(env):
+    script = r'''
+import json
+from pathlib import Path
+import api.profiles as p
+import api.models as m
+
+p.set_request_profile('foo')
+foo_home = p.get_active_hermes_home()
+explicit_foo_home = p.get_hermes_home_for_profile('foo')
+foo_runtime = p.get_profile_runtime_env(explicit_foo_home)
+model_home = m._get_profile_home('foo')
+explicit_bar_home = p.get_hermes_home_for_profile('bar')
+p.set_request_profile('bar')
+active_bar_home = p.get_active_hermes_home()
+print(json.dumps({
+    'default_home': str(p._DEFAULT_HERMES_HOME),
+    'foo_home': str(foo_home),
+    'explicit_foo_home': str(explicit_foo_home),
+    'foo_terminal_cwd': foo_runtime.get('TERMINAL_CWD'),
+    'model_home': str(model_home),
+    'explicit_bar_home': str(explicit_bar_home),
+    'active_bar_home': str(active_bar_home),
+}))
+'''
+    result = subprocess.run(
+        [sys.executable, '-c', script],
+        cwd=Path(__file__).parent.parent,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    return json.loads(result.stdout)
+
+
+def test_hermes_base_home_named_profile_matches_cookie_without_doubling(tmp_path):
+    """R19k / #749: HERMES_BASE_HOME may point directly at a named profile home.
+
+    A single-profile WebUI deployment can start with both HERMES_BASE_HOME and
+    HERMES_HOME set to /base/profiles/foo while the browser still sends the
+    logical cookie hermes_profile=foo.  Both active-profile and explicit
+    per-request helpers must use /base/profiles/foo, not the doubled
+    /base/profiles/foo/profiles/foo path — even if that nested path already
+    exists from a prior bad write.
+    """
+    profile_home = tmp_path / 'profiles' / 'foo'
+    doubled_home = profile_home / 'profiles' / 'foo'
+    doubled_home.mkdir(parents=True)
+    profile_home.joinpath('config.yaml').write_text(
+        'terminal:\n  cwd: /expected/profile-home\n', encoding='utf-8'
+    )
+    doubled_home.joinpath('config.yaml').write_text(
+        'terminal:\n  cwd: /wrong/doubled-home\n', encoding='utf-8'
+    )
+
+    env = os.environ.copy()
+    env.update({
+        'HERMES_BASE_HOME': str(profile_home),
+        'HERMES_HOME': str(profile_home),
+    })
+    data = _run_profile_resolution_probe(env)
+
+    assert data['default_home'] == str(tmp_path)
+    assert data['foo_home'] == str(profile_home)
+    assert data['explicit_foo_home'] == str(profile_home)
+    assert data['foo_terminal_cwd'] == '/expected/profile-home'
+    assert data['model_home'] == str(profile_home)
+
+
+def test_hermes_base_home_named_profile_nonmatching_cookie_uses_sibling_profile_path(tmp_path):
+    """R19l / #749: non-matching cookies must not silently route to the pinned home.
+
+    When HERMES_BASE_HOME is supplied as /base/profiles/foo but the request asks
+    for logical profile bar, preserving base semantics means bar resolves to the
+    sibling /base/profiles/bar.  It must not fall back to foo, and it must not
+    append bar under foo/profiles/bar.
+    """
+    profile_home = tmp_path / 'profiles' / 'foo'
+    profile_home.mkdir(parents=True)
+
+    env = os.environ.copy()
+    env.update({'HERMES_BASE_HOME': str(profile_home)})
+    data = _run_profile_resolution_probe(env)
+
+    expected_bar_home = tmp_path / 'profiles' / 'bar'
+    assert data['explicit_bar_home'] == str(expected_bar_home)
+    assert data['active_bar_home'] == str(expected_bar_home)
 
 
 # ── R19e-h: new_session() profile isolation ───────────────────────────────────


### PR DESCRIPTION
## Thinking Path

- Hermes WebUI profiles need to resolve to the same Hermes home that Hermes Agent will use for config, runtime env, sessions, and model startup.
- Issue #749 still had one concrete open repro: a per-profile deployment sets `HERMES_BASE_HOME=/base/profiles/foo` while the browser sends `hermes_profile=foo`.
- The root cause was that `_resolve_base_hermes_home()` unwrapped `HERMES_HOME=/base/profiles/foo` but trusted `HERMES_BASE_HOME` as already being the base, so later helpers appended `profiles/foo` again.
- This PR normalizes both env-var paths through the same base-home helper, then routes active-profile and explicit per-request lookups through one shared profile-home resolver.
- The result is a focused fix for the doubled `profiles/foo/profiles/foo` path without redesigning the broader profile UX umbrella.

## What Changed

- Added `_unwrap_profile_home_to_base()` so `HERMES_BASE_HOME=/base/profiles/<name>` is normalized to `/base`, matching the existing `HERMES_HOME` profile-subdir behavior.
- Added `_resolve_profile_home_for_name()` and made both `get_active_hermes_home()` and `get_hermes_home_for_profile()` delegate to it.
- Tightened active-profile resolution so valid named profiles resolve to their profile-scoped path even before the directory exists, matching the existing explicit per-request helper and avoiding silent fallback to the pinned home.
- Added #749 regression coverage for:
  - matching profile cookie `foo` resolving to `/base/profiles/foo`, not `/base/profiles/foo/profiles/foo`, even when the doubled path exists;
  - `api.models._get_profile_home('foo')` and `get_profile_runtime_env()` reading the intended profile home/config;
  - non-matching profile `bar` resolving to the sibling `/base/profiles/bar`, not the pinned `foo` directory or `foo/profiles/bar`.

## Why It Matters

A dedicated WebUI process per named profile is a useful isolation deployment shape. Before this fix, that setup could make chat/model startup read a nested empty profile directory and report misleading provider/config failures even though the intended profile was configured correctly. This keeps the runtime path model consistent across active profile, per-request profile, model/session startup, and profile runtime env loading.

## Verification

```bash
/home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_issue798.py::test_hermes_base_home_named_profile_matches_cookie_without_doubling tests/test_issue798.py::test_hermes_base_home_named_profile_nonmatching_cookie_uses_sibling_profile_path -q
/home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_issue798.py tests/test_issue803.py tests/test_issue1612_renamed_root_profile.py tests/test_issue1611_session_profile_filtering.py tests/test_profile_terminal_env.py tests/test_model_resolver.py tests/test_session_import_cli_fallback_model.py -q
git diff --check
HERMES_WEBUI_HOST=127.0.0.1 env -u HERMES_CONFIG_PATH /home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_dashboard_probe.py::test_status_tries_default_loopback_targets_until_dashboard_found tests/test_issue798.py tests/test_sprint1.py::test_health -q
HERMES_WEBUI_HOST=127.0.0.1 env -u HERMES_CONFIG_PATH /home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_gateway_sync.py::test_importing_older_gateway_session_preserves_original_timestamps_and_order tests/test_onboarding_mvp.py::test_onboarding_setup_rejects_api_key_with_newline tests/test_sprint14.py::test_file_rename tests/test_sprint14.py::test_create_dir tests/test_sprint5.py::test_workspace_suggest_hidden_dirs_only_when_requested -q
```

Result:

```text
2 passed in 1.79s
74 passed in 16.56s
git diff --check: passed
14 passed in 1.46s
5 passed in 6.47s
```

Full-suite note:

```text
Attempted full isolated suite with HERMES_WEBUI_HOST=127.0.0.1 and env -u HERMES_CONFIG_PATH:
5 failed, 4474 passed, 2 skipped, 3 xpassed, 1 warning, 8 subtests passed in 432.55s.
The 5 failed tests were order/environment-sensitive existing tests unrelated to this profile-path diff; rerunning those exact 5 tests in isolation passed (listed above).
```

UI media:

- Not applicable; backend/profile path resolution only.

## Risks / Follow-ups

- This PR treats `HERMES_BASE_HOME=/base/profiles/foo` as a profile-home input that should be unwrapped to `/base`; that matches the existing `HERMES_HOME` behavior and keeps non-matching profile cookies on sibling paths.
- The broader #749 profile-runtime UX alignment remains open; this intentionally only fixes the concrete doubled-path repro. Refs #749.

## Model Used

AI assisted.

- Provider: OpenAI Codex
- Model: `gpt-5.5`
- Notable tool use: Hermes Kanban worker, terminal/git/gh, pytest, source inspection
