### PR TITLE
v0.51.12 — 3-PR batch (cron subprocess return + custom provider routing + session runtime invariants)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Hermes Web UI -- Changelog
 
+## [v0.51.12] — 2026-05-06 — 3-PR full-sweep batch
+
+### Fixed
+
+- **PR #1746** by @Michaelyklam — Shorten cron profile lock for manual runs (closes #1574). Manual cron runs no longer hold the parent profile/env lock for the duration of `run_job()` execution. The cron job body now runs in a subprocess pinned to the selected profile context; the parent process retains run tracking + output persistence + profile-home metadata writes but stays responsive to unrelated cron/profile UI/API calls. **Returns from v0.51.11 deferral with the queue-drain blocker fixed.** Opus advisor on the v0.51.11 stage-305 pass caught a `multiprocessing.Queue` deadlock when child output exceeds the ~64 KB pipe buffer (parent's `process.join()` blocks before the queue is drained → child's feeder thread blocks on `os.write()` waiting for the parent → infinite hang on real cron jobs). Fix: `result_queue.get(timeout=...)` is now called BEFORE `process.join()` (drain-then-join pattern), with `queue.Empty` recovery for hung/wedged children (terminate + report exitcode), and a regression test that exercises an actual fork subprocess returning a 200,000-char payload to assert the parent does not deadlock. Opus stage-306 verified the fix correct + complete; the prior `fork`→`spawn` SHOULD-FIX is filed as **follow-up issue #1754** (separate architectural change).
+- **PR #1752** by @Michaelyklam — Route custom provider models dict selections (slice of #1240 source-of-truth umbrella). `resolve_model_provider()` now matches named `custom_providers` against both the singular `model` field AND `models` dict keys. The dropdown path already collected `custom_providers[].models` dict keys for named custom provider groups; runtime routing now matches that picker behavior, so selecting one of those secondary model IDs routes to `custom:<name>` with the configured `base_url` instead of falling through to OpenRouter heuristics. Custom-providers branch runs BEFORE the slash-based OpenRouter heuristic, so `provider/model`-shaped keys in `models` are correctly captured by the custom branch first. Reconciles the still-relevant slice from the stale conflicting #1311 without trying to close #1240 wholesale.
+- **PR #1753** by @Michaelyklam — Guard session-owned runtime invariants (refs #1694). Two changes at the same boundary: (a) new `tests/test_session_runtime_ownership_invariants.py` with 5 source-level tests covering sidebar row cancellation by session-owned `active_stream_id`, live `done`/settled-session fallback NOT idling unrelated active panes, approval/clarify pollers stopped by owner session (not by currently-viewed pane), `LIVE_STREAMS`/`INFLIGHT` session-keyed; (b) `static/messages.js` change so background terminal events (`done`, `error`, `cancelled`, fallback poll, terminal heartbeat) only clear active-pane busy/composer state when `isActiveSession || !S.session || !INFLIGHT[S.session.session_id]` — own stream done OR no other inflight runtime exists. The `_isSessionCurrentPane(activeSid)` helper additionally checks `_loadingSessionId` to guard the in-flight session-switch window. Approval/clarify pollers are stopped by owner-session guard (`stopApprovalPollingForSession(activeSid)`) instead of blindly stopping the currently viewed pane's poller. This protects the core Milestone 2 streaming invariant: a long-running turn can finish/cancel/error in the background without tearing down runtime state for the session the user is currently viewing.
+
+### Tests
+
+4622 → **4632 passing** (+10 regression tests across the 3 PRs). 0 regressions. Full suite ~142s. Stably green on first try.
+
+### Pre-release verification
+
+- Stage-306: 3 PRs merged with no conflicts (disjoint files: `api/config.py`, `static/messages.js`, `api/routes.py`).
+- All JS files syntax-clean (`node -c static/messages.js`).
+- All Python files syntax-clean.
+- pytest: 4632 passed, 0 failed (single clean run).
+- `scripts/run-browser-tests.sh`: all 11 endpoints PASS on isolated port 8789 with stage-306 binary.
+- Pre-stamp re-fetch: all 3 PR heads still match local rebases — no late contributor commits.
+- Opus advisor: SHIP all 3, 5/5 verification questions clean, 0 MUST-FIX, 1 SHOULD-FIX filed as follow-up issue #1754 (`fork`→`spawn` migration, architectural follow-up to #1746). One minor observation noted: in `_run_cron_job_in_profile_subprocess`'s outer `finally`, a successful drain followed by >5s child wedge silently overwrites the valid result with an error — included as a side-observation in #1754.
+
+Closes #1574.
+
 ## [v0.51.11] — 2026-05-06 — 3-PR full-sweep batch (#1746 deferred)
 
 ### Added

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 > Web companion to the Hermes Agent CLI. Same workflows, browser-native.
 >
