### PR TITLE
fix: suppress stale preserved task lists

### DIFF
--- a/static/ui.js
+++ b/static/ui.js
@@ -3966,9 +3966,29 @@ function _preservedCompressionTaskListCardHtml(m, open=false){
 function _preservedCompressionTaskListCardsHtml(messages){
   return (messages||[]).map(m=>_preservedCompressionTaskListCardHtml(m, false)).join('');
 }
+function _latestTodoToolItems(messages){
+  for(let i=(messages||[]).length-1;i>=0;i--){
+    const m=messages[i];
+    if(!m||m.role!=='tool') continue;
+    try{
+      const payload=typeof m.content==='string'?JSON.parse(m.content):m.content;
+      if(payload&&Array.isArray(payload.todos)) return payload.todos;
+    }catch(_){ }
+  }
+  return null;
+}
+function _hasActiveTodoItems(items){
+  return Array.isArray(items) && items.some(item=>{
+    const status=String(item&&item.status||'').trim().toLowerCase();
+    return status==='pending'||status==='in_progress';
+  });
+}
 function _latestPreservedCompressionTaskListMessages(messages){
   const latest=[...(messages||[])].reverse().find(m=>_isPreservedCompressionTaskListMessage(m));
-  return latest?[latest]:[];
+  if(!latest) return [];
+  const latestTodos=_latestTodoToolItems(messages);
+  if(Array.isArray(latestTodos) && !_hasActiveTodoItems(latestTodos)) return [];
+  return [latest];
 }
 function _isSameLocalDay(dateA, dateB){
   return dateA.getFullYear()===dateB.getFullYear()

--- a/tests/test_auto_compression_card.py
+++ b/tests/test_auto_compression_card.py
@@ -155,6 +155,20 @@ def test_preserved_task_list_attaches_once_per_render():
     assert "(!preservedCompressionTaskCardsAttached&&(!referenceMessage||compressionState)&&preservedCompressionTaskMessages.length)" in src
 
 
+def test_preserved_task_list_is_suppressed_when_latest_todo_state_has_no_active_items():
+    src = _read("static/ui.js")
+    start = src.find("function _latestTodoToolItems")
+    assert start != -1, "latest todo state helper not found"
+    end = src.find("function _isSameLocalDay", start)
+    assert end != -1, "preserved-task-list helper block end not found"
+    helpers = src[start:end]
+
+    assert "if(payload&&Array.isArray(payload.todos)) return payload.todos;" in helpers
+    assert "function _hasActiveTodoItems" in helpers
+    assert "status==='pending'||status==='in_progress'" in helpers
+    assert "if(Array.isArray(latestTodos) && !_hasActiveTodoItems(latestTodos)) return [];" in helpers
+
+
 def test_preserved_task_list_rendering_does_not_mutate_history():
     src = _read("static/ui.js")
     start = src.find("function _isPreservedCompressionTaskListMessage")


### PR DESCRIPTION
## Summary
- Suppress preserved compression task-list cards when a newer todo tool result shows no active items
- Treat only `pending` and `in_progress` todos as active when deciding whether to keep the preserved task list visible
- Add a regression assertion covering the stale-preserved-task-list suppression path

## Problem
After a context compaction or reload, the UI can re-render the most recent preserved compression task list from history even after the actual todo state has moved on and all items are completed or cancelled. That makes stale tasks reappear as if they were still pending.

## Fix
`_latestPreservedCompressionTaskListMessages()` now checks the latest todo tool payload. If that payload exists and contains no `pending` or `in_progress` items, the historical preserved task list is suppressed.

## Verification
- `node --check static/ui.js`
- `uv run --with pytest --with pyyaml python -m pytest -q tests/test_auto_compression_card.py`
- Independent blocker-only review: no security concerns or logic blockers

## Duplicate check
Searched open issues/PRs in `nesquena/hermes-webui` for preserved compression task lists, stale todo state, and context-compaction task-list rendering; no matching open issue/PR found.
