### PR TITLE
fix: route custom provider models dict selections

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -1349,7 +1349,17 @@ def resolve_model_provider(model_id: str) -> tuple:
             entry_model = (entry.get("model") or "").strip()
             entry_name = (entry.get("name") or "").strip()
             entry_base_url = (entry.get("base_url") or "").strip()
-            if entry_model and entry_name and model_id == entry_model:
+            entry_model_ids = set()
+            if entry_model:
+                entry_model_ids.add(entry_model)
+            entry_models = entry.get("models")
+            if isinstance(entry_models, dict):
+                entry_model_ids.update(
+                    key.strip()
+                    for key in entry_models.keys()
+                    if isinstance(key, str) and key.strip()
+                )
+            if entry_name and model_id in entry_model_ids:
                 provider_hint = "custom:" + entry_name.lower().replace(" ", "-")
                 return model_id, provider_hint, entry_base_url or None
 

--- a/tests/test_model_resolver.py
+++ b/tests/test_model_resolver.py
@@ -159,6 +159,26 @@ def test_custom_provider_model_with_slash_routes_to_named_custom_provider():
     assert base_url == 'http://lmstudio.local:1234/v1'
 
 
+def test_custom_provider_models_dict_routes_to_named_custom_provider():
+    """Models listed only under custom_providers[].models still route to that endpoint."""
+    model, provider, base_url = _resolve_with_config(
+        'sensenova-6.7-flash-lite',
+        provider='xiaomi',
+        custom_providers=[{
+            'name': 'LiteLLM Proxy',
+            'base_url': 'http://127.0.0.1:8080/v1',
+            'model': 'deepseek-v4-flash',
+            'models': {
+                'deepseek-v4-flash': {},
+                'sensenova-6.7-flash-lite': {},
+            },
+        }],
+    )
+    assert model == 'sensenova-6.7-flash-lite'
+    assert provider == 'custom:litellm-proxy'
+    assert base_url == 'http://127.0.0.1:8080/v1'
+
+
 # ── get_available_models() @provider: hint behaviour ──────────────────────
 
 


### PR DESCRIPTION
## Thinking Path
- Issue #1240 is the broad provider/model source-of-truth umbrella; PR #1311 is an older conflicting contributor PR in that area.
- Re-reading #1311 against current `origin/master` showed the cache-invalidation portions have been superseded by the current source-fingerprint cache contract in `api/config.py` and regression coverage in `tests/test_issue1699_model_cache_source_fingerprint.py` / `tests/test_issue1633_models_cache_version_stamp.py`.
- The remaining useful behavior from #1311 is narrower: models declared only under `custom_providers[].models` can appear in the picker, but bare selections of those model IDs were not resolved back to the named custom provider.
- This PR extracts that still-relevant slice into a clean branch from current `origin/master` instead of pushing to the non-Michael conflicting PR branch.

## What Changed
- Updated `resolve_model_provider()` so named `custom_providers` match both the singular `model` field and `models` dict keys.
- Added a regression test for a `custom_providers[].models`-only model routing to `custom:<name>` with the configured `base_url`.

## Why It Matters
- The dropdown path already collects `custom_providers[].models` dict keys for named custom provider groups.
- Runtime routing now matches that picker behavior, so selecting one of those secondary model IDs does not fall back to the active provider or OpenRouter heuristics.
- This gives maintainers a narrow, mergeable replacement for the non-Michael stale/conflicting #1311 slice without trying to close the entire #1240 umbrella.

## Verification
- `env -u HERMES_CONFIG_PATH -u HERMES_WEBUI_HOST /home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_model_resolver.py::test_custom_provider_models_dict_routes_to_named_custom_provider -q`
  - First run before implementation failed as expected: provider resolved to `xiaomi` instead of `custom:litellm-proxy`.
  - Final run passed.
- `env -u HERMES_CONFIG_PATH -u HERMES_WEBUI_HOST /home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_model_resolver.py tests/test_issue1699_model_cache_source_fingerprint.py tests/test_issue1633_models_cache_version_stamp.py tests/test_ttl_cache.py tests/test_pr1339_fallback_providers_list.py -q`
  - `51 passed in 48.98s`
- `env -u HERMES_CONFIG_PATH -u HERMES_WEBUI_HOST /home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/ -q`
  - `4597 passed, 2 skipped, 3 xpassed, 1 warning, 8 subtests passed in 378.87s`
- `git diff --check`

## Risks / Follow-ups
- This intentionally does not attempt to close #1240 wholesale; it only reconciles one concrete stale PR slice.
- PR #1311 still needs maintainer cleanup/closure after this lands because its cache-invalidation changes are superseded and its branch is conflicting.
- No UI screenshots: server-side routing only; no interface or interaction flow changed.

## Model Used
- OpenAI Codex `gpt-5.5` via Hermes Agent CLI.
- Tool use: GitHub CLI, git worktree, pytest, and file-edit tools.