### PR TITLE
fix: keep streaming chat pinned after final render

### DIFF
--- a/static/messages.js
+++ b/static/messages.js
@@ -889,6 +889,9 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       }
       _clearApprovalForOwner();
       _clearClarifyForOwner('terminal');
+      const shouldFollowOnDone=isActiveSession&&((typeof _shouldFollowMessagesOnDomReplace==='function')
+        ? _shouldFollowMessagesOnDomReplace()
+        : (typeof _isMessagePaneNearBottom==='function'&&_isMessagePaneNearBottom(1200)));
       if(isActiveSession){
         S.activeStreamId=null;
       }
@@ -968,7 +971,9 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         // No-reply guard (#373): if agent returned nothing, show inline error
         if(!S.messages.some(m=>m.role==='assistant'&&String(m.content||'').trim())&&!assistantText){removeThinking();S.messages.push({role:'assistant',content:'**No response received.** Check your API key and model selection.'});}
         if(isSessionViewed) _markSessionViewed(completedSid, completedSession.message_count ?? S.messages.length);
-        syncTopbar();renderMessages({preserveScroll:true});loadDir('.');
+        syncTopbar();renderMessages({preserveScroll:true});
+        if(shouldFollowOnDone&&typeof scrollToBottom==='function') scrollToBottom();
+        loadDir('.');
         // TTS auto-read: speak the last assistant response if enabled (#499)
         if(typeof autoReadLastAssistant==='function') setTimeout(()=>autoReadLastAssistant(), 300);
       }

--- a/static/ui.js
+++ b/static/ui.js
@@ -1498,7 +1498,10 @@ let _programmaticScroll=false;
 let _nearBottomCount=0;
 let _lastScrollTop=null;
 let _lastNonMessageScrollIntentMs=0;
+let _lastMessageUpwardIntentMs=0;
+let _messageUserUnpinned=false;
 const NON_MESSAGE_SCROLL_INTENT_SUPPRESS_MS=350;
