### PR TITLE
Fix session jump history load race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Hermes Web UI -- Changelog
 
+## Unreleased
+
+### Fixed
+
+- **Session jump/endless-scroll race** — the opt-in Start jump now serializes
+  its full-history load with in-flight endless-scroll prefetches before either
+  path rewrites `S.messages`, preventing duplicate transcript pages when both
+  features are enabled and the user jumps while a prefetch is still resolving.
+  (`static/sessions.js`, `tests/test_session_endless_scroll.py`) Closes #1937.
+
 ## [v0.51.30] — 2026-05-08 — 3-PR contributor batch (Release G: offline recovery + PWA hardening + opt-in session jump buttons + opt-in endless-scroll)
 
 ### Added (3 PRs, all from @ai-ag2026)

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -991,14 +991,29 @@ async function _ensureMessagesLoaded(sid) {
   }
 }
 
-// Load older messages when the user scrolls to the top of the conversation.
-// Prepends them to S.messages and re-renders, preserving scroll position.
+// Shared lock for history fetches that rewrite S.messages. Endless-scroll
+// prefetch and full-history loads must not race each other.
 let _loadingOlder = false;
 // _oldestIdx tracks the index (in the server's full message array) of the
 // oldest message currently loaded in S.messages. Starts at 0 when all
 // messages are loaded, or > 0 when truncated by msg_limit.
 let _oldestIdx = 0;
 
