### PR TITLE
fix: allow editing no-agent cron jobs without prompts

### DIFF
--- a/static/panels.js
+++ b/static/panels.js
@@ -667,7 +667,7 @@ function openCronCreate(){
   _cronMode = 'create';
   _cronIsDuplicate = false;
   _cronSelectedSkills = [];
-  _renderCronForm({ name:'', schedule:'', prompt:'', deliver:'local', profile:'', isEdit:false });
+  _renderCronForm({ name:'', schedule:'', prompt:'', deliver:'local', profile:'', noAgent:false, script:'', isEdit:false });
   _cronSkillsCache = null;
   api('/api/skills').then(d=>{_cronSkillsCache=d.skills||[]; _bindCronSkillPicker();}).catch(()=>{});
   loadCronProfiles().then(()=>_refreshCronProfileSelect('')).catch(()=>{});
@@ -685,6 +685,8 @@ function openCronEdit(job){
     prompt: job.prompt || '',
     deliver: job.deliver || 'local',
     profile: job.profile || '',
+    noAgent: !!job.no_agent,
+    script: job.script || '',
     isEdit: true,
   });
   if (!_cronSkillsCache) {
@@ -695,13 +697,17 @@ function openCronEdit(job){
   loadCronProfiles().then(()=>_refreshCronProfileSelect(job.profile || '')).catch(()=>{});
 }
 
-function _renderCronForm({ name, schedule, prompt, deliver, profile, isEdit }){
+function _renderCronForm({ name, schedule, prompt, deliver, profile, noAgent, script, isEdit }){
   const title = $('taskDetailTitle');
   const body = $('taskDetailBody');
   const empty = $('taskDetailEmpty');
   if (!body || !title) return;
   title.textContent = isEdit ? (t('edit') + ' · ' + (name || schedule || t('scheduled_jobs'))) : t('new_job');
   const deliverOpt = (v,l) => `<option value="${v}"${deliver===v?' selected':''}>${esc(l)}</option>`;
+  const promptRequired = !noAgent;
+  const promptHint = noAgent
+    ? `<div class="detail-form-hint">${esc(t('cron_no_agent_prompt_hint') || `No-agent mode runs the script directly; prompt is not used.${script ? ' Script: ' + script : ''}`)}</div>`
+    : '';
   body.innerHTML = `
     <div class="main-view-content">
       <form class="detail-form" onsubmit="event.preventDefault(); saveCronForm();">
@@ -716,7 +722,8 @@ function _renderCronForm({ name, schedule, prompt, deliver, profile, isEdit }){
         </div>
         <div class="detail-form-row">
           <label for="cronFormPrompt">${esc(t('cron_prompt_label') || 'Prompt')}</label>
-          <textarea id="cronFormPrompt" rows="6" placeholder="${esc(t('cron_prompt_placeholder') || 'Must be self-contained')}" required>${esc(prompt || '')}</textarea>
+          <textarea id="cronFormPrompt" rows="6" placeholder="${esc(t('cron_prompt_placeholder') || 'Must be self-contained')}" ${promptRequired ? 'required' : ''}>${esc(prompt || '')}</textarea>
+          ${promptHint}
         </div>
         <div class="detail-form-row">
           <label for="cronFormDeliver">${esc(t('cron_deliver_label') || 'Deliver output to')}</label>
@@ -825,12 +832,14 @@ async function saveCronForm(){
   const prompt=promptEl.value.trim();
   const deliver=delivEl?delivEl.value:'local';
   const profile=profileEl?profileEl.value:'';
+  const isNoAgent = !!(_editingCronId && _cronPreFormDetail && _cronPreFormDetail.no_agent);
   errEl.style.display='none';
   if(!schedule){errEl.textContent=t('cron_schedule_required_example');errEl.style.display='';return;}
-  if(!prompt){errEl.textContent=t('cron_prompt_required');errEl.style.display='';return;}
+  if(!isNoAgent&&!prompt){errEl.textContent=t('cron_prompt_required');errEl.style.display='';return;}
   try{
     if (_editingCronId) {
-      const updates = {job_id: _editingCronId, schedule, prompt, profile: profile};
+      const updates = {job_id: _editingCronId, schedule, profile: profile};
+      if(!isNoAgent) updates.prompt = prompt;
       if (name) updates.name = name;
       await api('/api/crons/update', {method:'POST', body: JSON.stringify(updates)});
       const editedId = _editingCronId;

--- a/tests/test_issue1820_cron_no_agent_edit.py
+++ b/tests/test_issue1820_cron_no_agent_edit.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+
+
+PANELS_JS = (Path(__file__).resolve().parents[1] / "static" / "panels.js").read_text(encoding="utf-8")
+
+
+def test_cron_edit_plumbs_no_agent_and_script_into_form():
+    """Editing no-agent jobs needs their mode metadata in the form renderer."""
+    open_edit_start = PANELS_JS.index("function openCronEdit(job)")
+    render_call = PANELS_JS.index("_renderCronForm({", open_edit_start)
+    render_call_end = PANELS_JS.index("});", render_call)
+    render_call_src = PANELS_JS[render_call:render_call_end]
+
+    assert "noAgent:" in render_call_src
+    assert "job.no_agent" in render_call_src
+    assert "script:" in render_call_src
+    assert "job.script" in render_call_src
+
+
+def test_cron_prompt_required_only_for_agent_jobs():
+    """No-agent cron jobs run scripts directly, so prompt validation must be skipped."""
+    render_form_start = PANELS_JS.index("function _renderCronForm")
+    save_start = PANELS_JS.index("async function saveCronForm()")
+    render_form_src = PANELS_JS[render_form_start:save_start]
+    save_src = PANELS_JS[save_start:PANELS_JS.index("// Back-compat aliases", save_start)]
+
+    assert "noAgent" in render_form_src
+    assert "cronFormPrompt" in render_form_src
+    assert "promptRequired ? 'required' : ''" in render_form_src
+    assert "const isNoAgent" in save_src
+    assert "_editingCronId &&" in save_src
+    assert "if(!isNoAgent&&!prompt)" in save_src.replace(" ", "")
+
+
+def test_cron_update_does_not_overwrite_prompt_for_no_agent_jobs():
+    """Editing schedule/name/profile for no-agent jobs should leave prompt untouched."""
+    save_start = PANELS_JS.index("async function saveCronForm()")
+    save_src = PANELS_JS[save_start:PANELS_JS.index("// Back-compat aliases", save_start)]
+
+    assert "if(!isNoAgent)updates.prompt=prompt" in save_src.replace(" ", "")
+    assert "isNoAgent" in save_src


### PR DESCRIPTION
## Summary
- allow editing existing no-agent cron jobs without requiring a prompt
- pass `no_agent` / `script` into the cron edit form and show a no-agent hint
- avoid overwriting the prompt field when saving no-agent cron edits

## Root cause
The cron editor treated every job as an agent-driven job. The prompt textarea was always rendered as `required`, `saveCronForm()` always rejected an empty prompt, and the update payload always included `prompt`, even though no-agent cron jobs run scripts directly and do not use prompts.

## Related reconnaissance
- Fixes #1820
- Checked open PRs for overlap with #1820 / no-agent cron edits: none found.
- This is a WebUI-only validation/rendering fix; the agent-side cron contract already supports `no_agent=True` with a script and empty prompt.

## Test plan
- `node --check static/panels.js`
- `python3 -m pytest tests/test_issue1820_cron_no_agent_edit.py tests/test_cron_refresh_button_835.py tests/test_cron_needs_attention.py -q` -> 13 passed
- Static scan of added lines: 0 findings
- Independent blocker review: passed
