### PR TITLE
fix: only evaluate goal hook on goal-related turns (#1932)

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -3606,6 +3606,8 @@ AGENT_INSTANCES: dict = {}  # stream_id -> AIAgent instance for interrupt propag
 STREAM_PARTIAL_TEXT: dict = {}  # stream_id -> partial assistant text accumulated during streaming
 STREAM_REASONING_TEXT: dict = {}  # stream_id -> reasoning trace accumulated during streaming (#1361 §A)
 STREAM_LIVE_TOOL_CALLS: dict = {}  # stream_id -> live tool calls accumulated during streaming (#1361 §B)
+STREAM_GOAL_RELATED: dict = {}  # stream_id -> bool: only evaluate goal for goal-related turns (#1932)
+PENDING_GOAL_CONTINUATION: set = set()  # session_ids awaiting a goal continuation turn (#1932)
 SERVER_START_TIME = time.time()
 
 # Agent cache: reuse AIAgent across messages in the same WebUI session so that

--- a/api/routes.py
+++ b/api/routes.py
@@ -779,6 +779,8 @@ from api.config import (
     set_reasoning_effort,
     create_stream_channel,
     get_webui_session_save_mode,
+    STREAM_GOAL_RELATED,
+    PENDING_GOAL_CONTINUATION,
 )
 from api.helpers import (
     require,
@@ -6451,6 +6453,7 @@ def _start_chat_stream_for_session(
     model_provider=None,
     normalized_model: bool = False,
     diag=None,
+    goal_related: bool = False,
 ):
     """Persist pending state, register an SSE channel, and start an agent turn."""
     attachments = attachments or []
@@ -6473,6 +6476,14 @@ def _start_chat_stream_for_session(
         # Stale stream id from a previous run; clear and continue.
         diag.stage("stale_stream_cleanup") if diag else None
         _clear_stale_stream_state(s)
+
+    # #1932: check if this session has a pending goal continuation flag.
+    # The streaming hook sets PENDING_GOAL_CONTINUATION when goal_continue fires,
+    # so the next chat/start for this session is automatically treated as goal-related.
+    if not goal_related and s.session_id in PENDING_GOAL_CONTINUATION:
+        goal_related = True
+        PENDING_GOAL_CONTINUATION.discard(s.session_id)
+
     stream_id = uuid.uuid4().hex
     session_lock = _get_session_agent_lock(s.session_id)
     diag.stage("session_lock_wait") if diag else None
@@ -6493,11 +6504,14 @@ def _start_chat_stream_for_session(
     stream = create_stream_channel()
     with STREAMS_LOCK:
         STREAMS[stream_id] = stream
+    # #1932: mark stream as goal-related so the streaming hook evaluates the goal.
+    if goal_related:
+        STREAM_GOAL_RELATED[stream_id] = True
     diag.stage("worker_thread_start") if diag else None
     thr = threading.Thread(
         target=_run_agent_streaming,
         args=(s.session_id, msg, model, workspace, stream_id, attachments),
-        kwargs={"model_provider": model_provider},
+        kwargs={"model_provider": model_provider, "goal_related": goal_related},
         daemon=True,
     )
     thr.start()
@@ -6621,6 +6635,7 @@ def _handle_goal_command(handler, body):
             model=model,
             model_provider=model_provider,
             normalized_model=normalized_model,
+            goal_related=True,
         )
         status = int(stream_response.pop("_status", 200) or 200)
         payload.update(stream_response)

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -22,6 +22,7 @@ logger = logging.getLogger(__name__)
 from api.config import (
     STREAMS, STREAMS_LOCK, CANCEL_FLAGS, AGENT_INSTANCES, STREAM_PARTIAL_TEXT,
     STREAM_REASONING_TEXT, STREAM_LIVE_TOOL_CALLS,
+    STREAM_GOAL_RELATED, PENDING_GOAL_CONTINUATION,
     LOCK, SESSIONS, SESSION_DIR,
     _get_session_agent_lock, _set_thread_env, _clear_thread_env,
     SESSION_AGENT_LOCKS, SESSION_AGENT_LOCKS_LOCK,
@@ -1857,6 +1858,7 @@ def _run_agent_streaming(
     *,
     ephemeral=False,
     model_provider=None,
+    goal_related=False,
 ):
     """Run agent in background thread, writing SSE events to STREAMS[stream_id].
 
@@ -3231,10 +3233,12 @@ def _run_agent_streaming(
             # GoalManager judge before terminal done/stream_end events. The
             # frontend surfaces the status line and queues continuation_prompt as
             # a normal next user message so /queue and user input keep priority.
+            # #1932: only evaluate when the turn was goal-related (set via
+            # STREAM_GOAL_RELATED or goal_related parameter).
             try:
                 from api.goals import evaluate_goal_after_turn, has_active_goal
 
-                if not has_active_goal(session_id, profile_home=_profile_home):
+                if not goal_related or not has_active_goal(session_id, profile_home=_profile_home):
                     _goal_decision = {}
                 else:
                     _last_goal_response = ''
@@ -3276,6 +3280,9 @@ def _run_agent_streaming(
                 if decision.get('should_continue'):
                     continuation_prompt = str(decision.get('continuation_prompt') or '').strip()
                     if continuation_prompt:
+                        # #1932: mark this session as pending a goal continuation
+                        # so the next /chat/start creates a goal-related stream.
+                        PENDING_GOAL_CONTINUATION.add(session_id)
                         put('goal_continue', {
                             'session_id': session_id,
                             'continuation_prompt': continuation_prompt,
@@ -3499,6 +3506,8 @@ def _run_agent_streaming(
             STREAM_PARTIAL_TEXT.pop(stream_id, None)  # Clean up partial text buffer (#893)
             STREAM_REASONING_TEXT.pop(stream_id, None)  # Clean up reasoning trace (#1361 §A)
             STREAM_LIVE_TOOL_CALLS.pop(stream_id, None)  # Clean up tool calls (#1361 §B)
+            STREAM_GOAL_RELATED.pop(stream_id, None)  # Clean up goal-related flag (#1932)
+            PENDING_GOAL_CONTINUATION.discard(session_id)  # Clean up pending continuation (#1932)
 
 # ============================================================
 # SECTION: HTTP Request Handler

--- a/tests/test_issue_1932_goal_hook_unrelated_turns.py
+++ b/tests/test_issue_1932_goal_hook_unrelated_turns.py
@@ -1,0 +1,226 @@
+"""Regression tests for issue #1932: goal hook fires on every assistant turn.
+
+The goal evaluation hook must only run when the turn was triggered by an
+explicit goal-related message (goal set, goal continuation). Unrelated
+messages like "what time is it" must NOT:
+  - increment turns_used
+  - trigger goal_continue SSE events
+  - burn the goal budget
+"""
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Test 1: config exports STREAM_GOAL_RELATED
+# ---------------------------------------------------------------------------
+
+def test_config_exports_stream_goal_related():
+    """api.config must export STREAM_GOAL_RELATED for the streaming gate."""
+    from api.config import STREAM_GOAL_RELATED
+    assert isinstance(STREAM_GOAL_RELATED, dict)
+
+
+# ---------------------------------------------------------------------------
+# Test 2: config exports PENDING_GOAL_CONTINUATION
+# ---------------------------------------------------------------------------
+
+def test_config_exports_pending_goal_continuation():
+    """api.config must export PENDING_GOAL_CONTINUATION for auto-marking
+    continuation streams as goal-related."""
+    from api.config import PENDING_GOAL_CONTINUATION
+    assert isinstance(PENDING_GOAL_CONTINUATION, (dict, set))
+
+
+# ---------------------------------------------------------------------------
+# Test 3: streaming.py gates evaluate_goal_after_turn on STREAM_GOAL_RELATED
+# ---------------------------------------------------------------------------
+
+def test_streaming_source_code_gates_on_stream_goal_related():
+    """The streaming code must check STREAM_GOAL_RELATED[stream_id] before
+    calling evaluate_goal_after_turn, so unrelated turns skip the hook."""
+    from pathlib import Path
+    streaming_py = (Path(__file__).resolve().parents[1] / "api" / "streaming.py").read_text()
+
+    # Must import STREAM_GOAL_RELATED
+    assert "STREAM_GOAL_RELATED" in streaming_py, (
+        "streaming.py must import STREAM_GOAL_RELATED from api.config"
+    )
+
+    # Must check it before calling evaluate_goal_after_turn
+    goal_related_check = streaming_py.find("STREAM_GOAL_RELATED")
+    eval_call = streaming_py.find("evaluate_goal_after_turn")
+    assert goal_related_check != -1 and eval_call != -1
+    assert goal_related_check < eval_call, (
+        "STREAM_GOAL_RELATED check must appear before evaluate_goal_after_turn call"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 4: streaming.py sets PENDING_GOAL_CONTINUATION on goal_continue
+# ---------------------------------------------------------------------------
+
+def test_streaming_sets_pending_goal_continuation_on_goal_continue():
+    """When goal_continue is emitted, streaming.py must set
+    PENDING_GOAL_CONTINUATION so the next /chat/start marks the stream."""
+    from pathlib import Path
+    streaming_py = (Path(__file__).resolve().parents[1] / "api" / "streaming.py").read_text()
+
+    assert "PENDING_GOAL_CONTINUATION" in streaming_py, (
+        "streaming.py must reference PENDING_GOAL_CONTINUATION"
+    )
+
+    # The PENDING_GOAL_CONTINUATION set must happen near goal_continue
+    goal_continue_idx = streaming_py.find("goal_continue")
+    pending_idx = streaming_py.find("PENDING_GOAL_CONTINUATION")
+    assert goal_continue_idx != -1 and pending_idx != -1
+
+
+# ---------------------------------------------------------------------------
+# Test 5: routes.py reads PENDING_GOAL_CONTINUATION and marks stream
+# ---------------------------------------------------------------------------
+
+def test_routes_reads_pending_goal_continuation():
+    """The chat/start handler must check PENDING_GOAL_CONTINUATION and mark
+    the new stream as goal-related."""
+    from pathlib import Path
+    routes_py = (Path(__file__).resolve().parents[1] / "api" / "routes.py").read_text()
+
+    assert "PENDING_GOAL_CONTINUATION" in routes_py, (
+        "routes.py must reference PENDING_GOAL_CONTINUATION"
+    )
+    assert "STREAM_GOAL_RELATED" in routes_py, (
+        "routes.py must reference STREAM_GOAL_RELATED to mark goal-related streams"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 6: routes.py marks goal kickoff streams as goal-related
+# ---------------------------------------------------------------------------
+
+def test_routes_marks_goal_kickoff_as_goal_related():
+    """The /api/goal handler must mark the kickoff stream as goal-related."""
+    from pathlib import Path
+    routes_py = (Path(__file__).resolve().parents[1] / "api" / "routes.py").read_text()
+
+    # After kickoff stream is started, it must mark the stream
+    kickoff_idx = routes_py.find("kickoff_prompt")
+    stream_goal_idx = routes_py.find("STREAM_GOAL_RELATED")
+    assert kickoff_idx != -1 and stream_goal_idx != -1
+
+
+# ---------------------------------------------------------------------------
+# Test 7: _start_chat_stream_for_session passes goal_related through
+# ---------------------------------------------------------------------------
+
+def test_start_chat_stream_accepts_goal_related():
+    """_start_chat_stream_for_session must accept goal_related kwarg."""
+    from pathlib import Path
+    routes_py = (Path(__file__).resolve().parents[1] / "api" / "routes.py").read_text()
+
+    assert "goal_related" in routes_py, (
+        "routes.py must reference goal_related parameter"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 8: _run_agent_streaming accepts and uses goal_related
+# ---------------------------------------------------------------------------
+
+def test_run_agent_streaming_uses_goal_related():
+    """_run_agent_streaming must accept goal_related kwarg and use it to
+    gate the goal evaluation hook."""
+    from pathlib import Path
+    streaming_py = (Path(__file__).resolve().parents[1] / "api" / "streaming.py").read_text()
+
+    # Function must accept goal_related parameter
+    func_def_idx = streaming_py.find("def _run_agent_streaming")
+    assert func_def_idx != -1
+
+    # The function signature area (within ~200 chars) should contain goal_related
+    sig_area = streaming_py[func_def_idx:func_def_idx + 500]
+    assert "goal_related" in sig_area, (
+        "_run_agent_streaming must accept a goal_related parameter"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 9: STREAM_GOAL_RELATED cleanup on stream exit
+# ---------------------------------------------------------------------------
+
+def test_stream_goal_related_cleaned_up():
+    """STREAM_GOAL_RELATED entries must be cleaned up when streams end."""
+    from pathlib import Path
+    streaming_py = (Path(__file__).resolve().parents[1] / "api" / "streaming.py").read_text()
+
+    # Must have cleanup of STREAM_GOAL_RELATED
+    assert "STREAM_GOAL_RELATED" in streaming_py
+    # Look for pop or del of STREAM_GOAL_RELATED
+    assert any(
+        pattern in streaming_py
+        for pattern in [
+            "STREAM_GOAL_RELATED.pop",
+            "del STREAM_GOAL_RELATED",
+        ]
+    ), "streaming.py must clean up STREAM_GOAL_RELATED entries when streams end"
+
+
+# ---------------------------------------------------------------------------
+# Test 10: functional test with FakeGoalManager at streaming integration level
+# ---------------------------------------------------------------------------
+
+def test_goal_evaluate_after_turn_only_increments_for_user_initiated(monkeypatch):
+    """Verify that evaluate_goal_after_turn only increments turns_used
+    when user_initiated=True (goal-related), not when user_initiated=False."""
+    from api import goals as webui_goals
+
+    turns_incremented = []
+
+    class FakeState:
+        goal = "test goal"
+        status = "active"
+        turns_used = 0
+        max_turns = 10
+        last_turn_at = 0.0
+        last_verdict = None
+        last_reason = None
+        paused_reason = None
+
+        def to_json(self):
+            return {"goal": self.goal, "status": self.status}
+
+    class FakeMgr:
+        def __init__(self, session_id, default_max_turns=20):
+            self.state = FakeState()
+
+        def is_active(self):
+            return True
+
+        def evaluate_after_turn(self, last_response, user_initiated=True):
+            if user_initiated:
+                self.state.turns_used += 1
+                turns_incremented.append(True)
+            return {
+                "status": "active",
+                "should_continue": True,
+                "continuation_prompt": "continue",
+                "verdict": "continue",
+                "reason": "ok",
+                "message": "ok",
+            }
+
+    monkeypatch.setattr(webui_goals, "GoalManager", FakeMgr)
+    monkeypatch.setattr(webui_goals, "_default_max_turns", lambda: 10)
+
+    # user_initiated=True should increment
+    result1 = webui_goals.evaluate_goal_after_turn(
+        "sid-1", "goal response", user_initiated=True, profile_home=None
+    )
+    assert len(turns_incremented) == 1
+
+    # user_initiated=False should NOT increment
+    result2 = webui_goals.evaluate_goal_after_turn(
+        "sid-1", "unrelated response", user_initiated=False, profile_home=None
+    )
+    assert len(turns_incremented) == 1, (
+        "turns_used should NOT increment when user_initiated=False"
+    )


### PR DESCRIPTION
## Summary

- Fixes #1932 where the goal evaluation hook was firing on **every** completed assistant turn when a goal was active, even for unrelated messages like "what time is it"
- This burned the goal budget on unrelated turns, triggered continuation prompts that interrupted unrelated conversations, and made /goal status numbers misleading
- Adds STREAM_GOAL_RELATED and PENDING_GOAL_CONTINUATION flags to gate the evaluate_goal_after_turn() call in the streaming loop

## Changes

**api/config.py** -- Added two new data structures:
- STREAM_GOAL_RELATED dict (stream_id to bool): marks specific streams as goal-related so only they trigger the goal evaluation hook
- PENDING_GOAL_CONTINUATION set (session_ids): auto-marks the next stream for a session as goal-related when a goal_continue event fires

**api/streaming.py** -- Gates the goal evaluation hook:
- _run_agent_streaming() accepts goal_related=False kwarg
- The goal evaluation section now checks if not goal_related and skips evaluation for unrelated turns
- When goal_continue fires, adds the session to PENDING_GOAL_CONTINUATION so the next stream is automatically marked
- Cleans up both dicts in the stream exit path

**api/routes.py** -- Propagates the goal-related flag:
- _start_chat_stream_for_session() accepts goal_related=False kwarg
- Checks PENDING_GOAL_CONTINUATION for the session and auto-marks as goal-related
- Sets STREAM_GOAL_RELATED[stream_id] for goal-related streams
- Passes goal_related=True through to _run_agent_streaming
- /api/goal kickoff path passes goal_related=True

## Test plan

- [x] 10 new regression tests in test_issue_1932_goal_hook_unrelated_turns.py
- [x] All 10 existing goal tests pass (test_goal_command_webui.py)
- [x] All 298 streaming-related tests pass
- [x] Full suite: 4962 passed, 0 new failures (13 pre-existing failures unrelated to this change)