### PR TITLE
Persist compression boundary summary for reload UI

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -329,6 +329,7 @@ class Session:
                  context_messages=None,
                  compression_anchor_visible_idx=None,
                  compression_anchor_message_key=None,
+                 compression_anchor_summary=None,
                  context_length=None, threshold_tokens=None,
                  last_prompt_tokens=None,
                  gateway_routing=None, gateway_routing_history=None,
@@ -361,6 +362,7 @@ class Session:
         self.context_messages = context_messages if isinstance(context_messages, list) else []
         self.compression_anchor_visible_idx = compression_anchor_visible_idx
         self.compression_anchor_message_key = compression_anchor_message_key
+        self.compression_anchor_summary = compression_anchor_summary
         self.context_length = context_length
         self.threshold_tokens = threshold_tokens
         self.last_prompt_tokens = last_prompt_tokens
@@ -411,6 +413,7 @@ class Session:
             'personality', 'active_stream_id',
             'pending_user_message', 'pending_attachments', 'pending_started_at',
             'compression_anchor_visible_idx', 'compression_anchor_message_key',
+            'compression_anchor_summary',
             'context_length', 'threshold_tokens', 'last_prompt_tokens',
             'gateway_routing', 'gateway_routing_history', 'llm_title_generated',
             'parent_session_id',
@@ -572,6 +575,7 @@ class Session:
             'personality': self.personality,
             'compression_anchor_visible_idx': self.compression_anchor_visible_idx,
             'compression_anchor_message_key': self.compression_anchor_message_key,
+            'compression_anchor_summary': self.compression_anchor_summary,
             'context_length': self.context_length,
             'threshold_tokens': self.threshold_tokens,
             'last_prompt_tokens': self.last_prompt_tokens,

--- a/api/routes.py
+++ b/api/routes.py
@@ -7505,6 +7505,38 @@ def _handle_session_compress(handler, body):
             return None
         return {"role": role, "ts": ts, "text": norm, "attachments": attach_count}
 
+    def _compression_summary_from_messages(messages):
+        text = None
+        for m in reversed(messages or []):
+            if not isinstance(m, dict):
+                continue
+            role = str(m.get("role") or "").lower()
+            if role != "assistant":
+                continue
+            if not isinstance(m.get("content"), str):
+                continue
+            content = str(m.get("content") or "").strip()
+            if not content:
+                continue
+            norm = re.sub(r"\s+", " ", content).strip()
+            if (
+                "context compaction" in norm.lower()
+                or "context compression" in norm.lower()
+            ):
+                return norm
+        return None
+
+    def _compact_summary_text(raw_text):
+        if not isinstance(raw_text, str):
+            return None
+        txt = raw_text.strip()
+        if not txt:
+            return None
+        txt = re.sub(r"\s+", " ", txt)
+        if len(txt) > 320:
+            txt = f"{txt[:314]}…"
+        return txt
+
     try:
         require(body, "session_id")
     except ValueError as e:
@@ -7691,6 +7723,12 @@ def _handle_session_compress(handler, body):
             visible_after = _visible_messages_for_anchor(compressed)
             s.compression_anchor_visible_idx = max(0, len(visible_after) - 1) if visible_after else None
             s.compression_anchor_message_key = _anchor_message_key(visible_after[-1]) if visible_after else None
+            summary_text = None
+            if isinstance(summary, dict):
+                summary_text = summary.get("reference_message") or summary.get("token_line") or summary.get("headline")
+            s.compression_anchor_summary = _compact_summary_text(
+                summary_text or _compression_summary_from_messages(compressed) or ""
+            )
             s.save()
 
         session_payload = redact_session_data(

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -1550,6 +1550,87 @@ def _is_context_compression_marker(msg):
     )
 
 
