### PR TITLE
feat: show provider account limits in quota card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Hermes Web UI -- Changelog
 
+## [Unreleased]
+
+### Added
+
+- Extend the active provider quota endpoint/card beyond OpenRouter for account-limit providers. OpenAI Codex and Anthropic OAuth now reuse Hermes Agent's `/usage` account-limits abstraction and render plan/window/detail fields in Settings → Providers without exposing credentials. Refs #1766.
+
 ## [v0.51.18] — 2026-05-07 — 5-PR batch (4 contributor + 1 self-built UX polish)
 
 ### Fixed

--- a/api/providers.py
+++ b/api/providers.py
@@ -12,6 +12,7 @@ import logging
 import os
 import urllib.error
 import urllib.request
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -28,6 +29,7 @@ logger = logging.getLogger(__name__)
 
 _OPENROUTER_KEY_URL = "https://openrouter.ai/api/v1/key"
 _PROVIDER_QUOTA_TIMEOUT_SECONDS = 3.0
+_ACCOUNT_USAGE_PROVIDERS = frozenset({"openai-codex", "anthropic"})
 
 # SECTION: Provider ↔ env var mapping
 
@@ -358,13 +360,122 @@ def _sanitize_openrouter_quota(payload: Any) -> dict[str, int | float | None]:
     }
 
 
+def _isoformat_utc(value: Any) -> str | None:
+    if value in (None, ""):
+        return None
+    if isinstance(value, datetime):
+        dt = value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+        return dt.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+    text = str(value).strip()
+    return text or None
+
+
+def _serialize_account_usage_snapshot(snapshot: Any) -> dict[str, Any] | None:
+    if snapshot is None:
+        return None
+    windows: list[dict[str, Any]] = []
+    for window in getattr(snapshot, "windows", ()) or ():
+        label = str(getattr(window, "label", "") or "").strip()
+        if not label:
+            continue
+        used_percent = _quota_number(getattr(window, "used_percent", None))
+        remaining_percent = None
+        if used_percent is not None:
+            remaining_percent = max(0.0, min(100.0, 100.0 - float(used_percent)))
+        windows.append({
+            "label": label,
+            "used_percent": used_percent,
+            "remaining_percent": remaining_percent,
+            "reset_at": _isoformat_utc(getattr(window, "reset_at", None)),
+            "detail": str(getattr(window, "detail", "") or "").strip() or None,
+        })
+
+    details = [
+        str(detail).strip()
+        for detail in (getattr(snapshot, "details", ()) or ())
+        if str(detail).strip()
+    ]
+    plan = str(getattr(snapshot, "plan", "") or "").strip() or None
+    unavailable_reason = str(getattr(snapshot, "unavailable_reason", "") or "").strip() or None
+    return {
+        "provider": str(getattr(snapshot, "provider", "") or "").strip() or None,
+        "source": str(getattr(snapshot, "source", "") or "").strip() or None,
+        "title": str(getattr(snapshot, "title", "") or "").strip() or "Account limits",
+        "plan": plan,
+        "windows": windows,
+        "details": details,
+        "available": bool(getattr(snapshot, "available", bool(windows or details))) and not unavailable_reason,
+        "unavailable_reason": unavailable_reason,
+        "fetched_at": _isoformat_utc(getattr(snapshot, "fetched_at", None)),
+    }
+
+
+def _agent_fetch_account_usage(provider: str, *, base_url: str | None = None, api_key: str | None = None) -> Any:
+    from agent.account_usage import fetch_account_usage
+
+    return fetch_account_usage(provider, base_url=base_url, api_key=api_key)
+
+
+def _fetch_account_usage_with_profile_context(provider: str) -> Any:
+    try:
+        from api.profiles import cron_profile_context_for_home
+    except ImportError:
+        cron_profile_context_for_home = None
+
+    home = _get_hermes_home()
+    api_key = _get_provider_api_key(provider)
+    try:
+        if cron_profile_context_for_home is None:
+            return _agent_fetch_account_usage(provider, api_key=api_key)
+        with cron_profile_context_for_home(home):
+            return _agent_fetch_account_usage(provider, api_key=api_key)
+    except Exception:
+        logger.debug("Failed to fetch account usage for %s", provider, exc_info=True)
+        return None
+
+
+def _provider_account_usage_status(provider: str, display_name: str) -> dict[str, Any]:
+    snapshot = _fetch_account_usage_with_profile_context(provider)
+    account_limits = _serialize_account_usage_snapshot(snapshot)
+    if account_limits and account_limits.get("available"):
+        return {
+            "ok": True,
+            "provider": provider,
+            "display_name": display_name,
+            "supported": True,
+            "status": "available",
+            "label": account_limits.get("title") or "Account limits",
+            "quota": None,
+            "account_limits": account_limits,
+            "message": f"{display_name} account limits loaded.",
+        }
+
+    reason = ""
+    if account_limits:
+        reason = str(account_limits.get("unavailable_reason") or "").strip()
+    message = (
+        f"{display_name} account limits are unavailable. {reason}"
+        if reason
+        else f"{display_name} account limits are unavailable. Confirm provider authentication and try again."
+    )
+    return {
+        "ok": False,
+        "provider": provider,
+        "display_name": display_name,
+        "supported": True,
+        "status": "unavailable",
+        "quota": None,
+        "account_limits": account_limits,
+        "message": message,
+    }
+
+
 def get_provider_quota(provider_id: str | None = None) -> dict[str, Any]:
     """Return sanitized quota/rate-limit status for the active provider.
 
-    Issue #706 starts conservatively with OpenRouter's documented key endpoint.
-    OpenAI/Anthropic only expose per-call headers; until the WebUI captures those
-    response headers, report a clear unsupported/follow-up state rather than
-    inventing stale or guessed quota numbers.
+    OpenRouter keeps its documented key endpoint. OAuth-backed account usage
+    providers reuse Hermes Agent's /usage account-limits abstraction so WebUI
+    stays aligned with CLI/Gateway provider semantics.
     """
     provider = (provider_id or _active_provider_id() or "").strip().lower()
     if not provider:
