### PR TITLE
fix: prefer latest compressed session segment

### DIFF
--- a/static/sessions.js
+++ b/static/sessions.js
@@ -2665,7 +2665,14 @@ function renderSessionListFromCache(){
       const lineageList=document.createElement('div');
       lineageList.className='session-lineage-segments';
       ['pointerdown','pointerup','click'].forEach(ev=>lineageList.addEventListener(ev,e=>e.stopPropagation()));
-      const sortedSegments=[...lineageSegments].sort((a,b)=>_sessionTimestampMs(b)-_sessionTimestampMs(a));
+      const sortedSegments=[...lineageSegments].sort((a,b)=>{
+        const bSeg=Number(b&&b._compression_segment_count||0);
+        const aSeg=Number(a&&a._compression_segment_count||0);
+        if(bSeg||aSeg){
+          if(bSeg!==aSeg) return bSeg-aSeg;
+        }
+        return _sessionTimestampMs(b)-_sessionTimestampMs(a);
+      });
       for(const seg of sortedSegments){
         const row=document.createElement('button');
         row.type='button';

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -2102,7 +2102,14 @@ function _collapseSessionLineageForSidebar(sessions){
   }
   for(const [key,items] of groups.entries()){
     if(items.length<=1){result.push(items[0]);continue;}
-    const sorted=[...items].sort((a,b)=>_sessionTimestampMs(b)-_sessionTimestampMs(a));
+    const sorted=[...items].sort((a,b)=>{
+      const bSeg=Number(b&&b._compression_segment_count||0);
+      const aSeg=Number(a&&a._compression_segment_count||0);
+      if(bSeg||aSeg){
+        if(bSeg!==aSeg) return bSeg-aSeg;
+      }
+      return _sessionTimestampMs(b)-_sessionTimestampMs(a);
+    });
     const chosen=sorted[0];
     result.push({...chosen,_lineage_key:key,_lineage_collapsed_count:items.length,_lineage_segments:sorted});
   }

--- a/tests/test_session_lineage_collapse.py
+++ b/tests/test_session_lineage_collapse.py
@@ -345,6 +345,8 @@ def test_lineage_segment_expansion_static_contract():
     assert "_expandedLineageKeys.delete(lineageKey)" in js
     assert "className='session-lineage-segments'" in js
     assert "className='session-lineage-segment'" in js
+    assert "const bSeg=Number(b&&b._compression_segment_count||0);" in js
+    assert "if(bSeg!==aSeg) return bSeg-aSeg;" in js
     assert "const segTitle=seg.title||t('session_lineage_segment_untitled');" in js
     assert "row.title=t('session_lineage_segment_open');" in js
     assert "await loadSession(seg.session_id);" in js

--- a/tests/test_session_lineage_collapse.py
+++ b/tests/test_session_lineage_collapse.py
@@ -170,6 +170,47 @@ console.log(JSON.stringify(collapsed));
     assert [seg["session_id"] for seg in collapsed[0]["_lineage_segments"]] == ["seg10", "seg9", "seg8", "seg7"]
 
 
+def test_sidebar_lineage_collapse_prefers_highest_compression_segment_over_touched_parent():
+    """A touched parent segment must not hide the newer compressed tip.
+
+    Opening or polling an older segment can refresh its updated_at without adding
+    messages. The collapsed sidebar row must still pick the highest compression
+    segment, otherwise the visible chat jumps back to a parent that lacks the
+    completed assistant answer.
+    """
+    js = SESSIONS_JS_PATH.read_text(encoding="utf-8")
+    source = f"""
+const src = {js!r};
+function extractFunc(name) {{
+  const re = new RegExp('function\\\\s+' + name + '\\\\s*\\\\(');
+  const start = src.search(re);
+  if (start < 0) throw new Error(name + ' not found');
+  let i = src.indexOf('{{', start);
+  let depth = 1; i++;
+  while (depth > 0 && i < src.length) {{
+    if (src[i] === '{{') depth++;
+    else if (src[i] === '}}') depth--;
+    i++;
+  }}
+  return src.slice(start, i);
+}}
+eval(extractFunc('_sessionTimestampMs'));
+eval(extractFunc('_isChildSession'));
+eval(extractFunc('_sessionLineageKey'));
+eval(extractFunc('_collapseSessionLineageForSidebar'));
+const sessions = [
+  {{session_id:'seg13', title:'Schaue dir die Release (fork)', message_count:2490, updated_at:200, last_message_at:200, _lineage_root_id:'root', _compression_segment_count:13}},
+  {{session_id:'seg14', title:'Schaue dir die Release (fork)', message_count:2532, updated_at:150, last_message_at:150, _lineage_root_id:'root', _compression_segment_count:14}},
+];
+const collapsed = _collapseSessionLineageForSidebar(sessions);
+console.log(JSON.stringify(collapsed));
+"""
+    collapsed = json.loads(_run_node(source))
+    assert [row["session_id"] for row in collapsed] == ["seg14"]
+    assert collapsed[0]["_lineage_collapsed_count"] == 2
+    assert [seg["session_id"] for seg in collapsed[0]["_lineage_segments"]] == ["seg14", "seg13"]
+
+
 
 def test_sidebar_attaches_child_sessions_to_collapsed_hidden_parent_lineage():
     js = SESSIONS_JS_PATH.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Prefer the highest `_compression_segment_count` when collapsing compressed session lineage rows in the sidebar.
- Add a regression test for a touched parent segment hiding the newer compressed tip.

## Root cause
The sidebar collapse helper picked the representative row by timestamp only. If an older compressed parent segment was opened or polled after a newer tip was created, that parent could get a fresher timestamp and become the visible collapsed row. The real latest answer stayed persisted in the newer child segment, but the sidebar navigated back to the older parent.

## Related reconnaissance
- Checked current `origin/master`: `_collapseSessionLineageForSidebar()` still sorts lineage rows only by `_sessionTimestampMs()`.
- Searched open PRs/issues for similar sidebar/compression lineage fixes; no duplicates found.

## Test plan
- `node --check static/sessions.js`
- `python3 -m pytest tests/test_session_lineage_collapse.py -q`
- `python3 -m pytest tests/test_session_lineage_collapse.py tests/test_session_lineage_metadata_api.py tests/test_gateway_sync.py::test_compression_chain_collapses_to_latest_tip_in_sidebar tests/test_gateway_sync.py::test_compression_chain_bubbles_to_top_by_tip_activity -q`
- `git diff --check`
- Added-line static scan: 4 findings, all expected `eval(extractFunc(...))` calls in the existing JS helper extraction test harness; no secrets/shell findings.
