### PR TITLE
fix: make kanban detail view scrollable

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -2275,7 +2275,7 @@ main.main.showing-settings > #mainSettings{display:flex;overflow-y:auto;}
 main.main.showing-skills > #mainSkills{display:flex;}
 main.main.showing-memory > #mainMemory{display:flex;}
 main.main.showing-tasks > #mainTasks{display:flex;}
-main.main.showing-kanban > #mainKanban{display:flex;}
+main.main.showing-kanban > #mainKanban{display:flex;overflow-y:auto;}
 main.main.showing-workspaces > #mainWorkspaces{display:flex;}
 main.main.showing-profiles > #mainProfiles{display:flex;}
 main.main.showing-logs > #mainLogs{display:flex;}

--- a/tests/test_kanban_ui_static.py
+++ b/tests/test_kanban_ui_static.py
@@ -93,6 +93,17 @@ def test_kanban_board_has_native_css_classes():
     assert "overflow-x:auto" in COMPACT_STYLE
 
 
+def test_kanban_main_view_scrolls_when_task_preview_is_tall():
+    """The app shell keeps body overflow hidden, so the Kanban main view
+    must own vertical scrolling. Otherwise a selected task with a long body
+    can push the board below the viewport with no way to reach it.
+    """
+    assert re.search(
+        r"main\.main\.showing-kanban\s*>\s*#mainKanban\s*\{[^}]*display:flex;[^}]*overflow-y:auto;",
+        COMPACT_STYLE,
+    ), "Kanban main view must expose a vertical scrollbar when detail content is taller than the viewport"
+
+
 def test_kanban_i18n_keys_exist_in_every_locale_block():
     locale_blocks = re.findall(r"\n\s*([a-z]{2}(?:-[A-Z]{2})?): \{(.*?)\n\s*\},", I18N, flags=re.S)
     assert len(locale_blocks) >= 8


### PR DESCRIPTION
## Thinking Path
- Hermes WebUI uses a fixed-height app shell (`body` is `100dvh` with hidden overflow).
- The Kanban main view renders the selected task detail above the board.
- A long task/issue body can make that detail region taller than the viewport.
- Because `#mainKanban` did not own vertical overflow, the board was pushed below the viewport with no scroll container to reach it.
- The smallest safe fix is to make the visible Kanban main view vertically scrollable, matching the existing Settings main-view pattern.

## What Changed
- Added `overflow-y: auto` to `main.main.showing-kanban > #mainKanban`.
- Added a static regression test asserting the Kanban main view owns vertical scrolling for tall task detail content.

## Why It Matters
Users can now scroll past an oversized selected task/issue detail and reach the rest of the Kanban board instead of having to zoom out.

Fixes #1915

## Verification
- Reproduced the bug in-browser against the static WebUI shell by injecting a long `#kanbanTaskPreview` body before the fix:
  - `body` had hidden overflow
  - `#mainKanban` had visible overflow
  - `.kanban-board-wrap` was pushed below the viewport with no usable scroll container
- Verified the fix in-browser after the change:
  - `#mainKanban` computed `overflow-y: auto`
  - `#mainKanban.scrollHeight > #mainKanban.clientHeight`
  - setting `#mainKanban.scrollTop` moved the pane and brought the board area back into reach
- Ran automated tests:
  - `/home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_kanban_ui_static.py -q`
  - Result: `29 passed`

## Risks / Follow-ups
- Low risk: scoped to the Kanban main view only.
- This does not alter Kanban API behavior or task rendering logic.
- Browser overlay scrollbars may only be visible while actively scrolling, but the scroll container is now present.

## Model Used
- Provider: OpenAI Codex
- Model: gpt-5.5
- AI-assisted implementation and browser/tool verification.