### PR TITLE
fix: use root home for gateway health status

### DIFF
--- a/api/agent_health.py
+++ b/api/agent_health.py
@@ -10,8 +10,13 @@ heartbeat without shelling out or adding psutil as a hard dependency.
 from __future__ import annotations
 
 import importlib
+import json
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any
+
+_GATEWAY_PID_FILE = "gateway.pid"
+_GATEWAY_RUNTIME_STATUS_FILE = "gateway_state.json"
 
 
 def _checked_at() -> str:
@@ -21,6 +26,69 @@ def _checked_at() -> str:
 def _gateway_status_module():
     """Load gateway.status lazily so tests and WebUI-only installs stay isolated."""
     return importlib.import_module("gateway.status")
+
+
+def _gateway_root_pid_path() -> Path | None:
+    """Return the root Hermes gateway PID path.
+
+    Gateway runtime files are root-level singletons.  A profile-scoped WebUI
+    process may have HERMES_HOME=<root>/profiles/<name>, but gateway.pid,
+    gateway.lock, and gateway_state.json still live under <root>.
+    """
+    try:
+        from hermes_constants import get_default_hermes_root
+        return get_default_hermes_root() / _GATEWAY_PID_FILE
+    except Exception:
+        return None
+
+
+def _read_runtime_status_path(path: Path) -> dict[str, Any] | None:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return None
+    if isinstance(payload, dict):
+        return payload
+    return None
+
+
+def _read_gateway_runtime_status(gateway_status: Any, pid_path: Path | None) -> dict[str, Any] | None:
+    read_runtime_status = gateway_status.read_runtime_status
+    if pid_path is not None:
+        try:
+            return read_runtime_status(pid_path=pid_path)
+        except TypeError:
+            try:
+                return read_runtime_status(pid_path)
+            except TypeError:
+                if getattr(gateway_status, "__name__", "") == "gateway.status" or hasattr(
+                    gateway_status,
+                    "_read_json_file",
+                ):
+                    runtime_status_file = str(
+                        getattr(gateway_status, "_RUNTIME_STATUS_FILE", _GATEWAY_RUNTIME_STATUS_FILE)
+                    )
+                    runtime_status = _read_runtime_status_path(pid_path.with_name(runtime_status_file))
+                    if runtime_status is not None:
+                        return runtime_status
+    return read_runtime_status()
+
+
+def _gateway_running_pid(gateway_status: Any, pid_path: Path | None) -> int | None:
+    get_running_pid = gateway_status.get_running_pid
+    if pid_path is not None:
+        try:
+            return get_running_pid(pid_path=pid_path, cleanup_stale=False)
+        except TypeError:
+            try:
+                return get_running_pid(pid_path, cleanup_stale=False)
+            except TypeError:
+                pass
+    try:
+        return get_running_pid(cleanup_stale=False)
+    except TypeError:
+        # Older agent versions may not expose cleanup_stale. Keep compatibility.
+        return get_running_pid()
 
 
 def _runtime_detail_subset(runtime_status: dict[str, Any] | None) -> dict[str, Any]:
@@ -86,17 +154,16 @@ def build_agent_health_payload() -> dict[str, Any]:
             },
         }
 
+    gateway_pid_path = _gateway_root_pid_path()
+
     runtime_status = None
     try:
-        runtime_status = gateway_status.read_runtime_status()
+        runtime_status = _read_gateway_runtime_status(gateway_status, gateway_pid_path)
     except Exception:
         runtime_status = None
 
     try:
-        running_pid = gateway_status.get_running_pid(cleanup_stale=False)
-    except TypeError:
-        # Older agent versions may not expose cleanup_stale. Keep compatibility.
-        running_pid = gateway_status.get_running_pid()
+        running_pid = _gateway_running_pid(gateway_status, gateway_pid_path)
     except Exception:
         running_pid = None
 

--- a/tests/test_issue716_agent_heartbeat.py
+++ b/tests/test_issue716_agent_heartbeat.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import json
 import pathlib
-
+import sys
+import types
 
 REPO_ROOT = pathlib.Path(__file__).parent.parent
+
 UI_JS = (REPO_ROOT / "static" / "ui.js").read_text(encoding="utf-8")
 INDEX_HTML = (REPO_ROOT / "static" / "index.html").read_text(encoding="utf-8")
 STYLE_CSS = (REPO_ROOT / "static" / "style.css").read_text(encoding="utf-8")
@@ -23,6 +26,33 @@ class _FakeGatewayStatus:
     def get_running_pid(self, cleanup_stale=False):
         assert cleanup_stale is False
         return self._running_pid
