### PR TITLE
Fix duplicate models across named custom providers

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -880,23 +880,23 @@ def _apply_provider_prefix(
 def _deduplicate_model_ids(groups: list[dict]) -> None:
     """Ensure every model ID across groups is globally unique.
 
-    When multiple providers expose the same bare model ID (e.g. two
-    custom providers both listing ``gpt-5.4``), the dropdown cannot
-    distinguish them.  This post-process detects such collisions and
-    prefixes colliding entries with ``@provider_id:`` so the frontend
-    can treat them as distinct options.
+    When multiple providers expose the same model ID (either bare names like
+    ``gpt-5.4`` or slash-qualified IDs like ``google/gemma-4-27b``), the
+    dropdown cannot distinguish them. This post-process detects such
+    collisions and prefixes colliding entries with ``@provider_id:`` so the
+    frontend can treat them as distinct options.
 
-    The first occurrence (in group order) is left bare for backward
-    compatibility with sessions that already store the bare model name.
-    If that provider is later removed from the config, the next cache
-    rebuild re-runs dedup — the remaining provider becomes the sole
-    occurrence and is left bare, so the session still matches.
+    The first occurrence (in provider-id order) is left unchanged for backward
+    compatibility with sessions that already store the original bare/slash
+    model name. If that provider is later removed from the config, the next
+    cache rebuild re-runs dedup — the remaining provider becomes the sole
+    occurrence and is left unchanged, so the session still matches.
 
     .. note::
-       The "first occurrence wins" rule means the bare ID is not stable
+       The "first occurrence wins" rule means the unchanged ID is not stable
        across config changes (adding, removing, or reordering providers).
        This is acceptable because the dedup runs on every cache rebuild,
-       so sessions always resolve to the current canonical bare ID.
+       so sessions always resolve to the current canonical unchanged ID.
 
     The ``@provider_id:model`` format is consistent with the existing
     ``_apply_provider_prefix()`` function and is handled by
@@ -908,8 +908,8 @@ def _deduplicate_model_ids(groups: list[dict]) -> None:
     if not groups:
         return
 
-    # Collect {bare_id: [(group_idx, model_idx), ...]} in alphabetical
-    # provider_id order so that the "first occurrence stays bare" rule is
+    # Collect {model_id: [(group_idx, model_idx), ...]} in alphabetical
+    # provider_id order so that the "first occurrence stays unchanged" rule is
     # deterministic across config edits (adding/removing/reordering providers).
     sorted_group_indices = sorted(
         range(len(groups)),
@@ -918,34 +918,29 @@ def _deduplicate_model_ids(groups: list[dict]) -> None:
     id_map: dict[str, list[tuple[int, int]]] = {}
     for gi in sorted_group_indices:
         group = groups[gi]
-        pid = group.get("provider_id", "")
         for mi, model in enumerate(group.get("models", [])):
-            mid = model.get("id", "")
-            # Skip IDs that are already provider-qualified
-            if mid.startswith("@") or "/" in mid:
+            mid = str(model.get("id", "") or "").strip()
+            # Skip IDs that are already provider-qualified.
+            if not mid or mid.startswith("@"):
                 continue
             id_map.setdefault(mid, []).append((gi, mi))
 
-    # For any bare ID appearing in 2+ groups, prefix all but the first
-    # occurrence.  The first stays bare for backward compat; the rest
-    # get ``@provider_id:id`` and a disambiguated label.
+    # For any ID appearing in 2+ groups, prefix all but the first occurrence.
     # This handles N>2 providers correctly: the loop iterates over all
     # occurrences after the first, prefixing each with its own provider_id.
-    for bare_id, locations in id_map.items():
+    for original_id, locations in id_map.items():
         if len(locations) < 2:
             continue
-        # Prefix all occurrences after the first
         for gi, mi in locations[1:]:
             group = groups[gi]
             model = group["models"][mi]
             pid = group.get("provider_id", "")
-            model["id"] = f"@{pid}:{bare_id}"
+            model["id"] = f"@{pid}:{original_id}"
             provider_name = group.get("provider", pid)
-            # Update label to show provider for clarity
-            if model.get("label") != bare_id:
+            if model.get("label") != original_id:
                 model["label"] = f"{model['label']} ({provider_name})"
             else:
-                model["label"] = f"{bare_id} ({provider_name})"
+                model["label"] = f"{original_id} ({provider_name})"
 
 
 def resolve_model_provider(model_id: str) -> tuple:

--- a/api/config.py
+++ b/api/config.py
@@ -1858,12 +1858,20 @@ def get_available_models() -> dict:
         _custom_providers_cfg = cfg.get("custom_providers", [])
         _named_custom_groups: dict = {}
         if isinstance(_custom_providers_cfg, list):
-            _seen_custom_ids = {m["id"] for m in auto_detected_models}
+            # Keep duplicate IDs distinct across different named custom providers.
+            # Cross-provider collisions are handled later by _deduplicate_model_ids();
+            # the local "seen" set here should only dedupe within the same rendered
+            # provider group (and against auto-detected unnamed custom models).
+            _seen_custom_ids_by_group: dict[str, set[str]] = {
+                "__unnamed__": {m["id"] for m in auto_detected_models}
+            }
             for _cp in _custom_providers_cfg:
                 if not isinstance(_cp, dict):
                     continue
                 _cp_name = (_cp.get("name") or "").strip()
                 _slug = ("custom:" + _cp_name.lower().replace(" ", "-")) if _cp_name else None
+                _bucket_key = _slug or "__unnamed__"
+                _bucket_seen = _seen_custom_ids_by_group.setdefault(_bucket_key, set())
 
                 # Collect model IDs: singular "model" field first, then "models" dict keys
                 _cp_model_ids: list[str] = []
@@ -1877,9 +1885,9 @@ def get_available_models() -> dict:
                             _cp_model_ids.append(_m_id.strip())
 
                 for _cp_model in _cp_model_ids:
-                    if _cp_model and _cp_model not in _seen_custom_ids:
+                    if _cp_model and _cp_model not in _bucket_seen:
                         _cp_label = _get_label_for_model(_cp_model, [])
-                        _seen_custom_ids.add(_cp_model)
+                        _bucket_seen.add(_cp_model)
                         if _slug:
                             if _slug not in _named_custom_groups:
                                 _named_custom_groups[_slug] = (_cp_name, [])

--- a/api/config.py
+++ b/api/config.py
@@ -940,6 +940,30 @@ def _deduplicate_model_ids(groups: list[dict], active_provider: str | None = Non
                 model["label"] = f"{original_id} ({provider_name})"
 
 
+def _provider_has_model(provider_id: str | None, model_id: str,
+                      custom_providers: list | None = None) -> bool:
+    """Check whether *provider_id* likely has *model_id* in its catalogue."""
+    if not provider_id or not model_id:
+        return False
+    if provider_id.startswith("custom:"):
+        name = provider_id[len("custom:"):]
+        for entry in (custom_providers or []):
+            if not isinstance(entry, dict):
+                continue
+            ename = (entry.get("name") or "").strip().lower().replace(" ", "-")
+            if ename == name:
+                if (entry.get("model") or "").strip() == model_id:
+                    return True
+                models = entry.get("models")
+                if isinstance(models, dict) and model_id in models:
+                    return True
+                return False
+        return False
+    # Built-in / known provider
+    pm = _PROVIDER_MODELS.get(provider_id, [])
+    return any(m.get("id") == model_id for m in pm if isinstance(m, dict))
+
+
 def resolve_model_provider(model_id: str) -> tuple:
     """Resolve model name, provider, and base_url for AIAgent.
 
@@ -976,15 +1000,52 @@ def resolve_model_provider(model_id: str) -> tuple:
     # OpenRouter heuristics. Their model IDs commonly contain '/' too.
     custom_providers = cfg.get("custom_providers", [])
     if isinstance(custom_providers, list):
+        # Collect ALL matching custom providers before deciding.
+        # A bare model ID can appear in multiple providers (e.g. gpt-5.4 in
+        # both edith and super-javis). Picking the first match blindly would
+        # hijack the model from the active provider (#1874).
+        cp_matches: list[tuple[str, str]] = []  # [(provider_hint, base_url), ...]
         for entry in custom_providers:
             if not isinstance(entry, dict):
                 continue
-            entry_model = (entry.get("model") or "").strip()
             entry_name = (entry.get("name") or "").strip()
+            if not entry_name:
+                continue
+            entry_model = (entry.get("model") or "").strip()
+            entry_models = entry.get("models")
             entry_base_url = (entry.get("base_url") or "").strip()
-            if entry_model and entry_name and model_id == entry_model:
+
+            is_match = bool(entry_model and model_id == entry_model)
+            if not is_match and isinstance(entry_models, dict):
+                is_match = model_id in entry_models
+
+            if is_match:
                 provider_hint = "custom:" + entry_name.lower().replace(" ", "-")
-                return model_id, provider_hint, entry_base_url or None
+                if (provider_hint, entry_base_url) not in cp_matches:
+                    cp_matches.append((provider_hint, entry_base_url or None))
+
+        if cp_matches:
+            # If the active provider is itself one of the matching custom
+            # providers, prefer it — the user's configured default wins.
+            for provider_hint, base_url in cp_matches:
+                if config_provider and provider_hint == config_provider:
+                    return model_id, provider_hint, base_url
+            # If exactly one custom provider is a match, use it — unless
+            # the active provider also has this model (which would cause a
+            # hijack, e.g. openai-codex's bare gpt-5.5 being routed to
+            # super-javis).
+            if len(cp_matches) == 1:
+                if not config_provider or cp_matches[0][0] == config_provider:
+                    return model_id, cp_matches[0][0], cp_matches[0][1]
+                if not _provider_has_model(config_provider, model_id, custom_providers):
+                    return model_id, cp_matches[0][0], cp_matches[0][1]
+                # Active provider also has this model — don't hijack;
+                # let the normal resolution path handle it.
+            # Multiple custom providers match the same bare model ID.
+            # Don't guess — let the normal resolution path route through
+            # the active provider (which is the user's configured intent).
+            # Prefixed IDs from the dedup logic will still route correctly
+            # because they are handled by the @provider:model branch below.
 
     # @provider:model format — explicit provider hint from the dropdown.
     # Route through that provider directly (resolve_runtime_provider will
@@ -1506,9 +1567,13 @@ def get_available_models() -> dict:
                             (m for m in matches if option_provider_lookup.get(m) == provider),
                             None,
                         )
