### PR TITLE
Fix backend tool snippet cap for Show more

### DIFF
--- a/api/streaming.py
+++ b/api/streaming.py
@@ -1379,16 +1379,22 @@ def _merge_display_messages_after_agent_result(previous_display, previous_contex
     return merged
 
 
-def _tool_result_snippet(raw) -> str:
-    """Extract a compact result preview from a stored tool message payload."""
+_TOOL_RESULT_SNIPPET_MAX = 4000
+
+
+def _tool_result_snippet(raw, limit: int = _TOOL_RESULT_SNIPPET_MAX) -> str:
+    """Extract a bounded result preview from a stored tool message payload."""
+    if limit <= 0:
+        return ''
     text = str(raw or '')
     try:
-        data = json.loads(text)
+        data = raw if isinstance(raw, dict) else json.loads(text)
         if isinstance(data, dict):
-            return str(data.get('output') or data.get('result') or data.get('error') or text)[:200]
+            preview = data.get('output') or data.get('result') or data.get('error') or text
+            text = str(preview)
     except Exception:
         pass
-    return text[:200]
+    return text[:limit]
 
 
 def _truncate_tool_args(args, limit: int = 6) -> dict:

--- a/tests/test_tool_call_persistence.py
+++ b/tests/test_tool_call_persistence.py
@@ -1,11 +1,12 @@
 """Tests for backend tool-call summary extraction used by WebUI session persistence."""
+import json
 import pathlib
 import sys
 
 REPO_ROOT = pathlib.Path(__file__).parent.parent.resolve()
 sys.path.insert(0, str(REPO_ROOT))
 
-from api.streaming import _extract_tool_calls_from_messages
+from api.streaming import _extract_tool_calls_from_messages, _tool_result_snippet
 
 
 def test_extract_tool_calls_from_openai_message_linkage():
@@ -30,6 +31,64 @@ def test_extract_tool_calls_from_openai_message_linkage():
     assert result[0]["name"] == "terminal"
     assert result[0]["assistant_msg_idx"] == 1
     assert result[0]["snippet"] == "file.txt"
+
+
+def test_tool_result_snippet_allows_frontend_show_more_threshold_but_stays_bounded():
+    """Persisted snippets should be long enough for frontend Show more but capped."""
+    medium_output = "m" * 1200
+    huge_output = "h" * 5000
+
+    medium_snippet = _tool_result_snippet(json.dumps({"output": medium_output}))
+    huge_snippet = _tool_result_snippet(json.dumps({"output": huge_output}))
+
+    assert len(medium_snippet) == 1200
+    assert len(medium_snippet) > 800
+    assert len(huge_snippet) == 4000
+
+
+def test_extract_tool_calls_persists_show_more_sized_snippets_with_bounded_cap():
+    """Tool-call summaries should store >800-char snippets without growing unbounded."""
+    long_output = "x" * 1200
+    huge_output = "y" * 5000
+    messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call-long",
+                    "function": {
+                        "name": "read_file",
+                        "arguments": '{"path":"/tmp/medium.log"}',
+                    },
+                },
+                {
+                    "id": "call-huge",
+                    "function": {
+                        "name": "terminal",
+                        "arguments": '{"command":"yes"}',
+                    },
+                },
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call-long",
+            "content": json.dumps({"output": long_output}),
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call-huge",
+            "content": json.dumps({"output": huge_output}),
+        },
+    ]
+
+    result = _extract_tool_calls_from_messages(messages)
+
+    assert len(result) == 2
+    assert len(result[0]["snippet"]) == 1200
+    assert len(result[0]["snippet"]) > 800
+    assert len(result[1]["snippet"]) == 4000
 
 
 def test_extract_tool_calls_falls_back_to_live_progress_when_ids_missing():


### PR DESCRIPTION
## Thinking Path

- Hermes WebUI already has frontend logic that previews long tool snippets at ~800 chars and reveals the rest with Show more.
- Issue #1714 showed that the backend still truncated persisted tool snippets to 200 chars, so the frontend threshold could never be reached.
- The maintainer-confirmed caveat is that removing the backend cap entirely would bloat persisted session JSON.
- This PR raises the persisted snippet cap to a conservative 4000 chars instead of making it unlimited.
- The result is that medium tool outputs can use the existing Show more affordance while huge outputs remain bounded on disk.

## What Changed

- Added `_TOOL_RESULT_SNIPPET_MAX = 4000` and changed `_tool_result_snippet()` to return bounded previews up to that cap instead of hard-capping at 200 chars.
- Kept JSON/dict tool-result extraction behavior focused on `output`, `result`, and `error`, with a safe text fallback.
- Added regression coverage proving medium snippets exceed the frontend 800-char Show more threshold and huge snippets are capped at 4000 chars through direct snippet extraction and persisted tool-call summary extraction.

Fixes #1714.

## Why It Matters

Expanded tool cards become useful again for common medium-length outputs like file reads and terminal output. At the same time, the backend still protects session persistence from unbounded multi-megabyte tool results.

## Verification

```bash
/home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_tool_call_persistence.py::test_tool_result_snippet_allows_frontend_show_more_threshold_but_stays_bounded tests/test_tool_call_persistence.py::test_extract_tool_calls_persists_show_more_sized_snippets_with_bounded_cap -q
/home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_tool_call_persistence.py tests/test_sprint10.py::test_tool_card_show_more_in_ui_js -q
node --check static/ui.js
git diff --check
env -u HERMES_CONFIG_PATH -u HERMES_WEBUI_HOST /home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_onboarding_existing_config.py::TestOnboardingGateIntegration::test_no_config_wizard_fires -q -vv
env -u HERMES_CONFIG_PATH -u HERMES_WEBUI_HOST /home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/ -q
```

Result:

```text
Regression RED before implementation: 2 expected failures at the old 200-char backend cap.
Targeted regression suite: 5 passed.
Targeted backend + frontend Show more source test: 6 passed.
node --check static/ui.js: passed.
git diff --check: passed.
Single onboarding test rerun after transient full-suite timeout: 1 passed.
Full isolated suite attempt 1: 4528 passed, 2 skipped, 3 xpassed, 1 warning, 1 error, 8 subtests passed in 439.02s; the lone failure was a transient timeout in tests/test_onboarding_existing_config.py::TestOnboardingGateIntegration::test_no_config_wizard_fires and passed when rerun directly.
Full isolated suite attempt 2: environment/server-fixture failure after the test server disconnected; 4089 tests had passed before cascading urllib connection failures. This did not reproduce in the targeted tests for this backend-only change.
GitHub Actions on PR #1720: test (3.11), test (3.12), and test (3.13) all passed.
```

Manual verification:

- Started an isolated WebUI server on port 18794 with disposable state.
- Injected a synthetic 1320-character tool snippet into the browser runtime.
- Confirmed the existing frontend rendered `Show more`, and clicking it changed the control to `Show less` while revealing the longer text.

UI media:

- Not attached. This is a backend persistence cap change; the visible frontend component is unchanged and was checked with synthetic browser DOM verification.

## Risks / Follow-ups

- 4000 chars is intentionally conservative. If users need larger persisted previews, a future settings/env knob such as `HERMES_WEBUI_TOOL_SNIPPET_MAX` could be added with validation.
- The snippet is still a persisted preview, not a full archival store for every tool byte.
- The repeated full-suite instability looked like the shared test server fixture disconnecting under concurrent load; targeted coverage for this change passed.

## Model Used

AI assisted.

- Provider: openai-codex
- Model: `gpt-5.5`
- Notable tool use: Hermes CLI agent with terminal, git, pytest, GitHub CLI, browser DOM verification, and Kanban coordination.