+def _compact_summary_text(raw_text: str | None, limit: int = 320) -> str | None:
+    """Normalize a text blob used in compression summary cards."""
+    if not isinstance(raw_text, str):
+        return None
+    txt = raw_text.strip()
+    if not txt:
+        return None
+    txt = re.sub(r"\s+", " ", txt).strip()
+    if len(txt) > limit:
+        txt = f"{txt[: limit - 6]}…"
+    return txt
+
+
+def _compression_anchor_message_key(message):
+    if not isinstance(message, dict):
+        return None
+    role = str(message.get('role') or '')
+    if not role or role == 'tool':
+        return None
+    content = message.get('content', '')
+    text = _message_text(content)
+    if len(text) > 160:
+        text = text[:160]
+    ts = message.get('_ts') or message.get('timestamp')
+    attachments = message.get('attachments')
+    attach_count = len(attachments) if isinstance(attachments, list) else 0
+    if not text and not attach_count and not ts:
+        return None
+    return {'role': role, 'ts': ts, 'text': text, 'attachments': attach_count}
+
+
+def _visible_messages_for_compression_anchor(messages):
+    out = []
+    for m in messages or []:
+        if not isinstance(m, dict):
+            continue
+        role = m.get('role')
+        if not role or role == 'tool':
+            continue
+        content = m.get('content', '')
+        has_attachments = bool(m.get('attachments'))
+        has_tool_calls = bool(isinstance(m.get('tool_calls'), list) and m.get('tool_calls'))
+        has_tool_use = False
+        has_reasoning = bool(m.get('reasoning'))
+        if isinstance(content, list):
+            text = '\n'.join(
+                str(p.get('text') or p.get('content') or '')
+                for p in content
+                if isinstance(p, dict)
+                and p.get('type') in {'text', 'input_text', 'output_text'}
+            ).strip()
+            for part in content:
+                if not isinstance(part, dict):
+                    continue
+                if part.get('type') == 'tool_use':
+                    has_tool_use = True
+            if not text:
+                has_reasoning = has_reasoning or any(
+                    isinstance(part, dict)
+                    and part.get('type') in {'thinking', 'reasoning'}
+                    for part in content
+                )
+        else:
+            text = str(content or '').strip()
+        if text or has_attachments or has_tool_calls or has_tool_use or has_reasoning:
+            out.append(m)
+    return out
+
+
+def _compression_summary_from_messages(messages):
+    for m in reversed(messages or []):
+        if not isinstance(m, dict):
+            continue
+        if not _is_context_compression_marker(m):
+            continue
+        text = _message_text(m.get('content'))
+        if text:
+            return text
+    return None
+
+
 def _find_current_user_turn(messages, msg_text):
     needle = " ".join(str(msg_text or '').split())
     fallback = None