@@ -379,6 +490,9 @@ def get_provider_quota(provider_id: str | None = None) -> dict[str, Any]:
         }
 
     display_name = _PROVIDER_DISPLAY.get(provider, provider.replace("-", " ").title())
+    if provider in _ACCOUNT_USAGE_PROVIDERS:
+        return _provider_account_usage_status(provider, display_name)
+
     if provider != "openrouter":
         detail = "OpenAI/Anthropic rate-limit headers are a follow-up once WebUI captures provider response metadata."
         return {

--- a/static/panels.js
+++ b/static/panels.js
@@ -4715,6 +4715,16 @@ function _formatProviderQuotaReset(value){
   try{return d.toLocaleString();}catch(e){return value;}
 }
 
+function _formatProviderQuotaWindowLabel(accountLimits,w){
+  const raw=((w&&w.label)||'Window').trim();
+  const provider=((accountLimits&&accountLimits.provider)||'').toLowerCase();
+  if(provider==='openai-codex'){
+    if(raw.toLowerCase()==='session') return '5-hour limit';
+    if(raw.toLowerCase()==='weekly') return 'Weekly limit';
+  }
+  return raw||'Window';
+}
+
 function _buildProviderQuotaCard(status){
   if(!status) return null;
   const card=document.createElement('div');
@@ -4737,7 +4747,7 @@ function _buildProviderQuotaCard(status){
       if(w&&w.detail) meta.push(w.detail);
       return `
         <div class="provider-quota-metric provider-quota-window">
-          <span>${esc((w&&w.label)||'Window')}</span>
+          <span>${esc(_formatProviderQuotaWindowLabel(accountLimits,w))}</span>
           <strong>${esc(_formatProviderQuotaPercent(w&&w.remaining_percent))}</strong>
           ${meta.length?`<small>${esc(meta.join(' · '))}</small>`:''}
         </div>

--- a/static/panels.js
+++ b/static/panels.js
@@ -4701,15 +4701,54 @@ function _formatProviderQuotaMoney(value){
   return '$'+n.toFixed(2);
 }
 
+function _formatProviderQuotaPercent(value){
+  if(value===null||value===undefined||value==='') return '—';
+  const n=Number(value);
+  if(!Number.isFinite(n)) return '—';
+  return Math.max(0,Math.min(100,Math.round(n)))+'%';
+}
+
+function _formatProviderQuotaReset(value){
+  if(!value) return '';
+  const d=new Date(value);
+  if(Number.isNaN(d.getTime())) return '';
+  try{return d.toLocaleString();}catch(e){return value;}
+}
+
 function _buildProviderQuotaCard(status){
   if(!status) return null;
   const card=document.createElement('div');
   const state=(status.status||'unavailable').replace(/[^a-z0-9_-]/gi,'').toLowerCase()||'unavailable';
   card.className='provider-quota-card provider-quota-card-'+state;
-  const provider=status.display_name||status.provider||'Active provider';
-  const quota=status.quota||{};
+  const accountLimits=status.account_limits||null;
+  const providerBase=status.display_name||status.provider||'Active provider';
+  const provider=(accountLimits&&accountLimits.plan)?`${providerBase} · ${accountLimits.plan}`:providerBase;
+  const quota=status.quota||null;
   let body='';
-  if(status.status==='available'&&quota){
+  if(status.status==='available'&&accountLimits){
+    const windows=Array.isArray(accountLimits.windows)?accountLimits.windows:[];
+    const details=Array.isArray(accountLimits.details)?accountLimits.details:[];
+    const windowHtml=windows.map(w=>{
+      const used=_formatProviderQuotaPercent(w&&w.used_percent);
+      const reset=_formatProviderQuotaReset(w&&w.reset_at);
+      const meta=[];
+      if(used!=='—') meta.push(`${used} used`);
+      if(reset) meta.push(`resets ${reset}`);
+      if(w&&w.detail) meta.push(w.detail);
+      return `
+        <div class="provider-quota-metric provider-quota-window">
+          <span>${esc((w&&w.label)||'Window')}</span>
+          <strong>${esc(_formatProviderQuotaPercent(w&&w.remaining_percent))}</strong>
+          ${meta.length?`<small>${esc(meta.join(' · '))}</small>`:''}
+        </div>
+      `;
+    }).join('');
+    const detailHtml=details.length
+      ? `<div class="provider-quota-details">${details.map(d=>`<span>${esc(d)}</span>`).join('')}</div>`
+      : '';
+    body=windowHtml+detailHtml;
+    if(!body) body=`<div class="provider-quota-message">${esc(status.message||'Account limits loaded.')}</div>`;
+  }else if(status.status==='available'&&quota){
     body=`
       <div class="provider-quota-metric"><span>Remaining</span><strong>${esc(_formatProviderQuotaMoney(quota.limit_remaining))}</strong></div>
       <div class="provider-quota-metric"><span>Used</span><strong>${esc(_formatProviderQuotaMoney(quota.usage))}</strong></div>

--- a/static/style.css
+++ b/static/style.css
@@ -2417,6 +2417,10 @@ main.main.showing-logs > #mainLogs{display:flex;}
 .provider-quota-metric{flex:1;min-width:88px;border:1px solid var(--border);border-radius:8px;background:var(--sidebar);padding:8px 10px;}
 .provider-quota-metric span{display:block;font-size:10.5px;color:var(--muted);margin-bottom:2px;}
 .provider-quota-metric strong{display:block;font-size:14px;color:var(--text);font-weight:650;}
+.provider-quota-metric small{display:block;font-size:10.5px;color:var(--muted);line-height:1.35;margin-top:3px;}
+.provider-quota-window{min-width:132px;}
+.provider-quota-details{display:flex;flex-wrap:wrap;gap:6px;width:100%;}
+.provider-quota-details span{font-size:11px;line-height:1.35;color:var(--muted);border:1px solid var(--border);border-radius:999px;background:var(--sidebar);padding:4px 8px;}
 .provider-quota-message{font-size:12px;color:var(--muted);line-height:1.45;}
 .provider-quota-card-available .provider-quota-badge{background:rgba(34,197,94,.12);color:#16a34a;}
 :root.dark .provider-quota-card-available .provider-quota-badge{background:rgba(34,197,94,.16);color:#4ade80;}

--- a/tests/test_provider_quota_status.py
+++ b/tests/test_provider_quota_status.py
@@ -325,6 +325,7 @@ def test_provider_quota_card_is_rendered_in_providers_panel():
     assert "account_limits" in panels
     assert "remaining_percent" in panels
     assert "provider-quota-details" in panels
+    assert "5-hour limit" in panels
 
 
 def test_provider_quota_styles_exist():

--- a/tests/test_provider_quota_status.py
+++ b/tests/test_provider_quota_status.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 import json
+import os
 import urllib.error
+from datetime import datetime, timezone
 from io import BytesIO
 from pathlib import Path
+from types import SimpleNamespace
 
 import api.config as config
 import api.profiles as profiles
@@ -162,6 +165,149 @@ def test_unsupported_provider_reports_followup_state(monkeypatch, tmp_path):
     assert "follow-up" in result["message"]
 
 
+def test_codex_account_usage_is_fetched_under_active_profile_home(monkeypatch, tmp_path):
+    """Codex account limits must use the selected WebUI profile's HERMES_HOME."""
+    monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
+    old_cfg, old_mtime = _with_config(model={"provider": "openai-codex"})
+
+    import api.providers as providers
+    seen = {}
+    previous_home = os.environ.get("HERMES_HOME")
+
+    def fake_fetch(provider, base_url=None, api_key=None):
+        seen["provider"] = provider
+        seen["api_key"] = api_key
+        seen["hermes_home"] = os.environ.get("HERMES_HOME")
+        return SimpleNamespace(
+            provider="openai-codex",
+            source="usage_api",
+            title="Account limits",
+            plan="Pro",
+            fetched_at=datetime(2030, 3, 17, 12, 30, tzinfo=timezone.utc),
+            available=True,
+            windows=(
+                SimpleNamespace(
+                    label="Session",
+                    used_percent=15.0,
+                    reset_at=datetime(2030, 3, 17, 17, 30, tzinfo=timezone.utc),
+                    detail=None,
+                ),
+                SimpleNamespace(
+                    label="Weekly",
+                    used_percent=40.0,
+                    reset_at=datetime(2030, 3, 24, 12, 30, tzinfo=timezone.utc),
+                    detail=None,
+                ),
+            ),
+            details=("Credits balance: $12.50",),
+            unavailable_reason=None,
+        )
+
+    monkeypatch.setattr(providers, "_agent_fetch_account_usage", fake_fetch)
+    try:
+        result = providers.get_provider_quota()
+    finally:
+        _restore_config(old_cfg, old_mtime)
+
+    assert seen == {
+        "provider": "openai-codex",
+        "api_key": None,
+        "hermes_home": str(tmp_path),
+    }
+    assert os.environ.get("HERMES_HOME") == previous_home
+    assert result["ok"] is True
+    assert result["provider"] == "openai-codex"
+    assert result["supported"] is True
+    assert result["status"] == "available"
+    assert result["quota"] is None
+    assert result["account_limits"] == {
+        "provider": "openai-codex",
+        "source": "usage_api",
+        "title": "Account limits",
+        "plan": "Pro",
+        "windows": [
+            {
+                "label": "Session",
+                "used_percent": 15.0,
+                "remaining_percent": 85.0,
+                "reset_at": "2030-03-17T17:30:00Z",
+                "detail": None,
+            },
+            {
+                "label": "Weekly",
+                "used_percent": 40.0,
+                "remaining_percent": 60.0,
+                "reset_at": "2030-03-24T12:30:00Z",
+                "detail": None,
+            },
+        ],
+        "details": ["Credits balance: $12.50"],
+        "available": True,
+        "unavailable_reason": None,
+        "fetched_at": "2030-03-17T12:30:00Z",
+    }
+
+
+def test_codex_account_usage_unavailable_is_sanitized(monkeypatch, tmp_path):
+    """Auth/network failures should not leak raw token or exception details."""
+    monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
+    old_cfg, old_mtime = _with_config(model={"provider": "openai-codex"})
+
+    import api.providers as providers
+
+    def fake_fetch(*_args, **_kwargs):
+        raise RuntimeError("secret access token should not leak")
+
+    monkeypatch.setattr(providers, "_agent_fetch_account_usage", fake_fetch)
+    try:
+        result = providers.get_provider_quota()
+    finally:
+        _restore_config(old_cfg, old_mtime)
+
+    assert result["ok"] is False
+    assert result["provider"] == "openai-codex"
+    assert result["supported"] is True
+    assert result["status"] == "unavailable"
+    assert result["account_limits"] is None
+    assert "Confirm provider authentication" in result["message"]
+    assert "secret" not in repr(result).lower()
+
+
+def test_anthropic_oauth_usage_unavailable_reason_is_reported(monkeypatch, tmp_path):
+    """Hermes Agent can report why account limits are not available."""
+    monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
+    old_cfg, old_mtime = _with_config(model={"provider": "anthropic"})
+
+    import api.providers as providers
+
+    monkeypatch.setattr(
+        providers,
+        "_agent_fetch_account_usage",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            provider="anthropic",
+            source="oauth_usage_api",
+            title="Account limits",
+            plan=None,
+            fetched_at=datetime(2030, 3, 17, 12, 30, tzinfo=timezone.utc),
+            available=False,
+            windows=(),
+            details=(),
+            unavailable_reason="Anthropic account limits are only available for OAuth-backed Claude accounts.",
+        ),
+    )
+    try:
+        result = providers.get_provider_quota()
+    finally:
+        _restore_config(old_cfg, old_mtime)
+
+    assert result["ok"] is False
+    assert result["provider"] == "anthropic"
+    assert result["supported"] is True
+    assert result["status"] == "unavailable"
+    assert result["account_limits"]["unavailable_reason"].startswith("Anthropic account limits")
+    assert "OAuth-backed Claude accounts" in result["message"]
+
+
 def test_provider_quota_route_is_registered():
     """The backend must expose a route for the UI to poll quota status."""
     routes = (ROOT / "api" / "routes.py").read_text(encoding="utf-8")
@@ -176,6 +322,9 @@ def test_provider_quota_card_is_rendered_in_providers_panel():
     assert "function _buildProviderQuotaCard" in panels
     assert "Active provider quota" in panels
     assert "provider-quota-card" in panels
+    assert "account_limits" in panels
+    assert "remaining_percent" in panels
+    assert "provider-quota-details" in panels
 
 
 def test_provider_quota_styles_exist():
@@ -187,5 +336,7 @@ def test_provider_quota_styles_exist():
         ".provider-quota-card-available",
         ".provider-quota-card-no_key",
         ".provider-quota-card-invalid_key",
+        ".provider-quota-details",
+        ".provider-quota-window",
     ):
         assert token in css


### PR DESCRIPTION
## Summary

- Extend `GET /api/provider/quota` beyond OpenRouter for OAuth-backed account-limit providers.
- Reuse Hermes Agent's `agent.account_usage.fetch_account_usage()` for OpenAI Codex and Anthropic OAuth so WebUI stays aligned with CLI/Gateway `/usage` behavior.
- Render account-limit windows/details in the existing Settings -> Providers quota card, including clearer Codex labels (`5-hour limit`, `Weekly limit`).

## Scope

This is the first slice for #1766. It adds provider coverage to the existing Settings card and endpoint. It does not add the ambient topbar indicator yet; that should remain a follow-up UI-surface decision.

Also note a source clarification from the issue body: local Agent behavior shows account limits are surfaced by `/usage`, not by `auth status openai-codex`.

Refs #1766

## Verification

- `pytest tests/test_provider_quota_status.py tests/test_provider_management.py -q` -> `29 passed`
- `node --check static/panels.js`
- `python -m py_compile api/providers.py api/routes.py`
- `git diff --check`
- Manual local Codex OAuth validation: `GET /api/provider/quota?provider=openai-codex` returned available account limits with plan, 5-hour window, and weekly window data.
