### PR TITLE
Add external memory approval queue UI

### DIFF
--- a/api/external_memory.py
+++ b/api/external_memory.py
@@ -1,0 +1,410 @@
+"""External memory approval-queue helpers for Hermes WebUI.
+
+This module is intentionally provider-oriented. Built-in or custom memory
+systems can appear in the WebUI by registering a small SQLite-backed review
+queue via ``external_memory_providers.json`` in the active Hermes home.
+
+No provider endpoints, hostnames, IP addresses, or collection names are baked
+into the public source tree. Optional indexing settings must come from the
+provider registration config, the provider config file, or environment.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sqlite3
+import time
+import uuid
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+VALID_CANDIDATE_STATES = {"candidate", "approved", "rejected"}
+
+
+class ExternalMemoryError(RuntimeError):
+    pass
+
+
+class ExternalMemoryNotFound(ExternalMemoryError):
+    pass
+
+
+class ExternalMemoryNotConfigured(ExternalMemoryError):
+    pass
+
+
+@dataclass(frozen=True)
+class ProviderSpec:
+    id: str
+    label: str
+    db_path: Path
+    config_path: Path | None = None
+    kind: str = "custom"
+    capabilities: tuple[str, ...] = ("review", "search", "approve", "reject", "delete", "edit")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "label": self.label,
+            "kind": self.kind,
+            "capabilities": list(self.capabilities),
+            "db_path": str(self.db_path),
+            "config_path": str(self.config_path) if self.config_path else "",
+            "available": self.db_path.exists() or self.db_path.parent.exists(),
+        }
+
+
+def _safe_provider_id(value: str | None) -> str:
+    provider = (value or "").strip().lower().replace("-", "_")
+    if not provider or not all(ch.isalnum() or ch == "_" for ch in provider):
+        raise ValueError("invalid external memory provider id")
+    return provider
+
+
+def _custom_provider_specs(hermes_home: str | Path) -> list[ProviderSpec]:
+    home = Path(hermes_home).expanduser()
+    path = home / "external_memory_providers.json"
+    if not path.exists():
+        return []
+    try:
+        parsed = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return []
+    raw_items = parsed.get("providers") if isinstance(parsed, dict) else parsed
+    if not isinstance(raw_items, list):
+        return []
+    specs: list[ProviderSpec] = []
+    for item in raw_items:
+        if not isinstance(item, dict):
+            continue
+        try:
+            provider_id = _safe_provider_id(str(item.get("id") or item.get("name") or ""))
+        except ValueError:
+            continue
+        db_raw = str(item.get("db_path") or "").strip()
+        if not db_raw:
+            continue
+        db = Path(db_raw).expanduser()
+        if not db.is_absolute():
+            db = home / db
+        cfg_raw = str(item.get("config_path") or "").strip()
+        cfg = Path(cfg_raw).expanduser() if cfg_raw else None
+        if cfg and not cfg.is_absolute():
+            cfg = home / cfg
+        specs.append(
+            ProviderSpec(
+                id=provider_id,
+                label=str(item.get("label") or provider_id.replace("_", " ").title()),
+                db_path=db,
+                config_path=cfg,
+                kind="custom",
+            )
+        )
+    return specs
+
+
+def provider_specs(hermes_home: str | Path) -> list[ProviderSpec]:
+    specs = _custom_provider_specs(hermes_home)
+    seen: set[str] = set()
+    unique: list[ProviderSpec] = []
+    for spec in specs:
+        if spec.id in seen:
+            continue
+        seen.add(spec.id)
+        unique.append(spec)
+    return unique
+
+
+def list_providers(hermes_home: str | Path) -> dict[str, Any]:
+    providers = [spec.to_dict() for spec in provider_specs(hermes_home)]
+    active = providers[0]["id"] if providers else ""
+    return {"ok": True, "active": active, "providers": providers}
+
+
+def get_provider_spec(hermes_home: str | Path, provider: str | None = None) -> ProviderSpec:
+    specs = provider_specs(hermes_home)
+    if not specs:
+        raise ExternalMemoryNotFound("no external memory providers configured")
+    provider_id = _safe_provider_id(provider) if provider else specs[0].id
+    for spec in specs:
+        if spec.id == provider_id:
+            return spec
+    raise ExternalMemoryNotFound(f"external memory provider not found: {provider_id}")
+
+
+def load_config(hermes_home: str | Path, provider: str | None = None) -> dict[str, Any]:
+    spec = get_provider_spec(hermes_home, provider)
+    data: dict[str, Any] = {}
+    if spec.config_path and spec.config_path.exists():
+        parsed = json.loads(spec.config_path.read_text(encoding="utf-8"))
+        if isinstance(parsed, dict):
+            data.update(parsed)
+    env_map = {
+        "ollama_url": "HERMES_EXTERNAL_MEMORY_OLLAMA_URL",
+        "qdrant_url": "HERMES_EXTERNAL_MEMORY_QDRANT_URL",
+        "qdrant_collection": "HERMES_EXTERNAL_MEMORY_QDRANT_COLLECTION",
+        "embed_model": "HERMES_EXTERNAL_MEMORY_EMBED_MODEL",
+    }
+    for key, env_name in env_map.items():
+        if not data.get(key) and os.environ.get(env_name):
+            data[key] = os.environ[env_name]
+    data.setdefault("timeout", 10)
+    return data
+
+
+def _require_indexing_config(cfg: dict[str, Any]) -> None:
+    missing = [key for key in ("ollama_url", "embed_model", "qdrant_url", "qdrant_collection") if not cfg.get(key)]
+    if missing:
+        raise ExternalMemoryNotConfigured(
+            "external memory indexing is not configured; missing " + ", ".join(missing)
+        )
+
+
+def ensure_db(path: str | Path) -> Path:
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(path) as con:
+        con.execute(
+            """
+            create table if not exists candidates(
+                id text primary key,
+                text text not null,
+                source text not null default 'agent',
+                metadata_json text not null default '{}',
+                state text not null default 'candidate',
+                content_sha256 text not null,
+                created_at real not null,
+                updated_at real not null
+            )
+            """
+        )
+        con.execute("create index if not exists idx_candidates_state on candidates(state)")
+        con.execute("create index if not exists idx_candidates_created_at on candidates(created_at)")
+    return path
+
+
+def _connect(hermes_home: str | Path, provider: str | None = None) -> sqlite3.Connection:
+    spec = get_provider_spec(hermes_home, provider)
+    path = ensure_db(spec.db_path)
+    con = sqlite3.connect(path)
+    con.row_factory = sqlite3.Row
+    return con
+
+
+def _row_to_candidate(row: sqlite3.Row, provider: str) -> dict[str, Any]:
+    try:
+        metadata = json.loads(row["metadata_json"] or "{}")
+    except Exception:
+        metadata = {}
+    return {
+        "provider": provider,
+        "id": row["id"],
+        "text": row["text"],
+        "source": row["source"],
+        "metadata": metadata if isinstance(metadata, dict) else {},
+        "state": row["state"],
+        "content_sha256": row["content_sha256"],
+        "created_at": row["created_at"],
+        "updated_at": row["updated_at"],
+    }
+
+
+def _coerce_limit(value: int | str | None, *, default: int, maximum: int) -> int:
+    try:
+        parsed = int(value if value is not None else default)
+    except (TypeError, ValueError):
+        parsed = default
+    return max(1, min(parsed, maximum))
+
+
+def _coerce_offset(value: int | str | None) -> int:
+    try:
+        parsed = int(value if value is not None else 0)
+    except (TypeError, ValueError):
+        parsed = 0
+    return max(0, parsed)
+
+
+def list_candidates(hermes_home: str | Path, *, provider: str | None = None, state: str | None = None, limit: int | str = 100, offset: int | str = 0) -> dict[str, Any]:
+    spec = get_provider_spec(hermes_home, provider)
+    provider_id = spec.id
+    limit = _coerce_limit(limit, default=100, maximum=500)
+    offset = _coerce_offset(offset)
+    requested_state = (state or "all").strip().lower()
+    state_filter = None if requested_state in ("", "all") else requested_state
+    if state_filter and state_filter not in VALID_CANDIDATE_STATES:
+        raise ValueError("state must be one of: candidate, approved, rejected, all")
+    with _connect(hermes_home, provider_id) as con:
+        if state_filter:
+            rows = con.execute("select * from candidates where state=? order by created_at desc limit ? offset ?", (state_filter, limit, offset)).fetchall()
+            total = con.execute("select count(*) from candidates where state=?", (state_filter,)).fetchone()[0]
+        else:
+            rows = con.execute("select * from candidates order by created_at desc limit ? offset ?", (limit, offset)).fetchall()
+            total = con.execute("select count(*) from candidates").fetchone()[0]
+    candidates = [_row_to_candidate(r, provider_id) for r in rows]
+    return {"ok": True, "provider": provider_id, "state": state_filter or "all", "limit": limit, "offset": offset, "count": len(candidates), "total": total, "candidates": candidates}
+
+
+def get_candidate(hermes_home: str | Path, candidate_id: str, *, provider: str | None = None) -> dict[str, Any]:
+    spec = get_provider_spec(hermes_home, provider)
+    provider_id = spec.id
+    with _connect(hermes_home, provider_id) as con:
+        row = con.execute("select * from candidates where id=?", (candidate_id,)).fetchone()
+    return {"ok": True, "provider": provider_id, "candidate": _row_to_candidate(row, provider_id) if row else None}
+
+
+def _set_candidate_state(hermes_home: str | Path, candidate_id: str, state: str, metadata_update: dict[str, Any] | None = None, *, provider: str | None = None) -> dict[str, Any]:
+    spec = get_provider_spec(hermes_home, provider)
+    provider_id = spec.id
+    current = get_candidate(hermes_home, candidate_id, provider=provider_id)["candidate"]
+    if not current:
+        raise ExternalMemoryNotFound(f"candidate not found: {candidate_id}")
+    metadata = dict(current.get("metadata") or {})
+    if metadata_update:
+        metadata.update(metadata_update)
+    now = time.time()
+    with _connect(hermes_home, provider_id) as con:
+        con.execute("update candidates set state=?, metadata_json=?, updated_at=? where id=?", (state, json.dumps(metadata, ensure_ascii=False, sort_keys=True), now, candidate_id))
+    return get_candidate(hermes_home, candidate_id, provider=provider_id)
+
+
+def update_candidate_text(hermes_home: str | Path, candidate_id: str, text: str, *, provider: str | None = None) -> dict[str, Any]:
+    spec = get_provider_spec(hermes_home, provider)
+    provider_id = spec.id
+    text = (text or "").strip()
+    if not text:
+        raise ValueError("text is required")
+    current = get_candidate(hermes_home, candidate_id, provider=provider_id)["candidate"]
+    if not current:
+        raise ExternalMemoryNotFound(f"candidate not found: {candidate_id}")
+    if current.get("state") == "approved":
+        raise ValueError("approved external memory cannot be edited; create a new candidate instead")
+    metadata = dict(current.get("metadata") or {})
+    metadata["edited_at"] = time.time()
+    now = time.time()
+    content_sha = hashlib.sha256(text.encode("utf-8")).hexdigest()
+    with _connect(hermes_home, provider_id) as con:
+        con.execute("update candidates set text=?, content_sha256=?, metadata_json=?, updated_at=? where id=?", (text, content_sha, json.dumps(metadata, ensure_ascii=False, sort_keys=True), now, candidate_id))
+    result = get_candidate(hermes_home, candidate_id, provider=provider_id)
+    result["ok"] = True
+    return result
+
+
+def reject_candidate(hermes_home: str | Path, candidate_id: str, *, provider: str | None = None, reason: str = "") -> dict[str, Any]:
+    result = _set_candidate_state(hermes_home, candidate_id, "rejected", {"review_reason": reason, "reviewed_at": time.time()}, provider=provider)
+    result["ok"] = True
+    return result
+
+
+def delete_candidate(hermes_home: str | Path, candidate_id: str, *, provider: str | None = None) -> dict[str, Any]:
+    spec = get_provider_spec(hermes_home, provider)
+    provider_id = spec.id
+    with _connect(hermes_home, provider_id) as con:
+        cur = con.execute("delete from candidates where id=?", (candidate_id,))
+    if cur.rowcount == 0:
+        raise ExternalMemoryNotFound(f"candidate not found: {candidate_id}")
+    return {"ok": True, "provider": provider_id, "deleted": candidate_id}
+
+
+def approve_candidate(hermes_home: str | Path, candidate_id: str, *, provider: str | None = None) -> dict[str, Any]:
+    spec = get_provider_spec(hermes_home, provider)
+    provider_id = spec.id
+    current = get_candidate(hermes_home, candidate_id, provider=provider_id)["candidate"]
+    if not current:
+        raise ExternalMemoryNotFound(f"candidate not found: {candidate_id}")
+    index_result = index_candidate(hermes_home, current, provider=provider_id)
+    result = _set_candidate_state(hermes_home, candidate_id, "approved", {"approved_at": time.time(), "qdrant_point_id": index_result.get("point_id", "")}, provider=provider_id)
+    result["index"] = index_result
+    return result
+
+
+def _request_json(url: str, payload: dict[str, Any], *, timeout: float, method: str = "POST") -> dict[str, Any]:
+    data = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(url, data=data, headers={"Content-Type": "application/json"}, method=method)
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        raw = resp.read().decode("utf-8")
+    parsed = json.loads(raw) if raw else {}
+    if not isinstance(parsed, dict):
+        raise ExternalMemoryError(f"response from {url} must be a JSON object")
+    return parsed
+
+
+def _post_json(url: str, payload: dict[str, Any], *, timeout: float) -> dict[str, Any]:
+    return _request_json(url, payload, timeout=timeout, method="POST")
+
+
+def embed_text(cfg: dict[str, Any], text: str) -> list[float]:
+    _require_indexing_config(cfg)
+    base = str(cfg["ollama_url"]).rstrip("/")
+    model = str(cfg["embed_model"])
+    timeout = float(cfg.get("timeout", 10))
+    try:
+        response = _post_json(f"{base}/api/embed", {"model": model, "input": text}, timeout=timeout)
+        embeddings = response.get("embeddings")
+        if isinstance(embeddings, list) and embeddings and isinstance(embeddings[0], list):
+            return [float(v) for v in embeddings[0]]
+    except Exception:
+        pass
+    response = _post_json(f"{base}/api/embeddings", {"model": model, "prompt": text}, timeout=timeout)
+    embedding = response.get("embedding")
+    if not isinstance(embedding, list):
+        raise ExternalMemoryError("embedding response missing embedding")
+    return [float(v) for v in embedding]
+
+
+def qdrant_upsert(cfg: dict[str, Any], point_id: str, vector: list[float], payload: dict[str, Any]) -> None:
+    _require_indexing_config(cfg)
+    base = str(cfg["qdrant_url"]).rstrip("/")
+    collection = str(cfg["qdrant_collection"])
+    timeout = float(cfg.get("timeout", 10))
+    _request_json(f"{base}/collections/{collection}/points?wait=true", {"points": [{"id": point_id, "vector": vector, "payload": payload}]}, timeout=timeout, method="PUT")
+
+
+def index_candidate(hermes_home: str | Path, candidate: dict[str, Any], *, provider: str | None = None) -> dict[str, Any]:
+    provider_id = get_provider_spec(hermes_home, provider or candidate.get("provider")).id
+    cfg = load_config(hermes_home, provider_id)
+    _require_indexing_config(cfg)
+    vector = embed_text(cfg, candidate["text"])
+    point_id = str(uuid.uuid5(uuid.NAMESPACE_URL, f"external-memory:{provider_id}:{candidate['id']}"))
+    metadata = candidate.get("metadata") or {}
+    payload = {
+        "text": candidate["text"],
+        "summary": candidate["text"],
+        "state": "active",
+        "memory_id": candidate["id"],
+        "memory_provider": provider_id,
+        "memory_type": metadata.get("type", "external_memory"),
+        "source_type": candidate.get("source", "candidate"),
+        "source": f"external_memory:{provider_id}",
+        "content_sha256": hashlib.sha256(candidate["text"].encode("utf-8")).hexdigest(),
+        "metadata": metadata,
+    }
+    qdrant_upsert(cfg, point_id, vector, payload)
+    return {"point_id": point_id}
+
+
+def search_external_memory(hermes_home: str | Path, query: str, *, provider: str | None = None, limit: int | str = 5) -> dict[str, Any]:
+    spec = get_provider_spec(hermes_home, provider)
+    provider_id = spec.id
+    query = (query or "").strip()
+    if not query:
+        raise ValueError("q is required")
+    limit = _coerce_limit(limit, default=5, maximum=50)
+    pattern = f"%{query}%"
+    with _connect(hermes_home, provider_id) as con:
+        rows = con.execute(
+            """
+            select * from candidates
+            where text like ? or metadata_json like ? or source like ?
+            order by case when state='approved' then 0 when state='candidate' then 1 else 2 end,
+                     updated_at desc
+            limit ?
+            """,
+            (pattern, pattern, pattern, limit),
+        ).fetchall()
+    results = [_row_to_candidate(row, provider_id) for row in rows]
+    return {"ok": True, "provider": provider_id, "q": query, "limit": limit, "count": len(results), "results": results}

--- a/api/external_memory.py
+++ b/api/external_memory.py
@@ -26,7 +26,27 @@ VALID_CANDIDATE_STATES = {"candidate", "approved", "rejected"}
 
 
 class ExternalMemoryError(RuntimeError):
-    pass
+    def __init__(
+        self,
+        message: str,
+        *,
+        stage: str = "persistence",
+        code: str = "provider_error",
+        retryable: bool = True,
+    ):
+        super().__init__(message)
+        self.stage = stage
+        self.code = code
+        self.retryable = retryable
+
+    def to_response(self) -> dict[str, Any]:
+        return {
+            "ok": False,
+            "stage": self.stage,
+            "code": self.code,
+            "message": str(self),
+            "retryable": self.retryable,
+        }
 
 
 class ExternalMemoryNotFound(ExternalMemoryError):
@@ -34,7 +54,8 @@ class ExternalMemoryNotFound(ExternalMemoryError):
 
 
 class ExternalMemoryNotConfigured(ExternalMemoryError):
-    pass
+    def __init__(self, message: str):
+        super().__init__(message, stage="policy", code="indexing_not_configured", retryable=True)
 
 
 @dataclass(frozen=True)
@@ -162,6 +183,14 @@ def _require_indexing_config(cfg: dict[str, Any]) -> None:
         raise ExternalMemoryNotConfigured(
             "external memory indexing is not configured; missing " + ", ".join(missing)
         )
+
+
+def check_write_policy(hermes_home: str | Path, *, provider: str | None = None) -> dict[str, Any]:
+    """Validate that a reviewed candidate may proceed to provider I/O."""
+    provider_id = get_provider_spec(hermes_home, provider).id
+    cfg = load_config(hermes_home, provider_id)
+    _require_indexing_config(cfg)
+    return {"ok": True, "provider": provider_id, "stage": "policy"}
 
 
 def ensure_db(path: str | Path) -> Path:
@@ -316,6 +345,7 @@ def approve_candidate(hermes_home: str | Path, candidate_id: str, *, provider: s
     current = get_candidate(hermes_home, candidate_id, provider=provider_id)["candidate"]
     if not current:
         raise ExternalMemoryNotFound(f"candidate not found: {candidate_id}")
+    check_write_policy(hermes_home, provider=provider_id)
     index_result = index_candidate(hermes_home, current, provider=provider_id)
     result = _set_candidate_state(hermes_home, candidate_id, "approved", {"approved_at": time.time(), "qdrant_point_id": index_result.get("point_id", "")}, provider=provider_id)
     result["index"] = index_result
@@ -364,6 +394,24 @@ def qdrant_upsert(cfg: dict[str, Any], point_id: str, vector: list[float], paylo
     _request_json(f"{base}/collections/{collection}/points?wait=true", {"points": [{"id": point_id, "vector": vector, "payload": payload}]}, timeout=timeout, method="PUT")
 
 
+def qdrant_verify_active(cfg: dict[str, Any], point_id: str, memory_id: str) -> bool:
+    _require_indexing_config(cfg)
+    base = str(cfg["qdrant_url"]).rstrip("/")
+    collection = str(cfg["qdrant_collection"])
+    timeout = float(cfg.get("timeout", 10))
+    response = _post_json(
+        f"{base}/collections/{collection}/points",
+        {"ids": [point_id], "with_payload": True, "with_vector": False},
+        timeout=timeout,
+    )
+    points = response.get("result")
+    if not isinstance(points, list) or not points:
+        return False
+    first = points[0]
+    payload = first.get("payload") if isinstance(first, dict) else None
+    return isinstance(payload, dict) and payload.get("state") == "active" and payload.get("memory_id") == memory_id
+
+
 def index_candidate(hermes_home: str | Path, candidate: dict[str, Any], *, provider: str | None = None) -> dict[str, Any]:
     provider_id = get_provider_spec(hermes_home, provider or candidate.get("provider")).id
     cfg = load_config(hermes_home, provider_id)
@@ -384,6 +432,13 @@ def index_candidate(hermes_home: str | Path, candidate: dict[str, Any], *, provi
         "metadata": metadata,
     }
     qdrant_upsert(cfg, point_id, vector, payload)
+    if not qdrant_verify_active(cfg, point_id, candidate["id"]):
+        raise ExternalMemoryError(
+            "external memory indexing did not verify an active persisted record",
+            stage="persistence",
+            code="indexing_failed",
+            retryable=True,
+        )
     return {"point_id": point_id}
 
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -6363,7 +6363,9 @@ def _handle_external_memory_candidate_action(handler, path: str, body: dict):
             return j(handler, external_memory.update_candidate_text(home, candidate_id, str(body.get("text") or ""), provider=provider))
         return bad(handler, "unknown external memory candidate action", 404)
     except external_memory.ExternalMemoryNotConfigured as e:
-        return bad(handler, str(e), 400)
+        return j(handler, e.to_response(), status=400)
+    except external_memory.ExternalMemoryError as e:
+        return j(handler, e.to_response(), status=502)
     except external_memory.ExternalMemoryNotFound as e:
         return bad(handler, str(e), 404)
     except ValueError as e:

--- a/api/routes.py
+++ b/api/routes.py
@@ -2868,7 +2868,7 @@ def handle_get(handler, parsed) -> bool:
             handler.end_headers()
         return True
 
-    # ── Insights / knowledge status ──
+    # ── Insights / external_memory status ──
     if parsed.path == "/api/insights":
         return _handle_insights(handler, parsed)
 
@@ -3580,6 +3580,16 @@ def handle_get(handler, parsed) -> bool:
     # ── Memory API (GET) ──
     if parsed.path == "/api/memory":
         return _handle_memory_read(handler)
+
+    # ── External Memory API (GET) ──
+    if parsed.path == "/api/external-memory/providers":
+        return _handle_external_memory_providers(handler)
+
+    if parsed.path == "/api/external-memory/candidates":
+        return _handle_external_memory_candidates(handler, parsed)
+
+    if parsed.path == "/api/external-memory/search":
+        return _handle_external_memory_search(handler, parsed)
 
     # ── Profile API (GET) ──
     if parsed.path == "/api/profiles":
@@ -4440,6 +4450,10 @@ def handle_post(handler, parsed) -> bool:
     if parsed.path == "/api/memory/write":
         return _handle_memory_write(handler, body)
 
+    # ── External Memory API (POST) ──
+    if parsed.path.startswith("/api/external-memory/candidates/"):
+        return _handle_external_memory_candidate_action(handler, parsed.path, body)
+
     # ── Profile API (POST) ──
     if parsed.path == "/api/profile/switch":
         name = body.get("name", "").strip()
@@ -4985,6 +4999,9 @@ def handle_delete(handler, parsed) -> bool:
     if not _check_csrf(handler):
         return j(handler, {"error": "Cross-origin request rejected"}, status=403)
     body = read_body(handler)
+    if parsed.path.startswith("/api/external-memory/candidates/"):
+        _handle_external_memory_candidate_delete(handler, parsed)
+        return True
     if parsed.path.startswith("/api/kanban/"):
         from api.kanban_bridge import handle_kanban_delete
 
@@ -6257,6 +6274,121 @@ def _handle_memory_read(handler):
             "user_mtime": user_file.stat().st_mtime if user_file.exists() else None,
         },
     )
+
+
+def _active_hermes_home_for_external_memory() -> Path:
+    try:
+        from api.profiles import get_active_hermes_home
+
+        return Path(get_active_hermes_home())
+    except Exception:
+        return Path(os.getenv("HERMES_HOME", str(Path.home() / ".hermes"))).expanduser()
+
+
+def _handle_external_memory_providers(handler):
+    from api import external_memory
+
+    try:
+        return j(handler, external_memory.list_providers(_active_hermes_home_for_external_memory()))
+    except Exception as e:
+        logger.exception("External memory providers list failed")
+        return bad(handler, _sanitize_error(e), 500)
+
+
+def _handle_external_memory_candidates(handler, parsed):
+    from api import external_memory
+
+    qs = parse_qs(parsed.query)
+    provider = (qs.get("provider", [""])[0] or "").strip() or None
+    state = (qs.get("state", [""])[0] or "").strip() or None
+    try:
+        limit = int(qs.get("limit", [100])[0] or 100)
+        offset = int(qs.get("offset", [0])[0] or 0)
+        return j(
+            handler,
+            external_memory.list_candidates(
+                _active_hermes_home_for_external_memory(),
+                provider=provider,
+                state=state,
+                limit=limit,
+                offset=offset,
+            ),
+        )
+    except ValueError as e:
+        return bad(handler, str(e), 400)
+    except external_memory.ExternalMemoryNotFound as e:
+        return bad(handler, str(e), 404)
+    except Exception as e:
+        logger.exception("External memory candidates list failed")
+        return bad(handler, _sanitize_error(e), 500)
+
+
+def _handle_external_memory_search(handler, parsed):
+    from api import external_memory
+
+    qs = parse_qs(parsed.query)
+    provider = (qs.get("provider", [""])[0] or "").strip() or None
+    query = (qs.get("q", [""])[0] or qs.get("query", [""])[0] or "").strip()
+    if not query:
+        return bad(handler, "q is required", 400)
+    try:
+        limit = int(qs.get("limit", [5])[0] or 5)
+        return j(handler, external_memory.search_external_memory(_active_hermes_home_for_external_memory(), query, provider=provider, limit=limit))
+    except ValueError as e:
+        return bad(handler, str(e), 400)
+    except external_memory.ExternalMemoryNotFound as e:
+        return bad(handler, str(e), 404)
+    except Exception as e:
+        logger.exception("External memory search failed")
+        return bad(handler, _sanitize_error(e), 500)
+
+
+def _handle_external_memory_candidate_action(handler, path: str, body: dict):
+    from api import external_memory
+
+    # Shape: /api/external-memory/candidates/{id}/{approve|reject}
+    parts = [p for p in path.split("/") if p]
+    if len(parts) != 5 or parts[:3] != ["api", "external-memory", "candidates"]:
+        return bad(handler, "invalid external memory candidate endpoint", 404)
+    provider = str(body.get("provider") or "").strip() or None
+    candidate_id = parts[3]
+    action = parts[4]
+    try:
+        home = _active_hermes_home_for_external_memory()
+        if action == "approve":
+            return j(handler, external_memory.approve_candidate(home, candidate_id, provider=provider))
+        if action == "reject":
+            return j(handler, external_memory.reject_candidate(home, candidate_id, provider=provider, reason=str(body.get("reason") or "")))
+        if action == "edit":
+            return j(handler, external_memory.update_candidate_text(home, candidate_id, str(body.get("text") or ""), provider=provider))
+        return bad(handler, "unknown external memory candidate action", 404)
+    except external_memory.ExternalMemoryNotConfigured as e:
+        return bad(handler, str(e), 400)
+    except external_memory.ExternalMemoryNotFound as e:
+        return bad(handler, str(e), 404)
+    except ValueError as e:
+        return bad(handler, str(e), 400)
+    except Exception as e:
+        logger.exception("External memory candidate action failed")
+        return bad(handler, _sanitize_error(e), 500)
+
+
+def _handle_external_memory_candidate_delete(handler, parsed):
+    from api import external_memory
+
+    # Shape: DELETE /api/external-memory/candidates/{id}?provider=...
+    parts = [p for p in parsed.path.split("/") if p]
+    if len(parts) != 4 or parts[:3] != ["api", "external-memory", "candidates"]:
+        return bad(handler, "invalid external memory candidate endpoint", 404)
+    qs = parse_qs(parsed.query)
+    provider = (qs.get("provider", [""])[0] or "").strip() or None
+    try:
+        return j(handler, external_memory.delete_candidate(_active_hermes_home_for_external_memory(), parts[3], provider=provider))
+    except external_memory.ExternalMemoryNotFound as e:
+        return bad(handler, str(e), 404)
+    except Exception as e:
+        logger.exception("External memory candidate delete failed")
+        return bad(handler, _sanitize_error(e), 500)
 
 
 # ── POST route helpers ────────────────────────────────────────────────────────

--- a/static/panels.js
+++ b/static/panels.js
@@ -4332,7 +4332,12 @@ async function searchExternalMemoryReview() {
 async function editExternalMemoryCandidate(id) {
   const all = [...((_externalMemoryData.candidate||{}).candidates||[]), ...((_externalMemoryData.approved||{}).candidates||[])];
   const item = all.find(x => x.id === id);
-  const next = prompt('Edit semantic statement before approval:', item ? item.text : '');
+  const next = await showPromptDialog({
+    title:'Edit External Memory candidate',
+    message:'Edit semantic statement before approval:',
+    value:item ? item.text : '',
+    confirmLabel:'Save',
+  });
   if (next == null) return;
   const provider = _activeExternalMemoryProvider();
   await api(`/api/external-memory/candidates/${encodeURIComponent(id)}/edit`, {method:'POST', body:JSON.stringify({provider,text:next})});
@@ -4348,9 +4353,15 @@ async function approveExternalMemoryCandidate(id) {
 }
 
 async function rejectExternalMemoryCandidate(id) {
-  const reason = prompt('Reject reason:', 'not durable external memory') || '';
+  const reason = await showPromptDialog({
+    title:'Reject External Memory candidate',
+    message:'Reject reason:',
+    value:'not durable external memory',
+    confirmLabel:'Reject',
+  });
+  if (reason == null) return;
   const provider = _activeExternalMemoryProvider();
-  await api(`/api/external-memory/candidates/${encodeURIComponent(id)}/reject`, {method:'POST', body:JSON.stringify({provider,reason})});
+  await api(`/api/external-memory/candidates/${encodeURIComponent(id)}/reject`, {method:'POST', body:JSON.stringify({provider,reason:reason||''})});
   showToast('External Memory candidate rejected');
   await loadExternalMemoryReview(true);
 }

--- a/static/panels.js
+++ b/static/panels.js
@@ -2378,7 +2378,7 @@ function _renderLlmWikiStatus(d) {
       <div class="wiki-status-head">
         <div>
           <div class="insights-card-title">LLM Wiki</div>
-          <div class="wiki-status-sub">Knowledge-base observability</div>
+          <div class="wiki-status-sub">External Memory-base observability</div>
         </div>
         <span class="wiki-status-badge ${badgeClass}">${esc(badgeText)}</span>
       </div>
@@ -2862,12 +2862,14 @@ async function deleteCurrentSkill() {
 
 // ── Memory (main view) ──
 let _memoryData = null;
-let _currentMemorySection = null; // 'memory' | 'user'
+let _externalMemoryData = {providers:[], activeProvider:'', candidate:{candidates:[], total:0}, approved:{candidates:[], total:0}, search:{q:'', results:[]}};
+let _currentMemorySection = null; // 'memory' | 'user' | 'external_memory'
 let _memoryMode = 'empty'; // 'empty' | 'read' | 'edit'
 
 const MEMORY_SECTIONS = [
   { key: 'memory', labelKey: 'my_notes', emptyKey: 'no_notes_yet', iconKey: 'brain' },
   { key: 'user',   labelKey: 'user_profile', emptyKey: 'no_profile_yet', iconKey: 'user' },
+  { key: 'external_memory', labelKey: 'External Memory', emptyKey: 'No external memory providers', iconKey: 'book-open' },
 ];
 
 function _memorySectionMeta(key) {
@@ -2901,7 +2903,11 @@ function _renderMemoryDetail(section) {
   const body = $('memoryDetailBody');
   const empty = $('memoryDetailEmpty');
   if (!title || !body) return;
-  title.textContent = t(meta.labelKey);
+  title.textContent = section === 'external_memory' ? 'External Memory' : t(meta.labelKey);
+  if (section === 'external_memory') {
+    _renderExternalMemoryDetail();
+    return;
+  }
   const content = _memorySectionContent(section);
   const mtime = _memorySectionMtime(section);
   const mtimeStr = mtime ? new Date(mtime * 1000).toLocaleString() : '';
@@ -2947,6 +2953,7 @@ function openMemorySection(section, el) {
   document.querySelectorAll('#memoryPanel .side-menu-item').forEach(e => e.classList.remove('active'));
   if (el) el.classList.add('active');
   _renderMemoryDetail(section);
+  if (section === 'external_memory') loadExternalMemoryReview(true);
 }
 
 function editCurrentMemory() {
@@ -4185,6 +4192,178 @@ async function deleteProfile(name) {
   } catch (e) { showToast(t('delete_failed') + e.message); }
 }
 
+// ── External Memory review inside Memory panel ──
+function _activeExternalMemoryProvider() {
+  return _externalMemoryData.activeProvider || ((_externalMemoryData.providers[0] || {}).id) || '';
+}
+
+function _externalMemoryProviderOptionsHtml() {
+  const active = _activeExternalMemoryProvider();
+  return (_externalMemoryData.providers || []).map(p => `<option value="${esc(p.id)}" ${p.id===active?'selected':''}>${esc(p.label || p.id)}</option>`).join('');
+}
+
+function _externalMemoryMetaHtml(item) {
+  const meta = item && item.metadata ? item.metadata : {};
+  const bits = [];
+  if (item.state) bits.push(item.state);
+  if (meta.type) bits.push(meta.type);
+  if (meta.confidence != null) bits.push('confidence ' + meta.confidence);
+  if (item.source) bits.push(item.source);
+  if (meta.qdrant_point_id) bits.push('qdrant ' + meta.qdrant_point_id);
+  return bits.map(esc).join(' · ');
+}
+
+function _externalMemoryCardHtml(item) {
+  const meta = item && item.metadata ? item.metadata : {};
+  const isCandidate = item.state === 'candidate';
+  const rationale = meta.rationale ? `<div class="memory-detail-mtime">${esc(meta.rationale)}</div>` : '';
+  const actions = isCandidate ? `
+    <div style="display:flex;gap:8px;flex-wrap:wrap;margin-top:10px">
+      <button class="btn secondary" onclick="editExternalMemoryCandidate('${esc(item.id)}')">Edit</button>
+      <button class="btn" onclick="approveExternalMemoryCandidate('${esc(item.id)}')">Approve</button>
+      <button class="btn secondary" onclick="rejectExternalMemoryCandidate('${esc(item.id)}')">Reject</button>
+      <button class="btn secondary" onclick="deleteExternalMemoryCandidate('${esc(item.id)}')">Delete</button>
+    </div>` : `<div style="display:flex;gap:8px;flex-wrap:wrap;margin-top:10px"><button class="btn secondary" onclick="deleteExternalMemoryCandidate('${esc(item.id)}')">Delete</button></div>`;
+  return `
+    <div class="memory-content" style="border:1px solid var(--border);border-radius:10px;padding:12px;margin-bottom:10px;background:rgba(255,255,255,.03)">
+      <div style="font-size:13px;line-height:1.45">${esc(item.text || '')}</div>
+      <div class="memory-detail-mtime">${esc(_externalMemoryMetaHtml(item))}</div>
+      ${rationale}
+      ${actions}
+    </div>`;
+}
+
+function _renderExternalMemoryDetail() {
+  const body = $('memoryDetailBody');
+  const empty = $('memoryDetailEmpty');
+  if (!body) return;
+  _memoryMode = 'read';
+  _setMemoryHeaderButtons('empty');
+  const candidates = (_externalMemoryData.candidate && _externalMemoryData.candidate.candidates) || [];
+  const approved = (_externalMemoryData.approved && _externalMemoryData.approved.candidates) || [];
+  const candidateTotal = (_externalMemoryData.candidate && Number.isFinite(_externalMemoryData.candidate.total)) ? _externalMemoryData.candidate.total : candidates.length;
+  const approvedTotal = (_externalMemoryData.approved && Number.isFinite(_externalMemoryData.approved.total)) ? _externalMemoryData.approved.total : approved.length;
+  const searchResults = (_externalMemoryData.search && _externalMemoryData.search.results) || [];
+  const hasProviders = !!((_externalMemoryData.providers || []).length);
+  const noProvidersHtml = `
+    <div class="memory-empty" style="margin-bottom:12px">
+      No external memory providers configured yet. Register one in <code>external_memory_providers.json</code> in the active Hermes home.
+    </div>`;
+  body.innerHTML = `
+    <div class="main-view-content" id="externalMemoryReviewPanel">
+      <div style="border:1px solid var(--border);border-radius:10px;padding:10px 12px;margin-bottom:12px;background:rgba(255,255,255,.025)">
+        <div style="font-size:12px;font-weight:600;margin-bottom:4px">Semantic format</div>
+        <div class="memory-detail-mtime">Use one standalone sentence: <code>&lt;Scope/Subject&gt; &lt;durable relation&gt; &lt;object/behavior&gt; &lt;condition/scope if needed&gt; &lt;purpose/rationale if useful&gt;.</code></div>
+      </div>
+      <div style="display:flex;gap:8px;align-items:center;margin-bottom:12px;flex-wrap:wrap">
+        <select id="externalMemoryProviderSelect" onchange="switchExternalMemoryProvider(this.value)" style="background:var(--input-bg);color:var(--text);border:1px solid var(--border);border-radius:8px;padding:8px 10px">
+          ${_externalMemoryProviderOptionsHtml() || '<option value="">No providers configured</option>'}
+        </select>
+        <input id="externalMemorySearchInput" ${hasProviders?'':'disabled'} placeholder="Search External Memory..." value="${esc((_externalMemoryData.search&&_externalMemoryData.search.q)||'')}" onkeydown="if(event.key==='Enter')searchExternalMemoryReview()" style="flex:1;min-width:220px;background:var(--input-bg);color:var(--text);border:1px solid var(--border);border-radius:8px;padding:8px 10px">
+        <button class="btn secondary" onclick="loadExternalMemoryReview(true)">Refresh</button>
+        <button class="btn secondary" ${hasProviders?'':'disabled'} onclick="searchExternalMemoryReview()">Search</button>
+      </div>
+      ${hasProviders ? '' : noProvidersHtml}
+      <section style="margin-bottom:18px">
+        <h3 style="font-size:13px;margin:0 0 8px;color:var(--muted)">Candidates (${candidateTotal})</h3>
+        <div class="memory-detail-mtime" style="margin-bottom:8px">Showing ${candidates.length} of ${candidateTotal} pending candidates.</div>
+        <div id="externalMemoryCandidateList" style="max-height:55vh;overflow-y:auto;padding-right:4px;border-radius:10px">
+          ${candidates.length ? candidates.map(_externalMemoryCardHtml).join('') : '<div class="memory-empty">No pending candidates.</div>'}
+        </div>
+      </section>
+      <section style="margin-bottom:18px">
+        <h3 style="font-size:13px;margin:0 0 8px;color:var(--muted)">Approved (${approvedTotal})</h3>
+        <div class="memory-detail-mtime" style="margin-bottom:8px">Showing ${approved.length} of ${approvedTotal} approved rows.</div>
+        <div id="externalMemoryApprovedList" style="max-height:45vh;overflow-y:auto;padding-right:4px;border-radius:10px">
+          ${approved.length ? approved.map(_externalMemoryCardHtml).join('') : '<div class="memory-empty">No approved external memory.</div>'}
+        </div>
+      </section>
+      <section>
+        <h3 style="font-size:13px;margin:0 0 8px;color:var(--muted)">Search results (${searchResults.length})</h3>
+        ${searchResults.length ? searchResults.map(_externalMemoryCardHtml).join('') : '<div class="memory-empty">Search results appear here.</div>'}
+      </section>
+    </div>`;
+  body.style.display = '';
+  if (empty) empty.style.display = 'none';
+}
+
+async function loadExternalMemoryReview(force) {
+  try {
+    const providers = await api('/api/external-memory/providers');
+    _externalMemoryData.providers = providers.providers || [];
+    if (!_externalMemoryData.activeProvider) _externalMemoryData.activeProvider = providers.active || ((_externalMemoryData.providers[0]||{}).id) || '';
+    const provider = _activeExternalMemoryProvider();
+    if (!provider) {
+      _externalMemoryData.candidate = {candidates:[]};
+      _externalMemoryData.approved = {candidates:[]};
+      _externalMemoryData.search = _externalMemoryData.search || {q:'', results:[]};
+      _renderExternalMemoryDetail();
+      return;
+    }
+    const qs = 'provider=' + encodeURIComponent(provider);
+    const [candidate, approved] = await Promise.all([
+      api('/api/external-memory/candidates?' + qs + '&state=candidate&limit=500'),
+      api('/api/external-memory/candidates?' + qs + '&state=approved&limit=500'),
+    ]);
+    _externalMemoryData.candidate = candidate;
+    _externalMemoryData.approved = approved;
+    _renderExternalMemoryDetail();
+  } catch (e) {
+    const body = $('memoryDetailBody');
+    if (body) body.innerHTML = `<div class="main-view-content"><div class="detail-form-error">${esc(t('error_prefix'))}${esc(e.message)}</div></div>`;
+  }
+}
+
+async function switchExternalMemoryProvider(provider) {
+  _externalMemoryData.activeProvider = provider || '';
+  _externalMemoryData.search = {q:'', results:[]};
+  await loadExternalMemoryReview(true);
+}
+
+async function searchExternalMemoryReview() {
+  const q = (($('externalMemorySearchInput') || {}).value || '').trim();
+  if (!q) return;
+  const provider = _activeExternalMemoryProvider();
+  const data = await api('/api/external-memory/search?provider=' + encodeURIComponent(provider) + '&q=' + encodeURIComponent(q) + '&limit=20');
+  _externalMemoryData.search = {q, results: data.results || []};
+  _renderExternalMemoryDetail();
+}
+
+async function editExternalMemoryCandidate(id) {
+  const all = [...((_externalMemoryData.candidate||{}).candidates||[]), ...((_externalMemoryData.approved||{}).candidates||[])];
+  const item = all.find(x => x.id === id);
+  const next = prompt('Edit semantic statement before approval:', item ? item.text : '');
+  if (next == null) return;
+  const provider = _activeExternalMemoryProvider();
+  await api(`/api/external-memory/candidates/${encodeURIComponent(id)}/edit`, {method:'POST', body:JSON.stringify({provider,text:next})});
+  showToast('External Memory candidate updated');
+  await loadExternalMemoryReview(true);
+}
+
+async function approveExternalMemoryCandidate(id) {
+  const provider = _activeExternalMemoryProvider();
+  await api(`/api/external-memory/candidates/${encodeURIComponent(id)}/approve`, {method:'POST', body:JSON.stringify({provider})});
+  showToast('External Memory approved and indexed');
+  await loadExternalMemoryReview(true);
+}
+
+async function rejectExternalMemoryCandidate(id) {
+  const reason = prompt('Reject reason:', 'not durable external memory') || '';
+  const provider = _activeExternalMemoryProvider();
+  await api(`/api/external-memory/candidates/${encodeURIComponent(id)}/reject`, {method:'POST', body:JSON.stringify({provider,reason})});
+  showToast('External Memory candidate rejected');
+  await loadExternalMemoryReview(true);
+}
+
+async function deleteExternalMemoryCandidate(id) {
+  const ok = await showConfirmDialog({title:'Delete external memory row?',message:'This removes the local External Memory row. Approved Qdrant payloads are not modified in this minimal UI.',confirmLabel:'Delete',danger:true,focusCancel:true});
+  if (!ok) return;
+  const provider = _activeExternalMemoryProvider();
+  await api(`/api/external-memory/candidates/${encodeURIComponent(id)}?provider=${encodeURIComponent(provider)}`, {method:'DELETE'});
+  showToast('External Memory row deleted');
+  await loadExternalMemoryReview(true);
+}
+
 // ── Memory panel ──
 async function loadMemory(force) {
   const panel = $('memoryPanel');
@@ -4198,7 +4377,8 @@ async function loadMemory(force) {
         el.type = 'button';
         el.className = 'side-menu-item';
         if (_currentMemorySection === s.key) el.classList.add('active');
-        el.innerHTML = `${li(s.iconKey,16)}<span>${esc(t(s.labelKey))}</span>`;
+        const label = s.labelKey && s.labelKey.startsWith('external memory ') ? s.labelKey : t(s.labelKey);
+        el.innerHTML = `${li(s.iconKey,16)}<span>${esc(label)}</span>`;
         el.onclick = () => openMemorySection(s.key, el);
         panel.appendChild(el);
       }

--- a/tests/external_memory_api_mini_sdd.md
+++ b/tests/external_memory_api_mini_sdd.md
@@ -1,0 +1,63 @@
+# Mini-SDD: External Memory Review API
+
+## Goal
+Expose a generic review-and-approval API for external memory providers that maintain human-reviewable candidate queues.
+
+## Scope
+- Discover custom external memory providers for the active Hermes profile.
+- Allow custom providers via `$HERMES_HOME/external_memory_providers.json`.
+- List, search, edit, approve, reject, and delete reviewable candidate rows.
+- Keep approval fail-closed when optional indexing is not configured or fails.
+- Do not ship any built-in provider, endpoint, hostname, IP address, model, or collection default.
+
+## Non-goals
+- No provider-specific implementation is bundled.
+- No coupling to any private memory backend.
+- No automatic discovery of existing agent memory plugins.
+
+## Provider registration
+A provider is registered in the active Hermes home:
+
+```json
+{
+  "providers": [
+    {
+      "id": "custom_store",
+      "label": "Custom Store",
+      "db_path": "custom_store/items.sqlite",
+      "config_path": "custom_store/config.json"
+    }
+  ]
+}
+```
+
+## Candidate table contract
+
+```sql
+candidates(
+  id text primary key,
+  text text not null,
+  source text not null default 'agent',
+  metadata_json text not null default '{}',
+  state text not null default 'candidate',
+  content_sha256 text not null,
+  created_at real not null,
+  updated_at real not null
+)
+```
+
+## Optional indexing config
+Indexing URLs and collection/model names must come from provider config or environment variables:
+
+- `ollama_url` / `HERMES_EXTERNAL_MEMORY_OLLAMA_URL`
+- `embed_model` / `HERMES_EXTERNAL_MEMORY_EMBED_MODEL`
+- `qdrant_url` / `HERMES_EXTERNAL_MEMORY_QDRANT_URL`
+- `qdrant_collection` / `HERMES_EXTERNAL_MEMORY_QDRANT_COLLECTION`
+
+When these are missing, approval fails clearly and leaves the candidate unchanged.
+
+## Acceptance
+- No providers appear until a custom provider is registered.
+- Custom providers registered in JSON can be selected and queried.
+- Missing indexing config disables approval rather than falling back to defaults.
+- Existing local memory/profile editing remains unchanged.

--- a/tests/external_memory_review_ui_mini_sdd.md
+++ b/tests/external_memory_review_ui_mini_sdd.md
@@ -1,0 +1,36 @@
+# Mini-SDD: External Memory Review UI
+
+## Goal
+Expose a generic review surface inside the existing Memory panel for custom external memory providers with candidate approval queues.
+
+## Scope
+- Add an `External Memory` entry to the Memory panel.
+- Load providers from `/api/external-memory/providers`.
+- Show a clear empty state when no providers are configured.
+- For a selected provider, show:
+  - pending candidates
+  - approved rows
+  - text search results
+- Allow review actions:
+  - edit before approval
+  - approve
+  - reject
+  - delete local row
+- Render common metadata:
+  - state
+  - type
+  - confidence
+  - source
+  - rationale
+  - optional indexing point id
+
+## Non-goals
+- No hardcoded provider name or built-in backend assumption.
+- No hardcoded endpoint, model, collection, IP address, hostname, or private infrastructure.
+- No automatic integration with existing memory plugins unless they explicitly register a review queue.
+
+## UX contract
+- The UI remains generic and provider-neutral.
+- If no providers are registered, the panel explains how to register one via `external_memory_providers.json`.
+- Provider-specific semantics live in provider metadata/config; the review panel only renders the common candidate shape.
+- A semantic sentence guidance block is displayed to help normalize knowledge before approval.

--- a/tests/test_external_memory_api.py
+++ b/tests/test_external_memory_api.py
@@ -1,0 +1,334 @@
+from __future__ import annotations
+
+import io
+import json
+import sqlite3
+from pathlib import Path
+from urllib.parse import urlparse
+from unittest.mock import patch
+
+from api import external_memory
+from api import routes
+
+
+class _FakeHandler:
+    def __init__(self, body: bytes = b""):
+        self.rfile = io.BytesIO(body)
+        self.wfile = io.BytesIO()
+        self.headers = {"Content-Length": str(len(body))}
+        self.status = None
+        self.sent_headers = {}
+
+    def send_response(self, status):
+        self.status = status
+
+    def send_header(self, key, value):
+        self.sent_headers[key] = value
+
+    def end_headers(self):
+        pass
+
+    def payload(self):
+        return json.loads(self.wfile.getvalue().decode("utf-8"))
+
+
+def _register_provider(home: Path, *, provider_id: str = "custom_store", label: str = "Custom Store", db_name: str = "items.sqlite", config: dict | None = None) -> Path:
+    db = home / provider_id / db_name
+    cfg_path = home / provider_id / "config.json"
+    providers = {
+        "providers": [
+            {
+                "id": provider_id,
+                "label": label,
+                "db_path": str(db),
+                "config_path": str(cfg_path),
+            }
+        ]
+    }
+    (home / "external_memory_providers.json").write_text(json.dumps(providers), encoding="utf-8")
+    if config is not None:
+        cfg_path.parent.mkdir(parents=True, exist_ok=True)
+        cfg_path.write_text(json.dumps(config), encoding="utf-8")
+    external_memory.ensure_db(db)
+    return db
+
+
+def _seed_candidate(
+    home: Path,
+    *,
+    provider_id: str = "custom_store",
+    candidate_id: str = "cand_test123",
+    text: str = "External Memory candidates require review before approval.",
+    state: str = "candidate",
+    created_at: float = 1000,
+) -> str:
+    db = _register_provider(home, provider_id=provider_id)
+    with sqlite3.connect(db) as con:
+        con.execute(
+            """
+            insert into candidates(id, text, source, metadata_json, state, content_sha256, created_at, updated_at)
+            values (?, ?, 'auto_capture', ?, ?, ?, ?, ?)
+            """,
+            (
+                candidate_id,
+                text,
+                json.dumps({"type": "decision", "confidence": 0.91}),
+                state,
+                f"sha-{candidate_id}",
+                created_at,
+                created_at,
+            ),
+        )
+    return candidate_id
+
+
+def test_list_providers_is_empty_until_custom_provider_is_registered(tmp_path):
+    data = external_memory.list_providers(tmp_path)
+
+    assert data == {"ok": True, "active": "", "providers": []}
+
+
+def test_custom_provider_can_be_registered_and_queried(tmp_path):
+    custom_db = _register_provider(tmp_path, provider_id="custom_store", label="Custom Store")
+    with sqlite3.connect(custom_db) as con:
+        con.execute(
+            """
+            insert into candidates(id, text, source, metadata_json, state, content_sha256, created_at, updated_at)
+            values ('custom_1', 'Custom external memory providers can expose reviewable candidates.', 'custom', '{}', 'candidate', 'sha', 1, 1)
+            """
+        )
+
+    providers = external_memory.list_providers(tmp_path)
+    data = external_memory.list_candidates(tmp_path, provider="custom_store", state="candidate")
+
+    assert providers["active"] == "custom_store"
+    assert any(p["id"] == "custom_store" for p in providers["providers"])
+    assert data["provider"] == "custom_store"
+    assert data["candidates"][0]["id"] == "custom_1"
+
+
+def test_missing_provider_raises_not_found(tmp_path):
+    try:
+        external_memory.list_candidates(tmp_path, state="all")
+        assert False, "unconfigured external memory should not pick an implicit provider"
+    except external_memory.ExternalMemoryNotFound as exc:
+        assert "no external memory providers configured" in str(exc)
+
+
+def test_list_candidates_reads_profile_scoped_db(tmp_path):
+    candidate_id = _seed_candidate(tmp_path)
+
+    data = external_memory.list_candidates(tmp_path, state="all", limit=10, offset=0)
+
+    assert data["ok"] is True
+    assert data["state"] == "all"
+    assert data["limit"] == 10
+    assert data["offset"] == 0
+    assert data["total"] == 1
+    assert data["count"] == 1
+    assert data["provider"] == "custom_store"
+    assert data["candidates"][0]["id"] == candidate_id
+    assert data["candidates"][0]["metadata"]["type"] == "decision"
+
+
+def test_list_candidates_filters_state_and_paginates(tmp_path):
+    _seed_candidate(tmp_path, candidate_id="cand_old", state="candidate", created_at=1000)
+    _seed_candidate(tmp_path, candidate_id="cand_new", state="candidate", created_at=2000)
+    _seed_candidate(tmp_path, candidate_id="approved", state="approved", created_at=3000)
+
+    data = external_memory.list_candidates(tmp_path, state="candidate", limit=1, offset=1)
+
+    assert data["ok"] is True
+    assert data["state"] == "candidate"
+    assert data["total"] == 2
+    assert data["count"] == 1
+    assert data["candidates"][0]["id"] == "cand_old"
+
+
+def test_reject_candidate_updates_state(tmp_path):
+    candidate_id = _seed_candidate(tmp_path)
+
+    data = external_memory.reject_candidate(tmp_path, candidate_id, reason="not durable")
+
+    assert data["ok"] is True
+    row = external_memory.get_candidate(tmp_path, candidate_id)
+    assert row["candidate"]["state"] == "rejected"
+    assert row["candidate"]["metadata"]["review_reason"] == "not durable"
+
+
+def test_delete_candidate_removes_row(tmp_path):
+    candidate_id = _seed_candidate(tmp_path)
+
+    data = external_memory.delete_candidate(tmp_path, candidate_id)
+
+    assert data["ok"] is True
+    assert data["provider"] == "custom_store"
+    assert external_memory.get_candidate(tmp_path, candidate_id)["candidate"] is None
+
+
+def test_update_candidate_text_edits_unapproved_candidate(tmp_path):
+    candidate_id = _seed_candidate(tmp_path)
+
+    data = external_memory.update_candidate_text(tmp_path, candidate_id, "External Memory candidates should be edited into canonical semantic statements before approval.")
+
+    assert data["ok"] is True
+    row = external_memory.get_candidate(tmp_path, candidate_id)["candidate"]
+    assert row["text"] == "External Memory candidates should be edited into canonical semantic statements before approval."
+    assert row["state"] == "candidate"
+    assert "edited_at" in row["metadata"]
+
+
+def test_update_candidate_text_rejects_approved_candidate(tmp_path):
+    candidate_id = _seed_candidate(tmp_path, state="approved")
+
+    try:
+        external_memory.update_candidate_text(tmp_path, candidate_id, "New text")
+        assert False, "approved external_memory should not be editable"
+    except ValueError as exc:
+        assert "approved external memory cannot be edited" in str(exc)
+
+
+def test_approve_candidate_indexes_then_marks_approved(tmp_path):
+    candidate_id = _seed_candidate(tmp_path)
+
+    with patch("api.external_memory.index_candidate", return_value={"point_id": "pt-1"}) as index:
+        data = external_memory.approve_candidate(tmp_path, candidate_id)
+
+    assert data["ok"] is True
+    index.assert_called_once()
+    row = external_memory.get_candidate(tmp_path, candidate_id)["candidate"]
+    assert row["state"] == "approved"
+    assert row["metadata"]["qdrant_point_id"] == "pt-1"
+    assert "approved_at" in row["metadata"]
+
+
+def test_approve_candidate_keeps_candidate_when_index_fails(tmp_path):
+    candidate_id = _seed_candidate(tmp_path)
+
+    with patch("api.external_memory.index_candidate", side_effect=external_memory.ExternalMemoryError("index down")):
+        try:
+            external_memory.approve_candidate(tmp_path, candidate_id)
+            assert False, "approval should fail when indexing fails"
+        except external_memory.ExternalMemoryError:
+            pass
+
+    row = external_memory.get_candidate(tmp_path, candidate_id)["candidate"]
+    assert row["state"] == "candidate"
+
+
+def test_approve_candidate_requires_explicit_indexing_config(tmp_path):
+    candidate_id = _seed_candidate(tmp_path)
+
+    try:
+        external_memory.approve_candidate(tmp_path, candidate_id)
+        assert False, "approval should fail when indexing is not configured"
+    except external_memory.ExternalMemoryNotConfigured as exc:
+        assert "external memory indexing is not configured" in str(exc)
+
+    row = external_memory.get_candidate(tmp_path, candidate_id)["candidate"]
+    assert row["state"] == "candidate"
+
+
+def test_load_config_reads_provider_config_and_env_without_defaults(tmp_path, monkeypatch):
+    _register_provider(tmp_path, config={"qdrant_collection": "fixture_collection"})
+    monkeypatch.setenv("HERMES_EXTERNAL_MEMORY_OLLAMA_URL", "http://127.0.0.1:11434")
+    monkeypatch.setenv("HERMES_EXTERNAL_MEMORY_QDRANT_URL", "http://127.0.0.1:6333")
+    monkeypatch.setenv("HERMES_EXTERNAL_MEMORY_EMBED_MODEL", "fixture-embed-model")
+
+    cfg = external_memory.load_config(tmp_path)
+
+    assert cfg["ollama_url"] == "http://127.0.0.1:11434"
+    assert cfg["qdrant_url"] == "http://127.0.0.1:6333"
+    assert cfg["embed_model"] == "fixture-embed-model"
+    assert cfg["qdrant_collection"] == "fixture_collection"
+
+
+def test_qdrant_upsert_uses_put_method():
+    cfg = {"qdrant_url": "http://127.0.0.1:6333", "qdrant_collection": "fixture_collection", "ollama_url": "http://127.0.0.1:11434", "embed_model": "fixture-embed-model", "timeout": 1}
+    with patch("api.external_memory._request_json", return_value={}) as req:
+        external_memory.qdrant_upsert(cfg, "00000000-0000-0000-0000-000000000001", [0.1], {"text": "x"})
+    assert req.call_args.kwargs["method"] == "PUT"
+
+
+def test_search_external_memory_uses_local_sqlite_like(tmp_path):
+    _seed_candidate(tmp_path, candidate_id="hit", text="Approved external memory fact about backend APIs", state="approved", created_at=1000)
+    _seed_candidate(tmp_path, candidate_id="miss", text="Unrelated local note", state="approved", created_at=2000)
+    data = external_memory.search_external_memory(tmp_path, "external memory fact", limit=3)
+
+    assert data["ok"] is True
+    assert data["q"] == "external memory fact"
+    assert data["count"] == 1
+    assert data["results"][0]["id"] == "hit"
+    assert data["results"][0]["text"] == "Approved external memory fact about backend APIs"
+
+
+def test_get_candidates_endpoint_uses_active_home_and_offset(tmp_path, monkeypatch):
+    _seed_candidate(tmp_path, candidate_id="old", state="candidate", created_at=1000)
+    _seed_candidate(tmp_path, candidate_id="new", state="candidate", created_at=2000)
+    monkeypatch.setattr(routes, "_active_hermes_home_for_external_memory", lambda: tmp_path)
+    handler = _FakeHandler()
+
+    routes.handle_get(handler, urlparse("/api/external-memory/candidates?state=candidate&limit=1&offset=1"))
+
+    payload = handler.payload()
+    assert handler.status == 200
+    assert payload["ok"] is True
+    assert payload["provider"] == "custom_store"
+    assert payload["candidates"][0]["id"] == "old"
+
+
+def test_delete_candidate_endpoint_removes_candidate(tmp_path, monkeypatch):
+    candidate_id = _seed_candidate(tmp_path)
+    monkeypatch.setattr(routes, "_active_hermes_home_for_external_memory", lambda: tmp_path)
+    handler = _FakeHandler()
+
+    handled = routes.handle_delete(handler, urlparse(f"/api/external-memory/candidates/{candidate_id}"))
+
+    assert handled is True
+    assert handler.status == 200
+    assert handler.payload() == {"ok": True, "provider": "custom_store", "deleted": candidate_id}
+    assert external_memory.get_candidate(tmp_path, candidate_id)["candidate"] is None
+
+
+def test_approve_endpoint_returns_400_when_indexing_is_not_configured(tmp_path, monkeypatch):
+    candidate_id = _seed_candidate(tmp_path)
+    monkeypatch.setattr(routes, "_active_hermes_home_for_external_memory", lambda: tmp_path)
+    handler = _FakeHandler(b"{}")
+
+    routes.handle_post(handler, urlparse(f"/api/external-memory/candidates/{candidate_id}/approve"))
+
+    assert handler.status == 400
+    assert "external memory indexing is not configured" in handler.payload()["error"]
+    assert external_memory.get_candidate(tmp_path, candidate_id)["candidate"]["state"] == "candidate"
+
+
+def test_approve_and_reject_candidate_endpoints_update_state(tmp_path, monkeypatch):
+    approve_id = _seed_candidate(tmp_path, candidate_id="cand_approve")
+    reject_id = _seed_candidate(tmp_path, candidate_id="cand_reject")
+    monkeypatch.setattr(routes, "_active_hermes_home_for_external_memory", lambda: tmp_path)
+
+    approve_handler = _FakeHandler(b"{}")
+    with patch("api.external_memory.index_candidate", return_value={"point_id": "pt-route"}):
+        routes.handle_post(approve_handler, urlparse(f"/api/external-memory/candidates/{approve_id}/approve"))
+    assert approve_handler.status == 200
+    assert approve_handler.payload()["candidate"]["state"] == "approved"
+
+    reject_handler = _FakeHandler(json.dumps({"reason": "not stable"}).encode("utf-8"))
+    routes.handle_post(reject_handler, urlparse(f"/api/external-memory/candidates/{reject_id}/reject"))
+    assert reject_handler.status == 200
+    payload = reject_handler.payload()
+    assert payload["candidate"]["state"] == "rejected"
+    assert payload["candidate"]["metadata"]["review_reason"] == "not stable"
+
+
+def test_edit_candidate_endpoint_updates_text(tmp_path, monkeypatch):
+    candidate_id = _seed_candidate(tmp_path)
+    monkeypatch.setattr(routes, "_active_hermes_home_for_external_memory", lambda: tmp_path)
+    handler = _FakeHandler(json.dumps({"text": "External Memory candidates should use semantic statements before approval."}).encode("utf-8"))
+
+    routes.handle_post(handler, urlparse(f"/api/external-memory/candidates/{candidate_id}/edit"))
+
+    assert handler.status == 200
+    payload = handler.payload()
+    assert payload["candidate"]["text"] == "External Memory candidates should use semantic statements before approval."
+    assert payload["candidate"]["metadata"]["edited_at"]

--- a/tests/test_external_memory_api.py
+++ b/tests/test_external_memory_api.py
@@ -191,7 +191,9 @@ def test_update_candidate_text_rejects_approved_candidate(tmp_path):
 def test_approve_candidate_indexes_then_marks_approved(tmp_path):
     candidate_id = _seed_candidate(tmp_path)
 
-    with patch("api.external_memory.index_candidate", return_value={"point_id": "pt-1"}) as index:
+    with patch("api.external_memory.check_write_policy", return_value={"ok": True, "stage": "policy"}), patch(
+        "api.external_memory.index_candidate", return_value={"point_id": "pt-1"}
+    ) as index:
         data = external_memory.approve_candidate(tmp_path, candidate_id)
 
     assert data["ok"] is True
@@ -227,6 +229,54 @@ def test_approve_candidate_requires_explicit_indexing_config(tmp_path):
 
     row = external_memory.get_candidate(tmp_path, candidate_id)["candidate"]
     assert row["state"] == "candidate"
+
+
+def test_policy_check_reports_missing_config_before_provider_io(tmp_path):
+    _seed_candidate(tmp_path)
+
+    try:
+        external_memory.check_write_policy(tmp_path)
+        assert False, "write policy should fail before provider I/O when indexing is not configured"
+    except external_memory.ExternalMemoryNotConfigured as exc:
+        error = exc.to_response()
+
+    assert error == {
+        "ok": False,
+        "stage": "policy",
+        "code": "indexing_not_configured",
+        "message": "external memory indexing is not configured; missing ollama_url, embed_model, qdrant_url, qdrant_collection",
+        "retryable": True,
+    }
+
+
+def test_index_candidate_requires_verified_active_qdrant_payload(tmp_path):
+    _register_provider(
+        tmp_path,
+        config={
+            "ollama_url": "http://127.0.0.1:11434",
+            "embed_model": "fixture-embed-model",
+            "qdrant_url": "http://127.0.0.1:6333",
+            "qdrant_collection": "fixture_collection",
+        },
+    )
+    candidate = {
+        "provider": "custom_store",
+        "id": "cand_verify",
+        "text": "External Memory approval requires verified active indexing.",
+        "source": "auto_capture",
+        "metadata": {},
+    }
+
+    with patch("api.external_memory.embed_text", return_value=[0.1]), patch("api.external_memory.qdrant_upsert"), patch(
+        "api.external_memory.qdrant_verify_active", return_value=False
+    ):
+        try:
+            external_memory.index_candidate(tmp_path, candidate)
+            assert False, "indexing should fail when active Qdrant payload cannot be verified"
+        except external_memory.ExternalMemoryError as exc:
+            assert exc.stage == "persistence"
+            assert exc.code == "indexing_failed"
+            assert exc.retryable is True
 
 
 def test_load_config_reads_provider_config_and_env_without_defaults(tmp_path, monkeypatch):
@@ -298,7 +348,37 @@ def test_approve_endpoint_returns_400_when_indexing_is_not_configured(tmp_path, 
     routes.handle_post(handler, urlparse(f"/api/external-memory/candidates/{candidate_id}/approve"))
 
     assert handler.status == 400
-    assert "external memory indexing is not configured" in handler.payload()["error"]
+    payload = handler.payload()
+    assert payload["ok"] is False
+    assert payload["stage"] == "policy"
+    assert payload["code"] == "indexing_not_configured"
+    assert "external memory indexing is not configured" in payload["message"]
+    assert payload["retryable"] is True
+    assert external_memory.get_candidate(tmp_path, candidate_id)["candidate"]["state"] == "candidate"
+
+
+def test_approve_endpoint_returns_structured_persistence_error(tmp_path, monkeypatch):
+    candidate_id = _seed_candidate(tmp_path)
+    monkeypatch.setattr(routes, "_active_hermes_home_for_external_memory", lambda: tmp_path)
+    handler = _FakeHandler(b"{}")
+
+    with patch("api.external_memory.check_write_policy", return_value={"ok": True, "stage": "policy"}), patch(
+        "api.external_memory.index_candidate",
+        side_effect=external_memory.ExternalMemoryError(
+            "external memory indexing did not verify an active persisted record",
+            stage="persistence",
+            code="indexing_failed",
+            retryable=True,
+        ),
+    ):
+        routes.handle_post(handler, urlparse(f"/api/external-memory/candidates/{candidate_id}/approve"))
+
+    assert handler.status == 502
+    payload = handler.payload()
+    assert payload["ok"] is False
+    assert payload["stage"] == "persistence"
+    assert payload["code"] == "indexing_failed"
+    assert payload["retryable"] is True
     assert external_memory.get_candidate(tmp_path, candidate_id)["candidate"]["state"] == "candidate"
 
 
@@ -308,7 +388,9 @@ def test_approve_and_reject_candidate_endpoints_update_state(tmp_path, monkeypat
     monkeypatch.setattr(routes, "_active_hermes_home_for_external_memory", lambda: tmp_path)
 
     approve_handler = _FakeHandler(b"{}")
-    with patch("api.external_memory.index_candidate", return_value={"point_id": "pt-route"}):
+    with patch("api.external_memory.check_write_policy", return_value={"ok": True, "stage": "policy"}), patch(
+        "api.external_memory.index_candidate", return_value={"point_id": "pt-route"}
+    ):
         routes.handle_post(approve_handler, urlparse(f"/api/external-memory/candidates/{approve_id}/approve"))
     assert approve_handler.status == 200
     assert approve_handler.payload()["candidate"]["state"] == "approved"

--- a/tests/test_external_memory_review_ui.py
+++ b/tests/test_external_memory_review_ui.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import pathlib
+
+REPO = pathlib.Path(__file__).parent.parent
+PANELS_JS = (REPO / "static" / "panels.js").read_text(encoding="utf-8")
+
+
+def test_memory_panel_includes_external_memory_section():
+    assert "key: 'external_memory'" in PANELS_JS
+    assert "External Memory" in PANELS_JS
+    assert "loadExternalMemoryReview(true)" in PANELS_JS
+
+
+def test_external_memory_review_ui_uses_backend_endpoints():
+    assert "/api/external-memory/providers" in PANELS_JS
+    assert "/api/external-memory/candidates?" in PANELS_JS
+    assert "state=candidate" in PANELS_JS
+    assert "state=approved" in PANELS_JS
+    assert "/api/external-memory/search?provider=" in PANELS_JS
+    assert "/api/external-memory/candidates/${encodeURIComponent(id)}/approve" in PANELS_JS
+    assert "/api/external-memory/candidates/${encodeURIComponent(id)}/reject" in PANELS_JS
+    assert "/api/external-memory/candidates/${encodeURIComponent(id)}/edit" in PANELS_JS
+
+
+def test_external_memory_review_ui_exposes_review_actions_and_metadata():
+    for text in ["Candidates (", "Approved (", "Search results (", "Edit", "Approve", "Reject", "Delete"]:
+        assert text in PANELS_JS
+    assert "qdrant_point_id" in PANELS_JS
+    assert "confidence" in PANELS_JS
+
+
+def test_external_memory_review_ui_fetches_max_review_page_to_avoid_hidden_candidates():
+    assert "state=candidate&limit=500" in PANELS_JS
+    assert "state=approved&limit=500" in PANELS_JS
+
+
+def test_external_memory_review_ui_uses_api_totals_for_section_counts():
+    assert "candidateTotal" in PANELS_JS
+    assert "approvedTotal" in PANELS_JS
+    assert "Candidates (${candidateTotal})" in PANELS_JS
+    assert "Approved (${approvedTotal})" in PANELS_JS
+    assert "Showing ${candidates.length} of ${candidateTotal} pending candidates." in PANELS_JS
+
+
+def test_external_memory_review_ui_uses_scrollable_review_lists():
+    assert "externalMemoryCandidateList" in PANELS_JS
+    assert "externalMemoryApprovedList" in PANELS_JS
+    assert "overflow-y:auto" in PANELS_JS
+    assert "max-height:55vh" in PANELS_JS
+
+
+def test_external_memory_review_ui_shows_empty_state_without_builtin_provider():
+    assert "No external memory providers configured yet" in PANELS_JS
+    assert "external_memory_providers.json" in PANELS_JS
+    assert "No providers configured" in PANELS_JS
+
+
+def test_external_memory_review_ui_shows_semantic_format_guidance():
+    assert "Semantic format" in PANELS_JS
+    assert "&lt;Scope/Subject&gt; &lt;durable relation&gt; &lt;object/behavior&gt;" in PANELS_JS
+    assert "one standalone sentence" in PANELS_JS


### PR DESCRIPTION
## Summary

Adds a generic **External Memory Approval Queue** surface to the WebUI Memory panel.

This is intentionally provider-neutral. WebUI ships no provider-specific backend, endpoint, hostname, model, collection, or built-in memory provider. Users opt in by registering a custom SQLite-backed approval queue in `external_memory_providers.json`.

Tracking issue: #1980

## What changed

- Adds `api/external_memory.py` as a generic backend helper for external memory approval queues.
- Adds `/api/external-memory/*` routes for:
  - provider discovery
  - candidate listing
  - candidate search
  - edit before approval
  - approve / reject / delete actions
- Adds an `External Memory` section under the existing Memory panel.
- Shows a clear empty state when no providers are configured.
- Keeps approval fail-closed: if indexing config is missing or indexing fails, the candidate remains unchanged.
- Keeps existing My Notes / User Profile memory editing unchanged.

## Provider contract

A provider can appear in the UI when it is explicitly registered from the active Hermes home:

```json
{
  "providers": [
    {
      "id": "custom_store",
      "label": "Custom Store",
      "db_path": "custom_memory/items.sqlite",
      "config_path": "custom_memory/config.json"
    }
  ]
}
```

The provider database exposes this SQLite table:

```sql
candidates(
  id text primary key,
  text text not null,
  source text not null default 'agent',
  metadata_json text not null default '{}',
  state text not null default 'candidate',
  content_sha256 text not null,
  created_at real not null,
  updated_at real not null
)
```

Optional indexing settings must come from provider config or environment variables. If they are absent, approval returns a clear not-configured error instead of using defaults.

## Tests

```bash
python -m pytest tests/test_external_memory_api.py tests/test_external_memory_review_ui.py -q
# 25 passed
```
