### PR TITLE
fix: normalize update banner repository URLs

### DIFF
--- a/api/updates.py
+++ b/api/updates.py
@@ -150,6 +150,25 @@ WEBUI_VERSION: str = _detect_webui_version()
 AGENT_VERSION: str = _detect_agent_version()
 
 
+def _normalize_remote_url(remote_url):
+    """Return the browser-facing repository URL for update compare links.
+
+    Git remotes may be HTTPS or SSH and may include a literal ``.git`` suffix.
+    Strip only that literal suffix — never use ``str.rstrip('.git')`` because it
+    treats the argument as a character set and can truncate ``hermes-webui`` to
+    ``hermes-webu``.
+    """
+    if not remote_url:
+        return remote_url
+    remote_url = remote_url.strip()
+    if remote_url.startswith('git@'):
+        remote_url = remote_url.replace(':', '/', 1).replace('git@', 'https://', 1)
+    remote_url = remote_url.rstrip('/')
+    if remote_url.endswith('.git'):
+        remote_url = remote_url[:-4]
+    return remote_url.rstrip('/')
+
+
 def _split_remote_ref(ref):
     """Split 'origin/branch-name' into ('origin', 'branch-name').
 
@@ -234,11 +253,7 @@ def _check_repo(path, name):
 
     # Get repo URL for "What's new?" link
     remote_url, _ = _run_git(['remote', 'get-url', 'origin'], path)
-    # Convert SSH URLs (git@github.com:org/repo.git) to HTTPS
-    if remote_url and remote_url.startswith('git@'):
-        remote_url = remote_url.replace(':', '/', 1).replace('git@', 'https://', 1)
-    if remote_url and remote_url.endswith('.git'):
-        remote_url = remote_url[:-4]
+    remote_url = _normalize_remote_url(remote_url)
 
     return {
         'name': name,

--- a/tests/test_update_banner_fixes.py
+++ b/tests/test_update_banner_fixes.py
@@ -79,6 +79,31 @@ class TestUpdateChecker:
 
         assert result['repo_url'] == 'https://github.com/NousResearch/hermes-agent'
 
+    def test_repo_url_strips_dot_git_before_trailing_slashes(self, tmp_path, monkeypatch):
+        import api.updates as upd
+
+        (tmp_path / '.git').mkdir()
+
+        def fake_run(args, cwd, timeout=10):
+            if args[0] == 'fetch':
+                return '', True
+            if args[:2] == ['rev-parse', '--abbrev-ref']:
+                return 'origin/master', True
+            if args[:2] == ['rev-list', '--count']:
+                return '2', True
+            if args[0] == 'merge-base':
+                return 'abcdef1234567890', True
+            if args[:2] == ['rev-parse', '--short']:
+                return 'abcdef1', True
+            if args[:2] == ['remote', 'get-url']:
+                return 'https://github.com/nesquena/hermes-webui.git/', True
+            return '', True
+
+        monkeypatch.setattr(upd, '_run_git', fake_run)
+        result = upd._check_repo(tmp_path, 'webui')
+
+        assert result['repo_url'] == 'https://github.com/nesquena/hermes-webui'
+
 
 class TestConflictError:
     """#813 — conflict error must include flag + recovery command."""


### PR DESCRIPTION
## Thinking Path

- The update banner's "What's new?" link is only useful if the backend provides a canonical browser-facing repository URL.
- Issue #1691 reports the link pointing at `https://github.com/nesquena/hermes-webu/` instead of `hermes-webui`.
- The fragile part is remote URL normalization: `.git` must be treated as a literal suffix, not as a character set, and trailing slashes should not prevent suffix removal.
- This PR keeps the fix narrow by centralizing update remote normalization in `api/updates.py` and pinning the edge case with a regression test.
- The user-visible benefit is that the "What's new?" compare link stays on the intended `nesquena/hermes-webui` repository.

## What Changed

- Added `_normalize_remote_url()` in `api/updates.py` for update-banner repository URLs.
- Preserved SSH-to-HTTPS conversion while stripping only a literal `.git` suffix.
- Normalized trailing slashes before and after `.git` removal so URLs like `https://github.com/nesquena/hermes-webui.git/` become `https://github.com/nesquena/hermes-webui`.
- Added a regression test covering the `.git/` trailing-slash case for the WebUI repo URL.

## Why It Matters

The update banner should send users to the actual Hermes WebUI repository when they click "What's new?". A truncated repository slug makes the link useless and undermines the update flow at exactly the moment users are trying to understand a release.

Closes #1691.

## Verification

```bash
/home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_update_banner_fixes.py::TestUpdateChecker::test_repo_url_strips_dot_git_before_trailing_slashes -q
/home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_update_banner_fixes.py::TestUpdateChecker -q
env -u HERMES_CONFIG_PATH -u HERMES_WEBUI_HOST /home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_update_banner_fixes.py tests/test_issue1579_whats_new_link_404.py -q
env -u HERMES_CONFIG_PATH -u HERMES_WEBUI_HOST /home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/ -q
git diff --check
```

Result:

```text
RED: new regression failed before the production change because repo_url remained `https://github.com/nesquena/hermes-webui.git/`.
GREEN: TestUpdateChecker passed (3 passed in 1.42s).
Related update-banner/link tests passed (42 passed in 3.33s).
Full suite passed: 4478 passed, 2 skipped, 3 xpassed, 1 warning, 8 subtests passed in 405.72s.
git diff --check passed.
```

Manual verification, if applicable:

- Not applicable; this is backend URL normalization covered by regression tests.

UI media, if applicable:

- Not applicable; no visual UI layout or interaction flow changed.

## Risks / Follow-ups

- Low risk: this only centralizes the existing update remote normalization and adds support for trailing slash variants.
- Follow-up only if maintainers want broader remote URL support beyond GitHub-style HTTPS/SSH origins.

## Model Used

AI assisted.

- Provider: OpenAI Codex
- Model: `gpt-5.5`
- Notable tool use: `gh` issue/PR workflow, git worktree isolation, pytest regression/full-suite verification, diff inspection.
