### PR TITLE
Gate goal continuation turns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Hermes Web UI -- Changelog
 
+## Unreleased
+
+### Fixed
+
+- **Goal continuation turn gating** — only run the `/goal` progress judge and
+  budget counter after goal-owned turns (`/goal` kickoff or queued continuation
+  prompts), so unrelated user messages in a session with an active goal no
+  longer spend goal budget or trigger continuation toasts. (`api/goals.py`,
+  `api/routes.py`, `api/streaming.py`, `static/messages.js`, `static/ui.js`,
+  `tests/test_goal_command_webui.py`) Closes #1932.
+
 ## [v0.51.30] — 2026-05-08 — 3-PR contributor batch (Release G: offline recovery + PWA hardening + opt-in session jump buttons + opt-in endless-scroll)
 
 ### Added (3 PRs, all from @ai-ag2026)

--- a/api/goals.py
+++ b/api/goals.py
@@ -437,6 +437,7 @@ def evaluate_goal_after_turn(
     last_response: str,
     *,
     user_initiated: bool = True,
+    goal_related: bool = True,
     profile_home: str | Path | None = None,
 ) -> Dict[str, Any]:
     """Evaluate a completed turn against the standing goal, if any."""
@@ -468,6 +469,15 @@ def evaluate_goal_after_turn(
                 "continuation_prompt": None,
                 "verdict": "inactive",
                 "reason": "no active goal",
+                "message": "",
+            }
+        if not goal_related:
+            return {
+                "status": getattr(getattr(mgr, "state", None), "status", None),
+                "should_continue": False,
+                "continuation_prompt": None,
+                "verdict": "skipped",
+                "reason": "turn not marked goal-related",
                 "message": "",
             }
         decision = mgr.evaluate_after_turn(str(last_response or ""), user_initiated=user_initiated)

--- a/api/routes.py
+++ b/api/routes.py
@@ -6451,6 +6451,7 @@ def _start_chat_stream_for_session(
     model_provider=None,
     normalized_model: bool = False,
     diag=None,
+    goal_related: bool = False,
 ):
     """Persist pending state, register an SSE channel, and start an agent turn."""
     attachments = attachments or []
@@ -6497,7 +6498,7 @@ def _start_chat_stream_for_session(
     thr = threading.Thread(
         target=_run_agent_streaming,
         args=(s.session_id, msg, model, workspace, stream_id, attachments),
-        kwargs={"model_provider": model_provider},
+        kwargs={"model_provider": model_provider, "goal_related": bool(goal_related)},
         daemon=True,
     )
     thr.start()
@@ -6621,6 +6622,7 @@ def _handle_goal_command(handler, body):
             model=model,
             model_provider=model_provider,
             normalized_model=normalized_model,
+            goal_related=True,
         )
         status = int(stream_response.pop("_status", 200) or 200)
         payload.update(stream_response)
@@ -6688,6 +6690,7 @@ def _handle_chat_start(handler, body, diag=None):
             requested_model,
             requested_provider,
         )
