### PR TITLE
fix(docker_init): fall back when /tmp not root-writable (Railway)

### DIFF
--- a/docker_init.bash
+++ b/docker_init.bash
@@ -227,9 +227,22 @@ if [ "A${whoami}" == "Aroot" ]; then
   chown hermeswebui:hermeswebui "${UV_CACHE_DIR}" || error_exit "Failed to set owner of ${UV_CACHE_DIR} to hermeswebui user"
 
   chown -R "${WANTED_UID}:${WANTED_GID}" "$itdir" || error_exit "Failed to set owner of $itdir"
-  save_env /tmp/hermeswebui_root_env.txt
-  chown "${WANTED_UID}:${WANTED_GID}" /tmp/hermeswebui_root_env.txt || error_exit "Failed to set owner of /tmp/hermeswebui_root_env.txt"
-  chmod 600 /tmp/hermeswebui_root_env.txt || error_exit "Failed to secure /tmp/hermeswebui_root_env.txt"
+  # Issue #2010 — Railway / user-namespaced runtimes: in-container UID 0 may map
+  # to a host UID outside the writable subuid range, so /tmp writes fail despite
+  # id -u == 0. Probe writability and fall back through $itdir → /app.
+  ENV_FILE="/tmp/hermeswebui_root_env.txt"
+  if ! ( : > "$ENV_FILE" ) 2>/dev/null; then
+    ENV_FILE="${itdir:-/tmp/hermeswebui_init}/hermeswebui_root_env.txt"
+    mkdir -p "$(dirname "$ENV_FILE")" 2>/dev/null
+    if ! ( : > "$ENV_FILE" ) 2>/dev/null; then
+      ENV_FILE="/app/.hermeswebui_root_env"
+    fi
+    echo "  !! /tmp not writable by root — falling back to $ENV_FILE (user-namespaced runtime?)"
+  fi
+  save_env "$ENV_FILE"
+  chown "${WANTED_UID}:${WANTED_GID}" "$ENV_FILE" || error_exit "Failed to set owner of $ENV_FILE"
+  chmod 600 "$ENV_FILE" || error_exit "Failed to secure $ENV_FILE"
+  export _HW_ROOT_ENV_PATH="$ENV_FILE"
 
   # restart the script as hermeswebui set with the correct UID/GID this time
   echo "-- Restarting as hermeswebui user with UID ${WANTED_UID} GID ${WANTED_GID}"
@@ -248,7 +261,7 @@ if [ "$WANTED_UID" != "$new_uid" ]; then error_exit "hermeswebui MUST be running
 echo ""; echo "== Running as hermeswebui"
 
 # Load environment variables one by one if they do not exist from the root init phase
-tmp_root_env=/tmp/hermeswebui_root_env.txt
+tmp_root_env="${_HW_ROOT_ENV_PATH:-/tmp/hermeswebui_root_env.txt}"
 if [ -f $tmp_root_env ]; then
   echo "-- Loading not already set environment variables from $tmp_root_env"
   load_env $tmp_root_env true


### PR DESCRIPTION
## Summary

Closes #2010.

On user-namespaced rootless container runtimes (Railway), in-container UID 0 maps to a host UID outside the writable subuid range, so `save_env /tmp/hermeswebui_root_env.txt` at `docker_init.bash:230` fails with `Permission denied` even though `id -u` returns 0. The existing read-only-rootfs guard at `:192-197` only covers `/etc/group`/`/etc/passwd` writability and doesn't catch this signature.

Implements the maintainer-suggested ~15 LOC patch:

- `docker_init.bash:229-244` — probe `/tmp` writability before `save_env`; fall back through `${itdir}/hermeswebui_root_env.txt` → `/app/.hermeswebui_root_env`. Export `_HW_ROOT_ENV_PATH` so the post-su phase finds the same file. Comment cites the issue so the rationale isn't lost.
- `docker_init.bash:264` — read `tmp_root_env` from `${_HW_ROOT_ENV_PATH:-/tmp/hermeswebui_root_env.txt}` (default preserves prior behavior on every non-Railway runtime).

State-dir verifier at the original `:272` is intentionally left alone, per the maintainer's guidance — silent degradation there would mask real volume-permission misconfig.

## Test plan

- [ ] **Negative case (Railway-like):** run the image with `--user 0:0 --tmpfs /tmp:exec,mode=0555,size=1m` (or otherwise make `/tmp` un-writable to UID 0); confirm `docker_init.bash` proceeds past the env-file write using the `$itdir` fallback, and that the post-su phase loads the env from the same fallback path.
- [ ] **Positive case (default):** run the image normally and confirm `/tmp/hermeswebui_root_env.txt` is still used (no fallback log line, no behavior change).
- [ ] **Real Railway deploy:** verify the container starts past the `:230` failure point that originally motivated the issue.