### PR TITLE
fix: use live Codex models in provider card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixed
 
+- **PR #1812** by @franksong2702 — OpenAI Codex Providers card live catalog (closes #1807). Settings -> Providers now asks `hermes_cli.models.provider_model_ids("openai-codex")` before rendering the Codex card model list, matching the account-specific live catalog used by `/api/models/live`. Static `_PROVIDER_MODELS["openai-codex"]` remains a fallback only when live discovery is unavailable, so stale static-only IDs such as `gpt-5.5-mini`, `gpt-5.2-codex`, and `codex-mini-latest` no longer appear as available for authenticated Codex accounts whose live catalog excludes them.
+
 - **PR #1783** by @Sanjays2402 — Custom provider + `:free`/`:beta`/`:thinking` suffix mis-resolution. **Closes #1776** (the follow-up I filed during the v0.51.15 sweep against PR #1762). `api/config.py +13` extends `resolve_model_provider()`'s rsplit-fallback so `@custom:my-key:some-model:free` correctly resolves to `provider=custom:my-key, model=some-model:free` (was previously dropping the suffix). 57 LOC test coverage in `tests/test_resolve_model_provider_free_suffix.py`. Opus verified: non-custom path (`@openrouter:tencent/hy3-preview:free`) preserved unchanged; `@custom:my-key:some-model` (no suffix) backward-compatible; no recursion risk.
 
 - **PR #1791** by @Michaelyklam — Keep assistant-only stream deltas on the current turn (closes #1787). When an SSE stream produces only assistant content (no user-turn material), `api/streaming.py +27` no longer promotes it to a new turn — appends to current. Tool-call responses (`role in ('assistant','tool')`) correctly trigger user-turn materialization. Pure display-merge logic with no INFLIGHT mutation. 27 LOC test coverage. Includes screenshot of correct transcript order.

