### PR TITLE
Stage 316: 3-PR batch — P0 markdown streaming hotfix + CSP source-map allowance + LaTeX delimiter rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Hermes Web UI -- Changelog
 
+## [v0.51.22] — 2026-05-07 — 3-PR batch (P0 markdown streaming hotfix + CSP source-map allowance + LaTeX delimiter rendering)
+
+### Fixed (3 PRs)
+
+- **PR #1851** by @ChaseFlorell — **P0 hotfix**: ES module import for `static/vendor/smd.min.js` used a bare specifier (`import * as smd from 'static/vendor/smd.min.js'`) which the [HTML spec](https://html.spec.whatwg.org/multipage/webappapis.html#resolve-a-module-specifier) rejects — relative ES module references must start with `/`, `./`, or `../`. Result: the entire `<script type="module">` block in `static/index.html` failed silently, `window.smd` was never set, and live token-by-token markdown streaming was broken for all users since the streaming-markdown library landed. Fix: change `'static/vendor/smd.min.js'` → `'/static/vendor/smd.min.js'`. 1-LOC change. Browser-verified post-fix: `typeof window.smd === 'object'` with all expected exports (BLOCKQUOTE, CODE_FENCE, EQUATION_BLOCK, etc.). Closes #1849.
+
+- **PR #1852** by @ChaseFlorell — CSP `connect-src 'self'` blocked DevTools-initiated fetches of source maps for the three xterm.js libraries (xterm@5.3.0, xterm-addon-fit@0.8.0, xterm-addon-web-links@0.9.0) loaded from `cdn.jsdelivr.net`. The script tags loaded fine (covered by `script-src https://cdn.jsdelivr.net`), but `.js.map` files are fetched via `connect` and got blocked, emitting CSP violation errors in the console whenever DevTools was open. Fix: add `https://cdn.jsdelivr.net` to `connect-src` in `api/helpers.py:_security_headers()`, alongside the existing `'self'`. Consistent with the existing jsDelivr allowlist on `script-src`/`style-src`/`font-src`. New regression test `test_issue1850_csp_connect_src_jsdelivr.py` pins both the new entry and that `'self'` is preserved. Closes #1850.
+
+- **PR #1848** by @Michaelyklam — Backslash LaTeX delimiters (`\[...\]` for display, `\(...\)` for inline) didn't render through the KaTeX pipeline. The renderer already supported `$$...$$` / `$...$`, but the prior regex for `\\(...\\)` / `\\[...\\]` required a *double* backslash, which is the JavaScript-source escape form, not the form LLMs actually emit in chat content. Result: multi-line display math from real assistant output appeared as raw `\[ ... \]` text with `<br>` line breaks instead of a centered KaTeX block. Fix in `static/ui.js`: math-stash regex relaxed to single backslashes, and the user-bubble path (`_renderUserFencedBlocks`) gets its own pre-escape math stash so backslash delimiters survive `esc()` instead of being HTML-escaped to `&#92;`. Test `test_backslash_latex_delimiters_render_to_katex_placeholders` runs the assistant and user pipelines via Node and asserts no raw delimiter leakage in either rendered output. Closes #1847.
+
+### Maintainer-side absorption
+
+- **`tests/test_streaming_markdown.py` + `tests/test_subpath_frontend_routes.py`** — tightened the smd-import-shape assertions to require the `./` relative form and forbid BOTH bare specifier (broken by ES spec, #1849) AND root-absolute (breaks `/hermes/` subpath mounts). The original tests only forbade root-absolute, which let the bare-specifier regression land unnoticed in the first place. PR #1851's original fix used the root-absolute form (which would have re-broken subpath deployments); the corrected `./` form satisfies both constraints. Subpath safety verified: `new URL('./static/vendor/smd.min.js', 'http://host/hermes/').href === 'http://host/hermes/static/vendor/smd.min.js'`.
+
+### Tests
+
+4810 → **4815 collected** (+5). Three new from #1848 augmenting `test_issue347.py` (Node-driven `_run_renderers()` harness for assistant + user pipelines), two new in `test_issue1850_csp_connect_src_jsdelivr.py`. **4788 passed, 0 failed**, 4 skipped, 3 xpassed in 142s.
+
+### Pre-release verification
+
+- `pytest tests/` — green
+- Live browser-verified at port 8789 against stage-316:
+  - `window.smd` resolves to streaming-markdown module (PR #1851)
+  - `Content-Security-Policy: ...connect-src 'self' https://cdn.jsdelivr.net...` in served headers (PR #1852)
+  - `renderMd()` produces `<div class="katex-block">` for `\[...\]` and `<span class="katex-inline">` for `\(...\)` with no raw delimiter leakage (PR #1848)
+
 ## [v0.51.21] — 2026-05-07 — 3-PR batch (P0 hotfix + auto-compression UI + shell route HTML fallback)
 
 ### Fixed (3 PRs)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,13 @@
 
 - **`tests/test_streaming_markdown.py` + `tests/test_subpath_frontend_routes.py`** — tightened the smd-import-shape assertions to require the `./` relative form and forbid BOTH bare specifier (broken by ES spec, #1849) AND root-absolute (breaks `/hermes/` subpath mounts). The original tests only forbade root-absolute, which let the bare-specifier regression land unnoticed in the first place. PR #1851's original fix used the root-absolute form (which would have re-broken subpath deployments); the corrected `./` form satisfies both constraints. Subpath safety verified: `new URL('./static/vendor/smd.min.js', 'http://host/hermes/').href === 'http://host/hermes/static/vendor/smd.min.js'`.
 
+- **`static/ui.js` + `tests/test_issue347.py`** (commit `d703959` by @nesquena, opus-4.7-paired) — fix code-fence-vs-math stash ordering in `_renderUserFencedBlocks`. PR #1848 added a math stash to the user-bubble path so backslash LaTeX delimiters survive `esc()` and reach KaTeX, but the math stash ran BEFORE the existing code-fence stash. Result: a user-typed code block containing LaTeX-like syntax (e.g. `` ``` ``\n`\[ a + b \]`\n`` ``` ``) had its math content extracted as KaTeX and rendered as a `<div class="katex-block">` placeholder INSIDE `<pre><code>`, replacing the user's literal source with rendered math. The assistant path (`renderMd()`) had the correct ordering already; the user-bubble path inherited the mistake from the inverted stash order. Fix reorders fences-first, then math, mirroring `renderMd()`. Two regression tests added: one fails pre-fix and asserts no KaTeX wrappers inside `<pre><code>`, one is a sibling guard against an over-correction that would disable user-bubble math entirely.
+
+- **`tests/test_issue1850_csp_connect_src_jsdelivr.py`** (absorbed from PR #1852 follow-up by @ChaseFlorell) — switched to `Path(__file__).resolve().parents[1]` rooting so the test survives being run from a non-repo-root cwd. Matches the pattern in `test_issue1112_csp_google_fonts.py`.
+
 ### Tests
 
-4810 → **4815 collected** (+5). Three new from #1848 augmenting `test_issue347.py` (Node-driven `_run_renderers()` harness for assistant + user pipelines), two new in `test_issue1850_csp_connect_src_jsdelivr.py`. **4788 passed, 0 failed**, 4 skipped, 3 xpassed in 142s.
+4810 → **4817 collected** (+7). Three from #1848 augmenting `test_issue347.py` (Node-driven `_run_renderers()` harness for assistant + user pipelines), two new in `test_issue1850_csp_connect_src_jsdelivr.py`, two from the d703959 user-bubble code-fence-vs-math ordering fix.
 
 ### Pre-release verification
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 > Web companion to the Hermes Agent CLI. Same workflows, browser-native.
 >
-> Last updated: v0.51.21 (May 7, 2026) — 4810 tests collected — 3-PR batch (P0 hotfix for v0.51.20 #1828 double-404 regression, auto-compression running indicator, shell route HTML fallback)
+> Last updated: v0.51.22 (May 7, 2026) — 4815 tests collected — 3-PR batch (P0 markdown streaming hotfix, CSP source-map allowance, LaTeX delimiter rendering)
 > Test source: `pytest tests/ --collect-only -q`
 > Per-version detail: see [CHANGELOG.md](./CHANGELOG.md)
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -1835,8 +1835,8 @@ Bridged CLI sessions:
 
 ---
 
-*Last updated: v0.51.21, May 7, 2026*
-*Total automated tests collected: 4810*
+*Last updated: v0.51.22, May 7, 2026*
+*Total automated tests collected: 4815*
 *Regression gate: tests/test_regressions.py*
 *Run: pytest tests/ -v --timeout=60*
 *Source: <repo>/*

--- a/TESTING.md
+++ b/TESTING.md
@@ -1836,7 +1836,7 @@ Bridged CLI sessions:
 ---
 
 *Last updated: v0.51.22, May 7, 2026*
-*Total automated tests collected: 4815*
+*Total automated tests collected: 4817*
 *Regression gate: tests/test_regressions.py*
 *Run: pytest tests/ -v --timeout=60*
 *Source: <repo>/*

--- a/api/helpers.py
+++ b/api/helpers.py
@@ -46,7 +46,7 @@ def _security_headers(handler):
         "default-src 'self' https://*.cloudflareaccess.com; "
         "script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://static.cloudflareinsights.com; "
         "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://fonts.googleapis.com; "
-        "img-src 'self' data: https: blob:; font-src 'self' data: https://cdn.jsdelivr.net https://fonts.gstatic.com; connect-src 'self'; "
+        "img-src 'self' data: https: blob:; font-src 'self' data: https://cdn.jsdelivr.net https://fonts.gstatic.com; connect-src 'self' https://cdn.jsdelivr.net; "
         "manifest-src 'self' https://*.cloudflareaccess.com; "
         "base-uri 'self'; form-action 'self'"
     )

--- a/static/index.html
+++ b/static/index.html
@@ -33,7 +33,7 @@
   <!-- ES module imports do not support the integrity= attribute (W3C limitation);    -->
   <!-- version is pinned in the vendored file path; hash documented above for audit. -->
   <script type="module">
-    import * as smd from 'static/vendor/smd.min.js';
+    import * as smd from './static/vendor/smd.min.js';
     // SRI verification happens at the ES module level via importmap or SW; pinning version in URL.
     // sha384 of smd.min.js @0.2.15: sha384-T6r95ocN9t3W8tUK2Fa6FPaO7bJryyjyW0WCalrUnpgtm2qXr5xcN4vwPYEJ6vHa
     window.smd = smd;

--- a/static/ui.js
+++ b/static/ui.js
@@ -72,7 +72,20 @@ function _stripWorkspaceDisplayPrefix(text){
 }
 function _renderUserFencedBlocks(text){
   const stash=[];
+  const mathStash=[];
+  const stashMath=(type,src)=>{mathStash.push({type,src});return '\x00UM'+(mathStash.length-1)+'\x00';};
+  const restoreMath=html=>String(html||'').replace(/\x00UM(\d+)\x00/g,(_,i)=>{
+    const item=mathStash[+i];
+    if(!item) return '';
+    if(item.type==='display') return `<div class="katex-block" data-katex="display">${esc(item.src)}</div>`;
+    return `<span class="katex-inline" data-katex="inline">${esc(item.src)}</span>`;
+  });
   let s=String(text||'');
+  // Stash math before escaping plain text; display delimiters must run before inline.
+  s=s.replace(/\$\$([\s\S]+?)\$\$/g,(_,m)=>stashMath('display',m));
+  s=s.replace(/\\\[([\s\S]+?)\\\]/g,(_,m)=>stashMath('display',m));
+  s=s.replace(/\$([^\s$\n][^$\n]*?[^\s$\n]|\S)\$/g,(_,m)=>stashMath('inline',m));
+  s=s.replace(/\\\((.+?)\\\)/g,(_,m)=>stashMath('inline',m));
   // Extract fenced code blocks → stash, replace with null-token placeholder
   // CommonMark §4.5 line-anchored fence: the closing run must use at least
   // as many backticks as the opener, so inner triple-backtick fences remain content.
@@ -100,8 +113,9 @@ function _renderUserFencedBlocks(text){
   });
   // Escape remaining plain text and convert newlines to <br>
   s=esc(s).replace(/\n/g,'<br>');
-  // Restore stashed code blocks
+  // Restore stashed code blocks, then math placeholders as KaTeX targets.
   s=s.replace(/\x00UF(\d+)\x00/g,(_,i)=>stash[+i]);
+  s=restoreMath(s);
   return s;
 }
 function _statusCardHtml(card){
@@ -2076,14 +2090,16 @@ function renderMd(raw){
   // Math stash: protect $$..$$ and $..$ from markdown processing
   // Runs AFTER fence_stash so backtick code spans protect their dollar-sign contents
   const math_stash=[];
-  // Display math: $$...$$  (must come before inline to avoid mis-parsing)
+  // Display math: $$...$$ and \[...\] (must come before inline to avoid mis-parsing)
   s=s.replace(/\$\$([\s\S]+?)\$\$/g,(_,m)=>{math_stash.push({type:'display',src:m});return '\x00M'+(math_stash.length-1)+'\x00';});
+  // Match a single literal backslash before the display delimiter (the common LLM form).
+  s=s.replace(/\\\[([\s\S]+?)\\\]/g,(_,m)=>{math_stash.push({type:'display',src:m});return '\x00M'+(math_stash.length-1)+'\x00';});
   // Inline math: $...$ — require non-space at boundaries to avoid false positives
   // e.g. "costs $5 and $10" should not trigger (space after opening $)
   s=s.replace(/\$([^\s$\n][^$\n]*?[^\s$\n]|\S)\$/g,(_,m)=>{math_stash.push({type:'inline',src:m});return '\x00M'+(math_stash.length-1)+'\x00';});
-  // Also stash \(...\) and \[...\] LaTeX delimiters
-  s=s.replace(/\\\\\((.+?)\\\\\)/g,(_,m)=>{math_stash.push({type:'inline',src:m});return '\x00M'+(math_stash.length-1)+'\x00';});
-  s=s.replace(/\\\\\[(.+?)\\\\\]/gs,(_,m)=>{math_stash.push({type:'display',src:m});return '\x00M'+(math_stash.length-1)+'\x00';});
+  // Also stash \(...\) LaTeX delimiters.
+  // Match a single literal backslash before the delimiter (the common LLM form).
+  s=s.replace(/\\\((.+?)\\\)/g,(_,m)=>{math_stash.push({type:'inline',src:m});return '\x00M'+(math_stash.length-1)+'\x00';});
   // Safe tag → markdown equivalent (these produce the same output as **text** etc.)
   // Stash raw <pre> blocks so the inline <code> rewrite below does not run
   // inside them. Running that rewrite in <pre> content can introduce stray

--- a/static/ui.js
+++ b/static/ui.js
@@ -81,12 +81,10 @@ function _renderUserFencedBlocks(text){
     return `<span class="katex-inline" data-katex="inline">${esc(item.src)}</span>`;
   });
   let s=String(text||'');
-  // Stash math before escaping plain text; display delimiters must run before inline.
-  s=s.replace(/\$\$([\s\S]+?)\$\$/g,(_,m)=>stashMath('display',m));
-  s=s.replace(/\\\[([\s\S]+?)\\\]/g,(_,m)=>stashMath('display',m));
-  s=s.replace(/\$([^\s$\n][^$\n]*?[^\s$\n]|\S)\$/g,(_,m)=>stashMath('inline',m));
-  s=s.replace(/\\\((.+?)\\\)/g,(_,m)=>stashMath('inline',m));
-  // Extract fenced code blocks → stash, replace with null-token placeholder
+  // Extract fenced code blocks FIRST so math regexes never run inside fenced
+  // content. If math were stashed first, a user-typed code block containing
+  // \[..\] / \(..\) / $$..$$ would be rendered as a KaTeX block inside
+  // <pre><code> instead of as literal source. Mirrors renderMd()'s ordering.
   // CommonMark §4.5 line-anchored fence: the closing run must use at least
   // as many backticks as the opener, so inner triple-backtick fences remain content.
   s=s.replace(/(^|\n)[ ]{0,3}(`{3,})([^\n`]*)\n(?:([\s\S]*?)\n)?[ ]{0,3}\2`*[ \t]*(?=\n|$)/g,(_,lead,_fence,info,code)=>{
@@ -111,6 +109,12 @@ function _renderUserFencedBlocks(text){
     }
     return lead+'\x00UF'+(stash.length-1)+'\x00';
   });
+  // Now stash math from the OUTSIDE-of-fence text. Display delimiters must
+  // run before inline so $$..$$ isn't mis-parsed as $..$..$..$.
+  s=s.replace(/\$\$([\s\S]+?)\$\$/g,(_,m)=>stashMath('display',m));
+  s=s.replace(/\\\[([\s\S]+?)\\\]/g,(_,m)=>stashMath('display',m));
+  s=s.replace(/\$([^\s$\n][^$\n]*?[^\s$\n]|\S)\$/g,(_,m)=>stashMath('inline',m));
+  s=s.replace(/\\\((.+?)\\\)/g,(_,m)=>stashMath('inline',m));
   // Escape remaining plain text and convert newlines to <br>
   s=esc(s).replace(/\n/g,'<br>');
   // Restore stashed code blocks, then math placeholders as KaTeX targets.

--- a/tests/test_issue1850_csp_connect_src_jsdelivr.py
+++ b/tests/test_issue1850_csp_connect_src_jsdelivr.py
@@ -6,11 +6,13 @@ jsDelivr and are fetched via connect (not script load), so connect-src must
 include cdn.jsdelivr.net or browsers block the fetch and emit CSP violations.
 """
 import re
+from pathlib import Path
+
+_HELPERS_PY = Path(__file__).resolve().parents[1] / "api/helpers.py"
 
 
 def _helpers_src() -> str:
-    with open("api/helpers.py") as f:
-        return f.read()
+    return _HELPERS_PY.read_text()
 
 
 class TestCSPConnectSrcJsdelivr:

--- a/tests/test_issue1850_csp_connect_src_jsdelivr.py
+++ b/tests/test_issue1850_csp_connect_src_jsdelivr.py
@@ -1,0 +1,36 @@
+"""Regression test for #1850 — CSP connect-src must allow cdn.jsdelivr.net.
+
+xterm.js, xterm-addon-fit, and xterm-addon-web-links are loaded from
+cdn.jsdelivr.net via <script> tags. Their bundled source maps also live on
+jsDelivr and are fetched via connect (not script load), so connect-src must
+include cdn.jsdelivr.net or browsers block the fetch and emit CSP violations.
+"""
+import re
+
+
+def _helpers_src() -> str:
+    with open("api/helpers.py") as f:
+        return f.read()
+
+
+class TestCSPConnectSrcJsdelivr:
+    """connect-src must allow cdn.jsdelivr.net for xterm source map fetches."""
+
+    def test_connect_src_includes_jsdelivr(self):
+        """connect-src must include https://cdn.jsdelivr.net."""
+        src = _helpers_src()
+        connect_match = re.search(r"connect-src\s+([^;]+);", src)
+        assert connect_match, "connect-src directive must exist in CSP"
+        assert "https://cdn.jsdelivr.net" in connect_match.group(1), (
+            "connect-src must allow cdn.jsdelivr.net — xterm.js source maps are "
+            "fetched from that origin and the CSP blocks them without this entry"
+        )
+
+    def test_connect_src_still_includes_self(self):
+        """connect-src must still include 'self' alongside the new jsdelivr entry."""
+        src = _helpers_src()
+        connect_match = re.search(r"connect-src\s+([^;]+);", src)
+        assert connect_match, "connect-src directive must exist in CSP"
+        assert "'self'" in connect_match.group(1), (
+            "connect-src must retain 'self' after adding cdn.jsdelivr.net"
+        )

--- a/tests/test_issue347.py
+++ b/tests/test_issue347.py
@@ -10,13 +10,71 @@ Structural tests — no server required. Verify:
 - SAFE_TAGS updated to allow <span> (for inline math)
 - renderKatexBlocks() is wired into the requestAnimationFrame call
 """
+import json
 import pathlib
 import re
+import subprocess
+import textwrap
 
 REPO = pathlib.Path(__file__).parent.parent
 UI_JS   = (REPO / 'static' / 'ui.js').read_text(encoding='utf-8')
 INDEX   = (REPO / 'static' / 'index.html').read_text(encoding='utf-8')
 CSS     = (REPO / 'static' / 'style.css').read_text(encoding='utf-8')
+
+
+def _extract_function(src: str, name: str) -> str:
+    marker = f"function {name}("
+    start = src.index(marker)
+    brace = src.index("{", start)
+    depth = 1
+    pos = brace + 1
+    while depth and pos < len(src):
+        ch = src[pos]
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+        pos += 1
+    assert depth == 0, f"could not extract {name}()"
+    return src[start:pos]
+
+
+def _run_renderers(markdown: str) -> dict:
+    js = textwrap.dedent(
+        r'''
+        const esc=s=>String(s??'').replace(/[&<>"']/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
+        const _IMAGE_EXTS=/\.(png|jpg|jpeg|gif|webp|bmp|ico|avif)$/i;
+        const _PDF_EXTS=/\.pdf$/i;
+        const _SVG_EXTS=/\.svg$/i;
+        const _AUDIO_EXTS=/\.(mp3|ogg|wav|m4a|aac|flac|wma|opus|webm|oga)$/i;
+        const _VIDEO_EXTS=/\.(mp4|webm|mkv|mov|avi|ogv|m4v)$/i;
+        function t(k){ return k; }
+        function _mediaPlayerHtml(){ return ''; }
+        global.document={baseURI:'http://example.test/'};
+        '''
+    )
+    js += "\n" + _extract_function(UI_JS, "_matchBacktickFenceLine")
+    js += "\n" + _extract_function(UI_JS, "_isBacktickFenceClose")
+    js += "\n" + _extract_function(UI_JS, "_renderUserFencedBlocks")
+    js += "\n" + _extract_function(UI_JS, "renderMd")
+    js += textwrap.dedent(
+        r'''
+        const input=process.argv[1];
+        console.log(JSON.stringify({
+          assistant: renderMd(input),
+          user: _renderUserFencedBlocks(input),
+        }));
+        '''
+    )
+    proc = subprocess.run(
+        ["node", "-e", js, markdown],
+        cwd=REPO,
+        text=True,
+        capture_output=True,
+        timeout=30,
+        check=True,
+    )
+    return json.loads(proc.stdout)
 
 
 # ── renderMd pipeline ──────────────────────────────────────────────────────────
@@ -39,6 +97,22 @@ def test_katex_block_placeholder_emitted():
     """renderMd restore pass must emit .katex-block divs for display math."""
     assert 'katex-block' in UI_JS, \
         '.katex-block placeholder div not emitted by renderMd restore pass'
+
+
+def test_backslash_latex_delimiters_render_to_katex_placeholders():
+    """Common LLM LaTeX delimiters \\[...\\] and \\(...\\) render in assistant and user bubbles."""
+    sample = """\\[
+\\text{SoundPower}(f)=10\\log_{10}(x)
+\\]
+
+where \\(L_i(f)\\) = SPL at angle \\(i\\)."""
+    rendered = _run_renderers(sample)
+    for role in ("assistant", "user"):
+        html = rendered[role]
+        assert 'class="katex-block" data-katex="display"' in html, html
+        assert 'class="katex-inline" data-katex="inline"' in html, html
+        assert "\\[" not in html and "\\]" not in html, html
+        assert "\\(" not in html and "\\)" not in html, html
 
 
 def test_katex_inline_placeholder_emitted():

--- a/tests/test_issue347.py
+++ b/tests/test_issue347.py
@@ -115,6 +115,41 @@ where \\(L_i(f)\\) = SPL at angle \\(i\\)."""
         assert "\\(" not in html and "\\)" not in html, html
 
 
+def test_user_code_block_with_latex_syntax_renders_as_literal_code():
+    """User-bubble code blocks containing \\[..\\] / \\(..\\) / $$..$$ must
+    render as literal code source, not as KaTeX. _renderUserFencedBlocks
+    must stash code fences BEFORE math (mirroring renderMd's ordering); if
+    math is stashed first, a user-typed code block containing LaTeX-like
+    syntax gets a `<div class="katex-block">` placeholder dropped INSIDE
+    `<pre><code>`, and the user's literal source is silently replaced by
+    rendered math.
+    """
+    sample = "```\n\\[ a + b \\] is wrong\n\\(L_i\\) too\n$$matrix$$\n```"
+    rendered = _run_renderers(sample)
+    user_html = rendered["user"]
+    # The whole code block should remain literal, no KaTeX wrappers inside.
+    assert "<pre><code>" in user_html, user_html
+    assert "katex-block" not in user_html, user_html
+    assert "katex-inline" not in user_html, user_html
+    # Backslashes survive HTML escape unchanged; the user's source is intact.
+    assert "\\[ a + b \\]" in user_html, user_html
+    assert "\\(L_i\\)" in user_html, user_html
+    assert "$$matrix$$" in user_html, user_html
+
+
+def test_user_bubble_top_level_latex_still_renders_after_fence_reorder():
+    """Sibling regression: top-level math (outside any code fence) must
+    still render through KaTeX in user bubbles after the fence-first
+    reorder. Guards against an over-correction that disables user-bubble
+    math rendering entirely.
+    """
+    sample = "math: \\[ x + y \\]\n\nand inline \\(L_i\\)"
+    rendered = _run_renderers(sample)
+    user_html = rendered["user"]
+    assert 'class="katex-block" data-katex="display"' in user_html, user_html
+    assert 'class="katex-inline" data-katex="inline"' in user_html, user_html
+
+
 def test_katex_inline_placeholder_emitted():
     """renderMd restore pass must emit .katex-inline spans for inline math."""
     assert 'katex-inline' in UI_JS, \

--- a/tests/test_streaming_markdown.py
+++ b/tests/test_streaming_markdown.py
@@ -108,9 +108,21 @@ class TestIndexHtmlSmdScript:
         )
 
     def test_smd_vendor_import_is_mount_agnostic(self):
-        assert "static/vendor/smd.min.js" in INDEX_HTML, (
-            "index.html must load the vendored streaming-markdown module"
+        """Import must resolve relative to current document, not a bare
+        specifier (rejected by ES module spec, #1849) and not root-absolute
+        (escapes /hermes/-style subpath mounts). The `./` form is the only
+        shape that satisfies both: ES-spec-valid AND mount-agnostic.
+        """
+        assert "from './static/vendor/smd.min.js'" in INDEX_HTML, (
+            "index.html must use the './static/vendor/smd.min.js' form — "
+            "bare specifiers are rejected by the ES module spec (#1849) and "
+            "leading-/ paths break subpath deployments such as /hermes/"
         )
+        # Forbid the bare form (#1849 broke streaming-markdown silently)
+        assert "import * as smd from 'static/vendor/smd.min.js'" not in INDEX_HTML, (
+            "bare specifier is rejected by the ES module spec — use './static/...'"
+        )
+        # Forbid the root-absolute form (subpath deployments escape the mount)
         assert "from '/static/vendor/smd.min.js'" not in INDEX_HTML, (
             "streaming-markdown import must not be root-absolute; root-absolute "
             "static paths break subpath deployments such as /hermes/"

--- a/tests/test_subpath_frontend_routes.py
+++ b/tests/test_subpath_frontend_routes.py
@@ -56,6 +56,15 @@ def test_direct_frontend_event_sources_are_relative_to_current_mount():
 
 
 def test_static_vendor_import_is_relative_to_current_mount():
+    """Import must use `./static/vendor/smd.min.js` form so the URL resolves
+    relative to the document URL. Bare specifier (no leading `./` or `/`)
+    is invalid per ES module spec and breaks markdown streaming silently
+    (#1849). Root-absolute (`/static/...`) escapes subpath mounts like
+    `/hermes/`. The `./` form satisfies both constraints.
+    """
     src = read("static/index.html")
-    assert "import * as smd from 'static/vendor/smd.min.js'" in src
+    assert "import * as smd from './static/vendor/smd.min.js'" in src
+    # Bare specifier — broken per ES module spec (#1849)
+    assert "import * as smd from 'static/vendor/smd.min.js'" not in src
+    # Root-absolute — breaks /hermes/ subpath mounts
     assert "import * as smd from '/static/vendor/smd.min.js'" not in src


### PR DESCRIPTION
## Summary

3-PR contributor batch — P0 markdown streaming hotfix + CSP source-map allowance + LaTeX backslash delimiter rendering. Plus one maintainer-side test absorption that caught a runtime-coexistence trap.

## PRs absorbed

### #1851 by @ChaseFlorell — P0: markdown streaming was silently broken

`import * as smd from 'static/vendor/smd.min.js'` is a bare module specifier. Per the [HTML spec](https://html.spec.whatwg.org/multipage/webappapis.html#resolve-a-module-specifier), relative ES module references must start with `/`, `./`, or `../`. The block was failing silently, `window.smd` was never defined, and live token-by-token markdown streaming was broken for every user.

Closes #1849.

### #1852 by @ChaseFlorell — CSP `connect-src` source-map allowance

`connect-src 'self'` blocked DevTools-initiated fetches of source maps for the three xterm.js libraries loaded from `cdn.jsdelivr.net`. Script tags loaded fine (`script-src` has jsDelivr), but `.js.map` is fetched via `connect`. Adding `https://cdn.jsdelivr.net` to `connect-src` matches the existing allowlist on `script-src`/`style-src`/`font-src`. New regression test pins both the new entry and that `'self'` is preserved.

Closes #1850.

### #1848 by @Michaelyklam — backslash LaTeX delimiters render through KaTeX

`\[...\]` (display) and `\(...\)` (inline) didn't render as math. Renderer already supported `$$...$$` / `$...$`, but the backslash regex required *double* backslash (the JS-source escape form), not the form LLMs actually emit. Fix: relax to single backslash, plus a pre-escape stash in `_renderUserFencedBlocks` so user-bubble path doesn't lose delimiters to `esc()`. Tests run assistant + user pipelines via Node and assert no raw delimiter leakage.

Closes #1847.

## Maintainer-side absorption — runtime-coexistence trap on #1851

PR #1851 as filed used **root-absolute** `/static/vendor/...`. That fixed the bare-specifier bug but **reintroduced a different bug**: two pre-existing tests forbid root-absolute paths because they break subpath deployments like `/hermes/`:
- `test_streaming_markdown.py::test_smd_vendor_import_is_mount_agnostic`
- `test_subpath_frontend_routes.py::test_static_vendor_import_is_relative_to_current_mount`

Pytest caught both regressions immediately on stage. Maintainer-side fix: use `'./static/vendor/smd.min.js'` (the explicit-`./`-relative form). Only shape that satisfies BOTH:
- Has leading `./` → not a bare specifier → ES spec accepts ✓
- No leading `/` → resolves relative to document URL → mount-agnostic ✓

Both tests tightened to require the `./` form and forbid both bare and root-absolute. The original tests only forbade root-absolute, which let the bare-specifier regression land unnoticed in the first place — that's now closed.

Subpath safety verified:
```
new URL('./static/vendor/smd.min.js', 'http://host/hermes/').href
= 'http://host/hermes/static/vendor/smd.min.js'  ✓
```

## Pre-release verification

### Pytest
4810 → **4815 collected** (+5: 3 from #1848 augmenting `test_issue347.py`, 2 from `test_issue1850_csp_connect_src_jsdelivr.py`). **4788 passed, 0 failed**, 4 skipped, 3 xpassed in 142s.

### Live browser at port 8789 against stage-316
- **#1851**: `typeof window.smd === 'object'` with full export list (BLOCKQUOTE, CHECKBOX, CODE_FENCE, CODE_INLINE, EQUATION_BLOCK, ...). Served HTML contains `import * as smd from './static/vendor/smd.min.js'`.
- **#1852**: `Content-Security-Policy: ...connect-src 'self' https://cdn.jsdelivr.net...` in served headers.
- **#1848**: `renderMd('\\[\\int_0^1 x^2\\,dx = \\frac{1}{3}\\]\n\nwhere \\(L_i(f)\\) is SPL.')` produces `<div class="katex-block">` and `<span class="katex-inline">` with no raw `\[`/`\]`/`\(`/`\)` leakage.

### Opus advisor
**Verdict: SHIP.** No MUST-FIX, no SHOULD-FIX. Confirmed:
- `./`-relative is correct under both root and subpath mount configurations
- CSP widening adds zero attacker capability (jsDelivr already in `script-src`, no data sink, KaTeX runs `trust:false`)
- LaTeX regex has no ReDoS, no HTML-escape hole; KaTeX is invoked with safe `trust:false` config

## Tagging for independent review

@nesquena — independent review please. Self-built portion is the test correction (24 LOC tightening assertions on smd import shape) + the `./` path correction in `static/index.html`. Everything else is contributor work absorbed via squash-merge.

Specifically worth a second look:
1. **`'./'` vs `'/'` smd import shape** — does the `./` form work under your `/hermes/` Cloudflare Tunnel mount path? The browser-side `new URL()` resolution says yes, but a real HTTP fetch under the tunnel is the only ground-truth test.
2. **CSP `connect-src` widening** — comfortable with jsDelivr being in `connect-src`, given it's already in `script-src`?
3. **LaTeX regex** — the user-bubble pre-escape stash is new; does it pass smell-check for any escape-fence-confusion risk?

Will hold the merge until you're explicitly approved.

## Composition diff

```
api/helpers.py                                   |  2 +-
static/index.html                                |  2 +-
static/ui.js                                     | 26 +++++++--
tests/test_issue1850_csp_connect_src_jsdelivr.py | 36 ++++++++++++ (new)
tests/test_issue347.py                           | 74 ++++++++++++++++++++++++
tests/test_streaming_markdown.py                 | 16 ++++-
tests/test_subpath_frontend_routes.py            | 11 +++-
CHANGELOG.md                                     | 22 +++++++
ROADMAP.md                                       |  2 +-
TESTING.md                                       |  2 +-
```

Total: 7 source/test files + 3 docs files = 10 files, ~190/-15 LOC.

## What is intentionally NOT in this batch

- **#1814** (custom provider creds) — has `maintainer-review` label; needs rebase against #1818 (already merged) + tests + dedup of slug helpers. Defer to next sprint.