+
+
+class _PathSensitiveGatewayStatus:
+    _RUNTIME_STATUS_FILE = "gateway_state.json"
+
+    def __init__(self, root_home: pathlib.Path):
+        self.root_home = root_home
+        self.runtime_pid_path = None
+        self.running_pid_path = None
+
+    def read_runtime_status(self, pid_path=None):
+        self.runtime_pid_path = pathlib.Path(pid_path) if pid_path is not None else None
+        if self.runtime_pid_path:
+            base = self.runtime_pid_path.parent
+        else:
+            base = self.root_home / "profiles" / "troubleshooting"
+        path = base / self._RUNTIME_STATUS_FILE
+        if not path.exists():
+            return None
+        return json.loads(path.read_text(encoding="utf-8"))
+
+    def get_running_pid(self, pid_path=None, cleanup_stale=False):
+        assert cleanup_stale is False
+        self.running_pid_path = pathlib.Path(pid_path) if pid_path is not None else None
+        if self.running_pid_path == self.root_home / "gateway.pid":
+            return 98765
+        return None
 
 
 def _runtime_status(**overrides):
@@ -43,6 +73,32 @@ def _runtime_status(**overrides):
     }
     payload.update(overrides)
     return payload
+
+
+def test_agent_health_uses_root_gateway_state_when_hermes_home_is_profile(monkeypatch, tmp_path):
+    from api import agent_health
+
+    root_home = tmp_path / "root-home"
+    profile_home = root_home / "profiles" / "troubleshooting"
+    profile_home.mkdir(parents=True)
+    (root_home / "gateway.pid").write_text(json.dumps({"pid": 98765}), encoding="utf-8")
+    (root_home / "gateway_state.json").write_text(json.dumps(_runtime_status()), encoding="utf-8")
+    fake_gateway_status = _PathSensitiveGatewayStatus(root_home)
+
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_constants",
+        types.SimpleNamespace(get_default_hermes_root=lambda: root_home),
+    )
+    monkeypatch.setattr(agent_health, "_gateway_status_module", lambda: fake_gateway_status)
+
+    payload = agent_health.build_agent_health_payload()
+
+    assert payload["alive"] is True
+    assert payload["details"]["state"] == "alive"
+    assert fake_gateway_status.runtime_pid_path == root_home / "gateway.pid"
+    assert fake_gateway_status.running_pid_path == root_home / "gateway.pid"
 
 
 def test_agent_health_payload_alive_uses_safe_runtime_details(monkeypatch):


### PR DESCRIPTION
## Thinking Path

- Hermes gateway runtime state is a root-level singleton, while WebUI can run under a profile-scoped `HERMES_HOME`.
- The agent health payload is the source of truth for `/api/gateway/status`, so fixing the path resolution there keeps the dashboard and heartbeat banner aligned.
- The bug was that gateway liveness/runtime reads followed the active profile home and missed root `gateway.pid` / `gateway_state.json` files.
- This PR resolves the gateway PID path through `get_default_hermes_root()` and passes that root path into gateway status helpers, with a compatibility fallback for installed Agent versions whose `read_runtime_status()` has not yet accepted `pid_path`.

## What Changed

- Added root gateway PID path resolution in `api/agent_health.py` using `hermes_constants.get_default_hermes_root()`.
- Routed runtime-status and running-PID checks through small helpers that prefer the root `gateway.pid` path while preserving compatibility with older gateway status helper signatures.
- Added regression coverage for a profile-scoped WebUI home where gateway state files exist only under the root Hermes home.
- Isolated the regression test from local developer installs by stubbing `hermes_constants.get_default_hermes_root()`, matching CI where Hermes Agent modules are not installed globally.

## Why It Matters

A WebUI running under `~/.hermes/profiles/<name>` should not report the root gateway as down just because the singleton gateway state files are not duplicated into that profile directory. This prevents false "Gateway not running" status and heartbeat alerts for multi-profile deployments.

Fixes #1878

## Verification

- RED check: copied the new regression test onto `origin/master`; `test_agent_health_uses_root_gateway_state_when_hermes_home_is_profile` failed with `assert None is True` as expected.
- `env -u HERMES_CONFIG_PATH -u HERMES_WEBUI_HOST /home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_issue716_agent_heartbeat.py::test_agent_health_uses_root_gateway_state_when_hermes_home_is_profile tests/test_issue716_agent_heartbeat.py tests/test_gateway_status_agent_health.py -q` — 19 passed.
- `env -u HERMES_CONFIG_PATH -u HERMES_WEBUI_HOST /home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/ -q` — 4824 passed, 4 skipped, 3 xpassed, 1 warning, 8 subtests passed in 366.90s.
- `git diff --check origin/master...HEAD` — passed.
- `node --check` — not applicable; no JavaScript files changed.

## Risks / Follow-ups

- This intentionally does not implement the separate cross-container PID namespace fallback tracked in #1879 / PR #1887.
- The compatibility fallback reads `gateway_state.json` directly only when the imported module is `gateway.status`/Agent-like and does not accept `pid_path`, so unit-test fakes and WebUI-only installs continue to behave as before.
- Backend-only behavior change; no UI screenshots included because no interface or interaction flow changed.

## Model Used

- Provider: OpenAI Codex via Hermes Agent
- Model: gpt-5.5
- Tool use: Kanban task tools, GitHub CLI, file edits, pytest verification
