### PR TITLE
fix: avoid sidebar jumps when active session is visible

### DIFF
--- a/static/sessions.js
+++ b/static/sessions.js
@@ -2910,6 +2910,7 @@ function renderSessionListFromCache(){
         _tapTimer=null;
         _lastTapTime=0;
         if(_renamingSid) return;
+        if(s.session_id===_activeSessionIdForSidebar()) return;
         // For CLI sessions, import into WebUI store first (idempotent)
         if(s.is_cli_session){
           try{

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -2420,6 +2420,17 @@ function renderSessionListFromCache(){
     list.dataset.sessionVirtualActiveAnchor!==activeSidForSidebar||
     list.dataset.sessionVirtualFilter!==q
   );
+  const virtualWindowBeforeActiveAnchor=_sessionVirtualWindow({
+    total:flatSessionRows.length,
+    scrollTop:listScrollTopBeforeRender,
+    viewportHeight:list.clientHeight||520,
+    itemHeight:SESSION_VIRTUAL_ROW_HEIGHT,
+    buffer:SESSION_VIRTUAL_BUFFER_ROWS,
+    threshold:SESSION_VIRTUAL_THRESHOLD_ROWS,
+    activeIndex:-1,
+  });
+  const activeWasAlreadyVisible=activeIndex>=virtualWindowBeforeActiveAnchor.start&&activeIndex<virtualWindowBeforeActiveAnchor.end;
+  const shouldMoveSidebarToActive=shouldAnchorActive&&!activeWasAlreadyVisible;
   let virtualWindow=_sessionVirtualWindow({
     total:flatSessionRows.length,
     scrollTop:listScrollTopBeforeRender,
@@ -2427,10 +2438,10 @@ function renderSessionListFromCache(){
     itemHeight:SESSION_VIRTUAL_ROW_HEIGHT,
     buffer:SESSION_VIRTUAL_BUFFER_ROWS,
     threshold:SESSION_VIRTUAL_THRESHOLD_ROWS,
-    activeIndex:shouldAnchorActive?activeIndex:-1,
+    activeIndex:shouldMoveSidebarToActive?activeIndex:-1,
   });
   let virtualAnchorScrollTop=null;
-  if(shouldAnchorActive&&virtualWindow.virtualized){
+  if(shouldMoveSidebarToActive&&virtualWindow.virtualized){
     list.dataset.sessionVirtualActiveAnchor=activeSidForSidebar;
     virtualAnchorScrollTop=virtualWindow.topPad;
   }else if(activeSidForSidebar){

--- a/tests/test_issue500_session_list_virtualization.py
+++ b/tests/test_issue500_session_list_virtualization.py
@@ -136,3 +136,15 @@ def test_session_list_only_moves_to_active_when_active_row_is_not_visible():
     assert before_idx < visible_idx < move_idx < final_idx < anchor_idx
     assert "activeIndex:-1" in render_body[before_idx:visible_idx]
     assert "activeIndex:shouldAnchorActive?activeIndex:-1" not in render_body
+
+
+def test_clicking_already_active_session_is_noop_before_reload():
+    """Clicking the selected row again should not rebuild the list and jump it."""
+    js = SESSIONS_JS_PATH.read_text(encoding="utf-8")
+    render_start = js.index("function renderSessionListFromCache()")
+    render_end = js.index("async function _handleActiveSessionStorageEvent", render_start)
+    render_body = js[render_start:render_end]
+
+    noop_idx = render_body.index("if(s.session_id===_activeSessionIdForSidebar()) return;")
+    load_idx = render_body.index("await loadSession(s.session_id);renderSessionListFromCache();")
+    assert noop_idx < load_idx

--- a/tests/test_issue500_session_list_virtualization.py
+++ b/tests/test_issue500_session_list_virtualization.py
@@ -119,3 +119,20 @@ def test_session_list_render_path_uses_virtual_spacers_and_scroll_rerender():
     assert "list.dataset.sessionVirtualFilter=q" in render_body
     assert "const flatSessionRows=[]" in render_body
     assert "flatSessionRows.push({group:g,session:s})" in render_body
+
+def test_session_list_only_moves_to_active_when_active_row_is_not_visible():
+    """Changing filters should not jump the sidebar when active row is already visible."""
+    js = SESSIONS_JS_PATH.read_text(encoding="utf-8")
+    render_start = js.index("function renderSessionListFromCache()")
+    render_end = js.index("async function _handleActiveSessionStorageEvent", render_start)
+    render_body = js[render_start:render_end]
+
+    before_idx = render_body.index("const virtualWindowBeforeActiveAnchor=_sessionVirtualWindow({")
+    visible_idx = render_body.index("const activeWasAlreadyVisible=activeIndex>=virtualWindowBeforeActiveAnchor.start&&activeIndex<virtualWindowBeforeActiveAnchor.end")
+    move_idx = render_body.index("const shouldMoveSidebarToActive=shouldAnchorActive&&!activeWasAlreadyVisible")
+    final_idx = render_body.index("activeIndex:shouldMoveSidebarToActive?activeIndex:-1")
+    anchor_idx = render_body.index("if(shouldMoveSidebarToActive&&virtualWindow.virtualized){")
+
+    assert before_idx < visible_idx < move_idx < final_idx < anchor_idx
+    assert "activeIndex:-1" in render_body[before_idx:visible_idx]
+    assert "activeIndex:shouldAnchorActive?activeIndex:-1" not in render_body


### PR DESCRIPTION
## Summary
- Avoid forcing the virtualized session sidebar to jump to the active row when that row is already visible in the current window.
- Keep the existing active-row anchoring behavior for cases where the active row is outside the rendered window.
- Add regression coverage for the visible-active-row path.

## Root cause
`renderSessionListFromCache()` treated any active-session/filter mismatch as a reason to pass `activeIndex` into `_sessionVirtualWindow()`. When the active row was already visible, this could still recenter the virtual window and reset `scrollTop`, producing an unnecessary sidebar jump while filtering or re-rendering.

## Related reconnaissance
- Searched existing PRs/issues for `active sidebar scroll`, `sessionVirtualActiveAnchor`, `virtual sidebar active`, `sidebar active session jump`, and `session sidebar active anchor`.
- Only related result was the merged/closed virtualization PR #1669; no open duplicate for this narrower follow-up.

## Test plan
- `node --check static/sessions.js`
- `uv run --with pytest --with pyyaml python -m pytest tests/test_issue500_session_list_virtualization.py tests/test_issue1669_sidebar_scroll_jump_fix.py -q -o addopts=`
- `git diff --check`
- Added-line static scan: 0 findings

## Review note
An independent delegate review was attempted, but the reviewer timed out. I performed a manual blocker review of the scoped diff and kept this PR to two files.