+        goal_related = body.get("goal_related") is True
         response = _start_chat_stream_for_session(
             s,
             msg=msg,
@@ -6697,6 +6700,7 @@ def _handle_chat_start(handler, body, diag=None):
             model_provider=model_provider,
             normalized_model=normalized_model,
             diag=diag,
+            goal_related=goal_related,
         )
         status = int(response.pop("_status", 200) or 200)
         diag.stage("response_write") if diag else None

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -1857,6 +1857,7 @@ def _run_agent_streaming(
     *,
     ephemeral=False,
     model_provider=None,
+    goal_related=False,
 ):
     """Run agent in background thread, writing SSE events to STREAMS[stream_id].
 
@@ -3234,7 +3235,8 @@ def _run_agent_streaming(
             try:
                 from api.goals import evaluate_goal_after_turn, has_active_goal
 
-                if not has_active_goal(session_id, profile_home=_profile_home):
+                _goal_related = bool(goal_related)
+                if not _goal_related or not has_active_goal(session_id, profile_home=_profile_home):
                     _goal_decision = {}
                 else:
                     _last_goal_response = ''
@@ -3262,6 +3264,7 @@ def _run_agent_streaming(
                         session_id,
                         _last_goal_response,
                         user_initiated=True,
+                        goal_related=True,
                         profile_home=_profile_home,
                     )
                 decision = _goal_decision or {}

--- a/static/messages.js
+++ b/static/messages.js
@@ -1075,6 +1075,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
           model:_goalNext.model,
           model_provider:_goalNext.model_provider,
           profile:_goalNext.profile,
+          goal_related:true,
         });
         if(typeof updateQueueBadge==='function')updateQueueBadge(_goalNext.sid);
       }

--- a/static/messages.js
+++ b/static/messages.js
@@ -170,6 +170,8 @@ async function send(){
   }
   if(!S.session){await newSession();await renderSessionList();}
 
+  const goalRelated=send.goal_related===true;
+  send.goal_related=false;
   const activeSid=S.session.session_id;
 
   setComposerStatus(S.pendingFiles&&S.pendingFiles.length?'Uploading…':'');
@@ -239,7 +241,8 @@ async function send(){
       model:S.session.model||$('modelSelect').value,workspace:S.session.workspace,
       model_provider:S.session.model_provider||null,
       profile:S.activeProfile||S.session.profile||'default',
-      attachments:uploaded.length?uploaded:undefined
+      attachments:uploaded.length?uploaded:undefined,
+      goal_related:goalRelated||undefined
     })});
     if(startData.effective_model && S.session){
       S.session.model=startData.effective_model;
@@ -286,7 +289,7 @@ async function send(){
       stopApprovalPolling();
       stopClarifyPolling();
       // Keep the user's attempted turn by queueing it for after the current run.
-      queueSessionMessage(activeSid,{text:msgText,files:[],model:S.session&&S.session.model||($('modelSelect')&&$('modelSelect').value)||'',model_provider:S.session&&S.session.model_provider||null,profile:S.activeProfile||'default'});
+      queueSessionMessage(activeSid,{text:msgText,files:[],model:S.session&&S.session.model||($('modelSelect')&&$('modelSelect').value)||'',model_provider:S.session&&S.session.model_provider||null,profile:S.activeProfile||'default',goal_related:goalRelated||undefined});
       updateQueueBadge(activeSid);
       showToast('Current session is still running. Reconnected and queued your message.',2600);
       try{
@@ -924,6 +927,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
           model:S.session&&S.session.model||'',
           model_provider:S.session&&S.session.model_provider||null,
           profile:S.activeProfile||'default',
+          goal_related:true,
         };
         showToast('Continuing toward goal…',2200);
       }catch(_){}

--- a/static/ui.js
+++ b/static/ui.js
@@ -2899,6 +2899,7 @@ function setBusy(v){
         }
         autoResize();
         renderTray();
+        send.goal_related=next.goal_related===true;
         send();
       },120);
     }

--- a/tests/test_goal_command_webui.py
+++ b/tests/test_goal_command_webui.py
@@ -309,6 +309,17 @@ def test_frontend_has_goal_slash_command_and_status_event_handler():
     assert "send.goal_related=next.goal_related===true" in UI_JS
 
 
+def test_frontend_queued_goal_continuation_preserves_goal_related_marker():
+    stash_idx = MESSAGES_JS.find("const _goalNext=_pendingGoalContinuation;")
+    assert stash_idx != -1
+    queue_idx = MESSAGES_JS.find("queueSessionMessage(_goalNext.sid,{", stash_idx)
+    assert queue_idx != -1
+    badge_idx = MESSAGES_JS.find("updateQueueBadge(_goalNext.sid)", queue_idx)
+    assert badge_idx != -1
+    queued_payload = MESSAGES_JS[queue_idx:badge_idx]
+    assert "goal_related:true" in queued_payload
+
+
 def test_frontend_goal_evaluating_state_uses_calm_composer_indicator():
     assert "const goalState=String(d.state||'').trim();" in MESSAGES_JS
     assert "const goalEvaluatingMessage='Evaluating goal progress…';" in MESSAGES_JS

--- a/tests/test_goal_command_webui.py
+++ b/tests/test_goal_command_webui.py
@@ -12,6 +12,7 @@ COMMANDS_JS = (REPO_ROOT / "static" / "commands.js").read_text(encoding="utf-8")
 MESSAGES_JS = (REPO_ROOT / "static" / "messages.js").read_text(encoding="utf-8")
 ROUTES_PY = (REPO_ROOT / "api" / "routes.py").read_text(encoding="utf-8")
 STREAMING_PY = (REPO_ROOT / "api" / "streaming.py").read_text(encoding="utf-8")
+UI_JS = (REPO_ROOT / "static" / "ui.js").read_text(encoding="utf-8")
 
 
 def test_goal_command_payload_matches_gateway_controls(monkeypatch):
@@ -143,11 +144,49 @@ def test_goal_continuation_decision_emits_status_and_normal_user_prompt(monkeypa
     monkeypatch.setattr(webui_goals, "GoalManager", FakeGoalManager)
     monkeypatch.setattr(webui_goals, "_default_max_turns", lambda: 20)
 
-    decision = webui_goals.evaluate_goal_after_turn("sid-123", "not done yet", user_initiated=False)
+    decision = webui_goals.evaluate_goal_after_turn("sid-123", "not done yet", goal_related=True)
 
     assert decision["message"].startswith("↻ Continuing toward goal")
     assert decision["should_continue"] is True
     assert decision["continuation_prompt"].startswith("[Continuing toward your standing goal]")
+
+
+def test_goal_evaluation_skips_unrelated_user_turns_without_budget_tick(monkeypatch):
+    """Active goals should not judge or spend budget on turns not marked goal-related."""
+    from api import goals as webui_goals
+
+    calls = []
+
+    class FakeState:
+        status = "active"
+
+    class FakeGoalManager:
+        state = FakeState()
+
+        def __init__(self, session_id, default_max_turns=20):
+            self.session_id = session_id
+
+        def is_active(self):
+            return True
+
+        def evaluate_after_turn(self, last_response, user_initiated=True):
+            calls.append((last_response, user_initiated))
+            raise AssertionError("unrelated turns must not reach the goal judge")
+
+    monkeypatch.setattr(webui_goals, "GoalManager", FakeGoalManager)
+    monkeypatch.setattr(webui_goals, "_default_max_turns", lambda: 20)
+
+    decision = webui_goals.evaluate_goal_after_turn(
+        "sid-123",
+        "Here is the weather.",
+        goal_related=False,
+    )
+
+    assert calls == []
+    assert decision["should_continue"] is False
+    assert decision["verdict"] == "skipped"
+    assert decision["reason"] == "turn not marked goal-related"
+    assert decision["message"] == ""
 
 
 def test_goal_endpoint_sets_goal_and_starts_kickoff_stream(monkeypatch, tmp_path):
@@ -218,6 +257,7 @@ def test_goal_endpoint_sets_goal_and_starts_kickoff_stream(monkeypatch, tmp_path
     assert result["payload"]["stream_id"] == "goal-stream"
     assert started and started[0]["msg"] == "ship the feature"
     assert started[0]["model_provider"] == "openai-codex"
+    assert started[0]["goal_related"] is True
 
 
 def test_routes_register_goal_endpoint_and_kickoff_stream():
@@ -230,6 +270,8 @@ def test_routes_register_goal_endpoint_and_kickoff_stream():
 
 def test_streaming_post_turn_goal_hook_surfaces_and_continues():
     assert "evaluate_goal_after_turn" in STREAMING_PY
+    assert "goal_related=False" in STREAMING_PY
+    assert "if not _goal_related or not has_active_goal" in STREAMING_PY
     assert "put('goal'" in STREAMING_PY
     assert "decision.get('should_continue')" in STREAMING_PY
     assert "continuation_prompt" in STREAMING_PY
@@ -262,6 +304,9 @@ def test_frontend_has_goal_slash_command_and_status_event_handler():
     assert "source.addEventListener('goal_continue'" in MESSAGES_JS
     assert "['steer','interrupt','queue','terminal','goal'].includes(_pc.name)" in MESSAGES_JS
     assert "queueSessionMessage" in MESSAGES_JS
+    assert "goal_related:true" in MESSAGES_JS
+    assert "goal_related:goalRelated||undefined" in MESSAGES_JS
+    assert "send.goal_related=next.goal_related===true" in UI_JS
 
 
 def test_frontend_goal_evaluating_state_uses_calm_composer_indicator():


### PR DESCRIPTION
## Thinking Path

Issue #1932 is a focused follow-up to the WebUI `/goal` command. The bug is not that goal evaluation exists, but that every completed assistant turn in a session with an active goal was treated as goal progress, including unrelated user messages.

The narrow fix is to mark only goal-owned turns as goal-related: the initial `/goal <text>` kickoff and the queued continuation prompts emitted by `goal_continue`. Normal user messages keep working as normal chat turns, but they no longer spend goal budget or trigger continuation toasts just because a goal is active.

## What Changed

- Added a `goal_related` flag through `/api/chat/start` and the streaming worker.
- Passed `goal_related=true` for `/goal` kickoff streams.
- Preserved `goal_related=true` when the frontend queues and drains a `goal_continue` continuation prompt.
- Skipped `evaluate_goal_after_turn()` entirely for active-goal turns that are not marked goal-related.
- Added regression coverage so unrelated turns do not reach the goal judge or spend budget.
- Added an Unreleased changelog note.

## Verification

- `.venv_test/bin/python -m pytest -q tests/test_goal_command_webui.py tests/test_sprint3.py tests/test_regressions.py tests/test_1062_busy_input_modes.py tests/test_cmd_idle_fallback.py tests/test_issue660.py tests/test_real_steer.py`
  - `152 passed, 11 skipped`
- `node --check static/messages.js`
- `node --check static/ui.js`
- `.venv_test/bin/python -m py_compile api/goals.py api/routes.py api/streaming.py`
- `git diff --check`

Closes #1932.

## Model Used

GPT-5.5 via Codex CLI.