### PR TITLE
feat: add opt-in session endless scroll

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -3682,6 +3682,7 @@ _SETTINGS_DEFAULTS = {
     "theme": "dark",  # light | dark | system
     "skin": "default",  # accent color skin: default | ares | mono | slate | poseidon | sisyphus | charizard
     "font_size": "default",  # small | default | large
+    "session_endless_scroll": False,  # auto-load older transcript pages while scrolling upward
     "language": "en",  # UI locale code; must match a key in static/i18n.js LOCALES
     "bot_name": os.getenv(
         "HERMES_WEBUI_BOT_NAME", "Hermes"
@@ -3810,6 +3811,7 @@ _SETTINGS_BOOL_KEYS = {
     "show_thinking",
     "simplified_tool_calling",
     "api_redact_enabled",
+    "session_endless_scroll",
 }
 # Language codes are validated as short alphanumeric BCP-47-like tags (e.g. 'en', 'zh', 'fr')
 _SETTINGS_LANG_RE = __import__("re").compile(r"^[a-zA-Z]{2,10}(-[a-zA-Z0-9]{2,8})?$")

--- a/static/boot.js
+++ b/static/boot.js
@@ -1303,6 +1303,7 @@ function applyBotName(){
     window._simplifiedToolCalling=s.simplified_tool_calling!==false;
     window._sidebarDensity=(s.sidebar_density==='detailed'?'detailed':'compact');
     window._busyInputMode=(s.busy_input_mode||'queue');
+    window._sessionEndlessScrollEnabled=!!s.session_endless_scroll;
     window._botName=s.bot_name||'Hermes';
     if(s.default_model) window._defaultModel=s.default_model;
     // Persist default workspace so the blank new-chat page can show it
@@ -1337,6 +1338,7 @@ function applyBotName(){
     window._simplifiedToolCalling=true;
     window._sidebarDensity='compact';
     window._busyInputMode='queue';
+    window._sessionEndlessScrollEnabled=false;
     window._botName='Hermes';
     _bootSettings={check_for_updates:false};
     if(typeof setLocale==='function'){

--- a/static/i18n.js
+++ b/static/i18n.js
@@ -420,6 +420,10 @@ const LOCALES = {
     settings_update_check_failed: 'Update check failed',
     settings_label_workspace_panel_open: 'Keep workspace panel open by default',
     settings_desc_workspace_panel_open: 'When enabled, the workspace / file browser panel opens automatically with each new session. You can still close it manually at any time.',
+
+    settings_label_session_endless_scroll: 'Load older messages while scrolling up',
+
+    settings_desc_session_endless_scroll: 'When enabled, older messages load automatically as you scroll upward. When disabled, use the older-messages button.',
     open_in_browser: 'Open in browser',
     settings_dropdown_conversation: 'Conversation',
     settings_dropdown_appearance: 'Appearance',
@@ -1441,6 +1445,10 @@ const LOCALES = {
     settings_updates_disabled: 'アップデート確認は無効です',
     settings_label_workspace_panel_open: 'ワークスペースパネルをデフォルトで開いておく',
     settings_desc_workspace_panel_open: '有効にすると、新しいセッションごとにワークスペース/ファイルブラウザパネルが自動で開きます。手動でいつでも閉じられます。',
+
+    settings_label_session_endless_scroll: '上スクロールで古いメッセージを読み込む',
+
+    settings_desc_session_endless_scroll: '有効にすると、上にスクロールしたとき古いメッセージを自動で読み込みます。無効の場合は古いメッセージボタンを使います。',
     open_in_browser: 'ブラウザで開く',
     settings_dropdown_conversation: '会話',
     settings_dropdown_appearance: '外観',
@@ -2880,6 +2888,10 @@ const LOCALES = {
     settings_update_check_failed: 'Ошибка проверки обновлений',
     settings_label_workspace_panel_open: 'Открывать панель рабочей области по умолчанию',
     settings_desc_workspace_panel_open: 'При включении панель файлов будет открываться автоматически в каждой новой сессии.',
+
+    settings_label_session_endless_scroll: 'Загружать старые сообщения при прокрутке вверх',
+
+    settings_desc_session_endless_scroll: 'Если включено, старые сообщения загружаются автоматически при прокрутке вверх. Если выключено, используйте кнопку загрузки старых сообщений.',
     open_in_browser: 'Открыть в браузере',
     settings_section_system_title: 'System',
     settings_tab_appearance: 'Appearance',
@@ -3823,6 +3835,10 @@ const LOCALES = {
     settings_update_check_failed: 'Error al comprobar actualizaciones',
     settings_label_workspace_panel_open: 'Mantener panel de espacio abierto',
     settings_desc_workspace_panel_open: 'Al activar, el panel de archivos se abre automáticamente en cada nueva sesión. Aún puedes cerrarlo manualmente.',
+
+    settings_label_session_endless_scroll: 'Cargar mensajes antiguos al desplazarse hacia arriba',
+
+    settings_desc_session_endless_scroll: 'Si está activado, los mensajes antiguos se cargan automáticamente al desplazarte hacia arriba. Si está desactivado, usa el botón de mensajes antiguos.',
     open_in_browser: 'Abrir en el navegador',
     settings_section_system_title: 'System',
     settings_tab_appearance: 'Appearance',
@@ -4511,6 +4527,10 @@ const LOCALES = {
     settings_update_check_failed: 'Update-Prüfung fehlgeschlagen',
     settings_label_workspace_panel_open: 'Arbeitsbereich-Panel standardmäßig öffnen',
     settings_desc_workspace_panel_open: 'Wenn aktiviert, wird der Datei-Browser bei jeder neuen Sitzung automatisch geöffnet. Er kann jederzeit manuell geschlossen werden.',
+
+    settings_label_session_endless_scroll: 'Ältere Nachrichten beim Hochscrollen laden',
+
+    settings_desc_session_endless_scroll: 'Wenn aktiviert, werden ältere Nachrichten beim Hochscrollen automatisch geladen. Wenn deaktiviert, nutzt du den Button für ältere Nachrichten.',
 
     workspace_drag_hint: 'Ziehen zum Neuordnen',
     workspace_reorder_failed: 'Neuordnen fehlgeschlagen',
@@ -5730,6 +5750,10 @@ const LOCALES = {
     settings_update_check_failed: '更新检查失败',
     settings_label_workspace_panel_open: '默认保持工作区面板打开',
     settings_desc_workspace_panel_open: '启用后，工作区/文件浏览器面板会在每次新会话时自动打开。您仍可随时手动关闭。',
+
+    settings_label_session_endless_scroll: '向上滚动时加载更早的消息',
+
+    settings_desc_session_endless_scroll: '启用后，向上滚动时会自动加载更早的消息。禁用时请使用加载更早消息按钮。',
     open_in_browser: '在浏览器中打开',
     settings_section_system_title: 'System',
     settings_tab_appearance: 'Appearance',
@@ -6136,6 +6160,10 @@ const LOCALES = {
     settings_update_check_failed: '更新檢查失敗',
     settings_label_workspace_panel_open: '預設保持工作區面板開啓',
     settings_desc_workspace_panel_open: '啟用後，工作區/檔案瀏覽器面板會在每次新會話時自動開啓。您仍可隨時手動關閉。',
+
+    settings_label_session_endless_scroll: '向上捲動時載入較早訊息',
+
+    settings_desc_session_endless_scroll: '啟用後，向上捲動時會自動載入較早訊息。停用時請使用載入較早訊息按鈕。',
     open_in_browser: '在瀏覽器中開啓',
     settings_dropdown_conversation: '對話',
     settings_dropdown_appearance: '外觀',
@@ -7168,6 +7196,10 @@ const LOCALES = {
     settings_update_check_failed: 'Falha ao verificar updates',
     settings_label_workspace_panel_open: 'Manter painel workspace aberto por padrão',
     settings_desc_workspace_panel_open: 'Quando ativo, o painel workspace abre automaticamente com cada nova sessão.',
+
+    settings_label_session_endless_scroll: 'Carregar mensagens antigas ao rolar para cima',
+
+    settings_desc_session_endless_scroll: 'Quando ativado, mensagens antigas carregam automaticamente ao rolar para cima. Quando desativado, use o botão de mensagens antigas.',
     open_in_browser: 'Abrir no navegador',
     settings_dropdown_conversation: 'Conversa',
     settings_dropdown_appearance: 'Aparência',
@@ -8087,6 +8119,10 @@ const LOCALES = {
     settings_update_check_failed: 'Update check failed',
     settings_label_workspace_panel_open: '기본으로 워크스페이스 패널 열기',
     settings_desc_workspace_panel_open: '활성화하면 새 세션마다 워크스페이스/파일 브라우저 패널이 자동으로 열립니다. 언제든지 수동으로 닫을 수 있습니다.',
+
+    settings_label_session_endless_scroll: '위로 스크롤할 때 이전 메시지 불러오기',
+
+    settings_desc_session_endless_scroll: '활성화하면 위로 스크롤할 때 이전 메시지를 자동으로 불러옵니다. 비활성화하면 이전 메시지 버튼을 사용합니다.',
     open_in_browser: '브라우저에서 열기',
     settings_dropdown_conversation: '대화',
     settings_dropdown_appearance: '외형',

--- a/static/index.html
+++ b/static/index.html
@@ -863,6 +863,13 @@
               </label>
               <div style="font-size:11px;color:var(--muted);margin-top:4px" data-i18n="settings_desc_workspace_panel_open">When enabled, the workspace / file browser panel opens automatically with each new session. You can still close it manually at any time.</div>
             </div>
+            <div class="settings-field">
+              <label style="display:flex;align-items:center;gap:8px;cursor:pointer">
+                <input type="checkbox" id="settingsSessionEndlessScroll" style="width:15px;height:15px;accent-color:var(--accent)">
+                <span data-i18n="settings_label_session_endless_scroll">Load older messages while scrolling up</span>
+              </label>
+              <div style="font-size:11px;color:var(--muted);margin-top:4px" data-i18n="settings_desc_session_endless_scroll">When enabled, older messages load automatically as you scroll upward. When disabled, use the older-messages button.</div>
+            </div>
             <div id="settingsAppearanceAutosaveStatus" class="settings-autosave-status" aria-live="polite"></div>
           </div>
           <div class="settings-pane" id="settingsPanePreferences">

--- a/static/panels.js
+++ b/static/panels.js
@@ -4251,6 +4251,7 @@ function _appearancePayloadFromUi(){
     theme: ($('settingsTheme')||{}).value || localStorage.getItem('hermes-theme') || 'dark',
     skin: ($('settingsSkin')||{}).value || localStorage.getItem('hermes-skin') || 'default',
     font_size: ($('settingsFontSize')||{}).value || localStorage.getItem('hermes-font-size') || 'default',
+    session_endless_scroll: !!($('settingsSessionEndlessScroll')||{}).checked,
   };
 }
 
@@ -4298,6 +4299,7 @@ async function _autosaveAppearanceSettings(payload){
     if(saved&&saved.font_size){
       localStorage.setItem('hermes-font-size',saved.font_size);
     }
+    window._sessionEndlessScrollEnabled=!!(saved&&saved.session_endless_scroll);
     _setAppearanceAutosaveStatus('saved');
   }catch(e){
     console.warn('[settings] appearance autosave failed', e);
@@ -4468,6 +4470,15 @@ async function loadSettingsPanel(){
         document.documentElement.dataset.workspacePanel=open?'open':'closed';
         if(open&&_workspacePanelMode==='closed') openWorkspacePanel('browse');
         else if(!open&&_workspacePanelMode!=='closed') toggleWorkspacePanel(false);
+      };
+    }
+    const endlessScrollCb=$('settingsSessionEndlessScroll');
+    if(endlessScrollCb){
+      endlessScrollCb.checked=!!settings.session_endless_scroll;
+      window._sessionEndlessScrollEnabled=endlessScrollCb.checked;
+      endlessScrollCb.onchange=function(){
+        window._sessionEndlessScrollEnabled=this.checked;
+        _scheduleAppearanceAutosave();
       };
     }
     const resolvedLanguage=(typeof resolvePreferredLocale==='function')
@@ -5126,6 +5137,7 @@ function _applySavedSettingsUi(saved, body, opts){
   window._simplifiedToolCalling=body.simplified_tool_calling!==false;
   window._sidebarDensity=sidebarDensity==='detailed'?'detailed':'compact';
   window._busyInputMode=body.busy_input_mode||'queue';
+  window._sessionEndlessScrollEnabled=!!body.session_endless_scroll;
   window._botName=body.bot_name||'Hermes';
   if(typeof applyBotName==='function') applyBotName();
   if(typeof setLocale==='function') setLocale(language);
@@ -5221,6 +5233,7 @@ async function saveSettings(andClose){
   body.theme=theme;
   body.skin=skin;
   body.font_size=fontSize;
+  body.session_endless_scroll=!!($('settingsSessionEndlessScroll')||{}).checked;
   body.language=language;
   body.show_token_usage=showTokenUsage;
   body.show_tps=showTps;

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1020,18 +1020,32 @@ async function _loadOlderMessages() {
     const container = $('messages');
     const prevScrollH = container ? container.scrollHeight : 0;
     S.messages = [...olderMsgs, ...S.messages];
+    // renderMessages() windows long transcripts from the end. If we do not
+    // expand that window before rendering, the newly prepended page stays
+    // hidden and the "hidden" counter rises while the viewport appears stuck.
+    // Count roughly by the same visible-message rules used by renderMessages().
+    const addedRenderable = olderMsgs.filter(m=>{
+      if(!m||!m.role||m.role==='tool') return false;
+      if(typeof _isContextCompactionMessage==='function'&&_isContextCompactionMessage(m)) return false;
+      if(typeof _isPreservedCompressionTaskListMessage==='function'&&_isPreservedCompressionTaskListMessage(m)) return false;
+      const hasTc=Array.isArray(m.tool_calls)&&m.tool_calls.length>0;
+      const hasTu=Array.isArray(m.content)&&m.content.some(p=>p&&p.type==='tool_use');
+      return !!(msgContent(m)||m._statusCard||m.attachments?.length||(m.role==='assistant'&&(hasTc||hasTu||(typeof _messageHasReasoningPayload==='function'&&_messageHasReasoningPayload(m)))));
+    }).length;
+    _messageRenderWindowSize=_currentMessageRenderWindowSize()+Math.max(addedRenderable, MESSAGE_RENDER_WINDOW_DEFAULT);
     _messagesTruncated = !!data.session._messages_truncated;
     _oldestIdx = data.session._messages_offset || 0;
-    renderMessages();
-    // Restore scroll position so the user stays at the same message.
-    // renderMessages() calls scrollToBottom() at the end, so we must
-    // counter-scroll to where the user was before loading older messages.
+    renderMessages({ preserveScroll: true });
     if (container) {
+      // Prepending older messages must not teleport the reader. Preserve the
+      // currently visible viewport by adding the inserted height to scrollTop.
+      const oldTop = container.scrollTop;
       const newScrollH = container.scrollHeight;
-      container.scrollTop = newScrollH - prevScrollH;
+      const addedHeight = Math.max(0, newScrollH - prevScrollH);
+      _programmaticScroll = true;
+      container.scrollTop = oldTop + addedHeight;
+      requestAnimationFrame(()=>{ _programmaticScroll = false; });
     }
-    // renderMessages() called scrollToBottom() which set _scrollPinned=true.
-    // We just restored the user's scroll position, so mark as not pinned.
     _scrollPinned = false;
   } catch(e) {
     console.warn('_loadOlderMessages failed:', e);

--- a/static/ui.js
+++ b/static/ui.js
@@ -185,6 +185,9 @@ function _messageRenderableMessageCount(){
 function _messageHiddenBeforeCount(){
   return Math.max(0,_messageRenderableMessageCount()-_currentMessageRenderWindowSize());
 }
+function _isSessionEndlessScrollEnabled(){
+  return window._sessionEndlessScrollEnabled===true;
+}
 function _wireMessageWindowLoadEarlierButton(){
   const indicator=$('loadOlderIndicator');
   if(!indicator) return;
@@ -1563,8 +1566,11 @@ if (typeof window !== 'undefined') window._resetScrollDirectionTracker = _resetS
       else { _nearBottomCount=nearBottom?_nearBottomCount+1:0; _scrollPinned=_nearBottomCount>=2; if(_scrollPinned) _messageUserUnpinned=false; } // #1360
       const btn=$('scrollToBottomBtn');
       if(btn) btn.style.display=_scrollPinned?'none':'flex';
-      // Load older messages when scrolled near the top
-      if(el.scrollTop<80 && typeof _messagesTruncated!=='undefined' && _messagesTruncated && typeof _loadOlderMessages==='function'){
+      // Prefetch older messages before the reader hits the hard top. Prepending
+      // then preserving scrollTop is seamless only if there is runway left for
+      // the user's continued upward wheel/touch movement.
+      const olderPrefetchPx=Math.max(600,el.clientHeight*1.5);
+      if(_isSessionEndlessScrollEnabled()&&el.scrollTop<olderPrefetchPx && typeof _messagesTruncated!=='undefined' && _messagesTruncated && typeof _loadOlderMessages==='function'){
         _loadOlderMessages();
       }
     });

--- a/tests/test_older_history_viewport_preservation.py
+++ b/tests/test_older_history_viewport_preservation.py
@@ -1,0 +1,55 @@
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+SESSIONS_JS = (REPO / "static" / "sessions.js").read_text(encoding="utf-8")
+
+
+def _function_body(src: str, signature: str) -> str:
+    start = src.index(signature)
+    brace = src.index("{", start)
+    depth = 0
+    for i in range(brace, len(src)):
+        if src[i] == "{":
+            depth += 1
+        elif src[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return src[start : i + 1]
+    raise AssertionError(f"function body not found: {signature}")
+
+
+def test_loading_older_messages_expands_render_window_before_rendering():
+    body = _function_body(SESSIONS_JS, "async function _loadOlderMessages")
+
+    prepend_idx = body.index("S.messages = [...olderMsgs, ...S.messages]")
+    expand_idx = body.index("_messageRenderWindowSize=_currentMessageRenderWindowSize()")
+    render_idx = body.index("renderMessages({ preserveScroll: true });")
+
+    assert prepend_idx < expand_idx < render_idx, (
+        "scroll-to-top paging must expand the DOM render window before renderMessages(); "
+        "otherwise fetched older messages stay hidden and only the hidden counter changes"
+    )
+    assert "Math.max(addedRenderable, MESSAGE_RENDER_WINDOW_DEFAULT)" in body
+
+
+def test_loading_older_messages_preserves_viewport_without_bottom_snap():
+    body = _function_body(SESSIONS_JS, "async function _loadOlderMessages")
+
+    assert "renderMessages({ preserveScroll: true });" in body
+    assert "const oldTop = container.scrollTop" in body
+    assert "const addedHeight = Math.max(0, newScrollH - prevScrollH)" in body
+    assert "container.scrollTop = oldTop + addedHeight" in body
+    assert "container.scrollTop = newScrollH - prevScrollH" not in body
+
+    restore_idx = body.index("container.scrollTop = oldTop + addedHeight")
+    unpin_idx = body.rindex("_scrollPinned = false")
+    assert restore_idx < unpin_idx
+
+
+def test_loading_older_messages_marks_scroll_programmatic_while_anchoring():
+    body = _function_body(SESSIONS_JS, "async function _loadOlderMessages")
+
+    set_idx = body.index("_programmaticScroll = true;")
+    restore_idx = body.index("container.scrollTop = oldTop + addedHeight")
+    clear_idx = body.index("requestAnimationFrame(()=>{ _programmaticScroll = false; })")
+    assert set_idx < restore_idx < clear_idx

--- a/tests/test_parallel_session_switch.py
+++ b/tests/test_parallel_session_switch.py
@@ -589,7 +589,7 @@ class TestScrollPositionPreservation:
         )
 
     def test_resets_scroll_pinned_after_restore(self):
-        """_scrollPinned must be set to false after restoring scroll position."""
+        """_scrollPinned must be false after older-history scroll anchoring."""
         SESSIONS_JS = pathlib.Path(__file__).parent.parent / "static" / "sessions.js"
         src = SESSIONS_JS.read_text(encoding="utf-8")
 
@@ -598,13 +598,12 @@ class TestScrollPositionPreservation:
         fn_body = src[fn_start:fn_end]
 
         assert "_scrollPinned = false" in fn_body, (
-            "renderMessages() calls scrollToBottom() which sets _scrollPinned=true. "
-            "After restoring the user's scroll position we must set _scrollPinned=false "
-            "to prevent the next render from snapping back to the bottom."
+            "Older-history paging must leave the transcript unpinned so the next "
+            "render does not snap back to the newest output."
         )
-        # _scrollPinned must appear after the scrollTop restore
-        restore_idx = fn_body.find("container.scrollTop = newScrollH - prevScrollH")
-        pinned_idx = fn_body.find("_scrollPinned = false")
-        assert restore_idx >= 0 and pinned_idx >= 0 and restore_idx < pinned_idx, (
-            "_scrollPinned = false must appear AFTER the scrollTop restore."
+        target_idx = fn_body.find("container.scrollTop = oldTop + addedHeight")
+        scroll_idx = fn_body.find("requestAnimationFrame(()=>{ _programmaticScroll = false; })")
+        pinned_idx = fn_body.rfind("_scrollPinned = false")
+        assert target_idx >= 0 and scroll_idx >= 0 and pinned_idx >= 0 and target_idx < scroll_idx < pinned_idx, (
+            "_scrollPinned = false must appear AFTER the older-history viewport-preserve scroll."
         )

--- a/tests/test_parallel_session_switch.py
+++ b/tests/test_parallel_session_switch.py
@@ -427,10 +427,11 @@ class TestMessagePaginationFrontend:
         assert "async function _ensureAllMessagesLoaded" in SESSIONS_JS
 
     def test_scroll_to_top_triggers_loading(self):
-        """Scroll event handler must trigger _loadOlderMessages near top."""
+        """Scroll event handler must trigger _loadOlderMessages near top when opt-in is enabled."""
         UI_JS = (REPO / "static" / "ui.js").read_text(encoding="utf-8")
 
-        assert "el.scrollTop<80" in UI_JS
+        assert "const olderPrefetchPx=Math.max(600,el.clientHeight*1.5)" in UI_JS
+        assert "_isSessionEndlessScrollEnabled()&&el.scrollTop<olderPrefetchPx" in UI_JS
         assert "_loadOlderMessages" in UI_JS
 
     def test_load_older_indicator_in_render(self):

--- a/tests/test_session_endless_scroll.py
+++ b/tests/test_session_endless_scroll.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CONFIG_PY = (ROOT / "api" / "config.py").read_text(encoding="utf-8")
+BOOT_JS = (ROOT / "static" / "boot.js").read_text(encoding="utf-8")
+INDEX_HTML = (ROOT / "static" / "index.html").read_text(encoding="utf-8")
+PANELS_JS = (ROOT / "static" / "panels.js").read_text(encoding="utf-8")
+UI_JS = (ROOT / "static" / "ui.js").read_text(encoding="utf-8")
+I18N_JS = (ROOT / "static" / "i18n.js").read_text(encoding="utf-8")
+
+
+def test_endless_scroll_is_opt_in_setting():
+    assert '"session_endless_scroll": False' in CONFIG_PY
+    assert '"session_endless_scroll"' in CONFIG_PY
+    assert 'id="settingsSessionEndlessScroll"' in INDEX_HTML
+    assert 'data-i18n="settings_label_session_endless_scroll"' in INDEX_HTML
+    assert 'data-i18n="settings_desc_session_endless_scroll"' in INDEX_HTML
+    assert "session_endless_scroll: !!($('settingsSessionEndlessScroll')||{}).checked" in PANELS_JS
+    assert "window._sessionEndlessScrollEnabled=!!s.session_endless_scroll" in BOOT_JS
+    assert "window._sessionEndlessScrollEnabled=false" in BOOT_JS
+
+
+def test_scroll_listener_prefetches_older_messages_only_when_enabled():
+    assert "function _isSessionEndlessScrollEnabled" in UI_JS
+    assert "const olderPrefetchPx=Math.max(600,el.clientHeight*1.5)" in UI_JS
+    assert "_isSessionEndlessScrollEnabled()&&el.scrollTop<olderPrefetchPx" in UI_JS
+    assert "el.scrollTop<80 && typeof _messagesTruncated" not in UI_JS
+
+
+def test_endless_scroll_i18n_keys_exist_for_each_locale():
+    assert I18N_JS.count("settings_label_session_endless_scroll") == I18N_JS.count("settings_label_workspace_panel_open")
+    assert I18N_JS.count("settings_desc_session_endless_scroll") == I18N_JS.count("settings_desc_workspace_panel_open")


### PR DESCRIPTION
## Summary
- Adds an opt-in `session_endless_scroll` setting for automatically loading older transcript pages while scrolling upward
- Prefetches before the hard top of the transcript so prepended pages have scroll runway
- Keeps the manual older-messages button path as the default behavior when the setting is disabled

## Stack / related PRs
- Builds on #1927 (`fix: preserve viewport when loading older messages`); that viewport preservation is what makes automatic prepending usable instead of jumpy
- Complements #1928 (`feat: add opt-in session jump buttons`) for long-session navigation, but does not depend on that UI slice

## Test plan
- `git diff --check`
- `python3 -m py_compile api/config.py`
- `node --check static/boot.js`
- `node --check static/panels.js`
- `node --check static/ui.js`
- `node --check static/i18n.js`
- `pytest -q tests/test_session_endless_scroll.py tests/test_older_history_viewport_preservation.py tests/test_parallel_session_switch.py tests/test_streaming_sidebar_scroll.py`
- `LC_ALL=C.UTF-8 LANG=C.UTF-8 pytest -q`
