### PR TITLE
fix(config): resolve bare provider names to custom:* slugs and filter unauthenticated providers

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -2731,6 +2731,75 @@ def get_available_models() -> dict:
             if not _has_unnamed:
                 detected_providers.discard("custom")
 
+        # Resolve bare active_provider to custom:* slug when it matches a
+        # custom_providers name, and deduplicate bare vs custom:* providers.
+        # Also filter out providers that have no actual credentials (e.g.
+        # copilot-acp appearing from list_available_providers() without real
+        # access).
+        _custom_providers_cfg = cfg.get("custom_providers", [])
+        _custom_names: dict[str, str] = {}  # bare name -> custom:* slug
+        _has_named_custom = False
+        if isinstance(_custom_providers_cfg, list):
+            for _cp in _custom_providers_cfg:
+                if not isinstance(_cp, dict):
+                    continue
+                _cp_name = (_cp.get("name") or "").strip()
+                if _cp_name:
+                    _slug = "custom:" + _cp_name.lower().replace(" ", "-")
+                    _custom_names[_cp_name.lower().replace("_", "-")] = _slug
+                    _has_named_custom = True
+
+        # 1) Resolve active_provider when it matches a bare custom provider name
+        if (
+            active_provider
+            and active_provider in _custom_names
+            and active_provider not in _PROVIDER_DISPLAY
+        ):
+            active_provider = _custom_names[active_provider]
+
+        # 2) Deduplicate: remove bare slug when custom:* group exists
+        if _has_named_custom:
+            for _bare_name, _slug in _custom_names.items():
+                if _slug in detected_providers:
+                    detected_providers.discard(_bare_name)
+
+        # 3) Filter providers without credentials (e.g. copilot-acp with no key)
+        _providers_cfg = cfg.get("providers", {})
+        _has_credentials = set()
+        if isinstance(_providers_cfg, dict):
+            for _pk, _pc in _providers_cfg.items():
+                if isinstance(_pc, dict) and (_pc.get("api_key") or "").strip():
+                    _has_credentials.add(_pk.lower().replace("_", "-"))
+        # Also check credential_pool for explicit entries
+        try:
+            from hermes_cli.auth import get_auth_status as _gas
+            for _pid in list(detected_providers):
+                try:
+                    if _gas(_pid).get("logged_in", False):
+                        _has_credentials.add(_pid)
+                except Exception:
+                    pass
+        except Exception:
+            pass
+
+        # Remove detected_providers that have no credentials and are not
+        # in _PROVIDER_DISPLAY (i.e. they're only visible because they
+        # appeared in list_available_providers() but have no actual access)
+        for _pid in list(detected_providers):
+            if _pid in _PROVIDER_DISPLAY:
+                continue
+            if _pid.startswith("custom:"):
+                continue
+            if _pid in _has_credentials:
+                continue
+            # Check if the provider has any API key in config at all
+            _normalized = _pid.lower().replace("_", "-")
+            if _normalized in _providers_cfg and _providers_cfg[_normalized].get("api_key", ""):
+                continue
+            # This provider has no credentials — remove it
+            detected_providers.discard(_pid)
+            logger.debug("Dropping provider %s from detected_providers (no credentials)", _pid)
+
         # Resolve bare "custom" active_provider to the actual custom provider
         # slug (e.g. "custom:llama-swap") so the frontend can match it to the
         # correct model group.  Without this, active_provider remains the

--- a/api/config.py
+++ b/api/config.py
@@ -2731,6 +2731,20 @@ def get_available_models() -> dict:
             if not _has_unnamed:
                 detected_providers.discard("custom")
 
+        # Resolve bare "custom" active_provider to the actual custom provider
+        # slug (e.g. "custom:llama-swap") so the frontend can match it to the
+        # correct model group.  Without this, active_provider remains the
+        # literal string "custom" while the groups use "custom:*" IDs — the
+        # frontend's provider-matching logic sees no match and falls back to
+        # the first available provider (GitHub Copilot), which is the bug
+        # behind the "shows Copilot when model.provider=custom" symptom.
+        if active_provider == "custom" and _named_custom_groups:
+            # Pick the first named custom provider group as the target.
+            # Named groups are keyed by the full slug ("custom:name"),
+            # whereas the auto-detected path only adds bare "custom".
+            _first_custom_slug = next(iter(_named_custom_groups))
+            active_provider = _first_custom_slug
+
         # Filter providers if providers.only_configured is set
         providers_cfg = cfg.get("providers", {})
         only_show_configured = providers_cfg.get("only_configured", False) if isinstance(providers_cfg, dict) else False


### PR DESCRIPTION
When `model.provider` is set to a bare custom provider name (e.g. `llama-swap`) instead of the literal string `custom`, the WebUI creates duplicate provider groups:

**Issues fixed:**

1. **Bare provider name resolution** — When `model.provider` is `llama-swap`, resolve it to `custom:llama-swap` so the frontend highlights the correct group in the model picker.

2. **Duplicate group deduplication** — When a named custom group exists (e.g. `custom:llama-swap` from `custom_providers`), remove the bare provider name (e.g. `llama-swap`) from `detected_providers`. Without this, users see both `llama-swap` AND `custom:llama-swap` as separate groups.

3. **Unauthenticated provider filtering** — Providers that appear in `list_available_providers()` but have no actual credentials (API key or authenticated session) are removed from `detected_providers`. This prevents `copilot-acp` and similar from appearing in the picker when the user has no access/token.

**Example fix:**
- Before: picker shows `llama-swap`, `custom:llama-swap`, `copilot-acp`
- After: picker shows only `custom:llama-swap` (with the correct active model highlighted)

**Changes:** `api/config.py` (+69 lines)