-> Last updated: v0.51.11 (May 6, 2026) — 4622 tests collected — 3-PR full-sweep batch (#1747, #1748, #1750)
+> Last updated: v0.51.12 (May 6, 2026) — 4632 tests collected — 3-PR full-sweep batch (#1746, #1752, #1753)
 > Test source: `pytest tests/ --collect-only -q`
 > Per-version detail: see [CHANGELOG.md](./CHANGELOG.md)
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -1835,8 +1835,8 @@ Bridged CLI sessions:
 
 ---
 
-*Last updated: v0.51.11, May 6, 2026*
-*Total automated tests collected: 4622*
+*Last updated: v0.51.12, May 6, 2026*
+*Total automated tests collected: 4632*
 *Regression gate: tests/test_regressions.py*
 *Run: pytest tests/ -v --timeout=60*
 *Source: <repo>/*

--- a/api/config.py
+++ b/api/config.py
@@ -1349,7 +1349,17 @@ def resolve_model_provider(model_id: str) -> tuple:
             entry_model = (entry.get("model") or "").strip()
             entry_name = (entry.get("name") or "").strip()
             entry_base_url = (entry.get("base_url") or "").strip()
-            if entry_model and entry_name and model_id == entry_model:
+            entry_model_ids = set()
+            if entry_model:
+                entry_model_ids.add(entry_model)
+            entry_models = entry.get("models")
+            if isinstance(entry_models, dict):
+                entry_model_ids.update(
+                    key.strip()
+                    for key in entry_models.keys()
+                    if isinstance(key, str) and key.strip()
+                )
+            if entry_name and model_id in entry_model_ids:
                 provider_hint = "custom:" + entry_name.lower().replace(" ", "-")
                 return model_id, provider_hint, entry_base_url or None
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -313,6 +313,71 @@ def _profile_home_for_cron_job(job: dict):
     return get_hermes_home_for_profile(raw)
 
 
+def _cron_job_subprocess_main(job, execution_profile_home, result_queue):
+    """Run one cron job inside a child process pinned to a profile home."""
+    try:
+        def _run():
+            from cron.scheduler import run_job
+
+            return run_job(job)
+
+        if execution_profile_home is None:
+            result = _run()
+        else:
+            from api.profiles import cron_profile_context_for_home
+
+            with cron_profile_context_for_home(execution_profile_home):
+                result = _run()
+        result_queue.put(("ok", result))
+    except BaseException as exc:  # pragma: no cover - surfaced in parent
+        import traceback
+
+        result_queue.put(("error", f"{type(exc).__name__}: {exc}", traceback.format_exc()))
+
+
+def _run_cron_job_in_profile_subprocess(job, execution_profile_home):
+    """Execute cron.scheduler.run_job without holding the parent cron env lock.
+
+    cron.scheduler/cron.jobs still rely on process-global HERMES_HOME and module
+    constants, so running the job body in a child process gives each long cron
+    execution its own globals. The parent process only uses cron_profile_context
+    for short metadata reads/writes and remains responsive to unrelated cron UI
+    and API calls while the job runs.
+    """
+    import multiprocessing
+    import queue
+
+    ctx = multiprocessing.get_context("fork")
+    result_queue = ctx.Queue(maxsize=1)
+    process = ctx.Process(
+        target=_cron_job_subprocess_main,
+        args=(job, execution_profile_home, result_queue),
+    )
+    process.start()
+    process.join()
+
+    try:
+        status, *payload = result_queue.get_nowait()
+    except queue.Empty:
+        status = "error"
+        payload = [
+            f"cron run subprocess exited with code {process.exitcode}",
+            "",
+        ]
+    finally:
+        result_queue.close()
+        result_queue.join_thread()
+
+    if status == "ok":
+        return payload[0]
+
+    message = payload[0]
+    traceback_text = payload[1] if len(payload) > 1 else ""
+    if traceback_text:
+        logger.error("Manual cron subprocess failed:\n%s", traceback_text)
+    raise RuntimeError(message)
+
+
 def _run_cron_tracked(job, profile_home=None, execution_profile_home=None):
     """Wrapper that tracks running state around cron.scheduler.run_job.
 
@@ -321,7 +386,6 @@ def _run_cron_tracked(job, profile_home=None, execution_profile_home=None):
     agent config/.env while running. When no job profile is selected, both homes
     are the same and legacy server-default behavior is preserved.
     """
-    from cron.scheduler import run_job  # import here — runs inside a worker thread
     from cron.jobs import mark_job_run, save_job_output
 
     job_id = job.get("id", "")
@@ -336,8 +400,8 @@ def _run_cron_tracked(job, profile_home=None, execution_profile_home=None):
             return fn()
 
     try:
-        success, output, final_response, error = _with_cron_home(
-            execution_profile_home, lambda: run_job(job)
+        success, output, final_response, error = _run_cron_job_in_profile_subprocess(
+            job, execution_profile_home
         )
 
         # Persist output and run metadata back to the job's owning cron store,

--- a/api/routes.py
+++ b/api/routes.py
@@ -335,6 +335,23 @@ def _cron_job_subprocess_main(job, execution_profile_home, result_queue):
         result_queue.put(("error", f"{type(exc).__name__}: {exc}", traceback.format_exc()))
 
 
+def _cron_subprocess_result_timeout_seconds(job):
+    """Return how long the manual-run parent waits for child result payloads."""
+    for key in ("timeout_seconds", "max_runtime_seconds", "timeout"):
+        raw = (job or {}).get(key)
+        if raw in (None, ""):
+            continue
+        try:
+            value = float(raw)
+        except (TypeError, ValueError):
+            continue
+        if value > 0:
+            return max(60.0, value + 30.0)
+    # Manual cron jobs can legitimately run for a long time.  Keep a recovery
+    # path for wedged children without truncating normal long-running jobs.
+    return 6 * 60 * 60.0
+
+
 def _run_cron_job_in_profile_subprocess(job, execution_profile_home):
     """Execute cron.scheduler.run_job without holding the parent cron env lock.
 
@@ -354,16 +371,42 @@ def _run_cron_job_in_profile_subprocess(job, execution_profile_home):
         args=(job, execution_profile_home, result_queue),
     )
     process.start()
-    process.join()
 
+    result_timeout = _cron_subprocess_result_timeout_seconds(job)
+    status = "error"
+    payload = ["cron run subprocess failed before producing a result", ""]
     try:
-        status, *payload = result_queue.get_nowait()
-    except queue.Empty:
-        status = "error"
-        payload = [
-            f"cron run subprocess exited with code {process.exitcode}",
-            "",
-        ]
+        try:
+            # Drain the potentially large pickled result before joining.  If the
+            # child puts >~64 KiB on a multiprocessing.Queue, joining first can
+            # deadlock while the child's feeder thread waits for the parent to
+            # read from the pipe.
+            status, *payload = result_queue.get(timeout=result_timeout)
+        except queue.Empty:
+            status = "error"
+            if process.is_alive():
+                process.terminate()
+                process.join(timeout=5)
+                payload = [
+                    f"cron run subprocess produced no result within {result_timeout:g}s and was terminated",
+                    "",
+                ]
+            else:
+                payload = [
+                    f"cron run subprocess exited with code {process.exitcode} without producing a result",
+                    "",
+                ]
+        finally:
+            process.join(timeout=5)
+            if process.is_alive():
+                process.terminate()
+                process.join(timeout=5)
+                if status == "ok":
+                    status = "error"
+                    payload = [
+                        "cron run subprocess did not exit after returning a result",
+                        "",
+                    ]
     finally:
         result_queue.close()
         result_queue.join_thread()

--- a/static/messages.js
+++ b/static/messages.js
@@ -857,8 +857,8 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       if(typeof _markSessionCompletedInList==='function'){
         _markSessionCompletedInList(completedSession, activeSid);
       }
-      stopApprovalPolling();
-      stopClarifyPolling();
+      stopApprovalPollingForSession(activeSid);
+      stopClarifyPollingForSession(activeSid);
       if(!_approvalSessionId || _approvalSessionId===activeSid) hideApprovalCard(true);
       if(!_clarifySessionId || _clarifySessionId===activeSid) hideClarifyCard(true, 'terminal');
       if(isActiveSession){
@@ -944,8 +944,13 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         // TTS auto-read: speak the last assistant response if enabled (#499)
         if(typeof autoReadLastAssistant==='function') setTimeout(()=>autoReadLastAssistant(), 300);
       }
-      _queueDrainSid=activeSid;renderSessionList();setBusy(false);setStatus('');
-      setComposerStatus('');
+      renderSessionList();
+      if(isActiveSession||!S.session||!INFLIGHT[S.session.session_id]){
+        _queueDrainSid=activeSid;
+        setBusy(false);
+        setStatus('');
+        setComposerStatus('');
+      }
       playNotificationSound();
       sendBrowserNotification('Response complete',assistantText?assistantText.slice(0,100):'Task finished');
     });
@@ -1026,7 +1031,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       // Application-level error sent explicitly by the server (rate limit, crash, etc.)
       // This is distinct from the SSE network 'error' event below.
       source.close();
-      delete INFLIGHT[activeSid];clearInflight();clearInflightState(activeSid);stopApprovalPolling();stopClarifyPolling();
+      delete INFLIGHT[activeSid];clearInflight();clearInflightState(activeSid);stopApprovalPollingForSession(activeSid);stopClarifyPollingForSession(activeSid);
       if(!_approvalSessionId||_approvalSessionId===activeSid) hideApprovalCard(true);
       if(!_clarifySessionId||_clarifySessionId===activeSid) hideClarifyCard(true, 'terminal');
       if(S.session&&S.session.session_id===activeSid){
@@ -1104,7 +1109,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       _smdEndParser();
       if(typeof finalizeThinkingCard==='function') finalizeThinkingCard();
       source.close();
-      delete INFLIGHT[activeSid];clearInflight();clearInflightState(activeSid);stopApprovalPolling();stopClarifyPolling();
+      delete INFLIGHT[activeSid];clearInflight();clearInflightState(activeSid);stopApprovalPollingForSession(activeSid);stopClarifyPollingForSession(activeSid);
       if(!_approvalSessionId||_approvalSessionId===activeSid) hideApprovalCard(true);
       if(!_clarifySessionId||_clarifySessionId===activeSid) hideClarifyCard(true, 'cancelled');
       if(S.session&&S.session.session_id===activeSid){
@@ -1143,7 +1148,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       const session=data&&data.session;
       if(!session) return false;
       if(session.active_stream_id||session.pending_user_message) return false;
-      delete INFLIGHT[activeSid];clearInflight();clearInflightState(activeSid);stopApprovalPolling();stopClarifyPolling();
+      delete INFLIGHT[activeSid];clearInflight();clearInflightState(activeSid);stopApprovalPollingForSession(activeSid);stopClarifyPollingForSession(activeSid);
       _closeSource();
       if(!_approvalSessionId||_approvalSessionId===activeSid) hideApprovalCard(true);
       if(!_clarifySessionId||_clarifySessionId===activeSid) hideClarifyCard(true, 'terminal');
@@ -1152,7 +1157,8 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       if(!isSessionViewed && typeof _markSessionCompletionUnread==='function'){
         _markSessionCompletionUnread(completedSid, session.message_count);
       }
-      if(S.session&&S.session.session_id===activeSid){
+      const isActiveSession=_isSessionCurrentPane(activeSid);
+      if(isActiveSession){
         S.activeStreamId=null;
         clearLiveToolCards();if(!assistantText)removeThinking();
         S.session=session;S.messages=(session.messages||[]).filter(m=>m&&m.role);
@@ -1179,7 +1185,12 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         if(isSessionViewed) _markSessionViewed(completedSid, session.message_count ?? S.messages.length);
         syncTopbar();renderMessages({preserveScroll:true});
       }
-      _queueDrainSid=activeSid;renderSessionList();setBusy(false);setComposerStatus('');
+      renderSessionList();
+      if(isActiveSession||!S.session||!INFLIGHT[S.session.session_id]){
+        _queueDrainSid=activeSid;
+        setBusy(false);
+        setComposerStatus('');
+      }
       return true;
     }catch(_){
       return false;
@@ -1193,7 +1204,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     _streamFinalized=true;
     if(_pendingRafHandle!==null){cancelAnimationFrame(_pendingRafHandle);clearTimeout(_pendingRafHandle);_pendingRafHandle=null;_renderPending=false;}
     if(typeof finalizeThinkingCard==='function') finalizeThinkingCard();
-    delete INFLIGHT[activeSid];clearInflight();clearInflightState(activeSid);stopApprovalPolling();stopClarifyPolling();
+    delete INFLIGHT[activeSid];clearInflight();clearInflightState(activeSid);stopApprovalPollingForSession(activeSid);stopClarifyPollingForSession(activeSid);
     _closeSource();
     if(!_approvalSessionId||_approvalSessionId===activeSid) hideApprovalCard(true);
     if(!_clarifySessionId||_clarifySessionId===activeSid) hideClarifyCard(true, 'terminal');
@@ -1221,8 +1232,8 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
           delete INFLIGHT[activeSid];
           clearInflight();
           clearInflightState(activeSid);
-          stopApprovalPolling();
-          stopClarifyPolling();
+          stopApprovalPollingForSession(activeSid);
+          stopClarifyPollingForSession(activeSid);
           if(!_approvalSessionId||_approvalSessionId===activeSid) hideApprovalCard(true);
           if(!_clarifySessionId||_clarifySessionId===activeSid) hideClarifyCard(true, 'terminal');
           if(S.session&&S.session.session_id===activeSid){
@@ -1413,6 +1424,7 @@ async function respondApproval(choice) {
 
 function startApprovalPolling(sid) {
   stopApprovalPolling();
+  _approvalPollingSessionId = sid || null;
   // ── SSE (preferred): long-lived connection, server pushes instantly ──
   try {
     const es = new EventSource(new URL('api/approval/stream?session_id=' + encodeURIComponent(sid), document.baseURI || location.href).href);
@@ -1455,6 +1467,7 @@ function startApprovalPolling(sid) {
 
 let _approvalEventSource = null;
 let _approvalSSEHealthTimer = null;
+let _approvalPollingSessionId = null;
 
 function _startApprovalFallbackPoll(sid) {
   _approvalPollTimer = setInterval(async () => {
@@ -1469,10 +1482,16 @@ function _startApprovalFallbackPoll(sid) {
   }, 1500);  // matches the v0.50.247 polling cadence so degraded-mode users see the same responsiveness
 }
 
+function stopApprovalPollingForSession(sid) {
+  if(sid && _approvalPollingSessionId && _approvalPollingSessionId!==sid) return;
+  stopApprovalPolling();
+}
+
 function stopApprovalPolling() {
   if (_approvalPollTimer) { clearInterval(_approvalPollTimer); _approvalPollTimer = null; }
   if (_approvalEventSource) { try { _approvalEventSource.close(); } catch(_){} _approvalEventSource = null; }
   if (_approvalSSEHealthTimer) { clearInterval(_approvalSSEHealthTimer); _approvalSSEHealthTimer = null; }
+  _approvalPollingSessionId = null;
 }
 
 // ── Clarify polling ──
@@ -1770,9 +1789,11 @@ async function respondClarify(response) {
 var _clarifyEventSource = null;
 var _clarifyFallbackTimer = null;
 var _clarifyHealthTimer = null;
+let _clarifyPollingSessionId = null;
 
 function startClarifyPolling(sid) {
   stopClarifyPolling();
+  _clarifyPollingSessionId = sid || null;
   _clarifyMissingEndpointWarned = false;
 
   // SSE primary path: long-lived connection pushes events instantly.
@@ -1852,10 +1873,16 @@ function _startClarifyFallbackPoll(sid) {
   }, 3000);
 }
 
+function stopClarifyPollingForSession(sid) {
+  if(sid && _clarifyPollingSessionId && _clarifyPollingSessionId!==sid) return;
+  stopClarifyPolling();
+}
+
 function stopClarifyPolling() {
   if (_clarifyEventSource) { try { _clarifyEventSource.close(); } catch(_){} _clarifyEventSource = null; }
   if (_clarifyFallbackTimer) { clearInterval(_clarifyFallbackTimer); _clarifyFallbackTimer = null; }
   if (_clarifyHealthTimer) { clearInterval(_clarifyHealthTimer); _clarifyHealthTimer = null; }
+  _clarifyPollingSessionId = null;
 }
 
 // ── Notifications and Sound ──────────────────────────────────────────────────

--- a/tests/test_cron_run_job_import.py
+++ b/tests/test_cron_run_job_import.py
@@ -28,9 +28,9 @@ class TestRunCronTrackedImport:
     """_run_cron_tracked must be self-contained — it runs in a worker thread."""
 
     def test_run_job_imported_inside_function(self):
-        """run_job must be imported inside _run_cron_tracked, not relied on
+        """run_job must be imported inside the subprocess target, not relied on
         from a caller's local scope."""
-        src = _get_function_source("_run_cron_tracked")
+        src = _get_function_source("_cron_job_subprocess_main")
         tree = ast.parse(src)
         names_used = set()
 
@@ -86,7 +86,12 @@ class TestRunCronTrackedImport:
             "_run_cron_tracked to avoid the NameError in worker threads."
         )
 
-    def test_run_cron_tracked_calls_run_job(self):
-        """Sanity: the function still actually calls run_job."""
+    def test_run_cron_tracked_calls_run_job_helper(self):
+        """Sanity: the function still delegates to the cron job runner."""
         src = _get_function_source("_run_cron_tracked")
-        assert "run_job" in src, "_run_cron_tracked should call run_job"
+        assert "_run_cron_job_in_profile_subprocess" in src
+
+    def test_cron_subprocess_target_calls_run_job(self):
+        """Sanity: the subprocess target still actually calls run_job."""
+        src = _get_function_source("_cron_job_subprocess_main")
+        assert "run_job" in src, "cron subprocess target should call run_job"

--- a/tests/test_issue1574_cron_profile_lock.py
+++ b/tests/test_issue1574_cron_profile_lock.py
@@ -1,0 +1,113 @@
+import sys
+import threading
+import types
+from pathlib import Path
+
+
+def _install_fake_cron(monkeypatch, run_job, events):
+    cron_pkg = types.ModuleType("cron")
+    cron_pkg.__path__ = []
+
+    cron_jobs = types.ModuleType("cron.jobs")
+    cron_jobs.HERMES_DIR = Path("/tmp/hermes")
+    cron_jobs.CRON_DIR = cron_jobs.HERMES_DIR / "cron"
+    cron_jobs.JOBS_FILE = cron_jobs.CRON_DIR / "jobs.json"
+    cron_jobs.OUTPUT_DIR = cron_jobs.CRON_DIR / "output"
+    cron_jobs.save_job_output = lambda job_id, output: events.append(("save", job_id, output))
+    cron_jobs.mark_job_run = lambda job_id, success, error=None: events.append(("mark", job_id, success, error))
+
+    cron_scheduler = types.ModuleType("cron.scheduler")
+    cron_scheduler._hermes_home = Path("/tmp/hermes")
+    cron_scheduler._LOCK_DIR = cron_scheduler._hermes_home / "cron"
+    cron_scheduler._LOCK_FILE = cron_scheduler._LOCK_DIR / ".tick.lock"
+    cron_scheduler.run_job = run_job
+
+    monkeypatch.setitem(sys.modules, "cron", cron_pkg)
+    monkeypatch.setitem(sys.modules, "cron.jobs", cron_jobs)
+    monkeypatch.setitem(sys.modules, "cron.scheduler", cron_scheduler)
+    return cron_jobs, cron_scheduler
+
+
+def test_manual_cron_run_does_not_hold_profile_lock_for_job_duration(tmp_path, monkeypatch):
+    """A long manual run must not freeze unrelated cron/profile operations.
+
+    The parent WebUI process still needs the cron profile lock for short metadata
+    writes, but the potentially minutes-long run_job body should execute outside
+    that process-wide critical section.
+    """
+    import api.routes as routes
+    from api.profiles import cron_profile_context_for_home
+
+    events = []
+    run_started = threading.Event()
+    release_run = threading.Event()
+
+    def fake_run_job_subprocess(job, execution_profile_home):
+        events.append(("run", job["id"], str(execution_profile_home)))
+        run_started.set()
+        assert release_run.wait(2), "test timed out waiting to release fake cron run"
+        return True, "output", "final", None
+
+    _install_fake_cron(monkeypatch, lambda job: (True, "unused", "unused", None), events)
+    monkeypatch.setattr(routes, "_run_cron_job_in_profile_subprocess", fake_run_job_subprocess)
+
+    job_home = tmp_path / "owner"
+    exec_home = tmp_path / "exec"
+    other_home = tmp_path / "other"
+
+    routes._mark_cron_running("job1574")
+    worker = threading.Thread(
+        target=routes._run_cron_tracked,
+        args=({"id": "job1574"}, job_home, exec_home),
+    )
+    worker.start()
+    assert run_started.wait(2), "fake run_job did not start"
+
+    contender_entered = threading.Event()
+
+    def contender():
+        with cron_profile_context_for_home(other_home):
+            events.append(("contender", str(other_home)))
+            contender_entered.set()
+
+    contender_thread = threading.Thread(target=contender)
+    contender_thread.start()
+
+    assert contender_entered.wait(0.5), (
+        "cron_profile_context_for_home stayed blocked while run_job was active; "
+        "the global cron profile lock is still held for the full job duration"
+    )
+
+    release_run.set()
+    worker.join(2)
+    contender_thread.join(2)
+
+    assert not worker.is_alive()
+    assert not contender_thread.is_alive()
+    assert ("run", "job1574", str(exec_home)) in events
+    assert ("save", "job1574", "output") in events
+    assert ("mark", "job1574", True, None) in events
+    assert routes._is_cron_running("job1574") == (False, 0.0)
+
+
+def test_cron_job_subprocess_executes_under_selected_profile_home(tmp_path, monkeypatch):
+    import api.routes as routes
+
+    def fake_run_job(job):
+        import cron.scheduler as scheduler
+
+        return True, str(scheduler._hermes_home), "final", None
+
+    events = []
+    _, cron_scheduler = _install_fake_cron(monkeypatch, fake_run_job, events)
+    exec_home = tmp_path / "exec-profile"
+
+    success, output, final_response, error = routes._run_cron_job_in_profile_subprocess(
+        {"id": "job1574"}, exec_home
+    )
+
+    assert success is True
+    assert output == str(exec_home)
+    assert final_response == "final"
+    assert error is None
+    assert cron_scheduler._hermes_home == Path("/tmp/hermes")

--- a/tests/test_issue1574_cron_profile_lock.py
+++ b/tests/test_issue1574_cron_profile_lock.py
@@ -1,3 +1,4 @@
+import multiprocessing
 import sys
 import threading
 import types
@@ -26,6 +27,85 @@ def _install_fake_cron(monkeypatch, run_job, events):
     monkeypatch.setitem(sys.modules, "cron.jobs", cron_jobs)
     monkeypatch.setitem(sys.modules, "cron.scheduler", cron_scheduler)
     return cron_jobs, cron_scheduler
+
+
+def _write_fake_large_payload_cron_package(root: Path):
+    cron_dir = root / "cron"
+    cron_dir.mkdir(parents=True)
+    (cron_dir / "__init__.py").write_text("", encoding="utf-8")
+    (cron_dir / "jobs.py").write_text(
+        "from pathlib import Path\n"
+        "HERMES_DIR = Path('/tmp/hermes')\n"
+        "CRON_DIR = HERMES_DIR / 'cron'\n"
+        "JOBS_FILE = CRON_DIR / 'jobs.json'\n"
+        "OUTPUT_DIR = CRON_DIR / 'output'\n",
+        encoding="utf-8",
+    )
+    (cron_dir / "scheduler.py").write_text(
+        "from pathlib import Path\n"
+        "_hermes_home = Path('/tmp/hermes')\n"
+        "_LOCK_DIR = _hermes_home / 'cron'\n"
+        "_LOCK_FILE = _LOCK_DIR / '.tick.lock'\n"
+        "def run_job(job):\n"
+        "    payload = 'x' * 200_000\n"
+        "    return True, payload, payload, None\n",
+        encoding="utf-8",
+    )
+
+
+def _large_cron_payload_runner(fake_pkg_root, profile_home, result_queue):
+    try:
+        import api.routes as routes
+
+        # api.routes/config may prepend the real hermes-agent path while importing.
+        # Re-prepend the fake cron package afterward and clear any already-loaded
+        # cron modules so the helper's child process imports the large-payload fake.
+        sys.path.insert(0, str(fake_pkg_root))
+        for module_name in ("cron.scheduler", "cron.jobs", "cron"):
+            sys.modules.pop(module_name, None)
+
+        success, output, final_response, error = routes._run_cron_job_in_profile_subprocess(
+            {"id": "large-payload"}, Path(profile_home)
+        )
+        result_queue.put(("ok", success, len(output), len(final_response), error))
+    except BaseException as exc:  # pragma: no cover - surfaced in parent process
+        import traceback
+
+        result_queue.put(("error", repr(exc), traceback.format_exc()))
+
+
+def test_manual_cron_subprocess_drains_large_result_before_join(tmp_path):
+    """A >100 KB result must not deadlock the parent before it can persist output."""
+    fake_pkg_root = tmp_path / "fake-cron-pkg"
+    _write_fake_large_payload_cron_package(fake_pkg_root)
+
+    # Use fork only for the outer test harness so this pytest module does not
+    # need to be importable as a package. The product helper under test owns its
+    # own multiprocessing context.
+    ctx = multiprocessing.get_context("fork")
+    result_queue = ctx.Queue()
+    runner = ctx.Process(
+        target=_large_cron_payload_runner,
+        args=(fake_pkg_root, tmp_path / "exec-profile", result_queue),
+    )
+    runner.start()
+    runner.join(10)
+    if runner.is_alive():
+        runner.terminate()
+        runner.join(5)
+        result_queue.close()
+        result_queue.join_thread()
+        raise AssertionError(
+            "manual cron subprocess deadlocked on a >100 KB Queue payload; "
+            "the parent must drain result_queue before process.join()"
+        )
+
+    try:
+        result = result_queue.get(timeout=2)
+    finally:
+        result_queue.close()
+        result_queue.join_thread()
+    assert result == ("ok", True, 200_000, 200_000, None)
 
 
 def test_manual_cron_run_does_not_hold_profile_lock_for_job_duration(tmp_path, monkeypatch):

--- a/tests/test_issue617_cron_profile_selector.py
+++ b/tests/test_issue617_cron_profile_selector.py
@@ -184,7 +184,12 @@ def test_manual_cron_run_uses_execution_profile_but_persists_to_owning_store(mon
     cron_scheduler = types.ModuleType("cron.scheduler")
     cron_scheduler.run_job = lambda job: events.append(("run", job["id"])) or (True, "output", "final", None)
 
+    def fake_subprocess_run(job, execution_profile_home):
+        events.append(("run", job["id"], str(execution_profile_home)))
+        return True, "output", "final", None
+
     monkeypatch.setattr(profiles, "cron_profile_context_for_home", Ctx)
+    monkeypatch.setattr(routes, "_run_cron_job_in_profile_subprocess", fake_subprocess_run)
     monkeypatch.setitem(sys.modules, "cron", cron_pkg)
     monkeypatch.setitem(sys.modules, "cron.jobs", cron_jobs)
     monkeypatch.setitem(sys.modules, "cron.scheduler", cron_scheduler)
@@ -197,9 +202,7 @@ def test_manual_cron_run_uses_execution_profile_but_persists_to_owning_store(mon
     )
 
     assert events == [
-        ("enter", "/hermes/profiles/research"),
-        ("run", "job617"),
-        ("exit", "/hermes/profiles/research"),
+        ("run", "job617", "/hermes/profiles/research"),
         ("enter", "/hermes/default"),
         ("save", "job617", "output"),
         ("mark", "job617", True, None),

--- a/tests/test_model_resolver.py
+++ b/tests/test_model_resolver.py
@@ -159,6 +159,26 @@ def test_custom_provider_model_with_slash_routes_to_named_custom_provider():
     assert base_url == 'http://lmstudio.local:1234/v1'
 
 
+def test_custom_provider_models_dict_routes_to_named_custom_provider():
+    """Models listed only under custom_providers[].models still route to that endpoint."""
+    model, provider, base_url = _resolve_with_config(
+        'sensenova-6.7-flash-lite',
+        provider='xiaomi',
+        custom_providers=[{
+            'name': 'LiteLLM Proxy',
+            'base_url': 'http://127.0.0.1:8080/v1',
+            'model': 'deepseek-v4-flash',
+            'models': {
+                'deepseek-v4-flash': {},
+                'sensenova-6.7-flash-lite': {},
+            },
+        }],
+    )
+    assert model == 'sensenova-6.7-flash-lite'
+    assert provider == 'custom:litellm-proxy'
+    assert base_url == 'http://127.0.0.1:8080/v1'
+
+
 # ── get_available_models() @provider: hint behaviour ──────────────────────
 
 

--- a/tests/test_scheduled_jobs_profile_isolation.py
+++ b/tests/test_scheduled_jobs_profile_isolation.py
@@ -288,30 +288,24 @@ def test_scheduler_run_job_wrapper_does_not_reenter_manual_cron_context(tmp_path
 
 
 def test_cron_worker_does_not_silently_fall_back_on_profile_context_failure():
-    """_run_cron_tracked must NOT silently set ctx=None when
-    cron_profile_context_for_home(...).__enter__() raises.
+    """The subprocess target must not fall back to an unpinned cron run.
 
-    A silent fallback in the worker thread would leave the job running
-    unpinned against process-global HERMES_HOME, silently corrupting
-    cross-profile state — the same class of bug as #1573. We'd rather
-    let the exception propagate and kill the worker thread than risk
-    that.
-
-    Source-level assertion to catch any future re-introduction of the
-    over-broad except clause around the context setup.
+    A silent fallback would leave the job running against process-global
+    HERMES_HOME, silently corrupting cross-profile state — the same class of bug
+    as #1573. The child process may report the exception to the parent, but it
+    must not continue into run_job outside the requested profile context.
     """
     from pathlib import Path
     src = (Path(__file__).resolve().parent.parent / "api" / "routes.py").read_text(encoding="utf-8")
 
-    idx = src.find("def _run_cron_tracked(job")
-    assert idx != -1, "_run_cron_tracked not found"
+    idx = src.find("def _cron_job_subprocess_main(job")
+    assert idx != -1, "_cron_job_subprocess_main not found"
     body = src[idx : idx + 2000]
 
-    # The profile-context setup must NOT be wrapped in try/except that
-    # silently falls back to ctx=None.
-    assert "except Exception" not in body[:body.find("run_job(job)")], (
-        "_run_cron_tracked silently falls back to ctx=None when "
-        "cron_profile_context_for_home(...).__enter__() raises. That leaves "
-        "the worker thread unpinned against process-global HERMES_HOME. "
-        "Let the exception propagate rather than corrupt cross-profile state."
+    assert "with cron_profile_context_for_home(execution_profile_home):" in body
+    assert "result = _run()" in body
+    assert "ctx = None" not in body
+    assert "except Exception" not in body[:body.find("with cron_profile_context_for_home")], (
+        "cron subprocess target appears to catch profile-context setup before "
+        "entering the context; do not fall back to an unpinned run_job call."
     )

--- a/tests/test_session_runtime_ownership_invariants.py
+++ b/tests/test_session_runtime_ownership_invariants.py
@@ -1,0 +1,119 @@
+"""Regression coverage for #1694 session-owned runtime invariants.
+
+These source-level tests protect the existing vanilla-JS runtime boundary:
+stream transports are keyed by stream_id/session_id, while the active pane is only
+one projection. Background terminal events must update session/sidebar metadata
+without tearing down the currently viewed pane's runtime state.
+"""
+
+import pathlib
+import re
+
+REPO = pathlib.Path(__file__).parent.parent
+
+
+def read(rel: str) -> str:
+    return (REPO / rel).read_text(encoding="utf-8")
+
+
+def _function_body(src: str, name: str) -> str:
+    idx = src.find(f"function {name}")
+    if idx == -1:
+        idx = src.find(f"async function {name}")
+    assert idx != -1, f"{name} not found"
+    brace = src.find("{", idx)
+    depth = 0
+    for pos in range(brace, len(src)):
+        ch = src[pos]
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return src[idx : pos + 1]
+    raise AssertionError(f"{name} body did not terminate")
+
+
+def _event_handler(src: str, event_name: str) -> str:
+    marker = f"source.addEventListener('{event_name}'"
+    idx = src.find(marker)
+    assert idx != -1, f"{event_name} handler not found"
+    next_handler = src.find("source.addEventListener(", idx + len(marker))
+    return src[idx:next_handler if next_handler != -1 else len(src)]
+
+
+class TestSessionOwnedRuntimeInvariants:
+    def test_sidebar_cancel_uses_row_stream_id_not_active_pane_stream(self):
+        boot = read("static/boot.js")
+        body = _function_body(boot, "cancelSessionStream")
+        assert "session&&session.active_stream_id" in body, (
+            "Sidebar row cancellation must target the row-owned active_stream_id, "
+            "not the currently viewed pane's S.activeStreamId."
+        )
+        assert "S.activeStreamId" not in body[: body.index("if(S.session&&S.session.session_id===sid)")], (
+            "cancelSessionStream must not read or clear active-pane stream state until "
+            "it has proved the row session is the active pane."
+        )
+
+    def test_done_event_does_not_clear_unrelated_active_pane_busy_state(self):
+        messages = read("static/messages.js")
+        done = _event_handler(messages, "done")
+        unconditional = "_queueDrainSid=activeSid;renderSessionList();setBusy(false);setStatus('');"
+        assert unconditional not in done, (
+            "A background session's done event must not unconditionally call setBusy(false); "
+            "that can idle an unrelated active pane that is still running."
+        )
+        assert "if(isActiveSession||!S.session||!INFLIGHT[S.session.session_id])" in done.replace(" ", ""), (
+            "The done handler should only idle composer state when the completed stream "
+            "belongs to the active pane, or when no other active-pane inflight runtime exists."
+        )
+
+    def test_server_session_finalize_does_not_idle_unrelated_active_pane(self):
+        messages = read("static/messages.js")
+        finalize = _function_body(messages, "_restoreSettledSession")
+        assert "_queueDrainSid=activeSid;renderSessionList();setBusy(false);setComposerStatus('');" not in finalize, (
+            "The fallback server-finalize path must not idle the active pane for a "
+            "background session completion."
+        )
+        assert "if(isActiveSession||!S.session||!INFLIGHT[S.session.session_id])" in finalize.replace(" ", ""), (
+            "The fallback server-finalize path should use the same active-pane guard as the live done event."
+        )
+
+    def test_approval_and_clarify_pollers_are_stopped_by_owner_session(self):
+        messages = read("static/messages.js")
+        assert "let _approvalPollingSessionId = null" in messages
+        assert "let _clarifyPollingSessionId = null" in messages
+        assert "function stopApprovalPollingForSession" in messages
+        assert "function stopClarifyPollingForSession" in messages
+
+        approval_stop = _function_body(messages, "stopApprovalPollingForSession")
+        clarify_stop = _function_body(messages, "stopClarifyPollingForSession")
+        assert "_approvalPollingSessionId!==sid" in approval_stop.replace(" ", ""), (
+            "A terminal event for session A must not stop approval polling that now belongs to session B."
+        )
+        assert "_clarifyPollingSessionId!==sid" in clarify_stop.replace(" ", ""), (
+            "A terminal event for session A must not stop clarify polling that now belongs to session B."
+        )
+
+        done = _event_handler(messages, "done")
+        assert "stopApprovalPollingForSession(activeSid)" in done
+        assert "stopClarifyPollingForSession(activeSid)" in done
+        assert "stopApprovalPolling();\n      stopClarifyPolling();" not in done, (
+            "The done handler must not blindly stop whatever approval/clarify poller "
+            "the active pane currently owns."
+        )
+
+    def test_live_stream_transport_and_inflight_state_remain_session_keyed(self):
+        messages = read("static/messages.js")
+        close_live = _function_body(messages, "closeLiveStream")
+        attach_start = messages.index("function attachLiveStream")
+        attach_live = messages[attach_start:messages.index("function _isActiveSession", attach_start)]
+        assert "constlive=LIVE_STREAMS[sessionId]" in close_live.replace(" ", ""), (
+            "LIVE_STREAMS must remain keyed by the owning session_id."
+        )
+        assert "constexistingLive=LIVE_STREAMS[activeSid]" in attach_live.replace(" ", ""), (
+            "attachLiveStream should reuse the session-owned live transport for the same stream."
+        )
+        assert re.search(r"INFLIGHT\[activeSid\].*messages", attach_live, re.DOTALL), (
+            "The browser-side inflight projection must remain keyed by the owning session_id."
+        )


### PR DESCRIPTION
# v0.51.12 — 3-PR batch (cron subprocess return + custom provider routing + session runtime invariants)

## Constituent PRs

- **#1746** by @Michaelyklam — Shorten cron profile lock for manual runs. **Closes #1574.** **RETURNS from v0.51.11 deferral** with the queue-drain blocker fixed (drain-then-join pattern + 200K-char regression test). Cron job body runs in a subprocess pinned to the selected profile context; parent stays responsive to unrelated cron/profile UI/API.
- **#1752** by @Michaelyklam — Route `custom_providers[].models` dict selections to `custom:<name>`. Slice of #1240 umbrella that reconciles the still-relevant portion of stale conflicting #1311.
- **#1753** by @Michaelyklam — Guard session-owned runtime invariants (refs #1694). Background terminal events no longer tear down active-pane runtime when an unrelated session finishes; approval/clarify pollers stop by owner-session, not by currently-viewed pane.

## Tests

**4622 → 4632 passing** (+10 regression tests). 0 regressions.

## Pre-release verification

- All 3 PRs CI-green + rebased onto master with NO conflicts (disjoint files).
- All JS files syntax-clean.
- Browser API sanity (11/11) — all pass.
- Opus advisor: **SHIP all 3**, 0 MUST-FIX, 1 SHOULD-FIX filed as **#1754** (`fork`→`spawn` migration, architectural follow-up).

## Closes

- #1574 (cron profile lock duration)
