### PR TITLE
fix: stamp profile on continuation session after context compression

### DIFF
--- a/api/streaming.py
+++ b/api/streaming.py
@@ -2022,7 +2022,24 @@ def _run_agent_streaming(
         except ImportError:
             _profile_home = os.environ.get('HERMES_HOME', '')
             _profile_runtime_env = {}
-
+        
+        # Capture the resolved profile name now, while profile context is
+        # reliable. Used in the compression migration block to stamp s.profile
+        # on the continuation session. We resolve it here rather than calling
+        # get_active_profile_name() at compression time because that function
+        # reads thread-local storage (_tls.profile) set by set_request_profile()
+        # on the HTTP handler thread. The streaming thread is a separate
+        # threading.Thread and does not inherit TLS. At compression time,
+        # get_active_profile_name() would fall back to the process-global
+        # _active_profile, which may belong to a different concurrent tab.
+        _resolved_profile_name = getattr(s, 'profile', None)
+        if not _resolved_profile_name:
+            try:
+                from api.profiles import get_active_profile_name
+                _resolved_profile_name = get_active_profile_name()
+            except Exception:
+                _resolved_profile_name = None
+        
         _thread_env = _build_agent_thread_env(
             _profile_runtime_env,
             str(s.workspace),
@@ -2972,6 +2989,22 @@ def _run_agent_streaming(
                     old_path = SESSION_DIR / f'{old_sid}.json'
                     new_path = SESSION_DIR / f'{new_sid}.json'
                     s.session_id = new_sid
+                    # Carry profile identity across the compression boundary.
+                    # Without this, s.profile stays None on the continuation
+                    # session. On the next request, _run_agent_streaming calls
+                    # get_hermes_home_for_profile(getattr(s, 'profile', None))
+                    # which falls back to the default profile's HERMES_HOME.
+                    # Memory writes then land in the wrong profile's MEMORY.md.
+                    # Stamping here also ensures s.save() persists a non-null
+                    # profile field to the continuation session's JSON file,
+                    # covering the case where the session is later evicted from
+                    # SESSIONS and reconstructed from disk via Session.load().
+                    if not s.profile and _resolved_profile_name:
+                        s.profile = _resolved_profile_name
+                        logger.info(
+                            "Stamped profile=%r on continuation session %s after compression",
+                            _resolved_profile_name, new_sid,
+                        )
                     with LOCK:
                         if old_sid in SESSIONS:
                             SESSIONS[new_sid] = SESSIONS.pop(old_sid)


### PR DESCRIPTION
## Problem

In multi-profile deployments, memory writes made after context compression fires silently target the **default profile's** `MEMORY.md`, regardless of which profile is active in the browser. No exception is raised, no warning is logged.

### Confirmed evidence

Session `0dfefb` (continuation after compression from a troubleshooting profile session) read `MEMORY.md` at **16% / 1,184 chars with 4 entries**. The troubleshooting profile's `MEMORY.md` was at **72-77% / 5,000+ chars** at that time. A 16% reading with 4 entries could only come from the default profile's memory bank.

`replace` operations in the same continuation session failed with "No entry matched" because the agent was searching the wrong profile's bank — the target entries existed only in the troubleshooting profile. The contaminating entry was found verbatim in the default profile's `MEMORY.md`.

Timestamps establish causation: original session ended at `07:56:28`, continuation session started at `07:56:28`. The WebUI sidecar for the original session was not yet written at that moment (born `08:10`) — a compounding factor described below.

### Root cause

The compression migration block in `_run_agent_streaming` (~line 2966) correctly migrates the session lock, `SESSION_AGENT_CACHE`, the `SESSIONS` dict, and renames the session file. It does not ensure `s.profile` is set on the continuation session.

There are two failure paths:

**Path 1 — In-memory:** If `s.profile` was `None` from the start (a legacy session or one created before this fix), the continuation session object carries `null` through the current request. On the next request, `get_hermes_home_for_profile(None)` falls back to the default profile's `HERMES_HOME`.

**Path 2 — Persistence:** `s.save()` persists `"profile": null` to the continuation session's JSON file (`profile` is in `METADATA_FIELDS`, `models.py` ~line 408). On the **next request**, `Session.load(new_sid)` reads back `profile: null` and `get_hermes_home_for_profile(None)` falls back to the default profile. This path triggers even if the in-memory object survives with `s.profile` intact — as soon as the session is evicted from the `SESSIONS` LRU and reconstructed from disk, the null persists.

### Fix

**Edit 1:** Capture `_resolved_profile_name` at request entry (~line 2019), immediately after profile home resolution. At this point profile context is reliable: `s.profile` if already set, otherwise `get_active_profile_name()` which reads thread-local storage (`_tls.profile`) correctly set by the HTTP handler thread via `set_request_profile()`.

**Edit 2:** Stamp `s.profile = _resolved_profile_name` in the compression migration block immediately after `s.session_id = new_sid`. Guarded by `if not s.profile` to avoid overwriting sessions that already have a profile set. A `logger.info` line records when the stamp fires. This ensures the field survives both the current request and any future reconstruction from disk.

### Why not call `get_active_profile_name()` at compression time?

`get_active_profile_name()` reads thread-local storage (`_tls.profile`) set by `set_request_profile()` on the HTTP handler thread. The streaming thread is a separate `threading.Thread` — it does not inherit TLS. At compression time, calling `get_active_profile_name()` falls back to the process-global `_active_profile`, which may belong to a different concurrent tab/profile. Capturing the value at request entry, where the handler thread's TLS is still valid, avoids this race entirely.

### Compounding factor: skipped sidecar rename

The compression block attempts to rename the WebUI sidecar file:

```python
old_path = SESSION_DIR / f"{old_sid}.json"
new_path = SESSION_DIR / f"{new_sid}.json"
if old_path.exists():
    old_path.rename(new_path)
```

The sidecar is not always written before compression fires. When it does not exist, `old_path.exists()` is `False`, the rename is skipped, and the continuation session has no sidecar on disk at all. If the session is later evicted from the `SESSIONS` LRU, `get_session(new_sid)` calls `Session.load(new_sid)` which returns `None` — the session becomes unresolvable and the route handler may reconstruct it without a profile stamp via `new_session(profile=body.get("profile"))`. If the browser does not send `profile` in that request body, the reconstructed session has `profile = None`, compounding the routing failure.

This PR fixes the profile stamp. The sidecar rename gap — where the continuation session may have no WebUI disk representation at all if the process restarts between turns — is a separate latent issue and is scoped out of this change.

### Related

- Compression migration block: `streaming.py` ~line 2966
- Profile resolution: `api/profiles.py` — `get_hermes_home_for_profile()`
- `Session.save()` metadata fields: `api/models.py` ~line 408 (`'profile'` is in `METADATA_FIELDS`)
- Similar migration precedent: `SESSION_AGENT_CACHE` migration in the same block (~line 2997)

## Files changed

- `api/streaming.py` — 2 edits, ~15 lines added

## Testing

1. Create a non-default profile in the WebUI (`Settings → Profiles`)
2. Lower the compression threshold to force it quickly:
   ```yaml
   compression:
     threshold: 0.10
   ```
3. Start a session on the non-default profile and send enough messages to trigger compression (watch for the `compressed` SSE event or a session_id change in browser devtools network tab)
4. After compression fires, check `agent.log` for: `Stamped profile=<name> on continuation session <sid> after compression`
5. Instruct the agent to write something distinctive to memory
6. Verify the write lands in the non-default profile's `memories/MEMORY.md`
7. Verify the default profile's `memories/MEMORY.md` is unchanged
8. Restart the WebUI process and repeat step 5 — confirms the persistence path (`Session.load` from disk) also routes correctly
9. Restore `compression.threshold` to its prior value

**To verify the sidecar timing race specifically:** delete the WebUI sidecar for the original session before compression fires (to simulate it not yet being written), then repeat steps 3-7. The profile stamp must still route correctly.

## Model Used

Hermes Agent on Claude Opus 4.6
