### PR TITLE
fix(config): custom provider + :free/:beta/:thinking suffix mis-resolution (#1776)

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -1373,10 +1373,21 @@ def resolve_model_provider(model_id: str) -> tuple:
     # into provider="openrouter:tencent/hy3-preview", model="free").  Guard
     # against that by falling back to split(":") when the rsplit result is not
     # a recognised provider (#1744).
+    #
+    # Edge case (#1776): for custom providers with the same suffix
+    # ("@custom:my-key:some-model:free"), rsplit yields
+    # provider_hint="custom:my-key:some-model", bare_model="free", and the
+    # custom-prefix guard below skips the split-fallback. Detect the
+    # over-split structurally — custom hints carry exactly one segment after
+    # "custom:", so any provider_hint with 2+ colons that starts with
+    # "custom:" has eaten part of the model name. Peel one segment back.
     if model_id.startswith("@") and ":" in model_id:
         inner = model_id[1:]
         provider_hint, bare_model = inner.rsplit(":", 1)
-        if (provider_hint not in _PROVIDER_MODELS
+        if provider_hint.startswith("custom:") and provider_hint.count(":") >= 2:
+            provider_hint, extra = provider_hint.rsplit(":", 1)
+            bare_model = f"{extra}:{bare_model}"
+        elif (provider_hint not in _PROVIDER_MODELS
                 and provider_hint not in _PROVIDER_DISPLAY
                 and not provider_hint.startswith("custom:")):
             provider_hint, bare_model = inner.split(":", 1)

--- a/tests/test_resolve_model_provider_free_suffix.py
+++ b/tests/test_resolve_model_provider_free_suffix.py
@@ -113,3 +113,60 @@ def test_known_provider_anthropic():
     model, provider, _ = resolve_model_provider(qualified)
     assert provider == "anthropic"
     assert model == "claude-sonnet-4.6"
+
+
+# ---------------------------------------------------------------------------
+# Issue #1776 — custom provider + :free / :beta / :thinking suffix
+#
+# The PR #1762 fix for #1744 skipped the rsplit-fallback when the provider
+# hint started with "custom:", on the assumption that custom-provider model
+# IDs route directly without further heuristics. But "@custom:my-key:model:free"
+# trips the same rsplit grammar collision: rsplit yields
+#   provider="custom:my-key:model", bare="free"
+# and the custom-prefix guard skips the fallback → wrong routing.
+#
+# The fix detects the over-split structurally: custom hints carry exactly
+# one segment after "custom:" (see api/config.py:1363 where the slug is
+# constructed as "custom:" + entry_name), so any rsplit result of the form
+# "custom:<a>:<b>" with bare model "<c>" has eaten one model segment. Peel
+# it back so the model becomes "<b>:<c>".
+# ---------------------------------------------------------------------------
+
+def test_custom_provider_free_suffix_1776():
+    """@custom:my-key:some-model:free → custom:my-key + some-model:free (#1776)."""
+    qualified = "@custom:my-key:some-model:free"
+    model, provider, _ = resolve_model_provider(qualified)
+    assert provider == "custom:my-key", f"expected provider='custom:my-key', got '{provider}'"
+    assert model == "some-model:free", f"expected model='some-model:free', got '{model}'"
+
+
+def test_custom_provider_beta_suffix_1776():
+    """@custom:my-key:some-model:beta — same bug class as :free."""
+    qualified = "@custom:my-key:some-model:beta"
+    model, provider, _ = resolve_model_provider(qualified)
+    assert provider == "custom:my-key"
+    assert model == "some-model:beta"
+
+
+def test_custom_provider_thinking_suffix_1776():
+    """@custom:my-key:some-model:thinking — same bug class as :free."""
+    qualified = "@custom:my-key:some-model:thinking"
+    model, provider, _ = resolve_model_provider(qualified)
+    assert provider == "custom:my-key"
+    assert model == "some-model:thinking"
+
+
+def test_custom_provider_preview_suffix_1776():
+    """@custom:my-key:some-model:preview — same bug class, no allowlist needed."""
+    qualified = "@custom:my-key:some-model:preview"
+    model, provider, _ = resolve_model_provider(qualified)
+    assert provider == "custom:my-key"
+    assert model == "some-model:preview"
+
+
+def test_custom_provider_slashed_model_with_free_suffix_1776():
+    """@custom:my-key:org/model:free — custom hint + slashed model + suffix."""
+    qualified = "@custom:my-key:org/model:free"
+    model, provider, _ = resolve_model_provider(qualified)
+    assert provider == "custom:my-key"
+    assert model == "org/model:free"


### PR DESCRIPTION
## Summary

Closes #1776.

PR #1762 fixed the `rsplit` grammar collision for plain `@openrouter:model:free` qualifiers, but skipped the fallback whenever the provider hint started with `custom:` on the assumption that custom providers route directly. That left `@custom:my-key:some-model:free` broken — issue body and the maintainer's confirmation comment trace the exact failure mode.

## Approach

Adopted the maintainer's recommended approach (no allowlist needed). Custom hints carry exactly one segment after `custom:` (constructed at `api/config.py:1363` as `\"custom:\" + entry_name.lower().replace(\" \", \"-\")`), so any rsplit result of `custom:<a>:<b>` with bare model `<c>` has eaten a model segment. Peel it back with a second rsplit and prepend to the bare model.

```python
provider_hint, bare_model = inner.rsplit(":", 1)
if provider_hint.startswith("custom:") and provider_hint.count(":") >= 2:
    provider_hint, extra = provider_hint.rsplit(":", 1)
    bare_model = f"{extra}:{bare_model}"
elif (provider_hint not in _PROVIDER_MODELS
        and provider_hint not in _PROVIDER_DISPLAY
        and not provider_hint.startswith("custom:")):
    provider_hint, bare_model = inner.split(":", 1)
```

Robust for `:free` / `:beta` / `:thinking` / `:preview` / any future OpenRouter suffix — no allowlist to keep in sync.

## Resolution matrix (verified by tests)

| Input | provider | model |
|---|---|---|
| `@custom:my-key:some-model:free` | `custom:my-key` | `some-model:free` ✅ |
| `@custom:my-key:some-model:beta` | `custom:my-key` | `some-model:beta` ✅ |
| `@custom:my-key:some-model:thinking` | `custom:my-key` | `some-model:thinking` ✅ |
| `@custom:my-key:some-model:preview` | `custom:my-key` | `some-model:preview` ✅ |
| `@custom:my-key:org/model:free` | `custom:my-key` | `org/model:free` ✅ |
| `@custom:my-key:some-model` (no suffix) | `custom:my-key` | `some-model` ✅ (existing test) |
| `@openrouter:tencent/hy3-preview:free` | `openrouter` | `tencent/hy3-preview:free` ✅ (existing test) |
| `@anthropic:claude-sonnet-4.6` | `anthropic` | `claude-sonnet-4.6` ✅ (existing test) |

## Tests

```
$ python -m pytest tests/test_resolve_model_provider_free_suffix.py tests/test_issue1228_model_picker_duplicate_ids.py -v
============================== 29 passed in 2.77s ==============================
```

- 5 new regression tests in `tests/test_resolve_model_provider_free_suffix.py` covering the issue matrix
- All 7 existing #1744 tests still pass
- All 17 #1228 tests (related custom-provider routing) still pass

## Open question (left for separate issue)

Per the maintainer's comment: `entry_name.lower().replace(\" \", \"-\")` doesn't strip colons, so a user who literally names a custom provider `\"foo:bar\"` would still produce a `custom:foo:bar` slug that this fix would mis-handle. Probably worth a separate input-validation issue to forbid `:` in `custom_provider` names rather than complicating this resolver. Happy to file a follow-up if useful.