### PR TITLE
fix: respect context-length overrides in streaming fallback

### DIFF
--- a/api/streaming.py
+++ b/api/streaming.py
@@ -27,6 +27,7 @@ from api.config import (
     SESSION_AGENT_LOCKS, SESSION_AGENT_LOCKS_LOCK,
     resolve_model_provider,
     model_with_provider_context,
+    get_config,
 )
 from api.helpers import redact_session_data, _redact_text
 from api.metering import meter
@@ -59,6 +60,72 @@ def _get_ai_agent():
         except ImportError:
             pass
     return AIAgent
+
+
+def _coerce_positive_int(value) -> Optional[int]:
+    try:
+        coerced = int(value)
+    except (TypeError, ValueError):
+        return None
+    return coerced if coerced > 0 else None
+
+
+def _resolve_context_length_fallback(
+    agent,
+    *,
+    resolved_model: str | None = None,
+    resolved_provider: str | None = None,
+    resolved_base_url: str | None = None,
+) -> int:
+    """Resolve a context window for fallback UI/session metering.
+
+    Mirrors AIAgent startup context resolution closely enough for the two
+    post-stream fallback sites: explicit ``model.context_length`` and
+    ``custom_providers`` per-model overrides must be forwarded to
+    ``agent.model_metadata.get_model_context_length()`` before it reaches the
+    broad 256K default.
+    """
+    try:
+        active_cfg = get_config()
+    except Exception:
+        active_cfg = {}
+    if not isinstance(active_cfg, dict):
+        active_cfg = {}
+
+    model_cfg = active_cfg.get("model", {})
+    if not isinstance(model_cfg, dict):
+        model_cfg = {}
+
+    config_context_length = _coerce_positive_int(
+        getattr(agent, "_config_context_length", None)
+    )
+    if config_context_length is None:
+        config_context_length = _coerce_positive_int(
+            model_cfg.get("context_length")
+        )
+
+    custom_providers = active_cfg.get("custom_providers")
+    if not isinstance(custom_providers, list):
+        custom_providers = None
+
+    model = getattr(agent, 'model', resolved_model or '') or resolved_model or ''
+    base_url = getattr(agent, 'base_url', '') or resolved_base_url or ''
+    provider = getattr(agent, 'provider', resolved_provider or '') or resolved_provider or ''
+
+    try:
+        from agent.model_metadata import get_model_context_length
+        return get_model_context_length(
+            model,
+            base_url,
+            config_context_length=config_context_length,
+            provider=provider,
+            custom_providers=custom_providers,
+        )
+    except Exception:
+        # Older hermes-agent builds may not expose this helper or may not accept
+        # the newer keyword arguments. Leave the caller's context_length unset
+        # rather than breaking stream completion/session persistence.
+        return 0
 
 
 def _is_quota_error_text(err_text: str) -> bool:
