### PR TITLE
Fix multi-image paste attachments

### DIFF
--- a/static/boot.js
+++ b/static/boot.js
@@ -975,10 +975,12 @@ $('msg').addEventListener('paste',e=>{
   const imageItems=items.filter(i=>i.kind==='file'&&i.type.startsWith('image/'));
   if(!imageItems.length||hasText)return;
   e.preventDefault();
-  const files=imageItems.map(i=>{
+  const pasteTs=Date.now();
+  const files=imageItems.map((i,idx)=>{
     const blob=i.getAsFile();
     const ext=i.type.split('/')[1]||'png';
-    return new File([blob],`screenshot-${Date.now()}.${ext}`,{type:i.type});
+    const suffix=imageItems.length>1?`-${idx+1}`:'';
+    return new File([blob],`screenshot-${pasteTs}${suffix}.${ext}`,{type:i.type});
   });
   addFiles(files);
   setStatus(t('image_pasted')+files.map(f=>f.name).join(', '));

--- a/tests/test_issue1697_multi_image_paste.py
+++ b/tests/test_issue1697_multi_image_paste.py
@@ -1,0 +1,142 @@
+"""Regression coverage for #1697: multi-image clipboard paste attachments."""
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).parent.parent.resolve()
+BOOT_JS_PATH = REPO_ROOT / "static" / "boot.js"
+PANELS_JS_PATH = REPO_ROOT / "static" / "panels.js"
+NODE = shutil.which("node")
+
+pytestmark = pytest.mark.skipif(NODE is None, reason="node not on PATH")
+
+
+def _read_js(path: Path) -> str:
+    with open(path, encoding="utf-8") as f:
+        return f.read()
+
+
+def _extract_msg_paste_registration() -> str:
+    boot = _read_js(BOOT_JS_PATH)
+    marker = "$('msg').addEventListener('paste',e=>{"
+    start = boot.find(marker)
+    assert start >= 0, "boot.js must register the composer paste handler"
+    end_marker = "\n});"
+    end = boot.find(end_marker, start)
+    assert end >= 0, "composer paste handler should end with a listener close"
+    return boot[start : end + len(end_marker)]
+
+
+def _run_node(source: str) -> str:
+    result = subprocess.run(
+        [NODE],
+        input=source,
+        text=True,
+        capture_output=True,
+        cwd=REPO_ROOT,
+        timeout=20,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"node driver failed:\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}")
+    return result.stdout.strip()
+
+
+def _paste_harness(items_js: str) -> dict:
+    paste_registration = json.dumps(_extract_msg_paste_registration())
+    source = f"""
+const vm = require('vm');
+const pasteRegistration = {paste_registration};
+const listeners = {{}};
+const S = {{pendingFiles: []}};
+let renderCount = 0;
+let lastStatus = '';
+let preventDefaultCount = 0;
+class File extends Blob {{
+  constructor(parts, name, options={{}}) {{
+    super(parts, options);
+    this.name = name;
+    this.lastModified = options.lastModified || 0;
+  }}
+}}
+const context = {{
+  S,
+  File,
+  Blob,
+  Date: {{now: () => 1700000000000}},
+  Array,
+  console,
+  $: (id) => {{
+    if (id !== 'msg') throw new Error('unexpected element id '+id);
+    return {{addEventListener: (type, cb) => {{listeners[type] = cb;}}}};
+  }},
+  addFiles: (files) => {{
+    for (const f of files) {{
+      if (!S.pendingFiles.find(p => p.name === f.name)) S.pendingFiles.push(f);
+    }}
+    renderCount += 1;
+  }},
+  setStatus: (text) => {{ lastStatus = text; }},
+  t: (key) => key === 'image_pasted' ? 'Image pasted: ' : key,
+}};
+vm.createContext(context);
+vm.runInContext(pasteRegistration, context);
+listeners.paste({{
+  clipboardData: {{items: {items_js}}},
+  preventDefault: () => {{ preventDefaultCount += 1; }},
+}});
+console.log(JSON.stringify({{
+  pendingNames: S.pendingFiles.map(f => f.name),
+  pendingCount: S.pendingFiles.length,
+  renderCount,
+  lastStatus,
+  preventDefaultCount,
+}}));
+"""
+    return json.loads(_run_node(source))
+
+
+def test_one_clipboard_paste_with_two_image_items_adds_two_attachment_chips():
+    """Two image clipboard items from one paste must survive addFiles() filename de-dupe."""
+    result = _paste_harness(
+        "["
+        "{kind:'file', type:'image/png', getAsFile:()=>new Blob(['one'], {type:'image/png'})},"
+        "{kind:'file', type:'image/png', getAsFile:()=>new Blob(['two'], {type:'image/png'})}"
+        "]"
+    )
+
+    assert result["preventDefaultCount"] == 1
+    assert result["renderCount"] == 1
+    assert result["pendingCount"] == 2
+    assert result["pendingNames"] == [
+        "screenshot-1700000000000-1.png",
+        "screenshot-1700000000000-2.png",
+    ]
+    assert result["lastStatus"] == (
+        "Image pasted: screenshot-1700000000000-1.png, "
+        "screenshot-1700000000000-2.png"
+    )
+
+
+def test_single_image_paste_keeps_existing_screenshot_filename_shape():
+    """The one-image path should keep screenshot-<timestamp>.<ext> for compatibility."""
+    result = _paste_harness(
+        "[{kind:'file', type:'image/png', getAsFile:()=>new Blob(['one'], {type:'image/png'})}]"
+    )
+
+    assert result["pendingNames"] == ["screenshot-1700000000000.png"]
+
+
+def test_file_picker_and_drop_paths_still_pass_real_file_names_to_addfiles():
+    """Non-clipboard multi-file paths should preserve browser-provided filenames."""
+    boot = _read_js(BOOT_JS_PATH)
+    panels = _read_js(PANELS_JS_PATH)
+
+    assert "$('fileInput').onchange=e=>{addFiles(Array.from(e.target.files));e.target.value='';};" in boot
+    assert "const files=Array.from(e.dataTransfer.files);" in panels
+    assert "if(files.length){addFiles(files);$('msg').focus();}" in panels
+    assert "screenshot-" not in panels[panels.find("document.addEventListener('drop'") : panels.find("document.addEventListener('drop'") + 900]


### PR DESCRIPTION
## Thinking Path

- Composer attachments intentionally de-dupe by filename in `addFiles()` to avoid duplicate chips.
- The paste handler generated clipboard screenshots with `Date.now()` inside one synchronous `map()`.
- A single clipboard event containing multiple image items can therefore create identical generated names, so `addFiles()` silently keeps only the first image.
- The smallest safe fix is to preserve the existing single-image filename shape while making multi-image paste names unique within that paste event.

## What Changed

- Compute one paste timestamp per image-only clipboard paste event.
- Add deterministic `-1`, `-2`, ... suffixes only when one paste event contains multiple image items.
- Preserve the existing single-image name shape: `screenshot-<timestamp>.<ext>`.
- Added Node-backed regression coverage that extracts and executes the real `static/boot.js` paste handler and asserts two pasted image items become two pending attachments.
- Added lightweight coverage confirming file picker and drag/drop paths still pass browser-provided filenames directly to `addFiles()`.

Fixes #1697

## Why It Matters

Pasting several screenshots/images at once should not silently drop attachments. This keeps the existing duplicate-filename guard for true duplicate files while preventing generated clipboard filenames from colliding inside the same paste event.

## Verification

```bash
# RED, with the production fix temporarily reverted
HERMES_WEBUI_TEST_STATE_DIR=/tmp/hermes-webui-test-1697-red-$$ \
HERMES_WEBUI_TEST_PORT=28697 \
HERMES_WEBUI_HOST=127.0.0.1 \
/home/michael/.hermes/hermes-agent/venv/bin/python -m pytest \
  tests/test_issue1697_multi_image_paste.py::test_one_clipboard_paste_with_two_image_items_adds_two_attachment_chips -q

HERMES_WEBUI_TEST_STATE_DIR=/tmp/hermes-webui-test-1697-green-$$ \
HERMES_WEBUI_TEST_PORT=28698 \
HERMES_WEBUI_HOST=127.0.0.1 \
/home/michael/.hermes/hermes-agent/venv/bin/python -m pytest \
  tests/test_issue1697_multi_image_paste.py -q

HERMES_WEBUI_TEST_STATE_DIR=/tmp/hermes-webui-test-1697-targeted-$$ \
HERMES_WEBUI_TEST_PORT=28699 \
HERMES_WEBUI_HOST=127.0.0.1 \
/home/michael/.hermes/hermes-agent/venv/bin/python -m pytest \
  tests/test_issue1697_multi_image_paste.py \
  tests/test_issue1095_pasted_images.py \
  tests/test_1620_paste_text_with_image.py \
  tests/test_native_image_attachments.py -q

env -u HERMES_CONFIG_PATH -u HERMES_WEBUI_HOST \
HERMES_WEBUI_TEST_STATE_DIR=/tmp/hermes-webui-test-1697-full-$$ \
HERMES_WEBUI_TEST_PORT=28700 \
/home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/ -q

git diff --check
```

Result:

```text
RED: failed as expected before the fix with assert 1 == 2 for pendingCount.
3 passed in 1.34s.
56 passed in 1.68s.
4480 passed, 2 skipped, 1 xfailed, 2 xpassed, 1 warning, 8 subtests passed in 403.59s (0:06:43).
git diff --check passed.
```

Browser verification:

- Started an isolated local WebUI server from this worktree on `127.0.0.1:18797` with temporary state.
- Dispatched one synthetic paste event containing two PNG clipboard items into the real composer.
- Verified the composer attachment tray contained two separate image chips with alt/title names like `screenshot-<timestamp>-1.png` and `screenshot-<timestamp>-2.png`.

UI media:

- No screenshots attached; this is a narrow interaction/data-loss fix with no visual styling change, and the browser/automated checks verify the visible two-chip attachment state.

## Risks / Follow-ups

- Low risk: the production change is limited to generated filenames for image-only clipboard paste events.
- Single-image paste filenames are intentionally unchanged for compatibility.
- File picker and drag/drop keep using browser-provided filenames; this PR only changes generated clipboard screenshot names.

## Model Used

AI assisted.

- Provider: OpenAI Codex
- Model: `gpt-5.5`
- Notable tool use: Hermes Agent CLI with terminal, file, browser, pytest, git, and GitHub CLI/API tools.