+const MESSAGE_UPWARD_INTENT_MS=450;
 function _recordNonMessageScrollIntent(e){
   const el=document.getElementById('messages');
   const target=e&&e.target;
@@ -1508,6 +1511,18 @@ function _recordNonMessageScrollIntent(e){
   // session sidebar (or another independent pane) must not be immediately fought
   // by scrollIfPinned() writing #messages.scrollTop on the next token (#1784).
   if(!el.contains(target)) _lastNonMessageScrollIntentMs=performance.now();
+  else if(e.type==='touchmove'||(typeof e.deltaY==='number'&&e.deltaY<0)){
+    // User is intentionally moving upward in the transcript. Record the real
+    // input event so later scrollTop decreases caused by layout/windowing do
+    // not masquerade as user intent and strand live streaming away from bottom.
+    _lastMessageUpwardIntentMs=performance.now();
+    _messageUserUnpinned=true;
+    _nearBottomCount=0;
+    _scrollPinned=false;
+  }
+}
+function _recentMessageUpwardIntent(){
+  return performance.now()-_lastMessageUpwardIntentMs<MESSAGE_UPWARD_INTENT_MS;
 }
 function _recentNonMessageScrollIntent(){
   return performance.now()-_lastNonMessageScrollIntentMs<NON_MESSAGE_SCROLL_INTENT_SUPPRESS_MS;
@@ -1531,10 +1546,11 @@ if (typeof window !== 'undefined') window._resetScrollDirectionTracker = _resetS
     _scrollRaf=requestAnimationFrame(()=>{
       const top=el.scrollTop;
       const nearBottom=el.scrollHeight-top-el.clientHeight<250;
-      const movedUp=_lastScrollTop!==null && top<_lastScrollTop-2;
+      // scrollToBottomBtn visibility is updated below after pin state settles.
+      const movedUp=_lastScrollTop!==null && top<_lastScrollTop-2 && _recentMessageUpwardIntent();
       _lastScrollTop=top;
-      if(movedUp){ _nearBottomCount=0; _scrollPinned=false; } // #1731
-      else { _nearBottomCount=nearBottom?_nearBottomCount+1:0; _scrollPinned=_nearBottomCount>=2; } // #1360
+      if(movedUp){ _nearBottomCount=0; _scrollPinned=false; _messageUserUnpinned=true; } // #1731
+      else { _nearBottomCount=nearBottom?_nearBottomCount+1:0; _scrollPinned=_nearBottomCount>=2; if(_scrollPinned) _messageUserUnpinned=false; } // #1360
       const btn=$('scrollToBottomBtn');
       if(btn) btn.style.display=_scrollPinned?'none':'flex';
       // Load older messages when scrolled near the top
@@ -1820,16 +1836,32 @@ document.addEventListener('DOMContentLoaded',function(){
   tooltip.addEventListener('click',function(e){e.stopPropagation();});
 });
 
+function _setMessageScrollToBottom(){
+  const el=$('messages');
+  if(!el) return;
+  _programmaticScroll=true;
+  el.scrollTop=el.scrollHeight;
+  _lastScrollTop=el.scrollTop;
+  requestAnimationFrame(()=>{ setTimeout(()=>{_programmaticScroll=false;},0); });
+}
+function _isMessagePaneNearBottom(threshold=250){
+  const el=$('messages');
+  if(!el) return false;
+  return el.scrollHeight-el.scrollTop-el.clientHeight<=threshold;
+}
+function _shouldFollowMessagesOnDomReplace(){
+  return !_messageUserUnpinned && (_scrollPinned || _isMessagePaneNearBottom(1200));
+}
 function scrollIfPinned(){
   if(!_scrollPinned) return;
   if(_recentNonMessageScrollIntent()) return;
   const el=$('messages');
-  if(el){_programmaticScroll=true;el.scrollTop=el.scrollHeight;setTimeout(()=>{_programmaticScroll=false;},0);}
+  if(el){_programmaticScroll=true;el.scrollTop=el.scrollHeight;_lastScrollTop=el.scrollTop;requestAnimationFrame(()=>{ setTimeout(()=>{_programmaticScroll=false;},0); });}
 }
 function scrollToBottom(){
   _scrollPinned=true;
-  const el=$('messages');
-  if(el){_programmaticScroll=true;el.scrollTop=el.scrollHeight;setTimeout(()=>{_programmaticScroll=false;},0);}
+  _messageUserUnpinned=false;
+  _setMessageScrollToBottom();
   const btn=$('scrollToBottomBtn');
   if(btn) btn.style.display='none';
 }

--- a/tests/test_dashboard_probe.py
+++ b/tests/test_dashboard_probe.py
@@ -111,6 +111,11 @@ def test_dashboard_target_validation_allows_only_loopback_base_urls():
 def test_status_tries_default_loopback_targets_until_dashboard_found(monkeypatch):
     from api import dashboard_probe
 
+    # This test verifies the default auto-probe sequence. Other tests exercise
+    # .env/bootstrap behavior and may leave HERMES_WEBUI_HOST at 0.0.0.0 in the
+    # process env; make the default precondition explicit here.
+    monkeypatch.delenv("HERMES_WEBUI_HOST", raising=False)
+
     attempts = []
 
     def fake_probe(host, port, timeout=0.5, scheme="http"):

--- a/tests/test_issue1560_password_env_var_lock.py
+++ b/tests/test_issue1560_password_env_var_lock.py
@@ -168,10 +168,13 @@ def test_i18n_locked_string_mentions_env_var_name_in_all_locales():
 # ── Live HTTP smoke test (env var NOT set in pytest) ──────────────────────
 
 
-def test_get_settings_returns_password_env_var_false_when_unset():
+def test_get_settings_returns_password_env_var_false_when_unset(monkeypatch):
     """When HERMES_WEBUI_PASSWORD is not set in the test process,
     GET /api/settings must include `password_env_var: False`."""
-    # The conftest server inherits this process's env; verify it's clean.
+    # Test the unset branch explicitly. Some suite neighbors intentionally set
+    # HERMES_WEBUI_PASSWORD while exercising the locked-password path.
+    monkeypatch.delenv('HERMES_WEBUI_PASSWORD', raising=False)
+    # The conftest server inherits a sanitized env; verify this process is clean.
     assert not os.getenv('HERMES_WEBUI_PASSWORD', '').strip(), \
         'this test requires HERMES_WEBUI_PASSWORD to be unset'
 

--- a/tests/test_issue1731_upward_scroll_unpins.py
+++ b/tests/test_issue1731_upward_scroll_unpins.py
@@ -91,6 +91,46 @@ def test_upward_scroll_unpins_immediately_without_hysteresis():
     )
 
 
+def test_upward_motion_only_unpins_after_recent_user_intent():
+    """Layout/programmatic scrollTop decreases must not masquerade as user scroll-up.
+
+    Long-session windowing can preserve/restore scroll positions while the live
+    stream is growing. If a plain scrollTop decrease always clears
+    ``_scrollPinned``, the viewport can be visually at bottom while the state says
+    "not pinned", so streaming stops auto-following. Explicit wheel/touch upward
+    input must still unpin immediately; passive layout movement must not.
+    """
+    assert "let _lastMessageUpwardIntentMs=" in UI_JS, (
+        "ui.js must track recent upward wheel/touch intent inside #messages so "
+        "programmatic/layout scroll changes do not permanently unpin streaming."
+    )
+    assert "function _recentMessageUpwardIntent()" in UI_JS, (
+        "ui.js must expose a recent upward transcript intent helper."
+    )
+    block = _scroll_listener_block()
+    moved_idx = block.index("const movedUp=")
+    moved_expr = block[moved_idx : block.find(";", moved_idx)]
+    assert "_recentMessageUpwardIntent()" in moved_expr, (
+        "movedUp must require recent wheel/touch upward intent, not only a "
+        "scrollTop decrease caused by DOM/layout changes."
+    )
+
+
+def test_wheel_touch_upward_intent_is_recorded_inside_messages():
+    """Wheel/touch gestures inside #messages must mark real upward user intent."""
+    fn_start = UI_JS.index("function _recordNonMessageScrollIntent")
+    fn_end = UI_JS.index("function _recentNonMessageScrollIntent", fn_start)
+    fn = UI_JS[fn_start:fn_end]
+    assert "_lastMessageUpwardIntentMs=performance.now()" in fn, (
+        "_recordNonMessageScrollIntent must timestamp real upward transcript "
+        "wheel/touch gestures before clearing _scrollPinned."
+    )
+    assert "e.deltaY<0" in fn and "e.type==='touchmove'" in fn, (
+        "Both wheel-up and touchmove gestures inside #messages should count as "
+        "user upward intent."
+    )
+
+
 def test_downward_path_preserves_macos_momentum_hysteresis():
     """Downward / stationary motion must still go through the original
     hysteresis re-pin path so the #1360 macOS trackpad momentum protection

--- a/tests/test_streaming_markdown.py
+++ b/tests/test_streaming_markdown.py
@@ -418,6 +418,38 @@ class TestDoneEventSmd:
             "before renderMessages() in the 'done' handler source"
         )
 
+    def test_done_handler_preserves_bottom_follow_on_final_render(self):
+        """Final DOM replacement must keep auto-following users at the bottom.
+
+        The live stream path can be visually at bottom while _scrollPinned was
+        knocked false by history/windowing/layout preservation. On `done`, the
+        live DOM is replaced with persisted messages; if the handler blindly calls
+        renderMessages({preserveScroll:true}) while the pin flag is false, the
+        transcript can jump to the top. Capture bottom/follow intent before the
+        replacement and explicitly bottom only for those users.
+        """
+        fn = self.get_fn()
+        assert fn, "'done' handler not found"
+        assert "shouldFollowOnDone" in fn, (
+            "'done' handler must capture whether the viewed transcript should "
+            "continue following before replacing the live DOM."
+        )
+        follow_idx = fn.index("shouldFollowOnDone")
+        render_idx = fn.index("renderMessages({preserveScroll:true})")
+        assert follow_idx < render_idx, (
+            "Follow intent must be captured before renderMessages() replaces the "
+            "live transcript DOM."
+        )
+        after_render = fn[render_idx:render_idx + 500]
+        assert "if(shouldFollowOnDone" in after_render and "scrollToBottom()" in after_render, (
+            "After final render, done handler must call scrollToBottom() when the "
+            "user was pinned/near-bottom before DOM replacement."
+        )
+        assert "_isMessagePaneNearBottom" in fn, (
+            "Done follow capture must include a near-bottom DOM check, not only "
+            "the possibly-stale _scrollPinned flag."
+        )
+
 
 # ── 7. apperror event: smd parser ends cleanly ───────────────────────────────
 


### PR DESCRIPTION
## Summary
- keep users at the bottom after the final streaming DOM replacement when they were still pinned/near-bottom
- distinguish real upward transcript gestures from layout/programmatic scrollTop changes before unpinning
- make two environment-sensitive tests establish their own `HERMES_WEBUI_HOST` / `HERMES_WEBUI_PASSWORD` preconditions

## Test plan
- `git diff --check`
- `node --check static/ui.js`
- `node --check static/messages.js`
- `scripts/tars_webui_test_sanitized.sh tests/test_issue1731_upward_scroll_unpins.py tests/test_streaming_markdown.py::TestDoneEventSmd::test_done_handler_preserves_bottom_follow_on_final_render tests/test_dashboard_probe.py::test_status_tries_default_loopback_targets_until_dashboard_found tests/test_issue1560_password_env_var_lock.py::test_get_settings_returns_password_env_var_false_when_unset -q -o 'addopts='` -> 11 passed
- `scripts/tars_webui_test_sanitized.sh tests/test_issue1731_upward_scroll_unpins.py tests/test_streaming_markdown.py tests/test_streaming_sidebar_scroll.py tests/test_parallel_session_switch.py tests/test_issue677.py -q -o 'addopts='` -> 108 passed
- `scripts/tars_webui_test_sanitized.sh tests -q -o 'addopts='` -> 4789 passed, 41 skipped, 3 xpassed, 1 warning, 8 subtests passed
