### PR TITLE
fix: wait for model catalog before opening picker

### DIFF
--- a/static/ui.js
+++ b/static/ui.js
@@ -563,6 +563,11 @@ async function populateModelDropdown(){
       _applyModelToDropdown(data.default_model, sel, data.active_provider||null);
     }
     if(typeof syncModelChip==='function') syncModelChip();
+    const dd=$('composerModelDropdown');
+    if(dd&&dd.classList.contains('open')&&typeof renderModelDropdown==='function'){
+      renderModelDropdown();
+      _positionModelDropdown();
+    }
     // Kick off a background live-model fetch for the active provider.
     // This runs after the static list is already shown (no blocking flicker).
     if(data.active_provider) _fetchLiveModels(data.active_provider, sel);
@@ -963,7 +968,7 @@ async function selectModelFromDropdown(value){
   if(typeof sel.onchange==='function') await sel.onchange();
 }
 
-function toggleModelDropdown(){
+async function toggleModelDropdown(){
   const dd=$('composerModelDropdown');
   const chip=$('composerModelChip');
   const sel=$('modelSelect');
@@ -974,6 +979,11 @@ function toggleModelDropdown(){
   if(typeof closeWsDropdown==='function') closeWsDropdown();
   if(typeof closeReasoningDropdown==='function') closeReasoningDropdown();
   if(typeof closeToolsetsDropdown==='function') closeToolsetsDropdown();
+  const ready=window._modelDropdownReady;
+  if(ready&&typeof ready.then==='function'){
+    try{await ready;}catch(_){}
+  }
+  if(dd.classList.contains('open')) return;
   renderModelDropdown();
   dd.classList.add('open');
   _positionModelDropdown();

--- a/tests/test_issue1743_model_picker_race.py
+++ b/tests/test_issue1743_model_picker_race.py
@@ -1,0 +1,30 @@
+"""Regression coverage for #1743 model picker async catalog race."""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+UI_JS = (ROOT / "static" / "ui.js").read_text()
+
+
+def _body_between(src: str, start: str, end: str) -> str:
+    start_idx = src.index(start)
+    end_idx = src.index(end, start_idx)
+    return src[start_idx:end_idx]
+
+
+def test_model_picker_open_waits_for_async_model_catalog_before_rendering():
+    """Opening the visible picker must not render stale static <select> options."""
+    body = _body_between(UI_JS, "async function toggleModelDropdown", "function closeModelDropdown")
+
+    assert "window._modelDropdownReady" in body
+    assert "await" in body
+    assert body.index("await") < body.index("renderModelDropdown()")
+
+
+def test_populate_model_dropdown_rerenders_if_picker_is_already_open():
+    """If the async catalog finishes while open, refresh the visible custom rows."""
+    body = _body_between(UI_JS, "async function populateModelDropdown", "// Cache so we don't re-fetch")
+
+    assert "composerModelDropdown" in body
+    assert "classList.contains('open')" in body or 'classList.contains("open")' in body
+    assert "renderModelDropdown()" in body

--- a/tests/test_ollama_model_chip_label_regression.py
+++ b/tests/test_ollama_model_chip_label_regression.py
@@ -14,6 +14,8 @@ def test_select_model_custom_option_uses_friendly_label_helper():
     start = src.find("async function selectModelFromDropdown(value)")
     assert start != -1, "selectModelFromDropdown() not found"
     end = src.find("\nfunction toggleModelDropdown()", start)
+    if end == -1:
+        end = src.find("\nasync function toggleModelDropdown()", start)
     assert end != -1, "toggleModelDropdown() boundary not found"
     body = src[start:end]
 


### PR DESCRIPTION
## Thinking Path
- The bottom model picker is backed by a hidden native `<select>` plus a visible custom dropdown.
- `/api/models` can correctly return OpenAI Codex models while the visible dropdown still renders the static HTML fallback if it opens before async model hydration finishes.
- The fix should preserve non-blocking page boot, but prevent the visible picker from rendering stale options.
- The safest narrow change is to await the already-exposed `window._modelDropdownReady` before first render, and re-render if hydration completes while the picker is already open.

## What Changed
- Makes `toggleModelDropdown()` async and waits for `window._modelDropdownReady` before calling `renderModelDropdown()`.
- Re-renders the visible custom dropdown after `populateModelDropdown()` replaces the hidden `<select>` when the picker is already open.
- Adds regression coverage for the #1743 race.
- Updates an existing source-boundary regression to accept the now-async toggle function.

## Why It Matters
- Fixes a race where fast-open users could see stale static OpenAI/Anthropic/Other options and miss the configured OpenAI Codex models.
- Keeps backend/catalog behavior unchanged; this is strictly a frontend synchronization fix.

Fixes #1743.

## Verification
- RED: `tests/test_issue1743_model_picker_race.py` failed before implementation with missing async wait/re-render assertions.
- Targeted: `/home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_issue1743_model_picker_race.py tests/test_ollama_model_chip_label_regression.py tests/test_byok_model_dropdown.py tests/test_model_picker_badges.py tests/test_issue1567_nous_picker_capacity_and_symmetry.py -q` → `48 passed in 11.33s`
- Full suite: `env -u HERMES_CONFIG_PATH -u HERMES_WEBUI_HOST /home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/ -q` → `4598 passed, 2 skipped, 3 xpassed, 1 warning, 8 subtests passed in 382.74s`
- `git diff --check` passed.
- Browser QA on an isolated local WebUI server:
  - Confirmed `toggleModelDropdown()` waits on a delayed `window._modelDropdownReady` before opening.
  - Confirmed a delayed catalog update renders OpenAI Codex rows instead of the stale static fallback.
  - Confirmed the hydrated dropdown includes `Configured`, `Gemini`, `OpenAI Codex`, and `OpenRouter` groups with Codex rows such as `GPT 5.5`, `GPT 5.4`, `GPT 5.3 Codex`, and `GPT 5.3 Codex Spark`.

## Risks / Follow-ups
- Waiting for `window._modelDropdownReady` can delay first dropdown open by the `/api/models` request duration, but avoids showing an incorrect catalog. If `/api/models` fails, the existing promise catches and the static fallback remains available.
- No backend model catalog behavior is changed.
- No screenshots included because this is an interaction/timing race with no persistent visual redesign; browser QA was DOM/behavior verified on an isolated server.

## Model Used
- OpenAI Codex / `gpt-5.5`
- Tool use: file inspection, pytest, isolated local WebUI browser QA, git/GitHub CLI.
