### PR TITLE
Fix Kanban stale-client false-positive

### DIFF
--- a/static/panels.js
+++ b/static/panels.js
@@ -1219,7 +1219,6 @@ async function hardRefreshWebUIClient(){
 function _kanbanLooksLikeStaleClientError(err){
   const msg = String((err && err.message) || err || '').toLowerCase();
   return !!(err && err.status === 404 && (
-    msg === 'not found' ||
     msg.includes('unknown kanban endpoint') ||
     msg.includes('stale cached bundle')
   ));

--- a/tests/test_issue1823_kanban_not_found.py
+++ b/tests/test_issue1823_kanban_not_found.py
@@ -58,8 +58,8 @@ def test_unknown_kanban_endpoint_routes_are_wrapped_for_all_methods():
 def test_kanban_stale_client_error_renders_hard_refresh_escape_hatch():
     assert "function _kanbanLooksLikeStaleClientError(err)" in PANELS
     assert "err.status === 404" in PANELS
-    assert "msg === 'not found'" in PANELS
     assert "msg.includes('unknown kanban endpoint')" in PANELS
+    assert "msg.includes('stale cached bundle')" in PANELS
     assert "Kanban needs a hard refresh" in PANELS
     assert "Hard refresh now" in PANELS
     assert "navigator.serviceWorker.getRegistrations()" in PANELS


### PR DESCRIPTION
## Thinking Path

- PR #1828 added a stale-client recovery UI for obsolete Kanban endpoints.
- The server now returns explicit Kanban stale-client messages for unknown `/api/kanban/*` routes.
- The browser predicate also accepted a bare `not found` 404, which can misclassify future genuine Kanban 404s as stale-bundle errors.
- The safer layer is to keep the hard-refresh recovery path only for explicit stale-client signals.

## What Changed

- Removed the bare `msg === 'not found'` match from `_kanbanLooksLikeStaleClientError`.
- Kept the explicit `unknown kanban endpoint` and `stale cached bundle` matches.
- Updated the existing Kanban stale-client regression test to assert the explicit stale signal instead of the broad bare-404 signal.

## Why It Matters

A real Kanban 404 should not tell users to hard-refresh the WebUI unless the server actually indicates a stale cached bundle or unknown Kanban endpoint. This keeps the recovery UI targeted to the stale-client failure mode it was designed for.

Fixes #1839.

## Verification

- `.venv_test/bin/python -m pytest -q tests/test_issue1823_kanban_not_found.py`
- `node --check static/panels.js`
- `git diff --check`

## Risks / Follow-ups

- Runtime change is intentionally narrow: only the client-side stale-client predicate changes.
- Existing explicit stale-client messages still trigger the hard-refresh UI.

## Model Used

OpenAI GPT-5.5 via Codex CLI.
