### PR TITLE
v0.51.25 — Release C: 6-PR streaming/runtime batch (profile-isolated quotas, wedge diagnostics, max_turns, per-turn usage, interim_assistant SSE, workspace dedup)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Hermes Web UI -- Changelog
 
+## [v0.51.25] — 2026-05-08 — 6-PR streaming/runtime contributor batch (Release C: profile-isolated quota probes, request wedge diagnostics, max_turns config honor, per-turn usage overwrite, interim_assistant SSE wiring, workspace-prefix transcript dedup)
+
+### Fixed (6 PRs)
+
+- **PR #1873** by @franksong2702 — Subprocess-based profile isolation for quota fetches. The original #1831 attempt added per-profile locks but CI exposed that approach as unsafe — `cron_profile_context_for_home()` mutates process-global `os.environ['HERMES_HOME']` and cron module globals. Per-profile locks would let different profile homes enter concurrently and one thread could observe another profile's home. This rework spawns subprocess workers (one per profile) that run quota probes in their own process with their own env vars, communicating results back via JSON over stdout. Eliminates the env-mutation race entirely. Closes #1831. **Operational follow-up filed:** worker-pool refactor + `prctl(PR_SET_PDEATHSIG)` + `BoundedSemaphore` concurrency cap before this hits busy multi-profile installs (current synchronous-spawn-per-probe is correct but inefficient under load).
+
+- **PR #1860** by @franksong2702 — Targeted slow-request diagnostics for the two #1855 paths (`POST /api/chat/start` + `GET /api/sessions`). Adds a lightweight `RequestDiagnostics` watchdog that only starts for those two paths. If a request is still running after the configured threshold, it logs a structured warning with request id, method, path, start time, elapsed time, current stage, accumulated stage timings, and Python thread stack snapshots. Completed requests that exceed the same threshold also log their stage timings (without thread stacks). **Does NOT alter locking or request semantics** — pure observability slice. `_diag_stage()` is a no-op shim when `diag=None` (the 99% path), so per-request overhead is near-zero. Refs #1855.
+
+- **PR #1877** by @Michaelyklam — Read `agent.max_turns` config when constructing WebUI streaming `AIAgent` instances. Pass the parsed positive value as `max_iterations` when the installed agent supports it (`'max_iterations' in _agent_params` gating, same pattern as `max_tokens`/`reasoning_config`). Include the parsed budget in the per-session agent cache signature so budget changes rebuild cached agents instead of reusing stale instances. Closes #1876.
+
+- **PR #1861** by @franksong2702 — Session usage counters (`input_tokens`, `output_tokens`, `estimated_cost`) were being **accumulated** on every completed turn. Because prompt tokens represent the full current context (which already contains all prior turns), accumulation double-counts and inflates long-session usage. Fix: store the most recent turn's values rather than the cumulative sum. **Defensive in-stage absorption (per Opus advisor on stage-320):** added `> 0` / `is not None` guards before overwriting `s.input_tokens` / `s.output_tokens` / `s.estimated_cost` so a rebuilt-from-cache-miss agent (post-restart, post-LRU-eviction) doesn't zero out persisted disk totals on its next turn. Closes #1857.
+
+- **PR #1865** by @franksong2702 — Wire runtime's `interim_assistant_callback` contract through the WebUI SSE stream. Pre-fix, the runtime emitted user-visible interim assistant commentary (e.g. "I'll inspect the workspace files now.") via the callback contract on AIAgent, but WebUI's SSE stream had no event path for it and the messages were swallowed. Fix: forward the callback through to `put('interim_assistant', {'text': visible, 'already_streamed': bool})` SSE events; frontend renders them as separate-but-non-tool live segments. The `already_streamed` flag tells the renderer not to duplicate text already emitted via `token` events (Codex-style backends). Single-purpose PR after the contributor split out earlier scope creep into separate PRs (#1869 / #1870 / #1871 / #1873).
+
+- **PR #1889** by @ai-ag2026 — WebUI sends model-facing `[Workspace: ...]` prefix to user prompts; transcript compaction was treating the prefixed and unprefixed forms as different turns and creating adjacent duplicate user bubbles. Fix: strip workspace prefix during current-user identity matching so context-compaction merges don't duplicate. The visible bubble's display content gets cleaned of the prefix during compaction merge — a desirable side effect. Refs #1217. **Follow-up filed:** consider distinguishing-sentinel format (`[Workspace::v1: ...]` or nonce) so user-typed `[Workspace: ...]` text isn't silently eaten; also handle workspace paths containing `]`. Pre-existing behavior in master (`api/streaming.py:1054` already used the same regex), this PR extends the same convention.
+
+### Tests
+
+4858 → **4872 collected, 4861 passing, 0 regressions** (+14 net new). Full suite ~145s on Python 3.11. JS syntax check (`node -c`) passes on `static/messages.js`. Browser API sanity harness (port 8789) all-green: 11 endpoints verified. Opus advisor pass: SHIP with three Medium-severity follow-ups (one absorbed in-release, two filed for follow-up PRs).
+
+### Pre-release verification
+
+- Full pytest under `HERMES_HOME` isolation: **4861 passed, 8 skipped, 1 xfailed, 2 xpassed, 8 subtests passed** in 145.96s.
+- Browser API harness against stage-320 on port 8789: all 11 checks PASS.
+- `node -c` on `static/messages.js`: clean.
+- Stage diff: 13 files, +1216/-196 (heavy in tests).
+- Opus advisor pass on stage-320 brief: **SHIP** with three Medium-severity concerns (one absorbed in-release: #1861 restart-zeros-totals defensive guard; two filed as follow-ups: #1873 worker-pool ops refactor, #1889 sentinel/nonce regex tightening).
+- Pre-stamp re-fetch of all 6 PR heads: no contributor force-pushes during the Opus window.
+
+### Opus-applied fixes (absorbed in-release)
+
+**From stage-320 absorption (this release):**
+- **#1861 restart-zeros-totals defensive guard.** Opus identified that the new per-turn overwrite at `api/streaming.py:2925-2927` would zero out `s.input_tokens` / `s.output_tokens` / `s.estimated_cost` on the first turn after a WebUI restart or LRU cache eviction (the rebuilt agent's `session_*` running totals start at zero and would overwrite the persisted disk values). Added `> 0` / `is not None` guards before each overwrite. Test still passes; the guard preserves PR #1861's intended fix while preventing the restart-induced regression. <10 LOC, clearly defensive.
+
 ## [v0.51.24] — 2026-05-08 — 5-PR contributor batch (Release B: local-server custom-provider model preservation, oversized upload preflight, ai-gateway phantom Custom group fix, Kanban lifecycle controls, cross-container gateway liveness)
 
 ### Fixed (5 PRs)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 > Web companion to the Hermes Agent CLI. Same workflows, browser-native.
 >
-> Last updated: v0.51.24 (May 8, 2026) — 4858 tests collected — 5-PR Release B batch (local-server custom-provider model preservation, oversized upload preflight, ai-gateway phantom Custom group, Kanban lifecycle controls, cross-container gateway liveness)
+> Last updated: v0.51.25 (May 8, 2026) — 4872 tests collected — 6-PR Release C batch (profile-isolated quota probes, request wedge diagnostics, max_turns config honor, per-turn usage overwrite, interim_assistant SSE wiring, workspace-prefix transcript dedup)
 > Test source: `pytest tests/ --collect-only -q`
 > Per-version detail: see [CHANGELOG.md](./CHANGELOG.md)
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -1835,8 +1835,8 @@ Bridged CLI sessions:
 
 ---
 
-*Last updated: v0.51.24, May 8, 2026*
-*Total automated tests collected: 4858*
+*Last updated: v0.51.25, May 8, 2026*
+*Total automated tests collected: 4872*
 *Regression gate: tests/test_regressions.py*
 *Run: pytest tests/ -v --timeout=60*
 *Source: <repo>/*

--- a/api/models.py
+++ b/api/models.py
@@ -966,12 +966,24 @@ def _enrich_sidebar_lineage_metadata(sessions: list[dict]) -> None:
             session.update(metadata[sid])
 
 
-def all_sessions():
+def _diag_stage(diag, name: str) -> None:
+    if diag is not None:
+        try:
+            diag.stage(name)
+        except Exception:
+            pass
+
+
+def all_sessions(diag=None):
+    _diag_stage(diag, "all_sessions.active_streams")
     active_stream_ids = _active_stream_ids()
     # Phase C: try index first for O(1) read; fall back to full scan
+    _diag_stage(diag, "all_sessions.index_exists")
     if SESSION_INDEX_FILE.exists():
         try:
+            _diag_stage(diag, "all_sessions.read_index")
             index = json.loads(SESSION_INDEX_FILE.read_text(encoding='utf-8'))
+            _diag_stage(diag, "all_sessions.prune_index")
             index = [
                 s for s in index
                 if _index_entry_exists(s.get('session_id'))
@@ -979,21 +991,25 @@ def all_sessions():
             backfilled = []
             for i, s in enumerate(index):
                 if 'last_message_at' not in s:
+                    _diag_stage(diag, "all_sessions.backfill_load")
                     full = Session.load(s.get('session_id'))
                     if full:
                         index[i] = full.compact()
                         backfilled.append(full)
             if backfilled:
                 try:
+                    _diag_stage(diag, "all_sessions.backfill_write")
                     _write_session_index(updates=backfilled)
                 except Exception:
                     logger.debug("Failed to persist last_message_at backfill")
+            _diag_stage(diag, "all_sessions.mark_streaming")
             for s in index:
                 s['is_streaming'] = _is_streaming_session(
                     s.get('active_stream_id'),
                     active_stream_ids,
                 )
             # Overlay any in-memory sessions that may be newer than the index
+            _diag_stage(diag, "all_sessions.overlay_lock")
             index_map = {s['session_id']: s for s in index}
             with LOCK:
                 for s in SESSIONS.values():
@@ -1001,6 +1017,7 @@ def all_sessions():
                         include_runtime=True,
                         active_stream_ids=active_stream_ids,
                     )
+            _diag_stage(diag, "all_sessions.sort_filter")
             result = sorted(index_map.values(), key=lambda s: (s.get('pinned', False), _session_sort_timestamp(s)), reverse=True)
             # Hide empty Untitled sessions from the UI entirely — they are ephemeral
             # scratch pads that only become real once the first message is sent (#1171).
@@ -1025,11 +1042,13 @@ def all_sessions():
             for s in result:
                 if not s.get('profile'):
                     s['profile'] = 'default'
+            _diag_stage(diag, "all_sessions.lineage_metadata")
             _enrich_sidebar_lineage_metadata(result)
             return result
         except Exception:
             logger.debug("Failed to load session index, falling back to full scan")
     # Full scan fallback
+    _diag_stage(diag, "all_sessions.full_scan")
     out = []
     for p in SESSION_DIR.glob('*.json'):
         if p.name.startswith('_'): continue
@@ -1038,8 +1057,10 @@ def all_sessions():
             if s: out.append(s)
         except Exception:
             logger.debug("Failed to load session from %s", p)
+    _diag_stage(diag, "all_sessions.full_scan_overlay")
     for s in SESSIONS.values():
         if all(s.session_id != x.session_id for x in out): out.append(s)
+    _diag_stage(diag, "all_sessions.full_scan_sort_filter")
     out.sort(key=lambda s: (getattr(s, 'pinned', False), _session_sort_timestamp(s)), reverse=True)
     # Hide empty Untitled sessions from the UI entirely — kept consistent with the
     # index-path filter above. No grace window: a 0-message Untitled session is
@@ -1054,6 +1075,7 @@ def all_sessions():
     for s in result:
         if not s.get('profile'):
             s['profile'] = 'default'
+    _diag_stage(diag, "all_sessions.lineage_metadata")
     _enrich_sidebar_lineage_metadata(result)
     return result
 

--- a/api/providers.py
+++ b/api/providers.py
@@ -10,10 +10,13 @@ from __future__ import annotations
 import json
 import logging
 import os
+import subprocess
+import sys
 import urllib.error
 import urllib.request
 from datetime import datetime, timezone
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 from api.config import (
@@ -33,7 +36,53 @@ logger = logging.getLogger(__name__)
 
 _OPENROUTER_KEY_URL = "https://openrouter.ai/api/v1/key"
 _PROVIDER_QUOTA_TIMEOUT_SECONDS = 3.0
+_ACCOUNT_USAGE_SUBPROCESS_TIMEOUT_SECONDS = 35.0
 _ACCOUNT_USAGE_PROVIDERS = frozenset({"openai-codex", "anthropic"})
+_ACCOUNT_USAGE_SUBPROCESS_CODE = r"""
+import json
+import sys
+
+from agent.account_usage import fetch_account_usage
+
+
+def _iso(value):
+    if value in (None, ""):
+        return None
+    if hasattr(value, "isoformat"):
+        text = value.isoformat()
+        return text.replace("+00:00", "Z")
+    text = str(value).strip()
+    return text or None
+
+
+def _snapshot_payload(snapshot):
+    if snapshot is None:
+        return None
+    windows = []
+    for window in getattr(snapshot, "windows", ()) or ():
+        windows.append({
+            "label": str(getattr(window, "label", "") or ""),
+            "used_percent": getattr(window, "used_percent", None),
+            "reset_at": _iso(getattr(window, "reset_at", None)),
+            "detail": getattr(window, "detail", None),
+        })
+    return {
+        "provider": str(getattr(snapshot, "provider", "") or ""),
+        "source": str(getattr(snapshot, "source", "") or ""),
+        "title": str(getattr(snapshot, "title", "") or ""),
+        "plan": getattr(snapshot, "plan", None),
+        "windows": windows,
+        "details": list(getattr(snapshot, "details", ()) or ()),
+        "available": bool(getattr(snapshot, "available", bool(windows))),
+        "unavailable_reason": getattr(snapshot, "unavailable_reason", None),
+        "fetched_at": _iso(getattr(snapshot, "fetched_at", None)),
+    }
+
+
+provider = sys.argv[1]
+api_key = sys.argv[2] or None
+print(json.dumps(_snapshot_payload(fetch_account_usage(provider, api_key=api_key))))
+"""
 
 # SECTION: Provider ↔ env var mapping
 
@@ -420,19 +469,102 @@ def _agent_fetch_account_usage(provider: str, *, base_url: str | None = None, ap
     return fetch_account_usage(provider, base_url=base_url, api_key=api_key)
 
 
-def _fetch_account_usage_with_profile_context(provider: str) -> Any:
-    try:
-        from api.profiles import cron_profile_context_for_home
-    except ImportError:
-        cron_profile_context_for_home = None
+def _account_usage_subprocess_env(home: Path, provider: str, api_key: str | None) -> dict[str, str]:
+    env = dict(os.environ)
+    env["HERMES_HOME"] = str(Path(home))
 
+    # Profile .env values should affect only the child quota probe, not the
+    # WebUI process-global environment. This is especially important for
+    # Anthropic account usage, where the agent resolver reads OAuth/API tokens
+    # from environment variables.
+    for key, value in _load_env_file(Path(home) / ".env").items():
+        if value:
+            env[key] = value
+
+    env_var = _PROVIDER_ENV_VAR.get((provider or "").strip().lower())
+    if env_var and api_key:
+        env[env_var] = api_key
+
+    try:
+        from api.config import _AGENT_DIR
+    except Exception:
+        _AGENT_DIR = None
+    pythonpath_parts: list[str] = []
+    if _AGENT_DIR:
+        pythonpath_parts.append(str(_AGENT_DIR))
+    existing_pythonpath = env.get("PYTHONPATH", "")
+    if existing_pythonpath:
+        pythonpath_parts.append(existing_pythonpath)
+    if pythonpath_parts:
+        env["PYTHONPATH"] = os.pathsep.join(pythonpath_parts)
+    return env
+
+
+def _account_usage_payload_to_snapshot(payload: Any) -> Any:
+    if not isinstance(payload, dict):
+        return None
+    windows = tuple(
+        SimpleNamespace(
+            label=window.get("label"),
+            used_percent=window.get("used_percent"),
+            reset_at=window.get("reset_at"),
+            detail=window.get("detail"),
+        )
+        for window in (payload.get("windows") or ())
+        if isinstance(window, dict)
+    )
+    return SimpleNamespace(
+        provider=payload.get("provider"),
+        source=payload.get("source"),
+        title=payload.get("title"),
+        plan=payload.get("plan"),
+        windows=windows,
+        details=tuple(payload.get("details") or ()),
+        available=bool(payload.get("available")),
+        unavailable_reason=payload.get("unavailable_reason"),
+        fetched_at=payload.get("fetched_at"),
+    )
+
+
+def _agent_fetch_account_usage_for_home(provider: str, home: Path, *, api_key: str | None = None) -> Any:
+    try:
+        from api.config import PYTHON_EXE
+    except Exception:
+        PYTHON_EXE = sys.executable or "python3"
+
+    try:
+        proc = subprocess.run(
+            [PYTHON_EXE, "-c", _ACCOUNT_USAGE_SUBPROCESS_CODE, provider, api_key or ""],
+            env=_account_usage_subprocess_env(home, provider, api_key),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=_ACCOUNT_USAGE_SUBPROCESS_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        logger.debug("Account usage probe for %s timed out", provider)
+        return None
+    except Exception:
+        logger.debug("Account usage probe for %s failed to launch", provider, exc_info=True)
+        return None
+
+    if proc.returncode != 0:
+        logger.debug("Account usage probe for %s exited with status %s", provider, proc.returncode)
+        return None
+    try:
+        payload = json.loads((proc.stdout or "").strip() or "null")
+    except json.JSONDecodeError:
+        logger.debug("Account usage probe for %s returned invalid JSON", provider)
+        return None
+    return _account_usage_payload_to_snapshot(payload)
+
+
+def _fetch_account_usage_with_profile_context(provider: str) -> Any:
     home = _get_hermes_home()
     api_key = _get_provider_api_key(provider)
     try:
-        if cron_profile_context_for_home is None:
-            return _agent_fetch_account_usage(provider, api_key=api_key)
-        with cron_profile_context_for_home(home):
-            return _agent_fetch_account_usage(provider, api_key=api_key)
+        return _agent_fetch_account_usage_for_home(provider, home, api_key=api_key)
     except Exception:
         logger.debug("Failed to fetch account usage for %s", provider, exc_info=True)
         return None

--- a/api/request_diagnostics.py
+++ b/api/request_diagnostics.py
@@ -1,0 +1,160 @@
+"""Slow request diagnostics for latency-sensitive browser API paths."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+import threading
+import time
+import traceback
+import uuid
+from typing import Any
+
+
+DEFAULT_SLOW_REQUEST_SECONDS = 5.0
+MAX_STACK_FRAMES_PER_THREAD = 40
+
+
+def _slow_request_seconds() -> float:
+    raw = os.getenv("HERMES_WEBUI_SLOW_REQUEST_SECONDS", "").strip()
+    if not raw:
+        return DEFAULT_SLOW_REQUEST_SECONDS
+    try:
+        value = float(raw)
+    except ValueError:
+        return DEFAULT_SLOW_REQUEST_SECONDS
+    return max(0.0, value)
+
+
+class RequestDiagnostics:
+    """Track request stages and emit a watchdog record if a request wedges."""
+
+    def __init__(
+        self,
+        method: str,
+        path: str,
+        *,
+        logger: logging.Logger | None = None,
+        timeout_seconds: float | None = None,
+        auto_start: bool = True,
+    ) -> None:
+        self.request_id = uuid.uuid4().hex[:10]
+        self.method = str(method or "-")
+        self.path = str(path or "-").split("?", 1)[0]
+        self.logger = logger or logging.getLogger(__name__)
+        self.timeout_seconds = _slow_request_seconds() if timeout_seconds is None else max(0.0, float(timeout_seconds))
+        self.started_monotonic = time.monotonic()
+        self.started_wall = time.time()
+        self._lock = threading.Lock()
+        self._stages: list[dict[str, Any]] = []
+        self._current_stage = "start"
+        self._current_stage_started = self.started_monotonic
+        self._finished = False
+        self._watchdog_logged = False
+        self._timer: threading.Timer | None = None
+        if auto_start and self.timeout_seconds > 0:
+            self._timer = threading.Timer(self.timeout_seconds, self._on_timeout)
+            self._timer.daemon = True
+            self._timer.start()
+
+    @classmethod
+    def maybe_start(
+        cls,
+        method: str,
+        path: str,
+        *,
+        logger: logging.Logger | None = None,
+    ) -> "RequestDiagnostics | None":
+        clean_path = str(path or "").split("?", 1)[0]
+        if (method.upper(), clean_path) not in {
+            ("GET", "/api/sessions"),
+            ("POST", "/api/chat/start"),
+        }:
+            return None
+        return cls(method, clean_path, logger=logger)
+
+    def stage(self, name: str) -> None:
+        now = time.monotonic()
+        clean = str(name or "unknown").strip() or "unknown"
+        with self._lock:
+            if self._finished:
+                return
+            self._stages.append(
+                {
+                    "name": self._current_stage,
+                    "ms": round((now - self._current_stage_started) * 1000, 1),
+                }
+            )
+            self._current_stage = clean
+            self._current_stage_started = now
+
+    def finish(self) -> None:
+        timer = None
+        record = None
+        with self._lock:
+            if self._finished:
+                return
+            self._finished = True
+            timer = self._timer
+            record = self._build_record_locked(include_stacks=False)
+        if timer is not None:
+            timer.cancel()
+        if record and self.timeout_seconds > 0 and record["elapsed_ms"] >= self.timeout_seconds * 1000:
+            self.logger.warning(
+                "Slow WebUI request completed: %s",
+                json.dumps(record, sort_keys=True),
+            )
+
+    def _on_timeout(self) -> None:
+        with self._lock:
+            if self._finished or self._watchdog_logged:
+                return
+            self._watchdog_logged = True
+            record = self._build_record_locked(include_stacks=True)
+        self.logger.warning(
+            "Slow WebUI request still running: %s",
+            json.dumps(record, sort_keys=True),
+        )
+
+    def _build_record_locked(self, *, include_stacks: bool) -> dict[str, Any]:
+        now = time.monotonic()
+        stages = list(self._stages)
+        stages.append(
+            {
+                "name": self._current_stage,
+                "ms": round((now - self._current_stage_started) * 1000, 1),
+            }
+        )
+        record: dict[str, Any] = {
+            "request_id": self.request_id,
+            "method": self.method,
+            "path": self.path,
+            "started_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(self.started_wall)),
+            "elapsed_ms": round((now - self.started_monotonic) * 1000, 1),
+            "current_stage": self._current_stage,
+            "stages": stages,
+        }
+        if include_stacks:
+            record["thread_stacks"] = _thread_stack_snapshot()
+        return record
+
+
+def _thread_stack_snapshot() -> list[dict[str, Any]]:
+    frames = sys._current_frames()
+    threads = {thread.ident: thread for thread in threading.enumerate()}
+    snapshot: list[dict[str, Any]] = []
+    for ident, frame in frames.items():
+        thread = threads.get(ident)
+        stack = traceback.format_stack(frame, limit=MAX_STACK_FRAMES_PER_THREAD)
+        snapshot.append(
+            {
+                "thread_id": ident,
+                "thread_name": thread.name if thread else "",
+                "daemon": bool(thread.daemon) if thread else None,
+                "stack": [line.rstrip() for line in stack],
+            }
+        )
+    snapshot.sort(key=lambda item: str(item.get("thread_name") or ""))
+    return snapshot

--- a/api/routes.py
+++ b/api/routes.py
@@ -587,6 +587,7 @@ from api.helpers import (
     _redact_text,
 )
 from api.agent_health import build_agent_health_payload
+from api.request_diagnostics import RequestDiagnostics
 from api.system_health import build_system_health_payload
 
 
@@ -2972,80 +2973,96 @@ def handle_get(handler, parsed) -> bool:
         return j(handler, {"results": get_results(sid)})
 
     if parsed.path == "/api/sessions":
-        webui_sessions = all_sessions()
-        settings = load_settings()
-        show_cli_sessions = bool(settings.get("show_cli_sessions"))
-        if show_cli_sessions:
-            cli = get_cli_sessions()
-            cli_by_id = {s["session_id"]: s for s in cli}
-            for s in webui_sessions:
-                meta = cli_by_id.get(s.get("session_id"))
-                if not meta:
-                    continue
-                if _is_messaging_session_record(meta):
-                    s.update(_merge_cli_sidebar_metadata(s, meta))
-                    if s.get("session_id") != meta.get("session_id"):
-                        s["session_id"] = meta.get("session_id")
-                else:
-                    for key in ("source_tag", "raw_source", "session_source", "source_label"):
-                        if not s.get(key) and meta.get(key):
-                            s[key] = meta[key]
-            # Apply the same CLI visibility semantics to imported local copies so
-            # low-value imported artifacts do not leak into the sidebar.
-            webui_sessions = [s for s in webui_sessions if is_cli_session_row_visible(s)]
-            webui_ids = {s["session_id"] for s in webui_sessions}
-            from api.models import _hide_from_default_sidebar as _cron_hide
-            deduped_cli = [s for s in cli if s["session_id"] not in webui_ids and is_cli_session_row_visible(s) and not _cron_hide(s)]
-        else:
-            webui_sessions = [s for s in webui_sessions if not _is_cli_session_for_settings(s)]
-            deduped_cli = []
-        merged = webui_sessions + deduped_cli
-        merged.sort(
-            key=lambda s: s.get("last_message_at") or s.get("updated_at", 0) or 0,
-            reverse=True,
-        )
-        # ── Profile scoping (#1611) ────────────────────────────────────────
-        # Default: filter to the active profile. ?all_profiles=1 opts into
-        # the aggregate view used by the "All profiles" sidebar toggle.
-        # The other_profile_count is always returned so the UI can render
-        # the "Show N from other profiles" affordance without sending the
-        # cross-profile rows by default.
-        #
-        # IMPORTANT: scope BEFORE _keep_latest_messaging_session_per_source.
-        # _messaging_source_key is profile-blind (#1614 follow-up): if the
-        # same Slack/Telegram identity has sessions in profiles A and B, a
-        # profile-blind dedupe would discard the older one even when scoped
-        # to its own profile, leaving that profile with zero rows for that
-        # source. Filter first so the dedupe operates only within the active
-        # profile's rows.
-        from api.profiles import get_active_profile_name
-        active_profile = get_active_profile_name()
-        all_profiles = _all_profiles_query_flag(parsed)
-        if all_profiles:
-            scoped = merged
-            other_profile_count = 0
-        else:
-            scoped = [s for s in merged
-                      if _profiles_match(s.get("profile"), active_profile)]
-            other_profile_count = len(merged) - len(scoped)
-        scoped = _keep_latest_messaging_session_per_source(scoped)
-        if show_cli_sessions:
-            scoped = _cap_recent_cli_sessions(scoped, cli_cap=CLI_VISIBLE_SESSION_CAP)
-        safe_merged = []
-        for s in scoped:
-            item = dict(s)
-            if isinstance(item.get("title"), str):
-                item["title"] = _redact_text(item["title"])
-            safe_merged.append(item)
-        return j(handler, {
-            "sessions": safe_merged,
-            "cli_count": len(deduped_cli),
-            "all_profiles": all_profiles,
-            "active_profile": active_profile,
-            "other_profile_count": other_profile_count,
-            "server_time": time.time(),
-            "server_tz": time.strftime("%z"),
-        })
+        diag = RequestDiagnostics.maybe_start("GET", parsed.path, logger=logger)
+        try:
+            diag.stage("all_sessions")
+            webui_sessions = all_sessions(diag=diag)
+            diag.stage("load_settings")
+            settings = load_settings()
+            show_cli_sessions = bool(settings.get("show_cli_sessions"))
+            if show_cli_sessions:
+                diag.stage("get_cli_sessions")
+                cli = get_cli_sessions()
+                diag.stage("merge_cli_sessions")
+                cli_by_id = {s["session_id"]: s for s in cli}
+                for s in webui_sessions:
+                    meta = cli_by_id.get(s.get("session_id"))
+                    if not meta:
+                        continue
+                    if _is_messaging_session_record(meta):
+                        s.update(_merge_cli_sidebar_metadata(s, meta))
+                        if s.get("session_id") != meta.get("session_id"):
+                            s["session_id"] = meta.get("session_id")
+                    else:
+                        for key in ("source_tag", "raw_source", "session_source", "source_label"):
+                            if not s.get(key) and meta.get(key):
+                                s[key] = meta[key]
+                # Apply the same CLI visibility semantics to imported local copies so
+                # low-value imported artifacts do not leak into the sidebar.
+                webui_sessions = [s for s in webui_sessions if is_cli_session_row_visible(s)]
+                webui_ids = {s["session_id"] for s in webui_sessions}
+                from api.models import _hide_from_default_sidebar as _cron_hide
+                deduped_cli = [s for s in cli if s["session_id"] not in webui_ids and is_cli_session_row_visible(s) and not _cron_hide(s)]
+            else:
+                diag.stage("filter_webui_sessions")
+                webui_sessions = [s for s in webui_sessions if not _is_cli_session_for_settings(s)]
+                deduped_cli = []
+            diag.stage("sort_sessions")
+            merged = webui_sessions + deduped_cli
+            merged.sort(
+                key=lambda s: s.get("last_message_at") or s.get("updated_at", 0) or 0,
+                reverse=True,
+            )
+            # ── Profile scoping (#1611) ────────────────────────────────────────
+            # Default: filter to the active profile. ?all_profiles=1 opts into
+            # the aggregate view used by the "All profiles" sidebar toggle.
+            # The other_profile_count is always returned so the UI can render
+            # the "Show N from other profiles" affordance without sending the
+            # cross-profile rows by default.
+            #
+            # IMPORTANT: scope BEFORE _keep_latest_messaging_session_per_source.
+            # _messaging_source_key is profile-blind (#1614 follow-up): if the
+            # same Slack/Telegram identity has sessions in profiles A and B, a
+            # profile-blind dedupe would discard the older one even when scoped
+            # to its own profile, leaving that profile with zero rows for that
+            # source. Filter first so the dedupe operates only within the active
+            # profile's rows.
+            diag.stage("active_profile")
+            from api.profiles import get_active_profile_name
+            active_profile = get_active_profile_name()
+            all_profiles = _all_profiles_query_flag(parsed)
+            diag.stage("profile_filter")
+            if all_profiles:
+                scoped = merged
+                other_profile_count = 0
+            else:
+                scoped = [s for s in merged
+                          if _profiles_match(s.get("profile"), active_profile)]
+                other_profile_count = len(merged) - len(scoped)
+            diag.stage("messaging_dedupe")
+            scoped = _keep_latest_messaging_session_per_source(scoped)
+            if show_cli_sessions:
+                diag.stage("cli_cap")
+                scoped = _cap_recent_cli_sessions(scoped, cli_cap=CLI_VISIBLE_SESSION_CAP)
+            diag.stage("redact_sessions")
+            safe_merged = []
+            for s in scoped:
+                item = dict(s)
+                if isinstance(item.get("title"), str):
+                    item["title"] = _redact_text(item["title"])
+                safe_merged.append(item)
+            diag.stage("response_write")
+            return j(handler, {
+                "sessions": safe_merged,
+                "cli_count": len(deduped_cli),
+                "all_profiles": all_profiles,
+                "active_profile": active_profile,
+                "other_profile_count": other_profile_count,
+                "server_time": time.time(),
+                "server_tz": time.strftime("%z"),
+            })
+        finally:
+            diag.finish()
 
     if parsed.path == "/api/projects":
         # ── Profile scoping (#1614) ────────────────────────────────────────
@@ -3453,9 +3470,16 @@ def handle_get(handler, parsed) -> bool:
 
 def handle_post(handler, parsed) -> bool:
     """Handle all POST routes. Returns True if handled, False for 404."""
+    diag = RequestDiagnostics.maybe_start("POST", parsed.path, logger=logger)
     # CSRF: reject cross-origin browser requests
+    if diag:
+        diag.stage("csrf")
     if not _check_csrf(handler):
-        return j(handler, {"error": "Cross-origin request rejected"}, status=403)
+        try:
+            return j(handler, {"error": "Cross-origin request rejected"}, status=403)
+        finally:
+            if diag:
+                diag.finish()
 
     if parsed.path == "/api/upload":
         return handle_upload(handler)
@@ -3465,7 +3489,14 @@ def handle_post(handler, parsed) -> bool:
     if parsed.path == "/api/transcribe":
         return handle_transcribe(handler)
 
-    body = read_body(handler)
+    if diag:
+        diag.stage("read_body")
+    try:
+        body = read_body(handler)
+    except Exception:
+        if diag:
+            diag.finish()
+        raise
 
     if parsed.path.startswith("/api/kanban/"):
         from api.kanban_bridge import handle_kanban_post
@@ -4002,7 +4033,7 @@ def handle_post(handler, parsed) -> bool:
         return _handle_background(handler, body)
 
     if parsed.path == "/api/chat/start":
-        return _handle_chat_start(handler, body)
+        return _handle_chat_start(handler, body, diag=diag)
 
     if parsed.path == "/api/chat":
         return _handle_chat_sync(handler, body)
@@ -6170,104 +6201,126 @@ def _prepare_chat_start_session_for_stream(
     s.save()
 
 
-def _handle_chat_start(handler, body):
+def _handle_chat_start(handler, body, diag=None):
     try:
-        require(body, "session_id")
-    except ValueError as e:
-        return bad(handler, str(e))
-    try:
-        s = get_session(body["session_id"])
-    except KeyError:
-        return bad(handler, "Session not found", 404)
-    requested_profile = str(body.get("profile") or "").strip()
-    if requested_profile:
+        diag.stage("validate_session_id") if diag else None
         try:
-            from api.profiles import _PROFILE_ID_RE
+            require(body, "session_id")
+        except ValueError as e:
+            return bad(handler, str(e))
+        diag.stage("get_session") if diag else None
+        try:
+            s = get_session(body["session_id"])
+        except KeyError:
+            return bad(handler, "Session not found", 404)
+        diag.stage("validate_profile") if diag else None
+        requested_profile = str(body.get("profile") or "").strip()
+        if requested_profile:
+            try:
+                from api.profiles import _PROFILE_ID_RE
 
-            if requested_profile != "default" and not _PROFILE_ID_RE.fullmatch(requested_profile):
-                return bad(handler, "invalid profile", 400)
-        except ImportError:
-            requested_profile = ""
-    if requested_profile and not _profiles_match(getattr(s, "profile", None), requested_profile):
-        has_persisted_turns = bool(
-            getattr(s, "messages", None)
-            or getattr(s, "context_messages", None)
-            or getattr(s, "pending_user_message", None)
-        )
-        if not has_persisted_turns:
-            # Empty sessions are placeholders. If the user switches profiles
-            # before sending the first turn, run the placeholder under the
-            # currently-selected profile instead of the stale one stamped at
-            # creation time.
-            s.profile = requested_profile
-    msg = str(body.get("message", "")).strip()
-    if not msg:
-        return bad(handler, "message is required")
-    attachments = _normalize_chat_attachments(body.get("attachments") or [])[:20]
-    try:
-        workspace = str(resolve_trusted_workspace(body.get("workspace") or s.workspace))
-    except ValueError as e:
-        return bad(handler, str(e))
-    requested_model = body.get("model") or s.model
-    requested_provider = (
-        body.get("model_provider")
-        if "model_provider" in body
-        else getattr(s, "model_provider", None)
-    )
-    model, model_provider, normalized_model = _resolve_compatible_session_model_state(
-        requested_model,
-        requested_provider,
-    )
-    # Prevent duplicate runs in the same session while a stream is still active.
-    # This commonly happens after page refresh/reconnect races and can produce
-    # duplicated clarify cards for what appears to be a single user request.
-    current_stream_id = getattr(s, "active_stream_id", None)
-    if current_stream_id:
-        with STREAMS_LOCK:
-            current_active = current_stream_id in STREAMS
-        if current_active:
-            return j(
-                handler,
-                {
-                    "error": "session already has an active stream",
-                    "active_stream_id": current_stream_id,
-                },
-                status=409,
+                if requested_profile != "default" and not _PROFILE_ID_RE.fullmatch(requested_profile):
+                    return bad(handler, "invalid profile", 400)
+            except ImportError:
+                requested_profile = ""
+        if requested_profile and not _profiles_match(getattr(s, "profile", None), requested_profile):
+            has_persisted_turns = bool(
+                getattr(s, "messages", None)
+                or getattr(s, "context_messages", None)
+                or getattr(s, "pending_user_message", None)
             )
-        # Stale stream id from a previous run; clear and continue.
-        _clear_stale_stream_state(s)
-    stream_id = uuid.uuid4().hex
-    with _get_session_agent_lock(s.session_id):
-        _prepare_chat_start_session_for_stream(
-            s,
-            msg=msg,
-            attachments=attachments,
-            workspace=workspace,
-            model=model,
-            model_provider=model_provider,
-            stream_id=stream_id,
+            if not has_persisted_turns:
+                # Empty sessions are placeholders. If the user switches profiles
+                # before sending the first turn, run the placeholder under the
+                # currently-selected profile instead of the stale one stamped at
+                # creation time.
+                s.profile = requested_profile
+        diag.stage("normalize_message") if diag else None
+        msg = str(body.get("message", "")).strip()
+        if not msg:
+            return bad(handler, "message is required")
+        diag.stage("normalize_attachments") if diag else None
+        attachments = _normalize_chat_attachments(body.get("attachments") or [])[:20]
+        diag.stage("resolve_workspace") if diag else None
+        try:
+            workspace = str(resolve_trusted_workspace(body.get("workspace") or s.workspace))
+        except ValueError as e:
+            return bad(handler, str(e))
+        requested_model = body.get("model") or s.model
+        requested_provider = (
+            body.get("model_provider")
+            if "model_provider" in body
+            else getattr(s, "model_provider", None)
         )
-    set_last_workspace(workspace)
-    stream = create_stream_channel()
-    with STREAMS_LOCK:
-        STREAMS[stream_id] = stream
-    thr = threading.Thread(
-        target=_run_agent_streaming,
-        args=(s.session_id, msg, model, workspace, stream_id, attachments),
-        kwargs={"model_provider": model_provider},
-        daemon=True,
-    )
-    thr.start()
-    response = {
-        "stream_id": stream_id,
-        "session_id": s.session_id,
-        "pending_started_at": s.pending_started_at,
-    }
-    if normalized_model:
-        response["effective_model"] = model
-    if model_provider:
-        response["effective_model_provider"] = model_provider
-    return j(handler, response)
+        diag.stage("resolve_model_provider") if diag else None
+        model, model_provider, normalized_model = _resolve_compatible_session_model_state(
+            requested_model,
+            requested_provider,
+        )
+        # Prevent duplicate runs in the same session while a stream is still active.
+        # This commonly happens after page refresh/reconnect races and can produce
+        # duplicated clarify cards for what appears to be a single user request.
+        diag.stage("active_stream_check") if diag else None
+        current_stream_id = getattr(s, "active_stream_id", None)
+        if current_stream_id:
+            diag.stage("active_stream_lock_wait") if diag else None
+            with STREAMS_LOCK:
+                current_active = current_stream_id in STREAMS
+            if current_active:
+                diag.stage("response_write") if diag else None
+                return j(
+                    handler,
+                    {
+                        "error": "session already has an active stream",
+                        "active_stream_id": current_stream_id,
+                    },
+                    status=409,
+                )
+            # Stale stream id from a previous run; clear and continue.
+            diag.stage("stale_stream_cleanup") if diag else None
+            _clear_stale_stream_state(s)
+        stream_id = uuid.uuid4().hex
+        session_lock = _get_session_agent_lock(s.session_id)
+        diag.stage("session_lock_wait") if diag else None
+        with session_lock:
+            diag.stage("save_pending_state") if diag else None
+            _prepare_chat_start_session_for_stream(
+                s,
+                msg=msg,
+                attachments=attachments,
+                workspace=workspace,
+                model=model,
+                model_provider=model_provider,
+                stream_id=stream_id,
+            )
+        diag.stage("set_last_workspace") if diag else None
+        set_last_workspace(workspace)
+        diag.stage("stream_registration") if diag else None
+        stream = create_stream_channel()
+        with STREAMS_LOCK:
+            STREAMS[stream_id] = stream
+        diag.stage("worker_thread_start") if diag else None
+        thr = threading.Thread(
+            target=_run_agent_streaming,
+            args=(s.session_id, msg, model, workspace, stream_id, attachments),
+            kwargs={"model_provider": model_provider},
+            daemon=True,
+        )
+        thr.start()
+        response = {
+            "stream_id": stream_id,
+            "session_id": s.session_id,
+            "pending_started_at": s.pending_started_at,
+        }
+        if normalized_model:
+            response["effective_model"] = model
+        if model_provider:
+            response["effective_model_provider"] = model_provider
+        diag.stage("response_write") if diag else None
+        return j(handler, response)
+    finally:
+        if diag:
+            diag.finish()
 
 
 def _normalize_chat_attachments(raw_attachments):

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -2102,6 +2102,17 @@ def _run_agent_streaming(
                 meter().record_reasoning(stream_id, _metering_reasoning_deltas[0])
                 _emit_metering()
 
+            def on_interim_assistant(text, **cb_kwargs):
+                if text is None:
+                    return
+                visible = str(text).strip()
+                if not visible:
+                    return
+                put('interim_assistant', {
+                    'text': visible,
+                    'already_streamed': bool(cb_kwargs.get('already_streamed', False)),
+                })
+
             # Pre-initialise the activity counter here so on_tool (which
             # closes over it) never captures an unbound name even if this
             # block is reordered later (Issue #765).
@@ -2353,6 +2364,8 @@ def _run_agent_streaming(
             # but guard defensively to avoid TypeError on an older agent build.
             if 'reasoning_config' in _agent_params and _reasoning_config is not None:
                 _agent_kwargs['reasoning_config'] = _reasoning_config
+            if 'interim_assistant_callback' in _agent_params:
+                _agent_kwargs['interim_assistant_callback'] = on_interim_assistant
             if 'status_callback' in _agent_params:
                 _agent_kwargs['status_callback'] = _agent_status_callback
             if 'max_tokens' in _agent_params and _max_tokens_cfg is not None:
@@ -2410,6 +2423,8 @@ def _run_agent_streaming(
                     agent.tool_progress_callback = _agent_kwargs.get('tool_progress_callback')
                     if hasattr(agent, 'status_callback'):
                         agent.status_callback = _agent_kwargs.get('status_callback')
+                    if hasattr(agent, 'interim_assistant_callback'):
+                        agent.interim_assistant_callback = _agent_kwargs.get('interim_assistant_callback')
                     if hasattr(agent, 'reasoning_callback'):
                         agent.reasoning_callback = _agent_kwargs.get('reasoning_callback')
                     if hasattr(agent, 'clarify_callback'):

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -2296,6 +2296,29 @@ def _run_agent_streaming(
             import inspect as _inspect
             _agent_params = set(_inspect.signature(_AIAgent.__init__).parameters)
 
+            # CLI-parity max-iteration budget: read config.yaml's
+            # agent.max_turns and pass it to AIAgent when supported. Without
+            # this WebUI-created agents silently use AIAgent's constructor
+            # default (90), so long browser-originated tasks hit the
+            # "maximum number of tool-calling iterations" summary path even
+            # after the operator raises Hermes' global turn budget.
+            _max_iterations_cfg = None
+            try:
+                _raw_max_iterations = None
+                _agent_cfg_for_iterations = _cfg.get('agent', {}) if isinstance(_cfg, dict) else {}
+                if isinstance(_agent_cfg_for_iterations, dict):
+                    _raw_max_iterations = _agent_cfg_for_iterations.get('max_turns')
+                if _raw_max_iterations is None and isinstance(_cfg, dict):
+                    # Back-compat for older Hermes config files that used a
+                    # root-level max_turns key.
+                    _raw_max_iterations = _cfg.get('max_turns')
+                if _raw_max_iterations is not None:
+                    _parsed_max_iterations = int(_raw_max_iterations)
+                    if _parsed_max_iterations > 0:
+                        _max_iterations_cfg = _parsed_max_iterations
+            except Exception:
+                _max_iterations_cfg = None
+
             # CLI-parity max output cap: read config.yaml's max_tokens and pass
             # it to AIAgent when supported. Without this WebUI-created agents use
             # provider-native output ceilings (e.g. Claude via OpenRouter can
@@ -2355,6 +2378,8 @@ def _run_agent_streaming(
                 _agent_kwargs['reasoning_config'] = _reasoning_config
             if 'status_callback' in _agent_params:
                 _agent_kwargs['status_callback'] = _agent_status_callback
+            if 'max_iterations' in _agent_params and _max_iterations_cfg is not None:
+                _agent_kwargs['max_iterations'] = _max_iterations_cfg
             if 'max_tokens' in _agent_params and _max_tokens_cfg is not None:
                 _agent_kwargs['max_tokens'] = _max_tokens_cfg
             # Params added in newer hermes-agent — skip if not supported
@@ -2388,6 +2413,7 @@ def _run_agent_streaming(
                     _hashlib.sha256((resolved_api_key or '').encode()).hexdigest()[:16],
                     resolved_base_url or '',
                     resolved_provider or '',
+                    _max_iterations_cfg or '',
                     _max_tokens_cfg or '',
                     _fallback_resolved or {},
                     sorted(_toolsets) if _toolsets else [],

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -2866,10 +2866,9 @@ def _run_agent_streaming(
                 input_tokens = getattr(agent, 'session_prompt_tokens', 0) or 0
                 output_tokens = getattr(agent, 'session_completion_tokens', 0) or 0
                 estimated_cost = getattr(agent, 'session_estimated_cost_usd', None)
-                s.input_tokens = (s.input_tokens or 0) + input_tokens
-                s.output_tokens = (s.output_tokens or 0) + output_tokens
-                if estimated_cost:
-                    s.estimated_cost = (s.estimated_cost or 0) + estimated_cost
+                s.input_tokens = input_tokens
+                s.output_tokens = output_tokens
+                s.estimated_cost = estimated_cost
                 # Persist tool-call summaries even when the final message history only
                 # kept bare tool rows and omitted explicit assistant tool_call IDs.
                 tool_calls = _extract_tool_calls_from_messages(

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -586,6 +586,11 @@ def _message_text(value) -> str:
     return _strip_thinking_markup(str(value or '').strip())
 
 
+def _strip_workspace_prefix(text: str) -> str:
+    """Remove WebUI's model-facing workspace tag from display identity text."""
+    return re.sub(r'^\s*\[Workspace:[^\]]+\]\s*', '', str(text or '')).strip()
+
+
 def _first_exchange_snippets(messages):
     """Return (first_user_text, first_assistant_text) snippets for title generation.
 
@@ -1433,6 +1438,12 @@ def _message_identity(msg):
     role = str(msg.get('role') or '')
     content = msg.get('content', '')
     text = _message_text(content)
+    if role == 'user':
+        # WebUI sends the model a workspace-prefixed user_message while the
+        # visible optimistic bubble contains only the human text. Treat them as
+        # the same turn for merge/dedup purposes; otherwise compaction results
+        # render two adjacent user bubbles ("Ok" and "[Workspace...]\nOk").
+        text = _strip_workspace_prefix(text)
     if not text and not msg.get('tool_call_id') and not msg.get('tool_calls'):
         return None
     return (
@@ -1471,7 +1482,7 @@ def _find_current_user_turn(messages, msg_text):
         if not isinstance(msg, dict) or msg.get('role') != 'user':
             continue
         fallback = idx
-        text = " ".join(_message_text(msg.get('content', '')).split())
+        text = " ".join(_strip_workspace_prefix(_message_text(msg.get('content', ''))).split())
         if needle and (needle in text or text in needle):
             return idx
     return fallback
@@ -1558,7 +1569,11 @@ def _merge_display_messages_after_agent_result(previous_display, previous_contex
             continue
         if _is_context_compression_marker(msg) and key is not None and key in seen:
             continue
-        merged.append(copy.deepcopy(msg))
+        display_msg = msg
+        if key is not None and key == current_user_key and isinstance(msg, dict) and msg.get('role') == 'user':
+            display_msg = copy.deepcopy(msg)
+            display_msg['content'] = msg_text
+        merged.append(copy.deepcopy(display_msg))
         if key is not None:
             seen.add(key)
     return merged

--- a/static/messages.js
+++ b/static/messages.js
@@ -645,6 +645,14 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       if(!_SMD_SAFE_URL_RE.test(v)){n.removeAttribute('src');n.setAttribute('data-blocked-scheme','1');}
     }
   }
+  function _resetAssistantSegment(){
+    assistantRow=null;
+    assistantBody=null;
+    segmentStart=assistantText.length;
+    _freshSegment=true;
+    _smdEndParser();
+  }
+
   let _lastRenderMs=0;
   function _scheduleRender(){
     if(_renderPending) return;
@@ -725,6 +733,26 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       _scheduleRender();
     });
 
+    source.addEventListener('interim_assistant',e=>{
+      if(!S.session||S.session.session_id!==activeSid) return;
+      const d=JSON.parse(e.data);
+      const visible=String(d&&d.text?d.text:'').trim();
+      const alreadyStreamed=!!(d&&d.already_streamed);
+      if(!visible){
+        return;
+      }
+      if(alreadyStreamed){
+        _resetAssistantSegment();
+        return;
+      }
+      assistantText+=visible;
+      syncInflightAssistantMessage();
+      if(!S.session||S.session.session_id!==activeSid) return;
+      const parsed=_parseStreamState();
+      if(String((parsed&&parsed.displayText)||'').trim()||assistantRow) ensureAssistantRow();
+      _scheduleRender();
+    });
+
     source.addEventListener('reasoning',e=>{
       const d=JSON.parse(e.data);
       reasoningText += d.text || '';
@@ -768,11 +796,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       // Reset the live assistant row reference so that any text tokens arriving
       // after this tool call create a NEW segment appended below the tool card,
       // rather than updating the old segment that sits above it in the DOM.
-      assistantRow=null;
-      assistantBody=null;
-      segmentStart=assistantText.length; // new segment starts at current text length
-      _freshSegment=true;                // prevent reuse of old DOM node
-      _smdEndParser();                   // finalize current smd parser; new one created on next token
+      _resetAssistantSegment();
       scrollIfPinned();
     });
 

--- a/static/messages.js
+++ b/static/messages.js
@@ -796,6 +796,8 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       // Reset the live assistant row reference so that any text tokens arriving
       // after this tool call create a NEW segment appended below the tool card,
       // rather than updating the old segment that sits above it in the DOM.
+      _freshSegment=true;
+      _smdEndParser();
       _resetAssistantSegment();
       scrollIfPinned();
     });

--- a/tests/test_agent_max_turns_parity.py
+++ b/tests/test_agent_max_turns_parity.py
@@ -1,0 +1,30 @@
+"""Regression checks for WebUI AIAgent iteration-budget parity.
+
+WebUI streaming agents must honor Hermes' configured agent.max_turns. Otherwise
+browser-originated long-running tasks silently fall back to AIAgent's constructor
+default and hit the "maximum number of tool-calling iterations" summary path even
+when the operator raised the global Hermes budget.
+"""
+
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parent.parent
+STREAMING_PY = (REPO / "api" / "streaming.py").read_text(encoding="utf-8")
+
+
+def test_streaming_agent_reads_agent_max_turns_from_config():
+    assert "_agent_cfg_for_iterations" in STREAMING_PY
+    assert "_agent_cfg_for_iterations.get('max_turns')" in STREAMING_PY
+    assert "_cfg.get('max_turns')" in STREAMING_PY
+
+
+def test_streaming_agent_passes_max_iterations_to_aiagent():
+    assert "if 'max_iterations' in _agent_params and _max_iterations_cfg is not None:" in STREAMING_PY
+    assert "_agent_kwargs['max_iterations'] = _max_iterations_cfg" in STREAMING_PY
+
+
+def test_streaming_agent_cache_signature_includes_max_iterations():
+    sig_start = STREAMING_PY.index("_sig_blob = _json.dumps")
+    sig_block = STREAMING_PY[sig_start:STREAMING_PY.index("], sort_keys=True)", sig_start)]
+    assert "_max_iterations_cfg or ''" in sig_block

--- a/tests/test_issue1217_transcript_compaction.py
+++ b/tests/test_issue1217_transcript_compaction.py
@@ -47,6 +47,36 @@ def test_session_persists_model_context_separately_from_display_transcript(tmp_p
     assert _sanitize_messages_for_api(_session_context_messages(reloaded)) == compacted_context
 
 
+def test_workspace_prefixed_current_user_after_compaction_is_not_duplicated():
+    previous_display = [
+        {"role": "user", "content": "older prompt"},
+        {"role": "assistant", "content": "older answer"},
+    ]
+    previous_context = list(previous_display)
+    compacted_result = [
+        {
+            "role": "assistant",
+            "content": "[CONTEXT COMPACTION — REFERENCE ONLY] Earlier turns were compacted.",
+        },
+        {"role": "user", "content": "[Workspace: /home/manfred/.hermes/workspace]\nOk, mache weiter"},
+        {"role": "assistant", "content": "continuing"},
+    ]
+
+    merged = _merge_display_messages_after_agent_result(
+        previous_display,
+        previous_context,
+        compacted_result,
+        "Ok, mache weiter",
+    )
+
+    assert [m["role"] for m in merged] == ["user", "assistant", "assistant", "user", "assistant"]
+    assert [m["content"] for m in merged[-2:]] == [
+        "Ok, mache weiter",
+        "continuing",
+    ]
+    assert sum(1 for m in merged if m.get("role") == "user" and "Ok, mache weiter" in m.get("content", "")) == 1
+
+
 def test_compacted_agent_result_keeps_old_prompts_and_appends_current_turn():
     previous_display = [
         {"role": "user", "content": "first prompt that must remain visible"},

--- a/tests/test_issue1855_request_diagnostics.py
+++ b/tests/test_issue1855_request_diagnostics.py
@@ -1,0 +1,110 @@
+import json
+import logging
+from pathlib import Path
+
+import api.models as models
+from api.models import Session
+from api.request_diagnostics import RequestDiagnostics
+
+
+class _StageRecorder:
+    def __init__(self):
+        self.stages = []
+
+    def stage(self, name):
+        self.stages.append(name)
+
+
+def test_request_diagnostics_timeout_record_includes_stage_and_thread_stacks(caplog):
+    logger = logging.getLogger("test.issue1855.timeout")
+    diag = RequestDiagnostics(
+        "GET",
+        "/api/sessions?all_profiles=1",
+        logger=logger,
+        timeout_seconds=5,
+        auto_start=False,
+    )
+    diag.stage("all_sessions.read_index")
+
+    with caplog.at_level(logging.WARNING, logger=logger.name):
+        diag._on_timeout()
+
+    assert len(caplog.records) == 1
+    record = json.loads(caplog.records[0].args[0])
+    assert record["method"] == "GET"
+    assert record["path"] == "/api/sessions"
+    assert record["current_stage"] == "all_sessions.read_index"
+    assert record["elapsed_ms"] >= 0
+    assert any(stage["name"] == "all_sessions.read_index" for stage in record["stages"])
+    assert record["thread_stacks"]
+
+
+def test_request_diagnostics_maybe_start_is_limited_to_issue1855_paths():
+    assert RequestDiagnostics.maybe_start("GET", "/api/sessions") is not None
+    assert RequestDiagnostics.maybe_start("POST", "/api/chat/start") is not None
+    assert RequestDiagnostics.maybe_start("GET", "/health") is None
+    assert RequestDiagnostics.maybe_start("POST", "/api/session/new") is None
+
+
+def test_all_sessions_reports_internal_index_stages(tmp_path, monkeypatch):
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    index_file = session_dir / "_index.json"
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", index_file)
+    monkeypatch.setattr(models, "_enrich_sidebar_lineage_metadata", lambda sessions: None)
+    models.SESSIONS.clear()
+
+    s = Session(
+        session_id="issue1855_indexed",
+        title="Indexed",
+        messages=[{"role": "user", "content": "hi", "timestamp": 100}],
+    )
+    s.path.write_text(json.dumps(s.__dict__, ensure_ascii=False), encoding="utf-8")
+    index_file.write_text(
+        json.dumps(
+            [
+                {
+                    "session_id": s.session_id,
+                    "title": s.title,
+                    "updated_at": s.updated_at,
+                    "workspace": s.workspace,
+                    "model": s.model,
+                    "message_count": 1,
+                    "created_at": s.created_at,
+                    "pinned": False,
+                    "archived": False,
+                    "last_message_at": 100,
+                }
+            ],
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+
+    diag = _StageRecorder()
+    rows = models.all_sessions(diag=diag)
+
+    assert [row["session_id"] for row in rows] == [s.session_id]
+    assert "all_sessions.read_index" in diag.stages
+    assert "all_sessions.overlay_lock" in diag.stages
+    assert "all_sessions.lineage_metadata" in diag.stages
+
+
+def test_issue1855_target_routes_are_wired_to_diagnostics():
+    src = Path("api/routes.py").read_text(encoding="utf-8")
+
+    assert 'RequestDiagnostics.maybe_start("GET", parsed.path' in src
+    assert "all_sessions(diag=diag)" in src
+    assert 'RequestDiagnostics.maybe_start("POST", parsed.path' in src
+    assert "_handle_chat_start(handler, body, diag=diag)" in src
+    for stage in (
+        "read_body",
+        "resolve_model_provider",
+        "session_lock_wait",
+        "save_pending_state",
+        "stream_registration",
+        "worker_thread_start",
+        "response_write",
+    ):
+        assert stage in src

--- a/tests/test_issue1857_usage_overwrite.py
+++ b/tests/test_issue1857_usage_overwrite.py
@@ -1,0 +1,162 @@
+import queue
+import sys
+import types
+from unittest import mock
+
+
+def test_stream_completion_overwrites_session_usage_with_latest_turn(cleanup_test_sessions):
+    """#1857: completed turns must not add prompt tokens to stale session totals."""
+    import api.streaming as streaming
+
+    saved_snapshots = []
+
+    class FakeSession:
+        def __init__(self):
+            self.session_id = "issue1857_usage_overwrite"
+            self.title = "Existing title"
+            self.workspace = "/tmp"
+            self.model = "gpt-5.4"
+            self.model_provider = None
+            self.profile = None
+            self.personality = None
+            self.messages = [
+                {"role": "user", "content": "old"},
+                {"role": "assistant", "content": "old answer"},
+            ]
+            self.context_messages = list(self.messages)
+            self.input_tokens = 9000
+            self.output_tokens = 800
+            self.estimated_cost = 12.34
+            self.tool_calls = []
+            self.gateway_routing = None
+            self.gateway_routing_history = []
+            self.active_stream_id = None
+            self.pending_user_message = None
+            self.pending_attachments = []
+            self.pending_started_at = None
+            self.context_length = 0
+            self.threshold_tokens = 0
+            self.last_prompt_tokens = 0
+            self.llm_title_generated = True
+
+        def save(self, *args, **kwargs):
+            saved_snapshots.append(
+                {
+                    "input_tokens": self.input_tokens,
+                    "output_tokens": self.output_tokens,
+                    "estimated_cost": self.estimated_cost,
+                    "kwargs": kwargs,
+                }
+            )
+
+        def compact(self):
+            return {
+                "session_id": self.session_id,
+                "title": self.title,
+                "workspace": self.workspace,
+                "model": self.model,
+                "created_at": 0,
+                "updated_at": 0,
+                "pinned": False,
+                "archived": False,
+                "project_id": None,
+                "profile": self.profile,
+                "input_tokens": self.input_tokens,
+                "output_tokens": self.output_tokens,
+                "estimated_cost": self.estimated_cost,
+                "personality": self.personality,
+            }
+
+    class UsageAgent:
+        def __init__(
+            self,
+            model=None,
+            provider=None,
+            base_url=None,
+            api_key=None,
+            platform=None,
+            quiet_mode=False,
+            enabled_toolsets=None,
+            fallback_model=None,
+            session_id=None,
+            session_db=None,
+            stream_delta_callback=None,
+            reasoning_callback=None,
+            tool_progress_callback=None,
+            clarify_callback=None,
+        ):
+            self.session_id = session_id
+            self.context_compressor = None
+            self.session_prompt_tokens = 123
+            self.session_completion_tokens = 45
+            self.session_estimated_cost_usd = 0.067
+            self.reasoning_config = None
+            self.ephemeral_system_prompt = None
+            self._last_error = None
+
+        def run_conversation(self, **kwargs):
+            return {
+                "messages": [
+                    {"role": "user", "content": kwargs["persist_user_message"]},
+                    {"role": "assistant", "content": "new answer"},
+                ]
+            }
+
+        def interrupt(self, _message):
+            pass
+
+    fake_session = FakeSession()
+    fake_stream_id = "stream_issue1857_usage_overwrite"
+    fake_queue = queue.Queue()
+    fake_runtime_module = types.ModuleType("hermes_cli.runtime_provider")
+    fake_runtime_module.resolve_runtime_provider = mock.Mock(
+        return_value={
+            "provider": "openai",
+            "base_url": None,
+            "api_key": "sk-test",
+            "api_mode": "chat_completions",
+            "command": None,
+            "args": [],
+            "credential_pool": None,
+        }
+    )
+    fake_hermes_cli = types.ModuleType("hermes_cli")
+    fake_hermes_cli.runtime_provider = fake_runtime_module
+    fake_hermes_state = types.ModuleType("hermes_state")
+    fake_hermes_state.SessionDB = mock.Mock(return_value=None)
+
+    with mock.patch.object(streaming, "get_session", return_value=fake_session), \
+         mock.patch.object(streaming, "_get_ai_agent", return_value=UsageAgent), \
+         mock.patch.object(streaming, "resolve_model_provider", return_value=("gpt-5.4", "openai", None)), \
+         mock.patch("api.config.get_config", return_value={}), \
+         mock.patch("api.config._resolve_cli_toolsets", return_value=[]), \
+         mock.patch.dict(
+             sys.modules,
+             {
+                 "hermes_cli": fake_hermes_cli,
+                 "hermes_cli.runtime_provider": fake_runtime_module,
+                 "hermes_state": fake_hermes_state,
+             },
+         ):
+        streaming.STREAMS[fake_stream_id] = fake_queue
+        streaming._run_agent_streaming(
+            session_id=fake_session.session_id,
+            msg_text="new turn",
+            model="gpt-5.4",
+            workspace="/tmp",
+            stream_id=fake_stream_id,
+        )
+
+    assert fake_session.input_tokens == 123
+    assert fake_session.output_tokens == 45
+    assert fake_session.estimated_cost == 0.067
+    assert any(
+        event == "done"
+        and payload["usage"]["input_tokens"] == 123
+        and payload["usage"]["output_tokens"] == 45
+        and payload["usage"]["estimated_cost"] == 0.067
+        for event, payload in list(fake_queue.queue)
+    )
+    assert saved_snapshots[-1]["input_tokens"] == 123
+    assert saved_snapshots[-1]["output_tokens"] == 45
+    assert saved_snapshots[-1]["estimated_cost"] == 0.067

--- a/tests/test_provider_quota_status.py
+++ b/tests/test_provider_quota_status.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import json
+import inspect
 import os
+import threading
 import urllib.error
 from datetime import datetime, timezone
 from io import BytesIO
@@ -174,10 +176,10 @@ def test_codex_account_usage_is_fetched_under_active_profile_home(monkeypatch, t
     seen = {}
     previous_home = os.environ.get("HERMES_HOME")
 
-    def fake_fetch(provider, base_url=None, api_key=None):
+    def fake_fetch(provider, home, api_key=None):
         seen["provider"] = provider
+        seen["home"] = str(home)
         seen["api_key"] = api_key
-        seen["hermes_home"] = os.environ.get("HERMES_HOME")
         return SimpleNamespace(
             provider="openai-codex",
             source="usage_api",
@@ -203,7 +205,7 @@ def test_codex_account_usage_is_fetched_under_active_profile_home(monkeypatch, t
             unavailable_reason=None,
         )
 
-    monkeypatch.setattr(providers, "_agent_fetch_account_usage", fake_fetch)
+    monkeypatch.setattr(providers, "_agent_fetch_account_usage_for_home", fake_fetch)
     try:
         result = providers.get_provider_quota()
     finally:
@@ -211,8 +213,8 @@ def test_codex_account_usage_is_fetched_under_active_profile_home(monkeypatch, t
 
     assert seen == {
         "provider": "openai-codex",
+        "home": str(tmp_path),
         "api_key": None,
-        "hermes_home": str(tmp_path),
     }
     assert os.environ.get("HERMES_HOME") == previous_home
     assert result["ok"] is True
@@ -258,7 +260,7 @@ def test_codex_account_usage_unavailable_is_sanitized(monkeypatch, tmp_path):
     def fake_fetch(*_args, **_kwargs):
         raise RuntimeError("secret access token should not leak")
 
-    monkeypatch.setattr(providers, "_agent_fetch_account_usage", fake_fetch)
+    monkeypatch.setattr(providers, "_agent_fetch_account_usage_for_home", fake_fetch)
     try:
         result = providers.get_provider_quota()
     finally:
@@ -282,7 +284,7 @@ def test_anthropic_oauth_usage_unavailable_reason_is_reported(monkeypatch, tmp_p
 
     monkeypatch.setattr(
         providers,
-        "_agent_fetch_account_usage",
+        "_agent_fetch_account_usage_for_home",
         lambda *_args, **_kwargs: SimpleNamespace(
             provider="anthropic",
             source="oauth_usage_api",
@@ -306,6 +308,76 @@ def test_anthropic_oauth_usage_unavailable_reason_is_reported(monkeypatch, tmp_p
     assert result["status"] == "unavailable"
     assert result["account_limits"]["unavailable_reason"].startswith("Anthropic account limits")
     assert "OAuth-backed Claude accounts" in result["message"]
+
+
+def test_account_usage_profile_fetch_does_not_enter_cron_env_context():
+    """Quota probes must not reuse cron's process-global env/module swapper."""
+    import api.providers as providers
+
+    body = inspect.getsource(providers._fetch_account_usage_with_profile_context)
+    assert "cron_profile_context_for_home" not in body
+    assert "_agent_fetch_account_usage_for_home" in body
+
+
+def test_account_usage_profile_env_is_child_scoped(monkeypatch, tmp_path):
+    """Profile .env values should be passed to the child probe only."""
+    import api.providers as providers
+
+    home = tmp_path / "profile-a"
+    home.mkdir()
+    (home / ".env").write_text("ANTHROPIC_API_KEY=profile-key\n", encoding="utf-8")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "process-key")
+
+    env = providers._account_usage_subprocess_env(home, "anthropic", None)
+
+    assert env["HERMES_HOME"] == str(home)
+    assert env["ANTHROPIC_API_KEY"] == "profile-key"
+    assert os.environ["ANTHROPIC_API_KEY"] == "process-key"
+
+
+def test_account_usage_profile_fetches_can_overlap_for_different_homes(monkeypatch, tmp_path):
+    """Different profile quota fetches should not serialize on cron's global lock."""
+    import api.providers as providers
+
+    homes = {
+        "quota-a": tmp_path / "a",
+        "quota-b": tmp_path / "b",
+    }
+    for home in homes.values():
+        home.mkdir()
+    barrier = threading.Barrier(2, timeout=2)
+    events = []
+    errors = []
+
+    def fake_home():
+        return homes[threading.current_thread().name]
+
+    def fake_fetch(provider, home, api_key=None):
+        events.append(("enter", str(home)))
+        barrier.wait()
+        events.append(("exit", str(home)))
+        return None
+
+    monkeypatch.setattr(providers, "_get_hermes_home", fake_home)
+    monkeypatch.setattr(providers, "_agent_fetch_account_usage_for_home", fake_fetch)
+
+    def worker():
+        try:
+            providers._fetch_account_usage_with_profile_context("openai-codex")
+        except Exception as exc:
+            errors.append(exc)
+
+    threads = [
+        threading.Thread(target=worker, name="quota-a"),
+        threading.Thread(target=worker, name="quota-b"),
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert not errors
+    assert [kind for kind, _home in events[:2]] == ["enter", "enter"]
 
 
 def test_provider_quota_route_is_registered():

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -693,6 +693,23 @@ def test_messages_js_supports_live_reasoning_and_tool_completion(cleanup_test_se
         "messages.js must parse live stream state into reasoning + visible answer"
 
 
+def test_messages_js_supports_interim_assistant_events(cleanup_test_sessions):
+    """R18b: messages.js must render live interim assistant commentary when
+    `interim_assistant` SSE events arrive.
+
+    AIAgent emits completed mid-turn commentary through an interim callback.
+    Without a dedicated SSE handler, Codex-style interim status text disappears
+    from the live answer and users only see the final response after tool calls.
+    """
+    src = (REPO_ROOT / "static/messages.js").read_text()
+    assert "source.addEventListener('interim_assistant'" in src or 'source.addEventListener("interim_assistant"' in src, \
+        "messages.js must listen for interim_assistant SSE events"
+    assert "function _resetAssistantSegment()" in src, \
+        "messages.js should share live-segment reset logic between interim assistant updates and tool events"
+    assert "_resetAssistantSegment();" in src, \
+        "messages.js should apply segment reset when tool or interim assistant events require it"
+
+
 def test_ui_js_can_upgrade_thinking_spinner_into_live_reasoning_card(cleanup_test_sessions):
     """R19: ui.js must be able to replace the placeholder thinking spinner with
     streamed reasoning text while a turn is in progress.

--- a/tests/test_sprint42.py
+++ b/tests/test_sprint42.py
@@ -251,6 +251,157 @@ class TestRuntimeRouteInjection(unittest.TestCase):
         self.assertEqual(init_kwargs["api_key"], "rt-key")
         self.assertIs(init_kwargs["session_db"], fake_session_db)
 
+    def test_runtime_provider_forwards_interim_assistant_callback(self):
+        """WebUI must pass interim_assistant_callback to AIAgent and emit SSE events."""
+        import api.streaming as streaming
+
+        captured = {}
+
+        class CapturingAgent:
+            def __init__(
+                self,
+                model=None,
+                provider=None,
+                base_url=None,
+                api_key=None,
+                platform=None,
+                quiet_mode=False,
+                enabled_toolsets=None,
+                fallback_model=None,
+                session_id=None,
+                session_db=None,
+                stream_delta_callback=None,
+                reasoning_callback=None,
+                tool_progress_callback=None,
+                interim_assistant_callback=None,
+                clarify_callback=None,
+                **kwargs,
+            ):
+                captured["init_kwargs"] = dict(
+                    model=model, provider=provider, base_url=base_url, api_key=api_key,
+                    platform=platform, quiet_mode=quiet_mode,
+                    enabled_toolsets=enabled_toolsets, fallback_model=fallback_model,
+                    session_id=session_id, session_db=session_db,
+                    stream_delta_callback=stream_delta_callback,
+                    reasoning_callback=reasoning_callback,
+                    tool_progress_callback=tool_progress_callback,
+                    interim_assistant_callback=interim_assistant_callback,
+                    clarify_callback=clarify_callback,
+                )
+                self.session_id = session_id
+                self.context_compressor = None
+                self.session_prompt_tokens = 0
+                self.session_completion_tokens = 0
+                self.session_estimated_cost_usd = None
+                self.reasoning_config = None
+                self.ephemeral_system_prompt = None
+                self._last_error = None
+                self.interim_assistant_callback = interim_assistant_callback
+
+            def run_conversation(self, **kwargs):
+                if self.interim_assistant_callback:
+                    self.interim_assistant_callback("Inspecting repo structure.", already_streamed=False)
+                return {
+                    "messages": [
+                        {"role": "user", "content": kwargs.get("persist_user_message", "")},
+                        {"role": "assistant", "content": "ok"},
+                    ]
+                }
+
+            def interrupt(self, _message):
+                captured["interrupted"] = True
+
+        class FakeSession:
+            session_id = "sess-interim-test"
+            title = "Test"
+            workspace = "/tmp"
+            model = "gpt-4o"
+            messages = []
+            personality = None
+            input_tokens = 0
+            output_tokens = 0
+            estimated_cost = None
+            tool_calls = []
+            active_stream_id = None
+            pending_user_message = None
+            pending_attachments = []
+            pending_started_at = None
+
+            def save(self, touch_updated_at=True, skip_index=True):
+                pass
+
+            def compact(self):
+                return {
+                    "session_id": self.session_id, "title": self.title,
+                    "workspace": self.workspace, "model": self.model,
+                    "created_at": 0, "updated_at": 0, "pinned": False,
+                    "archived": False, "project_id": None, "profile": None,
+                    "input_tokens": 0, "output_tokens": 0,
+                    "estimated_cost": None, "personality": None,
+                }
+
+            @property
+            def path(self):
+                return "/tmp/fake.json"
+
+        fake_stream_id = "stream-interim-callback"
+        fake_queue = queue.Queue()
+        fake_rt_module = types.ModuleType("hermes_cli.runtime_provider")
+        fake_rt_module.resolve_runtime_provider = mock.Mock(return_value={
+            "provider": "openai-codex",
+            "base_url": "https://api.openai.com/v1",
+            "api_key": "rt-key",
+            "api_mode": "codex_responses",
+            "command": "codex",
+            "args": ["exec", "--json"],
+            "credential_pool": object(),
+        })
+        fake_hermes_cli = types.ModuleType("hermes_cli")
+        fake_hermes_cli.runtime_provider = fake_rt_module
+        fake_hermes_state = types.ModuleType("hermes_state")
+        fake_hermes_state.SessionDB = mock.Mock(return_value=object())
+
+        with mock.patch.object(streaming, "get_session", return_value=FakeSession()), \
+             mock.patch.object(streaming, "_get_ai_agent", return_value=CapturingAgent), \
+             mock.patch.object(streaming, "resolve_model_provider", return_value=("gpt-4o", "openai-codex", None)), \
+             mock.patch("api.config.get_config", return_value={}), \
+             mock.patch("api.config._resolve_cli_toolsets", return_value=[]), \
+             mock.patch.dict(sys.modules, {
+                 "hermes_cli": fake_hermes_cli,
+                 "hermes_cli.runtime_provider": fake_rt_module,
+                 "hermes_state": fake_hermes_state,
+             }):
+            streaming.STREAMS[fake_stream_id] = fake_queue
+            streaming._run_agent_streaming(
+                session_id="sess-interim-test",
+                msg_text="hello",
+                model="gpt-4o",
+                workspace="/tmp",
+                stream_id=fake_stream_id,
+            )
+
+        init_kwargs = captured["init_kwargs"]
+        self.assertIsNotNone(init_kwargs["interim_assistant_callback"])
+        self.assertTrue(callable(init_kwargs["interim_assistant_callback"]))
+
+        interim_events = []
+        while not fake_queue.empty():
+            try:
+                interim_events.append(fake_queue.get_nowait())
+            except queue.Empty:
+                break
+        self.assertTrue(
+            any(event == "interim_assistant" for event, _ in interim_events),
+            "interim_assistant callback should emit interim_assistant SSE events",
+        )
+        self.assertTrue(
+            any(
+                event == "interim_assistant" and event_data.get("text") == "Inspecting repo structure."
+                for event, event_data in interim_events
+            ),
+            "interim_assistant event should carry the assistant commentary text"
+        )
+
 
 class TestSessionDBAST(unittest.TestCase):
     """AST-level checks: verify the try/except is not inside _ENV_LOCK (deadlock guard)."""


### PR DESCRIPTION
# v0.51.25 — Release C: 6-PR streaming/runtime contributor batch

**Theme:** Profile-isolated quota probes + request wedge diagnostics + max_turns config honor + per-turn usage overwrite + interim_assistant SSE wiring + workspace-prefix transcript dedup.

## Constituent PRs

- **#1873** by @franksong2702 — Subprocess-based profile isolation for quota fetches (closes #1831)
- **#1860** by @franksong2702 — Request wedge diagnostics for /api/chat/start + /api/sessions (refs #1855)
- **#1877** by @Michaelyklam — Honor `agent.max_turns` in WebUI streaming agents (closes #1876)
- **#1861** by @franksong2702 — Per-turn usage overwrite (vs cumulative accumulation) (closes #1857) + Opus-absorbed defensive guard against restart-zeros-totals
- **#1865** by @franksong2702 — Wire `interim_assistant_callback` runtime contract through SSE stream
- **#1889** by @ai-ag2026 — Dedup workspace-prefixed user turns during compaction (refs #1217)

## Pre-release verification

- Full pytest under `HERMES_HOME` isolation: **4861 passed, 8 skipped, 1 xfailed, 2 xpassed, 8 subtests passed** in 145.96s on Python 3.11.
- Browser API harness (port 8789): all 11 checks PASS.
- `node -c` on `static/messages.js`: clean.
- Stage diff: 13 files, +1216/-196.
- Opus advisor pass on stage-320: **SHIP** with three Medium-severity concerns (one absorbed in-release: #1861 restart-zeros-totals guard; two filed as follow-ups: #1873 worker-pool ops, #1889 regex sentinel).
- Pre-stamp re-fetch of all 6 PR heads: no contributor force-pushes during the Opus window.

## Opus-absorbed fixes

**#1861 defensive guard** — `api/streaming.py:2925-2934`: added `> 0` / `is not None` guards before overwriting `s.input_tokens` / `s.output_tokens` / `s.estimated_cost` so a rebuilt-from-cache-miss agent (post-restart or post-LRU-eviction) doesn't zero out persisted disk totals on its next turn. Test still passes.

## Test count

4858 → **4872 collected, 4861 passing** (+14 net new tests).

## Closes

- #1831 (PR #1873)
- #1857 (PR #1861)
- #1876 (PR #1877)

Closes #1860, #1861, #1865, #1873, #1877, #1889.
