### PR TITLE
fix: persist generated title refresh marker

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -332,6 +332,7 @@ class Session:
                  context_length=None, threshold_tokens=None,
                  last_prompt_tokens=None,
                  gateway_routing=None, gateway_routing_history=None,
+                 llm_title_generated: bool=False,
                 parent_session_id: str=None,
                 enabled_toolsets=None,
                 **kwargs):
@@ -364,6 +365,7 @@ class Session:
         self.last_prompt_tokens = last_prompt_tokens
         self.gateway_routing = gateway_routing if isinstance(gateway_routing, dict) else None
         self.gateway_routing_history = gateway_routing_history if isinstance(gateway_routing_history, list) else []
+        self.llm_title_generated = bool(llm_title_generated)
         self.parent_session_id = parent_session_id
         self.is_cli_session = bool(kwargs.get('is_cli_session', False))
         self.source_tag = kwargs.get('source_tag')
@@ -408,7 +410,7 @@ class Session:
             'pending_user_message', 'pending_attachments', 'pending_started_at',
             'compression_anchor_visible_idx', 'compression_anchor_message_key',
             'context_length', 'threshold_tokens', 'last_prompt_tokens',
-            'gateway_routing', 'gateway_routing_history',
+            'gateway_routing', 'gateway_routing_history', 'llm_title_generated',
             'parent_session_id',
             'is_cli_session', 'source_tag', 'raw_source', 'session_source', 'source_label',
             'enabled_toolsets',

--- a/tests/test_session_save_mode.py
+++ b/tests/test_session_save_mode.py
@@ -157,3 +157,25 @@ def test_deferred_turn_is_materialized_when_agent_returns_assistant_only_delta()
         "assistant",
     ]
     assert [m["content"] for m in merged[-2:]] == ["latest prompt", "current answer"]
+
+
+def test_llm_title_generated_survives_save_and_load(_isolate_state):
+    s = Session(
+        session_id="generated_title",
+        title="Useful generated title",
+        messages=[{"role": "user", "content": "first prompt"}],
+        llm_title_generated=True,
+    )
+    s.save()
+
+    loaded = Session.load("generated_title")
+
+    assert loaded.llm_title_generated is True
+    on_disk = json.loads(s.path.read_text(encoding="utf-8"))
+    assert on_disk["llm_title_generated"] is True
+
+
+def test_session_constructor_preserves_loaded_llm_title_generated_kwarg():
+    s = Session(session_id="loaded_generated_title", llm_title_generated=True)
+
+    assert s.llm_title_generated is True


### PR DESCRIPTION
## Summary
- persist `llm_title_generated` through `Session` load/save cycles
- keep adaptive title refresh eligible after a WebUI restart
- add regression coverage for constructor and disk round-trip behavior

## Root cause
`_maybe_schedule_title_refresh()` only refreshes sessions where `session.llm_title_generated` is true. `_run_background_title_update()` sets that attribute dynamically and `Session.save()` wrote it as an extra field, but `Session.__init__()` ignored the `llm_title_generated` kwarg when loading the JSON again. After restart, generated-title sessions lost the marker in memory, so adaptive title refresh silently skipped them.

## Related reconnaissance
- Checked existing title-refresh PRs/issues. #1061 introduced the adaptive title refresh feature; no open PR found for this persistence gap.

## Test plan
- `python3 -m pytest tests/test_session_save_mode.py -q`
- `python3 -m pytest tests/test_1058_adaptive_title_refresh.py tests/test_session_save_mode.py -q`
- `python3 -m py_compile api/models.py`
- Static added-line scan: 0 findings
