### PR TITLE
fix: add cdn.jsdelivr.net to CSP connect-src to allow xterm source map fetches

### DIFF
--- a/api/helpers.py
+++ b/api/helpers.py
@@ -46,7 +46,7 @@ def _security_headers(handler):
         "default-src 'self' https://*.cloudflareaccess.com; "
         "script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://static.cloudflareinsights.com; "
         "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://fonts.googleapis.com; "
-        "img-src 'self' data: https: blob:; font-src 'self' data: https://cdn.jsdelivr.net https://fonts.gstatic.com; connect-src 'self'; "
+        "img-src 'self' data: https: blob:; font-src 'self' data: https://cdn.jsdelivr.net https://fonts.gstatic.com; connect-src 'self' https://cdn.jsdelivr.net; "
         "manifest-src 'self' https://*.cloudflareaccess.com; "
         "base-uri 'self'; form-action 'self'"
     )

--- a/tests/test_issue1850_csp_connect_src_jsdelivr.py
+++ b/tests/test_issue1850_csp_connect_src_jsdelivr.py
@@ -6,11 +6,13 @@ jsDelivr and are fetched via connect (not script load), so connect-src must
 include cdn.jsdelivr.net or browsers block the fetch and emit CSP violations.
 """
 import re
+from pathlib import Path
+
+_HELPERS_PY = Path(__file__).resolve().parents[1] / "api/helpers.py"
 
 
 def _helpers_src() -> str:
-    with open("api/helpers.py") as f:
-        return f.read()
+    return _HELPERS_PY.read_text()
 
 
 class TestCSPConnectSrcJsdelivr:

--- a/tests/test_issue1850_csp_connect_src_jsdelivr.py
+++ b/tests/test_issue1850_csp_connect_src_jsdelivr.py
@@ -1,0 +1,36 @@
+"""Regression test for #1850 — CSP connect-src must allow cdn.jsdelivr.net.
+
+xterm.js, xterm-addon-fit, and xterm-addon-web-links are loaded from
+cdn.jsdelivr.net via <script> tags. Their bundled source maps also live on
+jsDelivr and are fetched via connect (not script load), so connect-src must
+include cdn.jsdelivr.net or browsers block the fetch and emit CSP violations.
+"""
+import re
+
+
+def _helpers_src() -> str:
+    with open("api/helpers.py") as f:
+        return f.read()
+
+
+class TestCSPConnectSrcJsdelivr:
+    """connect-src must allow cdn.jsdelivr.net for xterm source map fetches."""
+
+    def test_connect_src_includes_jsdelivr(self):
+        """connect-src must include https://cdn.jsdelivr.net."""
+        src = _helpers_src()
+        connect_match = re.search(r"connect-src\s+([^;]+);", src)
+        assert connect_match, "connect-src directive must exist in CSP"
+        assert "https://cdn.jsdelivr.net" in connect_match.group(1), (
+            "connect-src must allow cdn.jsdelivr.net — xterm.js source maps are "
+            "fetched from that origin and the CSP blocks them without this entry"
+        )
+
+    def test_connect_src_still_includes_self(self):
+        """connect-src must still include 'self' alongside the new jsdelivr entry."""
+        src = _helpers_src()
+        connect_match = re.search(r"connect-src\s+([^;]+);", src)
+        assert connect_match, "connect-src directive must exist in CSP"
+        assert "'self'" in connect_match.group(1), (
+            "connect-src must retain 'self' after adding cdn.jsdelivr.net"
+        )


### PR DESCRIPTION
Closes #1850

## Thinking Path

DevTools console showed three CSP violations on every page load:

```
Connecting to 'https://cdn.jsdelivr.net/npm/xterm@5.3.0/lib/xterm.js.map'
violates Content Security Policy directive: "connect-src 'self'".

Connecting to 'https://cdn.jsdelivr.net/npm/xterm-addon-fit@0.8.0/lib/xterm-addon-fit.js.map'
violates Content Security Policy directive: "connect-src 'self'".

Connecting to 'https://cdn.jsdelivr.net/npm/xterm-addon-web-links@0.9.0/lib/xterm-addon-web-links.js.map'
violates Content Security Policy directive: "connect-src 'self'".
```

Traced them to `api/helpers.py`: `script-src` already allows `cdn.jsdelivr.net` for the xterm family, but `connect-src` was `'self'`-only. Source maps embedded in CDN-hosted scripts are fetched via the connect mechanism (not a script load), so they fall under `connect-src`, not `script-src`. Adding `cdn.jsdelivr.net` to `connect-src` aligns it with `script-src`, `style-src`, and `font-src`, which already allow that origin.

## What Changed

**`api/helpers.py`** — one addition to the `connect-src` directive:

```diff
-"... connect-src 'self'; ..."
+"... connect-src 'self' https://cdn.jsdelivr.net; ..."
```

**`tests/test_issue1850_csp_connect_src_jsdelivr.py`** — new regression test, following the pattern of `test_issue1112_csp_google_fonts.py`:

- Asserts `connect-src` includes `https://cdn.jsdelivr.net`
- Asserts `connect-src` still retains `'self'`

## Why It Matters

Every developer who opens DevTools sees three CSP violation errors on every page load. These clutter the console and can mask real errors. The fix does not widen the effective security boundary — `cdn.jsdelivr.net` is already trusted for scripts, styles, and fonts.

## Verification

```bash
pytest tests/test_issue1850_csp_connect_src_jsdelivr.py \
       tests/test_issue1112_csp_google_fonts.py \
       tests/test_pwa_manifest_csp.py -v
```

All 8 tests pass. Manually: open the WebUI with DevTools — the three CSP violation messages are gone.

## Risks / Follow-ups

Minimal. `cdn.jsdelivr.net` is already in `script-src`, `style-src`, and `font-src`. Adding it to `connect-src` is consistent and does not grant new capabilities to untrusted origins. Source map fetches carry no credentials and expose no user data.

## Model Used

Provider: Anthropic  
Model: claude-sonnet-4-6  
Mode: Claude Code CLI (agentic) — used to identify the root cause, propose the fix, write the regression test, and author this PR.