### PR TITLE
fix(streaming): include profile home in agent cache signature (#1897)

### DIFF
--- a/api/streaming.py
+++ b/api/streaming.py
@@ -2392,6 +2392,13 @@ def _run_agent_streaming(
                     _fallback_resolved or {},
                     sorted(_toolsets) if _toolsets else [],
                     _reasoning_config or {},
+                    # #1897: profile_home is part of the agent's identity because
+                    # AIAgent caches `_cached_system_prompt` from `load_soul_md()`
+                    # at construction time, sourced from HERMES_HOME. Same-session
+                    # profile switches keep `session_id` stable, so without this
+                    # field the cached agent silently retains the previous
+                    # profile's SOUL.md (and any other profile-scoped context).
+                    _profile_home or '',
                 ], sort_keys=True)
                 _agent_sig = _hashlib.sha256(_sig_blob.encode()).hexdigest()[:16]
 

--- a/tests/test_issue1897_profile_switch_agent_cache.py
+++ b/tests/test_issue1897_profile_switch_agent_cache.py
@@ -1,0 +1,68 @@
+"""Regression checks for #1897 — same-session profile switch identity bleed.
+
+When a user switches profiles mid-session in the WebUI, `session_id` stays
+stable but the active profile's HERMES_HOME changes. The streaming layer
+caches `AIAgent` instances by `session_id` plus a signature blob in
+`api/streaming.py`. Before the fix, that signature did NOT include
+`_profile_home`, so the second turn after a profile switch reused the agent
+built under the previous profile — including its `_cached_system_prompt`
+loaded from the OLD profile's SOUL.md. The new persona's identity files
+never reached the LLM.
+
+These tests exercise the source-string contract — a unit-level functional
+test would require constructing a full streaming worker. Source-string
+tests are sufficient because the signature blob is a single literal list
+that drives the cache-hit comparison; if `_profile_home` is in that list,
+profile switches force a cache miss and a fresh agent build.
+"""
+
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parent.parent
+STREAMING_PY = (REPO / "api" / "streaming.py").read_text(encoding="utf-8")
+
+
+def _signature_block() -> str:
+    """Return the literal text of the cache-signature blob."""
+    sig_start = STREAMING_PY.index("_sig_blob = _json.dumps")
+    sig_end = STREAMING_PY.index("], sort_keys=True)", sig_start)
+    return STREAMING_PY[sig_start:sig_end]
+
+
+def test_cache_signature_includes_profile_home():
+    """The cache signature must include `_profile_home` so that switching
+    profiles mid-session forces a cache miss instead of reusing the
+    previous profile's agent (and its baked-in SOUL.md / system prompt)."""
+    block = _signature_block()
+    assert "_profile_home" in block, (
+        "SESSION_AGENT_CACHE signature is missing `_profile_home`. "
+        "Without this, same-session profile switches reuse the cached "
+        "agent built under the previous profile's HERMES_HOME, leaking "
+        "the old persona's SOUL.md into the new profile's turns. "
+        "See #1897."
+    )
+
+
+def test_profile_home_resolved_before_cache_signature():
+    """The `_profile_home` variable must be assigned before the cache
+    signature is built, otherwise the reference would NameError."""
+    profile_home_assignment = STREAMING_PY.index("_profile_home = str(_profile_home_path)")
+    sig_start = STREAMING_PY.index("_sig_blob = _json.dumps")
+    assert profile_home_assignment < sig_start, (
+        "`_profile_home` must be resolved before the SESSION_AGENT_CACHE "
+        "signature is built. If this ordering changed, #1897 would "
+        "regress with a NameError instead of an identity bleed."
+    )
+
+
+def test_signature_uses_profile_home_with_fallback():
+    """The signature must use `_profile_home or ''` — the fallback to an
+    empty string preserves cache stability when HERMES_HOME is unset
+    (older deployments / single-profile installs)."""
+    block = _signature_block()
+    assert "_profile_home or ''" in block, (
+        "Signature should use `_profile_home or ''` so that single-profile "
+        "deployments (where _profile_home may be empty) get a stable "
+        "cache key rather than churning on each turn."
+    )


### PR DESCRIPTION
Closes #1897

## Summary

Same-session profile switches were silently reusing the cached `AIAgent` from the previous profile. The agent's `_cached_system_prompt` (built from `load_soul_md()` at construction time) is sourced from `HERMES_HOME` — so when a user switched personas mid-session, the second turn still carried the first profile's SOUL.md and any other profile-scoped context.

Reported by @AvidFuturist in Discord (May 8 2026): two custom personas, mid-session switch, second turn loaded the wrong identity.

## Root cause

`SESSION_AGENT_CACHE` in `api/streaming.py` is keyed by `session_id`, with a signature blob comparing fields that should force a cache miss when they change. The signature included model/key/base_url/provider/max_tokens/fallback/toolsets/reasoning — but **not the active profile home**. Same-session profile switches keep `session_id` stable and don't touch any of those fields, so every signature input matched and the stale agent was reused.

`_profile_home` is already resolved a few hundred lines earlier in the same function (line ~1942-1953) for thread-env setup, so the fix is purely additive — append it to the signature blob.

## Fix

Added `_profile_home or ''` as the ninth field in the signature blob. Profile switches now produce a different signature, force a cache miss, and rebuild the agent under the new profile's `HERMES_HOME` — which means a fresh `load_soul_md()` call.

The `or ''` fallback preserves cache stability for single-profile deployments where `_profile_home` may be empty.

## Tests

`tests/test_issue1897_profile_switch_agent_cache.py` — 3 source-string checks:

1. The cache signature includes `_profile_home`.
2. `_profile_home` is assigned BEFORE the signature is built (catches an ordering regression that would NameError at runtime).
3. The signature uses `_profile_home or ''` (catches a regression that would churn the cache on every turn for empty-HERMES_HOME deployments).

Source-string checks are sufficient here because the signature blob is a literal list driving cache-hit comparison; if `_profile_home` is in the list, profile switches force a miss. A unit test would require constructing a full streaming worker to exercise the cache path, which is disproportionate.

## Verification

```text
$ pytest tests/test_issue1897_profile_switch_agent_cache.py -v
test_cache_signature_includes_profile_home PASSED
test_profile_home_resolved_before_cache_signature PASSED
test_signature_uses_profile_home_with_fallback PASSED

$ pytest tests/ -k "streaming or session_agent_cache or profile" -q
343 passed, 2 skipped, 3 xpassed
```

## Notes for review

- Touches `api/streaming.py` only — no behavior change for new sessions, agents created on cache miss, or process-wide profile switches via the CLI path.
- Trivial conflict expected with #1877 (max_turns parity) which adds a different field to the same signature blob — both can co-exist; the merger will need to add both fields.
- ~7 LOC of behavior + ~70 LOC of tests + comments.
