### PR TITLE
feat: add sidebar collapse toggle — hide session list on the left

### DIFF
--- a/static/boot.js
+++ b/static/boot.js
@@ -238,6 +238,37 @@ function toggleWorkspacePanel(force){
   const nextMode=_hasWorkspacePreviewVisible()?'preview':'browse';
   openWorkspacePanel(nextMode);
 }
+// ── Sidebar collapse toggle (session list on left) ─────────────────────────
+function toggleSidebar(force){
+  const layout=document.querySelector('.layout');
+  if(!layout)return;
+  const sidebar=layout.querySelector('.sidebar');
+  if(!sidebar)return;
+  const currentlyCollapsed=layout.classList.contains('sidebar-collapsed');
+  const nextCollapsed=typeof force==='boolean'?force:!currentlyCollapsed;
+  layout.classList.toggle('sidebar-collapsed',nextCollapsed);
+  sidebar.classList.toggle('sidebar-collapsed',nextCollapsed);
+  try{localStorage.setItem('hermes-webui-sidebar-collapsed',nextCollapsed?'1':'0');}catch(_){}
+  // Update the rail button's active state so the user can see it
+  const btn=$('btnToggleSidebar');
+  if(btn) btn.classList.toggle('active',nextCollapsed);
+}
+function _initSidebarState(){
+  // Clear the flash-prevention dataset first, regardless of DOM state
+  try{document.documentElement.removeAttribute('data-sidebar-collapsed');}catch(_){}
+  const layout=document.querySelector('.layout');
+  if(!layout)return;
+  const sidebar=layout.querySelector('.sidebar');
+  if(!sidebar)return;
+  let collapsed=false;
+  try{collapsed=localStorage.getItem('hermes-webui-sidebar-collapsed')==='1';}catch(_){}
+  if(collapsed){
+    layout.classList.add('sidebar-collapsed');
+    sidebar.classList.add('sidebar-collapsed');
+    const btn=$('btnToggleSidebar');
+    if(btn) btn.classList.add('active');
+  }
+}
 function mobileSwitchPanel(name){
   switchPanel(name);
   if(name==='chat'){
@@ -1349,6 +1380,7 @@ function applyBotName(){
     applyBotName();
     if(typeof _applyTtsEnabled==='function') _applyTtsEnabled(localStorage.getItem('hermes-tts-enabled')==='true');
   }
+  _initSidebarState();
   // Non-blocking update check (fire-and-forget, once per tab session)
   // ?test_updates=1 in URL forces banner display for testing (bypasses sessionStorage guards)
   const _testUpdates=new URLSearchParams(location.search).get('test_updates')==='1';

--- a/static/boot.js
+++ b/static/boot.js
@@ -249,9 +249,15 @@ function toggleSidebar(force){
   layout.classList.toggle('sidebar-collapsed',nextCollapsed);
   sidebar.classList.toggle('sidebar-collapsed',nextCollapsed);
   try{localStorage.setItem('hermes-webui-sidebar-collapsed',nextCollapsed?'1':'0');}catch(_){}
-  // Update the rail button's active state so the user can see it
+  // Swap rail button icon: panel-left open ↔ panel-left close
   const btn=$('btnToggleSidebar');
-  if(btn) btn.classList.toggle('active',nextCollapsed);
+  if(btn){
+    if(nextCollapsed){
+      btn.innerHTML='<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="3" width="18" height="18" rx="2"/><line x1="15" y1="3" x2="15" y2="21"/></svg>';
+    } else {
+      btn.innerHTML='<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="3" width="18" height="18" rx="2"/><line x1="9" y1="3" x2="9" y2="21"/></svg>';
+    }
+  }
 }
 function _initSidebarState(){
   // Clear the flash-prevention dataset first, regardless of DOM state
@@ -266,7 +272,7 @@ function _initSidebarState(){
     layout.classList.add('sidebar-collapsed');
     sidebar.classList.add('sidebar-collapsed');
     const btn=$('btnToggleSidebar');
-    if(btn) btn.classList.add('active');
+    if(btn) btn.innerHTML='<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="3" width="18" height="18" rx="2"/><line x1="15" y1="3" x2="15" y2="21"/></svg>';
   }
 }
 function mobileSwitchPanel(name){
@@ -1025,6 +1031,12 @@ document.addEventListener('keydown',async e=>{
       const bar=editArea.closest('.msg-row')&&editArea.closest('.msg-row').querySelector('.msg-edit-bar');
       if(bar){const cancel=bar.querySelector('.msg-edit-cancel');if(cancel)cancel.click();}
     }
+  }
+  // Cmd/Ctrl+B toggles sidebar collapse (VS Code convention)
+  if((e.metaKey||e.ctrlKey)&&e.key==='b'&&typeof toggleSidebar==='function'){
+    e.preventDefault();
+    toggleSidebar();
+    return;
   }
 });
 $('msg').addEventListener('paste',e=>{

--- a/static/i18n.js
+++ b/static/i18n.js
@@ -547,6 +547,8 @@ const LOCALES = {
     tab_logs: 'Logs',
     tab_settings: 'Settings',
     new_conversation: 'New conversation',
+    toggle_sidebar: 'Toggle sidebar',
+    close_sidebar: 'Close sidebar',
     filter_conversations: 'Filter conversations...',
     session_time_unknown: 'Unknown',
     session_time_minutes_ago: (n) => `${n}m`,
@@ -1568,6 +1570,8 @@ const LOCALES = {
     tab_logs: 'ログ',
     tab_settings: '設定',
     new_conversation: '新しい会話',
+    toggle_sidebar: 'サイドバーの切り替え',
+    close_sidebar: 'サイドバーを閉じる',
     filter_conversations: '会話を絞り込み...',
     session_time_unknown: '不明',
     session_time_minutes_ago: (n) => `${n}分前`,
@@ -2442,6 +2446,8 @@ const LOCALES = {
     logs_truncated_hint: 'Showing the tail of a large log file; older bytes were skipped to keep memory bounded.',  // TODO: translate
     logs_copied: 'Logs copied',  // TODO: translate
     new_conversation: 'Новая беседа',
+    toggle_sidebar: 'Переключить боковую панель',
+    close_sidebar: 'Закрыть боковую панель',
     filter_conversations: 'Фильтр бесед...',
     session_time_unknown: 'Неизвестно',
     session_time_minutes_ago: (n) => `${n}м`,
@@ -3397,6 +3403,8 @@ const LOCALES = {
     logs_truncated_hint: 'Showing the tail of a large log file; older bytes were skipped to keep memory bounded.',  // TODO: translate
     logs_copied: 'Logs copied',  // TODO: translate
     new_conversation: 'Nueva conversación',
+    toggle_sidebar: 'Alternar barra lateral',
+    close_sidebar: 'Cerrar barra lateral',
     filter_conversations: 'Filtrar conversaciones...',
     session_time_unknown: 'Desconocido',
     session_time_minutes_ago: (n) => `${n}m`,
@@ -4340,6 +4348,8 @@ const LOCALES = {
     logs_truncated_hint: 'Showing the tail of a large log file; older bytes were skipped to keep memory bounded.',  // TODO: translate
     logs_copied: 'Logs copied',  // TODO: translate
     new_conversation: 'Neuer Chat',
+    toggle_sidebar: 'Seitenleiste umschalten',
+    close_sidebar: 'Seitenleiste schließen',
     filter_conversations: 'Chats filtern...',
     scheduled_jobs: 'Geplante Aufgaben',
     new_job: 'Neuer Job',
@@ -5306,6 +5316,8 @@ const LOCALES = {
     logs_truncated_hint: 'Showing the tail of a large log file; older bytes were skipped to keep memory bounded.',  // TODO: translate
     logs_copied: 'Logs copied',  // TODO: translate
     new_conversation: '新建对话',
+    toggle_sidebar: '切换侧边栏',
+    close_sidebar: '关闭侧边栏',
     filter_conversations: '筛选对话…',
     session_time_unknown: '未知',
     session_time_minutes_ago: (n) => `${n}分`,
@@ -6203,6 +6215,8 @@ const LOCALES = {
     tab_logs: 'Logs',
     tab_workspaces: '\u5de5\u4f5c\u5340',
     new_conversation: '新對話',
+    toggle_sidebar: '切換側邊欄',
+    close_sidebar: '關閉側邊欄',
     filter_conversations: '篩選對話',
     scheduled_jobs: '排程任務',
     new_job: '\u65b0\u4efb\u52d9',
@@ -7301,6 +7315,8 @@ const LOCALES = {
     logs_truncated_hint: 'Showing the tail of a large log file; older bytes were skipped to keep memory bounded.',  // TODO: translate
     logs_copied: 'Logs copied',  // TODO: translate
     new_conversation: 'Nova conversa',
+    toggle_sidebar: 'Alternar barra lateral',
+    close_sidebar: 'Fechar barra lateral',
     filter_conversations: 'Filtrar conversas...',
     session_time_unknown: 'Desconhecido',
     session_time_minutes_ago: (n) => `${n}m`,
@@ -8220,6 +8236,8 @@ const LOCALES = {
     logs_truncated_hint: 'Showing the tail of a large log file; older bytes were skipped to keep memory bounded.',  // TODO: translate
     logs_copied: 'Logs copied',  // TODO: translate
     new_conversation: '새 대화',
+    toggle_sidebar: '사이드바 토글',
+    close_sidebar: '사이드바 닫기',
     filter_conversations: '대화 필터…',
     session_time_unknown: 'Unknown',
     session_time_minutes_ago: (n) => `${n}m`,

--- a/static/index.html
+++ b/static/index.html
@@ -23,6 +23,7 @@
 <meta name="theme-color" id="hermes-theme-color" content="#0D0D1A">
 <script>(function(){try{var t=localStorage.getItem('hermes-theme')||'dark';if(t==='system')t=window.matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light';var c=t==='dark'?'#0D0D1A':'#FEFCF7';var m=document.getElementById('hermes-theme-color');if(m)m.setAttribute('content',c);}catch(e){}})()</script>
 <script>(function(){try{document.documentElement.dataset.workspacePanel=localStorage.getItem('hermes-webui-workspace-panel')==='open'?'open':'closed';}catch(e){document.documentElement.dataset.workspacePanel='closed';}})()</script>
+<script>(function(){try{if(localStorage.getItem('hermes-webui-sidebar-collapsed')==='1')document.documentElement.dataset.sidebarCollapsed='1';}catch(e){}})()</script>
 <link rel="stylesheet" href="static/style.css?v=__WEBUI_VERSION__">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/xterm@5.3.0/css/xterm.css" integrity="sha384-LJcOxlx9IMbNXDqJ2axpfEQKkAYbFjJfhXexLfiRJhjDU81mzgkiQq8rkV0j6dVh" crossorigin="anonymous">
   <!-- KaTeX math rendering CSS (loaded eagerly to prevent layout shift) -->
@@ -98,6 +99,7 @@
     <button class="rail-btn nav-tab dashboard-link has-tooltip" id="dashboardRailBtn" data-dashboard-link style="display:none" onclick="openHermesDashboard(event)" data-tooltip="Hermes Dashboard" data-i18n-title="tab_dashboard" aria-label="Hermes Dashboard"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18"/><path d="M9 21V9"/></svg><span class="dashboard-external-badge" aria-hidden="true"></span></button>
     <button class="rail-btn nav-tab has-tooltip" data-panel="logs" onclick="switchPanel('logs')" data-tooltip="Logs" data-i18n-title="tab_logs" aria-label="Logs"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><path d="M14 2v6h6"/><path d="M8 13h8"/><path d="M8 17h8"/><path d="M8 9h2"/></svg></button>
     <div class="rail-spacer"></div>
+    <button class="rail-btn has-tooltip" id="btnToggleSidebar" onclick="toggleSidebar()" data-tooltip="Toggle sidebar" data-i18n-title="toggle_sidebar" aria-label="Toggle sidebar"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="3" width="18" height="18" rx="2"/><line x1="9" y1="3" x2="9" y2="21"/></svg></button>
     <button class="rail-btn nav-tab has-tooltip" data-panel="settings" onclick="switchPanel('settings')" data-tooltip="Settings" data-i18n-title="tab_settings" aria-label="Settings"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg></button>
   </nav>
   <aside class="sidebar">
@@ -122,6 +124,9 @@
       <div class="panel-head">
         <span data-i18n="tab_chat">Chat</span>
         <div class="panel-head-actions">
+          <button class="panel-head-btn has-tooltip has-tooltip--bottom" id="btnCloseSidebar" onclick="toggleSidebar(true)" data-tooltip="Close sidebar" data-i18n-title="close_sidebar" aria-label="Close sidebar">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+          </button>
           <button class="panel-head-btn has-tooltip has-tooltip--bottom-right" id="btnNewChat" data-tooltip="New conversation (Cmd+K)" data-i18n-title="new_conversation" aria-label="New conversation">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
           </button>

--- a/static/style.css
+++ b/static/style.css
@@ -315,8 +315,6 @@
   .app-titlebar-hamburger{-webkit-app-region:no-drag;align-items:center;justify-content:center;background:none;border:none;color:var(--muted);border-radius:8px;cursor:pointer;padding:0;-webkit-tap-highlight-color:transparent;transition:background-color .15s,color .15s;}
   .app-titlebar-hamburger:hover{background:var(--hover-bg);color:var(--text);}
   .sidebar{width:300px;background:var(--sidebar);border-right:1px solid var(--border);display:flex;flex-direction:column;overflow:visible;flex-shrink:0;transition:width .24s cubic-bezier(.22,1,.36,1),opacity .18s ease,transform .24s cubic-bezier(.22,1,.36,1),border-color .24s ease;}
-/* Instant sidebar hide on boot when previously collapsed (synced via dataset from inline script) */
-html[data-sidebar-collapsed="1"] .layout .sidebar{width:0 !important;min-width:0;opacity:0;pointer-events:none;overflow:hidden;border-right-color:transparent;transform:translateX(-14px);transition:none;}
   .sidebar-header{padding:16px 18px 14px;border-bottom:1px solid var(--border);display:flex;align-items:center;gap:10px;}
   .logo{width:32px;height:32px;border-radius:9px;background:linear-gradient(145deg,var(--accent-hover),var(--accent));display:flex;align-items:center;justify-content:center;font-weight:800;font-size:14px;color:#fff;flex-shrink:0;box-shadow:0 2px 8px var(--accent-bg-strong);}
   .sidebar-header h1{font-size:15px;font-weight:600;}
@@ -1297,6 +1295,8 @@ html[data-sidebar-collapsed="1"] .layout .sidebar{width:0 !important;min-width:0
     .layout.workspace-panel-collapsed .rightpanel{width:0 !important;opacity:0;transform:translateX(14px);border-left-color:transparent;pointer-events:none;}
     /* Sidebar collapse — same pattern as workspace panel */
     .layout.sidebar-collapsed .sidebar:not(.mobile-open){width:0 !important;min-width:0;opacity:0;transform:translateX(-14px);border-right-color:transparent;pointer-events:none;overflow:hidden;}
+    /* Sidebar flash prevention — scoped to desktop to avoid breaking mobile overlay */
+    html[data-sidebar-collapsed="1"] .layout .sidebar{width:0 !important;min-width:0;opacity:0;pointer-events:none;overflow:hidden;border-right-color:transparent;transform:translateX(-14px);transition:none;}
   }
 
   @media(max-width:900px){

--- a/static/style.css
+++ b/static/style.css
@@ -314,7 +314,9 @@
   .app-titlebar-hamburger,.app-titlebar-spacer{display:none;width:32px;height:32px;flex-shrink:0;}
   .app-titlebar-hamburger{-webkit-app-region:no-drag;align-items:center;justify-content:center;background:none;border:none;color:var(--muted);border-radius:8px;cursor:pointer;padding:0;-webkit-tap-highlight-color:transparent;transition:background-color .15s,color .15s;}
   .app-titlebar-hamburger:hover{background:var(--hover-bg);color:var(--text);}
-  .sidebar{width:300px;background:var(--sidebar);border-right:1px solid var(--border);display:flex;flex-direction:column;overflow:visible;flex-shrink:0;}
+  .sidebar{width:300px;background:var(--sidebar);border-right:1px solid var(--border);display:flex;flex-direction:column;overflow:visible;flex-shrink:0;transition:width .24s cubic-bezier(.22,1,.36,1),opacity .18s ease,transform .24s cubic-bezier(.22,1,.36,1),border-color .24s ease;}
+/* Instant sidebar hide on boot when previously collapsed (synced via dataset from inline script) */
+html[data-sidebar-collapsed="1"] .layout .sidebar{width:0 !important;min-width:0;opacity:0;pointer-events:none;overflow:hidden;border-right-color:transparent;transform:translateX(-14px);transition:none;}
   .sidebar-header{padding:16px 18px 14px;border-bottom:1px solid var(--border);display:flex;align-items:center;gap:10px;}
   .logo{width:32px;height:32px;border-radius:9px;background:linear-gradient(145deg,var(--accent-hover),var(--accent));display:flex;align-items:center;justify-content:center;font-weight:800;font-size:14px;color:#fff;flex-shrink:0;box-shadow:0 2px 8px var(--accent-bg-strong);}
   .sidebar-header h1{font-size:15px;font-weight:600;}
@@ -1293,6 +1295,8 @@
   @media(min-width:901px){
     html[data-workspace-panel="closed"] .rightpanel{width:0 !important;opacity:0;transform:translateX(14px);border-left-color:transparent;pointer-events:none;}
     .layout.workspace-panel-collapsed .rightpanel{width:0 !important;opacity:0;transform:translateX(14px);border-left-color:transparent;pointer-events:none;}
+    /* Sidebar collapse — same pattern as workspace panel */
+    .layout.sidebar-collapsed .sidebar:not(.mobile-open){width:0 !important;min-width:0;opacity:0;transform:translateX(-14px);border-right-color:transparent;pointer-events:none;overflow:hidden;}
   }
 
   @media(max-width:900px){
@@ -1301,6 +1305,7 @@
     .mobile-close-btn{display:flex;}
     .close-preview{display:none;}
     #btnCollapseWorkspacePanel{display:none;}
+    #btnCloseSidebar{display:none;}
   }
 
   @container composer-footer (max-width: 700px){


### PR DESCRIPTION
## Summary

Add a collapse/expand toggle for the left sidebar (session/chat list). When collapsed, the main chat area expands to fill the full width — gives more horizontal space for conversations on wide screens.

## Changes

****
- Toggle button in the rail nav (bottom section, above Settings) with panel-left icon
- Close button (X) in the Chat panel header for symmetry

****
-  — collapse rule with smooth transition (same easing as workspace panel)
- Flash prevention: inline \<script> sets  on \<html> before stylesheet loads, with  to avoid paint flash
- Close button hidden on mobile (feature is desktop-only)

****
-  — toggles class on  + , persists to localStorage
-  — restores state on boot, clears flash-prevention dataset

## UX
- Rail button gets  highlight when sidebar is hidden
- State persists across page refreshes (localStorage key: `hermes-webui-sidebar-collapsed`)
- Smooth 240ms slide animation matching the existing workspace panel collapse

## Testing
- Verified on mobile (<=900px): collapse rules scoped to , close button hidden
- Flash prevention tested: no sidebar flash on cold page load with collapsed state