### PR TITLE
Fix no-agent cron edit snapshot source

### DIFF
--- a/static/panels.js
+++ b/static/panels.js
@@ -834,7 +834,7 @@ async function saveCronForm(){
   const prompt=promptEl.value.trim();
   const deliver=delivEl?delivEl.value:'local';
   const profile=profileEl?profileEl.value:'';
-  const isNoAgent = !!(_currentCronDetail && _currentCronDetail.no_agent);
+  const isNoAgent = !!(_cronPreFormDetail && _cronPreFormDetail.no_agent);
   errEl.style.display='none';
   if(!schedule){errEl.textContent=t('cron_schedule_required_example');errEl.style.display='';return;}
   if(!isNoAgent && !prompt){errEl.textContent=t('cron_prompt_required');errEl.style.display='';return;}

--- a/tests/test_cron_no_agent_edit.py
+++ b/tests/test_cron_no_agent_edit.py
@@ -57,7 +57,7 @@ def test_no_agent_form_drops_prompt_required_attribute_and_shows_script_context(
 
 def test_save_cron_form_keeps_agent_prompt_required_but_skips_no_agent_edits():
     body = _function_body("saveCronForm")
-    assert "const isNoAgent = !!(_currentCronDetail && _currentCronDetail.no_agent);" in body
+    assert "const isNoAgent = !!(_cronPreFormDetail && _cronPreFormDetail.no_agent);" in body
     assert "if(!isNoAgent && !prompt)" in body
     assert "cron_prompt_required" in body
     assert "if (!isNoAgent) updates.prompt = prompt;" in body


### PR DESCRIPTION
## Thinking Path

Issue #1840 points out that `saveCronForm()` currently reads `no_agent` from `_currentCronDetail`. That is safe under the current DOM/detail invariant, but the explicit edit source of truth is `_cronPreFormDetail`, which is captured when the edit form opens.

## What Changed

- Changed `saveCronForm()` to read `no_agent` from `_cronPreFormDetail`.
- Updated the no-agent cron edit regression test to lock that source-of-truth choice.

## Why It Matters

This keeps save semantics tied to the cron edit snapshot rather than to the currently rendered detail object, reducing the chance that a future refresh or detail-render refactor changes no-agent save behavior.

Fixes #1840.

## Verification

- `pytest -q tests/test_cron_no_agent_edit.py`
- `node --check static/panels.js`
- `git diff --check`

## Risks

Low. The change is limited to no-agent detection while saving cron forms. Create mode still has no edit snapshot, so prompt validation remains active for normal cron creation.

## Model Used

OpenAI GPT-5.5 via Codex CLI
