### PR TITLE
fix(lint): apply ruff auto-fixes and formatting to Python source files

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -55,6 +55,7 @@ def _load_repo_dotenv() -> None:
                 os.environ[k] = v
     except Exception as exc:
         import sys as _sys
+
         print(f"[bootstrap] Warning: could not load .env — {exc}", file=_sys.stderr)
 
 
@@ -154,7 +155,12 @@ def discover_launcher_python(agent_dir: Path | None) -> str:
     if env_python:
         return env_python
     if agent_dir:
-        for rel in ("venv/bin/python", "venv/Scripts/python.exe", ".venv/bin/python", ".venv/Scripts/python.exe"):
+        for rel in (
+            "venv/bin/python",
+            "venv/Scripts/python.exe",
+            ".venv/bin/python",
+            ".venv/Scripts/python.exe",
+        ):
             candidate = agent_dir / rel
             if candidate.exists():
                 return str(candidate)
@@ -165,7 +171,9 @@ def discover_launcher_python(agent_dir: Path | None) -> str:
     return shutil.which("python3") or shutil.which("python") or sys.executable
 
 
-def _python_can_run_webui_and_agent(python_exe: str, agent_dir: Path | None = None) -> bool:
+def _python_can_run_webui_and_agent(
+    python_exe: str, agent_dir: Path | None = None
+) -> bool:
     script = "import yaml\nfrom run_agent import AIAgent\n"
     env = os.environ.copy()
     if agent_dir:
@@ -394,7 +402,9 @@ def main() -> int:
         install_hermes_agent()
         agent_dir = discover_agent_dir()
 
-    python_exe = ensure_python_has_webui_deps(discover_launcher_python(agent_dir), agent_dir)
+    python_exe = ensure_python_has_webui_deps(
+        discover_launcher_python(agent_dir), agent_dir
+    )
     state_dir = Path(
         os.getenv("HERMES_WEBUI_STATE_DIR", str(Path.home() / ".hermes" / "webui"))
     ).expanduser()

--- a/server.py
+++ b/server.py
@@ -3,6 +3,7 @@ Hermes Web UI -- Main server entry point.
 Thin routing shell: imports Handler, delegates to api/routes.py, runs server.
 All business logic lives in api/*.
 """
+
 import logging
 import socket
 import sys
@@ -29,12 +30,13 @@ from api.updates import WEBUI_VERSION
 
 class QuietHTTPServer(ThreadingHTTPServer):
     """Custom HTTP server that silently handles common network errors."""
+
     daemon_threads = True
     request_queue_size = 64
 
     def __init__(self, *args, **kwargs):
-        server_address = args[0] if args else kwargs.get('server_address', None)
-        if server_address and ':' in server_address[0]:
+        server_address = args[0] if args else kwargs.get("server_address", None)
+        if server_address and ":" in server_address[0]:
             self.address_family = socket.AF_INET6
         super().__init__(*args, **kwargs)
         self.accept_loop_requests_total = 0
@@ -56,29 +58,41 @@ class QuietHTTPServer(ThreadingHTTPServer):
         self.accept_loop_requests_total += 1
         self.accept_loop_last_request_at = time.time()
         return super()._handle_request_noblock()
-    
+
     def handle_error(self, request, client_address):
         """Override to suppress logging for common client disconnect errors."""
         exc_type, exc_value, _ = sys.exc_info()
-        
+
         # Silently ignore common connection errors caused by client disconnects
-        if exc_type in (ConnectionResetError, BrokenPipeError, ConnectionAbortedError, TimeoutError):
+        if exc_type in (
+            ConnectionResetError,
+            BrokenPipeError,
+            ConnectionAbortedError,
+            TimeoutError,
+        ):
             return
-        
+
         # Also handle socket errors that indicate client disconnect
         if issubclass(exc_type, OSError):
             # errno 54 is Connection reset by peer on macOS/BSD
             # errno 104 is Connection reset by peer on Linux
-            if getattr(exc_value, 'errno', None) in (32, 54, 104, 110):  # EPIPE, ECONNRESET, ETIMEDOUT
+            if getattr(exc_value, "errno", None) in (
+                32,
+                54,
+                104,
+                110,
+            ):  # EPIPE, ECONNRESET, ETIMEDOUT
                 return
-        
+
         # For other errors, use default logging
         super().handle_error(request, client_address)
 
 
 class Handler(BaseHTTPRequestHandler):
-    timeout = 30  # seconds — kills idle/incomplete connections to prevent thread exhaustion
-    
+    timeout = (
+        30  # seconds — kills idle/incomplete connections to prevent thread exhaustion
+    )
+
     def setup(self):
         """Set socket options for each accepted connection."""
         super().setup()
@@ -93,34 +107,44 @@ class Handler(BaseHTTPRequestHandler):
         except OSError:
             pass
         # Per-platform timing parameters
-        if hasattr(socket, 'TCP_KEEPIDLE'):  # Linux
+        if hasattr(socket, "TCP_KEEPIDLE"):  # Linux
             try:
                 self.connection.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 10)
                 self.connection.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, 5)
                 self.connection.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPCNT, 3)
             except OSError:
                 pass
-        elif hasattr(socket, 'TCP_KEEPALIVE'):  # macOS
+        elif hasattr(socket, "TCP_KEEPALIVE"):  # macOS
             try:
                 self.connection.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPALIVE, 10)
             except OSError:
                 pass
-    _ver_suffix = WEBUI_VERSION.removeprefix('v')
-    server_version = ('HermesWebUI/' + _ver_suffix) if _ver_suffix != 'unknown' else 'HermesWebUI'
-    def log_message(self, fmt, *args): pass  # suppress default Apache-style log
 
-    def log_request(self, code: str='-', size: str='-') -> None:
+    _ver_suffix = WEBUI_VERSION.removeprefix("v")
+    server_version = (
+        ("HermesWebUI/" + _ver_suffix) if _ver_suffix != "unknown" else "HermesWebUI"
+    )
+
+    def log_message(self, fmt, *args):
+        pass  # suppress default Apache-style log
+
+    def log_request(self, code: str = "-", size: str = "-") -> None:
         """Structured JSON logs for each request."""
         import json as _json
-        duration_ms = round((time.time() - getattr(self, '_req_t0', time.time())) * 1000, 1)
-        record = _json.dumps({
-            'ts': time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime()),
-            'method': self.command or '-',
-            'path': self.path or '-',
-            'status': int(code) if str(code).isdigit() else code,
-            'ms': duration_ms,
-        })
-        print(f'[webui] {record}', flush=True)
+
+        duration_ms = round(
+            (time.time() - getattr(self, "_req_t0", time.time())) * 1000, 1
+        )
+        record = _json.dumps(
+            {
+                "ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+                "method": self.command or "-",
+                "path": self.path or "-",
+                "status": int(code) if str(code).isdigit() else code,
+                "ms": duration_ms,
+            }
+        )
+        print(f"[webui] {record}", flush=True)
 
     def do_GET(self) -> None:
         self._req_t0 = time.time()
@@ -130,13 +154,17 @@ class Handler(BaseHTTPRequestHandler):
             set_request_profile(cookie_profile)
         try:
             parsed = urlparse(self.path)
-            if not check_auth(self, parsed): return
+            if not check_auth(self, parsed):
+                return
             result = handle_get(self, parsed)
             if result is False:
-                return j(self, {'error': 'not found'}, status=404)
-        except Exception as e:
-            print(f'[webui] ERROR {self.command} {self.path}\n' + traceback.format_exc(), flush=True)
-            return j(self, {'error': 'Internal server error'}, status=500)
+                return j(self, {"error": "not found"}, status=404)
+        except Exception:
+            print(
+                f"[webui] ERROR {self.command} {self.path}\n" + traceback.format_exc(),
+                flush=True,
+            )
+            return j(self, {"error": "Internal server error"}, status=500)
         finally:
             clear_request_profile()
 
@@ -148,13 +176,17 @@ class Handler(BaseHTTPRequestHandler):
             set_request_profile(cookie_profile)
         try:
             parsed = urlparse(self.path)
-            if not check_auth(self, parsed): return
+            if not check_auth(self, parsed):
+                return
             result = route_func(self, parsed)
             if result is False:
-                return j(self, {'error': 'not found'}, status=404)
-        except Exception as e:
-            print(f'[webui] ERROR {self.command} {self.path}\n' + traceback.format_exc(), flush=True)
-            return j(self, {'error': 'Internal server error'}, status=500)
+                return j(self, {"error": "not found"}, status=404)
+        except Exception:
+            print(
+                f"[webui] ERROR {self.command} {self.path}\n" + traceback.format_exc(),
+                flush=True,
+            )
+            return j(self, {"error": "Internal server error"}, status=500)
         finally:
             clear_request_profile()
 
@@ -210,7 +242,10 @@ def main() -> None:
             flush=True,
         )
     elif fd_limit.get("status") == "error":
-        print(f"[!!] WARNING: Could not raise file descriptor limit: {fd_limit.get('error')}", flush=True)
+        print(
+            f"[!!] WARNING: Could not raise file descriptor limit: {fd_limit.get('error')}",
+            flush=True,
+        )
 
     # Fix sensitive file permissions before doing anything else
     fix_credential_permissions()
@@ -221,9 +256,13 @@ def main() -> None:
     # Safe to run unconditionally — a clean install is a no-op.
     try:
         from api.session_recovery import recover_all_sessions_on_startup
+
         result = recover_all_sessions_on_startup(SESSION_DIR)
         if result.get("restored"):
-            print(f"[recovery] Restored {result['restored']}/{result['scanned']} sessions from .bak (see #1558).", flush=True)
+            print(
+                f"[recovery] Restored {result['restored']}/{result['scanned']} sessions from .bak (see #1558).",
+                flush=True,
+            )
     except Exception as exc:
         # Recovery is best-effort; never block server startup.
         print(f"[recovery] startup recovery failed: {exc}", flush=True)
@@ -231,43 +270,65 @@ def main() -> None:
     within_container = False
     # Check for the "/.within_container" file to determine if we're running inside a container; this file is created in the Dockerfile
     try:
-        with open('/.within_container', 'r') as f:
+        with open("/.within_container", "r") as f:
             within_container = True
     except FileNotFoundError:
         pass
 
     if within_container:
-        print('[ok] Running within container.', flush=True)
+        print("[ok] Running within container.", flush=True)
 
     # Security: warn if binding non-loopback without authentication
     from api.auth import is_auth_enabled
-    if HOST not in ('127.0.0.1', '::1', 'localhost') and not is_auth_enabled():
-        print(f'[!!] WARNING: Binding to {HOST} with NO PASSWORD SET.', flush=True)
-        print(f'     Anyone on the network can access your filesystem and agent.', flush=True)
-        print(f'     Set a password via Settings or HERMES_WEBUI_PASSWORD env var.', flush=True)
-        print(f'     To suppress: bind to 127.0.0.1 or set a password.', flush=True)
+
+    if HOST not in ("127.0.0.1", "::1", "localhost") and not is_auth_enabled():
+        print(f"[!!] WARNING: Binding to {HOST} with NO PASSWORD SET.", flush=True)
+        print(
+            "     Anyone on the network can access your filesystem and agent.",
+            flush=True,
+        )
+        print(
+            "     Set a password via Settings or HERMES_WEBUI_PASSWORD env var.",
+            flush=True,
+        )
+        print("     To suppress: bind to 127.0.0.1 or set a password.", flush=True)
         if within_container:
-            print(f'     Note: You are running within a container, must bind to 0.0.0.0 (IPv4) or :: (IPv6) to publish the port.', flush=True)
+            print(
+                "     Note: You are running within a container, must bind to 0.0.0.0 (IPv4) or :: (IPv6) to publish the port.",
+                flush=True,
+            )
     elif not is_auth_enabled():
-        print(f'  [tip] No password set. Any process on this machine can read sessions', flush=True)
-        print(f'        and memory via the local API. Set HERMES_WEBUI_PASSWORD to', flush=True)
-        print(f'        enable authentication.', flush=True)
+        print(
+            "  [tip] No password set. Any process on this machine can read sessions",
+            flush=True,
+        )
+        print(
+            "        and memory via the local API. Set HERMES_WEBUI_PASSWORD to",
+            flush=True,
+        )
+        print("        enable authentication.", flush=True)
 
     ok, missing, errors = verify_hermes_imports()
     if not ok and _HERMES_FOUND:
-        print(f'[!!] Warning: Hermes agent found but missing modules: {missing}', flush=True)
+        print(
+            f"[!!] Warning: Hermes agent found but missing modules: {missing}",
+            flush=True,
+        )
         for mod, err in errors.items():
-            print(f'     {mod}: {err}', flush=True)
-        print('     Attempting to install missing dependencies from agent requirements.txt...', flush=True)
+            print(f"     {mod}: {err}", flush=True)
+        print(
+            "     Attempting to install missing dependencies from agent requirements.txt...",
+            flush=True,
+        )
         auto_install_agent_deps()
         ok, missing, errors = verify_hermes_imports()
         if not ok:
-            print(f'[!!] Still missing after install attempt: {missing}', flush=True)
+            print(f"[!!] Still missing after install attempt: {missing}", flush=True)
             for mod, err in errors.items():
-                print(f'     {mod}: {err}', flush=True)
-            print('     Agent features may not work correctly.', flush=True)
+                print(f"     {mod}: {err}", flush=True)
+            print("     Agent features may not work correctly.", flush=True)
         else:
-            print('[ok] Agent dependencies installed successfully.', flush=True)
+            print("[ok] Agent dependencies installed successfully.", flush=True)
 
     STATE_DIR.mkdir(parents=True, exist_ok=True)
     SESSION_DIR.mkdir(parents=True, exist_ok=True)
@@ -276,41 +337,52 @@ def main() -> None:
     # Start the gateway session watcher for real-time SSE updates
     try:
         from api.gateway_watcher import start_watcher
+
         start_watcher()
     except Exception as e:
-        print(f'[!!] WARNING: Gateway watcher failed to start: {e}', flush=True)
+        print(f"[!!] WARNING: Gateway watcher failed to start: {e}", flush=True)
 
     httpd = QuietHTTPServer((HOST, PORT), Handler)
 
     # ── TLS/HTTPS setup (optional) ─────────────────────────────────────────
     from api.config import TLS_ENABLED, TLS_CERT, TLS_KEY
-    scheme = 'https' if TLS_ENABLED else 'http'
+
+    scheme = "https" if TLS_ENABLED else "http"
     if TLS_ENABLED:
         try:
             import ssl
+
             ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
             ctx.minimum_version = ssl.TLSVersion.TLSv1_2
             ctx.load_cert_chain(TLS_CERT, TLS_KEY)
             httpd.socket = ctx.wrap_socket(httpd.socket, server_side=True)
-            print(f'  TLS enabled: cert={TLS_CERT}, key={TLS_KEY}', flush=True)
+            print(f"  TLS enabled: cert={TLS_CERT}, key={TLS_KEY}", flush=True)
         except Exception as e:
-            print(f'[!!] WARNING: TLS setup failed ({e}), falling back to HTTP', flush=True)
-            scheme = 'http'
+            print(
+                f"[!!] WARNING: TLS setup failed ({e}), falling back to HTTP",
+                flush=True,
+            )
+            scheme = "http"
 
-    print(f'  Hermes Web UI listening on {scheme}://{HOST}:{PORT}', flush=True)
-    if HOST in ('127.0.0.1', '::1') or within_container:
-        print(f'  Remote access: ssh -N -L {PORT}:127.0.0.1:{PORT} <user>@<your-server>', flush=True)
-    print(f'  Then open:     {scheme}://localhost:{PORT}', flush=True)
-    print('', flush=True)
+    print(f"  Hermes Web UI listening on {scheme}://{HOST}:{PORT}", flush=True)
+    if HOST in ("127.0.0.1", "::1") or within_container:
+        print(
+            f"  Remote access: ssh -N -L {PORT}:127.0.0.1:{PORT} <user>@<your-server>",
+            flush=True,
+        )
+    print(f"  Then open:     {scheme}://localhost:{PORT}", flush=True)
+    print("", flush=True)
     try:
         httpd.serve_forever()
     finally:
         # Stop the gateway watcher on shutdown
         try:
             from api.gateway_watcher import stop_watcher
+
             stop_watcher()
         except Exception:
             logger.debug("Failed to stop gateway watcher during shutdown")
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/server.py
+++ b/server.py
@@ -270,7 +270,7 @@ def main() -> None:
     within_container = False
     # Check for the "/.within_container" file to determine if we're running inside a container; this file is created in the Dockerfile
     try:
-        with open("/.within_container", "r") as f:
+        with open("/.within_container", "r"):
             within_container = True
     except FileNotFoundError:
         pass

--- a/tests/_pytest_port.py
+++ b/tests/_pytest_port.py
@@ -15,32 +15,40 @@ conftest.py publishes ``HERMES_WEBUI_TEST_PORT`` and
 correct values.  The auto-derivation fallback matches conftest's logic
 exactly, so standalone imports also work correctly.
 """
+
 import hashlib
 import os
 import pathlib
+
 
 def _auto_test_port(repo_root: pathlib.Path) -> int:
     h = int(hashlib.md5(str(repo_root).encode()).hexdigest(), 16)
     return 20000 + (h % 10000)
 
+
 def _auto_state_dir_name(repo_root: pathlib.Path) -> str:
     h = hashlib.md5(str(repo_root).encode()).hexdigest()[:8]
     return f"webui-test-{h}"
 
-_TESTS_DIR   = pathlib.Path(__file__).parent.resolve()
-_REPO_ROOT   = _TESTS_DIR.parent.resolve()
-_HERMES_HOME = pathlib.Path(os.getenv('HERMES_HOME',
-                             str(pathlib.Path.home() / '.hermes')))
 
-TEST_PORT = int(os.environ.get('HERMES_WEBUI_TEST_PORT',
-                               str(_auto_test_port(_REPO_ROOT))))
+_TESTS_DIR = pathlib.Path(__file__).parent.resolve()
+_REPO_ROOT = _TESTS_DIR.parent.resolve()
+_HERMES_HOME = pathlib.Path(
+    os.getenv("HERMES_HOME", str(pathlib.Path.home() / ".hermes"))
+)
+
+TEST_PORT = int(
+    os.environ.get("HERMES_WEBUI_TEST_PORT", str(_auto_test_port(_REPO_ROOT)))
+)
 BASE = f"http://127.0.0.1:{TEST_PORT}"
 
-TEST_STATE_DIR = pathlib.Path(os.environ.get(
-    'HERMES_WEBUI_TEST_STATE_DIR',
-    str(_HERMES_HOME / _auto_state_dir_name(_REPO_ROOT))
-))
+TEST_STATE_DIR = pathlib.Path(
+    os.environ.get(
+        "HERMES_WEBUI_TEST_STATE_DIR",
+        str(_HERMES_HOME / _auto_state_dir_name(_REPO_ROOT)),
+    )
+)
 
 # Default model injected by conftest — tests that mutate the default model
 # must restore to this value so later tests see a consistent baseline.
-TEST_DEFAULT_MODEL = os.environ.get('HERMES_WEBUI_DEFAULT_MODEL', 'openai/gpt-5.4-mini')
+TEST_DEFAULT_MODEL = os.environ.get("HERMES_WEBUI_DEFAULT_MODEL", "openai/gpt-5.4-mini")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ PATH DISCOVERY:
     3. Common install paths (~/.hermes/hermes-agent)
     4. System python3 as a last resort
 """
+
 import json
 import os
 import pathlib
@@ -25,37 +26,43 @@ import pytest
 
 # ── Repo root discovery ────────────────────────────────────────────────────
 # conftest.py lives at <repo>/tests/conftest.py
-TESTS_DIR  = pathlib.Path(__file__).parent.resolve()
-REPO_ROOT  = TESTS_DIR.parent.resolve()
-HOME       = pathlib.Path.home()
-HERMES_HOME = pathlib.Path(os.getenv('HERMES_HOME', str(HOME / '.hermes')))
+TESTS_DIR = pathlib.Path(__file__).parent.resolve()
+REPO_ROOT = TESTS_DIR.parent.resolve()
+HOME = pathlib.Path.home()
+HERMES_HOME = pathlib.Path(os.getenv("HERMES_HOME", str(HOME / ".hermes")))
 
 # ── Test server config ────────────────────────────────────────────────────
 # Port and state dir auto-derive from the repo path when no env var is set,
 # giving every worktree its own isolated port (8800-8899) and state directory.
 # Override with HERMES_WEBUI_TEST_PORT / HERMES_WEBUI_TEST_STATE_DIR to pin.
 
+
 def _auto_test_port(repo_root) -> int:
     """Map repo path to a unique port in 20000-29999 (10k range = near-zero collisions).
     Far from system port ranges and Linux ephemeral ports (32768+).
     Override with HERMES_WEBUI_TEST_PORT to use a specific port."""
     import hashlib
+
     h = int(hashlib.md5(str(repo_root).encode()).hexdigest(), 16)
     return 20000 + (h % 10000)
 
+
 def _auto_state_dir_name(repo_root) -> str:
     import hashlib
+
     h = hashlib.md5(str(repo_root).encode()).hexdigest()[:8]
     return f"webui-test-{h}"
 
-TEST_PORT      = int(os.getenv('HERMES_WEBUI_TEST_PORT',
-                               str(_auto_test_port(REPO_ROOT))))
-TEST_BASE      = f"http://127.0.0.1:{TEST_PORT}"
-TEST_STATE_DIR = pathlib.Path(os.getenv(
-    'HERMES_WEBUI_TEST_STATE_DIR',
-    str(HERMES_HOME / _auto_state_dir_name(REPO_ROOT))
-))
-TEST_WORKSPACE = TEST_STATE_DIR / 'test-workspace'
+
+TEST_PORT = int(os.getenv("HERMES_WEBUI_TEST_PORT", str(_auto_test_port(REPO_ROOT))))
+TEST_BASE = f"http://127.0.0.1:{TEST_PORT}"
+TEST_STATE_DIR = pathlib.Path(
+    os.getenv(
+        "HERMES_WEBUI_TEST_STATE_DIR",
+        str(HERMES_HOME / _auto_state_dir_name(REPO_ROOT)),
+    )
+)
+TEST_WORKSPACE = TEST_STATE_DIR / "test-workspace"
 
 # Publish at module level so api.config, _pytest_port.py, and any test module
 # importing stateful API code during collection see the isolated test paths.
@@ -63,57 +70,60 @@ TEST_WORKSPACE = TEST_STATE_DIR / 'test-workspace'
 # Direct assignment is intentional for production-risk paths: tests that import
 # api.config/api.models in the pytest process must never inherit the real
 # ~/.hermes state tree before the server subprocess fixture starts.
-os.environ['HERMES_WEBUI_TEST_PORT'] = str(TEST_PORT)
-os.environ['HERMES_WEBUI_TEST_STATE_DIR'] = str(TEST_STATE_DIR)
-os.environ['HERMES_WEBUI_STATE_DIR'] = str(TEST_STATE_DIR)
-os.environ['HERMES_WEBUI_DEFAULT_WORKSPACE'] = str(TEST_WORKSPACE)
-os.environ['HERMES_HOME'] = str(TEST_STATE_DIR)
-os.environ['HERMES_BASE_HOME'] = str(TEST_STATE_DIR)
+os.environ["HERMES_WEBUI_TEST_PORT"] = str(TEST_PORT)
+os.environ["HERMES_WEBUI_TEST_STATE_DIR"] = str(TEST_STATE_DIR)
+os.environ["HERMES_WEBUI_STATE_DIR"] = str(TEST_STATE_DIR)
+os.environ["HERMES_WEBUI_DEFAULT_WORKSPACE"] = str(TEST_WORKSPACE)
+os.environ["HERMES_HOME"] = str(TEST_STATE_DIR)
+os.environ["HERMES_BASE_HOME"] = str(TEST_STATE_DIR)
 # Hermes Agent sessions may inherit HERMES_CONFIG_PATH pointing at the live
 # ~/.hermes/config.yaml.  Override it before any product modules are imported so
 # tests that read/write config.yaml stay inside the isolated test home.
-os.environ['HERMES_CONFIG_PATH'] = str(TEST_STATE_DIR / 'config.yaml')
+os.environ["HERMES_CONFIG_PATH"] = str(TEST_STATE_DIR / "config.yaml")
 
 # ── Server script: always relative to repo root ───────────────────────────
-SERVER_SCRIPT = REPO_ROOT / 'server.py'
+SERVER_SCRIPT = REPO_ROOT / "server.py"
 if not SERVER_SCRIPT.exists():
     raise RuntimeError(
         f"server.py not found at {SERVER_SCRIPT}. "
         "Is conftest.py in the tests/ subdirectory of the repo?"
     )
 
+
 # ── Hermes agent discovery (mirrors api/config._discover_agent_dir) ───────
 def _discover_agent_dir() -> pathlib.Path:
     candidates = [
-        os.getenv('HERMES_WEBUI_AGENT_DIR', ''),
-        str(HERMES_HOME / 'hermes-agent'),
-        str(REPO_ROOT.parent / 'hermes-agent'),
-        str(HOME / '.hermes' / 'hermes-agent'),
-        str(HOME / 'hermes-agent'),
+        os.getenv("HERMES_WEBUI_AGENT_DIR", ""),
+        str(HERMES_HOME / "hermes-agent"),
+        str(REPO_ROOT.parent / "hermes-agent"),
+        str(HOME / ".hermes" / "hermes-agent"),
+        str(HOME / "hermes-agent"),
     ]
     for c in candidates:
         if not c:
             continue
         p = pathlib.Path(c).expanduser()
-        if p.exists() and (p / 'run_agent.py').exists():
+        if p.exists() and (p / "run_agent.py").exists():
             return p.resolve()
     return None
 
+
 # ── Python discovery (mirrors api/config._discover_python) ────────────────
 def _discover_python(agent_dir) -> str:
-    if os.getenv('HERMES_WEBUI_PYTHON'):
-        return os.getenv('HERMES_WEBUI_PYTHON')
+    if os.getenv("HERMES_WEBUI_PYTHON"):
+        return os.getenv("HERMES_WEBUI_PYTHON")
     if agent_dir:
-        venv_py = agent_dir / 'venv' / 'bin' / 'python'
+        venv_py = agent_dir / "venv" / "bin" / "python"
         if venv_py.exists():
             return str(venv_py)
-    local_venv = REPO_ROOT / '.venv' / 'bin' / 'python'
+    local_venv = REPO_ROOT / ".venv" / "bin" / "python"
     if local_venv.exists():
         return str(local_venv)
-    return shutil.which('python3') or shutil.which('python') or 'python3'
+    return shutil.which("python3") or shutil.which("python") or "python3"
+
 
 HERMES_AGENT = _discover_agent_dir()
-VENV_PYTHON  = _discover_python(HERMES_AGENT)
+VENV_PYTHON = _discover_python(HERMES_AGENT)
 
 # Work dir: agent dir if found, else repo root
 WORKDIR = str(HERMES_AGENT) if HERMES_AGENT else str(REPO_ROOT)
@@ -123,34 +133,43 @@ WORKDIR = str(HERMES_AGENT) if HERMES_AGENT else str(REPO_ROOT)
 # are skipped when the agent isn't installed, instead of failing with 500 errors.
 AGENT_AVAILABLE = HERMES_AGENT is not None
 
+
 def _check_agent_modules():
     """Verify hermes-agent Python modules are actually importable."""
     if not HERMES_AGENT:
         return False
     try:
         import importlib
+
         # These are the modules that cause 500 errors when missing
-        for mod in ['cron.jobs', 'tools.skills_tool']:
+        for mod in ["cron.jobs", "tools.skills_tool"]:
             importlib.import_module(mod)
         return True
     except (ImportError, ModuleNotFoundError):
         return False
 
+
 AGENT_MODULES_AVAILABLE = _check_agent_modules()
 
 # pytest marker: skip tests that need hermes-agent when it's not present
 requires_agent = pytest.mark.skipif(
-    not AGENT_AVAILABLE,
-    reason="hermes-agent not found (skipping agent-dependent test)"
+    not AGENT_AVAILABLE, reason="hermes-agent not found (skipping agent-dependent test)"
 )
 requires_agent_modules = pytest.mark.skipif(
     not AGENT_MODULES_AVAILABLE,
-    reason="hermes-agent Python modules not importable (cron, skills_tool)"
+    reason="hermes-agent Python modules not importable (cron, skills_tool)",
 )
 
+
 def pytest_configure(config):
-    config.addinivalue_line("markers", "requires_agent: skip when hermes-agent dir is not found")
-    config.addinivalue_line("markers", "requires_agent_modules: skip when hermes-agent Python modules are not importable")
+    config.addinivalue_line(
+        "markers", "requires_agent: skip when hermes-agent dir is not found"
+    )
+    config.addinivalue_line(
+        "markers",
+        "requires_agent_modules: skip when hermes-agent Python modules are not importable",
+    )
+
 
 def pytest_collection_modifyitems(config, items):
     """Auto-skip agent-dependent tests when hermes-agent is not available.
@@ -168,34 +187,34 @@ def pytest_collection_modifyitems(config, items):
     # or require a running agent backend — returning 500 without the agent.
     _AGENT_DEPENDENT_TESTS = {
         # Cron endpoints (need cron.jobs module)
-        'test_crons_list',
-        'test_crons_list_has_required_fields',
-        'test_crons_output_requires_job_id',
-        'test_crons_output_real_job',
-        'test_crons_run_nonexistent',
-        'test_cron_create_success',
-        'test_cron_update_unknown_job_404',
-        'test_cron_delete_unknown_404',
-        'test_crons_output_limit_param',
+        "test_crons_list",
+        "test_crons_list_has_required_fields",
+        "test_crons_output_requires_job_id",
+        "test_crons_output_real_job",
+        "test_crons_run_nonexistent",
+        "test_cron_create_success",
+        "test_cron_update_unknown_job_404",
+        "test_cron_delete_unknown_404",
+        "test_crons_output_limit_param",
         # Skills endpoints (need tools.skills_tool module)
-        'test_skills_list',
-        'test_skills_list_has_required_fields',
-        'test_skills_content_known',
-        'test_skills_content_requires_name',
-        'test_skills_search_returns_subset',
-        'test_skill_save_delete_roundtrip',
-        'test_skill_delete_unknown_404',
+        "test_skills_list",
+        "test_skills_list_has_required_fields",
+        "test_skills_content_known",
+        "test_skills_content_requires_name",
+        "test_skills_search_returns_subset",
+        "test_skill_save_delete_roundtrip",
+        "test_skill_delete_unknown_404",
         # Agent backend (need running AIAgent)
-        'test_chat_stream_opens_successfully',
-        'test_approval_submit_and_respond',
+        "test_chat_stream_opens_successfully",
+        "test_approval_submit_and_respond",
         # Security redaction (flaky — session state varies across test ordering)
-        'test_api_sessions_list_redacts_titles',
+        "test_api_sessions_list_redacts_titles",
         # Workspace path (macOS /tmp -> /private/tmp symlink)
-        'test_new_session_inherits_workspace',
-        'test_workspace_add_valid',
-        'test_workspace_rename',
-        'test_last_workspace_updates_on_session_update',
-        'test_new_session_inherits_last_workspace',
+        "test_new_session_inherits_workspace",
+        "test_workspace_add_valid",
+        "test_workspace_rename",
+        "test_last_workspace_updates_on_session_update",
+        "test_new_session_inherits_last_workspace",
     }
 
     skip_marker = pytest.mark.skip(reason="requires hermes-agent (not installed)")
@@ -207,10 +226,13 @@ def pytest_collection_modifyitems(config, items):
             skipped += 1
 
     if skipped:
-        print(f"\nWARNING: hermes-agent not found; {skipped} agent-dependent tests will be skipped\n")
+        print(
+            f"\nWARNING: hermes-agent not found; {skipped} agent-dependent tests will be skipped\n"
+        )
 
 
 # ── Helpers ──────────────────────────────────────────────────────────────────
+
 
 def _post(base, path, body=None):
     data = json.dumps(body or {}).encode()
@@ -241,6 +263,7 @@ def _wait_for_server(base, timeout=20):
 
 # ── Session-scoped test server ────────────────────────────────────────────────
 
+
 @pytest.fixture(scope="session", autouse=True)
 def test_server():
     """
@@ -252,11 +275,12 @@ def test_server():
     # conftest to think the server is already up, producing false failures.
     try:
         import subprocess as _sp
-        _sp.run(['fuser', '-k', f'{TEST_PORT}/tcp'],
-                capture_output=True, timeout=5)
+
+        _sp.run(["fuser", "-k", f"{TEST_PORT}/tcp"], capture_output=True, timeout=5)
     except Exception:
         pass
     import time as _time
+
     _time.sleep(0.5)  # brief pause to let the port release
 
     # Clean slate
@@ -267,13 +291,13 @@ def test_server():
 
     # Symlink real skills into test home so skill-related tests work,
     # but all write-heavy state stays isolated.
-    real_skills  = HERMES_HOME / 'skills'
-    test_skills  = TEST_STATE_DIR / 'skills'
+    real_skills = HERMES_HOME / "skills"
+    test_skills = TEST_STATE_DIR / "skills"
     if real_skills.exists() and not test_skills.exists():
         test_skills.symlink_to(real_skills)
 
     # Isolated cron state
-    (TEST_STATE_DIR / 'cron').mkdir(parents=True, exist_ok=True)
+    (TEST_STATE_DIR / "cron").mkdir(parents=True, exist_ok=True)
 
     # Expose TEST_STATE_DIR to the test process itself so that tests which write
     # directly to state.db (e.g. test_gateway_sync.py) always use the same path
@@ -282,36 +306,44 @@ def test_server():
     # is reserved for this mapping and is never overridden by individual test files.
     # Export both port and state-dir as env vars so individual test files
     # can read them without importing conftest (avoids circular imports).
-    os.environ.setdefault('HERMES_WEBUI_TEST_PORT', str(TEST_PORT))
+    os.environ.setdefault("HERMES_WEBUI_TEST_PORT", str(TEST_PORT))
     # os.environ already set at module level above; no-op here.
 
     env = os.environ.copy()
     # Strip real provider keys so test subprocess never inherits production credentials.
     # The test server uses a mock/isolated config — no real API calls are made.
     for _k in list(env):
-        if any(_k.startswith(p) for p in (
-            'OPENROUTER_API_KEY', 'OPENAI_API_KEY', 'ANTHROPIC_API_KEY',
-            'GOOGLE_API_KEY', 'DEEPSEEK_API_KEY',
-        )):
+        if any(
+            _k.startswith(p)
+            for p in (
+                "OPENROUTER_API_KEY",
+                "OPENAI_API_KEY",
+                "ANTHROPIC_API_KEY",
+                "GOOGLE_API_KEY",
+                "DEEPSEEK_API_KEY",
+            )
+        ):
             del env[_k]
-    env.update({
-        "HERMES_WEBUI_PORT":              str(TEST_PORT),
-        "HERMES_WEBUI_HOST":              "127.0.0.1",
-        "HERMES_WEBUI_STATE_DIR":         str(TEST_STATE_DIR),
-        "HERMES_WEBUI_DEFAULT_WORKSPACE": str(TEST_WORKSPACE),
-        "HERMES_WEBUI_DEFAULT_MODEL":     "openai/gpt-5.4-mini",
-        "HERMES_HOME":                    str(TEST_STATE_DIR),
-        "HERMES_CONFIG_PATH":             str(TEST_STATE_DIR / 'config.yaml'),
-        # Belt-and-suspenders: HERMES_BASE_HOME hard-locks _DEFAULT_HERMES_HOME
-        # in api/profiles.py to the test state dir regardless of profile switching
-        # or any os.environ mutation that happens inside the server process.
-        # Without this, a profile switch or active_profile file in the real
-        # ~/.hermes can redirect _get_active_hermes_home() out of the sandbox,
-        # causing onboarding writes (config.yaml, .env) to land in the production
-        # ~/.hermes/profiles/webui/ and overwrite real API keys.
-        "HERMES_BASE_HOME":               str(TEST_STATE_DIR),
-        "HERMES_WEBUI_PASSWORD":          "",
-    })
+    env.update(
+        {
+            "HERMES_WEBUI_PORT": str(TEST_PORT),
+            "HERMES_WEBUI_HOST": "127.0.0.1",
+            "HERMES_WEBUI_STATE_DIR": str(TEST_STATE_DIR),
+            "HERMES_WEBUI_DEFAULT_WORKSPACE": str(TEST_WORKSPACE),
+            "HERMES_WEBUI_DEFAULT_MODEL": "openai/gpt-5.4-mini",
+            "HERMES_HOME": str(TEST_STATE_DIR),
+            "HERMES_CONFIG_PATH": str(TEST_STATE_DIR / "config.yaml"),
+            # Belt-and-suspenders: HERMES_BASE_HOME hard-locks _DEFAULT_HERMES_HOME
+            # in api/profiles.py to the test state dir regardless of profile switching
+            # or any os.environ mutation that happens inside the server process.
+            # Without this, a profile switch or active_profile file in the real
+            # ~/.hermes can redirect _get_active_hermes_home() out of the sandbox,
+            # causing onboarding writes (config.yaml, .env) to land in the production
+            # ~/.hermes/profiles/webui/ and overwrite real API keys.
+            "HERMES_BASE_HOME": str(TEST_STATE_DIR),
+            "HERMES_WEBUI_PASSWORD": "",
+        }
+    )
 
     # Pass agent dir if discovered so server.py doesn't have to re-discover
     if HERMES_AGENT:
@@ -351,6 +383,7 @@ def test_server():
 
 # ── Test base URL ─────────────────────────────────────────────────────────────
 
+
 @pytest.fixture(scope="session")
 def base_url():
     return TEST_BASE
@@ -362,6 +395,7 @@ def base_url():
 # so the cache must be explicitly invalidated after each test that exercises
 # provider/model detection.
 
+
 @pytest.fixture(autouse=True)
 def _invalidate_models_cache_after_test():
     """Force the TTL cache to be cleared before and after every test.
@@ -372,18 +406,21 @@ def _invalidate_models_cache_after_test():
     """
     try:
         from api.config import invalidate_models_cache
+
         invalidate_models_cache()
     except Exception:
         pass
     yield
     try:
         from api.config import invalidate_models_cache
+
         invalidate_models_cache()
     except Exception:
         pass
 
 
 # ── Per-test session cleanup ──────────────────────────────────────────────────
+
 
 @pytest.fixture(autouse=True)
 def cleanup_test_sessions():
@@ -408,12 +445,13 @@ def cleanup_test_sessions():
 
     try:
         last_ws_file = TEST_STATE_DIR / "last_workspace.txt"
-        last_ws_file.write_text(str(TEST_WORKSPACE), encoding='utf-8')
+        last_ws_file.write_text(str(TEST_WORKSPACE), encoding="utf-8")
     except Exception:
         pass
 
 
 # ── Convenience helpers ────────────────────────────────────────────────────────
+
 
 def make_session_tracked(created_list, ws=None):
     """

--- a/tests/test_1003_appearance_autosave.py
+++ b/tests/test_1003_appearance_autosave.py
@@ -6,6 +6,7 @@ Focus:
 - Full-save flow should still include font_size.
 - /api/settings should accept appearance-only payloads and preserve untouched fields.
 """
+
 import json
 import re
 import urllib.error
@@ -15,17 +16,27 @@ from pathlib import Path
 from tests._pytest_port import BASE
 
 
-BOOT_JS = (Path(__file__).parent.parent / "static" / "boot.js").read_text(encoding="utf-8")
-PANELS_JS = (Path(__file__).parent.parent / "static" / "panels.js").read_text(encoding="utf-8")
-INDEX_HTML = (Path(__file__).parent.parent / "static" / "index.html").read_text(encoding="utf-8")
-I18N_JS = (Path(__file__).parent.parent / "static" / "i18n.js").read_text(encoding="utf-8")
+BOOT_JS = (Path(__file__).parent.parent / "static" / "boot.js").read_text(
+    encoding="utf-8"
+)
+PANELS_JS = (Path(__file__).parent.parent / "static" / "panels.js").read_text(
+    encoding="utf-8"
+)
+INDEX_HTML = (Path(__file__).parent.parent / "static" / "index.html").read_text(
+    encoding="utf-8"
+)
+I18N_JS = (Path(__file__).parent.parent / "static" / "i18n.js").read_text(
+    encoding="utf-8"
+)
 
 
 def _function_block(src: str, name: str) -> str:
     marker = re.search(rf"(^|\n)(?:async\s+)?function\s+{re.escape(name)}\(", src)
     assert marker is not None, f"{name}() not found"
     start = marker.start()
-    next_marker = re.search(r"\n(?:function\s+\w+\(|async\s+function\s+\w+\()", src[start + 1 :])
+    next_marker = re.search(
+        r"\n(?:function\s+\w+\(|async\s+function\s+\w+\()", src[start + 1 :]
+    )
     if next_marker:
         end = start + 1 + next_marker.start()
     else:
@@ -121,7 +132,10 @@ def test_settings_api_accepts_appearance_only_payload_without_overwriting_other_
         "check_for_updates": original.get("check_for_updates"),
     }
     try:
-        d, status = _post("/api/settings", {"theme": "system", "skin": "charizard", "font_size": "large"})
+        d, status = _post(
+            "/api/settings",
+            {"theme": "system", "skin": "charizard", "font_size": "large"},
+        )
         assert status == 200
         assert d.get("theme") == "system"
         assert d.get("skin") == "charizard"
@@ -131,8 +145,11 @@ def test_settings_api_accepts_appearance_only_payload_without_overwriting_other_
         assert reloaded.get("show_cli_sessions") == snapshot["show_cli_sessions"]
         assert reloaded.get("check_for_updates") == snapshot["check_for_updates"]
     finally:
-        _post("/api/settings", {
-            "theme": snapshot["theme"],
-            "skin": snapshot["skin"],
-            "font_size": snapshot["font_size"],
-        })
+        _post(
+            "/api/settings",
+            {
+                "theme": snapshot["theme"],
+                "skin": snapshot["skin"],
+                "font_size": snapshot["font_size"],
+            },
+        )

--- a/tests/test_1003_preferences_autosave.py
+++ b/tests/test_1003_preferences_autosave.py
@@ -10,19 +10,28 @@ preferences-panel autosave pattern is wired correctly:
 - Status div exists in static/index.html
 - _autosavePreferencesSettings clears the dirty flag and hides the unsaved bar
 """
+
 import re
 from pathlib import Path
 
-PANELS_JS = (Path(__file__).parent.parent / "static" / "panels.js").read_text(encoding="utf-8")
-INDEX_HTML = (Path(__file__).parent.parent / "static" / "index.html").read_text(encoding="utf-8")
-I18N_JS = (Path(__file__).parent.parent / "static" / "i18n.js").read_text(encoding="utf-8")
+PANELS_JS = (Path(__file__).parent.parent / "static" / "panels.js").read_text(
+    encoding="utf-8"
+)
+INDEX_HTML = (Path(__file__).parent.parent / "static" / "index.html").read_text(
+    encoding="utf-8"
+)
+I18N_JS = (Path(__file__).parent.parent / "static" / "i18n.js").read_text(
+    encoding="utf-8"
+)
 
 
 def _function_block(src: str, name: str) -> str:
     marker = re.search(rf"(^|\n)(?:async\s+)?function\s+{re.escape(name)}\(", src)
     assert marker is not None, f"{name}() not found"
     start = marker.start()
-    next_marker = re.search(r"\n(?:function\s+\w+\(|async\s+function\s+\w+\()", src[start + 1:])
+    next_marker = re.search(
+        r"\n(?:function\s+\w+\(|async\s+function\s+\w+\()", src[start + 1 :]
+    )
     end = start + 1 + next_marker.start() if next_marker else len(src)
     return src[start:end]
 
@@ -56,10 +65,12 @@ def test_all_14_preference_fields_have_autosave_payload_entries():
     """_preferencesPayloadFromUi must include all 14 preference fields."""
     block = _function_block(PANELS_JS, "_preferencesPayloadFromUi")
     for dom_id, field in PREFERENCE_FIELDS_AUTOSAVE:
-        assert f"$('{dom_id}')" in block, \
+        assert f"$('{dom_id}')" in block, (
             f"_preferencesPayloadFromUi missing reference to {dom_id}"
-        assert f"payload.{field}=" in block, \
+        )
+        assert f"payload.{field}=" in block, (
             f"_preferencesPayloadFromUi missing payload assignment for {field}"
+        )
 
 
 def test_preference_fields_use_schedule_autosave_not_mark_dirty():
@@ -74,8 +85,9 @@ def test_preference_fields_use_schedule_autosave_not_mark_dirty():
         if dom_id == "settingsBotName":
             # Bot name uses a 500ms wrapper that calls _schedulePreferencesAutosave
             # via setTimeout. The wrapper itself is in the loadSettingsPanel block.
-            assert "_schedulePreferencesAutosave" in panel, \
+            assert "_schedulePreferencesAutosave" in panel, (
                 "_schedulePreferencesAutosave must be referenced for bot_name flow"
+            )
             continue
         # For other fields: search the field's block for the addEventListener call
         # and verify it points to _schedulePreferencesAutosave.
@@ -83,12 +95,14 @@ def test_preference_fields_use_schedule_autosave_not_mark_dirty():
         idx = panel.find(f"$('{dom_id}')")
         assert idx != -1, f"{dom_id} not loaded in loadSettingsPanel"
         # Window of next ~600 chars covers the .addEventListener call
-        window = panel[idx:idx + 600]
+        window = panel[idx : idx + 600]
         assert "addEventListener" in window, f"{dom_id} has no addEventListener"
-        assert "_schedulePreferencesAutosave" in window, \
+        assert "_schedulePreferencesAutosave" in window, (
             f"{dom_id} listener should call _schedulePreferencesAutosave (Phase 2 #1003)"
-        assert "_markSettingsDirty" not in window, \
+        )
+        assert "_markSettingsDirty" not in window, (
             f"{dom_id} should not call _markSettingsDirty (Phase 2 autosaves it)"
+        )
 
 
 def test_password_still_uses_mark_dirty():
@@ -97,11 +111,13 @@ def test_password_still_uses_mark_dirty():
     panel = _load_settings_panel_block()
     idx = panel.find("$('settingsPassword')")
     assert idx != -1, "settingsPassword field not loaded"
-    window = panel[idx:idx + 400]
-    assert "_markSettingsDirty" in window, \
+    window = panel[idx : idx + 400]
+    assert "_markSettingsDirty" in window, (
         "Password field MUST call _markSettingsDirty (security: never autosave passwords)"
-    assert "_schedulePreferencesAutosave" not in window, \
+    )
+    assert "_schedulePreferencesAutosave" not in window, (
         "Password field MUST NOT call _schedulePreferencesAutosave (security)"
+    )
 
 
 def test_autosave_clears_dirty_flag_and_hides_unsaved_bar():
@@ -125,7 +141,9 @@ def test_autosave_clears_dirty_flag_and_hides_unsaved_bar():
     )
     # The clear-and-hide block must be conditional, not unconditional
     compact = block.replace(" ", "").replace("\n", "")
-    assert "if(!pwDirty&&!modelDirty)" in compact or "if(pwDirty||modelDirty)" in compact, (
+    assert (
+        "if(!pwDirty&&!modelDirty)" in compact or "if(pwDirty||modelDirty)" in compact
+    ), (
         "_autosavePreferencesSettings must guard the dirty-clear and bar-hide "
         "with a condition that defers when a manual field has pending edits"
     )
@@ -152,22 +170,27 @@ def test_retry_function_exists_and_falls_back_gracefully():
     """_retryPreferencesAutosave must exist and use the saved retry payload (or
     rebuild from UI if unavailable)."""
     block = _function_block(PANELS_JS, "_retryPreferencesAutosave")
-    assert "_settingsPreferencesAutosaveRetryPayload" in block, \
+    assert "_settingsPreferencesAutosaveRetryPayload" in block, (
         "Retry must reference the stored payload"
-    assert "_preferencesPayloadFromUi" in block, \
+    )
+    assert "_preferencesPayloadFromUi" in block, (
         "Retry must fall back to rebuilding from UI when no stored payload"
-    assert "_autosavePreferencesSettings" in block, \
+    )
+    assert "_autosavePreferencesSettings" in block, (
         "Retry must invoke _autosavePreferencesSettings"
+    )
 
 
 def test_debounce_cancels_pending_timer_on_rapid_input():
     """_schedulePreferencesAutosave must clear any in-flight timer before
     setting a new one — otherwise rapid changes queue up multiple POSTs."""
     block = _function_block(PANELS_JS, "_schedulePreferencesAutosave")
-    assert "clearTimeout(_settingsPreferencesAutosaveTimer)" in block, \
+    assert "clearTimeout(_settingsPreferencesAutosaveTimer)" in block, (
         "_schedulePreferencesAutosave must clearTimeout the prior timer"
-    assert "350" in block, \
+    )
+    assert "350" in block, (
         "_schedulePreferencesAutosave must use 350ms debounce (matching Phase 1)"
+    )
 
 
 def test_phase1_appearance_autosave_still_passes():

--- a/tests/test_1038_pwa_auth_redirect.py
+++ b/tests/test_1038_pwa_auth_redirect.py
@@ -11,7 +11,6 @@ These are static regression tests that verify the JS source contains the
 correct guard patterns.
 """
 
-import re
 from pathlib import Path
 
 ROOT = Path(__file__).parent.parent
@@ -30,12 +29,18 @@ class TestPWAAuthRedirect:
         """api() in workspace.js must redirect to login on 401."""
         src = _workspace_js()
         # Guard must appear inside the !res.ok block, before throwing
-        assert "res.status===401" in src, \
+        assert "res.status===401" in src, (
             "workspace.js api() must check res.status===401"
-        assert "window.location.href='login" in src or 'window.location.href="login' in src, \
-            "workspace.js api() must redirect to login on 401"
-        assert "window.location.href='/login" not in src and 'window.location.href="/login' not in src, \
+        )
+        assert (
+            "window.location.href='login" in src or 'window.location.href="login' in src
+        ), "workspace.js api() must redirect to login on 401"
+        assert (
+            "window.location.href='/login" not in src
+            and 'window.location.href="/login' not in src
+        ), (
             "workspace.js api() must not escape subpath mounts by redirecting to root /login"
+        )
 
     def test_workspace_js_401_before_throw(self):
         """The 401 redirect must come before any error throw."""
@@ -50,33 +55,38 @@ class TestPWAAuthRedirect:
             idx_throw = src.find("throw err")
         assert idx_401 != -1, "401 guard not found in workspace.js"
         assert idx_throw != -1, "no error throw found in workspace.js"
-        assert idx_401 < idx_throw, \
+        assert idx_401 < idx_throw, (
             "401 redirect must appear before the generic throw in workspace.js"
+        )
 
     def test_ui_js_has_redirect_helper(self):
         """ui.js must define _redirectIfUnauth helper."""
         src = _ui_js()
-        assert "_redirectIfUnauth" in src, \
+        assert "_redirectIfUnauth" in src, (
             "ui.js must define _redirectIfUnauth helper function"
+        )
 
     def test_ui_js_models_fetch_uses_redirect(self):
         """populateModelDropdown() must call _redirectIfUnauth on the api/models response."""
         src = _ui_js()
         # The helper must be called after the api/models fetch
-        assert "_redirectIfUnauth(_modelsRes)" in src, \
+        assert "_redirectIfUnauth(_modelsRes)" in src, (
             "populateModelDropdown() must check 401 on api/models fetch"
+        )
 
     def test_ui_js_live_models_fetch_uses_redirect(self):
         """loadLiveModels() must call _redirectIfUnauth on the api/models/live response."""
         src = _ui_js()
-        assert "_redirectIfUnauth(_liveRes)" in src, \
+        assert "_redirectIfUnauth(_liveRes)" in src, (
             "loadLiveModels() must check 401 on api/models/live fetch"
+        )
 
     def test_ui_js_upload_fetch_uses_redirect(self):
         """File upload must call _redirectIfUnauth on the api/upload response."""
         src = _ui_js()
-        assert "_redirectIfUnauth(res)" in src, \
+        assert "_redirectIfUnauth(res)" in src, (
             "upload fetch must call _redirectIfUnauth"
+        )
 
 
 class TestLoginJsSafeNextPath:
@@ -84,7 +94,9 @@ class TestLoginJsSafeNextPath:
 
     @staticmethod
     def _login_js():
-        return (Path(__file__).parent.parent / "static" / "login.js").read_text(encoding="utf-8")
+        return (Path(__file__).parent.parent / "static" / "login.js").read_text(
+            encoding="utf-8"
+        )
 
     def test_safe_next_path_function_exists(self):
         """login.js must define _safeNextPath() to honor the ?next= redirect."""

--- a/tests/test_1045_bfcache_layout_restore.py
+++ b/tests/test_1045_bfcache_layout_restore.py
@@ -56,7 +56,6 @@ class TestBfcacheLayoutRestore:
             "pageshow handler must call syncWorkspacePanelState() on bfcache restore"
         )
 
-
     def test_pageshow_calls_start_gateway_sse(self):
         """pageshow handler must call startGatewaySSE() to reconnect the dead SSE connection."""
         src = _boot_js()
@@ -96,8 +95,15 @@ class TestBfcacheLayoutRestore:
         src = _boot_js()
         handler_body = _pageshow_handler(src)
         # Each of the new calls must be guarded
-        for fn in ("syncTopbar", "syncWorkspacePanelState", "startGatewaySSE",
-                   "closeModelDropdown", "closeReasoningDropdown", "closeWsDropdown", "closeProfileDropdown"):
+        for fn in (
+            "syncTopbar",
+            "syncWorkspacePanelState",
+            "startGatewaySSE",
+            "closeModelDropdown",
+            "closeReasoningDropdown",
+            "closeWsDropdown",
+            "closeProfileDropdown",
+        ):
             assert f"typeof {fn} === 'function'" in handler_body, (
                 f"{fn}() call in pageshow handler must be guarded with typeof === 'function'"
             )
@@ -106,7 +112,12 @@ class TestBfcacheLayoutRestore:
         """pageshow handler must close all known dropdowns to reset frozen bfcache popover state."""
         src = _boot_js()
         handler_body = _pageshow_handler(src)
-        for fn in ("closeModelDropdown", "closeReasoningDropdown", "closeWsDropdown", "closeProfileDropdown"):
+        for fn in (
+            "closeModelDropdown",
+            "closeReasoningDropdown",
+            "closeWsDropdown",
+            "closeProfileDropdown",
+        ):
             assert fn in handler_body, (
                 f"pageshow handler must call {fn}() to dismiss any dropdown left open by bfcache"
             )
@@ -117,8 +128,9 @@ class TestBfcacheLayoutRestore:
         handler_body = _pageshow_handler(src)
         close_idx = handler_body.find("closeModelDropdown")
         sync_idx = handler_body.find("syncTopbar")
-        assert close_idx != -1 and sync_idx != -1, "Both close and sync calls must be present"
+        assert close_idx != -1 and sync_idx != -1, (
+            "Both close and sync calls must be present"
+        )
         assert close_idx < sync_idx, (
             "Dropdown close calls must appear before layout sync calls in the pageshow handler"
         )
-

--- a/tests/test_1058_adaptive_title_refresh.py
+++ b/tests/test_1058_adaptive_title_refresh.py
@@ -7,17 +7,16 @@ Covers all five new functions added to api/streaming.py:
   - _run_background_title_refresh
   - _maybe_schedule_title_refresh
 """
+
 import sys
 import os
 import threading
-import types
-import unittest
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 # Ensure the project root is on sys.path
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from api.streaming import (
     _count_exchanges,
@@ -38,6 +37,7 @@ def _restore_auth_sessions():
     assume _sessions starts empty) when our file runs first alphabetically.
     """
     import api.auth as _auth
+
     snapshot = dict(_auth._sessions)
     yield
     _auth._sessions.clear()
@@ -48,23 +48,30 @@ def _restore_auth_sessions():
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _user_msg(text):
-    return {'role': 'user', 'content': text}
+    return {"role": "user", "content": text}
 
 
 def _asst_msg(text, tool_calls=None):
-    msg = {'role': 'assistant', 'content': text}
+    msg = {"role": "assistant", "content": text}
     if tool_calls is not None:
-        msg['tool_calls'] = tool_calls
+        msg["tool_calls"] = tool_calls
     return msg
 
 
 def _tool_only_asst():
     """Assistant message that only has tool_calls, no real text."""
-    return {'role': 'assistant', 'content': '', 'tool_calls': [{'id': 't1', 'type': 'function'}]}
+    return {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [{"id": "t1", "type": "function"}],
+    }
 
 
-def _make_session(title='My Title', llm_title_generated=True, messages=None, session_id='sid1'):
+def _make_session(
+    title="My Title", llm_title_generated=True, messages=None, session_id="sid1"
+):
     s = MagicMock()
     s.title = title
     s.llm_title_generated = llm_title_generated
@@ -78,6 +85,7 @@ def _make_session(title='My Title', llm_title_generated=True, messages=None, ses
 # _count_exchanges
 # ---------------------------------------------------------------------------
 
+
 class TestCountExchanges:
     def test_empty_messages_returns_zero(self):
         assert _count_exchanges([]) == 0
@@ -86,38 +94,38 @@ class TestCountExchanges:
         assert _count_exchanges(None) == 0
 
     def test_counts_only_user_messages(self):
-        msgs = [_user_msg('hello'), _asst_msg('hi'), _user_msg('world')]
+        msgs = [_user_msg("hello"), _asst_msg("hi"), _user_msg("world")]
         assert _count_exchanges(msgs) == 2
 
     def test_skips_empty_user_messages(self):
-        msgs = [_user_msg(''), _user_msg('   '), _user_msg('real question')]
+        msgs = [_user_msg(""), _user_msg("   "), _user_msg("real question")]
         assert _count_exchanges(msgs) == 1
 
     def test_counts_list_content_user_messages(self):
         msgs = [
-            {'role': 'user', 'content': [{'type': 'text', 'text': 'list question'}]},
+            {"role": "user", "content": [{"type": "text", "text": "list question"}]},
         ]
         assert _count_exchanges(msgs) == 1
 
     def test_skips_empty_list_content(self):
         msgs = [
-            {'role': 'user', 'content': [{'type': 'text', 'text': '   '}]},
+            {"role": "user", "content": [{"type": "text", "text": "   "}]},
         ]
         assert _count_exchanges(msgs) == 0
 
     def test_ignores_non_user_roles(self):
-        msgs = [_asst_msg('response'), {'role': 'system', 'content': 'system prompt'}]
+        msgs = [_asst_msg("response"), {"role": "system", "content": "system prompt"}]
         assert _count_exchanges(msgs) == 0
 
     def test_ignores_non_dict_entries(self):
-        msgs = ['not a dict', _user_msg('real'), None]
+        msgs = ["not a dict", _user_msg("real"), None]
         assert _count_exchanges(msgs) == 1
 
     def test_five_exchanges(self):
         msgs = []
         for i in range(5):
-            msgs.append(_user_msg(f'question {i}'))
-            msgs.append(_asst_msg(f'answer {i}'))
+            msgs.append(_user_msg(f"question {i}"))
+            msgs.append(_asst_msg(f"answer {i}"))
         assert _count_exchanges(msgs) == 5
 
 
@@ -125,89 +133,110 @@ class TestCountExchanges:
 # _latest_exchange_snippets
 # ---------------------------------------------------------------------------
 
+
 class TestLatestExchangeSnippets:
     def test_empty_returns_empty_strings(self):
         u, a = _latest_exchange_snippets([])
-        assert u == '' and a == ''
+        assert u == "" and a == ""
 
     def test_none_returns_empty_strings(self):
         u, a = _latest_exchange_snippets(None)
-        assert u == '' and a == ''
+        assert u == "" and a == ""
 
     def test_basic_pair(self):
-        msgs = [_user_msg('first q'), _asst_msg('first a'),
-                _user_msg('second q'), _asst_msg('second a')]
+        msgs = [
+            _user_msg("first q"),
+            _asst_msg("first a"),
+            _user_msg("second q"),
+            _asst_msg("second a"),
+        ]
         u, a = _latest_exchange_snippets(msgs)
-        assert u == 'second q'
-        assert a == 'second a'
+        assert u == "second q"
+        assert a == "second a"
 
     def test_returns_latest_not_first(self):
-        msgs = [_user_msg('old q'), _asst_msg('old a'),
-                _user_msg('new q'), _asst_msg('new a')]
+        msgs = [
+            _user_msg("old q"),
+            _asst_msg("old a"),
+            _user_msg("new q"),
+            _asst_msg("new a"),
+        ]
         u, a = _latest_exchange_snippets(msgs)
-        assert u == 'new q'
+        assert u == "new q"
 
     def test_skips_tool_call_only_assistant(self):
         """An assistant msg with tool_calls and no real text should be skipped."""
-        msgs = [_user_msg('q'), _asst_msg('real answer'),
-                _user_msg('q2'), _tool_only_asst()]
+        msgs = [
+            _user_msg("q"),
+            _asst_msg("real answer"),
+            _user_msg("q2"),
+            _tool_only_asst(),
+        ]
         u, a = _latest_exchange_snippets(msgs)
         # _tool_only_asst should be skipped; fall back to previous real assistant
-        assert a == 'real answer'
-        assert u == 'q2'
+        assert a == "real answer"
+        assert u == "q2"
 
     def test_truncates_long_content(self):
-        long_text = 'x' * 600
+        long_text = "x" * 600
         msgs = [_user_msg(long_text), _asst_msg(long_text)]
         u, a = _latest_exchange_snippets(msgs)
         assert len(u) == 500
         assert len(a) == 500
 
     def test_no_assistant_message(self):
-        msgs = [_user_msg('q')]
+        msgs = [_user_msg("q")]
         u, a = _latest_exchange_snippets(msgs)
-        assert u == 'q'
-        assert a == ''
+        assert u == "q"
+        assert a == ""
 
     def test_no_user_message(self):
-        msgs = [_asst_msg('a')]
+        msgs = [_asst_msg("a")]
         u, a = _latest_exchange_snippets(msgs)
-        assert u == ''
-        assert a == 'a'
+        assert u == ""
+        assert a == "a"
 
     def test_ignores_non_dict_entries(self):
-        msgs = ['noise', _user_msg('q'), None, _asst_msg('a')]
+        msgs = ["noise", _user_msg("q"), None, _asst_msg("a")]
         u, a = _latest_exchange_snippets(msgs)
-        assert u == 'q'
-        assert a == 'a'
+        assert u == "q"
+        assert a == "a"
 
 
 # ---------------------------------------------------------------------------
 # _get_title_refresh_interval
 # ---------------------------------------------------------------------------
 
+
 class TestGetTitleRefreshInterval:
     def test_returns_int_for_valid_setting(self):
         # _get_title_refresh_interval does a local import: `from api.config import load_settings`
         # so patch the source module, not api.streaming
-        with patch('api.config.load_settings', return_value={'auto_title_refresh_every': '5'}):
+        with patch(
+            "api.config.load_settings", return_value={"auto_title_refresh_every": "5"}
+        ):
             assert _get_title_refresh_interval() == 5
 
     def test_returns_zero_for_off_setting(self):
-        with patch('api.config.load_settings', return_value={'auto_title_refresh_every': '0'}):
+        with patch(
+            "api.config.load_settings", return_value={"auto_title_refresh_every": "0"}
+        ):
             assert _get_title_refresh_interval() == 0
 
     def test_returns_zero_when_key_absent(self):
-        with patch('api.config.load_settings', return_value={}):
+        with patch("api.config.load_settings", return_value={}):
             assert _get_title_refresh_interval() == 0
 
     def test_returns_zero_on_exception(self):
-        with patch('api.config.load_settings', side_effect=Exception('boom')):
+        with patch("api.config.load_settings", side_effect=Exception("boom")):
             assert _get_title_refresh_interval() == 0
 
     def test_valid_values_10_and_20(self):
-        for val in ('10', '20'):
-            with patch('api.config.load_settings', return_value={'auto_title_refresh_every': val}):
+        for val in ("10", "20"):
+            with patch(
+                "api.config.load_settings",
+                return_value={"auto_title_refresh_every": val},
+            ):
                 assert _get_title_refresh_interval() == int(val)
 
 
@@ -215,14 +244,17 @@ class TestGetTitleRefreshInterval:
 # _run_background_title_refresh
 # ---------------------------------------------------------------------------
 
+
 class TestRunBackgroundTitleRefresh:
     def _make_put_event(self):
         events = []
+
         def put(name, data):
             events.append((name, data))
+
         return put, events
 
-    def _make_session_obj(self, title='Old Title'):
+    def _make_session_obj(self, title="Old Title"):
         s = MagicMock()
         s.title = title
         s.llm_title_generated = True
@@ -232,63 +264,74 @@ class TestRunBackgroundTitleRefresh:
     def test_skips_when_title_changed_before_call(self):
         """If the title has changed (manual rename) since the refresh was scheduled, skip."""
         put, events = self._make_put_event()
-        with patch('api.streaming.get_session') as mock_get, \
-             patch('api.streaming.SESSIONS', {}), \
-             patch('api.streaming.LOCK', threading.Lock()):
-            s = self._make_session_obj(title='Different Title')
+        with (
+            patch("api.streaming.get_session") as mock_get,
+            patch("api.streaming.SESSIONS", {}),
+            patch("api.streaming.LOCK", threading.Lock()),
+        ):
+            s = self._make_session_obj(title="Different Title")
             mock_get.return_value = s
             _run_background_title_refresh(
-                'sid', 'user', 'asst', 'Old Title', put, agent=None
+                "sid", "user", "asst", "Old Title", put, agent=None
             )
         # No 'title' event should have been emitted
-        assert not any(name == 'title' for name, _ in events)
+        assert not any(name == "title" for name, _ in events)
 
     def test_skips_if_session_not_found(self):
         put, events = self._make_put_event()
-        with patch('api.streaming.get_session', side_effect=KeyError('not found')):
-            _run_background_title_refresh('sid', 'u', 'a', 'title', put)
+        with patch("api.streaming.get_session", side_effect=KeyError("not found")):
+            _run_background_title_refresh("sid", "u", "a", "title", put)
         assert events == []
 
     def test_skips_when_title_is_untitled(self):
         put, events = self._make_put_event()
-        with patch('api.streaming.get_session') as mock_get:
-            s = self._make_session_obj(title='Untitled')
+        with patch("api.streaming.get_session") as mock_get:
+            s = self._make_session_obj(title="Untitled")
             mock_get.return_value = s
-            _run_background_title_refresh('sid', 'u', 'a', 'Untitled', put)
-        assert not any(name == 'title' for name, _ in events)
+            _run_background_title_refresh("sid", "u", "a", "Untitled", put)
+        assert not any(name == "title" for name, _ in events)
 
     def test_skips_same_title(self):
         """If the LLM generates a title identical to the current one, no event is emitted."""
         put, events = self._make_put_event()
-        with patch('api.streaming.get_session') as mock_get, \
-             patch('api.streaming._aux_title_configured', return_value=True), \
-             patch('api.streaming._generate_llm_session_title_via_aux',
-                   return_value=('Old Title', 'llm_ok', 'raw')), \
-             patch('api.streaming.SESSIONS', {}), \
-             patch('api.streaming.LOCK', threading.Lock()):
-            s = self._make_session_obj(title='Old Title')
+        with (
+            patch("api.streaming.get_session") as mock_get,
+            patch("api.streaming._aux_title_configured", return_value=True),
+            patch(
+                "api.streaming._generate_llm_session_title_via_aux",
+                return_value=("Old Title", "llm_ok", "raw"),
+            ),
+            patch("api.streaming.SESSIONS", {}),
+            patch("api.streaming.LOCK", threading.Lock()),
+        ):
+            s = self._make_session_obj(title="Old Title")
             mock_get.return_value = s
-            _run_background_title_refresh('sid', 'u', 'a', 'Old Title', put)
-        assert not any(name == 'title' for name, _ in events)
+            _run_background_title_refresh("sid", "u", "a", "Old Title", put)
+        assert not any(name == "title" for name, _ in events)
 
     def test_emits_title_event_on_new_title(self):
         put, events = self._make_put_event()
-        s = self._make_session_obj(title='Old Title')
+        s = self._make_session_obj(title="Old Title")
         # Use a real dict for SESSIONS so .get() works, pre-populated with our session
-        fake_sessions = {'sid': s}
-        with patch('api.streaming.get_session', return_value=s), \
-             patch('api.streaming._aux_title_configured', return_value=True), \
-             patch('api.streaming._generate_llm_session_title_via_aux',
-                   return_value=('New Refreshed Title', 'llm_ok', 'raw')), \
-             patch('api.streaming.SESSIONS', fake_sessions), \
-             patch('api.streaming.LOCK', threading.Lock()):
-            _run_background_title_refresh('sid', 'u', 'a', 'Old Title', put)
-        title_events = [(n, d) for n, d in events if n == 'title']
+        fake_sessions = {"sid": s}
+        with (
+            patch("api.streaming.get_session", return_value=s),
+            patch("api.streaming._aux_title_configured", return_value=True),
+            patch(
+                "api.streaming._generate_llm_session_title_via_aux",
+                return_value=("New Refreshed Title", "llm_ok", "raw"),
+            ),
+            patch("api.streaming.SESSIONS", fake_sessions),
+            patch("api.streaming.LOCK", threading.Lock()),
+        ):
+            _run_background_title_refresh("sid", "u", "a", "Old Title", put)
+        title_events = [(n, d) for n, d in events if n == "title"]
         assert len(title_events) == 1
-        assert title_events[0][1]['title'] == 'New Refreshed Title'
+        assert title_events[0][1]["title"] == "New Refreshed Title"
 
     def test_saves_refreshed_title_outside_global_lock(self):
         """Refreshing an existing title must not call Session.save() while holding LOCK."""
+
         class TrackingLock:
             def __init__(self):
                 self.held = False
@@ -303,30 +346,34 @@ class TestRunBackgroundTitleRefresh:
 
         put, events = self._make_put_event()
         lock = TrackingLock()
-        s = self._make_session_obj(title='Old Title')
+        s = self._make_session_obj(title="Old Title")
 
         def save(*args, **kwargs):
             assert not lock.held, "Session.save() must run outside api.models.LOCK"
 
         s.save = save
-        fake_sessions = {'sid': s}
-        with patch('api.streaming.get_session', return_value=s), \
-             patch('api.streaming._aux_title_configured', return_value=True), \
-             patch('api.streaming._generate_llm_session_title_via_aux',
-                   return_value=('New Refreshed Title', 'llm_ok', 'raw')), \
-             patch('api.streaming.SESSIONS', fake_sessions), \
-             patch('api.streaming.LOCK', lock):
-            _run_background_title_refresh('sid', 'u', 'a', 'Old Title', put)
-        title_events = [(n, d) for n, d in events if n == 'title']
+        fake_sessions = {"sid": s}
+        with (
+            patch("api.streaming.get_session", return_value=s),
+            patch("api.streaming._aux_title_configured", return_value=True),
+            patch(
+                "api.streaming._generate_llm_session_title_via_aux",
+                return_value=("New Refreshed Title", "llm_ok", "raw"),
+            ),
+            patch("api.streaming.SESSIONS", fake_sessions),
+            patch("api.streaming.LOCK", lock),
+        ):
+            _run_background_title_refresh("sid", "u", "a", "Old Title", put)
+        title_events = [(n, d) for n, d in events if n == "title"]
         assert len(title_events) == 1
-        assert title_events[0][1]['title'] == 'New Refreshed Title'
+        assert title_events[0][1]["title"] == "New Refreshed Title"
 
     def test_exceptions_are_silently_swallowed(self):
         """Any unexpected error inside must not propagate — it's a background daemon."""
         put, events = self._make_put_event()
-        with patch('api.streaming.get_session', side_effect=RuntimeError('oops')):
+        with patch("api.streaming.get_session", side_effect=RuntimeError("oops")):
             # Should not raise
-            _run_background_title_refresh('sid', 'u', 'a', 'title', put)
+            _run_background_title_refresh("sid", "u", "a", "title", put)
         assert events == []
 
 
@@ -334,83 +381,110 @@ class TestRunBackgroundTitleRefresh:
 # _maybe_schedule_title_refresh
 # ---------------------------------------------------------------------------
 
+
 class TestMaybeScheduleTitleRefresh:
     def _noop_put(self, name, data):
         pass
 
     def test_does_nothing_when_disabled(self):
-        with patch('api.streaming._get_title_refresh_interval', return_value=0):
+        with patch("api.streaming._get_title_refresh_interval", return_value=0):
             spawned = []
-            with patch('threading.Thread', side_effect=lambda **kw: spawned.append(kw) or MagicMock()):
-                session = _make_session(messages=[_user_msg('q'), _asst_msg('a')] * 5)
+            with patch(
+                "threading.Thread",
+                side_effect=lambda **kw: spawned.append(kw) or MagicMock(),
+            ):
+                session = _make_session(messages=[_user_msg("q"), _asst_msg("a")] * 5)
                 _maybe_schedule_title_refresh(session, self._noop_put, None)
         assert spawned == []
 
     def test_does_nothing_when_title_is_empty(self):
-        with patch('api.streaming._get_title_refresh_interval', return_value=5):
+        with patch("api.streaming._get_title_refresh_interval", return_value=5):
             spawned = []
-            with patch('threading.Thread', side_effect=lambda **kw: spawned.append(kw) or MagicMock()):
-                session = _make_session(title='', messages=[_user_msg('q'), _asst_msg('a')] * 5)
+            with patch(
+                "threading.Thread",
+                side_effect=lambda **kw: spawned.append(kw) or MagicMock(),
+            ):
+                session = _make_session(
+                    title="", messages=[_user_msg("q"), _asst_msg("a")] * 5
+                )
                 _maybe_schedule_title_refresh(session, self._noop_put, None)
         assert spawned == []
 
     def test_does_nothing_for_untitled(self):
-        with patch('api.streaming._get_title_refresh_interval', return_value=5):
+        with patch("api.streaming._get_title_refresh_interval", return_value=5):
             spawned = []
-            with patch('threading.Thread', side_effect=lambda **kw: spawned.append(kw) or MagicMock()):
-                session = _make_session(title='Untitled', messages=[_user_msg('q'), _asst_msg('a')] * 5)
+            with patch(
+                "threading.Thread",
+                side_effect=lambda **kw: spawned.append(kw) or MagicMock(),
+            ):
+                session = _make_session(
+                    title="Untitled", messages=[_user_msg("q"), _asst_msg("a")] * 5
+                )
                 _maybe_schedule_title_refresh(session, self._noop_put, None)
         assert spawned == []
 
     def test_does_nothing_when_title_not_llm_generated(self):
-        with patch('api.streaming._get_title_refresh_interval', return_value=5):
+        with patch("api.streaming._get_title_refresh_interval", return_value=5):
             spawned = []
-            with patch('threading.Thread', side_effect=lambda **kw: spawned.append(kw) or MagicMock()):
-                session = _make_session(llm_title_generated=False,
-                                        messages=[_user_msg('q'), _asst_msg('a')] * 5)
+            with patch(
+                "threading.Thread",
+                side_effect=lambda **kw: spawned.append(kw) or MagicMock(),
+            ):
+                session = _make_session(
+                    llm_title_generated=False,
+                    messages=[_user_msg("q"), _asst_msg("a")] * 5,
+                )
                 _maybe_schedule_title_refresh(session, self._noop_put, None)
         assert spawned == []
 
     def test_does_nothing_when_exchange_count_not_at_interval(self):
         """Refresh only fires when exchange_count % interval == 0 (and > 0)."""
-        with patch('api.streaming._get_title_refresh_interval', return_value=5):
+        with patch("api.streaming._get_title_refresh_interval", return_value=5):
             spawned = []
-            with patch('threading.Thread', side_effect=lambda **kw: spawned.append(kw) or MagicMock()):
+            with patch(
+                "threading.Thread",
+                side_effect=lambda **kw: spawned.append(kw) or MagicMock(),
+            ):
                 # 4 exchanges — not a multiple of 5
-                session = _make_session(messages=[_user_msg('q'), _asst_msg('a')] * 4)
+                session = _make_session(messages=[_user_msg("q"), _asst_msg("a")] * 4)
                 _maybe_schedule_title_refresh(session, self._noop_put, None)
         assert spawned == []
 
     def test_spawns_thread_at_exact_interval(self):
         """Refresh fires when exchange_count == refresh_interval."""
-        with patch('api.streaming._get_title_refresh_interval', return_value=5):
+        with patch("api.streaming._get_title_refresh_interval", return_value=5):
             spawned = []
-            with patch('threading.Thread') as mock_thread_cls:
+            with patch("threading.Thread") as mock_thread_cls:
                 mock_thread = MagicMock()
                 mock_thread_cls.return_value = mock_thread
                 # 5 user messages = 5 exchanges
-                session = _make_session(messages=[_user_msg('q'), _asst_msg('a')] * 5)
+                session = _make_session(messages=[_user_msg("q"), _asst_msg("a")] * 5)
                 _maybe_schedule_title_refresh(session, self._noop_put, None)
                 assert mock_thread_cls.called
                 assert mock_thread.start.called
 
     def test_spawns_thread_at_multiple_of_interval(self):
         """Refresh fires at 10 exchanges when interval is 5."""
-        with patch('api.streaming._get_title_refresh_interval', return_value=5):
-            with patch('threading.Thread') as mock_thread_cls:
+        with patch("api.streaming._get_title_refresh_interval", return_value=5):
+            with patch("threading.Thread") as mock_thread_cls:
                 mock_thread = MagicMock()
                 mock_thread_cls.return_value = mock_thread
                 # 10 exchanges
-                session = _make_session(messages=[_user_msg('q'), _asst_msg('a')] * 10)
+                session = _make_session(messages=[_user_msg("q"), _asst_msg("a")] * 10)
                 _maybe_schedule_title_refresh(session, self._noop_put, None)
                 assert mock_thread_cls.called
 
     def test_does_nothing_when_no_exchange_content(self):
         """Even at interval, if both snippets are empty, don't spawn."""
-        with patch('api.streaming._get_title_refresh_interval', return_value=5), \
-             patch('api.streaming._latest_exchange_snippets', return_value=('', '')):
+        with (
+            patch("api.streaming._get_title_refresh_interval", return_value=5),
+            patch("api.streaming._latest_exchange_snippets", return_value=("", "")),
+        ):
             spawned = []
-            with patch('threading.Thread', side_effect=lambda **kw: spawned.append(kw) or MagicMock()):
-                session = _make_session(messages=[_user_msg('q'), _asst_msg('a')] * 5)
+            with patch(
+                "threading.Thread",
+                side_effect=lambda **kw: spawned.append(kw) or MagicMock(),
+            ):
+                session = _make_session(messages=[_user_msg("q"), _asst_msg("a")] * 5)
                 _maybe_schedule_title_refresh(session, self._noop_put, None)
         assert spawned == []

--- a/tests/test_1059_settings_picker_active_state.py
+++ b/tests/test_1059_settings_picker_active_state.py
@@ -8,10 +8,15 @@ override on the active state.
 
 Issue: #1059 (settings picker active state)
 """
+
 from pathlib import Path
 
-BOOT_JS = (Path(__file__).parent.parent / "static" / "boot.js").read_text(encoding="utf-8")
-STYLE_CSS = (Path(__file__).parent.parent / "static" / "style.css").read_text(encoding="utf-8")
+BOOT_JS = (Path(__file__).parent.parent / "static" / "boot.js").read_text(
+    encoding="utf-8"
+)
+STYLE_CSS = (Path(__file__).parent.parent / "static" / "style.css").read_text(
+    encoding="utf-8"
+)
 
 
 class TestSettingsPickerActiveState:
@@ -21,7 +26,7 @@ class TestSettingsPickerActiveState:
         """_syncThemePicker must toggle .active class, not set inline borderColor."""
         idx = BOOT_JS.find("function _syncThemePicker(")
         assert idx >= 0, "_syncThemePicker function not found in boot.js"
-        body = BOOT_JS[idx:idx + 300]
+        body = BOOT_JS[idx : idx + 300]
         assert "classList.toggle" in body, (
             "_syncThemePicker must use classList.toggle('active', ...) — "
             "inline style.borderColor is overridden by !important CSS rules"
@@ -36,7 +41,7 @@ class TestSettingsPickerActiveState:
         """_syncFontSizePicker must toggle .active class."""
         idx = BOOT_JS.find("function _syncFontSizePicker(")
         assert idx >= 0, "_syncFontSizePicker function not found in boot.js"
-        body = BOOT_JS[idx:idx + 300]
+        body = BOOT_JS[idx : idx + 300]
         assert "classList.toggle" in body, (
             "_syncFontSizePicker must use classList.toggle('active', ...)"
         )
@@ -48,7 +53,7 @@ class TestSettingsPickerActiveState:
         """_syncSkinPicker must toggle .active class."""
         idx = BOOT_JS.find("function _syncSkinPicker(")
         assert idx >= 0, "_syncSkinPicker function not found in boot.js"
-        body = BOOT_JS[idx:idx + 300]
+        body = BOOT_JS[idx : idx + 300]
         assert "classList.toggle" in body, (
             "_syncSkinPicker must use classList.toggle('active', ...)"
         )
@@ -69,7 +74,7 @@ class TestSettingsPickerActiveState:
         )
         # The active rule must use !important to beat the base !important rule
         idx = STYLE_CSS.find(".theme-pick-btn.active")
-        rule = STYLE_CSS[idx:idx + 200]
+        rule = STYLE_CSS[idx : idx + 200]
         assert "!important" in rule, (
             ".theme-pick-btn.active must use !important to override "
             "the base border-color:var(--border)!important rule"
@@ -78,7 +83,7 @@ class TestSettingsPickerActiveState:
     def test_active_rule_uses_accent_color(self):
         """The .active rule must apply the accent color to make selection visible."""
         idx = STYLE_CSS.find(".theme-pick-btn.active")
-        rule = STYLE_CSS[idx:idx + 200]
+        rule = STYLE_CSS[idx : idx + 200]
         assert "var(--accent)" in rule, (
             ".theme-pick-btn.active must set border-color to var(--accent)"
         )

--- a/tests/test_1062_busy_input_modes.py
+++ b/tests/test_1062_busy_input_modes.py
@@ -9,6 +9,7 @@ Pins the wiring for the three modes (queue / interrupt / steer):
 
 Issue: #720 (configurable busy-input behaviour)
 """
+
 from pathlib import Path
 
 ROOT = Path(__file__).parent.parent
@@ -24,6 +25,7 @@ I18N_JS = (ROOT / "static" / "i18n.js").read_text(encoding="utf-8")
 
 # ── Backend: setting registration + enum validation ─────────────────────
 
+
 class TestBusyInputModeSetting:
     """The new setting key must be registered with a default and enum validator."""
 
@@ -38,13 +40,14 @@ class TestBusyInputModeSetting:
         # Find the entry inside the enum dict (a set literal as the value)
         idx = CONFIG_PY.find('"busy_input_mode": {')
         assert idx >= 0, "busy_input_mode entry missing from _SETTINGS_ENUM_KEYS"
-        block = CONFIG_PY[idx:idx + 200]
+        block = CONFIG_PY[idx : idx + 200]
         assert '"queue"' in block and '"interrupt"' in block and '"steer"' in block, (
             "busy_input_mode enum must contain {queue, interrupt, steer}"
         )
 
 
 # ── Frontend: slash commands ─────────────────────────────────────────────
+
 
 class TestSlashCommandRegistration:
     """The three new slash commands must be registered in COMMANDS array."""
@@ -67,7 +70,7 @@ class TestSlashCommandRegistration:
         for name in ("queue", "interrupt", "steer"):
             idx = COMMANDS_JS.find(f"name:'{name}'")
             assert idx >= 0, f"{name} not registered"
-            block = COMMANDS_JS[idx:idx + 250]
+            block = COMMANDS_JS[idx : idx + 250]
             assert "noEcho:true" in block, (
                 f"/{name} registration must set noEcho:true — "
                 "without it the command text is echoed as a user bubble, causing duplicates"
@@ -83,15 +86,23 @@ class TestSlashCommandHandlers:
         idle-send path rather than the queue path."""
         idx = COMMANDS_JS.find("async function cmdQueue(")
         assert idx >= 0
-        body = COMMANDS_JS[idx:idx + 600]
-        assert "if(!S.busy)" in body, "/queue must have an if(!S.busy) guard that routes to send()"
+        body = COMMANDS_JS[idx : idx + 600]
+        assert "if(!S.busy)" in body, (
+            "/queue must have an if(!S.busy) guard that routes to send()"
+        )
 
     def test_cmd_interrupt_calls_cancel_stream(self):
         idx = COMMANDS_JS.find("async function cmdInterrupt(")
         assert idx >= 0
-        body = COMMANDS_JS[idx:idx + 1300]  # expanded: idle-fallback block added before the busy path
-        assert "queueSessionMessage" in body, "/interrupt must queue the new message before cancelling"
-        assert "cancelStream" in body, "/interrupt must call cancelStream() so the drain re-sends"
+        body = COMMANDS_JS[
+            idx : idx + 1300
+        ]  # expanded: idle-fallback block added before the busy path
+        assert "queueSessionMessage" in body, (
+            "/interrupt must queue the new message before cancelling"
+        )
+        assert "cancelStream" in body, (
+            "/interrupt must call cancelStream() so the drain re-sends"
+        )
 
     def test_cmd_steer_delegates_to_try_steer(self):
         """/steer delegates to _trySteer which calls /api/chat/steer with
@@ -99,21 +110,22 @@ class TestSlashCommandHandlers:
         in test_real_steer.py — this test just pins the delegation."""
         idx = COMMANDS_JS.find("async function cmdSteer(")
         assert idx >= 0
-        body = COMMANDS_JS[idx:idx + 800]
+        body = COMMANDS_JS[idx : idx + 800]
         # cmdSteer now delegates to _trySteer; the fallback (queueSessionMessage
         # + cancelStream) lives inside _trySteer.
-        assert "_trySteer" in body, "cmdSteer must call _trySteer to use the real /api/chat/steer endpoint"
+        assert "_trySteer" in body, (
+            "cmdSteer must call _trySteer to use the real /api/chat/steer endpoint"
+        )
         # The shared helper must contain the fallback path
         helper_idx = COMMANDS_JS.find("async function _trySteer(")
         assert helper_idx >= 0, "_trySteer helper must exist"
-        helper_body = COMMANDS_JS[helper_idx:helper_idx + 1500]
+        helper_body = COMMANDS_JS[helper_idx : helper_idx + 1500]
         assert "queueSessionMessage" in helper_body
         assert "cancelStream" in helper_body
         # Toast should differ from interrupt to signal it's the steer path
         assert "cmd_steer_fallback" in helper_body or "steer_fallback" in helper_body
 
-
-# ── send() busy branch ───────────────────────────────────────────────────
+    # ── send() busy branch ───────────────────────────────────────────────────
 
     def test_slash_commands_clear_pending_files(self):
         """All three busy command handlers must clear S.pendingFiles (directly
@@ -129,7 +141,7 @@ class TestSlashCommandHandlers:
         for fn_name in ("cmdQueue", "cmdInterrupt"):
             idx = COMMANDS_JS.find(f"function {fn_name}(")
             assert idx >= 0, f"{fn_name} not found"
-            body = COMMANDS_JS[idx:idx + 800]
+            body = COMMANDS_JS[idx : idx + 800]
             assert "S.pendingFiles=[]" in body, (
                 f"{fn_name} must clear S.pendingFiles after queueSessionMessage"
             )
@@ -139,7 +151,7 @@ class TestSlashCommandHandlers:
         # cmdSteer delegates to _trySteer; that helper clears pendingFiles
         idx_try = COMMANDS_JS.find("function _trySteer(")
         assert idx_try >= 0, "_trySteer not found"
-        try_body = COMMANDS_JS[idx_try:idx_try + 1200]
+        try_body = COMMANDS_JS[idx_try : idx_try + 1200]
         assert "S.pendingFiles=[]" in try_body, (
             "_trySteer must clear S.pendingFiles in its fallback path — "
             "without this, files are lost on steer→interrupt fallback"
@@ -155,7 +167,7 @@ class TestBusySendButton:
     def test_update_send_btn_uses_single_primary_action_button(self):
         idx = UI_JS.find("function updateSendBtn()")
         assert idx >= 0, "updateSendBtn() not found"
-        body = UI_JS[idx:UI_JS.find("function setBusy", idx)]
+        body = UI_JS[idx : UI_JS.find("function setBusy", idx)]
         assert "getComposerPrimaryAction()" in body, (
             "updateSendBtn must derive icon/color/enabled state from one composer-primary action helper"
         )
@@ -172,12 +184,20 @@ class TestBusySendButton:
     def test_composer_primary_action_accounts_for_all_busy_input_modes(self):
         idx = UI_JS.find("function getComposerPrimaryAction()")
         assert idx >= 0, "getComposerPrimaryAction() not found"
-        body = UI_JS[idx:UI_JS.find("function _setComposerPrimaryButtonIcon", idx)]
+        body = UI_JS[idx : UI_JS.find("function _setComposerPrimaryButtonIcon", idx)]
         assert "return 'stop'" in body, "busy/no-draft + active stream must map to stop"
-        assert "return 'queue'" in body, "queue mode and unavailable steer/interrupt fallbacks must map to queue"
-        assert "return 'interrupt'" in body, "interrupt mode with an active stream must map to interrupt"
-        assert "return 'steer'" in body, "steer mode with active stream support must map to steer"
-        assert "window._busyInputMode||'queue'" in body, "helper must respect the Busy input mode setting"
+        assert "return 'queue'" in body, (
+            "queue mode and unavailable steer/interrupt fallbacks must map to queue"
+        )
+        assert "return 'interrupt'" in body, (
+            "interrupt mode with an active stream must map to interrupt"
+        )
+        assert "return 'steer'" in body, (
+            "steer mode with active stream support must map to steer"
+        )
+        assert "window._busyInputMode||'queue'" in body, (
+            "helper must respect the Busy input mode setting"
+        )
         assert "_getExplicitBusyCommandAction(msg&&msg.value)" in body, (
             "explicit /queue, /interrupt, and /steer drafts must override the Busy input mode for button visuals"
         )
@@ -185,7 +205,7 @@ class TestBusySendButton:
     def test_explicit_busy_commands_override_button_visual_action(self):
         idx = UI_JS.find("function _getExplicitBusyCommandAction(")
         assert idx >= 0, "_getExplicitBusyCommandAction() not found"
-        body = UI_JS[idx:UI_JS.find("function getComposerPrimaryAction", idx)]
+        body = UI_JS[idx : UI_JS.find("function getComposerPrimaryAction", idx)]
         assert "name==='queue'" in body and "return 'queue'" in body, (
             "typing /queue <message> should show the queue/list-end button even in another busy mode"
         )
@@ -216,14 +236,14 @@ class TestSendBusyBranchDispatch:
         send_idx = MESSAGES_JS.find("async function send(")
         assert send_idx >= 0
         # Look in the first ~3000 chars of send() for the busy mode read
-        send_body = MESSAGES_JS[send_idx:send_idx + 3000]
+        send_body = MESSAGES_JS[send_idx : send_idx + 3000]
         assert "_busyInputMode" in send_body, (
             "send() must read window._busyInputMode in the S.busy branch"
         )
 
     def test_send_calls_cancel_stream_on_interrupt(self):
         send_idx = MESSAGES_JS.find("async function send(")
-        send_body = MESSAGES_JS[send_idx:send_idx + 3000]
+        send_body = MESSAGES_JS[send_idx : send_idx + 3000]
         # The interrupt branch must call cancelStream
         assert "cancelStream" in send_body
         # And queue before cancel (otherwise the drain has nothing to pick up)
@@ -236,7 +256,6 @@ class TestSendBusyBranchDispatch:
             "queueSessionMessage must run before cancelStream so the drain "
             "after setBusy(false) picks up the queued message"
         )
-
 
     def test_slash_commands_intercepted_before_busymode_routing(self):
         """The three busy-control slash commands (/steer /interrupt /queue) must be
@@ -308,6 +327,7 @@ class TestSendBusyBranchDispatch:
 
 # ── Boot init + settings panel wiring ───────────────────────────────────
 
+
 class TestBootAndPanelsWiring:
     def test_boot_init_default_path(self):
         """Boot success path initialises window._busyInputMode from settings."""
@@ -320,7 +340,9 @@ class TestBootAndPanelsWiring:
 
     def test_panels_load_save_apply(self):
         assert "settingsBusyInputMode" in PANELS_JS, "panels.js must load the setting"
-        assert "body.busy_input_mode" in PANELS_JS, "saveSettings must include busy_input_mode in body"
+        assert "body.busy_input_mode" in PANELS_JS, (
+            "saveSettings must include busy_input_mode in body"
+        )
         assert "window._busyInputMode=body.busy_input_mode" in PANELS_JS, (
             "_applySavedSettingsUi must propagate busy_input_mode to the global"
         )
@@ -328,13 +350,14 @@ class TestBootAndPanelsWiring:
     def test_index_html_dropdown_has_three_options(self):
         idx = INDEX_HTML.find('id="settingsBusyInputMode"')
         assert idx >= 0
-        block = INDEX_HTML[idx:idx + 800]
+        block = INDEX_HTML[idx : idx + 800]
         assert 'value="queue"' in block
         assert 'value="interrupt"' in block
         assert 'value="steer"' in block
 
 
 # ── i18n locale coverage ─────────────────────────────────────────────────
+
 
 class TestI18nKeys:
     """All 17 new keys must appear in each of the 6 locale blocks."""
@@ -370,6 +393,4 @@ class TestI18nKeys:
     def test_key_count_total(self):
         """17 keys × 6 locales = 102 minimum occurrences across the file."""
         total = sum(I18N_JS.count(f"{key}:") for key in self.REQUIRED_KEYS)
-        assert total >= 17 * 6, (
-            f"Total i18n occurrences = {total}; expected ≥ {17*6}"
-        )
+        assert total >= 17 * 6, f"Total i18n occurrences = {total}; expected ≥ {17 * 6}"

--- a/tests/test_1079_cron_session_project.py
+++ b/tests/test_1079_cron_session_project.py
@@ -2,12 +2,9 @@
 
 import json
 import pathlib
-import shutil
-import tempfile
 
 import pytest
 
-from tests.conftest import TEST_STATE_DIR, _post, TEST_BASE
 
 pytestmark = pytest.mark.usefixtures("test_server")
 
@@ -15,6 +12,7 @@ pytestmark = pytest.mark.usefixtures("test_server")
 def _get_projects(base_url):
     """Fetch the project list from the API."""
     import urllib.request
+
     with urllib.request.urlopen(base_url + "/api/projects", timeout=5) as r:
         return json.loads(r.read())
 
@@ -25,17 +23,17 @@ def test_ensure_cron_project_creates_project():
 
     # Remove any existing Cron Jobs project to test creation
     projects = load_projects()
-    original = [p for p in projects if p.get('name') != 'Cron Jobs']
+    original = [p for p in projects if p.get("name") != "Cron Jobs"]
     save_projects(original)
 
     pid = ensure_cron_project()
 
     # Should now exist
     projects = load_projects()
-    cron_projects = [p for p in projects if p.get('name') == 'Cron Jobs']
+    cron_projects = [p for p in projects if p.get("name") == "Cron Jobs"]
     assert len(cron_projects) == 1
-    assert cron_projects[0]['project_id'] == pid
-    assert cron_projects[0]['color'] == '#6366f1'
+    assert cron_projects[0]["project_id"] == pid
+    assert cron_projects[0]["color"] == "#6366f1"
     assert len(pid) == 12
 
     # Restore
@@ -47,7 +45,7 @@ def test_ensure_cron_project_idempotent():
     from api.models import ensure_cron_project, load_projects, save_projects
 
     projects = load_projects()
-    save_projects([p for p in projects if p.get('name') != 'Cron Jobs'])
+    save_projects([p for p in projects if p.get("name") != "Cron Jobs"])
 
     pid1 = ensure_cron_project()
     pid2 = ensure_cron_project()
@@ -82,12 +80,15 @@ def test_cron_jobs_project_i18n_key_exists():
 
     # Count occurrences of cron_jobs_project
     count = content.count("cron_jobs_project:")
-    assert count >= 9, f"Expected >= 9 locale entries for cron_jobs_project, found {count}"
+    assert count >= 9, (
+        f"Expected >= 9 locale entries for cron_jobs_project, found {count}"
+    )
 
 
 def test_cron_session_gets_project_id_in_cli_list():
     """get_cli_sessions() should assign project_id for cron sessions."""
     from api.models import get_cli_sessions
+
     # Just verify the function is callable and returns a list
     # The actual project assignment is tested indirectly via integration
     sessions = get_cli_sessions()

--- a/tests/test_1325_user_fenced_code.py
+++ b/tests/test_1325_user_fenced_code.py
@@ -1,9 +1,10 @@
 """Tests for issue #1325 — fenced code blocks in user message bubbles."""
+
 import os
 import subprocess
 import tempfile
 
-UI_JS = os.path.join(os.path.dirname(__file__), '..', 'static', 'ui.js')
+UI_JS = os.path.join(os.path.dirname(__file__), "..", "static", "ui.js")
 
 
 def _extract_js_functions():
@@ -28,7 +29,11 @@ def _extract_js_functions():
     esc_line = next(line for line in src.split("\n") if line.startswith("const esc="))
     helper_defs = "\n".join(
         extract_function(name)
-        for name in ("_matchBacktickFenceLine", "_isBacktickFenceClose", "_renderUserFencedBlocks")
+        for name in (
+            "_matchBacktickFenceLine",
+            "_isBacktickFenceClose",
+            "_renderUserFencedBlocks",
+        )
     )
     return esc_line, helper_defs
 
@@ -36,17 +41,22 @@ def _extract_js_functions():
 def _run_user_render(text_input):
     """Return the HTML output of _renderUserFencedBlocks for the given input text."""
     import json
+
     esc_def, fn_def = _extract_js_functions()
-    js_code = esc_def + '\n' + fn_def + '\n'
-    js_code += 'var input = JSON.parse(process.argv[2]);\n'
-    js_code += 'process.stdout.write(_renderUserFencedBlocks(input));\n'
-    tf = tempfile.NamedTemporaryFile(mode='w', suffix='.js', delete=False, encoding='utf-8')
+    js_code = esc_def + "\n" + fn_def + "\n"
+    js_code += "var input = JSON.parse(process.argv[2]);\n"
+    js_code += "process.stdout.write(_renderUserFencedBlocks(input));\n"
+    tf = tempfile.NamedTemporaryFile(
+        mode="w", suffix=".js", delete=False, encoding="utf-8"
+    )
     tf.write(js_code)
     tf.close()
     try:
         result = subprocess.run(
-            ['node', tf.name, json.dumps(text_input)],
-            capture_output=True, text=True, timeout=10
+            ["node", tf.name, json.dumps(text_input)],
+            capture_output=True,
+            text=True,
+            timeout=10,
         )
         if result.returncode != 0:
             raise RuntimeError(f"node error: {result.stderr}")
@@ -61,67 +71,67 @@ class TestUserFencedBlocks:
     def test_simple_fenced_block(self):
         out = _run_user_render("hello\n```python\nprint(1)\n```\nworld")
         assert '<pre><code class="language-python">' in out
-        assert 'print(1)' in out
+        assert "print(1)" in out
         # Newlines around the fenced block become <br> (same as original plain-text path)
-        assert 'hello<br>' in out
-        assert '<br>world' in out
+        assert "hello<br>" in out
+        assert "<br>world" in out
 
     def test_fenced_block_escaped_html(self):
         """HTML in code blocks should be escaped."""
         out = _run_user_render("```html\n<div>hi</div>\n```")
-        assert '&lt;div&gt;' in out
+        assert "&lt;div&gt;" in out
         # No raw <div> in code content
-        assert '<div>' not in out.replace('&lt;div&gt;', '').replace('&gt;', '')
+        assert "<div>" not in out.replace("&lt;div&gt;", "").replace("&gt;", "")
 
     def test_plain_text_not_interpreted_as_markdown(self):
         """Bold/italic/links in non-fenced text should stay escaped."""
         out = _run_user_render("**bold** and *italic* and <script>alert(1)</script>")
-        assert '**bold**' in out
-        assert '*italic*' in out
-        assert '&lt;script&gt;' in out
-        assert '<strong>' not in out
+        assert "**bold**" in out
+        assert "*italic*" in out
+        assert "&lt;script&gt;" in out
+        assert "<strong>" not in out
 
     def test_language_header_shown(self):
         out = _run_user_render("```javascript\nconst x = 1;\n```")
         assert 'class="pre-header"' in out
-        assert 'javascript' in out
+        assert "javascript" in out
 
     def test_no_language_no_header(self):
         out = _run_user_render("```\nsome code\n```")
         assert 'class="pre-header"' not in out
-        assert '<pre><code>' in out
-        assert 'some code' in out
+        assert "<pre><code>" in out
+        assert "some code" in out
 
     def test_diff_block_colored(self):
         out = _run_user_render("```diff\n+added\n-removed\n```")
-        assert 'diff-block' in out
-        assert 'diff-plus' in out
-        assert 'diff-minus' in out
+        assert "diff-block" in out
+        assert "diff-plus" in out
+        assert "diff-minus" in out
 
     def test_multiple_fenced_blocks(self):
         out = _run_user_render("first\n```python\n1\n```\nmiddle\n```js\n2\n```\nlast")
-        assert 'language-python' in out
-        assert 'language-js' in out
-        assert 'first<br>' in out
-        assert '<br>last' in out
+        assert "language-python" in out
+        assert "language-js" in out
+        assert "first<br>" in out
+        assert "<br>last" in out
 
     def test_fenced_block_with_ampersand(self):
         out = _run_user_render("```python\nx & y\n```")
-        assert 'x &amp; y' in out
+        assert "x &amp; y" in out
 
     def test_empty_code_block(self):
         out = _run_user_render("```\n```")
-        assert '<pre><code>' in out
+        assert "<pre><code>" in out
 
     def test_special_chars_outside_blocks_escaped(self):
         out = _run_user_render("a < b > c & d")
-        assert 'a &lt; b &gt; c &amp; d' in out
+        assert "a &lt; b &gt; c &amp; d" in out
 
     def test_links_not_rendered_in_plain_text(self):
         """URLs in plain text should NOT become clickable links."""
         out = _run_user_render("Check https://example.com for details")
-        assert '<a ' not in out
-        assert 'https://example.com' in out
+        assert "<a " not in out
+        assert "https://example.com" in out
 
     def test_four_backtick_outer_fence_preserves_inner_triple_fence(self):
         """User-message code fences should follow CommonMark fence-length matching too."""
@@ -136,5 +146,5 @@ class TestUserFencedBlocks:
     def test_inline_backticks_not_touched(self):
         """Inline backticks (single backtick, not fenced block) should remain escaped as text."""
         out = _run_user_render("use `var x = 1` here")
-        assert '`var x = 1`' in out
-        assert '<code>' not in out
+        assert "`var x = 1`" in out
+        assert "<code>" not in out

--- a/tests/test_1432_newchat_and_1423_profile_input.py
+++ b/tests/test_1432_newchat_and_1423_profile_input.py
@@ -4,14 +4,15 @@ and #1423 (profile name input lacks autocapitalize/spellcheck attrs).
 
 Both bugs ship as static-asset diffs verified by reading the JS files.
 """
+
 import os
 import re
 
-STATIC_DIR = os.path.join(os.path.dirname(__file__), '..', 'static')
+STATIC_DIR = os.path.join(os.path.dirname(__file__), "..", "static")
 
 
 def _read(filename):
-    return open(os.path.join(STATIC_DIR, filename), encoding='utf-8').read()
+    return open(os.path.join(STATIC_DIR, filename), encoding="utf-8").read()
 
 
 class TestIssue1432NewChatGuardInFlight:
@@ -25,50 +26,52 @@ class TestIssue1432NewChatGuardInFlight:
     """
 
     def test_btnNewChat_handler_checks_in_flight_state(self):
-        src = _read('boot.js')
+        src = _read("boot.js")
         # Locate the btnNewChat onclick handler
         m = re.search(
             r"\$\('btnNewChat'\)\.onclick=async\(\)=>\{(.*?)\};",
-            src, re.DOTALL,
+            src,
+            re.DOTALL,
         )
         assert m, "btnNewChat onclick handler not found in boot.js"
         body = m.group(1)
         # The empty-session guard must check all three in-flight signals
-        assert 'message_count' in body, \
-            "btnNewChat guard missing message_count check"
-        assert 'S.busy' in body, \
-            "btnNewChat guard missing S.busy check (#1432)"
-        assert 'active_stream_id' in body, \
+        assert "message_count" in body, "btnNewChat guard missing message_count check"
+        assert "S.busy" in body, "btnNewChat guard missing S.busy check (#1432)"
+        assert "active_stream_id" in body, (
             "btnNewChat guard missing active_stream_id check (#1432)"
-        assert 'pending_user_message' in body, \
+        )
+        assert "pending_user_message" in body, (
             "btnNewChat guard missing pending_user_message check (#1432)"
+        )
 
     def test_cmdK_handler_checks_in_flight_state(self):
-        src = _read('boot.js')
+        src = _read("boot.js")
         # Locate the Cmd/Ctrl+K branch — it sits inside a keydown listener
         idx = src.find("(e.metaKey||e.ctrlKey)&&e.key==='k'")
         assert idx >= 0, "Cmd/Ctrl+K handler not found in boot.js"
         # Read the next ~1500 chars (handler body)
-        body = src[idx:idx + 1500]
-        assert 'message_count' in body, \
-            "Cmd/Ctrl+K guard missing message_count check"
-        assert 'S.busy' in body, \
-            "Cmd/Ctrl+K guard missing S.busy check (#1432)"
-        assert 'active_stream_id' in body, \
+        body = src[idx : idx + 1500]
+        assert "message_count" in body, "Cmd/Ctrl+K guard missing message_count check"
+        assert "S.busy" in body, "Cmd/Ctrl+K guard missing S.busy check (#1432)"
+        assert "active_stream_id" in body, (
             "Cmd/Ctrl+K guard missing active_stream_id check (#1432)"
-        assert 'pending_user_message' in body, \
+        )
+        assert "pending_user_message" in body, (
             "Cmd/Ctrl+K guard missing pending_user_message check (#1432)"
+        )
 
     def test_in_flight_signal_matches_restoreSettledSession(self):
         """The new in-flight check uses the same signal as the canonical
         'session is in flight' detector at messages.js:_restoreSettledSession.
         Verifying both files use the same shape so future refactors don't
         diverge."""
-        msgs_src = _read('messages.js')
+        msgs_src = _read("messages.js")
         # The canonical detector
-        assert 'session.active_stream_id||session.pending_user_message' in msgs_src, \
-            "Canonical in-flight detector at _restoreSettledSession changed shape — " \
+        assert "session.active_stream_id||session.pending_user_message" in msgs_src, (
+            "Canonical in-flight detector at _restoreSettledSession changed shape — "
             "boot.js #1432 fix uses the same signals; keep them aligned"
+        )
 
 
 class TestIssue1423ProfileFormAutocapitalize:
@@ -80,7 +83,7 @@ class TestIssue1423ProfileFormAutocapitalize:
     so stored data is correct; the bug is purely a misleading display."""
 
     def _profile_input_html(self, input_id):
-        src = _read('panels.js')
+        src = _read("panels.js")
         # Match the input element — pull the full opening tag
         m = re.search(
             rf'<input\s+[^>]*id="{re.escape(input_id)}"[^>]*>',
@@ -89,34 +92,38 @@ class TestIssue1423ProfileFormAutocapitalize:
         return m.group(0) if m else None
 
     def test_profile_name_has_autocapitalize_none(self):
-        html = self._profile_input_html('profileFormName')
+        html = self._profile_input_html("profileFormName")
         assert html, "profileFormName input not found in panels.js"
-        assert 'autocapitalize="none"' in html, \
-            f"profileFormName missing autocapitalize=\"none\" (#1423): {html}"
+        assert 'autocapitalize="none"' in html, (
+            f'profileFormName missing autocapitalize="none" (#1423): {html}'
+        )
 
     def test_profile_name_has_spellcheck_false(self):
-        html = self._profile_input_html('profileFormName')
+        html = self._profile_input_html("profileFormName")
         assert html, "profileFormName input not found"
-        assert 'spellcheck="false"' in html, \
-            f"profileFormName missing spellcheck=\"false\" (#1423): {html}"
+        assert 'spellcheck="false"' in html, (
+            f'profileFormName missing spellcheck="false" (#1423): {html}'
+        )
 
     def test_profile_name_has_autocorrect_off(self):
-        html = self._profile_input_html('profileFormName')
+        html = self._profile_input_html("profileFormName")
         assert html, "profileFormName input not found"
-        assert 'autocorrect="off"' in html, \
-            f"profileFormName missing autocorrect=\"off\" (#1423): {html}"
+        assert 'autocorrect="off"' in html, (
+            f'profileFormName missing autocorrect="off" (#1423): {html}'
+        )
 
     def test_profile_name_keeps_required(self):
         """Regression guard: required must still be present."""
-        html = self._profile_input_html('profileFormName')
-        assert ' required' in html, \
-            f"profileFormName lost required attribute: {html}"
+        html = self._profile_input_html("profileFormName")
+        assert " required" in html, f"profileFormName lost required attribute: {html}"
 
     def test_profile_baseurl_has_autocapitalize_none(self):
         """Base URL inputs are equally bad targets for autocapitalize."""
-        html = self._profile_input_html('profileFormBaseUrl')
+        html = self._profile_input_html("profileFormBaseUrl")
         assert html, "profileFormBaseUrl input not found"
-        assert 'autocapitalize="none"' in html, \
-            f"profileFormBaseUrl missing autocapitalize=\"none\" (#1423)"
-        assert 'spellcheck="false"' in html, \
-            f"profileFormBaseUrl missing spellcheck=\"false\" (#1423)"
+        assert 'autocapitalize="none"' in html, (
+            'profileFormBaseUrl missing autocapitalize="none" (#1423)'
+        )
+        assert 'spellcheck="false"' in html, (
+            'profileFormBaseUrl missing spellcheck="false" (#1423)'
+        )

--- a/tests/test_1466_bfcache_inflight_reattach.py
+++ b/tests/test_1466_bfcache_inflight_reattach.py
@@ -5,6 +5,7 @@ A browser `pageshow` restore from BFCache does not re-run the boot IIFE. After
 `checkInflightOnBoot()`. BFCache restore should align with that path for the
 currently viewed session instead of only refreshing layout chrome/sidebar cache.
 """
+
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).parent.parent
@@ -63,4 +64,9 @@ def test_pageshow_active_session_restore_is_guarded_and_non_blocking():
     body = _pageshow_handler()
     assert "typeof loadSession === 'function'" in body
     assert "typeof checkInflightOnBoot === 'function'" in body
-    assert "catch" in body[body.find("loadSession(S.session.session_id") : body.find("startGatewaySSE")]
+    assert (
+        "catch"
+        in body[
+            body.find("loadSession(S.session.session_id") : body.find("startGatewaySSE")
+        ]
+    )

--- a/tests/test_1466_sidebar_cancel_clarify.py
+++ b/tests/test_1466_sidebar_cancel_clarify.py
@@ -5,6 +5,7 @@ owns the stream. Cancelling a running session from the sidebar context menu must
 address that session's stream id and must only clear approval/clarify UI owned by
 that session.
 """
+
 from pathlib import Path
 
 ROOT = Path(__file__).parent.parent
@@ -33,18 +34,22 @@ class TestSidebarCancelAction:
         assert "cancelSessionStream(session)" in body, (
             "running sidebar sessions must expose a stop action that cancels that session"
         )
-        assert body.find("cancelSessionStream(session)") < body.find("deleteSession(session.session_id)"), (
-            "stop action should appear before destructive delete action"
-        )
+        assert body.find("cancelSessionStream(session)") < body.find(
+            "deleteSession(session.session_id)"
+        ), "stop action should appear before destructive delete action"
 
     def test_cancel_session_stream_uses_session_owned_stream_id(self):
         """Cancel-from-sidebar must call /api/chat/cancel with the row's stream id."""
         body = _function_body(BOOT_JS, "cancelSessionStream")
-        assert "session&&session.active_stream_id" in body or "session && session.active_stream_id" in body
-        assert "stream_id=${encodeURIComponent(streamId)}" in body
-        assert "S.activeStreamId" not in body.split("const streamId", 1)[1].split("fetch", 1)[0], (
-            "sidebar cancel must not derive the stream id from the active pane global"
+        assert (
+            "session&&session.active_stream_id" in body
+            or "session && session.active_stream_id" in body
         )
+        assert "stream_id=${encodeURIComponent(streamId)}" in body
+        assert (
+            "S.activeStreamId"
+            not in body.split("const streamId", 1)[1].split("fetch", 1)[0]
+        ), "sidebar cancel must not derive the stream id from the active pane global"
 
     def test_cancel_session_stream_clears_only_owned_clarify_and_approval_cards(self):
         """Cancelling A from sidebar must not blanket-clear B's clarify/approval cards."""
@@ -80,5 +85,7 @@ class TestSidebarCancelAction:
         # duplicate/delete should both be gated by the same external-session check
         first = body.find("_appendSessionDuplicateAction")
         second = body.find("t('session_delete')")
-        assert first > 0 and second > 0, "menu actions should still include duplicate/delete nodes"
+        assert first > 0 and second > 0, (
+            "menu actions should still include duplicate/delete nodes"
+        )
         assert first < second, "duplicate action should render before delete action"

--- a/tests/test_1560_password_env_var_no_op.py
+++ b/tests/test_1560_password_env_var_no_op.py
@@ -20,7 +20,6 @@ the silent-no-op UX bug.
 
 import io
 import json
-import os
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -58,6 +57,7 @@ def _restore_settings_file_after_test():
 
 
 # ── FakeHandler that supports GET *and* POST body reading ─────────────────────
+
 
 class _FakeHandler:
     """Minimal BaseHTTPRequestHandler stand-in for routes.handle_get/handle_post.
@@ -110,6 +110,7 @@ class _FakeHandler:
 
 
 # ── Backend: GET /api/settings exposes password_env_var ──────────────────────
+
 
 def test_get_settings_exposes_password_env_var_true_when_env_set(monkeypatch):
     """Acceptance criterion: GET /api/settings includes `password_env_var: true`
@@ -168,9 +169,11 @@ def test_get_settings_password_env_var_false_when_env_blank(monkeypatch):
 
 # ── Backend: POST /api/settings returns 409 when env var shadows ─────────────
 
+
 def _post_settings(body_dict, cookie=""):
     """Helper: POST a JSON body to /api/settings via handle_post."""
     from api.routes import handle_post
+
     raw = json.dumps(body_dict).encode("utf-8")
     handler = _FakeHandler(body_bytes=raw, cookie=cookie)
     parsed = urlparse("http://example.com/api/settings")
@@ -219,10 +222,12 @@ def test_post_set_password_settings_hash_unchanged_after_409(monkeypatch):
     monkeypatch.setenv("HERMES_WEBUI_PASSWORD", "shadow-pw")
 
     # Seed settings.json with a known sentinel hash so we can detect any write.
-    from api.config import load_settings, save_settings
+    from api.config import load_settings
+
     # Don't go through save_settings (it would re-route _set_password) — write
     # the file directly via the same path load_settings reads from.
     import api.config as cfg
+
     sentinel_hash = "deadbeef" * 8  # 64 chars, matches PBKDF2 hex output shape
     settings_before = load_settings()
     settings_before["password_hash"] = sentinel_hash
@@ -274,7 +279,7 @@ def test_index_html_has_password_lock_banner_div():
     assert 'id="settingsPasswordEnvLock"' in INDEX_HTML
     assert 'data-i18n="password_env_var_locked"' in INDEX_HTML
     # Default-hidden; panels.js reveals it when settings.password_env_var is true.
-    assert 'settingsPasswordEnvLock' in INDEX_HTML
+    assert "settingsPasswordEnvLock" in INDEX_HTML
     # Sanity: banner sits inside the System pane (same context as the password
     # field) — this guards against a future refactor that moves the banner away
     # from the field it explains.
@@ -346,7 +351,7 @@ def _locale_block(locale_key: str) -> str:
         opener = f"  {locale_key}:"
     start = I18N_JS.index(opener)
     # Find the next locale opener, scanning all known locales.
-    rest = I18N_JS[start + len(opener):]
+    rest = I18N_JS[start + len(opener) :]
     next_starts = []
     for other in EXPECTED_LOCALES:
         if other == locale_key:

--- a/tests/test_1620_paste_text_with_image.py
+++ b/tests/test_1620_paste_text_with_image.py
@@ -16,12 +16,13 @@ The fix:
 These tests guard the handler shape against regression by static-analyzing
 `static/boot.js`. They follow the same pattern as `test_issue1095_pasted_images.py`.
 """
+
 import os
 import re
 
 
 def _read_boot_js() -> str:
-    with open(os.path.join('static', 'boot.js')) as f:
+    with open(os.path.join("static", "boot.js")) as f:
         return f.read()
 
 
@@ -35,12 +36,12 @@ def _paste_handler_body() -> str:
     depth = 0
     for i in range(start, len(src)):
         c = src[i]
-        if c == '{':
+        if c == "{":
             depth += 1
-        elif c == '}':
+        elif c == "}":
             depth -= 1
             if depth == 0:
-                return src[start:i + 1]
+                return src[start : i + 1]
     raise AssertionError("Unbalanced braces in #msg paste handler")
 
 
@@ -51,9 +52,11 @@ class TestPasteHandlerTextWithImage:
         """Handler must inspect string items for text/plain or text/html so it can
         defer to the browser's default text-paste behavior when text is present."""
         body = _paste_handler_body()
-        assert "kind==='string'" in body or 'kind === "string"' in body or "kind === 'string'" in body, (
-            "paste handler must check items[].kind === 'string' to detect text payload"
-        )
+        assert (
+            "kind==='string'" in body
+            or 'kind === "string"' in body
+            or "kind === 'string'" in body
+        ), "paste handler must check items[].kind === 'string' to detect text payload"
         assert "'text/plain'" in body, "paste handler must check for text/plain"
         assert "'text/html'" in body, "paste handler must check for text/html"
 
@@ -81,9 +84,15 @@ class TestPasteHandlerTextWithImage:
         """Pure-screenshot paste (image-only clipboard) must still call preventDefault()
         and route through addFiles() so the screenshot attaches as a file."""
         body = _paste_handler_body()
-        assert 'e.preventDefault()' in body, "handler must still preventDefault on image-only paste"
-        assert 'addFiles(files)' in body, "handler must still call addFiles(files) for screenshots"
-        assert 'screenshot-' in body, "handler must still synthesize screenshot-<ts> filename"
+        assert "e.preventDefault()" in body, (
+            "handler must still preventDefault on image-only paste"
+        )
+        assert "addFiles(files)" in body, (
+            "handler must still call addFiles(files) for screenshots"
+        )
+        assert "screenshot-" in body, (
+            "handler must still synthesize screenshot-<ts> filename"
+        )
 
     def test_handler_does_not_use_loose_image_check(self):
         """The pre-fix loose check `i.type.startsWith('image/')` (without kind==='file')

--- a/tests/test_1694_prompt_ownership.py
+++ b/tests/test_1694_prompt_ownership.py
@@ -5,6 +5,7 @@ session's approval/clarify event must not render over or hide the currently
 active pane's card, but the pending prompt should remain available when the user
 switches back to that session.
 """
+
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).parent.parent
@@ -81,7 +82,9 @@ def test_polling_empty_state_clears_only_the_owner_prompt():
     approval_fallback = _function_body(MESSAGES_JS, "_startApprovalFallbackPoll")
     clarify_poll = _function_body(MESSAGES_JS, "startClarifyPolling")
     clarify_fallback = _function_body(MESSAGES_JS, "_startClarifyFallbackPoll")
-    combined = "\n".join([approval_poll, approval_fallback, clarify_poll, clarify_fallback])
+    combined = "\n".join(
+        [approval_poll, approval_fallback, clarify_poll, clarify_fallback]
+    )
     assert "_clearApprovalPendingForSession(sid)" in combined
     assert "_hideApprovalCardIfOwner(sid" in combined
     assert "_clearClarifyPendingForSession(sid)" in combined
@@ -89,7 +92,10 @@ def test_polling_empty_state_clears_only_the_owner_prompt():
     assert "else { hideApprovalCard(); }" not in combined
     assert "else { hideClarifyCard(false, 'expired'); }" not in combined
     assert "stopApprovalPolling(); hideApprovalCard(true); return;" not in combined
-    assert "stopClarifyPolling(); hideClarifyCard(true, 'session'); return;" not in combined
+    assert (
+        "stopClarifyPolling(); hideClarifyCard(true, 'session'); return;"
+        not in combined
+    )
 
 
 def test_load_session_rerenders_cached_prompt_for_new_active_session():
@@ -98,7 +104,9 @@ def test_load_session_rerenders_cached_prompt_for_new_active_session():
 
 
 def test_prompt_rerender_hides_previous_session_cards_without_clearing_cache():
-    approval_body = _function_body(MESSAGES_JS, "_renderPendingApprovalForActiveSession")
+    approval_body = _function_body(
+        MESSAGES_JS, "_renderPendingApprovalForActiveSession"
+    )
     clarify_body = _function_body(MESSAGES_JS, "_renderPendingClarifyForActiveSession")
     assert "_approvalSessionId && _approvalSessionId !== sid" in approval_body
     assert "hideApprovalCard(true)" in approval_body

--- a/tests/test_1694_root_saved_running_policy.py
+++ b/tests/test_1694_root_saved_running_policy.py
@@ -64,14 +64,16 @@ def test_saved_running_session_helper_uses_metadata_only_and_runtime_markers():
     """The helper should inspect metadata without loading messages or attaching SSE."""
     helper_idx = BOOT_JS.find("async function _savedSessionShouldStaySidebarOnly")
     assert helper_idx > 0, "saved-running root policy helper not found"
-    helper = BOOT_JS[helper_idx:helper_idx + 1200]
+    helper = BOOT_JS[helper_idx : helper_idx + 1200]
     assert "/api/session?session_id=" in helper, (
         "helper should inspect session metadata via /api/session before deciding"
     )
     assert "messages=0" in helper, "helper must avoid loading full messages"
     assert "resolve_model=0" in helper, "helper must avoid unnecessary model resolution"
     assert "active_stream_id" in helper, "helper must treat active_stream_id as running"
-    assert "pending_user_message" in helper, "helper must treat pending_user_message as running"
+    assert "pending_user_message" in helper, (
+        "helper must treat pending_user_message as running"
+    )
     assert "loadSession(" not in helper, (
         "helper must not call loadSession(), because that would already project "
         "the saved session into the active pane"
@@ -88,4 +90,6 @@ def test_root_saved_running_sidebar_only_path_renders_empty_state_and_sidebar():
     assert helper_pos >= 0, "saved-running helper call not found"
     assert empty_pos > helper_pos, "sidebar-only path must show the empty state"
     assert render_pos > helper_pos, "sidebar-only path must render the session list"
-    assert return_pos > render_pos, "sidebar-only path should return before loadSession(saved)"
+    assert return_pos > render_pos, (
+        "sidebar-only path should return before loadSession(saved)"
+    )

--- a/tests/test_1694_terminal_cleanup_ownership.py
+++ b/tests/test_1694_terminal_cleanup_ownership.py
@@ -5,6 +5,7 @@ active pane. The owning session's persisted/runtime stream marker can be cleared
 but global pane state such as ``clearInflight()``, approval/clarify polling, and
 ``setBusy(false)`` must be gated to the session that owns the active pane/card.
 """
+
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).parent.parent
@@ -87,7 +88,10 @@ def test_reconnect_settled_and_error_paths_keep_cleanup_session_scoped():
     error_body = _function_body("_handleStreamError")
     combined = restore_body + "\n" + error_body
     assert combined.count("_clearOwnerInflightState();") >= 2
-    assert "delete INFLIGHT[activeSid];clearInflight();clearInflightState(activeSid)" not in combined
+    assert (
+        "delete INFLIGHT[activeSid];clearInflight();clearInflightState(activeSid)"
+        not in combined
+    )
     assert "stopApprovalPolling();stopClarifyPolling();" not in combined
     assert "renderSessionList();setBusy(false)" not in combined
     assert "_setActivePaneIdleIfOwner" in combined

--- a/tests/test_1695_aiagent_import_error_detail.py
+++ b/tests/test_1695_aiagent_import_error_detail.py
@@ -20,11 +20,9 @@ This test suite locks the diagnostic shape of the new error message:
 Behavioural test for the actual raise path lives in the streaming integration
 suite; this file only exercises the helper.
 """
-import os
+
 import sys
 from pathlib import Path
-
-import pytest
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -40,6 +38,7 @@ def _import_helper():
     """
     sys.path.insert(0, str(REPO_ROOT))
     from api import streaming  # noqa: F401
+
     return streaming._aiagent_import_error_detail
 
 
@@ -53,9 +52,9 @@ class TestAIAgentImportErrorDetail:
         helper = _import_helper()
         out = helper()
         first = out.splitlines()[0]
-        assert first == "AIAgent not available -- check that hermes-agent is on sys.path", (
-            f"first line must be the original error message verbatim, got: {first!r}"
-        )
+        assert (
+            first == "AIAgent not available -- check that hermes-agent is on sys.path"
+        ), f"first line must be the original error message verbatim, got: {first!r}"
 
     def test_includes_running_python_interpreter(self):
         """The diagnostic must include the running python so the user knows
@@ -152,13 +151,15 @@ class TestAIAgentImportErrorDocsPresence:
 
     def test_troubleshooting_md_exists(self):
         path = REPO_ROOT / "docs" / "troubleshooting.md"
-        assert path.exists(), "docs/troubleshooting.md must exist (referenced by streaming.py)"
+        assert path.exists(), (
+            "docs/troubleshooting.md must exist (referenced by streaming.py)"
+        )
 
     def test_troubleshooting_md_has_aiagent_section(self):
         path = REPO_ROOT / "docs" / "troubleshooting.md"
         content = path.read_text(encoding="utf-8")
         assert "AIAgent not available" in content, (
-            "docs/troubleshooting.md must have an entry titled \"AIAgent not available\""
+            'docs/troubleshooting.md must have an entry titled "AIAgent not available"'
         )
 
     def test_troubleshooting_md_includes_pip_install_editable(self):

--- a/tests/test_1707_workspace_filename_click.py
+++ b/tests/test_1707_workspace_filename_click.py
@@ -31,6 +31,7 @@ timer and triggers rename.
 These tests guard the handler shape against regression by static-analyzing
 `static/ui.js` and by driving the patched handler through a Node VM.
 """
+
 import json
 import re
 import shutil
@@ -61,7 +62,7 @@ def _name_handler_block() -> str:
     end_marker = "el.appendChild(nameEl);"
     end = src.find(end_marker, start)
     assert end >= 0, "el.appendChild(nameEl) not found after rename tooltip"
-    return src[start:end + len(end_marker)]
+    return src[start : end + len(end_marker)]
 
 
 # ── Source-level regression locks ─────────────────────────────────────────────
@@ -103,7 +104,7 @@ class TestNameClickHandlerShape:
             elif c == "}":
                 depth -= 1
                 if depth == 0:
-                    body = block[start:i + 1]
+                    body = block[start : i + 1]
                     break
         assert body is not None, "could not find balanced nameEl.onclick body"
         assert "setTimeout" in body, (
@@ -173,7 +174,9 @@ class TestNameClickHandlerShape:
 pytestmark = pytest.mark.skipif(NODE is None, reason="node not on PATH")
 
 
-def _run_node_with_clicks(click_count: int, dblclick_after_first: bool, item_type: str = "file"):
+def _run_node_with_clicks(
+    click_count: int, dblclick_after_first: bool, item_type: str = "file"
+):
     """Drive a synthesized click sequence against the patched handler."""
     handler = _name_handler_block()
     payload = {
@@ -183,7 +186,9 @@ def _run_node_with_clicks(click_count: int, dblclick_after_first: bool, item_typ
         "itemType": item_type,
     }
     js = (
-        "const params = " + json.dumps(payload) + ";\n"
+        "const params = "
+        + json.dumps(payload)
+        + ";\n"
         + r"""
 const handlerBlock = params.handlerBlock;
 const clickCount = params.clickCount;
@@ -263,7 +268,9 @@ setTimeout_(() => {
     )
     r = subprocess.run(
         [NODE, "-e", js],
-        capture_output=True, text=True, timeout=10,
+        capture_output=True,
+        text=True,
+        timeout=10,
     )
     if r.returncode != 0:
         raise RuntimeError(f"node failed: {r.stderr}")
@@ -275,7 +282,9 @@ class TestNameClickBehavior:
 
     def test_single_click_opens_file_after_debounce(self):
         """Single click on a FILE name → after 300ms debounce → openFile fires."""
-        out = _run_node_with_clicks(click_count=1, dblclick_after_first=False, item_type="file")
+        out = _run_node_with_clicks(
+            click_count=1, dblclick_after_first=False, item_type="file"
+        )
         assert out["openFileCalled"] is True, (
             f"single click on filename must trigger openFile after debounce; got {out}"
         )
@@ -284,14 +293,18 @@ class TestNameClickBehavior:
 
     def test_single_click_toggles_dir_after_debounce(self):
         """Single click on a DIRECTORY name → expand/collapse toggle fires."""
-        out = _run_node_with_clicks(click_count=1, dblclick_after_first=False, item_type="dir")
+        out = _run_node_with_clicks(
+            click_count=1, dblclick_after_first=False, item_type="dir"
+        )
         assert out["dirToggleCalled"] is True, (
             f"single click on directory name must trigger expand/collapse toggle; got {out}"
         )
 
     def test_dblclick_cancels_pending_open_and_mounts_rename(self):
         """Click → dblclick on a file name → rename input mounts, openFile does NOT fire."""
-        out = _run_node_with_clicks(click_count=1, dblclick_after_first=True, item_type="file")
+        out = _run_node_with_clicks(
+            click_count=1, dblclick_after_first=True, item_type="file"
+        )
         assert out["renameInputMounted"] is True, (
             f"dblclick on filename must mount rename input; got {out}"
         )

--- a/tests/test_1710_folder_tooltip.py
+++ b/tests/test_1710_folder_tooltip.py
@@ -5,9 +5,8 @@ is therefore misleading on directory rows.
 Fix: gate the tooltip on `item.type !== 'dir'` so it appears only on files.
 Folder rename is still reachable via the right-click context menu.
 """
-from pathlib import Path
 
-import pytest
+from pathlib import Path
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]

--- a/tests/test_1764_context_menu_essentials.py
+++ b/tests/test_1764_context_menu_essentials.py
@@ -24,6 +24,7 @@ These tests pin the source-level wiring — they do not exercise the live
 HTTP endpoints (those are covered by integration tests where they exist
 in the wider suite).
 """
+
 from pathlib import Path
 import re
 
@@ -218,10 +219,9 @@ class TestRevealFailedTostIncludesPath:
         """
         src = UI.read_text(encoding="utf-8")
         # Match both possible forms (with or without parens).
-        assert (
-            "(err.message||err)" in src or "(err.message || err)" in src
-        ), "Reveal-failed toast must guard against err with no .message"
-
+        assert "(err.message||err)" in src or "(err.message || err)" in src, (
+            "Reveal-failed toast must guard against err with no .message"
+        )
 
 
 # ════════════════════════════════════════════════════════════════════
@@ -300,7 +300,10 @@ class TestFilePathEndpointBehaviour:
         assert status == 400, body  # safe_resolve raises ValueError → bad()
         # Error message must NOT include the attempted traversal target's
         # contents, just a generic safe-resolve message.
-        assert "passwd" not in body.get("error", "").lower() or "outside" in body.get("error", "").lower()
+        assert (
+            "passwd" not in body.get("error", "").lower()
+            or "outside" in body.get("error", "").lower()
+        )
 
     def test_missing_session_id_returns_400(self):
         body, status = _post("/api/file/path", {"path": "foo.txt"})

--- a/tests/test_465_session_branching.py
+++ b/tests/test_465_session_branching.py
@@ -10,110 +10,125 @@ Verifies:
   7. i18n keys exist for all branch-related strings
   8. git-branch icon exists in icons.js
 """
+
 import re
 
 
 # ── Backend ────────────────────────────────────────────────────────────────────
 
+
 def test_branch_endpoint_exists():
     """Verify the POST /api/session/branch route handler exists."""
-    with open('api/routes.py') as f:
+    with open("api/routes.py") as f:
         src = f.read()
-    assert '"POST /api/session/branch"' in src or '"/api/session/branch"' in src, \
+    assert '"POST /api/session/branch"' in src or '"/api/session/branch"' in src, (
         "Missing /api/session/branch route"
+    )
 
 
 def test_branch_endpoint_validates_session_id():
     """Verify the branch endpoint requires session_id."""
-    with open('api/routes.py') as f:
+    with open("api/routes.py") as f:
         src = f.read()
     # Find the branch block
     branch_match = re.search(
         r'parsed\.path == "/api/session/branch"(.*?)(?=\n    if parsed\.path|$)',
-        src, re.DOTALL
+        src,
+        re.DOTALL,
     )
     assert branch_match, "Could not find /api/session/branch handler block"
     block = branch_match.group(1)
-    assert 'require(body, "session_id")' in block, \
+    assert 'require(body, "session_id")' in block, (
         "Branch handler should validate session_id"
+    )
 
 
 def test_branch_endpoint_returns_new_session_id():
     """Verify the branch endpoint returns session_id and title."""
-    with open('api/routes.py') as f:
+    with open("api/routes.py") as f:
         src = f.read()
     branch_match = re.search(
         r'parsed\.path == "/api/session/branch"(.*?)(?=\n    if parsed\.path|$)',
-        src, re.DOTALL
+        src,
+        re.DOTALL,
     )
     assert branch_match
     block = branch_match.group(1)
     assert '"session_id"' in block, "Branch handler should return session_id"
     assert '"title"' in block, "Branch handler should return title"
-    assert '"parent_session_id"' in block, \
+    assert '"parent_session_id"' in block, (
         "Branch handler should return parent_session_id"
+    )
 
 
 def test_branch_creates_session_with_parent():
     """Verify the branch creates a Session with parent_session_id set."""
-    with open('api/routes.py') as f:
+    with open("api/routes.py") as f:
         src = f.read()
     branch_match = re.search(
         r'parsed\.path == "/api/session/branch"(.*?)(?=\n    if parsed\.path|$)',
-        src, re.DOTALL
+        src,
+        re.DOTALL,
     )
     assert branch_match
     block = branch_match.group(1)
-    assert 'parent_session_id=source.session_id' in block, \
+    assert "parent_session_id=source.session_id" in block, (
         "Branch handler should set parent_session_id to source session"
+    )
 
 
 def test_branch_keep_count_support():
     """Verify the branch endpoint supports keep_count parameter."""
-    with open('api/routes.py') as f:
+    with open("api/routes.py") as f:
         src = f.read()
     branch_match = re.search(
         r'parsed\.path == "/api/session/branch"(.*?)(?=\n    if parsed\.path|$)',
-        src, re.DOTALL
+        src,
+        re.DOTALL,
     )
     assert branch_match
     block = branch_match.group(1)
-    assert 'keep_count' in block, "Branch handler should support keep_count"
-    assert 'forked_messages = source_messages[:keep_count]' in block, \
+    assert "keep_count" in block, "Branch handler should support keep_count"
+    assert "forked_messages = source_messages[:keep_count]" in block, (
         "Branch handler should slice messages by keep_count"
+    )
 
 
 def test_branch_auto_title():
     """Verify fork title defaults to '<original> (fork)'."""
-    with open('api/routes.py') as f:
+    with open("api/routes.py") as f:
         src = f.read()
     branch_match = re.search(
         r'parsed\.path == "/api/session/branch"(.*?)(?=\n    if parsed\.path|$)',
-        src, re.DOTALL
+        src,
+        re.DOTALL,
     )
     assert branch_match
     block = branch_match.group(1)
-    assert '(fork)' in block, "Branch handler should auto-title as '(fork)'"
+    assert "(fork)" in block, "Branch handler should auto-title as '(fork)'"
 
 
 # ── Session model ──────────────────────────────────────────────────────────────
 
+
 def test_session_model_parent_session_id():
     """Verify Session model supports parent_session_id."""
-    with open('api/models.py') as f:
+    with open("api/models.py") as f:
         src = f.read()
-    assert 'parent_session_id' in src, "Session model should have parent_session_id"
+    assert "parent_session_id" in src, "Session model should have parent_session_id"
     # Check __init__ parameter
-    assert 'parent_session_id: str=None' in src, \
+    assert "parent_session_id: str=None" in src, (
         "Session.__init__ should accept parent_session_id parameter"
+    )
     # Check it's set on self
-    assert 'self.parent_session_id = parent_session_id' in src, \
+    assert "self.parent_session_id = parent_session_id" in src, (
         "Session.__init__ should assign parent_session_id"
+    )
 
 
 def test_session_compact_includes_parent():
     """Verify compact() includes parent_session_id."""
-    with open('api/models.py') as f:
+    with open("api/models.py") as f:
         src = f.read()
     # Find the compact method and scan its full body for parent_session_id.
     # PR #1591 (May 2026) added a has_pending_user_message recompute block at
@@ -122,183 +137,193 @@ def test_session_compact_includes_parent():
     # return-dict body without re-tightening every time compact() grows.
     compact_def_match = re.search(r"def compact\(self", src)
     assert compact_def_match, "Could not find compact() method"
-    snippet = src[compact_def_match.start():compact_def_match.start() + 3000]
-    assert "'parent_session_id'" in snippet, \
+    snippet = src[compact_def_match.start() : compact_def_match.start() + 3000]
+    assert "'parent_session_id'" in snippet, (
         "compact() should include parent_session_id"
+    )
 
 
 def test_session_metadata_fields_includes_parent():
     """Verify parent_session_id is in METADATA_FIELDS for persistence."""
-    with open('api/models.py') as f:
+    with open("api/models.py") as f:
         src = f.read()
-    assert "'parent_session_id'" in src, \
+    assert "'parent_session_id'" in src, (
         "METADATA_FIELDS should include parent_session_id"
+    )
 
 
 # ── Frontend: slash command ────────────────────────────────────────────────────
 
+
 def test_branch_slash_command_registered():
     """Verify /branch is registered as a slash command."""
-    with open('static/commands.js') as f:
+    with open("static/commands.js") as f:
         src = f.read()
     assert "name:'branch'" in src, "/branch should be registered as a command"
-    assert 'cmdBranch' in src, "cmdBranch handler should be defined"
+    assert "cmdBranch" in src, "cmdBranch handler should be defined"
 
 
 def test_cmdBranch_function_exists():
     """Verify cmdBranch function is defined."""
-    with open('static/commands.js') as f:
+    with open("static/commands.js") as f:
         src = f.read()
-    assert 'async function cmdBranch(' in src, \
-        "cmdBranch should be an async function"
+    assert "async function cmdBranch(" in src, "cmdBranch should be an async function"
 
 
 def test_cmdBranch_calls_branch_endpoint():
     """Verify cmdBranch calls the /api/session/branch endpoint."""
-    with open('static/commands.js') as f:
+    with open("static/commands.js") as f:
         src = f.read()
-    branch_fn = re.search(r'async function cmdBranch\(.*?\n\}', src, re.DOTALL)
+    branch_fn = re.search(r"async function cmdBranch\(.*?\n\}", src, re.DOTALL)
     assert branch_fn, "Could not find cmdBranch function"
     block = branch_fn.group(0)
-    assert "'/api/session/branch'" in block, \
-        "cmdBranch should call /api/session/branch"
+    assert "'/api/session/branch'" in block, "cmdBranch should call /api/session/branch"
 
 
 def test_cmdBranch_switches_session():
     """Verify cmdBranch calls loadSession after branching."""
-    with open('static/commands.js') as f:
+    with open("static/commands.js") as f:
         src = f.read()
-    branch_fn = re.search(r'async function cmdBranch\(.*?\n\}', src, re.DOTALL)
+    branch_fn = re.search(r"async function cmdBranch\(.*?\n\}", src, re.DOTALL)
     assert branch_fn
     block = branch_fn.group(0)
-    assert 'loadSession(' in block, \
+    assert "loadSession(" in block, (
         "cmdBranch should switch to the new session via loadSession"
+    )
 
 
 # ── Frontend: forkFromMessage ─────────────────────────────────────────────────
 
+
 def test_forkFromMessage_function_exists():
     """Verify forkFromMessage function exists."""
-    with open('static/commands.js') as f:
+    with open("static/commands.js") as f:
         src = f.read()
-    assert 'async function forkFromMessage(' in src, \
-        "forkFromMessage should be defined"
+    assert "async function forkFromMessage(" in src, "forkFromMessage should be defined"
 
 
 def test_forkFromMessage_passes_keep_count():
     """Verify forkFromMessage passes keep_count to the endpoint."""
-    with open('static/commands.js') as f:
+    with open("static/commands.js") as f:
         src = f.read()
-    fn = re.search(r'async function forkFromMessage\(.*?\n\}', src, re.DOTALL)
+    fn = re.search(r"async function forkFromMessage\(.*?\n\}", src, re.DOTALL)
     assert fn
     block = fn.group(0)
-    assert 'keep_count' in block, \
+    assert "keep_count" in block, (
         "forkFromMessage should pass keep_count to /api/session/branch"
+    )
 
 
 # ── Frontend: fork button in messages ──────────────────────────────────────────
 
+
 def test_fork_button_rendered_in_ui():
     """Verify fork button is rendered in message actions."""
-    with open('static/ui.js') as f:
+    with open("static/ui.js") as f:
         src = f.read()
     assert "forkBtn" in src, "forkBtn variable should exist in ui.js"
-    assert "fork_from_here" in src, \
+    assert "fork_from_here" in src, (
         "fork_from_here i18n key should be referenced for tooltip"
-    assert "forkFromMessage(" in src, \
-        "forkFromMessage should be called from the button"
+    )
+    assert "forkFromMessage(" in src, "forkFromMessage should be called from the button"
 
 
 def test_fork_button_in_message_actions():
     """Verify fork button is included in the msg-actions span."""
-    with open('static/ui.js') as f:
+    with open("static/ui.js") as f:
         src = f.read()
     # The footHtml template should include forkBtn
-    assert '${forkBtn}' in src, \
-        "forkBtn should be included in message actions template"
+    assert "${forkBtn}" in src, "forkBtn should be included in message actions template"
 
 
 # ── Frontend: sidebar parent indicator ────────────────────────────────────────
 
+
 def test_sidebar_parent_indicator():
     """Verify parent session indicator is rendered in session list."""
-    with open('static/sessions.js') as f:
+    with open("static/sessions.js") as f:
         src = f.read()
-    assert 'parent_session_id' in src, \
-        "sessions.js should check parent_session_id"
-    assert 'session-branch-indicator' in src, \
+    assert "parent_session_id" in src, "sessions.js should check parent_session_id"
+    assert "session-branch-indicator" in src, (
         "Should have session-branch-indicator class"
-    assert "li('git-branch',12)" in src, \
+    )
+    assert "li('git-branch',12)" in src, (
         "Sidebar parent indicator should use the git-branch icon"
-    assert '\\u2442' not in src, \
+    )
+    assert "\\u2442" not in src, (
         "Sidebar parent indicator should not use the opaque OCR double-backslash glyph"
+    )
 
 
 def test_parent_indicator_not_clickable():
     """Verify parent indicator is informational, not hidden navigation."""
-    with open('static/sessions.js') as f:
+    with open("static/sessions.js") as f:
         src = f.read()
     # Find the parent indicator block
     parent_block = re.search(
-        r'branch-indicator[\s\S]*?parent_session_id[\s\S]*?titleRow\.appendChild',
-        src
+        r"branch-indicator[\s\S]*?parent_session_id[\s\S]*?titleRow\.appendChild", src
     )
     assert parent_block, "Could not find parent indicator block"
     block = parent_block.group(0)
-    assert 'loadSession(' not in block, \
+    assert "loadSession(" not in block, (
         "Parent indicator should not navigate to the parent from the sidebar"
-    assert 'onclick' not in block, \
+    )
+    assert "onclick" not in block, (
         "Parent indicator should not register a hidden click target"
+    )
 
 
 def test_parent_indicator_tooltip_uses_parent_title_fallback():
     """Tooltip should prefer a parent title and only fall back to a short id."""
-    with open('static/sessions.js') as f:
+    with open("static/sessions.js") as f:
         src = f.read()
-    assert 'function _sessionTitleForForkParent' in src, \
+    assert "function _sessionTitleForForkParent" in src, (
         "sessions.js should resolve a user-facing parent title"
-    assert 'function _truncatedSessionId' in src, \
+    )
+    assert "function _truncatedSessionId" in src, (
         "sessions.js should fall back to a truncated id, not raw session_id"
-    assert "_sessionTitleForForkParent(s.parent_session_id)||_truncatedSessionId(s.parent_session_id)" in src, \
-        "parent indicator tooltip must prefer title and fall back to truncated id"
+    )
+    assert (
+        "_sessionTitleForForkParent(s.parent_session_id)||_truncatedSessionId(s.parent_session_id)"
+        in src
+    ), "parent indicator tooltip must prefer title and fall back to truncated id"
 
 
 def test_parent_indicator_hover_only_style():
     """The sidebar lineage indicator should be visually subdued until row hover/focus."""
-    with open('static/style.css') as f:
+    with open("static/style.css") as f:
         src = f.read()
-    assert '.session-branch-indicator' in src, \
-        "Missing session branch indicator CSS"
-    assert 'opacity:.35' in src, \
-        "Fork lineage indicator should be subdued at rest"
-    assert '.session-item:hover .session-branch-indicator' in src, \
+    assert ".session-branch-indicator" in src, "Missing session branch indicator CSS"
+    assert "opacity:.35" in src, "Fork lineage indicator should be subdued at rest"
+    assert ".session-item:hover .session-branch-indicator" in src, (
         "Fork lineage indicator should become visible on row hover"
+    )
 
 
 # ── Frontend: i18n keys ────────────────────────────────────────────────────────
 
+
 def test_i18n_branch_keys():
     """Verify all branch-related i18n keys exist in English locale."""
-    with open('static/i18n.js') as f:
+    with open("static/i18n.js") as f:
         src = f.read()
     required_keys = [
-        'cmd_branch',
-        'cmd_branch_usage',
-        'branch_forked',
-        'branch_failed',
-        'fork_from_here',
-        'forked_from',
+        "cmd_branch",
+        "cmd_branch_usage",
+        "branch_forked",
+        "branch_failed",
+        "fork_from_here",
+        "forked_from",
     ]
     for key in required_keys:
-        assert f"{key}:" in src or f"{key} :" in src, \
-            f"Missing i18n key: {key}"
+        assert f"{key}:" in src or f"{key} :" in src, f"Missing i18n key: {key}"
 
 
 # ── Frontend: icon ─────────────────────────────────────────────────────────────
 
+
 def test_git_branch_icon_exists():
     """Verify git-branch icon is defined in icons.js."""
-    with open('static/icons.js') as f:
+    with open("static/icons.js") as f:
         src = f.read()
-    assert "'git-branch'" in src, \
-        "git-branch icon should be defined in LI_PATHS"
+    assert "'git-branch'" in src, "git-branch icon should be defined in LI_PATHS"

--- a/tests/test_499_tts_playback.py
+++ b/tests/test_499_tts_playback.py
@@ -4,58 +4,65 @@ Tests for #499: TTS playback of agent responses via Web Speech API.
 Verifies that TTS utility functions, speaker button rendering, and
 settings controls are present in the WebUI codebase.
 """
+
 import os
 import re
 
-STATIC_DIR = os.path.join(os.path.dirname(__file__), '..', 'static')
+STATIC_DIR = os.path.join(os.path.dirname(__file__), "..", "static")
 
 
 def _read(filename):
-    return open(os.path.join(STATIC_DIR, filename), encoding='utf-8').read()
+    return open(os.path.join(STATIC_DIR, filename), encoding="utf-8").read()
 
 
 class TestTtsUtilityFunctions:
     """TTS core functions exist in ui.js."""
 
     def test_strip_for_tts_exists(self):
-        src = _read('ui.js')
-        assert 'function _stripForTTS(' in src, \
+        src = _read("ui.js")
+        assert "function _stripForTTS(" in src, (
             "_stripForTTS function not found in ui.js"
+        )
 
     def test_speak_message_exists(self):
-        src = _read('ui.js')
-        assert 'function speakMessage(' in src, \
+        src = _read("ui.js")
+        assert "function speakMessage(" in src, (
             "speakMessage function not found in ui.js"
+        )
 
     def test_stop_tts_exists(self):
-        src = _read('ui.js')
-        assert 'function stopTTS(' in src, \
-            "stopTTS function not found in ui.js"
+        src = _read("ui.js")
+        assert "function stopTTS(" in src, "stopTTS function not found in ui.js"
 
     def test_auto_read_exists(self):
-        src = _read('ui.js')
-        assert 'function autoReadLastAssistant(' in src, \
+        src = _read("ui.js")
+        assert "function autoReadLastAssistant(" in src, (
             "autoReadLastAssistant function not found in ui.js"
+        )
 
     def test_strip_code_blocks(self):
         """_stripForTTS must remove ``` code blocks."""
-        src = _read('ui.js')
-        assert re.search(r'_stripForTTS.*```', src, re.DOTALL), \
+        src = _read("ui.js")
+        assert re.search(r"_stripForTTS.*```", src, re.DOTALL), (
             "_stripForTTS must handle fenced code blocks"
+        )
 
     def test_strip_media_paths(self):
         """_stripForTTS must replace MEDIA: paths."""
-        src = _read('ui.js')
-        assert 'MEDIA:' in src and 'a file' in src, \
+        src = _read("ui.js")
+        assert "MEDIA:" in src and "a file" in src, (
             "_stripForTTS must replace MEDIA: paths"
+        )
 
     def test_uses_speech_synthesis(self):
         """speakMessage must use window.speechSynthesis."""
-        src = _read('ui.js')
-        assert 'SpeechSynthesisUtterance' in src, \
+        src = _read("ui.js")
+        assert "SpeechSynthesisUtterance" in src, (
             "speakMessage must create SpeechSynthesisUtterance"
-        assert 'speechSynthesis.speak' in src, \
+        )
+        assert "speechSynthesis.speak" in src, (
             "speakMessage must call speechSynthesis.speak"
+        )
 
 
 class TestTtsSpeakerButton:
@@ -63,95 +70,97 @@ class TestTtsSpeakerButton:
 
     def test_tts_button_rendered(self):
         """ttsBtn must be generated for non-user messages."""
-        src = _read('ui.js')
-        assert 'msg-tts-btn' in src, \
-            "TTS button class not found in ui.js"
+        src = _read("ui.js")
+        assert "msg-tts-btn" in src, "TTS button class not found in ui.js"
 
     def test_tts_button_not_on_user_messages(self):
         """ttsBtn must only be added for non-user (assistant) messages."""
-        src = _read('ui.js')
+        src = _read("ui.js")
         # Find the ttsBtn definition — it should have !isUser guard
-        tts_line = [l for l in src.splitlines() if 'msg-tts-btn' in l][0]
-        assert '!isUser' in tts_line or 'isUser' in tts_line, \
+        tts_line = [l for l in src.splitlines() if "msg-tts-btn" in l][0]
+        assert "!isUser" in tts_line or "isUser" in tts_line, (
             "TTS button should have user-check guard"
+        )
 
     def test_tts_button_in_footer(self):
         """ttsBtn must be included in the msg-actions span."""
-        src = _read('ui.js')
+        src = _read("ui.js")
         # The footHtml line should include ttsBtn
-        foot_lines = [l for l in src.splitlines() if 'footHtml' in l and 'msg-actions' in l]
-        assert any('ttsBtn' in l for l in foot_lines), \
+        foot_lines = [
+            l for l in src.splitlines() if "footHtml" in l and "msg-actions" in l
+        ]
+        assert any("ttsBtn" in l for l in foot_lines), (
             "ttsBtn not included in footHtml msg-actions"
+        )
 
     def test_tts_button_uses_volume_icon(self):
         """Speaker button should use volume-2 icon."""
-        src = _read('ui.js')
-        tts_line = [l for l in src.splitlines() if 'msg-tts-btn' in l][0]
-        assert 'volume-2' in tts_line, \
-            "TTS button should use volume-2 icon"
+        src = _read("ui.js")
+        tts_line = [l for l in src.splitlines() if "msg-tts-btn" in l][0]
+        assert "volume-2" in tts_line, "TTS button should use volume-2 icon"
 
 
 class TestTtsSettings:
     """TTS settings controls exist in the HTML and are wired in panels.js."""
 
     def test_tts_enabled_checkbox(self):
-        src = _read('index.html')
-        assert 'settingsTtsEnabled' in src, \
+        src = _read("index.html")
+        assert "settingsTtsEnabled" in src, (
             "TTS enabled checkbox not found in index.html"
+        )
 
     def test_tts_auto_read_checkbox(self):
-        src = _read('index.html')
-        assert 'settingsTtsAutoRead' in src, \
+        src = _read("index.html")
+        assert "settingsTtsAutoRead" in src, (
             "TTS auto-read checkbox not found in index.html"
+        )
 
     def test_tts_voice_selector(self):
-        src = _read('index.html')
-        assert 'settingsTtsVoice' in src, \
-            "TTS voice selector not found in index.html"
+        src = _read("index.html")
+        assert "settingsTtsVoice" in src, "TTS voice selector not found in index.html"
 
     def test_tts_rate_slider(self):
-        src = _read('index.html')
-        assert 'settingsTtsRate' in src, \
-            "TTS rate slider not found in index.html"
+        src = _read("index.html")
+        assert "settingsTtsRate" in src, "TTS rate slider not found in index.html"
 
     def test_tts_pitch_slider(self):
-        src = _read('index.html')
-        assert 'settingsTtsPitch' in src, \
-            "TTS pitch slider not found in index.html"
+        src = _read("index.html")
+        assert "settingsTtsPitch" in src, "TTS pitch slider not found in index.html"
 
     def test_tts_settings_wired_in_panels(self):
         """TTS settings must be initialized in loadSettingsPanel."""
-        src = _read('panels.js')
-        assert 'settingsTtsEnabled' in src, \
-            "TTS enabled setting not wired in panels.js"
-        assert '_applyTtsEnabled' in src, \
-            "_applyTtsEnabled not called in panels.js"
+        src = _read("panels.js")
+        assert "settingsTtsEnabled" in src, "TTS enabled setting not wired in panels.js"
+        assert "_applyTtsEnabled" in src, "_applyTtsEnabled not called in panels.js"
 
     def test_apply_tts_enabled_function(self):
         """_applyTtsEnabled must toggle msg-tts-btn display."""
-        src = _read('panels.js')
-        assert 'function _applyTtsEnabled(' in src, \
+        src = _read("panels.js")
+        assert "function _applyTtsEnabled(" in src, (
             "_applyTtsEnabled function not found in panels.js"
+        )
 
 
 class TestTtsI18n:
     """TTS i18n keys exist in the English locale."""
 
     def test_tts_listen_key(self):
-        src = _read('i18n.js')
-        assert "tts_listen:" in src, \
-            "tts_listen key not found in i18n.js"
+        src = _read("i18n.js")
+        assert "tts_listen:" in src, "tts_listen key not found in i18n.js"
 
     def test_tts_not_supported_key(self):
-        src = _read('i18n.js')
-        assert "tts_not_supported:" in src, \
-            "tts_not_supported key not found in i18n.js"
+        src = _read("i18n.js")
+        assert "tts_not_supported:" in src, "tts_not_supported key not found in i18n.js"
 
     def test_tts_settings_keys(self):
-        src = _read('i18n.js')
-        for key in ['settings_label_tts', 'settings_label_tts_auto_read',
-                     'settings_label_tts_voice', 'settings_label_tts_rate',
-                     'settings_label_tts_pitch']:
+        src = _read("i18n.js")
+        for key in [
+            "settings_label_tts",
+            "settings_label_tts_auto_read",
+            "settings_label_tts_voice",
+            "settings_label_tts_rate",
+            "settings_label_tts_pitch",
+        ]:
             assert f"{key}:" in src, f"{key} not found in i18n.js"
 
 
@@ -159,40 +168,40 @@ class TestTtsAutoRead:
     """Auto-read is triggered after SSE done event."""
 
     def test_auto_read_called_in_messages(self):
-        src = _read('messages.js')
-        assert 'autoReadLastAssistant' in src, \
+        src = _read("messages.js")
+        assert "autoReadLastAssistant" in src, (
             "autoReadLastAssistant not called in messages.js"
+        )
 
     def test_tts_pause_on_composer_focus(self):
         """Speech should pause when user focuses the composer."""
-        src = _read('messages.js')
-        assert 'speechSynthesis.pause' in src, \
+        src = _read("messages.js")
+        assert "speechSynthesis.pause" in src, (
             "speechSynthesis.pause not called in messages.js"
-        assert 'speechSynthesis.resume' in src, \
+        )
+        assert "speechSynthesis.resume" in src, (
             "speechSynthesis.resume not called in messages.js"
+        )
 
 
 class TestTtsBoot:
     """TTS enabled state is applied on page load."""
 
     def test_apply_tts_on_boot(self):
-        src = _read('boot.js')
-        assert '_applyTtsEnabled' in src, \
-            "_applyTtsEnabled not called in boot.js"
+        src = _read("boot.js")
+        assert "_applyTtsEnabled" in src, "_applyTtsEnabled not called in boot.js"
 
 
 class TestTtsStyles:
     """TTS CSS styles exist."""
 
     def test_tts_button_hidden_default(self):
-        src = _read('style.css')
-        assert '.msg-tts-btn' in src, \
-            ".msg-tts-btn CSS class not found in style.css"
+        src = _read("style.css")
+        assert ".msg-tts-btn" in src, ".msg-tts-btn CSS class not found in style.css"
 
     def test_tts_pulse_animation(self):
-        src = _read('style.css')
-        assert 'tts-pulse' in src, \
-            "tts-pulse animation not found in style.css"
+        src = _read("style.css")
+        assert "tts-pulse" in src, "tts-pulse animation not found in style.css"
 
 
 class TestIssue1409TtsToggleBodyClass:
@@ -210,7 +219,7 @@ class TestIssue1409TtsToggleBodyClass:
 
     def test_apply_tts_enabled_uses_body_class(self):
         """_applyTtsEnabled must toggle the document body's `tts-enabled` class."""
-        src = _read('panels.js')
+        src = _read("panels.js")
         # The new shape: toggle body class instead of writing inline display
         assert "document.body.classList.toggle('tts-enabled'" in src, (
             "_applyTtsEnabled must toggle the body.tts-enabled class — see #1409. "
@@ -220,30 +229,31 @@ class TestIssue1409TtsToggleBodyClass:
 
     def test_apply_tts_enabled_does_not_use_inline_display(self):
         """_applyTtsEnabled must NOT set inline `style.display` on .msg-tts-btn."""
-        src = _read('panels.js')
+        src = _read("panels.js")
         # Find the function body and check it doesn't set inline display
         # on individual buttons (the broken pattern).
         m = re.search(
-            r'function _applyTtsEnabled\([^)]*\)\s*\{(?P<body>[^}]*)\}',
+            r"function _applyTtsEnabled\([^)]*\)\s*\{(?P<body>[^}]*)\}",
             src,
         )
         assert m, "_applyTtsEnabled function body not found in panels.js"
-        body = m.group('body')
-        assert '.style.display' not in body, (
+        body = m.group("body")
+        assert ".style.display" not in body, (
             "_applyTtsEnabled body must not set inline style.display — that's "
             "the #1409 bug. Use body.classList.toggle('tts-enabled') instead."
         )
 
     def test_body_class_selector_in_css(self):
         """style.css must show .msg-tts-btn only when body.tts-enabled is set."""
-        src = _read('style.css')
-        assert 'body.tts-enabled .msg-tts-btn' in src, (
+        src = _read("style.css")
+        assert "body.tts-enabled .msg-tts-btn" in src, (
             "Missing `body.tts-enabled .msg-tts-btn` selector in style.css — "
             "without this rule the body class has no visual effect (#1409)."
         )
         # The default-hidden rule must still be present (so no body class = no icon).
-        assert '.msg-tts-btn{display:none;}' in src or \
-               re.search(r'\.msg-tts-btn\s*\{[^}]*display\s*:\s*none', src), (
+        assert ".msg-tts-btn{display:none;}" in src or re.search(
+            r"\.msg-tts-btn\s*\{[^}]*display\s*:\s*none", src
+        ), (
             "Default `.msg-tts-btn{display:none;}` rule must remain so the "
             "icon is hidden by default (#1409)."
         )

--- a/tests/test_732_gateway_routing_metadata.py
+++ b/tests/test_732_gateway_routing_metadata.py
@@ -33,7 +33,9 @@ def test_gateway_routing_metadata_is_safely_normalized_from_response_metadata():
         ],
     }
 
-    normalized = _normalize_gateway_routing_metadata(metadata, requested_model="deepseek-v3.2", requested_provider="CanopyWave")
+    normalized = _normalize_gateway_routing_metadata(
+        metadata, requested_model="deepseek-v3.2", requested_provider="CanopyWave"
+    )
 
     assert normalized == {
         "used_provider": "Alibaba Cloud",
@@ -44,7 +46,12 @@ def test_gateway_routing_metadata_is_safely_normalized_from_response_metadata():
         "model_changed": False,
         "has_failover": True,
         "routing": [
-            {"provider": "CanopyWave", "status": "failed", "reason": "timeout", "score": 0.12},
+            {
+                "provider": "CanopyWave",
+                "status": "failed",
+                "reason": "timeout",
+                "score": 0.12,
+            },
             {"provider": "Alibaba Cloud", "status": "selected", "score": 0.91},
         ],
     }
@@ -52,8 +59,18 @@ def test_gateway_routing_metadata_is_safely_normalized_from_response_metadata():
 
 
 def test_gateway_routing_metadata_absent_returns_none_without_placeholder_noise():
-    assert _normalize_gateway_routing_metadata({}, requested_model="gpt-5.5", requested_provider="openai-codex") is None
-    assert _normalize_gateway_routing_metadata(None, requested_model="gpt-5.5", requested_provider="openai-codex") is None
+    assert (
+        _normalize_gateway_routing_metadata(
+            {}, requested_model="gpt-5.5", requested_provider="openai-codex"
+        )
+        is None
+    )
+    assert (
+        _normalize_gateway_routing_metadata(
+            None, requested_model="gpt-5.5", requested_provider="openai-codex"
+        )
+        is None
+    )
 
 
 def test_session_persists_latest_gateway_routing_and_history_across_reload():
@@ -71,8 +88,15 @@ def test_session_persists_latest_gateway_routing_and_history_across_reload():
         requested_model="model-a",
         requested_provider="provider-a",
     )
-    session = Session(session_id="732gateway", title="Gateway", gateway_routing=routing, gateway_routing_history=[routing])
-    session.messages = [{"role": "assistant", "content": "done", "_gatewayRouting": routing}]
+    session = Session(
+        session_id="732gateway",
+        title="Gateway",
+        gateway_routing=routing,
+        gateway_routing_history=[routing],
+    )
+    session.messages = [
+        {"role": "assistant", "content": "done", "_gatewayRouting": routing}
+    ]
     session.save()
 
     reloaded = Session.load("732gateway")

--- a/tests/test_745_code_block_newlines.py
+++ b/tests/test_745_code_block_newlines.py
@@ -6,45 +6,45 @@ Root cause: the paragraph-splitter in renderMd() replaced \n with <br> inside
 text. The fix stashes <pre> blocks (and pre-header divs, mermaid, katex) before
 the paragraph split and restores them afterwards.
 """
-import re
+
 import subprocess
-import sys
 import os
 
-UI_JS = os.path.join(os.path.dirname(__file__), '..', 'static', 'ui.js')
+UI_JS = os.path.join(os.path.dirname(__file__), "..", "static", "ui.js")
 
 
 def get_ui_js():
-    return open(UI_JS, encoding='utf-8').read()
+    return open(UI_JS, encoding="utf-8").read()
 
 
 class TestCodeBlockNewlinePreservation:
-
     def test_pre_stash_present(self):
         """The _pre_stash variable must exist in ui.js."""
         src = get_ui_js()
-        assert '_pre_stash' in src, "_pre_stash not found in ui.js"
+        assert "_pre_stash" in src, "_pre_stash not found in ui.js"
 
     def test_pre_stash_token_E_used(self):
         """Stash token \\x00E must be used for pre-block stashing."""
         src = get_ui_js()
-        assert r'\x00E' in src, r"\x00E stash token not found in ui.js"
+        assert r"\x00E" in src, r"\x00E stash token not found in ui.js"
 
     def test_stash_before_paragraph_split(self):
         """_pre_stash must be populated BEFORE the parts=s.split line."""
         src = get_ui_js()
-        pre_stash_pos = src.index('_pre_stash=[]')
-        split_pos = src.index('const parts=s.split(/\\n{2,}/)')
-        assert pre_stash_pos < split_pos, \
+        pre_stash_pos = src.index("_pre_stash=[]")
+        split_pos = src.index("const parts=s.split(/\\n{2,}/)")
+        assert pre_stash_pos < split_pos, (
             "_pre_stash must be initialised before the paragraph split"
+        )
 
     def test_restore_after_paragraph_split(self):
         """_pre_stash restore must happen AFTER the paragraph map/join line."""
         src = get_ui_js()
-        restore_pos = src.index('_pre_stash[+i]')
-        split_pos = src.index("}).join('\\n');", src.index('const parts=s.split'))
-        assert restore_pos > split_pos, \
+        restore_pos = src.index("_pre_stash[+i]")
+        split_pos = src.index("}).join('\\n');", src.index("const parts=s.split"))
+        assert restore_pos > split_pos, (
             "_pre_stash must be restored after the paragraph split/join"
+        )
 
     def test_paragraph_split_bypasses_stash_tokens(self):
         """The paragraph map must bypass lines that start with \\x00E (pre stash).
@@ -52,11 +52,8 @@ class TestCodeBlockNewlinePreservation:
         share the same bypass (e.g. \\x00Q for blockquote stash)."""
         src = get_ui_js()
         # The map line must check for \x00E in its bypass condition
-        map_line = next(
-            l for l in src.splitlines()
-            if 'parts.map' in l and '<br>' in l
-        )
-        assert r'\x00E' in map_line or r'\x00[E' in map_line, (
+        map_line = next(l for l in src.splitlines() if "parts.map" in l and "<br>" in l)
+        assert r"\x00E" in map_line or r"\x00[E" in map_line, (
             r"paragraph map must bypass \x00E stash tokens (literally or as "
             r"part of a character class like \x00[EQ])"
         )
@@ -65,44 +62,47 @@ class TestCodeBlockNewlinePreservation:
         """The stash regex must match <div class=\"pre-header\"> before <pre>."""
         src = get_ui_js()
         # Find the replacement regex used to populate _pre_stash
-        stash_block_idx = src.index('_pre_stash=[]')
-        stash_block = src[stash_block_idx:stash_block_idx + 1500]
-        assert 'pre-header' in stash_block, \
-            "pre-stash regex must match <div class=\"pre-header\"> wrappers"
+        stash_block_idx = src.index("_pre_stash=[]")
+        stash_block = src[stash_block_idx : stash_block_idx + 1500]
+        assert "pre-header" in stash_block, (
+            'pre-stash regex must match <div class="pre-header"> wrappers'
+        )
 
     def test_mermaid_covered_by_stash(self):
         """The stash regex must also cover mermaid-block divs."""
         src = get_ui_js()
-        stash_block_idx = src.index('_pre_stash=[]')
-        stash_block = src[stash_block_idx:stash_block_idx + 1500]
-        assert 'mermaid-block' in stash_block, \
+        stash_block_idx = src.index("_pre_stash=[]")
+        stash_block = src[stash_block_idx : stash_block_idx + 1500]
+        assert "mermaid-block" in stash_block, (
             "pre-stash regex must cover mermaid-block divs"
+        )
 
     def test_katex_covered_by_stash(self):
         """The stash regex must also cover katex-block divs."""
         src = get_ui_js()
-        stash_block_idx = src.index('_pre_stash=[]')
-        stash_block = src[stash_block_idx:stash_block_idx + 1500]
-        assert 'katex-block' in stash_block, \
+        stash_block_idx = src.index("_pre_stash=[]")
+        stash_block = src[stash_block_idx : stash_block_idx + 1500]
+        assert "katex-block" in stash_block, (
             "pre-stash regex must cover katex-block divs"
+        )
 
     def test_js_syntax_valid(self):
         """ui.js must pass node --check after the fix."""
         result = subprocess.run(
-            ['node', '--check', UI_JS],
-            capture_output=True, text=True
+            ["node", "--check", UI_JS], capture_output=True, text=True
         )
-        assert result.returncode == 0, \
-            f"node --check failed:\n{result.stderr}"
+        assert result.returncode == 0, f"node --check failed:\n{result.stderr}"
 
     def test_stash_token_e_not_used_elsewhere(self):
         """\\x00E must only appear in the pre-stash section (not reused)."""
         src = get_ui_js()
         occurrences = [
-            i for i in range(len(src))
-            if src[i:i+4] == r'\x00' and i + 4 < len(src) and src[i+4] == 'E'
+            i
+            for i in range(len(src))
+            if src[i : i + 4] == r"\x00" and i + 4 < len(src) and src[i + 4] == "E"
         ]
         # Allow 2 occurrences: the push token and the restore regex
         # (may be 3 if there's also a comment mentioning it)
-        assert len(occurrences) >= 2, \
+        assert len(occurrences) >= 2, (
             r"Expected at least 2 uses of \x00E (push + restore)"
+        )

--- a/tests/test_779_html_preview.py
+++ b/tests/test_779_html_preview.py
@@ -1,5 +1,4 @@
 """Tests for inline HTML preview in workspace panel (issue #779)."""
-import pytest
 
 
 def _get_routes_content():
@@ -54,6 +53,7 @@ def test_sandbox_allows_scripts_only():
     content = _get_index_html()
     # Find the sandbox attribute value
     import re
+
     sandboxes = re.findall(r'sandbox="([^"]*)"', content)
     preview_sandboxes = [s for s in sandboxes if "allow" in s]
     for sb in preview_sandboxes:
@@ -67,6 +67,7 @@ def test_mime_map_includes_html_and_htm():
     falls back to application/octet-stream and browsers refuse to render the
     response inside the preview iframe (issue #779 follow-up: PR #1070)."""
     from api.config import MIME_MAP
+
     assert MIME_MAP.get(".html") == "text/html", (
         "MIME_MAP['.html'] must be 'text/html' for the workspace HTML preview iframe"
     )
@@ -90,15 +91,15 @@ def test_inline_html_response_sets_csp_sandbox():
     # Find the html_inline_ok block in _handle_file_raw
     idx = content.find("html_inline_ok")
     assert idx != -1, "html_inline_ok block not found"
-    block = content[idx:idx + 2500]
+    block = content[idx : idx + 2500]
     assert "Content-Security-Policy" in block, (
         "_handle_file_raw must set Content-Security-Policy header on inline HTML responses"
     )
-    assert "sandbox" in block, (
-        "CSP must include the sandbox directive"
-    )
+    assert "sandbox" in block, "CSP must include the sandbox directive"
     # Must NOT have allow-same-origin in the sandbox directive
-    csp_sections = [line for line in block.splitlines() if "sandbox" in line and "Policy" in line]
+    csp_sections = [
+        line for line in block.splitlines() if "sandbox" in line and "Policy" in line
+    ]
     for line in csp_sections:
         # The line setting the CSP header — make sure it doesn't grant same-origin
         if "send_header" in line:

--- a/tests/test_886_ordered_list_numbering.py
+++ b/tests/test_886_ordered_list_numbering.py
@@ -9,27 +9,27 @@ at 1, producing "1. 1. 1." instead of "1. 2. 3.".
 Fix: emit value="N" on every <li> so the correct ordinal is preserved even when
 items end up in separate <ol> containers after the paragraph split.
 """
+
 import os
 import re
 
-UI_JS = os.path.join(os.path.dirname(__file__), '..', 'static', 'ui.js')
+UI_JS = os.path.join(os.path.dirname(__file__), "..", "static", "ui.js")
 
 
 def get_ui_js():
-    return open(UI_JS, encoding='utf-8').read()
+    return open(UI_JS, encoding="utf-8").read()
 
 
 class TestOrderedListNumbering:
-
     def test_li_value_attr_present_in_ordered_list_block(self):
         """The ordered-list renderer must emit value= on each <li>."""
         src = get_ui_js()
         # Locate the ordered-list replace block
-        ol_idx = src.find('s=s.replace(/((?:^(?:  )?\\d+\\. .+\\n?)+)/gm')
+        ol_idx = src.find("s=s.replace(/((?:^(?:  )?\\d+\\. .+\\n?)+)/gm")
         assert ol_idx != -1, "Ordered-list replace block not found in ui.js"
         # Extract a window large enough to cover the whole closure (~400 chars)
-        ol_block = src[ol_idx:ol_idx + 500]
-        assert 'value=' in ol_block, (
+        ol_block = src[ol_idx : ol_idx + 500]
+        assert "value=" in ol_block, (
             "Ordered-list block must emit value= attribute on <li> elements to "
             "preserve numbering when items are separated by blank lines (#886)"
         )
@@ -37,33 +37,33 @@ class TestOrderedListNumbering:
     def test_li_value_uses_parsed_number(self):
         """The value= must be derived from parseInt of the captured digit, not hardcoded."""
         src = get_ui_js()
-        ol_idx = src.find('s=s.replace(/((?:^(?:  )?\\d+\\. .+\\n?)+)/gm')
+        ol_idx = src.find("s=s.replace(/((?:^(?:  )?\\d+\\. .+\\n?)+)/gm")
         assert ol_idx != -1, "Ordered-list replace block not found in ui.js"
-        ol_block = src[ol_idx:ol_idx + 500]
-        assert 'parseInt' in ol_block, (
+        ol_block = src[ol_idx : ol_idx + 500]
+        assert "parseInt" in ol_block, (
             "Ordered-list block should use parseInt() to parse the list number (#886)"
         )
 
     def test_numMatch_variable_present(self):
         """The numMatch variable (or equivalent digit capture) must exist in the OL block."""
         src = get_ui_js()
-        ol_idx = src.find('s=s.replace(/((?:^(?:  )?\\d+\\. .+\\n?)+)/gm')
+        ol_idx = src.find("s=s.replace(/((?:^(?:  )?\\d+\\. .+\\n?)+)/gm")
         assert ol_idx != -1, "Ordered-list replace block not found in ui.js"
-        ol_block = src[ol_idx:ol_idx + 500]
+        ol_block = src[ol_idx : ol_idx + 500]
         # Either numMatch or a similar digit-capture variable
-        assert 'numMatch' in ol_block or re.search(r'match\(/.*\\d', ol_block), (
+        assert "numMatch" in ol_block or re.search(r"match\(/.*\\d", ol_block), (
             "Ordered-list block should capture the list item number with a regex match (#886)"
         )
 
     def test_valAttr_or_value_template_present(self):
         """The <li> template must include the value attribute conditionally or unconditionally."""
         src = get_ui_js()
-        ol_idx = src.find('s=s.replace(/((?:^(?:  )?\\d+\\. .+\\n?)+)/gm')
+        ol_idx = src.find("s=s.replace(/((?:^(?:  )?\\d+\\. .+\\n?)+)/gm")
         assert ol_idx != -1, "Ordered-list replace block not found in ui.js"
-        ol_block = src[ol_idx:ol_idx + 500]
+        ol_block = src[ol_idx : ol_idx + 500]
         # Either a valAttr variable or an inline value= in the template
-        has_val_attr = 'valAttr' in ol_block
-        has_inline_value = re.search(r'<li.*value=', ol_block)
+        has_val_attr = "valAttr" in ol_block
+        has_inline_value = re.search(r"<li.*value=", ol_block)
         assert has_val_attr or has_inline_value, (
             "Ordered-list block must have value= on <li> (via valAttr var or inline) (#886)"
         )
@@ -71,11 +71,15 @@ class TestOrderedListNumbering:
     def test_ordered_list_comment_references_issue(self):
         """A comment near the OL fix should reference the issue (#886) or the symptom."""
         src = get_ui_js()
-        ol_idx = src.find('s=s.replace(/((?:^(?:  )?\\d+\\. .+\\n?)+)/gm')
+        ol_idx = src.find("s=s.replace(/((?:^(?:  )?\\d+\\. .+\\n?)+)/gm")
         assert ol_idx != -1, "Ordered-list replace block not found in ui.js"
         # Look at the 300 chars BEFORE the replace line for an explanatory comment
-        context = src[max(0, ol_idx - 300):ol_idx]
-        has_comment = '#886' in context or '1. 1. 1.' in context or 'blank lines' in context.lower()
+        context = src[max(0, ol_idx - 300) : ol_idx]
+        has_comment = (
+            "#886" in context
+            or "1. 1. 1." in context
+            or "blank lines" in context.lower()
+        )
         assert has_comment, (
             "Expected a comment near the OL fix explaining the blank-line issue (#886)"
         )
@@ -84,9 +88,9 @@ class TestOrderedListNumbering:
         """A compact list (no blank lines) should still produce one <ol> with sequential items."""
         src = get_ui_js()
         # Structural check: the regex still captures multi-line blocks (\\n? allows groups)
-        ol_idx = src.find('s=s.replace(/((?:^(?:  )?\\d+\\. .+\\n?)+)/gm')
+        ol_idx = src.find("s=s.replace(/((?:^(?:  )?\\d+\\. .+\\n?)+)/gm")
         assert ol_idx != -1, "Ordered-list replace block not found"
         # The \\n? quantifier that allows grouping must still be present
-        assert '\\n?' in src[ol_idx:ol_idx + 80], (
+        assert "\\n?" in src[ol_idx : ol_idx + 80], (
             "The \\\\n? in the ordered-list regex was removed — compact lists may break"
         )

--- a/tests/test_agent_max_turns_parity.py
+++ b/tests/test_agent_max_turns_parity.py
@@ -20,11 +20,16 @@ def test_streaming_agent_reads_agent_max_turns_from_config():
 
 
 def test_streaming_agent_passes_max_iterations_to_aiagent():
-    assert "if 'max_iterations' in _agent_params and _max_iterations_cfg is not None:" in STREAMING_PY
+    assert (
+        "if 'max_iterations' in _agent_params and _max_iterations_cfg is not None:"
+        in STREAMING_PY
+    )
     assert "_agent_kwargs['max_iterations'] = _max_iterations_cfg" in STREAMING_PY
 
 
 def test_streaming_agent_cache_signature_includes_max_iterations():
     sig_start = STREAMING_PY.index("_sig_blob = _json.dumps")
-    sig_block = STREAMING_PY[sig_start:STREAMING_PY.index("], sort_keys=True)", sig_start)]
+    sig_block = STREAMING_PY[
+        sig_start : STREAMING_PY.index("], sort_keys=True)", sig_start)
+    ]
     assert "_max_iterations_cfg or ''" in sig_block

--- a/tests/test_app_titlebar_restore.py
+++ b/tests/test_app_titlebar_restore.py
@@ -13,8 +13,14 @@ def test_app_titlebar_no_longer_contains_tps_chip():
 
 
 def test_app_titlebar_returns_to_centered_desktop_layout():
-    assert ".app-titlebar{display:flex;align-items:center;justify-content:center;" in STYLE_CSS
-    assert ".app-titlebar-inner{display:flex;align-items:center;gap:8px;min-width:0;max-width:100%;justify-content:center;}" in STYLE_CSS
+    assert (
+        ".app-titlebar{display:flex;align-items:center;justify-content:center;"
+        in STYLE_CSS
+    )
+    assert (
+        ".app-titlebar-inner{display:flex;align-items:center;gap:8px;min-width:0;max-width:100%;justify-content:center;}"
+        in STYLE_CSS
+    )
 
 
 def test_app_titlebar_subtitle_shows_message_count_again():

--- a/tests/test_approval_card_layering.py
+++ b/tests/test_approval_card_layering.py
@@ -14,6 +14,7 @@ approval buttons. The fix raises `.approval-card.visible` to z-index 3.
 This test pins the invariant: approval-card.visible z-index must be strictly
 greater than queue-card z-index.
 """
+
 import re
 from pathlib import Path
 

--- a/tests/test_approval_queue.py
+++ b/tests/test_approval_queue.py
@@ -4,7 +4,7 @@ Previously _pending[sid] held one entry, so simultaneous approvals overwrote
 each other. This PR changes submit_pending() to append to a list and adds
 approval_id so /api/approval/respond can target a specific entry.
 """
-import json
+
 import pathlib
 import re
 import sys
@@ -21,106 +21,128 @@ INDEX_HTML = (REPO_ROOT / "static" / "index.html").read_text(encoding="utf-8")
 # Static-analysis: Python routes
 # ---------------------------------------------------------------------------
 
+
 def test_submit_pending_appends_to_list():
     """submit_pending() must append to a list, not overwrite."""
     # The new wrapper must contain a queue append (list mutation pattern)
-    assert "queue_list.append(entry)" in ROUTES_SRC or "queue.append(entry)" in ROUTES_SRC, \
-        "submit_pending() must append entry to a list queue, not overwrite _pending[sid]"
+    assert (
+        "queue_list.append(entry)" in ROUTES_SRC or "queue.append(entry)" in ROUTES_SRC
+    ), "submit_pending() must append entry to a list queue, not overwrite _pending[sid]"
 
 
 def test_submit_pending_adds_approval_id():
     """Each queued entry must get a unique approval_id."""
-    assert "approval_id" in ROUTES_SRC and "uuid.uuid4().hex" in ROUTES_SRC, \
+    assert "approval_id" in ROUTES_SRC and "uuid.uuid4().hex" in ROUTES_SRC, (
         "submit_pending() must assign a uuid4 approval_id to each queued entry"
+    )
 
 
 def test_handle_approval_pending_returns_count():
     """_handle_approval_pending must return pending_count in its response."""
-    assert '"pending_count"' in ROUTES_SRC, \
+    assert '"pending_count"' in ROUTES_SRC, (
         "_handle_approval_pending must include pending_count in the JSON response"
+    )
 
 
 def test_handle_approval_respond_pops_by_approval_id():
     """_handle_approval_respond must target entry by approval_id."""
-    assert 'approval_id = body.get("approval_id"' in ROUTES_SRC, \
+    assert 'approval_id = body.get("approval_id"' in ROUTES_SRC, (
         "_handle_approval_respond must read approval_id from request body"
-    assert 'entry.get("approval_id") == approval_id' in ROUTES_SRC, \
+    )
+    assert 'entry.get("approval_id") == approval_id' in ROUTES_SRC, (
         "_handle_approval_respond must find and pop the matching entry by approval_id"
+    )
 
 
 def test_handle_approval_respond_fallback_to_oldest():
     """When no approval_id is given, fall back to popping the oldest entry (FIFO)."""
     # The fallback path: queue.pop(0) when approval_id is empty
-    assert "queue.pop(0)" in ROUTES_SRC, \
+    assert "queue.pop(0)" in ROUTES_SRC, (
         "_handle_approval_respond must fall back to popping the oldest entry when approval_id is absent"
+    )
 
 
 def test_backward_compat_legacy_dict_value():
     """The respond handler must tolerate a legacy single-dict value in _pending."""
-    assert "Legacy single-dict value" in ROUTES_SRC or \
-           "# Legacy single-dict" in ROUTES_SRC or \
-           "elif queue:" in ROUTES_SRC, \
+    assert (
+        "Legacy single-dict value" in ROUTES_SRC
+        or "# Legacy single-dict" in ROUTES_SRC
+        or "elif queue:" in ROUTES_SRC
+    ), (
         "respond handler must handle legacy single-dict _pending values for backward compatibility"
+    )
 
 
 # ---------------------------------------------------------------------------
 # Static-analysis: JavaScript frontend
 # ---------------------------------------------------------------------------
 
+
 def test_respond_sends_approval_id():
     """respondApproval() must include approval_id in the POST body."""
-    assert "approval_id: approvalId" in MESSAGES_JS, \
+    assert "approval_id: approvalId" in MESSAGES_JS, (
         "respondApproval() must send approval_id in the POST body to /api/approval/respond"
+    )
 
 
 def test_show_approval_card_accepts_count():
     """showApprovalCard must accept a pendingCount parameter."""
-    assert re.search(r"function showApprovalCard\(pending,\s*pendingCount\)", MESSAGES_JS), \
-        "showApprovalCard() must accept a pendingCount argument"
+    assert re.search(
+        r"function showApprovalCard\(pending,\s*pendingCount\)", MESSAGES_JS
+    ), "showApprovalCard() must accept a pendingCount argument"
 
 
 def test_show_approval_card_renders_counter():
     """showApprovalCard must display a '1 of N pending' counter when N > 1."""
-    assert '"1 of " + pendingCount + " pending"' in MESSAGES_JS or \
-           "'1 of ' + pendingCount + ' pending'" in MESSAGES_JS, \
+    assert (
+        '"1 of " + pendingCount + " pending"' in MESSAGES_JS
+        or "'1 of ' + pendingCount + ' pending'" in MESSAGES_JS
+    ), (
         "showApprovalCard() must render '1 of N pending' counter for multiple queued approvals"
+    )
 
 
 def test_approval_current_id_tracked():
     """_approvalCurrentId must be set and cleared around each approval."""
-    assert "_approvalCurrentId" in MESSAGES_JS, \
+    assert "_approvalCurrentId" in MESSAGES_JS, (
         "_approvalCurrentId must track the approval_id of the currently displayed card"
-    assert "_approvalCurrentId = pending.approval_id" in MESSAGES_JS or \
-           "_approvalCurrentId = pending.approval_id || null" in MESSAGES_JS, \
-        "_approvalCurrentId must be assigned from pending.approval_id"
+    )
+    assert (
+        "_approvalCurrentId = pending.approval_id" in MESSAGES_JS
+        or "_approvalCurrentId = pending.approval_id || null" in MESSAGES_JS
+    ), "_approvalCurrentId must be assigned from pending.approval_id"
     # Must be nulled on respond
-    assert "_approvalCurrentId = null" in MESSAGES_JS, \
+    assert "_approvalCurrentId = null" in MESSAGES_JS, (
         "_approvalCurrentId must be cleared when respondApproval() is called"
+    )
 
 
 def test_polling_passes_count_to_show():
     """The poll loop must pass pending_count to the owner-aware approval renderer."""
-    assert "showApprovalForSession(sid, data.pending, data.pending_count" in MESSAGES_JS, \
-        "Poll loop must pass data.pending_count through showApprovalForSession"
+    assert (
+        "showApprovalForSession(sid, data.pending, data.pending_count" in MESSAGES_JS
+    ), "Poll loop must pass data.pending_count through showApprovalForSession"
 
 
 # ---------------------------------------------------------------------------
 # HTML: counter element present
 # ---------------------------------------------------------------------------
 
+
 def test_approval_counter_element_exists():
     """index.html must contain an approvalCounter element."""
-    assert 'id="approvalCounter"' in INDEX_HTML, \
+    assert 'id="approvalCounter"' in INDEX_HTML, (
         "index.html must contain an element with id='approvalCounter' for the '1 of N' display"
+    )
 
 
 # ---------------------------------------------------------------------------
 # Functional: multiple entries behave correctly (via routes module directly)
 # ---------------------------------------------------------------------------
 
+
 def test_multiple_approvals_both_surfaced():
     """Two submit_pending calls must produce two queued entries, not one."""
-    import threading
     from api import routes as r
 
     # Reset state
@@ -128,19 +150,39 @@ def test_multiple_approvals_both_surfaced():
     with r._lock:
         r._pending.pop(sid, None)
 
-    r.submit_pending(sid, {"command": "cmd1", "pattern_key": "p1", "pattern_keys": ["p1"], "description": "d1"})
-    r.submit_pending(sid, {"command": "cmd2", "pattern_key": "p2", "pattern_keys": ["p2"], "description": "d2"})
+    r.submit_pending(
+        sid,
+        {
+            "command": "cmd1",
+            "pattern_key": "p1",
+            "pattern_keys": ["p1"],
+            "description": "d1",
+        },
+    )
+    r.submit_pending(
+        sid,
+        {
+            "command": "cmd2",
+            "pattern_key": "p2",
+            "pattern_keys": ["p2"],
+            "description": "d2",
+        },
+    )
 
     with r._lock:
         queue = r._pending.get(sid)
 
-    assert isinstance(queue, list), "After two submit_pending calls, _pending[sid] must be a list"
+    assert isinstance(queue, list), (
+        "After two submit_pending calls, _pending[sid] must be a list"
+    )
     assert len(queue) == 2, f"Expected 2 queued entries, got {len(queue)}"
     assert queue[0]["command"] == "cmd1"
     assert queue[1]["command"] == "cmd2"
     assert queue[0].get("approval_id"), "First entry must have an approval_id"
     assert queue[1].get("approval_id"), "Second entry must have an approval_id"
-    assert queue[0]["approval_id"] != queue[1]["approval_id"], "Each entry must have a unique approval_id"
+    assert queue[0]["approval_id"] != queue[1]["approval_id"], (
+        "Each entry must have a unique approval_id"
+    )
 
     # Cleanup
     with r._lock:
@@ -155,8 +197,24 @@ def test_respond_by_approval_id_pops_correct_entry():
     with r._lock:
         r._pending.pop(sid, None)
 
-    r.submit_pending(sid, {"command": "cmd1", "pattern_key": "p1", "pattern_keys": ["p1"], "description": "d1"})
-    r.submit_pending(sid, {"command": "cmd2", "pattern_key": "p2", "pattern_keys": ["p2"], "description": "d2"})
+    r.submit_pending(
+        sid,
+        {
+            "command": "cmd1",
+            "pattern_key": "p1",
+            "pattern_keys": ["p1"],
+            "description": "d1",
+        },
+    )
+    r.submit_pending(
+        sid,
+        {
+            "command": "cmd2",
+            "pattern_key": "p2",
+            "pattern_keys": ["p2"],
+            "description": "d2",
+        },
+    )
 
     with r._lock:
         queue = r._pending.get(sid, [])

--- a/tests/test_approval_sse.py
+++ b/tests/test_approval_sse.py
@@ -11,7 +11,6 @@ Verifies:
   - Frontend EventSource / fallback polling patterns
 """
 
-import json
 import pathlib
 import queue
 import re
@@ -31,63 +30,71 @@ MESSAGES_JS = (REPO_ROOT / "static" / "messages.js").read_text(encoding="utf-8")
 # 1. Static-analysis tests (no server needed)
 # ═══════════════════════════════════════════════════════════════════════════════
 
+
 class TestSSEStaticAnalysis:
     """Verify the SSE infrastructure exists and is wired correctly in routes.py."""
 
     def test_sse_route_registered(self):
         """The /api/approval/stream route must be registered."""
-        assert '"/api/approval/stream"' in ROUTES_SRC, \
+        assert '"/api/approval/stream"' in ROUTES_SRC, (
             "Route /api/approval/stream must be registered in the URL dispatch"
+        )
 
     def test_sse_handler_function_exists(self):
         """_handle_approval_sse_stream handler must exist."""
-        assert "def _handle_approval_sse_stream(" in ROUTES_SRC, \
+        assert "def _handle_approval_sse_stream(" in ROUTES_SRC, (
             "_handle_approval_sse_stream handler function must exist"
+        )
 
     def test_subscribe_function_exists(self):
         """_approval_sse_subscribe must exist and use a Queue."""
-        assert "def _approval_sse_subscribe(" in ROUTES_SRC, \
+        assert "def _approval_sse_subscribe(" in ROUTES_SRC, (
             "_approval_sse_subscribe must be defined"
+        )
 
     def test_unsubscribe_function_exists(self):
         """_approval_sse_unsubscribe must exist and clean up empty lists."""
-        assert "def _approval_sse_unsubscribe(" in ROUTES_SRC, \
+        assert "def _approval_sse_unsubscribe(" in ROUTES_SRC, (
             "_approval_sse_unsubscribe must be defined"
+        )
 
     def test_notify_function_exists(self):
         """_approval_sse_notify must exist and push to subscriber queues."""
-        assert "def _approval_sse_notify(" in ROUTES_SRC, \
+        assert "def _approval_sse_notify(" in ROUTES_SRC, (
             "_approval_sse_notify must be defined"
+        )
 
     def test_sse_subscribers_dict_exists(self):
         """Module-level _approval_sse_subscribers dict must exist."""
-        assert "_approval_sse_subscribers" in ROUTES_SRC, \
+        assert "_approval_sse_subscribers" in ROUTES_SRC, (
             "_approval_sse_subscribers module-level dict must exist"
+        )
 
     def test_sse_content_type(self):
         """SSE handler must set text/event-stream content type."""
-        assert "text/event-stream" in ROUTES_SRC, \
+        assert "text/event-stream" in ROUTES_SRC, (
             "SSE handler must set Content-Type to text/event-stream"
+        )
 
     def test_sse_keepalive(self):
         """SSE handler must send keepalive comments to prevent proxy timeout."""
-        assert "keepalive" in ROUTES_SRC, \
-            "SSE handler must send keepalive comments"
+        assert "keepalive" in ROUTES_SRC, "SSE handler must send keepalive comments"
 
     def test_sse_cache_control(self):
         """SSE handler must set Cache-Control: no-cache."""
-        assert "no-cache" in ROUTES_SRC, \
-            "SSE handler must set Cache-Control: no-cache"
+        assert "no-cache" in ROUTES_SRC, "SSE handler must set Cache-Control: no-cache"
 
     def test_sse_initial_snapshot(self):
         """SSE handler must send initial snapshot on connect."""
-        assert "'initial'" in ROUTES_SRC, \
+        assert "'initial'" in ROUTES_SRC, (
             "SSE handler must send an 'initial' event with snapshot data"
+        )
 
     def test_sse_approval_event(self):
         """SSE handler must send 'approval' events on push."""
-        assert "'approval'" in ROUTES_SRC, \
+        assert "'approval'" in ROUTES_SRC, (
             "SSE handler must send 'approval' events when pushing notifications"
+        )
 
     def test_notify_called_from_submit_pending(self):
         """submit_pending must call _approval_sse_notify_locked."""
@@ -95,50 +102,65 @@ class TestSSEStaticAnalysis:
         # block as the queue mutation so two parallel submit_pending calls can't
         # deliver out-of-order with stale pending_count. Tracks the v0.50.248
         # MUST-FIX A fix.
-        assert "_approval_sse_notify_locked(session_key, head, total)" in ROUTES_SRC, \
-            ("submit_pending() must call _approval_sse_notify_locked(session_key, head, total) "
-             "from inside the `with _lock:` block — not the unlocked _approval_sse_notify wrapper, "
-             "and head must be queue_list[0] (the head, not the just-appended entry).")
+        assert "_approval_sse_notify_locked(session_key, head, total)" in ROUTES_SRC, (
+            "submit_pending() must call _approval_sse_notify_locked(session_key, head, total) "
+            "from inside the `with _lock:` block — not the unlocked _approval_sse_notify wrapper, "
+            "and head must be queue_list[0] (the head, not the just-appended entry)."
+        )
 
     def test_unsubscribe_in_finally(self):
         """SSE handler must unsubscribe in a finally block."""
         # Find the finally block that calls _approval_sse_unsubscribe
-        assert re.search(r"finally:.*\n.*_approval_sse_unsubscribe\(", ROUTES_SRC, re.DOTALL), \
-            "SSE handler must call _approval_sse_unsubscribe in a finally block"
+        assert re.search(
+            r"finally:.*\n.*_approval_sse_unsubscribe\(", ROUTES_SRC, re.DOTALL
+        ), "SSE handler must call _approval_sse_unsubscribe in a finally block"
 
     def test_client_disconnect_handled(self):
         """SSE handler must catch client disconnect errors."""
-        assert "_CLIENT_DISCONNECT_ERRORS" in ROUTES_SRC, \
+        assert "_CLIENT_DISCONNECT_ERRORS" in ROUTES_SRC, (
             "SSE handler must catch client disconnect errors"
+        )
 
     def test_subscriber_queue_maxsize(self):
         """Subscriber queues must have a bounded maxsize to prevent memory leaks."""
-        assert "queue.Queue(maxsize=" in ROUTES_SRC, \
+        assert "queue.Queue(maxsize=" in ROUTES_SRC, (
             "Subscriber queues must have maxsize set to prevent unbounded memory growth"
+        )
 
     def test_notify_drops_on_full(self):
         """_approval_sse_notify must silently drop events when subscriber is slow."""
         # The queue.Full exception handler
-        assert "queue.Full" in ROUTES_SRC, \
+        assert "queue.Full" in ROUTES_SRC, (
             "_approval_sse_notify must handle queue.Full to drop events for slow subscribers"
+        )
 
     def test_subscribe_uses_shared_lock(self):
         """subscribe/unsubscribe/notify must all use the same _lock."""
         # All three functions must use _lock
-        for func in ["_approval_sse_subscribe", "_approval_sse_unsubscribe", "_approval_sse_notify"]:
+        for func in [
+            "_approval_sse_subscribe",
+            "_approval_sse_unsubscribe",
+            "_approval_sse_notify",
+        ]:
             # Find the function and verify it uses "with _lock"
             func_start = ROUTES_SRC.find(f"def {func}(")
             assert func_start != -1, f"{func} must exist"
             # Find the next function definition after this one
             next_func = ROUTES_SRC.find("\ndef ", func_start + 1)
-            func_body = ROUTES_SRC[func_start:next_func] if next_func != -1 else ROUTES_SRC[func_start:]
-            assert "with _lock:" in func_body, \
+            func_body = (
+                ROUTES_SRC[func_start:next_func]
+                if next_func != -1
+                else ROUTES_SRC[func_start:]
+            )
+            assert "with _lock:" in func_body, (
                 f"{func} must use 'with _lock:' for thread safety"
+            )
 
     def test_unsubscribe_cleans_empty_session(self):
         """Unsubscribe must remove empty session keys from the dict."""
-        assert "_approval_sse_subscribers.pop(session_id, None)" in ROUTES_SRC, \
+        assert "_approval_sse_subscribers.pop(session_id, None)" in ROUTES_SRC, (
             "_approval_sse_unsubscribe must pop session_id when subscriber list is empty"
+        )
 
 
 class TestFrontendSSEImplementation:
@@ -146,56 +168,67 @@ class TestFrontendSSEImplementation:
 
     def test_eventsource_used(self):
         """Frontend must use EventSource for SSE connection."""
-        assert "new EventSource(" in MESSAGES_JS, \
+        assert "new EventSource(" in MESSAGES_JS, (
             "startApprovalPolling must create an EventSource for SSE"
+        )
 
     def test_sse_url_matches_backend(self):
         """Frontend SSE URL must match backend approval stream route."""
-        assert "api/approval/stream" in MESSAGES_JS, \
+        assert "api/approval/stream" in MESSAGES_JS, (
             "EventSource must connect to the approval stream endpoint"
-        assert "EventSource('/api/approval/stream" not in MESSAGES_JS, \
+        )
+        assert "EventSource('/api/approval/stream" not in MESSAGES_JS, (
             "EventSource URL must stay relative for subpath mounts"
+        )
 
     def test_initial_event_listener(self):
         """Frontend must listen for 'initial' SSE events."""
-        assert "'initial'" in MESSAGES_JS or '"initial"' in MESSAGES_JS, \
+        assert "'initial'" in MESSAGES_JS or '"initial"' in MESSAGES_JS, (
             "Frontend must addEventListener for 'initial' SSE events"
+        )
 
     def test_approval_event_listener(self):
         """Frontend must listen for 'approval' SSE events."""
-        assert "'approval'" in MESSAGES_JS or '"approval"' in MESSAGES_JS, \
+        assert "'approval'" in MESSAGES_JS or '"approval"' in MESSAGES_JS, (
             "Frontend must addEventListener for 'approval' SSE events"
+        )
 
     def test_onerror_fallback_to_polling(self):
         """onerror must fall back to HTTP polling."""
-        assert "_startApprovalFallbackPoll" in MESSAGES_JS, \
+        assert "_startApprovalFallbackPoll" in MESSAGES_JS, (
             "SSE onerror handler must call _startApprovalFallbackPoll"
+        )
 
     def test_fallback_poll_interval(self):
         """Fallback polling interval must match v0.50.247's 1500ms cadence."""
-        assert "1500" in MESSAGES_JS, \
+        assert "1500" in MESSAGES_JS, (
             "Fallback polling interval must be 1500ms to match degraded-mode parity with v0.50.247"
+        )
 
     def test_fallback_closes_eventsource(self):
         """onerror handler must close the EventSource before falling back."""
         # The onerror handler should call es.close()
-        assert "es.close()" in MESSAGES_JS, \
+        assert "es.close()" in MESSAGES_JS, (
             "onerror handler must close the EventSource before falling back"
+        )
 
     def test_stop_closes_eventsource(self):
         """stopApprovalPolling must close EventSource."""
-        assert "_approvalEventSource.close()" in MESSAGES_JS, \
+        assert "_approvalEventSource.close()" in MESSAGES_JS, (
             "stopApprovalPolling must close _approvalEventSource"
+        )
 
     def test_health_timer_cleanup(self):
         """stopApprovalPolling must clear the SSE health timer."""
-        assert "_approvalSSEHealthTimer" in MESSAGES_JS, \
+        assert "_approvalSSEHealthTimer" in MESSAGES_JS, (
             "SSE health timer must be tracked and cleared in stopApprovalPolling"
+        )
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # 2. Unit tests (in-process, no HTTP server)
 # ═══════════════════════════════════════════════════════════════════════════════
+
 
 class TestSSESubscribeUnsubscribe:
     """Test the subscribe/unsubscribe lifecycle."""
@@ -203,18 +236,21 @@ class TestSSESubscribeUnsubscribe:
     def setup_method(self):
         """Clean SSE subscriber state before each test."""
         from api import routes as r
+
         with r._lock:
             r._approval_sse_subscribers.clear()
 
     def teardown_method(self):
         """Clean up after each test."""
         from api import routes as r
+
         with r._lock:
             r._approval_sse_subscribers.clear()
 
     def test_subscribe_returns_queue(self):
         """_approval_sse_subscribe must return a Queue."""
         from api import routes as r
+
         sid = f"sse-test-{uuid.uuid4().hex[:8]}"
         q = r._approval_sse_subscribe(sid)
         assert isinstance(q, queue.Queue), "subscribe must return a queue.Queue"
@@ -224,6 +260,7 @@ class TestSSESubscribeUnsubscribe:
     def test_subscribe_registers_subscriber(self):
         """After subscribe, the queue must appear in _approval_sse_subscribers."""
         from api import routes as r
+
         sid = f"sse-reg-{uuid.uuid4().hex[:8]}"
         q = r._approval_sse_subscribe(sid)
         try:
@@ -236,6 +273,7 @@ class TestSSESubscribeUnsubscribe:
     def test_unsubscribe_removes_queue(self):
         """After unsubscribe, the queue must not be in the subscribers list."""
         from api import routes as r
+
         sid = f"sse-unsub-{uuid.uuid4().hex[:8]}"
         q = r._approval_sse_subscribe(sid)
         r._approval_sse_unsubscribe(sid, q)
@@ -246,16 +284,19 @@ class TestSSESubscribeUnsubscribe:
     def test_unsubscribe_removes_empty_session_key(self):
         """When the last subscriber is removed, the session key must be cleaned up."""
         from api import routes as r
+
         sid = f"sse-empty-{uuid.uuid4().hex[:8]}"
         q = r._approval_sse_subscribe(sid)
         r._approval_sse_unsubscribe(sid, q)
         with r._lock:
-            assert sid not in r._approval_sse_subscribers, \
+            assert sid not in r._approval_sse_subscribers, (
                 "Session key must be removed when subscriber list is empty"
+            )
 
     def test_unsubscribe_idempotent(self):
         """Unsubscribing twice must not raise."""
         from api import routes as r
+
         sid = f"sse-idem-{uuid.uuid4().hex[:8]}"
         q = r._approval_sse_subscribe(sid)
         r._approval_sse_unsubscribe(sid, q)
@@ -264,6 +305,7 @@ class TestSSESubscribeUnsubscribe:
     def test_unsubscribe_unknown_queue_noop(self):
         """Unsubscribing a queue that was never subscribed must not crash."""
         from api import routes as r
+
         sid = f"sse-noop-{uuid.uuid4().hex[:8]}"
         q = queue.Queue()
         r._approval_sse_unsubscribe(sid, q)  # should not raise
@@ -274,17 +316,20 @@ class TestSSENotify:
 
     def setup_method(self):
         from api import routes as r
+
         with r._lock:
             r._approval_sse_subscribers.clear()
 
     def teardown_method(self):
         from api import routes as r
+
         with r._lock:
             r._approval_sse_subscribers.clear()
 
     def test_notify_delivers_payload(self):
         """_approval_sse_notify must put the payload on subscriber queues."""
         from api import routes as r
+
         sid = f"sse-notify-{uuid.uuid4().hex[:8]}"
         q = r._approval_sse_subscribe(sid)
         try:
@@ -299,6 +344,7 @@ class TestSSENotify:
     def test_notify_multiple_subscribers(self):
         """All subscribers for a session must receive the notification."""
         from api import routes as r
+
         sid = f"sse-multi-{uuid.uuid4().hex[:8]}"
         q1 = r._approval_sse_subscribe(sid)
         q2 = r._approval_sse_subscribe(sid)
@@ -317,6 +363,7 @@ class TestSSENotify:
     def test_notify_cross_session_isolation(self):
         """Notify for session A must NOT deliver to session B subscribers."""
         from api import routes as r
+
         sid_a = f"sse-iso-a-{uuid.uuid4().hex[:8]}"
         sid_b = f"sse-iso-b-{uuid.uuid4().hex[:8]}"
         qa = r._approval_sse_subscribe(sid_a)
@@ -336,12 +383,14 @@ class TestSSENotify:
     def test_notify_no_subscribers_is_noop(self):
         """Notifying a session with no subscribers must not raise."""
         from api import routes as r
+
         sid = f"sse-nosub-{uuid.uuid4().hex[:8]}"
         r._approval_sse_notify(sid, {"command": "test"}, 1)  # should not raise
 
     def test_notify_drops_on_full_queue(self):
         """When subscriber queue is full, events must be silently dropped."""
         from api import routes as r
+
         sid = f"sse-full-{uuid.uuid4().hex[:8]}"
         q = r._approval_sse_subscribe(sid)
         try:
@@ -360,12 +409,14 @@ class TestSSENotifyFromSubmitPending:
 
     def setup_method(self):
         from api import routes as r
+
         with r._lock:
             r._approval_sse_subscribers.clear()
             r._pending.clear()
 
     def teardown_method(self):
         from api import routes as r
+
         with r._lock:
             r._approval_sse_subscribers.clear()
             r._pending.clear()
@@ -373,15 +424,19 @@ class TestSSENotifyFromSubmitPending:
     def test_submit_pending_notifies_sse_subscriber(self):
         """submit_pending must push an SSE event to subscribers."""
         from api import routes as r
+
         sid = f"sse-submit-{uuid.uuid4().hex[:8]}"
         q = r._approval_sse_subscribe(sid)
         try:
-            r.submit_pending(sid, {
-                "command": "rm -rf /tmp/test",
-                "pattern_key": "recursive delete",
-                "pattern_keys": ["recursive delete"],
-                "description": "recursive delete",
-            })
+            r.submit_pending(
+                sid,
+                {
+                    "command": "rm -rf /tmp/test",
+                    "pattern_key": "recursive delete",
+                    "pattern_keys": ["recursive delete"],
+                    "description": "recursive delete",
+                },
+            )
             payload = q.get(timeout=1)
             assert payload["pending"]["command"] == "rm -rf /tmp/test"
             assert payload["pending_count"] == 1
@@ -391,20 +446,25 @@ class TestSSENotifyFromSubmitPending:
     def test_submit_pending_delivers_count(self):
         """Multiple submit_pending calls must report correct pending_count."""
         from api import routes as r
+
         sid = f"sse-count-{uuid.uuid4().hex[:8]}"
         q = r._approval_sse_subscribe(sid)
         try:
             for i in range(3):
-                r.submit_pending(sid, {
-                    "command": f"cmd-{i}",
-                    "pattern_key": f"p{i}",
-                    "pattern_keys": [f"p{i}"],
-                    "description": f"d{i}",
-                })
+                r.submit_pending(
+                    sid,
+                    {
+                        "command": f"cmd-{i}",
+                        "pattern_key": f"p{i}",
+                        "pattern_keys": [f"p{i}"],
+                        "description": f"d{i}",
+                    },
+                )
             for expected_count in [1, 2, 3]:
                 payload = q.get(timeout=1)
-                assert payload["pending_count"] == expected_count, \
+                assert payload["pending_count"] == expected_count, (
                     f"Expected pending_count={expected_count}, got {payload['pending_count']}"
+                )
         finally:
             r._approval_sse_unsubscribe(sid, q)
 
@@ -414,12 +474,14 @@ class TestSSEConcurrency:
 
     def setup_method(self):
         from api import routes as r
+
         with r._lock:
             r._approval_sse_subscribers.clear()
             r._pending.clear()
 
     def teardown_method(self):
         from api import routes as r
+
         with r._lock:
             r._approval_sse_subscribers.clear()
             r._pending.clear()
@@ -427,6 +489,7 @@ class TestSSEConcurrency:
     def test_concurrent_subscribe_unsubscribe(self):
         """Concurrent subscribe/unsubscribe must not corrupt state."""
         from api import routes as r
+
         sid = f"sse-conc-{uuid.uuid4().hex[:8]}"
         errors = []
         queues = []
@@ -455,6 +518,7 @@ class TestSSEConcurrency:
     def test_concurrent_notify_while_subscribing(self):
         """Notify while new subscribers are joining must not deadlock or crash."""
         from api import routes as r
+
         sid = f"sse-notsub-{uuid.uuid4().hex[:8]}"
         errors = []
 

--- a/tests/test_approval_unblock.py
+++ b/tests/test_approval_unblock.py
@@ -6,7 +6,6 @@ need to prevent the UI getting stuck in "Thinking…" during dangerous commands.
 """
 
 import json
-import threading
 import uuid
 import urllib.request
 import urllib.error
@@ -28,6 +27,7 @@ try:
         _ApprovalEntry,
         submit_pending,
     )
+
     # has_pending and pop_pending were removed from tools.approval when the
     # agent renamed has_pending -> has_blocking_approval (gateway queue check)
     # and removed the polling-mode pop_pending. Routes now check _pending
@@ -37,8 +37,7 @@ except ImportError:
     APPROVAL_AVAILABLE = False
 
 pytestmark = pytest.mark.skipif(
-    not APPROVAL_AVAILABLE,
-    reason="tools.approval not available in this environment"
+    not APPROVAL_AVAILABLE, reason="tools.approval not available in this environment"
 )
 
 from tests._pytest_port import BASE
@@ -53,8 +52,9 @@ def get(path):
 def post(path, body=None):
     url = BASE + path
     data = json.dumps(body or {}).encode()
-    req = urllib.request.Request(url, data=data,
-          headers={"Content-Type": "application/json"})
+    req = urllib.request.Request(
+        url, data=data, headers={"Content-Type": "application/json"}
+    )
     try:
         with urllib.request.urlopen(req, timeout=10) as r:
             return json.loads(r.read()), r.status
@@ -63,6 +63,7 @@ def post(path, body=None):
 
 
 # ── Unit tests (in-process, no HTTP server needed) ──────────────────────────
+
 
 class TestGatewayApprovalUnblocking:
     """Unit tests for the gateway queue unblocking mechanism."""
@@ -159,6 +160,7 @@ class TestGatewayApprovalUnblocking:
         # Step 1: streaming.py registers the notify callback
         def _approval_notify_cb(approval_data):
             approval_events_sent.append(approval_data)  # would be put('approval', ...)
+
         register_gateway_notify(sid, _approval_notify_cb)
 
         # Step 2: check_all_command_guards fires the callback and queues an entry
@@ -176,7 +178,9 @@ class TestGatewayApprovalUnblocking:
             cb = _gateway_notify_cbs.get(sid)
         cb(approval_data)
 
-        assert len(approval_events_sent) == 1, "approval SSE event should have been queued"
+        assert len(approval_events_sent) == 1, (
+            "approval SSE event should have been queued"
+        )
 
         # Step 3: user responds via /api/approval/respond → resolve_gateway_approval
         resolved = resolve_gateway_approval(sid, "once")
@@ -192,31 +196,41 @@ class TestGatewayApprovalUnblocking:
 
 # ── Symbol existence tests ───────────────────────────────────────────────────
 
+
 class TestApprovalModuleExports:
     """Verify the module exports all symbols that streaming.py and routes.py need."""
 
     def test_register_gateway_notify_exported(self):
         import tools.approval as ap
-        assert hasattr(ap, "register_gateway_notify"), \
+
+        assert hasattr(ap, "register_gateway_notify"), (
             "tools.approval must export register_gateway_notify"
+        )
 
     def test_unregister_gateway_notify_exported(self):
         import tools.approval as ap
-        assert hasattr(ap, "unregister_gateway_notify"), \
+
+        assert hasattr(ap, "unregister_gateway_notify"), (
             "tools.approval must export unregister_gateway_notify"
+        )
 
     def test_resolve_gateway_approval_exported(self):
         import tools.approval as ap
-        assert hasattr(ap, "resolve_gateway_approval"), \
+
+        assert hasattr(ap, "resolve_gateway_approval"), (
             "tools.approval must export resolve_gateway_approval"
+        )
 
     def test_approval_entry_exported(self):
         import tools.approval as ap
-        assert hasattr(ap, "_ApprovalEntry"), \
+
+        assert hasattr(ap, "_ApprovalEntry"), (
             "tools.approval must export _ApprovalEntry"
+        )
 
 
 # ── HTTP regression tests (test server, port 8788) ───────────────────────────
+
 
 class TestApprovalHTTPEndpoints:
     """
@@ -228,10 +242,13 @@ class TestApprovalHTTPEndpoints:
     def test_respond_returns_ok_no_pending(self):
         """respond with no pending entry returns ok (no crash, no 500)."""
         sid = f"http-no-pending-{uuid.uuid4().hex[:8]}"
-        result, status = post("/api/approval/respond", {
-            "session_id": sid,
-            "choice": "deny",
-        })
+        result, status = post(
+            "/api/approval/respond",
+            {
+                "session_id": sid,
+                "choice": "deny",
+            },
+        )
         assert status == 200
         assert result["ok"] is True
 
@@ -240,17 +257,22 @@ class TestApprovalHTTPEndpoints:
         sid = f"http-clear-{uuid.uuid4().hex[:8]}"
         cmd = "rm -rf /tmp/testdir"
 
-        inject = get(f"/api/approval/inject_test?session_id={urllib.parse.quote(sid)}"
-                     f"&pattern_key=recursive+delete&command={urllib.parse.quote(cmd)}")
+        inject = get(
+            f"/api/approval/inject_test?session_id={urllib.parse.quote(sid)}"
+            f"&pattern_key=recursive+delete&command={urllib.parse.quote(cmd)}"
+        )
         assert inject["ok"] is True
 
         data = get(f"/api/approval/pending?session_id={urllib.parse.quote(sid)}")
         assert data["pending"] is not None
 
-        result, status = post("/api/approval/respond", {
-            "session_id": sid,
-            "choice": "deny",
-        })
+        result, status = post(
+            "/api/approval/respond",
+            {
+                "session_id": sid,
+                "choice": "deny",
+            },
+        )
         assert status == 200
         assert result["ok"] is True
 
@@ -259,10 +281,13 @@ class TestApprovalHTTPEndpoints:
 
     def test_respond_rejects_invalid_choice(self):
         """respond with an unknown choice returns 400."""
-        result, status = post("/api/approval/respond", {
-            "session_id": "some-session",
-            "choice": "INVALID",
-        })
+        result, status = post(
+            "/api/approval/respond",
+            {
+                "session_id": "some-session",
+                "choice": "INVALID",
+            },
+        )
         assert status == 400
 
     def test_respond_requires_session_id(self):
@@ -273,14 +298,19 @@ class TestApprovalHTTPEndpoints:
     def test_respond_session_choice_clears_pending(self):
         """Inject pending, respond with 'session', verify cleared."""
         sid = f"http-session-{uuid.uuid4().hex[:8]}"
-        inject = get(f"/api/approval/inject_test?session_id={urllib.parse.quote(sid)}"
-                     f"&pattern_key=force+kill+processes&command=pkill+-9+something")
+        inject = get(
+            f"/api/approval/inject_test?session_id={urllib.parse.quote(sid)}"
+            f"&pattern_key=force+kill+processes&command=pkill+-9+something"
+        )
         assert inject["ok"] is True
 
-        result, status = post("/api/approval/respond", {
-            "session_id": sid,
-            "choice": "session",
-        })
+        result, status = post(
+            "/api/approval/respond",
+            {
+                "session_id": sid,
+                "choice": "session",
+            },
+        )
         assert status == 200
         assert result["choice"] == "session"
 

--- a/tests/test_auth_session_persistence.py
+++ b/tests/test_auth_session_persistence.py
@@ -5,6 +5,7 @@ systemd, container) invalidates all active browser sessions and floods clients
 with 401s until they clear cookies. The HMAC signing key already persists to
 STATE_DIR; this PR persists the session table using the same pattern.
 """
+
 import importlib
 import json
 import os
@@ -28,7 +29,7 @@ class TestSessionPersistence(unittest.TestCase):
 
     def setUp(self) -> None:
         auth._sessions.clear()
-        sessions_file = _TEST_STATE / '.sessions.json'
+        sessions_file = _TEST_STATE / ".sessions.json"
         if sessions_file.exists():
             sessions_file.unlink()
 
@@ -42,6 +43,7 @@ class TestSessionPersistence(unittest.TestCase):
         invalidate imported references like STREAM_PARTIAL_TEXT in other tests).
         """
         import api.config as _config
+
         _saved = _config.STATE_DIR
         _config.STATE_DIR = _TEST_STATE
         try:
@@ -54,26 +56,34 @@ class TestSessionPersistence(unittest.TestCase):
         cookie = auth.create_session()
         self.assertTrue(auth.verify_session(cookie))
         self._simulate_restart()
-        self.assertTrue(auth.verify_session(cookie),
-                        "Session must survive process restart via persisted .sessions.json")
+        self.assertTrue(
+            auth.verify_session(cookie),
+            "Session must survive process restart via persisted .sessions.json",
+        )
 
     def test_invalidated_session_does_not_survive_restart(self) -> None:
         """Invalidating a session must be reflected after reload."""
         cookie = auth.create_session()
         auth.invalidate_session(cookie)
         self._simulate_restart()
-        self.assertFalse(auth.verify_session(cookie),
-                         "Invalidated session must not be reinstated after restart")
+        self.assertFalse(
+            auth.verify_session(cookie),
+            "Invalidated session must not be reinstated after restart",
+        )
 
     def test_expired_sessions_pruned_on_load(self) -> None:
         """Sessions that expire between restarts must not be loaded."""
-        sessions_file = _TEST_STATE / '.sessions.json'
+        sessions_file = _TEST_STATE / ".sessions.json"
         # Write a sessions file with one expired and one valid entry
         now = time.time()
-        sessions_file.write_text(json.dumps({
-            "expired_token": now - 10,
-            "valid_token": now + 3600,
-        }))
+        sessions_file.write_text(
+            json.dumps(
+                {
+                    "expired_token": now - 10,
+                    "valid_token": now + 3600,
+                }
+            )
+        )
         self._simulate_restart()
         self.assertNotIn("expired_token", auth._sessions)
         self.assertIn("valid_token", auth._sessions)
@@ -81,23 +91,27 @@ class TestSessionPersistence(unittest.TestCase):
     def test_sessions_file_permissions(self) -> None:
         """Sessions file must be owner-read-only (0600)."""
         auth.create_session()
-        sessions_file = _TEST_STATE / '.sessions.json'
+        sessions_file = _TEST_STATE / ".sessions.json"
         self.assertTrue(sessions_file.exists(), ".sessions.json was not created")
         mode = oct(sessions_file.stat().st_mode & 0o777)
-        self.assertEqual(mode, oct(0o600),
-                         f".sessions.json permissions {mode} — expected 0o600")
+        self.assertEqual(
+            mode, oct(0o600), f".sessions.json permissions {mode} — expected 0o600"
+        )
 
     def test_malformed_sessions_file_starts_fresh(self) -> None:
         """A corrupt sessions file must not crash auth — start with empty dict."""
-        sessions_file = _TEST_STATE / '.sessions.json'
+        sessions_file = _TEST_STATE / ".sessions.json"
         sessions_file.write_text("not valid json {{{{")
         self._simulate_restart()
-        self.assertEqual(auth._sessions, {},
-                         "Corrupt sessions file must result in empty session dict")
+        self.assertEqual(
+            auth._sessions,
+            {},
+            "Corrupt sessions file must result in empty session dict",
+        )
 
     def test_sessions_file_wrong_type_starts_fresh(self) -> None:
         """A sessions file containing a non-dict must be ignored."""
-        sessions_file = _TEST_STATE / '.sessions.json'
+        sessions_file = _TEST_STATE / ".sessions.json"
         sessions_file.write_text(json.dumps(["list", "not", "dict"]))
         self._simulate_restart()
         self.assertEqual(auth._sessions, {})

--- a/tests/test_auth_sessions.py
+++ b/tests/test_auth_sessions.py
@@ -2,6 +2,7 @@
 Tests for auth session lifecycle — session creation, verification, expiry,
 and lazy pruning of expired entries.
 """
+
 import time
 import unittest
 from pathlib import Path
@@ -13,6 +14,7 @@ _TEST_STATE = Path(tempfile.mkdtemp())
 os.environ["HERMES_WEBUI_STATE_DIR"] = str(_TEST_STATE)
 
 import sys
+
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 import importlib
@@ -57,7 +59,7 @@ class TestSessionPruning(unittest.TestCase):
     def test_prune_does_not_remove_valid_sessions(self):
         """_prune_expired_sessions should never remove sessions that are still active."""
         auth._sessions["active_1"] = time.time() + 86400  # 24 hours from now
-        auth._sessions["active_2"] = time.time() + 7200    # 2 hours from now
+        auth._sessions["active_2"] = time.time() + 7200  # 2 hours from now
         auth._sessions["expired_1"] = time.time() - 10
 
         auth._prune_expired_sessions()
@@ -97,6 +99,7 @@ class TestSessionPruning(unittest.TestCase):
         # We can check the expiry is approximately SESSION_TTL seconds from now
         # by looking up the raw entry via the token
         from api.auth import _sessions, SESSION_TTL
+
         # find our entry
         for t, exp in _sessions.items():
             if t == token_hex:
@@ -139,10 +142,7 @@ class TestSessionTtlResolution(unittest.TestCase):
 
     def setUp(self):
         # Snapshot environment + load_settings so each test starts clean.
-        self._saved_env = {
-            k: os.environ.get(k)
-            for k in ("HERMES_WEBUI_SESSION_TTL",)
-        }
+        self._saved_env = {k: os.environ.get(k) for k in ("HERMES_WEBUI_SESSION_TTL",)}
         os.environ.pop("HERMES_WEBUI_SESSION_TTL", None)
         self._saved_load_settings = auth.load_settings
 
@@ -158,6 +158,7 @@ class TestSessionTtlResolution(unittest.TestCase):
         """HERMES_WEBUI_SESSION_TTL env var should take priority."""
         os.environ["HERMES_WEBUI_SESSION_TTL"] = "3600"
         from api.auth import _resolve_session_ttl
+
         self.assertEqual(_resolve_session_ttl(), 3600)
 
     def test_clamps_minimum(self):
@@ -165,6 +166,7 @@ class TestSessionTtlResolution(unittest.TestCase):
         os.environ["HERMES_WEBUI_SESSION_TTL"] = "10"
         auth.load_settings = lambda: {}
         from api.auth import _resolve_session_ttl
+
         # Out-of-range env values are rejected; falls through to default 30 days.
         self.assertEqual(_resolve_session_ttl(), auth.SESSION_TTL)
 
@@ -173,6 +175,7 @@ class TestSessionTtlResolution(unittest.TestCase):
         os.environ["HERMES_WEBUI_SESSION_TTL"] = "100000000"
         auth.load_settings = lambda: {}
         from api.auth import _resolve_session_ttl
+
         # Out-of-range env values are rejected; falls through to default 30 days.
         self.assertEqual(_resolve_session_ttl(), auth.SESSION_TTL)
 
@@ -181,6 +184,7 @@ class TestSessionTtlResolution(unittest.TestCase):
         os.environ["HERMES_WEBUI_SESSION_TTL"] = "not-a-number"
         auth.load_settings = lambda: {}
         from api.auth import _resolve_session_ttl
+
         self.assertEqual(_resolve_session_ttl(), auth.SESSION_TTL)
 
     def test_empty_env_falls_through(self):
@@ -188,6 +192,7 @@ class TestSessionTtlResolution(unittest.TestCase):
         os.environ["HERMES_WEBUI_SESSION_TTL"] = ""
         auth.load_settings = lambda: {}
         from api.auth import _resolve_session_ttl
+
         self.assertEqual(_resolve_session_ttl(), auth.SESSION_TTL)
 
     def test_settings_path_returns_value(self):
@@ -195,6 +200,7 @@ class TestSessionTtlResolution(unittest.TestCase):
         os.environ.pop("HERMES_WEBUI_SESSION_TTL", None)
         auth.load_settings = lambda: {"session_ttl_seconds": 7200}
         from api.auth import _resolve_session_ttl
+
         self.assertEqual(_resolve_session_ttl(), 7200)
 
     def test_session_uses_dynamic_ttl(self):
@@ -203,6 +209,7 @@ class TestSessionTtlResolution(unittest.TestCase):
         os.environ["HERMES_WEBUI_SESSION_TTL"] = "3600"
         token_hex = auth.create_session().split(".")[0]
         from api.auth import _sessions
+
         for t, exp in _sessions.items():
             if t == token_hex:
                 # The resolved env-var value (3600s) should be applied, not

--- a/tests/test_auto_compression_card.py
+++ b/tests/test_auto_compression_card.py
@@ -152,7 +152,10 @@ def test_context_compaction_branch_precedes_user_bubble_branch():
     assert context_idx != -1, "context compaction render branch not found"
     assert user_idx != -1, "normal user bubble render branch not found"
     assert context_idx < user_idx
-    assert "_contextCompactionMessageHtml(m, tsTitle, preservedForThisCard)" in render_prefix
+    assert (
+        "_contextCompactionMessageHtml(m, tsTitle, preservedForThisCard)"
+        in render_prefix
+    )
 
 
 def test_preserved_task_list_skips_normal_visible_message_path():
@@ -164,7 +167,9 @@ def test_preserved_task_list_skips_normal_visible_message_path():
     assert visible_filter_end != -1, "empty state update after visible filter not found"
     visible_filter = src[visible_filter_start:visible_filter_end]
     assert "if(_isContextCompactionMessage(m)) return false;" in visible_filter
-    assert "if(_isPreservedCompressionTaskListMessage(m)) return false;" in visible_filter
+    assert (
+        "if(_isPreservedCompressionTaskListMessage(m)) return false;" in visible_filter
+    )
 
     vis_idx_start = src.find("for(const m of S.messages)", visible_filter_end)
     assert vis_idx_start != -1, "raw message index loop not found"
@@ -187,7 +192,7 @@ def test_preserved_task_list_renders_through_compression_card_path():
     assert "_compressionStatusCardHtml" in helper
     assert "preserved_task_list_label" in helper
     assert "tool-card-compress-reference" in helper
-    assert "data-compression-card=\"1\"" in helper
+    assert 'data-compression-card="1"' in helper
     assert "li('list-todo',13)" in helper
     assert "_contextCompactionMessageHtml(m, tsTitle, preservedForThisCard)" in src
 
@@ -197,12 +202,24 @@ def test_preserved_task_list_attaches_once_per_render():
 
     assert "function _latestPreservedCompressionTaskListMessages" in src
     assert ".reverse().find(m=>_isPreservedCompressionTaskListMessage(m))" in src
-    assert "const preservedCompressionTaskMessages=_latestPreservedCompressionTaskListMessages(S.messages);" in src
+    assert (
+        "const preservedCompressionTaskMessages=_latestPreservedCompressionTaskListMessages(S.messages);"
+        in src
+    )
     assert "S.messages.filter(m=>_isPreservedCompressionTaskListMessage(m))" not in src
     assert "let preservedCompressionTaskCardsAttached=!!referenceNode;" in src
-    assert "const preservedForThisCard=preservedCompressionTaskCardsAttached?[]:preservedCompressionTaskMessages;" in src
-    assert "if(preservedForThisCard.length) preservedCompressionTaskCardsAttached=true;" in src
-    assert "(!preservedCompressionTaskCardsAttached&&(!referenceMessage||compressionState)&&preservedCompressionTaskMessages.length)" in src
+    assert (
+        "const preservedForThisCard=preservedCompressionTaskCardsAttached?[]:preservedCompressionTaskMessages;"
+        in src
+    )
+    assert (
+        "if(preservedForThisCard.length) preservedCompressionTaskCardsAttached=true;"
+        in src
+    )
+    assert (
+        "(!preservedCompressionTaskCardsAttached&&(!referenceMessage||compressionState)&&preservedCompressionTaskMessages.length)"
+        in src
+    )
 
 
 def test_preserved_task_list_is_suppressed_when_latest_todo_state_has_no_active_items():
@@ -216,7 +233,10 @@ def test_preserved_task_list_is_suppressed_when_latest_todo_state_has_no_active_
     assert "if(payload&&Array.isArray(payload.todos)) return payload.todos;" in helpers
     assert "function _hasActiveTodoItems" in helpers
     assert "status==='pending'||status==='in_progress'" in helpers
-    assert "if(Array.isArray(latestTodos) && !_hasActiveTodoItems(latestTodos)) return [];" in helpers
+    assert (
+        "if(Array.isArray(latestTodos) && !_hasActiveTodoItems(latestTodos)) return [];"
+        in helpers
+    )
 
 
 def test_preserved_task_list_rendering_does_not_mutate_history():

--- a/tests/test_background_tasks.py
+++ b/tests/test_background_tasks.py
@@ -18,14 +18,12 @@ non-functional as originally shipped.  The fix in api/background.py +
 api/routes.py wires the completion hook and keeps running tasks in the
 tracker until they resolve.
 """
+
 from __future__ import annotations
 
-import os
 import pathlib
 import sys
-import time
 import unittest
-from unittest.mock import patch
 
 
 # Ensure the repo root is importable without relying on CWD.
@@ -39,6 +37,7 @@ class TestGetResultsKeepsRunningTasks(unittest.TestCase):
 
     def setUp(self):
         import api.background as bg
+
         bg._BACKGROUND_TASKS.clear()
         self.bg = bg
 
@@ -47,8 +46,11 @@ class TestGetResultsKeepsRunningTasks(unittest.TestCase):
         can still find it after the first poll returns."""
         parent = "parent-session-1"
         self.bg.track_background(
-            parent_sid=parent, bg_sid="bg-a", stream_id="s-a",
-            task_id="task-a", prompt="long task",
+            parent_sid=parent,
+            bg_sid="bg-a",
+            stream_id="s-a",
+            task_id="task-a",
+            prompt="long task",
         )
 
         # First poll: task is still running, no done results to return
@@ -58,11 +60,15 @@ class TestGetResultsKeepsRunningTasks(unittest.TestCase):
         # The running task MUST still be tracked — otherwise the worker
         # thread's complete_background call cannot find it.
         remaining = self.bg.get_background_tasks(parent)
-        self.assertEqual(len(remaining), 1, (
-            "get_results dropped the still-running task — subsequent "
-            "complete_background() calls will silently no-op and the "
-            "result will be lost forever"
-        ))
+        self.assertEqual(
+            len(remaining),
+            1,
+            (
+                "get_results dropped the still-running task — subsequent "
+                "complete_background() calls will silently no-op and the "
+                "result will be lost forever"
+            ),
+        )
         self.assertEqual(remaining[0]["status"], "running")
         self.assertEqual(remaining[0]["task_id"], "task-a")
 
@@ -128,20 +134,28 @@ class TestBackgroundCompletionHookWiring(unittest.TestCase):
         self.assertGreater(idx, -1, "_handle_background() not found in routes.py")
         # Take a generous window around the function body
         end = routes_src.find("\ndef ", idx + 1)
-        body = routes_src[idx:end if end > 0 else idx + 3000]
+        body = routes_src[idx : end if end > 0 else idx + 3000]
 
-        self.assertIn("complete_background", body, (
-            "_handle_background worker must call complete_background() after "
-            "_run_agent_streaming returns — otherwise the tracker never "
-            "transitions the task to status='done' and /api/background/status "
-            "returns nothing forever. See api/background.py:complete_background."
-        ))
+        self.assertIn(
+            "complete_background",
+            body,
+            (
+                "_handle_background worker must call complete_background() after "
+                "_run_agent_streaming returns — otherwise the tracker never "
+                "transitions the task to status='done' and /api/background/status "
+                "returns nothing forever. See api/background.py:complete_background."
+            ),
+        )
         # Must extract the last assistant message content from the bg session
         self.assertIn("_run_agent_streaming", body)
-        self.assertIn("Session.load", body, (
-            "_run_bg_and_notify must reload the bg session to extract the "
-            "final assistant reply so complete_background gets an actual answer"
-        ))
+        self.assertIn(
+            "Session.load",
+            body,
+            (
+                "_run_bg_and_notify must reload the bg session to extract the "
+                "final assistant reply so complete_background gets an actual answer"
+            ),
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_batch_fixes.py
+++ b/tests/test_batch_fixes.py
@@ -20,8 +20,8 @@ def read(rel):
 
 # ── Group A: /root workspace ──────────────────────────────────────────────────
 
-class TestRootWorkspaceUnblocked:
 
+class TestRootWorkspaceUnblocked:
     def test_root_not_in_blocked_system_roots(self):
         src = read("api/workspace.py")
         assert "Path('/root')" not in src, (
@@ -51,8 +51,8 @@ class TestRootWorkspaceUnblocked:
 
 # ── Group B: custom_providers visibility ─────────────────────────────────────
 
-class TestCustomProvidersVisibility:
 
+class TestCustomProvidersVisibility:
     def test_has_custom_providers_variable_present(self):
         src = read("api/config.py")
         assert "_has_custom_providers" in src, (
@@ -75,8 +75,8 @@ class TestCustomProvidersVisibility:
 
 # ── Group C: cron skill cache ─────────────────────────────────────────────────
 
-class TestCronSkillCacheInvalidation:
 
+class TestCronSkillCacheInvalidation:
     def _panels_src(self):
         return read("static/panels.js")
 
@@ -86,8 +86,9 @@ class TestCronSkillCacheInvalidation:
         # openCronCreate() opens the task create form (renamed from toggleCronForm
         # in the main-view refactor). It must null the skills cache before fetching.
         m = re.search(
-            r'function openCronCreate\(\)\{.*?_cronSkillsCache\s*=\s*null',
-            src, re.DOTALL
+            r"function openCronCreate\(\)\{.*?_cronSkillsCache\s*=\s*null",
+            src,
+            re.DOTALL,
         )
         assert m, (
             "openCronCreate must unconditionally null _cronSkillsCache "
@@ -97,10 +98,7 @@ class TestCronSkillCacheInvalidation:
     def test_cache_not_guarded_by_if_on_open(self):
         src = self._panels_src()
         # openCronCreate must not gate the fetch behind an if(!_cronSkillsCache) guard.
-        m = re.search(
-            r'function openCronCreate\(\)\{.*?\}',
-            src, re.DOTALL
-        )
+        m = re.search(r"function openCronCreate\(\)\{.*?\}", src, re.DOTALL)
         assert m, "openCronCreate definition not found"
         assert "if(!_cronSkillsCache)" not in m.group(0), (
             "openCronCreate should not use 'if(!_cronSkillsCache)' guard — "
@@ -112,8 +110,9 @@ class TestCronSkillCacheInvalidation:
         # saveSkillForm() is the handler invoked on skill save (renamed from
         # submitSkillSave in the main-view refactor; the old name still aliases it).
         m = re.search(
-            r'async function saveSkillForm\(\).*?_skillsData\s*=\s*null.*?_cronSkillsCache\s*=\s*null',
-            src, re.DOTALL
+            r"async function saveSkillForm\(\).*?_skillsData\s*=\s*null.*?_cronSkillsCache\s*=\s*null",
+            src,
+            re.DOTALL,
         )
         assert m, (
             "_cronSkillsCache must be set to null in saveSkillForm() "
@@ -123,8 +122,8 @@ class TestCronSkillCacheInvalidation:
 
 # ── Group D: System (auto) theme ──────────────────────────────────────────────
 
-class TestSystemTheme:
 
+class TestSystemTheme:
     def test_apply_theme_helper_in_boot_js(self):
         src = read("static/boot.js")
         assert "function _applyTheme(" in src, (
@@ -154,15 +153,11 @@ class TestSystemTheme:
         assert "_pickTheme('system')" in html, (
             "Theme picker must include a system theme button"
         )
-        assert ">System<" in html, (
-            "Theme picker must show 'System' label"
-        )
+        assert ">System<" in html, "Theme picker must show 'System' label"
 
     def test_theme_picker_uses_pick_theme(self):
         html = read("static/index.html")
-        assert "_pickTheme(" in html, (
-            "Theme buttons must call _pickTheme()"
-        )
+        assert "_pickTheme(" in html, "Theme buttons must call _pickTheme()"
 
     def test_flicker_script_resolves_system(self):
         html = read("static/index.html")
@@ -194,7 +189,9 @@ class TestSystemTheme:
 
     def test_panels_reverts_via_apply_theme(self):
         src = read("static/panels.js")
-        block = re.search(r"function _revertSettingsPreview\(\)\{.*?\n\}", src, re.DOTALL)
+        block = re.search(
+            r"function _revertSettingsPreview\(\)\{.*?\n\}", src, re.DOTALL
+        )
         assert block, "_revertSettingsPreview() should be present"
         assert "_applyTheme(" not in block.group(0), (
             "_revertSettingsPreview must no longer call _applyTheme() since Appearance now autosaves"

--- a/tests/test_blockquote_rendering.py
+++ b/tests/test_blockquote_rendering.py
@@ -10,10 +10,13 @@ Root cause: the old rule was `s.replace(/^> (.+)$/gm, ...)` which had three bugs
 Fix: group consecutive `>` lines into a single `<blockquote>`, handle bare `>` lines
 as `<br>`, and strip the `>` prefix before passing each line to `inlineMd()`.
 """
+
 import re
 import pathlib
 
-UI_JS = (pathlib.Path(__file__).parent.parent / "static" / "ui.js").read_text(encoding="utf-8")
+UI_JS = (pathlib.Path(__file__).parent.parent / "static" / "ui.js").read_text(
+    encoding="utf-8"
+)
 
 # ---------------------------------------------------------------------------
 # Python mirror of the new blockquote rule + inlineMd (for behavioural tests)
@@ -29,7 +32,11 @@ def _esc(s):
 def _inline_md(t):
     """Minimal inlineMd mirror — bold, italic, inline-code only."""
     t = re.sub(r"`([^`\n]+)`", lambda m: f"<code>{_esc(m.group(1))}</code>", t)
-    t = re.sub(r"\*\*\*(.+?)\*\*\*", lambda m: f"<strong><em>{_esc(m.group(1))}</em></strong>", t)
+    t = re.sub(
+        r"\*\*\*(.+?)\*\*\*",
+        lambda m: f"<strong><em>{_esc(m.group(1))}</em></strong>",
+        t,
+    )
     t = re.sub(r"\*\*(.+?)\*\*", lambda m: f"<strong>{_esc(m.group(1))}</strong>", t)
     t = re.sub(r"\*([^*\n]+)\*", lambda m: f"<em>{_esc(m.group(1))}</em>", t)
     return t
@@ -37,6 +44,7 @@ def _inline_md(t):
 
 def _apply_blockquote(s):
     """Python mirror of the new group-based blockquote rule in ui.js."""
+
     def replacer(m):
         block = m.group(0)
         lines = block.split("\n")
@@ -62,6 +70,7 @@ def _apply_blockquote(s):
 # ---------------------------------------------------------------------------
 # Source-level structural tests
 # ---------------------------------------------------------------------------
+
 
 class TestBlockquoteSourceStructure:
     """The new rule must be present in ui.js and the old single-line rule must be gone."""
@@ -107,6 +116,7 @@ class TestBlockquoteSourceStructure:
 # ---------------------------------------------------------------------------
 # Behavioural tests (using the Python mirror)
 # ---------------------------------------------------------------------------
+
 
 class TestMultiLineBlockquote:
     """Consecutive > lines must become ONE <blockquote>, not many."""
@@ -229,7 +239,7 @@ class TestBlockquoteFollowedByParagraph:
         assert out.count("<blockquote>") == 1
         assert "Normal paragraph" in out
         # Normal paragraph must be outside the blockquote
-        after_bq = out[out.index("</blockquote>"):]
+        after_bq = out[out.index("</blockquote>") :]
         assert "Normal paragraph" in after_bq
 
 

--- a/tests/test_bootstrap_discover_agent.py
+++ b/tests/test_bootstrap_discover_agent.py
@@ -48,7 +48,11 @@ def _make_hermes_cli(tmp_path, shebang_target: str | None):
 
 def _isolate_discover_agent_dir(monkeypatch, tmp_path, hermes_path):
     """Point `which("hermes")` at our fake CLI and clear all standard candidates."""
-    monkeypatch.setattr(bootstrap.shutil, "which", lambda name: str(hermes_path) if name == "hermes" else None)
+    monkeypatch.setattr(
+        bootstrap.shutil,
+        "which",
+        lambda name: str(hermes_path) if name == "hermes" else None,
+    )
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "no-such-hermes-home"))
     monkeypatch.delenv("HERMES_WEBUI_AGENT_DIR", raising=False)
     # Force REPO_ROOT.parent to a dir that won't accidentally contain a
@@ -60,7 +64,9 @@ def _isolate_discover_agent_dir(monkeypatch, tmp_path, hermes_path):
     # cannot pick up the dev machine's real install. Stage-313 absorbed
     # this in-stage after the original test file isolated only env vars
     # and REPO_ROOT, missing the Path.home() leakage.
-    monkeypatch.setattr(bootstrap.Path, "home", classmethod(lambda cls: tmp_path / "isolated-home"))
+    monkeypatch.setattr(
+        bootstrap.Path, "home", classmethod(lambda cls: tmp_path / "isolated-home")
+    )
 
 
 def test_discovers_agent_dir_from_hermes_shebang(monkeypatch, tmp_path):
@@ -90,7 +96,9 @@ def test_returns_none_when_hermes_has_no_shebang(monkeypatch, tmp_path):
     assert bootstrap.discover_agent_dir() is None
 
 
-def test_returns_none_when_shebang_interpreter_does_not_walk_to_run_agent(monkeypatch, tmp_path):
+def test_returns_none_when_shebang_interpreter_does_not_walk_to_run_agent(
+    monkeypatch, tmp_path
+):
     """Shebang points at a system Python — no parent of /usr/bin/python3 has run_agent.py."""
     hermes = _make_hermes_cli(tmp_path, "/usr/bin/python3")
     _isolate_discover_agent_dir(monkeypatch, tmp_path, hermes)

--- a/tests/test_bootstrap_dotenv.py
+++ b/tests/test_bootstrap_dotenv.py
@@ -17,18 +17,16 @@ Covers:
   9. Variables are set unconditionally (not setdefault)
   10. Structural: loader is called before DEFAULT_HOST/DEFAULT_PORT
 """
+
 import os
-import sys
 from pathlib import Path
 from unittest.mock import patch
 
-import pytest
 
 REPO_ROOT = Path(__file__).parent.parent
 
 
 class TestLoadRepoDotenv:
-
     def setup_method(self):
         self._saved_env = os.environ.copy()
 
@@ -39,6 +37,7 @@ class TestLoadRepoDotenv:
     def _run(self, tmp_path, env_content: str):
         """Write .env to tmp_path and run _load_repo_dotenv() with that root."""
         import bootstrap as bs
+
         (tmp_path / ".env").write_text(env_content, encoding="utf-8")
         orig_root = bs.REPO_ROOT
         try:
@@ -81,6 +80,7 @@ class TestLoadRepoDotenv:
     def test_noop_when_no_dotenv(self, tmp_path):
         """No .env file — function returns silently without error."""
         import bootstrap as bs
+
         orig = bs.REPO_ROOT
         try:
             bs.REPO_ROOT = tmp_path  # tmp_path has no .env
@@ -91,20 +91,24 @@ class TestLoadRepoDotenv:
     def test_noop_when_dotenv_unreadable(self, tmp_path, capsys):
         """Unreadable .env prints a warning to stderr — does not crash."""
         import bootstrap as bs
+
         env_path = tmp_path / ".env"
         env_path.write_text("HERMES_WEBUI_PORT=9999\n")
         orig = bs.REPO_ROOT
         try:
             bs.REPO_ROOT = tmp_path
-            with patch("pathlib.Path.read_text", side_effect=PermissionError("no access")):
+            with patch(
+                "pathlib.Path.read_text", side_effect=PermissionError("no access")
+            ):
                 bs._load_repo_dotenv()  # must not raise
         finally:
             bs.REPO_ROOT = orig
         captured = capsys.readouterr()
-        assert "bootstrap" in captured.err.lower() or "warning" in captured.err.lower() or \
-               "could not load" in captured.err.lower(), (
-            "_load_repo_dotenv() should print a warning to stderr on read failure"
-        )
+        assert (
+            "bootstrap" in captured.err.lower()
+            or "warning" in captured.err.lower()
+            or "could not load" in captured.err.lower()
+        ), "_load_repo_dotenv() should print a warning to stderr on read failure"
 
     def test_overwrites_existing_env_var(self, tmp_path):
         """Unconditional overwrite matches shell source semantics."""
@@ -119,7 +123,9 @@ class TestLoadRepoDotenv:
         # The current implementation sets key to "" (empty string) — verify it is
         # not set to a non-empty string, which would be clearly wrong.
         val = os.environ.get("HERMES_EMPTY_KEY")
-        assert val != "something-wrong", "Empty-value key must not be set to a non-empty string"
+        assert val != "something-wrong", (
+            "Empty-value key must not be set to a non-empty string"
+        )
         # Specifically: empty string or absent are both acceptable behaviours.
         assert val in (None, ""), f"Unexpected value for empty-quoted key: {val!r}"
 
@@ -147,11 +153,12 @@ class TestLoadRepoDotenv:
 # Structural tests — confirm the fix is in place
 # ---------------------------------------------------------------------------
 
-class TestBootstrapStructure:
 
+class TestBootstrapStructure:
     def test_load_repo_dotenv_function_exists(self):
         """bootstrap.py must export _load_repo_dotenv()."""
         import bootstrap as bs
+
         assert callable(getattr(bs, "_load_repo_dotenv", None)), (
             "bootstrap.py must define _load_repo_dotenv() so that "
             "python3 bootstrap.py loads REPO_ROOT/.env before reading env defaults"

--- a/tests/test_bootstrap_foreground.py
+++ b/tests/test_bootstrap_foreground.py
@@ -52,13 +52,13 @@ These tests do NOT actually exec — ``os.execv`` is monkeypatched. We're
 pinning the structural choice (which path runs, which cwd, which env) not the
 post-exec behavior (which is the OS kernel's job).
 """
+
 from __future__ import annotations
 
 import os
 import subprocess
 import sys
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 
@@ -103,6 +103,7 @@ def import_bootstrap():
     if "bootstrap" in sys.modules:
         del sys.modules["bootstrap"]
     import bootstrap as bs
+
     return bs
 
 
@@ -110,7 +111,6 @@ def import_bootstrap():
 
 
 class TestForegroundFlag:
-
     def test_foreground_is_recognized_flag(self, import_bootstrap, monkeypatch):
         monkeypatch.setattr(sys, "argv", ["bootstrap.py", "--foreground"])
         args = import_bootstrap.parse_args()
@@ -123,7 +123,9 @@ class TestForegroundFlag:
         args = import_bootstrap.parse_args()
         assert args.foreground is False
 
-    def test_foreground_help_mentions_supervisors(self, import_bootstrap, monkeypatch, capsys):
+    def test_foreground_help_mentions_supervisors(
+        self, import_bootstrap, monkeypatch, capsys
+    ):
         # argparse prints help and exits — capture and verify content.
         monkeypatch.setattr(sys, "argv", ["bootstrap.py", "--help"])
         with pytest.raises(SystemExit):
@@ -139,34 +141,44 @@ class TestForegroundFlag:
 
 
 class TestDetectSupervisor:
-
     def test_clean_env_returns_none(self, import_bootstrap, clean_env):
         assert import_bootstrap._detect_supervisor() is None
 
-    @pytest.mark.parametrize("var", [
-        "INVOCATION_ID",
-        "JOURNAL_STREAM",
-        "NOTIFY_SOCKET",
-        "XPC_SERVICE_NAME",
-        "SUPERVISOR_ENABLED",
-    ])
-    def test_each_supervisor_var_triggers(self, import_bootstrap, clean_env, monkeypatch, var):
+    @pytest.mark.parametrize(
+        "var",
+        [
+            "INVOCATION_ID",
+            "JOURNAL_STREAM",
+            "NOTIFY_SOCKET",
+            "XPC_SERVICE_NAME",
+            "SUPERVISOR_ENABLED",
+        ],
+    )
+    def test_each_supervisor_var_triggers(
+        self, import_bootstrap, clean_env, monkeypatch, var
+    ):
         monkeypatch.setenv(var, "anything-truthy")
         assert import_bootstrap._detect_supervisor() == var
 
     @pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes", "Yes", "on", "ON"])
-    def test_explicit_opt_in_truthy_values(self, import_bootstrap, clean_env, monkeypatch, value):
+    def test_explicit_opt_in_truthy_values(
+        self, import_bootstrap, clean_env, monkeypatch, value
+    ):
         monkeypatch.setenv("HERMES_WEBUI_FOREGROUND", value)
         assert import_bootstrap._detect_supervisor() == "HERMES_WEBUI_FOREGROUND"
 
     @pytest.mark.parametrize("value", ["0", "false", "FALSE", "no", "off", "", "  "])
-    def test_explicit_opt_in_falsy_values_fall_through(self, import_bootstrap, clean_env, monkeypatch, value):
+    def test_explicit_opt_in_falsy_values_fall_through(
+        self, import_bootstrap, clean_env, monkeypatch, value
+    ):
         # When HERMES_WEBUI_FOREGROUND is falsy, we should NOT short-circuit on it.
         # If no other supervisor var is set, returns None.
         monkeypatch.setenv("HERMES_WEBUI_FOREGROUND", value)
         assert import_bootstrap._detect_supervisor() is None
 
-    def test_explicit_opt_in_takes_precedence_over_supervisor_var(self, import_bootstrap, clean_env, monkeypatch):
+    def test_explicit_opt_in_takes_precedence_over_supervisor_var(
+        self, import_bootstrap, clean_env, monkeypatch
+    ):
         # Both set → explicit flag wins (returned name reflects user intent).
         monkeypatch.setenv("HERMES_WEBUI_FOREGROUND", "1")
         monkeypatch.setenv("INVOCATION_ID", "deadbeef")
@@ -182,32 +194,44 @@ class TestXPCServiceNameNoiseFilter:
     while rejecting the well-known noise values.
     """
 
-    @pytest.mark.parametrize("noise_value", [
-        "0",                                                 # launchd descendants
-        "application.com.apple.Terminal.0BCDDEAD-1234-5678", # Terminal.app shells
-        "application.com.googlecode.iterm2",                 # iTerm2
-        "application.com.microsoft.VSCode",                  # VSCode terminal
-    ])
-    def test_xpc_noise_values_do_not_trigger(self, import_bootstrap, clean_env, monkeypatch, noise_value):
+    @pytest.mark.parametrize(
+        "noise_value",
+        [
+            "0",  # launchd descendants
+            "application.com.apple.Terminal.0BCDDEAD-1234-5678",  # Terminal.app shells
+            "application.com.googlecode.iterm2",  # iTerm2
+            "application.com.microsoft.VSCode",  # VSCode terminal
+        ],
+    )
+    def test_xpc_noise_values_do_not_trigger(
+        self, import_bootstrap, clean_env, monkeypatch, noise_value
+    ):
         monkeypatch.setenv("XPC_SERVICE_NAME", noise_value)
         assert import_bootstrap._detect_supervisor() is None, (
             f"XPC_SERVICE_NAME={noise_value!r} should not trigger foreground "
             f"mode — that would break interactive ./start.sh on every Mac."
         )
 
-    @pytest.mark.parametrize("real_value", [
-        "com.example.hermes-webui",
-        "com.acme.production-server",
-        "io.github.user.my-service",
-    ])
-    def test_xpc_real_label_triggers(self, import_bootstrap, clean_env, monkeypatch, real_value):
+    @pytest.mark.parametrize(
+        "real_value",
+        [
+            "com.example.hermes-webui",
+            "com.acme.production-server",
+            "io.github.user.my-service",
+        ],
+    )
+    def test_xpc_real_label_triggers(
+        self, import_bootstrap, clean_env, monkeypatch, real_value
+    ):
         monkeypatch.setenv("XPC_SERVICE_NAME", real_value)
         assert import_bootstrap._detect_supervisor() == "XPC_SERVICE_NAME", (
             f"XPC_SERVICE_NAME={real_value!r} is a launchd Label and should "
             f"trigger foreground mode."
         )
 
-    def test_xpc_noise_does_not_block_other_supervisor_var(self, import_bootstrap, clean_env, monkeypatch):
+    def test_xpc_noise_does_not_block_other_supervisor_var(
+        self, import_bootstrap, clean_env, monkeypatch
+    ):
         # If XPC has a noise value but INVOCATION_ID is set (mixed env, e.g.
         # systemd unit run on a Mac CI runner), we should still detect via
         # INVOCATION_ID rather than swallow it.
@@ -231,10 +255,13 @@ class TestMainForegroundRouting:
     def stub_main_dependencies(self, monkeypatch, tmp_path):
         """Stub out everything main() calls except the routing decision."""
         import bootstrap as bs
+
         monkeypatch.setattr(bs, "ensure_supported_platform", lambda: None)
         monkeypatch.setattr(bs, "discover_agent_dir", lambda: tmp_path / "agent")
         monkeypatch.setattr(bs, "hermes_command_exists", lambda: True)
-        monkeypatch.setattr(bs, "discover_launcher_python", lambda *a: "/usr/bin/python3")
+        monkeypatch.setattr(
+            bs, "discover_launcher_python", lambda *a: "/usr/bin/python3"
+        )
         monkeypatch.setattr(bs, "ensure_python_has_webui_deps", lambda *a, **kw: a[0])
         monkeypatch.setattr(bs, "wait_for_health", lambda *a, **kw: True)
         monkeypatch.setattr(bs, "open_browser", lambda *a, **kw: None)
@@ -243,7 +270,9 @@ class TestMainForegroundRouting:
         (tmp_path / "agent").mkdir(parents=True, exist_ok=True)
         return bs
 
-    def test_default_path_uses_popen(self, stub_main_dependencies, clean_env, monkeypatch):
+    def test_default_path_uses_popen(
+        self, stub_main_dependencies, clean_env, monkeypatch
+    ):
         bs = stub_main_dependencies
         monkeypatch.setattr(sys, "argv", ["bootstrap.py", "--no-browser"])
 
@@ -253,33 +282,42 @@ class TestMainForegroundRouting:
 
         class FakePopen:
             pid = 12345
+
             def __init__(self, *args, **kwargs):
                 popen_calls.append((args, kwargs))
+
         monkeypatch.setattr(subprocess, "Popen", FakePopen)
 
         rc = bs.main()
         assert rc == 0
-        assert len(popen_calls) == 1, "Default path should call subprocess.Popen exactly once"
+        assert len(popen_calls) == 1, (
+            "Default path should call subprocess.Popen exactly once"
+        )
         assert len(execv_calls) == 0, "Default path must NOT call os.execv"
 
-    def test_foreground_flag_uses_execv(self, stub_main_dependencies, clean_env, monkeypatch):
+    def test_foreground_flag_uses_execv(
+        self, stub_main_dependencies, clean_env, monkeypatch
+    ):
         bs = stub_main_dependencies
         monkeypatch.setattr(sys, "argv", ["bootstrap.py", "--foreground"])
 
         execv_calls = []
         popen_calls = []
+
         # execv normally replaces the process; we capture+raise SystemExit so
         # main() returns control to us instead of falling through to the
         # legacy Popen branch.
         def fake_execv(path, argv):
             execv_calls.append((path, argv))
             raise SystemExit(0)
+
         monkeypatch.setattr(os, "execv", fake_execv)
         monkeypatch.setattr(os, "chdir", lambda p: None)
 
         def fake_popen(*args, **kwargs):
             popen_calls.append((args, kwargs))
             return None
+
         monkeypatch.setattr(subprocess, "Popen", fake_popen)
 
         with pytest.raises(SystemExit) as ei:
@@ -294,29 +332,37 @@ class TestMainForegroundRouting:
         assert argv[0] == "/usr/bin/python3"
         assert argv[1].endswith("server.py")
 
-    @pytest.mark.parametrize("var", [
-        "INVOCATION_ID",
-        "JOURNAL_STREAM",
-        "NOTIFY_SOCKET",
-        "XPC_SERVICE_NAME",
-        "SUPERVISOR_ENABLED",
-    ])
-    def test_supervisor_env_var_auto_promotes_to_execv(self, stub_main_dependencies, clean_env, monkeypatch, var):
+    @pytest.mark.parametrize(
+        "var",
+        [
+            "INVOCATION_ID",
+            "JOURNAL_STREAM",
+            "NOTIFY_SOCKET",
+            "XPC_SERVICE_NAME",
+            "SUPERVISOR_ENABLED",
+        ],
+    )
+    def test_supervisor_env_var_auto_promotes_to_execv(
+        self, stub_main_dependencies, clean_env, monkeypatch, var
+    ):
         bs = stub_main_dependencies
         monkeypatch.setattr(sys, "argv", ["bootstrap.py"])  # no --foreground
         monkeypatch.setenv(var, "deadbeef")
 
         execv_calls = []
         popen_calls = []
+
         def fake_execv(path, argv):
             execv_calls.append((path, argv))
             raise SystemExit(0)
+
         monkeypatch.setattr(os, "execv", fake_execv)
         monkeypatch.setattr(os, "chdir", lambda p: None)
 
         def fake_popen(*args, **kwargs):
             popen_calls.append((args, kwargs))
             return None
+
         monkeypatch.setattr(subprocess, "Popen", fake_popen)
 
         with pytest.raises(SystemExit):
@@ -324,15 +370,19 @@ class TestMainForegroundRouting:
         assert len(execv_calls) == 1, f"{var} must auto-promote to execv"
         assert len(popen_calls) == 0, f"{var} must NOT use Popen"
 
-    def test_explicit_opt_in_env_auto_promotes_to_execv(self, stub_main_dependencies, clean_env, monkeypatch):
+    def test_explicit_opt_in_env_auto_promotes_to_execv(
+        self, stub_main_dependencies, clean_env, monkeypatch
+    ):
         bs = stub_main_dependencies
         monkeypatch.setattr(sys, "argv", ["bootstrap.py"])  # no --foreground flag
         monkeypatch.setenv("HERMES_WEBUI_FOREGROUND", "1")
 
         execv_calls = []
+
         def fake_execv(path, argv):
             execv_calls.append((path, argv))
             raise SystemExit(0)
+
         monkeypatch.setattr(os, "execv", fake_execv)
         monkeypatch.setattr(os, "chdir", lambda p: None)
         monkeypatch.setattr(subprocess, "Popen", lambda *a, **kw: None)
@@ -348,12 +398,15 @@ class TestForegroundEnvAndCwd:
     @pytest.fixture
     def setup(self, monkeypatch, tmp_path):
         import bootstrap as bs
+
         monkeypatch.setattr(bs, "ensure_supported_platform", lambda: None)
         agent_dir = tmp_path / "agent"
         agent_dir.mkdir()
         monkeypatch.setattr(bs, "discover_agent_dir", lambda: agent_dir)
         monkeypatch.setattr(bs, "hermes_command_exists", lambda: True)
-        monkeypatch.setattr(bs, "discover_launcher_python", lambda *a: "/usr/bin/python3")
+        monkeypatch.setattr(
+            bs, "discover_launcher_python", lambda *a: "/usr/bin/python3"
+        )
         monkeypatch.setattr(bs, "ensure_python_has_webui_deps", lambda *a, **kw: a[0])
         monkeypatch.setattr(bs, "wait_for_health", lambda *a, **kw: True)
         monkeypatch.setattr(bs, "open_browser", lambda *a, **kw: None)
@@ -361,15 +414,20 @@ class TestForegroundEnvAndCwd:
         monkeypatch.setenv("HERMES_WEBUI_STATE_DIR", str(tmp_path / "state"))
         return bs, agent_dir
 
-    def test_foreground_chdirs_to_agent_dir_before_exec(self, setup, monkeypatch, clean_env):
+    def test_foreground_chdirs_to_agent_dir_before_exec(
+        self, setup, monkeypatch, clean_env
+    ):
         bs, agent_dir = setup
-        monkeypatch.setattr(sys, "argv", ["bootstrap.py", "--foreground", "--host", "127.0.0.1", "9999"])
+        monkeypatch.setattr(
+            sys, "argv", ["bootstrap.py", "--foreground", "--host", "127.0.0.1", "9999"]
+        )
 
         chdir_calls = []
         monkeypatch.setattr(os, "chdir", lambda p: chdir_calls.append(p))
 
         def fake_execv(*a):
             raise SystemExit(0)
+
         monkeypatch.setattr(os, "execv", fake_execv)
 
         with pytest.raises(SystemExit):
@@ -379,13 +437,14 @@ class TestForegroundEnvAndCwd:
 
     def test_foreground_exports_resolved_env_vars(self, setup, monkeypatch, clean_env):
         bs, agent_dir = setup
-        monkeypatch.setattr(sys, "argv", [
-            "bootstrap.py", "--foreground", "--host", "0.0.0.0", "9119"
-        ])
+        monkeypatch.setattr(
+            sys, "argv", ["bootstrap.py", "--foreground", "--host", "0.0.0.0", "9119"]
+        )
         monkeypatch.setattr(os, "chdir", lambda p: None)
 
         def fake_execv(*a):
             raise SystemExit(0)
+
         monkeypatch.setattr(os, "execv", fake_execv)
 
         with pytest.raises(SystemExit):
@@ -399,16 +458,21 @@ class TestForegroundEnvAndCwd:
         # state-dir was already set by the fixture; verify it survived.
         assert "HERMES_WEBUI_STATE_DIR" in os.environ
 
-    def test_foreground_does_not_call_wait_for_health(self, setup, monkeypatch, clean_env):
+    def test_foreground_does_not_call_wait_for_health(
+        self, setup, monkeypatch, clean_env
+    ):
         bs, _ = setup
         monkeypatch.setattr(sys, "argv", ["bootstrap.py", "--foreground"])
         monkeypatch.setattr(os, "chdir", lambda p: None)
 
         wait_calls = []
-        monkeypatch.setattr(bs, "wait_for_health", lambda *a, **kw: (wait_calls.append(a), True)[1])
+        monkeypatch.setattr(
+            bs, "wait_for_health", lambda *a, **kw: (wait_calls.append(a), True)[1]
+        )
 
         def fake_execv(*a):
             raise SystemExit(0)
+
         monkeypatch.setattr(os, "execv", fake_execv)
 
         with pytest.raises(SystemExit):
@@ -427,6 +491,7 @@ class TestForegroundExecutabilityGuard:
     @pytest.fixture
     def setup_with_bad_python(self, monkeypatch, tmp_path):
         import bootstrap as bs
+
         agent_dir = tmp_path / "agent"
         agent_dir.mkdir()
         # Create a non-executable file at the python path
@@ -441,7 +506,9 @@ class TestForegroundExecutabilityGuard:
         monkeypatch.setenv("HERMES_WEBUI_STATE_DIR", str(tmp_path / "state"))
         return bs
 
-    def test_non_executable_python_raises_runtime_error(self, setup_with_bad_python, monkeypatch, clean_env):
+    def test_non_executable_python_raises_runtime_error(
+        self, setup_with_bad_python, monkeypatch, clean_env
+    ):
         bs = setup_with_bad_python
         monkeypatch.setattr(sys, "argv", ["bootstrap.py", "--foreground"])
 

--- a/tests/test_bootstrap_python_selection.py
+++ b/tests/test_bootstrap_python_selection.py
@@ -4,7 +4,9 @@ from unittest.mock import patch
 import bootstrap
 
 
-def test_ensure_python_prefers_agent_venv_when_launcher_cannot_import_agent(monkeypatch, tmp_path):
+def test_ensure_python_prefers_agent_venv_when_launcher_cannot_import_agent(
+    monkeypatch, tmp_path
+):
     """Avoid starting WebUI with a local venv that later cannot import AIAgent."""
     local_python = tmp_path / "webui" / ".venv" / "bin" / "python"
     agent_python = tmp_path / "agent" / "venv" / "bin" / "python"
@@ -19,13 +21,17 @@ def test_ensure_python_prefers_agent_venv_when_launcher_cannot_import_agent(monk
 
     monkeypatch.setattr(bootstrap, "_python_can_run_webui_and_agent", fake_can_run)
 
-    selected = bootstrap.ensure_python_has_webui_deps(str(local_python), tmp_path / "agent")
+    selected = bootstrap.ensure_python_has_webui_deps(
+        str(local_python), tmp_path / "agent"
+    )
 
     assert selected == str(agent_python)
     assert probes == [local_python, agent_python]
 
 
-def test_ensure_python_fails_loudly_when_no_interpreter_can_import_agent(monkeypatch, tmp_path):
+def test_ensure_python_fails_loudly_when_no_interpreter_can_import_agent(
+    monkeypatch, tmp_path
+):
     """Do not report health OK when chat would fail with missing AIAgent."""
     local_python = tmp_path / "webui" / ".venv" / "bin" / "python"
     agent_python = tmp_path / "agent" / "venv" / "bin" / "python"
@@ -50,7 +56,9 @@ def test_ensure_python_fails_loudly_when_no_interpreter_can_import_agent(monkeyp
     if (tmp_path / ".venv").exists():  # platform-independent guard
         pass
 
-    monkeypatch.setattr(bootstrap, "_python_can_run_webui_and_agent", lambda *a, **k: False)
+    monkeypatch.setattr(
+        bootstrap, "_python_can_run_webui_and_agent", lambda *a, **k: False
+    )
     # Cover both subprocess.run (used for pip install) and any other subprocess
     # entry points the venv module might invoke. Returning None is fine because
     # we never inspect the result on this code path.
@@ -75,7 +83,9 @@ def test_local_venv_is_created_with_symlinks(monkeypatch, tmp_path):
     """
     local_python = tmp_path / "webui" / ".venv" / "bin" / "python"
     monkeypatch.setattr(bootstrap, "REPO_ROOT", tmp_path)
-    monkeypatch.setattr(bootstrap, "_python_can_run_webui_and_agent", lambda *a, **k: False)
+    monkeypatch.setattr(
+        bootstrap, "_python_can_run_webui_and_agent", lambda *a, **k: False
+    )
     monkeypatch.setattr(bootstrap.subprocess, "run", lambda *a, **k: None)
 
     with patch.object(bootstrap.venv, "EnvBuilder") as mock_builder:

--- a/tests/test_bugbatch_apr2026.py
+++ b/tests/test_bugbatch_apr2026.py
@@ -8,20 +8,22 @@ Covers:
 - #567: docker-compose.yml comment mentions macOS UID mismatch
 - #590: _transcribeBlob already calls setComposerStatus('Transcribing…') — confirmed present
 """
+
 import pathlib
 import re
 
 REPO_ROOT = pathlib.Path(__file__).parent.parent
 STYLE_CSS = (REPO_ROOT / "static" / "style.css").read_text(encoding="utf-8")
-BOOT_JS   = (REPO_ROOT / "static" / "boot.js").read_text(encoding="utf-8")
-COMPOSE   = (REPO_ROOT / "docker-compose.yml").read_text(encoding="utf-8")
+BOOT_JS = (REPO_ROOT / "static" / "boot.js").read_text(encoding="utf-8")
+COMPOSE = (REPO_ROOT / "docker-compose.yml").read_text(encoding="utf-8")
 
 
 # ── #594: light theme dialog overrides ───────────────────────────────────────
 
+
 def test_594_app_dialog_has_light_mode_override():
     """style.css must have a light mode rule targeting .app-dialog background."""
-    assert ':root:not(.dark) .app-dialog{' in STYLE_CSS, (
+    assert ":root:not(.dark) .app-dialog{" in STYLE_CSS, (
         "Missing light mode override for .app-dialog — dialogs appear dark on light theme"
     )
 
@@ -56,6 +58,7 @@ def test_594_file_rename_input_has_light_mode_override():
 
 # ── dark-mode user bubble semantics ──────────────────────────────────────────
 
+
 def test_dark_user_bubbles_use_dark_tinted_surface():
     """Dark mode should keep user bubbles dark, with skin only tinting the bubble."""
     assert "--user-bubble-bg: var(--accent-bg-strong);" in STYLE_CSS, (
@@ -71,7 +74,12 @@ def test_dark_user_bubbles_use_dark_tinted_surface():
 
 def test_dark_user_bubbles_do_not_need_per_skin_text_hacks():
     """Dark-mode user bubble contrast should not rely on per-skin text overrides."""
-    assert re.search(r':root\.dark\[data-skin="[^"]+"\]\s*\{\s*--user-bubble-text:', STYLE_CSS) is None, (
+    assert (
+        re.search(
+            r':root\.dark\[data-skin="[^"]+"\]\s*\{\s*--user-bubble-text:', STYLE_CSS
+        )
+        is None
+    ), (
         "Dark-mode user bubble contrast should come from shared theme tokens, not per-skin text hacks"
     )
 
@@ -101,6 +109,7 @@ def test_user_bubble_selection_is_scoped_to_user_message_body():
 
 # ── #576: workspace panel snap fix ───────────────────────────────────────────
 
+
 def test_576_panel_restore_gated_on_workspace():
     """boot.js: localStorage panel restore must be gated on session.workspace."""
     # The guard must appear: session.workspace check before _workspacePanelMode='browse'
@@ -116,7 +125,7 @@ def test_576_panel_restore_gated_on_workspace():
 
 def test_576_restore_happens_after_load_session():
     """boot.js: loadSession() must come before the panel restore guard."""
-    load_pos    = BOOT_JS.find("await loadSession(saved)")
+    load_pos = BOOT_JS.find("await loadSession(saved)")
     restore_pos = BOOT_JS.find("panelPref")
     assert load_pos != -1, "loadSession call not found in boot.js"
     assert restore_pos != -1, "workspace panel restore guard not found"
@@ -128,6 +137,7 @@ def test_576_restore_happens_after_load_session():
 
 # ── #585: get_available_models reloads config ─────────────────────────────────
 
+
 def test_585_get_available_models_calls_reload_config():
     """api/config.py: get_available_models() must do a mtime-based reload check."""
     config_src = (REPO_ROOT / "api" / "config.py").read_text(encoding="utf-8")
@@ -135,7 +145,7 @@ def test_585_get_available_models_calls_reload_config():
     assert fn_start != -1, "get_available_models not found"
     fn_body_end = config_src.find('"""', config_src.find('"""', fn_start + 30) + 3) + 3
     # Must check mtime before reading config
-    mtime_pos    = config_src.find("_current_mtime", fn_body_end)
+    mtime_pos = config_src.find("_current_mtime", fn_body_end)
     active_prov_pos = config_src.find("active_provider = None", fn_body_end)
     assert mtime_pos != -1, (
         "get_available_models() must check config file mtime before reading cache (#585)"
@@ -146,6 +156,7 @@ def test_585_get_available_models_calls_reload_config():
 
 
 # ── #567: docker-compose UID note ─────────────────────────────────────────────
+
 
 def test_567_compose_mentions_macos_uid():
     """docker-compose.yml must mention macOS UID / id -u to help macOS users."""
@@ -159,13 +170,14 @@ def test_567_compose_mentions_macos_uid():
 
 # ── #590: transcription spinner already present ───────────────────────────────
 
+
 def test_590_transcribing_status_shown_before_fetch():
     """boot.js: setComposerStatus('Transcribing…') must fire before the fetch call."""
     transcribe_fn_start = BOOT_JS.find("async function _transcribeBlob(")
     assert transcribe_fn_start != -1, "_transcribeBlob not found in boot.js"
-    fn_body = BOOT_JS[transcribe_fn_start:transcribe_fn_start + 600]
+    fn_body = BOOT_JS[transcribe_fn_start : transcribe_fn_start + 600]
     status_pos = fn_body.find("setComposerStatus('Transcribing")
-    fetch_pos  = fn_body.find("await fetch(")
+    fetch_pos = fn_body.find("await fetch(")
     assert status_pos != -1, (
         "setComposerStatus('Transcribing…') must be called before the fetch in _transcribeBlob"
     )
@@ -180,7 +192,7 @@ def test_590_recording_stops_before_transcribe():
     """boot.js: _setRecording(false) must fire in onstop before _transcribeBlob."""
     onstop_start = BOOT_JS.find("mediaRecorder.onstop")
     assert onstop_start != -1, "mediaRecorder.onstop not found"
-    onstop_body = BOOT_JS[onstop_start:onstop_start + 400]
+    onstop_body = BOOT_JS[onstop_start : onstop_start + 400]
     rec_pos = onstop_body.find("_setRecording(false)")
     blob_pos = onstop_body.find("_transcribeBlob(")
     assert rec_pos != -1 and blob_pos != -1

--- a/tests/test_byok_model_dropdown.py
+++ b/tests/test_byok_model_dropdown.py
@@ -12,6 +12,7 @@ Root causes fixed:
      custom_providers entries exist in config.yaml — the live enrichment
      step never added those models.
 """
+
 import pathlib
 import re
 import sys
@@ -40,6 +41,7 @@ def _isolate_models_cache():
     mocks.  Clearing the cache around each test breaks that linkage.
     """
     import api.config as c
+
     try:
         c.invalidate_models_cache()
     except Exception:
@@ -52,6 +54,7 @@ def _isolate_models_cache():
 
 
 # ── api/config.py — active_provider normalization ─────────────────────────────
+
 
 class TestActiveProviderNormalization:
     """get_available_models() must normalize active_provider aliases before lookup."""
@@ -72,6 +75,7 @@ class TestActiveProviderNormalization:
         fake_prov.return_value = []
         try:
             import hermes_cli.models as hm
+
             monkeypatch.setattr(hm, "list_available_providers", fake_prov)
         except Exception:
             pass
@@ -112,6 +116,7 @@ class TestActiveProviderNormalization:
 
 
 # ── api/routes.py — /api/models/live provider normalization ───────────────────
+
 
 class TestLiveModelsProviderNormalization:
     """_handle_live_models must normalize the provider query param."""
@@ -155,23 +160,25 @@ class TestLiveModelsProviderNormalization:
         The WebUI ships its own _PROVIDER_ALIASES table; the agent's table
         is merged only when available."""
         import api.config as c
+
         # Core CLI aliases from #815's bug report
-        assert c._resolve_provider_alias('z.ai') == 'zai'
-        assert c._resolve_provider_alias('x.ai') == 'xai'
-        assert c._resolve_provider_alias('google') == 'gemini'
-        assert c._resolve_provider_alias('grok') == 'xai'
+        assert c._resolve_provider_alias("z.ai") == "zai"
+        assert c._resolve_provider_alias("x.ai") == "xai"
+        assert c._resolve_provider_alias("google") == "gemini"
+        assert c._resolve_provider_alias("grok") == "xai"
         # Case / whitespace insensitive
-        assert c._resolve_provider_alias('  Z.AI  ') == 'zai'
+        assert c._resolve_provider_alias("  Z.AI  ") == "zai"
         # Canonical names pass through unchanged
-        assert c._resolve_provider_alias('openrouter') == 'openrouter'
-        assert c._resolve_provider_alias('anthropic') == 'anthropic'
-        assert c._resolve_provider_alias('custom') == 'custom'
+        assert c._resolve_provider_alias("openrouter") == "openrouter"
+        assert c._resolve_provider_alias("anthropic") == "anthropic"
+        assert c._resolve_provider_alias("custom") == "custom"
         # Empty / None pass through
-        assert c._resolve_provider_alias('') == ''
+        assert c._resolve_provider_alias("") == ""
         assert c._resolve_provider_alias(None) is None
 
 
 # ── api/routes.py — /api/models/live custom_providers fallback ────────────────
+
 
 class TestLiveModelsCustomProviderFallback:
     """When provider='custom' and provider_model_ids() returns [],
@@ -214,18 +221,20 @@ class TestLiveModelsCustomProviderFallback:
         # Mock handler and parsed URL
         handler = mock.MagicMock()
         responses = []
+
         def fake_j(h, data, **kw):
             responses.append(data)
             return True
+
         monkeypatch.setattr(r, "j", fake_j)
 
-        from urllib.parse import urlparse
         parsed = mock.MagicMock()
         parsed.query = "provider=custom"
 
         # Mock provider_model_ids to return [] (simulating no live endpoint)
         try:
             import hermes_cli.models as hm
+
             monkeypatch.setattr(hm, "provider_model_ids", lambda p: [])
         except Exception:
             pass
@@ -244,6 +253,7 @@ class TestLiveModelsCustomProviderFallback:
 
 # ── Regression: known-good providers still work ───────────────────────────────
 
+
 class TestKnownProvidersUnaffected:
     """Normalization must not break providers whose names are already canonical."""
 
@@ -260,6 +270,7 @@ class TestKnownProvidersUnaffected:
         """'custom' is not in _PROVIDER_ALIASES so normalization is a no-op."""
         try:
             from hermes_cli.models import _PROVIDER_ALIASES
+
             assert "custom" not in _PROVIDER_ALIASES, (
                 "'custom' must not be aliased to anything — it's a special sentinel"
             )
@@ -268,6 +279,7 @@ class TestKnownProvidersUnaffected:
 
 
 # ── Source-level: active_provider returned to browser is canonical ─────────────
+
 
 class TestProviderIdInGroupResponse:
     """get_available_models() must include provider_id on every group so the JS
@@ -285,10 +297,14 @@ class TestProviderIdInGroupResponse:
         c.reload_config()
         try:
             import hermes_cli.models as hm
-            monkeypatch.setattr(hm, "list_available_providers", lambda: [
-                {"id": "zai", "authenticated": True}
-            ])
+
+            monkeypatch.setattr(
+                hm,
+                "list_available_providers",
+                lambda: [{"id": "zai", "authenticated": True}],
+            )
             import hermes_cli.auth as ha
+
             monkeypatch.setattr(ha, "get_auth_status", lambda p: {"key_source": "env"})
         except Exception:
             pass
@@ -310,24 +326,25 @@ class TestProviderIdInGroupResponse:
     def test_fetch_live_models_prefers_data_provider_match(self):
         src = read("static/ui.js")
         # Live model optgroup matching was extracted to _addLiveModelsToSelect (#872)
-        m = re.search(r'function _addLiveModelsToSelect\b.*?\n\}', src, re.DOTALL)
+        m = re.search(r"function _addLiveModelsToSelect\b.*?\n\}", src, re.DOTALL)
         if not m:
-            m = re.search(r'function _fetchLiveModels\b.*?\n\}', src, re.DOTALL)
+            m = re.search(r"function _fetchLiveModels\b.*?\n\}", src, re.DOTALL)
         assert m, "_addLiveModelsToSelect or _fetchLiveModels not found"
         fn = m.group(0)
-        assert 'og.dataset.provider' in fn, (
+        assert "og.dataset.provider" in fn, (
             "_addLiveModelsToSelect must check og.dataset.provider===provider before "
             "falling back to label substring match"
         )
         # The data-provider check must come before the label.includes check
-        dp_pos = fn.index('og.dataset.provider')
-        label_pos = fn.index('og.label')
+        dp_pos = fn.index("og.dataset.provider")
+        label_pos = fn.index("og.label")
         assert dp_pos < label_pos, (
             "data-provider exact match must be attempted before label substring match"
         )
 
 
 # ── Opus-identified edge case: 'ollama' normalizes to 'custom' ────────────────
+
 
 class TestOllamaAliasEdgeCase:
     """Opus review found: 'ollama' -> 'custom' via _PROVIDER_ALIASES.
@@ -339,6 +356,7 @@ class TestOllamaAliasEdgeCase:
         intended behavior post-normalization (not a silent breakage)."""
         try:
             from hermes_cli.models import _PROVIDER_ALIASES
+
             # 'ollama' -> 'custom' means ollama users hit the custom_providers path
             # This is fine — ollama models appear via base_url auto-detection (step 3)
             # in get_available_models, not via _PROVIDER_MODELS lookup.
@@ -367,6 +385,7 @@ class TestGetAvailableModelsReturnsCanonicalProvider:
         c.reload_config()
         try:
             import hermes_cli.models as hm
+
             monkeypatch.setattr(hm, "list_available_providers", lambda: [])
         except Exception:
             pass

--- a/tests/test_byte_range_parser.py
+++ b/tests/test_byte_range_parser.py
@@ -6,6 +6,7 @@ if not handled correctly per RFC 7233. The PR adds higher-level tests
 for media inline streaming, but the range parser itself has no direct
 unit tests. This file pins the parser's contract.
 """
+
 import pytest
 
 from api.routes import _parse_range_header

--- a/tests/test_cancel_interrupt.py
+++ b/tests/test_cancel_interrupt.py
@@ -2,7 +2,7 @@
 Unit tests for cancel/interrupt functionality.
 Tests the integration between cancel_stream() and agent.interrupt().
 """
-import pytest
+
 import queue
 import threading
 from unittest.mock import Mock
@@ -45,8 +45,9 @@ class TestCancelInterrupt:
         mock_agent.interrupt.assert_called_once_with("Cancelled by user")
         # CANCEL_FLAGS is eagerly popped after cancel (#776 fix) so the flag
         # is no longer in the dict — verify the pop happened instead
-        assert stream_id not in CANCEL_FLAGS, \
+        assert stream_id not in CANCEL_FLAGS, (
             "cancel_stream() should eagerly pop CANCEL_FLAGS after signalling"
+        )
 
     def test_cancel_handles_interrupt_exception(self):
         """Verify that cancel_stream() handles interrupt() exceptions gracefully"""
@@ -64,8 +65,9 @@ class TestCancelInterrupt:
         # Assert
         assert result is True
         mock_agent.interrupt.assert_called_once()
-        assert stream_id not in CANCEL_FLAGS, \
+        assert stream_id not in CANCEL_FLAGS, (
             "cancel_stream() should eagerly pop CANCEL_FLAGS even on interrupt exception"
+        )
 
     def test_cancel_before_agent_ready(self):
         """Test cancel when agent not yet stored in AGENT_INSTANCES (race condition)"""
@@ -82,8 +84,9 @@ class TestCancelInterrupt:
         assert result is True
         # CANCEL_FLAGS is eagerly popped; the agent thread checks the event
         # object it already has a reference to — pop doesn't clear the event
-        assert stream_id not in CANCEL_FLAGS, \
+        assert stream_id not in CANCEL_FLAGS, (
             "cancel_stream() should eagerly pop CANCEL_FLAGS even without an agent"
+        )
         # Agent will check this flag (it holds a reference to the event object)
 
     def test_cancel_nonexistent_stream(self):
@@ -118,5 +121,5 @@ class TestCancelInterrupt:
         # Check that cancel message was queued
         assert not q.empty()
         event_type, data = q.get_nowait()
-        assert event_type == 'cancel'
-        assert data['message'] == 'Cancelled by user'
+        assert event_type == "cancel"
+        assert data["message"] == "Cancelled by user"

--- a/tests/test_chinese_locale.py
+++ b/tests/test_chinese_locale.py
@@ -134,4 +134,6 @@ def test_traditional_chinese_mcp_and_tree_labels_are_not_cyrillic():
     for entry in expected:
         assert entry in block
 
-    assert not re.search(r"[\u0400-\u04FF]", block), "zh-Hant locale contains Cyrillic text"
+    assert not re.search(r"[\u0400-\u04FF]", block), (
+        "zh-Hant locale contains Cyrillic text"
+    )

--- a/tests/test_clarify_sse.py
+++ b/tests/test_clarify_sse.py
@@ -9,7 +9,6 @@ Covers:
 import os
 import queue
 import threading
-import textwrap
 
 import pytest
 
@@ -27,12 +26,15 @@ def _read(path):
 # ══════════════════════════════════════════════════════════════════════════════
 # 1. Static analysis — verify code structure without importing the server
 # ══════════════════════════════════════════════════════════════════════════════
-@pytest.mark.parametrize("marker", [
-    "_clarify_sse_subscribers",
-    "def sse_subscribe",
-    "def sse_unsubscribe",
-    "_clarify_sse_notify",
-])
+@pytest.mark.parametrize(
+    "marker",
+    [
+        "_clarify_sse_subscribers",
+        "def sse_subscribe",
+        "def sse_unsubscribe",
+        "_clarify_sse_notify",
+    ],
+)
 class TestClarifySSEBackendMarkers:
     def test_clarify_module_has_marker(self, marker):
         src = _read(_CLARIFY)
@@ -89,7 +91,9 @@ class TestClarifySSEFrontendCode:
         assert "'clarify'" in self.js or '"clarify"' in self.js
 
     def test_frontend_has_fallback_poll(self):
-        assert "_startClarifyFallbackPoll" in self.js or "clarifyFallbackTimer" in self.js
+        assert (
+            "_startClarifyFallbackPoll" in self.js or "clarifyFallbackTimer" in self.js
+        )
 
     def test_frontend_fallback_interval_3s(self):
         # Fallback poll interval should be 3000ms
@@ -110,6 +114,7 @@ class TestClarifySSEFrontendCode:
 def clarify_mod():
     """Import api.clarify fresh (module-level state is shared)."""
     from api import clarify
+
     return clarify
 
 

--- a/tests/test_clarify_unblock.py
+++ b/tests/test_clarify_unblock.py
@@ -22,6 +22,7 @@ try:
         _ClarifyEntry,
         submit_pending,
     )
+
     CLARIFY_AVAILABLE = True
 except ImportError:
     CLARIFY_AVAILABLE = False
@@ -41,7 +42,9 @@ def get(path):
 def post(path, body=None):
     url = BASE + path
     data = json.dumps(body or {}).encode()
-    req = urllib.request.Request(url, data=data, headers={"Content-Type": "application/json"})
+    req = urllib.request.Request(
+        url, data=data, headers={"Content-Type": "application/json"}
+    )
     try:
         with urllib.request.urlopen(req, timeout=10) as r:
             return json.loads(r.read()), r.status
@@ -92,7 +95,11 @@ class TestClarifyUnblocking:
 
     def test_submit_pending_registers_entry(self):
         sid = f"unit-submit-{uuid.uuid4().hex[:8]}"
-        data = {"question": "Pick", "choices_offered": ["one", "two"], "session_id": sid}
+        data = {
+            "question": "Pick",
+            "choices_offered": ["one", "two"],
+            "session_id": sid,
+        }
         entry = submit_pending(sid, data)
         assert entry.data["question"] == data["question"]
         assert entry.data["choices_offered"] == data["choices_offered"]
@@ -119,18 +126,22 @@ class TestClarifyUnblocking:
 class TestClarifyModuleExports:
     def test_register_gateway_notify_exported(self):
         import api.clarify as ap
+
         assert hasattr(ap, "register_gateway_notify")
 
     def test_unregister_gateway_notify_exported(self):
         import api.clarify as ap
+
         assert hasattr(ap, "unregister_gateway_notify")
 
     def test_resolve_clarify_exported(self):
         import api.clarify as ap
+
         assert hasattr(ap, "resolve_clarify")
 
     def test_clarify_entry_exported(self):
         import api.clarify as ap
+
         assert hasattr(ap, "_ClarifyEntry")
 
 
@@ -139,10 +150,13 @@ class TestClarifyHTTPEndpoints:
 
     def test_respond_returns_ok_no_pending(self):
         sid = f"http-no-pending-{uuid.uuid4().hex[:8]}"
-        result, status = post("/api/clarify/respond", {
-            "session_id": sid,
-            "response": "Use option A",
-        })
+        result, status = post(
+            "/api/clarify/respond",
+            {
+                "session_id": sid,
+                "response": "Use option A",
+            },
+        )
         assert status == 200
         assert result["ok"] is True
 
@@ -168,10 +182,13 @@ class TestClarifyHTTPEndpoints:
         data = get(f"/api/clarify/pending?session_id={urllib.parse.quote(sid)}")
         assert data["pending"] is not None
 
-        result, status = post("/api/clarify/respond", {
-            "session_id": sid,
-            "response": "B",
-        })
+        result, status = post(
+            "/api/clarify/respond",
+            {
+                "session_id": sid,
+                "response": "B",
+            },
+        )
         assert status == 200
         assert result["ok"] is True
 

--- a/tests/test_claude_code_session_import.py
+++ b/tests/test_claude_code_session_import.py
@@ -15,8 +15,25 @@ def _write_jsonl(path: Path, rows: list[dict]) -> None:
 def _claude_fixture_rows() -> list[dict]:
     return [
         {"summary": "Claude Code import QA"},
-        {"timestamp": "2026-04-18T12:00:01Z", "message": {"role": "user", "content": [{"type": "text", "text": "Can Hermes show this Claude Code history read-only?"}]}},
-        {"timestamp": "2026-04-18T12:00:02Z", "message": {"role": "assistant", "content": "Yes — it appears with a Claude Code source badge."}},
+        {
+            "timestamp": "2026-04-18T12:00:01Z",
+            "message": {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "Can Hermes show this Claude Code history read-only?",
+                    }
+                ],
+            },
+        },
+        {
+            "timestamp": "2026-04-18T12:00:02Z",
+            "message": {
+                "role": "assistant",
+                "content": "Yes — it appears with a Claude Code source badge.",
+            },
+        },
         "not a dict",
         {"not_json_message": True},
     ]
@@ -55,10 +72,20 @@ def test_get_claude_code_sessions_reads_fixture_jsonl_without_real_home(tmp_path
     assert session["is_cli_session"] is True
     assert session["read_only"] is True
 
-    messages = models.get_claude_code_session_messages(session["session_id"], projects_dir=projects_dir)
+    messages = models.get_claude_code_session_messages(
+        session["session_id"], projects_dir=projects_dir
+    )
     assert messages == [
-        {"role": "user", "content": "Can Hermes show this Claude Code history read-only?", "timestamp": 1776513601.0},
-        {"role": "assistant", "content": "Yes — it appears with a Claude Code source badge.", "timestamp": 1776513602.0},
+        {
+            "role": "user",
+            "content": "Can Hermes show this Claude Code history read-only?",
+            "timestamp": 1776513601.0,
+        },
+        {
+            "role": "assistant",
+            "content": "Yes — it appears with a Claude Code source badge.",
+            "timestamp": 1776513602.0,
+        },
     ]
 
 
@@ -73,20 +100,27 @@ def test_claude_code_scan_skips_symlinks_and_oversized_files(tmp_path):
 
     outside = tmp_path / "outside"
     outside.mkdir()
-    _write_jsonl(outside / "leaked.jsonl", [{"message": {"role": "user", "content": "do not import"}}])
+    _write_jsonl(
+        outside / "leaked.jsonl",
+        [{"message": {"role": "user", "content": "do not import"}}],
+    )
     symlink_project = projects_dir / "symlink-project"
     symlink_project.symlink_to(outside, target_is_directory=True)
 
     root_link = tmp_path / "root-link"
     root_link.symlink_to(projects_dir, target_is_directory=True)
 
-    sessions = models.get_claude_code_sessions(projects_dir=projects_dir, max_file_bytes=512)
+    sessions = models.get_claude_code_sessions(
+        projects_dir=projects_dir, max_file_bytes=512
+    )
 
     assert [session["title"] for session in sessions] == ["valid import"]
     assert models.get_claude_code_sessions(projects_dir=root_link) == []
 
 
-def test_session_import_cli_returns_read_only_claude_code_payload(monkeypatch, tmp_path):
+def test_session_import_cli_returns_read_only_claude_code_payload(
+    monkeypatch, tmp_path
+):
     import api.routes as routes
 
     sid = "claude_code_fixture"
@@ -107,12 +141,26 @@ def test_session_import_cli_returns_read_only_claude_code_payload(monkeypatch, t
 
     monkeypatch.setattr(routes.Session, "load", classmethod(lambda _cls, _sid: None))
     monkeypatch.setattr(routes, "require", lambda body, *keys: None)
-    monkeypatch.setattr(routes, "bad", lambda _handler, msg, status=400: {"ok": False, "error": msg, "status": status})
-    monkeypatch.setattr(routes, "j", lambda _handler, payload, status=200, extra_headers=None: payload)
-    monkeypatch.setattr(routes, "get_cli_session_messages", lambda _sid: messages if _sid == sid else [])
+    monkeypatch.setattr(
+        routes,
+        "bad",
+        lambda _handler, msg, status=400: {"ok": False, "error": msg, "status": status},
+    )
+    monkeypatch.setattr(
+        routes, "j", lambda _handler, payload, status=200, extra_headers=None: payload
+    )
+    monkeypatch.setattr(
+        routes, "get_cli_session_messages", lambda _sid: messages if _sid == sid else []
+    )
     monkeypatch.setattr(routes, "get_cli_sessions", lambda: [meta])
     monkeypatch.setattr(routes, "get_last_workspace", lambda: tmp_path / "workspace")
-    monkeypatch.setattr(routes, "import_cli_session", lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("read-only import must not persist")))
+    monkeypatch.setattr(
+        routes,
+        "import_cli_session",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("read-only import must not persist")
+        ),
+    )
 
     response = routes._handle_session_import_cli(object(), {"session_id": sid})
 

--- a/tests/test_cli_only_slash_commands.py
+++ b/tests/test_cli_only_slash_commands.py
@@ -114,7 +114,9 @@ def _run_commands_js(script_body: str) -> dict:
         }});
         """
     )
-    proc = subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True)
+    proc = subprocess.run(
+        ["node", "-e", script], check=True, capture_output=True, text=True
+    )
     return json.loads(proc.stdout)
 
 
@@ -159,7 +161,9 @@ def test_cli_only_response_helper_uses_canonical_command_name():
 def test_send_intercepts_cli_only_commands_before_agent_round_trip():
     intercept_idx = MESSAGES_JS.find("Slash command intercept")
     assert intercept_idx != -1
-    normal_send_idx = MESSAGES_JS.find("const activeSid=S.session.session_id", intercept_idx)
+    normal_send_idx = MESSAGES_JS.find(
+        "const activeSid=S.session.session_id", intercept_idx
+    )
     assert normal_send_idx != -1
     intercept = MESSAGES_JS[intercept_idx:normal_send_idx]
 
@@ -172,23 +176,29 @@ def test_send_intercepts_cli_only_commands_before_agent_round_trip():
 def test_unknown_slash_commands_still_fall_through_to_agent():
     """Only known cli_only commands should be intercepted."""
     intercept_idx = MESSAGES_JS.find("Slash command intercept")
-    normal_send_idx = MESSAGES_JS.find("const activeSid=S.session.session_id", intercept_idx)
+    normal_send_idx = MESSAGES_JS.find(
+        "const activeSid=S.session.session_id", intercept_idx
+    )
     intercept = MESSAGES_JS[intercept_idx:normal_send_idx]
 
     assert "if(_agentCmd&&_agentCmd.cli_only)" in intercept
     assert "if(_parsedCmd&&!_cmd)" in intercept
     assert "if(!_agentCmd" not in intercept
-    assert "else" not in intercept[intercept.find("if(_agentCmd&&_agentCmd.cli_only)") :]
+    assert (
+        "else" not in intercept[intercept.find("if(_agentCmd&&_agentCmd.cli_only)") :]
+    )
 
 
 def test_builtin_command_opt_outs_do_not_hit_agent_metadata_lookup():
     """Built-in fall-through commands like /reasoning high keep their old path."""
     intercept_idx = MESSAGES_JS.find("Slash command intercept")
-    normal_send_idx = MESSAGES_JS.find("const activeSid=S.session.session_id", intercept_idx)
+    normal_send_idx = MESSAGES_JS.find(
+        "const activeSid=S.session.session_id", intercept_idx
+    )
     intercept = MESSAGES_JS[intercept_idx:normal_send_idx]
     optout_idx = intercept.find("if(_cmd.fn(_parsedCmd.args)===false)")
     metadata_idx = intercept.find("await getAgentCommandMetadata(_parsedCmd.name)")
 
     assert optout_idx != -1
     assert metadata_idx != -1
-    assert "if(_parsedCmd&&!_cmd)" in intercept[optout_idx:metadata_idx + 120]
+    assert "if(_parsedCmd&&!_cmd)" in intercept[optout_idx : metadata_idx + 120]

--- a/tests/test_cli_session_tool_metadata.py
+++ b/tests/test_cli_session_tool_metadata.py
@@ -108,7 +108,9 @@ def test_existing_cli_import_refreshes_same_length_tool_metadata(monkeypatch):
             "role": "assistant",
             "content": "",
             "timestamp": 1.0,
-            "tool_calls": [{"id": "call_123", "function": {"name": "terminal", "arguments": "{}"}}],
+            "tool_calls": [
+                {"id": "call_123", "function": {"name": "terminal", "arguments": "{}"}}
+            ],
         },
         {
             "role": "tool",
@@ -138,11 +140,33 @@ def test_existing_cli_import_refreshes_same_length_tool_metadata(monkeypatch):
 
     save_calls = []
     existing = FakeSession()
-    monkeypatch.setattr(routes.Session, "load", classmethod(lambda _cls, sid: existing if sid == session_id else None))
+    monkeypatch.setattr(
+        routes.Session,
+        "load",
+        classmethod(lambda _cls, sid: existing if sid == session_id else None),
+    )
     monkeypatch.setattr(routes, "require", lambda body, *keys: None)
-    monkeypatch.setattr(routes, "j", lambda _handler, payload, status=200, extra_headers=None: payload)
-    monkeypatch.setattr(routes, "get_cli_session_messages", lambda sid: enriched if sid == session_id else [])
-    monkeypatch.setattr(routes, "get_cli_sessions", lambda: [{"session_id": session_id, "source_tag": "cli", "raw_source": "cli", "session_source": "cli", "source_label": "CLI"}])
+    monkeypatch.setattr(
+        routes, "j", lambda _handler, payload, status=200, extra_headers=None: payload
+    )
+    monkeypatch.setattr(
+        routes,
+        "get_cli_session_messages",
+        lambda sid: enriched if sid == session_id else [],
+    )
+    monkeypatch.setattr(
+        routes,
+        "get_cli_sessions",
+        lambda: [
+            {
+                "session_id": session_id,
+                "source_tag": "cli",
+                "raw_source": "cli",
+                "session_source": "cli",
+                "source_label": "CLI",
+            }
+        ],
+    )
 
     response = routes._handle_session_import_cli(object(), {"session_id": session_id})
 

--- a/tests/test_cmd_dropdown_scroll_838.py
+++ b/tests/test_cmd_dropdown_scroll_838.py
@@ -1,5 +1,6 @@
 """Tests for #838 — slash command dropdown keyboard navigation keeps the
 selected item in view."""
+
 import os
 import re
 
@@ -18,10 +19,10 @@ class TestNavigateCmdDropdownScroll:
 
     def test_navigate_calls_scroll_into_view(self):
         js = _read("static/commands.js")
-        m = re.search(r'function navigateCmdDropdown\(.*?\n\}', js, re.DOTALL)
+        m = re.search(r"function navigateCmdDropdown\(.*?\n\}", js, re.DOTALL)
         assert m, "navigateCmdDropdown not found"
         fn = m.group(0)
-        assert 'scrollIntoView' in fn, (
+        assert "scrollIntoView" in fn, (
             "navigateCmdDropdown must call scrollIntoView on the newly "
             "selected item so ↓/↑ keeps the highlight visible (#838)"
         )
@@ -31,7 +32,7 @@ class TestNavigateCmdDropdownScroll:
         needed, minimum distance — won't jump the list around on every
         arrow-key press when the item is already in view."""
         js = _read("static/commands.js")
-        m = re.search(r'function navigateCmdDropdown\(.*?\n\}', js, re.DOTALL)
+        m = re.search(r"function navigateCmdDropdown\(.*?\n\}", js, re.DOTALL)
         assert m
         fn = m.group(0)
         assert "block:'nearest'" in fn or 'block: "nearest"' in fn, (
@@ -43,7 +44,7 @@ class TestNavigateCmdDropdownScroll:
         """The scroll call must come AFTER adding the .selected class so
         the correct item is targeted."""
         js = _read("static/commands.js")
-        m = re.search(r'function navigateCmdDropdown\(.*?\n\}', js, re.DOTALL)
+        m = re.search(r"function navigateCmdDropdown\(.*?\n\}", js, re.DOTALL)
         assert m
         fn = m.group(0)
         selected_pos = fn.find("classList.add('selected')")
@@ -59,11 +60,15 @@ class TestNavigateCmdDropdownScroll:
         (or similar) so scrollIntoView finds it as the scroll ancestor
         rather than bubbling up to the viewport."""
         css = _read("static/style.css")
-        m = re.search(r'\.cmd-dropdown\s*\{[^}]+\}', css)
+        m = re.search(r"\.cmd-dropdown\s*\{[^}]+\}", css)
         assert m, ".cmd-dropdown rule not found"
         block = m.group(0)
-        assert 'overflow-y:auto' in block or 'overflow-y: auto' in block or \
-               'overflow:auto' in block or 'overflow: auto' in block, (
+        assert (
+            "overflow-y:auto" in block
+            or "overflow-y: auto" in block
+            or "overflow:auto" in block
+            or "overflow: auto" in block
+        ), (
             ".cmd-dropdown must have overflow-y:auto so scrollIntoView "
             "scrolls within the dropdown, not the whole page"
         )

--- a/tests/test_cmd_idle_fallback.py
+++ b/tests/test_cmd_idle_fallback.py
@@ -8,15 +8,18 @@ fall through to a direct send() call, matching CLI behaviour:
   - /interrupt msg → send when idle, cancel+requeue when busy+streaming
   - /steer msg  → send when idle, inject mid-turn when busy+streaming
 """
-import re
+
 import pathlib
 
-COMMANDS_JS = (pathlib.Path(__file__).parent.parent / "static" / "commands.js").read_text(encoding="utf-8")
+COMMANDS_JS = (
+    pathlib.Path(__file__).parent.parent / "static" / "commands.js"
+).read_text(encoding="utf-8")
 
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Source-level structural checks
 # ─────────────────────────────────────────────────────────────────────────────
+
 
 class TestIdleFallbackStructure:
     """Each handler must contain an idle-path that calls send() instead of
@@ -25,7 +28,7 @@ class TestIdleFallbackStructure:
     def _get_function_body(self, fn_name: str, window: int = 800) -> str:
         idx = COMMANDS_JS.find(f"async function {fn_name}(")
         assert idx >= 0, f"{fn_name} not found in commands.js"
-        return COMMANDS_JS[idx: idx + window]
+        return COMMANDS_JS[idx : idx + window]
 
     # /queue ──────────────────────────────────────────────────────────────────
 
@@ -51,7 +54,7 @@ class TestIdleFallbackStructure:
         # be the only thing that happens when !S.busy.
         idle_branch_start = body.find("if(!S.busy)")
         assert idle_branch_start >= 0, "cmdQueue must have an if(!S.busy) branch"
-        idle_branch = body[idle_branch_start: idle_branch_start + 300]
+        idle_branch = body[idle_branch_start : idle_branch_start + 300]
         assert "send()" in idle_branch, (
             "cmdQueue's idle branch must call send(), not just show a toast"
         )
@@ -75,7 +78,7 @@ class TestIdleFallbackStructure:
         has_idle = "!S.busy||!S.activeStreamId" in body or "!S.busy" in body
         assert has_idle, "cmdInterrupt must have an idle guard"
         idle_start = body.find("!S.busy")
-        assert "send()" in body[idle_start: idle_start + 350], (
+        assert "send()" in body[idle_start : idle_start + 350], (
             "cmdInterrupt idle branch must call send()"
         )
 
@@ -113,7 +116,7 @@ class TestIdleFallbackStructure:
         body = self._get_function_body("cmdQueue")
         idle_idx = body.find("if(!S.busy)")
         assert idle_idx >= 0
-        idle_block = body[idle_idx: idle_idx + 250]
+        idle_block = body[idle_idx : idle_idx + 250]
         # send() must appear in the idle block
         assert "send()" in idle_block, (
             "cmdQueue idle block must contain send(), not just a toast+return"
@@ -126,7 +129,7 @@ class TestIdleFallbackStructure:
         body = self._get_function_body("cmdSteer")
         idle_idx = body.find("!S.busy")
         assert idle_idx >= 0
-        idle_block = body[idle_idx: idle_idx + 250]
+        idle_block = body[idle_idx : idle_idx + 250]
         assert "no_active_task" not in idle_block, (
             "cmdSteer idle path must not show 'no_active_task' — steer doesn't "
             "stop tasks, and when idle it should send normally"
@@ -139,7 +142,7 @@ class TestBusyPathsStillWork:
     def _get_function_body(self, fn_name: str, window: int = 800) -> str:
         idx = COMMANDS_JS.find(f"async function {fn_name}(")
         assert idx >= 0
-        return COMMANDS_JS[idx: idx + window]
+        return COMMANDS_JS[idx : idx + window]
 
     def test_queue_still_queues_when_busy(self):
         """When S.busy, cmdQueue must still call queueSessionMessage."""
@@ -161,7 +164,7 @@ class TestBusyPathsStillWork:
     def test_stop_command_unchanged(self):
         """cmdStop still uses no_active_task toast — that's correct for /stop."""
         idx = COMMANDS_JS.find("async function cmdStop(")
-        body = COMMANDS_JS[idx: idx + 400]
+        body = COMMANDS_JS[idx : idx + 400]
         assert "no_active_task" in body, (
             "/stop should still show 'no active task' when idle — stopping nothing is an error"
         )

--- a/tests/test_commands_endpoint.py
+++ b/tests/test_commands_endpoint.py
@@ -1,8 +1,8 @@
 """Tests for GET /api/commands -- exposes hermes-agent COMMAND_REGISTRY."""
+
 import json
 import urllib.request
 
-import pytest
 
 from tests.conftest import TEST_BASE, requires_agent_modules
 
@@ -16,58 +16,65 @@ def _get(path):
 @requires_agent_modules
 def test_commands_endpoint_returns_list():
     """GET /api/commands returns a JSON object with a 'commands' list."""
-    body = _get('/api/commands')
-    assert 'commands' in body
-    assert isinstance(body['commands'], list)
-    assert len(body['commands']) > 0
+    body = _get("/api/commands")
+    assert "commands" in body
+    assert isinstance(body["commands"], list)
+    assert len(body["commands"]) > 0
 
 
 @requires_agent_modules
 def test_commands_endpoint_includes_help():
     """The 'help' command must always be present (it's not cli_only)."""
-    body = _get('/api/commands')
-    names = {c['name'] for c in body['commands']}
-    assert 'help' in names
+    body = _get("/api/commands")
+    names = {c["name"] for c in body["commands"]}
+    assert "help" in names
 
 
 @requires_agent_modules
 def test_commands_endpoint_command_shape():
     """Each command entry has the required fields."""
-    body = _get('/api/commands')
-    cmd = next(c for c in body['commands'] if c['name'] == 'help')
+    body = _get("/api/commands")
+    cmd = next(c for c in body["commands"] if c["name"] == "help")
     required = {
-        'name', 'description', 'category', 'aliases',
-        'args_hint', 'subcommands', 'cli_only', 'gateway_only',
+        "name",
+        "description",
+        "category",
+        "aliases",
+        "args_hint",
+        "subcommands",
+        "cli_only",
+        "gateway_only",
     }
     assert set(cmd.keys()) >= required
-    assert isinstance(cmd['aliases'], list)
-    assert isinstance(cmd['subcommands'], list)
-    assert isinstance(cmd['cli_only'], bool)
-    assert isinstance(cmd['gateway_only'], bool)
+    assert isinstance(cmd["aliases"], list)
+    assert isinstance(cmd["subcommands"], list)
+    assert isinstance(cmd["cli_only"], bool)
+    assert isinstance(cmd["gateway_only"], bool)
 
 
 @requires_agent_modules
 def test_commands_endpoint_excludes_gateway_only_and_never_expose():
     """gateway_only commands and the _NEVER_EXPOSE set are filtered out."""
-    body = _get('/api/commands')
-    names = {c['name'] for c in body['commands']}
+    body = _get("/api/commands")
+    names = {c["name"] for c in body["commands"]}
     # /sethome, /restart, /update are gateway_only; /commands is in _NEVER_EXPOSE
-    for name in ('sethome', 'restart', 'update', 'commands'):
+    for name in ("sethome", "restart", "update", "commands"):
         assert name not in names, f"{name} must be excluded from /api/commands"
 
 
 @requires_agent_modules
 def test_commands_endpoint_keeps_new_with_reset_alias():
     """The 'new' command stays exposed and carries its 'reset' alias."""
-    body = _get('/api/commands')
-    new_cmd = next(c for c in body['commands'] if c['name'] == 'new')
-    assert 'reset' in new_cmd['aliases']
+    body = _get("/api/commands")
+    new_cmd = next(c for c in body["commands"] if c["name"] == "new")
+    assert "reset" in new_cmd["aliases"]
 
 
 def test_list_commands_returns_empty_for_empty_registry():
     """list_commands(_registry=[]) returns [] -- the same path as when
     hermes_cli is missing (the empty-or-missing case)."""
     from api.commands import list_commands
+
     assert list_commands(_registry=[]) == []
 
 
@@ -76,9 +83,11 @@ def test_list_commands_degrades_when_agent_missing(monkeypatch):
     via the ImportError path. Verified by stubbing sys.modules; test cleanup
     is handled by monkeypatch + the fact that we don't reload api.commands."""
     import sys
-    monkeypatch.setitem(sys.modules, 'hermes_cli.commands', None)
+
+    monkeypatch.setitem(sys.modules, "hermes_cli.commands", None)
     # NOTE: we do NOT reload api.commands. The lazy import inside
     # list_commands() will re-attempt the import on each call and hit
     # the stubbed-None module, raising ImportError, taking the fallback path.
     from api.commands import list_commands
+
     assert list_commands() == []

--- a/tests/test_composer_chip_lightbox.py
+++ b/tests/test_composer_chip_lightbox.py
@@ -14,6 +14,7 @@ delegated click handler must:
 
 It also pins the CSS cursor affordance so users discover the feature.
 """
+
 from pathlib import Path
 
 
@@ -58,9 +59,9 @@ class TestComposerChipLightboxDelegate:
         """
         src = UI.read_text(encoding="utf-8")
         # Audio chip block — uses <audio>, no .attach-thumb img
-        assert "<audio controls preload=\"metadata\"" in src
+        assert '<audio controls preload="metadata"' in src
         # Video chip block — uses <video>, no .attach-thumb img
-        assert "<video controls preload=\"metadata\"" in src
+        assert '<video controls preload="metadata"' in src
         # The .attach-thumb img tag is only generated in the image / svg branches.
         # Quick structural check: every chip-rendering line that emits
         # `class="attach-thumb"` has either `<img class="attach-thumb"` or

--- a/tests/test_credential_pool_providers.py
+++ b/tests/test_credential_pool_providers.py
@@ -10,7 +10,9 @@ import api.profiles as profiles
 _AMBIENT_SOURCES = {"gh_cli", "gh auth token"}
 
 
-def _install_fake_hermes_cli(monkeypatch, *, with_load_pool: bool = False, pool_data: dict | None = None):
+def _install_fake_hermes_cli(
+    monkeypatch, *, with_load_pool: bool = False, pool_data: dict | None = None
+):
     """Stub hermes_cli modules so tests are deterministic and offline.
 
     When *with_load_pool* is True, also stubs hermes_cli.credential_pool with a
@@ -44,6 +46,7 @@ def _install_fake_hermes_cli(monkeypatch, *, with_load_pool: bool = False, pool_
 
         class _FakeEntry:
             """Minimal PooledCredential stand-in with attribute access (matching the real class)."""
+
             def __init__(self, d):
                 self.source = d.get("source", "manual")
                 self.label = d.get("label", "")
@@ -69,7 +72,9 @@ def _install_fake_hermes_cli(monkeypatch, *, with_load_pool: bool = False, pool_
         monkeypatch.setitem(sys.modules, "agent.credential_pool", fake_cp)
 
 
-def _call_get_available_models(monkeypatch, tmp_path, auth_payload, *, with_load_pool: bool = False):
+def _call_get_available_models(
+    monkeypatch, tmp_path, auth_payload, *, with_load_pool: bool = False
+):
     """Call get_available_models() with auth.json pinned to a temp Hermes home."""
     _install_fake_hermes_cli(
         monkeypatch,
@@ -126,7 +131,9 @@ def test_ollama_cloud_manual_credential_shows_group(monkeypatch, tmp_path):
     groups = _group_by_provider(result)
     assert "Ollama Cloud" in groups, f"Expected Ollama Cloud in {list(groups)}"
     model_ids = [m["id"] for m in groups["Ollama Cloud"]]
-    assert model_ids == ["@ollama-cloud:gpt-oss:20b", "@ollama-cloud:qwen3:30b-a3b"], model_ids
+    assert model_ids == ["@ollama-cloud:gpt-oss:20b", "@ollama-cloud:qwen3:30b-a3b"], (
+        model_ids
+    )
 
 
 def test_copilot_gh_cli_only_credential_hidden(monkeypatch, tmp_path):
@@ -252,7 +259,9 @@ def test_load_pool_copilot_ambient_only_remains_hidden(monkeypatch, tmp_path):
         },
     }
 
-    result = _call_get_available_models(monkeypatch, tmp_path, auth_payload, with_load_pool=True)
+    result = _call_get_available_models(
+        monkeypatch, tmp_path, auth_payload, with_load_pool=True
+    )
     groups = _group_by_provider(result)
     assert "GitHub Copilot" not in groups, (
         "GitHub Copilot must be hidden when load_pool returns no usable entries; "
@@ -260,7 +269,9 @@ def test_load_pool_copilot_ambient_only_remains_hidden(monkeypatch, tmp_path):
     )
 
 
-def test_load_pool_copilot_ambient_key_source_only_remains_hidden(monkeypatch, tmp_path):
+def test_load_pool_copilot_ambient_key_source_only_remains_hidden(
+    monkeypatch, tmp_path
+):
     """load_pool path: key_source-only ambient markers must also be suppressed."""
     auth_payload = {
         "version": 1,
@@ -280,7 +291,9 @@ def test_load_pool_copilot_ambient_key_source_only_remains_hidden(monkeypatch, t
         },
     }
 
-    result = _call_get_available_models(monkeypatch, tmp_path, auth_payload, with_load_pool=True)
+    result = _call_get_available_models(
+        monkeypatch, tmp_path, auth_payload, with_load_pool=True
+    )
     groups = _group_by_provider(result)
     assert "GitHub Copilot" not in groups, (
         "GitHub Copilot must stay hidden when load_pool entries only differ by key_source ambient markers; "
@@ -307,10 +320,14 @@ def test_load_pool_alias_provider_key_is_resolved(monkeypatch, tmp_path):
         },
     }
 
-    result = _call_get_available_models(monkeypatch, tmp_path, auth_payload, with_load_pool=True)
+    result = _call_get_available_models(
+        monkeypatch, tmp_path, auth_payload, with_load_pool=True
+    )
     groups = _group_by_provider(result)
     assert "Gemini" in groups, f"Expected Gemini in {list(groups)}"
-    assert "Google" not in groups, f"Aliased provider key should not render under raw alias name: {list(groups)}"
+    assert "Google" not in groups, (
+        f"Aliased provider key should not render under raw alias name: {list(groups)}"
+    )
 
 
 def test_load_pool_explicit_credential_shows_provider(monkeypatch, tmp_path):
@@ -339,7 +356,9 @@ def test_load_pool_explicit_credential_shows_provider(monkeypatch, tmp_path):
         },
     }
 
-    result = _call_get_available_models(monkeypatch, tmp_path, auth_payload, with_load_pool=True)
+    result = _call_get_available_models(
+        monkeypatch, tmp_path, auth_payload, with_load_pool=True
+    )
     groups = _group_by_provider(result)
     assert "GitHub Copilot" in groups, (
         f"GitHub Copilot must appear when load_pool has at least one usable entry; got {list(groups)}"
@@ -353,7 +372,10 @@ def test_apply_provider_prefix_ollama_cloud_non_active():
     """Bare ollama-cloud model ids get @ollama-cloud: prefix when not active."""
     from api.config import _apply_provider_prefix
 
-    raw = [{"id": "gpt-oss:20b", "label": "gpt-oss:20b"}, {"id": "qwen3:30b-a3b", "label": "qwen3:30b-a3b"}]
+    raw = [
+        {"id": "gpt-oss:20b", "label": "gpt-oss:20b"},
+        {"id": "qwen3:30b-a3b", "label": "qwen3:30b-a3b"},
+    ]
     result = _apply_provider_prefix(raw, "ollama-cloud", "openai-codex")
     ids = [m["id"] for m in result]
     assert ids == ["@ollama-cloud:gpt-oss:20b", "@ollama-cloud:qwen3:30b-a3b"], ids
@@ -363,7 +385,10 @@ def test_apply_provider_prefix_copilot_non_active():
     """Bare copilot model ids get @copilot: prefix when not active."""
     from api.config import _apply_provider_prefix
 
-    raw = [{"id": "gpt-5.4", "label": "GPT-5.4"}, {"id": "claude-opus-4.6", "label": "Claude Opus 4.6"}]
+    raw = [
+        {"id": "gpt-5.4", "label": "GPT-5.4"},
+        {"id": "claude-opus-4.6", "label": "Claude Opus 4.6"},
+    ]
     result = _apply_provider_prefix(raw, "copilot", "openai-codex")
     ids = [m["id"] for m in result]
     assert ids == ["@copilot:gpt-5.4", "@copilot:claude-opus-4.6"], ids
@@ -458,6 +483,7 @@ def test_ollama_cloud_empty_catalog_skips_group(monkeypatch, tmp_path):
 
     # Override the stub to return empty for ollama-cloud.
     import sys as _sys
+
     _sys.modules["hermes_cli.models"].provider_model_ids = lambda pid: []
 
     auth_payload = {

--- a/tests/test_cron_manual_run_persistence.py
+++ b/tests/test_cron_manual_run_persistence.py
@@ -1,7 +1,6 @@
 """Regression tests for manual WebUI cron runs."""
 
 
-
 def test_manual_cron_run_saves_output_and_marks_job(monkeypatch):
     import api.routes as routes
 

--- a/tests/test_cron_needs_attention.py
+++ b/tests/test_cron_needs_attention.py
@@ -35,7 +35,9 @@ def _run_node(script: str) -> str:
 
 
 def test_legacy_broken_recurring_cron_is_needs_attention_not_off():
-    script = _cron_helper_source() + r"""
+    script = (
+        _cron_helper_source()
+        + r"""
 function t(key){ return key; }
 const legacyBroken = {
   id: 'legacy-broken',
@@ -70,6 +72,7 @@ console.log(JSON.stringify({
   scheduleError: _cronStatusMeta(scheduleError),
 }));
 """
+    )
     states = json.loads(_run_node(script))
 
     assert states["legacyBroken"]["state"] == "needs_attention"

--- a/tests/test_cron_no_agent_edit.py
+++ b/tests/test_cron_no_agent_edit.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import re
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -57,7 +56,10 @@ def test_no_agent_form_drops_prompt_required_attribute_and_shows_script_context(
 
 def test_save_cron_form_keeps_agent_prompt_required_but_skips_no_agent_edits():
     body = _function_body("saveCronForm")
-    assert "const isNoAgent = !!(_cronPreFormDetail && _cronPreFormDetail.no_agent);" in body
+    assert (
+        "const isNoAgent = !!(_cronPreFormDetail && _cronPreFormDetail.no_agent);"
+        in body
+    )
     assert "if(!isNoAgent && !prompt)" in body
     assert "cron_prompt_required" in body
     assert "if (!isNoAgent) updates.prompt = prompt;" in body

--- a/tests/test_cron_refresh_button_835.py
+++ b/tests/test_cron_refresh_button_835.py
@@ -1,4 +1,5 @@
 """Tests for #835 — refresh button in Tasks / Scheduled Jobs panel."""
+
 import os
 import re
 
@@ -28,10 +29,10 @@ class TestCronRefreshButtonHtml:
         m = re.search(r'<button[^>]*id="cronRefreshBtn"[^>]*>', html)
         assert m, "cronRefreshBtn tag not found"
         tag = m.group(0)
-        assert 'aria-label=' in tag, (
+        assert "aria-label=" in tag, (
             "#cronRefreshBtn is icon-only and must have aria-label"
         )
-        assert 'title=' in tag or 'data-tooltip=' in tag, (
+        assert "title=" in tag or "data-tooltip=" in tag, (
             "#cronRefreshBtn should have a hover tooltip "
             "(native title= or custom data-tooltip= per #1775)"
         )
@@ -41,7 +42,7 @@ class TestCronRefreshButtonHtml:
         m = re.search(r'<button[^>]*id="cronRefreshBtn"[^>]*>', html)
         assert m
         tag = m.group(0)
-        assert 'loadCrons(true)' in tag, (
+        assert "loadCrons(true)" in tag, (
             "#cronRefreshBtn must call loadCrons(true) to enable the dim-while-fetching animation"
         )
 
@@ -50,7 +51,7 @@ class TestCronRefreshButtonHtml:
         button so the header layout stays tight."""
         html = _read("static/index.html")
         ref_pos = html.find('id="cronRefreshBtn"')
-        newjob_pos = html.find('openCronCreate()')
+        newjob_pos = html.find("openCronCreate()")
         assert ref_pos != -1 and newjob_pos != -1
         # Must be close enough to be in the same header row (single SVG-inline
         # button can be around 500 chars by itself due to inline styles/attrs).
@@ -65,7 +66,7 @@ class TestLoadCronsAnimateFlag:
 
     def test_load_crons_accepts_animate_param(self):
         js = _read("static/panels.js")
-        assert re.search(r'async function loadCrons\s*\(\s*animate\s*\)', js), (
+        assert re.search(r"async function loadCrons\s*\(\s*animate\s*\)", js), (
             "loadCrons must accept an `animate` parameter"
         )
 
@@ -73,10 +74,10 @@ class TestLoadCronsAnimateFlag:
         """The opacity/disabled restore MUST be in a finally block so a
         throwing fetch doesn't leave the button stuck at 0.5 / disabled."""
         js = _read("static/panels.js")
-        m = re.search(r'async function loadCrons\(.*?\n\}', js, re.DOTALL)
+        m = re.search(r"async function loadCrons\(.*?\n\}", js, re.DOTALL)
         assert m, "loadCrons body not found"
         fn = m.group(0)
-        assert 'finally' in fn, (
+        assert "finally" in fn, (
             "loadCrons must restore the refresh button's opacity/disabled state "
             "in a finally block so errors during fetch don't leave the button stuck"
         )
@@ -95,9 +96,7 @@ class TestCronCreatedEventListener:
         assert re.search(
             r"addEventListener\(\s*['\"]hermes:cron_created['\"]",
             js,
-        ), (
-            "panels.js must register a window-level 'hermes:cron_created' event listener"
-        )
+        ), "panels.js must register a window-level 'hermes:cron_created' event listener"
 
     def test_listener_triggers_load_crons(self):
         js = _read("static/panels.js")
@@ -108,6 +107,6 @@ class TestCronCreatedEventListener:
         )
         assert m, "hermes:cron_created listener body not found"
         body = m.group(0)
-        assert 'loadCrons' in body, (
+        assert "loadCrons" in body, (
             "hermes:cron_created listener must call loadCrons() to refresh the list"
         )

--- a/tests/test_cron_run_job_import.py
+++ b/tests/test_cron_run_job_import.py
@@ -5,8 +5,8 @@ names it references must be resolvable from that thread's scope.
 Before the fix, run_job was only imported inside _handle_cron_run
 (a local scope invisible to _run_cron_tracked), causing NameError.
 """
+
 import ast
-import inspect
 from pathlib import Path
 
 import pytest
@@ -18,7 +18,10 @@ def _get_function_source(func_name: str) -> str:
     """Extract a top-level function's source via AST for stability."""
     tree = ast.parse(ROUTES_PY.read_text(encoding="utf-8"))
     for node in ast.iter_child_nodes(tree):
-        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == func_name:
+        if (
+            isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and node.name == func_name
+        ):
             lines = ROUTES_PY.read_text(encoding="utf-8").splitlines()
             return "\n".join(lines[node.lineno - 1 : node.end_lineno])
     pytest.fail(f"Function {func_name} not found in {ROUTES_PY}")
@@ -59,10 +62,14 @@ class TestRunCronTrackedImport:
         for node in ast.walk(tree):
             if isinstance(node, ast.ImportFrom):
                 for alias in node.names:
-                    func_imports.add(alias.name if alias.asname is None else alias.asname)
+                    func_imports.add(
+                        alias.name if alias.asname is None else alias.asname
+                    )
             elif isinstance(node, ast.Import):
                 for alias in node.names:
-                    func_imports.add(alias.name if alias.asname is None else alias.asname)
+                    func_imports.add(
+                        alias.name if alias.asname is None else alias.asname
+                    )
 
         # run_job is referenced → must be imported inside the function
         if "run_job" in names_used:
@@ -80,7 +87,9 @@ class TestRunCronTrackedImport:
         for node in ast.walk(tree):
             if isinstance(node, ast.ImportFrom):
                 for alias in node.names:
-                    imported_names.add(alias.name if alias.asname is None else alias.asname)
+                    imported_names.add(
+                        alias.name if alias.asname is None else alias.asname
+                    )
         assert "run_job" not in imported_names, (
             "_handle_cron_run still imports run_job — it should be moved to "
             "_run_cron_tracked to avoid the NameError in worker threads."

--- a/tests/test_cron_session_title.py
+++ b/tests/test_cron_session_title.py
@@ -6,6 +6,7 @@ instead of a generic "Cron Session" label.
 
 Session ID format produced by hermes-agent: cron_<job_id>_<YYYYMMDD>_<HHMMSS>
 """
+
 import json
 import sqlite3
 
@@ -55,9 +56,7 @@ def _write_jobs_json(hermes_home, jobs):
     """Write cron/jobs.json with the given jobs list."""
     cron_dir = hermes_home / "cron"
     cron_dir.mkdir(parents=True, exist_ok=True)
-    (cron_dir / "jobs.json").write_text(
-        json.dumps({"jobs": jobs}), encoding="utf-8"
-    )
+    (cron_dir / "jobs.json").write_text(json.dumps({"jobs": jobs}), encoding="utf-8")
 
 
 @pytest.fixture
@@ -70,6 +69,7 @@ def fake_hermes_home(tmp_path, monkeypatch):
     # Both profile helpers are imported lazily inside get_cli_sessions(),
     # so patching the api.profiles module reaches them.
     import api.profiles as profiles
+
     monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: home)
     monkeypatch.setattr(profiles, "get_active_profile_name", lambda: None)
 
@@ -78,12 +78,18 @@ def fake_hermes_home(tmp_path, monkeypatch):
 
 def test_cron_session_uses_job_name_when_title_missing(fake_hermes_home):
     """A cron session with no title should display the friendly job name."""
-    _write_jobs_json(fake_hermes_home, [
-        {"id": "cd65df6fc1a8", "name": "wiki-auto-ingest"},
-    ])
-    _make_state_db(fake_hermes_home / "state.db", [
-        ("cron_cd65df6fc1a8_20260417_191049", None, "cron"),
-    ])
+    _write_jobs_json(
+        fake_hermes_home,
+        [
+            {"id": "cd65df6fc1a8", "name": "wiki-auto-ingest"},
+        ],
+    )
+    _make_state_db(
+        fake_hermes_home / "state.db",
+        [
+            ("cron_cd65df6fc1a8_20260417_191049", None, "cron"),
+        ],
+    )
 
     sessions = models.get_cli_sessions()
 
@@ -93,9 +99,12 @@ def test_cron_session_uses_job_name_when_title_missing(fake_hermes_home):
 
 def test_cron_session_falls_back_when_jobs_json_missing(fake_hermes_home):
     """No jobs.json should not crash; title falls back to 'Cron Session'."""
-    _make_state_db(fake_hermes_home / "state.db", [
-        ("cron_abc123_20260417_191049", None, "cron"),
-    ])
+    _make_state_db(
+        fake_hermes_home / "state.db",
+        [
+            ("cron_abc123_20260417_191049", None, "cron"),
+        ],
+    )
 
     sessions = models.get_cli_sessions()
 
@@ -104,12 +113,18 @@ def test_cron_session_falls_back_when_jobs_json_missing(fake_hermes_home):
 
 def test_cron_session_falls_back_when_job_id_not_in_jobs_json(fake_hermes_home):
     """Stale session whose job has been deleted falls back gracefully."""
-    _write_jobs_json(fake_hermes_home, [
-        {"id": "different_job", "name": "Some Other Job"},
-    ])
-    _make_state_db(fake_hermes_home / "state.db", [
-        ("cron_orphan_20260417_191049", None, "cron"),
-    ])
+    _write_jobs_json(
+        fake_hermes_home,
+        [
+            {"id": "different_job", "name": "Some Other Job"},
+        ],
+    )
+    _make_state_db(
+        fake_hermes_home / "state.db",
+        [
+            ("cron_orphan_20260417_191049", None, "cron"),
+        ],
+    )
 
     sessions = models.get_cli_sessions()
 
@@ -119,12 +134,18 @@ def test_cron_session_falls_back_when_job_id_not_in_jobs_json(fake_hermes_home):
 def test_explicit_title_is_preserved(fake_hermes_home):
     """If state.db already has a title, the cron job lookup should not
     override it."""
-    _write_jobs_json(fake_hermes_home, [
-        {"id": "cd65df6fc1a8", "name": "wiki-auto-ingest"},
-    ])
-    _make_state_db(fake_hermes_home / "state.db", [
-        ("cron_cd65df6fc1a8_20260417_191049", "User-edited title", "cron"),
-    ])
+    _write_jobs_json(
+        fake_hermes_home,
+        [
+            {"id": "cd65df6fc1a8", "name": "wiki-auto-ingest"},
+        ],
+    )
+    _make_state_db(
+        fake_hermes_home / "state.db",
+        [
+            ("cron_cd65df6fc1a8_20260417_191049", "User-edited title", "cron"),
+        ],
+    )
 
     sessions = models.get_cli_sessions()
 
@@ -134,14 +155,20 @@ def test_explicit_title_is_preserved(fake_hermes_home):
 def test_non_cron_sessions_unaffected(fake_hermes_home):
     """The cron-name lookup must not run for cli-source sessions, so the
     generic 'Cli Session' fallback still applies when title is empty."""
-    _write_jobs_json(fake_hermes_home, [
-        {"id": "cd65df6fc1a8", "name": "wiki-auto-ingest"},
-    ])
+    _write_jobs_json(
+        fake_hermes_home,
+        [
+            {"id": "cd65df6fc1a8", "name": "wiki-auto-ingest"},
+        ],
+    )
     # A 'cli' session whose ID coincidentally starts with 'cron_' must not
     # pick up the job name — the source check guards against this.
-    _make_state_db(fake_hermes_home / "state.db", [
-        ("cron_cd65df6fc1a8_xx", None, "cli"),
-    ])
+    _make_state_db(
+        fake_hermes_home / "state.db",
+        [
+            ("cron_cd65df6fc1a8_xx", None, "cli"),
+        ],
+    )
     # PR #1587 hides one-off default-titled CLI rows. Keep this fixture visible
     # so the test remains focused on the cron-name guard rather than sidebar
     # filtering.

--- a/tests/test_css_tooltips.py
+++ b/tests/test_css_tooltips.py
@@ -54,7 +54,7 @@ def _extract_tags(html, class_filter=None):
 def _has_attr(attrs_str, attr_name):
     """Check if a bare attribute name is present in the attrs string.
     Handles both attr_name and attr_name="..."."""
-    return bool(re.search(r'\b' + re.escape(attr_name) + r'(?:=|\s|>)', attrs_str))
+    return bool(re.search(r"\b" + re.escape(attr_name) + r"(?:=|\s|>)", attrs_str))
 
 
 def _get_attr(attrs_str, attr_name):
@@ -64,7 +64,7 @@ def _get_attr(attrs_str, attr_name):
     'data-i18n-title' or similar prefixed attributes.
     """
     # Preceding char must be whitespace or start-of-string — not a letter/hyphen.
-    m = re.search(r'(?<![a-zA-Z\-])' + re.escape(attr_name) + r'="([^"]*)"', attrs_str)
+    m = re.search(r"(?<![a-zA-Z\-])" + re.escape(attr_name) + r'="([^"]*)"', attrs_str)
     return m.group(1) if m else None
 
 
@@ -90,7 +90,8 @@ class TestIndexHTMLTooltipCoverage(unittest.TestCase):
         for btn in rail_btns:
             cls_val = _get_attr(btn["attrs"], "class")
             self.assertIn(
-                "has-tooltip", cls_val,
+                "has-tooltip",
+                cls_val,
                 f".rail-btn missing has-tooltip class: ...{cls_val[:120]}",
             )
 
@@ -107,7 +108,7 @@ class TestIndexHTMLTooltipCoverage(unittest.TestCase):
         for btn in self._find("rail-btn"):
             self.assertIsNone(
                 _get_attr(btn["attrs"], "title"),
-                ".rail-btn still has native title=\"\" — should use data-tooltip",
+                '.rail-btn still has native title="" — should use data-tooltip',
             )
 
     # -- sidebar-nav .nav-tab ------------------------------------------------
@@ -118,7 +119,9 @@ class TestIndexHTMLTooltipCoverage(unittest.TestCase):
             self.html,
             re.DOTALL,
         )
-        self.assertIsNotNone(m, "Could not find <div class=\"sidebar-nav\"> in index.html")
+        self.assertIsNotNone(
+            m, 'Could not find <div class="sidebar-nav"> in index.html'
+        )
         return m.group(1)
 
     def test_sidebar_nav_tabs_have_tooltip_class(self):
@@ -129,7 +132,8 @@ class TestIndexHTMLTooltipCoverage(unittest.TestCase):
         for tab in nav_tabs:
             cls_val = _get_attr(tab["attrs"], "class")
             self.assertIn(
-                "has-tooltip", cls_val,
+                "has-tooltip",
+                cls_val,
                 f"sidebar-nav .nav-tab missing has-tooltip: ...{cls_val[:120]}",
             )
 
@@ -148,7 +152,7 @@ class TestIndexHTMLTooltipCoverage(unittest.TestCase):
         for tab in _extract_tags(section, class_filter=["nav-tab"]):
             self.assertIsNone(
                 _get_attr(tab["attrs"], "title"),
-                "sidebar-nav .nav-tab still has native title=\"\" — should use data-tooltip",
+                'sidebar-nav .nav-tab still has native title="" — should use data-tooltip',
             )
 
     # -- panel-head-btn ------------------------------------------------------
@@ -159,7 +163,8 @@ class TestIndexHTMLTooltipCoverage(unittest.TestCase):
         for btn in btns:
             cls_val = _get_attr(btn["attrs"], "class")
             self.assertIn(
-                "has-tooltip", cls_val,
+                "has-tooltip",
+                cls_val,
                 f".panel-head-btn missing has-tooltip class: ...{cls_val[:120]}",
             )
 
@@ -176,7 +181,7 @@ class TestIndexHTMLTooltipCoverage(unittest.TestCase):
         for btn in self._find("panel-head-btn"):
             self.assertIsNone(
                 _get_attr(btn["attrs"], "title"),
-                ".panel-head-btn still has native title=\"\" — should use data-tooltip",
+                '.panel-head-btn still has native title="" — should use data-tooltip',
             )
 
     # -- has-tooltip ↔ data-tooltip consistency -----------------------------
@@ -204,7 +209,8 @@ class TestStyleCSSTooltipClasses(unittest.TestCase):
     def test_has_tooltip_class_defined(self):
         """The .has-tooltip base class must be defined."""
         self.assertRegex(
-            self.css, r'\.has-tooltip\s*\{',
+            self.css,
+            r"\.has-tooltip\s*\{",
             ".has-tooltip class not found in CSS",
         )
 
@@ -212,14 +218,15 @@ class TestStyleCSSTooltipClasses(unittest.TestCase):
         """.has-tooltip::after must use content:attr(data-tooltip)."""
         self.assertRegex(
             self.css,
-            r'\.has-tooltip::after\s*\{[^}]*content:\s*attr\(data-tooltip\)',
+            r"\.has-tooltip::after\s*\{[^}]*content:\s*attr\(data-tooltip\)",
             ".has-tooltip::after does not use content:attr(data-tooltip)",
         )
 
     def test_has_tooltip_bottom_defined(self):
         """The .has-tooltip--bottom modifier class must be defined."""
         self.assertRegex(
-            self.css, r'\.has-tooltip--bottom\s*(?:::[\w-]+)?\s*\{',
+            self.css,
+            r"\.has-tooltip--bottom\s*(?:::[\w-]+)?\s*\{",
             ".has-tooltip--bottom class not found in CSS",
         )
 
@@ -227,26 +234,30 @@ class TestStyleCSSTooltipClasses(unittest.TestCase):
         """Both :hover and :focus-visible must trigger opacity on ::after."""
         # Look for a rule that combines both selectors
         hover_match = re.search(
-            r'\.has-tooltip:hover::after\s*\{[^}]*opacity',
+            r"\.has-tooltip:hover::after\s*\{[^}]*opacity",
             self.css,
         )
         focus_match = re.search(
-            r'\.has-tooltip:focus-visible::after\s*\{[^}]*opacity',
+            r"\.has-tooltip:focus-visible::after\s*\{[^}]*opacity",
             self.css,
         )
         # Also accept combined selectors: .has-tooltip:hover::after,.has-tooltip:focus-visible::after
         if not hover_match:
             combined = re.search(
-                r'\.has-tooltip:hover::after\s*,\s*\.has-tooltip:focus-visible::after\s*\{[^}]*opacity',
+                r"\.has-tooltip:hover::after\s*,\s*\.has-tooltip:focus-visible::after\s*\{[^}]*opacity",
                 self.css,
             )
             self.assertTrue(
                 combined,
                 ":hover does not trigger opacity on .has-tooltip::after",
             )
-        if not focus_match and not (hover_match and re.search(
-            r'\.has-tooltip:focus-visible::after', self.css,
-        )):
+        if not focus_match and not (
+            hover_match
+            and re.search(
+                r"\.has-tooltip:focus-visible::after",
+                self.css,
+            )
+        ):
             self.fail(
                 ":focus-visible does not trigger opacity on .has-tooltip::after",
             )
@@ -255,7 +266,7 @@ class TestStyleCSSTooltipClasses(unittest.TestCase):
         """A prefers-reduced-motion media query must exist for .has-tooltip."""
         self.assertRegex(
             self.css,
-            r'@media\s*\(\s*prefers-reduced-motion\s*:\s*reduce\s*\)\s*\{[^}]*\.has-tooltip',
+            r"@media\s*\(\s*prefers-reduced-motion\s*:\s*reduce\s*\)\s*\{[^}]*\.has-tooltip",
             "No prefers-reduced-motion media query found for .has-tooltip",
         )
 
@@ -405,7 +416,9 @@ class RailTooltipCascadeTests(unittest.TestCase):
             # whitespace, this is the unscoped bug form.
             # Trim to the part after the last selector-list separator.
             last_sep = max(prefix.rfind("}"), prefix.rfind("\n"), prefix.rfind(","))
-            scope_text = prefix[last_sep + 1:].strip() if last_sep >= 0 else prefix.strip()
+            scope_text = (
+                prefix[last_sep + 1 :].strip() if last_sep >= 0 else prefix.strip()
+            )
             self.assertTrue(
                 scope_text,
                 "Found unscoped `.nav-tab:hover::after { content: attr(data-label) }` "
@@ -435,31 +448,35 @@ class RailTooltipCascadeTests(unittest.TestCase):
             html,
             re.DOTALL,
         )
-        self.assertIsNotNone(rail_match, "Could not locate <nav class='rail'> in index.html")
+        self.assertIsNotNone(
+            rail_match, "Could not locate <nav class='rail'> in index.html"
+        )
         rail_block = rail_match.group(1)
 
         rail_btn_count = 0
         missing = []
-        for m in re.finditer(r'<button\b([^>]*?)>', rail_block):
+        for m in re.finditer(r"<button\b([^>]*?)>", rail_block):
             attrs = m.group(1)
-            if 'rail-btn' not in attrs:
+            if "rail-btn" not in attrs:
                 continue
             rail_btn_count += 1
-            if 'has-tooltip' not in attrs:
-                missing.append(('class missing has-tooltip', attrs[:120]))
+            if "has-tooltip" not in attrs:
+                missing.append(("class missing has-tooltip", attrs[:120]))
                 continue
             tooltip_attr = re.search(r'data-tooltip="([^"]*)"', attrs)
             if not tooltip_attr or not tooltip_attr.group(1).strip():
-                missing.append(('missing or empty data-tooltip', attrs[:120]))
+                missing.append(("missing or empty data-tooltip", attrs[:120]))
 
         self.assertGreaterEqual(
-            rail_btn_count, 10,
+            rail_btn_count,
+            10,
             f"Expected ≥10 rail buttons (found {rail_btn_count}). Test selector wrong?",
         )
         self.assertEqual(
-            missing, [],
-            f"Rail buttons without working tooltip markup:\n  " +
-            "\n  ".join(f"{reason}: {attrs}" for reason, attrs in missing),
+            missing,
+            [],
+            "Rail buttons without working tooltip markup:\n  "
+            + "\n  ".join(f"{reason}: {attrs}" for reason, attrs in missing),
         )
 
 
@@ -484,14 +501,19 @@ class BottomRightTooltipVariantTests(unittest.TestCase):
         self.assertIsNotNone(rule, "`.has-tooltip--bottom-right::after` rule missing")
         body = rule.group(1)
         # Must anchor right edge.
-        self.assertRegex(body, r"right\s*:\s*0",
-                         "--bottom-right variant must set right:0")
+        self.assertRegex(
+            body, r"right\s*:\s*0", "--bottom-right variant must set right:0"
+        )
         # Must clear the inherited `left:` so it doesn't fight with the base rule.
-        self.assertRegex(body, r"left\s*:\s*auto",
-                         "--bottom-right variant must clear left:auto")
+        self.assertRegex(
+            body, r"left\s*:\s*auto", "--bottom-right variant must clear left:auto"
+        )
         # Must clear the inherited transform (otherwise translateX(-50%) shifts it).
-        self.assertRegex(body, r"transform\s*:\s*none",
-                         "--bottom-right variant must reset transform:none")
+        self.assertRegex(
+            body,
+            r"transform\s*:\s*none",
+            "--bottom-right variant must reset transform:none",
+        )
 
     def test_btn_new_chat_uses_bottom_right_variant(self):
         """`#btnNewChat` sits flush with the chat-panel right edge; its tooltip
@@ -512,7 +534,7 @@ class BottomRightTooltipVariantTests(unittest.TestCase):
         # Must NOT also carry the old --bottom (would conflict).
         self.assertNotRegex(
             attrs,
-            r'has-tooltip--bottom(?!-)',
+            r"has-tooltip--bottom(?!-)",
             "#btnNewChat carries both --bottom and --bottom-right; pick one. "
             "The plain --bottom variant centers on left:50% and overflows.",
         )

--- a/tests/test_csv_table_rendering.py
+++ b/tests/test_csv_table_rendering.py
@@ -1,139 +1,161 @@
 """Test: CSV table rendering (#485)"""
+
 import re
 
 
 def test_csv_extension_regex():
     """Verify _CSV_EXTS regex is defined."""
-    with open('static/ui.js') as f:
+    with open("static/ui.js") as f:
         src = f.read()
-    assert '_CSV_EXTS' in src, "Missing _CSV_EXTS regex"
-    assert '.csv' in src, "CSV regex should match .csv extension"
+    assert "_CSV_EXTS" in src, "Missing _CSV_EXTS regex"
+    assert ".csv" in src, "CSV regex should match .csv extension"
 
 
 def test_csv_fence_block_handler():
     """Verify fenced ```csv blocks are handled."""
-    with open('static/ui.js') as f:
+    with open("static/ui.js") as f:
         src = f.read()
     assert "lang==='csv'" in src, "Missing csv language detection in fence handler"
-    assert 'csv-table' in src, "Missing csv-table class for fenced CSV rendering"
-    assert 'csv-table-wrap' in src, "Missing csv-table-wrap class"
+    assert "csv-table" in src, "Missing csv-table class for fenced CSV rendering"
+    assert "csv-table-wrap" in src, "Missing csv-table-wrap class"
 
 
 def test_csv_fence_renders_table_structure():
     """Verify fenced CSV blocks produce proper table HTML."""
-    with open('static/ui.js') as f:
+    with open("static/ui.js") as f:
         src = f.read()
     # Should have thead, tbody, th, td
-    assert '<thead>' in src, "CSV table should have <thead>"
-    assert '<tbody>' in src, "CSV table should have <tbody>"
+    assert "<thead>" in src, "CSV table should have <thead>"
+    assert "<tbody>" in src, "CSV table should have <tbody>"
     # In the fence handler section
-    fence_section = src[src.find("lang==='csv'"):src.find("lang==='csv'") + 800]
-    assert '<th>' in fence_section, "CSV headers should use <th>"
-    assert '<td>' in fence_section, "CSV body should use <td>"
+    fence_section = src[src.find("lang==='csv'") : src.find("lang==='csv'") + 800]
+    assert "<th>" in fence_section, "CSV headers should use <th>"
+    assert "<td>" in fence_section, "CSV body should use <td>"
 
 
 def test_csv_fence_fallback_for_insufficient_rows():
     """Verify CSV with < 2 rows falls back to code block."""
-    with open('static/ui.js') as f:
+    with open("static/ui.js") as f:
         src = f.read()
-    fence_section = src[src.find("lang==='csv'"):src.find("lang==='csv'") + 800]
-    assert 'rows.length>=2' in fence_section, "Should check for at least 2 rows"
-    assert '<pre><code' in fence_section, "Fallback should render as <pre><code>"
+    fence_section = src[src.find("lang==='csv'") : src.find("lang==='csv'") + 800]
+    assert "rows.length>=2" in fence_section, "Should check for at least 2 rows"
+    assert "<pre><code" in fence_section, "Fallback should render as <pre><code>"
 
 
 def test_csv_media_file_handler():
     """Verify MEDIA: CSV files trigger inline loading."""
-    with open('static/ui.js') as f:
+    with open("static/ui.js") as f:
         src = f.read()
-    assert 'csv-inline-load' in src, "Missing csv-inline-load class for MEDIA: CSV"
-    assert 'csv_loading' in src, "Missing csv_loading i18n key usage"
+    assert "csv-inline-load" in src, "Missing csv-inline-load class for MEDIA: CSV"
+    assert "csv_loading" in src, "Missing csv_loading i18n key usage"
 
 
 def test_loadCsvInline_function():
     """Verify loadCsvInline lazy-load function exists."""
-    with open('static/ui.js') as f:
+    with open("static/ui.js") as f:
         src = f.read()
-    assert 'function loadCsvInline()' in src, "Missing loadCsvInline function"
+    assert "function loadCsvInline()" in src, "Missing loadCsvInline function"
 
 
 def test_csv_inline_max_size():
     """Verify CSV inline rendering has a size cap."""
-    with open('static/ui.js') as f:
+    with open("static/ui.js") as f:
         src = f.read()
-    csv_section = src[src.find('function loadCsvInline()'):src.find('function loadCsvInline()') + 2000]
-    assert 'CSV_MAX_SIZE' in csv_section, "Should have CSV_MAX_SIZE constant"
-    assert 'csv_too_large' in csv_section, "Should use csv_too_large i18n for oversized files"
+    csv_section = src[
+        src.find("function loadCsvInline()") : src.find("function loadCsvInline()")
+        + 2000
+    ]
+    assert "CSV_MAX_SIZE" in csv_section, "Should have CSV_MAX_SIZE constant"
+    assert "csv_too_large" in csv_section, (
+        "Should use csv_too_large i18n for oversized files"
+    )
 
 
 def test_csv_auto_detect_separator():
     """Verify CSV handler auto-detects separator."""
-    with open('static/ui.js') as f:
+    with open("static/ui.js") as f:
         src = f.read()
-    csv_section = src[src.find('function loadCsvInline()'):src.find('function loadCsvInline()') + 2000]
-    assert 'separators' in csv_section, "Should have separator detection"
-    assert ';' in csv_section, "Should detect semicolon separator"
-    assert 'tab' in csv_section.lower() or '\\t' in csv_section, "Should detect tab separator"
+    csv_section = src[
+        src.find("function loadCsvInline()") : src.find("function loadCsvInline()")
+        + 2000
+    ]
+    assert "separators" in csv_section, "Should have separator detection"
+    assert ";" in csv_section, "Should detect semicolon separator"
+    assert "tab" in csv_section.lower() or "\\t" in csv_section, (
+        "Should detect tab separator"
+    )
 
 
 def test_csv_quote_stripping():
     """Verify CSV handler strips surrounding quotes from fields."""
-    with open('static/ui.js') as f:
+    with open("static/ui.js") as f:
         src = f.read()
     assert "replace(/^[\"']|[\"']$/g,'')" in src, "Should strip quotes from CSV fields"
 
 
 def test_csv_error_handling():
     """Verify CSV error and empty data handling."""
-    with open('static/ui.js') as f:
+    with open("static/ui.js") as f:
         src = f.read()
-    csv_section = src[src.find('function loadCsvInline()'):src.find('function loadCsvInline()') + 2500]
-    assert 'csv_error' in csv_section, "Should use csv_error i18n on fetch failure"
-    assert 'csv_no_data' in csv_section, "Should use csv_no_data i18n for insufficient data"
+    csv_section = src[
+        src.find("function loadCsvInline()") : src.find("function loadCsvInline()")
+        + 2500
+    ]
+    assert "csv_error" in csv_section, "Should use csv_error i18n on fetch failure"
+    assert "csv_no_data" in csv_section, (
+        "Should use csv_no_data i18n for insufficient data"
+    )
 
 
 def test_csv_loadCsvInline_called_after_render():
     """Verify loadCsvInline is called in requestAnimationFrame after rendering."""
-    with open('static/ui.js') as f:
+    with open("static/ui.js") as f:
         src = f.read()
-    assert src.count('loadCsvInline()') >= 2, \
+    assert src.count("loadCsvInline()") >= 2, (
         "loadCsvInline should be called at least twice (initial render + cache restore)"
+    )
 
 
 def test_csv_line_ending_normalization():
     """Verify CSV handler normalizes line endings."""
-    with open('static/ui.js') as f:
+    with open("static/ui.js") as f:
         src = f.read()
-    csv_section = src[src.find('function loadCsvInline()'):src.find('function loadCsvInline()') + 2000]
-    assert '\\r\\n' in csv_section, "Should handle \\r\\n line endings"
-    assert '\\r' in csv_section, "Should handle \\r line endings"
+    csv_section = src[
+        src.find("function loadCsvInline()") : src.find("function loadCsvInline()")
+        + 2000
+    ]
+    assert "\\r\\n" in csv_section, "Should handle \\r\\n line endings"
+    assert "\\r" in csv_section, "Should handle \\r line endings"
 
 
 def test_csv_i18n_keys():
     """Verify CSV i18n keys exist in all 7 locales."""
-    with open('static/i18n.js') as f:
+    with open("static/i18n.js") as f:
         src = f.read()
-    required_keys = ['csv_loading', 'csv_too_large', 'csv_no_data', 'csv_error']
+    required_keys = ["csv_loading", "csv_too_large", "csv_no_data", "csv_error"]
     for key in required_keys:
         count = src.count(f"{key}:")
-        assert count >= 8, f"Key '{key}' found {count} times, expected >= 8 (one per locale)"
+        assert count >= 8, (
+            f"Key '{key}' found {count} times, expected >= 8 (one per locale)"
+        )
 
 
 def test_csv_css_classes():
     """Verify CSV table CSS classes are defined."""
-    with open('static/style.css') as f:
+    with open("static/style.css") as f:
         src = f.read()
-    required_classes = ['csv-table-wrap', 'csv-table', 'csv-table th', 'csv-table td']
+    required_classes = ["csv-table-wrap", "csv-table", "csv-table th", "csv-table td"]
     for cls in required_classes:
         assert cls in src, f"Missing CSS: {cls}"
     # Check for hover effect
-    assert 'csv-table tbody tr:hover' in src, "Missing hover effect for CSV rows"
+    assert "csv-table tbody tr:hover" in src, "Missing hover effect for CSV rows"
 
 
 def test_csv_not_matched_by_image_exts():
     """Verify .csv is NOT in _IMAGE_EXTS."""
-    with open('static/ui.js') as f:
+    with open("static/ui.js") as f:
         src = f.read()
     match = re.search(r"const _IMAGE_EXTS=/([^/]+)/i", src)
     assert match
     exts = match.group(1)
-    assert 'csv' not in exts.lower(), ".csv should NOT be in _IMAGE_EXTS"
+    assert "csv" not in exts.lower(), ".csv should NOT be in _IMAGE_EXTS"

--- a/tests/test_ctl_script.py
+++ b/tests/test_ctl_script.py
@@ -86,7 +86,9 @@ def assert_process_exits(pid: int, timeout: float = 3.0) -> None:
     raise AssertionError(f"process {pid} did not exit")
 
 
-def test_start_writes_pid_under_hermes_home_runs_foreground_no_browser_and_logs(tmp_path):
+def test_start_writes_pid_under_hermes_home_runs_foreground_no_browser_and_logs(
+    tmp_path,
+):
     fake_python = tmp_path / "fake-python"
     fake_log = tmp_path / "fake-python.log"
     write_fake_python(fake_python)
@@ -131,7 +133,9 @@ def test_start_loads_dotenv_but_inline_overrides_win(tmp_path):
     repo_root = tmp_path / "repo"
     repo_root.mkdir()
     shutil.copy2(CTL, repo_root / "ctl.sh")
-    (repo_root / "bootstrap.py").write_text("# fake bootstrap target\n", encoding="utf-8")
+    (repo_root / "bootstrap.py").write_text(
+        "# fake bootstrap target\n", encoding="utf-8"
+    )
 
     fake_python = tmp_path / "fake-python"
     fake_log = tmp_path / "fake-python.log"

--- a/tests/test_custom_provider_display_name.py
+++ b/tests/test_custom_provider_display_name.py
@@ -5,6 +5,7 @@ When a custom_providers entry carries a `name` field (e.g. "Agent37"), the
 web UI model picker should show that name as the group header rather than the
 generic "Custom" label.
 """
+
 import pytest
 import api.config as config
 
@@ -68,15 +69,22 @@ def _models_with_cfg(model_cfg=None, custom_providers=None, active_provider=None
 
 # ── Named provider shows its name in the dropdown ─────────────────────────────
 
-class TestNamedCustomProviderGroup:
 
+class TestNamedCustomProviderGroup:
     def test_named_provider_uses_name_as_group_header(self):
         """A custom_provider entry with name='Agent37' should produce
         a group whose 'provider' key is 'Agent37', not 'Custom'."""
         result = _models_with_cfg(
-            model_cfg={"provider": "custom", "base_url": "https://agent37.example.com/v1"},
+            model_cfg={
+                "provider": "custom",
+                "base_url": "https://agent37.example.com/v1",
+            },
             custom_providers=[
-                {"name": "Agent37", "model": "default", "base_url": "https://agent37.example.com/v1"}
+                {
+                    "name": "Agent37",
+                    "model": "default",
+                    "base_url": "https://agent37.example.com/v1",
+                }
             ],
         )
         group_names = [g["provider"] for g in result.get("groups", [])]
@@ -88,9 +96,16 @@ class TestNamedCustomProviderGroup:
         """When all custom_provider entries have names, no group called 'Custom'
         should appear alongside them."""
         result = _models_with_cfg(
-            model_cfg={"provider": "custom", "base_url": "https://agent37.example.com/v1"},
+            model_cfg={
+                "provider": "custom",
+                "base_url": "https://agent37.example.com/v1",
+            },
             custom_providers=[
-                {"name": "Agent37", "model": "default", "base_url": "https://agent37.example.com/v1"}
+                {
+                    "name": "Agent37",
+                    "model": "default",
+                    "base_url": "https://agent37.example.com/v1",
+                }
             ],
         )
         group_names = [g["provider"] for g in result.get("groups", [])]
@@ -103,7 +118,11 @@ class TestNamedCustomProviderGroup:
         result = _models_with_cfg(
             model_cfg={"provider": "custom"},
             custom_providers=[
-                {"name": "Agent37", "model": "my-llm", "base_url": "https://agent37.example.com/v1"}
+                {
+                    "name": "Agent37",
+                    "model": "my-llm",
+                    "base_url": "https://agent37.example.com/v1",
+                }
             ],
         )
         agent37_group = next(
@@ -127,8 +146,12 @@ class TestNamedCustomProviderGroup:
         )
         group_names = [g["provider"] for g in result.get("groups", [])]
         assert "Agent37" in group_names, f"Expected 'Agent37' group, got {group_names}"
-        assert "PrivateProxy" in group_names, f"Expected 'PrivateProxy' group, got {group_names}"
-        assert "Custom" not in group_names, f"No generic 'Custom' group expected, got {group_names}"
+        assert "PrivateProxy" in group_names, (
+            f"Expected 'PrivateProxy' group, got {group_names}"
+        )
+        assert "Custom" not in group_names, (
+            f"No generic 'Custom' group expected, got {group_names}"
+        )
 
     def test_multiple_models_in_same_named_provider(self):
         """Multiple entries with the same name should be collapsed into one group."""
@@ -139,27 +162,29 @@ class TestNamedCustomProviderGroup:
                 {"name": "Agent37", "model": "model-b"},
             ],
         )
-        agent37_groups = [g for g in result.get("groups", []) if g["provider"] == "Agent37"]
+        agent37_groups = [
+            g for g in result.get("groups", []) if g["provider"] == "Agent37"
+        ]
         assert len(agent37_groups) == 1, (
             f"Expected exactly one 'Agent37' group, got {len(agent37_groups)}"
         )
         # PR #1415 prefixes IDs with @custom:NAME: when active provider differs from named slug
-        model_ids = [_strip_at_prefix(m["id"]) for m in agent37_groups[0].get("models", [])]
+        model_ids = [
+            _strip_at_prefix(m["id"]) for m in agent37_groups[0].get("models", [])
+        ]
         assert "model-a" in model_ids
         assert "model-b" in model_ids
 
 
 # ── Unnamed entry still falls back to 'Custom' ─────────────────────────────────
 
-class TestUnnamedCustomProviderFallback:
 
+class TestUnnamedCustomProviderFallback:
     def test_unnamed_entry_still_produces_custom_group(self):
         """A custom_provider entry without a name should still show as 'Custom'."""
         result = _models_with_cfg(
             model_cfg={"provider": "custom"},
-            custom_providers=[
-                {"model": "unnamed-model"}
-            ],
+            custom_providers=[{"model": "unnamed-model"}],
         )
         group_names = [g["provider"] for g in result.get("groups", [])]
         assert "Custom" in group_names, (
@@ -177,4 +202,6 @@ class TestUnnamedCustomProviderFallback:
         )
         group_names = [g["provider"] for g in result.get("groups", [])]
         assert "Agent37" in group_names, f"Expected 'Agent37' group, got {group_names}"
-        assert "Custom" in group_names, f"Expected 'Custom' group for unnamed entry, got {group_names}"
+        assert "Custom" in group_names, (
+            f"Expected 'Custom' group for unnamed entry, got {group_names}"
+        )

--- a/tests/test_custom_providers_in_panel.py
+++ b/tests/test_custom_providers_in_panel.py
@@ -4,14 +4,11 @@ Verifies that config.yaml custom_providers entries (e.g. glmcode, timicc)
 are surfaced in the /api/providers response alongside built-in providers.
 """
 
-import json
-import os
 import sys
 import types
 
 import api.config as config
 import api.profiles as profiles
-from tests._pytest_port import BASE
 
 
 def _install_fake_hermes_cli(monkeypatch):
@@ -34,6 +31,7 @@ def _install_fake_hermes_cli(monkeypatch):
 
     try:
         from api.config import invalidate_models_cache
+
         invalidate_models_cache()
     except Exception:
         pass
@@ -66,17 +64,20 @@ class TestCustomProvidersInGetProviders:
         monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
         monkeypatch.setenv("GLMCODE_API_KEY", "test-glm-key-12345678")
 
-        old_cfg, old_mtime = self._setup_cfg([
-            {
-                "name": "glmcode",
-                "base_url": "https://open.bigmodel.cn/api/coding/paas/v4",
-                "api_key": "${GLMCODE_API_KEY}",
-                "api_mode": "openai_compatible",
-                "model": "glm-5.1",
-            },
-        ])
+        old_cfg, old_mtime = self._setup_cfg(
+            [
+                {
+                    "name": "glmcode",
+                    "base_url": "https://open.bigmodel.cn/api/coding/paas/v4",
+                    "api_key": "${GLMCODE_API_KEY}",
+                    "api_mode": "openai_compatible",
+                    "model": "glm-5.1",
+                },
+            ]
+        )
 
         from api.providers import get_providers
+
         try:
             result = get_providers()
             provider_ids = {p["id"] for p in result["providers"]}
@@ -108,17 +109,20 @@ class TestCustomProvidersInGetProviders:
         monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
         monkeypatch.setenv("DEEPSEEK_API_KEY", "sk-deepseek-test-12345678")
 
-        old_cfg, old_mtime = self._setup_cfg([
-            {
-                "name": "deepseek",
-                "base_url": "https://api.deepseek.com",
-                "api_key": "${DEEPSEEK_API_KEY}",
-                "api_mode": "openai_compatible",
-                "models": ["deepseek-v4-flash", "deepseek-v4-pro"],
-            },
-        ])
+        old_cfg, old_mtime = self._setup_cfg(
+            [
+                {
+                    "name": "deepseek",
+                    "base_url": "https://api.deepseek.com",
+                    "api_key": "${DEEPSEEK_API_KEY}",
+                    "api_mode": "openai_compatible",
+                    "models": ["deepseek-v4-flash", "deepseek-v4-pro"],
+                },
+            ]
+        )
 
         from api.providers import get_providers
+
         try:
             result = get_providers()
             provider_ids = {p["id"] for p in result["providers"]}
@@ -140,16 +144,19 @@ class TestCustomProvidersInGetProviders:
         # Ensure TIMICC_API_KEY is not set
         monkeypatch.delenv("TIMICC_API_KEY", raising=False)
 
-        old_cfg, old_mtime = self._setup_cfg([
-            {
-                "name": "timicc-claude",
-                "base_url": "https://timicc.com/v1",
-                "api_key": "${TIMICC_API_KEY}",
-                "api_mode": "anthropic_messages",
-            },
-        ])
+        old_cfg, old_mtime = self._setup_cfg(
+            [
+                {
+                    "name": "timicc-claude",
+                    "base_url": "https://timicc.com/v1",
+                    "api_key": "${TIMICC_API_KEY}",
+                    "api_mode": "anthropic_messages",
+                },
+            ]
+        )
 
         from api.providers import get_providers
+
         try:
             result = get_providers()
             # TIMICC_API_KEY env var is not set → has_key should be False
@@ -168,6 +175,7 @@ class TestCustomProvidersInGetProviders:
         old_cfg, old_mtime = self._setup_cfg([])
 
         from api.providers import get_providers
+
         try:
             result = get_providers()
             # No crash, still returns built-in providers
@@ -185,15 +193,18 @@ class TestCustomProvidersInGetProviders:
         _install_fake_hermes_cli(monkeypatch)
         monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
 
-        old_cfg, old_mtime = self._setup_cfg([
-            {
-                "name": "my-proxy",
-                "base_url": "https://proxy.example.com/v1",
-                "api_key": "sk-inline-key-12345678",
-            },
-        ])
+        old_cfg, old_mtime = self._setup_cfg(
+            [
+                {
+                    "name": "my-proxy",
+                    "base_url": "https://proxy.example.com/v1",
+                    "api_key": "sk-inline-key-12345678",
+                },
+            ]
+        )
 
         from api.providers import get_providers
+
         try:
             result = get_providers()
             cp = [p for p in result["providers"] if p["id"] == "custom:my-proxy"]
@@ -207,14 +218,19 @@ class TestCustomProvidersInGetProviders:
         _install_fake_hermes_cli(monkeypatch)
         monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
 
-        old_cfg, old_mtime = self._setup_cfg([
-            {"base_url": "https://no-name.example.com/v1"},
-        ])
+        old_cfg, old_mtime = self._setup_cfg(
+            [
+                {"base_url": "https://no-name.example.com/v1"},
+            ]
+        )
 
         from api.providers import get_providers
+
         try:
             result = get_providers()
-            custom_ids = {p["id"] for p in result["providers"] if p["id"].startswith("custom:")}
+            custom_ids = {
+                p["id"] for p in result["providers"] if p["id"].startswith("custom:")
+            }
             assert len(custom_ids) == 0, (
                 f"Entry without name should be skipped, got: {custom_ids}"
             )
@@ -228,6 +244,7 @@ class TestDeepSeekV4Models:
     def test_v4_models_in_provider_models(self):
         """_PROVIDER_MODELS['deepseek'] should contain v4 and legacy v3 entries."""
         from api.config import _PROVIDER_MODELS
+
         ds_models = _PROVIDER_MODELS.get("deepseek", [])
         ids = {m["id"] for m in ds_models}
 
@@ -245,6 +262,7 @@ class TestDeepSeekV4Models:
     def test_zai_models_include_glm_series(self):
         """_PROVIDER_MODELS['zai'] should have GLM-5.x and GLM-4.x models."""
         from api.config import _PROVIDER_MODELS
+
         zai_models = _PROVIDER_MODELS.get("zai", [])
         ids = {m["id"] for m in zai_models}
 
@@ -258,6 +276,7 @@ class TestDeepSeekV4Models:
     def test_zai_in_onboarding_setup(self):
         """_SUPPORTED_PROVIDER_SETUPS should have 'zai' entry."""
         from api.onboarding import _SUPPORTED_PROVIDER_SETUPS
+
         assert "zai" in _SUPPORTED_PROVIDER_SETUPS, (
             "zai provider should be in onboarding quick-setup"
         )
@@ -270,6 +289,7 @@ class TestDeepSeekV4Models:
     def test_deepseek_onboarding_default_is_v4(self):
         """DeepSeek onboarding default should be v4-flash, not V3."""
         from api.onboarding import _SUPPORTED_PROVIDER_SETUPS
+
         ds = _SUPPORTED_PROVIDER_SETUPS.get("deepseek", {})
         assert ds.get("default_model") == "deepseek-v4-flash", (
             f"DeepSeek default should be v4-flash, got: {ds.get('default_model')}"

--- a/tests/test_dashboard_link_ui.py
+++ b/tests/test_dashboard_link_ui.py
@@ -10,16 +10,20 @@ STYLE_CSS = (REPO / "static" / "style.css").read_text(encoding="utf-8")
 def test_dashboard_nav_buttons_are_hidden_by_default_and_subpath_safe():
     assert 'id="dashboardRailBtn"' in INDEX_HTML
     assert 'id="dashboardMobileBtn"' in INDEX_HTML
-    assert 'data-dashboard-link' in INDEX_HTML
+    assert "data-dashboard-link" in INDEX_HTML
     assert 'data-i18n-title="tab_dashboard"' in INDEX_HTML
-    assert 'display:none' in INDEX_HTML
+    assert "display:none" in INDEX_HTML
     assert "Dashboard" in INDEX_HTML
-    assert "href=\"/" not in INDEX_HTML
+    assert 'href="/' not in INDEX_HTML
 
 
 def test_dashboard_rail_item_sits_between_insights_and_settings_spacer():
     rail = re.search(r'<nav class="rail".*?</nav>', INDEX_HTML, re.DOTALL).group(0)
-    assert rail.index('data-panel="insights"') < rail.index('id="dashboardRailBtn"') < rail.index('rail-spacer')
+    assert (
+        rail.index('data-panel="insights"')
+        < rail.index('id="dashboardRailBtn"')
+        < rail.index("rail-spacer")
+    )
 
 
 def test_dashboard_frontend_fetches_status_with_sixty_second_cache():
@@ -33,7 +37,10 @@ def test_dashboard_frontend_fetches_status_with_sixty_second_cache():
 
 def test_dashboard_probe_initializes_after_shared_api_helper_is_loaded():
     assert "function _initDashboardLinkProbe" in UI_JS
-    assert "document.addEventListener('DOMContentLoaded',_initDashboardLinkProbe,{once:true})" in UI_JS
+    assert (
+        "document.addEventListener('DOMContentLoaded',_initDashboardLinkProbe,{once:true})"
+        in UI_JS
+    )
     assert "else _initDashboardLinkProbe();" not in UI_JS
 
 
@@ -44,7 +51,9 @@ def test_dashboard_frontend_opens_external_tab_safely_and_derives_browser_host_u
     assert "window.location.hostname" in UI_JS
     assert "_dashboardBrowserUrl" in UI_JS
     assert 'id="dashboardRailBtn"' in INDEX_HTML
-    assert re.search(r'id="dashboardRailBtn"[^>]*onclick="openHermesDashboard\(event\)"', INDEX_HTML)
+    assert re.search(
+        r'id="dashboardRailBtn"[^>]*onclick="openHermesDashboard\(event\)"', INDEX_HTML
+    )
 
 
 def test_dashboard_loopback_warning_and_external_badge_are_present():

--- a/tests/test_dashboard_probe.py
+++ b/tests/test_dashboard_probe.py
@@ -45,7 +45,13 @@ def test_probe_uses_official_dashboard_status_fingerprint(monkeypatch):
 
     def fake_urlopen(request, timeout):
         calls.append((request.full_url, timeout))
-        return _FakeResponse({"version": "0.12.0", "release_date": "2026-05-01", "hermes_home": "/tmp/hermes"})
+        return _FakeResponse(
+            {
+                "version": "0.12.0",
+                "release_date": "2026-05-01",
+                "hermes_home": "/tmp/hermes",
+            }
+        )
 
     from api import dashboard_probe
 
@@ -88,9 +94,24 @@ def test_dashboard_target_validation_allows_only_loopback_base_urls():
     from api.dashboard_probe import normalize_dashboard_url
 
     assert normalize_dashboard_url("") is None
-    assert normalize_dashboard_url("http://127.0.0.1:9120") == ("127.0.0.1", 9120, "http", "http://127.0.0.1:9120")
-    assert normalize_dashboard_url("https://localhost:9443") == ("localhost", 9443, "https", "https://localhost:9443")
-    assert normalize_dashboard_url("http://[::1]:9119") == ("::1", 9119, "http", "http://[::1]:9119")
+    assert normalize_dashboard_url("http://127.0.0.1:9120") == (
+        "127.0.0.1",
+        9120,
+        "http",
+        "http://127.0.0.1:9120",
+    )
+    assert normalize_dashboard_url("https://localhost:9443") == (
+        "localhost",
+        9443,
+        "https",
+        "https://localhost:9443",
+    )
+    assert normalize_dashboard_url("http://[::1]:9119") == (
+        "::1",
+        9119,
+        "http",
+        "http://[::1]:9119",
+    )
 
     for bad in (
         "http://example.com:9119",
@@ -121,7 +142,13 @@ def test_status_tries_default_loopback_targets_until_dashboard_found(monkeypatch
     def fake_probe(host, port, timeout=0.5, scheme="http"):
         attempts.append((host, port, timeout, scheme))
         if host == "localhost":
-            return {"running": True, "host": host, "port": port, "url": "http://localhost:9119", "version": "0.12.0"}
+            return {
+                "running": True,
+                "host": host,
+                "port": port,
+                "url": "http://localhost:9119",
+                "version": "0.12.0",
+            }
         return {"running": False}
 
     monkeypatch.setattr(dashboard_probe, "probe_official_dashboard", fake_probe)
@@ -129,7 +156,10 @@ def test_status_tries_default_loopback_targets_until_dashboard_found(monkeypatch
 
     assert result["running"] is True
     assert result["host"] == "localhost"
-    assert attempts == [("127.0.0.1", 9119, 0.5, "http"), ("localhost", 9119, 0.5, "http")]
+    assert attempts == [
+        ("127.0.0.1", 9119, 0.5, "http"),
+        ("localhost", 9119, 0.5, "http"),
+    ]
 
 
 def test_status_honors_never_and_strict_override(monkeypatch):
@@ -139,23 +169,27 @@ def test_status_honors_never_and_strict_override(monkeypatch):
         raise AssertionError("disabled dashboard must not probe")
 
     monkeypatch.setattr(dashboard_probe, "probe_official_dashboard", fail_probe)
-    assert dashboard_probe.get_dashboard_status(config_data={"webui": {"dashboard": {"enabled": "never"}}}) == {
+    assert dashboard_probe.get_dashboard_status(
+        config_data={"webui": {"dashboard": {"enabled": "never"}}}
+    ) == {
         "running": False,
         "enabled": "never",
     }
 
-    result = dashboard_probe.get_dashboard_status(config_data={"webui": {"dashboard": {"url": "http://example.com:9119"}}})
+    result = dashboard_probe.get_dashboard_status(
+        config_data={"webui": {"dashboard": {"url": "http://example.com:9119"}}}
+    )
     assert result["running"] is False
     assert "invalid" in result["error"]
-
-
 
 
 def test_status_skips_auto_probe_when_webui_bind_host_is_non_loopback(monkeypatch):
     from api import dashboard_probe
 
     def fail_probe(*args, **kwargs):
-        raise AssertionError("auto mode must not probe dashboard when WebUI binds non-loopback")
+        raise AssertionError(
+            "auto mode must not probe dashboard when WebUI binds non-loopback"
+        )
 
     monkeypatch.setenv("HERMES_WEBUI_HOST", "0.0.0.0")
     monkeypatch.setattr(dashboard_probe, "probe_official_dashboard", fail_probe)
@@ -172,7 +206,13 @@ def test_dashboard_status_route_returns_safe_payload(monkeypatch):
     monkeypatch.setattr(
         dashboard_probe,
         "get_dashboard_status",
-        lambda: {"running": True, "host": "127.0.0.1", "port": 9119, "url": "http://127.0.0.1:9119", "version": "0.12.0"},
+        lambda: {
+            "running": True,
+            "host": "127.0.0.1",
+            "port": 9119,
+            "url": "http://127.0.0.1:9119",
+            "version": "0.12.0",
+        },
     )
 
     handler = _FakeHandler()

--- a/tests/test_default_workspace_fallback.py
+++ b/tests/test_default_workspace_fallback.py
@@ -1,10 +1,11 @@
 import json
-from pathlib import Path
 
 import api.config as config
 
 
-def test_resolve_default_workspace_falls_back_to_existing_home_work(monkeypatch, tmp_path):
+def test_resolve_default_workspace_falls_back_to_existing_home_work(
+    monkeypatch, tmp_path
+):
     preferred = tmp_path / "work"
     preferred.mkdir()
     state_dir = tmp_path / "state"
@@ -18,8 +19,9 @@ def test_resolve_default_workspace_falls_back_to_existing_home_work(monkeypatch,
     assert resolved == preferred.resolve()
 
 
-
-def test_save_settings_rewrites_bad_default_workspace_to_fallback(monkeypatch, tmp_path):
+def test_save_settings_rewrites_bad_default_workspace_to_fallback(
+    monkeypatch, tmp_path
+):
     preferred = tmp_path / "work"
     preferred.mkdir()
     state_dir = tmp_path / "state"
@@ -38,7 +40,9 @@ def test_save_settings_rewrites_bad_default_workspace_to_fallback(monkeypatch, t
     assert on_disk["default_workspace"] == str(preferred.resolve())
 
 
-def test_resolve_default_workspace_creates_home_workspace_when_missing(monkeypatch, tmp_path):
+def test_resolve_default_workspace_creates_home_workspace_when_missing(
+    monkeypatch, tmp_path
+):
     """When no preferred dir exists, resolve falls back to creating ~/workspace."""
     state_dir = tmp_path / "state"
     monkeypatch.setattr(config, "HOME", tmp_path)
@@ -50,9 +54,13 @@ def test_resolve_default_workspace_creates_home_workspace_when_missing(monkeypat
     assert resolved.is_dir()
 
 
-def test_resolve_default_workspace_raises_when_all_candidates_fail(monkeypatch, tmp_path):
+def test_resolve_default_workspace_raises_when_all_candidates_fail(
+    monkeypatch, tmp_path
+):
     """RuntimeError is raised when every candidate is unwritable."""
-    import stat, pytest
+    import stat
+    import pytest
+
     # Make tmp_path read-only so mkdir inside it fails
     tmp_path.chmod(stat.S_IRUSR | stat.S_IXUSR)
     state_dir = tmp_path / "state"
@@ -95,6 +103,7 @@ def test_env_var_workspace_takes_priority_over_passed_raw(monkeypatch, tmp_path)
 def test_ensure_workspace_dir_returns_false_for_unwritable_path(monkeypatch, tmp_path):
     """_ensure_workspace_dir returns False for a path that can't be created."""
     import stat
+
     # Make parent read-only so mkdir fails
     parent = tmp_path / "ro_parent"
     parent.mkdir()

--- a/tests/test_docker_env_readonly_vars.py
+++ b/tests/test_docker_env_readonly_vars.py
@@ -25,6 +25,7 @@ These tests pin:
   - The optional ``export`` prefix on those names is also caught
   - Non-readonly KEY=value lines in .env still load
 """
+
 import re
 import shutil
 import subprocess
@@ -116,7 +117,9 @@ class TestStartShReadonlyEnvFilterBehavioral:
         assert m is not None, "could not locate .env loader block in start.sh"
         return m.group(1)
 
-    def _run_loader(self, env_contents: str, tmp_path: Path) -> subprocess.CompletedProcess:
+    def _run_loader(
+        self, env_contents: str, tmp_path: Path
+    ) -> subprocess.CompletedProcess:
         """Write ``env_contents`` to a tmp .env and run start.sh's loader against it."""
         env_file = tmp_path / ".env"
         env_file.write_text(env_contents, encoding="utf-8")
@@ -152,12 +155,10 @@ class TestStartShReadonlyEnvFilterBehavioral:
         """)
         result = self._run_loader(env_contents, tmp_path)
         assert "EXIT_OK" in result.stdout, (
-            f"loader crashed on .env with readonly UID/GID. "
-            f"stderr: {result.stderr!r}"
+            f"loader crashed on .env with readonly UID/GID. stderr: {result.stderr!r}"
         )
         assert "readonly variable" not in result.stderr, (
-            f".env loader still triggered readonly-variable crash: "
-            f"{result.stderr!r}"
+            f".env loader still triggered readonly-variable crash: {result.stderr!r}"
         )
         # Non-readonly keys must still load.
         assert "PORT=8888" in result.stdout
@@ -186,9 +187,7 @@ class TestStartShReadonlyEnvFilterBehavioral:
             HERMES_WEBUI_PORT=7777
         """)
         result = self._run_loader(env_contents, tmp_path)
-        assert "EXIT_OK" in result.stdout, (
-            f"loader crashed; stderr: {result.stderr!r}"
-        )
+        assert "EXIT_OK" in result.stdout, f"loader crashed; stderr: {result.stderr!r}"
         assert "readonly variable" not in result.stderr
         assert "PORT=7777" in result.stdout
 

--- a/tests/test_embedded_workspace_terminal.py
+++ b/tests/test_embedded_workspace_terminal.py
@@ -21,8 +21,8 @@ def test_terminal_is_opened_by_slash_command_not_permanent_composer_icon():
     assert "toggleComposerTerminal(true)" in commands_js
     assert 'id="terminalViewport"' in html
     assert 'id="terminalSurface"' in html
-    assert 'static/terminal.js' in html
-    assert './static/terminal.js' in sw
+    assert "static/terminal.js" in html
+    assert "./static/terminal.js" in sw
     assert "xterm@5.3.0" in html
 
 
@@ -30,21 +30,39 @@ def test_terminal_surface_uses_composer_flyout_card_pattern():
     html = _read("static/index.html")
     style_css = _read("static/style.css")
 
-    flyout = html.split('<div class="composer-flyout">', 1)[1].split('<div class="queue-pill-outer">', 1)[0]
+    flyout = html.split('<div class="composer-flyout">', 1)[1].split(
+        '<div class="queue-pill-outer">', 1
+    )[0]
     assert 'id="composerTerminalPanel"' in flyout
     assert 'class="composer-terminal-inner"' in flyout
     assert 'id="composerTerminalDock"' in flyout
     assert 'id="terminalResizeHandle"' in flyout
-    assert 'id="composerTerminalPanel"' not in html.split('<div class="queue-pill-outer">', 1)[1]
+    assert (
+        'id="composerTerminalPanel"'
+        not in html.split('<div class="queue-pill-outer">', 1)[1]
+    )
     assert ".composer-terminal-panel{position:absolute" in style_css
     assert "bottom:-24px" in style_css
     assert "width:min(calc(100% - 64px),720px)" in style_css
-    assert ".composer-wrap.terminal-dock-visible .composer-flyout{z-index:4" in style_css
-    assert ".composer-terminal-panel.is-collapsed{bottom:-2px;width:min(calc(100% - 112px),560px);overflow:visible;z-index:4" in style_css
-    assert ".composer-terminal-panel.is-expanding-from-dock .composer-terminal-inner{transition:opacity .18s ease" in style_css
-    assert ".messages.terminal-expanding-from-dock{transition:none!important" in style_css
+    assert (
+        ".composer-wrap.terminal-dock-visible .composer-flyout{z-index:4" in style_css
+    )
+    assert (
+        ".composer-terminal-panel.is-collapsed{bottom:-2px;width:min(calc(100% - 112px),560px);overflow:visible;z-index:4"
+        in style_css
+    )
+    assert (
+        ".composer-terminal-panel.is-expanding-from-dock .composer-terminal-inner{transition:opacity .18s ease"
+        in style_css
+    )
+    assert (
+        ".messages.terminal-expanding-from-dock{transition:none!important" in style_css
+    )
     assert ".composer-terminal-dock{min-height:42px" in style_css
-    assert ".composer-terminal-inner{height:var(--composer-terminal-height,260px)" in style_css
+    assert (
+        ".composer-terminal-inner{height:var(--composer-terminal-height,260px)"
+        in style_css
+    )
     assert "transform:translateY(100%)" in style_css
 
 
@@ -56,7 +74,9 @@ def test_terminal_uses_controlled_desktop_resize_handle():
     assert 'class="composer-terminal-resize-handle"' in html
     assert 'role="separator"' in html
     assert 'aria-orientation="horizontal"' in html
-    terminal_inner_rule = style_css.split(".composer-terminal-inner{", 1)[1].split("}", 1)[0]
+    terminal_inner_rule = style_css.split(".composer-terminal-inner{", 1)[1].split(
+        "}", 1
+    )[0]
     assert "resize:" not in terminal_inner_rule
     assert "cursor:ns-resize" in style_css
     assert "const TERMINAL_HEIGHT_DEFAULT=260" in terminal_js
@@ -69,13 +89,24 @@ def test_terminal_resize_path_refits_backend_and_transcript_space():
     terminal_js = _read("static/terminal.js")
 
     assert "function _applyTerminalHeight" in terminal_js
-    apply_block = terminal_js.split("function _applyTerminalHeight", 1)[1].split("function _resetTerminalHeightForViewport", 1)[0]
+    apply_block = terminal_js.split("function _applyTerminalHeight", 1)[1].split(
+        "function _resetTerminalHeightForViewport", 1
+    )[0]
     assert "_fitTerminal();" in apply_block
     assert "_syncTerminalTranscriptSpace(true);" in apply_block
     assert "function _moveTerminalHeightResize" in terminal_js
-    assert "_applyTerminalHeight(TERMINAL_UI.resizeStartHeight+(TERMINAL_UI.resizeStartY-ev.clientY))" in terminal_js
-    assert "handle.addEventListener('pointerdown',_startTerminalHeightResize)" in terminal_js
-    assert "handle.addEventListener('pointermove',_moveTerminalHeightResize)" in terminal_js
+    assert (
+        "_applyTerminalHeight(TERMINAL_UI.resizeStartHeight+(TERMINAL_UI.resizeStartY-ev.clientY))"
+        in terminal_js
+    )
+    assert (
+        "handle.addEventListener('pointerdown',_startTerminalHeightResize)"
+        in terminal_js
+    )
+    assert (
+        "handle.addEventListener('pointermove',_moveTerminalHeightResize)"
+        in terminal_js
+    )
     assert "clearTimeout(TERMINAL_UI.resizeTimer)" in terminal_js
     assert "api('/api/terminal/resize'" in terminal_js
 
@@ -84,8 +115,13 @@ def test_terminal_open_reserves_transcript_space():
     style_css = _read("static/style.css")
     terminal_js = _read("static/terminal.js")
 
-    assert ".messages.terminal-open{padding-bottom:var(--terminal-card-height" in style_css
-    assert ".messages.terminal-collapsed{padding-bottom:var(--terminal-dock-height" in style_css
+    assert (
+        ".messages.terminal-open{padding-bottom:var(--terminal-card-height" in style_css
+    )
+    assert (
+        ".messages.terminal-collapsed{padding-bottom:var(--terminal-dock-height"
+        in style_css
+    )
     assert "scroll-padding-bottom:var(--terminal-card-height" in style_css
     assert "classList.add('terminal-open')" in terminal_js
     assert "classList.add('terminal-collapsed')" in terminal_js
@@ -102,14 +138,20 @@ def test_terminal_open_reserves_transcript_space():
 def test_terminal_initial_open_settles_transcript_space_before_reveal():
     terminal_js = _read("static/terminal.js")
 
-    open_block = terminal_js.split("async function toggleComposerTerminal", 1)[1].split("function collapseComposerTerminal", 1)[0]
+    open_block = terminal_js.split("async function toggleComposerTerminal", 1)[1].split(
+        "function collapseComposerTerminal", 1
+    )[0]
     assert "messages.classList.add('terminal-expanding-from-dock')" in open_block
     assert "_syncTerminalTranscriptSpace(true,{immediate:true});" in open_block
     assert "void messages.offsetHeight;" in open_block
     assert "panel.classList.add('is-open')" in open_block
     assert "messages.classList.remove('terminal-expanding-from-dock')" in open_block
-    assert open_block.index("_syncTerminalTranscriptSpace(true,{immediate:true});") < open_block.index("panel.classList.add('is-open')")
-    assert open_block.index("void messages.offsetHeight;") < open_block.index("panel.classList.add('is-open')")
+    assert open_block.index(
+        "_syncTerminalTranscriptSpace(true,{immediate:true});"
+    ) < open_block.index("panel.classList.add('is-open')")
+    assert open_block.index("void messages.offsetHeight;") < open_block.index(
+        "panel.classList.add('is-open')"
+    )
 
 
 def test_terminal_collapsed_state_preserves_pty_and_output_surface():
@@ -123,12 +165,19 @@ def test_terminal_collapsed_state_preserves_pty_and_output_surface():
     assert 'id="btnTerminalDockClose"' in html
     assert 'onclick="closeComposerTerminal()"' in html
     assert "collapsed:false" in terminal_js
-    collapse_block = terminal_js.split("function collapseComposerTerminal", 1)[1].split("function expandComposerTerminal", 1)[0]
+    collapse_block = terminal_js.split("function collapseComposerTerminal", 1)[1].split(
+        "function expandComposerTerminal", 1
+    )[0]
     assert "api('/api/terminal/close'" not in collapse_block
     assert "_disposeXterm" not in collapse_block
     assert "_setTerminalChromeState('collapsed')" in collapse_block
-    assert "composerWrap.classList.toggle('terminal-dock-visible',collapsed)" in terminal_js
-    expand_block = terminal_js.split("function expandComposerTerminal", 1)[1].split("function _disposeXterm", 1)[0]
+    assert (
+        "composerWrap.classList.toggle('terminal-dock-visible',collapsed)"
+        in terminal_js
+    )
+    expand_block = terminal_js.split("function expandComposerTerminal", 1)[1].split(
+        "function _disposeXterm", 1
+    )[0]
     assert "_setTerminalChromeState('expanded')" in expand_block
     assert "panel.classList.add('is-expanding-from-dock')" in expand_block
     assert "panel.classList.remove('is-expanding-from-dock')" in expand_block
@@ -136,11 +185,17 @@ def test_terminal_collapsed_state_preserves_pty_and_output_surface():
     assert "messages.classList.remove('terminal-expanding-from-dock')" in expand_block
     assert "_syncTerminalTranscriptSpace(true,{immediate:true});" in expand_block
     assert "void messages.offsetHeight;" in expand_block
-    assert expand_block.index("_syncTerminalTranscriptSpace(true,{immediate:true});") < expand_block.index("_setTerminalChromeState('expanded')")
-    assert expand_block.index("void messages.offsetHeight;") < expand_block.index("_setTerminalChromeState('expanded')")
+    assert expand_block.index(
+        "_syncTerminalTranscriptSpace(true,{immediate:true});"
+    ) < expand_block.index("_setTerminalChromeState('expanded')")
+    assert expand_block.index("void messages.offsetHeight;") < expand_block.index(
+        "_setTerminalChromeState('expanded')"
+    )
     assert "_resetTerminalHeightForViewport();" in expand_block
     assert "focusComposerTerminalInput();" in expand_block
-    close_block = terminal_js.split("async function closeComposerTerminal", 1)[1].split("async function restartComposerTerminal", 1)[0]
+    close_block = terminal_js.split("async function closeComposerTerminal", 1)[1].split(
+        "async function restartComposerTerminal", 1
+    )[0]
     assert "api('/api/terminal/close'" in close_block
     assert "_disposeXterm();" in close_block
 
@@ -150,7 +205,9 @@ def test_terminal_slash_command_expands_existing_collapsed_terminal():
     terminal_js = _read("static/terminal.js")
 
     assert "await toggleComposerTerminal(true)" in commands_js
-    toggle_block = terminal_js.split("async function toggleComposerTerminal", 1)[1].split("function collapseComposerTerminal", 1)[0]
+    toggle_block = terminal_js.split("async function toggleComposerTerminal", 1)[
+        1
+    ].split("function collapseComposerTerminal", 1)[0]
     assert "if(TERMINAL_UI.open)" in toggle_block
     assert "if(TERMINAL_UI.collapsed)expandComposerTerminal();" in toggle_block
     assert "else focusComposerTerminalInput();" in toggle_block
@@ -179,7 +236,9 @@ def test_terminal_restart_ignores_stale_sse_events():
 
     assert "if(TERMINAL_UI.source!==source)return;" in terminal_js
     assert "async function restartComposerTerminal" in terminal_js
-    restart_block = terminal_js.split("async function restartComposerTerminal", 1)[1].split("function clearComposerTerminal", 1)[0]
+    restart_block = terminal_js.split("async function restartComposerTerminal", 1)[
+        1
+    ].split("function clearComposerTerminal", 1)[0]
     assert "TERMINAL_UI.source.close()" in restart_block
     assert "TERMINAL_UI.source=null" in restart_block
 

--- a/tests/test_empty_session_no_disk_write.py
+++ b/tests/test_empty_session_no_disk_write.py
@@ -18,15 +18,14 @@ Crash-safety: if the process exits between create and first message, the
 session is lost. There were no messages to lose, so this is an explicit
 trade-off documented in ``new_session``'s docstring.
 """
+
 import json
-import time
 
 import pytest
 
 import api.models as models
 from api.models import (
     SESSIONS,
-    Session,
     all_sessions,
     get_session,
     new_session,
@@ -124,7 +123,9 @@ def test_repeated_new_session_creates_no_disk_files(_isolate, tmp_path):
     session_dir = tmp_path / "sessions"
     for _ in range(5):
         new_session()
-    on_disk_jsons = [p for p in session_dir.glob("*.json") if not p.name.startswith("_")]
+    on_disk_jsons = [
+        p for p in session_dir.glob("*.json") if not p.name.startswith("_")
+    ]
     assert on_disk_jsons == [], (
         f"new_session() produced disk files: {[p.name for p in on_disk_jsons]}"
     )

--- a/tests/test_excalidraw_inline_embed.py
+++ b/tests/test_excalidraw_inline_embed.py
@@ -1,162 +1,202 @@
 """Test: Excalidraw inline embed (#479)"""
-import re
 
 
 def test_excalidraw_extension_regex():
     """Verify _EXCALIDRAW_EXTS regex is defined."""
-    with open('static/ui.js') as f:
+    with open("static/ui.js") as f:
         src = f.read()
-    assert '_EXCALIDRAW_EXTS' in src, "Missing _EXCALIDRAW_EXTS regex"
-    assert '.excalidraw' in src, "Excalidraw regex should match .excalidraw"
+    assert "_EXCALIDRAW_EXTS" in src, "Missing _EXCALIDRAW_EXTS regex"
+    assert ".excalidraw" in src, "Excalidraw regex should match .excalidraw"
 
 
 def test_excalidraw_media_handler():
     """Verify MEDIA: .excalidraw files trigger inline loading."""
-    with open('static/ui.js') as f:
+    with open("static/ui.js") as f:
         src = f.read()
-    assert 'excalidraw-inline-load' in src, "Missing excalidraw-inline-load class"
-    assert 'excalidraw_loading' in src, "Missing excalidraw_loading i18n key usage"
+    assert "excalidraw-inline-load" in src, "Missing excalidraw-inline-load class"
+    assert "excalidraw_loading" in src, "Missing excalidraw_loading i18n key usage"
 
 
 def test_loadExcalidrawInline_function():
     """Verify loadExcalidrawInline lazy-load function exists."""
-    with open('static/ui.js') as f:
+    with open("static/ui.js") as f:
         src = f.read()
-    assert 'function loadExcalidrawInline()' in src, "Missing loadExcalidrawInline function"
+    assert "function loadExcalidrawInline()" in src, (
+        "Missing loadExcalidrawInline function"
+    )
 
 
 def test_excalidraw_json_validation():
     """Verify Excalidraw handler validates JSON format."""
-    with open('static/ui.js') as f:
+    with open("static/ui.js") as f:
         src = f.read()
-    func = src[src.find('function loadExcalidrawInline()'):src.find('function loadExcalidrawInline()') + 2000]
-    assert 'JSON.parse' in func, "Should parse JSON"
-    assert 'excalidraw_invalid' in func, "Should handle invalid format"
-    assert "data.type!=='excalidraw'" in func, "Should validate type field is 'excalidraw'"
+    func = src[
+        src.find("function loadExcalidrawInline()") : src.find(
+            "function loadExcalidrawInline()"
+        )
+        + 2000
+    ]
+    assert "JSON.parse" in func, "Should parse JSON"
+    assert "excalidraw_invalid" in func, "Should handle invalid format"
+    assert "data.type!=='excalidraw'" in func, (
+        "Should validate type field is 'excalidraw'"
+    )
 
 
 def test_excalidraw_size_cap():
     """Verify Excalidraw inline rendering has a size cap."""
-    with open('static/ui.js') as f:
+    with open("static/ui.js") as f:
         src = f.read()
-    func = src[src.find('function loadExcalidrawInline()'):src.find('function loadExcalidrawInline()') + 2000]
-    assert 'EXCALIDRAW_MAX_SIZE' in func, "Should have EXCALIDRAW_MAX_SIZE constant"
-    assert 'excalidraw_too_large' in func, "Should use excalidraw_too_large i18n for oversized files"
+    func = src[
+        src.find("function loadExcalidrawInline()") : src.find(
+            "function loadExcalidrawInline()"
+        )
+        + 2000
+    ]
+    assert "EXCALIDRAW_MAX_SIZE" in func, "Should have EXCALIDRAW_MAX_SIZE constant"
+    assert "excalidraw_too_large" in func, (
+        "Should use excalidraw_too_large i18n for oversized files"
+    )
 
 
 def test_excalidraw_error_handling():
     """Verify Excalidraw error handling."""
-    with open('static/ui.js') as f:
+    with open("static/ui.js") as f:
         src = f.read()
-    func = src[src.find('function loadExcalidrawInline()'):src.find('function loadExcalidrawInline()') + 3500]
-    assert 'excalidraw_error' in func, "Should use excalidraw_error i18n on fetch failure"
+    func = src[
+        src.find("function loadExcalidrawInline()") : src.find(
+            "function loadExcalidrawInline()"
+        )
+        + 3500
+    ]
+    assert "excalidraw_error" in func, (
+        "Should use excalidraw_error i18n on fetch failure"
+    )
 
 
 def test_excalidraw_svg_renderer_exists():
     """Verify SVG renderer for Excalidraw elements exists."""
-    with open('static/ui.js') as f:
+    with open("static/ui.js") as f:
         src = f.read()
-    assert 'function _renderExcalidrawCanvases()' in src, "Missing _renderExcalidrawCanvases function"
-    start = src.find('function _renderExcalidrawCanvases()')
-    end = src.find('// ── PDF inline preview', start)
-    render = src[start:end if end != -1 else start + 8000]
-    assert '<svg' in render, "Should generate SVG"
-    assert 'excalidraw-svg' in render, "Should use excalidraw-svg CSS class"
+    assert "function _renderExcalidrawCanvases()" in src, (
+        "Missing _renderExcalidrawCanvases function"
+    )
+    start = src.find("function _renderExcalidrawCanvases()")
+    end = src.find("// ── PDF inline preview", start)
+    render = src[start : end if end != -1 else start + 8000]
+    assert "<svg" in render, "Should generate SVG"
+    assert "excalidraw-svg" in render, "Should use excalidraw-svg CSS class"
 
 
 def test_excalidraw_renders_element_types():
     """Verify SVG renderer handles common Excalidraw element types."""
-    with open('static/ui.js') as f:
+    with open("static/ui.js") as f:
         src = f.read()
-    start = src.find('function _renderExcalidrawCanvases()')
-    end = src.find('// ── PDF inline preview', start)
-    render = src[start:end if end != -1 else start + 8000]
-    element_types = ['rectangle', 'ellipse', 'text', 'line', 'arrow', 'diamond', 'draw']
+    start = src.find("function _renderExcalidrawCanvases()")
+    end = src.find("// ── PDF inline preview", start)
+    render = src[start : end if end != -1 else start + 8000]
+    element_types = ["rectangle", "ellipse", "text", "line", "arrow", "diamond", "draw"]
     for etype in element_types:
         assert f"el.type==='{etype}'" in render, f"Should handle element type: {etype}"
 
 
 def test_excalidraw_arrow_marker():
     """Verify SVG renderer includes arrow marker definition."""
-    with open('static/ui.js') as f:
+    with open("static/ui.js") as f:
         src = f.read()
-    start = src.find('function _renderExcalidrawCanvases()')
-    end = src.find('// ── PDF inline preview', start)
-    render = src[start:end if end != -1 else start + 8000]
-    assert 'arrowhead' in render, "Should define arrowhead marker for arrows"
-    assert '<marker' in render, "Should use SVG <marker> element"
+    start = src.find("function _renderExcalidrawCanvases()")
+    end = src.find("// ── PDF inline preview", start)
+    render = src[start : end if end != -1 else start + 8000]
+    assert "arrowhead" in render, "Should define arrowhead marker for arrows"
+    assert "<marker" in render, "Should use SVG <marker> element"
 
 
 def test_excalidraw_bounds_calculation():
     """Verify SVG renderer calculates viewBox from element bounds."""
-    with open('static/ui.js') as f:
+    with open("static/ui.js") as f:
         src = f.read()
-    start = src.find('function _renderExcalidrawCanvases()')
-    end = src.find('// ── PDF inline preview', start)
-    render = src[start:end if end != -1 else start + 8000]
-    assert 'viewBox' in render, "Should calculate SVG viewBox"
-    assert 'minX' in render, "Should track minimum X bound"
-    assert 'maxX' in render, "Should track maximum X bound"
+    start = src.find("function _renderExcalidrawCanvases()")
+    end = src.find("// ── PDF inline preview", start)
+    render = src[start : end if end != -1 else start + 8000]
+    assert "viewBox" in render, "Should calculate SVG viewBox"
+    assert "minX" in render, "Should track minimum X bound"
+    assert "maxX" in render, "Should track maximum X bound"
 
 
 def test_excalidraw_empty_elements():
     """Verify empty diagrams show a message."""
-    with open('static/ui.js') as f:
+    with open("static/ui.js") as f:
         src = f.read()
-    start = src.find('function _renderExcalidrawCanvases()')
-    end = src.find('// ── PDF inline preview', start)
-    render = src[start:end if end != -1 else start + 8000]
-    assert 'excalidraw_empty' in render, "Should handle empty diagrams"
-    assert 'excalidraw_render_error' in render, "Should handle render errors"
+    start = src.find("function _renderExcalidrawCanvases()")
+    end = src.find("// ── PDF inline preview", start)
+    render = src[start : end if end != -1 else start + 8000]
+    assert "excalidraw_empty" in render, "Should handle empty diagrams"
+    assert "excalidraw_render_error" in render, "Should handle render errors"
 
 
 def test_excalidraw_download_link():
     """Verify Excalidraw embed includes download link."""
-    with open('static/ui.js') as f:
+    with open("static/ui.js") as f:
         src = f.read()
-    func = src[src.find('function loadExcalidrawInline()'):src.find('function loadExcalidrawInline()') + 2000]
-    assert 'excalidraw-open-link' in func, "Should include open/download link"
-    assert 'excalidraw_download' in func, "Should use excalidraw_download i18n"
+    func = src[
+        src.find("function loadExcalidrawInline()") : src.find(
+            "function loadExcalidrawInline()"
+        )
+        + 2000
+    ]
+    assert "excalidraw-open-link" in func, "Should include open/download link"
+    assert "excalidraw_download" in func, "Should use excalidraw_download i18n"
 
 
 def test_excalidraw_called_after_render():
     """Verify loadExcalidrawInline is called after message rendering."""
-    with open('static/ui.js') as f:
+    with open("static/ui.js") as f:
         src = f.read()
-    assert src.count('loadExcalidrawInline()') >= 2, \
+    assert src.count("loadExcalidrawInline()") >= 2, (
         "loadExcalidrawInline should be called at least twice"
+    )
 
 
 def test_excalidraw_embed_wrap_structure():
     """Verify Excalidraw embed uses proper container structure."""
-    with open('static/ui.js') as f:
+    with open("static/ui.js") as f:
         src = f.read()
-    assert 'excalidraw-embed-wrap' in src, "Missing excalidraw-embed-wrap container"
-    assert 'excalidraw-canvas' in src, "Missing excalidraw-canvas div"
-    assert 'data-excalidraw' in src, "Missing data-excalidraw attribute"
+    assert "excalidraw-embed-wrap" in src, "Missing excalidraw-embed-wrap container"
+    assert "excalidraw-canvas" in src, "Missing excalidraw-canvas div"
+    assert "data-excalidraw" in src, "Missing data-excalidraw attribute"
 
 
 def test_excalidraw_i18n_keys():
     """Verify Excalidraw i18n keys exist in all 7 locales."""
-    with open('static/i18n.js') as f:
+    with open("static/i18n.js") as f:
         src = f.read()
     required_keys = [
-        'excalidraw_loading', 'excalidraw_too_large', 'excalidraw_invalid',
-        'excalidraw_error', 'excalidraw_label', 'excalidraw_download',
-        'excalidraw_empty', 'excalidraw_render_error',
+        "excalidraw_loading",
+        "excalidraw_too_large",
+        "excalidraw_invalid",
+        "excalidraw_error",
+        "excalidraw_label",
+        "excalidraw_download",
+        "excalidraw_empty",
+        "excalidraw_render_error",
     ]
     for key in required_keys:
         count = src.count(f"{key}:")
-        assert count >= 8, f"Key '{key}' found {count} times, expected >= 8 (one per locale)"
+        assert count >= 8, (
+            f"Key '{key}' found {count} times, expected >= 8 (one per locale)"
+        )
 
 
 def test_excalidraw_css_classes():
     """Verify Excalidraw CSS classes are defined."""
-    with open('static/style.css') as f:
+    with open("static/style.css") as f:
         src = f.read()
     required_classes = [
-        'excalidraw-embed-wrap', 'excalidraw-canvas', 'excalidraw-svg',
-        'excalidraw-empty', 'excalidraw-open-link',
+        "excalidraw-embed-wrap",
+        "excalidraw-canvas",
+        "excalidraw-svg",
+        "excalidraw-empty",
+        "excalidraw-open-link",
     ]
     for cls in required_classes:
         assert cls in src, f"Missing CSS class: .{cls}"
@@ -178,14 +218,15 @@ def test_excalidraw_css_classes():
 # numeric fields (strokeWidth, fontSize, x/y/width/height, point coords) must
 # be coerced via Number()/isFinite gates so they cannot carry strings.
 
+
 def _excalidraw_render_block():
-    with open('static/ui.js') as f:
+    with open("static/ui.js") as f:
         src = f.read()
-    start = src.find('function _renderExcalidrawCanvases')
-    assert start != -1, '_renderExcalidrawCanvases not found'
+    start = src.find("function _renderExcalidrawCanvases")
+    assert start != -1, "_renderExcalidrawCanvases not found"
     # End at next sibling section
-    end = src.find('// ── PDF inline preview', start)
-    assert end != -1, 'end marker not found'
+    end = src.find("// ── PDF inline preview", start)
+    assert end != -1, "end marker not found"
     return src[start:end]
 
 
@@ -196,18 +237,19 @@ def test_excalidraw_string_color_fields_are_attribute_escaped():
     block = _excalidraw_render_block()
     # The escaper helper used in this block (named _sa for SVG-attr escape).
     # If renamed, update both the helper and this assertion together.
-    assert '_sa(el.strokeColor' in block, (
-        'el.strokeColor must be escaped via _sa() before SVG attribute interpolation'
+    assert "_sa(el.strokeColor" in block, (
+        "el.strokeColor must be escaped via _sa() before SVG attribute interpolation"
     )
-    assert '_sa(el.backgroundColor' in block, (
-        'el.backgroundColor must be escaped via _sa() before SVG attribute interpolation'
+    assert "_sa(el.backgroundColor" in block, (
+        "el.backgroundColor must be escaped via _sa() before SVG attribute interpolation"
     )
     # Helper definition must exist and escape the four HTML-significant chars.
-    assert "const _sa=" in block, 'attribute-escape helper _sa must be defined'
-    for ch in ('&', '"', '<', '>'):
-        assert repr(ch) in repr(block) or ch in block.split("const _sa=", 1)[1].split('\n', 1)[0], (
-            f'attribute escaper must replace {ch!r}'
-        )
+    assert "const _sa=" in block, "attribute-escape helper _sa must be defined"
+    for ch in ("&", '"', "<", ">"):
+        assert (
+            repr(ch) in repr(block)
+            or ch in block.split("const _sa=", 1)[1].split("\n", 1)[0]
+        ), f"attribute escaper must replace {ch!r}"
 
 
 def test_excalidraw_numeric_fields_are_coerced_via_Number():
@@ -215,13 +257,13 @@ def test_excalidraw_numeric_fields_are_coerced_via_Number():
     coerced to finite numbers, so a string like '2"/><script>...' cannot leak
     into the SVG attribute."""
     block = _excalidraw_render_block()
-    assert 'const _num=' in block, 'numeric coerce helper _num must be defined'
-    assert '_num(el.strokeWidth' in block, 'strokeWidth must be coerced via _num()'
-    assert '_num(el.fontSize' in block or '_num(el.x' in block, (
-        'numeric el.* fields must flow through _num() for coercion'
+    assert "const _num=" in block, "numeric coerce helper _num must be defined"
+    assert "_num(el.strokeWidth" in block, "strokeWidth must be coerced via _num()"
+    assert "_num(el.fontSize" in block or "_num(el.x" in block, (
+        "numeric el.* fields must flow through _num() for coercion"
     )
     # The bare `el.strokeWidth||2` and `el.x||0` pattern is the bug; ensure
     # neither pattern remains after the fix.
-    assert 'el.strokeWidth||2' not in block, (
-        'strokeWidth must use _num() coerce, not || fallback (string passes through ||)'
+    assert "el.strokeWidth||2" not in block, (
+        "strokeWidth must use _num() coerce, not || fallback (string passes through ||)"
     )

--- a/tests/test_extension_hooks.py
+++ b/tests/test_extension_hooks.py
@@ -85,7 +85,9 @@ def test_extension_config_accepts_only_safe_same_origin_urls(tmp_path, monkeypat
     }
 
 
-def test_index_html_injection_escapes_urls_and_preserves_disabled_default(tmp_path, monkeypatch):
+def test_index_html_injection_escapes_urls_and_preserves_disabled_default(
+    tmp_path, monkeypatch
+):
     monkeypatch.delenv("HERMES_WEBUI_EXTENSION_DIR", raising=False)
     monkeypatch.setenv("HERMES_WEBUI_EXTENSION_SCRIPT_URLS", "/extensions/app.js")
 
@@ -97,13 +99,17 @@ def test_index_html_injection_escapes_urls_and_preserves_disabled_default(tmp_pa
     root = tmp_path / "extensions"
     root.mkdir()
     monkeypatch.setenv("HERMES_WEBUI_EXTENSION_DIR", str(root))
-    monkeypatch.setenv("HERMES_WEBUI_EXTENSION_SCRIPT_URLS", "/extensions/app.js?v=1&mode=dev")
+    monkeypatch.setenv(
+        "HERMES_WEBUI_EXTENSION_SCRIPT_URLS", "/extensions/app.js?v=1&mode=dev"
+    )
     monkeypatch.setenv("HERMES_WEBUI_EXTENSION_STYLESHEET_URLS", "/extensions/app.css")
 
     injected = inject_extension_tags(html)
 
     assert '<link rel="stylesheet" href="/extensions/app.css">' in injected
-    assert '<script src="/extensions/app.js?v=1&amp;mode=dev" defer></script>' in injected
+    assert (
+        '<script src="/extensions/app.js?v=1&amp;mode=dev" defer></script>' in injected
+    )
     assert injected.index("/extensions/app.css") < injected.index("</head>")
     assert injected.index("/extensions/app.js") < injected.index("</body>")
 
@@ -117,7 +123,10 @@ def test_extension_route_remains_behind_webui_auth(monkeypatch):
     # SimpleNamespace must include `query` because api.auth.check_auth (since
     # v0.50.258, the multi-param ?next= encoding fix) accesses `parsed.query`
     # when constructing the redirect Location header.
-    assert check_auth(extension, SimpleNamespace(path="/extensions/app.js", query="")) is False
+    assert (
+        check_auth(extension, SimpleNamespace(path="/extensions/app.js", query=""))
+        is False
+    )
     assert extension.status == 302
     assert extension.header("Location") == "login?next=/extensions/app.js"
 
@@ -140,32 +149,52 @@ def test_extension_static_serving_is_sandboxed(tmp_path, monkeypatch):
     from api.extensions import serve_extension_static
 
     ok = FakeHandler()
-    assert serve_extension_static(ok, SimpleNamespace(path="/extensions/app.js")) is True
+    assert (
+        serve_extension_static(ok, SimpleNamespace(path="/extensions/app.js")) is True
+    )
     assert ok.status == 200
     assert ok.header("Content-Type") == "application/javascript; charset=utf-8"
     assert bytes(ok.body) == b"window.extensionLoaded = true;"
 
     traversal = FakeHandler()
-    assert serve_extension_static(traversal, SimpleNamespace(path="/extensions/../outside.txt")) is True
+    assert (
+        serve_extension_static(
+            traversal, SimpleNamespace(path="/extensions/../outside.txt")
+        )
+        is True
+    )
     assert traversal.status == 404
 
     encoded_traversal = FakeHandler()
-    assert serve_extension_static(encoded_traversal, SimpleNamespace(path="/extensions/%2e%2e/outside.txt")) is True
+    assert (
+        serve_extension_static(
+            encoded_traversal, SimpleNamespace(path="/extensions/%2e%2e/outside.txt")
+        )
+        is True
+    )
     assert encoded_traversal.status == 404
 
     dotfile = FakeHandler()
-    assert serve_extension_static(dotfile, SimpleNamespace(path="/extensions/.secret")) is True
+    assert (
+        serve_extension_static(dotfile, SimpleNamespace(path="/extensions/.secret"))
+        is True
+    )
     assert dotfile.status == 404
 
 
-def test_extension_static_serving_fails_closed_when_disabled_or_unreadable(tmp_path, monkeypatch):
+def test_extension_static_serving_fails_closed_when_disabled_or_unreadable(
+    tmp_path, monkeypatch
+):
     missing_root = tmp_path / "missing"
     monkeypatch.setenv("HERMES_WEBUI_EXTENSION_DIR", str(missing_root))
 
     from api.extensions import serve_extension_static
 
     disabled = FakeHandler()
-    assert serve_extension_static(disabled, SimpleNamespace(path="/extensions/app.js")) is True
+    assert (
+        serve_extension_static(disabled, SimpleNamespace(path="/extensions/app.js"))
+        is True
+    )
     assert disabled.status == 404
 
     root = tmp_path / "extensions"
@@ -175,14 +204,22 @@ def test_extension_static_serving_fails_closed_when_disabled_or_unreadable(tmp_p
     (root / "nested" / "app.js").write_text("ok", encoding="utf-8")
 
     encoded_slash_traversal = FakeHandler()
-    assert serve_extension_static(
-        encoded_slash_traversal,
-        SimpleNamespace(path="/extensions/nested%2f..%2f..%2foutside.txt"),
-    ) is True
+    assert (
+        serve_extension_static(
+            encoded_slash_traversal,
+            SimpleNamespace(path="/extensions/nested%2f..%2f..%2foutside.txt"),
+        )
+        is True
+    )
     assert encoded_slash_traversal.status == 404
 
     encoded_backslash = FakeHandler()
-    assert serve_extension_static(encoded_backslash, SimpleNamespace(path="/extensions/nested%5capp.js")) is True
+    assert (
+        serve_extension_static(
+            encoded_backslash, SimpleNamespace(path="/extensions/nested%5capp.js")
+        )
+        is True
+    )
     assert encoded_backslash.status == 404
 
 
@@ -205,5 +242,10 @@ def test_extension_static_serving_rejects_symlink_escape(tmp_path, monkeypatch):
     from api.extensions import serve_extension_static
 
     escaped = FakeHandler()
-    assert serve_extension_static(escaped, SimpleNamespace(path="/extensions/outside-link.txt")) is True
+    assert (
+        serve_extension_static(
+            escaped, SimpleNamespace(path="/extensions/outside-link.txt")
+        )
+        is True
+    )
     assert escaped.status == 404

--- a/tests/test_font_size_setting.py
+++ b/tests/test_font_size_setting.py
@@ -1,8 +1,10 @@
 """Tests for font size setting (#833) — 3-toggle Small/Default/Large in Appearance."""
+
 import os
 import re
 
 _SRC = os.path.join(os.path.dirname(__file__), "..")
+
 
 def _read(name):
     return open(os.path.join(_SRC, name), encoding="utf-8").read()
@@ -14,21 +16,27 @@ class TestFontSizeCssModifiers:
     def test_small_font_size_rule_exists(self):
         css = _read("static/style.css")
         assert 'data-font-size="small"' in css, (
-            "style.css must have :root[data-font-size=\"small\"] font-size rule"
+            'style.css must have :root[data-font-size="small"] font-size rule'
         )
 
     def test_large_font_size_rule_exists(self):
         css = _read("static/style.css")
         assert 'data-font-size="large"' in css, (
-            "style.css must have :root[data-font-size=\"large\"] font-size rule"
+            'style.css must have :root[data-font-size="large"] font-size rule'
         )
 
     def test_small_is_smaller_than_default(self):
         css = _read("static/style.css")
         # Match both compact {font-size:12px} and spaced { font-size: 12px; } formats
-        m_small = re.search(r':root\[data-font-size="small"\][^{]*\{[^}]*font-size:\s*(\d+)px', css)
-        m_large = re.search(r':root\[data-font-size="large"\][^{]*\{[^}]*font-size:\s*(\d+)px', css)
-        assert m_small and m_large, "Both small and large font-size rules must set px values"
+        m_small = re.search(
+            r':root\[data-font-size="small"\][^{]*\{[^}]*font-size:\s*(\d+)px', css
+        )
+        m_large = re.search(
+            r':root\[data-font-size="large"\][^{]*\{[^}]*font-size:\s*(\d+)px', css
+        )
+        assert m_small and m_large, (
+            "Both small and large font-size rules must set px values"
+        )
         assert int(m_small.group(1)) < 14, "Small font size must be < 14px (default)"
         assert int(m_large.group(1)) > 14, "Large font size must be > 14px (default)"
 
@@ -91,9 +99,7 @@ class TestFontSizeBootScript:
         next_pane_starts = [
             html.find(m, appearance_start + 1) for m in next_pane_markers
         ]
-        after_appearance = min(
-            [p for p in next_pane_starts if p != -1] or [len(html)]
-        )
+        after_appearance = min([p for p in next_pane_starts if p != -1] or [len(html)])
         picker_pos = html.find('id="fontSizePickerGrid"')
         assert appearance_start != -1, "settingsPaneAppearance not found"
         assert picker_pos != -1, "fontSizePickerGrid not found"
@@ -108,9 +114,7 @@ class TestFontSizeJsFunctions:
 
     def test_pick_font_size_function_exists(self):
         boot = _read("static/boot.js")
-        assert "function _pickFontSize(" in boot, (
-            "boot.js must define _pickFontSize()"
-        )
+        assert "function _pickFontSize(" in boot, "boot.js must define _pickFontSize()"
 
     def test_apply_font_size_function_exists(self):
         boot = _read("static/boot.js")
@@ -127,7 +131,7 @@ class TestFontSizeJsFunctions:
     def test_pick_font_size_persists_to_localstorage(self):
         boot = _read("static/boot.js")
         idx = boot.find("function _pickFontSize(")
-        block = boot[idx:idx+400]
+        block = boot[idx : idx + 400]
         assert "localStorage.setItem('hermes-font-size'" in block, (
             "_pickFontSize must persist choice to localStorage"
         )
@@ -135,7 +139,7 @@ class TestFontSizeJsFunctions:
     def test_apply_font_size_sets_data_attribute(self):
         boot = _read("static/boot.js")
         idx = boot.find("function _applyFontSize(")
-        block = boot[idx:idx+300]
+        block = boot[idx : idx + 300]
         assert "dataset.fontSize" in block, (
             "_applyFontSize must set document.documentElement.dataset.fontSize"
         )
@@ -150,10 +154,15 @@ class TestFontSizeI18nCoverage:
         if start < 0:
             return set()
         end = src.find(stop_marker, start)
-        block = src[start:end if end > 0 else start + 20000]
+        block = src[start : end if end > 0 else start + 20000]
         return set(re.findall(r"(\w[\w_]+):", block))
 
-    REQUIRED_KEYS = {"settings_label_font_size", "font_size_small", "font_size_default", "font_size_large"}
+    REQUIRED_KEYS = {
+        "settings_label_font_size",
+        "font_size_small",
+        "font_size_default",
+        "font_size_large",
+    }
 
     def test_all_locales_have_font_size_keys(self):
         src = _read("static/i18n.js")
@@ -166,12 +175,16 @@ class TestFontSizeI18nCoverage:
     def test_font_size_small_key_in_all_locales(self):
         src = _read("static/i18n.js")
         count = src.count("font_size_small")
-        assert count >= 6, f"font_size_small must appear in all 6 locales, found {count}"
+        assert count >= 6, (
+            f"font_size_small must appear in all 6 locales, found {count}"
+        )
 
     def test_font_size_large_key_in_all_locales(self):
         src = _read("static/i18n.js")
         count = src.count("font_size_large")
-        assert count >= 6, f"font_size_large must appear in all 6 locales, found {count}"
+        assert count >= 6, (
+            f"font_size_large must appear in all 6 locales, found {count}"
+        )
 
 
 class TestFontSizeCssTargetedOverrides:
@@ -184,45 +197,57 @@ class TestFontSizeCssTargetedOverrides:
 
     def test_msg_body_overridden_for_small(self):
         css = _read("static/style.css")
-        assert ':root[data-font-size="small"] .msg-body' in css, \
+        assert ':root[data-font-size="small"] .msg-body' in css, (
             "Chat message text must be explicitly scaled for small"
+        )
 
     def test_msg_body_overridden_for_large(self):
         css = _read("static/style.css")
-        assert ':root[data-font-size="large"] .msg-body' in css, \
+        assert ':root[data-font-size="large"] .msg-body' in css, (
             "Chat message text must be explicitly scaled for large"
+        )
 
     def test_session_item_overridden_for_small(self):
         css = _read("static/style.css")
-        assert ':root[data-font-size="small"] .session-item' in css, \
+        assert ':root[data-font-size="small"] .session-item' in css, (
             "Sidebar session list text must be explicitly scaled for small"
+        )
 
     def test_session_item_overridden_for_large(self):
         css = _read("static/style.css")
-        assert ':root[data-font-size="large"] .session-item' in css, \
+        assert ':root[data-font-size="large"] .session-item' in css, (
             "Sidebar session list text must be explicitly scaled for large"
+        )
 
     def test_composer_overridden_for_small(self):
         css = _read("static/style.css")
-        assert ':root[data-font-size="small"] #msg' in css, \
+        assert ':root[data-font-size="small"] #msg' in css, (
             "Composer textarea must be explicitly scaled for small"
+        )
 
     def test_composer_overridden_for_large(self):
         css = _read("static/style.css")
-        assert ':root[data-font-size="large"] #msg' in css, \
+        assert ':root[data-font-size="large"] #msg' in css, (
             "Composer textarea must be explicitly scaled for large"
+        )
         # Large composer must not equal the default 16px — that's a no-op
         import re
-        m = re.search(r':root\[data-font-size="large"\] #msg \{ font-size: (\d+)px', css)
-        assert m and int(m.group(1)) != 16, \
+
+        m = re.search(
+            r':root\[data-font-size="large"\] #msg \{ font-size: (\d+)px', css
+        )
+        assert m and int(m.group(1)) != 16, (
             "Large composer font-size must differ from default (16px) to have visible effect"
+        )
 
     def test_file_item_overridden_for_small(self):
         css = _read("static/style.css")
-        assert ':root[data-font-size="small"] .file-item' in css, \
+        assert ':root[data-font-size="small"] .file-item' in css, (
             "Workspace file tree text must be explicitly scaled for small"
+        )
 
     def test_file_item_overridden_for_large(self):
         css = _read("static/style.css")
-        assert ':root[data-font-size="large"] .file-item' in css, \
+        assert ':root[data-font-size="large"] .file-item' in css, (
             "Workspace file tree text must be explicitly scaled for large"
+        )

--- a/tests/test_gateway_status_agent_health.py
+++ b/tests/test_gateway_status_agent_health.py
@@ -19,6 +19,7 @@ from urllib.parse import urlparse
 
 # ── FakeHandler (mirrors test_1560_password_env_var_no_op._FakeHandler) ────────
 
+
 class _FakeHandler:
     """Minimal BaseHTTPRequestHandler stand-in for routes.handle_get."""
 
@@ -39,7 +40,9 @@ class _FakeHandler:
 
     def write(self, data):
         """Accumulate bytes written to wfile."""
-        self.body.extend(data if isinstance(data, (bytes, bytearray)) else data.encode("utf-8"))
+        self.body.extend(
+            data if isinstance(data, (bytes, bytearray)) else data.encode("utf-8")
+        )
 
     def get_json(self):
         """Parse the accumulated body as JSON."""
@@ -47,6 +50,7 @@ class _FakeHandler:
 
 
 # ── Helpers ──────────────────────────────────────────────────────────────────
+
 
 def _call_gateway_status(monkeypatch, agent_health_alive, identity_map=None):
     """Invoke handle_get for /api/gateway/status and return the parsed JSON.
@@ -81,7 +85,10 @@ def _call_gateway_status(monkeypatch, agent_health_alive, identity_map=None):
 
 # ── Acceptance criteria tests ─────────────────────────────────────────────────
 
-def test_gateway_status_running_true_when_agent_health_alive_and_no_sessions(monkeypatch):
+
+def test_gateway_status_running_true_when_agent_health_alive_and_no_sessions(
+    monkeypatch,
+):
     """AC1: alive=true + empty identity_map → running=true, configured=true, platforms=[]"""
     result = _call_gateway_status(monkeypatch, agent_health_alive=True, identity_map={})
     assert result["running"] is True
@@ -89,15 +96,21 @@ def test_gateway_status_running_true_when_agent_health_alive_and_no_sessions(mon
     assert result["platforms"] == []
 
 
-def test_gateway_status_running_false_when_agent_health_alive_false_and_no_sessions(monkeypatch):
+def test_gateway_status_running_false_when_agent_health_alive_false_and_no_sessions(
+    monkeypatch,
+):
     """AC2: alive=false + empty identity_map → running=false, configured=true, platforms=[]"""
-    result = _call_gateway_status(monkeypatch, agent_health_alive=False, identity_map={})
+    result = _call_gateway_status(
+        monkeypatch, agent_health_alive=False, identity_map={}
+    )
     assert result["running"] is False
     assert result["configured"] is True
     assert result["platforms"] == []
 
 
-def test_gateway_status_running_false_when_agent_health_alive_none_and_no_sessions(monkeypatch):
+def test_gateway_status_running_false_when_agent_health_alive_none_and_no_sessions(
+    monkeypatch,
+):
     """When alive=None (not configured): fall back to identity_map heuristic,
     and set configured=false so frontend can show 'not configured' state."""
     result = _call_gateway_status(monkeypatch, agent_health_alive=None, identity_map={})
@@ -106,13 +119,17 @@ def test_gateway_status_running_false_when_agent_health_alive_none_and_no_sessio
     assert result["platforms"] == []
 
 
-def test_gateway_status_running_true_and_platforms_when_agent_health_alive_and_sessions(monkeypatch):
+def test_gateway_status_running_true_and_platforms_when_agent_health_alive_and_sessions(
+    monkeypatch,
+):
     """AC3: alive=true + sessions with platforms → running=true, configured=true, platforms populated"""
     identity_map = {
         "sess_a": {"raw_source": "telegram", "platform": "telegram"},
         "sess_b": {"raw_source": "discord", "platform": "discord"},
     }
-    result = _call_gateway_status(monkeypatch, agent_health_alive=True, identity_map=identity_map)
+    result = _call_gateway_status(
+        monkeypatch, agent_health_alive=True, identity_map=identity_map
+    )
     assert result["running"] is True
     assert result["configured"] is True
     assert len(result["platforms"]) == 2
@@ -122,6 +139,7 @@ def test_gateway_status_running_true_and_platforms_when_agent_health_alive_and_s
 
 # ── Edge case tests ───────────────────────────────────────────────────────────
 
+
 def test_gateway_status_alive_none_falls_back_to_identity_map_heuristic(monkeypatch):
     """When alive=None (not configured) but sessions exist, running reflects identity_map.
     configured=false tells the frontend to show 'not configured' state."""
@@ -130,7 +148,11 @@ def test_gateway_status_alive_none_falls_back_to_identity_map_heuristic(monkeypa
     monkeypatch.setattr(
         routes,
         "build_agent_health_payload",
-        lambda: {"alive": None, "checked_at": "2026-05-06T12:00:00+00:00", "details": {}},
+        lambda: {
+            "alive": None,
+            "checked_at": "2026-05-06T12:00:00+00:00",
+            "details": {},
+        },
     )
     monkeypatch.setattr(
         routes,
@@ -155,7 +177,11 @@ def test_gateway_status_handles_corrupted_sessions_json(monkeypatch):
     monkeypatch.setattr(
         routes,
         "build_agent_health_payload",
-        lambda: {"alive": True, "checked_at": "2026-05-06T12:00:00+00:00", "details": {}},
+        lambda: {
+            "alive": True,
+            "checked_at": "2026-05-06T12:00:00+00:00",
+            "details": {},
+        },
     )
     # _load_gateway_session_identity_map already returns {} on JSON parse failure;
     # we monkeypatch it to return {} to simulate corrupted file.
@@ -177,7 +203,11 @@ def test_gateway_status_blank_platform_fields_empty_platforms_running_true(monke
     monkeypatch.setattr(
         routes,
         "build_agent_health_payload",
-        lambda: {"alive": True, "checked_at": "2026-05-06T12:00:00+00:00", "details": {}},
+        lambda: {
+            "alive": True,
+            "checked_at": "2026-05-06T12:00:00+00:00",
+            "details": {},
+        },
     )
     monkeypatch.setattr(
         routes,
@@ -198,14 +228,21 @@ def test_gateway_status_blank_platform_fields_empty_platforms_running_true(monke
 
 # ── Existing behavior preservation tests ──────────────────────────────────────
 
-def test_gateway_status_running_false_when_agent_health_down_even_with_sessions(monkeypatch):
+
+def test_gateway_status_running_false_when_agent_health_down_even_with_sessions(
+    monkeypatch,
+):
     """When agent_health says alive=false, running should be false regardless of sessions."""
     from api import routes
 
     monkeypatch.setattr(
         routes,
         "build_agent_health_payload",
-        lambda: {"alive": False, "checked_at": "2026-05-06T12:00:00+00:00", "details": {}},
+        lambda: {
+            "alive": False,
+            "checked_at": "2026-05-06T12:00:00+00:00",
+            "details": {},
+        },
     )
     monkeypatch.setattr(
         routes,

--- a/tests/test_gateway_sync.py
+++ b/tests/test_gateway_sync.py
@@ -9,8 +9,8 @@ Tests are ordered TDD-style:
   5. Watcher detects new sessions inserted into state.db
   6. Settings UI has renamed label
 """
+
 import json
-import os
 import pathlib
 import sqlite3
 import time
@@ -28,8 +28,9 @@ def get(path):
 
 def post(path, body=None):
     data = json.dumps(body or {}).encode()
-    req = urllib.request.Request(BASE + path, data=data,
-                                  headers={"Content-Type": "application/json"})
+    req = urllib.request.Request(
+        BASE + path, data=data, headers={"Content-Type": "application/json"}
+    )
     try:
         with urllib.request.urlopen(req, timeout=10) as r:
             return json.loads(r.read()), r.status
@@ -51,12 +52,13 @@ def _get_test_state_dir():
     """
     # Use _pytest_port which applies the same auto-derivation as conftest.py
     from tests._pytest_port import TEST_STATE_DIR as _ptsd
+
     return _ptsd
 
 
 def _get_state_db_path():
     """Return path to the test state.db."""
-    return _get_test_state_dir() / 'state.db'
+    return _get_test_state_dir() / "state.db"
 
 
 def _ensure_state_db():
@@ -87,35 +89,57 @@ def _ensure_state_db():
         );
     """)
     for column, ddl in (
-        ('user_id', 'ALTER TABLE sessions ADD COLUMN user_id TEXT'),
-        ('chat_id', 'ALTER TABLE sessions ADD COLUMN chat_id TEXT'),
-        ('chat_type', 'ALTER TABLE sessions ADD COLUMN chat_type TEXT'),
-        ('thread_id', 'ALTER TABLE sessions ADD COLUMN thread_id TEXT'),
-        ('session_key', 'ALTER TABLE sessions ADD COLUMN session_key TEXT'),
-        ('origin_chat_id', 'ALTER TABLE sessions ADD COLUMN origin_chat_id TEXT'),
-        ('origin_user_id', 'ALTER TABLE sessions ADD COLUMN origin_user_id TEXT'),
-        ('platform', 'ALTER TABLE sessions ADD COLUMN platform TEXT'),
-        ('parent_session_id', 'ALTER TABLE sessions ADD COLUMN parent_session_id TEXT'),
-        ('ended_at', 'ALTER TABLE sessions ADD COLUMN ended_at REAL'),
-        ('end_reason', 'ALTER TABLE sessions ADD COLUMN end_reason TEXT'),
+        ("user_id", "ALTER TABLE sessions ADD COLUMN user_id TEXT"),
+        ("chat_id", "ALTER TABLE sessions ADD COLUMN chat_id TEXT"),
+        ("chat_type", "ALTER TABLE sessions ADD COLUMN chat_type TEXT"),
+        ("thread_id", "ALTER TABLE sessions ADD COLUMN thread_id TEXT"),
+        ("session_key", "ALTER TABLE sessions ADD COLUMN session_key TEXT"),
+        ("origin_chat_id", "ALTER TABLE sessions ADD COLUMN origin_chat_id TEXT"),
+        ("origin_user_id", "ALTER TABLE sessions ADD COLUMN origin_user_id TEXT"),
+        ("platform", "ALTER TABLE sessions ADD COLUMN platform TEXT"),
+        ("parent_session_id", "ALTER TABLE sessions ADD COLUMN parent_session_id TEXT"),
+        ("ended_at", "ALTER TABLE sessions ADD COLUMN ended_at REAL"),
+        ("end_reason", "ALTER TABLE sessions ADD COLUMN end_reason TEXT"),
     ):
-        existing = {row[1] for row in conn.execute("PRAGMA table_info(sessions)").fetchall()}
+        existing = {
+            row[1] for row in conn.execute("PRAGMA table_info(sessions)").fetchall()
+        }
         if column not in existing:
             conn.execute(ddl)
     conn.commit()
     return conn
 
 
-def _insert_gateway_session(conn, session_id='20260401_120000_abcdefgh', source='telegram',
-                             title='Telegram Chat', model='anthropic/claude-sonnet-4-5',
-                             started_at=None, message_count=2, user_id=None, chat_id=None,
-                             chat_type=None, thread_id=None, session_key=None, origin_chat_id=None,
-                             origin_user_id=None, platform=None):
+def _insert_gateway_session(
+    conn,
+    session_id="20260401_120000_abcdefgh",
+    source="telegram",
+    title="Telegram Chat",
+    model="anthropic/claude-sonnet-4-5",
+    started_at=None,
+    message_count=2,
+    user_id=None,
+    chat_id=None,
+    chat_type=None,
+    thread_id=None,
+    session_key=None,
+    origin_chat_id=None,
+    origin_user_id=None,
+    platform=None,
+):
     """Insert a gateway session into state.db."""
     conn.execute(
         "INSERT OR REPLACE INTO sessions (id, source, user_id, title, model, started_at, message_count) "
         "VALUES (?, ?, ?, ?, ?, ?, ?)",
-        (session_id, source, user_id, title, model, started_at or time.time(), message_count)
+        (
+            session_id,
+            source,
+            user_id,
+            title,
+            model,
+            started_at or time.time(),
+            message_count,
+        ),
     )
     updates = []
     params = []
@@ -134,18 +158,18 @@ def _insert_gateway_session(conn, session_id='20260401_120000_abcdefgh', source=
     if updates:
         conn.execute(
             f"UPDATE sessions SET {', '.join(updates)} WHERE id = ?",
-            [*params, session_id]
+            [*params, session_id],
         )
     # Delete any existing messages for this session (idempotent re-insert)
     conn.execute("DELETE FROM messages WHERE session_id = ?", (session_id,))
     # Insert some messages
     conn.execute(
         "INSERT INTO messages (session_id, role, content, timestamp) VALUES (?, 'user', ?, ?)",
-        (session_id, 'Hello from Telegram', started_at or time.time())
+        (session_id, "Hello from Telegram", started_at or time.time()),
     )
     conn.execute(
         "INSERT INTO messages (session_id, role, content, timestamp) VALUES (?, 'assistant', ?, ?)",
-        (session_id, 'Hi there!', (started_at or time.time()) + 1)
+        (session_id, "Hi there!", (started_at or time.time()) + 1),
     )
     conn.commit()
 
@@ -153,9 +177,9 @@ def _insert_gateway_session(conn, session_id='20260401_120000_abcdefgh', source=
 def _insert_agent_session_row(
     conn,
     session_id,
-    source='weixin',
-    title='Agent Session',
-    model='openai/gpt-5',
+    source="weixin",
+    title="Agent Session",
+    model="openai/gpt-5",
     started_at=None,
     parent_session_id=None,
     ended_at=None,
@@ -186,8 +210,8 @@ def _insert_agent_session_row(
             "INSERT INTO messages (session_id, role, content, timestamp) VALUES (?, ?, ?, ?)",
             (
                 session_id,
-                'user' if i % 2 == 0 else 'assistant',
-                f'{title} message {i + 1}',
+                "user" if i % 2 == 0 else "assistant",
+                f"{title} message {i + 1}",
                 started_at + i,
             ),
         )
@@ -205,7 +229,11 @@ def _remove_test_sessions(conn, *session_ids):
 def _cleanup_state_db():
     """Remove state.db if it exists (only used for tests that need a blank slate)."""
     db_path = _get_state_db_path()
-    for p in [db_path, db_path.parent / 'state.db-wal', db_path.parent / 'state.db-shm']:
+    for p in [
+        db_path,
+        db_path.parent / "state.db-wal",
+        db_path.parent / "state.db-shm",
+    ]:
         try:
             p.unlink(missing_ok=True)
         except Exception:
@@ -221,83 +249,90 @@ def _insert_message(conn, sid, role, content, timestamp):
 
 # ── Tests ──────────────────────────────────────────────────────────────────
 
+
 def test_gateway_sessions_appear_when_enabled():
     """Gateway sessions from state.db appear in /api/sessions when show_cli_sessions is on."""
     conn = _ensure_state_db()
     try:
-        _insert_gateway_session(conn, session_id='gw_test_tg_001', source='telegram', title='TG Test Chat')
+        _insert_gateway_session(
+            conn, session_id="gw_test_tg_001", source="telegram", title="TG Test Chat"
+        )
 
         # Enable the setting
-        post('/api/settings', {'show_cli_sessions': True})
+        post("/api/settings", {"show_cli_sessions": True})
 
-        data, status = get('/api/sessions')
+        data, status = get("/api/sessions")
         assert status == 200
-        sessions = data.get('sessions', [])
-        gw_ids = [s['session_id'] for s in sessions if s.get('session_id') == 'gw_test_tg_001']
-        assert len(gw_ids) == 1, f"Expected gateway session gw_test_tg_001, got {[s['session_id'] for s in sessions]}"
+        sessions = data.get("sessions", [])
+        gw_ids = [
+            s["session_id"] for s in sessions if s.get("session_id") == "gw_test_tg_001"
+        ]
+        assert len(gw_ids) == 1, (
+            f"Expected gateway session gw_test_tg_001, got {[s['session_id'] for s in sessions]}"
+        )
     finally:
         try:
-            _remove_test_sessions(conn, 'gw_test_tg_001')
+            _remove_test_sessions(conn, "gw_test_tg_001")
             conn.close()
         except Exception:
             pass
-        post('/api/settings', {'show_cli_sessions': False})
+        post("/api/settings", {"show_cli_sessions": False})
 
 
 def test_webui_state_db_session_without_sidecar_appears_when_agent_sessions_enabled():
     """Regression: WebUI-origin rows in state.db can recover missing JSON sidecars."""
     conn = _ensure_state_db()
-    sid = 'webui_state_only_001'
+    sid = "webui_state_only_001"
     try:
         _insert_agent_session_row(
             conn,
             session_id=sid,
-            source='webui',
-            title='Recovered WebUI Session',
-            model='openai/gpt-5',
+            source="webui",
+            title="Recovered WebUI Session",
+            model="openai/gpt-5",
             messages=2,
         )
 
-        post('/api/settings', {'show_cli_sessions': True})
+        post("/api/settings", {"show_cli_sessions": True})
 
-        data, status = get('/api/sessions')
+        data, status = get("/api/sessions")
         assert status == 200
-        sessions = data.get('sessions', [])
-        recovered = [s for s in sessions if s.get('session_id') == sid]
+        sessions = data.get("sessions", [])
+        recovered = [s for s in sessions if s.get("session_id") == sid]
         assert len(recovered) == 1, (
             "WebUI-origin sessions that exist in state.db but have no JSON sidecar "
             "should be surfaced through the agent-session bridge for recovery."
         )
-        assert recovered[0].get('source_tag') == 'webui'
-        assert recovered[0].get('is_cli_session') is True
+        assert recovered[0].get("source_tag") == "webui"
+        assert recovered[0].get("is_cli_session") is True
     finally:
         try:
             _remove_test_sessions(conn, sid)
             conn.close()
         except Exception:
             pass
-        post('/api/settings', {'show_cli_sessions': False})
+        post("/api/settings", {"show_cli_sessions": False})
 
 
 def test_gateway_sessions_without_messages_are_hidden_from_sidebar():
     """Regression: empty agent session rows must not appear as broken sidebar entries."""
     conn = _ensure_state_db()
-    empty_sid = 'gw_empty_no_messages_001'
+    empty_sid = "gw_empty_no_messages_001"
     try:
         conn.execute(
             "INSERT OR REPLACE INTO sessions (id, source, title, model, started_at, message_count) "
             "VALUES (?, ?, ?, ?, ?, ?)",
-            (empty_sid, 'cron', 'Cron Session', 'openai/gpt-5', time.time(), 0),
+            (empty_sid, "cron", "Cron Session", "openai/gpt-5", time.time(), 0),
         )
         conn.execute("DELETE FROM messages WHERE session_id = ?", (empty_sid,))
         conn.commit()
 
-        post('/api/settings', {'show_cli_sessions': True})
+        post("/api/settings", {"show_cli_sessions": True})
 
-        data, status = get('/api/sessions')
+        data, status = get("/api/sessions")
         assert status == 200
-        sessions = data.get('sessions', [])
-        assert empty_sid not in {s.get('session_id') for s in sessions}, (
+        sessions = data.get("sessions", [])
+        assert empty_sid not in {s.get("session_id") for s in sessions}, (
             "Agent sessions with no readable message rows should be filtered before "
             "they reach the sidebar; otherwise clicking them fails during import."
         )
@@ -307,40 +342,47 @@ def test_gateway_sessions_without_messages_are_hidden_from_sidebar():
             conn.close()
         except Exception:
             pass
-        post('/api/settings', {'show_cli_sessions': False})
+        post("/api/settings", {"show_cli_sessions": False})
 
 
 def test_gateway_watcher_hides_sessions_without_messages(monkeypatch):
     """Regression: SSE watcher must use the same importable-agent filter."""
     conn = _ensure_state_db()
-    empty_sid = 'gw_empty_watcher_001'
-    live_sid = 'gw_live_watcher_001'
+    empty_sid = "gw_empty_watcher_001"
+    live_sid = "gw_live_watcher_001"
     try:
         conn.execute(
             "INSERT OR REPLACE INTO sessions (id, source, title, model, started_at, message_count) "
             "VALUES (?, ?, ?, ?, ?, ?)",
-            (empty_sid, 'telegram', 'Empty Telegram Session', 'openai/gpt-5', time.time(), 0),
+            (
+                empty_sid,
+                "telegram",
+                "Empty Telegram Session",
+                "openai/gpt-5",
+                time.time(),
+                0,
+            ),
         )
         conn.execute("DELETE FROM messages WHERE session_id = ?", (empty_sid,))
         _insert_gateway_session(
             conn,
             session_id=live_sid,
-            source='telegram',
-            title='Live Telegram Session',
+            source="telegram",
+            title="Live Telegram Session",
             message_count=0,
         )
 
         import api.gateway_watcher as gateway_watcher
 
-        monkeypatch.setattr(gateway_watcher, '_get_state_db_path', _get_state_db_path)
+        monkeypatch.setattr(gateway_watcher, "_get_state_db_path", _get_state_db_path)
 
         sessions = gateway_watcher._get_agent_sessions_from_db()
-        ids = {s.get('session_id') for s in sessions}
-        live = next((s for s in sessions if s.get('session_id') == live_sid), None)
+        ids = {s.get("session_id") for s in sessions}
+        live = next((s for s in sessions if s.get("session_id") == live_sid), None)
 
         assert empty_sid not in ids
         assert live is not None
-        assert live.get('message_count') == 2, (
+        assert live.get("message_count") == 2, (
             "Watcher should fall back to actual message rows when stored "
             "message_count is zero, matching the sidebar route."
         )
@@ -355,235 +397,255 @@ def test_gateway_watcher_hides_sessions_without_messages(monkeypatch):
 def test_compression_chain_collapses_to_latest_tip_in_sidebar():
     """Show one logical agent conversation for a compression continuation chain."""
     conn = _ensure_state_db()
-    ids_to_remove = ('chain_root_001', 'chain_empty_mid_001', 'chain_tip_001')
+    ids_to_remove = ("chain_root_001", "chain_empty_mid_001", "chain_tip_001")
     t0 = time.time() - 600
     try:
         _insert_agent_session_row(
             conn,
-            'chain_root_001',
-            title='Magazine Style PPT Skill',
+            "chain_root_001",
+            title="Magazine Style PPT Skill",
             started_at=t0,
             ended_at=t0 + 100,
-            end_reason='compression',
+            end_reason="compression",
             messages=3,
         )
         _insert_agent_session_row(
             conn,
-            'chain_empty_mid_001',
-            title='Magazine Style PPT Skill #2',
+            "chain_empty_mid_001",
+            title="Magazine Style PPT Skill #2",
             started_at=t0 + 101,
-            parent_session_id='chain_root_001',
+            parent_session_id="chain_root_001",
             ended_at=t0 + 200,
-            end_reason='compression',
+            end_reason="compression",
             messages=0,
         )
         _insert_agent_session_row(
             conn,
-            'chain_tip_001',
-            title='Magazine Style PPT Skill #3',
+            "chain_tip_001",
+            title="Magazine Style PPT Skill #3",
             started_at=t0 + 201,
-            parent_session_id='chain_empty_mid_001',
+            parent_session_id="chain_empty_mid_001",
             messages=2,
         )
 
-        post('/api/settings', {'show_cli_sessions': True})
-        data, status = get('/api/sessions')
+        post("/api/settings", {"show_cli_sessions": True})
+        data, status = get("/api/sessions")
         assert status == 200
-        ids = {s.get('session_id') for s in data.get('sessions', [])}
-        tip = next((s for s in data.get('sessions', []) if s.get('session_id') == 'chain_tip_001'), None)
+        ids = {s.get("session_id") for s in data.get("sessions", [])}
+        tip = next(
+            (
+                s
+                for s in data.get("sessions", [])
+                if s.get("session_id") == "chain_tip_001"
+            ),
+            None,
+        )
 
-        assert 'chain_tip_001' in ids
-        assert 'chain_root_001' not in ids
-        assert 'chain_empty_mid_001' not in ids
+        assert "chain_tip_001" in ids
+        assert "chain_root_001" not in ids
+        assert "chain_empty_mid_001" not in ids
         assert tip is not None
-        assert tip.get('title') == 'Magazine Style PPT Skill'
-        assert tip.get('message_count') == 2
+        assert tip.get("title") == "Magazine Style PPT Skill"
+        assert tip.get("message_count") == 2
         # created_at = the chain head's started_at (preserves original conversation date)
-        assert abs(tip.get('created_at') - t0) < 0.01
+        assert abs(tip.get("created_at") - t0) < 0.01
         # updated_at = the tip's last message timestamp so the sidebar entry
         # bubbles to the top by true recency, not by the root's stale activity.
         # tip messages are at t0+201 and t0+202, so last_activity = t0 + 202.
-        assert abs(tip.get('updated_at') - (t0 + 202)) < 0.01
-        assert tip.get('_lineage_root_id') == 'chain_root_001'
-        assert tip.get('_lineage_tip_id') == 'chain_tip_001'
-        assert tip.get('_compression_segment_count') == 3
+        assert abs(tip.get("updated_at") - (t0 + 202)) < 0.01
+        assert tip.get("_lineage_root_id") == "chain_root_001"
+        assert tip.get("_lineage_tip_id") == "chain_tip_001"
+        assert tip.get("_compression_segment_count") == 3
 
         from api.agent_sessions import read_importable_agent_session_rows
 
         rows = read_importable_agent_session_rows(_get_state_db_path(), limit=None)
-        projected_tip = next((row for row in rows if row.get('id') == 'chain_tip_001'), None)
+        projected_tip = next(
+            (row for row in rows if row.get("id") == "chain_tip_001"), None
+        )
         assert projected_tip is not None
-        assert projected_tip.get('title') == 'Magazine Style PPT Skill'
-        assert projected_tip.get('_lineage_root_id') == 'chain_root_001'
-        assert projected_tip.get('_lineage_tip_id') == 'chain_tip_001'
-        assert projected_tip.get('_compression_segment_count') == 3
+        assert projected_tip.get("title") == "Magazine Style PPT Skill"
+        assert projected_tip.get("_lineage_root_id") == "chain_root_001"
+        assert projected_tip.get("_lineage_tip_id") == "chain_tip_001"
+        assert projected_tip.get("_compression_segment_count") == 3
     finally:
         try:
             _remove_test_sessions(conn, *ids_to_remove)
             conn.close()
         except Exception:
             pass
-        post('/api/settings', {'show_cli_sessions': False})
+        post("/api/settings", {"show_cli_sessions": False})
 
 
 def test_compression_chain_with_empty_latest_tip_falls_back_to_latest_importable_segment():
     """Empty latest tips should not make the whole conversation disappear."""
     conn = _ensure_state_db()
-    ids_to_remove = ('empty_tip_root_001', 'empty_tip_001')
+    ids_to_remove = ("empty_tip_root_001", "empty_tip_001")
     t0 = time.time() - 500
     try:
         _insert_agent_session_row(
             conn,
-            'empty_tip_root_001',
-            title='Long Conversation',
+            "empty_tip_root_001",
+            title="Long Conversation",
             started_at=t0,
             ended_at=t0 + 100,
-            end_reason='compression',
+            end_reason="compression",
             messages=2,
         )
         _insert_agent_session_row(
             conn,
-            'empty_tip_001',
-            title='Long Conversation #2',
+            "empty_tip_001",
+            title="Long Conversation #2",
             started_at=t0 + 101,
-            parent_session_id='empty_tip_root_001',
+            parent_session_id="empty_tip_root_001",
             messages=0,
         )
 
-        post('/api/settings', {'show_cli_sessions': True})
-        data, status = get('/api/sessions')
+        post("/api/settings", {"show_cli_sessions": True})
+        data, status = get("/api/sessions")
         assert status == 200
-        ids = {s.get('session_id') for s in data.get('sessions', [])}
+        ids = {s.get("session_id") for s in data.get("sessions", [])}
 
-        assert 'empty_tip_root_001' in ids
-        assert 'empty_tip_001' not in ids
-        root = next((s for s in data.get('sessions', []) if s.get('session_id') == 'empty_tip_root_001'), None)
-        assert root and root.get('title') == 'Long Conversation'
+        assert "empty_tip_root_001" in ids
+        assert "empty_tip_001" not in ids
+        root = next(
+            (
+                s
+                for s in data.get("sessions", [])
+                if s.get("session_id") == "empty_tip_root_001"
+            ),
+            None,
+        )
+        assert root and root.get("title") == "Long Conversation"
     finally:
         try:
             _remove_test_sessions(conn, *ids_to_remove)
             conn.close()
         except Exception:
             pass
-        post('/api/settings', {'show_cli_sessions': False})
+        post("/api/settings", {"show_cli_sessions": False})
 
 
 def test_compression_chain_with_all_empty_segments_is_hidden():
     """A compression chain with no importable segment should not appear."""
     conn = _ensure_state_db()
-    ids_to_remove = ('all_empty_root_001', 'all_empty_tip_001')
+    ids_to_remove = ("all_empty_root_001", "all_empty_tip_001")
     t0 = time.time() - 450
     try:
         _insert_agent_session_row(
             conn,
-            'all_empty_root_001',
-            title='Empty Long Conversation',
+            "all_empty_root_001",
+            title="Empty Long Conversation",
             started_at=t0,
             ended_at=t0 + 100,
-            end_reason='compression',
+            end_reason="compression",
             messages=0,
         )
         _insert_agent_session_row(
             conn,
-            'all_empty_tip_001',
-            title='Empty Long Conversation #2',
+            "all_empty_tip_001",
+            title="Empty Long Conversation #2",
             started_at=t0 + 101,
-            parent_session_id='all_empty_root_001',
+            parent_session_id="all_empty_root_001",
             messages=0,
         )
 
-        post('/api/settings', {'show_cli_sessions': True})
-        data, status = get('/api/sessions')
+        post("/api/settings", {"show_cli_sessions": True})
+        data, status = get("/api/sessions")
         assert status == 200
-        ids = {s.get('session_id') for s in data.get('sessions', [])}
+        ids = {s.get("session_id") for s in data.get("sessions", [])}
 
-        assert 'all_empty_root_001' not in ids
-        assert 'all_empty_tip_001' not in ids
+        assert "all_empty_root_001" not in ids
+        assert "all_empty_tip_001" not in ids
     finally:
         try:
             _remove_test_sessions(conn, *ids_to_remove)
             conn.close()
         except Exception:
             pass
-        post('/api/settings', {'show_cli_sessions': False})
+        post("/api/settings", {"show_cli_sessions": False})
 
 
 def test_default_title_cli_compression_chain_is_kept_by_lineage():
     """Default-titled CLI compression chains are meaningful even with a short tip."""
     conn = _ensure_state_db()
-    ids_to_remove = ('cli_default_compress_root_001', 'cli_default_compress_tip_001')
+    ids_to_remove = ("cli_default_compress_root_001", "cli_default_compress_tip_001")
     t0 = time.time() - 430
     try:
         _insert_agent_session_row(
             conn,
-            'cli_default_compress_root_001',
-            source='cli',
-            title='Cli Session',
+            "cli_default_compress_root_001",
+            source="cli",
+            title="Cli Session",
             started_at=t0,
             ended_at=t0 + 100,
-            end_reason='compression',
+            end_reason="compression",
             messages=1,
         )
         _insert_agent_session_row(
             conn,
-            'cli_default_compress_tip_001',
-            source='cli',
-            title='Cli Session',
+            "cli_default_compress_tip_001",
+            source="cli",
+            title="Cli Session",
             started_at=t0 + 101,
-            parent_session_id='cli_default_compress_root_001',
+            parent_session_id="cli_default_compress_root_001",
             messages=1,
         )
 
-        post('/api/settings', {'show_cli_sessions': True})
-        data, status = get('/api/sessions')
+        post("/api/settings", {"show_cli_sessions": True})
+        data, status = get("/api/sessions")
         assert status == 200
-        ids = {s.get('session_id') for s in data.get('sessions', [])}
+        ids = {s.get("session_id") for s in data.get("sessions", [])}
 
-        assert 'cli_default_compress_tip_001' in ids
-        assert 'cli_default_compress_root_001' not in ids
-        tip = next(s for s in data.get('sessions', []) if s.get('session_id') == 'cli_default_compress_tip_001')
-        assert tip.get('_compression_segment_count') == 2
-        assert tip.get('_lineage_root_id') == 'cli_default_compress_root_001'
+        assert "cli_default_compress_tip_001" in ids
+        assert "cli_default_compress_root_001" not in ids
+        tip = next(
+            s
+            for s in data.get("sessions", [])
+            if s.get("session_id") == "cli_default_compress_tip_001"
+        )
+        assert tip.get("_compression_segment_count") == 2
+        assert tip.get("_lineage_root_id") == "cli_default_compress_root_001"
     finally:
         try:
             _remove_test_sessions(conn, *ids_to_remove)
             conn.close()
         except Exception:
             pass
-        post('/api/settings', {'show_cli_sessions': False})
+        post("/api/settings", {"show_cli_sessions": False})
 
 
 def test_non_compression_child_is_not_collapsed_into_parent():
     """Parent/child relationships that are not compression continuations stay flat."""
     conn = _ensure_state_db()
-    ids_to_remove = ('branch_parent_001', 'branch_child_001')
+    ids_to_remove = ("branch_parent_001", "branch_child_001")
     t0 = time.time() - 400
     try:
         _insert_agent_session_row(
             conn,
-            'branch_parent_001',
-            title='Branch Parent',
+            "branch_parent_001",
+            title="Branch Parent",
             started_at=t0,
             ended_at=t0 + 100,
-            end_reason='branched',
+            end_reason="branched",
             messages=2,
         )
         _insert_agent_session_row(
             conn,
-            'branch_child_001',
-            title='Branch Child',
+            "branch_child_001",
+            title="Branch Child",
             started_at=t0 + 101,
-            parent_session_id='branch_parent_001',
+            parent_session_id="branch_parent_001",
             messages=2,
         )
 
         from api.agent_sessions import read_importable_agent_session_rows
 
         rows = read_importable_agent_session_rows(_get_state_db_path(), limit=None)
-        ids = {row.get('id') for row in rows}
+        ids = {row.get("id") for row in rows}
 
-        assert 'branch_parent_001' in ids
-        assert 'branch_child_001' in ids
+        assert "branch_parent_001" in ids
+        assert "branch_child_001" in ids
     finally:
         try:
             _remove_test_sessions(conn, *ids_to_remove)
@@ -595,25 +657,25 @@ def test_non_compression_child_is_not_collapsed_into_parent():
 def test_agent_session_limit_applies_after_compression_projection():
     """A long raw chain should count as one logical sidebar row before limiting."""
     conn = _ensure_state_db()
-    chain_ids = [f'limit_chain_{i:03d}' for i in range(8)]
-    standalone_id = 'limit_standalone_001'
+    chain_ids = [f"limit_chain_{i:03d}" for i in range(8)]
+    standalone_id = "limit_standalone_001"
     t0 = time.time() - 300
     try:
         for i, sid in enumerate(chain_ids):
             _insert_agent_session_row(
                 conn,
                 sid,
-                title=f'Limit Chain #{i + 1}',
+                title=f"Limit Chain #{i + 1}",
                 started_at=t0 + i,
                 parent_session_id=chain_ids[i - 1] if i else None,
                 ended_at=t0 + i + 0.5 if i < len(chain_ids) - 1 else None,
-                end_reason='compression' if i < len(chain_ids) - 1 else None,
+                end_reason="compression" if i < len(chain_ids) - 1 else None,
                 messages=1,
             )
         _insert_agent_session_row(
             conn,
             standalone_id,
-            title='Limit Standalone',
+            title="Limit Standalone",
             started_at=t0 + 20,
             messages=1,
         )
@@ -621,16 +683,16 @@ def test_agent_session_limit_applies_after_compression_projection():
         from api.agent_sessions import read_importable_agent_session_rows
 
         rows = read_importable_agent_session_rows(_get_state_db_path(), limit=2)
-        ids = [row.get('id') for row in rows]
+        ids = [row.get("id") for row in rows]
 
         assert len(rows) == 2
         assert chain_ids[-1] in ids
         assert standalone_id in ids
         assert not any(sid in ids for sid in chain_ids[:-1])
-        chain = next(row for row in rows if row.get('id') == chain_ids[-1])
-        assert chain.get('title') == 'Limit Chain #1'
-        assert chain.get('_lineage_root_id') == chain_ids[0]
-        assert chain.get('_compression_segment_count') == len(chain_ids)
+        chain = next(row for row in rows if row.get("id") == chain_ids[-1])
+        assert chain.get("title") == "Limit Chain #1"
+        assert chain.get("_lineage_root_id") == chain_ids[0]
+        assert chain.get("_compression_segment_count") == len(chain_ids)
     finally:
         try:
             _remove_test_sessions(conn, *(chain_ids + [standalone_id]))
@@ -650,7 +712,7 @@ def test_compression_chain_bubbles_to_top_by_tip_activity():
     recency. This regression test pins the override.
     """
     conn = _ensure_state_db()
-    ids_to_remove = ('bubble_root_001', 'bubble_tip_001', 'bubble_standalone_001')
+    ids_to_remove = ("bubble_root_001", "bubble_tip_001", "bubble_standalone_001")
     now = time.time()
     # Root started long ago; tip is being edited "now" (very recent message)
     root_started = now - 30 * 86400
@@ -664,62 +726,68 @@ def test_compression_chain_bubbles_to_top_by_tip_activity():
     try:
         _insert_agent_session_row(
             conn,
-            'bubble_root_001',
-            title='Bubble Root',
+            "bubble_root_001",
+            title="Bubble Root",
             started_at=root_started,
             ended_at=root_ended,
-            end_reason='compression',
+            end_reason="compression",
             messages=2,
         )
         # Override message timestamps so root's last_activity is genuinely old.
         conn.execute("DELETE FROM messages WHERE session_id = 'bubble_root_001'")
         conn.execute(
             "INSERT INTO messages (session_id, role, content, timestamp) VALUES (?, ?, ?, ?)",
-            ('bubble_root_001', 'user', 'old root msg', root_started + 60),
+            ("bubble_root_001", "user", "old root msg", root_started + 60),
         )
         _insert_agent_session_row(
             conn,
-            'bubble_tip_001',
-            title='Bubble Tip',
+            "bubble_tip_001",
+            title="Bubble Tip",
             started_at=tip_started,
-            parent_session_id='bubble_root_001',
+            parent_session_id="bubble_root_001",
             messages=1,
         )
         conn.execute("DELETE FROM messages WHERE session_id = 'bubble_tip_001'")
         conn.execute(
             "INSERT INTO messages (session_id, role, content, timestamp) VALUES (?, ?, ?, ?)",
-            ('bubble_tip_001', 'user', 'fresh tip msg', tip_latest_msg),
+            ("bubble_tip_001", "user", "fresh tip msg", tip_latest_msg),
         )
         _insert_agent_session_row(
             conn,
-            'bubble_standalone_001',
-            title='Bubble Standalone',
+            "bubble_standalone_001",
+            title="Bubble Standalone",
             started_at=now - 2 * 86400 - 60,
             messages=1,
         )
         conn.execute("DELETE FROM messages WHERE session_id = 'bubble_standalone_001'")
         conn.execute(
             "INSERT INTO messages (session_id, role, content, timestamp) VALUES (?, ?, ?, ?)",
-            ('bubble_standalone_001', 'user', 'standalone msg', standalone_msg),
+            ("bubble_standalone_001", "user", "standalone msg", standalone_msg),
         )
         conn.commit()
 
         from api.agent_sessions import read_importable_agent_session_rows
 
         rows = read_importable_agent_session_rows(_get_state_db_path(), limit=200)
-        ids = [row.get('id') for row in rows]
+        ids = [row.get("id") for row in rows]
         # Filter out unrelated rows from the shared DB
-        ids = [i for i in ids if i in ('bubble_root_001', 'bubble_tip_001', 'bubble_standalone_001')]
+        ids = [
+            i
+            for i in ids
+            if i in ("bubble_root_001", "bubble_tip_001", "bubble_standalone_001")
+        ]
 
-        assert 'bubble_tip_001' in ids, (
+        assert "bubble_tip_001" in ids, (
             f"Compression tip must appear in projected output. ids={ids}"
         )
-        assert 'bubble_root_001' not in ids, (
+        assert "bubble_root_001" not in ids, (
             "Compression root row must be hidden once the tip is the active row."
         )
 
-        tip_pos = ids.index('bubble_tip_001')
-        standalone_pos = ids.index('bubble_standalone_001') if 'bubble_standalone_001' in ids else -1
+        tip_pos = ids.index("bubble_tip_001")
+        standalone_pos = (
+            ids.index("bubble_standalone_001") if "bubble_standalone_001" in ids else -1
+        )
         assert standalone_pos == -1 or tip_pos < standalone_pos, (
             f"Active compression tip (last msg 5s ago) must sort BEFORE standalone "
             f"session (last msg 2d ago). Got order: {ids}. "
@@ -727,8 +795,8 @@ def test_compression_chain_bubbles_to_top_by_tip_activity():
             f"not the tip's recent value."
         )
 
-        tip_row = next(r for r in rows if r['id'] == 'bubble_tip_001')
-        assert abs(tip_row['last_activity'] - tip_latest_msg) < 0.01, (
+        tip_row = next(r for r in rows if r["id"] == "bubble_tip_001")
+        assert abs(tip_row["last_activity"] - tip_latest_msg) < 0.01, (
             f"Projected tip's last_activity must equal the tip's most recent "
             f"message timestamp ({tip_latest_msg}), not the root's "
             f"({root_started + 60}). Got: {tip_row['last_activity']}"
@@ -745,19 +813,23 @@ def test_gateway_sessions_excluded_when_disabled():
     """Gateway sessions are NOT returned when show_cli_sessions is off."""
     conn = _ensure_state_db()
     try:
-        _insert_gateway_session(conn, session_id='gw_test_dc_001', source='discord', title='DC Test Chat')
+        _insert_gateway_session(
+            conn, session_id="gw_test_dc_001", source="discord", title="DC Test Chat"
+        )
 
         # Ensure setting is off
-        post('/api/settings', {'show_cli_sessions': False})
+        post("/api/settings", {"show_cli_sessions": False})
 
-        data, status = get('/api/sessions')
+        data, status = get("/api/sessions")
         assert status == 200
-        sessions = data.get('sessions', [])
-        gw_ids = [s['session_id'] for s in sessions if s.get('session_id') == 'gw_test_dc_001']
+        sessions = data.get("sessions", [])
+        gw_ids = [
+            s["session_id"] for s in sessions if s.get("session_id") == "gw_test_dc_001"
+        ]
         assert len(gw_ids) == 0, "Gateway session should not appear when setting is off"
     finally:
         try:
-            _remove_test_sessions(conn, 'gw_test_dc_001')
+            _remove_test_sessions(conn, "gw_test_dc_001")
             conn.close()
         except Exception:
             pass
@@ -767,28 +839,34 @@ def test_gateway_session_has_correct_metadata():
     """Gateway sessions include legacy source fields and normalized source metadata."""
     conn = _ensure_state_db()
     try:
-        _insert_gateway_session(conn, session_id='gw_meta_001', source='telegram', title='Meta Test')
+        _insert_gateway_session(
+            conn, session_id="gw_meta_001", source="telegram", title="Meta Test"
+        )
 
-        post('/api/settings', {'show_cli_sessions': True})
+        post("/api/settings", {"show_cli_sessions": True})
 
-        data, status = get('/api/sessions')
+        data, status = get("/api/sessions")
         assert status == 200
-        sessions = data.get('sessions', [])
-        gw = next((s for s in sessions if s['session_id'] == 'gw_meta_001'), None)
+        sessions = data.get("sessions", [])
+        gw = next((s for s in sessions if s["session_id"] == "gw_meta_001"), None)
         assert gw is not None, "Gateway session not found"
-        assert gw.get('source_tag') == 'telegram', f"Expected source_tag=telegram, got {gw.get('source_tag')}"
-        assert gw.get('raw_source') == 'telegram'
-        assert gw.get('session_source') == 'messaging'
-        assert gw.get('source_label') == 'Telegram'
-        assert gw.get('is_cli_session') is True, "is_cli_session should be True for agent sessions"
-        assert gw.get('title') == 'Meta Test'
+        assert gw.get("source_tag") == "telegram", (
+            f"Expected source_tag=telegram, got {gw.get('source_tag')}"
+        )
+        assert gw.get("raw_source") == "telegram"
+        assert gw.get("session_source") == "messaging"
+        assert gw.get("source_label") == "Telegram"
+        assert gw.get("is_cli_session") is True, (
+            "is_cli_session should be True for agent sessions"
+        )
+        assert gw.get("title") == "Meta Test"
     finally:
         try:
-            _remove_test_sessions(conn, 'gw_meta_001')
+            _remove_test_sessions(conn, "gw_meta_001")
             conn.close()
         except Exception:
             pass
-        post('/api/settings', {'show_cli_sessions': False})
+        post("/api/settings", {"show_cli_sessions": False})
 
 
 def test_agent_session_source_normalization_contract():
@@ -796,29 +874,31 @@ def test_agent_session_source_normalization_contract():
     from api.agent_sessions import normalize_agent_session_source
 
     cases = {
-        'cli': ('cli', 'CLI'),
-        'weixin': ('messaging', 'Weixin'),
-        'telegram': ('messaging', 'Telegram'),
-        'discord': ('messaging', 'Discord'),
-        'slack': ('messaging', 'Slack'),
-        'cron': ('cron', 'Cron'),
-        'tool': ('tool', 'Tool'),
-        'api_server': ('api', 'API'),
-        'something_new': ('other', 'Something New'),
-        None: ('other', 'Agent'),
+        "cli": ("cli", "CLI"),
+        "weixin": ("messaging", "Weixin"),
+        "telegram": ("messaging", "Telegram"),
+        "discord": ("messaging", "Discord"),
+        "slack": ("messaging", "Slack"),
+        "cron": ("cron", "Cron"),
+        "tool": ("tool", "Tool"),
+        "api_server": ("api", "API"),
+        "something_new": ("other", "Something New"),
+        None: ("other", "Agent"),
     }
 
     for raw_source, (session_source, source_label) in cases.items():
         normalized = normalize_agent_session_source(raw_source)
-        assert normalized['session_source'] == session_source
-        assert normalized['source_label'] == source_label
+        assert normalized["session_source"] == session_source
+        assert normalized["source_label"] == source_label
         if raw_source:
-            assert normalized['raw_source'] == raw_source
+            assert normalized["raw_source"] == raw_source
         else:
-            assert normalized['raw_source'] is None
+            assert normalized["raw_source"] is None
 
 
-def test_cross_source_parent_child_is_not_collapsed_into_root_metadata(cleanup_test_sessions):
+def test_cross_source_parent_child_is_not_collapsed_into_root_metadata(
+    cleanup_test_sessions,
+):
     """A WebUI continuation from a messaging parent must keep WebUI metadata.
 
     Regression for a production case where a WebUI session continued from a
@@ -828,43 +908,45 @@ def test_cross_source_parent_child_is_not_collapsed_into_root_metadata(cleanup_t
     from api.agent_sessions import read_importable_agent_session_rows
 
     conn = _ensure_state_db()
-    root_sid = 'gw_tg_cross_source_root_001'
-    webui_sid = 'webui_cross_source_tip_001'
+    root_sid = "gw_tg_cross_source_root_001"
+    webui_sid = "webui_cross_source_tip_001"
     now = time.time()
     cleanup_test_sessions.extend([root_sid, webui_sid])
     try:
         _insert_agent_session_row(
             conn,
             session_id=root_sid,
-            source='telegram',
-            title='Old Telegram Root',
+            source="telegram",
+            title="Old Telegram Root",
             started_at=now - 20,
             ended_at=now - 10,
-            end_reason='compression',
+            end_reason="compression",
             messages=2,
         )
         _insert_agent_session_row(
             conn,
             session_id=webui_sid,
-            source='webui',
-            title='Current WebUI Work',
+            source="webui",
+            title="Current WebUI Work",
             started_at=now - 9,
             parent_session_id=root_sid,
             messages=2,
         )
 
-        rows = read_importable_agent_session_rows(_get_state_db_path(), exclude_sources=None)
-        by_id = {row['id']: row for row in rows}
+        rows = read_importable_agent_session_rows(
+            _get_state_db_path(), exclude_sources=None
+        )
+        by_id = {row["id"]: row for row in rows}
 
         assert webui_sid in by_id
         assert root_sid in by_id
         webui = by_id[webui_sid]
-        assert webui.get('title') == 'Current WebUI Work'
-        assert webui.get('source') == 'webui'
-        assert webui.get('session_source') == 'webui'
-        assert webui.get('source_label') == 'WebUI'
-        assert webui.get('relationship_type') == 'child_session'
-        assert webui.get('parent_title') == 'Old Telegram Root'
+        assert webui.get("title") == "Current WebUI Work"
+        assert webui.get("source") == "webui"
+        assert webui.get("session_source") == "webui"
+        assert webui.get("source_label") == "WebUI"
+        assert webui.get("relationship_type") == "child_session"
+        assert webui.get("parent_title") == "Old Telegram Root"
     finally:
         try:
             _remove_test_sessions(conn, root_sid, webui_sid)
@@ -877,22 +959,29 @@ def test_gateway_watcher_uses_normalized_source_metadata(monkeypatch):
     """SSE snapshots use the same normalized source contract as /api/sessions."""
     conn = _ensure_state_db()
     try:
-        _insert_gateway_session(conn, session_id='gw_watcher_source_001', source='weixin', title='Weixin Chat')
+        _insert_gateway_session(
+            conn,
+            session_id="gw_watcher_source_001",
+            source="weixin",
+            title="Weixin Chat",
+        )
 
         import api.gateway_watcher as gateway_watcher
 
-        monkeypatch.setattr(gateway_watcher, '_get_state_db_path', _get_state_db_path)
+        monkeypatch.setattr(gateway_watcher, "_get_state_db_path", _get_state_db_path)
         sessions = gateway_watcher._get_agent_sessions_from_db()
-        gw = next((s for s in sessions if s['session_id'] == 'gw_watcher_source_001'), None)
+        gw = next(
+            (s for s in sessions if s["session_id"] == "gw_watcher_source_001"), None
+        )
 
         assert gw is not None
-        assert gw.get('source') == 'weixin'
-        assert gw.get('raw_source') == 'weixin'
-        assert gw.get('session_source') == 'messaging'
-        assert gw.get('source_label') == 'Weixin'
+        assert gw.get("source") == "weixin"
+        assert gw.get("raw_source") == "weixin"
+        assert gw.get("session_source") == "messaging"
+        assert gw.get("source_label") == "Weixin"
     finally:
         try:
-            _remove_test_sessions(conn, 'gw_watcher_source_001')
+            _remove_test_sessions(conn, "gw_watcher_source_001")
             conn.close()
         except Exception:
             pass
@@ -902,45 +991,49 @@ def test_imported_cli_session_metadata_survives_compact(cleanup_test_sessions):
     """Imported agent sessions should remain distinguishable in compact sidebar payloads."""
     from api.models import Session
 
-    sid = 'gw_imported_metadata_001'
+    sid = "gw_imported_metadata_001"
     cleanup_test_sessions.append(sid)
     s = Session(
         session_id=sid,
-        title='Imported Telegram Chat',
-        messages=[{'role': 'user', 'content': 'hello from telegram', 'timestamp': time.time()}],
-        model='openai/gpt-5',
+        title="Imported Telegram Chat",
+        messages=[
+            {"role": "user", "content": "hello from telegram", "timestamp": time.time()}
+        ],
+        model="openai/gpt-5",
     )
     s.is_cli_session = True
-    s.source_tag = 'telegram'
-    s.session_source = 'messaging'
-    s.source_label = 'Telegram'
+    s.source_tag = "telegram"
+    s.session_source = "messaging"
+    s.source_label = "Telegram"
     s.save(touch_updated_at=False)
 
     loaded = Session.load_metadata_only(sid)
     compact = loaded.compact()
 
-    assert compact['is_cli_session'] is True
-    assert compact['source_tag'] == 'telegram'
-    assert compact['session_source'] == 'messaging'
-    assert compact['source_label'] == 'Telegram'
+    assert compact["is_cli_session"] is True
+    assert compact["source_tag"] == "telegram"
+    assert compact["session_source"] == "messaging"
+    assert compact["source_label"] == "Telegram"
 
 
 def test_import_cli_preserves_messaging_source_metadata(cleanup_test_sessions):
     """Importing a messaging agent session should keep source metadata for WebUI policy."""
     conn = _ensure_state_db()
-    sid = 'gw_import_weixin_meta_001'
+    sid = "gw_import_weixin_meta_001"
     cleanup_test_sessions.append(sid)
     try:
-        _insert_gateway_session(conn, session_id=sid, source='weixin', title='Weixin Session')
+        _insert_gateway_session(
+            conn, session_id=sid, source="weixin", title="Weixin Session"
+        )
 
-        data, status = post('/api/session/import_cli', {'session_id': sid})
+        data, status = post("/api/session/import_cli", {"session_id": sid})
         assert status == 200
-        session = data.get('session', {})
-        assert session.get('is_cli_session') is True
-        assert session.get('source_tag') == 'weixin'
-        assert session.get('raw_source') == 'weixin'
-        assert session.get('session_source') == 'messaging'
-        assert session.get('source_label') == 'Weixin'
+        session = data.get("session", {})
+        assert session.get("is_cli_session") is True
+        assert session.get("source_tag") == "weixin"
+        assert session.get("raw_source") == "weixin"
+        assert session.get("session_source") == "messaging"
+        assert session.get("source_label") == "Weixin"
     finally:
         try:
             _remove_test_sessions(conn, sid)
@@ -949,122 +1042,154 @@ def test_import_cli_preserves_messaging_source_metadata(cleanup_test_sessions):
             pass
 
 
-def test_sessions_response_backfills_imported_messaging_source_metadata(cleanup_test_sessions):
+def test_sessions_response_backfills_imported_messaging_source_metadata(
+    cleanup_test_sessions,
+):
     """Old imported messaging sessions should still expose source metadata in /api/sessions."""
     from api.models import Session
 
     conn = _ensure_state_db()
-    sid = 'gw_legacy_import_weixin_001'
+    sid = "gw_legacy_import_weixin_001"
     cleanup_test_sessions.append(sid)
     try:
-        _insert_gateway_session(conn, session_id=sid, source='weixin', title='Weixin Session')
+        _insert_gateway_session(
+            conn, session_id=sid, source="weixin", title="Weixin Session"
+        )
         s = Session(
             session_id=sid,
-            title='Legacy Imported Weixin',
-            messages=[{'role': 'user', 'content': 'hello', 'timestamp': time.time()}],
-            model='openai/gpt-5',
+            title="Legacy Imported Weixin",
+            messages=[{"role": "user", "content": "hello", "timestamp": time.time()}],
+            model="openai/gpt-5",
         )
         s.is_cli_session = True
         s.save(touch_updated_at=False)
-        post('/api/settings', {'show_cli_sessions': True})
+        post("/api/settings", {"show_cli_sessions": True})
 
-        data, status = get('/api/sessions')
+        data, status = get("/api/sessions")
         assert status == 200
-        session = next(item for item in data.get('sessions', []) if item.get('session_id') == sid)
-        assert session.get('source_tag') == 'weixin'
-        assert session.get('raw_source') == 'weixin'
-        assert session.get('session_source') == 'messaging'
-        assert session.get('source_label') == 'Weixin'
+        session = next(
+            item for item in data.get("sessions", []) if item.get("session_id") == sid
+        )
+        assert session.get("source_tag") == "weixin"
+        assert session.get("raw_source") == "weixin"
+        assert session.get("session_source") == "messaging"
+        assert session.get("source_label") == "Weixin"
     finally:
         try:
-            post('/api/settings', {'show_cli_sessions': False})
+            post("/api/settings", {"show_cli_sessions": False})
             _remove_test_sessions(conn, sid)
             conn.close()
         except Exception:
             pass
 
 
-def test_sessions_response_keeps_only_latest_messaging_session_per_source(cleanup_test_sessions):
+def test_sessions_response_keeps_only_latest_messaging_session_per_source(
+    cleanup_test_sessions,
+):
     """Sidebar should keep messaging sessions by stable identity, not source-wide."""
     from api.models import Session
 
     conn = _ensure_state_db()
-    old_sid = 'gw_old_weixin_visible_001'
-    new_sid = 'gw_new_weixin_visible_001'
+    old_sid = "gw_old_weixin_visible_001"
+    new_sid = "gw_new_weixin_visible_001"
     cleanup_test_sessions.extend([old_sid, new_sid])
     try:
-        _insert_gateway_session(conn, session_id=old_sid, source='weixin', title='Old Weixin', started_at=time.time() - 100)
-        _insert_gateway_session(conn, session_id=new_sid, source='weixin', title='New Weixin', started_at=time.time())
+        _insert_gateway_session(
+            conn,
+            session_id=old_sid,
+            source="weixin",
+            title="Old Weixin",
+            started_at=time.time() - 100,
+        )
+        _insert_gateway_session(
+            conn,
+            session_id=new_sid,
+            source="weixin",
+            title="New Weixin",
+            started_at=time.time(),
+        )
 
         old = Session(
             session_id=old_sid,
-            title='Old Imported Weixin',
-            messages=[{'role': 'user', 'content': 'old', 'timestamp': time.time() - 100}],
-            model='openai/gpt-5',
+            title="Old Imported Weixin",
+            messages=[
+                {"role": "user", "content": "old", "timestamp": time.time() - 100}
+            ],
+            model="openai/gpt-5",
         )
         old.is_cli_session = True
         old.save(touch_updated_at=False)
-        post('/api/settings', {'show_cli_sessions': True})
+        post("/api/settings", {"show_cli_sessions": True})
 
-        data, status = get('/api/sessions')
+        data, status = get("/api/sessions")
         assert status == 200
-        ids = {item.get('session_id') for item in data.get('sessions', [])}
+        ids = {item.get("session_id") for item in data.get("sessions", [])}
         assert new_sid in ids
         assert old_sid not in ids
     finally:
         try:
-            post('/api/settings', {'show_cli_sessions': False})
+            post("/api/settings", {"show_cli_sessions": False})
             _remove_test_sessions(conn, old_sid, new_sid)
             conn.close()
         except Exception:
             pass
 
 
-def test_sessions_response_keeps_distinct_messaging_sessions_for_distinct_users(cleanup_test_sessions):
+def test_sessions_response_keeps_distinct_messaging_sessions_for_distinct_users(
+    cleanup_test_sessions,
+):
     """Messaging collapse should survive for different users on the same platform."""
     conn = _ensure_state_db()
-    sid_a = 'gw_tg_distinct_user_a'
-    sid_b = 'gw_tg_distinct_user_b'
+    sid_a = "gw_tg_distinct_user_a"
+    sid_b = "gw_tg_distinct_user_b"
     cleanup_test_sessions.extend([sid_a, sid_b])
     try:
         _insert_gateway_session(
             conn,
             session_id=sid_a,
-            source='telegram',
-            title='TG User A',
-            user_id='1143399746',
+            source="telegram",
+            title="TG User A",
+            user_id="1143399746",
             started_at=time.time() - 20,
         )
         _insert_gateway_session(
             conn,
             session_id=sid_b,
-            source='telegram',
-            title='TG User B',
-            user_id='9988776655',
+            source="telegram",
+            title="TG User B",
+            user_id="9988776655",
             started_at=time.time(),
         )
 
-        post('/api/settings', {'show_cli_sessions': True})
-        data, status = get('/api/sessions')
+        post("/api/settings", {"show_cli_sessions": True})
+        data, status = get("/api/sessions")
         assert status == 200
-        ids = {s['session_id'] for s in data.get('sessions', []) if s.get('session_id') in {sid_a, sid_b}}
-        assert ids == {sid_a, sid_b}, f"Expected both Telegram sessions to remain, got {ids}"
+        ids = {
+            s["session_id"]
+            for s in data.get("sessions", [])
+            if s.get("session_id") in {sid_a, sid_b}
+        }
+        assert ids == {sid_a, sid_b}, (
+            f"Expected both Telegram sessions to remain, got {ids}"
+        )
     finally:
         try:
-            post('/api/settings', {'show_cli_sessions': False})
+            post("/api/settings", {"show_cli_sessions": False})
             _remove_test_sessions(conn, sid_a, sid_b)
             conn.close()
         except Exception:
             pass
 
 
-def test_sessions_response_distinguishes_same_user_different_chat_identity_from_gateway_metadata(cleanup_test_sessions):
+def test_sessions_response_distinguishes_same_user_different_chat_identity_from_gateway_metadata(
+    cleanup_test_sessions,
+):
     """Same user_id sessions should stay separate when gateway metadata exposes chat identity."""
     conn = _ensure_state_db()
-    sid_dm = 'gw_tg_same_user_dm'
-    sid_group = 'gw_tg_same_user_group'
+    sid_dm = "gw_tg_same_user_dm"
+    sid_group = "gw_tg_same_user_group"
     cleanup_test_sessions.extend([sid_dm, sid_group])
-    sessions_file = _get_test_state_dir() / 'sessions' / 'sessions.json'
+    sessions_file = _get_test_state_dir() / "sessions" / "sessions.json"
     original_sessions_json = None
     if sessions_file.exists():
         original_sessions_json = sessions_file.read_text()
@@ -1092,23 +1217,43 @@ def test_sessions_response_distinguishes_same_user_different_chat_identity_from_
         },
     }
     try:
-        sessions_file.write_text(json.dumps(sessions_payload), encoding='utf-8')
-        _insert_gateway_session(conn, session_id=sid_dm, source='telegram', title='DM Same User', user_id='1143399746', started_at=time.time() - 40)
-        _insert_gateway_session(conn, session_id=sid_group, source='telegram', title='Group Same User', user_id='1143399746', started_at=time.time())
+        sessions_file.write_text(json.dumps(sessions_payload), encoding="utf-8")
+        _insert_gateway_session(
+            conn,
+            session_id=sid_dm,
+            source="telegram",
+            title="DM Same User",
+            user_id="1143399746",
+            started_at=time.time() - 40,
+        )
+        _insert_gateway_session(
+            conn,
+            session_id=sid_group,
+            source="telegram",
+            title="Group Same User",
+            user_id="1143399746",
+            started_at=time.time(),
+        )
 
-        post('/api/settings', {'show_cli_sessions': True})
-        data, status = get('/api/sessions')
+        post("/api/settings", {"show_cli_sessions": True})
+        data, status = get("/api/sessions")
         assert status == 200
-        ids = {s['session_id'] for s in data.get('sessions', []) if s.get('session_id') in {sid_dm, sid_group}}
-        assert ids == {sid_dm, sid_group}, f"Expected both DM/group Telegram sessions, got {ids}"
+        ids = {
+            s["session_id"]
+            for s in data.get("sessions", [])
+            if s.get("session_id") in {sid_dm, sid_group}
+        }
+        assert ids == {sid_dm, sid_group}, (
+            f"Expected both DM/group Telegram sessions, got {ids}"
+        )
     finally:
         try:
-            post('/api/settings', {'show_cli_sessions': False})
+            post("/api/settings", {"show_cli_sessions": False})
             _remove_test_sessions(conn, sid_dm, sid_group)
             if original_sessions_json is None:
                 sessions_file.unlink(missing_ok=True)
             else:
-                sessions_file.write_text(original_sessions_json, encoding='utf-8')
+                sessions_file.write_text(original_sessions_json, encoding="utf-8")
             conn.close()
         except Exception:
             pass
@@ -1231,7 +1376,9 @@ def test_messaging_projection_keeps_distinct_active_gateway_conversations(monkey
     assert ids == {"telegram_dm_sid", "telegram_group_sid"}
 
 
-def test_messaging_projection_does_not_aggressively_hide_without_gateway_metadata(monkeypatch):
+def test_messaging_projection_does_not_aggressively_hide_without_gateway_metadata(
+    monkeypatch,
+):
     """Without sessions.json as source of truth, keep fallback behavior."""
     from api import routes
 
@@ -1252,109 +1399,127 @@ def test_messaging_projection_does_not_aggressively_hide_without_gateway_metadat
     assert [session.get("session_id") for session in kept] == ["weixin_reset_sid"]
 
 
-def test_sessions_response_distinguishes_same_platform_same_group_chat_different_users_without_session_key(cleanup_test_sessions):
+def test_sessions_response_distinguishes_same_platform_same_group_chat_different_users_without_session_key(
+    cleanup_test_sessions,
+):
     """Group sessions with same chat_id but different users should not collapse without session_key."""
     conn = _ensure_state_db()
-    sid_u1 = 'gw_tg_group_chat_001'
-    sid_u2 = 'gw_tg_group_chat_002'
+    sid_u1 = "gw_tg_group_chat_001"
+    sid_u2 = "gw_tg_group_chat_002"
     cleanup_test_sessions.extend([sid_u1, sid_u2])
     try:
         _insert_gateway_session(
             conn,
             session_id=sid_u1,
-            source='telegram',
-            title='TG Group Same Chat User1',
-            user_id='2001001',
-            chat_id='tg_group_42',
-            chat_type='group',
+            source="telegram",
+            title="TG Group Same Chat User1",
+            user_id="2001001",
+            chat_id="tg_group_42",
+            chat_type="group",
             started_at=time.time() - 20,
         )
         _insert_gateway_session(
             conn,
             session_id=sid_u2,
-            source='telegram',
-            title='TG Group Same Chat User2',
-            user_id='2001002',
-            chat_id='tg_group_42',
-            chat_type='group',
+            source="telegram",
+            title="TG Group Same Chat User2",
+            user_id="2001002",
+            chat_id="tg_group_42",
+            chat_type="group",
             started_at=time.time(),
         )
 
-        post('/api/settings', {'show_cli_sessions': True})
-        data, status = get('/api/sessions')
+        post("/api/settings", {"show_cli_sessions": True})
+        data, status = get("/api/sessions")
         assert status == 200
-        ids = {s['session_id'] for s in data.get('sessions', []) if s.get('session_id') in {sid_u1, sid_u2}}
+        ids = {
+            s["session_id"]
+            for s in data.get("sessions", [])
+            if s.get("session_id") in {sid_u1, sid_u2}
+        }
         assert ids == {sid_u1, sid_u2}, (
             f"Expected both group sessions in same chat to stay visible without session_key, got {ids}"
         )
     finally:
         try:
-            post('/api/settings', {'show_cli_sessions': False})
+            post("/api/settings", {"show_cli_sessions": False})
             _remove_test_sessions(conn, sid_u1, sid_u2)
             conn.close()
         except Exception:
             pass
 
 
-def test_sessions_response_distinguishes_same_user_different_thread_without_session_key(cleanup_test_sessions):
+def test_sessions_response_distinguishes_same_user_different_thread_without_session_key(
+    cleanup_test_sessions,
+):
     """Same user_id but different thread context should remain separate without session_key."""
     conn = _ensure_state_db()
-    sid_t1 = 'gw_tg_thread_001'
-    sid_t2 = 'gw_tg_thread_002'
+    sid_t1 = "gw_tg_thread_001"
+    sid_t2 = "gw_tg_thread_002"
     cleanup_test_sessions.extend([sid_t1, sid_t2])
     try:
         _insert_gateway_session(
             conn,
             session_id=sid_t1,
-            source='telegram',
-            title='TG Thread A',
-            user_id='5550007',
-            chat_id='tg_group_42',
-            chat_type='thread',
-            thread_id='thread_a',
+            source="telegram",
+            title="TG Thread A",
+            user_id="5550007",
+            chat_id="tg_group_42",
+            chat_type="thread",
+            thread_id="thread_a",
             started_at=time.time() - 20,
         )
         _insert_gateway_session(
             conn,
             session_id=sid_t2,
-            source='telegram',
-            title='TG Thread B',
-            user_id='5550007',
-            chat_id='tg_group_42',
-            chat_type='thread',
-            thread_id='thread_b',
+            source="telegram",
+            title="TG Thread B",
+            user_id="5550007",
+            chat_id="tg_group_42",
+            chat_type="thread",
+            thread_id="thread_b",
             started_at=time.time(),
         )
 
-        post('/api/settings', {'show_cli_sessions': True})
-        data, status = get('/api/sessions')
+        post("/api/settings", {"show_cli_sessions": True})
+        data, status = get("/api/sessions")
         assert status == 200
-        ids = {s['session_id'] for s in data.get('sessions', []) if s.get('session_id') in {sid_t1, sid_t2}}
+        ids = {
+            s["session_id"]
+            for s in data.get("sessions", [])
+            if s.get("session_id") in {sid_t1, sid_t2}
+        }
         assert ids == {sid_t1, sid_t2}, (
             f"Expected both thread-scoped Telegram sessions to stay visible without session_key, got {ids}"
         )
     finally:
         try:
-            post('/api/settings', {'show_cli_sessions': False})
+            post("/api/settings", {"show_cli_sessions": False})
             _remove_test_sessions(conn, sid_t1, sid_t2)
             conn.close()
         except Exception:
             pass
 
 
-def test_archiving_raw_messaging_session_imports_without_erasing_agent_memory(cleanup_test_sessions):
+def test_archiving_raw_messaging_session_imports_without_erasing_agent_memory(
+    cleanup_test_sessions,
+):
     """Archive should be the safe hide path for raw messaging sessions."""
     conn = _ensure_state_db()
-    sid = 'gw_archive_weixin_001'
+    sid = "gw_archive_weixin_001"
     cleanup_test_sessions.append(sid)
     try:
-        _insert_gateway_session(conn, session_id=sid, source='weixin', title='Weixin Session')
+        _insert_gateway_session(
+            conn, session_id=sid, source="weixin", title="Weixin Session"
+        )
 
-        data, status = post('/api/session/archive', {'session_id': sid, 'archived': True})
+        data, status = post(
+            "/api/session/archive", {"session_id": sid, "archived": True}
+        )
         assert status == 200
-        session = data.get('session', {})
-        assert session.get('archived') is True
-        assert session.get('session_source') == 'messaging'
+        session = data.get("session", {})
+        assert session.get("archived") is True
+        assert session.get("session_source") == "messaging"
 
         remaining = conn.execute(
             "SELECT COUNT(*) FROM messages WHERE session_id = ?",
@@ -1369,17 +1534,21 @@ def test_archiving_raw_messaging_session_imports_without_erasing_agent_memory(cl
             pass
 
 
-def test_delete_imported_messaging_session_preserves_agent_memory(cleanup_test_sessions):
+def test_delete_imported_messaging_session_preserves_agent_memory(
+    cleanup_test_sessions,
+):
     """WebUI delete must not delete Hermes Agent memory for external channels."""
     conn = _ensure_state_db()
-    sid = 'gw_delete_weixin_safe_001'
+    sid = "gw_delete_weixin_safe_001"
     cleanup_test_sessions.append(sid)
     try:
-        _insert_gateway_session(conn, session_id=sid, source='weixin', title='Weixin Session')
-        _, import_status = post('/api/session/import_cli', {'session_id': sid})
+        _insert_gateway_session(
+            conn, session_id=sid, source="weixin", title="Weixin Session"
+        )
+        _, import_status = post("/api/session/import_cli", {"session_id": sid})
         assert import_status == 200
 
-        _, delete_status = post('/api/session/delete', {'session_id': sid})
+        _, delete_status = post("/api/session/delete", {"session_id": sid})
         assert delete_status == 200
 
         remaining = conn.execute(
@@ -1399,66 +1568,86 @@ def test_imported_cron_sessions_hidden_from_sidebar_by_default(cleanup_test_sess
     """Cron sessions already imported into the WebUI store should stay hidden from the sidebar."""
     from api.models import Session
 
-    sid = 'cron_imported_20260427'
+    sid = "cron_imported_20260427"
     cleanup_test_sessions.append(sid)
     s = Session(
         session_id=sid,
-        title='Hourly Cron Import',
-        messages=[{'role': 'user', 'content': 'run hourly job', 'timestamp': time.time()}],
-        model='openai/gpt-5',
+        title="Hourly Cron Import",
+        messages=[
+            {"role": "user", "content": "run hourly job", "timestamp": time.time()}
+        ],
+        model="openai/gpt-5",
     )
     s.is_cli_session = True
     s.save(touch_updated_at=False)
 
-    data, status = get('/api/sessions')
+    data, status = get("/api/sessions")
     assert status == 200
-    assert sid not in {session.get('session_id') for session in data.get('sessions', [])}
+    assert sid not in {
+        session.get("session_id") for session in data.get("sessions", [])
+    }
 
 
 def test_cron_sessions_hidden_from_sidebar_by_default():
     """Cron-run sessions are background/internal and should not appear in the default sidebar list."""
     conn = _ensure_state_db()
     try:
-        _insert_gateway_session(conn, session_id='cron_job123_20260427', source='cron', title='Nightly Cleanup')
-        _insert_gateway_session(conn, session_id='gw_noncron_001', source='telegram', title='Visible Chat')
+        _insert_gateway_session(
+            conn,
+            session_id="cron_job123_20260427",
+            source="cron",
+            title="Nightly Cleanup",
+        )
+        _insert_gateway_session(
+            conn, session_id="gw_noncron_001", source="telegram", title="Visible Chat"
+        )
 
-        post('/api/settings', {'show_cli_sessions': True})
+        post("/api/settings", {"show_cli_sessions": True})
 
-        data, status = get('/api/sessions')
+        data, status = get("/api/sessions")
         assert status == 200
-        sessions = data.get('sessions', [])
-        ids = {s['session_id'] for s in sessions}
-        assert 'gw_noncron_001' in ids, "Non-cron agent session should still appear"
-        assert 'cron_job123_20260427' not in ids, "Cron session should be hidden by default"
+        sessions = data.get("sessions", [])
+        ids = {s["session_id"] for s in sessions}
+        assert "gw_noncron_001" in ids, "Non-cron agent session should still appear"
+        assert "cron_job123_20260427" not in ids, (
+            "Cron session should be hidden by default"
+        )
     finally:
         try:
-            _remove_test_sessions(conn, 'cron_job123_20260427', 'gw_noncron_001')
+            _remove_test_sessions(conn, "cron_job123_20260427", "gw_noncron_001")
             conn.close()
         except Exception:
             pass
-        post('/api/settings', {'show_cli_sessions': False})
+        post("/api/settings", {"show_cli_sessions": False})
 
 
 def test_importable_agent_rows_can_opt_into_cron_source():
     """Diagnostic callers can opt out of the default cron exclusion explicitly."""
     conn = _ensure_state_db()
     try:
-        _insert_agent_session_row(conn, session_id='cron_diag_20260427', source='cron', title='Cron Diagnostic')
+        _insert_agent_session_row(
+            conn,
+            session_id="cron_diag_20260427",
+            source="cron",
+            title="Cron Diagnostic",
+        )
 
         from api.agent_sessions import read_importable_agent_session_rows
 
-        default_rows = read_importable_agent_session_rows(_get_state_db_path(), limit=None)
-        assert 'cron_diag_20260427' not in {row.get('id') for row in default_rows}
+        default_rows = read_importable_agent_session_rows(
+            _get_state_db_path(), limit=None
+        )
+        assert "cron_diag_20260427" not in {row.get("id") for row in default_rows}
 
         diagnostic_rows = read_importable_agent_session_rows(
             _get_state_db_path(),
             limit=None,
             exclude_sources=None,
         )
-        assert 'cron_diag_20260427' in {row.get('id') for row in diagnostic_rows}
+        assert "cron_diag_20260427" in {row.get("id") for row in diagnostic_rows}
     finally:
         try:
-            _remove_test_sessions(conn, 'cron_diag_20260427')
+            _remove_test_sessions(conn, "cron_diag_20260427")
             conn.close()
         except Exception:
             pass
@@ -1468,78 +1657,102 @@ def test_gateway_session_has_message_count():
     """Gateway sessions report correct message_count from state.db."""
     conn = _ensure_state_db()
     try:
-        _insert_gateway_session(conn, session_id='gw_msg_001', source='discord', title='Msg Count Test', message_count=5)
+        _insert_gateway_session(
+            conn,
+            session_id="gw_msg_001",
+            source="discord",
+            title="Msg Count Test",
+            message_count=5,
+        )
 
-        post('/api/settings', {'show_cli_sessions': True})
+        post("/api/settings", {"show_cli_sessions": True})
 
-        data, status = get('/api/sessions')
+        data, status = get("/api/sessions")
         assert status == 200
-        sessions = data.get('sessions', [])
-        gw = next((s for s in sessions if s['session_id'] == 'gw_msg_001'), None)
+        sessions = data.get("sessions", [])
+        gw = next((s for s in sessions if s["session_id"] == "gw_msg_001"), None)
         assert gw is not None
-        assert gw.get('message_count') == 5, f"Expected message_count=5, got {gw.get('message_count')}"
+        assert gw.get("message_count") == 5, (
+            f"Expected message_count=5, got {gw.get('message_count')}"
+        )
     finally:
         try:
-            _remove_test_sessions(conn, 'gw_msg_001')
+            _remove_test_sessions(conn, "gw_msg_001")
             conn.close()
         except Exception:
             pass
-        post('/api/settings', {'show_cli_sessions': False})
+        post("/api/settings", {"show_cli_sessions": False})
 
 
 def test_gateway_sessions_multiple_sources():
     """Sessions from multiple gateway sources (telegram, discord, slack) all appear."""
     conn = _ensure_state_db()
     try:
-        _insert_gateway_session(conn, session_id='gw_multi_tg', source='telegram', title='TG Chat')
-        _insert_gateway_session(conn, session_id='gw_multi_dc', source='discord', title='DC Chat')
-        _insert_gateway_session(conn, session_id='gw_multi_sl', source='slack', title='SL Chat')
+        _insert_gateway_session(
+            conn, session_id="gw_multi_tg", source="telegram", title="TG Chat"
+        )
+        _insert_gateway_session(
+            conn, session_id="gw_multi_dc", source="discord", title="DC Chat"
+        )
+        _insert_gateway_session(
+            conn, session_id="gw_multi_sl", source="slack", title="SL Chat"
+        )
 
-        post('/api/settings', {'show_cli_sessions': True})
+        post("/api/settings", {"show_cli_sessions": True})
 
-        data, status = get('/api/sessions')
+        data, status = get("/api/sessions")
         assert status == 200
-        sessions = data.get('sessions', [])
-        gw_ids = {s['session_id'] for s in sessions if s.get('session_id') in ('gw_multi_tg', 'gw_multi_dc', 'gw_multi_sl')}
-        assert len(gw_ids) == 3, f"Expected 3 gateway sessions, got {len(gw_ids)}: {gw_ids}"
+        sessions = data.get("sessions", [])
+        gw_ids = {
+            s["session_id"]
+            for s in sessions
+            if s.get("session_id") in ("gw_multi_tg", "gw_multi_dc", "gw_multi_sl")
+        }
+        assert len(gw_ids) == 3, (
+            f"Expected 3 gateway sessions, got {len(gw_ids)}: {gw_ids}"
+        )
     finally:
         try:
-            _remove_test_sessions(conn, 'gw_multi_tg', 'gw_multi_dc', 'gw_multi_sl')
+            _remove_test_sessions(conn, "gw_multi_tg", "gw_multi_dc", "gw_multi_sl")
             conn.close()
         except Exception:
             pass
-        post('/api/settings', {'show_cli_sessions': False})
+        post("/api/settings", {"show_cli_sessions": False})
 
 
 def test_gateway_session_messages_readable():
     """Gateway session messages can be loaded via /api/session."""
     conn = _ensure_state_db()
     try:
-        _insert_gateway_session(conn, session_id='gw_read_001', source='telegram', title='Readable')
+        _insert_gateway_session(
+            conn, session_id="gw_read_001", source="telegram", title="Readable"
+        )
 
-        post('/api/settings', {'show_cli_sessions': True})
+        post("/api/settings", {"show_cli_sessions": True})
 
-        data, status = get(f'/api/session?session_id=gw_read_001')
+        data, status = get("/api/session?session_id=gw_read_001")
         assert status == 200
-        msgs = data.get('session', {}).get('messages', [])
+        msgs = data.get("session", {}).get("messages", [])
         assert len(msgs) >= 2, f"Expected at least 2 messages, got {len(msgs)}"
-        assert msgs[0].get('role') == 'user'
-        assert msgs[0].get('content') == 'Hello from Telegram'
+        assert msgs[0].get("role") == "user"
+        assert msgs[0].get("content") == "Hello from Telegram"
     finally:
         try:
-            _remove_test_sessions(conn, 'gw_read_001')
+            _remove_test_sessions(conn, "gw_read_001")
             conn.close()
         except Exception:
             pass
-        post('/api/settings', {'show_cli_sessions': False})
+        post("/api/settings", {"show_cli_sessions": False})
 
 
-def test_session_prefers_state_db_messages_over_stale_local_snapshot(cleanup_test_sessions):
+def test_session_prefers_state_db_messages_over_stale_local_snapshot(
+    cleanup_test_sessions,
+):
     """Stale local JSON for messaging sessions should not mask newer state.db messages."""
     from api.models import Session
 
     conn = _ensure_state_db()
-    sid = 'gw_masking_regression_001'
+    sid = "gw_masking_regression_001"
     cleanup_test_sessions.append(sid)
     base_ts = time.time() - 120
     stale_messages = [
@@ -1558,8 +1771,8 @@ def test_session_prefers_state_db_messages_over_stale_local_snapshot(cleanup_tes
         _insert_gateway_session(
             conn,
             session_id=sid,
-            source='telegram',
-            title='Regression Telegram Chat',
+            source="telegram",
+            title="Regression Telegram Chat",
             message_count=expected_total,
             started_at=base_ts + 1,
         )
@@ -1576,26 +1789,30 @@ def test_session_prefers_state_db_messages_over_stale_local_snapshot(cleanup_tes
 
         s = Session(
             session_id=sid,
-            title='Legacy Local Telegram Snapshot',
-            workspace=str(pathlib.Path.home() / '.hermes'),
-            model='openai/gpt-5',
-            messages=[{"role": r, "content": c, "timestamp": t} for r, c, t in stale_messages],
+            title="Legacy Local Telegram Snapshot",
+            workspace=str(pathlib.Path.home() / ".hermes"),
+            model="openai/gpt-5",
+            messages=[
+                {"role": r, "content": c, "timestamp": t} for r, c, t in stale_messages
+            ],
         )
         s.is_cli_session = True
-        s.session_source = 'messaging'
-        s.source_tag = 'telegram'
-        s.raw_source = 'telegram'
-        s.source_label = 'Telegram'
+        s.session_source = "messaging"
+        s.source_tag = "telegram"
+        s.raw_source = "telegram"
+        s.source_label = "Telegram"
         s.save(touch_updated_at=False)
 
-        post('/api/settings', {'show_cli_sessions': True})
-        data, status = get(f'/api/session?session_id={sid}')
+        post("/api/settings", {"show_cli_sessions": True})
+        data, status = get(f"/api/session?session_id={sid}")
         assert status == 200, data
-        session = data.get('session', {})
-        msgs = session.get('messages', [])
-        assert len(msgs) == expected_total, f"Expected {expected_total} messages, got {len(msgs)}"
-        assert msgs[-1].get('content') == expected_tail
-        assert session.get('message_count') == expected_total
+        session = data.get("session", {})
+        msgs = session.get("messages", [])
+        assert len(msgs) == expected_total, (
+            f"Expected {expected_total} messages, got {len(msgs)}"
+        )
+        assert msgs[-1].get("content") == expected_tail
+        assert session.get("message_count") == expected_total
     finally:
         try:
             _remove_test_sessions(conn, sid)
@@ -1603,15 +1820,17 @@ def test_session_prefers_state_db_messages_over_stale_local_snapshot(cleanup_tes
         except Exception:
             pass
         try:
-            post('/api/settings', {'show_cli_sessions': False})
+            post("/api/settings", {"show_cli_sessions": False})
         except Exception:
             pass
 
 
-def test_sessions_prefers_state_db_metadata_for_messaging_overlap(cleanup_test_sessions):
+def test_sessions_prefers_state_db_metadata_for_messaging_overlap(
+    cleanup_test_sessions,
+):
     """Sidebar metadata for messaging sessions should come from state.db, not local JSON snapshots."""
     conn = _ensure_state_db()
-    sid = 'gw_sidebar_metadata_regression_001'
+    sid = "gw_sidebar_metadata_regression_001"
     cleanup_test_sessions.append(sid)
     now = time.time()
     rows = [
@@ -1620,7 +1839,14 @@ def test_sessions_prefers_state_db_metadata_for_messaging_overlap(cleanup_test_s
         ("user", "Need details", now - 5),
     ]
     try:
-        _insert_gateway_session(conn, session_id=sid, source='weixin', title='Live metadata chat', message_count=len(rows), started_at=now - 30)
+        _insert_gateway_session(
+            conn,
+            session_id=sid,
+            source="weixin",
+            title="Live metadata chat",
+            message_count=len(rows),
+            started_at=now - 30,
+        )
         conn.execute("DELETE FROM messages WHERE session_id = ?", (sid,))
         for role, content, ts in rows:
             _insert_message(conn, sid, role, content, ts)
@@ -1631,29 +1857,32 @@ def test_sessions_prefers_state_db_metadata_for_messaging_overlap(cleanup_test_s
             {"role": "assistant", "content": "stale two", "timestamp": now - 99},
         ]
         from api.models import Session
+
         local = Session(
             session_id=sid,
-            title='Stale Sidebar',
+            title="Stale Sidebar",
             messages=stale,
-            model='openai/gpt-4',
+            model="openai/gpt-4",
         )
         local.is_cli_session = True
-        local.session_source = 'messaging'
-        local.source_tag = 'weixin'
-        local.raw_source = 'weixin'
-        local.source_label = 'Weixin'
+        local.session_source = "messaging"
+        local.source_tag = "weixin"
+        local.raw_source = "weixin"
+        local.source_label = "Weixin"
         local.save(touch_updated_at=False)
 
-        post('/api/settings', {'show_cli_sessions': True})
-        data, status = get('/api/sessions')
+        post("/api/settings", {"show_cli_sessions": True})
+        data, status = get("/api/sessions")
         assert status == 200, data
-        session = next(item for item in data.get('sessions', []) if item.get('session_id') == sid)
-        assert session.get('message_count') == len(rows)
+        session = next(
+            item for item in data.get("sessions", []) if item.get("session_id") == sid
+        )
+        assert session.get("message_count") == len(rows)
         expected_updated = max(ts for _, _, ts in rows)
-        assert abs(float(session.get('updated_at') or 0) - expected_updated) < 1.0
+        assert abs(float(session.get("updated_at") or 0) - expected_updated) < 1.0
     finally:
         try:
-            post('/api/settings', {'show_cli_sessions': False})
+            post("/api/settings", {"show_cli_sessions": False})
             _remove_test_sessions(conn, sid)
             conn.close()
         except Exception:
@@ -1665,22 +1894,24 @@ def test_archiving_messaging_session_keeps_state_db_history(cleanup_test_session
     from api.models import Session
 
     conn = _ensure_state_db()
-    sid = 'gw_archive_metadata_only_001'
+    sid = "gw_archive_metadata_only_001"
     cleanup_test_sessions.append(sid)
     try:
         _insert_gateway_session(
             conn,
             session_id=sid,
-            source='discord',
-            title='Archive Safe',
+            source="discord",
+            title="Archive Safe",
             message_count=2,
             started_at=time.time() - 20,
         )
         # Do not create a local session first; archive should create minimal metadata only.
-        data, status = post('/api/session/archive', {'session_id': sid, 'archived': True})
+        data, status = post(
+            "/api/session/archive", {"session_id": sid, "archived": True}
+        )
         assert status == 200, data
-        archived = data.get('session', {})
-        assert archived.get('archived') is True
+        archived = data.get("session", {})
+        assert archived.get("archived") is True
         remaining = conn.execute(
             "SELECT COUNT(*) FROM messages WHERE session_id = ?",
             (sid,),
@@ -1689,13 +1920,15 @@ def test_archiving_messaging_session_keeps_state_db_history(cleanup_test_session
 
         local = Session.load(sid)
         assert local is not None
-        assert local.messages == [], "Archive should not import historical messages into local JSON"
+        assert local.messages == [], (
+            "Archive should not import historical messages into local JSON"
+        )
         assert local.archived is True
 
-        session_data, session_status = get(f'/api/session?session_id={sid}')
+        session_data, session_status = get(f"/api/session?session_id={sid}")
         assert session_status == 200, session_data
-        assert session_data.get('session', {}).get('archived') is True
-        assert session_data.get('session', {}).get('message_count') == 2
+        assert session_data.get("session", {}).get("archived") is True
+        assert session_data.get("session", {}).get("message_count") == 2
     finally:
         try:
             _remove_test_sessions(conn, sid)
@@ -1708,40 +1941,50 @@ def test_importing_older_gateway_session_preserves_original_timestamps_and_order
     """Importing an older gateway session should not bump it above newer WebUI sessions."""
     conn = _ensure_state_db()
     older_started_at = time.time() - 1800
-    imported_sid = 'gw_import_old_001'
+    imported_sid = "gw_import_old_001"
     newer_webui_sid = None
     try:
-        newer_webui, status = post('/api/session/new', {'model': 'openai/gpt-5'})
+        newer_webui, status = post("/api/session/new", {"model": "openai/gpt-5"})
         assert status == 200, newer_webui
-        newer_webui_sid = newer_webui['session']['session_id']
+        newer_webui_sid = newer_webui["session"]["session_id"]
 
         rename, rename_status = post(
-            '/api/session/rename',
-            {'session_id': newer_webui_sid, 'title': 'Newer WebUI Session'},
+            "/api/session/rename",
+            {"session_id": newer_webui_sid, "title": "Newer WebUI Session"},
         )
         assert rename_status == 200, rename
 
         _insert_gateway_session(
             conn,
             session_id=imported_sid,
-            source='discord',
-            title='Older imported gateway session',
+            source="discord",
+            title="Older imported gateway session",
             started_at=older_started_at,
         )
-        post('/api/settings', {'show_cli_sessions': True})
+        post("/api/settings", {"show_cli_sessions": True})
 
-        imported, imported_status = post('/api/session/import_cli', {'session_id': imported_sid})
+        imported, imported_status = post(
+            "/api/session/import_cli", {"session_id": imported_sid}
+        )
         assert imported_status == 200, imported
-        imported_session = imported['session']
-        assert abs(imported_session['created_at'] - older_started_at) < 2, imported_session
-        assert abs(imported_session['updated_at'] - older_started_at) < 5, imported_session
+        imported_session = imported["session"]
+        assert abs(imported_session["created_at"] - older_started_at) < 2, (
+            imported_session
+        )
+        assert abs(imported_session["updated_at"] - older_started_at) < 5, (
+            imported_session
+        )
 
-        sessions_payload, sessions_status = get('/api/sessions')
+        sessions_payload, sessions_status = get("/api/sessions")
         assert sessions_status == 200, sessions_payload
-        ordered_ids = [item['session_id'] for item in sessions_payload.get('sessions', [])]
+        ordered_ids = [
+            item["session_id"] for item in sessions_payload.get("sessions", [])
+        ]
         assert newer_webui_sid in ordered_ids, ordered_ids
         assert imported_sid in ordered_ids, ordered_ids
-        assert ordered_ids.index(newer_webui_sid) < ordered_ids.index(imported_sid), ordered_ids
+        assert ordered_ids.index(newer_webui_sid) < ordered_ids.index(imported_sid), (
+            ordered_ids
+        )
     finally:
         try:
             _remove_test_sessions(conn, imported_sid)
@@ -1750,76 +1993,83 @@ def test_importing_older_gateway_session_preserves_original_timestamps_and_order
             pass
         if imported_sid:
             try:
-                post('/api/session/delete', {'session_id': imported_sid})
+                post("/api/session/delete", {"session_id": imported_sid})
             except Exception:
                 pass
         if newer_webui_sid:
             try:
-                post('/api/session/delete', {'session_id': newer_webui_sid})
+                post("/api/session/delete", {"session_id": newer_webui_sid})
             except Exception:
                 pass
-        post('/api/settings', {'show_cli_sessions': False})
-
+        post("/api/settings", {"show_cli_sessions": False})
 
 
 def test_gateway_sse_stream_endpoint_exists():
     """GET /api/sessions/gateway/stream returns a response (200 or 200-range)."""
     # The SSE endpoint requires show_cli_sessions to be enabled
-    post('/api/settings', {'show_cli_sessions': True})
+    post("/api/settings", {"show_cli_sessions": True})
     try:
-        req = urllib.request.Request(BASE + '/api/sessions/gateway/stream')
+        req = urllib.request.Request(BASE + "/api/sessions/gateway/stream")
         with urllib.request.urlopen(req, timeout=5) as r:
             assert r.status in (200, 204), f"Expected 200/204, got {r.status}"
             # SSE should have content-type text/event-stream
-            ctype = r.headers.get('Content-Type', '')
-            assert 'text/event-stream' in ctype, f"Expected text/event-stream, got {ctype}"
+            ctype = r.headers.get("Content-Type", "")
+            assert "text/event-stream" in ctype, (
+                f"Expected text/event-stream, got {ctype}"
+            )
     except Exception as e:
         # Timeout is acceptable — means the connection is held open (SSE behavior)
-        if 'timed out' in str(e).lower() or 'timeout' in str(e).lower():
+        if "timed out" in str(e).lower() or "timeout" in str(e).lower():
             pass  # Good: SSE keeps the connection open
         else:
             raise
     finally:
-        post('/api/settings', {'show_cli_sessions': False})
+        post("/api/settings", {"show_cli_sessions": False})
 
 
 def test_gateway_sse_stream_probe_reports_status():
     """Probe mode returns JSON watcher status instead of holding open an SSE stream."""
-    post('/api/settings', {'show_cli_sessions': True})
+    post("/api/settings", {"show_cli_sessions": True})
     try:
-        req = urllib.request.Request(BASE + '/api/sessions/gateway/stream?probe=1')
+        req = urllib.request.Request(BASE + "/api/sessions/gateway/stream?probe=1")
         with urllib.request.urlopen(req, timeout=5) as r:
             assert r.status == 200, f"Expected 200, got {r.status}"
-            ctype = r.headers.get('Content-Type', '')
-            assert 'application/json' in ctype, f"Expected application/json, got {ctype}"
-            data = json.loads(r.read().decode('utf-8'))
-            assert data['enabled'] is True
-            assert 'watcher_running' in data
-            assert data['fallback_poll_ms'] == 30000
+            ctype = r.headers.get("Content-Type", "")
+            assert "application/json" in ctype, (
+                f"Expected application/json, got {ctype}"
+            )
+            data = json.loads(r.read().decode("utf-8"))
+            assert data["enabled"] is True
+            assert "watcher_running" in data
+            assert data["fallback_poll_ms"] == 30000
     finally:
-        post('/api/settings', {'show_cli_sessions': False})
+        post("/api/settings", {"show_cli_sessions": False})
 
 
 def test_gateway_webui_sessions_not_duplicated():
     """If a session_id exists both in WebUI store and state.db, it's not duplicated."""
     # Create a WebUI session with a known ID
     body = {}
-    d, _ = post('/api/session/new', body)
-    webui_sid = d['session']['session_id']
+    d, _ = post("/api/session/new", body)
+    webui_sid = d["session"]["session_id"]
 
     try:
         # Insert the same session_id into state.db as a gateway session
         conn = _ensure_state_db()
-        _insert_gateway_session(conn, session_id=webui_sid, source='telegram', title='Dup Test')
+        _insert_gateway_session(
+            conn, session_id=webui_sid, source="telegram", title="Dup Test"
+        )
         conn.close()
 
-        post('/api/settings', {'show_cli_sessions': True})
+        post("/api/settings", {"show_cli_sessions": True})
 
-        data, status = get('/api/sessions')
+        data, status = get("/api/sessions")
         assert status == 200
-        sessions = data.get('sessions', [])
-        matching = [s for s in sessions if s['session_id'] == webui_sid]
-        assert len(matching) == 1, f"Expected 1 entry for {webui_sid}, got {len(matching)}"
+        sessions = data.get("sessions", [])
+        matching = [s for s in sessions if s["session_id"] == webui_sid]
+        assert len(matching) == 1, (
+            f"Expected 1 entry for {webui_sid}, got {len(matching)}"
+        )
     finally:
         try:
             conn2 = sqlite3.connect(str(_get_state_db_path()))
@@ -1827,45 +2077,55 @@ def test_gateway_webui_sessions_not_duplicated():
             conn2.close()
         except Exception:
             pass
-        post('/api/session/delete', {'session_id': webui_sid})
-        post('/api/settings', {'show_cli_sessions': False})
+        post("/api/session/delete", {"session_id": webui_sid})
+        post("/api/settings", {"show_cli_sessions": False})
 
 
 def test_gateway_sessions_no_state_db():
     """When state.db doesn't exist, /api/sessions works fine (no gateway sessions)."""
     _cleanup_state_db()
 
-    post('/api/settings', {'show_cli_sessions': True})
+    post("/api/settings", {"show_cli_sessions": True})
     try:
-        data, status = get('/api/sessions')
+        data, status = get("/api/sessions")
         assert status == 200
         # Should succeed with just webui sessions (or empty)
-        assert 'sessions' in data
+        assert "sessions" in data
     finally:
-        post('/api/settings', {'show_cli_sessions': False})
+        post("/api/settings", {"show_cli_sessions": False})
 
 
 def test_cli_sessions_still_work():
     """CLI sessions (source='cli') still appear alongside gateway sessions."""
     conn = _ensure_state_db()
     try:
-        _insert_gateway_session(conn, session_id='cli_legacy_001', source='cli', title='CLI Legacy')
-        _insert_gateway_session(conn, session_id='gw_new_001', source='telegram', title='GW New')
+        _insert_gateway_session(
+            conn, session_id="cli_legacy_001", source="cli", title="CLI Legacy"
+        )
+        _insert_gateway_session(
+            conn, session_id="gw_new_001", source="telegram", title="GW New"
+        )
 
-        post('/api/settings', {'show_cli_sessions': True})
+        post("/api/settings", {"show_cli_sessions": True})
 
-        data, status = get('/api/sessions')
+        data, status = get("/api/sessions")
         assert status == 200
-        sessions = data.get('sessions', [])
-        agent_ids = {s['session_id'] for s in sessions if s.get('session_id') in ('cli_legacy_001', 'gw_new_001')}
-        assert len(agent_ids) == 2, f"Expected 2 agent sessions (cli + gateway), got {len(agent_ids)}"
+        sessions = data.get("sessions", [])
+        agent_ids = {
+            s["session_id"]
+            for s in sessions
+            if s.get("session_id") in ("cli_legacy_001", "gw_new_001")
+        }
+        assert len(agent_ids) == 2, (
+            f"Expected 2 agent sessions (cli + gateway), got {len(agent_ids)}"
+        )
     finally:
         try:
-            _remove_test_sessions(conn, 'cli_legacy_001', 'gw_new_001')
+            _remove_test_sessions(conn, "cli_legacy_001", "gw_new_001")
             conn.close()
         except Exception:
             pass
-        post('/api/settings', {'show_cli_sessions': False})
+        post("/api/settings", {"show_cli_sessions": False})
 
 
 # ── Unit tests for _gateway_sse_probe_payload ────────────────────────────────
@@ -1874,62 +2134,72 @@ def test_cli_sessions_still_work():
 
 import sys
 import threading
+
 sys.path.insert(0, str(REPO_ROOT))
 from api.routes import _gateway_sse_probe_payload
 
 
 def test_probe_payload_when_disabled():
     """Probe returns 404 when show_cli_sessions is False."""
-    body, status = _gateway_sse_probe_payload({'show_cli_sessions': False}, watcher=None)
+    body, status = _gateway_sse_probe_payload(
+        {"show_cli_sessions": False}, watcher=None
+    )
     assert status == 404
-    assert body['ok'] is False
-    assert body['enabled'] is False
-    assert body['watcher_running'] is False
-    assert body['error'] == 'agent sessions not enabled'
-    assert body['fallback_poll_ms'] == 30000
+    assert body["ok"] is False
+    assert body["enabled"] is False
+    assert body["watcher_running"] is False
+    assert body["error"] == "agent sessions not enabled"
+    assert body["fallback_poll_ms"] == 30000
 
 
 def test_probe_payload_when_watcher_missing():
     """Probe returns 503 when enabled but no watcher instance."""
-    body, status = _gateway_sse_probe_payload({'show_cli_sessions': True}, watcher=None)
+    body, status = _gateway_sse_probe_payload({"show_cli_sessions": True}, watcher=None)
     assert status == 503
-    assert body['ok'] is False
-    assert body['enabled'] is True
-    assert body['watcher_running'] is False
-    assert body['error'] == 'watcher not started'
-    assert body['fallback_poll_ms'] == 30000
+    assert body["ok"] is False
+    assert body["enabled"] is True
+    assert body["watcher_running"] is False
+    assert body["error"] == "watcher not started"
+    assert body["fallback_poll_ms"] == 30000
 
 
 def test_probe_payload_when_watcher_instance_no_thread():
     """Probe returns 503 when watcher exists but _thread attribute is missing/None."""
+
     class _FakeWatcher:
         _thread = None
-    body, status = _gateway_sse_probe_payload({'show_cli_sessions': True}, watcher=_FakeWatcher())
+
+    body, status = _gateway_sse_probe_payload(
+        {"show_cli_sessions": True}, watcher=_FakeWatcher()
+    )
     assert status == 503
-    assert body['watcher_running'] is False
+    assert body["watcher_running"] is False
 
 
 def test_probe_payload_when_watcher_thread_alive():
     """Probe returns 200 when enabled and watcher thread is alive."""
+
     class _FakeWatcher:
         pass
+
     w = _FakeWatcher()
     t = threading.Thread(target=lambda: None)
     t.daemon = True
     t.start()
     w._thread = t
     # Thread may finish fast — loop-start a live daemon thread for reliability
-    import time as _time
     done = threading.Event()
     live = threading.Thread(target=done.wait, daemon=True)
     live.start()
     w._thread = live
     try:
-        body, status = _gateway_sse_probe_payload({'show_cli_sessions': True}, watcher=w)
+        body, status = _gateway_sse_probe_payload(
+            {"show_cli_sessions": True}, watcher=w
+        )
         assert status == 200
-        assert body['ok'] is True
-        assert body['watcher_running'] is True
-        assert body['fallback_poll_ms'] == 30000
+        assert body["ok"] is True
+        assert body["watcher_running"] is True
+        assert body["fallback_poll_ms"] == 30000
     finally:
         done.set()
         live.join(timeout=1)
@@ -1937,23 +2207,26 @@ def test_probe_payload_when_watcher_thread_alive():
 
 def test_probe_payload_when_watcher_thread_dead():
     """Probe returns 503 when watcher instance exists but thread has exited."""
+
     class _FakeWatcher:
         pass
+
     w = _FakeWatcher()
     t = threading.Thread(target=lambda: None)
     t.start()
     t.join()  # wait for it to finish
     w._thread = t
-    body, status = _gateway_sse_probe_payload({'show_cli_sessions': True}, watcher=w)
+    body, status = _gateway_sse_probe_payload({"show_cli_sessions": True}, watcher=w)
     assert status == 503
-    assert body['watcher_running'] is False
-    assert body['ok'] is False
+    assert body["watcher_running"] is False
+    assert body["ok"] is False
 
 
 def test_gateway_watcher_is_alive_public_method():
     """GatewayWatcher.is_alive() is the public API the probe uses. Cover all
     three states: before start(), while running, after stop()."""
     from api.gateway_watcher import GatewayWatcher
+
     w = GatewayWatcher()
     # Before start(): no thread
     assert w.is_alive() is False, "is_alive() must be False before start()"
@@ -1974,16 +2247,17 @@ def test_probe_payload_prefers_public_is_alive():
 
     class _WatcherWithPublicApi:
         def is_alive(self):
-            calls.append('is_alive')
+            calls.append("is_alive")
             return True
+
         # _thread is deliberately absent — must not be accessed.
 
     body, status = _gateway_sse_probe_payload(
-        {'show_cli_sessions': True},
+        {"show_cli_sessions": True},
         watcher=_WatcherWithPublicApi(),
     )
     assert status == 200
-    assert body['watcher_running'] is True
-    assert calls == ['is_alive'], (
+    assert body["watcher_running"] is True
+    assert calls == ["is_alive"], (
         "probe must prefer the public is_alive() method over poking _thread"
     )

--- a/tests/test_goal_command_webui.py
+++ b/tests/test_goal_command_webui.py
@@ -1,11 +1,7 @@
 """Regression tests for first-class WebUI /goal command parity."""
 
-import io
-import json
 from pathlib import Path
-from types import SimpleNamespace
 
-import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 COMMANDS_JS = (REPO_ROOT / "static" / "commands.js").read_text(encoding="utf-8")
@@ -92,7 +88,9 @@ def test_goal_command_payload_rejects_new_goal_while_stream_running(monkeypatch)
     monkeypatch.setattr(webui_goals, "_default_max_turns", lambda: 20)
 
     status = webui_goals.goal_command_payload("sid-123", "status", stream_running=True)
-    rejected = webui_goals.goal_command_payload("sid-123", "replace it", stream_running=True)
+    rejected = webui_goals.goal_command_payload(
+        "sid-123", "replace it", stream_running=True
+    )
 
     assert status["ok"] is True
     assert rejected["ok"] is False
@@ -143,11 +141,15 @@ def test_goal_continuation_decision_emits_status_and_normal_user_prompt(monkeypa
     monkeypatch.setattr(webui_goals, "GoalManager", FakeGoalManager)
     monkeypatch.setattr(webui_goals, "_default_max_turns", lambda: 20)
 
-    decision = webui_goals.evaluate_goal_after_turn("sid-123", "not done yet", user_initiated=False)
+    decision = webui_goals.evaluate_goal_after_turn(
+        "sid-123", "not done yet", user_initiated=False
+    )
 
     assert decision["message"].startswith("↻ Continuing toward goal")
     assert decision["should_continue"] is True
-    assert decision["continuation_prompt"].startswith("[Continuing toward your standing goal]")
+    assert decision["continuation_prompt"].startswith(
+        "[Continuing toward your standing goal]"
+    )
 
 
 def test_goal_endpoint_sets_goal_and_starts_kickoff_stream(monkeypatch, tmp_path):
@@ -197,10 +199,21 @@ def test_goal_endpoint_sets_goal_and_starts_kickoff_stream(monkeypatch, tmp_path
 
     def fake_start(session, **kwargs):
         started.append(kwargs)
-        return {"stream_id": "goal-stream", "session_id": session.session_id, "pending_started_at": 123.0}
+        return {
+            "stream_id": "goal-stream",
+            "session_id": session.session_id,
+            "pending_started_at": 123.0,
+        }
 
     monkeypatch.setattr(routes, "_start_chat_stream_for_session", fake_start)
-    monkeypatch.setattr(routes, "j", lambda handler, payload, status=200, **kwargs: {"status": status, "payload": payload})
+    monkeypatch.setattr(
+        routes,
+        "j",
+        lambda handler, payload, status=200, **kwargs: {
+            "status": status,
+            "payload": payload,
+        },
+    )
 
     result = routes._handle_goal_command(
         object(),
@@ -237,18 +250,25 @@ def test_streaming_post_turn_goal_hook_surfaces_and_continues():
     goal_idx = STREAMING_PY.find("evaluate_goal_after_turn")
     done_idx = STREAMING_PY.find("put('done'", goal_idx)
     assert goal_idx != -1 and done_idx != -1
-    assert goal_idx < done_idx, "goal status should be emitted before the terminal done payload"
+    assert goal_idx < done_idx, (
+        "goal status should be emitted before the terminal done payload"
+    )
 
 
 def test_streaming_goal_hook_emits_evaluating_state_before_judge():
     evaluating_idx = STREAMING_PY.find("'state': 'evaluating'")
     judge_idx = STREAMING_PY.find("_goal_decision = evaluate_goal_after_turn")
     done_idx = STREAMING_PY.find("put('done'", judge_idx)
-    assert evaluating_idx != -1, "goal hook should emit an evaluating state before judge round-trip"
+    assert evaluating_idx != -1, (
+        "goal hook should emit an evaluating state before judge round-trip"
+    )
     assert judge_idx != -1 and done_idx != -1
     assert evaluating_idx < judge_idx < done_idx
     assert "Evaluating goal progress…" in STREAMING_PY
-    assert "'state': 'continuing' if decision.get('should_continue') else 'idle'" in STREAMING_PY
+    assert (
+        "'state': 'continuing' if decision.get('should_continue') else 'idle'"
+        in STREAMING_PY
+    )
 
 
 def test_frontend_has_goal_slash_command_and_status_event_handler():
@@ -260,7 +280,10 @@ def test_frontend_has_goal_slash_command_and_status_event_handler():
     assert "goal'" in MESSAGES_JS
     assert "source.addEventListener('goal'" in MESSAGES_JS
     assert "source.addEventListener('goal_continue'" in MESSAGES_JS
-    assert "['steer','interrupt','queue','terminal','goal'].includes(_pc.name)" in MESSAGES_JS
+    assert (
+        "['steer','interrupt','queue','terminal','goal'].includes(_pc.name)"
+        in MESSAGES_JS
+    )
     assert "queueSessionMessage" in MESSAGES_JS
 
 

--- a/tests/test_ime_composition.py
+++ b/tests/test_ime_composition.py
@@ -27,8 +27,8 @@ def _ime_guarded_enter_pattern(event_var_pattern, require_no_shift=False):
     )
     return (
         rf"if\s*\(\s*{event_var_pattern}\.key\s*===\s*'Enter'{no_shift}\s*\)\s*\{{\s*"
-        + guard +
-        rf"(?:\{{\s*return\s*;?\s*\}}|return\s*;?)"
+        + guard
+        + r"(?:\{\s*return\s*;?\s*\}|return\s*;?)"
     )
 
 
@@ -42,7 +42,9 @@ def test_boot_chat_enter_send_respects_ime_composition():
         _ime_guarded_enter_pattern("e", require_no_shift=True),
         BOOT_JS,
         re.DOTALL,
-    ), "Command dropdown Enter handler must ignore IME composition Enter in static/boot.js"
+    ), (
+        "Command dropdown Enter handler must ignore IME composition Enter in static/boot.js"
+    )
 
 
 def test_ui_enter_submit_paths_respect_ime_composition():
@@ -50,20 +52,21 @@ def test_ui_enter_submit_paths_respect_ime_composition():
         rf"document\.addEventListener\('keydown',e=>\{{[\s\S]*?{_ime_guarded_enter_pattern('e')}",
         UI_JS,
         re.DOTALL,
-    ), \
-        "App dialog Enter handler must ignore IME composition Enter in static/ui.js"
+    ), "App dialog Enter handler must ignore IME composition Enter in static/ui.js"
     assert re.search(
         _ime_guarded_enter_pattern("e", require_no_shift=True),
         UI_JS,
         re.DOTALL,
-    ), \
+    ), (
         "Message edit Enter-to-save handler must ignore IME composition Enter in static/ui.js"
+    )
     assert re.search(
         rf"inp\.onkeydown=\(e2\)=>\{{\s*{_ime_guarded_enter_pattern('e2')}",
         UI_JS,
         re.DOTALL,
-    ), \
+    ), (
         "Workspace rename Enter handler must ignore IME composition Enter in static/ui.js"
+    )
 
 
 def test_sessions_enter_submit_paths_respect_ime_composition():
@@ -72,5 +75,6 @@ def test_sessions_enter_submit_paths_respect_ime_composition():
         SESSIONS_JS,
         re.DOTALL,
     )
-    assert len(matches) >= 3, \
+    assert len(matches) >= 3, (
         "Session and project rename/create Enter handlers must ignore IME composition Enter in static/sessions.js"
+    )

--- a/tests/test_import_cli_session_lineage.py
+++ b/tests/test_import_cli_session_lineage.py
@@ -4,21 +4,21 @@ import json
 def test_import_cli_session_preserves_parent_session_id():
     from api.models import import_cli_session, SESSION_DIR, Session
 
-    parent_id = 'parent_lineage_001'
-    child_id = 'child_lineage_001'
+    parent_id = "parent_lineage_001"
+    child_id = "child_lineage_001"
 
     # Ensure clean fixture state for direct model-level import.
     for sid in (parent_id, child_id):
         try:
-            (SESSION_DIR / f'{sid}.json').unlink(missing_ok=True)
+            (SESSION_DIR / f"{sid}.json").unlink(missing_ok=True)
         except Exception:
             pass
 
     session = import_cli_session(
         child_id,
-        'Child Session',
-        [{'role': 'user', 'content': 'hello', 'timestamp': 1.0}],
-        model='test-model',
+        "Child Session",
+        [{"role": "user", "content": "hello", "timestamp": 1.0}],
+        model="test-model",
         parent_session_id=parent_id,
         created_at=1.0,
         updated_at=2.0,
@@ -26,9 +26,9 @@ def test_import_cli_session_preserves_parent_session_id():
 
     assert session.parent_session_id == parent_id
 
-    payload = json.loads((SESSION_DIR / f'{child_id}.json').read_text(encoding='utf-8'))
-    assert payload['parent_session_id'] == parent_id
+    payload = json.loads((SESSION_DIR / f"{child_id}.json").read_text(encoding="utf-8"))
+    assert payload["parent_session_id"] == parent_id
 
     loaded = Session.load(child_id)
     assert loaded.parent_session_id == parent_id
-    assert loaded.compact()['parent_session_id'] == parent_id
+    assert loaded.compact()["parent_session_id"] == parent_id

--- a/tests/test_inflight_stream_reuse.py
+++ b/tests/test_inflight_stream_reuse.py
@@ -1,4 +1,5 @@
 """Regression tests for preserving live streams across session switches."""
+
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).parent.parent
@@ -37,9 +38,15 @@ def test_attach_live_stream_reuses_existing_same_stream_transport():
     body = _function_body(MESSAGES_JS, "attachLiveStream")
     close_pos = body.find("\n  closeLiveStream(activeSid);\n")
     reuse_pos = body.find("const existingLive=LIVE_STREAMS[activeSid]")
-    assert reuse_pos != -1, "attachLiveStream() should check for an existing live stream"
-    assert close_pos != -1, "attachLiveStream() should still close stale/different streams"
-    assert reuse_pos < close_pos, "same-stream reuse must run before closeLiveStream(activeSid)"
+    assert reuse_pos != -1, (
+        "attachLiveStream() should check for an existing live stream"
+    )
+    assert close_pos != -1, (
+        "attachLiveStream() should still close stale/different streams"
+    )
+    assert reuse_pos < close_pos, (
+        "same-stream reuse must run before closeLiveStream(activeSid)"
+    )
     assert "existingLive.streamId===streamId" in body
     assert "existingLive.source.readyState!==EventSource.CLOSED" in body
     assert "return" in body[reuse_pos:close_pos]
@@ -48,7 +55,9 @@ def test_attach_live_stream_reuses_existing_same_stream_transport():
 def test_attach_live_stream_updates_uploads_before_same_stream_reuse():
     """Reusing transport must not skip per-session uploaded attachment state."""
     body = _function_body(MESSAGES_JS, "attachLiveStream")
-    upload_pos = body.find("if(uploaded.length) INFLIGHT[activeSid].uploaded=[...uploaded]")
+    upload_pos = body.find(
+        "if(uploaded.length) INFLIGHT[activeSid].uploaded=[...uploaded]"
+    )
     reuse_pos = body.find("const existingLive=LIVE_STREAMS[activeSid]")
     close_pos = body.find("\n  closeLiveStream(activeSid);\n")
     assert upload_pos != -1

--- a/tests/test_insights.py
+++ b/tests/test_insights.py
@@ -60,7 +60,9 @@ def _day(ts):
     return time.strftime("%Y-%m-%d", time.localtime(ts))
 
 
-def test_insights_daily_tokens_zero_fills_selected_range_and_parses_cost(monkeypatch, tmp_path):
+def test_insights_daily_tokens_zero_fills_selected_range_and_parses_cost(
+    monkeypatch, tmp_path
+):
     now = time.mktime((2026, 5, 4, 12, 0, 0, 0, 0, -1))
     two_days_ago = now - (2 * 86400)
     entries = [
@@ -115,9 +117,30 @@ def test_insights_daily_tokens_zero_fills_selected_range_and_parses_cost(monkeyp
 def test_insights_model_breakdown_tracks_tokens_cost_and_shares(monkeypatch, tmp_path):
     now = time.mktime((2026, 5, 4, 12, 0, 0, 0, 0, -1))
     entries = [
-        {"updated_at": now, "message_count": 1, "model": "cheap", "input_tokens": 200, "output_tokens": 50, "estimated_cost": 0.01},
-        {"updated_at": now, "message_count": 1, "model": "costly", "input_tokens": 100, "output_tokens": 50, "estimated_cost": "0.20"},
-        {"updated_at": now, "message_count": 1, "model": "cheap", "input_tokens": 300, "output_tokens": 150, "estimated_cost": "$0.04"},
+        {
+            "updated_at": now,
+            "message_count": 1,
+            "model": "cheap",
+            "input_tokens": 200,
+            "output_tokens": 50,
+            "estimated_cost": 0.01,
+        },
+        {
+            "updated_at": now,
+            "message_count": 1,
+            "model": "costly",
+            "input_tokens": 100,
+            "output_tokens": 50,
+            "estimated_cost": "0.20",
+        },
+        {
+            "updated_at": now,
+            "message_count": 1,
+            "model": "cheap",
+            "input_tokens": 300,
+            "output_tokens": 150,
+            "estimated_cost": "$0.04",
+        },
     ]
 
     data = _call_insights(monkeypatch, tmp_path, entries, days="7", now=now)

--- a/tests/test_issue1013_handoff_dock.py
+++ b/tests/test_issue1013_handoff_dock.py
@@ -77,37 +77,60 @@ def test_handoff_dock_reserves_transcript_space_like_terminal_dock():
 
 
 def test_handoff_dock_width_aligns_with_existing_slide_up_panels():
-    assert ".handoff-hint-container{position:absolute;left:0;right:0;bottom:-2px;width:min(calc(100% - 112px),560px);" in STYLE_CSS
+    assert (
+        ".handoff-hint-container{position:absolute;left:0;right:0;bottom:-2px;width:min(calc(100% - 112px),560px);"
+        in STYLE_CSS
+    )
     assert ".handoff-hint-container{bottom:-2px;width:calc(100% - 28px);}" in STYLE_CSS
     start = STYLE_CSS.find(".handoff-hint-container")
     assert start != -1
     end = STYLE_CSS.find("}", start)
     assert end != -1
-    handoff_hint_rule = STYLE_CSS[start:end+1]
+    handoff_hint_rule = STYLE_CSS[start : end + 1]
     assert "width:min(calc(100% - 112px),560px)" in handoff_hint_rule
     assert "border-bottom:none;border-radius:13px 13px 0 0" in STYLE_CSS
     assert "padding:7px 12px 9px" in STYLE_CSS
-    assert ".handoff-hint-text{min-width:0;display:flex;align-items:center;gap:10px;color:var(--muted);font-size:12px;font-weight:700;line-height:1.2;" in STYLE_CSS
-    assert ".handoff-hint-action,.handoff-hint-dismiss{border:none;background:transparent;color:var(--muted);font:inherit;font-size:12px;font-weight:700;line-height:1.2;" in STYLE_CSS
-    assert ".handoff-hint-dot{width:7px;height:7px;border-radius:999px;background:var(--success);" in STYLE_CSS
+    assert (
+        ".handoff-hint-text{min-width:0;display:flex;align-items:center;gap:10px;color:var(--muted);font-size:12px;font-weight:700;line-height:1.2;"
+        in STYLE_CSS
+    )
+    assert (
+        ".handoff-hint-action,.handoff-hint-dismiss{border:none;background:transparent;color:var(--muted);font:inherit;font-size:12px;font-weight:700;line-height:1.2;"
+        in STYLE_CSS
+    )
+    assert (
+        ".handoff-hint-dot{width:7px;height:7px;border-radius:999px;background:var(--success);"
+        in STYLE_CSS
+    )
 
 
 def test_handoff_summary_fallback_displays_clear_user_note():
     assert "const isFallback=!!state.fallback;" in UI_JS
-    assert "class=\"handoff-summary-fallback-note\"" in UI_JS
-    assert "Fallback summary generated from recent turns; no model-based rewrite was used." in UI_JS
+    assert 'class="handoff-summary-fallback-note"' in UI_JS
+    assert (
+        "Fallback summary generated from recent turns; no model-based rewrite was used."
+        in UI_JS
+    )
 
 
 def test_handoff_delete_clears_local_storage_markers():
     assert "function _clearHandoffStorageForSession(sid) {" in SESSIONS_JS
-    assert "_setHandoffStorageValue(sid, _HANDOFF_SUFFIX_DISMISSED_AT, null);" in SESSIONS_JS
-    assert "_setHandoffStorageValue(sid, _HANDOFF_SUFFIX_SUMMARY_HANDLED_AT, null);" in SESSIONS_JS
+    assert (
+        "_setHandoffStorageValue(sid, _HANDOFF_SUFFIX_DISMISSED_AT, null);"
+        in SESSIONS_JS
+    )
+    assert (
+        "_setHandoffStorageValue(sid, _HANDOFF_SUFFIX_SUMMARY_HANDLED_AT, null);"
+        in SESSIONS_JS
+    )
     assert "_clearHandoffStorageForSession(sid);" in SESSIONS_JS
     assert "ids.forEach(_clearHandoffStorageForSession);" in SESSIONS_JS
 
 
 def test_handoff_summary_renders_as_transcript_card_not_dock_card():
-    assert "function setHandoffUi" in SESSIONS_JS or "function setHandoffUi" in (ROOT / "static" / "ui.js").read_text(encoding="utf-8")
+    assert "function setHandoffUi" in SESSIONS_JS or "function setHandoffUi" in (
+        ROOT / "static" / "ui.js"
+    ).read_text(encoding="utf-8")
     ui_js = (ROOT / "static" / "ui.js").read_text(encoding="utf-8")
     assert "_handoffCardsNode" in ui_js
     assert "data-handoff-card" in ui_js
@@ -115,7 +138,10 @@ def test_handoff_summary_renders_as_transcript_card_not_dock_card():
     assert 'class="tool-card-result handoff-summary-body"' in ui_js
     assert "renderMd(detail)" in ui_js
     assert "_insertCompressionLikeNode(handoffState?_handoffCardsNode" in ui_js
-    assert "window._handoffUi&&(!window._handoffUi.sessionId||window._handoffUi.sessionId===sid)" in ui_js
+    assert (
+        "window._handoffUi&&(!window._handoffUi.sessionId||window._handoffUi.sessionId===sid)"
+        in ui_js
+    )
     assert "!hasTransientTranscriptUi" in ui_js
     assert "handoff-summary-card" not in SESSIONS_JS
     assert "handoff-summary-card" not in STYLE_CSS
@@ -159,11 +185,15 @@ def test_handoff_summary_prompt_uses_you_and_你():
 def test_generating_handoff_summary_marks_session_as_handled():
     """Summary success uses a max(dismissed/handled) baseline for future checks."""
     generate_start = SESSIONS_JS.index("async function _generateHandoffSummary")
-    resolve_start = SESSIONS_JS.index("function _resolveSessionModelForDisplaySoon", generate_start)
+    resolve_start = SESSIONS_JS.index(
+        "function _resolveSessionModelForDisplaySoon", generate_start
+    )
     generate_body = SESSIONS_JS[generate_start:resolve_start]
 
     dismiss_start = SESSIONS_JS.index("function _dismissHandoffHint")
-    generate_start_after_dismiss = SESSIONS_JS.index("async function _generateHandoffSummary", dismiss_start)
+    generate_start_after_dismiss = SESSIONS_JS.index(
+        "async function _generateHandoffSummary", dismiss_start
+    )
     dismiss_body = SESSIONS_JS[dismiss_start:generate_start_after_dismiss]
 
     assert "_getHandoffSince(sid)" in generate_body
@@ -200,23 +230,38 @@ def test_no_api_key_handoff_summary_persists_fallback_summary(monkeypatch):
 
     # Force API-path validation to focus on fallback behavior only.
     monkeypatch.setattr(routes, "require", lambda body, *keys: None)
-    monkeypatch.setattr(routes, "bad", lambda _handler, msg, status=400: {"ok": False, "error": msg, "status": status})
-    monkeypatch.setattr(routes, "j", lambda _handler, payload, status=200, extra_headers=None: payload)
+    monkeypatch.setattr(
+        routes,
+        "bad",
+        lambda _handler, msg, status=400: {"ok": False, "error": msg, "status": status},
+    )
+    monkeypatch.setattr(
+        routes, "j", lambda _handler, payload, status=200, extra_headers=None: payload
+    )
 
     persisted = []
     monkeypatch.setattr(
         routes,
         "_persist_handoff_summary",
-        lambda sid, summary, channel, rounds, fallback=False: persisted.append({
-            "sid": sid,
-            "summary": summary,
-            "channel": channel,
-            "rounds": rounds,
-            "fallback": fallback,
-        }) or {"ok": True},
+        lambda sid, summary, channel, rounds, fallback=False: (
+            persisted.append(
+                {
+                    "sid": sid,
+                    "summary": summary,
+                    "channel": channel,
+                    "rounds": rounds,
+                    "fallback": fallback,
+                }
+            )
+            or {"ok": True}
+        ),
     )
 
-    monkeypatch.setattr(models, "count_conversation_rounds", lambda sid, since=None: models.CONVERSATION_ROUND_THRESHOLD)
+    monkeypatch.setattr(
+        models,
+        "count_conversation_rounds",
+        lambda sid, since=None: models.CONVERSATION_ROUND_THRESHOLD,
+    )
     monkeypatch.setattr(
         models,
         "get_cli_session_messages",
@@ -225,17 +270,27 @@ def test_no_api_key_handoff_summary_persists_fallback_summary(monkeypatch):
             {"role": "assistant", "content": "I'll help you", "timestamp": 2.0},
         ],
     )
-    monkeypatch.setattr(cfg, "resolve_model_provider", lambda resolved_model=None: ("gpt-test", "openrouter", None))
+    monkeypatch.setattr(
+        cfg,
+        "resolve_model_provider",
+        lambda resolved_model=None: ("gpt-test", "openrouter", None),
+    )
 
     fake_runtime_module = types.ModuleType("hermes_cli.runtime_provider")
-    fake_runtime_module.resolve_runtime_provider = lambda requested=None: {"api_key": "", "provider": "openrouter", "base_url": None}
+    fake_runtime_module.resolve_runtime_provider = lambda requested=None: {
+        "api_key": "",
+        "provider": "openrouter",
+        "base_url": None,
+    }
     fake_hermes_cli = types.ModuleType("hermes_cli")
     fake_hermes_cli.__path__ = []
     fake_hermes_cli.runtime_provider = fake_runtime_module
     monkeypatch.setitem(sys.modules, "hermes_cli", fake_hermes_cli)
     monkeypatch.setitem(sys.modules, "hermes_cli.runtime_provider", fake_runtime_module)
 
-    response = routes._handle_handoff_summary(object(), {"session_id": "session-without-api-key"})
+    response = routes._handle_handoff_summary(
+        object(), {"session_id": "session-without-api-key"}
+    )
 
     assert response["ok"] is True
     assert response["fallback"] is True
@@ -255,23 +310,38 @@ def test_exception_handoff_summary_persists_fallback_summary(monkeypatch):
     import api.models as models
 
     monkeypatch.setattr(routes, "require", lambda body, *keys: None)
-    monkeypatch.setattr(routes, "bad", lambda _handler, msg, status=400: {"ok": False, "error": msg, "status": status})
-    monkeypatch.setattr(routes, "j", lambda _handler, payload, status=200, extra_headers=None: payload)
+    monkeypatch.setattr(
+        routes,
+        "bad",
+        lambda _handler, msg, status=400: {"ok": False, "error": msg, "status": status},
+    )
+    monkeypatch.setattr(
+        routes, "j", lambda _handler, payload, status=200, extra_headers=None: payload
+    )
 
     persisted = []
     monkeypatch.setattr(
         routes,
         "_persist_handoff_summary",
-        lambda sid, summary, channel, rounds, fallback=False: persisted.append({
-            "sid": sid,
-            "summary": summary,
-            "channel": channel,
-            "rounds": rounds,
-            "fallback": fallback,
-        }) or {"ok": True},
+        lambda sid, summary, channel, rounds, fallback=False: (
+            persisted.append(
+                {
+                    "sid": sid,
+                    "summary": summary,
+                    "channel": channel,
+                    "rounds": rounds,
+                    "fallback": fallback,
+                }
+            )
+            or {"ok": True}
+        ),
     )
 
-    monkeypatch.setattr(models, "count_conversation_rounds", lambda sid, since=None: models.CONVERSATION_ROUND_THRESHOLD)
+    monkeypatch.setattr(
+        models,
+        "count_conversation_rounds",
+        lambda sid, since=None: models.CONVERSATION_ROUND_THRESHOLD,
+    )
     monkeypatch.setattr(
         models,
         "get_cli_session_messages",
@@ -280,7 +350,11 @@ def test_exception_handoff_summary_persists_fallback_summary(monkeypatch):
             {"role": "assistant", "content": "Sure, I can help", "timestamp": 2.0},
         ],
     )
-    monkeypatch.setattr(cfg, "resolve_model_provider", lambda resolved_model=None: ("gpt-test", "openrouter", None))
+    monkeypatch.setattr(
+        cfg,
+        "resolve_model_provider",
+        lambda resolved_model=None: ("gpt-test", "openrouter", None),
+    )
 
     fake_runtime_module = types.ModuleType("hermes_cli.runtime_provider")
     fake_runtime_module.resolve_runtime_provider = lambda requested=None: {
@@ -326,7 +400,9 @@ def test_exception_handoff_summary_persists_fallback_summary(monkeypatch):
     fake_run_agent.AIAgent = _FailingAgent
     monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
 
-    response = routes._handle_handoff_summary(object(), {"session_id": "session-with-exception"})
+    response = routes._handle_handoff_summary(
+        object(), {"session_id": "session-with-exception"}
+    )
 
     assert response["ok"] is True
     assert response["fallback"] is True
@@ -347,34 +423,65 @@ def test_handoff_summary_retries_once_when_length_limit_reached(monkeypatch):
     import api.models as models
 
     monkeypatch.setattr(routes, "require", lambda body, *keys: None)
-    monkeypatch.setattr(routes, "bad", lambda _handler, msg, status=400: {"ok": False, "error": msg, "status": status})
-    monkeypatch.setattr(routes, "j", lambda _handler, payload, status=200, extra_headers=None: payload)
+    monkeypatch.setattr(
+        routes,
+        "bad",
+        lambda _handler, msg, status=400: {"ok": False, "error": msg, "status": status},
+    )
+    monkeypatch.setattr(
+        routes, "j", lambda _handler, payload, status=200, extra_headers=None: payload
+    )
 
     persisted = []
     monkeypatch.setattr(
         routes,
         "_persist_handoff_summary",
-        lambda sid, summary, channel, rounds, fallback=False: persisted.append({
-            "sid": sid,
-            "summary": summary,
-            "channel": channel,
-            "rounds": rounds,
-            "fallback": fallback,
-        }) or {"ok": True},
+        lambda sid, summary, channel, rounds, fallback=False: (
+            persisted.append(
+                {
+                    "sid": sid,
+                    "summary": summary,
+                    "channel": channel,
+                    "rounds": rounds,
+                    "fallback": fallback,
+                }
+            )
+            or {"ok": True}
+        ),
     )
 
-    monkeypatch.setattr(models, "count_conversation_rounds", lambda sid, since=None: models.CONVERSATION_ROUND_THRESHOLD)
+    monkeypatch.setattr(
+        models,
+        "count_conversation_rounds",
+        lambda sid, since=None: models.CONVERSATION_ROUND_THRESHOLD,
+    )
     monkeypatch.setattr(
         models,
         "get_cli_session_messages",
         lambda sid: [
-            {"role": "user", "content": "Can we switch to a different method?", "timestamp": 1.0},
-            {"role": "assistant", "content": "Sure, here is the outline.", "timestamp": 2.0},
+            {
+                "role": "user",
+                "content": "Can we switch to a different method?",
+                "timestamp": 1.0,
+            },
+            {
+                "role": "assistant",
+                "content": "Sure, here is the outline.",
+                "timestamp": 2.0,
+            },
             {"role": "user", "content": "Keep going.", "timestamp": 3.0},
-            {"role": "assistant", "content": "Step 1 is done, step 2 is pending.", "timestamp": 4.0},
+            {
+                "role": "assistant",
+                "content": "Step 1 is done, step 2 is pending.",
+                "timestamp": 4.0,
+            },
         ],
     )
-    monkeypatch.setattr(cfg, "resolve_model_provider", lambda resolved_model=None: ("gpt-test", "openrouter", None))
+    monkeypatch.setattr(
+        cfg,
+        "resolve_model_provider",
+        lambda resolved_model=None: ("gpt-test", "openrouter", None),
+    )
 
     completion_calls = []
 
@@ -388,15 +495,26 @@ def test_handoff_summary_retries_once_when_length_limit_reached(monkeypatch):
         class completions:
             @staticmethod
             def create(*args, **kwargs):
-                max_tokens = kwargs.get("max_tokens") or kwargs.get("max_completion_tokens")
+                max_tokens = kwargs.get("max_tokens") or kwargs.get(
+                    "max_completion_tokens"
+                )
                 completion_calls.append(max_tokens)
                 if len(completion_calls) == 1:
-                    return types.SimpleNamespace(choices=[
-                        _choice("- You can do step A, B, and C", finish_reason="length")
-                    ])
-                return types.SimpleNamespace(choices=[
-                    _choice("- You should continue with step D.\n- You can then review results.", finish_reason="stop")
-                ])
+                    return types.SimpleNamespace(
+                        choices=[
+                            _choice(
+                                "- You can do step A, B, and C", finish_reason="length"
+                            )
+                        ]
+                    )
+                return types.SimpleNamespace(
+                    choices=[
+                        _choice(
+                            "- You should continue with step D.\n- You can then review results.",
+                            finish_reason="stop",
+                        )
+                    ]
+                )
 
     class _Chat:
         completions = _Client.completions
@@ -436,7 +554,9 @@ def test_handoff_summary_retries_once_when_length_limit_reached(monkeypatch):
     monkeypatch.setitem(sys.modules, "hermes_cli", fake_hermes_cli)
     monkeypatch.setitem(sys.modules, "hermes_cli.runtime_provider", fake_runtime_module)
 
-    response = routes._handle_handoff_summary(object(), {"session_id": "session-length-retry"})
+    response = routes._handle_handoff_summary(
+        object(), {"session_id": "session-length-retry"}
+    )
 
     assert response["ok"] is True
     assert response["fallback"] is False
@@ -454,47 +574,76 @@ def test_handoff_summary_falls_back_when_retry_still_incomplete(monkeypatch):
     import api.models as models
 
     monkeypatch.setattr(routes, "require", lambda body, *keys: None)
-    monkeypatch.setattr(routes, "bad", lambda _handler, msg, status=400: {"ok": False, "error": msg, "status": status})
-    monkeypatch.setattr(routes, "j", lambda _handler, payload, status=200, extra_headers=None: payload)
+    monkeypatch.setattr(
+        routes,
+        "bad",
+        lambda _handler, msg, status=400: {"ok": False, "error": msg, "status": status},
+    )
+    monkeypatch.setattr(
+        routes, "j", lambda _handler, payload, status=200, extra_headers=None: payload
+    )
 
     persisted = []
     monkeypatch.setattr(
         routes,
         "_persist_handoff_summary",
-        lambda sid, summary, channel, rounds, fallback=False: persisted.append({
-            "sid": sid,
-            "summary": summary,
-            "channel": channel,
-            "rounds": rounds,
-            "fallback": fallback,
-        }) or {"ok": True},
+        lambda sid, summary, channel, rounds, fallback=False: (
+            persisted.append(
+                {
+                    "sid": sid,
+                    "summary": summary,
+                    "channel": channel,
+                    "rounds": rounds,
+                    "fallback": fallback,
+                }
+            )
+            or {"ok": True}
+        ),
     )
 
-    monkeypatch.setattr(models, "count_conversation_rounds", lambda sid, since=None: models.CONVERSATION_ROUND_THRESHOLD)
+    monkeypatch.setattr(
+        models,
+        "count_conversation_rounds",
+        lambda sid, since=None: models.CONVERSATION_ROUND_THRESHOLD,
+    )
     monkeypatch.setattr(
         models,
         "get_cli_session_messages",
         lambda sid: [
             {"role": "user", "content": "Could you plan next moves?", "timestamp": 1.0},
-            {"role": "assistant", "content": "Let's draft a schedule.", "timestamp": 2.0},
+            {
+                "role": "assistant",
+                "content": "Let's draft a schedule.",
+                "timestamp": 2.0,
+            },
             {"role": "user", "content": "Anything else?", "timestamp": 3.0},
-            {"role": "assistant", "content": "Yes, one more check is needed.", "timestamp": 4.0},
+            {
+                "role": "assistant",
+                "content": "Yes, one more check is needed.",
+                "timestamp": 4.0,
+            },
         ],
     )
-    monkeypatch.setattr(cfg, "resolve_model_provider", lambda resolved_model=None: ("gpt-test", "openrouter", None))
+    monkeypatch.setattr(
+        cfg,
+        "resolve_model_provider",
+        lambda resolved_model=None: ("gpt-test", "openrouter", None),
+    )
 
     class _Client:
         class completions:
             @staticmethod
             def create(*args, **kwargs):
-                return types.SimpleNamespace(choices=[
-                    types.SimpleNamespace(
-                        message=types.SimpleNamespace(
-                            content="I can help summarize this but",
+                return types.SimpleNamespace(
+                    choices=[
+                        types.SimpleNamespace(
+                            message=types.SimpleNamespace(
+                                content="I can help summarize this but",
                             ),
-                        finish_reason="length",
-                    )
-                ])
+                            finish_reason="length",
+                        )
+                    ]
+                )
 
     class _Chat:
         completions = _Client.completions
@@ -531,7 +680,9 @@ def test_handoff_summary_falls_back_when_retry_still_incomplete(monkeypatch):
     monkeypatch.setitem(sys.modules, "hermes_cli", fake_hermes_cli)
     monkeypatch.setitem(sys.modules, "hermes_cli.runtime_provider", fake_runtime_module)
 
-    response = routes._handle_handoff_summary(object(), {"session_id": "session-length-fallback"})
+    response = routes._handle_handoff_summary(
+        object(), {"session_id": "session-length-fallback"}
+    )
 
     assert response["ok"] is True
     assert response["fallback"] is True
@@ -542,7 +693,9 @@ def test_handoff_summary_falls_back_when_retry_still_incomplete(monkeypatch):
     assert persisted[0]["sid"] == "session-length-fallback"
 
 
-def test_handoff_summary_persistence_targets_both_backends_for_messaging_session(tmp_path, monkeypatch):
+def test_handoff_summary_persistence_targets_both_backends_for_messaging_session(
+    tmp_path, monkeypatch
+):
     """Messaging sessions should persist handoff summary markers into both local JSON and state.db."""
     import api.routes as routes
     import api.models as models
@@ -580,7 +733,9 @@ def test_handoff_summary_persistence_targets_both_backends_for_messaging_session
         session.source_label = "Telegram"
         session.save(touch_updated_at=False)
 
-        routes._persist_handoff_summary(sid, "Please handoff after context", "telegram", 2, False)
+        routes._persist_handoff_summary(
+            sid, "Please handoff after context", "telegram", 2, False
+        )
 
         saved = models.Session.load(sid)
         assert len(saved.messages) == 2
@@ -607,7 +762,9 @@ def test_handoff_summary_persistence_targets_both_backends_for_messaging_session
         conn.close()
 
 
-def test_persisted_handoff_summary_deduplicates_identical_tail_markers(tmp_path, monkeypatch):
+def test_persisted_handoff_summary_deduplicates_identical_tail_markers(
+    tmp_path, monkeypatch
+):
     """When the tail already contains the same handoff marker, repeated generation should be idempotent."""
     import api.routes as routes
     import api.models as models
@@ -631,7 +788,9 @@ def test_persisted_handoff_summary_deduplicates_identical_tail_markers(tmp_path,
         )
         conn.commit()
 
-        marker = routes._build_handoff_summary_tool_message(sid, "Repeat me", "telegram", 3, False)
+        marker = routes._build_handoff_summary_tool_message(
+            sid, "Repeat me", "telegram", 3, False
+        )
         session = models.Session(
             session_id=sid,
             title="Imported Messaging Session",
@@ -669,7 +828,9 @@ def test_persisted_handoff_summary_deduplicates_identical_tail_markers(tmp_path,
         conn.close()
 
 
-def test_persist_handoff_summary_falls_back_when_local_session_file_missing(tmp_path, monkeypatch):
+def test_persist_handoff_summary_falls_back_when_local_session_file_missing(
+    tmp_path, monkeypatch
+):
     """Messaging session IDs should still persist to state.db when no local WebUI session exists."""
     import api.routes as routes
     import api.profiles as profiles
@@ -684,7 +845,9 @@ def test_persist_handoff_summary_falls_back_when_local_session_file_missing(tmp_
     # Force messaging classification while keeping the local shell absent.
     monkeypatch.setattr(routes, "_is_messaging_session_id", lambda _sid: True)
     try:
-        routes._persist_handoff_summary(sid, "Persist without local shell", "telegram", 1, True)
+        routes._persist_handoff_summary(
+            sid, "Persist without local shell", "telegram", 1, True
+        )
         rows = conn.execute(
             "SELECT role, content FROM messages WHERE session_id = ? ORDER BY rowid ASC",
             (sid,),

--- a/tests/test_issue1014_model_not_found.py
+++ b/tests/test_issue1014_model_not_found.py
@@ -8,6 +8,7 @@ Covers:
   4. static/i18n.js: model_not_found_label key present in all locales
   5. streaming.py: model_not_found checked after auth but before generic error
 """
+
 import pathlib
 import re
 
@@ -19,6 +20,7 @@ def _read(rel_path: str) -> str:
 
 
 # ── 1. streaming.py: model-not-found error detection ─────────────────────────
+
 
 class TestStreamingModelNotFoundDetection:
     """streaming.py must classify 404/model-not-found errors as model_not_found."""
@@ -43,7 +45,7 @@ class TestStreamingModelNotFoundDetection:
         src = _read("api/streaming.py")
         idx = src.find("_exc_is_not_found")
         assert idx != -1, "_exc_is_not_found not found"
-        block = src[idx:idx + 600]
+        block = src[idx : idx + 600]
         assert "'404'" in block or '"404"' in block, (
             "'404' not in model-not-found detection block"
         )
@@ -52,7 +54,7 @@ class TestStreamingModelNotFoundDetection:
         """'not found' must be part of the detection logic."""
         src = _read("api/streaming.py")
         idx = src.find("_exc_is_not_found")
-        block = src[idx:idx + 600]
+        block = src[idx : idx + 600]
         assert "not found" in block.lower(), (
             "'not found' not in model-not-found detection block"
         )
@@ -61,7 +63,7 @@ class TestStreamingModelNotFoundDetection:
         """'does not exist' must be part of the detection logic."""
         src = _read("api/streaming.py")
         idx = src.find("_exc_is_not_found")
-        block = src[idx:idx + 600]
+        block = src[idx : idx + 600]
         assert "does not exist" in block.lower(), (
             "'does not exist' not in model-not-found detection block"
         )
@@ -70,7 +72,7 @@ class TestStreamingModelNotFoundDetection:
         """'invalid model' must be part of the detection logic."""
         src = _read("api/streaming.py")
         idx = src.find("_exc_is_not_found")
-        block = src[idx:idx + 600]
+        block = src[idx : idx + 600]
         assert "invalid model" in block.lower(), (
             "'invalid model' not in model-not-found detection block"
         )
@@ -79,7 +81,7 @@ class TestStreamingModelNotFoundDetection:
         """The model_not_found hint must mention Settings or hermes model."""
         src = _read("api/streaming.py")
         idx = src.find("model_not_found")
-        block = src[idx:idx + 500]
+        block = src[idx : idx + 500]
         assert "Settings" in block or "hermes model" in block, (
             "model_not_found hint must mention Settings or hermes model command"
         )
@@ -98,6 +100,7 @@ class TestStreamingModelNotFoundDetection:
 
 
 # ── 2. streaming.py: HTML sanitization ───────────────────────────────────────
+
 
 class TestStreamingHtmlSanitization:
     """Provider error messages containing HTML must be stripped."""
@@ -121,13 +124,14 @@ class TestStreamingHtmlSanitization:
         """Stripped HTML must have whitespace collapsed."""
         src = _read("api/streaming.py")
         sanitize_idx = src.find("re.sub(r'<[^>]+>'")
-        block = src[sanitize_idx:sanitize_idx + 300]
+        block = src[sanitize_idx : sanitize_idx + 300]
         assert r"\s+" in block, (
             "Whitespace normalization (\\s+) not found after HTML strip"
         )
 
 
 # ── 3. static/messages.js: apperror handler ──────────────────────────────────
+
 
 class TestApperrorModelNotFound:
     """messages.js apperror handler must handle model_not_found type."""
@@ -156,6 +160,7 @@ class TestApperrorModelNotFound:
 
 # ── 4. static/i18n.js: all locales ───────────────────────────────────────────
 
+
 class TestI18nModelNotFound:
     """All locales must have model_not_found_label."""
 
@@ -172,7 +177,7 @@ class TestI18nModelNotFound:
         return names
 
     def _count_key(self, src: str, key: str) -> int:
-        return len(re.findall(r'\b' + re.escape(key) + r'\b', src))
+        return len(re.findall(r"\b" + re.escape(key) + r"\b", src))
 
     def test_all_locales_have_model_not_found_label(self):
         """model_not_found_label must appear in all locales."""
@@ -192,7 +197,7 @@ class TestI18nModelNotFound:
         en_block = src[en_start:es_start]
         assert self.REQUIRED_KEY in en_block, "Key not in en block"
         idx = en_block.find(self.REQUIRED_KEY)
-        line = en_block[idx:idx + 200]
+        line = en_block[idx : idx + 200]
         assert "=>" not in line, (
             "model_not_found_label should be a plain string, not an arrow function"
         )

--- a/tests/test_issue1094_provider_bugs.py
+++ b/tests/test_issue1094_provider_bugs.py
@@ -33,7 +33,9 @@ def _post(path, body=None):
     """POST helper — returns (parsed_json, status_code)."""
     data = json.dumps(body or {}).encode()
     req = urllib.request.Request(
-        BASE + path, data=data, headers={"Content-Type": "application/json"},
+        BASE + path,
+        data=data,
+        headers={"Content-Type": "application/json"},
     )
     try:
         with urllib.request.urlopen(req, timeout=10) as r:
@@ -66,6 +68,7 @@ def _install_fake_hermes_cli(monkeypatch):
 
     try:
         from api.config import invalidate_models_cache
+
         invalidate_models_cache()
     except Exception:
         pass
@@ -82,11 +85,20 @@ def _setup_clean_config(monkeypatch, tmp_path):
 
     # Clear provider API key env vars to prevent host env leaking into tests
     _provider_env_vars = [
-        "OPENROUTER_API_KEY", "ANTHROPIC_API_KEY", "OPENAI_API_KEY",
-        "GOOGLE_API_KEY", "GEMINI_API_KEY", "GLM_API_KEY",
-        "KIMI_API_KEY", "DEEPSEEK_API_KEY", "MINIMAX_API_KEY",
-        "MISTRAL_API_KEY", "XAI_API_KEY", "OLLAMA_API_KEY",
-        "OPENCODE_ZEN_API_KEY", "OPENCODE_GO_API_KEY",
+        "OPENROUTER_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "OPENAI_API_KEY",
+        "GOOGLE_API_KEY",
+        "GEMINI_API_KEY",
+        "GLM_API_KEY",
+        "KIMI_API_KEY",
+        "DEEPSEEK_API_KEY",
+        "MINIMAX_API_KEY",
+        "MISTRAL_API_KEY",
+        "XAI_API_KEY",
+        "OLLAMA_API_KEY",
+        "OPENCODE_ZEN_API_KEY",
+        "OPENCODE_GO_API_KEY",
     ]
     for var in _provider_env_vars:
         monkeypatch.delenv(var, raising=False)
@@ -132,14 +144,18 @@ class TestBug1094HasKeyFalsePositive:
                 "model": "claude-sonnet-4-20250514",
             }
 
-            assert _provider_has_key("anthropic") is True, \
+            assert _provider_has_key("anthropic") is True, (
                 "anthropic (active provider) should have key"
-            assert _provider_has_key("openai") is False, \
+            )
+            assert _provider_has_key("openai") is False, (
                 "openai should NOT show has_key just because anthropic has model.api_key"
-            assert _provider_has_key("deepseek") is False, \
+            )
+            assert _provider_has_key("deepseek") is False, (
                 "deepseek should NOT show has_key just because anthropic has model.api_key"
-            assert _provider_has_key("openrouter") is False, \
+            )
+            assert _provider_has_key("openrouter") is False, (
                 "openrouter should NOT show has_key just because anthropic has model.api_key"
+            )
         finally:
             _restore_config(old_cfg, old_mtime)
 
@@ -209,6 +225,7 @@ class TestBug1094RemoveProviderKey:
 
         # Create a fake config.yaml with a provider key
         import yaml as _yaml
+
         config_path = tmp_path / "config.yaml"
         config_data = {
             "model": {"provider": "anthropic", "model": "claude-sonnet-4-20250514"},
@@ -235,14 +252,16 @@ class TestBug1094RemoveProviderKey:
             # Verify key is gone from config.yaml
             reloaded = _yaml.safe_load(config_path.read_text(encoding="utf-8"))
             deepseek_cfg = reloaded.get("providers", {}).get("deepseek", {})
-            assert "api_key" not in deepseek_cfg, \
+            assert "api_key" not in deepseek_cfg, (
                 "api_key should be removed from providers.deepseek in config.yaml"
+            )
 
             # Verify _provider_has_key no longer detects it
             config.cfg.clear()
             config.cfg.update(reloaded)
-            assert _provider_has_key("deepseek") is False, \
+            assert _provider_has_key("deepseek") is False, (
                 "deepseek should not have key after removal"
+            )
         finally:
             _restore_config(old_cfg, old_mtime)
 
@@ -251,6 +270,7 @@ class TestBug1094RemoveProviderKey:
         old_cfg, old_mtime = _setup_clean_config(monkeypatch, tmp_path)
 
         import yaml as _yaml
+
         config_path = tmp_path / "config.yaml"
         config_data = {
             "model": {
@@ -274,8 +294,9 @@ class TestBug1094RemoveProviderKey:
 
             reloaded = _yaml.safe_load(config_path.read_text(encoding="utf-8"))
             model_cfg = reloaded.get("model", {})
-            assert "api_key" not in model_cfg, \
+            assert "api_key" not in model_cfg, (
                 "api_key should be removed from model section in config.yaml"
+            )
 
             config.cfg.clear()
             config.cfg.update(reloaded)
@@ -290,6 +311,7 @@ class TestBug1094RemoveProviderKey:
         old_cfg, old_mtime = _setup_clean_config(monkeypatch, tmp_path)
 
         import yaml as _yaml
+
         config_path = tmp_path / "config.yaml"
         config_data = {
             "model": {
@@ -314,8 +336,9 @@ class TestBug1094RemoveProviderKey:
 
             reloaded = _yaml.safe_load(config_path.read_text(encoding="utf-8"))
             # anthropic's model.api_key should still exist (we only removed deepseek)
-            assert reloaded["model"].get("api_key"), \
+            assert reloaded["model"].get("api_key"), (
                 "model.api_key for active provider should not be removed"
+            )
             # deepseek's key should be gone
             assert "api_key" not in reloaded.get("providers", {}).get("deepseek", {})
         finally:
@@ -365,5 +388,6 @@ class TestBug1094Endpoints:
         assert anthropic is not None, "anthropic should be in providers list"
         # has_key should be False unless there's a config.yaml key set
         # (which integration tests won't have in tmp test state)
-        assert anthropic["has_key"] is False, \
+        assert anthropic["has_key"] is False, (
             f"anthropic should not have key after deletion, got has_key={anthropic['has_key']}"
+        )

--- a/tests/test_issue1095_pasted_images.py
+++ b/tests/test_issue1095_pasted_images.py
@@ -3,85 +3,101 @@
 Bug 1: Composer tray shows paperclip chip for images instead of thumbnail preview.
 Bug 2: Chat history renders uploaded images as broken <img> (wrong endpoint / dead URL).
 """
+
 import os
 import re
-import pytest
 
 
 def _read_js(name):
-    with open(os.path.join('static', name)) as f:
+    with open(os.path.join("static", name)) as f:
         return f.read()
 
 
 def _read_css():
-    with open(os.path.join('static', 'style.css')) as f:
+    with open(os.path.join("static", "style.css")) as f:
         return f.read()
 
 
 # ── Bug 1: Composer tray thumbnail previews ────────────────────────────────
+
 
 class TestComposerTrayThumbnails:
     """renderTray() must show thumbnail previews for image files, not paperclip chips."""
 
     def test_rendertray_checks_image_extension(self):
         """renderTray must branch on _IMAGE_EXTS for the file object in S.pendingFiles."""
-        ui = _read_js('ui.js')
+        ui = _read_js("ui.js")
         # Find renderTray function body
-        idx = ui.find('function renderTray()')
-        assert idx >= 0, 'renderTray() not found in ui.js'
-        body = ui[idx:idx + 800]
-        assert '_IMAGE_EXTS.test(' in body, 'renderTray must check _IMAGE_EXTS for thumbnail vs chip'
+        idx = ui.find("function renderTray()")
+        assert idx >= 0, "renderTray() not found in ui.js"
+        body = ui[idx : idx + 800]
+        assert "_IMAGE_EXTS.test(" in body, (
+            "renderTray must check _IMAGE_EXTS for thumbnail vs chip"
+        )
 
     def test_rendertray_uses_createobjecturl_for_images(self):
         """Image files must use URL.createObjectURL(f) to generate a blob URL for the thumbnail."""
-        ui = _read_js('ui.js')
-        idx = ui.find('function renderTray()')
-        body = ui[idx:idx + 800]
-        assert 'URL.createObjectURL(' in body, 'renderTray must use URL.createObjectURL for image thumbnails'
+        ui = _read_js("ui.js")
+        idx = ui.find("function renderTray()")
+        body = ui[idx : idx + 800]
+        assert "URL.createObjectURL(" in body, (
+            "renderTray must use URL.createObjectURL for image thumbnails"
+        )
 
     def test_rendertray_revokes_blob_url_on_remove(self):
         """Blob URLs must be revoked when a file is removed to prevent memory leaks."""
-        ui = _read_js('ui.js')
-        idx = ui.find('function renderTray()')
-        body = ui[idx:idx + 2500]
-        assert 'URL.revokeObjectURL(' in body, 'renderTray must revoke blob URL when chip is removed'
+        ui = _read_js("ui.js")
+        idx = ui.find("function renderTray()")
+        body = ui[idx : idx + 2500]
+        assert "URL.revokeObjectURL(" in body, (
+            "renderTray must revoke blob URL when chip is removed"
+        )
 
     def test_rendertray_uses_attach_thumb_class(self):
         """Image chips must use attach-thumb class for the thumbnail <img> element."""
-        ui = _read_js('ui.js')
-        idx = ui.find('function renderTray()')
-        body = ui[idx:idx + 800]
-        assert 'attach-thumb' in body, 'renderTray image chip must use attach-thumb class'
+        ui = _read_js("ui.js")
+        idx = ui.find("function renderTray()")
+        body = ui[idx : idx + 800]
+        assert "attach-thumb" in body, (
+            "renderTray image chip must use attach-thumb class"
+        )
 
     def test_rendertray_non_image_still_uses_paperclip(self):
         """Non-image files must still get the paperclip chip (not thumbnail)."""
-        ui = _read_js('ui.js')
-        idx = ui.find('function renderTray()')
-        body = ui[idx:idx + 800]
-        assert 'paperclip' in body, 'non-image files must still use paperclip chip in renderTray'
+        ui = _read_js("ui.js")
+        idx = ui.find("function renderTray()")
+        body = ui[idx : idx + 800]
+        assert "paperclip" in body, (
+            "non-image files must still use paperclip chip in renderTray"
+        )
 
     def test_attach_thumb_css_present(self):
         """CSS must define .attach-thumb with width/height/object-fit for the thumbnail."""
         css = _read_css()
-        assert '.attach-thumb' in css, '.attach-thumb CSS class must be defined'
+        assert ".attach-thumb" in css, ".attach-thumb CSS class must be defined"
         # Find the rule — use .attach-thumb{ to avoid matching .attach-thumb--svg variant
-        idx = css.find('.attach-thumb{')
-        assert idx >= 0, '.attach-thumb rule not found'
-        rule = css[idx:idx + 200]
-        assert 'object-fit' in rule, '.attach-thumb must set object-fit to crop image to square'
+        idx = css.find(".attach-thumb{")
+        assert idx >= 0, ".attach-thumb rule not found"
+        rule = css[idx : idx + 200]
+        assert "object-fit" in rule, (
+            ".attach-thumb must set object-fit to crop image to square"
+        )
 
     def test_attach_chip_image_variant_css(self):
         """CSS must define .attach-chip--image for the image chip variant."""
         css = _read_css()
-        assert '.attach-chip--image' in css, '.attach-chip--image CSS variant must be defined'
+        assert ".attach-chip--image" in css, (
+            ".attach-chip--image CSS variant must be defined"
+        )
 
     def test_adfiles_function_still_present(self):
         """addFiles() must still exist after renderTray refactor."""
-        ui = _read_js('ui.js')
-        assert 'function addFiles(' in ui, 'addFiles() must not be removed from ui.js'
+        ui = _read_js("ui.js")
+        assert "function addFiles(" in ui, "addFiles() must not be removed from ui.js"
 
 
 # ── Bug 2: Chat history image rendering ───────────────────────────────────
+
 
 class TestChatHistoryImageRendering:
     """Uploaded images in chat history must render via a working HTTP endpoint, not a dead path."""
@@ -96,57 +112,65 @@ class TestChatHistoryImageRendering:
         api/file/raw resolves the filename relative to the session's workspace, which is
         exactly where the upload endpoint stores the file.
         """
-        ui = _read_js('ui.js')
-        m = re.search(r'm\.attachments&&m\.attachments\.length', ui)
-        assert m, 'attachments rendering block not found in ui.js'
-        body = ui[m.start():m.start() + 2000]
-        assert 'api/file/raw' in body, (
-            'Image attachments in chat history must use api/file/raw endpoint '
-            '(resolves filename relative to session workspace). '
-            'api/media requires a full absolute path which is not stored on the client.'
+        ui = _read_js("ui.js")
+        m = re.search(r"m\.attachments&&m\.attachments\.length", ui)
+        assert m, "attachments rendering block not found in ui.js"
+        body = ui[m.start() : m.start() + 2000]
+        assert "api/file/raw" in body, (
+            "Image attachments in chat history must use api/file/raw endpoint "
+            "(resolves filename relative to session workspace). "
+            "api/media requires a full absolute path which is not stored on the client."
         )
-        assert 'api/media?path=' not in body, (
-            'api/media?path= must not be used for user-uploaded image attachments — '
-            'it expects a full absolute path, but only filenames are stored in m.attachments.'
+        assert "api/media?path=" not in body, (
+            "api/media?path= must not be used for user-uploaded image attachments — "
+            "it expects a full absolute path, but only filenames are stored in m.attachments."
         )
 
     def test_attachment_render_includes_session_id(self):
         """api/file/raw URL must include session_id parameter for workspace resolution."""
-        ui = _read_js('ui.js')
-        m = re.search(r'm\.attachments&&m\.attachments\.length', ui)
-        body = ui[m.start():m.start() + 2000]
-        assert 'session_id' in body, (
-            'api/file/raw URL in attachment rendering must include session_id '
-            'so the server can resolve the filename against the correct workspace.'
+        ui = _read_js("ui.js")
+        m = re.search(r"m\.attachments&&m\.attachments\.length", ui)
+        body = ui[m.start() : m.start() + 2000]
+        assert "session_id" in body, (
+            "api/file/raw URL in attachment rendering must include session_id "
+            "so the server can resolve the filename against the correct workspace."
         )
 
     def test_attachment_render_image_uses_msg_media_img(self):
         """Image attachments must still render with msg-media-img class for consistent styling."""
-        ui = _read_js('ui.js')
-        m = re.search(r'm\.attachments&&m\.attachments\.length', ui)
-        body = ui[m.start():m.start() + 2000]
-        assert 'msg-media-img' in body, 'Image attachment <img> must use msg-media-img class'
+        ui = _read_js("ui.js")
+        m = re.search(r"m\.attachments&&m\.attachments\.length", ui)
+        body = ui[m.start() : m.start() + 2000]
+        assert "msg-media-img" in body, (
+            "Image attachment <img> must use msg-media-img class"
+        )
 
     def test_attachment_render_click_to_fullscreen(self):
         """Click-to-fullscreen uses the delegated .msg-media-img listener, not inline JS."""
-        ui = _read_js('ui.js')
+        ui = _read_js("ui.js")
         assert "document.addEventListener('click'" in ui
         assert "closest('.msg-media-img')" in ui
-        m = re.search(r'm\.attachments&&m\.attachments\.length', ui)
-        body = ui[m.start():m.start() + 2000]
-        img_line = next(line for line in body.splitlines() if 'msg-media-img' in line)
-        assert 'onclick' not in img_line, 'Chat history image HTML must not embed inline JS handlers'
+        m = re.search(r"m\.attachments&&m\.attachments\.length", ui)
+        body = ui[m.start() : m.start() + 2000]
+        img_line = next(line for line in body.splitlines() if "msg-media-img" in line)
+        assert "onclick" not in img_line, (
+            "Chat history image HTML must not embed inline JS handlers"
+        )
 
     def test_attachment_render_non_image_keeps_paperclip(self):
         """Non-image attachments in chat history must still show paperclip badge."""
-        ui = _read_js('ui.js')
-        m = re.search(r'm\.attachments&&m\.attachments\.length', ui)
-        body = ui[m.start():m.start() + 2000]
-        assert 'msg-file-badge' in body, 'Non-image attachments must still use msg-file-badge in chat history'
+        ui = _read_js("ui.js")
+        m = re.search(r"m\.attachments&&m\.attachments\.length", ui)
+        body = ui[m.start() : m.start() + 2000]
+        assert "msg-file-badge" in body, (
+            "Non-image attachments must still use msg-file-badge in chat history"
+        )
 
     def test_attachment_render_extracts_filename(self):
         """Filename extraction (.split('/').pop()) must still be present for display."""
-        ui = _read_js('ui.js')
-        m = re.search(r'm\.attachments&&m\.attachments\.length', ui)
-        body = ui[m.start():m.start() + 2000]
-        assert ".split('/').pop()" in body, 'Must extract filename from path for display'
+        ui = _read_js("ui.js")
+        m = re.search(r"m\.attachments&&m\.attachments\.length", ui)
+        body = ui[m.start() : m.start() + 2000]
+        assert ".split('/').pop()" in body, (
+            "Must extract filename from path for display"
+        )

--- a/tests/test_issue1096_copy_buttons.py
+++ b/tests/test_issue1096_copy_buttons.py
@@ -1,4 +1,5 @@
 """Tests for #1096 — copy buttons work via Permissions-Policy + fallback."""
+
 import re
 
 
@@ -21,8 +22,9 @@ class TestClipboardPermissions:
         # Match the Permissions-Policy value string (may span lines)
         m = re.search(r"Permissions-Policy',\s*'(.*?)'", src, re.DOTALL)
         assert m, "Permissions-Policy header value must exist"
-        assert "clipboard-write=(self)" in m.group(1), \
+        assert "clipboard-write=(self)" in m.group(1), (
             "Permissions-Policy must include clipboard-write=(self)"
+        )
 
 
 class TestCopyTextFunction:
@@ -31,26 +33,30 @@ class TestCopyTextFunction:
     def test_copyText_uses_clipboard_api(self):
         """_copyText must call navigator.clipboard.writeText."""
         src = _src("ui.js")
-        assert "navigator.clipboard.writeText(text)" in src, \
+        assert "navigator.clipboard.writeText(text)" in src, (
             "_copyText must use Clipboard API"
+        )
 
     def test_copyText_has_fallback(self):
         """_copyText must fall back to execCommand if clipboard API fails."""
         src = _src("ui.js")
-        assert "function _fallbackCopy" in src, \
+        assert "function _fallbackCopy" in src, (
             "Must have a separate _fallbackCopy function"
+        )
         # Clipboard API call must .catch() to fallback
         m = re.search(r"navigator\.clipboard\.writeText\(text\)", src)
         assert m, "Must call clipboard API"
-        after = src[m.start():m.start() + 300]
-        assert "_fallbackCopy" in after, \
+        after = src[m.start() : m.start() + 300]
+        assert "_fallbackCopy" in after, (
             "clipboard.writeText must .catch() → _fallbackCopy"
+        )
 
     def test_fallbackCopy_uses_execCommand(self):
         """_fallbackCopy must use document.execCommand('copy')."""
         src = _src("ui.js")
-        assert "document.execCommand('copy')" in src, \
+        assert "document.execCommand('copy')" in src, (
             "_fallbackCopy must use execCommand('copy')"
+        )
 
     def test_fallbackCopy_focuses_textarea(self):
         """_fallbackCopy must explicitly focus textarea before select()."""
@@ -58,25 +64,25 @@ class TestCopyTextFunction:
         # Find _fallbackCopy function
         m = re.search(r"function _fallbackCopy", src)
         assert m, "_fallbackCopy function must exist"
-        fn = src[m.start():m.start() + 600]
-        assert "ta.focus()" in fn, \
-            "Must call .focus() on textarea before .select()"
+        fn = src[m.start() : m.start() + 600]
+        assert "ta.focus()" in fn, "Must call .focus() on textarea before .select()"
 
     def test_fallbackCopy_not_offscreen(self):
         """_fallbackCopy textarea must NOT be positioned at -9999px (fails in some browsers)."""
         src = _src("ui.js")
         m = re.search(r"function _fallbackCopy", src)
-        fn = src[m.start():m.start() + 600]
-        assert "-9999" not in fn, \
+        fn = src[m.start() : m.start() + 600]
+        assert "-9999" not in fn, (
             "Textarea must not be positioned at -9999px (offscreen select fails)"
+        )
 
     def test_copyMsg_copies_raw_text(self):
         """copyMsg must extract text from data-raw-text attribute."""
         src = _src("ui.js")
-        assert "closest('[data-raw-text]')" in src, \
+        assert "closest('[data-raw-text]')" in src, (
             "copyMsg must find nearest element with data-raw-text"
-        assert "dataset.rawText" in src, \
-            "copyMsg must read rawText from dataset"
+        )
+        assert "dataset.rawText" in src, "copyMsg must read rawText from dataset"
 
 
 class TestCodeCopyButton:
@@ -88,11 +94,11 @@ class TestCodeCopyButton:
         # Find addCopyButtons function
         m = re.search(r"function addCopyButtons", src)
         assert m, "addCopyButtons must exist"
-        fn = src[m.start():m.start() + 1000]
-        assert "_copyText" in fn, \
-            "Code copy button must use _copyText function"
-        assert "codeEl.textContent" in fn, \
+        fn = src[m.start() : m.start() + 1000]
+        assert "_copyText" in fn, "Code copy button must use _copyText function"
+        assert "codeEl.textContent" in fn, (
             "Code copy must copy the code element's textContent"
+        )
 
     def test_code_copy_button_is_idempotent_for_header_blocks(self):
         """Repeated post-render passes must not append duplicate header buttons.
@@ -105,15 +111,19 @@ class TestCodeCopyButton:
         src = _src("ui.js")
         m = re.search(r"function addCopyButtons", src)
         assert m, "addCopyButtons must exist"
-        fn = src[m.start():m.start() + 1200]
+        fn = src[m.start() : m.start() + 1200]
         assert "const header=pre.previousElementSibling;" in fn
         assert "header.querySelector('.code-copy-btn')" in fn
-        assert fn.index("header.querySelector('.code-copy-btn')") < fn.index("document.createElement('button')")
+        assert fn.index("header.querySelector('.code-copy-btn')") < fn.index(
+            "document.createElement('button')"
+        )
+
 
 class TestCopyFailedI18n:
-
     def test_copy_failed_in_all_locales(self):
         """copy_failed key must exist in all locale blocks (currently 7 with Korean)."""
-        i18n = _src('i18n.js')
-        count = i18n.count('copy_failed')
-        assert count >= 6, f'Expected copy_failed in at least 6 locale blocks, found {count}'
+        i18n = _src("i18n.js")
+        count = i18n.count("copy_failed")
+        assert count >= 6, (
+            f"Expected copy_failed in at least 6 locale blocks, found {count}"
+        )

--- a/tests/test_issue1097_workspace_drag_drop.py
+++ b/tests/test_issue1097_workspace_drag_drop.py
@@ -1,4 +1,5 @@
 """Tests for #1097 — drag & drop workspace files into chat composer."""
+
 import re
 
 
@@ -13,60 +14,66 @@ class TestWorkspaceDragDrop:
     def test_renderTreeItems_makes_items_draggable(self):
         """Each file-item must have draggable='true'."""
         src = _src("ui.js")
-        assert "el.setAttribute('draggable','true')" in src, \
+        assert "el.setAttribute('draggable','true')" in src, (
             "_renderTreeItems must set draggable=true on each item"
+        )
 
     def test_dragstart_stores_ws_path(self):
         """dragstart must store 'application/ws-path' with item.path."""
         src = _src("ui.js")
-        assert "application/ws-path" in src, \
+        assert "application/ws-path" in src, (
             "dragstart must setData with application/ws-path"
-        assert "item.path" in src, \
-            "dragstart must include item.path in data transfer"
+        )
+        assert "item.path" in src, "dragstart must include item.path in data transfer"
 
     def test_dragstart_stores_ws_type(self):
         """dragstart must store 'application/ws-type' (file or dir)."""
         src = _src("ui.js")
-        assert "application/ws-type" in src, \
+        assert "application/ws-type" in src, (
             "dragstart must setData with application/ws-type"
+        )
 
     def test_dragstart_effectAllowed_copy(self):
         """Drag effect must be 'copy' (not move — we insert a reference)."""
         src = _src("ui.js")
-        assert "effectAllowed='copy'" in src, \
+        assert "effectAllowed='copy'" in src, (
             "dragstart must set effectAllowed to 'copy'"
+        )
 
     def test_drop_handler_checks_ws_path(self):
         """Global drop handler must check for application/ws-path first."""
         src = _src("panels.js")
         m = re.search(r"document\.addEventListener\('drop'", src)
         assert m, "Global drop listener must exist"
-        after = src[m.start():m.start() + 2000]
-        assert "application/ws-path" in after, \
+        after = src[m.start() : m.start() + 2000]
+        assert "application/ws-path" in after, (
             "Drop handler must check for workspace path data"
+        )
 
     def test_workspace_drop_inserts_at_path(self):
         """Workspace drop must insert @path into composer textarea."""
         src = _src("panels.js")
         m = re.search(r"document\.addEventListener\('drop'", src)
-        after = src[m.start():m.start() + 2000]
+        after = src[m.start() : m.start() + 2000]
         # Must insert @-prefixed path
-        assert "'@'+wsPath" in after or '"@"+wsPath' in after or "@"+"" in after, \
+        assert "'@'+wsPath" in after or '"@"+wsPath' in after or "@" + "" in after, (
             "Workspace drop must insert @-prefixed path into composer"
+        )
         # Must position cursor after insert
-        assert "selectionStart" in after, \
-            "Drop handler must update cursor position"
+        assert "selectionStart" in after, "Drop handler must update cursor position"
         # Must focus composer
-        assert "msgEl.focus()" in after or "$('msg').focus()" in after, \
+        assert "msgEl.focus()" in after or "$('msg').focus()" in after, (
             "Drop handler must focus the composer textarea"
+        )
 
     def test_workspace_drop_has_prefix_logic(self):
         """Workspace drop should add space prefix if cursor is mid-word."""
         src = _src("panels.js")
         m = re.search(r"document\.addEventListener\('drop'", src)
-        after = src[m.start():m.start() + 2000]
-        assert "prefix" in after.lower(), \
+        after = src[m.start() : m.start() + 2000]
+        assert "prefix" in after.lower(), (
             "Drop handler should handle spacing between existing text and @path"
+        )
 
     def test_dragenter_accepts_ws_path(self):
         """dragenter must highlight composer for workspace drags too."""
@@ -74,14 +81,16 @@ class TestWorkspaceDragDrop:
         # Find dragenter listener
         m = re.search(r"document\.addEventListener\('dragenter'", src)
         assert m, "dragenter listener must exist"
-        after = src[m.start():m.start() + 300]
-        assert "application/ws-path" in after, \
+        after = src[m.start() : m.start() + 300]
+        assert "application/ws-path" in after, (
             "dragenter must also trigger for workspace drags (application/ws-path)"
+        )
 
     def test_os_file_drop_still_works(self):
         """OS file drag (dataTransfer.files) must still attach files."""
         src = _src("panels.js")
         m = re.search(r"document\.addEventListener\('drop'", src)
-        after = src[m.start():m.start() + 2000]
-        assert "addFiles(files)" in after, \
+        after = src[m.start() : m.start() + 2000]
+        assert "addFiles(files)" in after, (
             "OS file drop path (addFiles) must still work after workspace drop addition"
+        )

--- a/tests/test_issue1100_prism_sri.py
+++ b/tests/test_issue1100_prism_sri.py
@@ -1,4 +1,5 @@
 """Tests for #1100 — Prism.js SRI integrity check no longer blocks theme CSS."""
+
 import re
 
 
@@ -7,42 +8,34 @@ def test_prism_theme_link_has_no_integrity():
     with open("static/index.html") as f:
         src = f.read()
     # Find the prism-theme link tag
-    m = re.search(
-        r'<link[^>]*id="prism-theme"[^>]*>',
-        src
-    )
+    m = re.search(r'<link[^>]*id="prism-theme"[^>]*>', src)
     assert m, "prism-theme link must exist"
     link_tag = m.group(0)
-    assert "integrity=" not in link_tag, \
+    assert "integrity=" not in link_tag, (
         "prism-theme link must not have integrity attribute (causes intermittent failures)"
+    )
 
 
 def test_prism_theme_link_has_crossorigin():
     """The prism-theme link should still have crossorigin for CORS."""
     with open("static/index.html") as f:
         src = f.read()
-    m = re.search(
-        r'<link[^>]*id="prism-theme"[^>]*>',
-        src
-    )
+    m = re.search(r'<link[^>]*id="prism-theme"[^>]*>', src)
     assert m, "prism-theme link must exist"
     link_tag = m.group(0)
-    assert "crossorigin" in link_tag, \
+    assert "crossorigin" in link_tag, (
         "prism-theme link should still have crossorigin attribute"
+    )
 
 
 def test_prism_theme_version_pinned():
     """The prism CSS URL must pin the version to prevent breaking changes."""
     with open("static/index.html") as f:
         src = f.read()
-    m = re.search(
-        r'<link[^>]*id="prism-theme"[^>]*href="([^"]*)"[^>]*>',
-        src
-    )
+    m = re.search(r'<link[^>]*id="prism-theme"[^>]*href="([^"]*)"[^>]*>', src)
     assert m, "prism-theme link must have href"
     href = m.group(1)
-    assert "@1.29.0" in href, \
-        f"Prism CSS version must be pinned, found href: {href}"
+    assert "@1.29.0" in href, f"Prism CSS version must be pinned, found href: {href}"
 
 
 def test_prism_js_still_has_integrity():
@@ -50,11 +43,13 @@ def test_prism_js_still_has_integrity():
     with open("static/index.html") as f:
         src = f.read()
     # prism-core.min.js
-    assert re.search(r'prism-core\.min\.js[^>]*integrity=', src), \
+    assert re.search(r"prism-core\.min\.js[^>]*integrity=", src), (
         "prism-core.min.js should still have integrity attribute"
+    )
     # prism-autoloader.min.js
-    assert re.search(r'prism-autoloader\.min\.js[^>]*integrity=', src), \
+    assert re.search(r"prism-autoloader\.min\.js[^>]*integrity=", src), (
         "prism-autoloader.min.js should still have integrity attribute"
+    )
 
 
 def test_boot_js_set_resolved_theme_no_integrity():
@@ -64,11 +59,14 @@ def test_boot_js_set_resolved_theme_no_integrity():
     # _setResolvedTheme function must exist
     assert "_setResolvedTheme" in src, "_setResolvedTheme function must exist"
     # Must NOT assign link.integrity with a hash value
-    assert not re.search(r'link\.integrity\s*=\s*["\']sha', src), \
+    assert not re.search(r'link\.integrity\s*=\s*["\']sha', src), (
         "_setResolvedTheme must not set link.integrity to an SRI hash"
+    )
     # Must NOT have a wantIntegrity variable
-    assert "wantIntegrity" not in src, \
+    assert "wantIntegrity" not in src, (
         "wantIntegrity variable should be removed from _setResolvedTheme"
+    )
     # Should clear integrity (set to empty) when switching theme
-    assert re.search(r"link\.integrity\s*=\s*['\"]", src), \
+    assert re.search(r"link\.integrity\s*=\s*['\"]", src), (
         "_setResolvedTheme should clear link.integrity on theme switch"
+    )

--- a/tests/test_issue1103_reasoning_chip_visibility.py
+++ b/tests/test_issue1103_reasoning_chip_visibility.py
@@ -1,4 +1,5 @@
 """Tests for #1103 — reasoning chip visible on page load."""
+
 import re
 
 
@@ -6,10 +7,13 @@ def test_boot_calls_fetchReasoningChip():
     """boot.js must call fetchReasoningChip() during boot initialization."""
     with open("static/boot.js") as f:
         src = f.read()
-    assert "fetchReasoningChip" in src, "fetchReasoningChip must be referenced in boot.js"
+    assert "fetchReasoningChip" in src, (
+        "fetchReasoningChip must be referenced in boot.js"
+    )
     # Must be called (not just defined)
-    assert re.search(r"fetchReasoningChip\s*\(\s*\)", src), \
+    assert re.search(r"fetchReasoningChip\s*\(\s*\)", src), (
         "fetchReasoningChip() must be called in boot.js"
+    )
 
 
 def test_boot_call_before_session_load():
@@ -22,27 +26,30 @@ def test_boot_call_before_session_load():
     boot_pos = src.index(boot_marker)
     fetch_pos = src.index("fetchReasoningChip()")
     # fetchReasoningChip must be called just before the saved session load
-    assert fetch_pos < boot_pos, \
+    assert fetch_pos < boot_pos, (
         "fetchReasoningChip() should be called before saved session load in boot.js"
+    )
 
 
 def test_boot_call_has_typeof_guard():
     """fetchReasoningChip() call in boot.js should have a typeof guard."""
     with open("static/boot.js") as f:
         src = f.read()
-    assert "typeof fetchReasoningChip" in src, \
+    assert "typeof fetchReasoningChip" in src, (
         "fetchReasoningChip call should be guarded with typeof check"
+    )
 
 
 def test_reasoning_chip_html_starts_hidden():
     """The reasoning wrap must start hidden (display:none) in HTML."""
     with open("static/index.html") as f:
         src = f.read()
-    assert 'id="composerReasoningWrap"' in src, "composerReasoningWrap must exist in HTML"
+    assert 'id="composerReasoningWrap"' in src, (
+        "composerReasoningWrap must exist in HTML"
+    )
     # Extract the element and check for display:none
     m = re.search(
-        r'<div[^>]*id="composerReasoningWrap"[^>]*style="display:none"[^>]*>',
-        src
+        r'<div[^>]*id="composerReasoningWrap"[^>]*style="display:none"[^>]*>', src
     )
     assert m, "composerReasoningWrap must start with style='display:none'"
 
@@ -51,8 +58,9 @@ def test_applyReasoningChip_shows_wrap():
     """_applyReasoningChip must set wrap display to empty string (visible)."""
     with open("static/ui.js") as f:
         src = f.read()
-    assert "wrap.style.display=''" in src or "wrap.style.display =''" in src, \
+    assert "wrap.style.display=''" in src or "wrap.style.display =''" in src, (
         "_applyReasoningChip must set wrap.style.display='' to make chip visible"
+    )
 
 
 def test_fetchReasoningChip_calls_apply():
@@ -63,8 +71,9 @@ def test_fetchReasoningChip_calls_apply():
     func_match = re.search(r"function fetchReasoningChip\(\)\{(.+?)\}", src, re.DOTALL)
     assert func_match, "fetchReasoningChip function must exist"
     func_body = func_match.group(1)
-    assert "_applyReasoningChip" in func_body, \
+    assert "_applyReasoningChip" in func_body, (
         "fetchReasoningChip must call _applyReasoningChip"
+    )
 
 
 def test_syncReasoningChip_called_on_session_load():
@@ -72,5 +81,6 @@ def test_syncReasoningChip_called_on_session_load():
     with open("static/ui.js") as f:
         src = f.read()
     # Should be called in the session render flow
-    assert "syncReasoningChip()" in src, \
+    assert "syncReasoningChip()" in src, (
         "syncReasoningChip() must be called somewhere in ui.js"
+    )

--- a/tests/test_issue1105_ssrf_custom_providers.py
+++ b/tests/test_issue1105_ssrf_custom_providers.py
@@ -5,11 +5,10 @@ hardcoded allowlist. This fix extracts hostnames from custom_providers config
 and adds them to the trusted set, so user-explicitly configured local endpoints
 (ollama, llama.cpp, vLLM, TabbyAPI, etc.) are not blocked.
 """
-import os
-import pytest
 
 
 # ---------- Source-code analysis tests ----------
+
 
 def test_ssrf_trusted_hosts_variable_exists():
     """The _ssrf_trusted_hosts set must be built from custom_providers config."""
@@ -53,10 +52,11 @@ def test_ssrf_block_still_present():
     """SSRF ValueError must still be raised for unknown private IPs."""
     with open("api/config.py") as f:
         src = f.read()
-    assert 'SSRF: resolved hostname to private IP' in src
+    assert "SSRF: resolved hostname to private IP" in src
 
 
 # ---------- Functional tests (mocked socket) ----------
+
 
 def test_custom_provider_hostname_added_to_trusted():
     """A hostname from custom_providers base_url is added to trusted set."""
@@ -66,20 +66,29 @@ def test_custom_provider_hostname_added_to_trusted():
 
     old_cfg = dict(config.cfg)
     try:
-        config.cfg.update({
-            "model": {"model": "my-model", "base_url": "http://my-llama-server:8080/v1"},
-            "custom_providers": [
-                {"name": "my-llama", "base_url": "http://my-llama-server:8080/v1", "model": "llama-3"}
-            ],
-            "providers": {},
-        })
+        config.cfg.update(
+            {
+                "model": {
+                    "model": "my-model",
+                    "base_url": "http://my-llama-server:8080/v1",
+                },
+                "custom_providers": [
+                    {
+                        "name": "my-llama",
+                        "base_url": "http://my-llama-server:8080/v1",
+                        "model": "llama-3",
+                    }
+                ],
+                "providers": {},
+            }
+        )
         config.invalidate_models_cache()
 
         # Mock socket.getaddrinfo to return a private IP for my-llama-server
         private_addr = ("192.168.1.100", None)
-        mock_getaddrinfo = MagicMock(return_value=[
-            (socket.AF_INET, socket.SOCK_STREAM, 6, "", private_addr)
-        ])
+        mock_getaddrinfo = MagicMock(
+            return_value=[(socket.AF_INET, socket.SOCK_STREAM, 6, "", private_addr)]
+        )
 
         # Mock urllib to prevent actual HTTP call
         mock_urlopen = MagicMock()
@@ -87,8 +96,10 @@ def test_custom_provider_hostname_added_to_trusted():
         mock_urlopen.__enter__ = MagicMock(return_value=mock_urlopen)
         mock_urlopen.__exit__ = MagicMock(return_value=False)
 
-        with patch("socket.getaddrinfo", mock_getaddrinfo), \
-             patch("urllib.request.urlopen", mock_urlopen):
+        with (
+            patch("socket.getaddrinfo", mock_getaddrinfo),
+            patch("urllib.request.urlopen", mock_urlopen),
+        ):
             # Should NOT raise ValueError (SSRF) because hostname is in trusted set
             result = config.get_available_models()
 
@@ -115,20 +126,29 @@ def test_unknown_private_ip_still_blocked():
 
     old_cfg = dict(config.cfg)
     try:
-        config.cfg.update({
-            "model": {"model": "test", "base_url": "http://unknown-local-server:9999/v1"},
-            "custom_providers": [
-                {"name": "other", "base_url": "http://other-server:8080/v1", "model": "x"}
-            ],
-            "providers": {},
-        })
+        config.cfg.update(
+            {
+                "model": {
+                    "model": "test",
+                    "base_url": "http://unknown-local-server:9999/v1",
+                },
+                "custom_providers": [
+                    {
+                        "name": "other",
+                        "base_url": "http://other-server:8080/v1",
+                        "model": "x",
+                    }
+                ],
+                "providers": {},
+            }
+        )
         config.invalidate_models_cache()
 
         # Mock socket.getaddrinfo to return a private IP for unknown-local-server
         private_addr = ("10.0.0.50", None)
-        mock_getaddrinfo = MagicMock(return_value=[
-            (socket.AF_INET, socket.SOCK_STREAM, 6, "", private_addr)
-        ])
+        mock_getaddrinfo = MagicMock(
+            return_value=[(socket.AF_INET, socket.SOCK_STREAM, 6, "", private_addr)]
+        )
 
         with patch("socket.getaddrinfo", mock_getaddrinfo):
             # Should NOT crash (ValueError is caught internally)

--- a/tests/test_issue1106_custom_providers_models.py
+++ b/tests/test_issue1106_custom_providers_models.py
@@ -1,5 +1,5 @@
 """Tests for #1106 — custom_providers[].models dict keys populate model dropdown."""
-import pytest
+
 import api.config as config
 
 
@@ -93,7 +93,12 @@ class TestCustomProvidersModelsDict:
             ],
         )
         ids = _all_model_ids_bare(result)
-        for expected in ["unsloth-qwen3.6-35b-a3b", "gemma4-26b", "qwen3.5-27b", "qwen3-coder-30b"]:
+        for expected in [
+            "unsloth-qwen3.6-35b-a3b",
+            "gemma4-26b",
+            "qwen3.5-27b",
+            "qwen3-coder-30b",
+        ]:
             assert expected in ids, f"Expected '{expected}' in model IDs, got {ids}"
 
     def test_models_dict_without_model_field_still_works(self):
@@ -132,7 +137,9 @@ class TestCustomProvidersModelsDict:
             ],
         )
         ids = _all_model_ids_bare(result)
-        assert ids.count("base-model") == 1, f"'base-model' should appear exactly once, got {ids.count('base-model')}"
+        assert ids.count("base-model") == 1, (
+            f"'base-model' should appear exactly once, got {ids.count('base-model')}"
+        )
         assert "other-model" in ids
 
     def test_unnamed_provider_models_dict_works(self):

--- a/tests/test_issue1112_csp_google_fonts.py
+++ b/tests/test_issue1112_csp_google_fonts.py
@@ -1,4 +1,5 @@
 """Tests for #1112 — CSP allows Google Fonts stylesheet and font files."""
+
 import re
 
 
@@ -13,24 +14,28 @@ class TestCSPGoogleFonts:
     def test_style_src_includes_google_fonts(self):
         """style-src must include https://fonts.googleapis.com for Google Fonts CSS."""
         src = _helpers_src()
-        assert "https://fonts.googleapis.com" in src, \
+        assert "https://fonts.googleapis.com" in src, (
             "style-src must allow fonts.googleapis.com (Google Fonts stylesheets)"
+        )
         # Must be in the style-src directive, not accidentally elsewhere
         style_match = re.search(r"style-src\s+([^;]+);", src)
         assert style_match, "style-src directive must exist"
-        assert "fonts.googleapis.com" in style_match.group(1), \
+        assert "fonts.googleapis.com" in style_match.group(1), (
             "fonts.googleapis.com must be in style-src directive"
+        )
 
     def test_font_src_includes_fonts_gstatic(self):
         """font-src must include https://fonts.gstatic.com for Google Font files."""
         src = _helpers_src()
-        assert "https://fonts.gstatic.com" in src, \
+        assert "https://fonts.gstatic.com" in src, (
             "font-src must allow fonts.gstatic.com (Google Font WOFF2/WOFF files)"
+        )
         # Must be in the font-src directive
         font_match = re.search(r"font-src\s+([^;]+);", src)
         assert font_match, "font-src directive must exist"
-        assert "fonts.gstatic.com" in font_match.group(1), \
+        assert "fonts.gstatic.com" in font_match.group(1), (
             "fonts.gstatic.com must be in font-src directive"
+        )
 
     def test_existing_csp_directives_preserved(self):
         """All pre-existing CSP directives must still be present after the fix."""

--- a/tests/test_issue1116_composer_placeholder.py
+++ b/tests/test_issue1116_composer_placeholder.py
@@ -1,4 +1,5 @@
 """Tests for #1116 — composer placeholder reflects active profile name."""
+
 import re
 
 
@@ -13,48 +14,51 @@ class TestComposerPlaceholderProfile:
     def test_applyBotName_uses_profile_name(self):
         """applyBotName must check S.activeProfile and prefer it over global bot_name."""
         src = _src("boot.js")
-        assert "S.activeProfile" in src, \
-            "applyBotName must reference S.activeProfile"
+        assert "S.activeProfile" in src, "applyBotName must reference S.activeProfile"
         # Should fall back to _botName when activeProfile is 'default'
-        assert "S.activeProfile!=='default'" in src, \
+        assert "S.activeProfile!=='default'" in src, (
             "applyBotName must skip 'default' profile (use bot_name instead)"
+        )
 
     def test_applyBotName_capitalises_profile_name(self):
         """Profile name should be capitalised (first letter uppercase)."""
         src = _src("boot.js")
-        m = re.search(r'function applyBotName\(\)\{.*?\n\}', src, re.DOTALL)
+        m = re.search(r"function applyBotName\(\)\{.*?\n\}", src, re.DOTALL)
         assert m, "applyBotName function must exist"
         body = m.group(0)
-        assert "charAt(0).toUpperCase()" in body, \
+        assert "charAt(0).toUpperCase()" in body, (
             "applyBotName must capitalise first letter of profile name"
+        )
 
     def test_applyBotName_falls_back_to_bot_name(self):
         """When no active profile, must fall back to window._botName."""
         src = _src("boot.js")
-        m = re.search(r'function applyBotName\(\)\{.*?\n\}', src, re.DOTALL)
+        m = re.search(r"function applyBotName\(\)\{.*?\n\}", src, re.DOTALL)
         assert m, "applyBotName function must exist"
         body = m.group(0)
-        assert "window._botName||'Hermes'" in body, \
+        assert "window._botName||'Hermes'" in body, (
             "applyBotName must fall back to window._botName or 'Hermes'"
+        )
 
     def test_switchToProfile_calls_applyBotName(self):
         """switchToProfile() must call applyBotName() after switching."""
         src = _src("panels.js")
-        assert "function switchToProfile" in src, \
-            "switchToProfile function must exist"
+        assert "function switchToProfile" in src, "switchToProfile function must exist"
         # Find the function block (starts with 'async function switchToProfile')
-        m = re.search(r'async function switchToProfile\s*\(', src)
+        m = re.search(r"async function switchToProfile\s*\(", src)
         assert m, "switchToProfile must be an async function"
         # Get everything after the function declaration (enough context)
-        after = src[m.start():m.start()+5000]
-        assert "applyBotName" in after, \
+        after = src[m.start() : m.start() + 5000]
+        assert "applyBotName" in after, (
             "switchToProfile must call applyBotName after profile switch"
+        )
 
     def test_placeholder_uses_name_variable(self):
         """The composer placeholder must use the resolved name variable."""
         src = _src("boot.js")
-        m = re.search(r'function applyBotName\(\)\{.*?\n\}', src, re.DOTALL)
+        m = re.search(r"function applyBotName\(\)\{.*?\n\}", src, re.DOTALL)
         assert m, "applyBotName function must exist"
         body = m.group(0)
-        assert re.search(r"msg\.placeholder\s*=\s*.*Message.*name", body), \
+        assert re.search(r"msg\.placeholder\s*=\s*.*Message.*name", body), (
             "applyBotName must set composer placeholder to 'Message <name>…'"
+        )

--- a/tests/test_issue1118_idle_session_retry.py
+++ b/tests/test_issue1118_idle_session_retry.py
@@ -1,4 +1,5 @@
 """Tests for #1118 — api() retries on network errors (stale keep-alive after idle)."""
+
 import re
 
 
@@ -13,56 +14,62 @@ class TestApiRetryOnNetworkError:
     def test_api_function_has_retry_loop(self):
         """api() must contain a retry loop (for/while with attempt counter)."""
         src = _src()
-        assert re.search(r'for\s*\(\s*let\s+\w+\s*=\s*0\s*;', src), \
+        assert re.search(r"for\s*\(\s*let\s+\w+\s*=\s*0\s*;", src), (
             "api() must have a for loop with attempt counter"
+        )
 
     def test_api_retries_on_typeerror(self):
         """api() must retry when fetch throws TypeError (network failure)."""
         src = _src()
         # Find the api function body
-        m = re.search(r'async function api\(path,opts.*?\n\}(?!\n[\s]*function)', src, re.DOTALL)
+        m = re.search(
+            r"async function api\(path,opts.*?\n\}(?!\n[\s]*function)", src, re.DOTALL
+        )
         assert m, "api() function must exist"
         body = m.group(0)
-        assert 'TypeError' in body, \
+        assert "TypeError" in body, (
             "api() must check for TypeError to detect network failures"
-        assert 'attempt' in body, \
-            "api() must track attempt count for retry logic"
+        )
+        assert "attempt" in body, "api() must track attempt count for retry logic"
 
     def test_api_does_not_retry_http_errors(self):
         """api() must NOT retry on HTTP error responses (4xx/5xx) — only network failures."""
         src = _src()
-        m = re.search(r'async function api\(path,opts.*?\n\}(?!\n[\s]*function)', src, re.DOTALL)
+        m = re.search(
+            r"async function api\(path,opts.*?\n\}(?!\n[\s]*function)", src, re.DOTALL
+        )
         assert m, "api() function must exist"
         body = m.group(0)
         # The retry should be in catch block (after res.ok check), not in the ok path
         # HTTP errors throw Error (not TypeError), so only TypeError triggers retry
-        assert 'e instanceof TypeError' in body, \
+        assert "e instanceof TypeError" in body, (
             "api() retry must be limited to TypeError (network errors), not all errors"
+        )
 
     def test_api_max_3_attempts(self):
         """api() must limit retries (max 3 attempts total = 1 initial + 2 retries)."""
         src = _src()
-        m = re.search(r'async function api\(path,opts.*?\n\}(?!\n[\s]*function)', src, re.DOTALL)
+        m = re.search(
+            r"async function api\(path,opts.*?\n\}(?!\n[\s]*function)", src, re.DOTALL
+        )
         assert m, "api() function must exist"
         body = m.group(0)
         # Should have attempt < 2 (0, 1, 2 = 3 attempts max)
-        assert re.search(r'attempt\s*<\s*2', body), \
+        assert re.search(r"attempt\s*<\s*2", body), (
             "api() must limit to 3 attempts max (attempt < 2)"
+        )
 
     def test_api_preserves_401_redirect(self):
         """api() must still redirect to login on 401 without escaping subpath mounts."""
         src = _src()
-        assert "res.status===401" in src, \
-            "api() must still check for 401 status"
-        assert "login?next=" in src, \
-            "api() must still redirect to login on 401"
-        assert "/login?next=" not in src, \
+        assert "res.status===401" in src, "api() must still check for 401 status"
+        assert "login?next=" in src, "api() must still redirect to login on 401"
+        assert "/login?next=" not in src, (
             "api() must not escape subpath mounts by redirecting to root /login"
+        )
 
     def test_api_preserves_error_parsing(self):
         """api() must still parse JSON error bodies for non-200 responses."""
         src = _src()
-        assert "JSON.parse(text)" in src, \
-            "api() must still parse JSON error responses"
-        assert "res.json()" in src, \
-            "api() must still parse JSON success responses"
+        assert "JSON.parse(text)" in src, "api() must still parse JSON error responses"
+        assert "res.json()" in src, "api() must still parse JSON success responses"

--- a/tests/test_issue1139_password_remote.py
+++ b/tests/test_issue1139_password_remote.py
@@ -5,75 +5,83 @@ Users in Settings > System could type a new password but had no way to submit it
 Disable Auth and Sign Out buttons existed but Save was missing.
 """
 
-import pytest
-
 
 def test_system_pane_has_save_button():
     """The System settings pane must include a Save Settings button."""
-    with open('static/index.html') as f:
+    with open("static/index.html") as f:
         html = f.read()
 
     # Find the System pane block (last pane, so search until parent close)
     start = html.index('id="settingsPaneSystem"')
     # The parent container closes after all panes
-    end_marker = '</div>\n      </div>\n    </div>'  # pane + panes container + settings panel
+    end_marker = (
+        "</div>\n      </div>\n    </div>"  # pane + panes container + settings panel
+    )
     end = html.index(end_marker, start) + len(end_marker)
     pane_block = html[start:end]
 
-    assert 'saveSettings()' in pane_block, \
+    assert "saveSettings()" in pane_block, (
         'System pane must contain a Save Settings button (onclick="saveSettings()")'
+    )
 
 
 def test_system_pane_has_password_field_and_auth_buttons():
     """System pane should have password field, Disable Auth, and Sign Out buttons."""
-    with open('static/index.html') as f:
+    with open("static/index.html") as f:
         html = f.read()
 
     start = html.index('id="settingsPaneSystem"')
-    end_marker = '</div>\n      </div>\n    </div>'
+    end_marker = "</div>\n      </div>\n    </div>"
     end = html.index(end_marker, start) + len(end_marker)
     pane_block = html[start:end]
 
-    assert 'settingsPassword' in pane_block, 'Password field missing from System pane'
-    assert 'btnDisableAuth' in pane_block, 'Disable Auth button missing from System pane'
-    assert 'btnSignOut' in pane_block, 'Sign Out button missing from System pane'
+    assert "settingsPassword" in pane_block, "Password field missing from System pane"
+    assert "btnDisableAuth" in pane_block, (
+        "Disable Auth button missing from System pane"
+    )
+    assert "btnSignOut" in pane_block, "Sign Out button missing from System pane"
 
 
 def test_save_settings_sends_password():
     """saveSettings() must read settingsPassword and send _set_password."""
-    with open('static/panels.js') as f:
+    with open("static/panels.js") as f:
         src = f.read()
 
-    assert 'settingsPassword' in src, 'saveSettings should read settingsPassword'
-    assert '_set_password' in src, 'saveSettings should send _set_password key'
+    assert "settingsPassword" in src, "saveSettings should read settingsPassword"
+    assert "_set_password" in src, "saveSettings should send _set_password key"
 
 
 def test_disable_auth_sends_clear_password():
     """disableAuth() must send _clear_password: true."""
-    with open('static/panels.js') as f:
+    with open("static/panels.js") as f:
         src = f.read()
 
-    assert '_clear_password:true' in src, 'disableAuth should send _clear_password: true'
+    assert "_clear_password:true" in src, (
+        "disableAuth should send _clear_password: true"
+    )
 
 
 def test_all_settings_panes_have_save_button():
     """All settings panes that have user-editable fields should have a Save button."""
-    with open('static/index.html') as f:
+    with open("static/index.html") as f:
         html = f.read()
 
     import re
+
     # Find all settings panes
     panes = re.findall(
         r'<div class="settings-pane" id="(settingsPane\w+)"[^>]*>(.*?)</div>\s*</div>',
-        html, re.DOTALL
+        html,
+        re.DOTALL,
     )
 
     for pane_id, pane_html in panes:
         # Providers pane has per-provider controls; Appearance pane is autosave-only.
-        if pane_id in ('settingsPaneProviders', 'settingsPaneAppearance'):
+        if pane_id in ("settingsPaneProviders", "settingsPaneAppearance"):
             continue
         # Check if pane has any input fields (not just buttons)
-        has_inputs = bool(re.search(r'<input|<select|<textarea', pane_html))
+        has_inputs = bool(re.search(r"<input|<select|<textarea", pane_html))
         if has_inputs:
-            assert 'saveSettings()' in pane_html, \
-                f'{pane_id} has input fields but no Save Settings button'
+            assert "saveSettings()" in pane_html, (
+                f"{pane_id} has input fields but no Save Settings button"
+            )

--- a/tests/test_issue1140_cron_badge_per_job.py
+++ b/tests/test_issue1140_cron_badge_per_job.py
@@ -8,46 +8,48 @@ Verifies that:
 5. _renderCronDetail() adds has-new-run class to Last Output card
 """
 
-import pytest
 
 # ── Static file tests (no server needed) ──
 
+
 def test_cron_new_job_ids_tracking_in_panels_js():
     """panels.js should declare _cronNewJobIds Set and populate it in startCronPolling."""
-    with open('static/panels.js') as f:
+    with open("static/panels.js") as f:
         src = f.read()
 
     # _cronNewJobIds declared as Set
-    assert '_cronNewJobIds' in src, '_cronNewJobIds not found in panels.js'
-    assert 'new Set()' in src, '_cronNewJobIds should be initialized as Set()'
+    assert "_cronNewJobIds" in src, "_cronNewJobIds not found in panels.js"
+    assert "new Set()" in src, "_cronNewJobIds should be initialized as Set()"
 
     # In startCronPolling, job IDs are added to the set
-    assert '_cronNewJobIds.add(String(c.job_id))' in src, \
-        'startCronPolling should add job_id to _cronNewJobIds'
+    assert "_cronNewJobIds.add(String(c.job_id))" in src, (
+        "startCronPolling should add job_id to _cronNewJobIds"
+    )
 
 
 def test_cron_dot_indicator_rendered_in_load_crons():
     """loadCrons() should render a .cron-new-dot for jobs in _cronNewJobIds."""
-    with open('static/panels.js') as f:
+    with open("static/panels.js") as f:
         src = f.read()
 
     # Dot indicator in cron-item rendering
-    assert 'cron-new-dot' in src, 'cron-new-dot class not found'
-    assert "_cronNewJobIds.has(String(job.id))" in src, \
-        'loadCrons should check _cronNewJobIds for each job'
+    assert "cron-new-dot" in src, "cron-new-dot class not found"
+    assert "_cronNewJobIds.has(String(job.id))" in src, (
+        "loadCrons should check _cronNewJobIds for each job"
+    )
 
 
 def test_open_cron_detail_clears_unread():
     """openCronDetail() should mark job as read and remove the dot."""
-    with open('static/panels.js') as f:
+    with open("static/panels.js") as f:
         src = f.read()
 
     # _clearCronUnreadForJob called in openCronDetail
-    assert '_clearCronUnreadForJob' in src, \
-        '_clearCronUnreadForJob function not found'
+    assert "_clearCronUnreadForJob" in src, "_clearCronUnreadForJob function not found"
     # Dot removal in openCronDetail
-    assert "target.querySelector('.cron-new-dot')" in src, \
-        'openCronDetail should remove the dot element'
+    assert "target.querySelector('.cron-new-dot')" in src, (
+        "openCronDetail should remove the dot element"
+    )
 
 
 def test_clear_cron_unread_for_job_function():
@@ -56,45 +58,46 @@ def test_clear_cron_unread_for_job_function():
     _cronUnreadCount is derived from _cronNewJobIds.size in updateCronBadge,
     so the function only needs to delete from the set and trigger a badge sync.
     """
-    with open('static/panels.js') as f:
+    with open("static/panels.js") as f:
         src = f.read()
 
     # Locate the function body to make assertions order-dependent
-    start = src.find('function _clearCronUnreadForJob(')
-    assert start != -1, '_clearCronUnreadForJob should be defined'
-    body = src[start:start + 400]
-    assert '_cronNewJobIds.delete(id)' in body, \
-        '_clearCronUnreadForJob should delete from _cronNewJobIds'
-    assert 'updateCronBadge()' in body, \
-        '_clearCronUnreadForJob should call updateCronBadge to re-sync count'
+    start = src.find("function _clearCronUnreadForJob(")
+    assert start != -1, "_clearCronUnreadForJob should be defined"
+    body = src[start : start + 400]
+    assert "_cronNewJobIds.delete(id)" in body, (
+        "_clearCronUnreadForJob should delete from _cronNewJobIds"
+    )
+    assert "updateCronBadge()" in body, (
+        "_clearCronUnreadForJob should call updateCronBadge to re-sync count"
+    )
 
 
 def test_switch_panel_no_longer_clears_badge():
     """switchPanel override should NOT clear badge on tasks panel open."""
-    with open('static/panels.js') as f:
+    with open("static/panels.js") as f:
         src = f.read()
 
     # The old pattern "if(name==='tasks'){_cronUnreadCount=0" should NOT exist
-    assert "if(name==='tasks'){_cronUnreadCount=0" not in src, \
-        'switchPanel should NOT clear _cronUnreadCount on tasks open'
+    assert "if(name==='tasks'){_cronUnreadCount=0" not in src, (
+        "switchPanel should NOT clear _cronUnreadCount on tasks open"
+    )
 
 
 def test_has_new_run_class_in_render_detail():
     """_renderCronDetail() should add has-new-run class to Last Output card."""
-    with open('static/panels.js') as f:
+    with open("static/panels.js") as f:
         src = f.read()
 
     # Check has-new-run class in the cronDetailRuns div
-    assert 'has-new-run' in src, 'has-new-run class not found'
+    assert "has-new-run" in src, "has-new-run class not found"
 
 
 def test_cron_css_classes_exist():
     """style.css should contain .cron-new-dot and .has-new-run styles."""
-    with open('static/style.css') as f:
+    with open("static/style.css") as f:
         src = f.read()
 
-    assert '.cron-new-dot{' in src, '.cron-new-dot CSS rule not found'
-    assert '.has-new-run{' in src, '.has-new-run CSS rule not found'
-    assert 'cron-dot-pulse' in src, 'cron-dot-pulse animation not found'
-
-
+    assert ".cron-new-dot{" in src, ".cron-new-dot CSS rule not found"
+    assert ".has-new-run{" in src, ".has-new-run CSS rule not found"
+    assert "cron-dot-pulse" in src, "cron-dot-pulse animation not found"

--- a/tests/test_issue1144_session_time_sync.py
+++ b/tests/test_issue1144_session_time_sync.py
@@ -18,7 +18,6 @@ import subprocess
 import textwrap
 import time
 
-import pytest
 
 REPO_ROOT = pathlib.Path(__file__).parent.parent.resolve()
 SESSIONS_JS = (REPO_ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
@@ -29,10 +28,12 @@ UI_JS = (REPO_ROOT / "static" / "ui.js").read_text(encoding="utf-8")
 # Backend: /api/sessions includes server_time and server_tz
 # ---------------------------------------------------------------------------
 
+
 def test_sessions_endpoint_includes_server_time_and_tz():
     """GET /api/sessions must return server_time (float) and server_tz (str)."""
     from tests._pytest_port import BASE
     import urllib.request
+
     with urllib.request.urlopen(BASE + "/api/sessions", timeout=10) as r:
         data = json.loads(r.read())
     assert "server_time" in data
@@ -51,6 +52,7 @@ def test_server_time_allows_clock_skew_compensation():
     """server_time lets the client detect clock skew relative to the server."""
     from tests._pytest_port import BASE
     import urllib.request
+
     before = time.time()
     with urllib.request.urlopen(BASE + "/api/sessions", timeout=10) as r:
         data = json.loads(r.read())
@@ -63,6 +65,7 @@ def test_server_time_allows_clock_skew_compensation():
 # ---------------------------------------------------------------------------
 # JS: _serverNowMs compensates for clock skew
 # ---------------------------------------------------------------------------
+
 
 def _extract_function(source: str, name: str) -> str:
     marker = f"function {name}"
@@ -120,7 +123,9 @@ def _run_time_case(script_body: str, tz: str = "UTC") -> dict:
         {script_body}
         """
     )
-    proc = subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True)
+    proc = subprocess.run(
+        ["node", "-e", script], check=True, capture_output=True, text=True
+    )
     return json.loads(proc.stdout)
 
 
@@ -279,6 +284,7 @@ def test_explicit_now_param_overrides_server_clock():
 # JS: _serverTzOptions builds correct timeZone option
 # ---------------------------------------------------------------------------
 
+
 def test_server_tz_options_positive_offset():
     result = _run_time_case(
         """
@@ -339,6 +345,7 @@ def test_server_tz_options_empty_returns_undefined():
 # JS: _formatMessageFooterTimestamp uses server timezone
 # ---------------------------------------------------------------------------
 
+
 def _extract_ui_function(name: str) -> str:
     return _extract_function(UI_JS, name)
 
@@ -390,7 +397,9 @@ def test_message_footer_timestamp_uses_server_tz():
         process.stdout.write(JSON.stringify({{ formatted: result }}));
         """
     )
-    proc = subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True)
+    proc = subprocess.run(
+        ["node", "-e", script], check=True, capture_output=True, text=True
+    )
     data = json.loads(proc.stdout)
     # Should display in UTC+8, not America/New_York.
     # 2026-03-29 02:00 UTC = 10:00 in UTC+8
@@ -430,7 +439,9 @@ def test_message_footer_timestamp_handles_fractional_offset():
         process.stdout.write(JSON.stringify({{ formatted: result }}));
         """
     )
-    proc = subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True)
+    proc = subprocess.run(
+        ["node", "-e", script], check=True, capture_output=True, text=True
+    )
     data = json.loads(proc.stdout)
     # 2026-03-29 02:00 UTC = 07:30 IST. Old Etc/GMT-5 mapping would have shown 07:00.
     # Accept either "07:30" or "7:30" (en-US uses hour:'numeric' for non-same-day).
@@ -462,7 +473,9 @@ def test_message_footer_timestamp_falls_back_without_server_tz():
         process.stdout.write(JSON.stringify({{ formatted: result, hasValue: result.length > 0 }}));
         """
     )
-    proc = subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True)
+    proc = subprocess.run(
+        ["node", "-e", script], check=True, capture_output=True, text=True
+    )
     data = json.loads(proc.stdout)
     assert data["hasValue"] is True
 
@@ -470,6 +483,7 @@ def test_message_footer_timestamp_falls_back_without_server_tz():
 # ---------------------------------------------------------------------------
 # JS: sessions.js contains the compensation variables and helpers
 # ---------------------------------------------------------------------------
+
 
 def test_sessions_js_has_server_time_compensation_vars():
     assert "_serverTimeDelta" in SESSIONS_JS

--- a/tests/test_issue1154_fenced_code_leak.py
+++ b/tests/test_issue1154_fenced_code_leak.py
@@ -11,6 +11,7 @@ HTML inside <pre>, breaking </pre> closure and corrupting layout.
 Fix: fenced blocks are converted to <pre><code> HTML inside the stash
 callback and kept as \\x00P tokens until AFTER all markdown passes.
 """
+
 import re
 import shutil
 
@@ -62,9 +63,13 @@ def driver_path(tmp_path_factory):
 
 def _render(driver_path, markdown: str) -> str:
     import subprocess
+
     result = subprocess.run(
         [NODE, driver_path, str(UI_JS_PATH)],
-        input=markdown, capture_output=True, text=True, timeout=10,
+        input=markdown,
+        capture_output=True,
+        text=True,
+        timeout=10,
     )
     if result.returncode != 0:
         raise RuntimeError(f"node driver failed: {result.stderr}")
@@ -75,28 +80,28 @@ class TestFencedCodeBlockIsolation:
     """Content inside fenced code blocks must never be interpreted as markdown."""
 
     def test_diff_block_plus_minus_lines_not_treated_as_list(self, driver_path):
-        html = _render(driver_path,
-            "before\n\n```diff\n- removed line\n+ added line\n```\nafter")
+        html = _render(
+            driver_path, "before\n\n```diff\n- removed line\n+ added line\n```\nafter"
+        )
         pre = _extract_pre(html)
         assert pre is not None, "Expected a <pre> block"
         assert "<ul>" not in pre, "List HTML must not appear inside <pre>"
         assert "<li>" not in pre, "List items must not appear inside <pre>"
         assert "- removed line" in pre
         assert "+ added line" in pre
-        assert html.count("<pre") == html.count("</pre>"), \
+        assert html.count("<pre") == html.count("</pre>"), (
             "Every <pre> must have a matching </pre>"
+        )
 
     def test_bash_block_asterisk_lines_not_treated_as_list(self, driver_path):
-        html = _render(driver_path,
-            "```bash\n* not a list item\n* another one\n```")
+        html = _render(driver_path, "```bash\n* not a list item\n* another one\n```")
         pre = _extract_pre(html)
         assert pre is not None
         assert "<ul>" not in pre
         assert "<li>" not in pre
 
     def test_markdown_block_heading_not_treated_as_h1(self, driver_path):
-        html = _render(driver_path,
-            "```markdown\n# Not a heading\n## Also not\n```")
+        html = _render(driver_path, "```markdown\n# Not a heading\n## Also not\n```")
         pre = _extract_pre(html)
         assert pre is not None
         assert "<h1>" not in pre
@@ -111,9 +116,11 @@ class TestFencedCodeBlockIsolation:
         assert "**not bold**" in pre
 
     def test_content_after_code_block_renders_normally(self, driver_path):
-        html = _render(driver_path,
+        html = _render(
+            driver_path,
             "```diff\n- old\n+ new\n```\n\n"
-            "# Real Heading\n\n- real list item\n\n**bold text**")
+            "# Real Heading\n\n- real list item\n\n**bold text**",
+        )
         assert "<h1>Real Heading</h1>" in html
         assert "<ul>" in html
         assert "<strong>bold text</strong>" in html
@@ -121,14 +128,15 @@ class TestFencedCodeBlockIsolation:
         assert "<ul>" not in pre
 
     def test_no_escaped_pre_closing_tag(self, driver_path):
-        html = _render(driver_path,
-            "```diff\n- old line\n+ new line\n```\n\nAfter the block")
-        assert "&lt;/pre&gt;" not in html, \
+        html = _render(
+            driver_path, "```diff\n- old line\n+ new line\n```\n\nAfter the block"
+        )
+        assert "&lt;/pre&gt;" not in html, (
             "Escaped </pre> indicates broken HTML nesting"
+        )
 
     def test_code_block_without_language(self, driver_path):
-        html = _render(driver_path,
-            "```\n- item\n+ item\n```\n\n- real list")
+        html = _render(driver_path, "```\n- item\n+ item\n```\n\n- real list")
         pre = _extract_pre(html)
         assert pre is not None
         assert "<ul>" not in pre
@@ -139,18 +147,15 @@ class TestFencedCodeBlockIsolation:
         assert "<strong><code>code</code></strong>" in html
 
     def test_inline_backtick_inside_bold(self, driver_path):
-        html = _render(driver_path,
-            "Text with `inline code` and **bold**")
+        html = _render(driver_path, "Text with `inline code` and **bold**")
         assert "<code>inline code</code>" in html
         assert "<strong>bold</strong>" in html
 
     def test_large_diff_output_no_corruption(self, driver_path):
         diff_lines = "\n".join(
-            f"- old_line_{i}" if i % 2 == 0 else f"+ new_line_{i}"
-            for i in range(50)
+            f"- old_line_{i}" if i % 2 == 0 else f"+ new_line_{i}" for i in range(50)
         )
-        html = _render(driver_path,
-            f"```diff\n{diff_lines}\n```\n\nSummary after diff")
+        html = _render(driver_path, f"```diff\n{diff_lines}\n```\n\nSummary after diff")
         pre = _extract_pre(html)
         assert pre is not None
         assert "<ul>" not in pre
@@ -159,9 +164,10 @@ class TestFencedCodeBlockIsolation:
         assert "Summary after diff" in html
 
     def test_mixed_fenced_and_inline_code(self, driver_path):
-        html = _render(driver_path,
-            "Use `rm -rf` to delete:\n\n"
-            "```bash\nrm -rf /tmp/stuff\n```\n\nDone.")
+        html = _render(
+            driver_path,
+            "Use `rm -rf` to delete:\n\n```bash\nrm -rf /tmp/stuff\n```\n\nDone.",
+        )
         assert "<code>rm -rf</code>" in html
         pre = _extract_pre(html)
         assert pre is not None
@@ -172,8 +178,7 @@ class TestFencedBlockPreHeaderPreserved:
     """Pre-header div (language label) must still be generated."""
 
     def test_language_header_present(self, driver_path):
-        html = _render(driver_path,
-            "```python\ndef hello():\n    pass\n```")
+        html = _render(driver_path, "```python\ndef hello():\n    pass\n```")
         assert '<div class="pre-header">python</div>' in html
 
     def test_no_language_no_header(self, driver_path):
@@ -181,8 +186,7 @@ class TestFencedBlockPreHeaderPreserved:
         assert "pre-header" not in html
 
     def test_language_class_on_code_tag(self, driver_path):
-        html = _render(driver_path,
-            "```javascript\nconsole.log('hi')\n```")
+        html = _render(driver_path, "```javascript\nconsole.log('hi')\n```")
         assert 'class="language-javascript"' in html
 
 

--- a/tests/test_issue1164_env_file_corruption.py
+++ b/tests/test_issue1164_env_file_corruption.py
@@ -15,6 +15,7 @@ Fix:
 
 Sprint/commit: v0.50.227+
 """
+
 import os
 import tempfile
 import textwrap
@@ -30,6 +31,7 @@ class TestEnvFileCommentPreservation(unittest.TestCase):
         self.env_path = Path(self.tmpdir) / ".env"
         # Must import AFTER setting up, as the module has top-level code
         from api.providers import _write_env_file
+
         self._write_env_file = _write_env_file
 
     def tearDown(self):
@@ -37,6 +39,7 @@ class TestEnvFileCommentPreservation(unittest.TestCase):
         for key in ("OPENROUTER_API_KEY", "OPENAI_API_KEY", "NEW_KEY"):
             os.environ.pop(key, None)
         import shutil
+
         shutil.rmtree(self.tmpdir, ignore_errors=True)
 
     def _read(self) -> str:
@@ -46,38 +49,40 @@ class TestEnvFileCommentPreservation(unittest.TestCase):
 
     def test_comments_preserved_on_update(self):
         """Comments in .env must survive a key value update."""
-        self.env_path.write_text(textwrap.dedent("""\
+        self.env_path.write_text(
+            textwrap.dedent("""\
             # Hermes API keys
             OPENROUTER_API_KEY=sk-or-old
             # Another comment
             OPENAI_API_KEY=sk-oai-old
-        """).strip() + "\n", encoding="utf-8")
+        """).strip()
+            + "\n",
+            encoding="utf-8",
+        )
 
         self._write_env_file(self.env_path, {"OPENROUTER_API_KEY": "sk-or-new"})
 
         content = self._read()
-        self.assertIn("# Hermes API keys", content,
-                      "Leading comment must be preserved")
-        self.assertIn("# Another comment", content,
-                      "Inline comment must be preserved")
+        self.assertIn("# Hermes API keys", content, "Leading comment must be preserved")
+        self.assertIn("# Another comment", content, "Inline comment must be preserved")
         self.assertIn("sk-or-new", content)
 
     def test_blank_lines_preserved(self):
         """Blank lines between key blocks must be preserved."""
-        self.env_path.write_text(
-            "KEY_A=val_a\n\nKEY_B=val_b\n", encoding="utf-8")
+        self.env_path.write_text("KEY_A=val_a\n\nKEY_B=val_b\n", encoding="utf-8")
 
         self._write_env_file(self.env_path, {"KEY_A": "updated"})
 
         content = self._read()
-        self.assertEqual(content.count("\n\n"), 1,
-                         "Blank line between keys must be preserved")
+        self.assertEqual(
+            content.count("\n\n"), 1, "Blank line between keys must be preserved"
+        )
 
     def test_key_order_preserved(self):
         """Original key order must not be sorted alphabetically."""
         self.env_path.write_text(
-            "ZZZ_KEY=last\nAAA_KEY=first\nBBB_KEY=middle\n",
-            encoding="utf-8")
+            "ZZZ_KEY=last\nAAA_KEY=first\nBBB_KEY=middle\n", encoding="utf-8"
+        )
 
         self._write_env_file(self.env_path, {"AAA_KEY": "updated"})
 
@@ -86,15 +91,16 @@ class TestEnvFileCommentPreservation(unittest.TestCase):
         aaa_pos = content.find("AAA_KEY")
         bbb_pos = content.find("BBB_KEY")
         # Original order: ZZZ, AAA, BBB
-        self.assertLess(zzz_pos, aaa_pos,
-                        "ZZZ_KEY must still come before AAA_KEY (original order)")
-        self.assertLess(aaa_pos, bbb_pos,
-                        "AAA_KEY must still come before BBB_KEY (original order)")
+        self.assertLess(
+            zzz_pos, aaa_pos, "ZZZ_KEY must still come before AAA_KEY (original order)"
+        )
+        self.assertLess(
+            aaa_pos, bbb_pos, "AAA_KEY must still come before BBB_KEY (original order)"
+        )
 
     def test_new_key_appended_with_separator(self):
         """New keys are appended at the end with a blank-line separator."""
-        self.env_path.write_text(
-            "EXISTING_KEY=value\n", encoding="utf-8")
+        self.env_path.write_text("EXISTING_KEY=value\n", encoding="utf-8")
 
         self._write_env_file(self.env_path, {"NEW_KEY": "new_value"})
 
@@ -105,12 +111,16 @@ class TestEnvFileCommentPreservation(unittest.TestCase):
 
     def test_key_removal_preserves_others(self):
         """Removing a key leaves other keys and comments intact."""
-        self.env_path.write_text(textwrap.dedent("""\
+        self.env_path.write_text(
+            textwrap.dedent("""\
             # Comment A
             KEY_A=val_a
             # Comment B
             KEY_B=val_b
-        """).strip() + "\n", encoding="utf-8")
+        """).strip()
+            + "\n",
+            encoding="utf-8",
+        )
 
         self._write_env_file(self.env_path, {"KEY_B": None})
 
@@ -137,21 +147,29 @@ class TestOnboardingUsesProviderWriteEnv(unittest.TestCase):
         """api.onboarding._write_env_file must be the same object as
         api.providers._write_env_file (shared implementation with lock)."""
         from api import onboarding, providers
+
         self.assertIs(
             onboarding._write_env_file,
             providers._write_env_file,
-            "onboarding must use providers._write_env_file for thread safety (#1164)"
+            "onboarding must use providers._write_env_file for thread safety (#1164)",
         )
 
     def test_providers_write_env_holds_env_lock(self):
         """providers._write_env_file must acquire _ENV_LOCK from api.streaming."""
         import inspect
         from api.providers import _write_env_file
+
         source = inspect.getsource(_write_env_file)
-        self.assertIn("_ENV_LOCK", source,
-                      "_write_env_file must use _ENV_LOCK for concurrency safety")
-        self.assertIn("from api.streaming import _ENV_LOCK", source,
-                      "_ENV_LOCK must be imported from api.streaming")
+        self.assertIn(
+            "_ENV_LOCK",
+            source,
+            "_write_env_file must use _ENV_LOCK for concurrency safety",
+        )
+        self.assertIn(
+            "from api.streaming import _ENV_LOCK",
+            source,
+            "_ENV_LOCK must be imported from api.streaming",
+        )
 
     def test_providers_write_env_uses_atomic_rename(self):
         """providers._write_env_file must write atomically via tempfile +
@@ -159,12 +177,18 @@ class TestOnboardingUsesProviderWriteEnv(unittest.TestCase):
         a truncated half-written file (#1164 cross-process leg)."""
         import inspect
         from api.providers import _write_env_file
+
         source = inspect.getsource(_write_env_file)
-        self.assertIn("tempfile", source,
-                      "_write_env_file must stage writes through a tempfile")
-        self.assertIn("os.replace(", source,
-                      "_write_env_file must atomically rename via os.replace")
+        self.assertIn(
+            "tempfile", source, "_write_env_file must stage writes through a tempfile"
+        )
+        self.assertIn(
+            "os.replace(",
+            source,
+            "_write_env_file must atomically rename via os.replace",
+        )
         # The original O_TRUNC pattern must NOT remain — it is the source of
         # the cross-process race the PR is closing.
-        self.assertNotIn("O_TRUNC", source,
-                         "_write_env_file must not truncate-in-place (#1164)")
+        self.assertNotIn(
+            "O_TRUNC", source, "_write_env_file must not truncate-in-place (#1164)"
+        )

--- a/tests/test_issue1188_fuzzy_match.py
+++ b/tests/test_issue1188_fuzzy_match.py
@@ -17,6 +17,7 @@ Tests below run the live ``_findModelInDropdown`` function via Node so
 the real regex/normalization rules are exercised — drift between this
 test and the JS would be caught by behavioural mismatch.
 """
+
 import shutil
 import subprocess
 
@@ -62,10 +63,17 @@ def driver_path(tmp_path_factory):
 
 def _find(driver_path, model_id: str, options: list[str]):
     import json
+
     result = subprocess.run(
-        [NODE, driver_path, str(UI_JS_PATH),
-         json.dumps({"modelId": model_id, "options": options})],
-        capture_output=True, text=True, timeout=10,
+        [
+            NODE,
+            driver_path,
+            str(UI_JS_PATH),
+            json.dumps({"modelId": model_id, "options": options}),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=10,
     )
     if result.returncode != 0:
         raise RuntimeError(f"node driver failed: {result.stderr}")
@@ -85,9 +93,7 @@ class TestNoFalseSiblingVersionMatch:
             "gpt-5.5",
             ["@nous:openai/gpt-5.4-mini", "@nous:anthropic/claude-opus-4.6"],
         )
-        assert got is None, (
-            "gpt-5.5 must not fuzzy-match gpt-5.4-mini (#1188)"
-        )
+        assert got is None, "gpt-5.5 must not fuzzy-match gpt-5.4-mini (#1188)"
 
     def test_claude_opus_4_7_does_not_match_claude_opus_4_6(self, driver_path):
         """Same shape: a different minor version must not be a fuzzy hit."""
@@ -96,9 +102,7 @@ class TestNoFalseSiblingVersionMatch:
             "claude-opus-4.7",
             ["@nous:anthropic/claude-opus-4.6"],
         )
-        assert got is None, (
-            "claude-opus-4.7 must not fuzzy-match claude-opus-4.6"
-        )
+        assert got is None, "claude-opus-4.7 must not fuzzy-match claude-opus-4.6"
 
 
 # ── Things that should still match (no regression for legit fuzzy use) ─────
@@ -125,17 +129,13 @@ class TestPreservedFuzzyMatches:
         assert got == "@nous:openai/gpt-5.4-mini"
 
     def test_bare_root_claude_matches(self, driver_path):
-        got = _find(
-            driver_path, "claude", ["@nous:anthropic/claude-opus-4.6"]
-        )
+        got = _find(driver_path, "claude", ["@nous:anthropic/claude-opus-4.6"])
         assert got == "@nous:anthropic/claude-opus-4.6"
 
     def test_target_without_version_suffix_still_matches(self, driver_path):
         """claude-opus has no trailing version → base === target → useBase
         path → still finds claude-opus-4.6 via prefix."""
-        got = _find(
-            driver_path, "claude-opus", ["@nous:anthropic/claude-opus-4.6"]
-        )
+        got = _find(driver_path, "claude-opus", ["@nous:anthropic/claude-opus-4.6"])
         assert got == "@nous:anthropic/claude-opus-4.6"
 
     def test_exact_match_short_circuits(self, driver_path):
@@ -147,7 +147,5 @@ class TestPreservedFuzzyMatches:
         assert got == "@nous:openai/gpt-5.4-mini"
 
     def test_unrelated_target_returns_null(self, driver_path):
-        got = _find(
-            driver_path, "mistral-large", ["@nous:openai/gpt-5.4-mini"]
-        )
+        got = _find(driver_path, "mistral-large", ["@nous:openai/gpt-5.4-mini"])
         assert got is None

--- a/tests/test_issue1189_openai_codex_detection.py
+++ b/tests/test_issue1189_openai_codex_detection.py
@@ -18,6 +18,7 @@ UX (no manual config.yaml edit needed for users who DO have both), but
 the simple detect-on-OPENAI_API_KEY shortcut is documented here as a
 known limitation.
 """
+
 import pathlib
 
 import api.config as config
@@ -60,7 +61,9 @@ def test_openai_api_key_env_var_path_detects_openai_codex(monkeypatch):
     )
 
     # Also verify the detection logic is present in the source
-    src = (_cfg.Path(__file__).parent.parent / "api" / "config.py").read_text(encoding="utf-8")
+    src = (_cfg.Path(__file__).parent.parent / "api" / "config.py").read_text(
+        encoding="utf-8"
+    )
     assert 'detected_providers.add("openai-codex")' in src, (
         "The openai-codex detection line must be present in api/config.py"
     )

--- a/tests/test_issue1195_session_profile_routing.py
+++ b/tests/test_issue1195_session_profile_routing.py
@@ -1,8 +1,6 @@
 """Tests for issue #1195: sessions must route to the correct profile directory
 even when that profile directory does not exist yet on disk."""
 
-import os
-import tempfile
 from pathlib import Path
 from unittest.mock import patch
 
@@ -10,6 +8,7 @@ import pytest
 
 
 # ── helpers ──────────────────────────────────────────────────────────────────
+
 
 def _make_hermes_home(base: Path, profile_name: str | None = None) -> Path:
     """Create a temp HERMES_HOME (with optional profile dir) and return it."""
@@ -21,6 +20,7 @@ def _make_hermes_home(base: Path, profile_name: str | None = None) -> Path:
 
 
 # ── tests ────────────────────────────────────────────────────────────────────
+
 
 class TestGetHermesHomeForProfile:
     """get_hermes_home_for_profile() must return the profile path regardless of

--- a/tests/test_issue1202_oauth_provider_status.py
+++ b/tests/test_issue1202_oauth_provider_status.py
@@ -14,11 +14,10 @@ Fixes:
   5. static/i18n.js: new i18n keys for config_yaml and not_configured hints
 """
 
-import re
 import sys
 import types
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 REPO_ROOT = Path(__file__).parent.parent.resolve()
 
@@ -27,8 +26,12 @@ REPO_ROOT = Path(__file__).parent.parent.resolve()
 # Helper: build a fake hermes_cli.auth module so tests work without the dep
 # ---------------------------------------------------------------------------
 
-def _make_fake_auth(logged_in: bool, error: str | None = None, key_source: str = "oauth"):
+
+def _make_fake_auth(
+    logged_in: bool, error: str | None = None, key_source: str = "oauth"
+):
     mod = types.ModuleType("hermes_cli.auth")
+
     def get_auth_status(pid):
         if logged_in:
             return {"logged_in": True, "key_source": key_source}
@@ -36,6 +39,7 @@ def _make_fake_auth(logged_in: bool, error: str | None = None, key_source: str =
         if error:
             result["error"] = error
         return result
+
     mod.get_auth_status = get_auth_status
     return mod
 
@@ -43,6 +47,7 @@ def _make_fake_auth(logged_in: bool, error: str | None = None, key_source: str =
 # ---------------------------------------------------------------------------
 # Tests for api/providers.py OAuth block
 # ---------------------------------------------------------------------------
+
 
 class TestGetProvidersOauthBlock:
     """Unit tests for the OAuth override block in get_providers()."""
@@ -55,10 +60,16 @@ class TestGetProvidersOauthBlock:
         import api.providers as prov_mod
 
         # Patch _provider_has_key to return our desired value
-        with patch.object(prov_mod, "_provider_has_key", return_value=has_key_in_config), \
-             patch.object(prov_mod, "_provider_is_oauth", side_effect=lambda pid: pid in ("openai-codex", "nous", "copilot")), \
-             patch.dict(sys.modules, {"hermes_cli.auth": fake_auth_module}), \
-             patch.object(prov_mod, "get_config", return_value={}):
+        with (
+            patch.object(prov_mod, "_provider_has_key", return_value=has_key_in_config),
+            patch.object(
+                prov_mod,
+                "_provider_is_oauth",
+                side_effect=lambda pid: pid in ("openai-codex", "nous", "copilot"),
+            ),
+            patch.dict(sys.modules, {"hermes_cli.auth": fake_auth_module}),
+            patch.object(prov_mod, "get_config", return_value={}),
+        ):
             result = prov_mod.get_providers()
 
         providers = {p["id"]: p for p in result["providers"]}
@@ -77,7 +88,7 @@ class TestGetProvidersOauthBlock:
         REGRESSION TEST (#1202 Bug 1):
         When _provider_has_key() returns True (token in config.yaml) but
         get_auth_status() returns logged_in=False, has_key must remain True.
-        
+
         Before the fix: has_key was overwritten to False, hiding the working token.
         """
         auth = _make_fake_auth(logged_in=False)
@@ -126,14 +137,22 @@ class TestGetProvidersOauthBlock:
 
         # Use a module that raises ImportError
         bad_mod = types.ModuleType("hermes_cli.auth")
+
         def bad_get_auth_status(pid):
             raise ImportError("hermes_cli not installed")
+
         bad_mod.get_auth_status = bad_get_auth_status
 
-        with patch.object(prov_mod, "_provider_has_key", return_value=True), \
-             patch.object(prov_mod, "_provider_is_oauth", side_effect=lambda pid: pid in ("openai-codex", "nous", "copilot")), \
-             patch.dict(sys.modules, {"hermes_cli.auth": bad_mod}), \
-             patch.object(prov_mod, "get_config", return_value={}):
+        with (
+            patch.object(prov_mod, "_provider_has_key", return_value=True),
+            patch.object(
+                prov_mod,
+                "_provider_is_oauth",
+                side_effect=lambda pid: pid in ("openai-codex", "nous", "copilot"),
+            ),
+            patch.dict(sys.modules, {"hermes_cli.auth": bad_mod}),
+            patch.object(prov_mod, "get_config", return_value={}),
+        ):
             result = prov_mod.get_providers()
 
         providers = {p["id"]: p for p in result["providers"]}
@@ -147,10 +166,13 @@ class TestGetProvidersOauthBlock:
     def test_auth_error_field_present_on_all_oauth_providers(self):
         """Every provider dict must include auth_error (may be None)."""
         import api.providers as prov_mod
+
         auth = _make_fake_auth(logged_in=False)
-        with patch.object(prov_mod, "_provider_has_key", return_value=False), \
-             patch.dict(sys.modules, {"hermes_cli.auth": auth}), \
-             patch.object(prov_mod, "get_config", return_value={}):
+        with (
+            patch.object(prov_mod, "_provider_has_key", return_value=False),
+            patch.dict(sys.modules, {"hermes_cli.auth": auth}),
+            patch.object(prov_mod, "get_config", return_value={}),
+        ):
             result = prov_mod.get_providers()
 
         for p in result["providers"]:
@@ -163,6 +185,7 @@ class TestGetProvidersOauthBlock:
 # Tests for static/panels.js isOauth detection
 # ---------------------------------------------------------------------------
 
+
 class TestBuildProviderCardJs:
     """Static-analysis tests for the JS card rendering."""
 
@@ -173,7 +196,8 @@ class TestBuildProviderCardJs:
         assert idx != -1, "_buildProviderCard not found in panels.js"
         depth = 0
         for i, ch in enumerate(self.JS[idx:], idx):
-            if ch == "{": depth += 1
+            if ch == "{":
+                depth += 1
             elif ch == "}":
                 depth -= 1
                 if depth == 0:
@@ -190,7 +214,7 @@ class TestBuildProviderCardJs:
         fn = self._get_fn()
         isOauth_line_idx = fn.find("const isOauth=")
         assert isOauth_line_idx != -1, "isOauth not found in _buildProviderCard"
-        isOauth_line = fn[isOauth_line_idx: isOauth_line_idx + 150]
+        isOauth_line = fn[isOauth_line_idx : isOauth_line_idx + 150]
         assert "p.is_oauth" in isOauth_line, (
             "REGRESSION: isOauth does not use p.is_oauth from the backend. "
             "OAuth providers may not render the OAuth card correctly."
@@ -228,6 +252,7 @@ class TestBuildProviderCardJs:
 # Tests for i18n.js new keys
 # ---------------------------------------------------------------------------
 
+
 class TestI18nNewKeys:
     """Verify new i18n keys exist in the English locale."""
 
@@ -244,7 +269,6 @@ class TestI18nNewKeys:
             "Missing i18n key: providers_oauth_not_configured_hint."
         )
 
-
     def test_is_oauth_field_true_for_oauth_providers(self):
         """
         REGRESSION TEST (#1202 — Opus blocking issue):
@@ -253,10 +277,13 @@ class TestI18nNewKeys:
         providers from the Settings panel entirely (configurable=False for OAuth).
         """
         import api.providers as prov_mod
+
         auth = _make_fake_auth(logged_in=False)
-        with patch.object(prov_mod, "_provider_has_key", return_value=False), \
-             patch.dict(sys.modules, {"hermes_cli.auth": auth}), \
-             patch.object(prov_mod, "get_config", return_value={}):
+        with (
+            patch.object(prov_mod, "_provider_has_key", return_value=False),
+            patch.dict(sys.modules, {"hermes_cli.auth": auth}),
+            patch.object(prov_mod, "get_config", return_value={}),
+        ):
             result = prov_mod.get_providers()
 
         providers = {p["id"]: p for p in result["providers"]}
@@ -273,7 +300,9 @@ class TestI18nNewKeys:
 class TestProviderListFilter:
     """Test that the JS filter includes OAuth providers."""
 
-    JS = (Path(__file__).parent.parent / "static" / "panels.js").read_text(encoding="utf-8")
+    JS = (Path(__file__).parent.parent / "static" / "panels.js").read_text(
+        encoding="utf-8"
+    )
 
     def test_providers_filter_includes_is_oauth(self):
         """

--- a/tests/test_issue1217_transcript_compaction.py
+++ b/tests/test_issue1217_transcript_compaction.py
@@ -8,7 +8,9 @@ from api.streaming import (
 )
 
 
-def test_session_persists_model_context_separately_from_display_transcript(tmp_path, monkeypatch):
+def test_session_persists_model_context_separately_from_display_transcript(
+    tmp_path, monkeypatch
+):
     """Compacted model context must not replace the visible WebUI transcript."""
     state_dir = tmp_path / "state"
     session_dir = state_dir / "sessions"
@@ -44,7 +46,10 @@ def test_session_persists_model_context_separately_from_display_transcript(tmp_p
     assert reloaded.messages == original_display
     assert reloaded.context_messages == compacted_context
     assert _session_context_messages(reloaded) == compacted_context
-    assert _sanitize_messages_for_api(_session_context_messages(reloaded)) == compacted_context
+    assert (
+        _sanitize_messages_for_api(_session_context_messages(reloaded))
+        == compacted_context
+    )
 
 
 def test_workspace_prefixed_current_user_after_compaction_is_not_duplicated():
@@ -58,7 +63,10 @@ def test_workspace_prefixed_current_user_after_compaction_is_not_duplicated():
             "role": "assistant",
             "content": "[CONTEXT COMPACTION — REFERENCE ONLY] Earlier turns were compacted.",
         },
-        {"role": "user", "content": "[Workspace: /home/manfred/.hermes/workspace]\nOk, mache weiter"},
+        {
+            "role": "user",
+            "content": "[Workspace: /home/manfred/.hermes/workspace]\nOk, mache weiter",
+        },
         {"role": "assistant", "content": "continuing"},
     ]
 
@@ -69,12 +77,25 @@ def test_workspace_prefixed_current_user_after_compaction_is_not_duplicated():
         "Ok, mache weiter",
     )
 
-    assert [m["role"] for m in merged] == ["user", "assistant", "assistant", "user", "assistant"]
+    assert [m["role"] for m in merged] == [
+        "user",
+        "assistant",
+        "assistant",
+        "user",
+        "assistant",
+    ]
     assert [m["content"] for m in merged[-2:]] == [
         "Ok, mache weiter",
         "continuing",
     ]
-    assert sum(1 for m in merged if m.get("role") == "user" and "Ok, mache weiter" in m.get("content", "")) == 1
+    assert (
+        sum(
+            1
+            for m in merged
+            if m.get("role") == "user" and "Ok, mache weiter" in m.get("content", "")
+        )
+        == 1
+    )
 
 
 def test_compacted_agent_result_keeps_old_prompts_and_appends_current_turn():
@@ -166,7 +187,9 @@ def test_session_context_falls_back_to_display_messages_for_legacy_sessions(tmp_
         {"role": "user", "content": "legacy prompt"},
         {"role": "assistant", "content": "legacy answer"},
     ]
-    session = Session(session_id="legacy1217", workspace=str(tmp_path), messages=messages)
+    session = Session(
+        session_id="legacy1217", workspace=str(tmp_path), messages=messages
+    )
 
     assert session.context_messages == []
     assert _session_context_messages(session) == messages
@@ -185,7 +208,10 @@ def test_retry_truncates_model_context_when_it_is_separate(monkeypatch, tmp_path
             {"role": "assistant", "content": "visible four"},
         ],
         context_messages=[
-            {"role": "user", "content": "[CONTEXT COMPACTION — REFERENCE ONLY] summary"},
+            {
+                "role": "user",
+                "content": "[CONTEXT COMPACTION — REFERENCE ONLY] summary",
+            },
             {"role": "user", "content": "visible three"},
             {"role": "assistant", "content": "visible four"},
         ],
@@ -194,7 +220,9 @@ def test_retry_truncates_model_context_when_it_is_separate(monkeypatch, tmp_path
     session.save = lambda *args, **kwargs: saved.append(True)
     monkeypatch.setattr(session_ops, "get_session", lambda sid: session)
     monkeypatch.setattr(session_ops, "SESSIONS", {session.session_id: session})
-    monkeypatch.setattr(session_ops, "_get_session_agent_lock", lambda sid: contextlib.nullcontext())
+    monkeypatch.setattr(
+        session_ops, "_get_session_agent_lock", lambda sid: contextlib.nullcontext()
+    )
 
     result = session_ops.retry_last(session.session_id)
 
@@ -219,7 +247,10 @@ def test_undo_truncates_model_context_when_it_is_separate(monkeypatch, tmp_path)
             {"role": "assistant", "content": "visible four"},
         ],
         context_messages=[
-            {"role": "user", "content": "[CONTEXT COMPACTION — REFERENCE ONLY] summary"},
+            {
+                "role": "user",
+                "content": "[CONTEXT COMPACTION — REFERENCE ONLY] summary",
+            },
             {"role": "user", "content": "visible three"},
             {"role": "assistant", "content": "visible four"},
         ],
@@ -228,7 +259,9 @@ def test_undo_truncates_model_context_when_it_is_separate(monkeypatch, tmp_path)
     session.save = lambda *args, **kwargs: saved.append(True)
     monkeypatch.setattr(session_ops, "get_session", lambda sid: session)
     monkeypatch.setattr(session_ops, "SESSIONS", {session.session_id: session})
-    monkeypatch.setattr(session_ops, "_get_session_agent_lock", lambda sid: contextlib.nullcontext())
+    monkeypatch.setattr(
+        session_ops, "_get_session_agent_lock", lambda sid: contextlib.nullcontext()
+    )
 
     result = session_ops.undo_last(session.session_id)
 

--- a/tests/test_issue1228_model_picker_duplicate_ids.py
+++ b/tests/test_issue1228_model_picker_duplicate_ids.py
@@ -6,6 +6,7 @@ Covers:
 - _deduplicate_model_ids() post-process in api/config.py
 - Frontend norm() regex in ui.js that strips @provider: prefixes
 """
+
 import copy
 import unittest
 
@@ -15,6 +16,7 @@ class TestDeduplicateModelIds(unittest.TestCase):
 
     def _call(self, groups):
         from api.config import _deduplicate_model_ids
+
         groups = copy.deepcopy(groups)
         _deduplicate_model_ids(groups)
         return groups
@@ -24,12 +26,20 @@ class TestDeduplicateModelIds(unittest.TestCase):
     def test_unique_ids_unchanged(self):
         """When all model IDs are unique across groups, nothing changes."""
         groups = [
-            {"provider": "Anthropic", "provider_id": "anthropic", "models": [
-                {"id": "claude-sonnet-4.6", "label": "Claude Sonnet 4.6"},
-            ]},
-            {"provider": "OpenAI", "provider_id": "openai-codex", "models": [
-                {"id": "gpt-5.4", "label": "GPT-5.4"},
-            ]},
+            {
+                "provider": "Anthropic",
+                "provider_id": "anthropic",
+                "models": [
+                    {"id": "claude-sonnet-4.6", "label": "Claude Sonnet 4.6"},
+                ],
+            },
+            {
+                "provider": "OpenAI",
+                "provider_id": "openai-codex",
+                "models": [
+                    {"id": "gpt-5.4", "label": "GPT-5.4"},
+                ],
+            },
         ]
         result = self._call(groups)
         assert result[0]["models"][0]["id"] == "claude-sonnet-4.6"
@@ -38,10 +48,14 @@ class TestDeduplicateModelIds(unittest.TestCase):
     def test_single_group_unchanged(self):
         """A single group never triggers deduplication."""
         groups = [
-            {"provider": "Anthropic", "provider_id": "anthropic", "models": [
-                {"id": "claude-sonnet-4.6", "label": "Claude Sonnet 4.6"},
-                {"id": "claude-opus-4.6", "label": "Claude Opus 4.6"},
-            ]},
+            {
+                "provider": "Anthropic",
+                "provider_id": "anthropic",
+                "models": [
+                    {"id": "claude-sonnet-4.6", "label": "Claude Sonnet 4.6"},
+                    {"id": "claude-opus-4.6", "label": "Claude Opus 4.6"},
+                ],
+            },
         ]
         result = self._call(groups)
         ids = [m["id"] for m in result[0]["models"]]
@@ -59,12 +73,20 @@ class TestDeduplicateModelIds(unittest.TestCase):
         """When two providers share the same bare model ID, the second
         gets @provider_id: prefix and a disambiguated label."""
         groups = [
-            {"provider": "Edith", "provider_id": "custom:edith", "models": [
-                {"id": "gpt-5.4", "label": "GPT-5.4"},
-            ]},
-            {"provider": "OpenAI Codex", "provider_id": "openai-codex", "models": [
-                {"id": "gpt-5.4", "label": "GPT-5.4"},
-            ]},
+            {
+                "provider": "Edith",
+                "provider_id": "custom:edith",
+                "models": [
+                    {"id": "gpt-5.4", "label": "GPT-5.4"},
+                ],
+            },
+            {
+                "provider": "OpenAI Codex",
+                "provider_id": "openai-codex",
+                "models": [
+                    {"id": "gpt-5.4", "label": "GPT-5.4"},
+                ],
+            },
         ]
         result = self._call(groups)
         # First stays bare for backward compat
@@ -78,15 +100,27 @@ class TestDeduplicateModelIds(unittest.TestCase):
         """With three providers sharing the same model, first stays bare,
         the other two get prefixed."""
         groups = [
-            {"provider": "A", "provider_id": "alpha", "models": [
-                {"id": "gpt-5.4", "label": "GPT-5.4"},
-            ]},
-            {"provider": "B", "provider_id": "beta", "models": [
-                {"id": "gpt-5.4", "label": "GPT-5.4"},
-            ]},
-            {"provider": "C", "provider_id": "gamma", "models": [
-                {"id": "gpt-5.4", "label": "GPT-5.4"},
-            ]},
+            {
+                "provider": "A",
+                "provider_id": "alpha",
+                "models": [
+                    {"id": "gpt-5.4", "label": "GPT-5.4"},
+                ],
+            },
+            {
+                "provider": "B",
+                "provider_id": "beta",
+                "models": [
+                    {"id": "gpt-5.4", "label": "GPT-5.4"},
+                ],
+            },
+            {
+                "provider": "C",
+                "provider_id": "gamma",
+                "models": [
+                    {"id": "gpt-5.4", "label": "GPT-5.4"},
+                ],
+            },
         ]
         result = self._call(groups)
         assert result[0]["models"][0]["id"] == "gpt-5.4"
@@ -98,12 +132,26 @@ class TestDeduplicateModelIds(unittest.TestCase):
     def test_already_prefixed_ids_and_unique_slash_ids_unchanged(self):
         """Already-qualified IDs stay untouched; unique slash IDs are still allowed."""
         groups = [
-            {"provider": "Anthropic", "provider_id": "anthropic", "models": [
-                {"id": "@anthropic:claude-sonnet-4.6", "label": "Claude Sonnet 4.6"},
-            ]},
-            {"provider": "OpenRouter", "provider_id": "openrouter", "models": [
-                {"id": "anthropic/claude-sonnet-4.6", "label": "Claude Sonnet 4.6 (OR)"},
-            ]},
+            {
+                "provider": "Anthropic",
+                "provider_id": "anthropic",
+                "models": [
+                    {
+                        "id": "@anthropic:claude-sonnet-4.6",
+                        "label": "Claude Sonnet 4.6",
+                    },
+                ],
+            },
+            {
+                "provider": "OpenRouter",
+                "provider_id": "openrouter",
+                "models": [
+                    {
+                        "id": "anthropic/claude-sonnet-4.6",
+                        "label": "Claude Sonnet 4.6 (OR)",
+                    },
+                ],
+            },
         ]
         result = self._call(groups)
         assert result[0]["models"][0]["id"] == "@anthropic:claude-sonnet-4.6"
@@ -112,12 +160,20 @@ class TestDeduplicateModelIds(unittest.TestCase):
     def test_two_providers_same_slash_qualified_model_prefixes_second(self):
         """Slash-qualified duplicates must also be made unique (#1313)."""
         groups = [
-            {"provider": "Alpha", "provider_id": "custom:alpha", "models": [
-                {"id": "google/gemma-4-27b", "label": "Gemma 4 27B"},
-            ]},
-            {"provider": "Beta", "provider_id": "custom:beta", "models": [
-                {"id": "google/gemma-4-27b", "label": "Gemma 4 27B"},
-            ]},
+            {
+                "provider": "Alpha",
+                "provider_id": "custom:alpha",
+                "models": [
+                    {"id": "google/gemma-4-27b", "label": "Gemma 4 27B"},
+                ],
+            },
+            {
+                "provider": "Beta",
+                "provider_id": "custom:beta",
+                "models": [
+                    {"id": "google/gemma-4-27b", "label": "Gemma 4 27B"},
+                ],
+            },
         ]
         result = self._call(groups)
         assert result[0]["models"][0]["id"] == "google/gemma-4-27b"
@@ -129,14 +185,22 @@ class TestDeduplicateModelIds(unittest.TestCase):
     def test_mixed_unique_and_colliding(self):
         """Only colliding IDs get prefixed; unique ones stay bare."""
         groups = [
-            {"provider": "Edith", "provider_id": "custom:edith", "models": [
-                {"id": "gpt-5.4", "label": "GPT-5.4"},
-                {"id": "claude-sonnet-4.6", "label": "Claude Sonnet 4.6"},
-            ]},
-            {"provider": "OpenAI Codex", "provider_id": "openai-codex", "models": [
-                {"id": "gpt-5.4", "label": "GPT-5.4"},
-                {"id": "o3-pro", "label": "O3 Pro"},
-            ]},
+            {
+                "provider": "Edith",
+                "provider_id": "custom:edith",
+                "models": [
+                    {"id": "gpt-5.4", "label": "GPT-5.4"},
+                    {"id": "claude-sonnet-4.6", "label": "Claude Sonnet 4.6"},
+                ],
+            },
+            {
+                "provider": "OpenAI Codex",
+                "provider_id": "openai-codex",
+                "models": [
+                    {"id": "gpt-5.4", "label": "GPT-5.4"},
+                    {"id": "o3-pro", "label": "O3 Pro"},
+                ],
+            },
         ]
         result = self._call(groups)
         # gpt-5.4 collides → second gets prefixed
@@ -153,12 +217,20 @@ class TestDeduplicateModelIds(unittest.TestCase):
         """When the original label differs from the bare ID, the
         disambiguated label preserves the custom label + adds provider."""
         groups = [
-            {"provider": "Edith", "provider_id": "custom:edith", "models": [
-                {"id": "gpt-5.4", "label": "GPT 5.4 Turbo"},
-            ]},
-            {"provider": "Codex", "provider_id": "openai-codex", "models": [
-                {"id": "gpt-5.4", "label": "GPT 5.4 Standard"},
-            ]},
+            {
+                "provider": "Edith",
+                "provider_id": "custom:edith",
+                "models": [
+                    {"id": "gpt-5.4", "label": "GPT 5.4 Turbo"},
+                ],
+            },
+            {
+                "provider": "Codex",
+                "provider_id": "openai-codex",
+                "models": [
+                    {"id": "gpt-5.4", "label": "GPT 5.4 Standard"},
+                ],
+            },
         ]
         result = self._call(groups)
         assert result[0]["models"][0]["label"] == "GPT 5.4 Turbo"
@@ -168,12 +240,20 @@ class TestDeduplicateModelIds(unittest.TestCase):
         """When label == bare_id, the disambiguated label becomes
         'model_id (Provider Name)'."""
         groups = [
-            {"provider": "Edith", "provider_id": "custom:edith", "models": [
-                {"id": "gpt-5.4", "label": "gpt-5.4"},
-            ]},
-            {"provider": "OpenAI Codex", "provider_id": "openai-codex", "models": [
-                {"id": "gpt-5.4", "label": "gpt-5.4"},
-            ]},
+            {
+                "provider": "Edith",
+                "provider_id": "custom:edith",
+                "models": [
+                    {"id": "gpt-5.4", "label": "gpt-5.4"},
+                ],
+            },
+            {
+                "provider": "OpenAI Codex",
+                "provider_id": "openai-codex",
+                "models": [
+                    {"id": "gpt-5.4", "label": "gpt-5.4"},
+                ],
+            },
         ]
         result = self._call(groups)
         assert result[0]["models"][0]["label"] == "gpt-5.4"
@@ -186,6 +266,7 @@ class TestFrontendNormRegex(unittest.TestCase):
     @staticmethod
     def _read_js():
         import pathlib
+
         return (pathlib.Path(__file__).parent.parent / "static" / "ui.js").read_text()
 
     def _extract_norm(self):
@@ -193,6 +274,7 @@ class TestFrontendNormRegex(unittest.TestCase):
         src = self._read_js()
         # Find: const norm=s=>...;
         import re
+
         m = re.search(r"const norm=(s=>[^;]+);", src)
         assert m, "norm() not found in ui.js"
         return m.group(1)
@@ -201,33 +283,77 @@ class TestFrontendNormRegex(unittest.TestCase):
         """norm('@custom:edith:gpt-5.4') === norm('gpt-5.4')."""
         norm_js = self._extract_norm()
         import subprocess
-        r1 = subprocess.run(["node", "-e", f"console.log(({norm_js})('gpt-5.4'))"], capture_output=True, text=True)
-        r2 = subprocess.run(["node", "-e", f"console.log(({norm_js})('@custom:edith:gpt-5.4'))"], capture_output=True, text=True)
-        assert r1.stdout.strip() == r2.stdout.strip(), f"{r1.stdout.strip()} != {r2.stdout.strip()}"
+
+        r1 = subprocess.run(
+            ["node", "-e", f"console.log(({norm_js})('gpt-5.4'))"],
+            capture_output=True,
+            text=True,
+        )
+        r2 = subprocess.run(
+            ["node", "-e", f"console.log(({norm_js})('@custom:edith:gpt-5.4'))"],
+            capture_output=True,
+            text=True,
+        )
+        assert r1.stdout.strip() == r2.stdout.strip(), (
+            f"{r1.stdout.strip()} != {r2.stdout.strip()}"
+        )
 
     def test_norm_strips_simple_provider_prefix(self):
         """norm('@openai-codex:gpt-5.4') === norm('gpt-5.4')."""
         norm_js = self._extract_norm()
         import subprocess
-        r1 = subprocess.run(["node", "-e", f"console.log(({norm_js})('gpt-5.4'))"], capture_output=True, text=True)
-        r2 = subprocess.run(["node", "-e", f"console.log(({norm_js})('@openai-codex:gpt-5.4'))"], capture_output=True, text=True)
-        assert r1.stdout.strip() == r2.stdout.strip(), f"{r1.stdout.strip()} != {r2.stdout.strip()}"
+
+        r1 = subprocess.run(
+            ["node", "-e", f"console.log(({norm_js})('gpt-5.4'))"],
+            capture_output=True,
+            text=True,
+        )
+        r2 = subprocess.run(
+            ["node", "-e", f"console.log(({norm_js})('@openai-codex:gpt-5.4'))"],
+            capture_output=True,
+            text=True,
+        )
+        assert r1.stdout.strip() == r2.stdout.strip(), (
+            f"{r1.stdout.strip()} != {r2.stdout.strip()}"
+        )
 
     def test_norm_preserves_openrouter(self):
         """norm('openai/gpt-5.4') === norm('gpt-5.4') still works."""
         norm_js = self._extract_norm()
         import subprocess
-        r1 = subprocess.run(["node", "-e", f"console.log(({norm_js})('gpt-5.4'))"], capture_output=True, text=True)
-        r2 = subprocess.run(["node", "-e", f"console.log(({norm_js})('openai/gpt-5.4'))"], capture_output=True, text=True)
-        assert r1.stdout.strip() == r2.stdout.strip(), f"{r1.stdout.strip()} != {r2.stdout.strip()}"
+
+        r1 = subprocess.run(
+            ["node", "-e", f"console.log(({norm_js})('gpt-5.4'))"],
+            capture_output=True,
+            text=True,
+        )
+        r2 = subprocess.run(
+            ["node", "-e", f"console.log(({norm_js})('openai/gpt-5.4'))"],
+            capture_output=True,
+            text=True,
+        )
+        assert r1.stdout.strip() == r2.stdout.strip(), (
+            f"{r1.stdout.strip()} != {r2.stdout.strip()}"
+        )
 
     def test_norm_preserves_minimax_prefix(self):
         """norm('@minimax:MiniMax-M2.7') === norm('minimax-m2.7') still works."""
         norm_js = self._extract_norm()
         import subprocess
-        r1 = subprocess.run(["node", "-e", f"console.log(({norm_js})('minimax-m2.7'))"], capture_output=True, text=True)
-        r2 = subprocess.run(["node", "-e", f"console.log(({norm_js})('@minimax:MiniMax-M2.7'))"], capture_output=True, text=True)
-        assert r1.stdout.strip() == r2.stdout.strip(), f"{r1.stdout.strip()} != {r2.stdout.strip()}"
+
+        r1 = subprocess.run(
+            ["node", "-e", f"console.log(({norm_js})('minimax-m2.7'))"],
+            capture_output=True,
+            text=True,
+        )
+        r2 = subprocess.run(
+            ["node", "-e", f"console.log(({norm_js})('@minimax:MiniMax-M2.7'))"],
+            capture_output=True,
+            text=True,
+        )
+        assert r1.stdout.strip() == r2.stdout.strip(), (
+            f"{r1.stdout.strip()} != {r2.stdout.strip()}"
+        )
 
 
 class TestFrontendPreferredProviderMatch(unittest.TestCase):
@@ -236,6 +362,7 @@ class TestFrontendPreferredProviderMatch(unittest.TestCase):
     @staticmethod
     def _read_js():
         import pathlib
+
         return (pathlib.Path(__file__).parent.parent / "static" / "ui.js").read_text()
 
     def test_find_model_prefers_matching_provider_for_slash_collision(self):
@@ -244,7 +371,11 @@ class TestFrontendPreferredProviderMatch(unittest.TestCase):
 
         src = self._read_js()
         helper = re.search(r"function _getOptionProviderId\(opt\)\{.*?\n\}", src, re.S)
-        finder = re.search(r"function _findModelInDropdown\(modelId, sel, preferredProviderId\)\{.*?\n\}", src, re.S)
+        finder = re.search(
+            r"function _findModelInDropdown\(modelId, sel, preferredProviderId\)\{.*?\n\}",
+            src,
+            re.S,
+        )
         assert helper, "_getOptionProviderId() not found in ui.js"
         assert finder, "_findModelInDropdown() not found in ui.js"
 
@@ -259,7 +390,9 @@ const sel = {{
 }};
 console.log(_findModelInDropdown('google/gemma-4-27b', sel, 'custom:beta') || '');
 """
-        resolved = subprocess.run(["node", "-e", script], capture_output=True, text=True, check=True)
+        resolved = subprocess.run(
+            ["node", "-e", script], capture_output=True, text=True, check=True
+        )
         assert resolved.stdout.strip() == "@custom:beta:google/gemma-4-27b"
 
 
@@ -274,9 +407,12 @@ class TestResolveModelProviderColonInProviderId(unittest.TestCase):
     def test_custom_provider_id_with_colon(self):
         """@custom:edith:gpt-5.4 → ('gpt-5.4', 'custom:edith', None)."""
         from api.config import resolve_model_provider
+
         model, provider, base_url = resolve_model_provider("@custom:edith:gpt-5.4")
         assert model == "gpt-5.4", f"Expected bare model 'gpt-5.4', got '{model}'"
-        assert provider == "custom:edith", f"Expected provider 'custom:edith', got '{provider}'"
+        assert provider == "custom:edith", (
+            f"Expected provider 'custom:edith', got '{provider}'"
+        )
         assert base_url is None
 
     def test_simple_provider_id_unchanged(self):
@@ -285,6 +421,7 @@ class TestResolveModelProviderColonInProviderId(unittest.TestCase):
         Backward compat: simple provider_ids (no colon) still work.
         """
         from api.config import resolve_model_provider
+
         model, provider, base_url = resolve_model_provider("@openai-codex:gpt-5.4")
         assert model == "gpt-5.4"
         assert provider == "openai-codex"

--- a/tests/test_issue1240_generic_cli_catalog_sync.py
+++ b/tests/test_issue1240_generic_cli_catalog_sync.py
@@ -40,7 +40,9 @@ def _scrub_provider_env(monkeypatch):
         monkeypatch.delenv(name, raising=False)
 
 
-def _install_fake_hermes_cli(monkeypatch, *, provider_id: str, live_ids, raise_on_lookup: bool = False):
+def _install_fake_hermes_cli(
+    monkeypatch, *, provider_id: str, live_ids, raise_on_lookup: bool = False
+):
     """Install a hermes_cli stub that reports one authenticated provider."""
     fake_pkg = types.ModuleType("hermes_cli")
     fake_pkg.__path__ = []
@@ -79,7 +81,9 @@ def _install_fake_hermes_cli(monkeypatch, *, provider_id: str, live_ids, raise_o
 
 
 def _configure(monkeypatch, tmp_path, *, provider: str, default: str = ""):
-    monkeypatch.setattr(config, "_get_config_path", lambda: tmp_path / "missing-config.yaml")
+    monkeypatch.setattr(
+        config, "_get_config_path", lambda: tmp_path / "missing-config.yaml"
+    )
     monkeypatch.setattr(config, "_models_cache_path", tmp_path / "models_cache.json")
     monkeypatch.setattr(
         config,
@@ -102,7 +106,9 @@ def _ids(group: dict) -> list[str]:
     return [m.get("id") for m in group.get("models", [])]
 
 
-def test_generic_provider_uses_hermes_cli_catalog_before_static_snapshot(monkeypatch, tmp_path):
+def test_generic_provider_uses_hermes_cli_catalog_before_static_snapshot(
+    monkeypatch, tmp_path
+):
     """A normal provider should show fresh CLI-discovered models.
 
     ``claude-sonnet-5.0`` is intentionally absent from WebUI's static Anthropic
@@ -125,7 +131,9 @@ def test_generic_provider_uses_hermes_cli_catalog_before_static_snapshot(monkeyp
     assert group["models"][1]["label"] == "Claude Sonnet 5.0"
 
 
-def test_generic_provider_keeps_static_catalog_as_cli_failure_fallback(monkeypatch, tmp_path):
+def test_generic_provider_keeps_static_catalog_as_cli_failure_fallback(
+    monkeypatch, tmp_path
+):
     _scrub_provider_env(monkeypatch)
     calls = _install_fake_hermes_cli(
         monkeypatch,
@@ -143,7 +151,9 @@ def test_generic_provider_keeps_static_catalog_as_cli_failure_fallback(monkeypat
     assert "claude-sonnet-4.6" in _ids(group)
 
 
-def test_generic_provider_prefixes_live_ids_when_not_active_provider(monkeypatch, tmp_path):
+def test_generic_provider_prefixes_live_ids_when_not_active_provider(
+    monkeypatch, tmp_path
+):
     """Provider-qualified live IDs must route through the selected provider."""
     _scrub_provider_env(monkeypatch)
     calls = _install_fake_hermes_cli(

--- a/tests/test_issue1257_llm_wiki_status.py
+++ b/tests/test_issue1257_llm_wiki_status.py
@@ -15,20 +15,31 @@ def _write(path: Path, text: str = "# Synthetic\n") -> Path:
     return path
 
 
-def test_llm_wiki_status_reads_synthetic_fixture_without_exposing_content(tmp_path, monkeypatch):
+def test_llm_wiki_status_reads_synthetic_fixture_without_exposing_content(
+    tmp_path, monkeypatch
+):
     """The wiki status API should summarize counts/mtime without leaking page text."""
     import api.routes as routes
 
     wiki = tmp_path / "wiki"
     _write(wiki / "SCHEMA.md", "# Schema\n")
     _write(wiki / "index.md", "# Index\n")
-    _write(wiki / "log.md", "# Log\n## [2026-05-04] update | Secret project name\n- Details stay private\n")
+    _write(
+        wiki / "log.md",
+        "# Log\n## [2026-05-04] update | Secret project name\n- Details stay private\n",
+    )
     _write(
         wiki / "entities" / "private-agent.md",
         "---\ntitle: Private Agent\nupdated: 2026-05-04\n---\nSensitive body text must not ship.\n",
     )
-    _write(wiki / "concepts" / "safe-summary.md", "---\ntitle: Safe Summary\n---\nMore private text\n")
-    _write(wiki / "raw" / "articles" / "source.md", "Raw source body should not count as wiki page\n")
+    _write(
+        wiki / "concepts" / "safe-summary.md",
+        "---\ntitle: Safe Summary\n---\nMore private text\n",
+    )
+    _write(
+        wiki / "raw" / "articles" / "source.md",
+        "Raw source body should not count as wiki page\n",
+    )
 
     monkeypatch.setenv("WIKI_PATH", str(wiki))
 

--- a/tests/test_issue1298_cancel_and_activity.py
+++ b/tests/test_issue1298_cancel_and_activity.py
@@ -9,6 +9,7 @@ Bug 2 is server-side data loss (the message is gone from session JSON, not just
 the in-memory client copy) caused by cancel_stream() clearing pending_user_message
 without first persisting it to s.messages. This test suite locks down both fixes.
 """
+
 import pathlib
 import queue
 import re
@@ -19,7 +20,6 @@ import pytest
 
 import api.config as config
 import api.models as models
-import api.streaming as streaming
 from api.models import Session
 from api.streaming import cancel_stream
 
@@ -27,6 +27,7 @@ REPO_ROOT = pathlib.Path(__file__).parent.parent.resolve()
 
 
 # ── Fixtures ────────────────────────────────────────────────────────────────
+
 
 @pytest.fixture(autouse=True)
 def _isolate_session_dir(tmp_path, monkeypatch):
@@ -61,10 +62,12 @@ def _isolate_agent_locks():
     config.SESSION_AGENT_LOCKS.clear()
 
 
-def _make_pending_session(session_id="cancel_sid_1298",
-                          pending_msg="Help me debug this issue",
-                          messages=None,
-                          attachments=None):
+def _make_pending_session(
+    session_id="cancel_sid_1298",
+    pending_msg="Help me debug this issue",
+    messages=None,
+    attachments=None,
+):
     """Build a session in mid-stream state: pending_user_message set, messages may be empty."""
     s = Session(
         session_id=session_id,
@@ -92,6 +95,7 @@ def _setup_cancel_stream_state(session_id, stream_id="stream_1298"):
 
 
 # ── Server-side: cancel preserves pending_user_message in s.messages ────────
+
 
 class TestIssue1298CancelPreservesUserMessage:
     """Issue 2: Latest user message disappears after Stop/Cancel during streaming.
@@ -127,8 +131,7 @@ class TestIssue1298CancelPreservesUserMessage:
         contents = [m.get("content") for m in s2.messages if isinstance(m, dict)]
 
         assert "user" in roles, (
-            "Expected user turn synthesized into s.messages — "
-            f"got roles={roles}"
+            f"Expected user turn synthesized into s.messages — got roles={roles}"
         )
         assert "What's the weather forecast?" in contents, (
             "Expected pending_user_message text preserved verbatim in s.messages — "
@@ -154,11 +157,15 @@ class TestIssue1298CancelPreservesUserMessage:
         cancel_stream(stream_id)
 
         s2 = models.SESSIONS[s.session_id]
-        user_messages = [m for m in s2.messages
-                         if isinstance(m, dict) and m.get("role") == "user"]
+        user_messages = [
+            m for m in s2.messages if isinstance(m, dict) and m.get("role") == "user"
+        ]
         # Exactly one user turn — no duplicate
-        matching = [m for m in user_messages
-                    if "Run a tool for me" in str(m.get("content") or "")]
+        matching = [
+            m
+            for m in user_messages
+            if "Run a tool for me" in str(m.get("content") or "")
+        ]
         assert len(matching) == 1, (
             "Expected exactly one user turn matching pending_user_message — "
             f"got {len(matching)} ({user_messages})"
@@ -178,12 +185,14 @@ class TestIssue1298CancelPreservesUserMessage:
         cancel_stream(stream_id)
 
         s2 = models.SESSIONS[s.session_id]
-        user_msgs = [m for m in s2.messages
-                     if isinstance(m, dict) and m.get("role") == "user"]
+        user_msgs = [
+            m for m in s2.messages if isinstance(m, dict) and m.get("role") == "user"
+        ]
         assert user_msgs, "User turn must be persisted on cancel"
         recovered = user_msgs[0]
         assert recovered.get("attachments") == [
-            "bug_screenshot.png", "stack_trace.txt"
+            "bug_screenshot.png",
+            "stack_trace.txt",
         ], (
             "Attachment list must be preserved on the synthesized user turn — "
             f"got {recovered.get('attachments')}"
@@ -207,8 +216,9 @@ class TestIssue1298CancelPreservesUserMessage:
         cancel_stream(stream_id)
 
         s2 = models.SESSIONS[s.session_id]
-        user_messages = [m for m in s2.messages
-                         if isinstance(m, dict) and m.get("role") == "user"]
+        user_messages = [
+            m for m in s2.messages if isinstance(m, dict) and m.get("role") == "user"
+        ]
         # Still exactly one — the original earlier turn
         assert len(user_messages) == 1
         assert user_messages[0].get("content") == "earlier turn"
@@ -229,6 +239,7 @@ class TestIssue1298CancelPreservesUserMessage:
         the synthesis path.
         """
         import time as _time
+
         # Prior reply was "ok" (a common short reply).
         prior_ts = int(_time.time()) - 60  # 1 minute ago
         prior_user = {
@@ -250,8 +261,9 @@ class TestIssue1298CancelPreservesUserMessage:
         cancel_stream(stream_id)
 
         s2 = models.SESSIONS[s.session_id]
-        user_messages = [m for m in s2.messages
-                         if isinstance(m, dict) and m.get("role") == "user"]
+        user_messages = [
+            m for m in s2.messages if isinstance(m, dict) and m.get("role") == "user"
+        ]
         contents = [m.get("content") for m in user_messages]
 
         assert "ok please continue with the analysis" in contents, (
@@ -266,6 +278,7 @@ class TestIssue1298CancelPreservesUserMessage:
 
 
 # ── Client-side: ui.js source-level guards for activity-group state ─────────
+
 
 class TestIssue1298ActivityGroupExpandPersistence:
     """Issue 1: Expanded Activity list collapses automatically when new
@@ -303,7 +316,8 @@ class TestIssue1298ActivityGroupExpandPersistence:
         # Find the ensureActivityGroup function body
         m = re.search(
             r"function ensureActivityGroup\(inner, opts\)\{(.*?)\n\}",
-            src, re.DOTALL,
+            src,
+            re.DOTALL,
         )
         assert m, "ensureActivityGroup() must exist in ui.js"
         body = m.group(1)
@@ -322,7 +336,8 @@ class TestIssue1298ActivityGroupExpandPersistence:
         src = (REPO_ROOT / "static" / "ui.js").read_text()
         m = re.search(
             r"function finalizeThinkingCard\(\)\{(.*?)\n\}",
-            src, re.DOTALL,
+            src,
+            re.DOTALL,
         )
         assert m, "finalizeThinkingCard() must exist in ui.js"
         body = m.group(1)
@@ -331,8 +346,10 @@ class TestIssue1298ActivityGroupExpandPersistence:
             "without this guard, the panel snaps shut on every tool boundary"
         )
         # Hard fail if force-collapse is unconditional
-        assert "_liveActivityUserExpanded !== true" in body or \
-               "_liveActivityUserExpanded!==true" in body.replace(" ", ""), (
+        assert (
+            "_liveActivityUserExpanded !== true" in body
+            or "_liveActivityUserExpanded!==true" in body.replace(" ", "")
+        ), (
             "finalizeThinkingCard() must skip the force-collapse path when "
             "_liveActivityUserExpanded === true"
         )
@@ -353,7 +370,7 @@ class TestIssue1298ActivityGroupExpandPersistence:
         # captured into _liveActivityUserExpanded.
         m = re.search(r'class="tool-call-group-summary"[^`]*`', src)
         assert m, "live activity summary button template must be present"
-        assert "onclick=\"_toggleActivityGroup(this)\"" in m.group(0), (
+        assert 'onclick="_toggleActivityGroup(this)"' in m.group(0), (
             "ensureActivityGroup() summary button should use the shared toggle helper"
         )
         toggle_body = re.search(
@@ -373,7 +390,8 @@ class TestIssue1298ActivityGroupExpandPersistence:
         src = (REPO_ROOT / "static" / "ui.js").read_text()
         m = re.search(
             r"function clearLiveToolCards\(\)\{(.*?)\n\}",
-            src, re.DOTALL,
+            src,
+            re.DOTALL,
         )
         assert m, "clearLiveToolCards() must exist"
         body = m.group(1)

--- a/tests/test_issue1360_streaming_scroll_hardening.py
+++ b/tests/test_issue1360_streaming_scroll_hardening.py
@@ -18,7 +18,7 @@ def _extract_function(src: str, name: str) -> str:
         elif ch == "}":
             depth -= 1
             if depth == 0:
-                return src[idx:i + 1]
+                return src[idx : i + 1]
     raise AssertionError(f"Could not extract {name}")
 
 
@@ -40,20 +40,22 @@ def test_queue_card_measurement_does_not_force_repin_during_streaming():
     fn = _extract_function(UI_JS, "_renderQueueChips")
     measurement_idx = fn.find("setTimeout(()=>")
     assert measurement_idx != -1, "queue card measurement timeout not found"
-    measurement_block = fn[measurement_idx:measurement_idx + 500]
+    measurement_block = fn[measurement_idx : measurement_idx + 500]
 
     assert "S.activeStreamId" in measurement_block
     assert "scrollIfPinned()" in measurement_block
     assert "!S.activeStreamId" in measurement_block
     assert "scrollToBottom()" in measurement_block
-    assert measurement_block.find("scrollIfPinned()") < measurement_block.find("scrollToBottom()")
+    assert measurement_block.find("scrollIfPinned()") < measurement_block.find(
+        "scrollToBottom()"
+    )
 
 
 def test_queue_pill_click_does_not_force_repin_during_streaming():
     fn = _extract_function(UI_JS, "_updateQueuePill")
     click_idx = fn.find("pill.onclick=()=>")
     assert click_idx != -1, "queue pill click handler not found"
-    click_block = fn[click_idx:click_idx + 700]
+    click_block = fn[click_idx : click_idx + 700]
 
     assert "S.activeStreamId" in click_block
     assert "scrollIfPinned()" in click_block

--- a/tests/test_issue1361_cancel_data_loss.py
+++ b/tests/test_issue1361_cancel_data_loss.py
@@ -15,15 +15,13 @@ All three fix the same "tokens-paid-for-data-loss" class of bug.
 
 import pathlib
 import queue
-import re
 import threading
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 import pytest
 
 import api.config as config
 import api.models as models
-import api.streaming as streaming
 from api.models import Session
 from api.streaming import cancel_stream
 
@@ -31,6 +29,7 @@ REPO_ROOT = pathlib.Path(__file__).parent.parent.resolve()
 
 
 # ── Fixtures ────────────────────────────────────────────────────────────────
+
 
 @pytest.fixture(autouse=True)
 def _isolate_session_dir(tmp_path, monkeypatch):
@@ -53,18 +52,18 @@ def _isolate_stream_state():
     config.AGENT_INSTANCES.clear()
     config.STREAM_PARTIAL_TEXT.clear()
     # New shared dicts for §A and §B
-    if hasattr(config, 'STREAM_REASONING_TEXT'):
+    if hasattr(config, "STREAM_REASONING_TEXT"):
         config.STREAM_REASONING_TEXT.clear()
-    if hasattr(config, 'STREAM_LIVE_TOOL_CALLS'):
+    if hasattr(config, "STREAM_LIVE_TOOL_CALLS"):
         config.STREAM_LIVE_TOOL_CALLS.clear()
     yield
     config.STREAMS.clear()
     config.CANCEL_FLAGS.clear()
     config.AGENT_INSTANCES.clear()
     config.STREAM_PARTIAL_TEXT.clear()
-    if hasattr(config, 'STREAM_REASONING_TEXT'):
+    if hasattr(config, "STREAM_REASONING_TEXT"):
         config.STREAM_REASONING_TEXT.clear()
-    if hasattr(config, 'STREAM_LIVE_TOOL_CALLS'):
+    if hasattr(config, "STREAM_LIVE_TOOL_CALLS"):
         config.STREAM_LIVE_TOOL_CALLS.clear()
 
 
@@ -75,9 +74,9 @@ def _isolate_agent_locks():
     config.SESSION_AGENT_LOCKS.clear()
 
 
-def _make_session(session_id="cancel_sid_1361",
-                  pending_msg="Help me debug this",
-                  messages=None):
+def _make_session(
+    session_id="cancel_sid_1361", pending_msg="Help me debug this", messages=None
+):
     """Build a session in mid-stream state."""
     s = Session(
         session_id=session_id,
@@ -106,9 +105,10 @@ def _setup_cancel_state(session_id, stream_id="stream_1361"):
 
 # ── §A: Reasoning text lost on cancel ───────────────────────────────────────
 
+
 class TestCancelPreservesReasoningText:
     """§A: _reasoning_text is thread-local and invisible to cancel_stream().
-    
+
     After fix: reasoning text should be persisted in a shared dict
     (STREAM_REASONING_TEXT) keyed by stream_id, and cancel_stream()
     should append it as a 'reasoning' field on the partial assistant message.
@@ -125,7 +125,7 @@ class TestCancelPreservesReasoningText:
         reasoning = "Let me think about this step by step..."
         config.STREAM_PARTIAL_TEXT[stream_id] = ""  # no visible tokens
 
-        if hasattr(config, 'STREAM_REASONING_TEXT'):
+        if hasattr(config, "STREAM_REASONING_TEXT"):
             config.STREAM_REASONING_TEXT[stream_id] = reasoning
 
         cancel_stream(stream_id)
@@ -134,10 +134,13 @@ class TestCancelPreservesReasoningText:
         s2 = models.SESSIONS[sid]
         msgs = s2.messages
         # There should be a partial assistant message with reasoning
-        assistant_msgs = [m for m in msgs if isinstance(m, dict) and m.get('role') == 'assistant']
-        has_reasoning = any(m.get('reasoning') for m in assistant_msgs)
-        assert has_reasoning, \
+        assistant_msgs = [
+            m for m in msgs if isinstance(m, dict) and m.get("role") == "assistant"
+        ]
+        has_reasoning = any(m.get("reasoning") for m in assistant_msgs)
+        assert has_reasoning, (
             f"Expected reasoning field on partial assistant msg after cancel. Got messages: {assistant_msgs}"
+        )
 
     def test_cancel_with_reasoning_and_partial_tokens_preserves_both(self):
         """Cancel mid-stream with both reasoning and some visible tokens."""
@@ -150,18 +153,23 @@ class TestCancelPreservesReasoningText:
         partial_text = "Based on my analysis, the bug is in the"
         config.STREAM_PARTIAL_TEXT[stream_id] = partial_text
 
-        if hasattr(config, 'STREAM_REASONING_TEXT'):
+        if hasattr(config, "STREAM_REASONING_TEXT"):
             config.STREAM_REASONING_TEXT[stream_id] = reasoning
 
         cancel_stream(stream_id)
 
         s2 = models.SESSIONS[sid]
-        assistant_msgs = [m for m in s2.messages if isinstance(m, dict) and m.get('role') == 'assistant']
+        assistant_msgs = [
+            m
+            for m in s2.messages
+            if isinstance(m, dict) and m.get("role") == "assistant"
+        ]
         # Should have partial content
-        partial_msgs = [m for m in assistant_msgs if m.get('_partial')]
-        has_content = any(m.get('content') for m in partial_msgs)
-        assert has_content, \
+        partial_msgs = [m for m in assistant_msgs if m.get("_partial")]
+        has_content = any(m.get("content") for m in partial_msgs)
+        assert has_content, (
             f"Expected partial assistant content after cancel. Got: {partial_msgs}"
+        )
 
     def test_cancel_without_reasoning_dict_works_as_before(self):
         """If STREAM_REASONING_TEXT doesn't exist yet (pre-fix), cancel still works."""
@@ -178,7 +186,7 @@ class TestCancelPreservesReasoningText:
         msgs = s2.messages
         # Should have the cancel marker
         has_cancel = any(
-            isinstance(m, dict) and m.get('role') == 'assistant' and m.get('_error')
+            isinstance(m, dict) and m.get("role") == "assistant" and m.get("_error")
             for m in msgs
         )
         assert has_cancel, "Cancel marker should always be present"
@@ -186,9 +194,10 @@ class TestCancelPreservesReasoningText:
 
 # ── §B: Tool calls lost on cancel ───────────────────────────────────────────
 
+
 class TestCancelPreservesToolCalls:
     """§B: _live_tool_calls is thread-local and invisible to cancel_stream().
-    
+
     After fix: tool calls should be persisted in a shared dict
     (STREAM_LIVE_TOOL_CALLS) keyed by stream_id, and cancel_stream()
     should append them as tool_call entries on the partial assistant message.
@@ -203,7 +212,7 @@ class TestCancelPreservesToolCalls:
 
         config.STREAM_PARTIAL_TEXT[stream_id] = ""
 
-        if hasattr(config, 'STREAM_LIVE_TOOL_CALLS'):
+        if hasattr(config, "STREAM_LIVE_TOOL_CALLS"):
             config.STREAM_LIVE_TOOL_CALLS[stream_id] = [
                 {"name": "read_file", "args": {"path": "/tmp/test.py"}, "done": True},
                 {"name": "terminal", "args": {"command": "ls"}, "done": False},
@@ -212,10 +221,18 @@ class TestCancelPreservesToolCalls:
         cancel_stream(stream_id)
 
         s2 = models.SESSIONS[sid]
-        assistant_msgs = [m for m in s2.messages if isinstance(m, dict) and m.get('role') == 'assistant']
-        has_tools = any(m.get('_partial_tool_calls') or m.get('tool_calls') or m.get('tools') for m in assistant_msgs)
-        assert has_tools, \
+        assistant_msgs = [
+            m
+            for m in s2.messages
+            if isinstance(m, dict) and m.get("role") == "assistant"
+        ]
+        has_tools = any(
+            m.get("_partial_tool_calls") or m.get("tool_calls") or m.get("tools")
+            for m in assistant_msgs
+        )
+        assert has_tools, (
             f"Expected _partial_tool_calls on partial assistant msg after cancel. Got: {assistant_msgs}"
+        )
 
     def test_cancel_with_tools_and_text_preserves_both(self):
         """Cancel after tools + partial text should keep both."""
@@ -225,7 +242,7 @@ class TestCancelPreservesToolCalls:
         _setup_cancel_state(sid, stream_id)
 
         config.STREAM_PARTIAL_TEXT[stream_id] = "Here's what I found:"
-        if hasattr(config, 'STREAM_LIVE_TOOL_CALLS'):
+        if hasattr(config, "STREAM_LIVE_TOOL_CALLS"):
             config.STREAM_LIVE_TOOL_CALLS[stream_id] = [
                 {"name": "web_search", "args": {"query": "test"}, "done": True},
             ]
@@ -233,19 +250,25 @@ class TestCancelPreservesToolCalls:
         cancel_stream(stream_id)
 
         s2 = models.SESSIONS[sid]
-        assistant_msgs = [m for m in s2.messages if isinstance(m, dict) and m.get('role') == 'assistant']
-        partial_msgs = [m for m in assistant_msgs if m.get('_partial')]
-        has_content = any(m.get('content') for m in partial_msgs)
-        assert has_content, \
+        assistant_msgs = [
+            m
+            for m in s2.messages
+            if isinstance(m, dict) and m.get("role") == "assistant"
+        ]
+        partial_msgs = [m for m in assistant_msgs if m.get("_partial")]
+        has_content = any(m.get("content") for m in partial_msgs)
+        assert has_content, (
             f"Expected partial content with tools after cancel. Got: {partial_msgs}"
+        )
 
 
 # ── §C: Empty _stripped skips entire append ─────────────────────────────────
 
+
 class TestCancelWithReasoningOnlyNoText:
     """§C: When streaming was 100% reasoning (no visible tokens), _stripped is
     empty after regex cleanup, so no partial assistant message is appended.
-    
+
     After fix: even when _stripped is empty, if reasoning or tool calls exist,
     a partial assistant message should be appended (with no content, but with
     reasoning and/or tool_calls fields).
@@ -261,17 +284,22 @@ class TestCancelWithReasoningOnlyNoText:
         # Only reasoning, no visible tokens at all
         config.STREAM_PARTIAL_TEXT[stream_id] = ""
 
-        if hasattr(config, 'STREAM_REASONING_TEXT'):
+        if hasattr(config, "STREAM_REASONING_TEXT"):
             config.STREAM_REASONING_TEXT[stream_id] = "Deep reasoning here..."
 
         cancel_stream(stream_id)
 
         s2 = models.SESSIONS[sid]
-        assistant_msgs = [m for m in s2.messages if isinstance(m, dict) and m.get('role') == 'assistant']
+        assistant_msgs = [
+            m
+            for m in s2.messages
+            if isinstance(m, dict) and m.get("role") == "assistant"
+        ]
         # Should NOT be only the cancel marker — there should be a partial msg
-        partial_msgs = [m for m in assistant_msgs if m.get('_partial')]
-        assert len(partial_msgs) > 0, \
+        partial_msgs = [m for m in assistant_msgs if m.get("_partial")]
+        assert len(partial_msgs) > 0, (
             f"Expected at least one partial assistant msg for reasoning-only cancel. Got: {assistant_msgs}"
+        )
 
     def test_tools_only_creates_partial_message(self):
         """Cancel after tool-only output (no text, no reasoning) should still create a partial msg."""
@@ -282,7 +310,7 @@ class TestCancelWithReasoningOnlyNoText:
 
         config.STREAM_PARTIAL_TEXT[stream_id] = ""
 
-        if hasattr(config, 'STREAM_LIVE_TOOL_CALLS'):
+        if hasattr(config, "STREAM_LIVE_TOOL_CALLS"):
             config.STREAM_LIVE_TOOL_CALLS[stream_id] = [
                 {"name": "read_file", "args": {"path": "/tmp/x"}, "done": True},
             ]
@@ -290,10 +318,15 @@ class TestCancelWithReasoningOnlyNoText:
         cancel_stream(stream_id)
 
         s2 = models.SESSIONS[sid]
-        assistant_msgs = [m for m in s2.messages if isinstance(m, dict) and m.get('role') == 'assistant']
-        partial_msgs = [m for m in assistant_msgs if m.get('_partial')]
-        assert len(partial_msgs) > 0, \
+        assistant_msgs = [
+            m
+            for m in s2.messages
+            if isinstance(m, dict) and m.get("role") == "assistant"
+        ]
+        partial_msgs = [m for m in assistant_msgs if m.get("_partial")]
+        assert len(partial_msgs) > 0, (
             f"Expected at least one partial assistant msg for tools-only cancel. Got: {assistant_msgs}"
+        )
 
     def test_no_reasoning_no_tools_no_partial(self):
         """Cancel with no reasoning and no tools and no text = only cancel marker (no change)."""
@@ -307,16 +340,24 @@ class TestCancelWithReasoningOnlyNoText:
         cancel_stream(stream_id)
 
         s2 = models.SESSIONS[sid]
-        assistant_msgs = [m for m in s2.messages if isinstance(m, dict) and m.get('role') == 'assistant']
+        assistant_msgs = [
+            m
+            for m in s2.messages
+            if isinstance(m, dict) and m.get("role") == "assistant"
+        ]
         # Should only have the cancel marker, no partial messages
-        partial_msgs = [m for m in assistant_msgs if m.get('_partial')]
-        cancel_msgs = [m for m in assistant_msgs if m.get('_error')]
-        assert len(partial_msgs) == 0, \
+        partial_msgs = [m for m in assistant_msgs if m.get("_partial")]
+        cancel_msgs = [m for m in assistant_msgs if m.get("_error")]
+        assert len(partial_msgs) == 0, (
             f"Expected no partial msg when nothing was streamed. Got partials: {partial_msgs}"
-        assert len(cancel_msgs) == 1, \
+        )
+        assert len(cancel_msgs) == 1, (
             f"Expected exactly 1 cancel marker. Got: {cancel_msgs}"
+        )
+
 
 # ── §D: Error paths must not lose pending user turn ─────────────────────────
+
 
 def test_stream_error_materializes_pending_user_turn_before_clearing_runtime_state():
     """If a stream errors before normal merge, pending_user_message must become a
@@ -402,6 +443,7 @@ def test_stale_stream_cleanup_materializes_pending_turn_before_clearing_state():
 
 # ── Structural guard: pin call sites of the materialize helper at error branches ──
 
+
 def test_materialize_helper_called_immediately_before_error_path_clears():
     """Pin call sites of _materialize_pending_user_turn_before_error.
 
@@ -417,12 +459,20 @@ def test_materialize_helper_called_immediately_before_error_path_clears():
     call from one of the error sites, this assertion fires.
     """
     from pathlib import Path
-    src = Path(__file__).parent.parent.joinpath('api', 'streaming.py').read_text(encoding='utf-8')
+
+    src = (
+        Path(__file__)
+        .parent.parent.joinpath("api", "streaming.py")
+        .read_text(encoding="utf-8")
+    )
     lines = src.splitlines()
 
-    helper_name = '_materialize_pending_user_turn_before_error('
-    clear_sites = [(i + 1, line) for i, line in enumerate(lines)
-                   if 'pending_user_message = None' in line]
+    helper_name = "_materialize_pending_user_turn_before_error("
+    clear_sites = [
+        (i + 1, line)
+        for i, line in enumerate(lines)
+        if "pending_user_message = None" in line
+    ]
     assert len(clear_sites) >= 4, (
         f"Expected ≥4 sites that clear pending_user_message; found {len(clear_sites)}. "
         f"If api/streaming.py was refactored, re-audit this test."
@@ -430,7 +480,7 @@ def test_materialize_helper_called_immediately_before_error_path_clears():
 
     sites_with_helper = []
     for lineno, _ in clear_sites:
-        prev_block = '\n'.join(lines[max(0, lineno - 5):lineno - 1])
+        prev_block = "\n".join(lines[max(0, lineno - 5) : lineno - 1])
         if helper_name in prev_block:
             sites_with_helper.append(lineno)
 

--- a/tests/test_issue1362_codex_oauth_onboarding.py
+++ b/tests/test_issue1362_codex_oauth_onboarding.py
@@ -43,11 +43,15 @@ def test_start_payload_does_not_leak_provider_device_secrets(monkeypatch, tmp_pa
 
     oauth._OAUTH_FLOWS.clear()
     monkeypatch.setattr(oauth, "_get_active_hermes_home", lambda: tmp_path)
-    monkeypatch.setattr(oauth, "_request_codex_user_code", lambda: {
-        "device_auth_id": "device-secret",
-        "user_code": "ABCD-EFGH",
-        "interval": 3,
-    })
+    monkeypatch.setattr(
+        oauth,
+        "_request_codex_user_code",
+        lambda: {
+            "device_auth_id": "device-secret",
+            "user_code": "ABCD-EFGH",
+            "interval": 3,
+        },
+    )
     monkeypatch.setattr(oauth, "_spawn_codex_oauth_worker", lambda flow_id: None)
 
     payload = oauth.start_onboarding_oauth_flow({"provider": "openai-codex"})
@@ -88,9 +92,19 @@ def test_poll_returns_high_level_status_only(monkeypatch, tmp_path):
 
     payload = oauth.poll_onboarding_oauth_flow(flow_id)
 
-    assert payload == {"ok": True, "provider": "openai-codex", "flow_id": flow_id, "status": "pending"}
+    assert payload == {
+        "ok": True,
+        "provider": "openai-codex",
+        "flow_id": flow_id,
+        "status": "pending",
+    }
     serialized = json.dumps(payload)
-    for forbidden in ("device_auth_id", "device-secret", "code_verifier", "authorization_code"):
+    for forbidden in (
+        "device_auth_id",
+        "device-secret",
+        "code_verifier",
+        "authorization_code",
+    ):
         assert forbidden not in serialized
 
 
@@ -113,7 +127,9 @@ def test_cancel_marks_flow_cancelled_and_poll_stops(tmp_path):
     assert polled["status"] == "cancelled"
 
 
-def test_cancel_during_token_exchange_does_not_persist_credentials(monkeypatch, tmp_path):
+def test_cancel_during_token_exchange_does_not_persist_credentials(
+    monkeypatch, tmp_path
+):
     """Cancel arriving while the worker is mid-network-call must win.
 
     Without the post-exchange status re-check, the worker would proceed to
@@ -152,7 +168,9 @@ def test_cancel_during_token_exchange_does_not_persist_credentials(monkeypatch, 
         "updated_at": time.time(),
     }
 
-    worker = threading.Thread(target=oauth._run_codex_oauth_worker, args=(flow_id,), daemon=True)
+    worker = threading.Thread(
+        target=oauth._run_codex_oauth_worker, args=(flow_id,), daemon=True
+    )
     worker.start()
     assert poll_started.wait(timeout=5)
 
@@ -231,7 +249,7 @@ def test_frontend_uses_onboarding_oauth_endpoints_and_no_secret_poll_url():
 def test_unsupported_note_mentions_codex_and_claude_as_in_app():
     src = (REPO / "api" / "onboarding.py").read_text(encoding="utf-8")
     start = src.find("_UNSUPPORTED_PROVIDER_NOTE")
-    body = src[start:start + 500]
+    body = src[start : start + 500]
     assert "OpenAI Codex, and GitHub" not in body
     assert "OpenAI Codex" in body and "authenticated in this onboarding flow" in body
     assert "Claude" in body or "Anthropic" in body
@@ -260,13 +278,19 @@ def test_anthropic_immediate_success_when_credentials_exist(monkeypatch, tmp_pat
 
     oauth._OAUTH_FLOWS.clear()
     monkeypatch.setattr(oauth, "_get_active_hermes_home", lambda: tmp_path)
-    monkeypatch.setattr(oauth, "_read_claude_code_credentials", lambda: {
-        "accessToken": "cc-access-secret",
-        "refreshToken": "cc-refresh-secret",
-        "expiresAt": 9999999999999,
-    })
+    monkeypatch.setattr(
+        oauth,
+        "_read_claude_code_credentials",
+        lambda: {
+            "accessToken": "cc-access-secret",
+            "refreshToken": "cc-refresh-secret",
+            "expiresAt": 9999999999999,
+        },
+    )
     linked = []
-    monkeypatch.setattr(oauth, "_link_anthropic_credentials", lambda hh: linked.append(str(hh)))
+    monkeypatch.setattr(
+        oauth, "_link_anthropic_credentials", lambda hh: linked.append(str(hh))
+    )
 
     payload = oauth.start_onboarding_oauth_flow({"provider": "anthropic"})
 
@@ -274,11 +298,20 @@ def test_anthropic_immediate_success_when_credentials_exist(monkeypatch, tmp_pat
     assert payload["provider"] == "anthropic"
     assert linked == [str(tmp_path)]
     serialized = json.dumps(payload)
-    for forbidden in ("cc-access-secret", "cc-refresh-secret", "accessToken", "refreshToken", "access_token", "refresh_token"):
+    for forbidden in (
+        "cc-access-secret",
+        "cc-refresh-secret",
+        "accessToken",
+        "refreshToken",
+        "access_token",
+        "refresh_token",
+    ):
         assert forbidden not in serialized
 
 
-def test_anthropic_pending_payload_is_action_only_and_secret_free(monkeypatch, tmp_path):
+def test_anthropic_pending_payload_is_action_only_and_secret_free(
+    monkeypatch, tmp_path
+):
     import api.oauth as oauth
 
     oauth._OAUTH_FLOWS.clear()
@@ -295,9 +328,16 @@ def test_anthropic_pending_payload_is_action_only_and_secret_free(monkeypatch, t
     assert "claude" in payload["action_required"].lower()
     serialized = json.dumps(payload)
     for forbidden in (
-        "access_token", "refresh_token", "accessToken", "refreshToken",
-        ".credentials.json", ".claude", "hermes_home", str(tmp_path),
-        "ANTHROPIC_API_KEY", "ANTHROPIC_TOKEN",
+        "access_token",
+        "refresh_token",
+        "accessToken",
+        "refreshToken",
+        ".credentials.json",
+        ".claude",
+        "hermes_home",
+        str(tmp_path),
+        "ANTHROPIC_API_KEY",
+        "ANTHROPIC_TOKEN",
     ):
         assert forbidden not in serialized
 
@@ -344,7 +384,9 @@ def test_anthropic_worker_detects_credentials_and_cancel_wins(monkeypatch, tmp_p
         return {"accessToken": "cc-access-secret", "refreshToken": "cc-refresh-secret"}
 
     monkeypatch.setattr(oauth, "_read_claude_code_credentials", _slow_read_creds)
-    monkeypatch.setattr(oauth, "_link_anthropic_credentials", lambda hh: linked.append(str(hh)))
+    monkeypatch.setattr(
+        oauth, "_link_anthropic_credentials", lambda hh: linked.append(str(hh))
+    )
 
     flow_id = "claude-race-flow"
     oauth._OAUTH_FLOWS[flow_id] = {
@@ -356,7 +398,9 @@ def test_anthropic_worker_detects_credentials_and_cancel_wins(monkeypatch, tmp_p
         "created_at": time.time(),
         "updated_at": time.time(),
     }
-    worker = threading.Thread(target=oauth._run_anthropic_credential_worker, args=(flow_id,), daemon=True)
+    worker = threading.Thread(
+        target=oauth._run_anthropic_credential_worker, args=(flow_id,), daemon=True
+    )
     worker.start()
     assert started.wait(timeout=5)
     oauth.cancel_onboarding_oauth_flow({"flow_id": flow_id})
@@ -376,7 +420,14 @@ def test_anthropic_cancel_during_link_keeps_flow_cancelled(monkeypatch, tmp_path
     link_started = threading.Event()
     link_continue = threading.Event()
     monkeypatch.setattr(oauth.time, "sleep", lambda _seconds: None)
-    monkeypatch.setattr(oauth, "_read_claude_code_credentials", lambda: {"accessToken": "cc-access-secret", "refreshToken": "cc-refresh-secret"})
+    monkeypatch.setattr(
+        oauth,
+        "_read_claude_code_credentials",
+        lambda: {
+            "accessToken": "cc-access-secret",
+            "refreshToken": "cc-refresh-secret",
+        },
+    )
 
     def _slow_clear(_home):
         link_started.set()
@@ -394,10 +445,15 @@ def test_anthropic_cancel_during_link_keeps_flow_cancelled(monkeypatch, tmp_path
         "updated_at": time.time(),
     }
 
-    worker = threading.Thread(target=oauth._run_anthropic_credential_worker, args=(flow_id,), daemon=True)
+    worker = threading.Thread(
+        target=oauth._run_anthropic_credential_worker, args=(flow_id,), daemon=True
+    )
     worker.start()
     assert link_started.wait(timeout=5)
-    assert oauth.cancel_onboarding_oauth_flow({"flow_id": flow_id})["status"] == "cancelled"
+    assert (
+        oauth.cancel_onboarding_oauth_flow({"flow_id": flow_id})["status"]
+        == "cancelled"
+    )
     link_continue.set()
     worker.join(timeout=5)
 
@@ -411,7 +467,9 @@ def test_anthropic_cancel_missing_flow_keeps_requested_provider():
 
     oauth._OAUTH_FLOWS.clear()
 
-    assert oauth.cancel_onboarding_oauth_flow({"flow_id": "missing", "provider": "claude-code"}) == {
+    assert oauth.cancel_onboarding_oauth_flow(
+        {"flow_id": "missing", "provider": "claude-code"}
+    ) == {
         "ok": True,
         "provider": "anthropic",
         "flow_id": "missing",
@@ -444,7 +502,14 @@ def test_anthropic_worker_reports_link_errors(monkeypatch, tmp_path):
 
     oauth._OAUTH_FLOWS.clear()
     monkeypatch.setattr(oauth.time, "sleep", lambda _seconds: None)
-    monkeypatch.setattr(oauth, "_read_claude_code_credentials", lambda: {"accessToken": "cc-access-secret", "refreshToken": "cc-refresh-secret"})
+    monkeypatch.setattr(
+        oauth,
+        "_read_claude_code_credentials",
+        lambda: {
+            "accessToken": "cc-access-secret",
+            "refreshToken": "cc-refresh-secret",
+        },
+    )
 
     def _raise_link_error(_home):
         raise RuntimeError("link failed without secrets")
@@ -480,7 +545,10 @@ def test_anthropic_link_clears_env_and_writes_secret_free_marker(monkeypatch, tm
     from api.onboarding import _provider_oauth_authenticated
 
     env_path = tmp_path / ".env"
-    env_path.write_text("ANTHROPIC_TOKEN=old-token\nANTHROPIC_API_KEY=old-key\nOTHER=value\n", encoding="utf-8")
+    env_path.write_text(
+        "ANTHROPIC_TOKEN=old-token\nANTHROPIC_API_KEY=old-key\nOTHER=value\n",
+        encoding="utf-8",
+    )
     monkeypatch.setenv("ANTHROPIC_TOKEN", "old-token")
     monkeypatch.setenv("ANTHROPIC_API_KEY", "old-key")
 
@@ -551,21 +619,34 @@ def test_runtime_provider_reads_use_anthropic_env_lock():
     assert "resolve_runtime_provider_with_anthropic_env_lock" in routes_src
 
 
-def test_anthropic_onboarding_setup_allows_linked_oauth_without_api_key(monkeypatch, tmp_path):
+def test_anthropic_onboarding_setup_allows_linked_oauth_without_api_key(
+    monkeypatch, tmp_path
+):
     import api.onboarding as onboarding
 
     cfg_path = tmp_path / "config.yaml"
     home = tmp_path / "home"
     home.mkdir()
-    (home / "auth.json").write_text(json.dumps({
-        "credential_pool": {"anthropic": [{"auth_type": "oauth", "source": "claude_code_linked"}]}
-    }), encoding="utf-8")
+    (home / "auth.json").write_text(
+        json.dumps(
+            {
+                "credential_pool": {
+                    "anthropic": [
+                        {"auth_type": "oauth", "source": "claude_code_linked"}
+                    ]
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
     monkeypatch.setattr(onboarding, "_get_config_path", lambda: cfg_path)
     monkeypatch.setattr(onboarding, "_get_active_hermes_home", lambda: home)
     monkeypatch.setattr(onboarding, "get_onboarding_status", lambda: {"ok": True})
     monkeypatch.setattr(onboarding, "reload_config", lambda: None)
 
-    result = onboarding.apply_onboarding_setup({"provider": "anthropic", "model": "claude-sonnet-4.6"})
+    result = onboarding.apply_onboarding_setup(
+        {"provider": "anthropic", "model": "claude-sonnet-4.6"}
+    )
 
     assert result == {"ok": True}
     saved = cfg_path.read_text(encoding="utf-8")
@@ -585,6 +666,6 @@ def test_frontend_has_anthropic_oauth_support():
     assert "/api/onboarding/oauth/start" in js
     assert "/api/onboarding/oauth/poll" in js
     assert "/api/onboarding/oauth/cancel" in js
-    assert "window.open(" not in js[js.find("startAnthropicOAuth"):]
-    assert "accessToken" not in js[js.find("startAnthropicOAuth"):]
-    assert "refreshToken" not in js[js.find("startAnthropicOAuth"):]
+    assert "window.open(" not in js[js.find("startAnthropicOAuth") :]
+    assert "accessToken" not in js[js.find("startAnthropicOAuth") :]
+    assert "refreshToken" not in js[js.find("startAnthropicOAuth") :]

--- a/tests/test_issue1384_local_provider.py
+++ b/tests/test_issue1384_local_provider.py
@@ -26,7 +26,6 @@ healed automatically:
 import re
 from pathlib import Path
 
-import pytest
 
 import api.config as cfg
 
@@ -57,7 +56,7 @@ class TestAutoDetectWritesCustom:
             r'\s*provider = "ollama"\s*\n'
             r'\s*elif "lmstudio" in host or "lm-studio" in host:\s*\n'
             r'\s*provider = "lmstudio"\s*\n'
-            r'\s*else:',
+            r"\s*else:",
             src,
         )
         assert m, "Auto-detect host-classifier block not found in api/config.py"
@@ -66,7 +65,7 @@ class TestAutoDetectWritesCustom:
         provider_assign = re.search(r'provider = "([a-z-]+)"', tail)
         assert provider_assign, "No provider assignment found after auto-detect else"
         assert provider_assign.group(1) == "custom", (
-            f"Auto-detect else branch must assign provider = \"custom\", "
+            f'Auto-detect else branch must assign provider = "custom", '
             f"got {provider_assign.group(1)!r}"
         )
 
@@ -91,7 +90,9 @@ class TestResolveModelProviderHealsLegacyLocal:
         monkeypatch.setattr(cfg, "_get_config_path", lambda: cfgfile)
         cfg.reload_config()
         try:
-            model_id, provider, base_url = cfg.resolve_model_provider("qwen2.5-coder:14b")
+            model_id, provider, base_url = cfg.resolve_model_provider(
+                "qwen2.5-coder:14b"
+            )
             assert provider == "custom", (
                 f"resolve_model_provider must rewrite legacy 'local' to 'custom', "
                 f"got {provider!r}"
@@ -123,9 +124,7 @@ class TestResolveModelProviderHealsLegacyLocal:
         """The migration must not touch any other provider name."""
         cfgfile = tmp_path / "config.yaml"
         cfgfile.write_text(
-            "model:\n"
-            "  default: claude-sonnet-4.6\n"
-            "  provider: anthropic\n",
+            "model:\n  default: claude-sonnet-4.6\n  provider: anthropic\n",
             encoding="utf-8",
         )
         monkeypatch.setattr(cfg, "_get_config_path", lambda: cfgfile)

--- a/tests/test_issue1413_li_path_coverage.py
+++ b/tests/test_issue1413_li_path_coverage.py
@@ -103,8 +103,7 @@ def test_all_li_calls_reference_registered_icons() -> None:
         pytest.fail(
             "li() called with icon name(s) not registered in LI_PATHS in "
             "static/icons.js. The button/container will render empty in "
-            "production. Add the Lucide SVG path to LI_PATHS for each:\n"
-            + report
+            "production. Add the Lucide SVG path to LI_PATHS for each:\n" + report
         )
 
 

--- a/tests/test_issue1420_lmstudio_provider_env_var.py
+++ b/tests/test_issue1420_lmstudio_provider_env_var.py
@@ -61,6 +61,7 @@ def _install_fake_hermes_cli(monkeypatch):
 
     try:
         from api.config import invalidate_models_cache
+
         invalidate_models_cache()
     except Exception:
         pass
@@ -108,6 +109,7 @@ class TestIssue1420LMStudioProviderEnvVar:
         `_PROVIDER_ENV_VAR_ALIASES` so existing users don't lose detection.
         """
         from api.providers import _PROVIDER_ENV_VAR, _PROVIDER_ENV_VAR_ALIASES
+
         assert "lmstudio" in _PROVIDER_ENV_VAR, (
             "_PROVIDER_ENV_VAR is missing the 'lmstudio' entry — Settings → "
             "Providers will render LM Studio as has_key=False / "
@@ -141,6 +143,7 @@ class TestIssue1420LMStudioProviderEnvVar:
         restore = _swap_in_test_config({"model": {"provider": "lmstudio"}})
         try:
             from api.providers import get_providers
+
             result = get_providers()
             by_id = {p["id"]: p for p in result["providers"]}
             assert "lmstudio" in by_id, (
@@ -179,12 +182,15 @@ class TestIssue1420LMStudioProviderEnvVar:
         monkeypatch.delenv("LMSTUDIO_API_KEY", raising=False)
         monkeypatch.delenv("LM_API_KEY", raising=False)
 
-        restore = _swap_in_test_config({
-            "model": {"provider": "lmstudio"},
-            "providers": {"lmstudio": {"api_key": "lm-studio"}},
-        })
+        restore = _swap_in_test_config(
+            {
+                "model": {"provider": "lmstudio"},
+                "providers": {"lmstudio": {"api_key": "lm-studio"}},
+            }
+        )
         try:
             from api.providers import get_providers
+
             result = get_providers()
             by_id = {p["id"]: p for p in result["providers"]}
             assert by_id["lmstudio"]["has_key"] is True, (
@@ -214,6 +220,7 @@ class TestIssue1420LMStudioProviderEnvVar:
         restore = _swap_in_test_config({"model": {"provider": "lmstudio"}})
         try:
             from api.providers import get_providers
+
             result = get_providers()
             by_id = {p["id"]: p for p in result["providers"]}
             assert by_id["lmstudio"]["has_key"] is False
@@ -226,7 +233,9 @@ class TestIssue1420LMStudioProviderEnvVar:
         finally:
             restore()
 
-    def test_lmstudio_does_not_collide_with_other_providers(self, monkeypatch, tmp_path):
+    def test_lmstudio_does_not_collide_with_other_providers(
+        self, monkeypatch, tmp_path
+    ):
         """LMSTUDIO_API_KEY must NOT cross-detect any other provider.
 
         Sibling-defense modeled on the #1410 (OLLAMA_API_KEY / Ollama Cloud /
@@ -240,12 +249,25 @@ class TestIssue1420LMStudioProviderEnvVar:
         # Strip every other detection signal so LMSTUDIO_API_KEY is the only
         # input — any other provider showing has_key=True must be a leak.
         for var in (
-            "OPENAI_API_KEY", "OPENROUTER_API_KEY", "ANTHROPIC_API_KEY",
-            "GH_TOKEN", "GITHUB_TOKEN", "OLLAMA_API_KEY", "GOOGLE_API_KEY",
-            "GEMINI_API_KEY", "DEEPSEEK_API_KEY", "MINIMAX_API_KEY",
-            "MINIMAX_CN_API_KEY", "MISTRAL_API_KEY", "XAI_API_KEY",
-            "GLM_API_KEY", "KIMI_API_KEY", "OPENCODE_ZEN_API_KEY",
-            "OPENCODE_GO_API_KEY", "NVIDIA_API_KEY", "LMSTUDIO_API_KEY",
+            "OPENAI_API_KEY",
+            "OPENROUTER_API_KEY",
+            "ANTHROPIC_API_KEY",
+            "GH_TOKEN",
+            "GITHUB_TOKEN",
+            "OLLAMA_API_KEY",
+            "GOOGLE_API_KEY",
+            "GEMINI_API_KEY",
+            "DEEPSEEK_API_KEY",
+            "MINIMAX_API_KEY",
+            "MINIMAX_CN_API_KEY",
+            "MISTRAL_API_KEY",
+            "XAI_API_KEY",
+            "GLM_API_KEY",
+            "KIMI_API_KEY",
+            "OPENCODE_ZEN_API_KEY",
+            "OPENCODE_GO_API_KEY",
+            "NVIDIA_API_KEY",
+            "LMSTUDIO_API_KEY",
         ):
             monkeypatch.delenv(var, raising=False)
         # Set the canonical post-#1500 env var; sibling providers must not
@@ -255,10 +277,13 @@ class TestIssue1420LMStudioProviderEnvVar:
         restore = _swap_in_test_config({"model": {"provider": "lmstudio"}})
         try:
             from api.providers import get_providers
+
             result = get_providers()
             by_id = {p["id"]: p for p in result["providers"]}
 
-            assert by_id["lmstudio"]["has_key"] is True, "lmstudio itself should be configured"
+            assert by_id["lmstudio"]["has_key"] is True, (
+                "lmstudio itself should be configured"
+            )
             for pid, entry in by_id.items():
                 if pid == "lmstudio":
                     continue

--- a/tests/test_issue1426_openrouter_free_tier_live_fetch.py
+++ b/tests/test_issue1426_openrouter_free_tier_live_fetch.py
@@ -15,6 +15,7 @@ as a defense-in-depth fallback) when the API is unreachable.
 These tests verify the structural fix without depending on real network access:
 the urllib.request layer is monkeypatched.
 """
+
 from __future__ import annotations
 
 import json
@@ -71,7 +72,10 @@ def _isolate_openrouter_cache(monkeypatch):
         config,
         "cfg",
         {
-            "model": {"provider": "openrouter", "default": "anthropic/claude-sonnet-4.6"},
+            "model": {
+                "provider": "openrouter",
+                "default": "anthropic/claude-sonnet-4.6",
+            },
             "providers": {"openrouter": {"api_key": "sk-or-test-key"}},
         },
         raising=False,
@@ -86,10 +90,16 @@ def _isolate_openrouter_cache(monkeypatch):
 def test_fallback_list_contains_free_tier_entries():
     """The hardcoded fallback list (defense-in-depth) still contains the
     contributor's free-tier entries so offline / test envs see them."""
-    or_entries = [m for m in config._FALLBACK_MODELS if m.get("provider") == "OpenRouter"]
-    assert len(or_entries) >= 5, "fallback list should include at least 5 free-tier entries"
+    or_entries = [
+        m for m in config._FALLBACK_MODELS if m.get("provider") == "OpenRouter"
+    ]
+    assert len(or_entries) >= 5, (
+        "fallback list should include at least 5 free-tier entries"
+    )
     free_labels = [m["label"] for m in or_entries if "free" in m["label"].lower()]
-    assert len(free_labels) >= 5, f"expected ≥5 free-tier entries in fallback, got {len(free_labels)}"
+    assert len(free_labels) >= 5, (
+        f"expected ≥5 free-tier entries in fallback, got {len(free_labels)}"
+    )
 
 
 def test_openrouter_group_uses_live_fetch_when_available(monkeypatch):
@@ -97,14 +107,26 @@ def test_openrouter_group_uses_live_fetch_when_available(monkeypatch):
     not just the fallback list. Free-tier entries get a (free) suffix."""
     fake_payload = _make_or_payload(
         # Tool-supporting paid model
-        {"id": "anthropic/claude-sonnet-4.6", "name": "Claude Sonnet 4.6",
-         "supported_parameters": ["tools"], "pricing": {"prompt": "0.000003", "completion": "0.000015"}},
+        {
+            "id": "anthropic/claude-sonnet-4.6",
+            "name": "Claude Sonnet 4.6",
+            "supported_parameters": ["tools"],
+            "pricing": {"prompt": "0.000003", "completion": "0.000015"},
+        },
         # Free-tier model NOT advertising tools — the bug from #1426
-        {"id": "minimax/minimax-m2.5:free", "name": "MiniMax M2.5",
-         "supported_parameters": [], "pricing": {"prompt": "0", "completion": "0"}},
+        {
+            "id": "minimax/minimax-m2.5:free",
+            "name": "MiniMax M2.5",
+            "supported_parameters": [],
+            "pricing": {"prompt": "0", "completion": "0"},
+        },
         # Free model without :free suffix but pricing shows free
-        {"id": "openrouter/elephant-alpha", "name": "Elephant Alpha",
-         "supported_parameters": ["tools"], "pricing": {"prompt": "0", "completion": "0"}},
+        {
+            "id": "openrouter/elephant-alpha",
+            "name": "Elephant Alpha",
+            "supported_parameters": ["tools"],
+            "pricing": {"prompt": "0", "completion": "0"},
+        },
     )
 
     def _fake_urlopen(req, timeout=None):
@@ -113,6 +135,7 @@ def test_openrouter_group_uses_live_fetch_when_available(monkeypatch):
     monkeypatch.setattr(urllib.request, "urlopen", _fake_urlopen)
     try:
         from hermes_cli import models as _hm
+
         monkeypatch.setattr(_hm, "_openrouter_catalog_cache", None, raising=False)
     except Exception:
         pass
@@ -130,17 +153,23 @@ def test_openrouter_group_uses_live_fetch_when_available(monkeypatch):
     has_prefix = any(mid.startswith("@openrouter:") for mid in model_ids)
     if has_prefix:
         import pytest
-        pytest.skip("openrouter active provider not honored (likely test-isolation pollution from sibling test)")
+
+        pytest.skip(
+            "openrouter active provider not honored (likely test-isolation pollution from sibling test)"
+        )
     # Free-tier variants must be visible despite not advertising tool support
-    assert "minimax/minimax-m2.5:free" in model_ids, \
+    assert "minimax/minimax-m2.5:free" in model_ids, (
         "free-tier minimax/minimax-m2.5:free must surface in the picker even without tools support"
-    assert "openrouter/elephant-alpha" in model_ids, \
+    )
+    assert "openrouter/elephant-alpha" in model_ids, (
         "free pricing model must surface even without :free suffix"
+    )
 
 
 def test_openrouter_falls_back_to_static_when_live_fails(monkeypatch):
     """If both hermes_cli.fetch and the direct urlopen raise, the picker
     must fall back to the hardcoded `_FALLBACK_MODELS` list — never empty."""
+
     def _fake_urlopen(req, timeout=None):
         raise OSError("simulated network outage")
 
@@ -148,6 +177,7 @@ def test_openrouter_falls_back_to_static_when_live_fails(monkeypatch):
 
     # Force hermes_cli to fail too
     import sys
+
     fake_module = type(sys)("hermes_cli.models")
 
     def _raise(*args, **kwargs):
@@ -159,7 +189,9 @@ def test_openrouter_falls_back_to_static_when_live_fails(monkeypatch):
 
     grouped = _get_grouped_models()
     or_group = next((g for g in grouped if g.get("provider_id") == "openrouter"), None)
-    assert or_group is not None, "openrouter group must still be present in fallback path"
+    assert or_group is not None, (
+        "openrouter group must still be present in fallback path"
+    )
     assert len(or_group["models"]) > 0, "fallback must produce a non-empty model list"
     # The hardcoded free-tier entries MUST be in the fallback
     fallback_ids = {m["id"] for m in or_group["models"]}
@@ -172,8 +204,9 @@ def test_openrouter_falls_back_to_static_when_live_fails(monkeypatch):
         "arcee-ai/trinity-large-preview:free",
     }
     overlap = fallback_ids & expected_free_ids
-    assert len(overlap) >= 3, \
+    assert len(overlap) >= 3, (
         f"static fallback must include the contributor's hardcoded free-tier entries; got overlap={overlap}"
+    )
 
 
 def test_free_tier_cap_prevents_picker_drowning(monkeypatch):
@@ -181,12 +214,14 @@ def test_free_tier_cap_prevents_picker_drowning(monkeypatch):
     caps the live-fetch additions at 30 to keep the picker usable."""
     items = []
     for i in range(50):
-        items.append({
-            "id": f"vendor{i}/model-{i}:free",
-            "name": f"Model {i}",
-            "supported_parameters": [],
-            "pricing": {"prompt": "0", "completion": "0"},
-        })
+        items.append(
+            {
+                "id": f"vendor{i}/model-{i}:free",
+                "name": f"Model {i}",
+                "supported_parameters": [],
+                "pricing": {"prompt": "0", "completion": "0"},
+            }
+        )
     fake_payload = _make_or_payload(*items)
 
     def _fake_urlopen(req, timeout=None):
@@ -196,6 +231,7 @@ def test_free_tier_cap_prevents_picker_drowning(monkeypatch):
 
     try:
         from hermes_cli import models as _hm
+
         monkeypatch.setattr(_hm, "_openrouter_catalog_cache", None, raising=False)
     except Exception:
         pass
@@ -205,15 +241,21 @@ def test_free_tier_cap_prevents_picker_drowning(monkeypatch):
     assert or_group is not None
     free_added_ids = {m["id"] for m in or_group["models"] if ":free" in m["id"]}
     assert len(free_added_ids) <= 50, "should not exceed the items provided"
-    assert len(free_added_ids) > 0, "free-tier live fetch should add at least some entries"
+    assert len(free_added_ids) > 0, (
+        "free-tier live fetch should add at least some entries"
+    )
 
 
 def test_openrouter_dedupe_curated_and_free_tier(monkeypatch):
     """If a model appears in both the curated catalog AND the free-tier fetch,
     it must appear exactly once in the picker (via `seen_ids` deduplication)."""
     fake_payload = _make_or_payload(
-        {"id": "anthropic/claude-sonnet-4.6", "name": "Claude Sonnet 4.6",
-         "supported_parameters": ["tools"], "pricing": {"prompt": "0", "completion": "0"}},
+        {
+            "id": "anthropic/claude-sonnet-4.6",
+            "name": "Claude Sonnet 4.6",
+            "supported_parameters": ["tools"],
+            "pricing": {"prompt": "0", "completion": "0"},
+        },
     )
 
     def _fake_urlopen(req, timeout=None):
@@ -222,8 +264,11 @@ def test_openrouter_dedupe_curated_and_free_tier(monkeypatch):
     monkeypatch.setattr(urllib.request, "urlopen", _fake_urlopen)
 
     import sys
+
     fake_module = type(sys)("hermes_cli.models")
-    fake_module.fetch_openrouter_models = lambda **k: [("anthropic/claude-sonnet-4.6", "")]
+    fake_module.fetch_openrouter_models = lambda **k: [
+        ("anthropic/claude-sonnet-4.6", "")
+    ]
     fake_module.provider_model_ids = lambda *a, **k: ["anthropic/claude-sonnet-4.6"]
     monkeypatch.setitem(sys.modules, "hermes_cli.models", fake_module)
 
@@ -233,7 +278,13 @@ def test_openrouter_dedupe_curated_and_free_tier(monkeypatch):
     # Skip on prefix pollution — see test_openrouter_group_uses_live_fetch_when_available
     if any(m["id"].startswith("@openrouter:") for m in or_group["models"]):
         import pytest
-        pytest.skip("openrouter active provider not honored (likely test-isolation pollution from sibling test)")
-    matching = [m for m in or_group["models"] if m["id"] == "anthropic/claude-sonnet-4.6"]
-    assert len(matching) == 1, \
+
+        pytest.skip(
+            "openrouter active provider not honored (likely test-isolation pollution from sibling test)"
+        )
+    matching = [
+        m for m in or_group["models"] if m["id"] == "anthropic/claude-sonnet-4.6"
+    ]
+    assert len(matching) == 1, (
         f"model present in both surfaces should appear once, got {len(matching)}"
+    )

--- a/tests/test_issue1431_toolsets_chip_responsive.py
+++ b/tests/test_issue1431_toolsets_chip_responsive.py
@@ -8,6 +8,7 @@ The chip must:
   * Continue to track state through _applyToolsetsChip() so /api/session/toolsets
     keeps working for scripted callers regardless of UI visibility.
 """
+
 import re
 
 
@@ -24,8 +25,9 @@ class TestToolsetsChipResponsiveCSS:
         css = _src("style.css")
         # The base rule (outside any @container or @media block) must default-hide
         m = re.search(
-            r'^\s*\.composer-toolsets-wrap\{[^}]*\}',
-            css, re.MULTILINE,
+            r"^\s*\.composer-toolsets-wrap\{[^}]*\}",
+            css,
+            re.MULTILINE,
         )
         assert m, "Base .composer-toolsets-wrap CSS rule must exist"
         rule = m.group(0)
@@ -39,8 +41,9 @@ class TestToolsetsChipResponsiveCSS:
         # Find the min-width container query — accept either display:block or display:flex
         # (we use block to match sibling wraps but either is a valid reveal)
         m = re.search(
-            r'@container\s+composer-footer\s*\(\s*min-width:\s*1100px\s*\)\s*\{[^}]*\.composer-toolsets-wrap\s*\{[^}]*display:\s*(block|flex)[^}]*\}',
-            css, re.DOTALL,
+            r"@container\s+composer-footer\s*\(\s*min-width:\s*1100px\s*\)\s*\{[^}]*\.composer-toolsets-wrap\s*\{[^}]*display:\s*(block|flex)[^}]*\}",
+            css,
+            re.DOTALL,
         )
         assert m, (
             "Must have @container composer-footer (min-width: 1100px) rule "
@@ -52,8 +55,9 @@ class TestToolsetsChipResponsiveCSS:
         css = _src("style.css")
         # Look for the existing 520px rule that already hid composer-toolsets-wrap
         m = re.search(
-            r'@container\s+composer-footer\s*\(\s*max-width:\s*520px\s*\).*?\.composer-toolsets-wrap\s*\{\s*display:\s*none\s*!important',
-            css, re.DOTALL,
+            r"@container\s+composer-footer\s*\(\s*max-width:\s*520px\s*\).*?\.composer-toolsets-wrap\s*\{\s*display:\s*none\s*!important",
+            css,
+            re.DOTALL,
         )
         assert m, (
             "@container composer-footer (max-width: 520px) must continue to "
@@ -64,8 +68,9 @@ class TestToolsetsChipResponsiveCSS:
         """The existing @media max-width:640px rule must still hide the chip on mobile."""
         css = _src("style.css")
         m = re.search(
-            r'@media\s*\(\s*max-width:\s*640px\s*\).*?\.composer-toolsets-wrap\s*\{\s*display:\s*none\s*!important',
-            css, re.DOTALL,
+            r"@media\s*\(\s*max-width:\s*640px\s*\).*?\.composer-toolsets-wrap\s*\{\s*display:\s*none\s*!important",
+            css,
+            re.DOTALL,
         )
         assert m, (
             "@media (max-width:640px) must continue to hide "
@@ -79,7 +84,9 @@ class TestToolsetsChipJSDoesNotForceHide:
     def test_applyToolsetsChip_does_not_set_display_none(self):
         """_applyToolsetsChip must not contain wrap.style.display = 'none'."""
         js = _src("ui.js")
-        m = re.search(r'function _applyToolsetsChip\([^)]*\)\s*\{.*?\n\}', js, re.DOTALL)
+        m = re.search(
+            r"function _applyToolsetsChip\([^)]*\)\s*\{.*?\n\}", js, re.DOTALL
+        )
         assert m, "_applyToolsetsChip function must exist"
         body = m.group(0)
         # The PR initially had wrap.style.display = 'none'; we replaced with CSS.
@@ -95,14 +102,13 @@ class TestToolsetsChipJSDoesNotForceHide:
     def test_applyToolsetsChip_clears_inline_style(self):
         """_applyToolsetsChip must clear inline display so CSS rules can apply."""
         js = _src("ui.js")
-        m = re.search(r'function _applyToolsetsChip\([^)]*\)\s*\{.*?\n\}', js, re.DOTALL)
+        m = re.search(
+            r"function _applyToolsetsChip\([^)]*\)\s*\{.*?\n\}", js, re.DOTALL
+        )
         assert m, "_applyToolsetsChip function must exist"
         body = m.group(0)
         # Either ='' or ="" (clearing inline style)
-        assert (
-            "wrap.style.display = ''" in body
-            or 'wrap.style.display = ""' in body
-        ), (
+        assert "wrap.style.display = ''" in body or 'wrap.style.display = ""' in body, (
             "_applyToolsetsChip must clear wrap.style.display so the CSS "
             "@container query is the single source of truth"
         )
@@ -148,6 +154,7 @@ class TestToolsetsAPIStillWorks:
         except FileNotFoundError:
             # If routes.py is named differently, search
             import os
+
             found = False
             for root, _, files in os.walk("api"):
                 for f in files:
@@ -196,7 +203,8 @@ class TestToolsetsDropdownResizeGuard:
         # It must check chip.offsetParent === null and close, not reposition
         m = re.search(
             r"window\.addEventListener\('resize',\s*\([^)]*\)\s*=>\s*\{[^}]*composerToolsetsDropdown[^}]*\}",
-            js, re.DOTALL,
+            js,
+            re.DOTALL,
         )
         assert m, "Toolsets resize handler must exist"
         body = m.group(0)
@@ -216,7 +224,8 @@ class TestToolsetsDropdownResizeGuard:
         js = _src("ui.js")
         m = re.search(
             r"function _positionToolsetsDropdown\(\)\s*\{.*?\n\}",
-            js, re.DOTALL,
+            js,
+            re.DOTALL,
         )
         assert m, "_positionToolsetsDropdown function must exist"
         body = m.group(0)
@@ -232,7 +241,8 @@ class TestToolsetsDropdownResizeGuard:
         js = _src("ui.js")
         m = re.search(
             r"function toggleToolsetsDropdown\(\)\s*\{.*?\n\}",
-            js, re.DOTALL,
+            js,
+            re.DOTALL,
         )
         assert m, "toggleToolsetsDropdown function must exist"
         body = m.group(0)

--- a/tests/test_issue1436_context_indicator_load_path.py
+++ b/tests/test_issue1436_context_indicator_load_path.py
@@ -28,7 +28,7 @@ Reported by @AvidFuturist in Discord (May 1 2026, "the 100 comes up way too
 often").  Confirmed live on the dev server: 23 of 75 sessions had
 `context_length=0` + `input_tokens > 128K`, all rendering >100%.
 """
-import json
+
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 from urllib.parse import urlparse
@@ -46,8 +46,9 @@ class TestIssue1436BackendFallback:
     """The /api/session GET handler must resolve context_length via
     agent.model_metadata.get_model_context_length when the persisted value is 0."""
 
-    def _stub_session(self, *, context_length, model, last_prompt_tokens=0,
-                      input_tokens=0):
+    def _stub_session(
+        self, *, context_length, model, last_prompt_tokens=0, input_tokens=0
+    ):
         """Build a mock Session that mimics the persisted-session shape."""
         s = MagicMock()
         s.context_length = context_length
@@ -96,9 +97,11 @@ class TestIssue1436BackendFallback:
         parsed = urlparse("/api/session?session_id=test-1436&messages=0")
 
         # Patch import so `from agent.model_metadata import ...` resolves to our fake.
-        with patch("api.routes.get_session", return_value=session_obj), \
-             patch("api.routes.j", side_effect=fake_j), \
-             patch.dict("sys.modules", {"agent.model_metadata": fake_module}):
+        with (
+            patch("api.routes.get_session", return_value=session_obj),
+            patch("api.routes.j", side_effect=fake_j),
+            patch.dict("sys.modules", {"agent.model_metadata": fake_module}),
+        ):
             routes.handle_get(handler, parsed)
         return captured
 
@@ -114,8 +117,9 @@ class TestIssue1436BackendFallback:
 
     def test_zero_context_length_falls_back_to_model_metadata(self):
         """Pre-#1318 sessions with context_length=0 must resolve via model_metadata."""
-        s = self._stub_session(context_length=0, model="claude-opus-4-7",
-                               input_tokens=1_200_000)
+        s = self._stub_session(
+            context_length=0, model="claude-opus-4-7", input_tokens=1_200_000
+        )
         result = self._invoke_get_session(s, fallback_returns=1_000_000)
         body = result["data"]["session"]
         assert body["context_length"] == 1_000_000, (
@@ -139,9 +143,11 @@ class TestIssue1436BackendFallback:
         handler = MagicMock()
         parsed = urlparse("/api/session?session_id=test-1436&messages=0")
 
-        with patch("api.routes.get_session", return_value=s), \
-             patch("api.routes.j", side_effect=fake_j), \
-             patch.dict("sys.modules", {"agent.model_metadata": fake_module}):
+        with (
+            patch("api.routes.get_session", return_value=s),
+            patch("api.routes.j", side_effect=fake_j),
+            patch.dict("sys.modules", {"agent.model_metadata": fake_module}),
+        ):
             routes.handle_get(handler, parsed)
 
         # First positional arg should be the model name; second is base_url ("")
@@ -157,6 +163,7 @@ class TestIssue1436BackendFallback:
         s = self._stub_session(context_length=0, model="")
         # resolve_model=0 to skip _resolve_effective_session_model_for_display
         import api.routes as routes
+
         captured = {}
 
         def fake_j(h, data, status=200):
@@ -170,9 +177,11 @@ class TestIssue1436BackendFallback:
             "/api/session?session_id=test-1436&messages=0&resolve_model=0"
         )
 
-        with patch("api.routes.get_session", return_value=s), \
-             patch("api.routes.j", side_effect=fake_j), \
-             patch.dict("sys.modules", {"agent.model_metadata": fake_module}):
+        with (
+            patch("api.routes.get_session", return_value=s),
+            patch("api.routes.j", side_effect=fake_j),
+            patch.dict("sys.modules", {"agent.model_metadata": fake_module}),
+        ):
             routes.handle_get(handler, parsed)
 
         # When model is empty, fallback either isn't called OR returns no value
@@ -187,6 +196,7 @@ class TestIssue1436BackendFallback:
         """If the fallback raises (older agent build, missing module), the route
         must still return a response — context_length just stays 0."""
         import api.routes as routes
+
         captured = {}
 
         def fake_j(h, data, status=200):
@@ -202,9 +212,11 @@ class TestIssue1436BackendFallback:
         handler = MagicMock()
         parsed = urlparse("/api/session?session_id=test-1436&messages=0")
 
-        with patch("api.routes.get_session", return_value=s), \
-             patch("api.routes.j", side_effect=fake_j), \
-             patch.dict("sys.modules", {"agent.model_metadata": fake_module}):
+        with (
+            patch("api.routes.get_session", return_value=s),
+            patch("api.routes.j", side_effect=fake_j),
+            patch.dict("sys.modules", {"agent.model_metadata": fake_module}),
+        ):
             routes.handle_get(handler, parsed)  # must not raise
 
         body = captured["data"]["session"]
@@ -233,7 +245,11 @@ class TestIssue1436FrontendDefense:
             stripped = line.strip()
             if stripped.startswith("//") or stripped.startswith("*"):
                 continue
-            if "promptTok" in line and "=" in line and "usage.last_prompt_tokens" in line:
+            if (
+                "promptTok" in line
+                and "=" in line
+                and "usage.last_prompt_tokens" in line
+            ):
                 assert "usage.input_tokens" not in line, (
                     f"static/ui.js:{line_num} still falls back to cumulative "
                     f"input_tokens for promptTok — this produces the >100% indicator "

--- a/tests/test_issue1438_fence_anchoring.py
+++ b/tests/test_issue1438_fence_anchoring.py
@@ -31,7 +31,6 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-import pytest
 
 from tests.test_sprint16 import render_md  # Python mirror of renderMd()
 
@@ -201,13 +200,17 @@ def test_inline_code_after_fence():
 def test_renderMd_fence_regex_is_line_anchored():
     """The fence regex in renderMd must keep line anchoring and fence-length matching."""
     pattern = r"s=s.replace(/(^|\n)[ ]{0,3}(`{3,})([^\n`]*)\n(?:([\s\S]*?)\n)?[ ]{0,3}\2`*[ \t]*(?=\n|$)/g"
-    assert pattern in UI_JS, "renderMd fence regex lost line anchoring or #1696 fence-length matching"
+    assert pattern in UI_JS, (
+        "renderMd fence regex lost line anchoring or #1696 fence-length matching"
+    )
 
 
 def test_renderUserFencedBlocks_fence_regex_is_line_anchored():
     """The fence regex in _renderUserFencedBlocks must also be line-anchored."""
     pattern = r"s=s.replace(/(^|\n)[ ]{0,3}(`{3,})([^\n`]*)\n(?:([\s\S]*?)\n)?[ ]{0,3}\2`*[ \t]*(?=\n|$)/g"
-    assert UI_JS.count(pattern) >= 2, "render/user fence regexes lost line anchoring or #1696 fence-length matching"
+    assert UI_JS.count(pattern) >= 2, (
+        "render/user fence regexes lost line anchoring or #1696 fence-length matching"
+    )
 
 
 def test_stripForTTS_fence_regex_is_line_anchored():
@@ -241,10 +244,16 @@ def test_no_unanchored_fence_regex_remains_in_render_paths():
     """
     # The exact OLD vulnerable forms that this PR replaces.
     old_render_md = "s=s.replace(/```([\\s\\S]*?)```/g,(_,raw)=>{"
-    old_user_fenced = "s=s.replace(/```([a-zA-Z0-9_+-]*)\\n([\\s\\S]*?)```/g,(_,lang,code)=>{"
+    old_user_fenced = (
+        "s=s.replace(/```([a-zA-Z0-9_+-]*)\\n([\\s\\S]*?)```/g,(_,lang,code)=>{"
+    )
     old_tts_strip = "text=text.replace(/```[\\s\\S]*?```/g,' ');"
-    assert old_render_md not in UI_JS, "old unanchored renderMd fence regex still present"
-    assert old_user_fenced not in UI_JS, "old unanchored _renderUserFencedBlocks regex still present"
+    assert old_render_md not in UI_JS, (
+        "old unanchored renderMd fence regex still present"
+    )
+    assert old_user_fenced not in UI_JS, (
+        "old unanchored _renderUserFencedBlocks regex still present"
+    )
     assert old_tts_strip not in UI_JS, "old unanchored _stripForTTS regex still present"
 
 

--- a/tests/test_issue1443_ime_helper_promotion.py
+++ b/tests/test_issue1443_ime_helper_promotion.py
@@ -87,8 +87,7 @@ def test_session_rename_uses_windowed_helper():
     # The session rename block: `inp.onkeydown=e2=>{ if(e2.key==='Enter'){ <guard> ...
     pattern = re.compile(
         r"inp\.onkeydown\s*=\s*e2\s*=>\s*\{\s*"
-        r"if\s*\(\s*e2\.key\s*===\s*'Enter'\s*\)\s*\{\s*"
-        + _windowed_guard("e2"),
+        r"if\s*\(\s*e2\.key\s*===\s*'Enter'\s*\)\s*\{\s*" + _windowed_guard("e2"),
         re.DOTALL,
     )
     assert pattern.search(SESSIONS_JS), (
@@ -102,8 +101,7 @@ def test_project_create_and_rename_use_windowed_helper():
     # Both project blocks share the shape `inp.onkeydown=(e)=>{...}` (note the parens).
     pattern = re.compile(
         r"inp\.onkeydown\s*=\s*\(\s*e\s*\)\s*=>\s*\{\s*"
-        r"if\s*\(\s*e\.key\s*===\s*'Enter'\s*\)\s*\{\s*"
-        + _windowed_guard("e"),
+        r"if\s*\(\s*e\.key\s*===\s*'Enter'\s*\)\s*\{\s*" + _windowed_guard("e"),
         re.DOTALL,
     )
     matches = pattern.findall(SESSIONS_JS)
@@ -120,8 +118,7 @@ def test_app_dialog_uses_windowed_helper():
     #   if(window._isImeEnter && window._isImeEnter(e)) return;`
     pattern = re.compile(
         r"document\.addEventListener\(\s*'keydown'\s*,\s*e\s*=>\s*\{[\s\S]*?"
-        r"if\s*\(\s*e\.key\s*===\s*'Enter'\s*\)\s*\{\s*"
-        + _windowed_guard("e"),
+        r"if\s*\(\s*e\.key\s*===\s*'Enter'\s*\)\s*\{\s*" + _windowed_guard("e"),
         re.DOTALL,
     )
     assert pattern.search(UI_JS), (
@@ -151,8 +148,7 @@ def test_workspace_rename_uses_windowed_helper():
     # Pattern: `inp.onkeydown=(e2)=>{ if(e2.key==='Enter'){ if(window._isImeEnter && ...
     pattern = re.compile(
         r"inp\.onkeydown\s*=\s*\(\s*e2\s*\)\s*=>\s*\{\s*"
-        r"if\s*\(\s*e2\.key\s*===\s*'Enter'\s*\)\s*\{\s*"
-        + _windowed_guard("e2"),
+        r"if\s*\(\s*e2\.key\s*===\s*'Enter'\s*\)\s*\{\s*" + _windowed_guard("e2"),
         re.DOTALL,
     )
     assert pattern.search(UI_JS), (

--- a/tests/test_issue1446_glued_heading_lift.py
+++ b/tests/test_issue1446_glued_heading_lift.py
@@ -136,11 +136,7 @@ def test_intentional_block_final_bold_with_no_glue_unchanged():
 
 def test_chain_of_glued_headings_all_lifted():
     """Chained glued-heading paragraphs should all lift — common LLM thinking-mode shape."""
-    src = (
-        "First text.**Heading A**\n\n"
-        "Second text.**Heading B**\n\n"
-        "Third text.\n"
-    )
+    src = "First text.**Heading A**\n\nSecond text.**Heading B**\n\nThird text.\n"
     out = render_md(src)
     assert "<p>First text.</p>" in out, out
     assert "<p><strong>Heading A</strong></p>" in out, out
@@ -160,7 +156,7 @@ def test_lift_pass_present_in_ui_js_at_correct_position():
     (which are stashed as \x00R / \x00P / \x00F tokens at this point and don't
     match the lift regex).
     """
-    lift_idx = UI_JS.find(r'(/([.!?])\*\*([^*\n]{1,80})\*\*\n\n/g')
+    lift_idx = UI_JS.find(r"(/([.!?])\*\*([^*\n]{1,80})\*\*\n\n/g")
     assert lift_idx > 0, "Glued-bold-heading lift regex not found in static/ui.js"
     raw_pre_restore = UI_JS.find("rawPreStash[+i]")
     fence_restore = UI_JS.find("fence_stash[+i]")
@@ -285,11 +281,7 @@ def test_real_renderer_preserves_mid_paragraph_emphasis(driver_path):
 @pytest.mark.skipif(NODE is None, reason="node not on PATH")
 def test_real_renderer_chain_of_glued_headings(driver_path):
     """Chain of glued headings — verifies the regex's `g` flag fires multiple times."""
-    src = (
-        "First text.**Heading A**\n\n"
-        "Second text.**Heading B**\n\n"
-        "Third text.\n"
-    )
+    src = "First text.**Heading A**\n\nSecond text.**Heading B**\n\nThird text.\n"
     out = _render(driver_path, src)
     assert "<p>First text.</p>" in out, out
     assert "<p><strong>Heading A</strong></p>" in out, out

--- a/tests/test_issue1447_heading_hierarchy.py
+++ b/tests/test_issue1447_heading_hierarchy.py
@@ -68,10 +68,16 @@ def test_msg_body_heading_sizes_form_clear_hierarchy():
     assert h3 >= h4 + 2, f"h3 ({h3}) must be at least 2px larger than h4 ({h4})"
     # Body is 14px.
     assert h4 >= 14, f"h4 ({h4}) must not be smaller than body (14px)"
-    assert h5 >= 14, f"h5 ({h5}) must not be smaller than body (14px) — uppercase compensates"
-    assert h6 >= 13, f"h6 ({h6}) must not be much smaller than body (uppercase compensates) — got {h6}"
+    assert h5 >= 14, (
+        f"h5 ({h5}) must not be smaller than body (14px) — uppercase compensates"
+    )
+    assert h6 >= 13, (
+        f"h6 ({h6}) must not be much smaller than body (uppercase compensates) — got {h6}"
+    )
     # h3 must be visibly above body — Cygnus's specific complaint.
-    assert h3 > 14, f"h3 ({h3}) must be larger than body (14px) so it is visibly a heading"
+    assert h3 > 14, (
+        f"h3 ({h3}) must be larger than body (14px) so it is visibly a heading"
+    )
 
 
 def test_msg_body_h1_and_h2_have_bottom_border():

--- a/tests/test_issue1458_stability_hardening.py
+++ b/tests/test_issue1458_stability_hardening.py
@@ -1,4 +1,5 @@
 """Regression coverage for issue #1458 persistent-host hardening."""
+
 import json
 import urllib.request
 

--- a/tests/test_issue1464_workspace_dropdown_filter.py
+++ b/tests/test_issue1464_workspace_dropdown_filter.py
@@ -9,6 +9,7 @@ should appear only when zero items match the filter.
 This test pins both ternaries inside renderWorkspaceDropdownInto.filterWs() to
 their correct shape, so future edits can't silently re-invert either of them.
 """
+
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parent.parent
@@ -21,7 +22,9 @@ def test_workspace_dropdown_noresults_hides_when_matches_exist():
 
     # Locate filterWs body inside the renderWorkspaceDropdownInto function.
     filter_start = panels.find("function filterWs(", fn_start)
-    assert filter_start != -1, "filterWs helper must exist inside the dropdown render function"
+    assert filter_start != -1, (
+        "filterWs helper must exist inside the dropdown render function"
+    )
     filter_end = panels.find("\n  }\n", filter_start)
     assert filter_end != -1, "filterWs body must close cleanly"
     body = panels[filter_start:filter_end]
@@ -48,13 +51,15 @@ def test_workspace_dropdown_noresults_hides_when_matches_exist():
     nr_idx = body.find("noResults.style.display=")
     assert opt_idx < nr_idx, "opt visibility line must come before noResults line"
 
-    opt_line = body[opt_idx:body.find("\n", opt_idx)]
-    nr_line = body[nr_idx:body.find("\n", nr_idx)]
+    opt_line = body[opt_idx : body.find("\n", opt_idx)]
+    nr_line = body[nr_idx : body.find("\n", nr_idx)]
     # Each line picks one branch for show/hide; the chosen branch must be
     # opposite. The simplest invariant: the noResults line must NOT be string-
     # equal to the opt line with `opt` swapped for `noResults` and `show` for
     # `visible`.
-    parallel = opt_line.replace("opt.style.display", "noResults.style.display").replace("show?", "visible?")
+    parallel = opt_line.replace("opt.style.display", "noResults.style.display").replace(
+        "show?", "visible?"
+    )
     assert nr_line != parallel, (
         f"opt and noResults visibility ternaries are accidentally parallel — "
         f"they must be mirror images. opt={opt_line!r} noResults={nr_line!r}"

--- a/tests/test_issue1488_composer_voice_buttons.py
+++ b/tests/test_issue1488_composer_voice_buttons.py
@@ -16,6 +16,7 @@ share the same tooltip ("Voice input") in master. This module pins the fix:
 6. The legacy `voice_toggle` i18n key MUST be removed everywhere — its
    string was identical to the dictation tooltip and caused the bug.
 """
+
 import re
 
 
@@ -38,14 +39,16 @@ class TestComposerVoiceButtonHTML:
         )
         assert m, "btnMic <button> tag must exist"
         tag = m.group(0)
-        assert 'data-i18n-title="voice_dictate"' in tag, \
-            "btnMic must have data-i18n-title=\"voice_dictate\" — without " \
+        assert 'data-i18n-title="voice_dictate"' in tag, (
+            'btnMic must have data-i18n-title="voice_dictate" — without '
             "it the tooltip stays as the static fallback and ignores locale."
+        )
         # Static fallback should also match (read by users with stale i18n).
         # Accept either the legacy `title="Dictate"` or the custom-tooltip
         # variant `data-tooltip="Dictate"` introduced in #1775.
-        assert 'title="Dictate"' in tag or 'data-tooltip="Dictate"' in tag, \
+        assert 'title="Dictate"' in tag or 'data-tooltip="Dictate"' in tag, (
             "btnMic static tooltip fallback must say 'Dictate' (not 'Voice input')."
+        )
 
     def test_voice_mode_button_has_voice_mode_i18n_key(self):
         """btnVoiceMode must bind data-i18n-title="voice_mode_toggle"."""
@@ -57,12 +60,14 @@ class TestComposerVoiceButtonHTML:
         )
         assert m, "btnVoiceMode <button> tag must exist"
         tag = m.group(0)
-        assert 'data-i18n-title="voice_mode_toggle"' in tag, \
-            "btnVoiceMode must use data-i18n-title=\"voice_mode_toggle\". " \
-            "The legacy key 'voice_toggle' resolved to 'Voice input' and " \
+        assert 'data-i18n-title="voice_mode_toggle"' in tag, (
+            'btnVoiceMode must use data-i18n-title="voice_mode_toggle". '
+            "The legacy key 'voice_toggle' resolved to 'Voice input' and "
             "made btnMic and btnVoiceMode appear identical."
-        assert 'voice_toggle"' not in tag, \
+        )
+        assert 'voice_toggle"' not in tag, (
             "Stale voice_toggle reference still on btnVoiceMode — must be voice_mode_toggle."
+        )
 
     def test_buttons_have_distinct_static_titles(self):
         """The static title/tooltip attributes must differ as a fallback for
@@ -71,21 +76,27 @@ class TestComposerVoiceButtonHTML:
         mic = re.search(r'<button[^>]*\bid="btnMic"[^>]*>', html, re.DOTALL)
         vm = re.search(r'<button[^>]*\bid="btnVoiceMode"[^>]*>', html, re.DOTALL)
         assert mic and vm
+
         # Accept either `title=` (legacy) or `data-tooltip=` (custom tooltip
         # introduced in #1775) as the static fallback string.
         def _static_tooltip(tag: str) -> str:
-            m = re.search(r'\bdata-tooltip="([^"]+)"', tag) \
-                or re.search(r'\btitle="([^"]+)"', tag)
+            m = re.search(r'\bdata-tooltip="([^"]+)"', tag) or re.search(
+                r'\btitle="([^"]+)"', tag
+            )
             assert m, f"no static tooltip on {tag[:120]}"
             return m.group(1)
+
         mic_title = _static_tooltip(mic.group(0))
         vm_title = _static_tooltip(vm.group(0))
-        assert mic_title != vm_title, \
+        assert mic_title != vm_title, (
             f"Static tooltips must differ; both say {mic_title!r}"
-        assert "voice input" not in mic_title.lower(), \
+        )
+        assert "voice input" not in mic_title.lower(), (
             f"btnMic static tooltip still says 'Voice input': {mic_title!r}"
-        assert "voice input" not in vm_title.lower(), \
+        )
+        assert "voice input" not in vm_title.lower(), (
             f"btnVoiceMode static tooltip still says 'Voice input': {vm_title!r}"
+        )
 
     def test_voice_mode_uses_audio_lines_glyph(self):
         """btnVoiceMode SVG must use the audio-lines (waveform) shape.
@@ -109,8 +120,9 @@ class TestComposerVoiceButtonHTML:
         )
         # Must NOT contain the old mic-shaped rect (rx="3" capsule) — that's
         # the dictation glyph and using it again recreates #1488.
-        assert 'rect x="9" y="1" width="6" height="12" rx="3"' not in body, \
+        assert 'rect x="9" y="1" width="6" height="12" rx="3"' not in body, (
             "btnVoiceMode regressed to mic shape — the visual confusion bug returns."
+        )
 
 
 class TestComposerVoiceButtonI18n:
@@ -130,7 +142,7 @@ class TestComposerVoiceButtonI18n:
         tooltip bug. It must no longer appear in i18n.js."""
         src = _src("i18n.js")
         # Match the property name only (not strings that happen to mention it).
-        leftover = re.findall(r'\bvoice_toggle\s*:', src)
+        leftover = re.findall(r"\bvoice_toggle\s*:", src)
         assert not leftover, (
             f"Stale voice_toggle: key still in i18n.js ({len(leftover)} "
             f"occurrences). Replace with voice_mode_toggle / voice_dictate."
@@ -140,7 +152,7 @@ class TestComposerVoiceButtonI18n:
         """Every locale block must define all 4 new composer voice-button keys."""
         src = _src("i18n.js")
         for key in self.REQUIRED_KEYS:
-            count = len(re.findall(rf'\b{re.escape(key)}\s*:', src))
+            count = len(re.findall(rf"\b{re.escape(key)}\s*:", src))
             assert count == len(self.LOCALES), (
                 f"i18n key {key!r} appears {count} times — expected one per "
                 f"locale ({len(self.LOCALES)} locales: {self.LOCALES}). "
@@ -153,8 +165,9 @@ class TestComposerVoiceButtonI18n:
         # Find the en block (first occurrence of voice_dictate is in en)
         m = re.search(r"\bvoice_dictate\s*:\s*'([^']+)'", src)
         assert m, "voice_dictate key not found"
-        assert m.group(1) == "Dictate", \
+        assert m.group(1) == "Dictate", (
             f"English voice_dictate should be 'Dictate'; got {m.group(1)!r}"
+        )
 
     def test_english_voice_mode_label_is_voice_mode(self):
         """English voice_mode_toggle must read 'Voice mode' — matches
@@ -164,8 +177,9 @@ class TestComposerVoiceButtonI18n:
         # _active suffix variant — use a lookahead to assert no _active.
         m = re.search(r"\bvoice_mode_toggle\s*:\s*'([^']+)'", src)
         assert m, "voice_mode_toggle key not found"
-        assert m.group(1) == "Voice mode", \
+        assert m.group(1) == "Voice mode", (
             f"English voice_mode_toggle should be 'Voice mode'; got {m.group(1)!r}"
+        )
 
 
 class TestVoiceModePreferenceGate:
@@ -186,10 +200,12 @@ class TestVoiceModePreferenceGate:
         # Find the voice-mode pref helper. Must NOT contain an
         # unconditional `modeBtn.style.display='';` (the master bug).
         # Instead, the function _applyVoiceModePref must be the source of truth.
-        assert "_applyVoiceModePref" in src, \
+        assert "_applyVoiceModePref" in src, (
             "boot.js must expose _applyVoiceModePref so settings toggle re-applies live."
-        assert "_voiceModePrefEnabled" in src, \
+        )
+        assert "_voiceModePrefEnabled" in src, (
             "boot.js must define _voiceModePrefEnabled to read the pref."
+        )
         # The pre-existing `modeBtn.style.display='';` line must be gone.
         # We allow `style.display = _voiceModePrefEnabled() ? '' : 'none'`.
         assert "modeBtn.style.display='';" not in src, (
@@ -200,18 +216,21 @@ class TestVoiceModePreferenceGate:
     def test_settings_pane_has_voice_mode_checkbox(self):
         """index.html Preferences pane must include the toggle checkbox."""
         html = _src("index.html")
-        assert 'id="settingsVoiceModeEnabled"' in html, \
+        assert 'id="settingsVoiceModeEnabled"' in html, (
             "Preferences pane must include #settingsVoiceModeEnabled checkbox."
-        assert 'data-i18n="settings_label_voice_mode"' in html, \
+        )
+        assert 'data-i18n="settings_label_voice_mode"' in html, (
             "Voice-mode pref label must use data-i18n='settings_label_voice_mode'."
-        assert 'data-i18n="settings_desc_voice_mode"' in html, \
+        )
+        assert 'data-i18n="settings_desc_voice_mode"' in html, (
             "Voice-mode pref description must use data-i18n='settings_desc_voice_mode'."
+        )
 
     def test_settings_pane_has_voice_mode_i18n_keys(self):
         """The two new pref-label i18n keys must exist in every locale."""
         src = _src("i18n.js")
         for key in ("settings_label_voice_mode", "settings_desc_voice_mode"):
-            count = len(re.findall(rf'\b{re.escape(key)}\s*:', src))
+            count = len(re.findall(rf"\b{re.escape(key)}\s*:", src))
             assert count == 9, (
                 f"Preferences i18n key {key!r} appears {count} times — "
                 f"expected 9 (one per locale)."
@@ -221,13 +240,16 @@ class TestVoiceModePreferenceGate:
         """panels.js must read the checkbox state, persist to localStorage,
         and call _applyVoiceModePref so the change is live without reload."""
         src = _src("panels.js")
-        assert "settingsVoiceModeEnabled" in src, \
+        assert "settingsVoiceModeEnabled" in src, (
             "panels.js must reference the #settingsVoiceModeEnabled checkbox."
-        assert "'hermes-voice-mode-button'" in src, \
+        )
+        assert "'hermes-voice-mode-button'" in src, (
             "panels.js must persist the pref to localStorage key 'hermes-voice-mode-button'."
-        assert "_applyVoiceModePref" in src, \
-            "panels.js onchange handler must call window._applyVoiceModePref() " \
+        )
+        assert "_applyVoiceModePref" in src, (
+            "panels.js onchange handler must call window._applyVoiceModePref() "
             "so the button appears/disappears immediately."
+        )
 
 
 class TestActiveStateTooltips:
@@ -244,8 +266,9 @@ class TestActiveStateTooltips:
             "_setRecording must flip the tooltip to voice_dictate_active when "
             "recording starts so the user knows pressing it now stops dictation."
         )
-        assert "voice_dictate'" in body or "voice_dictate\"" in body, \
+        assert "voice_dictate'" in body or 'voice_dictate"' in body, (
             "_setRecording must restore voice_dictate when recording stops."
+        )
 
     def test_voice_mode_active_tooltip(self):
         """_activate() should set modeBtn.title to voice_mode_toggle_active."""
@@ -275,5 +298,6 @@ class TestAudioLinesIconRegistered:
 
     def test_audio_lines_in_li_paths(self):
         src = _src("icons.js")
-        assert "'audio-lines'" in src, \
+        assert "'audio-lines'" in src, (
             "audio-lines must be registered in LI_PATHS for li('audio-lines') reuse."
+        )

--- a/tests/test_issue1494_state_db_fd_leak.py
+++ b/tests/test_issue1494_state_db_fd_leak.py
@@ -27,6 +27,7 @@ audited as still leaking on master @ 7fddc33:
 Each test monkeypatches sqlite3.connect to track every connection the function
 opens, then asserts every connection is .close()'d after the call returns.
 """
+
 import sqlite3
 
 import pytest
@@ -151,7 +152,9 @@ def _assert_all_closed(tracking, fn_name):
     )
 
 
-def test_read_importable_agent_session_rows_closes_connection(tmp_path, tracking_sqlite):
+def test_read_importable_agent_session_rows_closes_connection(
+    tmp_path, tracking_sqlite
+):
     """`read_importable_agent_session_rows` must close every sqlite connection."""
     db = tmp_path / "state.db"
     _make_state_db(db)
@@ -180,7 +183,9 @@ def test_read_session_lineage_metadata_closes_connection(tmp_path, tracking_sqli
     assert len(tracking_sqlite.instances) == 5
 
 
-def test_get_cli_session_messages_closes_connection(tmp_path, tracking_sqlite, monkeypatch):
+def test_get_cli_session_messages_closes_connection(
+    tmp_path, tracking_sqlite, monkeypatch
+):
     """`get_cli_session_messages` must close every sqlite connection."""
     db = tmp_path / "state.db"
     _make_state_db(db)
@@ -188,6 +193,7 @@ def test_get_cli_session_messages_closes_connection(tmp_path, tracking_sqlite, m
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     # Stub get_active_hermes_home so the tmp_path is used regardless of profile state.
     import api.profiles
+
     monkeypatch.setattr(api.profiles, "get_active_hermes_home", lambda: str(tmp_path))
 
     from api.models import get_cli_session_messages
@@ -208,6 +214,7 @@ def test_delete_cli_session_closes_connection(tmp_path, tracking_sqlite, monkeyp
 
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     import api.profiles
+
     monkeypatch.setattr(api.profiles, "get_active_hermes_home", lambda: str(tmp_path))
 
     from api.models import delete_cli_session
@@ -228,7 +235,9 @@ def test_delete_cli_session_closes_connection(tmp_path, tracking_sqlite, monkeyp
     try:
         cur = real.execute("SELECT COUNT(*) FROM sessions WHERE id = ?", ("s1",))
         assert cur.fetchone()[0] == 0
-        cur = real.execute("SELECT COUNT(*) FROM messages WHERE session_id = ?", ("s1",))
+        cur = real.execute(
+            "SELECT COUNT(*) FROM messages WHERE session_id = ?", ("s1",)
+        )
         assert cur.fetchone()[0] == 0
     finally:
         real.close()

--- a/tests/test_issue1499_keyless_onboarding.py
+++ b/tests/test_issue1499_keyless_onboarding.py
@@ -31,7 +31,6 @@ from __future__ import annotations
 
 import sys
 import types
-from pathlib import Path
 
 import pytest
 
@@ -66,15 +65,22 @@ def _isolate_onboarding_writes(monkeypatch, tmp_path):
     ``~/.hermes`` and clobber the developer's actual config.
     """
     from api import onboarding as ob
+
     monkeypatch.setattr(ob, "_get_active_hermes_home", lambda: tmp_path)
     cfg_path = tmp_path / "config.yaml"
     monkeypatch.setattr(ob, "_get_config_path", lambda: cfg_path)
     monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
     monkeypatch.delenv("HERMES_WEBUI_SKIP_ONBOARDING", raising=False)
     for var in (
-        "LM_API_KEY", "LMSTUDIO_API_KEY", "OLLAMA_API_KEY", "OPENAI_API_KEY",
-        "OPENROUTER_API_KEY", "ANTHROPIC_API_KEY", "GOOGLE_API_KEY",
-        "GH_TOKEN", "GITHUB_TOKEN",
+        "LM_API_KEY",
+        "LMSTUDIO_API_KEY",
+        "OLLAMA_API_KEY",
+        "OPENAI_API_KEY",
+        "OPENROUTER_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "GOOGLE_API_KEY",
+        "GH_TOKEN",
+        "GITHUB_TOKEN",
     ):
         monkeypatch.delenv(var, raising=False)
     return cfg_path
@@ -85,6 +91,7 @@ class TestKeyOptionalProviderSchema:
 
     def test_lmstudio_is_key_optional(self):
         from api.onboarding import _SUPPORTED_PROVIDER_SETUPS
+
         assert _SUPPORTED_PROVIDER_SETUPS["lmstudio"].get("key_optional") is True, (
             "lmstudio must declare key_optional=True so onboarding accepts an "
             "empty api_key.  Pre-fix the wizard required users to type "
@@ -93,6 +100,7 @@ class TestKeyOptionalProviderSchema:
 
     def test_ollama_is_key_optional(self):
         from api.onboarding import _SUPPORTED_PROVIDER_SETUPS
+
         assert _SUPPORTED_PROVIDER_SETUPS["ollama"].get("key_optional") is True, (
             "ollama must declare key_optional=True — local Ollama runs keyless "
             "by default."
@@ -100,6 +108,7 @@ class TestKeyOptionalProviderSchema:
 
     def test_custom_is_key_optional(self):
         from api.onboarding import _SUPPORTED_PROVIDER_SETUPS
+
         assert _SUPPORTED_PROVIDER_SETUPS["custom"].get("key_optional") is True, (
             "custom must declare key_optional=True — many self-hosted "
             "OpenAI-compatible servers (vLLM, llama-server, TabbyAPI) run "
@@ -109,6 +118,7 @@ class TestKeyOptionalProviderSchema:
     def test_cloud_providers_are_not_key_optional(self):
         """Regression-defense: openrouter/anthropic/openai must STILL require a key."""
         from api.onboarding import _SUPPORTED_PROVIDER_SETUPS
+
         for pid in ("openrouter", "anthropic", "openai"):
             assert not _SUPPORTED_PROVIDER_SETUPS[pid].get("key_optional"), (
                 f"{pid} must NOT be key_optional — cloud providers always need "
@@ -118,6 +128,7 @@ class TestKeyOptionalProviderSchema:
     def test_setup_catalog_exposes_key_optional_flag(self):
         """Frontend reads `provider.key_optional` from the catalog."""
         from api.onboarding import _build_setup_catalog
+
         catalog = _build_setup_catalog({"model": {"provider": "lmstudio"}})
         by_id = {p["id"]: p for p in catalog["providers"]}
         assert by_id["lmstudio"]["key_optional"] is True
@@ -138,13 +149,16 @@ class TestKeylessOnboarding:
         cfg_path = _isolate_onboarding_writes(monkeypatch, tmp_path)
 
         from api import onboarding as ob
+
         # Empty api_key — should NOT raise.
-        ob.apply_onboarding_setup({
-            "provider": "lmstudio",
-            "model": "qwen3-27b",
-            "base_url": "http://example.local:1234/v1",
-            "api_key": "",
-        })
+        ob.apply_onboarding_setup(
+            {
+                "provider": "lmstudio",
+                "model": "qwen3-27b",
+                "base_url": "http://example.local:1234/v1",
+                "api_key": "",
+            }
+        )
 
         # config.yaml gets written with provider/model/base_url
         assert cfg_path.exists()
@@ -168,12 +182,15 @@ class TestKeylessOnboarding:
         _isolate_onboarding_writes(monkeypatch, tmp_path)
 
         from api import onboarding as ob
-        ob.apply_onboarding_setup({
-            "provider": "ollama",
-            "model": "qwen3:32b",
-            "base_url": "http://localhost:11434/v1",
-            "api_key": "",
-        })
+
+        ob.apply_onboarding_setup(
+            {
+                "provider": "ollama",
+                "model": "qwen3:32b",
+                "base_url": "http://localhost:11434/v1",
+                "api_key": "",
+            }
+        )
         env_path = tmp_path / ".env"
         if env_path.exists():
             assert "OLLAMA_API_KEY=" not in env_path.read_text(encoding="utf-8")
@@ -183,12 +200,15 @@ class TestKeylessOnboarding:
         _isolate_onboarding_writes(monkeypatch, tmp_path)
 
         from api import onboarding as ob
-        ob.apply_onboarding_setup({
-            "provider": "custom",
-            "model": "gpt-4o-mini",
-            "base_url": "http://my-vllm.local/v1",
-            "api_key": "",
-        })
+
+        ob.apply_onboarding_setup(
+            {
+                "provider": "custom",
+                "model": "gpt-4o-mini",
+                "base_url": "http://my-vllm.local/v1",
+                "api_key": "",
+            }
+        )
         env_path = tmp_path / ".env"
         if env_path.exists():
             assert "OPENAI_API_KEY=" not in env_path.read_text(encoding="utf-8")
@@ -199,27 +219,35 @@ class TestKeylessOnboarding:
         _isolate_onboarding_writes(monkeypatch, tmp_path)
 
         from api import onboarding as ob
+
         with pytest.raises(ValueError, match="OPENROUTER_API_KEY is required"):
-            ob.apply_onboarding_setup({
-                "provider": "openrouter",
-                "model": "anthropic/claude-sonnet-4.6",
-                "base_url": "",
-                "api_key": "",
-            })
+            ob.apply_onboarding_setup(
+                {
+                    "provider": "openrouter",
+                    "model": "anthropic/claude-sonnet-4.6",
+                    "base_url": "",
+                    "api_key": "",
+                }
+            )
 
     def test_anthropic_empty_api_key_still_rejected(self, monkeypatch, tmp_path):
         _install_fake_hermes_cli(monkeypatch)
         _isolate_onboarding_writes(monkeypatch, tmp_path)
 
         from api import onboarding as ob
-        with pytest.raises(ValueError, match="ANTHROPIC_API_KEY is required"):
-            ob.apply_onboarding_setup({
-                "provider": "anthropic",
-                "model": "claude-sonnet-4.6",
-                "api_key": "",
-            })
 
-    def test_lmstudio_with_explicit_api_key_still_writes_env(self, monkeypatch, tmp_path):
+        with pytest.raises(ValueError, match="ANTHROPIC_API_KEY is required"):
+            ob.apply_onboarding_setup(
+                {
+                    "provider": "anthropic",
+                    "model": "claude-sonnet-4.6",
+                    "api_key": "",
+                }
+            )
+
+    def test_lmstudio_with_explicit_api_key_still_writes_env(
+        self, monkeypatch, tmp_path
+    ):
         """Auth-enabled LM Studio: user supplies a key, .env still gets written.
 
         Regression-defense for the keyless path: when the user DOES supply a
@@ -229,12 +257,15 @@ class TestKeylessOnboarding:
         _isolate_onboarding_writes(monkeypatch, tmp_path)
 
         from api import onboarding as ob
-        ob.apply_onboarding_setup({
-            "provider": "lmstudio",
-            "model": "qwen3-27b",
-            "base_url": "http://example.local:1234/v1",
-            "api_key": "real-secret-token",
-        })
+
+        ob.apply_onboarding_setup(
+            {
+                "provider": "lmstudio",
+                "model": "qwen3-27b",
+                "base_url": "http://example.local:1234/v1",
+                "api_key": "real-secret-token",
+            }
+        )
         env_text = (tmp_path / ".env").read_text(encoding="utf-8")
         assert "LM_API_KEY=" in env_text, (
             f"Auth-enabled lmstudio user supplied an api_key but .env doesn't "
@@ -246,13 +277,16 @@ class TestKeylessChatReady:
     """``provider_ready`` and ``chat_ready`` are True for key_optional providers."""
 
     def test_lmstudio_keyless_provider_ready_via_status_runtime(
-        self, monkeypatch, tmp_path,
+        self,
+        monkeypatch,
+        tmp_path,
     ):
         """``_status_from_runtime`` returns provider_ready=True with no api_key."""
         _install_fake_hermes_cli(monkeypatch)
         _isolate_onboarding_writes(monkeypatch, tmp_path)
 
         from api import onboarding as ob
+
         cfg = {
             "model": {
                 "provider": "lmstudio",
@@ -268,12 +302,15 @@ class TestKeylessChatReady:
         )
 
     def test_ollama_keyless_provider_ready_via_status_runtime(
-        self, monkeypatch, tmp_path,
+        self,
+        monkeypatch,
+        tmp_path,
     ):
         _install_fake_hermes_cli(monkeypatch)
         _isolate_onboarding_writes(monkeypatch, tmp_path)
 
         from api import onboarding as ob
+
         cfg = {
             "model": {
                 "provider": "ollama",
@@ -285,13 +322,16 @@ class TestKeylessChatReady:
         assert status.get("provider_ready") is True
 
     def test_custom_keyless_provider_ready_requires_base_url(
-        self, monkeypatch, tmp_path,
+        self,
+        monkeypatch,
+        tmp_path,
     ):
         """custom is key_optional but still requires base_url."""
         _install_fake_hermes_cli(monkeypatch)
         _isolate_onboarding_writes(monkeypatch, tmp_path)
 
         from api import onboarding as ob
+
         # With base_url → ready
         cfg_with = {
             "model": {
@@ -300,7 +340,10 @@ class TestKeylessChatReady:
                 "base_url": "http://my-vllm.local/v1",
             },
         }
-        assert ob._status_from_runtime(cfg_with, imports_ok=True).get("provider_ready") is True
+        assert (
+            ob._status_from_runtime(cfg_with, imports_ok=True).get("provider_ready")
+            is True
+        )
 
         # Without base_url → NOT ready (custom still requires it)
         cfg_without = {
@@ -309,7 +352,10 @@ class TestKeylessChatReady:
                 "default": "gpt-4o-mini",
             },
         }
-        assert ob._status_from_runtime(cfg_without, imports_ok=True).get("provider_ready") is False, (
+        assert (
+            ob._status_from_runtime(cfg_without, imports_ok=True).get("provider_ready")
+            is False
+        ), (
             "custom is key_optional but still requires base_url — this test "
             "catches a regression where the requires_base_url check is "
             "accidentally dropped for key_optional providers."
@@ -321,13 +367,16 @@ class TestKeylessChatReady:
         _isolate_onboarding_writes(monkeypatch, tmp_path)
 
         from api import onboarding as ob
+
         cfg = {
             "model": {
                 "provider": "openrouter",
                 "default": "anthropic/claude-sonnet-4.6",
             },
         }
-        assert ob._status_from_runtime(cfg, imports_ok=True).get("provider_ready") is False, (
+        assert (
+            ob._status_from_runtime(cfg, imports_ok=True).get("provider_ready") is False
+        ), (
             "openrouter with no api_key must NOT be provider_ready — that "
             "would silently let the wizard finish without the user actually "
             "entering a key."
@@ -339,12 +388,15 @@ class TestKeylessChatReady:
         cfg_path = _isolate_onboarding_writes(monkeypatch, tmp_path)
 
         from api import onboarding as ob
-        ob.apply_onboarding_setup({
-            "provider": "lmstudio",
-            "model": "qwen3-27b",
-            "base_url": "http://example.local:1234/v1",
-            "api_key": "",
-        })
+
+        ob.apply_onboarding_setup(
+            {
+                "provider": "lmstudio",
+                "model": "qwen3-27b",
+                "base_url": "http://example.local:1234/v1",
+                "api_key": "",
+            }
+        )
 
         # Reload config so get_onboarding_status sees the just-written values.
         # _swap_in_test_config-style — replicate just enough of that pattern.
@@ -353,7 +405,10 @@ class TestKeylessChatReady:
         config.cfg.clear()
         try:
             import yaml
-            config.cfg.update(yaml.safe_load(cfg_path.read_text(encoding="utf-8")) or {})
+
+            config.cfg.update(
+                yaml.safe_load(cfg_path.read_text(encoding="utf-8")) or {}
+            )
         except Exception:
             pass
         try:

--- a/tests/test_issue1499_onboarding_probe.py
+++ b/tests/test_issue1499_onboarding_probe.py
@@ -52,12 +52,24 @@ def mock_models_server():
                 self.send_response(200)
                 self.send_header("Content-Type", "application/json")
                 self.end_headers()
-                self.wfile.write(json.dumps({
-                    "data": [
-                        {"id": "qwen3-27b", "object": "model", "owned_by": "user"},
-                        {"id": "llama-3.3-70b", "object": "model", "owned_by": "user"},
-                    ]
-                }).encode())
+                self.wfile.write(
+                    json.dumps(
+                        {
+                            "data": [
+                                {
+                                    "id": "qwen3-27b",
+                                    "object": "model",
+                                    "owned_by": "user",
+                                },
+                                {
+                                    "id": "llama-3.3-70b",
+                                    "object": "model",
+                                    "owned_by": "user",
+                                },
+                            ]
+                        }
+                    ).encode()
+                )
                 return
 
             # /barelist/models — bare list shape some self-hosted servers return
@@ -65,9 +77,14 @@ def mock_models_server():
                 self.send_response(200)
                 self.send_header("Content-Type", "application/json")
                 self.end_headers()
-                self.wfile.write(json.dumps([
-                    {"id": "alpha"}, {"id": "beta"},
-                ]).encode())
+                self.wfile.write(
+                    json.dumps(
+                        [
+                            {"id": "alpha"},
+                            {"id": "beta"},
+                        ]
+                    ).encode()
+                )
                 return
 
             # /v1bad/models — 404 (wrong path)
@@ -138,18 +155,21 @@ class TestIssue1499OnboardingProbe:
 
     def test_invalid_url_empty(self):
         from api.onboarding import probe_provider_endpoint
+
         r = probe_provider_endpoint("lmstudio", "")
         assert r["ok"] is False
         assert r["error"] == "invalid_url"
 
     def test_invalid_url_bad_scheme(self):
         from api.onboarding import probe_provider_endpoint
+
         r = probe_provider_endpoint("lmstudio", "ftp://example.com:1234/v1")
         assert r["ok"] is False
         assert r["error"] == "invalid_url"
 
     def test_invalid_url_no_host(self):
         from api.onboarding import probe_provider_endpoint
+
         r = probe_provider_endpoint("lmstudio", "http:///models")
         assert r["ok"] is False
         assert r["error"] == "invalid_url"
@@ -157,6 +177,7 @@ class TestIssue1499OnboardingProbe:
     def test_dns_resolution_failure(self):
         """Unresolvable hostname → error='dns'."""
         from api.onboarding import probe_provider_endpoint
+
         r = probe_provider_endpoint(
             "lmstudio",
             "http://this-host-definitely-does-not-exist-zxq987.invalid:1234/v1",
@@ -168,6 +189,7 @@ class TestIssue1499OnboardingProbe:
     def test_connect_refused(self):
         """Connecting to a port nobody's listening on → error='connect_refused'."""
         from api.onboarding import probe_provider_endpoint
+
         # Port 1 is reserved tcpmux and on Linux/macOS dev boxes is universally
         # not listening. If a future CI environment binds something there this
         # will need updating, but no realistic CI binds port 1.
@@ -177,6 +199,7 @@ class TestIssue1499OnboardingProbe:
 
     def test_success_openai_shape(self, mock_models_server):
         from api.onboarding import probe_provider_endpoint
+
         r = probe_provider_endpoint("lmstudio", f"{mock_models_server['base']}/v1")
         assert r["ok"] is True, f"Expected success, got {r}"
         assert len(r["models"]) == 2
@@ -189,13 +212,17 @@ class TestIssue1499OnboardingProbe:
     def test_success_bare_list_shape(self, mock_models_server):
         """Some self-hosted servers return a bare list, not an OpenAI envelope."""
         from api.onboarding import probe_provider_endpoint
-        r = probe_provider_endpoint("lmstudio", f"{mock_models_server['base']}/barelist")
+
+        r = probe_provider_endpoint(
+            "lmstudio", f"{mock_models_server['base']}/barelist"
+        )
         assert r["ok"] is True, f"Expected success, got {r}"
         ids = [m["id"] for m in r["models"]]
         assert ids == ["alpha", "beta"]
 
     def test_http_4xx(self, mock_models_server):
         from api.onboarding import probe_provider_endpoint
+
         r = probe_provider_endpoint("lmstudio", f"{mock_models_server['base']}/v1bad")
         assert r["ok"] is False
         assert r["error"] == "http_4xx"
@@ -203,14 +230,20 @@ class TestIssue1499OnboardingProbe:
 
     def test_http_5xx(self, mock_models_server):
         from api.onboarding import probe_provider_endpoint
-        r = probe_provider_endpoint("lmstudio", f"{mock_models_server['base']}/v1explode")
+
+        r = probe_provider_endpoint(
+            "lmstudio", f"{mock_models_server['base']}/v1explode"
+        )
         assert r["ok"] is False
         assert r["error"] == "http_5xx"
         assert r.get("status") == 500
 
     def test_parse_non_json(self, mock_models_server):
         from api.onboarding import probe_provider_endpoint
-        r = probe_provider_endpoint("lmstudio", f"{mock_models_server['base']}/v1/parse")
+
+        r = probe_provider_endpoint(
+            "lmstudio", f"{mock_models_server['base']}/v1/parse"
+        )
         assert r["ok"] is False
         assert r["error"] == "parse"
         assert "JSON" in r["detail"] or "json" in r["detail"]
@@ -218,7 +251,10 @@ class TestIssue1499OnboardingProbe:
     def test_parse_wrong_shape(self, mock_models_server):
         """JSON body but not OpenAI /models shape → error='parse'."""
         from api.onboarding import probe_provider_endpoint
-        r = probe_provider_endpoint("lmstudio", f"{mock_models_server['base']}/v1/wrongshape")
+
+        r = probe_provider_endpoint(
+            "lmstudio", f"{mock_models_server['base']}/v1/wrongshape"
+        )
         assert r["ok"] is False
         assert r["error"] == "parse"
         assert "OpenAI" in r["detail"] or "shape" in r["detail"]
@@ -248,7 +284,9 @@ class TestIssue1499OnboardingProbe:
         assert r["ok"] is True
         assert [m["id"] for m in r["models"]] == ["auth-only"]
 
-    def test_probe_does_not_persist_to_config(self, mock_models_server, tmp_path, monkeypatch):
+    def test_probe_does_not_persist_to_config(
+        self, mock_models_server, tmp_path, monkeypatch
+    ):
         """Probe is read-only — must NOT touch config.yaml or .env.
 
         Pre-fix the wizard would have happily auto-written the probed model
@@ -311,7 +349,9 @@ class TestIssue1499OnboardingProbe:
                 self.send_response(200)
                 self.send_header("Content-Type", "application/json")
                 self.end_headers()
-                self.wfile.write(json.dumps({"data": [{"id": "should-not-see"}]}).encode())
+                self.wfile.write(
+                    json.dumps({"data": [{"id": "should-not-see"}]}).encode()
+                )
 
             def log_message(self, *args, **kwargs):  # noqa: N802
                 pass
@@ -348,12 +388,19 @@ class TestIssue1499OnboardingProbe:
         so frontend localization keys can mechanically derive from it.
         """
         from api.onboarding import PROBE_ERROR_CODES
+
         # If you add a new error code, also add an i18n key
         # `onboarding_probe_error_<code>` to all 9 locale blocks in
         # static/i18n.js (search for `onboarding_probe_error_`).
         expected = {
-            "invalid_url", "dns", "connect_refused", "timeout",
-            "http_4xx", "http_5xx", "parse", "unreachable",
+            "invalid_url",
+            "dns",
+            "connect_refused",
+            "timeout",
+            "http_4xx",
+            "http_5xx",
+            "parse",
+            "unreachable",
         }
         assert set(PROBE_ERROR_CODES) == expected, (
             f"PROBE_ERROR_CODES drift: got {set(PROBE_ERROR_CODES)}, "
@@ -390,20 +437,24 @@ class TestIssue1499ProbeRouteEndToEnd:
         assert body["error"] == "invalid_url"
 
     def test_route_returns_success_against_mock(self, mock_models_server):
-        body, status = self._post({
-            "provider": "lmstudio",
-            "base_url": f"{mock_models_server['base']}/v1",
-        })
+        body, status = self._post(
+            {
+                "provider": "lmstudio",
+                "base_url": f"{mock_models_server['base']}/v1",
+            }
+        )
         assert status == 200, f"unexpected status {status}: {body}"
         assert body["ok"] is True
         assert isinstance(body["models"], list)
         assert any(m["id"] == "qwen3-27b" for m in body["models"])
 
     def test_route_returns_dns_error_for_bad_host(self):
-        body, status = self._post({
-            "provider": "lmstudio",
-            "base_url": "http://this-host-definitely-does-not-exist-zxq987.invalid:1234/v1",
-        })
+        body, status = self._post(
+            {
+                "provider": "lmstudio",
+                "base_url": "http://this-host-definitely-does-not-exist-zxq987.invalid:1234/v1",
+            }
+        )
         assert status == 200
         assert body["ok"] is False
         assert body["error"] == "dns"

--- a/tests/test_issue1500_lmstudio_env_var_alignment.py
+++ b/tests/test_issue1500_lmstudio_env_var_alignment.py
@@ -27,7 +27,6 @@ from __future__ import annotations
 
 import sys
 import types
-from pathlib import Path
 
 import api.config as config
 import api.profiles as profiles
@@ -49,6 +48,7 @@ def _install_fake_hermes_cli(monkeypatch):
     monkeypatch.delitem(sys.modules, "agent", raising=False)
     try:
         from api.config import invalidate_models_cache
+
         invalidate_models_cache()
     except Exception:
         pass
@@ -77,6 +77,7 @@ class TestIssue1500EnvVarAlignment:
     def test_onboarding_supported_provider_setup_uses_lm_api_key(self):
         """The wizard's lmstudio entry must declare the canonical env var name."""
         from api.onboarding import _SUPPORTED_PROVIDER_SETUPS
+
         assert "lmstudio" in _SUPPORTED_PROVIDER_SETUPS
         meta = _SUPPORTED_PROVIDER_SETUPS["lmstudio"]
         assert meta["env_var"] == "LM_API_KEY", (
@@ -99,6 +100,7 @@ class TestIssue1500EnvVarAlignment:
         # Redirect every write target to the tmp_path so we don't touch the real
         # ~/.hermes — pattern from webui-onboarding-provider-readiness skill.
         from api import onboarding as ob
+
         monkeypatch.setattr(ob, "_get_active_hermes_home", lambda: tmp_path)
         cfg_path = tmp_path / "config.yaml"
         monkeypatch.setattr(ob, "_get_config_path", lambda: cfg_path)
@@ -107,12 +109,14 @@ class TestIssue1500EnvVarAlignment:
         monkeypatch.delenv("LM_API_KEY", raising=False)
         monkeypatch.delenv("LMSTUDIO_API_KEY", raising=False)
 
-        ob.apply_onboarding_setup({
-            "provider": "lmstudio",
-            "model": "qwen3-27b",
-            "base_url": "http://example.local:1234/v1",
-            "api_key": "fresh-canon",
-        })
+        ob.apply_onboarding_setup(
+            {
+                "provider": "lmstudio",
+                "model": "qwen3-27b",
+                "base_url": "http://example.local:1234/v1",
+                "api_key": "fresh-canon",
+            }
+        )
 
         env_path = tmp_path / ".env"
         assert env_path.exists(), "onboarding must write .env"
@@ -136,6 +140,7 @@ class TestIssue1500EnvVarAlignment:
         restore = _swap_in_test_config({"model": {"provider": "lmstudio"}})
         try:
             from api.providers import get_providers
+
             result = get_providers()
             by_id = {p["id"]: p for p in result["providers"]}
             assert by_id["lmstudio"]["has_key"] is True, (
@@ -162,6 +167,7 @@ class TestIssue1500EnvVarAlignment:
         restore = _swap_in_test_config({"model": {"provider": "lmstudio"}})
         try:
             from api.providers import get_providers, _provider_has_key
+
             assert _provider_has_key("lmstudio") is True
             # Both lead to has_key=True; the contract is that canonical is
             # checked first (so it's definitely returning True and not just
@@ -184,6 +190,7 @@ class TestIssue1500EnvVarAlignment:
         user gets a re-firing wizard even though their LM Studio is configured.
         """
         from api.onboarding import _provider_api_key_present
+
         cfg = {"model": {"provider": "lmstudio"}}
 
         # Only the legacy name set in .env values — onboarding must still see it.

--- a/tests/test_issue1511_dedup_shared_reference.py
+++ b/tests/test_issue1511_dedup_shared_reference.py
@@ -48,7 +48,11 @@ def test_groups_have_independent_model_lists():
     groups = [
         {"provider": "Xiaomi", "provider_id": "xiaomi", "models": copy.deepcopy(auto)},
         {"provider": "Ollama", "provider_id": "ollama", "models": copy.deepcopy(auto)},
-        {"provider": "HuggingFace", "provider_id": "huggingface", "models": copy.deepcopy(auto)},
+        {
+            "provider": "HuggingFace",
+            "provider_id": "huggingface",
+            "models": copy.deepcopy(auto),
+        },
     ]
     assert groups[0]["models"] is not groups[1]["models"]
     assert groups[0]["models"][0] is not groups[1]["models"][0]
@@ -75,8 +79,16 @@ def test_unconfigured_providers_no_shared_dedup_bleed():
     groups = [
         {"provider": "Xiaomi", "provider_id": "xiaomi", "models": copy.deepcopy(auto)},
         {"provider": "Ollama", "provider_id": "ollama", "models": copy.deepcopy(auto)},
-        {"provider": "HuggingFace", "provider_id": "huggingface", "models": copy.deepcopy(auto)},
-        {"provider": "Google Gemini CLI", "provider_id": "google-gemini-cli", "models": copy.deepcopy(auto)},
+        {
+            "provider": "HuggingFace",
+            "provider_id": "huggingface",
+            "models": copy.deepcopy(auto),
+        },
+        {
+            "provider": "Google Gemini CLI",
+            "provider_id": "google-gemini-cli",
+            "models": copy.deepcopy(auto),
+        },
     ]
     _deduplicate_model_ids(groups)
 
@@ -85,7 +97,9 @@ def test_unconfigured_providers_no_shared_dedup_bleed():
     assert by_pid["google-gemini-cli"]["models"][0]["label"] == "Deepseek V4 Flash"
 
     assert by_pid["huggingface"]["models"][0]["id"] == "@huggingface:deepseek-v4-flash"
-    assert by_pid["huggingface"]["models"][0]["label"] == "Deepseek V4 Flash (HuggingFace)"
+    assert (
+        by_pid["huggingface"]["models"][0]["label"] == "Deepseek V4 Flash (HuggingFace)"
+    )
 
     assert by_pid["ollama"]["models"][0]["id"] == "@ollama:deepseek-v4-flash"
     assert by_pid["ollama"]["models"][0]["label"] == "Deepseek V4 Flash (Ollama)"
@@ -96,7 +110,9 @@ def test_unconfigured_providers_no_shared_dedup_bleed():
     for g in groups:
         for m in g["models"]:
             n = m["label"].count("(")
-            assert n <= 1, f"label {m['label']!r} accumulated {n} provider names — shared-ref bug"
+            assert n <= 1, (
+                f"label {m['label']!r} accumulated {n} provider names — shared-ref bug"
+            )
 
 
 def test_shared_reference_pre_fix_demonstrates_corruption():
@@ -131,7 +147,9 @@ def test_shared_reference_pre_fix_demonstrates_corruption():
     )
 
 
-def test_get_models_grouped_unconfigured_providers_get_independent_dicts(monkeypatch, tmp_path):
+def test_get_models_grouped_unconfigured_providers_get_independent_dicts(
+    monkeypatch, tmp_path
+):
     """Production-path regression guard for the exact line that was broken.
 
     Per Opus advisor feedback on stage-277: tests #1-3 above document the
@@ -147,7 +165,6 @@ def test_get_models_grouped_unconfigured_providers_get_independent_dicts(monkeyp
     A regression of the deepcopy() removal causes the `is not` assertion
     to flip immediately.
     """
-    import importlib
 
     import api.config as cfg_mod
 
@@ -194,7 +211,12 @@ def test_get_models_grouped_unconfigured_providers_get_independent_dicts(monkeyp
     # call at the assignment site, AND by running an integration check
     # of the loop pattern.
     import inspect
-    src = inspect.getsource(cfg_mod.get_models_grouped) if hasattr(cfg_mod, "get_models_grouped") else inspect.getsource(cfg_mod)
+
+    src = (
+        inspect.getsource(cfg_mod.get_models_grouped)
+        if hasattr(cfg_mod, "get_models_grouped")
+        else inspect.getsource(cfg_mod)
+    )
     assert "copy.deepcopy(auto_detected_models)" in src, (
         "api/config.py must wrap auto_detected_models in copy.deepcopy() at "
         "the unconfigured-provider fall-through (line ~2078) so dedup mutation "
@@ -206,7 +228,13 @@ def test_get_models_grouped_unconfigured_providers_get_independent_dicts(monkeyp
     detected = ["provider-a", "provider-b"]
     groups = []
     for pid in sorted(detected):
-        groups.append({"provider": pid.title(), "provider_id": pid, "models": copy.deepcopy(fake_auto_detected)})
+        groups.append(
+            {
+                "provider": pid.title(),
+                "provider_id": pid,
+                "models": copy.deepcopy(fake_auto_detected),
+            }
+        )
     cfg_mod._deduplicate_model_ids(groups)
     assert groups[0]["models"] is not groups[1]["models"]
     assert groups[0]["models"][0] is not groups[1]["models"][0]
@@ -214,4 +242,3 @@ def test_get_models_grouped_unconfigured_providers_get_independent_dicts(monkeyp
     assert groups[1]["models"][0]["id"] == "@provider-b:shared-model-x"
     assert groups[0]["models"][0]["label"].count("(") == 0
     assert groups[1]["models"][0]["label"].count("(") == 1
-

--- a/tests/test_issue1527_lmstudio_base_url_classification.py
+++ b/tests/test_issue1527_lmstudio_base_url_classification.py
@@ -95,8 +95,7 @@ def _mock_model_discovery(monkeypatch, model_ids: list[str], resolved_ip: str) -
 
 def _groups_by_id() -> dict[str, dict]:
     return {
-        group["provider_id"]: group
-        for group in config.get_available_models()["groups"]
+        group["provider_id"]: group for group in config.get_available_models()["groups"]
     }
 
 
@@ -140,7 +139,9 @@ providers:
     assert {"qwen3.6-35b-a3b@q6_k", "second-lmstudio-model"} <= model_ids
 
 
-def test_custom_configured_base_url_is_not_reclassified_as_ollama(tmp_path, monkeypatch):
+def test_custom_configured_base_url_is_not_reclassified_as_ollama(
+    tmp_path, monkeypatch
+):
     _write_config(
         tmp_path,
         monkeypatch,
@@ -178,9 +179,7 @@ providers:
 """,
     )
 
-    model, provider, base_url = config.resolve_model_provider(
-        "qwen3.6-35b-a3b@q6_k"
-    )
+    model, provider, base_url = config.resolve_model_provider("qwen3.6-35b-a3b@q6_k")
 
     assert model == "qwen3.6-35b-a3b@q6_k"
     assert provider == "lmstudio"

--- a/tests/test_issue1538_nous_live_catalog.py
+++ b/tests/test_issue1538_nous_live_catalog.py
@@ -69,8 +69,10 @@ def _install_fake_hermes_cli(monkeypatch, *, nous_ids=None, raise_on_lookup=Fals
     fake_models = types.ModuleType("hermes_cli.models")
     fake_models.list_available_providers = lambda: []
     if raise_on_lookup:
+
         def _raise(_pid):
             raise RuntimeError("simulated hermes_cli failure")
+
         fake_models.provider_model_ids = _raise
     else:
         ids = list(nous_ids) if nous_ids is not None else []
@@ -120,14 +122,28 @@ def _scrub_provider_env(monkeypatch):
     """Drop every provider env var so detection only sees what we install
     via the fake hermes_cli stubs (not unrelated keys leaked from the runner)."""
     for var in (
-        "ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GOOGLE_API_KEY", "GEMINI_API_KEY",
-        "DEEPSEEK_API_KEY", "XAI_API_KEY", "GROQ_API_KEY",
-        "MISTRAL_API_KEY", "OPENROUTER_API_KEY",
-        "OLLAMA_CLOUD_API_KEY", "OLLAMA_API_KEY",
-        "GLM_API_KEY", "KIMI_API_KEY", "MOONSHOT_API_KEY",
-        "MINIMAX_API_KEY", "MINIMAX_CN_API_KEY",
-        "OPENCODE_ZEN_API_KEY", "OPENCODE_GO_API_KEY",
-        "NOUS_API_KEY", "NVIDIA_API_KEY", "LM_API_KEY", "LMSTUDIO_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "OPENAI_API_KEY",
+        "GOOGLE_API_KEY",
+        "GEMINI_API_KEY",
+        "DEEPSEEK_API_KEY",
+        "XAI_API_KEY",
+        "GROQ_API_KEY",
+        "MISTRAL_API_KEY",
+        "OPENROUTER_API_KEY",
+        "OLLAMA_CLOUD_API_KEY",
+        "OLLAMA_API_KEY",
+        "GLM_API_KEY",
+        "KIMI_API_KEY",
+        "MOONSHOT_API_KEY",
+        "MINIMAX_API_KEY",
+        "MINIMAX_CN_API_KEY",
+        "OPENCODE_ZEN_API_KEY",
+        "OPENCODE_GO_API_KEY",
+        "NOUS_API_KEY",
+        "NVIDIA_API_KEY",
+        "LM_API_KEY",
+        "LMSTUDIO_API_KEY",
     ):
         monkeypatch.delenv(var, raising=False)
 
@@ -136,7 +152,9 @@ class TestNousLiveCatalog:
     """When the Nous live catalog is available, the dropdown must surface it
     in full (>=20 entries) — not the four-entry static fallback (#1538)."""
 
-    def test_nous_models_live_fetch_when_hermes_cli_available(self, monkeypatch, tmp_path):
+    def test_nous_models_live_fetch_when_hermes_cli_available(
+        self, monkeypatch, tmp_path
+    ):
         _scrub_provider_env(monkeypatch)
         _install_fake_hermes_cli(monkeypatch, nous_ids=SAMPLE_NOUS_LIVE_IDS)
         monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
@@ -144,7 +162,9 @@ class TestNousLiveCatalog:
         restore = _swap_in_test_config({"model": {"provider": "nous"}})
         try:
             data = config.get_available_models()
-            nous_groups = [g for g in data.get("groups", []) if g.get("provider_id") == "nous"]
+            nous_groups = [
+                g for g in data.get("groups", []) if g.get("provider_id") == "nous"
+            ]
             assert len(nous_groups) == 1, (
                 f"Expected exactly one Nous group, got {len(nous_groups)}: "
                 f"{[g.get('provider_id') for g in data.get('groups', [])]}"
@@ -236,7 +256,9 @@ class TestNousStaticFallback:
         restore = _swap_in_test_config({"model": {"provider": "nous"}})
         try:
             data = config.get_available_models()
-            nous_groups = [g for g in data.get("groups", []) if g.get("provider_id") == "nous"]
+            nous_groups = [
+                g for g in data.get("groups", []) if g.get("provider_id") == "nous"
+            ]
             assert nous_groups, (
                 "Nous group must still appear when hermes_cli fails — the "
                 "branch should fall back to the curated static list."
@@ -258,16 +280,22 @@ class TestFormatNousLabel:
 
     def test_strips_vendor_namespace(self):
         from api.config import _format_nous_label
-        assert _format_nous_label("anthropic/claude-opus-4.7") == "Claude Opus 4.7 (via Nous)"
+
+        assert (
+            _format_nous_label("anthropic/claude-opus-4.7")
+            == "Claude Opus 4.7 (via Nous)"
+        )
         assert _format_nous_label("openai/gpt-5.4-mini") == "GPT 5.4 Mini (via Nous)"
 
     def test_handles_missing_vendor(self):
         from api.config import _format_nous_label
+
         # Defensive: id without slash should still render a sane label.
         assert _format_nous_label("kimi-k2.6") == "Kimi K2.6 (via Nous)"
 
     def test_handles_variant_after_colon(self):
         from api.config import _format_nous_label
+
         # Variant rendered in parentheses, mirroring _format_ollama_label.
         out = _format_nous_label("minimax/minimax-m2.5:free")
         assert out.endswith(" (via Nous)")
@@ -276,12 +304,14 @@ class TestFormatNousLabel:
 
     def test_minimax_renders_mixed_case(self):
         from api.config import _format_nous_label
+
         # Live wire returns lowercase 'minimax/minimax-...' but the curated
         # convention is mixed-case 'MiniMax'.
         assert _format_nous_label("minimax/minimax-m2.7").startswith("MiniMax M2.7")
 
     def test_label_always_ends_with_via_nous_suffix(self):
         from api.config import _format_nous_label
+
         for sample in [
             "anthropic/claude-opus-4.7",
             "openai/gpt-5.5",
@@ -300,6 +330,7 @@ class TestStaticListPreservedAsFallback:
 
     def test_static_list_present(self):
         from api.config import _PROVIDER_MODELS
+
         assert _PROVIDER_MODELS.get("nous"), (
             "The curated static Nous list must remain in _PROVIDER_MODELS as "
             "a fallback for environments where hermes_cli is unavailable."
@@ -309,5 +340,6 @@ class TestStaticListPreservedAsFallback:
         # Keep parity with tests/test_nous_portal_routing.py — ensures the
         # static fallback path produces correctly-routable ids when used.
         from api.config import _PROVIDER_MODELS
+
         for m in _PROVIDER_MODELS["nous"]:
             assert m["id"].startswith("@nous:"), m["id"]

--- a/tests/test_issue1539_provider_removal_dropdown_invalidation.py
+++ b/tests/test_issue1539_provider_removal_dropdown_invalidation.py
@@ -32,8 +32,6 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-import pytest
-
 
 REPO = Path(__file__).resolve().parent.parent
 
@@ -144,7 +142,9 @@ class TestProviderRemoveInvalidatesDropdowns:
 
     def test_dropdown_flush_calls_slash_cache_invalidator(self):
         src = _read_static("panels.js")
-        body = _extract_function_body(src, "function _refreshModelDropdownsAfterProviderChange(")
+        body = _extract_function_body(
+            src, "function _refreshModelDropdownsAfterProviderChange("
+        )
         # Must invoke the commands.js helper — directly poking module-local
         # lets across module boundaries is brittle.
         assert "_invalidateSlashModelCache" in body, (
@@ -155,7 +155,9 @@ class TestProviderRemoveInvalidatesDropdowns:
 
     def test_dropdown_flush_calls_populate_model_dropdown(self):
         src = _read_static("panels.js")
-        body = _extract_function_body(src, "function _refreshModelDropdownsAfterProviderChange(")
+        body = _extract_function_body(
+            src, "function _refreshModelDropdownsAfterProviderChange("
+        )
         assert "populateModelDropdown" in body, (
             "_refreshModelDropdownsAfterProviderChange must call "
             "populateModelDropdown() so the composer model picker, Settings → "
@@ -168,7 +170,9 @@ class TestProviderRemoveInvalidatesDropdowns:
         """If commands.js or ui.js failed to load, the providers panel must
         still update — the dropdown flush is best-effort (#1539)."""
         src = _read_static("panels.js")
-        body = _extract_function_body(src, "function _refreshModelDropdownsAfterProviderChange(")
+        body = _extract_function_body(
+            src, "function _refreshModelDropdownsAfterProviderChange("
+        )
         # Outer try/catch wraps the whole helper so a runtime error inside
         # populateModelDropdown / cache flush cannot surface as an unhandled
         # rejection that breaks the surrounding save/remove flow.
@@ -189,7 +193,9 @@ class TestProviderRemoveInvalidatesDropdowns:
         synchronously inside the helper — otherwise a slow /api/models would
         delay the providers panel re-render (#1539)."""
         src = _read_static("panels.js")
-        body = _extract_function_body(src, "function _refreshModelDropdownsAfterProviderChange(")
+        body = _extract_function_body(
+            src, "function _refreshModelDropdownsAfterProviderChange("
+        )
         # The helper itself is non-async (signature checked indirectly: the
         # source begins with 'function _refresh...', not 'async function').
         # Anything async is fired with Promise.resolve(...).catch(...) so the

--- a/tests/test_issue1560_password_env_var_lock.py
+++ b/tests/test_issue1560_password_env_var_lock.py
@@ -20,7 +20,7 @@ REPO = pathlib.Path(__file__).parent.parent
 
 
 def _read(rel_path):
-    return (REPO / rel_path).read_text(encoding='utf-8')
+    return (REPO / rel_path).read_text(encoding="utf-8")
 
 
 # ── Backend (api/routes.py) ───────────────────────────────────────────────
@@ -28,41 +28,45 @@ def _read(rel_path):
 
 def test_get_settings_surfaces_password_env_var_flag():
     """GET /api/settings handler must include `password_env_var: bool(env)`."""
-    src = _read('api/routes.py')
+    src = _read("api/routes.py")
     # Locate the GET /api/settings block (by handler comment + path string)
     start = src.index('if parsed.path == "/api/settings":')
     # Block ends at next top-level `if parsed.path == ...` or `if parsed.path.startswith`
-    end = src.index('if parsed.path', start + 50)
+    end = src.index("if parsed.path", start + 50)
     block = src[start:end]
 
-    assert 'password_env_var' in block, \
-        'GET /api/settings must expose password_env_var so UI can disable the field'
-    assert 'HERMES_WEBUI_PASSWORD' in block, \
-        'GET /api/settings must read HERMES_WEBUI_PASSWORD env var'
+    assert "password_env_var" in block, (
+        "GET /api/settings must expose password_env_var so UI can disable the field"
+    )
+    assert "HERMES_WEBUI_PASSWORD" in block, (
+        "GET /api/settings must read HERMES_WEBUI_PASSWORD env var"
+    )
 
 
 def test_post_settings_refuses_set_password_when_env_var_shadowed():
     """POST /api/settings with _set_password must return 409 when env var is set."""
-    src = _read('api/routes.py')
+    src = _read("api/routes.py")
     # The guard lives near the POST /api/settings handler; locate it via the
     # canonical error-message substring (defense-in-depth comment + bad() call).
-    assert 'HERMES_WEBUI_PASSWORD env var is set' in src, \
-        'POST /api/settings must refuse with a clear message naming the env var'
-    assert '409' in src, 'POST /api/settings must use HTTP 409 for env-var conflict'
+    assert "HERMES_WEBUI_PASSWORD env var is set" in src, (
+        "POST /api/settings must refuse with a clear message naming the env var"
+    )
+    assert "409" in src, "POST /api/settings must use HTTP 409 for env-var conflict"
 
 
 def test_post_settings_refuses_clear_password_when_env_var_shadowed():
     """POST /api/settings with _clear_password=true must also be refused."""
-    src = _read('api/routes.py')
+    src = _read("api/routes.py")
     # Same guard must cover both paths
-    assert '_clear_password' in src
+    assert "_clear_password" in src
     # Find the guard and verify it tests both flags
-    guard_idx = src.index('HERMES_WEBUI_PASSWORD env var is set')
+    guard_idx = src.index("HERMES_WEBUI_PASSWORD env var is set")
     # Look back ~2KB for the conditional that triggers the guard
-    window = src[max(0, guard_idx - 2000):guard_idx]
-    assert 'requested_password' in window or '_set_password' in window
-    assert 'requested_clear_password' in window or '_clear_password' in window, \
-        'guard must cover both _set_password and _clear_password'
+    window = src[max(0, guard_idx - 2000) : guard_idx]
+    assert "requested_password" in window or "_set_password" in window
+    assert "requested_clear_password" in window or "_clear_password" in window, (
+        "guard must cover both _set_password and _clear_password"
+    )
 
 
 # ── Frontend: lock UI elements (static/index.html) ────────────────────────
@@ -70,11 +74,13 @@ def test_post_settings_refuses_clear_password_when_env_var_shadowed():
 
 def test_settings_html_has_password_env_lock_banner():
     """The settings password block must include a hidden lock banner element."""
-    html = _read('static/index.html')
-    assert 'id="settingsPasswordEnvLock"' in html, \
-        'settingsPasswordEnvLock banner element required (revealed when env var set)'
-    assert 'data-i18n="password_env_var_locked"' in html, \
-        'banner must use the i18n key password_env_var_locked'
+    html = _read("static/index.html")
+    assert 'id="settingsPasswordEnvLock"' in html, (
+        "settingsPasswordEnvLock banner element required (revealed when env var set)"
+    )
+    assert 'data-i18n="password_env_var_locked"' in html, (
+        "banner must use the i18n key password_env_var_locked"
+    )
 
 
 # ── Frontend: env-locked logic (static/panels.js) ─────────────────────────
@@ -82,32 +88,36 @@ def test_settings_html_has_password_env_lock_banner():
 
 def test_panels_js_disables_password_when_env_locked():
     """panels.js must disable the password field and show the banner when password_env_var is true."""
-    src = _read('static/panels.js')
-    assert 'password_env_var' in src, \
-        'panels.js must read settings.password_env_var from GET /api/settings'
-    assert 'settingsPasswordEnvLock' in src, \
-        'panels.js must toggle the settingsPasswordEnvLock banner'
+    src = _read("static/panels.js")
+    assert "password_env_var" in src, (
+        "panels.js must read settings.password_env_var from GET /api/settings"
+    )
+    assert "settingsPasswordEnvLock" in src, (
+        "panels.js must toggle the settingsPasswordEnvLock banner"
+    )
     # The disable logic should set pwField.disabled
-    assert 'pwField.disabled' in src or 'disabled=pwEnvLocked' in src.replace(' ', ''), \
-        'password field must be disabled when env-locked'
+    assert "pwField.disabled" in src or "disabled=pwEnvLocked" in src.replace(
+        " ", ""
+    ), "password field must be disabled when env-locked"
 
 
 def test_panels_js_hides_disable_auth_button_when_env_locked():
     """The Disable Auth button must be hidden when env var shadows the settings password."""
-    src = _read('static/panels.js')
+    src = _read("static/panels.js")
     # When env-locked, btnDisableAuth should be set display:none
     # We verify by locating the env-locked block and checking it touches btnDisableAuth
-    idx = src.index('pwEnvLocked')
+    idx = src.index("pwEnvLocked")
     # Look in a window after the first env-locked reference for btnDisableAuth handling
-    window = src[idx:idx + 3000]
-    assert 'btnDisableAuth' in window, \
-        'Disable Auth button must be hidden in the env-locked code path'
+    window = src[idx : idx + 3000]
+    assert "btnDisableAuth" in window, (
+        "Disable Auth button must be hidden in the env-locked code path"
+    )
 
 
 # ── i18n: keys present in all 9 locales (static/i18n.js) ──────────────────
 
 
-LOCALES = ['en', 'ja', 'ru', 'es', 'de', 'zh', 'zh-Hant', 'pt', 'ko']
+LOCALES = ["en", "ja", "ru", "es", "de", "zh", "zh-Hant", "pt", "ko"]
 
 
 def _split_locales(i18n_src):
@@ -117,6 +127,7 @@ def _split_locales(i18n_src):
     block from its header to the next sibling header at the same indentation.
     """
     import re
+
     pattern = re.compile(r"^  ['\"]?([\w\-]+)['\"]?: \{$", re.MULTILINE)
     matches = list(pattern.finditer(i18n_src))
     blocks = {}
@@ -130,39 +141,46 @@ def _split_locales(i18n_src):
 
 def test_i18n_password_env_var_locked_in_all_locales():
     """Every locale must define the password_env_var_locked banner string."""
-    src = _read('static/i18n.js')
+    src = _read("static/i18n.js")
     blocks = _split_locales(src)
-    missing = [loc for loc in LOCALES if loc not in blocks
-               or 'password_env_var_locked:' not in blocks[loc]]
-    assert not missing, \
-        f"Locales missing password_env_var_locked: {missing}"
+    missing = [
+        loc
+        for loc in LOCALES
+        if loc not in blocks or "password_env_var_locked:" not in blocks[loc]
+    ]
+    assert not missing, f"Locales missing password_env_var_locked: {missing}"
 
 
 def test_i18n_password_env_var_locked_placeholder_in_all_locales():
     """Every locale must define the password_env_var_locked_placeholder string."""
-    src = _read('static/i18n.js')
+    src = _read("static/i18n.js")
     blocks = _split_locales(src)
-    missing = [loc for loc in LOCALES
-               if loc not in blocks
-               or 'password_env_var_locked_placeholder:' not in blocks[loc]]
-    assert not missing, \
+    missing = [
+        loc
+        for loc in LOCALES
+        if loc not in blocks
+        or "password_env_var_locked_placeholder:" not in blocks[loc]
+    ]
+    assert not missing, (
         f"Locales missing password_env_var_locked_placeholder: {missing}"
+    )
 
 
 def test_i18n_locked_string_mentions_env_var_name_in_all_locales():
     """Each locale's banner must literally mention HERMES_WEBUI_PASSWORD so users can find it."""
-    src = _read('static/i18n.js')
+    src = _read("static/i18n.js")
     blocks = _split_locales(src)
     for loc in LOCALES:
-        block = blocks.get(loc, '')
+        block = blocks.get(loc, "")
         # Find the password_env_var_locked entry
-        idx = block.find('password_env_var_locked:')
+        idx = block.find("password_env_var_locked:")
         assert idx != -1, f"{loc}: missing password_env_var_locked"
         # Take the rest of that line (the message string)
-        line_end = block.index('\n', idx)
+        line_end = block.index("\n", idx)
         line = block[idx:line_end]
-        assert 'HERMES_WEBUI_PASSWORD' in line, \
+        assert "HERMES_WEBUI_PASSWORD" in line, (
             f"{loc}: banner must literally name HERMES_WEBUI_PASSWORD"
+        )
 
 
 # ── Live HTTP smoke test (env var NOT set in pytest) ──────────────────────
@@ -173,20 +191,24 @@ def test_get_settings_returns_password_env_var_false_when_unset(monkeypatch):
     GET /api/settings must include `password_env_var: False`."""
     # Test the unset branch explicitly. Some suite neighbors intentionally set
     # HERMES_WEBUI_PASSWORD while exercising the locked-password path.
-    monkeypatch.delenv('HERMES_WEBUI_PASSWORD', raising=False)
+    monkeypatch.delenv("HERMES_WEBUI_PASSWORD", raising=False)
     # The conftest server inherits a sanitized env; verify this process is clean.
-    assert not os.getenv('HERMES_WEBUI_PASSWORD', '').strip(), \
-        'this test requires HERMES_WEBUI_PASSWORD to be unset'
+    assert not os.getenv("HERMES_WEBUI_PASSWORD", "").strip(), (
+        "this test requires HERMES_WEBUI_PASSWORD to be unset"
+    )
 
     from tests._pytest_port import BASE
-    req = urllib.request.Request(BASE + '/api/settings')
+
+    req = urllib.request.Request(BASE + "/api/settings")
     try:
         with urllib.request.urlopen(req, timeout=10) as r:
             payload = json.loads(r.read())
     except urllib.error.HTTPError as e:
         payload = json.loads(e.read())
 
-    assert 'password_env_var' in payload, \
-        'GET /api/settings must always include password_env_var key'
-    assert payload['password_env_var'] is False, \
-        'env var unset => password_env_var must be False'
+    assert "password_env_var" in payload, (
+        "GET /api/settings must always include password_env_var key"
+    )
+    assert payload["password_env_var"] is False, (
+        "env var unset => password_env_var must be False"
+    )

--- a/tests/test_issue1567_nous_picker_capacity_and_symmetry.py
+++ b/tests/test_issue1567_nous_picker_capacity_and_symmetry.py
@@ -36,10 +36,25 @@ import api.profiles as profiles
 # Volume distribution mirrors what we saw on Nathan's machine (~30 models)
 # extrapolated up to ~400 with the same vendor mix Deor reported.
 _BIG_CATALOG_VENDORS = {
-    "anthropic": 8, "openai": 30, "google": 12, "moonshotai": 5, "z-ai": 15,
-    "minimax": 10, "qwen": 80, "x-ai": 8, "deepseek": 20, "stepfun": 10,
-    "xiaomi": 6, "tencent": 12, "nvidia": 25, "arcee-ai": 8,
-    "meta-llama": 50, "mistralai": 40, "cohere": 25, "databricks": 15, "lambda-ai": 18,
+    "anthropic": 8,
+    "openai": 30,
+    "google": 12,
+    "moonshotai": 5,
+    "z-ai": 15,
+    "minimax": 10,
+    "qwen": 80,
+    "x-ai": 8,
+    "deepseek": 20,
+    "stepfun": 10,
+    "xiaomi": 6,
+    "tencent": 12,
+    "nvidia": 25,
+    "arcee-ai": 8,
+    "meta-llama": 50,
+    "mistralai": 40,
+    "cohere": 25,
+    "databricks": 15,
+    "lambda-ai": 18,
 }
 
 
@@ -71,11 +86,18 @@ def _install_fake_hermes_cli(
 
     fake_models = types.ModuleType("hermes_cli.models")
     fake_models.list_available_providers = lambda: [
-        {"id": "nous", "label": "Nous Portal", "aliases": [], "authenticated": list_authenticated},
+        {
+            "id": "nous",
+            "label": "Nous Portal",
+            "aliases": [],
+            "authenticated": list_authenticated,
+        },
     ]
     if raise_on_lookup:
+
         def _raise(_pid):
             raise RuntimeError("simulated hermes_cli failure")
+
         fake_models.provider_model_ids = _raise
     else:
         ids = list(nous_ids) if nous_ids is not None else []
@@ -121,14 +143,28 @@ def _swap_in_test_config(extra_cfg):
 def _scrub_provider_env(monkeypatch):
     """Drop every provider env var so detection doesn't leak unrelated keys."""
     for var in (
-        "ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GOOGLE_API_KEY", "GEMINI_API_KEY",
-        "DEEPSEEK_API_KEY", "XAI_API_KEY", "GROQ_API_KEY",
-        "MISTRAL_API_KEY", "OPENROUTER_API_KEY",
-        "OLLAMA_CLOUD_API_KEY", "OLLAMA_API_KEY",
-        "GLM_API_KEY", "KIMI_API_KEY", "MOONSHOT_API_KEY",
-        "MINIMAX_API_KEY", "MINIMAX_CN_API_KEY",
-        "OPENCODE_ZEN_API_KEY", "OPENCODE_GO_API_KEY",
-        "NOUS_API_KEY", "NVIDIA_API_KEY", "LM_API_KEY", "LMSTUDIO_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "OPENAI_API_KEY",
+        "GOOGLE_API_KEY",
+        "GEMINI_API_KEY",
+        "DEEPSEEK_API_KEY",
+        "XAI_API_KEY",
+        "GROQ_API_KEY",
+        "MISTRAL_API_KEY",
+        "OPENROUTER_API_KEY",
+        "OLLAMA_CLOUD_API_KEY",
+        "OLLAMA_API_KEY",
+        "GLM_API_KEY",
+        "KIMI_API_KEY",
+        "MOONSHOT_API_KEY",
+        "MINIMAX_API_KEY",
+        "MINIMAX_CN_API_KEY",
+        "OPENCODE_ZEN_API_KEY",
+        "OPENCODE_GO_API_KEY",
+        "NOUS_API_KEY",
+        "NVIDIA_API_KEY",
+        "LM_API_KEY",
+        "LMSTUDIO_API_KEY",
     ):
         monkeypatch.delenv(var, raising=False)
 
@@ -143,6 +179,7 @@ class TestBuildNousFeaturedSet:
 
     def test_small_catalog_is_no_op(self):
         from api.config import _build_nous_featured_set, _NOUS_FEATURED_THRESHOLD
+
         # 20 entries — below the threshold, helper should return the input
         # untouched and an empty extras list.
         catalog = [f"vendor/model-{i:02d}" for i in range(20)]
@@ -153,6 +190,7 @@ class TestBuildNousFeaturedSet:
 
     def test_large_catalog_is_capped_to_target(self):
         from api.config import _build_nous_featured_set, _NOUS_FEATURED_TARGET
+
         catalog = _build_big_catalog()
         assert len(catalog) > 100, "test fixture should produce a large catalog"
         featured, extras = _build_nous_featured_set(catalog)
@@ -164,6 +202,7 @@ class TestBuildNousFeaturedSet:
 
     def test_featured_and_extras_are_disjoint_and_complete(self):
         from api.config import _build_nous_featured_set
+
         catalog = _build_big_catalog()
         featured, extras = _build_nous_featured_set(catalog)
         assert set(featured) & set(extras) == set(), (
@@ -177,6 +216,7 @@ class TestBuildNousFeaturedSet:
 
     def test_priority_vendors_get_picked_first(self):
         from api.config import _build_nous_featured_set, _NOUS_VENDOR_PRIORITY
+
         catalog = _build_big_catalog()
         featured, _ = _build_nous_featured_set(catalog)
         # Every priority vendor with ≥1 entry in the catalog must appear in
@@ -191,6 +231,7 @@ class TestBuildNousFeaturedSet:
 
     def test_sticky_selection_is_preserved(self):
         from api.config import _build_nous_featured_set
+
         catalog = _build_big_catalog()
         # Pick a model from a leftover (non-priority) vendor that wouldn't
         # normally make the featured cut.
@@ -206,23 +247,27 @@ class TestBuildNousFeaturedSet:
 
     def test_sticky_selection_handles_at_nous_prefix(self):
         from api.config import _build_nous_featured_set
+
         catalog = _build_big_catalog()
         # The frontend stores selections as @nous:vendor/model — helper must
         # strip the prefix to match against the bare-id catalog.
         sticky_with_prefix = "@nous:lambda-ai/model-lambda-ai-15"
         bare = "lambda-ai/model-lambda-ai-15"
-        featured, _ = _build_nous_featured_set(catalog, selected_model_id=sticky_with_prefix)
+        featured, _ = _build_nous_featured_set(
+            catalog, selected_model_id=sticky_with_prefix
+        )
         assert bare in featured
 
     def test_curated_static_flagships_are_preserved(self):
         from api.config import _build_nous_featured_set, _PROVIDER_MODELS
+
         # Build a catalog that contains all the curated static IDs so the
         # rule-2 path fires.
         static_ids = []
         for entry in _PROVIDER_MODELS.get("nous", []):
             sid = entry["id"]
             if sid.startswith("@nous:"):
-                sid = sid[len("@nous:"):]
+                sid = sid[len("@nous:") :]
             static_ids.append(sid)
         catalog = static_ids + [f"filler-vendor/filler-{i:03d}" for i in range(100)]
         featured, _ = _build_nous_featured_set(catalog)
@@ -233,11 +278,13 @@ class TestBuildNousFeaturedSet:
 
     def test_empty_catalog_returns_empty(self):
         from api.config import _build_nous_featured_set
+
         f, e = _build_nous_featured_set([])
         assert f == [] and e == []
 
     def test_deterministic_across_calls(self):
         from api.config import _build_nous_featured_set
+
         catalog = _build_big_catalog()
         f1, e1 = _build_nous_featured_set(catalog)
         f2, e2 = _build_nous_featured_set(catalog)
@@ -268,6 +315,7 @@ class TestApiModelsLargeCatalog:
             assert len(nous_groups) == 1
             grp = nous_groups[0]
             from api.config import _NOUS_FEATURED_TARGET
+
             assert len(grp["models"]) == _NOUS_FEATURED_TARGET, (
                 f"Picker should render {_NOUS_FEATURED_TARGET} featured entries "
                 f"on a {len(catalog)}-model catalog, got {len(grp['models'])}."
@@ -316,7 +364,9 @@ class TestNousDetectionSymmetry:
     """The picker must include Nous whenever the providers card would —
     fixes the asymmetric-detection bug at the heart of #1567."""
 
-    def test_picker_includes_nous_when_get_auth_status_logged_in(self, monkeypatch, tmp_path):
+    def test_picker_includes_nous_when_get_auth_status_logged_in(
+        self, monkeypatch, tmp_path
+    ):
         """list_available_providers() reports authenticated=False but
         get_auth_status('nous').logged_in=True. Picker must still show Nous."""
         _scrub_provider_env(monkeypatch)
@@ -342,7 +392,9 @@ class TestNousDetectionSymmetry:
         finally:
             restore()
 
-    def test_picker_omits_nous_when_both_auth_signals_false(self, monkeypatch, tmp_path):
+    def test_picker_omits_nous_when_both_auth_signals_false(
+        self, monkeypatch, tmp_path
+    ):
         """When neither signal reports authenticated, Nous should NOT appear.
         Previously the static 4-entry list could leak in via the fallback path
         even for unauthenticated users — that fallback is now scoped to the
@@ -444,7 +496,9 @@ class TestProvidersCardPickerSymmetry:
     Nous Portal. This is the load-bearing invariant that ends the visual
     disagreement #1567 reports."""
 
-    def test_providers_card_and_picker_agree_on_featured_set(self, monkeypatch, tmp_path):
+    def test_providers_card_and_picker_agree_on_featured_set(
+        self, monkeypatch, tmp_path
+    ):
         _scrub_provider_env(monkeypatch)
         catalog = _build_big_catalog()
         _install_fake_hermes_cli(monkeypatch, nous_ids=catalog)
@@ -457,7 +511,9 @@ class TestProvidersCardPickerSymmetry:
 
             providers = {p["id"]: p for p in get_providers()["providers"]}
             picker = config.get_available_models()
-            picker_nous = next(g for g in picker["groups"] if g["provider_id"] == "nous")
+            picker_nous = next(
+                g for g in picker["groups"] if g["provider_id"] == "nous"
+            )
 
             card = providers["nous"]
             # Both render exactly _NOUS_FEATURED_TARGET visible models.
@@ -502,7 +558,10 @@ class TestFrontendExtrasContract:
 
     def test_ui_js_hydrates_dynamic_labels_from_extra_models(self):
         from pathlib import Path
-        src = (Path(__file__).resolve().parent.parent / "static" / "ui.js").read_text(encoding="utf-8")
+
+        src = (Path(__file__).resolve().parent.parent / "static" / "ui.js").read_text(
+            encoding="utf-8"
+        )
         # Find the populateModelDropdown function and check it consumes
         # extra_models. Use a windowed substring search so the test stays
         # robust against minor refactors of surrounding code.
@@ -518,7 +577,10 @@ class TestFrontendExtrasContract:
 
     def test_commands_js_loads_slash_args_from_extra_models(self):
         from pathlib import Path
-        src = (Path(__file__).resolve().parent.parent / "static" / "commands.js").read_text(encoding="utf-8")
+
+        src = (
+            Path(__file__).resolve().parent.parent / "static" / "commands.js"
+        ).read_text(encoding="utf-8")
         idx = src.find("async function _loadSlashModelSubArgs")
         assert idx != -1
         body = src[idx : idx + 1500]
@@ -531,7 +593,10 @@ class TestFrontendExtrasContract:
 
     def test_panels_js_uses_models_total_for_count(self):
         from pathlib import Path
-        src = (Path(__file__).resolve().parent.parent / "static" / "panels.js").read_text(encoding="utf-8")
+
+        src = (
+            Path(__file__).resolve().parent.parent / "static" / "panels.js"
+        ).read_text(encoding="utf-8")
         idx = src.find("function _buildProviderCard")
         assert idx != -1
         body = src[idx : idx + 1500]
@@ -544,7 +609,10 @@ class TestFrontendExtrasContract:
 
     def test_panels_js_renders_more_disclosure_pill(self):
         from pathlib import Path
-        src = (Path(__file__).resolve().parent.parent / "static" / "panels.js").read_text(encoding="utf-8")
+
+        src = (
+            Path(__file__).resolve().parent.parent / "static" / "panels.js"
+        ).read_text(encoding="utf-8")
         # The "+N more" disclosure must reference the difference between
         # rendered count and total count somewhere in the providers-card
         # rendering path.

--- a/tests/test_issue1568_duplicate_provider_groups.py
+++ b/tests/test_issue1568_duplicate_provider_groups.py
@@ -79,14 +79,28 @@ def _swap_in_test_config(extra_cfg):
 
 def _scrub_provider_env(monkeypatch):
     for var in (
-        "ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GOOGLE_API_KEY", "GEMINI_API_KEY",
-        "DEEPSEEK_API_KEY", "XAI_API_KEY", "GROQ_API_KEY",
-        "MISTRAL_API_KEY", "OPENROUTER_API_KEY",
-        "OLLAMA_CLOUD_API_KEY", "OLLAMA_API_KEY",
-        "GLM_API_KEY", "KIMI_API_KEY", "MOONSHOT_API_KEY",
-        "MINIMAX_API_KEY", "MINIMAX_CN_API_KEY",
-        "OPENCODE_ZEN_API_KEY", "OPENCODE_GO_API_KEY",
-        "NOUS_API_KEY", "NVIDIA_API_KEY", "LM_API_KEY", "LMSTUDIO_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "OPENAI_API_KEY",
+        "GOOGLE_API_KEY",
+        "GEMINI_API_KEY",
+        "DEEPSEEK_API_KEY",
+        "XAI_API_KEY",
+        "GROQ_API_KEY",
+        "MISTRAL_API_KEY",
+        "OPENROUTER_API_KEY",
+        "OLLAMA_CLOUD_API_KEY",
+        "OLLAMA_API_KEY",
+        "GLM_API_KEY",
+        "KIMI_API_KEY",
+        "MOONSHOT_API_KEY",
+        "MINIMAX_API_KEY",
+        "MINIMAX_CN_API_KEY",
+        "OPENCODE_ZEN_API_KEY",
+        "OPENCODE_GO_API_KEY",
+        "NOUS_API_KEY",
+        "NVIDIA_API_KEY",
+        "LM_API_KEY",
+        "LMSTUDIO_API_KEY",
     ):
         monkeypatch.delenv(var, raising=False)
 
@@ -99,31 +113,39 @@ def _scrub_provider_env(monkeypatch):
 class TestCanonicaliseProviderId:
     def test_canonical_id_preserved(self):
         from api.config import _canonicalise_provider_id
+
         assert _canonicalise_provider_id("opencode-go") == "opencode-go"
         assert _canonicalise_provider_id("anthropic") == "anthropic"
         assert _canonicalise_provider_id("x-ai") == "x-ai"
 
     def test_underscore_folded_to_hyphen(self):
         from api.config import _canonicalise_provider_id
+
         # Deor's exact failure mode — the config-file key uses underscores
         # but every other code path uses the hyphenated canonical form.
         assert _canonicalise_provider_id("opencode_go") == "opencode-go"
 
     def test_case_folded(self):
         from api.config import _canonicalise_provider_id
+
         assert _canonicalise_provider_id("OpenCode-Go") == "opencode-go"
         assert _canonicalise_provider_id("OPENCODE_GO") == "opencode-go"
         assert _canonicalise_provider_id("Anthropic") == "anthropic"
 
     def test_alias_resolved_when_target_is_canonical(self):
         from api.config import _canonicalise_provider_id
+
         # z-ai is an alias for the canonical zai.
         assert _canonicalise_provider_id("z-ai") == "zai"
         assert _canonicalise_provider_id("z_ai") == "zai"
-        assert _canonicalise_provider_id("Z.AI") == "zai" or _canonicalise_provider_id("Z.AI") == "z.ai"
+        assert (
+            _canonicalise_provider_id("Z.AI") == "zai"
+            or _canonicalise_provider_id("Z.AI") == "z.ai"
+        )
 
     def test_alias_not_applied_when_input_is_already_canonical(self):
         from api.config import _canonicalise_provider_id
+
         # x-ai IS the canonical key in _PROVIDER_DISPLAY/_PROVIDER_MODELS.
         # _PROVIDER_ALIASES happens to also map x-ai → xai (for hermes_cli
         # compat), but we must NOT round-trip through that alias because
@@ -133,12 +155,14 @@ class TestCanonicaliseProviderId:
 
     def test_empty_input(self):
         from api.config import _canonicalise_provider_id
+
         assert _canonicalise_provider_id("") == ""
         assert _canonicalise_provider_id(None) == ""
         assert _canonicalise_provider_id("   ") == ""
 
     def test_unknown_id_normalised_but_preserved(self):
         from api.config import _canonicalise_provider_id
+
         # Unknown ids: still get the underscore→hyphen + lowercase fold so
         # downstream dedup works, but no alias resolution.
         assert _canonicalise_provider_id("future_provider") == "future-provider"
@@ -146,10 +170,13 @@ class TestCanonicaliseProviderId:
 
     def test_idempotent(self):
         from api.config import _canonicalise_provider_id
+
         for raw in ("opencode_go", "OPENCODE-GO", "z-ai", "anthropic", "future_x"):
             once = _canonicalise_provider_id(raw)
             twice = _canonicalise_provider_id(once)
-            assert once == twice, f"helper must be idempotent: {raw!r} -> {once!r} -> {twice!r}"
+            assert once == twice, (
+                f"helper must be idempotent: {raw!r} -> {once!r} -> {twice!r}"
+            )
 
 
 # ────────────────────────────────────────────────────────────────────────
@@ -161,21 +188,26 @@ class TestProviderGroupDedup:
     """When config.yaml uses a non-canonical providers.<id> key, the picker
     must still surface ONE provider group, not two."""
 
-    def test_underscored_providers_key_does_not_create_phantom_group(self, monkeypatch, tmp_path):
+    def test_underscored_providers_key_does_not_create_phantom_group(
+        self, monkeypatch, tmp_path
+    ):
         """Deor's exact reproduction case: ``providers.opencode_go.api_key``
         (underscored) with ``model.provider: opencode-go`` (hyphenated)."""
         _scrub_provider_env(monkeypatch)
         _install_fake_hermes_cli(monkeypatch)
         monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
 
-        restore = _swap_in_test_config({
-            "model": {"provider": "opencode-go", "default": "glm-5.1"},
-            "providers": {"opencode_go": {"api_key": "fake-test-key"}},
-        })
+        restore = _swap_in_test_config(
+            {
+                "model": {"provider": "opencode-go", "default": "glm-5.1"},
+                "providers": {"opencode_go": {"api_key": "fake-test-key"}},
+            }
+        )
         try:
             data = config.get_available_models()
             opencode_groups = [
-                g for g in data["groups"]
+                g
+                for g in data["groups"]
                 if "opencode" in (g.get("provider_id") or "").lower()
                 or "opencode" in (g.get("provider") or "").lower()
             ]
@@ -197,20 +229,26 @@ class TestProviderGroupDedup:
         finally:
             restore()
 
-    def test_uppercase_providers_key_does_not_create_phantom_group(self, monkeypatch, tmp_path):
+    def test_uppercase_providers_key_does_not_create_phantom_group(
+        self, monkeypatch, tmp_path
+    ):
         _scrub_provider_env(monkeypatch)
         _install_fake_hermes_cli(monkeypatch)
         monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
 
-        restore = _swap_in_test_config({
-            "model": {"provider": "opencode-go", "default": "glm-5.1"},
-            "providers": {"OPENCODE-GO": {"api_key": "fake"}},
-        })
+        restore = _swap_in_test_config(
+            {
+                "model": {"provider": "opencode-go", "default": "glm-5.1"},
+                "providers": {"OPENCODE-GO": {"api_key": "fake"}},
+            }
+        )
         try:
             data = config.get_available_models()
             opencode_groups = [
-                g for g in data["groups"]
-                if (g.get("provider_id") or "").lower().replace("_", "-") == "opencode-go"
+                g
+                for g in data["groups"]
+                if (g.get("provider_id") or "").lower().replace("_", "-")
+                == "opencode-go"
             ]
             assert len(opencode_groups) == 1
         finally:
@@ -223,14 +261,17 @@ class TestProviderGroupDedup:
         _install_fake_hermes_cli(monkeypatch)
         monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
 
-        restore = _swap_in_test_config({
-            "model": {"provider": "zai", "default": "glm-5"},
-            "providers": {"z-ai": {"api_key": "fake"}},
-        })
+        restore = _swap_in_test_config(
+            {
+                "model": {"provider": "zai", "default": "glm-5"},
+                "providers": {"z-ai": {"api_key": "fake"}},
+            }
+        )
         try:
             data = config.get_available_models()
             zai_groups = [
-                g for g in data["groups"]
+                g
+                for g in data["groups"]
                 if (g.get("provider_id") or "") in ("zai", "z-ai")
             ]
             assert len(zai_groups) == 1, (
@@ -247,15 +288,16 @@ class TestProviderGroupDedup:
         _install_fake_hermes_cli(monkeypatch)
         monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
 
-        restore = _swap_in_test_config({
-            "model": {"provider": "opencode-go", "default": "glm-5.1"},
-            "providers": {"opencode-go": {"api_key": "fake"}},
-        })
+        restore = _swap_in_test_config(
+            {
+                "model": {"provider": "opencode-go", "default": "glm-5.1"},
+                "providers": {"opencode-go": {"api_key": "fake"}},
+            }
+        )
         try:
             data = config.get_available_models()
             opencode_groups = [
-                g for g in data["groups"]
-                if g.get("provider_id") == "opencode-go"
+                g for g in data["groups"] if g.get("provider_id") == "opencode-go"
             ]
             assert len(opencode_groups) == 1
             assert opencode_groups[0]["provider"] == "OpenCode Go"
@@ -274,15 +316,19 @@ class TestDefaultModelProviderIdGuard:
     picker silently injected the provider id as a phantom model option.
     Post-fix the injection is skipped + a warning is logged."""
 
-    def test_provider_id_as_default_does_not_inject_phantom(self, monkeypatch, tmp_path, caplog):
+    def test_provider_id_as_default_does_not_inject_phantom(
+        self, monkeypatch, tmp_path, caplog
+    ):
         _scrub_provider_env(monkeypatch)
         _install_fake_hermes_cli(monkeypatch)
         monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
 
-        restore = _swap_in_test_config({
-            "model": {"provider": "opencode-go", "default": "opencode_go"},
-            "providers": {"opencode-go": {"api_key": "fake"}},
-        })
+        restore = _swap_in_test_config(
+            {
+                "model": {"provider": "opencode-go", "default": "opencode_go"},
+                "providers": {"opencode-go": {"api_key": "fake"}},
+            }
+        )
         try:
             with caplog.at_level("WARNING", logger="api.config"):
                 data = config.get_available_models()
@@ -310,17 +356,21 @@ class TestDefaultModelProviderIdGuard:
         finally:
             restore()
 
-    def test_provider_alias_as_default_does_not_inject_phantom(self, monkeypatch, tmp_path):
+    def test_provider_alias_as_default_does_not_inject_phantom(
+        self, monkeypatch, tmp_path
+    ):
         _scrub_provider_env(monkeypatch)
         _install_fake_hermes_cli(monkeypatch)
         monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
 
         # Z.AI / GLM has display name "Z.AI / GLM", canonical id "zai",
         # alias "z-ai". model.default == "z-ai" should be caught.
-        restore = _swap_in_test_config({
-            "model": {"provider": "zai", "default": "z-ai"},
-            "providers": {"zai": {"api_key": "fake"}},
-        })
+        restore = _swap_in_test_config(
+            {
+                "model": {"provider": "zai", "default": "z-ai"},
+                "providers": {"zai": {"api_key": "fake"}},
+            }
+        )
         try:
             data = config.get_available_models()
             zai = next(g for g in data["groups"] if g.get("provider_id") == "zai")
@@ -338,10 +388,12 @@ class TestDefaultModelProviderIdGuard:
         _install_fake_hermes_cli(monkeypatch)
         monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
 
-        restore = _swap_in_test_config({
-            "model": {"provider": "anthropic", "default": "claude-opus-5.0-future"},
-            "providers": {"anthropic": {"api_key": "fake"}},
-        })
+        restore = _swap_in_test_config(
+            {
+                "model": {"provider": "anthropic", "default": "claude-opus-5.0-future"},
+                "providers": {"anthropic": {"api_key": "fake"}},
+            }
+        )
         try:
             data = config.get_available_models()
             all_ids = {m["id"] for g in data["groups"] for m in g["models"]}
@@ -373,16 +425,19 @@ class TestEmptyGroupFilter:
         _install_fake_hermes_cli(monkeypatch)
         monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
 
-        restore = _swap_in_test_config({
-            "model": {"provider": "opencode-go", "default": "glm-5.1"},
-            "providers": {"opencode_go": {"api_key": "fake"}},
-        })
+        restore = _swap_in_test_config(
+            {
+                "model": {"provider": "opencode-go", "default": "glm-5.1"},
+                "providers": {"opencode_go": {"api_key": "fake"}},
+            }
+        )
         try:
             data = config.get_available_models()
             empty_groups = [g for g in data["groups"] if not g.get("models")]
             # Only custom: groups are allowed to be empty (intentional UX).
             allowed_empty = [
-                g for g in empty_groups
+                g
+                for g in empty_groups
                 if (g.get("provider_id") or "").startswith("custom:")
             ]
             disallowed = [g for g in empty_groups if g not in allowed_empty]
@@ -402,12 +457,14 @@ class TestEmptyGroupFilter:
         _install_fake_hermes_cli(monkeypatch)
         monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
 
-        restore = _swap_in_test_config({
-            "model": {"provider": "custom", "default": "some-model"},
-            "custom_providers": [
-                {"name": "my-empty-provider", "api_key": "fake"},
-            ],
-        })
+        restore = _swap_in_test_config(
+            {
+                "model": {"provider": "custom", "default": "some-model"},
+                "custom_providers": [
+                    {"name": "my-empty-provider", "api_key": "fake"},
+                ],
+            }
+        )
         try:
             data = config.get_available_models()
             # The empty-group filter should NOT drop a custom: provider.

--- a/tests/test_issue1574_cron_profile_lock.py
+++ b/tests/test_issue1574_cron_profile_lock.py
@@ -15,8 +15,12 @@ def _install_fake_cron(monkeypatch, run_job, events):
     cron_jobs.CRON_DIR = cron_jobs.HERMES_DIR / "cron"
     cron_jobs.JOBS_FILE = cron_jobs.CRON_DIR / "jobs.json"
     cron_jobs.OUTPUT_DIR = cron_jobs.CRON_DIR / "output"
-    cron_jobs.save_job_output = lambda job_id, output: events.append(("save", job_id, output))
-    cron_jobs.mark_job_run = lambda job_id, success, error=None: events.append(("mark", job_id, success, error))
+    cron_jobs.save_job_output = lambda job_id, output: events.append(
+        ("save", job_id, output)
+    )
+    cron_jobs.mark_job_run = lambda job_id, success, error=None: events.append(
+        ("mark", job_id, success, error)
+    )
 
     cron_scheduler = types.ModuleType("cron.scheduler")
     cron_scheduler._hermes_home = Path("/tmp/hermes")
@@ -28,7 +32,6 @@ def _install_fake_cron(monkeypatch, run_job, events):
     monkeypatch.setitem(sys.modules, "cron.jobs", cron_jobs)
     monkeypatch.setitem(sys.modules, "cron.scheduler", cron_scheduler)
     return cron_jobs, cron_scheduler
-
 
 
 def _write_spawn_fake_agent(root: Path, *, run_job_body: str):
@@ -65,11 +68,11 @@ def _activate_spawn_fake_agent(fake_agent_root: Path):
         for p in existing.split(os.pathsep)
         if p and ("hermes-agent" not in p or p == fake_path)
     ]
-    os.environ["PYTHONPATH"] = os.pathsep.join([fake_path, *[p for p in parts if p != fake_path]])
+    os.environ["PYTHONPATH"] = os.pathsep.join(
+        [fake_path, *[p for p in parts if p != fake_path]]
+    )
     sys.path[:] = [
-        p
-        for p in sys.path
-        if not p or "hermes-agent" not in p or p == fake_path
+        p for p in sys.path if not p or "hermes-agent" not in p or p == fake_path
     ]
     if fake_path not in sys.path:
         sys.path.insert(0, fake_path)
@@ -107,6 +110,7 @@ def _real_hermes_agent_editable_install_present() -> bool:
     """
     try:
         import importlib.util
+
         spec = importlib.util.find_spec("cron.scheduler")
     except Exception:
         return False
@@ -116,7 +120,11 @@ def _real_hermes_agent_editable_install_present() -> bool:
     # Tests write fake cron.scheduler under tmp_path; tmp paths shouldn't
     # count as a "real" competing install. Treat anything outside common tmp
     # roots as a real install that will out-resolve the fake.
-    tmp_prefixes = ("/tmp/", "/var/folders/", os.path.expandvars("$TMPDIR/") if os.environ.get("TMPDIR") else "")
+    tmp_prefixes = (
+        "/tmp/",
+        "/var/folders/",
+        os.path.expandvars("$TMPDIR/") if os.environ.get("TMPDIR") else "",
+    )
     return not any(p and origin.startswith(p) for p in tmp_prefixes)
 
 
@@ -126,15 +134,16 @@ def _large_cron_payload_runner(profile_home, result_queue):
         _write_spawn_fake_agent(
             fake_agent_root,
             run_job_body=(
-                "    payload = 'x' * 200_000\n"
-                "    return True, payload, payload, None\n"
+                "    payload = 'x' * 200_000\n    return True, payload, payload, None\n"
             ),
         )
         _activate_spawn_fake_agent(fake_agent_root)
         import api.routes as routes
 
-        success, output, final_response, error = routes._run_cron_job_in_profile_subprocess(
-            {"id": "large-payload"}, Path(profile_home)
+        success, output, final_response, error = (
+            routes._run_cron_job_in_profile_subprocess(
+                {"id": "large-payload"}, Path(profile_home)
+            )
         )
         result_queue.put(("ok", success, len(output), len(final_response), error))
     except BaseException as exc:  # pragma: no cover - surfaced in parent process
@@ -156,8 +165,10 @@ def _selected_profile_home_runner(profile_home, result_queue):
         _activate_spawn_fake_agent(fake_agent_root)
         import api.routes as routes
 
-        success, output, final_response, error = routes._run_cron_job_in_profile_subprocess(
-            {"id": "job1574"}, Path(profile_home)
+        success, output, final_response, error = (
+            routes._run_cron_job_in_profile_subprocess(
+                {"id": "job1574"}, Path(profile_home)
+            )
         )
         result_queue.put(("ok", success, output, final_response, error))
     except BaseException as exc:  # pragma: no cover - surfaced in parent process
@@ -168,9 +179,9 @@ def _selected_profile_home_runner(profile_home, result_queue):
 
 def test_manual_cron_subprocess_uses_spawn_context():
     """Manual cron subprocesses must avoid fork-from-threaded-WebUI hazards."""
-    routes_src = (Path(__file__).resolve().parent.parent / "api" / "routes.py").read_text(
-        encoding="utf-8"
-    )
+    routes_src = (
+        Path(__file__).resolve().parent.parent / "api" / "routes.py"
+    ).read_text(encoding="utf-8")
     start = routes_src.find("def _run_cron_job_in_profile_subprocess")
     assert start != -1, "_run_cron_job_in_profile_subprocess not found"
     body = routes_src[start : start + 1200]
@@ -248,6 +259,7 @@ def test_manual_cron_subprocess_drains_large_result_before_join(tmp_path):
     """A >100 KB result must not deadlock the parent before it can persist output."""
     if _real_hermes_agent_editable_install_present():
         import pytest as _pytest
+
         _pytest.skip(
             "skipped on dev machines with an editable hermes-agent install — "
             "the spawn child resolves the real cron.scheduler first instead of "
@@ -287,7 +299,9 @@ def test_manual_cron_subprocess_drains_large_result_before_join(tmp_path):
     assert error is None
 
 
-def test_manual_cron_run_does_not_hold_profile_lock_for_job_duration(tmp_path, monkeypatch):
+def test_manual_cron_run_does_not_hold_profile_lock_for_job_duration(
+    tmp_path, monkeypatch
+):
     """A long manual run must not freeze unrelated cron/profile operations.
 
     The parent WebUI process still needs the cron profile lock for short metadata
@@ -307,8 +321,12 @@ def test_manual_cron_run_does_not_hold_profile_lock_for_job_duration(tmp_path, m
         assert release_run.wait(2), "test timed out waiting to release fake cron run"
         return True, "output", "final", None
 
-    _install_fake_cron(monkeypatch, lambda job: (True, "unused", "unused", None), events)
-    monkeypatch.setattr(routes, "_run_cron_job_in_profile_subprocess", fake_run_job_subprocess)
+    _install_fake_cron(
+        monkeypatch, lambda job: (True, "unused", "unused", None), events
+    )
+    monkeypatch.setattr(
+        routes, "_run_cron_job_in_profile_subprocess", fake_run_job_subprocess
+    )
 
     job_home = tmp_path / "owner"
     exec_home = tmp_path / "exec"
@@ -349,9 +367,12 @@ def test_manual_cron_run_does_not_hold_profile_lock_for_job_duration(tmp_path, m
     assert routes._is_cron_running("job1574") == (False, 0.0)
 
 
-def test_cron_job_subprocess_executes_under_selected_profile_home(tmp_path, monkeypatch):
+def test_cron_job_subprocess_executes_under_selected_profile_home(
+    tmp_path, monkeypatch
+):
     if _real_hermes_agent_editable_install_present():
         import pytest as _pytest
+
         _pytest.skip(
             "skipped on dev machines with an editable hermes-agent install — "
             "the spawn child resolves the real cron.scheduler first instead of "
@@ -371,7 +392,9 @@ def test_cron_job_subprocess_executes_under_selected_profile_home(tmp_path, monk
         runner.join(5)
         result_queue.close()
         result_queue.join_thread()
-        raise AssertionError("manual cron subprocess did not finish selected-profile probe")
+        raise AssertionError(
+            "manual cron subprocess did not finish selected-profile probe"
+        )
 
     try:
         result = result_queue.get(timeout=2)

--- a/tests/test_issue1579_whats_new_link_404.py
+++ b/tests/test_issue1579_whats_new_link_404.py
@@ -16,7 +16,6 @@ Fix:
   suppresses the link rather than emitting a known-broken URL.
 """
 
-import os
 import re
 import subprocess
 import sys
@@ -29,6 +28,7 @@ sys.path.insert(0, str(REPO_ROOT))
 
 # ── 1. Server-side: api.updates._check_repo uses merge-base, not HEAD ──
 
+
 def _make_throwaway_repo(tmp_path, *, local_only_commits=0, upstream_advanced=0):
     """Create a tiny git repo with a fake 'origin' remote.
 
@@ -36,46 +36,76 @@ def _make_throwaway_repo(tmp_path, *, local_only_commits=0, upstream_advanced=0)
     on local HEAD that don't exist on origin (the #1579 trigger). Set
     upstream_advanced>0 to make the remote ahead.
     """
-    upstream = tmp_path / 'upstream.git'
-    subprocess.run(['git', 'init', '--quiet', '--bare', str(upstream)], check=True)
+    upstream = tmp_path / "upstream.git"
+    subprocess.run(["git", "init", "--quiet", "--bare", str(upstream)], check=True)
 
-    seed = tmp_path / 'seed'
-    subprocess.run(['git', 'init', '--quiet', '--initial-branch=master', str(seed)], check=True)
+    seed = tmp_path / "seed"
+    subprocess.run(
+        ["git", "init", "--quiet", "--initial-branch=master", str(seed)], check=True
+    )
     for cmd in [
-        ['git', '-C', str(seed), 'config', 'user.email', 'test@test.test'],
-        ['git', '-C', str(seed), 'config', 'user.name', 'test'],
-        ['git', '-C', str(seed), 'commit', '--allow-empty', '-m', 'initial', '--quiet'],
-        ['git', '-C', str(seed), 'remote', 'add', 'origin', str(upstream)],
-        ['git', '-C', str(seed), 'push', '--quiet', '-u', 'origin', 'master'],
+        ["git", "-C", str(seed), "config", "user.email", "test@test.test"],
+        ["git", "-C", str(seed), "config", "user.name", "test"],
+        ["git", "-C", str(seed), "commit", "--allow-empty", "-m", "initial", "--quiet"],
+        ["git", "-C", str(seed), "remote", "add", "origin", str(upstream)],
+        ["git", "-C", str(seed), "push", "--quiet", "-u", "origin", "master"],
     ]:
         subprocess.run(cmd, check=True)
 
     # Clone FIRST — local and upstream share the initial commit only.
-    local = tmp_path / 'local'
-    subprocess.run(['git', 'clone', '--quiet', str(upstream), str(local)], check=True)
-    subprocess.run(['git', '-C', str(local), 'config', 'user.email', 'test@test.test'], check=True)
-    subprocess.run(['git', '-C', str(local), 'config', 'user.name', 'test'], check=True)
+    local = tmp_path / "local"
+    subprocess.run(["git", "clone", "--quiet", str(upstream), str(local)], check=True)
+    subprocess.run(
+        ["git", "-C", str(local), "config", "user.email", "test@test.test"], check=True
+    )
+    subprocess.run(["git", "-C", str(local), "config", "user.name", "test"], check=True)
 
     # Add local-only commits to the local clone (the #1579 trigger). These never
     # get pushed — they exist only on the local clone's master branch.
     for i in range(local_only_commits):
-        subprocess.run(['git', '-C', str(local), 'commit', '--allow-empty',
-                        '-m', f'local-only commit {i}', '--quiet'], check=True)
+        subprocess.run(
+            [
+                "git",
+                "-C",
+                str(local),
+                "commit",
+                "--allow-empty",
+                "-m",
+                f"local-only commit {i}",
+                "--quiet",
+            ],
+            check=True,
+        )
 
     # Advance upstream by committing on the seed and pushing — so local clone
     # is now `upstream_advanced` commits behind on the remote-tracking branch.
     for i in range(upstream_advanced):
-        subprocess.run(['git', '-C', str(seed), 'commit', '--allow-empty',
-                        '-m', f'upstream commit {i}', '--quiet'], check=True)
+        subprocess.run(
+            [
+                "git",
+                "-C",
+                str(seed),
+                "commit",
+                "--allow-empty",
+                "-m",
+                f"upstream commit {i}",
+                "--quiet",
+            ],
+            check=True,
+        )
     if upstream_advanced:
-        subprocess.run(['git', '-C', str(seed), 'push', '--quiet'], check=True)
+        subprocess.run(["git", "-C", str(seed), "push", "--quiet"], check=True)
 
     return local
 
 
 def _short_sha(repo, ref):
-    out = subprocess.run(['git', '-C', str(repo), 'rev-parse', '--short', ref],
-                         capture_output=True, text=True, check=True)
+    out = subprocess.run(
+        ["git", "-C", str(repo), "rev-parse", "--short", ref],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
     return out.stdout.strip()
 
 
@@ -87,44 +117,48 @@ def test_current_sha_is_merge_base_not_local_HEAD(tmp_path, monkeypatch):
     """
     # Clear cached config (api.updates may import HERMES_HOME at import time)
     repo = _make_throwaway_repo(
-        tmp_path, local_only_commits=2, upstream_advanced=3,
+        tmp_path,
+        local_only_commits=2,
+        upstream_advanced=3,
     )
 
-    head_sha = _short_sha(repo, 'HEAD')
-    expected_base = _short_sha(repo, 'HEAD~2')  # merge-base in this scenario
+    head_sha = _short_sha(repo, "HEAD")
+    expected_base = _short_sha(repo, "HEAD~2")  # merge-base in this scenario
 
     # Import updates with a stable CWD
-    if 'api.updates' in sys.modules:
-        del sys.modules['api.updates']
+    if "api.updates" in sys.modules:
+        del sys.modules["api.updates"]
     from api import updates as upd
 
-    result = upd._check_repo(repo, 'webui')
+    result = upd._check_repo(repo, "webui")
 
     assert result is not None, "non-bare repo with origin should return a result"
-    assert result['behind'] == 3, f"expected 3 commits behind, got {result['behind']}"
+    assert result["behind"] == 3, f"expected 3 commits behind, got {result['behind']}"
 
     # The core fix: current_sha must be the merge-base, not local HEAD.
     # merge-base = HEAD~2 in this scenario (local has 2 unpushed commits,
     # so the most recent shared point with upstream is 2 commits before HEAD).
-    assert result['current_sha'] == expected_base, (
+    assert result["current_sha"] == expected_base, (
         f"current_sha should be merge-base ({expected_base}), got {result['current_sha']} "
         f"(local HEAD is {head_sha}). Old #1579 bug regressed."
     )
-    assert result['current_sha'] != head_sha, (
+    assert result["current_sha"] != head_sha, (
         f"current_sha must NOT be local HEAD ({head_sha}) — that's the #1579 bug."
     )
     # latest_sha is what _check_repo's own fetch+rev-parse returns
-    assert result['latest_sha'], "latest_sha must be populated"
+    assert result["latest_sha"], "latest_sha must be populated"
     # Critical compare-URL property: current_sha and latest_sha both correspond
     # to commits the upstream knows about (one by being upstream tip, the other
     # by being a shared ancestor). The merge-base is verifiable via the local
     # clone's remote-tracking branch:
     upstream_history = subprocess.run(
-        ['git', '-C', str(repo), 'log', '--format=%h', 'origin/master'],
-        capture_output=True, text=True, check=True,
+        ["git", "-C", str(repo), "log", "--format=%h", "origin/master"],
+        capture_output=True,
+        text=True,
+        check=True,
     ).stdout.split()
-    assert result['current_sha'] in upstream_history or any(
-        h.startswith(result['current_sha']) for h in upstream_history
+    assert result["current_sha"] in upstream_history or any(
+        h.startswith(result["current_sha"]) for h in upstream_history
     ), (
         f"current_sha ({result['current_sha']}) must be present in upstream history "
         f"— that's what guarantees the GitHub /compare/ URL won't 404."
@@ -138,17 +172,18 @@ def test_current_sha_equals_HEAD_when_no_local_commits(tmp_path):
     we shipped before #1579.
     """
     repo = _make_throwaway_repo(tmp_path, local_only_commits=0, upstream_advanced=4)
-    if 'api.updates' in sys.modules:
-        del sys.modules['api.updates']
+    if "api.updates" in sys.modules:
+        del sys.modules["api.updates"]
     from api import updates as upd
-    result = upd._check_repo(repo, 'webui')
 
-    head_sha = _short_sha(repo, 'HEAD')
-    assert result['current_sha'] == head_sha, (
+    result = upd._check_repo(repo, "webui")
+
+    head_sha = _short_sha(repo, "HEAD")
+    assert result["current_sha"] == head_sha, (
         "Pure-behind clone: merge-base equals HEAD; URL should be unchanged "
         "from pre-#1579 behavior."
     )
-    assert result['behind'] == 4
+    assert result["behind"] == 4
 
 
 def test_current_sha_falls_back_to_None_when_merge_base_fails(tmp_path):
@@ -157,34 +192,35 @@ def test_current_sha_falls_back_to_None_when_merge_base_fails(tmp_path):
     rather than emitting one that 404s.
     """
     repo = _make_throwaway_repo(tmp_path, local_only_commits=0, upstream_advanced=1)
-    if 'api.updates' in sys.modules:
-        del sys.modules['api.updates']
+    if "api.updates" in sys.modules:
+        del sys.modules["api.updates"]
     from api import updates as upd
 
     # Patch _run_git so any 'merge-base' call returns failure
     real_run = upd._run_git
 
     def fake_run(args, *a, **kw):
-        if args and args[0] == 'merge-base':
-            return ('', False)
+        if args and args[0] == "merge-base":
+            return ("", False)
         return real_run(args, *a, **kw)
 
-    with patch.object(upd, '_run_git', side_effect=fake_run):
-        result = upd._check_repo(repo, 'webui')
+    with patch.object(upd, "_run_git", side_effect=fake_run):
+        result = upd._check_repo(repo, "webui")
 
     assert result is not None
-    assert result['current_sha'] is None, (
+    assert result["current_sha"] is None, (
         "merge-base failure must fall back to None so JS suppresses the link "
         "(emitting a known-broken URL is worse than no link)."
     )
     # latest_sha should still be populated — that path doesn't depend on merge-base
-    assert result['latest_sha']
+    assert result["latest_sha"]
 
 
 # ── 2. Client-side: ui.js link guard suppresses URL on null current_sha ──
 
+
 def _read_ui_js():
-    return (REPO_ROOT / 'static' / 'ui.js').read_text(encoding='utf-8')
+    return (REPO_ROOT / "static" / "ui.js").read_text(encoding="utf-8")
 
 
 def test_whats_new_link_resets_display_and_href_on_every_render():
@@ -193,9 +229,9 @@ def test_whats_new_link_resets_display_and_href_on_every_render():
     """
     src = _read_ui_js()
     # Find the "What's new" wiring block (~50-line window)
-    idx = src.find("Wire up \"What's new?\" link")
+    idx = src.find('Wire up "What\'s new?" link')
     assert idx != -1, "What's-new link wiring block not found"
-    block = src[idx:idx + 800]
+    block = src[idx : idx + 800]
 
     # Reset must happen BEFORE the conditional href set
     reset_idx = block.find("style.display='none'")
@@ -212,10 +248,10 @@ def test_whats_new_link_resets_display_and_href_on_every_render():
 def test_whats_new_link_suppressed_when_curSha_falsy():
     """The conditional must guard on all three of repoUrl/curSha/newSha."""
     src = _read_ui_js()
-    idx = src.find("Wire up \"What's new?\" link")
-    block = src[idx:idx + 800]
+    idx = src.find('Wire up "What\'s new?" link')
+    block = src[idx : idx + 800]
     # Match "if(repoUrl && curSha && newSha)" with arbitrary whitespace
-    pattern = re.compile(r'if\s*\(\s*repoUrl\s*&&\s*curSha\s*&&\s*newSha\s*\)')
+    pattern = re.compile(r"if\s*\(\s*repoUrl\s*&&\s*curSha\s*&&\s*newSha\s*\)")
     assert pattern.search(block), (
         "Link must require all three of repoUrl, curSha, newSha to be truthy. "
         "If any is null/empty, link stays display:none."
@@ -224,22 +260,24 @@ def test_whats_new_link_suppressed_when_curSha_falsy():
 
 # ── 3. End-to-end: simulate the exact reporter URL shape ──
 
+
 def test_reporter_url_shape_no_longer_produces_invalid_compare_url(tmp_path):
     """Reporter saw https://github.com/.../compare/c660c7f...86cb22e where
     c660c7f was an unpublished local SHA. After fix, the URL should use
     a SHA that exists upstream.
     """
     repo = _make_throwaway_repo(tmp_path, local_only_commits=2, upstream_advanced=5)
-    if 'api.updates' in sys.modules:
-        del sys.modules['api.updates']
+    if "api.updates" in sys.modules:
+        del sys.modules["api.updates"]
     from api import updates as upd
-    result = upd._check_repo(repo, 'webui')
 
-    head_sha = _short_sha(repo, 'HEAD')
-    base_sha = _short_sha(repo, 'HEAD~2')  # the merge-base
+    result = upd._check_repo(repo, "webui")
+
+    head_sha = _short_sha(repo, "HEAD")
+    base_sha = _short_sha(repo, "HEAD~2")  # the merge-base
 
     # The compare URL the JS would build
-    cur, latest = result['current_sha'], result['latest_sha']
+    cur, latest = result["current_sha"], result["latest_sha"]
     # In a real run repo_url is converted from origin's URL; in this test the
     # value will be a file:// path, but that's fine — what we care about is
     # the cur and latest shas.

--- a/tests/test_issue1611_session_profile_filtering.py
+++ b/tests/test_issue1611_session_profile_filtering.py
@@ -25,15 +25,17 @@ import pytest
 def test_profiles_match_exact():
     """Same name on both sides matches."""
     from api.routes import _profiles_match
-    assert _profiles_match('haku', 'haku') is True
-    assert _profiles_match('default', 'default') is True
+
+    assert _profiles_match("haku", "haku") is True
+    assert _profiles_match("default", "default") is True
 
 
 def test_profiles_match_distinct_named_profiles():
     """Different named profiles do not cross-match."""
     from api.routes import _profiles_match
-    assert _profiles_match('haku', 'kinni') is False
-    assert _profiles_match('noblepro', 'haku') is False
+
+    assert _profiles_match("haku", "kinni") is False
+    assert _profiles_match("noblepro", "haku") is False
 
 
 def test_profiles_match_default_alias_treated_as_root(monkeypatch):
@@ -43,16 +45,20 @@ def test_profiles_match_default_alias_treated_as_root(monkeypatch):
     import api.profiles as p
     from api.routes import _profiles_match
 
-    monkeypatch.setattr(p, 'list_profiles_api', lambda: [
-        {'name': 'kinni', 'is_default': True, 'path': str(p._DEFAULT_HERMES_HOME)},
-    ])
+    monkeypatch.setattr(
+        p,
+        "list_profiles_api",
+        lambda: [
+            {"name": "kinni", "is_default": True, "path": str(p._DEFAULT_HERMES_HOME)},
+        ],
+    )
     p._invalidate_root_profile_cache()
 
-    assert _profiles_match('default', 'kinni') is True
-    assert _profiles_match('kinni', 'default') is True
+    assert _profiles_match("default", "kinni") is True
+    assert _profiles_match("kinni", "default") is True
     # And neither matches a true named profile
-    assert _profiles_match('default', 'haku') is False
-    assert _profiles_match('kinni', 'haku') is False
+    assert _profiles_match("default", "haku") is False
+    assert _profiles_match("kinni", "haku") is False
 
 
 def test_profiles_match_empty_row_treated_as_root():
@@ -63,16 +69,18 @@ def test_profiles_match_empty_row_treated_as_root():
     to 'default' for such rows.
     """
     from api.routes import _profiles_match
-    assert _profiles_match(None, 'default') is True
-    assert _profiles_match('', 'default') is True
-    assert _profiles_match(None, 'haku') is False
+
+    assert _profiles_match(None, "default") is True
+    assert _profiles_match("", "default") is True
+    assert _profiles_match(None, "haku") is False
 
 
 def test_profiles_match_active_none_treated_as_default():
     """If active profile resolves to None/empty (boot edge case), treat as 'default'."""
     from api.routes import _profiles_match
-    assert _profiles_match('default', None) is True
-    assert _profiles_match('default', '') is True
+
+    assert _profiles_match("default", None) is True
+    assert _profiles_match("default", "") is True
 
 
 # ── _all_profiles_query_flag ───────────────────────────────────────────────
@@ -81,16 +89,22 @@ def test_profiles_match_active_none_treated_as_default():
 def test_all_profiles_query_flag_true_values():
     """1, true, yes, on (case-insensitive) all enable aggregate mode."""
     from api.routes import _all_profiles_query_flag
-    for v in ('1', 'true', 'TRUE', 'yes', 'YES', 'on'):
-        u = urlparse(f'/api/sessions?all_profiles={v}')
+
+    for v in ("1", "true", "TRUE", "yes", "YES", "on"):
+        u = urlparse(f"/api/sessions?all_profiles={v}")
         assert _all_profiles_query_flag(u) is True, f"value {v!r} should be true"
 
 
 def test_all_profiles_query_flag_false_values():
     """0, empty, garbage, missing — all default to scoped mode (False)."""
     from api.routes import _all_profiles_query_flag
-    for path in ('/api/sessions', '/api/sessions?all_profiles=0',
-                 '/api/sessions?all_profiles=', '/api/sessions?all_profiles=lol'):
+
+    for path in (
+        "/api/sessions",
+        "/api/sessions?all_profiles=0",
+        "/api/sessions?all_profiles=",
+        "/api/sessions?all_profiles=lol",
+    ):
         u = urlparse(path)
         assert _all_profiles_query_flag(u) is False, f"path {path!r} should be false"
 
@@ -110,7 +124,7 @@ def test_static_sessions_js_no_cli_session_bypass():
     from pathlib import Path
 
     repo_root = Path(__file__).parent.parent
-    src = (repo_root / 'static' / 'sessions.js').read_text(encoding='utf-8')
+    src = (repo_root / "static" / "sessions.js").read_text(encoding="utf-8")
 
     assert "s.is_cli_session||s.profile===S.activeProfile" not in src, (
         "Old CLI-session bypass must be removed (#1611)"
@@ -129,7 +143,7 @@ def test_static_sessions_js_uses_all_profiles_query_when_toggle_on():
     from pathlib import Path
 
     repo_root = Path(__file__).parent.parent
-    src = (repo_root / 'static' / 'sessions.js').read_text(encoding='utf-8')
+    src = (repo_root / "static" / "sessions.js").read_text(encoding="utf-8")
 
     assert "_showAllProfiles ? '?all_profiles=1' : ''" in src, (
         "Expected fetch path to flip on the toggle state"
@@ -156,7 +170,7 @@ def test_keep_latest_messaging_runs_after_profile_filter():
     from pathlib import Path
 
     repo_root = Path(__file__).parent.parent
-    src = (repo_root / 'api' / 'routes.py').read_text(encoding='utf-8')
+    src = (repo_root / "api" / "routes.py").read_text(encoding="utf-8")
 
     handler_idx = src.find('parsed.path == "/api/sessions":')
     assert handler_idx > 0
@@ -164,7 +178,7 @@ def test_keep_latest_messaging_runs_after_profile_filter():
     block = src[handler_idx:next_handler]
 
     filter_idx = block.find('_profiles_match(s.get("profile"), active_profile)')
-    dedupe_idx = block.find('_keep_latest_messaging_session_per_source(scoped)')
+    dedupe_idx = block.find("_keep_latest_messaging_session_per_source(scoped)")
     assert filter_idx > 0, "Profile filter not found in /api/sessions handler"
     assert dedupe_idx > 0, "Messaging dedupe must run on the scoped list"
     assert filter_idx < dedupe_idx, (
@@ -189,10 +203,12 @@ def test_static_sessions_js_trusts_server_profile_scoping():
     from pathlib import Path
 
     repo_root = Path(__file__).parent.parent
-    src = (repo_root / 'static' / 'sessions.js').read_text(encoding='utf-8')
+    src = (repo_root / "static" / "sessions.js").read_text(encoding="utf-8")
 
     # The fragile client-side strict-equality filter must be gone.
-    forbidden = "withMessages.filter(s=>(s.profile||'default')===(S.activeProfile||'default'))"
+    forbidden = (
+        "withMessages.filter(s=>(s.profile||'default')===(S.activeProfile||'default'))"
+    )
     assert forbidden not in src, (
         "Client must not re-filter rows the server already cross-aliased "
         "(Opus pre-release SHOULD-FIX #1)"
@@ -211,6 +227,7 @@ def test_static_sessions_js_trusts_server_profile_scoping():
 @pytest.fixture(autouse=True)
 def _invalidate_profile_cache():
     import api.profiles as p
+
     p._invalidate_root_profile_cache()
     yield
     p._invalidate_root_profile_cache()

--- a/tests/test_issue1612_renamed_root_profile.py
+++ b/tests/test_issue1612_renamed_root_profile.py
@@ -11,10 +11,6 @@ Fix: centralize the "is this the root?" check in `_is_root_profile(name)`
 and replace each scattered `if name == 'default':` with it.
 """
 
-import os
-from pathlib import Path
-from unittest.mock import patch
-
 import pytest
 
 
@@ -24,14 +20,16 @@ import pytest
 def test_is_root_profile_default_alias():
     """Legacy 'default' literal always resolves as root, regardless of cache state."""
     import api.profiles as p
+
     p._invalidate_root_profile_cache()
-    assert p._is_root_profile('default') is True
+    assert p._is_root_profile("default") is True
 
 
 def test_is_root_profile_empty_or_none_is_false():
     """Empty/None name is NOT root — caller code decides what to do."""
     import api.profiles as p
-    assert p._is_root_profile('') is False
+
+    assert p._is_root_profile("") is False
     assert p._is_root_profile(None) is False
 
 
@@ -39,32 +37,38 @@ def test_is_root_profile_renamed_root_via_list_profiles_api(monkeypatch):
     """A profile name reported by list_profiles_api with is_default=True is treated as root."""
     import api.profiles as p
 
-    monkeypatch.setattr(p, 'list_profiles_api', lambda: [
-        {'name': 'kinni', 'is_default': True, 'path': str(p._DEFAULT_HERMES_HOME)},
-        {'name': 'haku', 'is_default': False, 'path': '/tmp/profiles/haku'},
-    ])
+    monkeypatch.setattr(
+        p,
+        "list_profiles_api",
+        lambda: [
+            {"name": "kinni", "is_default": True, "path": str(p._DEFAULT_HERMES_HOME)},
+            {"name": "haku", "is_default": False, "path": "/tmp/profiles/haku"},
+        ],
+    )
     p._invalidate_root_profile_cache()
 
-    assert p._is_root_profile('kinni') is True
-    assert p._is_root_profile('haku') is False
-    assert p._is_root_profile('default') is True
+    assert p._is_root_profile("kinni") is True
+    assert p._is_root_profile("haku") is False
+    assert p._is_root_profile("default") is True
 
 
 def test_is_root_profile_caches_results(monkeypatch):
     """Repeated calls don't re-invoke list_profiles_api — once-per-mutation memoization."""
     import api.profiles as p
 
-    calls = {'n': 0}
+    calls = {"n": 0}
+
     def fake_list():
-        calls['n'] += 1
-        return [{'name': 'kinni', 'is_default': True, 'path': '/tmp/.hermes'}]
-    monkeypatch.setattr(p, 'list_profiles_api', fake_list)
+        calls["n"] += 1
+        return [{"name": "kinni", "is_default": True, "path": "/tmp/.hermes"}]
+
+    monkeypatch.setattr(p, "list_profiles_api", fake_list)
     p._invalidate_root_profile_cache()
 
-    p._is_root_profile('kinni')
-    p._is_root_profile('kinni')
-    p._is_root_profile('haku')
-    assert calls['n'] == 1, "Cache should be hit after first lookup"
+    p._is_root_profile("kinni")
+    p._is_root_profile("kinni")
+    p._is_root_profile("haku")
+    assert calls["n"] == 1, "Cache should be hit after first lookup"
 
 
 def test_is_root_profile_invalidation_drops_stale(monkeypatch):
@@ -72,20 +76,20 @@ def test_is_root_profile_invalidation_drops_stale(monkeypatch):
     import api.profiles as p
 
     seq = [
-        [{'name': 'kinni', 'is_default': True, 'path': '/tmp/.hermes'}],
-        [{'name': 'noblepro', 'is_default': True, 'path': '/tmp/.hermes'}],
+        [{"name": "kinni", "is_default": True, "path": "/tmp/.hermes"}],
+        [{"name": "noblepro", "is_default": True, "path": "/tmp/.hermes"}],
     ]
-    monkeypatch.setattr(p, 'list_profiles_api', lambda: seq[0] if seq else [])
+    monkeypatch.setattr(p, "list_profiles_api", lambda: seq[0] if seq else [])
 
     p._invalidate_root_profile_cache()
-    assert p._is_root_profile('kinni') is True
-    assert p._is_root_profile('noblepro') is False
+    assert p._is_root_profile("kinni") is True
+    assert p._is_root_profile("noblepro") is False
 
     # Simulate rename — drop first state, second is now the truth
     seq.pop(0)
     p._invalidate_root_profile_cache()
-    assert p._is_root_profile('kinni') is False
-    assert p._is_root_profile('noblepro') is True
+    assert p._is_root_profile("kinni") is False
+    assert p._is_root_profile("noblepro") is True
 
 
 def test_is_root_profile_handles_list_profiles_failure(monkeypatch):
@@ -94,13 +98,14 @@ def test_is_root_profile_handles_list_profiles_failure(monkeypatch):
 
     def boom():
         raise RuntimeError("hermes_cli explosion")
-    monkeypatch.setattr(p, 'list_profiles_api', boom)
+
+    monkeypatch.setattr(p, "list_profiles_api", boom)
     p._invalidate_root_profile_cache()
 
     # 'default' still works (handled before list_profiles_api call).
-    assert p._is_root_profile('default') is True
+    assert p._is_root_profile("default") is True
     # Other names return False on failure.
-    assert p._is_root_profile('kinni') is False
+    assert p._is_root_profile("kinni") is False
 
 
 # ── get_active_hermes_home: returns _DEFAULT_HERMES_HOME for renamed root ──
@@ -111,30 +116,40 @@ def test_get_active_hermes_home_returns_default_for_renamed_root(tmp_path, monke
     not _DEFAULT_HERMES_HOME / 'profiles' / <name>."""
     import api.profiles as p
 
-    monkeypatch.setattr(p, '_DEFAULT_HERMES_HOME', tmp_path)
-    monkeypatch.setattr(p, 'list_profiles_api', lambda: [
-        {'name': 'kinni', 'is_default': True, 'path': str(tmp_path)},
-    ])
+    monkeypatch.setattr(p, "_DEFAULT_HERMES_HOME", tmp_path)
+    monkeypatch.setattr(
+        p,
+        "list_profiles_api",
+        lambda: [
+            {"name": "kinni", "is_default": True, "path": str(tmp_path)},
+        ],
+    )
     p._invalidate_root_profile_cache()
-    monkeypatch.setattr(p, '_active_profile', 'kinni')
+    monkeypatch.setattr(p, "_active_profile", "kinni")
 
     result = p.get_active_hermes_home()
     assert result == tmp_path, f"Expected {tmp_path}, got {result}"
 
 
-def test_get_active_hermes_home_returns_named_for_real_named_profile(tmp_path, monkeypatch):
+def test_get_active_hermes_home_returns_named_for_real_named_profile(
+    tmp_path, monkeypatch
+):
     """Backward compat: a real named (non-default) profile still resolves to profiles/<name>."""
     import api.profiles as p
 
-    profile_dir = tmp_path / 'profiles' / 'haku'
+    profile_dir = tmp_path / "profiles" / "haku"
     profile_dir.mkdir(parents=True)
-    monkeypatch.setattr(p, '_DEFAULT_HERMES_HOME', tmp_path)
-    monkeypatch.setattr(p, 'list_profiles_api', lambda: [
-        {'name': 'kinni', 'is_default': True, 'path': str(tmp_path)},
-        {'name': 'haku', 'is_default': False, 'path': str(profile_dir)},
-    ])
+    monkeypatch.setattr(p, "_DEFAULT_HERMES_HOME", tmp_path)
+    monkeypatch.setattr(
+        p,
+        "list_profiles_api",
+        lambda: [
+            {"name": "kinni", "is_default": True, "path": str(tmp_path)},
+            {"name": "haku", "is_default": False, "path": str(profile_dir)},
+        ],
+    )
     p._invalidate_root_profile_cache()
-    monkeypatch.setattr(p, '_active_profile', 'haku')
+    monkeypatch.setattr(p, "_active_profile", "haku")
 
     result = p.get_active_hermes_home()
     assert result == profile_dir
@@ -143,7 +158,9 @@ def test_get_active_hermes_home_returns_named_for_real_named_profile(tmp_path, m
 # ── switch_profile: accepts renamed root display name ─────────────────────
 
 
-def test_switch_profile_resolution_renamed_root_picks_default_home(tmp_path, monkeypatch):
+def test_switch_profile_resolution_renamed_root_picks_default_home(
+    tmp_path, monkeypatch
+):
     """switch_profile()'s resolution branch: a renamed root must select
     _DEFAULT_HERMES_HOME, not raise 'Profile <name> does not exist.'
 
@@ -153,14 +170,18 @@ def test_switch_profile_resolution_renamed_root_picks_default_home(tmp_path, mon
     """
     import api.profiles as p
 
-    monkeypatch.setattr(p, '_DEFAULT_HERMES_HOME', tmp_path)
-    monkeypatch.setattr(p, 'list_profiles_api', lambda: [
-        {'name': 'kinni', 'is_default': True, 'path': str(tmp_path)},
-    ])
+    monkeypatch.setattr(p, "_DEFAULT_HERMES_HOME", tmp_path)
+    monkeypatch.setattr(
+        p,
+        "list_profiles_api",
+        lambda: [
+            {"name": "kinni", "is_default": True, "path": str(tmp_path)},
+        ],
+    )
     p._invalidate_root_profile_cache()
 
     # Mirror switch_profile's resolution logic
-    name = 'kinni'
+    name = "kinni"
     if p._is_root_profile(name):
         home = p._DEFAULT_HERMES_HOME
     else:
@@ -171,7 +192,7 @@ def test_switch_profile_resolution_renamed_root_picks_default_home(tmp_path, mon
 
     # Sanity: a TRULY missing profile still raises (backward compat)
     with pytest.raises(ValueError, match="does not exist"):
-        name = 'phantom'
+        name = "phantom"
         if p._is_root_profile(name):
             home = p._DEFAULT_HERMES_HOME
         else:
@@ -188,32 +209,40 @@ def test_switch_profile_sticky_marker_renamed_root(tmp_path, monkeypatch):
     is the only correct location for the renamed-root case."""
     import api.profiles as p
 
-    monkeypatch.setattr(p, '_DEFAULT_HERMES_HOME', tmp_path)
-    monkeypatch.setattr(p, 'list_profiles_api', lambda: [
-        {'name': 'kinni', 'is_default': True, 'path': str(tmp_path)},
-    ])
+    monkeypatch.setattr(p, "_DEFAULT_HERMES_HOME", tmp_path)
+    monkeypatch.setattr(
+        p,
+        "list_profiles_api",
+        lambda: [
+            {"name": "kinni", "is_default": True, "path": str(tmp_path)},
+        ],
+    )
     p._invalidate_root_profile_cache()
 
     # Mirror the sticky-write line directly — guards that the new ternary
     # uses _is_root_profile, not the literal-'default' compare.
-    written = '' if p._is_root_profile('kinni') else 'kinni'
-    assert written == ''
-    written2 = '' if p._is_root_profile('haku') else 'haku'
-    assert written2 == 'haku' 
+    written = "" if p._is_root_profile("kinni") else "kinni"
+    assert written == ""
+    written2 = "" if p._is_root_profile("haku") else "haku"
+    assert written2 == "haku"
 
 
 def test_delete_profile_blocks_renamed_root(tmp_path, monkeypatch):
     """delete_profile_api on a renamed root must refuse, same as 'default'."""
     import api.profiles as p
 
-    monkeypatch.setattr(p, '_DEFAULT_HERMES_HOME', tmp_path)
-    monkeypatch.setattr(p, 'list_profiles_api', lambda: [
-        {'name': 'kinni', 'is_default': True, 'path': str(tmp_path)},
-    ])
+    monkeypatch.setattr(p, "_DEFAULT_HERMES_HOME", tmp_path)
+    monkeypatch.setattr(
+        p,
+        "list_profiles_api",
+        lambda: [
+            {"name": "kinni", "is_default": True, "path": str(tmp_path)},
+        ],
+    )
     p._invalidate_root_profile_cache()
 
     with pytest.raises(ValueError, match="Cannot delete the default profile"):
-        p.delete_profile_api('kinni')
+        p.delete_profile_api("kinni")
 
 
 # ── Cleanup: invalidate cache between tests so they don't leak ─────────────
@@ -222,6 +251,7 @@ def test_delete_profile_blocks_renamed_root(tmp_path, monkeypatch):
 @pytest.fixture(autouse=True)
 def _invalidate_cache_around_test():
     import api.profiles as p
+
     p._invalidate_root_profile_cache()
     yield
     p._invalidate_root_profile_cache()

--- a/tests/test_issue1614_project_profile_filtering.py
+++ b/tests/test_issue1614_project_profile_filtering.py
@@ -17,7 +17,6 @@ Fix:
 import json
 import threading
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 
@@ -31,26 +30,26 @@ def test_ensure_cron_project_creates_per_profile(tmp_path, monkeypatch):
     import api.models as models
     import api.profiles as profiles
 
-    projects_file = tmp_path / 'projects.json'
-    monkeypatch.setattr(cfg, 'PROJECTS_FILE', projects_file)
-    monkeypatch.setattr(models, 'PROJECTS_FILE', projects_file)
-    monkeypatch.setattr(models, '_projects_migrated', True)
-    monkeypatch.setattr(models, '_CRON_PROJECT_LOCK', threading.Lock())
+    projects_file = tmp_path / "projects.json"
+    monkeypatch.setattr(cfg, "PROJECTS_FILE", projects_file)
+    monkeypatch.setattr(models, "PROJECTS_FILE", projects_file)
+    monkeypatch.setattr(models, "_projects_migrated", True)
+    monkeypatch.setattr(models, "_CRON_PROJECT_LOCK", threading.Lock())
     profiles._invalidate_root_profile_cache()
-    monkeypatch.setattr(profiles, 'list_profiles_api', lambda: [])
+    monkeypatch.setattr(profiles, "list_profiles_api", lambda: [])
 
-    monkeypatch.setattr(profiles, '_active_profile', 'haku')
+    monkeypatch.setattr(profiles, "_active_profile", "haku")
     pid_haku = models.ensure_cron_project()
-    monkeypatch.setattr(profiles, '_active_profile', 'kinni')
+    monkeypatch.setattr(profiles, "_active_profile", "kinni")
     pid_kinni = models.ensure_cron_project()
 
     assert pid_haku != pid_kinni, "Per-profile cron projects must have distinct ids"
 
     # Verify on disk
     saved = json.loads(projects_file.read_text())
-    cron_rows = [p for p in saved if p['name'] == 'Cron Jobs']
+    cron_rows = [p for p in saved if p["name"] == "Cron Jobs"]
     assert len(cron_rows) == 2
-    assert {r['profile'] for r in cron_rows} == {'haku', 'kinni'}
+    assert {r["profile"] for r in cron_rows} == {"haku", "kinni"}
 
 
 def test_ensure_cron_project_idempotent_per_profile(tmp_path, monkeypatch):
@@ -59,14 +58,14 @@ def test_ensure_cron_project_idempotent_per_profile(tmp_path, monkeypatch):
     import api.models as models
     import api.profiles as profiles
 
-    projects_file = tmp_path / 'projects.json'
-    monkeypatch.setattr(cfg, 'PROJECTS_FILE', projects_file)
-    monkeypatch.setattr(models, 'PROJECTS_FILE', projects_file)
-    monkeypatch.setattr(models, '_projects_migrated', True)
-    monkeypatch.setattr(models, '_CRON_PROJECT_LOCK', threading.Lock())
+    projects_file = tmp_path / "projects.json"
+    monkeypatch.setattr(cfg, "PROJECTS_FILE", projects_file)
+    monkeypatch.setattr(models, "PROJECTS_FILE", projects_file)
+    monkeypatch.setattr(models, "_projects_migrated", True)
+    monkeypatch.setattr(models, "_CRON_PROJECT_LOCK", threading.Lock())
     profiles._invalidate_root_profile_cache()
-    monkeypatch.setattr(profiles, 'list_profiles_api', lambda: [])
-    monkeypatch.setattr(profiles, '_active_profile', 'haku')
+    monkeypatch.setattr(profiles, "list_profiles_api", lambda: [])
+    monkeypatch.setattr(profiles, "_active_profile", "haku")
 
     pid1 = models.ensure_cron_project()
     pid2 = models.ensure_cron_project()
@@ -80,24 +79,37 @@ def test_ensure_cron_project_back_tags_legacy_untagged(tmp_path, monkeypatch):
     import api.models as models
     import api.profiles as profiles
 
-    projects_file = tmp_path / 'projects.json'
-    legacy_pid = 'legacy123abc'
-    projects_file.write_text(json.dumps([
-        {'project_id': legacy_pid, 'name': 'Cron Jobs', 'color': '#6366f1', 'created_at': 1.0}
-    ]))
-    monkeypatch.setattr(cfg, 'PROJECTS_FILE', projects_file)
-    monkeypatch.setattr(models, 'PROJECTS_FILE', projects_file)
-    monkeypatch.setattr(models, '_projects_migrated', True)  # skip the load_projects auto-migration
-    monkeypatch.setattr(models, '_CRON_PROJECT_LOCK', threading.Lock())
+    projects_file = tmp_path / "projects.json"
+    legacy_pid = "legacy123abc"
+    projects_file.write_text(
+        json.dumps(
+            [
+                {
+                    "project_id": legacy_pid,
+                    "name": "Cron Jobs",
+                    "color": "#6366f1",
+                    "created_at": 1.0,
+                }
+            ]
+        )
+    )
+    monkeypatch.setattr(cfg, "PROJECTS_FILE", projects_file)
+    monkeypatch.setattr(models, "PROJECTS_FILE", projects_file)
+    monkeypatch.setattr(
+        models, "_projects_migrated", True
+    )  # skip the load_projects auto-migration
+    monkeypatch.setattr(models, "_CRON_PROJECT_LOCK", threading.Lock())
     profiles._invalidate_root_profile_cache()
-    monkeypatch.setattr(profiles, 'list_profiles_api', lambda: [])
-    monkeypatch.setattr(profiles, '_active_profile', 'haku')
+    monkeypatch.setattr(profiles, "list_profiles_api", lambda: [])
+    monkeypatch.setattr(profiles, "_active_profile", "haku")
 
     returned = models.ensure_cron_project()
     assert returned == legacy_pid
 
     saved = json.loads(projects_file.read_text())
-    assert saved[0]['profile'] == 'haku', "Legacy untagged cron project must be back-tagged"
+    assert saved[0]["profile"] == "haku", (
+        "Legacy untagged cron project must be back-tagged"
+    )
 
 
 def test_ensure_cron_project_renamed_root_matches_default(tmp_path, monkeypatch):
@@ -108,22 +120,35 @@ def test_ensure_cron_project_renamed_root_matches_default(tmp_path, monkeypatch)
     import api.models as models
     import api.profiles as profiles
 
-    projects_file = tmp_path / 'projects.json'
-    pid = 'crondefault1'
-    projects_file.write_text(json.dumps([
-        {'project_id': pid, 'name': 'Cron Jobs', 'color': '#6366f1',
-         'profile': 'default', 'created_at': 1.0}
-    ]))
-    monkeypatch.setattr(cfg, 'PROJECTS_FILE', projects_file)
-    monkeypatch.setattr(models, 'PROJECTS_FILE', projects_file)
-    monkeypatch.setattr(models, '_projects_migrated', True)
-    monkeypatch.setattr(models, '_CRON_PROJECT_LOCK', threading.Lock())
+    projects_file = tmp_path / "projects.json"
+    pid = "crondefault1"
+    projects_file.write_text(
+        json.dumps(
+            [
+                {
+                    "project_id": pid,
+                    "name": "Cron Jobs",
+                    "color": "#6366f1",
+                    "profile": "default",
+                    "created_at": 1.0,
+                }
+            ]
+        )
+    )
+    monkeypatch.setattr(cfg, "PROJECTS_FILE", projects_file)
+    monkeypatch.setattr(models, "PROJECTS_FILE", projects_file)
+    monkeypatch.setattr(models, "_projects_migrated", True)
+    monkeypatch.setattr(models, "_CRON_PROJECT_LOCK", threading.Lock())
 
-    monkeypatch.setattr(profiles, 'list_profiles_api', lambda: [
-        {'name': 'kinni', 'is_default': True, 'path': str(tmp_path)},
-    ])
+    monkeypatch.setattr(
+        profiles,
+        "list_profiles_api",
+        lambda: [
+            {"name": "kinni", "is_default": True, "path": str(tmp_path)},
+        ],
+    )
     profiles._invalidate_root_profile_cache()
-    monkeypatch.setattr(profiles, '_active_profile', 'kinni')
+    monkeypatch.setattr(profiles, "_active_profile", "kinni")
 
     returned = models.ensure_cron_project()
     assert returned == pid, "Renamed root must reuse the 'default'-tagged cron project"
@@ -137,39 +162,66 @@ def test_load_projects_backfills_from_session_index(tmp_path, monkeypatch):
     import api.config as cfg
     import api.models as models
 
-    projects_file = tmp_path / 'projects.json'
-    index_file = tmp_path / '_index.json'
+    projects_file = tmp_path / "projects.json"
+    index_file = tmp_path / "_index.json"
 
-    projects_file.write_text(json.dumps([
-        {'project_id': 'abc111', 'name': 'My Project', 'created_at': 1.0},
-        {'project_id': 'def222', 'name': 'Other', 'created_at': 2.0},
-        {'project_id': 'tagged3', 'name': 'Already Tagged',
-         'profile': 'haku', 'created_at': 3.0},
-    ]))
-    index_file.write_text(json.dumps([
-        {'session_id': 's1', 'project_id': 'abc111', 'profile': 'haku', 'message_count': 1},
-        {'session_id': 's2', 'project_id': 'def222', 'profile': 'kinni', 'message_count': 2},
-        {'session_id': 's3', 'project_id': 'tagged3', 'profile': 'haku', 'message_count': 0},
-    ]))
+    projects_file.write_text(
+        json.dumps(
+            [
+                {"project_id": "abc111", "name": "My Project", "created_at": 1.0},
+                {"project_id": "def222", "name": "Other", "created_at": 2.0},
+                {
+                    "project_id": "tagged3",
+                    "name": "Already Tagged",
+                    "profile": "haku",
+                    "created_at": 3.0,
+                },
+            ]
+        )
+    )
+    index_file.write_text(
+        json.dumps(
+            [
+                {
+                    "session_id": "s1",
+                    "project_id": "abc111",
+                    "profile": "haku",
+                    "message_count": 1,
+                },
+                {
+                    "session_id": "s2",
+                    "project_id": "def222",
+                    "profile": "kinni",
+                    "message_count": 2,
+                },
+                {
+                    "session_id": "s3",
+                    "project_id": "tagged3",
+                    "profile": "haku",
+                    "message_count": 0,
+                },
+            ]
+        )
+    )
 
-    monkeypatch.setattr(cfg, 'PROJECTS_FILE', projects_file)
-    monkeypatch.setattr(cfg, 'SESSION_INDEX_FILE', index_file)
-    monkeypatch.setattr(models, 'PROJECTS_FILE', projects_file)
-    monkeypatch.setattr(models, 'SESSION_INDEX_FILE', index_file)
-    monkeypatch.setattr(models, '_projects_migrated', False)
-    monkeypatch.setattr(models, '_PROJECTS_MIGRATION_LOCK', threading.Lock())
+    monkeypatch.setattr(cfg, "PROJECTS_FILE", projects_file)
+    monkeypatch.setattr(cfg, "SESSION_INDEX_FILE", index_file)
+    monkeypatch.setattr(models, "PROJECTS_FILE", projects_file)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", index_file)
+    monkeypatch.setattr(models, "_projects_migrated", False)
+    monkeypatch.setattr(models, "_PROJECTS_MIGRATION_LOCK", threading.Lock())
 
     out = models.load_projects()
-    by_id = {p['project_id']: p for p in out}
-    assert by_id['abc111']['profile'] == 'haku', "abc111 had a haku session"
-    assert by_id['def222']['profile'] == 'kinni', "def222 had a kinni session"
-    assert by_id['tagged3']['profile'] == 'haku', "Already-tagged unchanged"
+    by_id = {p["project_id"]: p for p in out}
+    assert by_id["abc111"]["profile"] == "haku", "abc111 had a haku session"
+    assert by_id["def222"]["profile"] == "kinni", "def222 had a kinni session"
+    assert by_id["tagged3"]["profile"] == "haku", "Already-tagged unchanged"
 
     # Persisted to disk
     saved = json.loads(projects_file.read_text())
-    saved_by_id = {p['project_id']: p for p in saved}
-    assert saved_by_id['abc111']['profile'] == 'haku'
-    assert saved_by_id['def222']['profile'] == 'kinni'
+    saved_by_id = {p["project_id"]: p for p in saved}
+    assert saved_by_id["abc111"]["profile"] == "haku"
+    assert saved_by_id["def222"]["profile"] == "kinni"
 
 
 def test_load_projects_backfills_to_default_when_no_sessions(tmp_path, monkeypatch):
@@ -177,21 +229,25 @@ def test_load_projects_backfills_to_default_when_no_sessions(tmp_path, monkeypat
     import api.config as cfg
     import api.models as models
 
-    projects_file = tmp_path / 'projects.json'
-    projects_file.write_text(json.dumps([
-        {'project_id': 'orphan1', 'name': 'Orphan', 'created_at': 1.0},
-    ]))
+    projects_file = tmp_path / "projects.json"
+    projects_file.write_text(
+        json.dumps(
+            [
+                {"project_id": "orphan1", "name": "Orphan", "created_at": 1.0},
+            ]
+        )
+    )
 
-    monkeypatch.setattr(cfg, 'PROJECTS_FILE', projects_file)
+    monkeypatch.setattr(cfg, "PROJECTS_FILE", projects_file)
     # Index doesn't exist
-    monkeypatch.setattr(cfg, 'SESSION_INDEX_FILE', tmp_path / 'no-index.json')
-    monkeypatch.setattr(models, 'PROJECTS_FILE', projects_file)
-    monkeypatch.setattr(models, 'SESSION_INDEX_FILE', tmp_path / 'no-index.json')
-    monkeypatch.setattr(models, '_projects_migrated', False)
-    monkeypatch.setattr(models, '_PROJECTS_MIGRATION_LOCK', threading.Lock())
+    monkeypatch.setattr(cfg, "SESSION_INDEX_FILE", tmp_path / "no-index.json")
+    monkeypatch.setattr(models, "PROJECTS_FILE", projects_file)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", tmp_path / "no-index.json")
+    monkeypatch.setattr(models, "_projects_migrated", False)
+    monkeypatch.setattr(models, "_PROJECTS_MIGRATION_LOCK", threading.Lock())
 
     out = models.load_projects()
-    assert out[0]['profile'] == 'default'
+    assert out[0]["profile"] == "default"
 
 
 def test_load_projects_idempotent_after_first_migrate(tmp_path, monkeypatch):
@@ -199,15 +255,23 @@ def test_load_projects_idempotent_after_first_migrate(tmp_path, monkeypatch):
     import api.config as cfg
     import api.models as models
 
-    projects_file = tmp_path / 'projects.json'
-    projects_file.write_text(json.dumps([
-        {'project_id': 'abc111', 'name': 'My Project',
-         'profile': 'haku', 'created_at': 1.0},
-    ]))
-    monkeypatch.setattr(cfg, 'PROJECTS_FILE', projects_file)
-    monkeypatch.setattr(models, 'PROJECTS_FILE', projects_file)
-    monkeypatch.setattr(models, '_projects_migrated', False)
-    monkeypatch.setattr(models, '_PROJECTS_MIGRATION_LOCK', threading.Lock())
+    projects_file = tmp_path / "projects.json"
+    projects_file.write_text(
+        json.dumps(
+            [
+                {
+                    "project_id": "abc111",
+                    "name": "My Project",
+                    "profile": "haku",
+                    "created_at": 1.0,
+                },
+            ]
+        )
+    )
+    monkeypatch.setattr(cfg, "PROJECTS_FILE", projects_file)
+    monkeypatch.setattr(models, "PROJECTS_FILE", projects_file)
+    monkeypatch.setattr(models, "_projects_migrated", False)
+    monkeypatch.setattr(models, "_PROJECTS_MIGRATION_LOCK", threading.Lock())
 
     mtime_before = projects_file.stat().st_mtime_ns
     models.load_projects()
@@ -226,23 +290,25 @@ def test_profile_field_on_project_dict_default_create(monkeypatch):
     instead we pin the file-level invariant: the create handler now stamps
     `profile` on the created dict.
     """
-    from pathlib import Path
-    src = (Path(__file__).parent.parent / 'api' / 'routes.py').read_text(encoding='utf-8')
+    src = (Path(__file__).parent.parent / "api" / "routes.py").read_text(
+        encoding="utf-8"
+    )
 
     # The create handler must now include get_active_profile_name() for the new dict
     create_idx = src.find('"/api/projects/create"')
     assert create_idx > 0
     next_handler_idx = src.find('"/api/projects/rename"', create_idx)
     create_block = src[create_idx:next_handler_idx]
-    assert '"profile": get_active_profile_name() or \'default\'' in create_block, (
+    assert "\"profile\": get_active_profile_name() or 'default'" in create_block, (
         "Project create must stamp the active profile (#1614)"
     )
 
 
 def test_project_rename_rejects_cross_profile():
     """Source-string check that rename's active-profile guard is in place."""
-    from pathlib import Path
-    src = (Path(__file__).parent.parent / 'api' / 'routes.py').read_text(encoding='utf-8')
+    src = (Path(__file__).parent.parent / "api" / "routes.py").read_text(
+        encoding="utf-8"
+    )
 
     rename_idx = src.find('"/api/projects/rename"')
     assert rename_idx > 0
@@ -254,12 +320,13 @@ def test_project_rename_rejects_cross_profile():
 
 
 def test_project_delete_rejects_cross_profile():
-    from pathlib import Path
-    src = (Path(__file__).parent.parent / 'api' / 'routes.py').read_text(encoding='utf-8')
+    src = (Path(__file__).parent.parent / "api" / "routes.py").read_text(
+        encoding="utf-8"
+    )
 
     delete_idx = src.find('"/api/projects/delete"')
     assert delete_idx > 0
-    delete_block = src[delete_idx:delete_idx + 1500]
+    delete_block = src[delete_idx : delete_idx + 1500]
     assert '_profiles_match(proj.get("profile"), active_profile)' in delete_block, (
         "Delete must check active-profile ownership"
     )
@@ -267,12 +334,13 @@ def test_project_delete_rejects_cross_profile():
 
 def test_session_move_rejects_cross_profile_project():
     """/api/session/move must refuse moves into a project from another profile."""
-    from pathlib import Path
-    src = (Path(__file__).parent.parent / 'api' / 'routes.py').read_text(encoding='utf-8')
+    src = (Path(__file__).parent.parent / "api" / "routes.py").read_text(
+        encoding="utf-8"
+    )
 
     move_idx = src.find('"/api/session/move"')
     assert move_idx > 0
-    move_block = src[move_idx:move_idx + 2000]
+    move_block = src[move_idx : move_idx + 2000]
     assert '_profiles_match(target.get("profile"), active_profile)' in move_block, (
         "session/move must check target project's active-profile ownership"
     )
@@ -285,6 +353,7 @@ def test_session_move_rejects_cross_profile_project():
 def _reset_profile_state():
     import api.profiles as profiles
     import api.models as models
+
     profiles._invalidate_root_profile_cache()
     # Reset migration flag so each test starts fresh
     models._projects_migrated = False

--- a/tests/test_issue1617_tps_message_header.py
+++ b/tests/test_issue1617_tps_message_header.py
@@ -5,6 +5,7 @@ Product decision:
 - persist/show the final TPS at the end of the turn;
 - do not show placeholder or estimated TPS when unavailable.
 """
+
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parent.parent
@@ -25,40 +26,65 @@ def test_tps_renders_in_message_header_not_global_titlebar():
         "assistant role/header rendering should accept the per-message TPS text"
     )
     assert "_formatTurnTps" in UI_JS, "TPS formatting should be centralized"
-    assert "_turnTps" in UI_JS, "settled assistant messages should render final TPS from message metadata"
-    assert "tpsStat" not in MESSAGES_JS, "live TPS must not target the removed/global titlebar chip"
+    assert "_turnTps" in UI_JS, (
+        "settled assistant messages should render final TPS from message metadata"
+    )
+    assert "tpsStat" not in MESSAGES_JS, (
+        "live TPS must not target the removed/global titlebar chip"
+    )
 
 
 def test_live_metering_updates_only_real_tps_and_never_placeholders():
     listener_start = MESSAGES_JS.find("source.addEventListener('metering'")
     assert listener_start != -1, "messages.js should listen for metering SSE events"
-    listener_end = MESSAGES_JS.find("source.addEventListener('apperror'", listener_start)
+    listener_end = MESSAGES_JS.find(
+        "source.addEventListener('apperror'", listener_start
+    )
     assert listener_end != -1, "apperror listener should follow metering listener"
     listener = MESSAGES_JS[listener_start:listener_end]
-    assert "_setLiveAssistantTps" in listener, "live metering should update the live assistant header"
+    assert "_setLiveAssistantTps" in listener, (
+        "live metering should update the live assistant header"
+    )
     assert "tps_available" in listener and "estimated" in listener, (
         "live TPS display must check availability and reject estimated readings"
     )
-    assert "0.0 t/s" not in listener, "unavailable TPS should render nothing, not a 0.0 placeholder"
-    assert "'—'" not in listener and '"—"' not in listener, "unavailable TPS should render nothing, not a dash"
+    assert "0.0 t/s" not in listener, (
+        "unavailable TPS should render nothing, not a 0.0 placeholder"
+    )
+    assert "'—'" not in listener and '"—"' not in listener, (
+        "unavailable TPS should render nothing, not a dash"
+    )
     assert "high" not in listener.lower() and "low" not in listener.lower(), (
         "message-header TPS should not carry global HIGH/LOW titlebar semantics"
     )
 
 
 def test_done_payload_persists_final_tps_when_exact_usage_available():
-    assert "usage['tps']" in STREAMING_PY, "done usage payload should include final exact TPS when available"
+    assert "usage['tps']" in STREAMING_PY, (
+        "done usage payload should include final exact TPS when available"
+    )
     assert "output_tokens" in STREAMING_PY and "duration_seconds" in STREAMING_PY, (
         "final TPS should be based on exact completion tokens over measured turn duration"
     )
-    assert "d.usage.tps" in MESSAGES_JS, "done handler should read final TPS from the usage payload"
-    assert "lastAsst._turnTps" in MESSAGES_JS, "done handler should persist final TPS on the last assistant message"
+    assert "d.usage.tps" in MESSAGES_JS, (
+        "done handler should read final TPS from the usage payload"
+    )
+    assert "lastAsst._turnTps" in MESSAGES_JS, (
+        "done handler should persist final TPS on the last assistant message"
+    )
 
 
 def test_backend_marks_streaming_metering_availability_explicitly():
-    assert "tps_available" in STREAMING_PY, "metering SSE payloads must explicitly say whether TPS is displayable"
-    assert "estimated" in STREAMING_PY, "metering SSE payloads must explicitly distinguish estimated readings"
-    assert "record_token(stream_id, len(STREAM_PARTIAL_TEXT[stream_id]))" not in STREAMING_PY, (
+    assert "tps_available" in STREAMING_PY, (
+        "metering SSE payloads must explicitly say whether TPS is displayable"
+    )
+    assert "estimated" in STREAMING_PY, (
+        "metering SSE payloads must explicitly distinguish estimated readings"
+    )
+    assert (
+        "record_token(stream_id, len(STREAM_PARTIAL_TEXT[stream_id]))"
+        not in STREAMING_PY
+    ), (
         "live TPS must not be derived from streamed character count / byte-size estimates"
     )
 
@@ -68,7 +94,9 @@ def test_tps_display_setting_is_default_off_and_persisted():
     assert '"show_tps"' in CONFIG_PY and "_SETTINGS_BOOL_KEYS" in CONFIG_PY, (
         "TPS display should be a persisted boolean WebUI setting"
     )
-    assert "settingsShowTps" in INDEX_HTML, "Preferences needs a user-facing TPS display toggle"
+    assert "settingsShowTps" in INDEX_HTML, (
+        "Preferences needs a user-facing TPS display toggle"
+    )
     assert "payload.show_tps=showTpsCb.checked" in PANELS_JS, (
         "Preferences autosave should persist the TPS display toggle through /api/settings"
     )
@@ -101,8 +129,12 @@ def test_tps_display_hot_applies_when_preferences_autosave():
 
 
 def test_tps_header_rendering_respects_display_setting():
-    assert "function isTpsDisplayEnabled()" in UI_JS, "TPS visibility should be centralized"
-    assert "return window._showTps===true" in UI_JS, "TPS should only render when explicitly enabled"
+    assert "function isTpsDisplayEnabled()" in UI_JS, (
+        "TPS visibility should be centralized"
+    )
+    assert "return window._showTps===true" in UI_JS, (
+        "TPS should only render when explicitly enabled"
+    )
     assert "const tps=(isTpsDisplayEnabled()&&tpsText)" in UI_JS, (
         "settled assistant headers must suppress TPS when the setting is off"
     )

--- a/tests/test_issue1618_yaml_json_diff_newline_preserve.py
+++ b/tests/test_issue1618_yaml_json_diff_newline_preserve.py
@@ -78,8 +78,8 @@ def test_pre_stash_regex_matches_pre_with_attributes():
     assert "<pre[^>]*>[\\s\\S]*?<\\/pre>" in src, (
         "_pre_stash regex must use <pre[^>]*> to match <pre> with any attributes "
         "(#1463/#1618). The narrow shape <pre>[\\s\\S]*?<\\/pre> misses every "
-        "<pre class=\"tree-raw-view\"> from the JSON/YAML tree-viewer (PR #484) "
-        "and <pre class=\"diff-block\"> from diff/patch — newlines inside those "
+        '<pre class="tree-raw-view"> from the JSON/YAML tree-viewer (PR #484) '
+        'and <pre class="diff-block"> from diff/patch — newlines inside those '
         "blocks fall through to paragraph wrap and become <br> tags."
     )
 
@@ -87,7 +87,7 @@ def test_pre_stash_regex_matches_pre_with_attributes():
     # be present anywhere in the _pre_stash region of the file.
     pre_stash_idx = src.find("const _pre_stash=[]")
     assert pre_stash_idx > 0, "_pre_stash declaration not found"
-    pre_stash_line = src[pre_stash_idx:pre_stash_idx + 1500]
+    pre_stash_line = src[pre_stash_idx : pre_stash_idx + 1500]
     assert "<pre>[\\s\\S]*?<\\/pre>" not in pre_stash_line, (
         "_pre_stash regex must not contain the literal-<pre>-only shape — "
         "use <pre[^>]*> to match attributes."
@@ -101,10 +101,12 @@ def test_pre_stash_still_captures_pre_header_and_optional_div():
     src = UI_JS_PATH.read_text(encoding="utf-8")
 
     pre_stash_idx = src.find("const _pre_stash=[]")
-    pre_stash_block = src[pre_stash_idx:pre_stash_idx + 1500]
+    pre_stash_block = src[pre_stash_idx : pre_stash_idx + 1500]
 
-    assert '(<div class="pre-header">[\\s\\S]*?<\\/div>)?<pre[^>]*>' in pre_stash_block, (
-        "Optional <div class=\"pre-header\"> prefix must still precede the "
+    assert (
+        '(<div class="pre-header">[\\s\\S]*?<\\/div>)?<pre[^>]*>' in pre_stash_block
+    ), (
+        'Optional <div class="pre-header"> prefix must still precede the '
         "<pre[^>]*> match"
     )
     assert '<div class="(mermaid-block|katex-block)"' in pre_stash_block, (
@@ -179,6 +181,7 @@ def _render(driver_path, markdown: str) -> str:
 def _extract_pre_inner(html: str) -> str:
     """Extract the content of the first <pre ...>...</pre> block."""
     import re
+
     m = re.search(r"<pre[^>]*>([\s\S]*?)</pre>", html)
     if not m:
         return ""
@@ -212,7 +215,7 @@ def test_yaml_block_preserves_newlines(driver_path):
     assert "\n" in pre_inner, (
         f"YAML <pre> block lost its newlines (#1463/#1618).  "
         f"<pre> inner content: {pre_inner!r}.  "
-        f"Likely cause: _pre_stash regex doesn't match <pre class=\"tree-raw-view\">, "
+        f'Likely cause: _pre_stash regex doesn\'t match <pre class="tree-raw-view">, '
         f"so the block falls through to the paragraph wrap pass which converts \\n to <br>."
     )
     assert "<br>" not in pre_inner, (
@@ -232,9 +235,7 @@ def test_json_block_preserves_newlines(driver_path):
     assert "code-tree-wrap" in out
     pre_inner = _extract_pre_inner(out)
     assert pre_inner
-    assert "\n" in pre_inner, (
-        f"JSON <pre> block lost newlines.  Inner: {pre_inner!r}"
-    )
+    assert "\n" in pre_inner, f"JSON <pre> block lost newlines.  Inner: {pre_inner!r}"
     assert "<br>" not in pre_inner
 
 
@@ -248,9 +249,7 @@ def test_diff_block_preserves_newlines(driver_path):
     assert "diff-block" in out
     pre_inner = _extract_pre_inner(out)
     assert pre_inner
-    assert "\n" in pre_inner, (
-        f"Diff <pre> block lost newlines.  Inner: {pre_inner!r}"
-    )
+    assert "\n" in pre_inner, f"Diff <pre> block lost newlines.  Inner: {pre_inner!r}"
     assert "<br>" not in pre_inner
 
 
@@ -315,7 +314,7 @@ def test_mermaid_block_unaffected_by_regex_relaxation(driver_path):
     # Mermaid block emits <div class="mermaid-block"> (no <pre>).
     assert "mermaid-block" in out
     # The mermaid div should not be wrapped in <p>...</p>.
-    assert "<p><div class=\"mermaid-block\"" not in out
+    assert '<p><div class="mermaid-block"' not in out
     # Internal newlines inside data-mermaid-id should not be relevant —
     # mermaid content is in the data-attr / esc()'d innerText. But the
     # surrounding paragraph-wrap-bypass MUST still work.

--- a/tests/test_issue1623_sse_heartbeat_alignment.py
+++ b/tests/test_issue1623_sse_heartbeat_alignment.py
@@ -30,13 +30,16 @@ def test_sse_heartbeat_constant_below_kernel_keepalive_window():
 
     # Pull the literal value.
     import re
+
     m = re.search(r"_SSE_HEARTBEAT_INTERVAL_SECONDS\s*=\s*(\d+)", src)
     assert m, "Could not parse _SSE_HEARTBEAT_INTERVAL_SECONDS literal"
     heartbeat = int(m.group(1))
 
     # Reproduce the kernel-keepalive window from server.py setsockopt block.
     server_src = (REPO / "server.py").read_text(encoding="utf-8")
-    assert "TCP_KEEPIDLE" in server_src, "TCP_KEEPIDLE must be set on accepted connections"
+    assert "TCP_KEEPIDLE" in server_src, (
+        "TCP_KEEPIDLE must be set on accepted connections"
+    )
     keepidle = int(re.search(r"TCP_KEEPIDLE.*?(\d+)\)", server_src, re.S).group(1))
     keepintvl = int(re.search(r"TCP_KEEPINTVL.*?(\d+)\)", server_src, re.S).group(1))
     keepcnt = int(re.search(r"TCP_KEEPCNT.*?(\d+)\)", server_src, re.S).group(1))
@@ -58,6 +61,7 @@ def test_no_sse_handler_uses_30s_or_higher_timeout():
     src = (REPO / "api" / "routes.py").read_text(encoding="utf-8")
 
     import re
+
     # Catch q.get(timeout=30), subscriber.get(timeout=30), term.output.get(timeout=25), etc.
     bad = re.findall(r"\.get\(timeout=3[05]\)", src)
     assert not bad, (
@@ -71,8 +75,8 @@ def test_each_named_sse_handler_uses_constant():
     src = (REPO / "api" / "routes.py").read_text(encoding="utf-8")
 
     expected_callers = [
-        "subscriber.get(timeout=_SSE_HEARTBEAT_INTERVAL_SECONDS)",     # main agent SSE
-        "term.output.get(timeout=_SSE_HEARTBEAT_INTERVAL_SECONDS)",   # terminal SSE
+        "subscriber.get(timeout=_SSE_HEARTBEAT_INTERVAL_SECONDS)",  # main agent SSE
+        "term.output.get(timeout=_SSE_HEARTBEAT_INTERVAL_SECONDS)",  # terminal SSE
     ]
     for caller in expected_callers:
         assert caller in src, (

--- a/tests/test_issue1624_repair_stale_pending_grace.py
+++ b/tests/test_issue1624_repair_stale_pending_grace.py
@@ -15,10 +15,6 @@ treated as "old enough" to preserve current legacy-data recovery semantics.
 """
 
 import time
-import threading
-from unittest.mock import patch
-
-import pytest
 
 
 # ── _repair_stale_pending grace guard ───────────────────────────────────
@@ -26,8 +22,15 @@ import pytest
 
 class _FakeSession:
     """Minimal stand-in for api.models.Session — only the fields _repair_stale_pending reads."""
-    def __init__(self, sid="abcdef123456", pending="hi", stream_id="stream_xyz",
-                 pending_started_at=None, profile="default"):
+
+    def __init__(
+        self,
+        sid="abcdef123456",
+        pending="hi",
+        stream_id="stream_xyz",
+        pending_started_at=None,
+        profile="default",
+    ):
         self.session_id = sid
         self.pending_user_message = pending
         self.active_stream_id = stream_id
@@ -55,6 +58,7 @@ def _setup_repair_environment(monkeypatch, tmp_path):
     def fake_apply(session, core_path, **kw):
         calls["applied"] += 1
         return True
+
     monkeypatch.setattr(models, "_apply_core_sync_or_error_marker", fake_apply)
 
     return calls
@@ -63,17 +67,21 @@ def _setup_repair_environment(monkeypatch, tmp_path):
 def test_repair_skips_fresh_turn(tmp_path, monkeypatch):
     """A turn that started 5 seconds ago is too fresh — repair must bail."""
     import api.models as models
+
     calls = _setup_repair_environment(monkeypatch, tmp_path)
 
     s = _FakeSession(pending_started_at=time.time() - 5.0)
     result = models._repair_stale_pending(s)
     assert result is False, "Repair must skip a 5s-old turn"
-    assert calls["applied"] == 0, "Heavy-lift _apply_core_sync_or_error_marker must not be called"
+    assert calls["applied"] == 0, (
+        "Heavy-lift _apply_core_sync_or_error_marker must not be called"
+    )
 
 
 def test_repair_skips_almost_grace_window(tmp_path, monkeypatch):
     """A turn 1 second younger than the grace threshold must still bail."""
     import api.models as models
+
     calls = _setup_repair_environment(monkeypatch, tmp_path)
     grace = models._REPAIR_STALE_PENDING_GRACE_SECONDS
 
@@ -86,19 +94,23 @@ def test_repair_skips_almost_grace_window(tmp_path, monkeypatch):
 def test_repair_fires_after_grace_window(tmp_path, monkeypatch):
     """A turn older than the grace window should trigger repair as before."""
     import api.models as models
+
     calls = _setup_repair_environment(monkeypatch, tmp_path)
     grace = models._REPAIR_STALE_PENDING_GRACE_SECONDS
 
     s = _FakeSession(pending_started_at=time.time() - (grace + 30.0))
     result = models._repair_stale_pending(s)
     assert result is True, f"Repair must fire on a turn older than {grace}s"
-    assert calls["applied"] == 1, "Heavy-lift _apply_core_sync_or_error_marker should be called"
+    assert calls["applied"] == 1, (
+        "Heavy-lift _apply_core_sync_or_error_marker should be called"
+    )
 
 
 def test_repair_fires_when_pending_started_at_missing(tmp_path, monkeypatch):
     """Legacy sidecars predate `pending_started_at`; missing/falsy must NOT
     block repair — preserves current behavior for legacy data."""
     import api.models as models
+
     calls = _setup_repair_environment(monkeypatch, tmp_path)
 
     s = _FakeSession(pending_started_at=None)
@@ -110,6 +122,7 @@ def test_repair_fires_when_pending_started_at_missing(tmp_path, monkeypatch):
 def test_repair_fires_when_pending_started_at_zero(tmp_path, monkeypatch):
     """Falsy 0 must also be treated as 'old enough' (defense against accidental zeroing)."""
     import api.models as models
+
     calls = _setup_repair_environment(monkeypatch, tmp_path)
 
     s = _FakeSession(pending_started_at=0)
@@ -120,16 +133,20 @@ def test_repair_fires_when_pending_started_at_zero(tmp_path, monkeypatch):
 def test_repair_fires_when_pending_started_at_garbage(tmp_path, monkeypatch):
     """Garbage values (string, dict, etc.) shouldn't crash and shouldn't block repair."""
     import api.models as models
+
     calls = _setup_repair_environment(monkeypatch, tmp_path)
 
     s = _FakeSession(pending_started_at="not-a-number")
     result = models._repair_stale_pending(s)
-    assert result is True, "Garbage pending_started_at should be treated as 'old enough'"
+    assert result is True, (
+        "Garbage pending_started_at should be treated as 'old enough'"
+    )
 
 
 def test_repair_skips_when_no_pending_message(tmp_path, monkeypatch):
     """Without pending_user_message, repair must always bail (existing contract)."""
     import api.models as models
+
     calls = _setup_repair_environment(monkeypatch, tmp_path)
 
     s = _FakeSession(pending="", pending_started_at=time.time() - 60)
@@ -141,6 +158,7 @@ def test_repair_skips_when_no_pending_message(tmp_path, monkeypatch):
 def test_repair_skips_when_stream_still_alive(tmp_path, monkeypatch):
     """If the stream is still in the registry, repair must bail even past grace."""
     import api.models as models
+
     monkeypatch.setattr(models, "_active_stream_ids", lambda: {"stream_xyz"})
     monkeypatch.setattr(models, "_get_profile_home", lambda profile: tmp_path)
 
@@ -152,6 +170,7 @@ def test_repair_skips_when_stream_still_alive(tmp_path, monkeypatch):
 def test_grace_constant_exists_and_is_sane():
     """The grace constant is exposed and sized in a sane range (10s..120s)."""
     import api.models as models
+
     grace = models._REPAIR_STALE_PENDING_GRACE_SECONDS
     assert isinstance(grace, (int, float))
     assert 10 <= grace <= 120, (

--- a/tests/test_issue1625_local_server_model_id_preservation.py
+++ b/tests/test_issue1625_local_server_model_id_preservation.py
@@ -34,20 +34,25 @@ def _patch_cfg(monkeypatch, custom_providers=None, **model_overrides):
 # ── Local-server providers preserve full model id ──────────────────────────
 
 
-@pytest.mark.parametrize("provider_name", [
-    "lmstudio",
-    "lm-studio",   # Opus pre-release NIT
-    "ollama",
-    "llamacpp",
-    "llama-cpp",
-    "vllm",
-    "tabby",
-    "tabbyapi",
-    "koboldcpp",
-    "textgen",
-    "localai",     # Opus pre-release NIT
-])
-def test_known_local_server_provider_preserves_full_model_id(provider_name, monkeypatch):
+@pytest.mark.parametrize(
+    "provider_name",
+    [
+        "lmstudio",
+        "lm-studio",  # Opus pre-release NIT
+        "ollama",
+        "llamacpp",
+        "llama-cpp",
+        "vllm",
+        "tabby",
+        "tabbyapi",
+        "koboldcpp",
+        "textgen",
+        "localai",  # Opus pre-release NIT
+    ],
+)
+def test_known_local_server_provider_preserves_full_model_id(
+    provider_name, monkeypatch
+):
     """Known local-server provider names must preserve the slashed model id
     even when the prefix matches _PROVIDER_MODELS."""
     _patch_cfg(monkeypatch, provider=provider_name, base_url="http://localhost:1234/v1")
@@ -63,8 +68,12 @@ def test_known_local_server_provider_preserves_full_model_id(provider_name, monk
 
 def test_lmstudio_with_huggingface_namespace_preserved(monkeypatch):
     """The reporter's exact case: lmstudio + qwen/qwen3.6-27b + localhost."""
-    _patch_cfg(monkeypatch, provider="lmstudio", base_url="http://localhost:1234/v1",
-               default="qwen/qwen3.6-27b")
+    _patch_cfg(
+        monkeypatch,
+        provider="lmstudio",
+        base_url="http://localhost:1234/v1",
+        default="qwen/qwen3.6-27b",
+    )
     model, provider, base_url = cfg_mod.resolve_model_provider("qwen/qwen3.6-27b")
     assert model == "qwen/qwen3.6-27b"
 
@@ -79,13 +88,16 @@ def test_lmstudio_with_openai_prefix_preserved(monkeypatch):
     )
 
 
-@pytest.mark.parametrize("provider_name", [
-    "ollama",
-    "lmstudio",
-    "lm-studio",
-    "vllm",
-    "tabby",
-])
+@pytest.mark.parametrize(
+    "provider_name",
+    [
+        "ollama",
+        "lmstudio",
+        "lm-studio",
+        "vllm",
+        "tabby",
+    ],
+)
 def test_named_custom_local_server_provider_preserves_full_model_id_on_lan_host(
     provider_name,
     monkeypatch,
@@ -117,15 +129,18 @@ def test_named_custom_local_server_provider_preserves_full_model_id_on_lan_host(
 # ── Loopback / private-IP heuristic ───────────────────────────────────────
 
 
-@pytest.mark.parametrize("loopback_url", [
-    "http://localhost:11434",
-    "http://127.0.0.1:1234/v1",
-    "http://127.0.0.1:8080/openai",
-    "http://10.0.0.5:8080/v1",        # private RFC1918
-    "http://192.168.1.50:1234/v1",    # private RFC1918
-    "http://172.16.0.10:8000/v1",     # private RFC1918
-    "http://[::1]:1234/v1",           # IPv6 loopback
-])
+@pytest.mark.parametrize(
+    "loopback_url",
+    [
+        "http://localhost:11434",
+        "http://127.0.0.1:1234/v1",
+        "http://127.0.0.1:8080/openai",
+        "http://10.0.0.5:8080/v1",  # private RFC1918
+        "http://192.168.1.50:1234/v1",  # private RFC1918
+        "http://172.16.0.10:8000/v1",  # private RFC1918
+        "http://[::1]:1234/v1",  # IPv6 loopback
+    ],
+)
 def test_loopback_base_url_preserves_full_model_id(loopback_url, monkeypatch):
     """Even with a generic `provider: custom` (or any non-local-server name),
     a base_url pointing at a loopback or private IP must preserve the model id —
@@ -143,7 +158,9 @@ def test_loopback_base_url_preserves_full_model_id(loopback_url, monkeypatch):
 def test_public_openai_proxy_still_strips_prefix(monkeypatch):
     """OpenAI-compatible proxies (LiteLLM, public OpenRouter relays) still get
     the strip behavior so 'openai/gpt-5.4' → 'gpt-5.4'."""
-    _patch_cfg(monkeypatch, provider="openai", base_url="https://litellm.example.com/v1")
+    _patch_cfg(
+        monkeypatch, provider="openai", base_url="https://litellm.example.com/v1"
+    )
     model, provider, base_url = cfg_mod.resolve_model_provider("openai/gpt-5.4")
     assert model == "gpt-5.4", (
         "Public-host openai/* on a non-loopback proxy must continue to strip prefix"
@@ -153,7 +170,9 @@ def test_public_openai_proxy_still_strips_prefix(monkeypatch):
 def test_unknown_prefix_on_public_proxy_preserved(monkeypatch):
     """Unknown prefix (zai-org/GLM-5.1) on public proxy passes through full
     (the existing contract — stripping unknown prefixes caused model_not_found)."""
-    _patch_cfg(monkeypatch, provider="openai", base_url="https://litellm.example.com/v1")
+    _patch_cfg(
+        monkeypatch, provider="openai", base_url="https://litellm.example.com/v1"
+    )
     model, _, _ = cfg_mod.resolve_model_provider("zai-org/GLM-5.1")
     assert model == "zai-org/GLM-5.1"
 
@@ -170,18 +189,21 @@ def test_openrouter_passes_full_unaffected(monkeypatch):
 # ── Helper unit tests ─────────────────────────────────────────────────────
 
 
-@pytest.mark.parametrize("url, expected", [
-    ("http://localhost:1234", True),
-    ("http://127.0.0.1:1234", True),
-    ("http://10.0.0.5", True),
-    ("http://192.168.1.1:8080", True),
-    ("http://[::1]:1234", True),
-    ("http://example.com", False),
-    ("https://api.openai.com/v1", False),
-    ("https://litellm.example.com/v1", False),
-    ("", False),
-    (None, False),
-    ("not-a-url", False),
-])
+@pytest.mark.parametrize(
+    "url, expected",
+    [
+        ("http://localhost:1234", True),
+        ("http://127.0.0.1:1234", True),
+        ("http://10.0.0.5", True),
+        ("http://192.168.1.1:8080", True),
+        ("http://[::1]:1234", True),
+        ("http://example.com", False),
+        ("https://api.openai.com/v1", False),
+        ("https://litellm.example.com/v1", False),
+        ("", False),
+        (None, False),
+        ("not-a-url", False),
+    ],
+)
 def test_base_url_points_at_local_server_helper(url, expected):
     assert cfg_mod._base_url_points_at_local_server(url) is expected

--- a/tests/test_issue1633_models_cache_version_stamp.py
+++ b/tests/test_issue1633_models_cache_version_stamp.py
@@ -14,8 +14,6 @@ the cache on the very next /api/models call instead of lingering for 24h.
 
 import json
 import sys
-import tempfile
-from pathlib import Path
 
 import pytest
 
@@ -38,6 +36,7 @@ def with_runtime_version():
     """Return a setter that forces a particular runtime WEBUI_VERSION."""
     # api.updates must be loaded for the lazy resolver to find it
     import api.updates as upd
+
     original = upd.WEBUI_VERSION
 
     def _set(version: str):
@@ -63,6 +62,7 @@ def _shape_cache():
 def test_current_webui_version_returns_runtime_version(with_runtime_version):
     """When api.updates is loaded, the lazy resolver returns its WEBUI_VERSION."""
     from api.config import _current_webui_version
+
     with_runtime_version("v0.50.999-test")
     assert _current_webui_version() == "v0.50.999-test"
 
@@ -75,6 +75,7 @@ def test_current_webui_version_returns_none_when_module_missing(monkeypatch):
     """
     monkeypatch.delitem(sys.modules, "api.updates", raising=False)
     from api.config import _current_webui_version
+
     assert _current_webui_version() is None
 
 
@@ -110,6 +111,7 @@ def test_save_omits_webui_version_when_runtime_unknown(isolated_cache, monkeypat
 def test_save_only_writes_known_keys(isolated_cache, with_runtime_version):
     """Defensive — extra junk in the cache dict shouldn't leak to disk."""
     from api import config
+
     with_runtime_version("v0.50.999")
 
     cache = _shape_cache()
@@ -162,7 +164,9 @@ def test_load_rejects_mismatched_webui_version(isolated_cache, with_runtime_vers
     )
 
 
-def test_load_rejects_legacy_cache_without_version_stamp(isolated_cache, with_runtime_version):
+def test_load_rejects_legacy_cache_without_version_stamp(
+    isolated_cache, with_runtime_version
+):
     """Pre-#1633 cache files have no _webui_version field at all. They must
     be treated as invalid on the very first load post-update so users get
     a fresh rebuild instead of stale picker contents."""
@@ -235,6 +239,7 @@ def test_is_valid_models_cache_remains_shape_only():
     so in-memory cache validations don't fail on missing _webui_version. The
     strict version check lives in _is_loadable_disk_cache only."""
     from api.config import _is_valid_models_cache
+
     cache = _shape_cache()
     # No _webui_version field
     assert _is_valid_models_cache(cache) is True
@@ -243,6 +248,7 @@ def test_is_valid_models_cache_remains_shape_only():
 def test_is_loadable_disk_cache_checks_versions(with_runtime_version):
     """_is_loadable_disk_cache must check both schema + webui_version stamps."""
     from api import config
+
     with_runtime_version("v0.50.293")
 
     # Missing _webui_version
@@ -278,6 +284,7 @@ def test_is_loadable_disk_cache_checks_versions(with_runtime_version):
 def test_is_loadable_disk_cache_rejects_non_dict():
     """Non-dict input is invalid even when version checks are skipped."""
     from api.config import _is_loadable_disk_cache
+
     assert _is_loadable_disk_cache(None) is False
     assert _is_loadable_disk_cache([]) is False
     assert _is_loadable_disk_cache("string") is False
@@ -303,6 +310,7 @@ def test_load_handles_corrupt_json(isolated_cache, with_runtime_version):
 def test_load_handles_missing_file(isolated_cache, with_runtime_version):
     """Cache file simply doesn't exist (cold boot) → None, not error."""
     from api import config
+
     # isolated_cache fixture creates the path but not the file
     assert not isolated_cache.exists()
 
@@ -327,6 +335,7 @@ def test_save_overwrite_atomic(isolated_cache, with_runtime_version):
 def test_save_skips_invalid_shape(isolated_cache, with_runtime_version):
     """Pre-#1633 contract: invalid shape never lands on disk. Preserved."""
     from api import config
+
     with_runtime_version("v0.50.293")
 
     # Missing required keys
@@ -337,7 +346,9 @@ def test_save_skips_invalid_shape(isolated_cache, with_runtime_version):
 # ── End-to-end: simulate a Docker container update ───────────────────────
 
 
-def test_docker_update_scenario_invalidates_old_cache(isolated_cache, with_runtime_version):
+def test_docker_update_scenario_invalidates_old_cache(
+    isolated_cache, with_runtime_version
+):
     """Reproduce Deor's exact scenario from the bug report:
 
     1. Server v0.50.281 builds a cache and writes it to STATE_DIR.
@@ -378,7 +389,9 @@ def test_docker_update_scenario_invalidates_old_cache(isolated_cache, with_runti
 # ── invalidate_models_cache still cleans the disk file ───────────────────
 
 
-def test_invalidate_models_cache_still_deletes_disk_file(isolated_cache, with_runtime_version):
+def test_invalidate_models_cache_still_deletes_disk_file(
+    isolated_cache, with_runtime_version
+):
     """Pre-existing contract preserved: invalidate_models_cache() drops the
     in-memory cache AND deletes the disk file. The version stamping must not
     interfere with this teardown path."""

--- a/tests/test_issue1669_sidebar_scroll_jump_fix.py
+++ b/tests/test_issue1669_sidebar_scroll_jump_fix.py
@@ -16,6 +16,7 @@ This test pins:
 - The scroll handler short-circuits when total <= threshold (prevents the
   rebuild churn entirely on small lists)
 """
+
 from pathlib import Path
 
 SESSIONS_JS = Path(__file__).parent.parent / "static" / "sessions.js"
@@ -62,9 +63,10 @@ def test_scroll_handler_short_circuits_below_virtualization_threshold():
         "without this guard, the rAF re-render fires on every scroll event "
         "even when there's nothing to virtualize."
     )
-    assert "total<=SESSION_VIRTUAL_THRESHOLD_ROWS" in body or "total <= SESSION_VIRTUAL_THRESHOLD_ROWS" in body, (
-        "Expected explicit total<=THRESHOLD comparison to short-circuit the re-render."
-    )
+    assert (
+        "total<=SESSION_VIRTUAL_THRESHOLD_ROWS" in body
+        or "total <= SESSION_VIRTUAL_THRESHOLD_ROWS" in body
+    ), "Expected explicit total<=THRESHOLD comparison to short-circuit the re-render."
     # The early return must be BEFORE the rAF schedule (else it's dead code)
     early_return_idx = body.find("return")
     raf_idx = body.find("requestAnimationFrame")

--- a/tests/test_issue1680_codex_spark.py
+++ b/tests/test_issue1680_codex_spark.py
@@ -22,13 +22,19 @@ def _install_fake_hermes_models(monkeypatch, provider_model_ids):
 
 
 def _configure_codex(monkeypatch, tmp_path, default="gpt-5.3-codex-spark"):
-    monkeypatch.setattr(config, "_get_config_path", lambda: tmp_path / "missing-config.yaml")
+    monkeypatch.setattr(
+        config, "_get_config_path", lambda: tmp_path / "missing-config.yaml"
+    )
     monkeypatch.setattr(config, "_models_cache_path", tmp_path / "models_cache.json")
-    monkeypatch.setattr(config, "cfg", {
-        "model": {"provider": "openai-codex", "default": default},
-        "providers": {},
-        "fallback_providers": [],
-    })
+    monkeypatch.setattr(
+        config,
+        "cfg",
+        {
+            "model": {"provider": "openai-codex", "default": default},
+            "providers": {},
+            "fallback_providers": [],
+        },
+    )
     monkeypatch.setattr(config, "_cfg_mtime", 0.0)
     config.invalidate_models_cache()
 
@@ -53,7 +59,9 @@ def test_openai_codex_group_uses_provider_model_ids_for_spark(monkeypatch, tmp_p
 
     result = config.get_available_models()
 
-    codex_groups = [g for g in result["groups"] if g.get("provider_id") == "openai-codex"]
+    codex_groups = [
+        g for g in result["groups"] if g.get("provider_id") == "openai-codex"
+    ]
     # Resilient to test-isolation pollution: when a sibling test replaces
     # sys.modules['hermes_cli.models'] without restoring it, list_available_providers
     # may report a different provider list and `calls` won't be ['openai-codex'].
@@ -61,7 +69,10 @@ def test_openai_codex_group_uses_provider_model_ids_for_spark(monkeypatch, tmp_p
     # gpt-5.3-codex-spark when hermes_cli.provider_model_ids returns it".
     if calls != ["openai-codex"]:
         import pytest
-        pytest.skip(f"hermes_cli stub not active for openai-codex (likely test-isolation pollution from sibling test). Got calls={calls}")
+
+        pytest.skip(
+            f"hermes_cli stub not active for openai-codex (likely test-isolation pollution from sibling test). Got calls={calls}"
+        )
     assert codex_groups, "OpenAI Codex group should be present"
     assert "gpt-5.3-codex-spark" in _flatten_ids(codex_groups)
     assert codex_groups[0]["models"][0]["label"] == "GPT 5.4"
@@ -75,6 +86,7 @@ def test_openai_codex_group_merges_visible_codex_cache_models(monkeypatch, tmp_p
     out, but the WebUI picker is a Codex-model selection surface and should
     mirror the visible Codex catalog instead of hiding Spark.
     """
+
     def provider_model_ids(provider):
         assert provider == "openai-codex"
         return ["gpt-5.4", "gpt-5.3-codex"]
@@ -105,7 +117,9 @@ def test_openai_codex_group_merges_visible_codex_cache_models(monkeypatch, tmp_p
 
     result = config.get_available_models()
 
-    codex_groups = [g for g in result["groups"] if g.get("provider_id") == "openai-codex"]
+    codex_groups = [
+        g for g in result["groups"] if g.get("provider_id") == "openai-codex"
+    ]
     ids = _flatten_ids(codex_groups)
     assert "gpt-5.3-codex-spark" in ids
     assert "hidden-test-model" not in ids

--- a/tests/test_issue1690_scroll_completion.py
+++ b/tests/test_issue1690_scroll_completion.py
@@ -55,22 +55,42 @@ def test_render_messages_preserve_scroll_option_uses_user_pin_state_not_stream_l
     assert "function renderMessages(options)" in render_body
     assert "const preserveScroll=!!(options&&options.preserveScroll);" in render_body
     assert "_scrollAfterMessageRender(preserveScroll, scrollSnapshot);" in render_body
-    assert "const scrollSnapshot=preserveScroll?_captureMessageScrollSnapshot():null" in render_body
-    assert "if(preserveScroll){\n    if(_scrollPinned) scrollIfPinned();\n    else _restoreMessageScrollSnapshot(scrollSnapshot);\n    return;\n  }" in scroll_helper
-    assert "if(S.activeStreamId){\n    scrollIfPinned();\n    return;\n  }" in scroll_helper
+    assert (
+        "const scrollSnapshot=preserveScroll?_captureMessageScrollSnapshot():null"
+        in render_body
+    )
+    assert (
+        "if(preserveScroll){\n    if(_scrollPinned) scrollIfPinned();\n    else _restoreMessageScrollSnapshot(scrollSnapshot);\n    return;\n  }"
+        in scroll_helper
+    )
+    assert (
+        "if(S.activeStreamId){\n    scrollIfPinned();\n    return;\n  }"
+        in scroll_helper
+    )
 
 
 def test_cached_render_path_uses_same_scroll_policy_as_fresh_render():
     render_body = _function_body(UI_JS, "renderMessages")
-    cached_branch = render_body[render_body.index("if(sid&&sid!==_sessionHtmlCacheSid") : render_body.index("const compressionState=")]
+    cached_branch = render_body[
+        render_body.index("if(sid&&sid!==_sessionHtmlCacheSid") : render_body.index(
+            "const compressionState="
+        )
+    ]
 
     assert "_scrollAfterMessageRender(preserveScroll, scrollSnapshot);" in cached_branch
-    assert "if(S.activeStreamId){scrollIfPinned();}else{scrollToBottom();}" not in cached_branch
+    assert (
+        "if(S.activeStreamId){scrollIfPinned();}else{scrollToBottom();}"
+        not in cached_branch
+    )
 
 
 def test_session_switch_and_idle_session_load_keep_default_bottom_pin_behavior():
     load_session = _function_body(SESSIONS_JS, "loadSession")
-    idle_branch = load_session[load_session.index("}else{\n      S.busy=false;") : load_session.index("// Sync context usage indicator")]
+    idle_branch = load_session[
+        load_session.index("}else{\n      S.busy=false;") : load_session.index(
+            "// Sync context usage indicator"
+        )
+    ]
 
     assert "syncTopbar();renderMessages();" in idle_branch
     assert "preserveScroll:true" not in idle_branch

--- a/tests/test_issue1697_multi_image_paste.py
+++ b/tests/test_issue1697_multi_image_paste.py
@@ -1,4 +1,5 @@
 """Regression coverage for #1697: multi-image clipboard paste attachments."""
+
 import json
 import shutil
 import subprocess
@@ -42,7 +43,9 @@ def _run_node(source: str) -> str:
         check=False,
     )
     if result.returncode != 0:
-        raise RuntimeError(f"node driver failed:\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}")
+        raise RuntimeError(
+            f"node driver failed:\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+        )
     return result.stdout.strip()
 
 
@@ -117,8 +120,7 @@ def test_one_clipboard_paste_with_two_image_items_adds_two_attachment_chips():
         "screenshot-1700000000000-2.png",
     ]
     assert result["lastStatus"] == (
-        "Image pasted: screenshot-1700000000000-1.png, "
-        "screenshot-1700000000000-2.png"
+        "Image pasted: screenshot-1700000000000-1.png, screenshot-1700000000000-2.png"
     )
 
 
@@ -136,7 +138,18 @@ def test_file_picker_and_drop_paths_still_pass_real_file_names_to_addfiles():
     boot = _read_js(BOOT_JS_PATH)
     panels = _read_js(PANELS_JS_PATH)
 
-    assert "$('fileInput').onchange=e=>{addFiles(Array.from(e.target.files));e.target.value='';};" in boot
+    assert (
+        "$('fileInput').onchange=e=>{addFiles(Array.from(e.target.files));e.target.value='';};"
+        in boot
+    )
     assert "const files=Array.from(e.dataTransfer.files);" in panels
     assert "if(files.length){addFiles(files);$('msg').focus();}" in panels
-    assert "screenshot-" not in panels[panels.find("document.addEventListener('drop'") : panels.find("document.addEventListener('drop'") + 900]
+    assert (
+        "screenshot-"
+        not in panels[
+            panels.find("document.addEventListener('drop'") : panels.find(
+                "document.addEventListener('drop'"
+            )
+            + 900
+        ]
+    )

--- a/tests/test_issue1699_model_cache_source_fingerprint.py
+++ b/tests/test_issue1699_model_cache_source_fingerprint.py
@@ -33,7 +33,9 @@ def _valid_models_cache(provider_id: str, model_id: str) -> dict:
         },
         "groups": [
             {
-                "provider": config._PROVIDER_DISPLAY.get(provider_id, provider_id.title()),
+                "provider": config._PROVIDER_DISPLAY.get(
+                    provider_id, provider_id.title()
+                ),
                 "provider_id": provider_id,
                 "models": [{"id": model_id, "label": model_id}],
             }
@@ -107,7 +109,9 @@ def test_memory_models_cache_invalidates_when_auth_store_active_provider_changes
     result = config.get_available_models()
 
     assert result["active_provider"] == "opencode-go"
-    assert not any(group.get("provider_id") == "openrouter" for group in result["groups"])
+    assert not any(
+        group.get("provider_id") == "openrouter" for group in result["groups"]
+    )
     assert any(group.get("provider_id") == "opencode-go" for group in result["groups"])
 
 
@@ -127,7 +131,9 @@ def test_disk_models_cache_invalidates_when_auth_store_active_provider_changes(
     result = config.get_available_models()
 
     assert result["active_provider"] == "opencode-go"
-    assert not any(group.get("provider_id") == "openrouter" for group in result["groups"])
+    assert not any(
+        group.get("provider_id") == "openrouter" for group in result["groups"]
+    )
     assert any(group.get("provider_id") == "opencode-go" for group in result["groups"])
 
 

--- a/tests/test_issue1700_parallel_profile_switch.py
+++ b/tests/test_issue1700_parallel_profile_switch.py
@@ -4,6 +4,7 @@ A WebUI profile switch uses cookie/thread-local profile state, so it should be
 allowed while another session is streaming. Only process-wide profile switches
 must remain blocked because they mutate global Hermes runtime state.
 """
+
 from pathlib import Path
 
 import pytest
@@ -43,7 +44,9 @@ def _prepare_profile_tree(tmp_path, monkeypatch):
 
     monkeypatch.setattr(profiles, "_DEFAULT_HERMES_HOME", default_home)
     monkeypatch.setattr(profiles, "_active_profile", "default")
-    monkeypatch.setattr(profiles, "list_profiles_api", lambda: [{"name": "default"}, {"name": "writer"}])
+    monkeypatch.setattr(
+        profiles, "list_profiles_api", lambda: [{"name": "default"}, {"name": "writer"}]
+    )
     profiles._tls.profile = None
     return profiles
 
@@ -55,7 +58,9 @@ def test_process_wide_switch_still_blocks_when_stream_is_active(tmp_path, monkey
     STREAMS.clear()
     STREAMS["stream-default"] = object()
     try:
-        with pytest.raises(RuntimeError, match="Cannot switch profiles while an agent is running"):
+        with pytest.raises(
+            RuntimeError, match="Cannot switch profiles while an agent is running"
+        ):
             profiles.switch_profile("writer", process_wide=True)
     finally:
         STREAMS.clear()
@@ -88,7 +93,11 @@ def test_frontend_profile_switch_no_longer_blocks_on_busy_state():
 
 def test_frontend_treats_active_or_pending_session_as_in_progress():
     fn = _extract_switch_to_profile()
-    session_block = fn[fn.find("const sessionInProgress") : fn.find("try {", fn.find("const sessionInProgress"))]
+    session_block = fn[
+        fn.find("const sessionInProgress") : fn.find(
+            "try {", fn.find("const sessionInProgress")
+        )
+    ]
 
     assert "S.session.active_stream_id" in session_block
     assert "S.session.pending_user_message" in session_block

--- a/tests/test_issue1731_upward_scroll_unpins.py
+++ b/tests/test_issue1731_upward_scroll_unpins.py
@@ -40,8 +40,7 @@ def _scroll_listener_block() -> str:
 def test_scroll_listener_tracks_last_scroll_top():
     """The listener must remember the previous scrollTop to detect direction."""
     assert "let _lastScrollTop=" in UI_JS, (
-        "Direction detection requires a closure-scoped _lastScrollTop "
-        "tracker (#1731)."
+        "Direction detection requires a closure-scoped _lastScrollTop tracker (#1731)."
     )
 
     block = _scroll_listener_block()

--- a/tests/test_issue1743_model_picker_race.py
+++ b/tests/test_issue1743_model_picker_race.py
@@ -14,7 +14,9 @@ def _body_between(src: str, start: str, end: str) -> str:
 
 def test_model_picker_open_waits_for_async_model_catalog_before_rendering():
     """Opening the visible picker must not render stale static <select> options."""
-    body = _body_between(UI_JS, "async function toggleModelDropdown", "function closeModelDropdown")
+    body = _body_between(
+        UI_JS, "async function toggleModelDropdown", "function closeModelDropdown"
+    )
 
     assert "window._modelDropdownReady" in body
     assert "await" in body
@@ -23,7 +25,9 @@ def test_model_picker_open_waits_for_async_model_catalog_before_rendering():
 
 def test_populate_model_dropdown_rerenders_if_picker_is_already_open():
     """If the async catalog finishes while open, refresh the visible custom rows."""
-    body = _body_between(UI_JS, "async function populateModelDropdown", "// Cache so we don't re-fetch")
+    body = _body_between(
+        UI_JS, "async function populateModelDropdown", "// Cache so we don't re-fetch"
+    )
 
     assert "composerModelDropdown" in body
     assert "classList.contains('open')" in body or 'classList.contains("open")' in body

--- a/tests/test_issue1765_codex_quota.py
+++ b/tests/test_issue1765_codex_quota.py
@@ -2,61 +2,74 @@ from api import streaming
 
 
 CODEX_PLAN_LIMIT_ERROR = (
-    "HTTP 429: {\"error\": {\"type\": \"usage_limit_exceeded\", "
-    "\"message\": \"Plan limit reached. You've reached the limit of messages per 5 hours.\"}}"
+    'HTTP 429: {"error": {"type": "usage_limit_exceeded", '
+    '"message": "Plan limit reached. You\'ve reached the limit of messages per 5 hours."}}'
 )
 
 
 def test_codex_oauth_usage_exhaustion_is_classified_as_quota():
     for err in [
-        'Plan limit reached',
-        'usage_limit_exceeded',
-        'usage limit exceeded',
+        "Plan limit reached",
+        "usage_limit_exceeded",
+        "usage limit exceeded",
         "You've reached the limit of messages per 5 hours",
         "You've used up your usage",
         CODEX_PLAN_LIMIT_ERROR,
     ]:
         classified = streaming._classify_provider_error(err, Exception(err))
-        assert classified['type'] == 'quota_exhausted', err
-        assert classified['label'] == 'Out of credits'
-        assert 'credits' in classified['hint'].lower() or 'usage' in classified['hint'].lower()
+        assert classified["type"] == "quota_exhausted", err
+        assert classified["label"] == "Out of credits"
+        assert (
+            "credits" in classified["hint"].lower()
+            or "usage" in classified["hint"].lower()
+        )
 
 
 def test_silent_provider_failure_gets_specific_catch_all_error():
-    classified = streaming._classify_provider_error('', None, silent_failure=True)
+    classified = streaming._classify_provider_error("", None, silent_failure=True)
 
-    assert classified['type'] == 'no_response'
-    assert classified['label'] == 'No response from provider'
-    assert 'returned no content and no error' in classified['hint']
+    assert classified["type"] == "no_response"
+    assert classified["label"] == "No response from provider"
+    assert "returned no content and no error" in classified["hint"]
 
 
 def test_provider_error_payload_includes_bounded_redacted_details(monkeypatch):
-    secret = 'sk-proj-' + ('a' * 80)
-    raw_error = CODEX_PLAN_LIMIT_ERROR + ' token=' + secret
+    secret = "sk-proj-" + ("a" * 80)
+    raw_error = CODEX_PLAN_LIMIT_ERROR + " token=" + secret
 
-    monkeypatch.setattr(streaming, '_redact_text', lambda text: text.replace(secret, '[REDACTED]'))
-    payload = streaming._provider_error_payload(raw_error, 'quota_exhausted', 'Switch providers')
+    monkeypatch.setattr(
+        streaming, "_redact_text", lambda text: text.replace(secret, "[REDACTED]")
+    )
+    payload = streaming._provider_error_payload(
+        raw_error, "quota_exhausted", "Switch providers"
+    )
 
-    assert payload['message']
-    assert secret not in payload['message']
-    assert payload['details']
-    assert secret not in payload['details']
-    assert '[REDACTED]' in payload['details']
-    assert len(payload['details']) <= 1200
+    assert payload["message"]
+    assert secret not in payload["message"]
+    assert payload["details"]
+    assert secret not in payload["details"]
+    assert "[REDACTED]" in payload["details"]
+    assert len(payload["details"]) <= 1200
 
 
 def test_frontend_renders_apperror_details_in_collapsible_block():
-    messages_js = (streaming.Path(__file__).resolve().parent.parent / 'static' / 'messages.js').read_text()
-    ui_js = (streaming.Path(__file__).resolve().parent.parent / 'static' / 'ui.js').read_text()
-    style_css = (streaming.Path(__file__).resolve().parent.parent / 'static' / 'style.css').read_text()
+    messages_js = (
+        streaming.Path(__file__).resolve().parent.parent / "static" / "messages.js"
+    ).read_text()
+    ui_js = (
+        streaming.Path(__file__).resolve().parent.parent / "static" / "ui.js"
+    ).read_text()
+    style_css = (
+        streaming.Path(__file__).resolve().parent.parent / "static" / "style.css"
+    ).read_text()
     apperror_idx = messages_js.find("source.addEventListener('apperror'")
     warning_idx = messages_js.find("source.addEventListener('warning'", apperror_idx)
     assert apperror_idx != -1 and warning_idx != -1
     apperror_block = messages_js[apperror_idx:warning_idx]
 
-    assert 'd.details' in apperror_block
-    assert 'provider_details:details' in apperror_block
-    assert 'm.provider_details' in ui_js
+    assert "d.details" in apperror_block
+    assert "provider_details:details" in apperror_block
+    assert "m.provider_details" in ui_js
     assert '<details class="provider-error-details"' in ui_js
-    assert 'Provider details' in ui_js
-    assert '.provider-error-details' in style_css
+    assert "Provider details" in ui_js
+    assert ".provider-error-details" in style_css

--- a/tests/test_issue1771_session_model_switch_sync.py
+++ b/tests/test_issue1771_session_model_switch_sync.py
@@ -7,6 +7,7 @@ These tests execute the real static/ui.js syncTopbar() path in Node with a tiny
 DOM/select shim so the behavioral contract is protected without needing a full
 browser harness.
 """
+
 import json
 import shutil
 import subprocess
@@ -144,7 +145,15 @@ def driver_path(tmp_path_factory):
     return str(p)
 
 
-def _run_sync(driver_path, *, session_model, initial_value="@expensive:gpt-5.5", default_model="@safe:gpt-4o-mini", dropdown_open=False, model_resolution_deferred=False):
+def _run_sync(
+    driver_path,
+    *,
+    session_model,
+    initial_value="@expensive:gpt-5.5",
+    default_model="@safe:gpt-4o-mini",
+    dropdown_open=False,
+    model_resolution_deferred=False,
+):
     payload = {
         "sessionModel": session_model,
         "sessionProvider": None,
@@ -154,7 +163,11 @@ def _run_sync(driver_path, *, session_model, initial_value="@expensive:gpt-5.5",
         "dropdownOpen": dropdown_open,
         "modelResolutionDeferred": model_resolution_deferred,
         "options": [
-            {"provider": "expensive", "value": "@expensive:gpt-5.5", "label": "GPT-5.5"},
+            {
+                "provider": "expensive",
+                "value": "@expensive:gpt-5.5",
+                "label": "GPT-5.5",
+            },
             {"provider": "safe", "value": "@safe:gpt-4o-mini", "label": "GPT-4o mini"},
         ],
     }
@@ -165,11 +178,15 @@ def _run_sync(driver_path, *, session_model, initial_value="@expensive:gpt-5.5",
         timeout=10,
     )
     if result.returncode != 0:
-        raise RuntimeError(f"node driver failed:\nSTDOUT={result.stdout}\nSTDERR={result.stderr}")
+        raise RuntimeError(
+            f"node driver failed:\nSTDOUT={result.stdout}\nSTDERR={result.stderr}"
+        )
     return json.loads(result.stdout)
 
 
-def test_sync_topbar_missing_model_falls_back_to_configured_default_not_previous_chat(driver_path):
+def test_sync_topbar_missing_model_falls_back_to_configured_default_not_previous_chat(
+    driver_path,
+):
     got = _run_sync(driver_path, session_model="")
 
     assert got["selectValue"] == "@safe:gpt-4o-mini"
@@ -178,7 +195,9 @@ def test_sync_topbar_missing_model_falls_back_to_configured_default_not_previous
     assert got["selectValue"] != "@expensive:gpt-5.5"
 
 
-def test_sync_topbar_unknown_model_falls_back_to_configured_default_not_first_option(driver_path):
+def test_sync_topbar_unknown_model_falls_back_to_configured_default_not_first_option(
+    driver_path,
+):
     got = _run_sync(driver_path, session_model="unknown")
 
     assert got["selectValue"] == "@safe:gpt-4o-mini"
@@ -186,7 +205,9 @@ def test_sync_topbar_unknown_model_falls_back_to_configured_default_not_first_op
     assert got["sessionProvider"] == "safe"
 
 
-def test_sync_topbar_rerenders_open_visible_model_dropdown_after_session_model_change(driver_path):
+def test_sync_topbar_rerenders_open_visible_model_dropdown_after_session_model_change(
+    driver_path,
+):
     got = _run_sync(driver_path, session_model="", dropdown_open=True)
 
     assert got["selectValue"] == "@safe:gpt-4o-mini"
@@ -194,8 +215,9 @@ def test_sync_topbar_rerenders_open_visible_model_dropdown_after_session_model_c
     assert got["calls"]["positionModelDropdown"] >= 1
 
 
-
-def test_sync_topbar_does_not_persist_correction_while_model_resolution_deferred(driver_path):
+def test_sync_topbar_does_not_persist_correction_while_model_resolution_deferred(
+    driver_path,
+):
     """Regression for stage-310 Opus review: the !hasSessionModel branch must
     skip the network write + state mutation while sessions.js has set
     _modelResolutionDeferred=true between the fast-path session render and
@@ -210,12 +232,28 @@ def test_sync_topbar_does_not_persist_correction_while_model_resolution_deferred
     # Visible UX still happens (sel.value gets the safe default) ...
     assert got_empty["selectValue"] == "@safe:gpt-4o-mini"
     # ... but session state is NOT mutated and NO POST is issued.
-    assert got_empty["sessionModel"] == "", "S.session.model must not be mutated while resolution is deferred"
-    update_calls = [c for c in got_empty["calls"]["fetches"] if "session" in c["url"] and "update" in c["url"]]
-    assert update_calls == [], f"no /api/session/update POSTs while deferred (got {update_calls})"
+    assert got_empty["sessionModel"] == "", (
+        "S.session.model must not be mutated while resolution is deferred"
+    )
+    update_calls = [
+        c
+        for c in got_empty["calls"]["fetches"]
+        if "session" in c["url"] and "update" in c["url"]
+    ]
+    assert update_calls == [], (
+        f"no /api/session/update POSTs while deferred (got {update_calls})"
+    )
 
-    got_unknown = _run_sync(driver_path, session_model="unknown", model_resolution_deferred=True)
+    got_unknown = _run_sync(
+        driver_path, session_model="unknown", model_resolution_deferred=True
+    )
     assert got_unknown["selectValue"] == "@safe:gpt-4o-mini"
     assert got_unknown["sessionModel"] == "unknown"
-    update_calls_u = [c for c in got_unknown["calls"]["fetches"] if "session" in c["url"] and "update" in c["url"]]
-    assert update_calls_u == [], "imported/read-only CLI session with model=unknown must not be silently written"
+    update_calls_u = [
+        c
+        for c in got_unknown["calls"]["fetches"]
+        if "session" in c["url"] and "update" in c["url"]
+    ]
+    assert update_calls_u == [], (
+        "imported/read-only CLI session with model=unknown must not be silently written"
+    )

--- a/tests/test_issue1785_workspace_preview_breadcrumb.py
+++ b/tests/test_issue1785_workspace_preview_breadcrumb.py
@@ -31,11 +31,16 @@ def test_clear_preview_can_keep_preview_only_panel_open_for_directory_navigation
         "clearPreview() needs an explicit keep-open option so breadcrumb/directory "
         "navigation can leave preview-only mode without closing the workspace panel."
     )
-    assert "_workspacePanelMode==='preview'&&!keepPanelOpen" in block.replace(" ", ""), (
+    assert "_workspacePanelMode==='preview'&&!keepPanelOpen" in block.replace(
+        " ", ""
+    ), (
         "Preview-only close behavior should remain for the X button, but must be gated "
         "off when directory navigation requests keepPanelOpen."
     )
-    assert "openWorkspacePanel('browse')" in block or '_setWorkspacePanelMode("browse")' in block, (
+    assert (
+        "openWorkspacePanel('browse')" in block
+        or '_setWorkspacePanelMode("browse")' in block
+    ), (
         "When keepPanelOpen is requested from preview-only mode, clearPreview() should "
         "transition the workspace panel to browse mode so the root listing remains visible."
     )
@@ -52,7 +57,9 @@ def test_load_dir_keeps_workspace_panel_open_when_clearing_preview():
 
 def test_file_preview_breadcrumb_uses_directory_navigation_for_root():
     block = _function_block(WORKSPACE_JS, "renderFileBreadcrumb")
-    assert "loadDir('.')" in block, "The preview root breadcrumb should navigate to the workspace root."
+    assert "loadDir('.')" in block, (
+        "The preview root breadcrumb should navigate to the workspace root."
+    )
     assert "clearPreview(); loadDir('.')" not in block, (
         "The preview root breadcrumb should not do a close-style preview clear before "
         "directory navigation; loadDir() owns the keep-open preview clear."

--- a/tests/test_issue1786_workspace_heading_actions.py
+++ b/tests/test_issue1786_workspace_heading_actions.py
@@ -25,11 +25,15 @@ def test_workspace_heading_context_menu_exposes_root_reveal_and_copy_path():
 
 def test_workspace_heading_affordance_requires_workspace():
     """The heading should only advertise button behavior when a workspace exists."""
-    heading_line = next(line for line in INDEX_HTML.splitlines() if 'id="workspacePanelHeading"' in line)
+    heading_line = next(
+        line for line in INDEX_HTML.splitlines() if 'id="workspacePanelHeading"' in line
+    )
     assert 'role="button"' not in heading_line
     assert 'tabindex="0"' not in heading_line
     assert "_syncWorkspaceHeadingState" in UI_JS
-    assert "heading.classList.toggle('workspace-panel-heading--enabled',enabled)" in UI_JS
+    assert (
+        "heading.classList.toggle('workspace-panel-heading--enabled',enabled)" in UI_JS
+    )
     assert "heading.setAttribute('role','button')" in UI_JS
     assert "heading.setAttribute('tabindex','0')" in UI_JS
     assert "heading.removeAttribute('role')" in UI_JS

--- a/tests/test_issue1793_file_tree_cruft_filter.py
+++ b/tests/test_issue1793_file_tree_cruft_filter.py
@@ -40,8 +40,14 @@ def test_workspace_panel_has_show_hidden_files_toggle():
 def test_file_tree_filters_common_cruft_by_default():
     """macOS/Windows/VCS/cache noise should not render by default."""
     assert "WORKSPACE_HIDDEN_FILE_NAMES" in UI_JS
-    for name in [".DS_Store", "Thumbs.db", "Desktop.ini", ".git",
-                 "__pycache__", "node_modules"]:
+    for name in [
+        ".DS_Store",
+        "Thumbs.db",
+        "Desktop.ini",
+        ".git",
+        "__pycache__",
+        "node_modules",
+    ]:
         assert name in UI_JS
     assert "_visibleWorkspaceEntries" in UI_JS
     assert "S.showHiddenWorkspaceFiles" in UI_JS
@@ -95,7 +101,7 @@ def test_panel_heading_has_hidden_files_indicator():
     """
     assert 'id="workspaceHiddenIndicator"' in INDEX_HTML
     # The indicator opens the same menu when clicked (no separate code path)
-    block = INDEX_HTML[INDEX_HTML.index('id="workspaceHiddenIndicator"'):]
+    block = INDEX_HTML[INDEX_HTML.index('id="workspaceHiddenIndicator"') :]
     block = block[: block.index("</span>") + 7]
     assert "toggleWorkspacePrefsMenu" in block
     # Default-hidden so the chip doesn't clutter normal state

--- a/tests/test_issue1796_error_toasts.py
+++ b/tests/test_issue1796_error_toasts.py
@@ -8,12 +8,17 @@ STYLE_CSS = (ROOT / "static" / "style.css").read_text()
 def test_error_toast_default_duration_is_substantially_longer_than_info_toasts():
     assert "const TOAST_DEFAULT_MS=2800" in UI_JS
     assert "const TOAST_ERROR_DEFAULT_MS=20000" in UI_JS
-    assert "const duration=(ms==null)?(t==='error'?TOAST_ERROR_DEFAULT_MS:TOAST_DEFAULT_MS):ms" in UI_JS
+    assert (
+        "const duration=(ms==null)?(t==='error'?TOAST_ERROR_DEFAULT_MS:TOAST_DEFAULT_MS):ms"
+        in UI_JS
+    )
     assert "ms||2800" not in UI_JS
 
 
 def test_error_toast_keeps_explicit_duration_override():
-    show_toast = UI_JS[UI_JS.index("function showToast"):UI_JS.index("// ── Shared app dialogs")]
+    show_toast = UI_JS[
+        UI_JS.index("function showToast") : UI_JS.index("// ── Shared app dialogs")
+    ]
     assert "ms==null" in show_toast
     assert "?TOAST_ERROR_DEFAULT_MS" in show_toast
     assert ":TOAST_DEFAULT_MS" in show_toast
@@ -21,7 +26,9 @@ def test_error_toast_keeps_explicit_duration_override():
 
 
 def test_error_toast_has_copy_button_for_exact_error_text():
-    show_toast = UI_JS[UI_JS.index("function showToast"):UI_JS.index("// ── Shared app dialogs")]
+    show_toast = UI_JS[
+        UI_JS.index("function showToast") : UI_JS.index("// ── Shared app dialogs")
+    ]
     assert "toast-copy" in show_toast
     assert "data-toast-copy" in show_toast
     assert "copyToastText" in show_toast

--- a/tests/test_issue1800_file_html_interactions.py
+++ b/tests/test_issue1800_file_html_interactions.py
@@ -51,8 +51,8 @@ def test_html_chat_attachment_opens_sandboxed_inline_raw_file():
     body = _slice_after(UI_JS, "function _renderAttachmentHtml", 900)
     assert "_HTML_EXTS.test(fname)" in body
     assert "inline=1" in body
-    assert "target=\"_blank\"" in body
-    assert "rel=\"noopener\"" in body
+    assert 'target="_blank"' in body
+    assert 'rel="noopener"' in body
     assert "msg-file-badge--html" in body
 
 
@@ -60,8 +60,8 @@ def test_html_media_open_full_uses_inline_new_tab_not_download():
     """MEDIA: HTML preview's Open full page link should open a browser view."""
     body = _slice_after(UI_JS, "function loadHtmlInline", 1800)
     assert "'&inline=1'" in body
-    assert "target=\"_blank\"" in body
-    assert "rel=\"noopener\"" in body
+    assert 'target="_blank"' in body
+    assert 'rel="noopener"' in body
     normal_open = next(line for line in body.splitlines() if "html-open-link" in line)
     assert "download=" not in normal_open
 

--- a/tests/test_issue1806_named_custom_provider_resolution.py
+++ b/tests/test_issue1806_named_custom_provider_resolution.py
@@ -83,7 +83,11 @@ def test_available_models_drops_base_url_derived_custom_slug(monkeypatch):
     fake_auth.get_auth_status = lambda _pid: {"key_source": "config_yaml"}
     monkeypatch.setitem(sys.modules, "hermes_cli.models", fake_models)
     monkeypatch.setitem(sys.modules, "hermes_cli.auth", fake_auth)
-    monkeypatch.setattr(config, "_get_auth_store_path", lambda: config.Path("/tmp/does-not-exist-auth.json"))
+    monkeypatch.setattr(
+        config,
+        "_get_auth_store_path",
+        lambda: config.Path("/tmp/does-not-exist-auth.json"),
+    )
     monkeypatch.setattr("socket.getaddrinfo", lambda *a, **k: [])
 
     class _Resp:

--- a/tests/test_issue1807_codex_provider_card_live_models.py
+++ b/tests/test_issue1807_codex_provider_card_live_models.py
@@ -28,12 +28,18 @@ def _install_fake_hermes_cli(monkeypatch, provider_model_ids):
 
 def _configure_codex(monkeypatch, tmp_path):
     monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
-    monkeypatch.setattr(config, "_get_config_path", lambda: tmp_path / "missing-config.yaml")
-    monkeypatch.setattr(config, "cfg", {
-        "model": {"provider": "openai-codex", "default": "gpt-5.5"},
-        "providers": {},
-        "fallback_providers": [],
-    })
+    monkeypatch.setattr(
+        config, "_get_config_path", lambda: tmp_path / "missing-config.yaml"
+    )
+    monkeypatch.setattr(
+        config,
+        "cfg",
+        {
+            "model": {"provider": "openai-codex", "default": "gpt-5.5"},
+            "providers": {},
+            "fallback_providers": [],
+        },
+    )
     monkeypatch.setattr(config, "_cfg_mtime", 0.0)
     # Isolate the Codex local model cache so the dev machine's real
     # ~/.codex/models_cache.json (which may include account-specific entries
@@ -77,7 +83,9 @@ def test_codex_provider_card_prefers_live_account_catalog(monkeypatch, tmp_path)
     assert "codex-mini-latest" not in ids
 
 
-def test_codex_provider_card_keeps_static_fallback_when_live_catalog_empty(monkeypatch, tmp_path):
+def test_codex_provider_card_keeps_static_fallback_when_live_catalog_empty(
+    monkeypatch, tmp_path
+):
     _install_fake_hermes_cli(monkeypatch, lambda _pid: [])
     _configure_codex(monkeypatch, tmp_path)
 

--- a/tests/test_issue1823_kanban_not_found.py
+++ b/tests/test_issue1823_kanban_not_found.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import io
 import json
 import pytest
-from types import SimpleNamespace
 from urllib.parse import urlparse
 
 from api import routes
@@ -73,9 +72,24 @@ def test_kanban_stale_client_error_renders_hard_refresh_escape_hatch():
     ("method", "path", "payload_attr", "payload_error"),
     [
         ("GET", "/api/kanban/tasks/abc/log", "_task_log_payload", "task not found"),
-        ("POST", "/api/kanban/boards", "_create_board_payload", "invalid board payload"),
-        ("PATCH", "/api/kanban/boards/abc", "_update_board_payload", "invalid patch payload"),
-        ("DELETE", "/api/kanban/links", "_link_tasks_payload", "invalid delete payload"),
+        (
+            "POST",
+            "/api/kanban/boards",
+            "_create_board_payload",
+            "invalid board payload",
+        ),
+        (
+            "PATCH",
+            "/api/kanban/boards/abc",
+            "_update_board_payload",
+            "invalid patch payload",
+        ),
+        (
+            "DELETE",
+            "/api/kanban/links",
+            "_link_tasks_payload",
+            "invalid delete payload",
+        ),
     ],
 )
 def test_inner_handler_bad_response_does_not_emit_double_404(
@@ -91,7 +105,9 @@ def test_inner_handler_bad_response_does_not_emit_double_404(
     # Force one kanban payload helper to hit bad() and return None, so the
     # wrapper path should not append _kanban_unknown_endpoint.
     monkeypatch.setattr(
-        kanban_bridge, payload_attr, lambda *a, **kw: (_ for _ in ()).throw(LookupError(payload_error))
+        kanban_bridge,
+        payload_attr,
+        lambda *a, **kw: (_ for _ in ()).throw(LookupError(payload_error)),
     )
 
     handler = _FakeHandler()

--- a/tests/test_issue1850_csp_connect_src_jsdelivr.py
+++ b/tests/test_issue1850_csp_connect_src_jsdelivr.py
@@ -5,6 +5,7 @@ cdn.jsdelivr.net via <script> tags. Their bundled source maps also live on
 jsDelivr and are fetched via connect (not script load), so connect-src must
 include cdn.jsdelivr.net or browsers block the fetch and emit CSP violations.
 """
+
 import re
 from pathlib import Path
 

--- a/tests/test_issue1855_request_diagnostics.py
+++ b/tests/test_issue1855_request_diagnostics.py
@@ -52,7 +52,9 @@ def test_all_sessions_reports_internal_index_stages(tmp_path, monkeypatch):
     index_file = session_dir / "_index.json"
     monkeypatch.setattr(models, "SESSION_DIR", session_dir)
     monkeypatch.setattr(models, "SESSION_INDEX_FILE", index_file)
-    monkeypatch.setattr(models, "_enrich_sidebar_lineage_metadata", lambda sessions: None)
+    monkeypatch.setattr(
+        models, "_enrich_sidebar_lineage_metadata", lambda sessions: None
+    )
     models.SESSIONS.clear()
 
     s = Session(

--- a/tests/test_issue1857_usage_overwrite.py
+++ b/tests/test_issue1857_usage_overwrite.py
@@ -7,7 +7,9 @@ from unittest import mock
 _MISSING = object()
 
 
-def test_stream_completion_overwrites_session_usage_with_latest_turn(cleanup_test_sessions):
+def test_stream_completion_overwrites_session_usage_with_latest_turn(
+    cleanup_test_sessions,
+):
     """#1857: completed turns must not add prompt tokens to stale session totals."""
     import api.streaming as streaming
 
@@ -143,11 +145,17 @@ def test_stream_completion_overwrites_session_usage_with_latest_turn(cleanup_tes
     _saved = {k: sys.modules.get(k, _MISSING) for k in _injected}
     sys.modules.update(_injected)
     try:
-        with mock.patch.object(streaming, "get_session", return_value=fake_session), \
-             mock.patch.object(streaming, "_get_ai_agent", return_value=UsageAgent), \
-             mock.patch.object(streaming, "resolve_model_provider", return_value=("gpt-5.4", "openai", None)), \
-             mock.patch("api.config.get_config", return_value={}), \
-             mock.patch("api.config._resolve_cli_toolsets", return_value=[]):
+        with (
+            mock.patch.object(streaming, "get_session", return_value=fake_session),
+            mock.patch.object(streaming, "_get_ai_agent", return_value=UsageAgent),
+            mock.patch.object(
+                streaming,
+                "resolve_model_provider",
+                return_value=("gpt-5.4", "openai", None),
+            ),
+            mock.patch("api.config.get_config", return_value={}),
+            mock.patch("api.config._resolve_cli_toolsets", return_value=[]),
+        ):
             streaming.STREAMS[fake_stream_id] = fake_queue
             streaming._run_agent_streaming(
                 session_id=fake_session.session_id,

--- a/tests/test_issue1879_cross_container_gateway_liveness.py
+++ b/tests/test_issue1879_cross_container_gateway_liveness.py
@@ -299,7 +299,10 @@ def test_no_runtime_status_still_reports_unknown(monkeypatch):
     payload = agent_health.build_agent_health_payload()
 
     assert payload["alive"] is None
-    assert payload["details"] == {"state": "unknown", "reason": "gateway_not_configured"}
+    assert payload["details"] == {
+        "state": "unknown",
+        "reason": "gateway_not_configured",
+    }
 
 
 # -- _runtime_status_is_fresh unit-level coverage -----------------------------
@@ -312,7 +315,9 @@ def test_runtime_status_is_fresh_unit_helper():
     now = datetime(2026, 5, 8, 12, 0, 0, tzinfo=timezone.utc)
 
     # Boundary: exactly threshold = fresh.
-    on_boundary = _iso(now - timedelta(seconds=agent_health.GATEWAY_FRESHNESS_THRESHOLD_S))
+    on_boundary = _iso(
+        now - timedelta(seconds=agent_health.GATEWAY_FRESHNESS_THRESHOLD_S)
+    )
     assert agent_health._runtime_status_is_fresh(
         {"gateway_state": "running", "updated_at": on_boundary},
         now=now,

--- a/tests/test_issue1880_profile_scoped_skills.py
+++ b/tests/test_issue1880_profile_scoped_skills.py
@@ -50,7 +50,9 @@ class _IsolatedSkillsDirs:
             self.root_skills.symlink_to(self._root_symlink_target)
 
 
-def _write_skill(skills_dir: pathlib.Path, name: str, description: str, body: str) -> pathlib.Path:
+def _write_skill(
+    skills_dir: pathlib.Path, name: str, description: str, body: str
+) -> pathlib.Path:
     skill_dir = skills_dir / name
     (skill_dir / "references").mkdir(parents=True, exist_ok=True)
     (skill_dir / "SKILL.md").write_text(

--- a/tests/test_issue1881_phantom_custom_groups.py
+++ b/tests/test_issue1881_phantom_custom_groups.py
@@ -46,6 +46,7 @@ import api.config as config
 # Fixtures
 # ---------------------------------------------------------------------------
 
+
 @pytest.fixture(autouse=True)
 def _isolate_models_cache(tmp_path, monkeypatch):
     monkeypatch.setattr(config, "_models_cache_path", tmp_path / "models_cache.json")
@@ -99,7 +100,9 @@ def _stub_provider_modules(monkeypatch, detected_provider_ids: list[dict]):
     monkeypatch.setitem(sys.modules, "hermes_cli.models", fake_models)
     monkeypatch.setitem(sys.modules, "hermes_cli.auth", fake_auth)
     monkeypatch.setattr(
-        config, "_get_auth_store_path", lambda: config.Path("/tmp/does-not-exist-auth.json")
+        config,
+        "_get_auth_store_path",
+        lambda: config.Path("/tmp/does-not-exist-auth.json"),
     )
 
 
@@ -107,6 +110,7 @@ def _stub_provider_modules(monkeypatch, detected_provider_ids: list[dict]):
 # Fix #1 — bare "custom" PID must not absorb auto_detected_models when the
 # active provider is concrete (ai-gateway etc.)
 # ---------------------------------------------------------------------------
+
 
 def test_no_phantom_custom_group_when_active_provider_is_ai_gateway(monkeypatch):
     """The bare "custom" PID must not duplicate ai-gateway models (#1881)."""
@@ -143,6 +147,7 @@ def test_no_phantom_custom_group_when_active_provider_is_ai_gateway(monkeypatch)
 # ---------------------------------------------------------------------------
 # Fix #2 — unnamed custom:* PIDs must not fall through to auto_detected
 # ---------------------------------------------------------------------------
+
 
 def test_unnamed_custom_provider_id_does_not_inherit_auto_detected(monkeypatch):
     """A custom:* PID NOT in _named_custom_groups must skip cleanly (#1881).
@@ -185,6 +190,7 @@ def test_unnamed_custom_provider_id_does_not_inherit_auto_detected(monkeypatch):
 # active provider IS the named custom slug
 # ---------------------------------------------------------------------------
 
+
 def test_named_custom_group_still_populates_when_active_is_custom_alias(monkeypatch):
     """Named custom_providers groups still appear when the active provider IS
     the named custom slug — preserves test_issue1806 invariants."""
@@ -197,7 +203,9 @@ def test_named_custom_group_still_populates_when_active_is_custom_alias(monkeypa
     monkeypatch.setitem(sys.modules, "hermes_cli.models", fake_models)
     monkeypatch.setitem(sys.modules, "hermes_cli.auth", fake_auth)
     monkeypatch.setattr(
-        config, "_get_auth_store_path", lambda: config.Path("/tmp/does-not-exist-auth.json")
+        config,
+        "_get_auth_store_path",
+        lambda: config.Path("/tmp/does-not-exist-auth.json"),
     )
     monkeypatch.setattr("socket.getaddrinfo", lambda *a, **k: [])
 

--- a/tests/test_issue1896_context_length_fallback_args.py
+++ b/tests/test_issue1896_context_length_fallback_args.py
@@ -74,10 +74,9 @@ def _both_callsites():
         # Skip legacy fallbacks (gated under `except TypeError:` for older builds).
         # These are intentionally 2-arg.
         # Look back ~200 chars for the legacy marker.
-        lookback = src[max(0, idx - 400):idx]
+        lookback = src[max(0, idx - 400) : idx]
         is_legacy_fallback = (
-            "except TypeError:" in lookback
-            and "_legacy_cl" in block + lookback
+            "except TypeError:" in lookback and "_legacy_cl" in block + lookback
         ) or "_legacy_cl(" in block
         # Also exclude any callsite where the immediately preceding line
         # is part of a TypeError fallback block (the second callsite shape:
@@ -112,7 +111,7 @@ def test_both_callsites_pass_config_context_length():
     blocks = _both_callsites()
     for i, block in enumerate(blocks):
         assert "config_context_length=_cfg_ctx_len" in block, (
-            f"Callsite #{i+1} is missing `config_context_length=_cfg_ctx_len`. "
+            f"Callsite #{i + 1} is missing `config_context_length=_cfg_ctx_len`. "
             f"Without it, users who set `model.context_length: 1048576` in "
             f"config.yaml get 256K from the default fallback. See #1896.\n\n"
             f"Block:\n{block}"
@@ -124,7 +123,7 @@ def test_both_callsites_pass_provider():
     blocks = _both_callsites()
     for i, block in enumerate(blocks):
         assert "provider=resolved_provider" in block, (
-            f"Callsite #{i+1} is missing `provider=resolved_provider...`. "
+            f"Callsite #{i + 1} is missing `provider=resolved_provider...`. "
             f"Provider is needed for the registry lookup step (models.dev "
             f"provider-aware lookup). See #1896.\n\nBlock:\n{block}"
         )
@@ -135,7 +134,7 @@ def test_both_callsites_pass_custom_providers():
     blocks = _both_callsites()
     for i, block in enumerate(blocks):
         assert "custom_providers=_cfg_custom_providers" in block, (
-            f"Callsite #{i+1} is missing `custom_providers=_cfg_custom_providers`. "
+            f"Callsite #{i + 1} is missing `custom_providers=_cfg_custom_providers`. "
             f"This is needed for the `custom_providers` per-model context_length "
             f"override path. See #1896.\n\nBlock:\n{block}"
         )

--- a/tests/test_issue1897_profile_switch_agent_cache.py
+++ b/tests/test_issue1897_profile_switch_agent_cache.py
@@ -19,7 +19,9 @@ def _signature_block() -> str:
     return STREAMING_PY[sig_start:sig_end]
 
 
-def test_same_session_profile_switch_rebuilds_agent_under_new_soul_home(tmp_path, monkeypatch):
+def test_same_session_profile_switch_rebuilds_agent_under_new_soul_home(
+    tmp_path, monkeypatch
+):
     """Switching profiles in one WebUI session must not reuse old SOUL.md.
 
     The fake AIAgent mirrors the real failure mode: it reads SOUL.md from
@@ -158,7 +160,9 @@ def test_same_session_profile_switch_rebuilds_agent_under_new_soul_home(tmp_path
         "resolve_model_provider",
         lambda _model: ("test-model", "test-provider", None),
     )
-    monkeypatch.setattr(streaming, "_maybe_schedule_title_refresh", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        streaming, "_maybe_schedule_title_refresh", lambda *args, **kwargs: None
+    )
     monkeypatch.setattr(profiles, "get_hermes_home_for_profile", home_for_profile)
     monkeypatch.setattr(profiles, "get_profile_runtime_env", lambda _home: {})
     monkeypatch.setattr(
@@ -200,7 +204,9 @@ def test_same_session_profile_switch_rebuilds_agent_under_new_soul_home(tmp_path
 
     run_turn("alpha", "issue1897-stream-1", "first turn")
     run_turn("alpha", "issue1897-stream-2", "same profile second turn")
-    assert len(constructed_agents) == 1, "same-profile turns should reuse the cached agent"
+    assert len(constructed_agents) == 1, (
+        "same-profile turns should reuse the cached agent"
+    )
 
     run_turn("beta", "issue1897-stream-3", "profile switched turn")
 
@@ -219,7 +225,10 @@ def test_same_session_profile_switch_rebuilds_agent_under_new_soul_home(tmp_path
         str(profile_b_home),
     ]
     with cfg.SESSION_AGENT_CACHE_LOCK:
-        assert cfg.SESSION_AGENT_CACHE[fake_session.session_id][0] is constructed_agents[-1]
+        assert (
+            cfg.SESSION_AGENT_CACHE[fake_session.session_id][0]
+            is constructed_agents[-1]
+        )
 
 
 def test_cache_signature_includes_profile_home():
@@ -232,7 +241,9 @@ def test_cache_signature_includes_profile_home():
 
 
 def test_profile_home_resolved_before_cache_signature():
-    profile_home_assignment = STREAMING_PY.index("_profile_home = str(_profile_home_path)")
+    profile_home_assignment = STREAMING_PY.index(
+        "_profile_home = str(_profile_home_path)"
+    )
     sig_start = STREAMING_PY.index("_sig_blob = _json.dumps")
     assert profile_home_assignment < sig_start
 

--- a/tests/test_issue1908_docker_hardening.py
+++ b/tests/test_issue1908_docker_hardening.py
@@ -1,4 +1,5 @@
 """Regression coverage for issue #1908 Docker production hardening."""
+
 import pathlib
 import re
 
@@ -22,18 +23,26 @@ def test_production_dockerfile_does_not_grant_passwordless_sudo():
     """The production image must not install sudo or grant NOPASSWD root escalation."""
     packages = _dockerfile_install_packages()
     assert "sudo" not in packages, "production Dockerfile must not install sudo"
-    assert "NOPASSWD" not in DOCKERFILE, "production Dockerfile must not grant passwordless sudo"
+    assert "NOPASSWD" not in DOCKERFILE, (
+        "production Dockerfile must not grant passwordless sudo"
+    )
     assert "adduser hermeswebui sudo" not in DOCKERFILE
     assert "adduser hermeswebuitoo sudo" not in DOCKERFILE
-    assert "hermeswebuitoo" not in DOCKERFILE, "production image should not keep a sudo-capable staging user"
+    assert "hermeswebuitoo" not in DOCKERFILE, (
+        "production image should not keep a sudo-capable staging user"
+    )
 
 
 def test_init_script_does_not_depend_on_sudo_at_runtime():
     """Runtime setup may start as root, but must drop privileges without sudo."""
-    assert re.search(r"^if \[ \"A\$\{whoami\}\" == \"Aroot\" \]; then", INIT_SCRIPT, re.MULTILINE), (
+    assert re.search(
+        r"^if \[ \"A\$\{whoami\}\" == \"Aroot\" \]; then", INIT_SCRIPT, re.MULTILINE
+    ), (
         "docker_init.bash should perform privileged setup only in an explicit root init block"
     )
-    assert "sudo " not in INIT_SCRIPT, "docker_init.bash must not invoke sudo in production"
+    assert "sudo " not in INIT_SCRIPT, (
+        "docker_init.bash must not invoke sudo in production"
+    )
     assert re.search(r"\bsu\b.*\bhermeswebui\b", INIT_SCRIPT), (
         "docker_init.bash must drop from root to hermeswebui before launching the server"
     )
@@ -53,7 +62,9 @@ def test_init_script_uses_private_scratch_permissions():
 
 def test_docker_docs_explain_production_privilege_model():
     """Docs must describe the production threat model rather than hiding the tradeoff."""
-    hardening_section = DOCKER_DOCS[DOCKER_DOCS.find("## Production image security model") :]
+    hardening_section = DOCKER_DOCS[
+        DOCKER_DOCS.find("## Production image security model") :
+    ]
     assert "## Production image security model" in DOCKER_DOCS
     assert "passwordless sudo" in hardening_section
     assert "root" in hardening_section and "hermeswebui" in hardening_section

--- a/tests/test_issue1913_workspace_prefix_sentinel.py
+++ b/tests/test_issue1913_workspace_prefix_sentinel.py
@@ -7,7 +7,10 @@ from api.streaming import (
 
 def test_workspace_prefix_strips_only_versioned_sentinel():
     assert _strip_workspace_prefix("[Workspace::v1: /tmp/project]\nHello") == "Hello"
-    assert _strip_workspace_prefix("[Workspace: /tmp/project]\nHello") == "[Workspace: /tmp/project]\nHello"
+    assert (
+        _strip_workspace_prefix("[Workspace: /tmp/project]\nHello")
+        == "[Workspace: /tmp/project]\nHello"
+    )
 
 
 def test_workspace_prefix_escapes_paths_with_closing_brackets():

--- a/tests/test_issue1937_endless_scroll_jumpstart_race.py
+++ b/tests/test_issue1937_endless_scroll_jumpstart_race.py
@@ -59,6 +59,7 @@ def _function_body(src: str, name: str) -> str:
 # Generation token: declared at module scope, bumped via the helper.
 # ---------------------------------------------------------------------------
 
+
 def test_generation_token_declared_at_module_scope():
     """``_messagesGeneration`` exists as a module-scoped mutable counter."""
     assert "let _messagesGeneration = 0;" in SESSIONS_JS, (
@@ -83,6 +84,7 @@ def test_generation_bump_helper_exists():
 # ---------------------------------------------------------------------------
 # _loadOlderMessages: snapshot before await, re-check after.
 # ---------------------------------------------------------------------------
+
 
 def test_load_older_snapshots_generation_before_await():
     """Snapshot must be captured BEFORE the `await api(...)` call."""
@@ -120,6 +122,7 @@ def test_load_older_generation_check_runs_before_prepend():
 # ---------------------------------------------------------------------------
 # _ensureAllMessagesLoaded: claims the mutex, bumps the generation, yields.
 # ---------------------------------------------------------------------------
+
 
 def test_ensure_all_bumps_generation_before_replace():
     """Bump must happen BEFORE `S.messages = msgs` so racing prefetch sees it."""

--- a/tests/test_issue1968_mcp_profile_discovery.py
+++ b/tests/test_issue1968_mcp_profile_discovery.py
@@ -13,6 +13,7 @@ This is a static check (source ordering) rather than a runtime test, because
 mocking the entire agent stack to reach the call site would be brittle and
 miss the actual lexical ordering that's the load-bearing fix.
 """
+
 from pathlib import Path
 import re
 
@@ -68,9 +69,9 @@ def test_discover_mcp_tools_only_called_once_in_streaming():
     later refactor reintroduces a pre-mutation call site, this test catches it.
     """
     call_lines = [
-        line for line in STREAMING_PY.splitlines()
-        if "discover_mcp_tools()" in line
-        and not line.lstrip().startswith("#")
+        line
+        for line in STREAMING_PY.splitlines()
+        if "discover_mcp_tools()" in line and not line.lstrip().startswith("#")
     ]
     assert len(call_lines) == 1, (
         f"Expected exactly 1 `discover_mcp_tools()` call line in api/streaming.py "

--- a/tests/test_issue341.py
+++ b/tests/test_issue341.py
@@ -1,4 +1,5 @@
 """Tests for GitHub issue #341: .msg-body table CSS styles."""
+
 import os
 
 CSS_PATH = os.path.join(os.path.dirname(__file__), "..", "static", "style.css")
@@ -12,7 +13,9 @@ def _read_css():
 def test_msg_body_table_css_present():
     css = _read_css()
     assert ".msg-body table" in css, ".msg-body table rule missing from style.css"
-    assert "border-collapse:collapse" in css, "border-collapse:collapse missing from style.css"
+    assert "border-collapse:collapse" in css, (
+        "border-collapse:collapse missing from style.css"
+    )
 
 
 def test_msg_body_table_th_td_present():
@@ -23,12 +26,16 @@ def test_msg_body_table_th_td_present():
 
 def test_msg_body_table_tr_stripe_present():
     css = _read_css()
-    assert ".msg-body tr:nth-child(even)" in css, ".msg-body tr:nth-child(even) rule missing from style.css"
+    assert ".msg-body tr:nth-child(even)" in css, (
+        ".msg-body tr:nth-child(even) rule missing from style.css"
+    )
 
 
 def test_msg_body_light_theme_overrides():
     css = _read_css()
-    assert ':root:not(.dark) .msg-body th' in css, \
-        'Light-mode override for .msg-body th missing from style.css'
-    assert ':root:not(.dark) .msg-body td' in css, \
-        'Light-mode override for .msg-body td missing from style.css'
+    assert ":root:not(.dark) .msg-body th" in css, (
+        "Light-mode override for .msg-body th missing from style.css"
+    )
+    assert ":root:not(.dark) .msg-body td" in css, (
+        "Light-mode override for .msg-body td missing from style.css"
+    )

--- a/tests/test_issue342.py
+++ b/tests/test_issue342.py
@@ -4,21 +4,21 @@ Tests for GitHub issue #342: auto-link plain URLs in chat messages.
 These are structural tests that verify the fix is present in static/ui.js
 without requiring a running server or JavaScript engine.
 """
-import os
-import re
 
-UI_JS = os.path.join(os.path.dirname(__file__), '..', 'static', 'ui.js')
+import os
+
+UI_JS = os.path.join(os.path.dirname(__file__), "..", "static", "ui.js")
 
 
 def read_ui_js():
-    with open(UI_JS, 'r') as f:
+    with open(UI_JS, "r") as f:
         return f.read()
 
 
 def test_autolink_comment_present():
     """The Autolink comment should be present in renderMd() to document the feature."""
     content = read_ui_js()
-    assert 'Autolink: convert plain URLs' in content, (
+    assert "Autolink: convert plain URLs" in content, (
         "Expected 'Autolink: convert plain URLs' comment not found in static/ui.js. "
         "Did the autolink pass get added?"
     )
@@ -28,11 +28,11 @@ def test_autolink_regex_in_rendermd():
     """The autolink regex pattern (https?://) should appear in renderMd()."""
     content = read_ui_js()
     # Locate the renderMd function body
-    rendermd_start = content.find('function renderMd(raw){')
+    rendermd_start = content.find("function renderMd(raw){")
     assert rendermd_start != -1, "renderMd function not found in ui.js"
     # Find the closing brace after renderMd (look for the autolink pattern within it)
-    rendermd_body = content[rendermd_start:rendermd_start + 15000]
-    assert 'https?:\\/\\/' in rendermd_body, (
+    rendermd_body = content[rendermd_start : rendermd_start + 15000]
+    assert "https?:\\/\\/" in rendermd_body, (
         "Autolink regex (https?:\\/\\/) not found inside renderMd() body."
     )
 
@@ -43,18 +43,18 @@ def test_autolink_uses_esc_for_xss_safety():
     query strings). It IS applied to the visible link text (esc(clean)) to prevent XSS."""
     content = read_ui_js()
     # Find the autolink section (between the SAFE_TAGS pass and paragraph wrap)
-    autolink_idx = content.find('// Autolink: convert plain URLs')
+    autolink_idx = content.find("// Autolink: convert plain URLs")
     assert autolink_idx != -1, "Autolink comment not found in ui.js"
     # Extract the autolink block (next ~600 chars after the comment)
-    autolink_block = content[autolink_idx:autolink_idx + 600]
+    autolink_block = content[autolink_idx : autolink_idx + 600]
     # esc() must be used on the visible link text to prevent XSS
-    assert 'esc(clean)' in autolink_block, (
+    assert "esc(clean)" in autolink_block, (
         "Autolink block should use esc(clean) for the link display text (XSS safety), "
         "but it was not found."
     )
     # esc() must NOT be used on the href value — that breaks URLs containing &
     assert 'href="${esc(clean)}"' not in autolink_block, (
-        "Autolink block should use href=\"${clean}\" (not esc'd) to preserve & in query strings."
+        'Autolink block should use href="${clean}" (not esc\'d) to preserve & in query strings.'
     )
 
 
@@ -62,13 +62,13 @@ def test_autolink_in_inline_md():
     """The autolink pass should also be present inside the inlineMd() helper."""
     content = read_ui_js()
     # Find inlineMd function
-    inline_start = content.find('function inlineMd(t){')
+    inline_start = content.find("function inlineMd(t){")
     assert inline_start != -1, "inlineMd function not found in ui.js"
     # Find closing brace of inlineMd by looking for 'return t;' followed by '}'
-    inline_end = content.find('return t;\n  }', inline_start)
+    inline_end = content.find("return t;\n  }", inline_start)
     assert inline_end != -1, "Could not locate end of inlineMd function"
-    inline_body = content[inline_start:inline_end + 20]
-    assert 'https?:\\/\\/' in inline_body, (
+    inline_body = content[inline_start : inline_end + 20]
+    assert "https?:\\/\\/" in inline_body, (
         "Autolink regex not found inside inlineMd() — plain URLs in list items "
         "and blockquotes won't be autolinked."
     )
@@ -84,12 +84,16 @@ def test_autolink_after_safe_tags_pass():
     content = read_ui_js()
     # Accept either the new _tag() sanitizer or the legacy SAFE_TAGS line so this
     # test works on both the old and new renderer.
-    sanitizer_idx = content.find('s=s.replace(/<\\/?[a-z][^>]*>/gi,tag=>_tag(tag));')
+    sanitizer_idx = content.find("s=s.replace(/<\\/?[a-z][^>]*>/gi,tag=>_tag(tag));")
     if sanitizer_idx == -1:
-        sanitizer_idx = content.find('s=s.replace(/<\\/?[a-z][^>]*>/gi,tag=>SAFE_TAGS.test(tag)?tag:esc(tag));')
-    autolink_idx = content.find('// Autolink: convert plain URLs')
-    parts_idx = content.find('const parts=s.split(/\\n{2,}/);')
-    assert sanitizer_idx != -1, "HTML sanitizer pass not found (expected _tag() or SAFE_TAGS)"
+        sanitizer_idx = content.find(
+            "s=s.replace(/<\\/?[a-z][^>]*>/gi,tag=>SAFE_TAGS.test(tag)?tag:esc(tag));"
+        )
+    autolink_idx = content.find("// Autolink: convert plain URLs")
+    parts_idx = content.find("const parts=s.split(/\\n{2,}/);")
+    assert sanitizer_idx != -1, (
+        "HTML sanitizer pass not found (expected _tag() or SAFE_TAGS)"
+    )
     assert autolink_idx != -1, "Autolink pass not found"
     assert parts_idx != -1, "Paragraph-wrap parts line not found"
     assert sanitizer_idx < autolink_idx < parts_idx, (
@@ -102,10 +106,10 @@ def test_autolink_after_safe_tags_pass():
 def test_autolink_target_blank_and_rel():
     """Autolinked URLs should open in a new tab with rel=noopener for security."""
     content = read_ui_js()
-    autolink_idx = content.find('// Autolink: convert plain URLs')
+    autolink_idx = content.find("// Autolink: convert plain URLs")
     assert autolink_idx != -1, "Autolink comment not found"
     # Use a larger window to account for the stash preamble added by the fix
-    autolink_block = content[autolink_idx:autolink_idx + 700]
+    autolink_block = content[autolink_idx : autolink_idx + 700]
     assert 'target="_blank"' in autolink_block, (
         'Autolinked URLs should have target="_blank"'
     )

--- a/tests/test_issue347.py
+++ b/tests/test_issue347.py
@@ -10,6 +10,7 @@ Structural tests — no server required. Verify:
 - SAFE_TAGS updated to allow <span> (for inline math)
 - renderKatexBlocks() is wired into the requestAnimationFrame call
 """
+
 import json
 import pathlib
 import re
@@ -17,9 +18,9 @@ import subprocess
 import textwrap
 
 REPO = pathlib.Path(__file__).parent.parent
-UI_JS   = (REPO / 'static' / 'ui.js').read_text(encoding='utf-8')
-INDEX   = (REPO / 'static' / 'index.html').read_text(encoding='utf-8')
-CSS     = (REPO / 'static' / 'style.css').read_text(encoding='utf-8')
+UI_JS = (REPO / "static" / "ui.js").read_text(encoding="utf-8")
+INDEX = (REPO / "static" / "index.html").read_text(encoding="utf-8")
+CSS = (REPO / "static" / "style.css").read_text(encoding="utf-8")
 
 
 def _extract_function(src: str, name: str) -> str:
@@ -41,7 +42,7 @@ def _extract_function(src: str, name: str) -> str:
 
 def _run_renderers(markdown: str) -> dict:
     js = textwrap.dedent(
-        r'''
+        r"""
         const esc=s=>String(s??'').replace(/[&<>"']/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
         const _IMAGE_EXTS=/\.(png|jpg|jpeg|gif|webp|bmp|ico|avif)$/i;
         const _PDF_EXTS=/\.pdf$/i;
@@ -51,20 +52,20 @@ def _run_renderers(markdown: str) -> dict:
         function t(k){ return k; }
         function _mediaPlayerHtml(){ return ''; }
         global.document={baseURI:'http://example.test/'};
-        '''
+        """
     )
     js += "\n" + _extract_function(UI_JS, "_matchBacktickFenceLine")
     js += "\n" + _extract_function(UI_JS, "_isBacktickFenceClose")
     js += "\n" + _extract_function(UI_JS, "_renderUserFencedBlocks")
     js += "\n" + _extract_function(UI_JS, "renderMd")
     js += textwrap.dedent(
-        r'''
+        r"""
         const input=process.argv[1];
         console.log(JSON.stringify({
           assistant: renderMd(input),
           user: _renderUserFencedBlocks(input),
         }));
-        '''
+        """
     )
     proc = subprocess.run(
         ["node", "-e", js, markdown],
@@ -79,24 +80,27 @@ def _run_renderers(markdown: str) -> dict:
 
 # ── renderMd pipeline ──────────────────────────────────────────────────────────
 
+
 def test_display_math_stash_present():
     """renderMd must stash $$...$$ display math before other processing."""
-    assert r'\$\$([\s\S]+?)\$\$' in UI_JS or '$$' in UI_JS, \
-        'Display math $$..$$ stash regex not found in ui.js'
+    assert r"\$\$([\s\S]+?)\$\$" in UI_JS or "$$" in UI_JS, (
+        "Display math $$..$$ stash regex not found in ui.js"
+    )
     # The stash uses \\x00M token
-    assert '\\x00M' in UI_JS, 'Math stash token \\x00M not found in renderMd'
+    assert "\\x00M" in UI_JS, "Math stash token \\x00M not found in renderMd"
 
 
 def test_inline_math_stash_present():
     """renderMd must stash $..$ inline math."""
     # Inline math regex must be present
-    assert 'math_stash' in UI_JS, 'math_stash array not found in renderMd'
+    assert "math_stash" in UI_JS, "math_stash array not found in renderMd"
 
 
 def test_katex_block_placeholder_emitted():
     """renderMd restore pass must emit .katex-block divs for display math."""
-    assert 'katex-block' in UI_JS, \
-        '.katex-block placeholder div not emitted by renderMd restore pass'
+    assert "katex-block" in UI_JS, (
+        ".katex-block placeholder div not emitted by renderMd restore pass"
+    )
 
 
 def test_backslash_latex_delimiters_render_to_katex_placeholders():
@@ -152,73 +156,82 @@ def test_user_bubble_top_level_latex_still_renders_after_fence_reorder():
 
 def test_katex_inline_placeholder_emitted():
     """renderMd restore pass must emit .katex-inline spans for inline math."""
-    assert 'katex-inline' in UI_JS, \
-        '.katex-inline placeholder span not emitted by renderMd restore pass'
+    assert "katex-inline" in UI_JS, (
+        ".katex-inline placeholder span not emitted by renderMd restore pass"
+    )
 
 
 def test_data_katex_attribute_present():
     """Placeholders must carry data-katex attribute for display/inline distinction."""
-    assert 'data-katex' in UI_JS, \
-        'data-katex attribute not found — renderKatexBlocks cannot distinguish display from inline'
+    assert "data-katex" in UI_JS, (
+        "data-katex attribute not found — renderKatexBlocks cannot distinguish display from inline"
+    )
 
 
 # ── renderKatexBlocks() ────────────────────────────────────────────────────────
 
+
 def test_render_katex_blocks_function_exists():
     """renderKatexBlocks() function must exist in ui.js."""
-    assert 'function renderKatexBlocks()' in UI_JS, \
-        'renderKatexBlocks() function not found in ui.js'
+    assert "function renderKatexBlocks()" in UI_JS, (
+        "renderKatexBlocks() function not found in ui.js"
+    )
 
 
 def test_katex_lazy_load_follows_mermaid_pattern():
     """KaTeX must use the same lazy-load pattern as mermaid (load on first use)."""
-    assert '_katexLoading' in UI_JS, '_katexLoading flag not found'
-    assert '_katexReady' in UI_JS,   '_katexReady flag not found'
+    assert "_katexLoading" in UI_JS, "_katexLoading flag not found"
+    assert "_katexReady" in UI_JS, "_katexReady flag not found"
 
 
 def test_katex_js_loaded_from_cdn():
     """KaTeX JS must be loaded from jsdelivr CDN."""
-    assert 'katex@0.16' in UI_JS, \
-        'KaTeX JS CDN URL not found in ui.js — expected katex@0.16.x'
+    assert "katex@0.16" in UI_JS, (
+        "KaTeX JS CDN URL not found in ui.js — expected katex@0.16.x"
+    )
 
 
 def test_katex_js_has_sri_hash():
     """KaTeX JS CDN tag must have an SRI integrity hash."""
     # The hash is in the script.integrity assignment
-    assert "script.integrity='sha384-" in UI_JS or 'script.integrity="sha384-' in UI_JS, \
-        'KaTeX JS SRI integrity hash not found in ui.js'
+    assert (
+        "script.integrity='sha384-" in UI_JS or 'script.integrity="sha384-' in UI_JS
+    ), "KaTeX JS SRI integrity hash not found in ui.js"
 
 
 def test_katex_display_mode_used():
     """renderKatexBlocks must pass displayMode based on data-katex attribute."""
-    assert 'displayMode' in UI_JS, \
-        'displayMode not passed to katex.render() — display math will render inline'
+    assert "displayMode" in UI_JS, (
+        "displayMode not passed to katex.render() — display math will render inline"
+    )
 
 
 def test_katex_throw_on_error_false():
     """KaTeX must be configured with throwOnError:false to degrade gracefully."""
-    assert 'throwOnError:false' in UI_JS, \
-        'throwOnError:false not set — bad LaTeX will throw and break the message'
+    assert "throwOnError:false" in UI_JS, (
+        "throwOnError:false not set — bad LaTeX will throw and break the message"
+    )
 
 
 def test_render_katex_blocks_wired_into_raf():
     """renderKatexBlocks() must be called in the same requestAnimationFrame as renderMermaidBlocks()."""
     # Check that renderKatexBlocks appears somewhere near requestAnimationFrame
-    raf_idx = UI_JS.find('requestAnimationFrame')
+    raf_idx = UI_JS.find("requestAnimationFrame")
     # Find the rAF call that also contains renderKatexBlocks
     has_katex_in_raf = any(
-        'renderKatexBlocks' in UI_JS[m.start():m.start()+200]
-        for m in re.finditer(r'requestAnimationFrame', UI_JS)
+        "renderKatexBlocks" in UI_JS[m.start() : m.start() + 200]
+        for m in re.finditer(r"requestAnimationFrame", UI_JS)
     )
-    assert has_katex_in_raf, \
-        'renderKatexBlocks() not found in any requestAnimationFrame call — math will not render'
+    assert has_katex_in_raf, (
+        "renderKatexBlocks() not found in any requestAnimationFrame call — math will not render"
+    )
 
 
 def test_mermaid_render_failure_removes_temporary_error_dom():
     """Failed Mermaid renders must not leave Mermaid's body-level syntax-error SVG visible."""
-    fn_start = UI_JS.find('function renderMermaidBlocks()')
-    assert fn_start != -1, 'renderMermaidBlocks() function not found in ui.js'
-    fn = UI_JS[fn_start:fn_start + 2200]
+    fn_start = UI_JS.find("function renderMermaidBlocks()")
+    assert fn_start != -1, "renderMermaidBlocks() function not found in ui.js"
+    fn = UI_JS[fn_start : fn_start + 2200]
     cleanup = "const tmp=document.getElementById('d'+id);\n      if(tmp) tmp.remove();"
     assert cleanup in fn, (
         "renderMermaidBlocks() must remove Mermaid's temporary d<id> container; "
@@ -231,52 +244,55 @@ def test_mermaid_render_failure_removes_temporary_error_dom():
 
 # ── index.html ────────────────────────────────────────────────────────────────
 
+
 def test_katex_css_in_index_html():
     """KaTeX CSS must be loaded in index.html."""
-    assert 'katex@0.16' in INDEX, \
-        'KaTeX CSS CDN link not found in index.html'
+    assert "katex@0.16" in INDEX, "KaTeX CSS CDN link not found in index.html"
 
 
 def test_katex_css_has_sri_hash():
     """KaTeX CSS link in index.html must have an SRI integrity hash."""
-    assert 'sha384-5TcZemv2l' in INDEX or 'integrity' in INDEX and 'katex' in INDEX, \
-        'KaTeX CSS SRI integrity hash not found in index.html'
+    assert "sha384-5TcZemv2l" in INDEX or "integrity" in INDEX and "katex" in INDEX, (
+        "KaTeX CSS SRI integrity hash not found in index.html"
+    )
 
 
 # ── style.css ─────────────────────────────────────────────────────────────────
 
+
 def test_katex_block_css_present():
     """.katex-block CSS rule must exist for centered display math."""
-    assert '.katex-block' in CSS, \
-        '.katex-block CSS rule missing from style.css — display math will have no layout'
+    assert ".katex-block" in CSS, (
+        ".katex-block CSS rule missing from style.css — display math will have no layout"
+    )
 
 
 def test_katex_inline_css_present():
     """.katex-inline CSS rule must exist."""
-    assert '.katex-inline' in CSS, \
-        '.katex-inline CSS rule missing from style.css'
+    assert ".katex-inline" in CSS, ".katex-inline CSS rule missing from style.css"
 
 
 def test_katex_block_text_align_center():
     """.katex-block must be text-align:center for display math."""
-    assert 'text-align:center' in CSS, \
-        'text-align:center not found for .katex-block'
+    assert "text-align:center" in CSS, "text-align:center not found for .katex-block"
 
 
 # ── SAFE_TAGS ──────────────────────────────────────────────────────────────────
 
+
 def test_safe_tags_includes_span():
     """SAFE_TAGS must include <span> to allow .katex-inline spans through the escape pass."""
     # The SAFE_TAGS regex should contain 'span'
-    safe_tags_match = re.search(r'SAFE_TAGS\s*=\s*/.*?/i', UI_JS)
-    assert safe_tags_match, 'SAFE_TAGS pattern not found in ui.js'
-    assert 'span' in safe_tags_match.group(), \
-        '<span> not in SAFE_TAGS — inline math spans will be HTML-escaped and rendered as text'
+    safe_tags_match = re.search(r"SAFE_TAGS\s*=\s*/.*?/i", UI_JS)
+    assert safe_tags_match, "SAFE_TAGS pattern not found in ui.js"
+    assert "span" in safe_tags_match.group(), (
+        "<span> not in SAFE_TAGS — inline math spans will be HTML-escaped and rendered as text"
+    )
 
 
 # ── Stash ordering: fence must protect code spans from math extraction ─────────
 
-WORKSPACE_JS = (REPO / 'static' / 'workspace.js').read_text(encoding='utf-8')
+WORKSPACE_JS = (REPO / "static" / "workspace.js").read_text(encoding="utf-8")
 
 
 def test_fence_stash_before_math_stash():
@@ -320,6 +336,7 @@ def test_math_stash_comment_says_after_fence():
 
 # ── Pipeline regression: code spans protect their contents ────────────────────
 
+
 def test_math_restore_after_fence_restore():
     """Math stash tokens are restored AFTER fence restore, so code spans get
     their raw text back (not KaTeX placeholders)."""
@@ -329,7 +346,9 @@ def test_math_restore_after_fence_restore():
     assert math_restore_pos != -1, "math_stash restore not found"
     # Both restores must exist; their relative order doesn't matter for correctness
     # (they use different tokens: \x00F vs \x00M), but we assert both exist
-    assert fence_restore_pos != math_restore_pos, "fence and math restore must be separate calls"
+    assert fence_restore_pos != math_restore_pos, (
+        "fence and math restore must be separate calls"
+    )
 
 
 def test_stash_tokens_distinct():
@@ -337,19 +356,20 @@ def test_stash_tokens_distinct():
     # fence uses \x00F, math uses \x00M (or similar unique prefix)
     # The JS source uses escaped \\x00F and \\x00M as sentinel characters
     # In the Python string read from the file these appear as '\\\\x00F' and '\\\\x00M'
-    assert "'\\\\x00F'" in UI_JS or 'x00F' in UI_JS, (
+    assert "'\\\\x00F'" in UI_JS or "x00F" in UI_JS, (
         "fence stash token (\\x00F) not found — must be distinct from math token"
     )
-    assert "'\\\\x00M'" in UI_JS or 'x00M' in UI_JS, (
+    assert "'\\\\x00M'" in UI_JS or "x00M" in UI_JS, (
         "math stash token (\\x00M) not found — must be distinct from fence token"
     )
     # The two tokens must use different discriminator characters
-    assert 'x00F' in UI_JS and 'x00M' in UI_JS, (
+    assert "x00F" in UI_JS and "x00M" in UI_JS, (
         "Both \\x00F (fence) and \\x00M (math) tokens must exist"
     )
 
 
 # ── Workspace preview renderKatexBlocks wiring ────────────────────────────────
+
 
 def test_workspace_calls_render_katex_after_preview():
     """workspace.js must call renderKatexBlocks() after setting previewMd.innerHTML.
@@ -392,6 +412,7 @@ def test_workspace_katex_guarded_by_typeof():
 
 # ── SAFE_TAGS: span addition should not expand attack surface ─────────────────
 
+
 def test_safe_tags_span_is_narrowly_scoped():
     """SAFE_TAGS adding <span> is only a bypass if span carries dangerous attributes.
     Verify the SAFE_TAGS regex tests the tag NAME only, not arbitrary attributes.
@@ -401,17 +422,18 @@ def test_safe_tags_span_is_narrowly_scoped():
     # The SAFE_TAGS regex must still require a word boundary / tag-end pattern
     safe_tags_match = re.search(r"SAFE_TAGS\s*=\s*/(.+?)/i", UI_JS)
     if not safe_tags_match:
-        safe_tags_match = re.search(r'SAFE_TAGS\s*=\s*/(.*?)/i', UI_JS)
+        safe_tags_match = re.search(r"SAFE_TAGS\s*=\s*/(.*?)/i", UI_JS)
     assert safe_tags_match, "SAFE_TAGS regex not found"
     pattern = safe_tags_match.group(1)
     # Must have a trailing boundary check — ([\s>]|$) or similar
-    assert r"[\s>]" in pattern or r'[\s>]' in pattern, (
+    assert r"[\s>]" in pattern or r"[\s>]" in pattern, (
         "SAFE_TAGS must enforce a boundary after the tag name to prevent "
         "<spanxss> from matching when checking for <span>"
     )
 
 
 # ── False-positive prevention ─────────────────────────────────────────────────
+
 
 def test_inline_math_regex_requires_non_space_boundaries():
     """The $...$ inline regex must require non-space at both boundaries.
@@ -423,13 +445,15 @@ def test_inline_math_regex_requires_non_space_boundaries():
     inline_push_idx = UI_JS.find("type:'inline',src:m")
     assert inline_push_idx != -1, "Inline math stash push not found"
     # Get the text from the start of that line back to find the regex
-    line_start = UI_JS.rfind('\n', 0, inline_push_idx) + 1
-    inline_line = UI_JS[line_start:inline_push_idx + 50]
+    line_start = UI_JS.rfind("\n", 0, inline_push_idx) + 1
+    inline_line = UI_JS[line_start : inline_push_idx + 50]
     # The regex must use \s (via [^\s...]) to exclude spaces at boundaries
-    assert '\\s' in inline_line or '[^' in inline_line, (
+    assert "\\s" in inline_line or "[^" in inline_line, (
         f"Inline math regex must exclude spaces at boundaries to prevent false "
         f"positives on currency like $5. Found: {inline_line[:120]}"
     )
+
+
 def test_display_math_stashed_before_inline():
     """$$...$$ display math must be stashed before $...$ inline math.
 
@@ -460,6 +484,7 @@ def test_math_stash_token_uses_single_backslash_null_byte():
     # The wrong form (double backslash) would be: return '\\x00M'
     # Check that no double-backslash form exists in the math stash return statements
     import re
+
     bad_returns = re.findall(r"return\s+'\\\\x00M'", UI_JS)
     assert not bad_returns, (
         f"Found {len(bad_returns)} math stash return(s) using double-backslash \\\\x00M. "

--- a/tests/test_issue357.py
+++ b/tests/test_issue357.py
@@ -11,6 +11,7 @@ Two problems fixed:
    bind-mount dirs created by Docker as root are unwritable by hermeswebui.
    Fix: root init mkdir/chown, then runtime verifies access without sudo.
 """
+
 import pathlib
 import re
 
@@ -21,8 +22,8 @@ INIT_SCRIPT = (REPO / "docker_init.bash").read_text(encoding="utf-8")
 
 # ── Dockerfile: uv pre-installed at build time ───────────────────────────────
 
-class TestDockerfileUvPreinstall:
 
+class TestDockerfileUvPreinstall:
     def test_dockerfile_installs_uv_at_build_time(self):
         """Dockerfile must install uv via RUN curl at build time (not only at runtime)."""
         assert "RUN curl" in DOCKERFILE and "uv/install.sh" in DOCKERFILE, (
@@ -37,10 +38,15 @@ class TestDockerfileUvPreinstall:
             (line for line in DOCKERFILE.splitlines() if "uv/install.sh" in line),
             None,
         )
-        assert uv_install_line is not None, "Could not find uv install line in Dockerfile"
+        assert uv_install_line is not None, (
+            "Could not find uv install line in Dockerfile"
+        )
         # Must either use UV_INSTALL_DIR pointing to /usr/local/bin, or run as root
         # (so the default install location is accessible to hermeswebui user)
-        has_system_dir = "/usr/local/bin" in uv_install_line or "UV_INSTALL_DIR=/usr/local/bin" in DOCKERFILE
+        has_system_dir = (
+            "/usr/local/bin" in uv_install_line
+            or "UV_INSTALL_DIR=/usr/local/bin" in DOCKERFILE
+        )
         assert has_system_dir, (
             "uv must be installed to /usr/local/bin (system-wide) so hermeswebui user "
             "can find it. Installing as hermeswebuitoo puts it in /home/hermeswebuitoo/.local/bin "
@@ -50,6 +56,7 @@ class TestDockerfileUvPreinstall:
     def test_dockerfile_uv_installed_before_copy(self):
         """uv installation must happen before COPY . /apptoo so it's in the image."""
         import re
+
         uv_pos = DOCKERFILE.find("uv/install.sh")
         # Match COPY regardless of flags (e.g. --chown=...) — only the destination matters.
         m = re.search(r"^COPY\b.*\s/apptoo\b", DOCKERFILE, re.MULTILINE)
@@ -80,8 +87,8 @@ class TestDockerfileUvPreinstall:
 
 # ── docker_init.bash: skip uv download when already present ─────────────────
 
-class TestInitScriptUvSkip:
 
+class TestInitScriptUvSkip:
     def test_init_script_checks_uv_before_download(self):
         """docker_init.bash must check 'command -v uv' before attempting download."""
         assert "command -v uv" in INIT_SCRIPT, (
@@ -92,17 +99,14 @@ class TestInitScriptUvSkip:
     def test_init_script_skips_download_if_present(self):
         """Init script must use conditional logic (if/else) around the uv download."""
         # Pattern: if command -v uv ... else ... fi
-        assert re.search(r'if\s+command\s+-v\s+uv', INIT_SCRIPT), (
+        assert re.search(r"if\s+command\s+-v\s+uv", INIT_SCRIPT), (
             "docker_init.bash must use 'if command -v uv' guard around the download"
         )
 
     def test_init_script_curl_download_in_else_branch(self):
         """The curl download must be in the else branch (only runs if uv not found)."""
         # Find the conditional block
-        m = re.search(
-            r'if\s+command\s+-v\s+uv.*?fi',
-            INIT_SCRIPT, re.DOTALL
-        )
+        m = re.search(r"if\s+command\s+-v\s+uv.*?fi", INIT_SCRIPT, re.DOTALL)
         assert m, "Could not find uv conditional block in docker_init.bash"
         block = m.group(0)
         # curl must appear after 'else' not in the 'then' branch
@@ -131,8 +135,8 @@ class TestInitScriptUvSkip:
 
 # ── docker_init.bash: workspace directory permissions ────────────────────────
 
-class TestWorkspacePermissions:
 
+class TestWorkspacePermissions:
     def test_workspace_uses_root_init_mkdir(self):
         """docker_init.bash must create missing workspaces during root init.
 
@@ -141,8 +145,9 @@ class TestWorkspacePermissions:
         ships sudo, so root init handles mkdir before dropping privileges.
         """
         root_section = INIT_SCRIPT[
-            INIT_SCRIPT.find('if [ "A${whoami}" == "Aroot" ]; then'):
-            INIT_SCRIPT.find('exec su')
+            INIT_SCRIPT.find('if [ "A${whoami}" == "Aroot" ]; then') : INIT_SCRIPT.find(
+                "exec su"
+            )
         ]
         assert 'mkdir -p "$HERMES_WEBUI_DEFAULT_WORKSPACE"' in root_section, (
             "docker_init.bash must mkdir the workspace during root init "
@@ -156,10 +161,14 @@ class TestWorkspacePermissions:
         chown writable bind mounts, while read-only mounts continue with a warning.
         """
         root_section = INIT_SCRIPT[
-            INIT_SCRIPT.find('if [ "A${whoami}" == "Aroot" ]; then'):
-            INIT_SCRIPT.find('exec su')
+            INIT_SCRIPT.find('if [ "A${whoami}" == "Aroot" ]; then') : INIT_SCRIPT.find(
+                "exec su"
+            )
         ]
-        assert 'chown hermeswebui:hermeswebui "$HERMES_WEBUI_DEFAULT_WORKSPACE"' in root_section, (
+        assert (
+            'chown hermeswebui:hermeswebui "$HERMES_WEBUI_DEFAULT_WORKSPACE"'
+            in root_section
+        ), (
             "docker_init.bash must chown the workspace during root init "
             "so the app user can write to it when possible (#357)"
         )
@@ -167,16 +176,18 @@ class TestWorkspacePermissions:
     def test_workspace_mkdir_before_chown(self):
         """Root init mkdir must come before root init chown in docker_init.bash."""
         mkdir_pos = INIT_SCRIPT.find('mkdir -p "$HERMES_WEBUI_DEFAULT_WORKSPACE"')
-        chown_pos = INIT_SCRIPT.find('chown hermeswebui:hermeswebui "$HERMES_WEBUI_DEFAULT_WORKSPACE"')
+        chown_pos = INIT_SCRIPT.find(
+            'chown hermeswebui:hermeswebui "$HERMES_WEBUI_DEFAULT_WORKSPACE"'
+        )
         assert mkdir_pos != -1, "root init mkdir for workspace not found"
         assert chown_pos != -1, "root init chown for workspace not found"
         assert mkdir_pos < chown_pos, "root init mkdir must come before root init chown"
 
     def test_workspace_error_exit_on_mkdir_failure(self):
         """Root init mkdir must call error_exit on failure."""
-        assert 'mkdir -p "$HERMES_WEBUI_DEFAULT_WORKSPACE" || error_exit' in INIT_SCRIPT, (
-            "workspace mkdir must call error_exit on failure"
-        )
+        assert (
+            'mkdir -p "$HERMES_WEBUI_DEFAULT_WORKSPACE" || error_exit' in INIT_SCRIPT
+        ), "workspace mkdir must call error_exit on failure"
 
     def test_workspace_write_test_is_conditional_on_writable(self):
         """Write-test must be skipped for read-only workspace mounts (#670).
@@ -196,9 +207,11 @@ class TestWorkspacePermissions:
     def test_init_script_syntax_valid(self):
         """docker_init.bash must pass bash -n syntax check."""
         import subprocess
+
         result = subprocess.run(
             ["bash", "-n", str(REPO / "docker_init.bash")],
-            capture_output=True, text=True
+            capture_output=True,
+            text=True,
         )
         assert result.returncode == 0, (
             f"docker_init.bash failed bash -n syntax check:\n{result.stderr}"

--- a/tests/test_issue401.py
+++ b/tests/test_issue401.py
@@ -8,6 +8,7 @@ The older loadSession() path rewrote message history on the client:
 
 That broke both durable logging and page refresh for valid tool runs.
 """
+
 import json
 import pathlib
 import subprocess
@@ -28,10 +29,18 @@ def test_loadsession_preserves_tool_rows():
 
 def test_loadsession_uses_session_toolcalls_only_as_fallback():
     """Session summaries are the fallback, not the primary reload source."""
-    assert ("if(!hasMessageToolMetadata&&data.session.tool_calls&&data.session.tool_calls.length)" in SESSIONS_JS or
-            "if (!hasMessageToolMetadata && data.session.tool_calls && data.session.tool_calls.length)" in SESSIONS_JS)
-    assert ("S.toolCalls=(data.session.tool_calls||[]).map(tc=>({...tc,done:true}));" in SESSIONS_JS or
-            "S.toolCalls = data.session.tool_calls.map(tc => ({...tc, done: true}));" in SESSIONS_JS)
+    assert (
+        "if(!hasMessageToolMetadata&&data.session.tool_calls&&data.session.tool_calls.length)"
+        in SESSIONS_JS
+        or "if (!hasMessageToolMetadata && data.session.tool_calls && data.session.tool_calls.length)"
+        in SESSIONS_JS
+    )
+    assert (
+        "S.toolCalls=(data.session.tool_calls||[]).map(tc=>({...tc,done:true}));"
+        in SESSIONS_JS
+        or "S.toolCalls = data.session.tool_calls.map(tc => ({...tc, done: true}));"
+        in SESSIONS_JS
+    )
     assert "S.toolCalls=[];" in SESSIONS_JS
 
 
@@ -59,7 +68,9 @@ def _run_js(script_body: str) -> dict:
 
         {script_body}
     """)
-    proc = subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True)
+    proc = subprocess.run(
+        ["node", "-e", script], check=True, capture_output=True, text=True
+    )
     return json.loads(proc.stdout)
 
 

--- a/tests/test_issue467_yolo_mode_toggle.py
+++ b/tests/test_issue467_yolo_mode_toggle.py
@@ -9,10 +9,10 @@ Covers:
 - CSS classes for .yolo-pill and .approval-btn.yolo
 - i18n keys present in all 6 locales
 """
+
 import os
 import re
 import json
-import pathlib
 import pytest
 
 from tests.conftest import requires_agent_modules
@@ -21,7 +21,9 @@ TEST_BASE = f"http://127.0.0.1:{os.environ.get('HERMES_WEBUI_TEST_PORT', '8788')
 
 
 def _get(path, expect_ok=True):
-    import urllib.request, urllib.error
+    import urllib.request
+    import urllib.error
+
     try:
         with urllib.request.urlopen(TEST_BASE + path, timeout=10) as r:
             return json.loads(r.read())
@@ -36,7 +38,9 @@ def _get(path, expect_ok=True):
 
 
 def _post(path, body=None, expect_ok=True):
-    import urllib.request, urllib.error
+    import urllib.request
+    import urllib.error
+
     data = json.dumps(body or {}).encode()
     req = urllib.request.Request(
         TEST_BASE + path, data=data, headers={"Content-Type": "application/json"}
@@ -53,6 +57,7 @@ def _post(path, body=None, expect_ok=True):
 
 
 # ── Backend endpoint tests ──
+
 
 @requires_agent_modules
 class TestYoloEndpointGet:
@@ -128,6 +133,7 @@ class TestYoloEndpointPost:
 
 
 # ── Frontend JS tests (static file analysis — no server needed) ──
+
 
 class TestYoloCommandRegistration:
     """/yolo slash command should be registered in commands.js."""
@@ -220,7 +226,7 @@ class TestYoloI18n:
         start = match.end()
         next_locale = re.search(r"\n  \w{2}:\s*\{", i18n_js[start:])
         if next_locale:
-            block = i18n_js[start:start + next_locale.start()]
+            block = i18n_js[start : start + next_locale.start()]
         else:
             block = i18n_js[start:]
 

--- a/tests/test_issue470.py
+++ b/tests/test_issue470.py
@@ -14,6 +14,7 @@ running a lightweight Python mirror of the fixed renderMd logic.
 Strategy: verify the fix is present in the JS source, then test the
 expected rendering behaviour through the Python mirror.
 """
+
 import pathlib
 import re
 import html as _html
@@ -23,6 +24,7 @@ UI_JS = (REPO_ROOT / "static" / "ui.js").read_text()
 
 
 # ── Helpers ──────────────────────────────────────────────────────────────────
+
 
 def esc(s):
     return _html.escape(str(s), quote=True)
@@ -36,6 +38,7 @@ def _make_link(url, label):
 # Minimal Python mirror of the FIXED renderMd() — enough to test link behaviour.
 # Mirrors the stash-based approach introduced by the fix.
 
+
 def render_links_only(text):
     """
     Simplified render that only applies the link-related passes from the fixed
@@ -46,22 +49,29 @@ def render_links_only(text):
 
     # Stash [label](url) links (fix: store href as raw URL, not esc(url))
     link_stash = []
+
     def stash_link(m):
         label, url = m.group(1), m.group(2)
-        link_stash.append(f'<a href="{url}" target="_blank" rel="noopener">{esc(label)}</a>')
-        return f'\x00L{len(link_stash)-1}\x00'
-    s = re.sub(r'\[([^\]]+)\]\((https?://[^\)]+)\)', stash_link, s)
+        link_stash.append(
+            f'<a href="{url}" target="_blank" rel="noopener">{esc(label)}</a>'
+        )
+        return f"\x00L{len(link_stash) - 1}\x00"
+
+    s = re.sub(r"\[([^\]]+)\]\((https?://[^\)]+)\)", stash_link, s)
 
     # Autolink bare URLs (should NOT match inside already-stashed placeholders)
     def autolink(m):
         url = m.group(1)
-        trail = url[-1] if url[-1] in '.,;:!?)' else ''
+        trail = url[-1] if url[-1] in ".,;:!?)" else ""
         clean = url[:-1] if trail else url
-        return f'<a href="{clean}" target="_blank" rel="noopener">{esc(clean)}</a>{trail}'
+        return (
+            f'<a href="{clean}" target="_blank" rel="noopener">{esc(clean)}</a>{trail}'
+        )
+
     s = re.sub(r'(https?://[^\s<>"\')\]]+)', autolink, s)
 
     # Restore stashed links
-    s = re.sub(r'\x00L(\d+)\x00', lambda m: link_stash[int(m.group(1))], s)
+    s = re.sub(r"\x00L(\d+)\x00", lambda m: link_stash[int(m.group(1))], s)
     return s
 
 
@@ -70,50 +80,57 @@ def render_table_with_links(md):
     Render a markdown table that may contain [label](url) cells.
     Mirrors the fixed inlineMd() + table rendering.
     """
-    lines = md.strip().split('\n')
+    lines = md.strip().split("\n")
     if len(lines) < 2:
         return md
+
     def is_sep(r):
-        return bool(re.match(r'^\|[\s|:-]+\|$', r.strip()))
+        return bool(re.match(r"^\|[\s|:-]+\|$", r.strip()))
+
     if not is_sep(lines[1]):
         return md
 
     def inline_md_fixed(t):
         """Fixed inlineMd: stash links before autolink."""
         stash = []
+
         def stash_fn(m):
             lb, u = m.group(1), m.group(2)
             stash.append(f'<a href="{u}" target="_blank" rel="noopener">{esc(lb)}</a>')
-            return f'\x00L{len(stash)-1}\x00'
-        t = re.sub(r'\[([^\]]+)\]\((https?://[^\)]+)\)', stash_fn, t)
+            return f"\x00L{len(stash) - 1}\x00"
+
+        t = re.sub(r"\[([^\]]+)\]\((https?://[^\)]+)\)", stash_fn, t)
+
         # autolink remaining bare URLs
         def autolink(m):
             url = m.group(1)
-            trail = url[-1] if url[-1] in '.,;:!?)' else ''
+            trail = url[-1] if url[-1] in ".,;:!?)" else ""
             clean = url[:-1] if trail else url
             return f'<a href="{clean}" target="_blank" rel="noopener">{esc(clean)}</a>{trail}'
+
         t = re.sub(r'(https?://[^\s<>"\')\]]+)', autolink, t)
-        t = re.sub(r'\x00L(\d+)\x00', lambda m: stash[int(m.group(1))], t)
+        t = re.sub(r"\x00L(\d+)\x00", lambda m: stash[int(m.group(1))], t)
         return t
 
     def parse_row(r):
-        cells = r.strip().lstrip('|').rstrip('|').split('|')
-        return ''.join(f'<td>{inline_md_fixed(c.strip())}</td>' for c in cells)
+        cells = r.strip().lstrip("|").rstrip("|").split("|")
+        return "".join(f"<td>{inline_md_fixed(c.strip())}</td>" for c in cells)
 
     def parse_header(r):
-        cells = r.strip().lstrip('|').rstrip('|').split('|')
-        return ''.join(f'<th>{inline_md_fixed(c.strip())}</th>' for c in cells)
+        cells = r.strip().lstrip("|").rstrip("|").split("|")
+        return "".join(f"<th>{inline_md_fixed(c.strip())}</th>" for c in cells)
 
-    header = f'<tr>{parse_header(lines[0])}</tr>'
-    body = ''.join(f'<tr>{parse_row(r)}</tr>' for r in lines[2:])
-    return f'<table><thead>{header}</thead><tbody>{body}</tbody></table>'
+    header = f"<tr>{parse_header(lines[0])}</tr>"
+    body = "".join(f"<tr>{parse_row(r)}</tr>" for r in lines[2:])
+    return f"<table><thead>{header}</thead><tbody>{body}</tbody></table>"
 
 
 # ── Source-level checks (verify fix is in the JS) ─────────────────────────────
 
+
 def test_inlinemd_uses_link_stash():
     """Fixed inlineMd() must stash [label](url) links before autolink runs."""
-    assert '_link_stash' in UI_JS, (
+    assert "_link_stash" in UI_JS, (
         "inlineMd() should use _link_stash to prevent double-linking"
     )
 
@@ -128,23 +145,23 @@ def test_inlinemd_no_esc_on_href():
 
 def test_outer_link_pass_uses_a_stash():
     """Fixed outer link pass must stash existing <a> tags before running."""
-    assert '_a_stash' in UI_JS, (
+    assert "_a_stash" in UI_JS, (
         "Outer [label](url) pass should stash existing <a> tags to prevent autolink re-matching"
     )
 
 
 def test_autolink_pass_uses_al_stash():
     """Fixed autolink pass must stash existing <a> tags before running."""
-    assert '_al_stash' in UI_JS, (
+    assert "_al_stash" in UI_JS, (
         "Autolink pass should stash existing <a> tags to prevent double-linking"
     )
 
 
 def test_autolink_no_esc_on_href():
     """Fixed autolink pass must not call esc() on href URL."""
-    idx = UI_JS.find('// Autolink: convert plain URLs to clickable links.')
+    idx = UI_JS.find("// Autolink: convert plain URLs to clickable links.")
     assert idx != -1, "New autolink comment not found"
-    autolink_section = UI_JS[idx:idx+600]
+    autolink_section = UI_JS[idx : idx + 600]
     # The return line should have href="${clean}" (JS template literal, no esc call)
     assert 'href="${clean}"' in autolink_section, (
         'Autolink should use href="${clean}" not href="${esc(clean)}"'
@@ -156,86 +173,92 @@ def test_autolink_no_esc_on_href():
 
 # ── Behaviour tests (Python mirror of fixed renderMd) ─────────────────────────
 
+
 def test_labeled_link_renders_as_single_anchor():
     """[#461](https://github.com/.../461) must produce exactly one <a> tag."""
-    url = 'https://github.com/nesquena/hermes-webui/issues/461'
-    md = f'[#461]({url})'
+    url = "https://github.com/nesquena/hermes-webui/issues/461"
+    md = f"[#461]({url})"
     result = render_links_only(md)
-    assert result.count('<a ') == 1, f"Expected 1 <a> tag, got: {result}"
-    assert result.count('</a>') == 1
+    assert result.count("<a ") == 1, f"Expected 1 <a> tag, got: {result}"
+    assert result.count("</a>") == 1
     assert f'href="{url}"' in result
-    assert '#461' in result
+    assert "#461" in result
     # Must not contain the raw brackets
-    assert '[#461]' not in result
-    assert f']({url})' not in result
+    assert "[#461]" not in result
+    assert f"]({url})" not in result
 
 
 def test_href_not_html_escaped():
     """URLs with & must appear as literal & in href, not &amp;."""
-    url = 'https://example.com/search?q=foo&bar=baz'
-    md = f'[Search]({url})'
+    url = "https://example.com/search?q=foo&bar=baz"
+    md = f"[Search]({url})"
     result = render_links_only(md)
     assert f'href="{url}"' in result, (
         f"& in URL should not be escaped to &amp; in href. Got: {result}"
     )
-    assert '&amp;' not in result
+    assert "&amp;" not in result
 
 
 def test_bare_url_not_double_linked():
     """A bare https:// URL must produce exactly one <a> tag."""
-    url = 'https://github.com/nesquena/hermes-webui/issues/461'
+    url = "https://github.com/nesquena/hermes-webui/issues/461"
     result = render_links_only(url)
-    assert result.count('<a ') == 1, f"Expected 1 <a> tag, got: {result}"
-    assert result.count('</a>') == 1
+    assert result.count("<a ") == 1, f"Expected 1 <a> tag, got: {result}"
+    assert result.count("</a>") == 1
 
 
 def test_labeled_link_in_table_cell_single_anchor():
     """[#461](url) inside a markdown table cell must produce exactly one <a> tag."""
-    url = 'https://github.com/nesquena/hermes-webui/issues/461'
-    md = f'| Issue | Title |\n|---|---|\n| [#461]({url}) | Reasoning effort |'
+    url = "https://github.com/nesquena/hermes-webui/issues/461"
+    md = f"| Issue | Title |\n|---|---|\n| [#461]({url}) | Reasoning effort |"
     result = render_table_with_links(md)
-    assert result.count('<a ') == 1, f"Expected 1 <a> in table, got: {result}"
+    assert result.count("<a ") == 1, f"Expected 1 <a> in table, got: {result}"
     assert f'href="{url}"' in result
-    assert '#461' in result
+    assert "#461" in result
     # No raw brackets should appear in output
-    assert '[#461]' not in result
+    assert "[#461]" not in result
 
 
 def test_multiple_links_in_table_no_double_linking():
     """Multiple [label](url) links in a table must each produce exactly one <a>."""
     urls = [
-        'https://github.com/nesquena/hermes-webui/issues/461',
-        'https://github.com/nesquena/hermes-webui/issues/462',
-        'https://github.com/nesquena/hermes-webui/issues/463',
+        "https://github.com/nesquena/hermes-webui/issues/461",
+        "https://github.com/nesquena/hermes-webui/issues/462",
+        "https://github.com/nesquena/hermes-webui/issues/463",
     ]
-    rows = '\n'.join(f'| [#{461+i}]({url}) | Title {i} |' for i, url in enumerate(urls))
-    md = f'| Issue | Title |\n|---|---|\n{rows}'
+    rows = "\n".join(
+        f"| [#{461 + i}]({url}) | Title {i} |" for i, url in enumerate(urls)
+    )
+    md = f"| Issue | Title |\n|---|---|\n{rows}"
     result = render_table_with_links(md)
-    assert result.count('<a ') == 3, f"Expected 3 <a> tags, got {result.count('<a ')}:\n{result}"
-    assert result.count('</a>') == 3
+    assert result.count("<a ") == 3, (
+        f"Expected 3 <a> tags, got {result.count('<a ')}:\n{result}"
+    )
+    assert result.count("</a>") == 3
     for url in urls:
         assert f'href="{url}"' in result
 
 
 def test_link_label_is_escaped():
     """The label text (not the URL) must still be HTML-escaped."""
-    url = 'https://example.com'
-    md = f'[Click <here>]({url})'
+    url = "https://example.com"
+    md = f"[Click <here>]({url})"
     result = render_links_only(md)
-    assert '&lt;here&gt;' in result, "Label text should be HTML-escaped"
-    assert '<here>' not in result
+    assert "&lt;here&gt;" in result, "Label text should be HTML-escaped"
+    assert "<here>" not in result
 
 
 def test_link_not_broken_by_prior_autolink():
     """A [label](url) followed by a bare URL must each produce one clean <a>."""
-    url1 = 'https://github.com/issues/461'
-    url2 = 'https://github.com/issues/462'
-    md = f'See [#461]({url1}) and also {url2}'
+    url1 = "https://github.com/issues/461"
+    url2 = "https://github.com/issues/462"
+    md = f"See [#461]({url1}) and also {url2}"
     result = render_links_only(md)
-    assert result.count('<a ') == 2, f"Expected 2 links, got: {result}"
+    assert result.count("<a ") == 2, f"Expected 2 links, got: {result}"
     assert f'href="{url1}"' in result
     assert f'href="{url2}"' in result
-    assert '#461' in result
+    assert "#461" in result
+
 
 def test_href_quote_sanitized():
     """A URL containing a double-quote must have it percent-encoded in href to prevent attribute breakout."""
@@ -244,7 +267,7 @@ def test_href_quote_sanitized():
     # The [label](url) regex captures up to the closing ), so we test via the render helper
     # by constructing a URL that contains a literal quote character
     safe_url = 'https://example.com/path"with"quotes'
-    result = render_links_only(f'[click]({safe_url})')
+    result = render_links_only(f"[click]({safe_url})")
     # The href must not contain a raw unencoded double-quote
     href_start = result.find('href="') + 6
     href_end = result.find('"', href_start)
@@ -261,11 +284,13 @@ def test_js_source_sanitizes_quotes_in_href():
         "URL placed in href should have double-quotes percent-encoded via .replace to %22"
     )
 
+
 # ── Code-inside-bold tests (pre-existing bug, fixed in same PR) ───────────────
+
 
 def test_js_inlinemd_stashes_code_before_bold():
     """Fixed inlineMd() must stash backtick code spans before bold/italic processing."""
-    assert '_code_stash' in UI_JS, (
+    assert "_code_stash" in UI_JS, (
         "inlineMd() should use _code_stash to protect backtick spans from bold/italic esc()"
     )
 
@@ -274,40 +299,61 @@ def test_code_inside_bold_renders_correctly():
     """Inline code inside bold text must render as <strong><code>...</code></strong>,
     not with escaped &lt;code&gt; tags visible on screen."""
     # This was the pre-existing bug: **`esc()`** → <strong>&lt;code&gt;esc()&lt;/code&gt;</strong>
-    text = '**`esc()` on `href`**: breaks URLs'
+    text = "**`esc()` on `href`**: breaks URLs"
     # Simulate the fixed inlineMd()
     code_stash = []
     t = text
-    t = re.sub(r'`([^`\n]+)`',
-        lambda m: (code_stash.append(f'<code>{esc(m.group(1))}</code>') or f'\x00C{len(code_stash)-1}\x00'), t)
-    t = re.sub(r'\*\*(.+?)\*\*', lambda m: f'<strong>{esc(m.group(1))}</strong>', t)
-    t = re.sub(r'\x00C(\d+)\x00', lambda m: code_stash[int(m.group(1))], t)
-    assert '&lt;code&gt;' not in t, (
+    t = re.sub(
+        r"`([^`\n]+)`",
+        lambda m: (
+            code_stash.append(f"<code>{esc(m.group(1))}</code>")
+            or f"\x00C{len(code_stash) - 1}\x00"
+        ),
+        t,
+    )
+    t = re.sub(r"\*\*(.+?)\*\*", lambda m: f"<strong>{esc(m.group(1))}</strong>", t)
+    t = re.sub(r"\x00C(\d+)\x00", lambda m: code_stash[int(m.group(1))], t)
+    assert "&lt;code&gt;" not in t, (
         f"Code tags should not be HTML-escaped inside bold. Got: {t}"
     )
-    assert '<code>esc()</code>' in t, (
+    assert "<code>esc()</code>" in t, (
         f"Code tags should render as <code> elements inside bold. Got: {t}"
     )
-    assert '<strong>' in t, "Bold should still render"
+    assert "<strong>" in t, "Bold should still render"
 
 
 def test_code_and_bold_mixed_no_escaping():
     """Bold text containing multiple backtick spans must render all code tags correctly."""
     cases = [
-        ('**`esc()` on `href`**', '<strong>', '<code>esc()</code>', '<code>href</code>'),
-        ('***`code` in bold-italic***', '<strong>', '<code>code</code>'),
-        ('`code` then **bold**', '<code>code</code>', '<strong>bold</strong>'),
+        (
+            "**`esc()` on `href`**",
+            "<strong>",
+            "<code>esc()</code>",
+            "<code>href</code>",
+        ),
+        ("***`code` in bold-italic***", "<strong>", "<code>code</code>"),
+        ("`code` then **bold**", "<code>code</code>", "<strong>bold</strong>"),
     ]
     for args in cases:
         text = args[0]
         expected_fragments = args[1:]
         code_stash = []
         t = text
-        t = re.sub(r'`([^`\n]+)`',
-            lambda m: (code_stash.append(f'<code>{esc(m.group(1))}</code>') or f'\x00C{len(code_stash)-1}\x00'), t)
-        t = re.sub(r'\*\*\*(.+?)\*\*\*', lambda m: f'<strong><em>{esc(m.group(1))}</em></strong>', t)
-        t = re.sub(r'\*\*(.+?)\*\*', lambda m: f'<strong>{esc(m.group(1))}</strong>', t)
-        t = re.sub(r'\x00C(\d+)\x00', lambda m: code_stash[int(m.group(1))], t)
-        assert '&lt;code&gt;' not in t, f"Escaped code tag in: {text!r} → {t}"
+        t = re.sub(
+            r"`([^`\n]+)`",
+            lambda m: (
+                code_stash.append(f"<code>{esc(m.group(1))}</code>")
+                or f"\x00C{len(code_stash) - 1}\x00"
+            ),
+            t,
+        )
+        t = re.sub(
+            r"\*\*\*(.+?)\*\*\*",
+            lambda m: f"<strong><em>{esc(m.group(1))}</em></strong>",
+            t,
+        )
+        t = re.sub(r"\*\*(.+?)\*\*", lambda m: f"<strong>{esc(m.group(1))}</strong>", t)
+        t = re.sub(r"\x00C(\d+)\x00", lambda m: code_stash[int(m.group(1))], t)
+        assert "&lt;code&gt;" not in t, f"Escaped code tag in: {text!r} → {t}"
         for frag in expected_fragments:
             assert frag in t, f"Expected {frag!r} in output of {text!r}, got: {t}"

--- a/tests/test_issue477.py
+++ b/tests/test_issue477.py
@@ -1,4 +1,5 @@
 """Tests for fix #477: KaTeX font-src CSP fix."""
+
 import pathlib
 
 REPO = pathlib.Path(__file__).parent.parent

--- a/tests/test_issue483_inline_diff_viewer.py
+++ b/tests/test_issue483_inline_diff_viewer.py
@@ -1,5 +1,4 @@
 """Tests for issue #483 — inline diff/patch viewer."""
-import pytest
 
 
 class TestFencedDiffRenderer:
@@ -11,7 +10,7 @@ class TestFencedDiffRenderer:
             content = f.read()
         assert "diff-block" in content, "Missing diff-block class"
         # Should be in the fenced block renderer
-        assert "pre class=\"diff-block\"" in content
+        assert 'pre class="diff-block"' in content
 
     def test_diff_lines_get_span_classes(self):
         """Each diff line should be wrapped in a span with appropriate class."""
@@ -63,7 +62,9 @@ class TestMediaDiffInline:
         with open("static/ui.js", "r", encoding="utf-8") as f:
             content = f.read()
         count = content.count("loadDiffInline()")
-        assert count >= 2, f"loadDiffInline() called {count} times, expected >= 2 (cached + fresh render)"
+        assert count >= 2, (
+            f"loadDiffInline() called {count} times, expected >= 2 (cached + fresh render)"
+        )
 
     def test_diff_inline_error_class(self):
         """Should have error state class."""
@@ -78,16 +79,28 @@ class TestDiffCSS:
     def test_diff_css_classes_exist(self):
         with open("static/style.css", "r", encoding="utf-8") as f:
             content = f.read()
-        for cls in (".diff-block", ".diff-line", ".diff-plus", ".diff-minus",
-                    ".diff-hunk", ".diff-inline-load", ".diff-inline", ".diff-inline-error"):
+        for cls in (
+            ".diff-block",
+            ".diff-line",
+            ".diff-plus",
+            ".diff-minus",
+            ".diff-hunk",
+            ".diff-inline-load",
+            ".diff-inline",
+            ".diff-inline-error",
+        ):
             assert cls in content, f"Missing CSS class: {cls}"
 
     def test_diff_colors_are_present(self):
         """Green for plus, red for minus should use rgba colors."""
         with open("static/style.css", "r", encoding="utf-8") as f:
             content = f.read()
-        assert "rgba(34,197,94" in content or "#22c55e" in content, "Missing green color for diff-plus"
-        assert "rgba(239,68,68" in content or "#ef4444" in content, "Missing red color for diff-minus"
+        assert "rgba(34,197,94" in content or "#22c55e" in content, (
+            "Missing green color for diff-plus"
+        )
+        assert "rgba(239,68,68" in content or "#ef4444" in content, (
+            "Missing red color for diff-minus"
+        )
 
 
 class TestDiffI18n:
@@ -97,4 +110,6 @@ class TestDiffI18n:
         with open("static/i18n.js", "r", encoding="utf-8") as f:
             content = f.read()
         count = content.count("diff_loading")
-        assert count >= 8, f"diff_loading found {count} times, expected >= 8 (one per locale)"
+        assert count >= 8, (
+            f"diff_loading found {count} times, expected >= 8 (one per locale)"
+        )

--- a/tests/test_issue484_json_tree_viewer.py
+++ b/tests/test_issue484_json_tree_viewer.py
@@ -1,5 +1,4 @@
 """Tests for issue #484 — collapsible JSON/YAML tree viewer."""
-import pytest
 
 
 class TestTreeRenderer:
@@ -37,7 +36,14 @@ class TestTreeRenderer:
         """_buildTreeDOM should handle null, boolean, number, string, array, object."""
         with open("static/ui.js", "r", encoding="utf-8") as f:
             content = f.read()
-        for cls in ("tree-null", "tree-bool", "tree-num", "tree-str", "tree-array", "tree-object"):
+        for cls in (
+            "tree-null",
+            "tree-bool",
+            "tree-num",
+            "tree-str",
+            "tree-array",
+            "tree-object",
+        ):
             assert cls in content, f"Missing type class: {cls}"
 
     def test_tree_collapse_support(self):
@@ -79,10 +85,23 @@ class TestTreeCSS:
     def test_tree_css_classes_exist(self):
         with open("static/style.css", "r", encoding="utf-8") as f:
             content = f.read()
-        for cls in (".code-tree-wrap", ".tree-view", ".tree-hidden", ".tree-toggle-btn",
-                    ".tree-node", ".tree-collapsible", ".tree-children", ".tree-collapsed",
-                    ".tree-key", ".tree-str", ".tree-num", ".tree-bool", ".tree-null",
-                    ".tree-comma", ".tree-item"):
+        for cls in (
+            ".code-tree-wrap",
+            ".tree-view",
+            ".tree-hidden",
+            ".tree-toggle-btn",
+            ".tree-node",
+            ".tree-collapsible",
+            ".tree-children",
+            ".tree-collapsed",
+            ".tree-key",
+            ".tree-str",
+            ".tree-num",
+            ".tree-bool",
+            ".tree-null",
+            ".tree-comma",
+            ".tree-item",
+        ):
             assert cls in content, f"Missing CSS: {cls}"
 
     def test_tree_colors_match_types(self):

--- a/tests/test_issue486_487.py
+++ b/tests/test_issue486_487.py
@@ -16,6 +16,7 @@ Strategy:
   - Python mirror tests verify the rendering logic with exhaustive edge cases,
     especially code blocks inside tables (the specific case Nathan flagged).
 """
+
 import pathlib
 import re
 import html as _html
@@ -26,6 +27,7 @@ STYLE_CSS = (REPO_ROOT / "static" / "style.css").read_text()
 
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
+
 
 def esc(s):
     return _html.escape(str(s), quote=True)
@@ -55,130 +57,149 @@ def inline_md(t):
     """
     # 1. Code stash — must be first to protect code content from all subsequent passes
     code_stash = []
+
     def stash_code(m):
-        code_stash.append(f'<code>{esc(m.group(1))}</code>')
-        return f'\x00C{len(code_stash)-1}\x00'
-    t = re.sub(r'`([^`\n]+)`', stash_code, t)
+        code_stash.append(f"<code>{esc(m.group(1))}</code>")
+        return f"\x00C{len(code_stash) - 1}\x00"
+
+    t = re.sub(r"`([^`\n]+)`", stash_code, t)
 
     # 2. Bold/italic (code content is safely stashed)
-    t = re.sub(r'\*\*\*(.+?)\*\*\*', lambda m: f'<strong><em>{esc(m.group(1))}</em></strong>', t)
-    t = re.sub(r'\*\*(.+?)\*\*',     lambda m: f'<strong>{esc(m.group(1))}</strong>', t)
-    t = re.sub(r'\*([^*\n]+)\*',     lambda m: f'<em>{esc(m.group(1))}</em>', t)
+    t = re.sub(
+        r"\*\*\*(.+?)\*\*\*",
+        lambda m: f"<strong><em>{esc(m.group(1))}</em></strong>",
+        t,
+    )
+    t = re.sub(r"\*\*(.+?)\*\*", lambda m: f"<strong>{esc(m.group(1))}</strong>", t)
+    t = re.sub(r"\*([^*\n]+)\*", lambda m: f"<em>{esc(m.group(1))}</em>", t)
 
     # 3. Image pass (NEW — runs while code is still stashed, so ![x](url) inside
     #    backticks is protected as a \x00C token and won't match here)
     def render_image(m):
         alt, url = m.group(1), m.group(2)
-        safe_url = url.replace('"', '%22')
-        return (f'<img src="{safe_url}" alt="{esc(alt)}" '
-                f'class="msg-media-img" loading="lazy" '
-                f'onclick="this.classList.toggle(\'msg-media-img--full\')">')
-    t = re.sub(r'!\[([^\]]*)\]\((https?://[^\)]+)\)', render_image, t)
+        safe_url = url.replace('"', "%22")
+        return (
+            f'<img src="{safe_url}" alt="{esc(alt)}" '
+            f'class="msg-media-img" loading="lazy" '
+            f"onclick=\"this.classList.toggle('msg-media-img--full')\">"
+        )
+
+    t = re.sub(r"!\[([^\]]*)\]\((https?://[^\)]+)\)", render_image, t)
 
     # 4. Img stash — protect rendered <img> tags so autolink never touches src= values
     img_stash = []
+
     def stash_img(m):
         img_stash.append(m.group(0))
-        return f'\x00I{len(img_stash)-1}\x00'
-    t = re.sub(r'<img\b[^>]*>', stash_img, t)
+        return f"\x00I{len(img_stash) - 1}\x00"
+
+    t = re.sub(r"<img\b[^>]*>", stash_img, t)
 
     # 5. Link stash
     link_stash = []
+
     def stash_link(m):
         lb, u = m.group(1), m.group(2)
-        link_stash.append(f'<a href="{u.replace(chr(34), "%22")}" target="_blank" rel="noopener">{esc(lb)}</a>')
-        return f'\x00L{len(link_stash)-1}\x00'
-    t = re.sub(r'\[([^\]]+)\]\((https?://[^\)]+)\)', stash_link, t)
+        link_stash.append(
+            f'<a href="{u.replace(chr(34), "%22")}" target="_blank" rel="noopener">{esc(lb)}</a>'
+        )
+        return f"\x00L{len(link_stash) - 1}\x00"
+
+    t = re.sub(r"\[([^\]]+)\]\((https?://[^\)]+)\)", stash_link, t)
 
     # 6. Autolink (img and link URLs are both stashed — safe)
     def autolink(m):
         url = m.group(1)
-        trail = url[-1] if url[-1] in '.,;:!?)' else ''
+        trail = url[-1] if url[-1] in ".,;:!?)" else ""
         clean = url[:-1] if trail else url
-        return f'<a href="{clean}" target="_blank" rel="noopener">{esc(clean)}</a>{trail}'
+        return (
+            f'<a href="{clean}" target="_blank" rel="noopener">{esc(clean)}</a>{trail}'
+        )
+
     t = re.sub(r'(https?://[^\s<>"\')\]]+)', autolink, t)
 
     # 7. Restore link stash
-    t = re.sub(r'\x00L(\d+)\x00', lambda m: link_stash[int(m.group(1))], t)
+    t = re.sub(r"\x00L(\d+)\x00", lambda m: link_stash[int(m.group(1))], t)
 
     # 8. Restore img stash
-    t = re.sub(r'\x00I(\d+)\x00', lambda m: img_stash[int(m.group(1))], t)
+    t = re.sub(r"\x00I(\d+)\x00", lambda m: img_stash[int(m.group(1))], t)
 
     # 9. Restore code stash (last — code content was never touched by any pass)
-    t = re.sub(r'\x00C(\d+)\x00', lambda m: code_stash[int(m.group(1))], t)
+    t = re.sub(r"\x00C(\d+)\x00", lambda m: code_stash[int(m.group(1))], t)
     return t
 
 
 def render_table(md):
     """Python mirror of the table pass, using inline_md() per cell."""
-    lines = md.strip().split('\n')
+    lines = md.strip().split("\n")
     if len(lines) < 2:
         return md
 
     def is_sep(r):
-        return bool(re.match(r'^\|[\s|:-]+\|$', r.strip()))
+        return bool(re.match(r"^\|[\s|:-]+\|$", r.strip()))
 
     if not is_sep(lines[1]):
         return md
 
     def parse_header(r):
-        cells = r.strip().lstrip('|').rstrip('|').split('|')
-        return ''.join(f'<th>{inline_md(c.strip())}</th>' for c in cells)
+        cells = r.strip().lstrip("|").rstrip("|").split("|")
+        return "".join(f"<th>{inline_md(c.strip())}</th>" for c in cells)
 
     def parse_row(r):
-        cells = r.strip().lstrip('|').rstrip('|').split('|')
-        return ''.join(f'<td>{inline_md(c.strip())}</td>' for c in cells)
+        cells = r.strip().lstrip("|").rstrip("|").split("|")
+        return "".join(f"<td>{inline_md(c.strip())}</td>" for c in cells)
 
-    header = f'<tr>{parse_header(lines[0])}</tr>'
-    body = ''.join(f'<tr>{parse_row(r)}</tr>' for r in lines[2:])
-    return f'<table><thead>{header}</thead><tbody>{body}</tbody></table>'
+    header = f"<tr>{parse_header(lines[0])}</tr>"
+    body = "".join(f"<tr>{parse_row(r)}</tr>" for r in lines[2:])
+    return f"<table><thead>{header}</thead><tbody>{body}</tbody></table>"
 
 
 # ═════════════════════════════════════════════════════════════════════════════
 # ISSUE #486 — CSS: code inside table cells
 # ═════════════════════════════════════════════════════════════════════════════
 
+
 class TestIssue486CssCodeInTable:
     """CSS fix: td code and th code must have targeted sizing rules."""
 
     def test_td_code_font_size_present(self):
         """msg-body td code rule must set font-size (e.g. 0.85em) to prevent oversized code."""
-        assert 'td code' in STYLE_CSS, (
+        assert "td code" in STYLE_CSS, (
             "Missing 'td code' CSS rule — inline code in table cells needs sizing fix"
         )
 
     def test_th_code_rule_present(self):
         """th code rule must also exist for header cells."""
-        assert 'th code' in STYLE_CSS, (
+        assert "th code" in STYLE_CSS, (
             "Missing 'th code' CSS rule — inline code in header cells needs sizing fix"
         )
 
     def test_td_code_has_font_size(self):
         """The td code / th code block must include a font-size declaration."""
         # Find the msg-body scoped td code rule
-        idx = STYLE_CSS.find('td code')
+        idx = STYLE_CSS.find("td code")
         assert idx != -1, "td code rule not found in style.css"
         # Check nearby text (within 200 chars) has font-size
-        window = STYLE_CSS[idx:idx+200]
-        assert 'font-size' in window, (
+        window = STYLE_CSS[idx : idx + 200]
+        assert "font-size" in window, (
             f"td code rule must include font-size. Found near td code: {window!r}"
         )
 
     def test_td_code_has_padding(self):
         """The td code / th code block must include a padding declaration."""
-        idx = STYLE_CSS.find('td code')
+        idx = STYLE_CSS.find("td code")
         assert idx != -1
-        window = STYLE_CSS[idx:idx+200]
-        assert 'padding' in window, (
+        window = STYLE_CSS[idx : idx + 200]
+        assert "padding" in window, (
             f"td code rule must include padding. Found near td code: {window!r}"
         )
 
     def test_td_code_has_vertical_align(self):
         """The td code / th code block must include vertical-align: baseline."""
-        idx = STYLE_CSS.find('td code')
+        idx = STYLE_CSS.find("td code")
         assert idx != -1
-        window = STYLE_CSS[idx:idx+200]
-        assert 'vertical-align' in window, (
+        window = STYLE_CSS[idx : idx + 200]
+        assert "vertical-align" in window, (
             f"td code rule must include vertical-align. Found near td code: {window!r}"
         )
 
@@ -186,7 +207,7 @@ class TestIssue486CssCodeInTable:
         """Inline `code` inside a table cell must render as <code> element."""
         md = "| Syntax | Rendered |\n|---|---|\n| `code` | `code` |"
         result = render_table(md)
-        assert '<code>code</code>' in result, (
+        assert "<code>code</code>" in result, (
             f"Inline code in table cell should render as <code>. Got: {result}"
         )
 
@@ -195,7 +216,7 @@ class TestIssue486CssCodeInTable:
         md = "| Style | Example |\n|---|---|\n| bold code | **`bold code`** |"
         result = render_table(md)
         # Should have code tag (even inside bold)
-        assert '<code>bold code</code>' in result, (
+        assert "<code>bold code</code>" in result, (
             f"Bold code in table should render as <code>. Got: {result}"
         )
 
@@ -203,7 +224,7 @@ class TestIssue486CssCodeInTable:
         """Multiple backtick spans in one cell all render as <code>."""
         md = "| Combined |\n|---|\n| `a` and `b` |"
         result = render_table(md)
-        assert result.count('<code>') == 2, (
+        assert result.count("<code>") == 2, (
             f"Expected 2 code tags in cell, got: {result}"
         )
 
@@ -211,7 +232,7 @@ class TestIssue486CssCodeInTable:
         """`code` in a <th> header cell must also render as <code>."""
         md = "| `header code` | Normal |\n|---|---|\n| data | data |"
         result = render_table(md)
-        assert '<code>header code</code>' in result, (
+        assert "<code>header code</code>" in result, (
             f"Code in header cell should render. Got: {result}"
         )
 
@@ -219,42 +240,43 @@ class TestIssue486CssCodeInTable:
         """**`code`** in a table cell must NOT produce &lt;code&gt; (the pre-fix bug)."""
         md = "| Pattern | Example |\n|---|---|\n| bold-code | **`npm install`** |"
         result = render_table(md)
-        assert '&lt;code&gt;' not in result, (
+        assert "&lt;code&gt;" not in result, (
             f"Code tags inside bold in table must not be HTML-escaped. Got: {result}"
         )
-        assert '<strong>' in result, "Bold wrapper should be present"
-        assert '<code>npm install</code>' in result
+        assert "<strong>" in result, "Bold wrapper should be present"
+        assert "<code>npm install</code>" in result
 
     def test_code_with_special_chars_in_table(self):
         """`<script>` inside a table cell must have the angle brackets escaped."""
         md = "| Input | Output |\n|---|---|\n| `<script>` | sanitized |"
         result = render_table(md)
-        assert '&lt;script&gt;' in result, (
+        assert "&lt;script&gt;" in result, (
             f"Code content must be HTML-escaped. Got: {result}"
         )
         # The <code> wrapper itself must be there
-        assert '<code>' in result
+        assert "<code>" in result
 
     def test_code_adjacent_to_link_in_table(self):
         """`code` and [link](url) in same cell both render correctly."""
-        url = 'https://example.com'
+        url = "https://example.com"
         md = f"| Mixed |\n|---|\n| `foo` and [bar]({url}) |"
         result = render_table(md)
-        assert '<code>foo</code>' in result
+        assert "<code>foo</code>" in result
         assert f'href="{url}"' in result
-        assert 'bar' in result
+        assert "bar" in result
 
     def test_empty_code_span_in_table(self):
         """Edge case: empty backtick span in table cell (`` ` ` ``) — no crash."""
         # This won't match the code regex (requires at least 1 char), should pass through
         md = "| Col |\n|---|\n| normal text |"
         result = render_table(md)
-        assert '<td>normal text</td>' in result
+        assert "<td>normal text</td>" in result
 
 
 # ═════════════════════════════════════════════════════════════════════════════
 # ISSUE #487 — JS renderer: markdown image syntax
 # ═════════════════════════════════════════════════════════════════════════════
+
 
 class TestIssue487ImageRendering:
     """Image syntax ![alt](url) must render as <img>, not as ! + link."""
@@ -263,18 +285,16 @@ class TestIssue487ImageRendering:
 
     def test_image_pass_present_in_ui_js(self):
         """renderMd() must contain an image regex pass for ![alt](url)."""
-        assert '![' in UI_JS or r'!\[' in UI_JS, (
+        assert "![" in UI_JS or r"!\[" in UI_JS, (
             "ui.js should contain image syntax handling (![...](url) regex)"
         )
         # More specifically, look for the img tag being generated
-        assert 'msg-media-img' in UI_JS, (
-            "Image pass should reuse .msg-media-img class"
-        )
+        assert "msg-media-img" in UI_JS, "Image pass should reuse .msg-media-img class"
 
     def test_image_pass_runs_before_link_pass_in_outer(self):
         """Image regex must appear in ui.js BEFORE the [label](url) link pass."""
         # Find the image pass position
-        img_idx = UI_JS.find('!\\[')
+        img_idx = UI_JS.find("!\\[")
         if img_idx == -1:
             img_idx = UI_JS.find("![")
         # Find the outer labeled link pass position (after table pass)
@@ -290,27 +310,25 @@ class TestIssue487ImageRendering:
         """Image src URL must have double-quotes percent-encoded."""
         # The image pass must use .replace(/"/g,'%22') or equivalent
         # Look for the pattern near image handling
-        img_idx = UI_JS.find('msg-media-img')
+        img_idx = UI_JS.find("msg-media-img")
         assert img_idx != -1
         # Find all occurrences — there's the MEDIA restore and the new image pass
         # The new one should have %22 for URL sanitization
-        assert '%22' in UI_JS, (
-            "Image src URL must sanitize double-quotes to %22"
-        )
+        assert "%22" in UI_JS, "Image src URL must sanitize double-quotes to %22"
 
     def test_image_alt_uses_esc(self):
         """Alt text must be passed through esc() to prevent XSS."""
         # Look for esc( call near the image rendering code
         # The pattern should be: alt="${esc(alt)}"
-        assert 'esc(' in UI_JS, "esc() function must be used for alt text"
+        assert "esc(" in UI_JS, "esc() function must be used for alt text"
 
     def test_safe_tags_includes_img(self):
         """SAFE_TAGS allowlist must include 'img' to prevent the tag from being escaped."""
         # Find the SAFE_TAGS regex in ui.js
-        safe_idx = UI_JS.find('SAFE_TAGS=')
+        safe_idx = UI_JS.find("SAFE_TAGS=")
         assert safe_idx != -1, "SAFE_TAGS not found in ui.js"
-        safe_window = UI_JS[safe_idx:safe_idx+300]
-        assert 'img' in safe_window, (
+        safe_window = UI_JS[safe_idx : safe_idx + 300]
+        assert "img" in safe_window, (
             f"SAFE_TAGS must include 'img' tag. Found: {safe_window!r}"
         )
 
@@ -318,11 +336,11 @@ class TestIssue487ImageRendering:
         """inlineMd() must also handle ![alt](url) for images inside table cells."""
         # inlineMd is called for table cells, list items, blockquotes
         # Find inlineMd function body
-        start = UI_JS.find('function inlineMd(')
+        start = UI_JS.find("function inlineMd(")
         assert start != -1, "inlineMd function not found"
         # Get a generous window covering the function
-        fn_window = UI_JS[start:start+1500]
-        assert '![' in fn_window or r'!\[' in fn_window, (
+        fn_window = UI_JS[start : start + 1500]
+        assert "![" in fn_window or r"!\[" in fn_window, (
             "inlineMd() must handle image syntax for images in table cells"
         )
 
@@ -330,37 +348,37 @@ class TestIssue487ImageRendering:
 
     def test_basic_image_renders_as_img_tag(self):
         """![alt](https://example.com/img.png) must produce an <img> tag."""
-        t = '![A cat](https://example.com/cat.png)'
+        t = "![A cat](https://example.com/cat.png)"
         result = inline_md(t)
-        assert '<img ' in result, f"Expected <img> tag, got: {result}"
+        assert "<img " in result, f"Expected <img> tag, got: {result}"
         assert 'src="https://example.com/cat.png"' in result
         assert 'alt="A cat"' in result
         # Must NOT have the raw ![...] syntax left over
-        assert '![' not in result
+        assert "![" not in result
         # Must NOT have a stray ! character
-        assert result.startswith('<img '), f"Result should start with img tag: {result}"
+        assert result.startswith("<img "), f"Result should start with img tag: {result}"
 
     def test_image_does_not_render_as_link(self):
         """![alt](url) must NOT produce an <a> tag (the pre-fix bug)."""
-        t = '![Logo](https://example.com/logo.png)'
+        t = "![Logo](https://example.com/logo.png)"
         result = inline_md(t)
-        assert '<a ' not in result, (
+        assert "<a " not in result, (
             f"Image must not render as an <a> tag. Got: {result}"
         )
 
     def test_image_stray_exclamation_not_present(self):
         """No stray ! character before the img tag (the pre-fix symptom)."""
-        t = '![alt](https://example.com/img.png)'
+        t = "![alt](https://example.com/img.png)"
         result = inline_md(t)
         # Strip the img tag and check no ! is left
-        cleaned = re.sub(r'<img[^>]+>', '', result)
-        assert '!' not in cleaned, (
+        cleaned = re.sub(r"<img[^>]+>", "", result)
+        assert "!" not in cleaned, (
             f"Stray ! character present after image render. Got: {result}"
         )
 
     def test_image_uses_msg_media_img_class(self):
         """Rendered <img> must use class=\"msg-media-img\" for consistent styling."""
-        t = '![screenshot](https://example.com/shot.png)'
+        t = "![screenshot](https://example.com/shot.png)"
         result = inline_md(t)
         assert 'class="msg-media-img"' in result, (
             f"Image must use .msg-media-img class. Got: {result}"
@@ -368,26 +386,24 @@ class TestIssue487ImageRendering:
 
     def test_image_has_lazy_loading(self):
         """Rendered <img> must have loading=\"lazy\"."""
-        t = '![x](https://example.com/x.png)'
+        t = "![x](https://example.com/x.png)"
         result = inline_md(t)
         assert 'loading="lazy"' in result, f"Expected loading=lazy. Got: {result}"
 
     def test_image_has_click_to_zoom(self):
         """Rendered <img> must have onclick toggle for zoom."""
-        t = '![x](https://example.com/x.png)'
+        t = "![x](https://example.com/x.png)"
         result = inline_md(t)
-        assert 'msg-media-img--full' in result, (
+        assert "msg-media-img--full" in result, (
             f"Image must have click-to-zoom onclick. Got: {result}"
         )
 
     def test_image_alt_is_escaped(self):
         """Alt text with HTML special chars must be escaped."""
-        t = '![<evil>](https://example.com/img.png)'
+        t = "![<evil>](https://example.com/img.png)"
         result = inline_md(t)
-        assert '&lt;evil&gt;' in result, (
-            f"Alt text must be HTML-escaped. Got: {result}"
-        )
-        assert '<evil>' not in result
+        assert "&lt;evil&gt;" in result, f"Alt text must be HTML-escaped. Got: {result}"
+        assert "<evil>" not in result
 
     def test_image_url_quote_sanitized(self):
         """Double-quote in image URL must be percent-encoded to prevent attribute breakout."""
@@ -403,90 +419,91 @@ class TestIssue487ImageRendering:
 
     def test_image_no_javascript_uri(self):
         """javascript: URIs must not be rendered as image src (regex only matches http/https)."""
-        t = '![x](javascript:alert(1))'
+        t = "![x](javascript:alert(1))"
         result = inline_md(t)
         # The regex requires https?://, so this should pass through unmodified
-        assert '<img ' not in result, (
+        assert "<img " not in result, (
             f"javascript: URI must not render as <img>. Got: {result}"
         )
 
     def test_image_no_data_uri(self):
         """data: URIs must not be rendered as image src."""
-        t = '![x](data:image/png;base64,abc123)'
+        t = "![x](data:image/png;base64,abc123)"
         result = inline_md(t)
-        assert '<img ' not in result, (
+        assert "<img " not in result, (
             f"data: URI must not render as <img>. Got: {result}"
         )
 
     def test_image_followed_by_text(self):
         """Image followed by plain text — only the image becomes an <img>."""
-        t = '![cat](https://example.com/cat.png) and some text'
+        t = "![cat](https://example.com/cat.png) and some text"
         result = inline_md(t)
-        assert '<img ' in result
-        assert 'and some text' in result
+        assert "<img " in result
+        assert "and some text" in result
 
     def test_image_preceded_by_text(self):
         """Text before an image — both render correctly."""
-        t = 'Here is a screenshot: ![shot](https://example.com/shot.png)'
+        t = "Here is a screenshot: ![shot](https://example.com/shot.png)"
         result = inline_md(t)
-        assert 'Here is a screenshot:' in result
-        assert '<img ' in result
+        assert "Here is a screenshot:" in result
+        assert "<img " in result
 
     def test_image_and_link_in_same_cell(self):
         """Image and link in same inline context both render correctly."""
-        t = '![img](https://example.com/img.png) see [here](https://example.com)'
+        t = "![img](https://example.com/img.png) see [here](https://example.com)"
         result = inline_md(t)
-        assert '<img ' in result
+        assert "<img " in result
         assert '<a href="https://example.com"' in result
-        assert '![' not in result
+        assert "![" not in result
 
     def test_image_inside_table_cell(self):
         """![alt](url) inside a markdown table cell must render as <img>."""
-        md = ("| Image | Caption |\n"
-              "|---|---|\n"
-              "| ![logo](https://example.com/logo.png) | Company logo |")
+        md = (
+            "| Image | Caption |\n"
+            "|---|---|\n"
+            "| ![logo](https://example.com/logo.png) | Company logo |"
+        )
         result = render_table(md)
-        assert '<img ' in result, f"Image in table should render as <img>. Got: {result}"
+        assert "<img " in result, (
+            f"Image in table should render as <img>. Got: {result}"
+        )
         assert 'src="https://example.com/logo.png"' in result
-        assert '<a ' not in result, "Image in table must not render as <a>"
+        assert "<a " not in result, "Image in table must not render as <a>"
 
     def test_image_in_table_no_stray_exclamation(self):
         """No stray ! before the <img> when image is inside a table cell."""
-        md = ("| X |\n|---|\n| ![x](https://x.com/x.png) |")
+        md = "| X |\n|---|\n| ![x](https://x.com/x.png) |"
         result = render_table(md)
         # Strip known tags and check no ! appears
-        cleaned = re.sub(r'<[^>]+>', '', result)
-        assert '!' not in cleaned, (
+        cleaned = re.sub(r"<[^>]+>", "", result)
+        assert "!" not in cleaned, (
             f"Stray ! in table cell after image render. Cleaned: {cleaned!r}"
         )
 
     def test_empty_alt_text_image(self):
         """![](url) with empty alt renders as <img> with empty alt attribute."""
-        t = '![](https://example.com/img.png)'
+        t = "![](https://example.com/img.png)"
         result = inline_md(t)
-        assert '<img ' in result
+        assert "<img " in result
         assert 'alt=""' in result
 
     def test_multiple_images_in_one_cell(self):
         """Two images in one table cell both render as <img> tags."""
-        t = ('![a](https://example.com/a.png) '
-             '![b](https://example.com/b.png)')
+        t = "![a](https://example.com/a.png) ![b](https://example.com/b.png)"
         result = inline_md(t)
-        assert result.count('<img ') == 2, (
-            f"Expected 2 img tags. Got: {result}"
-        )
+        assert result.count("<img ") == 2, f"Expected 2 img tags. Got: {result}"
 
     def test_image_with_https_url(self):
         """https:// image URL renders correctly."""
-        t = '![secure](https://secure.example.com/img.jpg)'
+        t = "![secure](https://secure.example.com/img.jpg)"
         result = inline_md(t)
         assert 'src="https://secure.example.com/img.jpg"' in result
 
     def test_image_with_http_url(self):
         """http:// image URL also renders (non-https still valid)."""
-        t = '![old](http://example.com/img.jpg)'
+        t = "![old](http://example.com/img.jpg)"
         result = inline_md(t)
-        assert '<img ' in result
+        assert "<img " in result
         assert 'src="http://example.com/img.jpg"' in result
 
 
@@ -494,59 +511,69 @@ class TestIssue487ImageRendering:
 # Cross-cutting: code + image together inside tables (the edge case Nathan flagged)
 # ═════════════════════════════════════════════════════════════════════════════
 
+
 class TestEdgeCasesCodeAndImageInTables:
     """Combination edge cases: code blocks and images mixed inside table cells."""
 
     def test_code_and_image_in_same_table_row(self):
         """Table row with code in one cell and image in another renders both correctly."""
-        md = ("| Code | Preview |\n"
-              "|---|---|\n"
-              "| `print('hello')` | ![screenshot](https://example.com/shot.png) |")
-        result = render_table(md)
-        assert "<code>print(&#x27;hello&#x27;)</code>" in result or "<code>print('hello')</code>" in result, (
-            f"Code cell should render as <code>. Got: {result}"
+        md = (
+            "| Code | Preview |\n"
+            "|---|---|\n"
+            "| `print('hello')` | ![screenshot](https://example.com/shot.png) |"
         )
-        assert '<img ' in result, "Image cell should render as <img>"
+        result = render_table(md)
+        assert (
+            "<code>print(&#x27;hello&#x27;)</code>" in result
+            or "<code>print('hello')</code>" in result
+        ), f"Code cell should render as <code>. Got: {result}"
+        assert "<img " in result, "Image cell should render as <img>"
 
     def test_code_in_cell_with_image_in_next_cell(self):
         """Multiple columns: code stays code, image stays image, no cross-contamination."""
-        md = ("| Step | Example |\n"
-              "|---|---|\n"
-              "| Run `npm install` | ![demo](https://example.com/demo.gif) |")
+        md = (
+            "| Step | Example |\n"
+            "|---|---|\n"
+            "| Run `npm install` | ![demo](https://example.com/demo.gif) |"
+        )
         result = render_table(md)
-        assert '<code>npm install</code>' in result
-        assert '<img ' in result
-        assert '<a ' not in result  # image must not become a link
+        assert "<code>npm install</code>" in result
+        assert "<img " in result
+        assert "<a " not in result  # image must not become a link
 
     def test_bold_code_in_cell_and_image_in_cell(self):
         """**`code`** in one cell and image in another — no esc() mangling."""
-        md = ("| Command | Result |\n"
-              "|---|---|\n"
-              "| **`git status`** | ![result](https://example.com/r.png) |")
+        md = (
+            "| Command | Result |\n"
+            "|---|---|\n"
+            "| **`git status`** | ![result](https://example.com/r.png) |"
+        )
         result = render_table(md)
-        assert '&lt;code&gt;' not in result, (
+        assert "&lt;code&gt;" not in result, (
             "Bold+code in table cell must not produce escaped code tags"
         )
-        assert '<code>git status</code>' in result
-        assert '<img ' in result
+        assert "<code>git status</code>" in result
+        assert "<img " in result
 
     def test_link_code_image_all_in_table(self):
         """Table with code, link, and image cells all render correctly."""
-        url = 'https://github.com/issues/486'
-        img_url = 'https://example.com/img.png'
-        md = (f"| Code | Link | Image |\n"
-              f"|---|---|---|\n"
-              f"| `var x = 1` | [#486]({url}) | ![img]({img_url}) |")
+        url = "https://github.com/issues/486"
+        img_url = "https://example.com/img.png"
+        md = (
+            f"| Code | Link | Image |\n"
+            f"|---|---|---|\n"
+            f"| `var x = 1` | [#486]({url}) | ![img]({img_url}) |"
+        )
         result = render_table(md)
-        assert '<code>var x = 1</code>' in result
+        assert "<code>var x = 1</code>" in result
         assert f'href="{url}"' in result
-        assert '<img ' in result
+        assert "<img " in result
         # No double-linking
-        assert result.count('<a ') == 1
+        assert result.count("<a ") == 1
 
     def test_image_url_with_query_string_in_table(self):
         """Image URL with & in query string inside table cell — & not mangled."""
-        url = 'https://example.com/img?w=100&h=200'
+        url = "https://example.com/img?w=100&h=200"
         md = f"| Image |\n|---|\n| ![sized]({url}) |"
         result = render_table(md)
         assert f'src="{url}"' in result, (
@@ -555,18 +582,18 @@ class TestEdgeCasesCodeAndImageInTables:
 
     def test_image_adjacent_to_code_no_interference(self):
         """Image immediately followed by code span in same cell — no token cross-talk."""
-        t = '![x](https://x.com/x.png) `code`'
+        t = "![x](https://x.com/x.png) `code`"
         result = inline_md(t)
-        assert '<img ' in result
-        assert '<code>code</code>' in result
+        assert "<img " in result
+        assert "<code>code</code>" in result
 
     def test_image_inside_code_span_not_rendered(self):
         """An image syntax inside a backtick span must NOT render as an img tag."""
-        t = '`![not an image](https://example.com/img.png)`'
+        t = "`![not an image](https://example.com/img.png)`"
         result = inline_md(t)
         # The whole thing is inside backticks — should be literal code, not an img
-        assert '<img ' not in result, (
+        assert "<img " not in result, (
             f"Image syntax inside code span must not render as <img>. Got: {result}"
         )
         # Should render as a code element with the raw text inside
-        assert '<code>' in result
+        assert "<code>" in result

--- a/tests/test_issue487b.py
+++ b/tests/test_issue487b.py
@@ -10,6 +10,7 @@ a completely broken image source.
 Fix: extend _al_stash regex to also stash <img> tags:
   (<a\b[^>]*>[\s\S]*?<\/a>|<img\b[^>]*>)
 """
+
 import pathlib
 import re
 
@@ -19,9 +20,10 @@ UI_JS = (REPO_ROOT / "static" / "ui.js").read_text()
 
 # ── Source-level check ────────────────────────────────────────────────────────
 
+
 def test_al_stash_includes_img_tags():
     """_al_stash regex must stash both <a> and <img> tags to protect src= from autolink."""
-    assert '<img\\b[^>]*>' in UI_JS or '<img\\\\b[^>]*>' in UI_JS, (
+    assert "<img\\b[^>]*>" in UI_JS or "<img\\\\b[^>]*>" in UI_JS, (
         "_al_stash should include <img> tag pattern to prevent autolink mangling src= URLs"
     )
 
@@ -29,11 +31,16 @@ def test_al_stash_includes_img_tags():
 # ── Behaviour tests (Python mirror of fixed pipeline) ─────────────────────────
 
 import html as _html
-def esc(s): return _html.escape(str(s), quote=True)
+
+
+def esc(s):
+    return _html.escape(str(s), quote=True)
+
 
 SAFE_TAGS = re.compile(
-    r'^</?(strong|em|code|pre|h[1-6]|ul|ol|li|table|thead|tbody|tr|th|td'
-    r'|hr|blockquote|p|br|a|img|div|span)([\s>]|$)', re.I
+    r"^</?(strong|em|code|pre|h[1-6]|ul|ol|li|table|thead|tbody|tr|th|td"
+    r"|hr|blockquote|p|br|a|img|div|span)([\s>]|$)",
+    re.I,
 )
 
 
@@ -42,7 +49,7 @@ def render_with_image_and_autolink(raw):
     s = raw
     # Image pass
     s = re.sub(
-        r'!\[([^\]]*)\]\((https?://[^\)]+)\)',
+        r"!\[([^\]]*)\]\((https?://[^\)]+)\)",
         lambda m: (
             f'<img src="{m.group(2).replace(chr(34), "%22")}" '
             f'alt="{esc(m.group(1))}" class="msg-media-img" loading="lazy">'
@@ -51,73 +58,81 @@ def render_with_image_and_autolink(raw):
     )
     # SAFE_TAGS
     s = re.sub(
-        r'</?[a-zA-Z][^>]*>',
+        r"</?[a-zA-Z][^>]*>",
         lambda m: m.group() if SAFE_TAGS.match(m.group()) else esc(m.group()),
         s,
     )
     # _al_stash (fixed: stashes both <a> and <img>)
     al_stash = []
     s = re.sub(
-        r'(<a\b[^>]*>[\s\S]*?<\/a>|<img\b[^>]*>)',
-        lambda m: (al_stash.append(m.group(1)) or f'\x00B{len(al_stash)-1}\x00'),
+        r"(<a\b[^>]*>[\s\S]*?<\/a>|<img\b[^>]*>)",
+        lambda m: al_stash.append(m.group(1)) or f"\x00B{len(al_stash) - 1}\x00",
         s,
     )
+
     # Autolink
     def autolink(m):
         url = m.group(1)
-        trail = url[-1] if url[-1] in '.,;:!?)' else ''
+        trail = url[-1] if url[-1] in ".,;:!?)" else ""
         clean = url[:-1] if trail else url
-        return f'<a href="{clean}" target="_blank" rel="noopener">{esc(clean)}</a>{trail}'
+        return (
+            f'<a href="{clean}" target="_blank" rel="noopener">{esc(clean)}</a>{trail}'
+        )
+
     s = re.sub(r'(https?://[^\s<>"\')\]]+)', autolink, s)
     # Restore
-    s = re.sub(r'\x00B(\d+)\x00', lambda m: al_stash[int(m.group(1))], s)
+    s = re.sub(r"\x00B(\d+)\x00", lambda m: al_stash[int(m.group(1))], s)
     return s
 
 
 def test_image_src_not_mangled_by_autolink():
     """The URL inside src= of a rendered <img> must not be wrapped in <a> by autolink."""
-    url = 'https://upload.wikimedia.org/wikipedia/commons/thumb/4/47/PNG_transparency_demonstration_1.png/280px-PNG_transparency_demonstration_1.png'
-    result = render_with_image_and_autolink(f'![alt]({url})')
+    url = "https://upload.wikimedia.org/wikipedia/commons/thumb/4/47/PNG_transparency_demonstration_1.png/280px-PNG_transparency_demonstration_1.png"
+    result = render_with_image_and_autolink(f"![alt]({url})")
     assert f'src="{url}"' in result, f"src= URL should be intact, got: {result[:200]}"
     # The URL inside src= must NOT be wrapped in <a>
     src_part = result.split('src="')[1].split('"')[0]
-    assert '<a ' not in src_part, f"src= must not contain <a> tag, got: {src_part}"
+    assert "<a " not in src_part, f"src= must not contain <a> tag, got: {src_part}"
     assert src_part == url, f"src= URL mangled: expected {url}, got {src_part}"
 
 
 def test_image_tag_renders_as_img():
     """![alt](url) must produce an <img> tag, not a plain link."""
-    result = render_with_image_and_autolink('![Test image](https://example.com/img.png)')
-    assert '<img ' in result, f"Expected <img> tag, got: {result}"
+    result = render_with_image_and_autolink(
+        "![Test image](https://example.com/img.png)"
+    )
+    assert "<img " in result, f"Expected <img> tag, got: {result}"
     assert 'src="https://example.com/img.png"' in result
-    assert '<a ' not in result  # no spurious link wrapper
+    assert "<a " not in result  # no spurious link wrapper
 
 
 def test_image_and_link_in_same_paragraph():
     """Image and link in same paragraph must each render correctly without interference."""
     result = render_with_image_and_autolink(
-        'See ![logo](https://example.com/logo.png) and visit https://example.com'
+        "See ![logo](https://example.com/logo.png) and visit https://example.com"
     )
-    assert '<img ' in result, "Image should render"
-    assert '<a ' in result, "Bare URL should autolink"
+    assert "<img " in result, "Image should render"
+    assert "<a " in result, "Bare URL should autolink"
     # img src must not contain <a>
     src_part = result.split('src="')[1].split('"')[0]
-    assert '<a' not in src_part, f"src= mangled: {src_part}"
+    assert "<a" not in src_part, f"src= mangled: {src_part}"
 
 
 def test_image_count_is_one():
     """One ![alt](url) should produce exactly one <img> tag."""
-    result = render_with_image_and_autolink('![test](https://example.com/x.png)')
-    assert result.count('<img ') == 1, f"Expected 1 <img>, got {result.count('<img ')}: {result}"
+    result = render_with_image_and_autolink("![test](https://example.com/x.png)")
+    assert result.count("<img ") == 1, (
+        f"Expected 1 <img>, got {result.count('<img ')}: {result}"
+    )
 
 
 def test_multiple_images_not_mangled():
     """Multiple images in one message each get clean src= values."""
     urls = [
-        'https://example.com/a.png',
-        'https://example.com/b.png',
+        "https://example.com/a.png",
+        "https://example.com/b.png",
     ]
-    raw = '\n\n'.join(f'![img{i}]({url})' for i, url in enumerate(urls))
+    raw = "\n\n".join(f"![img{i}]({url})" for i, url in enumerate(urls))
     result = render_with_image_and_autolink(raw)
     for url in urls:
         assert f'src="{url}"' in result, f"src= for {url} mangled in: {result[:300]}"
@@ -125,7 +140,7 @@ def test_multiple_images_not_mangled():
 
 def test_image_with_query_string_src_intact():
     """Image URL with & in query string must have & (not &amp;) in src."""
-    url = 'https://example.com/img?w=100&h=200&fmt=png'
-    result = render_with_image_and_autolink(f'![img]({url})')
+    url = "https://example.com/img?w=100&h=200&fmt=png"
+    result = render_with_image_and_autolink(f"![img]({url})")
     assert f'src="{url}"' in result, f"Query string URL mangled: {result[:200]}"
-    assert '&amp;' not in result.split('src="')[1].split('"')[0]
+    assert "&amp;" not in result.split('src="')[1].split('"')[0]

--- a/tests/test_issue492_workspace_reorder.py
+++ b/tests/test_issue492_workspace_reorder.py
@@ -1,6 +1,6 @@
 """Tests for issue #492 — workspace drag-to-reorder."""
-import json, pytest
-from unittest.mock import patch, MagicMock, call
+
+from unittest.mock import patch, MagicMock
 from api.routes import _handle_workspace_reorder
 
 
@@ -24,9 +24,9 @@ class TestWorkspaceReorderEndpoint:
         ]
         mock_save.side_effect = lambda wss: wss
         handler = _make_handler()
-        _handle_workspace_reorder(handler, {
-            "paths": ["/home/user/c", "/home/user/a", "/home/user/b"]
-        })
+        _handle_workspace_reorder(
+            handler, {"paths": ["/home/user/c", "/home/user/a", "/home/user/b"]}
+        )
         mock_save.assert_called_once()
         saved = mock_save.call_args[0][0]
         assert saved[0]["path"] == "/home/user/c"
@@ -87,9 +87,7 @@ class TestWorkspaceReorderEndpoint:
         ]
         mock_save.side_effect = lambda wss: wss
         handler = _make_handler()
-        _handle_workspace_reorder(handler, {
-            "paths": ["/b", "/a", "/a", "/b"]
-        })
+        _handle_workspace_reorder(handler, {"paths": ["/b", "/a", "/a", "/b"]})
         saved = mock_save.call_args[0][0]
         assert len(saved) == 2
         assert saved[0]["path"] == "/b"
@@ -129,8 +127,14 @@ class TestWorkspaceReorderFrontend:
     def test_renderWorkspacesPanel_has_drag_attrs(self):
         with open("static/panels.js", "r", encoding="utf-8") as f:
             content = f.read()
-        for attr in ("draggable=true", "dragstart", "dragover", "dragend",
-                      "ws-drag-handle", "/api/workspaces/reorder"):
+        for attr in (
+            "draggable=true",
+            "dragstart",
+            "dragover",
+            "dragend",
+            "ws-drag-handle",
+            "/api/workspaces/reorder",
+        ):
             assert attr in content, f"Missing: {attr}"
 
     def test_css_drag_classes_exist(self):

--- a/tests/test_issue500_session_list_virtualization.py
+++ b/tests/test_issue500_session_list_virtualization.py
@@ -1,4 +1,5 @@
 """Regression coverage for issue #500 session-sidebar virtualization."""
+
 import json
 import shutil
 import subprocess
@@ -57,7 +58,9 @@ function extractFunc(name) {{
 def test_session_virtual_window_reduces_large_lists_and_tracks_scroll():
     """A 1000-row sidebar should render a bounded slice near scroll position."""
     js = SESSIONS_JS_PATH.read_text(encoding="utf-8")
-    source = _extract_func_script(js) + """
+    source = (
+        _extract_func_script(js)
+        + """
 eval(extractFunc('_sessionVirtualWindow'));
 const metrics = _sessionVirtualWindow({
   total: 1000,
@@ -69,6 +72,7 @@ const metrics = _sessionVirtualWindow({
 });
 console.log(JSON.stringify(metrics));
 """
+    )
     metrics = json.loads(_run_node(source))
     assert metrics["virtualized"] is True
     assert 390 <= metrics["start"] <= 420
@@ -81,7 +85,9 @@ console.log(JSON.stringify(metrics));
 def test_session_virtual_window_keeps_active_session_rendered():
     """The active sidebar row must remain in the DOM when we anchor a new active session."""
     js = SESSIONS_JS_PATH.read_text(encoding="utf-8")
-    source = _extract_func_script(js) + """
+    source = (
+        _extract_func_script(js)
+        + """
 eval(extractFunc('_sessionVirtualWindow'));
 const metrics = _sessionVirtualWindow({
   total: 1000,
@@ -94,6 +100,7 @@ const metrics = _sessionVirtualWindow({
 });
 console.log(JSON.stringify(metrics));
 """
+    )
     metrics = json.loads(_run_node(source))
     assert metrics["virtualized"] is True
     assert metrics["start"] <= 995 < metrics["end"]
@@ -104,14 +111,19 @@ def test_session_list_render_path_uses_virtual_spacers_and_scroll_rerender():
     """renderSessionListFromCache should window rows without stale cached slices."""
     js = SESSIONS_JS_PATH.read_text(encoding="utf-8")
     render_start = js.index("function renderSessionListFromCache()")
-    render_end = js.index("async function _handleActiveSessionStorageEvent", render_start)
+    render_end = js.index(
+        "async function _handleActiveSessionStorageEvent", render_start
+    )
     render_body = js[render_start:render_end]
 
     assert "_sessionVirtualWindow" in render_body
     assert "_sessionVirtualSpacer" in render_body
     assert "spacer.dataset.virtualSpacer=where||'gap'" in js
     assert "list.addEventListener('scroll', _scheduleSessionVirtualizedRender" in js
-    assert "requestAnimationFrame(()=>{_sessionVirtualScrollRaf=0;renderSessionListFromCache();})" in js
+    assert (
+        "requestAnimationFrame(()=>{_sessionVirtualScrollRaf=0;renderSessionListFromCache();})"
+        in js
+    )
     assert "const listScrollTopBeforeRender=list.scrollTop||0" in render_body
     assert "scrollTop:listScrollTopBeforeRender" in render_body
     assert "list.scrollTop=listScrollTopBeforeRender" in render_body

--- a/tests/test_issue513_wsl_autostart.py
+++ b/tests/test_issue513_wsl_autostart.py
@@ -41,12 +41,14 @@ def test_wsl_autostart_launcher_has_safe_duplicate_prevention_and_exports_runtim
     assert "HERMES_WEBUI_LOCK_FILE" in script
     assert "HERMES_WEBUI_PID_FILE" in script
     assert "curl -fsS --max-time 3" in script
-    assert "bash \"${HERMES_WEBUI_REPO}/start.sh\" --foreground" in script
+    assert 'bash "${HERMES_WEBUI_REPO}/start.sh" --foreground' in script
     assert "nohup" in script
 
     # The launcher documents HERMES_WEBUI_HOST/PORT as runtime knobs; they must
     # be exported so bootstrap.py/server.py receive the selected WSL values.
-    assert re.search(r"^export HERMES_WEBUI_HOST HERMES_WEBUI_PORT$", script, re.MULTILINE)
+    assert re.search(
+        r"^export HERMES_WEBUI_HOST HERMES_WEBUI_PORT$", script, re.MULTILINE
+    )
 
     assert "/root" not in script
     assert "/home/michael" not in script
@@ -76,7 +78,9 @@ def test_windows_task_scheduler_helper_is_idempotent_and_validates_wsl_script_pa
 def test_powershell_helper_passes_parser_when_pwsh_is_available():
     pwsh = None
     for candidate in ("pwsh", "powershell"):
-        result = subprocess.run(["bash", "-lc", f"command -v {candidate}"], capture_output=True, text=True)
+        result = subprocess.run(
+            ["bash", "-lc", f"command -v {candidate}"], capture_output=True, text=True
+        )
         if result.returncode == 0:
             pwsh = result.stdout.strip()
             break
@@ -86,7 +90,12 @@ def test_powershell_helper_passes_parser_when_pwsh_is_available():
         return
 
     subprocess.run(
-        [pwsh, "-NoProfile", "-Command", f"$null = [scriptblock]::Create((Get-Content -Raw '{POWERSHELL_SCRIPT.as_posix()}'))"],
+        [
+            pwsh,
+            "-NoProfile",
+            "-Command",
+            f"$null = [scriptblock]::Create((Get-Content -Raw '{POWERSHELL_SCRIPT.as_posix()}'))",
+        ],
         check=True,
         cwd=REPO_ROOT,
     )

--- a/tests/test_issue538_mcp_management.py
+++ b/tests/test_issue538_mcp_management.py
@@ -1,6 +1,7 @@
 """Tests for issue #538 — MCP server management API."""
-import json, pytest
-from unittest.mock import patch, MagicMock, call
+
+import json
+from unittest.mock import patch, MagicMock
 from api.routes import (
     _handle_mcp_servers_list,
     _handle_mcp_server_update,
@@ -14,43 +15,39 @@ from api.routes import (
 
 def _make_handler():
     h = MagicMock()
-    h.path = '/api/mcp/servers'
-    h.command = 'GET'
+    h.path = "/api/mcp/servers"
+    h.command = "GET"
     return h
 
 
 def _json_payload(handler):
     body = handler.wfile.write.call_args[0][0]
-    return json.loads(body.decode('utf-8'))
+    return json.loads(body.decode("utf-8"))
 
 
 SAMPLE_MCP = {
-    "searxng": {
-        "command": "mcp-searxng",
-        "args": ["--port", "8888"],
-        "timeout": 120
-    },
+    "searxng": {"command": "mcp-searxng", "args": ["--port", "8888"], "timeout": 120},
     "web-reader": {
         "url": "http://localhost:3001/mcp",
         "timeout": 60,
-        "headers": {"Authorization": "Bearer secret123"}
-    }
+        "headers": {"Authorization": "Bearer secret123"},
+    },
 }
 
 
 class TestMcpList:
     """GET /api/mcp/servers — list with masked secrets."""
 
-    @patch('api.routes.get_config')
+    @patch("api.routes.get_config")
     def test_returns_servers_list(self, mock_cfg):
-        mock_cfg.return_value = {'mcp_servers': SAMPLE_MCP}
+        mock_cfg.return_value = {"mcp_servers": SAMPLE_MCP}
         h = _make_handler()
         _handle_mcp_servers_list(h)
         assert h.send_response.called
         status = h.send_response.call_args[0][0]
         assert status == 200
 
-    @patch('api.routes.get_config')
+    @patch("api.routes.get_config")
     def test_empty_config(self, mock_cfg):
         mock_cfg.return_value = {}
         h = _make_handler()
@@ -59,64 +56,66 @@ class TestMcpList:
         status = h.send_response.call_args[0][0]
         assert status == 200
         payload = _json_payload(h)
-        assert payload['servers'] == []
-        assert payload['toggle_supported'] is False
-        assert payload['reload_required'] is True
+        assert payload["servers"] == []
+        assert payload["toggle_supported"] is False
+        assert payload["reload_required"] is True
 
-    @patch('api.routes._mcp_runtime_status_by_name')
-    @patch('api.routes.get_config')
-    def test_list_payload_includes_status_tool_counts_and_safe_invalid_config(self, mock_cfg, mock_runtime):
+    @patch("api.routes._mcp_runtime_status_by_name")
+    @patch("api.routes.get_config")
+    def test_list_payload_includes_status_tool_counts_and_safe_invalid_config(
+        self, mock_cfg, mock_runtime
+    ):
         mock_cfg.return_value = {
-            'mcp_servers': {
-                'searxng': {'command': 'mcp-searxng', 'args': ['--port', '8888']},
-                'web-reader': {
-                    'url': 'http://localhost:3001/mcp',
-                    'headers': {'Authorization': 'Bearer secret123'},
+            "mcp_servers": {
+                "searxng": {"command": "mcp-searxng", "args": ["--port", "8888"]},
+                "web-reader": {
+                    "url": "http://localhost:3001/mcp",
+                    "headers": {"Authorization": "Bearer secret123"},
                 },
-                'disabled': {'command': 'disabled-cmd', 'enabled': 0},
-                'broken': 'not-a-dict',
+                "disabled": {"command": "disabled-cmd", "enabled": 0},
+                "broken": "not-a-dict",
             }
         }
         mock_runtime.return_value = {
-            'searxng': {'connected': True, 'tools': 3},
-            'web-reader': {'connected': False, 'tools': 0},
+            "searxng": {"connected": True, "tools": 3},
+            "web-reader": {"connected": False, "tools": 0},
         }
         h = _make_handler()
         _handle_mcp_servers_list(h)
         payload = _json_payload(h)
-        by_name = {s['name']: s for s in payload['servers']}
-        assert by_name['searxng']['status'] == 'active'
-        assert by_name['searxng']['active'] is True
-        assert by_name['searxng']['tool_count'] == 3
-        assert by_name['web-reader']['status'] == 'configured'
-        assert '••••' in by_name['web-reader']['headers']['Authorization']
-        assert by_name['disabled']['enabled'] is False
-        assert by_name['disabled']['active'] is False
-        assert by_name['disabled']['status'] == 'disabled'
-        assert by_name['broken']['transport'] == 'invalid'
-        assert by_name['broken']['status'] == 'invalid_config'
+        by_name = {s["name"]: s for s in payload["servers"]}
+        assert by_name["searxng"]["status"] == "active"
+        assert by_name["searxng"]["active"] is True
+        assert by_name["searxng"]["tool_count"] == 3
+        assert by_name["web-reader"]["status"] == "configured"
+        assert "••••" in by_name["web-reader"]["headers"]["Authorization"]
+        assert by_name["disabled"]["enabled"] is False
+        assert by_name["disabled"]["active"] is False
+        assert by_name["disabled"]["status"] == "disabled"
+        assert by_name["broken"]["transport"] == "invalid"
+        assert by_name["broken"]["status"] == "invalid_config"
 
     def test_secrets_are_masked(self):
         """_mask_secrets hides API keys in headers and env."""
-        masked = _mask_secrets(SAMPLE_MCP['web-reader']['headers'])
-        assert masked['Authorization'] != 'Bearer secret123'
-        assert '••••' in masked['Authorization']
+        masked = _mask_secrets(SAMPLE_MCP["web-reader"]["headers"])
+        assert masked["Authorization"] != "Bearer secret123"
+        assert "••••" in masked["Authorization"]
 
     def test_server_summary_stdio(self):
-        summary = _server_summary('searxng', SAMPLE_MCP['searxng'])
-        assert summary['transport'] == 'stdio'
-        assert summary['command'] == 'mcp-searxng'
-        assert summary['args'] == ['--port', '8888']
+        summary = _server_summary("searxng", SAMPLE_MCP["searxng"])
+        assert summary["transport"] == "stdio"
+        assert summary["command"] == "mcp-searxng"
+        assert summary["args"] == ["--port", "8888"]
 
     def test_server_summary_http(self):
-        summary = _server_summary('web-reader', SAMPLE_MCP['web-reader'])
-        assert summary['transport'] == 'http'
-        assert summary['url'] == 'http://localhost:3001/mcp'
-        assert '••••' in summary['headers']['Authorization']
+        summary = _server_summary("web-reader", SAMPLE_MCP["web-reader"])
+        assert summary["transport"] == "http"
+        assert summary["url"] == "http://localhost:3001/mcp"
+        assert "••••" in summary["headers"]["Authorization"]
 
     def test_server_summary_default_timeout(self):
-        summary = _server_summary('minimal', {'command': 'x'})
-        assert summary['timeout'] == 120
+        summary = _server_summary("minimal", {"command": "x"})
+        assert summary["timeout"] == 120
 
     def test_numeric_zero_enabled_flag_is_disabled(self):
         """YAML numeric false-y values should not show a disabled server as enabled."""
@@ -126,73 +125,73 @@ class TestMcpList:
 class TestMcpSave:
     """PUT /api/mcp/servers/<name> — add or update."""
 
-    @patch('api.routes.reload_config')
-    @patch('api.routes._save_yaml_config_file')
-    @patch('api.routes._get_config_path', return_value='/tmp/test.yaml')
-    @patch('api.routes.get_config')
+    @patch("api.routes.reload_config")
+    @patch("api.routes._save_yaml_config_file")
+    @patch("api.routes._get_config_path", return_value="/tmp/test.yaml")
+    @patch("api.routes.get_config")
     def test_add_new_stdio_server(self, mock_cfg, mock_path, mock_save, mock_reload):
         mock_cfg.return_value = {}
         h = _make_handler()
-        h.command = 'PUT'
+        h.command = "PUT"
         body = {"command": "test-cmd", "timeout": 30}
-        _handle_mcp_server_update(h, 'test-server', body)
+        _handle_mcp_server_update(h, "test-server", body)
         assert mock_save.called
         saved = mock_save.call_args[0][1]
-        assert 'test-server' in saved['mcp_servers']
-        assert saved['mcp_servers']['test-server']['command'] == 'test-cmd'
+        assert "test-server" in saved["mcp_servers"]
+        assert saved["mcp_servers"]["test-server"]["command"] == "test-cmd"
 
-    @patch('api.routes.reload_config')
-    @patch('api.routes._save_yaml_config_file')
-    @patch('api.routes._get_config_path', return_value='/tmp/test.yaml')
-    @patch('api.routes.get_config')
+    @patch("api.routes.reload_config")
+    @patch("api.routes._save_yaml_config_file")
+    @patch("api.routes._get_config_path", return_value="/tmp/test.yaml")
+    @patch("api.routes.get_config")
     def test_add_new_http_server(self, mock_cfg, mock_path, mock_save, mock_reload):
         mock_cfg.return_value = {}
         h = _make_handler()
-        h.command = 'PUT'
+        h.command = "PUT"
         body = {"url": "http://localhost:4000", "timeout": 60}
-        _handle_mcp_server_update(h, 'http-srv', body)
+        _handle_mcp_server_update(h, "http-srv", body)
         saved = mock_save.call_args[0][1]
-        assert saved['mcp_servers']['http-srv']['url'] == 'http://localhost:4000'
+        assert saved["mcp_servers"]["http-srv"]["url"] == "http://localhost:4000"
 
-    @patch('api.routes.reload_config')
-    @patch('api.routes._save_yaml_config_file')
-    @patch('api.routes._get_config_path', return_value='/tmp/test.yaml')
-    @patch('api.routes.get_config')
+    @patch("api.routes.reload_config")
+    @patch("api.routes._save_yaml_config_file")
+    @patch("api.routes._get_config_path", return_value="/tmp/test.yaml")
+    @patch("api.routes.get_config")
     def test_update_existing(self, mock_cfg, mock_path, mock_save, mock_reload):
-        mock_cfg.return_value = {'mcp_servers': {'existing': {'command': 'old'}}}
+        mock_cfg.return_value = {"mcp_servers": {"existing": {"command": "old"}}}
         h = _make_handler()
-        h.command = 'PUT'
+        h.command = "PUT"
         body = {"command": "new-cmd"}
-        _handle_mcp_server_update(h, 'existing', body)
+        _handle_mcp_server_update(h, "existing", body)
         saved = mock_save.call_args[0][1]
-        assert saved['mcp_servers']['existing']['command'] == 'new-cmd'
+        assert saved["mcp_servers"]["existing"]["command"] == "new-cmd"
 
-    @patch('api.routes.reload_config')
-    @patch('api.routes._save_yaml_config_file')
-    @patch('api.routes._get_config_path', return_value='/tmp/test.yaml')
-    @patch('api.routes.get_config')
+    @patch("api.routes.reload_config")
+    @patch("api.routes._save_yaml_config_file")
+    @patch("api.routes._get_config_path", return_value="/tmp/test.yaml")
+    @patch("api.routes.get_config")
     def test_preserves_other_servers(self, mock_cfg, mock_path, mock_save, mock_reload):
-        mock_cfg.return_value = {'mcp_servers': {'keep': {'command': 'stay'}}}
+        mock_cfg.return_value = {"mcp_servers": {"keep": {"command": "stay"}}}
         h = _make_handler()
-        h.command = 'PUT'
+        h.command = "PUT"
         body = {"command": "new"}
-        _handle_mcp_server_update(h, 'add-me', body)
+        _handle_mcp_server_update(h, "add-me", body)
         saved = mock_save.call_args[0][1]
-        assert 'keep' in saved['mcp_servers']
-        assert 'add-me' in saved['mcp_servers']
+        assert "keep" in saved["mcp_servers"]
+        assert "add-me" in saved["mcp_servers"]
 
     def test_empty_name_rejected(self):
         h = _make_handler()
-        h.command = 'PUT'
-        _handle_mcp_server_update(h, '', {"command": "test"})
+        h.command = "PUT"
+        _handle_mcp_server_update(h, "", {"command": "test"})
         assert h.send_response.called
         status = h.send_response.call_args[0][0]
         assert status == 400
 
     def test_missing_command_and_url_rejected(self):
         h = _make_handler()
-        h.command = 'PUT'
-        _handle_mcp_server_update(h, 'test', {"timeout": 30})
+        h.command = "PUT"
+        _handle_mcp_server_update(h, "test", {"timeout": 30})
         assert h.send_response.called
         status = h.send_response.call_args[0][0]
         assert status == 400
@@ -201,45 +200,45 @@ class TestMcpSave:
 class TestMcpDelete:
     """DELETE /api/mcp/servers/<name>."""
 
-    @patch('api.routes.reload_config')
-    @patch('api.routes._save_yaml_config_file')
-    @patch('api.routes._get_config_path', return_value='/tmp/test.yaml')
-    @patch('api.routes.get_config')
+    @patch("api.routes.reload_config")
+    @patch("api.routes._save_yaml_config_file")
+    @patch("api.routes._get_config_path", return_value="/tmp/test.yaml")
+    @patch("api.routes.get_config")
     def test_delete_existing(self, mock_cfg, mock_path, mock_save, mock_reload):
-        mock_cfg.return_value = {'mcp_servers': {'target': {'command': 'rm'}}}
+        mock_cfg.return_value = {"mcp_servers": {"target": {"command": "rm"}}}
         h = _make_handler()
-        h.command = 'DELETE'
-        _handle_mcp_server_delete(h, 'target')
+        h.command = "DELETE"
+        _handle_mcp_server_delete(h, "target")
         assert mock_save.called
         saved = mock_save.call_args[0][1]
-        assert 'target' not in saved.get('mcp_servers', {})
+        assert "target" not in saved.get("mcp_servers", {})
 
-    @patch('api.routes.get_config')
+    @patch("api.routes.get_config")
     def test_delete_nonexistent(self, mock_cfg):
-        mock_cfg.return_value = {'mcp_servers': {}}
+        mock_cfg.return_value = {"mcp_servers": {}}
         h = _make_handler()
-        h.command = 'DELETE'
-        _handle_mcp_server_delete(h, 'ghost')
+        h.command = "DELETE"
+        _handle_mcp_server_delete(h, "ghost")
         status = h.send_response.call_args[0][0]
         assert status == 404
 
-    @patch('api.routes.reload_config')
-    @patch('api.routes._save_yaml_config_file')
-    @patch('api.routes._get_config_path', return_value='/tmp/test.yaml')
-    @patch('api.routes.get_config')
+    @patch("api.routes.reload_config")
+    @patch("api.routes._save_yaml_config_file")
+    @patch("api.routes._get_config_path", return_value="/tmp/test.yaml")
+    @patch("api.routes.get_config")
     def test_preserves_others(self, mock_cfg, mock_path, mock_save, mock_reload):
-        mock_cfg.return_value = {'mcp_servers': {'a': {'c': '1'}, 'b': {'c': '2'}}}
+        mock_cfg.return_value = {"mcp_servers": {"a": {"c": "1"}, "b": {"c": "2"}}}
         h = _make_handler()
-        h.command = 'DELETE'
-        _handle_mcp_server_delete(h, 'a')
+        h.command = "DELETE"
+        _handle_mcp_server_delete(h, "a")
         saved = mock_save.call_args[0][1]
-        assert 'a' not in saved['mcp_servers']
-        assert 'b' in saved['mcp_servers']
+        assert "a" not in saved["mcp_servers"]
+        assert "b" in saved["mcp_servers"]
 
     def test_empty_name_rejected(self):
         h = _make_handler()
-        h.command = 'DELETE'
-        _handle_mcp_server_delete(h, '')
+        h.command = "DELETE"
+        _handle_mcp_server_delete(h, "")
         status = h.send_response.call_args[0][0]
         assert status == 400
 
@@ -254,7 +253,9 @@ class TestMaskSecrets:
         assert result["env"]["PUBLIC_VAR"] == "visible"
 
     def test_masks_headers(self):
-        obj = {"headers": {"Authorization": "Bearer token", "Accept": "application/json"}}
+        obj = {
+            "headers": {"Authorization": "Bearer token", "Accept": "application/json"}
+        }
         result = _mask_secrets(obj)
         assert "••••" in result["headers"]["Authorization"]
         assert result["headers"]["Accept"] == "application/json"

--- a/tests/test_issue569_579.py
+++ b/tests/test_issue569_579.py
@@ -7,26 +7,27 @@ Tests for fixes:
          The legacy raw sidebar count was removed by #584, and later reintroduced
          in a gated detailed-density mode by #673.
 """
+
 import pathlib
-import re
 
 REPO_ROOT = pathlib.Path(__file__).parent.parent
-INIT_SH   = (REPO_ROOT / "docker_init.bash").read_text(encoding="utf-8")
-UI_JS     = (REPO_ROOT / "static" / "ui.js").read_text(encoding="utf-8")
+INIT_SH = (REPO_ROOT / "docker_init.bash").read_text(encoding="utf-8")
+UI_JS = (REPO_ROOT / "static" / "ui.js").read_text(encoding="utf-8")
 
 
 # ── #569: docker UID/GID auto-detect ─────────────────────────────────────────
 
+
 def test_569_uid_autodetect_present():
     """docker_init.bash must have workspace-based UID auto-detection (#569)."""
-    assert "stat -c '%u'" in INIT_SH or 'stat -c \'%u\'' in INIT_SH, (
+    assert "stat -c '%u'" in INIT_SH or "stat -c '%u'" in INIT_SH, (
         "docker_init.bash must use stat to read workspace UID (#569)"
     )
 
 
 def test_569_gid_autodetect_present():
     """docker_init.bash must have workspace-based GID auto-detection (#569)."""
-    assert "stat -c '%g'" in INIT_SH or 'stat -c \'%g\'' in INIT_SH, (
+    assert "stat -c '%g'" in INIT_SH or "stat -c '%g'" in INIT_SH, (
         "docker_init.bash must use stat to read workspace GID (#569)"
     )
 
@@ -49,7 +50,7 @@ def test_569_skips_root_uid():
     """Auto-detect must not use UID 0 (root-owned mount = untrustworthy)."""
     detect_block_start = INIT_SH.find("Auto-detect from mounted volumes")
     assert detect_block_start != -1, "auto-detect comment block not found"
-    block = INIT_SH[detect_block_start:detect_block_start + 1200]
+    block = INIT_SH[detect_block_start : detect_block_start + 1200]
     assert '"0"' in block or "'0'" in block, (
         "Auto-detect block must skip UID 0 to avoid incorrectly using root ownership"
     )
@@ -66,6 +67,7 @@ def test_569_fallback_preserved():
 
 
 # ── #668: UID/GID auto-detect from hermes-home shared volume (two-container) ──
+
 
 def test_668_uid_autodetect_checks_hermes_home():
     """docker_init.bash must probe hermes-home dirs for UID in two-container setups.
@@ -88,7 +90,7 @@ def test_668_gid_autodetect_checks_hermes_home():
     assert gid_detect_start != -1, (
         "GID auto-detect comment must be updated to mention shared volumes (#668)"
     )
-    gid_block = INIT_SH[gid_detect_start:gid_detect_start + 600]
+    gid_block = INIT_SH[gid_detect_start : gid_detect_start + 600]
     assert "/home/hermeswebui/.hermes" in gid_block or "HERMES_HOME" in gid_block, (
         "GID auto-detect block must probe hermes-home dirs (#668)"
     )
@@ -98,7 +100,7 @@ def test_668_uid_probe_loop_uses_break():
     """UID probe loop must stop on first match (no double-detection)."""
     uid_detect_start = INIT_SH.find("Auto-detect from mounted volumes")
     assert uid_detect_start != -1, "UID auto-detect comment not found"
-    uid_block = INIT_SH[uid_detect_start:uid_detect_start + 1200]
+    uid_block = INIT_SH[uid_detect_start : uid_detect_start + 1200]
     assert "break" in uid_block, (
         "UID probe loop must break after first successful detection "
         "to avoid being overridden by a later probe dir (#668)"
@@ -119,6 +121,7 @@ def test_668_hermes_home_probe_before_workspace():
 
 # ── #579: topbar message count already filters tool messages ──────────────────
 
+
 def test_579_topbar_filters_tool_messages():
     """ui.js topbar count must filter out role='tool' messages (#579).
 
@@ -132,15 +135,15 @@ def test_579_topbar_filters_tool_messages():
     assert meta_pos != -1, "topbarMeta assignment not found in ui.js"
 
     # Find the filter that precedes it — should exclude role==='tool'
-    context = UI_JS[max(0, meta_pos - 400):meta_pos + 100]
+    context = UI_JS[max(0, meta_pos - 400) : meta_pos + 100]
     assert "role" in context and "tool" in context, (
         "topbarMeta count must filter by role — "
         "messages with role='tool' must be excluded from the displayed count"
     )
     # The filter must exclude tool messages (not include them)
-    assert "!=='tool'" in context or "!= 'tool'" in context or "role!=='tool'" in context, (
-        "topbar count filter must use !== 'tool' to exclude tool messages"
-    )
+    assert (
+        "!=='tool'" in context or "!= 'tool'" in context or "role!=='tool'" in context
+    ), "topbar count filter must use !== 'tool' to exclude tool messages"
 
 
 def test_579_sidebar_count_is_gated_behind_detailed_density():
@@ -152,9 +155,10 @@ def test_579_sidebar_count_is_gated_behind_detailed_density():
     sidebar density.
     """
     sessions_js = (REPO_ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
-    assert "const density=(window._sidebarDensity==='detailed'?'detailed':'compact');" in sessions_js, (
-        "sessions.js must normalize sidebar density before rendering metadata"
-    )
+    assert (
+        "const density=(window._sidebarDensity==='detailed'?'detailed':'compact');"
+        in sessions_js
+    ), "sessions.js must normalize sidebar density before rendering metadata"
     assert "if(density==='detailed'){" in sessions_js, (
         "sessions.js must gate sidebar metadata behind detailed density mode"
     )

--- a/tests/test_issue570_permission.py
+++ b/tests/test_issue570_permission.py
@@ -7,12 +7,14 @@ Docker setups), Path.exists() raises PermissionError instead of returning False.
 load_settings() must treat that as "file not accessible = use defaults" rather
 than propagating the exception up to crash the request handler.
 """
+
 import stat
-import pytest
 import api.config as config
 
 
-def test_load_settings_returns_defaults_when_settings_file_unreadable(monkeypatch, tmp_path):
+def test_load_settings_returns_defaults_when_settings_file_unreadable(
+    monkeypatch, tmp_path
+):
     """PermissionError from SETTINGS_FILE.exists() must not propagate — return defaults instead.
 
     Regression for issue #570 comment: Docker UID mismatch caused every request
@@ -38,7 +40,9 @@ def test_load_settings_returns_defaults_when_settings_file_unreadable(monkeypatc
         state_dir.chmod(stat.S_IRWXU)  # restore for cleanup
 
 
-def test_load_settings_returns_defaults_when_exists_raises_permission_error(monkeypatch, tmp_path):
+def test_load_settings_returns_defaults_when_exists_raises_permission_error(
+    monkeypatch, tmp_path
+):
     """Direct simulation: monkeypatch SETTINGS_FILE.exists to raise PermissionError."""
     from unittest import mock
 
@@ -48,8 +52,9 @@ def test_load_settings_returns_defaults_when_exists_raises_permission_error(monk
 
     monkeypatch.setattr(config, "SETTINGS_FILE", settings_file)
 
-    with mock.patch.object(type(settings_file), "exists",
-                           side_effect=PermissionError("Permission denied")):
+    with mock.patch.object(
+        type(settings_file), "exists", side_effect=PermissionError("Permission denied")
+    ):
         result = config.load_settings()
 
     assert isinstance(result, dict)

--- a/tests/test_issue572.py
+++ b/tests/test_issue572.py
@@ -15,15 +15,13 @@ Covers:
      unsupported provider when config.yaml exists
   4. The hermes_cli import failure path is safe (falls back gracefully)
 """
+
 from __future__ import annotations
 
-import os
 import pathlib
 import sys
 import types
 from unittest import mock
-
-import pytest
 
 
 def _inject_hermes_cli_auth(get_auth_status_return):
@@ -38,18 +36,25 @@ def _inject_hermes_cli_auth(get_auth_status_return):
     mock_auth.get_auth_status = mock.MagicMock(return_value=get_auth_status_return)
     mock_hermes_cli = types.ModuleType("hermes_cli")
 
-    return mock.patch.dict(sys.modules, {
-        "hermes_cli": mock_hermes_cli,
-        "hermes_cli.auth": mock_auth,
-    })
+    return mock.patch.dict(
+        sys.modules,
+        {
+            "hermes_cli": mock_hermes_cli,
+            "hermes_cli.auth": mock_auth,
+        },
+    )
 
 
 # ---------------------------------------------------------------------------
 # Helper
 # ---------------------------------------------------------------------------
 
-def _call_provider_api_key_present(provider: str, cfg: dict = None, env_values: dict = None):
+
+def _call_provider_api_key_present(
+    provider: str, cfg: dict = None, env_values: dict = None
+):
     from api.onboarding import _provider_api_key_present
+
     return _provider_api_key_present(provider, cfg or {}, env_values or {})
 
 
@@ -57,22 +62,24 @@ def _call_provider_api_key_present(provider: str, cfg: dict = None, env_values: 
 # 1. _provider_api_key_present via hermes_cli fallback
 # ---------------------------------------------------------------------------
 
-class TestProviderApiKeyPresentFallback:
 
+class TestProviderApiKeyPresentFallback:
     def test_minimax_cn_logged_in_returns_true(self):
         """minimax-cn: if hermes_cli.auth.get_auth_status returns logged_in, must be True."""
-        with mock.patch("api.onboarding._SUPPORTED_PROVIDER_SETUPS", {
-            "openrouter": {}, "anthropic": {}, "openai": {}, "custom": {}
-        }):
+        with mock.patch(
+            "api.onboarding._SUPPORTED_PROVIDER_SETUPS",
+            {"openrouter": {}, "anthropic": {}, "openai": {}, "custom": {}},
+        ):
             with _inject_hermes_cli_auth({"logged_in": True}):
                 result = _call_provider_api_key_present("minimax-cn")
                 assert result is True
 
     def test_unsupported_provider_logged_out_returns_false(self):
         """Unsupported provider with no key → False, no crash."""
-        with mock.patch("api.onboarding._SUPPORTED_PROVIDER_SETUPS", {
-            "openrouter": {}, "anthropic": {}, "openai": {}, "custom": {}
-        }):
+        with mock.patch(
+            "api.onboarding._SUPPORTED_PROVIDER_SETUPS",
+            {"openrouter": {}, "anthropic": {}, "openai": {}, "custom": {}},
+        ):
             with _inject_hermes_cli_auth({"logged_in": False}):
                 result = _call_provider_api_key_present("deepseek")
                 assert result is False
@@ -80,6 +87,7 @@ class TestProviderApiKeyPresentFallback:
     def test_hermes_cli_import_failure_is_safe(self):
         """If hermes_cli is unavailable, falls back silently to False."""
         import builtins
+
         real_import = builtins.__import__
 
         def _block_hermes_cli(name, *args, **kwargs):
@@ -87,23 +95,31 @@ class TestProviderApiKeyPresentFallback:
                 raise ImportError("hermes_cli not available")
             return real_import(name, *args, **kwargs)
 
-        with mock.patch("api.onboarding._SUPPORTED_PROVIDER_SETUPS", {
-            "openrouter": {}, "anthropic": {}, "openai": {}, "custom": {}
-        }):
+        with mock.patch(
+            "api.onboarding._SUPPORTED_PROVIDER_SETUPS",
+            {"openrouter": {}, "anthropic": {}, "openai": {}, "custom": {}},
+        ):
             with mock.patch("builtins.__import__", side_effect=_block_hermes_cli):
                 result = _call_provider_api_key_present("minimax-cn")
                 assert result is False  # safe fallback
 
     def test_supported_provider_still_works_without_fallback(self):
         """openrouter with env key must still succeed via the original path."""
-        from api.onboarding import _provider_api_key_present, _SUPPORTED_PROVIDER_SETUPS
+        from api.onboarding import _provider_api_key_present
+
         env_values = {"OPENROUTER_API_KEY": "sk-test"}
         result = _provider_api_key_present("openrouter", {}, env_values)
         assert result is True
 
     def test_inline_api_key_in_cfg_still_works(self):
         """model.api_key in config.yaml must be recognized for any provider."""
-        cfg = {"model": {"provider": "minimax-cn", "default": "MiniMax-M2.7", "api_key": "key123"}}
+        cfg = {
+            "model": {
+                "provider": "minimax-cn",
+                "default": "MiniMax-M2.7",
+                "api_key": "key123",
+            }
+        }
         result = _call_provider_api_key_present("minimax-cn", cfg)
         assert result is True
 
@@ -112,17 +128,32 @@ class TestProviderApiKeyPresentFallback:
 # 2. _status_from_runtime: unsupported provider with key → chat_ready=True
 # ---------------------------------------------------------------------------
 
-class TestStatusFromRuntimeUnsupportedProvider:
 
-    def _run(self, provider: str, model: str, api_key_present: bool, oauth_present: bool = False):
+class TestStatusFromRuntimeUnsupportedProvider:
+    def _run(
+        self,
+        provider: str,
+        model: str,
+        api_key_present: bool,
+        oauth_present: bool = False,
+    ):
         from api.onboarding import _status_from_runtime
+
         cfg = {"model": {"provider": provider, "default": model}}
         with (
             mock.patch("api.onboarding._HERMES_FOUND", True),
             mock.patch("api.onboarding._load_env_file", return_value={}),
-            mock.patch("api.onboarding._get_active_hermes_home", return_value=pathlib.Path("/tmp")),
-            mock.patch("api.onboarding._provider_api_key_present", return_value=api_key_present),
-            mock.patch("api.onboarding._provider_oauth_authenticated", return_value=oauth_present),
+            mock.patch(
+                "api.onboarding._get_active_hermes_home",
+                return_value=pathlib.Path("/tmp"),
+            ),
+            mock.patch(
+                "api.onboarding._provider_api_key_present", return_value=api_key_present
+            ),
+            mock.patch(
+                "api.onboarding._provider_oauth_authenticated",
+                return_value=oauth_present,
+            ),
         ):
             return _status_from_runtime(cfg, True)
 
@@ -140,13 +171,17 @@ class TestStatusFromRuntimeUnsupportedProvider:
 
     def test_unsupported_provider_no_key_no_oauth_gives_not_ready(self):
         """No key, no oauth → provider_ready=False."""
-        result = self._run("minimax-cn", "MiniMax-M2.7", api_key_present=False, oauth_present=False)
+        result = self._run(
+            "minimax-cn", "MiniMax-M2.7", api_key_present=False, oauth_present=False
+        )
         assert result["chat_ready"] is False
         assert result["provider_ready"] is False
 
     def test_oauth_provider_still_works_via_oauth_path(self):
         """openai-codex (OAuth) with no api_key but oauth present → ready."""
-        result = self._run("openai-codex", "codex-model", api_key_present=False, oauth_present=True)
+        result = self._run(
+            "openai-codex", "codex-model", api_key_present=False, oauth_present=True
+        )
         assert result["chat_ready"] is True
 
 
@@ -154,10 +189,11 @@ class TestStatusFromRuntimeUnsupportedProvider:
 # 3. get_onboarding_status: minimax-cn fully configured → completed=True
 # ---------------------------------------------------------------------------
 
-class TestOnboardingStatusUnsupportedProvider:
 
+class TestOnboardingStatusUnsupportedProvider:
     def _make_status(self, chat_ready: bool, provider: str = "minimax-cn"):
         import api.onboarding as mod
+
         fake_config_path = pathlib.Path("/tmp/_test_572_config.yaml")
         cfg = {"model": {"provider": provider, "default": "MiniMax-M2.7"}}
         runtime = {
@@ -174,7 +210,9 @@ class TestOnboardingStatusUnsupportedProvider:
         with (
             mock.patch.object(mod, "load_settings", return_value={}),
             mock.patch.object(mod, "get_config", return_value=cfg),
-            mock.patch.object(mod, "verify_hermes_imports", return_value=(True, [], {})),
+            mock.patch.object(
+                mod, "verify_hermes_imports", return_value=(True, [], {})
+            ),
             mock.patch.object(mod, "_status_from_runtime", return_value=runtime),
             mock.patch.object(mod, "load_workspaces", return_value=[]),
             mock.patch.object(mod, "get_last_workspace", return_value=None),

--- a/tests/test_issue603_provider_categories.py
+++ b/tests/test_issue603_provider_categories.py
@@ -11,8 +11,8 @@ Validates:
   - Fallback when categories are empty
 """
 
-import pytest
-import sys, os
+import sys
+import os
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
@@ -25,6 +25,7 @@ from api.onboarding import (
 
 
 # ── Backend: provider catalog structure ──────────────────────────────────
+
 
 class TestProviderCatalog:
     """Verify the extended provider catalog has categories."""
@@ -149,15 +150,26 @@ class TestProviderCategoryOrder:
 
 # ── Backend: _build_setup_catalog ────────────────────────────────────────
 
+
 class TestBuildSetupCatalog:
     def test_catalog_has_categories_key(self):
-        cfg = {"model": {"provider": "openrouter", "default": "anthropic/claude-sonnet-4.6"}}
+        cfg = {
+            "model": {
+                "provider": "openrouter",
+                "default": "anthropic/claude-sonnet-4.6",
+            }
+        }
         catalog = _build_setup_catalog(cfg)
         assert "categories" in catalog
         assert isinstance(catalog["categories"], list)
 
     def test_catalog_categories_have_providers_list(self):
-        cfg = {"model": {"provider": "openrouter", "default": "anthropic/claude-sonnet-4.6"}}
+        cfg = {
+            "model": {
+                "provider": "openrouter",
+                "default": "anthropic/claude-sonnet-4.6",
+            }
+        }
         catalog = _build_setup_catalog(cfg)
         all_provider_ids = {p["id"] for p in catalog["providers"]}
         for cat in catalog["categories"]:
@@ -166,13 +178,23 @@ class TestBuildSetupCatalog:
                 assert pid in all_provider_ids
 
     def test_catalog_providers_have_category_field(self):
-        cfg = {"model": {"provider": "openrouter", "default": "anthropic/claude-sonnet-4.6"}}
+        cfg = {
+            "model": {
+                "provider": "openrouter",
+                "default": "anthropic/claude-sonnet-4.6",
+            }
+        }
         catalog = _build_setup_catalog(cfg)
         for p in catalog["providers"]:
             assert "category" in p
 
     def test_catalog_providers_sorted_by_category(self):
-        cfg = {"model": {"provider": "openrouter", "default": "anthropic/claude-sonnet-4.6"}}
+        cfg = {
+            "model": {
+                "provider": "openrouter",
+                "default": "anthropic/claude-sonnet-4.6",
+            }
+        }
         catalog = _build_setup_catalog(cfg)
         cat_order = {c["id"]: c["order"] for c in _PROVIDER_CATEGORIES}
         prev_order = -1
@@ -182,13 +204,23 @@ class TestBuildSetupCatalog:
             prev_order = order
 
     def test_catalog_quick_flag_on_openrouter(self):
-        cfg = {"model": {"provider": "openrouter", "default": "anthropic/claude-sonnet-4.6"}}
+        cfg = {
+            "model": {
+                "provider": "openrouter",
+                "default": "anthropic/claude-sonnet-4.6",
+            }
+        }
         catalog = _build_setup_catalog(cfg)
         orow = next(p for p in catalog["providers"] if p["id"] == "openrouter")
         assert orow["quick"] is True
 
     def test_catalog_no_quick_flag_on_others(self):
-        cfg = {"model": {"provider": "openrouter", "default": "anthropic/claude-sonnet-4.6"}}
+        cfg = {
+            "model": {
+                "provider": "openrouter",
+                "default": "anthropic/claude-sonnet-4.6",
+            }
+        }
         catalog = _build_setup_catalog(cfg)
         for p in catalog["providers"]:
             if p["id"] != "openrouter":
@@ -196,6 +228,7 @@ class TestBuildSetupCatalog:
 
 
 # ── Backend: apply_onboarding_setup base_url handling ───────────────────
+
 
 class TestApplyBaseURL:
     """Verify the generic base_url save logic."""
@@ -217,17 +250,21 @@ class TestApplyBaseURL:
         monkeypatch.setattr("api.onboarding.reload_config", lambda: None)
 
         saved_cfg = {}
+
         def mock_save(p, cfg):
             saved_cfg.update(cfg)
+
         monkeypatch.setattr("api.onboarding._save_yaml_config", mock_save)
 
-        apply_onboarding_setup({
-            "provider": "ollama",
-            "model": "qwen3:32b",
-            "api_key": "test-key",
-            "base_url": "http://my-ollama:11434/v1",
-            "confirm_overwrite": True,
-        })
+        apply_onboarding_setup(
+            {
+                "provider": "ollama",
+                "model": "qwen3:32b",
+                "api_key": "test-key",
+                "base_url": "http://my-ollama:11434/v1",
+                "confirm_overwrite": True,
+            }
+        )
 
         assert saved_cfg["model"]["base_url"] == "http://my-ollama:11434/v1"
 
@@ -246,16 +283,20 @@ class TestApplyBaseURL:
         monkeypatch.setattr("api.onboarding.reload_config", lambda: None)
 
         saved_cfg = {}
+
         def mock_save(p, cfg):
             saved_cfg.update(cfg)
+
         monkeypatch.setattr("api.onboarding._save_yaml_config", mock_save)
 
-        apply_onboarding_setup({
-            "provider": "openai",
-            "model": "gpt-4o",
-            "api_key": "test-key",
-            "confirm_overwrite": True,
-        })
+        apply_onboarding_setup(
+            {
+                "provider": "openai",
+                "model": "gpt-4o",
+                "api_key": "test-key",
+                "confirm_overwrite": True,
+            }
+        )
 
         assert saved_cfg["model"]["base_url"] == "https://api.openai.com/v1"
 
@@ -274,27 +315,36 @@ class TestApplyBaseURL:
         monkeypatch.setattr("api.onboarding.reload_config", lambda: None)
 
         saved_cfg = {}
+
         def mock_save(p, cfg):
             saved_cfg.update(cfg)
+
         monkeypatch.setattr("api.onboarding._save_yaml_config", mock_save)
 
-        apply_onboarding_setup({
-            "provider": "anthropic",
-            "model": "claude-sonnet-4.6",
-            "api_key": "test-key",
-            "confirm_overwrite": True,
-        })
+        apply_onboarding_setup(
+            {
+                "provider": "anthropic",
+                "model": "claude-sonnet-4.6",
+                "api_key": "test-key",
+                "confirm_overwrite": True,
+            }
+        )
 
         assert "base_url" not in saved_cfg["model"]
 
 
 # ── Frontend: i18n keys ─────────────────────────────────────────────────
 
+
 class TestI18nCategoryKeys:
     def test_en_has_all_category_keys(self):
         with open("static/i18n.js", encoding="utf-8") as f:
             content = f.read()
-        for key in ["provider_category_easy_start", "provider_category_self_hosted", "provider_category_specialized"]:
+        for key in [
+            "provider_category_easy_start",
+            "provider_category_self_hosted",
+            "provider_category_specialized",
+        ]:
             assert f"{key}:" in content, f"Missing i18n key: {key}"
 
     def test_ru_has_all_category_keys(self):
@@ -337,25 +387,37 @@ class TestApplyBaseURLSpecialized:
         monkeypatch.setattr("api.onboarding._get_config_path", lambda: config_path)
         monkeypatch.setattr("api.onboarding._get_active_hermes_home", lambda: tmp_path)
         monkeypatch.setattr("api.onboarding._load_yaml_config", lambda p: {})
-        monkeypatch.setattr("api.onboarding._normalize_model_for_provider", lambda prov, m: m)
+        monkeypatch.setattr(
+            "api.onboarding._normalize_model_for_provider", lambda prov, m: m
+        )
         monkeypatch.setattr("api.onboarding._write_env_file", lambda p, d: None)
         monkeypatch.setattr("api.onboarding._provider_api_key_present", lambda *a: True)
         monkeypatch.setattr("api.onboarding.reload_config", lambda: None)
 
         saved_cfg = {}
+
         def mock_save(p, cfg):
             saved_cfg.update(cfg)
+
         monkeypatch.setattr("api.onboarding._save_yaml_config", mock_save)
 
         from api.onboarding import apply_onboarding_setup
-        apply_onboarding_setup({"provider": provider, "model": model, "api_key": "test-key", "confirm_overwrite": True})
+
+        apply_onboarding_setup(
+            {
+                "provider": provider,
+                "model": model,
+                "api_key": "test-key",
+                "confirm_overwrite": True,
+            }
+        )
         return saved_cfg
 
     def test_gemini_gets_default_base_url(self, tmp_path, monkeypatch):
         saved = self._run_setup(tmp_path, monkeypatch, "gemini")
-        assert "generativelanguage.googleapis.com" in saved.get("model", {}).get("base_url", ""), (
-            "gemini setup must write the Gemini base_url to config"
-        )
+        assert "generativelanguage.googleapis.com" in saved.get("model", {}).get(
+            "base_url", ""
+        ), "gemini setup must write the Gemini base_url to config"
 
     def test_deepseek_gets_default_base_url(self, tmp_path, monkeypatch):
         saved = self._run_setup(tmp_path, monkeypatch, "deepseek")

--- a/tests/test_issue604_all_providers_model_picker.py
+++ b/tests/test_issue604_all_providers_model_picker.py
@@ -1,4 +1,5 @@
 """Tests for #604 — model picker shows all configured providers."""
+
 import re
 
 
@@ -21,7 +22,7 @@ def _get_provider_models_keys() -> set:
             m = re.match(r'^    "([^"]+)":\s*\[', line)
             if m:
                 keys.append(m.group(1))
-            if re.match(r'^\}', line):
+            if re.match(r"^\}", line):
                 break
     return set(keys)
 
@@ -33,29 +34,41 @@ class TestProviderDetectionEnvVars:
     """All known env vars should map to valid provider IDs."""
 
     # Providers that exist but aren't in _PROVIDER_MODELS (use special handling)
-    _SPECIAL_PROVIDERS = {"openrouter", "ollama-cloud", "custom", "ollama", "lmstudio", "local"}
+    _SPECIAL_PROVIDERS = {
+        "openrouter",
+        "ollama-cloud",
+        "custom",
+        "ollama",
+        "lmstudio",
+        "local",
+    }
 
     def test_xai_env_maps_to_xai_provider(self):
         """XAI_API_KEY should add 'x-ai' (not 'xai')."""
         src = _src()
-        assert re.search(r'XAI_API_KEY.*?add\("x-ai"\)', src, re.DOTALL), \
+        assert re.search(r'XAI_API_KEY.*?add\("x-ai"\)', src, re.DOTALL), (
             "XAI_API_KEY must map to provider 'x-ai'"
+        )
 
     def test_mistral_env_maps_to_mistralai_provider(self):
         """MISTRAL_API_KEY should add 'mistralai' (not 'mistral')."""
         src = _src()
-        assert re.search(r'MISTRAL_API_KEY.*?add\("mistralai"\)', src, re.DOTALL), \
+        assert re.search(r'MISTRAL_API_KEY.*?add\("mistralai"\)', src, re.DOTALL), (
             "MISTRAL_API_KEY must map to provider 'mistralai'"
+        )
 
     def test_all_provider_env_vars_map_to_known_providers(self):
         """Every detected_provider.add() call should reference a known provider."""
         src = _src()
-        fn = re.search(r'def _build_available_models_uncached', src)
-        fn_block = src[fn.start():fn.start() + 10000]
+        fn = re.search(r"def _build_available_models_uncached", src)
+        fn_block = src[fn.start() : fn.start() + 10000]
         adds = re.findall(r'detected_providers\.add\("([^"]+)"\)', fn_block)
-        unknown = [p for p in adds if p not in _PROVIDER_MODELS_KEYS and p not in self._SPECIAL_PROVIDERS]
-        assert not unknown, \
-            f"Unknown provider IDs in env var detection: {unknown}"
+        unknown = [
+            p
+            for p in adds
+            if p not in _PROVIDER_MODELS_KEYS and p not in self._SPECIAL_PROVIDERS
+        ]
+        assert not unknown, f"Unknown provider IDs in env var detection: {unknown}"
 
 
 class TestConfigProvidersDetection:
@@ -64,23 +77,22 @@ class TestConfigProvidersDetection:
     def test_cfg_providers_detection_exists(self):
         """_build_available_models must scan cfg['providers'] for known providers."""
         src = _src()
-        assert "cfg.get(\"providers\", {})" in src, \
-            "Must read cfg['providers']"
-        assert "_cfg_providers" in src, \
-            "Must use _cfg_providers variable"
+        assert 'cfg.get("providers", {})' in src, "Must read cfg['providers']"
+        assert "_cfg_providers" in src, "Must use _cfg_providers variable"
 
     def test_cfg_providers_only_adds_known(self):
         """Only providers in _PROVIDER_MODELS should be added from config."""
         src = _src()
         # Find the config providers detection block
-        m = re.search(r'Also detect providers explicitly listed', src)
+        m = re.search(r"Also detect providers explicitly listed", src)
         assert m, "Comment about config.yaml providers detection must exist"
         # 1500-char window absorbs documentation expansion (e.g. the
         # _canonicalise_provider_id discussion added in #1568) without
         # losing the structural-assertion intent.
-        block = src[m.start():m.start() + 1500]
-        assert "_PROVIDER_MODELS" in block, \
+        block = src[m.start() : m.start() + 1500]
+        assert "_PROVIDER_MODELS" in block, (
             "Config providers detection must check against _PROVIDER_MODELS"
+        )
 
 
 class TestProviderModelsCompleteness:

--- a/tests/test_issue607.py
+++ b/tests/test_issue607.py
@@ -1,7 +1,6 @@
 """Tests for PR #648 — Gemma 4 thinking token stripping (closes #607)."""
-import re
+
 import pathlib
-import pytest
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_issue609.py
+++ b/tests/test_issue609.py
@@ -11,7 +11,6 @@ Two independent bugs were fixed:
      Docker volume mount outside the user's home directory.  Any path under
      the boot-time default should be trusted automatically.
 """
-from pathlib import Path
 
 import pytest
 
@@ -19,6 +18,7 @@ from api.workspace import resolve_trusted_workspace
 
 
 # ── Fix 2: trust paths under DEFAULT_WORKSPACE ───────────────────────────────
+
 
 def test_subdir_of_boot_default_is_trusted(monkeypatch, tmp_path):
     """A subdirectory of BOOT_DEFAULT_WORKSPACE must be trusted without being in

--- a/tests/test_issue617_cron_profile_selector.py
+++ b/tests/test_issue617_cron_profile_selector.py
@@ -39,7 +39,9 @@ def test_cron_api_serializes_legacy_profile_as_explicit_server_default():
     payload = _cron_job_for_api(legacy)
 
     assert payload["profile"] is None
-    assert "profile" not in legacy, "API serialization must not mutate stored legacy jobs"
+    assert "profile" not in legacy, (
+        "API serialization must not mutate stored legacy jobs"
+    )
 
 
 def test_cron_profile_value_validates_against_existing_profiles(monkeypatch):
@@ -78,8 +80,12 @@ def test_cron_create_api_persists_profile_and_returns_it(monkeypatch):
     cron_pkg = types.ModuleType("cron")
     cron_pkg.__path__ = []
     cron_jobs = types.ModuleType("cron.jobs")
-    cron_jobs.create_job = lambda **kwargs: calls.append(("create", kwargs)) or dict(created)
-    cron_jobs.update_job = lambda job_id, updates: calls.append(("update", job_id, updates)) or dict(updated)
+    cron_jobs.create_job = lambda **kwargs: (
+        calls.append(("create", kwargs)) or dict(created)
+    )
+    cron_jobs.update_job = lambda job_id, updates: (
+        calls.append(("update", job_id, updates)) or dict(updated)
+    )
 
     monkeypatch.setattr(profiles, "list_profiles_api", lambda: [{"name": "research"}])
     monkeypatch.setitem(sys.modules, "cron", cron_pkg)
@@ -112,8 +118,12 @@ def test_cron_create_api_rejects_unknown_profile_before_persisting(monkeypatch):
     cron_pkg = types.ModuleType("cron")
     cron_pkg.__path__ = []
     cron_jobs = types.ModuleType("cron.jobs")
-    cron_jobs.create_job = lambda **kwargs: pytest.fail("invalid profiles must not create jobs")
-    cron_jobs.update_job = lambda *args, **kwargs: pytest.fail("invalid profiles must not update jobs")
+    cron_jobs.create_job = lambda **kwargs: pytest.fail(
+        "invalid profiles must not create jobs"
+    )
+    cron_jobs.update_job = lambda *args, **kwargs: pytest.fail(
+        "invalid profiles must not update jobs"
+    )
 
     monkeypatch.setattr(profiles, "list_profiles_api", lambda: [{"name": "research"}])
     monkeypatch.setitem(sys.modules, "cron", cron_pkg)
@@ -160,7 +170,9 @@ def test_cron_update_api_accepts_profile_clear_and_rejects_unknown(monkeypatch):
     assert calls == [("job617", {"profile": None})]
 
 
-def test_manual_cron_run_uses_execution_profile_but_persists_to_owning_store(monkeypatch):
+def test_manual_cron_run_uses_execution_profile_but_persists_to_owning_store(
+    monkeypatch,
+):
     import api.profiles as profiles
     import api.routes as routes
 
@@ -179,17 +191,25 @@ def test_manual_cron_run_uses_execution_profile_but_persists_to_owning_store(mon
     cron_pkg = types.ModuleType("cron")
     cron_pkg.__path__ = []
     cron_jobs = types.ModuleType("cron.jobs")
-    cron_jobs.save_job_output = lambda job_id, output: events.append(("save", job_id, output))
-    cron_jobs.mark_job_run = lambda job_id, success, error=None: events.append(("mark", job_id, success, error))
+    cron_jobs.save_job_output = lambda job_id, output: events.append(
+        ("save", job_id, output)
+    )
+    cron_jobs.mark_job_run = lambda job_id, success, error=None: events.append(
+        ("mark", job_id, success, error)
+    )
     cron_scheduler = types.ModuleType("cron.scheduler")
-    cron_scheduler.run_job = lambda job: events.append(("run", job["id"])) or (True, "output", "final", None)
+    cron_scheduler.run_job = lambda job: (
+        events.append(("run", job["id"])) or (True, "output", "final", None)
+    )
 
     def fake_subprocess_run(job, execution_profile_home):
         events.append(("run", job["id"], str(execution_profile_home)))
         return True, "output", "final", None
 
     monkeypatch.setattr(profiles, "cron_profile_context_for_home", Ctx)
-    monkeypatch.setattr(routes, "_run_cron_job_in_profile_subprocess", fake_subprocess_run)
+    monkeypatch.setattr(
+        routes, "_run_cron_job_in_profile_subprocess", fake_subprocess_run
+    )
     monkeypatch.setitem(sys.modules, "cron", cron_pkg)
     monkeypatch.setitem(sys.modules, "cron.jobs", cron_jobs)
     monkeypatch.setitem(sys.modules, "cron.scheduler", cron_scheduler)
@@ -218,7 +238,7 @@ def test_cron_profile_selector_source_hooks_present():
 
     assert "async function loadCronProfiles()" in panels
     assert "api('/api/profiles')" in panels
-    assert "id=\"cronFormProfile\"" in panels
+    assert 'id="cronFormProfile"' in panels
     assert "profile: profile" in panels
     assert "job.profile" in panels
     assert "cron-profile-badge" in panels

--- a/tests/test_issue632.py
+++ b/tests/test_issue632.py
@@ -9,6 +9,7 @@ Covers:
   locally executed built-in command
 - boot.js uses the async slash autocomplete helper while typing
 """
+
 import pathlib
 
 
@@ -23,12 +24,15 @@ def test_subarg_registry_exists_and_reasoning_is_promoted_to_builtin():
     assert "const SLASH_SUBARG_SOURCES=" in COMMANDS_JS
     # /reasoning is now a proper builtin command with a fn: handler (cmdReasoning)
     # so it is in the COMMANDS array, not SLASH_SUBARG_SOURCES
-    assert "{name:'reasoning'" in COMMANDS_JS, \
+    assert "{name:'reasoning'" in COMMANDS_JS, (
         "/reasoning must be registered as a local built-in command with fn: handler"
-    assert "fn:cmdReasoning" in COMMANDS_JS, \
+    )
+    assert "fn:cmdReasoning" in COMMANDS_JS, (
         "/reasoning entry must reference cmdReasoning function"
-    assert "function cmdReasoning" in COMMANDS_JS, \
+    )
+    assert "function cmdReasoning" in COMMANDS_JS, (
         "cmdReasoning function must be defined"
+    )
     # source:'subarg-command' is still used for model/personality in SLASH_SUBARG_SOURCES
     assert "source:'subarg-command'" in COMMANDS_JS
 
@@ -55,5 +59,6 @@ def test_subarg_dropdown_has_distinct_parent_and_argument_styling():
     assert ".cmd-item-subarg" in STYLE_CSS
     assert ".cmd-item.selected{background:var(--accent-bg);" in STYLE_CSS
     assert "_cmdSelectedIdx=matches.length?0:-1;" in COMMANDS_JS
-    assert "getSlashAutocompleteMatches(nextValue).then(matches=>" in COMMANDS_JS, \
+    assert "getSlashAutocompleteMatches(nextValue).then(matches=>" in COMMANDS_JS, (
         "selecting a first-level command with sub-args should immediately open second-level suggestions"
+    )

--- a/tests/test_issue634.py
+++ b/tests/test_issue634.py
@@ -10,13 +10,13 @@ Fixes:
    if missing and return early.
 2. Exception path: log a warning instead of silently returning [].
 """
-import pathlib
-import re
 
-MODELS_PY = pathlib.Path(__file__).parent.parent / 'api' / 'models.py'
-AGENT_SESSIONS_PY = pathlib.Path(__file__).parent.parent / 'api' / 'agent_sessions.py'
-src = MODELS_PY.read_text(encoding='utf-8')
-agent_src = AGENT_SESSIONS_PY.read_text(encoding='utf-8')
+import pathlib
+
+MODELS_PY = pathlib.Path(__file__).parent.parent / "api" / "models.py"
+AGENT_SESSIONS_PY = pathlib.Path(__file__).parent.parent / "api" / "agent_sessions.py"
+src = MODELS_PY.read_text(encoding="utf-8")
+agent_src = AGENT_SESSIONS_PY.read_text(encoding="utf-8")
 combined_src = src + "\n" + agent_src
 
 
@@ -30,11 +30,17 @@ class TestCliSessionsErrorSurface:
     def test_missing_source_column_logs_warning(self):
         """If 'source' column is absent, a warning is logged."""
         # The warning message must mention the missing column and how to fix it
-        assert "no 'source' column" in combined_src or "has no 'source' column" in combined_src
+        assert (
+            "no 'source' column" in combined_src
+            or "has no 'source' column" in combined_src
+        )
 
     def test_missing_source_column_suggests_upgrade(self):
         """Warning message must suggest upgrading hermes-agent."""
-        assert "Upgrade hermes-agent" in combined_src or "upgrade hermes-agent" in combined_src.lower()
+        assert (
+            "Upgrade hermes-agent" in combined_src
+            or "upgrade hermes-agent" in combined_src.lower()
+        )
 
     def test_exception_path_logs_warning(self):
         """The except clause must call logger.warning, not silently pass."""
@@ -42,8 +48,9 @@ class TestCliSessionsErrorSurface:
         func_start = src.find("def get_cli_sessions()")
         func_end = src.find("\ndef ", func_start + 1)
         func_body = src[func_start:func_end] if func_end != -1 else src[func_start:]
-        assert "warning(" in func_body, \
+        assert "warning(" in func_body, (
             "get_cli_sessions() exception handler must call logging.warning()"
+        )
 
     def test_exception_path_includes_db_path(self):
         """The warning must include the db_path for diagnosability."""
@@ -52,9 +59,10 @@ class TestCliSessionsErrorSurface:
         func_body = src[func_start:func_end] if func_end != -1 else src[func_start:]
         # db_path should appear in the warning call
         warning_pos = func_body.find("warning(")
-        warning_block = func_body[warning_pos:warning_pos + 300]
-        assert "db_path" in warning_block, \
+        warning_block = func_body[warning_pos : warning_pos + 300]
+        assert "db_path" in warning_block, (
             "Warning must include db_path so admins can find the problematic database"
+        )
 
     def test_still_returns_empty_on_error(self):
         """Function must still return [] after logging (graceful degradation)."""
@@ -64,9 +72,10 @@ class TestCliSessionsErrorSurface:
         func_body = src[func_start:func_end] if func_end != -1 else src[func_start:]
         # Must have a 'return' after the warning call
         warning_pos = func_body.find("_cli_err:")
-        after_warning = func_body[warning_pos:warning_pos + 400]
-        assert "return" in after_warning, \
+        after_warning = func_body[warning_pos : warning_pos + 400]
+        assert "return" in after_warning, (
             "Function must return after the warning (not raise)"
+        )
 
     def test_source_column_check_before_sql_query(self):
         """Schema check must happen before the main SQL SELECT."""
@@ -74,5 +83,6 @@ class TestCliSessionsErrorSurface:
         select_pos = agent_src.find("SELECT s.id, s.title, s.model")
         assert pragma_pos != -1, "PRAGMA check not found"
         assert select_pos != -1, "SELECT query not found"
-        assert pragma_pos < select_pos, \
+        assert pragma_pos < select_pos, (
             "Schema introspection must run before the main SQL query"
+        )

--- a/tests/test_issue644.py
+++ b/tests/test_issue644.py
@@ -1,4 +1,5 @@
 """Tests for PR #644 — load provider models from config.yaml in get_available_models()."""
+
 import pytest
 import api.config as _cfg
 
@@ -32,6 +33,7 @@ def _available_models_with_cfg(cfg_override):
     old_mtime = _cfg._cfg_mtime
     try:
         from pathlib import Path
+
         _cfg._cfg_mtime = Path(_cfg._get_config_path()).stat().st_mtime
     except OSError:
         _cfg._cfg_mtime = 0.0
@@ -62,7 +64,9 @@ class TestConfigYamlModelsLoading:
         groups = {g["provider"]: g["models"] for g in result["groups"]}
         # Provider should appear (previously it was silently skipped)
         provider_names = [g["provider"] for g in result["groups"]]
-        found = any("my-custom-llm" in n.lower() or "My-Custom-Llm" in n for n in provider_names)
+        found = any(
+            "my-custom-llm" in n.lower() or "My-Custom-Llm" in n for n in provider_names
+        )
         # If it appears, its models must include our cfg models
         for g in result["groups"]:
             if "custom" in g["provider"].lower():
@@ -116,7 +120,9 @@ class TestConfigYamlModelsLoading:
                 )
                 break
 
-    def test_provider_in_provider_models_but_no_cfg_override_uses_static_fallback(self, monkeypatch):
+    def test_provider_in_provider_models_but_no_cfg_override_uses_static_fallback(
+        self, monkeypatch
+    ):
         """When Hermes CLI has no live catalog, _PROVIDER_MODELS remains fallback."""
         monkeypatch.setattr(_cfg, "_read_live_provider_model_ids", lambda _pid: [])
         cfg = {

--- a/tests/test_issue646.py
+++ b/tests/test_issue646.py
@@ -1,5 +1,5 @@
 """Tests for PR #649 — empty DEFAULT_MODEL does not inject blank model entries."""
-import pytest
+
 from api import config as cfg
 
 
@@ -13,42 +13,59 @@ class TestEmptyDefaultModel:
         # We test the config module directly since it's a pure function path.
         # The key invariant: any model dict in the output must have non-empty id.
         # We check the branches that were patched in PR #649.
-        
+
         # Path 1: "no providers detected" branch
         # When default_model="", we should NOT append a Default group with empty model
         groups = []
         default_model = cfg.DEFAULT_MODEL
         if default_model:
-            label = default_model.split("/")[-1] if "/" in default_model else default_model
-            groups.append(
-                {"provider": "Default", "models": [{"id": default_model, "label": label}]}
+            label = (
+                default_model.split("/")[-1] if "/" in default_model else default_model
             )
-        
+            groups.append(
+                {
+                    "provider": "Default",
+                    "models": [{"id": default_model, "label": label}],
+                }
+            )
+
         # With empty default_model, groups should be empty (not appended)
         assert len(groups) == 0, "Empty default_model should not create any group"
 
     def test_no_empty_id_when_default_model_is_set(self, monkeypatch):
         """With a real DEFAULT_MODEL, the Default group should be created normally."""
-        monkeypatch.setattr(cfg, "DEFAULT_MODEL", "openrouter/mistralai/mistral-7b-instruct")
-        
+        monkeypatch.setattr(
+            cfg, "DEFAULT_MODEL", "openrouter/mistralai/mistral-7b-instruct"
+        )
+
         groups = []
         default_model = cfg.DEFAULT_MODEL
         if default_model:
-            label = default_model.split("/")[-1] if "/" in default_model else default_model
-            groups.append(
-                {"provider": "Default", "models": [{"id": default_model, "label": label}]}
+            label = (
+                default_model.split("/")[-1] if "/" in default_model else default_model
             )
-        
+            groups.append(
+                {
+                    "provider": "Default",
+                    "models": [{"id": default_model, "label": label}],
+                }
+            )
+
         assert len(groups) == 1
-        assert groups[0]["models"][0]["id"] == "openrouter/mistralai/mistral-7b-instruct"
+        assert (
+            groups[0]["models"][0]["id"] == "openrouter/mistralai/mistral-7b-instruct"
+        )
         assert groups[0]["models"][0]["label"] == "mistral-7b-instruct"
 
     def test_default_model_env_var_empty_string_accepted(self, monkeypatch):
         """Empty string is a valid DEFAULT_MODEL value — no KeyError or crash."""
         import os
+
         monkeypatch.setenv("HERMES_WEBUI_DEFAULT_MODEL", "")
         # Verify the env var resolution pattern handles empty string gracefully
         val = os.getenv("HERMES_WEBUI_DEFAULT_MODEL", "")
         assert val == ""
         # And that the guard works
-        assert not val  # empty string is falsy — the guard `if default_model:` fires correctly
+        assert (
+            not val
+        )  # empty string is falsy — the guard `if default_model:` fires correctly

--- a/tests/test_issue660.py
+++ b/tests/test_issue660.py
@@ -4,13 +4,14 @@ Tests for #660: session queue persistence across page refresh.
 The queue is stored to sessionStorage when entries are added/removed,
 and restored from sessionStorage on session load when the agent is idle.
 """
+
 import pathlib
 
-UI_JS = pathlib.Path(__file__).parent.parent / 'static' / 'ui.js'
-SESSIONS_JS = pathlib.Path(__file__).parent.parent / 'static' / 'sessions.js'
+UI_JS = pathlib.Path(__file__).parent.parent / "static" / "ui.js"
+SESSIONS_JS = pathlib.Path(__file__).parent.parent / "static" / "sessions.js"
 
-ui_src = UI_JS.read_text(encoding='utf-8')
-sess_src = SESSIONS_JS.read_text(encoding='utf-8')
+ui_src = UI_JS.read_text(encoding="utf-8")
+sess_src = SESSIONS_JS.read_text(encoding="utf-8")
 
 
 class TestQueuePersistence:
@@ -22,7 +23,7 @@ class TestQueuePersistence:
 
     def test_queue_stamps_queued_at_timestamp(self):
         """Each queue entry must have a _queued_at timestamp for stale-entry detection."""
-        assert '_queued_at' in ui_src
+        assert "_queued_at" in ui_src
 
     def test_shift_removes_from_session_storage(self):
         """shiftQueuedSessionMessage must remove/update sessionStorage on dequeue."""
@@ -31,7 +32,9 @@ class TestQueuePersistence:
     def test_shift_updates_session_storage_when_items_remain(self):
         """When queue still has items after shift, sessionStorage is updated (not removed)."""
         # After shift: if queue still has items, update storage with remaining
-        assert "sessionStorage.setItem('hermes-queue-'+sid, JSON.stringify(q))" in ui_src
+        assert (
+            "sessionStorage.setItem('hermes-queue-'+sid, JSON.stringify(q))" in ui_src
+        )
         # Counts: should appear in both add and update paths (2 occurrences minimum)
         count = ui_src.count("sessionStorage.setItem('hermes-queue-'+sid")
         assert count >= 2, f"Expected >=2 sessionStorage.setItem calls, found {count}"
@@ -46,12 +49,12 @@ class TestQueueRestore:
 
     def test_restore_uses_timestamp_guard(self):
         """Stale entries (created before last assistant response) must be dropped."""
-        assert '_queued_at' in sess_src
-        assert '_lastAsst' in sess_src
+        assert "_queued_at" in sess_src
+        assert "_lastAsst" in sess_src
 
     def test_restore_shows_toast(self):
         """User must see a toast notification when a queue is restored."""
-        assert 'queued message' in sess_src.lower() and 'restored' in sess_src.lower()
+        assert "queued message" in sess_src.lower() and "restored" in sess_src.lower()
 
     def test_restore_puts_text_in_composer(self):
         """First queued message goes into the composer input, not auto-sent."""
@@ -72,5 +75,6 @@ class TestQueueRestore:
         inflight_pos = sess_src.find("if(INFLIGHT[sid]){")
         restore_pos = sess_src.find("sessionStorage.getItem('hermes-queue-'")
         else_pos = sess_src.find("}else{", inflight_pos)
-        assert restore_pos > else_pos, \
+        assert restore_pos > else_pos, (
             "Queue restore must be inside the else (idle) branch, not the INFLIGHT branch"
+        )

--- a/tests/test_issue673.py
+++ b/tests/test_issue673.py
@@ -14,7 +14,6 @@ Covers:
 
 import json
 import pathlib
-import re
 import unittest
 import urllib.error
 import urllib.request
@@ -107,7 +106,9 @@ class TestSidebarDensitySessionRendering(unittest.TestCase):
         self.assertIn("if(density==='detailed')", SESSIONS_JS)
 
     def test_detailed_mode_uses_message_count_and_model(self):
-        self.assertIn("typeof s.message_count==='number'?s.message_count:0", SESSIONS_JS)
+        self.assertIn(
+            "typeof s.message_count==='number'?s.message_count:0", SESSIONS_JS
+        )
         self.assertIn("const modelMeta=_formatSessionModelWithGateway(s);", SESSIONS_JS)
         self.assertIn("if(modelMeta) metaBits.push(modelMeta);", SESSIONS_JS)
         self.assertIn("t('session_meta_messages', msgCount)", SESSIONS_JS)

--- a/tests/test_issue677.py
+++ b/tests/test_issue677.py
@@ -6,6 +6,7 @@ user scroll position. The bug was that scrollToBottom() was called
 unconditionally inside renderMessages() and appendThinking(), even during
 an active stream — overriding any scroll position the user had set.
 """
+
 import pathlib
 import re
 
@@ -16,7 +17,6 @@ STYLE_CSS = (REPO / "static" / "style.css").read_text(encoding="utf-8")
 
 
 class TestScrollPinningFix:
-
     def test_render_messages_respects_active_stream(self):
         """renderMessages() must not call scrollToBottom() while streaming (#677).
 
@@ -74,10 +74,12 @@ class TestScrollPinningFix:
         if near_bottom_pos == -1:
             near_bottom_pos = UI_JS.find("nearBottom =")
         assert near_bottom_pos != -1, "nearBottom scroll threshold assignment not found"
-        threshold_line = UI_JS[near_bottom_pos:near_bottom_pos + 120]
+        threshold_line = UI_JS[near_bottom_pos : near_bottom_pos + 120]
         # Extract the numeric threshold
         match = re.search(r"<\s*(\d+)", threshold_line)
-        assert match, f"Numeric threshold not found near nearBottom assignment: {threshold_line!r}"
+        assert match, (
+            f"Numeric threshold not found near nearBottom assignment: {threshold_line!r}"
+        )
         threshold = int(match.group(1))
         assert threshold >= 150, (
             f"Scroll re-pin threshold is {threshold}px — must be >= 150px to avoid "
@@ -101,7 +103,7 @@ class TestScrollPinningFix:
         """Scroll-to-bottom button must be hidden by default (display:none) (#677)."""
         btn_pos = INDEX_HTML.find("scrollToBottomBtn")
         assert btn_pos != -1
-        btn_context = INDEX_HTML[btn_pos:btn_pos + 200]
+        btn_context = INDEX_HTML[btn_pos : btn_pos + 200]
         assert "display:none" in btn_context or 'display="none"' in btn_context, (
             "scrollToBottomBtn must be hidden by default — only shown when user scrolls up (#677)"
         )
@@ -116,7 +118,7 @@ class TestScrollPinningFix:
         """Scroll-to-bottom button must use position:sticky so it stays visible (#677)."""
         btn_css_pos = STYLE_CSS.find(".scroll-to-bottom-btn")
         assert btn_css_pos != -1
-        btn_css = STYLE_CSS[btn_css_pos:btn_css_pos + 300]
+        btn_css = STYLE_CSS[btn_css_pos : btn_css_pos + 300]
         assert "sticky" in btn_css, (
             ".scroll-to-bottom-btn must use position:sticky to stay at bottom of viewport (#677)"
         )
@@ -127,7 +129,7 @@ class TestScrollPinningFix:
         assert scroll_listener_start != -1, "scroll event listener not found"
         # After #1360 fix, the nearBottom + btn logic lives inside an rAF
         # callback — extend search window to cover the full listener block.
-        listener_block = UI_JS[scroll_listener_start:scroll_listener_start + 600]
+        listener_block = UI_JS[scroll_listener_start : scroll_listener_start + 600]
         assert "scrollToBottomBtn" in listener_block, (
             "Scroll listener must show/hide scrollToBottomBtn based on _scrollPinned (#677)"
         )
@@ -136,7 +138,7 @@ class TestScrollPinningFix:
         """scrollToBottomBtn onclick must call scrollToBottom() (#677)."""
         btn_pos = INDEX_HTML.find("scrollToBottomBtn")
         assert btn_pos != -1
-        btn_context = INDEX_HTML[btn_pos:btn_pos + 200]
+        btn_context = INDEX_HTML[btn_pos : btn_pos + 200]
         assert "scrollToBottom()" in btn_context, (
             "scrollToBottomBtn onclick must call scrollToBottom() (#677)"
         )

--- a/tests/test_issue693_system_health_panel.py
+++ b/tests/test_issue693_system_health_panel.py
@@ -61,11 +61,28 @@ def test_system_health_payload_normalizes_safe_aggregate_metrics(monkeypatch):
     assert payload["status"] == "ok"
     assert payload["available"] is True
     assert payload["cpu"] == {"percent": 17.3}
-    assert payload["memory"] == {"used_bytes": 4000, "total_bytes": 10000, "percent": 40.0}
-    assert payload["disk"] == {"used_bytes": 55500, "total_bytes": 100000, "percent": 55.5}
+    assert payload["memory"] == {
+        "used_bytes": 4000,
+        "total_bytes": 10000,
+        "percent": 40.0,
+    }
+    assert payload["disk"] == {
+        "used_bytes": 55500,
+        "total_bytes": 100000,
+        "percent": 55.5,
+    }
     assert payload["checked_at"]
     rendered = repr(payload)
-    for private_fragment in ("/home/", "/Users/", "mount", "path", "argv", "command", "env", "token"):
+    for private_fragment in (
+        "/home/",
+        "/Users/",
+        "mount",
+        "path",
+        "argv",
+        "command",
+        "env",
+        "token",
+    ):
         assert private_fragment not in rendered
 
 
@@ -111,7 +128,10 @@ def test_system_health_route_registered_and_auth_gated(monkeypatch):
     from api.auth import check_auth
 
     handler = _FakeHandler()
-    assert check_auth(handler, SimpleNamespace(path="/api/system/health", query="")) is False
+    assert (
+        check_auth(handler, SimpleNamespace(path="/api/system/health", query=""))
+        is False
+    )
     assert handler.status in (302, 401)
 
 
@@ -132,29 +152,45 @@ def test_system_health_route_returns_only_sanitized_payload(monkeypatch):
         },
     )
     handler = _FakeHandler()
-    assert routes.handle_get(handler, urlparse("http://example.test/api/system/health")) is True
+    assert (
+        routes.handle_get(handler, urlparse("http://example.test/api/system/health"))
+        is True
+    )
     payload = handler.json_body()
     assert payload["cpu"]["percent"] == 12.0
-    assert set(payload) == {"status", "available", "checked_at", "cpu", "memory", "disk", "errors"}
+    assert set(payload) == {
+        "status",
+        "available",
+        "checked_at",
+        "cpu",
+        "memory",
+        "disk",
+        "errors",
+    }
 
 
 def test_system_health_panel_markup_and_styles_live_under_insights_not_top_chrome():
     top_shell = INDEX_HTML[: INDEX_HTML.index('<div class="layout">')]
     assert 'id="systemHealthPanel"' not in top_shell
     assert 'aria-label="Host resource health"' not in top_shell
-    assert 'function _renderSystemHealthPanel()' in PANELS_JS
+    assert "function _renderSystemHealthPanel()" in PANELS_JS
     assert 'id="systemHealthPanel"' in PANELS_JS
     assert 'aria-label="Host resource health"' in PANELS_JS
-    assert 'System health' in PANELS_JS
-    assert 'Current VPS resource usage' in PANELS_JS
-    assert PANELS_JS.index('_renderSystemHealthPanel()') < PANELS_JS.index('_renderLlmWikiStatus(wikiStatus)')
+    assert "System health" in PANELS_JS
+    assert "Current VPS resource usage" in PANELS_JS
+    assert PANELS_JS.index("_renderSystemHealthPanel()") < PANELS_JS.index(
+        "_renderLlmWikiStatus(wikiStatus)"
+    )
     assert 'data-system-health-metric="cpu"' in PANELS_JS
     assert 'data-system-health-metric="memory"' in PANELS_JS
     assert 'data-system-health-metric="disk"' in PANELS_JS
     assert ".system-health-panel.insights-card" in STYLE_CSS
     assert ".system-health-bar-fill" in STYLE_CSS
     assert ".system-health-panel.unavailable" in STYLE_CSS
-    assert "@media(max-width:640px)" in STYLE_CSS and ".system-health-panel.insights-card" in STYLE_CSS
+    assert (
+        "@media(max-width:640px)" in STYLE_CSS
+        and ".system-health-panel.insights-card" in STYLE_CSS
+    )
 
 
 def test_system_health_frontend_polls_visible_and_renders_progress_labels():
@@ -162,7 +198,10 @@ def test_system_health_frontend_polls_visible_and_renders_progress_labels():
     assert "api('/api/system/health')" in UI_JS
     assert "document.visibilityState !== 'visible'" in UI_JS
     assert "document.querySelector('main.main.showing-insights')" in UI_JS
-    assert "document.addEventListener('visibilitychange',_syncSystemHealthMonitorVisibility)" in UI_JS
+    assert (
+        "document.addEventListener('visibilitychange',_syncSystemHealthMonitorVisibility)"
+        in UI_JS
+    )
     assert "typeof _syncSystemHealthMonitorVisibility === 'function'" in PANELS_JS
     assert "function renderSystemHealth(payload)" in UI_JS
     assert "setSystemHealthUnavailable" in UI_JS

--- a/tests/test_issue696_mcp_visibility_panel.py
+++ b/tests/test_issue696_mcp_visibility_panel.py
@@ -1,4 +1,5 @@
 """Regression tests for issue #696 — MCP server visibility panel MVP."""
+
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]

--- a/tests/test_issue697_mcp_tool_inventory.py
+++ b/tests/test_issue697_mcp_tool_inventory.py
@@ -1,4 +1,5 @@
 """Regression tests for issue #697 — searchable global MCP tool inventory."""
+
 import json
 from unittest.mock import MagicMock, patch
 
@@ -24,16 +25,23 @@ def _json_payload(handler):
 def _read(relative_path: str) -> str:
     from pathlib import Path
 
-    return (Path(__file__).resolve().parents[1] / relative_path).read_text(encoding="utf-8")
+    return (Path(__file__).resolve().parents[1] / relative_path).read_text(
+        encoding="utf-8"
+    )
 
 
 class TestMcpToolInventoryApi:
     @patch("api.routes._mcp_runtime_status_by_name")
     @patch("api.routes.get_config")
-    def test_endpoint_returns_sanitized_registered_mcp_tools(self, mock_cfg, mock_runtime):
+    def test_endpoint_returns_sanitized_registered_mcp_tools(
+        self, mock_cfg, mock_runtime
+    ):
         mock_cfg.return_value = {
             "mcp_servers": {
-                "web-reader": {"url": "http://localhost:3001/mcp", "headers": {"Authorization": "Bearer secret-token"}},
+                "web-reader": {
+                    "url": "http://localhost:3001/mcp",
+                    "headers": {"Authorization": "Bearer secret-token"},
+                },
                 "disabled": {"command": "disabled-cmd", "enabled": False},
             }
         }
@@ -47,8 +55,15 @@ class TestMcpToolInventoryApi:
                         "parameters": {
                             "type": "object",
                             "properties": {
-                                "url": {"type": "string", "description": "URL to fetch", "default": "https://token.example/?key=secret-token"},
-                                "limit": {"type": "integer", "description": "Maximum bytes"},
+                                "url": {
+                                    "type": "string",
+                                    "description": "URL to fetch",
+                                    "default": "https://token.example/?key=secret-token",
+                                },
+                                "limit": {
+                                    "type": "integer",
+                                    "description": "Maximum bytes",
+                                },
                             },
                             "required": ["url"],
                         },
@@ -69,33 +84,68 @@ class TestMcpToolInventoryApi:
         assert payload["tools"][0]["active"] is True
         assert payload["tools"][0]["enabled"] is True
         assert payload["tools"][0]["schema_summary"] == [
-            {"name": "url", "type": "string", "required": True, "description": "URL to fetch"},
-            {"name": "limit", "type": "integer", "required": False, "description": "Maximum bytes"},
+            {
+                "name": "url",
+                "type": "string",
+                "required": True,
+                "description": "URL to fetch",
+            },
+            {
+                "name": "limit",
+                "type": "integer",
+                "required": False,
+                "description": "Maximum bytes",
+            },
         ]
         raw = json.dumps(payload)
         assert "secret-token" not in raw
         assert "default" not in raw
         assert "Authorization" not in raw
 
-    def test_schema_summary_uses_parameter_names_types_required_and_descriptions_only(self):
+    def test_schema_summary_uses_parameter_names_types_required_and_descriptions_only(
+        self,
+    ):
         schema = {
             "type": "object",
             "properties": {
-                "query": {"type": "string", "description": "Search text", "examples": ["secret"]},
-                "tags": {"type": "array", "items": {"type": "string"}, "description": "Tag filters"},
+                "query": {
+                    "type": "string",
+                    "description": "Search text",
+                    "examples": ["secret"],
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Tag filters",
+                },
             },
             "required": ["query"],
         }
         assert _mcp_schema_summary(schema) == [
-            {"name": "query", "type": "string", "required": True, "description": "Search text"},
-            {"name": "tags", "type": "array", "required": False, "description": "Tag filters"},
+            {
+                "name": "query",
+                "type": "string",
+                "required": True,
+                "description": "Search text",
+            },
+            {
+                "name": "tags",
+                "type": "array",
+                "required": False,
+                "description": "Tag filters",
+            },
         ]
 
     def test_tool_summary_rejects_non_dict_schema_and_redacts_description(self):
         summary = _mcp_tool_summary(
             "search",
             {"description": "use API_KEY=super-secret", "parameters": "not-a-dict"},
-            {"name": "search", "status": "configured", "enabled": True, "active": False},
+            {
+                "name": "search",
+                "status": "configured",
+                "enabled": True,
+                "active": False,
+            },
         )
         assert summary["description"] != "use API_KEY=super-secret"
         assert "super-secret" not in summary["description"]

--- a/tests/test_issue716_agent_heartbeat.py
+++ b/tests/test_issue716_agent_heartbeat.py
@@ -75,14 +75,18 @@ def _runtime_status(**overrides):
     return payload
 
 
-def test_agent_health_uses_root_gateway_state_when_hermes_home_is_profile(monkeypatch, tmp_path):
+def test_agent_health_uses_root_gateway_state_when_hermes_home_is_profile(
+    monkeypatch, tmp_path
+):
     from api import agent_health
 
     root_home = tmp_path / "root-home"
     profile_home = root_home / "profiles" / "troubleshooting"
     profile_home.mkdir(parents=True)
     (root_home / "gateway.pid").write_text(json.dumps({"pid": 98765}), encoding="utf-8")
-    (root_home / "gateway_state.json").write_text(json.dumps(_runtime_status()), encoding="utf-8")
+    (root_home / "gateway_state.json").write_text(
+        json.dumps(_runtime_status()), encoding="utf-8"
+    )
     fake_gateway_status = _PathSensitiveGatewayStatus(root_home)
 
     monkeypatch.setenv("HERMES_HOME", str(profile_home))
@@ -91,7 +95,9 @@ def test_agent_health_uses_root_gateway_state_when_hermes_home_is_profile(monkey
         "hermes_constants",
         types.SimpleNamespace(get_default_hermes_root=lambda: root_home),
     )
-    monkeypatch.setattr(agent_health, "_gateway_status_module", lambda: fake_gateway_status)
+    monkeypatch.setattr(
+        agent_health, "_gateway_status_module", lambda: fake_gateway_status
+    )
 
     payload = agent_health.build_agent_health_payload()
 
@@ -131,13 +137,17 @@ def test_agent_health_payload_alive_uses_safe_runtime_details(monkeypatch):
     assert "pid" not in payload["details"]
 
 
-def test_agent_health_payload_down_when_gateway_metadata_exists_but_no_process(monkeypatch):
+def test_agent_health_payload_down_when_gateway_metadata_exists_but_no_process(
+    monkeypatch,
+):
     from api import agent_health
 
     monkeypatch.setattr(
         agent_health,
         "_gateway_status_module",
-        lambda: _FakeGatewayStatus(_runtime_status(gateway_state="stale"), running_pid=None),
+        lambda: _FakeGatewayStatus(
+            _runtime_status(gateway_state="stale"), running_pid=None
+        ),
     )
 
     payload = agent_health.build_agent_health_payload()
@@ -160,7 +170,10 @@ def test_agent_health_payload_unknown_when_gateway_is_not_configured(monkeypatch
     payload = agent_health.build_agent_health_payload()
 
     assert payload["alive"] is None
-    assert payload["details"] == {"state": "unknown", "reason": "gateway_not_configured"}
+    assert payload["details"] == {
+        "state": "unknown",
+        "reason": "gateway_not_configured",
+    }
 
 
 def test_agent_health_route_is_registered_with_tri_state_payload_shape():
@@ -186,7 +199,10 @@ def test_agent_health_frontend_polls_only_visible_and_distinguishes_states():
     assert "const AGENT_HEALTH_INTERVAL_MS=30000" in UI_JS
     assert "api('/api/health/agent')" in UI_JS
     assert "document.visibilityState !== 'visible'" in UI_JS
-    assert "document.addEventListener('visibilitychange',_syncAgentHealthMonitorVisibility)" in UI_JS
+    assert (
+        "document.addEventListener('visibilitychange',_syncAgentHealthMonitorVisibility)"
+        in UI_JS
+    )
     assert "if(payload.alive === true)" in UI_JS
     assert "if(payload.alive === false)" in UI_JS
     assert "if(payload.alive == null)" in UI_JS

--- a/tests/test_issue734_message_windowing.py
+++ b/tests/test_issue734_message_windowing.py
@@ -20,14 +20,21 @@ def test_load_earlier_expands_local_window_before_server_pagination_and_preserve
     assert "prevScrollTop=container?container.scrollTop:0" in UI_JS
     assert "container.scrollTop=prevScrollTop+(newScrollH-prevScrollH)" in UI_JS
     assert "if(_messageHiddenBeforeCount()>0) _showEarlierRenderedMessages();" in UI_JS
-    assert "else if(typeof _loadOlderMessages==='function') _loadOlderMessages();" in UI_JS
+    assert (
+        "else if(typeof _loadOlderMessages==='function') _loadOlderMessages();" in UI_JS
+    )
 
 
 def test_windowed_render_keeps_streaming_and_tool_activity_anchored_to_rendered_messages():
     assert "_scrollAfterMessageRender(preserveScroll, scrollSnapshot);" in UI_JS
-    assert "const assistantIdxs=[...assistantSegments.keys()].sort((a,b)=>a-b);" in UI_JS
+    assert (
+        "const assistantIdxs=[...assistantSegments.keys()].sort((a,b)=>a-b);" in UI_JS
+    )
     assert "if(aIdx<assistantIdxs[0]) continue;" in UI_JS
-    assert "const renderedAssistantIdxs=[...assistantSegments.keys()].sort((a,b)=>a-b);" in UI_JS
+    assert (
+        "const renderedAssistantIdxs=[...assistantSegments.keys()].sort((a,b)=>a-b);"
+        in UI_JS
+    )
     assert "const seg=assistantSegments.get(mi);" in UI_JS
 
 

--- a/tests/test_issue739_652_653.py
+++ b/tests/test_issue739_652_653.py
@@ -6,18 +6,19 @@ Tests for streaming error handling fixes:
 
 All static tests (no live server required).
 """
-import ast
+
 import re
 import pathlib
 
-STREAMING = pathlib.Path(__file__).parent.parent / 'api' / 'streaming.py'
-MESSAGES_JS = pathlib.Path(__file__).parent.parent / 'static' / 'messages.js'
+STREAMING = pathlib.Path(__file__).parent.parent / "api" / "streaming.py"
+MESSAGES_JS = pathlib.Path(__file__).parent.parent / "static" / "messages.js"
 
-streaming_src = STREAMING.read_text(encoding='utf-8')
-messages_js_src = MESSAGES_JS.read_text(encoding='utf-8')
+streaming_src = STREAMING.read_text(encoding="utf-8")
+messages_js_src = MESSAGES_JS.read_text(encoding="utf-8")
 
 
 # ── #739: Quota exhaustion detection ─────────────────────────────────────────
+
 
 class TestQuotaDetection:
     """Quota-exhausted errors must be classified separately from rate limits."""
@@ -25,29 +26,31 @@ class TestQuotaDetection:
     def test_quota_patterns_present_in_silent_failure_path(self):
         """The silent-failure path checks for credit/quota strings."""
         block = streaming_src
-        assert 'insufficient credit' in block
-        assert 'credit balance' in block
-        assert 'credits exhausted' in block
-        assert 'quota_exceeded' in block
-        assert 'exceeded your current quota' in block
+        assert "insufficient credit" in block
+        assert "credit balance" in block
+        assert "credits exhausted" in block
+        assert "quota_exceeded" in block
+        assert "exceeded your current quota" in block
 
     def test_quota_type_emitted_as_quota_exhausted(self):
         """The apperror type is 'quota_exhausted', not 'error' or 'rate_limit'."""
-        assert "'quota_exhausted'" in streaming_src or '"quota_exhausted"' in streaming_src
+        assert (
+            "'quota_exhausted'" in streaming_src or '"quota_exhausted"' in streaming_src
+        )
 
     def test_quota_checked_before_rate_limit(self):
         """Quota check must appear before the rate-limit check in the exception path.
         OpenAI billing 429s overlap with rate-limit patterns."""
-        quota_pos = streaming_src.find('_exc_is_quota')
-        rate_pos = streaming_src.find('_exc_is_rate_limit')
-        assert quota_pos != -1, '_exc_is_quota not found in exception path'
-        assert rate_pos != -1, '_exc_is_rate_limit not found in exception path'
-        assert quota_pos < rate_pos, 'Quota check must appear before rate-limit check'
+        quota_pos = streaming_src.find("_exc_is_quota")
+        rate_pos = streaming_src.find("_exc_is_rate_limit")
+        assert quota_pos != -1, "_exc_is_quota not found in exception path"
+        assert rate_pos != -1, "_exc_is_rate_limit not found in exception path"
+        assert quota_pos < rate_pos, "Quota check must appear before rate-limit check"
 
     def test_rate_limit_excludes_quota(self):
         """Rate-limit detection must be guarded so quota errors don't also match."""
         # The pattern: _exc_is_rate_limit = (not _exc_is_quota) and (...)
-        assert '(not _exc_is_quota)' in streaming_src
+        assert "(not _exc_is_quota)" in streaming_src
 
     def test_js_quota_label_present(self):
         """messages.js renders a 'quota_exhausted' apperror with a distinct label."""
@@ -56,6 +59,7 @@ class TestQuotaDetection:
 
 
 # ── #739: Error persistence across reload ─────────────────────────────────────
+
 
 class TestErrorPersistence:
     """Errors must be saved to the session so they survive page reload."""
@@ -71,28 +75,35 @@ class TestErrorPersistence:
         # Find the silent failure block area and verify save precedes return
         pattern = re.compile(
             r"s\.messages\.append\(.*?'_error': True.*?\).*?s\.save\(\).*?return",
-            re.DOTALL
+            re.DOTALL,
         )
-        assert pattern.search(streaming_src), \
+        assert pattern.search(streaming_src), (
             "save() must be called after appending the error message in the silent-failure path"
+        )
 
     def test_exception_path_appends_error_message(self):
         """Exception path also persists the error to the session."""
         # Both paths should have _error persistence
         count = streaming_src.count("'_error': True")
-        assert count >= 2, f"Expected at least 2 _error persistence sites, found {count}"
+        assert count >= 2, (
+            f"Expected at least 2 _error persistence sites, found {count}"
+        )
 
     def test_sanitize_skips_error_messages(self):
         """_sanitize_messages_for_api must not send _error messages to the LLM."""
-        assert "msg.get('_error')" in streaming_src or 'msg.get("_error")' in streaming_src
+        assert (
+            "msg.get('_error')" in streaming_src or 'msg.get("_error")' in streaming_src
+        )
         # The skip must come before the role/tool filtering logic
         error_skip_pos = streaming_src.find("msg.get('_error')")
         tool_filter_pos = streaming_src.find("if role == 'tool':")
-        assert error_skip_pos < tool_filter_pos, \
+        assert error_skip_pos < tool_filter_pos, (
             "_error skip must appear before the tool-role filter in _sanitize_messages_for_api"
+        )
 
 
 # ── #652/#653: Context compaction stream_end fix ──────────────────────────────
+
 
 class TestStreamEndSessionId:
     """stream_end must use the original session_id param, not s.session_id."""
@@ -114,8 +125,9 @@ class TestStreamEndSessionId:
         """s.session_id (which may be rotated after compaction) must not appear in stream_end."""
         # Find all stream_end emissions and verify none use s.session_id
         for match in re.finditer(r"put[_a-z]*\('stream_end',[^)]+\)", streaming_src):
-            assert 's.session_id' not in match.group(), \
+            assert "s.session_id" not in match.group(), (
                 f"stream_end uses s.session_id (may be rotated): {match.group()}"
+            )
 
     def test_title_event_uses_original_session_id(self):
         """title event in background title thread uses original session_id, not s.session_id."""

--- a/tests/test_issue744.py
+++ b/tests/test_issue744.py
@@ -6,4 +6,3 @@ def test_only_latest_user_message_gets_edit_button():
     assert "let lastUserRawIdx=-1;" in src
     assert "const isEditableUser=isUser&&rawIdx===lastUserRawIdx;" in src
     assert "const editBtn  = isEditableUser ?" in src
-

--- a/tests/test_issue765_streaming_persistence.py
+++ b/tests/test_issue765_streaming_persistence.py
@@ -7,6 +7,7 @@ Validates:
     (as it would be by on_tool() during real agent execution)
   - Messages stored via pending_user_message survive a simulated server restart
 """
+
 import json
 import threading
 import time
@@ -67,7 +68,9 @@ class TestSaveSkipIndex:
         s = _make_session("s3")
         s.save(skip_index=True)
         index = models.SESSION_INDEX_FILE
-        assert not index.exists(), "Index file should not be created with skip_index=True"
+        assert not index.exists(), (
+            "Index file should not be created with skip_index=True"
+        )
 
     def test_save_without_skip_index_creates_index(self):
         """save() (default) DOES create the session index."""
@@ -153,10 +156,14 @@ class TestPeriodicCheckpoint:
 
         # Simulate on_tool() completing twice
         _checkpoint_activity[0] += 1  # first tool completes
-        assert _wait_for_save(1), f"Expected 1 save after first increment; got {save_count[0]}"
+        assert _wait_for_save(1), (
+            f"Expected 1 save after first increment; got {save_count[0]}"
+        )
 
         _checkpoint_activity[0] += 1  # second tool completes
-        assert _wait_for_save(2), f"Expected 2 saves after second increment; got {save_count[0]}"
+        assert _wait_for_save(2), (
+            f"Expected 2 saves after second increment; got {save_count[0]}"
+        )
 
         stop_event.set()
         t.join(timeout=2)
@@ -221,7 +228,9 @@ class TestPeriodicCheckpoint:
         This is the minimal guarantee for Issue #765: even if the agent produces
         no tool calls before a crash, the user's message is not silently lost.
         """
-        s = _make_session("survive1", messages=[{"role": "user", "content": "first turn"}])
+        s = _make_session(
+            "survive1", messages=[{"role": "user", "content": "first turn"}]
+        )
         s.save()  # initial full save
 
         # Simulate what routes.py does before _run_agent_streaming:
@@ -314,7 +323,9 @@ class TestIssue765FollowupHardening:
         t2.join(timeout=5)
 
         assert not errors, f"Concurrent same-session saves should not fail: {errors}"
-        assert len(replace_sources) == 2, f"Expected 2 replace calls, got {replace_sources}"
+        assert len(replace_sources) == 2, (
+            f"Expected 2 replace calls, got {replace_sources}"
+        )
         assert len(set(replace_sources)) == 2, (
             "Concurrent same-session saves must use distinct temp files; "
             f"got {replace_sources}"
@@ -331,8 +342,12 @@ class TestIssue765FollowupHardening:
         src = (Path(__file__).parent.parent / "api" / "streaming.py").read_text(
             encoding="utf-8"
         )
-        stop_idx = src.find("if _checkpoint_stop is not None:\n                _checkpoint_stop.set()")
-        join_idx = src.find("if _ckpt_thread is not None:\n                _ckpt_thread.join(timeout=15)")
+        stop_idx = src.find(
+            "if _checkpoint_stop is not None:\n                _checkpoint_stop.set()"
+        )
+        join_idx = src.find(
+            "if _ckpt_thread is not None:\n                _ckpt_thread.join(timeout=15)"
+        )
         lock_idx = src.find("with _agent_lock:\n                _result_messages =")
         save_idx = src.find("s.context_messages = _next_context_messages")
 
@@ -353,7 +368,9 @@ class TestIssue765FollowupHardening:
         src = (Path(__file__).parent.parent / "api" / "streaming.py").read_text(
             encoding="utf-8"
         )
-        outer_lock_idx = src.find("with _agent_lock:\n                _result_messages =")
+        outer_lock_idx = src.find(
+            "with _agent_lock:\n                _result_messages ="
+        )
         silent_failure_idx = src.find("if not _assistant_added and not _token_sent:")
         inner_lock_idx = src.find("with _agent_lock:", outer_lock_idx + 1)
         compression_idx = src.find("# ── Handle context compression side effects ──")
@@ -362,7 +379,8 @@ class TestIssue765FollowupHardening:
         assert silent_failure_idx != -1, "Silent-failure branch not found"
         assert compression_idx != -1, "Compression marker not found"
         assert not (
-            inner_lock_idx != -1 and silent_failure_idx < inner_lock_idx < compression_idx
+            inner_lock_idx != -1
+            and silent_failure_idx < inner_lock_idx < compression_idx
         ), "Silent-failure path must not reacquire _agent_lock inside the outer lock"
 
     def test_checkpoint_stop_initialised_before_any_raiseable_code(self):
@@ -373,7 +391,8 @@ class TestIssue765FollowupHardening:
         )
         lines = src.splitlines()
         try_line = next(
-            i for i, ln in enumerate(lines, 1)
+            i
+            for i, ln in enumerate(lines, 1)
             if ln.rstrip().endswith("try:")
             and any(
                 lines[j].strip().startswith("_checkpoint_stop = None")
@@ -383,8 +402,7 @@ class TestIssue765FollowupHardening:
         # The assignment must precede the `try:` — not sit inside the nested
         # block where an earlier line could raise before it runs.
         init_line = next(
-            i for i, ln in enumerate(lines, 1)
-            if "_checkpoint_stop = None" in ln
+            i for i, ln in enumerate(lines, 1) if "_checkpoint_stop = None" in ln
         )
         assert init_line < try_line, (
             f"_checkpoint_stop = None (line {init_line}) must precede the outer "
@@ -441,7 +459,7 @@ class TestIssue765FollowupHardening:
         # Find the _periodic_checkpoint function
         ckpt_idx = src.find("def _periodic_checkpoint():")
         assert ckpt_idx != -1, "_periodic_checkpoint function not found"
-        ckpt_block = src[ckpt_idx:ckpt_idx + 600]
+        ckpt_block = src[ckpt_idx : ckpt_idx + 600]
         assert "with _agent_lock:" in ckpt_block, (
             "_periodic_checkpoint must hold _agent_lock while calling s.save() "
             "to prevent race conditions with other session-mutating endpoints"
@@ -459,7 +477,7 @@ class TestIssue765FollowupHardening:
         )
         fn_idx = src.find("def _run_background_title_update(")
         assert fn_idx != -1, "_run_background_title_update not found"
-        fn_block = src[fn_idx:fn_idx + 3200]
+        fn_block = src[fn_idx : fn_idx + 3200]
         assert "with LOCK:" in fn_block, (
             "_run_background_title_update must acquire LOCK before rebinding "
             "to canonical cached session instance"
@@ -481,7 +499,7 @@ class TestIssue765FollowupHardening:
         # Find the session cleanup section
         cleanup_idx = cancel_block.find("Session cleanup outside STREAMS_LOCK")
         assert cleanup_idx != -1, "Session cleanup comment not found in cancel_stream"
-        cleanup_section = cancel_block[cleanup_idx:cleanup_idx + 800]
+        cleanup_section = cancel_block[cleanup_idx : cleanup_idx + 800]
         assert "_get_session_agent_lock" in cleanup_section, (
             "cancel_stream must acquire _get_session_agent_lock during "
             "session cleanup to serialise with the checkpoint thread and "
@@ -501,13 +519,15 @@ class TestIssue765FollowupHardening:
         for func_name in ("retry_last", "undo_last"):
             func_idx = src.find(f"def {func_name}(")
             assert func_idx != -1, f"{func_name} not found in session_ops.py"
-            func_block = src[func_idx:func_idx + 1200]
+            func_block = src[func_idx : func_idx + 1200]
             assert "with _get_session_agent_lock" in func_block, (
                 f"{func_name} must wrap its read-modify-save cycle in "
                 f"with _get_session_agent_lock(session_id)"
             )
 
-    def test_periodic_checkpoint_mutation_race_with_undo_last(self, tmp_path, monkeypatch):
+    def test_periodic_checkpoint_mutation_race_with_undo_last(
+        self, tmp_path, monkeypatch
+    ):
         """Run _periodic_checkpoint against a session whose messages list is
         concurrently truncated by undo_last; the on-disk JSON must remain
         parseable and internally consistent.
@@ -548,6 +568,7 @@ class TestIssue765FollowupHardening:
             _lock = threading.Lock()
 
             from api.config import _get_session_agent_lock
+
             _agent_lock = _get_session_agent_lock("race_test")
 
             def _periodic_checkpoint():
@@ -573,6 +594,7 @@ class TestIssue765FollowupHardening:
             t.start()
 
             from api.session_ops import undo_last
+
             # Collect the allowed message snapshots (each state the session
             # is in at a point where a checkpoint might observe it).
             allowed_message_snapshots = []
@@ -628,14 +650,16 @@ class TestIssue765FollowupHardening:
                 # Normalize for comparison (strip display-only metadata)
                 normalized = [
                     {k: v for k, v in m.items() if k in ("role", "content")}
-                    if isinstance(m, dict) else m
+                    if isinstance(m, dict)
+                    else m
                     for m in snap_msgs
                 ]
                 matched = False
                 for allowed in allowed_message_snapshots:
                     norm_allowed = [
                         {k: v for k, v in m.items() if k in ("role", "content")}
-                        if isinstance(m, dict) else m
+                        if isinstance(m, dict)
+                        else m
                         for m in allowed
                     ]
                     if normalized == norm_allowed:
@@ -649,7 +673,9 @@ class TestIssue765FollowupHardening:
         finally:
             models.SESSIONS.clear()
 
-    def test_cancel_stream_concurrent_checkpoint_produces_valid_json(self, tmp_path, monkeypatch):
+    def test_cancel_stream_concurrent_checkpoint_produces_valid_json(
+        self, tmp_path, monkeypatch
+    ):
         """Run cancel_stream while a _periodic_checkpoint thread is concurrently
         saving the same session; the resulting on-disk JSON must be parseable
         and active_stream_id must be None.
@@ -686,6 +712,7 @@ class TestIssue765FollowupHardening:
             _snap_lock = threading.Lock()
 
             from api.config import _get_session_agent_lock
+
             _agent_lock = _get_session_agent_lock("cancel_race")
 
             def _periodic_checkpoint():
@@ -765,7 +792,10 @@ class TestIssue765FollowupHardening:
                         "pending_user_message=None (atomic cancel cleanup "
                         "under _agent_lock)"
                     )
-                    assert snap.get("pending_attachments") == [] or snap.get("pending_attachments") is None, (
+                    assert (
+                        snap.get("pending_attachments") == []
+                        or snap.get("pending_attachments") is None
+                    ), (
                         "Snapshot with active_stream_id=None must also have "
                         "empty pending_attachments (atomic cancel cleanup "
                         "under _agent_lock)"
@@ -791,6 +821,7 @@ class TestIssue765FollowupHardening:
             SESSION_AGENT_LOCKS,
             SESSION_AGENT_LOCKS_LOCK,
         )
+
         old_sid = "pre-rotation-id"
         new_sid = "post-rotation-id"
 
@@ -835,6 +866,7 @@ class TestIssue765FollowupHardening:
             SESSION_AGENT_LOCKS,
             SESSION_AGENT_LOCKS_LOCK,
         )
+
         old_sid = "pre-rotation-pruned"
         new_sid = "post-rotation-pruned"
 

--- a/tests/test_issue789.py
+++ b/tests/test_issue789.py
@@ -13,6 +13,7 @@ from the sidebar **regardless of age** — no grace window. The button guard
 out of typing into a fresh session, but the sidebar list never surfaces empty
 ones. These tests reflect the new contract.
 """
+
 import json
 import time
 
@@ -72,6 +73,7 @@ def _make_titled_session(age_seconds, session_id=None):
 
 # ── Test 1: Untitled 0-message sessions are hidden regardless of age (#1171) ─
 
+
 def test_new_untitled_session_is_hidden_from_sidebar():
     """A brand-new (0 s old) Untitled 0-message session must NOT appear (#1171).
 
@@ -102,6 +104,7 @@ def test_recent_untitled_session_under_60s_is_hidden():
 
 # ── Test 2: old Untitled 0-message session is still filtered ─────────────────
 
+
 def test_old_untitled_session_over_60s_is_filtered():
     """A ghost session (Untitled, 0 messages, >60 s old) must be hidden."""
     old_session = _make_untitled_session(age_seconds=120)
@@ -127,6 +130,7 @@ def test_session_exactly_at_boundary_is_filtered():
 
 
 # ── Test 3: session with messages is always visible regardless of age ─────────
+
 
 def test_session_with_messages_always_visible_new():
     """A session with messages (even Untitled) is always visible when new."""
@@ -185,6 +189,7 @@ def test_titled_session_with_no_messages_old_is_visible():
 
 
 # ── Test 4: mixed bag — only old Untitled empty sessions are filtered ─────────
+
 
 def test_mixed_sessions_correct_visibility():
     """With a mix of sessions, only sessions with messages OR titled sessions

--- a/tests/test_issue798.py
+++ b/tests/test_issue798.py
@@ -17,32 +17,34 @@ import threading
 from pathlib import Path
 from unittest.mock import patch
 
-import pytest
-
 
 # ── R19: get_hermes_home_for_profile ─────────────────────────────────────────
+
 
 def test_get_hermes_home_for_profile_returns_default_for_none():
     """R19a: None / empty string / 'default' all return the base home."""
     import api.profiles as p
+
     base = p._DEFAULT_HERMES_HOME
     assert p.get_hermes_home_for_profile(None) == base
-    assert p.get_hermes_home_for_profile('') == base
-    assert p.get_hermes_home_for_profile('default') == base
+    assert p.get_hermes_home_for_profile("") == base
+    assert p.get_hermes_home_for_profile("default") == base
 
 
 def test_get_hermes_home_for_profile_returns_profile_subdir(tmp_path, monkeypatch):
     """R19b: Named profile that exists returns its subdirectory."""
     import api.profiles as p
 
-    profile_dir = tmp_path / 'profiles' / 'alice'
+    profile_dir = tmp_path / "profiles" / "alice"
     profile_dir.mkdir(parents=True)
-    monkeypatch.setattr(p, '_DEFAULT_HERMES_HOME', tmp_path)
-    result = p.get_hermes_home_for_profile('alice')
+    monkeypatch.setattr(p, "_DEFAULT_HERMES_HOME", tmp_path)
+    result = p.get_hermes_home_for_profile("alice")
     assert result == profile_dir
 
 
-def test_get_hermes_home_for_profile_returns_profile_path_for_missing_profile(tmp_path, monkeypatch):
+def test_get_hermes_home_for_profile_returns_profile_path_for_missing_profile(
+    tmp_path, monkeypatch
+):
     """R19c: Named profile that does not exist on disk now returns the
     profile-scoped path (created on first use by the agent layer), NOT the
     base home. Tightened in v0.50.251 / PR #1373 to fix #1195: the previous
@@ -51,9 +53,9 @@ def test_get_hermes_home_for_profile_returns_profile_path_for_missing_profile(tm
     Path traversal is still blocked by the _PROFILE_ID_RE regex (R19j)."""
     import api.profiles as p
 
-    monkeypatch.setattr(p, '_DEFAULT_HERMES_HOME', tmp_path)
-    result = p.get_hermes_home_for_profile('ghost')
-    assert result == tmp_path / 'profiles' / 'ghost'
+    monkeypatch.setattr(p, "_DEFAULT_HERMES_HOME", tmp_path)
+    result = p.get_hermes_home_for_profile("ghost")
+    assert result == tmp_path / "profiles" / "ghost"
 
 
 def test_get_hermes_home_for_profile_does_not_mutate_globals():
@@ -61,20 +63,20 @@ def test_get_hermes_home_for_profile_does_not_mutate_globals():
     import api.profiles as p
 
     before_active = p._active_profile
-    before_hermes_home = os.environ.get('HERMES_HOME')
+    before_hermes_home = os.environ.get("HERMES_HOME")
 
-    p.get_hermes_home_for_profile('some-other-profile')
+    p.get_hermes_home_for_profile("some-other-profile")
 
     assert p._active_profile == before_active, (
         "get_hermes_home_for_profile() must not mutate _active_profile"
     )
-    assert os.environ.get('HERMES_HOME') == before_hermes_home, (
+    assert os.environ.get("HERMES_HOME") == before_hermes_home, (
         "get_hermes_home_for_profile() must not mutate os.environ['HERMES_HOME']"
     )
 
 
 def _run_profile_resolution_probe(env):
-    script = r'''
+    script = r"""
 import json
 from pathlib import Path
 import api.profiles as p
@@ -97,9 +99,9 @@ print(json.dumps({
     'explicit_bar_home': str(explicit_bar_home),
     'active_bar_home': str(active_bar_home),
 }))
-'''
+"""
     result = subprocess.run(
-        [sys.executable, '-c', script],
+        [sys.executable, "-c", script],
         cwd=Path(__file__).parent.parent,
         env=env,
         text=True,
@@ -119,31 +121,35 @@ def test_hermes_base_home_named_profile_matches_cookie_without_doubling(tmp_path
     /base/profiles/foo/profiles/foo path — even if that nested path already
     exists from a prior bad write.
     """
-    profile_home = tmp_path / 'profiles' / 'foo'
-    doubled_home = profile_home / 'profiles' / 'foo'
+    profile_home = tmp_path / "profiles" / "foo"
+    doubled_home = profile_home / "profiles" / "foo"
     doubled_home.mkdir(parents=True)
-    profile_home.joinpath('config.yaml').write_text(
-        'terminal:\n  cwd: /expected/profile-home\n', encoding='utf-8'
+    profile_home.joinpath("config.yaml").write_text(
+        "terminal:\n  cwd: /expected/profile-home\n", encoding="utf-8"
     )
-    doubled_home.joinpath('config.yaml').write_text(
-        'terminal:\n  cwd: /wrong/doubled-home\n', encoding='utf-8'
+    doubled_home.joinpath("config.yaml").write_text(
+        "terminal:\n  cwd: /wrong/doubled-home\n", encoding="utf-8"
     )
 
     env = os.environ.copy()
-    env.update({
-        'HERMES_BASE_HOME': str(profile_home),
-        'HERMES_HOME': str(profile_home),
-    })
+    env.update(
+        {
+            "HERMES_BASE_HOME": str(profile_home),
+            "HERMES_HOME": str(profile_home),
+        }
+    )
     data = _run_profile_resolution_probe(env)
 
-    assert data['default_home'] == str(tmp_path)
-    assert data['foo_home'] == str(profile_home)
-    assert data['explicit_foo_home'] == str(profile_home)
-    assert data['foo_terminal_cwd'] == '/expected/profile-home'
-    assert data['model_home'] == str(profile_home)
+    assert data["default_home"] == str(tmp_path)
+    assert data["foo_home"] == str(profile_home)
+    assert data["explicit_foo_home"] == str(profile_home)
+    assert data["foo_terminal_cwd"] == "/expected/profile-home"
+    assert data["model_home"] == str(profile_home)
 
 
-def test_hermes_base_home_named_profile_nonmatching_cookie_uses_sibling_profile_path(tmp_path):
+def test_hermes_base_home_named_profile_nonmatching_cookie_uses_sibling_profile_path(
+    tmp_path,
+):
     """R19l / #749: non-matching cookies must not silently route to the pinned home.
 
     When HERMES_BASE_HOME is supplied as /base/profiles/foo but the request asks
@@ -151,16 +157,16 @@ def test_hermes_base_home_named_profile_nonmatching_cookie_uses_sibling_profile_
     sibling /base/profiles/bar.  It must not fall back to foo, and it must not
     append bar under foo/profiles/bar.
     """
-    profile_home = tmp_path / 'profiles' / 'foo'
+    profile_home = tmp_path / "profiles" / "foo"
     profile_home.mkdir(parents=True)
 
     env = os.environ.copy()
-    env.update({'HERMES_BASE_HOME': str(profile_home)})
+    env.update({"HERMES_BASE_HOME": str(profile_home)})
     data = _run_profile_resolution_probe(env)
 
-    expected_bar_home = tmp_path / 'profiles' / 'bar'
-    assert data['explicit_bar_home'] == str(expected_bar_home)
-    assert data['active_bar_home'] == str(expected_bar_home)
+    expected_bar_home = tmp_path / "profiles" / "bar"
+    assert data["explicit_bar_home"] == str(expected_bar_home)
+    assert data["active_bar_home"] == str(expected_bar_home)
 
 
 # ── R19e-h: new_session() profile isolation ───────────────────────────────────
@@ -168,6 +174,7 @@ def test_hermes_base_home_named_profile_nonmatching_cookie_uses_sibling_profile_
 # to SESSION_DIR which is set from HERMES_WEBUI_STATE_DIR at import time and may
 # point to a test-scoped tmp dir that has already been torn down.  We patch save()
 # to a no-op — the tests only care about s.profile, not persistence.
+
 
 def test_new_session_uses_explicit_profile_not_global():
     """R19e: new_session(profile='alice') stamps session.profile='alice' even when
@@ -179,10 +186,10 @@ def test_new_session_uses_explicit_profile_not_global():
 
     original = p._active_profile
     try:
-        p._active_profile = 'default'
-        with patch.object(m.Session, 'save', return_value=None):
-            s = m.new_session(profile='alice')
-        assert s.profile == 'alice', (
+        p._active_profile = "default"
+        with patch.object(m.Session, "save", return_value=None):
+            s = m.new_session(profile="alice")
+        assert s.profile == "alice", (
             f"Expected s.profile='alice', got {s.profile!r}. "
             "new_session() should use the explicit profile param, not the global."
         )
@@ -197,10 +204,10 @@ def test_new_session_falls_back_to_global_when_profile_not_supplied():
 
     original = p._active_profile
     try:
-        p._active_profile = 'default'
-        with patch.object(m.Session, 'save', return_value=None):
+        p._active_profile = "default"
+        with patch.object(m.Session, "save", return_value=None):
             s = m.new_session()
-        assert s.profile == 'default'
+        assert s.profile == "default"
     finally:
         p._active_profile = original
 
@@ -212,10 +219,10 @@ def test_new_session_none_profile_falls_back_to_global():
 
     original = p._active_profile
     try:
-        p._active_profile = 'default'
-        with patch.object(m.Session, 'save', return_value=None):
+        p._active_profile = "default"
+        with patch.object(m.Session, "save", return_value=None):
             s = m.new_session(profile=None)
-        assert s.profile == 'default'
+        assert s.profile == "default"
     finally:
         p._active_profile = original
 
@@ -243,24 +250,31 @@ def test_concurrent_new_sessions_get_correct_profiles():
         except Exception as exc:
             errors.append(exc)
 
-    with patch.object(m.Session, 'save', return_value=None):
-        t1 = threading.Thread(target=make_session, args=('alice', 'alice'))
-        t2 = threading.Thread(target=make_session, args=('bob', 'bob'))
-        t1.start(); t2.start()
-        t1.join(timeout=5); t2.join(timeout=5)
+    with patch.object(m.Session, "save", return_value=None):
+        t1 = threading.Thread(target=make_session, args=("alice", "alice"))
+        t2 = threading.Thread(target=make_session, args=("bob", "bob"))
+        t1.start()
+        t2.start()
+        t1.join(timeout=5)
+        t2.join(timeout=5)
 
     assert not errors, f"Threads raised: {errors}"
-    assert results.get('alice') == 'alice', f"alice session had profile {results.get('alice')!r}"
-    assert results.get('bob') == 'bob', f"bob session had profile {results.get('bob')!r}"
+    assert results.get("alice") == "alice", (
+        f"alice session had profile {results.get('alice')!r}"
+    )
+    assert results.get("bob") == "bob", (
+        f"bob session had profile {results.get('bob')!r}"
+    )
 
 
 # ── R19i: sessions.js sends profile in the POST body ─────────────────────────
 
+
 def test_sessions_js_sends_profile_in_new_session_post():
     """R19i: sessions.js newSession() must include profile:S.activeProfile in the
     JSON body sent to /api/session/new — the client-side half of the #798 fix."""
-    js = (Path(__file__).parent.parent / 'static' / 'sessions.js').read_text()
-    assert 'profile:S.activeProfile' in js or 'profile: S.activeProfile' in js, (
+    js = (Path(__file__).parent.parent / "static" / "sessions.js").read_text()
+    assert "profile:S.activeProfile" in js or "profile: S.activeProfile" in js, (
         "sessions.js newSession() must send profile: S.activeProfile in the POST body "
         "so the server uses the tab's active profile, not the process global."
     )
@@ -273,28 +287,31 @@ def test_get_hermes_home_for_profile_rejects_path_traversal():
     is the SOLE guard against path traversal — verify each known-bad shape
     still returns the base home, not a traversed path."""
     import api.profiles as p
+
     base = p._DEFAULT_HERMES_HOME
-    assert p.get_hermes_home_for_profile('../../etc') == base
-    assert p.get_hermes_home_for_profile('../escape') == base
-    assert p.get_hermes_home_for_profile('/absolute/path') == base
-    assert p.get_hermes_home_for_profile('has spaces') == base
-    assert p.get_hermes_home_for_profile('UPPERCASE') == base
+    assert p.get_hermes_home_for_profile("../../etc") == base
+    assert p.get_hermes_home_for_profile("../escape") == base
+    assert p.get_hermes_home_for_profile("/absolute/path") == base
+    assert p.get_hermes_home_for_profile("has spaces") == base
+    assert p.get_hermes_home_for_profile("UPPERCASE") == base
     # Valid names now route to the profile-scoped path (created on first use).
     # Previously these returned `base` because no profile dir existed on disk.
-    assert p.get_hermes_home_for_profile('alice') == base / 'profiles' / 'alice'
-    assert p.get_hermes_home_for_profile('my-profile') == base / 'profiles' / 'my-profile'
-    assert p.get_hermes_home_for_profile('profile_1') == base / 'profiles' / 'profile_1'
+    assert p.get_hermes_home_for_profile("alice") == base / "profiles" / "alice"
+    assert (
+        p.get_hermes_home_for_profile("my-profile") == base / "profiles" / "my-profile"
+    )
+    assert p.get_hermes_home_for_profile("profile_1") == base / "profiles" / "profile_1"
     # R19j coverage gaps closed in v0.50.251 per Opus pre-release review:
     # - Trailing-newline names must be rejected (re.match would let them through;
     #   re.fullmatch correctly anchors $). Catches the match-vs-fullmatch footgun.
-    assert p.get_hermes_home_for_profile('valid\n') == base
-    assert p.get_hermes_home_for_profile('a\n') == base
+    assert p.get_hermes_home_for_profile("valid\n") == base
+    assert p.get_hermes_home_for_profile("a\n") == base
     # - Length boundaries: 64 chars (max valid: 1 + 63 suffix) routes to profile path,
     #   65 chars rejected.
-    assert p.get_hermes_home_for_profile('a' * 64) == base / 'profiles' / ('a' * 64)
-    assert p.get_hermes_home_for_profile('a' * 65) == base
+    assert p.get_hermes_home_for_profile("a" * 64) == base / "profiles" / ("a" * 64)
+    assert p.get_hermes_home_for_profile("a" * 65) == base
     # - Single-char name is the minimum valid form.
-    assert p.get_hermes_home_for_profile('a') == base / 'profiles' / 'a'
+    assert p.get_hermes_home_for_profile("a") == base / "profiles" / "a"
     # - Non-ASCII / Unicode-trick names are rejected by the ASCII-only charset.
-    assert p.get_hermes_home_for_profile('voilà') == base
-    assert p.get_hermes_home_for_profile('名前') == base
+    assert p.get_hermes_home_for_profile("voilà") == base
+    assert p.get_hermes_home_for_profile("名前") == base

--- a/tests/test_issue803.py
+++ b/tests/test_issue803.py
@@ -13,62 +13,75 @@ Covers:
   4. switch_profile(process_wide=False) does NOT mutate process globals
   5. Concurrent requests on different threads see independent profiles
 """
+
 import os
 import threading
-from pathlib import Path
 from unittest.mock import MagicMock
-
-import pytest
 
 
 # ── 1. Cookie build/parse roundtrip ──────────────────────────────────────────
 
-class TestProfileCookieHelpers:
 
+class TestProfileCookieHelpers:
     def test_build_profile_cookie_sets_value(self):
         from api.helpers import build_profile_cookie
-        s = build_profile_cookie('alice')
-        assert 'hermes_profile=alice' in s
-        assert 'HttpOnly' in s
-        assert 'SameSite=Lax' in s
-        assert 'Path=/' in s
+
+        s = build_profile_cookie("alice")
+        assert "hermes_profile=alice" in s
+        assert "HttpOnly" in s
+        assert "SameSite=Lax" in s
+        assert "Path=/" in s
 
     def test_build_profile_cookie_default_persists(self):
         from api.helpers import build_profile_cookie
-        s = build_profile_cookie('default')
-        assert 'hermes_profile=default' in s
-        assert 'Max-Age=0' not in s
+
+        s = build_profile_cookie("default")
+        assert "hermes_profile=default" in s
+        assert "Max-Age=0" not in s
 
     def test_get_profile_cookie_returns_none_when_absent(self):
         from api.helpers import get_profile_cookie
+
         handler = MagicMock()
-        handler.headers.get = lambda k, d='': ''
+        handler.headers.get = lambda k, d="": ""
         assert get_profile_cookie(handler) is None
 
     def test_get_profile_cookie_extracts_valid_name(self):
         from api.helpers import get_profile_cookie
+
         handler = MagicMock()
-        handler.headers.get = lambda k, d='': 'hermes_profile=alice' if k == 'Cookie' else d
-        assert get_profile_cookie(handler) == 'alice'
+        handler.headers.get = lambda k, d="": (
+            "hermes_profile=alice" if k == "Cookie" else d
+        )
+        assert get_profile_cookie(handler) == "alice"
 
     def test_get_profile_cookie_accepts_default(self):
         from api.helpers import get_profile_cookie
+
         handler = MagicMock()
-        handler.headers.get = lambda k, d='': 'hermes_profile=default' if k == 'Cookie' else d
-        assert get_profile_cookie(handler) == 'default'
+        handler.headers.get = lambda k, d="": (
+            "hermes_profile=default" if k == "Cookie" else d
+        )
+        assert get_profile_cookie(handler) == "default"
 
     def test_get_profile_cookie_rejects_injection(self):
         """Cookie value must pass _PROFILE_ID_RE fullmatch — rejects traversal/injection."""
         from api.helpers import get_profile_cookie
-        for bad in ('../etc', 'a/b', 'name;DROP', 'WithCaps', 'has space', '.hidden'):
+
+        for bad in ("../etc", "a/b", "name;DROP", "WithCaps", "has space", ".hidden"):
             handler = MagicMock()
-            handler.headers.get = lambda k, d='', v=bad: f'hermes_profile={v}' if k == 'Cookie' else d
+            handler.headers.get = lambda k, d="", v=bad: (
+                f"hermes_profile={v}" if k == "Cookie" else d
+            )
             assert get_profile_cookie(handler) is None, f"{bad!r} should be rejected"
 
     def test_get_profile_cookie_ignores_malformed_header(self):
         from api.helpers import get_profile_cookie
+
         handler = MagicMock()
-        handler.headers.get = lambda k, d='': '\x00\x01not-a-cookie' if k == 'Cookie' else d
+        handler.headers.get = lambda k, d="": (
+            "\x00\x01not-a-cookie" if k == "Cookie" else d
+        )
         # Must not raise; returns None
         result = get_profile_cookie(handler)
         assert result is None
@@ -76,64 +89,69 @@ class TestProfileCookieHelpers:
     def test_profile_cookie_name_defaults_to_hermes_profile(self, monkeypatch):
         from api.helpers import build_profile_cookie
 
-        monkeypatch.delenv('WEBUI_PROFILE_COOKIE_NAME', raising=False)
+        monkeypatch.delenv("WEBUI_PROFILE_COOKIE_NAME", raising=False)
 
-        s = build_profile_cookie('alice')
-        assert 'hermes_profile=alice' in s
+        s = build_profile_cookie("alice")
+        assert "hermes_profile=alice" in s
 
     def test_profile_cookie_name_can_be_isolated_per_webui_instance(self, monkeypatch):
         from api.helpers import build_profile_cookie, get_profile_cookie
 
-        monkeypatch.setenv('WEBUI_PROFILE_COOKIE_NAME', 'hermes_profile_social')
+        monkeypatch.setenv("WEBUI_PROFILE_COOKIE_NAME", "hermes_profile_social")
 
-        s = build_profile_cookie('writer')
-        assert 'hermes_profile_social=writer' in s
-        assert 'hermes_profile=writer' not in s
+        s = build_profile_cookie("writer")
+        assert "hermes_profile_social=writer" in s
+        assert "hermes_profile=writer" not in s
 
         handler = MagicMock()
-        handler.headers.get = lambda k, d='': (
-            'hermes_profile=wrong; hermes_profile_social=writer' if k == 'Cookie' else d
+        handler.headers.get = lambda k, d="": (
+            "hermes_profile=wrong; hermes_profile_social=writer" if k == "Cookie" else d
         )
-        assert get_profile_cookie(handler) == 'writer'
+        assert get_profile_cookie(handler) == "writer"
 
     def test_configured_profile_cookie_ignores_default_cookie_name(self, monkeypatch):
         from api.helpers import get_profile_cookie
 
-        monkeypatch.setenv('WEBUI_PROFILE_COOKIE_NAME', 'hermes_profile_main')
+        monkeypatch.setenv("WEBUI_PROFILE_COOKIE_NAME", "hermes_profile_main")
 
         handler = MagicMock()
-        handler.headers.get = lambda k, d='': 'hermes_profile=social_profile' if k == 'Cookie' else d
+        handler.headers.get = lambda k, d="": (
+            "hermes_profile=social_profile" if k == "Cookie" else d
+        )
         assert get_profile_cookie(handler) is None
 
 
 # ── 2. Thread-local request context ──────────────────────────────────────────
 
-class TestThreadLocalProfileContext:
 
+class TestThreadLocalProfileContext:
     def test_tls_takes_priority_over_global(self):
         import api.profiles as p
+
         original = p._active_profile
         try:
-            p._active_profile = 'global-default'
-            p.set_request_profile('alice')
-            assert p.get_active_profile_name() == 'alice'
+            p._active_profile = "global-default"
+            p.set_request_profile("alice")
+            assert p.get_active_profile_name() == "alice"
         finally:
             p.clear_request_profile()
             p._active_profile = original
 
     def test_global_used_when_tls_cleared(self):
         import api.profiles as p
+
         original = p._active_profile
         try:
-            p._active_profile = 'global-default'
-            p.set_request_profile('alice')
+            p._active_profile = "global-default"
+            p.set_request_profile("alice")
             p.clear_request_profile()
-            assert p.get_active_profile_name() == 'global-default'
+            assert p.get_active_profile_name() == "global-default"
         finally:
             p._active_profile = original
 
     def test_clear_is_idempotent(self):
         import api.profiles as p
+
         # Calling clear on a thread that never set anything must not raise
         p.clear_request_profile()
         p.clear_request_profile()
@@ -141,15 +159,17 @@ class TestThreadLocalProfileContext:
 
 # ── 3. get_active_hermes_home routes through TLS ─────────────────────────────
 
+
 def test_get_active_hermes_home_respects_tls(tmp_path, monkeypatch):
     import api.profiles as p
-    monkeypatch.setattr(p, '_DEFAULT_HERMES_HOME', tmp_path)
-    profile_dir = tmp_path / 'profiles' / 'alice'
+
+    monkeypatch.setattr(p, "_DEFAULT_HERMES_HOME", tmp_path)
+    profile_dir = tmp_path / "profiles" / "alice"
     profile_dir.mkdir(parents=True)
     try:
-        p.set_request_profile('alice')
+        p.set_request_profile("alice")
         assert p.get_active_hermes_home() == profile_dir
-        p.set_request_profile('default')
+        p.set_request_profile("default")
         assert p.get_active_hermes_home() == tmp_path
     finally:
         p.clear_request_profile()
@@ -157,25 +177,26 @@ def test_get_active_hermes_home_respects_tls(tmp_path, monkeypatch):
 
 # ── 4. switch_profile(process_wide=False) does not mutate globals ─────────────
 
+
 def test_switch_profile_process_wide_false_does_not_mutate_global():
     """Per-client switches from the WebUI must leave _active_profile untouched."""
     import api.profiles as p
 
     # Monkey in a fake profile listing so switch_profile finds 'alice'
     original_global = p._active_profile
-    original_env_home = os.environ.get('HERMES_HOME')
+    original_env_home = os.environ.get("HERMES_HOME")
 
     # We need a profile that exists to get past the validation path.
     # Use 'default' — switch_profile accepts it without requiring hermes_cli.
     try:
-        result = p.switch_profile('default', process_wide=False)
+        result = p.switch_profile("default", process_wide=False)
         # Global must not change
         assert p._active_profile == original_global, (
             f"process_wide=False must not mutate _active_profile "
             f"(was {original_global!r}, now {p._active_profile!r})"
         )
         # HERMES_HOME env must not change
-        assert os.environ.get('HERMES_HOME') == original_env_home, (
+        assert os.environ.get("HERMES_HOME") == original_env_home, (
             "process_wide=False must not mutate os.environ['HERMES_HOME']"
         )
         # Response still shape-compatible
@@ -185,6 +206,7 @@ def test_switch_profile_process_wide_false_does_not_mutate_global():
 
 
 # ── 5. Concurrent threads see independent profile context ────────────────────
+
 
 def test_concurrent_threads_see_independent_profiles():
     """The whole point of thread-local isolation: two threads, two cookies,
@@ -205,11 +227,13 @@ def test_concurrent_threads_see_independent_profiles():
         except Exception as exc:
             errors.append(exc)
 
-    t1 = threading.Thread(target=worker, args=('alice', 'alice'))
-    t2 = threading.Thread(target=worker, args=('bob', 'bob'))
-    t1.start(); t2.start()
-    t1.join(timeout=10); t2.join(timeout=10)
+    t1 = threading.Thread(target=worker, args=("alice", "alice"))
+    t2 = threading.Thread(target=worker, args=("bob", "bob"))
+    t1.start()
+    t2.start()
+    t1.join(timeout=10)
+    t2.join(timeout=10)
 
     assert not errors, f"Workers raised: {errors}"
-    assert results.get('alice') == 'alice', f"alice thread saw {results.get('alice')!r}"
-    assert results.get('bob') == 'bob', f"bob thread saw {results.get('bob')!r}"
+    assert results.get("alice") == "alice", f"alice thread saw {results.get('alice')!r}"
+    assert results.get("bob") == "bob", f"bob thread saw {results.get('bob')!r}"

--- a/tests/test_issue840_slash_echo.py
+++ b/tests/test_issue840_slash_echo.py
@@ -1,4 +1,5 @@
 """Tests for slash command echo (#840) — user message shown in chat after /skills, /help, etc."""
+
 import os
 
 _SRC = os.path.join(os.path.dirname(__file__), "..")
@@ -14,7 +15,7 @@ class TestExecuteCommandReturnValue:
     def test_execute_command_returns_null_on_no_match(self):
         src = _read("static/commands.js")
         idx = src.find("function executeCommand(")
-        block = src[idx:idx + 400]
+        block = src[idx : idx + 400]
         # Must return null (not false) when no command matched
         assert "return null;" in block, (
             "executeCommand must return null when no command found (not false)"
@@ -31,56 +32,56 @@ class TestExecuteCommandReturnValue:
         # Find the clear command entry
         idx = src.find("name:'clear'")
         assert idx >= 0
-        entry = src[idx:idx + 100]
+        entry = src[idx : idx + 100]
         assert "noEcho:true" in entry, "/clear must have noEcho:true"
 
     def test_no_echo_flag_on_new(self):
         src = _read("static/commands.js")
         idx = src.find("name:'new'")
         assert idx >= 0
-        entry = src[idx:idx + 80]
+        entry = src[idx : idx + 80]
         assert "noEcho:true" in entry, "/new must have noEcho:true"
 
     def test_no_echo_flag_on_stop(self):
         src = _read("static/commands.js")
         idx = src.find("name:'stop'")
         assert idx >= 0
-        entry = src[idx:idx + 80]
+        entry = src[idx : idx + 80]
         assert "noEcho:true" in entry, "/stop must have noEcho:true"
 
     def test_no_echo_flag_on_retry(self):
         src = _read("static/commands.js")
         idx = src.find("name:'retry'")
         assert idx >= 0
-        entry = src[idx:idx + 80]
+        entry = src[idx : idx + 80]
         assert "noEcho:true" in entry, "/retry must have noEcho:true"
 
     def test_no_echo_flag_on_undo(self):
         src = _read("static/commands.js")
         idx = src.find("name:'undo'")
         assert idx >= 0
-        entry = src[idx:idx + 80]
+        entry = src[idx : idx + 80]
         assert "noEcho:true" in entry, "/undo must have noEcho:true"
 
     def test_no_echo_flag_on_voice(self):
         src = _read("static/commands.js")
         idx = src.find("name:'voice'")
         assert idx >= 0
-        entry = src[idx:idx + 80]
+        entry = src[idx : idx + 80]
         assert "noEcho:true" in entry, "/voice must have noEcho:true"
 
     def test_no_echo_flag_on_theme(self):
         src = _read("static/commands.js")
         idx = src.find("name:'theme'")
         assert idx >= 0
-        entry = src[idx:idx + 80]
+        entry = src[idx : idx + 80]
         assert "noEcho:true" in entry, "/theme must have noEcho:true"
 
     def test_no_echo_flag_on_model(self):
         src = _read("static/commands.js")
         idx = src.find("name:'model'")
         assert idx >= 0
-        entry = src[idx:idx + 130]
+        entry = src[idx : idx + 130]
         assert "noEcho:true" in entry, "/model must have noEcho:true"
 
     def test_skills_has_no_noecho(self):
@@ -88,21 +89,21 @@ class TestExecuteCommandReturnValue:
         src = _read("static/commands.js")
         idx = src.find("name:'skills'")
         assert idx >= 0
-        entry = src[idx:idx + 100]
+        entry = src[idx : idx + 100]
         assert "noEcho" not in entry, "/skills must echo — no noEcho flag"
 
     def test_help_has_no_noecho(self):
         src = _read("static/commands.js")
         idx = src.find("name:'help'")
         assert idx >= 0
-        entry = src[idx:idx + 80]
+        entry = src[idx : idx + 80]
         assert "noEcho" not in entry, "/help must echo — no noEcho flag"
 
     def test_status_has_no_noecho(self):
         src = _read("static/commands.js")
         idx = src.find("name:'status'")
         assert idx >= 0
-        entry = src[idx:idx + 80]
+        entry = src[idx : idx + 80]
         assert "noEcho" not in entry, "/status must echo — no noEcho flag"
 
 
@@ -112,7 +113,7 @@ class TestSendSlashIntercept:
     def test_send_checks_noecho_flag(self):
         src = _read("static/messages.js")
         idx = src.find("Slash command intercept")
-        block = src[idx:idx + 1400]
+        block = src[idx : idx + 1400]
         assert "_cmd.noEcho" in block or "cmd.noEcho" in block, (
             "send() must check the command's noEcho flag before pushing user message (#840)"
         )
@@ -120,7 +121,7 @@ class TestSendSlashIntercept:
     def test_send_pushes_user_message_for_echo_commands(self):
         src = _read("static/messages.js")
         idx = src.find("Slash command intercept")
-        block = src[idx:idx + 1400]
+        block = src[idx : idx + 1400]
         assert "role:'user'" in block and "content:text" in block, (
             "send() must push {role:'user', content:text} for echo-worthy slash commands (#840)"
         )
@@ -132,7 +133,7 @@ class TestSendSlashIntercept:
         which would display in reverse chronological order."""
         src = _read("static/messages.js")
         idx = src.find("Slash command intercept")
-        block = src[idx:idx + 1400]
+        block = src[idx : idx + 1400]
         user_push_pos = block.find("role:'user'")
         handler_call_pos = block.find("_cmd.fn(")
         if handler_call_pos == -1:
@@ -151,7 +152,7 @@ class TestSendSlashIntercept:
         can add it cleanly for forwarding to the agent."""
         src = _read("static/messages.js")
         idx = src.find("Slash command intercept")
-        block = src[idx:idx + 1400]
+        block = src[idx : idx + 1400]
         assert "S.messages.pop()" in block, (
             "send() must S.messages.pop() the user message on handler opt-out "
             "to avoid duplicating the user turn when falling through to "
@@ -166,18 +167,20 @@ def test_compress_has_no_echo_flag():
     """compress is action-only — it resets S.messages internally; echo would flicker."""
     src = _read("static/commands.js")
     import re
+
     m = re.search(r"\{name:'compress'[^}]+\}", src)
     assert m, "compress entry not found in COMMANDS"
-    assert 'noEcho:true' in m.group(), f"compress missing noEcho:true: {m.group()}"
+    assert "noEcho:true" in m.group(), f"compress missing noEcho:true: {m.group()}"
 
 
 def test_compact_has_no_echo_flag():
     """compact is an alias for compress — same noEcho requirement."""
     src = _read("static/commands.js")
     import re
+
     m = re.search(r"\{name:'compact'[^}]+\}", src)
     assert m, "compact entry not found in COMMANDS"
-    assert 'noEcho:true' in m.group(), f"compact missing noEcho:true: {m.group()}"
+    assert "noEcho:true" in m.group(), f"compact missing noEcho:true: {m.group()}"
 
 
 def test_title_with_args_pushes_confirmation_message():
@@ -185,9 +188,13 @@ def test_title_with_args_pushes_confirmation_message():
     src = _read("static/commands.js")
     # After the rename API call succeeds, an assistant message is pushed
     idx = src.find("title_set")
-    segment = src[idx: idx + 300]
-    assert 'S.messages.push' in segment, "cmdTitle success path must push an assistant message"
-    assert "role:'assistant'" in segment, "cmdTitle confirmation must have role:assistant"
+    segment = src[idx : idx + 300]
+    assert "S.messages.push" in segment, (
+        "cmdTitle success path must push an assistant message"
+    )
+    assert "role:'assistant'" in segment, (
+        "cmdTitle confirmation must have role:assistant"
+    )
 
 
 def test_personality_with_args_pushes_confirmation_message():
@@ -197,6 +204,10 @@ def test_personality_with_args_pushes_confirmation_message():
     # S.messages.push comes BEFORE the personality_set toast
     idx = src.find("personality_set')+`**${name}**`")
     assert idx != -1, "cmdPersonality confirmation push not found in source"
-    segment = src[max(0, idx-100): idx + 200]
-    assert 'S.messages.push' in segment, "cmdPersonality success path must push an assistant message"
-    assert "role:'assistant'" in segment, "cmdPersonality confirmation must have role:assistant"
+    segment = src[max(0, idx - 100) : idx + 200]
+    assert "S.messages.push" in segment, (
+        "cmdPersonality success path must push an assistant message"
+    )
+    assert "role:'assistant'" in segment, (
+        "cmdPersonality confirmation must have role:assistant"
+    )

--- a/tests/test_issue852_thinking_card_mirror.py
+++ b/tests/test_issue852_thinking_card_mirror.py
@@ -6,6 +6,7 @@ the reasoning SSE event had populated `reasoningText`. Providers that emit
 reasoning via BOTH `on_reasoning` AND `<think>` tags in the token stream
 then showed identical content in the thinking card and the main response.
 """
+
 import os
 import re
 
@@ -18,12 +19,11 @@ def _read(name):
 
 
 class TestStreamDisplayStripsThinkBlocksAlways:
-
     def test_early_return_on_reasoning_text_is_gone(self):
         """Regression guard: the bypass that caused the thinking card to
         mirror the main response must stay removed."""
         js = _read("static/messages.js")
-        m = re.search(r'function _streamDisplay\(\)\{.*?\n  \}', js, re.DOTALL)
+        m = re.search(r"function _streamDisplay\(\)\{.*?\n  \}", js, re.DOTALL)
         assert m, "_streamDisplay not found"
         fn = m.group(0)
         assert "if(reasoningText) return raw" not in fn, (
@@ -36,7 +36,7 @@ class TestStreamDisplayStripsThinkBlocksAlways:
         """The `_thinkPairs` stripping loop must still be present so the
         fix actually strips think blocks."""
         js = _read("static/messages.js")
-        m = re.search(r'function _streamDisplay\(\)\{.*?\n  \}', js, re.DOTALL)
+        m = re.search(r"function _streamDisplay\(\)\{.*?\n  \}", js, re.DOTALL)
         assert m
         fn = m.group(0)
         assert "_thinkPairs" in fn, (
@@ -50,7 +50,7 @@ class TestStreamDisplayStripsThinkBlocksAlways:
         """Existing behaviour preserved: partial `<thi`, `<think` prefixes
         must still be suppressed so users don't see them mid-stream."""
         js = _read("static/messages.js")
-        m = re.search(r'function _streamDisplay\(\)\{.*?\n  \}', js, re.DOTALL)
+        m = re.search(r"function _streamDisplay\(\)\{.*?\n  \}", js, re.DOTALL)
         assert m
         fn = m.group(0)
         assert "open.startsWith(trimmed)" in fn, (

--- a/tests/test_issue854_live_model_prefix.py
+++ b/tests/test_issue854_live_model_prefix.py
@@ -1,5 +1,6 @@
 """Regression tests for #854 — live-fetched models must route through the
 configured portal provider, not OpenRouter."""
+
 import os
 import re
 
@@ -24,9 +25,9 @@ class TestLiveModelPrefix:
         leaves the bug unfixed."""
         js = _read("static/ui.js")
         # Live model prefix logic was extracted to _addLiveModelsToSelect (#872)
-        m = re.search(r'function _addLiveModelsToSelect\(.*?\n\}', js, re.DOTALL)
+        m = re.search(r"function _addLiveModelsToSelect\(.*?\n\}", js, re.DOTALL)
         if not m:
-            m = re.search(r'async function _fetchLiveModels\(.*?\n\}', js, re.DOTALL)
+            m = re.search(r"async function _fetchLiveModels\(.*?\n\}", js, re.DOTALL)
         assert m, "_addLiveModelsToSelect or _fetchLiveModels not found"
         fn = m.group(0)
         # The prefix application block must NOT have `!mid.includes('/')`
@@ -51,9 +52,9 @@ class TestLiveModelPrefix:
         false.  Earlier revision used `!_needsPrefix` (inverted)."""
         js = _read("static/ui.js")
         # Live model prefix logic was extracted to _addLiveModelsToSelect (#872)
-        m = re.search(r'function _addLiveModelsToSelect\(.*?\n\}', js, re.DOTALL)
+        m = re.search(r"function _addLiveModelsToSelect\(.*?\n\}", js, re.DOTALL)
         if not m:
-            m = re.search(r'async function _fetchLiveModels\(.*?\n\}', js, re.DOTALL)
+            m = re.search(r"async function _fetchLiveModels\(.*?\n\}", js, re.DOTALL)
         assert m
         fn = m.group(0)
         # New flag: _isPortalFetch (positive semantics)
@@ -66,16 +67,18 @@ class TestLiveModelPrefix:
             r"if\s*\(\s*_isPortalFetch\s*&&\s*!mid\.startsWith",
             fn,
         )
-        assert gate, "prefix application must be guarded by _isPortalFetch (true ⇒ prefix)"
+        assert gate, (
+            "prefix application must be guarded by _isPortalFetch (true ⇒ prefix)"
+        )
 
     def test_portal_fetch_excludes_openrouter_and_custom(self):
         """OpenRouter IDs are cross-namespace by design, and `custom` providers
         use user-defined bare names — neither should get a `@provider:` prefix."""
         js = _read("static/ui.js")
         # Live model prefix logic was extracted to _addLiveModelsToSelect (#872)
-        m = re.search(r'function _addLiveModelsToSelect\(.*?\n\}', js, re.DOTALL)
+        m = re.search(r"function _addLiveModelsToSelect\(.*?\n\}", js, re.DOTALL)
         if not m:
-            m = re.search(r'async function _fetchLiveModels\(.*?\n\}', js, re.DOTALL)
+            m = re.search(r"async function _fetchLiveModels\(.*?\n\}", js, re.DOTALL)
         assert m
         fn = m.group(0)
         assert "_ap!=='openrouter'" in fn or "_ap !== 'openrouter'" in fn, (
@@ -92,7 +95,7 @@ class TestCheckProviderMismatchAtPrefix:
 
     def test_returns_null_for_at_prefix_ids(self):
         js = _read("static/ui.js")
-        m = re.search(r'function _checkProviderMismatch\(.*?\n\}', js, re.DOTALL)
+        m = re.search(r"function _checkProviderMismatch\(.*?\n\}", js, re.DOTALL)
         assert m, "_checkProviderMismatch not found"
         fn = m.group(0)
         assert "modelId.startsWith('@')" in fn or 'modelId.startsWith("@")' in fn, (

--- a/tests/test_issue856_active_session_read_state.py
+++ b/tests/test_issue856_active_session_read_state.py
@@ -3,7 +3,9 @@
 from pathlib import Path
 
 
-MESSAGES_JS = (Path(__file__).resolve().parent.parent / "static" / "messages.js").read_text()
+MESSAGES_JS = (
+    Path(__file__).resolve().parent.parent / "static" / "messages.js"
+).read_text()
 
 
 def test_messages_js_defines_active_session_viewed_helper():
@@ -18,7 +20,9 @@ def test_messages_js_defines_active_session_viewed_helper():
 def test_done_path_marks_active_session_as_viewed():
     done_idx = MESSAGES_JS.find("source.addEventListener('done'")
     assert done_idx != -1, "done handler not found in messages.js"
-    done_block = MESSAGES_JS[done_idx:MESSAGES_JS.find("source.addEventListener('stream_end'", done_idx)]
+    done_block = MESSAGES_JS[
+        done_idx : MESSAGES_JS.find("source.addEventListener('stream_end'", done_idx)
+    ]
     assert "const completedSid=completedSession.session_id||activeSid;" in done_block
     assert "_markSessionViewed(completedSid" in done_block, (
         "done handler must mark the final active session id as viewed so unread dot "
@@ -29,7 +33,11 @@ def test_done_path_marks_active_session_as_viewed():
 def test_cancel_path_marks_active_session_as_viewed():
     cancel_idx = MESSAGES_JS.find("source.addEventListener('cancel'")
     assert cancel_idx != -1, "cancel handler not found in messages.js"
-    cancel_block = MESSAGES_JS[cancel_idx:MESSAGES_JS.find("async function _restoreSettledSession()", cancel_idx)]
+    cancel_block = MESSAGES_JS[
+        cancel_idx : MESSAGES_JS.find(
+            "async function _restoreSettledSession()", cancel_idx
+        )
+    ]
     assert "_markSessionViewed(activeSid" in cancel_block, (
         "cancel handler must mark the active session as viewed after settling messages"
     )
@@ -38,7 +46,9 @@ def test_cancel_path_marks_active_session_as_viewed():
 def test_restore_and_error_paths_mark_active_session_as_viewed():
     restore_idx = MESSAGES_JS.find("async function _restoreSettledSession()")
     assert restore_idx != -1, "_restoreSettledSession() not found in messages.js"
-    restore_block = MESSAGES_JS[restore_idx:MESSAGES_JS.find("function _handleStreamError()", restore_idx)]
+    restore_block = MESSAGES_JS[
+        restore_idx : MESSAGES_JS.find("function _handleStreamError()", restore_idx)
+    ]
     assert "const completedSid=session.session_id||activeSid;" in restore_block
     assert "_markSessionViewed(completedSid" in restore_block, (
         "_restoreSettledSession() must mark the final session id as viewed"

--- a/tests/test_issue856_background_completion_unread.py
+++ b/tests/test_issue856_background_completion_unread.py
@@ -26,19 +26,28 @@ def _sessions_function_block(name: str, next_name: str) -> str:
 
 def test_background_completion_unread_uses_explicit_marker_not_message_delta():
     """A background completion must stay unread even when message_count has no delta."""
-    assert "SESSION_COMPLETION_UNREAD_KEY = 'hermes-session-completion-unread'" in SESSIONS_JS
+    assert (
+        "SESSION_COMPLETION_UNREAD_KEY = 'hermes-session-completion-unread'"
+        in SESSIONS_JS
+    )
     assert "function _markSessionCompletionUnread(" in SESSIONS_JS
     assert "function _clearSessionCompletionUnread(" in SESSIONS_JS
     assert "function _hasSessionCompletionUnread(" in SESSIONS_JS
 
     has_unread_idx = SESSIONS_JS.find("function _hasUnreadForSession(s)")
     assert has_unread_idx != -1, "_hasUnreadForSession not found"
-    has_unread_block = SESSIONS_JS[has_unread_idx:SESSIONS_JS.find("async function newSession", has_unread_idx)]
+    has_unread_block = SESSIONS_JS[
+        has_unread_idx : SESSIONS_JS.find("async function newSession", has_unread_idx)
+    ]
 
     marker_idx = has_unread_block.find("_hasSessionCompletionUnread(s.session_id)")
     count_idx = has_unread_block.find("s.message_count > Number")
-    assert marker_idx != -1, "_hasUnreadForSession must check explicit completion unread marker"
-    assert count_idx != -1, "_hasUnreadForSession must keep the existing message_count fallback"
+    assert marker_idx != -1, (
+        "_hasUnreadForSession must check explicit completion unread marker"
+    )
+    assert count_idx != -1, (
+        "_hasUnreadForSession must keep the existing message_count fallback"
+    )
     assert marker_idx < count_idx, (
         "explicit completion unread marker must be checked before message_count delta, "
         "because completed streams can have viewed_count == message_count"
@@ -50,20 +59,38 @@ def test_background_done_sets_marker_when_session_not_actively_viewed():
     assert "const isSessionViewed=_isSessionActivelyViewed(activeSid);" in done_block
     assert "const completedSession=d.session||{session_id:activeSid};" in done_block
     assert "const completedSid=completedSession.session_id||activeSid;" in done_block
-    assert "if(!isSessionViewed && typeof _markSessionCompletionUnread==='function')" in done_block
-    assert "_markSessionCompletionUnread(completedSid, completedSession.message_count);" in done_block
+    assert (
+        "if(!isSessionViewed && typeof _markSessionCompletionUnread==='function')"
+        in done_block
+    )
+    assert (
+        "_markSessionCompletionUnread(completedSid, completedSession.message_count);"
+        in done_block
+    )
 
 
 def test_background_done_uses_rotated_session_id_for_completion_unread():
     done_block = _done_block()
 
-    completed_sid_idx = done_block.find("const completedSid=completedSession.session_id||activeSid;")
-    marker_idx = done_block.find("_markSessionCompletionUnread(completedSid, completedSession.message_count);")
-    viewed_idx = done_block.find("_markSessionViewed(completedSid, completedSession.message_count")
+    completed_sid_idx = done_block.find(
+        "const completedSid=completedSession.session_id||activeSid;"
+    )
+    marker_idx = done_block.find(
+        "_markSessionCompletionUnread(completedSid, completedSession.message_count);"
+    )
+    viewed_idx = done_block.find(
+        "_markSessionViewed(completedSid, completedSession.message_count"
+    )
 
-    assert completed_sid_idx != -1, "done handler must derive the final post-compression session id"
-    assert marker_idx != -1, "background completion marker must be stored on the final session id"
-    assert viewed_idx != -1, "visible completions must mark the final session id as read"
+    assert completed_sid_idx != -1, (
+        "done handler must derive the final post-compression session id"
+    )
+    assert marker_idx != -1, (
+        "background completion marker must be stored on the final session id"
+    )
+    assert viewed_idx != -1, (
+        "visible completions must mark the final session id as read"
+    )
     assert completed_sid_idx < marker_idx < viewed_idx, (
         "context compression can rotate session_id before done; unread/read state must "
         "attach to the visible final row, not the old SSE activeSid"
@@ -77,13 +104,19 @@ def test_done_event_updates_sidebar_cache_immediately_after_completion_marker():
     cleanup_idx = done_block.find("_clearOwnerInflightState();")
     if cleanup_idx == -1:
         cleanup_idx = done_block.find("delete INFLIGHT[activeSid];")
-    cache_idx = done_block.find("_markSessionCompletedInList(completedSession, activeSid);")
+    cache_idx = done_block.find(
+        "_markSessionCompletedInList(completedSession, activeSid);"
+    )
     refresh_idx = done_block.find("renderSessionList();", cache_idx)
     sound_idx = done_block.find("playNotificationSound();", cache_idx)
 
     assert "function _markSessionCompletedInList(" in SESSIONS_JS
-    assert marker_idx != -1, "done handler must write the completion-unread marker first"
-    assert cleanup_idx != -1, "done handler must clear local INFLIGHT before rendering idle state"
+    assert marker_idx != -1, (
+        "done handler must write the completion-unread marker first"
+    )
+    assert cleanup_idx != -1, (
+        "done handler must clear local INFLIGHT before rendering idle state"
+    )
     assert cache_idx != -1, "done handler must update the sidebar cache immediately"
     assert refresh_idx != -1 and sound_idx != -1
     assert marker_idx < cleanup_idx < cache_idx < refresh_idx < sound_idx, (
@@ -98,10 +131,16 @@ def test_sidebar_cache_completion_handles_compression_session_rotation():
         "_markPollingCompletionUnreadTransitions",
     )
 
-    assert "function _markSessionCompletedInList(session, previousSid = null)" in helper_block
+    assert (
+        "function _markSessionCompletedInList(session, previousSid = null)"
+        in helper_block
+    )
     assert "const finalSid = session.session_id || previousSid;" in helper_block
     assert "s.session_id === finalSid || s.session_id === previousSid" in helper_block
-    assert "const {messages: _messages, tool_calls: _toolCalls, ...sessionMeta} = session;" in helper_block
+    assert (
+        "const {messages: _messages, tool_calls: _toolCalls, ...sessionMeta} = session;"
+        in helper_block
+    )
     assert "...sessionMeta" in helper_block
     assert "session_id: finalSid" in helper_block
     assert "_sessionStreamingById.set(finalSid, false);" in helper_block
@@ -121,7 +160,9 @@ def test_polling_transition_marks_completion_unread_without_sse_done():
     )
     render_idx = SESSIONS_JS.find("async function renderSessionList()")
     assert render_idx != -1, "renderSessionList not found"
-    render_block = SESSIONS_JS[render_idx:SESSIONS_JS.find("// ── Gateway session SSE", render_idx)]
+    render_block = SESSIONS_JS[
+        render_idx : SESSIONS_JS.find("// ── Gateway session SSE", render_idx)
+    ]
 
     assert "const _sessionStreamingById = new Map();" in SESSIONS_JS
     assert "const wasStreaming = _sessionStreamingById.get(sid);" in transition_block
@@ -184,7 +225,9 @@ def test_polling_transition_tracks_the_same_effective_streaming_state_as_sidebar
     )
     render_idx = SESSIONS_JS.find("function _renderOneSession")
     assert render_idx != -1, "_renderOneSession not found"
-    render_block = SESSIONS_JS[render_idx:SESSIONS_JS.find("const hasUnread=", render_idx)]
+    render_block = SESSIONS_JS[
+        render_idx : SESSIONS_JS.find("const hasUnread=", render_idx)
+    ]
 
     assert "(isActive && S.busy)" in local_block
     assert "INFLIGHT && INFLIGHT[s.session_id]" in local_block
@@ -202,7 +245,9 @@ def test_cache_render_seeds_streaming_transition_state_for_visible_spinners():
     )
     render_idx = SESSIONS_JS.find("function _renderOneSession")
     assert render_idx != -1, "_renderOneSession not found"
-    render_block = SESSIONS_JS[render_idx:SESSIONS_JS.find("const hasUnread=", render_idx)]
+    render_block = SESSIONS_JS[
+        render_idx : SESSIONS_JS.find("const hasUnread=", render_idx)
+    ]
 
     assert "if (!s || !s.session_id || !isStreaming) return;" in remember_block
     assert "_sessionStreamingById.set(s.session_id, true);" in remember_block
@@ -220,20 +265,43 @@ def test_polling_transition_marks_completion_when_long_running_stream_snapshot_a
     )
     render_idx = SESSIONS_JS.find("function _renderOneSession")
     assert render_idx != -1, "_renderOneSession not found"
-    render_block = SESSIONS_JS[render_idx:SESSIONS_JS.find("const hasUnread=", render_idx)]
+    render_block = SESSIONS_JS[
+        render_idx : SESSIONS_JS.find("const hasUnread=", render_idx)
+    ]
 
     assert "const _sessionListSnapshotById = new Map();" in SESSIONS_JS
-    assert "SESSION_OBSERVED_STREAMING_KEY = 'hermes-session-observed-streaming'" in SESSIONS_JS
+    assert (
+        "SESSION_OBSERVED_STREAMING_KEY = 'hermes-session-observed-streaming'"
+        in SESSIONS_JS
+    )
     assert "function _rememberObservedStreamingSession(" in SESSIONS_JS
     assert "function _forgetObservedStreamingSession(" in SESSIONS_JS
-    assert "const previousSnapshot = _sessionListSnapshotById.get(sid);" in transition_block
-    assert "const observedStreaming = _getSessionObservedStreaming()[sid];" in transition_block
+    assert (
+        "const previousSnapshot = _sessionListSnapshotById.get(sid);"
+        in transition_block
+    )
+    assert (
+        "const observedStreaming = _getSessionObservedStreaming()[sid];"
+        in transition_block
+    )
     assert "const completedWithNewMessages = Boolean(" in transition_block
     assert "(previousSnapshot || observedStreaming)" in transition_block
-    assert "messageCount > Number((previousSnapshot || observedStreaming).message_count || 0)" in transition_block
-    assert "lastMessageAt > Number((previousSnapshot || observedStreaming).last_message_at || 0)" in transition_block
-    assert "const completedPersistedObservedStream = Boolean(observedStreaming && !isStreaming);" in transition_block
-    assert "completedObservedStream || completedPersistedObservedStream || completedWithNewMessages" in transition_block
+    assert (
+        "messageCount > Number((previousSnapshot || observedStreaming).message_count || 0)"
+        in transition_block
+    )
+    assert (
+        "lastMessageAt > Number((previousSnapshot || observedStreaming).last_message_at || 0)"
+        in transition_block
+    )
+    assert (
+        "const completedPersistedObservedStream = Boolean(observedStreaming && !isStreaming);"
+        in transition_block
+    )
+    assert (
+        "completedObservedStream || completedPersistedObservedStream || completedWithNewMessages"
+        in transition_block
+    )
     assert "_sessionListSnapshotById.set(sid, {" in transition_block
     assert "_rememberRenderedSessionSnapshot(s);" in render_block, (
         "a visible sidebar spinner can outlive the original SSE context for "
@@ -248,13 +316,23 @@ def test_polling_snapshot_fallback_does_not_mark_first_seen_historical_sessions(
         "newSession",
     )
 
-    prev_idx = transition_block.find("const previousSnapshot = _sessionListSnapshotById.get(sid);")
+    prev_idx = transition_block.find(
+        "const previousSnapshot = _sessionListSnapshotById.get(sid);"
+    )
     fallback_idx = transition_block.find("const completedWithNewMessages = Boolean(")
     mark_idx = transition_block.find("_markSessionCompletionUnread(sid")
     snapshot_set_idx = transition_block.find("_sessionListSnapshotById.set(sid, {")
 
-    assert prev_idx != -1 and fallback_idx != -1 and mark_idx != -1 and snapshot_set_idx != -1
-    assert "(previousSnapshot || observedStreaming)\n      && !isStreaming" in transition_block, (
+    assert (
+        prev_idx != -1
+        and fallback_idx != -1
+        and mark_idx != -1
+        and snapshot_set_idx != -1
+    )
+    assert (
+        "(previousSnapshot || observedStreaming)\n      && !isStreaming"
+        in transition_block
+    ), (
         "snapshot-delta fallback must require a previous in-memory or persisted "
         "observation so old completed sessions do not become unread on first render"
     )
@@ -286,11 +364,15 @@ def test_active_done_marks_viewed_without_setting_unread_marker():
     done_block = _done_block()
     marker_idx = done_block.find("_markSessionCompletionUnread(completedSid")
     active_guard_idx = done_block.find("if(isActiveSession){", marker_idx)
-    viewed_guard_idx = done_block.find("if(isSessionViewed) _markSessionViewed(completedSid", active_guard_idx)
+    viewed_guard_idx = done_block.find(
+        "if(isSessionViewed) _markSessionViewed(completedSid", active_guard_idx
+    )
 
     assert marker_idx != -1, "background completion marker call missing"
     assert active_guard_idx != -1, "done handler must guard active-session UI updates"
-    assert viewed_guard_idx != -1, "active/current completion must still mark session viewed when visible/focused"
+    assert viewed_guard_idx != -1, (
+        "active/current completion must still mark session viewed when visible/focused"
+    )
     assert active_guard_idx < viewed_guard_idx, (
         "active-session viewed write must remain inside isSessionViewed guard so "
         "switch-away races cannot mark a background completion read"
@@ -300,21 +382,39 @@ def test_active_done_marks_viewed_without_setting_unread_marker():
 def test_hidden_active_done_still_updates_current_pane_but_not_read_state():
     done_block = _done_block()
 
-    active_const_idx = done_block.find("const isActiveSession=_isSessionCurrentPane(activeSid);")
-    viewed_const_idx = done_block.find("const isSessionViewed=_isSessionActivelyViewed(activeSid);")
+    active_const_idx = done_block.find(
+        "const isActiveSession=_isSessionCurrentPane(activeSid);"
+    )
+    viewed_const_idx = done_block.find(
+        "const isSessionViewed=_isSessionActivelyViewed(activeSid);"
+    )
     active_guard_idx = done_block.find("if(isActiveSession){", viewed_const_idx)
     session_update_idx = done_block.find("S.session=d.session", active_guard_idx)
     render_idx = done_block.find("renderMessages(", active_guard_idx)
     load_dir_idx = done_block.find("loadDir('.')", active_guard_idx)
-    mark_viewed_idx = done_block.find("if(isSessionViewed) _markSessionViewed(completedSid", active_guard_idx)
+    mark_viewed_idx = done_block.find(
+        "if(isSessionViewed) _markSessionViewed(completedSid", active_guard_idx
+    )
 
-    assert active_const_idx != -1, "done handler must compute active/current pane separately"
-    assert viewed_const_idx != -1, "done handler must still compute visible/focused read state"
+    assert active_const_idx != -1, (
+        "done handler must compute active/current pane separately"
+    )
+    assert viewed_const_idx != -1, (
+        "done handler must still compute visible/focused read state"
+    )
     assert active_const_idx < viewed_const_idx
-    assert session_update_idx != -1, "active hidden completion must still refresh S.session"
-    assert render_idx != -1, "active hidden completion must still render the final assistant response"
-    assert load_dir_idx != -1, "active hidden completion must keep normal active-session finalization"
-    assert mark_viewed_idx != -1, "read-state write must stay gated by visible/focused viewing"
+    assert session_update_idx != -1, (
+        "active hidden completion must still refresh S.session"
+    )
+    assert render_idx != -1, (
+        "active hidden completion must still render the final assistant response"
+    )
+    assert load_dir_idx != -1, (
+        "active hidden completion must keep normal active-session finalization"
+    )
+    assert mark_viewed_idx != -1, (
+        "read-state write must stay gated by visible/focused viewing"
+    )
     assert session_update_idx < mark_viewed_idx < render_idx, (
         "hidden active completion should update the pane, but only mark read when "
         "isSessionViewed is true"
@@ -324,7 +424,11 @@ def test_hidden_active_done_still_updates_current_pane_but_not_read_state():
 def test_hidden_or_unfocused_active_session_counts_as_background_completion():
     helper_idx = MESSAGES_JS.find("function _isSessionActivelyViewed(sid)")
     assert helper_idx != -1, "_isSessionActivelyViewed helper missing"
-    helper_block = MESSAGES_JS[helper_idx:MESSAGES_JS.find("function _markActiveSessionViewedOnReturn", helper_idx)]
+    helper_block = MESSAGES_JS[
+        helper_idx : MESSAGES_JS.find(
+            "function _markActiveSessionViewedOnReturn", helper_idx
+        )
+    ]
 
     current_idx = MESSAGES_JS.find("function _isSessionCurrentPane(sid)")
     assert current_idx != -1, "_isSessionCurrentPane helper missing"
@@ -343,7 +447,9 @@ def test_hidden_or_unfocused_active_session_counts_as_background_completion():
 def test_switching_away_counts_as_background_completion():
     helper_idx = MESSAGES_JS.find("function _isSessionCurrentPane(sid)")
     assert helper_idx != -1, "_isSessionCurrentPane helper missing"
-    helper_block = MESSAGES_JS[helper_idx:MESSAGES_JS.find("function _isSessionActivelyViewed", helper_idx)]
+    helper_block = MESSAGES_JS[
+        helper_idx : MESSAGES_JS.find("function _isSessionActivelyViewed", helper_idx)
+    ]
 
     assert "S.session.session_id!==sid" in helper_block
     assert "_loadingSessionId" in helper_block
@@ -356,12 +462,20 @@ def test_switching_away_counts_as_background_completion():
 def test_restore_settled_background_stream_marks_completion_unread():
     restore_idx = MESSAGES_JS.find("async function _restoreSettledSession()")
     assert restore_idx != -1, "_restoreSettledSession not found"
-    restore_block = MESSAGES_JS[restore_idx:MESSAGES_JS.find("function _handleStreamError", restore_idx)]
+    restore_block = MESSAGES_JS[
+        restore_idx : MESSAGES_JS.find("function _handleStreamError", restore_idx)
+    ]
 
     assert "const isSessionViewed=_isSessionActivelyViewed(activeSid);" in restore_block
     assert "const completedSid=session.session_id||activeSid;" in restore_block
-    assert "if(!isSessionViewed && typeof _markSessionCompletionUnread==='function')" in restore_block
-    assert "_markSessionCompletionUnread(completedSid, session.message_count);" in restore_block
+    assert (
+        "if(!isSessionViewed && typeof _markSessionCompletionUnread==='function')"
+        in restore_block
+    )
+    assert (
+        "_markSessionCompletionUnread(completedSid, session.message_count);"
+        in restore_block
+    )
     assert "if(isSessionViewed) _markSessionViewed(completedSid" in restore_block, (
         "restore-settled fallback must not mark a hidden/background completion read"
     )
@@ -370,29 +484,46 @@ def test_restore_settled_background_stream_marks_completion_unread():
 def test_focus_visibility_return_marks_active_session_viewed_and_clears_marker():
     return_idx = MESSAGES_JS.find("function _markActiveSessionViewedOnReturn()")
     assert return_idx != -1, "_markActiveSessionViewedOnReturn helper missing"
-    return_block = MESSAGES_JS[return_idx:MESSAGES_JS.find("async function send()", return_idx)]
+    return_block = MESSAGES_JS[
+        return_idx : MESSAGES_JS.find("async function send()", return_idx)
+    ]
 
-    assert "if(!_isDocumentVisibleAndFocused() || !S.session || !S.session.session_id) return;" in return_block
+    assert (
+        "if(!_isDocumentVisibleAndFocused() || !S.session || !S.session.session_id) return;"
+        in return_block
+    )
     assert "_markSessionViewed(S.session.session_id" in return_block
     assert "_clearSessionCompletionUnread(S.session.session_id)" in return_block, (
         "returning to a visible/focused tab must clear the explicit unread marker "
         "for the active session the user is now viewing"
     )
     assert "renderSessionListFromCache()" in return_block
-    assert "document.addEventListener('visibilitychange', _markActiveSessionViewedOnReturn);" in MESSAGES_JS
-    assert "window.addEventListener('focus', _markActiveSessionViewedOnReturn);" in MESSAGES_JS
+    assert (
+        "document.addEventListener('visibilitychange', _markActiveSessionViewedOnReturn);"
+        in MESSAGES_JS
+    )
+    assert (
+        "window.addEventListener('focus', _markActiveSessionViewedOnReturn);"
+        in MESSAGES_JS
+    )
 
 
 def test_completion_unread_clears_only_when_session_is_opened():
     load_idx = SESSIONS_JS.find("async function loadSession(sid)")
     assert load_idx != -1, "loadSession not found"
-    load_block = SESSIONS_JS[load_idx:SESSIONS_JS.find("function _resolveSessionModelForDisplaySoon", load_idx)]
+    load_block = SESSIONS_JS[
+        load_idx : SESSIONS_JS.find(
+            "function _resolveSessionModelForDisplaySoon", load_idx
+        )
+    ]
 
     stale_guard_idx = load_block.find("if (_loadingSessionId !== sid) return;")
     clear_idx = load_block.find("_clearSessionCompletionUnread(S.session.session_id);")
     set_viewed_idx = load_block.find("_setSessionViewedCount(S.session.session_id")
 
-    assert clear_idx != -1, "loadSession must clear explicit completion unread when the user opens the session"
+    assert clear_idx != -1, (
+        "loadSession must clear explicit completion unread when the user opens the session"
+    )
     assert stale_guard_idx != -1 and stale_guard_idx < clear_idx, (
         "stale loadSession responses must not clear unread markers for sessions the user did not actually open"
     )
@@ -406,12 +537,17 @@ def test_historical_sessions_are_not_marked_unread_on_list_render():
     has_unread_idx = SESSIONS_JS.find("function _hasUnreadForSession(s)")
     assert has_unread_idx != -1
     has_unread_block = SESSIONS_JS[
-        has_unread_idx:SESSIONS_JS.find("function _isSessionActivelyViewedForList", has_unread_idx)
+        has_unread_idx : SESSIONS_JS.find(
+            "function _isSessionActivelyViewedForList", has_unread_idx
+        )
     ]
 
     assert "_markSessionCompletionUnread" not in has_unread_block, (
         "rendering old historical sessions must not create completion-unread markers"
     )
-    assert "_setSessionViewedCount(s.session_id, Number(s.message_count || 0));" in has_unread_block, (
+    assert (
+        "_setSessionViewedCount(s.session_id, Number(s.message_count || 0));"
+        in has_unread_block
+    ), (
         "missing viewed-count baseline should still initialize as read for historical sessions"
     )

--- a/tests/test_issue856_pinned_indicator_layout.py
+++ b/tests/test_issue856_pinned_indicator_layout.py
@@ -3,24 +3,34 @@
 from pathlib import Path
 
 
-SESSIONS_JS = (Path(__file__).resolve().parent.parent / "static" / "sessions.js").read_text()
-STYLE_CSS = (Path(__file__).resolve().parent.parent / "static" / "style.css").read_text()
+SESSIONS_JS = (
+    Path(__file__).resolve().parent.parent / "static" / "sessions.js"
+).read_text()
+STYLE_CSS = (
+    Path(__file__).resolve().parent.parent / "static" / "style.css"
+).read_text()
 
 
 def test_pinned_indicator_renders_inside_title_row():
     title_row_idx = SESSIONS_JS.find("titleRow.className='session-title-row';")
     assert title_row_idx != -1, "session title row construction not found"
 
-    assert ("body.appendChild(_renderOneSession(s, Boolean(g.isPinned)))" in SESSIONS_JS
-            or "body.appendChild(parentEl)" in SESSIONS_JS)
+    assert (
+        "body.appendChild(_renderOneSession(s, Boolean(g.isPinned)))" in SESSIONS_JS
+        or "body.appendChild(parentEl)" in SESSIONS_JS
+    )
     assert "function _renderOneSession(s, isPinnedGroup=false)" in SESSIONS_JS
     assert "if(s.pinned&&!isPinnedGroup){" in SESSIONS_JS
 
-    pin_idx = SESSIONS_JS.find("pinInd.className='session-pin-indicator';", title_row_idx)
+    pin_idx = SESSIONS_JS.find(
+        "pinInd.className='session-pin-indicator';", title_row_idx
+    )
     assert pin_idx != -1, "pinned indicator creation not found after title row"
 
     append_to_title_row_idx = SESSIONS_JS.find("titleRow.appendChild(pinInd);", pin_idx)
-    assert append_to_title_row_idx != -1, "pinned indicator should be appended to titleRow"
+    assert append_to_title_row_idx != -1, (
+        "pinned indicator should be appended to titleRow"
+    )
 
     append_to_el_idx = SESSIONS_JS.find("el.appendChild(pinInd);", pin_idx)
     assert append_to_el_idx == -1, (
@@ -30,11 +40,21 @@ def test_pinned_indicator_renders_inside_title_row():
 
 
 def test_pinned_indicator_uses_fixed_indicator_box():
-    assert ".session-pin-indicator{" in STYLE_CSS, "session pin indicator CSS block missing"
-    css_block = STYLE_CSS[STYLE_CSS.find(".session-pin-indicator{"):STYLE_CSS.find(".session-pin-indicator svg{")]
+    assert ".session-pin-indicator{" in STYLE_CSS, (
+        "session pin indicator CSS block missing"
+    )
+    css_block = STYLE_CSS[
+        STYLE_CSS.find(".session-pin-indicator{") : STYLE_CSS.find(
+            ".session-pin-indicator svg{"
+        )
+    ]
     assert "width:10px;" in css_block, "pin indicator should reserve a fixed 10px width"
-    assert "height:10px;" in css_block, "pin indicator should reserve a fixed 10px height"
-    assert "justify-content:center;" in css_block, "pin indicator should center the star inside its box"
+    assert "height:10px;" in css_block, (
+        "pin indicator should reserve a fixed 10px height"
+    )
+    assert "justify-content:center;" in css_block, (
+        "pin indicator should center the star inside its box"
+    )
 
 
 def test_state_indicator_uses_right_actions_slot_to_prevent_title_shift():
@@ -43,47 +63,81 @@ def test_state_indicator_uses_right_actions_slot_to_prevent_title_shift():
     title_row_idx = SESSIONS_JS.find("titleRow.className='session-title-row';")
     assert title_row_idx != -1, "title row construction not found"
 
-    title_row_append_idx = SESSIONS_JS.find("titleRow.appendChild(state);", title_row_idx)
+    title_row_append_idx = SESSIONS_JS.find(
+        "titleRow.appendChild(state);", title_row_idx
+    )
     assert title_row_append_idx == -1, (
         "state indicator should not be inserted before the title; it should reuse "
         "the right-side actions slot to avoid title shift"
     )
 
-    state_idx = SESSIONS_JS.find("state.className='session-attention-indicator session-state-indicator'")
+    state_idx = SESSIONS_JS.find(
+        "state.className='session-attention-indicator session-state-indicator'"
+    )
     assert state_idx != -1, "right-side attention indicator creation not found"
 
     append_to_row_idx = SESSIONS_JS.find("el.appendChild(state);", state_idx)
-    assert append_to_row_idx != -1, "state indicator should be appended to the outer row"
+    assert append_to_row_idx != -1, (
+        "state indicator should be appended to the outer row"
+    )
 
-    actions_idx = SESSIONS_JS.find("actions.className='session-actions';", append_to_row_idx)
-    assert actions_idx != -1, "session actions should still be appended after attention indicator"
+    actions_idx = SESSIONS_JS.find(
+        "actions.className='session-actions';", append_to_row_idx
+    )
+    assert actions_idx != -1, (
+        "session actions should still be appended after attention indicator"
+    )
 
-    assert ".session-attention-indicator{" in STYLE_CSS, "attention indicator CSS rule missing"
+    assert ".session-attention-indicator{" in STYLE_CSS, (
+        "attention indicator CSS rule missing"
+    )
     css_block = STYLE_CSS[
-        STYLE_CSS.find(".session-attention-indicator{"):
-        STYLE_CSS.find(".session-item:hover .session-attention-indicator")
+        STYLE_CSS.find(".session-attention-indicator{") : STYLE_CSS.find(
+            ".session-item:hover .session-attention-indicator"
+        )
     ]
-    assert "position:absolute;" in css_block, "attention indicator should be positioned in the row action slot"
-    assert "right:6px;" in css_block, "attention indicator should align with the actions trigger"
-    assert "width:26px;" in css_block, "attention indicator should use the same width as the actions trigger"
-    assert "height:26px;" in css_block, "attention indicator should use the same height as the actions trigger"
+    assert "position:absolute;" in css_block, (
+        "attention indicator should be positioned in the row action slot"
+    )
+    assert "right:6px;" in css_block, (
+        "attention indicator should align with the actions trigger"
+    )
+    assert "width:26px;" in css_block, (
+        "attention indicator should use the same width as the actions trigger"
+    )
+    assert "height:26px;" in css_block, (
+        "attention indicator should use the same height as the actions trigger"
+    )
     assert ".session-attention-indicator.is-streaming::before{" in STYLE_CSS
     inner_spinner_block = STYLE_CSS[
-        STYLE_CSS.find(".session-attention-indicator.is-streaming::before{"):
-        STYLE_CSS.find(".session-attention-indicator.is-unread::before{")
+        STYLE_CSS.find(
+            ".session-attention-indicator.is-streaming::before{"
+        ) : STYLE_CSS.find(".session-attention-indicator.is-unread::before{")
     ]
-    assert "width:10px;" in inner_spinner_block, "spinner glyph should stay 10px inside the 26px action slot"
-    assert "height:10px;" in inner_spinner_block, "spinner glyph should stay 10px inside the 26px action slot"
+    assert "width:10px;" in inner_spinner_block, (
+        "spinner glyph should stay 10px inside the 26px action slot"
+    )
+    assert "height:10px;" in inner_spinner_block, (
+        "spinner glyph should stay 10px inside the 26px action slot"
+    )
 
     hover_rule = ".session-item:hover .session-attention-indicator"
-    assert hover_rule in STYLE_CSS, "hover rule should hide attention indicator when actions appear"
+    assert hover_rule in STYLE_CSS, (
+        "hover rule should hide attention indicator when actions appear"
+    )
 
 
 def test_timestamp_hidden_when_attention_state_is_present():
     assert "+(hasUnread?' unread':'')" in SESSIONS_JS
     assert "const hasAttentionState=isStreaming||hasUnread;" in SESSIONS_JS
-    assert "ts.className='session-time'+(hasAttentionState?' is-hidden':'');" in SESSIONS_JS
-    assert "ts.textContent=hasAttentionState?'':_formatRelativeSessionTime(tsMs);" in SESSIONS_JS
+    assert (
+        "ts.className='session-time'+(hasAttentionState?' is-hidden':'');"
+        in SESSIONS_JS
+    )
+    assert (
+        "ts.textContent=hasAttentionState?'':_formatRelativeSessionTime(tsMs);"
+        in SESSIONS_JS
+    )
     assert ".session-time.is-hidden{display:none;}" in STYLE_CSS
     # padding-right was 86px when the timestamp was position:absolute. Now that
     # the timestamp lives in the flex flow of .session-title-row, the rest
@@ -95,7 +149,10 @@ def test_timestamp_hidden_when_attention_state_is_present():
     # Instead, hover padding is restored via @media (hover:hover) which only applies to
     # devices with a real hover capability (mouse). Touch/iPad devices satisfy hover:none
     # and skip that block, preventing the layout-reflow mid-tap bug.
-    assert ".session-item.streaming,.session-item.unread,.session-item:focus-within,.session-item.menu-open{padding-right:40px;}" in STYLE_CSS
+    assert (
+        ".session-item.streaming,.session-item.unread,.session-item:focus-within,.session-item.menu-open{padding-right:40px;}"
+        in STYLE_CSS
+    )
     # Desktop hover padding restored via media query (mouse devices only)
     assert "@media (hover:hover)" in STYLE_CSS
     assert ".session-item:hover{padding-right:40px;}" in STYLE_CSS
@@ -104,16 +161,21 @@ def test_timestamp_hidden_when_attention_state_is_present():
     # absolute positioning. This stops the title's flex:1 bound from running
     # underneath the timestamp and lets the project dot sit beside it.
     session_time_block = STYLE_CSS[
-        STYLE_CSS.find(".session-time{"):
-        STYLE_CSS.find(".session-time.is-hidden")
+        STYLE_CSS.find(".session-time{") : STYLE_CSS.find(".session-time.is-hidden")
     ]
     assert "position:absolute;" not in session_time_block, (
         "Timestamp must live in flex flow (margin-left:auto), not absolute"
     )
     assert "margin-left:auto;" in session_time_block
     assert ".session-item:hover .session-time" in STYLE_CSS
-    assert ".session-item.streaming:not(:hover):not(:focus-within):not(.menu-open) .session-actions" in STYLE_CSS
-    assert ".session-item.unread:not(:hover):not(:focus-within):not(.menu-open) .session-actions" in STYLE_CSS
+    assert (
+        ".session-item.streaming:not(:hover):not(:focus-within):not(.menu-open) .session-actions"
+        in STYLE_CSS
+    )
+    assert (
+        ".session-item.unread:not(:hover):not(:focus-within):not(.menu-open) .session-actions"
+        in STYLE_CSS
+    )
 
 
 def test_plain_mouse_hover_does_not_mark_session_row_dragging():
@@ -126,22 +188,28 @@ def test_plain_mouse_hover_does_not_mark_session_row_dragging():
 
 
 def test_sidebar_uses_local_inflight_state_for_immediate_spinner():
-    messages_js = (Path(__file__).resolve().parent.parent / "static" / "messages.js").read_text()
+    messages_js = (
+        Path(__file__).resolve().parent.parent / "static" / "messages.js"
+    ).read_text()
 
     assert "function _isSessionLocallyStreaming(s)" in SESSIONS_JS
     assert "(isActive && S.busy)" in SESSIONS_JS
     assert "INFLIGHT[s.session_id]" in SESSIONS_JS
     assert "function _isSessionEffectivelyStreaming(s)" in SESSIONS_JS
     assert "const isStreaming=_isSessionEffectivelyStreaming(s);" in SESSIONS_JS
-    assert "if(typeof renderSessionListFromCache==='function') renderSessionListFromCache();" in messages_js
+    assert (
+        "if(typeof renderSessionListFromCache==='function') renderSessionListFromCache();"
+        in messages_js
+    )
 
 
 def test_date_group_caret_expanded_down_collapsed_right():
     assert "caret.textContent='\\u25BE';" in SESSIONS_JS
     assert ".session-date-caret{" in STYLE_CSS
     caret_block = STYLE_CSS[
-        STYLE_CSS.find(".session-date-caret{"):
-        STYLE_CSS.find(".session-date-caret.collapsed")
+        STYLE_CSS.find(".session-date-caret{") : STYLE_CSS.find(
+            ".session-date-caret.collapsed"
+        )
     ]
     assert "transform:rotate(0deg);" in caret_block
     assert ".session-date-caret.collapsed{transform:rotate(-90deg);}" in STYLE_CSS
@@ -150,7 +218,9 @@ def test_date_group_caret_expanded_down_collapsed_right():
 def test_apperror_path_calls_render_session_list():
     """apperror handler must call renderSessionList() to clear the streaming indicator
     immediately rather than waiting for the 5s streaming poll interval."""
-    messages_js = (Path(__file__).resolve().parent.parent / "static" / "messages.js").read_text()
+    messages_js = (
+        Path(__file__).resolve().parent.parent / "static" / "messages.js"
+    ).read_text()
     apperror_idx = messages_js.find("source.addEventListener('apperror'")
     assert apperror_idx != -1, "apperror handler not found in messages.js"
     warning_idx = messages_js.find("source.addEventListener('warning'", apperror_idx)

--- a/tests/test_issue893_cancel_preserves_partial.py
+++ b/tests/test_issue893_cancel_preserves_partial.py
@@ -14,13 +14,12 @@ After this fix:
   sees the partial content as prior context on the next turn
 - The cancel marker itself keeps _error=True so the model does not see it
 """
+
 import threading
-import time
 
 import pytest
 
 import api.config as config
-import api.streaming as streaming
 from api.config import STREAM_PARTIAL_TEXT, STREAMS_LOCK
 
 
@@ -39,27 +38,30 @@ def _isolate_stream_state():
 
 
 class TestStreamPartialTextAccumulation:
-
-    def test_stream_partial_text_initialized_on_stream_creation(self, tmp_path, monkeypatch):
+    def test_stream_partial_text_initialized_on_stream_creation(
+        self, tmp_path, monkeypatch
+    ):
         """STREAM_PARTIAL_TEXT[stream_id] starts empty when a stream is registered."""
         import queue
-        sid = 'test_init_stream'
+
+        sid = "test_init_stream"
         q = queue.Queue()
         cancel_event = threading.Event()
         with STREAMS_LOCK:
             config.STREAMS[sid] = q
             config.CANCEL_FLAGS[sid] = cancel_event
-            STREAM_PARTIAL_TEXT[sid] = ''
-        assert STREAM_PARTIAL_TEXT.get(sid) == ''
+            STREAM_PARTIAL_TEXT[sid] = ""
+        assert STREAM_PARTIAL_TEXT.get(sid) == ""
 
     def test_stream_partial_text_cleaned_up_on_stream_end(self):
         """STREAM_PARTIAL_TEXT[stream_id] is removed when the stream dict is cleaned up."""
         import queue
-        sid = 'test_cleanup_stream'
+
+        sid = "test_cleanup_stream"
         q = queue.Queue()
         with STREAMS_LOCK:
             config.STREAMS[sid] = q
-            STREAM_PARTIAL_TEXT[sid] = 'some partial text'
+            STREAM_PARTIAL_TEXT[sid] = "some partial text"
         with STREAMS_LOCK:
             config.STREAMS.pop(sid, None)
             STREAM_PARTIAL_TEXT.pop(sid, None)
@@ -67,158 +69,187 @@ class TestStreamPartialTextAccumulation:
 
 
 class TestCancelStreamPreservesPartial:
-
     def test_cancel_stream_saves_partial_text_to_session(self, tmp_path, monkeypatch):
         """cancel_stream() persists accumulated partial text as an assistant message."""
         import queue
         from api.models import Session
         from api.streaming import cancel_stream
 
-        session_dir = tmp_path / 'sessions'
+        session_dir = tmp_path / "sessions"
         session_dir.mkdir()
         import api.models as _models
-        monkeypatch.setattr(config, 'SESSION_DIR', session_dir)
-        monkeypatch.setattr(config, 'SESSION_INDEX_FILE', session_dir / '_index.json')
-        monkeypatch.setattr(_models, 'SESSION_DIR', session_dir)
-        monkeypatch.setattr(_models, 'SESSION_INDEX_FILE', session_dir / '_index.json')
+
+        monkeypatch.setattr(config, "SESSION_DIR", session_dir)
+        monkeypatch.setattr(config, "SESSION_INDEX_FILE", session_dir / "_index.json")
+        monkeypatch.setattr(_models, "SESSION_DIR", session_dir)
+        monkeypatch.setattr(_models, "SESSION_INDEX_FILE", session_dir / "_index.json")
         config.SESSIONS.clear()
         _models.SESSIONS.clear()
 
         # Create a session and a fake running stream
-        s = Session(session_id='sess_partial', title='Test')
-        s.messages.append({'role': 'user', 'content': 'Tell me about Python'})
-        s.active_stream_id = 'stream_partial'
+        s = Session(session_id="sess_partial", title="Test")
+        s.messages.append({"role": "user", "content": "Tell me about Python"})
+        s.active_stream_id = "stream_partial"
         s.save()
-        config.SESSIONS['sess_partial'] = s
+        config.SESSIONS["sess_partial"] = s
 
         q = queue.Queue()
         cancel_event = threading.Event()
         with STREAMS_LOCK:
-            config.STREAMS['stream_partial'] = q
-            config.CANCEL_FLAGS['stream_partial'] = cancel_event
-            STREAM_PARTIAL_TEXT['stream_partial'] = 'Python is a high-level programming language'
+            config.STREAMS["stream_partial"] = q
+            config.CANCEL_FLAGS["stream_partial"] = cancel_event
+            STREAM_PARTIAL_TEXT["stream_partial"] = (
+                "Python is a high-level programming language"
+            )
 
         # Fake agent with session_id attribute
         class FakeAgent:
-            session_id = 'sess_partial'
-            def interrupt(self, _): pass
-        config.AGENT_INSTANCES['stream_partial'] = FakeAgent()
+            session_id = "sess_partial"
 
-        result = cancel_stream('stream_partial')
+            def interrupt(self, _):
+                pass
+
+        config.AGENT_INSTANCES["stream_partial"] = FakeAgent()
+
+        result = cancel_stream("stream_partial")
 
         assert result is True
 
         # Reload the session and check messages
         from api.models import Session
-        saved = Session.load('sess_partial')
+
+        saved = Session.load("sess_partial")
         assert saved is not None
 
-        msg_contents = [m.get('content', '') for m in saved.messages]
+        msg_contents = [m.get("content", "") for m in saved.messages]
         # Should have: user message, partial assistant content, cancel marker
-        assert any('Python is a high-level programming language' in c for c in msg_contents), (
-            f"Partial text not found in session messages: {msg_contents}"
-        )
-        assert any('*Task cancelled.*' in c for c in msg_contents), (
+        assert any(
+            "Python is a high-level programming language" in c for c in msg_contents
+        ), f"Partial text not found in session messages: {msg_contents}"
+        assert any("*Task cancelled.*" in c for c in msg_contents), (
             "Cancel marker missing from session messages"
         )
         # Partial message should NOT have _error=True (it's real content)
-        partial_msg = next(m for m in saved.messages
-                           if 'Python is a high-level' in m.get('content', ''))
-        assert partial_msg.get('_partial') is True
-        assert not partial_msg.get('_error')
+        partial_msg = next(
+            m
+            for m in saved.messages
+            if "Python is a high-level" in m.get("content", "")
+        )
+        assert partial_msg.get("_partial") is True
+        assert not partial_msg.get("_error")
         # Cancel marker should have _error=True
-        cancel_msg = next(m for m in saved.messages if '*Task cancelled.*' in m.get('content', ''))
-        assert cancel_msg.get('_error') is True
+        cancel_msg = next(
+            m for m in saved.messages if "*Task cancelled.*" in m.get("content", "")
+        )
+        assert cancel_msg.get("_error") is True
 
-    def test_cancel_stream_with_no_partial_text_still_saves_cancel_marker(self, tmp_path, monkeypatch):
+    def test_cancel_stream_with_no_partial_text_still_saves_cancel_marker(
+        self, tmp_path, monkeypatch
+    ):
         """If no tokens were streamed before cancel, only the cancel marker is saved."""
         import queue
         from api.models import Session
         from api.streaming import cancel_stream
 
-        session_dir = tmp_path / 'sessions'
+        session_dir = tmp_path / "sessions"
         session_dir.mkdir()
         import api.models as _models
-        monkeypatch.setattr(config, 'SESSION_DIR', session_dir)
-        monkeypatch.setattr(config, 'SESSION_INDEX_FILE', session_dir / '_index.json')
-        monkeypatch.setattr(_models, 'SESSION_DIR', session_dir)
-        monkeypatch.setattr(_models, 'SESSION_INDEX_FILE', session_dir / '_index.json')
+
+        monkeypatch.setattr(config, "SESSION_DIR", session_dir)
+        monkeypatch.setattr(config, "SESSION_INDEX_FILE", session_dir / "_index.json")
+        monkeypatch.setattr(_models, "SESSION_DIR", session_dir)
+        monkeypatch.setattr(_models, "SESSION_INDEX_FILE", session_dir / "_index.json")
         config.SESSIONS.clear()
         _models.SESSIONS.clear()
 
-        s = Session(session_id='sess_nopartial', title='Test')
-        s.messages.append({'role': 'user', 'content': 'Hello'})
-        s.active_stream_id = 'stream_nopartial'
+        s = Session(session_id="sess_nopartial", title="Test")
+        s.messages.append({"role": "user", "content": "Hello"})
+        s.active_stream_id = "stream_nopartial"
         s.save()
-        config.SESSIONS['sess_nopartial'] = s
+        config.SESSIONS["sess_nopartial"] = s
 
         q = queue.Queue()
         cancel_event = threading.Event()
         with STREAMS_LOCK:
-            config.STREAMS['stream_nopartial'] = q
-            config.CANCEL_FLAGS['stream_nopartial'] = cancel_event
-            STREAM_PARTIAL_TEXT['stream_nopartial'] = ''  # empty — cancel before any tokens
+            config.STREAMS["stream_nopartial"] = q
+            config.CANCEL_FLAGS["stream_nopartial"] = cancel_event
+            STREAM_PARTIAL_TEXT["stream_nopartial"] = (
+                ""  # empty — cancel before any tokens
+            )
 
         class FakeAgent:
-            session_id = 'sess_nopartial'
-            def interrupt(self, _): pass
-        config.AGENT_INSTANCES['stream_nopartial'] = FakeAgent()
+            session_id = "sess_nopartial"
 
-        cancel_stream('stream_nopartial')
+            def interrupt(self, _):
+                pass
 
-        saved = Session.load('sess_nopartial')
-        msg_contents = [m.get('content', '') for m in saved.messages]
-        assert any('*Task cancelled.*' in c for c in msg_contents)
+        config.AGENT_INSTANCES["stream_nopartial"] = FakeAgent()
+
+        cancel_stream("stream_nopartial")
+
+        saved = Session.load("sess_nopartial")
+        msg_contents = [m.get("content", "") for m in saved.messages]
+        assert any("*Task cancelled.*" in c for c in msg_contents)
         # No extra partial message when there was nothing streamed
-        assert not any(m.get('_partial') for m in saved.messages), (
+        assert not any(m.get("_partial") for m in saved.messages), (
             "Should not add partial message when no tokens were streamed"
         )
 
-    def test_cancel_stream_strips_thinking_markup_from_partial(self, tmp_path, monkeypatch):
+    def test_cancel_stream_strips_thinking_markup_from_partial(
+        self, tmp_path, monkeypatch
+    ):
         """Thinking blocks in partial text are stripped before saving."""
         import queue
         from api.models import Session
         from api.streaming import cancel_stream
 
-        session_dir = tmp_path / 'sessions'
+        session_dir = tmp_path / "sessions"
         session_dir.mkdir()
         import api.models as _models
-        monkeypatch.setattr(config, 'SESSION_DIR', session_dir)
-        monkeypatch.setattr(config, 'SESSION_INDEX_FILE', session_dir / '_index.json')
-        monkeypatch.setattr(_models, 'SESSION_DIR', session_dir)
-        monkeypatch.setattr(_models, 'SESSION_INDEX_FILE', session_dir / '_index.json')
+
+        monkeypatch.setattr(config, "SESSION_DIR", session_dir)
+        monkeypatch.setattr(config, "SESSION_INDEX_FILE", session_dir / "_index.json")
+        monkeypatch.setattr(_models, "SESSION_DIR", session_dir)
+        monkeypatch.setattr(_models, "SESSION_INDEX_FILE", session_dir / "_index.json")
         config.SESSIONS.clear()
         _models.SESSIONS.clear()
 
-        s = Session(session_id='sess_thinking', title='Test')
-        s.messages.append({'role': 'user', 'content': 'Think about this'})
-        s.active_stream_id = 'stream_thinking'
+        s = Session(session_id="sess_thinking", title="Test")
+        s.messages.append({"role": "user", "content": "Think about this"})
+        s.active_stream_id = "stream_thinking"
         s.save()
-        config.SESSIONS['sess_thinking'] = s
+        config.SESSIONS["sess_thinking"] = s
 
         q = queue.Queue()
         cancel_event = threading.Event()
         with STREAMS_LOCK:
-            config.STREAMS['stream_thinking'] = q
-            config.CANCEL_FLAGS['stream_thinking'] = cancel_event
-            STREAM_PARTIAL_TEXT['stream_thinking'] = (
-                '<think>internal reasoning here</think>\nThe answer is 42'
+            config.STREAMS["stream_thinking"] = q
+            config.CANCEL_FLAGS["stream_thinking"] = cancel_event
+            STREAM_PARTIAL_TEXT["stream_thinking"] = (
+                "<think>internal reasoning here</think>\nThe answer is 42"
             )
 
         class FakeAgent:
-            session_id = 'sess_thinking'
-            def interrupt(self, _): pass
-        config.AGENT_INSTANCES['stream_thinking'] = FakeAgent()
+            session_id = "sess_thinking"
 
-        cancel_stream('stream_thinking')
+            def interrupt(self, _):
+                pass
 
-        saved = Session.load('sess_thinking')
-        partial_msg = next(
-            (m for m in saved.messages if m.get('_partial')), None
+        config.AGENT_INSTANCES["stream_thinking"] = FakeAgent()
+
+        cancel_stream("stream_thinking")
+
+        saved = Session.load("sess_thinking")
+        partial_msg = next((m for m in saved.messages if m.get("_partial")), None)
+        assert partial_msg is not None, (
+            "Partial message should be saved when content remains after stripping"
         )
-        assert partial_msg is not None, "Partial message should be saved when content remains after stripping"
-        assert '<think>' not in partial_msg['content'], "Closed thinking block should be stripped"
-        assert 'The answer is 42' in partial_msg['content'], "Visible content should be preserved"
+        assert "<think>" not in partial_msg["content"], (
+            "Closed thinking block should be stripped"
+        )
+        assert "The answer is 42" in partial_msg["content"], (
+            "Visible content should be preserved"
+        )
 
     def test_cancel_stream_strips_unclosed_think_tag(self, tmp_path, monkeypatch):
         """The common cancel-mid-reasoning case: <think> block without a closing tag."""
@@ -226,71 +257,78 @@ class TestCancelStreamPreservesPartial:
         from api.models import Session
         from api.streaming import cancel_stream
 
-        session_dir = tmp_path / 'sessions'
+        session_dir = tmp_path / "sessions"
         session_dir.mkdir()
         import api.models as _models
-        monkeypatch.setattr(config, 'SESSION_DIR', session_dir)
-        monkeypatch.setattr(config, 'SESSION_INDEX_FILE', session_dir / '_index.json')
-        monkeypatch.setattr(_models, 'SESSION_DIR', session_dir)
-        monkeypatch.setattr(_models, 'SESSION_INDEX_FILE', session_dir / '_index.json')
+
+        monkeypatch.setattr(config, "SESSION_DIR", session_dir)
+        monkeypatch.setattr(config, "SESSION_INDEX_FILE", session_dir / "_index.json")
+        monkeypatch.setattr(_models, "SESSION_DIR", session_dir)
+        monkeypatch.setattr(_models, "SESSION_INDEX_FILE", session_dir / "_index.json")
         config.SESSIONS.clear()
         _models.SESSIONS.clear()
 
-        s = Session(session_id='sess_unclosed', title='Test')
-        s.messages.append({'role': 'user', 'content': 'Please reason step by step'})
-        s.active_stream_id = 'stream_unclosed'
+        s = Session(session_id="sess_unclosed", title="Test")
+        s.messages.append({"role": "user", "content": "Please reason step by step"})
+        s.active_stream_id = "stream_unclosed"
         s.save()
-        config.SESSIONS['sess_unclosed'] = s
+        config.SESSIONS["sess_unclosed"] = s
 
         q = queue.Queue()
         cancel_event = threading.Event()
         with STREAMS_LOCK:
-            config.STREAMS['stream_unclosed'] = q
-            config.CANCEL_FLAGS['stream_unclosed'] = cancel_event
+            config.STREAMS["stream_unclosed"] = q
+            config.CANCEL_FLAGS["stream_unclosed"] = cancel_event
             # Simulates user hitting Stop mid-reasoning — <think> never closed
-            STREAM_PARTIAL_TEXT['stream_unclosed'] = (
-                '<think>\nStep 1: consider the problem...\nStep 2: the user wants'
+            STREAM_PARTIAL_TEXT["stream_unclosed"] = (
+                "<think>\nStep 1: consider the problem...\nStep 2: the user wants"
             )
 
         class FakeAgent:
-            session_id = 'sess_unclosed'
-            def interrupt(self, _): pass
-        config.AGENT_INSTANCES['stream_unclosed'] = FakeAgent()
+            session_id = "sess_unclosed"
 
-        cancel_stream('stream_unclosed')
+            def interrupt(self, _):
+                pass
 
-        saved = Session.load('sess_unclosed')
+        config.AGENT_INSTANCES["stream_unclosed"] = FakeAgent()
+
+        cancel_stream("stream_unclosed")
+
+        saved = Session.load("sess_unclosed")
         # The entire content was inside an unclosed <think> block — nothing visible
         # remains after stripping, so no _partial message should be saved
-        partial_msg = next((m for m in saved.messages if m.get('_partial')), None)
+        partial_msg = next((m for m in saved.messages if m.get("_partial")), None)
         assert partial_msg is None, (
             "Unclosed think block with no visible content should not produce a partial message"
         )
         # Cancel marker should still be present
-        assert any('Task cancelled' in m.get('content', '') for m in saved.messages)
+        assert any("Task cancelled" in m.get("content", "") for m in saved.messages)
 
 
 class TestPartialMessageInContext:
-
     def test_partial_message_included_in_api_sanitization(self):
         """Partial messages (_partial=True) are included in API history (model should see them)."""
         from api.streaming import _sanitize_messages_for_api
 
         messages = [
-            {'role': 'user', 'content': 'Tell me about Python'},
-            {'role': 'assistant', 'content': 'Python is a high-level', '_partial': True},
-            {'role': 'assistant', 'content': '*Task cancelled.*', '_error': True},
+            {"role": "user", "content": "Tell me about Python"},
+            {
+                "role": "assistant",
+                "content": "Python is a high-level",
+                "_partial": True,
+            },
+            {"role": "assistant", "content": "*Task cancelled.*", "_error": True},
         ]
         clean = _sanitize_messages_for_api(messages)
-        roles = [m['role'] for m in clean]
-        contents = [m.get('content', '') for m in clean]
+        roles = [m["role"] for m in clean]
+        contents = [m.get("content", "") for m in clean]
 
         # User message and partial assistant message should be included
-        assert 'user' in roles
-        assert any('Python is a high-level' in c for c in contents), (
+        assert "user" in roles
+        assert any("Python is a high-level" in c for c in contents), (
             "Partial assistant content should be in API context so model can continue from it"
         )
         # Cancel marker (_error=True) should be excluded
-        assert not any('Task cancelled' in c for c in contents), (
+        assert not any("Task cancelled" in c for c in contents), (
             "Cancel marker with _error=True must be stripped from API context"
         )

--- a/tests/test_issue895_894_nous_prefix.py
+++ b/tests/test_issue895_894_nous_prefix.py
@@ -2,7 +2,7 @@
 Regression tests for #895 (set_hermes_default_model strips @nous: prefix + blocks on live fetch)
 and #894 (resolve_model_provider strips cross-namespace prefix for portal providers with base_url).
 """
-import threading
+
 import pytest
 from pathlib import Path
 
@@ -11,6 +11,7 @@ from api.config import resolve_model_provider, set_hermes_default_model
 
 
 # ── Shared fixture ──────────────────────────────────────────────────────────
+
 
 @pytest.fixture(autouse=True)
 def _isolate(tmp_path, monkeypatch):
@@ -26,13 +27,15 @@ def _isolate(tmp_path, monkeypatch):
     )
     monkeypatch.setattr(config, "_get_config_path", lambda: Path(str(config_file)))
     config.cfg.clear()
-    config.cfg.update({
-        "model": {
-            "provider": "nous",
-            "base_url": "https://router.nous.ai/v1",
-            "default": "anthropic/claude-opus-4.6",
+    config.cfg.update(
+        {
+            "model": {
+                "provider": "nous",
+                "base_url": "https://router.nous.ai/v1",
+                "default": "anthropic/claude-opus-4.6",
+            }
         }
-    })
+    )
     try:
         config._cfg_mtime = config_file.stat().st_mtime
     except OSError:
@@ -50,8 +53,8 @@ def _isolate(tmp_path, monkeypatch):
 
 # ── #894: portal-provider + config_base_url prefix-stripping ───────────────
 
-class TestResolveModelProviderPortalPriority:
 
+class TestResolveModelProviderPortalPriority:
     def test_minimax_prefix_preserved_for_nous(self):
         """Nous with base_url must NOT strip minimax/ prefix (#894)."""
         m, p, _ = resolve_model_provider("minimax/minimax-m2.7")
@@ -85,9 +88,11 @@ class TestResolveModelProviderPortalPriority:
 
 # ── #895: set_hermes_default_model persists @provider: prefix ──────────────
 
-class TestSetDefaultModelPreservesAtPrefix:
 
-    def test_at_nous_prefix_strips_to_bare_for_cli_compatibility(self, tmp_path, monkeypatch):
+class TestSetDefaultModelPreservesAtPrefix:
+    def test_at_nous_prefix_strips_to_bare_for_cli_compatibility(
+        self, tmp_path, monkeypatch
+    ):
         """set_hermes_default_model must persist the RESOLVED bare/slash form, not the
         `@provider:` prefix. The `@provider:` syntax is a WebUI-internal routing hint;
         the hermes-agent CLI reads `config.yaml -> model.default` directly and passes
@@ -99,13 +104,17 @@ class TestSetDefaultModelPreservesAtPrefix:
         form via the smart matcher in `_applyModelToDropdown()`.
         """
         import yaml
+
         config_file = tmp_path / "config.yaml"
         config_file.write_text(
             "model:\n  provider: nous\n  base_url: https://router.nous.ai/v1\n",
             encoding="utf-8",
         )
         monkeypatch.setattr(config, "_get_config_path", lambda: Path(str(config_file)))
-        config.cfg["model"] = {"provider": "nous", "base_url": "https://router.nous.ai/v1"}
+        config.cfg["model"] = {
+            "provider": "nous",
+            "base_url": "https://router.nous.ai/v1",
+        }
         try:
             config._cfg_mtime = config_file.stat().st_mtime
         except OSError:
@@ -137,12 +146,14 @@ class TestSetDefaultModelPreservesAtPrefix:
         `@nous:anthropic/claude-opus-4.6`). `_applyModelToDropdown()` normalises
         on both sides and picks the matching option.
         """
-        js = (Path(__file__).resolve().parent.parent / "static" / "panels.js").read_text()
+        js = (
+            Path(__file__).resolve().parent.parent / "static" / "panels.js"
+        ).read_text()
         # Find the block that sets _settingsHermesDefaultModelOnOpen
         anchor = "_settingsHermesDefaultModelOnOpen=(models&&models.default_model)||"
         idx = js.find(anchor)
         assert idx != -1, "Settings default-model initialisation not found in panels.js"
-        block = js[idx:idx + 1200]
+        block = js[idx : idx + 1200]
         assert "_applyModelToDropdown" in block, (
             "Settings picker must use _applyModelToDropdown() so a saved bare form "
             "(e.g. anthropic/claude-opus-4.6) still selects the matching "

--- a/tests/test_issue926_hindsight_docker_dependency.py
+++ b/tests/test_issue926_hindsight_docker_dependency.py
@@ -1,4 +1,5 @@
 """Regression tests for #926 Hindsight dependency in Docker WebUI venv."""
+
 import pathlib
 
 

--- a/tests/test_issue_1932_goal_hook_unrelated_turns.py
+++ b/tests/test_issue_1932_goal_hook_unrelated_turns.py
@@ -7,16 +7,17 @@ messages like "what time is it" must NOT:
   - trigger goal_continue SSE events
   - burn the goal budget
 """
-import pytest
 
 
 # ---------------------------------------------------------------------------
 # Test 1: config exports STREAM_GOAL_RELATED
 # ---------------------------------------------------------------------------
 
+
 def test_config_exports_stream_goal_related():
     """api.config must export STREAM_GOAL_RELATED for the streaming gate."""
     from api.config import STREAM_GOAL_RELATED
+
     assert isinstance(STREAM_GOAL_RELATED, dict)
 
 
@@ -24,10 +25,12 @@ def test_config_exports_stream_goal_related():
 # Test 2: config exports PENDING_GOAL_CONTINUATION
 # ---------------------------------------------------------------------------
 
+
 def test_config_exports_pending_goal_continuation():
     """api.config must export PENDING_GOAL_CONTINUATION for auto-marking
     continuation streams as goal-related."""
     from api.config import PENDING_GOAL_CONTINUATION
+
     assert isinstance(PENDING_GOAL_CONTINUATION, (dict, set))
 
 
@@ -35,11 +38,15 @@ def test_config_exports_pending_goal_continuation():
 # Test 3: streaming.py gates evaluate_goal_after_turn on STREAM_GOAL_RELATED
 # ---------------------------------------------------------------------------
 
+
 def test_streaming_source_code_gates_on_stream_goal_related():
     """The streaming code must check STREAM_GOAL_RELATED[stream_id] before
     calling evaluate_goal_after_turn, so unrelated turns skip the hook."""
     from pathlib import Path
-    streaming_py = (Path(__file__).resolve().parents[1] / "api" / "streaming.py").read_text()
+
+    streaming_py = (
+        Path(__file__).resolve().parents[1] / "api" / "streaming.py"
+    ).read_text()
 
     # Must import STREAM_GOAL_RELATED
     assert "STREAM_GOAL_RELATED" in streaming_py, (
@@ -59,11 +66,15 @@ def test_streaming_source_code_gates_on_stream_goal_related():
 # Test 4: streaming.py sets PENDING_GOAL_CONTINUATION on goal_continue
 # ---------------------------------------------------------------------------
 
+
 def test_streaming_sets_pending_goal_continuation_on_goal_continue():
     """When goal_continue is emitted, streaming.py must set
     PENDING_GOAL_CONTINUATION so the next /chat/start marks the stream."""
     from pathlib import Path
-    streaming_py = (Path(__file__).resolve().parents[1] / "api" / "streaming.py").read_text()
+
+    streaming_py = (
+        Path(__file__).resolve().parents[1] / "api" / "streaming.py"
+    ).read_text()
 
     assert "PENDING_GOAL_CONTINUATION" in streaming_py, (
         "streaming.py must reference PENDING_GOAL_CONTINUATION"
@@ -79,10 +90,12 @@ def test_streaming_sets_pending_goal_continuation_on_goal_continue():
 # Test 5: routes.py reads PENDING_GOAL_CONTINUATION and marks stream
 # ---------------------------------------------------------------------------
 
+
 def test_routes_reads_pending_goal_continuation():
     """The chat/start handler must check PENDING_GOAL_CONTINUATION and mark
     the new stream as goal-related."""
     from pathlib import Path
+
     routes_py = (Path(__file__).resolve().parents[1] / "api" / "routes.py").read_text()
 
     assert "PENDING_GOAL_CONTINUATION" in routes_py, (
@@ -97,9 +110,11 @@ def test_routes_reads_pending_goal_continuation():
 # Test 6: routes.py marks goal kickoff streams as goal-related
 # ---------------------------------------------------------------------------
 
+
 def test_routes_marks_goal_kickoff_as_goal_related():
     """The /api/goal handler must mark the kickoff stream as goal-related."""
     from pathlib import Path
+
     routes_py = (Path(__file__).resolve().parents[1] / "api" / "routes.py").read_text()
 
     # After kickoff stream is started, it must mark the stream
@@ -112,9 +127,11 @@ def test_routes_marks_goal_kickoff_as_goal_related():
 # Test 7: _start_chat_stream_for_session passes goal_related through
 # ---------------------------------------------------------------------------
 
+
 def test_start_chat_stream_accepts_goal_related():
     """_start_chat_stream_for_session must accept goal_related kwarg."""
     from pathlib import Path
+
     routes_py = (Path(__file__).resolve().parents[1] / "api" / "routes.py").read_text()
 
     assert "goal_related" in routes_py, (
@@ -126,18 +143,22 @@ def test_start_chat_stream_accepts_goal_related():
 # Test 8: _run_agent_streaming accepts and uses goal_related
 # ---------------------------------------------------------------------------
 
+
 def test_run_agent_streaming_uses_goal_related():
     """_run_agent_streaming must accept goal_related kwarg and use it to
     gate the goal evaluation hook."""
     from pathlib import Path
-    streaming_py = (Path(__file__).resolve().parents[1] / "api" / "streaming.py").read_text()
+
+    streaming_py = (
+        Path(__file__).resolve().parents[1] / "api" / "streaming.py"
+    ).read_text()
 
     # Function must accept goal_related parameter
     func_def_idx = streaming_py.find("def _run_agent_streaming")
     assert func_def_idx != -1
 
     # The function signature area (within ~200 chars) should contain goal_related
-    sig_area = streaming_py[func_def_idx:func_def_idx + 500]
+    sig_area = streaming_py[func_def_idx : func_def_idx + 500]
     assert "goal_related" in sig_area, (
         "_run_agent_streaming must accept a goal_related parameter"
     )
@@ -147,10 +168,14 @@ def test_run_agent_streaming_uses_goal_related():
 # Test 9: STREAM_GOAL_RELATED cleanup on stream exit
 # ---------------------------------------------------------------------------
 
+
 def test_stream_goal_related_cleaned_up():
     """STREAM_GOAL_RELATED entries must be cleaned up when streams end."""
     from pathlib import Path
-    streaming_py = (Path(__file__).resolve().parents[1] / "api" / "streaming.py").read_text()
+
+    streaming_py = (
+        Path(__file__).resolve().parents[1] / "api" / "streaming.py"
+    ).read_text()
 
     # Must have cleanup of STREAM_GOAL_RELATED
     assert "STREAM_GOAL_RELATED" in streaming_py
@@ -167,6 +192,7 @@ def test_stream_goal_related_cleaned_up():
 # ---------------------------------------------------------------------------
 # Test 10: functional test with FakeGoalManager at streaming integration level
 # ---------------------------------------------------------------------------
+
 
 def test_goal_evaluate_after_turn_only_increments_for_user_initiated(monkeypatch):
     """Verify that evaluate_goal_after_turn only increments turns_used

--- a/tests/test_issue_code_syntax_highlight.py
+++ b/tests/test_issue_code_syntax_highlight.py
@@ -1,4 +1,5 @@
 """Regression tests for fenced code block syntax highlighting."""
+
 from pathlib import Path
 
 UI_JS = Path(__file__).resolve().parent.parent / "static" / "ui.js"
@@ -14,11 +15,12 @@ def test_fenced_code_blocks_add_prism_language_class():
         "Fenced code blocks should add Prism language-* classes so syntax highlighting works"
     )
 
+
 def test_fenced_code_blocks_keep_existing_pre_header_layout():
     js = _read_ui_js()
     # The fenced code rendering was moved into the stash callback (#1154 fix).
     # The template string now uses `lang` instead of `normalizedLang`.
-    assert '${h}<pre><code${langAttr}>${esc(code.replace(/\\n$/,' in js, (
+    assert "${h}<pre><code${langAttr}>${esc(code.replace(/\\n$/," in js, (
         "The syntax-highlight fix should preserve the existing fenced code block layout"
     )
     assert '<div class="code-block">' not in js, (

--- a/tests/test_issues_373_374_375.py
+++ b/tests/test_issues_373_374_375.py
@@ -5,18 +5,19 @@ Tests for issues #373, #374, and #375.
 #374: Remove stale OpenAI models from default list (gpt-4o, o3)
 #375: Model dropdown should fetch live models from provider
 """
+
 import pathlib
-import re
 
 REPO = pathlib.Path(__file__).parent.parent
 STREAMING_PY = (REPO / "api" / "streaming.py").read_text(encoding="utf-8")
-CONFIG_PY    = (REPO / "api" / "config.py").read_text(encoding="utf-8")
-ROUTES_PY    = (REPO / "api" / "routes.py").read_text(encoding="utf-8")
-MESSAGES_JS  = (REPO / "static" / "messages.js").read_text(encoding="utf-8")
-UI_JS        = (REPO / "static" / "ui.js").read_text(encoding="utf-8")
+CONFIG_PY = (REPO / "api" / "config.py").read_text(encoding="utf-8")
+ROUTES_PY = (REPO / "api" / "routes.py").read_text(encoding="utf-8")
+MESSAGES_JS = (REPO / "static" / "messages.js").read_text(encoding="utf-8")
+UI_JS = (REPO / "static" / "ui.js").read_text(encoding="utf-8")
 
 
 # ── Issue #373: Silent error detection ──────────────────────────────────────
+
 
 class TestSilentErrorDetection:
     """streaming.py must emit apperror when agent returns no assistant reply."""
@@ -38,7 +39,9 @@ class TestSilentErrorDetection:
         # The return statement must come after the put('apperror') for no_response
         no_resp_pos = STREAMING_PY.find("'no_response'")
         # Comment updated: "apperror already closes the stream on the client side"
-        return_pos = STREAMING_PY.find("return  # apperror already closes the stream", no_resp_pos)
+        return_pos = STREAMING_PY.find(
+            "return  # apperror already closes the stream", no_resp_pos
+        )
         assert no_resp_pos != -1, "no_response type not found in streaming.py"
         assert return_pos != -1, (
             "streaming.py must return after emitting apperror to prevent also emitting done (#373)"
@@ -57,9 +60,9 @@ class TestSilentErrorDetection:
     def test_messages_js_done_handler_detects_no_reply(self):
         """messages.js done handler must show an error if no assistant reply arrived."""
         # Check for either the variable name or the inlined check pattern
-        has_no_reply_guard = (
-            "hasAssistantReply" in MESSAGES_JS
-            or ("role==='assistant'" in MESSAGES_JS and "No response received" in MESSAGES_JS)
+        has_no_reply_guard = "hasAssistantReply" in MESSAGES_JS or (
+            "role==='assistant'" in MESSAGES_JS
+            and "No response received" in MESSAGES_JS
         )
         assert has_no_reply_guard, (
             "messages.js done handler must detect zero assistant replies (#373)"
@@ -82,6 +85,7 @@ class TestSilentErrorDetection:
 
 
 # ── Issue #374: Stale model list cleanup ─────────────────────────────────────
+
 
 class TestStaleModelListCleanup:
     """gpt-4o and o3 must be removed from the primary OpenAI model lists."""
@@ -131,6 +135,7 @@ class TestStaleModelListCleanup:
     def test_fallback_has_gpt54(self):
         """_FALLBACK_MODELS must contain gpt-5.4-mini as the primary OpenAI option."""
         from api.config import _FALLBACK_MODELS
+
         ids = [m["id"] for m in _FALLBACK_MODELS]
         assert any("gpt-5.4-mini" in mid for mid in ids), (
             "_FALLBACK_MODELS must include gpt-5.4-mini as the primary OpenAI option"
@@ -150,6 +155,7 @@ class TestStaleModelListCleanup:
 
 # ── Issue #375: Live model fetching ─────────────────────────────────────────
 
+
 class TestLiveModelFetching:
     """Backend and frontend must support live model fetching from provider APIs."""
 
@@ -167,15 +173,15 @@ class TestLiveModelFetching:
 
     def test_live_models_handler_validates_scheme(self):
         """_handle_live_models must validate URL scheme to prevent file:// injection (B310)."""
-        assert "nosec B310" in ROUTES_PY or ("scheme" in ROUTES_PY and "http" in ROUTES_PY), (
-            "_handle_live_models must validate URL scheme before urlopen (#375)"
-        )
+        assert "nosec B310" in ROUTES_PY or (
+            "scheme" in ROUTES_PY and "http" in ROUTES_PY
+        ), "_handle_live_models must validate URL scheme before urlopen (#375)"
 
     def test_live_models_handler_has_ssrf_guard(self):
         """_handle_live_models must guard against SSRF (private IP access)."""
-        assert "ssrf_blocked" in ROUTES_PY or ("is_private" in ROUTES_PY and "live" in ROUTES_PY), (
-            "_handle_live_models must have SSRF protection for private IP ranges (#375)"
-        )
+        assert "ssrf_blocked" in ROUTES_PY or (
+            "is_private" in ROUTES_PY and "live" in ROUTES_PY
+        ), "_handle_live_models must have SSRF protection for private IP ranges (#375)"
 
     def test_live_models_all_providers_handled_via_agent(self):
         """_handle_live_models must delegate to provider_model_ids() which handles all
@@ -189,9 +195,10 @@ class TestLiveModelFetching:
 
     def test_frontend_has_fetch_live_models_function(self):
         """ui.js must define _fetchLiveModels() for background live model loading (#375)."""
-        assert "function _fetchLiveModels(" in UI_JS or "async function _fetchLiveModels(" in UI_JS, (
-            "ui.js must define _fetchLiveModels() function (#375)"
-        )
+        assert (
+            "function _fetchLiveModels(" in UI_JS
+            or "async function _fetchLiveModels(" in UI_JS
+        ), "ui.js must define _fetchLiveModels() function (#375)"
 
     def test_frontend_live_models_cache_exists(self):
         """ui.js must cache live model responses to avoid redundant API calls (#375)."""
@@ -217,7 +224,7 @@ class TestLiveModelFetching:
         # The old skip list (anthropic, google, gemini) must be gone from the guard
         skip_guard_pos = UI_JS.find("includes(provider)")
         if skip_guard_pos != -1:
-            guard_line = UI_JS[max(0,skip_guard_pos-100):skip_guard_pos+50]
+            guard_line = UI_JS[max(0, skip_guard_pos - 100) : skip_guard_pos + 50]
             assert "anthropic" not in guard_line, (
                 "_fetchLiveModels must not skip anthropic — backend now handles it (#375 upgrade)"
             )
@@ -234,6 +241,7 @@ class TestLiveModelFetching:
 
 
 # ── #669: Gemini model IDs must be valid for Google AI Studio endpoint ────────
+
 
 class TestGeminiModelIds:
     """Gemini 3.x model IDs must be valid for the native Google AI Studio provider.
@@ -254,7 +262,7 @@ class TestGeminiModelIds:
         """_PROVIDER_MODELS['gemini'] must contain valid Gemini 3.x model IDs (#669)."""
         gemini_block_start = CONFIG_PY.find('"gemini": [')
         assert gemini_block_start != -1, "_PROVIDER_MODELS['gemini'] block not found"
-        gemini_block = CONFIG_PY[gemini_block_start:gemini_block_start + 600]
+        gemini_block = CONFIG_PY[gemini_block_start : gemini_block_start + 600]
         for mid in self.VALID_GEMINI_3:
             assert mid in gemini_block, (
                 f"_PROVIDER_MODELS['gemini'] must contain {mid!r} — "
@@ -269,7 +277,7 @@ class TestGeminiModelIds:
         """
         gemini_block_start = CONFIG_PY.find('"gemini": [')
         assert gemini_block_start != -1
-        gemini_block = CONFIG_PY[gemini_block_start:gemini_block_start + 600]
+        gemini_block = CONFIG_PY[gemini_block_start : gemini_block_start + 600]
         assert "gemini-3.1-flash-lite-preview" in gemini_block, (
             "_PROVIDER_MODELS['gemini'] missing gemini-3.1-flash-lite-preview — "
             "this was the exact model the #669 reporter tried and got API_KEY_INVALID"
@@ -283,9 +291,9 @@ class TestGeminiModelIds:
         depth = 0
         pos = fallback_start + len("_FALLBACK_MODELS = [")
         for i, ch in enumerate(CONFIG_PY[pos:], start=pos):
-            if ch == '[':
+            if ch == "[":
                 depth += 1
-            elif ch == ']':
+            elif ch == "]":
                 if depth == 0:
                     fallback_end = i
                     break
@@ -300,14 +308,17 @@ class TestGeminiModelIds:
         """_PROVIDER_MODELS['gemini'] must retain stable Gemini 2.5 models (#669)."""
         gemini_block_start = CONFIG_PY.find('"gemini": [')
         assert gemini_block_start != -1
-        gemini_block = CONFIG_PY[gemini_block_start:gemini_block_start + 600]
+        gemini_block = CONFIG_PY[gemini_block_start : gemini_block_start + 600]
         assert "gemini-2.5-pro" in gemini_block, (
             "_PROVIDER_MODELS['gemini'] must keep gemini-2.5-pro as a stable fallback"
         )
 
     def test_no_invalid_gemini_3_pro_model(self):
         """gemini-3-pro-preview must not appear — it was shut down March 9 2026 (#669)."""
-        assert "gemini-3-pro-preview" not in CONFIG_PY or "gemini-3.1-pro-preview" in CONFIG_PY, (
+        assert (
+            "gemini-3-pro-preview" not in CONFIG_PY
+            or "gemini-3.1-pro-preview" in CONFIG_PY
+        ), (
             "gemini-3-pro-preview was shut down — use gemini-3.1-pro-preview instead (#669)"
         )
         # More precise: ensure the bare (non-.1) version isn't the only one present

--- a/tests/test_issues_853_857.py
+++ b/tests/test_issues_853_857.py
@@ -1,5 +1,6 @@
 """Regression tests for #853 (image_generate inline rendering) and
 #857 (auto-title strips thinking preambles)."""
+
 import os
 import re
 
@@ -12,6 +13,7 @@ def _read(name):
 
 
 # ── #853: MEDIA: URL restore renders any https:// as <img> ────────────────────
+
 
 class TestMediaUrlRendersInline:
     """The `MEDIA:` stash restore in renderMd() must render https:// URLs
@@ -42,6 +44,7 @@ class TestMediaUrlRendersInline:
 
 # ── #857: thinking-preamble stripping in auto-title ──────────────────────────
 
+
 class TestThinkingPreambleStripping:
     """Qwen3 and similar models emit plain-text thinking preambles
     ("Here's a thinking process:", "Let me think through this…") without
@@ -50,6 +53,7 @@ class TestThinkingPreambleStripping:
 
     def test_strip_thinking_markup_drops_heres_thinking_process(self):
         from api.streaming import _strip_thinking_markup
+
         raw = "Here's a thinking process: 1. Analyze the request.\nThe answer is 42."
         out = _strip_thinking_markup(raw)
         assert "thinking process" not in out.lower()
@@ -57,12 +61,14 @@ class TestThinkingPreambleStripping:
 
     def test_strip_thinking_markup_drops_let_me_think(self):
         from api.streaming import _strip_thinking_markup
+
         raw = "Let me think through this carefully.\nHere's the answer."
         out = _strip_thinking_markup(raw)
         assert "let me think" not in out.lower()
 
     def test_strip_thinking_markup_drops_ill_think_about(self):
         from api.streaming import _strip_thinking_markup
+
         raw = "I'll think about this step by step.\nFinal result: 7."
         out = _strip_thinking_markup(raw)
         assert "i'll think about" not in out.lower()
@@ -70,6 +76,7 @@ class TestThinkingPreambleStripping:
 
     def test_strip_thinking_markup_drops_okay_let_me(self):
         from api.streaming import _strip_thinking_markup
+
         raw = "Okay, let me break this down.\nThe answer is yes."
         out = _strip_thinking_markup(raw)
         assert "okay, let me break" not in out.lower()
@@ -77,24 +84,30 @@ class TestThinkingPreambleStripping:
     def test_strip_thinking_markup_preserves_non_preamble_content(self):
         """When the text doesn't start with a thinking preamble, leave it alone."""
         from api.streaming import _strip_thinking_markup
+
         raw = "The user's question is about Python imports."
         out = _strip_thinking_markup(raw)
         assert "python imports" in out.lower()
 
     def test_strip_thinking_markup_case_insensitive(self):
         from api.streaming import _strip_thinking_markup
-        assert "Here's" not in _strip_thinking_markup("HERE'S A THINKING PROCESS:\nThe answer.")
+
+        assert "Here's" not in _strip_thinking_markup(
+            "HERE'S A THINKING PROCESS:\nThe answer."
+        )
 
     def test_looks_invalid_generated_title_catches_heres_thinking(self):
         """The belt-and-suspenders guard on titles that slip past the strip."""
         from api.streaming import _looks_invalid_generated_title
-        assert _looks_invalid_generated_title("Here's a thinking process about Python"), (
-            "_looks_invalid_generated_title must reject 'Here's a thinking ...' titles"
-        )
+
+        assert _looks_invalid_generated_title(
+            "Here's a thinking process about Python"
+        ), "_looks_invalid_generated_title must reject 'Here's a thinking ...' titles"
 
     def test_looks_invalid_generated_title_accepts_real_titles(self):
         """Normal, non-preamble titles must not be rejected."""
         from api.streaming import _looks_invalid_generated_title
+
         assert not _looks_invalid_generated_title("Python import debugging"), (
             "Real titles must still pass the invalid-title guard"
         )

--- a/tests/test_issues_907_908_909_model_dropdown.py
+++ b/tests/test_issues_907_908_909_model_dropdown.py
@@ -1,4 +1,5 @@
 """Regression tests for issues #907, #908, #909 — model dropdown fixes."""
+
 import re
 from pathlib import Path
 
@@ -9,32 +10,33 @@ PANELS_JS = (REPO_ROOT / "static" / "panels.js").read_text(encoding="utf-8")
 
 # ── #907: Normalized dedup in _addLiveModelsToSelect ─────────────────────────
 
+
 class TestIssue907LiveModelDedup:
     """Live-fetched models with @provider: prefix must not duplicate server-injected bare entries."""
 
     def test_addLiveModelsToSelect_has_norm_dedup(self):
         # _normId helper and existingNorm set must be present in _addLiveModelsToSelect
-        fn_idx = UI_JS.find('function _addLiveModelsToSelect(')
+        fn_idx = UI_JS.find("function _addLiveModelsToSelect(")
         assert fn_idx != -1, "_addLiveModelsToSelect not found"
         # Find the closing brace of the function (~800 chars is enough)
-        fn_body = UI_JS[fn_idx:fn_idx + 2000]
-        assert '_normId' in fn_body or 'existingNorm' in fn_body, (
+        fn_body = UI_JS[fn_idx : fn_idx + 2000]
+        assert "_normId" in fn_body or "existingNorm" in fn_body, (
             "_addLiveModelsToSelect must normalise IDs before dedup check (#907)"
         )
 
     def test_normId_strips_at_prefix(self):
         # The _normId lambda/function must strip @provider: prefix
-        fn_idx = UI_JS.find('function _addLiveModelsToSelect(')
-        fn_body = UI_JS[fn_idx:fn_idx + 2000]
-        has_at_strip = ("startsWith('@')" in fn_body or "split(':'" in fn_body)
+        fn_idx = UI_JS.find("function _addLiveModelsToSelect(")
+        fn_body = UI_JS[fn_idx : fn_idx + 2000]
+        has_at_strip = "startsWith('@')" in fn_body or "split(':'" in fn_body
         assert has_at_strip, (
             "_normId in _addLiveModelsToSelect must strip @provider: prefix for dedup (#907)"
         )
 
     def test_existingNorm_used_as_guard(self):
-        fn_idx = UI_JS.find('function _addLiveModelsToSelect(')
-        fn_body = UI_JS[fn_idx:fn_idx + 2000]
-        assert 'existingNorm.has(' in fn_body, (
+        fn_idx = UI_JS.find("function _addLiveModelsToSelect(")
+        fn_body = UI_JS[fn_idx : fn_idx + 2000]
+        assert "existingNorm.has(" in fn_body, (
             "_addLiveModelsToSelect must check existingNorm before appending (#907)"
         )
 
@@ -45,12 +47,12 @@ class TestIssue907LiveModelDedup:
         (unlike Python's split), so the naive variant would lose the tag suffix
         and mis-dedup.
         """
-        fn_idx = UI_JS.find('function _addLiveModelsToSelect(')
+        fn_idx = UI_JS.find("function _addLiveModelsToSelect(")
         assert fn_idx != -1
-        fn_body = UI_JS[fn_idx:fn_idx + 2000]
+        fn_body = UI_JS[fn_idx : fn_idx + 2000]
         # The implementation must use indexOf/substring or split().slice(1).join(),
         # not split(':', 2)[1] which truncates the tail.
-        good = 'indexOf' in fn_body or "slice(1).join(':')" in fn_body
+        good = "indexOf" in fn_body or "slice(1).join(':')" in fn_body
         assert good, (
             "_normId must strip only the first colon to preserve Ollama multi-colon "
             "tag IDs (e.g. @ollama-cloud:qwen3-vl:235b-instruct). Use "
@@ -65,45 +67,51 @@ class TestIssue907LiveModelDedup:
 
 # ── #908: window._defaultModel updated on settings save ─────────────────────
 
+
 class TestIssue908DefaultModelSync:
     """window._defaultModel must be updated when the user saves a new default in Preferences."""
 
     def test_applySavedSettingsUi_updates_window_defaultModel(self):
-        fn_idx = PANELS_JS.find('function _applySavedSettingsUi(')
+        fn_idx = PANELS_JS.find("function _applySavedSettingsUi(")
         assert fn_idx != -1, "_applySavedSettingsUi not found"
         # Find the end of the function (next function definition)
-        fn_end = PANELS_JS.find('\nasync function saveSettings(', fn_idx)
+        fn_end = PANELS_JS.find("\nasync function saveSettings(", fn_idx)
         fn_body = PANELS_JS[fn_idx:fn_end]
-        assert 'window._defaultModel' in fn_body, (
+        assert "window._defaultModel" in fn_body, (
             "_applySavedSettingsUi must update window._defaultModel so newSession() "
             "uses the newly saved default without a page reload (#908)"
         )
 
     def test_defaultModel_update_conditioned_on_body_default_model(self):
-        fn_idx = PANELS_JS.find('function _applySavedSettingsUi(')
-        fn_end = PANELS_JS.find('\nasync function saveSettings(', fn_idx)
+        fn_idx = PANELS_JS.find("function _applySavedSettingsUi(")
+        fn_end = PANELS_JS.find("\nasync function saveSettings(", fn_idx)
         fn_body = PANELS_JS[fn_idx:fn_end]
         # Must be guarded so we don't clear _defaultModel when body.default_model is absent
-        assert "if(body.default_model)" in fn_body or "body.default_model &&" in fn_body, (
+        assert (
+            "if(body.default_model)" in fn_body or "body.default_model &&" in fn_body
+        ), (
             "window._defaultModel assignment must be conditional on body.default_model being set"
         )
 
 
 # ── #909: Injected default model label quality ───────────────────────────────
 
+
 class TestIssue909InjectedModelLabel:
     """The server must use a proper label for the injected default model (not raw lowercase ID)."""
 
     def test_get_label_for_model_helper_exists(self):
         import api.config as config
-        assert hasattr(config, '_get_label_for_model'), (
+
+        assert hasattr(config, "_get_label_for_model"), (
             "api/config.py must define _get_label_for_model() for the injected default label (#909)"
         )
 
     def test_label_helper_capitalizes_bare_id(self):
         from api.config import _get_label_for_model
-        label = _get_label_for_model('minimax/minimax-m2.7', [])
-        assert label != 'minimax-m2.7', (
+
+        label = _get_label_for_model("minimax/minimax-m2.7", [])
+        assert label != "minimax-m2.7", (
             "_get_label_for_model should not return the raw lowercase ID (#909)"
         )
         # Should capitalize: "Minimax M2.7" or similar
@@ -111,41 +119,52 @@ class TestIssue909InjectedModelLabel:
 
     def test_label_helper_uses_catalog_when_available(self):
         from api.config import _get_label_for_model
+
         existing_groups = [
-            {"provider": "Nous", "models": [
-                {"id": "minimax/minimax-m2.7", "label": "Minimax M2.7 (Nous)"}
-            ]}
+            {
+                "provider": "Nous",
+                "models": [
+                    {"id": "minimax/minimax-m2.7", "label": "Minimax M2.7 (Nous)"}
+                ],
+            }
         ]
-        label = _get_label_for_model('minimax/minimax-m2.7', existing_groups)
+        label = _get_label_for_model("minimax/minimax-m2.7", existing_groups)
         assert label == "Minimax M2.7 (Nous)", (
             "_get_label_for_model should prefer catalog label over generated one"
         )
 
     def test_label_helper_strips_at_prefix_for_lookup(self):
         from api.config import _get_label_for_model
+
         existing_groups = [
-            {"provider": "Nous", "models": [
-                {"id": "minimax/minimax-m2.7", "label": "Minimax M2.7"}
-            ]}
+            {
+                "provider": "Nous",
+                "models": [{"id": "minimax/minimax-m2.7", "label": "Minimax M2.7"}],
+            }
         ]
         # @nous:minimax/minimax-m2.7 should match minimax/minimax-m2.7 in catalog
-        label = _get_label_for_model('@nous:minimax/minimax-m2.7', existing_groups)
+        label = _get_label_for_model("@nous:minimax/minimax-m2.7", existing_groups)
         assert label == "Minimax M2.7", (
             "_get_label_for_model must strip @provider: prefix before catalog lookup"
         )
 
     def test_config_uses_label_helper_not_raw_split(self):
         from pathlib import Path
-        config_src = (Path(__file__).resolve().parent.parent / "api" / "config.py").read_text()
+
+        config_src = (
+            Path(__file__).resolve().parent.parent / "api" / "config.py"
+        ).read_text()
         # The raw label-building pattern should be replaced by the helper
         assert "_get_label_for_model" in config_src, (
             "api/config.py must call _get_label_for_model() for injected default model labels (#909)"
         )
         # The old raw pattern should NOT be present in the injection block
-        old_pattern = 'default_model.split("/")[-1] if "/" in default_model else default_model'
+        old_pattern = (
+            'default_model.split("/")[-1] if "/" in default_model else default_model'
+        )
         label_sections = [
-            config_src[i:i+200]
-            for i in [m.start() for m in re.finditer(r'label\s*=\s*', config_src)]
+            config_src[i : i + 200]
+            for i in [m.start() for m in re.finditer(r"label\s*=\s*", config_src)]
         ]
         for sec in label_sections:
             assert old_pattern not in sec, (

--- a/tests/test_japanese_locale.py
+++ b/tests/test_japanese_locale.py
@@ -146,10 +146,18 @@ def test_japanese_locale_duplicates_match_english():
     src = read(REPO / "static" / "i18n.js")
     key_pattern = re.compile(r"^\s{4}([a-zA-Z0-9_]+):", re.MULTILINE)
     en_dupes = sorted(
-        k for k, c in Counter(key_pattern.findall(extract_locale_block(src, "en"))).items() if c > 1
+        k
+        for k, c in Counter(
+            key_pattern.findall(extract_locale_block(src, "en"))
+        ).items()
+        if c > 1
     )
     ja_dupes = sorted(
-        k for k, c in Counter(key_pattern.findall(extract_locale_block(src, "ja"))).items() if c > 1
+        k
+        for k, c in Counter(
+            key_pattern.findall(extract_locale_block(src, "ja"))
+        ).items()
+        if c > 1
     )
     assert en_dupes == ja_dupes, (
         f"Japanese duplicates must mirror English exactly. "

--- a/tests/test_kanban_bridge.py
+++ b/tests/test_kanban_bridge.py
@@ -76,7 +76,10 @@ class FakeConn:
                 rows.append(FakeRow(status=status, assignee=assignee, n=n))
             return SimpleNamespace(fetchall=lambda: rows)
         if "SELECT DISTINCT assignee FROM tasks" in sql:
-            rows = [FakeRow(assignee=a) for a in sorted({t.assignee for t in self.tasks if t.assignee})]
+            rows = [
+                FakeRow(assignee=a)
+                for a in sorted({t.assignee for t in self.tasks if t.assignee})
+            ]
             return SimpleNamespace(fetchall=lambda: rows)
         if "FROM task_events WHERE id >" in sql:
             since, limit = params
@@ -94,7 +97,12 @@ class FakeConn:
             ][:limit]
             return SimpleNamespace(fetchall=lambda: rows)
         if sql.startswith("UPDATE tasks SET "):
-            fields = [part.strip().split(" = ")[0] for part in sql[len("UPDATE tasks SET "):].split(" WHERE id = ")[0].split(",")]
+            fields = [
+                part.strip().split(" = ")[0]
+                for part in sql[len("UPDATE tasks SET ") :]
+                .split(" WHERE id = ")[0]
+                .split(",")
+            ]
             *values, task_id = params
             task = next((task for task in self.tasks if task.id == task_id), None)
             if task:
@@ -107,7 +115,9 @@ class FakeConn:
 class FakeKanbanDB:
     def __init__(self):
         self.tasks = [
-            FakeTask("t_1", "Read-only board target", "ready", "webui-test", tenant="webui"),
+            FakeTask(
+                "t_1", "Read-only board target", "ready", "webui-test", tenant="webui"
+            ),
             FakeTask("t_2", "Blocked target", "blocked", "other", tenant="ops"),
         ]
         self.events = [FakeEvent(7, "t_1", None, "created", {"status": "ready"}, 123)]
@@ -125,7 +135,9 @@ class FakeKanbanDB:
     def connect(self, *, board=None):
         return FakeConn(self.tasks, self.events)
 
-    def list_tasks(self, conn, tenant=None, assignee=None, include_archived=False, **_kwargs):
+    def list_tasks(
+        self, conn, tenant=None, assignee=None, include_archived=False, **_kwargs
+    ):
         tasks = list(conn.tasks)
         if tenant:
             tasks = [task for task in tasks if task.tenant == tenant]
@@ -157,7 +169,9 @@ class FakeKanbanDB:
         return [child for parent, child in self.links if parent == task_id]
 
     def _event(self, task_id, kind, payload=None):
-        self.events.append(FakeEvent(self.next_event_id, task_id, None, kind, payload or {}, 456))
+        self.events.append(
+            FakeEvent(self.next_event_id, task_id, None, kind, payload or {}, 456)
+        )
         self.next_event_id += 1
 
     def create_task(self, conn, **kwargs):
@@ -236,13 +250,18 @@ class FakeKanbanDB:
 
     def worker_log_path(self, task_id):
         from pathlib import Path
+
         return Path(f"/tmp/hermes-kanban/{task_id}.log")
 
     def dispatch_once(self, conn, dry_run=False, max_spawn=8):
         return {"dry_run": dry_run, "max_spawn": max_spawn, "spawned": []}
 
     def add_comment(self, conn, task_id, author, body):
-        self.comments.append(SimpleNamespace(id=len(self.comments) + 1, task_id=task_id, author=author, body=body))
+        self.comments.append(
+            SimpleNamespace(
+                id=len(self.comments) + 1, task_id=task_id, author=author, body=body
+            )
+        )
         self._event(task_id, "commented", {"author": author})
         return len(self.comments)
 
@@ -286,7 +305,13 @@ class FakeKanbanDB:
     def list_boards(self, *, include_archived=True):
         boards = getattr(self, "boards", None)
         if boards is None:
-            self.boards = {"default": {"slug": "default", "name": "Default board", "archived": False}}
+            self.boards = {
+                "default": {
+                    "slug": "default",
+                    "name": "Default board",
+                    "archived": False,
+                }
+            }
             boards = self.boards
         out = []
         for slug, meta in boards.items():
@@ -298,7 +323,13 @@ class FakeKanbanDB:
     def create_board(self, slug, *, name=None, description=None, icon=None, color=None):
         boards = getattr(self, "boards", None)
         if boards is None:
-            self.boards = {"default": {"slug": "default", "name": "Default board", "archived": False}}
+            self.boards = {
+                "default": {
+                    "slug": "default",
+                    "name": "Default board",
+                    "archived": False,
+                }
+            }
             boards = self.boards
         normed = self._normalize_board_slug(slug)
         if not normed:
@@ -316,16 +347,23 @@ class FakeKanbanDB:
         boards[normed] = meta
         return dict(meta)
 
-    def write_board_metadata(self, slug, *, name=None, description=None, icon=None, color=None, archived=None):
+    def write_board_metadata(
+        self, slug, *, name=None, description=None, icon=None, color=None, archived=None
+    ):
         boards = getattr(self, "boards", None) or {}
         if slug not in boards:
             raise LookupError(f"board {slug!r} does not exist")
         meta = dict(boards[slug])
-        if name is not None: meta["name"] = name
-        if description is not None: meta["description"] = description
-        if icon is not None: meta["icon"] = icon
-        if color is not None: meta["color"] = color
-        if archived is not None: meta["archived"] = bool(archived)
+        if name is not None:
+            meta["name"] = name
+        if description is not None:
+            meta["description"] = description
+        if icon is not None:
+            meta["icon"] = icon
+        if color is not None:
+            meta["color"] = color
+        if archived is not None:
+            meta["archived"] = bool(archived)
         boards[slug] = meta
         return dict(meta)
 
@@ -386,7 +424,10 @@ def test_kanban_board_payload_exposes_read_only_board(monkeypatch):
     for expected in ("triage", "todo", "ready", "running", "blocked", "done"):
         assert expected in names
     all_tasks = [task for column in data["columns"] for task in column["tasks"]]
-    assert any(task["id"] == "t_1" and task["title"] == "Read-only board target" for task in all_tasks)
+    assert any(
+        task["id"] == "t_1" and task["title"] == "Read-only board target"
+        for task in all_tasks
+    )
 
 
 def test_board_pointer_drift_falls_back_to_default(monkeypatch):
@@ -402,7 +443,9 @@ def test_board_pointer_drift_falls_back_to_default(monkeypatch):
 
     assert data["current"] == "default"
     assert fake_kanban.get_current_board() == "default"
-    assert any(board["slug"] == "default" and board["is_current"] for board in data["boards"])
+    assert any(
+        board["slug"] == "default" and board["is_current"] for board in data["boards"]
+    )
 
 
 def test_kanban_task_detail_payload_exposes_comments_events_links_and_runs(monkeypatch):
@@ -420,17 +463,18 @@ def test_kanban_task_detail_payload_exposes_comments_events_links_and_runs(monke
     assert isinstance(data["runs"], list)
 
 
-
 def test_kanban_create_task_payload_writes_to_agent_kanban(monkeypatch):
     bridge = _load_bridge(monkeypatch)
 
-    data = bridge._create_task_payload({
-        "title": "Write API target",
-        "body": "Created from WebUI",
-        "assignee": "webui-test",
-        "tenant": "webui",
-        "priority": 2,
-    })
+    data = bridge._create_task_payload(
+        {
+            "title": "Write API target",
+            "body": "Created from WebUI",
+            "assignee": "webui-test",
+            "tenant": "webui",
+            "priority": 2,
+        }
+    )
 
     assert data["read_only"] is False
     assert data["task"]["title"] == "Write API target"
@@ -444,8 +488,12 @@ def test_kanban_patch_task_payload_updates_status_title_and_comment(monkeypatch)
 
     created = bridge._create_task_payload({"title": "Patch target"})
     task_id = created["task"]["id"]
-    patched = bridge._patch_task_payload(task_id, {"title": "Patched target", "status": "done"})
-    comment = bridge._comment_payload(task_id, {"author": "webui", "body": "Looks done"})
+    patched = bridge._patch_task_payload(
+        task_id, {"title": "Patched target", "status": "done"}
+    )
+    comment = bridge._comment_payload(
+        task_id, {"author": "webui", "body": "Looks done"}
+    )
     detail = bridge._task_detail_payload(task_id)
 
     assert patched["read_only"] is False
@@ -463,8 +511,14 @@ def test_kanban_link_payload_adds_parent_child_relationship(monkeypatch):
     linked = bridge._link_tasks_payload({"parent_id": parent, "child_id": child})
     detail = bridge._task_detail_payload(child)
 
-    assert linked == {"ok": True, "parent_id": parent, "child_id": child, "read_only": False}
+    assert linked == {
+        "ok": True,
+        "parent_id": parent,
+        "child_id": child,
+        "read_only": False,
+    }
     assert detail["links"]["parents"] == [parent]
+
 
 def test_kanban_board_since_returns_lightweight_unchanged_payload(monkeypatch):
     bridge = _load_bridge(monkeypatch)
@@ -483,7 +537,9 @@ def test_kanban_events_payload_matches_polling_shape(monkeypatch):
     assert events["latest_event_id"] == 7
     assert events["read_only"] is False
     assert events["events"][0]["task_id"] == "t_1"
-    assert {"id", "task_id", "run_id", "kind", "payload", "created_at"} <= set(events["events"][0])
+    assert {"id", "task_id", "run_id", "kind", "payload", "created_at"} <= set(
+        events["events"][0]
+    )
 
 
 def test_routes_dispatches_api_kanban_get_to_bridge():
@@ -498,33 +554,46 @@ def test_routes_dispatches_api_kanban_post_to_bridge():
     assert "handle_kanban_post(handler, parsed, body)" in src
 
 
-
 def test_kanban_dashboard_core_api_exposes_stats_assignees_config_and_logs(monkeypatch):
     bridge = _load_bridge(monkeypatch)
 
     stats = bridge._stats_payload()
     assignees = bridge._assignees_payload()
     config = bridge._config_payload()
-    log = bridge._task_log_payload(_parsed(path="/api/kanban/tasks/t_1/log", query="tail=64"), "t_1")
+    log = bridge._task_log_payload(
+        _parsed(path="/api/kanban/tasks/t_1/log", query="tail=64"), "t_1"
+    )
 
     assert stats["by_status"]["ready"] == 1
     assert "webui-test" in assignees["assignees"]
     assert config["columns"]
-    assert {"default_tenant", "lane_by_profile", "include_archived_by_default", "render_markdown", "assignees"} <= set(config)
+    assert {
+        "default_tenant",
+        "lane_by_profile",
+        "include_archived_by_default",
+        "render_markdown",
+        "assignees",
+    } <= set(config)
     assert log["task_id"] == "t_1"
     assert log["content"] == "worker log for t_1"
 
 
 def test_kanban_only_mine_bulk_dispatch_and_block_unblock(monkeypatch):
     bridge = _load_bridge(monkeypatch)
-    monkeypatch.setattr("api.profiles.get_active_profile_name", lambda: "webui-test", raising=False)
+    monkeypatch.setattr(
+        "api.profiles.get_active_profile_name", lambda: "webui-test", raising=False
+    )
 
     mine = bridge._board_payload(_parsed(query="only_mine=1"))
     visible_ids = [task["id"] for col in mine["columns"] for task in col["tasks"]]
-    bulk = bridge._bulk_tasks_payload({"ids": ["t_1", "t_2"], "status": "done", "priority": 3})
+    bulk = bridge._bulk_tasks_payload(
+        {"ids": ["t_1", "t_2"], "status": "done", "priority": 3}
+    )
     blocked = bridge._task_action_payload("t_1", {"reason": "waiting"}, "block")
     unblocked = bridge._task_action_payload("t_1", {}, "unblock")
-    dispatch = bridge._dispatch_payload(_parsed(path="/api/kanban/dispatch", query="dry_run=1&max=2"))
+    dispatch = bridge._dispatch_payload(
+        _parsed(path="/api/kanban/dispatch", query="dry_run=1&max=2")
+    )
 
     assert visible_ids == ["t_1"]
     assert [row["ok"] for row in bulk["results"]] == [True, True]
@@ -532,7 +601,6 @@ def test_kanban_only_mine_bulk_dispatch_and_block_unblock(monkeypatch):
     assert unblocked["task"]["status"] == "ready"
     assert dispatch["dry_run"] is True
     assert dispatch["max_spawn"] == 2
-
 
 
 def test_routes_dispatches_canonical_kanban_patch_and_delete_verbs():
@@ -558,7 +626,7 @@ def test_patch_status_running_is_rejected_to_protect_dispatcher_contract(monkeyp
     reject this transition.
     """
     bridge = _load_bridge(monkeypatch)
-    bridge._OAUTH_FLOWS = getattr(bridge, '_OAUTH_FLOWS', {})  # no-op safe
+    bridge._OAUTH_FLOWS = getattr(bridge, "_OAUTH_FLOWS", {})  # no-op safe
     # The fake board includes t_1 (ready) — try to PATCH it to 'running'
     try:
         bridge._patch_task_payload("t_1", {"status": "running"})
@@ -615,7 +683,8 @@ def test_handle_kanban_get_returns_503_when_hermes_cli_missing(monkeypatch):
     bridge = _load_bridge(monkeypatch)
     # Force _kb() to raise ImportError as if hermes_cli was uninstalled
     monkeypatch.setattr(
-        bridge, "_kb",
+        bridge,
+        "_kb",
         lambda: (_ for _ in ()).throw(ImportError("No module named 'hermes_cli'")),
     )
 
@@ -646,7 +715,8 @@ def test_handle_kanban_post_returns_503_when_hermes_cli_missing(monkeypatch):
     """Same fallback contract for POST verb."""
     bridge = _load_bridge(monkeypatch)
     monkeypatch.setattr(
-        bridge, "_kb",
+        bridge,
+        "_kb",
         lambda: (_ for _ in ()).throw(ImportError("hermes_cli missing")),
     )
     captured = {}
@@ -671,7 +741,8 @@ def test_handle_kanban_patch_returns_503_when_hermes_cli_missing(monkeypatch):
     """Same fallback contract for PATCH verb."""
     bridge = _load_bridge(monkeypatch)
     monkeypatch.setattr(
-        bridge, "_kb",
+        bridge,
+        "_kb",
         lambda: (_ for _ in ()).throw(ImportError("hermes_cli missing")),
     )
     captured = {}
@@ -718,9 +789,11 @@ def test_board_counts_returns_empty_for_nonexistent_board(monkeypatch):
     fake_kanban = FakeKanbanDB()
     connect_calls = []
     orig_connect = fake_kanban.connect
+
     def tracking_connect(*, board=None):
         connect_calls.append(("connect", board))
         return orig_connect(board=board)
+
     fake_kanban.connect = tracking_connect
 
     fake_hermes_cli = types.ModuleType("hermes_cli")
@@ -728,6 +801,7 @@ def test_board_counts_returns_empty_for_nonexistent_board(monkeypatch):
     monkeypatch.setitem(sys.modules, "hermes_cli", fake_hermes_cli)
     monkeypatch.setitem(sys.modules, "hermes_cli.kanban_db", fake_kanban)
     import api.kanban_bridge as bridge
+
     bridge = importlib.reload(bridge)
 
     counts = bridge._board_counts_for_slug("no-such-board")
@@ -746,13 +820,18 @@ def test_board_counts_returns_real_counts_for_populated_board(monkeypatch):
     monkeypatch.setitem(sys.modules, "hermes_cli", fake_hermes_cli)
     monkeypatch.setitem(sys.modules, "hermes_cli.kanban_db", fake_kanban)
     import api.kanban_bridge as bridge
+
     bridge = importlib.reload(bridge)
 
     # Patch FakeConn.execute to handle the board-counts SQL:
     #   SELECT status, COUNT(*) AS n FROM tasks WHERE status != 'archived' GROUP BY status
     orig_execute = FakeConn.execute
+
     def patched_execute(self, sql, params=()):
-        if "SELECT status, COUNT(*) AS n FROM tasks" in sql and "GROUP BY status" in sql:
+        if (
+            "SELECT status, COUNT(*) AS n FROM tasks" in sql
+            and "GROUP BY status" in sql
+        ):
             rows = []
             grouped = {}
             for task in self.tasks:
@@ -763,6 +842,7 @@ def test_board_counts_returns_real_counts_for_populated_board(monkeypatch):
                 rows.append(FakeRow(status=status, n=n))
             return SimpleNamespace(fetchall=lambda: rows)
         return orig_execute(self, sql, params)
+
     FakeConn.execute = patched_execute
 
     try:
@@ -778,14 +858,16 @@ def test_create_board_payload_creates_and_optionally_switches(monkeypatch):
     """POST /boards must create a board and, when ``switch=true``, also set
     it as the active board so subsequent requests resolve to it."""
     bridge = _load_bridge(monkeypatch)
-    payload = bridge._create_board_payload({
-        "slug": "experiments",
-        "name": "Experiments",
-        "description": "Research backlog",
-        "icon": "🧪",
-        "color": "#7aa2ff",
-        "switch": True,
-    })
+    payload = bridge._create_board_payload(
+        {
+            "slug": "experiments",
+            "name": "Experiments",
+            "description": "Research backlog",
+            "icon": "🧪",
+            "color": "#7aa2ff",
+            "switch": True,
+        }
+    )
     assert payload["board"]["slug"] == "experiments"
     assert payload["board"]["name"] == "Experiments"
     assert payload["current"] == "experiments"  # switch=true honoured
@@ -808,11 +890,14 @@ def test_update_board_payload_renames_metadata_only(monkeypatch):
     and re-pointing every saved active-board pointer."""
     bridge = _load_bridge(monkeypatch)
     bridge._create_board_payload({"slug": "experiments", "name": "Experiments"})
-    res = bridge._update_board_payload("experiments", {
-        "name": "R&D Experiments",
-        "description": "All ongoing research",
-        "icon": "🔬",
-    })
+    res = bridge._update_board_payload(
+        "experiments",
+        {
+            "name": "R&D Experiments",
+            "description": "All ongoing research",
+            "icon": "🔬",
+        },
+    )
     assert res["board"]["name"] == "R&D Experiments"
     assert res["board"]["description"] == "All ongoing research"
     assert res["board"]["icon"] == "🔬"
@@ -953,13 +1038,15 @@ def test_handle_kanban_post_routes_create_board_and_switch(monkeypatch):
     monkeypatch.setattr(bridge, "j", fake_j)
     # Create
     bridge.handle_kanban_post(
-        FakeHandler(), _parsed(path="/api/kanban/boards"),
+        FakeHandler(),
+        _parsed(path="/api/kanban/boards"),
         {"slug": "experiments", "name": "Experiments"},
     )
     assert "board" in captured[0]
     # Switch
     bridge.handle_kanban_post(
-        FakeHandler(), _parsed(path="/api/kanban/boards/experiments/switch"),
+        FakeHandler(),
+        _parsed(path="/api/kanban/boards/experiments/switch"),
         {},
     )
     assert captured[1]["current"] == "experiments"
@@ -1001,7 +1088,8 @@ def test_handle_kanban_patch_routes_update_board(monkeypatch):
     monkeypatch.setattr(bridge, "j", fake_j)
     bridge._create_board_payload({"slug": "experiments", "name": "x"})
     bridge.handle_kanban_patch(
-        FakeHandler(), _parsed(path="/api/kanban/boards/experiments"),
+        FakeHandler(),
+        _parsed(path="/api/kanban/boards/experiments"),
         {"name": "Renamed"},
     )
     assert captured[0]["board"]["name"] == "Renamed"
@@ -1213,9 +1301,14 @@ def test_sse_emits_id_lines_so_browser_can_resume_via_last_event_id(monkeypatch)
             self.headers = {}
             self.responses = []
 
-        def send_response(self, code): self.responses.append(code)
-        def send_header(self, k, v): pass
-        def end_headers(self): pass
+        def send_response(self, code):
+            self.responses.append(code)
+
+        def send_header(self, k, v):
+            pass
+
+        def end_headers(self):
+            pass
 
     handler = FakeHandler()
     done = threading.Event()
@@ -1269,9 +1362,14 @@ def test_sse_honours_last_event_id_header_when_since_absent(monkeypatch):
             self.headers = {"Last-Event-ID": "42"}
             self.responses = []
 
-        def send_response(self, code): self.responses.append(code)
-        def send_header(self, k, v): pass
-        def end_headers(self): pass
+        def send_response(self, code):
+            self.responses.append(code)
+
+        def send_header(self, k, v):
+            pass
+
+        def end_headers(self):
+            pass
 
     handler = FakeHandler()
     done = threading.Event()

--- a/tests/test_kanban_ui_static.py
+++ b/tests/test_kanban_ui_static.py
@@ -14,9 +14,11 @@ COMPACT_STYLE = re.sub(r"\s+", "", STYLE)
 def test_kanban_has_native_sidebar_rail_and_mobile_tab():
     assert 'data-panel="kanban"' in INDEX
     assert 'data-i18n-title="tab_kanban"' in INDEX
-    assert 'onclick="switchPanel(\'kanban\')"' in INDEX
+    assert "onclick=\"switchPanel('kanban')\"" in INDEX
     assert 'data-label="Kanban"' in INDEX
-    kanban_section = INDEX[INDEX.find('id="mainKanban"'):INDEX.find('id="mainWorkspaces"')]
+    kanban_section = INDEX[
+        INDEX.find('id="mainKanban"') : INDEX.find('id="mainWorkspaces"')
+    ]
     assert "<iframe" not in kanban_section.lower()
 
 
@@ -33,7 +35,9 @@ def test_kanban_has_sidebar_panel_and_main_board_mounts():
 
 
 def test_switch_panel_lazy_loads_kanban_and_toggles_main_view():
-    assert "'kanban'" in re.search(r"\[[^\]]+\]\.forEach\(p => \{\s*mainEl\.classList", PANELS).group(0)
+    assert "'kanban'" in re.search(
+        r"\[[^\]]+\]\.forEach\(p => \{\s*mainEl\.classList", PANELS
+    ).group(0)
     assert "if (nextPanel === 'kanban') await loadKanban();" in PANELS
     assert "if (_currentPanel === 'kanban') await loadKanban();" in PANELS
 
@@ -59,8 +63,14 @@ def test_kanban_task_detail_renders_read_only_sections():
         "kanban-detail-runs",
     ):
         assert section_class in PANELS
-    assert "method: 'POST'" not in PANELS[PANELS.find("async function loadKanbanTask"):PANELS.find("function loadTodos")]
-
+    assert (
+        "method: 'POST'"
+        not in PANELS[
+            PANELS.find("async function loadKanbanTask") : PANELS.find(
+                "function loadTodos"
+            )
+        ]
+    )
 
 
 def test_kanban_write_mvp_has_native_controls_and_api_calls():
@@ -93,7 +103,7 @@ def test_kanban_new_task_header_button_opens_modal():
     """
     # 1. Header "+" button is wired to openKanbanCreate(), NOT createKanbanTask().
     assert 'id="kanbanNewTaskBtn"' in INDEX
-    btn_html = INDEX[INDEX.find('id="kanbanNewTaskBtn"'):]
+    btn_html = INDEX[INDEX.find('id="kanbanNewTaskBtn"') :]
     btn_html = btn_html[: btn_html.find("</button>") + len("</button>")]
     assert 'onclick="openKanbanCreate()"' in btn_html, (
         "Panel-head '+' button must call openKanbanCreate() (modal), not "
@@ -103,7 +113,10 @@ def test_kanban_new_task_header_button_opens_modal():
     # 2. The create-task modal markup exists in index.html, with all the field
     #    ids the JS / API contract expects.
     assert 'id="kanbanTaskModal"' in INDEX
-    assert 'class="kanban-modal-overlay"' in INDEX[INDEX.find('id="kanbanTaskModal"') - 80:]
+    assert (
+        'class="kanban-modal-overlay"'
+        in INDEX[INDEX.find('id="kanbanTaskModal"') - 80 :]
+    )
     for field_id in (
         "kanbanTaskModalTitleInput",
         "kanbanTaskModalBody",
@@ -123,9 +136,7 @@ def test_kanban_new_task_header_button_opens_modal():
     # 4. openKanbanCreate() unhides the modal, focuses the title field, populates
     #    assignee/tenant datalists, binds keydown listener.
     assert "function openKanbanCreate()" in PANELS
-    open_fn = re.search(
-        r"function openKanbanCreate\(\)\{(.*?)\n\}", PANELS, re.DOTALL
-    )
+    open_fn = re.search(r"function openKanbanCreate\(\)\{(.*?)\n\}", PANELS, re.DOTALL)
     assert open_fn, "openKanbanCreate() not found"
     body = open_fn.group(1)
     assert "modal.hidden = false" in body
@@ -201,9 +212,9 @@ def test_kanban_task_detail_has_edit_button_and_modal_supports_edit_mode():
     )
     assert render_match, "_kanbanRenderTaskDetail() not found"
     render_body = render_match.group(1)
-    assert 'class="kanban-edit-btn"' in render_body or "kanban-edit-btn" in render_body, (
-        "Task detail view must include the Edit button (.kanban-edit-btn)."
-    )
+    assert (
+        'class="kanban-edit-btn"' in render_body or "kanban-edit-btn" in render_body
+    ), "Task detail view must include the Edit button (.kanban-edit-btn)."
     assert "openKanbanEdit(" in render_body, (
         "Edit button must invoke openKanbanEdit(taskId)."
     )
@@ -314,22 +325,26 @@ def test_kanban_assignee_dropdown_uses_select_not_freetext():
     sel_idx = INDEX.find('id="kanbanTaskModalAssignee"')
     assert sel_idx != -1, "kanbanTaskModalAssignee element not found"
     # Walk back to find the opening tag — it must be a <select>, not <input>.
-    start = INDEX.rfind('<', 0, sel_idx)
-    tag_open = INDEX[start:sel_idx + 60]
-    assert tag_open.startswith('<select'), (
+    start = INDEX.rfind("<", 0, sel_idx)
+    tag_open = INDEX[start : sel_idx + 60]
+    assert tag_open.startswith("<select"), (
         f"kanbanTaskModalAssignee must be a <select> element, got: {tag_open[:80]!r}"
     )
 
     # Hint element exists and references the dispatcher claim contract.
     assert 'id="kanbanTaskModalAssigneeHint"' in INDEX
     hint_idx = INDEX.find('id="kanbanTaskModalAssigneeHint"')
-    hint_block = INDEX[hint_idx:hint_idx + 400]
-    assert "Hermes profile" in hint_block or "data-i18n=\"kanban_assignee_hint\"" in hint_block
+    hint_block = INDEX[hint_idx : hint_idx + 400]
+    assert (
+        "Hermes profile" in hint_block
+        or 'data-i18n="kanban_assignee_hint"' in hint_block
+    )
 
     # The populator function loads from /api/profiles and groups options.
     pop_match = re.search(
         r"async function _kanbanPopulateAssigneeSelect\([^)]*\)\{(.*?)\n\}",
-        PANELS, re.DOTALL,
+        PANELS,
+        re.DOTALL,
     )
     assert pop_match, "_kanbanPopulateAssigneeSelect() not found"
     pop_body = pop_match.group(1)
@@ -387,8 +402,8 @@ def test_kanban_run_dispatcher_button_exists_and_is_distinct_from_preview():
     btn_idx = INDEX.find('id="btnKanbanRunDispatcher"')
     # Search backward to the opening `<button` and forward to `</button>` to
     # capture the full element (class= attribute precedes id= in the markup).
-    btn_start = INDEX.rfind('<button', 0, btn_idx)
-    btn_end = INDEX.find('</button>', btn_idx) + len('</button>')
+    btn_start = INDEX.rfind("<button", 0, btn_idx)
+    btn_end = INDEX.find("</button>", btn_idx) + len("</button>")
     btn_html = INDEX[btn_start:btn_end]
     assert 'onclick="runKanbanDispatcher()"' in btn_html
     # Distinct visual class so users can tell it apart from the preview button.
@@ -397,7 +412,7 @@ def test_kanban_run_dispatcher_button_exists_and_is_distinct_from_preview():
     # 4. The sidebar bulk bar also has a Run dispatcher button alongside the
     # existing Preview button, so users in the filter pane can also run.
     bulk_idx = INDEX.find("kanbanBulkBar")
-    bulk_html = INDEX[bulk_idx:bulk_idx + 1500]
+    bulk_html = INDEX[bulk_idx : bulk_idx + 1500]
     assert 'onclick="runKanbanDispatcher()"' in bulk_html, (
         "Sidebar bulk bar must also expose Run dispatcher."
     )
@@ -405,13 +420,13 @@ def test_kanban_run_dispatcher_button_exists_and_is_distinct_from_preview():
     assert "function _kanbanFormatDispatchResult" in PANELS
     fmt_match = re.search(
         r"function _kanbanFormatDispatchResult\([^)]*\)\{(.*?)\n\}",
-        PANELS, re.DOTALL,
+        PANELS,
+        re.DOTALL,
     )
     assert fmt_match
     fmt_body = fmt_match.group(1)
     for token in ("spawned", "skipped_unassigned", "skipped_nonspawnable", "promoted"):
         assert token in fmt_body, f"dispatch summary missing field: {token}"
-
 
 
 def test_kanban_board_has_native_css_classes():
@@ -435,11 +450,15 @@ def test_kanban_main_view_scrolls_when_task_preview_is_tall():
     assert re.search(
         r"main\.main\.showing-kanban\s*>\s*#mainKanban\s*\{[^}]*display:flex;[^}]*overflow-y:auto;",
         COMPACT_STYLE,
-    ), "Kanban main view must expose a vertical scrollbar when detail content is taller than the viewport"
+    ), (
+        "Kanban main view must expose a vertical scrollbar when detail content is taller than the viewport"
+    )
 
 
 def test_kanban_i18n_keys_exist_in_every_locale_block():
-    locale_blocks = re.findall(r"\n\s*([a-z]{2}(?:-[A-Z]{2})?): \{(.*?)\n\s*\},", I18N, flags=re.S)
+    locale_blocks = re.findall(
+        r"\n\s*([a-z]{2}(?:-[A-Z]{2})?): \{(.*?)\n\s*\},", I18N, flags=re.S
+    )
     assert len(locale_blocks) >= 8
     required_keys = [
         "tab_kanban",
@@ -472,7 +491,6 @@ def test_kanban_i18n_keys_exist_in_every_locale_block():
     assert missing == []
 
 
-
 def test_kanban_dashboard_parity_core_controls_are_native():
     assert 'id="kanbanOnlyMine"' in INDEX
     assert 'id="kanbanBulkBar"' in INDEX
@@ -495,16 +513,17 @@ def test_kanban_dashboard_parity_core_controls_are_native():
     # the new SSE /api/kanban/events/stream subscription must be present.
     # The multi-board PR replaced setInterval with EventSource as the
     # default, falling back to setInterval after repeated SSE failures.
-    assert (
-        "setInterval(refreshKanbanEvents" in PANELS
-        or "new EventSource" in PANELS
-    ), "Kanban must subscribe to live events via SSE or polling"
+    assert "setInterval(refreshKanbanEvents" in PANELS or "new EventSource" in PANELS, (
+        "Kanban must subscribe to live events via SSE or polling"
+    )
     assert "prompt(" not in PANELS
     assert "confirm(" not in PANELS
 
 
 def test_kanban_dashboard_parity_i18n_keys_exist():
-    locale_blocks = re.findall(r"\n\s*([a-z]{2}(?:-[A-Z]{2})?): \{(.*?)\n\s*\},", I18N, flags=re.S)
+    locale_blocks = re.findall(
+        r"\n\s*([a-z]{2}(?:-[A-Z]{2})?): \{(.*?)\n\s*\},", I18N, flags=re.S
+    )
     required_keys = [
         "kanban_only_mine",
         "kanban_bulk_action",
@@ -524,7 +543,6 @@ def test_kanban_dashboard_parity_i18n_keys_exist():
     assert missing == []
 
 
-
 def test_kanban_ui_parity_polish_adds_card_metadata_quick_actions_and_swimlanes():
     for symbol in (
         "function _kanbanRenderProfileLanes",
@@ -542,12 +560,12 @@ def test_kanban_ui_parity_polish_adds_card_metadata_quick_actions_and_swimlanes(
         "kanban-card-actions",
         "kanban-card-id",
         "kanban-card-assignee",
-        "draggable=\"true\"",
-        "ondrop=\"dropKanbanTask",
+        'draggable="true"',
+        'ondrop="dropKanbanTask',
         "onkeydown=\"if(event.key==='Enter'||event.key===' ')",
     ):
         assert token in PANELS
-    assert "target=\"_blank\" rel=\"noopener noreferrer\"" in PANELS
+    assert 'target="_blank" rel="noopener noreferrer"' in PANELS
     assert "javascript:" not in PANELS.lower()
 
 
@@ -575,8 +593,16 @@ def test_kanban_ui_parity_polish_css_and_i18n_exist():
         ".hermes-kanban-md",
     ):
         assert selector in STYLE
-    locale_blocks = re.findall(r"\n\s*([a-z]{2}(?:-[A-Z]{2})?): \{(.*?)\n\s*\},", I18N, flags=re.S)
-    required_keys = ["kanban_lanes_by_profile", "kanban_card_complete", "kanban_card_archive", "kanban_unassigned", "kanban_work_queue_hint"]
+    locale_blocks = re.findall(
+        r"\n\s*([a-z]{2}(?:-[A-Z]{2})?): \{(.*?)\n\s*\},", I18N, flags=re.S
+    )
+    required_keys = [
+        "kanban_lanes_by_profile",
+        "kanban_card_complete",
+        "kanban_card_archive",
+        "kanban_unassigned",
+        "kanban_work_queue_hint",
+    ]
     missing = [
         f"{locale}:{key}"
         for locale, body in locale_blocks
@@ -584,7 +610,6 @@ def test_kanban_ui_parity_polish_css_and_i18n_exist():
         if re.search(rf"\b{re.escape(key)}\s*:", body) is None
     ]
     assert missing == []
-
 
 
 def test_kanban_review_feedback_static_ui_fixes_exist():
@@ -603,6 +628,7 @@ def test_kanban_review_feedback_static_ui_fixes_exist():
 def test_kanban_task_detail_renderer_executes_with_log_and_formats_feedback():
     import json
     import subprocess
+
     script = """
 const fs = require('fs');
 const vm = require('vm');
@@ -640,7 +666,9 @@ const html = vm.runInContext(`_kanbanRenderTaskDetail({
 })`, context);
 console.log(JSON.stringify({html}));
 """
-    result = subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True)
+    result = subprocess.run(
+        ["node", "-e", script], check=True, capture_output=True, text=True
+    )
     html = json.loads(result.stdout)["html"]
     assert "worker log" in html
     assert "kanban-back-btn" in html
@@ -656,6 +684,7 @@ def test_kanban_readonly_banner_starts_hidden_and_is_toggled_on_load():
     label is misleading when the kanban_db is fully writable.
     """
     import os
+
     here = os.path.dirname(os.path.abspath(__file__))
     index_path = os.path.join(here, "..", "static", "index.html")
     with open(index_path, "r", encoding="utf-8") as f:
@@ -665,8 +694,11 @@ def test_kanban_readonly_banner_starts_hidden_and_is_toggled_on_load():
     assert 'data-i18n="kanban_read_only"' in html
     # The banner element must have inline style="display:none" (default-hidden)
     # A naive substring check is sufficient — there is exactly one such element.
-    banner_block = html[html.find('class="kanban-readonly"'):html.find('class="kanban-readonly"') + 200]
-    assert 'display:none' in banner_block, (
+    banner_block = html[
+        html.find('class="kanban-readonly"') : html.find('class="kanban-readonly"')
+        + 200
+    ]
+    assert "display:none" in banner_block, (
         "Read-only banner must default to display:none in HTML to avoid "
         "flashing the wrong message before loadKanban() resolves the actual "
         "read_only flag from the API."
@@ -685,6 +717,7 @@ def test_kanban_readonly_banner_starts_hidden_and_is_toggled_on_load():
 
 # ── Multi-board switcher UI tests ───────────────────────────────────────────
 
+
 def test_kanban_board_switcher_markup_in_index():
     """The board switcher next to the Board title must be in index.html so
     it loads on first paint without a JS round-trip."""
@@ -695,7 +728,7 @@ def test_kanban_board_switcher_markup_in_index():
     # Switcher must be hidden by default — only revealed when ≥1 non-default
     # board exists, otherwise it would clutter single-board deployments.
     assert 'id="kanbanBoardSwitcher"' in INDEX
-    assert 'hidden>' in INDEX or 'hidden ' in INDEX  # presence of hidden attr
+    assert "hidden>" in INDEX or "hidden " in INDEX  # presence of hidden attr
 
 
 def test_kanban_board_modal_markup_in_index():
@@ -776,12 +809,13 @@ def test_kanban_archive_board_uses_showConfirmDialog():
     arch_idx = PANELS.find("async function archiveKanbanBoard")
     assert arch_idx > 0
     # Look at the next 800 chars
-    archive_block = PANELS[arch_idx:arch_idx + 800]
+    archive_block = PANELS[arch_idx : arch_idx + 800]
     assert "showConfirmDialog" in archive_block
     assert "danger: true" in archive_block
 
 
 # ── SSE event stream UI tests ───────────────────────────────────────────────
+
 
 def test_kanban_sse_eventsource_subscription_is_default():
     """The Kanban panel must subscribe to /api/kanban/events/stream via
@@ -835,6 +869,7 @@ def test_kanban_board_color_is_validated_against_css_injection():
     """
     import json
     import subprocess
+
     script = """
 const fs = require('fs');
 const src = fs.readFileSync('static/panels.js', 'utf8');
@@ -866,7 +901,9 @@ const results = cases.map(([input, expected]) => ({
 }));
 console.log(JSON.stringify(results));
 """
-    result = subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True)
+    result = subprocess.run(
+        ["node", "-e", script], check=True, capture_output=True, text=True
+    )
     results = json.loads(result.stdout)
     failures = [r for r in results if r["actual"] != r["expected"]]
     assert not failures, f"_kanbanSafeColor mismatches: {failures}"

--- a/tests/test_language_precedence.py
+++ b/tests/test_language_precedence.py
@@ -35,7 +35,9 @@ def _run_i18n_case(script_expr: str) -> dict:
         process.stdout.write(JSON.stringify(out));
         """
     )
-    proc = subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True)
+    proc = subprocess.run(
+        ["node", "-e", script], check=True, capture_output=True, text=True
+    )
     return json.loads(proc.stdout)
 
 

--- a/tests/test_live_models_ttl_cache.py
+++ b/tests/test_live_models_ttl_cache.py
@@ -19,7 +19,9 @@ def _patch_live_models_basics(monkeypatch, routes, profile="default"):
     import api.profiles as profiles
 
     routes._clear_live_models_cache()
-    monkeypatch.setattr(routes, "j", lambda _handler, payload, status=200, extra_headers=None: payload)
+    monkeypatch.setattr(
+        routes, "j", lambda _handler, payload, status=200, extra_headers=None: payload
+    )
     monkeypatch.setattr(config, "get_config", lambda: {"model": {"provider": "openai"}})
     monkeypatch.setattr(config, "_resolve_provider_alias", lambda provider: provider)
     monkeypatch.setattr(profiles, "get_active_profile_name", lambda: profile)

--- a/tests/test_login_locale.py
+++ b/tests/test_login_locale.py
@@ -78,8 +78,14 @@ def test_login_page_uses_russian_for_ru():
         assert status2 == 200
         assert 'lang="ru-RU"' in html
         assert "\u0412\u043e\u0439\u0442\u0438" in html
-        assert "\u0412\u0432\u0435\u0434\u0438\u0442\u0435 \u043f\u0430\u0440\u043e\u043b\u044c, \u0447\u0442\u043e\u0431\u044b \u043f\u0440\u043e\u0434\u043e\u043b\u0436\u0438\u0442\u044c" in html
-        assert "\u041d\u0435\u0432\u0435\u0440\u043d\u044b\u0439 \u043f\u0430\u0440\u043e\u043b\u044c" in html
+        assert (
+            "\u0412\u0432\u0435\u0434\u0438\u0442\u0435 \u043f\u0430\u0440\u043e\u043b\u044c, \u0447\u0442\u043e\u0431\u044b \u043f\u0440\u043e\u0434\u043e\u043b\u0436\u0438\u0442\u044c"
+            in html
+        )
+        assert (
+            "\u041d\u0435\u0432\u0435\u0440\u043d\u044b\u0439 \u043f\u0430\u0440\u043e\u043b\u044c"
+            in html
+        )
     finally:
         restored, restore_status = post("/api/settings", {"language": prev_lang})
         assert restore_status == 200

--- a/tests/test_login_locale_parity.py
+++ b/tests/test_login_locale_parity.py
@@ -267,7 +267,9 @@ def test_login_locale_count_matches_or_exceeds_floor():
         assert k in login, f"_LOGIN_LOCALE missing core locale {k!r}"
 
 
-@pytest.mark.parametrize("loc_key", ["en", "es", "de", "ru", "zh", "zh-Hant", "ja", "pt", "ko"])
+@pytest.mark.parametrize(
+    "loc_key", ["en", "es", "de", "ru", "zh", "zh-Hant", "ja", "pt", "ko"]
+)
 def test_login_locale_entry_well_formed(loc_key: str):
     """Each _LOGIN_LOCALE entry must have all required sub-keys and non-empty string values."""
     login = _load_login_locale()
@@ -277,7 +279,9 @@ def test_login_locale_entry_well_formed(loc_key: str):
         f"Expected {set(REQUIRED_LOGIN_KEYS)}, got {set(entry.keys())}."
     )
     for k, v in entry.items():
-        assert isinstance(v, str) and v, f"_LOGIN_LOCALE[{loc_key!r}][{k!r}] is empty/non-str: {v!r}"
+        assert isinstance(v, str) and v, (
+            f"_LOGIN_LOCALE[{loc_key!r}][{k!r}] is empty/non-str: {v!r}"
+        )
 
 
 def test_login_locale_resolver_handles_new_locales():
@@ -308,7 +312,9 @@ def _value_of(seg: str, key: str) -> str | None:
     return None
 
 
-@pytest.mark.parametrize("loc_key", ["es", "de", "ru", "zh", "zh-Hant", "ja", "pt", "ko"])
+@pytest.mark.parametrize(
+    "loc_key", ["es", "de", "ru", "zh", "zh-Hant", "ja", "pt", "ko"]
+)
 def test_login_flow_keys_are_translated(loc_key: str):
     """Login/sign-out/password keys in static/i18n.js must NOT equal the English value.
 

--- a/tests/test_logs_endpoint.py
+++ b/tests/test_logs_endpoint.py
@@ -28,7 +28,8 @@ def test_logs_endpoint_tails_whitelisted_synthetic_agent_log():
         "\n".join(
             [f"2026-05-04 INFO synthetic-log-marker line {i}" for i in range(105)]
             + ["2026-05-04 ERROR synthetic-log-marker failed safely"]
-        ) + "\n",
+        )
+        + "\n",
         encoding="utf-8",
     )
 
@@ -74,7 +75,8 @@ def test_logs_endpoint_tail_selector_is_allowlisted_and_defaults_to_200():
     logs_dir = TEST_STATE_DIR / "logs"
     logs_dir.mkdir(parents=True, exist_ok=True)
     (logs_dir / "errors.log").write_text(
-        "\n".join(f"2026-05-04 ERROR synthetic-log-marker line {i}" for i in range(250)) + "\n",
+        "\n".join(f"2026-05-04 ERROR synthetic-log-marker line {i}" for i in range(250))
+        + "\n",
         encoding="utf-8",
     )
 

--- a/tests/test_logs_ui_static.py
+++ b/tests/test_logs_ui_static.py
@@ -61,19 +61,23 @@ def _function_body(src: str, name: str) -> str:
             depth -= 1
         i += 1
     assert depth == 0, f"{name}() body did not close"
-    return src[brace + 1:i - 1]
+    return src[brace + 1 : i - 1]
 
 
 def test_logs_tab_is_wired_between_insights_and_settings_in_rail_and_mobile_nav():
-    rail = INDEX[INDEX.index('data-panel="insights"'):INDEX.index('<div class="rail-spacer"')]
+    rail = INDEX[
+        INDEX.index('data-panel="insights"') : INDEX.index('<div class="rail-spacer"')
+    ]
     assert 'data-panel="logs"' in rail
     assert rail.index('data-panel="insights"') < rail.index('data-panel="logs"')
 
     mobile_start = INDEX.index('class="sidebar-nav"')
-    mobile_end = INDEX.index('<!-- Settings button mirrored here for mobile')
+    mobile_end = INDEX.index("<!-- Settings button mirrored here for mobile")
     mobile_nav = INDEX[mobile_start:mobile_end]
     assert 'data-panel="logs"' in mobile_nav
-    assert mobile_nav.index('data-panel="insights"') < mobile_nav.index('data-panel="logs"')
+    assert mobile_nav.index('data-panel="insights"') < mobile_nav.index(
+        'data-panel="logs"'
+    )
 
     assert 'id="panelLogs"' in INDEX
     assert 'id="mainLogs"' in INDEX
@@ -120,7 +124,12 @@ def test_logs_severity_coloring_and_monospace_wrap_css_are_present():
     assert ".logs-output{" in css_min
     assert "font-family" in css_min and "monospace" in css_min
     assert ".logs-output.wrap" in css_min and "white-space:pre-wrap" in css_min
-    for cls in ("log-line-error", "log-line-warning", "log-line-info", "log-line-debug"):
+    for cls in (
+        "log-line-error",
+        "log-line-warning",
+        "log-line-info",
+        "log-line-debug",
+    ):
         assert f".{cls}" in css_min
 
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -12,7 +12,6 @@ import json
 import os
 import sys
 import tempfile
-import uuid
 from pathlib import Path
 
 import pytest
@@ -26,7 +25,9 @@ pytest.importorskip("mcp", reason="mcp package not installed (optional MCP serve
 
 # pytest-asyncio is also optional but always installed alongside mcp tests
 # in our local runs. If absent, importorskip the asyncio plugin gracefully.
-pytest.importorskip("pytest_asyncio", reason="pytest-asyncio required for MCP server tests")
+pytest.importorskip(
+    "pytest_asyncio", reason="pytest-asyncio required for MCP server tests"
+)
 
 pytestmark = pytest.mark.asyncio
 
@@ -58,6 +59,7 @@ _SAVED_CONSTANTS = {"captured": False}
 #  Helpers
 # ═══════════════════════════════════════════════════════════════════════════
 
+
 def _fresh_state_dir():
     """Create a clean temp state dir and set HERMES_WEBUI_STATE_DIR."""
     td = tempfile.mkdtemp()
@@ -70,7 +72,6 @@ def _fresh_state_dir():
     return state_dir
 
 
-
 def _cleanup_state_dir(state_dir: Path):
     """Remove temp state dir, clear env var, and restore api.config/mcp_server
     module constants to whatever they were before the fixture started.
@@ -80,6 +81,7 @@ def _cleanup_state_dir(state_dir: Path):
     fixture's tmpdir from `api.config.STATE_DIR` and fail because the path
     no longer exists or doesn't match their pytest-managed state dir."""
     import shutil
+
     shutil.rmtree(state_dir, ignore_errors=True)
     os.environ.pop("HERMES_WEBUI_STATE_DIR", None)
 
@@ -87,6 +89,7 @@ def _cleanup_state_dir(state_dir: Path):
     saved = _SAVED_CONSTANTS
     if saved.get("captured"):
         import api.config as _cfg
+
         for attr, val in saved["api.config"].items():
             setattr(_cfg, attr, val)
         if "mcp_server" in sys.modules:
@@ -103,6 +106,7 @@ def _cleanup_state_dir(state_dir: Path):
                 os.environ.pop(env_key, None)
             else:
                 os.environ[env_key] = env_val
+
 
 def _reimport_mcp():
     """Re-point mcp_server's module-level STATE_DIR / SESSION_DIR /
@@ -128,7 +132,7 @@ def _reimport_mcp():
     that mutate those env vars during their own setup and don't restore
     them in the strict sense the active-profile path resolution needs.
     """
-    state_dir = Path(os.environ['HERMES_WEBUI_STATE_DIR'])
+    state_dir = Path(os.environ["HERMES_WEBUI_STATE_DIR"])
 
     # Sibling test files (e.g. test_profile_path_security.py) mutate
     # HERMES_BASE_HOME / HERMES_HOME but only restore sys.modules — the
@@ -157,16 +161,28 @@ def _reimport_mcp():
     if not _SAVED_CONSTANTS.get("captured"):
         _SAVED_CONSTANTS["api.config"] = {
             attr: getattr(cfg, attr)
-            for attr in ("STATE_DIR", "SESSION_DIR", "WORKSPACES_FILE",
-                         "SETTINGS_FILE", "LAST_WORKSPACE_FILE", "PROJECTS_FILE",
-                         "SESSION_INDEX_FILE")
+            for attr in (
+                "STATE_DIR",
+                "SESSION_DIR",
+                "WORKSPACES_FILE",
+                "SETTINGS_FILE",
+                "LAST_WORKSPACE_FILE",
+                "PROJECTS_FILE",
+                "SESSION_INDEX_FILE",
+            )
             if hasattr(cfg, attr)
         }
         _SAVED_CONSTANTS["mcp_server"] = {
             attr: getattr(mod, attr)
-            for attr in ("STATE_DIR", "SESSION_DIR", "PROJECTS_FILE",
-                         "SESSION_INDEX_FILE", "WEBUI_HOST", "WEBUI_PORT",
-                         "WEBUI_URL")
+            for attr in (
+                "STATE_DIR",
+                "SESSION_DIR",
+                "PROJECTS_FILE",
+                "SESSION_INDEX_FILE",
+                "WEBUI_HOST",
+                "WEBUI_PORT",
+                "WEBUI_URL",
+            )
             if hasattr(mod, attr)
         }
         if "api.models" in sys.modules:
@@ -188,7 +204,6 @@ def _reimport_mcp():
     # object as `mcp_server.get_active_profile_name`'s closure reference.
     # We need to mutate the closure-bound module so mcp_server sees our
     # _active_profile assignment.
-    import api.profiles as fresh_profiles_via_import
     # mcp_server.get_active_profile_name is bound at first-import time and
     # reads `_active_profile` from its own module's globals via closure.
     # That module is the function's __globals__["__name__"] entry in
@@ -211,6 +226,7 @@ def _reimport_mcp():
         class _ProxyModule:
             def __init__(self, globs):
                 self.__dict__ = globs
+
         fresh_profiles = _ProxyModule(bound_globals)
 
     # Re-point api.config module-level constants
@@ -220,7 +236,7 @@ def _reimport_mcp():
     cfg.SETTINGS_FILE = state_dir / "settings.json"
     cfg.LAST_WORKSPACE_FILE = state_dir / "last_workspace.txt"
     cfg.PROJECTS_FILE = state_dir / "projects.json"
-    if hasattr(cfg, 'SESSION_INDEX_FILE'):
+    if hasattr(cfg, "SESSION_INDEX_FILE"):
         cfg.SESSION_INDEX_FILE = state_dir / "sessions" / "_index.json"
 
     # Re-point mcp_server's imported aliases (they were copied at first
@@ -228,19 +244,19 @@ def _reimport_mcp():
     mod.STATE_DIR = cfg.STATE_DIR
     mod.SESSION_DIR = cfg.SESSION_DIR
     mod.PROJECTS_FILE = cfg.PROJECTS_FILE
-    if hasattr(mod, 'SESSION_INDEX_FILE'):
+    if hasattr(mod, "SESSION_INDEX_FILE"):
         mod.SESSION_INDEX_FILE = cfg.SESSION_INDEX_FILE
 
     # api.models also imports STATE_DIR / PROJECTS_FILE etc. as module
     # constants — re-point those too so load_projects() / save_projects()
     # see the fresh STATE_DIR.
-    if 'api.models' in sys.modules:
-        models_mod = sys.modules['api.models']
-        if hasattr(models_mod, 'STATE_DIR'):
+    if "api.models" in sys.modules:
+        models_mod = sys.modules["api.models"]
+        if hasattr(models_mod, "STATE_DIR"):
             models_mod.STATE_DIR = cfg.STATE_DIR
-        if hasattr(models_mod, 'PROJECTS_FILE'):
+        if hasattr(models_mod, "PROJECTS_FILE"):
             models_mod.PROJECTS_FILE = cfg.PROJECTS_FILE
-        if hasattr(models_mod, 'SESSION_DIR'):
+        if hasattr(models_mod, "SESSION_DIR"):
             models_mod.SESSION_DIR = cfg.SESSION_DIR
 
     # Re-evaluate WEBUI_URL from current env (PR #1895 made it env-aware
@@ -250,17 +266,17 @@ def _reimport_mcp():
     mod.WEBUI_PORT = os.environ.get("HERMES_WEBUI_PORT", "8787")
     mod.WEBUI_URL = f"http://{mod.WEBUI_HOST}:{mod.WEBUI_PORT}"
 
-    fresh_profiles._active_profile = 'default'
+    fresh_profiles._active_profile = "default"
 
     # Invalidate the root-profile cache (set at module load to detect
     # renamed-root profiles, but stale after sibling tests that called
     # switch_profile / list_profiles_api in their own setup).
-    if hasattr(fresh_profiles, '_invalidate_root_profile_cache'):
+    if hasattr(fresh_profiles, "_invalidate_root_profile_cache"):
         fresh_profiles._invalidate_root_profile_cache()
-    elif hasattr(fresh_profiles, '_root_profile_name_cache'):
+    elif hasattr(fresh_profiles, "_root_profile_name_cache"):
         fresh_profiles._root_profile_name_cache.clear()
-        fresh_profiles._root_profile_name_cache.add('default')
-        if hasattr(fresh_profiles, '_root_profile_name_cache_loaded'):
+        fresh_profiles._root_profile_name_cache.add("default")
+        if hasattr(fresh_profiles, "_root_profile_name_cache_loaded"):
             fresh_profiles._root_profile_name_cache_loaded = False
     return mod, fresh_profiles
 
@@ -275,6 +291,7 @@ async def _call(mod, tool_name, **kwargs):
 # ═══════════════════════════════════════════════════════════════════════════
 #  Project CRUD
 # ═══════════════════════════════════════════════════════════════════════════
+
 
 class TestCreateProject:
     @pytest.fixture(autouse=True)
@@ -292,8 +309,9 @@ class TestCreateProject:
         assert result["session_count"] == 0
 
     async def test_create_with_color(self):
-        result = await _call(self.mod, "create_project",
-                             name="Colored", color="#ff6600")
+        result = await _call(
+            self.mod, "create_project", name="Colored", color="#ff6600"
+        )
         assert result["color"] == "#ff6600"
 
     async def test_create_duplicate_exact_match(self):
@@ -313,15 +331,17 @@ class TestCreateProject:
         assert "error" in result
 
     async def test_create_invalid_color(self):
-        result = await _call(self.mod, "create_project",
-                             name="Bad", color="not-a-color")
+        result = await _call(
+            self.mod, "create_project", name="Bad", color="not-a-color"
+        )
         assert "error" in result
         assert "Invalid color" in result["error"]
 
     async def test_create_valid_color_formats(self):
         for color in ["#fff", "#ff6600", "#ff6600aa"]:
-            result = await _call(self.mod, "create_project",
-                                 name=f"Color-{color}", color=color)
+            result = await _call(
+                self.mod, "create_project", name=f"Color-{color}", color=color
+            )
             assert result["color"] == color
 
 
@@ -336,29 +356,32 @@ class TestRenameProject:
     async def test_rename_basic(self):
         created = await _call(self.mod, "create_project", name="Old")
         pid = created["project_id"]
-        result = await _call(self.mod, "rename_project",
-                             project_id=pid, name="New")
+        result = await _call(self.mod, "rename_project", project_id=pid, name="New")
         assert result["name"] == "New"
         assert result["project_id"] == pid
 
     async def test_rename_with_color(self):
         created = await _call(self.mod, "create_project", name="X")
-        result = await _call(self.mod, "rename_project",
-                             project_id=created["project_id"],
-                             name="X", color="#000")
+        result = await _call(
+            self.mod,
+            "rename_project",
+            project_id=created["project_id"],
+            name="X",
+            color="#000",
+        )
         assert result["color"] == "#000"
 
     async def test_rename_not_found(self):
-        result = await _call(self.mod, "rename_project",
-                             project_id="nonexistent", name="Nope")
+        result = await _call(
+            self.mod, "rename_project", project_id="nonexistent", name="Nope"
+        )
         assert "error" in result
 
     async def test_rename_wrong_profile(self):
         created = await _call(self.mod, "create_project", name="DefaultOwned")
         pid = created["project_id"]
-        self.profiles._active_profile = 'other'
-        result = await _call(self.mod, "rename_project",
-                             project_id=pid, name="Stolen")
+        self.profiles._active_profile = "other"
+        result = await _call(self.mod, "rename_project", project_id=pid, name="Stolen")
         assert "error" in result
         assert "not found" in result["error"].lower()
 
@@ -379,14 +402,13 @@ class TestDeleteProject:
         assert result["deleted"] == "ToDelete"
 
     async def test_delete_not_found(self):
-        result = await _call(self.mod, "delete_project",
-                             project_id="nonexistent")
+        result = await _call(self.mod, "delete_project", project_id="nonexistent")
         assert "error" in result
 
     async def test_delete_wrong_profile(self):
         created = await _call(self.mod, "create_project", name="Owned")
         pid = created["project_id"]
-        self.profiles._active_profile = 'other'
+        self.profiles._active_profile = "other"
         result = await _call(self.mod, "delete_project", project_id=pid)
         assert "error" in result
 
@@ -401,6 +423,7 @@ class TestDeleteProject:
         surface a `warning` field telling the operator to set the env var.
         """
         from api.config import SESSION_DIR, SESSION_INDEX_FILE
+
         os.environ.pop("HERMES_WEBUI_PASSWORD", None)
 
         # Create project + a session JSON that points at it
@@ -418,7 +441,8 @@ class TestDeleteProject:
         # Index references the session under the project
         SESSION_INDEX_FILE.write_text(
             json.dumps([{"session_id": sid, "project_id": pid, "title": "T"}]),
-            encoding="utf-8")
+            encoding="utf-8",
+        )
         index_before = SESSION_INDEX_FILE.read_text(encoding="utf-8")
         session_before = session_path.read_text(encoding="utf-8")
 
@@ -438,6 +462,7 @@ class TestDeleteProject:
 #  Profile Scoping
 # ═══════════════════════════════════════════════════════════════════════════
 
+
 class TestProfileScoping:
     @pytest.fixture(autouse=True)
     def setup(self):
@@ -455,7 +480,7 @@ class TestProfileScoping:
         await _call(self.mod, "create_project", name="DefaultProject")
 
         # Switch to other
-        self.profiles._active_profile = 'other'
+        self.profiles._active_profile = "other"
         await _call(self.mod, "create_project", name="OtherProject")
 
         # List should only show current profile's projects
@@ -465,7 +490,7 @@ class TestProfileScoping:
         assert "DefaultProject" not in names
 
         # Switch back
-        self.profiles._active_profile = 'default'
+        self.profiles._active_profile = "default"
         projects = await _call(self.mod, "list_projects")
         names = [p["name"] for p in projects]
         assert "DefaultProject" in names
@@ -474,7 +499,7 @@ class TestProfileScoping:
     async def test_cross_profile_isolation_create(self):
         """Same name in different profiles should be allowed."""
         await _call(self.mod, "create_project", name="Shared")
-        self.profiles._active_profile = 'other'
+        self.profiles._active_profile = "other"
         result = await _call(self.mod, "create_project", name="Shared")
         assert "project_id" in result
 
@@ -486,25 +511,28 @@ class TestProfileScoping:
         """
         # Manually write a legacy untagged project (pre-#1614 schema)
         import api.config as _cfg_mod
+
         PROJECTS_FILE = _cfg_mod.PROJECTS_FILE
-        legacy = [{
-            "project_id": "legacy000001",
-            "name": "LegacyUntagged",
-            "color": None,
-            "created_at": 1700000000.0,
-            # No "profile" field on purpose
-        }]
+        legacy = [
+            {
+                "project_id": "legacy000001",
+                "name": "LegacyUntagged",
+                "color": None,
+                "created_at": 1700000000.0,
+                # No "profile" field on purpose
+            }
+        ]
         PROJECTS_FILE.write_text(json.dumps(legacy), encoding="utf-8")
 
         # Non-root profile must NOT see it
-        self.profiles._active_profile = 'other'
+        self.profiles._active_profile = "other"
         projects = await _call(self.mod, "list_projects")
         names = [p["name"] for p in projects]
         assert "LegacyUntagged" not in names
 
         # Root profile still sees it (load_projects backfills `profile`
         # to 'default', so visibility is preserved for the root).
-        self.profiles._active_profile = 'default'
+        self.profiles._active_profile = "default"
         projects = await _call(self.mod, "list_projects")
         names = [p["name"] for p in projects]
         assert "LegacyUntagged" in names
@@ -512,23 +540,28 @@ class TestProfileScoping:
     async def test_legacy_untagged_rename_blocked_from_non_root(self):
         """Non-root profile cannot rename a legacy untagged project."""
         import api.config as _cfg_mod
+
         PROJECTS_FILE = _cfg_mod.PROJECTS_FILE
-        legacy = [{
-            "project_id": "legacy000002",
-            "name": "Legacy",
-            "color": None,
-            "created_at": 1700000000.0,
-        }]
+        legacy = [
+            {
+                "project_id": "legacy000002",
+                "name": "Legacy",
+                "color": None,
+                "created_at": 1700000000.0,
+            }
+        ]
         PROJECTS_FILE.write_text(json.dumps(legacy), encoding="utf-8")
-        self.profiles._active_profile = 'other'
-        result = await _call(self.mod, "rename_project",
-                             project_id="legacy000002", name="Stolen")
+        self.profiles._active_profile = "other"
+        result = await _call(
+            self.mod, "rename_project", project_id="legacy000002", name="Stolen"
+        )
         assert "error" in result
 
 
 # ═══════════════════════════════════════════════════════════════════════════
 #  Session listing
 # ═══════════════════════════════════════════════════════════════════════════
+
 
 class TestListSessions:
     @pytest.fixture(autouse=True)
@@ -555,6 +588,7 @@ class TestListSessions:
 #  Session mutations (HTTP API — basic validation only)
 # ═══════════════════════════════════════════════════════════════════════════
 
+
 class TestSessionMutations:
     @pytest.fixture(autouse=True)
     def setup(self):
@@ -564,27 +598,25 @@ class TestSessionMutations:
         _cleanup_state_dir(self.state_dir)
 
     async def test_rename_missing_args(self):
-        result = await _call(self.mod, "rename_session",
-                             session_id="", title="")
+        result = await _call(self.mod, "rename_session", session_id="", title="")
         assert "error" in result
 
     async def test_move_missing_args(self):
-        result = await _call(self.mod, "move_session",
-                             session_id="", project_id="x")
+        result = await _call(self.mod, "move_session", session_id="", project_id="x")
         assert "error" in result
 
     async def test_move_project_not_found(self):
-        result = await _call(self.mod, "move_session",
-                             session_id="s1", project_id="nonexistent")
+        result = await _call(
+            self.mod, "move_session", session_id="s1", project_id="nonexistent"
+        )
         assert "error" in result
 
     async def test_move_target_owned_by_other_profile_rejected(self):
         """A project owned by profile A is invisible to profile B (#1614)."""
         created = await _call(self.mod, "create_project", name="ATarget")
         pid = created["project_id"]
-        self.profiles._active_profile = 'other'
-        result = await _call(self.mod, "move_session",
-                             session_id="any", project_id=pid)
+        self.profiles._active_profile = "other"
+        result = await _call(self.mod, "move_session", session_id="any", project_id=pid)
         assert "error" in result
         assert "not found" in result["error"].lower()
 
@@ -592,6 +624,7 @@ class TestSessionMutations:
 # ═══════════════════════════════════════════════════════════════════════════
 #  Auth helper
 # ═══════════════════════════════════════════════════════════════════════════
+
 
 class TestApiPassword:
     @pytest.fixture(autouse=True)
@@ -610,9 +643,10 @@ class TestApiPassword:
         """settings.json holds a hash, not a plaintext password — must NOT
         be returned as if it were a usable password."""
         from api.config import STATE_DIR as _SD
+
         (_SD / "settings.json").write_text(
-            json.dumps({"password_hash": "$2b$12$abcdefghijk"}),
-            encoding="utf-8")
+            json.dumps({"password_hash": "$2b$12$abcdefghijk"}), encoding="utf-8"
+        )
         assert self.mod._api_password() is None
 
     async def test_env_var_returned(self):
@@ -631,6 +665,7 @@ class TestApiPassword:
 # now import _profiles_match from api/profiles.py. If anyone re-introduces a
 # local copy in either module, both the identity check and the input-matrix
 # parametrize trip immediately.
+
 
 async def test_profiles_match_single_source_of_truth():
     """All three module names resolve to the same canonical object.
@@ -653,7 +688,7 @@ async def test_profiles_match_single_source_of_truth():
     # Snapshot the originals; we'll put them back at the end.
     saved_modules = {
         k: sys.modules[k]
-        for k in ('mcp_server', 'api.routes', 'api.profiles')
+        for k in ("mcp_server", "api.routes", "api.profiles")
         if k in sys.modules
     }
     # Also snapshot the attributes on the parent `api` package, because
@@ -663,23 +698,25 @@ async def test_profiles_match_single_source_of_truth():
     # bind to the fresh re-imported module even though sys.modules
     # holds the original.
     import api as _api_parent
+
     saved_api_attrs = {}
-    for sub in ('routes', 'profiles'):
+    for sub in ("routes", "profiles"):
         if hasattr(_api_parent, sub):
             saved_api_attrs[sub] = getattr(_api_parent, sub)
 
-    for k in ('mcp_server', 'api.routes', 'api.profiles'):
+    for k in ("mcp_server", "api.routes", "api.profiles"):
         sys.modules.pop(k, None)
     try:
         import api.profiles as _profiles_mod
         import api.routes as _routes_mod
         import mcp_server as _mcp_mod
+
         canonical = _profiles_mod._profiles_match
         assert _routes_mod._profiles_match is canonical
         assert _mcp_mod._profiles_match is canonical
     finally:
         # Restore so monkeypatch handles in sibling tests target the right module.
-        for k in ('mcp_server', 'api.routes', 'api.profiles'):
+        for k in ("mcp_server", "api.routes", "api.profiles"):
             sys.modules.pop(k, None)
         sys.modules.update(saved_modules)
         # Restore parent-package attributes too (see above for why).
@@ -687,21 +724,24 @@ async def test_profiles_match_single_source_of_truth():
             setattr(_api_parent, sub, mod_obj)
 
 
-@pytest.mark.parametrize("a, b", [
-    (None, None),
-    (None, ''),
-    ('', None),
-    ('', ''),
-    (None, 'default'),
-    ('default', None),
-    ('default', 'default'),
-    ('foo', 'foo'),
-    ('foo', 'bar'),
-    ('foo', None),
-    (None, 'foo'),
-    ('default', 'foo'),
-    ('foo', 'default'),
-])
+@pytest.mark.parametrize(
+    "a, b",
+    [
+        (None, None),
+        (None, ""),
+        ("", None),
+        ("", ""),
+        (None, "default"),
+        ("default", None),
+        ("default", "default"),
+        ("foo", "foo"),
+        ("foo", "bar"),
+        ("foo", None),
+        (None, "foo"),
+        ("default", "foo"),
+        ("foo", "default"),
+    ],
+)
 async def test_profiles_match_input_matrix(a, b):
     """mcp_server._profiles_match agrees with api.routes._profiles_match
     on every (row, active) pair across the visibility matrix.
@@ -712,6 +752,7 @@ async def test_profiles_match_input_matrix(a, b):
     clear and re-execute api.profiles."""
     from mcp_server import _profiles_match as mcp_match
     from api.routes import _profiles_match as routes_match
+
     assert mcp_match(a, b) == routes_match(a, b)
 
 
@@ -729,6 +770,7 @@ async def test_profiles_match_input_matrix(a, b):
 # the behaviour: setting _active_profile = 'foo' before the first list call
 # produces results filtered to 'foo', not the default.
 
+
 class TestProfileCliOrdering:
     @pytest.fixture(autouse=True)
     def setup(self):
@@ -745,19 +787,30 @@ class TestProfileCliOrdering:
         helper had latched the profile at import time, the override here
         would be too late and the test would see 'default'-tagged rows."""
         import api.config as _cfg_mod
+
         PROJECTS_FILE = _cfg_mod.PROJECTS_FILE
         # Pre-seed two projects: one for default, one for foo.
         seeded = [
-            {"project_id": "p_default_0001", "name": "DefaultRow",
-             "color": None, "profile": "default", "created_at": 1.0},
-            {"project_id": "p_foo_0001", "name": "FooRow",
-             "color": None, "profile": "foo", "created_at": 2.0},
+            {
+                "project_id": "p_default_0001",
+                "name": "DefaultRow",
+                "color": None,
+                "profile": "default",
+                "created_at": 1.0,
+            },
+            {
+                "project_id": "p_foo_0001",
+                "name": "FooRow",
+                "color": None,
+                "profile": "foo",
+                "created_at": 2.0,
+            },
         ]
         PROJECTS_FILE.write_text(json.dumps(seeded), encoding="utf-8")
 
         # Apply the override BEFORE the first list call. This is what
         # mcp_server.py:62-64 does after argparse.
-        self.profiles._active_profile = 'foo'
+        self.profiles._active_profile = "foo"
 
         projects = await _call(self.mod, "list_projects")
         names = [p["name"] for p in projects]
@@ -783,6 +836,7 @@ import threading
 class _RecordingHandler(http.server.BaseHTTPRequestHandler):
     """Captures POST path + body, returns canned JSON. Class-level state is
     set by the fixture before each test so handlers can cross-reference."""
+
     captured = None  # populated per-test as a list of (path, body, headers)
     canned_response = None  # populated per-test: dict to be JSON-encoded
 
@@ -796,12 +850,14 @@ class _RecordingHandler(http.server.BaseHTTPRequestHandler):
             body = json.loads(raw.decode("utf-8")) if raw else {}
         except Exception:
             body = {"_raw": raw.decode("utf-8", errors="replace")}
-        type(self).captured.append({
-            "path": self.path,
-            "body": body,
-            "cookie": self.headers.get("Cookie"),
-            "content_type": self.headers.get("Content-Type"),
-        })
+        type(self).captured.append(
+            {
+                "path": self.path,
+                "body": body,
+                "cookie": self.headers.get("Cookie"),
+                "content_type": self.headers.get("Content-Type"),
+            }
+        )
         payload = json.dumps(type(self).canned_response or {}).encode("utf-8")
         self.send_response(200)
         self.send_header("Content-Type", "application/json")
@@ -827,10 +883,8 @@ class TestApiWireFormat:
         self.port = _free_port()
         _RecordingHandler.captured = []
         _RecordingHandler.canned_response = {}
-        self.httpd = http.server.HTTPServer(("127.0.0.1", self.port),
-                                            _RecordingHandler)
-        self.thread = threading.Thread(target=self.httpd.serve_forever,
-                                       daemon=True)
+        self.httpd = http.server.HTTPServer(("127.0.0.1", self.port), _RecordingHandler)
+        self.thread = threading.Thread(target=self.httpd.serve_forever, daemon=True)
         self.thread.start()
 
         # Disable auth so _api_post() does not attempt a real /api/auth/login.
@@ -850,8 +904,9 @@ class TestApiWireFormat:
         _RecordingHandler.canned_response = {
             "session": {"session_id": "abc123", "title": "Renamed"}
         }
-        result = await _call(self.mod, "rename_session",
-                             session_id="abc123", title="Renamed")
+        result = await _call(
+            self.mod, "rename_session", session_id="abc123", title="Renamed"
+        )
         assert len(_RecordingHandler.captured) == 1
         req = _RecordingHandler.captured[0]
         assert req["path"] == "/api/session/rename"
@@ -871,10 +926,9 @@ class TestApiWireFormat:
         pid = created["project_id"]
         _RecordingHandler.canned_response = {
             "ok": True,
-            "session": {"session_id": "s1", "title": "T", "project_id": pid}
+            "session": {"session_id": "s1", "title": "T", "project_id": pid},
         }
-        result = await _call(self.mod, "move_session",
-                             session_id="s1", project_id=pid)
+        result = await _call(self.mod, "move_session", session_id="s1", project_id=pid)
         assert len(_RecordingHandler.captured) == 1
         req = _RecordingHandler.captured[0]
         assert req["path"] == "/api/session/move"
@@ -887,10 +941,10 @@ class TestApiWireFormat:
     async def test_move_session_unassign_sends_null_project_id(self):
         """Passing project_id=None must serialize as JSON null (not omitted)."""
         _RecordingHandler.canned_response = {
-            "ok": True, "session": {"session_id": "s1", "project_id": None}
+            "ok": True,
+            "session": {"session_id": "s1", "project_id": None},
         }
-        result = await _call(self.mod, "move_session",
-                             session_id="s1", project_id=None)
+        result = await _call(self.mod, "move_session", session_id="s1", project_id=None)
         assert len(_RecordingHandler.captured) == 1
         req = _RecordingHandler.captured[0]
         assert req["path"] == "/api/session/move"

--- a/tests/test_media_inline.py
+++ b/tests/test_media_inline.py
@@ -9,17 +9,17 @@ Covers:
 5. renderMd() MEDIA: stash/restore logic (static JS analysis)
 6. /api/media endpoint: integration test via live server (requires 8788)
 """
+
 from __future__ import annotations
 
 import json
-import os
 import pathlib
 import tempfile
 import unittest
 import urllib.error
 import urllib.request
 
-from tests._pytest_port import BASE, TEST_STATE_DIR
+from tests._pytest_port import BASE
 
 REPO_ROOT = pathlib.Path(__file__).parent.parent
 UI_JS = (REPO_ROOT / "static" / "ui.js").read_text(encoding="utf-8")
@@ -28,49 +28,73 @@ WORKSPACE_JS = (REPO_ROOT / "static" / "workspace.js").read_text(encoding="utf-8
 
 # ── Static analysis: renderMd MEDIA stash ────────────────────────────────────
 
+
 class TestMediaRenderMdStash(unittest.TestCase):
     """Verify the MEDIA: stash/restore logic exists in ui.js."""
 
     def test_media_stash_defined(self):
-        self.assertIn("media_stash", UI_JS,
-                      "media_stash array must be defined in renderMd()")
+        self.assertIn(
+            "media_stash", UI_JS, "media_stash array must be defined in renderMd()"
+        )
 
     def test_media_token_regex(self):
-        self.assertIn("MEDIA:", UI_JS,
-                      "MEDIA: token regex must be present in renderMd()")
+        self.assertIn(
+            "MEDIA:", UI_JS, "MEDIA: token regex must be present in renderMd()"
+        )
 
     def test_media_restore_produces_img_tag(self):
-        self.assertIn("msg-media-img", UI_JS,
-                      "restore pass must produce <img class='msg-media-img'>")
+        self.assertIn(
+            "msg-media-img",
+            UI_JS,
+            "restore pass must produce <img class='msg-media-img'>",
+        )
 
     def test_media_restore_produces_download_link(self):
-        self.assertIn("msg-media-link", UI_JS,
-                      "restore pass must produce download link for non-image files")
+        self.assertIn(
+            "msg-media-link",
+            UI_JS,
+            "restore pass must produce download link for non-image files",
+        )
 
     def test_media_api_url_pattern(self):
-        self.assertIn("api/media?path=", UI_JS,
-                      "renderMd must build api/media?path=... URL for local files")
+        self.assertIn(
+            "api/media?path=",
+            UI_JS,
+            "renderMd must build api/media?path=... URL for local files",
+        )
 
     def test_local_audio_video_media_tokens_request_inline_streaming(self):
-        self.assertIn("apiUrl+'&inline=1'", UI_JS,
-                      "MEDIA: audio/video local paths must request inline streaming")
+        self.assertIn(
+            "apiUrl+'&inline=1'",
+            UI_JS,
+            "MEDIA: audio/video local paths must request inline streaming",
+        )
 
     def test_media_stash_uses_null_byte_token(self):
-        self.assertIn("\\x00D", UI_JS,
-                      "MEDIA stash must use null-byte token (\\x00D) to avoid conflicts")
+        self.assertIn(
+            "\\x00D",
+            UI_JS,
+            "MEDIA stash must use null-byte token (\\x00D) to avoid conflicts",
+        )
 
     def test_media_stash_runs_before_fence_stash(self):
         media_pos = UI_JS.find("media_stash")
         fence_pos = UI_JS.find("fence_stash")
-        self.assertGreater(fence_pos, media_pos,
-                           "media_stash must be defined before fence_stash in renderMd()")
+        self.assertGreater(
+            fence_pos,
+            media_pos,
+            "media_stash must be defined before fence_stash in renderMd()",
+        )
 
     def test_image_extension_regex_covers_common_types(self):
         # The JS source has these extensions in a regex like /\.png|jpg|.../i
         # Check for the extension strings (without the dot, which may be escaped as \.)
         for ext in ["png", "jpg", "jpeg", "gif", "webp"]:
-            self.assertIn(ext, UI_JS,
-                          f"Image extension {ext} must be in the MEDIA img-check regex")
+            self.assertIn(
+                ext,
+                UI_JS,
+                f"Image extension {ext} must be in the MEDIA img-check regex",
+            )
 
     def test_http_url_media_rendered_as_img(self):
         # renderMd should treat MEDIA:https://... as an <img>
@@ -82,14 +106,17 @@ class TestMediaRenderMdStash(unittest.TestCase):
 
     def test_zoom_toggle_on_click(self):
         # PR #1135: CSS class toggle replaced by proper lightbox overlay
-        self.assertIn("_openImgLightbox", UI_JS,
-                      "Clicking the image must open lightbox overlay (_openImgLightbox)")
+        self.assertIn(
+            "_openImgLightbox",
+            UI_JS,
+            "Clicking the image must open lightbox overlay (_openImgLightbox)",
+        )
 
 
 # ── Static analysis: CSS ──────────────────────────────────────────────────────
 
-class TestMediaCSS(unittest.TestCase):
 
+class TestMediaCSS(unittest.TestCase):
     CSS = (REPO_ROOT / "static" / "style.css").read_text(encoding="utf-8")
 
     def test_msg_media_img_class_defined(self):
@@ -100,18 +127,23 @@ class TestMediaCSS(unittest.TestCase):
         # Lightbox shows full-size. Check width is set instead.
         idx = self.CSS.find(".msg-media-img{")
         self.assertGreater(idx, 0)
-        rule = self.CSS[idx:idx+200]
+        rule = self.CSS[idx : idx + 200]
         self.assertIn("width:120px", rule, "Thumbnail must have fixed 120px width")
 
     def test_msg_media_img_full_class_defined(self):
         # PR #1135: .msg-media-img--full removed; lightbox replaces inline zoom.
-        self.assertIn(".img-lightbox", self.CSS,
-                      "Full-size toggle class must exist for zoom-on-click")
+        self.assertIn(
+            ".img-lightbox",
+            self.CSS,
+            "Full-size toggle class must exist for zoom-on-click",
+        )
 
     def test_msg_media_link_class_defined(self):
-        self.assertIn(".msg-media-link", self.CSS,
-                      "Download link style must be defined for non-image media")
-
+        self.assertIn(
+            ".msg-media-link",
+            self.CSS,
+            "Download link style must be defined for non-image media",
+        )
 
 
 class TestInlineAudioVideoEditor(unittest.TestCase):
@@ -172,7 +204,14 @@ class TestInlineAudioVideoEditor(unittest.TestCase):
         self.assertIn('id="previewMediaWrap"', self.INDEX_HTML)
 
     def test_media_editor_css_defined(self):
-        for cls in [".msg-media-editor", ".msg-media-player", ".msg-media-video", ".media-speed-controls", ".media-speed-btn", ".preview-media-wrap"]:
+        for cls in [
+            ".msg-media-editor",
+            ".msg-media-player",
+            ".msg-media-video",
+            ".media-speed-controls",
+            ".media-speed-btn",
+            ".preview-media-wrap",
+        ]:
             self.assertIn(cls, self.CSS)
 
 
@@ -198,13 +237,16 @@ class TestWorkspacePdfViewer(unittest.TestCase):
         for cls in [".preview-pdf-wrap", ".preview-pdf-frame", ".preview-badge.pdf"]:
             self.assertIn(cls, self.CSS)
 
+
 # ── Backend: /api/media endpoint (unit-level, no server needed) ─────────────
+
 
 class TestMediaEndpointUnit(unittest.TestCase):
     """Test route registration and handler logic via imports."""
 
     def test_handle_media_function_exists(self):
         from api import routes
+
         self.assertTrue(
             hasattr(routes, "_handle_media"),
             "_handle_media must be defined in api/routes.py",
@@ -213,27 +255,37 @@ class TestMediaEndpointUnit(unittest.TestCase):
     def test_api_media_route_registered(self):
         """The GET dispatch must include the /api/media path."""
         routes_src = (REPO_ROOT / "api" / "routes.py").read_text(encoding="utf-8")
-        self.assertIn('"/api/media"', routes_src,
-                      '/api/media must be registered in the GET route dispatch')
+        self.assertIn(
+            '"/api/media"',
+            routes_src,
+            "/api/media must be registered in the GET route dispatch",
+        )
 
     def test_allowed_roots_include_tmp(self):
         """Handler must allow /tmp so screenshot paths work."""
         routes_src = (REPO_ROOT / "api" / "routes.py").read_text(encoding="utf-8")
-        self.assertIn('/tmp', routes_src,
-                      '/tmp must be in the allowed roots list for /api/media')
+        self.assertIn(
+            "/tmp", routes_src, "/tmp must be in the allowed roots list for /api/media"
+        )
 
     def test_svg_forces_download(self):
         """.svg must not be served inline (XSS risk)."""
         routes_src = (REPO_ROOT / "api" / "routes.py").read_text(encoding="utf-8")
         # SVG should be in _DOWNLOAD_TYPES or explicitly excluded from inline
-        self.assertIn("image/svg+xml", routes_src,
-                      "SVG MIME type must be handled (forced download) in _handle_media")
+        self.assertIn(
+            "image/svg+xml",
+            routes_src,
+            "SVG MIME type must be handled (forced download) in _handle_media",
+        )
 
     def test_non_image_forces_download(self):
         """Non-image files should be forced to download, not served inline."""
         routes_src = (REPO_ROOT / "api" / "routes.py").read_text(encoding="utf-8")
-        self.assertIn("_INLINE_IMAGE_TYPES", routes_src,
-                      "_INLINE_IMAGE_TYPES whitelist must exist in _handle_media")
+        self.assertIn(
+            "_INLINE_IMAGE_TYPES",
+            routes_src,
+            "_INLINE_IMAGE_TYPES whitelist must exist in _handle_media",
+        )
 
     def test_media_endpoints_advertise_byte_range_support(self):
         routes_src = (REPO_ROOT / "api" / "routes.py").read_text(encoding="utf-8")
@@ -250,7 +302,6 @@ class TestMediaEndpointUnit(unittest.TestCase):
 
 
 class TestMediaEndpointIntegration(unittest.TestCase):
-
     def setUp(self):
         try:
             urllib.request.urlopen(BASE + "/health", timeout=5)
@@ -282,9 +333,9 @@ class TestMediaEndpointIntegration(unittest.TestCase):
         """Create a 1-pixel PNG in /tmp and verify it's served correctly."""
         # Minimal valid 1x1 transparent PNG (67 bytes)
         png_bytes = (
-            b'\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01'
-            b'\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\nIDATx\x9cc\x00'
-            b'\x01\x00\x00\x05\x00\x01\r\n-\xb4\x00\x00\x00\x00IEND\xaeB`\x82'
+            b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01"
+            b"\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\nIDATx\x9cc\x00"
+            b"\x01\x00\x00\x05\x00\x01\r\n-\xb4\x00\x00\x00\x00IEND\xaeB`\x82"
         )
         with tempfile.NamedTemporaryFile(
             suffix=".png", prefix="hermes_test_", dir="/tmp", delete=False
@@ -325,7 +376,9 @@ class TestMediaEndpointIntegration(unittest.TestCase):
             )
             self.assertEqual(status, 206)
             self.assertEqual(body, b"RIFF")
-            self.assertEqual(headers.get("Content-Range"), f"bytes 0-3/{len(audio_bytes)}")
+            self.assertEqual(
+                headers.get("Content-Range"), f"bytes 0-3/{len(audio_bytes)}"
+            )
         finally:
             pathlib.Path(tmp_path).unlink(missing_ok=True)
 
@@ -346,7 +399,10 @@ class TestMediaEndpointIntegration(unittest.TestCase):
             self.assertIn("attachment", headers.get("Content-Disposition", ""))
             self.assertIn("DENY", headers.get_all("X-Frame-Options", []))
             self.assertFalse(
-                any("sandbox allow-scripts" == h for h in headers.get_all("Content-Security-Policy", []))
+                any(
+                    "sandbox allow-scripts" == h
+                    for h in headers.get_all("Content-Security-Policy", [])
+                )
             )
             self.assertEqual(body, html_bytes)
 
@@ -356,7 +412,10 @@ class TestMediaEndpointIntegration(unittest.TestCase):
             self.assertIn("inline", headers.get("Content-Disposition", ""))
             self.assertEqual(headers.get_all("X-Frame-Options", []), [])
             self.assertTrue(
-                any("sandbox allow-scripts" == h for h in headers.get_all("Content-Security-Policy", []))
+                any(
+                    "sandbox allow-scripts" == h
+                    for h in headers.get_all("Content-Security-Policy", [])
+                )
             )
             self.assertEqual(body, html_bytes)
         finally:

--- a/tests/test_metadata_save_wipe_1558.py
+++ b/tests/test_metadata_save_wipe_1558.py
@@ -17,9 +17,8 @@ restart could wipe a 1000-message conversation in a single round-trip.
 
 This test reproduces the data loss path against the on-disk session file.
 """
+
 import json
-import sys
-from pathlib import Path
 
 import pytest
 
@@ -32,14 +31,18 @@ def temp_session_dir(tmp_path, monkeypatch):
     # api.models reads SESSION_DIR at import time; patch the module-level binding.
     import api.models as _m
     from collections import OrderedDict
+
     monkeypatch.setattr(_m, "SESSION_DIR", sd)
     monkeypatch.setattr(_m, "SESSIONS", OrderedDict())
     yield sd
 
 
-def _make_session_on_disk(session_dir, sid="s_test_1557", n_msgs=1000, with_active_stream=True):
+def _make_session_on_disk(
+    session_dir, sid="s_test_1557", n_msgs=1000, with_active_stream=True
+):
     """Write a realistic session JSON with N messages and a stale active_stream_id."""
     from api.models import Session
+
     s = Session(
         session_id=sid,
         title="A long conversation",
@@ -48,10 +51,15 @@ def _make_session_on_disk(session_dir, sid="s_test_1557", n_msgs=1000, with_acti
         model_provider="ollama-cloud",
         created_at=1.0,
         updated_at=2.0,
-        active_stream_id="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" if with_active_stream else None,
-        pending_user_message="What is the meaning of life?" if with_active_stream else None,
+        active_stream_id="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        if with_active_stream
+        else None,
+        pending_user_message="What is the meaning of life?"
+        if with_active_stream
+        else None,
         messages=[
-            {"role": "user", "content": f"prompt {i}"} if i % 2 == 0
+            {"role": "user", "content": f"prompt {i}"}
+            if i % 2 == 0
             else {"role": "assistant", "content": f"reply {i}"}
             for i in range(n_msgs)
         ],
@@ -65,15 +73,20 @@ def _make_session_on_disk(session_dir, sid="s_test_1557", n_msgs=1000, with_acti
 def test_metadata_only_save_raises_to_prevent_wipe(temp_session_dir):
     """Direct test of the #1558 guard: save() must refuse to wipe on-disk messages."""
     from api.models import get_session
+
     sid = _make_session_on_disk(temp_session_dir, n_msgs=1000)
 
     # Pre-state: on-disk file has 1000 messages.
-    raw_before = json.loads((temp_session_dir / f"{sid}.json").read_text(encoding="utf-8"))
+    raw_before = json.loads(
+        (temp_session_dir / f"{sid}.json").read_text(encoding="utf-8")
+    )
     assert len(raw_before["messages"]) == 1000
 
     # Load metadata-only — synthesizes a stub with messages=[].
     s = get_session(sid, metadata_only=True)
-    assert len(s.messages) == 0, "metadata-only load synthesizes empty messages — that's its job"
+    assert len(s.messages) == 0, (
+        "metadata-only load synthesizes empty messages — that's its job"
+    )
     assert getattr(s, "_loaded_metadata_only", False) is True, (
         "load_metadata_only() must set the _loaded_metadata_only flag so save() "
         "knows to refuse this save and prevent #1558 data-loss."
@@ -86,7 +99,9 @@ def test_metadata_only_save_raises_to_prevent_wipe(temp_session_dir):
         s.save()
 
     # On-disk file MUST still have 1000 messages — the guard prevented the wipe.
-    raw_after = json.loads((temp_session_dir / f"{sid}.json").read_text(encoding="utf-8"))
+    raw_after = json.loads(
+        (temp_session_dir / f"{sid}.json").read_text(encoding="utf-8")
+    )
     assert len(raw_after["messages"]) == 1000, (
         "save() raised but the file still got mutated — the guard must run BEFORE "
         "any disk write happens."
@@ -96,11 +111,13 @@ def test_metadata_only_save_raises_to_prevent_wipe(temp_session_dir):
 def test_clear_stale_stream_state_preserves_messages(temp_session_dir):
     """High-level: the production trigger from #1558 must NOT wipe messages."""
     from api.models import get_session
+
     sid = _make_session_on_disk(temp_session_dir, n_msgs=1000, with_active_stream=True)
 
     # Simulate a server restart: STREAMS is empty, but the session has a stale
     # active_stream_id on disk. This is exactly the production trigger.
     from api.config import STREAMS, STREAMS_LOCK
+
     with STREAMS_LOCK:
         STREAMS.clear()
 
@@ -108,6 +125,7 @@ def test_clear_stale_stream_state_preserves_messages(temp_session_dir):
     s = get_session(sid, metadata_only=True)
 
     from api.routes import _clear_stale_stream_state
+
     # We don't care about the return value — the post-fix path may return False
     # because _repair_stale_pending clears the stream during the metadata=False
     # reload. What we care about is the messages array surviving.
@@ -133,6 +151,7 @@ def test_clear_stale_stream_state_preserves_messages(temp_session_dir):
 def test_save_writes_bak_when_messages_shrink(temp_session_dir):
     """The backup safeguard: a save that shrinks messages must leave a .bak."""
     from api.models import Session
+
     sid = _make_session_on_disk(temp_session_dir, n_msgs=1000, with_active_stream=False)
 
     # Build a fresh in-memory Session with a smaller messages array, then save —
@@ -156,13 +175,16 @@ def test_save_writes_bak_when_messages_shrink(temp_session_dir):
     assert len(bak_data["messages"]) == 1000, (
         "The .bak must contain the pre-shrink state (1000 messages), not the new state."
     )
-    live_data = json.loads((temp_session_dir / f"{sid}.json").read_text(encoding="utf-8"))
+    live_data = json.loads(
+        (temp_session_dir / f"{sid}.json").read_text(encoding="utf-8")
+    )
     assert len(live_data["messages"]) == 500
 
 
 def test_save_does_not_write_bak_when_messages_grow(temp_session_dir):
     """No backup overhead on the normal grow-the-conversation path."""
     from api.models import Session
+
     sid = _make_session_on_disk(temp_session_dir, n_msgs=1000, with_active_stream=False)
 
     # Build a session with MORE messages than on disk — the normal grow path.
@@ -196,6 +218,7 @@ def test_recover_all_sessions_on_startup_restores_shrunken_session(temp_session_
     live_path.write_text(json.dumps(live), encoding="utf-8")
 
     from api.session_recovery import recover_all_sessions_on_startup
+
     result = recover_all_sessions_on_startup(temp_session_dir)
     assert result["restored"] == 1
     assert result["scanned"] >= 1
@@ -204,12 +227,15 @@ def test_recover_all_sessions_on_startup_restores_shrunken_session(temp_session_
     assert len(restored["messages"]) == 1000
 
 
-def test_recover_all_sessions_on_startup_is_idempotent_no_op_on_clean_state(temp_session_dir):
+def test_recover_all_sessions_on_startup_is_idempotent_no_op_on_clean_state(
+    temp_session_dir,
+):
     """A clean install (no .bak files) must not modify anything."""
     sid = _make_session_on_disk(temp_session_dir, n_msgs=1000)
     live_before = (temp_session_dir / f"{sid}.json").read_text(encoding="utf-8")
 
     from api.session_recovery import recover_all_sessions_on_startup
+
     result = recover_all_sessions_on_startup(temp_session_dir)
     assert result["restored"] == 0
 
@@ -230,14 +256,17 @@ def test_recover_all_sessions_on_startup_skips_non_session_index_json(temp_sessi
     # _index.json is the index file shape — a top-level list of metadata dicts
     index_path = temp_session_dir / "_index.json"
     index_path.write_text(
-        json.dumps([
-            {"session_id": sid, "title": "Test", "updated_at": 1.0},
-            {"session_id": "other", "title": "Other", "updated_at": 2.0},
-        ]),
+        json.dumps(
+            [
+                {"session_id": sid, "title": "Test", "updated_at": 1.0},
+                {"session_id": "other", "title": "Other", "updated_at": 2.0},
+            ]
+        ),
         encoding="utf-8",
     )
 
     from api.session_recovery import recover_all_sessions_on_startup
+
     # Before the fix, this raised AttributeError; the broad except in server.py
     # swallowed it and printed [recovery] startup recovery failed: 'list'
     # object has no attribute 'get'. Now the scanner skips _index.json
@@ -254,8 +283,8 @@ def test_recover_all_sessions_on_startup_skips_non_session_index_json(temp_sessi
 def test_msg_count_returns_neg1_for_non_dict_top_level(temp_session_dir):
     """``_msg_count`` must not raise on a JSON file whose top-level is a list."""
     from api.session_recovery import _msg_count
+
     list_shaped = temp_session_dir / "_index.json"
     list_shaped.write_text(json.dumps([{"session_id": "x"}]), encoding="utf-8")
     # Pre-fix: AttributeError. Post-fix: -1.
     assert _msg_count(list_shaped) == -1
-

--- a/tests/test_minimax_provider.py
+++ b/tests/test_minimax_provider.py
@@ -7,7 +7,7 @@ Covers:
   - @minimax: provider hint routing works correctly
   - minimax/MiniMax-M2.7 (slash format) is routed via openrouter when active provider differs
 """
-import os
+
 import pytest
 import api.config as config
 
@@ -30,7 +30,9 @@ def _run_available_models_with_cfg(monkeypatch, tmp_path, cfg):
     old_cfg = dict(config.cfg)
     old_mtime = config._cfg_mtime
     monkeypatch.setattr(config, "_models_cache_path", tmp_path / "models_cache.json")
-    monkeypatch.setattr(config, "_get_config_path", lambda: tmp_path / "missing-config.yaml")
+    monkeypatch.setattr(
+        config, "_get_config_path", lambda: tmp_path / "missing-config.yaml"
+    )
     config.cfg.clear()
     config.cfg.update(cfg)
     config._cfg_mtime = 0.0
@@ -58,14 +60,15 @@ def _isolate_models_cache():
 
 # ── Helper ────────────────────────────────────────────────────────────────────
 
+
 def _resolve_with_config(model_id, provider=None, base_url=None):
     old_cfg = dict(config.cfg)
     model_cfg = {}
     if provider:
-        model_cfg['provider'] = provider
+        model_cfg["provider"] = provider
     if base_url:
-        model_cfg['base_url'] = base_url
-    config.cfg['model'] = model_cfg if model_cfg else {}
+        model_cfg["base_url"] = base_url
+    config.cfg["model"] = model_cfg if model_cfg else {}
     try:
         return config.resolve_model_provider(model_id)
     finally:
@@ -75,18 +78,19 @@ def _resolve_with_config(model_id, provider=None, base_url=None):
 
 # ── Fallback model list ───────────────────────────────────────────────────────
 
+
 def test_minimax_m2_7_in_fallback_models():
     """MiniMax-M2.7 must appear in the hardcoded fallback model list."""
-    ids = [m['id'] for m in config._FALLBACK_MODELS]
-    assert 'minimax/MiniMax-M2.7' in ids, (
+    ids = [m["id"] for m in config._FALLBACK_MODELS]
+    assert "minimax/MiniMax-M2.7" in ids, (
         f"minimax/MiniMax-M2.7 missing from _FALLBACK_MODELS. Found: {ids}"
     )
 
 
 def test_minimax_m2_7_highspeed_in_fallback_models():
     """MiniMax-M2.7-highspeed must appear in the hardcoded fallback model list."""
-    ids = [m['id'] for m in config._FALLBACK_MODELS]
-    assert 'minimax/MiniMax-M2.7-highspeed' in ids, (
+    ids = [m["id"] for m in config._FALLBACK_MODELS]
+    assert "minimax/MiniMax-M2.7-highspeed" in ids, (
         f"minimax/MiniMax-M2.7-highspeed missing from _FALLBACK_MODELS. Found: {ids}"
     )
 
@@ -103,58 +107,62 @@ def test_minimax_fallback_provider_label():
     MiniMax, and correctly carry provider='OpenRouter'. See #1426.
     """
     direct_minimax = [
-        m for m in config._FALLBACK_MODELS
-        if m['id'].startswith('minimax/') and ':free' not in m['id']
+        m
+        for m in config._FALLBACK_MODELS
+        if m["id"].startswith("minimax/") and ":free" not in m["id"]
     ]
     assert direct_minimax, "No direct-MiniMax entries found in _FALLBACK_MODELS"
     for entry in direct_minimax:
-        assert entry['provider'] == 'MiniMax', (
+        assert entry["provider"] == "MiniMax", (
             f"Expected provider='MiniMax', got '{entry['provider']}' for {entry['id']}"
         )
 
 
 # ── _PROVIDER_MODELS ──────────────────────────────────────────────────────────
 
+
 def test_minimax_provider_models_has_m2_7():
     """_PROVIDER_MODELS['minimax'] must include MiniMax-M2.7."""
-    models = config._PROVIDER_MODELS.get('minimax', [])
-    ids = [m['id'] for m in models]
-    assert 'MiniMax-M2.7' in ids, (
+    models = config._PROVIDER_MODELS.get("minimax", [])
+    ids = [m["id"] for m in models]
+    assert "MiniMax-M2.7" in ids, (
         f"MiniMax-M2.7 missing from _PROVIDER_MODELS['minimax']. Found: {ids}"
     )
 
 
 def test_minimax_provider_models_has_highspeed():
     """_PROVIDER_MODELS['minimax'] must include MiniMax-M2.7-highspeed."""
-    models = config._PROVIDER_MODELS.get('minimax', [])
-    ids = [m['id'] for m in models]
-    assert 'MiniMax-M2.7-highspeed' in ids, (
+    models = config._PROVIDER_MODELS.get("minimax", [])
+    ids = [m["id"] for m in models]
+    assert "MiniMax-M2.7-highspeed" in ids, (
         f"MiniMax-M2.7-highspeed missing from _PROVIDER_MODELS['minimax']. Found: {ids}"
     )
 
 
 def test_minimax_cn_provider_models_match_hermes_agent_catalog():
     """minimax-cn must have its own static catalog so an empty config provider still shows models."""
-    models = config._PROVIDER_MODELS.get('minimax-cn', [])
-    ids = [m['id'] for m in models]
+    models = config._PROVIDER_MODELS.get("minimax-cn", [])
+    ids = [m["id"] for m in models]
     assert ids == [
-        'MiniMax-M2.7',
-        'MiniMax-M2.5',
-        'MiniMax-M2.1',
-        'MiniMax-M2',
+        "MiniMax-M2.7",
+        "MiniMax-M2.5",
+        "MiniMax-M2.1",
+        "MiniMax-M2",
     ]
-    assert config._PROVIDER_DISPLAY.get('minimax-cn') == 'MiniMax (China)'
+    assert config._PROVIDER_DISPLAY.get("minimax-cn") == "MiniMax (China)"
 
 
 # ── MINIMAX_API_KEY env var detection ─────────────────────────────────────────
+
 
 def test_minimax_api_key_in_env_scan_tuple():
     """MINIMAX_API_KEY must be included in the env var scan performed by
     get_available_models(), so users who export MINIMAX_API_KEY see the
     MiniMax provider in the dropdown without editing ~/.hermes/.env."""
-    import inspect, ast, textwrap
+    import inspect
+
     src = inspect.getsource(config.get_available_models)
-    assert 'MINIMAX_API_KEY' in src, (
+    assert "MINIMAX_API_KEY" in src, (
         "MINIMAX_API_KEY not found in get_available_models() source — "
         "it must be added to the env var scan tuple so os.environ is checked."
     )
@@ -163,22 +171,23 @@ def test_minimax_api_key_in_env_scan_tuple():
 def test_minimax_cn_api_key_in_env_scan_tuple():
     """MINIMAX_CN_API_KEY must also be scanned (mainland China API key variant)."""
     import inspect
+
     src = inspect.getsource(config.get_available_models)
-    assert 'MINIMAX_CN_API_KEY' in src, (
+    assert "MINIMAX_CN_API_KEY" in src, (
         "MINIMAX_CN_API_KEY not found in get_available_models() source."
     )
 
 
 def test_minimax_detected_from_os_environ(monkeypatch):
     """Setting MINIMAX_API_KEY in os.environ triggers minimax provider detection."""
-    monkeypatch.setenv('MINIMAX_API_KEY', 'test-key-from-env')
+    monkeypatch.setenv("MINIMAX_API_KEY", "test-key-from-env")
     old_cfg = dict(config.cfg)
     # Clear model config so the env-var fallback path is exercised
-    config.cfg['model'] = {}
+    config.cfg["model"] = {}
     try:
         result = config.get_available_models()
-        provider_names = [g['provider'] for g in result['groups']]
-        assert 'MiniMax' in provider_names, (
+        provider_names = [g["provider"] for g in result["groups"]]
+        assert "MiniMax" in provider_names, (
             f"MiniMax not detected when MINIMAX_API_KEY is set in os.environ. "
             f"Active provider groups: {provider_names}"
         )
@@ -190,21 +199,21 @@ def test_minimax_detected_from_os_environ(monkeypatch):
 def test_minimax_cn_detected_from_os_environ(monkeypatch, tmp_path):
     """MINIMAX_CN_API_KEY should show MiniMax (China), not the global MiniMax provider."""
     _force_env_fallback(monkeypatch)
-    monkeypatch.delenv('MINIMAX_API_KEY', raising=False)
-    monkeypatch.setenv('MINIMAX_CN_API_KEY', 'test-cn-key-from-env')
+    monkeypatch.delenv("MINIMAX_API_KEY", raising=False)
+    monkeypatch.setenv("MINIMAX_CN_API_KEY", "test-cn-key-from-env")
 
-    result = _run_available_models_with_cfg(monkeypatch, tmp_path, {'model': {}})
-    groups = {g['provider_id']: g for g in result['groups']}
+    result = _run_available_models_with_cfg(monkeypatch, tmp_path, {"model": {}})
+    groups = {g["provider_id"]: g for g in result["groups"]}
 
-    assert 'minimax-cn' in groups, f"minimax-cn group missing: {groups.keys()}"
-    assert groups['minimax-cn']['provider'] == 'MiniMax (China)'
-    assert {m['id'] for m in groups['minimax-cn']['models']} == {
-        'MiniMax-M2.7',
-        'MiniMax-M2.5',
-        'MiniMax-M2.1',
-        'MiniMax-M2',
+    assert "minimax-cn" in groups, f"minimax-cn group missing: {groups.keys()}"
+    assert groups["minimax-cn"]["provider"] == "MiniMax (China)"
+    assert {m["id"] for m in groups["minimax-cn"]["models"]} == {
+        "MiniMax-M2.7",
+        "MiniMax-M2.5",
+        "MiniMax-M2.1",
+        "MiniMax-M2",
     }
-    assert 'minimax' not in groups, (
+    assert "minimax" not in groups, (
         "MINIMAX_CN_API_KEY must not be collapsed into the global minimax provider"
     )
 
@@ -212,56 +221,60 @@ def test_minimax_cn_detected_from_os_environ(monkeypatch, tmp_path):
 def test_minimax_cn_empty_config_provider_gets_static_models(monkeypatch, tmp_path):
     """providers.minimax-cn: {} should still render a populated model group."""
     _force_env_fallback(monkeypatch)
-    monkeypatch.delenv('MINIMAX_API_KEY', raising=False)
-    monkeypatch.delenv('MINIMAX_CN_API_KEY', raising=False)
+    monkeypatch.delenv("MINIMAX_API_KEY", raising=False)
+    monkeypatch.delenv("MINIMAX_CN_API_KEY", raising=False)
 
     result = _run_available_models_with_cfg(
         monkeypatch,
         tmp_path,
         {
-            'model': {'provider': 'minimax-cn', 'default': 'MiniMax-M2.7'},
-            'providers': {'minimax-cn': {}},
+            "model": {"provider": "minimax-cn", "default": "MiniMax-M2.7"},
+            "providers": {"minimax-cn": {}},
         },
     )
-    groups = {g['provider_id']: g for g in result['groups']}
+    groups = {g["provider_id"]: g for g in result["groups"]}
 
-    assert 'minimax-cn' in groups, f"minimax-cn group missing: {groups.keys()}"
-    assert groups['minimax-cn']['models'], "minimax-cn group must not be empty"
+    assert "minimax-cn" in groups, f"minimax-cn group missing: {groups.keys()}"
+    assert groups["minimax-cn"]["models"], "minimax-cn group must not be empty"
 
 
 def test_minimax_cn_key_can_be_managed_from_provider_settings():
     """Provider settings should use the Hermes Agent env var for minimax-cn."""
     from api.providers import _PROVIDER_ENV_VAR
 
-    assert _PROVIDER_ENV_VAR.get('minimax-cn') == 'MINIMAX_CN_API_KEY'
+    assert _PROVIDER_ENV_VAR.get("minimax-cn") == "MINIMAX_CN_API_KEY"
 
 
 # ── Model routing ─────────────────────────────────────────────────────────────
 
+
 def test_provider_hint_minimax_m2_7():
     """@minimax:MiniMax-M2.7 routes to minimax provider with bare model name."""
     model, provider, base_url = _resolve_with_config(
-        '@minimax:MiniMax-M2.7', provider='anthropic',
+        "@minimax:MiniMax-M2.7",
+        provider="anthropic",
     )
-    assert model == 'MiniMax-M2.7'
-    assert provider == 'minimax'
+    assert model == "MiniMax-M2.7"
+    assert provider == "minimax"
     assert base_url is None
 
 
 def test_provider_hint_minimax_highspeed():
     """@minimax:MiniMax-M2.7-highspeed routes to minimax provider."""
     model, provider, base_url = _resolve_with_config(
-        '@minimax:MiniMax-M2.7-highspeed', provider='openai',
+        "@minimax:MiniMax-M2.7-highspeed",
+        provider="openai",
     )
-    assert model == 'MiniMax-M2.7-highspeed'
-    assert provider == 'minimax'
+    assert model == "MiniMax-M2.7-highspeed"
+    assert provider == "minimax"
 
 
 def test_minimax_slash_format_routes_openrouter_when_not_active():
     """minimax/MiniMax-M2.7 (slash format) routes via openrouter when active
     provider is anthropic (cross-provider routing)."""
     model, provider, base_url = _resolve_with_config(
-        'minimax/MiniMax-M2.7', provider='anthropic',
+        "minimax/MiniMax-M2.7",
+        provider="anthropic",
     )
-    assert model == 'minimax/MiniMax-M2.7'
-    assert provider == 'openrouter'
+    assert model == "minimax/MiniMax-M2.7"
+    assert provider == "openrouter"

--- a/tests/test_mobile_layout.py
+++ b/tests/test_mobile_layout.py
@@ -22,12 +22,12 @@ from html.parser import HTMLParser
 
 REPO = pathlib.Path(__file__).parent.parent
 HTML = (REPO / "static" / "index.html").read_text(encoding="utf-8")
-CSS  = (REPO / "static" / "style.css").read_text(encoding="utf-8")
+CSS = (REPO / "static" / "style.css").read_text(encoding="utf-8")
 
 
 def _max_width_media_blocks(width_px):
     """Return all @media(max-width:Npx) bodies using balanced braces."""
-    pattern = re.compile(rf'@media\s*\(\s*max-width\s*:\s*{width_px}px\s*\)\s*\{{')
+    pattern = re.compile(rf"@media\s*\(\s*max-width\s*:\s*{width_px}px\s*\)\s*\{{")
     blocks = []
     for match in pattern.finditer(CSS):
         open_brace = match.end() - 1
@@ -38,7 +38,7 @@ def _max_width_media_blocks(width_px):
             elif CSS[idx] == "}":
                 depth -= 1
                 if depth == 0:
-                    blocks.append(CSS[open_brace + 1:idx])
+                    blocks.append(CSS[open_brace + 1 : idx])
                     break
     return blocks
 
@@ -51,11 +51,11 @@ def _composer_phone_media_block():
 
 
 def _strip_css_comments(css):
-    return re.sub(r'/\*.*?\*/', '', css, flags=re.DOTALL)
+    return re.sub(r"/\*.*?\*/", "", css, flags=re.DOTALL)
 
 
 def _rule_body(css, selector):
-    for match in re.finditer(r'([^{}]+)\{([^{}]*)\}', _strip_css_comments(css)):
+    for match in re.finditer(r"([^{}]+)\{([^{}]*)\}", _strip_css_comments(css)):
         selectors = {part.strip() for part in match.group(1).split(",")}
         if selector in selectors:
             return match.group(2)
@@ -68,7 +68,7 @@ def _declarations(rule_body):
         if ":" not in item:
             continue
         prop, value = item.split(":", 1)
-        declarations[prop.strip()] = re.sub(r'\s+', ' ', value.strip())
+        declarations[prop.strip()] = re.sub(r"\s+", " ", value.strip())
     return declarations
 
 
@@ -80,17 +80,35 @@ def _optional_declarations(css, selector):
 
 
 def _display_hidden(declarations):
-    return declarations.get("display", "").replace(" ", "") in {"none", "none!important"}
+    return declarations.get("display", "").replace(" ", "") in {
+        "none",
+        "none!important",
+    }
 
 
 def _display_inline_flex(declarations):
-    return declarations.get("display", "").replace(" ", "") in {"inline-flex", "inline-flex!important"}
+    return declarations.get("display", "").replace(" ", "") in {
+        "inline-flex",
+        "inline-flex!important",
+    }
 
 
 class _ComposerLeftDropdownParser(HTMLParser):
     _VOID_TAGS = {
-        "area", "base", "br", "col", "embed", "hr", "img", "input",
-        "link", "meta", "param", "source", "track", "wbr",
+        "area",
+        "base",
+        "br",
+        "col",
+        "embed",
+        "hr",
+        "img",
+        "input",
+        "link",
+        "meta",
+        "param",
+        "source",
+        "track",
+        "wbr",
     }
 
     def __init__(self):
@@ -119,9 +137,8 @@ class _ComposerLeftDropdownParser(HTMLParser):
         inside_composer_left = any(
             "composer-left" in item["classes"] for item in self.stack
         )
-        is_dropdown = (
-            element_id.endswith("Dropdown") or
-            any("dropdown" in class_name for class_name in classes)
+        is_dropdown = element_id.endswith("Dropdown") or any(
+            "dropdown" in class_name for class_name in classes
         )
         if inside_composer_left and is_dropdown:
             label = f"#{element_id}" if element_id else "." + ".".join(sorted(classes))
@@ -132,68 +149,96 @@ class _ComposerLeftDropdownParser(HTMLParser):
 
 # ── Mobile breakpoint rules ───────────────────────────────────────────────────
 
+
 def test_mobile_breakpoint_900px_present():
     """@media(max-width:900px) must hide the right panel and show mobile-files-btn."""
-    assert "@media(max-width:900px)" in CSS or "@media (max-width: 900px)" in CSS, \
+    assert "@media(max-width:900px)" in CSS or "@media (max-width: 900px)" in CSS, (
         "Missing @media(max-width:900px) breakpoint in style.css"
+    )
     # Right panel should be hidden at 900px, replaced by slide-over
-    assert ".rightpanel{display:none" in CSS or ".rightpanel {display:none" in CSS or \
-           re.search(r'max-width:900px\).*?\.rightpanel\{display:none', CSS, re.DOTALL), \
-        ".rightpanel must be display:none at max-width:900px (slide-over replaces it)"
+    assert (
+        ".rightpanel{display:none" in CSS
+        or ".rightpanel {display:none" in CSS
+        or re.search(r"max-width:900px\).*?\.rightpanel\{display:none", CSS, re.DOTALL)
+    ), ".rightpanel must be display:none at max-width:900px (slide-over replaces it)"
 
 
 def test_mobile_breakpoint_640px_present():
     """@media(max-width:640px) must exist for narrow phone layouts."""
-    assert "@media(max-width:640px)" in CSS or "@media (max-width: 640px)" in CSS, \
+    assert "@media(max-width:640px)" in CSS or "@media (max-width: 640px)" in CSS, (
         "Missing @media(max-width:640px) breakpoint in style.css"
+    )
 
 
 def test_rightpanel_mobile_slide_over_css():
     """Right panel must have position:fixed slide-over CSS for mobile."""
     # At max-width:900px the rightpanel should be position:fixed, off-screen right
-    assert "position:fixed" in CSS, \
+    assert "position:fixed" in CSS, (
         "style.css must have position:fixed for rightpanel mobile slide-over"
-    assert ".rightpanel.mobile-open{right:0" in CSS or ".rightpanel.mobile-open {right:0" in CSS, \
-        ".rightpanel.mobile-open must set right:0 to slide panel in from right"
-    assert "min(300px, 100vw)" in CSS or "min(300px,100vw)" in CSS, \
+    )
+    assert (
+        ".rightpanel.mobile-open{right:0" in CSS
+        or ".rightpanel.mobile-open {right:0" in CSS
+    ), ".rightpanel.mobile-open must set right:0 to slide panel in from right"
+    assert "min(300px, 100vw)" in CSS or "min(300px,100vw)" in CSS, (
         "rightpanel mobile width should be capped defensively with 100vw"
-    assert "var(--mobile-rightpanel-width)" in CSS, \
+    )
+    assert "var(--mobile-rightpanel-width)" in CSS, (
         "mobile rightpanel width variable should be used in compact mode rules"
-    assert "calc(-1 * var(--mobile-rightpanel-width))" in CSS, \
+    )
+    assert "calc(-1 * var(--mobile-rightpanel-width))" in CSS, (
         "closed mobile rightpanel should be off-canvas using a width-based negative offset"
-    mobile_640 = re.search(r'@media\(max-width:640px\)\{([^{}]*(?:\{[^{}]*\}[^{}]*)*)\}', CSS, re.DOTALL)
+    )
+    mobile_640 = re.search(
+        r"@media\(max-width:640px\)\{([^{}]*(?:\{[^{}]*\}[^{}]*)*)\}", CSS, re.DOTALL
+    )
     assert mobile_640, "@media(max-width:640px) block missing from style.css"
     rightpanel_block = mobile_640.group(1)
-    assert re.search(r'\.rightpanel\{[^}]*width:\s*var\(--mobile-rightpanel-width\)\s*!important',
-                     rightpanel_block, re.DOTALL), \
+    assert re.search(
+        r"\.rightpanel\{[^}]*width:\s*var\(--mobile-rightpanel-width\)\s*!important",
+        rightpanel_block,
+        re.DOTALL,
+    ), (
         ".rightpanel width must use var(--mobile-rightpanel-width) with !important in mobile block"
-    assert re.search(r'\.rightpanel\.mobile-open\{[^}]*right:\s*0\s*!important',
-                     rightpanel_block, re.DOTALL), \
-        "mobile-open mobile rightpanel must force right:0 with !important"
-    assert re.search(r'\.rightpanel\{[^}]*box-shadow:\s*none\s*!important',
-                     rightpanel_block, re.DOTALL), \
-        "closed mobile rightpanel should have no shadow to avoid right-edge bleed"
-    assert re.search(r'\.rightpanel\.mobile-open\{[^}]*box-shadow:\s*-4px 0 24px rgba\(0,\s*0,\s*0,\s*\.?4\)',
-                     rightpanel_block, re.DOTALL), \
-        "open mobile rightpanel should keep the edge shadow"
+    )
+    assert re.search(
+        r"\.rightpanel\.mobile-open\{[^}]*right:\s*0\s*!important",
+        rightpanel_block,
+        re.DOTALL,
+    ), "mobile-open mobile rightpanel must force right:0 with !important"
+    assert re.search(
+        r"\.rightpanel\{[^}]*box-shadow:\s*none\s*!important",
+        rightpanel_block,
+        re.DOTALL,
+    ), "closed mobile rightpanel should have no shadow to avoid right-edge bleed"
+    assert re.search(
+        r"\.rightpanel\.mobile-open\{[^}]*box-shadow:\s*-4px 0 24px rgba\(0,\s*0,\s*0,\s*\.?4\)",
+        rightpanel_block,
+        re.DOTALL,
+    ), "open mobile rightpanel should keep the edge shadow"
 
 
 def test_workspace_panel_inline_width_is_desktop_only():
     """Persisted rightpanel width must only be restored above compact/mobile breakpoints."""
     boot_js = (REPO / "static" / "boot.js").read_text(encoding="utf-8")
-    assert "function _syncWorkspacePanelInlineWidth()" in boot_js, \
+    assert "function _syncWorkspacePanelInlineWidth()" in boot_js, (
         "_syncWorkspacePanelInlineWidth() must exist to keep panel width mobile-safe"
-    assert "_syncWorkspacePanelInlineWidth();" in boot_js, \
+    )
+    assert "_syncWorkspacePanelInlineWidth();" in boot_js, (
         "_syncWorkspacePanelInlineWidth() must be called when viewport changes"
-    assert "localStorage.getItem('hermes-panel-w')" in boot_js, \
+    )
+    assert "localStorage.getItem('hermes-panel-w')" in boot_js, (
         "Panel width helper must source hermes-panel-w from localStorage"
-    assert "_workspacePanelEls();" in boot_js and "style.removeProperty('width')" in boot_js, \
-        "Panel helper must clear inline width while in compact/mobile viewport"
+    )
+    assert (
+        "_workspacePanelEls();" in boot_js
+        and "style.removeProperty('width')" in boot_js
+    ), "Panel helper must clear inline width while in compact/mobile viewport"
 
 
 def _container_query_block(css: str, container_query: str):
     query_pattern = re.compile(
-        rf'@container\s+{re.escape(container_query)}\s*\{{',
+        rf"@container\s+{re.escape(container_query)}\s*\{{",
         re.DOTALL,
     )
     for match in query_pattern.finditer(css):
@@ -203,14 +248,14 @@ def _container_query_block(css: str, container_query: str):
             end = css.find("@media", start + 1)
         if end == -1:
             end = len(css)
-        block = css[start + 1:end]
+        block = css[start + 1 : end]
         return block
     return ""
 
 
 def _container_media_block(css: str, media_query: str):
     query_pattern = re.compile(
-        rf'@media\s*\(\s*max-width:\s*{re.escape(media_query)}\s*\)\s*\{{',
+        rf"@media\s*\(\s*max-width:\s*{re.escape(media_query)}\s*\)\s*\{{",
         re.DOTALL,
     )
 
@@ -248,7 +293,7 @@ def _container_media_block(css: str, media_query: str):
         end = _media_block_end(css, start)
         if end == -1:
             continue
-        block = css[start + 1:end]
+        block = css[start + 1 : end]
         block = _strip_nested_media(block)
         if ".composer-profile-label" in block or ".composer-profile-chip" in block:
             return block
@@ -257,10 +302,16 @@ def _container_media_block(css: str, media_query: str):
 
 def test_composer_controls_switch_to_icon_only_by_container_width():
     """Composer controls should progressively compact based on footer width."""
-    assert re.search(r'\.composer-footer\s*\{[^}]*container-type:inline-size[^}]*container-name:composer-footer[^}]*\}', CSS), \
+    assert re.search(
+        r"\.composer-footer\s*\{[^}]*container-type:inline-size[^}]*container-name:composer-footer[^}]*\}",
+        CSS,
+    ), (
         ".composer-footer should define container-type:inline-size and container-name:composer-footer"
+    )
     compact_700 = _container_query_block(CSS, "composer-footer (max-width: 700px)")
-    assert compact_700, "Expected composer mid-width compact rules at @container composer-footer (max-width: 700px)"
+    assert compact_700, (
+        "Expected composer mid-width compact rules at @container composer-footer (max-width: 700px)"
+    )
     for selector in (
         ".composer-workspace-label",
         ".composer-model-label",
@@ -271,7 +322,9 @@ def test_composer_controls_switch_to_icon_only_by_container_width():
         ".composer-model-chip",
         ".composer-divider",
     ):
-        assert selector in compact_700, f"{selector} should be present in the 700px composer compact block"
+        assert selector in compact_700, (
+            f"{selector} should be present in the 700px composer compact block"
+        )
     assert "display:none" in compact_700
     assert "max-width:52px" in compact_700
     # Ensure this first stage does not prematurely remove profile/reasoning labels.
@@ -281,7 +334,9 @@ def test_composer_controls_switch_to_icon_only_by_container_width():
     assert ".composer-reasoning-chevron" not in compact_700
 
     compact_520 = _container_query_block(CSS, "composer-footer (max-width: 520px)")
-    assert compact_520, "Expected full composer icon-only rules at @container composer-footer (max-width: 520px)"
+    assert compact_520, (
+        "Expected full composer icon-only rules at @container composer-footer (max-width: 520px)"
+    )
     for selector in (
         ".composer-profile-label",
         ".composer-workspace-label",
@@ -299,92 +354,122 @@ def test_composer_controls_switch_to_icon_only_by_container_width():
         ".composer-profile-chip",
         ".composer-reasoning-chip",
     ):
-        assert selector in compact_520, f"{selector} should be present in the 520px composer compact block"
+        assert selector in compact_520, (
+            f"{selector} should be present in the 520px composer compact block"
+        )
     assert "width:44px" in compact_520
     assert "display:none" in compact_520
-    assert ".composer-workspace-chip{display:none!important" in compact_520.replace(" ", ""), \
-        "520px container compact mode must remove the blank workspace switch slot"
-    assert ".composer-left>*{flex-shrink:0" in compact_520.replace(" ", ""), \
+    assert ".composer-workspace-chip{display:none!important" in compact_520.replace(
+        " ", ""
+    ), "520px container compact mode must remove the blank workspace switch slot"
+    assert ".composer-left>*{flex-shrink:0" in compact_520.replace(" ", ""), (
         "520px container compact mode must stop controls from shrinking into each other"
-    assert ".composer-mobile-config-btn" in compact_520 and "display:inline-flex!important" in compact_520, \
+    )
+    assert (
+        ".composer-mobile-config-btn" in compact_520
+        and "display:inline-flex!important" in compact_520
+    ), (
         "520px container compact mode must expose the mobile config button even when viewport is wider than 640px"
+    )
 
     # Regression intent:
     # - this container rule should not depend on right-panel open/closed state.
     # - left-sidebar-only constriction must still collapse composer controls together.
-    assert ".layout:not(.workspace-panel-collapsed)" not in compact_700, \
+    assert ".layout:not(.workspace-panel-collapsed)" not in compact_700, (
         "composer-footer compact rule should be state-agnostic (left sidebar + closed right panel case included)"
-    assert ".layout:not(.workspace-panel-collapsed)" not in compact_520, \
+    )
+    assert ".layout:not(.workspace-panel-collapsed)" not in compact_520, (
         "composer-footer compact rule should be state-agnostic (left sidebar + closed right panel case included)"
+    )
 
 
 def test_composer_700px_workspace_switch_does_not_become_blank_chip():
     """The 700px container state may hide the workspace label, but needs a switch affordance."""
     compact_700 = _container_query_block(CSS, "composer-footer (max-width: 700px)")
-    assert compact_700, "Expected composer mid-width compact rules at @container composer-footer (max-width: 700px)"
+    assert compact_700, (
+        "Expected composer mid-width compact rules at @container composer-footer (max-width: 700px)"
+    )
 
-    workspace_label = _declarations(_rule_body(compact_700, ".composer-workspace-label"))
+    workspace_label = _declarations(
+        _rule_body(compact_700, ".composer-workspace-label")
+    )
     workspace_chip = _optional_declarations(compact_700, ".composer-workspace-chip")
-    workspace_chevron = _optional_declarations(compact_700, ".composer-workspace-chevron")
+    workspace_chevron = _optional_declarations(
+        compact_700, ".composer-workspace-chevron"
+    )
     mobile_config = _optional_declarations(compact_700, ".composer-mobile-config-btn")
 
-    assert _display_hidden(workspace_label), \
+    assert _display_hidden(workspace_label), (
         "700px container state should hide the long workspace label before tighter mobile rules"
+    )
     if not _display_hidden(workspace_chip) and not _display_inline_flex(mobile_config):
-        assert not _display_hidden(workspace_chevron), \
+        assert not _display_hidden(workspace_chevron), (
             "700px container state must not leave the visible workspace switch chip without a label or chevron"
+        )
 
 
 def test_composer_compact_switch_is_not_viewport_only():
     """Compact controls should be container-triggered, not bound to viewport width alone."""
-    assert "composer-footer (max-width: 700px)" in CSS, \
+    assert "composer-footer (max-width: 700px)" in CSS, (
         "Container-query breakpoint should track composer footer width"
-    assert "composer-footer (max-width: 520px)" in CSS, \
+    )
+    assert "composer-footer (max-width: 520px)" in CSS, (
         "Container-query second-stage breakpoint should track composer footer width"
-    assert re.search(r'@container\s+composer-footer\s*\(max-width:\s*860px\)', CSS) is None, \
-        "Full icon-only should not be tied to a 860px threshold any more"
-    assert re.search(r'@container\s+composer-footer\s*\(max-width:\s*1000px\)', CSS) is None, \
-        "Full icon-only/first-stage container gate should not be tied to 1000px"
+    )
+    assert (
+        re.search(r"@container\s+composer-footer\s*\(max-width:\s*860px\)", CSS) is None
+    ), "Full icon-only should not be tied to a 860px threshold any more"
+    assert (
+        re.search(r"@container\s+composer-footer\s*\(max-width:\s*1000px\)", CSS)
+        is None
+    ), "Full icon-only/first-stage container gate should not be tied to 1000px"
     media_860 = _container_media_block(CSS, "860px")
-    assert media_860 == "", \
+    assert media_860 == "", (
         "Composer compact breakpoint should not be a dedicated 860px viewport media query"
+    )
     media_900 = _container_media_block(CSS, "900px")
-    assert media_900 == "", \
+    assert media_900 == "", (
         "Composer compact breakpoint should use container queries, not viewport media at 900px"
+    )
+
 
 def test_mobile_overlay_present():
     """Mobile overlay element must exist for tap-to-close sidebar behavior."""
-    assert 'id="mobileOverlay"' in HTML, \
+    assert 'id="mobileOverlay"' in HTML, (
         "#mobileOverlay element missing from index.html"
-    assert "mobile-overlay" in CSS, \
-        ".mobile-overlay CSS rule missing from style.css"
+    )
+    assert "mobile-overlay" in CSS, ".mobile-overlay CSS rule missing from style.css"
 
 
 def test_sidebar_nav_present():
     """Sidebar top navigation tabs must be present."""
-    assert 'class="sidebar-nav"' in HTML, \
-        ".sidebar-nav missing from index.html"
-    assert ".sidebar-nav{" in CSS or ".sidebar-nav {" in CSS, \
+    assert 'class="sidebar-nav"' in HTML, ".sidebar-nav missing from index.html"
+    assert ".sidebar-nav{" in CSS or ".sidebar-nav {" in CSS, (
         ".sidebar-nav CSS rule missing from style.css"
+    )
 
 
 def test_mobile_does_not_hide_sidebar_nav():
     """Phone breakpoint must keep the sidebar top navigation visible."""
     mobile_css = "\n".join(_max_width_media_blocks(640))
     assert mobile_css, "Missing @media(max-width:640px) block in style.css"
-    assert ".sidebar-nav{display:none" not in mobile_css.replace(" ", ""), \
+    assert ".sidebar-nav{display:none" not in mobile_css.replace(" ", ""), (
         ".sidebar-nav must stay visible on mobile"
+    )
 
 
 def test_mobile_files_button_present():
     """Mobile files toggle button (#btnWorkspacePanelToggle.workspace-toggle-btn) must be in HTML and CSS."""
-    assert 'id="btnWorkspacePanelToggle"' in HTML, \
+    assert 'id="btnWorkspacePanelToggle"' in HTML, (
         "#btnWorkspacePanelToggle missing from index.html"
-    assert "workspace-toggle-btn" in CSS, \
+    )
+    assert "workspace-toggle-btn" in CSS, (
         ".workspace-toggle-btn CSS missing from style.css"
+    )
 
 
 # ── Profile dropdown overflow ─────────────────────────────────────────────────
+
 
 def test_profile_dropdown_not_clipped_by_overflow():
     """Profile dropdown must not be inside an overflow:hidden or overflow-x:auto ancestor
@@ -395,16 +480,17 @@ def test_profile_dropdown_not_clipped_by_overflow():
     must use position:fixed on mobile OR the topbar-chips must not clip it.
     """
     # The profile-chip wrapper must have position:relative so the dropdown can escape
-    assert 'id="profileChipWrap"' in HTML, \
-        "#profileChipWrap missing from index.html"
+    assert 'id="profileChipWrap"' in HTML, "#profileChipWrap missing from index.html"
     # Profile dropdown must have a z-index high enough to clear the topbar
-    assert ".profile-dropdown{" in CSS or ".profile-dropdown {" in CSS, \
+    assert ".profile-dropdown{" in CSS or ".profile-dropdown {" in CSS, (
         ".profile-dropdown CSS rule missing"
+    )
     # z-index must be at least 200 (topbar is z-index:10)
-    m = re.search(r'\.profile-dropdown\{[^}]*z-index:(\d+)', CSS)
+    m = re.search(r"\.profile-dropdown\{[^}]*z-index:(\d+)", CSS)
     if m:
-        assert int(m.group(1)) >= 100, \
+        assert int(m.group(1)) >= 100, (
             f".profile-dropdown z-index {m.group(1)} is too low — must be >= 100 to clear topbar"
+        )
 
 
 def test_composer_dropdowns_are_not_nested_inside_left_control_row():
@@ -428,11 +514,13 @@ def test_topbar_chips_mobile_overflow():
     viewports rather than wrapping onto a second line which would break the topbar layout.
     """
     # At narrow viewport, topbar-chips should scroll
-    assert "overflow-x:auto" in CSS or "overflow-x: auto" in CSS, \
+    assert "overflow-x:auto" in CSS or "overflow-x: auto" in CSS, (
         "topbar-chips must have overflow-x:auto for mobile chip scrolling"
+    )
 
 
 # ── Workspace panel close ─────────────────────────────────────────────────────
+
 
 def test_workspace_close_button_present():
     """Workspace panel must have a close/hide button accessible on mobile."""
@@ -440,41 +528,62 @@ def test_workspace_close_button_present():
     # lower-level functions directly.  handleWorkspaceClose is preferred because
     # it dismisses a file preview first before closing the panel.
     has_close = (
-        'onclick="handleWorkspaceClose()"' in HTML or
-        'onclick="closeWorkspacePanel()"' in HTML or
-        'onclick="toggleWorkspacePanel()"' in HTML
+        'onclick="handleWorkspaceClose()"' in HTML
+        or 'onclick="closeWorkspacePanel()"' in HTML
+        or 'onclick="toggleWorkspacePanel()"' in HTML
     )
-    assert has_close, \
+    assert has_close, (
         "handleWorkspaceClose() or closeWorkspacePanel() must be wired to a button to close the workspace panel on mobile"
+    )
 
 
 def test_toggle_mobile_files_js_defined():
     """toggleMobileFiles() must be defined in boot.js."""
     boot_js = (REPO / "static" / "boot.js").read_text(encoding="utf-8")
-    assert "function toggleMobileFiles()" in boot_js, \
+    assert "function toggleMobileFiles()" in boot_js, (
         "toggleMobileFiles() missing from static/boot.js"
-    assert "mobile-open" in boot_js, \
+    )
+    assert "mobile-open" in boot_js, (
         "toggleMobileFiles() must toggle mobile-open class on the right panel"
+    )
 
 
 def test_new_conversation_closes_mobile_sidebar():
     """New conversation must close the mobile drawer so the chat pane is visible immediately."""
     boot_js = (REPO / "static" / "boot.js").read_text(encoding="utf-8")
     # Handler is now multi-line — search for the full block rather than a single line.
-    assert "$('btnNewChat').onclick" in boot_js, "btnNewChat onclick handler missing from static/boot.js"
+    assert "$('btnNewChat').onclick" in boot_js, (
+        "btnNewChat onclick handler missing from static/boot.js"
+    )
     # Find the handler block and verify closeMobileSidebar appears in it.
     # The handler grew comments after #1432 (in-flight guard refactor), so use a
     # generous window to cover the full handler body.
     idx = boot_js.find("$('btnNewChat').onclick")
-    handler_block = boot_js[idx:idx+1500]
-    assert "closeMobileSidebar" in handler_block, \
+    handler_block = boot_js[idx : idx + 1500]
+    assert "closeMobileSidebar" in handler_block, (
         "btnNewChat handler must closeMobileSidebar() after creating the new session"
+    )
 
-    shortcut_line = next((ln for ln in boot_js.splitlines() if "e.key==='k'" in ln or "e.key === 'k'" in ln), "")
+    shortcut_line = next(
+        (
+            ln
+            for ln in boot_js.splitlines()
+            if "e.key==='k'" in ln or "e.key === 'k'" in ln
+        ),
+        "",
+    )
     assert shortcut_line, "Cmd/Ctrl+K new chat shortcut missing from static/boot.js"
-    shortcut_block = "\n".join(boot_js.splitlines()[boot_js.splitlines().index(shortcut_line):boot_js.splitlines().index(shortcut_line)+24])
-    assert "closeMobileSidebar" in shortcut_block, \
+    shortcut_block = "\n".join(
+        boot_js.splitlines()[
+            boot_js.splitlines().index(shortcut_line) : boot_js.splitlines().index(
+                shortcut_line
+            )
+            + 24
+        ]
+    )
+    assert "closeMobileSidebar" in shortcut_block, (
         "Cmd/Ctrl+K new chat shortcut must closeMobileSidebar() after creating the new session"
+    )
 
 
 def test_new_conversation_shortcut_works_while_busy():
@@ -485,12 +594,19 @@ def test_new_conversation_shortcut_works_while_busy():
     new — the exact moment they want to switch context.
     """
     boot_js = (REPO / "static" / "boot.js").read_text(encoding="utf-8")
-    shortcut_line = next((ln for ln in boot_js.splitlines() if "e.key==='k'" in ln or "e.key === 'k'" in ln), "")
+    shortcut_line = next(
+        (
+            ln
+            for ln in boot_js.splitlines()
+            if "e.key==='k'" in ln or "e.key === 'k'" in ln
+        ),
+        "",
+    )
     assert shortcut_line, "Cmd/Ctrl+K new chat shortcut missing from static/boot.js"
     # Inspect the next 10 lines after the keybinding match — the gating block
     # would live there if it had been kept.
     idx = boot_js.splitlines().index(shortcut_line)
-    shortcut_block = "\n".join(boot_js.splitlines()[idx:idx + 10])
+    shortcut_block = "\n".join(boot_js.splitlines()[idx : idx + 10])
     # Strip the existing message-count guard (which is unrelated and stays) so
     # we only check for an S.busy gate on the newSession() call itself.
     assert "if(!S.busy)" not in shortcut_block, (
@@ -503,12 +619,13 @@ def test_new_conversation_shortcut_works_while_busy():
 
 # ── Viewport and scroll safety ────────────────────────────────────────────────
 
+
 def test_body_overflow_hidden():
     """body must have overflow:hidden to prevent double scrollbars on mobile."""
-    assert "body{" in CSS or "body {" in CSS, \
-        "body rule missing from style.css"
-    assert re.search(r'body\{[^}]*overflow:hidden', CSS), \
+    assert "body{" in CSS or "body {" in CSS, "body rule missing from style.css"
+    assert re.search(r"body\{[^}]*overflow:hidden", CSS), (
         "body must have overflow:hidden to prevent double scrollbars"
+    )
 
 
 def test_flex_parents_allow_message_scroller_to_shrink():
@@ -517,10 +634,12 @@ def test_flex_parents_allow_message_scroller_to_shrink():
     Mobile Safari/Chrome can trap scroll when a flex child with overflow:auto sits inside
     parents whose min-height remains auto. Both .layout and .main need min-height:0.
     """
-    assert re.search(r'\.layout\{[^}]*min-height:0', CSS), \
+    assert re.search(r"\.layout\{[^}]*min-height:0", CSS), (
         ".layout must set min-height:0 so the chat column can shrink and scroll"
-    assert re.search(r'\.main\{[^}]*min-height:0', CSS), \
+    )
+    assert re.search(r"\.main\{[^}]*min-height:0", CSS), (
         ".main must set min-height:0 so .messages remains scrollable while busy"
+    )
 
 
 def test_messages_touch_scrolling_hints_present():
@@ -529,12 +648,15 @@ def test_messages_touch_scrolling_hints_present():
     On mobile browsers, momentum scrolling and explicit pan-y/overscroll behavior help
     prevent the chat area from feeling locked while the app body itself stays overflow:hidden.
     """
-    assert re.search(r'\.messages\{[^}]*-webkit-overflow-scrolling:\s*touch', CSS), \
+    assert re.search(r"\.messages\{[^}]*-webkit-overflow-scrolling:\s*touch", CSS), (
         ".messages must enable -webkit-overflow-scrolling:touch for mobile momentum scroll"
-    assert re.search(r'\.messages\{[^}]*touch-action:\s*pan-y', CSS), \
+    )
+    assert re.search(r"\.messages\{[^}]*touch-action:\s*pan-y", CSS), (
         ".messages must set touch-action:pan-y so vertical swipe gestures scroll the transcript"
-    assert re.search(r'\.messages\{[^}]*overscroll-behavior-y:\s*contain', CSS), \
+    )
+    assert re.search(r"\.messages\{[^}]*overscroll-behavior-y:\s*contain", CSS), (
         ".messages must contain vertical overscroll so the transcript keeps the gesture"
+    )
 
 
 def test_100dvh_viewport_height():
@@ -543,8 +665,9 @@ def test_100dvh_viewport_height():
     On mobile Safari and Chrome, 100vh includes the browser chrome (address bar),
     causing content to be hidden. 100dvh accounts for the actual available height.
     """
-    assert "100dvh" in CSS, \
+    assert "100dvh" in CSS, (
         "style.css must use 100dvh for correct mobile viewport height (100vh hides content under address bar)"
+    )
 
 
 def test_titlebar_safe_area_top_not_double_counted_in_browser_viewport():
@@ -554,7 +677,7 @@ def test_titlebar_safe_area_top_not_double_counted_in_browser_viewport():
     their own chrome/status area. Applying the top env inset unconditionally can
     double-count that space and push the titlebar down.
     """
-    m = re.search(r'\.app-titlebar\{(?P<body>[^}]*)\}', CSS)
+    m = re.search(r"\.app-titlebar\{(?P<body>[^}]*)\}", CSS)
     assert m, ".app-titlebar rule missing from style.css"
     rule = m.group("body")
     assert "padding-top:var(--app-titlebar-safe-top)" in rule, (
@@ -572,9 +695,9 @@ def test_titlebar_safe_area_top_preserved_for_standalone_modes():
         "titlebar top safe-area variable must default to 0px for browser/webview layouts"
     )
     pattern = re.compile(
-        r'@media\s*\(display-mode:\s*standalone\)\s*,\s*'
-        r'\(display-mode:\s*fullscreen\)\s*\{[^}]*'
-        r'--app-titlebar-safe-top:\s*env\(safe-area-inset-top',
+        r"@media\s*\(display-mode:\s*standalone\)\s*,\s*"
+        r"\(display-mode:\s*fullscreen\)\s*\{[^}]*"
+        r"--app-titlebar-safe-top:\s*env\(safe-area-inset-top",
         re.DOTALL,
     )
     assert pattern.search(CSS), (
@@ -590,8 +713,9 @@ def test_composer_touch_target_size():
     """
     # Check that mobile CSS doesn't make the send button smaller than 44×44
     # We check that there's at least a min-height definition for touch targets
-    assert re.search(r'(min-height|height).*44px', CSS), \
+    assert re.search(r"(min-height|height).*44px", CSS), (
         "style.css must define 44px minimum touch targets for mobile (send button, nav buttons)"
+    )
 
 
 def test_mobile_composer_footer_stays_single_row():
@@ -599,64 +723,80 @@ def test_mobile_composer_footer_stays_single_row():
     mobile_css = _composer_phone_media_block()
 
     footer = _declarations(_rule_body(mobile_css, ".composer-footer"))
-    assert footer.get("flex-wrap") == "nowrap", \
+    assert footer.get("flex-wrap") == "nowrap", (
         "mobile composer footer must stay visually single-row"
+    )
 
     left = _declarations(_rule_body(mobile_css, ".composer-left"))
-    assert left.get("flex") != "1 1 100%", \
+    assert left.get("flex") != "1 1 100%", (
         "mobile composer-left controls must not take their own full-width row"
-    assert left.get("width") != "100%", \
+    )
+    assert left.get("width") != "100%", (
         "mobile composer-left controls must not span a separate row"
-    assert left.get("flex-wrap") == "nowrap", \
+    )
+    assert left.get("flex-wrap") == "nowrap", (
         "mobile composer-left controls must remain in one row"
+    )
 
     right = _declarations(_rule_body(mobile_css, ".composer-right"))
-    assert right.get("flex") != "1 1 100%", \
+    assert right.get("flex") != "1 1 100%", (
         "mobile composer-right actions must not take their own full-width row"
-    assert right.get("width") != "100%", \
+    )
+    assert right.get("width") != "100%", (
         "mobile composer-right actions must not span a separate row"
-    assert right.get("justify-content") == "flex-end", \
+    )
+    assert right.get("justify-content") == "flex-end", (
         "mobile composer-right actions must stay end-aligned"
+    )
 
 
 def test_mobile_composer_left_scrolls_horizontally_without_wrapping():
     """If many primary controls are visible, the single control row should scroll."""
     left = _declarations(_rule_body(_composer_phone_media_block(), ".composer-left"))
-    assert left.get("overflow-x") == "auto", \
+    assert left.get("overflow-x") == "auto", (
         "mobile composer-left must allow horizontal overflow in the single row"
-    assert left.get("overflow-y") == "hidden", \
+    )
+    assert left.get("overflow-y") == "hidden", (
         "mobile composer-left must not create a second vertical control row"
-    assert left.get("max-height") == "none", \
+    )
+    assert left.get("max-height") == "none", (
         "mobile composer-left must not preserve the old bounded two-row height"
+    )
 
 
 def test_mobile_composer_left_children_do_not_shrink_into_each_other():
     """Phone composer controls must scroll or compact, never shrink/overlap siblings."""
     mobile_css = _composer_phone_media_block()
     left = _declarations(_rule_body(mobile_css, ".composer-left"))
-    assert left.get("gap") == "10px", \
+    assert left.get("gap") == "10px", (
         "mobile composer-left needs explicit spacing between 44px touch targets"
+    )
 
     children = _declarations(_rule_body(mobile_css, ".composer-left > *"))
-    assert children.get("flex-shrink") == "0", \
+    assert children.get("flex-shrink") == "0", (
         "mobile composer-left children must not shrink and visually overlap"
+    )
 
     for selector in (
         ".composer-profile-wrap",
         ".composer-ws-wrap",
     ):
         declarations = _declarations(_rule_body(mobile_css, selector))
-        assert declarations.get("flex") == "0 0 auto", \
+        assert declarations.get("flex") == "0 0 auto", (
             f"{selector} must opt out of flex shrinking on phones"
+        )
 
     workspace_group = _declarations(_rule_body(mobile_css, ".composer-workspace-group"))
-    assert workspace_group.get("flex") == "0 0 44px", \
+    assert workspace_group.get("flex") == "0 0 44px", (
         ".composer-workspace-group must reserve exactly one 44px slot on phones"
+    )
 
 
 def test_legacy_320px_composer_tightens_spacing_without_shrinking_targets():
     """At 320px, keep 44px controls but use smaller gutters so config stays visible."""
-    narrow_blocks = [block for block in _max_width_media_blocks(340) if ".composer-left" in block]
+    narrow_blocks = [
+        block for block in _max_width_media_blocks(340) if ".composer-left" in block
+    ]
     assert narrow_blocks, "Missing 320px/legacy-phone composer spacing override"
     narrow_css = narrow_blocks[0]
 
@@ -664,74 +804,105 @@ def test_legacy_320px_composer_tightens_spacing_without_shrinking_targets():
     left = _declarations(_rule_body(narrow_css, ".composer-left"))
     wrap = _declarations(_rule_body(narrow_css, ".composer-wrap"))
 
-    assert footer.get("gap") == "4px", \
+    assert footer.get("gap") == "4px", (
         "320px footer should tighten only the gutter between left controls and send"
-    assert left.get("gap") == "2px", \
+    )
+    assert left.get("gap") == "2px", (
         "320px left controls need compact gutters to fit config before the fixed send button"
-    assert wrap.get("padding-left") == "8px!important", \
+    )
+    assert wrap.get("padding-left") == "8px!important", (
         "320px composer should reclaim a little side padding without shrinking touch targets"
-    assert ".send-btn{width:44px;height:44px;" in _composer_phone_media_block(), \
+    )
+    assert ".send-btn{width:44px;height:44px;" in _composer_phone_media_block(), (
         "narrow spacing override must not shrink the 44px send button"
-    assert ".composer-mobile-config-btn{box-sizing:border-box;position:relative;display:inline-flex!important;width:44px;height:44px" in _composer_phone_media_block(), \
-        "narrow spacing override must not shrink the 44px mobile config button"
+    )
+    assert (
+        ".composer-mobile-config-btn{box-sizing:border-box;position:relative;display:inline-flex!important;width:44px;height:44px"
+        in _composer_phone_media_block()
+    ), "narrow spacing override must not shrink the 44px mobile config button"
 
 
 def test_mobile_composer_workspace_switch_does_not_leave_empty_icon_slot():
     """The phone footer should keep only the useful workspace files button inline."""
     mobile_css = _composer_phone_media_block()
     workspace_group = _declarations(_rule_body(mobile_css, ".composer-workspace-group"))
-    workspace_files = _declarations(_rule_body(mobile_css, ".composer-workspace-files-btn"))
+    workspace_files = _declarations(
+        _rule_body(mobile_css, ".composer-workspace-files-btn")
+    )
     workspace_chip = _declarations(_rule_body(mobile_css, ".composer-workspace-chip"))
 
-    assert workspace_group.get("max-width") == "44px", \
+    assert workspace_group.get("max-width") == "44px", (
         "workspace group should collapse to one 44px files button on phones"
-    assert workspace_group.get("width") == "44px", \
+    )
+    assert workspace_group.get("width") == "44px", (
         "workspace group should have an exact border-box phone width"
-    assert workspace_group.get("box-sizing") == "border-box", \
+    )
+    assert workspace_group.get("box-sizing") == "border-box", (
         "workspace group must use border-box for its 44px phone slot"
-    assert workspace_group.get("border") == "none", \
+    )
+    assert workspace_group.get("border") == "none", (
         "workspace files shortcut should not keep the desktop pill/circle border on phones"
-    assert workspace_group.get("background") == "transparent", \
+    )
+    assert workspace_group.get("background") == "transparent", (
         "workspace files shortcut should visually match other transparent mobile icon buttons"
-    assert workspace_files.get("max-width") == "44px", \
+    )
+    assert workspace_files.get("max-width") == "44px", (
         "workspace files button should be the only visible workspace footer target on phones"
-    assert workspace_files.get("width") == "44px", \
+    )
+    assert workspace_files.get("width") == "44px", (
         "workspace files button should have an exact border-box phone width"
-    assert workspace_files.get("box-sizing") == "border-box", \
+    )
+    assert workspace_files.get("box-sizing") == "border-box", (
         "workspace files button must not grow beyond its 44px phone slot due to padding"
-    assert workspace_chip.get("display") == "none!important", \
+    )
+    assert workspace_chip.get("display") == "none!important", (
         "workspace switch chip has no visible mobile label/icon and must not consume a blank slot"
+    )
 
 
 def test_mobile_composer_overflow_control_present():
     """Phone composer must expose a compact overflow/settings control."""
-    assert 'id="composerMobileConfigBtn"' in HTML, \
+    assert 'id="composerMobileConfigBtn"' in HTML, (
         "#composerMobileConfigBtn missing from index.html"
-    assert 'id="composerMobileConfigPanel"' in HTML, \
+    )
+    assert 'id="composerMobileConfigPanel"' in HTML, (
         "#composerMobileConfigPanel missing from index.html"
-    assert 'aria-controls="composerMobileConfigPanel"' in HTML, \
+    )
+    assert 'aria-controls="composerMobileConfigPanel"' in HTML, (
         "mobile config button must be associated with its panel"
+    )
     left_start = HTML.index('<div class="composer-left">')
     left_end = HTML.index('<div class="composer-right">', left_start)
-    assert 'id="composerMobileConfigPanel"' not in HTML[left_start:left_end], \
+    assert 'id="composerMobileConfigPanel"' not in HTML[left_start:left_end], (
         "mobile overflow panel must not be nested inside .composer-left where overflow can clip it"
-    assert "function toggleMobileComposerConfig()" in (REPO / "static" / "ui.js").read_text(encoding="utf-8"), \
+    )
+    assert "function toggleMobileComposerConfig()" in (
+        REPO / "static" / "ui.js"
+    ).read_text(encoding="utf-8"), (
         "toggleMobileComposerConfig() must be defined in static/ui.js"
+    )
 
     mobile_css = _composer_phone_media_block()
     btn = _declarations(_rule_body(mobile_css, ".composer-mobile-config-btn"))
     panel = _declarations(_rule_body(CSS, ".composer-mobile-config-panel"))
-    panel_open = _declarations(_rule_body(mobile_css, ".composer-mobile-config-panel.open"))
-    assert btn.get("display") == "inline-flex!important", \
+    panel_open = _declarations(
+        _rule_body(mobile_css, ".composer-mobile-config-panel.open")
+    )
+    assert btn.get("display") == "inline-flex!important", (
         "mobile overflow button must be visible at phone width"
-    assert panel.get("display") == "none", \
+    )
+    assert panel.get("display") == "none", (
         "mobile overflow panel should be closed by default"
-    assert panel.get("position") == "absolute", \
+    )
+    assert panel.get("position") == "absolute", (
         "mobile overflow panel should open above the composer footer"
-    assert panel.get("flex-wrap") == "wrap", \
+    )
+    assert panel.get("flex-wrap") == "wrap", (
         "mobile overflow panel must allow the context details row to span below primary actions"
-    assert panel_open.get("display") == "flex", \
+    )
+    assert panel_open.get("display") == "flex", (
         "mobile overflow panel must become visible when opened"
+    )
 
 
 def test_model_and_reasoning_controls_live_in_mobile_overflow_panel():
@@ -739,31 +910,42 @@ def test_model_and_reasoning_controls_live_in_mobile_overflow_panel():
     panel_start = HTML.index('id="composerMobileConfigPanel"')
     panel_end = HTML.index('<div class="profile-dropdown"', panel_start)
     panel_html = HTML[panel_start:panel_end]
-    assert 'id="composerMobileModelAction"' in panel_html, \
+    assert 'id="composerMobileModelAction"' in panel_html, (
         "mobile model action must be inside the overflow panel"
-    assert 'id="composerMobileReasoningAction"' in panel_html, \
+    )
+    assert 'id="composerMobileReasoningAction"' in panel_html, (
         "mobile reasoning action must be inside the overflow panel"
-    assert 'onclick="toggleModelDropdown()"' in panel_html, \
+    )
+    assert 'onclick="toggleModelDropdown()"' in panel_html, (
         "mobile model action must reuse the existing model dropdown"
-    assert 'onclick="toggleReasoningDropdown()"' in panel_html, \
+    )
+    assert 'onclick="toggleReasoningDropdown()"' in panel_html, (
         "mobile reasoning action must reuse the existing reasoning dropdown"
-    assert 'id="composerMobileModelLabel"' in panel_html, \
+    )
+    assert 'id="composerMobileModelLabel"' in panel_html, (
         "mobile model action must expose the selected model label"
-    assert 'id="composerMobileReasoningLabel"' in panel_html, \
+    )
+    assert 'id="composerMobileReasoningLabel"' in panel_html, (
         "mobile reasoning action must expose the selected reasoning label"
+    )
     ui_js = (REPO / "static" / "ui.js").read_text(encoding="utf-8")
-    assert "composerMobileModelAction" in ui_js, \
+    assert "composerMobileModelAction" in ui_js, (
         "model dropdown positioning/click handling must know the mobile model action"
-    assert "composerMobileReasoningAction" in ui_js, \
+    )
+    assert "composerMobileReasoningAction" in ui_js, (
         "reasoning dropdown positioning/click handling must know the mobile reasoning action"
+    )
 
     mobile_css = _composer_phone_media_block()
-    assert ".composer-left > .composer-model-wrap" in mobile_css, \
+    assert ".composer-left > .composer-model-wrap" in mobile_css, (
         "phone width must hide the footer model chip behind overflow"
-    assert ".composer-left > .composer-reasoning-wrap" in mobile_css, \
+    )
+    assert ".composer-left > .composer-reasoning-wrap" in mobile_css, (
         "phone width must hide the footer reasoning chip behind overflow"
-    assert ".composer-mobile-config-action" in mobile_css, \
+    )
+    assert ".composer-mobile-config-action" in mobile_css, (
         "mobile overflow panel must size the model/reasoning actions"
+    )
 
 
 def test_model_and_reasoning_dropdowns_use_mobile_panel_anchors():
@@ -777,8 +959,9 @@ def test_model_and_reasoning_dropdowns_use_mobile_panel_anchors():
         "composerMobileModelAction",
         "classList.contains('open')",
     ):
-        assert expected in model_body, \
+        assert expected in model_body, (
             f"_positionModelDropdown must keep mobile-panel anchor logic ({expected})"
+        )
 
     reasoning_start = ui_js.index("function _positionReasoningDropdown()")
     reasoning_end = ui_js.index("function closeReasoningDropdown()", reasoning_start)
@@ -788,8 +971,9 @@ def test_model_and_reasoning_dropdowns_use_mobile_panel_anchors():
         "composerMobileReasoningAction",
         "classList.contains('open')",
     ):
-        assert expected in reasoning_body, \
+        assert expected in reasoning_body, (
             f"_positionReasoningDropdown must keep mobile-panel anchor logic ({expected})"
+        )
 
 
 def test_context_details_live_in_mobile_overflow_panel():
@@ -805,16 +989,21 @@ def test_context_details_live_in_mobile_overflow_panel():
         "composerMobileContextCost",
         "composerMobileCtxCompressBtn",
     ):
-        assert f'id="{element_id}"' in panel_html, \
+        assert f'id="{element_id}"' in panel_html, (
             f"#{element_id} must be inside the mobile overflow panel"
+        )
 
-    right_start = HTML.index('<div class="composer-right">', HTML.index('<div class="composer-footer">'))
+    right_start = HTML.index(
+        '<div class="composer-right">', HTML.index('<div class="composer-footer">')
+    )
     right_end = HTML.index('<div class="composer-mobile-config-panel"', right_start)
     right_html = HTML[right_start:right_end]
-    assert 'id="composerMobileContextAction"' not in right_html, \
+    assert 'id="composerMobileContextAction"' not in right_html, (
         "mobile context details must not live in composer-right as another phone slot"
-    assert 'id="composerMobileCtxBadge"' not in right_html, \
+    )
+    assert 'id="composerMobileCtxBadge"' not in right_html, (
         "mobile context badge must stay on the config button, not composer-right"
+    )
 
     ui_js = (REPO / "static" / "ui.js").read_text(encoding="utf-8")
     sync_start = ui_js.index("function _syncMobileCtxDisplay(state)")
@@ -830,20 +1019,24 @@ def test_context_details_live_in_mobile_overflow_panel():
         "composerMobileContextTokens",
         "composerMobileCtxCompressBtn",
     ):
-        assert expected in sync_body, \
+        assert expected in sync_body, (
             f"_syncCtxIndicator must preserve upstream context logic while updating mobile context UI ({expected})"
+        )
 
     mobile_css = _composer_phone_media_block()
     ctx_wrap = _declarations(_rule_body(mobile_css, ".ctx-indicator-wrap"))
-    assert ctx_wrap.get("display") == "none!important", \
+    assert ctx_wrap.get("display") == "none!important", (
         "standalone context indicator must remain hidden from the phone composer row"
+    )
 
     context_row = _declarations(_rule_body(CSS, ".composer-mobile-context-action"))
-    assert context_row.get("flex") == "1 0 100%", \
+    assert context_row.get("flex") == "1 0 100%", (
         "mobile context details should span the overflow panel instead of crowding the action row"
+    )
     context_button = _declarations(_rule_body(CSS, ".composer-mobile-context-compress"))
-    assert context_button.get("width") == "auto", \
+    assert context_button.get("width") == "auto", (
         "mobile compress affordance should be compact inside the context row"
+    )
 
 
 def test_workspace_control_lives_in_mobile_overflow_panel():
@@ -851,62 +1044,79 @@ def test_workspace_control_lives_in_mobile_overflow_panel():
     panel_start = HTML.index('id="composerMobileConfigPanel"')
     panel_end = HTML.index('<div class="profile-dropdown"', panel_start)
     panel_html = HTML[panel_start:panel_end]
-    assert 'id="composerMobileWorkspaceAction"' in panel_html, \
+    assert 'id="composerMobileWorkspaceAction"' in panel_html, (
         "mobile workspace action must be inside the overflow panel"
-    assert 'onclick="toggleComposerWsDropdown()"' in panel_html, \
+    )
+    assert 'onclick="toggleComposerWsDropdown()"' in panel_html, (
         "mobile workspace action must reuse the existing workspace dropdown"
-    assert 'id="composerMobileWorkspaceLabel"' in panel_html, \
+    )
+    assert 'id="composerMobileWorkspaceLabel"' in panel_html, (
         "mobile workspace action must expose the current workspace label"
+    )
 
     mobile_css = _composer_phone_media_block()
     workspace_chip = _declarations(_rule_body(mobile_css, ".composer-workspace-chip"))
-    assert workspace_chip.get("display") == "none!important", \
+    assert workspace_chip.get("display") == "none!important", (
         "inline workspace switch chip must remain hidden on phones"
+    )
 
     panels_js = (REPO / "static" / "panels.js").read_text(encoding="utf-8")
     pos_start = panels_js.index("function _positionComposerWsDropdown()")
     pos_end = panels_js.index("function _positionProfileDropdown()", pos_start)
     position_body = panels_js[pos_start:pos_end]
-    assert "composerMobileWorkspaceAction" in position_body, \
+    assert "composerMobileWorkspaceAction" in position_body, (
         "workspace dropdown positioning must know the mobile workspace action"
-    assert "composerMobileConfigPanel" in position_body, \
+    )
+    assert "composerMobileConfigPanel" in position_body, (
         "workspace dropdown positioning must anchor to the mobile panel action while open"
-    assert "anchor to #composerMobileWorkspaceAction" in position_body, \
+    )
+    assert "anchor to #composerMobileWorkspaceAction" in position_body, (
         "workspace dropdown positioning should document the mobile-panel anchor choice"
+    )
 
     toggle_start = panels_js.index("function toggleComposerWsDropdown()")
     toggle_end = panels_js.index("function closeWsDropdown()", toggle_start)
     toggle_body = panels_js[toggle_start:toggle_end]
-    assert "usingMobileAction" in toggle_body and "chip.disabled" in toggle_body, \
+    assert "usingMobileAction" in toggle_body and "chip.disabled" in toggle_body, (
         "mobile workspace action must bypass only the hidden/disabled desktop chip guard"
-    assert "!e.target.closest('#composerMobileWorkspaceAction')" in panels_js, \
+    )
+    assert "!e.target.closest('#composerMobileWorkspaceAction')" in panels_js, (
         "workspace dropdown click-away handling must include the mobile workspace action"
+    )
 
     ui_js = (REPO / "static" / "ui.js").read_text(encoding="utf-8")
-    assert "e.target.closest('#composerWsDropdown')" in ui_js, \
+    assert "e.target.closest('#composerWsDropdown')" in ui_js, (
         "mobile overflow click-away handling must allow interaction with the workspace dropdown"
+    )
 
 
 def test_mobile_config_panel_escape_closes_panel_and_dropdowns():
     """Escape should close mobile overflow state without touching desktop-only dropdowns."""
     ui_js = (REPO / "static" / "ui.js").read_text(encoding="utf-8")
-    keydown_start = ui_js.index("document.addEventListener('keydown',function(e){", ui_js.index("function toggleMobileComposerConfig()"))
+    keydown_start = ui_js.index(
+        "document.addEventListener('keydown',function(e){",
+        ui_js.index("function toggleMobileComposerConfig()"),
+    )
     keydown_end = ui_js.index("\n});", keydown_start)
     keydown_body = ui_js[keydown_start:keydown_end]
-    assert "e.key!=='Escape'" in keydown_body, \
+    assert "e.key!=='Escape'" in keydown_body, (
         "mobile config Escape handler must only handle Escape"
-    assert "composerMobileConfigPanel" in keydown_body, \
+    )
+    assert "composerMobileConfigPanel" in keydown_body, (
         "mobile config Escape handler must look up the mobile config panel"
-    assert "classList.contains('open')" in keydown_body, \
+    )
+    assert "classList.contains('open')" in keydown_body, (
         "mobile config Escape handler must be gated on the open mobile panel"
+    )
     for expected in (
         "closeMobileComposerConfig()",
         "closeWsDropdown",
         "closeModelDropdown()",
         "closeReasoningDropdown()",
     ):
-        assert expected in keydown_body, \
+        assert expected in keydown_body, (
             f"mobile config Escape handler must close related state ({expected})"
+        )
 
 
 def test_reasoning_chip_updates_desktop_and_mobile_controls():
@@ -923,8 +1133,9 @@ def test_reasoning_chip_updates_desktop_and_mobile_controls():
         "label.textContent=text",
         "mobileLabel.textContent=text",
     ):
-        assert expected in chip_body, \
+        assert expected in chip_body, (
             f"_applyReasoningChip must update desktop and mobile reasoning UI ({expected})"
+        )
 
 
 def test_mobile_config_kickers_have_i18n_fallbacks():
@@ -942,10 +1153,10 @@ def test_mobile_config_kickers_have_i18n_fallbacks():
         ("composer_mobile_reasoning", "Reasoning"),
         ("composer_mobile_context", "Context"),
     ):
-        assert f'data-i18n="{key}">{label}</span>' in panel_html, \
+        assert f'data-i18n="{key}">{label}</span>' in panel_html, (
             f"mobile panel kicker {label} must keep data-i18n and fallback text"
-        assert f"{key}: '{label}'" in english, \
-            f"English locale must define {key}"
+        )
+        assert f"{key}: '{label}'" in english, f"English locale must define {key}"
 
 
 def test_mobile_composer_primary_controls_keep_touch_friendly_sizing():
@@ -957,46 +1168,62 @@ def test_mobile_composer_primary_controls_keep_touch_friendly_sizing():
         ".composer-mobile-config-action",
     ):
         declarations = _declarations(_rule_body(mobile_css, selector))
-        assert declarations.get("box-sizing") == "border-box", \
+        assert declarations.get("box-sizing") == "border-box", (
             f"{selector} must use border-box so padding/border cannot exceed 44px"
-        assert declarations.get("min-height") == "44px", \
+        )
+        assert declarations.get("min-height") == "44px", (
             f"{selector} must keep a 44px minimum height on phones"
+        )
         if selector != ".composer-mobile-config-action":
-            assert declarations.get("min-width") == "44px", \
+            assert declarations.get("min-width") == "44px", (
                 f"{selector} must keep a 44px minimum width on phones"
+            )
 
     send = _declarations(_rule_body(mobile_css, ".send-btn"))
     assert send.get("width") == "44px", ".send-btn must keep 44px width on phones"
     assert send.get("height") == "44px", ".send-btn must keep 44px height on phones"
 
     ctx_wrap = _declarations(_rule_body(mobile_css, ".ctx-indicator-wrap"))
-    assert ctx_wrap.get("display") == "none!important", \
+    assert ctx_wrap.get("display") == "none!important", (
         "context indicator must not add a late-appearing composer-right slot on phones"
+    )
 
     ctx_badge = _declarations(_rule_body(CSS, ".composer-mobile-ctx-badge"))
-    assert ctx_badge.get("position") == "absolute", \
+    assert ctx_badge.get("position") == "absolute", (
         "mobile context usage should be shown as a badge on the config button, not a separate slot"
-    assert ctx_badge.get("pointer-events") == "none", \
+    )
+    assert ctx_badge.get("pointer-events") == "none", (
         "mobile context badge must not shrink or steal the config button touch target"
-    assert 'id="composerMobileCtxBadge"' in HTML, \
+    )
+    assert 'id="composerMobileCtxBadge"' in HTML, (
         "mobile context badge element must exist in the composer config button"
+    )
 
     icon_btn = _declarations(_rule_body(mobile_css, ".icon-btn"))
-    assert icon_btn.get("min-width") == "44px", \
+    assert icon_btn.get("min-width") == "44px", (
         ".icon-btn controls such as attach/mic must keep 44px minimum width on phones"
-    assert icon_btn.get("min-height") == "44px", \
+    )
+    assert icon_btn.get("min-height") == "44px", (
         ".icon-btn controls such as attach/mic must keep 44px minimum height on phones"
+    )
 
     if ".composer-workspace-files-btn" in mobile_css:
-        files_btn = _declarations(_rule_body(mobile_css, ".composer-workspace-files-btn"))
-        workspace_group = _declarations(_rule_body(mobile_css, ".composer-workspace-group"))
-        assert files_btn.get("min-width") == "44px", \
+        files_btn = _declarations(
+            _rule_body(mobile_css, ".composer-workspace-files-btn")
+        )
+        workspace_group = _declarations(
+            _rule_body(mobile_css, ".composer-workspace-group")
+        )
+        assert files_btn.get("min-width") == "44px", (
             ".composer-workspace-files-btn must keep a 44px minimum width on phones"
-        assert workspace_group.get("min-height") == "44px", \
+        )
+        assert workspace_group.get("min-height") == "44px", (
             ".composer-workspace-group must preserve 44px touch height on phones"
+        )
 
 
 # ── Input zoom prevention ─────────────────────────────────────────────────────
+
 
 def test_composer_textarea_font_size_mobile():
     """Composer textarea must have font-size >= 16px on mobile.
@@ -1005,8 +1232,9 @@ def test_composer_textarea_font_size_mobile():
     which breaks the layout. The composer textarea must be >= 16px at mobile widths.
     """
     # Check for 16px font-size on the textarea in a mobile breakpoint
-    assert re.search(r'font-size:16px', CSS), \
+    assert re.search(r"font-size:16px", CSS), (
         "Composer textarea must have font-size:16px at mobile widths to prevent iOS zoom-on-focus"
+    )
 
 
 def test_touch_device_inputs_meet_zoom_threshold():
@@ -1021,9 +1249,9 @@ def test_touch_device_inputs_meet_zoom_threshold():
     # detection (won't match desktop with mouse, won't match touch laptops
     # that report hover:hover).
     pattern = re.compile(
-        r'@media\s*\(hover:none\)\s*and\s*\(pointer:coarse\)\s*\{[^}]*'
-        r'input\s*,\s*textarea\s*,\s*select\s*\{[^}]*'
-        r'font-size:\s*max\(\s*16px',
+        r"@media\s*\(hover:none\)\s*and\s*\(pointer:coarse\)\s*\{[^}]*"
+        r"input\s*,\s*textarea\s*,\s*select\s*\{[^}]*"
+        r"font-size:\s*max\(\s*16px",
         re.DOTALL,
     )
     assert pattern.search(CSS), (
@@ -1033,54 +1261,64 @@ def test_touch_device_inputs_meet_zoom_threshold():
     )
 
 
-
 # ── Sidebar tabs on mobile ───────────────────────────────────────────────────
+
 
 def test_profiles_sidebar_tab_present():
     """Sidebar tab strip must include Profiles."""
     # Tolerate additional utility classes (e.g. `has-tooltip` from #1775).
     # We just need a nav-tab classed button targeting the profiles panel.
     import re
+
     pattern = r'class="[^"]*\bnav-tab\b[^"]*"[^>]*data-panel="profiles"'
-    assert re.search(pattern, HTML), \
-        "Sidebar nav must have a nav-tab button with data-panel=\"profiles\""
+    assert re.search(pattern, HTML), (
+        'Sidebar nav must have a nav-tab button with data-panel="profiles"'
+    )
 
 
 def test_mobile_bottom_nav_removed():
     """The old fixed mobile bottom nav should not be present anymore."""
-    assert "mobile-bottom-nav" not in HTML, \
+    assert "mobile-bottom-nav" not in HTML, (
         "mobile-bottom-nav markup should be removed from index.html"
-    assert "mobile-bottom-nav" not in CSS, \
+    )
+    assert "mobile-bottom-nav" not in CSS, (
         "mobile-bottom-nav CSS should be removed from style.css"
+    )
 
 
 # ── Mobile Enter key inserts newline (PR #315, fixes #269) ───────────────────
 
+
 def test_mobile_enter_newline_condition_present():
     """boot.js keydown handler must detect touch-primary devices via pointer:coarse."""
     boot_js = (REPO / "static" / "boot.js").read_text(encoding="utf-8")
-    assert "pointer:coarse" in boot_js, \
+    assert "pointer:coarse" in boot_js, (
         "boot.js must use pointer:coarse media query for mobile Enter detection"
+    )
 
 
 def test_mobile_enter_newline_uses_match_media():
     """boot.js must call matchMedia for pointer detection, not a hardcoded flag."""
     boot_js = (REPO / "static" / "boot.js").read_text(encoding="utf-8")
-    assert "matchMedia('(pointer:coarse)')" in boot_js or 'matchMedia("(pointer:coarse)")' in boot_js, \
-        "boot.js must use matchMedia('(pointer:coarse)') for mobile detection"
+    assert (
+        "matchMedia('(pointer:coarse)')" in boot_js
+        or 'matchMedia("(pointer:coarse)")' in boot_js
+    ), "boot.js must use matchMedia('(pointer:coarse)') for mobile detection"
 
 
 def test_mobile_enter_newline_only_overrides_enter_default():
     """Mobile newline override must only apply when _sendKey is the default 'enter'."""
     boot_js = (REPO / "static" / "boot.js").read_text(encoding="utf-8")
     # The _mobileDefault check must gate on _sendKey==='enter' so ctrl+enter users aren't affected
-    assert "_sendKey===" in boot_js and "'enter'" in boot_js, \
+    assert "_sendKey===" in boot_js and "'enter'" in boot_js, (
         "Mobile newline fallback must check window._sendKey==='enter' to avoid overriding user preference"
+    )
 
 
 def test_mobile_enter_does_not_affect_desktop_logic():
     """The mobile Enter override must not alter the existing else branch for desktop users."""
     boot_js = (REPO / "static" / "boot.js").read_text(encoding="utf-8")
     # The else branch (desktop, sends on Enter without Shift) must still be present
-    assert "if(!e.shiftKey){e.preventDefault();send();" in boot_js, \
+    assert "if(!e.shiftKey){e.preventDefault();send();" in boot_js, (
         "Desktop Enter-to-send logic (else branch) must still be present in boot.js"
+    )

--- a/tests/test_model_cache_metadata.py
+++ b/tests/test_model_cache_metadata.py
@@ -43,6 +43,7 @@ def test_save_models_cache_to_disk_preserves_response_metadata(tmp_path, monkeyp
     # _webui_version may be absent in early-init paths where api.updates isn't
     # yet imported; in normal test runs api.updates IS imported, so assert it.
     import sys
+
     if "api.updates" in sys.modules:
         assert on_disk.get("_webui_version") == sys.modules["api.updates"].WEBUI_VERSION
 
@@ -51,7 +52,9 @@ def test_save_models_cache_to_disk_preserves_response_metadata(tmp_path, monkeyp
     assert loaded == payload
 
 
-def test_load_models_cache_from_disk_rejects_legacy_groups_only_cache(tmp_path, monkeypatch):
+def test_load_models_cache_from_disk_rejects_legacy_groups_only_cache(
+    tmp_path, monkeypatch
+):
     cache_path = tmp_path / "models_cache.json"
     monkeypatch.setattr(config, "_models_cache_path", cache_path)
     cache_path.write_text(
@@ -93,10 +96,18 @@ def test_load_models_cache_from_disk_rejects_partial_metadata_cache(
     }
 
     invalid_payloads = [
-        {key: value for key, value in valid_payload.items() if key != "active_provider"},
+        {
+            key: value
+            for key, value in valid_payload.items()
+            if key != "active_provider"
+        },
         {key: value for key, value in valid_payload.items() if key != "default_model"},
         {key: value for key, value in valid_payload.items() if key != "groups"},
-        {key: value for key, value in valid_payload.items() if key != "configured_model_badges"},
+        {
+            key: value
+            for key, value in valid_payload.items()
+            if key != "configured_model_badges"
+        },
         {**valid_payload, "active_provider": 123},
         {**valid_payload, "default_model": None},
         {**valid_payload, "groups": {}},

--- a/tests/test_model_picker_badges.py
+++ b/tests/test_model_picker_badges.py
@@ -3,7 +3,9 @@ from pathlib import Path
 from api import config
 
 
-def _models_with_cfg(model_cfg=None, fallback_providers=None, custom_providers=None, active_provider=None):
+def _models_with_cfg(
+    model_cfg=None, fallback_providers=None, custom_providers=None, active_provider=None
+):
     old_cfg = config.cfg
     old_mtime = config._cfg_mtime
     old_cache = config._available_models_cache
@@ -56,8 +58,12 @@ def test_duplicate_slash_id_primary_badge_sticks_to_matching_provider_only():
 
     root = Path(__file__).resolve().parent.parent
     src = (root / "api" / "config.py").read_text(encoding="utf-8")
-    start = src.index("def _build_configured_model_badges() -> dict[str, dict[str, str]]:")
-    end = src.index("            return badges", start) + len("            return badges")
+    start = src.index(
+        "def _build_configured_model_badges() -> dict[str, dict[str, str]]:"
+    )
+    end = src.index("            return badges", start) + len(
+        "            return badges"
+    )
     fn_src = textwrap.dedent(src[start:end])
 
     scope = {
@@ -65,8 +71,16 @@ def test_duplicate_slash_id_primary_badge_sticks_to_matching_provider_only():
         "default_model": "google/gemma-4-27b",
         "cfg": {"fallback_providers": []},
         "groups": [
-            {"provider": "Alpha", "provider_id": "custom:alpha", "models": [{"id": "google/gemma-4-27b"}]},
-            {"provider": "Beta", "provider_id": "custom:beta", "models": [{"id": "@custom:beta:google/gemma-4-27b"}]},
+            {
+                "provider": "Alpha",
+                "provider_id": "custom:alpha",
+                "models": [{"id": "google/gemma-4-27b"}],
+            },
+            {
+                "provider": "Beta",
+                "provider_id": "custom:beta",
+                "models": [{"id": "@custom:beta:google/gemma-4-27b"}],
+            },
         ],
         "_resolve_provider_alias": lambda provider: provider,
     }
@@ -94,7 +108,10 @@ def test_ui_badge_lookup_prefers_row_provider_for_duplicate_model_ids():
 
     assert "function _getConfiguredModelBadge(modelId,badgeMap,providerId){" in js
     assert "child.dataset&&child.dataset.provider?child.dataset.provider:''" in js
-    assert "const providerMatch=matches.find(badge=>String(badge&&badge.provider||'').toLowerCase()===provider);" in js
+    assert (
+        "const providerMatch=matches.find(badge=>String(badge&&badge.provider||'').toLowerCase()===provider);"
+        in js
+    )
 
 
 def test_configured_model_group_label_has_i18n_key():
@@ -110,7 +127,9 @@ def test_configured_model_group_label_has_i18n_key():
     )
 
 
-def test_get_available_models_cache_preserves_configured_model_badges(tmp_path, monkeypatch):
+def test_get_available_models_cache_preserves_configured_model_badges(
+    tmp_path, monkeypatch
+):
     cache_path = tmp_path / "models_cache.json"
     old_cfg = config.cfg
     old_mtime = config._cfg_mtime
@@ -129,7 +148,12 @@ def test_get_available_models_cache_preserves_configured_model_badges(tmp_path, 
         }
 
         cold = config.get_available_models()
-        assert cold.get("configured_model_badges", {}).get("@copilot:gpt-4.1", {}).get("label") == "Fallback 1"
+        assert (
+            cold.get("configured_model_badges", {})
+            .get("@copilot:gpt-4.1", {})
+            .get("label")
+            == "Fallback 1"
+        )
 
         config._available_models_cache = None
         config._available_models_cache_ts = 0.0
@@ -139,14 +163,16 @@ def test_get_available_models_cache_preserves_configured_model_badges(tmp_path, 
             "O cache persistido de /api/models não pode descartar configured_model_badges, "
             "senão o deploy/servidor reiniciado perde as TAGS do dropdown mesmo com o código novo."
         )
-        assert warm["configured_model_badges"].get("@copilot:gpt-4.1", {}).get("label") == "Fallback 1"
+        assert (
+            warm["configured_model_badges"].get("@copilot:gpt-4.1", {}).get("label")
+            == "Fallback 1"
+        )
     finally:
         config.cfg = old_cfg
         config._cfg_mtime = old_mtime
         config._available_models_cache = old_cache
         config._available_models_cache_ts = old_cache_ts
         monkeypatch.setattr(config, "_models_cache_path", old_cache_path)
-
 
 
 def test_ui_renders_model_badges_from_api_payload():
@@ -175,7 +201,10 @@ def test_ui_renders_model_badges_from_api_payload():
         "A UI deve calcular uma prioridade estável (primary -> fallback 1 -> fallback N) "
         "para renderizar os modelos configurados no topo do dropdown."
     )
-    assert "Object.entries(_badgeMap)" in js and "_normalizeConfiguredModelKey(existing.value)" in js, (
+    assert (
+        "Object.entries(_badgeMap)" in js
+        and "_normalizeConfiguredModelKey(existing.value)" in js
+    ), (
         "renderModelDropdown() deve sintetizar entradas para modelos configurados ausentes "
         "do catálogo atual, senão fallbacks locais/Ollama desaparecem da seção Configured."
     )

--- a/tests/test_model_resolver.py
+++ b/tests/test_model_resolver.py
@@ -3,23 +3,26 @@ Tests for resolve_model_provider() model routing logic.
 Verifies that model IDs are correctly resolved to (model, provider, base_url)
 tuples for different provider configurations.
 """
+
 import pytest
 import api.config as config
 
 
-def _resolve_with_config(model_id, provider=None, base_url=None, default=None, custom_providers=None):
+def _resolve_with_config(
+    model_id, provider=None, base_url=None, default=None, custom_providers=None
+):
     """Helper: temporarily set config.cfg model/custom provider sections, call resolve, restore."""
     old_cfg = dict(config.cfg)
     model_cfg = {}
     if provider:
-        model_cfg['provider'] = provider
+        model_cfg["provider"] = provider
     if base_url:
-        model_cfg['base_url'] = base_url
+        model_cfg["base_url"] = base_url
     if default:
-        model_cfg['default'] = default
-    config.cfg['model'] = model_cfg if model_cfg else {}
+        model_cfg["default"] = default
+    config.cfg["model"] = model_cfg if model_cfg else {}
     if custom_providers is not None:
-        config.cfg['custom_providers'] = custom_providers
+        config.cfg["custom_providers"] = custom_providers
     try:
         return config.resolve_model_provider(model_id)
     finally:
@@ -29,154 +32,174 @@ def _resolve_with_config(model_id, provider=None, base_url=None, default=None, c
 
 # ── OpenRouter prefix handling ────────────────────────────────────────────
 
+
 def test_openrouter_free_keeps_full_path():
     """openrouter/free must NOT be stripped to 'free' when provider is openrouter."""
     model, provider, base_url = _resolve_with_config(
-        'openrouter/free', provider='openrouter',
-        base_url='https://openrouter.ai/api/v1',
+        "openrouter/free",
+        provider="openrouter",
+        base_url="https://openrouter.ai/api/v1",
     )
-    assert model == 'openrouter/free', f"Expected 'openrouter/free', got '{model}'"
-    assert provider == 'openrouter'
+    assert model == "openrouter/free", f"Expected 'openrouter/free', got '{model}'"
+    assert provider == "openrouter"
 
 
 def test_openrouter_model_with_provider_prefix():
     """anthropic/claude-sonnet-4.6 via openrouter keeps full path."""
     model, provider, base_url = _resolve_with_config(
-        'anthropic/claude-sonnet-4.6', provider='openrouter',
-        base_url='https://openrouter.ai/api/v1',
+        "anthropic/claude-sonnet-4.6",
+        provider="openrouter",
+        base_url="https://openrouter.ai/api/v1",
     )
-    assert model == 'anthropic/claude-sonnet-4.6'
-    assert provider == 'openrouter'
+    assert model == "anthropic/claude-sonnet-4.6"
+    assert provider == "openrouter"
 
 
 # ── Direct provider prefix stripping ─────────────────────────────────────
 
+
 def test_anthropic_prefix_stripped_for_direct_api():
     """anthropic/claude-sonnet-4.6 strips prefix when provider is anthropic."""
     model, provider, base_url = _resolve_with_config(
-        'anthropic/claude-sonnet-4.6', provider='anthropic',
+        "anthropic/claude-sonnet-4.6",
+        provider="anthropic",
     )
-    assert model == 'claude-sonnet-4.6'
-    assert provider == 'anthropic'
+    assert model == "claude-sonnet-4.6"
+    assert provider == "anthropic"
 
 
 def test_openai_prefix_stripped_for_direct_api():
     """openai/gpt-5.4-mini strips prefix when provider is openai."""
     model, provider, base_url = _resolve_with_config(
-        'openai/gpt-5.4-mini', provider='openai',
+        "openai/gpt-5.4-mini",
+        provider="openai",
     )
-    assert model == 'gpt-5.4-mini'
-    assert provider == 'openai'
+    assert model == "gpt-5.4-mini"
+    assert provider == "openai"
 
 
 # ── Cross-provider routing ───────────────────────────────────────────────
 
+
 def test_cross_provider_routes_through_openrouter():
     """Picking openai model when config is anthropic routes via openrouter."""
     model, provider, base_url = _resolve_with_config(
-        'openai/gpt-5.4-mini', provider='anthropic',
+        "openai/gpt-5.4-mini",
+        provider="anthropic",
     )
-    assert model == 'openai/gpt-5.4-mini'
-    assert provider == 'openrouter'
+    assert model == "openai/gpt-5.4-mini"
+    assert provider == "openrouter"
     assert base_url is None  # openrouter uses its own endpoint
 
 
 # ── Bare model names ─────────────────────────────────────────────────────
 
+
 def test_bare_model_uses_config_provider():
     """A model name without / uses the config provider and base_url."""
     model, provider, base_url = _resolve_with_config(
-        'gemma-4-26B', provider='custom',
-        base_url='http://192.168.1.160:4000',
+        "gemma-4-26B",
+        provider="custom",
+        base_url="http://192.168.1.160:4000",
     )
-    assert model == 'gemma-4-26B'
-    assert provider == 'custom'
-    assert base_url == 'http://192.168.1.160:4000'
+    assert model == "gemma-4-26B"
+    assert provider == "custom"
+    assert base_url == "http://192.168.1.160:4000"
 
 
 def test_empty_model_returns_config_defaults():
     """Empty model string returns config provider and base_url."""
     model, provider, base_url = _resolve_with_config(
-        '', provider='anthropic',
+        "",
+        provider="anthropic",
     )
-    assert model == ''
-    assert provider == 'anthropic'
+    assert model == ""
+    assert provider == "anthropic"
 
 
 # ── @provider:model hint routing (Issue #138 v2) ────────────────────────
 
+
 def test_provider_hint_routes_to_specific_provider():
     """@minimax:MiniMax-M2.7 routes to minimax provider directly."""
     model, provider, base_url = _resolve_with_config(
-        '@minimax:MiniMax-M2.7', provider='anthropic',
+        "@minimax:MiniMax-M2.7",
+        provider="anthropic",
     )
-    assert model == 'MiniMax-M2.7'
-    assert provider == 'minimax'
+    assert model == "MiniMax-M2.7"
+    assert provider == "minimax"
     assert base_url is None  # resolve_runtime_provider will fill this
 
 
 def test_provider_hint_zai():
     """@zai:GLM-5 routes to zai provider directly."""
     model, provider, base_url = _resolve_with_config(
-        '@zai:GLM-5', provider='openai',
+        "@zai:GLM-5",
+        provider="openai",
     )
-    assert model == 'GLM-5'
-    assert provider == 'zai'
+    assert model == "GLM-5"
+    assert provider == "zai"
 
 
 def test_provider_hint_deepseek():
     """@deepseek:deepseek-chat routes to deepseek provider."""
     model, provider, base_url = _resolve_with_config(
-        '@deepseek:deepseek-chat', provider='anthropic',
+        "@deepseek:deepseek-chat",
+        provider="anthropic",
     )
-    assert model == 'deepseek-chat'
-    assert provider == 'deepseek'
+    assert model == "deepseek-chat"
+    assert provider == "deepseek"
 
 
 def test_slash_prefix_non_default_still_routes_openrouter():
     """minimax/MiniMax-M2.7 (old format) still routes through openrouter."""
     model, provider, base_url = _resolve_with_config(
-        'minimax/MiniMax-M2.7', provider='anthropic',
+        "minimax/MiniMax-M2.7",
+        provider="anthropic",
     )
-    assert model == 'minimax/MiniMax-M2.7'
-    assert provider == 'openrouter'
+    assert model == "minimax/MiniMax-M2.7"
+    assert provider == "openrouter"
 
 
 def test_custom_provider_model_with_slash_routes_to_named_custom_provider():
     """Slash-containing custom endpoint model IDs must not be mistaken for OpenRouter models."""
     model, provider, base_url = _resolve_with_config(
-        'google/gemma-4-26b-a4b',
-        provider='openrouter',
-        base_url='https://openrouter.ai/api/v1',
-        custom_providers=[{
-            'name': 'Local LM Studio',
-            'base_url': 'http://lmstudio.local:1234/v1',
-            'model': 'google/gemma-4-26b-a4b',
-        }],
+        "google/gemma-4-26b-a4b",
+        provider="openrouter",
+        base_url="https://openrouter.ai/api/v1",
+        custom_providers=[
+            {
+                "name": "Local LM Studio",
+                "base_url": "http://lmstudio.local:1234/v1",
+                "model": "google/gemma-4-26b-a4b",
+            }
+        ],
     )
-    assert model == 'google/gemma-4-26b-a4b'
-    assert provider == 'custom:local-lm-studio'
-    assert base_url == 'http://lmstudio.local:1234/v1'
+    assert model == "google/gemma-4-26b-a4b"
+    assert provider == "custom:local-lm-studio"
+    assert base_url == "http://lmstudio.local:1234/v1"
 
 
 def test_custom_provider_models_dict_routes_to_named_custom_provider():
     """Models listed only under custom_providers[].models still route to that endpoint."""
     model, provider, base_url = _resolve_with_config(
-        'sensenova-6.7-flash-lite',
-        provider='xiaomi',
-        custom_providers=[{
-            'name': 'LiteLLM Proxy',
-            'base_url': 'http://127.0.0.1:8080/v1',
-            'model': 'deepseek-v4-flash',
-            'models': {
-                'deepseek-v4-flash': {},
-                'sensenova-6.7-flash-lite': {},
-            },
-        }],
+        "sensenova-6.7-flash-lite",
+        provider="xiaomi",
+        custom_providers=[
+            {
+                "name": "LiteLLM Proxy",
+                "base_url": "http://127.0.0.1:8080/v1",
+                "model": "deepseek-v4-flash",
+                "models": {
+                    "deepseek-v4-flash": {},
+                    "sensenova-6.7-flash-lite": {},
+                },
+            }
+        ],
     )
-    assert model == 'sensenova-6.7-flash-lite'
-    assert provider == 'custom:litellm-proxy'
-    assert base_url == 'http://127.0.0.1:8080/v1'
+    assert model == "sensenova-6.7-flash-lite"
+    assert provider == "custom:litellm-proxy"
+    assert base_url == "http://127.0.0.1:8080/v1"
 
 
 # ── get_available_models() @provider: hint behaviour ──────────────────────
@@ -208,7 +231,7 @@ def _isolate_models_cache():
 def _available_models_with_provider(provider):
     """Helper: temporarily set active_provider in config."""
     old_cfg = dict(config.cfg)
-    config.cfg['model'] = {'provider': provider}
+    config.cfg["model"] = {"provider": provider}
     try:
         return config.get_available_models()
     finally:
@@ -218,11 +241,11 @@ def _available_models_with_provider(provider):
 
 def test_non_default_provider_models_use_hint_prefix():
     """With anthropic as default, minimax model IDs should use @minimax: prefix."""
-    result = _available_models_with_provider('anthropic')
-    groups = {g['provider']: g['models'] for g in result['groups']}
-    if 'MiniMax' in groups:
-        for m in groups['MiniMax']:
-            assert m['id'].startswith('@minimax:'), (
+    result = _available_models_with_provider("anthropic")
+    groups = {g["provider"]: g["models"] for g in result["groups"]}
+    if "MiniMax" in groups:
+        for m in groups["MiniMax"]:
+            assert m["id"].startswith("@minimax:"), (
                 f"Expected @minimax: prefix, got: {m['id']!r}"
             )
 
@@ -232,18 +255,19 @@ def test_no_duplicate_when_default_model_is_prefixed():
     inject a duplicate alongside the existing bare 'claude-opus-4.6' entry in
     the same provider group."""
     import api.config as _cfg
+
     old_cfg = dict(_cfg.cfg)
-    _cfg.cfg['model'] = {
-        'provider': 'anthropic',
-        'default': 'anthropic/claude-opus-4.6',
+    _cfg.cfg["model"] = {
+        "provider": "anthropic",
+        "default": "anthropic/claude-opus-4.6",
     }
     try:
         result = _cfg.get_available_models()
-        norm = lambda mid: mid.split('/', 1)[-1] if '/' in mid else mid
+        norm = lambda mid: mid.split("/", 1)[-1] if "/" in mid else mid
         # Check each group individually: no group should have two entries that
         # normalize to the same bare model name
-        for g in result['groups']:
-            bare_ids = [norm(m['id']) for m in g['models']]
+        for g in result["groups"]:
+            bare_ids = [norm(m["id"]) for m in g["models"]]
             duplicates = [mid for mid in set(bare_ids) if bare_ids.count(mid) > 1]
             assert not duplicates, (
                 f"Provider group '{g['provider']}' has duplicate models after normalization: "
@@ -257,13 +281,20 @@ def test_no_duplicate_when_default_model_is_prefixed():
 def test_default_provider_models_not_prefixed(monkeypatch):
     """The active provider's models remain bare (no @prefix added)."""
     import api.config as _cfg
-    monkeypatch.setattr(_cfg, "_read_live_provider_model_ids", lambda pid: ["claude-sonnet-5.0"] if pid == "anthropic" else [])
-    result = _available_models_with_provider('anthropic')
-    groups = {g['provider']: g['models'] for g in result['groups']}
-    if 'Anthropic' in groups:
-        returned_ids = {m['id'] for m in groups['Anthropic']}
+
+    monkeypatch.setattr(
+        _cfg,
+        "_read_live_provider_model_ids",
+        lambda pid: ["claude-sonnet-5.0"] if pid == "anthropic" else [],
+    )
+    result = _available_models_with_provider("anthropic")
+    groups = {g["provider"]: g["models"] for g in result["groups"]}
+    if "Anthropic" in groups:
+        returned_ids = {m["id"] for m in groups["Anthropic"]}
         assert "claude-sonnet-5.0" in returned_ids
-        assert not any(mid.startswith('@anthropic:') for mid in returned_ids), returned_ids
+        assert not any(mid.startswith("@anthropic:") for mid in returned_ids), (
+            returned_ids
+        )
 
 
 # ── get_available_models(): phantom "Custom" group regression ─────────────
@@ -272,6 +303,7 @@ def test_default_provider_models_not_prefixed(monkeypatch):
 # AND a model.base_url set, hermes_cli reports the 'custom' pseudo-provider as
 # authenticated. The WebUI picker must NOT build a separate "Custom" group in
 # that case — the base_url belongs to the active provider.
+
 
 def _available_models_with_full_cfg(provider, default, base_url):
     """Helper: set model.provider, model.default, model.base_url at once.
@@ -282,11 +314,12 @@ def _available_models_with_full_cfg(provider, default, base_url):
     """
     import os
     import api.config as _cfg
+
     old_cfg = dict(_cfg.cfg)
-    _cfg.cfg['model'] = {
-        'provider': provider,
-        'default': default,
-        'base_url': base_url,
+    _cfg.cfg["model"] = {
+        "provider": provider,
+        "default": default,
+        "base_url": base_url,
     }
     try:
         _cfg._cfg_mtime = _cfg.Path(_cfg._get_config_path()).stat().st_mtime
@@ -296,7 +329,7 @@ def _available_models_with_full_cfg(provider, default, base_url):
         # which would overwrite the in-memory cfg we just set up.
         _cfg._cfg_mtime = 0.0
     # Clear model-override env vars to prevent the real profile from leaking in
-    _model_env_keys = ('HERMES_MODEL', 'OPENAI_MODEL', 'LLM_MODEL')
+    _model_env_keys = ("HERMES_MODEL", "OPENAI_MODEL", "LLM_MODEL")
     _saved_env = {k: os.environ.pop(k, None) for k in _model_env_keys}
     try:
         return _cfg.get_available_models()
@@ -311,28 +344,29 @@ def _available_models_with_full_cfg(provider, default, base_url):
 def test_no_phantom_custom_group_when_active_provider_is_set(monkeypatch):
     """Issue: with provider=openai-codex + base_url set, gpt-5.4 was landing
     under a phantom "Custom" group instead of the "OpenAI Codex" group."""
-    import sys, types
+    import sys
+    import types
 
     # Force hermes_cli to report both the real provider and the phantom
     # 'custom' as authenticated, simulating what list_available_providers()
     # returns when base_url is configured.
-    fake_mod = types.ModuleType('hermes_cli.models')
+    fake_mod = types.ModuleType("hermes_cli.models")
     fake_mod.list_available_providers = lambda: [
-        {'id': 'openai-codex', 'authenticated': True},
-        {'id': 'custom',       'authenticated': True},
+        {"id": "openai-codex", "authenticated": True},
+        {"id": "custom", "authenticated": True},
     ]
-    fake_auth = types.ModuleType('hermes_cli.auth')
-    fake_auth.get_auth_status = lambda pid: {'key_source': 'env'}
-    monkeypatch.setitem(sys.modules, 'hermes_cli.models', fake_mod)
-    monkeypatch.setitem(sys.modules, 'hermes_cli.auth', fake_auth)
+    fake_auth = types.ModuleType("hermes_cli.auth")
+    fake_auth.get_auth_status = lambda pid: {"key_source": "env"}
+    monkeypatch.setitem(sys.modules, "hermes_cli.models", fake_mod)
+    monkeypatch.setitem(sys.modules, "hermes_cli.auth", fake_auth)
 
     result = _available_models_with_full_cfg(
-        provider='openai-codex',
-        default='gpt-5.4',
-        base_url='https://chatgpt.com/backend-api/codex',
+        provider="openai-codex",
+        default="gpt-5.4",
+        base_url="https://chatgpt.com/backend-api/codex",
     )
-    group_names = [g['provider'] for g in result['groups']]
-    assert 'Custom' not in group_names, (
+    group_names = [g["provider"] for g in result["groups"]]
+    assert "Custom" not in group_names, (
         f"Phantom 'Custom' group present; full groups: {group_names}"
     )
 
@@ -349,32 +383,34 @@ def test_default_model_lands_under_active_provider_group(monkeypatch):
     to groups[0] — which, when another provider sorted earlier
     alphabetically (e.g. 'anthropic'), placed gpt-5.4 in the WRONG group.
     """
-    import sys, types
-    fake_mod = types.ModuleType('hermes_cli.models')
+    import sys
+    import types
+
+    fake_mod = types.ModuleType("hermes_cli.models")
     fake_mod.list_available_providers = lambda: [
-        {'id': 'anthropic',    'authenticated': True},  # sorts before openai-codex
-        {'id': 'openai-codex', 'authenticated': True},
-        {'id': 'custom',       'authenticated': True},
+        {"id": "anthropic", "authenticated": True},  # sorts before openai-codex
+        {"id": "openai-codex", "authenticated": True},
+        {"id": "custom", "authenticated": True},
     ]
-    fake_auth = types.ModuleType('hermes_cli.auth')
-    fake_auth.get_auth_status = lambda pid: {'key_source': 'env'}
-    monkeypatch.setitem(sys.modules, 'hermes_cli.models', fake_mod)
-    monkeypatch.setitem(sys.modules, 'hermes_cli.auth', fake_auth)
+    fake_auth = types.ModuleType("hermes_cli.auth")
+    fake_auth.get_auth_status = lambda pid: {"key_source": "env"}
+    monkeypatch.setitem(sys.modules, "hermes_cli.models", fake_mod)
+    monkeypatch.setitem(sys.modules, "hermes_cli.auth", fake_auth)
 
     result = _available_models_with_full_cfg(
-        provider='openai-codex',
-        default='gpt-5.4',
-        base_url='https://chatgpt.com/backend-api/codex',
+        provider="openai-codex",
+        default="gpt-5.4",
+        base_url="https://chatgpt.com/backend-api/codex",
     )
-    groups = {g['provider']: [m['id'] for m in g['models']] for g in result['groups']}
-    assert 'OpenAI Codex' in groups, f"OpenAI Codex group missing: {list(groups)}"
-    norm = lambda mid: mid.split('/', 1)[-1].split(':', 1)[-1]
-    assert 'gpt-5.4' in {norm(mid) for mid in groups['OpenAI Codex']}, (
+    groups = {g["provider"]: [m["id"] for m in g["models"]] for g in result["groups"]}
+    assert "OpenAI Codex" in groups, f"OpenAI Codex group missing: {list(groups)}"
+    norm = lambda mid: mid.split("/", 1)[-1].split(":", 1)[-1]
+    assert "gpt-5.4" in {norm(mid) for mid in groups["OpenAI Codex"]}, (
         f"gpt-5.4 not in OpenAI Codex group; contents: {groups['OpenAI Codex']}"
     )
     # And crucially, it must NOT have landed in the alphabetically-first
     # group (Anthropic) via the fallback path.
-    assert 'gpt-5.4' not in {norm(mid) for mid in groups.get('Anthropic', [])}, (
+    assert "gpt-5.4" not in {norm(mid) for mid in groups.get("Anthropic", [])}, (
         f"gpt-5.4 leaked into Anthropic group via fallback: {groups.get('Anthropic')}"
     )
 
@@ -387,39 +423,38 @@ def test_unknown_providers_do_not_inherit_default_model(monkeypatch):
     gpt-5.4-mini even though those providers do not serve it. Minimax-Cn is
     now known and should show its own catalog instead.
     """
-    import sys, types
+    import sys
+    import types
 
-    fake_mod = types.ModuleType('hermes_cli.models')
+    fake_mod = types.ModuleType("hermes_cli.models")
     fake_mod.list_available_providers = lambda: [
-        {'id': 'openai-codex', 'authenticated': True},
-        {'id': 'alibaba',      'authenticated': True},
-        {'id': 'minimax-cn',   'authenticated': True},
+        {"id": "openai-codex", "authenticated": True},
+        {"id": "alibaba", "authenticated": True},
+        {"id": "minimax-cn", "authenticated": True},
     ]
-    fake_auth = types.ModuleType('hermes_cli.auth')
-    fake_auth.get_auth_status = lambda pid: {'key_source': 'env'}
-    monkeypatch.setitem(sys.modules, 'hermes_cli.models', fake_mod)
-    monkeypatch.setitem(sys.modules, 'hermes_cli.auth', fake_auth)
+    fake_auth = types.ModuleType("hermes_cli.auth")
+    fake_auth.get_auth_status = lambda pid: {"key_source": "env"}
+    monkeypatch.setitem(sys.modules, "hermes_cli.models", fake_mod)
+    monkeypatch.setitem(sys.modules, "hermes_cli.auth", fake_auth)
 
     result = _available_models_with_full_cfg(
-        provider='openai-codex',
-        default='gpt-5.4-mini',
-        base_url='',
+        provider="openai-codex",
+        default="gpt-5.4-mini",
+        base_url="",
     )
-    groups = {g['provider']: [m['id'] for m in g['models']] for g in result['groups']}
-    norm = lambda mid: mid.split('/', 1)[-1].split(':', 1)[-1]
+    groups = {g["provider"]: [m["id"] for m in g["models"]] for g in result["groups"]}
+    norm = lambda mid: mid.split("/", 1)[-1].split(":", 1)[-1]
 
-    assert 'Alibaba' not in groups, (
+    assert "Alibaba" not in groups, (
         f"Alibaba should not inherit the default model placeholder: {groups}"
     )
-    assert 'MiniMax (China)' in groups, (
+    assert "MiniMax (China)" in groups, (
         f"Minimax-Cn should render its own static catalog: {groups}"
     )
     assert not any(
-        norm(mid) == 'gpt-5.4-mini'
-        for mid in groups.get('Alibaba', []) + groups.get('MiniMax (China)', [])
-    ), (
-        f"Unknown provider groups still inherited the default model: {groups}"
-    )
+        norm(mid) == "gpt-5.4-mini"
+        for mid in groups.get("Alibaba", []) + groups.get("MiniMax (China)", [])
+    ), f"Unknown provider groups still inherited the default model: {groups}"
 
 
 def test_custom_endpoint_uses_model_config_api_key_for_model_discovery(monkeypatch):
@@ -430,11 +465,11 @@ def test_custom_endpoint_uses_model_config_api_key_for_model_discovery(monkeypat
     import api.config as _cfg
 
     old_cfg = dict(_cfg.cfg)
-    _cfg.cfg['model'] = {
-        'provider': 'custom',
-        'default': 'gpt-5.4',
-        'base_url': 'https://example.test/v1',
-        'api_key': 'sk-test-model-key',
+    _cfg.cfg["model"] = {
+        "provider": "custom",
+        "default": "gpt-5.4",
+        "base_url": "https://example.test/v1",
+        "api_key": "sk-test-model-key",
     }
     try:
         _cfg._cfg_mtime = _cfg.Path(_cfg._get_config_path()).stat().st_mtime
@@ -442,48 +477,55 @@ def test_custom_endpoint_uses_model_config_api_key_for_model_discovery(monkeypat
         # No config.yaml on this machine (e.g. CI); pin to 0.0 so the mtime check
         # inside get_available_models() sees 0.0 == 0.0 and skips reload_config().
         _cfg._cfg_mtime = 0.0
-    _cfg.cfg.pop('providers', None)
+    _cfg.cfg.pop("providers", None)
 
     captured = {}
 
     class _Resp:
         def read(self):
-            return _json.dumps({'data': [{'id': 'gpt-5.2', 'name': 'GPT-5.2'}]}).encode('utf-8')
+            return _json.dumps({"data": [{"id": "gpt-5.2", "name": "GPT-5.2"}]}).encode(
+                "utf-8"
+            )
+
         def __enter__(self):
             return self
+
         def __exit__(self, exc_type, exc, tb):
             return False
 
     def _fake_urlopen(req, timeout=10):
-        url = getattr(req, 'full_url', '')
-        if 'example.test' in url:
-            captured['auth'] = req.get_header('Authorization')
-            captured['ua'] = req.get_header('User-agent')
+        url = getattr(req, "full_url", "")
+        if "example.test" in url:
+            captured["auth"] = req.get_header("Authorization")
+            captured["ua"] = req.get_header("User-agent")
         return _Resp()
 
-    monkeypatch.setattr('urllib.request.urlopen', _fake_urlopen)
-    monkeypatch.setattr('socket.getaddrinfo', lambda *a, **k: [])
-    monkeypatch.delenv('OPENAI_API_KEY', raising=False)
-    monkeypatch.delenv('HERMES_API_KEY', raising=False)
-    monkeypatch.delenv('HERMES_OPENAI_API_KEY', raising=False)
-    monkeypatch.delenv('LOCAL_API_KEY', raising=False)
-    monkeypatch.delenv('OPENROUTER_API_KEY', raising=False)
-    monkeypatch.delenv('API_KEY', raising=False)
+    monkeypatch.setattr("urllib.request.urlopen", _fake_urlopen)
+    monkeypatch.setattr("socket.getaddrinfo", lambda *a, **k: [])
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("HERMES_API_KEY", raising=False)
+    monkeypatch.delenv("HERMES_OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("LOCAL_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.delenv("API_KEY", raising=False)
     try:
         result = _cfg.get_available_models()
     finally:
         _cfg.cfg.clear()
         _cfg.cfg.update(old_cfg)
 
-    assert captured['auth'] == 'Bearer sk-test-model-key'
-    assert captured['ua'] == 'OpenAI/Python 1.0'
-    groups = {g['provider']: [m['id'] for m in g['models']] for g in result['groups']}
-    assert 'Custom' in groups
+    assert captured["auth"] == "Bearer sk-test-model-key"
+    assert captured["ua"] == "OpenAI/Python 1.0"
+    groups = {g["provider"]: [m["id"] for m in g["models"]] for g in result["groups"]}
+    assert "Custom" in groups
     # Model ID may be prefixed with @provider: due to cross-provider dedup (#1228)
-    assert any('gpt-5.2' in m for m in groups['Custom']), f'gpt-5.2 not found in Custom: {groups}'
+    assert any("gpt-5.2" in m for m in groups["Custom"]), (
+        f"gpt-5.2 not found in Custom: {groups}"
+    )
 
 
 # -- Issue #230: custom provider with slash model name -----------------------
+
 
 def test_custom_endpoint_slash_model_routes_to_custom_not_openrouter():
     """Regression test for #230, updated for #1625.
@@ -501,47 +543,55 @@ def test_custom_endpoint_slash_model_routes_to_custom_not_openrouter():
     """
     # --- custom provider with slash model name should NOT go to openrouter ---
     model, provider, base_url = _resolve_with_config(
-        'google/gemma-4-26b-a4b',
-        provider='custom',
-        base_url='http://127.0.0.1:1234/v1',
-        default='google/gemma-4-26b-a4b',
+        "google/gemma-4-26b-a4b",
+        provider="custom",
+        base_url="http://127.0.0.1:1234/v1",
+        default="google/gemma-4-26b-a4b",
     )
-    assert provider.startswith('custom'), (
+    assert provider.startswith("custom"), (
         "Expected provider starting with 'custom', got '{}'. "
-        "Slash in model name should NOT trigger OpenRouter rerouting when base_url is set.".format(provider)
+        "Slash in model name should NOT trigger OpenRouter rerouting when base_url is set.".format(
+            provider
+        )
     )
-    assert base_url == 'http://127.0.0.1:1234/v1', (
+    assert base_url == "http://127.0.0.1:1234/v1", (
         "Expected base_url 'http://127.0.0.1:1234/v1', got '{}'.".format(base_url)
     )
     # #1625 (supersedes the v0.50 #433 strip-on-custom rule for loopback hosts):
     # 127.0.0.1 base_url is almost certainly a local LM Studio / Ollama / etc.,
     # which keys models on the full HuggingFace path. Preserve the prefix.
-    assert model == 'google/gemma-4-26b-a4b', (
-        "Model name prefix must be PRESERVED on loopback base_url (#1625), got '{}'.".format(model)
+    assert model == "google/gemma-4-26b-a4b", (
+        "Model name prefix must be PRESERVED on loopback base_url (#1625), got '{}'.".format(
+            model
+        )
     )
 
     # --- public-host openai-compatible proxy STILL strips per #433 ----------
     model2, provider2, base_url2 = _resolve_with_config(
-        'google/gemma-4-26b-a4b',
-        provider='openai',
-        base_url='https://litellm.example.com/v1',
-        default='google/gemma-4-26b-a4b',
+        "google/gemma-4-26b-a4b",
+        provider="openai",
+        base_url="https://litellm.example.com/v1",
+        default="google/gemma-4-26b-a4b",
     )
-    assert model2 == 'gemma-4-26b-a4b', (
-        "Public-host OpenAI-compat proxy must still strip prefix per #433, got '{}'.".format(model2)
+    assert model2 == "gemma-4-26b-a4b", (
+        "Public-host OpenAI-compat proxy must still strip prefix per #433, got '{}'.".format(
+            model2
+        )
     )
 
     # --- openrouter with slash model name MUST still route to openrouter -----
     model_or, provider_or, _ = _resolve_with_config(
-        'google/gemma-4-26b-a4b',
-        provider='openrouter',
-        base_url='https://openrouter.ai/api/v1',
-        default='google/gemma-4-26b-a4b',
+        "google/gemma-4-26b-a4b",
+        provider="openrouter",
+        base_url="https://openrouter.ai/api/v1",
+        default="google/gemma-4-26b-a4b",
     )
-    assert provider_or == 'openrouter', (
+    assert provider_or == "openrouter", (
         "Expected provider 'openrouter', got '{}'. "
-        "Slash model via openrouter provider must still resolve to openrouter.".format(provider_or)
+        "Slash model via openrouter provider must still resolve to openrouter.".format(
+            provider_or
+        )
     )
-    assert model_or == 'google/gemma-4-26b-a4b', (
+    assert model_or == "google/gemma-4-26b-a4b", (
         "Model name should be preserved for openrouter, got '{}'.".format(model_or)
     )

--- a/tests/test_model_scope_copy.py
+++ b/tests/test_model_scope_copy.py
@@ -15,7 +15,9 @@ def test_composer_model_dropdown_has_scope_advisory():
     assert "model-scope-note" in ui
     assert "model_scope_advisory" in ui
     assert "Applies to this conversation from your next message." in ui
-    assert ui.index("dd.appendChild(_scopeNote);") < ui.index("dd.appendChild(_searchRow);")
+    assert ui.index("dd.appendChild(_scopeNote);") < ui.index(
+        "dd.appendChild(_searchRow);"
+    )
     assert ".model-scope-note" in style
     assert "position:sticky" in style
 
@@ -26,8 +28,14 @@ def test_model_selection_toast_describes_conversation_scope():
 
     assert "model_scope_toast" in boot
     assert "Applies to this conversation from your next message." in i18n
-    assert "model_scope_advisory: 'Applies to this conversation from your next message.'" in i18n
-    assert "model_scope_toast: 'Applies to this conversation from your next message.'" in i18n
+    assert (
+        "model_scope_advisory: 'Applies to this conversation from your next message.'"
+        in i18n
+    )
+    assert (
+        "model_scope_toast: 'Applies to this conversation from your next message.'"
+        in i18n
+    )
     assert "Model change takes effect in your next conversation" not in boot
 
 
@@ -36,5 +44,8 @@ def test_settings_default_model_copy_describes_new_conversations():
     i18n = read("static/i18n.js")
 
     assert 'data-i18n="settings_desc_model"' in html
-    assert "Used for new conversations. Existing conversations keep their selected model." in html
+    assert (
+        "Used for new conversations. Existing conversations keep their selected model."
+        in html
+    )
     assert "settings_desc_model" in i18n

--- a/tests/test_native_image_attachments.py
+++ b/tests/test_native_image_attachments.py
@@ -5,13 +5,12 @@ and _attachment_name from api.streaming / api.routes behave correctly
 across the workspace-path safety, size ceiling, multi-image, MIME, and
 fallback cases the maintainer asked about.
 """
+
 import base64
 import os
-import struct
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
-import pytest
 
 from api.streaming import (
     _attachment_name,
@@ -23,18 +22,19 @@ from api.routes import _normalize_chat_attachments
 
 # ── Helpers ─────────────────────────────────────────────────────────────────
 
+
 def _make_png(path: Path, size: int = 0) -> Path:
     """Write a minimal valid PNG to *path* (IHDR + IDAT + IEND)."""
     if size <= 0:
         # smallest valid PNG (67 bytes)
         data = (
-            b'\x89PNG\r\n\x1a\n'
-            b'\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x02\x00\x00\x00\x90wS\xde'
-            b'\x00\x00\x00\x0bIDATx\x9cc\xf8\x0f\x00\x00\x01\x01\x00\x05\x18\xd8N'
-            b'\x00\x00\x00\x00IEND\xaeB`\x82'
+            b"\x89PNG\r\n\x1a\n"
+            b"\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x02\x00\x00\x00\x90wS\xde"
+            b"\x00\x00\x00\x0bIDATx\x9cc\xf8\x0f\x00\x00\x01\x01\x00\x05\x18\xd8N"
+            b"\x00\x00\x00\x00IEND\xaeB`\x82"
         )
     else:
-        data = b'\x89PNG\r\n\x1a\n' + b'\x00' * (size - 8)
+        data = b"\x89PNG\r\n\x1a\n" + b"\x00" * (size - 8)
     path.write_bytes(data)
     return path
 
@@ -42,162 +42,221 @@ def _make_png(path: Path, size: int = 0) -> Path:
 def _make_jpeg(path: Path, size: int = 107) -> Path:
     """Write a tiny but valid JPEG."""
     data = (
-        b'\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01\x01\x00\x00\x01\x00\x01\x00\x00'
-        b'\xff\xdb\x00C\x00\x08\x06\x06\x07\x06\x05\x08\x07\x07\x07\t\t\x08\n'
-        b'\x0c\x14\r\x0c\x0b\x0b\x0c\x19\x12\x13\x0f\x14\x1d\x1a\x1f\x1e\x1d\x1a'
-        b'\x1c\x1c $.\' ",#\x1c\x1c(7),01444\x1f\'9=82<.342'
-        b'\xff\xc0\x00\x0b\x08\x00\x01\x00\x01\x01\x01\x11\x00'
-        b'\xff\xc4\x00\x1f\x00\x00\x01\x05\x01\x01\x01\x01\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00'
-        b'\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x0b'
-        b'\xff\xda\x00\x08\x01\x01\x00\x00?\x00\x7f\x00'
-        b'\xff\xd9'
+        b"\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01\x01\x00\x00\x01\x00\x01\x00\x00"
+        b"\xff\xdb\x00C\x00\x08\x06\x06\x07\x06\x05\x08\x07\x07\x07\t\t\x08\n"
+        b"\x0c\x14\r\x0c\x0b\x0b\x0c\x19\x12\x13\x0f\x14\x1d\x1a\x1f\x1e\x1d\x1a"
+        b"\x1c\x1c $.' \",#\x1c\x1c(7),01444\x1f'9=82<.342"
+        b"\xff\xc0\x00\x0b\x08\x00\x01\x00\x01\x01\x01\x11\x00"
+        b"\xff\xc4\x00\x1f\x00\x00\x01\x05\x01\x01\x01\x01\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00"
+        b"\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x0b"
+        b"\xff\xda\x00\x08\x01\x01\x00\x00?\x00\x7f\x00"
+        b"\xff\xd9"
     )
     if size > len(data):
-        data += b'\x00' * (size - len(data))
+        data += b"\x00" * (size - len(data))
     path.write_bytes(data[:size] if size < len(data) else data)
     return path
 
 
 # ── _attachment_name ────────────────────────────────────────────────────────
 
+
 class TestAttachmentName:
     def test_dict_with_name(self):
-        assert _attachment_name({'name': 'photo.png', 'path': '/tmp/x'}) == 'photo.png'
+        assert _attachment_name({"name": "photo.png", "path": "/tmp/x"}) == "photo.png"
 
     def test_dict_with_filename_fallback(self):
-        assert _attachment_name({'filename': 'img.jpg'}) == 'img.jpg'
+        assert _attachment_name({"filename": "img.jpg"}) == "img.jpg"
 
     def test_dict_with_path_fallback(self):
-        assert _attachment_name({'path': '/ws/snap.png'}) == '/ws/snap.png'
+        assert _attachment_name({"path": "/ws/snap.png"}) == "/ws/snap.png"
 
     def test_string_attachment(self):
-        assert _attachment_name('readme.md') == 'readme.md'
+        assert _attachment_name("readme.md") == "readme.md"
 
     def test_empty_attachment(self):
-        assert _attachment_name({}) == ''
+        assert _attachment_name({}) == ""
 
     def test_none_attachment(self):
-        assert _attachment_name(None) == ''
+        assert _attachment_name(None) == ""
 
 
 # ── _normalize_chat_attachments ─────────────────────────────────────────────
 
+
 class TestNormalizeChatAttachments:
     def test_legacy_string_list(self):
-        result = _normalize_chat_attachments(['a.png', 'b.txt'])
+        result = _normalize_chat_attachments(["a.png", "b.txt"])
         assert result == [
-            {'name': 'a.png', 'path': '', 'mime': ''},
-            {'name': 'b.txt', 'path': '', 'mime': ''},
+            {"name": "a.png", "path": "", "mime": ""},
+            {"name": "b.txt", "path": "", "mime": ""},
         ]
 
     def test_dict_with_mime_and_is_image(self):
-        result = _normalize_chat_attachments([{
-            'name': 'photo.png', 'path': '/ws/photo.png',
-            'mime': 'image/png', 'size': 1234, 'is_image': True,
-        }])
-        assert result == [{
-            'name': 'photo.png', 'path': '/ws/photo.png',
-            'mime': 'image/png', 'size': 1234, 'is_image': True,
-        }]
+        result = _normalize_chat_attachments(
+            [
+                {
+                    "name": "photo.png",
+                    "path": "/ws/photo.png",
+                    "mime": "image/png",
+                    "size": 1234,
+                    "is_image": True,
+                }
+            ]
+        )
+        assert result == [
+            {
+                "name": "photo.png",
+                "path": "/ws/photo.png",
+                "mime": "image/png",
+                "size": 1234,
+                "is_image": True,
+            }
+        ]
 
     def test_dict_missing_fields_defaults(self):
-        result = _normalize_chat_attachments([{'path': '/x'}])
-        assert result == [{'name': '/x', 'path': '/x', 'mime': ''}]
+        result = _normalize_chat_attachments([{"path": "/x"}])
+        assert result == [{"name": "/x", "path": "/x", "mime": ""}]
 
     def test_mixed_list(self):
-        result = _normalize_chat_attachments([
-            'old.txt',
-            {'name': 'new.png', 'path': '/ws/new.png', 'mime': 'image/png'},
-        ])
+        result = _normalize_chat_attachments(
+            [
+                "old.txt",
+                {"name": "new.png", "path": "/ws/new.png", "mime": "image/png"},
+            ]
+        )
         assert len(result) == 2
-        assert result[0] == {'name': 'old.txt', 'path': '', 'mime': ''}
-        assert result[1]['name'] == 'new.png'
+        assert result[0] == {"name": "old.txt", "path": "", "mime": ""}
+        assert result[1]["name"] == "new.png"
 
     def test_empty_list(self):
         assert _normalize_chat_attachments([]) == []
 
     def test_not_a_list(self):
         assert _normalize_chat_attachments(None) == []
-        assert _normalize_chat_attachments('abc') == []
+        assert _normalize_chat_attachments("abc") == []
 
 
 # ── _build_native_multimodal_message ────────────────────────────────────────
 
+
 class TestBuildNativeMultimodalMessage:
     def test_no_attachments_returns_string(self):
-        result = _build_native_multimodal_message('[WS: x]\n', 'describe', [], '/ws')
-        assert result == '[WS: x]\ndescribe'
+        result = _build_native_multimodal_message("[WS: x]\n", "describe", [], "/ws")
+        assert result == "[WS: x]\ndescribe"
 
     def test_single_image_in_workspace(self):
         with TemporaryDirectory() as d:
             root = Path(d)
-            img = root / 'pic.png'
+            img = root / "pic.png"
             _make_png(img)
-            atts = _normalize_chat_attachments([{
-                'name': 'pic.png', 'path': str(img),
-                'mime': 'image/png', 'size': img.stat().st_size, 'is_image': True,
-            }])
-            result = _build_native_multimodal_message('[WS]\n', 'look', atts, str(root))
+            atts = _normalize_chat_attachments(
+                [
+                    {
+                        "name": "pic.png",
+                        "path": str(img),
+                        "mime": "image/png",
+                        "size": img.stat().st_size,
+                        "is_image": True,
+                    }
+                ]
+            )
+            result = _build_native_multimodal_message("[WS]\n", "look", atts, str(root))
             assert isinstance(result, list)
-            assert result[0] == {'type': 'text', 'text': '[WS]\nlook'}
+            assert result[0] == {"type": "text", "text": "[WS]\nlook"}
             assert len(result) == 2
-            assert result[1]['type'] == 'image_url'
-            url = result[1]['image_url']['url']
-            assert url.startswith('data:image/png;base64,')
-            decoded = base64.b64decode(url.split(',', 1)[1])
-            assert decoded[:4] == b'\x89PNG'
+            assert result[1]["type"] == "image_url"
+            url = result[1]["image_url"]["url"]
+            assert url.startswith("data:image/png;base64,")
+            decoded = base64.b64decode(url.split(",", 1)[1])
+            assert decoded[:4] == b"\x89PNG"
 
     def test_jpeg_image_in_workspace(self):
         with TemporaryDirectory() as d:
             root = Path(d)
-            img = root / 'photo.jpeg'
+            img = root / "photo.jpeg"
             _make_jpeg(img)
-            atts = _normalize_chat_attachments([{
-                'name': 'photo.jpeg', 'path': str(img),
-                'mime': 'image/jpeg', 'size': img.stat().st_size, 'is_image': True,
-            }])
-            result = _build_native_multimodal_message('', 'hi', atts, str(root))
-            assert result[1]['image_url']['url'].startswith('data:image/jpeg;base64,')
+            atts = _normalize_chat_attachments(
+                [
+                    {
+                        "name": "photo.jpeg",
+                        "path": str(img),
+                        "mime": "image/jpeg",
+                        "size": img.stat().st_size,
+                        "is_image": True,
+                    }
+                ]
+            )
+            result = _build_native_multimodal_message("", "hi", atts, str(root))
+            assert result[1]["image_url"]["url"].startswith("data:image/jpeg;base64,")
 
     def test_multiple_images_become_multiple_parts(self):
         with TemporaryDirectory() as d:
             root = Path(d)
-            img1 = root / 'a.png'
-            img2 = root / 'b.png'
+            img1 = root / "a.png"
+            img2 = root / "b.png"
             _make_png(img1)
             _make_png(img2)
-            atts = _normalize_chat_attachments([
-                {'name': 'a.png', 'path': str(img1), 'mime': 'image/png', 'size': img1.stat().st_size, 'is_image': True},
-                {'name': 'b.png', 'path': str(img2), 'mime': 'image/png', 'size': img2.stat().st_size, 'is_image': True},
-            ])
-            result = _build_native_multimodal_message('', 'multi', atts, str(root))
-            image_parts = [p for p in result if p['type'] == 'image_url']
+            atts = _normalize_chat_attachments(
+                [
+                    {
+                        "name": "a.png",
+                        "path": str(img1),
+                        "mime": "image/png",
+                        "size": img1.stat().st_size,
+                        "is_image": True,
+                    },
+                    {
+                        "name": "b.png",
+                        "path": str(img2),
+                        "mime": "image/png",
+                        "size": img2.stat().st_size,
+                        "is_image": True,
+                    },
+                ]
+            )
+            result = _build_native_multimodal_message("", "multi", atts, str(root))
+            image_parts = [p for p in result if p["type"] == "image_url"]
             assert len(image_parts) == 2
 
     def test_non_image_attachment_stays_text_fallback(self):
         with TemporaryDirectory() as d:
             root = Path(d)
-            doc = root / 'notes.txt'
-            doc.write_text('hello')
-            atts = _normalize_chat_attachments([{
-                'name': 'notes.txt', 'path': str(doc),
-                'mime': 'text/plain', 'size': doc.stat().st_size, 'is_image': False,
-            }])
-            result = _build_native_multimodal_message('[WS]\n', 'read', atts, str(root))
+            doc = root / "notes.txt"
+            doc.write_text("hello")
+            atts = _normalize_chat_attachments(
+                [
+                    {
+                        "name": "notes.txt",
+                        "path": str(doc),
+                        "mime": "text/plain",
+                        "size": doc.stat().st_size,
+                        "is_image": False,
+                    }
+                ]
+            )
+            result = _build_native_multimodal_message("[WS]\n", "read", atts, str(root))
             assert isinstance(result, str)
-            assert 'read' in result
+            assert "read" in result
 
     def test_outside_workspace_path_rejected(self):
         with TemporaryDirectory() as d:
             root = Path(d)
-            outside = Path(d) / '..' / 'outside.png'
+            outside = Path(d) / ".." / "outside.png"
             outside = outside.resolve()
             _make_png(outside)
-            atts = _normalize_chat_attachments([{
-                'name': 'outside.png', 'path': str(outside),
-                'mime': 'image/png', 'size': outside.stat().st_size, 'is_image': True,
-            }])
-            result = _build_native_multimodal_message('', 'hi', atts, str(root))
+            atts = _normalize_chat_attachments(
+                [
+                    {
+                        "name": "outside.png",
+                        "path": str(outside),
+                        "mime": "image/png",
+                        "size": outside.stat().st_size,
+                        "is_image": True,
+                    }
+                ]
+            )
+            result = _build_native_multimodal_message("", "hi", atts, str(root))
             # Should fall back to string; outside path is rejected
             assert isinstance(result, str)
 
@@ -205,130 +264,189 @@ class TestBuildNativeMultimodalMessage:
         """Symlink inside workspace pointing to workspace file is allowed."""
         with TemporaryDirectory() as d:
             root = Path(d)
-            real_file = root / 'real.png'
+            real_file = root / "real.png"
             _make_png(real_file)
-            link = root / 'link.png'
+            link = root / "link.png"
             os.symlink(str(real_file), str(link))
-            atts = _normalize_chat_attachments([{
-                'name': 'link.png', 'path': str(link),
-                'mime': 'image/png', 'size': real_file.stat().st_size, 'is_image': True,
-            }])
-            result = _build_native_multimodal_message('', 'hi', atts, str(root))
+            atts = _normalize_chat_attachments(
+                [
+                    {
+                        "name": "link.png",
+                        "path": str(link),
+                        "mime": "image/png",
+                        "size": real_file.stat().st_size,
+                        "is_image": True,
+                    }
+                ]
+            )
+            result = _build_native_multimodal_message("", "hi", atts, str(root))
             # Symlink resolves inside workspace, so it should be accepted
             assert isinstance(result, list)
-            assert result[1]['type'] == 'image_url'
+            assert result[1]["type"] == "image_url"
 
     def test_symlink_pointing_outside_workspace_rejected(self):
         """Symlink inside workspace pointing outside must be rejected by .resolve()."""
         with TemporaryDirectory() as d:
             root = Path(d)
-            outside_file = Path(d) / '..' / 'escape.png'
+            outside_file = Path(d) / ".." / "escape.png"
             outside_file = outside_file.resolve()
             _make_png(outside_file)
-            link = root / 'trap.link'
+            link = root / "trap.link"
             os.symlink(str(outside_file), str(link))
-            atts = _normalize_chat_attachments([{
-                'name': 'trap.link', 'path': str(link),
-                'mime': 'image/png', 'size': outside_file.stat().st_size, 'is_image': True,
-            }])
-            result = _build_native_multimodal_message('', 'hi', atts, str(root))
+            atts = _normalize_chat_attachments(
+                [
+                    {
+                        "name": "trap.link",
+                        "path": str(link),
+                        "mime": "image/png",
+                        "size": outside_file.stat().st_size,
+                        "is_image": True,
+                    }
+                ]
+            )
+            result = _build_native_multimodal_message("", "hi", atts, str(root))
             assert isinstance(result, str)
 
     def test_size_above_cap_rejected(self):
         """Images larger than _NATIVE_IMAGE_MAX_BYTES must not be included."""
         with TemporaryDirectory() as d:
             root = Path(d)
-            huge = root / 'huge.png'
+            huge = root / "huge.png"
             _make_png(huge, size=_NATIVE_IMAGE_MAX_BYTES + 1)
-            atts = _normalize_chat_attachments([{
-                'name': 'huge.png', 'path': str(huge),
-                'mime': 'image/png', 'size': huge.stat().st_size, 'is_image': True,
-            }])
-            result = _build_native_multimodal_message('', 'hi', atts, str(root))
+            atts = _normalize_chat_attachments(
+                [
+                    {
+                        "name": "huge.png",
+                        "path": str(huge),
+                        "mime": "image/png",
+                        "size": huge.stat().st_size,
+                        "is_image": True,
+                    }
+                ]
+            )
+            result = _build_native_multimodal_message("", "hi", atts, str(root))
             assert isinstance(result, str)
 
     def test_missing_path_skipped(self):
         with TemporaryDirectory() as d:
             root = Path(d)
-            atts = _normalize_chat_attachments([{
-                'name': 'ghost.png', 'path': str(root / 'no-such.png'),
-                'mime': 'image/png', 'is_image': True,
-            }])
-            result = _build_native_multimodal_message('', 'hi', atts, str(root))
+            atts = _normalize_chat_attachments(
+                [
+                    {
+                        "name": "ghost.png",
+                        "path": str(root / "no-such.png"),
+                        "mime": "image/png",
+                        "is_image": True,
+                    }
+                ]
+            )
+            result = _build_native_multimodal_message("", "hi", atts, str(root))
             assert isinstance(result, str)
 
     def test_no_mime_guessed_from_extension(self):
         with TemporaryDirectory() as d:
             root = Path(d)
-            img = root / 'pic.png'
+            img = root / "pic.png"
             _make_png(img)
-            atts = _normalize_chat_attachments([{
-                'name': 'pic.png', 'path': str(img),
-                'mime': '', 'size': img.stat().st_size, 'is_image': True,
-            }])
-            result = _build_native_multimodal_message('', 'hi', atts, str(root))
+            atts = _normalize_chat_attachments(
+                [
+                    {
+                        "name": "pic.png",
+                        "path": str(img),
+                        "mime": "",
+                        "size": img.stat().st_size,
+                        "is_image": True,
+                    }
+                ]
+            )
+            result = _build_native_multimodal_message("", "hi", atts, str(root))
             assert isinstance(result, list)
-            assert result[1]['image_url']['url'].startswith('data:image/png;base64,')
+            assert result[1]["image_url"]["url"].startswith("data:image/png;base64,")
 
     def test_mixed_image_and_nonimage(self):
         """Non-image is skipped; image still goes through."""
         with TemporaryDirectory() as d:
             root = Path(d)
-            img = root / 'pic.png'
+            img = root / "pic.png"
             _make_png(img)
-            doc = root / 'readme.md'
-            doc.write_text('# hello')
-            atts = _normalize_chat_attachments([
-                {'name': 'pic.png', 'path': str(img), 'mime': 'image/png', 'size': img.stat().st_size, 'is_image': True},
-                {'name': 'readme.md', 'path': str(doc), 'mime': 'text/markdown', 'size': doc.stat().st_size, 'is_image': False},
-            ])
-            result = _build_native_multimodal_message('', 'hi', atts, str(root))
+            doc = root / "readme.md"
+            doc.write_text("# hello")
+            atts = _normalize_chat_attachments(
+                [
+                    {
+                        "name": "pic.png",
+                        "path": str(img),
+                        "mime": "image/png",
+                        "size": img.stat().st_size,
+                        "is_image": True,
+                    },
+                    {
+                        "name": "readme.md",
+                        "path": str(doc),
+                        "mime": "text/markdown",
+                        "size": doc.stat().st_size,
+                        "is_image": False,
+                    },
+                ]
+            )
+            result = _build_native_multimodal_message("", "hi", atts, str(root))
             assert isinstance(result, list)
-            image_parts = [p for p in result if p['type'] == 'image_url']
+            image_parts = [p for p in result if p["type"] == "image_url"]
             assert len(image_parts) == 1
-            assert 'hi' in result[0]['text']
+            assert "hi" in result[0]["text"]
 
     def test_upload_result_structure_roundtrip(self):
         """Simulate the full flow: upload result → normalize → build message."""
         with TemporaryDirectory() as d:
             root = Path(d)
-            img = root / 'screenshot.png'
+            img = root / "screenshot.png"
             _make_png(img)
             # what /api/upload returns
             upload_result = {
-                'filename': 'screenshot.png',
-                'path': str(img),
-                'mime': 'image/png',
-                'size': img.stat().st_size,
-                'is_image': True,
+                "filename": "screenshot.png",
+                "path": str(img),
+                "mime": "image/png",
+                "size": img.stat().st_size,
+                "is_image": True,
             }
             # what the frontend sends to /api/chat/start
-            frontend_payload = [{
-                'name': upload_result['filename'],
-                'path': upload_result['path'],
-                'mime': upload_result['mime'],
-                'size': upload_result['size'],
-                'is_image': upload_result['is_image'],
-            }]
+            frontend_payload = [
+                {
+                    "name": upload_result["filename"],
+                    "path": upload_result["path"],
+                    "mime": upload_result["mime"],
+                    "size": upload_result["size"],
+                    "is_image": upload_result["is_image"],
+                }
+            ]
             normalized = _normalize_chat_attachments(frontend_payload)
-            result = _build_native_multimodal_message('[WS]\n', 'describe this', normalized, str(root))
+            result = _build_native_multimodal_message(
+                "[WS]\n", "describe this", normalized, str(root)
+            )
             assert isinstance(result, list)
-            assert result[1]['type'] == 'image_url'
-            data_url = result[1]['image_url']['url']
-            assert data_url.startswith('data:image/png;base64,')
+            assert result[1]["type"] == "image_url"
+            data_url = result[1]["image_url"]["url"]
+            assert data_url.startswith("data:image/png;base64,")
             assert len(result) == 2
 
     def test_fake_png_rejected_by_magic_bytes(self):
         """A file named .png that is not actually an image must be rejected."""
         with TemporaryDirectory() as d:
             root = Path(d)
-            fake = root / 'not-really.png'
-            fake.write_text('this is plain text, not an image')
-            atts = _normalize_chat_attachments([{
-                'name': 'not-really.png', 'path': str(fake),
-                'mime': 'image/png', 'size': fake.stat().st_size, 'is_image': True,
-            }])
-            result = _build_native_multimodal_message('', 'hi', atts, str(root))
+            fake = root / "not-really.png"
+            fake.write_text("this is plain text, not an image")
+            atts = _normalize_chat_attachments(
+                [
+                    {
+                        "name": "not-really.png",
+                        "path": str(fake),
+                        "mime": "image/png",
+                        "size": fake.stat().st_size,
+                        "is_image": True,
+                    }
+                ]
+            )
+            result = _build_native_multimodal_message("", "hi", atts, str(root))
             assert isinstance(result, str)
 
 
@@ -340,41 +458,41 @@ from api.streaming import _is_valid_image
 class TestIsValidImage:
     def test_valid_png(self):
         with TemporaryDirectory() as d:
-            p = Path(d) / 'a.png'
+            p = Path(d) / "a.png"
             _make_png(p)
-            assert _is_valid_image(p, 'image/png')
+            assert _is_valid_image(p, "image/png")
 
     def test_valid_jpeg(self):
         with TemporaryDirectory() as d:
-            p = Path(d) / 'a.jpg'
+            p = Path(d) / "a.jpg"
             _make_jpeg(p)
-            assert _is_valid_image(p, 'image/jpeg')
+            assert _is_valid_image(p, "image/jpeg")
 
     def test_fake_png_rejected(self):
         with TemporaryDirectory() as d:
-            p = Path(d) / 'fake.png'
-            p.write_text('hello world')
-            assert not _is_valid_image(p, 'image/png')
+            p = Path(d) / "fake.png"
+            p.write_text("hello world")
+            assert not _is_valid_image(p, "image/png")
 
     def test_text_file_not_image(self):
         with TemporaryDirectory() as d:
-            p = Path(d) / 'notes.txt'
-            p.write_text('plain text')
-            assert not _is_valid_image(p, 'image/png')
-            assert not _is_valid_image(p, 'text/plain')
+            p = Path(d) / "notes.txt"
+            p.write_text("plain text")
+            assert not _is_valid_image(p, "image/png")
+            assert not _is_valid_image(p, "text/plain")
 
     def test_svg_allowed(self):
         """SVG is text-based with no binary magic, so it passes."""
         with TemporaryDirectory() as d:
-            p = Path(d) / 'diagram.svg'
+            p = Path(d) / "diagram.svg"
             p.write_text('<svg xmlns="http://www.w3.org/2000/svg"/>')
-            assert _is_valid_image(p, 'image/svg+xml')
+            assert _is_valid_image(p, "image/svg+xml")
 
     def test_missing_file(self):
-        assert not _is_valid_image(Path('/no/such/file.png'), 'image/png')
+        assert not _is_valid_image(Path("/no/such/file.png"), "image/png")
 
     def test_mime_with_charset(self):
         with TemporaryDirectory() as d:
-            p = Path(d) / 'a.png'
+            p = Path(d) / "a.png"
             _make_png(p)
-            assert _is_valid_image(p, 'image/png; charset=utf-8')
+            assert _is_valid_image(p, "image/png; charset=utf-8")

--- a/tests/test_norm_model_id_trailing_empty_guard.py
+++ b/tests/test_norm_model_id_trailing_empty_guard.py
@@ -9,6 +9,7 @@ Mirrors:
   api/config.py        _norm_model_id
   static/ui.js         _normalizeConfiguredModelKey
 """
+
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).parent.parent
@@ -74,7 +75,14 @@ def test_ui_js_mirror_has_trailing_empty_guard():
     # The new pattern uses `const last=s.split(':').pop();s=last||s;`
     assert "s.split(':').pop()" in UI_JS, "ui.js no longer uses split-pop pattern"
     # Look for the `||s` fallback specifically
-    snippet = UI_JS[UI_JS.find("function _normalizeConfiguredModelKey"):UI_JS.find("function _normalizeConfiguredModelKey") + 600]
+    snippet = UI_JS[
+        UI_JS.find("function _normalizeConfiguredModelKey") : UI_JS.find(
+            "function _normalizeConfiguredModelKey"
+        )
+        + 600
+    ]
     assert "last||s" in snippet, "ui.js missing trailing-empty guard `||s` fallback"
     # And mirror on / branch
-    assert snippet.count("last||s") >= 2, "ui.js trailing-empty guard not mirrored on slash branch"
+    assert snippet.count("last||s") >= 2, (
+        "ui.js trailing-empty guard not mirrored on slash branch"
+    )

--- a/tests/test_nous_portal_routing.py
+++ b/tests/test_nous_portal_routing.py
@@ -12,8 +12,6 @@ provider/model path as the canonical name at their inference endpoint.
 Stripping the prefix to a bare name is exactly Bug 1, so the fix for Bug 2
 must not reintroduce it.
 """
-import sys
-import types
 
 
 def _models_with_provider(provider, monkeypatch):
@@ -29,6 +27,7 @@ def _models_with_provider(provider, monkeypatch):
         config._cfg_mtime = 0.0
     try:
         from api.config import resolve_model_provider
+
         return resolve_model_provider
     finally:
         config.cfg.clear()
@@ -46,6 +45,7 @@ class TestNousModelIds:
         than relying on the slash-only portal provider guard.
         """
         from api.config import _PROVIDER_MODELS
+
         nous_models = _PROVIDER_MODELS.get("nous", [])
         assert nous_models, "Nous must have at least one static model"
         for m in nous_models:
@@ -59,6 +59,7 @@ class TestNousModelIds:
     def test_nous_known_models_present(self):
         """Key Nous models must be present with correct @nous:-prefixed IDs."""
         from api.config import _PROVIDER_MODELS
+
         nous_ids = {m["id"] for m in _PROVIDER_MODELS.get("nous", [])}
         assert "@nous:anthropic/claude-opus-4.6" in nous_ids, (
             "@nous:anthropic/claude-opus-4.6 must be in Nous model list"
@@ -73,11 +74,16 @@ class TestNousModelIds:
     def test_nous_models_no_bare_or_slash_only(self):
         """No Nous static model should be bare or slash-only without @nous: prefix."""
         from api.config import _PROVIDER_MODELS
+
         bad_ids = {
-            "claude-opus-4.6", "claude-sonnet-4.6", "gpt-5.4-mini",
+            "claude-opus-4.6",
+            "claude-sonnet-4.6",
+            "gpt-5.4-mini",
             "gemini-3.1-pro-preview",
-            "anthropic/claude-opus-4.6", "anthropic/claude-sonnet-4.6",
-            "openai/gpt-5.4-mini", "google/gemini-3.1-pro-preview",
+            "anthropic/claude-opus-4.6",
+            "anthropic/claude-sonnet-4.6",
+            "openai/gpt-5.4-mini",
+            "google/gemini-3.1-pro-preview",
         }
         nous_ids = {m["id"] for m in _PROVIDER_MODELS.get("nous", [])}
         for bad in bad_ids:
@@ -93,6 +99,7 @@ class TestPortalProviderRouting:
 
     def _resolve(self, model_id, provider):
         import api.config as config
+
         old = dict(config.cfg)
         old_mtime = config._cfg_mtime
         config.cfg.clear()
@@ -103,6 +110,7 @@ class TestPortalProviderRouting:
             config._cfg_mtime = 0.0
         try:
             from api.config import resolve_model_provider
+
             return resolve_model_provider(model_id)
         finally:
             config.cfg.clear()
@@ -141,8 +149,12 @@ class TestPortalProviderRouting:
     def test_opencode_zen_routes_cross_namespace(self):
         """opencode-zen is also a portal — cross-namespace models must route through it
         with the slash-prefixed ID preserved."""
-        model, provider, _ = self._resolve("anthropic/claude-sonnet-4.6", "opencode-zen")
-        assert provider == "opencode-zen", f"Expected provider='opencode-zen', got '{provider}'."
+        model, provider, _ = self._resolve(
+            "anthropic/claude-sonnet-4.6", "opencode-zen"
+        )
+        assert provider == "opencode-zen", (
+            f"Expected provider='opencode-zen', got '{provider}'."
+        )
         assert model == "anthropic/claude-sonnet-4.6", (
             f"Expected 'anthropic/claude-sonnet-4.6', got '{model}'."
         )

--- a/tests/test_offline_banner.py
+++ b/tests/test_offline_banner.py
@@ -36,8 +36,13 @@ def test_offline_banner_markup_styles_and_copy_exist():
 def test_offline_monitor_patches_fetch_and_auto_reloads_after_health_probe():
     assert "const OFFLINE_RECHECK_MS=2500" in UI_JS
     assert "window.fetch=async function(...args)" in UI_JS
-    assert "window.addEventListener('offline',()=>showOfflineBanner('browser'))" in UI_JS
-    assert "window.addEventListener('online',()=>{if(_offlineVisible)checkOfflineRecoveryNow();})" in UI_JS
+    assert (
+        "window.addEventListener('offline',()=>showOfflineBanner('browser'))" in UI_JS
+    )
+    assert (
+        "window.addEventListener('online',()=>{if(_offlineVisible)checkOfflineRecoveryNow();})"
+        in UI_JS
+    )
     assert "setInterval(()=>{checkOfflineRecoveryNow();},OFFLINE_RECHECK_MS)" in UI_JS
     assert "new URL('health',document.baseURI||location.href)" in UI_JS
     assert "window.location.reload()" in UI_JS
@@ -56,10 +61,15 @@ def test_offline_recovery_probe_is_serialized_and_stops_timer_before_reload():
 
 
 def test_fetch_typeerror_is_gated_by_health_probe_not_blind_banner():
-    fetch_patch = UI_JS.split("window.fetch=async function(...args){", 1)[1].split("function initOfflineMonitor", 1)[0]
+    fetch_patch = UI_JS.split("window.fetch=async function(...args){", 1)[1].split(
+        "function initOfflineMonitor", 1
+    )[0]
     assert "function _isAbortError(e)" in UI_JS
     assert "e instanceof TypeError&&!_isAbortError(e)" in fetch_patch
-    assert "void _probeOfflineRecovery().then(ok=>{if(!ok)showOfflineBanner('network');})" in fetch_patch
+    assert (
+        "void _probeOfflineRecovery().then(ok=>{if(!ok)showOfflineBanner('network');})"
+        in fetch_patch
+    )
     assert "if(!_browserReportsOnline())showOfflineBanner('browser');" in fetch_patch
     assert "e instanceof TypeError||!_browserReportsOnline()" not in fetch_patch
 
@@ -68,5 +78,9 @@ def test_sse_network_error_defers_to_offline_banner_instead_of_inline_error():
     assert "function _deferStreamErrorIfOffline()" in MESSAGES_JS
     assert "t('offline_stream_waiting')" in MESSAGES_JS
     assert "if(_deferStreamErrorIfOffline()) return;" in MESSAGES_JS
-    error_handler = MESSAGES_JS.split("source.addEventListener('error',async e=>{", 1)[1].split("source.addEventListener('cancel'", 1)[0]
-    assert error_handler.find("_deferStreamErrorIfOffline()") < error_handler.rfind("_handleStreamError()")
+    error_handler = MESSAGES_JS.split("source.addEventListener('error',async e=>{", 1)[
+        1
+    ].split("source.addEventListener('cancel'", 1)[0]
+    assert error_handler.find("_deferStreamErrorIfOffline()") < error_handler.rfind(
+        "_handleStreamError()"
+    )

--- a/tests/test_older_history_viewport_preservation.py
+++ b/tests/test_older_history_viewport_preservation.py
@@ -22,7 +22,9 @@ def test_loading_older_messages_expands_render_window_before_rendering():
     body = _function_body(SESSIONS_JS, "async function _loadOlderMessages")
 
     prepend_idx = body.index("S.messages = [...olderMsgs, ...S.messages]")
-    expand_idx = body.index("_messageRenderWindowSize=_currentMessageRenderWindowSize()")
+    expand_idx = body.index(
+        "_messageRenderWindowSize=_currentMessageRenderWindowSize()"
+    )
     render_idx = body.index("renderMessages({ preserveScroll: true });")
 
     assert prepend_idx < expand_idx < render_idx, (
@@ -51,5 +53,7 @@ def test_loading_older_messages_marks_scroll_programmatic_while_anchoring():
 
     set_idx = body.index("_programmaticScroll = true;")
     restore_idx = body.index("container.scrollTop = oldTop + addedHeight")
-    clear_idx = body.index("requestAnimationFrame(()=>{ _programmaticScroll = false; })")
+    clear_idx = body.index(
+        "requestAnimationFrame(()=>{ _programmaticScroll = false; })"
+    )
     assert set_idx < restore_idx < clear_idx

--- a/tests/test_ollama_model_chip_label_regression.py
+++ b/tests/test_ollama_model_chip_label_regression.py
@@ -32,15 +32,23 @@ def test_select_model_custom_option_uses_friendly_label_helper():
 
 def test_get_model_label_formats_bare_ollama_ids():
     src = _read_ui()
-    assert "const looksLikeOllamaTag = /^[a-z0-9][\\w.-]*:[\\w.-]+$/i.test(_last);" in src
+    assert (
+        "const looksLikeOllamaTag = /^[a-z0-9][\\w.-]*:[\\w.-]+$/i.test(_last);" in src
+    )
     # Tightened heuristic: only apply Ollama formatter to IDs with @ollama prefix or colon-tag format,
     # avoiding reformatting of bare provider model IDs like claude-sonnet-4-6 or gpt-4o.
-    assert "const looksLikeBareOllamaId = modelId.startsWith('@ollama') || looksLikeOllamaTag;" in src, (
+    assert (
+        "const looksLikeBareOllamaId = modelId.startsWith('@ollama') || looksLikeOllamaTag;"
+        in src
+    ), (
         "looksLikeBareOllamaId must be restricted to @ollama-prefixed or colon-tagged IDs "
         "to avoid reformatting generic bare model IDs."
     )
     assert "const ollamaLabel = _fmtOllamaLabel(_last);" in src
-    assert "if ((modelId.startsWith('ollama/') || modelId.startsWith('@ollama') || looksLikeOllamaTag || looksLikeBareOllamaId) && ollamaLabel !== _last) {" in src, (
+    assert (
+        "if ((modelId.startsWith('ollama/') || modelId.startsWith('@ollama') || looksLikeOllamaTag || looksLikeBareOllamaId) && ollamaLabel !== _last) {"
+        in src
+    ), (
         "Ollama-tagged ids like 'kimi-k2.6:3b' should still pass through _fmtOllamaLabel() "
         "when the formatter produces a friendlier label."
     )
@@ -48,6 +56,6 @@ def test_get_model_label_formats_bare_ollama_ids():
 
 def test_fmt_ollama_label_preserves_dotted_acronyms():
     src = _read_ui()
-    assert "if (t.length <= 3 && /^[a-zA-Z.]+$/.test(t)) return t.toUpperCase();" in src, (
-        "JS Ollama formatter should preserve dotted acronyms like 'a.b' -> 'A.B'."
-    )
+    assert (
+        "if (t.length <= 3 && /^[a-zA-Z.]+$/.test(t)) return t.toUpperCase();" in src
+    ), "JS Ollama formatter should preserve dotted acronyms like 'a.b' -> 'A.B'."

--- a/tests/test_onboarding_existing_config.py
+++ b/tests/test_onboarding_existing_config.py
@@ -9,6 +9,7 @@ Covers:
   (c) apply_onboarding_setup refuses to overwrite an existing config without
       confirm_overwrite=True
 """
+
 from __future__ import annotations
 
 import json
@@ -23,19 +24,23 @@ import pytest
 # Skip tests that call apply_onboarding_setup → _save_yaml_config when PyYAML is missing
 try:
     import yaml as _yaml
+
     _HAS_YAML = True
 except ImportError:
     _HAS_YAML = False
-_needs_yaml = pytest.mark.skipif(not _HAS_YAML, reason="PyYAML not installed — onboarding setup tests require it")
+_needs_yaml = pytest.mark.skipif(
+    not _HAS_YAML, reason="PyYAML not installed — onboarding setup tests require it"
+)
 
 # ---------------------------------------------------------------------------
 # Unit tests — no live server needed, test logic directly via imports
 # ---------------------------------------------------------------------------
 
 
-def _make_status(*, config_exists: bool, chat_ready: bool, onboarding_done: bool = False):
+def _make_status(
+    *, config_exists: bool, chat_ready: bool, onboarding_done: bool = False
+):
     """Call get_onboarding_status() with a controlled filesystem + settings."""
-    import importlib
 
     # Import fresh copies each call so module-level state doesn't bleed across
     import api.onboarding as mod
@@ -107,7 +112,9 @@ class TestOnboardingGate:
 
     def test_onboarding_done_flag_always_respected(self):
         """If user already completed onboarding in settings, never show wizard."""
-        result = _make_status(config_exists=False, chat_ready=False, onboarding_done=True)
+        result = _make_status(
+            config_exists=False, chat_ready=False, onboarding_done=True
+        )
         assert result["completed"] is True
 
     def test_config_exists_always_exposed_in_system(self):
@@ -123,6 +130,7 @@ class TestOnboardingGate:
         signal so the user isn't blocked from using the UI.
         """
         import api.onboarding as mod
+
         settings = {"onboarding_completed": False}
         runtime = {
             "chat_ready": True,
@@ -140,7 +148,9 @@ class TestOnboardingGate:
         with (
             mock.patch.object(mod, "load_settings", return_value=settings),
             mock.patch.object(mod, "get_config", return_value={}),
-            mock.patch.object(mod, "verify_hermes_imports", return_value=(True, [], {})),
+            mock.patch.object(
+                mod, "verify_hermes_imports", return_value=(True, [], {})
+            ),
             mock.patch.object(mod, "_status_from_runtime", return_value=runtime),
             mock.patch.object(mod, "load_workspaces", return_value=[]),
             mock.patch.object(mod, "get_last_workspace", return_value=None),
@@ -205,7 +215,9 @@ class TestApplyOnboardingSetupGuard:
                 # Without patching Path.exists, use a non-existent path so it won't block.
                 # Also redirect _get_active_hermes_home so .env writes go to the temp dir,
                 # never to the real ~/.hermes/.env.
-                with mock.patch.object(mod, "_get_active_hermes_home", return_value=tmp_home_path):
+                with mock.patch.object(
+                    mod, "_get_active_hermes_home", return_value=tmp_home_path
+                ):
                     result = mod.apply_onboarding_setup(
                         {
                             "provider": "openrouter",
@@ -236,8 +248,12 @@ class TestApplyOnboardingSetupGuard:
                 # Redirect both config path and hermes home so writes stay in /tmp,
                 # never touching the real ~/.hermes/.env.
                 with (
-                    mock.patch.object(mod, "_get_config_path", return_value=fake_config_path),
-                    mock.patch.object(mod, "_get_active_hermes_home", return_value=tmp_home_path),
+                    mock.patch.object(
+                        mod, "_get_config_path", return_value=fake_config_path
+                    ),
+                    mock.patch.object(
+                        mod, "_get_active_hermes_home", return_value=tmp_home_path
+                    ),
                 ):
                     result = mod.apply_onboarding_setup(
                         {
@@ -282,7 +298,12 @@ def _server_hermes_home() -> pathlib.Path:
     env_path = data.get("system", {}).get("env_path", "")
     if env_path:
         return pathlib.Path(env_path).parent
-    return pathlib.Path(os.environ.get("HERMES_WEBUI_TEST_STATE_DIR", str(pathlib.Path.home() / ".hermes" / "webui-mvp-test")))
+    return pathlib.Path(
+        os.environ.get(
+            "HERMES_WEBUI_TEST_STATE_DIR",
+            str(pathlib.Path.home() / ".hermes" / "webui-mvp-test"),
+        )
+    )
 
 
 def _server_reachable() -> bool:
@@ -343,7 +364,12 @@ class TestOnboardingGateIntegration:
 
         hermes_home = _server_hermes_home()
         # Write a real config.yaml
-        cfg = {"model": {"provider": "openrouter", "default": "anthropic/claude-sonnet-4.6"}}
+        cfg = {
+            "model": {
+                "provider": "openrouter",
+                "default": "anthropic/claude-sonnet-4.6",
+            }
+        }
         (hermes_home / "config.yaml").write_text(
             yaml.safe_dump(cfg, sort_keys=False), encoding="utf-8"
         )
@@ -371,13 +397,19 @@ class TestOnboardingGateIntegration:
             (hermes_home / "config.yaml").unlink(missing_ok=True)
             (hermes_home / ".env").unlink(missing_ok=True)
             _http_post("/api/settings", {"onboarding_completed": False})
+
     @_needs_yaml
     def test_setup_blocked_for_existing_config(self):
         """POST /api/onboarding/setup must return config_exists error if config.yaml exists."""
         import yaml
 
         hermes_home = _server_hermes_home()
-        cfg = {"model": {"provider": "openrouter", "default": "anthropic/claude-sonnet-4.6"}}
+        cfg = {
+            "model": {
+                "provider": "openrouter",
+                "default": "anthropic/claude-sonnet-4.6",
+            }
+        }
         (hermes_home / "config.yaml").write_text(
             yaml.safe_dump(cfg, sort_keys=False), encoding="utf-8"
         )
@@ -402,7 +434,12 @@ class TestOnboardingGateIntegration:
         import yaml
 
         hermes_home = _server_hermes_home()
-        cfg = {"model": {"provider": "openrouter", "default": "anthropic/claude-sonnet-4.6"}}
+        cfg = {
+            "model": {
+                "provider": "openrouter",
+                "default": "anthropic/claude-sonnet-4.6",
+            }
+        }
         (hermes_home / "config.yaml").write_text(
             yaml.safe_dump(cfg, sort_keys=False), encoding="utf-8"
         )

--- a/tests/test_onboarding_mvp.py
+++ b/tests/test_onboarding_mvp.py
@@ -5,9 +5,9 @@ Python environment (the agent venv). They are skipped when hermes-agent is
 not installed, since the server falls back to system Python which typically
 lacks pyyaml.
 """
+
 import json
 import pathlib
-import sys
 import urllib.error
 import urllib.request
 
@@ -18,10 +18,13 @@ from tests._pytest_port import BASE
 # Check if pyyaml is available — onboarding setup tests need it on the server
 try:
     import yaml as _yaml
+
     _HAS_YAML = True
 except ImportError:
     _HAS_YAML = False
-_needs_yaml = pytest.mark.skipif(not _HAS_YAML, reason="PyYAML not installed — onboarding setup tests require it")
+_needs_yaml = pytest.mark.skipif(
+    not _HAS_YAML, reason="PyYAML not installed — onboarding setup tests require it"
+)
 
 
 def get(path):
@@ -67,7 +70,6 @@ def clean_hermes_config_files():
     yield
     for rel in ("config.yaml", ".env"):
         (hermes_home / rel).unlink(missing_ok=True)
-
 
 
 def test_onboarding_status_defaults_incomplete():
@@ -212,6 +214,7 @@ def test_onboarding_complete_preserves_other_settings():
     finally:
         # Always restore default send_key to avoid contaminating other tests
         post("/api/settings", {"send_key": "enter"})
+
 
 def test_onboarding_already_completed_status():
     """After marking onboarding complete, status must reflect completed=True

--- a/tests/test_onboarding_network.py
+++ b/tests/test_onboarding_network.py
@@ -14,9 +14,7 @@ Covers:
 """
 
 import json
-import os
 import pathlib
-import sys
 import unittest.mock
 import urllib.error
 import urllib.request
@@ -31,6 +29,7 @@ from tests._pytest_port import BASE
 # without needing a live server. We replicate the logic to keep tests fast
 # and independent of server startup.
 # ---------------------------------------------------------------------------
+
 
 def _is_local_from_handler(
     raw_ip: str,
@@ -112,7 +111,10 @@ class TestOnboardingIPLogic:
     def test_xff_takes_priority_over_xri(self):
         """X-Forwarded-For wins over X-Real-IP when both present."""
         # XFF says public, XRI says local → blocked (XFF takes priority)
-        assert _is_local_from_handler("172.20.0.1", xff="8.8.8.8", xri="127.0.0.1") is False
+        assert (
+            _is_local_from_handler("172.20.0.1", xff="8.8.8.8", xri="127.0.0.1")
+            is False
+        )
 
     def test_open_env_bypasses_check(self):
         """HERMES_WEBUI_ONBOARDING_OPEN=1 allows any IP."""
@@ -131,6 +133,7 @@ class TestOnboardingIPLogic:
 # Integration tests — hit the live test server at test server port
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.integration
 class TestOnboardingSetupEndpoint:
     """
@@ -138,7 +141,9 @@ class TestOnboardingSetupEndpoint:
     These require the test server running on test server port.
     """
 
-    def _post(self, path: str, data: dict, headers: dict | None = None) -> tuple[int, dict]:
+    def _post(
+        self, path: str, data: dict, headers: dict | None = None
+    ) -> tuple[int, dict]:
         payload = json.dumps(data).encode()
         req = urllib.request.Request(
             BASE + path,
@@ -160,25 +165,37 @@ class TestOnboardingSetupEndpoint:
         # The test server runs on 127.0.0.1:{TEST_PORT} so client_address[0] is 127.0.0.1.
         # A valid setup payload with a mock provider should not be rejected for IP reasons.
         # We patch apply_onboarding_setup to avoid actually writing any config.
-        import unittest.mock
-        with unittest.mock.patch("api.onboarding.apply_onboarding_setup", return_value={"ok": True}):
+        with unittest.mock.patch(
+            "api.onboarding.apply_onboarding_setup", return_value={"ok": True}
+        ):
             status, body = self._post(
                 "/api/onboarding/setup",
-                {"provider": "anthropic", "model": "claude-sonnet-4.6", "api_key": "test-key"},
+                {
+                    "provider": "anthropic",
+                    "model": "claude-sonnet-4.6",
+                    "api_key": "test-key",
+                },
             )
         # Should not be 403 (IP blocked). May be 200 or another error from apply logic.
-        assert status != 403, f"Got 403 — IP check incorrectly blocked loopback. Body: {body}"
+        assert status != 403, (
+            f"Got 403 — IP check incorrectly blocked loopback. Body: {body}"
+        )
 
     def test_xff_loopback_header_respected(self):
         """
         Simulated reverse proxy: raw TCP is 127.0.0.1 but X-Forwarded-For is also
         127.0.0.1. Should be allowed.
         """
-        import unittest.mock
-        with unittest.mock.patch("api.onboarding.apply_onboarding_setup", return_value={"ok": True}):
+        with unittest.mock.patch(
+            "api.onboarding.apply_onboarding_setup", return_value={"ok": True}
+        ):
             status, body = self._post(
                 "/api/onboarding/setup",
-                {"provider": "anthropic", "model": "claude-sonnet-4.6", "api_key": "test-key"},
+                {
+                    "provider": "anthropic",
+                    "model": "claude-sonnet-4.6",
+                    "api_key": "test-key",
+                },
                 headers={"X-Forwarded-For": "127.0.0.1"},
             )
         assert status != 403, f"Got 403 with XFF=127.0.0.1. Body: {body}"

--- a/tests/test_opencode_providers.py
+++ b/tests/test_opencode_providers.py
@@ -3,7 +3,7 @@ Tests for OpenCode Zen and OpenCode Go provider support.
 Verifies provider registration in display/model catalogs and
 env-var fallback detection.
 """
-import os
+
 import sys
 import types
 import pytest
@@ -25,6 +25,7 @@ def _isolate_models_cache():
 
 
 # ── Provider registration ─────────────────────────────────────────────
+
 
 def test_opencode_zen_in_provider_display():
     assert "opencode-zen" in config._PROVIDER_DISPLAY
@@ -65,6 +66,7 @@ def test_opencode_go_in_provider_models():
 
 # ── Env-var fallback detection ────────────────────────────────────────
 
+
 def _models_with_env_key(monkeypatch, env_var, expected_provider_display):
     """Helper: fake hermes_cli unavailable, set an env var, check detection."""
     # Force the env-var fallback path by making hermes_cli import fail
@@ -101,9 +103,15 @@ def test_openai_codex_model_catalog_includes_gpt54():
     assert "openai-codex" in config._PROVIDER_MODELS
     ids = [m["id"] for m in config._PROVIDER_MODELS["openai-codex"]]
     assert "gpt-5.4" in ids, f"gpt-5.4 missing from openai-codex catalog: {ids}"
-    assert "gpt-5.4-mini" in ids, f"gpt-5.4-mini missing from openai-codex catalog: {ids}"
-    assert "gpt-5.3-codex" in ids, f"gpt-5.3-codex missing from openai-codex catalog: {ids}"
-    assert "gpt-5.2-codex" in ids, f"gpt-5.2-codex missing from openai-codex catalog: {ids}"
+    assert "gpt-5.4-mini" in ids, (
+        f"gpt-5.4-mini missing from openai-codex catalog: {ids}"
+    )
+    assert "gpt-5.3-codex" in ids, (
+        f"gpt-5.3-codex missing from openai-codex catalog: {ids}"
+    )
+    assert "gpt-5.2-codex" in ids, (
+        f"gpt-5.2-codex missing from openai-codex catalog: {ids}"
+    )
 
 
 def test_openai_codex_display_name():
@@ -117,7 +125,10 @@ def test_live_models_handler_delegates_to_provider_model_ids():
     rather than maintain its own per-provider fetch logic.
     """
     import pathlib
-    routes_src = (pathlib.Path(__file__).parent.parent / "api" / "routes.py").read_text()
+
+    routes_src = (
+        pathlib.Path(__file__).parent.parent / "api" / "routes.py"
+    ).read_text()
     assert "provider_model_ids" in routes_src, (
         "_handle_live_models must call hermes_cli.models.provider_model_ids() "
         "to delegate all provider-specific live-fetch logic to the agent"
@@ -139,9 +150,13 @@ def test_live_models_ui_no_longer_skips_any_provider():
     handles them all (with graceful fallback to static lists).
     """
     import pathlib
+
     ui_src = (pathlib.Path(__file__).parent.parent / "static" / "ui.js").read_text()
     # The old exclusion list must be gone
-    assert "includes(provider)" not in ui_src or "anthropic" not in ui_src[:ui_src.find("includes(provider)")+100], (
+    assert (
+        "includes(provider)" not in ui_src
+        or "anthropic" not in ui_src[: ui_src.find("includes(provider)") + 100]
+    ), (
         "_fetchLiveModels must not skip anthropic, google, or gemini — "
         "the backend now returns live models for all providers"
     )

--- a/tests/test_orphaned_tool_messages.py
+++ b/tests/test_orphaned_tool_messages.py
@@ -4,6 +4,7 @@ Regression for issue #534: strictly-conformant providers (Mercury-2/Inception,
 newer OpenAI models) reject histories containing tool-role messages whose
 tool_call_id has no matching tool_calls entry in a prior assistant message.
 """
+
 import sys
 import pathlib
 
@@ -17,11 +18,18 @@ from api.streaming import _sanitize_messages_for_api
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _asst_with_tool_call(call_id="call-1", call_id_key="id"):
     return {
         "role": "assistant",
         "content": None,
-        "tool_calls": [{"type": "function", call_id_key: call_id, "function": {"name": "terminal", "arguments": "{}"}}],
+        "tool_calls": [
+            {
+                "type": "function",
+                call_id_key: call_id,
+                "function": {"name": "terminal", "arguments": "{}"},
+            }
+        ],
         "_ts": 12345,  # extra field that should be stripped
     }
 
@@ -41,6 +49,7 @@ def _asst(text="hi"):
 # ---------------------------------------------------------------------------
 # Tests: normal valid histories are preserved
 # ---------------------------------------------------------------------------
+
 
 def test_valid_tool_roundtrip_preserved():
     """A linked assistant→tool pair must be kept intact."""
@@ -72,8 +81,16 @@ def test_multiple_valid_tool_calls_preserved():
         "role": "assistant",
         "content": None,
         "tool_calls": [
-            {"type": "function", "id": "call-1", "function": {"name": "f1", "arguments": "{}"}},
-            {"type": "function", "id": "call-2", "function": {"name": "f2", "arguments": "{}"}},
+            {
+                "type": "function",
+                "id": "call-1",
+                "function": {"name": "f1", "arguments": "{}"},
+            },
+            {
+                "type": "function",
+                "id": "call-2",
+                "function": {"name": "f2", "arguments": "{}"},
+            },
         ],
     }
     msgs = [_user(), asst, _tool_result("call-1"), _tool_result("call-2"), _asst()]
@@ -85,6 +102,7 @@ def test_multiple_valid_tool_calls_preserved():
 # ---------------------------------------------------------------------------
 # Tests: orphaned tool messages are dropped
 # ---------------------------------------------------------------------------
+
 
 def test_orphaned_tool_message_dropped():
     """A tool message with no matching assistant tool_call is dropped."""
@@ -110,8 +128,8 @@ def test_partially_orphaned_tool_messages():
     msgs = [
         _user(),
         asst,
-        _tool_result("call-valid"),   # linked → kept
-        _tool_result("call-ghost"),   # orphaned → dropped
+        _tool_result("call-valid"),  # linked → kept
+        _tool_result("call-ghost"),  # orphaned → dropped
         _asst(),
     ]
     result = _sanitize_messages_for_api(msgs)
@@ -133,6 +151,7 @@ def test_orphaned_tool_only_history():
 # Tests: Anthropic 'call_id' field name (not OpenAI 'id')
 # ---------------------------------------------------------------------------
 
+
 def test_anthropic_call_id_field_recognized():
     """Anthropic tool calls use 'call_id' not 'id' — both must be recognized."""
     asst = _asst_with_tool_call("call-anthropic", call_id_key="call_id")
@@ -145,6 +164,7 @@ def test_anthropic_call_id_field_recognized():
 # ---------------------------------------------------------------------------
 # Tests: edge cases
 # ---------------------------------------------------------------------------
+
 
 def test_empty_messages_list():
     assert _sanitize_messages_for_api([]) == []

--- a/tests/test_parallel_session_switch.py
+++ b/tests/test_parallel_session_switch.py
@@ -157,7 +157,7 @@ class TestGitInfoParallel:
             f"Expected 3 parallel git calls, got {call_count['n']}"
         )
         assert started_times[-1] - started_times[0] < 0.15, (
-            f"Git commands started too far apart ({started_times[-1]-started_times[0]:.3f}s), "
+            f"Git commands started too far apart ({started_times[-1] - started_times[0]:.3f}s), "
             f"suggesting serial execution."
         )
 
@@ -360,7 +360,7 @@ class TestMessagePaginationBackend:
 
         reduction = 1 - len(tail_json) / len(all_json)
         assert reduction > 0.6, (
-            f"Expected >60% payload reduction, got {reduction*100:.0f}%."
+            f"Expected >60% payload reduction, got {reduction * 100:.0f}%."
         )
 
     def test_msg_before_bounds_clamping(self):
@@ -474,7 +474,10 @@ class TestSessionSwitchCancellation:
             "call returns to detect session-switch race conditions."
         )
         # The guard should be: if _loadingSessionId !== null && _loadingSessionId !== sid
-        assert "_loadingSessionId !== null" in fn_body or "_loadingSessionId!==null" in fn_body, (
+        assert (
+            "_loadingSessionId !== null" in fn_body
+            or "_loadingSessionId!==null" in fn_body
+        ), (
             "_loadOlderMessages should bail out if a new session load started "
             "while the older-messages request was in flight."
         )
@@ -555,9 +558,11 @@ class TestSessionSwitchCancellation:
         # The S.session check must appear BEFORE the S.messages mutation.
         active_check_idx = fn_body.find("S.session.session_id !== sid")
         mutation_idx = fn_body.find("S.messages = [...olderMsgs")
-        assert active_check_idx >= 0 and mutation_idx >= 0 and active_check_idx < mutation_idx, (
-            "Active-session guard must run before S.messages mutation."
-        )
+        assert (
+            active_check_idx >= 0
+            and mutation_idx >= 0
+            and active_check_idx < mutation_idx
+        ), "Active-session guard must run before S.messages mutation."
 
 
 # ── 6. Scroll position preservation ──────────────────────────────────────────
@@ -603,8 +608,15 @@ class TestScrollPositionPreservation:
             "render does not snap back to the newest output."
         )
         target_idx = fn_body.find("container.scrollTop = oldTop + addedHeight")
-        scroll_idx = fn_body.find("requestAnimationFrame(()=>{ _programmaticScroll = false; })")
+        scroll_idx = fn_body.find(
+            "requestAnimationFrame(()=>{ _programmaticScroll = false; })"
+        )
         pinned_idx = fn_body.rfind("_scrollPinned = false")
-        assert target_idx >= 0 and scroll_idx >= 0 and pinned_idx >= 0 and target_idx < scroll_idx < pinned_idx, (
+        assert (
+            target_idx >= 0
+            and scroll_idx >= 0
+            and pinned_idx >= 0
+            and target_idx < scroll_idx < pinned_idx
+        ), (
             "_scrollPinned = false must appear AFTER the older-history viewport-preserve scroll."
         )

--- a/tests/test_pdf_html_preview.py
+++ b/tests/test_pdf_html_preview.py
@@ -4,296 +4,344 @@ Validates that the MEDIA: restore block in ui.js produces the correct
 placeholder HTML for .pdf and .html files, that lazy-load functions exist,
 and that CSS classes are defined.
 """
+
 import os
 import re
-import pytest
 
 
 def _read_js(name):
-    with open(os.path.join('static', name)) as f:
+    with open(os.path.join("static", name)) as f:
         return f.read()
 
 
 def _read_css():
-    with open(os.path.join('static', 'style.css')) as f:
+    with open(os.path.join("static", "style.css")) as f:
         return f.read()
 
 
 # ── Extension regexes ──────────────────────────────────────────────────────
 
+
 class TestExtensionRegexes:
     """PDF and HTML extension regexes must be defined at module scope."""
 
     def test_pdf_exts_regex_exists(self):
-        ui = _read_js('ui.js')
-        assert '_PDF_EXTS' in ui, '_PDF_EXTS regex must be defined'
-        idx = ui.find('_PDF_EXTS')
-        assert '.pdf' in ui[idx:idx+100], '_PDF_EXTS must match .pdf extension'
+        ui = _read_js("ui.js")
+        assert "_PDF_EXTS" in ui, "_PDF_EXTS regex must be defined"
+        idx = ui.find("_PDF_EXTS")
+        assert ".pdf" in ui[idx : idx + 100], "_PDF_EXTS must match .pdf extension"
 
     def test_html_exts_regex_exists(self):
-        ui = _read_js('ui.js')
-        assert '_HTML_EXTS' in ui, '_HTML_EXTS regex must be defined'
-        idx = ui.find('_HTML_EXTS')
-        assert 'html' in ui[idx:idx+100], '_HTML_EXTS must match .html extension'
+        ui = _read_js("ui.js")
+        assert "_HTML_EXTS" in ui, "_HTML_EXTS regex must be defined"
+        idx = ui.find("_HTML_EXTS")
+        assert "html" in ui[idx : idx + 100], "_HTML_EXTS must match .html extension"
 
     def test_pdf_not_matched_by_image_exts(self):
         """PDF files must not be caught by _IMAGE_EXTS."""
-        ui = _read_js('ui.js')
-        m = re.search(r'const _IMAGE_EXTS=/(.+?)/[a-z]*;', ui)
+        ui = _read_js("ui.js")
+        m = re.search(r"const _IMAGE_EXTS=/(.+?)/[a-z]*;", ui)
         assert m
         pattern = m.group(1)
-        assert 'pdf' not in pattern, 'PDF must not be in _IMAGE_EXTS (would render as broken <img>)'
+        assert "pdf" not in pattern, (
+            "PDF must not be in _IMAGE_EXTS (would render as broken <img>)"
+        )
 
     def test_html_not_matched_by_image_exts(self):
         """HTML files must not be caught by _IMAGE_EXTS."""
-        ui = _read_js('ui.js')
-        m = re.search(r'const _IMAGE_EXTS=/(.+?)/[a-z]*;', ui)
+        ui = _read_js("ui.js")
+        m = re.search(r"const _IMAGE_EXTS=/(.+?)/[a-z]*;", ui)
         assert m
         pattern = m.group(1)
-        assert 'html' not in pattern, 'HTML must not be in _IMAGE_EXTS'
+        assert "html" not in pattern, "HTML must not be in _IMAGE_EXTS"
 
 
 # ── MEDIA: placeholder HTML ────────────────────────────────────────────────
+
 
 class TestPdfMediaPlaceholder:
     """PDF files in MEDIA: tokens must produce a lazy-load placeholder div."""
 
     def test_pdf_media_produces_placeholder_div(self):
-        ui = _read_js('ui.js')
-        m = re.search(r'_PDF_EXTS\.test\(ref\)', ui)
-        assert m, 'MEDIA restore must check _PDF_EXTS for PDF files'
-        body = ui[m.start():m.start() + 300]
-        assert 'pdf-preview-load' in body, 'PDF MEDIA must produce .pdf-preview-load placeholder'
-        assert 'data-path' in body, 'PDF placeholder must include data-path attribute'
+        ui = _read_js("ui.js")
+        m = re.search(r"_PDF_EXTS\.test\(ref\)", ui)
+        assert m, "MEDIA restore must check _PDF_EXTS for PDF files"
+        body = ui[m.start() : m.start() + 300]
+        assert "pdf-preview-load" in body, (
+            "PDF MEDIA must produce .pdf-preview-load placeholder"
+        )
+        assert "data-path" in body, "PDF placeholder must include data-path attribute"
 
     def test_pdf_media_uses_i18n_loading_key(self):
-        ui = _read_js('ui.js')
-        m = re.search(r'_PDF_EXTS\.test\(ref\)', ui)
-        body = ui[m.start():m.start() + 300]
-        assert 'pdf_loading' in body, 'PDF placeholder must use pdf_loading i18n key'
+        ui = _read_js("ui.js")
+        m = re.search(r"_PDF_EXTS\.test\(ref\)", ui)
+        body = ui[m.start() : m.start() + 300]
+        assert "pdf_loading" in body, "PDF placeholder must use pdf_loading i18n key"
 
 
 class TestHtmlMediaPlaceholder:
     """HTML files in MEDIA: tokens must produce a lazy-load placeholder div."""
 
     def test_html_media_produces_placeholder_div(self):
-        ui = _read_js('ui.js')
-        m = re.search(r'_HTML_EXTS\.test\(ref\)', ui)
-        assert m, 'MEDIA restore must check _HTML_EXTS for HTML files'
-        body = ui[m.start():m.start() + 300]
-        assert 'html-preview-load' in body, 'HTML MEDIA must produce .html-preview-load placeholder'
-        assert 'data-path' in body, 'HTML placeholder must include data-path attribute'
+        ui = _read_js("ui.js")
+        m = re.search(r"_HTML_EXTS\.test\(ref\)", ui)
+        assert m, "MEDIA restore must check _HTML_EXTS for HTML files"
+        body = ui[m.start() : m.start() + 300]
+        assert "html-preview-load" in body, (
+            "HTML MEDIA must produce .html-preview-load placeholder"
+        )
+        assert "data-path" in body, "HTML placeholder must include data-path attribute"
 
     def test_html_media_uses_i18n_loading_key(self):
-        ui = _read_js('ui.js')
-        m = re.search(r'_HTML_EXTS\.test\(ref\)', ui)
-        body = ui[m.start():m.start() + 300]
-        assert 'html_loading' in body, 'HTML placeholder must use html_loading i18n key'
+        ui = _read_js("ui.js")
+        m = re.search(r"_HTML_EXTS\.test\(ref\)", ui)
+        body = ui[m.start() : m.start() + 300]
+        assert "html_loading" in body, "HTML placeholder must use html_loading i18n key"
 
     def test_html_iframe_has_sandbox_attribute(self):
         """HTML preview iframe must use sandbox attribute for security."""
-        ui = _read_js('ui.js')
-        assert 'sandbox=' in ui, 'loadHtmlInline must set sandbox attribute on iframe'
-        assert 'allow-scripts' in ui, 'sandbox must include allow-scripts for interactive content'
+        ui = _read_js("ui.js")
+        assert "sandbox=" in ui, "loadHtmlInline must set sandbox attribute on iframe"
+        assert "allow-scripts" in ui, (
+            "sandbox must include allow-scripts for interactive content"
+        )
 
 
 # ── Lazy-load functions ────────────────────────────────────────────────────
+
 
 class TestLoadPdfInlineFunction:
     """loadPdfInline() must exist and follow the same pattern as loadDiffInline()."""
 
     def test_function_exists(self):
-        ui = _read_js('ui.js')
-        assert 'function loadPdfInline()' in ui, 'loadPdfInline() function must exist'
+        ui = _read_js("ui.js")
+        assert "function loadPdfInline()" in ui, "loadPdfInline() function must exist"
 
     def test_selects_pdf_preview_load_elements(self):
-        ui = _read_js('ui.js')
-        idx = ui.find('function loadPdfInline()')
-        body = ui[idx:idx + 500]
-        assert 'pdf-preview-load' in body, 'Must query .pdf-preview-load elements'
-        assert 'data-loaded' in body, 'Must use data-loaded attribute to prevent double-processing'
+        ui = _read_js("ui.js")
+        idx = ui.find("function loadPdfInline()")
+        body = ui[idx : idx + 500]
+        assert "pdf-preview-load" in body, "Must query .pdf-preview-load elements"
+        assert "data-loaded" in body, (
+            "Must use data-loaded attribute to prevent double-processing"
+        )
 
     def test_fetches_via_api_media(self):
-        ui = _read_js('ui.js')
-        idx = ui.find('function loadPdfInline()')
-        body = ui[idx:idx + 1500]
-        assert 'api/media?path=' in body, 'Must fetch PDF via api/media endpoint'
+        ui = _read_js("ui.js")
+        idx = ui.find("function loadPdfInline()")
+        body = ui[idx : idx + 1500]
+        assert "api/media?path=" in body, "Must fetch PDF via api/media endpoint"
 
     def test_has_size_cap(self):
-        ui = _read_js('ui.js')
-        idx = ui.find('function loadPdfInline()')
-        body = ui[idx:idx + 1500]
-        assert 'MAX_SIZE' in body or 'byteLength' in body, 'Must enforce a size cap on PDF files'
+        ui = _read_js("ui.js")
+        idx = ui.find("function loadPdfInline()")
+        body = ui[idx : idx + 1500]
+        assert "MAX_SIZE" in body or "byteLength" in body, (
+            "Must enforce a size cap on PDF files"
+        )
 
     def test_fallback_on_error(self):
-        ui = _read_js('ui.js')
-        idx = ui.find('function loadPdfInline()')
-        body = ui[idx:idx + 3000]
-        assert 'pdf_error' in body, 'Must show error fallback on failure'
-        assert 'pdf_download' in body or 'download=' in body, 'Error fallback must include download link'
+        ui = _read_js("ui.js")
+        idx = ui.find("function loadPdfInline()")
+        body = ui[idx : idx + 3000]
+        assert "pdf_error" in body, "Must show error fallback on failure"
+        assert "pdf_download" in body or "download=" in body, (
+            "Error fallback must include download link"
+        )
 
     def test_lazy_loads_pdfjs_from_cdn(self):
-        ui = _read_js('ui.js')
-        idx = ui.find('function loadPdfInline()')
-        body = ui[idx:idx + 3000]
-        assert 'pdfjs' in body, 'Must lazy-load PDF.js from CDN'
+        ui = _read_js("ui.js")
+        idx = ui.find("function loadPdfInline()")
+        body = ui[idx : idx + 3000]
+        assert "pdfjs" in body, "Must lazy-load PDF.js from CDN"
 
     def test_pdfjs_state_variables(self):
-        ui = _read_js('ui.js')
-        assert '_pdfjsReady' in ui, '_pdfjsReady state variable must exist'
-        assert '_pdfjsLoading' in ui, '_pdfjsLoading state variable must exist'
+        ui = _read_js("ui.js")
+        assert "_pdfjsReady" in ui, "_pdfjsReady state variable must exist"
+        assert "_pdfjsLoading" in ui, "_pdfjsLoading state variable must exist"
 
 
 class TestLoadHtmlInlineFunction:
     """loadHtmlInline() must exist and render HTML in a sandboxed iframe."""
 
     def test_function_exists(self):
-        ui = _read_js('ui.js')
-        assert 'function loadHtmlInline()' in ui, 'loadHtmlInline() function must exist'
+        ui = _read_js("ui.js")
+        assert "function loadHtmlInline()" in ui, "loadHtmlInline() function must exist"
 
     def test_selects_html_preview_load_elements(self):
-        ui = _read_js('ui.js')
-        idx = ui.find('function loadHtmlInline()')
-        body = ui[idx:idx + 500]
-        assert 'html-preview-load' in body, 'Must query .html-preview-load elements'
-        assert 'data-loaded' in body, 'Must use data-loaded attribute'
+        ui = _read_js("ui.js")
+        idx = ui.find("function loadHtmlInline()")
+        body = ui[idx : idx + 500]
+        assert "html-preview-load" in body, "Must query .html-preview-load elements"
+        assert "data-loaded" in body, "Must use data-loaded attribute"
 
     def test_fetches_via_api_media(self):
-        ui = _read_js('ui.js')
-        idx = ui.find('function loadHtmlInline()')
-        body = ui[idx:idx + 1000]
-        assert 'api/media?path=' in body, 'Must fetch HTML via api/media endpoint'
+        ui = _read_js("ui.js")
+        idx = ui.find("function loadHtmlInline()")
+        body = ui[idx : idx + 1000]
+        assert "api/media?path=" in body, "Must fetch HTML via api/media endpoint"
 
     def test_has_size_cap(self):
-        ui = _read_js('ui.js')
-        idx = ui.find('function loadHtmlInline()')
-        body = ui[idx:idx + 1000]
-        assert 'MAX_SIZE' in body or 'html.length' in body, 'Must enforce a size cap on HTML files'
+        ui = _read_js("ui.js")
+        idx = ui.find("function loadHtmlInline()")
+        body = ui[idx : idx + 1000]
+        assert "MAX_SIZE" in body or "html.length" in body, (
+            "Must enforce a size cap on HTML files"
+        )
 
     def test_fallback_on_error(self):
-        ui = _read_js('ui.js')
-        idx = ui.find('function loadHtmlInline()')
-        body = ui[idx:idx + 2000]
-        assert 'html_error' in body, 'Must show error fallback on failure'
+        ui = _read_js("ui.js")
+        idx = ui.find("function loadHtmlInline()")
+        body = ui[idx : idx + 2000]
+        assert "html_error" in body, "Must show error fallback on failure"
 
     def test_uses_srcdoc_attribute(self):
         """Must use srcdoc (not src) for HTML content to keep it same-origin sandboxed."""
-        ui = _read_js('ui.js')
-        idx = ui.find('function loadHtmlInline()')
-        body = ui[idx:idx + 1500]
-        assert 'srcdoc=' in body, 'Must use srcdoc attribute for inline HTML rendering'
+        ui = _read_js("ui.js")
+        idx = ui.find("function loadHtmlInline()")
+        body = ui[idx : idx + 1500]
+        assert "srcdoc=" in body, "Must use srcdoc attribute for inline HTML rendering"
 
     def test_escapes_html_for_srcdoc(self):
         """HTML content must be escaped before embedding in srcdoc to prevent attribute injection."""
-        ui = _read_js('ui.js')
-        idx = ui.find('function loadHtmlInline()')
-        body = ui[idx:idx + 1500]
+        ui = _read_js("ui.js")
+        idx = ui.find("function loadHtmlInline()")
+        body = ui[idx : idx + 1500]
         # Must escape &, <, >, " to prevent breaking out of srcdoc attribute
-        assert '&amp;' in body or 'replace' in body, 'Must escape HTML entities for srcdoc'
+        assert "&amp;" in body or "replace" in body, (
+            "Must escape HTML entities for srcdoc"
+        )
 
 
 # ── requestAnimationFrame integration ──────────────────────────────────────
+
 
 class TestRAFIntegration:
     """Both lazy-load functions must be called in the requestAnimationFrame blocks."""
 
     def test_loadPdfInline_called_after_render(self):
-        ui = _read_js('ui.js')
-        raf_blocks = re.findall(r'requestAnimationFrame\(\(\)=>\{[^}]+\}\)', ui)
-        load_blocks = [b for b in raf_blocks if 'loadDiffInline' in b]
-        assert len(load_blocks) >= 2, 'Expected at least 2 rAF blocks with loadDiffInline'
+        ui = _read_js("ui.js")
+        raf_blocks = re.findall(r"requestAnimationFrame\(\(\)=>\{[^}]+\}\)", ui)
+        load_blocks = [b for b in raf_blocks if "loadDiffInline" in b]
+        assert len(load_blocks) >= 2, (
+            "Expected at least 2 rAF blocks with loadDiffInline"
+        )
         for block in load_blocks:
-            assert 'loadPdfInline()' in block, 'loadPdfInline() must be called alongside loadDiffInline'
+            assert "loadPdfInline()" in block, (
+                "loadPdfInline() must be called alongside loadDiffInline"
+            )
 
     def test_loadHtmlInline_called_after_render(self):
-        ui = _read_js('ui.js')
-        raf_blocks = re.findall(r'requestAnimationFrame\(\(\)=>\{[^}]+\}\)', ui)
-        load_blocks = [b for b in raf_blocks if 'loadDiffInline' in b]
+        ui = _read_js("ui.js")
+        raf_blocks = re.findall(r"requestAnimationFrame\(\(\)=>\{[^}]+\}\)", ui)
+        load_blocks = [b for b in raf_blocks if "loadDiffInline" in b]
         for block in load_blocks:
-            assert 'loadHtmlInline()' in block, 'loadHtmlInline() must be called alongside loadDiffInline'
+            assert "loadHtmlInline()" in block, (
+                "loadHtmlInline() must be called alongside loadDiffInline"
+            )
 
     def test_initTreeViews_blocks_also_call_loaders(self):
         """rAF blocks with initTreeViews (not loadDiffInline) must also call PDF/HTML loaders."""
-        ui = _read_js('ui.js')
-        raf_blocks = re.findall(r'requestAnimationFrame\(\(\)=>\{[^}]+\}\)', ui)
-        tree_blocks = [b for b in raf_blocks if 'initTreeViews' in b and 'loadDiffInline' not in b]
+        ui = _read_js("ui.js")
+        raf_blocks = re.findall(r"requestAnimationFrame\(\(\)=>\{[^}]+\}\)", ui)
+        tree_blocks = [
+            b for b in raf_blocks if "initTreeViews" in b and "loadDiffInline" not in b
+        ]
         for block in tree_blocks:
-            assert 'loadPdfInline()' in block, 'initTreeViews rAF block must also call loadPdfInline'
-            assert 'loadHtmlInline()' in block, 'initTreeViews rAF block must also call loadHtmlInline'
+            assert "loadPdfInline()" in block, (
+                "initTreeViews rAF block must also call loadPdfInline"
+            )
+            assert "loadHtmlInline()" in block, (
+                "initTreeViews rAF block must also call loadHtmlInline"
+            )
 
 
 # ── CSS classes ────────────────────────────────────────────────────────────
+
 
 class TestCSSClasses:
     """CSS must define styles for PDF and HTML preview components."""
 
     def test_pdf_preview_wrap(self):
         css = _read_css()
-        assert '.pdf-preview-wrap' in css
+        assert ".pdf-preview-wrap" in css
 
     def test_pdf_preview_header(self):
         css = _read_css()
-        assert '.pdf-preview-header' in css
+        assert ".pdf-preview-header" in css
 
     def test_pdf_preview_body(self):
         css = _read_css()
-        assert '.pdf-preview-body' in css
+        assert ".pdf-preview-body" in css
 
     def test_pdf_preview_canvas(self):
         css = _read_css()
-        assert '.pdf-preview-canvas' in css
+        assert ".pdf-preview-canvas" in css
 
     def test_pdf_preview_fallback(self):
         css = _read_css()
-        assert '.pdf-preview-fallback' in css
+        assert ".pdf-preview-fallback" in css
 
     def test_pdf_download_link(self):
         css = _read_css()
         # pdf-download-link class used in JS; styled via header a selector
-        assert '.pdf-download-link' in css or '.pdf-preview-header a' in css
+        assert ".pdf-download-link" in css or ".pdf-preview-header a" in css
 
     def test_html_preview_wrap(self):
         css = _read_css()
-        assert '.html-preview-wrap' in css
+        assert ".html-preview-wrap" in css
 
     def test_html_preview_header(self):
         css = _read_css()
-        assert '.html-preview-header' in css
+        assert ".html-preview-header" in css
 
     def test_html_preview_iframe(self):
         css = _read_css()
-        assert '.html-preview-iframe' in css
+        assert ".html-preview-iframe" in css
 
     def test_html_preview_fallback(self):
         css = _read_css()
-        assert '.html-preview-fallback' in css
+        assert ".html-preview-fallback" in css
 
     def test_html_iframe_has_fixed_height(self):
         """HTML iframe must have a fixed height to prevent overflow."""
         css = _read_css()
-        m = re.search(r'\.html-preview-iframe\{[^}]+\}', css)
-        assert m, '.html-preview-iframe rule must exist'
-        assert 'height' in m.group(), 'HTML iframe must have a height constraint'
+        m = re.search(r"\.html-preview-iframe\{[^}]+\}", css)
+        assert m, ".html-preview-iframe rule must exist"
+        assert "height" in m.group(), "HTML iframe must have a height constraint"
 
 
 # ── i18n keys ──────────────────────────────────────────────────────────────
 
+
 class TestI18nKeys:
     """All required i18n keys must exist in the en locale."""
 
-    PDF_KEYS = ['pdf_loading', 'pdf_too_large', 'pdf_no_pages', 'pdf_error', 'pdf_download']
-    HTML_KEYS = ['html_loading', 'html_too_large', 'html_error', 'html_open_full', 'html_sandbox_label']
+    PDF_KEYS = [
+        "pdf_loading",
+        "pdf_too_large",
+        "pdf_no_pages",
+        "pdf_error",
+        "pdf_download",
+    ]
+    HTML_KEYS = [
+        "html_loading",
+        "html_too_large",
+        "html_error",
+        "html_open_full",
+        "html_sandbox_label",
+    ]
 
     def _find_locale_block(self, locale):
-        with open('static/i18n.js') as f:
+        with open("static/i18n.js") as f:
             content = f.read()
         start = content.find(f"'{locale}':")
         if start < 0:
-            start = content.find(f'{locale}:')
+            start = content.find(f"{locale}:")
         if start < 0:
-            return ''
+            return ""
         # Find end by scanning for next top-level locale
-        locales = ['en', 'ru', 'es', 'de', 'zh', 'zh-Hant', 'ko']
+        locales = ["en", "ru", "es", "de", "zh", "zh-Hant", "ko"]
         end = len(content)
         for loc in locales:
             if loc == locale:
@@ -304,26 +352,26 @@ class TestI18nKeys:
         return content[start:end]
 
     def test_pdf_keys_in_en(self):
-        block = self._find_locale_block('en')
+        block = self._find_locale_block("en")
         for key in self.PDF_KEYS:
-            assert f'{key}:' in block, f'en locale must have key {key}'
+            assert f"{key}:" in block, f"en locale must have key {key}"
 
     def test_html_keys_in_en(self):
-        block = self._find_locale_block('en')
+        block = self._find_locale_block("en")
         for key in self.HTML_KEYS:
-            assert f'{key}:' in block, f'en locale must have key {key}'
+            assert f"{key}:" in block, f"en locale must have key {key}"
 
     def test_pdf_keys_in_all_locales(self):
-        for loc in ['ru', 'es', 'de', 'zh', 'zh-Hant', 'ko']:
+        for loc in ["ru", "es", "de", "zh", "zh-Hant", "ko"]:
             block = self._find_locale_block(loc)
-            missing = [k for k in self.PDF_KEYS if f'{k}:' not in block]
-            assert not missing, f'{loc} locale missing PDF keys: {missing}'
+            missing = [k for k in self.PDF_KEYS if f"{k}:" not in block]
+            assert not missing, f"{loc} locale missing PDF keys: {missing}"
 
     def test_html_keys_in_all_locales(self):
-        for loc in ['ru', 'es', 'de', 'zh', 'zh-Hant', 'ko']:
+        for loc in ["ru", "es", "de", "zh", "zh-Hant", "ko"]:
             block = self._find_locale_block(loc)
-            missing = [k for k in self.HTML_KEYS if f'{k}:' not in block]
-            assert not missing, f'{loc} locale missing HTML keys: {missing}'
+            missing = [k for k in self.HTML_KEYS if f"{k}:" not in block]
+            assert not missing, f"{loc} locale missing HTML keys: {missing}"
 
 
 class TestPdfCanvasAttachmentNotSerialized:
@@ -337,23 +385,23 @@ class TestPdfCanvasAttachmentNotSerialized:
     """
 
     def _pdf_block(self):
-        ui = _read_js('ui.js')
-        start = ui.find('// ── PDF inline preview')
-        end = ui.find('// ── HTML inline preview', start)
-        assert start != -1 and end != -1, 'PDF preview block not found in ui.js'
+        ui = _read_js("ui.js")
+        start = ui.find("// ── PDF inline preview")
+        end = ui.find("// ── HTML inline preview", start)
+        assert start != -1 and end != -1, "PDF preview block not found in ui.js"
         return ui[start:end]
 
     def test_pdf_does_not_serialize_canvas_via_outerhtml(self):
         block = self._pdf_block()
-        assert '${canvas.outerHTML}' not in block, (
-            'canvas.outerHTML loses the rendered bitmap when interpolated; '
-            'attach the canvas via appendChild or replaceWith instead'
+        assert "${canvas.outerHTML}" not in block, (
+            "canvas.outerHTML loses the rendered bitmap when interpolated; "
+            "attach the canvas via appendChild or replaceWith instead"
         )
 
     def test_pdf_attaches_canvas_as_dom_node(self):
         block = self._pdf_block()
-        attaches_dom = 'appendChild(canvas)' in block or '.replaceWith(' in block
+        attaches_dom = "appendChild(canvas)" in block or ".replaceWith(" in block
         assert attaches_dom, (
-            'PDF preview must attach the rendered canvas as a DOM node '
-            '(appendChild / replaceWith), not interpolate it as a string'
+            "PDF preview must attach the rendered canvas as a DOM node "
+            "(appendChild / replaceWith), not interpolate it as a string"
         )

--- a/tests/test_plugins_panel.py
+++ b/tests/test_plugins_panel.py
@@ -6,11 +6,14 @@ from urllib.parse import urlparse
 
 def read(path: str) -> str:
     from pathlib import Path
+
     return Path(path).read_text(encoding="utf-8")
 
 
 class _FakeManifest:
-    def __init__(self, *, name, key, version="", description="", provides_hooks=None, path=None):
+    def __init__(
+        self, *, name, key, version="", description="", provides_hooks=None, path=None
+    ):
         self.name = name
         self.key = key
         self.version = version
@@ -41,6 +44,7 @@ class _FakePluginManager:
 class TestPluginsApi:
     def _capture_plugins_response(self, manager):
         import api.routes as routes
+
         captured = {}
 
         def fake_j(handler, payload, status=200, extra_headers=None):
@@ -49,8 +53,12 @@ class TestPluginsApi:
             return True
 
         handler = MagicMock()
-        with patch("api.routes.j", side_effect=fake_j), \
-             patch("api.routes._get_plugin_manager_for_visibility", return_value=manager):
+        with (
+            patch("api.routes.j", side_effect=fake_j),
+            patch(
+                "api.routes._get_plugin_manager_for_visibility", return_value=manager
+            ),
+        ):
             handled = routes.handle_get(handler, urlparse("/api/plugins"))
 
         assert handled is True
@@ -58,19 +66,21 @@ class TestPluginsApi:
         return captured["payload"]
 
     def test_api_plugins_exposes_sanitized_metadata_and_hook_names(self):
-        manager = _FakePluginManager({
-            "guard": _FakeLoadedPlugin(
-                _FakeManifest(
-                    name="guard",
-                    key="guard",
-                    version="1.2.3",
-                    description="Blocks unsafe tool calls",
-                    path="/home/michael/.hermes/plugins/guard",
-                ),
-                enabled=True,
-                hooks_registered=["pre_tool_call", "post_tool_call"],
-            )
-        })
+        manager = _FakePluginManager(
+            {
+                "guard": _FakeLoadedPlugin(
+                    _FakeManifest(
+                        name="guard",
+                        key="guard",
+                        version="1.2.3",
+                        description="Blocks unsafe tool calls",
+                        path="/home/michael/.hermes/plugins/guard",
+                    ),
+                    enabled=True,
+                    hooks_registered=["pre_tool_call", "post_tool_call"],
+                )
+            }
+        )
 
         payload = self._capture_plugins_response(manager)
 
@@ -80,14 +90,16 @@ class TestPluginsApi:
             "pre_llm_call",
             "post_llm_call",
         ]
-        assert payload["plugins"] == [{
-            "name": "guard",
-            "key": "guard",
-            "version": "1.2.3",
-            "description": "Blocks unsafe tool calls",
-            "enabled": True,
-            "hooks": ["pre_tool_call", "post_tool_call"],
-        }]
+        assert payload["plugins"] == [
+            {
+                "name": "guard",
+                "key": "guard",
+                "version": "1.2.3",
+                "description": "Blocks unsafe tool calls",
+                "enabled": True,
+                "hooks": ["pre_tool_call", "post_tool_call"],
+            }
+        ]
         serialized = repr(payload)
         assert "/home/michael" not in serialized
         assert "callback" not in serialized.lower()
@@ -108,20 +120,30 @@ class TestPluginsApi:
         ]
 
     def test_api_plugins_filters_non_visibility_hooks_and_manifest_paths(self):
-        manager = _FakePluginManager({
-            "mixed": _FakeLoadedPlugin(
-                _FakeManifest(
-                    name="mixed",
-                    key="mixed",
-                    version="0.1",
-                    description="Mixed hooks",
-                    provides_hooks=["/tmp/not-a-hook", "pre_llm_call", "on_session_end"],
-                    path="/secret/plugin.py",
-                ),
-                enabled=False,
-                hooks_registered=["post_llm_call", "pre_gateway_dispatch", "post_llm_call"],
-            )
-        })
+        manager = _FakePluginManager(
+            {
+                "mixed": _FakeLoadedPlugin(
+                    _FakeManifest(
+                        name="mixed",
+                        key="mixed",
+                        version="0.1",
+                        description="Mixed hooks",
+                        provides_hooks=[
+                            "/tmp/not-a-hook",
+                            "pre_llm_call",
+                            "on_session_end",
+                        ],
+                        path="/secret/plugin.py",
+                    ),
+                    enabled=False,
+                    hooks_registered=[
+                        "post_llm_call",
+                        "pre_gateway_dispatch",
+                        "post_llm_call",
+                    ],
+                )
+            }
+        )
 
         payload = self._capture_plugins_response(manager)
 
@@ -156,6 +178,8 @@ class TestPluginsSettingsUi:
         assert "_buildPluginCard" in js
         assert "plugin-hook-badge" in js
         assert "esc(plugin.description" in js
-        segment = js[js.find("function _buildPluginCard"):js.find("// ── Providers panel")]
+        segment = js[
+            js.find("function _buildPluginCard") : js.find("// ── Providers panel")
+        ]
         assert ".path" not in segment
         assert ".callback" not in segment

--- a/tests/test_pr1318_context_length_fallback.py
+++ b/tests/test_pr1318_context_length_fallback.py
@@ -17,7 +17,7 @@ Tests:
 4. Fallback exception is silently swallowed (older agent builds)
 5. Fallback runs before s.save() so the value is persisted
 """
-import re
+
 from pathlib import Path
 
 STREAMING = Path(__file__).resolve().parent.parent / "api" / "streaming.py"
@@ -73,7 +73,7 @@ def test_fallback_exception_is_swallowed():
     bad provider config), the fallback must not break s.save()."""
     block = _persistence_block()
     # Must wrap the import + call in try/except
-    fallback_section = block[block.find("Fallback"):]
+    fallback_section = block[block.find("Fallback") :]
     assert "try:" in fallback_section, "Fallback must use try/except"
     # except Exception: pass-style — old agent builds may not have this helper at all
     assert "except Exception:" in fallback_section, (
@@ -96,7 +96,7 @@ def test_fallback_runs_before_save():
 def test_fallback_assigns_context_length_when_resolved():
     """The fallback must assign s.context_length when get_model_context_length returns a non-zero value."""
     block = _persistence_block()
-    fallback_section = block[block.find("Fallback"):]
+    fallback_section = block[block.find("Fallback") :]
     # Must have an `if _resolved_cl:` guard followed by `s.context_length = _resolved_cl`
     assert "_resolved_cl" in fallback_section, "Fallback must capture the result"
     assert "s.context_length = _resolved_cl" in fallback_section, (

--- a/tests/test_pr1339_fallback_providers_list.py
+++ b/tests/test_pr1339_fallback_providers_list.py
@@ -8,7 +8,7 @@ which would raise `AttributeError: 'list' object has no attribute 'get'`.
 The fix makes streaming.py handle both legacy dict form and new list form, picking
 the first entry from the list when given a list.
 """
-import re
+
 from pathlib import Path
 
 STREAMING_PY = Path(__file__).resolve().parent.parent / "api" / "streaming.py"
@@ -30,7 +30,9 @@ def test_fallback_handles_both_dict_and_list_config():
     block = _extract_fallback_block()
 
     # Both keys must be consulted
-    assert "fallback_model" in block, "Must still support legacy single-dict fallback_model"
+    assert "fallback_model" in block, (
+        "Must still support legacy single-dict fallback_model"
+    )
     assert "fallback_providers" in block, (
         "Must support new list-form fallback_providers (PR #1339)"
     )
@@ -44,9 +46,9 @@ def test_fallback_list_iteration_picks_first_valid_entry():
     assert "isinstance(_fallback, list)" in block, (
         "Must detect list-form fallback_providers explicitly to avoid AttributeError"
     )
-    assert "isinstance(_fallback, dict)" in block or "isinstance(_fallback,dict)" in block, (
-        "Must keep legacy single-dict path explicitly"
-    )
+    assert (
+        "isinstance(_fallback, dict)" in block or "isinstance(_fallback,dict)" in block
+    ), "Must keep legacy single-dict path explicitly"
 
     # No bare _fallback.get() — every .get() on _fallback must be guarded by an isinstance(_fallback, dict) check.
     # We verify this structurally: every line containing `_fallback.get(` must be inside or preceded by an isinstance(_fallback, dict) gate.
@@ -57,7 +59,7 @@ def test_fallback_list_iteration_picks_first_valid_entry():
             in_dict_block = True
         if "_fallback.get(" in line and not in_dict_block:
             # Look back up to 3 lines for the isinstance gate on the same elif/if
-            window = "\n".join(lines[max(0, i - 3): i + 1])
+            window = "\n".join(lines[max(0, i - 3) : i + 1])
             assert "isinstance(_fallback, dict)" in window, (
                 f"Line {i} calls _fallback.get() without a nearby isinstance(_fallback, dict) gate:\n{line}"
             )

--- a/tests/test_pr1341_context_window_persistence.py
+++ b/tests/test_pr1341_context_window_persistence.py
@@ -16,6 +16,7 @@ This test verifies that:
 Implementation reference: api/streaming.py around line 2188 (the per-turn
 post-merge save) writes from getattr(agent, 'context_compressor', None).
 """
+
 import re
 from pathlib import Path
 
@@ -76,7 +77,9 @@ def test_session_init_accepts_context_fields():
     sig = init_match.group(1)
     assert "context_length" in sig, "Session.__init__ must accept context_length"
     assert "threshold_tokens" in sig, "Session.__init__ must accept threshold_tokens"
-    assert "last_prompt_tokens" in sig, "Session.__init__ must accept last_prompt_tokens"
+    assert "last_prompt_tokens" in sig, (
+        "Session.__init__ must accept last_prompt_tokens"
+    )
 
 
 def test_session_metadata_fields_includes_context_fields():
@@ -91,8 +94,12 @@ def test_session_metadata_fields_includes_context_fields():
     assert meta_match, "METADATA_FIELDS list not found in Session.save"
     fields = meta_match.group(1)
     assert "'context_length'" in fields, "METADATA_FIELDS must include 'context_length'"
-    assert "'threshold_tokens'" in fields, "METADATA_FIELDS must include 'threshold_tokens'"
-    assert "'last_prompt_tokens'" in fields, "METADATA_FIELDS must include 'last_prompt_tokens'"
+    assert "'threshold_tokens'" in fields, (
+        "METADATA_FIELDS must include 'threshold_tokens'"
+    )
+    assert "'last_prompt_tokens'" in fields, (
+        "METADATA_FIELDS must include 'last_prompt_tokens'"
+    )
 
 
 def test_session_compact_exposes_context_fields():
@@ -103,7 +110,7 @@ def test_session_compact_exposes_context_fields():
     assert compact_idx != -1, "Session.compact not found"
     # Look ahead for the next def or 200 lines
     end = src.find("\n    def ", compact_idx + 1)
-    body = src[compact_idx:end if end != -1 else compact_idx + 4000]
+    body = src[compact_idx : end if end != -1 else compact_idx + 4000]
 
     assert "'context_length':" in body, "compact() must include context_length"
     assert "'threshold_tokens':" in body, "compact() must include threshold_tokens"
@@ -115,9 +122,15 @@ def test_routes_session_get_returns_context_fields():
     src = ROUTES.read_text(encoding="utf-8")
     # The session-detail response builder uses getattr(s, ..., 0) or 0 pattern.
     # Look for the three keys in the same response shape.
-    assert '"context_length"' in src, "GET /api/session response must include context_length"
-    assert '"threshold_tokens"' in src, "GET /api/session response must include threshold_tokens"
-    assert '"last_prompt_tokens"' in src, "GET /api/session response must include last_prompt_tokens"
+    assert '"context_length"' in src, (
+        "GET /api/session response must include context_length"
+    )
+    assert '"threshold_tokens"' in src, (
+        "GET /api/session response must include threshold_tokens"
+    )
+    assert '"last_prompt_tokens"' in src, (
+        "GET /api/session response must include last_prompt_tokens"
+    )
 
 
 def test_session_round_trip_persists_context_fields(tmp_path, monkeypatch):
@@ -143,6 +156,12 @@ def test_session_round_trip_persists_context_fields(tmp_path, monkeypatch):
     # Reload from disk
     s2 = models.Session.load("ctxtest1")
     assert s2 is not None, "Session should reload"
-    assert s2.context_length == 200000, f"context_length lost on reload: got {s2.context_length}"
-    assert s2.threshold_tokens == 180000, f"threshold_tokens lost on reload: got {s2.threshold_tokens}"
-    assert s2.last_prompt_tokens == 45123, f"last_prompt_tokens lost on reload: got {s2.last_prompt_tokens}"
+    assert s2.context_length == 200000, (
+        f"context_length lost on reload: got {s2.context_length}"
+    )
+    assert s2.threshold_tokens == 180000, (
+        f"threshold_tokens lost on reload: got {s2.threshold_tokens}"
+    )
+    assert s2.last_prompt_tokens == 45123, (
+        f"last_prompt_tokens lost on reload: got {s2.last_prompt_tokens}"
+    )

--- a/tests/test_pr1350_sse_atomic_subscribe.py
+++ b/tests/test_pr1350_sse_atomic_subscribe.py
@@ -62,25 +62,27 @@ def _handler_body() -> str:
     start = ROUTES_SRC.find("def _handle_approval_sse_stream(")
     assert start != -1, "_handle_approval_sse_stream must exist"
     end = ROUTES_SRC.find("\ndef ", start + 1)
-    return ROUTES_SRC[start:end if end != -1 else len(ROUTES_SRC)]
+    return ROUTES_SRC[start : end if end != -1 else len(ROUTES_SRC)]
 
 
 def test_snapshot_taken_under_lock():
     """The initial _pending snapshot must be guarded by `with _lock:`."""
     lock_body = _extract_lock_block(_handler_body())
     assert lock_body, "_handle_approval_sse_stream must contain a `with _lock:` block"
-    assert "_pending.get(sid)" in lock_body, \
+    assert "_pending.get(sid)" in lock_body, (
         "Initial snapshot of _pending must be read inside the `with _lock:` block"
+    )
 
 
 def test_subscriber_registered_inside_lock():
     """The subscriber queue must be registered inside the same `with _lock:` block."""
     lock_body = _extract_lock_block(_handler_body())
     assert lock_body, "Handler must contain a `with _lock:` block"
-    assert "_approval_sse_subscribers" in lock_body and "append(q)" in lock_body, \
-        ("Subscriber registration (`_approval_sse_subscribers.setdefault(sid, []).append(q)`) "
-         "must happen inside the same `with _lock:` block as the snapshot. "
-         "Otherwise a submit_pending() between snapshot-and-subscribe is lost.")
+    assert "_approval_sse_subscribers" in lock_body and "append(q)" in lock_body, (
+        "Subscriber registration (`_approval_sse_subscribers.setdefault(sid, []).append(q)`) "
+        "must happen inside the same `with _lock:` block as the snapshot. "
+        "Otherwise a submit_pending() between snapshot-and-subscribe is lost."
+    )
 
 
 def test_subscribe_before_snapshot_in_lock():

--- a/tests/test_pr1350_sse_notify_correctness.py
+++ b/tests/test_pr1350_sse_notify_correctness.py
@@ -27,9 +27,7 @@ The fix:
 """
 
 import pathlib
-import queue
 import sys
-import time
 import uuid
 
 REPO_ROOT = pathlib.Path(__file__).parent.parent.resolve()
@@ -41,12 +39,14 @@ class TestParallelApprovalsHeadFidelity:
 
     def setup_method(self):
         from api import routes as r
+
         with r._lock:
             r._approval_sse_subscribers.clear()
             r._pending.clear()
 
     def teardown_method(self):
         from api import routes as r
+
         with r._lock:
             r._approval_sse_subscribers.clear()
             r._pending.clear()
@@ -54,21 +54,28 @@ class TestParallelApprovalsHeadFidelity:
     def test_second_submit_pending_sends_head_not_tail(self):
         """When B is appended while A is still pending, SSE payload must show A as head."""
         from api import routes as r
+
         sid = f"sse-headtail-{uuid.uuid4().hex[:8]}"
         q = r._approval_sse_subscribe(sid)
         try:
-            r.submit_pending(sid, {
-                "command": "first-A",
-                "pattern_key": "first",
-                "pattern_keys": ["first"],
-                "description": "A",
-            })
-            r.submit_pending(sid, {
-                "command": "second-B",
-                "pattern_key": "second",
-                "pattern_keys": ["second"],
-                "description": "B",
-            })
+            r.submit_pending(
+                sid,
+                {
+                    "command": "first-A",
+                    "pattern_key": "first",
+                    "pattern_keys": ["first"],
+                    "description": "A",
+                },
+            )
+            r.submit_pending(
+                sid,
+                {
+                    "command": "second-B",
+                    "pattern_key": "second",
+                    "pattern_keys": ["second"],
+                    "description": "B",
+                },
+            )
             # First payload should be A (just-appended, also head).
             p1 = q.get(timeout=1)
             assert p1["pending"]["command"] == "first-A"
@@ -89,12 +96,14 @@ class TestRespondNotifiesTrailingApproval:
 
     def setup_method(self):
         from api import routes as r
+
         with r._lock:
             r._approval_sse_subscribers.clear()
             r._pending.clear()
 
     def teardown_method(self):
         from api import routes as r
+
         with r._lock:
             r._approval_sse_subscribers.clear()
             r._pending.clear()
@@ -102,25 +111,32 @@ class TestRespondNotifiesTrailingApproval:
     def test_respond_to_first_pushes_second_as_new_head(self):
         """submit A; submit B; respond(A) -> SSE must push (B, 1) so the UI surfaces B."""
         from api import routes as r
+
         sid = f"sse-trailing-{uuid.uuid4().hex[:8]}"
 
         # Subscribe BEFORE any submit so we capture all events deterministically.
         sub_q = r._approval_sse_subscribe(sid)
         try:
-            r.submit_pending(sid, {
-                "command": "first-A",
-                "pattern_key": "p1",
-                "pattern_keys": ["p1"],
-                "description": "A",
-                "approval_id": "id-A",
-            })
-            r.submit_pending(sid, {
-                "command": "second-B",
-                "pattern_key": "p2",
-                "pattern_keys": ["p2"],
-                "description": "B",
-                "approval_id": "id-B",
-            })
+            r.submit_pending(
+                sid,
+                {
+                    "command": "first-A",
+                    "pattern_key": "p1",
+                    "pattern_keys": ["p1"],
+                    "description": "A",
+                    "approval_id": "id-A",
+                },
+            )
+            r.submit_pending(
+                sid,
+                {
+                    "command": "second-B",
+                    "pattern_key": "p2",
+                    "pattern_keys": ["p2"],
+                    "description": "B",
+                    "approval_id": "id-B",
+                },
+            )
             # Drain the two submit-driven events.
             sub_q.get(timeout=1)  # head=A, total=1
             sub_q.get(timeout=1)  # head=A, total=2 (head is still A)
@@ -130,6 +146,7 @@ class TestRespondNotifiesTrailingApproval:
             # would require an HTTP handler mock; the inner sequence is what we
             # need to verify.)
             from api.routes import _approval_sse_notify_locked, _lock, _pending
+
             with _lock:
                 qlist = _pending.get(sid)
                 # Pop A by approval_id
@@ -139,16 +156,20 @@ class TestRespondNotifiesTrailingApproval:
                         break
                 # Re-emit head
                 if isinstance(_pending.get(sid), list) and _pending[sid]:
-                    _approval_sse_notify_locked(sid, _pending[sid][0], len(_pending[sid]))
+                    _approval_sse_notify_locked(
+                        sid, _pending[sid][0], len(_pending[sid])
+                    )
                 else:
                     _approval_sse_notify_locked(sid, None, 0)
 
             # SSE must push (B, 1) so the UI surfaces the trailing approval.
             p3 = sub_q.get(timeout=1)
-            assert p3["pending"] is not None, \
+            assert p3["pending"] is not None, (
                 "After responding to A, SSE must emit the new head B (not None)"
-            assert p3["pending"]["command"] == "second-B", \
+            )
+            assert p3["pending"]["command"] == "second-B", (
                 f"New head should be B, got: {p3['pending']['command']}"
+            )
             assert p3["pending_count"] == 1
         finally:
             r._approval_sse_unsubscribe(sid, sub_q)
@@ -156,20 +177,25 @@ class TestRespondNotifiesTrailingApproval:
     def test_respond_to_only_pending_pushes_empty_state(self):
         """If respond pops the last entry, SSE must push a None/0 sentinel so UI hides card."""
         from api import routes as r
+
         sid = f"sse-empty-{uuid.uuid4().hex[:8]}"
 
         sub_q = r._approval_sse_subscribe(sid)
         try:
-            r.submit_pending(sid, {
-                "command": "only-A",
-                "pattern_key": "p",
-                "pattern_keys": ["p"],
-                "description": "A",
-                "approval_id": "id-only-A",
-            })
+            r.submit_pending(
+                sid,
+                {
+                    "command": "only-A",
+                    "pattern_key": "p",
+                    "pattern_keys": ["p"],
+                    "description": "A",
+                    "approval_id": "id-only-A",
+                },
+            )
             sub_q.get(timeout=1)  # drain submit notify
 
             from api.routes import _approval_sse_notify_locked, _lock, _pending
+
             with _lock:
                 qlist = _pending.get(sid)
                 for i, e in enumerate(qlist):
@@ -179,13 +205,16 @@ class TestRespondNotifiesTrailingApproval:
                 if not qlist:
                     _pending.pop(sid, None)
                 if isinstance(_pending.get(sid), list) and _pending[sid]:
-                    _approval_sse_notify_locked(sid, _pending[sid][0], len(_pending[sid]))
+                    _approval_sse_notify_locked(
+                        sid, _pending[sid][0], len(_pending[sid])
+                    )
                 else:
                     _approval_sse_notify_locked(sid, None, 0)
 
             payload = sub_q.get(timeout=1)
-            assert payload["pending"] is None, \
+            assert payload["pending"] is None, (
                 "After responding to the only approval, SSE must push pending=None"
+            )
             assert payload["pending_count"] == 0
         finally:
             r._approval_sse_unsubscribe(sid, sub_q)
@@ -196,12 +225,14 @@ class TestNotifyOrderUnderContention:
 
     def setup_method(self):
         from api import routes as r
+
         with r._lock:
             r._approval_sse_subscribers.clear()
             r._pending.clear()
 
     def teardown_method(self):
         from api import routes as r
+
         with r._lock:
             r._approval_sse_subscribers.clear()
             r._pending.clear()
@@ -215,6 +246,7 @@ class TestNotifyOrderUnderContention:
         """
         import threading
         from api import routes as r
+
         sid = f"sse-order-{uuid.uuid4().hex[:8]}"
 
         sub_q = r._approval_sse_subscribe(sid)
@@ -225,12 +257,15 @@ class TestNotifyOrderUnderContention:
             def submitter(idx):
                 try:
                     barrier.wait(timeout=2)
-                    r.submit_pending(sid, {
-                        "command": f"cmd-{idx}",
-                        "pattern_key": f"p{idx}",
-                        "pattern_keys": [f"p{idx}"],
-                        "description": f"d{idx}",
-                    })
+                    r.submit_pending(
+                        sid,
+                        {
+                            "command": f"cmd-{idx}",
+                            "pattern_key": f"p{idx}",
+                            "pattern_keys": [f"p{idx}"],
+                            "description": f"d{idx}",
+                        },
+                    )
                 except Exception as e:
                     errors.append(e)
 
@@ -253,7 +288,6 @@ class TestNotifyOrderUnderContention:
                 f"pending_count must be monotonically increasing under contention. "
                 f"Got: {counts}. Pre-fix this could be out-of-order."
             )
-            assert counts == list(range(1, 9)), \
-                f"Expected [1..8], got {counts}"
+            assert counts == list(range(1, 9)), f"Expected [1..8], got {counts}"
         finally:
             r._approval_sse_unsubscribe(sid, sub_q)

--- a/tests/test_pr1355_sse_handler_no_deadlock.py
+++ b/tests/test_pr1355_sse_handler_no_deadlock.py
@@ -92,10 +92,13 @@ def test_handler_snapshot_does_not_deadlock_when_queue_has_entry():
 
     sid = f"clarify-sse-populated-{time.time_ns()}"
     try:
-        clarify.submit_pending(sid, {
-            "question": "Pick one?",
-            "choices_offered": ["a", "b"],
-        })
+        clarify.submit_pending(
+            sid,
+            {
+                "question": "Pick one?",
+                "choices_offered": ["a", "b"],
+            },
+        )
         initial_pending, initial_count = _run_handler_snapshot(sid)
         assert initial_count == 1
         assert initial_pending is not None
@@ -114,7 +117,7 @@ def test_routes_handler_does_not_call_get_pending_under_lock():
     start = src.find("def _handle_clarify_sse_stream(")
     assert start != -1, "_handle_clarify_sse_stream must exist"
     end = src.find("\ndef ", start + 1)
-    body = src[start:end if end != -1 else len(src)]
+    body = src[start : end if end != -1 else len(src)]
 
     # Find the lock block
     lock_start = body.find("with _clarify_lock:")

--- a/tests/test_pr1366_finalize_thinking_card_guard.py
+++ b/tests/test_pr1366_finalize_thinking_card_guard.py
@@ -29,7 +29,7 @@ def test_finalize_thinking_card_guard_exists():
     start = UI_JS.find("function finalizeThinkingCard()")
     assert start != -1, "finalizeThinkingCard() must exist"
     end = UI_JS.find("\nfunction ", start + 1)
-    body = UI_JS[start:end if end != -1 else len(UI_JS)]
+    body = UI_JS[start : end if end != -1 else len(UI_JS)]
     # The guard must read dataset.sessionId from the live turn AND compare
     # against S.session.session_id. The exact form must early-return.
     assert "dataset.sessionId" in body, (
@@ -53,14 +53,16 @@ def test_live_turn_creation_sites_stamp_session_id():
     for m in re.finditer(r"\.id=['\"]liveAssistantTurn['\"]", UI_JS):
         # Find what variable name was used (e.g. `turn.id=`, `currentAssistantTurn.id=`)
         line_start = UI_JS.rfind("\n", 0, m.start()) + 1
-        line = UI_JS[line_start:m.end() + 1]
+        line = UI_JS[line_start : m.end() + 1]
         # Get the variable name
         var_m = re.search(r"(\w+)\.id=['\"]liveAssistantTurn['\"]", line)
         var_name = var_m.group(1) if var_m else "?"
         # Look at the next ~500 chars for a dataset.sessionId stamp on the same var
         # (500 chars accommodates an explanatory comment block before the stamp).
-        window = UI_JS[m.end():m.end() + 500]
-        stamped = bool(re.search(rf"{re.escape(var_name)}\.dataset\.sessionId\s*=", window))
+        window = UI_JS[m.end() : m.end() + 500]
+        stamped = bool(
+            re.search(rf"{re.escape(var_name)}\.dataset\.sessionId\s*=", window)
+        )
         sites.append((var_name, m.start(), stamped))
 
     assert sites, "Expected at least one site setting `<var>.id='liveAssistantTurn'`"

--- a/tests/test_pr1370_lineage_metadata_perf_and_orphan.py
+++ b/tests/test_pr1370_lineage_metadata_perf_and_orphan.py
@@ -13,11 +13,8 @@ output, because #1358's frontend `_sessionLineageKey` falls through to
 group orphans by a key no other session shares (cosmetic dead state).
 """
 
-import os
 import sqlite3
 import time
-
-import pytest
 
 
 def _make_db(path):
@@ -72,15 +69,20 @@ def test_does_not_full_scan_sessions_table(tmp_path, monkeypatch):
     class _TrackingConn:
         def __init__(self, *args, **kw):
             self._real = real_connect(*args, **kw)
+
         def cursor(self):
             return _TrackingCursor(self._real.cursor())
+
         def __enter__(self):
             return self
+
         def __exit__(self, *a):
             return self._real.__exit__(*a)
+
         @property
         def row_factory(self):
             return self._real.row_factory
+
         @row_factory.setter
         def row_factory(self, v):
             self._real.row_factory = v
@@ -88,11 +90,14 @@ def test_does_not_full_scan_sessions_table(tmp_path, monkeypatch):
     class _TrackingCursor:
         def __init__(self, real):
             self._real = real
+
         def execute(self, sql, *args):
             queries.append(sql)
             return self._real.execute(sql, *args)
+
         def fetchall(self):
             return self._real.fetchall()
+
         def fetchone(self):
             return self._real.fetchone()
 
@@ -100,10 +105,13 @@ def test_does_not_full_scan_sessions_table(tmp_path, monkeypatch):
     agent_sessions.read_session_lineage_metadata(db, ["wanted_1", "wanted_2"])
 
     # No query may select from sessions without a WHERE clause
-    bad = [q for q in queries
-           if "from sessions" in q.lower()
-           and "where" not in q.lower()
-           and "pragma" not in q.lower()]
+    bad = [
+        q
+        for q in queries
+        if "from sessions" in q.lower()
+        and "where" not in q.lower()
+        and "pragma" not in q.lower()
+    ]
     assert not bad, (
         f"read_session_lineage_metadata must scope its SELECTs to specific "
         f"session ids (PR #1370 originally did a full scan). Found unscoped "
@@ -143,6 +151,7 @@ def test_cycle_in_parent_chain_terminates(tmp_path):
     conn.close()
 
     import threading
+
     done = threading.Event()
     result_box = []
 
@@ -204,23 +213,38 @@ def test_in_clause_chunked_for_large_session_set(tmp_path, monkeypatch):
     class _TrackingConn:
         def __init__(self, *args, **kw):
             self._real = real_connect(*args, **kw)
+
         def cursor(self):
             return _TrackingCursor(self._real.cursor())
-        def __enter__(self): return self
-        def __exit__(self, *a): return self._real.__exit__(*a)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return self._real.__exit__(*a)
+
         @property
-        def row_factory(self): return self._real.row_factory
+        def row_factory(self):
+            return self._real.row_factory
+
         @row_factory.setter
-        def row_factory(self, v): self._real.row_factory = v
+        def row_factory(self, v):
+            self._real.row_factory = v
 
     class _TrackingCursor:
-        def __init__(self, real): self._real = real
+        def __init__(self, real):
+            self._real = real
+
         def execute(self, sql, *args):
             if "IN (" in sql:
                 in_counts.append(sql.count("?"))
             return self._real.execute(sql, *args)
-        def fetchall(self): return self._real.fetchall()
-        def fetchone(self): return self._real.fetchone()
+
+        def fetchall(self):
+            return self._real.fetchall()
+
+        def fetchone(self):
+            return self._real.fetchone()
 
     monkeypatch.setattr(sqlite3, "connect", _TrackingConn)
 

--- a/tests/test_pr1375_partial_tool_calls_sanitize.py
+++ b/tests/test_pr1375_partial_tool_calls_sanitize.py
@@ -17,10 +17,10 @@ This test pins the invariant: a partial assistant message with
 `_partial_tool_calls` set must produce ZERO `tool_calls` after
 sanitize-for-API.
 """
+
 import pathlib
 import sys
 
-import pytest
 
 REPO_ROOT = pathlib.Path(__file__).parent.parent.resolve()
 sys.path.insert(0, str(REPO_ROOT))
@@ -80,7 +80,7 @@ def test_legitimate_tool_calls_are_preserved_for_completed_turns():
                 {
                     "id": "call_abc",
                     "type": "function",
-                    "function": {"name": "web_search", "arguments": '{"query":"x"}'}
+                    "function": {"name": "web_search", "arguments": '{"query":"x"}'},
                 },
             ],
         },

--- a/tests/test_pr1445_opus_followups.py
+++ b/tests/test_pr1445_opus_followups.py
@@ -8,7 +8,6 @@ These tests pin the defense-in-depth additions from the Opus advisor review:
 """
 
 import logging
-from pathlib import Path
 from types import SimpleNamespace
 
 
@@ -47,14 +46,26 @@ def test_fully_unquote_handles_quadruple_encoded(monkeypatch):
     from api.extensions import _fully_unquote_path
 
     # Plain percent-encoding stops at `..` after 1 unquote
-    assert _fully_unquote_path("/extensions/%2e%2e/api/session") == "/extensions/../api/session"
+    assert (
+        _fully_unquote_path("/extensions/%2e%2e/api/session")
+        == "/extensions/../api/session"
+    )
     # Double-encoded after 2 unquotes
-    assert _fully_unquote_path("/extensions/%252e%252e/api/session") == "/extensions/../api/session"
+    assert (
+        _fully_unquote_path("/extensions/%252e%252e/api/session")
+        == "/extensions/../api/session"
+    )
     # Triple-encoded after 3 unquotes
-    assert _fully_unquote_path("/extensions/%25252e%25252e/api/session") == "/extensions/../api/session"
+    assert (
+        _fully_unquote_path("/extensions/%25252e%25252e/api/session")
+        == "/extensions/../api/session"
+    )
     # Quadruple-encoded after 4 unquotes — the case that slipped through the
     # original `range(3)` and reached the validator unchanged
-    assert _fully_unquote_path("/extensions/%2525252e%2525252e/api/session") == "/extensions/../api/session"
+    assert (
+        _fully_unquote_path("/extensions/%2525252e%2525252e/api/session")
+        == "/extensions/../api/session"
+    )
 
 
 def test_quadruple_encoded_traversal_url_now_rejected(tmp_path, monkeypatch):
@@ -114,6 +125,7 @@ def test_url_list_logs_rejected_urls_once(tmp_path, monkeypatch, caplog):
     # Reset the per-process warning cache so the test doesn't accidentally
     # depend on state from other tests in the same run
     from api.extensions import _warned_urls
+
     _warned_urls.clear()
 
     caplog.set_level(logging.WARNING, logger="api.extensions")
@@ -135,7 +147,8 @@ def test_url_list_logs_rejected_urls_once(tmp_path, monkeypatch, caplog):
     config2 = get_extension_config()
     assert config2["script_urls"] == ["/extensions/legit.js"]
     rejection_records = [
-        r for r in caplog.records
+        r
+        for r in caplog.records
         if "Rejected extension URL" in r.message and "evil.example.com" in r.message
     ]
     assert rejection_records == [], (
@@ -159,17 +172,26 @@ def test_expanded_mime_map_serves_fonts_and_wasm(tmp_path, monkeypatch):
     from api.extensions import serve_extension_static
 
     ttf = FakeHandler()
-    assert serve_extension_static(ttf, SimpleNamespace(path="/extensions/font.ttf")) is True
+    assert (
+        serve_extension_static(ttf, SimpleNamespace(path="/extensions/font.ttf"))
+        is True
+    )
     assert ttf.status == 200
     assert ttf.header("Content-Type") == "font/ttf"
 
     otf = FakeHandler()
-    assert serve_extension_static(otf, SimpleNamespace(path="/extensions/font.otf")) is True
+    assert (
+        serve_extension_static(otf, SimpleNamespace(path="/extensions/font.otf"))
+        is True
+    )
     assert otf.status == 200
     assert otf.header("Content-Type") == "font/otf"
 
     wasm = FakeHandler()
-    assert serve_extension_static(wasm, SimpleNamespace(path="/extensions/module.wasm")) is True
+    assert (
+        serve_extension_static(wasm, SimpleNamespace(path="/extensions/module.wasm"))
+        is True
+    )
     assert wasm.status == 200
     assert wasm.header("Content-Type") == "application/wasm"
     # Binary types must NOT have a charset suffix

--- a/tests/test_pr1947_same_model_multiple_custom_providers.py
+++ b/tests/test_pr1947_same_model_multiple_custom_providers.py
@@ -13,6 +13,7 @@ Post-fix, the dedup key is ``f"{slug}:{model_id}"`` per named provider, so each
 provider's models are tracked independently. Per-provider dedup of duplicate
 entries within the same provider still works.
 """
+
 import pytest
 import api.config as config
 
@@ -84,10 +85,21 @@ class TestPR1947SameModelMultipleProviders:
         dropped. Post-fix: the dedup key is ``slug:model_id`` so both survive.
         """
         result = _models_with_cfg(
-            model_cfg={"provider": "custom", "base_url": "https://baidu.example.com/v1"},
+            model_cfg={
+                "provider": "custom",
+                "base_url": "https://baidu.example.com/v1",
+            },
             custom_providers=[
-                {"name": "baidu", "model": "glm-5.1", "base_url": "https://baidu.example.com/v1"},
-                {"name": "huoshan", "model": "glm-5.1", "base_url": "https://huoshan.example.com/v1"},
+                {
+                    "name": "baidu",
+                    "model": "glm-5.1",
+                    "base_url": "https://baidu.example.com/v1",
+                },
+                {
+                    "name": "huoshan",
+                    "model": "glm-5.1",
+                    "base_url": "https://huoshan.example.com/v1",
+                },
             ],
         )
 
@@ -119,9 +131,21 @@ class TestPR1947SameModelMultipleProviders:
         result = _models_with_cfg(
             model_cfg={"provider": "custom", "base_url": "https://a.example.com/v1"},
             custom_providers=[
-                {"name": "edith", "model": "gpt-5.4", "base_url": "https://a.example.com/v1"},
-                {"name": "super-javis", "model": "gpt-5.4", "base_url": "https://b.example.com/v1"},
-                {"name": "vision-prime", "model": "gpt-5.4", "base_url": "https://c.example.com/v1"},
+                {
+                    "name": "edith",
+                    "model": "gpt-5.4",
+                    "base_url": "https://a.example.com/v1",
+                },
+                {
+                    "name": "super-javis",
+                    "model": "gpt-5.4",
+                    "base_url": "https://b.example.com/v1",
+                },
+                {
+                    "name": "vision-prime",
+                    "model": "gpt-5.4",
+                    "base_url": "https://c.example.com/v1",
+                },
             ],
         )
 
@@ -142,8 +166,16 @@ class TestPR1947SameModelMultipleProviders:
         result = _models_with_cfg(
             model_cfg={"provider": "custom", "base_url": "https://a.example.com/v1"},
             custom_providers=[
-                {"name": "alpha", "model": "model-a", "base_url": "https://a.example.com/v1"},
-                {"name": "beta", "model": "model-b", "base_url": "https://b.example.com/v1"},
+                {
+                    "name": "alpha",
+                    "model": "model-a",
+                    "base_url": "https://a.example.com/v1",
+                },
+                {
+                    "name": "beta",
+                    "model": "model-b",
+                    "base_url": "https://b.example.com/v1",
+                },
             ],
         )
         alpha = _group_for_provider(result, "alpha")

--- a/tests/test_profile_default_workspace_823.py
+++ b/tests/test_profile_default_workspace_823.py
@@ -8,6 +8,7 @@ was created and then deleted.
 Fix: introduce S._profileSwitchWorkspace as the dedicated one-shot flag for
 profile-switch semantics; S._profileDefaultWorkspace is now persistent.
 """
+
 import pathlib
 import re
 
@@ -15,50 +16,53 @@ REPO = pathlib.Path(__file__).parent.parent
 
 
 def read(rel):
-    return (REPO / rel).read_text(encoding='utf-8')
+    return (REPO / rel).read_text(encoding="utf-8")
 
 
 class TestProfileDefaultWorkspacePersistence:
     """_profileDefaultWorkspace must NOT be nulled by newSession()."""
 
     def test_new_session_does_not_null_profile_default_workspace(self):
-        src = read('static/sessions.js')
-        m = re.search(r'async function newSession\(.*?\n\}', src, re.DOTALL)
+        src = read("static/sessions.js")
+        m = re.search(r"async function newSession\(.*?\n\}", src, re.DOTALL)
         assert m, "newSession not found"
         fn = m.group(0)
         # The old consume pattern must be gone
-        assert '_profileDefaultWorkspace=null' not in fn and \
-               '_profileDefaultWorkspace = null' not in fn, (
+        assert (
+            "_profileDefaultWorkspace=null" not in fn
+            and "_profileDefaultWorkspace = null" not in fn
+        ), (
             "newSession must NOT null S._profileDefaultWorkspace — it is the persistent "
             "boot/settings default used for blank-page display after session delete (#823)"
         )
 
     def test_new_session_uses_dedicated_switch_workspace_flag(self):
-        src = read('static/sessions.js')
-        m = re.search(r'async function newSession\(.*?\n\}', src, re.DOTALL)
+        src = read("static/sessions.js")
+        m = re.search(r"async function newSession\(.*?\n\}", src, re.DOTALL)
         assert m
         fn = m.group(0)
-        assert '_profileSwitchWorkspace' in fn, (
+        assert "_profileSwitchWorkspace" in fn, (
             "newSession must read S._profileSwitchWorkspace for the one-shot "
             "profile-switch inherit, not S._profileDefaultWorkspace"
         )
         # It should null the switch flag, not the default
-        assert '_profileSwitchWorkspace=null' in fn or '_profileSwitchWorkspace = null' in fn, (
-            "newSession must null S._profileSwitchWorkspace after consuming it"
-        )
+        assert (
+            "_profileSwitchWorkspace=null" in fn
+            or "_profileSwitchWorkspace = null" in fn
+        ), "newSession must null S._profileSwitchWorkspace after consuming it"
 
     def test_new_session_still_inherits_default_workspace(self):
         """newSession must still pass a workspace to /api/session/new —
         now via the _profileSwitchWorkspace → current session → _profileDefaultWorkspace chain."""
-        src = read('static/sessions.js')
-        m = re.search(r'async function newSession\(.*?\n\}', src, re.DOTALL)
+        src = read("static/sessions.js")
+        m = re.search(r"async function newSession\(.*?\n\}", src, re.DOTALL)
         assert m
         fn = m.group(0)
         # inheritWs must be computed and passed to /api/session/new
-        assert 'inheritWs' in fn or 'inherit' in fn.lower(), (
+        assert "inheritWs" in fn or "inherit" in fn.lower(), (
             "newSession must compute an inheritWs from switch/current/default workspace"
         )
-        assert '_profileDefaultWorkspace' in fn, (
+        assert "_profileDefaultWorkspace" in fn, (
             "newSession must fall through to S._profileDefaultWorkspace as last resort"
         )
 
@@ -67,24 +71,24 @@ class TestProfileSwitchWorkspaceSetter:
     """panels.js must set _profileSwitchWorkspace on profile switch."""
 
     def test_panels_sets_profile_switch_workspace(self):
-        src = read('static/panels.js')
+        src = read("static/panels.js")
         # Find the profile-switch workspace block
-        assert 'S._profileSwitchWorkspace' in src, (
+        assert "S._profileSwitchWorkspace" in src, (
             "panels.js must set S._profileSwitchWorkspace during profile switch "
             "so newSession() can apply it to the first new session"
         )
 
     def test_panels_still_sets_profile_default_workspace(self):
-        src = read('static/panels.js')
-        assert 'S._profileDefaultWorkspace = data.default_workspace' in src, (
+        src = read("static/panels.js")
+        assert "S._profileDefaultWorkspace = data.default_workspace" in src, (
             "panels.js must still set S._profileDefaultWorkspace (persistent default) "
             "alongside S._profileSwitchWorkspace"
         )
 
     def test_both_set_together_in_same_block(self):
-        src = read('static/panels.js')
-        default_pos = src.find('S._profileDefaultWorkspace = data.default_workspace')
-        switch_pos = src.find('S._profileSwitchWorkspace = data.default_workspace')
+        src = read("static/panels.js")
+        default_pos = src.find("S._profileDefaultWorkspace = data.default_workspace")
+        switch_pos = src.find("S._profileSwitchWorkspace = data.default_workspace")
         assert default_pos != -1, "S._profileDefaultWorkspace setter not found"
         assert switch_pos != -1, "S._profileSwitchWorkspace setter not found"
         # Both must be set within 200 chars of each other (same block)
@@ -93,16 +97,18 @@ class TestProfileSwitchWorkspaceSetter:
             "together in the same profile-switch workspace block"
         )
 
-
     def test_switch_to_workspace_clears_profile_switch_workspace(self):
         """Opus Q4: when the user manually changes workspace, the pending one-shot
         switch flag should be cleared so a subsequent newSession() inherits the
         user's explicit choice rather than the stale profile-switch default."""
-        src = read('static/panels.js')
-        m = re.search(r'async function switchToWorkspace\(.*?\n\}', src, re.DOTALL)
+        src = read("static/panels.js")
+        m = re.search(r"async function switchToWorkspace\(.*?\n\}", src, re.DOTALL)
         assert m, "switchToWorkspace not found"
         fn = m.group(0)
-        assert '_profileSwitchWorkspace=null' in fn or '_profileSwitchWorkspace = null' in fn, (
+        assert (
+            "_profileSwitchWorkspace=null" in fn
+            or "_profileSwitchWorkspace = null" in fn
+        ), (
             "switchToWorkspace must null S._profileSwitchWorkspace after a manual switch "
             "so the next newSession() inherits the user's explicit workspace choice"
         )
@@ -114,21 +120,21 @@ class TestBlankPageAfterSessionDelete:
     def test_sync_workspace_displays_reads_profile_default(self):
         """syncWorkspaceDisplays relies on S._profileDefaultWorkspace which must
         still be set after a session is created and deleted."""
-        src = read('static/panels.js')
-        m = re.search(r'function syncWorkspaceDisplays\(\)\{.*?\n\}', src, re.DOTALL)
+        src = read("static/panels.js")
+        m = re.search(r"function syncWorkspaceDisplays\(\)\{.*?\n\}", src, re.DOTALL)
         assert m, "syncWorkspaceDisplays not found"
         fn = m.group(0)
-        assert '_profileDefaultWorkspace' in fn, (
+        assert "_profileDefaultWorkspace" in fn, (
             "syncWorkspaceDisplays must read S._profileDefaultWorkspace as fallback"
         )
 
     def test_prompt_new_file_reads_profile_default(self):
         """promptNewFile on blank page reads _profileDefaultWorkspace which must
         be non-null even after a newSession() + deleteSession() cycle."""
-        src = read('static/ui.js')
-        m = re.search(r'async function promptNewFile\(\)\{.*?\n\}', src, re.DOTALL)
+        src = read("static/ui.js")
+        m = re.search(r"async function promptNewFile\(\)\{.*?\n\}", src, re.DOTALL)
         assert m, "promptNewFile not found"
         fn = m.group(0)
-        assert '_profileDefaultWorkspace' in fn, (
+        assert "_profileDefaultWorkspace" in fn, (
             "promptNewFile must read S._profileDefaultWorkspace (must persist after newSession)"
         )

--- a/tests/test_profile_env_isolation.py
+++ b/tests/test_profile_env_isolation.py
@@ -1,7 +1,6 @@
 import importlib
 import os
 import sys
-from pathlib import Path
 
 
 def test_profile_switch_clears_previous_profile_env_vars(monkeypatch, tmp_path):

--- a/tests/test_profile_path_security.py
+++ b/tests/test_profile_path_security.py
@@ -18,8 +18,11 @@ def _reload_profiles_module(base_home: Path):
     # Save the original module references so we can restore them after the test.
     # Permanently deleting api.config / api.profiles from sys.modules breaks
     # subsequent tests that import these modules and expect consistent state.
-    _saved = {name: sys.modules[name] for name in ["api.config", "api.profiles"]
-              if name in sys.modules}
+    _saved = {
+        name: sys.modules[name]
+        for name in ["api.config", "api.profiles"]
+        if name in sys.modules
+    }
 
     for name in ["api.config", "api.profiles"]:
         if name in sys.modules:

--- a/tests/test_profile_switch_1200.py
+++ b/tests/test_profile_switch_1200.py
@@ -10,10 +10,9 @@ Bug 2: /api/models returned stale results after a profile switch because the
 
 These tests verify both fixes.
 """
+
 import os
-import json
 import tempfile
-import textwrap
 from pathlib import Path
 
 
@@ -30,40 +29,40 @@ def test_switch_profile_returns_target_workspace_not_current(tmp_path, monkeypat
     import api.profiles as profiles
 
     # Build fake profile structure
-    default_home = tmp_path / '.hermes'
+    default_home = tmp_path / ".hermes"
     default_home.mkdir()
-    ayan_home = default_home / 'profiles' / 'ayan'
+    ayan_home = default_home / "profiles" / "ayan"
     ayan_home.mkdir(parents=True)
 
     # Give ayan a terminal.cwd config (common case)
-    ayan_workspace = tmp_path / 'ayan_workspace'
+    ayan_workspace = tmp_path / "ayan_workspace"
     ayan_workspace.mkdir()
-    ayan_config = ayan_home / 'config.yaml'
+    ayan_config = ayan_home / "config.yaml"
     ayan_config.write_text(
-        f'model:\n  default: kimi-k2-instruct\n  provider: nous\n'
-        f'terminal:\n  cwd: {ayan_workspace}\n',
-        encoding='utf-8',
+        f"model:\n  default: kimi-k2-instruct\n  provider: nous\n"
+        f"terminal:\n  cwd: {ayan_workspace}\n",
+        encoding="utf-8",
     )
 
     # Give default profile a different workspace stored in last_workspace.txt
-    default_ws = tmp_path / 'default_workspace'
+    default_ws = tmp_path / "default_workspace"
     default_ws.mkdir()
-    default_state = default_home / 'webui_state'
+    default_state = default_home / "webui_state"
     default_state.mkdir()
-    (default_state / 'last_workspace.txt').write_text(str(default_ws), encoding='utf-8')
+    (default_state / "last_workspace.txt").write_text(str(default_ws), encoding="utf-8")
 
     # Patch _DEFAULT_HERMES_HOME to our tmp dir
     orig_default = profiles._DEFAULT_HERMES_HOME
     profiles._DEFAULT_HERMES_HOME = default_home
     # Ensure _active_profile = 'default'
     orig_active = profiles._active_profile
-    profiles._active_profile = 'default'
+    profiles._active_profile = "default"
     # Clear TLS
     profiles._tls.profile = None
 
     try:
-        result = profiles.switch_profile('ayan', process_wide=False)
-        ws = result.get('default_workspace', '')
+        result = profiles.switch_profile("ayan", process_wide=False)
+        ws = result.get("default_workspace", "")
         # Must be ayan's workspace, NOT default's workspace
         assert str(ayan_workspace) in ws or ayan_workspace.resolve() == Path(ws), (
             f"Expected ayan's workspace ({ayan_workspace}), got: {ws}"
@@ -84,34 +83,35 @@ def test_switch_profile_uses_last_workspace_txt_over_config(tmp_path, monkeypatc
     """
     import api.profiles as profiles
 
-    default_home = tmp_path / '.hermes'
+    default_home = tmp_path / ".hermes"
     default_home.mkdir()
-    target_home = default_home / 'profiles' / 'myprofile'
+    target_home = default_home / "profiles" / "myprofile"
     target_home.mkdir(parents=True)
 
     # config.yaml has terminal.cwd
-    cfg_ws = tmp_path / 'cfg_workspace'
+    cfg_ws = tmp_path / "cfg_workspace"
     cfg_ws.mkdir()
-    (target_home / 'config.yaml').write_text(
-        f'terminal:\n  cwd: {cfg_ws}\n', encoding='utf-8',
+    (target_home / "config.yaml").write_text(
+        f"terminal:\n  cwd: {cfg_ws}\n",
+        encoding="utf-8",
     )
 
     # last_workspace.txt overrides it
-    explicit_ws = tmp_path / 'explicit_workspace'
+    explicit_ws = tmp_path / "explicit_workspace"
     explicit_ws.mkdir()
-    state_dir = target_home / 'webui_state'
+    state_dir = target_home / "webui_state"
     state_dir.mkdir()
-    (state_dir / 'last_workspace.txt').write_text(str(explicit_ws), encoding='utf-8')
+    (state_dir / "last_workspace.txt").write_text(str(explicit_ws), encoding="utf-8")
 
     orig_default = profiles._DEFAULT_HERMES_HOME
     profiles._DEFAULT_HERMES_HOME = default_home
     orig_active = profiles._active_profile
-    profiles._active_profile = 'default'
+    profiles._active_profile = "default"
     profiles._tls.profile = None
 
     try:
-        result = profiles.switch_profile('myprofile', process_wide=False)
-        ws = result.get('default_workspace', '')
+        result = profiles.switch_profile("myprofile", process_wide=False)
+        ws = result.get("default_workspace", "")
         assert str(explicit_ws) in ws or Path(ws) == explicit_ws.resolve(), (
             f"Expected last_workspace.txt ({explicit_ws}), got: {ws}"
         )
@@ -131,28 +131,28 @@ def test_switch_profile_process_wide_false_returns_correct_model(tmp_path, monke
     """
     import api.profiles as profiles
 
-    default_home = tmp_path / '.hermes'
+    default_home = tmp_path / ".hermes"
     default_home.mkdir()
-    target_home = default_home / 'profiles' / 'aiprofile'
+    target_home = default_home / "profiles" / "aiprofile"
     target_home.mkdir(parents=True)
 
-    target_ws = tmp_path / 'ai_ws'
+    target_ws = tmp_path / "ai_ws"
     target_ws.mkdir()
-    (target_home / 'config.yaml').write_text(
-        f'model:\n  default: kimi-k2-instruct\n  provider: nous\n'
-        f'terminal:\n  cwd: {target_ws}\n',
-        encoding='utf-8',
+    (target_home / "config.yaml").write_text(
+        f"model:\n  default: kimi-k2-instruct\n  provider: nous\n"
+        f"terminal:\n  cwd: {target_ws}\n",
+        encoding="utf-8",
     )
 
     orig_default = profiles._DEFAULT_HERMES_HOME
     profiles._DEFAULT_HERMES_HOME = default_home
     orig_active = profiles._active_profile
-    profiles._active_profile = 'default'
+    profiles._active_profile = "default"
     profiles._tls.profile = None
 
     try:
-        result = profiles.switch_profile('aiprofile', process_wide=False)
-        assert result.get('default_model') == 'kimi-k2-instruct', (
+        result = profiles.switch_profile("aiprofile", process_wide=False)
+        assert result.get("default_model") == "kimi-k2-instruct", (
             f"Expected 'kimi-k2-instruct', got: {result.get('default_model')!r}"
         )
     finally:
@@ -165,7 +165,7 @@ def test_profile_switch_route_invalidates_models_cache(tmp_path):
     """
     After a profile switch, the model cache must be invalidated so the next
     /api/models request rebuilds from the new profile's config.
-    
+
     This is a unit test verifying that invalidate_models_cache() is called
     as part of the /api/profile/switch response flow.
     """
@@ -175,9 +175,9 @@ def test_profile_switch_route_invalidates_models_cache(tmp_path):
     # Seed a non-None cache value to simulate a populated cache
     with _available_models_cache_lock:
         config_module._available_models_cache = {
-            'active_provider': 'old_provider',
-            'default_model': 'old-model',
-            'groups': [],
+            "active_provider": "old_provider",
+            "default_model": "old-model",
+            "groups": [],
         }
         config_module._available_models_cache_ts = 9999999.0
 
@@ -203,8 +203,6 @@ no active session), the early-return branch ran without updating the chip.
 This caused the chip to keep showing the old profile name after switchToProfile().
 """
 
-import re
-
 
 def test_syncTopbar_early_return_updates_profile_chip():
     """
@@ -212,7 +210,10 @@ def test_syncTopbar_early_return_updates_profile_chip():
     Without this, the composer profile chip stays stale when there is no active session.
     """
     from pathlib import Path
-    ui_js = (Path(__file__).parent.parent / "static" / "ui.js").read_text(encoding="utf-8")
+
+    ui_js = (Path(__file__).parent.parent / "static" / "ui.js").read_text(
+        encoding="utf-8"
+    )
 
     # Find the syncTopbar function
     fn_start = ui_js.find("function syncTopbar(){")
@@ -220,7 +221,9 @@ def test_syncTopbar_early_return_updates_profile_chip():
 
     # Find the early-return block (!S.session branch)
     early_ret_start = ui_js.find("if(!S.session){", fn_start)
-    assert early_ret_start != -1, "!S.session early-return block not found in syncTopbar"
+    assert early_ret_start != -1, (
+        "!S.session early-return block not found in syncTopbar"
+    )
 
     # Find where the early return ends (the closing brace + return)
     early_ret_end = ui_js.find("return;", early_ret_start)
@@ -242,7 +245,10 @@ def test_syncTopbar_early_return_updates_profile_chip():
 # These tests exist to catch future regressions in profile switching behavior.
 # Each one corresponds to a specific bug that was fixed in the #1200 PR.
 
-def test_regression_switch_profile_default_workspace_not_from_process_global(tmp_path, monkeypatch):
+
+def test_regression_switch_profile_default_workspace_not_from_process_global(
+    tmp_path, monkeypatch
+):
     """
     REGRESSION GUARD (#1200 Bug 1): switch_profile(process_wide=False) must NOT
     return the active (old) profile's workspace via get_last_workspace().
@@ -290,7 +296,7 @@ def test_regression_switch_profile_default_workspace_not_from_process_global(tmp
             "switch_profile() is reading from the wrong profile."
         )
         assert str(old_ws) not in ws, (
-            f"REGRESSION: Returned old profile workspace. Bug 1 regressed."
+            "REGRESSION: Returned old profile workspace. Bug 1 regressed."
         )
     finally:
         profiles._DEFAULT_HERMES_HOME = orig_default
@@ -335,7 +341,9 @@ def test_regression_synctopbar_early_return_updates_profile_chip():
     """
     from pathlib import Path
 
-    ui_js = (Path(__file__).parent.parent / "static" / "ui.js").read_text(encoding="utf-8")
+    ui_js = (Path(__file__).parent.parent / "static" / "ui.js").read_text(
+        encoding="utf-8"
+    )
 
     fn_start = ui_js.find("function syncTopbar(){")
     assert fn_start != -1, "syncTopbar not found — has it been renamed?"
@@ -362,13 +370,13 @@ def test_regression_switch_profile_returns_target_model():
     """
     import api.profiles as profiles
     from pathlib import Path
-    import tempfile
 
     with tempfile.TemporaryDirectory() as tmp:
         base = Path(tmp)
         target = base / "profiles" / "myp"
         target.mkdir(parents=True)
-        ws = base / "mypws"; ws.mkdir()
+        ws = base / "mypws"
+        ws.mkdir()
         (target / "config.yaml").write_text(
             f"model:\n  default: my-target-model\nterminal:\n  cwd: {ws}\n",
             encoding="utf-8",
@@ -567,7 +575,9 @@ def test_chat_start_does_not_retag_non_empty_session(monkeypatch, tmp_path):
             pass
 
     monkeypatch.setattr(routes.threading, "Thread", FakeThread)
-    monkeypatch.setattr(routes, "j", lambda handler, payload, status=200, **kwargs: payload)
+    monkeypatch.setattr(
+        routes, "j", lambda handler, payload, status=200, **kwargs: payload
+    )
 
     routes._handle_chat_start(
         object(),

--- a/tests/test_profile_switch_ux.py
+++ b/tests/test_profile_switch_ux.py
@@ -7,6 +7,7 @@ Two changes:
 2. populateModelDropdown() and loadWorkspaceList() are now parallelized via Promise.all
    instead of sequential awaits.
 """
+
 import re
 from pathlib import Path
 
@@ -23,11 +24,12 @@ class TestProfileSwitchSpinner:
         assert idx != -1, "switchToProfile not found in panels.js"
         depth = 0
         for i, ch in enumerate(self.JS[idx:], idx):
-            if ch == "{": depth += 1
+            if ch == "{":
+                depth += 1
             elif ch == "}":
                 depth -= 1
                 if depth == 0:
-                    return self.JS[idx: i + 1]
+                    return self.JS[idx : i + 1]
         raise AssertionError("Could not extract switchToProfile")
 
     def test_switching_class_added_on_start(self):
@@ -88,11 +90,12 @@ class TestParallelizedFetches:
         assert idx != -1
         depth = 0
         for i, ch in enumerate(self.JS[idx:], idx):
-            if ch == "{": depth += 1
+            if ch == "{":
+                depth += 1
             elif ch == "}":
                 depth -= 1
                 if depth == 0:
-                    return self.JS[idx: i + 1]
+                    return self.JS[idx : i + 1]
         raise AssertionError("Could not extract switchToProfile")
 
     def test_populate_and_workspace_in_promise_all(self):
@@ -106,8 +109,7 @@ class TestParallelizedFetches:
         """The old sequential await pattern must be gone."""
         fn = self._get_switch_fn()
         sequential = re.search(
-            r"await populateModelDropdown\(\)\s*;\s*\n\s*await loadWorkspaceList",
-            fn
+            r"await populateModelDropdown\(\)\s*;\s*\n\s*await loadWorkspaceList", fn
         )
         assert not sequential, (
             "Old sequential await pattern still present — both fetches would run twice."
@@ -135,11 +137,11 @@ class TestSpinnerCss:
     def test_switching_class_has_cursor_wait(self):
         idx = self.CSS.find(".composer-profile-chip.switching")
         assert idx != -1
-        block = self.CSS[idx: idx + 200]
+        block = self.CSS[idx : idx + 200]
         assert "cursor:wait" in block
 
     def test_switching_class_has_pointer_events_none(self):
         idx = self.CSS.find(".composer-profile-chip.switching")
         assert idx != -1
-        block = self.CSS[idx: idx + 200]
+        block = self.CSS[idx : idx + 200]
         assert "pointer-events:none" in block

--- a/tests/test_profile_terminal_env.py
+++ b/tests/test_profile_terminal_env.py
@@ -1,4 +1,3 @@
-import os
 import re
 from pathlib import Path
 
@@ -62,7 +61,10 @@ def test_streaming_thread_env_allows_profile_terminal_cwd_override():
     assert "def _build_agent_thread_env" in src
     assert "_thread_env = _build_agent_thread_env(" in src
     assert "_set_thread_env(**_thread_env)" in src
-    assert "_set_thread_env(\n            **_profile_runtime_env,\n            TERMINAL_CWD" not in src
+    assert (
+        "_set_thread_env(\n            **_profile_runtime_env,\n            TERMINAL_CWD"
+        not in src
+    )
 
     match = re.search(
         r"(def _build_agent_thread_env\(.*?\n)(?=\ndef |\nclass )",

--- a/tests/test_project_chip_ui.py
+++ b/tests/test_project_chip_ui.py
@@ -33,7 +33,6 @@ STYLE_CSS = (REPO / "static" / "style.css").read_text(encoding="utf-8")
 
 
 class TestContextMenuBackground:
-
     def test_panel_variable_not_defined_in_stylesheet(self):
         """`--panel` is not defined as a CSS custom property anywhere — so
         any rule using `var(--panel)` falls back to `transparent`, which is
@@ -54,7 +53,7 @@ class TestContextMenuBackground:
         idx = SESSIONS_JS.find("project-ctx-menu")
         assert idx >= 0, "project-ctx-menu className not found in sessions.js"
         # Look at the surrounding 800 chars where the cssText is set
-        window = SESSIONS_JS[idx: idx + 1200]
+        window = SESSIONS_JS[idx : idx + 1200]
         assert "background:var(--surface)" in window, (
             "Project context menu must use background:var(--surface) for an "
             "opaque surface — var(--panel) is undefined and falls back to "
@@ -73,7 +72,7 @@ class TestContextMenuBackground:
         # Find the rule and confirm it uses --surface
         idx = STYLE_CSS.find(".session-action-menu")
         assert idx >= 0
-        rule = STYLE_CSS[idx: idx + 400]
+        rule = STYLE_CSS[idx : idx + 400]
         assert "var(--surface)" in rule, (
             ".session-action-menu should use var(--surface) — kept here as "
             "the canonical reference for opaque popover surfaces."
@@ -84,12 +83,11 @@ class TestContextMenuBackground:
 
 
 class TestProjectCreateInputWidth:
-
     def test_no_hardcoded_100px_width(self):
         """The fixed `width: 100px` on .project-create-input is gone."""
         idx = STYLE_CSS.find(".project-create-input{")
         assert idx >= 0, ".project-create-input rule not found in style.css"
-        rule = STYLE_CSS[idx: idx + 400]
+        rule = STYLE_CSS[idx : idx + 400]
         assert "width:100px" not in rule and "width: 100px" not in rule, (
             "Fixed 100px width must be replaced with min-width/max-width/"
             "width:auto so the input grows with its content."
@@ -98,7 +96,7 @@ class TestProjectCreateInputWidth:
     def test_min_and_max_width_present(self):
         """Both min-width and max-width must be set on .project-create-input."""
         idx = STYLE_CSS.find(".project-create-input{")
-        rule = STYLE_CSS[idx: idx + 400]
+        rule = STYLE_CSS[idx : idx + 400]
         assert "min-width:40px" in rule, (
             f"min-width:40px not found in .project-create-input rule: {rule}"
         )
@@ -125,13 +123,14 @@ class TestResizeProjectInputHelper:
         via getComputedStyle so the sizer stays calibrated if CSS changes."""
         idx = SESSIONS_JS.find("function _resizeProjectInput(")
         assert idx >= 0
-        body = SESSIONS_JS[idx: idx + 900]
+        body = SESSIONS_JS[idx : idx + 900]
         assert "position:absolute" in body and "visibility:hidden" in body, (
             "_resizeProjectInput should use a hidden absolute span to "
             "measure the value's rendered width."
         )
         assert "getComputedStyle(inp)" in body, (
-            "_resizeProjectInput should use getComputedStyle to read font "            "properties so the sizer stays calibrated if CSS changes."
+            "_resizeProjectInput should use getComputedStyle to read font "
+            "properties so the sizer stays calibrated if CSS changes."
         )
         assert "Math.min(180" in body, (
             "max bound (180) not applied in _resizeProjectInput"
@@ -145,7 +144,7 @@ class TestResizeProjectInputHelper:
         creation and again on every input event."""
         idx = SESSIONS_JS.find("function _startProjectRename(")
         assert idx >= 0
-        body = SESSIONS_JS[idx: idx + 1200]
+        body = SESSIONS_JS[idx : idx + 1200]
         assert "_resizeProjectInput(inp)" in body, (
             "_startProjectRename must call _resizeProjectInput so the "
             "input width matches the existing project name."
@@ -159,7 +158,7 @@ class TestResizeProjectInputHelper:
         """Same for `_startProjectCreate` (new-project entry field)."""
         idx = SESSIONS_JS.find("function _startProjectCreate(")
         assert idx >= 0
-        body = SESSIONS_JS[idx: idx + 1200]
+        body = SESSIONS_JS[idx : idx + 1200]
         assert "_resizeProjectInput(inp)" in body, (
             "_startProjectCreate must call _resizeProjectInput on focus"
         )

--- a/tests/test_provider_management.py
+++ b/tests/test_provider_management.py
@@ -28,7 +28,9 @@ def _post(path, body=None):
     """POST helper — returns (parsed_json, status_code)."""
     data = json.dumps(body or {}).encode()
     req = urllib.request.Request(
-        BASE + path, data=data, headers={"Content-Type": "application/json"},
+        BASE + path,
+        data=data,
+        headers={"Content-Type": "application/json"},
     )
     try:
         with urllib.request.urlopen(req, timeout=10) as r:
@@ -62,6 +64,7 @@ def _install_fake_hermes_cli(monkeypatch):
     # Flush the 60-second TTL model cache so no prior test's result bleeds in.
     try:
         from api.config import invalidate_models_cache
+
         invalidate_models_cache()
     except Exception:
         pass
@@ -88,6 +91,7 @@ class TestGetProviders:
             config._cfg_mtime = 0.0
 
         from api.providers import get_providers
+
         try:
             result = get_providers()
             assert "providers" in result
@@ -118,10 +122,11 @@ class TestGetProviders:
             config._cfg_mtime = 0.0
 
         from api.providers import get_providers
+
         try:
             result = get_providers()
             for p in result["providers"]:
-                assert "id" in p, f"Missing 'id' in provider entry"
+                assert "id" in p, "Missing 'id' in provider entry"
                 assert "display_name" in p, f"Missing 'display_name' for {p['id']}"
                 assert "has_key" in p, f"Missing 'has_key' for {p['id']}"
                 assert "configurable" in p, f"Missing 'configurable' for {p['id']}"
@@ -148,20 +153,27 @@ class TestGetProviders:
             config._cfg_mtime = 0.0
 
         from api.providers import get_providers
+
         try:
             result = get_providers()
             for p in result["providers"]:
                 if p["id"] in ("copilot", "nous", "openai-codex"):
-                    assert p["configurable"] is False, f"{p['id']} should not be configurable"
+                    assert p["configurable"] is False, (
+                        f"{p['id']} should not be configurable"
+                    )
                 # ollama-cloud is now configurable (uses OLLAMA_API_KEY)
                 if p["id"] == "ollama-cloud":
-                    assert p["configurable"] is True, "ollama-cloud should be configurable"
+                    assert p["configurable"] is True, (
+                        "ollama-cloud should be configurable"
+                    )
         finally:
             config.cfg.clear()
             config.cfg.update(old_cfg)
             config._cfg_mtime = old_mtime
 
-    def test_openai_codex_provider_card_prefers_live_catalog(self, monkeypatch, tmp_path):
+    def test_openai_codex_provider_card_prefers_live_catalog(
+        self, monkeypatch, tmp_path
+    ):
         """OpenAI Codex provider cards should not advertise stale static fallback models.
 
         /api/models already uses hermes_cli/Codex cache discovery for Codex.  The
@@ -193,6 +205,7 @@ class TestGetProviders:
             config._cfg_mtime = 0.0
 
         from api.providers import get_providers
+
         try:
             result = get_providers()
             codex = next(p for p in result["providers"] if p["id"] == "openai-codex")
@@ -233,6 +246,7 @@ class TestSetProviderKey:
             config._cfg_mtime = 0.0
 
         from api.providers import set_provider_key
+
         try:
             result = set_provider_key("anthropic", "sk-ant-test-key-12345678")
             assert result["ok"] is True
@@ -241,7 +255,9 @@ class TestSetProviderKey:
 
             # Verify .env file was written
             env_path = tmp_path / ".env"
-            assert env_path.exists(), f".env not written to {env_path}; HERMES_HOME={__import__('os').environ.get('HERMES_HOME')!r}"
+            assert env_path.exists(), (
+                f".env not written to {env_path}; HERMES_HOME={__import__('os').environ.get('HERMES_HOME')!r}"
+            )
             content = env_path.read_text()
             assert "ANTHROPIC_API_KEY=sk-ant-test-key-12345678" in content
         finally:
@@ -264,6 +280,7 @@ class TestSetProviderKey:
             config._cfg_mtime = 0.0
 
         from api.providers import set_provider_key
+
         try:
             # First set a key
             set_provider_key("anthropic", "sk-ant-test-key-12345678")
@@ -296,6 +313,7 @@ class TestSetProviderKey:
             config._cfg_mtime = 0.0
 
         from api.providers import set_provider_key
+
         try:
             result = set_provider_key("copilot", "some-key")
             assert result["ok"] is False
@@ -320,6 +338,7 @@ class TestSetProviderKey:
             config._cfg_mtime = 0.0
 
         from api.providers import set_provider_key
+
         try:
             result = set_provider_key("anthropic", "short")
             assert result["ok"] is False
@@ -332,6 +351,7 @@ class TestSetProviderKey:
     def test_empty_provider_id_rejected(self, monkeypatch, tmp_path):
         """Empty provider ID should be rejected."""
         from api.providers import set_provider_key
+
         result = set_provider_key("", "some-key")
         assert result["ok"] is False
         assert "required" in result["error"]
@@ -339,6 +359,7 @@ class TestSetProviderKey:
     def test_newline_in_key_rejected(self, monkeypatch, tmp_path):
         """API keys with newlines should be rejected."""
         from api.providers import set_provider_key
+
         result = set_provider_key("anthropic", "sk-ant-key\nINJECTED=evil")
         assert result["ok"] is False
         assert "newline" in result["error"]
@@ -347,7 +368,9 @@ class TestSetProviderKey:
 class TestRemoveProviderKey:
     """Unit tests for remove_provider_key() wrapper."""
 
-    def test_clean_provider_key_uses_late_bound_config_path(self, monkeypatch, tmp_path):
+    def test_clean_provider_key_uses_late_bound_config_path(
+        self, monkeypatch, tmp_path
+    ):
         """Config cleanup must honor api.config._get_config_path monkeypatches.
 
         PR #1597 fixed provider-key cleanup by resolving the config path through
@@ -371,7 +394,9 @@ class TestRemoveProviderKey:
             encoding="utf-8",
         )
 
-        monkeypatch.setattr(providers, "_get_config_path", lambda: stale_config, raising=False)
+        monkeypatch.setattr(
+            providers, "_get_config_path", lambda: stale_config, raising=False
+        )
         monkeypatch.setattr(cfg_mod, "_get_config_path", lambda: active_config)
         monkeypatch.setattr(providers, "reload_config", lambda: None)
 
@@ -398,6 +423,7 @@ class TestRemoveProviderKey:
             config._cfg_mtime = 0.0
 
         from api.providers import remove_provider_key
+
         try:
             result = remove_provider_key("anthropic")
             assert result["ok"] is True
@@ -422,29 +448,38 @@ class TestProvidersEndpoints:
 
     def test_post_provider_set_key(self):
         """POST /api/providers with provider + api_key should set the key."""
-        body, status = _post("/api/providers", {
-            "provider": "anthropic",
-            "api_key": "sk-ant-integration-test-key-12345678",
-        })
+        body, status = _post(
+            "/api/providers",
+            {
+                "provider": "anthropic",
+                "api_key": "sk-ant-integration-test-key-12345678",
+            },
+        )
         assert status == 200
         assert body.get("ok") is True
         assert body.get("provider") == "anthropic"
 
     def test_post_provider_remove_key(self):
         """POST /api/providers with provider but no api_key should remove the key."""
-        body, status = _post("/api/providers", {
-            "provider": "anthropic",
-            "api_key": None,
-        })
+        body, status = _post(
+            "/api/providers",
+            {
+                "provider": "anthropic",
+                "api_key": None,
+            },
+        )
         assert status == 200
         assert body.get("ok") is True
         assert body.get("action") == "removed"
 
     def test_post_provider_delete(self):
         """POST /api/providers/delete should remove the key."""
-        body, status = _post("/api/providers/delete", {
-            "provider": "anthropic",
-        })
+        body, status = _post(
+            "/api/providers/delete",
+            {
+                "provider": "anthropic",
+            },
+        )
         assert status == 200
         assert body.get("ok") is True
 
@@ -475,7 +510,9 @@ class TestIssue1410OllamaEnvVarBleed:
     """
 
     def test_ollama_local_not_configured_when_only_cloud_env_var_set(
-        self, monkeypatch, tmp_path,
+        self,
+        monkeypatch,
+        tmp_path,
     ):
         """OLLAMA_API_KEY in env should mark ollama-cloud configured but not bare ollama."""
         _install_fake_hermes_cli(monkeypatch)
@@ -492,13 +529,17 @@ class TestIssue1410OllamaEnvVarBleed:
             config._cfg_mtime = 0.0
 
         from api.providers import get_providers
+
         try:
             result = get_providers()
             by_id = {p["id"]: p for p in result["providers"]}
-            assert "ollama-cloud" in by_id, "ollama-cloud should appear in provider list"
+            assert "ollama-cloud" in by_id, (
+                "ollama-cloud should appear in provider list"
+            )
             assert "ollama" in by_id, "ollama (local) should appear in provider list"
-            assert by_id["ollama-cloud"]["has_key"] is True, \
+            assert by_id["ollama-cloud"]["has_key"] is True, (
                 "ollama-cloud should be has_key=True when OLLAMA_API_KEY is set"
+            )
             assert by_id["ollama"]["has_key"] is False, (
                 "ollama (local) must NOT be has_key=True when only the cloud env "
                 "var is set — local Ollama is keyless and shares no env var with "
@@ -515,7 +556,9 @@ class TestIssue1410OllamaEnvVarBleed:
             config._cfg_mtime = old_mtime
 
     def test_ollama_local_still_configured_via_config_yaml(
-        self, monkeypatch, tmp_path,
+        self,
+        monkeypatch,
+        tmp_path,
     ):
         """providers.ollama.api_key in config.yaml should still mark local ollama configured."""
         _install_fake_hermes_cli(monkeypatch)
@@ -534,6 +577,7 @@ class TestIssue1410OllamaEnvVarBleed:
             config._cfg_mtime = 0.0
 
         from api.providers import get_providers
+
         try:
             result = get_providers()
             by_id = {p["id"]: p for p in result["providers"]}

--- a/tests/test_provider_mismatch.py
+++ b/tests/test_provider_mismatch.py
@@ -10,6 +10,7 @@ Covers:
   5. static/boot.js: modelSelect.onchange calls _checkProviderMismatch
   6. /api/models: response includes active_provider field
 """
+
 import json
 import pathlib
 import re
@@ -34,6 +35,7 @@ def _post(path, body=None):
 
 
 # ── 1. streaming.py: auth error detection ───────────────────────────────────
+
 
 class TestStreamingAuthErrorDetection:
     """streaming.py must classify auth/401 errors as auth_mismatch."""
@@ -61,7 +63,7 @@ class TestStreamingAuthErrorDetection:
         # Variable renamed to _exc_is_auth in exception path, _is_auth in silent-failure path
         idx = src.find("_exc_is_auth")
         assert idx != -1
-        block = src[idx:idx + 500]
+        block = src[idx : idx + 500]
         assert "'401'" in block or '"401"' in block, (
             "'401' not in auth error detection block"
         )
@@ -71,7 +73,7 @@ class TestStreamingAuthErrorDetection:
         src = _read("api/streaming.py")
         # Variable renamed to _exc_is_auth in exception path
         idx = src.find("_exc_is_auth")
-        block = src[idx:idx + 500]
+        block = src[idx : idx + 500]
         assert "unauthorized" in block.lower(), (
             "'unauthorized' not in auth error detection block"
         )
@@ -81,7 +83,7 @@ class TestStreamingAuthErrorDetection:
         src = _read("api/streaming.py")
         # Find the auth_mismatch apperror block
         idx = src.find("auth_mismatch")
-        block = src[idx:idx + 500]
+        block = src[idx : idx + 500]
         assert "hermes model" in block, (
             "auth_mismatch hint must mention 'hermes model' command "
             "so users know how to fix provider mismatch"
@@ -94,7 +96,9 @@ class TestStreamingAuthErrorDetection:
         # Quota check comes first (before rate limit), then rate limit, then auth
         rl_idx = src.find("_exc_is_rate_limit")
         ae_idx = src.find("_exc_is_auth")
-        assert rl_idx != -1, "_exc_is_rate_limit not found in streaming.py exception path"
+        assert rl_idx != -1, (
+            "_exc_is_rate_limit not found in streaming.py exception path"
+        )
         assert ae_idx != -1, "_exc_is_auth not found in streaming.py exception path"
         assert rl_idx < ae_idx, (
             "_exc_is_rate_limit check should precede _exc_is_auth — "
@@ -103,6 +107,7 @@ class TestStreamingAuthErrorDetection:
 
 
 # ── 2. static/ui.js: _checkProviderMismatch() ───────────────────────────────
+
 
 class TestCheckProviderMismatch:
     """ui.js must expose _checkProviderMismatch() helper."""
@@ -118,7 +123,7 @@ class TestCheckProviderMismatch:
         """Function must read window._activeProvider."""
         src = _read("static/ui.js")
         idx = src.find("function _checkProviderMismatch")
-        block = src[idx:idx + 800]
+        block = src[idx : idx + 800]
         assert "_activeProvider" in block, (
             "_checkProviderMismatch must read window._activeProvider"
         )
@@ -127,7 +132,7 @@ class TestCheckProviderMismatch:
         """OpenRouter can route to any provider — skip the warning."""
         src = _read("static/ui.js")
         idx = src.find("function _checkProviderMismatch")
-        block = src[idx:idx + 800]
+        block = src[idx : idx + 800]
         assert "openrouter" in block.lower(), (
             "_checkProviderMismatch must skip the check for openrouter"
         )
@@ -136,7 +141,7 @@ class TestCheckProviderMismatch:
         """Custom endpoints can serve any model — skip the warning."""
         src = _read("static/ui.js")
         idx = src.find("function _checkProviderMismatch")
-        block = src[idx:idx + 800]
+        block = src[idx : idx + 800]
         assert "custom" in block.lower(), (
             "_checkProviderMismatch must skip the check for custom provider"
         )
@@ -147,7 +152,7 @@ class TestCheckProviderMismatch:
         # Find the function definition (skip the comment that also mentions the name)
         idx = src.find("async function populateModelDropdown")
         assert idx != -1, "async function populateModelDropdown not found"
-        block = src[idx:idx + 800]
+        block = src[idx : idx + 800]
         assert "_activeProvider" in block, (
             "populateModelDropdown must set window._activeProvider "
             "from the /api/models response"
@@ -155,6 +160,7 @@ class TestCheckProviderMismatch:
 
 
 # ── 3. static/messages.js: apperror handler ─────────────────────────────────
+
 
 class TestApperrorHandler:
     """messages.js apperror handler must handle auth_mismatch type."""
@@ -183,6 +189,7 @@ class TestApperrorHandler:
 
 # ── 4. static/i18n.js: all locales ───────────────────────────────────────────
 
+
 class TestI18nProviderMismatch:
     """All locales must have provider_mismatch_warning and provider_mismatch_label."""
 
@@ -199,7 +206,7 @@ class TestI18nProviderMismatch:
         return names
 
     def _count_key(self, src: str, key: str) -> int:
-        return len(re.findall(r'\b' + re.escape(key) + r'\b', src))
+        return len(re.findall(r"\b" + re.escape(key) + r"\b", src))
 
     def test_all_locales_have_warning_key(self):
         """provider_mismatch_warning must appear in all locales."""
@@ -229,7 +236,7 @@ class TestI18nProviderMismatch:
         en_block = src[en_start:es_start]
         assert "provider_mismatch_warning" in en_block, "Key not in en block"
         idx = en_block.find("provider_mismatch_warning")
-        line = en_block[idx:idx + 200]
+        line = en_block[idx : idx + 200]
         # Must be a function, not a plain string
         assert "=>" in line, (
             "provider_mismatch_warning in en locale must be an arrow function "
@@ -248,6 +255,7 @@ class TestI18nProviderMismatch:
 
 # ── 5. static/boot.js: dropdown change handler ──────────────────────────────
 
+
 class TestBootModelSelectChange:
     """boot.js modelSelect.onchange must call _checkProviderMismatch."""
 
@@ -264,7 +272,7 @@ class TestBootModelSelectChange:
             # Try alternate patterns
             idx = src.find("modelSelect")
         block_start = src.rfind("\n", 0, src.find("_checkProviderMismatch")) or 0
-        surrounding = src[max(0, block_start - 200):block_start + 400]
+        surrounding = src[max(0, block_start - 200) : block_start + 400]
         assert "modelSelect" in surrounding or "selectedModel" in surrounding, (
             "_checkProviderMismatch must be called in the context of model selection"
         )
@@ -275,13 +283,14 @@ class TestBootModelSelectChange:
         # Both _checkProviderMismatch call and showToast must be near each other
         idx = src.find("_checkProviderMismatch")
         assert idx != -1, "_checkProviderMismatch not found in boot.js"
-        block = src[idx:idx + 300]
+        block = src[idx : idx + 300]
         assert "showToast" in block, (
             "Provider mismatch warning must be shown via showToast(), not alert()"
         )
 
 
 # ── 6. /api/models: active_provider in response ──────────────────────────────
+
 
 def test_api_models_includes_active_provider():
     """/api/models must include 'active_provider' key in response."""
@@ -317,7 +326,9 @@ def test_codex_provider_qualified_model_routes_to_codex_not_openrouter():
     assert base_url is None
 
 
-def test_default_model_save_persists_codex_provider_for_qualified_model(tmp_path, monkeypatch):
+def test_default_model_save_persists_codex_provider_for_qualified_model(
+    tmp_path, monkeypatch
+):
     """Saving @openai-codex:gpt-5.5 must persist model.provider=openai-codex."""
     import yaml
     import api.config as config
@@ -413,14 +424,18 @@ def test_bare_codex_gpt_session_model_gets_separate_provider_context(monkeypatch
         },
     )
 
-    effective, provider, changed = routes._resolve_compatible_session_model_state("gpt-5.5")
+    effective, provider, changed = routes._resolve_compatible_session_model_state(
+        "gpt-5.5"
+    )
 
     assert changed is False
     assert effective == "gpt-5.5"
     assert provider == "openai-codex"
 
 
-def test_session_model_normalizer_keeps_bare_codex_model_and_saves_provider(monkeypatch):
+def test_session_model_normalizer_keeps_bare_codex_model_and_saves_provider(
+    monkeypatch,
+):
     """Write-path normalization must persist model_provider without adding @."""
     import api.routes as routes
 
@@ -583,7 +598,9 @@ def test_bare_gemini_session_model_normalizes_to_active_provider_default(monkeyp
     assert effective == "gpt-5.4-mini"
 
 
-def test_prefixed_google_session_model_normalizes_to_active_provider_default(monkeypatch):
+def test_prefixed_google_session_model_normalizes_to_active_provider_default(
+    monkeypatch,
+):
     """Persisted provider-prefixed Gemini IDs must normalize too."""
     import api.routes as routes
 
@@ -624,9 +641,7 @@ def test_legacy_at_provider_session_model_normalizes_when_provider_hidden(monkey
         },
     )
 
-    effective, changed = routes._resolve_compatible_session_model(
-        "@copilot:gpt-5.5"
-    )
+    effective, changed = routes._resolve_compatible_session_model("@copilot:gpt-5.5")
 
     assert changed is True
     assert effective == "gpt-5.5"
@@ -694,9 +709,7 @@ def test_routable_non_active_at_provider_session_model_is_preserved(monkeypatch)
         },
     )
 
-    effective, changed = routes._resolve_compatible_session_model(
-        "@copilot:gpt-5.4"
-    )
+    effective, changed = routes._resolve_compatible_session_model("@copilot:gpt-5.4")
 
     assert changed is False
     assert effective == "@copilot:gpt-5.4"
@@ -746,9 +759,7 @@ def test_issue1253_duplicate_model_id_active_provider_hint_preserved(monkeypatch
         f"_resolve_compatible_session_model must not strip @custom:edith "
         f"(got effective='{effective}', changed={changed})"
     )
-    assert effective == "@custom:edith", (
-        f"expected '@custom:edith', got '{effective}'"
-    )
+    assert effective == "@custom:edith", f"expected '@custom:edith', got '{effective}'"
 
 
 def test_named_custom_provider_hint_with_colon_is_preserved(monkeypatch):
@@ -881,7 +892,12 @@ def test_issue1734_chat_start_persists_repaired_codex_provider(monkeypatch):
     class FakeThread:
         def __init__(self, target, args=(), kwargs=None, daemon=None):
             captured_thread.update(
-                {"target": target, "args": args, "kwargs": kwargs or {}, "daemon": daemon}
+                {
+                    "target": target,
+                    "args": args,
+                    "kwargs": kwargs or {},
+                    "daemon": daemon,
+                }
             )
 
         def start(self):
@@ -905,7 +921,9 @@ def test_issue1734_chat_start_persists_repaired_codex_provider(monkeypatch):
     session = DummySession()
     monkeypatch.setattr(routes, "get_session", lambda sid: session)
     monkeypatch.setattr(routes, "resolve_trusted_workspace", lambda value: value)
-    monkeypatch.setattr(routes, "_get_session_agent_lock", lambda sid: contextlib.nullcontext())
+    monkeypatch.setattr(
+        routes, "_get_session_agent_lock", lambda sid: contextlib.nullcontext()
+    )
     monkeypatch.setattr(routes, "set_last_workspace", lambda workspace: None)
     monkeypatch.setattr(routes, "create_stream_channel", lambda: object())
     monkeypatch.setattr(routes.threading, "Thread", FakeThread)
@@ -1065,7 +1083,9 @@ def test_api_session_is_side_effect_free_for_stale_models():
         payload = json.loads(r.read())
 
     after = session_path.read_text(encoding="utf-8")
-    assert payload["session"]["model"], "response should still expose an effective display model"
+    assert payload["session"]["model"], (
+        "response should still expose an effective display model"
+    )
     assert payload["session"]["model"] != stale_model, (
         "response model should be compatibility-normalized on the read path"
     )
@@ -1077,6 +1097,7 @@ def test_api_session_is_side_effect_free_for_stale_models():
 
 # ── Model switch toast (#419) ─────────────────────────────────────────────────
 
+
 class TestModelSwitchToast:
     """Toast appears when user switches the current conversation model."""
 
@@ -1086,7 +1107,7 @@ class TestModelSwitchToast:
         # Find the onchange block
         idx = src.find("modelSelect').onchange")
         assert idx != -1, "modelSelect.onchange not found in boot.js"
-        block = src[idx:idx + 1100]
+        block = src[idx : idx + 1100]
         assert "model_scope_toast" in block, (
             "modelSelect.onchange must show that the selected model applies to this conversation"
         )
@@ -1096,7 +1117,7 @@ class TestModelSwitchToast:
         src = _read("static/boot.js")
         idx = src.find("model_scope_toast")
         assert idx != -1
-        surrounding = src[max(0, idx - 220):idx + 80]
+        surrounding = src[max(0, idx - 220) : idx + 80]
         assert not ("S.messages" in surrounding and ".length" in surrounding), (
             "Model scope toast should not be gated on S.messages.length"
         )
@@ -1106,7 +1127,7 @@ class TestModelSwitchToast:
         src = _read("static/boot.js")
         idx = src.find("model_scope_toast")
         assert idx != -1
-        surrounding = src[max(0, idx - 50):idx + 100]
+        surrounding = src[max(0, idx - 50) : idx + 100]
         assert "showToast" in surrounding, "Must use showToast() not alert()"
         assert "alert(" not in surrounding, "Must not use alert()"
 
@@ -1115,7 +1136,7 @@ class TestModelSwitchToast:
         src = _read("static/boot.js")
         idx = src.find("model_scope_toast")
         assert idx != -1
-        surrounding = src[max(0, idx - 100):idx + 50]
+        surrounding = src[max(0, idx - 100) : idx + 50]
         assert "typeof showToast" in surrounding, (
             "showToast call must be guarded with typeof check"
         )
@@ -1130,9 +1151,10 @@ class TestChatStartEffectiveModelRecovery:
             "send() must read effective_model from /api/chat/start so the UI can "
             "recover from stale persisted session models"
         )
-        assert "localStorage.setItem('hermes-webui-model', startData.effective_model)" in src, (
-            "effective_model correction must update the saved model preference"
-        )
+        assert (
+            "localStorage.setItem('hermes-webui-model', startData.effective_model)"
+            in src
+        ), "effective_model correction must update the saved model preference"
         assert "startData.effective_model_provider" in src, (
             "send() must preserve provider context returned by /api/chat/start"
         )
@@ -1223,6 +1245,7 @@ def test_empty_model_session_does_not_trigger_save(monkeypatch):
 
 # ── Issue #829: stale cross-provider model on custom_providers-only setup ─────
 
+
 def test_stale_openai_model_cleared_for_custom_only_provider(monkeypatch):
     """A stale openai/... session model must be cleared when active provider is
     'custom' and no catalog group can route the openai prefix (#829)."""
@@ -1235,15 +1258,16 @@ def test_stale_openai_model_cleared_for_custom_only_provider(monkeypatch):
             "active_provider": "custom",
             "default_model": "",
             "groups": [
-                {"provider": "Agent37", "provider_id": "custom:agent37",
-                 "models": [{"id": "agent37/default", "label": "default"}]},
+                {
+                    "provider": "Agent37",
+                    "provider_id": "custom:agent37",
+                    "models": [{"id": "agent37/default", "label": "default"}],
+                },
             ],
         },
     )
 
-    effective, changed = routes._resolve_compatible_session_model(
-        "openai/gpt-5.4-mini"
-    )
+    effective, changed = routes._resolve_compatible_session_model("openai/gpt-5.4-mini")
 
     # No routable group for openai/ — should clear to default (empty → model itself
     # only if no default available, which means changed=False when default_model="")
@@ -1264,15 +1288,16 @@ def test_stale_openai_model_cleared_for_custom_provider_with_default(monkeypatch
             "active_provider": "custom",
             "default_model": "agent37/default",
             "groups": [
-                {"provider": "Agent37", "provider_id": "custom:agent37",
-                 "models": [{"id": "agent37/default", "label": "default"}]},
+                {
+                    "provider": "Agent37",
+                    "provider_id": "custom:agent37",
+                    "models": [{"id": "agent37/default", "label": "default"}],
+                },
             ],
         },
     )
 
-    effective, changed = routes._resolve_compatible_session_model(
-        "openai/gpt-5.4-mini"
-    )
+    effective, changed = routes._resolve_compatible_session_model("openai/gpt-5.4-mini")
 
     assert changed is True
     assert effective == "agent37/default"
@@ -1290,15 +1315,16 @@ def test_openrouter_model_preserved_when_openrouter_group_present(monkeypatch):
             "active_provider": "openrouter",
             "default_model": "openai/gpt-5.4-mini",
             "groups": [
-                {"provider": "OpenRouter", "provider_id": "openrouter",
-                 "models": [{"id": "openai/gpt-5.4-mini", "label": "GPT-5.4 Mini"}]},
+                {
+                    "provider": "OpenRouter",
+                    "provider_id": "openrouter",
+                    "models": [{"id": "openai/gpt-5.4-mini", "label": "GPT-5.4 Mini"}],
+                },
             ],
         },
     )
 
-    effective, changed = routes._resolve_compatible_session_model(
-        "openai/gpt-5.4-mini"
-    )
+    effective, changed = routes._resolve_compatible_session_model("openai/gpt-5.4-mini")
 
     assert changed is False
     assert effective == "openai/gpt-5.4-mini"
@@ -1316,15 +1342,16 @@ def test_custom_namespace_model_always_preserved_on_custom_provider(monkeypatch)
             "active_provider": "custom",
             "default_model": "agent37/default",
             "groups": [
-                {"provider": "Agent37", "provider_id": "custom:agent37",
-                 "models": [{"id": "agent37/default", "label": "default"}]},
+                {
+                    "provider": "Agent37",
+                    "provider_id": "custom:agent37",
+                    "models": [{"id": "agent37/default", "label": "default"}],
+                },
             ],
         },
     )
 
-    effective, changed = routes._resolve_compatible_session_model(
-        "custom/my-local-llm"
-    )
+    effective, changed = routes._resolve_compatible_session_model("custom/my-local-llm")
 
     assert changed is False
     assert effective == "custom/my-local-llm"
@@ -1335,8 +1362,11 @@ def test_stale_ui_js_does_not_inject_unavailable_option():
     modelSelect when the session model is not in the provider list (#829).
     It should silently reset to the first available model instead."""
     import os
-    src = open(os.path.join(os.path.dirname(__file__), "..", "static", "ui.js"),
-               encoding="utf-8").read()
+
+    src = open(
+        os.path.join(os.path.dirname(__file__), "..", "static", "ui.js"),
+        encoding="utf-8",
+    ).read()
 
     # The old pattern must be gone — both keys removed from ui.js
     assert "model_unavailable" not in src and "model_unavailable_title" not in src, (

--- a/tests/test_provider_quota_status.py
+++ b/tests/test_provider_quota_status.py
@@ -52,21 +52,33 @@ def _restore_config(old_cfg, old_mtime):
     config._cfg_mtime = old_mtime
 
 
-def test_openrouter_quota_fetches_key_endpoint_and_sanitizes_response(monkeypatch, tmp_path):
+def test_openrouter_quota_fetches_key_endpoint_and_sanitizes_response(
+    monkeypatch, tmp_path
+):
     """OpenRouter's documented key endpoint should be called server-side only."""
     monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
     monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
-    (tmp_path / ".env").write_text("OPENROUTER_API_KEY=test-openrouter-key-private\n", encoding="utf-8")
+    (tmp_path / ".env").write_text(
+        "OPENROUTER_API_KEY=test-openrouter-key-private\n", encoding="utf-8"
+    )
     old_cfg, old_mtime = _with_config(model={"provider": "openrouter"})
 
     import api.providers as providers
+
     seen = {}
 
     def fake_urlopen(req, timeout):
         seen["url"] = req.full_url
         seen["timeout"] = timeout
         seen["authorization"] = req.headers.get("Authorization")
-        payload = {"data": {"limit_remaining": "12.5", "usage": 3, "limit": 20, "key": "must-not-leak"}}
+        payload = {
+            "data": {
+                "limit_remaining": "12.5",
+                "usage": 3,
+                "limit": 20,
+                "key": "must-not-leak",
+            }
+        }
         return _FakeResponse(json.dumps(payload).encode("utf-8"))
 
     monkeypatch.setattr(providers.urllib.request, "urlopen", fake_urlopen)
@@ -94,7 +106,9 @@ def test_openrouter_quota_fetches_key_endpoint_and_sanitizes_response(monkeypatc
     assert "must-not-leak" not in repr(result)
 
 
-def test_openrouter_quota_no_key_returns_safe_no_key_without_network(monkeypatch, tmp_path):
+def test_openrouter_quota_no_key_returns_safe_no_key_without_network(
+    monkeypatch, tmp_path
+):
     """No-key state must not call OpenRouter or leak environment details."""
     monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
     monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
@@ -123,17 +137,22 @@ def test_openrouter_quota_invalid_key_and_timeout_are_sanitized(monkeypatch, tmp
     """Invalid-key and timeout/error paths should expose statuses, not secrets."""
     monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
     monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
-    (tmp_path / ".env").write_text("OPENROUTER_API_KEY=test-openrouter-key-private\n", encoding="utf-8")
+    (tmp_path / ".env").write_text(
+        "OPENROUTER_API_KEY=test-openrouter-key-private\n", encoding="utf-8"
+    )
     old_cfg, old_mtime = _with_config(model={"provider": "openrouter"})
 
     import api.providers as providers
 
     req = providers.urllib.request.Request("https://openrouter.ai/api/v1/key")
-    invalid = urllib.error.HTTPError(req.full_url, 401, "Unauthorized", {}, BytesIO(b"secret body"))
+    invalid = urllib.error.HTTPError(
+        req.full_url, 401, "Unauthorized", {}, BytesIO(b"secret body")
+    )
     errors = [invalid, TimeoutError("slow secret")]
 
     try:
         for expected in ("invalid_key", "unavailable"):
+
             def fake_urlopen(_req, timeout=None, *, _err=errors.pop(0)):
                 raise _err
 
@@ -154,6 +173,7 @@ def test_unsupported_provider_reports_followup_state(monkeypatch, tmp_path):
     old_cfg, old_mtime = _with_config(model={"provider": "openai"})
 
     import api.providers as providers
+
     try:
         result = providers.get_provider_quota()
     finally:
@@ -167,12 +187,15 @@ def test_unsupported_provider_reports_followup_state(monkeypatch, tmp_path):
     assert "follow-up" in result["message"]
 
 
-def test_codex_account_usage_is_fetched_under_active_profile_home(monkeypatch, tmp_path):
+def test_codex_account_usage_is_fetched_under_active_profile_home(
+    monkeypatch, tmp_path
+):
     """Codex account limits must use the selected WebUI profile's HERMES_HOME."""
     monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
     old_cfg, old_mtime = _with_config(model={"provider": "openai-codex"})
 
     import api.providers as providers
+
     seen = {}
     previous_home = os.environ.get("HERMES_HOME")
 
@@ -306,7 +329,9 @@ def test_anthropic_oauth_usage_unavailable_reason_is_reported(monkeypatch, tmp_p
     assert result["provider"] == "anthropic"
     assert result["supported"] is True
     assert result["status"] == "unavailable"
-    assert result["account_limits"]["unavailable_reason"].startswith("Anthropic account limits")
+    assert result["account_limits"]["unavailable_reason"].startswith(
+        "Anthropic account limits"
+    )
     assert "OAuth-backed Claude accounts" in result["message"]
 
 
@@ -335,7 +360,9 @@ def test_account_usage_profile_env_is_child_scoped(monkeypatch, tmp_path):
     assert os.environ["ANTHROPIC_API_KEY"] == "process-key"
 
 
-def test_account_usage_profile_fetches_can_overlap_for_different_homes(monkeypatch, tmp_path):
+def test_account_usage_profile_fetches_can_overlap_for_different_homes(
+    monkeypatch, tmp_path
+):
     """Different profile quota fetches should not serialize on cron's global lock."""
     import api.providers as providers
 

--- a/tests/test_pwa_manifest_csp.py
+++ b/tests/test_pwa_manifest_csp.py
@@ -4,6 +4,7 @@ PR #920 added static/manifest.json for PWA support. Without an explicit
 manifest-src directive the browser falls back to default-src and emits
 a noisy console warning. This test locks the explicit directive in place.
 """
+
 import sys
 from pathlib import Path
 
@@ -19,7 +20,7 @@ class TestManifestSrcCSP:
         start = text.find("Content-Security-Policy")
         assert start != -1, "Content-Security-Policy not found in helpers.py"
         # Grab the full CSP string (up to the closing paren of send_header)
-        chunk = text[start:start + 600]
+        chunk = text[start : start + 600]
         return chunk
 
     def test_manifest_src_self_present(self):
@@ -38,6 +39,13 @@ class TestManifestSrcCSP:
     def test_existing_directives_unchanged(self):
         """Existing CSP directives must still be present after the manifest-src addition."""
         csp = self._csp()
-        for directive in ("default-src 'self'", "script-src", "style-src",
-                          "font-src", "connect-src", "base-uri 'self'", "form-action 'self'"):
+        for directive in (
+            "default-src 'self'",
+            "script-src",
+            "style-src",
+            "font-src",
+            "connect-src",
+            "base-uri 'self'",
+            "form-action 'self'",
+        ):
             assert directive in csp, f"Expected CSP directive missing: {directive}"

--- a/tests/test_pwa_manifest_sw.py
+++ b/tests/test_pwa_manifest_sw.py
@@ -8,6 +8,7 @@ Covers:
   fallback Response would never be used)
 - /manifest.json, /manifest.webmanifest, /sw.js routes serve correct Content-Type
 """
+
 import json
 import re
 from pathlib import Path
@@ -79,7 +80,9 @@ class TestServiceWorker:
 
     def test_sw_bypasses_api_and_stream(self):
         src = SW.read_text(encoding="utf-8")
-        assert "/api/" in src, "SW must bypass /api/* (no cached auth/session responses)"
+        assert "/api/" in src, (
+            "SW must bypass /api/* (no cached auth/session responses)"
+        )
         assert "/stream" in src, "SW must bypass streaming endpoints"
 
     def test_sw_offline_fallback_awaits_caches_match(self):
@@ -118,7 +121,10 @@ class TestServiceWorker:
         src = SW.read_text(encoding="utf-8")
         assert "Shell assets: network-first with cache fallback" in src
         assert "fetch(event.request).then((response)" in src
-        assert "caches.open(CACHE_NAME).then((cache) => cache.put(event.request, clone))" in src
+        assert (
+            "caches.open(CACHE_NAME).then((cache) => cache.put(event.request, clone))"
+            in src
+        )
         assert ".catch(() => caches.match(event.request)" in src
         assert "if (cached) return cached;" not in src, (
             "shell assets must not be cache-first; stale JS can survive hard refresh"
@@ -140,7 +146,7 @@ class TestPWARoutes:
         # The handler block for /manifest.json
         idx = src.find('"/manifest.json"')
         assert idx != -1, "routes.py must handle /manifest.json"
-        block = src[idx:idx + 800]
+        block = src[idx : idx + 800]
         assert "application/manifest+json" in block, (
             "manifest.json route must serve Content-Type: application/manifest+json"
         )
@@ -152,7 +158,7 @@ class TestPWARoutes:
         src = ROUTES.read_text(encoding="utf-8")
         idx = src.find('"/sw.js"')
         assert idx != -1, "routes.py must handle /sw.js"
-        block = src[idx:idx + 1000]
+        block = src[idx : idx + 1000]
         assert "__WEBUI_VERSION__" in block, (
             "sw.js route must replace __WEBUI_VERSION__ with the current WEBUI_VERSION"
         )
@@ -164,8 +170,8 @@ class TestPWARoutes:
         src = ROUTES.read_text(encoding="utf-8")
         idx = src.find('"/sw.js"')
         assert idx != -1, "routes.py must handle /sw.js"
-        block = src[idx:idx + 1200]
-        assert "quote(WEBUI_VERSION, safe=\"\")" in block, (
+        block = src[idx : idx + 1200]
+        assert 'quote(WEBUI_VERSION, safe="")' in block, (
             "sw.js route must URL-encode the injected cache version so unusual git tags "
             "cannot break the JavaScript string literal"
         )
@@ -173,7 +179,7 @@ class TestPWARoutes:
     def test_sw_route_sets_service_worker_allowed(self):
         src = ROUTES.read_text(encoding="utf-8")
         idx = src.find('"/sw.js"')
-        block = src[idx:idx + 1000]
+        block = src[idx : idx + 1000]
         assert "Service-Worker-Allowed" in block, (
             "sw.js route must set Service-Worker-Allowed header so the SW can control "
             "the expected scope"
@@ -183,7 +189,7 @@ class TestPWARoutes:
         src = AUTH.read_text(encoding="utf-8")
         public_idx = src.find("PUBLIC_PATHS")
         assert public_idx != -1, "auth.py must define PUBLIC_PATHS"
-        block = src[public_idx:public_idx + 400]
+        block = src[public_idx : public_idx + 400]
         assert "'/sw.js'" in block, (
             "/sw.js must be public so service-worker updates never return login HTML"
         )
@@ -256,7 +262,7 @@ class TestIndexHtmlIntegration:
             # Either inline `?v=__WEBUI_VERSION__` or via the VQ constant
             # produces a URL string the cache lookup can match.
             has_inline = f"{asset}?v=__WEBUI_VERSION__" in src
-            has_concat = f"{asset}' + VQ" in src or f"{asset}\" + VQ" in src
+            has_concat = f"{asset}' + VQ" in src or f'{asset}" + VQ' in src
             assert has_inline or has_concat, (
                 f"sw.js SHELL_ASSETS entry for {asset} must carry "
                 "?v=__WEBUI_VERSION__ to match the URL the page requests"
@@ -272,7 +278,7 @@ class TestIndexHtmlIntegration:
         src = SW.read_text(encoding="utf-8")
         marker = "// Shell assets: network-first with cache fallback"
         assert marker in src
-        block = src[src.find(marker):src.find(marker) + 900]
+        block = src[src.find(marker) : src.find(marker) + 900]
         assert "fetch(event.request).then" in block
         assert "caches.match(event.request)" in block
         assert "caches.match(event.request).then((cached)" not in block[:250]
@@ -283,8 +289,8 @@ class TestIndexHtmlIntegration:
         if idx == -1:
             idx = src.find('parsed.path.startswith("/session/")')
         assert idx != -1, "routes.py must handle /, /index.html, and /session/<id>"
-        block = src[idx:idx + 800]
-        assert "quote(WEBUI_VERSION, safe=\"\")" in block, (
+        block = src[idx : idx + 800]
+        assert 'quote(WEBUI_VERSION, safe="")' in block, (
             "index route must URL-encode the cache-busting version token before "
             "injecting it into script src attributes and service worker registration"
         )

--- a/tests/test_pytest_config_isolation.py
+++ b/tests/test_pytest_config_isolation.py
@@ -1,4 +1,5 @@
 """Regression coverage for pytest isolation of Hermes config paths."""
+
 import os
 from pathlib import Path
 

--- a/tests/test_quote_entity_mangling.py
+++ b/tests/test_quote_entity_mangling.py
@@ -12,6 +12,7 @@ in the copy buffer.
 Fix: extend _al_stash regex to also stash <pre\b[^>]*>[\s\S]*?<\/pre>
 blocks so the outer autolink scanner never touches code-block content.
 """
+
 import html as _html
 import pathlib
 import re
@@ -24,37 +25,41 @@ UI_JS = UI_JS_PATH.read_text(encoding="utf-8")
 
 # ── helpers: Python mirror of the relevant renderMd() segment ────────────────
 
+
 def esc(s):
     return _html.escape(str(s), quote=True)
 
 
 def _render_code_block(md):
     """Simulate the fenced-code-block pass (renderMd lines ~537-541)."""
+
     def repl(m):
         lang = (m.group(1) or "").strip().lower()
-        code = re.sub(r'\n$', '', m.group(2))
-        h = f'<div class="pre-header">{esc(lang)}</div>' if lang else ''
-        lang_attr = f' class="language-{esc(lang)}"' if lang else ''
-        return f'{h}<pre><code{lang_attr}>{esc(code)}</code></pre>'
-    return re.sub(r'```([\w+-]*)\n?([\s\S]*?)```', repl, md)
+        code = re.sub(r"\n$", "", m.group(2))
+        h = f'<div class="pre-header">{esc(lang)}</div>' if lang else ""
+        lang_attr = f' class="language-{esc(lang)}"' if lang else ""
+        return f"{h}<pre><code{lang_attr}>{esc(code)}</code></pre>"
+
+    return re.sub(r"```([\w+-]*)\n?([\s\S]*?)```", repl, md)
 
 
 SAFE_TAGS_RE = re.compile(
-    r'^</?(strong|em|code|pre|h[1-6]|ul|ol|li|table|thead|tbody|tr|th|td'
-    r'|hr|blockquote|p|br|a|img|div|span)([\s>]|$)', re.I
+    r"^</?(strong|em|code|pre|h[1-6]|ul|ol|li|table|thead|tbody|tr|th|td"
+    r"|hr|blockquote|p|br|a|img|div|span)([\s>]|$)",
+    re.I,
 )
 
 
 def _safe_tags_pass(s):
     return re.sub(
-        r'</?[a-zA-Z][^>]*>',
+        r"</?[a-zA-Z][^>]*>",
         lambda m: m.group() if SAFE_TAGS_RE.match(m.group()) else esc(m.group()),
         s,
     )
 
 
 def _autolink(url):
-    trail = url[-1] if url[-1] in '.,;:!?)' else ''
+    trail = url[-1] if url[-1] in ".,;:!?)" else ""
     clean = url[:-1] if trail else url
     return f'<a href="{clean}" target="_blank" rel="noopener">{esc(clean)}</a>{trail}'
 
@@ -69,16 +74,16 @@ def _al_stash_and_autolink(s, fixed=True):
 
     def stash_fn(m):
         al_stash.append(m.group(0))
-        return f'\x00B{len(al_stash)-1}\x00'
+        return f"\x00B{len(al_stash) - 1}\x00"
 
     if fixed:
-        pattern = r'(<a\b[^>]*>[\s\S]*?</a>|<img\b[^>]*>|<pre\b[^>]*>[\s\S]*?</pre>)'
+        pattern = r"(<a\b[^>]*>[\s\S]*?</a>|<img\b[^>]*>|<pre\b[^>]*>[\s\S]*?</pre>)"
     else:
-        pattern = r'(<a\b[^>]*>[\s\S]*?</a>|<img\b[^>]*>)'
+        pattern = r"(<a\b[^>]*>[\s\S]*?</a>|<img\b[^>]*>)"
 
     s = re.sub(pattern, stash_fn, s)
     s = re.sub(r'(https?://[^\s<>"\'\)\]]+)', lambda m: _autolink(m.group(1)), s)
-    s = re.sub(r'\x00B(\d+)\x00', lambda m: al_stash[int(m.group(1))], s)
+    s = re.sub(r"\x00B(\d+)\x00", lambda m: al_stash[int(m.group(1))], s)
     return s
 
 
@@ -98,66 +103,69 @@ def render_buggy(md):
 
 def strip_tags(html):
     """Return text content of HTML (tags removed, entities preserved)."""
-    return re.sub(r'<[^>]+>', '', html)
+    return re.sub(r"<[^>]+>", "", html)
 
 
 # ── Source-level checks ───────────────────────────────────────────────────────
 
-class TestAlStashSourceFix:
 
+class TestAlStashSourceFix:
     def test_al_stash_includes_pre_pattern(self):
         """_al_stash regex must stash <pre>…</pre> blocks to protect code from autolink."""
-        al_stash_idx = UI_JS.index('const _al_stash=[]')
+        al_stash_idx = UI_JS.index("const _al_stash=[]")
         al_stash_block = UI_JS[al_stash_idx : al_stash_idx + 300]
-        assert '<pre\\b' in al_stash_block, (
+        assert "<pre\\b" in al_stash_block, (
             "_al_stash replacement must include an attribute-tolerant <pre\\b[^>]*> "
             "pattern so code blocks are protected from the outer autolink scanner"
         )
 
     def test_al_stash_pre_regex_uses_lazy_dotall(self):
         """_al_stash must use [\\s\\S]*? (lazy dotall) for the <pre> branch."""
-        al_stash_idx = UI_JS.index('const _al_stash=[]')
+        al_stash_idx = UI_JS.index("const _al_stash=[]")
         al_stash_block = UI_JS[al_stash_idx : al_stash_idx + 300]
         # The pattern <pre>[\s\S]*?<\/pre> must appear in the stash line
-        assert r'[\s\S]*?' in al_stash_block, (
+        assert r"[\s\S]*?" in al_stash_block, (
             "_al_stash <pre> branch must use [\\s\\S]*? for multi-line matching"
         )
-        assert r'<\/pre>' in al_stash_block or '</pre>' in al_stash_block, (
+        assert r"<\/pre>" in al_stash_block or "</pre>" in al_stash_block, (
             "_al_stash must close the <pre> branch with </pre>"
         )
 
     def test_al_stash_still_covers_a_and_img(self):
         """_al_stash must continue to stash <a> and <img> (regression guard for #487b)."""
-        al_stash_idx = UI_JS.index('const _al_stash=[]')
+        al_stash_idx = UI_JS.index("const _al_stash=[]")
         al_stash_block = UI_JS[al_stash_idx : al_stash_idx + 300]
-        assert '<a\\b' in al_stash_block or '<a\\\\b' in al_stash_block, (
+        assert "<a\\b" in al_stash_block or "<a\\\\b" in al_stash_block, (
             "_al_stash must still stash <a> tags"
         )
-        assert '<img\\b' in al_stash_block or '<img\\\\b' in al_stash_block, (
+        assert "<img\\b" in al_stash_block or "<img\\\\b" in al_stash_block, (
             "_al_stash must still stash <img> tags"
         )
 
     def test_js_syntax_valid(self):
         """ui.js must pass node --check after the fix."""
         result = subprocess.run(
-            ['node', '--check', str(UI_JS_PATH)],
-            capture_output=True, text=True,
+            ["node", "--check", str(UI_JS_PATH)],
+            capture_output=True,
+            text=True,
         )
         assert result.returncode == 0, f"node --check failed:\n{result.stderr}"
 
 
 # ── Behaviour: code blocks with quoted URLs ───────────────────────────────────
 
-class TestCodeBlockQuotedUrlFixed:
 
+class TestCodeBlockQuotedUrlFixed:
     _MD_SIMPLE = '```\nhttps://example.com/path?q="hello"\n```'
     _MD_PYTHON = '```python\nurl = "https://api.example.com/v1?token=\\"abc\\""\n```'
-    _MD_BASH   = '```bash\ncurl -H \'Accept: application/json\' "https://api.example.com/"\n```'
+    _MD_BASH = (
+        "```bash\ncurl -H 'Accept: application/json' \"https://api.example.com/\"\n```"
+    )
 
     def test_no_amp_quot_in_code_block_url(self):
         """Code block with a quoted URL must not produce &amp;quot; in output."""
         result = render_fixed(self._MD_SIMPLE)
-        assert '&amp;quot;' not in result, (
+        assert "&amp;quot;" not in result, (
             f"&amp;quot; found in rendered output — quote entity double-escaped:\n{result}"
         )
 
@@ -165,10 +173,10 @@ class TestCodeBlockQuotedUrlFixed:
         """The autolink pass must NOT inject <a> tags inside <pre><code> blocks."""
         result = render_fixed(self._MD_SIMPLE)
         # Extract the <pre>…</pre> portion
-        pre_match = re.search(r'<pre>[\s\S]*?</pre>', result)
+        pre_match = re.search(r"<pre>[\s\S]*?</pre>", result)
         assert pre_match, "No <pre> block found in rendered output"
         pre_content = pre_match.group(0)
-        assert '<a ' not in pre_content, (
+        assert "<a " not in pre_content, (
             f"<a> tag injected inside <pre> block:\n{pre_content}"
         )
 
@@ -185,41 +193,41 @@ class TestCodeBlockQuotedUrlFixed:
     def test_python_code_block_not_mangled(self):
         """Python code block with double-quoted URL strings must not be mangled."""
         result = render_fixed(self._MD_PYTHON)
-        assert '&amp;quot;' not in result, (
+        assert "&amp;quot;" not in result, (
             f"&amp;quot; found in Python code block output:\n{result}"
         )
-        pre_match = re.search(r'<pre>[\s\S]*?</pre>', result)
-        assert pre_match and '<a ' not in pre_match.group(0), (
+        pre_match = re.search(r"<pre>[\s\S]*?</pre>", result)
+        assert pre_match and "<a " not in pre_match.group(0), (
             "autolink injected inside Python code block"
         )
 
     def test_bash_code_block_not_mangled(self):
         """Bash code block with a double-quoted URL must not be mangled."""
         result = render_fixed(self._MD_BASH)
-        assert '&amp;quot;' not in result, (
+        assert "&amp;quot;" not in result, (
             f"&amp;quot; found in bash code block output:\n{result}"
         )
 
     def test_buggy_pipeline_does_mangle(self):
         """Confirm the unfixed pipeline DOES produce &amp;quot; (proves test catches the bug)."""
         buggy = render_buggy(self._MD_SIMPLE)
-        assert '&amp;quot;' in buggy, (
+        assert "&amp;quot;" in buggy, (
             "Expected buggy pipeline to produce &amp;quot; — test validity check failed"
         )
 
     def test_buggy_pipeline_does_inject_a_in_pre(self):
         """Confirm the unfixed pipeline DOES inject <a> inside <pre> (proves test catches it)."""
         buggy = render_buggy(self._MD_SIMPLE)
-        pre_match = re.search(r'<pre>[\s\S]*?</pre>', buggy)
-        assert pre_match and '<a ' in pre_match.group(0), (
+        pre_match = re.search(r"<pre>[\s\S]*?</pre>", buggy)
+        assert pre_match and "<a " in pre_match.group(0), (
             "Expected buggy pipeline to inject <a> inside <pre> — test validity check failed"
         )
 
 
 # ── Behaviour: non-code autolink is unaffected ───────────────────────────────
 
-class TestNonCodeAutolinkUnaffected:
 
+class TestNonCodeAutolinkUnaffected:
     def test_bare_url_in_paragraph_still_autolinks(self):
         """A plain URL in running text must still be wrapped in <a> by the fixed pipeline."""
         result = render_fixed("Visit https://example.com for more info.")
@@ -231,14 +239,14 @@ class TestNonCodeAutolinkUnaffected:
         """A plain URL with ampersand query params must not be double-escaped."""
         result = render_fixed("See https://example.com/search?a=1&b=2 for results.")
         # The href should contain the raw & (or %26), not &amp;amp;
-        assert '&amp;amp;' not in result, (
+        assert "&amp;amp;" not in result, (
             f"Ampersand in URL double-escaped in paragraph context:\n{result}"
         )
 
     def test_multiple_urls_in_paragraph_all_autolinked(self):
         """Multiple bare URLs in a paragraph must each get their own <a> tag."""
         result = render_fixed("See https://foo.com and https://bar.com")
-        assert result.count('<a ') >= 2, (
+        assert result.count("<a ") >= 2, (
             f"Expected 2 autolinks, got {result.count('<a ')}:\n{result}"
         )
 
@@ -246,57 +254,57 @@ class TestNonCodeAutolinkUnaffected:
         """After stash+restore the <pre> block must appear verbatim in the output."""
         md = '```python\nprint("hello")\n```'
         result = render_fixed(md)
-        assert '<pre>' in result, "No <pre> block in output"
-        assert '</pre>' in result, "Unclosed <pre> in output"
+        assert "<pre>" in result, "No <pre> block in output"
+        assert "</pre>" in result, "Unclosed <pre> in output"
         # The code must still contain the escaped quote
-        assert '&quot;' in result or 'hello' in result, (
+        assert "&quot;" in result or "hello" in result, (
             f"Code block content lost after stash/restore:\n{result}"
         )
 
     def test_code_block_and_bare_url_in_same_message(self):
         """A message with both a code block and a bare URL must autolink only the URL."""
-        md = "```\nhttps://internal.example.com?token=\"abc\"\n```\n\nSee https://docs.example.com"
+        md = '```\nhttps://internal.example.com?token="abc"\n```\n\nSee https://docs.example.com'
         result = render_fixed(md)
         # The bare URL in text should be linked
         assert '<a href="https://docs.example.com"' in result, (
             "Bare URL outside code block not autolinked"
         )
         # The URL inside the code block must NOT be linked
-        pre_match = re.search(r'<pre>[\s\S]*?</pre>', result)
-        assert pre_match and '<a ' not in pre_match.group(0), (
+        pre_match = re.search(r"<pre>[\s\S]*?</pre>", result)
+        assert pre_match and "<a " not in pre_match.group(0), (
             f"URL inside code block was autolinked:\n{pre_match.group(0)}"
         )
         # And there must be no double-escaped entity
-        assert '&amp;quot;' not in result, (
+        assert "&amp;quot;" not in result, (
             f"&amp;quot; appeared in mixed message output:\n{result}"
         )
 
 
 # ── Sanitizer / security expectations ────────────────────────────────────────
 
-class TestSanitizerUnaffected:
 
+class TestSanitizerUnaffected:
     def test_script_tag_in_code_block_escaped(self):
         """<script> inside a code block must be HTML-escaped, not executed."""
-        result = render_fixed('```\n<script>alert(1)</script>\n```')
-        assert '<script>' not in result, (
+        result = render_fixed("```\n<script>alert(1)</script>\n```")
+        assert "<script>" not in result, (
             "Raw <script> tag leaked through code block rendering"
         )
         # It should appear escaped inside the pre block
-        assert '&lt;script&gt;' in result, (
+        assert "&lt;script&gt;" in result, (
             f"<script> not escaped in code block output:\n{result}"
         )
 
     def test_untrusted_tag_outside_code_escaped_by_safe_tags(self):
         """An unknown tag outside a code block must be escaped by the SAFE_TAGS pass."""
-        result = render_fixed('<marquee>hello</marquee>')
-        assert '<marquee>' not in result, (
+        result = render_fixed("<marquee>hello</marquee>")
+        assert "<marquee>" not in result, (
             "Untrusted <marquee> tag passed through unescaped"
         )
 
     def test_javascript_url_not_autolinked(self):
         """javascript: URLs must not be autolinked (regex requires http/https)."""
-        result = render_fixed('javascript:alert(1)')
+        result = render_fixed("javascript:alert(1)")
         assert 'href="javascript:' not in result, (
             "javascript: URL was incorrectly autolinked"
         )

--- a/tests/test_real_steer.py
+++ b/tests/test_real_steer.py
@@ -14,21 +14,22 @@ steer is consumed (no tool-call boundary), _drain_pending_steer is called
 after run_conversation returns and a `pending_steer_leftover` SSE event is
 emitted so the frontend can queue the leftover text as a next-turn message.
 """
+
 import sys
 import os
-import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 
 @pytest.fixture(autouse=True)
 def _restore_auth_sessions():
     """Snapshot and restore api.auth._sessions — see test_1058 for the rationale."""
     import api.auth as _auth
+
     snapshot = dict(_auth._sessions)
     yield
     _auth._sessions.clear()
@@ -38,7 +39,13 @@ def _restore_auth_sessions():
 @pytest.fixture
 def _clear_caches():
     """Snapshot SESSION_AGENT_CACHE and STREAMS so tests don't bleed."""
-    from api.config import SESSION_AGENT_CACHE, SESSION_AGENT_CACHE_LOCK, STREAMS, STREAMS_LOCK
+    from api.config import (
+        SESSION_AGENT_CACHE,
+        SESSION_AGENT_CACHE_LOCK,
+        STREAMS,
+        STREAMS_LOCK,
+    )
+
     with SESSION_AGENT_CACHE_LOCK:
         cache_snap = dict(SESSION_AGENT_CACHE)
         SESSION_AGENT_CACHE.clear()
@@ -66,6 +73,7 @@ def _make_handler():
 def _captured_response(handler):
     """Pull the JSON body that j() wrote to handler.wfile."""
     import json as _json
+
     # j() calls handler.wfile.write(body)
     write_calls = handler.wfile.write.call_args_list
     assert write_calls, "no body was written to handler.wfile"
@@ -82,12 +90,19 @@ def _captured_status(handler):
 
 # ── Backend: the /api/chat/steer endpoint ─────────────────────────────────
 
+
 class TestHandleChatSteerHappyPath:
     """Endpoint accepts text and calls agent.steer() when all gates pass."""
 
     def test_accepts_when_agent_cached_and_running(self, _clear_caches):
         from api.streaming import _handle_chat_steer
-        from api.config import SESSION_AGENT_CACHE, SESSION_AGENT_CACHE_LOCK, STREAMS, STREAMS_LOCK
+        from api.config import (
+            SESSION_AGENT_CACHE,
+            SESSION_AGENT_CACHE_LOCK,
+            STREAMS,
+            STREAMS_LOCK,
+        )
+
         sid, stream_id = "sid_happy", "stream_happy"
         agent = MagicMock()
         agent.steer = MagicMock(return_value=True)
@@ -95,13 +110,16 @@ class TestHandleChatSteerHappyPath:
             SESSION_AGENT_CACHE[sid] = (agent, "sig")
         with STREAMS_LOCK:
             import queue as _q
+
             STREAMS[stream_id] = _q.Queue()
 
         sess = MagicMock()
         sess.active_stream_id = stream_id
         with patch("api.streaming.get_session", return_value=sess):
             handler = _make_handler()
-            _handle_chat_steer(handler, {"session_id": sid, "text": "Use Python instead"})
+            _handle_chat_steer(
+                handler, {"session_id": sid, "text": "Use Python instead"}
+            )
 
         agent.steer.assert_called_once_with("Use Python instead")
         body = _captured_response(handler)
@@ -113,6 +131,7 @@ class TestHandleChatSteerFallbacks:
 
     def test_no_cached_agent(self, _clear_caches):
         from api.streaming import _handle_chat_steer
+
         handler = _make_handler()
         _handle_chat_steer(handler, {"session_id": "sid_x", "text": "hint"})
         body = _captured_response(handler)
@@ -122,6 +141,7 @@ class TestHandleChatSteerFallbacks:
     def test_agent_lacks_steer_method(self, _clear_caches):
         from api.streaming import _handle_chat_steer
         from api.config import SESSION_AGENT_CACHE, SESSION_AGENT_CACHE_LOCK
+
         sid = "sid_old"
         # Older agent without steer() — use spec to suppress MagicMock auto-create
         agent = MagicMock(spec=["interrupt", "run_conversation"])
@@ -136,6 +156,7 @@ class TestHandleChatSteerFallbacks:
     def test_session_not_found(self, _clear_caches):
         from api.streaming import _handle_chat_steer
         from api.config import SESSION_AGENT_CACHE, SESSION_AGENT_CACHE_LOCK
+
         sid = "sid_missing"
         agent = MagicMock()
         agent.steer = MagicMock(return_value=True)
@@ -152,6 +173,7 @@ class TestHandleChatSteerFallbacks:
     def test_session_not_running(self, _clear_caches):
         from api.streaming import _handle_chat_steer
         from api.config import SESSION_AGENT_CACHE, SESSION_AGENT_CACHE_LOCK
+
         sid = "sid_idle"
         agent = MagicMock()
         agent.steer = MagicMock(return_value=True)
@@ -171,6 +193,7 @@ class TestHandleChatSteerFallbacks:
         """Session has active_stream_id but the stream is gone from STREAMS (e.g. crashed)."""
         from api.streaming import _handle_chat_steer
         from api.config import SESSION_AGENT_CACHE, SESSION_AGENT_CACHE_LOCK
+
         sid = "sid_zombie"
         agent = MagicMock()
         agent.steer = MagicMock(return_value=True)
@@ -189,7 +212,13 @@ class TestHandleChatSteerFallbacks:
     def test_steer_raises(self, _clear_caches):
         """If agent.steer() raises, return steer_error rather than 500."""
         from api.streaming import _handle_chat_steer
-        from api.config import SESSION_AGENT_CACHE, SESSION_AGENT_CACHE_LOCK, STREAMS, STREAMS_LOCK
+        from api.config import (
+            SESSION_AGENT_CACHE,
+            SESSION_AGENT_CACHE_LOCK,
+            STREAMS,
+            STREAMS_LOCK,
+        )
+
         sid, stream_id = "sid_throws", "stream_throws"
         agent = MagicMock()
         agent.steer = MagicMock(side_effect=RuntimeError("boom"))
@@ -197,6 +226,7 @@ class TestHandleChatSteerFallbacks:
             SESSION_AGENT_CACHE[sid] = (agent, "sig")
         with STREAMS_LOCK:
             import queue as _q
+
             STREAMS[stream_id] = _q.Queue()
         sess = MagicMock()
         sess.active_stream_id = stream_id
@@ -213,18 +243,21 @@ class TestHandleChatSteerInputValidation:
 
     def test_missing_session_id(self, _clear_caches):
         from api.streaming import _handle_chat_steer
+
         handler = _make_handler()
         _handle_chat_steer(handler, {"text": "hint"})
         assert _captured_status(handler) == 400
 
     def test_missing_text(self, _clear_caches):
         from api.streaming import _handle_chat_steer
+
         handler = _make_handler()
         _handle_chat_steer(handler, {"session_id": "sid"})
         assert _captured_status(handler) == 400
 
     def test_empty_text_after_strip(self, _clear_caches):
         from api.streaming import _handle_chat_steer
+
         handler = _make_handler()
         _handle_chat_steer(handler, {"session_id": "sid", "text": "   \n\t  "})
         assert _captured_status(handler) == 400
@@ -232,43 +265,53 @@ class TestHandleChatSteerInputValidation:
 
 # ── Routing ───────────────────────────────────────────────────────────────
 
+
 class TestRouting:
     """The POST handler must dispatch /api/chat/steer to _handle_chat_steer."""
 
     def test_route_registered(self):
-        src = (Path(__file__).parent.parent / "api" / "routes.py").read_text(encoding="utf-8")
-        assert '/api/chat/steer' in src
-        assert '_handle_chat_steer' in src
+        src = (Path(__file__).parent.parent / "api" / "routes.py").read_text(
+            encoding="utf-8"
+        )
+        assert "/api/chat/steer" in src
+        assert "_handle_chat_steer" in src
 
 
 # ── Frontend: cmdSteer + busy-mode steer use the new endpoint ────────────
+
 
 class TestFrontendWiring:
     """The slash command and busy-mode steer paths must call /api/chat/steer."""
 
     @classmethod
     def setup_class(cls):
-        cls.cmds = (Path(__file__).parent.parent / "static" / "commands.js").read_text(encoding="utf-8")
-        cls.msgs = (Path(__file__).parent.parent / "static" / "messages.js").read_text(encoding="utf-8")
-        cls.i18n = (Path(__file__).parent.parent / "static" / "i18n.js").read_text(encoding="utf-8")
+        cls.cmds = (Path(__file__).parent.parent / "static" / "commands.js").read_text(
+            encoding="utf-8"
+        )
+        cls.msgs = (Path(__file__).parent.parent / "static" / "messages.js").read_text(
+            encoding="utf-8"
+        )
+        cls.i18n = (Path(__file__).parent.parent / "static" / "i18n.js").read_text(
+            encoding="utf-8"
+        )
 
     def test_cmd_steer_calls_endpoint(self):
         idx = self.cmds.find("async function cmdSteer(")
         assert idx >= 0
-        body = self.cmds[idx:idx + 600]
+        body = self.cmds[idx : idx + 600]
         # Should call _trySteer (which calls the endpoint), not directly cancelStream
         assert "_trySteer" in body, "cmdSteer must delegate to _trySteer"
 
     def test_try_steer_calls_endpoint(self):
         idx = self.cmds.find("async function _trySteer(")
         assert idx >= 0
-        body = self.cmds[idx:idx + 1500]
+        body = self.cmds[idx : idx + 1500]
         assert "/api/chat/steer" in body, "_trySteer must POST to /api/chat/steer"
         assert "method:'POST'" in body or 'method:"POST"' in body
 
     def test_try_steer_handles_fallback(self):
         idx = self.cmds.find("async function _trySteer(")
-        body = self.cmds[idx:idx + 1500]
+        body = self.cmds[idx : idx + 1500]
         # Must check result.accepted and fall back via queueSessionMessage + cancelStream
         assert "result&&result.accepted" in body or "result.accepted" in body
         assert "queueSessionMessage" in body
@@ -278,14 +321,14 @@ class TestFrontendWiring:
         # send() in messages.js: when busyMode === 'steer', should call _trySteer
         idx = self.msgs.find("busyMode==='steer'")
         assert idx >= 0
-        block = self.msgs[idx:idx + 800]
+        block = self.msgs[idx : idx + 800]
         assert "_trySteer" in block, "send()'s steer branch must delegate to _trySteer"
 
     def test_pending_steer_leftover_listener(self):
         """Frontend must listen for pending_steer_leftover SSE events and queue them."""
         idx = self.msgs.find("addEventListener('pending_steer_leftover'")
         assert idx >= 0, "messages.js must add a listener for pending_steer_leftover"
-        block = self.msgs[idx:idx + 600]
+        block = self.msgs[idx : idx + 600]
         assert "queueSessionMessage" in block, (
             "pending_steer_leftover handler must queue the leftover text for the next turn"
         )
@@ -293,12 +336,15 @@ class TestFrontendWiring:
 
 # ── i18n keys ─────────────────────────────────────────────────────────────
 
+
 class TestI18nKeys:
     """The two new keys (cmd_steer_delivered, steer_leftover_queued) must be in all 6 locales."""
 
     @classmethod
     def setup_class(cls):
-        cls.i18n = (Path(__file__).parent.parent / "static" / "i18n.js").read_text(encoding="utf-8")
+        cls.i18n = (Path(__file__).parent.parent / "static" / "i18n.js").read_text(
+            encoding="utf-8"
+        )
 
     def test_cmd_steer_delivered_in_all_locales(self):
         assert self.i18n.count("cmd_steer_delivered:") >= 6, (
@@ -315,13 +361,16 @@ class TestI18nKeys:
 
 # ── Leftover SSE delivery: streaming.py emits pending_steer_leftover ─────
 
+
 class TestLeftoverDelivery:
     """After run_conversation returns, _drain_pending_steer is called and a
     pending_steer_leftover SSE event is emitted if there's still text stashed."""
 
     def test_leftover_drain_call_in_streaming(self):
         """Verify the streaming.py source contains the drain call before put('done', ...)."""
-        src = (Path(__file__).parent.parent / "api" / "streaming.py").read_text(encoding="utf-8")
+        src = (Path(__file__).parent.parent / "api" / "streaming.py").read_text(
+            encoding="utf-8"
+        )
         assert "_drain_pending_steer" in src, (
             "_run_agent_streaming must call agent._drain_pending_steer() to deliver leftovers"
         )
@@ -332,7 +381,9 @@ class TestLeftoverDelivery:
     def test_leftover_drain_runs_before_done_event(self):
         """The drain must happen BEFORE put('done', ...) so frontend gets both events
         on the same turn."""
-        src = (Path(__file__).parent.parent / "api" / "streaming.py").read_text(encoding="utf-8")
+        src = (Path(__file__).parent.parent / "api" / "streaming.py").read_text(
+            encoding="utf-8"
+        )
         # Find the drain invocation and the next put('done', ...) AFTER it
         drain_idx = src.find("_drain_pending_steer()")
         assert drain_idx >= 0

--- a/tests/test_reasoning_chip_btw_fixes.py
+++ b/tests/test_reasoning_chip_btw_fixes.py
@@ -17,6 +17,7 @@ Four invariants this file locks in place:
    gates `onerror`'s row removal on `!_streamDone` — otherwise the browser's
    post-`stream_end` error event wipes the just-rendered answer.
 """
+
 from __future__ import annotations
 
 import pathlib
@@ -98,7 +99,7 @@ class TestReasoningChipIcon:
         assert 'stroke="currentColor"' in btn_body, (
             "reasoning chip must use stroke='currentColor' SVG matching other chips"
         )
-        assert '<svg' in btn_body, "reasoning chip must contain an <svg> icon"
+        assert "<svg" in btn_body, "reasoning chip must contain an <svg> icon"
 
     def test_apply_reasoning_chip_label_has_no_emoji(self):
         # Locate _applyReasoningChip and confirm the label assignment doesn't
@@ -221,8 +222,9 @@ class TestBtwStreamDoneGuard:
             fn,
         )
         assert done_block_m, "done handler not found in attachBtwStream"
-        assert "_streamDone=true" in done_block_m.group(0) or \
-               "_streamDone = true" in done_block_m.group(0), (
+        assert "_streamDone=true" in done_block_m.group(
+            0
+        ) or "_streamDone = true" in done_block_m.group(0), (
             "_streamDone must be set to true in the done handler so onerror "
             "knows the stream completed successfully"
         )
@@ -268,7 +270,7 @@ class TestBtwStreamDoneGuard:
         assert done_block_m
         block = done_block_m.group(0)
         # The _ensureBtwRow call must be guarded by a session-match check
-        assert ("S.session" in block and "parentSid" in block), (
+        assert "S.session" in block and "parentSid" in block, (
             "_ensureBtwRow() in the done handler must be gated on "
             "S.session.session_id === parentSid — otherwise a user who "
             "switched sessions during the /btw stream gets the answer "

--- a/tests/test_reasoning_chip_js_behaviour.py
+++ b/tests/test_reasoning_chip_js_behaviour.py
@@ -10,7 +10,7 @@ label fell through to a wrong value for an unknown input.
 This file pins the actual rendered output for every effort state so the
 chip's None/Default visibility cannot silently regress.
 """
-import os
+
 import shutil
 import subprocess
 from pathlib import Path
@@ -106,9 +106,12 @@ def driver_path(tmp_path_factory):
 def _apply(driver_path, value):
     """Run _applyReasoningChip(value) against the actual ui.js."""
     import json as _json
+
     result = subprocess.run(
         [NODE, driver_path, str(UI_JS_PATH), _json.dumps(value)],
-        capture_output=True, text=True, timeout=10,
+        capture_output=True,
+        text=True,
+        timeout=10,
     )
     if result.returncode != 0:
         raise RuntimeError(f"node driver failed: {result.stderr}")
@@ -124,7 +127,6 @@ def _apply(driver_path, value):
 
 
 class TestChipAlwaysVisible:
-
     def test_empty_string_shows_chip_with_default_label(self, driver_path):
         out = _apply(driver_path, "")
         assert out["display"] == "", f"empty effort must show the chip: {out}"

--- a/tests/test_reasoning_show_hide.py
+++ b/tests/test_reasoning_show_hide.py
@@ -17,65 +17,68 @@ REPO = pathlib.Path(__file__).parent.parent
 
 
 def read(rel):
-    return (REPO / rel).read_text(encoding='utf-8')
+    return (REPO / rel).read_text(encoding="utf-8")
 
 
 # ── api/config.py ─────────────────────────────────────────────────────────────
+
 
 class TestShowThinkingConfig:
     """show_thinking must appear in defaults and bool keys."""
 
     def test_show_thinking_in_defaults(self):
-        src = read('api/config.py')
+        src = read("api/config.py")
         assert '"show_thinking": True' in src, (
             "show_thinking must be True in _SETTINGS_DEFAULTS"
         )
 
     def test_show_thinking_in_bool_keys(self):
-        src = read('api/config.py')
+        src = read("api/config.py")
         assert '"show_thinking"' in src
         # Find the _SETTINGS_BOOL_KEYS set and confirm show_thinking is in it
-        m = re.search(r'_SETTINGS_BOOL_KEYS\s*=\s*\{([^}]+)\}', src, re.DOTALL)
+        m = re.search(r"_SETTINGS_BOOL_KEYS\s*=\s*\{([^}]+)\}", src, re.DOTALL)
         assert m, "_SETTINGS_BOOL_KEYS not found"
-        assert 'show_thinking' in m.group(1), (
+        assert "show_thinking" in m.group(1), (
             "show_thinking must be in _SETTINGS_BOOL_KEYS"
         )
 
 
 # ── static/boot.js ────────────────────────────────────────────────────────────
 
+
 class TestBootJsShowThinking:
     """window._showThinking must be set in both the settings and fallback paths."""
 
     def test_settings_path_initialises_show_thinking(self):
-        src = read('static/boot.js')
+        src = read("static/boot.js")
         # Must read from the settings object, defaulting true when absent
-        assert 'window._showThinking=s.show_thinking!==false' in src, (
+        assert "window._showThinking=s.show_thinking!==false" in src, (
             "boot.js must initialise _showThinking from settings (default true)"
         )
 
     def test_fallback_path_initialises_show_thinking_true(self):
-        src = read('static/boot.js')
-        assert 'window._showThinking=true' in src, (
+        src = read("static/boot.js")
+        assert "window._showThinking=true" in src, (
             "boot.js fallback path must default _showThinking to true"
         )
 
 
 # ── static/ui.js ──────────────────────────────────────────────────────────────
 
+
 class TestUiJsThinkingGate:
     """Historical thinking cards must be gated by window._showThinking."""
 
     def test_thinking_card_gated_in_render_messages(self):
-        src = read('static/ui.js')
-        assert 'window._showThinking!==false' in src, (
+        src = read("static/ui.js")
+        assert "window._showThinking!==false" in src, (
             "ui.js must gate thinkingCardHtml on window._showThinking"
         )
         # The guard must be on the same line as _thinkingCardHtml insertion
         lines = src.splitlines()
         for line in lines:
-            if '_thinkingCardHtml' in line and 'insertAdjacentHTML' in line:
-                assert 'window._showThinking' in line, (
+            if "_thinkingCardHtml" in line and "insertAdjacentHTML" in line:
+                assert "window._showThinking" in line, (
                     f"thinking card insertion must be gated: {line.strip()}"
                 )
                 break
@@ -83,95 +86,96 @@ class TestUiJsThinkingGate:
 
 # ── static/messages.js ────────────────────────────────────────────────────────
 
+
 class TestMessagesJsLiveThinkingGate:
     """Live streaming thinking card must be hidden when _showThinking is false."""
 
     def test_live_thinking_gated(self):
-        src = read('static/messages.js')
-        assert 'window._showThinking===false' in src, (
+        src = read("static/messages.js")
+        assert "window._showThinking===false" in src, (
             "messages.js _renderLiveThinking must early-return when _showThinking is false"
         )
         # Guard must be inside _renderLiveThinking
-        m = re.search(r'function _renderLiveThinking\(.*?\{(.*?)^\s*\}',
-                      src, re.DOTALL | re.MULTILINE)
+        m = re.search(
+            r"function _renderLiveThinking\(.*?\{(.*?)^\s*\}",
+            src,
+            re.DOTALL | re.MULTILINE,
+        )
         assert m, "_renderLiveThinking not found"
-        assert 'window._showThinking' in m.group(1)
+        assert "window._showThinking" in m.group(1)
 
 
 # ── static/commands.js ────────────────────────────────────────────────────────
+
 
 class TestReasoningCommand:
     """cmdReasoning must be wired into COMMANDS with show/hide subArgs."""
 
     def test_reasoning_in_commands_array(self):
-        src = read('static/commands.js')
+        src = read("static/commands.js")
         # Must appear in COMMANDS array (not just SLASH_SUBARG_SOURCES)
-        m = re.search(r'const COMMANDS\s*=\s*\[(.*?)\];', src, re.DOTALL)
+        m = re.search(r"const COMMANDS\s*=\s*\[(.*?)\];", src, re.DOTALL)
         assert m, "COMMANDS array not found"
         commands_block = m.group(1)
-        assert 'reasoning' in commands_block, (
+        assert "reasoning" in commands_block, (
             "/reasoning must be in the COMMANDS array with a fn: handler"
         )
-        assert 'fn:cmdReasoning' in commands_block or "fn: cmdReasoning" in commands_block, (
-            "/reasoning entry must reference cmdReasoning"
-        )
+        assert (
+            "fn:cmdReasoning" in commands_block or "fn: cmdReasoning" in commands_block
+        ), "/reasoning entry must reference cmdReasoning"
 
     def test_reasoning_subargs_include_show_hide(self):
-        src = read('static/commands.js')
-        m = re.search(r'const COMMANDS\s*=\s*\[(.*?)\];', src, re.DOTALL)
+        src = read("static/commands.js")
+        m = re.search(r"const COMMANDS\s*=\s*\[(.*?)\];", src, re.DOTALL)
         assert m
         commands_block = m.group(1)
         # Find the reasoning entry
         rm = re.search(r"\{name:'reasoning'.*?\}", commands_block, re.DOTALL)
         assert rm, "reasoning entry not found in COMMANDS"
         entry = rm.group(0)
-        assert 'show' in entry, "subArgs must include 'show'"
-        assert 'hide' in entry, "subArgs must include 'hide'"
+        assert "show" in entry, "subArgs must include 'show'"
+        assert "hide" in entry, "subArgs must include 'hide'"
 
     def test_reasoning_not_only_in_subarg_sources(self):
-        src = read('static/commands.js')
+        src = read("static/commands.js")
         # It's fine if SLASH_SUBARG_SOURCES is empty or doesn't have reasoning
         # (reasoning moved to COMMANDS with a real fn)
-        m = re.search(r'const SLASH_SUBARG_SOURCES\s*=\s*\{(.*?)\};', src, re.DOTALL)
+        m = re.search(r"const SLASH_SUBARG_SOURCES\s*=\s*\{(.*?)\};", src, re.DOTALL)
         if m:
             subarg_block = m.group(1)
-            assert 'reasoning' not in subarg_block, (
+            assert "reasoning" not in subarg_block, (
                 "reasoning must not remain in SLASH_SUBARG_SOURCES once it has a fn: handler"
             )
 
     def test_cmd_reasoning_function_exists(self):
-        src = read('static/commands.js')
-        assert 'function cmdReasoning' in src, (
-            "cmdReasoning function must be defined"
-        )
+        src = read("static/commands.js")
+        assert "function cmdReasoning" in src, "cmdReasoning function must be defined"
 
     def test_cmd_reasoning_handles_show(self):
-        src = read('static/commands.js')
-        m = re.search(r'function cmdReasoning\(.*?\n\}', src, re.DOTALL)
+        src = read("static/commands.js")
+        m = re.search(r"function cmdReasoning\(.*?\n\}", src, re.DOTALL)
         assert m, "cmdReasoning not found"
         fn = m.group(0)
         # Handler must write to the UI render gate (assignment may use a
         # boolean literal or a locally-computed variable) and call renderMessages.
-        assert re.search(r'window\._showThinking\s*=\s*(?:true|on)\b', fn), (
+        assert re.search(r"window\._showThinking\s*=\s*(?:true|on)\b", fn), (
             "cmdReasoning show branch must assign true/on to window._showThinking"
         )
-        assert 'renderMessages' in fn, (
-            "show/hide branch must call renderMessages()"
-        )
+        assert "renderMessages" in fn, "show/hide branch must call renderMessages()"
         # Persistence: POST to /api/reasoning (CLI-shared config.yaml) AND
         # /api/settings (boot.js mirror).
         assert "api('/api/reasoning'" in fn, (
             "show/hide branch must POST to /api/reasoning so config.yaml "
             "display.show_reasoning is updated (CLI parity)"
         )
-        assert 'show_thinking' in fn, (
+        assert "show_thinking" in fn, (
             "show/hide branch must also mirror show_thinking into "
             "WebUI settings.json for boot.js hydration"
         )
 
     def test_cmd_reasoning_handles_hide(self):
-        src = read('static/commands.js')
-        m = re.search(r'function cmdReasoning\(.*?\n\}', src, re.DOTALL)
+        src = read("static/commands.js")
+        m = re.search(r"function cmdReasoning\(.*?\n\}", src, re.DOTALL)
         assert m
         fn = m.group(0)
         # The hide branch shares logic with show via a computed `on` variable;
@@ -180,52 +184,46 @@ class TestReasoningCommand:
         assert "arg==='off'" in fn, "off alias missing"
 
     def test_cmd_reasoning_i18n_key_exists(self):
-        i18n = read('static/i18n.js')
-        assert 'cmd_reasoning' in i18n, (
-            "i18n.js must define the cmd_reasoning key"
-        )
+        i18n = read("static/i18n.js")
+        assert "cmd_reasoning" in i18n, "i18n.js must define the cmd_reasoning key"
 
     def test_cmd_reasoning_posts_api_endpoints_not_gets(self):
         """Regression: the api() helper spreads its 2nd arg into fetch(), so
         passing a plain options object without method:'POST' silently becomes
         a GET and the update is dropped.  Every mutating call inside
         cmdReasoning (/api/reasoning, /api/settings) must be a proper POST."""
-        src = read('static/commands.js')
-        m = re.search(r'function cmdReasoning\(.*?\n\}', src, re.DOTALL)
+        src = read("static/commands.js")
+        m = re.search(r"function cmdReasoning\(.*?\n\}", src, re.DOTALL)
         assert m
         fn = m.group(0)
         # Every write call — /api/reasoning and /api/settings — must be a POST.
-        write_calls = re.findall(
-            r"api\('/api/(?:reasoning|settings)'\s*,[^)]*\)", fn
-        )
+        write_calls = re.findall(r"api\('/api/(?:reasoning|settings)'\s*,[^)]*\)", fn)
         assert write_calls, "cmdReasoning must POST to /api/reasoning or /api/settings"
         for call in write_calls:
             assert "method:'POST'" in call or 'method: "POST"' in call, (
                 f"write call missing method:'POST' — would fall through "
                 f"to GET and silently drop the update: {call}"
             )
-            assert 'JSON.stringify' in call, (
-                f"write call missing JSON body: {call}"
-            )
+            assert "JSON.stringify" in call, f"write call missing JSON body: {call}"
 
     def test_cmd_reasoning_routes_effort_through_api_reasoning(self):
         """Effort levels (none|minimal|low|medium|high|xhigh) must POST to
         /api/reasoning so the agent's config.yaml agent.reasoning_effort is
         updated — the same key the CLI writes via `/reasoning <level>`.
         Previous design stored in a dead client variable, which did nothing."""
-        src = read('static/commands.js')
-        m = re.search(r'function cmdReasoning\(.*?\n\}', src, re.DOTALL)
+        src = read("static/commands.js")
+        m = re.search(r"function cmdReasoning\(.*?\n\}", src, re.DOTALL)
         assert m
         fn = m.group(0)
         assert "api('/api/reasoning'" in fn, (
             "cmdReasoning must POST effort levels to /api/reasoning so "
             "config.yaml agent.reasoning_effort is updated (CLI parity)"
         )
-        assert "'effort:'" in fn or 'effort:arg' in fn or 'effort: arg' in fn, (
+        assert "'effort:'" in fn or "effort:arg" in fn or "effort: arg" in fn, (
             "effort-level branch must send {effort: arg} to /api/reasoning"
         )
         # Must NOT still hold a dead local-only variable for effort.
-        assert '_reasoningEffort=' not in fn, (
+        assert "_reasoningEffort=" not in fn, (
             "cmdReasoning must not keep a dead client-side _reasoningEffort "
             "(effort now round-trips through /api/reasoning → config.yaml)"
         )
@@ -234,11 +232,11 @@ class TestReasoningCommand:
         """show|hide|on|off must POST to /api/reasoning (config.yaml
         display.show_reasoning — the CLI's key) in addition to mirroring
         into WebUI settings.json for boot.js hydration."""
-        src = read('static/commands.js')
-        m = re.search(r'function cmdReasoning\(.*?\n\}', src, re.DOTALL)
+        src = read("static/commands.js")
+        m = re.search(r"function cmdReasoning\(.*?\n\}", src, re.DOTALL)
         assert m
         fn = m.group(0)
-        assert 'display:arg' in fn or 'display: arg' in fn or "'display'" in fn, (
+        assert "display:arg" in fn or "display: arg" in fn or "'display'" in fn, (
             "show|hide branch must send {display: arg} to /api/reasoning so "
             "config.yaml display.show_reasoning matches the CLI's source"
         )
@@ -246,11 +244,11 @@ class TestReasoningCommand:
     def test_cmd_reasoning_supports_all_cli_effort_levels(self):
         """The effort-level set must match hermes_constants.VALID_REASONING_EFFORTS
         + 'none' — i.e. the exact set the CLI accepts in /reasoning."""
-        src = read('static/commands.js')
-        m = re.search(r'function cmdReasoning\(.*?\n\}', src, re.DOTALL)
+        src = read("static/commands.js")
+        m = re.search(r"function cmdReasoning\(.*?\n\}", src, re.DOTALL)
         assert m
         fn = m.group(0)
-        for level in ('none', 'minimal', 'low', 'medium', 'high', 'xhigh'):
+        for level in ("none", "minimal", "low", "medium", "high", "xhigh"):
             assert f"'{level}'" in fn, (
                 f"cmdReasoning must accept '{level}' (CLI parity with "
                 f"hermes_constants.parse_reasoning_effort)"
@@ -258,12 +256,19 @@ class TestReasoningCommand:
 
     def test_reasoning_subargs_match_cli_levels(self):
         """Autocomplete subArgs must expose every CLI effort level + show/hide."""
-        src = read('static/commands.js')
+        src = read("static/commands.js")
         m = re.search(r"\{name:'reasoning'[^}]*\}", src, re.DOTALL)
         assert m, "reasoning COMMANDS entry not found"
         entry = m.group(0)
         for suggestion in (
-            'show', 'hide', 'none', 'minimal', 'low', 'medium', 'high', 'xhigh'
+            "show",
+            "hide",
+            "none",
+            "minimal",
+            "low",
+            "medium",
+            "high",
+            "xhigh",
         ):
             assert f"'{suggestion}'" in entry, (
                 f"reasoning subArgs must include '{suggestion}' for CLI parity"
@@ -272,44 +277,47 @@ class TestReasoningCommand:
 
 # ── api/config.py — reasoning helpers ────────────────────────────────────────
 
+
 class TestReasoningConfigHelpers:
     """Validate that api/config.py exposes the CLI-parity helpers and that
     they read/write the same keys the CLI uses."""
 
     def test_parse_reasoning_effort_matches_cli_semantics(self):
         from api.config import parse_reasoning_effort, VALID_REASONING_EFFORTS
+
         # Empty → None
-        assert parse_reasoning_effort('') is None
+        assert parse_reasoning_effort("") is None
         assert parse_reasoning_effort(None) is None
         # none → disabled
-        assert parse_reasoning_effort('none') == {'enabled': False}
+        assert parse_reasoning_effort("none") == {"enabled": False}
         # Each valid level → {enabled, effort}
         for level in VALID_REASONING_EFFORTS:
-            assert parse_reasoning_effort(level) == {'enabled': True, 'effort': level}
+            assert parse_reasoning_effort(level) == {"enabled": True, "effort": level}
         # Unknown → None (fall back to default)
-        assert parse_reasoning_effort('garbage') is None
+        assert parse_reasoning_effort("garbage") is None
         # Case-insensitive + trimmed
-        assert parse_reasoning_effort('  HIGH  ') == {'enabled': True, 'effort': 'high'}
+        assert parse_reasoning_effort("  HIGH  ") == {"enabled": True, "effort": "high"}
 
     def test_valid_reasoning_efforts_matches_hermes_constants(self):
         """Ensure our mirror stays in sync with hermes_constants."""
         from api.config import VALID_REASONING_EFFORTS
+
         # Snapshot-style assertion: if hermes_constants adds a level, this
         # test will fail fast so we know to update WebUI too.
-        assert VALID_REASONING_EFFORTS == (
-            'minimal', 'low', 'medium', 'high', 'xhigh'
-        )
+        assert VALID_REASONING_EFFORTS == ("minimal", "low", "medium", "high", "xhigh")
 
     def test_set_reasoning_effort_persists_to_config_yaml(self, tmp_path, monkeypatch):
         """set_reasoning_effort writes agent.reasoning_effort to the active
         profile's config.yaml — the same key the CLI writes."""
         import api.config as cfg
-        cfgfile = tmp_path / 'config.yaml'
-        monkeypatch.setattr(cfg, '_get_config_path', lambda: cfgfile)
-        cfg.set_reasoning_effort('high')
+
+        cfgfile = tmp_path / "config.yaml"
+        monkeypatch.setattr(cfg, "_get_config_path", lambda: cfgfile)
+        cfg.set_reasoning_effort("high")
         import yaml as _yaml
-        data = _yaml.safe_load(cfgfile.read_text(encoding='utf-8'))
-        assert data.get('agent', {}).get('reasoning_effort') == 'high', (
+
+        data = _yaml.safe_load(cfgfile.read_text(encoding="utf-8"))
+        assert data.get("agent", {}).get("reasoning_effort") == "high", (
             "agent.reasoning_effort must be persisted to config.yaml"
         )
 
@@ -317,38 +325,44 @@ class TestReasoningConfigHelpers:
         """set_reasoning_display writes display.show_reasoning to the same
         config.yaml the CLI writes."""
         import api.config as cfg
-        cfgfile = tmp_path / 'config.yaml'
-        monkeypatch.setattr(cfg, '_get_config_path', lambda: cfgfile)
+
+        cfgfile = tmp_path / "config.yaml"
+        monkeypatch.setattr(cfg, "_get_config_path", lambda: cfgfile)
         cfg.set_reasoning_display(False)
         import yaml as _yaml
-        data = _yaml.safe_load(cfgfile.read_text(encoding='utf-8'))
-        assert data.get('display', {}).get('show_reasoning') is False, (
+
+        data = _yaml.safe_load(cfgfile.read_text(encoding="utf-8"))
+        assert data.get("display", {}).get("show_reasoning") is False, (
             "display.show_reasoning must be persisted to config.yaml"
         )
         cfg.set_reasoning_display(True)
-        data = _yaml.safe_load(cfgfile.read_text(encoding='utf-8'))
-        assert data.get('display', {}).get('show_reasoning') is True
+        data = _yaml.safe_load(cfgfile.read_text(encoding="utf-8"))
+        assert data.get("display", {}).get("show_reasoning") is True
 
     def test_set_reasoning_effort_rejects_invalid(self, tmp_path, monkeypatch):
         import api.config as cfg
-        monkeypatch.setattr(cfg, '_get_config_path', lambda: tmp_path / 'config.yaml')
+
+        monkeypatch.setattr(cfg, "_get_config_path", lambda: tmp_path / "config.yaml")
         import pytest as _pt
+
         with _pt.raises(ValueError):
-            cfg.set_reasoning_effort('garbage')
+            cfg.set_reasoning_effort("garbage")
         with _pt.raises(ValueError):
-            cfg.set_reasoning_effort('')
+            cfg.set_reasoning_effort("")
 
     def test_get_reasoning_status_defaults_to_show_true(self, tmp_path, monkeypatch):
         """When config.yaml has no display section, show_reasoning defaults
         to True (matches CLI default where the setting is opt-in)."""
         import api.config as cfg
-        monkeypatch.setattr(cfg, '_get_config_path', lambda: tmp_path / 'config.yaml')
+
+        monkeypatch.setattr(cfg, "_get_config_path", lambda: tmp_path / "config.yaml")
         st = cfg.get_reasoning_status()
-        assert st['show_reasoning'] is True
-        assert st['reasoning_effort'] == ''
+        assert st["show_reasoning"] is True
+        assert st["reasoning_effort"] == ""
 
 
 # ── api/streaming.py — AIAgent receives reasoning_config ──────────────────────
+
 
 class TestStreamingReasoningWiring:
     """Confirm api/streaming.py reads agent.reasoning_effort from config and
@@ -356,12 +370,14 @@ class TestStreamingReasoningWiring:
     on the next session)."""
 
     def test_streaming_reads_reasoning_effort_from_config(self):
-        src = read('api/streaming.py')
-        assert 'parse_reasoning_effort' in src, (
+        src = read("api/streaming.py")
+        assert "parse_reasoning_effort" in src, (
             "api/streaming.py must import parse_reasoning_effort to translate "
             "config.yaml agent.reasoning_effort into AIAgent reasoning_config"
         )
-        assert "reasoning_config" in src and "'reasoning_config' in _agent_params" in src, (
+        assert (
+            "reasoning_config" in src and "'reasoning_config' in _agent_params" in src
+        ), (
             "api/streaming.py must guard the reasoning_config kwarg with "
             "inspect.signature so older hermes-agent builds don't TypeError"
         )
@@ -369,29 +385,28 @@ class TestStreamingReasoningWiring:
 
 # ── api/routes.py — /api/reasoning endpoints ──────────────────────────────────
 
-class TestReasoningRoutes:
 
+class TestReasoningRoutes:
     def test_get_api_reasoning_route_exists(self):
-        src = read('api/routes.py')
+        src = read("api/routes.py")
         assert 'parsed.path == "/api/reasoning"' in src, (
             "GET /api/reasoning route must exist"
         )
-        assert 'get_reasoning_status' in src, (
+        assert "get_reasoning_status" in src, (
             "api/routes.py must import and call get_reasoning_status"
         )
 
     def test_post_api_reasoning_accepts_display(self):
-        src = read('api/routes.py')
+        src = read("api/routes.py")
         # The POST branch reads 'display' from body and dispatches to
         # set_reasoning_display.
-        assert 'set_reasoning_display' in src, (
+        assert "set_reasoning_display" in src, (
             "POST /api/reasoning must route display toggles through "
             "set_reasoning_display"
         )
 
     def test_post_api_reasoning_accepts_effort(self):
-        src = read('api/routes.py')
-        assert 'set_reasoning_effort' in src, (
-            "POST /api/reasoning must route effort changes through "
-            "set_reasoning_effort"
+        src = read("api/routes.py")
+        assert "set_reasoning_effort" in src, (
+            "POST /api/reasoning must route effort changes through set_reasoning_effort"
         )

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -4,24 +4,28 @@ These tests exist specifically to prevent those bugs from silently returning.
 
 Each test is tagged with the sprint/commit where the bug was found and fixed.
 """
+
 import json
 import os
 import pathlib
-import time
 import urllib.error
 import urllib.request
 import urllib.parse
+
 REPO_ROOT = pathlib.Path(__file__).parent.parent.resolve()
 
 from tests._pytest_port import BASE
+
 
 def get(path):
     with urllib.request.urlopen(BASE + path, timeout=10) as r:
         return json.loads(r.read()), r.status
 
+
 def get_raw(path):
     with urllib.request.urlopen(BASE + path, timeout=10) as r:
-        return r.read(), r.headers.get("Content-Type",""), r.status
+        return r.read(), r.headers.get("Content-Type", ""), r.status
+
 
 def post(path, body=None):
     data = json.dumps(body or {}).encode()
@@ -33,6 +37,7 @@ def post(path, body=None):
             return json.loads(r.read()), r.status
     except urllib.error.HTTPError as e:
         return json.loads(e.read()), e.code
+
 
 def make_session(created_list):
     d, _ = post("/api/session/new", {})
@@ -53,16 +58,20 @@ def _make_auth_json_with_credential_pool(
 
 # ── R1: uuid not imported in server.py (Sprint 10 split regression) ──────────
 
+
 def test_chat_start_returns_stream_id(cleanup_test_sessions):
     """R1: chat/start must return stream_id -- catches missing uuid import.
     When uuid was missing, this returned 500 (NameError).
     """
     sid = make_session(cleanup_test_sessions)
-    data, status = post("/api/chat/start", {
-        "session_id": sid,
-        "message": "ping",
-        "model": "openai/gpt-5.4-mini",
-    })
+    data, status = post(
+        "/api/chat/start",
+        {
+            "session_id": sid,
+            "message": "ping",
+            "model": "openai/gpt-5.4-mini",
+        },
+    )
     # Must return 200 with a stream_id -- not 500
     assert status == 200, f"chat/start failed with {status}: {data}"
     assert "stream_id" in data, "stream_id missing from chat/start response"
@@ -73,17 +82,21 @@ def test_chat_start_returns_stream_id(cleanup_test_sessions):
 
 # ── R2: AIAgent not imported in api/streaming.py (Sprint 10 split regression) ─
 
+
 def test_chat_stream_opens_successfully(cleanup_test_sessions):
     """R2: After chat/start, GET /api/chat/stream must return 200 (SSE opens).
     When AIAgent was missing, the thread crashed immediately, popped STREAMS,
     and the SSE GET returned 404.
     """
     sid = make_session(cleanup_test_sessions)
-    data, status = post("/api/chat/start", {
-        "session_id": sid,
-        "message": "say: hello",
-        "model": "openai/gpt-5.4-mini",
-    })
+    data, status = post(
+        "/api/chat/start",
+        {
+            "session_id": sid,
+            "message": "say: hello",
+            "model": "openai/gpt-5.4-mini",
+        },
+    )
     assert status == 200, f"chat/start failed: {data}"
     stream_id = data["stream_id"]
 
@@ -107,6 +120,7 @@ def test_chat_stream_opens_successfully(cleanup_test_sessions):
 
 # ── R3: Session.__init__ missing tool_calls param (Sprint 10 split regression) ─
 
+
 def test_session_with_tool_calls_in_json_loads_ok(cleanup_test_sessions):
     """R3: Sessions that have tool_calls in their JSON must load without 500.
     When tool_calls=None was missing from Session.__init__, loading such sessions
@@ -115,12 +129,25 @@ def test_session_with_tool_calls_in_json_loads_ok(cleanup_test_sessions):
     sid = make_session(cleanup_test_sessions)
 
     # Manually inject tool_calls into the session's JSON file
-    sessions_dir = pathlib.Path(os.environ.get("HERMES_WEBUI_TEST_STATE_DIR", str(pathlib.Path.home() / ".hermes" / "webui-mvp-test"))) / "sessions"
+    sessions_dir = (
+        pathlib.Path(
+            os.environ.get(
+                "HERMES_WEBUI_TEST_STATE_DIR",
+                str(pathlib.Path.home() / ".hermes" / "webui-mvp-test"),
+            )
+        )
+        / "sessions"
+    )
     session_file = sessions_dir / f"{sid}.json"
     if session_file.exists():
         d = json.loads(session_file.read_text())
         d["tool_calls"] = [
-            {"name": "terminal", "snippet": "test output", "tid": "test_tid_001", "assistant_msg_idx": 1}
+            {
+                "name": "terminal",
+                "snippet": "test output",
+                "tid": "test_tid_001",
+                "assistant_msg_idx": 1,
+            }
         ]
         session_file.write_text(json.dumps(d))
 
@@ -135,6 +162,7 @@ def test_session_with_tool_calls_in_json_loads_ok(cleanup_test_sessions):
 
 # ── R4: has_pending not imported in streaming.py (Sprint 10 split regression) ─
 
+
 def test_streaming_py_imports_has_pending(cleanup_test_sessions):
     """R4: api/streaming.py must import or define has_pending.
     When missing, the approval check mid-stream caused NameError.
@@ -142,8 +170,9 @@ def test_streaming_py_imports_has_pending(cleanup_test_sessions):
     src = (REPO_ROOT / "api/streaming.py").read_text()
     assert "has_pending" in src, "has_pending not found in api/streaming.py"
     # Verify it's imported (not just used)
-    assert "import" in src and "has_pending" in src, \
+    assert "import" in src and "has_pending" in src, (
         "has_pending must be imported in api/streaming.py"
+    )
 
 
 def test_aiagent_imported_in_streaming(cleanup_test_sessions):
@@ -152,11 +181,13 @@ def test_aiagent_imported_in_streaming(cleanup_test_sessions):
     """
     src = (REPO_ROOT / "api/streaming.py").read_text()
     assert "AIAgent" in src, "AIAgent not referenced in api/streaming.py"
-    assert "from run_agent import AIAgent" in src or "import AIAgent" in src, \
+    assert "from run_agent import AIAgent" in src or "import AIAgent" in src, (
         "AIAgent must be imported in api/streaming.py"
+    )
 
 
 # ── R5: SSE loop did not break on cancel event (Sprint 10 bug) ───────────────
+
 
 def test_cancel_nonexistent_stream_returns_not_cancelled(cleanup_test_sessions):
     """R5a: Cancel endpoint works and returns cancelled:false for unknown stream."""
@@ -172,17 +203,24 @@ def test_server_py_sse_loop_breaks_on_cancel(cleanup_test_sessions):
     Sprint 11: logic moved from server.py to api/routes.py -- check both.
     """
     import re
+
     # Check server.py first, then api/routes.py (Sprint 11 extracted routes)
     src = (REPO_ROOT / "server.py").read_text()
-    routes_src = (REPO_ROOT / "api" / "routes.py").read_text() if (REPO_ROOT / "api" / "routes.py").exists() else ""
+    routes_src = (
+        (REPO_ROOT / "api" / "routes.py").read_text()
+        if (REPO_ROOT / "api" / "routes.py").exists()
+        else ""
+    )
     combined = src + routes_src
     m = re.search(r"if event in \([^)]+\):\s*break", combined)
     assert m, "SSE break condition not found in server.py or api/routes.py"
-    assert "cancel" in m.group(), \
+    assert "cancel" in m.group(), (
         f"'cancel' missing from SSE break condition: {m.group()}"
+    )
 
 
 # ── R6: Test cron isolation (Sprint 10) ──────────────────────────────────────
+
 
 def test_real_jobs_json_not_polluted_by_tests(cleanup_test_sessions):
     """R6: Test runs must not write to the real ~/.hermes/cron/jobs.json.
@@ -197,18 +235,21 @@ def test_real_jobs_json_not_polluted_by_tests(cleanup_test_sessions):
         jobs = jobs.get("jobs", [])
 
     test_jobs = [j for j in jobs if j.get("name", "").startswith("test-job-")]
-    assert len(test_jobs) == 0, \
-        f"Real jobs.json contains {len(test_jobs)} test-job-* entries: " \
+    assert len(test_jobs) == 0, (
+        f"Real jobs.json contains {len(test_jobs)} test-job-* entries: "
         f"{[j['name'] for j in test_jobs]}"
+    )
 
 
 # ── General: api modules all importable ──────────────────────────────────────
+
 
 def test_all_api_modules_importable(cleanup_test_sessions):
     """All api/ modules must be importable without NameError or ImportError.
     Catches missing imports introduced during future module splits.
     """
-    import ast, pathlib
+    import ast
+
     api_dir = REPO_ROOT / "api"
     for module_file in api_dir.glob("*.py"):
         src = module_file.read_text()
@@ -220,14 +261,17 @@ def test_all_api_modules_importable(cleanup_test_sessions):
 
 def test_server_py_importable(cleanup_test_sessions):
     """server.py must parse without syntax errors after any split."""
-    import ast, pathlib
+    import ast
+
     src = (REPO_ROOT / "server.py").read_text()
     try:
         ast.parse(src)
     except SyntaxError as e:
         assert False, f"server.py has syntax error: {e}"
 
+
 # ── R7: Cross-session busy state bleed ───────────────────────────────────────
+
 
 def test_loadSession_resets_busy_state_for_idle_session(cleanup_test_sessions):
     """R7: sessions.js loadSession for a non-inflight session must reset S.busy to false.
@@ -236,9 +280,13 @@ def test_loadSession_resets_busy_state_for_idle_session(cleanup_test_sessions):
     """
     src = (REPO_ROOT / "static/sessions.js").read_text()
     # The fix adds explicit S.busy=false in the non-inflight else branch
-    assert "S.busy=false;" in src,         "sessions.js loadSession must set S.busy=false when loading a non-inflight session"
+    assert "S.busy=false;" in src, (
+        "sessions.js loadSession must set S.busy=false when loading a non-inflight session"
+    )
     # btnSend state must be refreshed via updateSendBtn
-    assert "updateSendBtn()" in src,         "sessions.js loadSession must call updateSendBtn for non-inflight sessions"
+    assert "updateSendBtn()" in src, (
+        "sessions.js loadSession must call updateSendBtn for non-inflight sessions"
+    )
 
 
 def test_done_handler_guards_setbusy_with_inflight_check(cleanup_test_sessions):
@@ -257,7 +305,9 @@ def test_done_handler_guards_setbusy_with_inflight_check(cleanup_test_sessions):
     ), "messages.js must guard setBusy(false) for the current session"
 
 
-def test_refresh_handler_does_not_drop_tool_messages_needed_by_todos(cleanup_test_sessions):
+def test_refresh_handler_does_not_drop_tool_messages_needed_by_todos(
+    cleanup_test_sessions,
+):
     """Todo panel state must survive session reload/refresh.
     The UI can hide tool-role messages from the visible transcript, but it must not
     destroy the raw session messages because loadTodos reconstructs state from the
@@ -267,12 +317,18 @@ def test_refresh_handler_does_not_drop_tool_messages_needed_by_todos(cleanup_tes
     ui_src = (REPO_ROOT / "static/ui.js").read_text()
     panels_src = (REPO_ROOT / "static/panels.js").read_text()
 
-    assert "data.session.messages=(data.session.messages||[]).filter(" not in sessions_src, \
+    assert (
+        "data.session.messages=(data.session.messages||[]).filter(" not in sessions_src
+    ), (
         "sessions.js must not overwrite raw session.messages when filtering transcript display"
-    assert "S.messages = (data.session.messages || []).filter(" not in ui_src, \
+    )
+    assert "S.messages = (data.session.messages || []).filter(" not in ui_src, (
         "ui.js refreshSession must not rebuild S.messages by discarding tool messages from the raw session payload"
-    assert "const sourceMessages = (S.session && Array.isArray(S.session.messages) && S.session.messages.length) ? S.session.messages : S.messages;" in panels_src, \
-        "loadTodos must prefer raw S.session.messages so todo state survives reloads"
+    )
+    assert (
+        "const sourceMessages = (S.session && Array.isArray(S.session.messages) && S.session.messages.length) ? S.session.messages : S.messages;"
+        in panels_src
+    ), "loadTodos must prefer raw S.session.messages so todo state survives reloads"
 
 
 def test_cancel_button_not_cleared_across_sessions(cleanup_test_sessions):
@@ -282,9 +338,13 @@ def test_cancel_button_not_cleared_across_sessions(cleanup_test_sessions):
     src = (REPO_ROOT / "static/messages.js").read_text()
     # Both clear operations must be inside the activeSid === S.session guard
     # We check for the pattern added by the fix
-    assert "S.session.session_id===activeSid" in src,         "messages.js must guard activeStreamId/Cancel clearing with session identity check"
+    assert "S.session.session_id===activeSid" in src, (
+        "messages.js must guard activeStreamId/Cancel clearing with session identity check"
+    )
+
 
 # ── R8: Session delete does not invalidate index (ghost sessions) ─────────────
+
 
 def test_deleted_session_does_not_appear_in_list(cleanup_test_sessions):
     """R8: After deleting a session, it must not appear in /api/sessions.
@@ -294,7 +354,9 @@ def test_deleted_session_does_not_appear_in_list(cleanup_test_sessions):
     # Create a session with a title so it shows in the list
     d, _ = post("/api/session/new", {})
     sid = d["session"]["session_id"]
-    post("/api/session/rename", {"session_id": sid, "title": "regression-test-delete-R8"})
+    post(
+        "/api/session/rename", {"session_id": sid, "title": "regression-test-delete-R8"}
+    )
 
     # Verify it appears
     sessions, _ = get("/api/sessions")
@@ -308,7 +370,9 @@ def test_deleted_session_does_not_appear_in_list(cleanup_test_sessions):
     # Verify it no longer appears -- even after a second fetch (index rebuild)
     sessions2, _ = get("/api/sessions")
     ids_after = [s["session_id"] for s in sessions2["sessions"]]
-    assert sid not in ids_after,         f"Deleted session {sid} still appears in list -- index not invalidated on delete"
+    assert sid not in ids_after, (
+        f"Deleted session {sid} still appears in list -- index not invalidated on delete"
+    )
 
 
 def test_server_delete_invalidates_index(cleanup_test_sessions):
@@ -317,7 +381,11 @@ def test_server_delete_invalidates_index(cleanup_test_sessions):
     Sprint 11: handler moved from server.py to api/routes.py -- check both.
     """
     src = (REPO_ROOT / "server.py").read_text()
-    routes_src = (REPO_ROOT / "api" / "routes.py").read_text() if (REPO_ROOT / "api" / "routes.py").exists() else ""
+    routes_src = (
+        (REPO_ROOT / "api" / "routes.py").read_text()
+        if (REPO_ROOT / "api" / "routes.py").exists()
+        else ""
+    )
     # Find the delete handler in either file
     for label, text in [("server.py", src), ("api/routes.py", routes_src)]:
         # Accept both single-quote and double-quote style (formatting varies by contributor)
@@ -329,13 +397,16 @@ def test_server_delete_invalidates_index(cleanup_test_sessions):
             # Use 1200 chars to accommodate any validation/guard code added
             # before the SESSION_INDEX_FILE.unlink() call (e.g. session_id
             # character checks, path traversal guards).
-            delete_block = text[delete_idx:delete_idx+1200]
-            assert "SESSION_INDEX_FILE" in delete_block, \
+            delete_block = text[delete_idx : delete_idx + 1200]
+            assert "SESSION_INDEX_FILE" in delete_block, (
                 f"{label} session/delete must invalidate SESSION_INDEX_FILE"
+            )
             return
     assert False, "session/delete handler not found in server.py or api/routes.py"
 
+
 # ── R9: Token/tool SSE events write to wrong session after switch ─────────────
+
 
 def test_token_handler_guards_session_id(cleanup_test_sessions):
     """R9a: The SSE token event handler must check activeSid before writing to DOM.
@@ -349,12 +420,14 @@ def test_token_handler_guards_session_id(cleanup_test_sessions):
     if token_idx < 0:
         token_idx = src.find("es.addEventListener('token'")
     assert token_idx >= 0, "token event handler not found"
-    token_block = src[token_idx:token_idx+300]
-    assert "activeSid" in token_block, \
+    token_block = src[token_idx : token_idx + 300]
+    assert "activeSid" in token_block, (
         "token handler must check activeSid before writing to DOM"
-    assert "S.session.session_id!==activeSid" in token_block or \
-           "S.session.session_id===activeSid" in token_block, \
-    "token handler must compare current session to activeSid"
+    )
+    assert (
+        "S.session.session_id!==activeSid" in token_block
+        or "S.session.session_id===activeSid" in token_block
+    ), "token handler must compare current session to activeSid"
 
 
 def test_tool_handler_guards_session_id(cleanup_test_sessions):
@@ -367,12 +440,14 @@ def test_tool_handler_guards_session_id(cleanup_test_sessions):
     if tool_idx < 0:
         tool_idx = src.find("es.addEventListener('tool'")
     assert tool_idx >= 0, "tool event handler not found"
-    tool_block = src[tool_idx:tool_idx+400]
-    assert "activeSid" in tool_block, \
+    tool_block = src[tool_idx : tool_idx + 400]
+    assert "activeSid" in tool_block, (
         "tool handler must check activeSid before writing to DOM"
+    )
 
 
 # ── R10: respondApproval uses wrong session_id after switch (multi-session) ─
+
 
 def test_respond_approval_uses_approval_session_id(cleanup_test_sessions):
     """R10: respondApproval must use the session_id of the session that triggered
@@ -381,15 +456,20 @@ def test_respond_approval_uses_approval_session_id(cleanup_test_sessions):
     """
     src = (REPO_ROOT / "static/messages.js").read_text()
     # The fix introduces _approvalSessionId to track the correct session
-    assert "_approvalSessionId" in src,         "messages.js must use _approvalSessionId in respondApproval"
+    assert "_approvalSessionId" in src, (
+        "messages.js must use _approvalSessionId in respondApproval"
+    )
     # respondApproval must use _approvalSessionId, not S.session.session_id directly
     idx = src.find("async function respondApproval(")
     assert idx >= 0, "respondApproval not found"
-    fn_body = src[idx:idx+300]
-    assert "_approvalSessionId" in fn_body,         "respondApproval must read _approvalSessionId, not S.session.session_id"
+    fn_body = src[idx : idx + 300]
+    assert "_approvalSessionId" in fn_body, (
+        "respondApproval must read _approvalSessionId, not S.session.session_id"
+    )
 
 
 # ── R11: Tool progress must not use shared status chrome ──────────────────
+
 
 def test_tool_status_only_shown_for_current_session(cleanup_test_sessions):
     """R11: Tool progress should not drive the global status bar or composer
@@ -402,13 +482,17 @@ def test_tool_status_only_shown_for_current_session(cleanup_test_sessions):
     if tool_idx < 0:
         tool_idx = src.find("es.addEventListener('tool'")
     assert tool_idx >= 0
-    tool_block = src[tool_idx:tool_idx+400]
-    assert "setStatus(" not in tool_block, \
+    tool_block = src[tool_idx : tool_idx + 400]
+    assert "setStatus(" not in tool_block, (
         "tool handler should not use the global activity/status bar"
-    assert "setComposerStatus(" not in tool_block, \
+    )
+    assert "setComposerStatus(" not in tool_block, (
         "tool handler should not use composer status for tool progress"
+    )
+
 
 # ── R12: Live tool cards lost on switch-away and switch-back ──────────────
+
 
 def test_loadSession_inflight_restores_live_tool_cards(cleanup_test_sessions):
     """R12: When switching back to an in-flight session, live tool cards in
@@ -420,11 +504,17 @@ def test_loadSession_inflight_restores_live_tool_cards(cleanup_test_sessions):
     # INFLIGHT branch must call appendLiveToolCard
     inflight_idx = src.find("if(INFLIGHT[sid]){")
     assert inflight_idx >= 0, "INFLIGHT branch not found in loadSession"
-    inflight_block = src[inflight_idx:inflight_idx+900]
-    assert "appendLiveToolCard" in inflight_block,         "loadSession INFLIGHT branch must restore live tool cards via appendLiveToolCard"
-    assert "clearLiveToolCards" in inflight_block,         "loadSession INFLIGHT branch must clear old live cards before restoring"
+    inflight_block = src[inflight_idx : inflight_idx + 900]
+    assert "appendLiveToolCard" in inflight_block, (
+        "loadSession INFLIGHT branch must restore live tool cards via appendLiveToolCard"
+    )
+    assert "clearLiveToolCards" in inflight_block, (
+        "loadSession INFLIGHT branch must clear old live cards before restoring"
+    )
+
 
 # ── R13: renderMessages() called before S.busy=false in done handler ────────
+
 
 def test_done_handler_sets_busy_false_before_renderMessages(cleanup_test_sessions):
     """R13: In the done handler, S.busy must be set to false BEFORE renderMessages()
@@ -446,10 +536,13 @@ def test_done_handler_sets_busy_false_before_renderMessages(cleanup_test_session
     render_pos = done_block.find("renderMessages(")
     assert busy_pos >= 0, "done handler must set S.busy=false before renderMessages()"
     assert render_pos >= 0, "done handler must call renderMessages after settling state"
-    assert busy_pos < render_pos,         f"S.busy=false (pos {busy_pos}) must come before renderMessages (pos {render_pos})"
+    assert busy_pos < render_pos, (
+        f"S.busy=false (pos {busy_pos}) must come before renderMessages (pos {render_pos})"
+    )
 
 
 # ── R14: send() uses stale modelSelect.value instead of session model ────────
+
 
 def test_send_uses_session_model_as_authoritative_source(cleanup_test_sessions):
     """R14: send() must use S.session.model as the authoritative model, not just
@@ -466,12 +559,14 @@ def test_send_uses_session_model_as_authoritative_source(cleanup_test_sessions):
     # explicitly to land on the payload block.
     chat_start_idx = src.find("api('/api/chat/start'")
     assert chat_start_idx >= 0, "could not find /api/chat/start POST in messages.js"
-    payload_block = src[chat_start_idx:chat_start_idx+400]
-    assert "S.session.model" in payload_block, \
+    payload_block = src[chat_start_idx : chat_start_idx + 400]
+    assert "S.session.model" in payload_block, (
         "send() must use S.session.model in the chat/start payload"
+    )
 
 
 # ── R15: newSession does not clear live tool cards ────────────────────────────
+
 
 def test_newSession_clears_live_tool_cards(cleanup_test_sessions):
     """R15: newSession() must call clearLiveToolCards() so live cards from a
@@ -483,7 +578,9 @@ def test_newSession_clears_live_tool_cards(cleanup_test_sessions):
     # Find end of newSession (next async function)
     next_fn = src.find("async function ", new_sess_idx + 10)
     new_sess_body = src[new_sess_idx:next_fn]
-    assert "clearLiveToolCards" in new_sess_body,         "newSession() must call clearLiveToolCards() to clear stale live cards"
+    assert "clearLiveToolCards" in new_sess_body, (
+        "newSession() must call clearLiveToolCards() to clear stale live cards"
+    )
 
 
 def test_newSession_resets_busy_state_for_fresh_chat(cleanup_test_sessions):
@@ -496,12 +593,15 @@ def test_newSession_resets_busy_state_for_fresh_chat(cleanup_test_sessions):
     assert new_sess_idx >= 0
     next_fn = src.find("async function ", new_sess_idx + 10)
     new_sess_body = src[new_sess_idx:next_fn]
-    assert "S.busy=false;" in new_sess_body, \
+    assert "S.busy=false;" in new_sess_body, (
         "newSession() must clear S.busy so a fresh chat is immediately sendable"
-    assert "S.activeStreamId=null;" in new_sess_body, \
+    )
+    assert "S.activeStreamId=null;" in new_sess_body, (
         "newSession() must clear the active stream id for the newly viewed chat"
-    assert "updateQueueBadge(S.session.session_id);" in new_sess_body, \
+    )
+    assert "updateQueueBadge(S.session.session_id);" in new_sess_body, (
         "newSession() must refresh the badge for the new session rather than leaving the old session's queue badge visible"
+    )
 
 
 def test_session_scoped_message_queue_frontend_wiring(cleanup_test_sessions):
@@ -523,39 +623,49 @@ def test_session_scoped_message_queue_frontend_wiring(cleanup_test_sessions):
     assert "updateQueueBadge(sid);" in sessions_src
 
 
-def test_chat_start_persists_pending_turn_metadata_for_reload_recovery(cleanup_test_sessions):
+def test_chat_start_persists_pending_turn_metadata_for_reload_recovery(
+    cleanup_test_sessions,
+):
     """R15c: chat/start must expose enough pending-turn metadata for a reload to
     rebuild the in-flight conversation instead of showing a blank session.
     """
     routes_src = (REPO_ROOT / "api/routes.py").read_text()
-    assert 's.active_stream_id = stream_id' in routes_src
-    assert 's.pending_user_message = msg' in routes_src
-    assert 's.pending_attachments = attachments' in routes_src
+    assert "s.active_stream_id = stream_id" in routes_src
+    assert "s.pending_user_message = msg" in routes_src
+    assert "s.pending_attachments = attachments" in routes_src
     assert '"active_stream_id": getattr(s, "active_stream_id", None)' in routes_src
-    assert '"pending_user_message": getattr(s, "pending_user_message", None)' in routes_src
+    assert (
+        '"pending_user_message": getattr(s, "pending_user_message", None)' in routes_src
+    )
 
 
-def test_reload_path_restores_pending_message_and_reattaches_live_stream(cleanup_test_sessions):
+def test_reload_path_restores_pending_message_and_reattaches_live_stream(
+    cleanup_test_sessions,
+):
     """R15d: the frontend reload path must show the pending user turn and
     reattach to the live SSE stream after loadSession().
     """
     sessions_src = (REPO_ROOT / "static/sessions.js").read_text()
     ui_src = (REPO_ROOT / "static/ui.js").read_text()
     messages_src = (REPO_ROOT / "static/messages.js").read_text()
-    assert 'getPendingSessionMessage' in ui_src
-    assert 'pending_user_message' in ui_src
-    assert 'function attachLiveStream' in messages_src
-    assert 'const pendingMsg=typeof getPendingSessionMessage' in sessions_src
-    assert ('const activeStreamId=data.session.active_stream_id||null;' in sessions_src or
-            'const activeStreamId=S.session.active_stream_id||null;' in sessions_src)
-    assert 'attachLiveStream(sid, activeStreamId' in sessions_src
-    assert 'if (S.activeStreamId && S.activeStreamId === streamId) return;' in ui_src
+    assert "getPendingSessionMessage" in ui_src
+    assert "pending_user_message" in ui_src
+    assert "function attachLiveStream" in messages_src
+    assert "const pendingMsg=typeof getPendingSessionMessage" in sessions_src
+    assert (
+        "const activeStreamId=data.session.active_stream_id||null;" in sessions_src
+        or "const activeStreamId=S.session.active_stream_id||null;" in sessions_src
+    )
+    assert "attachLiveStream(sid, activeStreamId" in sessions_src
+    assert "if (S.activeStreamId && S.activeStreamId === streamId) return;" in ui_src
 
 
 # ── R16: Switching away/back must preserve live partial assistant output ─────
 
 
-def test_live_stream_tokens_persist_partial_assistant_for_session_switch(cleanup_test_sessions):
+def test_live_stream_tokens_persist_partial_assistant_for_session_switch(
+    cleanup_test_sessions,
+):
     """R16: in-flight assistant text must be mirrored into INFLIGHT session state,
     and the live stream must rebind to the rebuilt DOM after switching away and back.
     Without this, partial assistant output disappears until the final done payload lands.
@@ -563,29 +673,38 @@ def test_live_stream_tokens_persist_partial_assistant_for_session_switch(cleanup
     messages_src = (REPO_ROOT / "static/messages.js").read_text()
     ui_src = (REPO_ROOT / "static/ui.js").read_text()
 
-    assert "content:assistantText" in messages_src, \
+    assert "content:assistantText" in messages_src, (
         "messages.js must persist the partial assistant text into INFLIGHT state"
-    assert "_live:true" in messages_src, \
+    )
+    assert "_live:true" in messages_src, (
         "messages.js must mark the persisted in-flight assistant row so renderMessages can re-anchor it"
-    assert "syncInflightAssistantMessage();" in messages_src, \
+    )
+    assert "syncInflightAssistantMessage();" in messages_src, (
         "token handler must update INFLIGHT state before checking the active session"
-    assert "assistantRow&&!assistantRow.isConnected" in messages_src, \
+    )
+    assert "assistantRow&&!assistantRow.isConnected" in messages_src, (
         "live stream must drop stale detached assistant DOM references after session switches"
-    assert "data-live-assistant" in ui_src, \
+    )
+    assert "data-live-assistant" in ui_src, (
         "renderMessages must preserve a live-assistant DOM anchor when rebuilding the thread"
+    )
 
 
-def test_inflight_session_state_tracks_live_tool_cards_per_session(cleanup_test_sessions):
+def test_inflight_session_state_tracks_live_tool_cards_per_session(
+    cleanup_test_sessions,
+):
     """R16b: live tool cards must be stored on the in-flight session, not only in the
     global S.toolCalls array, so switching chats does not lose or misattach them.
     """
     messages_src = (REPO_ROOT / "static/messages.js").read_text()
     sessions_src = (REPO_ROOT / "static/sessions.js").read_text()
 
-    assert "INFLIGHT[activeSid].toolCalls.push(tc);" in messages_src, \
+    assert "INFLIGHT[activeSid].toolCalls.push(tc);" in messages_src, (
         "tool SSE handler must persist live tool calls onto the in-flight session"
-    assert "S.toolCalls=(INFLIGHT[sid].toolCalls||[]);" in sessions_src, \
+    )
+    assert "S.toolCalls=(INFLIGHT[sid].toolCalls||[]);" in sessions_src, (
         "loadSession() must restore live tool calls from the in-flight session state"
+    )
 
 
 def test_loadSession_inflight_sets_busy_before_renderMessages(cleanup_test_sessions):
@@ -597,16 +716,19 @@ def test_loadSession_inflight_sets_busy_before_renderMessages(cleanup_test_sessi
     src = (REPO_ROOT / "static/sessions.js").read_text()
     inflight_idx = src.find("if(INFLIGHT[sid]){")
     assert inflight_idx >= 0, "INFLIGHT branch not found in loadSession"
-    inflight_block = src[inflight_idx:inflight_idx+700]
+    inflight_block = src[inflight_idx : inflight_idx + 700]
     busy_pos = inflight_block.find("S.busy=true;")
     render_pos = inflight_block.find("renderMessages();appendThinking();")
     assert busy_pos >= 0, "loadSession INFLIGHT branch must set S.busy=true"
     assert render_pos >= 0, "loadSession INFLIGHT branch must call renderMessages()"
-    assert busy_pos < render_pos, \
+    assert busy_pos < render_pos, (
         "loadSession must set S.busy=true before renderMessages() to avoid duplicate tool cards"
+    )
 
 
-def test_loadSession_inflight_sets_active_stream_before_replaying_live_tool_cards(cleanup_test_sessions):
+def test_loadSession_inflight_sets_active_stream_before_replaying_live_tool_cards(
+    cleanup_test_sessions,
+):
     """#1715: returning to an active chat must replay persisted tool cards.
 
     appendLiveToolCard() intentionally no-ops unless S.activeStreamId is already
@@ -617,30 +739,39 @@ def test_loadSession_inflight_sets_active_stream_before_replaying_live_tool_card
     src = (REPO_ROOT / "static/sessions.js").read_text()
     inflight_idx = src.find("if(INFLIGHT[sid]){")
     assert inflight_idx >= 0, "INFLIGHT branch not found in loadSession"
-    inflight_block = src[inflight_idx:inflight_idx+1000]
+    inflight_block = src[inflight_idx : inflight_idx + 1000]
     active_pos = inflight_block.find("S.activeStreamId=activeStreamId;")
     replay_pos = inflight_block.find("appendLiveToolCard(tc);")
     attach_pos = inflight_block.find("attachLiveStream(sid, activeStreamId")
     assert active_pos >= 0, "loadSession INFLIGHT branch must restore S.activeStreamId"
-    assert replay_pos >= 0, "loadSession INFLIGHT branch must replay persisted live tool cards"
-    assert active_pos < replay_pos, \
+    assert replay_pos >= 0, (
+        "loadSession INFLIGHT branch must replay persisted live tool cards"
+    )
+    assert active_pos < replay_pos, (
         "S.activeStreamId must be restored before appendLiveToolCard() replays persisted tools"
-    assert attach_pos < 0 or active_pos < attach_pos, \
+    )
+    assert attach_pos < 0 or active_pos < attach_pos, (
         "S.activeStreamId should also be restored before SSE reattach can deliver more tool events"
+    )
 
 
-def test_streaming_bridge_accepts_current_tool_progress_callback_signature(cleanup_test_sessions):
+def test_streaming_bridge_accepts_current_tool_progress_callback_signature(
+    cleanup_test_sessions,
+):
     """R17: api/streaming.py must accept the current Hermes agent callback contract.
     The agent now calls tool_progress_callback(event_type, name, preview, args, **kwargs).
     If the WebUI bridge only accepts (name, preview, args), live tool updates silently vanish.
     """
     src = (REPO_ROOT / "api/streaming.py").read_text()
-    assert "def on_tool(*cb_args, **cb_kwargs):" in src, \
+    assert "def on_tool(*cb_args, **cb_kwargs):" in src, (
         "streaming.py must accept variable callback args for tool progress events"
-    assert "reasoning_callback=on_reasoning" in src, \
+    )
+    assert "reasoning_callback=on_reasoning" in src, (
         "streaming.py must wire the agent's reasoning callback into the SSE bridge"
-    assert "put('tool_complete'" in src or 'put("tool_complete"' in src, \
+    )
+    assert "put('tool_complete'" in src or 'put("tool_complete"' in src, (
         "streaming.py must emit live tool completion SSE events"
+    )
 
 
 def test_streaming_reads_reasoning_effort_from_config_dict(cleanup_test_sessions):
@@ -653,13 +784,17 @@ def test_streaming_reads_reasoning_effort_from_config_dict(cleanup_test_sessions
     source assertion pins the fix because the runtime symptom is silent.
     """
     src = (REPO_ROOT / "api/streaming.py").read_text()
-    assert "_cfg.cfg" not in src, \
+    assert "_cfg.cfg" not in src, (
         "get_config() returns a dict; accessing _cfg.cfg drops reasoning_config to None"
-    assert "_cfg.get('agent', {})" in src or '_cfg.get("agent", {})' in src, \
+    )
+    assert "_cfg.get('agent', {})" in src or '_cfg.get("agent", {})' in src, (
         "streaming.py must read agent.reasoning_effort via the config dict"
+    )
 
 
-def test_streaming_agent_cache_signature_includes_reasoning_config(cleanup_test_sessions):
+def test_streaming_agent_cache_signature_includes_reasoning_config(
+    cleanup_test_sessions,
+):
     """R17c: changing reasoning effort mid-session must rebuild the cached per-session agent.
 
     Without `_reasoning_config` participating in `_sig_blob`, the cache key
@@ -671,8 +806,9 @@ def test_streaming_agent_cache_signature_includes_reasoning_config(cleanup_test_
     end = src.find("_agent_sig", start)
     assert start >= 0 and end > start, "agent cache signature block not found"
     sig_block = src[start:end]
-    assert "_reasoning_config" in sig_block, \
+    assert "_reasoning_config" in sig_block, (
         "agent cache signature must include reasoning_config so xhigh/medium changes take effect"
+    )
 
 
 def test_messages_js_supports_live_reasoning_and_tool_completion(cleanup_test_sessions):
@@ -681,16 +817,23 @@ def test_messages_js_supports_live_reasoning_and_tool_completion(cleanup_test_se
     until the final done snapshot redraws the whole turn.
     """
     src = (REPO_ROOT / "static/messages.js").read_text()
-    assert "let reasoningText=''" in src, \
+    assert "let reasoningText=''" in src, (
         "messages.js must track streamed reasoning text separately from assistant text"
-    assert "let liveReasoningText=''" in src or 'let liveReasoningText = ""' in src, \
+    )
+    assert "let liveReasoningText=''" in src or 'let liveReasoningText = ""' in src, (
         "messages.js must track the currently active reasoning segment separately from cumulative reasoning"
-    assert "source.addEventListener('reasoning'" in src or 'source.addEventListener("reasoning"' in src, \
-        "messages.js must listen for live reasoning SSE events"
-    assert "source.addEventListener('tool_complete'" in src or 'source.addEventListener("tool_complete"' in src, \
-        "messages.js must listen for live tool completion SSE events"
-    assert "function _parseStreamState()" in src, \
+    )
+    assert (
+        "source.addEventListener('reasoning'" in src
+        or 'source.addEventListener("reasoning"' in src
+    ), "messages.js must listen for live reasoning SSE events"
+    assert (
+        "source.addEventListener('tool_complete'" in src
+        or 'source.addEventListener("tool_complete"' in src
+    ), "messages.js must listen for live tool completion SSE events"
+    assert "function _parseStreamState()" in src, (
         "messages.js must parse live stream state into reasoning + visible answer"
+    )
 
 
 def test_messages_js_supports_interim_assistant_events(cleanup_test_sessions):
@@ -702,25 +845,38 @@ def test_messages_js_supports_interim_assistant_events(cleanup_test_sessions):
     from the live answer and users only see the final response after tool calls.
     """
     src = (REPO_ROOT / "static/messages.js").read_text()
-    assert "source.addEventListener('interim_assistant'" in src or 'source.addEventListener("interim_assistant"' in src, \
-        "messages.js must listen for interim_assistant SSE events"
-    assert "function _resetAssistantSegment()" in src, \
+    assert (
+        "source.addEventListener('interim_assistant'" in src
+        or 'source.addEventListener("interim_assistant"' in src
+    ), "messages.js must listen for interim_assistant SSE events"
+    assert "function _resetAssistantSegment()" in src, (
         "messages.js should share live-segment reset logic between interim assistant updates and tool events"
-    assert "_resetAssistantSegment();" in src, \
+    )
+    assert "_resetAssistantSegment();" in src, (
         "messages.js should apply segment reset when tool or interim assistant events require it"
+    )
 
 
-def test_ui_js_can_upgrade_thinking_spinner_into_live_reasoning_card(cleanup_test_sessions):
+def test_ui_js_can_upgrade_thinking_spinner_into_live_reasoning_card(
+    cleanup_test_sessions,
+):
     """R19: ui.js must be able to replace the placeholder thinking spinner with
     streamed reasoning text while a turn is in progress.
     """
     src = (REPO_ROOT / "static/ui.js").read_text()
-    assert "function _thinkingMarkup(text='')" in src or 'function _thinkingMarkup(text="")' in src, \
+    assert (
+        "function _thinkingMarkup(text='')" in src
+        or 'function _thinkingMarkup(text="")' in src
+    ), (
         "ui.js must centralize thinking row markup so it can switch between spinner and live text"
-    assert "function updateThinking(text=''){appendThinking(text);}" in src or 'function updateThinking(text=""){appendThinking(text);}' in src, \
-        "ui.js must expose an updateThinking helper for live reasoning rendering"
-    assert "function finalizeThinkingCard()" in src, \
+    )
+    assert (
+        "function updateThinking(text=''){appendThinking(text);}" in src
+        or 'function updateThinking(text=""){appendThinking(text);}' in src
+    ), "ui.js must expose an updateThinking helper for live reasoning rendering"
+    assert "function finalizeThinkingCard()" in src, (
         "ui.js must expose a helper to finalize one live thinking card before starting another"
+    )
 
 
 def test_ui_js_keeps_split_thinking_cards_and_assistant_header(cleanup_test_sessions):
@@ -729,12 +885,15 @@ def test_ui_js_keeps_split_thinking_cards_and_assistant_header(cleanup_test_sess
     for the whole response while keeping multiple thinking cards distinct.
     """
     src = (REPO_ROOT / "static" / "ui.js").read_text()
-    assert "pendingTurnThinking" not in src, \
+    assert "pendingTurnThinking" not in src, (
         "renderMessages must not merge distinct thinking blocks into one settled card"
-    assert "_createAssistantTurn(" in src, \
+    )
+    assert "_createAssistantTurn(" in src, (
         "renderMessages must build a shared assistant turn wrapper instead of separate top-level rows"
-    assert "assistant-segment" in src, \
+    )
+    assert "assistant-segment" in src, (
         "settled assistant turns must preserve per-message segments for multiple thinking/tool/result blocks"
+    )
 
 
 def test_ui_js_keeps_reasoning_only_assistant_messages_visible(cleanup_test_sessions):
@@ -742,53 +901,77 @@ def test_ui_js_keeps_reasoning_only_assistant_messages_visible(cleanup_test_sess
     rerenders, otherwise prior thinking cards disappear on the next turn.
     """
     src = (REPO_ROOT / "static" / "ui.js").read_text()
-    assert "function _messageHasReasoningPayload(m)" in src, \
+    assert "function _messageHasReasoningPayload(m)" in src, (
         "ui.js must detect reasoning-only assistant messages"
-    assert "hasTc||hasTu||_messageHasReasoningPayload(m)" in src.replace(' ', ''), \
+    )
+    assert "hasTc||hasTu||_messageHasReasoningPayload(m)" in src.replace(" ", ""), (
         "renderMessages visibility filter must preserve reasoning-only assistant messages"
+    )
 
 
-def test_ui_js_does_not_hide_anchor_segments_that_contain_thinking(cleanup_test_sessions):
+def test_ui_js_does_not_hide_anchor_segments_that_contain_thinking(
+    cleanup_test_sessions,
+):
     """R19c2/R19c3: reasoning-only messages must remain visible through the
     shared collapsed activity dropdown, even when the anchor segment has no prose.
     """
     src = (REPO_ROOT / "static" / "ui.js").read_text()
-    compact = src.replace(' ', '').replace('\n', '')
-    assert "assistantThinking.set(rawIdx,thinkingText)" in compact, \
+    compact = src.replace(" ", "").replace("\n", "")
+    assert "assistantThinking.set(rawIdx,thinkingText)" in compact, (
         "renderMessages must preserve reasoning text before hiding empty anchor segments"
-    assert "_thinkingActivityNode(thinkingText)" in src, \
+    )
+    assert "_thinkingActivityNode(thinkingText)" in src, (
         "thinking-only assistant content should render inside the shared activity dropdown"
+    )
 
 
-def test_messages_js_live_assistant_segment_reuses_live_turn_wrapper(cleanup_test_sessions):
+def test_messages_js_live_assistant_segment_reuses_live_turn_wrapper(
+    cleanup_test_sessions,
+):
     """R19d: live streaming must reuse the existing live assistant turn wrapper created
     by appendThinking(), otherwise the header gets recreated when answer tokens start.
     """
     src = (REPO_ROOT / "static" / "messages.js").read_text()
-    assert "function ensureAssistantRow(force=false)" in src or 'function ensureAssistantRow(force = false)' in src, \
-        "ensureAssistantRow should manage the live assistant content segment"
-    assert "let turn=$('liveAssistantTurn');" in src, \
+    assert (
+        "function ensureAssistantRow(force=false)" in src
+        or "function ensureAssistantRow(force = false)" in src
+    ), "ensureAssistantRow should manage the live assistant content segment"
+    assert "let turn=$('liveAssistantTurn');" in src, (
         "ensureAssistantRow must bind to the existing live assistant turn wrapper"
-    assert "appendThinking();" in src, \
+    )
+    assert "appendThinking();" in src, (
         "ensureAssistantRow should create the live turn via appendThinking() when needed"
-    assert "assistantRow.className='assistant-segment';" in src or 'assistantRow.className = \'assistant-segment\';' in src, \
+    )
+    assert (
+        "assistantRow.className='assistant-segment';" in src
+        or "assistantRow.className = 'assistant-segment';" in src
+    ), (
         "live answer content should be appended as a segment inside the live turn wrapper"
-    assert "if(!force&&!assistantRow){" in src.replace(' ', ''), \
+    )
+    assert "if(!force&&!assistantRow){" in src.replace(" ", ""), (
         "ensureAssistantRow must still avoid creating the live answer segment when no display text exists yet"
-    assert "if(String((parsed&&parsed.displayText)||'').trim()||assistantRow) ensureAssistantRow();" in src, \
+    )
+    assert (
+        "if(String((parsed&&parsed.displayText)||'').trim()||assistantRow) ensureAssistantRow();"
+        in src
+    ), (
         "token handler must only create the live answer segment once visible answer text starts"
+    )
 
 
 def test_messages_js_finalizes_thinking_card_before_tool_card(cleanup_test_sessions):
     """R19e: later reasoning after a tool call must render in a fresh card."""
     src = (REPO_ROOT / "static/messages.js").read_text()
-    assert "finalizeThinkingCard" in src, \
+    assert "finalizeThinkingCard" in src, (
         "tool handler must finalize the current live thinking card before appending a tool card"
-    assert "liveReasoningText='';" in src or 'liveReasoningText = "";' in src, \
+    )
+    assert "liveReasoningText='';" in src or 'liveReasoningText = "";' in src, (
         "tool handler must reset the active reasoning segment before post-tool reasoning arrives"
+    )
 
 
 # ── R17: Stack traces must not leak to clients in 500 responses ────────────
+
 
 def test_500_response_has_no_trace_field():
     """R16: HTTP 500 responses must not include a 'trace' field.
@@ -798,8 +981,8 @@ def test_500_response_has_no_trace_field():
     # POST to /api/chat/start with missing required fields to trigger an error
     data, status = post("/api/chat/start", {})
     # Should be an error response (4xx or 5xx)
-    assert "trace" not in data, \
-        "Server must not leak stack traces to clients"
+    assert "trace" not in data, "Server must not leak stack traces to clients"
+
 
 def test_upload_error_has_no_trace_field():
     """R16b: Upload 500 responses must not include a 'trace' field."""
@@ -817,12 +1000,12 @@ def test_upload_error_has_no_trace_field():
         body = json.loads(e.read())
         code = e.code
     assert code >= 400, "Invalid upload should return an error status"
-    assert "trace" not in body, \
-        "Upload errors must not leak stack traces to clients"
+    assert "trace" not in body, "Upload errors must not leak stack traces to clients"
     assert "error" in body, "Error responses must include an 'error' key"
 
 
 # ── #248: /skills slash command ───────────────────────────────────────────────
+
 
 def test_skills_slash_command_defined():
     """#248: /skills slash command must be wired up.
@@ -837,12 +1020,14 @@ def test_skills_slash_command_defined():
     src = (REPO_ROOT / "static/commands.js").read_text()
 
     # 1. cmdSkills function must be defined
-    assert "async function cmdSkills" in src or "function cmdSkills" in src, \
+    assert "async function cmdSkills" in src or "function cmdSkills" in src, (
         "cmdSkills function missing from commands.js"
+    )
 
     # 2. HANDLERS.skills must be registered to dispatch /skills to cmdSkills
-    assert "HANDLERS.skills" in src, \
+    assert "HANDLERS.skills" in src, (
         "HANDLERS.skills registration missing from commands.js"
+    )
 
 
 def test_reload_recovery_persists_durable_inflight_state(cleanup_test_sessions):
@@ -858,15 +1043,19 @@ def test_reload_recovery_persists_durable_inflight_state(cleanup_test_sessions):
     assert "function saveInflightState(sid, state)" in ui_src
     assert "function loadInflightState(sid, streamId)" in ui_src
     assert "function clearInflightState(sid)" in ui_src
-    assert "saveInflightState(activeSid" in messages_src, \
+    assert "saveInflightState(activeSid" in messages_src, (
         "messages.js must persist live stream snapshots while a turn is in flight"
-    assert "clearInflightState(activeSid)" in messages_src, \
+    )
+    assert "clearInflightState(activeSid)" in messages_src, (
         "messages.js must clear durable inflight snapshots when the run ends/errors/cancels"
-    assert "const stored=loadInflightState(sid, activeStreamId);" in sessions_src, \
+    )
+    assert "const stored=loadInflightState(sid, activeStreamId);" in sessions_src, (
         "loadSession() must hydrate in-flight state from durable browser storage on reload"
+    )
 
 
 # ── R18: OAuth onboarding must recognize credential_pool-only auth ───────────
+
 
 def test_provider_oauth_authenticated_accepts_credential_pool_entries(
     cleanup_test_sessions, tmp_path

--- a/tests/test_renderer_comprehensive.py
+++ b/tests/test_renderer_comprehensive.py
@@ -7,10 +7,13 @@ Python mirrors the renderMd/inlineMd pipeline at the level needed for each
 test — either source-level assertions (checking the JS source directly) or
 behavioural assertions (checking rendered HTML via a Python mirror).
 """
+
 import re
 import pathlib
 
-UI_JS = (pathlib.Path(__file__).parent.parent / "static" / "ui.js").read_text(encoding="utf-8")
+UI_JS = (pathlib.Path(__file__).parent.parent / "static" / "ui.js").read_text(
+    encoding="utf-8"
+)
 
 import html as _html
 
@@ -22,51 +25,76 @@ def _esc(s):
 def _inline_md(t):
     """Mirror of inlineMd() in ui.js — processes one line of text."""
     _code_stash = []
-    t = re.sub(r"`([^`\n]+)`",
-               lambda m: (_code_stash.append(f"<code>{_esc(m.group(1))}</code>")
-                          or f"\x00C{len(_code_stash)-1}\x00"), t)
-    t = re.sub(r"\*\*\*(.+?)\*\*\*", lambda m: f"<strong><em>{_esc(m.group(1))}</em></strong>", t)
-    t = re.sub(r"\*\*(.+?)\*\*",     lambda m: f"<strong>{_esc(m.group(1))}</strong>", t)
-    t = re.sub(r"\*([^*\n]+)\*",     lambda m: f"<em>{_esc(m.group(1))}</em>", t)
-    t = re.sub(r"~~(.+?)~~",         lambda m: f"<del>{_esc(m.group(1))}</del>", t)
+    t = re.sub(
+        r"`([^`\n]+)`",
+        lambda m: (
+            _code_stash.append(f"<code>{_esc(m.group(1))}</code>")
+            or f"\x00C{len(_code_stash) - 1}\x00"
+        ),
+        t,
+    )
+    t = re.sub(
+        r"\*\*\*(.+?)\*\*\*",
+        lambda m: f"<strong><em>{_esc(m.group(1))}</em></strong>",
+        t,
+    )
+    t = re.sub(r"\*\*(.+?)\*\*", lambda m: f"<strong>{_esc(m.group(1))}</strong>", t)
+    t = re.sub(r"\*([^*\n]+)\*", lambda m: f"<em>{_esc(m.group(1))}</em>", t)
+    t = re.sub(r"~~(.+?)~~", lambda m: f"<del>{_esc(m.group(1))}</del>", t)
     t = re.sub(r"\x00C(\d+)\x00", lambda m: _code_stash[int(m.group(1))], t)
     return t
 
 
 def _apply_blockquotes(src):
     """Mirror of _applyBlockquotes() — handles nested + lists + blank lines."""
+
     def replacer(m):
         block = m.group(0)
         lines = block.split("\n")
         while lines and (lines[-1].strip() in (">", "")):
             if lines[-1].strip() == ">":
-                lines.pop(); break
+                lines.pop()
+                break
             lines.pop()
         stripped = [re.sub(r"^>[ \t]?", "", l) for l in lines]
         inner_raw = "\n".join(stripped)
         if re.search(r"^>", inner_raw, re.MULTILINE):
             inner = _apply_blockquotes(inner_raw)
         elif re.search(r"^(  )?[-*+] .+", inner_raw, re.MULTILINE):
+
             def inner_list(lb):
-                ll = lb.strip().split("\n"); h = "<ul>"
+                ll = lb.strip().split("\n")
+                h = "<ul>"
                 for li in ll:
                     txt = re.sub(r"^ {0,4}[-*+] ", "", li)
-                    if re.match(r"\[x\] ", txt, re.I): ih = f"✅ {_inline_md(txt[4:])}"
-                    elif txt.startswith("[ ] "): ih = f"☐ {_inline_md(txt[4:])}"
-                    else: ih = _inline_md(txt)
+                    if re.match(r"\[x\] ", txt, re.I):
+                        ih = f"✅ {_inline_md(txt[4:])}"
+                    elif txt.startswith("[ ] "):
+                        ih = f"☐ {_inline_md(txt[4:])}"
+                    else:
+                        ih = _inline_md(txt)
                     h += f"<li>{ih}</li>"
                 return h + "</ul>"
-            inner = re.sub(r"((?:^(?:  )?[-*+] .+\n?)+)", lambda m2: inner_list(m2.group(0)),
-                           inner_raw, flags=re.MULTILINE)
+
+            inner = re.sub(
+                r"((?:^(?:  )?[-*+] .+\n?)+)",
+                lambda m2: inner_list(m2.group(0)),
+                inner_raw,
+                flags=re.MULTILINE,
+            )
         else:
-            inner = "\n".join("<br>" if l.strip() == "" else _inline_md(l) for l in stripped)
+            inner = "\n".join(
+                "<br>" if l.strip() == "" else _inline_md(l) for l in stripped
+            )
         return f"<blockquote>{inner}</blockquote>"
+
     return re.sub(r"((?:^>[^\n]*(?:\n|$))+)", replacer, src, flags=re.MULTILINE)
 
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Source-level structural checks (JS must contain these patterns)
 # ─────────────────────────────────────────────────────────────────────────────
+
 
 class TestSourceStructure:
     """Verify key patterns are present in ui.js."""
@@ -90,7 +118,7 @@ class TestSourceStructure:
         # SAFE_INLINE is used inside inlineMd
         safe_inline_idx = UI_JS.find("SAFE_INLINE")
         assert safe_inline_idx >= 0
-        window = UI_JS[safe_inline_idx: safe_inline_idx + 100]
+        window = UI_JS[safe_inline_idx : safe_inline_idx + 100]
         assert "del" in window, "<del> must be in SAFE_INLINE"
 
     def test_task_list_checked_handled(self):
@@ -123,7 +151,9 @@ class TestSourceStructure:
             assert f"<{h}>" in UI_JS or f"`<{h}>" in UI_JS
 
     def test_ordered_list_value_attr(self):
-        assert 'value=' in UI_JS, "Ordered list items must use value= to preserve numbering"
+        assert "value=" in UI_JS, (
+            "Ordered list items must use value= to preserve numbering"
+        )
 
     def test_table_handler_present(self):
         assert "<table>" in UI_JS and "<thead>" in UI_JS
@@ -133,15 +163,17 @@ class TestSourceStructure:
 
     def test_autolink_present(self):
         # JS stores regex slashes as \/ — search for both forms
-        assert ("https?:\\/\\/" in UI_JS or "https?://" in UI_JS) and "target=\"_blank\"" in UI_JS
+        assert (
+            "https?:\\/\\/" in UI_JS or "https?://" in UI_JS
+        ) and 'target="_blank"' in UI_JS
 
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Behavioural: inline formatting
 # ─────────────────────────────────────────────────────────────────────────────
 
-class TestInlineFormatting:
 
+class TestInlineFormatting:
     def test_bold(self):
         assert _inline_md("**bold**") == "<strong>bold</strong>"
 
@@ -189,8 +221,8 @@ class TestInlineFormatting:
 # Behavioural: blockquotes
 # ─────────────────────────────────────────────────────────────────────────────
 
-class TestBlockquotes:
 
+class TestBlockquotes:
     def test_single_line(self):
         out = _apply_blockquotes("> Hello")
         assert out.count("<blockquote>") == 1
@@ -252,7 +284,7 @@ class TestBlockquotes:
     def test_blockquote_followed_by_paragraph(self):
         out = _apply_blockquotes("> Quoted\n\nNormal text")
         assert out.count("<blockquote>") == 1
-        after = out[out.index("</blockquote>"):]
+        after = out[out.index("</blockquote>") :]
         assert "Normal text" in after
 
 
@@ -260,8 +292,8 @@ class TestBlockquotes:
 # Behavioural: task lists
 # ─────────────────────────────────────────────────────────────────────────────
 
-class TestTaskLists:
 
+class TestTaskLists:
     def _apply_list(self, block):
         lines = block.strip().split("\n")
         html = "<ul>"
@@ -305,8 +337,8 @@ class TestTaskLists:
 # Behavioural: strikethrough edge cases
 # ─────────────────────────────────────────────────────────────────────────────
 
-class TestStrikethrough:
 
+class TestStrikethrough:
     def test_basic(self):
         assert _inline_md("~~text~~") == "<del>text</del>"
 
@@ -329,8 +361,8 @@ class TestStrikethrough:
 # Edge-case combinations
 # ─────────────────────────────────────────────────────────────────────────────
 
-class TestEdgeCases:
 
+class TestEdgeCases:
     def test_empty_string(self):
         out = _apply_blockquotes("")
         assert out == ""

--- a/tests/test_renderer_js_behaviour.py
+++ b/tests/test_renderer_js_behaviour.py
@@ -12,11 +12,10 @@ asserting the rendered HTML for the most common LLM-output shapes.
 Add a case here whenever the renderer fix targets a class of input the
 Python mirror cannot exercise faithfully.
 """
-import os
+
 import re
 import shutil
 import subprocess
-import sys
 from pathlib import Path
 
 import pytest
@@ -137,8 +136,7 @@ class TestBlockquotePrefixStrip:
         """Task lists inside blockquotes render checkbox spans, not literal [x]."""
         out = _render(driver_path, "> - [x] done\n> - [ ] todo")
         assert 'class="task-done"' in out, (
-            f"`- [x]` inside a blockquote must produce a task-done span.  "
-            f"Got: {out!r}"
+            f"`- [x]` inside a blockquote must produce a task-done span.  Got: {out!r}"
         )
         assert 'class="task-todo"' in out
 
@@ -155,38 +153,45 @@ class TestRendererSanitization:
     @pytest.mark.parametrize(
         "payload, forbidden",
         [
-            ('<img src=x onerror=alert(1)>', 'onerror'),
-            ('<span onclick=alert(1)>click</span>', 'onclick'),
-            ('<div onmouseover=alert(1)>hover</div>', 'onmouseover'),
-            ('<a href="javascript:alert(1)">x</a>', 'javascript:'),
+            ("<img src=x onerror=alert(1)>", "onerror"),
+            ("<span onclick=alert(1)>click</span>", "onclick"),
+            ("<div onmouseover=alert(1)>hover</div>", "onmouseover"),
+            ('<a href="javascript:alert(1)">x</a>', "javascript:"),
         ],
     )
-    def test_raw_html_dangerous_attributes_and_schemes_are_removed(self, driver_path, payload, forbidden):
+    def test_raw_html_dangerous_attributes_and_schemes_are_removed(
+        self, driver_path, payload, forbidden
+    ):
         out = _render(driver_path, payload).lower()
         assert forbidden not in out, f"dangerous HTML survived sanitization: {out!r}"
-        assert 'alert(1)' not in out, f"executable payload text should not remain executable: {out!r}"
+        assert "alert(1)" not in out, (
+            f"executable payload text should not remain executable: {out!r}"
+        )
 
-    def test_generated_image_markdown_uses_delegated_lightbox_not_inline_js(self, driver_path):
+    def test_generated_image_markdown_uses_delegated_lightbox_not_inline_js(
+        self, driver_path
+    ):
         out = _render(driver_path, "![capy](https://example.com/capy.png)").lower()
-        assert '<img' in out and 'msg-media-img' in out
-        assert 'onclick' not in out
-        assert '_openimglightbox' not in out
+        assert "<img" in out and "msg-media-img" in out
+        assert "onclick" not in out
+        assert "_openimglightbox" not in out
 
     def test_media_token_image_uses_delegated_lightbox_not_inline_js(self, driver_path):
         out = _render(driver_path, "MEDIA:https://example.com/capy.png").lower()
-        assert '<img' in out and 'msg-media-img' in out
-        assert 'onclick' not in out
-        assert '_openimglightbox' not in out
+        assert "<img" in out and "msg-media-img" in out
+        assert "onclick" not in out
+        assert "_openimglightbox" not in out
 
-    def test_incomplete_raw_html_tag_is_escaped_before_paragraph_wrapping(self, driver_path):
-        out = _render(driver_path, '<img src=x onerror=alert(1)//').lower()
-        assert '&lt;img' in out
-        assert '<img' not in out
-        assert 'onerror' not in out or '&lt;img' in out
+    def test_incomplete_raw_html_tag_is_escaped_before_paragraph_wrapping(
+        self, driver_path
+    ):
+        out = _render(driver_path, "<img src=x onerror=alert(1)//").lower()
+        assert "&lt;img" in out
+        assert "<img" not in out
+        assert "onerror" not in out or "&lt;img" in out
 
 
 class TestCommonLLMShapes:
-
     def test_strikethrough_outside_quote(self, driver_path):
         out = _render(driver_path, "This was ~~outdated~~ but is now fine.")
         assert "<del>outdated</del>" in out
@@ -409,9 +414,7 @@ class TestBugOrderedListInsideBlockquote:
         )
         # All three list items present
         for item in ["Open the app", "Click the button", "Observe the crash"]:
-            assert f">{item}</li>" in out, (
-                f"Missing <li>{item}</li> in {out!r}"
-            )
+            assert f">{item}</li>" in out, f"Missing <li>{item}</li> in {out!r}"
 
 
 class TestBugHorizontalRuleInsideBlockquote:
@@ -420,16 +423,12 @@ class TestBugHorizontalRuleInsideBlockquote:
     def test_hr_renders_inside_blockquote(self, driver_path):
         src = "> Above the rule\n>\n> ---\n>\n> Below the rule"
         out = _render(driver_path, src)
-        assert "<hr>" in out, (
-            f"--- inside blockquote must render as <hr>: {out!r}"
-        )
+        assert "<hr>" in out, f"--- inside blockquote must render as <hr>: {out!r}"
         assert "Above the rule" in out
         assert "Below the rule" in out
         # No literal '---' as text
         text_only = re.sub(r"<[^>]+>", "", out)
-        assert "---" not in text_only, (
-            f"Literal --- in rendered text: {text_only!r}"
-        )
+        assert "---" not in text_only, f"Literal --- in rendered text: {text_only!r}"
 
 
 class TestBugComplexBlockquoteAllFeatures:
@@ -518,9 +517,7 @@ class TestBlockquoteRegressionsDontTouchOutsideContent:
         src = "> outer line\n> > inner line"
         out = _render(driver_path, src)
         # Should produce nested <blockquote><blockquote>
-        assert out.count("<blockquote>") == 2, (
-            f"Expected 2 <blockquote>: {out!r}"
-        )
+        assert out.count("<blockquote>") == 2, f"Expected 2 <blockquote>: {out!r}"
 
 
 class TestBlockquoteEntityEncodedInput:
@@ -545,7 +542,9 @@ class TestBlockquoteEntityEncodedInput:
         assert "<blockquote>" in out, (
             f"Entity-encoded blockquote with fenced code must render: {out!r}"
         )
-        assert "<pre>" in out, f"Fenced code inside entity-encoded blockquote must render: {out!r}"
+        assert "<pre>" in out, (
+            f"Fenced code inside entity-encoded blockquote must render: {out!r}"
+        )
 
 
 class TestMermaidToolOutputGuard:
@@ -559,28 +558,35 @@ class TestMermaidToolOutputGuard:
         )
         assert '<div class="pre-header">mermaid</div>' in out
         assert '<pre><code class="language-mermaid">' in out
-        assert '23|flowchart TB' in out
+        assert "23|flowchart TB" in out
 
     def test_valid_mermaid_fence_still_creates_mermaid_block(self, driver_path):
         out = _render(driver_path, "```mermaid\nflowchart TB\n    A --> B\n```")
         assert 'class="mermaid-block"' in out, (
             f"Valid Mermaid fences should still be queued for Mermaid rendering: {out!r}"
         )
-        assert 'flowchart TB' in out
+        assert "flowchart TB" in out
 
     def test_valid_mermaid_c4_fence_still_creates_mermaid_block(self, driver_path):
-        out = _render(driver_path, "```mermaid\nC4Context\n    title System Context\n```")
+        out = _render(
+            driver_path, "```mermaid\nC4Context\n    title System Context\n```"
+        )
         assert 'class="mermaid-block"' in out, (
             f"Valid C4 Mermaid fences should still be queued for Mermaid rendering: {out!r}"
         )
-        assert 'C4Context' in out
+        assert "C4Context" in out
 
-    def test_valid_mermaid_frontmatter_fence_still_creates_mermaid_block(self, driver_path):
-        out = _render(driver_path, "```mermaid\n---\ntitle: Demo\n---\nflowchart TB\n    A --> B\n```")
+    def test_valid_mermaid_frontmatter_fence_still_creates_mermaid_block(
+        self, driver_path
+    ):
+        out = _render(
+            driver_path,
+            "```mermaid\n---\ntitle: Demo\n---\nflowchart TB\n    A --> B\n```",
+        )
         assert 'class="mermaid-block"' in out, (
             f"Valid Mermaid fences with frontmatter should still be queued for Mermaid rendering: {out!r}"
         )
-        assert 'title: Demo' in out
+        assert "title: Demo" in out
 
     def test_prose_mention_of_mermaid_fence_renders_as_code_block(self, driver_path):
         src = "```mermaid\n` fence should not be auto-rendered too aggressively.\n\nSome prose, not a diagram.\n```"
@@ -590,7 +596,7 @@ class TestMermaidToolOutputGuard:
         )
         assert '<div class="pre-header">mermaid</div>' in out
         assert '<pre><code class="language-mermaid">' in out
-        assert 'Some prose, not a diagram.' in out
+        assert "Some prose, not a diagram." in out
 
 
 class TestRawPreCodePreservation:

--- a/tests/test_repair_workspace_user_turns.py
+++ b/tests/test_repair_workspace_user_turns.py
@@ -4,21 +4,28 @@ import sqlite3
 from pathlib import Path
 
 
-SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "repair_workspace_user_turns.py"
+SCRIPT = (
+    Path(__file__).resolve().parents[1] / "scripts" / "repair_workspace_user_turns.py"
+)
 spec = importlib.util.spec_from_file_location("repair_workspace_user_turns", SCRIPT)
 repair = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(repair)
 
 
 def test_clean_message_list_strips_workspace_prefix_and_dedupes_adjacent_user_turns():
-    cleaned, stats = repair.clean_message_list([
-        {"role": "user", "content": "Ok, mache weiter"},
-        {"role": "user", "content": "[Workspace: /tmp/project]\nOk, mache weiter"},
-        {"role": "assistant", "content": "continuing"},
-        {"role": "user", "content": "[Workspace: /tmp/project]\nNext"},
-    ])
+    cleaned, stats = repair.clean_message_list(
+        [
+            {"role": "user", "content": "Ok, mache weiter"},
+            {"role": "user", "content": "[Workspace: /tmp/project]\nOk, mache weiter"},
+            {"role": "assistant", "content": "continuing"},
+            {"role": "user", "content": "[Workspace: /tmp/project]\nNext"},
+        ]
+    )
 
-    assert stats == {"stripped_workspace_prefixes": 2, "removed_adjacent_user_duplicates": 1}
+    assert stats == {
+        "stripped_workspace_prefixes": 2,
+        "removed_adjacent_user_duplicates": 1,
+    }
     assert [m["role"] for m in cleaned] == ["user", "assistant", "user"]
     assert [m["content"] for m in cleaned] == ["Ok, mache weiter", "continuing", "Next"]
 
@@ -28,15 +35,20 @@ def test_repair_sidecars_writes_backup_and_updates_message_count(tmp_path):
     backup_dir = tmp_path / "backup"
     sessions_dir.mkdir()
     sidecar = sessions_dir / "abc.json"
-    sidecar.write_text(json.dumps({
-        "session_id": "abc",
-        "message_count": 3,
-        "messages": [
-            {"role": "user", "content": "ping"},
-            {"role": "user", "content": "[Workspace: /tmp]\nping"},
-            {"role": "assistant", "content": "pong"},
-        ],
-    }), encoding="utf-8")
+    sidecar.write_text(
+        json.dumps(
+            {
+                "session_id": "abc",
+                "message_count": 3,
+                "messages": [
+                    {"role": "user", "content": "ping"},
+                    {"role": "user", "content": "[Workspace: /tmp]\nping"},
+                    {"role": "assistant", "content": "pong"},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
 
     report = repair.repair_sidecars(sessions_dir, backup_dir=backup_dir, dry_run=False)
 
@@ -47,7 +59,9 @@ def test_repair_sidecars_writes_backup_and_updates_message_count(tmp_path):
     assert (backup_dir / "abc.json").exists()
 
 
-def test_repair_state_db_strips_prefixes_deletes_duplicates_and_updates_counts(tmp_path):
+def test_repair_state_db_strips_prefixes_deletes_duplicates_and_updates_counts(
+    tmp_path,
+):
     db = tmp_path / "state.db"
     con = sqlite3.connect(db)
     con.executescript("""
@@ -64,7 +78,9 @@ def test_repair_state_db_strips_prefixes_deletes_duplicates_and_updates_counts(t
             tool_name text
         );
     """)
-    con.execute("insert into sessions(id, message_count, tool_call_count) values ('s1', 4, 1)")
+    con.execute(
+        "insert into sessions(id, message_count, tool_call_count) values ('s1', 4, 1)"
+    )
     con.executemany(
         "insert into messages(session_id, role, content, tool_name) values (?, ?, ?, ?)",
         [
@@ -82,7 +98,9 @@ def test_repair_state_db_strips_prefixes_deletes_duplicates_and_updates_counts(t
     assert report["updated_workspace_prefix_user_messages"] == 1
     assert report["removed_adjacent_user_duplicates"] == 1
     con = sqlite3.connect(db)
-    assert con.execute("select message_count, tool_call_count from sessions where id = 's1'").fetchone() == (3, 1)
+    assert con.execute(
+        "select message_count, tool_call_count from sessions where id = 's1'"
+    ).fetchone() == (3, 1)
     assert con.execute("select role, content from messages order by id").fetchall() == [
         ("user", "hello"),
         ("assistant", "hi"),

--- a/tests/test_resolve_model_provider_free_suffix.py
+++ b/tests/test_resolve_model_provider_free_suffix.py
@@ -26,6 +26,7 @@ from api.config import resolve_model_provider, model_with_provider_context
 def _set_config_provider(provider: str, default_model: str = "claude-sonnet-4.6"):
     """Temporarily set the model config provider for testing."""
     import api.config as cfg_mod
+
     old = dict(cfg_mod.cfg.get("model", {}))
     cfg_mod.cfg["model"] = {"provider": provider, "default": default_model}
     return old, cfg_mod
@@ -39,15 +40,23 @@ def _restore_config(old, cfg_mod):
 # Tests
 # ---------------------------------------------------------------------------
 
+
 def test_openrouter_free_suffix_survives_provider_qualification():
     """tencent/hy3-preview:free must resolve correctly when qualified."""
     import api.config as cfg_mod
+
     old, cfg_mod = _set_config_provider("anthropic")
     try:
-        qualified = model_with_provider_context("tencent/hy3-preview:free", "openrouter")
+        qualified = model_with_provider_context(
+            "tencent/hy3-preview:free", "openrouter"
+        )
         model, provider, _ = resolve_model_provider(qualified)
-        assert provider == "openrouter", f"expected provider='openrouter', got '{provider}'"
-        assert model == "tencent/hy3-preview:free", f"expected model='tencent/hy3-preview:free', got '{model}'"
+        assert provider == "openrouter", (
+            f"expected provider='openrouter', got '{provider}'"
+        )
+        assert model == "tencent/hy3-preview:free", (
+            f"expected model='tencent/hy3-preview:free', got '{model}'"
+        )
     finally:
         _restore_config(old, cfg_mod)
 
@@ -55,9 +64,12 @@ def test_openrouter_free_suffix_survives_provider_qualification():
 def test_openrouter_free_suffix_nvidia():
     """nvidia/nemotron-3-super-120b-a12b:free — same bug class."""
     import api.config as cfg_mod
+
     old, cfg_mod = _set_config_provider("anthropic")
     try:
-        qualified = model_with_provider_context("nvidia/nemotron-3-super-120b-a12b:free", "openrouter")
+        qualified = model_with_provider_context(
+            "nvidia/nemotron-3-super-120b-a12b:free", "openrouter"
+        )
         model, provider, _ = resolve_model_provider(qualified)
         assert provider == "openrouter"
         assert model == "nvidia/nemotron-3-super-120b-a12b:free"
@@ -68,9 +80,12 @@ def test_openrouter_free_suffix_nvidia():
 def test_openrouter_free_suffix_arcee():
     """arcee-ai/trinity-large-preview:free — same bug class."""
     import api.config as cfg_mod
+
     old, cfg_mod = _set_config_provider("anthropic")
     try:
-        qualified = model_with_provider_context("arcee-ai/trinity-large-preview:free", "openrouter")
+        qualified = model_with_provider_context(
+            "arcee-ai/trinity-large-preview:free", "openrouter"
+        )
         model, provider, _ = resolve_model_provider(qualified)
         assert provider == "openrouter"
         assert model == "arcee-ai/trinity-large-preview:free"
@@ -81,6 +96,7 @@ def test_openrouter_free_suffix_arcee():
 def test_openrouter_thinking_suffix():
     """Models ending in :thinking should also be preserved."""
     import api.config as cfg_mod
+
     old, cfg_mod = _set_config_provider("anthropic")
     try:
         qualified = model_with_provider_context("some/model:thinking", "openrouter")
@@ -95,7 +111,9 @@ def test_custom_provider_rsplit_still_works():
     """custom:my-key:model must still parse correctly via rsplit."""
     qualified = "@custom:my-key:some-model"
     model, provider, _ = resolve_model_provider(qualified)
-    assert provider == "custom:my-key", f"expected provider='custom:my-key', got '{provider}'"
+    assert provider == "custom:my-key", (
+        f"expected provider='custom:my-key', got '{provider}'"
+    )
     assert model == "some-model", f"expected model='some-model', got '{model}'"
 
 
@@ -132,12 +150,17 @@ def test_known_provider_anthropic():
 # it back so the model becomes "<b>:<c>".
 # ---------------------------------------------------------------------------
 
+
 def test_custom_provider_free_suffix_1776():
     """@custom:my-key:some-model:free → custom:my-key + some-model:free (#1776)."""
     qualified = "@custom:my-key:some-model:free"
     model, provider, _ = resolve_model_provider(qualified)
-    assert provider == "custom:my-key", f"expected provider='custom:my-key', got '{provider}'"
-    assert model == "some-model:free", f"expected model='some-model:free', got '{model}'"
+    assert provider == "custom:my-key", (
+        f"expected provider='custom:my-key', got '{provider}'"
+    )
+    assert model == "some-model:free", (
+        f"expected model='some-model:free', got '{model}'"
+    )
 
 
 def test_custom_provider_beta_suffix_1776():

--- a/tests/test_scheduled_jobs_profile_isolation.py
+++ b/tests/test_scheduled_jobs_profile_isolation.py
@@ -9,18 +9,20 @@ This test writes two distinct jobs.json files (default + a named profile),
 then verifies `cron_profile_context` pins the cron.jobs call to the named
 profile's file.
 """
+
 import json
 import os
 import pathlib
 import sys
 import threading
-from unittest import mock
 
 import pytest
 
 # Ensure both repos are importable.
 WEBUI_ROOT = pathlib.Path(__file__).resolve().parent.parent
-AGENT_ROOT = pathlib.Path(os.environ.get("HERMES_AGENT_ROOT", pathlib.Path.home() / "hermes-agent"))
+AGENT_ROOT = pathlib.Path(
+    os.environ.get("HERMES_AGENT_ROOT", pathlib.Path.home() / "hermes-agent")
+)
 for p in (str(WEBUI_ROOT), str(AGENT_ROOT)):
     if p not in sys.path:
         sys.path.insert(0, p)
@@ -29,9 +31,7 @@ for p in (str(WEBUI_ROOT), str(AGENT_ROOT)):
 def _write_jobs(home: pathlib.Path, jobs: list):
     cron_dir = home / "cron"
     cron_dir.mkdir(parents=True, exist_ok=True)
-    (cron_dir / "jobs.json").write_text(
-        json.dumps({"jobs": jobs}), encoding="utf-8"
-    )
+    (cron_dir / "jobs.json").write_text(json.dumps({"jobs": jobs}), encoding="utf-8")
 
 
 def test_cron_profile_context_pins_profile_home(tmp_path, monkeypatch):
@@ -53,33 +53,39 @@ def test_cron_profile_context_pins_profile_home(tmp_path, monkeypatch):
 
     # Baseline: no context → default profile.
     from cron.jobs import list_jobs
+
     # Force cron.jobs to re-evaluate its cached constants for this test run.
     import cron.jobs as _cj
+
     _cj.HERMES_DIR = default_home
     _cj.CRON_DIR = default_home / "cron"
     _cj.JOBS_FILE = _cj.CRON_DIR / "jobs.json"
     _cj.OUTPUT_DIR = _cj.CRON_DIR / "output"
 
     jobs_before = list_jobs(include_disabled=True)
-    assert any(j["id"] == "d1" for j in jobs_before), \
+    assert any(j["id"] == "d1" for j in jobs_before), (
         f"Expected default-profile job before entering context, got {jobs_before}"
+    )
 
     # Simulate a request with TLS profile = 'meow'.
     p.set_request_profile("meow")
     try:
         with p.cron_profile_context():
             jobs_inside = list_jobs(include_disabled=True)
-            assert any(j["id"] == "m1" for j in jobs_inside), \
+            assert any(j["id"] == "m1" for j in jobs_inside), (
                 f"Expected meow-profile job inside context, got {jobs_inside}"
-            assert not any(j["id"] == "d1" for j in jobs_inside), \
+            )
+            assert not any(j["id"] == "d1" for j in jobs_inside), (
                 "Default-profile job leaked into meow context"
+            )
     finally:
         p.clear_request_profile()
 
     # After the context exits, we should be back to default.
     jobs_after = list_jobs(include_disabled=True)
-    assert any(j["id"] == "d1" for j in jobs_after), \
+    assert any(j["id"] == "d1" for j in jobs_after), (
         f"Expected default-profile job after exiting context, got {jobs_after}"
+    )
 
 
 def test_cron_profile_context_for_home_pins_explicit_home(tmp_path):
@@ -96,6 +102,7 @@ def test_cron_profile_context_for_home_pins_explicit_home(tmp_path):
     os.environ["HERMES_HOME"] = str(home_a)
     try:
         import cron.jobs as _cj
+
         _cj.HERMES_DIR = home_a
         _cj.CRON_DIR = home_a / "cron"
         _cj.JOBS_FILE = _cj.CRON_DIR / "jobs.json"
@@ -131,8 +138,8 @@ def test_cron_profile_context_serializes_concurrent_access(tmp_path):
 
     # Ensure the context lock is released between tests.
     from api import profiles as p
-    assert not p._cron_env_lock.locked(), \
-        "Lock leaked from a previous test"
+
+    assert not p._cron_env_lock.locked(), "Lock leaked from a previous test"
 
     observed = []
     barrier = threading.Barrier(2)
@@ -147,8 +154,10 @@ def test_cron_profile_context_serializes_concurrent_access(tmp_path):
 
     t1 = threading.Thread(target=worker, args=(home_a, "A"))
     t2 = threading.Thread(target=worker, args=(home_b, "B"))
-    t1.start(); t2.start()
-    t1.join(); t2.join()
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()
 
     # Every enter must be immediately followed by its matching exit (no
     # interleaving), because the lock serializes the two contexts.
@@ -173,7 +182,10 @@ def test_cron_run_does_not_silently_swallow_profile_resolution_errors():
     over-broad except clause.
     """
     from pathlib import Path
-    src = (Path(__file__).resolve().parent.parent / "api" / "routes.py").read_text(encoding="utf-8")
+
+    src = (Path(__file__).resolve().parent.parent / "api" / "routes.py").read_text(
+        encoding="utf-8"
+    )
 
     # Locate _handle_cron_run definition; assert the spawn block does NOT
     # wrap get_active_hermes_home() in a bare except that falls back to None.
@@ -199,7 +211,9 @@ def test_cron_run_does_not_silently_swallow_profile_resolution_errors():
     )
 
 
-def test_webui_installs_profile_context_on_in_process_scheduler_run_job(tmp_path, monkeypatch):
+def test_webui_installs_profile_context_on_in_process_scheduler_run_job(
+    tmp_path, monkeypatch
+):
     """If WebUI ever runs cron.scheduler.tick in-process, scheduled run_job calls
     must execute under the job's selected profile home, not the process-global
     HERMES_HOME that happened to be active when the scheduler thread fired.
@@ -245,7 +259,9 @@ def test_webui_installs_profile_context_on_in_process_scheduler_run_job(tmp_path
     ]
 
 
-def test_scheduler_run_job_wrapper_does_not_reenter_manual_cron_context(tmp_path, monkeypatch):
+def test_scheduler_run_job_wrapper_does_not_reenter_manual_cron_context(
+    tmp_path, monkeypatch
+):
     """Manual /api/crons/run already pins run_job before calling it.
 
     The scheduler safety wrapper must detect that existing context and delegate
@@ -296,7 +312,10 @@ def test_cron_worker_does_not_silently_fall_back_on_profile_context_failure():
     must not continue into run_job outside the requested profile context.
     """
     from pathlib import Path
-    src = (Path(__file__).resolve().parent.parent / "api" / "routes.py").read_text(encoding="utf-8")
+
+    src = (Path(__file__).resolve().parent.parent / "api" / "routes.py").read_text(
+        encoding="utf-8"
+    )
 
     idx = src.find("def _cron_job_subprocess_main(job")
     assert idx != -1, "_cron_job_subprocess_main not found"
@@ -305,7 +324,10 @@ def test_cron_worker_does_not_silently_fall_back_on_profile_context_failure():
     assert "with cron_profile_context_for_home(execution_profile_home):" in body
     assert "result = _run()" in body
     assert "ctx = None" not in body
-    assert "except Exception" not in body[:body.find("with cron_profile_context_for_home")], (
+    assert (
+        "except Exception"
+        not in body[: body.find("with cron_profile_context_for_home")]
+    ), (
         "cron subprocess target appears to catch profile-context setup before "
         "entering the context; do not fall back to an unpinned run_job call."
     )

--- a/tests/test_security_redaction.py
+++ b/tests/test_security_redaction.py
@@ -39,12 +39,13 @@ from tests._pytest_port import BASE
 
 # Sample credentials that should be masked in every API response
 _FAKE_GITHUB_PAT = "ghp_TestFakeCredential1234567890ab"
-_FAKE_SK_KEY     = "sk-TestFakeOpenAIKey1234567890abcdef"
-_FAKE_HF_TOKEN   = "hf_TestFakeHuggingFaceToken12345"
-_FAKE_AWS_KEY    = "AKIATESTFAKEKEY12345"
+_FAKE_SK_KEY = "sk-TestFakeOpenAIKey1234567890abcdef"
+_FAKE_HF_TOKEN = "hf_TestFakeHuggingFaceToken12345"
+_FAKE_AWS_KEY = "AKIATESTFAKEKEY12345"
 
 
 # ── HTTP helpers ──────────────────────────────────────────────────────────────
+
 
 def _get(path):
     with urllib.request.urlopen(BASE + path, timeout=10) as r:
@@ -54,7 +55,8 @@ def _get(path):
 def _post(path, body=None):
     data = json.dumps(body or {}).encode()
     req = urllib.request.Request(
-        BASE + path, data=data,
+        BASE + path,
+        data=data,
         headers={"Content-Type": "application/json"},
     )
     try:
@@ -81,9 +83,11 @@ def _assert_no_plaintext_credentials(text: str, label: str = ""):
 
 # ── helpers.py unit tests (import-level, no test_server needed) ───────────────────
 
+
 def test_redact_value_str():
     """_redact_value masks a plaintext GitHub PAT in a string."""
     from api.helpers import _redact_value
+
     result = _redact_value(f"my token is {_FAKE_GITHUB_PAT} bye")
     assert _FAKE_GITHUB_PAT not in result
     assert "ghp_Te" in result  # prefix preserved
@@ -92,6 +96,7 @@ def test_redact_value_str():
 def test_redact_value_dict():
     """_redact_value recurses into dicts."""
     from api.helpers import _redact_value
+
     d = {"content": f"key={_FAKE_SK_KEY}", "role": "user"}
     result = _redact_value(d)
     assert _FAKE_SK_KEY not in result["content"]
@@ -101,6 +106,7 @@ def test_redact_value_dict():
 def test_redact_value_list():
     """_redact_value recurses into lists."""
     from api.helpers import _redact_value
+
     lst = [{"content": _FAKE_GITHUB_PAT}, {"content": "safe text"}]
     result = _redact_value(lst)
     assert _FAKE_GITHUB_PAT not in result[0]["content"]
@@ -120,6 +126,7 @@ def test_redact_value_works_with_legacy_agent_redact_signature(monkeypatch):
     monkeypatch.setitem(sys.modules, "agent.redact", fake_redact)
 
     import api.helpers as helpers
+
     helpers = importlib.reload(helpers)
     try:
         result = helpers._redact_value(f"token={_FAKE_GITHUB_PAT}")
@@ -132,6 +139,7 @@ def test_redact_value_works_with_legacy_agent_redact_signature(monkeypatch):
 def test_redact_session_data_messages():
     """redact_session_data masks credentials in messages[]."""
     from api.helpers import redact_session_data
+
     session = {
         "session_id": "abc123",
         "title": f"my token {_FAKE_GITHUB_PAT}",
@@ -140,8 +148,11 @@ def test_redact_session_data_messages():
             {"role": "assistant", "content": "sure"},
         ],
         "tool_calls": [
-            {"name": "terminal", "args": {"command": f"gh auth login --token {_FAKE_GITHUB_PAT}"},
-             "snippet": "ok"},
+            {
+                "name": "terminal",
+                "args": {"command": f"gh auth login --token {_FAKE_GITHUB_PAT}"},
+                "snippet": "ok",
+            },
         ],
     }
     result = redact_session_data(session)
@@ -155,14 +166,20 @@ def test_redact_session_data_messages():
 def test_redact_session_data_multiple_cred_types():
     """redact_session_data handles sk-, ghp_, hf_, and AKIA keys."""
     from api.helpers import redact_session_data
+
     session = {
         "title": "test",
-        "messages": [{"role": "user", "content": (
-            f"openai={_FAKE_SK_KEY} "
-            f"github={_FAKE_GITHUB_PAT} "
-            f"hf={_FAKE_HF_TOKEN} "
-            f"aws={_FAKE_AWS_KEY}"
-        )}],
+        "messages": [
+            {
+                "role": "user",
+                "content": (
+                    f"openai={_FAKE_SK_KEY} "
+                    f"github={_FAKE_GITHUB_PAT} "
+                    f"hf={_FAKE_HF_TOKEN} "
+                    f"aws={_FAKE_AWS_KEY}"
+                ),
+            }
+        ],
         "tool_calls": [],
     }
     result = redact_session_data(session)
@@ -173,6 +190,7 @@ def test_redact_session_data_multiple_cred_types():
 def test_redact_session_data_non_sensitive_unchanged():
     """redact_session_data does not corrupt innocent content."""
     from api.helpers import redact_session_data
+
     session = {
         "title": "Hello world",
         "messages": [{"role": "user", "content": "What is 2+2?"}],
@@ -187,6 +205,7 @@ def test_redact_session_data_non_sensitive_unchanged():
 # ── API-level tests (require running test server started by conftest.py) ─────
 # Run via `start.sh && pytest tests/test_security_redaction.py -v`
 
+
 def _create_session_with_credentials() -> str:
     """Write a session file with credential-containing messages directly to disk.
 
@@ -194,9 +213,12 @@ def _create_session_with_credentials() -> str:
     from disk, exercising the redaction code path on load.
     Uses TEST_STATE_DIR from conftest.py (the isolated test server state directory).
     """
-    import time, uuid
+    import time
+    import uuid
+
     try:
         from conftest import TEST_STATE_DIR
+
         sessions_dir = TEST_STATE_DIR / "sessions"
     except ImportError:
         from api.config import SESSION_DIR as sessions_dir
@@ -207,27 +229,40 @@ def _create_session_with_credentials() -> str:
     sid = "sec_test_" + uuid.uuid4().hex[:8]
     now = time.time()
     session_file = sessions_dir / f"{sid}.json"
-    session_file.write_text(json.dumps({
-        "session_id": sid,
-        "title": f"session with {_FAKE_GITHUB_PAT}",
-        "workspace": "/tmp",
-        "model": "test",
-        "created_at": now,
-        "updated_at": now,
-        "pinned": False, "archived": False, "project_id": None,
-        "profile": "default", "input_tokens": 0, "output_tokens": 0,
-        "estimated_cost": None, "personality": None,
-        "messages": [
-            {"role": "user",      "content": f"my PAT is {_FAKE_GITHUB_PAT}"},
-            {"role": "assistant", "content": f"sk key is {_FAKE_SK_KEY}"},
-            {"role": "tool",      "content": "result ok", "name": "terminal"},
-        ],
-        "tool_calls": [
-            {"name": "terminal",
-             "args": {"command": f"gh auth login --token {_FAKE_GITHUB_PAT}"},
-             "snippet": "blocked"}
-        ],
-    }))
+    session_file.write_text(
+        json.dumps(
+            {
+                "session_id": sid,
+                "title": f"session with {_FAKE_GITHUB_PAT}",
+                "workspace": "/tmp",
+                "model": "test",
+                "created_at": now,
+                "updated_at": now,
+                "pinned": False,
+                "archived": False,
+                "project_id": None,
+                "profile": "default",
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "estimated_cost": None,
+                "personality": None,
+                "messages": [
+                    {"role": "user", "content": f"my PAT is {_FAKE_GITHUB_PAT}"},
+                    {"role": "assistant", "content": f"sk key is {_FAKE_SK_KEY}"},
+                    {"role": "tool", "content": "result ok", "name": "terminal"},
+                ],
+                "tool_calls": [
+                    {
+                        "name": "terminal",
+                        "args": {
+                            "command": f"gh auth login --token {_FAKE_GITHUB_PAT}"
+                        },
+                        "snippet": "blocked",
+                    }
+                ],
+            }
+        )
+    )
     return sid
 
 
@@ -235,6 +270,7 @@ def test_api_session_redacts_messages():
     """GET /api/session route must call redact_session_data() before returning."""
     import inspect
     import api.routes as routes
+
     src = inspect.getsource(routes.handle_get)
     # Verify redact_session_data is applied to the session payload
     assert "redact_session_data" in src, (
@@ -245,6 +281,7 @@ def test_api_session_redacts_messages():
 def test_api_session_redacts_title():
     """redact_session_data must redact credentials from session title field."""
     from api.helpers import redact_session_data
+
     session = {
         "session_id": "abc123",
         "title": f"session with {_FAKE_GITHUB_PAT}",
@@ -253,7 +290,7 @@ def test_api_session_redacts_title():
     }
     result = redact_session_data(session)
     assert _FAKE_GITHUB_PAT not in result["title"], (
-        f"redact_session_data must mask credentials in title field"
+        "redact_session_data must mask credentials in title field"
     )
     assert result["session_id"] == "abc123"  # safe fields preserved
 
@@ -271,6 +308,7 @@ def test_api_session_export_redacts():
     """GET /api/session/export must call redact_session_data() in _handle_session_export."""
     import inspect
     import api.routes as routes
+
     # The export handler is a separate function (_handle_session_export)
     src = inspect.getsource(routes._handle_session_export)
     assert "redact_session_data" in src, (
@@ -284,23 +322,25 @@ def test_api_memory_redacts_via_write_read(test_server):
     original = _get("/api/memory").get("memory", "")
 
     cred_content = f"GitHub PAT: {_FAKE_GITHUB_PAT}\nNormal note: hello world"
-    data, status = _post("/api/memory/write", {"section": "memory", "content": cred_content})
+    data, status = _post(
+        "/api/memory/write", {"section": "memory", "content": cred_content}
+    )
     assert status == 200, f"memory/write failed: {data}"
 
     try:
         read_back = _get("/api/memory")
         dump = json.dumps(read_back)
         _assert_no_plaintext_credentials(dump, "GET /api/memory")
-        assert "hello world" in read_back["memory"]   # non-sensitive content preserved
+        assert "hello world" in read_back["memory"]  # non-sensitive content preserved
     finally:
         _post("/api/memory/write", {"section": "memory", "content": original})
 
 
 # ── startup: fix_credential_permissions ──────────────────────────────────────
 
+
 def test_fix_credential_permissions_corrects_loose_files(tmp_path, monkeypatch):
     """fix_credential_permissions() tightens group/other read bits."""
-    import os
     from api.startup import fix_credential_permissions
 
     env_file = tmp_path / ".env"
@@ -315,8 +355,11 @@ def test_fix_credential_permissions_corrects_loose_files(tmp_path, monkeypatch):
     fix_credential_permissions()
 
     import stat
+
     assert stat.S_IMODE(env_file.stat().st_mode) == 0o600, ".env not fixed to 600"
-    assert stat.S_IMODE(google_file.stat().st_mode) == 0o600, "google_token.json not fixed to 600"
+    assert stat.S_IMODE(google_file.stat().st_mode) == 0o600, (
+        "google_token.json not fixed to 600"
+    )
 
 
 def test_fix_credential_permissions_skips_correct_files(tmp_path, monkeypatch):
@@ -328,7 +371,9 @@ def test_fix_credential_permissions_skips_correct_files(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
 
     from api.startup import fix_credential_permissions
+
     fix_credential_permissions()
 
     import stat
+
     assert stat.S_IMODE(env_file.stat().st_mode) == 0o600

--- a/tests/test_service_worker_api_cache.py
+++ b/tests/test_service_worker_api_cache.py
@@ -5,6 +5,7 @@ The WebUI can be served at /hermes/. In that deployment API requests look like
 network-only; otherwise cache-first handling can serve a stale sidebar session
 list until the browser cache/service-worker cache is cleared.
 """
+
 from pathlib import Path
 
 
@@ -44,7 +45,9 @@ def test_service_worker_uses_network_first_for_page_navigation():
     fetch_idx = SW_SRC.find("fetch(event.request)", navigate_idx)
     cache_idx = SW_SRC.find("caches.match", navigate_idx)
     assert fetch_idx != -1, "navigation branch must try the live server first"
-    assert cache_idx != -1, "navigation branch may use cached shell only as offline fallback"
+    assert cache_idx != -1, (
+        "navigation branch may use cached shell only as offline fallback"
+    )
     assert fetch_idx < cache_idx, (
         "navigation requests must be network-first, not cache-first, so auth redirects "
         "and freshly set login cookies are honored without a manual refresh"
@@ -53,7 +56,11 @@ def test_service_worker_uses_network_first_for_page_navigation():
 
 def test_service_worker_does_not_precache_page_shell_under_auth():
     """Do not cache './' during install; it may be the authenticated app or login redirect."""
-    shell_block = SW_SRC[SW_SRC.find("const SHELL_ASSETS"):SW_SRC.find("];", SW_SRC.find("const SHELL_ASSETS"))]
+    shell_block = SW_SRC[
+        SW_SRC.find("const SHELL_ASSETS") : SW_SRC.find(
+            "];", SW_SRC.find("const SHELL_ASSETS")
+        )
+    ]
     assert "'./'" not in shell_block and '"./"' not in shell_block, (
         "pre-caching './' can serve a stale authenticated app shell while logged out; "
         "navigation should populate shell cache only after a successful non-redirect network load"
@@ -61,7 +68,10 @@ def test_service_worker_does_not_precache_page_shell_under_auth():
 
 
 def test_service_worker_never_caches_login_page_or_login_script():
-    assert "url.pathname.endsWith('/login')" in SW_SRC or "url.pathname.includes('/login')" in SW_SRC, (
+    assert (
+        "url.pathname.endsWith('/login')" in SW_SRC
+        or "url.pathname.includes('/login')" in SW_SRC
+    ), (
         "service worker must bypass the login page so stale auth UI cannot survive until cache clear"
     )
     assert "url.pathname.endsWith('/static/login.js')" in SW_SRC, (

--- a/tests/test_session_batch_select.py
+++ b/tests/test_session_batch_select.py
@@ -1,194 +1,226 @@
 """Test: session batch select mode functions exist in sessions.js (#568)"""
-import re
 
 
 def test_batch_select_state_variables():
     """Verify batch select state variables are declared."""
-    with open('static/sessions.js') as f:
+    with open("static/sessions.js") as f:
         src = f.read()
-    assert '_sessionSelectMode' in src, "Missing _sessionSelectMode variable"
-    assert '_selectedSessions' in src, "Missing _selectedSessions variable"
-    assert 'new Set()' in src, "Selected sessions should use Set"
+    assert "_sessionSelectMode" in src, "Missing _sessionSelectMode variable"
+    assert "_selectedSessions" in src, "Missing _selectedSessions variable"
+    assert "new Set()" in src, "Selected sessions should use Set"
 
 
 def test_batch_select_functions_exist():
     """Verify all batch select functions are defined."""
-    with open('static/sessions.js') as f:
+    with open("static/sessions.js") as f:
         src = f.read()
     required_funcs = [
-        'toggleSessionSelectMode',
-        'exitSessionSelectMode',
-        'toggleSessionSelect',
-        'selectAllSessions',
-        'deselectAllSessions',
-        '_updateBatchActionBar',
-        '_renderBatchActionBar',
-        '_showBatchProjectPicker',
+        "toggleSessionSelectMode",
+        "exitSessionSelectMode",
+        "toggleSessionSelect",
+        "selectAllSessions",
+        "deselectAllSessions",
+        "_updateBatchActionBar",
+        "_renderBatchActionBar",
+        "_showBatchProjectPicker",
     ]
     for fn in required_funcs:
-        assert f'function {fn}(' in src, f"Missing function: {fn}"
+        assert f"function {fn}(" in src, f"Missing function: {fn}"
 
 
 def test_batch_select_checkbox_rendering():
     """Verify checkbox is rendered when in select mode."""
-    with open('static/sessions.js') as f:
+    with open("static/sessions.js") as f:
         src = f.read()
-    assert 'session-select-cb' in src, "Missing session-select-cb class"
-    assert 'session-select-cb-wrapper' in src, "Missing session-select-cb-wrapper class"
+    assert "session-select-cb" in src, "Missing session-select-cb class"
+    assert "session-select-cb-wrapper" in src, "Missing session-select-cb-wrapper class"
     assert "cb.type='checkbox'" in src, "Checkbox should be type checkbox"
 
 
 def test_batch_select_intercepts_navigation():
     """Verify select mode intercepts session navigation."""
-    with open('static/sessions.js') as f:
+    with open("static/sessions.js") as f:
         src = f.read()
     assert "_sessionSelectMode" in src
     # Should have early return when in select mode
-    assert 'toggleSessionSelect(s.session_id)' in src, \
+    assert "toggleSessionSelect(s.session_id)" in src, (
         "Pointerup handler should call toggleSessionSelect in select mode"
+    )
 
 
 def test_batch_checkbox_sets_selection_without_row_double_toggle():
     """Clicking the checkbox itself must not also trigger row-level toggling."""
-    with open('static/sessions.js') as f:
+    with open("static/sessions.js") as f:
         src = f.read()
-    assert 'function setSessionSelected(sid, selected)' in src, \
+    assert "function setSessionSelected(sid, selected)" in src, (
         "Checkbox changes should set explicit state instead of toggling blindly"
-    assert 'cb.onchange=(e)=>{e.stopPropagation();setSessionSelected(s.session_id,cb.checked);};' in src, \
-        "Checkbox change must use its checked state"
-    assert 'cb.onpointerup=(e)=>{e.stopPropagation();};' in src, \
+    )
+    assert (
+        "cb.onchange=(e)=>{e.stopPropagation();setSessionSelected(s.session_id,cb.checked);};"
+        in src
+    ), "Checkbox change must use its checked state"
+    assert "cb.onpointerup=(e)=>{e.stopPropagation();};" in src, (
         "Checkbox pointerup must not bubble to the row pointerup handler"
-    assert 'cbWrapper.onpointerup=(e)=>{e.stopPropagation();};' in src, \
+    )
+    assert "cbWrapper.onpointerup=(e)=>{e.stopPropagation();};" in src, (
         "Checkbox wrapper pointerup must not bubble to the row pointerup handler"
+    )
 
 
 def test_batch_select_escape_handler():
     """Verify Escape key exits select mode."""
-    with open('static/sessions.js') as f:
+    with open("static/sessions.js") as f:
         src = f.read()
-    assert "e.key==='Escape'&&_sessionSelectMode" in src, \
+    assert "e.key==='Escape'&&_sessionSelectMode" in src, (
         "Should have Escape key handler for select mode"
+    )
 
 
 def test_batch_select_toggle_button():
     """Verify select mode toggle button is rendered."""
-    with open('static/sessions.js') as f:
+    with open("static/sessions.js") as f:
         src = f.read()
-    assert 'session-select-toggle' in src, "Missing session-select-toggle class"
-    assert 'toggleSessionSelectMode' in src, "Missing toggleSessionSelectMode call"
+    assert "session-select-toggle" in src, "Missing session-select-toggle class"
+    assert "toggleSessionSelectMode" in src, "Missing toggleSessionSelectMode call"
 
 
 def test_batch_select_bar_element():
     """Verify batch action bar DOM element is created."""
-    with open('static/sessions.js') as f:
+    with open("static/sessions.js") as f:
         src = f.read()
-    assert 'batchActionBar' in src, "Missing batchActionBar element"
-    assert 'batch-action-bar' in src, "Missing batch-action-bar CSS class"
-    assert 'batch-action-btn' in src, "Missing batch-action-btn class"
+    assert "batchActionBar" in src, "Missing batchActionBar element"
+    assert "batch-action-bar" in src, "Missing batch-action-bar CSS class"
+    assert "batch-action-btn" in src, "Missing batch-action-btn class"
 
 
 def test_batch_action_bar_overrides_css_hidden_state():
     """Selected sessions must make the fixed action bar visible."""
-    with open('static/sessions.js') as f:
+    with open("static/sessions.js") as f:
         src = f.read()
-    assert "if(count>0){_renderBatchActionBar();}" in src, \
+    assert "if(count>0){_renderBatchActionBar();}" in src, (
         "Updating selected count must render action buttons, not just reveal an empty bar"
-    assert "t('session_selected_count',_selectedSessions.size)" in src, \
+    )
+    assert "t('session_selected_count',_selectedSessions.size)" in src, (
         "Selected count must pass the selected session count to i18n"
-    assert "t('session_batch_archive_confirm',ids.length)" in src, \
+    )
+    assert "t('session_batch_archive_confirm',ids.length)" in src, (
         "Batch archive confirmation must pass selected session count to i18n"
-    assert "t('session_batch_delete_confirm',ids.length)" in src, \
+    )
+    assert "t('session_batch_delete_confirm',ids.length)" in src, (
         "Batch delete confirmation must pass selected session count to i18n"
-    assert "bar.innerHTML='';bar.style.display=_selectedSessions.size>0?'flex':'none'" in src, \
-        "Rendering the action bar must explicitly show it when selections exist"
-    assert "batchBar.style.display='flex'" in src, \
+    )
+    assert (
+        "bar.innerHTML='';bar.style.display=_selectedSessions.size>0?'flex':'none'"
+        in src
+    ), "Rendering the action bar must explicitly show it when selections exist"
+    assert "batchBar.style.display='flex'" in src, (
         "Session list render must explicitly show the action bar in select mode"
+    )
 
 
 def test_batch_action_bar_is_sidebar_inline_not_global_footer():
     """Batch actions should appear in the session list, not over the composer."""
-    with open('static/sessions.js') as f:
+    with open("static/sessions.js") as f:
         js = f.read()
-    with open('static/style.css') as f:
+    with open("static/style.css") as f:
         css = f.read()
-    assert "list.appendChild(batchBar)" in js, \
+    assert "list.appendChild(batchBar)" in js, (
         "Batch action bar should be rendered inside the session list"
-    assert "document.body.appendChild(batchBar)" not in js, \
+    )
+    assert "document.body.appendChild(batchBar)" not in js, (
         "Batch action bar must not be mounted as a global footer"
-    assert ".batch-action-bar{display:none;margin:" in css, \
+    )
+    assert ".batch-action-bar{display:none;margin:" in css, (
         "Batch action bar should use inline sidebar spacing"
-    assert "position:fixed" not in css[css.find(".batch-action-bar{"):css.find(".batch-count{")], \
-        "Batch action bar must not be fixed to the bottom of the viewport"
+    )
+    assert (
+        "position:fixed"
+        not in css[css.find(".batch-action-bar{") : css.find(".batch-count{")]
+    ), "Batch action bar must not be fixed to the bottom of the viewport"
 
 
 def test_batch_project_picker_is_anchored_to_batch_actions():
     """Batch move project picker should open inside the sidebar action bar."""
-    with open('static/sessions.js') as f:
+    with open("static/sessions.js") as f:
         js = f.read()
-    with open('static/style.css') as f:
+    with open("static/style.css") as f:
         css = f.read()
-    assert "const bar=$('batchActionBar');if(!bar)return;" in js, \
+    assert "const bar=$('batchActionBar');if(!bar)return;" in js, (
         "Batch project picker should anchor to the batch action bar"
-    assert "picker.className='project-picker batch-project-picker'" in js, \
+    )
+    assert "picker.className='project-picker batch-project-picker'" in js, (
         "Batch project picker needs its own inline styling hook"
-    assert "bar.appendChild(picker)" in js, \
+    )
+    assert "bar.appendChild(picker)" in js, (
         "Batch project picker should render inside the batch action bar"
-    assert "document.body.appendChild(picker);picker.style.cssText='position:fixed" not in js, \
-        "Batch project picker must not use the old global fixed placement"
-    assert ".batch-action-bar .batch-project-picker{position:static;" in css, \
+    )
+    assert (
+        "document.body.appendChild(picker);picker.style.cssText='position:fixed"
+        not in js
+    ), "Batch project picker must not use the old global fixed placement"
+    assert ".batch-action-bar .batch-project-picker{position:static;" in css, (
         "Batch project picker should override the shared absolute project picker style"
-    assert css.find(".project-picker{") < css.find(".batch-action-bar .batch-project-picker{"), \
-        "Batch project picker override must come after the shared project picker rule"
+    )
+    assert css.find(".project-picker{") < css.find(
+        ".batch-action-bar .batch-project-picker{"
+    ), "Batch project picker override must come after the shared project picker rule"
 
 
 def test_streaming_zero_message_sessions_stay_visible_after_reload():
     """In-flight sessions may have zero saved messages during reload recovery."""
-    with open('static/sessions.js') as f:
+    with open("static/sessions.js") as f:
         src = f.read()
-    assert "_isSessionEffectivelyStreaming(s)" in src, \
+    assert "_isSessionEffectivelyStreaming(s)" in src, (
         "Streaming sessions must bypass the zero-message sidebar filter"
-    assert "!!s.active_stream_id" in src, \
+    )
+    assert "!!s.active_stream_id" in src, (
         "Sessions with persisted active stream IDs must remain visible after reload"
-    assert "!!s.pending_user_message" in src, \
+    )
+    assert "!!s.pending_user_message" in src, (
         "Sessions with pending user turns must remain visible after reload"
+    )
 
 
 def test_boot_does_not_drop_zero_message_inflight_session():
     """Reloading /session/<id> during a running turn must keep the session open."""
-    with open('static/boot.js') as f:
+    with open("static/boot.js") as f:
         src = f.read()
-    assert "const _restoredInFlight = S.session && (" in src, \
+    assert "const _restoredInFlight = S.session && (" in src, (
         "Boot must detect restored in-flight sessions before ephemeral cleanup"
-    assert "S.session.active_stream_id" in src, \
+    )
+    assert "S.session.active_stream_id" in src, (
         "Boot must treat active stream IDs as real sessions"
-    assert "S.session.pending_user_message" in src, \
+    )
+    assert "S.session.pending_user_message" in src, (
         "Boot must treat pending user messages as real sessions"
-    assert "&& !_restoredInFlight" in src, \
+    )
+    assert "&& !_restoredInFlight" in src, (
         "Zero-message cleanup must not run for in-flight sessions"
+    )
 
 
 def test_batch_select_i18n_keys():
     """Verify all batch select i18n keys exist in all locales."""
-    with open('static/i18n.js') as f:
+    with open("static/i18n.js") as f:
         src = f.read()
     required_keys = [
-        'session_select_mode',
-        'session_select_mode_desc',
-        'session_select_all',
-        'session_deselect_all',
-        'session_selected_count',
-        'session_batch_archive',
-        'session_batch_delete',
-        'session_batch_move',
-        'session_batch_delete_confirm',
-        'session_batch_archive_confirm',
-        'session_no_selection',
+        "session_select_mode",
+        "session_select_mode_desc",
+        "session_select_all",
+        "session_deselect_all",
+        "session_selected_count",
+        "session_batch_archive",
+        "session_batch_delete",
+        "session_batch_move",
+        "session_batch_delete_confirm",
+        "session_batch_archive_confirm",
+        "session_no_selection",
     ]
-    locales = ['en', 'ru', 'es', 'de', 'zh', 'zh-Hant', 'ko']
+    locales = ["en", "ru", "es", "de", "zh", "zh-Hant", "ko"]
     for key in required_keys:
         for locale in locales:
             # Check if the key exists in the locale block
-            if locale == 'zh-Hant':
+            if locale == "zh-Hant":
                 pattern = rf"'{locale}'\s*:.*?{key}"
             else:
                 pattern = rf"{locale}\s*:.*?{key}"
@@ -197,35 +229,39 @@ def test_batch_select_i18n_keys():
     # Count occurrences - each key should appear in all 7 locales
     for key in required_keys:
         count = src.count(f"{key}:")
-        assert count >= 8, f"Key '{key}' found {count} times, expected >= 8 (one per locale) (one per locale)"
+        assert count >= 8, (
+            f"Key '{key}' found {count} times, expected >= 8 (one per locale) (one per locale)"
+        )
 
 
 def test_i18n_string_placeholder_interpolation_supported():
     """String-valued translations with {0} placeholders should interpolate args."""
-    with open('static/i18n.js') as f:
+    with open("static/i18n.js") as f:
         src = f.read()
-    assert "String(val).replace(/\\{(\\d+)\\}/g" in src, \
+    assert "String(val).replace(/\\{(\\d+)\\}/g" in src, (
         "t() must interpolate {0}-style placeholders for string-valued translations"
-    assert "Object.prototype.hasOwnProperty.call(args, idx)" in src, \
+    )
+    assert "Object.prototype.hasOwnProperty.call(args, idx)" in src, (
         "t() must preserve unknown placeholders instead of replacing with undefined"
+    )
 
 
 def test_batch_select_css_exists():
     """Verify batch select CSS classes are defined."""
-    with open('static/style.css') as f:
+    with open("static/style.css") as f:
         src = f.read()
     required_classes = [
-        'session-select-toggle',
-        'session-select-bar',
-        'batch-exit-btn',
-        'batch-select-all-btn',
-        'session-select-cb-wrapper',
-        'session-select-cb',
-        'session-item.selected',
-        'batch-action-bar',
-        'batch-count',
-        'batch-action-btn',
-        'batch-action-btn-danger',
+        "session-select-toggle",
+        "session-select-bar",
+        "batch-exit-btn",
+        "batch-select-all-btn",
+        "session-select-cb-wrapper",
+        "session-select-cb",
+        "session-item.selected",
+        "batch-action-bar",
+        "batch-count",
+        "batch-action-btn",
+        "batch-action-btn-danger",
     ]
     for cls in required_classes:
         assert cls in src, f"Missing CSS class: .{cls}"
@@ -233,24 +269,27 @@ def test_batch_select_css_exists():
 
 def test_batch_select_mode_flags():
     """Verify select mode properly toggles state."""
-    with open('static/sessions.js') as f:
+    with open("static/sessions.js") as f:
         src = f.read()
     # toggleSessionSelectMode should flip the flag
-    assert '_sessionSelectMode=!_sessionSelectMode' in src, \
+    assert "_sessionSelectMode=!_sessionSelectMode" in src, (
         "toggleSessionSelectMode should flip _sessionSelectMode"
+    )
     # exitSessionSelectMode should clear state
-    assert '_sessionSelectMode=false' in src, \
+    assert "_sessionSelectMode=false" in src, (
         "exitSessionSelectMode should set _sessionSelectMode=false"
-    assert '_selectedSessions.clear()' in src, \
-        "Exit should clear selected sessions"
+    )
+    assert "_selectedSessions.clear()" in src, "Exit should clear selected sessions"
 
 
 def test_batch_delete_uses_confirm_dialog():
     """Verify batch delete shows confirmation dialog."""
-    with open('static/sessions.js') as f:
+    with open("static/sessions.js") as f:
         src = f.read()
     # The delete handler should call showConfirmDialog with batch message
-    assert "session_batch_delete_confirm" in src, \
+    assert "session_batch_delete_confirm" in src, (
         "Batch delete should use session_batch_delete_confirm i18n key"
-    assert "showConfirmDialog" in src, \
+    )
+    assert "showConfirmDialog" in src, (
         "Should use showConfirmDialog for batch operations"
+    )

--- a/tests/test_session_cross_tab_sync.py
+++ b/tests/test_session_cross_tab_sync.py
@@ -1,4 +1,5 @@
 """Regression tests for cross-tab active session behavior."""
+
 import json
 import re
 import subprocess
@@ -14,7 +15,10 @@ ROUTES_PY = (REPO_ROOT / "api" / "routes.py").read_text(encoding="utf-8")
 
 
 def test_sessions_js_listens_for_active_session_storage_changes():
-    assert "addEventListener('storage'" in SESSIONS_JS or 'addEventListener("storage"' in SESSIONS_JS
+    assert (
+        "addEventListener('storage'" in SESSIONS_JS
+        or 'addEventListener("storage"' in SESSIONS_JS
+    )
     assert "hermes-webui-session" in SESSIONS_JS
     assert "_handleActiveSessionStorageEvent" in SESSIONS_JS
 
@@ -36,14 +40,23 @@ def test_session_switch_updates_url_path_for_tab_local_anchor():
     assert "'/session/'" in SESSIONS_JS
     assert "_setActiveSessionUrl(S.session.session_id)" in SESSIONS_JS
     assert "_setActiveSessionUrl(S.session.session_id)" in COMMANDS_JS
-    assert "addEventListener('popstate'" in SESSIONS_JS or 'addEventListener("popstate"' in SESSIONS_JS
+    assert (
+        "addEventListener('popstate'" in SESSIONS_JS
+        or 'addEventListener("popstate"' in SESSIONS_JS
+    )
 
 
 def test_boot_prefers_url_session_over_local_storage_session():
-    assert "const urlSession=(typeof _sessionIdFromLocation==='function')?_sessionIdFromLocation():null;" in BOOT_JS
+    assert (
+        "const urlSession=(typeof _sessionIdFromLocation==='function')?_sessionIdFromLocation():null;"
+        in BOOT_JS
+    )
     assert "const savedLocal=localStorage.getItem('hermes-webui-session');" in BOOT_JS
     assert "const saved=urlSession||savedLocal;" in BOOT_JS
-    assert "if(!urlSession&&savedLocal&&await _savedSessionShouldStaySidebarOnly(savedLocal))" in BOOT_JS
+    assert (
+        "if(!urlSession&&savedLocal&&await _savedSessionShouldStaySidebarOnly(savedLocal))"
+        in BOOT_JS
+    )
 
 
 def test_api_helper_resolves_against_document_base_not_session_path():
@@ -79,8 +92,23 @@ console.log(written);
 
 
 def test_base_href_resolution_handles_session_urls_under_subpath_mounts():
-    assert _evaluate_base_href_for_path("/session/abc123") == '<base href="https://example.test/">'
-    assert _evaluate_base_href_for_path("/myapp/session/abc123") == '<base href="https://example.test/myapp/">'
-    assert _evaluate_base_href_for_path("/myapp/session/abc123/extra") == '<base href="https://example.test/myapp/">'
-    assert _evaluate_base_href_for_path("/session-tools/session/abc123") == '<base href="https://example.test/session-tools/">'
-    assert _evaluate_base_href_for_path("/session-tools/page") == '<base href="https://example.test/session-tools/">'
+    assert (
+        _evaluate_base_href_for_path("/session/abc123")
+        == '<base href="https://example.test/">'
+    )
+    assert (
+        _evaluate_base_href_for_path("/myapp/session/abc123")
+        == '<base href="https://example.test/myapp/">'
+    )
+    assert (
+        _evaluate_base_href_for_path("/myapp/session/abc123/extra")
+        == '<base href="https://example.test/myapp/">'
+    )
+    assert (
+        _evaluate_base_href_for_path("/session-tools/session/abc123")
+        == '<base href="https://example.test/session-tools/">'
+    )
+    assert (
+        _evaluate_base_href_for_path("/session-tools/page")
+        == '<base href="https://example.test/session-tools/">'
+    )

--- a/tests/test_session_duplicate.py
+++ b/tests/test_session_duplicate.py
@@ -7,19 +7,13 @@ Tests verify that:
 3. The duplicate is independent from the original
 4. Error handling works properly
 """
+
 import json
-import pathlib
-import shutil
-import subprocess
-import time
 import urllib.request
 import urllib.error
-import uuid
-import tempfile
 
-import pytest
 
-from tests.conftest import TEST_BASE, TEST_STATE_DIR, _post, TEST_WORKSPACE, _wait_for_server
+from tests.conftest import TEST_BASE, _post
 
 
 def _get(path):
@@ -33,9 +27,9 @@ def test_duplicate_session_handles_missing_session_id(cleanup_test_sessions):
     Test that duplicate endpoint returns error when session_id is missing.
     """
     # Try to duplicate without session_id
-    r = _post(TEST_BASE, '/api/session/duplicate', {})
+    r = _post(TEST_BASE, "/api/session/duplicate", {})
 
-    assert 'error' in r, "Should return error when session_id is missing"
+    assert "error" in r, "Should return error when session_id is missing"
 
 
 def test_duplicate_session_handles_invalid_session_id(cleanup_test_sessions):
@@ -43,13 +37,14 @@ def test_duplicate_session_handles_invalid_session_id(cleanup_test_sessions):
     Test that duplicate endpoint returns error when session doesn't exist.
     """
     # Try to duplicate non-existent session
-    r = _post(TEST_BASE, '/api/session/duplicate', {'session_id': 'nonexistent_xyz'})
+    r = _post(TEST_BASE, "/api/session/duplicate", {"session_id": "nonexistent_xyz"})
 
     # Should return an error (could be auth error or not found)
-    assert 'error' in r, "Should return error when session not found"
+    assert "error" in r, "Should return error when session not found"
     # Check that we got some kind of error response
-    assert r.get('error') is not None or 'error' in r, \
+    assert r.get("error") is not None or "error" in r, (
         f"Should return error when session not found. Got: {r}"
+    )
 
 
 def test_duplicate_session_handles_empty_session_id(cleanup_test_sessions):
@@ -57,9 +52,9 @@ def test_duplicate_session_handles_empty_session_id(cleanup_test_sessions):
     Test that duplicate endpoint returns error when session_id is empty string.
     """
     # Try to duplicate with empty session_id
-    r = _post(TEST_BASE, '/api/session/duplicate', {'session_id': ''})
+    r = _post(TEST_BASE, "/api/session/duplicate", {"session_id": ""})
 
-    assert 'error' in r, "Should return error when session_id is empty"
+    assert "error" in r, "Should return error when session_id is empty"
 
 
 def test_duplicate_session_endpoint_exists():
@@ -67,19 +62,20 @@ def test_duplicate_session_endpoint_exists():
     Test that the duplicate endpoint is registered.
     """
     # This test verifies that the endpoint exists in routes.py
-    with open('api/routes.py', 'r', encoding='utf-8') as f:
+    with open("api/routes.py", "r", encoding="utf-8") as f:
         content = f.read()
 
-    assert '/api/session/duplicate' in content, \
+    assert "/api/session/duplicate" in content, (
         "Duplicate endpoint should be registered in routes.py"
+    )
 
     # Verify the endpoint calls Session.load
-    assert 'Session.load(sid)' in content or 'session = Session.load' in content, \
+    assert "Session.load(sid)" in content or "session = Session.load" in content, (
         "Endpoint should load the session from database"
+    )
 
     # Verify the endpoint creates a copy
-    assert 'copied_session' in content, \
-        "Endpoint should create a copied session"
+    assert "copied_session" in content, "Endpoint should create a copied session"
 
 
 def test_duplicate_creates_independent_session():
@@ -88,7 +84,7 @@ def test_duplicate_creates_independent_session():
 
     This test verifies the implementation logic by inspecting routes.py.
     """
-    with open('api/routes.py', 'r', encoding='utf-8') as f:
+    with open("api/routes.py", "r", encoding="utf-8") as f:
         content = f.read()
 
     # Verify that parent_session_id is NOT set (this would make it a fork)
@@ -97,153 +93,165 @@ def test_duplicate_creates_independent_session():
     assert duplicate_start != -1, "Duplicate endpoint not found"
 
     # Extract the duplicate endpoint code (next few lines)
-    lines = content[duplicate_start:].split('\n')
-    endpoint_code = '\n'.join(lines[:80])
+    lines = content[duplicate_start:].split("\n")
+    endpoint_code = "\n".join(lines[:80])
 
     # Verify that parent_session_id is NOT passed to Session constructor
-    assert 'parent_session_id' not in endpoint_code, \
+    assert "parent_session_id" not in endpoint_code, (
         "Duplicate should NOT set parent_session_id (that would make it a fork)"
+    )
 
     # Verify that messages are copied (accept both plain assignment and the
     # corrected deepcopy form added May 2 2026).
-    assert 'messages=session.messages' in endpoint_code or \
-           'messages=copy.deepcopy(session.messages)' in endpoint_code or \
-           'messages=copied_session.messages' in endpoint_code, \
-        "Messages should be copied to duplicate"
+    assert (
+        "messages=session.messages" in endpoint_code
+        or "messages=copy.deepcopy(session.messages)" in endpoint_code
+        or "messages=copied_session.messages" in endpoint_code
+    ), "Messages should be copied to duplicate"
 
     # Verify that title includes (copy)
-    assert '(copy)' in endpoint_code, \
-        "Duplicate title should include '(copy)' suffix"
+    assert "(copy)" in endpoint_code, "Duplicate title should include '(copy)' suffix"
 
 
 def test_duplicate_session_copies_title_logic():
     """
     Test that the duplicate session title includes (copy) suffix.
     """
-    with open('api/routes.py', 'r', encoding='utf-8') as f:
+    with open("api/routes.py", "r", encoding="utf-8") as f:
         content = f.read()
 
     duplicate_start = content.find('if parsed.path == "/api/session/duplicate":')
     assert duplicate_start != -1, "Duplicate endpoint not found"
 
-    lines = content[duplicate_start:].split('\n')
-    endpoint_code = '\n'.join(lines[:80])
+    lines = content[duplicate_start:].split("\n")
+    endpoint_code = "\n".join(lines[:80])
 
     # Verify title includes (copy). Accept the original `session.title + " (copy)"`
     # form OR the May 2 2026 SF-3 hardened form `(session.title or "Untitled") + " (copy)"`
     # which guards against legacy null titles.
-    assert 'session.title + " (copy)"' in endpoint_code or \
-           '(session.title or "Untitled") + " (copy)"' in endpoint_code or \
-           'session.title + \' (copy\')' in endpoint_code or \
-           'title=session.title + " (copy)"' in endpoint_code, \
-        f"Title should include '(copy)' suffix. Got: {endpoint_code}"
+    assert (
+        'session.title + " (copy)"' in endpoint_code
+        or '(session.title or "Untitled") + " (copy)"' in endpoint_code
+        or "session.title + ' (copy')" in endpoint_code
+        or 'title=session.title + " (copy)"' in endpoint_code
+    ), f"Title should include '(copy)' suffix. Got: {endpoint_code}"
 
 
 def test_duplicate_session_copies_messages_logic():
     """
     Test that the duplicate session copies all messages.
     """
-    with open('api/routes.py', 'r', encoding='utf-8') as f:
+    with open("api/routes.py", "r", encoding="utf-8") as f:
         content = f.read()
 
     duplicate_start = content.find('if parsed.path == "/api/session/duplicate":')
     assert duplicate_start != -1, "Duplicate endpoint not found"
 
-    lines = content[duplicate_start:].split('\n')
-    endpoint_code = '\n'.join(lines[:80])
+    lines = content[duplicate_start:].split("\n")
+    endpoint_code = "\n".join(lines[:80])
 
     # Verify messages are copied from original session.  Accept either the
     # plain assignment (insufficient — see test_duplicate_runtime_messages_independence)
     # or the proper deepcopy form (the May 2 2026 fix).
-    assert 'messages=session.messages' in endpoint_code or \
-           'messages=copy.deepcopy(session.messages)' in endpoint_code, \
-        f"Messages should be copied from original. Got: {endpoint_code}"
+    assert (
+        "messages=session.messages" in endpoint_code
+        or "messages=copy.deepcopy(session.messages)" in endpoint_code
+    ), f"Messages should be copied from original. Got: {endpoint_code}"
 
 
 def test_duplicate_session_copies_model_logic():
     """
     Test that the duplicate session copies the model.
     """
-    with open('api/routes.py', 'r', encoding='utf-8') as f:
+    with open("api/routes.py", "r", encoding="utf-8") as f:
         content = f.read()
 
     duplicate_start = content.find('if parsed.path == "/api/session/duplicate":')
     assert duplicate_start != -1, "Duplicate endpoint not found"
 
-    lines = content[duplicate_start:].split('\n')
-    endpoint_code = '\n'.join(lines[:80])
+    lines = content[duplicate_start:].split("\n")
+    endpoint_code = "\n".join(lines[:80])
 
     # Verify model is copied
-    assert 'model=session.model' in endpoint_code, \
+    assert "model=session.model" in endpoint_code, (
         f"Model should be copied. Got: {endpoint_code}"
+    )
 
 
 def test_duplicate_session_copies_workspace_logic():
     """
     Test that the duplicate session copies the workspace.
     """
-    with open('api/routes.py', 'r', encoding='utf-8') as f:
+    with open("api/routes.py", "r", encoding="utf-8") as f:
         content = f.read()
 
     duplicate_start = content.find('if parsed.path == "/api/session/duplicate":')
     assert duplicate_start != -1, "Duplicate endpoint not found"
 
-    lines = content[duplicate_start:].split('\n')
-    endpoint_code = '\n'.join(lines[:80])
+    lines = content[duplicate_start:].split("\n")
+    endpoint_code = "\n".join(lines[:80])
 
     # Verify workspace is copied
-    assert 'workspace=session.workspace' in endpoint_code, \
+    assert "workspace=session.workspace" in endpoint_code, (
         f"Workspace should be copied. Got: {endpoint_code}"
+    )
 
 
 def test_duplicate_session_copies_all_session_properties():
     """
     Test that the duplicate session copies all properties.
     """
-    with open('api/routes.py', 'r', encoding='utf-8') as f:
+    with open("api/routes.py", "r", encoding="utf-8") as f:
         content = f.read()
 
     duplicate_start = content.find('if parsed.path == "/api/session/duplicate":')
     assert duplicate_start != -1, "Duplicate endpoint not found"
 
-    lines = content[duplicate_start:].split('\n')
-    endpoint_code = '\n'.join(lines[:80])
+    lines = content[duplicate_start:].split("\n")
+    endpoint_code = "\n".join(lines[:80])
 
     # Extract the copied_session = Session( lines
-    session_construction_start = endpoint_code.find('copied_session = Session(')
+    session_construction_start = endpoint_code.find("copied_session = Session(")
     assert session_construction_start != -1, "Should construct copied_session"
 
     # Get the construction block
-    construction_block = endpoint_code[session_construction_start:session_construction_start+1600]
+    construction_block = endpoint_code[
+        session_construction_start : session_construction_start + 1600
+    ]
 
     # Verify all key properties are copied
     # `title` accepts either the original `title=session.title` or the
     # SF-3 hardened form `title=(session.title or "Untitled")` (May 2 2026).
     properties_to_check = [
-        'session_id=uuid.uuid4',  # New unique ID
-        'workspace=session.workspace',
-        'model=session.model',
-        'model_provider=session.model_provider',
+        "session_id=uuid.uuid4",  # New unique ID
+        "workspace=session.workspace",
+        "model=session.model",
+        "model_provider=session.model_provider",
     ]
 
     for prop in properties_to_check:
-        assert prop in construction_block, \
+        assert prop in construction_block, (
             f"Property should be copied: {prop}. Got: {construction_block[:300]}"
+        )
 
-    assert 'title=session.title' in construction_block or \
-           'title=(session.title or "Untitled")' in construction_block, \
-        f"title must be copied (plain or guarded form). Got: {construction_block[:300]}"
+    assert (
+        "title=session.title" in construction_block
+        or 'title=(session.title or "Untitled")' in construction_block
+    ), f"title must be copied (plain or guarded form). Got: {construction_block[:300]}"
 
     # `messages` accepts either the plain assignment or the deepcopy form (May 2 2026 fix).
-    assert 'messages=session.messages' in construction_block or \
-           'messages=copy.deepcopy(session.messages)' in construction_block, \
+    assert (
+        "messages=session.messages" in construction_block
+        or "messages=copy.deepcopy(session.messages)" in construction_block
+    ), (
         f"messages must be copied (plain or deepcopy form). Got: {construction_block[:300]}"
-
+    )
 
 
 # ---------------------------------------------------------------------------
 # Runtime tests added May 2 2026 (Opus pre-release follow-up to #1462 review)
 # ---------------------------------------------------------------------------
+
 
 def test_duplicate_uses_deepcopy_for_messages():
     """The duplicate must use copy.deepcopy() for messages and tool_calls.
@@ -252,16 +260,18 @@ def test_duplicate_uses_deepcopy_for_messages():
     `messages=session.messages` was a plain reference assignment, leaving
     both sessions sharing the same list object in memory.
     """
-    with open('api/routes.py', 'r', encoding='utf-8') as f:
+    with open("api/routes.py", "r", encoding="utf-8") as f:
         content = f.read()
     duplicate_start = content.find('if parsed.path == "/api/session/duplicate":')
     assert duplicate_start != -1, "Duplicate endpoint not found"
-    lines = content[duplicate_start:].split('\n')
-    endpoint_code = '\n'.join(lines[:80])
-    assert 'copy.deepcopy(session.messages)' in endpoint_code, \
+    lines = content[duplicate_start:].split("\n")
+    endpoint_code = "\n".join(lines[:80])
+    assert "copy.deepcopy(session.messages)" in endpoint_code, (
         "duplicate must use copy.deepcopy(session.messages) — plain assignment shares list refs"
-    assert 'copy.deepcopy(session.tool_calls)' in endpoint_code, \
+    )
+    assert "copy.deepcopy(session.tool_calls)" in endpoint_code, (
         "duplicate must use copy.deepcopy(session.tool_calls) — plain assignment shares list refs"
+    )
 
 
 def test_duplicate_explicitly_persists_to_disk():
@@ -272,14 +282,15 @@ def test_duplicate_explicitly_persists_to_disk():
     sent a turn (which triggered _handle_chat_start save). Refreshing
     mid-flow lost the duplicate.
     """
-    with open('api/routes.py', 'r', encoding='utf-8') as f:
+    with open("api/routes.py", "r", encoding="utf-8") as f:
         content = f.read()
     duplicate_start = content.find('if parsed.path == "/api/session/duplicate":')
     assert duplicate_start != -1, "Duplicate endpoint not found"
-    lines = content[duplicate_start:].split('\n')
-    endpoint_code = '\n'.join(lines[:80])
-    assert 'copied_session.save()' in endpoint_code, \
+    lines = content[duplicate_start:].split("\n")
+    endpoint_code = "\n".join(lines[:80])
+    assert "copied_session.save()" in endpoint_code, (
         "duplicate must call .save() explicitly — without it the copy vanishes on refresh"
+    )
 
 
 def test_duplicate_resets_pinned_and_archived():
@@ -289,22 +300,26 @@ def test_duplicate_resets_pinned_and_archived():
     (un-archived) copy. Inheriting `archived=True` makes the duplicate
     invisible in the sidebar and users think the operation didn't work.
     """
-    with open('api/routes.py', 'r', encoding='utf-8') as f:
+    with open("api/routes.py", "r", encoding="utf-8") as f:
         content = f.read()
     duplicate_start = content.find('if parsed.path == "/api/session/duplicate":')
     assert duplicate_start != -1, "Duplicate endpoint not found"
-    lines = content[duplicate_start:].split('\n')
-    endpoint_code = '\n'.join(lines[:80])
+    lines = content[duplicate_start:].split("\n")
+    endpoint_code = "\n".join(lines[:80])
     # Both must be hard-coded to False, NOT inherited from `session.pinned`/`session.archived`
-    assert 'pinned=False' in endpoint_code, \
+    assert "pinned=False" in endpoint_code, (
         "duplicate must reset pinned=False — duplicating shouldn't propagate pin state"
-    assert 'archived=False' in endpoint_code, \
+    )
+    assert "archived=False" in endpoint_code, (
         "duplicate must reset archived=False — archived duplicates are invisible in the sidebar"
+    )
     # Negative: the old (buggy) `pinned=session.pinned` form must not still be there
-    assert 'pinned=session.pinned' not in endpoint_code, \
+    assert "pinned=session.pinned" not in endpoint_code, (
         "duplicate must NOT inherit pinned from source session"
-    assert 'archived=session.archived' not in endpoint_code, \
+    )
+    assert "archived=session.archived" not in endpoint_code, (
         "duplicate must NOT inherit archived from source session"
+    )
 
 
 def test_duplicate_returns_404_when_session_not_found():
@@ -313,25 +328,30 @@ def test_duplicate_returns_404_when_session_not_found():
     Pre-fix, `bad(handler, "Session not found")` defaulted to status=400.
     A missing resource is conceptually 404, not "malformed request".
     """
-    with open('api/routes.py', 'r', encoding='utf-8') as f:
+    with open("api/routes.py", "r", encoding="utf-8") as f:
         content = f.read()
     duplicate_start = content.find('if parsed.path == "/api/session/duplicate":')
     assert duplicate_start != -1, "Duplicate endpoint not found"
-    lines = content[duplicate_start:].split('\n')
-    endpoint_code = '\n'.join(lines[:80])
-    assert 'bad(handler, "Session not found", status=404)' in endpoint_code, \
+    lines = content[duplicate_start:].split("\n")
+    endpoint_code = "\n".join(lines[:80])
+    assert 'bad(handler, "Session not found", status=404)' in endpoint_code, (
         "missing session must return status=404, not the default 400"
+    )
 
 
 def test_duplicate_local_imports_removed():
     """Style: `import uuid` and `import time` should not be re-imported inside
     the handler — both are already at the top of routes.py."""
-    with open('api/routes.py', 'r', encoding='utf-8') as f:
+    with open("api/routes.py", "r", encoding="utf-8") as f:
         content = f.read()
     duplicate_start = content.find('if parsed.path == "/api/session/duplicate":')
     assert duplicate_start != -1, "Duplicate endpoint not found"
     # Only check the next ~10 lines — the local imports were right at the top of the handler
-    lines = content[duplicate_start:].split('\n')
-    handler_top = '\n'.join(lines[:10])
-    assert '            import uuid' not in handler_top, "redundant `import uuid` inside handler"
-    assert '            import time' not in handler_top, "redundant `import time` inside handler"
+    lines = content[duplicate_start:].split("\n")
+    handler_top = "\n".join(lines[:10])
+    assert "            import uuid" not in handler_top, (
+        "redundant `import uuid` inside handler"
+    )
+    assert "            import time" not in handler_top, (
+        "redundant `import time` inside handler"
+    )

--- a/tests/test_session_endless_scroll.py
+++ b/tests/test_session_endless_scroll.py
@@ -15,7 +15,10 @@ def test_endless_scroll_is_opt_in_setting():
     assert 'id="settingsSessionEndlessScroll"' in INDEX_HTML
     assert 'data-i18n="settings_label_session_endless_scroll"' in INDEX_HTML
     assert 'data-i18n="settings_desc_session_endless_scroll"' in INDEX_HTML
-    assert "session_endless_scroll: !!($('settingsSessionEndlessScroll')||{}).checked" in PANELS_JS
+    assert (
+        "session_endless_scroll: !!($('settingsSessionEndlessScroll')||{}).checked"
+        in PANELS_JS
+    )
     assert "window._sessionEndlessScrollEnabled=!!s.session_endless_scroll" in BOOT_JS
     assert "window._sessionEndlessScrollEnabled=false" in BOOT_JS
 
@@ -28,5 +31,9 @@ def test_scroll_listener_prefetches_older_messages_only_when_enabled():
 
 
 def test_endless_scroll_i18n_keys_exist_for_each_locale():
-    assert I18N_JS.count("settings_label_session_endless_scroll") == I18N_JS.count("settings_label_workspace_panel_open")
-    assert I18N_JS.count("settings_desc_session_endless_scroll") == I18N_JS.count("settings_desc_workspace_panel_open")
+    assert I18N_JS.count("settings_label_session_endless_scroll") == I18N_JS.count(
+        "settings_label_workspace_panel_open"
+    )
+    assert I18N_JS.count("settings_desc_session_endless_scroll") == I18N_JS.count(
+        "settings_desc_workspace_panel_open"
+    )

--- a/tests/test_session_import_cli_fallback_model.py
+++ b/tests/test_session_import_cli_fallback_model.py
@@ -40,7 +40,7 @@ def test_import_cli_initializes_model_before_metadata_loop():
         # Allow single quotes too.
         init_idx = handler.find("model = 'unknown'")
     assert init_idx != -1, (
-        "Expected `model = \"unknown\"` initialization in "
+        'Expected `model = "unknown"` initialization in '
         "_handle_session_import_cli before the metadata loop. Without it, "
         "import crashes when the session has messages but no metadata row."
     )
@@ -69,7 +69,9 @@ def test_import_cli_passes_model_to_import_helper():
     )
 
 
-def test_session_import_cli_refresh_matches_messages_despite_timestamp_type_differences(monkeypatch):
+def test_session_import_cli_refresh_matches_messages_despite_timestamp_type_differences(
+    monkeypatch,
+):
     """Refreshing an imported session should still extend when timestamps differ only by type.
 
     Existing WebUI messages can use integer timestamps while CLI refresh returns
@@ -106,12 +108,38 @@ def test_session_import_cli_refresh_matches_messages_despite_timestamp_type_diff
         {"role": "assistant", "content": "next", "timestamp": 1710000002.0},
     ]
 
-    monkeypatch.setattr(routes.Session, "load", classmethod(lambda _cls, sid: existing if sid == session_id else None))
+    monkeypatch.setattr(
+        routes.Session,
+        "load",
+        classmethod(lambda _cls, sid: existing if sid == session_id else None),
+    )
     monkeypatch.setattr(routes, "require", lambda body, *keys: None)
-    monkeypatch.setattr(routes, "bad", lambda _handler, msg, status=400: {"ok": False, "error": msg, "status": status})
-    monkeypatch.setattr(routes, "j", lambda _handler, payload, status=200, extra_headers=None: payload)
-    monkeypatch.setattr(routes, "get_cli_session_messages", lambda sid: fresh if sid == session_id else [])
-    monkeypatch.setattr(routes, "get_cli_sessions", lambda: [{"session_id": session_id, "source_tag": "weixin", "raw_source": "weixin", "session_source": "messaging", "source_label": "WeChat"}])
+    monkeypatch.setattr(
+        routes,
+        "bad",
+        lambda _handler, msg, status=400: {"ok": False, "error": msg, "status": status},
+    )
+    monkeypatch.setattr(
+        routes, "j", lambda _handler, payload, status=200, extra_headers=None: payload
+    )
+    monkeypatch.setattr(
+        routes,
+        "get_cli_session_messages",
+        lambda sid: fresh if sid == session_id else [],
+    )
+    monkeypatch.setattr(
+        routes,
+        "get_cli_sessions",
+        lambda: [
+            {
+                "session_id": session_id,
+                "source_tag": "weixin",
+                "raw_source": "weixin",
+                "session_source": "messaging",
+                "source_label": "WeChat",
+            }
+        ],
+    )
 
     response = routes._handle_session_import_cli(object(), {"session_id": session_id})
 
@@ -121,7 +149,9 @@ def test_session_import_cli_refresh_matches_messages_despite_timestamp_type_diff
     assert save_calls == [False]
 
 
-def test_session_import_cli_refresh_rejects_prefix_if_non_timing_content_diverges(monkeypatch):
+def test_session_import_cli_refresh_rejects_prefix_if_non_timing_content_diverges(
+    monkeypatch,
+):
     """Only true prefixes should be treated as unchanged history during refresh.
 
     If the refreshed message body diverges, we should keep the existing in-memory
@@ -158,12 +188,38 @@ def test_session_import_cli_refresh_rejects_prefix_if_non_timing_content_diverge
         {"role": "assistant", "content": "next", "timestamp": 1710000002.0},
     ]
 
-    monkeypatch.setattr(routes.Session, "load", classmethod(lambda _cls, sid: existing if sid == session_id else None))
+    monkeypatch.setattr(
+        routes.Session,
+        "load",
+        classmethod(lambda _cls, sid: existing if sid == session_id else None),
+    )
     monkeypatch.setattr(routes, "require", lambda body, *keys: None)
-    monkeypatch.setattr(routes, "bad", lambda _handler, msg, status=400: {"ok": False, "error": msg, "status": status})
-    monkeypatch.setattr(routes, "j", lambda _handler, payload, status=200, extra_headers=None: payload)
-    monkeypatch.setattr(routes, "get_cli_session_messages", lambda sid: fresh if sid == session_id else [])
-    monkeypatch.setattr(routes, "get_cli_sessions", lambda: [{"session_id": session_id, "source_tag": "telegram", "raw_source": "telegram", "session_source": "messaging", "source_label": "Telegram"}])
+    monkeypatch.setattr(
+        routes,
+        "bad",
+        lambda _handler, msg, status=400: {"ok": False, "error": msg, "status": status},
+    )
+    monkeypatch.setattr(
+        routes, "j", lambda _handler, payload, status=200, extra_headers=None: payload
+    )
+    monkeypatch.setattr(
+        routes,
+        "get_cli_session_messages",
+        lambda sid: fresh if sid == session_id else [],
+    )
+    monkeypatch.setattr(
+        routes,
+        "get_cli_sessions",
+        lambda: [
+            {
+                "session_id": session_id,
+                "source_tag": "telegram",
+                "raw_source": "telegram",
+                "session_source": "messaging",
+                "source_label": "Telegram",
+            }
+        ],
+    )
 
     response = routes._handle_session_import_cli(object(), {"session_id": session_id})
 
@@ -191,7 +247,11 @@ def test_session_import_cli_preserves_parent_metadata_on_existing_import(monkeyp
             self.is_cli_session = True
 
         def compact(self):
-            return {"session_id": session_id, "title": "Imported", "parent_session_id": self.parent_session_id}
+            return {
+                "session_id": session_id,
+                "title": "Imported",
+                "parent_session_id": self.parent_session_id,
+            }
 
         def save(self, touch_updated_at=False):
             save_calls.append(touch_updated_at)
@@ -199,21 +259,33 @@ def test_session_import_cli_preserves_parent_metadata_on_existing_import(monkeyp
     save_calls = []
     existing = FakeSession()
 
-    monkeypatch.setattr(routes.Session, "load", classmethod(lambda _cls, sid: existing if sid == session_id else None))
+    monkeypatch.setattr(
+        routes.Session,
+        "load",
+        classmethod(lambda _cls, sid: existing if sid == session_id else None),
+    )
     monkeypatch.setattr(routes, "require", lambda body, *keys: None)
-    monkeypatch.setattr(routes, "j", lambda _handler, payload, status=200, extra_headers=None: payload)
-    monkeypatch.setattr(routes, "get_cli_session_messages", lambda sid: existing.messages if sid == session_id else [])
+    monkeypatch.setattr(
+        routes, "j", lambda _handler, payload, status=200, extra_headers=None: payload
+    )
+    monkeypatch.setattr(
+        routes,
+        "get_cli_session_messages",
+        lambda sid: existing.messages if sid == session_id else [],
+    )
     monkeypatch.setattr(
         routes,
         "get_cli_sessions",
-        lambda: [{
-            "session_id": session_id,
-            "source_tag": "telegram",
-            "raw_source": "telegram",
-            "session_source": "messaging",
-            "source_label": "Telegram",
-            "parent_session_id": parent_id,
-        }],
+        lambda: [
+            {
+                "session_id": session_id,
+                "source_tag": "telegram",
+                "raw_source": "telegram",
+                "session_source": "messaging",
+                "source_label": "Telegram",
+                "parent_session_id": parent_id,
+            }
+        ],
     )
 
     response = routes._handle_session_import_cli(object(), {"session_id": session_id})
@@ -234,25 +306,37 @@ def test_read_only_import_payload_includes_parent_session_id(monkeypatch):
 
     monkeypatch.setattr(routes.Session, "load", classmethod(lambda _cls, sid: None))
     monkeypatch.setattr(routes, "require", lambda body, *keys: None)
-    monkeypatch.setattr(routes, "bad", lambda _handler, msg, status=400: {"ok": False, "error": msg, "status": status})
-    monkeypatch.setattr(routes, "j", lambda _handler, payload, status=200, extra_headers=None: payload)
-    monkeypatch.setattr(routes, "get_cli_session_messages", lambda sid: messages if sid == session_id else [])
+    monkeypatch.setattr(
+        routes,
+        "bad",
+        lambda _handler, msg, status=400: {"ok": False, "error": msg, "status": status},
+    )
+    monkeypatch.setattr(
+        routes, "j", lambda _handler, payload, status=200, extra_headers=None: payload
+    )
+    monkeypatch.setattr(
+        routes,
+        "get_cli_session_messages",
+        lambda sid: messages if sid == session_id else [],
+    )
     monkeypatch.setattr(
         routes,
         "get_cli_sessions",
-        lambda: [{
-            "session_id": session_id,
-            "title": "Read-only child",
-            "model": "test-model",
-            "created_at": 1.0,
-            "updated_at": 2.0,
-            "source_tag": "discord",
-            "raw_source": "discord",
-            "session_source": "messaging",
-            "source_label": "Discord",
-            "parent_session_id": parent_id,
-            "read_only": True,
-        }],
+        lambda: [
+            {
+                "session_id": session_id,
+                "title": "Read-only child",
+                "model": "test-model",
+                "created_at": 1.0,
+                "updated_at": 2.0,
+                "source_tag": "discord",
+                "raw_source": "discord",
+                "session_source": "messaging",
+                "source_label": "Discord",
+                "parent_session_id": parent_id,
+                "read_only": True,
+            }
+        ],
     )
 
     response = routes._handle_session_import_cli(object(), {"session_id": session_id})
@@ -279,5 +363,5 @@ def test_messaging_session_loader_prefers_longer_sidecar_transcript():
     handler = _extract_handler("handle_get")
     old = "if is_messaging_session and cli_messages:\n                    _all_msgs = cli_messages"
     assert old not in handler
-    assert "sidecar_messages = getattr(s, \"messages\", []) or []" in handler
+    assert 'sidecar_messages = getattr(s, "messages", []) or []' in handler
     assert "len(sidecar_messages) > len(cli_messages)" in handler

--- a/tests/test_session_import_cli_sse_refresh.py
+++ b/tests/test_session_import_cli_sse_refresh.py
@@ -15,7 +15,10 @@ def test_sse_import_cli_guard_skips_shorter_transcript_overwrite():
     assert "const prev = S.messages.length;" in sse_block
     assert "const next = res.session.messages.filter(m => m && m.role);" in sse_block
     assert "if (next.length < prev) return;" in sse_block
-    assert "if (prev > 0 && !_isCliImportRefreshPrefixMatch(S.messages, next)) return;" in sse_block
+    assert (
+        "if (prev > 0 && !_isCliImportRefreshPrefixMatch(S.messages, next)) return;"
+        in sse_block
+    )
     assert "S.messages = next;" in sse_block
 
 
@@ -24,6 +27,9 @@ def test_sse_import_cli_refresh_prefix_helper_ignores_timestamps():
     assert "function _normalizeMessageForCliImportComparison(message)" in SESSIONS_JS
     assert "delete clone.timestamp;" in SESSIONS_JS
     assert "delete clone._ts;" in SESSIONS_JS
-    assert "function _isCliImportRefreshPrefixMatch(localMessages, freshMessages)" in SESSIONS_JS
+    assert (
+        "function _isCliImportRefreshPrefixMatch(localMessages, freshMessages)"
+        in SESSIONS_JS
+    )
     assert "_normalizeMessageForCliImportComparison" in SESSIONS_JS
     assert "localMessages.length > freshMessages.length" in SESSIONS_JS

--- a/tests/test_session_index.py
+++ b/tests/test_session_index.py
@@ -10,10 +10,10 @@ Validates:
   - Atomic write leaves no .tmp file behind
   - Deadlock guard on fallback path
 """
+
 import json
 import os
 import threading
-import time
 from pathlib import Path
 from unittest.mock import patch
 
@@ -47,7 +47,9 @@ def _isolate_session_dir(tmp_path, monkeypatch):
 
 def _make_session(session_id, title="Untitled", updated_at=None):
     """Helper to create a Session with a known ID and title."""
-    s = Session(session_id=session_id, title=title, messages=[{"role": "user", "content": "hi"}])
+    s = Session(
+        session_id=session_id, title=title, messages=[{"role": "user", "content": "hi"}]
+    )
     if updated_at is not None:
         s.updated_at = updated_at
     return s
@@ -91,7 +93,9 @@ def test_all_sessions_backfills_last_message_at_for_legacy_index_rows():
         updated_at=300.0,
         messages=[{"role": "assistant", "content": "reply", "_ts": 100.0}],
     )
-    s.path.write_text(json.dumps(s.__dict__, ensure_ascii=False, indent=2), encoding="utf-8")
+    s.path.write_text(
+        json.dumps(s.__dict__, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
     _write_index_file(
         index_file,
         [
@@ -125,12 +129,12 @@ def test_all_sessions_backfills_last_message_at_for_legacy_index_rows():
 
 # ── 6. test_incremental_patch_correctness ─────────────────────────────────
 
+
 def test_incremental_patch_correctness():
     """Pre-write an index with 3 sessions (A, B, C). Create an updated
     Session for B with a new title. Call _write_session_index(updates=[B]).
     Verify A and C are unchanged, B has the new title, sort order preserved.
     """
-
 
     # We need to get the fixture values — but since it's autouse, the monkeypatch
     # has already been applied. Access the patched values directly.
@@ -144,7 +148,9 @@ def test_incremental_patch_correctness():
 
     # Write session files to disk (so full rebuild can find them)
     for s in (sA, sB, sC):
-        s.path.write_text(json.dumps(s.__dict__, ensure_ascii=False, indent=2), encoding="utf-8")
+        s.path.write_text(
+            json.dumps(s.__dict__, ensure_ascii=False, indent=2), encoding="utf-8"
+        )
 
     # Build initial index
     _write_session_index(updates=None)
@@ -176,6 +182,7 @@ def test_incremental_patch_correctness():
 
 # ── 7. test_new_session_appended_to_index ─────────────────────────────────
 
+
 def test_new_session_appended_to_index():
     """Pre-write index with sessions A, B. Call _write_session_index(updates=[C])
     where C is not in the existing index. Verify C appears in the index.
@@ -187,13 +194,17 @@ def test_new_session_appended_to_index():
     sB = _make_session("sess_b", "Bravo", updated_at=200.0)
 
     for s in (sA, sB):
-        s.path.write_text(json.dumps(s.__dict__, ensure_ascii=False, indent=2), encoding="utf-8")
+        s.path.write_text(
+            json.dumps(s.__dict__, ensure_ascii=False, indent=2), encoding="utf-8"
+        )
 
     _write_session_index(updates=None)
 
     # Create a new session C not in the index
     sC = _make_session("sess_c", "Charlie", updated_at=300.0)
-    sC.path.write_text(json.dumps(sC.__dict__, ensure_ascii=False, indent=2), encoding="utf-8")
+    sC.path.write_text(
+        json.dumps(sC.__dict__, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
 
     _write_session_index(updates=[sC])
 
@@ -226,7 +237,9 @@ def test_incremental_update_prunes_stale_entries():
     _write_index_file(index_file, [stale])
 
     sA = _make_session("sess_a", "Alpha", updated_at=200.0)
-    sA.path.write_text(json.dumps(sA.__dict__, ensure_ascii=False, indent=2), encoding="utf-8")
+    sA.path.write_text(
+        json.dumps(sA.__dict__, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
 
     _write_session_index(updates=[sA])
 
@@ -248,7 +261,9 @@ def test_load_metadata_only_does_not_parse_large_message_body():
     )
     s.save()
 
-    with patch.object(Session, "load", side_effect=AssertionError("full load should not run")):
+    with patch.object(
+        Session, "load", side_effect=AssertionError("full load should not run")
+    ):
         meta = Session.load_metadata_only("sess_large")
 
     assert meta is not None
@@ -293,6 +308,7 @@ def test_session_save_does_not_persist_metadata_message_count_hint():
 
 # ── 8. test_first_call_full_rebuild ──────────────────────────────────────
 
+
 def test_first_call_full_rebuild():
     """When no index file exists, calling _write_session_index(updates=[session])
     should fall back to full rebuild and create the index.
@@ -304,7 +320,9 @@ def test_first_call_full_rebuild():
     assert not index_file.exists()
 
     sA = _make_session("sess_a", "Alpha", updated_at=100.0)
-    sA.path.write_text(json.dumps(sA.__dict__, ensure_ascii=False, indent=2), encoding="utf-8")
+    sA.path.write_text(
+        json.dumps(sA.__dict__, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
 
     # Call with updates — should trigger full rebuild since index doesn't exist
     _write_session_index(updates=[sA])
@@ -319,6 +337,7 @@ def test_first_call_full_rebuild():
 
 # ── 9. test_corrupt_index_fallback ────────────────────────────────────────
 
+
 def test_corrupt_index_fallback():
     """Write garbage/invalid JSON to SESSION_INDEX_FILE. Call
     _write_session_index(updates=[session]). Verify it falls back to
@@ -331,7 +350,9 @@ def test_corrupt_index_fallback():
     index_file.write_text("THIS IS NOT JSON {{{", encoding="utf-8")
 
     sA = _make_session("sess_a", "Alpha", updated_at=100.0)
-    sA.path.write_text(json.dumps(sA.__dict__, ensure_ascii=False, indent=2), encoding="utf-8")
+    sA.path.write_text(
+        json.dumps(sA.__dict__, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
 
     # Should not raise; should fall back to full rebuild
     _write_session_index(updates=[sA])
@@ -347,6 +368,7 @@ def test_corrupt_index_fallback():
 
 # ── 10. test_concurrent_saves_dont_lose_data ────────────────────────────
 
+
 def test_concurrent_saves_dont_lose_data():
     """Create 2 threads, each calling Session.save() on different sessions
     with a pre-existing index. Use a threading.Event barrier to force them
@@ -359,7 +381,9 @@ def test_concurrent_saves_dont_lose_data():
     sB = _make_session("sess_b", "Bravo", updated_at=200.0)
 
     for s in (sA, sB):
-        s.path.write_text(json.dumps(s.__dict__, ensure_ascii=False, indent=2), encoding="utf-8")
+        s.path.write_text(
+            json.dumps(s.__dict__, ensure_ascii=False, indent=2), encoding="utf-8"
+        )
 
     # Build initial index
     _write_session_index(updates=None)
@@ -402,11 +426,16 @@ def test_concurrent_saves_dont_lose_data():
 
     assert "sess_a" in index_map, "Session A should be in index"
     assert "sess_b" in index_map, "Session B should be in index"
-    assert index_map["sess_a"]["title"] == "Alpha V2", "Session A title should be updated"
-    assert index_map["sess_b"]["title"] == "Bravo V2", "Session B title should be updated"
+    assert index_map["sess_a"]["title"] == "Alpha V2", (
+        "Session A title should be updated"
+    )
+    assert index_map["sess_b"]["title"] == "Bravo V2", (
+        "Session B title should be updated"
+    )
 
 
 # ── 11. test_atomic_write_no_tmp_remains ─────────────────────────────────
+
 
 def test_atomic_write_no_tmp_remains():
     """After _write_session_index completes, no .tmp file should remain
@@ -416,7 +445,9 @@ def test_atomic_write_no_tmp_remains():
     index_file = models.SESSION_INDEX_FILE
 
     sA = _make_session("sess_a", "Alpha", updated_at=100.0)
-    sA.path.write_text(json.dumps(sA.__dict__, ensure_ascii=False, indent=2), encoding="utf-8")
+    sA.path.write_text(
+        json.dumps(sA.__dict__, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
 
     _write_session_index(updates=[sA])
 
@@ -430,10 +461,13 @@ def test_atomic_write_no_tmp_remains():
     _write_session_index(updates=[sA])
 
     tmp_files = list(session_dir.glob("*.tmp"))
-    assert len(tmp_files) == 0, f"Unexpected .tmp files after incremental write: {tmp_files}"
+    assert len(tmp_files) == 0, (
+        f"Unexpected .tmp files after incremental write: {tmp_files}"
+    )
 
 
 # ── 12. test_deadlock_guard_on_fallback ──────────────────────────────────
+
 
 def test_deadlock_guard_on_fallback():
     """Mock the index file read to raise an exception, then verify
@@ -446,14 +480,27 @@ def test_deadlock_guard_on_fallback():
     index_file = models.SESSION_INDEX_FILE
 
     # Create a valid index file so the incremental path is attempted
-    _write_index_file(index_file, [
-        {"session_id": "sess_a", "title": "Alpha", "updated_at": 100.0,
-         "workspace": "/tmp", "model": "test", "message_count": 0,
-         "created_at": 100.0, "pinned": False, "archived": False},
-    ])
+    _write_index_file(
+        index_file,
+        [
+            {
+                "session_id": "sess_a",
+                "title": "Alpha",
+                "updated_at": 100.0,
+                "workspace": "/tmp",
+                "model": "test",
+                "message_count": 0,
+                "created_at": 100.0,
+                "pinned": False,
+                "archived": False,
+            },
+        ],
+    )
 
     sB = _make_session("sess_b", "Bravo", updated_at=200.0)
-    sB.path.write_text(json.dumps(sB.__dict__, ensure_ascii=False, indent=2), encoding="utf-8")
+    sB.path.write_text(
+        json.dumps(sB.__dict__, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
 
     # Make the index file read raise an exception to trigger fallback
     original_read_text = Path.read_text
@@ -500,7 +547,9 @@ def test_incremental_index_disk_io_runs_outside_lock(monkeypatch):
     index_file = models.SESSION_INDEX_FILE
 
     sA = _make_session("sess_a", "Alpha", updated_at=100.0)
-    sA.path.write_text(json.dumps(sA.__dict__, ensure_ascii=False, indent=2), encoding="utf-8")
+    sA.path.write_text(
+        json.dumps(sA.__dict__, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
     _write_session_index(updates=None)  # seed index
 
     sA.title = "Alpha V2"
@@ -526,7 +575,9 @@ def test_incremental_index_disk_io_runs_outside_lock(monkeypatch):
 def test_full_rebuild_index_disk_io_runs_outside_lock(monkeypatch):
     """Full-rebuild disk I/O (fsync/replace) must run after releasing LOCK."""
     sA = _make_session("sess_a", "Alpha", updated_at=100.0)
-    sA.path.write_text(json.dumps(sA.__dict__, ensure_ascii=False, indent=2), encoding="utf-8")
+    sA.path.write_text(
+        json.dumps(sA.__dict__, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
 
     fsync_lock_states = []
     original_fsync = models.os.fsync

--- a/tests/test_session_jump_buttons.py
+++ b/tests/test_session_jump_buttons.py
@@ -29,9 +29,16 @@ def test_session_jump_buttons_are_opt_in_and_keep_existing_bottom_button():
     assert '"session_jump_buttons"' in CONFIG_PY
     assert "window._sessionJumpButtonsEnabled=!!s.session_jump_buttons" in BOOT_JS
     assert "window._sessionJumpButtonsEnabled=false" in BOOT_JS
-    assert "session_jump_buttons: !!($('settingsSessionJumpButtons')||{}).checked" in PANELS_JS
+    assert (
+        "session_jump_buttons: !!($('settingsSessionJumpButtons')||{}).checked"
+        in PANELS_JS
+    )
 
-    scroll_listener = UI_JS[UI_JS.index("el.addEventListener('scroll'") : UI_JS.index("})();", UI_JS.index("el.addEventListener('scroll'"))]
+    scroll_listener = UI_JS[
+        UI_JS.index("el.addEventListener('scroll'") : UI_JS.index(
+            "})();", UI_JS.index("el.addEventListener('scroll'")
+        )
+    ]
     assert "if(btn) btn.style.display=_scrollPinned?'none':'flex'" in scroll_listener
     assert "!_isSessionJumpButtonsEnabled()||_scrollPinned" not in UI_JS
 
@@ -42,16 +49,22 @@ def test_jump_to_session_start_button_loads_full_history_and_scrolls_top():
 
     assert 'id="jumpToSessionStartBtn"' in INDEX_HTML
     assert 'class="session-jump-btn session-jump-btn--start"' in INDEX_HTML
-    assert "data-i18n=\"session_jump_start\"" in INDEX_HTML
-    assert "data-i18n=\"session_jump_end\"" in INDEX_HTML
-    assert "data-i18n-aria-label=\"session_jump_start_label\"" in INDEX_HTML
-    assert "data-i18n-aria-label=\"session_jump_end_label\"" in INDEX_HTML
+    assert 'data-i18n="session_jump_start"' in INDEX_HTML
+    assert 'data-i18n="session_jump_end"' in INDEX_HTML
+    assert 'data-i18n-aria-label="session_jump_start_label"' in INDEX_HTML
+    assert 'data-i18n-aria-label="session_jump_end_label"' in INDEX_HTML
 
     assert "_ensureAllMessagesLoaded" in jump
-    assert "_messageRenderWindowSize=Math.max(_currentMessageRenderWindowSize(),_messageRenderableMessageCount())" in jump
+    assert (
+        "_messageRenderWindowSize=Math.max(_currentMessageRenderWindowSize(),_messageRenderableMessageCount())"
+        in jump
+    )
     assert "renderMessages({ preserveScroll:true })" in jump
     assert "container.scrollTop=0" in jump
-    assert "btn.style.display=(hasSession&&canRevealStart&&awayFromStart)?'flex':'none'" in update
+    assert (
+        "btn.style.display=(hasSession&&canRevealStart&&awayFromStart)?'flex':'none'"
+        in update
+    )
 
 
 def test_session_jump_buttons_match_pill_layout_without_regressing_default_arrow():
@@ -59,8 +72,14 @@ def test_session_jump_buttons_match_pill_layout_without_regressing_default_arrow
     assert ".session-jump-btn--start{top:16px" in STYLE_CSS
     assert ".session-jump-btn__text{display:none" in STYLE_CSS
     assert ".messages.session-nav-enabled .scroll-to-bottom-btn" in STYLE_CSS
-    assert ".messages.session-nav-enabled .session-jump-btn__text{display:inline" in STYLE_CSS
-    assert "classList.toggle('session-nav-enabled',_isSessionJumpButtonsEnabled())" in UI_JS
+    assert (
+        ".messages.session-nav-enabled .session-jump-btn__text{display:inline"
+        in STYLE_CSS
+    )
+    assert (
+        "classList.toggle('session-nav-enabled',_isSessionJumpButtonsEnabled())"
+        in UI_JS
+    )
 
 
 def test_session_jump_buttons_are_i18n_localized_in_text_tooltip_and_aria():
@@ -75,6 +94,8 @@ def test_session_jump_buttons_are_i18n_localized_in_text_tooltip_and_aria():
     for key in english_literals:
         assert I18N_JS.count(f"{key}:") >= 8, f"missing locale entries for {key}"
     for key, value in english_literals.items():
-        assert I18N_JS.count(f"{key}: '{value}'") == 1, f"non-English locale still uses English literal for {key}"
+        assert I18N_JS.count(f"{key}: '{value}'") == 1, (
+            f"non-English locale still uses English literal for {key}"
+        )
     assert "document.querySelectorAll('[data-i18n-aria-label]')" in I18N_JS
     assert "el.setAttribute('aria-label', val)" in I18N_JS

--- a/tests/test_session_lineage_collapse.py
+++ b/tests/test_session_lineage_collapse.py
@@ -1,4 +1,5 @@
 """Regression tests for sidebar lineage collapse helpers."""
+
 import json
 import shutil
 import subprocess
@@ -63,7 +64,10 @@ console.log(JSON.stringify(collapsed));
     by_sid = {row["session_id"]: row for row in collapsed}
     assert set(by_sid) == {"tip", "solo"}
     assert by_sid["tip"]["_lineage_collapsed_count"] == 2
-    assert [seg["session_id"] for seg in by_sid["tip"]["_lineage_segments"]] == ["tip", "root"]
+    assert [seg["session_id"] for seg in by_sid["tip"]["_lineage_segments"]] == [
+        "tip",
+        "root",
+    ]
 
 
 def test_sidebar_active_state_can_fall_back_to_url_session_during_boot():
@@ -167,8 +171,12 @@ console.log(JSON.stringify(collapsed));
     assert [row["session_id"] for row in collapsed] == ["seg10"]
     assert collapsed[0]["_lineage_collapsed_count"] == 4
     assert collapsed[0]["_compression_segment_count"] == 10
-    assert [seg["session_id"] for seg in collapsed[0]["_lineage_segments"]] == ["seg10", "seg9", "seg8", "seg7"]
-
+    assert [seg["session_id"] for seg in collapsed[0]["_lineage_segments"]] == [
+        "seg10",
+        "seg9",
+        "seg8",
+        "seg7",
+    ]
 
 
 def test_sidebar_attaches_child_sessions_to_collapsed_hidden_parent_lineage():
@@ -297,7 +305,9 @@ def test_lineage_segment_expansion_static_contract():
     js = SESSIONS_JS_PATH.read_text(encoding="utf-8")
     css = (REPO_ROOT / "static" / "style.css").read_text(encoding="utf-8")
     assert "const _expandedLineageKeys = new Set();" in js
-    assert "session-lineage-count,.session-lineage-segments,.session-lineage-segment" in js
+    assert (
+        "session-lineage-count,.session-lineage-segments,.session-lineage-segment" in js
+    )
     assert "segmentCountEl.setAttribute('aria-expanded'" in js
     assert "_expandedLineageKeys.has(lineageKey)" in js
     assert "_expandedLineageKeys.add(lineageKey)" in js
@@ -358,4 +368,6 @@ def test_lineage_segment_locale_keys_are_defined_for_sidebar_locales():
     ]
     locale_count = i18n.count("session_meta_messages:")
     for key in required:
-        assert i18n.count(key) >= locale_count, f"{key} missing from one or more locale blocks"
+        assert i18n.count(key) >= locale_count, (
+            f"{key} missing from one or more locale blocks"
+        )

--- a/tests/test_session_lineage_metadata_api.py
+++ b/tests/test_session_lineage_metadata_api.py
@@ -45,7 +45,16 @@ def _ensure_state_db(path):
     return conn
 
 
-def _insert_state_row(conn, sid, *, parent=None, ended_at=None, end_reason=None, started_at=None, source='webui'):
+def _insert_state_row(
+    conn,
+    sid,
+    *,
+    parent=None,
+    ended_at=None,
+    end_reason=None,
+    started_at=None,
+    source="webui",
+):
     conn.execute(
         """
         INSERT INTO sessions
@@ -61,20 +70,27 @@ def _save_webui_session(sid, *, title, updated_at):
     session = Session(
         session_id=sid,
         title=title,
-        messages=[{"role": "user", "content": "hello"}, {"role": "assistant", "content": "hi"}],
+        messages=[
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi"},
+        ],
         updated_at=updated_at,
     )
     session.save(touch_updated_at=False)
     return session
 
 
-def test_all_sessions_exposes_state_db_lineage_metadata_for_webui_json_sessions(_isolate):
+def test_all_sessions_exposes_state_db_lineage_metadata_for_webui_json_sessions(
+    _isolate,
+):
     """PR #1358 can only collapse rows when /api/sessions exposes lineage keys."""
     conn = _ensure_state_db(_isolate)
     t0 = time.time() - 100
     try:
         _save_webui_session("lineage_api_root", title="Hermes WebUI", updated_at=t0)
-        _save_webui_session("lineage_api_tip", title="Hermes WebUI #2", updated_at=t0 + 10)
+        _save_webui_session(
+            "lineage_api_tip", title="Hermes WebUI #2", updated_at=t0 + 10
+        )
         _insert_state_row(
             conn,
             "lineage_api_root",
@@ -104,7 +120,9 @@ def test_non_compression_state_db_parent_does_not_create_sidebar_lineage(_isolat
     t0 = time.time() - 100
     try:
         _save_webui_session("lineage_api_plain_parent", title="Parent", updated_at=t0)
-        _save_webui_session("lineage_api_plain_child", title="Child", updated_at=t0 + 10)
+        _save_webui_session(
+            "lineage_api_plain_child", title="Child", updated_at=t0 + 10
+        )
         _insert_state_row(
             conn,
             "lineage_api_plain_parent",
@@ -132,7 +150,6 @@ def test_non_compression_state_db_parent_does_not_create_sidebar_lineage(_isolat
         assert "_lineage_root_id" not in child
     finally:
         conn.close()
-
 
 
 def test_child_of_hidden_compression_segment_exposes_parent_lineage_root(_isolate):
@@ -175,13 +192,16 @@ def test_child_of_hidden_compression_segment_exposes_parent_lineage_root(_isolat
         conn.close()
 
 
-
 def test_cli_close_parent_preserves_cross_surface_continuation_lineage(_isolate):
     conn = _ensure_state_db(_isolate)
     t0 = time.time() - 100
     try:
-        _save_webui_session("lineage_api_cli_parent", title="Hermes WebUI #8", updated_at=t0)
-        _save_webui_session("lineage_api_webui_child", title="Hermes WebUI #8", updated_at=t0 + 10)
+        _save_webui_session(
+            "lineage_api_cli_parent", title="Hermes WebUI #8", updated_at=t0
+        )
+        _save_webui_session(
+            "lineage_api_webui_child", title="Hermes WebUI #8", updated_at=t0 + 10
+        )
         _insert_state_row(
             conn,
             "lineage_api_cli_parent",
@@ -198,18 +218,30 @@ def test_cli_close_parent_preserves_cross_surface_continuation_lineage(_isolate)
 
         rows = {row["session_id"]: row for row in all_sessions()}
 
-        assert rows["lineage_api_webui_child"].get("parent_session_id") == "lineage_api_cli_parent"
-        assert rows["lineage_api_webui_child"].get("_lineage_root_id") == "lineage_api_cli_parent"
+        assert (
+            rows["lineage_api_webui_child"].get("parent_session_id")
+            == "lineage_api_cli_parent"
+        )
+        assert (
+            rows["lineage_api_webui_child"].get("_lineage_root_id")
+            == "lineage_api_cli_parent"
+        )
     finally:
         conn.close()
 
 
-def test_cross_surface_child_session_metadata_marks_orphan_top_level_candidate(_isolate):
+def test_cross_surface_child_session_metadata_marks_orphan_top_level_candidate(
+    _isolate,
+):
     conn = _ensure_state_db(_isolate)
     t0 = time.time() - 100
     try:
-        _save_webui_session("lineage_api_telegram_parent", title="Telegram parent", updated_at=t0)
-        _save_webui_session("lineage_api_webui_tip", title="WebUI tip", updated_at=t0 + 10)
+        _save_webui_session(
+            "lineage_api_telegram_parent", title="Telegram parent", updated_at=t0
+        )
+        _save_webui_session(
+            "lineage_api_webui_tip", title="WebUI tip", updated_at=t0 + 10
+        )
         _insert_state_row(
             conn,
             "lineage_api_telegram_parent",

--- a/tests/test_session_metadata_fast_path.py
+++ b/tests/test_session_metadata_fast_path.py
@@ -20,8 +20,14 @@ def test_messages_zero_skips_effective_model_resolution():
 def test_full_message_load_updates_viewed_count_after_metadata_fast_path():
     src = (ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
 
-    assert "_setSessionViewedCount(S.session.session_id, Number(data.session.message_count || 0));" in src
-    assert "_setSessionViewedCount(sid, Number(S.session.message_count || msgs.length));" in src
+    assert (
+        "_setSessionViewedCount(S.session.session_id, Number(data.session.message_count || 0));"
+        in src
+    )
+    assert (
+        "_setSessionViewedCount(sid, Number(S.session.message_count || msgs.length));"
+        in src
+    )
 
 
 def test_lazy_message_load_skips_model_resolution():

--- a/tests/test_session_ops.py
+++ b/tests/test_session_ops.py
@@ -5,6 +5,7 @@ Tests run against the live test subprocess server (see tests/conftest.py).
 We seed transcripts via POST /api/session/import (ignores incoming
 session_id; returns a fresh one we register for cleanup).
 """
+
 import json
 import urllib.request
 import urllib.error
@@ -20,7 +21,7 @@ def _get(path):
         return json.loads(r.read())
 
 
-def _import_session_with_messages(cleanup_list, messages, model='openai/gpt-5.4-mini'):
+def _import_session_with_messages(cleanup_list, messages, model="openai/gpt-5.4-mini"):
     """Create a session pre-populated with `messages` via /api/session/import.
 
     Returns the server-assigned session_id (registered for cleanup).
@@ -31,67 +32,77 @@ def _import_session_with_messages(cleanup_list, messages, model='openai/gpt-5.4-
     generated one.
     """
     body = {
-        'title': 'test',
-        'messages': messages,
-        'model': model,
+        "title": "test",
+        "messages": messages,
+        "model": model,
     }
-    r = _post(TEST_BASE, '/api/session/import', body)
-    assert r.get('ok') is True and 'session' in r, f"Import failed: {r}"
-    sid = r['session']['session_id']
+    r = _post(TEST_BASE, "/api/session/import", body)
+    assert r.get("ok") is True and "session" in r, f"Import failed: {r}"
+    sid = r["session"]["session_id"]
     cleanup_list.append(sid)
     return sid
 
 
 # -- /api/session/retry ----------------------------------------------------
 
+
 def test_retry_returns_last_user_text(cleanup_test_sessions):
-    sid = _import_session_with_messages(cleanup_test_sessions, [
-        {'role': 'user', 'content': 'first user msg'},
-        {'role': 'assistant', 'content': 'first reply'},
-        {'role': 'user', 'content': 'second user msg'},
-        {'role': 'assistant', 'content': 'second reply'},
-        {'role': 'tool', 'content': 'tool output'},
-    ])
-    r = _post(TEST_BASE, '/api/session/retry', {'session_id': sid})
-    assert r.get('ok') is True, r
-    assert r.get('last_user_text') == 'second user msg'
-    assert r.get('removed_count') == 3
+    sid = _import_session_with_messages(
+        cleanup_test_sessions,
+        [
+            {"role": "user", "content": "first user msg"},
+            {"role": "assistant", "content": "first reply"},
+            {"role": "user", "content": "second user msg"},
+            {"role": "assistant", "content": "second reply"},
+            {"role": "tool", "content": "tool output"},
+        ],
+    )
+    r = _post(TEST_BASE, "/api/session/retry", {"session_id": sid})
+    assert r.get("ok") is True, r
+    assert r.get("last_user_text") == "second user msg"
+    assert r.get("removed_count") == 3
 
 
 def test_retry_truncates_transcript(cleanup_test_sessions):
-    sid = _import_session_with_messages(cleanup_test_sessions, [
-        {'role': 'user', 'content': 'first user msg'},
-        {'role': 'assistant', 'content': 'first reply'},
-        {'role': 'user', 'content': 'second user msg'},
-        {'role': 'assistant', 'content': 'second reply'},
-    ])
-    _post(TEST_BASE, '/api/session/retry', {'session_id': sid})
-    sess = _get(f'/api/session?session_id={sid}')['session']
+    sid = _import_session_with_messages(
+        cleanup_test_sessions,
+        [
+            {"role": "user", "content": "first user msg"},
+            {"role": "assistant", "content": "first reply"},
+            {"role": "user", "content": "second user msg"},
+            {"role": "assistant", "content": "second reply"},
+        ],
+    )
+    _post(TEST_BASE, "/api/session/retry", {"session_id": sid})
+    sess = _get(f"/api/session?session_id={sid}")["session"]
     # After retry: only the first exchange remains (2 messages).
-    assert len(sess['messages']) == 2
-    assert sess['messages'][-1]['content'] == 'first reply'
+    assert len(sess["messages"]) == 2
+    assert sess["messages"][-1]["content"] == "first reply"
 
 
 def test_retry_no_user_returns_error(cleanup_test_sessions):
-    sid = _import_session_with_messages(cleanup_test_sessions, [
-        {'role': 'assistant', 'content': 'orphan reply'},
-    ])
-    r = _post(TEST_BASE, '/api/session/retry', {'session_id': sid})
-    assert 'error' in r
-    assert 'no previous message' in r['error'].lower()
+    sid = _import_session_with_messages(
+        cleanup_test_sessions,
+        [
+            {"role": "assistant", "content": "orphan reply"},
+        ],
+    )
+    r = _post(TEST_BASE, "/api/session/retry", {"session_id": sid})
+    assert "error" in r
+    assert "no previous message" in r["error"].lower()
 
 
 def test_retry_unknown_session_returns_404():
     # _post catches HTTPError and returns the body as JSON.
     # bad(handler, ..., 404) sends 404 + {error: "..."}.
-    r = _post(TEST_BASE, '/api/session/retry', {'session_id': 'nonexistent_zzz'})
-    assert 'error' in r
-    assert 'not found' in r['error'].lower()
+    r = _post(TEST_BASE, "/api/session/retry", {"session_id": "nonexistent_zzz"})
+    assert "error" in r
+    assert "not found" in r["error"].lower()
 
 
 def test_retry_missing_session_id_returns_error():
-    r = _post(TEST_BASE, '/api/session/retry', {})
-    assert 'error' in r
+    r = _post(TEST_BASE, "/api/session/retry", {})
+    assert "error" in r
 
 
 def test_retry_does_not_double_append(cleanup_test_sessions):
@@ -99,20 +110,23 @@ def test_retry_does_not_double_append(cleanup_test_sessions):
     message BEFORE the last user message. Critical assertion: no duplicate
     of the resent user message gets left behind in the truncated transcript.
     """
-    sid = _import_session_with_messages(cleanup_test_sessions, [
-        {'role': 'user', 'content': 'msg A'},
-        {'role': 'assistant', 'content': 'reply A'},
-        {'role': 'user', 'content': 'msg B'},
-        {'role': 'assistant', 'content': 'reply B'},
-    ])
-    r = _post(TEST_BASE, '/api/session/retry', {'session_id': sid})
-    assert r['removed_count'] == 2  # msg B + reply B
-    sess = _get(f'/api/session?session_id={sid}')['session']
-    msgs = sess['messages']
+    sid = _import_session_with_messages(
+        cleanup_test_sessions,
+        [
+            {"role": "user", "content": "msg A"},
+            {"role": "assistant", "content": "reply A"},
+            {"role": "user", "content": "msg B"},
+            {"role": "assistant", "content": "reply B"},
+        ],
+    )
+    r = _post(TEST_BASE, "/api/session/retry", {"session_id": sid})
+    assert r["removed_count"] == 2  # msg B + reply B
+    sess = _get(f"/api/session?session_id={sid}")["session"]
+    msgs = sess["messages"]
     # Only msg A + reply A remain. Critically: there is NO 'msg B' anywhere.
     assert len(msgs) == 2
-    assert msgs[0]['content'] == 'msg A'
-    assert msgs[1]['content'] == 'reply A'
+    assert msgs[0]["content"] == "msg A"
+    assert msgs[1]["content"] == "reply A"
 
 
 def test_retry_concurrent_requests_are_safe(cleanup_test_sessions):
@@ -126,15 +140,19 @@ def test_retry_concurrent_requests_are_safe(cleanup_test_sessions):
     inside the lock so both threads converge on the canonical instance.
     """
     from concurrent.futures import ThreadPoolExecutor
-    sid = _import_session_with_messages(cleanup_test_sessions, [
-        {'role': 'user', 'content': 'msg A'},
-        {'role': 'assistant', 'content': 'reply A'},
-        {'role': 'user', 'content': 'msg B'},
-        {'role': 'assistant', 'content': 'reply B'},
-    ])
+
+    sid = _import_session_with_messages(
+        cleanup_test_sessions,
+        [
+            {"role": "user", "content": "msg A"},
+            {"role": "assistant", "content": "reply A"},
+            {"role": "user", "content": "msg B"},
+            {"role": "assistant", "content": "reply B"},
+        ],
+    )
 
     def _do_retry():
-        return _post(TEST_BASE, '/api/session/retry', {'session_id': sid})
+        return _post(TEST_BASE, "/api/session/retry", {"session_id": sid})
 
     with ThreadPoolExecutor(max_workers=4) as ex:
         futures = [ex.submit(_do_retry) for _ in range(4)]
@@ -144,15 +162,18 @@ def test_retry_concurrent_requests_are_safe(cleanup_test_sessions):
     # message to retry' once nothing is left. After the dust settles, the
     # transcript must be a strict prefix of the original — never have a
     # phantom duplicate of the resent message.
-    sess = _get(f'/api/session?session_id={sid}')['session']
-    msgs = sess['messages']
+    sess = _get(f"/api/session?session_id={sid}")["session"]
+    msgs = sess["messages"]
     valid_prefixes = (
         [],
-        [{'role': 'user', 'content': 'msg A'}, {'role': 'assistant', 'content': 'reply A'}],
-        [{'role': 'user', 'content': 'msg A'}],
+        [
+            {"role": "user", "content": "msg A"},
+            {"role": "assistant", "content": "reply A"},
+        ],
+        [{"role": "user", "content": "msg A"}],
     )
-    msg_pairs = [(m['role'], m.get('content', '')) for m in msgs]
-    valid_pairs = [[(m['role'], m['content']) for m in p] for p in valid_prefixes]
+    msg_pairs = [(m["role"], m.get("content", "")) for m in msgs]
+    valid_pairs = [[(m["role"], m["content"]) for m in p] for p in valid_prefixes]
     assert msg_pairs in valid_pairs, (
         f"Concurrent retries left transcript in unexpected state: {msg_pairs}. "
         "TOCTOU race in get_session/save likely re-introduced."
@@ -161,113 +182,128 @@ def test_retry_concurrent_requests_are_safe(cleanup_test_sessions):
 
 # ── /api/session/undo ─────────────────────────────────────────────────────
 
+
 def test_undo_returns_removed_preview(cleanup_test_sessions):
-    sid = _import_session_with_messages(cleanup_test_sessions, [
-        {'role': 'user', 'content': 'first user msg'},
-        {'role': 'assistant', 'content': 'first reply'},
-        {'role': 'user', 'content': 'second user msg'},
-        {'role': 'assistant', 'content': 'second reply'},
-        {'role': 'tool', 'content': 'tool output'},
-    ])
-    r = _post(TEST_BASE, '/api/session/undo', {'session_id': sid})
-    assert r.get('ok') is True
-    assert r.get('removed_count') == 3
-    assert 'second user msg' in r.get('removed_preview', '')
+    sid = _import_session_with_messages(
+        cleanup_test_sessions,
+        [
+            {"role": "user", "content": "first user msg"},
+            {"role": "assistant", "content": "first reply"},
+            {"role": "user", "content": "second user msg"},
+            {"role": "assistant", "content": "second reply"},
+            {"role": "tool", "content": "tool output"},
+        ],
+    )
+    r = _post(TEST_BASE, "/api/session/undo", {"session_id": sid})
+    assert r.get("ok") is True
+    assert r.get("removed_count") == 3
+    assert "second user msg" in r.get("removed_preview", "")
 
 
 def test_undo_truncates_transcript(cleanup_test_sessions):
-    sid = _import_session_with_messages(cleanup_test_sessions, [
-        {'role': 'user', 'content': 'first user msg'},
-        {'role': 'assistant', 'content': 'first reply'},
-        {'role': 'user', 'content': 'second user msg'},
-        {'role': 'assistant', 'content': 'second reply'},
-    ])
-    _post(TEST_BASE, '/api/session/undo', {'session_id': sid})
-    sess = _get(f'/api/session?session_id={sid}')['session']
-    assert len(sess['messages']) == 2
-    assert sess['messages'][-1]['content'] == 'first reply'
+    sid = _import_session_with_messages(
+        cleanup_test_sessions,
+        [
+            {"role": "user", "content": "first user msg"},
+            {"role": "assistant", "content": "first reply"},
+            {"role": "user", "content": "second user msg"},
+            {"role": "assistant", "content": "second reply"},
+        ],
+    )
+    _post(TEST_BASE, "/api/session/undo", {"session_id": sid})
+    sess = _get(f"/api/session?session_id={sid}")["session"]
+    assert len(sess["messages"]) == 2
+    assert sess["messages"][-1]["content"] == "first reply"
 
 
 def test_undo_repeated_until_empty(cleanup_test_sessions):
-    sid = _import_session_with_messages(cleanup_test_sessions, [
-        {'role': 'user', 'content': 'msg A'},
-        {'role': 'assistant', 'content': 'reply A'},
-    ])
-    _post(TEST_BASE, '/api/session/undo', {'session_id': sid})
-    r = _post(TEST_BASE, '/api/session/undo', {'session_id': sid})
-    assert 'error' in r
-    assert 'nothing to undo' in r['error'].lower()
+    sid = _import_session_with_messages(
+        cleanup_test_sessions,
+        [
+            {"role": "user", "content": "msg A"},
+            {"role": "assistant", "content": "reply A"},
+        ],
+    )
+    _post(TEST_BASE, "/api/session/undo", {"session_id": sid})
+    r = _post(TEST_BASE, "/api/session/undo", {"session_id": sid})
+    assert "error" in r
+    assert "nothing to undo" in r["error"].lower()
 
 
 def test_undo_unknown_session_returns_404():
-    r = _post(TEST_BASE, '/api/session/undo', {'session_id': 'nonexistent_zzz'})
-    assert 'error' in r
-    assert 'not found' in r['error'].lower()
+    r = _post(TEST_BASE, "/api/session/undo", {"session_id": "nonexistent_zzz"})
+    assert "error" in r
+    assert "not found" in r["error"].lower()
 
 
 # ── /api/session/status ───────────────────────────────────────────────────
 
+
 def test_status_returns_summary(cleanup_test_sessions):
-    sid = _import_session_with_messages(cleanup_test_sessions, [
-        {'role': 'user', 'content': 'a'},
-        {'role': 'assistant', 'content': 'b'},
-        {'role': 'user', 'content': 'c'},
-    ])
-    r = _get(f'/api/session/status?session_id={sid}')
-    assert r['session_id'] == sid
-    assert r['title'] == 'test'
-    assert r['message_count'] == 3
-    assert 'model' in r
-    assert r['profile'] == 'default'
-    assert r['hermes_home'] == str(TEST_STATE_DIR)
-    assert 'workspace' in r
-    assert 'created_at' in r
-    assert 'updated_at' in r
-    assert r['agent_running'] is False  # no active stream
+    sid = _import_session_with_messages(
+        cleanup_test_sessions,
+        [
+            {"role": "user", "content": "a"},
+            {"role": "assistant", "content": "b"},
+            {"role": "user", "content": "c"},
+        ],
+    )
+    r = _get(f"/api/session/status?session_id={sid}")
+    assert r["session_id"] == sid
+    assert r["title"] == "test"
+    assert r["message_count"] == 3
+    assert "model" in r
+    assert r["profile"] == "default"
+    assert r["hermes_home"] == str(TEST_STATE_DIR)
+    assert "workspace" in r
+    assert "created_at" in r
+    assert "updated_at" in r
+    assert r["agent_running"] is False  # no active stream
     # #463 – token usage and cost fields included in status
-    assert 'input_tokens' in r
-    assert 'output_tokens' in r
-    assert 'total_tokens' in r
-    assert 'estimated_cost' in r
+    assert "input_tokens" in r
+    assert "output_tokens" in r
+    assert "total_tokens" in r
+    assert "estimated_cost" in r
     # Freshly imported session: no tokens yet
-    assert r['input_tokens'] == 0
-    assert r['output_tokens'] == 0
-    assert r['total_tokens'] == 0
+    assert r["input_tokens"] == 0
+    assert r["output_tokens"] == 0
+    assert r["total_tokens"] == 0
 
 
 def test_status_returns_profile_specific_hermes_home(cleanup_test_sessions):
-    data = _post(TEST_BASE, '/api/session/new', {'profile': 'research'})
-    sid = data['session']['session_id']
+    data = _post(TEST_BASE, "/api/session/new", {"profile": "research"})
+    sid = data["session"]["session_id"]
     cleanup_test_sessions.append(sid)
 
-    r = _get(f'/api/session/status?session_id={sid}')
+    r = _get(f"/api/session/status?session_id={sid}")
 
-    assert r['profile'] == 'research'
-    assert r['hermes_home'] == str(TEST_STATE_DIR / 'profiles' / 'research')
+    assert r["profile"] == "research"
+    assert r["hermes_home"] == str(TEST_STATE_DIR / "profiles" / "research")
 
 
 def test_status_unknown_returns_404():
     try:
-        _get('/api/session/status?session_id=nonexistent_zzz')
-        pytest.fail('Expected HTTPError')
+        _get("/api/session/status?session_id=nonexistent_zzz")
+        pytest.fail("Expected HTTPError")
     except urllib.error.HTTPError as e:
         assert e.code == 404
 
 
 def test_status_missing_param():
     try:
-        _get('/api/session/status')
-        pytest.fail('Expected HTTPError')
+        _get("/api/session/status")
+        pytest.fail("Expected HTTPError")
     except urllib.error.HTTPError as e:
         assert e.code == 400
 
 
 # ── /api/session/usage ────────────────────────────────────────────────────
 
+
 def test_usage_returns_token_counts(cleanup_test_sessions):
     sid, _ws = make_session_tracked(cleanup_test_sessions)
     # Usage on a new session: zero everything.
-    r = _get(f'/api/session/usage?session_id={sid}')
-    assert r['input_tokens'] == 0
-    assert r['output_tokens'] == 0
-    assert r['total_tokens'] == 0
+    r = _get(f"/api/session/usage?session_id={sid}")
+    assert r["input_tokens"] == 0
+    assert r["output_tokens"] == 0
+    assert r["total_tokens"] == 0

--- a/tests/test_session_rename_lifecycle.py
+++ b/tests/test_session_rename_lifecycle.py
@@ -68,7 +68,7 @@ def test_session_rename_failure_restores_state_and_surfaces_error():
     block = _session_rename_block()
     catch_pos = block.find("}catch(err){")
     assert catch_pos >= 0, "session rename save path must handle API failures"
-    catch_block = block[catch_pos:block.find("}finally{", catch_pos)]
+    catch_block = block[catch_pos : block.find("}finally{", catch_pos)]
     assert "applyTitle(oldTitle,false);" in catch_block, (
         "failed session rename must restore the cached/active title instead of "
         "silently appearing successful"

--- a/tests/test_session_rotate_url_sync.py
+++ b/tests/test_session_rotate_url_sync.py
@@ -1,4 +1,5 @@
 """Regression tests for session id rotation URL sync."""
+
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).parent.parent.resolve()
@@ -8,7 +9,9 @@ MESSAGES_JS = (REPO_ROOT / "static" / "messages.js").read_text(encoding="utf-8")
 def test_stream_completion_syncs_rotated_session_id_to_tab_state():
     """When compact/restore returns a new session id, the tab anchor follows it."""
     completion_marker = "S.session=d.session;S.messages=d.session.messages||[]"
-    settled_marker = "S.session=session;S.messages=(session.messages||[]).filter(m=>m&&m.role);"
+    settled_marker = (
+        "S.session=session;S.messages=(session.messages||[]).filter(m=>m&&m.role);"
+    )
 
     completion_pos = MESSAGES_JS.find(completion_marker)
     settled_pos = MESSAGES_JS.find(settled_marker)
@@ -19,6 +22,9 @@ def test_stream_completion_syncs_rotated_session_id_to_tab_state():
     settled_block = MESSAGES_JS[settled_pos : settled_pos + 500]
 
     for block in (completion_block, settled_block):
-        assert "localStorage.setItem('hermes-webui-session',S.session.session_id);" in block
+        assert (
+            "localStorage.setItem('hermes-webui-session',S.session.session_id);"
+            in block
+        )
         assert "_setActiveSessionUrl(S.session.session_id)" in block
         assert "typeof _setActiveSessionUrl==='function'" in block

--- a/tests/test_session_runtime_ownership_invariants.py
+++ b/tests/test_session_runtime_ownership_invariants.py
@@ -39,7 +39,7 @@ def _event_handler(src: str, event_name: str) -> str:
     idx = src.find(marker)
     assert idx != -1, f"{event_name} handler not found"
     next_handler = src.find("source.addEventListener(", idx + len(marker))
-    return src[idx:next_handler if next_handler != -1 else len(src)]
+    return src[idx : next_handler if next_handler != -1 else len(src)]
 
 
 class TestSessionOwnedRuntimeInvariants:
@@ -50,7 +50,10 @@ class TestSessionOwnedRuntimeInvariants:
             "Sidebar row cancellation must target the row-owned active_stream_id, "
             "not the currently viewed pane's S.activeStreamId."
         )
-        assert "S.activeStreamId" not in body[: body.index("if(S.session&&S.session.session_id===sid)")], (
+        assert (
+            "S.activeStreamId"
+            not in body[: body.index("if(S.session&&S.session.session_id===sid)")]
+        ), (
             "cancelSessionStream must not read or clear active-pane stream state until "
             "it has proved the row session is the active pane."
         )
@@ -58,14 +61,17 @@ class TestSessionOwnedRuntimeInvariants:
     def test_done_event_does_not_clear_unrelated_active_pane_busy_state(self):
         messages = read("static/messages.js")
         done = _event_handler(messages, "done")
-        unconditional = "_queueDrainSid=activeSid;renderSessionList();setBusy(false);setStatus('');"
+        unconditional = (
+            "_queueDrainSid=activeSid;renderSessionList();setBusy(false);setStatus('');"
+        )
         assert unconditional not in done, (
             "A background session's done event must not unconditionally call setBusy(false); "
             "that can idle an unrelated active pane that is still running."
         )
         normalized = done.replace(" ", "")
         assert (
-            "if(isActiveSession||!S.session||!INFLIGHT[S.session.session_id])" in normalized
+            "if(isActiveSession||!S.session||!INFLIGHT[S.session.session_id])"
+            in normalized
             or "_setActivePaneIdleIfOwner();" in done
         ), (
             "The done handler should only idle composer state through an active-pane guard, "
@@ -75,13 +81,17 @@ class TestSessionOwnedRuntimeInvariants:
     def test_server_session_finalize_does_not_idle_unrelated_active_pane(self):
         messages = read("static/messages.js")
         finalize = _function_body(messages, "_restoreSettledSession")
-        assert "_queueDrainSid=activeSid;renderSessionList();setBusy(false);setComposerStatus('');" not in finalize, (
+        assert (
+            "_queueDrainSid=activeSid;renderSessionList();setBusy(false);setComposerStatus('');"
+            not in finalize
+        ), (
             "The fallback server-finalize path must not idle the active pane for a "
             "background session completion."
         )
         normalized = finalize.replace(" ", "")
         assert (
-            "if(isActiveSession||!S.session||!INFLIGHT[S.session.session_id])" in normalized
+            "if(isActiveSession||!S.session||!INFLIGHT[S.session.session_id])"
+            in normalized
             or "_setActivePaneIdleIfOwner();" in finalize
         ), (
             "The fallback server-finalize path should use the same active-pane guard as the live done event."
@@ -121,11 +131,15 @@ class TestSessionOwnedRuntimeInvariants:
         messages = read("static/messages.js")
         close_live = _function_body(messages, "closeLiveStream")
         attach_start = messages.index("function attachLiveStream")
-        attach_live = messages[attach_start:messages.index("function _isActiveSession", attach_start)]
+        attach_live = messages[
+            attach_start : messages.index("function _isActiveSession", attach_start)
+        ]
         assert "constlive=LIVE_STREAMS[sessionId]" in close_live.replace(" ", ""), (
             "LIVE_STREAMS must remain keyed by the owning session_id."
         )
-        assert "constexistingLive=LIVE_STREAMS[activeSid]" in attach_live.replace(" ", ""), (
+        assert "constexistingLive=LIVE_STREAMS[activeSid]" in attach_live.replace(
+            " ", ""
+        ), (
             "attachLiveStream should reuse the session-owned live transport for the same stream."
         )
         assert re.search(r"INFLIGHT\[activeSid\].*messages", attach_live, re.DOTALL), (

--- a/tests/test_session_save_mode.py
+++ b/tests/test_session_save_mode.py
@@ -1,4 +1,5 @@
 """Regression tests for config-driven first-turn session persistence (#1406)."""
+
 import json
 
 import pytest
@@ -40,20 +41,30 @@ def test_session_save_mode_defaults_to_deferred_for_missing_config():
 
 @pytest.mark.parametrize("raw", ["bogus", "", None, 42, {"mode": "eager"}])
 def test_invalid_session_save_mode_falls_back_to_deferred(raw):
-    assert config.get_webui_session_save_mode({"webui": {"session_save_mode": raw}}) == "deferred"
+    assert (
+        config.get_webui_session_save_mode({"webui": {"session_save_mode": raw}})
+        == "deferred"
+    )
 
 
 def test_eager_session_save_mode_is_accepted():
-    assert config.get_webui_session_save_mode({"webui": {"session_save_mode": "eager"}}) == "eager"
+    assert (
+        config.get_webui_session_save_mode({"webui": {"session_save_mode": "eager"}})
+        == "eager"
+    )
 
 
 def test_eager_mode_still_does_not_save_empty_new_sessions(_isolate_state, monkeypatch):
     monkeypatch.setattr(config, "cfg", {"webui": {"session_save_mode": "eager"}})
     s = new_session()
-    assert not s.path.exists(), "eager mode must not recreate empty Untitled session files"
+    assert not s.path.exists(), (
+        "eager mode must not recreate empty Untitled session files"
+    )
 
 
-def test_deferred_chat_start_persists_pending_only_before_thread(_isolate_state, monkeypatch):
+def test_deferred_chat_start_persists_pending_only_before_thread(
+    _isolate_state, monkeypatch
+):
     monkeypatch.setattr(config, "cfg", {"webui": {"session_save_mode": "deferred"}})
     s = new_session(workspace=str(_isolate_state.parent))
     routes._prepare_chat_start_session_for_stream(
@@ -71,7 +82,9 @@ def test_deferred_chat_start_persists_pending_only_before_thread(_isolate_state,
     assert on_disk["pending_user_message"] == "hello deferred"
 
 
-def test_eager_chat_start_checkpoints_first_user_message_before_thread(_isolate_state, monkeypatch):
+def test_eager_chat_start_checkpoints_first_user_message_before_thread(
+    _isolate_state, monkeypatch
+):
     monkeypatch.setattr(config, "cfg", {"webui": {"session_save_mode": "eager"}})
     s = new_session(workspace=str(_isolate_state.parent))
     routes._prepare_chat_start_session_for_stream(
@@ -91,8 +104,12 @@ def test_eager_chat_start_checkpoints_first_user_message_before_thread(_isolate_
     assert on_disk["pending_user_message"] == "hello eager"
 
 
-def test_eager_wal_repair_does_not_duplicate_checkpointed_user_message(_isolate_state, monkeypatch):
-    s = Session(session_id="eager_repair", messages=[{"role": "user", "content": "survive"}])
+def test_eager_wal_repair_does_not_duplicate_checkpointed_user_message(
+    _isolate_state, monkeypatch
+):
+    s = Session(
+        session_id="eager_repair", messages=[{"role": "user", "content": "survive"}]
+    )
     s.pending_user_message = "survive"
     s.active_stream_id = "dead_stream"
     s.pending_started_at = 789.0
@@ -101,7 +118,11 @@ def test_eager_wal_repair_does_not_duplicate_checkpointed_user_message(_isolate_
     repaired = models._repair_stale_pending(s)
 
     assert repaired is True
-    user_messages = [m for m in s.messages if m.get("role") == "user" and m.get("content") == "survive"]
+    user_messages = [
+        m
+        for m in s.messages
+        if m.get("role") == "user" and m.get("content") == "survive"
+    ]
     assert len(user_messages) == 1
     assert s.pending_user_message is None
     assert any(m.get("_error") for m in s.messages if m.get("role") == "assistant")

--- a/tests/test_session_search_bfcache_822.py
+++ b/tests/test_session_search_bfcache_822.py
@@ -11,6 +11,7 @@ Fix:
 - ``pageshow`` listener that checks ``event.persisted`` covers the true bfcache
   restore case (where the async boot IIFE does NOT re-run)
 """
+
 import pathlib
 import re
 
@@ -18,19 +19,19 @@ REPO = pathlib.Path(__file__).parent.parent
 
 
 def read(rel):
-    return (REPO / rel).read_text(encoding='utf-8')
+    return (REPO / rel).read_text(encoding="utf-8")
 
 
 class TestSessionSearchAutocompleteAttribute:
     """index.html must opt the session search input out of browser autocomplete/restore."""
 
     def test_session_search_has_autocomplete_off(self):
-        src = read('static/index.html')
+        src = read("static/index.html")
         m = re.search(r'<input[^>]*id="sessionSearch"[^>]*>', src)
         assert m, "#sessionSearch input tag not found in index.html"
         tag = m.group(0)
         assert 'autocomplete="off"' in tag or "autocomplete='off'" in tag, (
-            "#sessionSearch must have autocomplete=\"off\" so browsers do not "
+            '#sessionSearch must have autocomplete="off" so browsers do not '
             "restore a prior search query across reloads or bfcache restores (#822)"
         )
 
@@ -41,7 +42,7 @@ class TestBootClearsSessionSearch:
     an empty filter and shows all sessions."""
 
     def test_boot_clears_session_search_value_before_first_render(self):
-        src = read('static/boot.js')
+        src = read("static/boot.js")
         # Must find a line that sets sessionSearch.value = '' at boot
         assert re.search(
             r"getElementById\(['\"]sessionSearch['\"]\)\s*;\s*if\s*\([^)]+\)\s*[^=]+\.value\s*=\s*['\"]{2}"
@@ -56,13 +57,13 @@ class TestBootClearsSessionSearch:
     def test_boot_clear_is_before_first_render_call(self):
         """The clear must precede the first renderSessionList call path so the
         initial render shows an unfiltered list."""
-        src = read('static/boot.js')
+        src = read("static/boot.js")
         clear_pos = None
         m = re.search(r"getElementById\(['\"]sessionSearch['\"]\)", src)
         if m:
             clear_pos = m.start()
         assert clear_pos is not None, "session search clear not found in boot.js"
-        first_render_pos = src.find('renderSessionList()', clear_pos)
+        first_render_pos = src.find("renderSessionList()", clear_pos)
         assert first_render_pos != -1, "renderSessionList() call not found after clear"
         assert clear_pos < first_render_pos, (
             "sessionSearch clear must appear before the first renderSessionList() call"
@@ -76,7 +77,7 @@ class TestPageShowBfcacheHandler:
     with `event.persisted` check is the only reliable way to clear on bfcache."""
 
     def test_pageshow_listener_registered(self):
-        src = read('static/boot.js')
+        src = read("static/boot.js")
         assert re.search(
             r"addEventListener\(\s*['\"]pageshow['\"]",
             src,
@@ -90,7 +91,7 @@ class TestPageShowBfcacheHandler:
         it false and are already handled by the boot IIFE. Guarding prevents
         clearing the search on every page show (which would wipe an in-progress
         user filter if any other pageshow triggers happen)."""
-        src = read('static/boot.js')
+        src = read("static/boot.js")
         m = re.search(
             r"addEventListener\(\s*['\"]pageshow['\"].*?\}\s*\)",
             src,
@@ -98,13 +99,13 @@ class TestPageShowBfcacheHandler:
         )
         assert m, "pageshow listener body not found"
         body = m.group(0)
-        assert 'persisted' in body, (
+        assert "persisted" in body, (
             "pageshow handler must guard on event.persisted so fresh loads "
             "don't double-clear the field"
         )
 
     def test_pageshow_handler_clears_session_search(self):
-        src = read('static/boot.js')
+        src = read("static/boot.js")
         m = re.search(
             r"addEventListener\(\s*['\"]pageshow['\"].*?\}\s*\)",
             src,
@@ -112,7 +113,7 @@ class TestPageShowBfcacheHandler:
         )
         assert m
         body = m.group(0)
-        assert 'sessionSearch' in body, (
+        assert "sessionSearch" in body, (
             "pageshow handler must target #sessionSearch specifically"
         )
         assert re.search(r"\.value\s*=\s*['\"]{2}", body), (
@@ -123,7 +124,7 @@ class TestPageShowBfcacheHandler:
         """After clearing on bfcache restore, the cached DOM still shows the
         filtered view. Re-rendering from cache with the now-empty filter
         repopulates the list."""
-        src = read('static/boot.js')
+        src = read("static/boot.js")
         m = re.search(
             r"addEventListener\(\s*['\"]pageshow['\"].*?\}\s*\)",
             src,
@@ -131,7 +132,7 @@ class TestPageShowBfcacheHandler:
         )
         assert m
         body = m.group(0)
-        assert 'renderSessionListFromCache' in body or 'renderSessionList' in body, (
+        assert "renderSessionListFromCache" in body or "renderSessionList" in body, (
             "pageshow handler must re-render the list after clearing the filter "
             "so the stale filtered DOM is replaced with the full list"
         )

--- a/tests/test_session_sidebar_relative_time.py
+++ b/tests/test_session_sidebar_relative_time.py
@@ -60,7 +60,9 @@ def _run_session_time_case(script_body: str) -> dict:
         {script_body}
         """
     )
-    proc = subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True)
+    proc = subprocess.run(
+        ["node", "-e", script], check=True, capture_output=True, text=True
+    )
     return json.loads(proc.stdout)
 
 

--- a/tests/test_session_sidecar_repair.py
+++ b/tests/test_session_sidecar_repair.py
@@ -1,7 +1,7 @@
 """Regression tests for session sidecar repair logic."""
+
 import json
 import queue
-import os
 import sys
 import threading
 import time
@@ -16,7 +16,6 @@ from api.models import (
     _get_profile_home,
     _apply_core_sync_or_error_marker,
     _repair_stale_pending,
-    _active_stream_ids,
 )
 import api.config as config
 import api.streaming as streaming
@@ -24,6 +23,7 @@ import api.profiles as profiles
 
 
 # ── Fixtures ────────────────────────────────────────────────────────────────
+
 
 @pytest.fixture(autouse=True)
 def _isolate_session_dir(tmp_path, monkeypatch):
@@ -85,7 +85,9 @@ def _make_session(session_id="test_sid", messages=None, **kwargs):
     return Session(**defaults)
 
 
-def _make_stale_session(session_id="stale_sid", pending_msg="Hello hermes", stream_id="stream_1"):
+def _make_stale_session(
+    session_id="stale_sid", pending_msg="Hello hermes", stream_id="stream_1"
+):
     """Helper to create a session in stale-pending state (messages empty, pending set)."""
     s = _make_session(session_id=session_id, messages=[])
     s.pending_user_message = pending_msg
@@ -131,7 +133,9 @@ class TestRepairStalePendingNoDeadlock:
         finally:
             lock.release()
 
-    def test_no_deadlock_when_get_session_triggers_repair(self, hermes_home, monkeypatch):
+    def test_no_deadlock_when_get_session_triggers_repair(
+        self, hermes_home, monkeypatch
+    ):
         """Simulate the real deadlock scenario: a caller holds the per-session
         lock and then calls get_session(), which evicts the session from cache
         and re-loads it, triggering _repair_stale_pending.
@@ -191,7 +195,9 @@ class TestRepairStalePendingNoDeadlock:
             f"Worker raised exception: {worker_exc[0] if worker_exc else 'none'}"
         )
 
-    def test_lock_contended_skip_retries_on_next_cache_miss(self, hermes_home, monkeypatch):
+    def test_lock_contended_skip_retries_on_next_cache_miss(
+        self, hermes_home, monkeypatch
+    ):
         """A lock-contended repair skip should not become stuck forever.
 
         The first get_session() call happens while the per-session lock is held,
@@ -224,7 +230,10 @@ class TestRepairStalePendingNoDeadlock:
         repaired = models.get_session(sid)
         assert repaired.pending_user_message is None
         assert repaired.active_stream_id is None
-        assert [m["content"] for m in repaired.messages] == ["Recover me", "Recovered answer"]
+        assert [m["content"] for m in repaired.messages] == [
+            "Recover me",
+            "Recovered answer",
+        ]
         assert models.SESSIONS.get(sid) is repaired
 
 
@@ -244,7 +253,9 @@ class TestDraftRecovery:
 
         with lock:
             core_path = hermes_home / "sessions" / f"session_{s.session_id}.json"
-            result = _apply_core_sync_or_error_marker(s, core_path, stream_id_for_recheck="stream_1")
+            result = _apply_core_sync_or_error_marker(
+                s, core_path, stream_id_for_recheck="stream_1"
+            )
 
         assert result is True
         # Find the recovered user turn
@@ -264,7 +275,9 @@ class TestDraftRecovery:
 
         with lock:
             core_path = hermes_home / "sessions" / f"session_{s.session_id}.json"
-            _apply_core_sync_or_error_marker(s, core_path, stream_id_for_recheck="stream_1")
+            _apply_core_sync_or_error_marker(
+                s, core_path, stream_id_for_recheck="stream_1"
+            )
 
         error_msgs = [m for m in s.messages if m.get("_error")]
         assert len(error_msgs) == 1
@@ -282,11 +295,15 @@ class TestDraftRecovery:
 
         with lock:
             core_path = hermes_home / "sessions" / f"session_{s.session_id}.json"
-            _apply_core_sync_or_error_marker(s, core_path, stream_id_for_recheck="stream_1")
+            _apply_core_sync_or_error_marker(
+                s, core_path, stream_id_for_recheck="stream_1"
+            )
 
         user_msgs = [m for m in s.messages if m.get("role") == "user"]
         assert len(user_msgs) == 1
-        assert user_msgs[0].get("attachments") == [{"type": "image", "name": "photo.png"}]
+        assert user_msgs[0].get("attachments") == [
+            {"type": "image", "name": "photo.png"}
+        ]
 
     def test_pending_fields_cleared_after_recovery(self, hermes_home, monkeypatch):
         """After recovery, all pending fields are cleared."""
@@ -297,7 +314,9 @@ class TestDraftRecovery:
 
         with lock:
             core_path = hermes_home / "sessions" / f"session_{s.session_id}.json"
-            _apply_core_sync_or_error_marker(s, core_path, stream_id_for_recheck="stream_1")
+            _apply_core_sync_or_error_marker(
+                s, core_path, stream_id_for_recheck="stream_1"
+            )
 
         assert s.pending_user_message is None
         assert s.pending_attachments == []
@@ -321,7 +340,9 @@ class TestStreamIdRecheck:
         with lock:
             core_path = hermes_home / "sessions" / f"session_{s.session_id}.json"
             result = _apply_core_sync_or_error_marker(
-                s, core_path, stream_id_for_recheck="stream_old",
+                s,
+                core_path,
+                stream_id_for_recheck="stream_old",
             )
 
         assert result is False, "Should bail when stream_id rotated"
@@ -339,7 +360,9 @@ class TestStreamIdRecheck:
             with lock:
                 core_path = hermes_home / "sessions" / f"session_{s.session_id}.json"
                 result = _apply_core_sync_or_error_marker(
-                    s, core_path, stream_id_for_recheck="stream_alive",
+                    s,
+                    core_path,
+                    stream_id_for_recheck="stream_alive",
                 )
 
             assert result is False, "Should bail when stream is still alive"
@@ -356,7 +379,9 @@ class TestStreamIdRecheck:
         with lock:
             core_path = hermes_home / "sessions" / f"session_{s.session_id}.json"
             result = _apply_core_sync_or_error_marker(
-                s, core_path, stream_id_for_recheck="stream_dead",
+                s,
+                core_path,
+                stream_id_for_recheck="stream_dead",
             )
 
         assert result is True
@@ -461,7 +486,9 @@ class TestEmptyMessagesGuard:
     session.messages is non-empty, while still recovering the pending user turn
     before clearing stale stream runtime fields."""
 
-    def test_pending_cleared_when_messages_nonempty_direct(self, hermes_home, monkeypatch):
+    def test_pending_cleared_when_messages_nonempty_direct(
+        self, hermes_home, monkeypatch
+    ):
         """When _apply_core_sync_or_error_marker is called on a session with
         non-empty messages and pending set, it recovers the pending user turn,
         clears the pending fields, and appends an error marker."""
@@ -473,7 +500,9 @@ class TestEmptyMessagesGuard:
         with lock:
             core_path = hermes_home / "sessions" / f"session_{s.session_id}.json"
             result = _apply_core_sync_or_error_marker(
-                s, core_path, stream_id_for_recheck="stream_1",
+                s,
+                core_path,
+                stream_id_for_recheck="stream_1",
             )
 
         assert result is True
@@ -499,7 +528,9 @@ class TestEmptyMessagesGuard:
         with lock:
             core_path = hermes_home / "sessions" / f"session_{s.session_id}.json"
             result = _apply_core_sync_or_error_marker(
-                s, core_path, stream_id_for_recheck="stream_1",
+                s,
+                core_path,
+                stream_id_for_recheck="stream_1",
             )
 
         assert result is False
@@ -512,7 +543,9 @@ class TestEmptyMessagesGuard:
         with lock:
             core_path = hermes_home / "sessions" / f"session_{s.session_id}.json"
             result = _apply_core_sync_or_error_marker(
-                s, core_path, stream_id_for_recheck="stream_1",
+                s,
+                core_path,
+                stream_id_for_recheck="stream_1",
             )
 
         assert result is True
@@ -561,7 +594,9 @@ class TestNonEmptyMessagesPendingCleared:
         assert len(recovered_msgs) == 1
         assert recovered_msgs[0]["role"] == "user"
         assert recovered_msgs[0]["content"] == "Stuck draft"
-        assert recovered_msgs[0]["attachments"] == [{"type": "image", "name": "screenshot.png"}]
+        assert recovered_msgs[0]["attachments"] == [
+            {"type": "image", "name": "screenshot.png"}
+        ]
 
         # Exactly one error marker
         error_msgs = [m for m in s.messages if m.get("_error")]
@@ -604,7 +639,9 @@ class TestLastResortSyncDelegation:
         assert len(called) == 1, "_get_profile_home should have been called once"
         assert called[0] == s.profile
 
-    def test_uses_shared_apply_core_sync_or_error_marker(self, hermes_home, monkeypatch):
+    def test_uses_shared_apply_core_sync_or_error_marker(
+        self, hermes_home, monkeypatch
+    ):
         """_last_resort_sync_from_core delegates to _apply_core_sync_or_error_marker
         instead of duplicating the logic."""
         s = _make_stale_session()
@@ -624,7 +661,9 @@ class TestLastResortSyncDelegation:
             _register_active_stream("stream_1")
             streaming._last_resort_sync_from_core(s, "stream_1", agent_lock)
 
-        assert len(called) == 1, "_apply_core_sync_or_error_marker should have been called"
+        assert len(called) == 1, (
+            "_apply_core_sync_or_error_marker should have been called"
+        )
         assert called[0][0] == s.session_id
         assert called[0][1] == "stream_1"
         assert called[0][2] == {"require_stream_dead": False}
@@ -664,6 +703,7 @@ class TestCheckpointOrdering:
         _run_agent_streaming: checkpoint stop appears before
         _last_resort_sync_from_core."""
         import inspect
+
         source = inspect.getsource(streaming._run_agent_streaming)
 
         # Find the finally block
@@ -677,7 +717,9 @@ class TestCheckpointOrdering:
         recovery_pos = finally_block.find("_last_resort_sync_from_core")
 
         assert ckpt_pos != -1, "Could not find _checkpoint_stop in finally block"
-        assert recovery_pos != -1, "Could not find _last_resort_sync_from_core in finally block"
+        assert recovery_pos != -1, (
+            "Could not find _last_resort_sync_from_core in finally block"
+        )
         assert ckpt_pos < recovery_pos, (
             f"_checkpoint_stop (pos {ckpt_pos}) must appear BEFORE "
             f"_last_resort_sync_from_core (pos {recovery_pos}) in finally block"
@@ -685,6 +727,7 @@ class TestCheckpointOrdering:
 
 
 # ── Integration: _repair_stale_pending end-to-end ────────────────────────────
+
 
 class TestRepairStalePendingIntegration:
     """End-to-end tests for _repair_stale_pending (cache-miss repair path)."""
@@ -734,7 +777,10 @@ class TestRepairStalePendingIntegration:
 
         result = _repair_stale_pending(s)
         assert result is True
-        assert [m["content"] for m in s.messages if m["role"] == "user"] == ["hi", "more"]
+        assert [m["content"] for m in s.messages if m["role"] == "user"] == [
+            "hi",
+            "more",
+        ]
         assert s.messages[1].get("_recovered") is True
         assert any(m.get("_error") for m in s.messages)
 
@@ -764,6 +810,7 @@ class TestRepairStalePendingIntegration:
 
 # ── Core sync with metadata fields ───────────────────────────────────────────
 
+
 class TestCoreSyncMetadata:
     """When syncing from core transcript, token/cost metadata is carried over."""
 
@@ -778,13 +825,19 @@ class TestCoreSyncMetadata:
             {"role": "assistant", "content": "World"},
         ]
         core_path = _write_core_transcript(
-            hermes_home, s.session_id, core_messages,
-            input_tokens=100, output_tokens=50, estimated_cost=0.05,
+            hermes_home,
+            s.session_id,
+            core_messages,
+            input_tokens=100,
+            output_tokens=50,
+            estimated_cost=0.05,
         )
 
         with lock:
             result = _apply_core_sync_or_error_marker(
-                s, core_path, stream_id_for_recheck="stream_1",
+                s,
+                core_path,
+                stream_id_for_recheck="stream_1",
             )
 
         assert result is True
@@ -792,7 +845,9 @@ class TestCoreSyncMetadata:
         assert s.output_tokens == 50
         assert s.estimated_cost == 0.05
 
-    def test_core_empty_messages_falls_through_to_recovery(self, hermes_home, monkeypatch):
+    def test_core_empty_messages_falls_through_to_recovery(
+        self, hermes_home, monkeypatch
+    ):
         """If core transcript exists but messages is empty, the recovery path
         (restoring pending user message + error marker) is taken instead."""
         s = _make_stale_session(pending_msg="My question")
@@ -803,7 +858,9 @@ class TestCoreSyncMetadata:
 
         with lock:
             result = _apply_core_sync_or_error_marker(
-                s, core_path, stream_id_for_recheck="stream_1",
+                s,
+                core_path,
+                stream_id_for_recheck="stream_1",
             )
 
         assert result is True

--- a/tests/test_session_static_assets.py
+++ b/tests/test_session_static_assets.py
@@ -72,7 +72,9 @@ def test_session_static_js_returns_javascript_mime(monkeypatch):
     assert handle_get(handler, parsed) is True
     assert handler.status == 200
     ct = handler.header("Content-Type") or ""
-    assert ct.startswith("application/javascript"), f"expected application/javascript, got {ct!r}"
+    assert ct.startswith("application/javascript"), (
+        f"expected application/javascript, got {ct!r}"
+    )
 
 
 def test_session_html_route_still_serves_index():
@@ -120,12 +122,19 @@ def test_session_static_auth_exemption(monkeypatch):
 
     # /session/static/* is public (matches /static/* policy)
     handler = _FakeHandler()
-    assert check_auth(handler, SimpleNamespace(path="/session/static/style.css", query="")) is True
+    assert (
+        check_auth(handler, SimpleNamespace(path="/session/static/style.css", query=""))
+        is True
+    )
 
     # Confirm the /static/ baseline still works (regression guard)
     handler = _FakeHandler()
-    assert check_auth(handler, SimpleNamespace(path="/static/style.css", query="")) is True
+    assert (
+        check_auth(handler, SimpleNamespace(path="/static/style.css", query="")) is True
+    )
 
     # And confirm a non-static /session/* path still requires auth
     handler = _FakeHandler()
-    assert check_auth(handler, SimpleNamespace(path="/session/abc123", query="")) is False
+    assert (
+        check_auth(handler, SimpleNamespace(path="/session/abc123", query="")) is False
+    )

--- a/tests/test_session_summary_redaction.py
+++ b/tests/test_session_summary_redaction.py
@@ -12,6 +12,7 @@ sys.path.insert(0, str(pathlib.Path(__file__).parent.parent.parent))
 
 _needs_server = pytest.mark.usefixtures("test_server")
 from tests._pytest_port import BASE
+
 _FULL_SECRET = "sk-" + ("B" * 24)
 
 
@@ -27,24 +28,28 @@ def _write_session_with_secret_title():
     sessions_dir = TEST_STATE_DIR / "sessions"
     sessions_dir.mkdir(parents=True, exist_ok=True)
     now = time.time()
-    (sessions_dir / f"{sid}.json").write_text(json.dumps({
-        "session_id": sid,
-        "title": f"session with {_FULL_SECRET}",
-        "workspace": "/tmp",
-        "model": "test",
-        "created_at": now,
-        "updated_at": now,
-        "pinned": False,
-        "archived": False,
-        "project_id": None,
-        "profile": "default",
-        "input_tokens": 0,
-        "output_tokens": 0,
-        "estimated_cost": None,
-        "personality": None,
-        "messages": [],
-        "tool_calls": [],
-    }))
+    (sessions_dir / f"{sid}.json").write_text(
+        json.dumps(
+            {
+                "session_id": sid,
+                "title": f"session with {_FULL_SECRET}",
+                "workspace": "/tmp",
+                "model": "test",
+                "created_at": now,
+                "updated_at": now,
+                "pinned": False,
+                "archived": False,
+                "project_id": None,
+                "profile": "default",
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "estimated_cost": None,
+                "personality": None,
+                "messages": [],
+                "tool_calls": [],
+            }
+        )
+    )
     return sid
 
 

--- a/tests/test_settings_navigation_and_detail_refresh.py
+++ b/tests/test_settings_navigation_and_detail_refresh.py
@@ -1,4 +1,5 @@
 """Regression coverage for settings navigation and master-detail refresh state."""
+
 import pathlib
 import re
 
@@ -11,7 +12,10 @@ class TestSettingsNavigationGuard:
     """Leaving Settings through the rail must still honor save/discard semantics."""
 
     def test_switch_panel_checks_settings_guard(self):
-        assert "if (!opts.bypassSettingsGuard && !_beforePanelSwitch(nextPanel)) return false;" in PANELS_JS, (
+        assert (
+            "if (!opts.bypassSettingsGuard && !_beforePanelSwitch(nextPanel)) return false;"
+            in PANELS_JS
+        ), (
             "switchPanel() must consult the settings guard before leaving Settings "
             "so rail/sidebar navigation cannot bypass the unsaved-changes flow"
         )
@@ -44,7 +48,10 @@ class TestSettingsNavigationGuard:
         )
 
     def test_entering_settings_starts_fresh_preview_session(self):
-        assert "if (prevPanel !== 'settings' && nextPanel === 'settings') _beginSettingsPanelSession();" in PANELS_JS, (
+        assert (
+            "if (prevPanel !== 'settings' && nextPanel === 'settings') _beginSettingsPanelSession();"
+            in PANELS_JS
+        ), (
             "switchPanel() must snapshot the preview baseline when entering Settings "
             "through the main navigation"
         )
@@ -54,9 +61,10 @@ class TestMasterDetailRefreshClearsRemovedSelections:
     """Refreshes must not leave dead detail panes visible after a selection disappears."""
 
     def test_tasks_clear_empty_state_detail(self):
-        assert "if (_cronMode !== 'create' && _cronMode !== 'edit') _clearCronDetail();" in PANELS_JS, (
-            "loadCrons() must clear the detail pane when the jobs list becomes empty"
-        )
+        assert (
+            "if (_cronMode !== 'create' && _cronMode !== 'edit') _clearCronDetail();"
+            in PANELS_JS
+        ), "loadCrons() must clear the detail pane when the jobs list becomes empty"
 
     def test_tasks_clear_missing_selected_job(self):
         m = re.search(

--- a/tests/test_sidebar_first_turn_visibility.py
+++ b/tests/test_sidebar_first_turn_visibility.py
@@ -16,7 +16,9 @@ class TestSidebarFirstTurnVisibility:
             "send() must optimistically upsert the active session into the sidebar "
             "as soon as the local user message is pushed."
         )
-        push_idx = src.index("S.messages.push(userMsg);renderMessages();appendThinking();setBusy(true);")
+        push_idx = src.index(
+            "S.messages.push(userMsg);renderMessages();appendThinking();setBusy(true);"
+        )
         helper_idx = src.index("upsertActiveSessionForLocalTurn", push_idx)
         start_idx = src.index("api('/api/chat/start'", push_idx)
         assert helper_idx < start_idx, (
@@ -53,10 +55,17 @@ class TestSidebarFirstTurnVisibility:
 
     def test_chat_start_failure_clears_optimistic_streaming_state(self):
         messages = read("static/messages.js")
-        catch_start = messages.index("}catch(e){", messages.index("api('/api/chat/start'"))
-        failure_start = messages.index("S.messages.push({role:'assistant',content:`**Error:** ${errMsg}`});", catch_start)
-        catch_body = messages[failure_start:messages.index("return;", failure_start)]
-        assert "setBusy(false)" in catch_body, "chat/start failure must leave the active pane idle"
+        catch_start = messages.index(
+            "}catch(e){", messages.index("api('/api/chat/start'")
+        )
+        failure_start = messages.index(
+            "S.messages.push({role:'assistant',content:`**Error:** ${errMsg}`});",
+            catch_start,
+        )
+        catch_body = messages[failure_start : messages.index("return;", failure_start)]
+        assert "setBusy(false)" in catch_body, (
+            "chat/start failure must leave the active pane idle"
+        )
         assert "clearOptimisticSessionStreaming(activeSid)" in catch_body, (
             "If /api/chat/start fails after the optimistic sidebar upsert, the cached row "
             "must drop its streaming spinner immediately instead of waiting for polling."
@@ -77,8 +86,10 @@ class TestSidebarFirstTurnVisibility:
 
     def test_backend_compact_counts_pending_first_turn_as_visible(self):
         src = read("api/models.py")
-        compact = src[src.index("def compact"):src.index("def _get_profile_home")]
-        assert "has_pending_user_message" in compact and "pending_user_message" in compact, (
+        compact = src[src.index("def compact") : src.index("def _get_profile_home")]
+        assert (
+            "has_pending_user_message" in compact and "pending_user_message" in compact
+        ), (
             "Session.compact() must account for pending_user_message in sidebar metadata."
         )
         assert "message_count = max(message_count, 1)" in compact, (
@@ -90,15 +101,22 @@ class TestSidebarFirstTurnVisibility:
 
     def test_backend_index_filter_keeps_pending_first_turn_sessions(self):
         src = read("api/models.py")
-        index_filter_start = src.index("# Hide empty Untitled sessions from the UI entirely")
-        index_filter_end = src.index("result = [s for s in result if not _hide_from_default_sidebar", index_filter_start)
+        index_filter_start = src.index(
+            "# Hide empty Untitled sessions from the UI entirely"
+        )
+        index_filter_end = src.index(
+            "result = [s for s in result if not _hide_from_default_sidebar",
+            index_filter_start,
+        )
         index_filter = src[index_filter_start:index_filter_end]
         assert "has_pending_user_message" in index_filter, (
             "The index-path empty-session filter must exempt pending first-turn sessions, "
             "matching the full-scan fallback."
         )
 
-    def test_session_refresh_preserves_optimistic_first_turn_rows_when_server_lags(self):
+    def test_session_refresh_preserves_optimistic_first_turn_rows_when_server_lags(
+        self,
+    ):
         src = read("static/sessions.js")
         assert "function _mergeOptimisticFirstTurnSessions" in src, (
             "renderSessionList() must merge locally optimistically inserted first-turn rows "
@@ -110,7 +128,7 @@ class TestSidebarFirstTurnVisibility:
         render_end = src.index("// ── Gateway session SSE", render_start)
         render_body = src[render_start:render_end]
         assign_idx = render_body.index("_allSessions =")
-        assert "_mergeOptimisticFirstTurnSessions" in render_body[:assign_idx + 160], (
+        assert "_mergeOptimisticFirstTurnSessions" in render_body[: assign_idx + 160], (
             "The fetched session list should be merged with optimistic rows at the assignment "
             "site, before completion transitions or renderSessionListFromCache() run."
         )

--- a/tests/test_sidebar_unassigned_filter.py
+++ b/tests/test_sidebar_unassigned_filter.py
@@ -121,9 +121,10 @@ def test_empty_state_message_for_unassigned_filter():
     assert "'No unassigned sessions.'" in js, (
         "Empty-state copy must be specific when the Unassigned filter is active"
     )
-    assert "_activeProject===NO_PROJECT_FILTER?'No unassigned sessions.':'No sessions in this project yet.'" in js, (
-        "Empty-state copy must branch on the active filter"
-    )
+    assert (
+        "_activeProject===NO_PROJECT_FILTER?'No unassigned sessions.':'No sessions in this project yet.'"
+        in js
+    ), "Empty-state copy must branch on the active filter"
 
 
 def test_all_chip_clear_clears_unassigned_filter_too():
@@ -139,7 +140,9 @@ def test_all_chip_clear_clears_unassigned_filter_too():
     js = _js()
     # Find the "All" chip handler. It must clear _activeProject to null and
     # NOT preserve any unassigned-flag state.
-    assert "allChip.onclick=()=>{_activeProject=null;renderSessionListFromCache();};" in js, (
+    assert (
+        "allChip.onclick=()=>{_activeProject=null;renderSessionListFromCache();};" in js
+    ), (
         "The All chip handler must reset _activeProject to null. If a parallel "
         "_showNoneProject boolean is reintroduced, this test will catch it because "
         "the handler will need additional state to reset."

--- a/tests/test_sienna_skin.py
+++ b/tests/test_sienna_skin.py
@@ -11,9 +11,7 @@ INDEX_HTML = (REPO / "static" / "index.html").read_text(encoding="utf-8")
 def test_sienna_skin_present_in_skins_list():
     """The Sienna skin must be exposed in the picker grid via _SKINS."""
     assert "{name:'Sienna'" in BOOT_JS, "Sienna skin missing from _SKINS list"
-    assert "'#D97757','#C06A49','#9A523A'" in BOOT_JS, (
-        "Sienna preview swatches missing"
-    )
+    assert "'#D97757','#C06A49','#9A523A'" in BOOT_JS, "Sienna preview swatches missing"
 
 
 def test_sienna_skin_in_early_init_allowlist():
@@ -50,7 +48,12 @@ def test_sienna_skin_does_not_force_migration():
     init_script_idx = INDEX_HTML.find("var themes=")
     end_idx = INDEX_HTML.find("</script>", init_script_idx)
     init_block = INDEX_HTML[init_script_idx:end_idx]
-    forbidden = ["sienna-migrated", "skin-sienna-migrated", "skin='sienna'", 'skin="sienna"']
+    forbidden = [
+        "sienna-migrated",
+        "skin-sienna-migrated",
+        "skin='sienna'",
+        'skin="sienna"',
+    ]
     for marker in forbidden:
         assert marker not in init_block, (
             f"Sienna skin must be opt-in, not force-migrated. Found '{marker}' "

--- a/tests/test_simplified_tool_calling_setting.py
+++ b/tests/test_simplified_tool_calling_setting.py
@@ -1,10 +1,11 @@
 """Regression tests for the Simplified tool calling setting."""
 
-import importlib
 import json
 
 
-def test_simplified_tool_calling_defaults_enabled_and_round_trips(monkeypatch, tmp_path):
+def test_simplified_tool_calling_defaults_enabled_and_round_trips(
+    monkeypatch, tmp_path
+):
     import api.config as config
 
     settings_path = tmp_path / "settings.json"
@@ -15,7 +16,10 @@ def test_simplified_tool_calling_defaults_enabled_and_round_trips(monkeypatch, t
 
     saved = config.save_settings({"simplified_tool_calling": False})
     assert saved["simplified_tool_calling"] is False
-    assert json.loads(settings_path.read_text(encoding="utf-8"))["simplified_tool_calling"] is False
+    assert (
+        json.loads(settings_path.read_text(encoding="utf-8"))["simplified_tool_calling"]
+        is False
+    )
 
     saved = config.save_settings({"simplified_tool_calling": True})
     assert saved["simplified_tool_calling"] is True

--- a/tests/test_skills_category_collapse.py
+++ b/tests/test_skills_category_collapse.py
@@ -3,151 +3,167 @@
 Validates that renderSkills() produces collapsible category headers
 with chevron toggles, click handlers, and persisted collapse state.
 """
+
 import os
 import re
-import pytest
 
 
 def _readpanels():
-    with open(os.path.join('static', 'panels.js')) as f:
+    with open(os.path.join("static", "panels.js")) as f:
         return f.read()
 
 
 def _readcss():
-    with open(os.path.join('static', 'style.css')) as f:
+    with open(os.path.join("static", "style.css")) as f:
         return f.read()
 
 
 # ── State variable ──────────────────────────────────────────────────────────
+
 
 class TestCollapseState:
     """A Set must track collapsed categories across re-renders."""
 
     def test_collapsed_cats_set_exists(self):
         p = _readpanels()
-        assert '_collapsedCats' in p, '_collapsedCats Set must exist'
-        assert 'new Set()' in p, '_collapsedCats must be initialized as Set'
+        assert "_collapsedCats" in p, "_collapsedCats Set must exist"
+        assert "new Set()" in p, "_collapsedCats must be initialized as Set"
 
     def test_toggle_function_exists(self):
         p = _readpanels()
-        assert '_toggleCatCollapse' in p, '_toggleCatCollapse() function must exist'
+        assert "_toggleCatCollapse" in p, "_toggleCatCollapse() function must exist"
 
 
 # ── renderSkills produces collapsible headers ──────────────────────────────
+
 
 class TestRenderSkillsCollapse:
     """renderSkills() must render category headers with chevron icons and click handlers."""
 
     def test_chevron_icon_used_instead_of_folder(self):
         p = _readpanels()
-        idx = p.find('function renderSkills(')
-        body = p[idx:idx + 2000]
-        assert 'chevron-right' in body, 'Must use chevron-right icon instead of folder'
-        assert "li('folder'" not in body, 'Must not use folder icon anymore'
+        idx = p.find("function renderSkills(")
+        body = p[idx : idx + 2000]
+        assert "chevron-right" in body, "Must use chevron-right icon instead of folder"
+        assert "li('folder'" not in body, "Must not use folder icon anymore"
 
     def test_cat_header_has_dataset_cat(self):
         p = _readpanels()
-        idx = p.find('function renderSkills(')
-        body = p[idx:idx + 2000]
-        assert 'dataset.cat' in body, 'Header must store category in data-cat attribute'
+        idx = p.find("function renderSkills(")
+        body = p[idx : idx + 2000]
+        assert "dataset.cat" in body, "Header must store category in data-cat attribute"
 
     def test_cat_header_has_click_handler(self):
         p = _readpanels()
-        idx = p.find('function renderSkills(')
-        body = p[idx:idx + 2000]
-        assert 'hdr.onclick' in body or 'onclick' in body, 'Header must have onclick handler'
+        idx = p.find("function renderSkills(")
+        body = p[idx : idx + 2000]
+        assert "hdr.onclick" in body or "onclick" in body, (
+            "Header must have onclick handler"
+        )
 
     def test_collapsed_class_toggled(self):
         p = _readpanels()
-        idx = p.find('function renderSkills(')
-        body = p[idx:idx + 2000]
-        assert 'collapsed' in body, 'Must apply collapsed class based on state'
+        idx = p.find("function renderSkills(")
+        body = p[idx : idx + 2000]
+        assert "collapsed" in body, "Must apply collapsed class based on state"
 
     def test_skill_items_hidden_when_collapsed(self):
         p = _readpanels()
-        idx = p.find('function renderSkills(')
-        body = p[idx:idx + 2000]
-        assert "'none'" in body and "style.display" in body, 'Skill items must be hidden when category is collapsed'
+        idx = p.find("function renderSkills(")
+        body = p[idx : idx + 2000]
+        assert "'none'" in body and "style.display" in body, (
+            "Skill items must be hidden when category is collapsed"
+        )
 
     def test_chevron_rotation_on_collapse(self):
         p = _readpanels()
-        idx = p.find('function renderSkills(')
-        body = p[idx:idx + 2000]
-        assert 'rotate(90deg)' in body, 'Chevron must rotate 90deg when expanded'
+        idx = p.find("function renderSkills(")
+        body = p[idx : idx + 2000]
+        assert "rotate(90deg)" in body, "Chevron must rotate 90deg when expanded"
 
     def test_renderSkills_preserves_search_query(self):
         """Search query must still be read and applied before grouping."""
         p = _readpanels()
-        idx = p.find('function renderSkills(')
-        body = p[idx:idx + 500]
-        assert 'skillsSearch' in body, 'Must read search input value'
-        assert 'toLowerCase().includes(query)' in body, 'Must filter by name/description/category'
+        idx = p.find("function renderSkills(")
+        body = p[idx : idx + 500]
+        assert "skillsSearch" in body, "Must read search input value"
+        assert "toLowerCase().includes(query)" in body, (
+            "Must filter by name/description/category"
+        )
 
 
 # ── _toggleCatCollapse DOM manipulation ────────────────────────────────────
+
 
 class TestToggleCatCollapse:
     """_toggleCatCollapse() must toggle DOM without full re-render."""
 
     def test_toggles_set_membership(self):
         p = _readpanels()
-        idx = p.find('function _toggleCatCollapse(')
-        body = p[idx:idx + 500]
-        assert '_collapsedCats.has(cat)' in body
-        assert '_collapsedCats.delete(cat)' in body
-        assert '_collapsedCats.add(cat)' in body
+        idx = p.find("function _toggleCatCollapse(")
+        body = p[idx : idx + 500]
+        assert "_collapsedCats.has(cat)" in body
+        assert "_collapsedCats.delete(cat)" in body
+        assert "_collapsedCats.add(cat)" in body
 
     def test_queries_skills_category_elements(self):
         p = _readpanels()
-        idx = p.find('function _toggleCatCollapse(')
-        body = p[idx:idx + 800]
-        assert '.skills-category' in body, 'Must query .skills-category elements'
+        idx = p.find("function _toggleCatCollapse(")
+        body = p[idx : idx + 800]
+        assert ".skills-category" in body, "Must query .skills-category elements"
 
     def test_matches_by_dataset_cat(self):
         p = _readpanels()
-        idx = p.find('function _toggleCatCollapse(')
-        body = p[idx:idx + 800]
-        assert 'header.dataset.cat === cat' in body or 'dataset.cat' in body, 'Must match category by data attribute'
+        idx = p.find("function _toggleCatCollapse(")
+        body = p[idx : idx + 800]
+        assert "header.dataset.cat === cat" in body or "dataset.cat" in body, (
+            "Must match category by data attribute"
+        )
 
     def test_toggles_skill_item_display(self):
         p = _readpanels()
-        idx = p.find('function _toggleCatCollapse(')
-        body = p[idx:idx + 800]
-        assert '.skill-item' in body, 'Must query .skill-item elements'
-        assert "display = collapsed ? 'none'" in body or "style.display" in body, 'Must toggle display property'
+        idx = p.find("function _toggleCatCollapse(")
+        body = p[idx : idx + 800]
+        assert ".skill-item" in body, "Must query .skill-item elements"
+        assert "display = collapsed ? 'none'" in body or "style.display" in body, (
+            "Must toggle display property"
+        )
 
     def test_toggles_chevron_rotation(self):
         p = _readpanels()
-        idx = p.find('function _toggleCatCollapse(')
-        body = p[idx:idx + 800]
-        assert '.cat-chevron' in body, 'Must select chevron element'
-        assert 'rotate' in body, 'Must toggle rotation on chevron'
+        idx = p.find("function _toggleCatCollapse(")
+        body = p[idx : idx + 800]
+        assert ".cat-chevron" in body, "Must select chevron element"
+        assert "rotate" in body, "Must toggle rotation on chevron"
 
 
 # ── CSS ────────────────────────────────────────────────────────────────────
+
 
 class TestCSSClasses:
     """CSS must support collapsible categories."""
 
     def test_cat_chevron_class(self):
         css = _readcss()
-        assert '.cat-chevron' in css, '.cat-chevron class must exist in CSS'
+        assert ".cat-chevron" in css, ".cat-chevron class must exist in CSS"
 
     def test_cat_chevron_has_fixed_size(self):
         css = _readcss()
-        m = re.search(r'\.cat-chevron\{[^}]+\}', css)
-        assert m, '.cat-chevron rule must exist'
-        assert 'width' in m.group(), 'Chevron must have fixed width'
-        assert 'flex-shrink' in m.group(), 'Chevron must not shrink'
+        m = re.search(r"\.cat-chevron\{[^}]+\}", css)
+        assert m, ".cat-chevron rule must exist"
+        assert "width" in m.group(), "Chevron must have fixed width"
+        assert "flex-shrink" in m.group(), "Chevron must not shrink"
 
     def test_skills_cat_header_user_select_none(self):
         css = _readcss()
-        m = re.search(r'\.skills-cat-header\{[^}]+\}', css)
-        assert m, '.skills-cat-header rule must exist'
-        assert 'user-select' in m.group(), 'Header must have user-select:none to prevent text selection on click'
+        m = re.search(r"\.skills-cat-header\{[^}]+\}", css)
+        assert m, ".skills-cat-header rule must exist"
+        assert "user-select" in m.group(), (
+            "Header must have user-select:none to prevent text selection on click"
+        )
 
     def test_skills_cat_header_has_cursor_pointer(self):
         css = _readcss()
-        m = re.search(r'\.skills-cat-header\{[^}]+\}', css)
-        assert m, '.skills-cat-header rule must exist'
-        assert 'cursor:pointer' in m.group(), 'Header must have cursor:pointer'
+        m = re.search(r"\.skills-cat-header\{[^}]+\}", css)
+        assert m, ".skills-cat-header rule must exist"
+        assert "cursor:pointer" in m.group(), "Header must have cursor:pointer"

--- a/tests/test_sprint1.py
+++ b/tests/test_sprint1.py
@@ -14,14 +14,12 @@ No mocking required for session CRUD, upload parser, or approval API.
 
 import io
 import json
-import os
 import sys
 import time
 import uuid
 import urllib.request
 import urllib.parse
 import urllib.error
-import tempfile
 import pathlib
 
 # Allow importing server modules directly for unit tests
@@ -34,6 +32,7 @@ from tests._pytest_port import BASE
 # HTTP helpers
 # ──────────────────────────────────────────────
 
+
 def get(path):
     url = BASE + path
     with urllib.request.urlopen(url, timeout=10) as r:
@@ -43,8 +42,9 @@ def get(path):
 def post(path, body=None):
     url = BASE + path
     data = json.dumps(body or {}).encode()
-    req = urllib.request.Request(url, data=data,
-          headers={"Content-Type": "application/json"})
+    req = urllib.request.Request(
+        url, data=data, headers={"Content-Type": "application/json"}
+    )
     try:
         with urllib.request.urlopen(req, timeout=10) as r:
             return json.loads(r.read()), r.status
@@ -58,16 +58,19 @@ def post_multipart(path, fields, files):
     body = b""
     for name, value in fields.items():
         body += b"--" + boundary + b"\r\n"
-        body += f"Content-Disposition: form-data; name=\"{name}\"\r\n\r\n".encode()
+        body += f'Content-Disposition: form-data; name="{name}"\r\n\r\n'.encode()
         body += value.encode() + b"\r\n"
     for name, (filename, data) in files.items():
         body += b"--" + boundary + b"\r\n"
-        body += f"Content-Disposition: form-data; name=\"{name}\"; filename=\"{filename}\"\r\n".encode()
+        body += f'Content-Disposition: form-data; name="{name}"; filename="{filename}"\r\n'.encode()
         body += b"Content-Type: application/octet-stream\r\n\r\n"
         body += data + b"\r\n"
     body += b"--" + boundary + b"--\r\n"
-    req = urllib.request.Request(BASE + path, data=body,
-          headers={"Content-Type": f"multipart/form-data; boundary={boundary.decode()}"})
+    req = urllib.request.Request(
+        BASE + path,
+        data=body,
+        headers={"Content-Type": f"multipart/form-data; boundary={boundary.decode()}"},
+    )
     try:
         with urllib.request.urlopen(req, timeout=10) as r:
             return json.loads(r.read()), r.status
@@ -78,17 +81,18 @@ def post_multipart(path, fields, files):
 def make_session_tracked(created_list, ws=None):
     """Create a session and register it with the cleanup fixture."""
     body = {}
-    if ws: body["workspace"] = str(ws)
+    if ws:
+        body["workspace"] = str(ws)
     d, _ = post("/api/session/new", body)
     sid = d["session"]["session_id"]
     created_list.append(sid)
     return sid, pathlib.Path(d["session"]["workspace"])
 
 
-
 # ──────────────────────────────────────────────
 # Health check (prerequisite for all tests)
 # ──────────────────────────────────────────────
+
 
 def test_health():
     """Server must be running and healthy."""
@@ -99,6 +103,7 @@ def test_health():
 # ──────────────────────────────────────────────
 # B11: /api/session GET footgun fix
 # ──────────────────────────────────────────────
+
 
 def test_session_get_no_id_returns_400():
     """B11: GET /api/session with no session_id must return 400, not silently create."""
@@ -115,6 +120,7 @@ def test_session_get_no_id_returns_400():
 # ──────────────────────────────────────────────
 # Session CRUD
 # ──────────────────────────────────────────────
+
 
 def test_session_create_and_load():
     """Create a session, verify it appears in /api/sessions, load it."""
@@ -149,11 +155,14 @@ def test_session_update():
     child_ws = current_ws / f"session-update-{uuid.uuid4().hex[:6]}"
     child_ws.mkdir(parents=True, exist_ok=True)
 
-    updated, status = post("/api/session/update", {
-        "session_id": sid,
-        "workspace": str(child_ws),
-        "model": "anthropic/claude-sonnet-4.6"
-    })
+    updated, status = post(
+        "/api/session/update",
+        {
+            "session_id": sid,
+            "workspace": str(child_ws),
+            "model": "anthropic/claude-sonnet-4.6",
+        },
+    )
     assert status == 200
     assert updated["session"]["model"] == "anthropic/claude-sonnet-4.6"
 
@@ -202,8 +211,9 @@ def test_sessions_list_sorted():
     sids = [s["session_id"] for s in sessions["sessions"]]
 
     # b was updated more recently, should appear before a
-    assert sids.index(sid_b) < sids.index(sid_a), \
+    assert sids.index(sid_b) < sids.index(sid_a), (
         "Sessions not sorted by updated_at desc"
+    )
 
     # Cleanup
     post("/api/session/delete", {"session_id": sid_a})
@@ -214,20 +224,22 @@ def test_sessions_list_sorted():
 # Upload parser unit tests (pure function, no HTTP)
 # ──────────────────────────────────────────────
 
+
 def test_parse_multipart_text_file():
     """parse_multipart correctly parses a text file field."""
     sys.path.insert(0, str(pathlib.Path(__file__).parent.parent.parent))
     # Import the function directly from the server module
     import importlib.util
+
     spec = importlib.util.spec_from_file_location(
-        "server",
-        str(pathlib.Path(__file__).parent.parent / "server.py")
+        "server", str(pathlib.Path(__file__).parent.parent / "server.py")
     )
     # We only need parse_multipart; import it without running the server
     # Parse manually by reading the source and exec only the function
     src = pathlib.Path(__file__).parent.parent.joinpath("api/upload.py").read_text()
     # Extract and exec parse_multipart
     import re
+
     # Find the function
     m = re.search(r"(def parse_multipart\(.*?)(?=\ndef )", src, re.DOTALL)
     assert m, "Could not find parse_multipart in server.py"
@@ -239,18 +251,16 @@ def test_parse_multipart_text_file():
     boundary = b"testboundary"
     body = (
         b"--testboundary\r\n"
-        b"Content-Disposition: form-data; name=\"session_id\"\r\n\r\n"
+        b'Content-Disposition: form-data; name="session_id"\r\n\r\n'
         b"abc123\r\n"
         b"--testboundary\r\n"
-        b"Content-Disposition: form-data; name=\"file\"; filename=\"hello.txt\"\r\n"
+        b'Content-Disposition: form-data; name="file"; filename="hello.txt"\r\n'
         b"Content-Type: text/plain\r\n\r\n"
         b"hello world\r\n"
         b"--testboundary--\r\n"
     )
     fields, files = parse_multipart(
-        io.BytesIO(body),
-        "multipart/form-data; boundary=testboundary",
-        len(body)
+        io.BytesIO(body), "multipart/form-data; boundary=testboundary", len(body)
     )
     assert fields.get("session_id") == "abc123", f"fields: {fields}"
     assert "file" in files, f"files: {files}"
@@ -263,6 +273,7 @@ def test_parse_multipart_binary_file():
     """parse_multipart handles binary (PNG header bytes) without corruption."""
     src = pathlib.Path(__file__).parent.parent.joinpath("api/upload.py").read_text()
     import re
+
     m = re.search(r"(def parse_multipart\(.*?)(?=\ndef )", src, re.DOTALL)
     ns = {}
     exec("import re as _re, email.parser as _ep\n" + m.group(1), ns)
@@ -273,17 +284,15 @@ def test_parse_multipart_binary_file():
     boundary = b"binboundary"
     body = (
         b"--binboundary\r\n"
-        b"Content-Disposition: form-data; name=\"session_id\"\r\n\r\n"
+        b'Content-Disposition: form-data; name="session_id"\r\n\r\n'
         b"sess1\r\n"
         b"--binboundary\r\n"
-        b"Content-Disposition: form-data; name=\"file\"; filename=\"test.png\"\r\n"
+        b'Content-Disposition: form-data; name="file"; filename="test.png"\r\n'
         b"Content-Type: image/png\r\n\r\n" + png_magic + b"\r\n"
         b"--binboundary--\r\n"
     )
     fields, files = parse_multipart(
-        io.BytesIO(body),
-        "multipart/form-data; boundary=binboundary",
-        len(body)
+        io.BytesIO(body), "multipart/form-data; boundary=binboundary", len(body)
     )
     assert "file" in files
     filename, content = files["file"]
@@ -295,13 +304,16 @@ def test_parse_multipart_binary_file():
 # File upload via HTTP
 # ──────────────────────────────────────────────
 
+
 def test_upload_text_file(cleanup_test_sessions):
     """Upload a text file to a session workspace, verify it appears in /api/list."""
     sid, ws = make_session_tracked(cleanup_test_sessions)
 
-    result, status = post_multipart("/api/upload", {"session_id": sid}, {
-        "file": ("test_upload.txt", b"sprint1 test content")
-    })
+    result, status = post_multipart(
+        "/api/upload",
+        {"session_id": sid},
+        {"file": ("test_upload.txt", b"sprint1 test content")},
+    )
     assert status == 200, f"Upload failed {status}: {result}"
     assert "filename" in result
     assert result["size"] == len(b"sprint1 test content")
@@ -321,9 +333,9 @@ def test_upload_too_large(cleanup_test_sessions):
     # 21MB > 20MB limit
     big = b"x" * (21 * 1024 * 1024)
     try:
-        result, status = post_multipart("/api/upload", {"session_id": sid}, {
-            "file": ("big.bin", big)
-        })
+        result, status = post_multipart(
+            "/api/upload", {"session_id": sid}, {"file": ("big.bin", big)}
+        )
         # If we get a response it should be 413
         assert status == 413, f"Expected 413, got {status}: {result}"
     except (urllib.error.URLError, ConnectionResetError, BrokenPipeError):
@@ -341,15 +353,16 @@ def test_upload_no_file_field(cleanup_test_sessions):
 
 def test_upload_bad_session():
     """Upload to nonexistent session returns 404."""
-    result, status = post_multipart("/api/upload", {"session_id": "nosuchsession"}, {
-        "file": ("x.txt", b"data")
-    })
+    result, status = post_multipart(
+        "/api/upload", {"session_id": "nosuchsession"}, {"file": ("x.txt", b"data")}
+    )
     assert status == 404, f"Expected 404, got {status}: {result}"
 
 
 # ──────────────────────────────────────────────
 # Approval API
 # ──────────────────────────────────────────────
+
 
 def test_approval_pending_none():
     """GET /api/approval/pending for a session with no pending entry returns null."""
@@ -364,7 +377,9 @@ def test_approval_submit_and_respond():
     key = "recursive_delete"
 
     # Inject into server process via test endpoint (shared module state)
-    inject = get(f"/api/approval/inject_test?session_id={urllib.parse.quote(test_sid)}&pattern_key={key}&command={urllib.parse.quote(cmd)}")
+    inject = get(
+        f"/api/approval/inject_test?session_id={urllib.parse.quote(test_sid)}&pattern_key={key}&command={urllib.parse.quote(cmd)}"
+    )
     assert inject["ok"] is True
 
     # Poll should now show the pending entry
@@ -373,10 +388,9 @@ def test_approval_submit_and_respond():
     assert data["pending"]["command"] == cmd
 
     # Respond with deny
-    result, status = post("/api/approval/respond", {
-        "session_id": test_sid,
-        "choice": "deny"
-    })
+    result, status = post(
+        "/api/approval/respond", {"session_id": test_sid, "choice": "deny"}
+    )
     assert status == 200
     assert result["ok"] is True
     assert result["choice"] == "deny"
@@ -390,25 +404,29 @@ def test_approval_respond_allow_session():
     """Inject pending entry, respond with session choice, verify cleared (approved)."""
     test_sid = f"test-approval-sess-{uuid.uuid4().hex[:6]}"
 
-    inject = get(f"/api/approval/inject_test?session_id={urllib.parse.quote(test_sid)}&pattern_key=force_kill&command=pkill+-9+someproc")
+    inject = get(
+        f"/api/approval/inject_test?session_id={urllib.parse.quote(test_sid)}&pattern_key=force_kill&command=pkill+-9+someproc"
+    )
     assert inject["ok"] is True
 
-    result, status = post("/api/approval/respond", {
-        "session_id": test_sid,
-        "choice": "session"
-    })
+    result, status = post(
+        "/api/approval/respond", {"session_id": test_sid, "choice": "session"}
+    )
     assert status == 200
     assert result["ok"] is True
     assert result["choice"] == "session"
 
     # After session approval, pending should be cleared
     data = get(f"/api/approval/pending?session_id={urllib.parse.quote(test_sid)}")
-    assert data["pending"] is None, "Pending entry should be cleared after session approval"
+    assert data["pending"] is None, (
+        "Pending entry should be cleared after session approval"
+    )
 
 
 # ──────────────────────────────────────────────
 # Stream status endpoint (B4/B5)
 # ──────────────────────────────────────────────
+
 
 def test_stream_status_unknown_id():
     """GET /api/chat/stream/status for unknown stream_id returns active:false."""
@@ -419,6 +437,7 @@ def test_stream_status_unknown_id():
 # ──────────────────────────────────────────────
 # File browser
 # ──────────────────────────────────────────────
+
 
 def test_list_dir(cleanup_test_sessions):
     """List workspace directory for a session."""
@@ -437,4 +456,6 @@ def test_list_dir_path_traversal(cleanup_test_sessions):
         # (safe_resolve should raise ValueError)
         assert False, f"Expected error for path traversal, got: {listing}"
     except urllib.error.HTTPError as e:
-        assert e.code in (400, 404, 500), f"Expected 400/404/500 for traversal, got {e.code}"
+        assert e.code in (400, 404, 500), (
+            f"Expected 400/404/500 for traversal, got {e.code}"
+        )

--- a/tests/test_sprint10.py
+++ b/tests/test_sprint10.py
@@ -1,28 +1,39 @@
 """
 Sprint 10 Tests: server.py split, cancel endpoint, cron history, tool card polish.
 """
-import json, pathlib, urllib.error, urllib.request, urllib.parse
+
+import json
+import pathlib
+import urllib.error
+import urllib.request
+import urllib.parse
+
 REPO_ROOT = pathlib.Path(__file__).parent.parent.resolve()
 
 from tests._pytest_port import BASE
+
 
 def get(path):
     with urllib.request.urlopen(BASE + path, timeout=10) as r:
         return json.loads(r.read()), r.status
 
+
 def get_text(path):
     with urllib.request.urlopen(BASE + path, timeout=10) as r:
         return r.read().decode(), r.status
 
+
 def post(path, body=None):
     data = json.dumps(body or {}).encode()
-    req = urllib.request.Request(BASE + path, data=data,
-                                  headers={"Content-Type": "application/json"})
+    req = urllib.request.Request(
+        BASE + path, data=data, headers={"Content-Type": "application/json"}
+    )
     try:
         with urllib.request.urlopen(req, timeout=10) as r:
             return json.loads(r.read()), r.status
     except urllib.error.HTTPError as e:
         return json.loads(e.read()), e.code
+
 
 def make_session(created_list):
     d, _ = post("/api/session/new", {})
@@ -30,7 +41,9 @@ def make_session(created_list):
     created_list.append(sid)
     return sid
 
+
 # ── server.py split: api/ modules served / importable ─────────────────────
+
 
 def test_health_still_works(cleanup_test_sessions):
     data, status = get("/health")
@@ -39,22 +52,33 @@ def test_health_still_works(cleanup_test_sessions):
     assert "uptime_seconds" in data
     assert "active_streams" in data
 
+
 def test_api_modules_exist(cleanup_test_sessions):
     """All api/ module files must exist on disk."""
     base = REPO_ROOT / "api"
-    for mod in ["__init__.py", "config.py", "helpers.py", "models.py",
-                "workspace.py", "upload.py", "streaming.py"]:
+    for mod in [
+        "__init__.py",
+        "config.py",
+        "helpers.py",
+        "models.py",
+        "workspace.py",
+        "upload.py",
+        "streaming.py",
+    ]:
         assert (base / mod).exists(), f"Missing api/{mod}"
+
 
 def test_server_py_under_750_lines(cleanup_test_sessions):
     """server.py should be under 750 lines after the split."""
     lines = len((REPO_ROOT / "server.py").read_text().splitlines())
     assert lines < 750, f"server.py is {lines} lines -- split may not have landed"
 
+
 def test_api_config_has_cancel_flags(cleanup_test_sessions):
     src = (REPO_ROOT / "api/config.py").read_text()
     assert "CANCEL_FLAGS" in src
     assert "STREAMS" in src
+
 
 def test_session_crud_still_works(cleanup_test_sessions):
     """Full session lifecycle works after split."""
@@ -65,13 +89,23 @@ def test_session_crud_still_works(cleanup_test_sessions):
     assert data["session"]["session_id"] == sid
     post("/api/session/delete", {"session_id": sid})
 
+
 def test_static_files_still_served(cleanup_test_sessions):
-    for f in ["ui.js", "workspace.js", "sessions.js", "messages.js", "panels.js", "boot.js"]:
+    for f in [
+        "ui.js",
+        "workspace.js",
+        "sessions.js",
+        "messages.js",
+        "panels.js",
+        "boot.js",
+    ]:
         src, status = get_text(f"/static/{f}")
         assert status == 200, f"/static/{f} returned {status}"
         assert len(src) > 100
 
+
 # ── Cancel endpoint ────────────────────────────────────────────────────────
+
 
 def test_cancel_requires_stream_id(cleanup_test_sessions):
     try:
@@ -80,29 +114,35 @@ def test_cancel_requires_stream_id(cleanup_test_sessions):
     except urllib.error.HTTPError as e:
         assert e.code == 400
 
+
 def test_cancel_nonexistent_stream(cleanup_test_sessions):
     data, status = get("/api/chat/cancel?stream_id=nonexistent_xyz")
     assert status == 200
     assert data["ok"] is True
     assert data["cancelled"] is False
 
+
 def test_send_button_in_html(cleanup_test_sessions):
     src, _ = get_text("/")
-    assert "btnSend" in src                   # single primary action button present
-    assert 'id="btnCancel"' not in src        # deprecated composer cancel button removed
+    assert "btnSend" in src  # single primary action button present
+    assert 'id="btnCancel"' not in src  # deprecated composer cancel button removed
+
 
 def test_cancel_function_in_boot_js(cleanup_test_sessions):
     src, _ = get_text("/static/boot.js")
     assert "async function cancelStream(" in src
     assert "api/chat/cancel" in src
 
+
 # ── Cron history ───────────────────────────────────────────────────────────
+
 
 def test_crons_output_limit_param(cleanup_test_sessions):
     """Server accepts limit parameter > 1."""
     data, status = get("/api/crons/output?job_id=nonexistent&limit=20")
     # 404 or 200 with empty -- both acceptable for nonexistent job
     assert status in (200, 404)
+
 
 def test_cron_history_button_in_panels_js(cleanup_test_sessions):
     src, _ = get_text("/static/panels.js")
@@ -111,20 +151,21 @@ def test_cron_history_button_in_panels_js(cleanup_test_sessions):
     assert "_loadCronDetailRuns" in src
     assert "cron_last_output" in src  # i18n key used by the runs card
 
+
 def test_cron_output_snippet_helper(cleanup_test_sessions):
     src, _ = get_text("/static/panels.js")
     assert "_cronOutputSnippet" in src
 
 
-def test_cron_output_window_preserves_response_after_large_prompt(cleanup_test_sessions):
+def test_cron_output_window_preserves_response_after_large_prompt(
+    cleanup_test_sessions,
+):
     """Large skill dumps before ## Response must not hide the useful output."""
     from api.routes import _cron_output_content_window
 
     content = (
         "Job metadata\n"
-        "## Prompt\n"
-        + ("skill dump\n" * 1200)
-        + "user prompt\n"
+        "## Prompt\n" + ("skill dump\n" * 1200) + "user prompt\n"
         "## Response\n"
         "actual useful cron result\n"
     )
@@ -149,26 +190,32 @@ def test_cron_output_window_without_response_uses_tail(cleanup_test_sessions):
     assert window.endswith("tail result")
     assert "old prompt" not in window
 
+
 # ── Tool card polish ───────────────────────────────────────────────────────
+
 
 def test_tool_card_running_dot_in_css(cleanup_test_sessions):
     src, _ = get_text("/static/style.css")
     assert "tool-card-running-dot" in src
+
 
 def test_tool_card_show_more_in_ui_js(cleanup_test_sessions):
     src, _ = get_text("/static/ui.js")
     assert "Show more" in src
     assert "tool-card-more" in src
 
+
 def test_tool_card_smart_truncation_in_ui_js(cleanup_test_sessions):
     src, _ = get_text("/static/ui.js")
     assert "displaySnippet" in src
     assert "lastBreak" in src
 
+
 def test_cancel_sse_event_handler_in_messages_js(cleanup_test_sessions):
     src, _ = get_text("/static/messages.js")
     assert "addEventListener('cancel'" in src
     assert "Task cancelled" in src
+
 
 def test_active_stream_id_tracked(cleanup_test_sessions):
     src, _ = get_text("/static/messages.js")

--- a/tests/test_sprint11.py
+++ b/tests/test_sprint11.py
@@ -1,19 +1,28 @@
 """
 Sprint 11 Tests: multi-provider model support, streaming smoothness, routes extraction.
 """
-import json, pathlib, urllib.error, urllib.request, urllib.parse
+
+import json
+import pathlib
+import urllib.error
+import urllib.request
+import urllib.parse
+
 REPO_ROOT = pathlib.Path(__file__).parent.parent.resolve()
 
 from tests._pytest_port import BASE
+
 
 def get(path):
     with urllib.request.urlopen(BASE + path, timeout=10) as r:
         return json.loads(r.read()), r.status
 
+
 def post(path, body=None):
     data = json.dumps(body or {}).encode()
-    req = urllib.request.Request(BASE + path, data=data,
-                                  headers={"Content-Type": "application/json"})
+    req = urllib.request.Request(
+        BASE + path, data=data, headers={"Content-Type": "application/json"}
+    )
     try:
         with urllib.request.urlopen(req, timeout=10) as r:
             return json.loads(r.read()), r.status
@@ -23,79 +32,92 @@ def post(path, body=None):
 
 # ── /api/models endpoint ──────────────────────────────────────────────────
 
+
 def test_models_endpoint_returns_200():
     """GET /api/models returns a valid response."""
     d, status = get("/api/models")
     assert status == 200
 
+
 def test_models_has_required_fields():
     """Response includes groups, default_model, and active_provider."""
     d, _ = get("/api/models")
-    assert 'groups' in d
-    assert 'default_model' in d
-    assert 'active_provider' in d
+    assert "groups" in d
+    assert "default_model" in d
+    assert "active_provider" in d
+
 
 def test_models_groups_structure():
     """Each group has provider name and models list."""
     d, _ = get("/api/models")
-    assert isinstance(d['groups'], list)
-    assert len(d['groups']) > 0
-    for group in d['groups']:
-        assert 'provider' in group
-        assert 'models' in group
-        assert isinstance(group['models'], list)
-        assert len(group['models']) > 0
+    assert isinstance(d["groups"], list)
+    assert len(d["groups"]) > 0
+    for group in d["groups"]:
+        assert "provider" in group
+        assert "models" in group
+        assert isinstance(group["models"], list)
+        assert len(group["models"]) > 0
+
 
 def test_models_model_structure():
     """Each model has id and label."""
     d, _ = get("/api/models")
-    for group in d['groups']:
-        for model in group['models']:
-            assert 'id' in model
-            assert 'label' in model
-            assert isinstance(model['id'], str)
-            assert isinstance(model['label'], str)
-            assert len(model['id']) > 0
-            assert len(model['label']) > 0
+    for group in d["groups"]:
+        for model in group["models"]:
+            assert "id" in model
+            assert "label" in model
+            assert isinstance(model["id"], str)
+            assert isinstance(model["label"], str)
+            assert len(model["id"]) > 0
+            assert len(model["label"]) > 0
+
 
 def test_models_default_model_not_empty():
     """When HERMES_WEBUI_DEFAULT_MODEL env var is set (as in conftest), the
     /api/models response includes a non-empty default_model string."""
     d, _ = get("/api/models")
-    assert isinstance(d['default_model'], str)
+    assert isinstance(d["default_model"], str)
     # conftest sets HERMES_WEBUI_DEFAULT_MODEL to "openai/gpt-5.4-mini", so
     # this value should be non-empty in the test environment.
     # When no env var is set (production with empty default), default_model
     # can be "" — that is intentional (see PR #649).
-    assert len(d['default_model']) > 0  # only holds because conftest sets the env var
+    assert len(d["default_model"]) > 0  # only holds because conftest sets the env var
+
 
 def test_models_at_least_one_provider():
     """At least one provider group should exist (fallback list at minimum)."""
     d, _ = get("/api/models")
-    providers = [g['provider'] for g in d['groups']]
+    providers = [g["provider"] for g in d["groups"]]
     assert len(providers) >= 1
+
 
 def test_models_no_duplicate_ids():
     """Model IDs should not be duplicated within a single group."""
     d, _ = get("/api/models")
-    for group in d['groups']:
-        ids = [m['id'] for m in group['models']]
-        assert len(ids) == len(set(ids)), f"Duplicate model IDs in {group['provider']}: {ids}"
+    for group in d["groups"]:
+        ids = [m["id"] for m in group["models"]]
+        assert len(ids) == len(set(ids)), (
+            f"Duplicate model IDs in {group['provider']}: {ids}"
+        )
+
 
 def test_session_preserves_unlisted_model():
     """A session with a model not in the dropdown should still load correctly."""
     # Create a session with a custom model string
     d, _ = post("/api/session/new", {})
-    sid = d['session']['session_id']
+    sid = d["session"]["session_id"]
     try:
-        custom_model = 'custom-provider/test-model-999'
-        post("/api/session/update", {
-            'session_id': sid,
-            'model': custom_model,
-            'workspace': d['session']['workspace']
-        })
+        custom_model = "custom-provider/test-model-999"
+        post(
+            "/api/session/update",
+            {
+                "session_id": sid,
+                "model": custom_model,
+                "workspace": d["session"]["workspace"],
+            },
+        )
         # Reload and verify model persisted
         d2, _ = get(f"/api/session?session_id={sid}")
-        assert d2['session']['model'] == custom_model
+        assert d2["session"]["model"] == custom_model
     finally:
-        post("/api/session/delete", {'session_id': sid})
+        post("/api/session/delete", {"session_id": sid})

--- a/tests/test_sprint12.py
+++ b/tests/test_sprint12.py
@@ -1,7 +1,11 @@
 """
 Sprint 12 Tests: settings panel, session pinning, session import, SSE reconnect.
 """
-import json, pathlib, urllib.error, urllib.request, urllib.parse
+
+import json
+import urllib.error
+import urllib.request
+import urllib.parse
 
 from tests._pytest_port import BASE, TEST_DEFAULT_MODEL
 
@@ -13,8 +17,9 @@ def get(path):
 
 def post(path, body=None):
     data = json.dumps(body or {}).encode()
-    req = urllib.request.Request(BASE + path, data=data,
-                                headers={"Content-Type": "application/json"})
+    req = urllib.request.Request(
+        BASE + path, data=data, headers={"Content-Type": "application/json"}
+    )
     try:
         with urllib.request.urlopen(req, timeout=10) as r:
             return json.loads(r.read()), r.status
@@ -31,12 +36,14 @@ def make_session(created_list):
 
 # ── Settings API ──────────────────────────────────────────────────────────
 
+
 def test_settings_get_returns_defaults():
     """GET /api/settings returns default settings."""
     d, status = get("/api/settings")
     assert status == 200
-    assert 'default_model' in d
-    assert 'default_workspace' in d
+    assert "default_model" in d
+    assert "default_workspace" in d
+
 
 def test_default_model_updates_hermes_config():
     """POST /api/default-model updates the effective Hermes default model.
@@ -50,12 +57,12 @@ def test_default_model_updates_hermes_config():
         assert status == 200
         # Lightweight ack — no longer the full catalog
         assert d.get("ok") is True, f"expected ok=True, got {d}"
-        assert 'claude-sonnet-4.6' in d.get("model", ""), (
+        assert "claude-sonnet-4.6" in d.get("model", ""), (
             f"response model field should echo the saved model: {d}"
         )
         # Verify the setting actually persisted
         d2, _ = get("/api/settings")
-        assert 'claude-sonnet-4.6' in d2['default_model']
+        assert "claude-sonnet-4.6" in d2["default_model"]
     finally:
         post("/api/default-model", {"model": TEST_DEFAULT_MODEL})
 
@@ -63,11 +70,11 @@ def test_default_model_updates_hermes_config():
 def test_settings_does_not_persist_default_model():
     """POST /api/settings with default_model in body is silently ignored."""
     d1, _ = get("/api/settings")
-    original_model = d1['default_model']
+    original_model = d1["default_model"]
     # Send default_model via /api/settings — it must be dropped (not persisted)
     post("/api/settings", {"default_model": "openai/fake-model-xyz"})
     d2, _ = get("/api/settings")
-    assert d2['default_model'] == original_model, (
+    assert d2["default_model"] == original_model, (
         "POST /api/settings must not persist default_model — use /api/default-model instead"
     )
 
@@ -77,18 +84,20 @@ def test_default_model_empty_returns_400():
     d, status = post("/api/default-model", {"model": ""})
     assert status == 400
 
+
 def test_settings_partial_update():
     """POST /api/settings with partial data doesn't clobber other fields."""
     d1, _ = get("/api/settings")
-    original_ws = d1['default_workspace']
+    original_ws = d1["default_workspace"]
     post("/api/settings", {"send_key": "ctrl+enter"})
     d2, _ = get("/api/settings")
-    assert d2['send_key'] == 'ctrl+enter'
-    assert d2['default_workspace'] == original_ws
+    assert d2["send_key"] == "ctrl+enter"
+    assert d2["default_workspace"] == original_ws
     post("/api/settings", {"send_key": "enter"})
 
 
 # ── Session Pinning ───────────────────────────────────────────────────────
+
 
 def test_pin_session():
     """POST /api/session/pin sets pinned=true."""
@@ -97,11 +106,12 @@ def test_pin_session():
         sid = make_session(created)
         d, status = post("/api/session/pin", {"session_id": sid, "pinned": True})
         assert status == 200
-        assert d['ok'] is True
-        assert d['session']['pinned'] is True
+        assert d["ok"] is True
+        assert d["session"]["pinned"] is True
     finally:
         for sid in created:
             post("/api/session/delete", {"session_id": sid})
+
 
 def test_unpin_session():
     """POST /api/session/pin with pinned=false unpins."""
@@ -111,10 +121,11 @@ def test_unpin_session():
         post("/api/session/pin", {"session_id": sid, "pinned": True})
         d, status = post("/api/session/pin", {"session_id": sid, "pinned": False})
         assert status == 200
-        assert d['session']['pinned'] is False
+        assert d["session"]["pinned"] is False
     finally:
         for sid in created:
             post("/api/session/delete", {"session_id": sid})
+
 
 def test_pinned_in_session_list():
     """Pinned sessions include pinned field in session list."""
@@ -125,12 +136,13 @@ def test_pinned_in_session_list():
         post("/api/session/rename", {"session_id": sid, "title": "Pinned Test"})
         post("/api/session/pin", {"session_id": sid, "pinned": True})
         d, _ = get("/api/sessions")
-        match = [s for s in d['sessions'] if s['session_id'] == sid]
+        match = [s for s in d["sessions"] if s["session_id"] == sid]
         assert len(match) == 1
-        assert match[0]['pinned'] is True
+        assert match[0]["pinned"] is True
     finally:
         for sid in created:
             post("/api/session/delete", {"session_id": sid})
+
 
 def test_pinned_persists_on_reload():
     """Pin status survives session reload from disk."""
@@ -139,13 +151,14 @@ def test_pinned_persists_on_reload():
         sid = make_session(created)
         post("/api/session/pin", {"session_id": sid, "pinned": True})
         d, _ = get(f"/api/session?session_id={sid}")
-        assert d['session']['pinned'] is True
+        assert d["session"]["pinned"] is True
     finally:
         for sid in created:
             post("/api/session/delete", {"session_id": sid})
 
 
 # ── Session Import ────────────────────────────────────────────────────────
+
 
 def test_import_session_basic():
     """POST /api/session/import creates a new session from JSON."""
@@ -159,21 +172,23 @@ def test_import_session_basic():
     }
     d, status = post("/api/session/import", payload)
     assert status == 200
-    assert d['ok'] is True
-    sid = d['session']['session_id']
+    assert d["ok"] is True
+    sid = d["session"]["session_id"]
     try:
-        assert d['session']['title'] == 'Imported Test'
-        assert len(d['session']['messages']) == 2
+        assert d["session"]["title"] == "Imported Test"
+        assert len(d["session"]["messages"]) == 2
         # Verify it loads correctly
         d2, _ = get(f"/api/session?session_id={sid}")
-        assert d2['session']['model'] == 'test/import-model'
+        assert d2["session"]["model"] == "test/import-model"
     finally:
         post("/api/session/delete", {"session_id": sid})
+
 
 def test_import_requires_messages():
     """Import fails without a messages array."""
     d, status = post("/api/session/import", {"title": "No messages"})
     assert status == 400
+
 
 def test_import_creates_new_id():
     """Imported session gets a new session_id, not reusing any from the payload."""
@@ -183,12 +198,13 @@ def test_import_creates_new_id():
         "messages": [{"role": "user", "content": "test"}],
     }
     d, _ = post("/api/session/import", payload)
-    sid = d['session']['session_id']
+    sid = d["session"]["session_id"]
     try:
         # The import should create a new ID, not use the one from the payload
         assert sid != "should_be_ignored"
     finally:
         post("/api/session/delete", {"session_id": sid})
+
 
 def test_import_with_pinned():
     """Imported session can be pinned."""
@@ -198,9 +214,9 @@ def test_import_with_pinned():
         "pinned": True,
     }
     d, _ = post("/api/session/import", payload)
-    sid = d['session']['session_id']
+    sid = d["session"]["session_id"]
     try:
         d2, _ = get(f"/api/session?session_id={sid}")
-        assert d2['session']['pinned'] is True
+        assert d2["session"]["pinned"] is True
     finally:
         post("/api/session/delete", {"session_id": sid})

--- a/tests/test_sprint13.py
+++ b/tests/test_sprint13.py
@@ -1,7 +1,11 @@
 """
 Sprint 13 Tests: cron recent endpoint, session duplicate, background alerts.
 """
-import json, pathlib, urllib.error, urllib.request
+
+import json
+import pathlib
+import urllib.error
+import urllib.request
 
 from tests._pytest_port import BASE
 
@@ -13,8 +17,9 @@ def get(path):
 
 def post(path, body=None):
     data = json.dumps(body or {}).encode()
-    req = urllib.request.Request(BASE + path, data=data,
-                                headers={"Content-Type": "application/json"})
+    req = urllib.request.Request(
+        BASE + path, data=data, headers={"Content-Type": "application/json"}
+    )
     try:
         with urllib.request.urlopen(req, timeout=10) as r:
             return json.loads(r.read()), r.status
@@ -31,28 +36,33 @@ def make_session(created_list):
 
 # ── Cron recent endpoint ──────────────────────────────────────────────────
 
+
 def test_crons_recent_returns_200():
     """GET /api/crons/recent returns completions list."""
     d, status = get("/api/crons/recent?since=0")
     assert status == 200
-    assert 'completions' in d
-    assert isinstance(d['completions'], list)
-    assert 'since' in d
+    assert "completions" in d
+    assert isinstance(d["completions"], list)
+    assert "since" in d
+
 
 def test_crons_recent_with_future_since():
     """Completions list is empty when since is in the future."""
     import time
+
     d, _ = get(f"/api/crons/recent?since={time.time() + 99999}")
-    assert d['completions'] == []
+    assert d["completions"] == []
+
 
 def test_crons_recent_default_since():
     """Default since=0 returns all completions."""
     d, status = get("/api/crons/recent")
     assert status == 200
-    assert 'completions' in d
+    assert "completions" in d
 
 
 # ── Session duplicate ─────────────────────────────────────────────────────
+
 
 def test_duplicate_session():
     """Duplicating a session creates a new one with same workspace/model."""
@@ -60,14 +70,19 @@ def test_duplicate_session():
     try:
         sid, sess = make_session(created)
         # Set a specific model on the session
-        post("/api/session/update", {
-            "session_id": sid, "model": "test/dup-model",
-            "workspace": sess["workspace"]
-        })
+        post(
+            "/api/session/update",
+            {
+                "session_id": sid,
+                "model": "test/dup-model",
+                "workspace": sess["workspace"],
+            },
+        )
         # Duplicate: create new session with same workspace/model
-        d2, status = post("/api/session/new", {
-            "workspace": sess["workspace"], "model": "test/dup-model"
-        })
+        d2, status = post(
+            "/api/session/new",
+            {"workspace": sess["workspace"], "model": "test/dup-model"},
+        )
         assert status == 200
         new_sid = d2["session"]["session_id"]
         created.append(new_sid)
@@ -81,6 +96,7 @@ def test_duplicate_session():
 
 # ── Session pinned field preserved across operations ──────────────────────
 
+
 def test_pinned_survives_update():
     """Pinned status survives session update."""
     created = []
@@ -88,10 +104,10 @@ def test_pinned_survives_update():
         sid, sess = make_session(created)
         post("/api/session/pin", {"session_id": sid, "pinned": True})
         # Update workspace/model
-        post("/api/session/update", {
-            "session_id": sid, "model": "test/other",
-            "workspace": sess["workspace"]
-        })
+        post(
+            "/api/session/update",
+            {"session_id": sid, "model": "test/other", "workspace": sess["workspace"]},
+        )
         d, _ = get(f"/api/session?session_id={sid}")
         assert d["session"]["pinned"] is True
     finally:
@@ -101,10 +117,12 @@ def test_pinned_survives_update():
 
 # ── Workspace symlink validation ──────────────────────────────────────────
 
+
 def test_workspace_add_rejects_nonexistent():
     """Adding a non-existent path returns 400."""
     d, status = post("/api/workspaces/add", {"path": "/nonexistent/path/12345"})
     assert status == 400
+
 
 def test_workspace_add_accepts_real_dir():
     """Adding a real directory under the trusted workspace root succeeds."""
@@ -119,4 +137,5 @@ def test_workspace_add_accepts_real_dir():
     finally:
         post("/api/workspaces/remove", {"path": str(tmp)})
         import shutil
+
         shutil.rmtree(tmp, ignore_errors=True)

--- a/tests/test_sprint14.py
+++ b/tests/test_sprint14.py
@@ -1,7 +1,10 @@
 """
 Sprint 14 Tests: file rename, folder create, session archive, session tags, mermaid, timestamps.
 """
-import json, os, pathlib, shutil, tempfile, urllib.error, urllib.request
+
+import json
+import urllib.error
+import urllib.request
 
 from tests._pytest_port import BASE
 
@@ -13,8 +16,9 @@ def get(path):
 
 def post(path, body=None):
     data = json.dumps(body or {}).encode()
-    req = urllib.request.Request(BASE + path, data=data,
-                                headers={"Content-Type": "application/json"})
+    req = urllib.request.Request(
+        BASE + path, data=data, headers={"Content-Type": "application/json"}
+    )
     try:
         with urllib.request.urlopen(req, timeout=10) as r:
             return json.loads(r.read()), r.status
@@ -31,16 +35,21 @@ def make_session(created_list):
 
 # ── File rename ───────────────────────────────────────────────────────────
 
+
 def test_file_rename():
     """Renaming a file changes its name on disk."""
     created = []
     try:
         sid, sess = make_session(created)
         # Create a file first
-        post("/api/file/create", {"session_id": sid, "path": "rename_test.txt", "content": "hello"})
-        d, status = post("/api/file/rename", {
-            "session_id": sid, "path": "rename_test.txt", "new_name": "renamed.txt"
-        })
+        post(
+            "/api/file/create",
+            {"session_id": sid, "path": "rename_test.txt", "content": "hello"},
+        )
+        d, status = post(
+            "/api/file/rename",
+            {"session_id": sid, "path": "rename_test.txt", "new_name": "renamed.txt"},
+        )
         assert status == 200
         assert d["ok"] is True
         assert "renamed.txt" in d["new_path"]
@@ -55,9 +64,10 @@ def test_file_rename_rejects_path_traversal():
     try:
         sid, sess = make_session(created)
         post("/api/file/create", {"session_id": sid, "path": "safe.txt", "content": ""})
-        d, status = post("/api/file/rename", {
-            "session_id": sid, "path": "safe.txt", "new_name": "../evil.txt"
-        })
+        d, status = post(
+            "/api/file/rename",
+            {"session_id": sid, "path": "safe.txt", "new_name": "../evil.txt"},
+        )
         assert status == 400
     finally:
         for s in created:
@@ -71,9 +81,10 @@ def test_file_rename_rejects_existing():
         sid, sess = make_session(created)
         post("/api/file/create", {"session_id": sid, "path": "a.txt", "content": "a"})
         post("/api/file/create", {"session_id": sid, "path": "b.txt", "content": "b"})
-        d, status = post("/api/file/rename", {
-            "session_id": sid, "path": "a.txt", "new_name": "b.txt"
-        })
+        d, status = post(
+            "/api/file/rename",
+            {"session_id": sid, "path": "a.txt", "new_name": "b.txt"},
+        )
         assert status == 400
     finally:
         for s in created:
@@ -82,14 +93,15 @@ def test_file_rename_rejects_existing():
 
 # ── Folder create ─────────────────────────────────────────────────────────
 
+
 def test_create_dir():
     """Creating a folder succeeds."""
     created = []
     try:
         sid, sess = make_session(created)
-        d, status = post("/api/file/create-dir", {
-            "session_id": sid, "path": "test_folder"
-        })
+        d, status = post(
+            "/api/file/create-dir", {"session_id": sid, "path": "test_folder"}
+        )
         assert status == 200
         assert d["ok"] is True
     finally:
@@ -103,7 +115,9 @@ def test_create_dir_rejects_existing():
     try:
         sid, sess = make_session(created)
         post("/api/file/create-dir", {"session_id": sid, "path": "dup_folder"})
-        d, status = post("/api/file/create-dir", {"session_id": sid, "path": "dup_folder"})
+        d, status = post(
+            "/api/file/create-dir", {"session_id": sid, "path": "dup_folder"}
+        )
         assert status == 400
     finally:
         for s in created:
@@ -111,6 +125,7 @@ def test_create_dir_rejects_existing():
 
 
 # ── Session archive ───────────────────────────────────────────────────────
+
 
 def test_archive_session():
     """Archiving a session sets archived=true."""

--- a/tests/test_sprint15.py
+++ b/tests/test_sprint15.py
@@ -1,7 +1,10 @@
 """
 Sprint 15 Tests: session projects (CRUD, move, backward compat).
 """
-import json, urllib.error, urllib.request
+
+import json
+import urllib.error
+import urllib.request
 
 from tests._pytest_port import BASE
 
@@ -13,8 +16,9 @@ def get(path):
 
 def post(path, body=None):
     data = json.dumps(body or {}).encode()
-    req = urllib.request.Request(BASE + path, data=data,
-                                headers={"Content-Type": "application/json"})
+    req = urllib.request.Request(
+        BASE + path, data=data, headers={"Content-Type": "application/json"}
+    )
     try:
         with urllib.request.urlopen(req, timeout=10) as r:
             return json.loads(r.read()), r.status
@@ -49,6 +53,7 @@ def cleanup_projects(project_ids):
 
 
 # ── Project CRUD ─────────────────────────────────────────────────────────
+
 
 def test_create_project():
     """Creating a project returns a valid project dict."""
@@ -90,7 +95,9 @@ def test_rename_project():
     pids = []
     try:
         pid, _ = make_project(pids, "Old Name")
-        d, status = post("/api/projects/rename", {"project_id": pid, "name": "New Name"})
+        d, status = post(
+            "/api/projects/rename", {"project_id": pid, "name": "New Name"}
+        )
         assert status == 200
         assert d["project"]["name"] == "New Name"
         # Verify via list
@@ -155,6 +162,7 @@ def test_delete_nonexistent_project():
 
 # ── Session move ─────────────────────────────────────────────────────────
 
+
 def test_session_move_to_project():
     """Moving a session to a project sets its project_id."""
     pids = []
@@ -197,7 +205,9 @@ def test_session_project_in_list():
         pid, _ = make_project(pids, "Listed")
         sid, _ = make_session(sids)
         # Give it a title so it shows in list (non-empty Untitled sessions are hidden)
-        post("/api/session/rename", {"session_id": sid, "title": "Project Test Session"})
+        post(
+            "/api/session/rename", {"session_id": sid, "title": "Project Test Session"}
+        )
         post("/api/session/move", {"session_id": sid, "project_id": pid})
         dl, _ = get("/api/sessions")
         match = [s for s in dl["sessions"] if s["session_id"] == sid]
@@ -210,6 +220,7 @@ def test_session_project_in_list():
 
 
 # ── Backward compat ──────────────────────────────────────────────────────
+
 
 def test_compact_includes_project_id():
     """New session compact dict includes project_id as null."""

--- a/tests/test_sprint16.py
+++ b/tests/test_sprint16.py
@@ -2,16 +2,19 @@
 Sprint 16 Tests: safe HTML rendering in renderMd(), active session styling,
 session sidebar polish (SVG icons, dropdown actions).
 """
+
 import html as _html
 import pathlib
 import re
 import urllib.request
 
 from tests._pytest_port import BASE
+
 REPO_ROOT = pathlib.Path(__file__).parent.parent
 
 
 # ── Helpers ──────────────────────────────────────────────────────────────────
+
 
 def get_text(path):
     with urllib.request.urlopen(BASE + path, timeout=10) as r:
@@ -33,16 +36,28 @@ SAFE_INLINE = re.compile(r"^<\/?(strong|em|code|a)([\s>]|$)", re.I)
 
 def inline_md(t):
     """Mirror of inlineMd() in ui.js — for use inside list items / blockquotes."""
-    t = re.sub(r"\*\*\*(.+?)\*\*\*", lambda m: "<strong><em>" + esc(m.group(1)) + "</em></strong>", t)
-    t = re.sub(r"\*\*(.+?)\*\*",     lambda m: "<strong>" + esc(m.group(1)) + "</strong>", t)
-    t = re.sub(r"\*([^*\n]+)\*",     lambda m: "<em>" + esc(m.group(1)) + "</em>", t)
-    t = re.sub(r"`([^`\n]+)`",        lambda m: "<code>" + esc(m.group(1)) + "</code>", t)
     t = re.sub(
-        r"\[([^\]]+)\]\((https?://[^\)]+)\)",
-        lambda m: f'<a href="{esc(m.group(2))}" target="_blank" rel="noopener">{esc(m.group(1))}</a>',
+        r"\*\*\*(.+?)\*\*\*",
+        lambda m: "<strong><em>" + esc(m.group(1)) + "</em></strong>",
         t,
     )
-    t = re.sub(r"</?[a-zA-Z][^>]*>", lambda m: m.group() if SAFE_INLINE.match(m.group()) else esc(m.group()), t)
+    t = re.sub(
+        r"\*\*(.+?)\*\*", lambda m: "<strong>" + esc(m.group(1)) + "</strong>", t
+    )
+    t = re.sub(r"\*([^*\n]+)\*", lambda m: "<em>" + esc(m.group(1)) + "</em>", t)
+    t = re.sub(r"`([^`\n]+)`", lambda m: "<code>" + esc(m.group(1)) + "</code>", t)
+    t = re.sub(
+        r"\[([^\]]+)\]\((https?://[^\)]+)\)",
+        lambda m: (
+            f'<a href="{esc(m.group(2))}" target="_blank" rel="noopener">{esc(m.group(1))}</a>'
+        ),
+        t,
+    )
+    t = re.sub(
+        r"</?[a-zA-Z][^>]*>",
+        lambda m: m.group() if SAFE_INLINE.match(m.group()) else esc(m.group()),
+        t,
+    )
     return t
 
 
@@ -62,12 +77,23 @@ def render_md(raw):
         return "\x00F" + str(len(fence_stash) - 1) + "\x00"
 
     # Fence regex line-anchored to match JS fix for #1438 and fence-length fix for #1696
-    s = re.sub(r"(?:^|\n)[ ]{0,3}(`{3,})[^\n`]*\n(?:[\s\S]*?\n)?[ ]{0,3}\1`*(?=\n|$)|`[^`\n]+`", stash, s)
-    s = re.sub(r"<strong>([\s\S]*?)</strong>", lambda m: "**" + m.group(1) + "**", s, flags=re.I)
-    s = re.sub(r"<b>([\s\S]*?)</b>",           lambda m: "**" + m.group(1) + "**", s, flags=re.I)
-    s = re.sub(r"<em>([\s\S]*?)</em>",          lambda m: "*"  + m.group(1) + "*",  s, flags=re.I)
-    s = re.sub(r"<i>([\s\S]*?)</i>",            lambda m: "*"  + m.group(1) + "*",  s, flags=re.I)
-    s = re.sub(r"<code>([^<]*?)</code>",         lambda m: "`"  + m.group(1) + "`",  s, flags=re.I)
+    s = re.sub(
+        r"(?:^|\n)[ ]{0,3}(`{3,})[^\n`]*\n(?:[\s\S]*?\n)?[ ]{0,3}\1`*(?=\n|$)|`[^`\n]+`",
+        stash,
+        s,
+    )
+    s = re.sub(
+        r"<strong>([\s\S]*?)</strong>",
+        lambda m: "**" + m.group(1) + "**",
+        s,
+        flags=re.I,
+    )
+    s = re.sub(r"<b>([\s\S]*?)</b>", lambda m: "**" + m.group(1) + "**", s, flags=re.I)
+    s = re.sub(r"<em>([\s\S]*?)</em>", lambda m: "*" + m.group(1) + "*", s, flags=re.I)
+    s = re.sub(r"<i>([\s\S]*?)</i>", lambda m: "*" + m.group(1) + "*", s, flags=re.I)
+    s = re.sub(
+        r"<code>([^<]*?)</code>", lambda m: "`" + m.group(1) + "`", s, flags=re.I
+    )
     s = re.sub(r"<br\s*/?>", "\n", s, flags=re.I)
     # Glued-bold-heading lift (issue #1446) — must mirror static/ui.js behavior:
     # protected code/pre placeholders stay hidden while a sentence-glued bold
@@ -81,21 +107,43 @@ def render_md(raw):
         lang = info.lower() if re.match(r"^\w[\w+-]*$", info) else ""
         h = f'<div class="pre-header">{esc(lang)}</div>' if lang else ""
         return h + "<pre><code>" + esc(code) + "</code></pre>"
+
     # Fenced code blocks (line-anchored, fixes #1438; fence-length matching fixes #1696)
-    s = re.sub(r"(?:^|\n)[ ]{0,3}(`{3,})([^\n`]*)\n(?:([\s\S]*?)\n)?[ ]{0,3}\1`*(?=\n|$)", fenced, s)
+    s = re.sub(
+        r"(?:^|\n)[ ]{0,3}(`{3,})([^\n`]*)\n(?:([\s\S]*?)\n)?[ ]{0,3}\1`*(?=\n|$)",
+        fenced,
+        s,
+    )
     s = re.sub(r"`([^`\n]+)`", lambda m: "<code>" + esc(m.group(1)) + "</code>", s)
 
     # Inline formatting (top-level, outside list items)
-    s = re.sub(r"\*\*\*(.+?)\*\*\*", lambda m: "<strong><em>" + esc(m.group(1)) + "</em></strong>", s)
-    s = re.sub(r"\*\*(.+?)\*\*",     lambda m: "<strong>" + esc(m.group(1)) + "</strong>", s)
-    s = re.sub(r"\*([^*\n]+)\*",     lambda m: "<em>" + esc(m.group(1)) + "</em>", s)
+    s = re.sub(
+        r"\*\*\*(.+?)\*\*\*",
+        lambda m: "<strong><em>" + esc(m.group(1)) + "</em></strong>",
+        s,
+    )
+    s = re.sub(
+        r"\*\*(.+?)\*\*", lambda m: "<strong>" + esc(m.group(1)) + "</strong>", s
+    )
+    s = re.sub(r"\*([^*\n]+)\*", lambda m: "<em>" + esc(m.group(1)) + "</em>", s)
 
     # Block elements using inlineMd for their content
-    s = re.sub(r"^### (.+)$", lambda m: "<h3>" + inline_md(m.group(1)) + "</h3>", s, flags=re.M)
-    s = re.sub(r"^## (.+)$",  lambda m: "<h2>" + inline_md(m.group(1)) + "</h2>", s, flags=re.M)
-    s = re.sub(r"^# (.+)$",   lambda m: "<h1>" + inline_md(m.group(1)) + "</h1>", s, flags=re.M)
+    s = re.sub(
+        r"^### (.+)$", lambda m: "<h3>" + inline_md(m.group(1)) + "</h3>", s, flags=re.M
+    )
+    s = re.sub(
+        r"^## (.+)$", lambda m: "<h2>" + inline_md(m.group(1)) + "</h2>", s, flags=re.M
+    )
+    s = re.sub(
+        r"^# (.+)$", lambda m: "<h1>" + inline_md(m.group(1)) + "</h1>", s, flags=re.M
+    )
     s = re.sub(r"^---+$", "<hr>", s, flags=re.M)
-    s = re.sub(r"^> (.+)$", lambda m: "<blockquote>" + inline_md(m.group(1)) + "</blockquote>", s, flags=re.M)
+    s = re.sub(
+        r"^> (.+)$",
+        lambda m: "<blockquote>" + inline_md(m.group(1)) + "</blockquote>",
+        s,
+        flags=re.M,
+    )
 
     def handle_ul(block):
         lines = block.strip().split("\n")
@@ -107,7 +155,9 @@ def render_md(raw):
             out += f"<li{style}>{inline_md(text)}</li>"
         return out + "</ul>"
 
-    s = re.sub(r"((?:^(?:  )?[-*+] .+\n?)+)", lambda m: handle_ul(m.group()), s, flags=re.M)
+    s = re.sub(
+        r"((?:^(?:  )?[-*+] .+\n?)+)", lambda m: handle_ul(m.group()), s, flags=re.M
+    )
 
     def handle_ol(block):
         lines = block.strip().split("\n")
@@ -117,23 +167,34 @@ def render_md(raw):
             out += f"<li>{inline_md(text)}</li>"
         return out + "</ol>"
 
-    s = re.sub(r"((?:^(?:  )?\d+\. .+\n?)+)", lambda m: handle_ol(m.group()), s, flags=re.M)
+    s = re.sub(
+        r"((?:^(?:  )?\d+\. .+\n?)+)", lambda m: handle_ol(m.group()), s, flags=re.M
+    )
 
     # Safety net: escape unknown tags in remaining text
-    s = re.sub(r"</?[a-zA-Z][^>]*>", lambda m: m.group() if SAFE_TAGS.match(m.group()) else esc(m.group()), s)
+    s = re.sub(
+        r"</?[a-zA-Z][^>]*>",
+        lambda m: m.group() if SAFE_TAGS.match(m.group()) else esc(m.group()),
+        s,
+    )
 
     # Paragraph wrap
     parts = s.split("\n\n")
+
     def wrap(p):
         p = p.strip()
-        if not p: return ""
-        if re.match(r"^<(h[1-6]|ul|ol|pre|hr|blockquote)", p): return p
+        if not p:
+            return ""
+        if re.match(r"^<(h[1-6]|ul|ol|pre|hr|blockquote)", p):
+            return p
         return "<p>" + p.replace("\n", "<br>") + "</p>"
+
     s = "\n".join(wrap(p) for p in parts)
     return s
 
 
 # ── Static analysis: verify key structures exist in ui.js ────────────────────
+
 
 def test_render_md_pre_pass_converts_strong(cleanup_test_sessions):
     """ui.js renderMd() must have pre-pass that converts <strong> to **."""
@@ -141,8 +202,9 @@ def test_render_md_pre_pass_converts_strong(cleanup_test_sessions):
     code = src.read_text()
     assert "<strong>" in code and "**" in code, "pre-pass for <strong> not found"
     # Verify the specific conversion pattern
-    assert re.search(r"<strong>.*?\*\*", code, re.S), \
+    assert re.search(r"<strong>.*?\*\*", code, re.S), (
         "renderMd pre-pass should convert <strong>...</strong> to **...**"
+    )
 
 
 def test_render_md_has_safety_net(cleanup_test_sessions):
@@ -172,16 +234,30 @@ def test_render_md_no_placeholder_remnants(cleanup_test_sessions):
     src = REPO_ROOT / "static" / "ui.js"
     code = src.read_text()
     for old_ph in ["\\uE001", "\\uE002", "\\uE003", "\\uE004", "\\uE005"]:
-        assert old_ph not in code, \
+        assert old_ph not in code, (
             f"Old placeholder {old_ph} still present — broken implementation not cleaned up"
+        )
 
 
 def test_render_md_safe_tag_allowlist_complete(cleanup_test_sessions):
     """SAFE_TAGS allowlist must include all tags the pipeline emits."""
     src = REPO_ROOT / "static" / "ui.js"
     code = src.read_text()
-    required = ["strong", "em", "code", "pre", "ul", "ol", "li",
-                "table", "blockquote", "hr", "br", "a", "div"]
+    required = [
+        "strong",
+        "em",
+        "code",
+        "pre",
+        "ul",
+        "ol",
+        "li",
+        "table",
+        "blockquote",
+        "hr",
+        "br",
+        "a",
+        "div",
+    ]
     safe_tags_match = re.search(r"SAFE_TAGS\s*=\s*/(.+?)/i", code)
     assert safe_tags_match, "SAFE_TAGS regex not found"
     pattern = safe_tags_match.group(1)
@@ -190,6 +266,7 @@ def test_render_md_safe_tag_allowlist_complete(cleanup_test_sessions):
 
 
 # ── Behavioural: renderMd logic via Python mirror ─────────────────────────────
+
 
 def test_render_md_markdown_bold(cleanup_test_sessions):
     """**word** markdown renders as <strong>word</strong>."""
@@ -249,8 +326,9 @@ def test_render_md_html_strong_in_list_item(cleanup_test_sessions):
         "- <strong>Project items</strong> show their color\n"
         "- <strong>Regular items</strong> stay muted"
     )
-    assert "&lt;strong&gt;" not in out, \
+    assert "&lt;strong&gt;" not in out, (
         "Escaped <strong> literal found in list output — bold not rendering"
+    )
     assert "<strong>All items</strong>" in out
     assert "<strong>Active item</strong>" in out
     assert "<code>border-radius: 0 8px 8px 0</code>" in out
@@ -272,12 +350,15 @@ def test_render_md_exact_screenshot_content(cleanup_test_sessions):
         "- <strong>Regular items</strong> (no project) still have no left border color"
     )
     # None of the safe tags should appear as literal escaped text
-    assert "&lt;strong&gt;" not in out, \
+    assert "&lt;strong&gt;" not in out, (
         "Literal &lt;strong&gt; found — <strong> is not rendering as bold"
-    assert "&lt;/strong&gt;" not in out, \
+    )
+    assert "&lt;/strong&gt;" not in out, (
         "Literal &lt;/strong&gt; found — closing tag is not rendering"
-    assert "&lt;code&gt;" not in out, \
+    )
+    assert "&lt;code&gt;" not in out, (
         "Literal &lt;code&gt; found — <code> is not rendering as inline code"
+    )
     # Each item's bold label must render correctly
     assert "<strong>All items</strong>" in out
     assert "<strong>Active item</strong>" in out
@@ -338,7 +419,9 @@ def test_render_md_code_block_protects_html(cleanup_test_sessions):
     """HTML inside a backtick code span must NOT be converted — shown as literal."""
     out = render_md("keep `<strong>literal</strong>` safe")
     assert "&lt;strong&gt;" in out, "HTML inside code span should be escaped"
-    assert "<strong>literal</strong>" not in out, "HTML inside code span should NOT render as bold"
+    assert "<strong>literal</strong>" not in out, (
+        "HTML inside code span should NOT render as bold"
+    )
 
 
 def test_render_md_fenced_code_protects_html(cleanup_test_sessions):
@@ -352,14 +435,18 @@ def test_render_md_fenced_code_protects_html(cleanup_test_sessions):
     out = render_md(src)
     # Pre-pass stash preserves the raw content -- it should NOT have been
     # converted to **not bold** (which would render as bold outside the fence)
-    assert "**not bold**" not in out, \
+    assert "**not bold**" not in out, (
         "Fenced code content was incorrectly converted to markdown by the pre-pass"
+    )
     # The raw content should still be present (stash/restore worked)
-    assert "<strong>not bold</strong>" in out or "&lt;strong&gt;" in out, \
+    assert "<strong>not bold</strong>" in out or "&lt;strong&gt;" in out, (
         "Fenced code content was lost after stash/restore"
+    )
 
 
-def test_render_md_fenced_code_with_five_backtick_outer_preserves_inner_triples(cleanup_test_sessions):
+def test_render_md_fenced_code_with_five_backtick_outer_preserves_inner_triples(
+    cleanup_test_sessions,
+):
     """CommonMark §4.5: a 5-backtick fence must not close at an inner triple fence."""
     src = (
         "- optionally also support fenced code blocks\n\n"
@@ -384,7 +471,9 @@ def test_render_md_fenced_code_with_five_backtick_outer_preserves_inner_triples(
     assert "<br>`````" not in out
 
 
-def test_render_md_fenced_code_with_four_backtick_outer_preserves_inner_triples(cleanup_test_sessions):
+def test_render_md_fenced_code_with_four_backtick_outer_preserves_inner_triples(
+    cleanup_test_sessions,
+):
     """A 4-backtick outer fence should also require a 4+ backtick closer."""
     src = "````md\n```inner\nfoo\n```\n````\n"
     out = render_md(src)
@@ -396,7 +485,9 @@ def test_render_md_fenced_code_with_four_backtick_outer_preserves_inner_triples(
     assert "<p>````" not in out
 
 
-def test_render_md_fenced_code_three_backtick_path_still_renders_language(cleanup_test_sessions):
+def test_render_md_fenced_code_three_backtick_path_still_renders_language(
+    cleanup_test_sessions,
+):
     """The common 3-backtick path must keep rendering a single language-tagged block."""
     src = "```js\nconsole.log('ok')\n```"
     out = render_md(src)
@@ -406,6 +497,7 @@ def test_render_md_fenced_code_three_backtick_path_still_renders_language(cleanu
 
 
 # ── Security: XSS must be blocked ─────────────────────────────────────────────
+
 
 def test_render_md_xss_img_tag_escaped(cleanup_test_sessions):
     """<img src=x onerror=alert(1)> must be HTML-escaped, not rendered."""
@@ -462,27 +554,32 @@ def test_render_md_xss_object_tag_escaped(cleanup_test_sessions):
 
 # --- Unordered list variants ---
 
+
 def test_list_bold_only(cleanup_test_sessions):
     """Single bold word in list item."""
     out = render_md("- **bold**")
     assert "<strong>bold</strong>" in out
     assert "&lt;" not in out
 
+
 def test_list_italic_only(cleanup_test_sessions):
     """Single italic word in list item."""
     out = render_md("- *italic*")
     assert "<em>italic</em>" in out
+
 
 def test_list_code_only(cleanup_test_sessions):
     """Single code span in list item."""
     out = render_md("- `code`")
     assert "<code>code</code>" in out
 
+
 def test_list_bold_and_code_mixed(cleanup_test_sessions):
     """Bold and code together in one list item."""
     out = render_md("- **run** `pip install foo`")
     assert "<strong>run</strong>" in out
     assert "<code>pip install foo</code>" in out
+
 
 def test_list_html_strong_and_code_mixed(cleanup_test_sessions):
     """HTML <strong> and <code> together — the exact screenshot scenario."""
@@ -492,11 +589,13 @@ def test_list_html_strong_and_code_mixed(cleanup_test_sessions):
     assert "&lt;strong&gt;" not in out
     assert "&lt;code&gt;" not in out
 
+
 def test_list_html_em(cleanup_test_sessions):
     """HTML <em> in list item renders as italic."""
     out = render_md("- <em>emphasized</em> text")
     assert "<em>emphasized</em>" in out
     assert "&lt;em&gt;" not in out
+
 
 def test_list_html_b_tag(cleanup_test_sessions):
     """HTML <b> in list item renders as bold."""
@@ -504,24 +603,22 @@ def test_list_html_b_tag(cleanup_test_sessions):
     assert "<strong>bold via b tag</strong>" in out
     assert "&lt;b&gt;" not in out
 
+
 def test_list_html_i_tag(cleanup_test_sessions):
     """HTML <i> in list item renders as italic."""
     out = render_md("- <i>italic via i tag</i>")
     assert "<em>italic via i tag</em>" in out
     assert "&lt;i&gt;" not in out
 
+
 def test_list_multiple_items_each_formatted(cleanup_test_sessions):
     """Multiple list items each with different formatting."""
-    out = render_md(
-        "- **bold item**\n"
-        "- *italic item*\n"
-        "- `code item`\n"
-        "- plain item"
-    )
+    out = render_md("- **bold item**\n- *italic item*\n- `code item`\n- plain item")
     assert "<strong>bold item</strong>" in out
     assert "<em>italic item</em>" in out
     assert "<code>code item</code>" in out
     assert "<li>plain item</li>" in out
+
 
 def test_list_item_bold_mid_sentence(cleanup_test_sessions):
     """Bold in middle of a list item sentence."""
@@ -530,11 +627,13 @@ def test_list_item_bold_mid_sentence(cleanup_test_sessions):
     assert "Set the" in out
     assert "to 30 seconds" in out
 
+
 def test_list_item_multiple_bold_spans(cleanup_test_sessions):
     """Multiple bold spans in one list item."""
     out = render_md("- **A** and **B** are both important")
     assert "<strong>A</strong>" in out
     assert "<strong>B</strong>" in out
+
 
 def test_ordered_list_bold(cleanup_test_sessions):
     """Bold text inside ordered list items."""
@@ -544,13 +643,17 @@ def test_ordered_list_bold(cleanup_test_sessions):
     assert "<strong>Second</strong>" in out
     assert "<li>Plain step</li>" in out
 
+
 def test_ordered_list_html_strong(cleanup_test_sessions):
     """HTML <strong> inside ordered list items renders correctly."""
-    out = render_md("1. <strong>Install</strong> the package\n2. <strong>Configure</strong> the settings")
+    out = render_md(
+        "1. <strong>Install</strong> the package\n2. <strong>Configure</strong> the settings"
+    )
     assert "<ol>" in out
     assert "<strong>Install</strong>" in out
     assert "<strong>Configure</strong>" in out
     assert "&lt;strong&gt;" not in out
+
 
 def test_ordered_list_code_spans(cleanup_test_sessions):
     """Code spans inside ordered list items."""
@@ -558,23 +661,28 @@ def test_ordered_list_code_spans(cleanup_test_sessions):
     assert "<code>npm install</code>" in out
     assert "<code>npm start</code>" in out
 
+
 def test_indented_list_item_bold(cleanup_test_sessions):
     """Bold inside indented (nested) list item."""
     out = render_md("- top level\n  - **nested bold**")
     assert "<strong>nested bold</strong>" in out
     assert "margin-left:16px" in out
 
+
 # --- Blockquote variants ---
+
 
 def test_blockquote_plain(cleanup_test_sessions):
     """Plain blockquote wraps in <blockquote>."""
     out = render_md("> simple quote")
     assert "<blockquote>simple quote</blockquote>" in out
 
+
 def test_blockquote_bold(cleanup_test_sessions):
     """**bold** inside blockquote renders correctly."""
     out = render_md("> **important** note")
     assert "<strong>important</strong>" in out
+
 
 def test_blockquote_html_strong(cleanup_test_sessions):
     """<strong> inside blockquote renders as bold."""
@@ -582,10 +690,12 @@ def test_blockquote_html_strong(cleanup_test_sessions):
     assert "<strong>Warning:</strong>" in out
     assert "&lt;strong&gt;" not in out
 
+
 def test_blockquote_code_span(cleanup_test_sessions):
     """Code span inside blockquote renders correctly."""
     out = render_md("> Use `git commit` to save")
     assert "<code>git commit</code>" in out
+
 
 def test_blockquote_mixed_formatting(cleanup_test_sessions):
     """Mixed bold and code in blockquote."""
@@ -593,18 +703,22 @@ def test_blockquote_mixed_formatting(cleanup_test_sessions):
     assert "<strong>Note:</strong>" in out
     assert "<code>pip install foo</code>" in out
 
+
 def test_blockquote_xss_blocked(cleanup_test_sessions):
     """XSS in blockquote content must be escaped."""
     out = render_md("> <img src=x onerror=alert(1)>")
     assert "&lt;img" in out
     assert "<img" not in out
 
+
 # --- Heading variants ---
+
 
 def test_heading_h1_bold(cleanup_test_sessions):
     """Bold inside h1 renders correctly."""
     out = render_md("# **Main** Title")
     assert "<h1><strong>Main</strong> Title</h1>" in out
+
 
 def test_heading_h2_html_strong(cleanup_test_sessions):
     """HTML <strong> inside h2 renders correctly."""
@@ -612,10 +726,12 @@ def test_heading_h2_html_strong(cleanup_test_sessions):
     assert "<h2><strong>Section</strong> Name</h2>" in out
     assert "&lt;strong&gt;" not in out
 
+
 def test_heading_h3_code(cleanup_test_sessions):
     """Code span inside h3 renders correctly."""
     out = render_md("### The `renderMd` function")
     assert "<h3>The <code>renderMd</code> function</h3>" in out
+
 
 def test_heading_xss_blocked(cleanup_test_sessions):
     """XSS attempt in heading must be escaped."""
@@ -623,12 +739,15 @@ def test_heading_xss_blocked(cleanup_test_sessions):
     assert "<script>" not in out
     assert "&lt;script" in out
 
+
 # --- Paragraph / top-level formatting ---
+
 
 def test_paragraph_bold_renders(cleanup_test_sessions):
     """Bold in a plain paragraph renders correctly."""
     out = render_md("The **quick brown fox** jumps.")
     assert "<strong>quick brown fox</strong>" in out
+
 
 def test_paragraph_html_strong_renders(cleanup_test_sessions):
     """HTML <strong> in a plain paragraph renders correctly."""
@@ -636,11 +755,13 @@ def test_paragraph_html_strong_renders(cleanup_test_sessions):
     assert "<strong>quick brown fox</strong>" in out
     assert "&lt;strong&gt;" not in out
 
+
 def test_paragraph_html_code_renders(cleanup_test_sessions):
     """HTML <code> in a plain paragraph renders correctly."""
     out = render_md("Call <code>foo()</code> to start.")
     assert "<code>foo()</code>" in out
     assert "&lt;code&gt;" not in out
+
 
 def test_paragraph_br_creates_line_break(cleanup_test_sessions):
     """<br> in paragraph becomes a line break inside <p>."""
@@ -648,12 +769,15 @@ def test_paragraph_br_creates_line_break(cleanup_test_sessions):
     # br converts to \n which inside <p> becomes <br>
     assert "Line one" in out and "Line two" in out
 
+
 def test_multiple_paragraphs_separated(cleanup_test_sessions):
     """Double newline creates separate <p> elements."""
     out = render_md("First paragraph.\n\nSecond paragraph.")
     assert out.count("<p>") == 2
 
+
 # --- Table variants ---
+
 
 def test_table_structure_in_ui_js(cleanup_test_sessions):
     """ui.js must contain table rendering logic with thead/tbody structure."""
@@ -663,7 +787,9 @@ def test_table_structure_in_ui_js(cleanup_test_sessions):
     assert "tbody" in src, "tbody not found in table renderer"
     assert "parseRow" in src, "parseRow helper not found in table renderer"
 
+
 # --- br tag specifically ---
+
 
 def test_br_in_list_item(cleanup_test_sessions):
     """<br> inside a list item becomes a newline."""
@@ -671,24 +797,31 @@ def test_br_in_list_item(cleanup_test_sessions):
     assert "Line one" in out
     assert "Line two" in out
 
+
 def test_br_self_closing_in_paragraph(cleanup_test_sessions):
     """<br/> self-closing form is also handled."""
     out = render_md("Before<br/>After")
     assert "Before" in out and "After" in out
 
+
 # --- No double-escaping ---
+
 
 def test_no_double_escaping_ampersand(cleanup_test_sessions):
     """A literal & in text must become &amp; exactly once, not &amp;amp;."""
     out = render_md("foo & bar")
     assert "&amp;amp;" not in out
-    assert "&amp;" in out or "foo & bar" in out  # either fine (paragraph wrap may not escape)
+    assert (
+        "&amp;" in out or "foo & bar" in out
+    )  # either fine (paragraph wrap may not escape)
+
 
 def test_no_double_escaping_lt_in_code(cleanup_test_sessions):
     """< inside a code span must become &lt; exactly once."""
     out = render_md("`a < b`")
     assert "&lt;lt;" not in out
     assert "&lt;" in out
+
 
 def test_strong_text_not_double_escaped(cleanup_test_sessions):
     """Content of <strong> must not be double-escaped."""
@@ -697,21 +830,31 @@ def test_strong_text_not_double_escaped(cleanup_test_sessions):
     assert "&amp;amp;" not in out
     assert "<strong>" in out
 
+
 # --- inlineMd helper present in source ---
+
 
 def test_inline_md_helper_in_ui_js(cleanup_test_sessions):
     """ui.js must define inlineMd() helper function."""
     src = (REPO_ROOT / "static" / "ui.js").read_text()
     assert "function inlineMd(" in src, "inlineMd() helper not found in ui.js"
 
+
 def test_inline_md_used_in_list_handler(cleanup_test_sessions):
     """List handler in ui.js must call inlineMd() not esc() for item text."""
     src = (REPO_ROOT / "static" / "ui.js").read_text()
     # Find the list block handler
-    ul_idx = src.find("html+='<ul>'") or src.find('html+=`<ul>`') or src.find("let html='<ul>'")
+    ul_idx = (
+        src.find("html+='<ul>'")
+        or src.find("html+=`<ul>`")
+        or src.find("let html='<ul>'")
+    )
     assert ul_idx >= 0 or "inlineMd(text)" in src, "inlineMd not called in list handler"
     # Verify inlineMd is called, not bare esc
-    assert "inlineMd(text)" in src, "inlineMd(text) call not found — list items may not render formatting"
+    assert "inlineMd(text)" in src, (
+        "inlineMd(text) call not found — list items may not render formatting"
+    )
+
 
 def test_inline_md_used_in_blockquote_handler(cleanup_test_sessions):
     """Blockquote handler in ui.js must call inlineMd() not esc() for content."""
@@ -733,8 +876,12 @@ def test_sessions_js_has_dropdown_actions(cleanup_test_sessions):
     """sessions.js must use a single trigger button and dropdown for session actions."""
     src = REPO_ROOT / "static" / "sessions.js"
     code = src.read_text()
-    assert "session-actions-trigger" in code, "session action trigger button not found in sessions.js"
-    assert "session-action-menu" in code, "session action dropdown menu not found in sessions.js"
+    assert "session-actions-trigger" in code, (
+        "session action trigger button not found in sessions.js"
+    )
+    assert "session-action-menu" in code, (
+        "session action dropdown menu not found in sessions.js"
+    )
 
 
 def test_style_css_has_session_actions_dropdown(cleanup_test_sessions):
@@ -743,16 +890,18 @@ def test_style_css_has_session_actions_dropdown(cleanup_test_sessions):
     code = src.read_text()
     assert ".session-actions" in code, ".session-actions not found in style.css"
     assert ".session-action-menu" in code, ".session-action-menu not found in style.css"
-    assert "position:fixed" in code or "position: fixed" in code, \
+    assert "position:fixed" in code or "position: fixed" in code, (
         ".session-action-menu must use position:fixed to avoid sidebar clipping"
+    )
 
 
 def test_style_css_active_session_uses_accent(cleanup_test_sessions):
     """Active session style should use accent color variable, not hardcoded hex."""
     src = REPO_ROOT / "static" / "style.css"
     code = src.read_text()
-    assert "var(--accent" in code and ".session-item.active" in code, \
+    assert "var(--accent" in code and ".session-item.active" in code, (
         "Active session must use var(--accent) variables in style.css"
+    )
 
 
 def test_sessions_js_uses_action_menu_not_per_row_buttons(cleanup_test_sessions):
@@ -766,9 +915,17 @@ def test_sessions_js_uses_action_menu_not_per_row_buttons(cleanup_test_sessions)
     """
     src = REPO_ROOT / "static" / "sessions.js"
     code = src.read_text()
-    assert "session-actions-trigger" in code, "session-actions-trigger not found in sessions.js"
-    assert "_openSessionActionMenu" in code, "_openSessionActionMenu not found in sessions.js"
-    assert "closeSessionActionMenu" in code, "closeSessionActionMenu not found in sessions.js"
+    assert "session-actions-trigger" in code, (
+        "session-actions-trigger not found in sessions.js"
+    )
+    assert "_openSessionActionMenu" in code, (
+        "_openSessionActionMenu not found in sessions.js"
+    )
+    assert "closeSessionActionMenu" in code, (
+        "closeSessionActionMenu not found in sessions.js"
+    )
     # The old per-row buttons must not be present (they were replaced by the menu)
     assert "act-pin" not in code, "old act-pin per-row button still in sessions.js"
-    assert "act-archive" not in code, "old act-archive per-row button still in sessions.js"
+    assert "act-archive" not in code, (
+        "old act-archive per-row button still in sessions.js"
+    )

--- a/tests/test_sprint17.py
+++ b/tests/test_sprint17.py
@@ -1,7 +1,10 @@
 """
 Sprint 17 Tests: send_key setting, commands.js static file, workspace subdir listing.
 """
-import json, urllib.error, urllib.request
+
+import json
+import urllib.error
+import urllib.request
 
 from tests._pytest_port import BASE
 
@@ -13,8 +16,9 @@ def get(path):
 
 def post(path, body=None):
     data = json.dumps(body or {}).encode()
-    req = urllib.request.Request(BASE + path, data=data,
-                                headers={"Content-Type": "application/json"})
+    req = urllib.request.Request(
+        BASE + path, data=data, headers={"Content-Type": "application/json"}
+    )
     try:
         with urllib.request.urlopen(req, timeout=10) as r:
             return json.loads(r.read()), r.status
@@ -30,6 +34,7 @@ def make_session(created_list):
 
 
 # ── Settings: send_key ──────────────────────────────────────────────────────
+
 
 def test_settings_send_key_default():
     """GET /api/settings returns send_key with default value 'enter'."""
@@ -74,6 +79,7 @@ def test_settings_unknown_key_ignored():
 
 # ── Static file: commands.js ────────────────────────────────────────────────
 
+
 def test_static_commands_js_served():
     """GET /static/commands.js returns 200 and contains COMMANDS registry."""
     req = urllib.request.Request(BASE + "/static/commands.js")
@@ -85,6 +91,7 @@ def test_static_commands_js_served():
 
 
 # ── Workspace: subdir listing ───────────────────────────────────────────────
+
 
 def test_list_workspace_root():
     """GET /api/list with path=. returns entries for workspace root."""

--- a/tests/test_sprint19.py
+++ b/tests/test_sprint19.py
@@ -1,7 +1,10 @@
 """
 Sprint 19 Tests: auth/login, security headers, request size limit.
 """
-import json, urllib.error, urllib.request
+
+import json
+import urllib.error
+import urllib.request
 
 from tests._pytest_port import BASE
 
@@ -17,8 +20,9 @@ def get(path, headers=None):
 
 def post(path, body=None, headers=None):
     data = json.dumps(body or {}).encode()
-    req = urllib.request.Request(BASE + path, data=data,
-                                headers={"Content-Type": "application/json"})
+    req = urllib.request.Request(
+        BASE + path, data=data, headers={"Content-Type": "application/json"}
+    )
     if headers:
         for k, v in headers.items():
             req.add_header(k, v)
@@ -30,6 +34,7 @@ def post(path, body=None, headers=None):
 
 
 # ── Auth status (no password configured in test env) ──────────────────────
+
 
 def test_auth_status_disabled():
     """Auth should be disabled by default (no password set)."""
@@ -75,13 +80,24 @@ def test_login_route_injects_webui_version_for_login_script():
     """The /login route should replace the login.js version placeholder."""
     from pathlib import Path
 
-    src = Path(__file__).resolve().parents[1].joinpath("api", "routes.py").read_text(encoding="utf-8")
-    login_block = src[src.find('if parsed.path == "/login"'):src.find('if parsed.path == "/api/auth/status"')]
+    src = (
+        Path(__file__)
+        .resolve()
+        .parents[1]
+        .joinpath("api", "routes.py")
+        .read_text(encoding="utf-8")
+    )
+    login_block = src[
+        src.find('if parsed.path == "/login"') : src.find(
+            'if parsed.path == "/api/auth/status"'
+        )
+    ]
     assert "WEBUI_VERSION" in login_block
     assert "{{WEBUI_VERSION}}" in login_block
 
 
 # ── Security headers ─────────────────────────────────────────────────────
+
 
 def test_security_headers_on_json():
     """JSON responses should include security headers."""
@@ -105,8 +121,9 @@ def test_permissions_policy_does_not_disable_microphone():
     assert status == 200
     policy = headers.get("Permissions-Policy", "")
     assert policy, "Permissions-Policy header missing"
-    assert "microphone=()" not in policy, \
+    assert "microphone=()" not in policy, (
         "Permissions-Policy must not block microphone access or desktop/mobile voice input cannot work"
+    )
 
 
 def test_cache_control_no_store():
@@ -116,6 +133,7 @@ def test_cache_control_no_store():
 
 
 # ── Settings password field ──────────────────────────────────────────────
+
 
 def test_settings_password_hash_not_exposed():
     """GET /api/settings must never expose the stored password hash."""

--- a/tests/test_sprint2.py
+++ b/tests/test_sprint2.py
@@ -1,65 +1,83 @@
 """Sprint 2 tests: image preview, file types, markdown. Uses cleanup_test_sessions fixture."""
-import io, json, uuid, urllib.request, urllib.error, pathlib
+
+import json
+import urllib.request
+import urllib.error
 
 from tests._pytest_port import BASE
+
 
 def get(path):
     with urllib.request.urlopen(BASE + path, timeout=10) as r:
         return json.loads(r.read()), r.status
 
+
 def get_raw(path):
     with urllib.request.urlopen(BASE + path, timeout=10) as r:
-        return r.read(), r.headers.get('Content-Type', ''), r.status
+        return r.read(), r.headers.get("Content-Type", ""), r.status
+
 
 def post(path, body=None):
     data = json.dumps(body or {}).encode()
-    req = urllib.request.Request(BASE + path, data=data, headers={"Content-Type": "application/json"})
+    req = urllib.request.Request(
+        BASE + path, data=data, headers={"Content-Type": "application/json"}
+    )
     try:
         with urllib.request.urlopen(req, timeout=10) as r:
             return json.loads(r.read()), r.status
     except urllib.error.HTTPError as e:
         return json.loads(e.read()), e.code
 
+
 def make_session_tracked(created_list, ws=None):
     """Create a session and register it with the cleanup fixture."""
     import pathlib as _pathlib
+
     body = {}
-    if ws: body["workspace"] = str(ws)
+    if ws:
+        body["workspace"] = str(ws)
     d, _ = post("/api/session/new", body)
     sid = d["session"]["session_id"]
     created_list.append(sid)
     return sid, _pathlib.Path(d["session"]["workspace"])
 
 
-
 def test_raw_endpoint_serves_png(cleanup_test_sessions):
     sid, ws = make_session_tracked(cleanup_test_sessions)
-    png = (b"\x89PNG\r\n\x1a\n" b"\x00\x00\x00\rIHDR\x00\x00\x00\x01"
-           b"\x00\x00\x00\x01\x08\x02\x00\x00\x00"
-           b"\x90wS\xde\x00\x00\x00\x0cIDATx\x9cc"
-           b"\xf8\x0f\x00\x00\x01\x01\x00\x05\x18"
-           b"\xd8N\x00\x00\x00\x00IEND\xaeB`\x82")
+    png = (
+        b"\x89PNG\r\n\x1a\n"
+        b"\x00\x00\x00\rIHDR\x00\x00\x00\x01"
+        b"\x00\x00\x00\x01\x08\x02\x00\x00\x00"
+        b"\x90wS\xde\x00\x00\x00\x0cIDATx\x9cc"
+        b"\xf8\x0f\x00\x00\x01\x01\x00\x05\x18"
+        b"\xd8N\x00\x00\x00\x00IEND\xaeB`\x82"
+    )
     (ws / "test.png").write_bytes(png)
     raw, ct, status = get_raw(f"/api/file/raw?session_id={sid}&path=test.png")
     assert status == 200
     assert "image/png" in ct
     assert raw == png
 
+
 def test_raw_endpoint_serves_jpeg(cleanup_test_sessions):
     sid, ws = make_session_tracked(cleanup_test_sessions)
-    jpeg = b"\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01\x01\x00\x00\x01\x00\x01\x00\x00\xff\xd9"
+    jpeg = (
+        b"\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01\x01\x00\x00\x01\x00\x01\x00\x00\xff\xd9"
+    )
     (ws / "photo.jpg").write_bytes(jpeg)
     raw, ct, status = get_raw(f"/api/file/raw?session_id={sid}&path=photo.jpg")
     assert status == 200
     assert "image/jpeg" in ct
 
+
 def test_raw_endpoint_serves_svg(cleanup_test_sessions):
     sid, ws = make_session_tracked(cleanup_test_sessions)
-    svg = b"<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"100\" height=\"100\"><circle/></svg>"
+    svg = b'<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100"><circle/></svg>'
     (ws / "icon.svg").write_bytes(svg)
     raw, ct, status = get_raw(f"/api/file/raw?session_id={sid}&path=icon.svg")
     assert status == 200
     assert "image/svg" in ct
+
 
 def test_raw_endpoint_path_traversal_blocked(cleanup_test_sessions):
     sid, _ = make_session_tracked(cleanup_test_sessions)
@@ -69,6 +87,7 @@ def test_raw_endpoint_path_traversal_blocked(cleanup_test_sessions):
     except urllib.error.HTTPError as e:
         assert e.code in (400, 500)
 
+
 def test_raw_endpoint_missing_file_returns_404(cleanup_test_sessions):
     sid, _ = make_session_tracked(cleanup_test_sessions)
     try:
@@ -76,6 +95,7 @@ def test_raw_endpoint_missing_file_returns_404(cleanup_test_sessions):
         assert False
     except urllib.error.HTTPError as e:
         assert e.code in (404, 500)
+
 
 def test_md_file_returns_text_via_api_file(cleanup_test_sessions):
     sid, ws = make_session_tracked(cleanup_test_sessions)
@@ -85,6 +105,7 @@ def test_md_file_returns_text_via_api_file(cleanup_test_sessions):
     assert status == 200
     assert data["content"] == md
 
+
 def test_md_file_with_table(cleanup_test_sessions):
     sid, ws = make_session_tracked(cleanup_test_sessions)
     md = "| Name | Value |\n|------|-------|\n| foo  | bar   |\n"
@@ -92,6 +113,7 @@ def test_md_file_with_table(cleanup_test_sessions):
     data, status = get(f"/api/file?session_id={sid}&path=table.md")
     assert status == 200
     assert "| Name | Value |" in data["content"]
+
 
 def test_file_listing_includes_images(cleanup_test_sessions):
     sid, ws = make_session_tracked(cleanup_test_sessions)

--- a/tests/test_sprint20.py
+++ b/tests/test_sprint20.py
@@ -5,9 +5,9 @@ These tests verify the static assets contain the correct HTML structure,
 CSS rules, and JS logic for the mic feature — all of which runs purely in
 the browser with no server-side component.
 """
+
 import re
 import urllib.request
-import json
 import pathlib
 
 from tests._pytest_port import BASE
@@ -33,8 +33,10 @@ def test_mic_button_has_mic_btn_class():
     html, _ = get_text("/")
     # Tolerate additional utility classes (e.g. has-tooltip from #1775).
     import re
-    assert re.search(r'class="[^"]*\bicon-btn\b[^"]*\bmic-btn\b[^"]*"', html), \
+
+    assert re.search(r'class="[^"]*\bicon-btn\b[^"]*\bmic-btn\b[^"]*"', html), (
         "btnMic must have both 'icon-btn' and 'mic-btn' classes"
+    )
 
 
 def test_mic_button_hidden_by_default():
@@ -44,7 +46,7 @@ def test_mic_button_hidden_by_default():
     assert 'id="btnMic"' in html
     btn_match = re.search(r'id="btnMic"[^>]*>', html)
     assert btn_match, "btnMic element not found"
-    assert 'display:none' in btn_match.group(0)
+    assert "display:none" in btn_match.group(0)
 
 
 def test_mic_button_has_title():
@@ -52,7 +54,7 @@ def test_mic_button_has_title():
     html, _ = get_text("/")
     btn_match = re.search(r'id="btnMic"[^>]*>', html)
     assert btn_match
-    assert 'title=' in btn_match.group(0)
+    assert "title=" in btn_match.group(0)
 
 
 def test_mic_status_div_present():
@@ -66,7 +68,7 @@ def test_mic_status_hidden_by_default():
     html, _ = get_text("/")
     status_match = re.search(r'id="micStatus"[^>]*>', html)
     assert status_match, "#micStatus element not found"
-    assert 'display:none' in status_match.group(0)
+    assert "display:none" in status_match.group(0)
 
 
 def test_mic_status_has_mic_dot():
@@ -74,7 +76,7 @@ def test_mic_status_has_mic_dot():
     html, _ = get_text("/")
     # mic-dot should appear after micStatus
     idx_status = html.find('id="micStatus"')
-    idx_dot = html.find('mic-dot', idx_status)
+    idx_dot = html.find("mic-dot", idx_status)
     assert idx_status != -1 and idx_dot != -1
     assert idx_dot > idx_status
 
@@ -82,7 +84,7 @@ def test_mic_status_has_mic_dot():
 def test_mic_status_has_listening_text():
     """#micStatus should display a 'Listening' label."""
     html, _ = get_text("/")
-    assert 'Listening' in html
+    assert "Listening" in html
 
 
 def test_mic_button_svg_microphone_shape():
@@ -90,21 +92,21 @@ def test_mic_button_svg_microphone_shape():
     html, _ = get_text("/")
     # Find mic button section
     btn_start = html.find('id="btnMic"')
-    btn_end = html.find('</button>', btn_start) + len('</button>')
+    btn_end = html.find("</button>", btn_start) + len("</button>")
     btn_html = html[btn_start:btn_end]
-    assert '<rect' in btn_html, "mic SVG missing rect (mic body)"
-    assert '<path' in btn_html, "mic SVG missing path (arc)"
-    assert '<line' in btn_html, "mic SVG missing line (stand)"
+    assert "<rect" in btn_html, "mic SVG missing rect (mic body)"
+    assert "<path" in btn_html, "mic SVG missing path (arc)"
+    assert "<line" in btn_html, "mic SVG missing line (stand)"
 
 
 def test_mic_button_inside_composer_left():
     """btnMic must be inside .composer-left, next to the attach button."""
     html, _ = get_text("/")
     composer_left_start = html.find('class="composer-left"')
-    composer_left_end = html.find('</div>', composer_left_start)
+    composer_left_end = html.find("</div>", composer_left_start)
     section = html[composer_left_start:composer_left_end]
-    assert 'btnAttach' in section
-    assert 'btnMic' in section
+    assert "btnAttach" in section
+    assert "btnMic" in section
 
 
 # ── style.css ────────────────────────────────────────────────────────────
@@ -114,70 +116,70 @@ def test_mic_btn_css_rule_exists():
     """style.css must define .mic-btn rule."""
     css, status = get_text("/static/style.css")
     assert status == 200
-    assert '.mic-btn' in css
+    assert ".mic-btn" in css
 
 
 def test_mic_btn_recording_state_css():
     """.mic-btn.recording must be defined for active recording visual state."""
     css, _ = get_text("/static/style.css")
-    assert '.mic-btn.recording' in css
+    assert ".mic-btn.recording" in css
 
 
 def test_mic_recording_color_error():
     """.mic-btn.recording must use the error color variable or red."""
     css, _ = get_text("/static/style.css")
-    recording_idx = css.find('.mic-btn.recording')
+    recording_idx = css.find(".mic-btn.recording")
     # Find the rule block after the selector
-    brace_open = css.find('{', recording_idx)
-    brace_close = css.find('}', brace_open)
+    brace_open = css.find("{", recording_idx)
+    brace_close = css.find("}", brace_open)
     rule = css[brace_open:brace_close]
-    assert 'var(--error)' in rule or '#e94560' in rule
+    assert "var(--error)" in rule or "#e94560" in rule
 
 
 def test_mic_recording_has_animation():
     """.mic-btn.recording must use an animation for the pulse effect."""
     css, _ = get_text("/static/style.css")
-    recording_idx = css.find('.mic-btn.recording')
-    brace_open = css.find('{', recording_idx)
-    brace_close = css.find('}', brace_open)
+    recording_idx = css.find(".mic-btn.recording")
+    brace_open = css.find("{", recording_idx)
+    brace_close = css.find("}", brace_open)
     rule = css[brace_open:brace_close]
-    assert 'animation' in rule
+    assert "animation" in rule
 
 
 def test_mic_pulse_keyframes_defined():
     """@keyframes mic-pulse must be defined for the pulsing animation."""
     css, _ = get_text("/static/style.css")
-    assert 'mic-pulse' in css
-    assert '@keyframes' in css
+    assert "mic-pulse" in css
+    assert "@keyframes" in css
 
 
 def test_mic_status_css_rule_exists():
     """style.css must define .mic-status rule."""
     css, _ = get_text("/static/style.css")
-    assert '.mic-status' in css
+    assert ".mic-status" in css
 
 
 def test_mic_dot_css_rule_exists():
     """style.css must define .mic-dot rule with animation."""
     css, _ = get_text("/static/style.css")
-    assert '.mic-dot' in css
-    dot_idx = css.find('.mic-dot')
-    brace_open = css.find('{', dot_idx)
-    brace_close = css.find('}', brace_open)
+    assert ".mic-dot" in css
+    dot_idx = css.find(".mic-dot")
+    brace_open = css.find("{", dot_idx)
+    brace_close = css.find("}", brace_open)
     rule = css[brace_open:brace_close]
-    assert 'animation' in rule
+    assert "animation" in rule
 
 
 def test_mic_btn_has_transition():
     """.mic-btn must define a transition for smooth state changes."""
     css, _ = get_text("/static/style.css")
-    mic_btn_idx = css.find('.mic-btn{')
+    mic_btn_idx = css.find(".mic-btn{")
     if mic_btn_idx == -1:
-        mic_btn_idx = css.find('.mic-btn ')
-    brace_open = css.find('{', mic_btn_idx)
-    brace_close = css.find('}', brace_open)
+        mic_btn_idx = css.find(".mic-btn ")
+    brace_open = css.find("{", mic_btn_idx)
+    brace_close = css.find("}", brace_open)
     rule = css[brace_open:brace_close]
-    assert 'transition' in rule
+    assert "transition" in rule
 
 
 # ── boot.js ──────────────────────────────────────────────────────────────
@@ -192,28 +194,33 @@ def test_boot_js_serves_ok():
 def test_boot_js_speech_recognition_check():
     """boot.js must check for SpeechRecognition (with webkit fallback)."""
     js, _ = get_text("/static/boot.js")
-    assert 'SpeechRecognition' in js
-    assert 'webkitSpeechRecognition' in js
+    assert "SpeechRecognition" in js
+    assert "webkitSpeechRecognition" in js
 
 
 def test_boot_js_recognition_config():
     """boot.js must configure recognition.continuous, interimResults, and lang."""
     js, _ = get_text("/static/boot.js")
-    assert 'recognition.continuous' in js
-    assert 'recognition.interimResults' in js
-    assert 'recognition.lang' in js
+    assert "recognition.continuous" in js
+    assert "recognition.interimResults" in js
+    assert "recognition.lang" in js
 
 
 def test_boot_js_recognition_not_continuous():
     """recognition.continuous must be false (auto-stop after silence)."""
     js, _ = get_text("/static/boot.js")
-    assert 'recognition.continuous=false' in js or 'recognition.continuous = false' in js
+    assert (
+        "recognition.continuous=false" in js or "recognition.continuous = false" in js
+    )
 
 
 def test_boot_js_recognition_interim_results():
     """recognition.interimResults must be true (live transcription preview)."""
     js, _ = get_text("/static/boot.js")
-    assert 'recognition.interimResults=true' in js or 'recognition.interimResults = true' in js
+    assert (
+        "recognition.interimResults=true" in js
+        or "recognition.interimResults = true" in js
+    )
 
 
 def test_boot_js_recognition_lang_en():
@@ -223,39 +230,42 @@ def test_boot_js_recognition_lang_en():
     assert (
         "recognition.lang='en-US'" in js
         or 'recognition.lang = "en-US"' in js
-        or "recognition.lang=" in js  # dynamic: recognition.lang=(_locale._speech)||'en-US'
+        or "recognition.lang="
+        in js  # dynamic: recognition.lang=(_locale._speech)||'en-US'
     )
 
 
 def test_boot_js_onresult_handler():
     """boot.js must define recognition.onresult to handle transcription."""
     js, _ = get_text("/static/boot.js")
-    assert 'recognition.onresult' in js
+    assert "recognition.onresult" in js
 
 
 def test_boot_js_onend_handler():
     """boot.js must define recognition.onend to reset state when recording stops."""
     js, _ = get_text("/static/boot.js")
-    assert 'recognition.onend' in js
+    assert "recognition.onend" in js
 
 
 def test_boot_js_onerror_handler():
     """boot.js must define recognition.onerror for graceful error handling."""
     js, _ = get_text("/static/boot.js")
-    assert 'recognition.onerror' in js
+    assert "recognition.onerror" in js
 
 
 def test_boot_js_not_allowed_error_message():
     """onerror must handle 'not-allowed' with a user-friendly message."""
     js, _ = get_text("/static/boot.js")
-    assert 'not-allowed' in js
-    assert 'permission' in js.lower() or 'denied' in js.lower() or 'access' in js.lower()
+    assert "not-allowed" in js
+    assert (
+        "permission" in js.lower() or "denied" in js.lower() or "access" in js.lower()
+    )
 
 
 def test_boot_js_no_speech_error_message():
     """onerror must handle 'no-speech' with a user-friendly message."""
     js, _ = get_text("/static/boot.js")
-    assert 'no-speech' in js
+    assert "no-speech" in js
 
 
 def test_boot_js_network_error_message():
@@ -267,7 +277,7 @@ def test_boot_js_network_error_message():
 def test_boot_js_mic_active_flag():
     """boot.js must track recording state via _micActive flag."""
     js, _ = get_text("/static/boot.js")
-    assert '_micActive' in js
+    assert "_micActive" in js
 
 
 def test_boot_js_mic_recording_class_toggle():
@@ -279,7 +289,7 @@ def test_boot_js_mic_recording_class_toggle():
 def test_boot_js_mic_status_toggle():
     """boot.js must show/hide #micStatus during recording."""
     js, _ = get_text("/static/boot.js")
-    assert 'micStatus' in js
+    assert "micStatus" in js
 
 
 def test_boot_js_send_stops_mic():
@@ -288,59 +298,67 @@ def test_boot_js_send_stops_mic():
     ui_js, _ = get_text("/static/ui.js")
     send_onclick_idx = boot_js.find("$('btnSend').onclick")
     assert send_onclick_idx != -1
-    assert 'handleComposerPrimaryAction' in boot_js[send_onclick_idx:send_onclick_idx + 200]
-    handler_idx = ui_js.find('function handleComposerPrimaryAction')
+    assert (
+        "handleComposerPrimaryAction"
+        in boot_js[send_onclick_idx : send_onclick_idx + 200]
+    )
+    handler_idx = ui_js.find("function handleComposerPrimaryAction")
     assert handler_idx != -1
-    handler = ui_js[handler_idx:handler_idx + 500]
-    assert '_micActive' in handler
-    assert '_stopMic()' in handler
+    handler = ui_js[handler_idx : handler_idx + 500]
+    assert "_micActive" in handler
+    assert "_stopMic()" in handler
 
 
 def test_boot_js_btn_mic_onclick():
     """boot.js must attach an onclick handler to btnMic."""
     js, _ = get_text("/static/boot.js")
-    assert 'btn.onclick' in js or "btnMic.onclick" in js or "$('btnMic').onclick" in js
+    assert "btn.onclick" in js or "btnMic.onclick" in js or "$('btnMic').onclick" in js
 
 
 def test_boot_js_recognition_start():
     """boot.js must call recognition.start() to begin recording."""
     js, _ = get_text("/static/boot.js")
-    assert 'recognition.start()' in js
+    assert "recognition.start()" in js
 
 
 def test_boot_js_recognition_stop():
     """boot.js must call recognition.stop() to end recording."""
     js, _ = get_text("/static/boot.js")
-    assert 'recognition.stop()' in js
+    assert "recognition.stop()" in js
 
 
 def test_boot_js_iife_guard():
     """Mic logic must be wrapped in an IIFE so it doesn't pollute global scope."""
     js, _ = get_text("/static/boot.js")
     # IIFE pattern: (function(){...})() or (() => {...})()
-    assert '(function(){' in js or '(function () {' in js
+    assert "(function(){" in js or "(function () {" in js
 
 
 def test_boot_js_browser_unsupported_guard_uses_fallback_capabilities():
     """boot.js must keep the mic available when either speech recognition OR recorder capture exists."""
     js, _ = get_text("/static/boot.js")
-    assert 'navigator.mediaDevices' in js
-    assert 'getUserMedia' in js
-    assert 'MediaRecorder' in js
-    assert '_canRecordAudio' in js or 'canRecordAudio' in js, \
+    assert "navigator.mediaDevices" in js
+    assert "getUserMedia" in js
+    assert "MediaRecorder" in js
+    assert "_canRecordAudio" in js or "canRecordAudio" in js, (
         "boot.js should compute a recorder fallback instead of bailing only on SpeechRecognition"
+    )
 
 
 def test_boot_js_media_recorder_fallback_posts_to_transcribe_api():
     """Desktop fallback must send recorded audio to /api/transcribe for transcription."""
     js, _ = get_text("/static/boot.js")
-    assert 'api/transcribe' in js
-    assert 'fetch(' in js
+    assert "api/transcribe" in js
+    assert "fetch(" in js
 
 
 def test_routes_define_transcribe_endpoint():
     """Server routes must expose /api/transcribe for MediaRecorder fallback uploads."""
-    routes = pathlib.Path(__file__).parent.parent.joinpath("api/routes.py").read_text(encoding="utf-8")
+    routes = (
+        pathlib.Path(__file__)
+        .parent.parent.joinpath("api/routes.py")
+        .read_text(encoding="utf-8")
+    )
     assert '"/api/transcribe"' in routes
 
 
@@ -353,13 +371,13 @@ def test_boot_js_shows_mic_button_when_any_voice_path_is_supported():
 def test_boot_js_show_toast_on_error():
     """boot.js must call showToast() for mic errors."""
     js, _ = get_text("/static/boot.js")
-    assert 'showToast' in js
+    assert "showToast" in js
 
 
 def test_boot_js_autoresize_called():
     """boot.js must call autoResize() after updating textarea from transcript."""
     js, _ = get_text("/static/boot.js")
-    assert 'autoResize()' in js
+    assert "autoResize()" in js
 
 
 # ── Append behaviour (fix: mic appends to existing text, not replace) ────
@@ -417,8 +435,12 @@ def test_boot_js_auto_space_between_prefix_and_transcript():
     onend_end = js.find("};", onend_idx)
     onend_body = js[onend_idx:onend_end]
     # Should handle spacing — look for trimStart or endsWith(' ') check
-    has_spacing = ("trimStart" in onend_body or "endsWith(' ')" in onend_body
-                   or "endsWith(\" \")" in onend_body or "endsWith('\\n')" in onend_body)
+    has_spacing = (
+        "trimStart" in onend_body
+        or "endsWith(' ')" in onend_body
+        or 'endsWith(" ")' in onend_body
+        or "endsWith('\\n')" in onend_body
+    )
     assert has_spacing, "onend should handle spacing between prefix and new transcript"
 
 

--- a/tests/test_sprint20b.py
+++ b/tests/test_sprint20b.py
@@ -2,6 +2,7 @@
 Sprint 21 Tests: Send button polish — hidden until content, pop-in animation,
 icon-only circle design.
 """
+
 import re
 import urllib.request
 
@@ -28,29 +29,29 @@ def test_send_button_disabled_by_default():
     html, _ = get_text("/")
     btn_match = re.search(r'id="btnSend"[^>]*>', html)
     assert btn_match, "btnSend element not found"
-    assert 'disabled' in btn_match.group(0)
+    assert "disabled" in btn_match.group(0)
 
 
 def test_send_button_no_text_label():
     """Send button must be icon-only — no visible 'Send' text label."""
     html, _ = get_text("/")
     # Find the full button element (from opening tag to closing tag)
-    btn_open_end = html.find('>', html.find('id="btnSend"')) + 1
-    btn_end = html.find('</button>', btn_open_end) + len('</button>')
+    btn_open_end = html.find(">", html.find('id="btnSend"')) + 1
+    btn_end = html.find("</button>", btn_open_end) + len("</button>")
     btn_inner = html[btn_open_end:btn_end]
     # Strip SVG content and any remaining tags; check visible text
-    no_svg = re.sub(r'<svg[^>]*>.*?</svg>', '', btn_inner, flags=re.DOTALL)
-    visible_text = re.sub(r'<[^>]+>', '', no_svg).strip()
-    assert visible_text == '', f"Send button has visible text: {visible_text!r}"
+    no_svg = re.sub(r"<svg[^>]*>.*?</svg>", "", btn_inner, flags=re.DOTALL)
+    visible_text = re.sub(r"<[^>]+>", "", no_svg).strip()
+    assert visible_text == "", f"Send button has visible text: {visible_text!r}"
 
 
 def test_send_button_has_svg_icon():
     """Send button must have an SVG icon."""
     html, _ = get_text("/")
     btn_start = html.find('id="btnSend"')
-    btn_end = html.find('</button>', btn_start) + len('</button>')
+    btn_end = html.find("</button>", btn_start) + len("</button>")
     btn_html = html[btn_start:btn_end]
-    assert '<svg' in btn_html
+    assert "<svg" in btn_html
 
 
 def test_send_button_has_title_attribute():
@@ -63,19 +64,24 @@ def test_send_button_has_title_attribute():
     btn_match = re.search(r'id="btnSend"[^>]*>', html)
     assert btn_match
     tag = btn_match.group(0)
-    assert 'title=' in tag or 'data-tooltip=' in tag, \
+    assert "title=" in tag or "data-tooltip=" in tag, (
         "btnSend must have a tooltip (native title= or custom data-tooltip= per #1775)"
+    )
 
 
 def test_send_button_svg_arrow_up():
     """Send button SVG should use an upward arrow (line + polyline or path)."""
     html, _ = get_text("/")
     btn_start = html.find('id="btnSend"')
-    btn_end = html.find('</button>', btn_start) + len('</button>')
+    btn_end = html.find("</button>", btn_start) + len("</button>")
     btn_html = html[btn_start:btn_end]
     # Must have some directional shape element
-    has_shape = ('<line' in btn_html or '<polyline' in btn_html or
-                 '<polygon' in btn_html or '<path' in btn_html)
+    has_shape = (
+        "<line" in btn_html
+        or "<polyline" in btn_html
+        or "<polygon" in btn_html
+        or "<path" in btn_html
+    )
     assert has_shape, "Send button SVG missing directional shape"
 
 
@@ -86,116 +92,116 @@ def test_send_btn_is_circle():
     """send-btn must use border-radius:50% for the circle shape."""
     css, status = get_text("/static/style.css")
     assert status == 200
-    send_idx = css.find('.send-btn{')
-    brace_open = css.find('{', send_idx)
-    brace_close = css.find('}', brace_open)
+    send_idx = css.find(".send-btn{")
+    brace_open = css.find("{", send_idx)
+    brace_close = css.find("}", brace_open)
     rule = css[brace_open:brace_close]
-    assert 'border-radius:50%' in rule or 'border-radius: 50%' in rule
+    assert "border-radius:50%" in rule or "border-radius: 50%" in rule
 
 
 def test_send_btn_fixed_dimensions():
     """send-btn must have explicit width and height (icon-circle, not text-padded)."""
     css, _ = get_text("/static/style.css")
-    send_idx = css.find('.send-btn{')
-    brace_open = css.find('{', send_idx)
-    brace_close = css.find('}', brace_open)
+    send_idx = css.find(".send-btn{")
+    brace_open = css.find("{", send_idx)
+    brace_close = css.find("}", brace_open)
     rule = css[brace_open:brace_close]
-    assert 'width:' in rule or 'width :' in rule
-    assert 'height:' in rule or 'height :' in rule
+    assert "width:" in rule or "width :" in rule
+    assert "height:" in rule or "height :" in rule
 
 
 def test_send_btn_no_old_padding():
     """send-btn must not use text padding layout (old pill style removed)."""
     css, _ = get_text("/static/style.css")
-    send_idx = css.find('.send-btn{')
-    brace_open = css.find('{', send_idx)
-    brace_close = css.find('}', brace_open)
+    send_idx = css.find(".send-btn{")
+    brace_open = css.find("{", send_idx)
+    brace_close = css.find("}", brace_open)
     rule = css[brace_open:brace_close]
     # Old style used padding:7px 18px — should be gone
-    assert 'padding:7px' not in rule and 'padding: 7px' not in rule
+    assert "padding:7px" not in rule and "padding: 7px" not in rule
 
 
 def test_send_btn_accent_background():
     """send-btn background must use the accent color variable."""
     css, _ = get_text("/static/style.css")
-    send_idx = css.find('.send-btn{')
-    brace_open = css.find('{', send_idx)
-    brace_close = css.find('}', brace_open)
+    send_idx = css.find(".send-btn{")
+    brace_open = css.find("{", send_idx)
+    brace_close = css.find("}", brace_open)
     rule = css[brace_open:brace_close]
-    assert 'var(--accent)' in rule or 'var(--blue)' in rule or '7cb9ff' in rule
+    assert "var(--accent)" in rule or "var(--blue)" in rule or "7cb9ff" in rule
 
 
 def test_send_btn_has_transition():
     """send-btn must have transition for smooth hover/active states."""
     css, _ = get_text("/static/style.css")
-    send_idx = css.find('.send-btn{')
-    brace_open = css.find('{', send_idx)
-    brace_close = css.find('}', brace_open)
+    send_idx = css.find(".send-btn{")
+    brace_open = css.find("{", send_idx)
+    brace_close = css.find("}", brace_open)
     rule = css[brace_open:brace_close]
-    assert 'transition' in rule
+    assert "transition" in rule
 
 
 def test_send_btn_has_box_shadow():
     """send-btn must have a box-shadow glow effect."""
     css, _ = get_text("/static/style.css")
-    send_idx = css.find('.send-btn{')
-    brace_open = css.find('{', send_idx)
-    brace_close = css.find('}', brace_open)
+    send_idx = css.find(".send-btn{")
+    brace_open = css.find("{", send_idx)
+    brace_close = css.find("}", brace_open)
     rule = css[brace_open:brace_close]
-    assert 'box-shadow' in rule
+    assert "box-shadow" in rule
 
 
 def test_send_btn_hover_has_scale():
     """send-btn:hover must use transform:scale for a satisfying hover effect."""
     css, _ = get_text("/static/style.css")
-    hover_idx = css.find('.send-btn:hover{')
-    brace_open = css.find('{', hover_idx)
-    brace_close = css.find('}', brace_open)
+    hover_idx = css.find(".send-btn:hover{")
+    brace_open = css.find("{", hover_idx)
+    brace_close = css.find("}", brace_open)
     rule = css[brace_open:brace_close]
-    assert 'scale' in rule
+    assert "scale" in rule
 
 
 def test_send_btn_active_shrinks():
     """send-btn:active must scale down slightly for tactile press feedback."""
     css, _ = get_text("/static/style.css")
-    active_idx = css.find('.send-btn:active{')
-    brace_open = css.find('{', active_idx)
-    brace_close = css.find('}', brace_open)
+    active_idx = css.find(".send-btn:active{")
+    brace_open = css.find("{", active_idx)
+    brace_close = css.find("}", brace_open)
     rule = css[brace_open:brace_close]
-    assert 'scale' in rule
+    assert "scale" in rule
 
 
 def test_send_btn_disabled_rule_exists():
     """send-btn:disabled must still be styled."""
     css, _ = get_text("/static/style.css")
-    assert '.send-btn:disabled' in css
+    assert ".send-btn:disabled" in css
 
 
 def test_send_btn_visible_class_defined():
     """.send-btn.visible class must be defined for the pop-in animation."""
     css, _ = get_text("/static/style.css")
-    assert '.send-btn.visible' in css
+    assert ".send-btn.visible" in css
 
 
 def test_send_pop_in_keyframes_defined():
     """@keyframes send-pop-in must be defined."""
     css, _ = get_text("/static/style.css")
-    assert 'send-pop-in' in css
-    assert '@keyframes' in css
+    assert "send-pop-in" in css
+    assert "@keyframes" in css
 
 
 def _extract_keyframe(css, name):
     """Extract the full @keyframes block for the given animation name."""
     # Find '@keyframes <name>' directly (forward search) to avoid hitting
     # an earlier keyframe when multiple are defined on the same line.
-    kf_start = css.find('@keyframes ' + name)
+    kf_start = css.find("@keyframes " + name)
     assert kf_start != -1, f"@keyframes {name} not found in CSS"
     depth = 0
     kf_end = kf_start
     for i, ch in enumerate(css[kf_start:], kf_start):
-        if ch == '{':
+        if ch == "{":
             depth += 1
-        elif ch == '}':
+        elif ch == "}":
             depth -= 1
             if depth == 0:
                 kf_end = i
@@ -206,29 +212,29 @@ def _extract_keyframe(css, name):
 def test_send_pop_in_uses_scale():
     """send-pop-in keyframe must animate from a scaled-down state."""
     css, _ = get_text("/static/style.css")
-    kf_rule = _extract_keyframe(css, 'send-pop-in')
-    assert 'scale' in kf_rule
+    kf_rule = _extract_keyframe(css, "send-pop-in")
+    assert "scale" in kf_rule
 
 
 def test_send_pop_in_uses_opacity():
     """send-pop-in keyframe must fade in (opacity transition)."""
     css, _ = get_text("/static/style.css")
-    kf_rule = _extract_keyframe(css, 'send-pop-in')
-    assert 'opacity' in kf_rule
+    kf_rule = _extract_keyframe(css, "send-pop-in")
+    assert "opacity" in kf_rule
 
 
 def test_send_btn_mobile_override_no_padding():
     """Mobile override for send-btn must not add text padding (keeps circle shape)."""
     css, _ = get_text("/static/style.css")
     # Find the @media block
-    media_idx = css.find('@media')
-    send_mobile_idx = css.find('.send-btn', media_idx)
+    media_idx = css.find("@media")
+    send_mobile_idx = css.find(".send-btn", media_idx)
     if send_mobile_idx == -1:
         return  # No mobile override, fine
-    brace_open = css.find('{', send_mobile_idx)
-    brace_close = css.find('}', brace_open)
+    brace_open = css.find("{", send_mobile_idx)
+    brace_close = css.find("}", brace_open)
     rule = css[brace_open:brace_close]
-    assert 'padding:' not in rule and 'font-size' not in rule
+    assert "padding:" not in rule and "font-size" not in rule
 
 
 # ── ui.js ─────────────────────────────────────────────────────────────────
@@ -238,63 +244,63 @@ def test_ui_js_update_send_btn_function():
     """ui.js must define updateSendBtn() function."""
     js, status = get_text("/static/ui.js")
     assert status == 200
-    assert 'function updateSendBtn' in js
+    assert "function updateSendBtn" in js
 
 
 def test_update_send_btn_checks_content():
     """Composer primary action helper must check textarea value length."""
     js, _ = get_text("/static/ui.js")
-    fn_idx = js.find('function _composerHasContent')
-    fn_end = js.find('\n}', fn_idx) + 2
+    fn_idx = js.find("function _composerHasContent")
+    fn_end = js.find("\n}", fn_idx) + 2
     fn_body = js[fn_idx:fn_end]
-    assert 'msg' in fn_body
-    assert '.value' in fn_body
-    assert '.length' in fn_body or '.trim()' in fn_body
+    assert "msg" in fn_body
+    assert ".value" in fn_body
+    assert ".length" in fn_body or ".trim()" in fn_body
 
 
 def test_update_send_btn_checks_pending_files():
     """Composer primary action helper must also count attached files as content."""
     js, _ = get_text("/static/ui.js")
-    fn_idx = js.find('function _composerHasContent')
-    fn_end = js.find('\n}', fn_idx) + 2
+    fn_idx = js.find("function _composerHasContent")
+    fn_end = js.find("\n}", fn_idx) + 2
     fn_body = js[fn_idx:fn_end]
-    assert 'pendingFiles' in fn_body
+    assert "pendingFiles" in fn_body
 
 
 def test_update_send_btn_uses_visible_class():
     """updateSendBtn must add .visible class to trigger the pop-in animation."""
     js, _ = get_text("/static/ui.js")
-    fn_idx = js.find('function updateSendBtn')
-    fn_end = js.find('\n}', fn_idx) + 2
+    fn_idx = js.find("function updateSendBtn")
+    fn_end = js.find("\n}", fn_idx) + 2
     fn_body = js[fn_idx:fn_end]
-    assert 'visible' in fn_body
+    assert "visible" in fn_body
 
 
 def test_update_send_btn_uses_disabled():
     """updateSendBtn must disable the button when no content or busy."""
     js, _ = get_text("/static/ui.js")
-    fn_idx = js.find('function updateSendBtn')
-    fn_end = js.find('\n}', fn_idx) + 2
+    fn_idx = js.find("function updateSendBtn")
+    fn_end = js.find("\n}", fn_idx) + 2
     fn_body = js[fn_idx:fn_end]
-    assert 'disabled' in fn_body
+    assert "disabled" in fn_body
 
 
 def test_set_busy_calls_update_send_btn():
     """setBusy must call updateSendBtn() so button hides while agent is responding."""
     js, _ = get_text("/static/ui.js")
-    busy_idx = js.find('function setBusy')
-    busy_end = js.find('\n}', busy_idx) + 2
+    busy_idx = js.find("function setBusy")
+    busy_end = js.find("\n}", busy_idx) + 2
     busy_body = js[busy_idx:busy_end]
-    assert 'updateSendBtn' in busy_body
+    assert "updateSendBtn" in busy_body
 
 
 def test_render_tray_calls_update_send_btn():
     """renderTray must call updateSendBtn() so button appears when files are attached."""
     js, _ = get_text("/static/ui.js")
-    tray_idx = js.find('function renderTray')
-    tray_end = js.find('\n}', tray_idx) + 2
+    tray_idx = js.find("function renderTray")
+    tray_end = js.find("\n}", tray_idx) + 2
     tray_body = js[tray_idx:tray_end]
-    assert 'updateSendBtn' in tray_body
+    assert "updateSendBtn" in tray_body
 
 
 # ── boot.js ──────────────────────────────────────────────────────────────
@@ -304,7 +310,7 @@ def test_boot_js_input_calls_update_send_btn():
     """boot.js input event listener must call updateSendBtn()."""
     js, status = get_text("/static/boot.js")
     assert status == 200
-    assert 'updateSendBtn' in js
+    assert "updateSendBtn" in js
 
 
 # ── messages.js ───────────────────────────────────────────────────────────
@@ -314,7 +320,7 @@ def test_auto_resize_calls_update_send_btn():
     """autoResize() must call updateSendBtn() so button hides after send clears textarea."""
     js, status = get_text("/static/messages.js")
     assert status == 200
-    assert 'updateSendBtn' in js
+    assert "updateSendBtn" in js
 
 
 # ── Regression: existing behaviour unchanged ──────────────────────────────
@@ -325,17 +331,19 @@ def test_send_button_still_has_send_btn_class():
     html, _ = get_text("/")
     # Tolerate additional utility classes (e.g. has-tooltip from #1775).
     import re
-    assert re.search(r'class="[^"]*\bsend-btn\b[^"]*"', html), \
+
+    assert re.search(r'class="[^"]*\bsend-btn\b[^"]*"', html), (
         "btnSend must still carry the 'send-btn' class for CSS targeting"
+    )
 
 
 def test_ui_js_set_busy_calls_update_send_btn():
     """setBusy must call updateSendBtn to manage button disabled state."""
     js, _ = get_text("/static/ui.js")
-    busy_idx = js.find('function setBusy')
-    busy_end = js.find('\n}', busy_idx) + 2
+    busy_idx = js.find("function setBusy")
+    busy_end = js.find("\n}", busy_idx) + 2
     busy_body = js[busy_idx:busy_end]
-    assert 'updateSendBtn' in busy_body
+    assert "updateSendBtn" in busy_body
 
 
 def test_index_html_attach_button_unchanged():
@@ -347,4 +355,4 @@ def test_index_html_attach_button_unchanged():
 def test_send_function_still_exists():
     """send() function must still be defined in messages.js."""
     js, _ = get_text("/static/messages.js")
-    assert 'async function send()' in js
+    assert "async function send()" in js

--- a/tests/test_sprint23.py
+++ b/tests/test_sprint23.py
@@ -2,7 +2,10 @@
 Sprint 23 Tests: agentic transparency — token/cost display, session usage fields,
 subagent card names, skill picker in cron, skill linked files.
 """
-import json, urllib.error, urllib.request
+
+import json
+import urllib.error
+import urllib.request
 
 from tests._pytest_port import BASE
 
@@ -14,8 +17,9 @@ def get(path):
 
 def post(path, body=None):
     data = json.dumps(body or {}).encode()
-    req = urllib.request.Request(BASE + path, data=data,
-                                headers={"Content-Type": "application/json"})
+    req = urllib.request.Request(
+        BASE + path, data=data, headers={"Content-Type": "application/json"}
+    )
     try:
         with urllib.request.urlopen(req, timeout=10) as r:
             return json.loads(r.read()), r.status
@@ -31,6 +35,7 @@ def make_session(created_list):
 
 
 # ── Session usage fields ─────────────────────────────────────────────────
+
 
 def test_new_session_has_usage_fields():
     """New session should include input_tokens, output_tokens, estimated_cost."""
@@ -76,7 +81,9 @@ def test_session_usage_defaults_zero():
     try:
         sid, sess = make_session(created)
         assert "input_tokens" in sess, "input_tokens missing from new session response"
-        assert "output_tokens" in sess, "output_tokens missing from new session response"
+        assert "output_tokens" in sess, (
+            "output_tokens missing from new session response"
+        )
         assert sess["input_tokens"] == 0
         assert sess["output_tokens"] == 0
     finally:
@@ -85,6 +92,7 @@ def test_session_usage_defaults_zero():
 
 
 # ── Skills content linked_files ──────────────────────────────────────────
+
 
 def test_skills_content_requires_name():
     """GET /api/skills/content without name should return 400 (or 500 if skills module unavailable)."""
@@ -104,7 +112,9 @@ def test_skills_content_has_linked_files_key():
         name = d["skills"][0]["name"]
         d2, status2 = get(f"/api/skills/content?name={name}")
         assert status2 == 200
-        assert "linked_files" in d2, "linked_files key missing from skills/content response"
+        assert "linked_files" in d2, (
+            "linked_files key missing from skills/content response"
+        )
         # linked_files must be a dict (possibly empty), not None
         assert isinstance(d2["linked_files"], dict), "linked_files must be a dict"
     except urllib.error.HTTPError:
@@ -114,6 +124,7 @@ def test_skills_content_has_linked_files_key():
 def test_skills_content_file_path_traversal_rejected():
     """GET /api/skills/content with traversal path should be rejected."""
     from urllib.parse import quote as _quote
+
     try:
         d, status = get("/api/skills")
         if not d.get("skills"):
@@ -122,9 +133,13 @@ def test_skills_content_file_path_traversal_rejected():
         traversal = _quote("../../etc/passwd", safe="")
         try:
             d2, status2 = get(f"/api/skills/content?name={name}&file={traversal}")
-            assert status2 in (400, 404, 500), f"Path traversal should be rejected, got {status2}"
+            assert status2 in (400, 404, 500), (
+                f"Path traversal should be rejected, got {status2}"
+            )
         except urllib.error.HTTPError as e:
-            assert e.code in (400, 404, 500), f"Path traversal should be rejected, got {e.code}"
+            assert e.code in (400, 404, 500), (
+                f"Path traversal should be rejected, got {e.code}"
+            )
     except urllib.error.HTTPError:
         pass  # skills module unavailable in test env
 
@@ -136,12 +151,15 @@ def test_skills_content_wildcard_name_rejected():
             d2, status2 = get("/api/skills/content?name=*&file=SKILL.md")
             assert status2 == 400, f"Wildcard name should return 400, got {status2}"
         except urllib.error.HTTPError as e:
-            assert e.code in (400, 404), f"Wildcard name should be rejected, got {e.code}"
+            assert e.code in (400, 404), (
+                f"Wildcard name should be rejected, got {e.code}"
+            )
     except Exception:
         pass
 
 
 # ── Cron create with skills ───────────────────────────────────────────────
+
 
 def test_cron_create_accepts_skills():
     """POST /api/crons/create should accept and store a skills array (or 500 if cron module unavailable)."""
@@ -152,10 +170,12 @@ def test_cron_create_accepts_skills():
             "schedule": "0 9 * * *",
             "prompt": "test prompt",
             "deliver": "local",
-            "skills": ["some-skill"]
+            "skills": ["some-skill"],
         }
         d, status = post("/api/crons/create", body)
-        if status in (400, 500) and ('module' in str(d.get('error','')) or 'cron' in str(d.get('error',''))):
+        if status in (400, 500) and (
+            "module" in str(d.get("error", "")) or "cron" in str(d.get("error", ""))
+        ):
             return  # cron module not available in test env
         assert status == 200, f"Expected 200 from cron create, got {status}: {d}"
         assert d.get("ok"), f"Cron create did not return ok: {d}"
@@ -164,10 +184,18 @@ def test_cron_create_accepts_skills():
             created_jobs.append(job_id)
         # Verify job appears in list
         jobs_d, _ = get("/api/crons")
-        job = next((j for j in jobs_d.get("jobs", []) if j.get("name") == "test-sprint23-skills"), None)
+        job = next(
+            (
+                j
+                for j in jobs_d.get("jobs", [])
+                if j.get("name") == "test-sprint23-skills"
+            ),
+            None,
+        )
         assert job is not None, "Created cron job not found in job list"
-        assert job.get("skills") == ["some-skill"] or job.get("skill") == "some-skill", \
-            f"skills not stored on job: {job}"
+        assert (
+            job.get("skills") == ["some-skill"] or job.get("skill") == "some-skill"
+        ), f"skills not stored on job: {job}"
     finally:
         try:
             for jid in created_jobs:
@@ -182,6 +210,7 @@ def test_cron_create_accepts_skills():
 
 # ── Tool call integrity ──────────────────────────────────────────────────
 
+
 def test_tool_calls_have_real_names():
     """Tool calls in session JSON should not have unresolved 'tool' name."""
     created = []
@@ -190,7 +219,9 @@ def test_tool_calls_have_real_names():
         d, status = get(f"/api/session?session_id={sid}")
         assert status == 200
         for tc in d["session"].get("tool_calls", []):
-            assert tc.get("name") not in ("tool", "", None), f"Unresolved tool name: {tc}"
+            assert tc.get("name") not in ("tool", "", None), (
+                f"Unresolved tool name: {tc}"
+            )
     finally:
         for s in created:
             post("/api/session/delete", {"session_id": s})

--- a/tests/test_sprint26.py
+++ b/tests/test_sprint26.py
@@ -2,7 +2,10 @@
 Sprint 26 Tests: canonical appearance settings persist and legacy theme names
 map onto the new theme + skin system.
 """
-import json, urllib.error, urllib.request
+
+import json
+import urllib.error
+import urllib.request
 import pathlib
 import sys
 
@@ -22,8 +25,9 @@ def get(path):
 
 def post(path, body=None):
     data = json.dumps(body or {}).encode()
-    req = urllib.request.Request(BASE + path, data=data,
-                                headers={"Content-Type": "application/json"})
+    req = urllib.request.Request(
+        BASE + path, data=data, headers={"Content-Type": "application/json"}
+    )
     try:
         with urllib.request.urlopen(req, timeout=10) as r:
             return json.loads(r.read()), r.status
@@ -32,6 +36,7 @@ def post(path, body=None):
 
 
 # ── Theme settings ───────────────────────────────────────────────────────
+
 
 def test_settings_default_theme():
     """Default theme should be 'dark'."""

--- a/tests/test_sprint27.py
+++ b/tests/test_sprint27.py
@@ -3,6 +3,7 @@ Sprint 27 Tests: configurable assistant display name (bot_name).
 Tests cover settings API round-trip, empty/missing input defaults,
 login page rendering, and server-side sanitization.
 """
+
 import json
 import urllib.error
 import urllib.request
@@ -22,8 +23,9 @@ def get_raw(path):
 
 def post(path, body=None):
     data = json.dumps(body or {}).encode()
-    req = urllib.request.Request(BASE + path, data=data,
-                                 headers={"Content-Type": "application/json"})
+    req = urllib.request.Request(
+        BASE + path, data=data, headers={"Content-Type": "application/json"}
+    )
     try:
         with urllib.request.urlopen(req, timeout=10) as r:
             return json.loads(r.read()), r.status
@@ -32,6 +34,7 @@ def post(path, body=None):
 
 
 # ── Default value ─────────────────────────────────────────────────────────
+
 
 def test_settings_default_bot_name():
     """GET /api/settings should return bot_name defaulting to 'Hermes'."""
@@ -42,6 +45,7 @@ def test_settings_default_bot_name():
 
 
 # ── Round-trip ────────────────────────────────────────────────────────────
+
 
 def test_settings_set_bot_name():
     """POST /api/settings with bot_name should persist and round-trip."""
@@ -68,6 +72,7 @@ def test_settings_bot_name_special_chars():
 
 # ── Server-side sanitization ──────────────────────────────────────────────
 
+
 def test_settings_empty_bot_name_defaults_to_hermes():
     """Posting an empty bot_name should default to 'Hermes' server-side."""
     try:
@@ -91,6 +96,7 @@ def test_settings_whitespace_bot_name_defaults_to_hermes():
 
 
 # ── Login page rendering ──────────────────────────────────────────────────
+
 
 def test_login_page_shows_default_bot_name():
     """GET /login should contain 'Hermes' in title and h1 when default."""

--- a/tests/test_sprint28.py
+++ b/tests/test_sprint28.py
@@ -3,6 +3,7 @@ Sprint 28 Tests: /personality slash command — backend API coverage.
 Tests: GET /api/personalities, POST /api/personality/set, Session.compact(),
 path traversal defence, size cap, clear personality.
 """
+
 import json
 import pathlib
 import shutil
@@ -24,8 +25,9 @@ def get(path):
 
 def post(path, body=None):
     data = json.dumps(body or {}).encode()
-    req = urllib.request.Request(BASE + path, data=data,
-                                 headers={"Content-Type": "application/json"})
+    req = urllib.request.Request(
+        BASE + path, data=data, headers={"Content-Type": "application/json"}
+    )
     try:
         with urllib.request.urlopen(req, timeout=10) as r:
             return json.loads(r.read()), r.status
@@ -41,7 +43,7 @@ def _personalities_dir():
     so get_active_hermes_home() returns TEST_STATE_DIR, and personalities
     live at TEST_STATE_DIR/personalities.
     """
-    p = TEST_STATE_DIR / 'personalities'
+    p = TEST_STATE_DIR / "personalities"
     p.mkdir(parents=True, exist_ok=True)
     return p
 
@@ -69,6 +71,7 @@ def _cleanup_session(sid):
 
 
 # ── GET /api/personalities ────────────────────────────────────────────────────
+
 
 def test_personalities_empty_when_none_exist():
     """GET /api/personalities returns empty list when no personalities exist."""
@@ -116,29 +119,32 @@ def test_personalities_skips_non_dict_config():
 
 _test_personalities = {}
 
+
 def _inject_personality(name, value):
     """Write a personality into the test config.yaml so the server picks it up."""
     _test_personalities[name] = value
     _write_test_config()
+
 
 def _remove_personality(name):
     """Remove a personality from the test config.yaml."""
     _test_personalities.pop(name, None)
     _write_test_config()
 
+
 def _write_test_config():
     """Write config.yaml with test personalities using simple YAML format."""
     TEST_STATE_DIR.mkdir(parents=True, exist_ok=True)
-    config_path = TEST_STATE_DIR / 'config.yaml'
-    lines = ['agent:', '  personalities:']
+    config_path = TEST_STATE_DIR / "config.yaml"
+    lines = ["agent:", "  personalities:"]
     for pname, pval in _test_personalities.items():
         if isinstance(pval, dict):
-            lines.append(f'    {pname}:')
+            lines.append(f"    {pname}:")
             for k, v in pval.items():
                 lines.append(f'      {k}: "{v}"')
         else:
             lines.append(f'    {pname}: "{pval}"')
-    config_path.write_text('\n'.join(lines) + '\n')
+    config_path.write_text("\n".join(lines) + "\n")
 
 
 def test_set_personality_valid():
@@ -199,8 +205,9 @@ def test_set_personality_not_found_returns_404():
     """Setting a non-existent personality returns 404."""
     sid = _make_session()
     try:
-        d, status = post("/api/personality/set",
-                         {"session_id": sid, "name": "doesnotexist"})
+        d, status = post(
+            "/api/personality/set", {"session_id": sid, "name": "doesnotexist"}
+        )
         assert status == 404
     finally:
         _cleanup_session(sid)
@@ -210,8 +217,9 @@ def test_set_personality_nonexistent_returns_404():
     """Names not in config.yaml agent.personalities return 404."""
     sid = _make_session()
     try:
-        d, status = post("/api/personality/set",
-                         {"session_id": sid, "name": "doesnotexist"})
+        d, status = post(
+            "/api/personality/set", {"session_id": sid, "name": "doesnotexist"}
+        )
         assert status == 404, f"Expected 404, got {status}: {d}"
     finally:
         _cleanup_session(sid)
@@ -219,6 +227,7 @@ def test_set_personality_nonexistent_returns_404():
 
 def test_set_personality_missing_session_returns_404():
     """Setting personality on non-existent session returns 404."""
-    d, status = post("/api/personality/set",
-                     {"session_id": "nonexistent000", "name": "x"})
+    d, status = post(
+        "/api/personality/set", {"session_id": "nonexistent000", "name": "x"}
+    )
     assert status == 404

--- a/tests/test_sprint29.py
+++ b/tests/test_sprint29.py
@@ -15,7 +15,7 @@ Covers:
   11. SSRF DNS check logic (unit test on helper function)
   12. ENV_LOCK export — _ENV_LOCK importable from streaming module
 """
-import importlib
+
 import json
 import pathlib
 import sys
@@ -25,7 +25,6 @@ import urllib.parse
 import urllib.request
 
 sys.path.insert(0, str(pathlib.Path(__file__).parent))
-from conftest import TEST_STATE_DIR
 
 from tests._pytest_port import BASE
 
@@ -82,8 +81,13 @@ class TestCSRF:
             {},
             headers={"Origin": "http://evil.com", "Host": "127.0.0.1:8788"},
         )
-        assert status == 403, f"Expected 403 for cross-origin request, got {status}: {body}"
-        assert "cross-origin" in body.get("error", "").lower() or "rejected" in body.get("error", "").lower()
+        assert status == 403, (
+            f"Expected 403 for cross-origin request, got {status}: {body}"
+        )
+        assert (
+            "cross-origin" in body.get("error", "").lower()
+            or "rejected" in body.get("error", "").lower()
+        )
 
     def test_same_origin_post_allowed(self):
         """Same-origin POST (Origin matches Host) must be allowed."""
@@ -92,7 +96,9 @@ class TestCSRF:
             {},
             headers={"Origin": "http://127.0.0.1:8788", "Host": "127.0.0.1:8788"},
         )
-        assert status != 403, f"Expected non-403 for same-origin request, got {status}: {body}"
+        assert status != 403, (
+            f"Expected non-403 for same-origin request, got {status}: {body}"
+        )
 
     def test_same_origin_referer_allowed(self):
         """Same-origin Referer (matching Host) must be allowed."""
@@ -113,42 +119,56 @@ class TestCSRF:
         See test_proxy_host_default_https_port_matches_https_origin for the
         real-world proxy case that should pass.
         """
-        assert not self._csrf_allowed({
-            "Origin": "http://example.com",
-            "X-Forwarded-Host": "example.com:443",
-        }), 'http origin (port :80) must not match https host (:443)'
+        assert not self._csrf_allowed(
+            {
+                "Origin": "http://example.com",
+                "X-Forwarded-Host": "example.com:443",
+            }
+        ), "http origin (port :80) must not match https host (:443)"
 
     def test_proxy_host_default_https_port_matches_https_origin(self):
         """HTTPS Origin without port should match X-Forwarded-Host with explicit :443."""
-        assert self._csrf_allowed({
-            "Origin": "https://example.com",
-            "X-Forwarded-Host": "example.com:443",
-        })
+        assert self._csrf_allowed(
+            {
+                "Origin": "https://example.com",
+                "X-Forwarded-Host": "example.com:443",
+            }
+        )
 
     def test_proxy_host_port_normalization_still_rejects_other_host(self):
         """Port normalization must not allow different hosts through."""
-        assert not self._csrf_allowed({
-            "Origin": "https://evil.com",
-            "X-Forwarded-Host": "example.com:443",
-        })
+        assert not self._csrf_allowed(
+            {
+                "Origin": "https://evil.com",
+                "X-Forwarded-Host": "example.com:443",
+            }
+        )
 
     def test_allowed_public_origin_bypasses_missing_proxy_port(self, monkeypatch):
         """Explicitly configured public origins should pass even if proxy strips :port from Host."""
-        monkeypatch.setenv('HERMES_WEBUI_ALLOWED_ORIGINS', 'https://myapp.example.com:8000')
-        assert self._csrf_allowed({
-            'Origin': 'https://myapp.example.com:8000',
-            'Host': 'myapp.example.com',
-            'X-Forwarded-Proto': 'https',
-        })
+        monkeypatch.setenv(
+            "HERMES_WEBUI_ALLOWED_ORIGINS", "https://myapp.example.com:8000"
+        )
+        assert self._csrf_allowed(
+            {
+                "Origin": "https://myapp.example.com:8000",
+                "Host": "myapp.example.com",
+                "X-Forwarded-Proto": "https",
+            }
+        )
 
     def test_other_origin_not_allowed_by_public_origin_allowlist(self, monkeypatch):
         """Allowlist must stay exact; unrelated origins must still be rejected."""
-        monkeypatch.setenv('HERMES_WEBUI_ALLOWED_ORIGINS', 'https://myapp.example.com:8000')
-        assert not self._csrf_allowed({
-            'Origin': 'https://evil.com:8000',
-            'Host': 'myapp.example.com',
-            'X-Forwarded-Proto': 'https',
-        })
+        monkeypatch.setenv(
+            "HERMES_WEBUI_ALLOWED_ORIGINS", "https://myapp.example.com:8000"
+        )
+        assert not self._csrf_allowed(
+            {
+                "Origin": "https://evil.com:8000",
+                "Host": "myapp.example.com",
+                "X-Forwarded-Proto": "https",
+            }
+        )
 
     # ── Port normalization: scheme-aware (M-1 fix) ────────────────────────────
 
@@ -158,42 +178,54 @@ class TestCSRF:
         Before M-1 fix, _ports_match treated both 80 and 443 as equivalent to
         absent port, allowing http://host to match https://host:443 servers.
         """
-        assert not self._csrf_allowed({
-            'Origin': 'http://example.com',     # http, no port = :80
-            'X-Forwarded-Host': 'example.com:443',  # HTTPS port
-        }), 'http origin should NOT match host advertising port 443'
+        assert not self._csrf_allowed(
+            {
+                "Origin": "http://example.com",  # http, no port = :80
+                "X-Forwarded-Host": "example.com:443",  # HTTPS port
+            }
+        ), "http origin should NOT match host advertising port 443"
 
     def test_cross_protocol_port_not_confused_https_origin_http_host(self):
         """https:// origin must NOT match a host with :80 (HTTP default)."""
-        assert not self._csrf_allowed({
-            'Origin': 'https://example.com',    # https, no port = :443
-            'X-Forwarded-Host': 'example.com:80',   # HTTP port
-        }), 'https origin should NOT match host advertising port 80'
+        assert not self._csrf_allowed(
+            {
+                "Origin": "https://example.com",  # https, no port = :443
+                "X-Forwarded-Host": "example.com:80",  # HTTP port
+            }
+        ), "https origin should NOT match host advertising port 80"
 
     def test_http_explicit_port_80_matches_host_without_port(self):
         """http://example.com:80 is the same origin as http://example.com."""
-        assert self._csrf_allowed({
-            'Origin': 'http://example.com:80',
-            'Host': 'example.com',
-        })
+        assert self._csrf_allowed(
+            {
+                "Origin": "http://example.com:80",
+                "Host": "example.com",
+            }
+        )
 
     def test_https_explicit_port_443_matches_host_without_port(self):
         """https://example.com:443 is the same origin as https://example.com."""
-        assert self._csrf_allowed({
-            'Origin': 'https://example.com:443',
-            'Host': 'example.com',
-        })
+        assert self._csrf_allowed(
+            {
+                "Origin": "https://example.com:443",
+                "Host": "example.com",
+            }
+        )
 
     def test_non_default_port_not_waived(self):
         """Non-default ports (e.g. :8000) must not be treated as equivalent to absent."""
-        assert not self._csrf_allowed({
-            'Origin': 'https://example.com:8000',
-            'Host': 'example.com',
-        })
+        assert not self._csrf_allowed(
+            {
+                "Origin": "https://example.com:8000",
+                "Host": "example.com",
+            }
+        )
 
     # ── Bug scenario: proxy strips non-standard port ──────────────────────────
 
-    def test_bug_origin_8000_host_without_port_rejected_without_allowlist(self, monkeypatch):
+    def test_bug_origin_8000_host_without_port_rejected_without_allowlist(
+        self, monkeypatch
+    ):
         """Without the allowlist, origin with :8000 must be rejected when proxy strips port.
 
         This documents the original bug: Origin: https://app.com:8000 with
@@ -201,38 +233,51 @@ class TestCSRF:
         The fix (HERMES_WEBUI_ALLOWED_ORIGINS) handles it; without the env var
         the request is still rejected, which is the safe default.
         """
-        monkeypatch.delenv('HERMES_WEBUI_ALLOWED_ORIGINS', raising=False)
-        assert not self._csrf_allowed({
-            'Origin': 'https://myapp.example.com:8000',
-            'Host': 'myapp.example.com',
-        }), 'without allowlist, port mismatch must be rejected (safe default)'
+        monkeypatch.delenv("HERMES_WEBUI_ALLOWED_ORIGINS", raising=False)
+        assert not self._csrf_allowed(
+            {
+                "Origin": "https://myapp.example.com:8000",
+                "Host": "myapp.example.com",
+            }
+        ), "without allowlist, port mismatch must be rejected (safe default)"
 
     def test_allowed_origins_comma_separated(self, monkeypatch):
         """HERMES_WEBUI_ALLOWED_ORIGINS accepts multiple comma-separated origins."""
         monkeypatch.setenv(
-            'HERMES_WEBUI_ALLOWED_ORIGINS',
-            'https://app1.example.com:8000, https://app2.example.com:9000',
+            "HERMES_WEBUI_ALLOWED_ORIGINS",
+            "https://app1.example.com:8000, https://app2.example.com:9000",
         )
-        assert self._csrf_allowed({'Origin': 'https://app1.example.com:8000', 'Host': 'proxy.internal'})
-        assert self._csrf_allowed({'Origin': 'https://app2.example.com:9000', 'Host': 'proxy.internal'})
-        assert not self._csrf_allowed({'Origin': 'https://evil.com:8000', 'Host': 'proxy.internal'})
+        assert self._csrf_allowed(
+            {"Origin": "https://app1.example.com:8000", "Host": "proxy.internal"}
+        )
+        assert self._csrf_allowed(
+            {"Origin": "https://app2.example.com:9000", "Host": "proxy.internal"}
+        )
+        assert not self._csrf_allowed(
+            {"Origin": "https://evil.com:8000", "Host": "proxy.internal"}
+        )
 
     def test_allowed_origins_without_scheme_ignored(self, monkeypatch, capsys):
         """Allowlist entries missing the scheme are skipped and a warning is printed."""
-        monkeypatch.setenv('HERMES_WEBUI_ALLOWED_ORIGINS', 'myapp.example.com:8000')
+        monkeypatch.setenv("HERMES_WEBUI_ALLOWED_ORIGINS", "myapp.example.com:8000")
         from api.routes import _allowed_public_origins
+
         result = _allowed_public_origins()
-        assert len(result) == 0, 'entry without scheme must be ignored'
+        assert len(result) == 0, "entry without scheme must be ignored"
         captured = capsys.readouterr()
-        assert 'WARNING' in captured.err and 'scheme' in captured.err.lower()
+        assert "WARNING" in captured.err and "scheme" in captured.err.lower()
 
     def test_allowed_origins_trailing_slash_normalized(self, monkeypatch):
         """Trailing slash in allowlist entry is stripped before comparison."""
-        monkeypatch.setenv('HERMES_WEBUI_ALLOWED_ORIGINS', 'https://myapp.example.com:8000/')
-        assert self._csrf_allowed({
-            'Origin': 'https://myapp.example.com:8000',
-            'Host': 'proxy.internal',
-        })
+        monkeypatch.setenv(
+            "HERMES_WEBUI_ALLOWED_ORIGINS", "https://myapp.example.com:8000/"
+        )
+        assert self._csrf_allowed(
+            {
+                "Origin": "https://myapp.example.com:8000",
+                "Host": "proxy.internal",
+            }
+        )
 
 
 # ── CSRF helpers: unit tests ─────────────────────────────────────────────────
@@ -240,73 +285,89 @@ class TestCSRF:
 
 class TestCSRFHelpers:
     """Direct unit tests for _normalize_host_port and _ports_match."""
+
     def test_normalize_host_only(self):
         from api.routes import _normalize_host_port
-        assert _normalize_host_port('example.com') == ('example.com', None)
+
+        assert _normalize_host_port("example.com") == ("example.com", None)
 
     def test_normalize_host_with_port(self):
         from api.routes import _normalize_host_port
-        assert _normalize_host_port('example.com:8000') == ('example.com', '8000')
+
+        assert _normalize_host_port("example.com:8000") == ("example.com", "8000")
 
     def test_normalize_ipv6_no_port(self):
         from api.routes import _normalize_host_port
-        assert _normalize_host_port('[::1]') == ('::1', None)
+
+        assert _normalize_host_port("[::1]") == ("::1", None)
 
     def test_normalize_ipv6_with_port(self):
         from api.routes import _normalize_host_port
-        assert _normalize_host_port('[::1]:8080') == ('::1', '8080')
+
+        assert _normalize_host_port("[::1]:8080") == ("::1", "8080")
 
     def test_normalize_empty(self):
         from api.routes import _normalize_host_port
-        assert _normalize_host_port('') == ('', None)
+
+        assert _normalize_host_port("") == ("", None)
 
     def test_normalize_whitespace_stripped(self):
         from api.routes import _normalize_host_port
-        assert _normalize_host_port('  example.com  ') == ('example.com', None)
+
+        assert _normalize_host_port("  example.com  ") == ("example.com", None)
 
     def test_normalize_lowercases(self):
         from api.routes import _normalize_host_port
-        assert _normalize_host_port('EXAMPLE.COM:80') == ('example.com', '80')
+
+        assert _normalize_host_port("EXAMPLE.COM:80") == ("example.com", "80")
 
     def test_ports_match_identical(self):
         from api.routes import _ports_match
-        assert _ports_match('https', '8000', '8000') is True
+
+        assert _ports_match("https", "8000", "8000") is True
 
     def test_ports_match_both_absent(self):
         from api.routes import _ports_match
-        assert _ports_match('https', None, None) is True
+
+        assert _ports_match("https", None, None) is True
 
     def test_ports_match_https_absent_vs_443(self):
         from api.routes import _ports_match
-        assert _ports_match('https', None, '443') is True
-        assert _ports_match('https', '443', None) is True
+
+        assert _ports_match("https", None, "443") is True
+        assert _ports_match("https", "443", None) is True
 
     def test_ports_match_http_absent_vs_80(self):
         from api.routes import _ports_match
-        assert _ports_match('http', None, '80') is True
-        assert _ports_match('http', '80', None) is True
+
+        assert _ports_match("http", None, "80") is True
+        assert _ports_match("http", "80", None) is True
 
     def test_ports_match_http_absent_vs_443_rejected(self):
         """http:// scheme: absent port is :80, not :443."""
         from api.routes import _ports_match
-        assert _ports_match('http', None, '443') is False
-        assert _ports_match('http', '443', None) is False
+
+        assert _ports_match("http", None, "443") is False
+        assert _ports_match("http", "443", None) is False
 
     def test_ports_match_https_absent_vs_80_rejected(self):
         """https:// scheme: absent port is :443, not :80."""
         from api.routes import _ports_match
-        assert _ports_match('https', None, '80') is False
-        assert _ports_match('https', '80', None) is False
+
+        assert _ports_match("https", None, "80") is False
+        assert _ports_match("https", "80", None) is False
 
     def test_ports_match_non_default_never_waived(self):
         from api.routes import _ports_match
-        assert _ports_match('https', None, '8000') is False
-        assert _ports_match('https', '8000', None) is False
-        assert _ports_match('http', None, '8080') is False
+
+        assert _ports_match("https", None, "8000") is False
+        assert _ports_match("https", "8000", None) is False
+        assert _ports_match("http", None, "8080") is False
 
     def test_ports_match_different_non_default(self):
         from api.routes import _ports_match
-        assert _ports_match('https', '8000', '9000') is False
+
+        assert _ports_match("https", "8000", "9000") is False
 
 
 # ── 2. Login Rate Limiting ─────────────────────────────────────────────────
@@ -315,13 +376,11 @@ class TestCSRFHelpers:
 class TestLoginRateLimit:
     def test_rate_limit_triggers_429(self):
         """More than 5 failed login attempts from same IP must yield 429."""
-        from api.auth import _login_attempts, _LOGIN_WINDOW
 
         # Force the rate limiter state: inject 5 stale-now timestamps so next call is fresh
         # Actually easier: just hit the endpoint 6 times with wrong password
         # But we can't set a password in a test without config file.
         # Instead test the helper directly.
-        import time
         from api import auth as _auth
 
         # Reset state for a fake IP
@@ -331,8 +390,9 @@ class TestLoginRateLimit:
         # Record 5 attempts — should still be allowed
         for _ in range(5):
             _auth._record_login_attempt(fake_ip)
-        assert not _auth._check_login_rate(fake_ip), \
+        assert not _auth._check_login_rate(fake_ip), (
             "After 5 attempts, _check_login_rate should return False (blocked)"
+        )
 
     def test_rate_limit_resets_after_window(self):
         """After window expires, rate limit resets."""
@@ -343,8 +403,9 @@ class TestLoginRateLimit:
         # Inject 5 old timestamps (outside window)
         old_ts = time.time() - 70  # 70s ago, outside 60s window
         _auth._login_attempts[fake_ip] = [old_ts] * 5
-        assert _auth._check_login_rate(fake_ip), \
+        assert _auth._check_login_rate(fake_ip), (
             "After window expires, IP should be allowed again"
+        )
 
     def test_rate_limit_endpoint_returns_429(self, webui_server):
         """Live endpoint: 6th bad attempt returns 429 (auth enabled required)."""
@@ -366,8 +427,10 @@ class TestSessionIDValidation:
     def test_hex_session_id_loads(self, tmp_path):
         """A valid hex session ID gets past the validation check."""
         import sys
+
         sys.path.insert(0, str(pathlib.Path(__file__).parent.parent))
-        from api.models import Session, SESSION_DIR
+        from api.models import Session
+
         valid_hex = "deadbeef" * 8  # 64 hex chars
         # Should not raise — returns None only if file doesn't exist (it won't)
         result = Session.load(valid_hex)
@@ -376,6 +439,7 @@ class TestSessionIDValidation:
     def test_new_format_session_id_passes_validation(self):
         """New hermes-agent session IDs (YYYYMMDD_HHMMSS_xxxxxx) must pass validation."""
         from api.models import Session
+
         # Should pass the validator (returns None only because the file doesn't exist)
         result = Session.load("20260406_164014_74b2d1")
         assert result is None  # file doesn't exist, but validator passed
@@ -383,6 +447,7 @@ class TestSessionIDValidation:
     def test_non_hex_session_id_rejected(self):
         """A session ID with dangerous chars must be rejected."""
         from api.models import Session
+
         evil_ids = [
             "../../../etc/passwd",
             "../../../../root/.ssh/id_rsa",
@@ -396,12 +461,14 @@ class TestSessionIDValidation:
         ]
         for sid in evil_ids:
             result = Session.load(sid)
-            assert result is None, \
+            assert result is None, (
                 f"Session.load should reject dangerous ID '{sid}', got {result}"
+            )
 
     def test_empty_session_id_rejected(self):
         """An empty session ID must be rejected."""
         from api.models import Session
+
         assert Session.load("") is None
         assert Session.load(None) is None
 
@@ -412,6 +479,7 @@ class TestSessionIDValidation:
 class TestSanitizeError:
     def test_unix_path_stripped(self):
         from api.helpers import _sanitize_error
+
         e = FileNotFoundError("/home/hermes/.hermes/sessions/abc123.json")
         result = _sanitize_error(e)
         assert "/home/hermes" not in result
@@ -419,6 +487,7 @@ class TestSanitizeError:
 
     def test_nested_unix_path_stripped(self):
         from api.helpers import _sanitize_error
+
         e = ValueError("cannot read /var/lib/hermes/data.db: permission denied")
         result = _sanitize_error(e)
         assert "/var/lib/hermes" not in result
@@ -426,12 +495,14 @@ class TestSanitizeError:
 
     def test_no_path_unchanged(self):
         from api.helpers import _sanitize_error
+
         e = ValueError("session not found")
         result = _sanitize_error(e)
         assert result == "session not found"
 
     def test_windows_path_stripped(self):
         from api.helpers import _sanitize_error
+
         e = FileNotFoundError("C:\\Users\\hermes\\AppData\\sessions\\x.json not found")
         result = _sanitize_error(e)
         assert "C:\\Users\\hermes" not in result
@@ -440,8 +511,9 @@ class TestSanitizeError:
         """Live server: file-not-found errors must not expose filesystem paths."""
         body, status = post("/api/file/read", {"path": "../../etc/passwd"})
         err = body.get("error", "")
-        assert "/home" not in err and "/var" not in err and "/etc" not in err, \
+        assert "/home" not in err and "/var" not in err and "/etc" not in err, (
             f"Error message leaks filesystem path: {err}"
+        )
 
 
 # ── 5. Secure Cookie Flag ─────────────────────────────────────────────────
@@ -451,12 +523,12 @@ class TestSecureCookieFlag:
     def test_getattr_safe_on_plain_socket(self):
         """getattr(handler.request, 'getpeercert', None) must not raise on plain socket."""
         import socket
+
         # Plain socket has no getpeercert attribute
         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         try:
-            result = getattr(s, 'getpeercert', None)
-            assert result is None, \
-                f"Expected None on plain socket, got {result}"
+            result = getattr(s, "getpeercert", None)
+            assert result is None, f"Expected None on plain socket, got {result}"
         finally:
             s.close()
 
@@ -475,10 +547,12 @@ class TestHMACLength:
     def test_session_token_sig_is_32_chars(self):
         """Session cookie signature must be 32 hex chars (128-bit), not 16."""
         from api.auth import create_session
+
         cookie = create_session()
-        token, sig = cookie.rsplit('.', 1)
-        assert len(sig) == 32, \
+        token, sig = cookie.rsplit(".", 1)
+        assert len(sig) == 32, (
             f"Expected 32-char signature (128-bit), got {len(sig)}: {sig}"
+        )
 
     def test_verify_session_rejects_old_16char_sig(self):
         """A cookie with a 16-char sig must fail verification."""
@@ -490,11 +564,14 @@ class TestHMACLength:
 
         token = secrets.token_hex(32)
         _sessions[token] = time.time() + 3600  # valid session
-        old_sig = _hmac.new(_signing_key(), token.encode(), hashlib.sha256).hexdigest()[:16]
+        old_sig = _hmac.new(_signing_key(), token.encode(), hashlib.sha256).hexdigest()[
+            :16
+        ]
         old_cookie = f"{token}.{old_sig}"
         # Should fail: sig length wrong
-        assert not verify_session(old_cookie), \
+        assert not verify_session(old_cookie), (
             "Old 16-char sig cookie must not verify (sig mismatch)"
+        )
 
 
 # ── 7. Skills Path Traversal ──────────────────────────────────────────────
@@ -503,25 +580,35 @@ class TestHMACLength:
 class TestSkillsPathTraversal:
     def test_traversal_rejected(self, webui_server):
         """Saving a skill with a traversal path must return 400."""
-        body, status = post("/api/skills/save", {
-            "name": "../../evil",
-            "content": "# evil",
-        })
-        assert status in (400, 403), \
+        body, status = post(
+            "/api/skills/save",
+            {
+                "name": "../../evil",
+                "content": "# evil",
+            },
+        )
+        assert status in (400, 403), (
             f"Expected 400/403 for traversal skill path, got {status}: {body}"
+        )
 
     def test_valid_skill_accepted(self, webui_server):
         """Saving a skill with a valid name must succeed."""
-        body, status = post("/api/skills/save", {
-            "name": "test-security-skill",
-            "content": "---\nname: test-security-skill\ndescription: test\n---\n# test",
-        })
+        body, status = post(
+            "/api/skills/save",
+            {
+                "name": "test-security-skill",
+                "content": "---\nname: test-security-skill\ndescription: test\n---\n# test",
+            },
+        )
         # 500 = skills module not available (hermes-agent not installed) — skip
         if status == 500:
-            import pytest; pytest.skip("skills module requires hermes-agent")
+            import pytest
+
+            pytest.skip("skills module requires hermes-agent")
         # Should succeed (200) or need auth (401/403) — not path error (400)
-        assert status in (200, 401, 403, 404), \
+        assert status in (200, 401, 403, 404), (
             f"Valid skill save got unexpected status {status}: {body}"
+        )
         # Clean up the saved skill so it doesn't pollute later tests'
         # SKILLS_DIR enumeration (sprint3 skills tests in particular).
         try:
@@ -536,8 +623,6 @@ class TestSkillsPathTraversal:
 class TestContentDisposition:
     def test_html_file_forced_download(self, webui_server, tmp_path):
         """HTML files served via /api/file/raw must have Content-Disposition: attachment."""
-        import urllib.request
-        import urllib.error
 
         # Use a session to create an HTML file in the workspace
         sessions_body, _ = post("/api/sessions/new", {})
@@ -547,15 +632,14 @@ class TestContentDisposition:
 
         # Can't easily create a file via the test server without a workspace,
         # so test the logic directly instead.
-        from api.routes import _handle_file_raw
-        dangerous_types = {'text/html', 'application/xhtml+xml', 'image/svg+xml'}
+        dangerous_types = {"text/html", "application/xhtml+xml", "image/svg+xml"}
         for mime in dangerous_types:
             assert mime in dangerous_types, f"{mime} should be in dangerous_types set"
 
     def test_dangerous_mime_types_set_complete(self):
         """The set of dangerous MIME types must include html, xhtml, and svg."""
-        import ast
         import pathlib
+
         routes_src = pathlib.Path(__file__).parent.parent / "api" / "routes.py"
         src = routes_src.read_text()
         assert "text/html" in src
@@ -563,7 +647,9 @@ class TestContentDisposition:
         assert "image/svg+xml" in src
         assert "dangerous_types" in src
 
-    def test_unicode_filename_download_header_is_latin1_safe(self, cleanup_test_sessions):
+    def test_unicode_filename_download_header_is_latin1_safe(
+        self, cleanup_test_sessions
+    ):
         """Unicode filenames must not crash download responses."""
         body, status = post("/api/session/new", {})
         assert status == 200, body
@@ -617,16 +703,20 @@ class TestPasswordHashing:
     def test_hash_password_is_hex(self):
         """_hash_password must produce a non-empty hex string (PBKDF2-SHA256)."""
         from api.auth import _hash_password
+
         result = _hash_password("mysecretpassword")
-        assert isinstance(result, str) and len(result) == 64, \
+        assert isinstance(result, str) and len(result) == 64, (
             f"Expected 64-char hex hash (SHA-256 output), got len={len(result)}: {result}"
+        )
         # Hex-only chars
-        assert all(c in "0123456789abcdef" for c in result), \
+        assert all(c in "0123456789abcdef" for c in result), (
             f"Hash must be hex string, got: {result}"
+        )
 
     def test_hash_password_is_deterministic_with_same_salt(self):
         """_hash_password must return the same hash for same input (signing key is stable)."""
         from api.auth import _hash_password
+
         h1 = _hash_password("consistent_password")
         h2 = _hash_password("consistent_password")
         assert h1 == h2, "Same password must produce same hash (stable signing key)"
@@ -634,24 +724,28 @@ class TestPasswordHashing:
     def test_hash_password_different_inputs_differ(self):
         """Different passwords must produce different hashes."""
         from api.auth import _hash_password
-        assert _hash_password("password_a") != _hash_password("password_b"), \
+
+        assert _hash_password("password_a") != _hash_password("password_b"), (
             "Different passwords must produce different hashes"
+        )
 
     def test_hash_password_longer_than_sha256(self):
         """PBKDF2 with 600k iterations is much stronger than single SHA-256.
         We verify indirectly: the code must call pbkdf2_hmac, not sha256 directly."""
         import inspect
         from api import auth as _auth
+
         src = inspect.getsource(_auth._hash_password)
-        assert "pbkdf2_hmac" in src, \
+        assert "pbkdf2_hmac" in src, (
             "_hash_password must use pbkdf2_hmac, not raw sha256"
-        assert "600_000" in src or "600000" in src, \
+        )
+        assert "600_000" in src or "600000" in src, (
             "_hash_password must use 600,000 iterations"
+        )
 
     def test_save_settings_stores_64char_hex_hash(self):
         """save_settings with _set_password must store a 64-char hex hash (PBKDF2)."""
         from api.config import save_settings, load_settings, SETTINGS_FILE
-        import json
 
         # Remember original content so we can restore it
         original = None
@@ -662,8 +756,9 @@ class TestPasswordHashing:
             save_settings({"_set_password": "test_pbkdf2_pw"})
             settings = load_settings()
             ph = settings.get("password_hash", "")
-            assert len(ph) == 64 and all(c in "0123456789abcdef" for c in ph), \
+            assert len(ph) == 64 and all(c in "0123456789abcdef" for c in ph), (
                 f"save_settings must store 64-char hex PBKDF2 hash, got: {ph!r}"
+            )
         finally:
             # Restore original settings
             if original is not None:
@@ -680,10 +775,12 @@ class TestStartupWarning:
         """server.py must contain non-loopback warning code."""
         src = pathlib.Path(__file__).parent.parent / "server.py"
         text = src.read_text()
-        assert "0.0.0.0" in text or "non-loopback" in text.lower() or "WARNING" in text, \
-            "server.py must contain non-loopback warning logic"
-        assert "is_auth_enabled" in text, \
+        assert (
+            "0.0.0.0" in text or "non-loopback" in text.lower() or "WARNING" in text
+        ), "server.py must contain non-loopback warning logic"
+        assert "is_auth_enabled" in text, (
             "server.py must check is_auth_enabled() before warning"
+        )
 
 
 # ── 11. SSRF DNS Check ─────────────────────────────────────────────────────
@@ -715,13 +812,14 @@ class TestENVLock:
         """_ENV_LOCK must be importable from api.streaming."""
         from api.streaming import _ENV_LOCK
         import threading
-        assert isinstance(_ENV_LOCK, type(threading.Lock())), \
+
+        assert isinstance(_ENV_LOCK, type(threading.Lock())), (
             "_ENV_LOCK must be a threading.Lock"
+        )
 
     def test_env_lock_importable_in_routes(self):
         """api.routes must be able to import _ENV_LOCK from api.streaming."""
         # If routes.py fails to import, this will raise ImportError
-        import importlib
         import api.routes  # noqa: F401 -- just checking import works
         # No error means the circular import is OK
 

--- a/tests/test_sprint3.py
+++ b/tests/test_sprint3.py
@@ -1,26 +1,36 @@
 """Sprint 3 tests: cron API, skills API, memory API, input validation."""
-import json, uuid, urllib.request, urllib.error
+
+import json
+import urllib.request
+import urllib.error
 
 from tests._pytest_port import BASE
+
 
 def get(path):
     with urllib.request.urlopen(BASE + path, timeout=10) as r:
         return json.loads(r.read()), r.status
 
+
 def post(path, body=None):
     data = json.dumps(body or {}).encode()
-    req = urllib.request.Request(BASE + path, data=data, headers={"Content-Type": "application/json"})
+    req = urllib.request.Request(
+        BASE + path, data=data, headers={"Content-Type": "application/json"}
+    )
     try:
         with urllib.request.urlopen(req, timeout=10) as r:
             return json.loads(r.read()), r.status
     except urllib.error.HTTPError as e:
         return json.loads(e.read()), e.code
 
+
 def make_session_tracked(created_list, ws=None):
     """Create a session and register it with the cleanup fixture."""
     import pathlib as _pathlib
+
     body = {}
-    if ws: body["workspace"] = str(ws)
+    if ws:
+        body["workspace"] = str(ws)
     d, _ = post("/api/session/new", body)
     sid = d["session"]["session_id"]
     created_list.append(sid)
@@ -32,12 +42,15 @@ def test_crons_list():
     assert status == 200
     assert "jobs" in data
 
+
 def test_crons_list_has_required_fields():
     data, _ = get("/api/crons")
-    if not data["jobs"]: return
+    if not data["jobs"]:
+        return
     job = data["jobs"][0]
     for field in ("id", "name", "prompt", "enabled", "schedule_display"):
         assert field in job
+
 
 def test_crons_output_requires_job_id():
     try:
@@ -46,25 +59,31 @@ def test_crons_output_requires_job_id():
     except urllib.error.HTTPError as e:
         assert e.code == 400
 
+
 def test_crons_output_real_job():
     data, _ = get("/api/crons")
-    if not data["jobs"]: return
+    if not data["jobs"]:
+        return
     job_id = data["jobs"][0]["id"]
     out, status = get(f"/api/crons/output?job_id={job_id}&limit=3")
     assert status == 200
     assert "outputs" in out
 
+
 def test_crons_pause_requires_job_id():
     result, status = post("/api/crons/pause", {})
     assert status in (400, 404)
+
 
 def test_crons_resume_requires_job_id():
     result, status = post("/api/crons/resume", {})
     assert status in (400, 404)
 
+
 def test_crons_run_nonexistent():
     result, status = post("/api/crons/run", {"job_id": "doesnotexist999"})
     assert status == 404
+
 
 def test_skills_list():
     """Verify /api/skills returns built-in skills.
@@ -81,8 +100,12 @@ def test_skills_list():
     skills = data.get("skills", [])
     if not skills:
         import pytest
-        pytest.skip("No skills visible (likely profile-switch pollution from sibling test)")
+
+        pytest.skip(
+            "No skills visible (likely profile-switch pollution from sibling test)"
+        )
     assert len(skills) > 0
+
 
 def test_skills_list_has_required_fields():
     """Verify each skill has the required fields.
@@ -94,9 +117,13 @@ def test_skills_list_has_required_fields():
     skills = data.get("skills", [])
     if not skills:
         import pytest
-        pytest.skip("No skills visible (likely profile-switch pollution from sibling test)")
+
+        pytest.skip(
+            "No skills visible (likely profile-switch pollution from sibling test)"
+        )
     skill = skills[0]
     assert "name" in skill and "description" in skill
+
 
 def test_skills_content_known():
     """Verify a known built-in skill is fetchable from /api/skills/content.
@@ -113,7 +140,10 @@ def test_skills_content_known():
         # at a profile with no skills. Skip rather than fail — root cause is
         # in the polluting test, not the API contract under test here.
         import pytest
-        pytest.skip("No skills visible (likely profile-switch pollution from sibling test)")
+
+        pytest.skip(
+            "No skills visible (likely profile-switch pollution from sibling test)"
+        )
     skill_name = skills[0].get("name")
     data, status = get(f"/api/skills/content?name={skill_name}")
     assert status == 200, f"Failed to fetch known skill {skill_name!r}: {data}"
@@ -125,12 +155,14 @@ def test_skills_content_known():
         # (test concurrency edge). Accept the not-found shape.
         assert "error" in data, f"Unexpected response for skill {skill_name!r}: {data}"
 
+
 def test_skills_content_requires_name():
     try:
         get("/api/skills/content")
         assert False
     except urllib.error.HTTPError as e:
         assert e.code == 400
+
 
 def test_skills_search_returns_subset():
     """Verify /api/skills returns multiple built-in skills.
@@ -146,28 +178,36 @@ def test_skills_search_returns_subset():
     skills = data.get("skills", [])
     if not skills:
         import pytest
-        pytest.skip("No skills visible (likely profile-switch pollution from sibling test)")
+
+        pytest.skip(
+            "No skills visible (likely profile-switch pollution from sibling test)"
+        )
     # Without pollution we expect 5+ built-in skills; under pollution we may see
     # only a handful left. The functional contract is non-empty.
     assert len(skills) > 0, "/api/skills must return at least one skill"
+
 
 def test_memory_returns_both_files():
     data, status = get("/api/memory")
     assert status == 200
     assert "memory" in data and "user" in data
 
+
 def test_memory_content_is_string():
     data, _ = get("/api/memory")
     assert isinstance(data["memory"], str)
     assert isinstance(data["user"], str)
 
+
 def test_memory_has_mtime():
     data, _ = get("/api/memory")
     assert "memory_mtime" in data and "user_mtime" in data
 
+
 def test_session_update_requires_session_id():
     result, status = post("/api/session/update", {"model": "openai/gpt-5.4-mini"})
     assert status == 400
+
 
 def test_session_delete_requires_session_id():
     result, status = post("/api/session/delete", {})
@@ -177,7 +217,9 @@ def test_session_delete_requires_session_id():
 def test_session_delete_rejects_absolute_path_payload(tmp_path):
     victim = tmp_path / "victim.json"
     victim.write_text("TOPSECRET", encoding="utf-8")
-    result, status = post("/api/session/delete", {"session_id": str(victim.with_suffix(""))})
+    result, status = post(
+        "/api/session/delete", {"session_id": str(victim.with_suffix(""))}
+    )
     assert status == 400
     assert victim.exists(), "absolute-path payload must not delete arbitrary files"
 
@@ -195,13 +237,18 @@ def test_chat_start_requires_session_id():
     result, status = post("/api/chat/start", {"message": "hello"})
     assert status == 400
 
+
 def test_chat_start_requires_message(cleanup_test_sessions):
     sid, _ = make_session_tracked(cleanup_test_sessions)
     result, status = post("/api/chat/start", {"session_id": sid, "message": ""})
     assert status == 400
 
+
 def test_session_update_unknown_id_returns_404():
-    result, status = post("/api/session/update", {"session_id": "nosuchsession", "model": "openai/gpt-5.4-mini"})
+    result, status = post(
+        "/api/session/update",
+        {"session_id": "nosuchsession", "model": "openai/gpt-5.4-mini"},
+    )
     assert status == 404
 
 
@@ -210,7 +257,9 @@ def test_session_update_rejects_workspace_outside_trusted_root(tmp_path):
     sid = d["session"]["session_id"]
     outside = tmp_path / "outside"
     outside.mkdir(parents=True, exist_ok=True)
-    result, status = post("/api/session/update", {"session_id": sid, "workspace": str(outside)})
+    result, status = post(
+        "/api/session/update", {"session_id": sid, "workspace": str(outside)}
+    )
     assert status == 400
     assert "outside" in result.get("error", "").lower()
 
@@ -220,7 +269,10 @@ def test_chat_start_rejects_workspace_outside_trusted_root(tmp_path):
     sid = d["session"]["session_id"]
     outside = tmp_path / "outside-chat"
     outside.mkdir(parents=True, exist_ok=True)
-    result, status = post("/api/chat/start", {"session_id": sid, "message": "hello", "workspace": str(outside)})
+    result, status = post(
+        "/api/chat/start",
+        {"session_id": sid, "message": "hello", "workspace": str(outside)},
+    )
     assert status == 400
     assert "outside" in result.get("error", "").lower()
 
@@ -231,7 +283,9 @@ def test_workspace_add_allows_external_valid_paths(tmp_path):
     an existing workspace, not when registering a new one (validate_workspace_to_add)."""
     outside = tmp_path / "outside-add"
     outside.mkdir(parents=True, exist_ok=True)
-    result, status = post("/api/workspaces/add", {"path": str(outside), "name": "Outside"})
+    result, status = post(
+        "/api/workspaces/add", {"path": str(outside), "name": "Outside"}
+    )
     # Explicit registration of an external path is now allowed
     assert status == 200, f"Expected 200, got {status}: {result}"
     # Verify it was actually saved
@@ -253,7 +307,9 @@ def test_legacy_chat_rejects_workspace_outside_trusted_root(tmp_path):
     sid = d["session"]["session_id"]
     outside = tmp_path / "outside-legacy-chat"
     outside.mkdir(parents=True, exist_ok=True)
-    result, status = post("/api/chat", {"session_id": sid, "message": "hello", "workspace": str(outside)})
+    result, status = post(
+        "/api/chat", {"session_id": sid, "message": "hello", "workspace": str(outside)}
+    )
     assert status == 400
     assert "outside" in result.get("error", "").lower()
 
@@ -274,9 +330,11 @@ def test_session_search_returns_matches(cleanup_test_sessions):
     sids = [s["session_id"] for s in data["sessions"]]
     assert sid in sids
 
+
 def test_session_search_empty_query_returns_all():
     data, status = get("/api/sessions/search?q=")
     assert status == 200 and "sessions" in data
+
 
 def test_session_search_no_results():
     data, status = get("/api/sessions/search?q=zzznomatchzzz9999")

--- a/tests/test_sprint30.py
+++ b/tests/test_sprint30.py
@@ -30,8 +30,9 @@ def get(path):
 def post(path, body=None):
     url = BASE + path
     data = json.dumps(body or {}).encode()
-    req = urllib.request.Request(url, data=data,
-          headers={"Content-Type": "application/json"})
+    req = urllib.request.Request(
+        url, data=data, headers={"Content-Type": "application/json"}
+    )
     try:
         with urllib.request.urlopen(req, timeout=10) as r:
             return json.loads(r.read()), r.status
@@ -43,53 +44,68 @@ def read(path):
     with open(path, encoding="utf-8") as f:
         return f.read()
 
+
 REPO = pathlib.Path(__file__).parent.parent
 
 
 # ── HTML structure ───────────────────────────────────────────────────────────
 
-class TestApprovalCardHTML:
 
+class TestApprovalCardHTML:
     def test_approval_card_has_four_buttons(self):
         html = read(REPO / "static/index.html")
         for choice in ("once", "session", "always", "deny"):
-            assert f"respondApproval('{choice}')" in html, \
+            assert f"respondApproval('{choice}')" in html, (
                 f"approval button for '{choice}' missing from index.html"
+            )
 
     def test_approval_buttons_have_ids(self):
         html = read(REPO / "static/index.html")
-        for btn_id in ("approvalBtnOnce", "approvalBtnSession",
-                       "approvalBtnAlways", "approvalBtnDeny"):
-            assert f'id="{btn_id}"' in html, \
+        for btn_id in (
+            "approvalBtnOnce",
+            "approvalBtnSession",
+            "approvalBtnAlways",
+            "approvalBtnDeny",
+        ):
+            assert f'id="{btn_id}"' in html, (
                 f"button id '{btn_id}' missing from approval card"
+            )
 
     def test_approval_heading_has_data_i18n(self):
         html = read(REPO / "static/index.html")
-        assert 'data-i18n="approval_heading"' in html, \
+        assert 'data-i18n="approval_heading"' in html, (
             "approval heading missing data-i18n attribute"
+        )
 
     def test_approval_buttons_have_data_i18n_labels(self):
         html = read(REPO / "static/index.html")
-        for key in ("approval_btn_once", "approval_btn_session",
-                    "approval_btn_always", "approval_btn_deny"):
-            assert f'data-i18n="{key}"' in html, \
+        for key in (
+            "approval_btn_once",
+            "approval_btn_session",
+            "approval_btn_always",
+            "approval_btn_deny",
+        ):
+            assert f'data-i18n="{key}"' in html, (
                 f"button label data-i18n='{key}' missing"
+            )
 
     def test_approval_once_button_has_kbd_badge(self):
         html = read(REPO / "static/index.html")
-        assert '<kbd class="approval-kbd">' in html, \
+        assert '<kbd class="approval-kbd">' in html, (
             "kbd badge missing from Allow once button"
+        )
 
     def test_approval_card_has_aria_roles(self):
         html = read(REPO / "static/index.html")
-        assert 'role="alertdialog"' in html, \
+        assert 'role="alertdialog"' in html, (
             "approval card missing role=alertdialog for accessibility"
-        assert 'aria-labelledby="approvalHeading"' in html, \
+        )
+        assert 'aria-labelledby="approvalHeading"' in html, (
             "approval card missing aria-labelledby"
+        )
 
 
 class TestClarifyCardHTML:
-
     def test_clarify_card_markup_present(self):
         html = read(REPO / "static/index.html")
         assert 'id="clarifyCard"' in html, "clarify card missing from index.html"
@@ -107,53 +123,61 @@ class TestClarifyCardHTML:
 
     def test_clarify_card_has_aria_roles(self):
         html = read(REPO / "static/index.html")
-        assert 'role="dialog"' in html, \
+        assert 'role="dialog"' in html, (
             "clarify card missing role=dialog for accessibility"
-        assert 'aria-labelledby="clarifyHeading"' in html, \
+        )
+        assert 'aria-labelledby="clarifyHeading"' in html, (
             "clarify card missing aria-labelledby"
+        )
 
 
 # ── CSS ──────────────────────────────────────────────────────────────────────
 
-class TestApprovalCardCSS:
 
+class TestApprovalCardCSS:
     def test_btn_disabled_style_present(self):
         css = read(REPO / "static/style.css")
-        assert ".approval-btn:disabled" in css, \
+        assert ".approval-btn:disabled" in css, (
             "disabled state style missing for approval buttons"
+        )
 
     def test_btn_loading_class_present(self):
         css = read(REPO / "static/style.css")
-        assert ".approval-btn.loading" in css, \
+        assert ".approval-btn.loading" in css, (
             "loading class style missing for approval buttons"
+        )
 
     def test_approval_kbd_style_present(self):
         css = read(REPO / "static/style.css")
-        assert ".approval-kbd" in css, \
-            ".approval-kbd style missing from style.css"
+        assert ".approval-kbd" in css, ".approval-kbd style missing from style.css"
 
     def test_approval_kbd_hidden_on_mobile(self):
         css = read(REPO / "static/style.css")
         # Should be display:none inside the mobile media query
-        assert ".approval-kbd{display:none;}" in css or \
-               ".approval-kbd { display: none; }" in css or \
-               re.search(r'\.approval-kbd\s*\{[^}]*display\s*:\s*none', css), \
-            ".approval-kbd should be hidden on mobile"
+        assert (
+            ".approval-kbd{display:none;}" in css
+            or ".approval-kbd { display: none; }" in css
+            or re.search(r"\.approval-kbd\s*\{[^}]*display\s*:\s*none", css)
+        ), ".approval-kbd should be hidden on mobile"
 
     def test_btn_transform_on_hover(self):
         css = read(REPO / "static/style.css")
-        assert "translateY(-1px)" in css, \
+        assert "translateY(-1px)" in css, (
             "hover lift effect missing from approval buttons"
+        )
 
     def test_four_choice_styles_present(self):
         css = read(REPO / "static/style.css")
-        for cls in (".approval-btn.once", ".approval-btn.session",
-                    ".approval-btn.always", ".approval-btn.deny"):
+        for cls in (
+            ".approval-btn.once",
+            ".approval-btn.session",
+            ".approval-btn.always",
+            ".approval-btn.deny",
+        ):
             assert cls in css, f"CSS class '{cls}' missing"
 
 
 class TestClarifyCardCSS:
-
     def test_clarify_styles_present(self):
         css = read(REPO / "static/style.css")
         for cls in (
@@ -173,20 +197,23 @@ class TestClarifyCardCSS:
 
     def test_clarify_mobile_styles_present(self):
         css = read(REPO / "static/style.css")
-        assert ".clarify-card{padding:0 10px 8px;}" in css or \
-               ".clarify-card { padding:0 10px 8px; }" in css or \
-               "clarify-card" in css, "clarify mobile styles missing"
+        assert (
+            ".clarify-card{padding:0 10px 8px;}" in css
+            or ".clarify-card { padding:0 10px 8px; }" in css
+            or "clarify-card" in css
+        ), "clarify mobile styles missing"
 
     def test_clarify_focus_styles_present(self):
         css = read(REPO / "static/style.css")
-        assert ".clarify-choice:focus" in css and ".clarify-submit:focus" in css, \
+        assert ".clarify-choice:focus" in css and ".clarify-submit:focus" in css, (
             "clarify focus styles missing"
+        )
 
 
 # ── i18n keys ────────────────────────────────────────────────────────────────
 
-class TestApprovalI18nKeys:
 
+class TestApprovalI18nKeys:
     REQUIRED_KEYS = [
         "approval_heading",
         "approval_btn_once",
@@ -202,8 +229,7 @@ class TestApprovalI18nKeys:
         en_block_end = src.find("\n};")
         en_block = src[:en_block_end]
         for key in self.REQUIRED_KEYS:
-            assert f"{key}:" in en_block, \
-                f"English locale missing i18n key: {key}"
+            assert f"{key}:" in en_block, f"English locale missing i18n key: {key}"
 
     def test_chinese_locale_has_all_approval_keys(self):
         src = read(REPO / "static/i18n.js")
@@ -212,27 +238,28 @@ class TestApprovalI18nKeys:
         assert zh_start != -1, "zh locale block not found in i18n.js"
         zh_block = src[zh_start:]
         for key in self.REQUIRED_KEYS:
-            assert f"{key}:" in zh_block, \
-                f"Chinese locale missing i18n key: {key}"
+            assert f"{key}:" in zh_block, f"Chinese locale missing i18n key: {key}"
 
     def test_approval_heading_english_value(self):
         src = read(REPO / "static/i18n.js")
-        assert "approval_heading: 'Approval required'" in src, \
+        assert "approval_heading: 'Approval required'" in src, (
             "English approval_heading value incorrect"
+        )
 
     def test_approval_btn_once_english_value(self):
         src = read(REPO / "static/i18n.js")
-        assert "approval_btn_once: 'Allow once'" in src, \
+        assert "approval_btn_once: 'Allow once'" in src, (
             "English approval_btn_once value incorrect"
+        )
 
     def test_approval_btn_deny_english_value(self):
         src = read(REPO / "static/i18n.js")
-        assert "approval_btn_deny: 'Deny'" in src, \
+        assert "approval_btn_deny: 'Deny'" in src, (
             "English approval_btn_deny value incorrect"
+        )
 
 
 class TestClarifyI18nKeys:
-
     REQUIRED_KEYS = [
         "clarify_heading",
         "clarify_hint",
@@ -259,137 +286,162 @@ class TestClarifyI18nKeys:
 
     def test_clarify_heading_english_value(self):
         src = read(REPO / "static/i18n.js")
-        assert "clarify_heading: 'Clarification needed'" in src, \
+        assert "clarify_heading: 'Clarification needed'" in src, (
             "English clarify_heading value incorrect"
+        )
 
 
 # ── messages.js behaviour ────────────────────────────────────────────────────
 
-class TestApprovalMessagesJS:
 
+class TestApprovalMessagesJS:
     def test_show_approval_card_re_enables_buttons(self):
         src = read(REPO / "static/messages.js")
-        assert "b.disabled = false" in src and "loading" in src, \
+        assert "b.disabled = false" in src and "loading" in src, (
             "showApprovalCard should re-enable buttons on each show"
+        )
 
     def test_respond_disables_buttons_immediately(self):
         src = read(REPO / "static/messages.js")
-        assert "b.disabled = true" in src, \
+        assert "b.disabled = true" in src, (
             "respondApproval should disable buttons immediately to prevent double-submit"
+        )
 
     def test_respond_uses_i18n_for_error(self):
         src = read(REPO / "static/messages.js")
         # Should use t('approval_responding') not a hardcoded string
-        assert "t(\"approval_responding\")" in src or "t('approval_responding')" in src, \
+        assert 't("approval_responding")' in src or "t('approval_responding')" in src, (
             "respondApproval error message should use t('approval_responding')"
+        )
 
     def test_show_card_applies_locale_to_dom(self):
         src = read(REPO / "static/messages.js")
-        assert "applyLocaleToDOM" in src, \
+        assert "applyLocaleToDOM" in src, (
             "showApprovalCard should call applyLocaleToDOM to translate data-i18n labels"
+        )
 
     def test_show_card_focuses_once_button(self):
         src = read(REPO / "static/messages.js")
-        assert "approvalBtnOnce" in src and "focus()" in src, \
+        assert "approvalBtnOnce" in src and "focus()" in src, (
             "showApprovalCard should focus the Allow once button"
+        )
 
 
 class TestClarifyMessagesJS:
-
     def test_clarify_event_listener_present(self):
         src = read(REPO / "static/messages.js")
-        assert "addEventListener('clarify'" in src, \
+        assert "addEventListener('clarify'" in src, (
             "clarify SSE listener missing from messages.js"
+        )
 
     def test_show_clarify_card_present(self):
         src = read(REPO / "static/messages.js")
         assert "function showClarifyCard" in src, "showClarifyCard missing"
-        assert "clarifyChoices" in src and "clarifyInput" in src, \
+        assert "clarifyChoices" in src and "clarifyInput" in src, (
             "showClarifyCard should manage clarify DOM elements"
+        )
 
     def test_respond_clarify_uses_api_endpoint(self):
         src = read(REPO / "static/messages.js")
-        assert '/api/clarify/respond' in src, \
+        assert "/api/clarify/respond" in src, (
             "respondClarify should POST to /api/clarify/respond"
+        )
 
     def test_clarify_polling_helpers_present(self):
         src = read(REPO / "static/messages.js")
-        for token in ("startClarifyPolling", "stopClarifyPolling", "hideClarifyCard", "_clarifySessionId"):
+        for token in (
+            "startClarifyPolling",
+            "stopClarifyPolling",
+            "hideClarifyCard",
+            "_clarifySessionId",
+        ):
             assert token in src, f"{token} missing from messages.js"
 
 
 # ── boot.js keyboard shortcut ────────────────────────────────────────────────
 
-class TestApprovalKeyboardShortcut:
 
+class TestApprovalKeyboardShortcut:
     def test_enter_shortcut_present_in_boot_js(self):
         src = read(REPO / "static/boot.js")
-        assert "respondApproval('once')" in src or 'respondApproval("once")' in src, \
+        assert "respondApproval('once')" in src or 'respondApproval("once")' in src, (
             "Enter shortcut calling respondApproval('once') missing from boot.js"
+        )
 
     def test_enter_shortcut_checks_card_visible(self):
         src = read(REPO / "static/boot.js")
-        assert "approvalCard" in src and "visible" in src, \
+        assert "approvalCard" in src and "visible" in src, (
             "Enter shortcut should check if approval card is visible"
+        )
 
     def test_enter_shortcut_guards_input_elements(self):
         src = read(REPO / "static/boot.js")
-        assert "TEXTAREA" in src and "INPUT" in src, \
+        assert "TEXTAREA" in src and "INPUT" in src, (
             "Enter shortcut should not fire when focus is on TEXTAREA or INPUT"
+        )
 
 
 # ── streaming.py scoping fix ─────────────────────────────────────────────────
 
-class TestStreamingApprovalScoping:
 
+class TestStreamingApprovalScoping:
     def test_unreg_notify_initialised_to_none(self):
         src = read(REPO / "api/streaming.py")
-        assert "_unreg_notify = None" in src, \
+        assert "_unreg_notify = None" in src, (
             "_unreg_notify must be initialised to None before the try block"
+        )
 
     def test_finally_checks_unreg_notify_not_none(self):
         src = read(REPO / "api/streaming.py")
-        assert "_unreg_notify is not None" in src, \
+        assert "_unreg_notify is not None" in src, (
             "finally block must check '_unreg_notify is not None' before calling it"
+        )
 
     def test_approval_registered_flag_present(self):
         src = read(REPO / "api/streaming.py")
-        assert "_approval_registered = False" in src, \
+        assert "_approval_registered = False" in src, (
             "_approval_registered flag must be initialised to False"
+        )
 
     def test_clarify_registered_flag_present(self):
         src = read(REPO / "api/streaming.py")
-        assert "_clarify_registered = False" in src, \
+        assert "_clarify_registered = False" in src, (
             "_clarify_registered flag must be initialised to False"
+        )
 
     def test_clarify_unreg_notify_initialised_to_none(self):
         src = read(REPO / "api/streaming.py")
-        assert "_unreg_clarify_notify = None" in src, \
+        assert "_unreg_clarify_notify = None" in src, (
             "_unreg_clarify_notify must be initialised to None before the try block"
+        )
 
     def test_finally_checks_clarify_unreg_notify_not_none(self):
         src = read(REPO / "api/streaming.py")
-        assert "_unreg_clarify_notify is not None" in src, \
+        assert "_unreg_clarify_notify is not None" in src, (
             "finally block must check '_unreg_clarify_notify is not None' before calling it"
+        )
 
 
 # ── HTTP regression: approval respond ────────────────────────────────────────
 
-class TestApprovalRespondHTTP:
 
+class TestApprovalRespondHTTP:
     def test_respond_ok_with_all_choices(self):
         for choice in ("once", "session", "always", "deny"):
             import uuid
+
             sid = f"sprint30-{uuid.uuid4().hex[:8]}"
-            result, status = post("/api/approval/respond",
-                                  {"session_id": sid, "choice": choice})
+            result, status = post(
+                "/api/approval/respond", {"session_id": sid, "choice": choice}
+            )
             assert status == 200, f"choice={choice} should return 200"
             assert result["ok"] is True
             assert result["choice"] == choice
 
     def test_respond_rejects_bad_choice(self):
-        result, status = post("/api/approval/respond",
-                              {"session_id": "x", "choice": "HACKED"})
+        result, status = post(
+            "/api/approval/respond", {"session_id": "x", "choice": "HACKED"}
+        )
         assert status == 400
 
     def test_respond_requires_session_id(self):
@@ -398,9 +450,11 @@ class TestApprovalRespondHTTP:
 
     def test_respond_returns_choice_field(self):
         import uuid
+
         sid = f"sprint30-choice-{uuid.uuid4().hex[:8]}"
-        result, status = post("/api/approval/respond",
-                              {"session_id": sid, "choice": "always"})
+        result, status = post(
+            "/api/approval/respond", {"session_id": sid, "choice": "always"}
+        )
         assert status == 200
         assert "choice" in result
         assert result["choice"] == "always"
@@ -410,76 +464,88 @@ class TestApprovalCardTimerLogic:
     """Tests for the 30s minimum visibility guard introduced in PR #225."""
 
     def _get_js(self):
-        return pathlib.Path(__file__).parent.parent / 'static' / 'messages.js'
+        return pathlib.Path(__file__).parent.parent / "static" / "messages.js"
 
     def test_approval_min_visible_ms_constant_present(self):
         """APPROVAL_MIN_VISIBLE_MS constant exists and is 30000."""
         src = self._get_js().read_text()
-        assert 'APPROVAL_MIN_VISIBLE_MS' in src
+        assert "APPROVAL_MIN_VISIBLE_MS" in src
         import re
-        m = re.search(r'APPROVAL_MIN_VISIBLE_MS\s*=\s*(\d+)', src)
-        assert m is not None, 'APPROVAL_MIN_VISIBLE_MS not assigned'
-        assert int(m.group(1)) == 30000, f'Expected 30000, got {m.group(1)}'
+
+        m = re.search(r"APPROVAL_MIN_VISIBLE_MS\s*=\s*(\d+)", src)
+        assert m is not None, "APPROVAL_MIN_VISIBLE_MS not assigned"
+        assert int(m.group(1)) == 30000, f"Expected 30000, got {m.group(1)}"
 
     def test_hide_approval_card_has_force_parameter(self):
         """hideApprovalCard() accepts a force parameter."""
         src = self._get_js().read_text()
-        assert 'hideApprovalCard(force=false)' in src or \
-               'hideApprovalCard(force = false)' in src, \
-            'hideApprovalCard must have force=false default parameter'
+        assert (
+            "hideApprovalCard(force=false)" in src
+            or "hideApprovalCard(force = false)" in src
+        ), "hideApprovalCard must have force=false default parameter"
 
     def test_hide_approval_card_checks_force_flag(self):
         """hideApprovalCard body has a conditional on force."""
         src = self._get_js().read_text()
         # The guard: if (!force && _approvalVisibleSince)
-        assert '!force' in src, 'hideApprovalCard must check !force before deferred hide'
+        assert "!force" in src, (
+            "hideApprovalCard must check !force before deferred hide"
+        )
 
     def test_approval_hide_timer_variable_present(self):
         """Module-level _approvalHideTimer variable is declared."""
         src = self._get_js().read_text()
-        assert '_approvalHideTimer' in src
+        assert "_approvalHideTimer" in src
 
     def test_approval_visible_since_variable_present(self):
         """Module-level _approvalVisibleSince variable is declared."""
         src = self._get_js().read_text()
-        assert '_approvalVisibleSince' in src
+        assert "_approvalVisibleSince" in src
 
     def test_approval_signature_variable_present(self):
         """Module-level _approvalSignature variable is declared."""
         src = self._get_js().read_text()
-        assert '_approvalSignature' in src
+        assert "_approvalSignature" in src
 
     def test_respond_approval_calls_hide_with_force(self):
         """respondApproval must call hideApprovalCard(true) — not no-arg."""
         src = self._get_js().read_text()
         # Extract respondApproval function body
         import re
-        m = re.search(r'async function respondApproval.*?(?=\nasync function|\nfunction |\Z)',
-                      src, re.DOTALL)
-        assert m, 'respondApproval function not found'
+
+        m = re.search(
+            r"async function respondApproval.*?(?=\nasync function|\nfunction |\Z)",
+            src,
+            re.DOTALL,
+        )
+        assert m, "respondApproval function not found"
         body = m.group(0)
         # Must call hideApprovalCard(true), not the bare hideApprovalCard()
-        assert 'hideApprovalCard(true)' in body, \
-            'respondApproval must call hideApprovalCard(true) so card hides immediately after user clicks'
+        assert "hideApprovalCard(true)" in body, (
+            "respondApproval must call hideApprovalCard(true) so card hides immediately after user clicks"
+        )
         # Must NOT have bare hideApprovalCard() without force
-        bare_calls = re.findall(r'hideApprovalCard\((?!true)', body)
-        assert not bare_calls, \
-            f'respondApproval has bare hideApprovalCard() calls (no force=true): {bare_calls}'
+        bare_calls = re.findall(r"hideApprovalCard\((?!true)", body)
+        assert not bare_calls, (
+            f"respondApproval has bare hideApprovalCard() calls (no force=true): {bare_calls}"
+        )
 
     def test_stream_done_calls_hide_with_force(self):
         """Done SSE event handler must call hideApprovalCard(true)."""
         src = self._get_js().read_text()
         # Find the done event handler section (stopApprovalPolling followed by hideApprovalCard)
         import re
+
         # Look for pattern: stopApprovalPolling();\n + hideApprovalCard
         matches = re.findall(
-            r'stopApprovalPolling\(\);\s*\n\s*if\(!_approvalSessionId[^)]*\)\s*hideApprovalCard\((\w*)\)',
-            src
+            r"stopApprovalPolling\(\);\s*\n\s*if\(!_approvalSessionId[^)]*\)\s*hideApprovalCard\((\w*)\)",
+            src,
         )
         # All stopApprovalPolling paths that call hideApprovalCard should use force=true
         for match in matches:
-            assert match == 'true', \
-                f'After stopApprovalPolling(), hideApprovalCard called without force=true (got: {match!r})'
+            assert match == "true", (
+                f"After stopApprovalPolling(), hideApprovalCard called without force=true (got: {match!r})"
+            )
 
     def test_poll_loop_still_uses_no_force(self):
         """Poll loop approval hides (when pending gone) keep no-force behavior."""
@@ -487,161 +553,207 @@ class TestApprovalCardTimerLogic:
         # Poll/SSE empty-state hides should preserve the 30s visibility guard.
         # Owner-scoped prompt cleanup now routes this through the helper, whose
         # default force=false is behavior-equivalent to the old hideApprovalCard().
-        assert '_hideApprovalCardIfOwner(sid);' in src or \
-               'else { hideApprovalCard(); }' in src or \
-               'else {hideApprovalCard();}' in src or \
-               'else { hideApprovalCard() }' in src, \
-            'Poll loop should still hide approval prompts without force=true'
+        assert (
+            "_hideApprovalCardIfOwner(sid);" in src
+            or "else { hideApprovalCard(); }" in src
+            or "else {hideApprovalCard();}" in src
+            or "else { hideApprovalCard() }" in src
+        ), "Poll loop should still hide approval prompts without force=true"
 
     def test_show_approval_card_signature_dedup(self):
         """showApprovalCard uses a signature to avoid resetting timer on repeat polls."""
         src = self._get_js().read_text()
         # The sig computation must use JSON.stringify on card content
         import re
-        m = re.search(r'function showApprovalCard.*?(?=\nfunction |\nasync function |\Z)',
-                      src, re.DOTALL)
-        assert m, 'showApprovalCard function not found'
+
+        m = re.search(
+            r"function showApprovalCard.*?(?=\nfunction |\nasync function |\Z)",
+            src,
+            re.DOTALL,
+        )
+        assert m, "showApprovalCard function not found"
         body = m.group(0)
-        assert 'JSON.stringify' in body, 'showApprovalCard must compute a signature via JSON.stringify'
-        assert '_approvalSignature' in body, 'showApprovalCard must check/set _approvalSignature'
+        assert "JSON.stringify" in body, (
+            "showApprovalCard must compute a signature via JSON.stringify"
+        )
+        assert "_approvalSignature" in body, (
+            "showApprovalCard must check/set _approvalSignature"
+        )
 
     def test_clear_approval_hide_timer_helper_present(self):
         """_clearApprovalHideTimer helper exists to cancel deferred hides."""
         src = self._get_js().read_text()
-        assert '_clearApprovalHideTimer' in src, \
-            '_clearApprovalHideTimer helper must exist to cancel deferred setTimeout'
+        assert "_clearApprovalHideTimer" in src, (
+            "_clearApprovalHideTimer helper must exist to cancel deferred setTimeout"
+        )
 
 
 class TestClarifyCardTimerLogic:
-
     def _get_js(self):
-        return pathlib.Path(__file__).parent.parent / 'static' / 'messages.js'
+        return pathlib.Path(__file__).parent.parent / "static" / "messages.js"
 
     def _get_html(self):
-        return pathlib.Path(__file__).parent.parent / 'static' / 'index.html'
+        return pathlib.Path(__file__).parent.parent / "static" / "index.html"
 
     def _get_css(self):
-        return pathlib.Path(__file__).parent.parent / 'static' / 'style.css'
+        return pathlib.Path(__file__).parent.parent / "static" / "style.css"
 
     def test_clarify_min_visible_ms_constant_present(self):
         src = self._get_js().read_text()
-        assert 'CLARIFY_MIN_VISIBLE_MS' in src
+        assert "CLARIFY_MIN_VISIBLE_MS" in src
         import re
-        m = re.search(r'CLARIFY_MIN_VISIBLE_MS\s*=\s*(\d+)', src)
-        assert m is not None, 'CLARIFY_MIN_VISIBLE_MS not assigned'
-        assert int(m.group(1)) == 30000, f'Expected 30000, got {m.group(1)}'
+
+        m = re.search(r"CLARIFY_MIN_VISIBLE_MS\s*=\s*(\d+)", src)
+        assert m is not None, "CLARIFY_MIN_VISIBLE_MS not assigned"
+        assert int(m.group(1)) == 30000, f"Expected 30000, got {m.group(1)}"
 
     def test_hide_clarify_card_has_force_parameter(self):
         src = self._get_js().read_text()
-        assert 'hideClarifyCard(force=false)' in src or \
-               'hideClarifyCard(force=false, reason=' in src or \
-               'hideClarifyCard(force = false)' in src, \
-            'hideClarifyCard must have force=false default parameter'
+        assert (
+            "hideClarifyCard(force=false)" in src
+            or "hideClarifyCard(force=false, reason=" in src
+            or "hideClarifyCard(force = false)" in src
+        ), "hideClarifyCard must have force=false default parameter"
 
     def test_hide_clarify_card_checks_force_flag(self):
         src = self._get_js().read_text()
-        assert '!force' in src, 'hideClarifyCard must check !force before deferred hide'
+        assert "!force" in src, "hideClarifyCard must check !force before deferred hide"
 
     def test_clarify_hide_timer_variable_present(self):
         src = self._get_js().read_text()
-        assert '_clarifyHideTimer' in src
+        assert "_clarifyHideTimer" in src
 
     def test_clarify_visible_since_variable_present(self):
         src = self._get_js().read_text()
-        assert '_clarifyVisibleSince' in src
+        assert "_clarifyVisibleSince" in src
 
     def test_clarify_signature_variable_present(self):
         src = self._get_js().read_text()
-        assert '_clarifySignature' in src
+        assert "_clarifySignature" in src
 
     def test_clarify_countdown_element_present(self):
         html = self._get_html().read_text()
-        assert 'id="clarifyCountdown"' in html, \
-            'clarify card must include a countdown element so users see timeout risk'
+        assert 'id="clarifyCountdown"' in html, (
+            "clarify card must include a countdown element so users see timeout risk"
+        )
 
     def test_clarify_countdown_uses_pending_expiry(self):
         src = self._get_js().read_text()
-        assert '_clarifyCountdownTimer' in src
-        assert 'function _startClarifyCountdown' in src
-        assert 'expires_at' in src, \
-            'clarify countdown must use expires_at from the pending payload'
+        assert "_clarifyCountdownTimer" in src
+        assert "function _startClarifyCountdown" in src
+        assert "expires_at" in src, (
+            "clarify countdown must use expires_at from the pending payload"
+        )
 
     def test_clarify_countdown_does_not_restart_for_same_expiry(self):
         src = self._get_js().read_text()
-        m = re.search(r'function _startClarifyCountdown.*?(?=\nfunction |\nasync function |\Z)',
-                      src, re.DOTALL)
-        assert m, '_startClarifyCountdown function not found'
+        m = re.search(
+            r"function _startClarifyCountdown.*?(?=\nfunction |\nasync function |\Z)",
+            src,
+            re.DOTALL,
+        )
+        assert m, "_startClarifyCountdown function not found"
         body = m.group(0)
-        assert 'const expiresAt = _clarifyExpiryMs(pending)' in body, \
-            'countdown start should compute the next expiry before clearing the existing timer'
-        assert '_clarifyCountdownTimer && _clarifyExpiresAt === expiresAt' in body, \
-            'same pending clarify poll updates must not restart the countdown interval'
-        assert body.index('_clarifyCountdownTimer && _clarifyExpiresAt === expiresAt') < \
-               body.index('_clearClarifyCountdownTimer()'), \
-            'same-expiry guard must run before clearing the current interval'
+        assert "const expiresAt = _clarifyExpiryMs(pending)" in body, (
+            "countdown start should compute the next expiry before clearing the existing timer"
+        )
+        assert "_clarifyCountdownTimer && _clarifyExpiresAt === expiresAt" in body, (
+            "same pending clarify poll updates must not restart the countdown interval"
+        )
+        assert body.index(
+            "_clarifyCountdownTimer && _clarifyExpiresAt === expiresAt"
+        ) < body.index("_clearClarifyCountdownTimer()"), (
+            "same-expiry guard must run before clearing the current interval"
+        )
 
     def test_hide_clarify_card_can_preserve_draft(self):
         src = self._get_js().read_text()
-        assert 'function _stashClarifyDraft' in src
-        assert 'sessionStorage.setItem' in src
-        assert "$('msg')" in src, \
-            'clarify timeout should keep the typed draft visible in the composer'
+        assert "function _stashClarifyDraft" in src
+        assert "sessionStorage.setItem" in src
+        assert "$('msg')" in src, (
+            "clarify timeout should keep the typed draft visible in the composer"
+        )
 
     def test_clarify_draft_appends_to_existing_composer_text(self):
         src = self._get_js().read_text()
-        m = re.search(r'function _stashClarifyDraft.*?(?=\nfunction |\nasync function |\Z)',
-                      src, re.DOTALL)
-        assert m, '_stashClarifyDraft function not found'
+        m = re.search(
+            r"function _stashClarifyDraft.*?(?=\nfunction |\nasync function |\Z)",
+            src,
+            re.DOTALL,
+        )
+        assert m, "_stashClarifyDraft function not found"
         body = m.group(0)
-        assert 'current.replace(/\\s+$/, "")' in body, \
-            'preserved clarify drafts must append after existing composer text instead of replacing it'
-        assert '\\n\\n${draft}' in body, \
-            'preserved clarify drafts should be separated from existing composer text'
+        assert 'current.replace(/\\s+$/, "")' in body, (
+            "preserved clarify drafts must append after existing composer text instead of replacing it"
+        )
+        assert "\\n\\n${draft}" in body, (
+            "preserved clarify drafts should be separated from existing composer text"
+        )
 
     def test_cancel_stream_does_not_preserve_clarify_draft(self):
         src = self._get_js().read_text()
-        m = re.search(r"source\.addEventListener\('cancel'.*?\n    \}\);",
-                      src, re.DOTALL)
-        assert m, 'cancel event handler not found'
+        m = re.search(
+            r"source\.addEventListener\('cancel'.*?\n    \}\);", src, re.DOTALL
+        )
+        assert m, "cancel event handler not found"
         body = m.group(0)
         assert (
             "hideClarifyCard(true, 'cancelled')" in body
             or "_clearClarifyForOwner('cancelled')" in body
-        ), 'explicit stream cancel must not use the timeout/terminal draft preservation path'
+        ), (
+            "explicit stream cancel must not use the timeout/terminal draft preservation path"
+        )
 
     def test_clarify_urgent_countdown_has_non_color_cue(self):
         css = self._get_css().read_text()
-        m = re.search(r'\.clarify-countdown\.urgent\{([^}]*)\}', css)
-        assert m, 'urgent clarify countdown style missing'
+        m = re.search(r"\.clarify-countdown\.urgent\{([^}]*)\}", css)
+        assert m, "urgent clarify countdown style missing"
         body = m.group(1)
-        assert any(prop in body for prop in ('box-shadow', 'outline', 'border', 'text-decoration')), \
-            'urgent countdown styling must include a non-color visual cue'
+        assert any(
+            prop in body
+            for prop in ("box-shadow", "outline", "border", "text-decoration")
+        ), "urgent countdown styling must include a non-color visual cue"
 
     def test_respond_clarify_calls_hide_with_force(self):
         src = self._get_js().read_text()
         import re
-        m = re.search(r'async function respondClarify.*?(?=\nasync function|\nfunction |\Z)',
-                      src, re.DOTALL)
-        assert m, 'respondClarify function not found'
+
+        m = re.search(
+            r"async function respondClarify.*?(?=\nasync function|\nfunction |\Z)",
+            src,
+            re.DOTALL,
+        )
+        assert m, "respondClarify function not found"
         body = m.group(0)
-        assert 'hideClarifyCard(true' in body, \
-            'respondClarify must call hideClarifyCard(true) so card hides immediately after user clicks'
-        assert "'sent'" in body, \
-            'respondClarify must mark user-submitted hides so drafts are not re-stashed'
+        assert "hideClarifyCard(true" in body, (
+            "respondClarify must call hideClarifyCard(true) so card hides immediately after user clicks"
+        )
+        assert "'sent'" in body, (
+            "respondClarify must mark user-submitted hides so drafts are not re-stashed"
+        )
 
     def test_clarify_poll_loop_uses_no_force(self):
         src = self._get_js().read_text()
-        assert "_hideClarifyCardIfOwner(sid, false, 'expired');" in src or \
-               "else { hideClarifyCard(false, 'expired'); }" in src or \
-               "else {hideClarifyCard(false,'expired');}" in src, \
-            'Clarify poll loop should hide without force=true'
+        assert (
+            "_hideClarifyCardIfOwner(sid, false, 'expired');" in src
+            or "else { hideClarifyCard(false, 'expired'); }" in src
+            or "else {hideClarifyCard(false,'expired');}" in src
+        ), "Clarify poll loop should hide without force=true"
 
     def test_show_clarify_card_signature_dedup(self):
         src = self._get_js().read_text()
         import re
-        m = re.search(r'function showClarifyCard.*?(?=\nfunction |\nasync function |\Z)',
-                      src, re.DOTALL)
-        assert m, 'showClarifyCard function not found'
+
+        m = re.search(
+            r"function showClarifyCard.*?(?=\nfunction |\nasync function |\Z)",
+            src,
+            re.DOTALL,
+        )
+        assert m, "showClarifyCard function not found"
         body = m.group(0)
-        assert 'JSON.stringify' in body, 'showClarifyCard must compute a signature via JSON.stringify'
-        assert '_clarifySignature' in body, 'showClarifyCard must check/set _clarifySignature'
+        assert "JSON.stringify" in body, (
+            "showClarifyCard must compute a signature via JSON.stringify"
+        )
+        assert "_clarifySignature" in body, (
+            "showClarifyCard must check/set _clarifySignature"
+        )

--- a/tests/test_sprint31.py
+++ b/tests/test_sprint31.py
@@ -10,6 +10,7 @@ Tests cover:
   6. API route accepts base_url and api_key in POST body
   7. Profile created via API has base_url in config.yaml
 """
+
 import json
 import pathlib
 import shutil
@@ -21,31 +22,41 @@ yaml = pytest.importorskip("yaml", reason="PyYAML required for config write test
 
 # ── 1-5: _write_endpoint_to_config unit tests ─────────────────────────────────
 
+
 class TestWriteEndpointToConfig:
     def test_writes_base_url(self, tmp_path):
         from api.profiles import _write_endpoint_to_config
+
         _write_endpoint_to_config(tmp_path, base_url="http://localhost:11434")
         cfg = yaml.safe_load((tmp_path / "config.yaml").read_text())
         assert cfg["model"]["base_url"] == "http://localhost:11434"
 
     def test_writes_api_key(self, tmp_path):
         from api.profiles import _write_endpoint_to_config
+
         _write_endpoint_to_config(tmp_path, api_key="sk-local-test")
         cfg = yaml.safe_load((tmp_path / "config.yaml").read_text())
         assert cfg["model"]["api_key"] == "sk-local-test"
 
     def test_writes_both(self, tmp_path):
         from api.profiles import _write_endpoint_to_config
-        _write_endpoint_to_config(tmp_path, base_url="http://localhost:8080", api_key="mykey")
+
+        _write_endpoint_to_config(
+            tmp_path, base_url="http://localhost:8080", api_key="mykey"
+        )
         cfg = yaml.safe_load((tmp_path / "config.yaml").read_text())
         assert cfg["model"]["base_url"] == "http://localhost:8080"
         assert cfg["model"]["api_key"] == "mykey"
 
     def test_merges_with_existing_config(self, tmp_path):
         """Does not clobber other top-level config keys."""
-        existing = {"model": {"default": "gpt-4o", "provider": "openai"}, "agent": {"max_turns": 90}}
+        existing = {
+            "model": {"default": "gpt-4o", "provider": "openai"},
+            "agent": {"max_turns": 90},
+        }
         (tmp_path / "config.yaml").write_text(yaml.dump(existing))
         from api.profiles import _write_endpoint_to_config
+
         _write_endpoint_to_config(tmp_path, base_url="http://localhost:1234")
         cfg = yaml.safe_load((tmp_path / "config.yaml").read_text())
         # Existing keys preserved
@@ -57,11 +68,13 @@ class TestWriteEndpointToConfig:
 
     def test_noop_when_both_none(self, tmp_path):
         from api.profiles import _write_endpoint_to_config
+
         _write_endpoint_to_config(tmp_path, base_url=None, api_key=None)
         assert not (tmp_path / "config.yaml").exists()
 
     def test_noop_when_both_empty_strings(self, tmp_path):
         from api.profiles import _write_endpoint_to_config
+
         _write_endpoint_to_config(tmp_path, base_url="", api_key="")
         assert not (tmp_path / "config.yaml").exists()
 
@@ -73,6 +86,7 @@ from tests._pytest_port import BASE as _TEST_BASE
 
 def _post(path, body=None):
     import urllib.request
+
     data = json.dumps(body or {}).encode()
     req = urllib.request.Request(
         _TEST_BASE + path, data=data, headers={"Content-Type": "application/json"}
@@ -87,7 +101,9 @@ def _post(path, body=None):
             return {}, e.code
 
 
-@pytest.mark.xfail(reason="Pre-existing isolation issue: test_server fixture conflict (#sprint31)")
+@pytest.mark.xfail(
+    reason="Pre-existing isolation issue: test_server fixture conflict (#sprint31)"
+)
 class TestProfileCreateAPIWithEndpoint:
     _PROFILE_NAME = "test-ep-sprint31"
 
@@ -115,10 +131,13 @@ class TestProfileCreateAPIWithEndpoint:
 
     def test_api_route_accepts_base_url(self, test_server):
         """POST /api/profile/create with base_url returns ok:True."""
-        data, err = _post("/api/profile/create", {
-            "name": self._PROFILE_NAME,
-            "base_url": "http://localhost:11434",
-        })
+        data, err = _post(
+            "/api/profile/create",
+            {
+                "name": self._PROFILE_NAME,
+                "base_url": "http://localhost:11434",
+            },
+        )
         assert err is None, f"Expected 200, got {err}: {data}"
         assert data.get("ok") is True
 
@@ -127,18 +146,26 @@ class TestProfileCreateAPIWithEndpoint:
 
         The actual config.yaml write is covered by the unit tests above.
         """
-        data, err = _post("/api/profile/create", {
-            "name": self._PROFILE_NAME,
-            "base_url": "http://localhost:9999",
-        })
+        data, err = _post(
+            "/api/profile/create",
+            {
+                "name": self._PROFILE_NAME,
+                "base_url": "http://localhost:9999",
+            },
+        )
         assert err is None, f"Expected 200, got {err}: {data}"
         assert data.get("ok") is True
-        assert data.get("profile", {}).get("path"), f"API response missing profile.path: {data}"
+        assert data.get("profile", {}).get("path"), (
+            f"API response missing profile.path: {data}"
+        )
 
     def test_api_route_rejects_invalid_base_url(self, test_server):
         """POST /api/profile/create with a non-http base_url returns 400."""
-        data, err = _post("/api/profile/create", {
-            "name": self._PROFILE_NAME,
-            "base_url": "ftp://localhost:11434",
-        })
+        data, err = _post(
+            "/api/profile/create",
+            {
+                "name": self._PROFILE_NAME,
+                "base_url": "ftp://localhost:11434",
+            },
+        )
         assert err == 400, f"Expected 400, got {err}: {data}"

--- a/tests/test_sprint32.py
+++ b/tests/test_sprint32.py
@@ -1,8 +1,7 @@
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 import subprocess
 import os
-from api.startup import auto_install_agent_deps, _trusted_agent_dir
+from api.startup import auto_install_agent_deps
 
 
 class TestAutoInstallAgentDeps:
@@ -17,102 +16,124 @@ class TestAutoInstallAgentDeps:
 
     def test_disabled_by_default(self, tmp_path, capsys):
         """Auto-install must be off unless HERMES_WEBUI_AUTO_INSTALL=1 is set."""
-        agent_dir = tmp_path / 'hermes-agent'
+        agent_dir = tmp_path / "hermes-agent"
         agent_dir.mkdir()
-        (agent_dir / 'requirements.txt').write_text('somepkg\n')
-        env = {'HERMES_WEBUI_AGENT_DIR': str(agent_dir)}
-        with patch.dict('os.environ', env, clear=False):
-            os.environ.pop('HERMES_WEBUI_AUTO_INSTALL', None)
-            with patch('subprocess.run') as mock_run:
+        (agent_dir / "requirements.txt").write_text("somepkg\n")
+        env = {"HERMES_WEBUI_AGENT_DIR": str(agent_dir)}
+        with patch.dict("os.environ", env, clear=False):
+            os.environ.pop("HERMES_WEBUI_AUTO_INSTALL", None)
+            with patch("subprocess.run") as mock_run:
                 assert auto_install_agent_deps() is False
                 assert not mock_run.called
-        assert 'disabled' in capsys.readouterr().out.lower()
+        assert "disabled" in capsys.readouterr().out.lower()
 
     def test_installs_from_requirements_txt(self, tmp_path):
-        agent_dir = tmp_path / 'hermes-agent'
+        agent_dir = tmp_path / "hermes-agent"
         agent_dir.mkdir()
-        req = agent_dir / 'requirements.txt'
-        req.write_text('pyyaml\n')
-        env = {'HERMES_WEBUI_AGENT_DIR': str(agent_dir), 'HERMES_WEBUI_AUTO_INSTALL': '1'}
-        with patch.dict('os.environ', env, clear=False):
-            with patch('api.startup._trusted_agent_dir', return_value=True):
-                with patch('subprocess.run') as mock_run:
-                    mock_run.return_value = MagicMock(returncode=0, stderr='')
+        req = agent_dir / "requirements.txt"
+        req.write_text("pyyaml\n")
+        env = {
+            "HERMES_WEBUI_AGENT_DIR": str(agent_dir),
+            "HERMES_WEBUI_AUTO_INSTALL": "1",
+        }
+        with patch.dict("os.environ", env, clear=False):
+            with patch("api.startup._trusted_agent_dir", return_value=True):
+                with patch("subprocess.run") as mock_run:
+                    mock_run.return_value = MagicMock(returncode=0, stderr="")
                     assert auto_install_agent_deps() is True
                     args = mock_run.call_args[0][0]
-                    assert '-r' in args and str(req) in args
+                    assert "-r" in args and str(req) in args
 
     def test_falls_back_to_pyproject(self, tmp_path):
-        agent_dir = tmp_path / 'hermes-agent'
+        agent_dir = tmp_path / "hermes-agent"
         agent_dir.mkdir()
-        (agent_dir / 'pyproject.toml').write_text('[project]\nname="hermes-agent"\n')
-        env = {'HERMES_WEBUI_AGENT_DIR': str(agent_dir), 'HERMES_WEBUI_AUTO_INSTALL': '1'}
-        with patch.dict('os.environ', env, clear=False):
-            with patch('api.startup._trusted_agent_dir', return_value=True):
-                with patch('subprocess.run') as mock_run:
-                    mock_run.return_value = MagicMock(returncode=0, stderr='')
+        (agent_dir / "pyproject.toml").write_text('[project]\nname="hermes-agent"\n')
+        env = {
+            "HERMES_WEBUI_AGENT_DIR": str(agent_dir),
+            "HERMES_WEBUI_AUTO_INSTALL": "1",
+        }
+        with patch.dict("os.environ", env, clear=False):
+            with patch("api.startup._trusted_agent_dir", return_value=True):
+                with patch("subprocess.run") as mock_run:
+                    mock_run.return_value = MagicMock(returncode=0, stderr="")
                     assert auto_install_agent_deps() is True
                     args = mock_run.call_args[0][0]
-                    assert str(agent_dir) in args and '-r' not in args
+                    assert str(agent_dir) in args and "-r" not in args
 
     def test_skips_when_agent_dir_missing(self, tmp_path, capsys):
-        missing = tmp_path / 'nonexistent-agent'
+        missing = tmp_path / "nonexistent-agent"
         env_overrides = {
-            'HERMES_WEBUI_AGENT_DIR': str(missing),
-            'HERMES_HOME': str(tmp_path / 'no-hermes-home'),
-            'HERMES_WEBUI_AUTO_INSTALL': '1',
+            "HERMES_WEBUI_AGENT_DIR": str(missing),
+            "HERMES_HOME": str(tmp_path / "no-hermes-home"),
+            "HERMES_WEBUI_AUTO_INSTALL": "1",
         }
-        with patch.dict('os.environ', env_overrides, clear=False):
-            with patch('subprocess.run') as mock_run:
+        with patch.dict("os.environ", env_overrides, clear=False):
+            with patch("subprocess.run") as mock_run:
                 assert auto_install_agent_deps() is False
                 assert not mock_run.called
         out = capsys.readouterr().out.lower()
-        assert 'skipped' in out or 'not found' in out
+        assert "skipped" in out or "not found" in out
 
     def test_skips_when_no_install_file(self, tmp_path, capsys):
-        agent_dir = tmp_path / 'hermes-agent'
+        agent_dir = tmp_path / "hermes-agent"
         agent_dir.mkdir()
-        env = {'HERMES_WEBUI_AGENT_DIR': str(agent_dir), 'HERMES_WEBUI_AUTO_INSTALL': '1'}
-        with patch.dict('os.environ', env, clear=False):
-            with patch('api.startup._trusted_agent_dir', return_value=True):
-                with patch('subprocess.run') as mock_run:
+        env = {
+            "HERMES_WEBUI_AGENT_DIR": str(agent_dir),
+            "HERMES_WEBUI_AUTO_INSTALL": "1",
+        }
+        with patch.dict("os.environ", env, clear=False):
+            with patch("api.startup._trusted_agent_dir", return_value=True):
+                with patch("subprocess.run") as mock_run:
                     assert auto_install_agent_deps() is False
                     assert not mock_run.called
-        assert 'skipped' in capsys.readouterr().out.lower()
+        assert "skipped" in capsys.readouterr().out.lower()
 
     def test_skips_when_dir_not_trusted(self, tmp_path, capsys):
         """_trusted_agent_dir returning False must block installation."""
-        agent_dir = tmp_path / 'hermes-agent'
+        agent_dir = tmp_path / "hermes-agent"
         agent_dir.mkdir()
-        (agent_dir / 'requirements.txt').write_text('somepkg\n')
-        env = {'HERMES_WEBUI_AGENT_DIR': str(agent_dir), 'HERMES_WEBUI_AUTO_INSTALL': '1'}
-        with patch.dict('os.environ', env, clear=False):
-            with patch('api.startup._trusted_agent_dir', return_value=False):
-                with patch('subprocess.run') as mock_run:
+        (agent_dir / "requirements.txt").write_text("somepkg\n")
+        env = {
+            "HERMES_WEBUI_AGENT_DIR": str(agent_dir),
+            "HERMES_WEBUI_AUTO_INSTALL": "1",
+        }
+        with patch.dict("os.environ", env, clear=False):
+            with patch("api.startup._trusted_agent_dir", return_value=False):
+                with patch("subprocess.run") as mock_run:
                     assert auto_install_agent_deps() is False
                     assert not mock_run.called
-        assert 'trust' in capsys.readouterr().out.lower()
+        assert "trust" in capsys.readouterr().out.lower()
 
     def test_tolerates_pip_failure(self, tmp_path, capsys):
-        agent_dir = tmp_path / 'hermes-agent'
+        agent_dir = tmp_path / "hermes-agent"
         agent_dir.mkdir()
-        (agent_dir / 'requirements.txt').write_text('somepkg\n')
-        env = {'HERMES_WEBUI_AGENT_DIR': str(agent_dir), 'HERMES_WEBUI_AUTO_INSTALL': '1'}
-        with patch.dict('os.environ', env, clear=False):
-            with patch('api.startup._trusted_agent_dir', return_value=True):
-                with patch('subprocess.run') as mock_run:
-                    mock_run.return_value = MagicMock(returncode=1, stderr='ERROR: could not find package')
+        (agent_dir / "requirements.txt").write_text("somepkg\n")
+        env = {
+            "HERMES_WEBUI_AGENT_DIR": str(agent_dir),
+            "HERMES_WEBUI_AUTO_INSTALL": "1",
+        }
+        with patch.dict("os.environ", env, clear=False):
+            with patch("api.startup._trusted_agent_dir", return_value=True):
+                with patch("subprocess.run") as mock_run:
+                    mock_run.return_value = MagicMock(
+                        returncode=1, stderr="ERROR: could not find package"
+                    )
                     assert auto_install_agent_deps() is False
         out = capsys.readouterr().out.lower()
-        assert 'failed' in out or 'pip' in out
+        assert "failed" in out or "pip" in out
 
     def test_tolerates_timeout(self, tmp_path, capsys):
-        agent_dir = tmp_path / 'hermes-agent'
+        agent_dir = tmp_path / "hermes-agent"
         agent_dir.mkdir()
-        (agent_dir / 'requirements.txt').write_text('somepkg\n')
-        env = {'HERMES_WEBUI_AGENT_DIR': str(agent_dir), 'HERMES_WEBUI_AUTO_INSTALL': '1'}
-        with patch.dict('os.environ', env, clear=False):
-            with patch('api.startup._trusted_agent_dir', return_value=True):
-                with patch('subprocess.run', side_effect=subprocess.TimeoutExpired('pip', 120)):
+        (agent_dir / "requirements.txt").write_text("somepkg\n")
+        env = {
+            "HERMES_WEBUI_AGENT_DIR": str(agent_dir),
+            "HERMES_WEBUI_AUTO_INSTALL": "1",
+        }
+        with patch.dict("os.environ", env, clear=False):
+            with patch("api.startup._trusted_agent_dir", return_value=True):
+                with patch(
+                    "subprocess.run", side_effect=subprocess.TimeoutExpired("pip", 120)
+                ):
                     assert auto_install_agent_deps() is False
-        assert 'timed out' in capsys.readouterr().out.lower()
+        assert "timed out" in capsys.readouterr().out.lower()

--- a/tests/test_sprint33.py
+++ b/tests/test_sprint33.py
@@ -50,10 +50,14 @@ def test_ui_js_exposes_shared_dialog_helpers():
 def test_no_native_confirm_calls_remain_in_static_js():
     for path in (REPO / "static").glob("*.js"):
         src = path.read_text(encoding="utf-8")
-        assert not re.search(r"\bconfirm\s*\(", src), f"native confirm() remains in {path.name}"
+        assert not re.search(r"\bconfirm\s*\(", src), (
+            f"native confirm() remains in {path.name}"
+        )
 
 
 def test_no_native_prompt_calls_remain_in_static_js():
     for path in (REPO / "static").glob("*.js"):
         src = path.read_text(encoding="utf-8")
-        assert not re.search(r"\bprompt\s*\(", src), f"native prompt() remains in {path.name}"
+        assert not re.search(r"\bprompt\s*\(", src), (
+            f"native prompt() remains in {path.name}"
+        )

--- a/tests/test_sprint34.py
+++ b/tests/test_sprint34.py
@@ -19,7 +19,6 @@ import pathlib
 import tempfile
 import unittest.mock
 
-import pytest
 
 REPO = pathlib.Path(__file__).parent.parent
 from tests._pytest_port import BASE
@@ -27,7 +26,10 @@ from tests._pytest_port import BASE
 
 # ── Helpers ──────────────────────────────────────────────────────────────────
 
-def _make_auth_json(provider_id: str, tokens: dict, tmp_dir: pathlib.Path) -> pathlib.Path:
+
+def _make_auth_json(
+    provider_id: str, tokens: dict, tmp_dir: pathlib.Path
+) -> pathlib.Path:
     """Write an auth.json with the given tokens for provider_id into tmp_dir."""
     store = {"providers": {provider_id: tokens}}
     auth_path = tmp_dir / "auth.json"
@@ -51,12 +53,14 @@ def _make_auth_json_with_credential_pool(
 
 # ── 1–3. _provider_oauth_authenticated unit tests ────────────────────────────
 
+
 class TestProviderOAuthAuthenticated:
     """Unit tests for the new _provider_oauth_authenticated() helper."""
 
     def _call(self, provider: str, hermes_home: pathlib.Path) -> bool:
         # Import fresh so we don't get a stale module reference
         from api.onboarding import _provider_oauth_authenticated
+
         return _provider_oauth_authenticated(provider, hermes_home)
 
     def test_returns_false_when_auth_json_absent(self, tmp_path):
@@ -124,12 +128,14 @@ class TestProviderOAuthAuthenticated:
 
 # ── 4–5. _status_from_runtime integration ────────────────────────────────────
 
+
 class TestStatusFromRuntimeOAuth:
     """_status_from_runtime should treat OAuth providers with tokens as ready."""
 
     def _call(self, provider: str, model: str, hermes_home: pathlib.Path) -> dict:
         from api.onboarding import _status_from_runtime
         import api.onboarding as _ob
+
         orig_home = _ob._get_active_hermes_home
         orig_found = _ob._HERMES_FOUND
         _ob._get_active_hermes_home = lambda: hermes_home
@@ -169,7 +175,6 @@ class TestStatusFromRuntimeOAuth:
         We mock hermes_cli.auth to be unavailable so the function falls through
         to the auth.json path.  With no auth.json the result must be False.
         """
-        import unittest.mock
 
         # Prevent the hermes_cli fast path from finding real credentials
         with unittest.mock.patch(
@@ -211,6 +216,7 @@ class TestStatusFromRuntimeOAuth:
 
 # ── 6. API endpoint reflects OAuth-ready state ───────────────────────────────
 
+
 class TestOnboardingStatusApiOAuth:
     """
     The /api/onboarding/status endpoint should report provider_ready=True
@@ -219,6 +225,7 @@ class TestOnboardingStatusApiOAuth:
 
     def test_status_endpoint_returns_200(self):
         import urllib.request
+
         with urllib.request.urlopen(BASE + "/api/onboarding/status", timeout=10) as r:
             assert r.status == 200
             data = json.loads(r.read())
@@ -227,6 +234,7 @@ class TestOnboardingStatusApiOAuth:
 
     def test_onboarding_status_has_chat_ready_field(self):
         import urllib.request
+
         with urllib.request.urlopen(BASE + "/api/onboarding/status", timeout=10) as r:
             data = json.loads(r.read())
         assert "chat_ready" in data["system"]
@@ -234,6 +242,7 @@ class TestOnboardingStatusApiOAuth:
     def test_status_setup_state_valid_values(self):
         """setup_state must be one of the known string values."""
         import urllib.request
+
         with urllib.request.urlopen(BASE + "/api/onboarding/status", timeout=10) as r:
             data = json.loads(r.read())
         valid = {"ready", "provider_incomplete", "needs_provider", "agent_unavailable"}
@@ -244,23 +253,32 @@ class TestOnboardingStatusApiOAuth:
 
 # ── Control Center: section reset on close ─────────────────────────────────
 
+
 def test_control_center_resets_active_section_on_close():
     """Closing the control center must reset _settingsSection to 'conversation'."""
-    src = open(pathlib.Path(__file__).parent.parent / 'static' / 'panels.js').read()
-    assert '_settingsSection' in src, '_settingsSection state variable missing from panels.js'
-    assert "_settingsSection = 'conversation'" in src or "_settingsSection='conversation'" in src, \
-        'Control center does not reset section to conversation on close'
+    src = open(pathlib.Path(__file__).parent.parent / "static" / "panels.js").read()
+    assert "_settingsSection" in src, (
+        "_settingsSection state variable missing from panels.js"
+    )
+    assert (
+        "_settingsSection = 'conversation'" in src
+        or "_settingsSection='conversation'" in src
+    ), "Control center does not reset section to conversation on close"
 
 
 def test_control_center_tab_highlight_on_open():
     """The settings left-rail menu must have a CSS rule that highlights the active section."""
-    css = open(pathlib.Path(__file__).parent.parent / 'static' / 'style.css').read()
-    assert 'side-menu-item' in css, 'side-menu-item CSS class for left-rail nav missing from style.css'
-    assert '.side-menu-item.active' in css or 'side-menu-item.active' in css, \
-        'No active-state style for .side-menu-item — sidebar section highlight missing'
+    css = open(pathlib.Path(__file__).parent.parent / "static" / "style.css").read()
+    assert "side-menu-item" in css, (
+        "side-menu-item CSS class for left-rail nav missing from style.css"
+    )
+    assert ".side-menu-item.active" in css or "side-menu-item.active" in css, (
+        "No active-state style for .side-menu-item — sidebar section highlight missing"
+    )
 
 
 # ── apply_onboarding_setup: unsupported/OAuth providers complete gracefully ──
+
 
 class TestApplyOnboardingSetupUnsupportedProvider:
     """PR #323 / Issue #322: apply_onboarding_setup must not raise ValueError for
@@ -269,7 +287,9 @@ class TestApplyOnboardingSetupUnsupportedProvider:
     """
 
     def _call(self, provider: str) -> dict:
-        import sys, pathlib, unittest.mock, tempfile, os
+        import sys
+        import pathlib
+
         repo = pathlib.Path(__file__).parent.parent
         if str(repo) not in sys.path:
             sys.path.insert(0, str(repo))
@@ -277,14 +297,24 @@ class TestApplyOnboardingSetupUnsupportedProvider:
         from api.onboarding import apply_onboarding_setup
 
         with tempfile.TemporaryDirectory() as tmp:
-            with unittest.mock.patch("api.onboarding._get_active_hermes_home",
-                                     return_value=pathlib.Path(tmp)), \
-                 unittest.mock.patch("api.onboarding._get_config_path",
-                                     return_value=pathlib.Path(tmp) / "config.yaml"), \
-                 unittest.mock.patch("api.onboarding.save_settings") as mock_save, \
-                 unittest.mock.patch("api.onboarding.get_onboarding_status",
-                                     return_value={"completed": True, "system": {}}):
-                result = apply_onboarding_setup({"provider": provider, "model": "", "api_key": ""})
+            with (
+                unittest.mock.patch(
+                    "api.onboarding._get_active_hermes_home",
+                    return_value=pathlib.Path(tmp),
+                ),
+                unittest.mock.patch(
+                    "api.onboarding._get_config_path",
+                    return_value=pathlib.Path(tmp) / "config.yaml",
+                ),
+                unittest.mock.patch("api.onboarding.save_settings") as mock_save,
+                unittest.mock.patch(
+                    "api.onboarding.get_onboarding_status",
+                    return_value={"completed": True, "system": {}},
+                ),
+            ):
+                result = apply_onboarding_setup(
+                    {"provider": provider, "model": "", "api_key": ""}
+                )
                 return result, mock_save
 
     def test_openai_codex_does_not_raise(self):
@@ -306,11 +336,13 @@ class TestApplyOnboardingSetupUnsupportedProvider:
         """apply_onboarding_setup with an unsupported provider must save onboarding_completed=True."""
         _, mock_save = self._call("openai-codex")
         calls = [str(c) for c in mock_save.call_args_list]
-        assert any("onboarding_completed" in c for c in calls), \
+        assert any("onboarding_completed" in c for c in calls), (
             "save_settings must be called with onboarding_completed=True for unsupported providers"
+        )
 
     def test_unsupported_provider_returns_status_dict(self):
         """apply_onboarding_setup with an unsupported provider must return a status dict (not raise)."""
         result, _ = self._call("openai-codex")
-        assert isinstance(result, dict), \
+        assert isinstance(result, dict), (
             "apply_onboarding_setup must return a dict for unsupported providers, not raise"
+        )

--- a/tests/test_sprint35.py
+++ b/tests/test_sprint35.py
@@ -13,7 +13,6 @@ Covers:
 """
 
 import pathlib
-import re
 
 REPO = pathlib.Path(__file__).parent.parent
 
@@ -23,6 +22,7 @@ def read(path):
 
 
 # ── 1. PANEL_MAX raised ──────────────────────────────────────────────────────
+
 
 def test_panel_max_raised_to_1200():
     """PANEL_MAX must be 1200 (raised from 500) for wider right panel."""
@@ -41,6 +41,7 @@ def test_panel_max_is_not_500():
 
 
 # ── 2. Responsive messages-inner ─────────────────────────────────────────────
+
 
 def test_messages_inner_has_responsive_breakpoints():
     """style.css must have @media breakpoints for .messages-inner."""
@@ -79,6 +80,7 @@ def test_messages_inner_breakpoint_values():
 
 # ── 3–6. Breadcrumb navigation ───────────────────────────────────────────────
 
+
 def test_render_file_breadcrumb_function_exists():
     """workspace.js must expose renderFileBreadcrumb()."""
     src = read("static/workspace.js")
@@ -99,7 +101,7 @@ def test_breadcrumb_has_root_segment():
     """renderFileBreadcrumb must add a root '~' segment."""
     src = read("static/workspace.js")
     idx = src.find("function renderFileBreadcrumb")
-    block = src[idx:idx + 800]
+    block = src[idx : idx + 800]
     assert "'~'" in block or '"~"' in block, (
         "renderFileBreadcrumb missing root '~' segment"
     )
@@ -119,7 +121,7 @@ def test_clear_preview_calls_render_breadcrumb():
     # Find clearPreview and check renderBreadcrumb is called nearby
     idx = src.find("function clearPreview")
     assert idx != -1, "clearPreview not found in boot.js"
-    block = src[idx:idx + 600]
+    block = src[idx : idx + 600]
     assert "renderBreadcrumb" in block, (
         "clearPreview() does not call renderBreadcrumb() — "
         "directory breadcrumb won't restore after closing file preview"
@@ -127,6 +129,7 @@ def test_clear_preview_calls_render_breadcrumb():
 
 
 # ── 7. HTML markup ───────────────────────────────────────────────────────────
+
 
 def test_breadcrumb_bar_in_index_html():
     """index.html must have the breadcrumbBar element."""
@@ -138,6 +141,7 @@ def test_breadcrumb_bar_in_index_html():
 
 
 # ── 8. Breadcrumb CSS ────────────────────────────────────────────────────────
+
 
 def test_breadcrumb_css_rules_exist():
     """style.css must have breadcrumb CSS rules."""

--- a/tests/test_sprint36.py
+++ b/tests/test_sprint36.py
@@ -40,6 +40,7 @@ def _locale_count(src: str) -> int:
 
 # ── 1–4. cancelStream() cleanup is unconditional ─────────────────────────────
 
+
 class TestCancelStreamCleanup:
     """cancelStream() must clear all busy state regardless of SSE connection state."""
 
@@ -52,9 +53,9 @@ class TestCancelStreamCleanup:
         depth = 0
         end = idx
         for i, ch in enumerate(src[idx:]):
-            if ch == '{':
+            if ch == "{":
                 depth += 1
-            elif ch == '}':
+            elif ch == "}":
                 depth -= 1
                 if depth == 0:
                     end = idx + i + 1
@@ -111,6 +112,7 @@ class TestCancelStreamCleanup:
 
 # ── 5. Error path behavior ────────────────────────────────────────────────────
 
+
 class TestCancelStreamErrorPath:
     """The catch block should not prevent cleanup from running."""
 
@@ -123,7 +125,7 @@ class TestCancelStreamErrorPath:
         """
         src = read("static/boot.js")
         idx = src.find("async function cancelStream()")
-        block = src[idx:idx + 400]
+        block = src[idx : idx + 400]
         # The old pattern was setStatus inside catch; new pattern has it outside
         # Look for the catch block specifically
         catch_idx = block.find("}catch(")
@@ -133,7 +135,7 @@ class TestCancelStreamErrorPath:
         # Get just the catch body
         brace_open = block.find("{", catch_idx)
         brace_close = block.find("}", brace_open)
-        catch_body = block[brace_open:brace_close + 1]
+        catch_body = block[brace_open : brace_close + 1]
         assert "cancel_failed" not in catch_body, (
             "catch block still calls setStatus(cancel_failed) — "
             "this means a failed cancel shows an error instead of cleaning up silently"
@@ -141,6 +143,7 @@ class TestCancelStreamErrorPath:
 
 
 # ── 6. SSE cancel handler still present ──────────────────────────────────────
+
 
 def test_sse_cancel_handler_still_present():
     """The SSE 'cancel' event handler must still exist in messages.js.
@@ -165,18 +168,17 @@ def test_sse_cancel_handler_calls_set_busy():
     assert idx != -1
     # Find the closing of this handler block (next top-level addEventListener)
     next_handler = src.find("source.addEventListener(", idx + 50)
-    block = src[idx:next_handler] if next_handler != -1 else src[idx:idx + 3000]
-    assert (
-        "setBusy(false)" in block
-        or "_setActivePaneIdleIfOwner()" in block
-    ), (
+    block = src[idx:next_handler] if next_handler != -1 else src[idx : idx + 3000]
+    assert "setBusy(false)" in block or "_setActivePaneIdleIfOwner()" in block, (
         "SSE cancel handler no longer idles the owning active pane"
     )
     if "_setActivePaneIdleIfOwner()" in block:
         helper_idx = src.find("function _setActivePaneIdleIfOwner")
         assert helper_idx != -1
         next_function = src.find("\n  function ", helper_idx + 1)
-        helper = src[helper_idx:next_function if next_function != -1 else helper_idx + 800]
+        helper = src[
+            helper_idx : next_function if next_function != -1 else helper_idx + 800
+        ]
         assert "setBusy(false)" in helper
         # The helper MUST preserve the v0.51.12 (#1753) 3-way OR guard so
         # idling the active pane on a background completion is gated on the
@@ -193,6 +195,7 @@ def test_sse_cancel_handler_calls_set_busy():
 
 # ── 7. i18n key preserved ─────────────────────────────────────────────────────
 
+
 def test_cancel_failed_i18n_key_exists_in_all_locales():
     """cancel_failed key must still exist in i18n.js for all locales."""
     src = read("static/i18n.js")
@@ -206,6 +209,7 @@ def test_cancel_failed_i18n_key_exists_in_all_locales():
 
 
 # ── 8. Server-persisted cancel marker doesn't leak into agent history ────────
+
 
 def test_cancel_marker_flagged_as_error_to_skip_in_api_history():
     """The server-side cancel marker appended in cancel_stream() must carry
@@ -228,7 +232,7 @@ def test_cancel_marker_flagged_as_error_to_skip_in_api_history():
     brace_close = src.find("}", idx)
     assert brace_open != -1 and brace_close != -1, "couldn't locate cancel marker dict"
 
-    marker_dict = src[brace_open:brace_close + 1]
+    marker_dict = src[brace_open : brace_close + 1]
     assert "_error" in marker_dict and "True" in marker_dict, (
         "cancel marker is missing _error: True — it will leak into the agent's "
         "conversation_history via _sanitize_messages_for_api() on the next turn. "
@@ -240,6 +244,7 @@ def test_sanitize_strips_error_flagged_assistant_messages():
     """_sanitize_messages_for_api() must drop messages with _error: True —
     this is the invariant the cancel marker's _error flag relies on."""
     from api.streaming import _sanitize_messages_for_api
+
     messages = [
         {"role": "user", "content": "hello"},
         {"role": "assistant", "content": "hi"},

--- a/tests/test_sprint37.py
+++ b/tests/test_sprint37.py
@@ -1,20 +1,22 @@
 """
 Sprint 37 Tests: Workspace panel open/closed state persists across refreshes via localStorage.
 """
+
 import pathlib
-import re
 
 REPO_ROOT = pathlib.Path(__file__).parent.parent
-BOOT_JS   = (REPO_ROOT / "static" / "boot.js").read_text()
-HTML      = (REPO_ROOT / "static" / "index.html").read_text()
+BOOT_JS = (REPO_ROOT / "static" / "boot.js").read_text()
+HTML = (REPO_ROOT / "static" / "index.html").read_text()
 
 
 # ── Persistence: save on change ───────────────────────────────────────────────
 
+
 def test_workspace_panel_saves_to_localstorage():
     """_setWorkspacePanelMode must call localStorage.setItem with hermes-webui-workspace-panel."""
-    assert "hermes-webui-workspace-panel" in BOOT_JS, \
+    assert "hermes-webui-workspace-panel" in BOOT_JS, (
         "boot.js must use localStorage key 'hermes-webui-workspace-panel' to persist panel state"
+    )
 
 
 def test_workspace_panel_save_inside_set_mode():
@@ -22,8 +24,9 @@ def test_workspace_panel_save_inside_set_mode():
     fn_idx = BOOT_JS.find("function _setWorkspacePanelMode(")
     fn_end = BOOT_JS.find("\n}", fn_idx) + 2
     fn_body = BOOT_JS[fn_idx:fn_end]
-    assert "hermes-webui-workspace-panel" in fn_body, \
+    assert "hermes-webui-workspace-panel" in fn_body, (
         "localStorage save must be inside _setWorkspacePanelMode so every state change is captured"
+    )
 
 
 def test_workspace_panel_saves_open_value():
@@ -31,8 +34,9 @@ def test_workspace_panel_saves_open_value():
     fn_idx = BOOT_JS.find("function _setWorkspacePanelMode(")
     fn_end = BOOT_JS.find("\n}", fn_idx) + 2
     fn_body = BOOT_JS[fn_idx:fn_end]
-    assert "'open'" in fn_body or '"open"' in fn_body, \
+    assert "'open'" in fn_body or '"open"' in fn_body, (
         "_setWorkspacePanelMode must store 'open' for an open panel state"
+    )
 
 
 def test_workspace_panel_saves_closed_value():
@@ -40,11 +44,13 @@ def test_workspace_panel_saves_closed_value():
     fn_idx = BOOT_JS.find("function _setWorkspacePanelMode(")
     fn_end = BOOT_JS.find("\n}", fn_idx) + 2
     fn_body = BOOT_JS[fn_idx:fn_end]
-    assert "'closed'" in fn_body or '"closed"' in fn_body, \
+    assert "'closed'" in fn_body or '"closed"' in fn_body, (
         "_setWorkspacePanelMode must store 'closed' for a closed panel state"
+    )
 
 
 # ── Persistence: restore on boot ─────────────────────────────────────────────
+
 
 def test_workspace_panel_restored_on_boot():
     """Boot IIFE must read hermes-webui-workspace-panel from localStorage and restore the mode."""
@@ -53,8 +59,9 @@ def test_workspace_panel_restored_on_boot():
     if iife_idx < 0:
         iife_idx = BOOT_JS.rfind("(async()=>{")
     iife_body = BOOT_JS[iife_idx:]
-    assert "hermes-webui-workspace-panel" in iife_body, \
+    assert "hermes-webui-workspace-panel" in iife_body, (
         "Boot IIFE must read 'hermes-webui-workspace-panel' from localStorage to restore panel state on load"
+    )
 
 
 def test_workspace_panel_restore_sets_browse_mode():
@@ -64,8 +71,10 @@ def test_workspace_panel_restore_sets_browse_mode():
         iife_idx = BOOT_JS.rfind("(async()=>{")
     iife_body = BOOT_JS[iife_idx:]
     # The restore block must assign _workspacePanelMode = 'browse'
-    assert "_workspacePanelMode='browse'" in iife_body or "_workspacePanelMode = 'browse'" in iife_body, \
-        "Boot must set _workspacePanelMode='browse' when restoring an open panel"
+    assert (
+        "_workspacePanelMode='browse'" in iife_body
+        or "_workspacePanelMode = 'browse'" in iife_body
+    ), "Boot must set _workspacePanelMode='browse' when restoring an open panel"
 
 
 def test_workspace_panel_restore_before_sync():
@@ -84,11 +93,12 @@ def test_workspace_panel_restore_before_sync():
     # workspace-panel-pref is only read in the normal (has-messages) restore path
     restore_pos = iife_body.find("hermes-webui-workspace-panel-pref")
     # Use the LAST syncWorkspacePanelState() — this is the one in the normal restore path
-    sync_pos    = iife_body.rfind("syncWorkspacePanelState()")
+    sync_pos = iife_body.rfind("syncWorkspacePanelState()")
     assert restore_pos >= 0, "restore read must be present in boot IIFE"
-    assert sync_pos >= 0,    "syncWorkspacePanelState call must be present in boot IIFE"
-    assert restore_pos < sync_pos, \
+    assert sync_pos >= 0, "syncWorkspacePanelState call must be present in boot IIFE"
+    assert restore_pos < sync_pos, (
         "Workspace panel restore must happen BEFORE syncWorkspacePanelState() so the correct mode is applied"
+    )
 
 
 def test_workspace_panel_preload_marker_restored_in_head():
@@ -100,10 +110,13 @@ def test_workspace_panel_preload_marker_restored_in_head():
     css_link = '<link rel="stylesheet" href="static/style.css'
     marker_pos = HTML.find(marker)
     css_pos = HTML.find(css_link)
-    assert marker_pos >= 0, "index.html must preload documentElement.dataset.workspacePanel from localStorage"
+    assert marker_pos >= 0, (
+        "index.html must preload documentElement.dataset.workspacePanel from localStorage"
+    )
     assert css_pos >= 0, "main stylesheet link missing from index.html"
-    assert marker_pos < css_pos, \
+    assert marker_pos < css_pos, (
         "workspace panel preload marker must be set before style.css loads to avoid first-paint flash"
+    )
 
 
 def test_workspace_panel_mode_syncs_document_dataset():
@@ -111,5 +124,6 @@ def test_workspace_panel_mode_syncs_document_dataset():
     fn_idx = BOOT_JS.find("function _setWorkspacePanelMode(")
     fn_end = BOOT_JS.find("\n}", fn_idx) + 2
     fn_body = BOOT_JS[fn_idx:fn_end]
-    assert "document.documentElement.dataset.workspacePanel" in fn_body, \
+    assert "document.documentElement.dataset.workspacePanel" in fn_body, (
         "_setWorkspacePanelMode must keep documentElement.dataset.workspacePanel in sync with the panel state"
+    )

--- a/tests/test_sprint38.py
+++ b/tests/test_sprint38.py
@@ -4,34 +4,38 @@ Sprint 38 Tests: Think-tag stripping with leading whitespace (PR #327).
 Covers the static render path (ui.js regex logic, verified against the JS source)
 and the streaming render path (messages.js _streamDisplay logic).
 """
+
 import pathlib
 import re
 
 REPO_ROOT = pathlib.Path(__file__).parent.parent
-UI_JS     = (REPO_ROOT / "static" / "ui.js").read_text()
-MSG_JS    = (REPO_ROOT / "static" / "messages.js").read_text()
+UI_JS = (REPO_ROOT / "static" / "ui.js").read_text()
+MSG_JS = (REPO_ROOT / "static" / "messages.js").read_text()
 
 
 # ── ui.js: static render path ────────────────────────────────────────────────
+
 
 def test_think_regex_has_no_anchor():
     """The <think> regex in ui.js must not use a ^ anchor so leading whitespace is allowed."""
     # Find the thinkMatch line by locating the .match( call on that line
     idx = UI_JS.find("const thinkMatch=content.match(")
     assert idx >= 0, "thinkMatch line not found in ui.js"
-    line = UI_JS[idx:idx+100]
+    line = UI_JS[idx : idx + 100]
     # The regex must NOT start with ^ right after the opening /
-    assert "/^<think>" not in line and "(/^" not in line, \
+    assert "/^<think>" not in line and "(/^" not in line, (
         f"thinkMatch regex must not use ^ anchor — found: {line.strip()}"
+    )
 
 
 def test_gemma_regex_has_no_anchor():
     """The Gemma channel-token regex in ui.js must not use a ^ anchor."""
-    match = re.search(r'const gemmaMatch=content\.match\((/[^/]+/)\)', UI_JS)
+    match = re.search(r"const gemmaMatch=content\.match\((/[^/]+/)\)", UI_JS)
     assert match, "gemmaMatch line not found in ui.js"
     pattern = match.group(1)
-    assert not pattern.startswith('/^'), \
+    assert not pattern.startswith("/^"), (
         f"gemmaMatch regex must not use ^ anchor — got {pattern}"
+    )
 
 
 def test_think_content_removal_uses_replace_not_slice():
@@ -39,22 +43,26 @@ def test_think_content_removal_uses_replace_not_slice():
     # Find the block that handles thinkMatch
     idx = UI_JS.find("if(thinkMatch){")
     assert idx >= 0, "thinkMatch handler block not found"
-    block = UI_JS[idx:idx+200]
-    assert "content.replace(" in block, \
+    block = UI_JS[idx : idx + 200]
+    assert "content.replace(" in block, (
         "ui.js must use content.replace() to remove <think> block (not .slice())"
-    assert ".trimStart()" in block, \
+    )
+    assert ".trimStart()" in block, (
         "ui.js must call .trimStart() on content after removing the <think> block"
+    )
 
 
 def test_gemma_content_removal_uses_replace_not_slice():
     """Gemma channel token removal must also use .replace() not .slice()."""
     idx = UI_JS.find("if(gemmaMatch){")
     assert idx >= 0, "gemmaMatch handler block not found"
-    block = UI_JS[idx:idx+200]
-    assert "content.replace(" in block, \
+    block = UI_JS[idx : idx + 200]
+    assert "content.replace(" in block, (
         "ui.js must use content.replace() to remove Gemma channel block (not .slice())"
-    assert ".trimStart()" in block, \
+    )
+    assert ".trimStart()" in block, (
         "ui.js must call .trimStart() on content after removing the Gemma channel block"
+    )
 
 
 def test_gemma_turn_regex_in_ui_js():
@@ -65,10 +73,10 @@ def test_gemma_turn_regex_in_ui_js():
         " (note: double-pipe: <|turn|> not <|turn>)"
     )
     # Extraction block
-    match = re.search(r'const gemmaTurnMatch=content\.match\((/[^/]+/)\)', UI_JS)
+    match = re.search(r"const gemmaTurnMatch=content\.match\((/[^/]+/)\)", UI_JS)
     assert match, "gemmaTurnMatch line not found in ui.js"
     pattern = match.group(1)
-    assert not pattern.startswith('/^'), (
+    assert not pattern.startswith("/^"), (
         f"gemmaTurnMatch regex must not use ^ anchor — got {pattern}"
     )
 
@@ -77,7 +85,7 @@ def test_gemma_turn_content_removal_uses_replace_not_slice():
     """Gemma 4 turn token removal must use .replace() not .slice()."""
     idx = UI_JS.find("if(gemmaTurnMatch){")
     assert idx >= 0, "gemmaTurnMatch handler block not found in ui.js"
-    block = UI_JS[idx:idx+240]
+    block = UI_JS[idx : idx + 240]
     assert "content.replace(" in block, (
         "ui.js must use content.replace() to remove Gemma 4 turn block (not .slice())"
     )
@@ -88,14 +96,16 @@ def test_gemma_turn_content_removal_uses_replace_not_slice():
 
 # ── messages.js: streaming render path ───────────────────────────────────────
 
+
 def test_stream_display_trims_before_startswith():
     """_streamDisplay in messages.js must call .trimStart() before .startsWith() check."""
     fn_idx = MSG_JS.find("function _streamDisplay()")
     assert fn_idx >= 0, "_streamDisplay function not found in messages.js"
     fn_end = MSG_JS.find("\n  }", fn_idx) + 4
     fn_body = MSG_JS[fn_idx:fn_end]
-    assert "trimStart()" in fn_body, \
+    assert "trimStart()" in fn_body, (
         "_streamDisplay must call trimStart() to handle models that emit leading whitespace before <think>"
+    )
 
 
 def test_stream_display_uses_trimmed_for_startswith():
@@ -103,8 +113,9 @@ def test_stream_display_uses_trimmed_for_startswith():
     fn_idx = MSG_JS.find("function _streamDisplay()")
     fn_end = MSG_JS.find("\n  }", fn_idx) + 4
     fn_body = MSG_JS[fn_idx:fn_end]
-    assert "trimmed.startsWith(open)" in fn_body, \
+    assert "trimmed.startsWith(open)" in fn_body, (
         "_streamDisplay must use trimmed.startsWith(open) not raw.startsWith(open)"
+    )
 
 
 def test_stream_display_partial_tag_uses_trimmed():
@@ -112,8 +123,9 @@ def test_stream_display_partial_tag_uses_trimmed():
     fn_idx = MSG_JS.find("function _streamDisplay()")
     fn_end = MSG_JS.find("\n  }", fn_idx) + 4
     fn_body = MSG_JS[fn_idx:fn_end]
-    assert "open.startsWith(trimmed)" in fn_body, \
+    assert "open.startsWith(trimmed)" in fn_body, (
         "Partial-tag guard must use open.startsWith(trimmed) not open.startsWith(raw)"
+    )
 
 
 def test_stream_display_trims_return_after_close():
@@ -122,19 +134,23 @@ def test_stream_display_trims_return_after_close():
     fn_end = MSG_JS.find("\n  }", fn_idx) + 4
     fn_body = MSG_JS[fn_idx:fn_end]
     # The return after finding close must strip whitespace from the result
-    assert ".replace(/^" in fn_body and "s+/,'')" in fn_body, \
+    assert ".replace(/^" in fn_body and "s+/,'')" in fn_body, (
         "_streamDisplay must strip leading whitespace from content after the closing think tag"
+    )
 
 
 # ── Regression: existing anchored patterns must be gone ──────────────────────
 
+
 def test_no_anchored_think_regex_in_ui_js():
     """The old anchored regex /^<think>/ must not exist in ui.js."""
-    assert "/^<think>" not in UI_JS, \
+    assert "/^<think>" not in UI_JS, (
         "Old anchored /^<think>/ regex still present in ui.js — fix not applied"
+    )
 
 
 def test_no_anchored_gemma_regex_in_ui_js():
     """The old anchored Gemma regex must not exist in ui.js."""
-    assert "/^<|channel>" not in UI_JS, \
+    assert "/^<|channel>" not in UI_JS, (
         "Old anchored /^<|channel>/ regex still present in ui.js — fix not applied"
+    )

--- a/tests/test_sprint39.py
+++ b/tests/test_sprint39.py
@@ -7,6 +7,7 @@ Covers:
 - apply_onboarding_setup sets os.environ synchronously when an API key is saved
 - apply_onboarding_setup refuses to write config/env files when SKIP_ONBOARDING is set
 """
+
 import os
 import unittest
 import unittest.mock
@@ -40,15 +41,18 @@ _NOT_READY_RUNTIME = {
 }
 
 _COMMON_PATCHES = [
-    ("api.onboarding.load_settings",        lambda: {}),
-    ("api.onboarding.get_config",           lambda: {}),
-    ("api.onboarding.verify_hermes_imports",lambda: (True, [], [])),
-    ("api.onboarding.load_workspaces",      lambda: []),
-    ("api.onboarding.get_last_workspace",   lambda: "/tmp"),
+    ("api.onboarding.load_settings", lambda: {}),
+    ("api.onboarding.get_config", lambda: {}),
+    ("api.onboarding.verify_hermes_imports", lambda: (True, [], [])),
+    ("api.onboarding.load_workspaces", lambda: []),
+    ("api.onboarding.get_last_workspace", lambda: "/tmp"),
     ("api.onboarding.get_available_models", lambda: []),
-    ("api.onboarding.is_auth_enabled",      lambda: False),
+    ("api.onboarding.is_auth_enabled", lambda: False),
     ("api.onboarding._build_setup_catalog", lambda cfg: {}),
-    ("api.onboarding._get_config_path",     lambda: __import__("pathlib").Path("/tmp/fake.yaml")),
+    (
+        "api.onboarding._get_config_path",
+        lambda: __import__("pathlib").Path("/tmp/fake.yaml"),
+    ),
 ]
 
 
@@ -64,9 +68,10 @@ def _apply_patches(extra_patches=()):
 
 
 class TestSkipOnboardingEnvVar(unittest.TestCase):
-
     def _run_status(self, runtime, env_override):
-        runtime_patches = [("api.onboarding._status_from_runtime", lambda cfg, ok: runtime)]
+        runtime_patches = [
+            ("api.onboarding._status_from_runtime", lambda cfg, ok: runtime)
+        ]
         all_patches = _apply_patches(runtime_patches)
         with patch.dict(os.environ, env_override, clear=False):
             for p in all_patches:
@@ -80,39 +85,59 @@ class TestSkipOnboardingEnvVar(unittest.TestCase):
     def test_skip_env_1_and_chat_ready_marks_completed(self):
         """HERMES_WEBUI_SKIP_ONBOARDING=1 + chat_ready=True → completed=True."""
         status = self._run_status(_READY_RUNTIME, {"HERMES_WEBUI_SKIP_ONBOARDING": "1"})
-        self.assertTrue(status["completed"],
-                        "completed must be True when skip env var is 1 and chat_ready")
+        self.assertTrue(
+            status["completed"],
+            "completed must be True when skip env var is 1 and chat_ready",
+        )
 
     def test_skip_env_true_and_chat_ready_marks_completed(self):
         """HERMES_WEBUI_SKIP_ONBOARDING=true also accepted."""
-        status = self._run_status(_READY_RUNTIME, {"HERMES_WEBUI_SKIP_ONBOARDING": "true"})
+        status = self._run_status(
+            _READY_RUNTIME, {"HERMES_WEBUI_SKIP_ONBOARDING": "true"}
+        )
         self.assertTrue(status["completed"])
 
     def test_skip_env_yes_and_chat_ready_marks_completed(self):
         """HERMES_WEBUI_SKIP_ONBOARDING=yes also accepted."""
-        status = self._run_status(_READY_RUNTIME, {"HERMES_WEBUI_SKIP_ONBOARDING": "yes"})
+        status = self._run_status(
+            _READY_RUNTIME, {"HERMES_WEBUI_SKIP_ONBOARDING": "yes"}
+        )
         self.assertTrue(status["completed"])
 
     def test_skip_env_1_works_even_when_not_chat_ready(self):
         """HERMES_WEBUI_SKIP_ONBOARDING=1 skips unconditionally — chat_ready is NOT required."""
-        status = self._run_status(_NOT_READY_RUNTIME, {"HERMES_WEBUI_SKIP_ONBOARDING": "1"})
-        self.assertTrue(status["completed"],
-                        "completed must be True when skip env var is set, regardless of chat_ready")
+        status = self._run_status(
+            _NOT_READY_RUNTIME, {"HERMES_WEBUI_SKIP_ONBOARDING": "1"}
+        )
+        self.assertTrue(
+            status["completed"],
+            "completed must be True when skip env var is set, regardless of chat_ready",
+        )
 
     def test_skip_env_unset_leaves_default_false(self):
         """Without the env var, completed is False when settings are empty."""
-        env = {k: v for k, v in os.environ.items() if k != "HERMES_WEBUI_SKIP_ONBOARDING"}
+        env = {
+            k: v for k, v in os.environ.items() if k != "HERMES_WEBUI_SKIP_ONBOARDING"
+        }
         with patch.dict(os.environ, env, clear=True):
             status = self._run_status(_READY_RUNTIME, {})
-        self.assertFalse(status["completed"],
-                         "completed must be False when env var absent and settings empty")
+        self.assertFalse(
+            status["completed"],
+            "completed must be False when env var absent and settings empty",
+        )
 
     def test_settings_completed_still_works_without_env_var(self):
         """onboarding_completed in settings → completed=True regardless of env var."""
-        runtime_patches = [("api.onboarding._status_from_runtime", lambda cfg, ok: _READY_RUNTIME)]
-        settings_patch = [("api.onboarding.load_settings", lambda: {"onboarding_completed": True})]
+        runtime_patches = [
+            ("api.onboarding._status_from_runtime", lambda cfg, ok: _READY_RUNTIME)
+        ]
+        settings_patch = [
+            ("api.onboarding.load_settings", lambda: {"onboarding_completed": True})
+        ]
         all_patches = _apply_patches(runtime_patches + settings_patch)
-        env = {k: v for k, v in os.environ.items() if k != "HERMES_WEBUI_SKIP_ONBOARDING"}
+        env = {
+            k: v for k, v in os.environ.items() if k != "HERMES_WEBUI_SKIP_ONBOARDING"
+        }
         with patch.dict(os.environ, env, clear=True):
             for p in all_patches:
                 p.start()
@@ -135,24 +160,38 @@ class TestApplyOnboardingKeySync(unittest.TestCase):
 
         mock_cfg = {"model": {"provider": "openai", "default": "gpt-4o"}}
 
-        with patch("api.onboarding._load_yaml_config", return_value=mock_cfg), \
-             patch("api.onboarding._save_yaml_config"), \
-             patch("api.onboarding._write_env_file"), \
-             patch("api.onboarding.reload_config"), \
-             patch("api.onboarding.get_onboarding_status", return_value={"completed": True}), \
-             patch("api.onboarding._get_config_path", return_value=pathlib.Path("/tmp/fake.yaml")), \
-             patch("api.onboarding._load_env_file", return_value={}), \
-             patch("api.onboarding._provider_api_key_present", return_value=False), \
-             patch("api.onboarding._get_active_hermes_home", return_value=pathlib.Path("/tmp")):
+        with (
+            patch("api.onboarding._load_yaml_config", return_value=mock_cfg),
+            patch("api.onboarding._save_yaml_config"),
+            patch("api.onboarding._write_env_file"),
+            patch("api.onboarding.reload_config"),
+            patch(
+                "api.onboarding.get_onboarding_status", return_value={"completed": True}
+            ),
+            patch(
+                "api.onboarding._get_config_path",
+                return_value=pathlib.Path("/tmp/fake.yaml"),
+            ),
+            patch("api.onboarding._load_env_file", return_value={}),
+            patch("api.onboarding._provider_api_key_present", return_value=False),
+            patch(
+                "api.onboarding._get_active_hermes_home",
+                return_value=pathlib.Path("/tmp"),
+            ),
+        ):
+            mod.apply_onboarding_setup(
+                {
+                    "provider": "openai",
+                    "model": "gpt-4o",
+                    "api_key": "sk-test-key-123",
+                }
+            )
 
-            mod.apply_onboarding_setup({
-                "provider": "openai",
-                "model": "gpt-4o",
-                "api_key": "sk-test-key-123",
-            })
-
-        self.assertEqual(os.environ.get("OPENAI_API_KEY"), "sk-test-key-123",
-                         "OPENAI_API_KEY must be set directly on os.environ after apply")
+        self.assertEqual(
+            os.environ.get("OPENAI_API_KEY"),
+            "sk-test-key-123",
+            "OPENAI_API_KEY must be set directly on os.environ after apply",
+        )
         os.environ.pop("OPENAI_API_KEY", None)
 
     def test_no_key_provided_does_not_set_environ(self):
@@ -163,20 +202,34 @@ class TestApplyOnboardingKeySync(unittest.TestCase):
 
         mock_cfg = {"model": {"provider": "openai", "default": "gpt-4o"}}
 
-        with patch("api.onboarding._load_yaml_config", return_value=mock_cfg), \
-             patch("api.onboarding._save_yaml_config"), \
-             patch("api.onboarding._write_env_file"), \
-             patch("api.onboarding.reload_config"), \
-             patch("api.onboarding.get_onboarding_status", return_value={"completed": True}), \
-             patch("api.onboarding._get_config_path", return_value=pathlib.Path("/tmp/fake.yaml")), \
-             patch("api.onboarding._load_env_file", return_value={"OPENAI_API_KEY": "sk-existing-key"}), \
-             patch("api.onboarding._provider_api_key_present", return_value=True), \
-             patch("api.onboarding._get_active_hermes_home", return_value=pathlib.Path("/tmp")):
-
-            mod.apply_onboarding_setup({
-                "provider": "openai",
-                "model": "gpt-4o",
-            })
+        with (
+            patch("api.onboarding._load_yaml_config", return_value=mock_cfg),
+            patch("api.onboarding._save_yaml_config"),
+            patch("api.onboarding._write_env_file"),
+            patch("api.onboarding.reload_config"),
+            patch(
+                "api.onboarding.get_onboarding_status", return_value={"completed": True}
+            ),
+            patch(
+                "api.onboarding._get_config_path",
+                return_value=pathlib.Path("/tmp/fake.yaml"),
+            ),
+            patch(
+                "api.onboarding._load_env_file",
+                return_value={"OPENAI_API_KEY": "sk-existing-key"},
+            ),
+            patch("api.onboarding._provider_api_key_present", return_value=True),
+            patch(
+                "api.onboarding._get_active_hermes_home",
+                return_value=pathlib.Path("/tmp"),
+            ),
+        ):
+            mod.apply_onboarding_setup(
+                {
+                    "provider": "openai",
+                    "model": "gpt-4o",
+                }
+            )
 
         # Key must be unchanged
         self.assertEqual(os.environ.get("OPENAI_API_KEY"), "sk-existing-key")
@@ -191,16 +244,22 @@ class TestApplyOnboardingSkipGuard(unittest.TestCase):
         save_yaml_mock = unittest.mock.MagicMock()
         write_env_mock = unittest.mock.MagicMock()
 
-        with patch.dict(os.environ, {"HERMES_WEBUI_SKIP_ONBOARDING": "1"}, clear=False), \
-             patch("api.onboarding._save_yaml_config", save_yaml_mock), \
-             patch("api.onboarding._write_env_file", write_env_mock), \
-             patch("api.onboarding.save_settings"), \
-             patch("api.onboarding.get_onboarding_status", return_value={"completed": True}):
-            mod.apply_onboarding_setup({
-                "provider": "openai",
-                "model": "gpt-4o",
-                "api_key": "should-not-be-saved",
-            })
+        with (
+            patch.dict(os.environ, {"HERMES_WEBUI_SKIP_ONBOARDING": "1"}, clear=False),
+            patch("api.onboarding._save_yaml_config", save_yaml_mock),
+            patch("api.onboarding._write_env_file", write_env_mock),
+            patch("api.onboarding.save_settings"),
+            patch(
+                "api.onboarding.get_onboarding_status", return_value={"completed": True}
+            ),
+        ):
+            mod.apply_onboarding_setup(
+                {
+                    "provider": "openai",
+                    "model": "gpt-4o",
+                    "api_key": "should-not-be-saved",
+                }
+            )
 
         save_yaml_mock.assert_not_called()
         write_env_mock.assert_not_called()
@@ -208,25 +267,43 @@ class TestApplyOnboardingSkipGuard(unittest.TestCase):
     def test_apply_setup_proceeds_normally_without_skip_env(self):
         """Without SKIP_ONBOARDING, apply_onboarding_setup writes config as usual."""
         import pathlib
+
         save_yaml_mock = unittest.mock.MagicMock()
 
         mock_cfg = {"model": {"provider": "openai", "default": "gpt-4o"}}
-        env = {k: v for k, v in os.environ.items() if k != "HERMES_WEBUI_SKIP_ONBOARDING"}
+        env = {
+            k: v for k, v in os.environ.items() if k != "HERMES_WEBUI_SKIP_ONBOARDING"
+        }
 
-        with patch.dict(os.environ, env, clear=True), \
-             patch("api.onboarding._load_yaml_config", return_value=mock_cfg), \
-             patch("api.onboarding._save_yaml_config", save_yaml_mock), \
-             patch("api.onboarding._write_env_file"), \
-             patch("api.onboarding.reload_config"), \
-             patch("api.onboarding.get_onboarding_status", return_value={"completed": True}), \
-             patch("api.onboarding._get_config_path", return_value=pathlib.Path("/tmp/fake.yaml")), \
-             patch("api.onboarding._load_env_file", return_value={"OPENAI_API_KEY": "existing"}), \
-             patch("api.onboarding._provider_api_key_present", return_value=True), \
-             patch("api.onboarding._get_active_hermes_home", return_value=pathlib.Path("/tmp")):
-            mod.apply_onboarding_setup({
-                "provider": "openai",
-                "model": "gpt-4o",
-            })
+        with (
+            patch.dict(os.environ, env, clear=True),
+            patch("api.onboarding._load_yaml_config", return_value=mock_cfg),
+            patch("api.onboarding._save_yaml_config", save_yaml_mock),
+            patch("api.onboarding._write_env_file"),
+            patch("api.onboarding.reload_config"),
+            patch(
+                "api.onboarding.get_onboarding_status", return_value={"completed": True}
+            ),
+            patch(
+                "api.onboarding._get_config_path",
+                return_value=pathlib.Path("/tmp/fake.yaml"),
+            ),
+            patch(
+                "api.onboarding._load_env_file",
+                return_value={"OPENAI_API_KEY": "existing"},
+            ),
+            patch("api.onboarding._provider_api_key_present", return_value=True),
+            patch(
+                "api.onboarding._get_active_hermes_home",
+                return_value=pathlib.Path("/tmp"),
+            ),
+        ):
+            mod.apply_onboarding_setup(
+                {
+                    "provider": "openai",
+                    "model": "gpt-4o",
+                }
+            )
 
         save_yaml_mock.assert_called_once()
 

--- a/tests/test_sprint4.py
+++ b/tests/test_sprint4.py
@@ -1,30 +1,42 @@
 """Sprint 4 tests: relocation, session rename, search, file ops, validation."""
-import json, pathlib, uuid, urllib.request, urllib.error
+
+import json
+import uuid
+import urllib.request
+import urllib.error
 
 from tests._pytest_port import BASE
+
 
 def get(path):
     with urllib.request.urlopen(BASE + path, timeout=10) as r:
         return json.loads(r.read()), r.status
 
+
 def get_raw(path):
     with urllib.request.urlopen(BASE + path, timeout=10) as r:
-        return r.read(), r.headers.get("Content-Type",""), r.status
+        return r.read(), r.headers.get("Content-Type", ""), r.status
+
 
 def post(path, body=None):
     data = json.dumps(body or {}).encode()
-    req = urllib.request.Request(BASE + path, data=data, headers={"Content-Type": "application/json"})
+    req = urllib.request.Request(
+        BASE + path, data=data, headers={"Content-Type": "application/json"}
+    )
     try:
         with urllib.request.urlopen(req, timeout=10) as r:
             return json.loads(r.read()), r.status
     except urllib.error.HTTPError as e:
         return json.loads(e.read()), e.code
 
+
 def make_session_tracked(created_list, ws=None):
     """Create a session and register it with the cleanup fixture."""
     import pathlib as _pathlib
+
     body = {}
-    if ws: body["workspace"] = str(ws)
+    if ws:
+        body["workspace"] = str(ws)
     d, _ = post("/api/session/new", body)
     sid = d["session"]["session_id"]
     created_list.append(sid)
@@ -35,9 +47,11 @@ def test_server_running_from_new_location():
     data, status = get("/health")
     assert status == 200 and data["status"] == "ok"
 
+
 def test_static_css_served():
     raw, ct, status = get_raw("/static/style.css")
     assert status == 200 and "text/css" in ct and b"--bg" in raw
+
 
 def test_static_unknown_file_404():
     try:
@@ -46,10 +60,14 @@ def test_static_unknown_file_404():
     except urllib.error.HTTPError as e:
         assert e.code == 404
 
+
 def test_session_rename(cleanup_test_sessions):
     sid, _ = make_session_tracked(cleanup_test_sessions)
-    result, status = post("/api/session/rename", {"session_id": sid, "title": "Renamed Session"})
+    result, status = post(
+        "/api/session/rename", {"session_id": sid, "title": "Renamed Session"}
+    )
     assert status == 200 and result["session"]["title"] == "Renamed Session"
+
 
 def test_session_rename_persists(cleanup_test_sessions):
     sid, _ = make_session_tracked(cleanup_test_sessions)
@@ -57,10 +75,14 @@ def test_session_rename_persists(cleanup_test_sessions):
     loaded, _ = get(f"/api/session?session_id={sid}")
     assert loaded["session"]["title"] == "Persisted"
 
+
 def test_session_rename_truncates(cleanup_test_sessions):
     sid, _ = make_session_tracked(cleanup_test_sessions)
-    result, status = post("/api/session/rename", {"session_id": sid, "title": "A" * 200})
+    result, status = post(
+        "/api/session/rename", {"session_id": sid, "title": "A" * 200}
+    )
     assert status == 200 and len(result["session"]["title"]) <= 80
+
 
 def test_session_rename_requires_fields():
     result, status = post("/api/session/rename", {"session_id": "x"})
@@ -68,9 +90,13 @@ def test_session_rename_requires_fields():
     result2, status2 = post("/api/session/rename", {"title": "hi"})
     assert status2 == 400
 
+
 def test_session_rename_unknown_id():
-    result, status = post("/api/session/rename", {"session_id": "nosuchid", "title": "hi"})
+    result, status = post(
+        "/api/session/rename", {"session_id": "nosuchid", "title": "hi"}
+    )
     assert status == 404
+
 
 def test_session_search_returns_matches(cleanup_test_sessions):
     sid, _ = make_session_tracked(cleanup_test_sessions)
@@ -81,20 +107,27 @@ def test_session_search_returns_matches(cleanup_test_sessions):
     sids = [s["session_id"] for s in data["sessions"]]
     assert sid in sids
 
+
 def test_session_search_empty_query_returns_all():
     data, status = get("/api/sessions/search?q=")
     assert status == 200 and "sessions" in data
+
 
 def test_session_search_no_results():
     data, status = get("/api/sessions/search?q=zzznomatchzzz9999")
     assert status == 200 and data["sessions"] == []
 
+
 def test_file_create(cleanup_test_sessions):
     sid, ws = make_session_tracked(cleanup_test_sessions)
     fname = f"test_{uuid.uuid4().hex[:6]}.txt"
-    result, status = post("/api/file/create", {"session_id": sid, "path": fname, "content": "hello sprint4"})
+    result, status = post(
+        "/api/file/create",
+        {"session_id": sid, "path": fname, "content": "hello sprint4"},
+    )
     assert status == 200 and result["ok"] is True
     assert (ws / fname).read_text() == "hello sprint4"
+
 
 def test_file_create_requires_fields(cleanup_test_sessions):
     sid, _ = make_session_tracked(cleanup_test_sessions)
@@ -103,28 +136,41 @@ def test_file_create_requires_fields(cleanup_test_sessions):
     result2, status2 = post("/api/file/create", {"path": "x.txt"})
     assert status2 == 400
 
+
 def test_file_create_duplicate_rejected(cleanup_test_sessions):
     sid, ws = make_session_tracked(cleanup_test_sessions)
     fname = f"dup_{uuid.uuid4().hex[:6]}.txt"
     post("/api/file/create", {"session_id": sid, "path": fname, "content": ""})
-    result, status = post("/api/file/create", {"session_id": sid, "path": fname, "content": ""})
+    result, status = post(
+        "/api/file/create", {"session_id": sid, "path": fname, "content": ""}
+    )
     assert status == 400
+
 
 def test_file_delete(cleanup_test_sessions):
     sid, ws = make_session_tracked(cleanup_test_sessions)
     (ws / "to_delete.txt").write_text("bye")
-    result, status = post("/api/file/delete", {"session_id": sid, "path": "to_delete.txt"})
+    result, status = post(
+        "/api/file/delete", {"session_id": sid, "path": "to_delete.txt"}
+    )
     assert status == 200 and not (ws / "to_delete.txt").exists()
+
 
 def test_file_delete_missing_returns_404(cleanup_test_sessions):
     sid, _ = make_session_tracked(cleanup_test_sessions)
-    result, status = post("/api/file/delete", {"session_id": sid, "path": "nosuchfile.txt"})
+    result, status = post(
+        "/api/file/delete", {"session_id": sid, "path": "nosuchfile.txt"}
+    )
     assert status == 404
+
 
 def test_file_delete_path_traversal_blocked(cleanup_test_sessions):
     sid, _ = make_session_tracked(cleanup_test_sessions)
-    result, status = post("/api/file/delete", {"session_id": sid, "path": "../../etc/passwd"})
+    result, status = post(
+        "/api/file/delete", {"session_id": sid, "path": "../../etc/passwd"}
+    )
     assert status in (400, 500)
+
 
 def test_list_requires_session_id():
     try:
@@ -133,12 +179,14 @@ def test_list_requires_session_id():
     except urllib.error.HTTPError as e:
         assert e.code == 400
 
+
 def test_file_requires_session_id():
     try:
         get("/api/file?path=readme.txt")
         assert False
     except urllib.error.HTTPError as e:
         assert e.code == 400
+
 
 def test_file_requires_path(cleanup_test_sessions):
     sid, _ = make_session_tracked(cleanup_test_sessions)
@@ -148,11 +196,15 @@ def test_file_requires_path(cleanup_test_sessions):
     except urllib.error.HTTPError as e:
         assert e.code == 400
 
+
 def test_new_session_inherits_workspace(cleanup_test_sessions):
     sid, ws = make_session_tracked(cleanup_test_sessions)
     child = ws / f"workspace-inherit-{uuid.uuid4().hex[:6]}"
     child.mkdir(parents=True, exist_ok=True)
-    post("/api/session/update", {"session_id": sid, "workspace": str(child), "model": "openai/gpt-5.4-mini"})
+    post(
+        "/api/session/update",
+        {"session_id": sid, "workspace": str(child), "model": "openai/gpt-5.4-mini"},
+    )
     sid2, _ = make_session_tracked(cleanup_test_sessions)
     data, _ = get(f"/api/session?session_id={sid2}")
     assert data["session"]["workspace"] == str(child)

--- a/tests/test_sprint40.py
+++ b/tests/test_sprint40.py
@@ -8,8 +8,8 @@ Covers:
 - apply_onboarding_setup with unsupported provider marks onboarding complete directly
 - i18n.js contains all required OAuth onboarding keys in both English and Spanish
 """
+
 import pathlib
-import re
 import unittest
 from unittest.mock import patch
 
@@ -24,19 +24,22 @@ ONBOARDING_JS = (REPO_ROOT / "static" / "onboarding.js").read_text()
 
 
 class TestBuildSetupCatalog(unittest.TestCase):
-
     def _catalog(self, provider, model="gpt-4o", base_url=""):
         cfg = {}
         if provider:
-            cfg = {"model": {"provider": provider, "default": model, "base_url": base_url}}
+            cfg = {
+                "model": {"provider": provider, "default": model, "base_url": base_url}
+            }
         with patch.object(mod, "get_config", return_value=cfg):
             return mod._build_setup_catalog(cfg)
 
     def test_oauth_provider_sets_current_is_oauth_true(self):
         """openai-codex is not in _SUPPORTED_PROVIDER_SETUPS → current_is_oauth=True."""
         catalog = self._catalog("openai-codex", "gpt-5.4")
-        self.assertTrue(catalog["current_is_oauth"],
-                        "current_is_oauth must be True for openai-codex")
+        self.assertTrue(
+            catalog["current_is_oauth"],
+            "current_is_oauth must be True for openai-codex",
+        )
 
     def test_copilot_provider_sets_current_is_oauth_true(self):
         """copilot is also OAuth."""
@@ -46,8 +49,10 @@ class TestBuildSetupCatalog(unittest.TestCase):
     def test_openai_provider_sets_current_is_oauth_false(self):
         """openai is in _SUPPORTED_PROVIDER_SETUPS → current_is_oauth=False."""
         catalog = self._catalog("openai", "gpt-4o")
-        self.assertFalse(catalog["current_is_oauth"],
-                         "current_is_oauth must be False for API-key provider openai")
+        self.assertFalse(
+            catalog["current_is_oauth"],
+            "current_is_oauth must be False for API-key provider openai",
+        )
 
     def test_anthropic_provider_sets_current_is_oauth_false(self):
         catalog = self._catalog("anthropic", "claude-sonnet-4.6")
@@ -68,7 +73,6 @@ class TestBuildSetupCatalog(unittest.TestCase):
 
 
 class TestApplyOnboardingOAuthPath(unittest.TestCase):
-
     def test_unsupported_provider_skips_to_complete(self):
         """apply_onboarding_setup with an OAuth provider just marks onboarding done."""
         saved = {}
@@ -78,19 +82,27 @@ class TestApplyOnboardingOAuthPath(unittest.TestCase):
 
         mock_status = {"completed": True, "system": {"chat_ready": True}}
 
-        with patch.object(mod, "save_settings", side_effect=_save), \
-             patch.object(mod, "get_onboarding_status", return_value=mock_status):
-            result = mod.apply_onboarding_setup({"provider": "openai-codex", "model": "gpt-5.4"})
+        with (
+            patch.object(mod, "save_settings", side_effect=_save),
+            patch.object(mod, "get_onboarding_status", return_value=mock_status),
+        ):
+            result = mod.apply_onboarding_setup(
+                {"provider": "openai-codex", "model": "gpt-5.4"}
+            )
 
-        self.assertTrue(saved.get("onboarding_completed"),
-                        "save_settings must set onboarding_completed=True for OAuth provider")
+        self.assertTrue(
+            saved.get("onboarding_completed"),
+            "save_settings must set onboarding_completed=True for OAuth provider",
+        )
         self.assertEqual(result, mock_status)
 
     def test_unsupported_provider_does_not_write_config_yaml(self):
         """OAuth path must not call _save_yaml_config — no config mutation."""
-        with patch.object(mod, "save_settings"), \
-             patch.object(mod, "get_onboarding_status", return_value={}), \
-             patch.object(mod, "_save_yaml_config") as mock_save_yaml:
+        with (
+            patch.object(mod, "save_settings"),
+            patch.object(mod, "get_onboarding_status", return_value={}),
+            patch.object(mod, "_save_yaml_config") as mock_save_yaml,
+        ):
             mod.apply_onboarding_setup({"provider": "copilot", "model": "gpt-4o"})
 
         mock_save_yaml.assert_not_called()
@@ -109,38 +121,43 @@ _REQUIRED_OAUTH_KEYS = [
 
 
 class TestOAuthI18nKeys(unittest.TestCase):
-
     def test_english_locale_has_all_oauth_keys(self):
         """All OAuth onboarding i18n keys must be present in the English locale."""
         missing = [k for k in _REQUIRED_OAUTH_KEYS if k not in I18N_JS]
-        self.assertFalse(missing,
-                         f"English locale missing OAuth keys: {missing}")
+        self.assertFalse(missing, f"English locale missing OAuth keys: {missing}")
 
     def test_spanish_locale_has_all_oauth_keys(self):
         """All OAuth onboarding i18n keys must be present in the Spanish locale."""
         # Spanish locale is the second occurrence of each key
         counts = {k: I18N_JS.count(k) for k in _REQUIRED_OAUTH_KEYS}
         under = [k for k, c in counts.items() if c < 2]
-        self.assertFalse(under,
-                         f"Spanish locale missing OAuth keys (need 2 occurrences each): {under}")
+        self.assertFalse(
+            under,
+            f"Spanish locale missing OAuth keys (need 2 occurrences each): {under}",
+        )
 
     def test_oauth_body_strings_contain_provider_placeholder(self):
         """Body strings must contain {provider} so JS can substitute the provider name."""
-        for key in ["onboarding_oauth_provider_ready_body",
-                    "onboarding_oauth_provider_not_ready_body"]:
-            self.assertIn("{provider}", I18N_JS,
-                          f"{key} must contain {{provider}} placeholder")
+        for key in [
+            "onboarding_oauth_provider_ready_body",
+            "onboarding_oauth_provider_not_ready_body",
+        ]:
+            self.assertIn(
+                "{provider}", I18N_JS, f"{key} must contain {{provider}} placeholder"
+            )
 
 
 # ── Frontend: onboarding.js uses current_is_oauth ─────────────────────────
 
 
 class TestOAuthOnboardingJs(unittest.TestCase):
-
     def test_onboarding_js_reads_current_is_oauth(self):
         """onboarding.js must check current_is_oauth from the status payload."""
-        self.assertIn("current_is_oauth", ONBOARDING_JS,
-                      "onboarding.js must read current_is_oauth from ONBOARDING.status.setup")
+        self.assertIn(
+            "current_is_oauth",
+            ONBOARDING_JS,
+            "onboarding.js must read current_is_oauth from ONBOARDING.status.setup",
+        )
 
     def test_onboarding_js_renders_oauth_ready_card(self):
         """onboarding.js must render the oauth-ready card class."""

--- a/tests/test_sprint40_ui_polish.py
+++ b/tests/test_sprint40_ui_polish.py
@@ -5,25 +5,24 @@ Covers:
 - .session-item.active .session-title uses var(--gold) instead of hardcoded #e8a030
 - The hardcoded amber color #e8a030 is NOT present in the active session title rule
 """
-import os
+
 import pathlib
-import re
 import sys
 import unittest
-from unittest import mock
 
 # Ensure repo is on sys.path so api.config can be imported
 _REPO_ROOT = pathlib.Path(__file__).parent.parent
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
-REPO_ROOT  = _REPO_ROOT
-STYLE_CSS  = (REPO_ROOT / "static" / "style.css").read_text()
+REPO_ROOT = _REPO_ROOT
+STYLE_CSS = (REPO_ROOT / "static" / "style.css").read_text()
 SESSIONS_JS = (REPO_ROOT / "static" / "sessions.js").read_text()
-PANELS_JS   = (REPO_ROOT / "static" / "panels.js").read_text()
+PANELS_JS = (REPO_ROOT / "static" / "panels.js").read_text()
 
 try:
     from api import config as _api_config
+
     _config_available = True
 except Exception:
     _api_config = None
@@ -36,7 +35,6 @@ except Exception:
 
 # ── #451 active title ─────────────────────────────────────────────
 class TestActiveSessionTitleThemeColor(unittest.TestCase):
-
     def test_active_session_title_uses_theme_variable(self):
         """
         .session-item.active .session-title must use var(--gold) not a hardcoded hex.
@@ -46,30 +44,30 @@ class TestActiveSessionTitleThemeColor(unittest.TestCase):
         # Find all lines that match the active session title selector
         lines = STYLE_CSS.splitlines()
         base_rule_lines = [
-            line for line in lines
+            line
+            for line in lines
             if ".session-item.active .session-title" in line
-            and ':not(.dark)' not in line
+            and ":not(.dark)" not in line
         ]
 
         self.assertTrue(
             len(base_rule_lines) >= 1,
-            "Could not find .session-item.active .session-title base rule in style.css"
+            "Could not find .session-item.active .session-title base rule in style.css",
         )
 
         for line in base_rule_lines:
             self.assertTrue(
                 "var(--gold)" in line or "var(--accent-text)" in line,
-                f"Expected var(--gold) or var(--accent-text) in active session title rule, got: {line.strip()}"
+                f"Expected var(--gold) or var(--accent-text) in active session title rule, got: {line.strip()}",
             )
             self.assertNotIn(
                 "#e8a030",
                 line,
-                f"Hardcoded #e8a030 must be removed from active session title rule: {line.strip()}"
+                f"Hardcoded #e8a030 must be removed from active session title rule: {line.strip()}",
             )
 
 
 class TestDarkTopbarSelector(unittest.TestCase):
-
     def test_topbar_dark_border_uses_root_dark_selector(self):
         self.assertIn(
             ":root.dark .topbar{border-bottom:1px solid rgba(255,255,255,.07);}",
@@ -85,6 +83,7 @@ class TestDarkTopbarSelector(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
 
 # ── #452 unknown model ─────────────────────────────────────────────
 class TestGatewaySessionNullModel(unittest.TestCase):
@@ -135,6 +134,7 @@ class TestGatewaySessionNullModel(unittest.TestCase):
 if __name__ == "__main__":
     unittest.main()
 
+
 # ── #454 model routing ─────────────────────────────────────────────
 @unittest.skipUnless(_config_available, "api.config not importable")
 class TestCustomEndpointModelStripping:
@@ -145,10 +145,10 @@ class TestCustomEndpointModelStripping:
         old_cfg = dict(_api_config.cfg)
         model_cfg = {}
         if provider:
-            model_cfg['provider'] = provider
+            model_cfg["provider"] = provider
         if base_url:
-            model_cfg['base_url'] = base_url
-        _api_config.cfg['model'] = model_cfg
+            model_cfg["base_url"] = base_url
+        _api_config.cfg["model"] = model_cfg
         try:
             return _api_config.resolve_model_provider(model_id)
         finally:
@@ -158,44 +158,45 @@ class TestCustomEndpointModelStripping:
     def test_prefixed_model_stripped_for_custom_endpoint(self):
         """Issue #433: 'openai/gpt-5.4' with custom base_url returns bare 'gpt-5.4'."""
         model, provider, base_url = self._resolve(
-            'openai/gpt-5.4',
-            provider='custom',
-            base_url='http://my-proxy.local:8080/v1',
+            "openai/gpt-5.4",
+            provider="custom",
+            base_url="http://my-proxy.local:8080/v1",
         )
-        assert model == 'gpt-5.4', (
+        assert model == "gpt-5.4", (
             "Expected bare 'gpt-5.4' for custom endpoint, got '{}'."
             " Stale provider-prefix must be stripped.".format(model)
         )
-        assert base_url == 'http://my-proxy.local:8080/v1'
-        assert provider == 'custom'
+        assert base_url == "http://my-proxy.local:8080/v1"
+        assert provider == "custom"
 
     def test_bare_model_unchanged_for_custom_endpoint(self):
         """Bare model ID (no slash) must pass through untouched with custom base_url."""
         model, provider, base_url = self._resolve(
-            'gpt-4o',
-            provider='custom',
-            base_url='http://my-proxy.local:8080/v1',
+            "gpt-4o",
+            provider="custom",
+            base_url="http://my-proxy.local:8080/v1",
         )
-        assert model == 'gpt-4o', (
+        assert model == "gpt-4o", (
             "Bare model 'gpt-4o' should not be modified, got '{}'.".format(model)
         )
-        assert base_url == 'http://my-proxy.local:8080/v1'
-        assert provider == 'custom'
+        assert base_url == "http://my-proxy.local:8080/v1"
+        assert provider == "custom"
 
     def test_prefixed_model_kept_for_openrouter(self):
         """When NO custom base_url (openrouter route), prefixed model must stay prefixed."""
         model, provider, base_url = self._resolve(
-            'openai/gpt-5.4',
-            provider='anthropic',  # cross-provider pick triggers openrouter routing
+            "openai/gpt-5.4",
+            provider="anthropic",  # cross-provider pick triggers openrouter routing
         )
         # Cross-provider model with openrouter routing must keep full provider/model path
-        assert 'openai/gpt-5.4' in model or provider == 'openrouter', (
+        assert "openai/gpt-5.4" in model or provider == "openrouter", (
             "Expected prefixed model or openrouter routing for non-custom endpoint, "
             "got model='{}', provider='{}'.".format(model, provider)
         )
         assert base_url is None, (
             "OpenRouter routing must not set a base_url, got '{}'.".format(base_url)
         )
+
 
 # ── #455 workspace chip ─────────────────────────────────────────────
 class TestWorkspaceChipAfterProfileSwitch(unittest.TestCase):
@@ -207,61 +208,79 @@ class TestWorkspaceChipAfterProfileSwitch(unittest.TestCase):
         the code must call syncTopbar() so the profile/workspace chips reflect
         the new profile's default workspace."""
         # Find the sessionInProgress block
-        idx = PANELS_JS.find('if (sessionInProgress)')
+        idx = PANELS_JS.find("if (sessionInProgress)")
         self.assertGreater(idx, -1, "sessionInProgress branch must exist in panels.js")
 
         # Slice from that point to cover the relevant block
-        block = PANELS_JS[idx:idx + 1000]
+        block = PANELS_JS[idx : idx + 1000]
 
         # newSession(false) must be called first
-        self.assertIn('await newSession(false)', block,
-                      "sessionInProgress branch must call await newSession(false)")
+        self.assertIn(
+            "await newSession(false)",
+            block,
+            "sessionInProgress branch must call await newSession(false)",
+        )
 
         # The fix: syncTopbar() must be called after newSession(false)
-        pos_new_session = block.find('await newSession(false)')
-        pos_sync_topbar = block.find('syncTopbar()')
-        self.assertGreater(pos_sync_topbar, -1,
-                           "syncTopbar() must be called in the sessionInProgress branch")
-        self.assertGreater(pos_sync_topbar, pos_new_session,
-                           "syncTopbar() must be called AFTER newSession(false)")
+        pos_new_session = block.find("await newSession(false)")
+        pos_sync_topbar = block.find("syncTopbar()")
+        self.assertGreater(
+            pos_sync_topbar,
+            -1,
+            "syncTopbar() must be called in the sessionInProgress branch",
+        )
+        self.assertGreater(
+            pos_sync_topbar,
+            pos_new_session,
+            "syncTopbar() must be called AFTER newSession(false)",
+        )
 
     def test_profile_default_workspace_applied_to_new_session(self):
         """After newSession(false) the code must assign S._profileDefaultWorkspace
         to S.session.workspace so the session is correctly tagged."""
-        idx = PANELS_JS.find('if (sessionInProgress)')
+        idx = PANELS_JS.find("if (sessionInProgress)")
         self.assertGreater(idx, -1)
-        block = PANELS_JS[idx:idx + 1000]
+        block = PANELS_JS[idx : idx + 1000]
 
         # The fix block must set S.session.workspace from S._profileDefaultWorkspace
-        self.assertIn('S.session.workspace = S._profileDefaultWorkspace', block,
-                      "S.session.workspace must be set from S._profileDefaultWorkspace "
-                      "in the sessionInProgress branch after newSession(false)")
+        self.assertIn(
+            "S.session.workspace = S._profileDefaultWorkspace",
+            block,
+            "S.session.workspace must be set from S._profileDefaultWorkspace "
+            "in the sessionInProgress branch after newSession(false)",
+        )
 
     def test_api_session_update_called_for_new_session_workspace(self):
         """The fix must call /api/session/update to persist the workspace on the server."""
-        idx = PANELS_JS.find('if (sessionInProgress)')
+        idx = PANELS_JS.find("if (sessionInProgress)")
         self.assertGreater(idx, -1)
-        block = PANELS_JS[idx:idx + 1000]
+        block = PANELS_JS[idx : idx + 1000]
 
         # Must patch the session on the backend too
-        self.assertIn('/api/session/update', block,
-                      "The sessionInProgress branch must call /api/session/update "
-                      "to persist the new workspace after newSession(false)")
+        self.assertIn(
+            "/api/session/update",
+            block,
+            "The sessionInProgress branch must call /api/session/update "
+            "to persist the new workspace after newSession(false)",
+        )
 
     def test_sync_topbar_before_render_session_list(self):
         """syncTopbar() should be called before renderSessionList()
         so the chips are correct when the UI re-renders."""
-        idx = PANELS_JS.find('if (sessionInProgress)')
+        idx = PANELS_JS.find("if (sessionInProgress)")
         self.assertGreater(idx, -1)
-        block = PANELS_JS[idx:idx + 1000]
+        block = PANELS_JS[idx : idx + 1000]
 
-        pos_sync = block.find('syncTopbar()')
-        pos_render = block.find('await renderSessionList()')
+        pos_sync = block.find("syncTopbar()")
+        pos_render = block.find("await renderSessionList()")
         self.assertGreater(pos_sync, -1, "syncTopbar() must exist in block")
         self.assertGreater(pos_render, -1, "renderSessionList() must exist in block")
-        self.assertLess(pos_sync, pos_render,
-                        "syncTopbar() must be called before renderSessionList()")
+        self.assertLess(
+            pos_sync,
+            pos_render,
+            "syncTopbar() must be called before renderSessionList()",
+        )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_sprint41.py
+++ b/tests/test_sprint41.py
@@ -11,6 +11,7 @@ Covers:
 - style.css: #btnCollapseWorkspacePanel hidden in <=900px media query
 - index.html: both .mobile-close-btn and #btnCollapseWorkspacePanel buttons exist
 """
+
 import pathlib
 import re
 import unittest
@@ -24,6 +25,7 @@ STREAMING_PY = (REPO_ROOT / "api" / "streaming.py").read_text()
 
 # ── streaming.py: title auto-generation condition ─────────────────────────
 
+
 class TestTitleAutoGenerationCondition(unittest.TestCase):
     """Verify the guarded condition in streaming.py covers all default title cases."""
 
@@ -31,11 +33,13 @@ class TestTitleAutoGenerationCondition(unittest.TestCase):
         """Extract the condition from the source so tests stay in sync with code."""
         # Find the if-condition that calls title_from
         m = re.search(
-            r'if\s+(s\.title\s*==.*?):\s*\n\s*s\.title\s*=\s*title_from',
+            r"if\s+(s\.title\s*==.*?):\s*\n\s*s\.title\s*=\s*title_from",
             STREAMING_PY,
             re.DOTALL,
         )
-        self.assertIsNotNone(m, "Could not find title auto-generation condition in streaming.py")
+        self.assertIsNotNone(
+            m, "Could not find title auto-generation condition in streaming.py"
+        )
         return m.group(1)
 
     def test_untitled_in_condition(self):
@@ -48,18 +52,24 @@ class TestTitleAutoGenerationCondition(unittest.TestCase):
 
     def test_empty_title_guard_in_condition(self):
         cond = self._titles_that_trigger()
-        self.assertIn("not s.title", cond, "Empty/falsy title guard must be present (PR #333)")
+        self.assertIn(
+            "not s.title", cond, "Empty/falsy title guard must be present (PR #333)"
+        )
 
     def test_condition_logic_covers_all_defaults(self):
         """The condition uses OR so any one default title triggers generation."""
         cond = self._titles_that_trigger()
         # All three guards must be joined by 'or'
-        parts = re.split(r'\bor\b', cond)
-        self.assertGreaterEqual(len(parts), 3,
-            "Expected at least 3 OR-joined sub-conditions (Untitled, New Chat, not s.title)")
+        parts = re.split(r"\bor\b", cond)
+        self.assertGreaterEqual(
+            len(parts),
+            3,
+            "Expected at least 3 OR-joined sub-conditions (Untitled, New Chat, not s.title)",
+        )
 
 
 # ── style.css: mobile close button visibility ─────────────────────────────
+
 
 class TestMobileCloseButtonCSS(unittest.TestCase):
     """Verify CSS rules that control the duplicate close button on mobile."""
@@ -71,59 +81,81 @@ class TestMobileCloseButtonCSS(unittest.TestCase):
         self.assertIn(
             ".mobile-close-btn{display:none;}",
             CSS.replace(" ", ""),
-            ".mobile-close-btn should be hidden by default (desktop) — rule missing or wrong"
+            ".mobile-close-btn should be hidden by default (desktop) — rule missing or wrong",
         )
 
     def test_mobile_close_btn_shown_in_900px_query(self):
         """Inside max-width:900px media query, .mobile-close-btn must be display:flex."""
         # Extract the 900px media block
-        m = re.search(r'@media\s*\(max-width\s*:\s*900px\)\s*\{([^{}]*(?:\{[^{}]*\}[^{}]*)*)\}',
-                      CSS)
+        m = re.search(
+            r"@media\s*\(max-width\s*:\s*900px\)\s*\{([^{}]*(?:\{[^{}]*\}[^{}]*)*)\}",
+            CSS,
+        )
         self.assertIsNotNone(m, "@media(max-width:900px) block not found in style.css")
         block = m.group(1).replace(" ", "")
-        self.assertIn(".mobile-close-btn{display:flex;}",
-                      block,
-                      ".mobile-close-btn must be display:flex inside the 900px media query")
+        self.assertIn(
+            ".mobile-close-btn{display:flex;}",
+            block,
+            ".mobile-close-btn must be display:flex inside the 900px media query",
+        )
 
     def test_desktop_collapse_btn_hidden_in_900px_query(self):
         """Inside max-width:900px media query, #btnCollapseWorkspacePanel must be display:none."""
-        m = re.search(r'@media\s*\(max-width\s*:\s*900px\)\s*\{([^{}]*(?:\{[^{}]*\}[^{}]*)*)\}',
-                      CSS)
+        m = re.search(
+            r"@media\s*\(max-width\s*:\s*900px\)\s*\{([^{}]*(?:\{[^{}]*\}[^{}]*)*)\}",
+            CSS,
+        )
         self.assertIsNotNone(m, "@media(max-width:900px) block not found in style.css")
         block = m.group(1).replace(" ", "")
-        self.assertIn("#btnCollapseWorkspacePanel{display:none;}",
-                      block,
-                      "#btnCollapseWorkspacePanel must be display:none in 900px media query")
+        self.assertIn(
+            "#btnCollapseWorkspacePanel{display:none;}",
+            block,
+            "#btnCollapseWorkspacePanel must be display:none in 900px media query",
+        )
 
     def test_900px_query_retains_existing_rules(self):
         """Ensure the PR didn't accidentally drop existing rules from the 900px block."""
-        m = re.search(r'@media\s*\(max-width\s*:\s*900px\)\s*\{([^{}]*(?:\{[^{}]*\}[^{}]*)*)\}',
-                      CSS)
+        m = re.search(
+            r"@media\s*\(max-width\s*:\s*900px\)\s*\{([^{}]*(?:\{[^{}]*\}[^{}]*)*)\}",
+            CSS,
+        )
         self.assertIsNotNone(m)
         block = m.group(1)
         self.assertIn("rightpanel", block, ".rightpanel rule missing from 900px block")
-        self.assertIn("mobile-files-btn", block, ".mobile-files-btn rule missing from 900px block")
+        self.assertIn(
+            "mobile-files-btn", block, ".mobile-files-btn rule missing from 900px block"
+        )
 
 
 # ── index.html: button presence ───────────────────────────────────────────
+
 
 class TestWorkspacePanelButtons(unittest.TestCase):
     """Verify both panel buttons are present in the HTML so CSS rules have targets."""
 
     def test_desktop_collapse_button_exists(self):
-        self.assertIn("btnCollapseWorkspacePanel", HTML,
-                      "#btnCollapseWorkspacePanel button must exist in index.html")
+        self.assertIn(
+            "btnCollapseWorkspacePanel",
+            HTML,
+            "#btnCollapseWorkspacePanel button must exist in index.html",
+        )
 
     def test_mobile_close_button_exists(self):
-        self.assertIn("mobile-close-btn", HTML,
-                      ".mobile-close-btn button must exist in index.html")
+        self.assertIn(
+            "mobile-close-btn",
+            HTML,
+            ".mobile-close-btn button must exist in index.html",
+        )
 
     def test_mobile_close_button_has_aria_label(self):
         """Accessibility: mobile close button must have an aria-label."""
         m = re.search(r'class="[^"]*mobile-close-btn[^"]*"[^>]*>', HTML)
         self.assertIsNotNone(m, "Could not find mobile-close-btn element")
-        self.assertIn("aria-label", m.group(0),
-                      "mobile-close-btn must have aria-label for accessibility")
+        self.assertIn(
+            "aria-label",
+            m.group(0),
+            "mobile-close-btn must have aria-label for accessibility",
+        )
 
 
 class TestIssue495TitleStreaming(unittest.TestCase):
@@ -209,7 +241,8 @@ class TestIssue495TitleStreaming(unittest.TestCase):
             "messages.js title listener should sync top bar title",
         )
         self.assertTrue(
-            ("renderSessionListFromCache()" in MESSAGES_JS) or ("renderSessionList()" in MESSAGES_JS),
+            ("renderSessionListFromCache()" in MESSAGES_JS)
+            or ("renderSessionList()" in MESSAGES_JS),
             "messages.js title listener should refresh session list UI",
         )
 
@@ -285,7 +318,9 @@ class TestIssue495TitleStreaming(unittest.TestCase):
         ]
 
         derived = title_from(messages, "")
-        current = derived[:63]  # Simulate the provisional title the UI writes immediately.
+        current = derived[
+            :63
+        ]  # Simulate the provisional title the UI writes immediately.
 
         self.assertNotEqual(current, derived[:64])
         self.assertTrue(

--- a/tests/test_sprint42.py
+++ b/tests/test_sprint42.py
@@ -8,9 +8,9 @@ Covers:
 - streaming.py: SessionDB init failure prints a WARNING (not silently swallowed)
 - streaming.py: SessionDB init is placed before AIAgent construction
 """
+
 import ast
 import pathlib
-import re
 import queue
 import sys
 import types
@@ -24,15 +24,18 @@ STREAMING_PY = (REPO_ROOT / "api" / "streaming.py").read_text()
 # ── Shared helpers for sprint-42 additional tests ────────────────────────────
 
 REPO = REPO_ROOT  # alias used by #427 tests
-_SESSIONS_JS = REPO_ROOT / 'static' / 'sessions.js'
-_STREAMING_PY = REPO_ROOT / 'api' / 'streaming.py'
-_MESSAGES_JS = REPO_ROOT / 'static' / 'messages.js'
-_UI_JS = REPO_ROOT / 'static' / 'ui.js'
+_SESSIONS_JS = REPO_ROOT / "static" / "sessions.js"
+_STREAMING_PY = REPO_ROOT / "api" / "streaming.py"
+_MESSAGES_JS = REPO_ROOT / "static" / "messages.js"
+_UI_JS = REPO_ROOT / "static" / "ui.js"
+
 
 def _read_sessions_js():
-    return _SESSIONS_JS.read_text(encoding='utf-8')
+    return _SESSIONS_JS.read_text(encoding="utf-8")
+
 
 # ─────────────────────────────────────────────────────────────────────────────
+
 
 class TestSessionDBInjection(unittest.TestCase):
     """Verify SessionDB is initialized and passed to AIAgent in streaming.py."""
@@ -170,20 +173,43 @@ class TestRuntimeRouteInjection(unittest.TestCase):
                 }
 
         class CapturingAgent:
-            def __init__(self, model=None, provider=None, base_url=None, api_key=None,
-                         api_mode=None, acp_command=None, acp_args=None,
-                         credential_pool=None, platform=None, quiet_mode=False,
-                         enabled_toolsets=None, fallback_model=None, session_id=None,
-                         session_db=None, stream_delta_callback=None,
-                         reasoning_callback=None, tool_progress_callback=None,
-                         clarify_callback=None, **kwargs):
+            def __init__(
+                self,
+                model=None,
+                provider=None,
+                base_url=None,
+                api_key=None,
+                api_mode=None,
+                acp_command=None,
+                acp_args=None,
+                credential_pool=None,
+                platform=None,
+                quiet_mode=False,
+                enabled_toolsets=None,
+                fallback_model=None,
+                session_id=None,
+                session_db=None,
+                stream_delta_callback=None,
+                reasoning_callback=None,
+                tool_progress_callback=None,
+                clarify_callback=None,
+                **kwargs,
+            ):
                 captured["init_kwargs"] = dict(
-                    model=model, provider=provider, base_url=base_url,
-                    api_key=api_key, api_mode=api_mode, acp_command=acp_command,
-                    acp_args=acp_args, credential_pool=credential_pool,
-                    platform=platform, quiet_mode=quiet_mode,
-                    enabled_toolsets=enabled_toolsets, fallback_model=fallback_model,
-                    session_id=session_id, session_db=session_db,
+                    model=model,
+                    provider=provider,
+                    base_url=base_url,
+                    api_key=api_key,
+                    api_mode=api_mode,
+                    acp_command=acp_command,
+                    acp_args=acp_args,
+                    credential_pool=credential_pool,
+                    platform=platform,
+                    quiet_mode=quiet_mode,
+                    enabled_toolsets=enabled_toolsets,
+                    fallback_model=fallback_model,
+                    session_id=session_id,
+                    session_db=session_db,
                     stream_delta_callback=stream_delta_callback,
                     reasoning_callback=reasoning_callback,
                     tool_progress_callback=tool_progress_callback,
@@ -220,19 +246,25 @@ class TestRuntimeRouteInjection(unittest.TestCase):
         fake_hermes_state = types.ModuleType("hermes_state")
         fake_hermes_state.SessionDB = mock.Mock(return_value=fake_session_db)
 
-        with mock.patch.object(streaming, "get_session", return_value=fake_session), \
-             mock.patch.object(streaming, "_get_ai_agent", return_value=CapturingAgent), \
-             mock.patch.object(streaming, "resolve_model_provider", return_value=("gpt-5.4", "openai-codex", None)), \
-             mock.patch("api.config.get_config", return_value={}), \
-             mock.patch("api.config._resolve_cli_toolsets", return_value=[]), \
-             mock.patch.dict(
-                 sys.modules,
-                 {
-                     "hermes_cli": fake_hermes_cli,
-                     "hermes_cli.runtime_provider": fake_runtime_module,
-                     "hermes_state": fake_hermes_state,
-                 },
-             ):
+        with (
+            mock.patch.object(streaming, "get_session", return_value=fake_session),
+            mock.patch.object(streaming, "_get_ai_agent", return_value=CapturingAgent),
+            mock.patch.object(
+                streaming,
+                "resolve_model_provider",
+                return_value=("gpt-5.4", "openai-codex", None),
+            ),
+            mock.patch("api.config.get_config", return_value={}),
+            mock.patch("api.config._resolve_cli_toolsets", return_value=[]),
+            mock.patch.dict(
+                sys.modules,
+                {
+                    "hermes_cli": fake_hermes_cli,
+                    "hermes_cli.runtime_provider": fake_runtime_module,
+                    "hermes_state": fake_hermes_state,
+                },
+            ),
+        ):
             streaming.STREAMS[fake_stream_id] = fake_queue
             streaming._run_agent_streaming(
                 session_id=fake_session.session_id,
@@ -278,10 +310,16 @@ class TestRuntimeRouteInjection(unittest.TestCase):
                 **kwargs,
             ):
                 captured["init_kwargs"] = dict(
-                    model=model, provider=provider, base_url=base_url, api_key=api_key,
-                    platform=platform, quiet_mode=quiet_mode,
-                    enabled_toolsets=enabled_toolsets, fallback_model=fallback_model,
-                    session_id=session_id, session_db=session_db,
+                    model=model,
+                    provider=provider,
+                    base_url=base_url,
+                    api_key=api_key,
+                    platform=platform,
+                    quiet_mode=quiet_mode,
+                    enabled_toolsets=enabled_toolsets,
+                    fallback_model=fallback_model,
+                    session_id=session_id,
+                    session_db=session_db,
                     stream_delta_callback=stream_delta_callback,
                     reasoning_callback=reasoning_callback,
                     tool_progress_callback=tool_progress_callback,
@@ -300,10 +338,15 @@ class TestRuntimeRouteInjection(unittest.TestCase):
 
             def run_conversation(self, **kwargs):
                 if self.interim_assistant_callback:
-                    self.interim_assistant_callback("Inspecting repo structure.", already_streamed=False)
+                    self.interim_assistant_callback(
+                        "Inspecting repo structure.", already_streamed=False
+                    )
                 return {
                     "messages": [
-                        {"role": "user", "content": kwargs.get("persist_user_message", "")},
+                        {
+                            "role": "user",
+                            "content": kwargs.get("persist_user_message", ""),
+                        },
                         {"role": "assistant", "content": "ok"},
                     ]
                 }
@@ -332,12 +375,20 @@ class TestRuntimeRouteInjection(unittest.TestCase):
 
             def compact(self):
                 return {
-                    "session_id": self.session_id, "title": self.title,
-                    "workspace": self.workspace, "model": self.model,
-                    "created_at": 0, "updated_at": 0, "pinned": False,
-                    "archived": False, "project_id": None, "profile": None,
-                    "input_tokens": 0, "output_tokens": 0,
-                    "estimated_cost": None, "personality": None,
+                    "session_id": self.session_id,
+                    "title": self.title,
+                    "workspace": self.workspace,
+                    "model": self.model,
+                    "created_at": 0,
+                    "updated_at": 0,
+                    "pinned": False,
+                    "archived": False,
+                    "project_id": None,
+                    "profile": None,
+                    "input_tokens": 0,
+                    "output_tokens": 0,
+                    "estimated_cost": None,
+                    "personality": None,
                 }
 
             @property
@@ -347,30 +398,41 @@ class TestRuntimeRouteInjection(unittest.TestCase):
         fake_stream_id = "stream-interim-callback"
         fake_queue = queue.Queue()
         fake_rt_module = types.ModuleType("hermes_cli.runtime_provider")
-        fake_rt_module.resolve_runtime_provider = mock.Mock(return_value={
-            "provider": "openai-codex",
-            "base_url": "https://api.openai.com/v1",
-            "api_key": "rt-key",
-            "api_mode": "codex_responses",
-            "command": "codex",
-            "args": ["exec", "--json"],
-            "credential_pool": object(),
-        })
+        fake_rt_module.resolve_runtime_provider = mock.Mock(
+            return_value={
+                "provider": "openai-codex",
+                "base_url": "https://api.openai.com/v1",
+                "api_key": "rt-key",
+                "api_mode": "codex_responses",
+                "command": "codex",
+                "args": ["exec", "--json"],
+                "credential_pool": object(),
+            }
+        )
         fake_hermes_cli = types.ModuleType("hermes_cli")
         fake_hermes_cli.runtime_provider = fake_rt_module
         fake_hermes_state = types.ModuleType("hermes_state")
         fake_hermes_state.SessionDB = mock.Mock(return_value=object())
 
-        with mock.patch.object(streaming, "get_session", return_value=FakeSession()), \
-             mock.patch.object(streaming, "_get_ai_agent", return_value=CapturingAgent), \
-             mock.patch.object(streaming, "resolve_model_provider", return_value=("gpt-4o", "openai-codex", None)), \
-             mock.patch("api.config.get_config", return_value={}), \
-             mock.patch("api.config._resolve_cli_toolsets", return_value=[]), \
-             mock.patch.dict(sys.modules, {
-                 "hermes_cli": fake_hermes_cli,
-                 "hermes_cli.runtime_provider": fake_rt_module,
-                 "hermes_state": fake_hermes_state,
-             }):
+        with (
+            mock.patch.object(streaming, "get_session", return_value=FakeSession()),
+            mock.patch.object(streaming, "_get_ai_agent", return_value=CapturingAgent),
+            mock.patch.object(
+                streaming,
+                "resolve_model_provider",
+                return_value=("gpt-4o", "openai-codex", None),
+            ),
+            mock.patch("api.config.get_config", return_value={}),
+            mock.patch("api.config._resolve_cli_toolsets", return_value=[]),
+            mock.patch.dict(
+                sys.modules,
+                {
+                    "hermes_cli": fake_hermes_cli,
+                    "hermes_cli.runtime_provider": fake_rt_module,
+                    "hermes_state": fake_hermes_state,
+                },
+            ),
+        ):
             streaming.STREAMS[fake_stream_id] = fake_queue
             streaming._run_agent_streaming(
                 session_id="sess-interim-test",
@@ -396,10 +458,11 @@ class TestRuntimeRouteInjection(unittest.TestCase):
         )
         self.assertTrue(
             any(
-                event == "interim_assistant" and event_data.get("text") == "Inspecting repo structure."
+                event == "interim_assistant"
+                and event_data.get("text") == "Inspecting repo structure."
                 for event, event_data in interim_events
             ),
-            "interim_assistant event should carry the assistant commentary text"
+            "interim_assistant event should carry the assistant commentary text",
         )
 
 
@@ -438,168 +501,199 @@ class TestSessionDBAST(unittest.TestCase):
 class TestModelCustomInput(unittest.TestCase):
     """Tests for issue #444 — custom model ID input in model dropdown."""
 
-    STATIC = pathlib.Path(__file__).parent.parent / 'static'
+    STATIC = pathlib.Path(__file__).parent.parent / "static"
 
     def _read(self, filename):
         path = self.STATIC / filename
-        with open(path, 'r', encoding='utf-8') as f:
+        with open(path, "r", encoding="utf-8") as f:
             return f.read()
 
     def _renderModelDropdown_body(self):
-        src = self._read('ui.js')
-        start = src.find('function renderModelDropdown()')
-        end = src.find('\nasync function selectModelFromDropdown', start)
+        src = self._read("ui.js")
+        start = src.find("function renderModelDropdown()")
+        end = src.find("\nasync function selectModelFromDropdown", start)
         return src[start:end]
 
     def test_model_custom_input_in_dropdown(self):
         body = self._renderModelDropdown_body()
-        self.assertIn('model-custom-input', body,
-                      'model-custom-input class must be in renderModelDropdown')
+        self.assertIn(
+            "model-custom-input",
+            body,
+            "model-custom-input class must be in renderModelDropdown",
+        )
 
     def test_model_custom_enter_handler(self):
         body = self._renderModelDropdown_body()
-        self.assertIn('_applyCustom', body,
-                      '_applyCustom function must be defined in renderModelDropdown')
+        self.assertIn(
+            "_applyCustom",
+            body,
+            "_applyCustom function must be defined in renderModelDropdown",
+        )
 
     def test_model_custom_css_defined(self):
-        css = self._read('style.css')
-        self.assertIn('.model-custom-row', css,
-                      '.model-custom-row must be defined in style.css')
-        self.assertIn('.model-custom-input', css,
-                      '.model-custom-input must be defined in style.css')
+        css = self._read("style.css")
+        self.assertIn(
+            ".model-custom-row", css, ".model-custom-row must be defined in style.css"
+        )
+        self.assertIn(
+            ".model-custom-input",
+            css,
+            ".model-custom-input must be defined in style.css",
+        )
 
     def test_model_custom_i18n_keys(self):
-        i18n = self._read('i18n.js')
+        i18n = self._read("i18n.js")
         # Find en locale block (appears first before es)
         en_block_start = i18n.find("'en'")
         es_block_start = i18n.find("'es'")
         en_block = i18n[en_block_start:es_block_start]
-        self.assertIn('model_custom_label', en_block,
-                      'model_custom_label must be in en locale')
-        self.assertIn('model_custom_placeholder', en_block,
-                      'model_custom_placeholder must be in en locale')
+        self.assertIn(
+            "model_custom_label", en_block, "model_custom_label must be in en locale"
+        )
+        self.assertIn(
+            "model_custom_placeholder",
+            en_block,
+            "model_custom_placeholder must be in en locale",
+        )
 
 
 # ── Sprint 42 additional tests: context indicator (#437) ─────────────────
 def test_context_indicator_uses_pick_helper():
     """The _pick helper must be present in sessions.js to prefer latest over stale values."""
     content = _read_sessions_js()
-    assert '_pick' in content, "_pick helper not found in static/sessions.js"
+    assert "_pick" in content, "_pick helper not found in static/sessions.js"
 
 
 def test_context_indicator_old_pattern_removed():
     """The old || pattern that preferred stale session data must be gone."""
     content = _read_sessions_js()
-    assert '_s.input_tokens||u.input_tokens' not in content, \
+    assert "_s.input_tokens||u.input_tokens" not in content, (
         "Old stale-data-first pattern '_s.input_tokens||u.input_tokens' still present in static/sessions.js"
+    )
 
 
 def test_context_indicator_all_six_fields():
     """All six token/cost fields must appear in the _syncCtxIndicator call."""
     content = _read_sessions_js()
     fields = [
-        'input_tokens',
-        'output_tokens',
-        'estimated_cost',
-        'context_length',
-        'last_prompt_tokens',
-        'threshold_tokens',
+        "input_tokens",
+        "output_tokens",
+        "estimated_cost",
+        "context_length",
+        "last_prompt_tokens",
+        "threshold_tokens",
     ]
     for field in fields:
-        assert field in content, \
+        assert field in content, (
             f"Field '{field}' not found in static/sessions.js _syncCtxIndicator call"
+        )
 
 
 # ── Sprint 42 additional tests: system prompt title (#441) ──────────────
 def test_system_prompt_title_guard_exists():
     """The guard that detects [SYSTEM: prefixes must be present in sessions.js."""
     content = _read_sessions_js()
-    assert '[SYSTEM:' in content, \
+    assert "[SYSTEM:" in content, (
         "sessions.js must contain the [SYSTEM: guard to intercept system-prompt titles"
+    )
     # Make sure it appears in an if-condition context, not just a comment
-    assert "cleanTitle.startsWith('[SYSTEM:')" in content, \
+    assert "cleanTitle.startsWith('[SYSTEM:')" in content, (
         "sessions.js must have: cleanTitle.startsWith('[SYSTEM:') guard expression"
+    )
 
 
 def test_cleanTitle_is_let_not_const():
     """cleanTitle must be declared with let (not const) to allow reassignment in the guard."""
     content = _read_sessions_js()
-    assert 'let cleanTitle' in content, \
+    assert "let cleanTitle" in content, (
         "cleanTitle must be declared with 'let' (not 'const') to allow reassignment"
+    )
     # Make sure the old const form is gone in this context
     # (check the specific assignment line pattern)
-    assert "const cleanTitle=tags.length" not in content, \
+    assert "const cleanTitle=tags.length" not in content, (
         "Old 'const cleanTitle=tags.length...' must be replaced by 'let cleanTitle=...'"
+    )
 
 
 # ── Sprint 42 additional tests: thinking panel persistence (#427) ────────
 def test_streaming_persists_reasoning_in_session():
     """streaming.py must accumulate reasoning_text and patch last assistant message."""
-    src = (REPO / 'api' / 'streaming.py').read_text()
+    src = (REPO / "api" / "streaming.py").read_text()
 
     # _reasoning_text must be initialised
-    assert "_reasoning_text = ''" in src, \
+    assert "_reasoning_text = ''" in src, (
         "_reasoning_text variable not initialised in streaming.py"
+    )
 
     # on_reasoning must accumulate into _reasoning_text
-    assert '_reasoning_text += str(text)' in src, \
+    assert "_reasoning_text += str(text)" in src, (
         "on_reasoning callback does not accumulate into _reasoning_text"
+    )
 
     # Persistence block must exist before raw_session is built
-    assert "Persist reasoning trace in the session so it survives reload" in src, \
+    assert "Persist reasoning trace in the session so it survives reload" in src, (
         "Reasoning persistence comment not found in streaming.py"
+    )
 
-    assert "_rm['reasoning'] = _reasoning_text" in src, \
+    assert "_rm['reasoning'] = _reasoning_text" in src, (
         "Code to set _rm['reasoning'] not found in streaming.py"
+    )
 
     # Persistence block must come BEFORE raw_session assignment
     persist_idx = src.index("Persist reasoning trace in the session")
     raw_session_idx = src.index("raw_session = s.compact()")
-    assert persist_idx < raw_session_idx, \
+    assert persist_idx < raw_session_idx, (
         "Reasoning persistence block must appear before raw_session assignment"
+    )
 
 
 def test_done_handler_patches_reasoning_field():
     """messages.js done SSE handler must patch reasoningText onto the last assistant message."""
-    src = (REPO / 'static' / 'messages.js').read_text()
+    src = (REPO / "static" / "messages.js").read_text()
 
     # The persistence comment must be present inside the done handler
-    assert "Persist reasoning trace so thinking card survives page reload" in src, \
+    assert "Persist reasoning trace so thinking card survives page reload" in src, (
         "Reasoning persistence comment not found in messages.js done handler"
+    )
 
     # The guard and assignment must be present
-    assert "if(reasoningText){" in src, \
-        "reasoningText guard not found in messages.js"
+    assert "if(reasoningText){" in src, "reasoningText guard not found in messages.js"
 
-    assert "lastAsst.reasoning=reasoningText" in src, \
+    assert "lastAsst.reasoning=reasoningText" in src, (
         "lastAsst.reasoning assignment not found in messages.js"
+    )
 
     # Verify the patch is inside the done handler (after 'source.addEventListener' for done)
     done_handler_idx = src.index("source.addEventListener('done'")
-    persist_idx = src.index("Persist reasoning trace so thinking card survives page reload")
-    assert done_handler_idx < persist_idx, \
+    persist_idx = src.index(
+        "Persist reasoning trace so thinking card survives page reload"
+    )
+    assert done_handler_idx < persist_idx, (
         "Reasoning persistence patch must be inside the done SSE handler"
+    )
 
     # The guard must also check !lastAsst.reasoning to avoid overwriting server value
-    assert "!lastAsst.reasoning" in src, \
+    assert "!lastAsst.reasoning" in src, (
         "Guard '!lastAsst.reasoning' missing — would overwrite server-persisted reasoning"
+    )
 
 
 def test_rendermessages_reads_reasoning_from_messages():
     """ui.js renderMessages must read m.reasoning to display the thinking card."""
-    src = (REPO / 'static' / 'ui.js').read_text()
+    src = (REPO / "static" / "ui.js").read_text()
 
     # m.reasoning must be read in the render path
-    assert 'm.reasoning' in src, \
+    assert "m.reasoning" in src, (
         "m.reasoning not referenced in ui.js — thinking card won't render on reload"
+    )
 
     # The thinking card rendering block must also be present
-    assert 'thinking-card' in src, \
-        "thinking-card CSS class not found in ui.js"
+    assert "thinking-card" in src, "thinking-card CSS class not found in ui.js"
 
     # Specifically, the fallback that reads from top-level m.reasoning field
-    assert 'thinkingText=m.reasoning' in src.replace(' ', ''), \
+    assert "thinkingText=m.reasoning" in src.replace(" ", ""), (
         "thinkingText=m.reasoning assignment not found in ui.js renderMessages"
+    )
 
 
 def test_streaming_restores_prior_reasoning_metadata_after_followup():
@@ -610,26 +704,33 @@ def test_streaming_restores_prior_reasoning_metadata_after_followup():
     history before saving the session, including reinserting dropped
     reasoning-only assistant segments.
     """
-    src = (REPO / 'api' / 'streaming.py').read_text()
-    assert "def _restore_reasoning_metadata(" in src, \
+    src = (REPO / "api" / "streaming.py").read_text()
+    assert "def _restore_reasoning_metadata(" in src, (
         "streaming.py must define a helper to restore prior reasoning metadata"
-    assert "s.context_messages = _next_context_messages" in src, \
+    )
+    assert "s.context_messages = _next_context_messages" in src, (
         "streaming.py must restore prior reasoning metadata into model context"
-    assert "s.messages = _merge_display_messages_after_agent_result(" in src, \
+    )
+    assert "s.messages = _merge_display_messages_after_agent_result(" in src, (
         "streaming.py must merge restored result messages into the visible transcript"
-    assert "updated_messages.insert(safe_pos, copy.deepcopy(prev_msg))" in src, \
+    )
+    assert "updated_messages.insert(safe_pos, copy.deepcopy(prev_msg))" in src, (
         "streaming.py must reinsert dropped reasoning-only assistant messages"
+    )
 
 
 def test_routes_restores_prior_reasoning_metadata_after_followup():
     """The non-streaming route path must preserve prior reasoning metadata too."""
-    src = (REPO / 'api' / 'routes.py').read_text()
-    assert "_restore_reasoning_metadata" in src, \
+    src = (REPO / "api" / "routes.py").read_text()
+    assert "_restore_reasoning_metadata" in src, (
         "routes.py must import reasoning metadata restoration helper"
-    assert "s.context_messages = _next_context_messages" in src, \
+    )
+    assert "s.context_messages = _next_context_messages" in src, (
         "routes.py must restore prior reasoning metadata into model context"
-    assert 's.messages = _merge_display_messages_after_agent_result(' in src, \
+    )
+    assert "s.messages = _merge_display_messages_after_agent_result(" in src, (
         "routes.py must merge restored result messages into the visible transcript"
+    )
 
 
 class TestCredentialPoolBackwardCompat(unittest.TestCase):
@@ -644,11 +745,24 @@ class TestCredentialPoolBackwardCompat(unittest.TestCase):
 
         class OlderAgent:
             """Simulates a hermes-agent build that predates credential_pool."""
-            def __init__(self, model=None, provider=None, base_url=None, api_key=None,
-                         platform=None, quiet_mode=False, enabled_toolsets=None,
-                         fallback_model=None, session_id=None, session_db=None,
-                         stream_delta_callback=None, reasoning_callback=None,
-                         tool_progress_callback=None, clarify_callback=None):
+
+            def __init__(
+                self,
+                model=None,
+                provider=None,
+                base_url=None,
+                api_key=None,
+                platform=None,
+                quiet_mode=False,
+                enabled_toolsets=None,
+                fallback_model=None,
+                session_id=None,
+                session_db=None,
+                stream_delta_callback=None,
+                reasoning_callback=None,
+                tool_progress_callback=None,
+                clarify_callback=None,
+            ):
                 # No api_mode / acp_command / acp_args / credential_pool params
                 captured["init_kwargs"] = {"session_id": session_id, "model": model}
                 self.session_id = session_id
@@ -663,7 +777,10 @@ class TestCredentialPoolBackwardCompat(unittest.TestCase):
             def run_conversation(self, **kwargs):
                 return {
                     "messages": [
-                        {"role": "user", "content": kwargs.get("persist_user_message", "")},
+                        {
+                            "role": "user",
+                            "content": kwargs.get("persist_user_message", ""),
+                        },
                         {"role": "assistant", "content": "ok"},
                     ]
                 }
@@ -692,37 +809,60 @@ class TestCredentialPoolBackwardCompat(unittest.TestCase):
 
             def compact(self):
                 return {
-                    "session_id": self.session_id, "title": self.title,
-                    "workspace": self.workspace, "model": self.model,
-                    "created_at": 0, "updated_at": 0, "pinned": False,
-                    "archived": False, "project_id": None, "profile": None,
-                    "input_tokens": 0, "output_tokens": 0,
-                    "estimated_cost": None, "personality": None,
+                    "session_id": self.session_id,
+                    "title": self.title,
+                    "workspace": self.workspace,
+                    "model": self.model,
+                    "created_at": 0,
+                    "updated_at": 0,
+                    "pinned": False,
+                    "archived": False,
+                    "project_id": None,
+                    "profile": None,
+                    "input_tokens": 0,
+                    "output_tokens": 0,
+                    "estimated_cost": None,
+                    "personality": None,
                 }
 
         fake_stream_id = "stream-compat-test"
         fake_queue = queue.Queue()
         fake_rt_module = types.ModuleType("hermes_cli.runtime_provider")
-        fake_rt_module.resolve_runtime_provider = mock.Mock(return_value={
-            "provider": "openai", "base_url": None, "api_key": "sk-test",
-            "api_mode": "chat_completions", "command": None, "args": [],
-            "credential_pool": object(),
-        })
+        fake_rt_module.resolve_runtime_provider = mock.Mock(
+            return_value={
+                "provider": "openai",
+                "base_url": None,
+                "api_key": "sk-test",
+                "api_mode": "chat_completions",
+                "command": None,
+                "args": [],
+                "credential_pool": object(),
+            }
+        )
         fake_hermes_cli = types.ModuleType("hermes_cli")
         fake_hermes_cli.runtime_provider = fake_rt_module
         fake_hermes_state = types.ModuleType("hermes_state")
         fake_hermes_state.SessionDB = mock.Mock(return_value=None)
 
-        with mock.patch.object(streaming, "get_session", return_value=FakeSession()), \
-             mock.patch.object(streaming, "_get_ai_agent", return_value=OlderAgent), \
-             mock.patch.object(streaming, "resolve_model_provider", return_value=("gpt-4o", "openai", None)), \
-             mock.patch("api.config.get_config", return_value={}), \
-             mock.patch("api.config._resolve_cli_toolsets", return_value=[]), \
-             mock.patch.dict(sys.modules, {
-                 "hermes_cli": fake_hermes_cli,
-                 "hermes_cli.runtime_provider": fake_rt_module,
-                 "hermes_state": fake_hermes_state,
-             }):
+        with (
+            mock.patch.object(streaming, "get_session", return_value=FakeSession()),
+            mock.patch.object(streaming, "_get_ai_agent", return_value=OlderAgent),
+            mock.patch.object(
+                streaming,
+                "resolve_model_provider",
+                return_value=("gpt-4o", "openai", None),
+            ),
+            mock.patch("api.config.get_config", return_value={}),
+            mock.patch("api.config._resolve_cli_toolsets", return_value=[]),
+            mock.patch.dict(
+                sys.modules,
+                {
+                    "hermes_cli": fake_hermes_cli,
+                    "hermes_cli.runtime_provider": fake_rt_module,
+                    "hermes_state": fake_hermes_state,
+                },
+            ),
+        ):
             streaming.STREAMS[fake_stream_id] = fake_queue
             # Must not raise TypeError
             streaming._run_agent_streaming(

--- a/tests/test_sprint43.py
+++ b/tests/test_sprint43.py
@@ -11,10 +11,9 @@ Covers:
 - Logging: at least 5 modules add a module-level logger (B110 remediation)
 - routes.py: session titles redacted in /api/sessions list response
 """
-import ast
+
 import pathlib
 import re
-import sys
 import unittest
 
 REPO_ROOT = pathlib.Path(__file__).parent.parent
@@ -32,6 +31,7 @@ STATE_SYNC_PY = (REPO_ROOT / "api" / "state_sync.py").read_text()
 
 # ── B324: MD5 usedforsecurity=False ─────────────────────────────────────────
 
+
 class TestMD5SecurityFix(unittest.TestCase):
     """B324: hashlib.md5 must use usedforsecurity=False for non-crypto hashes."""
 
@@ -46,14 +46,18 @@ class TestMD5SecurityFix(unittest.TestCase):
     def test_gateway_watcher_md5_pattern(self):
         """Exact pattern: hashlib.md5(..., usedforsecurity=False)."""
         # Use re.search with DOTALL since the arg may span parens internally
-        import re
         self.assertIsNotNone(
-            re.search(r"hashlib\.md5\(.*?usedforsecurity=False\)", GATEWAY_WATCHER_PY, re.DOTALL),
+            re.search(
+                r"hashlib\.md5\(.*?usedforsecurity=False\)",
+                GATEWAY_WATCHER_PY,
+                re.DOTALL,
+            ),
             "MD5 call must include usedforsecurity=False kwarg",
         )
 
 
 # ── B310: URL scheme validation ──────────────────────────────────────────────
+
 
 class TestUrlSchemeValidation(unittest.TestCase):
     """B310: urllib.request.urlopen must not be called with arbitrary schemes."""
@@ -68,7 +72,7 @@ class TestUrlSchemeValidation(unittest.TestCase):
         # Must check against allowed schemes
         self.assertRegex(
             CONFIG_PY,
-            r'parsed_url\.scheme\s+not\s+in\s+\(',
+            r"parsed_url\.scheme\s+not\s+in\s+\(",
             "config.py: scheme check must use 'not in (...)' pattern",
         )
 
@@ -89,7 +93,7 @@ class TestUrlSchemeValidation(unittest.TestCase):
         )
         self.assertRegex(
             BOOTSTRAP_PY,
-            r'url\.startswith\([^)]+http',
+            r"url\.startswith\([^)]+http",
             "bootstrap.py: must check url starts with http:// or https://",
         )
 
@@ -104,10 +108,13 @@ class TestUrlSchemeValidation(unittest.TestCase):
     def test_config_allows_http_and_https(self):
         """config.py scheme check must permit both http and https."""
         self.assertIn('"http"', CONFIG_PY, "config.py: http must be in allowed schemes")
-        self.assertIn('"https"', CONFIG_PY, "config.py: https must be in allowed schemes")
+        self.assertIn(
+            '"https"', CONFIG_PY, "config.py: https must be in allowed schemes"
+        )
 
 
 # ── B110: Bare except/pass → logger.debug() ─────────────────────────────────
+
 
 class TestBareExceptLogging(unittest.TestCase):
     """B110: bare except/pass blocks must be replaced with logger.debug()."""
@@ -159,6 +166,7 @@ class TestBareExceptLogging(unittest.TestCase):
 
 # ── QuietHTTPServer ──────────────────────────────────────────────────────────
 
+
 class TestQuietHTTPServer(unittest.TestCase):
     """server.py: QuietHTTPServer suppresses client disconnect noise."""
 
@@ -181,7 +189,7 @@ class TestQuietHTTPServer(unittest.TestCase):
     def test_quiet_http_server_used_as_server(self):
         """main() must instantiate QuietHTTPServer not raw ThreadingHTTPServer."""
         # After the class is defined, the server creation should use QuietHTTPServer
-        after_class = SERVER_PY[SERVER_PY.find("class QuietHTTPServer"):]
+        after_class = SERVER_PY[SERVER_PY.find("class QuietHTTPServer") :]
         self.assertIn(
             "QuietHTTPServer(",
             after_class,
@@ -216,7 +224,6 @@ class TestQuietHTTPServer(unittest.TestCase):
 
     def test_sys_imported_in_server(self):
         """server.py must import sys (needed for sys.exc_info)."""
-        import re
         self.assertIsNotNone(
             re.search(r"^import sys", SERVER_PY, re.MULTILINE),
             "server.py: sys must be imported",
@@ -233,6 +240,7 @@ class TestQuietHTTPServer(unittest.TestCase):
 
 # ── Session title redaction in /api/sessions ────────────────────────────────
 
+
 class TestSessionTitleRedaction(unittest.TestCase):
     """routes.py: session titles must be redacted in the sessions list endpoint."""
 
@@ -240,7 +248,7 @@ class TestSessionTitleRedaction(unittest.TestCase):
         """routes.py must call _redact_text on session titles in /api/sessions."""
         self.assertRegex(
             ROUTES_PY,
-            r'_redact_text\([^)]*\btitle\b[^)]*\)',
+            r"_redact_text\([^)]*\btitle\b[^)]*\)",
             "routes.py: session titles must be redacted via _redact_text in /api/sessions",
         )
 

--- a/tests/test_sprint44.py
+++ b/tests/test_sprint44.py
@@ -11,6 +11,7 @@ Covers:
 - boot.js: handleWorkspaceClose() logic — clears preview when one is visible,
   closes panel otherwise (existing function, confirmed wired to both buttons).
 """
+
 import pathlib
 import re
 import unittest
@@ -64,6 +65,7 @@ class TestMobileCloseButtonBehavior(unittest.TestCase):
             BOOT_JS,
             "handleWorkspaceClose() must call clearPreview() when preview is visible",
         )
+
     def test_handle_workspace_close_falls_back_to_close_panel(self):
         """handleWorkspaceClose() must call closeWorkspacePanel() as fallback."""
         # Find the function start and extract until the closing brace by scanning
@@ -105,7 +107,9 @@ class TestDesktopNoDuplicateXButton(unittest.TestCase):
     def test_clear_preview_toggle_only_applied_on_desktop(self):
         """The display toggle must be guarded by !isCompact so mobile is unaffected."""
         # Expect: if(!isCompact) clearBtn.style.display=...
-        pattern = r"isCompact.*clearBtn\.style\.display|clearBtn\.style\.display.*isCompact"
+        pattern = (
+            r"isCompact.*clearBtn\.style\.display|clearBtn\.style\.display.*isCompact"
+        )
         self.assertRegex(
             BOOT_JS,
             pattern,

--- a/tests/test_sprint45.py
+++ b/tests/test_sprint45.py
@@ -7,6 +7,7 @@ Covers:
 - Legacy assistant_language is no longer exposed and is removed on the next save
 - The local reply-language UI/runtime enhancement is gone from the synced codebase
 """
+
 import json
 import pathlib
 import urllib.error
@@ -15,14 +16,19 @@ import urllib.request
 import os
 
 from tests._pytest_port import BASE
+
 REPO = pathlib.Path(__file__).parent.parent
+
+
 # Use HERMES_WEBUI_TEST_STATE_DIR if available (set by conftest for the test process),
 # falling back to the conventional webui-mvp-test path.
 def _get_settings_file() -> pathlib.Path:
     """Resolve SETTINGS_FILE at call time (env var set by conftest after module import)."""
     state_dir = pathlib.Path(
-        os.environ.get("HERMES_WEBUI_TEST_STATE_DIR",
-                       str(pathlib.Path.home() / ".hermes" / "webui-mvp-test"))
+        os.environ.get(
+            "HERMES_WEBUI_TEST_STATE_DIR",
+            str(pathlib.Path.home() / ".hermes" / "webui-mvp-test"),
+        )
     )
     return state_dir / "settings.json"
 
@@ -70,7 +76,9 @@ def test_first_password_enablement_returns_cookie_and_keeps_browser_logged_in():
     original_settings = _snapshot_settings_file()
     cookie_header = None  # captured for teardown use
     try:
-        saved, status, headers = post("/api/settings", {"_set_password": "sprint45-secret"})
+        saved, status, headers = post(
+            "/api/settings", {"_set_password": "sprint45-secret"}
+        )
         assert status == 200
         assert saved["auth_enabled"] is True
         assert saved["logged_in"] is True
@@ -80,7 +88,9 @@ def test_first_password_enablement_returns_cookie_and_keeps_browser_logged_in():
         assert "hermes_session=" in set_cookie
         cookie_header = set_cookie.split(";", 1)[0]
 
-        auth, auth_status, _ = get("/api/auth/status", headers={"Cookie": cookie_header})
+        auth, auth_status, _ = get(
+            "/api/auth/status", headers={"Cookie": cookie_header}
+        )
         assert auth_status == 200
         assert auth["auth_enabled"] is True
         assert auth["logged_in"] is True
@@ -96,10 +106,13 @@ def test_first_password_enablement_returns_cookie_and_keeps_browser_logged_in():
         # First: write a clean settings file (no password_hash) directly to disk
         try:
             import json as _json
+
             clean = _json.loads(original_settings) if original_settings else {}
             clean.pop("password_hash", None)
             _get_settings_file().parent.mkdir(parents=True, exist_ok=True)
-            _get_settings_file().write_text(_json.dumps(clean, indent=2), encoding="utf-8")
+            _get_settings_file().write_text(
+                _json.dumps(clean, indent=2), encoding="utf-8"
+            )
         except Exception:
             pass
         # Then: tell the server to clear auth via API (must use the session cookie)
@@ -153,5 +166,3 @@ def test_reply_language_customization_ui_and_runtime_are_removed():
     assert "settingsAssistantLanguage" not in panels_js
     assert "assistant_language" not in streaming_py
     assert "Default reply language:" not in streaming_py
-
-

--- a/tests/test_sprint46.py
+++ b/tests/test_sprint46.py
@@ -11,7 +11,6 @@ import types
 from api.models import Session
 from api.config import SESSION_DIR
 from api.routes import _handle_session_compress
-from tests._pytest_port import BASE
 
 
 class _FakeHandler:
@@ -95,6 +94,7 @@ def test_session_compress_roundtrip(monkeypatch, cleanup_test_sessions):
     monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
 
     import api.config as _cfg
+
     fake_runtime_provider = types.ModuleType("hermes_cli.runtime_provider")
     fake_runtime_provider.resolve_runtime_provider = lambda requested=None: {
         "api_key": "fake-key",
@@ -105,7 +105,9 @@ def test_session_compress_roundtrip(monkeypatch, cleanup_test_sessions):
     fake_hermes_cli.__path__ = []
     fake_hermes_cli.runtime_provider = fake_runtime_provider
     monkeypatch.setitem(sys.modules, "hermes_cli", fake_hermes_cli)
-    monkeypatch.setitem(sys.modules, "hermes_cli.runtime_provider", fake_runtime_provider)
+    monkeypatch.setitem(
+        sys.modules, "hermes_cli.runtime_provider", fake_runtime_provider
+    )
     import hermes_cli.runtime_provider as _rtp
 
     monkeypatch.setattr(
@@ -129,7 +131,9 @@ def test_session_compress_roundtrip(monkeypatch, cleanup_test_sessions):
     )
 
     handler = _FakeHandler()
-    _handle_session_compress(handler, {"session_id": sid, "focus_topic": "database schema"})
+    _handle_session_compress(
+        handler, {"session_id": sid, "focus_topic": "database schema"}
+    )
 
     assert handler.status == 200
     payload = handler.payload()
@@ -142,13 +146,18 @@ def test_session_compress_roundtrip(monkeypatch, cleanup_test_sessions):
         {"role": "assistant", "content": "four"},
     ]
     assert _FakeAgent.last_instance is not None
-    assert _FakeAgent.last_instance.context_compressor.calls[0]["focus_topic"] == "database schema"
+    assert (
+        _FakeAgent.last_instance.context_compressor.calls[0]["focus_topic"]
+        == "database schema"
+    )
 
 
 def test_static_commands_js_registers_compress_alias(cleanup_test_sessions):
     from pathlib import Path
 
-    with open(Path(__file__).resolve().parents[1] / "static" / "commands.js", encoding="utf-8") as f:
+    with open(
+        Path(__file__).resolve().parents[1] / "static" / "commands.js", encoding="utf-8"
+    ) as f:
         src = f.read()
     assert "name:'compress'" in src
     assert "name:'compact'" in src
@@ -160,8 +169,13 @@ def test_static_commands_js_registers_compress_alias(cleanup_test_sessions):
 def test_static_commands_js_prefers_persisted_reference_message(cleanup_test_sessions):
     from pathlib import Path
 
-    with open(Path(__file__).resolve().parents[1] / "static" / "commands.js", encoding="utf-8") as f:
+    with open(
+        Path(__file__).resolve().parents[1] / "static" / "commands.js", encoding="utf-8"
+    ) as f:
         src = f.read()
 
-    assert "const messageRef=referenceMsg?msgContent(referenceMsg)||String(referenceMsg.content||''):'';" in src
+    assert (
+        "const messageRef=referenceMsg?msgContent(referenceMsg)||String(referenceMsg.content||''):'';"
+        in src
+    )
     assert "const referenceText=messageRef || summaryRef;" in src

--- a/tests/test_sprint47.py
+++ b/tests/test_sprint47.py
@@ -7,6 +7,7 @@ Covers:
 - boot.js primes the async skill load when typing '/'
 - the dropdown marks skill-backed entries visually
 """
+
 import pathlib
 
 
@@ -24,9 +25,10 @@ def test_skill_commands_are_loaded_from_api_skills_for_autocomplete():
 
 def test_builtin_commands_take_precedence_over_skill_slug_collisions():
     # In the combined implementation, REGISTRY (agent registry + WEBUI_ONLY) wins over skills
-    assert ("if(COMMANDS.some(c=>c.name===slug)) return null;" in COMMANDS_JS or
-            "if(REGISTRY.some(c=>c.name===slug)) return null;" in COMMANDS_JS), \
-        "Built-in commands must block skill slug collisions"
+    assert (
+        "if(COMMANDS.some(c=>c.name===slug)) return null;" in COMMANDS_JS
+        or "if(REGISTRY.some(c=>c.name===slug)) return null;" in COMMANDS_JS
+    ), "Built-in commands must block skill slug collisions"
 
 
 def test_typing_slash_primes_async_skill_command_loading():

--- a/tests/test_sprint48.py
+++ b/tests/test_sprint48.py
@@ -20,6 +20,7 @@ def read(rel):
 
 # ── Bug #702 — XML tool-call leak on DeepSeek ────────────────────────────────
 
+
 class TestXmlToolCallStrip:
     """_strip_xml_tool_calls() is defined in api/streaming.py and must remove
     <function_calls>...</function_calls> blocks from assistant content."""
@@ -27,49 +28,58 @@ class TestXmlToolCallStrip:
     def _load_fn(self):
         """Import the helper from streaming.py without triggering full server
         initialisation (which would fail in unit-test contexts)."""
-        import importlib, sys, types
+        import sys
+        import types
 
         # Stub heavy transitive imports so we can import the module cleanly.
-        for mod in ('api.config', 'api.helpers', 'api.models', 'api.workspace'):
+        for mod in ("api.config", "api.helpers", "api.models", "api.workspace"):
             if mod not in sys.modules:
                 sys.modules[mod] = types.ModuleType(mod)
 
         # Provide minimal symbols that streaming.py needs at import time.
-        cfg = sys.modules.setdefault('api.config', types.ModuleType('api.config'))
-        for attr in ('STREAMS', 'STREAMS_LOCK', 'CANCEL_FLAGS', 'AGENT_INSTANCES',
-                     'LOCK', 'SESSIONS', 'SESSION_DIR',
-                     '_get_session_agent_lock', '_set_thread_env',
-                     '_clear_thread_env', 'resolve_model_provider'):
+        cfg = sys.modules.setdefault("api.config", types.ModuleType("api.config"))
+        for attr in (
+            "STREAMS",
+            "STREAMS_LOCK",
+            "CANCEL_FLAGS",
+            "AGENT_INSTANCES",
+            "LOCK",
+            "SESSIONS",
+            "SESSION_DIR",
+            "_get_session_agent_lock",
+            "_set_thread_env",
+            "_clear_thread_env",
+            "resolve_model_provider",
+        ):
             if not hasattr(cfg, attr):
                 setattr(cfg, attr, None)
 
         # Fall back to reading the source and exec-ing just the function.
-        src = read('api/streaming.py')
+        src = read("api/streaming.py")
         ns: dict = {}
         # Extract the function definition with regex so we don't need to import
         # the whole module (avoids all the heavy deps).
         match = re.search(
-            r'(def _strip_xml_tool_calls\(.*?)\n(?=\ndef |\nclass )',
-            src, re.DOTALL
+            r"(def _strip_xml_tool_calls\(.*?)\n(?=\ndef |\nclass )", src, re.DOTALL
         )
         assert match, "_strip_xml_tool_calls not found in api/streaming.py"
-        exec(compile('import re\n' + match.group(1), '<streaming_extract>', 'exec'), ns)
-        return ns['_strip_xml_tool_calls']
+        exec(compile("import re\n" + match.group(1), "<streaming_extract>", "exec"), ns)
+        return ns["_strip_xml_tool_calls"]
 
     def test_complete_block_removed(self):
         fn = self._load_fn()
         text = "Hello <function_calls><invoke>foo</invoke></function_calls> world"
         result = fn(text)
-        assert '<function_calls>' not in result
-        assert 'Hello' in result
-        assert 'world' in result
+        assert "<function_calls>" not in result
+        assert "Hello" in result
+        assert "world" in result
 
     def test_orphaned_opening_tag_removed(self):
         fn = self._load_fn()
         text = "Some answer text\n<function_calls>\n<invoke>tool</invoke>"
         result = fn(text)
-        assert '<function_calls>' not in result
-        assert 'Some answer text' in result
+        assert "<function_calls>" not in result
+        assert "Some answer text" in result
 
     def test_no_tag_unchanged(self):
         fn = self._load_fn()
@@ -83,122 +93,122 @@ class TestXmlToolCallStrip:
             "middle <function_calls><invoke>b</invoke></function_calls> end"
         )
         result = fn(text)
-        assert '<function_calls>' not in result
-        assert 'Part one' in result
-        assert 'middle' in result
-        assert 'end' in result
+        assert "<function_calls>" not in result
+        assert "Part one" in result
+        assert "middle" in result
+        assert "end" in result
 
     def test_dsml_prefixed_truncated_opening_tag_removed(self):
         fn = self._load_fn()
         text = "Answer before tool tag <｜DSML｜function_calls"
         result = fn(text)
-        assert 'function_calls' not in result.lower()
-        assert 'Answer before tool tag' in result
+        assert "function_calls" not in result.lower()
+        assert "Answer before tool tag" in result
 
     def test_malformed_dsml_fragment_removed(self):
         fn = self._load_fn()
         text = "Answer <｜DSML | still streaming"
         result = fn(text)
-        assert '<｜DSML |' not in result
-        assert 'Answer' in result
-        assert 'still streaming' in result
+        assert "<｜DSML |" not in result
+        assert "Answer" in result
+        assert "still streaming" in result
 
     def test_function_defined_in_streaming_py(self):
-        src = read('api/streaming.py')
-        assert 'def _strip_xml_tool_calls(' in src, (
+        src = read("api/streaming.py")
+        assert "def _strip_xml_tool_calls(" in src, (
             "_strip_xml_tool_calls must be defined in api/streaming.py"
         )
 
     def test_strip_applied_to_assistant_messages(self):
         """Verify the strip call is applied to assistant message content after
         the agent run completes (server-side persistence fix)."""
-        src = read('api/streaming.py')
-        assert '_strip_xml_tool_calls' in src, (
+        src = read("api/streaming.py")
+        assert "_strip_xml_tool_calls" in src, (
             "_strip_xml_tool_calls must be referenced in api/streaming.py"
         )
         # Confirm it is called on message content, not just defined
-        assert src.count('_strip_xml_tool_calls') >= 2, (
+        assert src.count("_strip_xml_tool_calls") >= 2, (
             "_strip_xml_tool_calls must be both defined and called"
         )
 
     def test_client_side_strip_in_messages_js(self):
-        src = read('static/messages.js')
-        assert '_stripXmlToolCalls' in src, (
+        src = read("static/messages.js")
+        assert "_stripXmlToolCalls" in src, (
             "Client-side _stripXmlToolCalls must exist in static/messages.js"
         )
-        assert 'function_calls' in src.lower(), (
+        assert "function_calls" in src.lower(), (
             "Client-side strip must reference 'function_calls'"
         )
 
     def test_client_side_strip_in_ui_js(self):
-        src = read('static/ui.js')
-        assert '_stripXmlToolCallsDisplay' in src, (
+        src = read("static/ui.js")
+        assert "_stripXmlToolCallsDisplay" in src, (
             "_stripXmlToolCallsDisplay must exist in static/ui.js"
         )
 
     def test_thinking_card_text_is_sanitized(self):
-        src = read('static/ui.js')
-        assert '_sanitizeThinkingDisplayText' in src, (
+        src = read("static/ui.js")
+        assert "_sanitizeThinkingDisplayText" in src, (
             "Thinking card text sanitizer must exist in static/ui.js"
         )
-        assert '_thinkingCardHtml' in src and '_thinkingMarkup' in src, (
+        assert "_thinkingCardHtml" in src and "_thinkingMarkup" in src, (
             "Thinking card render helpers must exist in static/ui.js"
         )
-        assert src.count('_sanitizeThinkingDisplayText(') >= 3, (
+        assert src.count("_sanitizeThinkingDisplayText(") >= 3, (
             "Thinking card helpers must call _sanitizeThinkingDisplayText"
         )
 
 
 # ── Bug #703 — Workspace file panel empty state ───────────────────────────────
 
-class TestWorkspaceEmptyState:
 
+class TestWorkspaceEmptyState:
     def test_i18n_no_path_string_present(self):
-        src = read('static/i18n.js')
-        assert 'workspace_empty_no_path' in src, (
+        src = read("static/i18n.js")
+        assert "workspace_empty_no_path" in src, (
             "i18n key workspace_empty_no_path must be defined in i18n.js"
         )
 
     def test_i18n_no_path_mentions_settings(self):
-        src = read('static/i18n.js')
+        src = read("static/i18n.js")
         # Extract the value of the key
         m = re.search(r"workspace_empty_no_path:\s*'([^']+)'", src)
         assert m, "workspace_empty_no_path value not found in i18n.js"
-        assert 'Settings' in m.group(1), (
+        assert "Settings" in m.group(1), (
             "workspace_empty_no_path should mention Settings"
         )
 
     def test_i18n_empty_dir_string_present(self):
-        src = read('static/i18n.js')
-        assert 'workspace_empty_dir' in src, (
+        src = read("static/i18n.js")
+        assert "workspace_empty_dir" in src, (
             "i18n key workspace_empty_dir must be defined in i18n.js"
         )
 
     def test_empty_state_element_in_html(self):
-        src = read('static/index.html')
-        assert 'wsEmptyState' in src, (
-            "id=\"wsEmptyState\" empty-state element must exist in index.html"
+        src = read("static/index.html")
+        assert "wsEmptyState" in src, (
+            'id="wsEmptyState" empty-state element must exist in index.html'
         )
 
     def test_render_file_tree_shows_empty_state(self):
-        src = read('static/ui.js')
-        assert 'wsEmptyState' in src, (
+        src = read("static/ui.js")
+        assert "wsEmptyState" in src, (
             "renderFileTree in ui.js must reference wsEmptyState"
         )
-        assert 'workspace_empty_no_path' in src, (
+        assert "workspace_empty_no_path" in src, (
             "renderFileTree must use workspace_empty_no_path i18n key"
         )
-        assert 'workspace_empty_dir' in src, (
+        assert "workspace_empty_dir" in src, (
             "renderFileTree must use workspace_empty_dir i18n key"
         )
 
 
 # ── Bug #704 — Notification description says "tab" ───────────────────────────
 
-class TestNotificationDescriptionText:
 
+class TestNotificationDescriptionText:
     def test_english_uses_app_not_tab(self):
-        src = read('static/i18n.js')
+        src = read("static/i18n.js")
         # Find the English locale block (appears before other locales)
         # The English block starts at line 1 (it's the first locale object).
         # We look for the settings_desc_notifications in the English section.
@@ -210,23 +220,21 @@ class TestNotificationDescriptionText:
         m = re.search(r"settings_desc_notifications:\s*'([^']+)'", en_section)
         assert m, "English settings_desc_notifications not found"
         desc = m.group(1)
-        assert 'tab' not in desc.lower(), (
+        assert "tab" not in desc.lower(), (
             f"English notification description must not say 'tab', got: {desc!r}"
         )
-        assert 'app' in desc.lower(), (
+        assert "app" in desc.lower(), (
             f"English notification description must say 'app', got: {desc!r}"
         )
 
     def test_new_wording_exact(self):
-        src = read('static/i18n.js')
-        expected = 'while the app is in the background'
-        assert expected in src, (
-            f"Exact phrase {expected!r} must appear in i18n.js"
-        )
+        src = read("static/i18n.js")
+        expected = "while the app is in the background"
+        assert expected in src, f"Exact phrase {expected!r} must appear in i18n.js"
 
     def test_old_wording_removed_from_english(self):
-        src = read('static/i18n.js')
-        old_phrase = 'while the tab is in the background'
+        src = read("static/i18n.js")
+        old_phrase = "while the tab is in the background"
         # The old phrase must not appear in the English locale section
         es_marker = "settings_desc_notifications: 'Muestra"
         en_end = src.index(es_marker) if es_marker in src else len(src)

--- a/tests/test_sprint49.py
+++ b/tests/test_sprint49.py
@@ -10,7 +10,6 @@ Covers:
 """
 
 import pathlib
-import re
 
 from api.streaming import _restore_reasoning_metadata
 
@@ -38,9 +37,10 @@ def test_footer_timestamp_uses_richer_format_for_older_messages():
 
 def test_timestamp_footer_stays_on_visible_response_segments():
     assert "if(hasVisibleBody){" in UI_JS
-    assert 'seg.insertAdjacentHTML(\'beforeend\', `${filesHtml}<div class="msg-body">${bodyHtml}</div>${footHtml}`);' in UI_JS, (
-        "Footer timestamp should stay attached to visible response segments"
-    )
+    assert (
+        "seg.insertAdjacentHTML('beforeend', `${filesHtml}<div class=\"msg-body\">${bodyHtml}</div>${footHtml}`);"
+        in UI_JS
+    ), "Footer timestamp should stay attached to visible response segments"
     assert "assistantThinking.set(rawIdx, thinkingText);" in UI_JS, (
         "Thinking-only assistant segments should preserve thinking for the shared activity dropdown without rendering a footer"
     )
@@ -50,9 +50,9 @@ def test_timestamp_footer_stays_on_visible_response_segments():
 
 
 def test_footer_chrome_is_hover_only_for_user_and_assistant_messages():
-    assert ".msg-row[data-role=\"user\"] .msg-foot {\n  opacity: 0;" in UI_CSS
-    assert ".msg-row[data-role=\"user\"]:hover .msg-foot," in UI_CSS
-    assert ".msg-row[data-role=\"assistant\"] .msg-foot," in UI_CSS
+    assert '.msg-row[data-role="user"] .msg-foot {\n  opacity: 0;' in UI_CSS
+    assert '.msg-row[data-role="user"]:hover .msg-foot,' in UI_CSS
+    assert '.msg-row[data-role="assistant"] .msg-foot,' in UI_CSS
     assert ".assistant-turn .msg-foot {" in UI_CSS
     assert ".assistant-turn:hover .msg-foot," in UI_CSS
 
@@ -65,16 +65,30 @@ def test_last_assistant_keeps_usage_visible_and_reveals_time_and_actions_on_hove
         or "targetFoot.insertBefore(fragments[i], targetFoot.firstChild);" in UI_JS
     )
     assert ".assistant-turn .msg-foot-with-usage," in UI_CSS
-    assert ".msg-row[data-role=\"assistant\"] .msg-foot-with-usage {\n  opacity: 1;" in UI_CSS
-    assert ".msg-foot-with-usage .msg-time,\n.msg-foot-with-usage .msg-actions {\n  opacity: 0;" in UI_CSS
+    assert (
+        '.msg-row[data-role="assistant"] .msg-foot-with-usage {\n  opacity: 1;'
+        in UI_CSS
+    )
+    assert (
+        ".msg-foot-with-usage .msg-time,\n.msg-foot-with-usage .msg-actions {\n  opacity: 0;"
+        in UI_CSS
+    )
     assert ".assistant-turn:hover .msg-foot-with-usage .msg-time," in UI_CSS
 
 
 def test_restore_reasoning_metadata_preserves_existing_timestamps():
-    assert "def _restore_reasoning_metadata(previous_messages, updated_messages):" in STREAMING_PY
-    assert "if prev_msg.get('timestamp') and not cur_msg.get('timestamp'):" in STREAMING_PY
+    assert (
+        "def _restore_reasoning_metadata(previous_messages, updated_messages):"
+        in STREAMING_PY
+    )
+    assert (
+        "if prev_msg.get('timestamp') and not cur_msg.get('timestamp'):" in STREAMING_PY
+    )
     assert "cur_msg['timestamp'] = prev_msg['timestamp']" in STREAMING_PY
-    assert "elif prev_msg.get('_ts') and not cur_msg.get('_ts') and not cur_msg.get('timestamp'):" in STREAMING_PY
+    assert (
+        "elif prev_msg.get('_ts') and not cur_msg.get('_ts') and not cur_msg.get('timestamp'):"
+        in STREAMING_PY
+    )
     assert "cur_msg['_ts'] = prev_msg['_ts']" in STREAMING_PY
 
 

--- a/tests/test_sprint5.py
+++ b/tests/test_sprint5.py
@@ -1,31 +1,45 @@
 """Sprint 5 tests: workspace CRUD, file save, session index, JS serving."""
-import json, pathlib, uuid, urllib.request, urllib.error, urllib.parse
+
+import json
+import pathlib
+import uuid
+import urllib.request
+import urllib.error
+import urllib.parse
 import os
 
 from tests._pytest_port import BASE
+
 
 def get(path):
     with urllib.request.urlopen(BASE + path, timeout=10) as r:
         return json.loads(r.read()), r.status
 
+
 def get_raw(path):
     with urllib.request.urlopen(BASE + path, timeout=10) as r:
-        return r.read(), r.headers.get("Content-Type",""), r.status
+        return r.read(), r.headers.get("Content-Type", ""), r.status
+
 
 def post(path, body=None):
     data = json.dumps(body or {}).encode()
-    req = urllib.request.Request(BASE + path, data=data, headers={"Content-Type": "application/json"})
+    req = urllib.request.Request(
+        BASE + path, data=data, headers={"Content-Type": "application/json"}
+    )
     try:
         with urllib.request.urlopen(req, timeout=10) as r:
             return json.loads(r.read()), r.status
     except urllib.error.HTTPError as e:
         return json.loads(e.read()), e.code
 
+
 def make_session_tracked(created_list, ws=None):
     """Create a session and register it with the cleanup fixture."""
     import pathlib as _pathlib
+
     body = {}
-    if ws: body["workspace"] = str(ws)
+    if ws:
+        body["workspace"] = str(ws)
     d, _ = post("/api/session/new", body)
     sid = d["session"]["session_id"]
     created_list.append(sid)
@@ -42,14 +56,17 @@ def test_server_running_from_new_location():
     data, status = get("/health")
     assert status == 200 and data["status"] == "ok"
 
+
 def test_app_js_served():
     """Sprint 9: app.js replaced by modules. Verify ui.js (contains renderMd) is served."""
     raw, ct, status = get_raw("/static/ui.js")
     assert status == 200 and "javascript" in ct and b"renderMd" in raw
 
+
 def test_workspaces_list():
     data, status = get("/api/workspaces")
     assert status == 200 and "workspaces" in data and "last" in data
+
 
 def test_workspace_add_valid(cleanup_test_sessions):
     _, ws = make_session_tracked(cleanup_test_sessions)
@@ -59,13 +76,18 @@ def test_workspace_add_valid(cleanup_test_sessions):
     assert status == 200 and any(w["path"] == str(child) for w in result["workspaces"])
     post("/api/workspaces/remove", {"path": str(child)})
 
+
 def test_workspace_add_validates_existence():
-    result, status = post("/api/workspaces/add", {"path": "/tmp/does_not_exist_xyz_999"})
+    result, status = post(
+        "/api/workspaces/add", {"path": "/tmp/does_not_exist_xyz_999"}
+    )
     assert status == 400
+
 
 def test_workspace_add_validates_is_dir():
     result, status = post("/api/workspaces/add", {"path": "/etc/hostname"})
     assert status == 400
+
 
 def test_workspace_add_no_duplicate(cleanup_test_sessions):
     _, ws = make_session_tracked(cleanup_test_sessions)
@@ -73,12 +95,14 @@ def test_workspace_add_no_duplicate(cleanup_test_sessions):
     post("/api/workspaces/remove", {"path": str(child)})
     post("/api/workspaces/add", {"path": str(child)})
     result, status = post("/api/workspaces/add", {"path": str(child)})
-    assert status == 400 and "already" in result.get("error","").lower()
+    assert status == 400 and "already" in result.get("error", "").lower()
     post("/api/workspaces/remove", {"path": str(child)})
+
 
 def test_workspace_add_requires_path():
     result, status = post("/api/workspaces/add", {})
     assert status == 400
+
 
 def test_workspace_suggest_returns_trusted_directories(cleanup_test_sessions):
     _, ws = make_session_tracked(cleanup_test_sessions)
@@ -88,12 +112,14 @@ def test_workspace_suggest_returns_trusted_directories(cleanup_test_sessions):
     data, status = get(f"/api/workspaces/suggest?prefix={urllib.parse.quote(prefix)}")
     assert status == 200
     assert str(child) in data["suggestions"]
-    assert all(not pathlib.Path(p).name.startswith('.') for p in data["suggestions"])
+    assert all(not pathlib.Path(p).name.startswith(".") for p in data["suggestions"])
+
 
 def test_workspace_suggest_hides_untrusted_system_prefix():
     data, status = get("/api/workspaces/suggest?prefix=/etc")
     assert status == 200
     assert data["suggestions"] == []
+
 
 def test_workspace_suggest_hidden_dirs_only_when_requested(cleanup_test_sessions):
     _, ws = make_session_tracked(cleanup_test_sessions)
@@ -104,9 +130,12 @@ def test_workspace_suggest_hidden_dirs_only_when_requested(cleanup_test_sessions
     assert status == 200
     assert str(visible) in data["suggestions"]
     assert str(hidden) not in data["suggestions"]
-    data2, status2 = get(f"/api/workspaces/suggest?prefix={urllib.parse.quote(base + '.w')}")
+    data2, status2 = get(
+        f"/api/workspaces/suggest?prefix={urllib.parse.quote(base + '.w')}"
+    )
     assert status2 == 200
     assert str(hidden) in data2["suggestions"]
+
 
 def test_workspace_remove(cleanup_test_sessions):
     _, ws = make_session_tracked(cleanup_test_sessions)
@@ -116,58 +145,87 @@ def test_workspace_remove(cleanup_test_sessions):
     result, status = post("/api/workspaces/remove", {"path": str(child)})
     assert status == 200 and str(child) not in [w["path"] for w in result["workspaces"]]
 
+
 def test_workspace_rename(cleanup_test_sessions):
     _, ws = make_session_tracked(cleanup_test_sessions)
     child = make_workspace_child(ws, f"workspace-rename-{uuid.uuid4().hex[:6]}")
     post("/api/workspaces/remove", {"path": str(child)})
     post("/api/workspaces/add", {"path": str(child), "name": "Temp"})
-    result, status = post("/api/workspaces/rename", {"path": str(child), "name": "My Temp"})
+    result, status = post(
+        "/api/workspaces/rename", {"path": str(child), "name": "My Temp"}
+    )
     assert status == 200
-    assert {w["path"]: w["name"] for w in result["workspaces"]}.get(str(child)) == "My Temp"
+    assert {w["path"]: w["name"] for w in result["workspaces"]}.get(
+        str(child)
+    ) == "My Temp"
     post("/api/workspaces/remove", {"path": str(child)})
 
+
 def test_workspace_rename_unknown():
-    result, status = post("/api/workspaces/rename", {"path": "/no/such/path", "name": "X"})
+    result, status = post(
+        "/api/workspaces/rename", {"path": "/no/such/path", "name": "X"}
+    )
     assert status == 404
+
 
 def test_last_workspace_updates_on_session_update(cleanup_test_sessions):
     sid, ws = make_session_tracked(cleanup_test_sessions)
     child = make_workspace_child(ws, f"workspace-last-{uuid.uuid4().hex[:6]}")
-    post("/api/session/update", {"session_id": sid, "workspace": str(child), "model": "openai/gpt-5.4-mini"})
+    post(
+        "/api/session/update",
+        {"session_id": sid, "workspace": str(child), "model": "openai/gpt-5.4-mini"},
+    )
     data, _ = get("/api/workspaces")
     assert data["last"] == str(child)
+
 
 def test_file_save(cleanup_test_sessions):
     sid, ws = make_session_tracked(cleanup_test_sessions)
     fname = f"save_{uuid.uuid4().hex[:6]}.txt"
     (ws / fname).write_text("original content")
-    result, status = post("/api/file/save", {"session_id": sid, "path": fname, "content": "updated"})
+    result, status = post(
+        "/api/file/save", {"session_id": sid, "path": fname, "content": "updated"}
+    )
     assert status == 200 and (ws / fname).read_text() == "updated"
+
 
 def test_file_save_requires_fields(cleanup_test_sessions):
     sid, _ = make_session_tracked(cleanup_test_sessions)
     result, status = post("/api/file/save", {"session_id": sid})
     assert status == 400
 
+
 def test_file_save_nonexistent_returns_404(cleanup_test_sessions):
     sid, _ = make_session_tracked(cleanup_test_sessions)
-    result, status = post("/api/file/save", {"session_id": sid, "path": "no_such.txt", "content": ""})
+    result, status = post(
+        "/api/file/save", {"session_id": sid, "path": "no_such.txt", "content": ""}
+    )
     assert status == 404
+
 
 def test_file_save_path_traversal_blocked(cleanup_test_sessions):
     sid, _ = make_session_tracked(cleanup_test_sessions)
-    result, status = post("/api/file/save", {"session_id": sid, "path": "../../etc/passwd", "content": ""})
+    result, status = post(
+        "/api/file/save", {"session_id": sid, "path": "../../etc/passwd", "content": ""}
+    )
     assert status in (400, 500)
+
 
 def test_session_index_created_after_save(cleanup_test_sessions):
     # Index is created in the TEST state dir, not the production dir
-    test_state_dir = pathlib.Path(os.environ.get("HERMES_WEBUI_TEST_STATE_DIR", str(pathlib.Path.home() / ".hermes" / "webui-mvp-test")))
+    test_state_dir = pathlib.Path(
+        os.environ.get(
+            "HERMES_WEBUI_TEST_STATE_DIR",
+            str(pathlib.Path.home() / ".hermes" / "webui-mvp-test"),
+        )
+    )
     index_path = test_state_dir / "sessions" / "_index.json"
     make_session_tracked(cleanup_test_sessions)
     # Index may not exist yet if cleanup already wiped it -- just check the endpoint works
     data, status = get("/api/sessions")
     assert status == 200
     assert isinstance(data["sessions"], list)
+
 
 def test_sessions_endpoint_returns_sorted():
     data, status = get("/api/sessions")
@@ -176,10 +234,14 @@ def test_sessions_endpoint_returns_sorted():
     if len(sessions) >= 2:
         assert sessions[0]["updated_at"] >= sessions[1]["updated_at"]
 
+
 def test_new_session_inherits_last_workspace(cleanup_test_sessions):
     sid, ws = make_session_tracked(cleanup_test_sessions)
     child = make_workspace_child(ws, f"workspace-inherit-{uuid.uuid4().hex[:6]}")
-    post("/api/session/update", {"session_id": sid, "workspace": str(child), "model": "openai/gpt-5.4-mini"})
+    post(
+        "/api/session/update",
+        {"session_id": sid, "workspace": str(child), "model": "openai/gpt-5.4-mini"},
+    )
     sid2, _ = make_session_tracked(cleanup_test_sessions)
     d, _ = get(f"/api/session?session_id={sid2}")
     assert d["session"]["workspace"] == str(child)

--- a/tests/test_sprint51.py
+++ b/tests/test_sprint51.py
@@ -11,13 +11,12 @@ These tests verify that after cancel_stream() is called:
 All tests are isolated and clean up after themselves.
 """
 
-import pytest
 import queue
 import threading
-from unittest.mock import Mock, patch, MagicMock
+from unittest.mock import Mock, patch
 
 from api.streaming import cancel_stream
-from api.config import AGENT_INSTANCES, STREAMS, STREAMS_LOCK, CANCEL_FLAGS
+from api.config import AGENT_INSTANCES, STREAMS, CANCEL_FLAGS
 
 
 class TestCancelStreamEagerRelease:
@@ -45,8 +44,9 @@ class TestCancelStreamEagerRelease:
         result = cancel_stream(stream_id)
 
         assert result is True
-        assert stream_id not in STREAMS, \
+        assert stream_id not in STREAMS, (
             "cancel_stream() should eagerly pop from STREAMS to release the session lock"
+        )
 
     def test_cancel_pops_cancel_flags(self):
         """After cancel, stream_id should no longer be in CANCEL_FLAGS."""
@@ -56,8 +56,9 @@ class TestCancelStreamEagerRelease:
 
         cancel_stream(stream_id)
 
-        assert stream_id not in CANCEL_FLAGS, \
+        assert stream_id not in CANCEL_FLAGS, (
             "cancel_stream() should eagerly pop from CANCEL_FLAGS"
+        )
 
     def test_cancel_pops_agent_instances(self):
         """After cancel, stream_id should no longer be in AGENT_INSTANCES."""
@@ -70,8 +71,9 @@ class TestCancelStreamEagerRelease:
 
         cancel_stream(stream_id)
 
-        assert stream_id not in AGENT_INSTANCES, \
+        assert stream_id not in AGENT_INSTANCES, (
             "cancel_stream() should eagerly pop from AGENT_INSTANCES"
+        )
 
     def test_cancel_clears_session_active_stream_id(self):
         """After cancel, session.active_stream_id should be None."""
@@ -91,17 +93,21 @@ class TestCancelStreamEagerRelease:
         CANCEL_FLAGS[stream_id] = threading.Event()
         AGENT_INSTANCES[stream_id] = mock_agent
 
-        with patch('api.streaming.get_session', return_value=mock_session):
+        with patch("api.streaming.get_session", return_value=mock_session):
             cancel_stream(stream_id)
 
-        assert mock_session.active_stream_id is None, \
+        assert mock_session.active_stream_id is None, (
             "cancel_stream() should clear session.active_stream_id"
-        assert mock_session.pending_user_message is None, \
+        )
+        assert mock_session.pending_user_message is None, (
             "cancel_stream() should clear session.pending_user_message"
-        assert mock_session.pending_attachments == [], \
+        )
+        assert mock_session.pending_attachments == [], (
             "cancel_stream() should clear session.pending_attachments"
-        assert mock_session.pending_started_at is None, \
+        )
+        assert mock_session.pending_started_at is None, (
             "cancel_stream() should clear session.pending_started_at"
+        )
         mock_session.save.assert_called_once()
 
     def test_cancel_without_agent_still_pops_streams(self):
@@ -113,8 +119,9 @@ class TestCancelStreamEagerRelease:
 
         cancel_stream(stream_id)
 
-        assert stream_id not in STREAMS, \
+        assert stream_id not in STREAMS, (
             "cancel_stream() should pop STREAMS even without agent instance"
+        )
         assert stream_id not in CANCEL_FLAGS
 
     def test_cancel_sentinel_still_queued(self):
@@ -129,8 +136,8 @@ class TestCancelStreamEagerRelease:
         # The cancel sentinel should have been queued before the pop
         assert not q.empty()
         event_type, data = q.get_nowait()
-        assert event_type == 'cancel'
-        assert data['message'] == 'Cancelled by user'
+        assert event_type == "cancel"
+        assert data["message"] == "Cancelled by user"
 
     def test_double_cancel_is_safe(self):
         """Calling cancel_stream() twice should not raise."""
@@ -163,7 +170,9 @@ class TestCancelStreamEagerRelease:
         CANCEL_FLAGS[stream_id] = threading.Event()
         AGENT_INSTANCES[stream_id] = mock_agent
 
-        with patch('api.streaming.get_session', side_effect=KeyError("Session not found")):
+        with patch(
+            "api.streaming.get_session", side_effect=KeyError("Session not found")
+        ):
             # Should not raise
             result = cancel_stream(stream_id)
 

--- a/tests/test_sprint6.py
+++ b/tests/test_sprint6.py
@@ -1,35 +1,50 @@
 """Sprint 6 tests: Escape from editor, Phase D validation, HTML extraction, cron create, session export."""
-import json, uuid, pathlib, urllib.request, urllib.error
+
+import json
+import uuid
+import pathlib
+import urllib.request
+import urllib.error
+
 REPO_ROOT = pathlib.Path(__file__).parent.parent.resolve()
 
 from tests._pytest_port import BASE
+
 
 def get(path):
     with urllib.request.urlopen(BASE + path, timeout=10) as r:
         return json.loads(r.read()), r.status
 
+
 def get_raw(path):
     with urllib.request.urlopen(BASE + path, timeout=10) as r:
         return r.read(), r.headers, r.status
 
+
 def post(path, body=None):
     data = json.dumps(body or {}).encode()
-    req = urllib.request.Request(BASE + path, data=data, headers={"Content-Type": "application/json"})
+    req = urllib.request.Request(
+        BASE + path, data=data, headers={"Content-Type": "application/json"}
+    )
     try:
         with urllib.request.urlopen(req, timeout=10) as r:
             return json.loads(r.read()), r.status
     except urllib.error.HTTPError as e:
         return json.loads(e.read()), e.code
 
+
 def make_session_tracked(created_list, ws=None):
     body = {}
-    if ws: body["workspace"] = str(ws)
+    if ws:
+        body["workspace"] = str(ws)
     d, _ = post("/api/session/new", body)
     sid = d["session"]["session_id"]
     created_list.append(sid)
     return sid, pathlib.Path(d["session"]["workspace"])
 
+
 # ── Phase E: HTML served from static/index.html ──
+
 
 def test_index_html_served():
     raw, headers, status = get_raw("/")
@@ -39,26 +54,34 @@ def test_index_html_served():
     assert b'id="settingsMenu"' in raw, "Settings left-rail menu not found in HTML"
     assert b"btnExportJSON" in raw, "Export JSON button not found in HTML"
 
+
 def test_index_html_file_exists():
     p = REPO_ROOT / "static/index.html"
     assert p.exists(), "static/index.html does not exist"
     assert p.stat().st_size > 5000, "index.html seems too small"
+
 
 def test_server_py_has_no_html_string():
     txt = (REPO_ROOT / "server.py").read_text()
     assert 'HTML = r"""' not in txt, "server.py still contains inline HTML string"
     assert "doctype html" not in txt.lower(), "server.py still contains raw HTML"
 
+
 # ── Phase D: remaining endpoint validation ──
+
 
 def test_approval_respond_requires_session_id():
     result, status = post("/api/approval/respond", {"choice": "deny"})
     assert status == 400
 
+
 def test_approval_respond_rejects_invalid_choice(cleanup_test_sessions):
     sid, _ = make_session_tracked(cleanup_test_sessions)
-    result, status = post("/api/approval/respond", {"session_id": sid, "choice": "INVALID"})
+    result, status = post(
+        "/api/approval/respond", {"session_id": sid, "choice": "INVALID"}
+    )
     assert status == 400
+
 
 def test_file_raw_requires_session_id():
     try:
@@ -67,6 +90,7 @@ def test_file_raw_requires_session_id():
     except urllib.error.HTTPError as e:
         assert e.code == 400
 
+
 def test_file_raw_unknown_session():
     try:
         get_raw("/api/file/raw?session_id=nosuchsession&path=test.png")
@@ -74,32 +98,41 @@ def test_file_raw_unknown_session():
     except urllib.error.HTTPError as e:
         assert e.code == 404
 
+
 # ── Cron create ──
+
 
 def test_cron_create_requires_prompt():
     result, status = post("/api/crons/create", {"schedule": "0 9 * * *"})
     assert status == 400
     assert "prompt" in result.get("error", "").lower()
 
+
 def test_cron_create_requires_schedule():
     result, status = post("/api/crons/create", {"prompt": "Say hello"})
     assert status == 400
     assert "schedule" in result.get("error", "").lower()
 
+
 def test_cron_create_invalid_schedule():
-    result, status = post("/api/crons/create", {
-        "prompt": "Say hello", "schedule": "not_a_valid_schedule_xyz"
-    })
+    result, status = post(
+        "/api/crons/create",
+        {"prompt": "Say hello", "schedule": "not_a_valid_schedule_xyz"},
+    )
     assert status == 400
+
 
 def test_cron_create_success():
     uid = uuid.uuid4().hex[:6]
-    result, status = post("/api/crons/create", {
-        "name": f"test-job-{uid}",
-        "prompt": "Just say 'hello' and nothing else.",
-        "schedule": "every 999h",  # far future -- won't actually run during test
-        "deliver": "local",
-    })
+    result, status = post(
+        "/api/crons/create",
+        {
+            "name": f"test-job-{uid}",
+            "prompt": "Just say 'hello' and nothing else.",
+            "schedule": "every 999h",  # far future -- won't actually run during test
+            "deliver": "local",
+        },
+    )
     assert status == 200, f"Expected 200 got {status}: {result}"
     assert result["ok"] is True
     assert "job" in result
@@ -109,7 +142,9 @@ def test_cron_create_success():
     ids = [j["id"] for j in jobs["jobs"]]
     assert job_id in ids, f"Created job {job_id} not in list"
 
+
 # ── Session export ──
+
 
 def test_session_export_requires_session_id():
     try:
@@ -118,12 +153,14 @@ def test_session_export_requires_session_id():
     except urllib.error.HTTPError as e:
         assert e.code == 400
 
+
 def test_session_export_unknown_session():
     try:
         get_raw("/api/session/export?session_id=nosuchsession")
         assert False
     except urllib.error.HTTPError as e:
         assert e.code == 404
+
 
 def test_session_export_returns_json(cleanup_test_sessions):
     sid, _ = make_session_tracked(cleanup_test_sessions)
@@ -135,13 +172,16 @@ def test_session_export_returns_json(cleanup_test_sessions):
     assert "messages" in data
     assert "title" in data
 
+
 # ── Resizable panels: static files present ──
+
 
 def test_static_index_has_resize_handles():
     raw, _, status = get_raw("/")
     assert status == 200
     assert b"sidebarResize" in raw
     assert b"rightpanelResize" in raw
+
 
 def test_app_js_has_resize_logic():
     """Sprint 9: app.js replaced by modules. Resize logic lives in boot.js."""

--- a/tests/test_sprint7.py
+++ b/tests/test_sprint7.py
@@ -1,90 +1,123 @@
 """
 Sprint 7 Tests: Cron CRUD, Skill CRUD, Memory Write, Session Content Search, Health
 """
-import json, pathlib, urllib.error, urllib.parse, urllib.request
+
+import json
+import pathlib
+import urllib.error
+import urllib.parse
+import urllib.request
 
 from tests._pytest_port import BASE
+
 
 def get(path):
     with urllib.request.urlopen(BASE + path, timeout=10) as r:
         return json.loads(r.read())
 
+
 def post(path, body=None):
     data = json.dumps(body or {}).encode()
-    req = urllib.request.Request(BASE + path, data=data, headers={"Content-Type": "application/json"})
+    req = urllib.request.Request(
+        BASE + path, data=data, headers={"Content-Type": "application/json"}
+    )
     try:
         with urllib.request.urlopen(req, timeout=10) as r:
             return json.loads(r.read()), r.status
     except urllib.error.HTTPError as e:
         return json.loads(e.read()), e.code
 
+
 def make_session_tracked(created_list, ws=None):
     body = {}
-    if ws: body["workspace"] = str(ws)
+    if ws:
+        body["workspace"] = str(ws)
     d, _ = post("/api/session/new", body)
     sid = d["session"]["session_id"]
     created_list.append(sid)
     return sid, pathlib.Path(d["session"]["workspace"])
 
+
 # ── Health (Phase G) ──────────────────────────────────────────────
+
 
 def test_health_has_active_streams():
     data = get("/health")
     assert "active_streams" in data
     assert isinstance(data["active_streams"], int) and data["active_streams"] >= 0
 
+
 def test_health_has_uptime_seconds():
     data = get("/health")
     assert "uptime_seconds" in data
-    assert isinstance(data["uptime_seconds"], (int, float)) and data["uptime_seconds"] >= 0
+    assert (
+        isinstance(data["uptime_seconds"], (int, float)) and data["uptime_seconds"] >= 0
+    )
+
 
 # ── Session content search ────────────────────────────────────────
+
 
 def test_session_search_empty_returns_all(cleanup_test_sessions):
     data = get("/api/sessions/search?q=")
     assert "sessions" in data
 
+
 def test_session_search_content_params_accepted(cleanup_test_sessions):
     data = get("/api/sessions/search?q=hello&content=1&depth=3")
     assert "sessions" in data and "query" in data and data["query"] == "hello"
+
 
 def test_session_search_returns_count(cleanup_test_sessions):
     data = get("/api/sessions/search?q=nonexistent_xyz_9999&content=1")
     assert "count" in data and data["count"] == 0
 
+
 # ── Cron update ───────────────────────────────────────────────────
+
 
 def test_cron_update_requires_job_id(cleanup_test_sessions):
     data, status = post("/api/crons/update", {"name": "test"})
     assert status == 400
 
+
 def test_cron_update_unknown_job_404(cleanup_test_sessions):
     data, status = post("/api/crons/update", {"job_id": "nonexistent_abc123"})
     assert status == 404
 
+
 # ── Cron delete ───────────────────────────────────────────────────
+
 
 def test_cron_delete_requires_job_id(cleanup_test_sessions):
     data, status = post("/api/crons/delete", {})
     assert status == 400
 
+
 def test_cron_delete_unknown_404(cleanup_test_sessions):
     data, status = post("/api/crons/delete", {"job_id": "nonexistent_xyz999"})
     assert status == 404
 
+
 # ── Skill save ────────────────────────────────────────────────────
+
 
 def test_skill_save_requires_name(cleanup_test_sessions):
     data, status = post("/api/skills/save", {"content": "# test"})
     assert status == 400
 
+
 def test_skill_save_requires_content(cleanup_test_sessions):
     data, status = post("/api/skills/save", {"name": "test-no-content"})
     assert status == 400
 
+
 def test_skill_save_invalid_name_rejected(cleanup_test_sessions):
-    data, status = post("/api/skills/save", {"name": "../../../etc/passwd", "content": "bad"})
+    data, status = post(
+        "/api/skills/save", {"name": "../../../etc/passwd", "content": "bad"}
+    )
     assert status == 400
+
 
 def test_skill_save_delete_roundtrip(cleanup_test_sessions):
     skill_name = "test-sprint7-skill"
@@ -97,32 +130,41 @@ def test_skill_save_delete_roundtrip(cleanup_test_sessions):
     assert del_status == 200 and del_data.get("ok") is True
     assert not skill_path.exists()
 
+
 def test_skill_delete_requires_name(cleanup_test_sessions):
     data, status = post("/api/skills/delete", {})
     assert status == 400
+
 
 def test_skill_delete_unknown_404(cleanup_test_sessions):
     data, status = post("/api/skills/delete", {"name": "nonexistent-skill-xyz-9999"})
     assert status == 404
 
+
 # ── Memory write ──────────────────────────────────────────────────
+
 
 def test_memory_write_requires_section(cleanup_test_sessions):
     data, status = post("/api/memory/write", {"content": "test"})
     assert status == 400
 
+
 def test_memory_write_requires_content(cleanup_test_sessions):
     data, status = post("/api/memory/write", {"section": "memory"})
     assert status == 400
+
 
 def test_memory_write_invalid_section(cleanup_test_sessions):
     data, status = post("/api/memory/write", {"section": "invalid", "content": "test"})
     assert status == 400
 
+
 def test_memory_write_read_roundtrip(cleanup_test_sessions):
     original = get("/api/memory").get("memory", "")
     test_content = "# Sprint 7 Test\nWritten by test_memory_write_read_roundtrip."
-    data, status = post("/api/memory/write", {"section": "memory", "content": test_content})
+    data, status = post(
+        "/api/memory/write", {"section": "memory", "content": test_content}
+    )
     assert status == 200 and data.get("ok") is True
     read_back = get("/api/memory").get("memory")
     assert read_back == test_content

--- a/tests/test_sprint8.py
+++ b/tests/test_sprint8.py
@@ -1,22 +1,31 @@
 """
 Sprint 8 Tests: Edit/regenerate, clear conversation, truncate, reconnect banner fix, syntax highlight.
 """
-import json, pathlib, urllib.error, urllib.parse, urllib.request
+
+import json
+import urllib.error
+import urllib.parse
+import urllib.request
 
 from tests._pytest_port import BASE
+
 
 def get(path):
     with urllib.request.urlopen(BASE + path, timeout=10) as r:
         return json.loads(r.read())
 
+
 def post(path, body=None):
     data = json.dumps(body or {}).encode()
-    req = urllib.request.Request(BASE + path, data=data, headers={"Content-Type": "application/json"})
+    req = urllib.request.Request(
+        BASE + path, data=data, headers={"Content-Type": "application/json"}
+    )
     try:
         with urllib.request.urlopen(req, timeout=10) as r:
             return json.loads(r.read()), r.status
     except urllib.error.HTTPError as e:
         return json.loads(e.read()), e.code
+
 
 def make_session_tracked(created_list):
     d, _ = post("/api/session/new", {})
@@ -24,15 +33,19 @@ def make_session_tracked(created_list):
     created_list.append(sid)
     return sid
 
+
 # ── /api/session/clear ─────────────────────────────────────────────
+
 
 def test_session_clear_requires_session_id(cleanup_test_sessions):
     data, status = post("/api/session/clear", {})
     assert status == 400
 
+
 def test_session_clear_unknown_session_404(cleanup_test_sessions):
     data, status = post("/api/session/clear", {"session_id": "nonexistent_xyz"})
     assert status == 404
+
 
 def test_session_clear_wipes_messages(cleanup_test_sessions):
     created = []
@@ -54,6 +67,7 @@ def test_session_clear_wipes_messages(cleanup_test_sessions):
     # Cleanup
     post("/api/session/delete", {"session_id": sid})
 
+
 def test_session_clear_returns_session_compact(cleanup_test_sessions):
     created = []
     sid = make_session_tracked(created)
@@ -63,19 +77,26 @@ def test_session_clear_returns_session_compact(cleanup_test_sessions):
     assert data["session"]["session_id"] == sid
     post("/api/session/delete", {"session_id": sid})
 
+
 # ── /api/session/truncate ──────────────────────────────────────────
+
 
 def test_session_truncate_requires_session_id(cleanup_test_sessions):
     data, status = post("/api/session/truncate", {"keep_count": 2})
     assert status == 400
 
+
 def test_session_truncate_requires_keep_count(cleanup_test_sessions):
     data, status = post("/api/session/truncate", {"session_id": "xyz"})
     assert status == 400
 
+
 def test_session_truncate_unknown_session_404(cleanup_test_sessions):
-    data, status = post("/api/session/truncate", {"session_id": "nonexistent_xyz", "keep_count": 0})
+    data, status = post(
+        "/api/session/truncate", {"session_id": "nonexistent_xyz", "keep_count": 0}
+    )
     assert status == 404
+
 
 def test_session_truncate_returns_messages(cleanup_test_sessions):
     created = []
@@ -87,7 +108,9 @@ def test_session_truncate_returns_messages(cleanup_test_sessions):
     assert data["session"]["messages"] == []
     post("/api/session/delete", {"session_id": sid})
 
+
 # ── Static files contain new features ─────────────────────────────
+
 
 def test_app_js_contains_edit_message(cleanup_test_sessions):
     """Verify editMessage function is present in ui.js (Sprint 9: module split)."""
@@ -96,10 +119,12 @@ def test_app_js_contains_edit_message(cleanup_test_sessions):
     assert "editMessage" in src
     assert "msg-edit-area" in src
 
+
 def test_app_js_contains_regenerate(cleanup_test_sessions):
     with urllib.request.urlopen(BASE + "/static/ui.js", timeout=10) as r:
         src = r.read().decode()
     assert "regenerateResponse" in src
+
 
 def test_app_js_contains_clear_conversation(cleanup_test_sessions):
     with urllib.request.urlopen(BASE + "/static/panels.js", timeout=10) as r:
@@ -107,16 +132,19 @@ def test_app_js_contains_clear_conversation(cleanup_test_sessions):
     assert "clearConversation" in src
     assert "api/session/clear" in src
 
+
 def test_app_js_contains_highlight_code(cleanup_test_sessions):
     with urllib.request.urlopen(BASE + "/static/ui.js", timeout=10) as r:
         src = r.read().decode()
     assert "highlightCode" in src
     assert "Prism" in src
 
+
 def test_index_html_contains_prism(cleanup_test_sessions):
     with urllib.request.urlopen(BASE + "/", timeout=10) as r:
         src = r.read().decode()
     assert "prismjs" in src.lower()
+
 
 def test_index_html_contains_clear_button(cleanup_test_sessions):
     with urllib.request.urlopen(BASE + "/", timeout=10) as r:

--- a/tests/test_sprint9.py
+++ b/tests/test_sprint9.py
@@ -2,29 +2,38 @@
 Sprint 9 Tests: app.js module split verification, tool cards, todo panel.
 Run: python -m pytest tests/test_sprint9.py -v
 """
-import json, pathlib, urllib.error, urllib.request
+
+import json
+import urllib.error
+import urllib.request
 
 from tests._pytest_port import BASE
+
 
 def get_text(path):
     with urllib.request.urlopen(BASE + path, timeout=10) as r:
         return r.read().decode()
 
+
 def get(path):
     with urllib.request.urlopen(BASE + path, timeout=10) as r:
         return json.loads(r.read())
 
+
 def post(path, body=None):
     data = json.dumps(body or {}).encode()
-    req = urllib.request.Request(BASE + path, data=data,
-                                  headers={"Content-Type": "application/json"})
+    req = urllib.request.Request(
+        BASE + path, data=data, headers={"Content-Type": "application/json"}
+    )
     try:
         with urllib.request.urlopen(req, timeout=10) as r:
             return json.loads(r.read()), r.status
     except urllib.error.HTTPError as e:
         return json.loads(e.read()), e.code
 
+
 # ── Module split: all 6 files served ──────────────────────────────────────
+
 
 def test_ui_js_served(cleanup_test_sessions):
     src = get_text("/static/ui.js")
@@ -33,11 +42,13 @@ def test_ui_js_served(cleanup_test_sessions):
     assert "function syncTopbar" in src
     assert "const S=" in src or "const S =" in src
 
+
 def test_workspace_js_served(cleanup_test_sessions):
     src = get_text("/static/workspace.js")
     assert "async function api(" in src
     assert "async function loadDir(" in src
     assert "async function openFile(" in src  # renderFileTree is in ui.js
+
 
 def test_sessions_js_served(cleanup_test_sessions):
     src = get_text("/static/sessions.js")
@@ -45,10 +56,12 @@ def test_sessions_js_served(cleanup_test_sessions):
     assert "async function loadSession(" in src
     assert "async function renderSessionList(" in src
 
+
 def test_messages_js_served(cleanup_test_sessions):
     src = get_text("/static/messages.js")
     assert "async function send(" in src
     assert "function transcript(" in src
+
 
 def test_panels_js_served(cleanup_test_sessions):
     src = get_text("/static/panels.js")
@@ -57,6 +70,7 @@ def test_panels_js_served(cleanup_test_sessions):
     assert "async function loadSkills(" in src
     assert "async function loadMemory(" in src
 
+
 def test_boot_js_served(cleanup_test_sessions):
     src = get_text("/static/boot.js")
     assert "btnSend" in src
@@ -64,13 +78,24 @@ def test_boot_js_served(cleanup_test_sessions):
     # boot IIFE
     assert "(async()=>{" in src or "(async () => {" in src
 
+
 def test_app_js_no_longer_referenced_in_html(cleanup_test_sessions):
     """index.html must not reference the old monolithic app.js."""
     html = get_text("/")
     assert 'src="static/app.js"' not in html
     # All split modules must be present with the server-injected cache-busting version query.
-    for module in ["ui.js", "workspace.js", "sessions.js", "messages.js", "panels.js", "boot.js"]:
-        assert f'src="static/{module}?v=' in html, f"Missing versioned {module} in index.html"
+    for module in [
+        "ui.js",
+        "workspace.js",
+        "sessions.js",
+        "messages.js",
+        "panels.js",
+        "boot.js",
+    ]:
+        assert f'src="static/{module}?v=' in html, (
+            f"Missing versioned {module} in index.html"
+        )
+
 
 def test_module_load_order_correct(cleanup_test_sessions):
     """ui.js must appear before sessions.js which must appear before boot.js."""
@@ -83,33 +108,63 @@ def test_module_load_order_correct(cleanup_test_sessions):
     boot_pos = html.find('src="static/boot.js?v=')
     assert ui_pos < ws_pos < sess_pos < msg_pos < panels_pos < boot_pos
 
+
 def test_no_duplicate_function_definitions(cleanup_test_sessions):
     """No function name should appear in more than one module."""
     import re
-    modules = ["ui.js", "workspace.js", "sessions.js", "messages.js", "panels.js", "boot.js"]
+
+    modules = [
+        "ui.js",
+        "workspace.js",
+        "sessions.js",
+        "messages.js",
+        "panels.js",
+        "boot.js",
+    ]
     seen = {}
     for m in modules:
         src = get_text(f"/static/{m}")
-        fns = re.findall(r'(?:async )?function ([a-zA-Z_$][a-zA-Z0-9_$]*)\s*\(', src)
+        fns = re.findall(r"(?:async )?function ([a-zA-Z_$][a-zA-Z0-9_$]*)\s*\(", src)
         for fn in fns:
             if fn in seen:
                 assert False, f"Duplicate function {fn} in both {seen[fn]} and {m}"
             seen[fn] = m
     assert len(seen) > 50, f"Expected 50+ functions, got {len(seen)}"
 
+
 def test_all_functions_present_across_modules(cleanup_test_sessions):
     """Key functions must be present somewhere in the split modules."""
-    import re
-    modules = ["ui.js", "workspace.js", "sessions.js", "messages.js", "panels.js", "boot.js"]
+    modules = [
+        "ui.js",
+        "workspace.js",
+        "sessions.js",
+        "messages.js",
+        "panels.js",
+        "boot.js",
+    ]
     all_src = ""
     for m in modules:
         all_src += get_text(f"/static/{m}")
     required = [
-        "setBusy", "syncTopbar", "renderMessages", "send", "loadSession",
-        "newSession", "renderSessionList", "loadDir", "switchPanel",
-        "loadCrons", "loadSkills", "loadMemory", "editMessage",
-        "regenerateResponse", "clearConversation", "highlightCode",
-        "toggleSkillForm", "submitSkillSave", "toggleMemoryEdit",
+        "setBusy",
+        "syncTopbar",
+        "renderMessages",
+        "send",
+        "loadSession",
+        "newSession",
+        "renderSessionList",
+        "loadDir",
+        "switchPanel",
+        "loadCrons",
+        "loadSkills",
+        "loadMemory",
+        "editMessage",
+        "regenerateResponse",
+        "clearConversation",
+        "highlightCode",
+        "toggleSkillForm",
+        "submitSkillSave",
+        "toggleMemoryEdit",
     ]
     for fn in required:
         assert fn in all_src, f"Function {fn} missing from all modules"

--- a/tests/test_stage268_opus_followups.py
+++ b/tests/test_stage268_opus_followups.py
@@ -6,6 +6,7 @@ Pin the three SHOULD-FIX items applied during stage-268 review:
 - SF-2 (#1462): duplicate carries personality / enabled_toolsets / context_length / threshold_tokens.
 - SF-3 (#1462): duplicate handles legacy null title via `(session.title or 'Untitled')` fallback.
 """
+
 from pathlib import Path
 import re
 
@@ -16,6 +17,7 @@ I18N_JS = (REPO_ROOT / "static" / "i18n.js").read_text(encoding="utf-8")
 
 
 # --- SF-1 (#1450): child-count UI uses i18n key ---
+
 
 def test_sf1_child_count_uses_i18n_in_sessions_js():
     """The child-count badge and meta line must call t('session_meta_children', ...).
@@ -44,17 +46,20 @@ def test_sf1_session_meta_children_present_in_all_locales():
         f"session_meta_children appears {child_count} — must be in every locale"
     )
     # Sanity: 9 known locales (en, ja, ru, es, de, zh, zh-Hant, plus the legacy zh-tw/zh-hk aliases)
-    assert child_count >= 9, f"expected >=9 locales with session_meta_children, got {child_count}"
+    assert child_count >= 9, (
+        f"expected >=9 locales with session_meta_children, got {child_count}"
+    )
 
 
 # --- SF-2 (#1462): duplicate carries per-session settings ---
+
 
 def test_sf2_duplicate_carries_personality():
     """The duplicate must propagate `personality` from source to copy."""
     duplicate_start = ROUTES_PY.find('if parsed.path == "/api/session/duplicate":')
     assert duplicate_start != -1
-    block = ROUTES_PY[duplicate_start:duplicate_start + 3000]
-    assert 'personality=session.personality' in block, (
+    block = ROUTES_PY[duplicate_start : duplicate_start + 3000]
+    assert "personality=session.personality" in block, (
         "duplicate must carry over personality — without it, customized "
         "personalities silently revert to default in the copy"
     )
@@ -63,7 +68,7 @@ def test_sf2_duplicate_carries_personality():
 def test_sf2_duplicate_carries_enabled_toolsets():
     """The duplicate must propagate `enabled_toolsets` (per-session toolset overrides)."""
     duplicate_start = ROUTES_PY.find('if parsed.path == "/api/session/duplicate":')
-    block = ROUTES_PY[duplicate_start:duplicate_start + 3000]
+    block = ROUTES_PY[duplicate_start : duplicate_start + 3000]
     assert 'enabled_toolsets=getattr(session, "enabled_toolsets", None)' in block, (
         "duplicate must carry enabled_toolsets — without it, per-session "
         "toolset overrides silently revert to defaults in the copy"
@@ -73,12 +78,13 @@ def test_sf2_duplicate_carries_enabled_toolsets():
 def test_sf2_duplicate_carries_context_settings():
     """The duplicate must propagate context_length + threshold_tokens."""
     duplicate_start = ROUTES_PY.find('if parsed.path == "/api/session/duplicate":')
-    block = ROUTES_PY[duplicate_start:duplicate_start + 3000]
+    block = ROUTES_PY[duplicate_start : duplicate_start + 3000]
     assert 'context_length=getattr(session, "context_length", None)' in block
     assert 'threshold_tokens=getattr(session, "threshold_tokens", None)' in block
 
 
 # --- SF-3 (#1462): None-title fallback ---
+
 
 def test_sf3_duplicate_handles_none_title():
     """The duplicate handler must guard `session.title or 'Untitled'` to avoid
@@ -86,7 +92,7 @@ def test_sf3_duplicate_handles_none_title():
     on legacy sessions with title=null."""
     duplicate_start = ROUTES_PY.find('if parsed.path == "/api/session/duplicate":')
     assert duplicate_start != -1
-    block = ROUTES_PY[duplicate_start:duplicate_start + 3000]
+    block = ROUTES_PY[duplicate_start : duplicate_start + 3000]
     # Must use the (session.title or "Untitled") form, not raw session.title
     assert '(session.title or "Untitled") + " (copy)"' in block, (
         "duplicate must guard against None title — `session.title + ' (copy)'` "
@@ -95,8 +101,9 @@ def test_sf3_duplicate_handles_none_title():
     # Negative: the unguarded form must be gone
     # Allow it inside comment text but not as actual code
     code_lines = [
-        ln for ln in block.split('\n')
-        if not ln.lstrip().startswith('#') and 'title=session.title + " (copy)"' in ln
+        ln
+        for ln in block.split("\n")
+        if not ln.lstrip().startswith("#") and 'title=session.title + " (copy)"' in ln
     ]
     assert not code_lines, (
         f"unguarded `session.title + ' (copy)'` still present in duplicate handler: {code_lines}"

--- a/tests/test_stage299_opus_fixes.py
+++ b/tests/test_stage299_opus_fixes.py
@@ -12,6 +12,7 @@ These tests pin the defenses applied per Opus advisor on stage-299:
 - Bounded behavior: if WIKI_PATH points at a forbidden root, both
   functions return 0/empty without iterating
 """
+
 from pathlib import Path
 
 ROUTES_PY = Path(__file__).parent.parent / "api" / "routes.py"
@@ -37,7 +38,10 @@ def test_count_files_has_iteration_cap():
     body = src[start:end]
     assert "_LLM_WIKI_MAX_FILES" in body
     assert "_LLM_WIKI_FORBIDDEN_ROOTS" in body
-    assert "iterated > _LLM_WIKI_MAX_FILES" in body or "iterated >= _LLM_WIKI_MAX_FILES" in body
+    assert (
+        "iterated > _LLM_WIKI_MAX_FILES" in body
+        or "iterated >= _LLM_WIKI_MAX_FILES" in body
+    )
 
 
 def test_page_files_has_iteration_cap():
@@ -54,16 +58,19 @@ def test_forbidden_roots_includes_system_paths():
     # Find the constant definition
     start = src.find("_LLM_WIKI_FORBIDDEN_ROOTS = ")
     end = src.find(")\n", start) + 1
-    decl = src[start:end + 1]
+    decl = src[start : end + 1]
     for forbidden in ("/", "/etc", "/usr", "/var"):
-        assert f'"{forbidden}"' in decl, f"Forbidden root {forbidden!r} not in _LLM_WIKI_FORBIDDEN_ROOTS"
+        assert f'"{forbidden}"' in decl, (
+            f"Forbidden root {forbidden!r} not in _LLM_WIKI_FORBIDDEN_ROOTS"
+        )
 
 
 def test_count_files_returns_zero_for_forbidden_root(tmp_path, monkeypatch):
     """Behavioral test: walking a forbidden root returns 0 without iterating."""
     import importlib
+
     routes = importlib.import_module("api.routes")
-    
+
     forbidden_root = Path("/etc")
     if forbidden_root.exists():  # skip on systems without /etc (Windows)
         result = routes._llm_wiki_count_files(forbidden_root)
@@ -78,7 +85,9 @@ def test_render_llm_wiki_status_uses_url_scheme_guard():
     end = panels_js.find("\nfunction ", start + 1)
     body = panels_js[start:end]
     # Must use a scheme-guarded form, not raw esc()
-    assert "/^https?:" in body or "test(rawDocsUrl)" in body or "test(docsUrl)" in body, (
+    assert (
+        "/^https?:" in body or "test(rawDocsUrl)" in body or "test(docsUrl)" in body
+    ), (
         "Expected URL scheme guard (e.g. /^https?:\\/\\//.test(...)) before "
         "interpolating docsUrl into href to prevent javascript: scheme XSS "
         "if docs_url ever becomes config-driven."

--- a/tests/test_stage302_config_override_regression.py
+++ b/tests/test_stage302_config_override_regression.py
@@ -24,6 +24,7 @@ Fix:
 
 These tests pin both prongs.
 """
+
 from __future__ import annotations
 
 import api.config as config
@@ -57,7 +58,9 @@ def test_cfg_has_in_memory_overrides_detects_attr_rebind(monkeypatch):
     assert config._cfg_has_in_memory_overrides() is False
 
     # Rebind cfg.
-    monkeypatch.setattr(config, "cfg", {"model": {"provider": "openrouter"}}, raising=False)
+    monkeypatch.setattr(
+        config, "cfg", {"model": {"provider": "openrouter"}}, raising=False
+    )
     assert config._cfg_has_in_memory_overrides() is True
 
 

--- a/tests/test_stage326_composer_draft_validation.py
+++ b/tests/test_stage326_composer_draft_validation.py
@@ -8,12 +8,7 @@ debounced auto-save. The hardening:
 - text: must be str; clamped to 50 KB
 - files: must be list; clamped to 50 entries
 """
-import json
-import os
-import sys
-import threading
-import urllib.request
-from http.server import BaseHTTPRequestHandler, HTTPServer
+
 from pathlib import Path
 
 import pytest
@@ -35,12 +30,17 @@ def isolated_state_dir(tmp_path, monkeypatch):
 def test_draft_text_clamped_to_50kb(isolated_state_dir):
     """Posting a >50KB text field should be silently truncated to 50_000 chars."""
     # Read the routes.py source and assert the clamp logic is present.
-    src = Path(__file__).parents[1].joinpath("api", "routes.py").read_text(encoding="utf-8")
+    src = (
+        Path(__file__)
+        .parents[1]
+        .joinpath("api", "routes.py")
+        .read_text(encoding="utf-8")
+    )
 
     # The clamp constant must exist.
-    assert "_MAX_DRAFT_TEXT = 50_000" in src or "_MAX_DRAFT_TEXT=50_000" in src.replace(" ", ""), (
-        "routes.py must define _MAX_DRAFT_TEXT clamp for the composer-draft POST handler"
-    )
+    assert "_MAX_DRAFT_TEXT = 50_000" in src or "_MAX_DRAFT_TEXT=50_000" in src.replace(
+        " ", ""
+    ), "routes.py must define _MAX_DRAFT_TEXT clamp for the composer-draft POST handler"
 
     # And the truncation must be applied.
     assert "text = text[:_MAX_DRAFT_TEXT]" in src, (
@@ -50,7 +50,12 @@ def test_draft_text_clamped_to_50kb(isolated_state_dir):
 
 def test_draft_files_clamped_to_50_entries():
     """Posting a >50-entry files list should be silently truncated."""
-    src = Path(__file__).parents[1].joinpath("api", "routes.py").read_text(encoding="utf-8")
+    src = (
+        Path(__file__)
+        .parents[1]
+        .joinpath("api", "routes.py")
+        .read_text(encoding="utf-8")
+    )
     assert "_MAX_DRAFT_FILES = 50" in src, (
         "routes.py must define _MAX_DRAFT_FILES clamp"
     )
@@ -61,24 +66,39 @@ def test_draft_files_clamped_to_50_entries():
 
 def test_draft_text_type_coerced_to_string():
     """Non-string text must be coerced to empty string, not stored as-is."""
-    src = Path(__file__).parents[1].joinpath("api", "routes.py").read_text(encoding="utf-8")
+    src = (
+        Path(__file__)
+        .parents[1]
+        .joinpath("api", "routes.py")
+        .read_text(encoding="utf-8")
+    )
     # The type-coerce pattern must be present.
-    assert 'if text is not None and not isinstance(text, str):' in src, (
+    assert "if text is not None and not isinstance(text, str):" in src, (
         "routes.py must coerce non-string text to empty string before persist"
     )
 
 
 def test_draft_files_type_coerced_to_list():
     """Non-list files must be coerced to empty list."""
-    src = Path(__file__).parents[1].joinpath("api", "routes.py").read_text(encoding="utf-8")
-    assert 'if files is not None and not isinstance(files, list):' in src, (
+    src = (
+        Path(__file__)
+        .parents[1]
+        .joinpath("api", "routes.py")
+        .read_text(encoding="utf-8")
+    )
+    assert "if files is not None and not isinstance(files, list):" in src, (
         "routes.py must coerce non-list files to empty list before persist"
     )
 
 
 def test_draft_validation_appears_before_persist():
     """The validation must run BEFORE the lock acquire / save, not after."""
-    src = Path(__file__).parents[1].joinpath("api", "routes.py").read_text(encoding="utf-8")
+    src = (
+        Path(__file__)
+        .parents[1]
+        .joinpath("api", "routes.py")
+        .read_text(encoding="utf-8")
+    )
     # Anchor on the unique POST-validation comment marker.
     marker_idx = src.find("Stage-326 hardening (per Opus advisor)")
     persist_idx = src.find("s.composer_draft = draft\n            s.save()")

--- a/tests/test_stage326_pending_goal_continuation_race.py
+++ b/tests/test_stage326_pending_goal_continuation_race.py
@@ -17,16 +17,27 @@ These tests exercise the full chain to guard against the regression:
 2. Setting the marker survives the streaming finally
 3. routes.py consumer discards atomically on read
 """
+
 import re
 from pathlib import Path
 
 
 def _read_streaming():
-    return Path(__file__).parents[1].joinpath("api", "streaming.py").read_text(encoding="utf-8")
+    return (
+        Path(__file__)
+        .parents[1]
+        .joinpath("api", "streaming.py")
+        .read_text(encoding="utf-8")
+    )
 
 
 def _read_routes():
-    return Path(__file__).parents[1].joinpath("api", "routes.py").read_text(encoding="utf-8")
+    return (
+        Path(__file__)
+        .parents[1]
+        .joinpath("api", "routes.py")
+        .read_text(encoding="utf-8")
+    )
 
 
 def test_streaming_finally_does_not_discard_pending_goal_continuation():
@@ -43,7 +54,7 @@ def test_streaming_finally_does_not_discard_pending_goal_continuation():
     assert pop_idx != -1, "STREAM_GOAL_RELATED cleanup not found — test needs update"
 
     # Look at the next ~600 chars (the immediate cleanup block).
-    block = src[pop_idx:pop_idx + 600]
+    block = src[pop_idx : pop_idx + 600]
 
     # The discard must NOT appear in this cleanup block.
     assert "PENDING_GOAL_CONTINUATION.discard" not in block, (
@@ -84,6 +95,7 @@ def test_pending_goal_continuation_is_a_set():
     """The marker store must be a set so add/discard is GIL-safe single-op
     (mutated from streaming worker thread, read from HTTP threads)."""
     from api.config import PENDING_GOAL_CONTINUATION
+
     assert isinstance(PENDING_GOAL_CONTINUATION, set), (
         "PENDING_GOAL_CONTINUATION must be a set for thread-safe single-op "
         "add/discard semantics"

--- a/tests/test_stale_stream_cleanup.py
+++ b/tests/test_stale_stream_cleanup.py
@@ -54,14 +54,20 @@ def test_stale_stream_cleanup_helper_exists():
 
 
 def test_session_load_clears_stale_stream_before_response():
-    load_pos = ROUTES_SRC.index("s = get_session(sid, metadata_only=(not load_messages))")
+    load_pos = ROUTES_SRC.index(
+        "s = get_session(sid, metadata_only=(not load_messages))"
+    )
     cleanup_pos = ROUTES_SRC.index("_clear_stale_stream_state(s)", load_pos)
-    response_pos = ROUTES_SRC.index('"active_stream_id": getattr(s, "active_stream_id", None)', cleanup_pos)
+    response_pos = ROUTES_SRC.index(
+        '"active_stream_id": getattr(s, "active_stream_id", None)', cleanup_pos
+    )
     assert load_pos < cleanup_pos < response_pos
 
 
 def test_chat_start_clears_stale_pending_state_not_only_active_id():
-    stale_comment_pos = ROUTES_SRC.index("# Stale stream id from a previous run; clear and continue.")
+    stale_comment_pos = ROUTES_SRC.index(
+        "# Stale stream id from a previous run; clear and continue."
+    )
     cleanup_pos = ROUTES_SRC.index("_clear_stale_stream_state(s)", stale_comment_pos)
     stream_id_pos = ROUTES_SRC.index("stream_id = uuid.uuid4().hex", cleanup_pos)
     assert stale_comment_pos < cleanup_pos < stream_id_pos
@@ -117,7 +123,7 @@ def test_stale_stream_cleanup_does_not_clobber_concurrent_chat_start(monkeypatch
 def test_frontend_drops_inflight_cache_when_server_session_is_idle():
     marker = "If the server says the session is idle, discard any browser-side inflight"
     marker_pos = SESSIONS_SRC.index(marker)
-    window = SESSIONS_SRC[marker_pos:marker_pos + 500]
+    window = SESSIONS_SRC[marker_pos : marker_pos + 500]
     assert "if(!activeStreamId&&INFLIGHT[sid])" in window
     assert "delete INFLIGHT[sid]" in window
     assert "clearInflightState" in window

--- a/tests/test_stale_stream_pending_recovery.py
+++ b/tests/test_stale_stream_pending_recovery.py
@@ -11,7 +11,9 @@ import api.models as models
 from api.models import Session, get_session
 
 
-def test_stale_stream_cleanup_recovers_pending_turn_on_non_empty_session(tmp_path, monkeypatch):
+def test_stale_stream_cleanup_recovers_pending_turn_on_non_empty_session(
+    tmp_path, monkeypatch
+):
     session_dir = tmp_path / "sessions"
     session_dir.mkdir()
     monkeypatch.setattr(models, "SESSION_DIR", session_dir)

--- a/tests/test_status_command_card.py
+++ b/tests/test_status_command_card.py
@@ -5,6 +5,7 @@ ephemeral assistant-style card from already-loaded session/profile/model data.
 It must not round-trip through the agent or a status endpoint just to draw the
 card.
 """
+
 import pathlib
 
 
@@ -27,7 +28,7 @@ def _function_body(src: str, name: str) -> str:
         elif src[idx] == "}":
             depth -= 1
             if depth == 0:
-                return src[start:idx + 1]
+                return src[start : idx + 1]
     raise AssertionError(f"Could not extract {name}()")
 
 
@@ -65,13 +66,15 @@ def test_status_card_renderer_escapes_all_dynamic_values_and_is_copyable():
     body = _function_body(UI_JS, "_statusCardHtml")
     assert "data-status-card" in body
     assert "data-copy-status-session" in body
-    assert "onclick=\"copyStatusSessionId(this);event.stopPropagation()\"" in body
+    assert 'onclick="copyStatusSessionId(this);event.stopPropagation()"' in body
     assert "esc(card.title" in body
     assert "esc(card.subtitle" in body
     assert "esc(row.label" in body
     assert "esc(row.value" in body
     assert "esc(card.sessionId" in body
-    assert "renderMd(" not in body, "Status card data should not be interpreted as markdown"
+    assert "renderMd(" not in body, (
+        "Status card data should not be interpreted as markdown"
+    )
 
 
 def test_render_messages_treats_status_card_as_visible_assistant_content():

--- a/tests/test_streaming_markdown.py
+++ b/tests/test_streaming_markdown.py
@@ -29,6 +29,7 @@ INDEX_HTML = (REPO / "static" / "index.html").read_text(encoding="utf-8")
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
+
 def extract_fn(src, name, *, brace_depth=1):
     """Return the text of a JS function starting from `function <name>` to its
     closing brace.  Works for both standalone and closure-local functions.
@@ -81,13 +82,14 @@ def extract_attach_live_stream_prelude(src):
     if not m:
         return None
     # Find the first nested function definition inside the closure
-    inner = re.search(r"\bfunction _isActiveSession\b", src[m.start():])
+    inner = re.search(r"\bfunction _isActiveSession\b", src[m.start() :])
     if not inner:
-        return src[m.start(): m.start() + 5000]
-    return src[m.start(): m.start() + inner.start()]
+        return src[m.start() : m.start() + 5000]
+    return src[m.start() : m.start() + inner.start()]
 
 
 # ── 1. index.html: smd script tag ─────────────────────────────────────────────
+
 
 class TestIndexHtmlSmdScript:
     """streaming-markdown must be loaded in index.html before messages.js uses it."""
@@ -104,7 +106,7 @@ class TestIndexHtmlSmdScript:
 
     def test_smd_loaded_as_module(self):
         assert 'type="module"' in INDEX_HTML or "type='module'" in INDEX_HTML, (
-            "streaming-markdown must be loaded with type=\"module\" (it is an ES module)"
+            'streaming-markdown must be loaded with type="module" (it is an ES module)'
         )
 
     def test_smd_vendor_import_is_mount_agnostic(self):
@@ -134,6 +136,7 @@ class TestIndexHtmlSmdScript:
 
 
 # ── 2. Closure variable declarations ─────────────────────────────────────────
+
 
 class TestClosureVariables:
     """_smdParser, _smdWrittenLen and _smdReconnect must be declared in the
@@ -181,6 +184,7 @@ class TestClosureVariables:
 
 # ── 3. Helper functions ───────────────────────────────────────────────────────
 
+
 class TestSmdHelpers:
     """_smdNewParser, _smdEndParser and _smdWrite must exist and have the right shape."""
 
@@ -190,9 +194,9 @@ class TestSmdHelpers:
 
     def test_smd_new_parser_resets_written_len(self):
         fn = extract_fn(MESSAGES_JS, "_smdNewParser")
-        assert fn and (
-            "_smdWrittenLen=0" in fn or "_smdWrittenLen = 0" in fn
-        ), "_smdNewParser must reset _smdWrittenLen to 0"
+        assert fn and ("_smdWrittenLen=0" in fn or "_smdWrittenLen = 0" in fn), (
+            "_smdNewParser must reset _smdWrittenLen to 0"
+        )
 
     def test_smd_new_parser_calls_default_renderer(self):
         fn = extract_fn(MESSAGES_JS, "_smdNewParser")
@@ -202,9 +206,9 @@ class TestSmdHelpers:
 
     def test_smd_new_parser_calls_parser(self):
         fn = extract_fn(MESSAGES_JS, "_smdNewParser")
-        assert fn and (
-            "window.smd.parser(" in fn or "smd.parser(" in fn
-        ), "_smdNewParser must call smd.parser(renderer) to create a parser"
+        assert fn and ("window.smd.parser(" in fn or "smd.parser(" in fn), (
+            "_smdNewParser must call smd.parser(renderer) to create a parser"
+        )
 
     def test_smd_new_parser_guards_on_window_smd(self):
         fn = extract_fn(MESSAGES_JS, "_smdNewParser")
@@ -224,15 +228,15 @@ class TestSmdHelpers:
 
     def test_smd_end_parser_nulls_parser(self):
         fn = extract_fn(MESSAGES_JS, "_smdEndParser")
-        assert fn and (
-            "_smdParser=null" in fn or "_smdParser = null" in fn
-        ), "_smdEndParser must set _smdParser to null after flushing"
+        assert fn and ("_smdParser=null" in fn or "_smdParser = null" in fn), (
+            "_smdEndParser must set _smdParser to null after flushing"
+        )
 
     def test_smd_end_parser_resets_written_len(self):
         fn = extract_fn(MESSAGES_JS, "_smdEndParser")
-        assert fn and (
-            "_smdWrittenLen=0" in fn or "_smdWrittenLen = 0" in fn
-        ), "_smdEndParser must reset _smdWrittenLen to 0"
+        assert fn and ("_smdWrittenLen=0" in fn or "_smdWrittenLen = 0" in fn), (
+            "_smdEndParser must reset _smdWrittenLen to 0"
+        )
 
     def test_smd_write_exists(self):
         fn = extract_fn(MESSAGES_JS, "_smdWrite")
@@ -270,6 +274,7 @@ class TestSmdHelpers:
 
 
 # ── 4. _scheduleRender: smd path vs fallback ──────────────────────────────────
+
 
 class TestScheduleRenderSmdPath:
     """_scheduleRender must use smd when available and fall back to renderMd."""
@@ -341,6 +346,7 @@ class TestScheduleRenderSmdPath:
 
 # ── 5. tool event: smd parser finalised between segments ──────────────────────
 
+
 class TestToolEventSmdEnd:
     """When a tool call is received, the current smd parser must be ended so
     the next text segment gets a fresh parser bound to the new assistantBody."""
@@ -357,6 +363,7 @@ class TestToolEventSmdEnd:
 
 
 # ── 6. done event: smd parser finalized + post-finalize highlighting ──────────
+
 
 class TestDoneEventSmd:
     """The 'done' handler must end the smd parser and trigger Prism/KaTeX/copy."""
@@ -399,7 +406,7 @@ class TestDoneEventSmd:
         fn = self.get_fn()
         assert fn, "'done' handler not found"
         # Strip single-line comments to avoid matching 'renderMessages(' inside comments
-        fn_no_comments = re.sub(r'//[^\n]*', '', fn)
+        fn_no_comments = re.sub(r"//[^\n]*", "", fn)
         # Find the rAF that contains highlightCode
         raf_pos = fn_no_comments.find("requestAnimationFrame")
         render_messages_pos = fn_no_comments.find("renderMessages(")
@@ -440,8 +447,11 @@ class TestDoneEventSmd:
             "Follow intent must be captured before renderMessages() replaces the "
             "live transcript DOM."
         )
-        after_render = fn[render_idx:render_idx + 500]
-        assert "if(shouldFollowOnDone" in after_render and "scrollToBottom()" in after_render, (
+        after_render = fn[render_idx : render_idx + 500]
+        assert (
+            "if(shouldFollowOnDone" in after_render
+            and "scrollToBottom()" in after_render
+        ), (
             "After final render, done handler must call scrollToBottom() when the "
             "user was pinned/near-bottom before DOM replacement."
         )
@@ -452,6 +462,7 @@ class TestDoneEventSmd:
 
 
 # ── 7. apperror event: smd parser ends cleanly ───────────────────────────────
+
 
 class TestAppErrorSmd:
     """The 'apperror' handler must call _smdEndParser to avoid leaking state."""
@@ -468,6 +479,7 @@ class TestAppErrorSmd:
 
 # ── 8. cancel event: smd parser ends cleanly ─────────────────────────────────
 
+
 class TestCancelSmd:
     """The 'cancel' handler must call _smdEndParser to avoid leaking state."""
 
@@ -482,6 +494,7 @@ class TestCancelSmd:
 
 
 # ── 9. Regression: existing streaming guards still intact ─────────────────────
+
 
 class TestExistingStreamingGuardsIntact:
     """The smd integration must not break pre-existing correctness properties."""
@@ -519,19 +532,20 @@ class TestExistingStreamingGuardsIntact:
 
     def test_segment_start_still_tracked(self):
         src = MESSAGES_JS
-        assert "segmentStart=assistantText.length" in src or \
-               "segmentStart = assistantText.length" in src, (
-            "segmentStart must still be advanced on tool events"
-        )
+        assert (
+            "segmentStart=assistantText.length" in src
+            or "segmentStart = assistantText.length" in src
+        ), "segmentStart must still be advanced on tool events"
 
     def test_fresh_segment_flag_still_set_on_tool(self):
         fn = extract_event_handler(MESSAGES_JS, "tool")
-        assert fn and (
-            "_freshSegment=true" in fn or "_freshSegment = true" in fn
-        ), "_freshSegment must still be set on tool events"
+        assert fn and ("_freshSegment=true" in fn or "_freshSegment = true" in fn), (
+            "_freshSegment must still be set on tool events"
+        )
 
 
 # ── XSS: smd does NOT sanitize URL schemes — we must do it ourselves ──────────
+
 
 class TestSmdUrlSchemeSanitization:
     """streaming-markdown@0.2.15 preserves `javascript:`, `vbscript:`, and dangerous
@@ -560,6 +574,7 @@ class TestSmdUrlSchemeSanitization:
         )
         # Find the regex definition
         import re as _re
+
         m = _re.search(r"_SMD_SAFE_URL_RE\s*=\s*/([^/]+)/i?", MESSAGES_JS)
         assert m, "_SMD_SAFE_URL_RE regex literal not found in messages.js"
         pattern = m.group(1)

--- a/tests/test_streaming_max_tokens_quota.py
+++ b/tests/test_streaming_max_tokens_quota.py
@@ -6,6 +6,7 @@ native 64k output ceiling and failed with HTTP 402 "more credits / fewer
 max_tokens". The stream then looked like a stuck Thinking card instead of a
 clear quota error.
 """
+
 from pathlib import Path
 
 

--- a/tests/test_streaming_race_fix.py
+++ b/tests/test_streaming_race_fix.py
@@ -15,6 +15,7 @@ Fixes:
 - _wireSSE: reset accumulators when (re)opening source, unless stream already finalized
 - error handler: bail if _streamFinalized (same as _terminalStateReached)
 """
+
 import pathlib
 import re
 
@@ -22,74 +23,74 @@ REPO = pathlib.Path(__file__).parent.parent
 
 
 def read(rel):
-    return (REPO / rel).read_text(encoding='utf-8')
+    return (REPO / rel).read_text(encoding="utf-8")
 
 
 class TestStreamFinalized:
     """_streamFinalized flag and rAF cancellation."""
 
     def test_stream_finalized_declared(self):
-        src = read('static/messages.js')
-        assert '_streamFinalized' in src, (
+        src = read("static/messages.js")
+        assert "_streamFinalized" in src, (
             "_streamFinalized must be declared in attachLiveStream"
         )
 
     def test_pending_raf_handle_declared(self):
-        src = read('static/messages.js')
-        assert '_pendingRafHandle' in src, (
+        src = read("static/messages.js")
+        assert "_pendingRafHandle" in src, (
             "_pendingRafHandle must be declared to enable rAF cancellation"
         )
 
     def test_schedule_render_guards_on_stream_finalized(self):
-        src = read('static/messages.js')
-        m = re.search(r'function _scheduleRender\(\)\{.*?\n  \}', src, re.DOTALL)
+        src = read("static/messages.js")
+        m = re.search(r"function _scheduleRender\(\)\{.*?\n  \}", src, re.DOTALL)
         assert m, "_scheduleRender not found"
         fn = m.group(0)
-        assert '_streamFinalized' in fn, (
+        assert "_streamFinalized" in fn, (
             "_scheduleRender must return early when _streamFinalized is true"
         )
 
     def test_raf_handle_stored_in_schedule_render(self):
-        src = read('static/messages.js')
-        assert '_pendingRafHandle=requestAnimationFrame' in src or \
-               '_pendingRafHandle = requestAnimationFrame' in src, (
-            "rAF handle must be stored in _pendingRafHandle for cancellation"
-        )
+        src = read("static/messages.js")
+        assert (
+            "_pendingRafHandle=requestAnimationFrame" in src
+            or "_pendingRafHandle = requestAnimationFrame" in src
+        ), "rAF handle must be stored in _pendingRafHandle for cancellation"
 
     def test_done_sets_stream_finalized(self):
-        src = read('static/messages.js')
+        src = read("static/messages.js")
         m = re.search(r"source\.addEventListener\('done'.*?\}\);", src, re.DOTALL)
         assert m, "'done' handler not found"
         fn = m.group(0)
-        assert '_streamFinalized=true' in fn or '_streamFinalized = true' in fn, (
+        assert "_streamFinalized=true" in fn or "_streamFinalized = true" in fn, (
             "'done' handler must set _streamFinalized=true"
         )
-        assert 'cancelAnimationFrame' in fn, (
+        assert "cancelAnimationFrame" in fn, (
             "'done' handler must cancel any pending rAF"
         )
-        assert 'finalizeThinkingCard' in fn, (
+        assert "finalizeThinkingCard" in fn, (
             "'done' handler must call finalizeThinkingCard() to close thinking card"
         )
 
     def test_apperror_sets_stream_finalized(self):
-        src = read('static/messages.js')
+        src = read("static/messages.js")
         m = re.search(r"source\.addEventListener\('apperror'.*?\}\);", src, re.DOTALL)
         assert m, "'apperror' handler not found"
         fn = m.group(0)
-        assert '_streamFinalized=true' in fn or '_streamFinalized = true' in fn, (
+        assert "_streamFinalized=true" in fn or "_streamFinalized = true" in fn, (
             "'apperror' handler must set _streamFinalized=true"
         )
-        assert 'cancelAnimationFrame' in fn
+        assert "cancelAnimationFrame" in fn
 
     def test_cancel_sets_stream_finalized(self):
-        src = read('static/messages.js')
+        src = read("static/messages.js")
         m = re.search(r"source\.addEventListener\('cancel'.*?\}\);", src, re.DOTALL)
         assert m, "'cancel' handler not found"
         fn = m.group(0)
-        assert '_streamFinalized=true' in fn or '_streamFinalized = true' in fn, (
+        assert "_streamFinalized=true" in fn or "_streamFinalized = true" in fn, (
             "'cancel' handler must set _streamFinalized=true"
         )
-        assert 'cancelAnimationFrame' in fn
+        assert "cancelAnimationFrame" in fn
 
 
 class TestReconnectAccumulatorPreservation:
@@ -117,8 +118,8 @@ class TestReconnectAccumulatorPreservation:
         """Regression guard: _wireSSE must not contain a literal
         accumulator-reset statement.  Preserves pre-reconnect content so
         the user sees the full response across a drop+reconnect."""
-        src = read('static/messages.js')
-        m = re.search(r'function _wireSSE\(source\)\{.*?\n  \}', src, re.DOTALL)
+        src = read("static/messages.js")
+        m = re.search(r"function _wireSSE\(source\)\{.*?\n  \}", src, re.DOTALL)
         assert m, "_wireSSE not found"
         fn = m.group(0)
         assert "assistantText=''" not in fn and 'assistantText = ""' not in fn, (
@@ -134,15 +135,17 @@ class TestReconnectAccumulatorPreservation:
         the closure scope in attachLiveStream, not inside _wireSSE.  That
         covers the first call; reconnects must preserve whatever was
         accumulated before the drop."""
-        src = read('static/messages.js')
+        src = read("static/messages.js")
         m = re.search(
-            r'function attachLiveStream\(.*?function _closeSource',
+            r"function attachLiveStream\(.*?function _closeSource",
             src,
             re.DOTALL,
         )
         assert m, "attachLiveStream prelude not found"
         prelude = m.group(0)
-        assert "let assistantText=''" in prelude or 'let assistantText = ""' in prelude, (
+        assert (
+            "let assistantText=''" in prelude or 'let assistantText = ""' in prelude
+        ), (
             "assistantText must be initialised to '' at closure scope — "
             "this is the only legitimate reset; _wireSSE must not re-reset"
         )
@@ -151,11 +154,11 @@ class TestReconnectAccumulatorPreservation:
         """`error` must still bail out when `_streamFinalized` is true —
         otherwise a trailing network 'error' event after `done` would
         attempt a reconnect against a stream that already completed."""
-        src = read('static/messages.js')
+        src = read("static/messages.js")
         m = re.search(r"source\.addEventListener\('error'.*?\}\);", src, re.DOTALL)
         assert m, "'error' handler not found"
         fn = m.group(0)
-        assert '_streamFinalized' in fn, (
+        assert "_streamFinalized" in fn, (
             "'error' reconnect handler must bail if _streamFinalized is true"
         )
 
@@ -163,13 +166,13 @@ class TestReconnectAccumulatorPreservation:
         """Opus review Q1: _handleStreamError is called after the reconnect fails.
         It calls renderMessages() which settles the DOM. Any pending rAF must be
         cancelled before that renderMessages call — same as done/apperror/cancel."""
-        src = read('static/messages.js')
-        m = re.search(r'function _handleStreamError\(\)\{.*?\n  \}', src, re.DOTALL)
+        src = read("static/messages.js")
+        m = re.search(r"function _handleStreamError\(\)\{.*?\n  \}", src, re.DOTALL)
         assert m, "_handleStreamError not found"
         fn = m.group(0)
-        assert '_streamFinalized=true' in fn or '_streamFinalized = true' in fn, (
+        assert "_streamFinalized=true" in fn or "_streamFinalized = true" in fn, (
             "_handleStreamError must set _streamFinalized=true (Opus Q1 fix)"
         )
-        assert 'cancelAnimationFrame' in fn, (
+        assert "cancelAnimationFrame" in fn, (
             "_handleStreamError must cancel any pending rAF before renderMessages() runs"
         )

--- a/tests/test_streaming_session_sidebar.py
+++ b/tests/test_streaming_session_sidebar.py
@@ -7,13 +7,13 @@ initial streaming turn, the session still looks like Untitled + 0-messages
 The sidebar filter must exempt actively-streaming sessions from the empty-
 Untitled rule so they remain visible while the user navigates away.
 """
+
 import pytest
 
 import api.models as models
 from api.models import (
     SESSIONS,
     STREAMS,
-    Session,
     all_sessions,
     new_session,
 )

--- a/tests/test_streaming_sidebar_scroll.py
+++ b/tests/test_streaming_sidebar_scroll.py
@@ -1,4 +1,5 @@
 """Regression tests for #1784: sidebar scroll remains independent while streaming."""
+
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -48,4 +49,7 @@ def test_scroll_if_pinned_skips_during_recent_non_message_scroll():
 
 def test_session_list_has_its_own_scroll_boundary():
     """The session list is its own scroll surface, not chained to the chat/body scroller."""
-    assert ".session-list{flex:1;overflow-y:auto;padding:0 8px 8px;min-height:0;overscroll-behavior-y:contain;touch-action:pan-y;}" in STYLE_CSS
+    assert (
+        ".session-list{flex:1;overflow-y:auto;padding:0 8px 8px;min-height:0;overscroll-behavior-y:contain;touch-action:pan-y;}"
+        in STYLE_CSS
+    )

--- a/tests/test_subpath_frontend_routes.py
+++ b/tests/test_subpath_frontend_routes.py
@@ -1,4 +1,5 @@
 """Regression tests for frontend routing under subpath mounts like /hermes/."""
+
 from pathlib import Path
 
 
@@ -32,7 +33,9 @@ def test_server_auth_redirect_uses_relative_login_path_with_encoded_next():
     src = read("api/auth.py")
     assert "handler.send_header('Location', 'login?next=' + _next)" in src
     assert "handler.send_header('Location', '/login?next='" not in src
-    assert "safe='/'" in src, "the relative redirect must keep the existing next= encoding fix"
+    assert "safe='/'" in src, (
+        "the relative redirect must keep the existing next= encoding fix"
+    )
 
 
 def test_direct_frontend_fetches_are_relative_to_current_mount():

--- a/tests/test_svg_audio_video_rendering.py
+++ b/tests/test_svg_audio_video_rendering.py
@@ -1,25 +1,26 @@
 """Test: SVG, audio, video inline rendering (#481)"""
+
 import re
 
 
 def test_media_extension_regexes_exist():
     """Verify SVG/audio/video extension regexes are defined."""
-    with open('static/ui.js') as f:
+    with open("static/ui.js") as f:
         src = f.read()
-    assert '_SVG_EXTS' in src, "Missing _SVG_EXTS regex"
-    assert '_AUDIO_EXTS' in src, "Missing _AUDIO_EXTS regex"
-    assert '_VIDEO_EXTS' in src, "Missing _VIDEO_EXTS regex"
+    assert "_SVG_EXTS" in src, "Missing _SVG_EXTS regex"
+    assert "_AUDIO_EXTS" in src, "Missing _AUDIO_EXTS regex"
+    assert "_VIDEO_EXTS" in src, "Missing _VIDEO_EXTS regex"
     # Verify they test correct extensions
-    assert 'svg' in src, "SVG regex should match .svg"
-    assert 'mp3' in src, "AUDIO regex should match .mp3"
-    assert 'ogg' in src, "AUDIO regex should match .ogg"
-    assert 'mp4' in src, "VIDEO regex should match .mp4"
-    assert 'webm' in src, "VIDEO regex should match .webm"
+    assert "svg" in src, "SVG regex should match .svg"
+    assert "mp3" in src, "AUDIO regex should match .mp3"
+    assert "ogg" in src, "AUDIO regex should match .ogg"
+    assert "mp4" in src, "VIDEO regex should match .mp4"
+    assert "webm" in src, "VIDEO regex should match .webm"
 
 
 def test_svg_rendered_before_image_catch_all():
     """Verify SVG handler for URLs runs before the catch-all image handler."""
-    with open('static/ui.js') as f:
+    with open("static/ui.js") as f:
         src = f.read()
     # Find positions of SVG vs image catch-all in the URL section
     svg_url_match = src.find("SVG URLs")
@@ -27,13 +28,14 @@ def test_svg_rendered_before_image_catch_all():
     image_catch_all = src.find("Render all https:// URLs as <img>")
     assert svg_url_match > 0, "SVG URL handler not found"
     assert image_catch_all > 0, "Image catch-all handler not found"
-    assert svg_url_match < image_catch_all, \
+    assert svg_url_match < image_catch_all, (
         "SVG handler must come before image catch-all to avoid being shadowed"
+    )
 
 
 def test_local_svg_inline_rendering():
     """Verify local SVG files render as inline image."""
-    with open('static/ui.js') as f:
+    with open("static/ui.js") as f:
         src = f.read()
     assert "msg-media-svg" in src, "Missing msg-media-svg CSS class for SVG rendering"
     # Should have at least 2 SVG handlers (URL + local)
@@ -43,7 +45,7 @@ def test_local_svg_inline_rendering():
 
 def test_local_audio_inline_rendering():
     """Verify local audio files render as inline player."""
-    with open('static/ui.js') as f:
+    with open("static/ui.js") as f:
         src = f.read()
     assert "msg-media-audio" in src, "Missing msg-media-audio CSS class"
     assert "<audio controls" in src, "Should render <audio> element with controls"
@@ -53,7 +55,7 @@ def test_local_audio_inline_rendering():
 
 def test_local_video_inline_rendering():
     """Verify local video files render as inline player."""
-    with open('static/ui.js') as f:
+    with open("static/ui.js") as f:
         src = f.read()
     assert "msg-media-video" in src, "Missing msg-media-video CSS class"
     assert "<video controls" in src, "Should render <video> element with controls"
@@ -63,13 +65,23 @@ def test_local_video_inline_rendering():
 
 def test_url_svg_audio_video_handlers():
     """Verify HTTPS URLs for SVG/audio/video get inline rendering."""
-    with open('static/ui.js') as f:
+    with open("static/ui.js") as f:
         src = f.read()
     # SVG URLs should be handled via _SVG_EXTS test on urlPath
-    url_svg = "_SVG_EXTS.test(urlPath)" in src or ("_SVG_EXTS.test" in src and "urlPath" in src)
+    url_svg = "_SVG_EXTS.test(urlPath)" in src or (
+        "_SVG_EXTS.test" in src and "urlPath" in src
+    )
     # Audio/video via mediaKindForName or explicit _AUDIO/_VIDEO tests
-    url_audio = src.count("_AUDIO_EXTS.test(src.split") + src.count("_AUDIO_EXTS.test(urlPath") + src.count("mediaKindForName")
-    url_video = src.count("_VIDEO_EXTS.test(src.split") + src.count("_VIDEO_EXTS.test(urlPath") + src.count("mediaKindForName")
+    url_audio = (
+        src.count("_AUDIO_EXTS.test(src.split")
+        + src.count("_AUDIO_EXTS.test(urlPath")
+        + src.count("mediaKindForName")
+    )
+    url_video = (
+        src.count("_VIDEO_EXTS.test(src.split")
+        + src.count("_VIDEO_EXTS.test(urlPath")
+        + src.count("mediaKindForName")
+    )
     assert url_svg, "URL SVG handler should test extension on src"
     assert url_audio >= 1, "URL audio handler should test extension on src"
     assert url_video >= 1, "URL video handler should test extension on src"
@@ -77,7 +89,7 @@ def test_url_svg_audio_video_handlers():
 
 def test_attachment_svg_audio_video():
     """Verify file attachments for SVG/audio/video get inline previews."""
-    with open('static/ui.js') as f:
+    with open("static/ui.js") as f:
         src = f.read()
     assert "attach-thumb--svg" in src, "Missing attach-thumb--svg for SVG thumbnails"
     assert "attach-chip--audio" in src, "Missing attach-chip--audio"
@@ -87,7 +99,7 @@ def test_attachment_svg_audio_video():
 
 def test_attachment_blob_url_cleanup():
     """Verify audio/video attachment chips create blob URLs."""
-    with open('static/ui.js') as f:
+    with open("static/ui.js") as f:
         src = f.read()
     # SVG and media attachments should use createObjectURL
     assert "URL.createObjectURL(f)" in src, "Should create blob URLs for attachments"
@@ -95,45 +107,47 @@ def test_attachment_blob_url_cleanup():
 
 def test_preload_metadata():
     """Verify audio/video elements use preload='metadata' for performance."""
-    with open('static/ui.js') as f:
+    with open("static/ui.js") as f:
         src = f.read()
     assert 'preload="metadata"' in src, "Audio/video should use preload='metadata'"
 
 
 def test_media_label_class():
     """Verify media label class exists for type identification."""
-    with open('static/ui.js') as f:
+    with open("static/ui.js") as f:
         src = f.read()
     assert "msg-media-label" in src, "Missing msg-media-label class"
 
 
 def test_i18n_keys():
     """Verify media rendering i18n keys exist in all locales."""
-    with open('static/i18n.js') as f:
+    with open("static/i18n.js") as f:
         src = f.read()
     required_keys = [
-        'media_audio_label',
-        'media_svg_label',
-        'media_video_label',
+        "media_audio_label",
+        "media_svg_label",
+        "media_video_label",
     ]
     for key in required_keys:
         count = src.count(f"{key}:")
-        assert count >= 8, f"Key '{key}' found {count} times, expected >= 8 (one per locale)"
+        assert count >= 8, (
+            f"Key '{key}' found {count} times, expected >= 8 (one per locale)"
+        )
 
 
 def test_css_classes_exist():
     """Verify all media CSS classes are defined."""
-    with open('static/style.css') as f:
+    with open("static/style.css") as f:
         src = f.read()
     required_classes = [
-        'msg-media-svg',
-        'msg-media-label',
-        'msg-media-audio',
-        'msg-media-video',
-        'attach-thumb--svg',
-        'attach-chip--audio',
-        'attach-chip--video',
-        'attach-chip-media',
+        "msg-media-svg",
+        "msg-media-label",
+        "msg-media-audio",
+        "msg-media-video",
+        "attach-thumb--svg",
+        "attach-chip--audio",
+        "attach-chip--video",
+        "attach-chip-media",
     ]
     for cls in required_classes:
         assert cls in src, f"Missing CSS class: .{cls}"
@@ -141,21 +155,21 @@ def test_css_classes_exist():
 
 def test_svg_not_matched_by_image_exts():
     """Verify .svg is NOT in _IMAGE_EXTS (SVG has its own handler)."""
-    with open('static/ui.js') as f:
+    with open("static/ui.js") as f:
         src = f.read()
     # Extract the _IMAGE_EXTS regex
     match = re.search(r"const _IMAGE_EXTS=/([^/]+)/i", src)
     assert match, "Could not find _IMAGE_EXTS regex"
     exts = match.group(1)
-    assert 'svg' not in exts.lower(), ".svg should NOT be in _IMAGE_EXTS"
+    assert "svg" not in exts.lower(), ".svg should NOT be in _IMAGE_EXTS"
 
 
 def test_audio_video_not_matched_by_image_exts():
     """Verify audio/video extensions are NOT in _IMAGE_EXTS."""
-    with open('static/ui.js') as f:
+    with open("static/ui.js") as f:
         src = f.read()
     match = re.search(r"const _IMAGE_EXTS=/([^/]+)/i", src)
     assert match
     exts = match.group(1)
-    for ext in ['mp3', 'mp4', 'wav', 'ogg', 'webm', 'mov', 'm4a']:
+    for ext in ["mp3", "mp4", "wav", "ogg", "webm", "mov", "m4a"]:
         assert ext not in exts.lower(), f".{ext} should NOT be in _IMAGE_EXTS"

--- a/tests/test_symlink_cycle_detection.py
+++ b/tests/test_symlink_cycle_detection.py
@@ -11,12 +11,11 @@ recursion.  Covers:
 - Symlink entries carry correct type / is_dir / target fields
 - Browsing into a symlink directory via workspace-relative path works
 """
+
 import json
-import os
 import pathlib
 import urllib.request
 import urllib.error
-import tempfile
 
 from tests._pytest_port import BASE
 
@@ -30,8 +29,9 @@ def get(path):
 def post(path, body=None):
     url = BASE + path
     data = json.dumps(body or {}).encode()
-    req = urllib.request.Request(url, data=data,
-          headers={"Content-Type": "application/json"})
+    req = urllib.request.Request(
+        url, data=data, headers={"Content-Type": "application/json"}
+    )
     try:
         with urllib.request.urlopen(req, timeout=10) as r:
             return json.loads(r.read()), r.status
@@ -57,7 +57,9 @@ def make_session(created_list, ws=None):
 class TestSymlinkCycleDetection:
     """Symlink cycle detection in list_dir / safe_resolve_ws."""
 
-    def test_external_symlink_listed_as_symlink(self, cleanup_test_sessions, tmp_path_factory):
+    def test_external_symlink_listed_as_symlink(
+        self, cleanup_test_sessions, tmp_path_factory
+    ):
         """External symlink dir should appear with type='symlink', is_dir=True."""
         ws = tmp_path_factory.mktemp("ws")
         target = tmp_path_factory.mktemp("target")
@@ -87,7 +89,9 @@ class TestSymlinkCycleDetection:
         names = [e["name"] for e in entries]
         assert "inner.txt" in names
 
-    def test_self_referencing_symlink_filtered(self, cleanup_test_sessions, tmp_path_factory):
+    def test_self_referencing_symlink_filtered(
+        self, cleanup_test_sessions, tmp_path_factory
+    ):
         """Symlink pointing to the workspace root itself must be filtered out."""
         ws = tmp_path_factory.mktemp("ws")
         (ws / "file.txt").write_text("data")
@@ -130,7 +134,9 @@ class TestSymlinkCycleDetection:
         # List inside ext/subdir — 'back' should be filtered
         listing2 = get(f"/api/list?session_id={sid}&path=ext/subdir")
         names2 = [e["name"] for e in listing2["entries"]]
-        assert "back" not in names2, "Cycle symlink inside external target should be filtered"
+        assert "back" not in names2, (
+            "Cycle symlink inside external target should be filtered"
+        )
 
     def test_symlink_file_entry(self, cleanup_test_sessions, tmp_path_factory):
         """Symlink to a file should have is_dir=False and include size."""
@@ -147,7 +153,9 @@ class TestSymlinkCycleDetection:
         assert link[0]["is_dir"] is False
         assert link[0]["size"] == 11  # len("hello world")
 
-    def test_path_traversal_still_blocked(self, cleanup_test_sessions, tmp_path_factory):
+    def test_path_traversal_still_blocked(
+        self, cleanup_test_sessions, tmp_path_factory
+    ):
         """Raw .. traversal must still be blocked even with symlink support."""
         ws = tmp_path_factory.mktemp("ws")
         sid, _ = make_session(cleanup_test_sessions, ws)

--- a/tests/test_tars_scroll_reset_regressions.py
+++ b/tests/test_tars_scroll_reset_regressions.py
@@ -27,7 +27,9 @@ def _scroll_listener_block() -> str:
 def test_clicking_current_session_is_noop_before_load_session_side_effects():
     load_session = _function_body(SESSIONS_JS, "async function loadSession")
 
-    current_idx = load_session.index("const currentSid = S.session ? S.session.session_id : null")
+    current_idx = load_session.index(
+        "const currentSid = S.session ? S.session.session_id : null"
+    )
     noop_idx = load_session.index("if(currentSid===sid) return")
     loading_idx = load_session.index("_loadingSessionId = sid")
     stop_idx = load_session.index("stopApprovalPolling")
@@ -91,9 +93,13 @@ def test_preserve_scroll_restores_unpinned_viewport_after_dom_rebuild():
     after_render = _function_body(UI_JS, "function _scrollAfterMessageRender")
     restore = _function_body(UI_JS, "function _restoreMessageScrollSnapshot")
 
-    snapshot_idx = render.index("const scrollSnapshot=preserveScroll?_captureMessageScrollSnapshot():null")
+    snapshot_idx = render.index(
+        "const scrollSnapshot=preserveScroll?_captureMessageScrollSnapshot():null"
+    )
     inner_idx = render.index("const inner=$('msgInner')")
-    final_scroll_idx = render.rindex("_scrollAfterMessageRender(preserveScroll, scrollSnapshot)")
+    final_scroll_idx = render.rindex(
+        "_scrollAfterMessageRender(preserveScroll, scrollSnapshot)"
+    )
 
     assert snapshot_idx < inner_idx < final_scroll_idx, (
         "renderMessages({preserveScroll:true}) must capture #messages.scrollTop before "
@@ -101,5 +107,7 @@ def test_preserve_scroll_restores_unpinned_viewport_after_dom_rebuild():
     )
     assert "if(_scrollPinned) scrollIfPinned()" in after_render
     assert "else _restoreMessageScrollSnapshot(scrollSnapshot)" in after_render
-    assert "el.scrollTop=Math.max(0,Math.min(Number(snapshot.top)||0,maxTop))" in restore
+    assert (
+        "el.scrollTop=Math.max(0,Math.min(Number(snapshot.top)||0,maxTop))" in restore
+    )
     assert "_programmaticScroll=true" in restore

--- a/tests/test_theme_color_meta_bridge.py
+++ b/tests/test_theme_color_meta_bridge.py
@@ -16,6 +16,7 @@ This bridge is the source of truth that native WKWebView wrappers
 (hermes-webui/hermes-swift-mac) read instead of pixel-sampling the page —
 overlay-resistant (modals/lightboxes don't poison it) and IPC-free.
 """
+
 from pathlib import Path
 
 
@@ -73,7 +74,9 @@ class TestBootJsThemeColorSync:
         """
         src = BOOT.read_text(encoding="utf-8")
         # The helper reads getComputedStyle on documentElement and extracts --bg.
-        assert "getComputedStyle(document.documentElement).getPropertyValue('--bg')" in src
+        assert (
+            "getComputedStyle(document.documentElement).getPropertyValue('--bg')" in src
+        )
 
     def test_sync_helper_updates_all_theme_color_tags(self):
         """The helper must update the canonical id tag and the static fallback tags.

--- a/tests/test_title_aux_routing.py
+++ b/tests/test_title_aux_routing.py
@@ -6,6 +6,7 @@ Covers:
   - aux→agent fallback triggers on 'llm_invalid_aux' status
   - _aux_title_timeout rejects zero, negative, and non-numeric values
 """
+
 import sys
 import types
 import unittest
@@ -13,56 +14,78 @@ from unittest.mock import MagicMock, patch
 
 # Stub agent.auxiliary_client so it is importable in the test environment
 # (the real package lives in hermes-agent, which is not installed here).
-_agent_stub = types.ModuleType('agent')
-_aux_stub = types.ModuleType('agent.auxiliary_client')
-sys.modules.setdefault('agent', _agent_stub)
-sys.modules.setdefault('agent.auxiliary_client', _aux_stub)
+_agent_stub = types.ModuleType("agent")
+_aux_stub = types.ModuleType("agent.auxiliary_client")
+sys.modules.setdefault("agent", _agent_stub)
+sys.modules.setdefault("agent.auxiliary_client", _aux_stub)
 _agent_stub.auxiliary_client = _aux_stub
 
 
 def _patch_tg_config(config_dict):
     """Return a patch context manager that makes _get_auxiliary_task_config return config_dict."""
-    return patch('agent.auxiliary_client._get_auxiliary_task_config', return_value=config_dict, create=True)
+    return patch(
+        "agent.auxiliary_client._get_auxiliary_task_config",
+        return_value=config_dict,
+        create=True,
+    )
 
 
 class TestAuxTitleConfigured(unittest.TestCase):
     def _call(self, tg_config):
         from api.streaming import _aux_title_configured
+
         with _patch_tg_config(tg_config):
             return _aux_title_configured()
 
     def test_model_set_returns_true(self):
-        self.assertTrue(self._call({'provider': '', 'model': 'gpt-4o-mini', 'base_url': ''}))
+        self.assertTrue(
+            self._call({"provider": "", "model": "gpt-4o-mini", "base_url": ""})
+        )
 
     def test_base_url_set_returns_true(self):
-        self.assertTrue(self._call({'provider': '', 'model': '', 'base_url': 'http://localhost:1234'}))
+        self.assertTrue(
+            self._call(
+                {"provider": "", "model": "", "base_url": "http://localhost:1234"}
+            )
+        )
 
     def test_provider_set_non_auto_returns_true(self):
-        self.assertTrue(self._call({'provider': 'openai', 'model': '', 'base_url': ''}))
+        self.assertTrue(self._call({"provider": "openai", "model": "", "base_url": ""}))
 
     def test_provider_auto_returns_false(self):
-        self.assertFalse(self._call({'provider': 'auto', 'model': '', 'base_url': ''}))
+        self.assertFalse(self._call({"provider": "auto", "model": "", "base_url": ""}))
 
     def test_provider_auto_case_insensitive_returns_false(self):
-        self.assertFalse(self._call({'provider': 'AUTO', 'model': '', 'base_url': ''}))
+        self.assertFalse(self._call({"provider": "AUTO", "model": "", "base_url": ""}))
 
     def test_all_empty_returns_false(self):
-        self.assertFalse(self._call({'provider': '', 'model': '', 'base_url': ''}))
+        self.assertFalse(self._call({"provider": "", "model": "", "base_url": ""}))
 
     def test_empty_dict_returns_false(self):
         self.assertFalse(self._call({}))
 
     def test_provider_configured_model_blank_returns_true(self):
         """Regression: provider set + blank model must still be treated as configured."""
-        self.assertTrue(self._call({'provider': 'anthropic', 'model': '', 'base_url': ''}))
+        self.assertTrue(
+            self._call({"provider": "anthropic", "model": "", "base_url": ""})
+        )
 
     def test_base_url_only_returns_true(self):
         """Regression: base_url alone (no model) must still be treated as configured."""
-        self.assertTrue(self._call({'provider': '', 'model': '', 'base_url': 'https://api.example.com'}))
+        self.assertTrue(
+            self._call(
+                {"provider": "", "model": "", "base_url": "https://api.example.com"}
+            )
+        )
 
     def test_import_error_returns_false(self):
         from api.streaming import _aux_title_configured
-        with patch('agent.auxiliary_client._get_auxiliary_task_config', side_effect=ImportError("no module"), create=True):
+
+        with patch(
+            "agent.auxiliary_client._get_auxiliary_task_config",
+            side_effect=ImportError("no module"),
+            create=True,
+        ):
             self.assertFalse(_aux_title_configured())
 
 
@@ -75,8 +98,8 @@ class TestGenerateTitleRawViaAuxTimeout(unittest.TestCase):
         mock_resp = types.SimpleNamespace(
             choices=[
                 types.SimpleNamespace(
-                    message=types.SimpleNamespace(content='Test Title'),
-                    finish_reason='stop',
+                    message=types.SimpleNamespace(content="Test Title"),
+                    finish_reason="stop",
                 )
             ]
         )
@@ -84,41 +107,45 @@ class TestGenerateTitleRawViaAuxTimeout(unittest.TestCase):
         captured = {}
 
         def fake_call_llm(**kwargs):
-            captured['timeout'] = kwargs.get('timeout')
+            captured["timeout"] = kwargs.get("timeout")
             return mock_resp
 
         with _patch_tg_config(tg_config):
-            with patch('agent.auxiliary_client.call_llm', side_effect=fake_call_llm, create=True):
+            with patch(
+                "agent.auxiliary_client.call_llm",
+                side_effect=fake_call_llm,
+                create=True,
+            ):
                 result, status = generate_title_raw_via_aux(
-                    user_text='What is the weather?',
-                    assistant_text='It is sunny.',
+                    user_text="What is the weather?",
+                    assistant_text="It is sunny.",
                 )
 
-        self.assertEqual(result, 'Test Title')
-        self.assertAlmostEqual(captured['timeout'], expected_timeout)
+        self.assertEqual(result, "Test Title")
+        self.assertAlmostEqual(captured["timeout"], expected_timeout)
 
     def test_default_timeout_when_not_set(self):
         """No timeout in config → uses 15.0 default."""
-        self._run_with_config({'provider': '', 'model': 'gpt-4o', 'base_url': ''}, 15.0)
+        self._run_with_config({"provider": "", "model": "gpt-4o", "base_url": ""}, 15.0)
 
     def test_custom_timeout_from_config(self):
         """Regression: timeout set in config must be used instead of hardcoded 15.0."""
         self._run_with_config(
-            {'provider': '', 'model': 'gpt-4o', 'base_url': '', 'timeout': 30.0},
+            {"provider": "", "model": "gpt-4o", "base_url": "", "timeout": 30.0},
             30.0,
         )
 
     def test_integer_timeout_from_config(self):
         """Config timeout as int is coerced to float."""
         self._run_with_config(
-            {'provider': '', 'model': 'gpt-4o', 'base_url': '', 'timeout': 5},
+            {"provider": "", "model": "gpt-4o", "base_url": "", "timeout": 5},
             5.0,
         )
 
     def test_timeout_none_in_config_falls_back_to_default(self):
         """Explicit None in config falls back to 15.0."""
         self._run_with_config(
-            {'provider': '', 'model': 'gpt-4o', 'base_url': '', 'timeout': None},
+            {"provider": "", "model": "gpt-4o", "base_url": "", "timeout": None},
             15.0,
         )
 
@@ -128,7 +155,10 @@ class TestReasoningModelTitleGeneration(unittest.TestCase):
 
     def test_title_budget_defaults_to_reasoning_safe_value(self):
         """Title generation should not use a tiny output cap that starves final content."""
-        from api.streaming import _title_completion_budget, _title_retry_completion_budget
+        from api.streaming import (
+            _title_completion_budget,
+            _title_retry_completion_budget,
+        )
 
         self.assertEqual(_title_completion_budget(), 512)
         self.assertEqual(_title_retry_completion_budget(), 1024)
@@ -139,30 +169,50 @@ class TestReasoningModelTitleGeneration(unittest.TestCase):
 
         responses = [
             {
-                'choices': [
+                "choices": [
                     {
-                        'message': {'content': '', 'reasoning': 'long hidden reasoning'},
-                        'finish_reason': 'length',
+                        "message": {
+                            "content": "",
+                            "reasoning": "long hidden reasoning",
+                        },
+                        "finish_reason": "length",
                     }
                 ]
             },
-            {'choices': [{'message': {'content': 'Useful Session Title'}, 'finish_reason': 'stop'}]},
+            {
+                "choices": [
+                    {
+                        "message": {"content": "Useful Session Title"},
+                        "finish_reason": "stop",
+                    }
+                ]
+            },
         ]
         captured_budgets = []
 
         def fake_call_llm(**kwargs):
-            captured_budgets.append(kwargs.get('max_tokens'))
+            captured_budgets.append(kwargs.get("max_tokens"))
             return responses.pop(0)
 
-        with _patch_tg_config({'provider': 'ollama', 'model': 'kimi-k2.6', 'base_url': 'https://ollama.com/v1'}):
-            with patch('agent.auxiliary_client.call_llm', side_effect=fake_call_llm, create=True):
+        with _patch_tg_config(
+            {
+                "provider": "ollama",
+                "model": "kimi-k2.6",
+                "base_url": "https://ollama.com/v1",
+            }
+        ):
+            with patch(
+                "agent.auxiliary_client.call_llm",
+                side_effect=fake_call_llm,
+                create=True,
+            ):
                 result, status = generate_title_raw_via_aux(
-                    user_text='Hey nur ein kurzer Test',
-                    assistant_text='Alles klar, ich helfe dir dabei.',
+                    user_text="Hey nur ein kurzer Test",
+                    assistant_text="Alles klar, ich helfe dir dabei.",
                 )
 
-        self.assertEqual(result, 'Useful Session Title')
-        self.assertEqual(status, 'llm_aux_retry')
+        self.assertEqual(result, "Useful Session Title")
+        self.assertEqual(status, "llm_aux_retry")
         self.assertEqual(captured_budgets, [512, 1024])
 
     def test_aux_returns_specific_status_when_reasoning_retry_still_empty(self):
@@ -171,23 +221,33 @@ class TestReasoningModelTitleGeneration(unittest.TestCase):
 
         def empty_length_response(**kwargs):
             return {
-                'choices': [
+                "choices": [
                     {
-                        'message': {'content': '', 'reasoning': 'still reasoning'},
-                        'finish_reason': 'length',
+                        "message": {"content": "", "reasoning": "still reasoning"},
+                        "finish_reason": "length",
                     }
                 ]
             }
 
-        with _patch_tg_config({'provider': 'ollama', 'model': 'kimi-k2.6', 'base_url': 'https://ollama.com/v1'}):
-            with patch('agent.auxiliary_client.call_llm', side_effect=empty_length_response, create=True):
+        with _patch_tg_config(
+            {
+                "provider": "ollama",
+                "model": "kimi-k2.6",
+                "base_url": "https://ollama.com/v1",
+            }
+        ):
+            with patch(
+                "agent.auxiliary_client.call_llm",
+                side_effect=empty_length_response,
+                create=True,
+            ):
                 result, status = generate_title_raw_via_aux(
-                    user_text='Hey nur ein kurzer Test',
-                    assistant_text='Alles klar, ich helfe dir dabei.',
+                    user_text="Hey nur ein kurzer Test",
+                    assistant_text="Alles klar, ich helfe dir dabei.",
                 )
 
         self.assertIsNone(result)
-        self.assertEqual(status, 'llm_length_aux')
+        self.assertEqual(status, "llm_length_aux")
 
     def test_agent_route_retries_empty_reasoning_length_response(self):
         """The active-agent route should get the same reasoning-model retry path as aux."""
@@ -195,19 +255,31 @@ class TestReasoningModelTitleGeneration(unittest.TestCase):
 
         responses = [
             {
-                'choices': [
+                "choices": [
                     {
-                        'message': {'content': '', 'reasoning': 'long hidden reasoning'},
-                        'finish_reason': 'length',
+                        "message": {
+                            "content": "",
+                            "reasoning": "long hidden reasoning",
+                        },
+                        "finish_reason": "length",
                     }
                 ]
             },
-            {'choices': [{'message': {'content': 'Agent Session Title'}, 'finish_reason': 'stop'}]},
+            {
+                "choices": [
+                    {
+                        "message": {"content": "Agent Session Title"},
+                        "finish_reason": "stop",
+                    }
+                ]
+            },
         ]
         captured_budgets = []
 
         def fake_create(**kwargs):
-            captured_budgets.append(kwargs.get('max_tokens') or kwargs.get('max_completion_tokens'))
+            captured_budgets.append(
+                kwargs.get("max_tokens") or kwargs.get("max_completion_tokens")
+            )
             return responses.pop(0)
 
         client = types.SimpleNamespace(
@@ -216,97 +288,107 @@ class TestReasoningModelTitleGeneration(unittest.TestCase):
             )
         )
         agent = MagicMock()
-        agent.api_mode = 'openai'
-        agent.provider = 'ollama'
-        agent.model = 'kimi-k2.6'
-        agent.base_url = 'https://ollama.com/v1'
+        agent.api_mode = "openai"
+        agent.provider = "ollama"
+        agent.model = "kimi-k2.6"
+        agent.base_url = "https://ollama.com/v1"
         agent.reasoning_config = None
         agent._build_api_kwargs.return_value = {}
         agent._ensure_primary_openai_client.return_value = client
 
         result, status = generate_title_raw_via_agent(
             agent,
-            user_text='Hey nur ein kurzer Test',
-            assistant_text='Alles klar, ich helfe dir dabei.',
+            user_text="Hey nur ein kurzer Test",
+            assistant_text="Alles klar, ich helfe dir dabei.",
         )
 
-        self.assertEqual(result, 'Agent Session Title')
-        self.assertEqual(status, 'llm_retry')
+        self.assertEqual(result, "Agent Session Title")
+        self.assertEqual(status, "llm_retry")
         self.assertEqual(captured_budgets, [512, 1024])
         self.assertIsNone(agent.reasoning_config)
 
-    @patch('api.streaming._aux_title_configured', return_value=True)
-    @patch('api.streaming._generate_llm_session_title_via_aux')
-    @patch('api.streaming.get_session')
+    @patch("api.streaming._aux_title_configured", return_value=True)
+    @patch("api.streaming._generate_llm_session_title_via_aux")
+    @patch("api.streaming.get_session")
     def test_fallback_title_status_keeps_underlying_llm_reason(
-        self, mock_get_session, mock_aux_title, mock_configured,
+        self,
+        mock_get_session,
+        mock_aux_title,
+        mock_configured,
     ):
         """Local fallback should not hide that the LLM failed because it hit length."""
         from api.streaming import _run_background_title_update
 
         mock_session = MagicMock()
-        mock_session.title = 'Untitled'
+        mock_session.title = "Untitled"
         mock_session.llm_title_generated = False
         mock_session.messages = [
-            {'role': 'user', 'content': 'Hey nur ein kurzer Test'},
-            {'role': 'assistant', 'content': 'Alles klar, ich helfe dir dabei.'},
+            {"role": "user", "content": "Hey nur ein kurzer Test"},
+            {"role": "assistant", "content": "Alles klar, ich helfe dir dabei."},
         ]
         mock_get_session.return_value = mock_session
-        mock_aux_title.return_value = (None, 'llm_length_aux', '')
+        mock_aux_title.return_value = (None, "llm_length_aux", "")
         events = []
 
         _run_background_title_update(
-            session_id='reasoning-title-session',
-            user_text='Hey nur ein kurzer Test',
-            assistant_text='Alles klar, ich helfe dir dabei.',
-            placeholder_title='Untitled',
+            session_id="reasoning-title-session",
+            user_text="Hey nur ein kurzer Test",
+            assistant_text="Alles klar, ich helfe dir dabei.",
+            placeholder_title="Untitled",
             put_event=lambda event_type, data: events.append((event_type, data)),
             agent=None,
         )
 
-        title_status = [data for event_type, data in events if event_type == 'title_status']
+        title_status = [
+            data for event_type, data in events if event_type == "title_status"
+        ]
         self.assertTrue(title_status)
-        self.assertEqual(title_status[0]['status'], 'fallback')
-        self.assertEqual(title_status[0]['reason'], 'local_summary:llm_length_aux')
+        self.assertEqual(title_status[0]["status"], "fallback")
+        self.assertEqual(title_status[0]["reason"], "local_summary:llm_length_aux")
 
-    @patch('api.streaming._aux_title_configured', return_value=True)
-    @patch('api.streaming._generate_llm_session_title_via_aux')
-    @patch('api.streaming.get_session')
+    @patch("api.streaming._aux_title_configured", return_value=True)
+    @patch("api.streaming._generate_llm_session_title_via_aux")
+    @patch("api.streaming.get_session")
     def test_generic_fallback_title_is_not_persisted(
-        self, mock_get_session, mock_aux_title, mock_configured,
+        self,
+        mock_get_session,
+        mock_aux_title,
+        mock_configured,
     ):
         """A generic local fallback is worse than the provisional first-message title."""
         from api.streaming import _run_background_title_update
 
-        provisional_title = '\u5e2e\u6211\u53bb\u627e\u4e00\u672c\u300a\u7ea2\u697c\u68a6\u300b\u7535\u5b50\u4e66'
-        first_user_text = provisional_title + '\u3002'
+        provisional_title = "\u5e2e\u6211\u53bb\u627e\u4e00\u672c\u300a\u7ea2\u697c\u68a6\u300b\u7535\u5b50\u4e66"
+        first_user_text = provisional_title + "\u3002"
         mock_session = MagicMock()
         mock_session.title = provisional_title
         mock_session.llm_title_generated = False
         mock_session.messages = [
-            {'role': 'user', 'content': first_user_text},
-            {'role': 'assistant', 'content': ''},
+            {"role": "user", "content": first_user_text},
+            {"role": "assistant", "content": ""},
         ]
         mock_get_session.return_value = mock_session
-        mock_aux_title.return_value = (None, 'llm_error_aux', '')
+        mock_aux_title.return_value = (None, "llm_error_aux", "")
         events = []
 
         _run_background_title_update(
-            session_id='generic-title-session',
+            session_id="generic-title-session",
             user_text=first_user_text,
-            assistant_text='',
+            assistant_text="",
             placeholder_title=provisional_title,
             put_event=lambda event_type, data: events.append((event_type, data)),
             agent=None,
         )
 
-        title_events = [data for event_type, data in events if event_type == 'title']
-        title_status = [data for event_type, data in events if event_type == 'title_status']
+        title_events = [data for event_type, data in events if event_type == "title"]
+        title_status = [
+            data for event_type, data in events if event_type == "title_status"
+        ]
         self.assertEqual(title_events, [])
         self.assertTrue(title_status)
-        self.assertEqual(title_status[0]['status'], 'skipped')
-        self.assertEqual(title_status[0]['reason'], 'llm_error_aux')
-        self.assertEqual(title_status[0]['title'], provisional_title)
+        self.assertEqual(title_status[0]["status"], "skipped")
+        self.assertEqual(title_status[0]["reason"], "llm_error_aux")
+        self.assertEqual(title_status[0]["title"], provisional_title)
         self.assertEqual(mock_session.title, provisional_title)
         self.assertFalse(mock_session.llm_title_generated)
         mock_session.save.assert_not_called()
@@ -317,37 +399,38 @@ class TestAuxTitleTimeoutEdgeCases(unittest.TestCase):
 
     def _call(self, tg_config, default=15.0):
         from api.streaming import _aux_title_timeout
+
         with _patch_tg_config(tg_config):
             return _aux_title_timeout(default=default)
 
     def test_timeout_zero_falls_back_to_default(self):
         """timeout: 0 is not strictly positive → fall back to default."""
-        result = self._call({'timeout': 0}, default=15.0)
+        result = self._call({"timeout": 0}, default=15.0)
         self.assertEqual(result, 15.0)
 
     def test_timeout_negative_falls_back_to_default(self):
         """timeout: -1 is not strictly positive → fall back to default."""
-        result = self._call({'timeout': -1}, default=15.0)
+        result = self._call({"timeout": -1}, default=15.0)
         self.assertEqual(result, 15.0)
 
     def test_timeout_non_numeric_string_falls_back_to_default(self):
         """timeout: 'abc' cannot be coerced to float → fall back to default."""
-        result = self._call({'timeout': 'abc'}, default=15.0)
+        result = self._call({"timeout": "abc"}, default=15.0)
         self.assertEqual(result, 15.0)
 
     def test_timeout_empty_string_falls_back_to_default(self):
         """timeout: '' cannot be coerced to a positive float → fall back to default."""
-        result = self._call({'timeout': ''}, default=15.0)
+        result = self._call({"timeout": ""}, default=15.0)
         self.assertEqual(result, 15.0)
 
     def test_timeout_positive_passes_through(self):
         """A valid positive timeout is returned as-is."""
-        result = self._call({'timeout': 25.0}, default=15.0)
+        result = self._call({"timeout": 25.0}, default=15.0)
         self.assertEqual(result, 25.0)
 
     def test_custom_default_used_on_invalid(self):
         """When the value is invalid, the caller-supplied *default* is returned."""
-        result = self._call({'timeout': 0}, default=20.0)
+        result = self._call({"timeout": 0}, default=20.0)
         self.assertEqual(result, 20.0)
 
 
@@ -359,31 +442,35 @@ class TestAuxInvalidAuxTriggersAgentFallback(unittest.TestCase):
     actually emits.
     """
 
-    @patch('api.streaming._aux_title_configured', return_value=True)
-    @patch('api.streaming._generate_llm_session_title_via_aux')
-    @patch('api.streaming._generate_llm_session_title_for_agent')
-    @patch('api.streaming.get_session')
+    @patch("api.streaming._aux_title_configured", return_value=True)
+    @patch("api.streaming._generate_llm_session_title_via_aux")
+    @patch("api.streaming._generate_llm_session_title_for_agent")
+    @patch("api.streaming.get_session")
     def test_llm_invalid_aux_triggers_agent_fallback(
-        self, mock_get_session, mock_agent_title, mock_aux_title, mock_configured,
+        self,
+        mock_get_session,
+        mock_agent_title,
+        mock_aux_title,
+        mock_configured,
     ):
         """Simulate aux returning (None, 'llm_invalid_aux', '...') and verify agent fallback fires."""
         from api.streaming import _run_background_title_update
 
         # Build a mock session that passes all the pre-checks
         mock_session = MagicMock()
-        mock_session.title = 'Untitled'
+        mock_session.title = "Untitled"
         mock_session.llm_title_generated = False
         mock_session.messages = [
-            {'role': 'user', 'content': 'What is the weather?'},
-            {'role': 'assistant', 'content': 'It is sunny and warm.'},
+            {"role": "user", "content": "What is the weather?"},
+            {"role": "assistant", "content": "It is sunny and warm."},
         ]
         mock_get_session.return_value = mock_session
 
         # aux route returns invalid title
-        mock_aux_title.return_value = (None, 'llm_invalid_aux', 'bad thinking preamble')
+        mock_aux_title.return_value = (None, "llm_invalid_aux", "bad thinking preamble")
 
         # agent route succeeds
-        mock_agent_title.return_value = ('Weather Report', 'llm', '')
+        mock_agent_title.return_value = ("Weather Report", "llm", "")
 
         events = []
 
@@ -391,10 +478,10 @@ class TestAuxInvalidAuxTriggersAgentFallback(unittest.TestCase):
             events.append((event_type, data))
 
         _run_background_title_update(
-            session_id='test-session',
-            user_text='What is the weather?',
-            assistant_text='It is sunny and warm.',
-            placeholder_title='Untitled',
+            session_id="test-session",
+            user_text="What is the weather?",
+            assistant_text="It is sunny and warm.",
+            placeholder_title="Untitled",
             put_event=fake_put_event,
             agent=MagicMock(),
         )
@@ -403,31 +490,35 @@ class TestAuxInvalidAuxTriggersAgentFallback(unittest.TestCase):
         mock_agent_title.assert_called_once()
 
         # A title must have been produced via the agent route
-        title_events = [(e, d) for e, d in events if e == 'title']
+        title_events = [(e, d) for e, d in events if e == "title"]
         self.assertTrue(len(title_events) > 0, "Expected a 'title' event to be emitted")
-        self.assertEqual(title_events[0][1]['title'], 'Weather Report')
+        self.assertEqual(title_events[0][1]["title"], "Weather Report")
 
-    @patch('api.streaming._aux_title_configured', return_value=True)
-    @patch('api.streaming._generate_llm_session_title_via_aux')
-    @patch('api.streaming._generate_llm_session_title_for_agent')
-    @patch('api.streaming.get_session')
+    @patch("api.streaming._aux_title_configured", return_value=True)
+    @patch("api.streaming._generate_llm_session_title_via_aux")
+    @patch("api.streaming._generate_llm_session_title_for_agent")
+    @patch("api.streaming.get_session")
     def test_llm_error_aux_triggers_agent_fallback(
-        self, mock_get_session, mock_agent_title, mock_aux_title, mock_configured,
+        self,
+        mock_get_session,
+        mock_agent_title,
+        mock_aux_title,
+        mock_configured,
     ):
         """Simulate aux returning (None, 'llm_error_aux', '') and verify agent fallback fires."""
         from api.streaming import _run_background_title_update
 
         mock_session = MagicMock()
-        mock_session.title = 'Untitled'
+        mock_session.title = "Untitled"
         mock_session.llm_title_generated = False
         mock_session.messages = [
-            {'role': 'user', 'content': 'Tell me a joke.'},
-            {'role': 'assistant', 'content': 'Why did the chicken cross the road?'},
+            {"role": "user", "content": "Tell me a joke."},
+            {"role": "assistant", "content": "Why did the chicken cross the road?"},
         ]
         mock_get_session.return_value = mock_session
 
-        mock_aux_title.return_value = (None, 'llm_error_aux', '')
-        mock_agent_title.return_value = ('Chicken Joke', 'llm', '')
+        mock_aux_title.return_value = (None, "llm_error_aux", "")
+        mock_agent_title.return_value = ("Chicken Joke", "llm", "")
 
         events = []
 
@@ -435,37 +526,41 @@ class TestAuxInvalidAuxTriggersAgentFallback(unittest.TestCase):
             events.append((event_type, data))
 
         _run_background_title_update(
-            session_id='test-session-2',
-            user_text='Tell me a joke.',
-            assistant_text='Why did the chicken cross the road?',
-            placeholder_title='Untitled',
+            session_id="test-session-2",
+            user_text="Tell me a joke.",
+            assistant_text="Why did the chicken cross the road?",
+            placeholder_title="Untitled",
             put_event=fake_put_event,
             agent=MagicMock(),
         )
 
         mock_agent_title.assert_called_once()
 
-    @patch('api.streaming._aux_title_configured', return_value=True)
-    @patch('api.streaming._generate_llm_session_title_via_aux')
-    @patch('api.streaming._generate_llm_session_title_for_agent')
-    @patch('api.streaming.get_session')
+    @patch("api.streaming._aux_title_configured", return_value=True)
+    @patch("api.streaming._generate_llm_session_title_via_aux")
+    @patch("api.streaming._generate_llm_session_title_for_agent")
+    @patch("api.streaming.get_session")
     def test_success_status_does_not_trigger_agent_fallback(
-        self, mock_get_session, mock_agent_title, mock_aux_title, mock_configured,
+        self,
+        mock_get_session,
+        mock_agent_title,
+        mock_aux_title,
+        mock_configured,
     ):
         """When aux succeeds, the agent route must NOT be called."""
         from api.streaming import _run_background_title_update
 
         mock_session = MagicMock()
-        mock_session.title = 'Untitled'
+        mock_session.title = "Untitled"
         mock_session.llm_title_generated = False
         mock_session.messages = [
-            {'role': 'user', 'content': 'Hello'},
-            {'role': 'assistant', 'content': 'Hi there'},
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi there"},
         ]
         mock_get_session.return_value = mock_session
 
         # aux succeeds on first try
-        mock_aux_title.return_value = ('Greeting', 'llm_aux', '')
+        mock_aux_title.return_value = ("Greeting", "llm_aux", "")
 
         events = []
 
@@ -473,10 +568,10 @@ class TestAuxInvalidAuxTriggersAgentFallback(unittest.TestCase):
             events.append((event_type, data))
 
         _run_background_title_update(
-            session_id='test-session-3',
-            user_text='Hello',
-            assistant_text='Hi there',
-            placeholder_title='Untitled',
+            session_id="test-session-3",
+            user_text="Hello",
+            assistant_text="Hi there",
+            placeholder_title="Untitled",
             put_event=fake_put_event,
             agent=MagicMock(),
         )
@@ -485,5 +580,5 @@ class TestAuxInvalidAuxTriggersAgentFallback(unittest.TestCase):
         mock_agent_title.assert_not_called()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_title_sanitization.py
+++ b/tests/test_title_sanitization.py
@@ -11,7 +11,9 @@ from api.streaming import (
 class TestGeneratedTitleSanitization(unittest.TestCase):
     def test_strips_session_title_markdown_prefix(self):
         self.assertEqual(
-            _sanitize_generated_title("**Session Title:** Clarifying Topic for Discussion"),
+            _sanitize_generated_title(
+                "**Session Title:** Clarifying Topic for Discussion"
+            ),
             "Clarifying Topic for Discussion",
         )
 
@@ -65,4 +67,6 @@ class TestGeneratedTitleSanitization(unittest.TestCase):
 
     def test_title_generation_source_has_no_cjk_literals(self):
         src = Path("api/streaming.py").read_text(encoding="utf-8")
-        self.assertNotRegex(src, r"[\u4e00-\u9fff]", "title generation code should stay English-only")
+        self.assertNotRegex(
+            src, r"[\u4e00-\u9fff]", "title generation code should stay English-only"
+        )

--- a/tests/test_tls_support.py
+++ b/tests/test_tls_support.py
@@ -3,6 +3,7 @@ Tests for optional TLS/HTTPS support (HERMES_WEBUI_TLS_CERT / TLS_KEY).
 
 Tests use a self-signed certificate generated at test time via openssl.
 """
+
 import http.client
 import json
 import os
@@ -23,23 +24,39 @@ def _gen_test_cert(tmpdir: Path) -> tuple[str, str]:
     cert = str(tmpdir / "test_cert.pem")
     key = str(tmpdir / "test_key.pem")
     subprocess.run(
-        ["openssl", "req", "-x509", "-newkey", "rsa:2048",
-         "-keyout", key, "-out", cert, "-days", "1", "-nodes",
-         "-subj", "/CN=localhost"],
-        check=True, capture_output=True,
+        [
+            "openssl",
+            "req",
+            "-x509",
+            "-newkey",
+            "rsa:2048",
+            "-keyout",
+            key,
+            "-out",
+            cert,
+            "-days",
+            "1",
+            "-nodes",
+            "-subj",
+            "/CN=localhost",
+        ],
+        check=True,
+        capture_output=True,
     )
     return cert, key
 
 
 def _find_free_port() -> int:
     import socket
+
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         s.bind(("127.0.0.1", 0))
         return s.getsockname()[1]
 
 
-def _wait_for_server(host: str, port: int, use_ssl: bool = False,
-                     timeout: float = 8.0) -> bool:
+def _wait_for_server(
+    host: str, port: int, use_ssl: bool = False, timeout: float = 8.0
+) -> bool:
     """Poll until the server accepts a connection or times out."""
     ctx = None
     if use_ssl:
@@ -77,7 +94,9 @@ def _start_server(port: int, cert: str = None, key: str = None) -> subprocess.Po
     env["HERMES_WEBUI_STATE_DIR"] = str(Path(tempfile.mkdtemp()))
     proc = subprocess.Popen(
         [os.sys.executable, str(ROOT / "server.py")],
-        env=env, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
         text=True,
     )
     return proc
@@ -85,8 +104,8 @@ def _start_server(port: int, cert: str = None, key: str = None) -> subprocess.Po
 
 # ── Test class ──────────────────────────────────────────────────────────────
 
-class TestTLSConfigFlag(unittest.TestCase):
 
+class TestTLSConfigFlag(unittest.TestCase):
     def test_tls_enabled_true_when_both_env_set(self):
         code = textwrap.dedent("""\
             import os
@@ -97,14 +116,19 @@ class TestTLSConfigFlag(unittest.TestCase):
         """)
         r = subprocess.run(
             [os.sys.executable, "-c", code],
-            capture_output=True, text=True, timeout=10,
+            capture_output=True,
+            text=True,
+            timeout=10,
             cwd=str(ROOT),
         )
         self.assertEqual(r.stdout.strip(), "True")
 
     def test_tls_enabled_false_when_env_absent(self):
-        env = {k: v for k, v in os.environ.items()
-               if k not in ("HERMES_WEBUI_TLS_CERT", "HERMES_WEBUI_TLS_KEY")}
+        env = {
+            k: v
+            for k, v in os.environ.items()
+            if k not in ("HERMES_WEBUI_TLS_CERT", "HERMES_WEBUI_TLS_KEY")
+        }
         code = textwrap.dedent("""\
             import os
             os.environ.pop('HERMES_WEBUI_TLS_CERT', None)
@@ -114,14 +138,20 @@ class TestTLSConfigFlag(unittest.TestCase):
         """)
         r = subprocess.run(
             [os.sys.executable, "-c", code],
-            capture_output=True, text=True, timeout=10,
-            cwd=str(ROOT), env=env,
+            capture_output=True,
+            text=True,
+            timeout=10,
+            cwd=str(ROOT),
+            env=env,
         )
         self.assertEqual(r.stdout.strip(), "False")
 
     def test_tls_enabled_false_when_only_cert_set(self):
-        env = {k: v for k, v in os.environ.items()
-               if k not in ("HERMES_WEBUI_TLS_CERT", "HERMES_WEBUI_TLS_KEY")}
+        env = {
+            k: v
+            for k, v in os.environ.items()
+            if k not in ("HERMES_WEBUI_TLS_CERT", "HERMES_WEBUI_TLS_KEY")
+        }
         env["HERMES_WEBUI_TLS_CERT"] = "/tmp/cert.pem"
         code = textwrap.dedent("""\
             from api.config import TLS_ENABLED
@@ -129,14 +159,16 @@ class TestTLSConfigFlag(unittest.TestCase):
         """)
         r = subprocess.run(
             [os.sys.executable, "-c", code],
-            capture_output=True, text=True, timeout=10,
-            cwd=str(ROOT), env=env,
+            capture_output=True,
+            text=True,
+            timeout=10,
+            cwd=str(ROOT),
+            env=env,
         )
         self.assertEqual(r.stdout.strip(), "False")
 
 
 class TestTLSEndToEnd(unittest.TestCase):
-
     @classmethod
     def setUpClass(cls):
         cls._tmpdir = Path(tempfile.mkdtemp())
@@ -146,6 +178,7 @@ class TestTLSEndToEnd(unittest.TestCase):
     def tearDownClass(cls):
         with suppress(Exception):
             import shutil
+
             shutil.rmtree(cls._tmpdir, ignore_errors=True)
 
     def tearDown(self):
@@ -192,7 +225,9 @@ class TestTLSEndToEnd(unittest.TestCase):
         """Bad cert paths should print a warning and start HTTP anyway."""
         port = _find_free_port()
         self._proc = _start_server(
-            port, cert="/nonexistent/cert.pem", key="/nonexistent/key.pem",
+            port,
+            cert="/nonexistent/cert.pem",
+            key="/nonexistent/key.pem",
         )
         # Server should be reachable over plain HTTP even though TLS setup failed
         self.assertTrue(
@@ -200,7 +235,6 @@ class TestTLSEndToEnd(unittest.TestCase):
             "HTTP fallback server did not start after TLS failure",
         )
         # Confirm TLS warning was printed
-        import fcntl
         os.set_blocking(self._proc.stdout.fileno(), False)
         output = ""
         try:

--- a/tests/test_tool_call_persistence.py
+++ b/tests/test_tool_call_persistence.py
@@ -1,4 +1,5 @@
 """Tests for backend tool-call summary extraction used by WebUI session persistence."""
+
 import json
 import pathlib
 import sys
@@ -15,10 +16,12 @@ def test_extract_tool_calls_from_openai_message_linkage():
         {
             "role": "assistant",
             "content": "",
-            "tool_calls": [{
-                "id": "call-1",
-                "function": {"name": "terminal", "arguments": '{"command":"ls"}'},
-            }],
+            "tool_calls": [
+                {
+                    "id": "call-1",
+                    "function": {"name": "terminal", "arguments": '{"command":"ls"}'},
+                }
+            ],
         },
         {
             "role": "tool",
@@ -99,7 +102,9 @@ def test_extract_tool_calls_falls_back_to_live_progress_when_ids_missing():
         {"role": "assistant", "content": ""},
     ]
     live_tool_calls = [{"name": "write_file", "args": {"path": "/tmp/SPEC.md"}}]
-    result = _extract_tool_calls_from_messages(messages, live_tool_calls=live_tool_calls)
+    result = _extract_tool_calls_from_messages(
+        messages, live_tool_calls=live_tool_calls
+    )
     assert len(result) == 1
     assert result[0]["name"] == "write_file"
     assert result[0]["assistant_msg_idx"] == 1
@@ -112,7 +117,12 @@ def test_extract_tool_calls_preserves_mixed_linked_and_fallback_results():
         {
             "role": "assistant",
             "content": "",
-            "tool_calls": [{"id": "call-1", "function": {"name": "terminal", "arguments": '{"command":"pwd"}'}}],
+            "tool_calls": [
+                {
+                    "id": "call-1",
+                    "function": {"name": "terminal", "arguments": '{"command":"pwd"}'},
+                }
+            ],
         },
         {"role": "tool", "tool_call_id": "call-1", "content": '{"output":"/tmp"}'},
         {"role": "assistant", "content": "Next"},
@@ -122,7 +132,9 @@ def test_extract_tool_calls_preserves_mixed_linked_and_fallback_results():
         {"name": "terminal", "args": {"command": "pwd"}},
         {"name": "write_file", "args": {"path": "/tmp/out.txt"}},
     ]
-    result = _extract_tool_calls_from_messages(messages, live_tool_calls=live_tool_calls)
+    result = _extract_tool_calls_from_messages(
+        messages, live_tool_calls=live_tool_calls
+    )
     assert len(result) == 2
     assert result[0]["name"] == "terminal"
     assert result[1]["name"] == "write_file"

--- a/tests/test_ttl_cache.py
+++ b/tests/test_ttl_cache.py
@@ -8,6 +8,7 @@ Validates:
   - copy.deepcopy() isolation (mutating returned dict doesn't pollute cache)
   - invalidate_models_cache() direct invalidation
 """
+
 import time
 from unittest.mock import patch
 
@@ -21,6 +22,7 @@ def _reset_cache():
 
 
 # ── 1. test_cache_hit_within_ttl ──────────────────────────────────────────
+
 
 def test_cache_hit_within_ttl():
     """Call get_available_models() twice within the TTL window.
@@ -38,7 +40,9 @@ def test_cache_hit_within_ttl():
         call_count += 1
         return original_reload()
 
-    with patch.object(config, "reload_config", wraps=original_reload, side_effect=_counting_reload):
+    with patch.object(
+        config, "reload_config", wraps=original_reload, side_effect=_counting_reload
+    ):
         saved_mtime = config._cfg_mtime
         try:
             # Force mtime mismatch so the first call triggers reload_config + cache fill
@@ -49,7 +53,9 @@ def test_cache_hit_within_ttl():
             # Sync _cfg_mtime to the actual file so the second call doesn't
             # re-trigger reload_config via mtime mismatch — we want it to hit the TTL cache.
             try:
-                config._cfg_mtime = config.Path(config._get_config_path()).stat().st_mtime
+                config._cfg_mtime = (
+                    config.Path(config._get_config_path()).stat().st_mtime
+                )
             except OSError:
                 config._cfg_mtime = 0.0
 
@@ -71,6 +77,7 @@ def test_cache_hit_within_ttl():
 
 
 # ── 2. test_ttl_expiry ───────────────────────────────────────────────────
+
 
 def test_ttl_expiry():
     """Populate the cache, then advance time.monotonic() past 60s.
@@ -95,7 +102,9 @@ def test_ttl_expiry():
     original_monotonic = time.monotonic
     offset = config._AVAILABLE_MODELS_CACHE_TTL + 10.0  # 70s past the real monotonic
 
-    with patch.object(time, "monotonic", side_effect=lambda: original_monotonic() + offset):
+    with patch.object(
+        time, "monotonic", side_effect=lambda: original_monotonic() + offset
+    ):
         result2 = config.get_available_models()
 
     # The cache should have been refreshed — the timestamp must be newer
@@ -107,6 +116,7 @@ def test_ttl_expiry():
 
 
 # ── 3. test_mtime_invalidation ───────────────────────────────────────────
+
 
 def test_mtime_invalidation():
     """Populate the cache, then change _cfg_mtime to simulate a config file
@@ -148,6 +158,7 @@ def test_mtime_invalidation():
 
 # ── 4. test_deepcopy_isolation ────────────────────────────────────────────
 
+
 def test_deepcopy_isolation():
     """Mutating the returned dict from get_available_models() must not
     affect the cache or subsequent return values.
@@ -174,9 +185,9 @@ def test_deepcopy_isolation():
 
     # The mutated keys must not appear in the second result
     assert result2["active_provider"] != "HACKED", "Mutation leaked into cache"
-    assert not any(
-        g.get("provider") == "FAKE" for g in result2["groups"]
-    ), "Fake provider leaked into cache"
+    assert not any(g.get("provider") == "FAKE" for g in result2["groups"]), (
+        "Fake provider leaked into cache"
+    )
 
     # If there were groups originally, the first group's models should not be empty
     # (unless it genuinely had no models, which is unlikely)
@@ -190,6 +201,7 @@ def test_deepcopy_isolation():
 
 
 # ── 5. test_invalidate_models_cache_direct ───────────────────────────────
+
 
 def test_invalidate_models_cache_direct():
     """Call invalidate_models_cache() after populating the cache.

--- a/tests/test_turn_duration_display.py
+++ b/tests/test_turn_duration_display.py
@@ -3,6 +3,7 @@
 The WebUI should expose how long an agent turn took, using backend timing so
 reload/reconnect does not lose the measurement.
 """
+
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parent.parent
@@ -73,9 +74,9 @@ def test_active_compact_activity_elapsed_timer_uses_persisted_start_time():
         "send() should copy chat-start pending_started_at into S.session before "
         "attaching the live stream."
     )
-    assert "function _formatActiveElapsedTimer" in UI_JS and "padStart(2,'0')" in UI_JS, (
-        "ui.js should format the running timer in MM:SS form."
-    )
+    assert (
+        "function _formatActiveElapsedTimer" in UI_JS and "padStart(2,'0')" in UI_JS
+    ), "ui.js should format the running timer in MM:SS form."
     assert "data-turn-started-at" in UI_JS and "data-active-turn-elapsed" in UI_JS, (
         "Live compact Activity groups need stable start-time and active-elapsed "
         "hooks for browser QA and reconnect/rerender safety."

--- a/tests/test_ui_card_animation.py
+++ b/tests/test_ui_card_animation.py
@@ -2,8 +2,12 @@ import pathlib
 import re
 
 
-STYLE_CSS = (pathlib.Path(__file__).parent.parent / "static" / "style.css").read_text(encoding="utf-8")
-UI_JS = (pathlib.Path(__file__).parent.parent / "static" / "ui.js").read_text(encoding="utf-8")
+STYLE_CSS = (pathlib.Path(__file__).parent.parent / "static" / "style.css").read_text(
+    encoding="utf-8"
+)
+UI_JS = (pathlib.Path(__file__).parent.parent / "static" / "ui.js").read_text(
+    encoding="utf-8"
+)
 COMPACT_CSS = re.sub(r"\s+", "", STYLE_CSS)
 
 
@@ -14,7 +18,10 @@ def test_tool_card_toggle_uses_transformable_layout_and_transition():
 
 
 def test_tool_card_detail_uses_transitionable_collapsed_state():
-    assert ".tool-card-detail{display:block;max-height:0;opacity:0;overflow:hidden;" in COMPACT_CSS
+    assert (
+        ".tool-card-detail{display:block;max-height:0;opacity:0;overflow:hidden;"
+        in COMPACT_CSS
+    )
     assert re.search(
         r"\.tool-card\.open\s+\.tool-card-detail\s*\{[^}]*max-height:\s*600px;[^}]*opacity:\s*1;",
         STYLE_CSS,
@@ -27,8 +34,13 @@ def test_tool_card_detail_uses_transitionable_collapsed_state():
 
 
 def test_thinking_card_toggle_and_body_use_animation_friendly_state():
-    assert ".thinking-card-toggle{margin-left:auto;font-size:10px;display:inline-flex;" in COMPACT_CSS
-    assert ".thinking-card-header{display:flex;align-items:center;gap:8px;" in COMPACT_CSS
+    assert (
+        ".thinking-card-toggle{margin-left:auto;font-size:10px;display:inline-flex;"
+        in COMPACT_CSS
+    )
+    assert (
+        ".thinking-card-header{display:flex;align-items:center;gap:8px;" in COMPACT_CSS
+    )
     # Body uses div default (display:block); canonical rule lives in the
     # consolidated block. Open state caps at 260px (intentional "quieter" sizing).
     assert ".thinking-card-body{max-height:0;opacity:0;overflow:hidden;" in COMPACT_CSS
@@ -39,9 +51,14 @@ def test_thinking_card_toggle_and_body_use_animation_friendly_state():
 
 
 def test_tool_card_toggle_uses_same_chevron_icon_markup_as_thinking_card():
-    assert "<span class=\"thinking-card-toggle\">${li('chevron-right',12)}</span>" in UI_JS
+    assert (
+        "<span class=\"thinking-card-toggle\">${li('chevron-right',12)}</span>" in UI_JS
+    )
     assert "<span class=\"tool-card-toggle\">${li('chevron-right',12)}</span>" in UI_JS
-    assert "<div class=\"thinking-card\"><div class=\"thinking-card-header\" onclick=\"this.parentElement.classList.toggle('open')\"><span class=\"thinking-card-icon\">" in UI_JS
+    assert (
+        '<div class="thinking-card"><div class="thinking-card-header" onclick="this.parentElement.classList.toggle(\'open\')"><span class="thinking-card-icon">'
+        in UI_JS
+    )
 
 
 def test_thinking_card_uses_panel_chrome_with_gold_palette():

--- a/tests/test_ui_tool_call_cleanup.py
+++ b/tests/test_ui_tool_call_cleanup.py
@@ -4,6 +4,7 @@ These tests intentionally follow the repo's existing pytest style: read static
 source files, isolate the relevant function/rule, and assert implementation
 invariants before changing the UI.
 """
+
 import pathlib
 import re
 
@@ -66,21 +67,26 @@ def _function_body(src: str, name: str) -> str:
             depth -= 1
         i += 1
     assert depth == 0, f"{name}() body did not close"
-    return src[brace + 1:i - 1]
+    return src[brace + 1 : i - 1]
 
 
 class TestToolCallGroupingStatic:
     def test_simplified_tool_calling_setting_is_wired_through_frontend(self):
-        assert "settingsSimplifiedToolCalling" in (REPO / "static" / "index.html").read_text(encoding="utf-8"), (
+        assert "settingsSimplifiedToolCalling" in (
+            REPO / "static" / "index.html"
+        ).read_text(encoding="utf-8"), (
             "Settings should expose a Compact tool activity checkbox."
         )
-        assert "window._simplifiedToolCalling" in (REPO / "static" / "boot.js").read_text(encoding="utf-8"), (
+        assert "window._simplifiedToolCalling" in (
+            REPO / "static" / "boot.js"
+        ).read_text(encoding="utf-8"), (
             "Boot should hydrate simplified_tool_calling into a runtime flag."
         )
         panels = (REPO / "static" / "panels.js").read_text(encoding="utf-8")
-        assert "settingsSimplifiedToolCalling" in panels and "simplified_tool_calling" in panels, (
-            "Settings panel should load and save the simplified_tool_calling setting."
-        )
+        assert (
+            "settingsSimplifiedToolCalling" in panels
+            and "simplified_tool_calling" in panels
+        ), "Settings panel should load and save the simplified_tool_calling setting."
 
     def test_simplified_tool_calling_autosave_hot_applies_renderer_mode(self):
         panels = (REPO / "static" / "panels.js").read_text(encoding="utf-8")
@@ -107,7 +113,9 @@ class TestToolCallGroupingStatic:
         assert "data-tool-call-group" in helper, (
             "Tool-call groups need a stable data-tool-call-group attribute for CSS and tests."
         )
-        assert re.search(r"cards\.length|toolCount|toolCalls\.length|group\.length", fn + helper), (
+        assert re.search(
+            r"cards\.length|toolCount|toolCalls\.length|group\.length", fn + helper
+        ), (
             "The simplified group header should derive its summary/count from the number of tool calls."
         )
 
@@ -139,7 +147,9 @@ class TestToolCallGroupingStatic:
             "The summary sync path should not update a hidden/removed trailing count badge."
         )
 
-    def test_activity_summary_keeps_header_compact_without_tool_names_or_thinking_prefix(self):
+    def test_activity_summary_keeps_header_compact_without_tool_names_or_thinking_prefix(
+        self,
+    ):
         helper = _function_body(UI_JS, "ensureActivityGroup")
         sync_fn = _function_body(UI_JS, "_syncToolCallGroupSummary")
         assert "tool-call-group-list" not in helper, (
@@ -200,7 +210,9 @@ class TestToolCallGroupingStatic:
         assert "live:" in live_fn + thinking_fn, (
             "Live Activity groups should be keyed by active stream id."
         )
-        assert "_copyActivityDisclosureState('live:'+streamId, 'assistant:'" in done_fn, (
+        assert (
+            "_copyActivityDisclosureState('live:'+streamId, 'assistant:'" in done_fn
+        ), (
             "When a live turn settles, its saved disclosure state should transfer to the persisted assistant turn."
         )
 
@@ -226,12 +238,16 @@ class TestToolCallGroupingStatic:
             "Thinking content should be nested inside the shared activity dropdown, not rendered separately."
         )
         render_fn = _function_body(UI_JS, "renderMessages")
-        assert "isSimplifiedToolCalling()" in render_fn and "assistantThinking.set(rawIdx, thinkingText)" in render_fn, (
+        assert (
+            "isSimplifiedToolCalling()" in render_fn
+            and "assistantThinking.set(rawIdx, thinkingText)" in render_fn
+        ), (
             "Settled thinking should move into the shared activity dropdown only when Compact tool activity is enabled."
         )
-        assert "seg.insertAdjacentHTML('beforeend', _thinkingCardHtml(thinkingText))" in render_fn, (
-            "The non-simplified path should preserve standalone settled thinking cards."
-        )
+        assert (
+            "seg.insertAdjacentHTML('beforeend', _thinkingCardHtml(thinkingText))"
+            in render_fn
+        ), "The non-simplified path should preserve standalone settled thinking cards."
 
     def test_live_thinking_uses_shared_activity_dropdown_only_when_simplified(self):
         live_thinking_fn = _function_body(UI_JS, "appendThinking")
@@ -319,9 +335,10 @@ class TestToolCardDesignTokens:
         assert "padding:var(--space-1)var(--space-3)" in css_min, (
             ".tool-card-header padding should use spacing tokens."
         )
-        assert ".tool-card-name{" in css_min and "font-size:var(--font-size-xs)" in css_min, (
-            ".tool-card-name should use --font-size-xs."
-        )
-        assert ".tool-card-preview{" in css_min and "font-size:var(--font-size-xs)" in css_min, (
-            ".tool-card-preview should use --font-size-xs."
-        )
+        assert (
+            ".tool-card-name{" in css_min and "font-size:var(--font-size-xs)" in css_min
+        ), ".tool-card-name should use --font-size-xs."
+        assert (
+            ".tool-card-preview{" in css_min
+            and "font-size:var(--font-size-xs)" in css_min
+        ), ".tool-card-preview should use --font-size-xs."

--- a/tests/test_update_apply_ui.py
+++ b/tests/test_update_apply_ui.py
@@ -1,4 +1,5 @@
 """Frontend regression coverage for Update Now apply failures (#1321)."""
+
 from pathlib import Path
 import re
 
@@ -28,7 +29,10 @@ def test_update_apply_structured_server_errors_still_use_json_message_path():
     show_error_call = src.index("_showUpdateError(target,res);", apply_start)
     reset_button = src.index("resetApplyButton(0);", show_error_call)
     assert show_error_call < reset_button
-    assert "const msg='Update failed ('+target+'): '+(res.message||'unknown error');" in src
+    assert (
+        "const msg='Update failed ('+target+'): '+(res.message||'unknown error');"
+        in src
+    )
 
 
 def test_update_apply_network_error_classifier_ignores_http_status_errors():
@@ -39,7 +43,9 @@ def test_update_apply_network_error_classifier_ignores_http_status_errors():
     body = src[fn_start:fn_end]
     compact = re.sub(r"\s+", "", body)
     assert "if(error&&error.status)returnfalse;" in compact
-    assert body.index("error.status") < body.index("/Failed to fetch|NetworkError|Load failed/i")
+    assert body.index("error.status") < body.index(
+        "/Failed to fetch|NetworkError|Load failed/i"
+    )
     assert "Failed to fetch|NetworkError|Load failed" in body
 
 

--- a/tests/test_update_banner_fixes.py
+++ b/tests/test_update_banner_fixes.py
@@ -14,95 +14,98 @@ Covers:
 
 import pathlib
 import re
-import threading
 import time
-import sys
 import os
 
 REPO = pathlib.Path(__file__).parent.parent
 
 
 def read(rel):
-    return (REPO / rel).read_text(encoding='utf-8')
+    return (REPO / rel).read_text(encoding="utf-8")
 
 
 # ── api/updates.py ────────────────────────────────────────────────────────────
+
 
 class TestUpdateChecker:
     def test_repo_url_strips_only_dot_git_suffix(self, tmp_path, monkeypatch):
         import api.updates as upd
 
-        (tmp_path / '.git').mkdir()
+        (tmp_path / ".git").mkdir()
 
         def fake_run(args, cwd, timeout=10):
-            if args[0] == 'fetch':
-                return '', True
-            if args[:2] == ['rev-parse', '--abbrev-ref']:
-                return 'origin/master', True
-            if args[:2] == ['rev-list', '--count']:
-                return '0', True
-            if args[0] == 'merge-base':
-                return 'abcdef1234567890', True
-            if args[:2] == ['rev-parse', '--short']:
-                return 'abcdef1', True
-            if args[:2] == ['remote', 'get-url']:
-                return 'https://github.com/nesquena/hermes-webui.git', True
-            return '', True
+            if args[0] == "fetch":
+                return "", True
+            if args[:2] == ["rev-parse", "--abbrev-ref"]:
+                return "origin/master", True
+            if args[:2] == ["rev-list", "--count"]:
+                return "0", True
+            if args[0] == "merge-base":
+                return "abcdef1234567890", True
+            if args[:2] == ["rev-parse", "--short"]:
+                return "abcdef1", True
+            if args[:2] == ["remote", "get-url"]:
+                return "https://github.com/nesquena/hermes-webui.git", True
+            return "", True
 
-        monkeypatch.setattr(upd, '_run_git', fake_run)
-        result = upd._check_repo(tmp_path, 'webui')
+        monkeypatch.setattr(upd, "_run_git", fake_run)
+        result = upd._check_repo(tmp_path, "webui")
 
-        assert result['repo_url'] == 'https://github.com/nesquena/hermes-webui'
+        assert result["repo_url"] == "https://github.com/nesquena/hermes-webui"
 
-    def test_repo_url_converts_ssh_and_strips_only_dot_git_suffix(self, tmp_path, monkeypatch):
+    def test_repo_url_converts_ssh_and_strips_only_dot_git_suffix(
+        self, tmp_path, monkeypatch
+    ):
         import api.updates as upd
 
-        (tmp_path / '.git').mkdir()
+        (tmp_path / ".git").mkdir()
 
         def fake_run(args, cwd, timeout=10):
-            if args[0] == 'fetch':
-                return '', True
-            if args[:2] == ['rev-parse', '--abbrev-ref']:
-                return 'origin/main', True
-            if args[:2] == ['rev-list', '--count']:
-                return '0', True
-            if args[0] == 'merge-base':
-                return 'abcdef1234567890', True
-            if args[:2] == ['rev-parse', '--short']:
-                return 'abcdef1', True
-            if args[:2] == ['remote', 'get-url']:
-                return 'git@github.com:NousResearch/hermes-agent.git', True
-            return '', True
+            if args[0] == "fetch":
+                return "", True
+            if args[:2] == ["rev-parse", "--abbrev-ref"]:
+                return "origin/main", True
+            if args[:2] == ["rev-list", "--count"]:
+                return "0", True
+            if args[0] == "merge-base":
+                return "abcdef1234567890", True
+            if args[:2] == ["rev-parse", "--short"]:
+                return "abcdef1", True
+            if args[:2] == ["remote", "get-url"]:
+                return "git@github.com:NousResearch/hermes-agent.git", True
+            return "", True
 
-        monkeypatch.setattr(upd, '_run_git', fake_run)
-        result = upd._check_repo(tmp_path, 'agent')
+        monkeypatch.setattr(upd, "_run_git", fake_run)
+        result = upd._check_repo(tmp_path, "agent")
 
-        assert result['repo_url'] == 'https://github.com/NousResearch/hermes-agent'
+        assert result["repo_url"] == "https://github.com/NousResearch/hermes-agent"
 
-    def test_repo_url_strips_dot_git_before_trailing_slashes(self, tmp_path, monkeypatch):
+    def test_repo_url_strips_dot_git_before_trailing_slashes(
+        self, tmp_path, monkeypatch
+    ):
         import api.updates as upd
 
-        (tmp_path / '.git').mkdir()
+        (tmp_path / ".git").mkdir()
 
         def fake_run(args, cwd, timeout=10):
-            if args[0] == 'fetch':
-                return '', True
-            if args[:2] == ['rev-parse', '--abbrev-ref']:
-                return 'origin/master', True
-            if args[:2] == ['rev-list', '--count']:
-                return '2', True
-            if args[0] == 'merge-base':
-                return 'abcdef1234567890', True
-            if args[:2] == ['rev-parse', '--short']:
-                return 'abcdef1', True
-            if args[:2] == ['remote', 'get-url']:
-                return 'https://github.com/nesquena/hermes-webui.git/', True
-            return '', True
+            if args[0] == "fetch":
+                return "", True
+            if args[:2] == ["rev-parse", "--abbrev-ref"]:
+                return "origin/master", True
+            if args[:2] == ["rev-list", "--count"]:
+                return "2", True
+            if args[0] == "merge-base":
+                return "abcdef1234567890", True
+            if args[:2] == ["rev-parse", "--short"]:
+                return "abcdef1", True
+            if args[:2] == ["remote", "get-url"]:
+                return "https://github.com/nesquena/hermes-webui.git/", True
+            return "", True
 
-        monkeypatch.setattr(upd, '_run_git', fake_run)
-        result = upd._check_repo(tmp_path, 'webui')
+        monkeypatch.setattr(upd, "_run_git", fake_run)
+        result = upd._check_repo(tmp_path, "webui")
 
-        assert result['repo_url'] == 'https://github.com/nesquena/hermes-webui'
+        assert result["repo_url"] == "https://github.com/nesquena/hermes-webui"
 
 
 class TestConflictError:
@@ -112,54 +115,55 @@ class TestConflictError:
         import api.updates as upd
 
         # Fake a repo with conflict markers in git status output
-        (tmp_path / '.git').mkdir()
-        conflict_status = 'UU some/file.py'
+        (tmp_path / ".git").mkdir()
+        conflict_status = "UU some/file.py"
 
         calls = []
+
         def fake_run(args, cwd, timeout=10):
             calls.append(args)
-            if args[:2] == ['status', '--porcelain']:
+            if args[:2] == ["status", "--porcelain"]:
                 return conflict_status, True
-            if args[0] == 'fetch':
-                return '', True
-            if args[:2] == ['rev-parse', '--abbrev-ref']:
-                return 'origin/master', True
-            return '', True
+            if args[0] == "fetch":
+                return "", True
+            if args[:2] == ["rev-parse", "--abbrev-ref"]:
+                return "origin/master", True
+            return "", True
 
-        monkeypatch.setattr(upd, '_run_git', fake_run)
-        monkeypatch.setattr(upd, 'REPO_ROOT', tmp_path)
-        monkeypatch.setattr(upd, '_AGENT_DIR', tmp_path)
+        monkeypatch.setattr(upd, "_run_git", fake_run)
+        monkeypatch.setattr(upd, "REPO_ROOT", tmp_path)
+        monkeypatch.setattr(upd, "_AGENT_DIR", tmp_path)
 
-        result = upd.apply_update('webui')
-        assert result['ok'] is False
-        assert result.get('conflict') is True, "conflict flag must be True"
-        assert 'checkout' in result['message'] or 'pull' in result['message'], (
+        result = upd.apply_update("webui")
+        assert result["ok"] is False
+        assert result.get("conflict") is True, "conflict flag must be True"
+        assert "checkout" in result["message"] or "pull" in result["message"], (
             "conflict message must include recovery command"
         )
-        assert 'merge conflict' in result['message'].lower()
+        assert "merge conflict" in result["message"].lower()
 
     def test_conflict_message_includes_git_command(self, tmp_path, monkeypatch):
         import api.updates as upd
 
-        (tmp_path / '.git').mkdir()
+        (tmp_path / ".git").mkdir()
 
         def fake_run(args, cwd, timeout=10):
-            if args[:2] == ['status', '--porcelain']:
-                return 'AA conflict.txt', True
-            if args[0] == 'fetch':
-                return '', True
-            if args[:2] == ['rev-parse', '--abbrev-ref']:
-                return 'origin/master', True
-            return '', True
+            if args[:2] == ["status", "--porcelain"]:
+                return "AA conflict.txt", True
+            if args[0] == "fetch":
+                return "", True
+            if args[:2] == ["rev-parse", "--abbrev-ref"]:
+                return "origin/master", True
+            return "", True
 
-        monkeypatch.setattr(upd, '_run_git', fake_run)
-        monkeypatch.setattr(upd, 'REPO_ROOT', tmp_path)
-        monkeypatch.setattr(upd, '_AGENT_DIR', tmp_path)
+        monkeypatch.setattr(upd, "_run_git", fake_run)
+        monkeypatch.setattr(upd, "REPO_ROOT", tmp_path)
+        monkeypatch.setattr(upd, "_AGENT_DIR", tmp_path)
 
-        result = upd.apply_update('agent')
+        result = upd.apply_update("agent")
         # Message must be actionable — should mention git checkout or pull
-        msg = result['message']
-        assert 'git' in msg.lower(), f"message should mention git: {msg}"
+        msg = result["message"]
+        assert "git" in msg.lower(), f"message should mention git: {msg}"
 
 
 class TestScheduleRestart:
@@ -167,6 +171,7 @@ class TestScheduleRestart:
 
     def test_schedule_restart_exists(self):
         from api.updates import _schedule_restart
+
         assert callable(_schedule_restart)
 
     def test_schedule_restart_is_nonblocking(self, monkeypatch):
@@ -180,15 +185,18 @@ class TestScheduleRestart:
 
         # Monkeypatch os.execv inside the module's thread closure
         import os as _os
+
         original_execv = _os.execv
 
-        monkeypatch.setattr(_os, 'execv', fake_execv)
+        monkeypatch.setattr(_os, "execv", fake_execv)
 
         start = time.monotonic()
         upd._schedule_restart(delay=0.05)
         elapsed = time.monotonic() - start
 
-        assert elapsed < 0.5, f"_schedule_restart must return immediately, took {elapsed:.2f}s"
+        assert elapsed < 0.5, (
+            f"_schedule_restart must return immediately, took {elapsed:.2f}s"
+        )
         # Give the thread time to call execv
         time.sleep(0.2)
         assert execv_called, "_schedule_restart must eventually call os.execv"
@@ -202,28 +210,34 @@ class TestApplyUpdateRestartSafety:
         import api.updates as upd
         from api.config import STREAMS, STREAMS_LOCK
 
-        (tmp_path / '.git').mkdir()
-        monkeypatch.setattr(upd, 'REPO_ROOT', tmp_path)
-        monkeypatch.setattr(upd, '_AGENT_DIR', tmp_path)
+        (tmp_path / ".git").mkdir()
+        monkeypatch.setattr(upd, "REPO_ROOT", tmp_path)
+        monkeypatch.setattr(upd, "_AGENT_DIR", tmp_path)
         called = []
-        monkeypatch.setattr(upd, '_run_git', lambda *a, **k: (called.append(a) or ('', True)))
-        monkeypatch.setattr(upd, '_schedule_restart', lambda delay=2.0: (_ for _ in ()).throw(AssertionError('must not restart')))
+        monkeypatch.setattr(
+            upd, "_run_git", lambda *a, **k: called.append(a) or ("", True)
+        )
+        monkeypatch.setattr(
+            upd,
+            "_schedule_restart",
+            lambda delay=2.0: (_ for _ in ()).throw(AssertionError("must not restart")),
+        )
 
         with STREAMS_LOCK:
             old = dict(STREAMS)
             STREAMS.clear()
-            STREAMS['stream_active'] = queue.Queue()
+            STREAMS["stream_active"] = queue.Queue()
         try:
-            result = upd.apply_update('webui')
+            result = upd.apply_update("webui")
         finally:
             with STREAMS_LOCK:
                 STREAMS.clear()
                 STREAMS.update(old)
 
-        assert result['ok'] is False
-        assert result.get('active_streams') == 1
-        assert result.get('restart_blocked') is True
-        assert 'active chat stream' in result['message']
+        assert result["ok"] is False
+        assert result.get("active_streams") == 1
+        assert result.get("restart_blocked") is True
+        assert "active chat stream" in result["message"]
         assert called == []
 
     def test_force_update_refuses_when_stream_active(self, tmp_path, monkeypatch):
@@ -231,27 +245,35 @@ class TestApplyUpdateRestartSafety:
         import api.updates as upd
         from api.config import STREAMS, STREAMS_LOCK
 
-        (tmp_path / '.git').mkdir()
-        monkeypatch.setattr(upd, 'REPO_ROOT', tmp_path)
-        monkeypatch.setattr(upd, '_AGENT_DIR', tmp_path)
-        monkeypatch.setattr(upd, '_run_git', lambda *a, **k: (_ for _ in ()).throw(AssertionError('must not run git')))
-        monkeypatch.setattr(upd, '_schedule_restart', lambda delay=2.0: (_ for _ in ()).throw(AssertionError('must not restart')))
+        (tmp_path / ".git").mkdir()
+        monkeypatch.setattr(upd, "REPO_ROOT", tmp_path)
+        monkeypatch.setattr(upd, "_AGENT_DIR", tmp_path)
+        monkeypatch.setattr(
+            upd,
+            "_run_git",
+            lambda *a, **k: (_ for _ in ()).throw(AssertionError("must not run git")),
+        )
+        monkeypatch.setattr(
+            upd,
+            "_schedule_restart",
+            lambda delay=2.0: (_ for _ in ()).throw(AssertionError("must not restart")),
+        )
 
         with STREAMS_LOCK:
             old = dict(STREAMS)
             STREAMS.clear()
-            STREAMS['stream_active'] = queue.Queue()
+            STREAMS["stream_active"] = queue.Queue()
         try:
-            result = upd.apply_force_update('agent')
+            result = upd.apply_force_update("agent")
         finally:
             with STREAMS_LOCK:
                 STREAMS.clear()
                 STREAMS.update(old)
 
-        assert result['ok'] is False
-        assert result.get('active_streams') == 1
-        assert result.get('restart_blocked') is True
-        assert 'active chat stream' in result['message']
+        assert result["ok"] is False
+        assert result.get("active_streams") == 1
+        assert result.get("restart_blocked") is True
+        assert "active chat stream" in result["message"]
 
 
 class TestSuccessfulUpdateReturnsRestartScheduled:
@@ -260,28 +282,28 @@ class TestSuccessfulUpdateReturnsRestartScheduled:
     def test_apply_update_returns_restart_scheduled(self, tmp_path, monkeypatch):
         import api.updates as upd
 
-        (tmp_path / '.git').mkdir()
+        (tmp_path / ".git").mkdir()
 
         def fake_run(args, cwd, timeout=10):
-            if args[0] == 'fetch':
-                return '', True
-            if args[:2] == ['status', '--porcelain']:
-                return '', True   # clean tree
-            if args[:2] == ['rev-parse', '--abbrev-ref']:
-                return 'origin/master', True
-            if args[0] == 'pull':
-                return 'Already up to date.', True
-            return '', True
+            if args[0] == "fetch":
+                return "", True
+            if args[:2] == ["status", "--porcelain"]:
+                return "", True  # clean tree
+            if args[:2] == ["rev-parse", "--abbrev-ref"]:
+                return "origin/master", True
+            if args[0] == "pull":
+                return "Already up to date.", True
+            return "", True
 
-        monkeypatch.setattr(upd, '_run_git', fake_run)
-        monkeypatch.setattr(upd, 'REPO_ROOT', tmp_path)
-        monkeypatch.setattr(upd, '_AGENT_DIR', tmp_path)
+        monkeypatch.setattr(upd, "_run_git", fake_run)
+        monkeypatch.setattr(upd, "REPO_ROOT", tmp_path)
+        monkeypatch.setattr(upd, "_AGENT_DIR", tmp_path)
         # Don't actually restart
-        monkeypatch.setattr(upd, '_schedule_restart', lambda delay=2.0: None)
+        monkeypatch.setattr(upd, "_schedule_restart", lambda delay=2.0: None)
 
-        result = upd.apply_update('webui')
-        assert result['ok'] is True
-        assert result.get('restart_scheduled') is True, (
+        result = upd.apply_update("webui")
+        assert result["ok"] is True
+        assert result.get("restart_scheduled") is True, (
             "successful update must set restart_scheduled: True"
         )
 
@@ -292,106 +314,111 @@ class TestApplyForceUpdate:
     def test_apply_force_update_ok(self, tmp_path, monkeypatch):
         import api.updates as upd
 
-        (tmp_path / '.git').mkdir()
+        (tmp_path / ".git").mkdir()
         ran = []
 
         def fake_run(args, cwd, timeout=10):
             ran.append(args)
-            if args[0] == 'fetch':
-                return '', True
-            if args[:2] == ['rev-parse', '--abbrev-ref']:
-                return 'origin/master', True
-            if args[0] == 'checkout':
-                return '', True
-            if args[0] == 'reset':
-                return '', True
-            return '', True
+            if args[0] == "fetch":
+                return "", True
+            if args[:2] == ["rev-parse", "--abbrev-ref"]:
+                return "origin/master", True
+            if args[0] == "checkout":
+                return "", True
+            if args[0] == "reset":
+                return "", True
+            return "", True
 
-        monkeypatch.setattr(upd, '_run_git', fake_run)
-        monkeypatch.setattr(upd, 'REPO_ROOT', tmp_path)
-        monkeypatch.setattr(upd, '_AGENT_DIR', tmp_path)
-        monkeypatch.setattr(upd, '_schedule_restart', lambda delay=2.0: None)
+        monkeypatch.setattr(upd, "_run_git", fake_run)
+        monkeypatch.setattr(upd, "REPO_ROOT", tmp_path)
+        monkeypatch.setattr(upd, "_AGENT_DIR", tmp_path)
+        monkeypatch.setattr(upd, "_schedule_restart", lambda delay=2.0: None)
 
-        result = upd.apply_force_update('webui')
-        assert result['ok'] is True
-        assert result.get('restart_scheduled') is True
+        result = upd.apply_force_update("webui")
+        assert result["ok"] is True
+        assert result.get("restart_scheduled") is True
 
         git_cmds = [r[0] for r in ran]
-        assert 'reset' in git_cmds, "force update must call git reset --hard"
-        assert 'checkout' in git_cmds, "force update must call git checkout . to clear conflicts"
+        assert "reset" in git_cmds, "force update must call git reset --hard"
+        assert "checkout" in git_cmds, (
+            "force update must call git checkout . to clear conflicts"
+        )
 
     def test_apply_force_update_rejects_unknown_target(self, tmp_path, monkeypatch):
         import api.updates as upd
-        monkeypatch.setattr(upd, 'REPO_ROOT', tmp_path)
-        monkeypatch.setattr(upd, '_AGENT_DIR', tmp_path)
-        result = upd.apply_force_update('invalid')
-        assert result['ok'] is False
+
+        monkeypatch.setattr(upd, "REPO_ROOT", tmp_path)
+        monkeypatch.setattr(upd, "_AGENT_DIR", tmp_path)
+        result = upd.apply_force_update("invalid")
+        assert result["ok"] is False
 
 
 # ── api/routes.py ─────────────────────────────────────────────────────────────
+
 
 class TestForceUpdateRoute:
     """#813 — /api/updates/force route must exist in routes.py."""
 
     def test_force_route_exists(self):
-        src = read('api/routes.py')
+        src = read("api/routes.py")
         assert '"/api/updates/force"' in src, (
             "routes.py must handle POST /api/updates/force"
         )
-        assert 'apply_force_update' in src, (
+        assert "apply_force_update" in src, (
             "routes.py must import and call apply_force_update"
         )
 
 
 # ── static/ui.js ──────────────────────────────────────────────────────────────
 
+
 class TestUiJsUpdateBanner:
     """#813 + #814 — UI must show persistent error, force button, and correct toast."""
 
     def test_show_update_error_function_exists(self):
-        src = read('static/ui.js')
-        assert 'function _showUpdateError' in src, (
+        src = read("static/ui.js")
+        assert "function _showUpdateError" in src, (
             "_showUpdateError() must be defined in ui.js"
         )
 
     def test_force_update_function_exists(self):
-        src = read('static/ui.js')
-        assert 'function forceUpdate' in src or 'async function forceUpdate' in src, (
+        src = read("static/ui.js")
+        assert "function forceUpdate" in src or "async function forceUpdate" in src, (
             "forceUpdate() must be defined in ui.js"
         )
 
     def test_force_update_uses_confirm_dialog_not_native(self):
         """forceUpdate() must use showConfirmDialog(), not the banned native confirm()."""
-        src = read('static/ui.js')
-        m = re.search(r'function forceUpdate\b.*?\n\}', src, re.DOTALL)
+        src = read("static/ui.js")
+        m = re.search(r"function forceUpdate\b.*?\n\}", src, re.DOTALL)
         assert m, "forceUpdate() not found"
         fn = m.group(0)
-        assert 'showConfirmDialog' in fn, (
+        assert "showConfirmDialog" in fn, (
             "forceUpdate() must use showConfirmDialog() not the native confirm() "
             "(native confirm is banned by test_sprint33)"
         )
-        assert 'confirm(' not in fn.replace('showConfirmDialog(', ''), (
+        assert "confirm(" not in fn.replace("showConfirmDialog(", ""), (
             "forceUpdate() must not use native confirm()"
         )
 
     def test_force_update_calls_api_updates_force(self):
-        src = read('static/ui.js')
-        m = re.search(r'function forceUpdate\b.*?\n\}', src, re.DOTALL)
+        src = read("static/ui.js")
+        m = re.search(r"function forceUpdate\b.*?\n\}", src, re.DOTALL)
         assert m, "forceUpdate() not found"
         fn = m.group(0)
-        assert '/api/updates/force' in fn, (
+        assert "/api/updates/force" in fn, (
             "forceUpdate() must POST to /api/updates/force"
         )
 
     def test_success_toast_says_restarting(self):
-        src = read('static/ui.js')
-        m = re.search(r'function applyUpdates\b.*?\n\}', src, re.DOTALL)
+        src = read("static/ui.js")
+        m = re.search(r"function applyUpdates\b.*?\n\}", src, re.DOTALL)
         assert m, "applyUpdates() not found"
         fn = m.group(0)
-        assert 'restarting' in fn.lower(), (
+        assert "restarting" in fn.lower(), (
             "success toast must mention 'restarting' (server self-restarts after update)"
         )
-        assert 'Reloading' not in fn, (
+        assert "Reloading" not in fn, (
             "success toast must not say 'Reloading' — server restarts, page reloads after"
         )
 
@@ -402,16 +429,16 @@ class TestUiJsUpdateBanner:
         that return 502 immediately when the upstream socket is down.
         The polling approach retries until /health responds OK.
         """
-        src = read('static/ui.js')
-        m = re.search(r'function applyUpdates\b.*?\n\}', src, re.DOTALL)
+        src = read("static/ui.js")
+        m = re.search(r"function applyUpdates\b.*?\n\}", src, re.DOTALL)
         assert m, "applyUpdates() not found"
         fn = m.group(0)
-        assert '_waitForServerThenReload' in fn, (
+        assert "_waitForServerThenReload" in fn, (
             "applyUpdates() must call _waitForServerThenReload() instead of a blind "
             "setTimeout reload — blind timeouts race-lose against slow restarts and "
             "reverse proxies that 502 immediately on restart."
         )
-        assert 'setTimeout(()=>location.reload' not in fn, (
+        assert "setTimeout(()=>location.reload" not in fn, (
             "applyUpdates() must not use a fixed setTimeout reload — use _waitForServerThenReload()."
         )
 
@@ -419,23 +446,23 @@ class TestUiJsUpdateBanner:
         """_waitForServerThenReload() must actually exist — the original PR
         referenced it from applyUpdates()/forceUpdate() without defining it,
         which would have thrown ReferenceError on 'Update Now'."""
-        src = read('static/ui.js')
-        assert re.search(r'(async\s+)?function\s+_waitForServerThenReload\b', src), (
+        src = read("static/ui.js")
+        assert re.search(r"(async\s+)?function\s+_waitForServerThenReload\b", src), (
             "_waitForServerThenReload() is called but not defined — this breaks "
             "the Update Now flow entirely (ReferenceError at runtime)."
         )
 
     def test_wait_for_server_polls_health(self):
         """_waitForServerThenReload() must fetch health to determine readiness."""
-        src = read('static/ui.js')
-        m = re.search(r'function\s+_waitForServerThenReload\b.*?\n\}', src, re.DOTALL)
+        src = read("static/ui.js")
+        m = re.search(r"function\s+_waitForServerThenReload\b.*?\n\}", src, re.DOTALL)
         assert m, "_waitForServerThenReload() not found"
         fn = m.group(0)
         assert "new URL('health'" in fn, (
             "_waitForServerThenReload must poll the mount-relative health endpoint "
             "to detect server readiness"
         )
-        assert 'location.reload' in fn, (
+        assert "location.reload" in fn, (
             "_waitForServerThenReload must call location.reload() once the server is ready"
         )
 
@@ -443,83 +470,85 @@ class TestUiJsUpdateBanner:
         """When _restartingForUpdate flag is set, refreshSession() must do a
         full page reload rather than hit /api/session (which will 502 while
         the server is down)."""
-        src = read('static/ui.js')
-        m = re.search(r'async function refreshSession\b.*?\n\}', src, re.DOTALL)
+        src = read("static/ui.js")
+        m = re.search(r"async function refreshSession\b.*?\n\}", src, re.DOTALL)
         assert m, "refreshSession() not found"
         fn = m.group(0)
-        assert '_restartingForUpdate' in fn and 'location.reload' in fn, (
+        assert "_restartingForUpdate" in fn and "location.reload" in fn, (
             "refreshSession() must check the restart flag and bypass /api/session "
             "when the server is mid-restart."
         )
 
     def test_conflict_response_shows_force_button(self):
-        src = read('static/ui.js')
-        m = re.search(r'function _showUpdateError\b.*?\n\}', src, re.DOTALL)
+        src = read("static/ui.js")
+        m = re.search(r"function _showUpdateError\b.*?\n\}", src, re.DOTALL)
         assert m, "_showUpdateError() not found"
         fn = m.group(0)
-        assert 'conflict' in fn or 'diverged' in fn, (
+        assert "conflict" in fn or "diverged" in fn, (
             "_showUpdateError must check res.conflict / res.diverged to show force button"
         )
-        assert 'btnForceUpdate' in fn or 'forceBtn' in fn, (
+        assert "btnForceUpdate" in fn or "forceBtn" in fn, (
             "_showUpdateError must reference the force update button"
         )
 
     def test_error_displayed_persistently_not_just_toast(self):
-        src = read('static/ui.js')
-        m = re.search(r'function _showUpdateError\b.*?\n\}', src, re.DOTALL)
+        src = read("static/ui.js")
+        m = re.search(r"function _showUpdateError\b.*?\n\}", src, re.DOTALL)
         assert m
         fn = m.group(0)
-        assert 'updateError' in fn, (
+        assert "updateError" in fn, (
             "_showUpdateError must write to the #updateError element for persistent display"
         )
 
 
 class TestUpdateBannerUx:
     def test_update_banner_includes_repo_branch_labels(self):
-        src = read('static/ui.js')
-        assert 'function _formatUpdateTargetStatus' in src
-        assert 'info.branch' in src
+        src = read("static/ui.js")
+        assert "function _formatUpdateTargetStatus" in src
+        assert "info.branch" in src
         assert "_formatUpdateTargetStatus('WebUI',data.webui)" in src
         assert "_formatUpdateTargetStatus('Agent',data.agent)" in src
 
     def test_settings_update_check_uses_same_repo_branch_formatter(self):
-        src = read('static/panels.js')
-        m = re.search(r'async function checkUpdatesNow\b.*?\n\}', src, re.DOTALL)
+        src = read("static/panels.js")
+        m = re.search(r"async function checkUpdatesNow\b.*?\n\}", src, re.DOTALL)
         assert m, "checkUpdatesNow() not found"
         fn = m.group(0)
-        assert '_formatUpdateTargetStatus' in fn
+        assert "_formatUpdateTargetStatus" in fn
         assert "formatUpdatePart('WebUI',data.webui)" in fn
         assert "formatUpdatePart('Agent',data.agent)" in fn
 
 
 # ── static/index.html ─────────────────────────────────────────────────────────
 
+
 class TestIndexHtmlBanner:
     """#813 — update banner HTML must include error element and force button."""
 
     def test_update_error_element_exists(self):
-        src = read('static/index.html')
+        src = read("static/index.html")
         assert 'id="updateError"' in src, (
             "index.html must have #updateError element for persistent error display"
         )
 
     def test_force_update_button_exists(self):
-        src = read('static/index.html')
+        src = read("static/index.html")
         assert 'id="btnForceUpdate"' in src, (
             "index.html must have #btnForceUpdate button (hidden by default)"
         )
 
     def test_force_update_button_hidden_by_default(self):
-        src = read('static/index.html')
+        src = read("static/index.html")
         m = re.search(r'id="btnForceUpdate"[^>]*>', src)
         assert m, "#btnForceUpdate not found"
         tag = m.group(0)
-        assert 'display:none' in tag, (
+        assert "display:none" in tag, (
             "#btnForceUpdate must be hidden by default (display:none)"
         )
 
 
 # ── Regression: sequential webui+agent update — restart coordination ──────────
+
 
 class TestSequentialUpdateRestartCoordination:
     """Regression guard for the two-target race: when both webui and agent
@@ -547,7 +576,7 @@ class TestSequentialUpdateRestartCoordination:
             execv_time.append(_t.monotonic())
             execv_called.set()
 
-        monkeypatch.setattr(os, 'execv', fake_execv)
+        monkeypatch.setattr(os, "execv", fake_execv)
 
         # Hold _apply_lock from another thread (simulating an in-flight
         # second update) for 0.4 s.
@@ -592,18 +621,19 @@ class TestSequentialUpdateRestartCoordination:
         import time as _t
 
         execv_called = []
+
         def fake_execv(exe, args):
             execv_called.append(True)
-        monkeypatch.setattr(os, 'execv', fake_execv)
+
+        monkeypatch.setattr(os, "execv", fake_execv)
 
         upd._schedule_restart(delay=0.05)
         _t.sleep(0.25)
-        assert execv_called, (
-            "restart must still fire when _apply_lock is free"
-        )
+        assert execv_called, "restart must still fire when _apply_lock is free"
 
 
 # ── Regression: force button reset on retry ──────────────────────────────────
+
 
 class TestForceButtonResetOnRetry:
     """#813 UX: if a prior update attempt showed the force button (conflict),
@@ -612,14 +642,14 @@ class TestForceButtonResetOnRetry:
     pointing at the wrong target."""
 
     def test_apply_updates_resets_force_button_at_start(self):
-        src = read('static/ui.js')
-        m = re.search(r'async function applyUpdates\b.*?\n\}', src, re.DOTALL)
+        src = read("static/ui.js")
+        m = re.search(r"async function applyUpdates\b.*?\n\}", src, re.DOTALL)
         assert m, "applyUpdates() not found"
         fn = m.group(0)
         # The reset must appear BEFORE the main update loop, so it runs on
         # every retry — not only on first invocation.
-        setup, _, rest = fn.partition('const targets=')
-        assert 'btnForceUpdate' in setup, (
+        setup, _, rest = fn.partition("const targets=")
+        assert "btnForceUpdate" in setup, (
             "applyUpdates must reset btnForceUpdate visibility before "
             "starting the update loop (stale conflict state otherwise "
             "persists across retries)"
@@ -631,38 +661,36 @@ class TestForceButtonResetOnRetry:
 
 # ── #785: Manual 'Check for Updates' button ───────────────────────────────────
 
+
 class TestCheckForUpdatesButton:
     """#785: Ensure the 'Check for Updates' button is wired up correctly."""
 
     def test_checkUpdatesNow_defined_in_panels(self):
         """checkUpdatesNow() function must exist in panels.js."""
-        src = read('static/panels.js')
-        assert 'function checkUpdatesNow' in src or 'async function checkUpdatesNow' in src, (
-            "checkUpdatesNow() not found in panels.js"
-        )
+        src = read("static/panels.js")
+        assert (
+            "function checkUpdatesNow" in src or "async function checkUpdatesNow" in src
+        ), "checkUpdatesNow() not found in panels.js"
 
     def test_btnCheckUpdatesNow_in_html(self):
         """Button element with id='btnCheckUpdatesNow' must exist in index.html."""
-        src = read('static/index.html')
+        src = read("static/index.html")
         assert 'id="btnCheckUpdatesNow"' in src, (
             "btnCheckUpdatesNow element not found in index.html"
         )
 
     def test_checkUpdatesBlock_css_exists(self):
         """CSS rules for #checkUpdatesBlock and .btn-tiny must exist in style.css."""
-        src = read('static/style.css')
-        assert '#checkUpdatesBlock' in src, (
+        src = read("static/style.css")
+        assert "#checkUpdatesBlock" in src, (
             "#checkUpdatesBlock CSS selector not found in style.css"
         )
-        assert '.btn-tiny' in src, (
-            ".btn-tiny CSS selector not found in style.css"
-        )
+        assert ".btn-tiny" in src, ".btn-tiny CSS selector not found in style.css"
 
     def test_check_now_i18n_key_exists(self):
         """settings_check_now i18n key must exist in all locale blocks."""
-        src = read('static/i18n.js')
-        count = src.count('settings_check_now')
+        src = read("static/i18n.js")
+        count = src.count("settings_check_now")
         assert count >= 5, (
             f"settings_check_now found in only {count} locale blocks (expected ≥5: en, ru, es, zh, zh-Hant)"
         )
-

--- a/tests/test_update_checker.py
+++ b/tests/test_update_checker.py
@@ -8,22 +8,22 @@ Tests cover the four new branches in _apply_update_inner():
   3. pull fails + no upstream tracking  → recovery command with set-upstream-to
   4. pull fails + generic fallback  → raw git output truncated at 300 chars
 """
-from pathlib import Path
-from unittest.mock import patch, call
-import subprocess
 
-import pytest
+from unittest.mock import patch
 
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _make_run_git_side_effect(*sequence):
     """Return a side_effect function that yields successive (stdout, ok) tuples."""
     it = iter(sequence)
+
     def _side_effect(args, cwd, timeout=10):
         return next(it)
+
     return _side_effect
 
 
@@ -31,12 +31,13 @@ def _make_run_git_side_effect(*sequence):
 # Path used for patching
 # ---------------------------------------------------------------------------
 
-_MODULE = 'api.updates'
+_MODULE = "api.updates"
 
 
 # ---------------------------------------------------------------------------
 # Tests for _apply_update_inner() diagnostic paths
 # ---------------------------------------------------------------------------
+
 
 class TestApplyUpdateDiagnostics:
     """New code paths introduced in PR #227."""
@@ -44,8 +45,11 @@ class TestApplyUpdateDiagnostics:
     def _apply(self, target, run_git_side_effect):
         """Call _apply_update_inner with _apply_lock bypassed and _run_git mocked."""
         from api import updates
-        with patch(f'{_MODULE}._run_git', side_effect=run_git_side_effect), \
-             patch.object(updates, '_apply_lock') as mock_lock:
+
+        with (
+            patch(f"{_MODULE}._run_git", side_effect=run_git_side_effect),
+            patch.object(updates, "_apply_lock") as mock_lock,
+        ):
             mock_lock.acquire.return_value = True
             mock_lock.release.return_value = None
             return updates._apply_update_inner(target)
@@ -56,34 +60,44 @@ class TestApplyUpdateDiagnostics:
 
     def test_fetch_failure_returns_network_error_message(self, tmp_path):
         """When git fetch fails, return a human-readable connection error."""
-        (tmp_path / '.git').mkdir()
+        (tmp_path / ".git").mkdir()
 
         from api import updates
-        with patch(f'{_MODULE}.REPO_ROOT', tmp_path), \
-             patch(f'{_MODULE}._run_git') as mock_run_git:
+
+        with (
+            patch(f"{_MODULE}.REPO_ROOT", tmp_path),
+            patch(f"{_MODULE}._run_git") as mock_run_git,
+        ):
             # Call sequence: upstream query, fetch
             mock_run_git.side_effect = [
-                ('origin/master', True),   # rev-parse @{upstream}
-                ('', False),               # fetch fails
+                ("origin/master", True),  # rev-parse @{upstream}
+                ("", False),  # fetch fails
             ]
-            result = updates._apply_update_inner('webui')
+            result = updates._apply_update_inner("webui")
 
-        assert result['ok'] is False
-        msg = result['message'].lower()
-        assert 'could not reach' in msg or 'internet connection' in msg or 'remote repository' in msg
+        assert result["ok"] is False
+        msg = result["message"].lower()
+        assert (
+            "could not reach" in msg
+            or "internet connection" in msg
+            or "remote repository" in msg
+        )
 
     def test_fetch_failure_does_not_attempt_pull(self, tmp_path):
         """When fetch fails, pull is never called."""
-        (tmp_path / '.git').mkdir()
+        (tmp_path / ".git").mkdir()
 
         from api import updates
-        with patch(f'{_MODULE}.REPO_ROOT', tmp_path), \
-             patch(f'{_MODULE}._run_git') as mock_run_git:
+
+        with (
+            patch(f"{_MODULE}.REPO_ROOT", tmp_path),
+            patch(f"{_MODULE}._run_git") as mock_run_git,
+        ):
             mock_run_git.side_effect = [
-                ('origin/master', True),   # upstream query
-                ('', False),               # fetch fails
+                ("origin/master", True),  # upstream query
+                ("", False),  # fetch fails
             ]
-            updates._apply_update_inner('webui')
+            updates._apply_update_inner("webui")
             # Only 2 calls: upstream query + fetch. No pull call.
             assert mock_run_git.call_count == 2
 
@@ -93,59 +107,68 @@ class TestApplyUpdateDiagnostics:
 
     def test_diverged_history_returns_reset_hard_command(self, tmp_path):
         """Diverged history produces a message with 'reset --hard'."""
-        (tmp_path / '.git').mkdir()
+        (tmp_path / ".git").mkdir()
 
         from api import updates
-        with patch(f'{_MODULE}.REPO_ROOT', tmp_path), \
-             patch(f'{_MODULE}._run_git') as mock_run_git:
-            mock_run_git.side_effect = [
-                ('origin/master', True),                          # upstream query
-                ('', True),                                       # fetch succeeds
-                ('', True),                                       # status --porcelain (clean)
-                ('Not possible to fast-forward, aborting.', False),  # pull fails
-            ]
-            result = updates._apply_update_inner('webui')
 
-        assert result['ok'] is False
-        assert result.get('diverged') is True
-        msg = result['message']
-        assert 'reset --hard' in msg
+        with (
+            patch(f"{_MODULE}.REPO_ROOT", tmp_path),
+            patch(f"{_MODULE}._run_git") as mock_run_git,
+        ):
+            mock_run_git.side_effect = [
+                ("origin/master", True),  # upstream query
+                ("", True),  # fetch succeeds
+                ("", True),  # status --porcelain (clean)
+                ("Not possible to fast-forward, aborting.", False),  # pull fails
+            ]
+            result = updates._apply_update_inner("webui")
+
+        assert result["ok"] is False
+        assert result.get("diverged") is True
+        msg = result["message"]
+        assert "reset --hard" in msg
 
     def test_diverged_history_message_contains_compare_ref(self, tmp_path):
         """Diverged history message includes the upstream ref."""
-        (tmp_path / '.git').mkdir()
+        (tmp_path / ".git").mkdir()
 
         from api import updates
-        with patch(f'{_MODULE}.REPO_ROOT', tmp_path), \
-             patch(f'{_MODULE}._run_git') as mock_run_git:
-            mock_run_git.side_effect = [
-                ('origin/feat/my-feature', True),   # upstream query
-                ('', True),                         # fetch
-                ('', True),                         # status (clean)
-                ('Your branch and origin have diverged.', False),  # pull
-            ]
-            result = updates._apply_update_inner('webui')
 
-        assert result['ok'] is False
-        assert 'origin/feat/my-feature' in result['message']
+        with (
+            patch(f"{_MODULE}.REPO_ROOT", tmp_path),
+            patch(f"{_MODULE}._run_git") as mock_run_git,
+        ):
+            mock_run_git.side_effect = [
+                ("origin/feat/my-feature", True),  # upstream query
+                ("", True),  # fetch
+                ("", True),  # status (clean)
+                ("Your branch and origin have diverged.", False),  # pull
+            ]
+            result = updates._apply_update_inner("webui")
+
+        assert result["ok"] is False
+        assert "origin/feat/my-feature" in result["message"]
 
     def test_diverged_matching_is_case_insensitive(self, tmp_path):
         """'DIVERGED' in uppercase is still detected."""
-        (tmp_path / '.git').mkdir()
+        (tmp_path / ".git").mkdir()
 
         from api import updates
-        with patch(f'{_MODULE}.REPO_ROOT', tmp_path), \
-             patch(f'{_MODULE}._run_git') as mock_run_git:
-            mock_run_git.side_effect = [
-                ('origin/master', True),
-                ('', True),
-                ('', True),
-                ('DIVERGED from upstream', False),
-            ]
-            result = updates._apply_update_inner('webui')
 
-        assert result['ok'] is False
-        assert result.get('diverged') is True
+        with (
+            patch(f"{_MODULE}.REPO_ROOT", tmp_path),
+            patch(f"{_MODULE}._run_git") as mock_run_git,
+        ):
+            mock_run_git.side_effect = [
+                ("origin/master", True),
+                ("", True),
+                ("", True),
+                ("DIVERGED from upstream", False),
+            ]
+            result = updates._apply_update_inner("webui")
+
+        assert result["ok"] is False
+        assert result.get("diverged") is True
 
     # ------------------------------------------------------------------
     # Path 3: pull fails + no upstream tracking configured
@@ -153,58 +176,73 @@ class TestApplyUpdateDiagnostics:
 
     def test_no_tracking_returns_set_upstream_command(self, tmp_path):
         """Missing upstream tracking branch produces set-upstream-to message."""
-        (tmp_path / '.git').mkdir()
+        (tmp_path / ".git").mkdir()
 
         from api import updates
-        with patch(f'{_MODULE}.REPO_ROOT', tmp_path), \
-             patch(f'{_MODULE}._run_git') as mock_run_git:
-            mock_run_git.side_effect = [
-                ('origin/master', True),                               # upstream query
-                ('', True),                                            # fetch
-                ('', True),                                            # status (clean)
-                ('There is no tracking information for the current branch.', False),  # pull
-            ]
-            result = updates._apply_update_inner('webui')
 
-        assert result['ok'] is False
-        assert 'set-upstream-to' in result['message']
-        assert result.get('diverged') is None
+        with (
+            patch(f"{_MODULE}.REPO_ROOT", tmp_path),
+            patch(f"{_MODULE}._run_git") as mock_run_git,
+        ):
+            mock_run_git.side_effect = [
+                ("origin/master", True),  # upstream query
+                ("", True),  # fetch
+                ("", True),  # status (clean)
+                (
+                    "There is no tracking information for the current branch.",
+                    False,
+                ),  # pull
+            ]
+            result = updates._apply_update_inner("webui")
+
+        assert result["ok"] is False
+        assert "set-upstream-to" in result["message"]
+        assert result.get("diverged") is None
 
     def test_no_tracking_alternate_phrasing(self, tmp_path):
         """'does not track' alternate git message is also detected."""
-        (tmp_path / '.git').mkdir()
+        (tmp_path / ".git").mkdir()
 
         from api import updates
-        with patch(f'{_MODULE}.REPO_ROOT', tmp_path), \
-             patch(f'{_MODULE}._run_git') as mock_run_git:
-            mock_run_git.side_effect = [
-                ('origin/master', True),
-                ('', True),
-                ('', True),
-                ('fatal: The current branch local does not track a remote branch.', False),
-            ]
-            result = updates._apply_update_inner('webui')
 
-        assert result['ok'] is False
-        assert 'set-upstream-to' in result['message']
+        with (
+            patch(f"{_MODULE}.REPO_ROOT", tmp_path),
+            patch(f"{_MODULE}._run_git") as mock_run_git,
+        ):
+            mock_run_git.side_effect = [
+                ("origin/master", True),
+                ("", True),
+                ("", True),
+                (
+                    "fatal: The current branch local does not track a remote branch.",
+                    False,
+                ),
+            ]
+            result = updates._apply_update_inner("webui")
+
+        assert result["ok"] is False
+        assert "set-upstream-to" in result["message"]
 
     def test_no_tracking_message_contains_compare_ref(self, tmp_path):
         """set-upstream-to message includes the upstream ref to configure."""
-        (tmp_path / '.git').mkdir()
+        (tmp_path / ".git").mkdir()
 
         from api import updates
-        with patch(f'{_MODULE}.REPO_ROOT', tmp_path), \
-             patch(f'{_MODULE}._run_git') as mock_run_git:
-            mock_run_git.side_effect = [
-                ('origin/main', True),
-                ('', True),
-                ('', True),
-                ('no tracking information', False),
-            ]
-            result = updates._apply_update_inner('webui')
 
-        assert result['ok'] is False
-        assert 'origin/main' in result['message']
+        with (
+            patch(f"{_MODULE}.REPO_ROOT", tmp_path),
+            patch(f"{_MODULE}._run_git") as mock_run_git,
+        ):
+            mock_run_git.side_effect = [
+                ("origin/main", True),
+                ("", True),
+                ("", True),
+                ("no tracking information", False),
+            ]
+            result = updates._apply_update_inner("webui")
+
+        assert result["ok"] is False
+        assert "origin/main" in result["message"]
 
     # ------------------------------------------------------------------
     # Path 4: pull fails + generic fallback (truncated raw output)
@@ -212,61 +250,70 @@ class TestApplyUpdateDiagnostics:
 
     def test_generic_failure_includes_truncated_git_output(self, tmp_path):
         """Generic pull failure includes up to 300 chars of git output."""
-        (tmp_path / '.git').mkdir()
-        long_error = 'X' * 500  # 500-char error from git
+        (tmp_path / ".git").mkdir()
+        long_error = "X" * 500  # 500-char error from git
 
         from api import updates
-        with patch(f'{_MODULE}.REPO_ROOT', tmp_path), \
-             patch(f'{_MODULE}._run_git') as mock_run_git:
+
+        with (
+            patch(f"{_MODULE}.REPO_ROOT", tmp_path),
+            patch(f"{_MODULE}._run_git") as mock_run_git,
+        ):
             mock_run_git.side_effect = [
-                ('origin/master', True),
-                ('', True),
-                ('', True),
+                ("origin/master", True),
+                ("", True),
+                ("", True),
                 (long_error, False),
             ]
-            result = updates._apply_update_inner('webui')
+            result = updates._apply_update_inner("webui")
 
-        assert result['ok'] is False
-        msg = result['message']
+        assert result["ok"] is False
+        msg = result["message"]
         # The raw output in the message must be truncated at 300 chars
-        assert 'X' * 300 in msg
-        assert 'X' * 301 not in msg
+        assert "X" * 300 in msg
+        assert "X" * 301 not in msg
 
     def test_generic_failure_empty_output_shows_sentinel(self, tmp_path):
         """When git produces no output, message contains a fallback sentinel."""
-        (tmp_path / '.git').mkdir()
+        (tmp_path / ".git").mkdir()
 
         from api import updates
-        with patch(f'{_MODULE}.REPO_ROOT', tmp_path), \
-             patch(f'{_MODULE}._run_git') as mock_run_git:
-            mock_run_git.side_effect = [
-                ('origin/master', True),
-                ('', True),
-                ('', True),
-                ('', False),   # pull fails with empty output
-            ]
-            result = updates._apply_update_inner('webui')
 
-        assert result['ok'] is False
-        assert 'no output' in result['message'].lower() or result['message']
+        with (
+            patch(f"{_MODULE}.REPO_ROOT", tmp_path),
+            patch(f"{_MODULE}._run_git") as mock_run_git,
+        ):
+            mock_run_git.side_effect = [
+                ("origin/master", True),
+                ("", True),
+                ("", True),
+                ("", False),  # pull fails with empty output
+            ]
+            result = updates._apply_update_inner("webui")
+
+        assert result["ok"] is False
+        assert "no output" in result["message"].lower() or result["message"]
 
     def test_generic_failure_does_not_set_diverged(self, tmp_path):
         """A generic pull failure must not set diverged=True."""
-        (tmp_path / '.git').mkdir()
+        (tmp_path / ".git").mkdir()
 
         from api import updates
-        with patch(f'{_MODULE}.REPO_ROOT', tmp_path), \
-             patch(f'{_MODULE}._run_git') as mock_run_git:
-            mock_run_git.side_effect = [
-                ('origin/master', True),
-                ('', True),
-                ('', True),
-                ('Some unrecognized git error', False),
-            ]
-            result = updates._apply_update_inner('webui')
 
-        assert result['ok'] is False
-        assert not result.get('diverged')
+        with (
+            patch(f"{_MODULE}.REPO_ROOT", tmp_path),
+            patch(f"{_MODULE}._run_git") as mock_run_git,
+        ):
+            mock_run_git.side_effect = [
+                ("origin/master", True),
+                ("", True),
+                ("", True),
+                ("Some unrecognized git error", False),
+            ]
+            result = updates._apply_update_inner("webui")
+
+        assert result["ok"] is False
+        assert not result.get("diverged")
 
     # ------------------------------------------------------------------
     # Regression: existing success path still works after fetch addition
@@ -274,25 +321,28 @@ class TestApplyUpdateDiagnostics:
 
     def test_successful_update_still_returns_ok(self, tmp_path):
         """Fetch + status + pull success path returns ok=True (regression guard)."""
-        (tmp_path / '.git').mkdir()
+        (tmp_path / ".git").mkdir()
 
         from api import updates
+
         # Patch the cache's 'checked_at' key directly to avoid the lock
         # invalidation block raising. We use a fresh dict swap.
-        fake_cache = {'webui': None, 'agent': None, 'checked_at': 1}
-        with patch(f'{_MODULE}.REPO_ROOT', tmp_path), \
-             patch(f'{_MODULE}._run_git') as mock_run_git, \
-             patch(f'{_MODULE}._update_cache', fake_cache), \
-             patch(f'{_MODULE}._cache_lock'):
+        fake_cache = {"webui": None, "agent": None, "checked_at": 1}
+        with (
+            patch(f"{_MODULE}.REPO_ROOT", tmp_path),
+            patch(f"{_MODULE}._run_git") as mock_run_git,
+            patch(f"{_MODULE}._update_cache", fake_cache),
+            patch(f"{_MODULE}._cache_lock"),
+        ):
             mock_run_git.side_effect = [
-                ('origin/master', True),          # upstream query
-                ('', True),                       # fetch succeeds
-                ('', True),                       # status (clean working tree)
-                ('Already up to date.', True),    # pull succeeds
+                ("origin/master", True),  # upstream query
+                ("", True),  # fetch succeeds
+                ("", True),  # status (clean working tree)
+                ("Already up to date.", True),  # pull succeeds
             ]
-            result = updates._apply_update_inner('webui')
+            result = updates._apply_update_inner("webui")
 
-        assert result['ok'] is True
+        assert result["ok"] is True
 
     # ------------------------------------------------------------------
     # Agent target works the same as webui target
@@ -300,18 +350,23 @@ class TestApplyUpdateDiagnostics:
 
     def test_fetch_failure_for_agent_target(self, tmp_path):
         """Fetch failure path also works when target='agent'."""
-        (tmp_path / '.git').mkdir()
+        (tmp_path / ".git").mkdir()
 
         from api import updates
-        with patch(f'{_MODULE}._AGENT_DIR', tmp_path), \
-             patch(f'{_MODULE}._run_git') as mock_run_git:
-            mock_run_git.side_effect = [
-                ('origin/master', True),
-                ('', False),   # fetch fails
-            ]
-            result = updates._apply_update_inner('agent')
 
-        assert result['ok'] is False
-        assert 'could not reach' in result['message'].lower() or \
-               'internet' in result['message'].lower() or \
-               'remote' in result['message'].lower()
+        with (
+            patch(f"{_MODULE}._AGENT_DIR", tmp_path),
+            patch(f"{_MODULE}._run_git") as mock_run_git,
+        ):
+            mock_run_git.side_effect = [
+                ("origin/master", True),
+                ("", False),  # fetch fails
+            ]
+            result = updates._apply_update_inner("agent")
+
+        assert result["ok"] is False
+        assert (
+            "could not reach" in result["message"].lower()
+            or "internet" in result["message"].lower()
+            or "remote" in result["message"].lower()
+        )

--- a/tests/test_updates.py
+++ b/tests/test_updates.py
@@ -1,4 +1,5 @@
 """Tests for self-update diagnostics (api/updates.py)."""
+
 from unittest.mock import MagicMock, patch
 
 import api.updates as updates
@@ -6,13 +7,13 @@ import api.updates as updates
 
 def test_run_git_returns_stderr_on_failure(tmp_path):
     """When a git command fails, _run_git should return stderr (not empty string)."""
-    with patch('subprocess.run') as mock_run:
+    with patch("subprocess.run") as mock_run:
         mock_run.return_value = MagicMock(
             returncode=1,
-            stdout='',
+            stdout="",
             stderr="fatal: 'origin/master' does not appear to be a git repository\n",
         )
-        out, ok = updates._run_git(['pull', '--ff-only', 'origin/master'], tmp_path)
+        out, ok = updates._run_git(["pull", "--ff-only", "origin/master"], tmp_path)
 
     assert ok is False
     assert "does not appear to be a git repository" in out
@@ -20,34 +21,34 @@ def test_run_git_returns_stderr_on_failure(tmp_path):
 
 def test_run_git_returns_stdout_when_no_stderr(tmp_path):
     """If stderr is empty on failure, fall back to stdout."""
-    with patch('subprocess.run') as mock_run:
+    with patch("subprocess.run") as mock_run:
         mock_run.return_value = MagicMock(
             returncode=128,
-            stdout='Already up to date.',
-            stderr='',
+            stdout="Already up to date.",
+            stderr="",
         )
-        out, ok = updates._run_git(['pull'], tmp_path)
+        out, ok = updates._run_git(["pull"], tmp_path)
 
     assert ok is False
-    assert 'Already up to date' in out
+    assert "Already up to date" in out
 
 
 def test_run_git_returns_exit_code_when_no_output(tmp_path):
     """If both stdout and stderr are empty, report the exit code."""
-    with patch('subprocess.run') as mock_run:
+    with patch("subprocess.run") as mock_run:
         mock_run.return_value = MagicMock(
             returncode=1,
-            stdout='',
-            stderr='',
+            stdout="",
+            stderr="",
         )
-        out, ok = updates._run_git(['status'], tmp_path)
+        out, ok = updates._run_git(["status"], tmp_path)
 
     assert ok is False
-    assert 'status 1' in out
+    assert "status 1" in out
 
 
 def test_split_remote_ref_splits_tracking_ref():
     """_split_remote_ref should correctly split origin/branch."""
-    assert updates._split_remote_ref('origin/master') == ('origin', 'master')
-    assert updates._split_remote_ref('origin/feature/foo') == ('origin', 'feature/foo')
-    assert updates._split_remote_ref('master') == (None, 'master')
+    assert updates._split_remote_ref("origin/master") == ("origin", "master")
+    assert updates._split_remote_ref("origin/feature/foo") == ("origin", "feature/foo")
+    assert updates._split_remote_ref("master") == (None, "master")

--- a/tests/test_v050253_opus_followups.py
+++ b/tests/test_v050253_opus_followups.py
@@ -52,8 +52,7 @@ def test_branch_endpoint_rejects_negative_keep_count():
         "and that's a confusing fork behavior."
     )
     assert '"keep_count must be non-negative"' in block, (
-        "branch handler must return a clear error message for negative "
-        "keep_count."
+        "branch handler must return a clear error message for negative keep_count."
     )
 
 

--- a/tests/test_v050255_opus_followups.py
+++ b/tests/test_v050255_opus_followups.py
@@ -26,7 +26,6 @@ The v0.50.255 batch (#1390 + #1405) had four Opus advisor findings:
 
 from __future__ import annotations
 
-import re
 from pathlib import Path
 
 import pytest
@@ -64,6 +63,7 @@ def test_rollback_validates_checkpoint_id_against_path_traversal():
 def test_rollback_validate_checkpoint_id_runtime_behavior():
     """End-to-end test of the validator: traversal attempts raise ValueError."""
     import sys
+
     sys.path.insert(0, str(REPO))
     from api.rollback import _validate_checkpoint_id
 
@@ -122,6 +122,7 @@ def test_redact_session_data_threads_enabled_once_across_recursion():
     of api_redact_enabled, not N. We verify by counting load_settings calls
     via monkeypatch."""
     import sys
+
     sys.path.insert(0, str(REPO))
     from api import helpers
 
@@ -135,6 +136,7 @@ def test_redact_session_data_threads_enabled_once_across_recursion():
     # The from-import inside redact_session_data resolves at call time, so
     # patch in api.config where it lives.
     from api import config
+
     original = config.load_settings
     config.load_settings = counting_load_settings
     try:
@@ -142,8 +144,7 @@ def test_redact_session_data_threads_enabled_once_across_recursion():
         session = {
             "title": "Test session",
             "messages": [
-                {"role": "user", "content": "hello world " * 10}
-                for _ in range(20)
+                {"role": "user", "content": "hello world " * 10} for _ in range(20)
             ],
             "tool_calls": [
                 {"name": "tool", "args": {"x": "y", "z": ["a", "b", "c"]}}

--- a/tests/test_v050257_opus_followups.py
+++ b/tests/test_v050257_opus_followups.py
@@ -37,7 +37,6 @@ import sys
 import tempfile
 from pathlib import Path
 
-import pytest
 
 REPO = Path(__file__).resolve().parents[1]
 
@@ -102,7 +101,10 @@ def test_cron_history_rejects_traversal_in_job_id():
     detail_body = src[detail_idx : detail_idx + 1500]
 
     # Both must include the regex check
-    for body, name in [(history_body, "_handle_cron_history"), (detail_body, "_handle_cron_run_detail")]:
+    for body, name in [
+        (history_body, "_handle_cron_history"),
+        (detail_body, "_handle_cron_run_detail"),
+    ]:
         assert "_re.fullmatch" in body and "[A-Za-z0-9_-]" in body, (
             f"{name} must validate job_id via regex — without this, "
             f"`?job_id=../<other>` enumerates sibling directory contents."
@@ -131,7 +133,6 @@ def test_cron_history_clamps_offset_and_limit():
         "_handle_cron_history must clamp `limit` to a sane upper bound (500 chosen) "
         "to prevent DoS via `?limit=999999999`."
     )
-
 
 
 # ── Critical Opus finding: enabled_toolsets actually applies ─────────────────
@@ -176,26 +177,31 @@ def test_session_load_metadata_only_returns_instance_not_dict():
     if a future change converts it to a dict."""
     sys.path.insert(0, str(REPO))
     from api.models import Session
-    import tempfile
 
     with tempfile.TemporaryDirectory() as tmpd:
         # Create a fake session file
         import json as _json
+
         sid = "test1234abcd"
         from api import models
+
         original = models.SESSION_DIR
         models.SESSION_DIR = Path(tmpd)
         try:
             session_file = Path(tmpd) / f"{sid}.json"
-            session_file.write_text(_json.dumps({
-                "session_id": sid,
-                "title": "Test",
-                "workspace": tmpd,
-                "model": "test/model",
-                "enabled_toolsets": ["bash", "file"],
-                "messages": [],
-                "tool_calls": [],
-            }))
+            session_file.write_text(
+                _json.dumps(
+                    {
+                        "session_id": sid,
+                        "title": "Test",
+                        "workspace": tmpd,
+                        "model": "test/model",
+                        "enabled_toolsets": ["bash", "file"],
+                        "messages": [],
+                        "tool_calls": [],
+                    }
+                )
+            )
             result = Session.load_metadata_only(sid)
         finally:
             models.SESSION_DIR = original
@@ -206,4 +212,4 @@ def test_session_load_metadata_only_returns_instance_not_dict():
         f"load_metadata_only must return Session instance, got {type(result)}"
     )
     # And the enabled_toolsets must be readable via getattr
-    assert getattr(result, 'enabled_toolsets', None) == ["bash", "file"]
+    assert getattr(result, "enabled_toolsets", None) == ["bash", "file"]

--- a/tests/test_v050258_opus_followups.py
+++ b/tests/test_v050258_opus_followups.py
@@ -29,7 +29,6 @@ path-with-query string that the browser auto-decodes once.
 
 from __future__ import annotations
 
-import re
 import urllib.parse as _urlparse
 from pathlib import Path
 

--- a/tests/test_v050259_sessiondb_fd_leak.py
+++ b/tests/test_v050259_sessiondb_fd_leak.py
@@ -17,7 +17,6 @@ finalizes the agent — which on a long-running server may be never.
 
 from __future__ import annotations
 
-import os
 from pathlib import Path
 
 import pytest
@@ -80,14 +79,14 @@ def test_lru_eviction_closes_evicted_agent_session_db():
     # Negative pattern: the old `evicted_sid, _ = ...` discard form must NOT
     # be present — that's the bug shape.
     assert "evicted_sid, _ = SESSION_AGENT_CACHE.popitem" not in block, (
-        "LRU eviction must capture the evicted entry so the agent\'s "
+        "LRU eviction must capture the evicted entry so the agent's "
         "_session_db can be closed. The `evicted_sid, _ = ...` discard form "
         "is the original bug shape."
     )
 
     # Positive pattern: must close on the evicted agent.
     assert "_evicted_agent._session_db.close()" in block, (
-        "LRU eviction must close the evicted agent\'s _session_db. "
+        "LRU eviction must close the evicted agent's _session_db. "
         "(Opus pre-release follow-up to PR #1421.)"
     )
 
@@ -107,8 +106,11 @@ def test_session_db_close_is_idempotent():
     confirmation when both repos are co-located.
     """
     import importlib.util
+
     if importlib.util.find_spec("hermes_state") is None:
-        pytest.skip("hermes_state not on import path (CI-only — agent repo not present)")
+        pytest.skip(
+            "hermes_state not on import path (CI-only — agent repo not present)"
+        )
     from hermes_state import SessionDB  # type: ignore
     import tempfile
 
@@ -136,12 +138,14 @@ def test_cached_agent_reuse_calls_close_on_old_session_db():
     agent and verify the mock SessionDB.close() is called when _session_db
     is replaced. Pins the runtime behavior, not just the source pattern."""
     import sys
+
     sys.path.insert(0, str(REPO))
 
     class MockSessionDB:
         def __init__(self, name):
             self.name = name
             self.close_calls = 0
+
         def close(self):
             self.close_calls += 1
 
@@ -188,6 +192,7 @@ def test_lru_eviction_closes_evicted_session_db():
         def __init__(self, name):
             self.name = name
             self.close_calls = 0
+
         def close(self):
             self.close_calls += 1
 
@@ -206,8 +211,13 @@ def test_lru_eviction_closes_evicted_session_db():
     while len(cache) > MAX:
         evicted_sid, evicted_entry = cache.popitem(last=False)
         try:
-            _evicted_agent = evicted_entry[0] if isinstance(evicted_entry, tuple) else None
-            if _evicted_agent is not None and getattr(_evicted_agent, "_session_db", None) is not None:
+            _evicted_agent = (
+                evicted_entry[0] if isinstance(evicted_entry, tuple) else None
+            )
+            if (
+                _evicted_agent is not None
+                and getattr(_evicted_agent, "_session_db", None) is not None
+            ):
                 _evicted_agent._session_db.close()
         except Exception:
             pass

--- a/tests/test_v050260_docker_invariants.py
+++ b/tests/test_v050260_docker_invariants.py
@@ -93,7 +93,11 @@ def test_compose_files_document_skip_chmod_escape_hatch():
     hit by #1389 (the auth.json/.env chmod-override bug) can find the fix
     in the file they're reading. The fix shipped in v0.50.254 but Docker
     users may not be reading CHANGELOGs."""
-    for fname in ("docker-compose.yml", "docker-compose.two-container.yml", "docker-compose.three-container.yml"):
+    for fname in (
+        "docker-compose.yml",
+        "docker-compose.two-container.yml",
+        "docker-compose.three-container.yml",
+    ):
         src = (REPO / fname).read_text(encoding="utf-8")
         assert "HERMES_SKIP_CHMOD" in src, (
             f"{fname}: must document HERMES_SKIP_CHMOD as a bind-mount "
@@ -115,8 +119,15 @@ def test_env_docker_example_exists():
     src = p.read_text(encoding="utf-8")
 
     # Must document the critical vars
-    for var in ("UID", "GID", "HERMES_HOME", "HERMES_WORKSPACE",
-                "HERMES_WEBUI_PASSWORD", "HERMES_SKIP_CHMOD", "HERMES_HOME_MODE"):
+    for var in (
+        "UID",
+        "GID",
+        "HERMES_HOME",
+        "HERMES_WORKSPACE",
+        "HERMES_WEBUI_PASSWORD",
+        "HERMES_SKIP_CHMOD",
+        "HERMES_HOME_MODE",
+    ):
         assert var in src, (
             f".env.docker.example must document {var} — without it, users "
             f"hit by the related failure mode have no in-template hint."
@@ -183,8 +194,11 @@ def test_compose_files_parse_as_valid_yaml():
     file that breaks `docker compose up` for everyone."""
     import yaml
 
-    for fname in ("docker-compose.yml", "docker-compose.two-container.yml",
-                  "docker-compose.three-container.yml"):
+    for fname in (
+        "docker-compose.yml",
+        "docker-compose.two-container.yml",
+        "docker-compose.three-container.yml",
+    ):
         path = REPO / fname
         try:
             data = yaml.safe_load(path.read_text(encoding="utf-8"))
@@ -213,7 +227,10 @@ def test_agent_service_does_not_recommend_invalid_home_mode():
         "HERMES_HOME_MODE=0660",
     )
 
-    for fname in ("docker-compose.two-container.yml", "docker-compose.three-container.yml"):
+    for fname in (
+        "docker-compose.two-container.yml",
+        "docker-compose.three-container.yml",
+    ):
         src = (REPO / fname).read_text(encoding="utf-8")
 
         # Find each agent/dashboard service block by name and slice to the next
@@ -244,7 +261,10 @@ def test_compose_files_warn_about_home_mode_asymmetry():
     """The compose files must explicitly warn about the WebUI vs agent
     HERMES_HOME_MODE semantic asymmetry so users don't copy the WebUI's
     valid 0640 value into the agent service."""
-    for fname in ("docker-compose.two-container.yml", "docker-compose.three-container.yml"):
+    for fname in (
+        "docker-compose.two-container.yml",
+        "docker-compose.three-container.yml",
+    ):
         src = (REPO / fname).read_text(encoding="utf-8").lower()
         # Look for a comment that distinguishes directory mode from credential file mode
         assert "directory" in src and "credential" in src, (

--- a/tests/test_version_badge.py
+++ b/tests/test_version_badge.py
@@ -10,9 +10,7 @@ Covers:
   6. static/panels.js: loadSettingsPanel() populates both version badges from settings
   7. server.py: server_version is not the old hardcoded string
 """
-import importlib
-import sys
-import types
+
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 
@@ -23,69 +21,73 @@ REPO_ROOT = Path(__file__).parent.parent
 # 1. _detect_webui_version — resolution chain
 # ---------------------------------------------------------------------------
 
-class TestDetectWebUIVersion:
 
-    def _fresh_detect(self, mock_run_git=None, version_file_content=None, tmp_path=None):
+class TestDetectWebUIVersion:
+    def _fresh_detect(
+        self, mock_run_git=None, version_file_content=None, tmp_path=None
+    ):
         """Call _detect_webui_version() with controlled dependencies."""
         import api.updates as upd
 
-        fake_root = tmp_path or Path('/nonexistent-path')
+        fake_root = tmp_path or Path("/nonexistent-path")
 
         if version_file_content is not None:
-            vf = tmp_path / 'api' / '_version.py'
+            vf = tmp_path / "api" / "_version.py"
             vf.parent.mkdir(parents=True, exist_ok=True)
-            vf.write_text(version_file_content, encoding='utf-8')
+            vf.write_text(version_file_content, encoding="utf-8")
 
         def _run_git_side_effect(args, cwd, timeout=10):
             if mock_run_git is not None:
                 return mock_run_git(args, cwd, timeout)
-            return ('', False)
+            return ("", False)
 
-        with patch.object(upd, '_run_git', side_effect=_run_git_side_effect), \
-             patch.object(upd, 'REPO_ROOT', fake_root):
+        with (
+            patch.object(upd, "_run_git", side_effect=_run_git_side_effect),
+            patch.object(upd, "REPO_ROOT", fake_root),
+        ):
             return upd._detect_webui_version()
 
     def test_git_success_returns_tag(self, tmp_path):
         """When git describe succeeds, returns the tag string directly."""
         result = self._fresh_detect(
-            mock_run_git=lambda args, cwd, timeout: ('v0.50.123', True),
+            mock_run_git=lambda args, cwd, timeout: ("v0.50.123", True),
             tmp_path=tmp_path,
         )
-        assert result == 'v0.50.123'
+        assert result == "v0.50.123"
 
     def test_git_between_tags_returns_descriptor(self, tmp_path):
         """Between releases, git describe returns a post-tag descriptor — pass it through."""
         result = self._fresh_detect(
-            mock_run_git=lambda args, cwd, timeout: ('v0.50.123-3-ge91325d', True),
+            mock_run_git=lambda args, cwd, timeout: ("v0.50.123-3-ge91325d", True),
             tmp_path=tmp_path,
         )
-        assert result == 'v0.50.123-3-ge91325d'
+        assert result == "v0.50.123-3-ge91325d"
 
     def test_git_failure_falls_back_to_version_file(self, tmp_path):
         """When git fails (Docker image), falls back to api/_version.py."""
         result = self._fresh_detect(
-            mock_run_git=lambda args, cwd, timeout: ('', False),
+            mock_run_git=lambda args, cwd, timeout: ("", False),
             version_file_content="__version__ = 'v0.50.100'\n",
             tmp_path=tmp_path,
         )
-        assert result == 'v0.50.100'
+        assert result == "v0.50.100"
 
     def test_git_failure_no_version_file_returns_unknown(self, tmp_path):
         """When git fails and no _version.py exists, returns 'unknown'."""
         result = self._fresh_detect(
-            mock_run_git=lambda args, cwd, timeout: ('', False),
+            mock_run_git=lambda args, cwd, timeout: ("", False),
             tmp_path=tmp_path,
         )
-        assert result == 'unknown'
+        assert result == "unknown"
 
     def test_version_file_malformed_returns_unknown(self, tmp_path):
         """Malformed _version.py (no recognisable __version__ assignment) returns 'unknown'."""
         result = self._fresh_detect(
-            mock_run_git=lambda args, cwd, timeout: ('', False),
+            mock_run_git=lambda args, cwd, timeout: ("", False),
             version_file_content="this is not valid python !!! ~~~\n",
             tmp_path=tmp_path,
         )
-        assert result == 'unknown'
+        assert result == "unknown"
 
     def test_git_uses_correct_describe_flags(self, tmp_path):
         """git describe is called with --tags --always --dirty."""
@@ -93,92 +95,101 @@ class TestDetectWebUIVersion:
 
         def capture(args, cwd, timeout=10):
             called_args.append(args)
-            return ('v0.50.123', True)
+            return ("v0.50.123", True)
 
         self._fresh_detect(mock_run_git=capture, tmp_path=tmp_path)
-        assert called_args, 'git was never called'
-        assert '--tags' in called_args[0]
-        assert '--always' in called_args[0]
-        assert '--dirty' in called_args[0]
+        assert called_args, "git was never called"
+        assert "--tags" in called_args[0]
+        assert "--always" in called_args[0]
+        assert "--dirty" in called_args[0]
 
 
 # ---------------------------------------------------------------------------
 # 2. _detect_agent_version — resolution chain
 # ---------------------------------------------------------------------------
 
-class TestDetectAgentVersion:
 
-    def _fresh_detect(self, mock_run_git=None, version_file_content=None, tmp_path=None):
+class TestDetectAgentVersion:
+    def _fresh_detect(
+        self, mock_run_git=None, version_file_content=None, tmp_path=None
+    ):
         """Call _detect_agent_version() with controlled dependencies."""
         import api.updates as upd
 
-        fake_root = tmp_path or Path('/nonexistent-agent-path')
+        fake_root = tmp_path or Path("/nonexistent-agent-path")
 
         if version_file_content is not None:
-            vf = fake_root / 'VERSION'
-            vf.write_text(version_file_content, encoding='utf-8')
+            vf = fake_root / "VERSION"
+            vf.write_text(version_file_content, encoding="utf-8")
 
         def _run_git_side_effect(args, cwd, timeout=10):
             if mock_run_git is not None:
                 return mock_run_git(args, cwd, timeout)
-            return ('', False)
+            return ("", False)
 
-        with patch.object(upd, '_run_git', side_effect=_run_git_side_effect), \
-             patch.object(upd, '_AGENT_DIR', fake_root):
+        with (
+            patch.object(upd, "_run_git", side_effect=_run_git_side_effect),
+            patch.object(upd, "_AGENT_DIR", fake_root),
+        ):
             return upd._detect_agent_version()
 
     def test_version_file_is_preferred(self, tmp_path):
         """Agent VERSION file should be read before git fallback."""
         result = self._fresh_detect(
-            mock_run_git=lambda args, cwd, timeout: ('v0.50.999', True),
-            version_file_content='v0.60.1\n',
+            mock_run_git=lambda args, cwd, timeout: ("v0.50.999", True),
+            version_file_content="v0.60.1\n",
             tmp_path=tmp_path,
         )
-        assert result == 'v0.60.1'
+        assert result == "v0.60.1"
 
     def test_git_fallback_used_when_version_file_missing(self, tmp_path):
         """When VERSION file is absent, we fall back to git describe in agent path."""
-        (tmp_path / '.git').mkdir()
+        (tmp_path / ".git").mkdir()
         result = self._fresh_detect(
-            mock_run_git=lambda args, cwd, timeout: ('v0.60.2', True),
+            mock_run_git=lambda args, cwd, timeout: ("v0.60.2", True),
             tmp_path=tmp_path,
         )
-        assert result == 'v0.60.2'
+        assert result == "v0.60.2"
 
     def test_missing_agent_returns_not_detected(self):
         """When no agent checkout is available, detect function returns 'not detected'."""
         import api.updates as upd
-        with patch.object(upd, '_AGENT_DIR', None):
-            assert upd._detect_agent_version() == 'not detected'
+
+        with patch.object(upd, "_AGENT_DIR", None):
+            assert upd._detect_agent_version() == "not detected"
 
     def test_agent_detect_returns_not_detected_on_fail(self, tmp_path):
         """Git fallback failure should remain user-friendly and not raise."""
         result = self._fresh_detect(
-            mock_run_git=lambda args, cwd, timeout: ('', False),
+            mock_run_git=lambda args, cwd, timeout: ("", False),
             tmp_path=tmp_path,
         )
-        assert result == 'not detected'
+        assert result == "not detected"
 
 
 # ---------------------------------------------------------------------------
 # 3. WEBUI_VERSION module constant
 # ---------------------------------------------------------------------------
 
-class TestWebUIVersionConstant:
 
+class TestWebUIVersionConstant:
     def test_webui_version_is_set(self):
         """WEBUI_VERSION is a non-empty string exported from api.updates."""
         import api.updates as upd
-        assert hasattr(upd, 'WEBUI_VERSION'), 'WEBUI_VERSION not exported from api.updates'
+
+        assert hasattr(upd, "WEBUI_VERSION"), (
+            "WEBUI_VERSION not exported from api.updates"
+        )
         assert isinstance(upd.WEBUI_VERSION, str)
-        assert upd.WEBUI_VERSION, 'WEBUI_VERSION must not be empty string'
+        assert upd.WEBUI_VERSION, "WEBUI_VERSION must not be empty string"
 
     def test_webui_version_is_not_old_hardcoded(self):
         """WEBUI_VERSION must not be the old stale value from server.py."""
         import api.updates as upd
+
         # These were the two stale hardcoded strings before this fix
-        assert upd.WEBUI_VERSION not in ('0.50.38', 'HermesWebUI/0.50.38'), (
-            'WEBUI_VERSION still holds the old hardcoded server.py value'
+        assert upd.WEBUI_VERSION not in ("0.50.38", "HermesWebUI/0.50.38"), (
+            "WEBUI_VERSION still holds the old hardcoded server.py value"
         )
 
 
@@ -186,37 +197,40 @@ class TestWebUIVersionConstant:
 # 4. GET /api/settings includes webui_version and agent_version
 # ---------------------------------------------------------------------------
 
-class TestSettingsEndpointVersion:
 
+class TestSettingsEndpointVersion:
     def test_api_settings_includes_webui_version(self):
         """GET /api/settings response dict must include webui_version key."""
         import api.routes as routes
         import api.updates as upd
 
         # Patch load_settings to return a minimal dict (no disk I/O)
-        minimal_settings = {'send_key': 'enter', 'theme': 'dark'}
+        minimal_settings = {"send_key": "enter", "theme": "dark"}
 
         handler = MagicMock()
         from urllib.parse import urlparse
-        parsed = urlparse('/api/settings')
+
+        parsed = urlparse("/api/settings")
 
         captured = {}
 
         def fake_j(h, data, status=200):
-            captured['data'] = data
+            captured["data"] = data
 
-        with patch('api.routes.load_settings', return_value=dict(minimal_settings)), \
-             patch('api.routes.j', side_effect=fake_j):
+        with (
+            patch("api.routes.load_settings", return_value=dict(minimal_settings)),
+            patch("api.routes.j", side_effect=fake_j),
+        ):
             routes.handle_get(handler, parsed)
 
-        assert 'webui_version' in captured.get('data', {}), (
-            '/api/settings response must contain webui_version key'
+        assert "webui_version" in captured.get("data", {}), (
+            "/api/settings response must contain webui_version key"
         )
-        assert captured['data']['webui_version'] == upd.WEBUI_VERSION
-        assert 'agent_version' in captured.get('data', {}), (
-            '/api/settings response must contain agent_version key'
+        assert captured["data"]["webui_version"] == upd.WEBUI_VERSION
+        assert "agent_version" in captured.get("data", {}), (
+            "/api/settings response must contain agent_version key"
         )
-        assert captured['data']['agent_version'] == upd.AGENT_VERSION
+        assert captured["data"]["agent_version"] == upd.AGENT_VERSION
 
     def test_api_settings_webui_version_not_empty(self):
         """webui_version and agent_version in /api/settings must be non-empty strings."""
@@ -224,21 +238,24 @@ class TestSettingsEndpointVersion:
 
         handler = MagicMock()
         from urllib.parse import urlparse
-        parsed = urlparse('/api/settings')
+
+        parsed = urlparse("/api/settings")
 
         captured = {}
 
         def fake_j(h, data, status=200):
-            captured['data'] = data
+            captured["data"] = data
 
-        with patch('api.routes.load_settings', return_value={}), \
-             patch('api.routes.j', side_effect=fake_j):
+        with (
+            patch("api.routes.load_settings", return_value={}),
+            patch("api.routes.j", side_effect=fake_j),
+        ):
             routes.handle_get(handler, parsed)
 
-        version = captured.get('data', {}).get('webui_version', '')
-        assert version, 'webui_version in /api/settings must not be empty'
-        agent_version = captured.get('data', {}).get('agent_version', '')
-        assert agent_version, 'agent_version in /api/settings must not be empty'
+        version = captured.get("data", {}).get("webui_version", "")
+        assert version, "webui_version in /api/settings must not be empty"
+        agent_version = captured.get("data", {}).get("agent_version", "")
+        assert agent_version, "agent_version in /api/settings must not be empty"
 
     def test_api_settings_no_password_hash(self):
         """password_hash must still be stripped even with version injection."""
@@ -246,19 +263,24 @@ class TestSettingsEndpointVersion:
 
         handler = MagicMock()
         from urllib.parse import urlparse
-        parsed = urlparse('/api/settings')
+
+        parsed = urlparse("/api/settings")
 
         captured = {}
 
         def fake_j(h, data, status=200):
-            captured['data'] = data
+            captured["data"] = data
 
-        with patch('api.routes.load_settings', return_value={'password_hash': 'secret123'}), \
-             patch('api.routes.j', side_effect=fake_j):
+        with (
+            patch(
+                "api.routes.load_settings", return_value={"password_hash": "secret123"}
+            ),
+            patch("api.routes.j", side_effect=fake_j),
+        ):
             routes.handle_get(handler, parsed)
 
-        assert 'password_hash' not in captured.get('data', {}), (
-            'password_hash must still be stripped from /api/settings'
+        assert "password_hash" not in captured.get("data", {}), (
+            "password_hash must still be stripped from /api/settings"
         )
 
 
@@ -266,27 +288,27 @@ class TestSettingsEndpointVersion:
 # 5. static/index.html — version badges
 # ---------------------------------------------------------------------------
 
-class TestIndexHTMLBadge:
 
+class TestIndexHTMLBadge:
     def _read_html(self):
-        return (REPO_ROOT / 'static' / 'index.html').read_text(encoding='utf-8')
+        return (REPO_ROOT / "static" / "index.html").read_text(encoding="utf-8")
 
     def test_old_stale_version_removed_from_html(self):
         """The old hardcoded v0.50.87 badge must not appear in index.html."""
         html = self._read_html()
-        assert 'v0.50.87' not in html, (
-            'Stale hardcoded version v0.50.87 still present in index.html. '
-            'The badge should be a neutral placeholder; JS populates it at runtime.'
+        assert "v0.50.87" not in html, (
+            "Stale hardcoded version v0.50.87 still present in index.html. "
+            "The badge should be a neutral placeholder; JS populates it at runtime."
         )
 
     def test_badge_element_still_present(self):
         """System version badge spans must still be in the DOM for both WebUI and Agent pills."""
         html = self._read_html()
-        assert 'settings-webui-version-badge' in html, (
-            'WebUI badge element missing from index.html'
+        assert "settings-webui-version-badge" in html, (
+            "WebUI badge element missing from index.html"
         )
-        assert 'settings-agent-version-badge' in html, (
-            'Agent badge element missing from index.html'
+        assert "settings-agent-version-badge" in html, (
+            "Agent badge element missing from index.html"
         )
 
 
@@ -294,30 +316,30 @@ class TestIndexHTMLBadge:
 # 6. static/panels.js — badge population from settings
 # ---------------------------------------------------------------------------
 
-class TestPanelsJSVersionBadge:
 
+class TestPanelsJSVersionBadge:
     def _read_js(self):
-        return (REPO_ROOT / 'static' / 'panels.js').read_text(encoding='utf-8')
+        return (REPO_ROOT / "static" / "panels.js").read_text(encoding="utf-8")
 
     def test_panels_js_reads_webui_version(self):
         """loadSettingsPanel must reference settings.webui_version to populate the badge."""
         src = self._read_js()
-        assert 'webui_version' in src, (
-            'panels.js loadSettingsPanel() must read settings.webui_version '
-            'to populate the badge dynamically'
+        assert "webui_version" in src, (
+            "panels.js loadSettingsPanel() must read settings.webui_version "
+            "to populate the badge dynamically"
         )
 
     def test_panels_js_targets_version_badges(self):
         """loadSettingsPanel must target the two version badge elements."""
         src = self._read_js()
-        assert 'settings-webui-version-badge' in src, (
-            'panels.js must query #settings-webui-version-badge to update the WebUI text'
+        assert "settings-webui-version-badge" in src, (
+            "panels.js must query #settings-webui-version-badge to update the WebUI text"
         )
-        assert 'settings-agent-version-badge' in src, (
-            'panels.js must query #settings-agent-version-badge to update the Agent text'
+        assert "settings-agent-version-badge" in src, (
+            "panels.js must query #settings-agent-version-badge to update the Agent text"
         )
-        assert 'agent_version' in src, (
-            'loadSettingsPanel must read settings.agent_version to populate the agent badge'
+        assert "agent_version" in src, (
+            "loadSettingsPanel must read settings.agent_version to populate the agent badge"
         )
 
 
@@ -325,34 +347,34 @@ class TestPanelsJSVersionBadge:
 # 7. server.py — server_version not the old hardcoded string
 # ---------------------------------------------------------------------------
 
-class TestServerVersionHeader:
 
+class TestServerVersionHeader:
     def test_server_version_not_old_hardcoded(self):
         """server.py Handler.server_version must not be the stale hardcoded value."""
-        src = (REPO_ROOT / 'server.py').read_text(encoding='utf-8')
-        assert 'HermesWebUI/0.50.38' not in src, (
-            'server.py still contains the old hardcoded server_version string. '
-            'It should use WEBUI_VERSION from api.updates.'
+        src = (REPO_ROOT / "server.py").read_text(encoding="utf-8")
+        assert "HermesWebUI/0.50.38" not in src, (
+            "server.py still contains the old hardcoded server_version string. "
+            "It should use WEBUI_VERSION from api.updates."
         )
 
     def test_server_version_uses_webui_version(self):
         """server.py must reference WEBUI_VERSION when setting server_version."""
-        src = (REPO_ROOT / 'server.py').read_text(encoding='utf-8')
-        assert 'WEBUI_VERSION' in src, (
-            'server.py must import and use WEBUI_VERSION from api.updates '
-            'to keep the HTTP Server: header in sync with git tags'
+        src = (REPO_ROOT / "server.py").read_text(encoding="utf-8")
+        assert "WEBUI_VERSION" in src, (
+            "server.py must import and use WEBUI_VERSION from api.updates "
+            "to keep the HTTP Server: header in sync with git tags"
         )
 
     def test_server_py_imports_webui_version(self):
         """server.py must import WEBUI_VERSION from api.updates."""
-        src = (REPO_ROOT / 'server.py').read_text(encoding='utf-8')
-        assert 'from api.updates import WEBUI_VERSION' in src, (
-            'server.py must import WEBUI_VERSION from api.updates'
+        src = (REPO_ROOT / "server.py").read_text(encoding="utf-8")
+        assert "from api.updates import WEBUI_VERSION" in src, (
+            "server.py must import WEBUI_VERSION from api.updates"
         )
 
     def test_server_version_no_slash_when_unknown(self):
         """When WEBUI_VERSION is 'unknown', server_version must be bare 'HermesWebUI' with no slash."""
-        src = (REPO_ROOT / 'server.py').read_text(encoding='utf-8')
+        src = (REPO_ROOT / "server.py").read_text(encoding="utf-8")
         # The guard must be present so log aggregators don't see 'HermesWebUI/unknown'
         assert "'unknown'" in src or '"unknown"' in src, (
             "server.py must guard against emitting 'HermesWebUI/unknown' as the server header"
@@ -360,11 +382,11 @@ class TestServerVersionHeader:
 
     def test_server_version_uses_removeprefix_not_lstrip(self):
         """server.py must use str.removeprefix() to strip 'v', not lstrip() which strips chars."""
-        src = (REPO_ROOT / 'server.py').read_text(encoding='utf-8')
-        assert 'lstrip' not in src, (
+        src = (REPO_ROOT / "server.py").read_text(encoding="utf-8")
+        assert "lstrip" not in src, (
             "server.py must use removeprefix('v') not lstrip('v') — lstrip strips characters, "
             "not a prefix, and would incorrectly mangle strings like 'vvv0.50.124'"
         )
-        assert 'removeprefix' in src, (
+        assert "removeprefix" in src, (
             "server.py must use removeprefix('v') to strip the leading 'v' from the version tag"
         )

--- a/tests/test_voice_transcribe_endpoint.py
+++ b/tests/test_voice_transcribe_endpoint.py
@@ -18,7 +18,7 @@ def _multipart_body(fields=None, files=None, boundary=b"voiceboundary"):
         body += b"--" + boundary + b"\r\n"
         body += (
             f'Content-Disposition: form-data; name="{name}"; filename="{filename}"\r\n'
-            f'Content-Type: {content_type}\r\n\r\n'
+            f"Content-Type: {content_type}\r\n\r\n"
         ).encode()
         body += data + b"\r\n"
     body += b"--" + boundary + b"--\r\n"
@@ -59,7 +59,10 @@ def test_handle_transcribe_requires_file_field():
 
 def test_handle_transcribe_returns_transcript(monkeypatch):
     fake_mod = types.ModuleType("tools.transcription_tools")
-    fake_mod.transcribe_audio = lambda path: {"success": True, "transcript": "hello from audio"}
+    fake_mod.transcribe_audio = lambda path: {
+        "success": True,
+        "transcript": "hello from audio",
+    }
     monkeypatch.setitem(sys.modules, "tools.transcription_tools", fake_mod)
 
     body, content_type = _multipart_body(
@@ -74,7 +77,10 @@ def test_handle_transcribe_returns_transcript(monkeypatch):
 
 def test_handle_transcribe_surfaces_provider_error(monkeypatch):
     fake_mod = types.ModuleType("tools.transcription_tools")
-    fake_mod.transcribe_audio = lambda path: {"success": False, "error": "STT not configured"}
+    fake_mod.transcribe_audio = lambda path: {
+        "success": False,
+        "error": "STT not configured",
+    }
     monkeypatch.setitem(sys.modules, "tools.transcription_tools", fake_mod)
 
     body, content_type = _multipart_body(

--- a/tests/test_webui_platform_hint.py
+++ b/tests/test_webui_platform_hint.py
@@ -3,6 +3,7 @@
 These are static source-level checks that will catch any future regression where
 a developer accidentally reverts the platform kwarg back to 'cli'.
 """
+
 import pathlib
 import re
 
@@ -18,7 +19,9 @@ def _load_source(relative_path: str) -> str:
 
 
 def _count_platform_kwargs(source: str, platform: str) -> int:
-    return len(re.findall(PLATFORM_KWARG_RE.format(platform=re.escape(platform)), source))
+    return len(
+        re.findall(PLATFORM_KWARG_RE.format(platform=re.escape(platform)), source)
+    )
 
 
 def test_streaming_uses_webui_platform():

--- a/tests/test_workspace_add_quote_strip.py
+++ b/tests/test_workspace_add_quote_strip.py
@@ -12,21 +12,29 @@ This file pins the behaviour:
   - Mismatched / unpaired quotes are preserved (path may legitimately contain one).
   - Whitespace outside the quotes is also handled.
 """
-import pytest
 
 from api.workspace import _strip_surrounding_quotes
 
 
 class TestStripSurroundingQuotes:
     def test_unwrapped_path_unchanged(self):
-        assert _strip_surrounding_quotes("/Users/x/Documents/foo") == "/Users/x/Documents/foo"
+        assert (
+            _strip_surrounding_quotes("/Users/x/Documents/foo")
+            == "/Users/x/Documents/foo"
+        )
 
     def test_single_quotes_stripped(self):
         # macOS Finder default
-        assert _strip_surrounding_quotes("'/Users/x/Documents/foo'") == "/Users/x/Documents/foo"
+        assert (
+            _strip_surrounding_quotes("'/Users/x/Documents/foo'")
+            == "/Users/x/Documents/foo"
+        )
 
     def test_double_quotes_stripped(self):
-        assert _strip_surrounding_quotes('"/Users/x/Documents/foo"') == "/Users/x/Documents/foo"
+        assert (
+            _strip_surrounding_quotes('"/Users/x/Documents/foo"')
+            == "/Users/x/Documents/foo"
+        )
 
     def test_outer_whitespace_stripped_first(self):
         # User pastes with trailing whitespace, then the quotes are visible

--- a/tests/test_workspace_blank_page_fix.py
+++ b/tests/test_workspace_blank_page_fix.py
@@ -6,6 +6,7 @@ Fixes:
 - boot.js reads default_workspace from /api/settings and sets S._profileDefaultWorkspace
 - promptNewFile/promptNewFolder auto-create a session bound to default workspace
 """
+
 import pathlib
 import re
 
@@ -13,34 +14,36 @@ REPO = pathlib.Path(__file__).parent.parent
 
 
 def read(rel):
-    return (REPO / rel).read_text(encoding='utf-8')
+    return (REPO / rel).read_text(encoding="utf-8")
 
 
 class TestSyncWorkspaceDisplaysFallback:
     """syncWorkspaceDisplays must show default workspace when no session."""
 
     def test_uses_profile_default_workspace_as_fallback(self):
-        src = read('static/panels.js')
-        m = re.search(r'function syncWorkspaceDisplays\(\)\{.*?\n\}', src, re.DOTALL)
+        src = read("static/panels.js")
+        m = re.search(r"function syncWorkspaceDisplays\(\)\{.*?\n\}", src, re.DOTALL)
         assert m, "syncWorkspaceDisplays not found"
         fn = m.group(0)
-        assert '_profileDefaultWorkspace' in fn, (
+        assert "_profileDefaultWorkspace" in fn, (
             "syncWorkspaceDisplays must read S._profileDefaultWorkspace as fallback "
             "when no active session is present"
         )
 
     def test_has_workspace_not_has_session_for_chip_disable(self):
-        src = read('static/panels.js')
-        m = re.search(r'function syncWorkspaceDisplays\(\)\{.*?\n\}', src, re.DOTALL)
+        src = read("static/panels.js")
+        m = re.search(r"function syncWorkspaceDisplays\(\)\{.*?\n\}", src, re.DOTALL)
         assert m
         fn = m.group(0)
         # composerChip.disabled must use hasWorkspace, not hasSession
-        assert 'composerChip.disabled=!hasWorkspace' in fn or \
-               'composerChip.disabled = !hasWorkspace' in fn, (
+        assert (
+            "composerChip.disabled=!hasWorkspace" in fn
+            or "composerChip.disabled = !hasWorkspace" in fn
+        ), (
             "composerChip.disabled must use !hasWorkspace (not !hasSession) so the chip "
             "is enabled on the blank new-chat page when a default workspace is configured"
         )
-        assert 'composerChip.disabled=!hasSession' not in fn, (
+        assert "composerChip.disabled=!hasSession" not in fn, (
             "composerChip.disabled must not use !hasSession — this was the regression"
         )
 
@@ -49,8 +52,8 @@ class TestBootJsProfileDefaultWorkspace:
     """boot.js must read default_workspace from /api/settings into S._profileDefaultWorkspace."""
 
     def test_boot_reads_default_workspace_from_settings(self):
-        src = read('static/boot.js')
-        assert '_profileDefaultWorkspace' in src, (
+        src = read("static/boot.js")
+        assert "_profileDefaultWorkspace" in src, (
             "boot.js must set S._profileDefaultWorkspace from the /api/settings "
             "default_workspace field so it is available before any session is created"
         )
@@ -58,14 +61,16 @@ class TestBootJsProfileDefaultWorkspace:
     def test_boot_sets_profile_default_workspace_in_settings_block(self):
         """The settings block (lines ~758-800 in boot.js) must set
         S._profileDefaultWorkspace from the /api/settings response."""
-        src = read('static/boot.js')
+        src = read("static/boot.js")
         # Find the settings fetch and the _profileDefaultWorkspace ASSIGNMENT
         # (the if(s.default_workspace) line, not usages elsewhere in the file)
         settings_idx = src.find("await api('/api/settings')")
         assert settings_idx != -1, "await api('/api/settings') not found in boot.js"
         # Find the assignment specifically — it uses 's.default_workspace'
-        ws_assign_idx = src.find('S._profileDefaultWorkspace=s.default_workspace')
-        assert ws_assign_idx != -1, "S._profileDefaultWorkspace assignment not found in boot.js"
+        ws_assign_idx = src.find("S._profileDefaultWorkspace=s.default_workspace")
+        assert ws_assign_idx != -1, (
+            "S._profileDefaultWorkspace assignment not found in boot.js"
+        )
         # The assignment must be in the same settings-fetch block (within a few hundred chars)
         assert abs(ws_assign_idx - settings_idx) < 1000, (
             "S._profileDefaultWorkspace must be set in the same settings-fetch block"
@@ -76,36 +81,36 @@ class TestPromptNewFileNoSession:
     """promptNewFile/promptNewFolder must auto-create a session on blank page."""
 
     def test_prompt_new_file_auto_creates_session(self):
-        src = read('static/ui.js')
-        m = re.search(r'async function promptNewFile\(\)\{.*?\n\}', src, re.DOTALL)
+        src = read("static/ui.js")
+        m = re.search(r"async function promptNewFile\(\)\{.*?\n\}", src, re.DOTALL)
         assert m, "promptNewFile not found"
         fn = m.group(0)
         # Must have auto-create path (not just early return when no session)
-        assert '_profileDefaultWorkspace' in fn, (
+        assert "_profileDefaultWorkspace" in fn, (
             "promptNewFile must read S._profileDefaultWorkspace to auto-create "
             "a session when called on the blank new-chat page"
         )
-        assert 'session/new' in fn, (
+        assert "session/new" in fn, (
             "promptNewFile must call /api/session/new to create a session "
             "bound to the default workspace when S.session is null"
         )
 
     def test_prompt_new_folder_auto_creates_session(self):
-        src = read('static/ui.js')
-        m = re.search(r'async function promptNewFolder\(\)\{.*?\n\}', src, re.DOTALL)
+        src = read("static/ui.js")
+        m = re.search(r"async function promptNewFolder\(\)\{.*?\n\}", src, re.DOTALL)
         assert m, "promptNewFolder not found"
         fn = m.group(0)
-        assert '_profileDefaultWorkspace' in fn, (
+        assert "_profileDefaultWorkspace" in fn, (
             "promptNewFolder must read S._profileDefaultWorkspace for auto-create path"
         )
-        assert 'session/new' in fn, (
+        assert "session/new" in fn, (
             "promptNewFolder must call /api/session/new to create session on blank page"
         )
 
     def test_prompt_new_file_still_returns_early_without_default(self):
         """If no default workspace, the function should return early (not crash)."""
-        src = read('static/ui.js')
-        m = re.search(r'async function promptNewFile\(\)\{.*?\n\}', src, re.DOTALL)
+        src = read("static/ui.js")
+        m = re.search(r"async function promptNewFile\(\)\{.*?\n\}", src, re.DOTALL)
         assert m
         fn = m.group(0)
         # Must have a guard for empty workspace
@@ -118,36 +123,41 @@ class TestWorkspaceSwitcherBlankPage:
     """Opus review Q6: workspace switcher dropdown must not silently fail on blank page."""
 
     def test_switch_to_workspace_auto_creates_session(self):
-        src = read('static/panels.js')
-        m = re.search(r'async function switchToWorkspace\(.*?\n\}', src, re.DOTALL)
+        src = read("static/panels.js")
+        m = re.search(r"async function switchToWorkspace\(.*?\n\}", src, re.DOTALL)
         assert m, "switchToWorkspace not found"
         fn = m.group(0)
-        assert '_profileDefaultWorkspace' in fn or 'session/new' in fn, (
+        assert "_profileDefaultWorkspace" in fn or "session/new" in fn, (
             "switchToWorkspace must auto-create session on blank page (Opus Q6 fix)"
         )
-        assert 'session/new' in fn, (
+        assert "session/new" in fn, (
             "switchToWorkspace must call /api/session/new when S.session is null"
         )
 
     def test_prompt_workspace_path_auto_creates_session(self):
-        src = read('static/panels.js')
-        m = re.search(r'async function promptWorkspacePath\(\)\{.*?\n\}', src, re.DOTALL)
+        src = read("static/panels.js")
+        m = re.search(
+            r"async function promptWorkspacePath\(\)\{.*?\n\}", src, re.DOTALL
+        )
         assert m, "promptWorkspacePath not found"
         fn = m.group(0)
-        assert 'session/new' in fn, (
+        assert "session/new" in fn, (
             "promptWorkspacePath must call /api/session/new when S.session is null"
         )
 
     def test_sync_workspace_displays_dropdown_close_uses_has_workspace(self):
-        src = read('static/panels.js')
-        m = re.search(r'function syncWorkspaceDisplays\(\)\{.*?\n\}', src, re.DOTALL)
+        src = read("static/panels.js")
+        m = re.search(r"function syncWorkspaceDisplays\(\)\{.*?\n\}", src, re.DOTALL)
         assert m, "syncWorkspaceDisplays not found"
         fn = m.group(0)
         # Line 555: dropdown force-close must use hasWorkspace, not hasSession
-        assert '!hasWorkspace && composerDropdown' in fn or '!hasWorkspace&&composerDropdown' in fn, (
+        assert (
+            "!hasWorkspace && composerDropdown" in fn
+            or "!hasWorkspace&&composerDropdown" in fn
+        ), (
             "syncWorkspaceDisplays must use !hasWorkspace (not !hasSession) to decide "
             "whether to force-close the dropdown (Opus Q6 fix)"
         )
-        assert '!hasSession && composerDropdown' not in fn, (
+        assert "!hasSession && composerDropdown" not in fn, (
             "Regression guard: !hasSession for dropdown close must be removed"
         )

--- a/tests/test_workspace_blocked_roots_macos.py
+++ b/tests/test_workspace_blocked_roots_macos.py
@@ -17,6 +17,7 @@ resolves to ``/private/etc``); those tests are skipped on Linux where
 The cross-platform invariants (``/etc`` literal blocked, ``/tmp`` allowed,
 non-symlink roots blocked) run on every platform.
 """
+
 import sys
 from pathlib import Path
 
@@ -29,7 +30,7 @@ from api.workspace import (
 )
 
 
-_IS_MACOS = sys.platform == 'darwin'
+_IS_MACOS = sys.platform == "darwin"
 _macos_only = pytest.mark.skipif(not _IS_MACOS, reason="macOS-specific symlink layout")
 
 
@@ -38,18 +39,18 @@ _macos_only = pytest.mark.skipif(not _IS_MACOS, reason="macOS-specific symlink l
 
 class TestBlockedRootsCanonicalisation:
     def test_etc_literal_in_blocked_roots(self):
-        assert Path('/etc') in _workspace_blocked_roots()
+        assert Path("/etc") in _workspace_blocked_roots()
 
     def test_etc_resolved_in_blocked_roots(self):
         """``/etc.resolve()`` is ``/private/etc`` on macOS; same path on Linux.
         Either way the resolved form must appear in the set so a candidate
         that crossed a symlink during ``.resolve()`` still matches."""
-        resolved = Path('/etc').resolve()
+        resolved = Path("/etc").resolve()
         assert resolved in _workspace_blocked_roots()
 
     def test_var_literal_and_resolved_in_blocked_roots(self):
-        assert Path('/var') in _workspace_blocked_roots()
-        assert Path('/var').resolve() in _workspace_blocked_roots()
+        assert Path("/var") in _workspace_blocked_roots()
+        assert Path("/var").resolve() in _workspace_blocked_roots()
 
 
 # ── /etc is rejected on both Linux and macOS ────────────────────────────────
@@ -59,10 +60,10 @@ class TestEtcAlwaysBlocked:
     def test_etc_resolved_form_blocked(self):
         """The path-after-resolve form (``/private/etc`` on macOS, ``/etc`` on
         Linux) must be blocked."""
-        assert _is_blocked_system_path(Path('/etc').resolve())
+        assert _is_blocked_system_path(Path("/etc").resolve())
 
     def test_etc_subpath_blocked(self):
-        assert _is_blocked_system_path(Path('/etc/hostname').resolve())
+        assert _is_blocked_system_path(Path("/etc/hostname").resolve())
 
     @_macos_only
     def test_private_etc_explicit_blocked(self):
@@ -70,7 +71,7 @@ class TestEtcAlwaysBlocked:
         macOS layout), it must still be blocked.  Skipped on Linux —
         ``/private/etc`` doesn't exist there and ``Path('/etc').resolve()``
         is ``/etc`` so the resolved-form aliasing is a no-op."""
-        assert _is_blocked_system_path(Path('/private/etc'))
+        assert _is_blocked_system_path(Path("/private/etc"))
 
 
 # ── /var is selectively blocked (system parts) but tmp carve-outs work ──────
@@ -81,31 +82,31 @@ class TestVarSystemBlockedButUserTmpAllowed:
         """``/private/var/log`` would have been a macOS-only security gap
         before this fix — it resolved through the ``/var`` symlink and
         didn't match the literal blocked root."""
-        assert _is_blocked_system_path(Path('/var/log').resolve())
+        assert _is_blocked_system_path(Path("/var/log").resolve())
 
     @_macos_only
     def test_private_var_log_blocked(self):
         """Skipped on Linux: ``/private/var/log`` isn't an alias for
         ``/var/log`` there; ``Path('/var').resolve() == /var`` so no
         ``/private/var`` ever lands in the blocked set."""
-        assert _is_blocked_system_path(Path('/private/var/log'))
+        assert _is_blocked_system_path(Path("/private/var/log"))
 
     def test_var_folders_user_tmp_allowed(self):
         """macOS per-user tmp under /var/folders/<hash>/T/ — pytest's
         tmp_path_factory writes here. Must remain registerable."""
         # This path may not actually exist; the carve-out is path-shape based.
-        candidate = Path('/var/folders/abc/T/some-test-dir')
+        candidate = Path("/var/folders/abc/T/some-test-dir")
         assert not _is_blocked_system_path(candidate)
 
     def test_private_var_folders_user_tmp_allowed(self):
-        candidate = Path('/private/var/folders/abc/T/some-test-dir')
+        candidate = Path("/private/var/folders/abc/T/some-test-dir")
         assert not _is_blocked_system_path(candidate)
 
     def test_var_tmp_user_writable_allowed(self):
         """``/var/tmp`` is system-wide user-writable tmp on Linux/macOS.
         Carved out so users can register tmp dirs there."""
-        assert not _is_blocked_system_path(Path('/var/tmp/my-workspace'))
-        assert not _is_blocked_system_path(Path('/private/var/tmp/my-workspace'))
+        assert not _is_blocked_system_path(Path("/var/tmp/my-workspace"))
+        assert not _is_blocked_system_path(Path("/private/var/tmp/my-workspace"))
 
 
 # ── Carve-out invariants ───────────────────────────────────────────────────
@@ -113,39 +114,52 @@ class TestVarSystemBlockedButUserTmpAllowed:
 
 class TestUserTmpPrefixes:
     def test_var_folders_in_carveouts(self):
-        assert Path('/var/folders') in _USER_TMP_PREFIXES
-        assert Path('/private/var/folders') in _USER_TMP_PREFIXES
+        assert Path("/var/folders") in _USER_TMP_PREFIXES
+        assert Path("/private/var/folders") in _USER_TMP_PREFIXES
 
     def test_var_tmp_in_carveouts(self):
-        assert Path('/var/tmp') in _USER_TMP_PREFIXES
-        assert Path('/private/var/tmp') in _USER_TMP_PREFIXES
+        assert Path("/var/tmp") in _USER_TMP_PREFIXES
+        assert Path("/private/var/tmp") in _USER_TMP_PREFIXES
 
     def test_carveouts_only_loosen_var_subtree(self):
         """Carve-outs must not let /etc or other strict roots through."""
         for tmp in _USER_TMP_PREFIXES:
             # tmp paths are under /var or /private/var, never under /etc, /usr, /bin, etc.
-            assert str(tmp).startswith('/var/') or str(tmp).startswith('/private/var/')
+            assert str(tmp).startswith("/var/") or str(tmp).startswith("/private/var/")
 
 
 # ── Other roots: literal == resolved on both platforms ─────────────────────
 
 
 class TestNonSymlinkRootsUnchanged:
-    @pytest.mark.parametrize("root", [
-        '/usr', '/bin', '/sbin', '/proc', '/sys', '/dev', '/lib', '/opt/homebrew',
-    ])
+    @pytest.mark.parametrize(
+        "root",
+        [
+            "/usr",
+            "/bin",
+            "/sbin",
+            "/proc",
+            "/sys",
+            "/dev",
+            "/lib",
+            "/opt/homebrew",
+        ],
+    )
     def test_root_blocked(self, root):
         # Whether or not the root exists, the literal form must be blocked.
         assert _is_blocked_system_path(Path(root))
         # And the resolved form (almost always equal to literal for these).
         assert _is_blocked_system_path(Path(root).resolve())
 
-    @pytest.mark.parametrize("subpath", [
-        '/usr/local/bin/something',
-        '/proc/self/maps',
-        '/sys/class/net',
-        '/dev/null',
-    ])
+    @pytest.mark.parametrize(
+        "subpath",
+        [
+            "/usr/local/bin/something",
+            "/proc/self/maps",
+            "/sys/class/net",
+            "/dev/null",
+        ],
+    )
     def test_subpath_blocked(self, subpath):
         # Use Path() not .resolve() — we want to assert the shape-based block,
         # not test whether the path actually exists on the test runner.
@@ -161,15 +175,19 @@ class TestMacOSSystemAndLibraryBlocked:
     meaningful on macOS and should always be rejected.
     """
 
-    @pytest.mark.parametrize("path", [
-        '/Library',
-        '/Library/Application Support',
-        '/Library/Preferences',
-        '/System',
-        '/System/Library',
-        '/System/Library/CoreServices',
-    ])
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/Library",
+            "/Library/Application Support",
+            "/Library/Preferences",
+            "/System",
+            "/System/Library",
+            "/System/Library/CoreServices",
+        ],
+    )
     def test_macos_os_roots_blocked(self, path):
         """Paths under /Library and /System must be blocked regardless of platform."""
         from api.workspace import _is_blocked_workspace_path
+
         assert _is_blocked_workspace_path(Path(path))

--- a/tests/test_workspace_context_menu_and_rename.py
+++ b/tests/test_workspace_context_menu_and_rename.py
@@ -56,7 +56,8 @@ class ContextMenuHoverBackgroundTests(unittest.TestCase):
         # Negative lookahead handles the `-` case; we also bar `_` and word chars.
         bad = re.findall(r"var\(--hover\)(?![\w-])", src)
         self.assertEqual(
-            bad, [],
+            bad,
+            [],
             f"Found {len(bad)} `var(--hover)` reference(s) in static/ui.js. "
             "The variable `--hover` is undefined; this resolves to `transparent` "
             "and breaks visible hover state. Use `var(--hover-bg)` instead.",
@@ -66,7 +67,8 @@ class ContextMenuHoverBackgroundTests(unittest.TestCase):
         src = _read(SESSIONS_JS)
         bad = re.findall(r"var\(--hover\)(?![\w-])", src)
         self.assertEqual(
-            bad, [],
+            bad,
+            [],
             f"Found {len(bad)} `var(--hover)` reference(s) in static/sessions.js. "
             "Use `var(--hover-bg)` (the defined variable).",
         )
@@ -95,9 +97,12 @@ class ContextMenuHoverBackgroundTests(unittest.TestCase):
                     break
         body = src[start:end]
         # Expect at least 4 hover assignments (one per menu item).
-        hits = re.findall(r"\.style\.background\s*=\s*['\"]var\(--hover-bg\)['\"]", body)
+        hits = re.findall(
+            r"\.style\.background\s*=\s*['\"]var\(--hover-bg\)['\"]", body
+        )
         self.assertGreaterEqual(
-            len(hits), 4,
+            len(hits),
+            4,
             f"Expected ≥4 menu items to set background to var(--hover-bg) "
             f"(Rename, Reveal, Copy path, Delete). Found {len(hits)}.",
         )
@@ -122,9 +127,12 @@ class ContextMenuHoverBackgroundTests(unittest.TestCase):
                     end = i + 1
                     break
         body = src[start:end]
-        hits = re.findall(r"\.style\.background\s*=\s*['\"]var\(--hover-bg\)['\"]", body)
+        hits = re.findall(
+            r"\.style\.background\s*=\s*['\"]var\(--hover-bg\)['\"]", body
+        )
         self.assertGreaterEqual(
-            len(hits), 2,
+            len(hits),
+            2,
             f"Expected ≥2 menu items to set background to var(--hover-bg) "
             f"in _showProjectContextMenu. Found {len(hits)}.",
         )
@@ -189,7 +197,8 @@ class ShowPromptDialogPrefillTests(unittest.TestCase):
         # Must reference `opts.defaultValue` somewhere — the alias was the
         # backward-compatibility fix so future typos don't cause silent drops.
         self.assertIn(
-            "opts.defaultValue", body,
+            "opts.defaultValue",
+            body,
             "showPromptDialog must accept `defaultValue` as an alias for "
             "`value` so callers using the standard HTMLInputElement.defaultValue "
             "param name pre-fill correctly (regression protection).",
@@ -205,7 +214,8 @@ class ShowPromptDialogPrefillTests(unittest.TestCase):
         time."""
         body = self._slice_show_prompt_dialog()
         self.assertIn(
-            "selectStem", body,
+            "selectStem",
+            body,
             "showPromptDialog should support `selectStem:true` to select the "
             "filename portion before the last '.' on focus (Finder-style "
             "rename UX).",
@@ -213,11 +223,13 @@ class ShowPromptDialogPrefillTests(unittest.TestCase):
         # Pin the actual stem-selection mechanic — must use lastIndexOf('.')
         # and setSelectionRange. Anything else is the wrong selection rule.
         self.assertRegex(
-            body, r"lastIndexOf\(\s*['\"]\.['\"]\s*\)",
+            body,
+            r"lastIndexOf\(\s*['\"]\.['\"]\s*\)",
             "selectStem must use lastIndexOf('.') so 'a.b.c.d' selects 'a.b.c'.",
         )
         self.assertRegex(
-            body, r"setSelectionRange\s*\(\s*0\s*,",
+            body,
+            r"setSelectionRange\s*\(\s*0\s*,",
             "selectStem must use setSelectionRange(0, dot) to select the stem.",
         )
 
@@ -252,7 +264,8 @@ class ShowPromptDialogPrefillTests(unittest.TestCase):
         )
         # Must opt into selectStem for files (not directories).
         self.assertIn(
-            "selectStem", body,
+            "selectStem",
+            body,
             "_inlineRenameFileItem must pass selectStem:... so renaming "
             "'report.txt' selects 'report' and the user can immediately type "
             "the new basename while preserving the extension.",

--- a/tests/test_workspace_display_prefix.py
+++ b/tests/test_workspace_display_prefix.py
@@ -35,7 +35,9 @@ def test_user_render_uses_stripped_display_content_without_preempting_context_ca
     assert loop_end != -1, "assistant render branch not found after user branch"
     render_prefix = src[loop_start:loop_end]
 
-    display_idx = render_prefix.find("const displayContent=isUser?_stripWorkspaceDisplayPrefix(content):content;")
+    display_idx = render_prefix.find(
+        "const displayContent=isUser?_stripWorkspaceDisplayPrefix(content):content;"
+    )
     context_idx = render_prefix.find("if(_isContextCompactionMessage(m))")
     user_idx = render_prefix.find("if(isUser)")
     assert display_idx != -1, "display content stripper not used in render loop"

--- a/tests/test_workspace_files_persist_on_empty_reload.py
+++ b/tests/test_workspace_files_persist_on_empty_reload.py
@@ -19,6 +19,7 @@ The session ID persisting in localStorage is harmless — server-side
 sidebar entry appears, and ``newSession()`` overwrites the key when the
 user actually creates a real session.
 """
+
 import pathlib
 import re
 

--- a/tests/test_workspace_inaccessible_paths.py
+++ b/tests/test_workspace_inaccessible_paths.py
@@ -23,21 +23,28 @@ def test_load_workspaces_preserves_unavailable_entries_on_disk(tmp_path, monkeyp
 
     loaded = workspace.load_workspaces()
 
-    assert [w["path"] for w in loaded] == [str(existing.resolve()), str(unavailable.resolve())]
+    assert [w["path"] for w in loaded] == [
+        str(existing.resolve()),
+        str(unavailable.resolve()),
+    ]
     assert json.loads(ws_file.read_text(encoding="utf-8")) == raw
 
 
 def test_clean_workspace_list_still_renames_default_without_dropping_missing(tmp_path):
     missing = tmp_path / "temporarily-unavailable"
 
-    cleaned = workspace._clean_workspace_list([
-        {"path": str(missing), "name": "default"},
-    ])
+    cleaned = workspace._clean_workspace_list(
+        [
+            {"path": str(missing), "name": "default"},
+        ]
+    )
 
     assert cleaned == [{"path": str(missing.resolve()), "name": "Home"}]
 
 
-def test_validate_workspace_to_add_distinguishes_permission_denied(monkeypatch, tmp_path):
+def test_validate_workspace_to_add_distinguishes_permission_denied(
+    monkeypatch, tmp_path
+):
     candidate = tmp_path / "Documents"
     candidate.mkdir()
 
@@ -61,7 +68,9 @@ def test_validate_workspace_to_add_distinguishes_permission_denied(monkeypatch, 
     assert "Full Disk Access" in message
 
 
-def test_resolve_trusted_workspace_distinguishes_missing_from_permission_denied(monkeypatch, tmp_path):
+def test_resolve_trusted_workspace_distinguishes_missing_from_permission_denied(
+    monkeypatch, tmp_path
+):
     candidate = tmp_path / "Documents"
     candidate.mkdir()
 

--- a/tests/test_workspace_panel_persists_on_empty_boot.py
+++ b/tests/test_workspace_panel_persists_on_empty_boot.py
@@ -26,6 +26,7 @@ Fix verified by these tests:
   - ``canBrowse`` and ``openWorkspacePanel()`` include
     ``S._profileDefaultWorkspace`` so the toggle stays enabled.
 """
+
 import pathlib
 
 REPO = pathlib.Path(__file__).parent.parent
@@ -40,7 +41,7 @@ class TestSyncStateNoSession:
         """A 'preview' panel needs file content from a session — close it
         when there's no session."""
         idx = BOOT_JS.find("function syncWorkspacePanelState()")
-        body = BOOT_JS[idx:idx + 800]
+        body = BOOT_JS[idx : idx + 800]
         assert "_workspacePanelMode==='preview'" in body, (
             "syncWorkspacePanelState must check _workspacePanelMode==='preview' "
             "before force-closing on no-session boot"
@@ -54,7 +55,7 @@ class TestSyncStateNoSession:
         run so the panel renders its 'no workspace' or default-workspace state
         rather than being force-closed."""
         idx = BOOT_JS.find("function syncWorkspacePanelState()")
-        body = BOOT_JS[idx:idx + 800]
+        body = BOOT_JS[idx : idx + 800]
         # The else branch (browse / closed mode without session) calls UI sync
         assert "syncWorkspacePanelUI()" in body, (
             "syncWorkspacePanelState must call syncWorkspacePanelUI() in the "
@@ -83,7 +84,10 @@ class TestBootPathsRestorePanelPref:
             "Ephemeral-session boot path must read 'hermes-webui-workspace-panel-pref' "
             "from localStorage before calling syncWorkspacePanelState()"
         )
-        assert "_workspacePanelMode='browse'" in block or "_workspacePanelMode = 'browse'" in block, (
+        assert (
+            "_workspacePanelMode='browse'" in block
+            or "_workspacePanelMode = 'browse'" in block
+        ), (
             "Ephemeral-session path must set _workspacePanelMode='browse' "
             "when the pref is 'open'"
         )
@@ -97,13 +101,18 @@ class TestBootPathsRestorePanelPref:
         assert m_idx > 0, "no-saved-session path not found"
         # syncWorkspacePanelState should appear shortly after
         sync_idx = BOOT_JS.find("syncWorkspacePanelState()", m_idx)
-        assert sync_idx > 0, "syncWorkspacePanelState() not found after no-saved-session marker"
+        assert sync_idx > 0, (
+            "syncWorkspacePanelState() not found after no-saved-session marker"
+        )
         block = BOOT_JS[m_idx:sync_idx]
         assert self.PREF_PATTERN in block, (
             "No-saved-session boot path must read 'hermes-webui-workspace-panel-pref' "
             "before calling syncWorkspacePanelState()"
         )
-        assert "_workspacePanelMode='browse'" in block or "_workspacePanelMode = 'browse'" in block, (
+        assert (
+            "_workspacePanelMode='browse'" in block
+            or "_workspacePanelMode = 'browse'" in block
+        ), (
             "No-saved-session path must set _workspacePanelMode='browse' "
             "when the pref is 'open'"
         )
@@ -118,7 +127,7 @@ class TestToggleStaysEnabledWithProfileWorkspace:
         S._profileDefaultWorkspace is set, even with no active session."""
         idx = BOOT_JS.find("const canBrowse=")
         assert idx > 0, "canBrowse declaration not found in syncWorkspacePanelUI"
-        line = BOOT_JS[idx:idx + 200].split("\n", 1)[0]
+        line = BOOT_JS[idx : idx + 200].split("\n", 1)[0]
         assert "_profileDefaultWorkspace" in line, (
             "canBrowse must include S._profileDefaultWorkspace so the toggle "
             "button stays enabled when a profile workspace is configured"
@@ -129,7 +138,7 @@ class TestToggleStaysEnabledWithProfileWorkspace:
         S._profileDefaultWorkspace is set, otherwise clicking the toggle
         won't open the panel even though canBrowse said it should."""
         idx = BOOT_JS.find("function openWorkspacePanel(")
-        body = BOOT_JS[idx:idx + 600]
+        body = BOOT_JS[idx : idx + 600]
         # The early-return guard should include the profile-workspace check
         assert "_profileDefaultWorkspace" in body, (
             "openWorkspacePanel must include S._profileDefaultWorkspace in its "

--- a/tests/test_workspace_panel_session_list.py
+++ b/tests/test_workspace_panel_session_list.py
@@ -42,14 +42,13 @@ def _extract_js_function_body(src: str, name: str) -> str:
 
 
 class TestWorkspacePanelCollapsePriority:
-
     def test_rightpanel_is_a_size_container(self):
         """The right panel must declare itself as an inline-size container so
         its descendants can run @container queries against the panel's width."""
         # Look at the .rightpanel rule body
         idx = STYLE_CSS.find(".rightpanel{")
         assert idx >= 0, ".rightpanel rule not found"
-        rule = STYLE_CSS[idx: idx + 1200]
+        rule = STYLE_CSS[idx : idx + 1200]
         assert "container-type:inline-size" in rule, (
             ".rightpanel must declare container-type:inline-size for the "
             "header collapse-priority @container queries to work."
@@ -64,7 +63,7 @@ class TestWorkspacePanelCollapsePriority:
         simultaneous-shrink behaviour. The header now uses `gap` and
         `margin-left:auto` on `.panel-actions` to push them right."""
         idx = STYLE_CSS.find(".panel-header{")
-        rule = STYLE_CSS[idx: STYLE_CSS.find("}", idx) + 1]
+        rule = STYLE_CSS[idx : STYLE_CSS.find("}", idx) + 1]
         assert "justify-content:space-between" not in rule, (
             "panel-header still uses justify-content:space-between — that "
             "compresses all three children simultaneously."
@@ -85,8 +84,13 @@ class TestWorkspacePanelCollapsePriority:
                 "rule (.panel-header > span:first-child) handles the "
                 "title-text ellipsis as a fallback."
             )
-            inner_rule = STYLE_CSS[inner_span_idx: STYLE_CSS.find("}", inner_span_idx) + 1]
-            assert "overflow:hidden" in inner_rule and "text-overflow:ellipsis" in inner_rule, (
+            inner_rule = STYLE_CSS[
+                inner_span_idx : STYLE_CSS.find("}", inner_span_idx) + 1
+            ]
+            assert (
+                "overflow:hidden" in inner_rule
+                and "text-overflow:ellipsis" in inner_rule
+            ), (
                 ".panel-header > span:first-child must own the ellipsis "
                 "behaviour now that the parent is overflow:visible."
             )
@@ -96,7 +100,7 @@ class TestWorkspacePanelCollapsePriority:
         the icon buttons stay visible no matter how narrow the panel gets,
         and they sit at the right edge once `space-between` is removed."""
         idx = STYLE_CSS.find(".panel-actions{")
-        rule = STYLE_CSS[idx: STYLE_CSS.find("}", idx)]
+        rule = STYLE_CSS[idx : STYLE_CSS.find("}", idx)]
         assert "flex-shrink:0" in rule, (
             ".panel-actions must not shrink — icons are the priority."
         )
@@ -112,7 +116,7 @@ class TestWorkspacePanelCollapsePriority:
         sel = ".panel-header > span:first-child"
         idx = STYLE_CSS.find(sel)
         assert idx >= 0, f"Selector {sel!r} not found in style.css"
-        rule = STYLE_CSS[idx: STYLE_CSS.find("}", idx)]
+        rule = STYLE_CSS[idx : STYLE_CSS.find("}", idx)]
         assert "text-overflow:ellipsis" in rule
         assert "min-width:0" in rule
         assert "flex-shrink:2" in rule  # shrinks before icons (icons are 0)
@@ -121,7 +125,7 @@ class TestWorkspacePanelCollapsePriority:
         """`.git-badge` must shrink faster than the label so it disappears
         first as the panel narrows."""
         idx = STYLE_CSS.find(".git-badge{")
-        rule = STYLE_CSS[idx: STYLE_CSS.find("}", idx)]
+        rule = STYLE_CSS[idx : STYLE_CSS.find("}", idx)]
         assert "flex-shrink:3" in rule, (
             ".git-badge must have flex-shrink:3 so it shrinks before the "
             "label (flex-shrink:2) and the icons (flex-shrink:0)."
@@ -136,7 +140,7 @@ class TestWorkspacePanelCollapsePriority:
         )
         # Find the block and check git-badge is targeted
         idx = STYLE_CSS.find("@container rightpanel (max-width: 220px)")
-        block = STYLE_CSS[idx: idx + 200]
+        block = STYLE_CSS[idx : idx + 200]
         assert ".git-badge{display:none" in block
 
     def test_container_query_hides_label_at_narrower_width(self):
@@ -144,7 +148,7 @@ class TestWorkspacePanelCollapsePriority:
         confirms collapse priority order."""
         assert "@container rightpanel (max-width: 160px)" in STYLE_CSS
         idx = STYLE_CSS.find("@container rightpanel (max-width: 160px)")
-        block = STYLE_CSS[idx: idx + 200]
+        block = STYLE_CSS[idx : idx + 200]
         assert ".panel-header > span:first-child{display:none" in block
 
     def test_breakpoints_in_correct_order(self):
@@ -152,6 +156,7 @@ class TestWorkspacePanelCollapsePriority:
         label breakpoint (160px). Otherwise the label would vanish first."""
         # Both queries exist — extract numeric thresholds
         import re
+
         matches = re.findall(
             r"@container rightpanel \(max-width:\s*(\d+)px\)", STYLE_CSS
         )
@@ -168,7 +173,6 @@ class TestWorkspacePanelCollapsePriority:
 
 
 class TestProjectDotPlacement:
-
     def test_dot_appended_to_title_row_not_title(self):
         """The project dot must be appended to `titleRow` (a flex sibling
         of the title and timestamp), not to the title span (which truncates
@@ -207,7 +211,7 @@ class TestProjectDotPlacement:
         # Get the bare .session-time rule (not .session-time.is-hidden, not
         # .session-item:hover .session-time)
         idx = STYLE_CSS.find(".session-time{")
-        rule = STYLE_CSS[idx: STYLE_CSS.find("}", idx)]
+        rule = STYLE_CSS[idx : STYLE_CSS.find("}", idx)]
         assert "position:absolute" not in rule, (
             ".session-time must not be position:absolute — bug 2 requires "
             "it to live in the flex flow of .session-title-row."
@@ -223,7 +227,7 @@ class TestProjectDotPlacement:
         `vertical-align:middle` are unnecessary and only confuse layout."""
         idx = STYLE_CSS.find(".session-project-dot{")
         assert idx >= 0
-        rule = STYLE_CSS[idx: STYLE_CSS.find("}", idx)]
+        rule = STYLE_CSS[idx : STYLE_CSS.find("}", idx)]
         assert "margin-left:4px" not in rule, (
             "Old margin-left:4px is unnecessary now — gap:6px on "
             ".session-title-row handles spacing"
@@ -243,14 +247,16 @@ class TestProjectDotPlacement:
         # mobile-touch override).
         idx = STYLE_CSS.find(".session-item{padding:8px")
         assert idx >= 0, "Could not find desktop .session-item padding rule"
-        rule = STYLE_CSS[idx: STYLE_CSS.find("}", idx)]
+        rule = STYLE_CSS[idx : STYLE_CSS.find("}", idx)]
         assert "padding:8px 8px" in rule, (
             f"Expected 'padding:8px 8px' for at-rest session items, got: {rule!r}"
         )
         # Mobile also drops from 86px to 40px — the absolute timestamp is
         # gone (now flex-flow), so only the always-visible action button's
         # footprint (26px + 6px gap ≈ 32px, rounded to 40px) needs reservation.
-        assert ".session-item{min-height:44px;padding:10px 40px 10px 12px;}" in STYLE_CSS
+        assert (
+            ".session-item{min-height:44px;padding:10px 40px 10px 12px;}" in STYLE_CSS
+        )
 
     def test_session_item_expands_padding_on_hover_and_attention(self):
         """PR #1110: Touch layout-shift fix — :hover removed from the COMBINED
@@ -268,7 +274,7 @@ class TestProjectDotPlacement:
         assert idx >= 0, (
             "Combined streaming/unread/focus-within/menu-open padding rule not found"
         )
-        rule = STYLE_CSS[idx: STYLE_CSS.find("}", idx)]
+        rule = STYLE_CSS[idx : STYLE_CSS.find("}", idx)]
         assert "padding-right:40px" in rule
         # Desktop hover padding restored via @media (hover:hover) — mouse devices only
         assert "@media (hover:hover)" in STYLE_CSS


### PR DESCRIPTION
## Summary

- Applied `ruff check --fix` to auto-fix F401, F841, F541, E401 violations across all Python source files
- Applied `ruff format` for quote normalization, trailing commas, and line-length wrapping
- Manually fixed remaining F841: removed unused `as f` binding from `with open("/.within_container", "r")` in `server.py`
- Skipped `server.js` (no eslint config present in repo)

## Remaining lint errors (intentional, not fixed)

- 7x E402 in `server.py`: imports after bootstrap setup code — these run after `bootstrap.py` initialization and cannot be hoisted without breaking startup semantics

## Test plan

- [ ] Verify `ruff check server.py bootstrap.py tests/` shows only the 7 pre-existing E402 errors
- [ ] Confirm no F841 warnings remain
- [ ] Run existing test suite to confirm no semantic changes were introduced

Nightshift-Task: lint-fix
Nightshift-Ref: https://github.com/marcus/nightshift


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: lint-fix:/
task-type: lint-fix
task-title: Linter Fixes
provider: claude
score: 0.1
cost-tier: Low (10-50k)
iterations: 2
duration: 15m11s
run-started: 2026-05-10T02:00:05-05:00
nightshift:metadata -->
