### PR TITLE
fix: preserve local custom provider model ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Hermes Web UI -- Changelog
 
+## Unreleased
+
+### Fixed
+
+- Named custom providers whose slug matches a known local model server now preserve full slashed model IDs on non-loopback hosts such as `ollama.lan`, preventing local servers from loading a fresh default model instance. Fixes #1830.
+
 ## [v0.51.22] — 2026-05-07 — 3-PR batch (P0 markdown streaming hotfix + CSP source-map allowance + LaTeX delimiter rendering)
 
 ### Fixed (3 PRs)

--- a/api/config.py
+++ b/api/config.py
@@ -1385,6 +1385,20 @@ _LOCAL_SERVER_PROVIDERS = {
 }
 
 
+def _is_local_server_provider(provider_id: str) -> bool:
+    """True when provider_id names a local model server.
+
+    Named custom providers resolve to ``custom:<slug>``. Treat those as local
+    when the bare slug is one of the known local-server provider names too.
+    """
+    provider = str(provider_id or "").strip().lower()
+    if provider in _LOCAL_SERVER_PROVIDERS:
+        return True
+    if provider.startswith("custom:"):
+        return provider.removeprefix("custom:") in _LOCAL_SERVER_PROVIDERS
+    return False
+
+
 def _base_url_points_at_local_server(base_url: str) -> bool:
     """True if base_url's host is a loopback or private IP (likely local server).
 
@@ -1561,7 +1575,7 @@ def resolve_model_provider(model_id: str) -> tuple:
             # default settings, ignoring user-tuned context length / parallel slots.
             # See #1625. Detect either by canonical provider name OR by base_url
             # pointing at a loopback/private host.
-            if (str(config_provider or "").lower() in _LOCAL_SERVER_PROVIDERS
+            if (_is_local_server_provider(config_provider)
                     or _base_url_points_at_local_server(config_base_url)):
                 return model_id, config_provider, config_base_url
             # Only strip the provider prefix when it's a known provider namespace

--- a/tests/test_issue1625_local_server_model_id_preservation.py
+++ b/tests/test_issue1625_local_server_model_id_preservation.py
@@ -22,9 +22,12 @@ from api import config as cfg_mod
 # ── Helpers ───────────────────────────────────────────────────────────────
 
 
-def _patch_cfg(monkeypatch, **model_overrides):
+def _patch_cfg(monkeypatch, custom_providers=None, **model_overrides):
     """Patch api.config.cfg to a synthetic config dict for the duration of a test."""
-    fake_cfg = {"model": dict(model_overrides), "custom_providers": []}
+    fake_cfg = {
+        "model": dict(model_overrides),
+        "custom_providers": list(custom_providers or []),
+    }
     monkeypatch.setattr(cfg_mod, "cfg", fake_cfg)
 
 
@@ -74,6 +77,41 @@ def test_lmstudio_with_openai_prefix_preserved(monkeypatch):
     assert model == "openai/gpt-oss-120b", (
         "openai/gpt-oss-120b on LM Studio must preserve the full id (#1625)"
     )
+
+
+@pytest.mark.parametrize("provider_name", [
+    "ollama",
+    "lmstudio",
+    "lm-studio",
+    "vllm",
+    "tabby",
+])
+def test_named_custom_local_server_provider_preserves_full_model_id_on_lan_host(
+    provider_name,
+    monkeypatch,
+):
+    """#1830: custom:<local-server> slugs must keep local-server no-strip semantics.
+
+    Non-loopback hostnames like ollama.lan do not trigger the base_url local
+    heuristic, so the provider-id check must recognize custom:<slug> directly.
+    """
+    _patch_cfg(
+        monkeypatch,
+        provider=provider_name,
+        base_url="http://lan-host:1234/v1",
+        default="qwen/qwen3.6-27b",
+        custom_providers=[
+            {
+                "name": provider_name,
+                "base_url": "http://lan-host:1234/v1",
+                "api_key": "local-key",
+            },
+        ],
+    )
+    model, provider, base_url = cfg_mod.resolve_model_provider("qwen/qwen3.6-27b")
+    assert model == "qwen/qwen3.6-27b"
+    assert provider == f"custom:{provider_name}"
+    assert base_url == "http://lan-host:1234/v1"
 
 
 # ── Loopback / private-IP heuristic ───────────────────────────────────────


### PR DESCRIPTION
## Summary

- recognize `custom:<local-server>` provider ids as local model server providers
- preserve full slashed model ids for named custom Ollama/LM Studio/vLLM/Tabby providers on non-loopback hosts
- add regression coverage for #1830 across known local server provider slugs

Fixes #1830.

## Tests

- `python3 -m py_compile api/config.py tests/test_issue1625_local_server_model_id_preservation.py`
- `/Users/xuefusong/hermes-webui/.venv_test/bin/python -m pytest tests/test_issue1625_local_server_model_id_preservation.py -q`
- `/Users/xuefusong/hermes-webui/.venv_test/bin/python -m pytest tests/test_resolve_model_provider_free_suffix.py -q`
- `/Users/xuefusong/hermes-webui/.venv_test/bin/python -m pytest tests/test_provider_mismatch.py::test_issue1734_chat_start_persists_repaired_codex_provider -q`
- `git diff --check`
