### PR TITLE
fix: patch skills module-level caches on per-request profile switch

### DIFF
--- a/api/streaming.py
+++ b/api/streaming.py
@@ -2046,6 +2046,23 @@ def _run_agent_streaming(
             os.environ['HERMES_SESSION_KEY'] = session_id
             if _profile_home:
                 os.environ['HERMES_HOME'] = _profile_home
+                # Patch module-level caches to match the active profile.
+                # _set_hermes_home() does this for process-wide switches
+                # but per-request switches skip it (#1700).
+                from pathlib import Path as _P
+                _ph = _P(_profile_home)
+                try:
+                    import tools.skills_tool as _sk
+                    _sk.HERMES_HOME = _ph
+                    _sk.SKILLS_DIR = _ph / 'skills'
+                except (ImportError, AttributeError):
+                    pass
+                try:
+                    import tools.skill_manager_tool as _sm
+                    _sm.HERMES_HOME = _ph
+                    _sm.SKILLS_DIR = _ph / 'skills'
+                except (ImportError, AttributeError):
+                    pass
         # Lock released — agent runs without holding it
         # ── MCP Server Discovery (lazy import, idempotent) ──
         # MUST run AFTER the HERMES_HOME mutation above — `discover_mcp_tools()`


### PR DESCRIPTION
## Problem

In multi-profile WebUI deployments, the agent's skill tools (`skills_list()`, `skill_view()`, `skill_manage()`) always resolve from the root profile's skills directory, regardless of which profile is active in the browser session.

### Root cause

Both `tools/skills_tool.py` and `tools/skill_manager_tool.py` set `HERMES_HOME` and `SKILLS_DIR` as module-level constants at import time:

```python
HERMES_HOME = get_hermes_home()
SKILLS_DIR = HERMES_HOME / "skills"
```

Per-request profile switches (`switch_profile(process_wide=False)`, introduced in #1700) update `os.environ['HERMES_HOME']` in the `_ENV_LOCK` block of `streaming.py` but do not call `_set_hermes_home()`, which is responsible for patching these constants. Process-wide switches (`switch_profile(process_wide=True)`) do call `_set_hermes_home()` and correctly patch both — this is the gap between the two paths.

### Current behaviour

- Agent in non-root profile: `skills_list()` returns root profile skills
- `skill_view(<profile-specific-skill>)` returns "not found"
- `skill_manage(action='create')` writes to root profile directory

### Fix

Add the same monkeypatching that `_set_hermes_home()` already performs (`profiles.py` line ~620) to the per-turn env setup block in `streaming.py`, immediately after the `HERMES_HOME` env var update.
Covers both `tools.skills_tool` and `tools.skill_manager_tool`.
Guarded by the existing `_ENV_LOCK` and only applied when `_profile_home` is set.

This mirrors the existing pattern in `_set_hermes_home()` which patches `skills_tool.SKILLS_DIR`, `cron.jobs.HERMES_DIR`, and `cron.scheduler._hermes_home`. This PR adds the skills patches to the per-request path; cron patches are not needed here as cron jobs run in the gateway container, not the WebUI.

### Related

- #1917 — fixed WebUI display half (`_active_skills_dir()` in  `routes.py`)
- #1700 — introduced `process_wide=False` profile switching

## Files changed

- `api/streaming.py` — 1 edit, 15 lines added

## Testing

1. Create a non-root profile with profile-specific skills
2. Switch to that profile in the WebUI
3. Ask the agent to run `skills_list()` — should return profile-specific skills, not root profile skills
4. Ask the agent to run `skill_view(<profile-specific-skill>)` —   should resolve correctly
5. Ask the agent to `skill_manage(action='create')` — should write to the active profile's skills directory
6. Switch back to root profile — verify root skills resolve correctly