### PR TITLE
feat(composer): click pasted/attached image thumbnails to lightbox-zoom them

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -894,7 +894,8 @@
   .attach-chip--audio,.attach-chip--video{max-width:260px;}
   .attach-media-icon{display:inline-flex;align-items:center;color:var(--accent-text);}
   .attach-chip-name{min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
-  .attach-thumb{width:56px;height:56px;object-fit:cover;border-radius:4px;display:block;cursor:default;}
+  .attach-thumb{width:56px;height:56px;object-fit:cover;border-radius:4px;display:block;cursor:zoom-in;transition:filter .12s ease, transform .12s ease;}
+  .attach-thumb:hover{filter:brightness(1.05);transform:scale(1.04);}
   textarea#msg{width:100%;background:transparent;border:none;outline:none;color:var(--text);font-size:16px;line-height:1.65;padding:12px 16px 6px;resize:none;min-height:44px;max-height:200px;font-family:inherit;}
   textarea#msg::placeholder{color:var(--muted);}
   .composer-footer{display:flex;align-items:center;justify-content:space-between;gap:10px;padding:6px 10px 10px;position:relative;container-type:inline-size;container-name:composer-footer;}

--- a/static/ui.js
+++ b/static/ui.js
@@ -296,9 +296,19 @@ function _closeImgLightbox(lb) {
 }
 
 document.addEventListener('click', e => {
-  const img = e.target && e.target.closest ? e.target.closest('.msg-media-img') : null;
-  if(!img) return;
-  _openImgLightbox(img.src, img.alt);
+  if(!e.target || !e.target.closest) return;
+  // Message-attached images (already wired since v0.50.x).
+  let img = e.target.closest('.msg-media-img');
+  if(img){ _openImgLightbox(img.src, img.alt); return; }
+  // Composer attach-tray image thumbnails — click any pasted/dropped image
+  // chip to lightbox-zoom it before sending. Excludes audio/video chips,
+  // which keep their inline media controls. SVG thumbnails (.attach-thumb--svg)
+  // are still images visually, so they qualify.
+  img = e.target.closest('.attach-thumb');
+  if(img && img.tagName === 'IMG'){
+    _openImgLightbox(img.src, img.alt || img.title || 'Attached image');
+    return;
+  }
 });
 
 const _IMAGE_EXTS=/\.(png|jpg|jpeg|gif|webp|bmp|ico|avif)$/i;

--- a/tests/test_composer_chip_lightbox.py
+++ b/tests/test_composer_chip_lightbox.py
@@ -1,0 +1,100 @@
+"""Regression tests for composer attach-thumb lightbox click behaviour.
+
+User pasted/dropped/picked an image and wants to verify the right one
+attached before sending. Clicking the thumbnail in the composer's
+attach-tray should open the existing image lightbox (the same one
+that's wired to message-attached images).
+
+This file pins the wiring at the source level — the document-level
+delegated click handler must:
+  - Continue handling .msg-media-img (existing v0.50.x behaviour).
+  - Also handle .attach-thumb on IMG elements (new in this PR).
+  - NOT trigger on the chip's × remove button (sibling element).
+  - NOT trigger on audio/video chips (those have native controls).
+
+It also pins the CSS cursor affordance so users discover the feature.
+"""
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+UI = ROOT / "static" / "ui.js"
+STYLE = ROOT / "static" / "style.css"
+
+
+class TestComposerChipLightboxDelegate:
+    def test_delegate_handles_attach_thumb_clicks(self):
+        """The document click handler must pick up clicks on .attach-thumb
+        (composer image chips) and route them to _openImgLightbox().
+
+        Previously the handler only looked for .msg-media-img.
+        """
+        src = UI.read_text(encoding="utf-8")
+        assert "e.target.closest('.attach-thumb')" in src, (
+            "Document click delegate must also match .attach-thumb"
+        )
+        # And it must call _openImgLightbox in that path.
+        # Use a tighter anchor block to ensure both branches are wired.
+        anchor = (
+            "img = e.target.closest('.attach-thumb');\n"
+            "  if(img && img.tagName === 'IMG'){\n"
+        )
+        assert anchor in src
+
+    def test_delegate_still_handles_message_attached_images(self):
+        """Existing .msg-media-img wiring must not regress."""
+        src = UI.read_text(encoding="utf-8")
+        # The message-image branch must come first (so _openImgLightbox
+        # fires for them without falling through to the .attach-thumb check).
+        msg_branch = "let img = e.target.closest('.msg-media-img');\n  if(img){ _openImgLightbox(img.src, img.alt); return; }"
+        assert msg_branch in src
+
+    def test_delegate_excludes_audio_video_chips(self):
+        """Audio/video chips have their own inline controls (native <audio>
+        / <video>) — they don't get a thumbnail .attach-thumb at all, so
+        the handler can't possibly trigger on them. Pin that the chip
+        renderer uses .attach-chip--audio / .attach-chip--video sibling
+        classes (no IMG with class attach-thumb in those branches).
+        """
+        src = UI.read_text(encoding="utf-8")
+        # Audio chip block — uses <audio>, no .attach-thumb img
+        assert "<audio controls preload=\"metadata\"" in src
+        # Video chip block — uses <video>, no .attach-thumb img
+        assert "<video controls preload=\"metadata\"" in src
+        # The .attach-thumb img tag is only generated in the image / svg branches.
+        # Quick structural check: every chip-rendering line that emits
+        # `class="attach-thumb"` has either `<img class="attach-thumb"` or
+        # `attach-thumb attach-thumb--svg`. Both are images.
+        for line in src.splitlines():
+            if 'class="attach-thumb' in line:
+                assert "<img " in line, (
+                    "Every .attach-thumb emission should be an <img> tag, "
+                    f"got: {line.strip()[:120]}"
+                )
+
+
+class TestComposerChipCursorAffordance:
+    def test_attach_thumb_cursor_is_zoom_in(self):
+        """`cursor: zoom-in` signals to the user that the thumbnail is
+        clickable for zoom — the most discoverable affordance for this UX.
+        Previously it was `cursor: default` which silently advertised
+        non-interactivity.
+        """
+        src = STYLE.read_text(encoding="utf-8")
+        # The .attach-thumb rule must declare cursor:zoom-in
+        # Use a substring search resilient to other property additions.
+        for line in src.splitlines():
+            if line.strip().startswith(".attach-thumb{"):
+                assert "cursor:zoom-in" in line, (
+                    f".attach-thumb cursor must be 'zoom-in', got: {line.strip()[:120]}"
+                )
+                break
+        else:
+            raise AssertionError(".attach-thumb selector not found in style.css")
+
+    def test_attach_thumb_has_hover_emphasis(self):
+        """Subtle hover emphasis (brightness + scale) reinforces the
+        zoom-in cursor by giving instant visual feedback before click.
+        """
+        src = STYLE.read_text(encoding="utf-8")
+        assert ".attach-thumb:hover{" in src or ".attach-thumb:hover {" in src


### PR DESCRIPTION
# feat(composer): click pasted/attached image thumbnails to lightbox-zoom them

## Why

When pasting screenshots into the composer — especially multiple in sequence, which now works end-to-end with the companion Mac fix at `hermes-webui/hermes-swift-mac#74` — users had no way to verify which image actually attached. The 56×56 thumbnail in the chip is enough to confirm "an image is here" but offers no detail at all.

From the request:

> *"When I hit Cmd+C and save an image to the clipboard and then paste the clipboard out, I want to be able to click on any one of those uploaded images that's inside the composer bar and have it zoom up like a lightbox so I can see the image in full once it's been pasted in to the composer input."*

This is paired with the Mac sequential-paste fix in PR #74 — together they form a clean v0.51.13 + v1.6.4 release: paste multiple screenshots in a row, see them all as distinct chips, click any one to verify before sending.

## What changes

### `static/ui.js` — extend the existing lightbox delegate

The image lightbox infrastructure already exists for message-attached images (the `_openImgLightbox()` helper at line 269 + the document-level click delegate at line 298 for `.msg-media-img`). This PR extends the **same delegate** to also fire on `.attach-thumb` composer chips:

```js
document.addEventListener('click', e => {
  if(!e.target || !e.target.closest) return;
  // Message-attached images (already wired since v0.50.x).
  let img = e.target.closest('.msg-media-img');
  if(img){ _openImgLightbox(img.src, img.alt); return; }
  // Composer attach-tray image thumbnails — click any pasted/dropped image
  // chip to lightbox-zoom it before sending. Excludes audio/video chips,
  // which keep their inline media controls. SVG thumbnails (.attach-thumb--svg)
  // are still images visually, so they qualify.
  img = e.target.closest('.attach-thumb');
  if(img && img.tagName === 'IMG'){
    _openImgLightbox(img.src, img.alt || img.title || 'Attached image');
    return;
  }
});
```

Three correctness properties:

- **Audio/video chips are excluded.** They render `.attach-chip--audio` or `.attach-chip--video` with native `<audio>` / `<video>` controls — no `.attach-thumb` img is ever produced for them, so the `closest()` returns null and the handler does nothing.
- **SVG thumbnails qualify.** `.attach-thumb attach-thumb--svg` is still an `<img>`; users want to zoom SVGs the same way they zoom rasters.
- **The chip's × remove button is a sibling, not an ancestor, of the thumb.** Clicking × → `e.target.closest('.attach-thumb')` returns null → the handler doesn't fire → the existing remove handler runs unobstructed. No interference.

### `static/style.css` — affordance

Two-line change to make the click discoverable:

```css
/* Was: cursor: default — actively misleading. */
.attach-thumb{... cursor:zoom-in; transition:filter .12s ease, transform .12s ease;}
.attach-thumb:hover{filter:brightness(1.05); transform:scale(1.04);}
```

`cursor: zoom-in` is the standard browser cursor for "click to enlarge" — instantly tells the user the thumbnail is interactive. The hover emphasis (4% scale + slight brightness) gives instant visual feedback before click.

### `tests/test_composer_chip_lightbox.py` — 5 regression tests

Pin the wiring at the source level:

1. Document click delegate handles `.attach-thumb` clicks.
2. Document click delegate **still** handles `.msg-media-img` (no regression on the v0.50.x behaviour).
3. Audio/video chips never render an `.attach-thumb` img.
4. `.attach-thumb` cursor is `zoom-in` (catches anyone reverting to `cursor:default`).
5. `.attach-thumb:hover` emphasis rule present.

## Verification

### Tests

47 composer-area tests pass (the new file plus all existing paste/composer/attach tests). 0 regressions.

### Live browser check on port 8789

Programmatically simulated three sequential pastes via `addFiles()` with the new Mac-side filename pattern (`screenshot-1778097130001-1.png`, `-2`, `-3`):

```
{
  count: 3,
  names: ["screenshot-...001-1.png", "...002-2.png", "...003-3.png"],
  chips: 3,
  thumbs: 3,
  cursor: "zoom-in"
}
```

All three distinct files in `pendingFiles`, all three chips render, cursor is `zoom-in`. ✓

Click thumb #2:

```
{
  thumbs_count: 3,
  lightbox_before: 0,
  lightbox_after: 1,
  lightbox_img_src_present: true,
  lightbox_alt: "screenshot-1778097130002-2.png",
  lightbox_role: "dialog"
}
```

Lightbox opens with the right image, ARIA role is `dialog`, alt text matches the filename. ✓

Click × on chip #2 (sibling-of-thumb, after closing lightbox):

```
{ beforeLb: 0, afterLb: 0, remainingChips: 2, remainingNames: [...] }
```

× removes only that chip, no lightbox interference. ✓

Escape key:

```
{ lbBefore: 1, lbAfter: 0 }
```

Closes the lightbox — the existing `_escHandler` in `_openImgLightbox()` handles it. ✓

## Companion PR

[`hermes-webui/hermes-swift-mac#74`](https://github.com/hermes-webui/hermes-swift-mac/pull/74) — unique filename per paste so sequential screenshot pastes actually appear as distinct chips. Without that, the second paste's `'screenshot.png'` collides with the first in `addFiles()`'s `f.name`-keyed dedupe and silently disappears. Together: paste, paste, paste, click any to zoom-verify, send.

## Refs

Refs nesquena/hermes-webui#1733.
