### PR TITLE
fix(kanban): guard dispatcher actions while in-flight

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -160,8 +160,8 @@
         <div id="kanbanBulkBar" class="kanban-bulk-bar">
           <select id="kanbanBulkStatus" aria-label="Bulk status"><option value="">Status</option><option value="ready">Ready</option><option value="blocked">Blocked</option><option value="done">Done</option><option value="archived">Archived</option></select>
           <button class="btn secondary" onclick="bulkUpdateKanban()" data-i18n="kanban_bulk_action">Bulk action</button>
-          <button class="btn secondary" onclick="nudgeKanbanDispatcher()" data-i18n="kanban_nudge_dispatcher" title="Dry-run: shows what would be claimed without spawning workers">Preview</button>
-          <button class="btn primary" onclick="runKanbanDispatcher()" data-i18n="kanban_run_dispatcher" title="Claims Ready tasks and spawns worker subprocesses">Run dispatcher</button>
+          <button class="btn secondary kanban-nudge-dispatch-btn" onclick="nudgeKanbanDispatcher()" data-i18n="kanban_nudge_dispatcher" title="Dry-run: shows what would be claimed without spawning workers">Preview</button>
+          <button class="btn primary kanban-run-dispatch-btn" onclick="runKanbanDispatcher()" data-i18n="kanban_run_dispatcher" title="Claims Ready tasks and spawns worker subprocesses">Run dispatcher</button>
         </div>
         <div class="kanban-new-task-row">
           <input id="kanbanNewTaskTitle" placeholder="New task" data-i18n-placeholder="kanban_new_task" onkeydown="if(event.key==='Enter')createKanbanTask()">
@@ -719,7 +719,7 @@
         </div>
         <div class="main-view-actions">
           <button class="panel-head-btn has-tooltip has-tooltip--bottom" id="btnKanbanCreateBoard" onclick="openKanbanCreateBoard()" data-tooltip="New board" data-i18n-title="kanban_new_board" aria-label="New board"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><line x1="17.5" y1="14" x2="17.5" y2="21"/><line x1="14" y1="17.5" x2="21" y2="17.5"/></svg></button>
-          <button class="panel-head-btn has-tooltip has-tooltip--bottom" id="btnKanbanPreviewDispatcher" onclick="nudgeKanbanDispatcher()" data-tooltip="Preview dispatcher (dry-run)" data-i18n-title="kanban_nudge_dispatcher" aria-label="Preview dispatcher (dry-run)">▶</button>
+          <button class="panel-head-btn has-tooltip has-tooltip--bottom kanban-nudge-dispatch-btn" id="btnKanbanPreviewDispatcher" onclick="nudgeKanbanDispatcher()" data-tooltip="Preview dispatcher (dry-run)" data-i18n-title="kanban_nudge_dispatcher" aria-label="Preview dispatcher (dry-run)">▶</button>
           <button class="panel-head-btn has-tooltip has-tooltip--bottom kanban-run-dispatch-btn" id="btnKanbanRunDispatcher" onclick="runKanbanDispatcher()" data-tooltip="Run dispatcher — claim Ready tasks" data-i18n-title="kanban_run_dispatcher" aria-label="Run dispatcher"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M13 2L3 14h7l-1 8 10-12h-7l1-8z"/></svg></button>
         </div>
       </div>

--- a/static/panels.js
+++ b/static/panels.js
@@ -12,6 +12,7 @@ let _kanbanLanesByProfile = false;
 let _kanbanCurrentBoard = null;
 let _kanbanBoardsList = null;
 let _kanbanBoardMenuOpen = false;
+let _kanbanIsDispatching = false;
 // SSE event stream — replaces the 30s polling cadence with a long-lived
 // /api/kanban/events/stream connection. Falls back to polling when the
 // EventSource fails to connect (proxy that strips text/event-stream, etc).
