### PR TITLE
fix: keep explicit fork sessions out of compression lineage

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -4232,6 +4232,7 @@ def handle_post(handler, parsed) -> bool:
             title=branch_title,
             messages=forked_messages,
             parent_session_id=source.session_id,
+            session_source="fork",
         )
         with LOCK:
             SESSIONS[branch.session_id] = branch

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1978,6 +1978,7 @@ function _isChildSession(s){
 function _sessionLineageKey(s, sessionIdsInList){
   if(!s||!s.session_id) return null;
   if(_isChildSession(s)) return null;
+  if(s.session_source==='fork') return null;
   const lineageKey=s._lineage_root_id||s.lineage_root_id||null;
   if(lineageKey) return lineageKey;
   // If parent_session_id points to another session in the current list,

--- a/tests/test_465_session_branching.py
+++ b/tests/test_465_session_branching.py
@@ -68,6 +68,32 @@ def test_branch_creates_session_with_parent():
         "Branch handler should set parent_session_id to source session"
 
 
+def test_branch_marks_explicit_forks_as_fork_sessions():
+    """Explicit branches must not be mistaken for compression lineage rows."""
+    with open('api/routes.py') as f:
+        src = f.read()
+    branch_match = re.search(
+        r'parsed\.path == "/api/session/branch"(.*?)(?=\n    if parsed\.path|$)',
+        src, re.DOTALL
+    )
+    assert branch_match
+    block = branch_match.group(1)
+    assert 'session_source="fork"' in block, \
+        "Branch handler should mark explicit forks with session_source='fork'"
+
+
+def test_branch_fork_sessions_do_not_collapse_into_parent_lineage():
+    """Forks remain selectable rows even if their parent is not in the current list."""
+    with open('static/sessions.js') as f:
+        src = f.read()
+    fn = re.search(r'function _sessionLineageKey\(.*?\n\}', src, re.DOTALL)
+    assert fn, "Could not find _sessionLineageKey"
+    block = fn.group(0)
+    assert "if(s.session_source==='fork') return null;" in block, \
+        "Explicit fork sessions should not collapse via parent_session_id"
+    assert block.index("if(s.session_source==='fork') return null;") < block.index('return s.parent_session_id || null')
+
+
 def test_branch_keep_count_support():
     """Verify the branch endpoint supports keep_count parameter."""
     with open('api/routes.py') as f:


### PR DESCRIPTION
## Summary
- Mark `/api/session/branch` sessions with `session_source="fork"`.
- Keep explicit WebUI forks out of compression-lineage collapse even when their parent row is not currently present in the sidebar list.
- Add regression coverage for both the backend marker and the sidebar lineage guard.

## Root cause
The sidebar lineage collapse uses `parent_session_id` as a fallback lineage key when no explicit compression lineage metadata is present. That is useful for compression continuations, but explicit WebUI forks also have `parent_session_id`. When forking from an already forked/filtered session and the immediate parent is not in the current list, the new fork can be treated like a lineage continuation of its parent/root instead of remaining an independently selectable fork row.

## Related reconnaissance
- Searched existing PRs/issues for `fork from here fork`, `fork session fork parent`, `fork from fork session`, and `session fork parent`.
- No open duplicate found.

## Test plan
- `node --check static/sessions.js`
- `python3 -m py_compile api/routes.py`
- `uv run --with pytest --with pyyaml python -m pytest tests/test_465_session_branching.py tests/test_v050253_opus_followups.py tests/test_session_lineage_collapse.py -q -o addopts=`
- `git diff --check`
- Added-line static scan: 0 findings

## Review note
Independent delegate review was unavailable earlier due timeout, so this PR is intentionally narrow and manually reviewed against the scoped diff.
