### PR TITLE
fix: preserve inaccessible workspace entries

### DIFF
--- a/api/workspace.py
+++ b/api/workspace.py
@@ -10,6 +10,7 @@ paths are used as fallback when no profile module is available.
 import json
 import logging
 import os
+import stat
 import subprocess
 import concurrent.futures
 from pathlib import Path
@@ -92,7 +93,8 @@ def _profile_default_workspace() -> str:
 
 def _clean_workspace_list(workspaces: list) -> list:
     """Sanitize a workspace list:
-    - Remove entries whose paths no longer exist on disk.
+    - Preserve saved paths even when they are currently missing or inaccessible;
+      picker state must not be destroyed by a transient stat/permission failure.
     - Remove entries whose paths live inside another profile's directory
       (e.g. ~/.hermes/profiles/X/... should not appear on a different profile).
     - Rename any entry whose name is literally 'default' to 'Home' (avoids
@@ -104,10 +106,9 @@ def _clean_workspace_list(workspaces: list) -> list:
     for w in workspaces:
         path = w.get('path', '')
         name = w.get('name', '')
-        p = Path(path).resolve() if path else Path('/')
-        # Skip paths that no longer exist
-        if not p.is_dir():
+        if not path:
             continue
+        p = _safe_resolve(Path(path).expanduser())
         # Skip paths inside a DIFFERENT profile's directory (cross-profile leak).
         # Allow paths inside the CURRENT profile's own directory (e.g. test workspaces
         # created under ~/.hermes/profiles/webui/webui-mvp-test/).
@@ -128,6 +129,32 @@ def _clean_workspace_list(workspaces: list) -> list:
             name = 'Home'
         result.append({'path': str(p), 'name': name})
     return result
+
+
+def _workspace_access_error(candidate: Path, *, missing_label: str = "Path does not exist") -> str | None:
+    """Return a user-facing validation error for an unusable workspace path.
+
+    ``Path.exists()`` can collapse permission/stat failures into a generic falsey
+    result on some Python/OS combinations, which produced misleading "does not
+    exist" messages for macOS/TCC-denied directories.  Probe with ``stat()`` so
+    missing paths, non-directories, and permission-denied paths can be reported
+    separately.
+    """
+    try:
+        st = candidate.stat()
+    except FileNotFoundError:
+        return f"{missing_label}: {candidate}"
+    except PermissionError as exc:
+        return (
+            f"Cannot access path: {candidate}. The server process could not inspect "
+            f"this directory ({exc}). On macOS, grant Full Disk Access or Files and "
+            f"Folders permission to the Hermes/WebUI app or server process, then try again."
+        )
+    except OSError as exc:
+        return f"Cannot access path: {candidate}. The server process could not inspect this path ({exc})."
+    if not stat.S_ISDIR(st.st_mode):
+        return f"Path is not a directory: {candidate}"
+    return None
 
 
 def _migrate_global_workspaces() -> list:
@@ -517,10 +544,9 @@ def resolve_trusted_workspace(path: str | Path | None = None) -> Path:
 
     candidate = Path(path).expanduser().resolve()
 
-    if not candidate.exists():
-        raise ValueError(f"Path does not exist: {candidate}")
-    if not candidate.is_dir():
-        raise ValueError(f"Path is not a directory: {candidate}")
+    access_error = _workspace_access_error(candidate)
+    if access_error:
+        raise ValueError(access_error)
 
     # (A) Trusted if under the user's home directory — cross-platform via Path.home()
     # Must be checked before system roots to allow symlinks like /var/home.
@@ -602,10 +628,9 @@ def validate_workspace_to_add(path: str) -> Path:
     path = _strip_surrounding_quotes(path)
     candidate = Path(path).expanduser().resolve()
 
-    if not candidate.exists():
-        raise ValueError(f"Path does not exist: {candidate}")
-    if not candidate.is_dir():
-        raise ValueError(f"Path is not a directory: {candidate}")
+    access_error = _workspace_access_error(candidate)
+    if access_error:
+        raise ValueError(access_error)
 
     # Home directory is always trusted regardless of where it lives on disk
     # (e.g. /var/home/... on systemd-homed Fedora/RHEL).

--- a/tests/test_workspace_inaccessible_paths.py
+++ b/tests/test_workspace_inaccessible_paths.py
@@ -1,0 +1,82 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from api import workspace
+
+
+def test_load_workspaces_preserves_unavailable_entries_on_disk(tmp_path, monkeypatch):
+    """A transient stat/is_dir failure must not silently delete a saved workspace."""
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    existing = tmp_path / "existing"
+    existing.mkdir()
+    unavailable = tmp_path / "missing-or-inaccessible"
+    ws_file = state_dir / "workspaces.json"
+    raw = [
+        {"path": str(existing), "name": "Existing"},
+        {"path": str(unavailable), "name": "Unavailable"},
+    ]
+    ws_file.write_text(json.dumps(raw), encoding="utf-8")
+    monkeypatch.setattr(workspace, "_workspaces_file", lambda: ws_file)
+
+    loaded = workspace.load_workspaces()
+
+    assert [w["path"] for w in loaded] == [str(existing.resolve()), str(unavailable.resolve())]
+    assert json.loads(ws_file.read_text(encoding="utf-8")) == raw
+
+
+def test_clean_workspace_list_still_renames_default_without_dropping_missing(tmp_path):
+    missing = tmp_path / "temporarily-unavailable"
+
+    cleaned = workspace._clean_workspace_list([
+        {"path": str(missing), "name": "default"},
+    ])
+
+    assert cleaned == [{"path": str(missing.resolve()), "name": "Home"}]
+
+
+def test_validate_workspace_to_add_distinguishes_permission_denied(monkeypatch, tmp_path):
+    candidate = tmp_path / "Documents"
+    candidate.mkdir()
+
+    target = str(candidate.resolve())
+    original_stat = Path.stat
+
+    def fake_stat(self):
+        if str(self) == target:
+            raise PermissionError("Operation not permitted")
+        return original_stat(self)
+
+    monkeypatch.setattr(Path, "stat", fake_stat)
+
+    with pytest.raises(ValueError) as excinfo:
+        workspace.validate_workspace_to_add(str(candidate))
+
+    message = str(excinfo.value)
+    assert "Cannot access path" in message
+    assert "Operation not permitted" in message
+    assert "macOS" in message
+    assert "Full Disk Access" in message
+
+
+def test_resolve_trusted_workspace_distinguishes_missing_from_permission_denied(monkeypatch, tmp_path):
+    candidate = tmp_path / "Documents"
+    candidate.mkdir()
+
+    target = str(candidate.resolve())
+    original_stat = Path.stat
+
+    def fake_stat(self):
+        if str(self) == target:
+            raise PermissionError("Operation not permitted")
+        return original_stat(self)
+
+    monkeypatch.setattr(Path, "stat", fake_stat)
+
+    with pytest.raises(ValueError) as excinfo:
+        workspace.resolve_trusted_workspace(str(candidate))
+
+    assert "Cannot access path" in str(excinfo.value)
+    assert "Path does not exist" not in str(excinfo.value)


### PR DESCRIPTION
## Thinking Path
- Workspace registration is user state; a temporary inability to stat a directory should not delete that state.
- The existing loader treated `Path(...).is_dir() == false` as cleanup-worthy and persisted the shortened list, so inaccessible/missing paths disappeared from the picker.
- The add/switch validators also used generic existence checks, which can surface permission/TCC-denied paths as misleading “Path does not exist” errors.
- This PR keeps explicit removal as the only destructive workspace-list operation and makes validation errors distinguish missing paths from stat/permission failures.

## What Changed
- Changed workspace-list cleaning to preserve saved paths when they are missing or inaccessible, while still removing empty entries and cross-profile leaks and still renaming `default` labels to `Home`.
- Added `_workspace_access_error()` so add/switch validation probes paths with `stat()` and returns separate errors for missing paths, non-directories, permission-denied paths, and other stat failures.
- Added macOS-oriented guidance to permission-denied errors, pointing users toward Full Disk Access / Files and Folders permissions for the WebUI app or server process.
- Added regression coverage for non-destructive `load_workspaces()` behavior and permission-denied wording.

Fixes #1795

## Why It Matters
- Registered workspaces no longer disappear just because the server temporarily cannot inspect a path.
- Browser WebUI and native WKWebView users get a more accurate error when the server/app process lacks filesystem permission.
- The server-side fix avoids pretending to solve Mac-native security-scoped bookmark/TCC consent; if macOS still blocks access, the native app layer may still need a follow-up permission/bookmark flow.

## Verification
- `env -u HERMES_CONFIG_PATH -u HERMES_WEBUI_HOST /home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_workspace_inaccessible_paths.py -q` → 4 passed
- `env -u HERMES_CONFIG_PATH -u HERMES_WEBUI_HOST /home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_workspace_inaccessible_paths.py tests/test_workspace_add_quote_strip.py tests/test_workspace_blocked_roots_macos.py tests/test_sprint5.py -q` → 70 passed, 2 skipped
- `env -u HERMES_CONFIG_PATH -u HERMES_WEBUI_HOST /home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/ -q` → 4720 passed, 4 skipped, 3 xpassed, 1 warning, 8 subtests passed
- `git diff --check` → passed

## Risks / Follow-ups
- This preserves unavailable workspace entries instead of adding a full unavailable-status UI treatment; explicit remove still deletes entries.
- If Cygnus’s macOS native app cannot obtain TCC/security-scoped access to selected folders, a Swift/native-app follow-up may still be needed to request and retain permission before the WebUI server attempts to stat the path.
- The permission guidance is intentionally generic because this repository appears to own the server/WebUI behavior, not necessarily the native file-access consent flow.

## Model Used
- OpenAI Codex `gpt-5.5` via Hermes Agent CLI.
- Tool use: filesystem inspection/editing, pytest, git, gh CLI.