@@ -1424,11 +1425,14 @@ function _kanbanBoardQuery(extra){
 }
 
 async function nudgeKanbanDispatcher(){
+  if (_kanbanIsDispatching) return;
   // Dry-run dispatch: show what WOULD be spawned, without actually spawning
   // workers.  Uses ?dry_run=1 so the dispatcher reports its plan without
   // mutating the board.  The result shape includes spawned/skipped_unassigned/
   // skipped_nonspawnable/promoted/auto_blocked so users can diagnose why a
   // Ready task isn't being picked up before they commit to a real run.
+  _kanbanIsDispatching = true;
+  _setKanbanDispatcherButtonsDisabled(true);
   try {
     const dispatchEndpoint = '/api/kanban/dispatch';
     const result = await api(
@@ -1437,10 +1441,16 @@ async function nudgeKanbanDispatcher(){
     );
     showToast(_kanbanFormatDispatchResult(result, true), 'info', 6000);
     await loadKanban(true);
-  } catch(e) { showToast(t('kanban_unavailable') + ': ' + (e.message || e), 'error'); }
+  } catch(e) {
+    showToast(t('kanban_unavailable') + ': ' + (e.message || e), 'error');
+  } finally {
+    _kanbanIsDispatching = false;
+    _setKanbanDispatcherButtonsDisabled(false);
+  }
 }
 
 async function runKanbanDispatcher(){
+  if (_kanbanIsDispatching) return;
   // Real dispatch: claims Ready tasks and spawns worker subprocesses
   // (one `hermes -p <assignee>` per claimed row, up to max=8 per call).
   // Confirmation dialog first because this actually consumes API budget on
@@ -1450,14 +1460,17 @@ async function runKanbanDispatcher(){
     showToast(t('kanban_unavailable') || 'Kanban unavailable', 'error');
     return;
   }
-  const ok = await showConfirmDialog({
-    title: t('kanban_run_dispatcher') || 'Run dispatcher',
-    message: t('kanban_run_dispatcher_confirm')
-      || 'This will claim Ready tasks on this board and spawn worker subprocesses (one per task, up to 8 per click). Continue?',
-    confirmLabel: t('kanban_run_dispatcher') || 'Run dispatcher',
-  });
-  if (!ok) return;
+
+  _kanbanIsDispatching = true;
+  _setKanbanDispatcherButtonsDisabled(true);
   try {
+    const ok = await showConfirmDialog({
+      title: t('kanban_run_dispatcher') || 'Run dispatcher',
+      message: t('kanban_run_dispatcher_confirm')
+        || 'This will claim Ready tasks on this board and spawn worker subprocesses (one per task, up to 8 per click). Continue?',
+      confirmLabel: t('kanban_run_dispatcher') || 'Run dispatcher',
+    });
+    if (!ok) return;
     const dispatchEndpoint = '/api/kanban/dispatch';
     const result = await api(
       dispatchEndpoint + '?max=8' + (_kanbanCurrentBoard ? '&board=' + encodeURIComponent(_kanbanCurrentBoard) : ''),
@@ -1465,7 +1478,19 @@ async function runKanbanDispatcher(){
     );
     showToast(_kanbanFormatDispatchResult(result, false), 'info', 8000);
     await loadKanban(true);
-  } catch(e) { showToast(t('kanban_unavailable') + ': ' + (e.message || e), 'error'); }
+  } catch(e) {
+    showToast(t('kanban_unavailable') + ': ' + (e.message || e), 'error');
+  } finally {
+    _kanbanIsDispatching = false;
+    _setKanbanDispatcherButtonsDisabled(false);
+  }
+}
+
+function _setKanbanDispatcherButtonsDisabled(disabled){
+  document.querySelectorAll('.kanban-run-dispatch-btn, .kanban-nudge-dispatch-btn').forEach((btn) => {
+    btn.disabled = !!disabled;
+    btn.classList.toggle('disabled', !!disabled);
+  });
 }
 
 function _kanbanFormatDispatchResult(result, dryRun){

--- a/tests/test_kanban_ui_static.py
+++ b/tests/test_kanban_ui_static.py
@@ -413,6 +413,38 @@ def test_kanban_run_dispatcher_button_exists_and_is_distinct_from_preview():
         assert token in fmt_body, f"dispatch summary missing field: {token}"
 
 
+def test_kanban_dispatcher_inflight_guard_prevents_double_click_toast_confusion():
+    """Guard against concurrent dispatch invocations in both nudge and real run paths."""
+    assert "let _kanbanIsDispatching = false;" in PANELS
+    assert "function _setKanbanDispatcherButtonsDisabled" in PANELS
+
+    run_match = re.search(r"async function runKanbanDispatcher\(\)\{(.*?)\n\}", PANELS, re.DOTALL)
+    assert run_match, "runKanbanDispatcher() not found"
+    run_body = run_match.group(1)
+    assert "_kanbanIsDispatching" in run_body, (
+        "runKanbanDispatcher() must check or set _kanbanIsDispatching to block concurrent execution."
+    )
+    assert "finally" in run_body, "runKanbanDispatcher() must always clear _kanbanIsDispatching in finally."
+    assert "_setKanbanDispatcherButtonsDisabled(true)" in run_body, (
+        "runKanbanDispatcher() should disable both dispatcher buttons while posting."
+    )
+    assert "_setKanbanDispatcherButtonsDisabled(false)" in run_body, (
+        "runKanbanDispatcher() should re-enable dispatcher buttons when done."
+    )
+
+    nudge_match = re.search(r"async function nudgeKanbanDispatcher\(\)\{(.*?)\n\}", PANELS, re.DOTALL)
+    assert nudge_match, "nudgeKanbanDispatcher() not found"
+    nudge_body = nudge_match.group(1)
+    assert "_kanbanIsDispatching" in nudge_body, (
+        "nudgeKanbanDispatcher() should also respect the dispatch in-flight guard."
+    )
+    assert "finally" in nudge_body, "nudgeKanbanDispatcher() should always clear guard in finally."
+
+    assert 'kanban-run-dispatch-btn' in INDEX
+    assert 'kanban-nudge-dispatch-btn' in INDEX
+    assert 'btnKanbanRunDispatcher' in INDEX
+    assert 'btnKanbanPreviewDispatcher' in INDEX
+
 
 def test_kanban_board_has_native_css_classes():
     for selector in (


### PR DESCRIPTION
## What Changed
- Add `_kanbanIsDispatching` guard around `runKanbanDispatcher()` and `nudgeKanbanDispatcher()` in `static/panels.js`.
- Disable both Run/Preview dispatcher buttons while a dispatch call is in-flight to prevent duplicate toasts and accidental duplicate API posts.
- Re-enable buttons in `finally` so UI always recovers even on errors.
- Add CSS-hooked classes (`kanban-run-dispatch-btn`, `kanban-nudge-dispatch-btn`) to both bulk-bar and header dispatch controls for deterministic selection.
- Add regression test in `tests/test_kanban_ui_static.py` validating in-flight guard and button disabling behavior.

## Why
Issue #1984 reports cosmetic but confusing UX when rapid clicking dispatch buttons can trigger duplicate toasts (and redundant calls). This keeps dispatch paths idempotent from a UI perspective.

## Verification
- `node --check static/panels.js`
- `.venv_test/bin/python -m pytest -q tests/test_kanban_ui_static.py`
- `.venv_test/bin/python -m pytest -q tests/test_kanban_bridge.py::test_patch_status_running_is_rejected_to_protect_dispatcher_contract tests/test_kanban_bridge.py::test_patch_status_done_to_running_is_rejected`