@@ -2949,15 +3016,15 @@ def _run_agent_streaming(
                 # follow-up after PR #1344 was closed as superseded by #1341.
                 if not getattr(s, 'context_length', 0):
                     try:
-                        from agent.model_metadata import get_model_context_length
-                        _resolved_cl = get_model_context_length(
-                            getattr(agent, 'model', resolved_model or '') or '',
-                            getattr(agent, 'base_url', '') or '',
+                        _resolved_cl = _resolve_context_length_fallback(
+                            agent,
+                            resolved_model=resolved_model,
+                            resolved_provider=resolved_provider,
+                            resolved_base_url=resolved_base_url,
                         )
                         if _resolved_cl:
                             s.context_length = _resolved_cl
                     except Exception:
-                        # Older hermes-agent builds may not expose this helper.
                         # Better to leave context_length=0 than crash the save.
                         pass
                 s.save()
@@ -3001,10 +3068,11 @@ def _run_agent_streaming(
             # JS default.  Mirrors the session-save fallback above (lines ~2205-2217).
             if not usage.get('context_length'):
                 try:
-                    from agent.model_metadata import get_model_context_length as _get_cl
-                    _fb_cl = _get_cl(
-                        getattr(agent, 'model', resolved_model or '') or '',
-                        getattr(agent, 'base_url', '') or '',
+                    _fb_cl = _resolve_context_length_fallback(
+                        agent,
+                        resolved_model=resolved_model,
+                        resolved_provider=resolved_provider,
+                        resolved_base_url=resolved_base_url,
                     )
                     if _fb_cl:
                         usage['context_length'] = _fb_cl

--- a/tests/test_pr1318_context_length_fallback.py
+++ b/tests/test_pr1318_context_length_fallback.py
@@ -17,8 +17,11 @@ Tests:
 4. Fallback exception is silently swallowed (older agent builds)
 5. Fallback runs before s.save() so the value is persisted
 """
+import importlib
 import re
+import sys
 from pathlib import Path
+from types import ModuleType, SimpleNamespace
 
 STREAMING = Path(__file__).resolve().parent.parent / "api" / "streaming.py"
 
@@ -35,13 +38,44 @@ def _persistence_block():
     return src[start:end]
 
 
+def _usage_payload_block():
+    """Return the source range covering the live SSE usage payload fallback."""
+    src = STREAMING.read_text(encoding="utf-8")
+    start = src.find("usage = {")
+    assert start != -1, "usage payload block not found in streaming.py"
+    end = src.find("put('done'", start)
+    assert end != -1, "done SSE payload not found after usage block"
+    return src[start:end]
+
+
+def _resolver_helper_block():
+    """Return the helper that resolves context length for both fallback sites."""
+    src = STREAMING.read_text(encoding="utf-8")
+    start = src.find("def _resolve_context_length_fallback(")
+    assert start != -1, "context-length fallback helper missing"
+    end = src.find("\n\ndef ", start + 1)
+    assert end != -1, "helper end marker not found"
+    return src[start:end]
+
+
+def _install_fake_model_metadata(monkeypatch, get_model_context_length):
+    """Install a fake agent.model_metadata module for CI, where hermes-agent is absent."""
+    agent_pkg = ModuleType("agent")
+    agent_pkg.__path__ = []
+    metadata = ModuleType("agent.model_metadata")
+    metadata.get_model_context_length = get_model_context_length
+    monkeypatch.setitem(sys.modules, "agent", agent_pkg)
+    monkeypatch.setitem(sys.modules, "agent.model_metadata", metadata)
+    return metadata
+
+
 def test_fallback_uses_model_metadata():
-    """Block must import and call get_model_context_length on missing compressor data."""
-    block = _persistence_block()
-    assert "from agent.model_metadata import get_model_context_length" in block, (
+    """Fallback helper must import and call get_model_context_length on missing compressor data."""
+    helper = _resolver_helper_block()
+    assert "from agent.model_metadata import get_model_context_length" in helper, (
         "Fallback must import get_model_context_length from agent.model_metadata"
     )
-    assert "get_model_context_length(" in block, (
+    assert "get_model_context_length(" in helper, (
         "Fallback must call get_model_context_length()"
     )
 
@@ -61,21 +95,19 @@ def test_fallback_gates_on_falsy_context_length():
 
 
 def test_fallback_passes_model_and_base_url():
-    """Fallback must source the model and base_url from the agent itself."""
-    block = _persistence_block()
-    # Must reference both agent.model and agent.base_url in the call
-    assert "agent, 'model'" in block, "Fallback must read agent.model"
-    assert "agent, 'base_url'" in block, "Fallback must read agent.base_url"
+    """Fallback helper must source model and base_url from the agent itself."""
+    helper = _resolver_helper_block()
+    assert "agent, 'model'" in helper, "Fallback must read agent.model"
+    assert "agent, 'base_url'" in helper, "Fallback must read agent.base_url"
 
 
 def test_fallback_exception_is_swallowed():
     """If get_model_context_length raises (older agent build, network error,
     bad provider config), the fallback must not break s.save()."""
     block = _persistence_block()
-    # Must wrap the import + call in try/except
+    # Must wrap the call in try/except so session save still completes.
     fallback_section = block[block.find("Fallback"):]
     assert "try:" in fallback_section, "Fallback must use try/except"
-    # except Exception: pass-style — old agent builds may not have this helper at all
     assert "except Exception:" in fallback_section, (
         "Fallback must catch broad Exception (older agent builds may not have the helper)"
     )
@@ -84,7 +116,7 @@ def test_fallback_exception_is_swallowed():
 def test_fallback_runs_before_save():
     """The fallback must mutate s.context_length BEFORE s.save() so the value lands on disk."""
     block = _persistence_block()
-    fallback_idx = block.find("get_model_context_length")
+    fallback_idx = block.find("_resolve_context_length_fallback")
     save_idx = block.rfind("s.save()")
     assert fallback_idx != -1 and save_idx != -1
     assert fallback_idx < save_idx, (
@@ -97,8 +129,182 @@ def test_fallback_assigns_context_length_when_resolved():
     """The fallback must assign s.context_length when get_model_context_length returns a non-zero value."""
     block = _persistence_block()
     fallback_section = block[block.find("Fallback"):]
-    # Must have an `if _resolved_cl:` guard followed by `s.context_length = _resolved_cl`
     assert "_resolved_cl" in fallback_section, "Fallback must capture the result"
     assert "s.context_length = _resolved_cl" in fallback_section, (
         "Fallback must assign the resolved value to s.context_length"
     )
+
+
+def test_persistence_fallback_uses_shared_full_context_resolver():
+    """Session-save fallback must use the shared resolver that threads config/provider context."""
+    block = _persistence_block()
+    assert "_resolve_context_length_fallback(" in block
+    assert "resolved_model=resolved_model" in block
+    assert "resolved_provider=resolved_provider" in block
+    assert "resolved_base_url=resolved_base_url" in block
+
+
+def test_sse_usage_fallback_uses_shared_full_context_resolver():
+    """Live SSE usage fallback must mirror the persisted-session context resolver."""
+    block = _usage_payload_block()
+    assert "_resolve_context_length_fallback(" in block
+    assert "resolved_model=resolved_model" in block
+    assert "resolved_provider=resolved_provider" in block
+    assert "resolved_base_url=resolved_base_url" in block
+
+
+def test_shared_resolver_threads_config_provider_and_custom_providers():
+    """The resolver must pass all context that agent.model_metadata needs."""
+    helper = _resolver_helper_block()
+    assert "get_config()" in helper
+    assert "config_context_length=" in helper
+    assert "provider=" in helper
+    assert "custom_providers=" in helper
+    assert "getattr(agent, 'provider'" in helper
+
+
+def test_shared_resolver_respects_model_context_length_override(monkeypatch):
+    """Configured model.context_length must win over the 256K metadata fallback."""
+    streaming = importlib.import_module("api.streaming")
+    calls = []
+
+    def fake_get_model_context_length(
+        model,
+        base_url="",
+        api_key="",
+        config_context_length=None,
+        provider="",
+        custom_providers=None,
+    ):
+        calls.append(
+            {
+                "model": model,
+                "base_url": base_url,
+                "config_context_length": config_context_length,
+                "provider": provider,
+                "custom_providers": custom_providers,
+            }
+        )
+        return config_context_length or 256_000
+
+    _install_fake_model_metadata(monkeypatch, fake_get_model_context_length)
+    monkeypatch.setattr(
+        streaming,
+        "get_config",
+        lambda: {"model": {"context_length": 1_048_576}, "custom_providers": []},
+    )
+
+    agent = SimpleNamespace(
+        model="deepseek-v4-flash",
+        base_url="https://example.invalid/v1",
+        provider="custom:deepseek",
+        context_compressor=SimpleNamespace(context_length=0),
+    )
+
+    resolved = streaming._resolve_context_length_fallback(
+        agent,
+        resolved_model="deepseek-v4-flash",
+        resolved_provider="custom:deepseek",
+        resolved_base_url="https://example.invalid/v1",
+    )
+
+    assert resolved == 1_048_576
+    assert calls[-1]["config_context_length"] == 1_048_576
+    assert calls[-1]["provider"] == "custom:deepseek"
+    assert calls[-1]["custom_providers"] == []
+
+
+def test_shared_resolver_passes_custom_provider_model_overrides(monkeypatch):
+    """Named custom provider model context overrides must reach the metadata resolver."""
+    streaming = importlib.import_module("api.streaming")
+    custom_providers = [
+        {
+            "name": "DeepSeek Gateway",
+            "base_url": "https://deepseek.example/v1",
+            "models": {
+                "deepseek-v4-flash": {"context_length": 1_048_576},
+            },
+        }
+    ]
+    calls = []
+
+    def fake_get_model_context_length(
+        model,
+        base_url="",
+        api_key="",
+        config_context_length=None,
+        provider="",
+        custom_providers=None,
+    ):
+        calls.append(
+            {
+                "model": model,
+                "base_url": base_url,
+                "config_context_length": config_context_length,
+                "provider": provider,
+                "custom_providers": custom_providers,
+            }
+        )
+        model_cfg = custom_providers[0]["models"][model]
+        return int(model_cfg["context_length"])
+
+    _install_fake_model_metadata(monkeypatch, fake_get_model_context_length)
+    monkeypatch.setattr(
+        streaming,
+        "get_config",
+        lambda: {"model": {}, "custom_providers": custom_providers},
+    )
+
+    agent = SimpleNamespace(
+        model="deepseek-v4-flash",
+        base_url="https://deepseek.example/v1",
+        provider="custom:deepseek-gateway",
+    )
+
+    resolved = streaming._resolve_context_length_fallback(
+        agent,
+        resolved_model="deepseek-v4-flash",
+        resolved_provider="custom:deepseek-gateway",
+        resolved_base_url="https://deepseek.example/v1",
+    )
+
+    assert resolved == 1_048_576
+    assert calls[-1]["base_url"] == "https://deepseek.example/v1"
+    assert calls[-1]["provider"] == "custom:deepseek-gateway"
+    assert calls[-1]["custom_providers"] == custom_providers
+
+
+def test_shared_resolver_preserves_default_metadata_fallback(monkeypatch):
+    """Without config/custom overrides, the underlying metadata fallback still decides."""
+    streaming = importlib.import_module("api.streaming")
+    calls = []
+
+    def fake_get_model_context_length(
+        model,
+        base_url="",
+        api_key="",
+        config_context_length=None,
+        provider="",
+        custom_providers=None,
+    ):
+        calls.append(
+            {
+                "model": model,
+                "base_url": base_url,
+                "config_context_length": config_context_length,
+                "provider": provider,
+                "custom_providers": custom_providers,
+            }
+        )
+        return 256_000
+
+    _install_fake_model_metadata(monkeypatch, fake_get_model_context_length)
+    monkeypatch.setattr(streaming, "get_config", lambda: {"model": {}})
+
+    agent = SimpleNamespace(model="unknown-model", base_url="", provider="")
+
+    resolved = streaming._resolve_context_length_fallback(agent)
+
+    assert resolved == 256_000
+    assert calls[-1]["config_context_length"] is None
+    assert calls[-1]["custom_providers"] is None


### PR DESCRIPTION
## Thinking Path

- Hermes WebUI persists context-window metadata after a streamed turn and also sends it in the live SSE `done` usage payload.
- Both fallback paths ran when `agent.context_compressor.context_length` was missing or zero, but they only passed `model` and `base_url` to `get_model_context_length()`.
- That skipped explicit `model.context_length`, active provider metadata, and `custom_providers` per-model overrides, so 1M-context models could be displayed as the default 256K window.
- The narrow fix is to share one fallback resolver that mirrors the agent metadata call context and use it for both persistence and the SSE payload.
- This keeps existing fallback behavior delegated to `agent.model_metadata` while allowing configured overrides to win before the broad default.

## What Changed

- Added `_resolve_context_length_fallback()` in `api/streaming.py`.
- The helper reads active WebUI/Hermes config via `get_config()`, coerces positive `model.context_length` overrides, threads active provider/base URL/model metadata, and passes `custom_providers` through to `agent.model_metadata.get_model_context_length()`.
- Replaced both streaming fallback callsites with the shared helper:
  - session persistence before `s.save()`
  - live SSE `done` usage payload
- Expanded `tests/test_pr1318_context_length_fallback.py` to cover:
  - both fallback callsites using the shared resolver
  - `model.context_length: 1048576` override propagation
  - named custom-provider per-model context override propagation
  - default metadata fallback behavior when no override exists

Fixes #1896

## Why It Matters

Users with 1M-context models or explicit context-window overrides should not see the toolbar report ~262K tokens or trip auto-compression around 65K tokens. This prevents early/looping compression behavior caused by the WebUI under-reporting the actual context window when the compressor has not populated its value yet.

## Verification

- `env -u HERMES_CONFIG_PATH -u HERMES_WEBUI_HOST /home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_pr1318_context_length_fallback.py -q` → 12 passed
- `env -u HERMES_CONFIG_PATH -u HERMES_WEBUI_HOST /home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_pr1318_context_length_fallback.py tests/test_pr1341_context_window_persistence.py tests/test_sprint42.py -q` → 41 passed
- `env -u HERMES_CONFIG_PATH -u HERMES_WEBUI_HOST /home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/ -q` → 4829 passed, 4 skipped, 3 xpassed, 1 warning, 8 subtests passed
- `/home/michael/.hermes/hermes-agent/venv/bin/python -m py_compile api/streaming.py tests/test_pr1318_context_length_fallback.py`
- `git diff --check`
- No JS files changed, so `node --check` was not applicable.
- No UI/UX rendering changes, so screenshots/video are not applicable.

## Risks / Follow-ups

- The helper intentionally catches metadata-resolution exceptions and leaves the fallback value unset, preserving the previous “do not break stream completion/session save” behavior.
- This PR only fixes the WebUI fallback paths; it does not change the agent metadata resolver itself.

## Model Used

- OpenAI Codex `gpt-5.5`
- Tool use: terminal, file search/read/write/patch, GitHub CLI, Hermes Kanban tools
