### PR TITLE
feat: add read-only session lineage report endpoint

### DIFF
--- a/api/agent_sessions.py
+++ b/api/agent_sessions.py
@@ -439,6 +439,163 @@ def read_importable_agent_session_rows(
 
 
 
+def _lineage_report_row(row: dict, role: str) -> dict:
+    updated_at = row.get('ended_at') if row.get('ended_at') is not None else row.get('started_at')
+    return {
+        'session_id': row.get('id'),
+        'role': role,
+        'title': row.get('title'),
+        'source': row.get('source'),
+        'started_at': row.get('started_at'),
+        'updated_at': updated_at,
+        'end_reason': row.get('end_reason'),
+        'active': row.get('ended_at') is None,
+        'archived': False,
+    }
+
+
+def _empty_lineage_report(session_id: str, *, found: bool = False) -> dict:
+    return {
+        'mutation': False,
+        'found': found,
+        'session_id': session_id,
+        'lineage_key': session_id,
+        'tip_session_id': session_id,
+        'total_segments': 0,
+        'materialized_segments': 0,
+        'segments': [],
+        'children': [],
+        'manual_review': False,
+    }
+
+
+def read_session_lineage_report(db_path: Path, session_id: str | None, max_hops: int = 20) -> dict:
+    """Return a bounded, read-only lifecycle report for a session lineage.
+
+    This helper intentionally reports only facts that can be derived from
+    ``state.db.sessions`` without mutating WebUI JSON, archiving rows, or
+    deleting historical segments. It mirrors the sidebar continuation rules so
+    a future UI/PR can explain which rows are hidden compression/cli-close
+    segments and which child-session branches remain distinct.
+    """
+    sid = str(session_id or '').strip()
+    if not sid:
+        return _empty_lineage_report('')
+    db_path = Path(db_path)
+    if not db_path.exists():
+        return _empty_lineage_report(sid)
+
+    try:
+        with closing(sqlite3.connect(str(db_path))) as conn:
+            conn.row_factory = sqlite3.Row
+            cur = conn.cursor()
+            cur.execute("PRAGMA table_info(sessions)")
+            session_cols = {row[1] for row in cur.fetchall()}
+            required = {'id', 'parent_session_id', 'end_reason'}
+            if not required.issubset(session_cols):
+                return _empty_lineage_report(sid)
+
+            source_expr = _optional_col('source', session_cols)
+            title_expr = _optional_col('title', session_cols)
+            started_expr = _optional_col('started_at', session_cols, '0')
+            ended_expr = _optional_col('ended_at', session_cols)
+            end_reason_expr = _optional_col('end_reason', session_cols)
+            parent_expr = _optional_col('parent_session_id', session_cols)
+
+            def fetch_one(row_id: str | None) -> dict | None:
+                if not row_id:
+                    return None
+                cur.execute(
+                    f"""
+                    SELECT s.id,
+                           {source_expr},
+                           {title_expr},
+                           {started_expr},
+                           {parent_expr},
+                           {ended_expr},
+                           {end_reason_expr}
+                    FROM sessions s
+                    WHERE s.id = ?
+                    """,
+                    (row_id,),
+                )
+                row = cur.fetchone()
+                return dict(row) if row else None
+
+            target = fetch_one(sid)
+            if not target:
+                return _empty_lineage_report(sid)
+
+            segments = [target]
+            current = target
+            seen = {sid}
+            manual_review = False
+            for _hop in range(max(0, int(max_hops))):
+                parent_id = current.get('parent_session_id')
+                parent = fetch_one(parent_id)
+                if not parent or parent_id in seen:
+                    manual_review = bool(parent_id and parent_id in seen)
+                    break
+                if not _is_continuation_session(parent, current):
+                    break
+                segments.append(parent)
+                seen.add(parent_id)
+                current = parent
+            else:
+                manual_review = True
+
+            segment_ids = {row['id'] for row in segments}
+            child_rows: list[dict] = []
+            for parent in segments:
+                cur.execute(
+                    f"""
+                    SELECT s.id,
+                           {source_expr},
+                           {title_expr},
+                           {started_expr},
+                           {parent_expr},
+                           {ended_expr},
+                           {end_reason_expr}
+                    FROM sessions s
+                    WHERE s.parent_session_id = ?
+                    ORDER BY s.started_at DESC
+                    """,
+                    (parent['id'],),
+                )
+                for child_row in cur.fetchall():
+                    child = dict(child_row)
+                    if child['id'] in segment_ids:
+                        continue
+                    if _is_continuation_session(parent, child):
+                        # A continuation outside the selected path means the
+                        # lineage is branched or the caller selected an older
+                        # segment. Report manual review rather than proposing
+                        # destructive cleanup candidates.
+                        manual_review = True
+                        continue
+                    child_rows.append(child)
+    except Exception:
+        return _empty_lineage_report(sid)
+
+    root_id = segments[-1]['id'] if segments else sid
+    tip_id = segments[0]['id'] if segments else sid
+    return {
+        'mutation': False,
+        'found': True,
+        'session_id': sid,
+        'lineage_key': root_id,
+        'tip_session_id': tip_id,
+        'total_segments': len(segments),
+        'materialized_segments': len(segments),
+        'segments': [
+            _lineage_report_row(row, 'tip' if idx == 0 else 'hidden_segment')
+            for idx, row in enumerate(segments)
+        ],
+        'children': [_lineage_report_row(row, 'child_session') for row in child_rows],
+        'manual_review': manual_review,
+    }
+
+
 def read_session_lineage_metadata(db_path: Path, session_ids: list[str] | set[str]) -> dict[str, dict]:
     """Return compression-lineage metadata for known WebUI sidebar sessions.
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -26,6 +26,7 @@ from api.agent_sessions import (
     MESSAGING_SOURCES,
     is_cli_session_row,
     is_cli_session_row_visible,
+    read_session_lineage_report,
 )
 
 logger = logging.getLogger(__name__)
@@ -3183,6 +3184,15 @@ def handle_get(handler, parsed) -> bool:
                 sess = _merge_cli_sidebar_metadata(sess, cli_meta)
                 return j(handler, {"session": redact_session_data(sess)})
             return bad(handler, "Session not found", 404)
+
+    if parsed.path == "/api/session/lineage/report":
+        sid = parse_qs(parsed.query).get("session_id", [""])[0]
+        if not sid:
+            return bad(handler, "session_id required", 400)
+        report = read_session_lineage_report(_active_state_db_path(), sid)
+        if not report.get("found"):
+            return bad(handler, "Session not found", 404)
+        return j(handler, report)
 
     if parsed.path == "/api/session/status":
         sid = parse_qs(parsed.query).get("session_id", [""])[0]

--- a/tests/test_session_lineage_report.py
+++ b/tests/test_session_lineage_report.py
@@ -1,0 +1,196 @@
+"""Read-only session lineage report endpoint tests."""
+
+import json
+import sqlite3
+import time
+from types import SimpleNamespace
+from urllib.parse import urlparse
+from unittest.mock import patch
+
+import api.agent_sessions as agent_sessions
+import api.routes as routes
+
+
+def _ensure_state_db(path):
+    conn = sqlite3.connect(str(path))
+    conn.executescript(
+        """
+        CREATE TABLE sessions (
+            id TEXT PRIMARY KEY,
+            source TEXT,
+            title TEXT,
+            model TEXT,
+            started_at REAL NOT NULL,
+            message_count INTEGER DEFAULT 0,
+            parent_session_id TEXT,
+            ended_at REAL,
+            end_reason TEXT
+        );
+        """
+    )
+    return conn
+
+
+def _insert_state_row(conn, sid, *, parent=None, ended_at=None, end_reason=None, started_at=None, source="webui"):
+    conn.execute(
+        """
+        INSERT INTO sessions
+        (id, source, title, model, started_at, message_count, parent_session_id, ended_at, end_reason)
+        VALUES (?, ?, ?, 'openai/gpt-5', ?, 2, ?, ?, ?)
+        """,
+        (sid, source, sid.replace("_", " "), started_at or time.time(), parent, ended_at, end_reason),
+    )
+    conn.commit()
+
+
+def test_lineage_report_returns_bounded_read_only_tip_and_hidden_segments(tmp_path):
+    conn = _ensure_state_db(tmp_path / "state.db")
+    t0 = time.time() - 100
+    try:
+        _insert_state_row(conn, "lineage_report_root", started_at=t0, ended_at=t0 + 5, end_reason="compression")
+        _insert_state_row(conn, "lineage_report_mid", parent="lineage_report_root", started_at=t0 + 6, ended_at=t0 + 12, end_reason="cli_close")
+        _insert_state_row(conn, "lineage_report_tip", parent="lineage_report_mid", started_at=t0 + 13)
+
+        report = agent_sessions.read_session_lineage_report(tmp_path / "state.db", "lineage_report_tip")
+
+        assert report["mutation"] is False
+        assert report["session_id"] == "lineage_report_tip"
+        assert report["lineage_key"] == "lineage_report_root"
+        assert report["tip_session_id"] == "lineage_report_tip"
+        assert report["total_segments"] == 3
+        assert report["materialized_segments"] == 3
+        assert [s["session_id"] for s in report["segments"]] == [
+            "lineage_report_tip",
+            "lineage_report_mid",
+            "lineage_report_root",
+        ]
+        assert [s["role"] for s in report["segments"]] == ["tip", "hidden_segment", "hidden_segment"]
+        assert report["children"] == []
+        assert report["manual_review"] is False
+        assert "archive_candidates" not in report
+        assert "delete_candidates" not in report
+    finally:
+        conn.close()
+
+
+def test_lineage_report_keeps_cross_surface_parent_out_of_hidden_segments(tmp_path):
+    conn = _ensure_state_db(tmp_path / "state.db")
+    t0 = time.time() - 100
+    try:
+        _insert_state_row(
+            conn,
+            "lineage_report_telegram_parent",
+            source="telegram",
+            started_at=t0,
+            ended_at=t0 + 5,
+            end_reason="compression",
+        )
+        _insert_state_row(
+            conn,
+            "lineage_report_webui_tip",
+            source="webui",
+            parent="lineage_report_telegram_parent",
+            started_at=t0 + 6,
+        )
+
+        report = agent_sessions.read_session_lineage_report(tmp_path / "state.db", "lineage_report_webui_tip")
+
+        assert report["lineage_key"] == "lineage_report_webui_tip"
+        assert report["total_segments"] == 1
+        assert [s["session_id"] for s in report["segments"]] == ["lineage_report_webui_tip"]
+        assert report["segments"][0]["role"] == "tip"
+        assert report["children"] == []
+    finally:
+        conn.close()
+
+
+def test_lineage_report_surfaces_non_continuation_children_without_mutation(tmp_path):
+    conn = _ensure_state_db(tmp_path / "state.db")
+    t0 = time.time() - 100
+    try:
+        _insert_state_row(conn, "lineage_report_root", started_at=t0, ended_at=t0 + 5, end_reason="compression")
+        _insert_state_row(conn, "lineage_report_tip", parent="lineage_report_root", started_at=t0 + 6, ended_at=t0 + 15, end_reason="user_stop")
+        _insert_state_row(conn, "lineage_report_child", parent="lineage_report_tip", started_at=t0 + 8)
+
+        report = agent_sessions.read_session_lineage_report(tmp_path / "state.db", "lineage_report_tip")
+
+        assert report["lineage_key"] == "lineage_report_root"
+        assert [s["session_id"] for s in report["segments"]] == ["lineage_report_tip", "lineage_report_root"]
+        assert report["children"] == [
+            {
+                "session_id": "lineage_report_child",
+                "role": "child_session",
+                "title": "lineage report child",
+                "source": "webui",
+                "started_at": t0 + 8,
+                "updated_at": t0 + 8,
+                "end_reason": None,
+                "active": True,
+                "archived": False,
+            }
+        ]
+        assert report["mutation"] is False
+    finally:
+        conn.close()
+
+
+def test_lineage_report_marks_bounded_parent_walk_for_manual_review(tmp_path):
+    conn = _ensure_state_db(tmp_path / "state.db")
+    t0 = time.time() - 100
+    try:
+        _insert_state_row(conn, "lineage_report_root", started_at=t0, ended_at=t0 + 5, end_reason="compression")
+        _insert_state_row(conn, "lineage_report_mid", parent="lineage_report_root", started_at=t0 + 6, ended_at=t0 + 12, end_reason="compression")
+        _insert_state_row(conn, "lineage_report_tip", parent="lineage_report_mid", started_at=t0 + 13)
+
+        report = agent_sessions.read_session_lineage_report(tmp_path / "state.db", "lineage_report_tip", max_hops=1)
+
+        assert report["mutation"] is False
+        assert report["manual_review"] is True
+        assert [s["session_id"] for s in report["segments"]] == ["lineage_report_tip", "lineage_report_mid"]
+        assert report["total_segments"] == 2
+    finally:
+        conn.close()
+
+
+def test_lineage_report_endpoint_is_read_only_and_uses_active_state_db(tmp_path):
+    conn = _ensure_state_db(tmp_path / "state.db")
+    t0 = time.time() - 100
+    try:
+        _insert_state_row(conn, "lineage_report_root", started_at=t0, ended_at=t0 + 5, end_reason="compression")
+        _insert_state_row(conn, "lineage_report_tip", parent="lineage_report_root", started_at=t0 + 6)
+        captured = {}
+
+        def fake_j(handler, data, status=200, **_kwargs):
+            captured["status"] = status
+            captured["data"] = data
+            return data
+
+        handler = SimpleNamespace()
+        parsed = urlparse("/api/session/lineage/report?session_id=lineage_report_tip")
+        with patch.object(routes, "_active_state_db_path", return_value=tmp_path / "state.db"), patch.object(routes, "j", side_effect=fake_j):
+            routes.handle_get(handler, parsed)
+
+        assert captured["status"] == 200
+        assert captured["data"]["mutation"] is False
+        assert captured["data"]["lineage_key"] == "lineage_report_root"
+        assert captured["data"]["total_segments"] == 2
+    finally:
+        conn.close()
+
+
+def test_lineage_report_endpoint_returns_404_for_unknown_session(tmp_path):
+    conn = _ensure_state_db(tmp_path / "state.db")
+    conn.close()
+    captured = {}
+
+    def fake_bad(handler, message, status=400):
+        captured["status"] = status
+        captured["message"] = message
+        return {"error": message}
+
+    handler = SimpleNamespace()
+    parsed = urlparse("/api/session/lineage/report?session_id=missing_lineage_report_session")
+    with patch.object(routes, "_active_state_db_path", return_value=tmp_path / "state.db"), patch.object(routes, "bad", side_effect=fake_bad):
+        routes.handle_get(handler, parsed)
+
+    assert captured == {"status": 404, "message": "Session not found"}


### PR DESCRIPTION
## Thinking Path
- The sidebar lineage badge and expandable materialized segment rows have now shipped upstream via #1906 and #1943.
- Those UI affordances intentionally stay client-side and only use the segments already present in `/api/sessions`.
- The remaining gap is a bounded backend diagnostic/report contract for a specific session lineage, so future UI/debugging work can ask the server for the authoritative continuation chain without scanning or mutating stores in the browser.
- A current open PR (#2011) improves frontend representative-row selection for compressed segments; this PR avoids that lane and stays backend-only.

## What Changed
- Add `read_session_lineage_report(db_path, session_id, max_hops=20)` in `api.agent_sessions`.
- Add `GET /api/session/lineage/report?session_id=<sid>`.
- Return a read-only report with:
  - `mutation: false`
  - `found`, `lineage_key`, `tip_session_id`
  - bounded `segments` with `tip` / `hidden_segment` roles
  - non-continuation `children` with `child_session` roles
  - `manual_review: true` for bounded/pathological continuation cases
- Add focused tests for linear compression/cli-close chains, cross-source guard behavior, child-session branches, bounded/manual-review output, endpoint success, and endpoint 404.

## Why It Matters
This gives WebUI a small backend counterpart to the already-shipped lineage sidebar projection without adding archive/delete actions, background workers, storage migrations, or UI changes. Future UI work can lazily fetch this report only when needed.

## Verification
- `/home/dso2ng/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_session_lineage_report.py tests/test_session_lineage_metadata_api.py tests/test_session_lineage_collapse.py -q` -> `22 passed`
- `/home/dso2ng/.hermes/hermes-agent/venv/bin/python -m py_compile api/agent_sessions.py api/routes.py api/models.py`
- `git diff --check`
- Added-line non-ASCII guard -> `non_ascii_added_lines=0`

## Risks / Follow-ups
- This endpoint is intentionally read-only; it does not return `archive_candidates` or `delete_candidates` and does not mutate WebUI JSON or `state.db`.
- It only reports rows derivable from `state.db.sessions`; missing/old schemas degrade to a safe not-found/empty report.
- Frontend full-segment lazy expansion should remain a separate follow-up after this contract is reviewed.
- #2011 is a separate frontend/sidebar tip-selection fix and should be allowed to land independently.

## Model Used
- Provider: OpenAI Codex via Hermes Agent
- Model: gpt-5.5
