### PR TITLE
fix(workspace): hide 'Double-click to rename' tooltip on folders (closes #1710)

### DIFF
--- a/static/ui.js
+++ b/static/ui.js
@@ -5701,7 +5701,11 @@ function _renderTreeItems(container, entries, depth){
 
     // Name
     const nameEl=document.createElement('span');
-    nameEl.className='file-name';nameEl.textContent=item.name;nameEl.title=t('double_click_rename');
+    nameEl.className='file-name';nameEl.textContent=item.name;
+    // Tooltip only on FILES — dblclick renames them. On directories, dblclick
+    // navigates into the folder; rename lives in the right-click context menu
+    // (the "Double-click to rename" hint here would be misleading). #1710.
+    if(item.type!=='dir')nameEl.title=t('double_click_rename');
     // Single-click opens (file) or expand-toggles (dir) but is debounced 300ms so a
     // double-click can cancel it and trigger rename instead. Without the debounce, the
     // click bubbles to el.onclick before dblclick can fire — that's #1698. Without the

--- a/tests/test_1710_folder_tooltip.py
+++ b/tests/test_1710_folder_tooltip.py
@@ -1,0 +1,76 @@
+"""Tests for #1710 — file-tree tooltip says "Double-click to rename" on folders too,
+but folders don't rename on double-click; they navigate via loadDir(). The tooltip
+is therefore misleading on directory rows.
+
+Fix: gate the tooltip on `item.type !== 'dir'` so it appears only on files.
+Folder rename is still reachable via the right-click context menu.
+"""
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+UI_JS_PATH = REPO_ROOT / "static" / "ui.js"
+
+
+def _read_ui_js() -> str:
+    with open(UI_JS_PATH, encoding="utf-8") as f:
+        return f.read()
+
+
+def _name_block() -> str:
+    """Source slice covering the file-tree row's name span construction."""
+    src = _read_ui_js()
+    start = src.find("// Name\n    const nameEl=document.createElement('span');")
+    assert start >= 0, "name span construction marker not found in static/ui.js"
+    end = src.find("el.appendChild(nameEl);", start)
+    assert end >= 0, "el.appendChild(nameEl) not found after name span"
+    return src[start:end]
+
+
+class TestFolderTooltipGated:
+    """The 'Double-click to rename' tooltip must only attach to files, not dirs."""
+
+    def test_tooltip_assignment_is_guarded_by_item_type(self):
+        block = _name_block()
+        # We expect the tooltip line to be wrapped in an `if(item.type!=='dir')` guard.
+        # The pre-fix shape was `nameEl.title=t('double_click_rename');` unconditionally.
+        # Find every line that assigns nameEl.title and confirm at least one is gated.
+        gated = "if(item.type!=='dir')nameEl.title=t('double_click_rename')"
+        unguarded = "    nameEl.className='file-name';nameEl.textContent=item.name;nameEl.title=t('double_click_rename');"
+        assert gated in block, (
+            "tooltip assignment must be guarded by `if(item.type!=='dir')` so directories "
+            "do not show the misleading 'Double-click to rename' hint (#1701)"
+        )
+        assert unguarded not in block, (
+            "the pre-fix unguarded tooltip assignment is still present — folders will "
+            "still show the misleading hint"
+        )
+
+    def test_dir_dblclick_still_navigates_not_renames(self):
+        """Sanity: directory dblclick path is unchanged — must still call loadDir()."""
+        block = _name_block()
+        assert "if(item.type==='dir'){loadDir(item.path);return;}" in block, (
+            "directory dblclick must still navigate (call loadDir); the rename-only "
+            "tooltip gating depends on this contract being unchanged"
+        )
+
+    def test_files_still_get_tooltip(self):
+        """Sanity: the tooltip text is still defined for files via the i18n key."""
+        block = _name_block()
+        assert "t('double_click_rename')" in block, (
+            "tooltip i18n key must still be referenced — the gate hides it for dirs, "
+            "not for files"
+        )
+
+    def test_i18n_key_still_defined_in_all_locales(self):
+        """The i18n key must remain defined in every locale block in static/i18n.js."""
+        i18n = (REPO_ROOT / "static" / "i18n.js").read_text(encoding="utf-8")
+        # i18n.js has 9 locale blocks with the same key. Lock that the key still exists
+        # at least 5 times (en, plus a quorum of locales) — exact count is i18n maintenance.
+        count = i18n.count("double_click_rename:")
+        assert count >= 5, (
+            f"i18n key 'double_click_rename' should be defined in multiple locales; "
+            f"found {count} occurrences — did this PR accidentally drop translations?"
+        )


### PR DESCRIPTION
Closes #1710

## Summary

The workspace file-tree row tooltip says "Double-click to rename" on every entry — including folders. But double-clicking a folder navigates into it (`loadDir()`); rename for folders lives only in the right-click context menu. The tooltip is therefore misleading on directory rows.

Reported by @Deor in the WebUI Discord testers thread (May 5 2026), responding to the #1698 fix:

> Ah that works yeah. May want to change the popup text as it also says double click at the moment.

## Fix

`static/ui.js` `_renderTreeItems` — gate the `nameEl.title` assignment on `item.type !== 'dir'`. Files keep the existing hint that matches their dblclick behaviour. Folders get no tooltip (rename still reachable via the right-click → Rename context menu, which is unchanged). 4 lines of code change.

```diff
-    nameEl.className='file-name';nameEl.textContent=item.name;nameEl.title=t('double_click_rename');
+    nameEl.className='file-name';nameEl.textContent=item.name;
+    // Tooltip only on FILES — dblclick renames them. On directories, dblclick
+    // navigates into the folder; rename lives in the right-click context menu
+    // (the "Double-click to rename" hint here would be misleading). #1710.
+    if(item.type!=='dir')nameEl.title=t('double_click_rename');
```

## Why not remove the tooltip entirely

@AvidFuturist asked whether to drop it on files too. Keeping it on files is reasonable — dblclick-to-rename is non-obvious on a chat app's workspace pane (vs. a native file manager), and the tooltip is the primary discoverability path. Removing it on folders alone fixes the misleading affordance without losing useful discoverability for files.

## Companion to the rename-affordance triage

- **#1698** fixed: dblclick rename was unreachable on files (preview hijacked the first click)
- **#1707** fixed: single-click on filename did nothing (the #1698 fix was over-aggressive)
- **#1710** (this PR): tooltip claimed dblclick-rename on folders too

After this lands, the file-tree click affordances are consistent with what each click actually does.

## Tests

4 new source-level regression tests in `tests/test_1710_folder_tooltip.py`:

- `test_tooltip_assignment_is_guarded_by_item_type` — locks the `if(item.type!=='dir')` guard around the `nameEl.title` assignment so a future refactor can't reintroduce the unconditional tooltip.
- `test_dir_dblclick_still_navigates_not_renames` — sanity: directory dblclick still calls `loadDir(item.path)`, the navigate-not-rename contract this PR depends on.
- `test_files_still_get_tooltip` — locks that files retain the i18n-keyed tooltip.
- `test_i18n_key_still_defined_in_all_locales` — the `double_click_rename` key must remain defined in ≥5 locale blocks of `static/i18n.js`.

Result: 4 new + 9 existing #1707 tests = 13 passing for the file-tree handler block. Targeted suite (`tests/test_1710*.py tests/test_1707*.py`) passes locally; broader workspace/rename pattern (264 tests) also passes.

## Reporter

@Deor via WebUI Discord testers thread (May 5 2026 09:34 UTC).