--- a/api/providers.py
+++ b/api/providers.py
@@ -18,6 +18,7 @@ from typing import Any
 from api.config import (
     _PROVIDER_DISPLAY,
     _PROVIDER_MODELS,
+    _get_label_for_model,
     _save_yaml_config_file,
     get_config,
     invalidate_models_cache,
@@ -577,6 +578,23 @@ def get_providers() -> dict[str, Any]:
 
         models = list(_PROVIDER_MODELS.get(pid, []))
         models_total = len(models)
+        # Codex account catalogs are account-specific and can drift faster than
+        # WebUI's static fallback table (#1807). Prefer the live agent resolver
+        # for the providers card too so stale static-only model IDs are not
+        # presented as available when discovery succeeds.
+        if pid == "openai-codex":
+            try:
+                from hermes_cli.models import provider_model_ids as _provider_model_ids
+
+                live_ids = [mid for mid in (_provider_model_ids("openai-codex") or []) if mid]
+                if live_ids:
+                    models = [
+                        {"id": mid, "label": _get_label_for_model(mid, [])}
+                        for mid in live_ids
+                    ]
+                    models_total = len(models)
+            except Exception:
+                logger.debug("Failed to load OpenAI Codex models from hermes_cli")
         # Nous Portal: prefer the live catalog so the providers card matches
         # the dropdown picker (#1538). Same fallback shape as the static-only
         # case below — when hermes_cli is unavailable or its lookup raises,

--- a/tests/test_issue1807_codex_provider_card_live_models.py
+++ b/tests/test_issue1807_codex_provider_card_live_models.py
@@ -1,0 +1,81 @@
+"""Regression tests for #1807 -- Codex providers card uses live models."""
+
+import sys
+import types
+
+import api.config as config
+import api.profiles as profiles
+
+
+def _install_fake_hermes_cli(monkeypatch, provider_model_ids):
+    fake_pkg = types.ModuleType("hermes_cli")
+    fake_pkg.__path__ = []
+
+    fake_models = types.ModuleType("hermes_cli.models")
+    fake_models.list_available_providers = lambda: []
+    fake_models.provider_model_ids = provider_model_ids
+
+    fake_auth = types.ModuleType("hermes_cli.auth")
+    fake_auth.get_auth_status = lambda pid: {
+        "logged_in": pid == "openai-codex",
+        "key_source": "oauth",
+    }
+
+    monkeypatch.setitem(sys.modules, "hermes_cli", fake_pkg)
+    monkeypatch.setitem(sys.modules, "hermes_cli.models", fake_models)
+    monkeypatch.setitem(sys.modules, "hermes_cli.auth", fake_auth)
+
+
+def _configure_codex(monkeypatch, tmp_path):
+    monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(config, "_get_config_path", lambda: tmp_path / "missing-config.yaml")
+    monkeypatch.setattr(config, "cfg", {
+        "model": {"provider": "openai-codex", "default": "gpt-5.5"},
+        "providers": {},
+        "fallback_providers": [],
+    })
+    monkeypatch.setattr(config, "_cfg_mtime", 0.0)
+
+
+def _codex_provider():
+    from api.providers import get_providers
+
+    providers = get_providers()["providers"]
+    return next(p for p in providers if p["id"] == "openai-codex")
+
+
+def test_codex_provider_card_prefers_live_account_catalog(monkeypatch, tmp_path):
+    live_codex_ids = [
+        "gpt-5.5",
+        "gpt-5.4",
+        "gpt-5.4-mini",
+        "gpt-5.3-codex",
+        "gpt-5.2",
+    ]
+
+    def provider_model_ids(pid):
+        return live_codex_ids if pid == "openai-codex" else []
+
+    _install_fake_hermes_cli(monkeypatch, provider_model_ids)
+    _configure_codex(monkeypatch, tmp_path)
+
+    codex = _codex_provider()
+    ids = [m["id"] for m in codex["models"]]
+
+    assert ids == live_codex_ids
+    assert codex["models_total"] == len(live_codex_ids)
+    assert "gpt-5.5-mini" not in ids
+    assert "gpt-5.2-codex" not in ids
+    assert "codex-mini-latest" not in ids
+
+
+def test_codex_provider_card_keeps_static_fallback_when_live_catalog_empty(monkeypatch, tmp_path):
+    _install_fake_hermes_cli(monkeypatch, lambda _pid: [])
+    _configure_codex(monkeypatch, tmp_path)
+
+    codex = _codex_provider()
+    ids = [m["id"] for m in codex["models"]]
+
+    assert "gpt-5.5-mini" in ids
+    assert "codex-mini-latest" in ids
+    assert codex["models_total"] == len(ids)


### PR DESCRIPTION
## Summary

- Make the Settings -> Providers OpenAI Codex card prefer `hermes_cli.models.provider_model_ids("openai-codex")` when live account discovery succeeds.
- Keep the existing static `_PROVIDER_MODELS["openai-codex"]` list as fallback only when live discovery is unavailable or empty.
- Add regression coverage for both the live-catalog path and the static fallback path.

Fixes #1807.

## Verification

- `/Users/xuefusong/hermes-webui/.venv_test/bin/python -m pytest tests/test_issue1807_codex_provider_card_live_models.py tests/test_custom_providers_in_panel.py -q`
- `/Users/xuefusong/hermes-webui/.venv_test/bin/python -m pytest tests/test_issue1680_codex_spark.py tests/test_issue1807_codex_provider_card_live_models.py -q`
- `/Users/xuefusong/.hermes/hermes-agent/.venv/bin/python -m pytest tests/test_issue1807_codex_provider_card_live_models.py -q`
- `/opt/homebrew/bin/python3.12 -m py_compile api/providers.py tests/test_issue1807_codex_provider_card_live_models.py`
- `git diff --check`
- `git merge-tree --write-tree HEAD origin/pr/1805` clean
- `git merge-tree --write-tree HEAD origin/pr/1803` clean
- `git merge-tree --write-tree HEAD origin/pr/1802` clean
- `git merge-tree --write-tree HEAD origin/pr/1801` clean