-                        match_id = provider_match or exact_match or matches[0]
-                        if match_id:
+                        if provider_match:
+                            match_id = provider_match
                             break
+                        # Don't fall back to exact_match or matches[0] —
+                        # they may belong to a different provider and would
+                        # incorrectly assign the badge to the wrong model
+                        # (#1874 follow-up).
 
                 badge_payload = {"role": entry["role"], "label": entry["label"], "provider": provider}
                 # Only assign badges to keys that are real dropdown entries.
@@ -1523,7 +1588,12 @@ def get_available_models() -> dict:
                         continue
                     badges[candidate] = badge_payload
                 if match_id:
-                    badges[match_id] = badge_payload
+                    # Only assign the badge when match_id belongs to this
+                    # provider (defense-in-depth alongside the provider-aware
+                    # match_id selection above).
+                    match_provider = option_provider_lookup.get(match_id)
+                    if not match_provider or match_provider == provider:
+                        badges[match_id] = badge_payload
             return badges
 
         # 1. Read config.yaml model section

--- a/api/config.py
+++ b/api/config.py
@@ -1514,7 +1514,13 @@ def get_available_models() -> dict:
                             break
 
                 badge_payload = {"role": entry["role"], "label": entry["label"], "provider": provider}
+                # Only assign badges to keys that are real dropdown entries.
+                # Synthetic keys like "custom:provider/model" can normalize to
+                # the same string as a bare model id from a different provider,
+                # leaking the PRIMARY badge across providers (#1874 follow-up).
                 for candidate in raw_candidates:
