### PR TITLE
feat: add Xiaomi MiMo provider support

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -657,6 +657,7 @@ _PROVIDER_DISPLAY = {
     "qwen": "Qwen",
     "x-ai": "xAI",
     "nvidia": "NVIDIA NIM",
+    "xiaomi": "Xiaomi",
 }
 
 # Provider alias → canonical slug.  Users configure providers using the
@@ -707,6 +708,8 @@ _PROVIDER_ALIASES = {
     "nvidia-nim": "nvidia",
     "build-nvidia": "nvidia",
     "nemotron": "nvidia",
+    "mimo": "xiaomi",
+    "xiaomi-mimo": "xiaomi",
     # Legacy alias — earlier WebUI builds wrote ``provider: local`` for unknown
     # loopback endpoints, but ``local`` is not registered in
     # ``hermes_cli.auth.PROVIDER_REGISTRY``. Routing it through ``custom``
@@ -1065,6 +1068,14 @@ _PROVIDER_MODELS = {
         {"id": "nvidia/nemotron-3-nano-30b-a3b", "label": "Nemotron 3 Nano 30B"},
         {"id": "nvidia/llama-3.3-nemotron-super-49b-v1.5", "label": "Llama 3.3 Nemotron Super 49B"},
         {"id": "qwen/qwen3-next-80b-a3b-instruct", "label": "Qwen3 Next 80B"},
+    ],
+    # Xiaomi MiMo — direct API via api.xiaomimimo.com
+    "xiaomi": [
+        {"id": "mimo-v2.5-pro",    "label": "MiMo V2.5 Pro"},
+        {"id": "mimo-v2.5",        "label": "MiMo V2.5"},
+        {"id": "mimo-v2-pro",      "label": "MiMo V2 Pro"},
+        {"id": "mimo-v2-omni",     "label": "MiMo V2 Omni"},
+        {"id": "mimo-v2-flash",    "label": "MiMo V2 Flash"},
     ],
     # xAI — prefix used in OpenRouter model IDs (x-ai/grok-4-20)
     "x-ai": [


### PR DESCRIPTION
## Summary

Adds Xiaomi as a first-class provider in the WebUI's model catalog.

The hermes-agent CLI already registers Xiaomi (see `hermes_cli/models.py` and `hermes_cli/auth.py`) with full model support, but the WebUI's `api/config.py` was missing the corresponding entries. This caused:

1. **Model dropdown** falling back to OpenRouter's mimo entries instead of routing through Xiaomi's direct API
2. **Provider list** showing Xiaomi as `Unsupported` with no models
3. **Default model reverting** to `openrouter/mimo-v2.5-pro` instead of `xiaomi/mimo-v2.5-pro`

## Changes

Three additions to `api/config.py`:

- **`_PROVIDER_DISPLAY`** — `"xiaomi": "Xiaomi"`
- **`_PROVIDER_ALIASES`** — `"mimo": "xiaomi"`, `"xiaomi-mimo": "xiaomi"`
- **`_PROVIDER_MODELS`** — 5 models:
  - `mimo-v2.5-pro` (MiMo V2.5 Pro)
  - `mimo-v2.5` (MiMo V2.5)
  - `mimo-v2-pro` (MiMo V2 Pro)
  - `mimo-v2-omni` (MiMo V2 Omni)
  - `mimo-v2-flash` (MiMo V2 Flash)

## Test Plan

- [ ] Settings → Providers shows `Xiaomi — 5 models · API key configured`
- [ ] Model selector dropdown lists all 5 Xiaomi models
- [ ] Selecting a Xiaomi model routes through the Xiaomi API (not OpenRouter)