### PR TITLE
fix: show same model from different custom providers instead of deduplicating

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -2949,7 +2949,7 @@ def get_available_models() -> dict:
         _custom_providers_cfg = cfg.get("custom_providers", [])
         _named_custom_groups: dict = {}
         if isinstance(_custom_providers_cfg, list):
-            _seen_custom_ids = {m["id"] for m in auto_detected_models}
+            _seen_custom_ids = set()
             for _cp in _custom_providers_cfg:
                 if not isinstance(_cp, dict):
                     continue
@@ -2970,9 +2970,10 @@ def get_available_models() -> dict:
                             _cp_model_ids.append(_m_id.strip())
 
                 for _cp_model in _cp_model_ids:
-                    if _cp_model and _cp_model not in _seen_custom_ids:
+                    _dedup_key = f"{_slug}:{_cp_model}" if _slug else _cp_model
+                    if _cp_model and _dedup_key not in _seen_custom_ids:
                         _cp_label = _get_label_for_model(_cp_model, [])
-                        _seen_custom_ids.add(_cp_model)
+                        _seen_custom_ids.add(_dedup_key)
                         if _slug:
                             detected_providers.add(_slug)
                             _cp_option_id = _cp_model


### PR DESCRIPTION
## Problem

When multiple custom providers expose the same model ID (e.g. `baidu`, `huoshan`, and `liantong` all offering `glm-5.1`), only the first provider's entry appears in the model dropdown. The others are silently dropped.

## Root Cause

**Backend** (`api/config.py`): `_seen_custom_ids` is initialized with bare model IDs from `auto_detected_models` and used as a global dedup set when iterating `custom_providers`. Since the dedup key is the bare model ID (e.g. `glm-5.1`), the second and subsequent providers offering the same model are skipped.

```python
# Before: cross-provider dedup on bare model ID
_seen_custom_ids = {m["id"] for m in auto_detected_models}
...
if _cp_model and _cp_model not in _seen_custom_ids:  # baidu glm-5.1 blocks huoshan glm-5.1
```

**Frontend** (`static/ui.js`): `_normId()` strips the `@provider:` prefix and normalizes separators, so `@custom:baidu:glm-5.1` and `@custom:huoshan:glm-5.1` both normalize to `glm.5.1` and are treated as duplicates.

```javascript
// Before: dedup on normalized ID only
if(existingNorm.has(_normId(mid))) continue; // drops same model from different providers
```

## Fix

**Backend**: Change the `_seen_custom_ids` dedup key to `{slug}:{model_id}` so each provider's models are tracked independently.

```python
# After: per-provider dedup
_seen_custom_ids = set()
...
_dedup_key = f"{_slug}:{_cp_model}" if _slug else _cp_model
if _cp_model and _dedup_key not in _seen_custom_ids:
    _seen_custom_ids.add(_dedup_key)
```

**Frontend**: Add `_providerOf()` helper and deduplicate on the composite `(normId, provider)` key. Bare model IDs without `@provider:` prefix still deduplicate on `normId` alone for backward compatibility.

```javascript
// After: dedup on (normId, provider) composite key
const _providerOf=id=>{const m=String(id||"").match(/^@([^:]+):/);return m?m[1].toLowerCase():"";};
const existingNormProvider=new Set([...sel.options].map(o=>`${_normId(o.value)}|${_providerOf(o.value)}`));
...
const normKey=`${_normId(mid)}|${_providerOf(mid)}`;
if(existingNormProvider.has(normKey)) continue;        // same provider+model
if(existingNorm.has(_normId(mid)) && !_providerOf(mid)) continue; // bare IDs only
```

## Testing

Verified with a config containing 5 custom providers, where `glm-5.1` appears under `baidu`, `huoshan`, and `liantong`. After the fix, all three entries appear in the dropdown with their `@custom:provider:` prefix.

`GET /api/models` now returns:
```
custom:baidu:   ["@custom:baidu:glm-5", "@custom:baidu:glm-5.1"]
custom:huoshan: ["@custom:huoshan:glm-5.1"]
custom:liantong: ["glm-5", "glm-5.1"]   # active provider, no prefix needed
```