### PR TITLE
Persist login rate limit attempts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Hermes Web UI -- Changelog
 
+## Unreleased
+
+### Fixed
+
+- Persisted login rate-limit attempts under the WebUI state directory so failed password attempts survive server restarts. Closes #1910.
+
 ## [v0.51.26] — 2026-05-08 — 5-PR follow-on contributor batch (Release D: profile-isolation hardening across cache + skills + gateway-health, context-length config-override threading, sidebar segment count UI polish)
 
 ### Fixed (5 PRs + 1 absorbed test)

--- a/api/auth.py
+++ b/api/auth.py
@@ -77,9 +77,58 @@ def _save_sessions(sessions: dict[str, float]) -> None:
 _sessions = _load_sessions()
 
 # ── Login rate limiter ──────────────────────────────────────────────────────
-_login_attempts = {}  # ip -> [timestamp, ...]
+_LOGIN_ATTEMPTS_FILE = STATE_DIR / '.login_attempts.json'
 _LOGIN_MAX_ATTEMPTS = 5
 _LOGIN_WINDOW = 60  # seconds
+
+
+def _load_login_attempts() -> dict[str, list[float]]:
+    """Load persisted login attempts from STATE_DIR, pruning expired entries."""
+    try:
+        if _LOGIN_ATTEMPTS_FILE.exists():
+            data = json.loads(_LOGIN_ATTEMPTS_FILE.read_text(encoding='utf-8'))
+            if not isinstance(data, dict):
+                raise ValueError('malformed login-attempts file — expected dict')
+            now = time.time()
+            attempts: dict[str, list[float]] = {}
+            for ip, raw_times in data.items():
+                if not isinstance(ip, str) or not isinstance(raw_times, list):
+                    continue
+                fresh = [
+                    float(t)
+                    for t in raw_times
+                    if isinstance(t, (int, float)) and now - float(t) < _LOGIN_WINDOW
+                ]
+                if fresh:
+                    attempts[ip] = fresh
+            return attempts
+    except Exception as e:
+        logger.debug("Failed to load login attempts file, starting fresh: %s", e)
+    return {}
+
+
+def _save_login_attempts(attempts: dict[str, list[float]]) -> None:
+    """Atomically persist login attempts to STATE_DIR/.login_attempts.json (0600)."""
+    try:
+        _LOGIN_ATTEMPTS_FILE.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp = tempfile.mkstemp(dir=_LOGIN_ATTEMPTS_FILE.parent, suffix='.login_attempts.tmp')
+        try:
+            with os.fdopen(fd, 'w', encoding='utf-8') as f:
+                json.dump(attempts, f)
+            os.chmod(tmp, 0o600)
+            os.replace(tmp, _LOGIN_ATTEMPTS_FILE)
+        except Exception:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+            raise
+    except Exception as e:
+        logger.debug("Failed to persist login attempts: %s", e)
+
+
+_login_attempts = _load_login_attempts()  # ip -> [timestamp, ...]
+
 
 def _check_login_rate(ip: str) -> bool:
     """Return True if the IP is allowed to attempt login."""
@@ -87,14 +136,20 @@ def _check_login_rate(ip: str) -> bool:
     attempts = _login_attempts.get(ip, [])
     # Prune old attempts
     attempts = [t for t in attempts if now - t < _LOGIN_WINDOW]
-    _login_attempts[ip] = attempts
+    if attempts:
+        _login_attempts[ip] = attempts
+    else:
+        _login_attempts.pop(ip, None)
+    _save_login_attempts(_login_attempts)
     return len(attempts) < _LOGIN_MAX_ATTEMPTS
+
 
 def _record_login_attempt(ip: str) -> None:
     now = time.time()
     attempts = _login_attempts.get(ip, [])
     attempts.append(now)
     _login_attempts[ip] = attempts
+    _save_login_attempts(_login_attempts)
 
 
 def _signing_key():

--- a/tests/test_issue1910_login_attempt_persistence.py
+++ b/tests/test_issue1910_login_attempt_persistence.py
@@ -1,0 +1,52 @@
+import json
+import stat
+import time
+
+from api import auth
+
+
+def test_login_attempts_persist_failed_attempts(tmp_path, monkeypatch):
+    attempts_file = tmp_path / ".login_attempts.json"
+    monkeypatch.setattr(auth, "_LOGIN_ATTEMPTS_FILE", attempts_file)
+    monkeypatch.setattr(auth, "_login_attempts", {})
+
+    auth._record_login_attempt("203.0.113.10")
+
+    data = json.loads(attempts_file.read_text(encoding="utf-8"))
+    assert "203.0.113.10" in data
+    assert len(data["203.0.113.10"]) == 1
+    assert stat.S_IMODE(attempts_file.stat().st_mode) == 0o600
+
+
+def test_login_attempts_load_prunes_expired_entries(tmp_path, monkeypatch):
+    attempts_file = tmp_path / ".login_attempts.json"
+    now = time.time()
+    attempts_file.write_text(
+        json.dumps(
+            {
+                "203.0.113.10": [now],
+                "203.0.113.11": [now - auth._LOGIN_WINDOW - 5],
+                "bad": "not-a-list",
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(auth, "_LOGIN_ATTEMPTS_FILE", attempts_file)
+
+    loaded = auth._load_login_attempts()
+
+    assert list(loaded) == ["203.0.113.10"]
+    assert len(loaded["203.0.113.10"]) == 1
+
+
+def test_login_rate_limit_survives_reload(tmp_path, monkeypatch):
+    attempts_file = tmp_path / ".login_attempts.json"
+    monkeypatch.setattr(auth, "_LOGIN_ATTEMPTS_FILE", attempts_file)
+    monkeypatch.setattr(auth, "_login_attempts", {})
+
+    for _ in range(auth._LOGIN_MAX_ATTEMPTS):
+        auth._record_login_attempt("203.0.113.12")
+
+    monkeypatch.setattr(auth, "_login_attempts", auth._load_login_attempts())
+
+    assert not auth._check_login_rate("203.0.113.12")


### PR DESCRIPTION
## Thinking Path

Issue #1910 points out that the login rate limiter currently stores failed attempts only in process memory. A server restart clears the window, weakening the limiter for deployments with password auth enabled.

## What Changed

- Persist login-attempt buckets to `STATE_DIR/.login_attempts.json`.
- Load persisted attempts at startup and prune entries outside the configured window.
- Write attempts atomically with a temp file + `os.replace`, matching the existing session-cookie persistence pattern.
- Store the file with `0600` permissions.
- Avoid retaining empty IP buckets after pruning.
- Add regression tests for persistence, expiry pruning, file permissions, and reload behavior.

## Why It Matters

Password-auth deployments keep the same failed-attempt window across normal restarts instead of granting every IP a fresh bucket whenever the WebUI process restarts.

## Verification

- `.venv_test/bin/python -m pytest -q tests/test_issue1910_login_attempt_persistence.py tests/test_sprint29.py::TestLoginRateLimit`
- `python3 -m py_compile api/auth.py`
- `git diff --check`

## Risks

Low. The limiter remains single-process and keeps the same threshold/window semantics. If the file is missing, malformed, or unwritable, the auth path falls back to the current in-memory behavior and logs at debug level.

## Model Used

GPT-5 Codex via Codex CLI.

Closes #1910.