+function _waitForHistoryLoadIdle(sid) {
+  return new Promise(resolve => {
+    const tick = () => {
+      if (!_loadingOlder || !S.session || S.session.session_id !== sid) {
+        resolve();
+        return;
+      }
+      setTimeout(tick, 50);
+    };
+    tick();
+  });
+}
+
+// Load older messages when the user scrolls to the top of the conversation.
+// Prepends them to S.messages and re-renders, preserving scroll position.
 async function _loadOlderMessages() {
   if (_loadingOlder || !_messagesTruncated) return;
   const sid = S.session ? S.session.session_id : null;
@@ -1066,14 +1081,24 @@ async function _loadOlderMessages() {
 async function _ensureAllMessagesLoaded() {
   if (!_messagesTruncated || !S.session) return;
   const sid = S.session.session_id;
-  const data = await api(`/api/session?session_id=${encodeURIComponent(sid)}&messages=1&resolve_model=0`);
-  // Guard: api() may have redirected (401) and returned undefined.
-  if (!data || !data.session) return;
-  const msgs = (data.session.messages || []).filter(m => m && m.role);
-  S.messages = msgs;
-  _messagesTruncated = false;
-  if(S.session && S.session.session_id === sid){
-    S.session.message_count = Number(data.session.message_count || msgs.length);
+  if (_loadingOlder) await _waitForHistoryLoadIdle(sid);
+  if (!_messagesTruncated || !S.session || S.session.session_id !== sid) return;
+  _loadingOlder = true;
+  try {
+    const data = await api(`/api/session?session_id=${encodeURIComponent(sid)}&messages=1&resolve_model=0`);
+    // Guard: api() may have redirected (401) and returned undefined.
+    if (!data || !data.session) return;
+    if (!S.session || S.session.session_id !== sid) return;
+    if (_loadingSessionId !== null && _loadingSessionId !== sid) return;
+    const msgs = (data.session.messages || []).filter(m => m && m.role);
+    S.messages = msgs;
+    _messagesTruncated = false;
+    _oldestIdx = data.session._messages_offset || 0;
+    if(S.session && S.session.session_id === sid){
+      S.session.message_count = Number(data.session.message_count || msgs.length);
+    }
+  } finally {
+    _loadingOlder = false;
   }
 }
 

--- a/tests/test_session_endless_scroll.py
+++ b/tests/test_session_endless_scroll.py
@@ -5,8 +5,23 @@ CONFIG_PY = (ROOT / "api" / "config.py").read_text(encoding="utf-8")
 BOOT_JS = (ROOT / "static" / "boot.js").read_text(encoding="utf-8")
 INDEX_HTML = (ROOT / "static" / "index.html").read_text(encoding="utf-8")
 PANELS_JS = (ROOT / "static" / "panels.js").read_text(encoding="utf-8")
+SESSIONS_JS = (ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
 UI_JS = (ROOT / "static" / "ui.js").read_text(encoding="utf-8")
 I18N_JS = (ROOT / "static" / "i18n.js").read_text(encoding="utf-8")
+
+
+def _function_body(src: str, signature: str) -> str:
+    start = src.index(signature)
+    brace = src.index("{", start)
+    depth = 0
+    for i in range(brace, len(src)):
+        if src[i] == "{":
+            depth += 1
+        elif src[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return src[start : i + 1]
+    raise AssertionError(f"function body not found: {signature}")
 
 
 def test_endless_scroll_is_opt_in_setting():
@@ -30,3 +45,22 @@ def test_scroll_listener_prefetches_older_messages_only_when_enabled():
 def test_endless_scroll_i18n_keys_exist_for_each_locale():
     assert I18N_JS.count("settings_label_session_endless_scroll") == I18N_JS.count("settings_label_workspace_panel_open")
     assert I18N_JS.count("settings_desc_session_endless_scroll") == I18N_JS.count("settings_desc_workspace_panel_open")
+
+
+def test_full_history_load_serializes_with_endless_scroll_prefetch():
+    load_older = _function_body(SESSIONS_JS, "async function _loadOlderMessages")
+    load_all = _function_body(SESSIONS_JS, "async function _ensureAllMessagesLoaded")
+
+    assert "function _waitForHistoryLoadIdle" in SESSIONS_JS
+    assert "if (_loadingOlder || !_messagesTruncated) return;" in load_older
+    assert "if (_loadingOlder) await _waitForHistoryLoadIdle(sid);" in load_all
+
+    lock_idx = load_all.find("_loadingOlder = true")
+    fetch_idx = load_all.find("api(`/api/session?session_id=${encodeURIComponent(sid)}&messages=1&resolve_model=0`")
+    mutate_idx = load_all.find("S.messages = msgs")
+    unlock_idx = load_all.rfind("_loadingOlder = false")
+
+    assert lock_idx != -1 and fetch_idx != -1 and mutate_idx != -1 and unlock_idx != -1
+    assert lock_idx < fetch_idx < mutate_idx < unlock_idx
+    assert "finally" in load_all
+    assert "S.session.session_id !== sid" in load_all


### PR DESCRIPTION
## Thinking Path

Issue #1937 identified a narrow race introduced by the v0.51.30 opt-in session navigation features: endless-scroll can be loading an older transcript page while the Start jump calls `_ensureAllMessagesLoaded()`. Both paths rewrite `S.messages`, so a late prefetch response can prepend a duplicate page after the full-history load has already landed.

The fix belongs in `static/sessions.js`, where both history-loading paths already share `_loadingOlder` state.

## What Changed

- Treat `_loadingOlder` as the shared lock for history fetches that rewrite `S.messages`.
- Add `_waitForHistoryLoadIdle(sid)` so Start-jump full-history loading waits for any in-flight endless-scroll prefetch for the same session.
- Have `_ensureAllMessagesLoaded()` claim the lock before its full-history fetch, so a new endless-scroll prefetch cannot start until the full load finishes.
- Add session-id guards before applying the full-history response.
- Add regression coverage that locks the wait -> lock -> fetch -> mutate -> unlock order.

## Why It Matters

When both `session_jump_buttons` and `session_endless_scroll` are enabled, users should be able to jump to the start of a long transcript without duplicating message pages if an older-page prefetch is still resolving.

## Verification

- `.venv_test/bin/python -m pytest -q tests/test_session_endless_scroll.py tests/test_session_jump_buttons.py tests/test_parallel_session_switch.py::TestSessionSwitchCancellation tests/test_parallel_session_switch.py::TestScrollPositionPreservation`
- `node --check static/sessions.js`
- `git diff --check`

## Risks

Low. The change is limited to existing session-history fetch paths and keeps the old early-return behavior when no truncated history exists. If a session changes while a load is in flight, the existing session-id guards prevent stale responses from mutating the active transcript.

Closes #1937.

## Model Used

GPT-5.5 via Codex CLI.