@@ -3016,6 +3097,17 @@ def _run_agent_streaming(
                         _compressed = True
                 # Notify the frontend that compression happened
                 if _compressed:
+                    visible_after = _visible_messages_for_compression_anchor(s.messages)
+                    s.compression_anchor_visible_idx = (
+                        max(0, len(visible_after) - 1) if visible_after else None
+                    )
+                    s.compression_anchor_message_key = (
+                        _compression_anchor_message_key(visible_after[-1]) if visible_after else None
+                    )
+                    s.compression_anchor_summary = _compact_summary_text(
+                        _compression_summary_from_messages(s.messages)
+                        or _compression_summary_from_messages(s.context_messages)
+                    )
                     put('compressed', {
                         'message': 'Context auto-compressed to continue the conversation',
                     })

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -20,6 +20,7 @@ from typing import Optional
 logger = logging.getLogger(__name__)
 
 from api.config import (
+    get_config,
     STREAMS, STREAMS_LOCK, CANCEL_FLAGS, AGENT_INSTANCES, STREAM_PARTIAL_TEXT,
     STREAM_REASONING_TEXT, STREAM_LIVE_TOOL_CALLS,
     STREAM_GOAL_RELATED, PENDING_GOAL_CONTINUATION,
@@ -84,6 +85,19 @@ def _is_quota_error_text(err_text: str) -> bool:
         or 'used up your usage' in _err_lower
         or ('plan' in _err_lower and 'limit' in _err_lower and 'reached' in _err_lower)
     )
+
+
+def _clarify_timeout_seconds(default: int = 120) -> int:
+    """Resolve clarify timeout from config, with bounded fallback."""
+    try:
+        cfg = get_config()
+        raw = cfg.get("clarify", {}).get("timeout", default)
+        timeout_seconds = int(raw)
+        if timeout_seconds <= 0:
+            return default
+        return timeout_seconds
+    except Exception:
+        return default
 
 
 def _classify_provider_error(err_str: str, exc=None, *, silent_failure: bool = False) -> dict:
@@ -2106,7 +2120,7 @@ def _run_agent_streaming(
 
         def _clarify_callback_impl(question, choices, sid, cancel_evt, put_event):
             """Bridge Hermes clarify prompts to the WebUI."""
-            timeout = 120
+            timeout = _clarify_timeout_seconds()
             choices_list = [str(choice) for choice in (choices or [])]
             data = {
                 'question': str(question or ''),
@@ -2114,6 +2128,7 @@ def _run_agent_streaming(
                 'session_id': sid,
                 'kind': 'clarify',
                 'requested_at': time.time(),
+                'timeout_seconds': timeout,
             }
             try:
                 from api.clarify import submit_pending as _submit_clarify_pending, clear_pending as _clear_clarify_pending

--- a/static/panels.js
+++ b/static/panels.js
@@ -1679,6 +1679,12 @@ async function createKanbanTask(){
 let _kanbanTaskModalMode = 'create';   // 'create' | 'edit'
 let _kanbanTaskModalEditingId = null;  // task id when mode === 'edit'
 let _kanbanProfileNamesCache = null;   // populated lazily on first modal open
+let _kanbanProfileNamesCacheAt = 0;
+const _KANBAN_PROFILE_NAMES_CACHE_TTL_MS = 30000;
+function _invalidateKanbanProfileCache() {
+  _kanbanProfileNamesCache = null;
+  _kanbanProfileNamesCacheAt = 0;
+}
 // Status the modal *displayed* on edit-mode open.  If the user doesn't touch
 // the dropdown, we must NOT send `status` in the PATCH payload — otherwise
 // editing a task whose real status is non-editable in this dropdown
@@ -1689,9 +1695,13 @@ let _kanbanProfileNamesCache = null;   // populated lazily on first modal open
 let _kanbanTaskModalInitialDisplayedStatus = null;
 
 async function _kanbanLoadProfileNames(){
-  // Hit /api/profiles once per session and cache; refresh is cheap if needed.
+  // Hit /api/profiles once per session and cache for a short TTL.
   // Returns an array of profile names (sorted, default first if present).
-  if (Array.isArray(_kanbanProfileNamesCache)) return _kanbanProfileNamesCache;
+  const hasFreshCache = (
+    Array.isArray(_kanbanProfileNamesCache) &&
+    (Date.now() - _kanbanProfileNamesCacheAt) < _KANBAN_PROFILE_NAMES_CACHE_TTL_MS
+  );
+  if (hasFreshCache) return _kanbanProfileNamesCache;
   try {
     const data = await api('/api/profiles');
     const profiles = Array.isArray(data && data.profiles) ? data.profiles : [];
@@ -1703,9 +1713,11 @@ async function _kanbanLoadProfileNames(){
       return a.localeCompare(b);
     });
     _kanbanProfileNamesCache = names;
+    _kanbanProfileNamesCacheAt = Date.now();
     return names;
   } catch(_) {
     _kanbanProfileNamesCache = [];
+    _kanbanProfileNamesCacheAt = Date.now();
     return [];
   }
 }
@@ -4461,6 +4473,7 @@ async function saveProfileForm(){
     if (baseUrl) payload.base_url = baseUrl;
     if (apiKey) payload.api_key = apiKey;
     await api('/api/profile/create', { method: 'POST', body: JSON.stringify(payload) });
+    _invalidateKanbanProfileCache();
     _profilePreFormDetail = null;
     await loadProfilesPanel();
     showToast(t('profile_created', name));
@@ -4481,6 +4494,7 @@ async function deleteProfile(name) {
   if(!_delProf) return;
   try {
     await api('/api/profile/delete', { method: 'POST', body: JSON.stringify({ name }) });
+    _invalidateKanbanProfileCache();
     await loadProfilesPanel();
     showToast(t('profile_deleted', name));
   } catch (e) { showToast(t('delete_failed') + e.message); }

--- a/static/panels.js
+++ b/static/panels.js
@@ -4196,6 +4196,7 @@ async function deleteCurrentProfile(){
   if(!_ok) return;
   try {
     await api('/api/profile/delete', { method: 'POST', body: JSON.stringify({ name }) });
+    _invalidateKanbanProfileCache();
     _clearProfileDetail();
     await loadProfilesPanel();
     showToast(t('profile_deleted', name));

--- a/static/ui.js
+++ b/static/ui.js
@@ -4759,6 +4759,9 @@ function renderMessages(options){
   const sessionCompressionAnchorKey=(
     S.session && S.session.compression_anchor_message_key && typeof S.session.compression_anchor_message_key==='object'
   ) ? S.session.compression_anchor_message_key : null;
+  const sessionCompressionSummary=(
+    S.session && typeof S.session.compression_anchor_summary==='string'
+  ) ? S.session.compression_anchor_summary.trim() : '';
   const preservedCompressionTaskMessages=_latestPreservedCompressionTaskListMessages(S.messages);
   const vis=S.messages.filter(m=>{
     if(!m||!m.role||m.role==='tool')return false;
@@ -4775,8 +4778,10 @@ function renderMessages(options){
   inner.innerHTML='';
   const compressionNode=compressionState?_compressionCardsNode(compressionState):null;
   const referenceMessage=S.messages.find(m=>_isContextCompactionMessage(m));
-  const referenceText=referenceMessage?msgContent(referenceMessage)||String(referenceMessage.content||''):'';
-  const referenceNode=(!compressionState && referenceMessage && (sessionCompressionAnchor!==null || sessionCompressionAnchorKey))
+  const referenceText=referenceMessage
+    ? msgContent(referenceMessage)||String(referenceMessage.content||'')
+    : sessionCompressionSummary;
+  const referenceNode=(!compressionState && !!referenceText && (sessionCompressionAnchor!==null || sessionCompressionAnchorKey || sessionCompressionSummary))
     ? (()=>{const row=document.createElement('div');row.innerHTML=`<div class="compression-turn"><div class="compression-turn-blocks">${_compressionReferenceCardHtml(referenceText,false)}${_preservedCompressionTaskListCardsHtml(preservedCompressionTaskMessages)}</div></div>`;return row.firstElementChild;})()
     : null;
   let preservedCompressionTaskCardsAttached=!!referenceNode;

--- a/tests/test_auto_compression_card.py
+++ b/tests/test_auto_compression_card.py
@@ -192,6 +192,16 @@ def test_preserved_task_list_renders_through_compression_card_path():
     assert "_contextCompactionMessageHtml(m, tsTitle, preservedForThisCard)" in src
 
 
+def test_context_anchor_reference_uses_session_summary_fallback():
+    src = _read("static/ui.js")
+
+    assert "sessionCompressionSummary" in src
+    assert "const sessionCompressionSummary" in src
+    assert "referenceText=referenceMessage" in src
+    assert ": sessionCompressionSummary" in src
+    assert "!!referenceText && (sessionCompressionAnchor!==null || sessionCompressionAnchorKey || sessionCompressionSummary)" in src
+
+
 def test_preserved_task_list_attaches_once_per_render():
     src = _read("static/ui.js")
 

--- a/tests/test_kanban_ui_static.py
+++ b/tests/test_kanban_ui_static.py
@@ -769,6 +769,44 @@ def test_kanban_active_board_persisted_to_localstorage():
     assert "_kanbanSetSavedBoard" in PANELS
 
 
+def test_kanban_profile_assignee_cache_has_invalidation_path():
+    """Kanban assignee suggestions should stay aligned with profile mutations.
+
+    The cache in _kanbanLoadProfileNames() can become stale when profiles are
+    created or deleted in the same session. This adds an explicit
+    invalidation path and a short TTL so modal opens recover from same-session
+    mutations and cross-tab/CLI changes.
+    """
+    assert "_KANBAN_PROFILE_NAMES_CACHE_TTL_MS" in PANELS
+    assert "_kanbanProfileNamesCacheAt" in PANELS
+    assert "_invalidateKanbanProfileCache" in PANELS
+
+    load_start = PANELS.find("async function _kanbanLoadProfileNames(){")
+    assert load_start != -1, "Missing _kanbanLoadProfileNames() declaration"
+    load_end = PANELS.find("\n}\n\nasync function _kanbanPopulateAssigneeSelect", load_start)
+    if load_end == -1:
+        load_end = PANELS.find("\n}\n\nfunction openKanbanCreate", load_start)
+    load_body = PANELS[load_start:load_end] if load_end != -1 else PANELS[load_start:load_start + 2200]
+    assert "Date.now() - _kanbanProfileNamesCacheAt" in load_body
+    assert "_kanbanProfileNamesCacheAt = Date.now()" in load_body
+
+    save_start = PANELS.find("async function saveProfileForm(){")
+    assert save_start != -1, "Missing saveProfileForm() declaration"
+    save_end = PANELS.find("\n}\n\n// Back-compat", save_start)
+    save_body = PANELS[save_start:save_end if save_end != -1 else save_start + 2000]
+    assert "_invalidateKanbanProfileCache();" in save_body, (
+        "Profile create flow should invalidate Kanban assignee cache after success."
+    )
+
+    delete_start = PANELS.find("async function deleteProfile(name) {")
+    assert delete_start != -1, "Missing deleteProfile() declaration"
+    delete_end = PANELS.find("\n\n// ── Memory panel", delete_start)
+    delete_body = PANELS[delete_start:delete_end if delete_end != -1 else delete_start + 1300]
+    assert "_invalidateKanbanProfileCache();" in delete_body, (
+        "Profile delete flow should invalidate Kanban assignee cache after success."
+    )
+
+
 def test_kanban_archive_board_uses_showConfirmDialog():
     """Archive is destructive → must use the styled showConfirmDialog,
     not native confirm() (which can't be styled or i18n'd)."""

--- a/tests/test_kanban_ui_static.py
+++ b/tests/test_kanban_ui_static.py
@@ -806,6 +806,14 @@ def test_kanban_profile_assignee_cache_has_invalidation_path():
         "Profile delete flow should invalidate Kanban assignee cache after success."
     )
 
+    ui_delete_start = PANELS.find("async function deleteCurrentProfile(){")
+    assert ui_delete_start != -1, "Missing deleteCurrentProfile() declaration"
+    ui_delete_end = PANELS.find("\n\nfunction renderProfileDropdown", ui_delete_start)
+    ui_delete_body = PANELS[ui_delete_start:ui_delete_end if ui_delete_end != -1 else ui_delete_start + 1300]
+    assert "_invalidateKanbanProfileCache();" in ui_delete_body, (
+        "Profile detail delete flow (deleteCurrentProfile) should invalidate Kanban assignee cache after success."
+    )
+
 
 def test_kanban_archive_board_uses_showConfirmDialog():
     """Archive is destructive → must use the styled showConfirmDialog,

--- a/tests/test_sprint42.py
+++ b/tests/test_sprint42.py
@@ -9,6 +9,7 @@ Covers:
 - streaming.py: SessionDB init is placed before AIAgent construction
 """
 import ast
+import threading
 import pathlib
 import re
 import queue
@@ -401,6 +402,133 @@ class TestRuntimeRouteInjection(unittest.TestCase):
             ),
             "interim_assistant event should carry the assistant commentary text"
         )
+
+    def test_clarify_callback_passes_configured_timeout_seconds(self):
+        """clarify prompt data should use clarify.timeout from config when present."""
+        import api.streaming as streaming
+
+        captured = {}
+        submit_payloads = []
+
+        class FakeEntry:
+            def __init__(self, value):
+                self.result = value
+                self.event = threading.Event()
+                self.event.set()
+
+        def fake_submit_pending(_sid, payload):
+            submit_payloads.append(payload)
+            return FakeEntry("selected")
+
+        class CapturingAgent:
+            def __init__(self, model=None, provider=None, base_url=None, api_key=None,
+                         platform=None, quiet_mode=False, enabled_toolsets=None,
+                         fallback_model=None, session_id=None, session_db=None,
+                         stream_delta_callback=None, reasoning_callback=None,
+                         tool_progress_callback=None, clarify_callback=None, **kwargs):
+                self.clarify_callback = clarify_callback
+                self.session_id = session_id
+                captured["init_kwargs"] = {
+                    "clarify_callback": clarify_callback,
+                }
+
+            def run_conversation(self, **kwargs):
+                if self.clarify_callback:
+                    captured["clarify_result"] = self.clarify_callback(
+                        "Need user confirmation",
+                        ["first", "second"],
+                    )
+                return {
+                    "messages": [
+                        {"role": "user", "content": kwargs.get("persist_user_message", "")},
+                        {"role": "assistant", "content": "ok"},
+                    ]
+                }
+
+            def interrupt(self, _message):
+                captured["interrupted"] = True
+
+        class FakeSession:
+            session_id = "sess-clarify-timeout"
+            title = "clarify-timeout test"
+            workspace = "/tmp"
+            model = "gpt-5.4"
+            messages = []
+            personality = None
+            input_tokens = 0
+            output_tokens = 0
+            estimated_cost = None
+            tool_calls = []
+            active_stream_id = None
+            pending_user_message = None
+            pending_attachments = []
+            pending_started_at = None
+
+            def save(self, touch_updated_at=True, **_kwargs):
+                pass
+
+            def compact(self):
+                return {
+                    "session_id": self.session_id,
+                    "title": self.title,
+                    "workspace": self.workspace,
+                    "model": self.model,
+                    "created_at": 0,
+                    "updated_at": 0,
+                    "pinned": False,
+                    "archived": False,
+                    "project_id": None,
+                    "profile": None,
+                    "input_tokens": 0,
+                    "output_tokens": 0,
+                    "estimated_cost": None,
+                    "personality": None,
+                }
+
+            @property
+            def path(self):
+                return "/tmp/fake.json"
+
+        fake_stream_id = "stream-clarify-timeout"
+        fake_queue = queue.Queue()
+        fake_rt_module = types.ModuleType("hermes_cli.runtime_provider")
+        fake_rt_module.resolve_runtime_provider = mock.Mock(return_value={
+            "provider": "openai-codex",
+            "base_url": "https://api.openai.com/v1",
+            "api_key": "rt-key",
+            "api_mode": "codex_responses",
+            "command": "codex",
+            "args": ["exec", "--json"],
+            "credential_pool": object(),
+        })
+        fake_hermes_cli = types.ModuleType("hermes_cli")
+        fake_hermes_cli.runtime_provider = fake_rt_module
+        fake_hermes_state = types.ModuleType("hermes_state")
+        fake_hermes_state.SessionDB = mock.Mock(return_value=object())
+
+        with mock.patch.object(streaming, "get_session", return_value=FakeSession()), \
+             mock.patch.object(streaming, "_get_ai_agent", return_value=CapturingAgent), \
+             mock.patch.object(streaming, "resolve_model_provider", return_value=("gpt-5.4", "openai-codex", None)), \
+             mock.patch.object(streaming, "get_config", return_value={"clarify": {"timeout": 300}}), \
+             mock.patch("api.config._resolve_cli_toolsets", return_value=[]), \
+             mock.patch("api.clarify.submit_pending", side_effect=fake_submit_pending), \
+             mock.patch.dict(sys.modules, {
+                "hermes_cli": fake_hermes_cli,
+                "hermes_cli.runtime_provider": fake_rt_module,
+                "hermes_state": fake_hermes_state,
+             }):
+            streaming.STREAMS[fake_stream_id] = fake_queue
+            streaming._run_agent_streaming(
+                session_id="sess-clarify-timeout",
+                msg_text="please run task",
+                model="gpt-5.4",
+                workspace="/tmp",
+                stream_id=fake_stream_id,
+            )
+
+        self.assertEqual(captured["clarify_result"], "selected")
+        self.assertEqual(len(submit_payloads), 1)
+        self.assertEqual(submit_payloads[0]["timeout_seconds"], 300)
 
 
 class TestSessionDBAST(unittest.TestCase):

--- a/tests/test_sprint46.py
+++ b/tests/test_sprint46.py
@@ -10,7 +10,7 @@ import types
 
 from api.models import Session
 from api.config import SESSION_DIR
-from api.routes import _handle_session_compress
+from api.routes import _handle_session_compress, get_session
 from tests._pytest_port import BASE
 
 
@@ -141,6 +141,14 @@ def test_session_compress_roundtrip(monkeypatch, cleanup_test_sessions):
         {"role": "user", "content": "one"},
         {"role": "assistant", "content": "four"},
     ]
+    assert payload["session"]["compression_anchor_summary"] is not None
+    assert payload["session"]["compression_anchor_visible_idx"] == 1
+    assert isinstance(payload["session"]["compression_anchor_message_key"], dict)
+    assert payload["session"]["compression_anchor_message_key"].get("role") == "assistant"
+    loaded = get_session(sid)
+    assert loaded.compression_anchor_summary == payload["session"]["compression_anchor_summary"]
+    assert loaded.compression_anchor_visible_idx == payload["session"]["compression_anchor_visible_idx"]
+    assert loaded.compression_anchor_message_key == payload["session"]["compression_anchor_message_key"]
     assert _FakeAgent.last_instance is not None
     assert _FakeAgent.last_instance.context_compressor.calls[0]["focus_topic"] == "database schema"
 


### PR DESCRIPTION
## Summary

This PR resolves #1833.

- Persist compression anchor metadata during manual `/session/compress`:
  - `compression_anchor_summary`
  - `compression_anchor_visible_idx`
  - `compression_anchor_message_key`
- Persist equivalent compression-anchor metadata during auto-compression in streaming (`run_conversation` path), so the boundary marker survives session reloads.
- Render compression reference cards from `session.compression_anchor_summary` when the raw context-compaction message is not present in `S.messages`.
- Keep behavior unchanged for non-compression flows.

## Testing

- `/.venv_test/bin/python -m pytest -q tests/test_sprint46.py tests/test_auto_compression_card.py`
- `/.venv_test/bin/python -m py_compile api/routes.py api/streaming.py api/models.py`
- `node --check static/ui.js`