+                    if candidate not in option_lookup:
+                        continue
                     candidate_provider = option_provider_lookup.get(candidate)
                     if candidate_provider and candidate_provider != provider:
                         continue

--- a/api/config.py
+++ b/api/config.py
@@ -1470,6 +1470,12 @@ def get_available_models() -> dict:
 
             option_ids = [m.get("id", "") for g in groups for m in g.get("models", []) if m.get("id")]
             option_lookup = {str(opt_id): str(opt_id) for opt_id in option_ids}
+            option_provider_lookup = {
+                str(m.get("id")): str(g.get("provider_id") or "")
+                for g in groups
+                for m in g.get("models", [])
+                if m.get("id")
+            }
             norm_lookup: dict[str, list[str]] = {}
             for opt_id in option_ids:
                 norm_lookup.setdefault(_norm_model_id(opt_id), []).append(opt_id)
@@ -1488,8 +1494,9 @@ def get_available_models() -> dict:
                         raw_candidates.append(candidate)
 
                 match_id = None
+                exact_match = next((option_lookup[c] for c in raw_candidates if c in option_lookup), None)
                 for candidate in raw_candidates:
-                    if candidate in option_lookup:
+                    if candidate in option_lookup and option_provider_lookup.get(candidate) == provider:
                         match_id = option_lookup[candidate]
                         break
                 if match_id is None:
@@ -1499,15 +1506,18 @@ def get_available_models() -> dict:
                         if not matches:
                             continue
                         provider_match = next(
-                            (m for m in matches if m.startswith(f"@{provider}:") or m.startswith(f"{provider}/")),
+                            (m for m in matches if option_provider_lookup.get(m) == provider),
                             None,
                         )
-                        match_id = provider_match or matches[0]
+                        match_id = provider_match or exact_match or matches[0]
                         if match_id:
                             break
 
                 badge_payload = {"role": entry["role"], "label": entry["label"], "provider": provider}
                 for candidate in raw_candidates:
+                    candidate_provider = option_provider_lookup.get(candidate)
+                    if candidate_provider and candidate_provider != provider:
+                        continue
                     badges[candidate] = badge_payload
                 if match_id:
                     badges[match_id] = badge_payload

