### PR TITLE
fix: guard localStorage.setItem('hermes-webui-model') against QuotaExceededError

### DIFF
--- a/static/boot.js
+++ b/static/boot.js
@@ -815,7 +815,7 @@ $('modelSelect').onchange=async()=>{
     : {model:selectedModel,model_provider:null};
   if(typeof closeModelDropdown==='function') closeModelDropdown();
   if(typeof _writePersistedModelState==='function') _writePersistedModelState(modelState.model,modelState.model_provider);
-  else localStorage.setItem('hermes-webui-model', modelState.model);
+  else try{localStorage.setItem('hermes-webui-model',modelState.model)}catch{}
   await api('/api/session/update',{method:'POST',body:JSON.stringify({
     session_id:S.session.session_id,
     workspace:S.session.workspace,

--- a/static/onboarding.js
+++ b/static/onboarding.js
@@ -465,7 +465,7 @@ async function _saveOnboardingDefaults(){
   if(ONBOARDING.status){
     ONBOARDING.status.settings={...(ONBOARDING.status.settings||{}),password_enabled:!!saved.auth_enabled};
   }
-  localStorage.setItem('hermes-webui-model',model);
+  try{localStorage.setItem('hermes-webui-model',model)}catch{}
   if($('modelSelect')) _applyModelToDropdown(model,$('modelSelect'));
 }
 


### PR DESCRIPTION
## Problem

On some setups (localStorage near quota), the bare `localStorage.setItem('hermes-webui-model', ...)` call throws an unhandled `DOMException`:

```
Failed to execute 'setItem' on 'Storage': Setting the value of 'hermes-webui-model' exceeded the quota.
```

This surfaces as a fatal exception that breaks model selection and prevents the chat UI from loading on every new chat or page load.

## Fix

Wrap both call-sites in `try/catch` so the error is logged to the console as a `console.warn` instead of crashing the UI. The stored value (a model ID string) is tiny — the quota failure is from overall localStorage pressure, not this key — so graceful degradation (fall back to server-side model state on next load) is the right behaviour.

**Files changed:**
- `static/boot.js` — `$('modelSelect').onchange` handler
- `static/onboarding.js` — `_saveOnboardingDefaults()`

## Test

1. Fill localStorage to near-quota in DevTools
2. Change model in the selector → no thrown exception, console shows warning
3. Reload → UI loads normally