--- a/api/config.py
+++ b/api/config.py
@@ -877,7 +877,7 @@ def _apply_provider_prefix(
     return result
 
 
-def _deduplicate_model_ids(groups: list[dict]) -> None:
+def _deduplicate_model_ids(groups: list[dict], active_provider: str | None = None) -> None:
     """Ensure every model ID across groups is globally unique.
 
     When multiple providers expose the same model ID (either bare names like
@@ -886,17 +886,11 @@ def _deduplicate_model_ids(groups: list[dict]) -> None:
     collisions and prefixes colliding entries with ``@provider_id:`` so the
     frontend can treat them as distinct options.
 
-    The first occurrence (in provider-id order) is left unchanged for backward
-    compatibility with sessions that already store the original bare/slash
-    model name. If that provider is later removed from the config, the next
-    cache rebuild re-runs dedup — the remaining provider becomes the sole
-    occurrence and is left unchanged, so the session still matches.
-
-    .. note::
-       The "first occurrence wins" rule means the unchanged ID is not stable
-       across config changes (adding, removing, or reordering providers).
-       This is acceptable because the dedup runs on every cache rebuild,
-       so sessions always resolve to the current canonical unchanged ID.
+    The active provider's occurrence (if it participates in a collision) is
+    left unchanged — sessions that store a bare model ID will continue to
+    route through the active provider.  All other occurrences are prefixed
+    so selecting from a non-active provider routes through that provider
+    rather than being silently redirected to the active one.
 
     The ``@provider_id:model`` format is consistent with the existing
     ``_apply_provider_prefix()`` function and is handled by
@@ -908,12 +902,15 @@ def _deduplicate_model_ids(groups: list[dict]) -> None:
     if not groups:
         return
 
-    # Collect {model_id: [(group_idx, model_idx), ...]} in alphabetical
-    # provider_id order so that the "first occurrence stays unchanged" rule is
-    # deterministic across config edits (adding/removing/reordering providers).
+    # Sort so the active provider appears first (keeps bare IDs);
+    # remaining groups are sorted alphabetically by provider_id for
+    # deterministic behaviour.
     sorted_group_indices = sorted(
         range(len(groups)),
-        key=lambda i: groups[i].get("provider_id", ""),
+        key=lambda i: (
+            0 if groups[i].get("provider_id") == active_provider else 1,
+            groups[i].get("provider_id", ""),
+        ),
     )
     id_map: dict[str, list[tuple[int, int]]] = {}
     for gi in sorted_group_indices:
@@ -2035,7 +2032,7 @@ def get_available_models() -> dict:
         # Post-process: ensure model IDs are globally unique across groups.
         # When multiple providers expose the same bare model ID, prefix
         # collisions with @provider_id: so the frontend can distinguish them.
-        _deduplicate_model_ids(groups)
+        _deduplicate_model_ids(groups, active_provider=active_provider)
 
         return {
             "active_provider": active_provider,

--- a/static/panels.js
+++ b/static/panels.js
@@ -2244,7 +2244,7 @@ async function switchToProfile(name) {
     // ── Apply model ────────────────────────────────────────────────────────
     if (data.default_model) {
       const sel = $('modelSelect');
-      const resolved = _applyModelToDropdown(data.default_model, sel);
+      const resolved = _applyModelToDropdown(data.default_model, sel, window._activeProvider||null);
       const modelToUse = resolved || data.default_model;
       S._pendingProfileModel = modelToUse;
       // Only patch the in-memory session model if we're NOT about to replace the session
@@ -2753,7 +2753,7 @@ async function loadSettingsPanel(){
       // picker renders blank for any user whose default was persisted without the
       // @-prefix — CLI-first users, legacy installs, etc.
       if(typeof _applyModelToDropdown==='function'){
-        _applyModelToDropdown(_settingsHermesDefaultModelOnOpen, modelSel);
+        _applyModelToDropdown(_settingsHermesDefaultModelOnOpen, modelSel, (models&&models.active_provider)||window._activeProvider||null);
       }else{
         modelSel.value=_settingsHermesDefaultModelOnOpen;
       }

--- a/static/ui.js
+++ b/static/ui.js
@@ -428,15 +428,24 @@ function _normalizeConfiguredModelKey(modelId){
   return s.replace(/-/g,'.');
 }
 
-function _getConfiguredModelBadge(modelId,badgeMap){
+function _getConfiguredModelBadge(modelId,badgeMap,providerId){
   const map=badgeMap||window._configuredModelBadges||{};
   if(!modelId||!map) return null;
-  if(map[modelId]) return map[modelId];
+  const provider=String(providerId||'').toLowerCase();
+  const exact=map[modelId];
+  if(exact && (!provider || !exact.provider || String(exact.provider).toLowerCase()===provider)) return exact;
   const targetNorm=_normalizeConfiguredModelKey(modelId);
+  const matches=[];
   for(const [candidate,badge] of Object.entries(map)){
-    if(_normalizeConfiguredModelKey(candidate)===targetNorm) return badge;
+    if(_normalizeConfiguredModelKey(candidate)===targetNorm) matches.push(badge);
   }
-  return null;
+  if(!matches.length) return null;
+  if(provider){
+    const providerMatch=matches.find(badge=>String(badge&&badge.provider||'').toLowerCase()===provider);
+    if(providerMatch) return providerMatch;
+    return matches.length===1 ? matches[0] : null;
+  }
+  return matches[0];
 }
 
 function syncModelChip(){
@@ -479,8 +488,9 @@ function renderModelDropdown(){
   const _badgeMap=window._configuredModelBadges||{};
   for(const child of Array.from(sel.children)){
     if(child.tagName==='OPTGROUP'){
+      const providerId=child.dataset&&child.dataset.provider?child.dataset.provider:'';
       for(const opt of Array.from(child.children)){
-        _modelData.push({value:opt.value,name:esc(opt.textContent||getModelLabel(opt.value)),id:esc(opt.value),group:child.label||'',badge:_getConfiguredModelBadge(opt.value,_badgeMap)});
+        _modelData.push({value:opt.value,name:esc(opt.textContent||getModelLabel(opt.value)),id:esc(opt.value),group:child.label||'',badge:_getConfiguredModelBadge(opt.value,_badgeMap,providerId)});
       }
     }
     if(child.tagName==='OPTION'){

--- a/static/ui.js
+++ b/static/ui.js
@@ -192,16 +192,34 @@ window._configuredModelBadges=window._configuredModelBadges||{};
 // ── Smart model resolver ────────────────────────────────────────────────────
 // Finds the best matching option value in a <select> for a given model ID.
 // Handles mismatches like 'claude-sonnet-4-6' vs 'anthropic/claude-sonnet-4.6'.
-// Returns the matched option's value (already in the list), or null if no match.
-function _findModelInDropdown(modelId, sel){
+// When a preferred provider is supplied, duplicate normalized IDs prefer that
+// provider's option so Settings/profile rehydration doesn't snap back to the
+// first colliding entry.
+function _getOptionProviderId(opt){
+  if(!opt) return '';
+  const group=opt.parentElement;
+  if(group && group.tagName==='OPTGROUP' && group.dataset && group.dataset.provider){
+    return group.dataset.provider;
+  }
+  const value=String(opt.value||'');
+  if(value.startsWith('@') && value.includes(':')) return value.slice(1,value.indexOf(':'));
+  return '';
+}
+function _findModelInDropdown(modelId, sel, preferredProviderId){
   if(!modelId||!sel) return null;
-  const opts=Array.from(sel.options).map(o=>o.value);
-  // 1. Exact match
-  if(opts.includes(modelId)) return modelId;
-  // 2. Normalize: lowercase, strip namespace prefix, replace hyphens→dots
-  // Also strip @provider: prefix from deduplicated model IDs (#1228).
+  const options=Array.from(sel.options);
+  const opts=options.map(o=>o.value);
+  // 1. Normalize: lowercase, strip namespace prefix, replace hyphens→dots.
+  // Also strip @provider: prefix from deduplicated model IDs (#1228, #1313).
   const norm=s=>s.toLowerCase().replace(/^[^/]+\//,'').replace(/^@([^:]+:)+/,'').replace(/-/g,'.');
   const target=norm(modelId);
+  const preferred=String(preferredProviderId||'').toLowerCase();
+  if(preferred){
+    const providerMatch=options.find(o=>norm(o.value)===target && _getOptionProviderId(o).toLowerCase()===preferred);
+    if(providerMatch) return providerMatch.value;
+  }
+  // 2. Exact match
+  if(opts.includes(modelId)) return modelId;
   const exact=opts.find(o=>norm(o)===target);
   if(exact) return exact;
   // 3. Prefix/substring: require the candidate to start with the FULL normalized target
@@ -217,9 +235,9 @@ function _findModelInDropdown(modelId, sel){
 
 // Set the model picker to the best match for modelId.
 // Returns the resolved value that was actually set, or null if nothing matched.
-function _applyModelToDropdown(modelId, sel){
+function _applyModelToDropdown(modelId, sel, preferredProviderId){
   if(!modelId||!sel) return null;
-  const resolved=_findModelInDropdown(modelId,sel);
+  const resolved=_findModelInDropdown(modelId,sel,preferredProviderId);
   if(resolved){
     sel.value=resolved;
     if(sel.id==='modelSelect' && typeof syncModelChip==='function') syncModelChip();
@@ -260,7 +278,7 @@ async function populateModelDropdown(){
     }
     // Set default model from server if no localStorage preference
     if(data.default_model && !localStorage.getItem('hermes-webui-model')){
-      _applyModelToDropdown(data.default_model, sel);
+      _applyModelToDropdown(data.default_model, sel, data.active_provider||null);
     }
     if(typeof syncModelChip==='function') syncModelChip();
     // Kick off a background live-model fetch for the active provider.

--- a/static/ui.js
+++ b/static/ui.js
@@ -443,7 +443,7 @@ function _getConfiguredModelBadge(modelId,badgeMap,providerId){
   if(provider){
     const providerMatch=matches.find(badge=>String(badge&&badge.provider||'').toLowerCase()===provider);
     if(providerMatch) return providerMatch;
-    return matches.length===1 ? matches[0] : null;
+    return null;
   }
   return matches[0];
 }

--- a/tests/test_custom_provider_duplicate_models.py
+++ b/tests/test_custom_provider_duplicate_models.py
@@ -67,24 +67,30 @@ def test_named_custom_providers_keep_duplicate_model_ids(monkeypatch, tmp_path):
     edith_ids = [m["id"] for m in groups["edith"]]
     super_ids = [m["id"] for m in groups["super-javis"]]
 
-    assert "gpt-5.4" in edith_ids
-    assert "@custom:super-javis:gpt-5.4" in super_ids
+    assert "gpt-5.4" in super_ids
+    assert "@custom:edith:gpt-5.4" in edith_ids
     assert "gpt-5.5" in super_ids
 
+    # Active-provider-aware dedup: when active_provider is super-javis,
+    # super-javis keeps the bare gpt-5.4 and others are prefixed.
+    # (For gpt-5.5, super-javis is the only custom provider with it, so
+    # it stays bare.)
+
     # Badge must NOT leak across providers: only super-javis's gpt-5.4 gets
-    # the PRIMARY badge — Edith's bare gpt-5.4 must be left alone.
+    # the PRIMARY badge — Edith's gpt-5.4 must be left alone.
     badges = result.get("configured_model_badges", {})
-    # Only the deduplicated ID for super-javis should carry the "primary" badge.
+    # Only super-javis's gpt-5.4 (now bare as active provider) should
+    # carry the "primary" badge, not Edith's.
     primary_keys = [k for k, v in badges.items() if v.get("role") == "primary"]
-    assert any(k.startswith("@custom:super-javis:") and "gpt-5.4" in k for k in primary_keys), (
-        f"Expected a PRIMARY badge on super-javis's gpt-5.4; got {primary_keys}"
+    assert "gpt-5.4" in primary_keys, (
+        f"Expected bare gpt-5.4 PRIMARY badge (active provider is super-javis); got {primary_keys}"
     )
-    # The bare "gpt-5.4" (Edith's) must NOT receive the super-javis PRIMARY badge.
-    bare_badge = badges.get("gpt-5.4")
-    assert not bare_badge or bare_badge.get("role") != "primary", (
-        f"Edith's bare gpt-5.4 leaked a PRIMARY badge from super-javis: {bare_badge}"
+    # Edith's prefixed gpt-5.4 must NOT receive the PRIMARY badge.
+    edith_prefixed_badge = badges.get("@custom:edith:gpt-5.4")
+    assert not edith_prefixed_badge or edith_prefixed_badge.get("role") != "primary", (
+        f"Edith's gpt-5.4 leaked a PRIMARY badge: {edith_prefixed_badge}"
     )
-    # The provider field on the super-javis badge must correctly identify super-javis.
+    # The provider field on the PRIMARY badge must correctly identify super-javis.
     for k in primary_keys:
         assert badges[k].get("provider") == "custom:super-javis", (
             f"Badge provider mismatch: {badges[k]}"

--- a/tests/test_custom_provider_duplicate_models.py
+++ b/tests/test_custom_provider_duplicate_models.py
@@ -70,3 +70,22 @@ def test_named_custom_providers_keep_duplicate_model_ids(monkeypatch, tmp_path):
     assert "gpt-5.4" in edith_ids
     assert "@custom:super-javis:gpt-5.4" in super_ids
     assert "gpt-5.5" in super_ids
+
+    # Badge must NOT leak across providers: only super-javis's gpt-5.4 gets
+    # the PRIMARY badge — Edith's bare gpt-5.4 must be left alone.
+    badges = result.get("configured_model_badges", {})
+    # Only the deduplicated ID for super-javis should carry the "primary" badge.
+    primary_keys = [k for k, v in badges.items() if v.get("role") == "primary"]
+    assert any(k.startswith("@custom:super-javis:") and "gpt-5.4" in k for k in primary_keys), (
+        f"Expected a PRIMARY badge on super-javis's gpt-5.4; got {primary_keys}"
+    )
+    # The bare "gpt-5.4" (Edith's) must NOT receive the super-javis PRIMARY badge.
+    bare_badge = badges.get("gpt-5.4")
+    assert not bare_badge or bare_badge.get("role") != "primary", (
+        f"Edith's bare gpt-5.4 leaked a PRIMARY badge from super-javis: {bare_badge}"
+    )
+    # The provider field on the super-javis badge must correctly identify super-javis.
+    for k in primary_keys:
+        assert badges[k].get("provider") == "custom:super-javis", (
+            f"Badge provider mismatch: {badges[k]}"
+        )

--- a/tests/test_custom_provider_duplicate_models.py
+++ b/tests/test_custom_provider_duplicate_models.py
@@ -1,0 +1,72 @@
+import json
+import sys
+import types
+
+import api.config as config
+import api.profiles as profiles
+
+
+def _install_fake_hermes_cli(monkeypatch):
+    fake_pkg = types.ModuleType("hermes_cli")
+    fake_pkg.__path__ = []
+
+    fake_models = types.ModuleType("hermes_cli.models")
+    fake_models.list_available_providers = lambda: []
+    fake_models.provider_model_ids = lambda _pid: []
+
+    fake_auth = types.ModuleType("hermes_cli.auth")
+    fake_auth.get_auth_status = lambda _pid: {}
+
+    monkeypatch.setitem(sys.modules, "hermes_cli", fake_pkg)
+    monkeypatch.setitem(sys.modules, "hermes_cli.models", fake_models)
+    monkeypatch.setitem(sys.modules, "hermes_cli.auth", fake_auth)
+    monkeypatch.delitem(sys.modules, "agent.credential_pool", raising=False)
+    monkeypatch.delitem(sys.modules, "agent", raising=False)
+
+
+def test_named_custom_providers_keep_duplicate_model_ids(monkeypatch, tmp_path):
+    _install_fake_hermes_cli(monkeypatch)
+
+    (tmp_path / "auth.json").write_text(json.dumps({"version": 1, "providers": {}}), encoding="utf-8")
+    monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
+
+    old_cfg = dict(config.cfg)
+    old_mtime = config._cfg_mtime
+    config.cfg.clear()
+    config.cfg.update(
+        {
+            "model": {"default": "gpt-5.4", "provider": "custom:super-javis"},
+            "custom_providers": [
+                {"name": "edith", "models": {"gpt-5.4": {}}},
+                {
+                    "name": "super-javis",
+                    "models": {
+                        "gpt-5.3-codex": {},
+                        "gpt-5.4": {},
+                        "gpt-5.5": {},
+                    },
+                },
+            ],
+        }
+    )
+    config._cfg_mtime = 0.0
+    config.invalidate_models_cache()
+
+    try:
+        result = config.get_available_models()
+    finally:
+        config.cfg.clear()
+        config.cfg.update(old_cfg)
+        config._cfg_mtime = old_mtime
+        config.invalidate_models_cache()
+
+    groups = {g["provider"]: g["models"] for g in result.get("groups", [])}
+    assert "edith" in groups
+    assert "super-javis" in groups
+
+    edith_ids = [m["id"] for m in groups["edith"]]
+    super_ids = [m["id"] for m in groups["super-javis"]]
+
+    assert "gpt-5.4" in edith_ids
+    assert "@custom:super-javis:gpt-5.4" in super_ids
+    assert "gpt-5.5" in super_ids

--- a/tests/test_issue1228_model_picker_duplicate_ids.py
+++ b/tests/test_issue1228_model_picker_duplicate_ids.py
@@ -93,11 +93,10 @@ class TestDeduplicateModelIds(unittest.TestCase):
         assert result[1]["models"][0]["id"] == "@beta:gpt-5.4"
         assert result[2]["models"][0]["id"] == "@gamma:gpt-5.4"
 
-    # ── Already-prefixed IDs are skipped ───────────────────────────
+    # ── Already-prefixed IDs / slash IDs ───────────────────────────
 
-    def test_already_prefixed_ids_skipped(self):
-        """Model IDs already starting with @ or containing / are not
-        considered for deduplication."""
+    def test_already_prefixed_ids_and_unique_slash_ids_unchanged(self):
+        """Already-qualified IDs stay untouched; unique slash IDs are still allowed."""
         groups = [
             {"provider": "Anthropic", "provider_id": "anthropic", "models": [
                 {"id": "@anthropic:claude-sonnet-4.6", "label": "Claude Sonnet 4.6"},
@@ -107,9 +106,23 @@ class TestDeduplicateModelIds(unittest.TestCase):
             ]},
         ]
         result = self._call(groups)
-        # Neither should be modified
         assert result[0]["models"][0]["id"] == "@anthropic:claude-sonnet-4.6"
         assert result[1]["models"][0]["id"] == "anthropic/claude-sonnet-4.6"
+
+    def test_two_providers_same_slash_qualified_model_prefixes_second(self):
+        """Slash-qualified duplicates must also be made unique (#1313)."""
+        groups = [
+            {"provider": "Alpha", "provider_id": "custom:alpha", "models": [
+                {"id": "google/gemma-4-27b", "label": "Gemma 4 27B"},
+            ]},
+            {"provider": "Beta", "provider_id": "custom:beta", "models": [
+                {"id": "google/gemma-4-27b", "label": "Gemma 4 27B"},
+            ]},
+        ]
+        result = self._call(groups)
+        assert result[0]["models"][0]["id"] == "google/gemma-4-27b"
+        assert result[1]["models"][0]["id"] == "@custom:beta:google/gemma-4-27b"
+        assert result[1]["models"][0]["label"] == "Gemma 4 27B (Beta)"
 
     # ── Mixed: some unique, some colliding ─────────────────────────
 
@@ -215,6 +228,39 @@ class TestFrontendNormRegex(unittest.TestCase):
         r1 = subprocess.run(["node", "-e", f"console.log(({norm_js})('minimax-m2.7'))"], capture_output=True, text=True)
         r2 = subprocess.run(["node", "-e", f"console.log(({norm_js})('@minimax:MiniMax-M2.7'))"], capture_output=True, text=True)
         assert r1.stdout.strip() == r2.stdout.strip(), f"{r1.stdout.strip()} != {r2.stdout.strip()}"
+
+
+class TestFrontendPreferredProviderMatch(unittest.TestCase):
+    """Frontend: provider-aware rehydration should prefer the saved provider."""
+
+    @staticmethod
+    def _read_js():
+        import pathlib
+        return (pathlib.Path(__file__).parent.parent / "static" / "ui.js").read_text()
+
+    def test_find_model_prefers_matching_provider_for_slash_collision(self):
+        import re
+        import subprocess
+
+        src = self._read_js()
+        helper = re.search(r"function _getOptionProviderId\(opt\)\{.*?\n\}", src, re.S)
+        finder = re.search(r"function _findModelInDropdown\(modelId, sel, preferredProviderId\)\{.*?\n\}", src, re.S)
+        assert helper, "_getOptionProviderId() not found in ui.js"
+        assert finder, "_findModelInDropdown() not found in ui.js"
+
+        script = f"""
+{helper.group(0)}
+{finder.group(0)}
+const sel = {{
+  options: [
+    {{ value: 'google/gemma-4-27b', parentElement: {{ tagName: 'OPTGROUP', dataset: {{ provider: 'custom:alpha' }} }} }},
+    {{ value: '@custom:beta:google/gemma-4-27b', parentElement: {{ tagName: 'OPTGROUP', dataset: {{ provider: 'custom:beta' }} }} }},
+  ]
+}};
+console.log(_findModelInDropdown('google/gemma-4-27b', sel, 'custom:beta') || '');
+"""
+        resolved = subprocess.run(["node", "-e", script], capture_output=True, text=True, check=True)
+        assert resolved.stdout.strip() == "@custom:beta:google/gemma-4-27b"
 
 
 class TestResolveModelProviderColonInProviderId(unittest.TestCase):

--- a/tests/test_model_picker_badges.py
+++ b/tests/test_model_picker_badges.py
@@ -15,8 +15,10 @@ def _models_with_cfg(model_cfg=None, fallback_providers=None, custom_providers=N
         config.cfg = {
             "model": model_cfg or {"provider": "openai-codex", "default": "gpt-5.4"},
             "fallback_providers": fallback_providers or [],
-            "providers": custom_providers or {},
+            "providers": {},
         }
+        if custom_providers is not None:
+            config.cfg["custom_providers"] = custom_providers
         if active_provider:
             config.cfg["model"]["provider"] = active_provider
         return config.get_available_models()
@@ -47,6 +49,52 @@ def test_available_models_exposes_primary_and_fallback_badges():
     assert badges.get("@copilot:gpt-4.1", {}).get("label") == "Fallback 1"
     assert badges.get("anthropic/claude-haiku-4.5", {}).get("role") == "fallback"
     assert badges.get("anthropic/claude-haiku-4.5", {}).get("label") == "Fallback 2"
+
+
+def test_duplicate_slash_id_primary_badge_sticks_to_matching_provider_only():
+    import textwrap
+
+    root = Path(__file__).resolve().parent.parent
+    src = (root / "api" / "config.py").read_text(encoding="utf-8")
+    start = src.index("def _build_configured_model_badges() -> dict[str, dict[str, str]]:")
+    end = src.index("            return badges", start) + len("            return badges")
+    fn_src = textwrap.dedent(src[start:end])
+
+    scope = {
+        "active_provider": "custom:beta",
+        "default_model": "google/gemma-4-27b",
+        "cfg": {"fallback_providers": []},
+        "groups": [
+            {"provider": "Alpha", "provider_id": "custom:alpha", "models": [{"id": "google/gemma-4-27b"}]},
+            {"provider": "Beta", "provider_id": "custom:beta", "models": [{"id": "@custom:beta:google/gemma-4-27b"}]},
+        ],
+        "_resolve_provider_alias": lambda provider: provider,
+    }
+    exec(
+        "def _norm_model_id(model_id):\n"
+        "    s=str(model_id or '').strip().lower()\n"
+        "    if s.startswith('@') and ':' in s: s=s.split(':',1)[1]\n"
+        "    if '/' in s: s=s.split('/',1)[1]\n"
+        "    return s.replace('-', '.')\n",
+        scope,
+    )
+    exec(fn_src, scope)
+
+    badges = scope["_build_configured_model_badges"]()
+    assert badges.get("@custom:beta:google/gemma-4-27b", {}).get("role") == "primary"
+    assert "google/gemma-4-27b" not in badges, (
+        "When duplicate slash-qualified IDs are deduplicated across providers, "
+        "the shared raw ID must not keep the PRIMARY badge for the wrong provider."
+    )
+
+
+def test_ui_badge_lookup_prefers_row_provider_for_duplicate_model_ids():
+    root = Path(__file__).resolve().parent.parent
+    js = (root / "static" / "ui.js").read_text(encoding="utf-8")
+
+    assert "function _getConfiguredModelBadge(modelId,badgeMap,providerId){" in js
+    assert "child.dataset&&child.dataset.provider?child.dataset.provider:''" in js
+    assert "const providerMatch=matches.find(badge=>String(badge&&badge.provider||'').toLowerCase()===provider);" in js
 
 
 def test_get_available_models_cache_preserves_configured_model_badges(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

Fix `/api/models` so duplicate model IDs from different **named custom providers** are preserved instead of being dropped by an overly broad global de-duplication pass.

## Root cause

While assembling named custom provider groups in `get_available_models()`, the API used a single global `_seen_custom_ids` set seeded from auto-detected models. That meant if two named custom providers exposed the same raw model ID (for example both exposing `gpt-5.4`), the first provider to be processed "claimed" the ID and later providers silently lost their copy before provider-aware namespacing/deduplication ran.

In practice this caused configs like:

- `edith` -> `gpt-5.4`
- `super-javis` -> `gpt-5.4`, `gpt-5.5`

...to incorrectly omit `super-javis`'s `gpt-5.4` entry from `/api/models`.

## Fix

Replace the single global custom-provider seen set with a **per rendered provider-group** seen set:

- unnamed / auto-detected custom entries still dedupe against the `__unnamed__` bucket
- each named custom provider slug gets its own bucket
- later provider-aware duplicate handling (`_deduplicate_model_ids()`) remains responsible for cross-provider collisions and namespacing behavior

This keeps de-duplication scoped to the place where it is actually valid: inside the same rendered provider group.

## Why this is the correct behavior

Provider identity matters. Two providers can legitimately expose the same upstream model ID while still being different choices (different base URLs, auth, routing, latency, quotas, or semantics). The API should preserve both entries and only disambiguate them in a provider-aware way, not erase one globally just because the bare model ID matches.

## Regression coverage

Added `tests/test_custom_provider_duplicate_models.py`, which verifies that:

1. two named custom providers can both expose `gpt-5.4`
2. the first provider keeps its plain ID entry
3. the second provider is still present and survives provider-aware deduplication as `@custom:super-javis:gpt-5.4`
4. non-colliding sibling models like `gpt-5.5` are still returned normally

## Testing

```bash
pytest tests/test_custom_provider_duplicate_models.py
```
