### PR TITLE
Release O — v0.51.39 — 4-PR contributor batch (Railway docker + Stop-button race + model resolver + live context)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Hermes Web UI -- Changelog
 
+## [v0.51.39] — 2026-05-10 — Release O (4-PR contributor batch — Railway docker fix + Stop-button race + provider resolver + live context tracking)
+
+### Fixed
+
+- **PR #2017** by @michael-dg — `docker_init.bash` failed on user-namespaced rootless container runtimes (Railway). In-container UID 0 maps to a host UID outside the writable subuid range, so `save_env /tmp/hermeswebui_root_env.txt` failed with `Permission denied` even though `id -u` returns 0. The existing read-only-rootfs guard at `:192-197` only covered `/etc/group` / `/etc/passwd` writability and didn't catch this signature. Adds a writability probe before `save_env` and a fallback chain (`${itdir}/hermeswebui_root_env.txt` → `/app/.hermeswebui_root_env`); exports `_HW_ROOT_ENV_PATH` so the post-su phase finds the same file. State-dir verifier left intact (silent degradation there would mask real volume-permission misconfig). Closes #2010.
+
+- **PR #2018** by @rhelmer — Stop button didn't refresh after `/api/chat/start` returned a `stream_id`. The client became busy before it had a new stream id, updated the send button at that moment, but never updated again once the id arrived — so the Stop button only fixed itself when something else triggered a refresh (e.g. the user typing). Now refreshes when the new stream id is received and again when an old `activeStreamId` is cleared, so the button doesn't lie about whether stop/cancel is valid. Includes regression coverage in `tests/test_1062_busy_input_modes.py`.
+
+- **PR #2022** by @Michaelyklam — `resolve_model_provider()` in `api/config.py` checked `custom_providers[]` first, so when the configured default model also appeared in a custom provider entry, the request routed to `custom:<name>` instead of the explicit active provider. Users hit confusing 401/auth errors from a provider they didn't intend to use (#1922). The narrow fix skips custom-provider shadowing only for the configured default model when the active provider is an explicit non-custom provider. Existing custom-provider routing for explicitly selected custom-models and slash-containing endpoint model IDs is preserved. Regression tests added for `ai-gateway` and `xiaomi` overlap cases. Closes #1922.
+
+### Added
+
+- **PR #2009** by @dobby-d-elf — Live context-window tracking during streaming. Two gaps closed in the WebUI context indicator:
+  - **Updates during tool calls.** Token usage and context length were previously updated only after a full response completed; the indicator now receives live `usage` events mid-stream while tools are executing, so users see real-time consumption instead of stale numbers. Server emits `_live_usage_snapshot()` payloads during tool execution; frontend merges them via `_syncCtxIndicator()`. Tracks input tokens, output tokens, estimated cost, context length, threshold tokens, and last prompt tokens.
+  - **Reset on new sessions.** `_syncCtxIndicator()` is now called from `newSession()` so the indicator starts from the fresh session's reading instead of carrying stale values from the previous conversation.
+
+  Live metering events are tagged with the real WebUI `session_id` so the frontend session filter accepts them. Token-driven metering events include the live `usage` payload to keep the indicator moving while the agent is actively streaming. Reused cached agents refresh `tool_start_callback` and `tool_complete_callback` so live tracking continues after the first turn in a session.
+
+### Tests
+
+5066+ → **5071+ passing, 0 regressions** (+5 net new across `test_1062_busy_input_modes.py`, `test_model_resolver.py`, `test_issue1617_tps_message_header.py`). Full suite under 160s on Python 3.11 with `HERMES_HOME` isolation.
+
+### Notes
+
+- 4 PRs from 4 different authors. `static/messages.js` was the only multi-PR file (#2009 + #2018), with disjoint hunks at lines ~1159 and ~210/244/261 respectively. `api/streaming.py` only touched by #2009. Stage merge clean with no conflicts.
+
 ## [v0.51.38] — 2026-05-10 — Release N (UI polish — toast + mobile + diff renderer + sidebar)
 
 ### Fixed

--- a/api/config.py
+++ b/api/config.py
@@ -1517,18 +1517,36 @@ def resolve_model_provider(model_id: str) -> tuple:
 
     # Custom providers declared in config.yaml should win over slash-based
     # OpenRouter heuristics. Their model IDs commonly contain '/' too.
-    custom_providers = cfg.get("custom_providers", [])
-    if isinstance(custom_providers, list):
+    # However, when the active provider is an explicit non-custom provider and
+    # the requested model_id is the configured default model, that active
+    # provider takes precedence over overlapping custom_providers[] entries.
+    # Otherwise WebUI routes to custom:<name> instead of the intended endpoint
+    # and can surface a 401 from the wrong provider (#1922).
+    # For all other cases, preserve custom_providers[] routing for explicitly
+    # selected custom provider models.
+    _is_explicit_non_custom_provider = (
+        config_provider is not None
+        and config_provider != 'custom'
+        and not config_provider.startswith('custom:')
+    )
+    _default_model = model_cfg.get('default') if isinstance(model_cfg, dict) else None
+    _skip_custom_providers = (
+        _is_explicit_non_custom_provider
+        and _default_model is not None
+        and model_id == _default_model
+    )
+    custom_providers = cfg.get('custom_providers', [])
+    if isinstance(custom_providers, list) and not _skip_custom_providers:
         for entry in custom_providers:
             if not isinstance(entry, dict):
                 continue
-            entry_model = (entry.get("model") or "").strip()
-            entry_name = (entry.get("name") or "").strip()
-            entry_base_url = (entry.get("base_url") or "").strip()
+            entry_model = (entry.get('model') or '').strip()
+            entry_name = (entry.get('name') or '').strip()
+            entry_base_url = (entry.get('base_url') or '').strip()
             entry_model_ids = set()
             if entry_model:
                 entry_model_ids.add(entry_model)
-            entry_models = entry.get("models")
+            entry_models = entry.get('models')
             if isinstance(entry_models, dict):
                 entry_model_ids.update(
                     key.strip()
@@ -1536,7 +1554,7 @@ def resolve_model_provider(model_id: str) -> tuple:
                     if isinstance(key, str) and key.strip()
                 )
             if entry_name and model_id in entry_model_ids:
-                provider_hint = "custom:" + entry_name.lower().replace(" ", "-")
+                provider_hint = 'custom:' + entry_name.lower().replace(' ', '-')
                 return model_id, provider_hint, entry_base_url or None
 
     # @provider:model format — explicit provider hint from the dropdown.

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -2044,7 +2044,7 @@ def _run_agent_streaming(
             if _metering_stop.wait(interval):
                 break  # stream was cancelled or ended — exit
             stats = meter().get_stats()
-            stats['session_id'] = stream_id
+            stats['session_id'] = session_id
             stats['usage'] = _live_usage_snapshot()
             put('metering', stats)
 
@@ -2241,7 +2241,8 @@ def _run_agent_streaming(
                     return
                 _metering_last_emit[0] = now
                 stats = meter().get_stats()
-                stats['session_id'] = stream_id
+                stats['session_id'] = session_id
+                stats['usage'] = _live_usage_snapshot()
                 stats.setdefault('tps_available', False)
                 stats.setdefault('estimated', False)
                 put('metering', stats)
@@ -2377,7 +2378,7 @@ def _run_agent_streaming(
                         'args': args_snap,
                     })
                     _tool_stats = meter().get_stats()
-                    _tool_stats['session_id'] = stream_id
+                    _tool_stats['session_id'] = session_id
                     _tool_stats['usage'] = _live_usage_snapshot()
                     put('metering', _tool_stats)
                     # Fallback: poll for pending approval in case notify_cb wasn't
@@ -2424,7 +2425,7 @@ def _run_agent_streaming(
                         'is_error': bool(cb_kwargs.get('is_error', False)),
                     })
                     _tool_stats = meter().get_stats()
-                    _tool_stats['session_id'] = stream_id
+                    _tool_stats['session_id'] = session_id
                     _tool_stats['usage'] = _live_usage_snapshot()
                     put('metering', _tool_stats)
                     return
@@ -2433,7 +2434,7 @@ def _run_agent_streaming(
                 try:
                     _record_live_tool_start(tool_call_id, name, args)
                     _tool_stats = meter().get_stats()
-                    _tool_stats['session_id'] = stream_id
+                    _tool_stats['session_id'] = session_id
                     _tool_stats['usage'] = _live_usage_snapshot()
                     put('metering', _tool_stats)
                 except Exception:
@@ -2443,7 +2444,7 @@ def _run_agent_streaming(
                 try:
                     _record_live_tool_complete(tool_call_id, name, function_result)
                     _tool_stats = meter().get_stats()
-                    _tool_stats['session_id'] = stream_id
+                    _tool_stats['session_id'] = session_id
                     _tool_stats['usage'] = _live_usage_snapshot()
                     put('metering', _tool_stats)
                 except Exception:
@@ -2699,6 +2700,10 @@ def _run_agent_streaming(
                     # objects (put queue, cancel_event) that are new each request.
                     agent.stream_delta_callback = _agent_kwargs.get('stream_delta_callback')
                     agent.tool_progress_callback = _agent_kwargs.get('tool_progress_callback')
+                    if hasattr(agent, 'tool_start_callback'):
+                        agent.tool_start_callback = _agent_kwargs.get('tool_start_callback')
+                    if hasattr(agent, 'tool_complete_callback'):
+                        agent.tool_complete_callback = _agent_kwargs.get('tool_complete_callback')
                     if hasattr(agent, 'status_callback'):
                         agent.status_callback = _agent_kwargs.get('status_callback')
                     if hasattr(agent, 'interim_assistant_callback'):

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -1939,6 +1939,7 @@ def _run_agent_streaming(
 
     agent = None
     _live_prompt_estimate_tokens = [0]
+    _live_prompt_exact_tokens = [0]
     _live_prompt_estimate_seen_ids = set()
 
     def _seed_live_prompt_estimate() -> int:
@@ -1961,6 +1962,7 @@ def _run_agent_streaming(
             except Exception:
                 _base = 0
         _live_prompt_estimate_tokens[0] = int(_base or 0)
+        _live_prompt_exact_tokens[0] = _live_prompt_estimate_tokens[0]
         return _live_prompt_estimate_tokens[0]
 
     def _bump_live_prompt_estimate(messages) -> int:
@@ -2023,7 +2025,11 @@ def _run_agent_streaming(
                     except Exception:
                         pass
 
-        if _live_prompt_estimate_tokens[0] > (_usage.get('last_prompt_tokens') or 0):
+        _real_prompt_tokens = int(_usage.get('last_prompt_tokens') or 0)
+        if _real_prompt_tokens and _real_prompt_tokens != _live_prompt_exact_tokens[0]:
+            _live_prompt_exact_tokens[0] = _real_prompt_tokens
+            _live_prompt_estimate_tokens[0] = _real_prompt_tokens
+        elif _live_prompt_estimate_tokens[0] > _real_prompt_tokens:
             _usage['last_prompt_tokens'] = _live_prompt_estimate_tokens[0]
 
         return _usage

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -1937,6 +1937,97 @@ def _run_agent_streaming(
         STREAM_REASONING_TEXT[stream_id] = ''  # start accumulating reasoning trace (#1361 §A)
         STREAM_LIVE_TOOL_CALLS[stream_id] = []  # start accumulating tool calls (#1361 §B)
 
+    agent = None
+    _live_prompt_estimate_tokens = [0]
+    _live_prompt_estimate_seen_ids = set()
+
+    def _seed_live_prompt_estimate() -> int:
+        """Capture the latest exact prompt size before adding live tool deltas."""
+        if _live_prompt_estimate_tokens[0] > 0:
+            return _live_prompt_estimate_tokens[0]
+        _base = 0
+        _agent = agent
+        if _agent is not None:
+            try:
+                _cc = getattr(_agent, 'context_compressor', None)
+                if _cc:
+                    _base = getattr(_cc, 'last_prompt_tokens', 0) or 0
+            except Exception:
+                _base = 0
+        if not _base:
+            try:
+                _session_obj = get_session(session_id)
+                _base = getattr(_session_obj, 'last_prompt_tokens', 0) or 0
+            except Exception:
+                _base = 0
+        _live_prompt_estimate_tokens[0] = int(_base or 0)
+        return _live_prompt_estimate_tokens[0]
+
+    def _bump_live_prompt_estimate(messages) -> int:
+        """Increment a rough next-prompt estimate from live tool activity."""
+        if not messages:
+            return _live_prompt_estimate_tokens[0]
+        try:
+            from agent.model_metadata import estimate_messages_tokens_rough
+            _delta = int(estimate_messages_tokens_rough(messages) or 0)
+        except Exception:
+            _delta = 0
+        if _delta > 0:
+            _seed_live_prompt_estimate()
+            _live_prompt_estimate_tokens[0] += _delta
+        return _live_prompt_estimate_tokens[0]
+
+    def _live_usage_snapshot():
+        """Best-effort live usage payload for mid-stream UI updates.
+
+        During tool execution the final `done` event has not fired yet, but the
+        frontend still benefits from seeing the latest known token / context
+        values. These are exact for the most recent model call and a truthful
+        lower bound for the pending next call after a tool result is appended.
+        """
+        _usage = {
+            'input_tokens': 0,
+            'output_tokens': 0,
+            'estimated_cost': 0,
+            'context_length': 0,
+            'threshold_tokens': 0,
+            'last_prompt_tokens': 0,
+        }
+        try:
+            _session_obj = get_session(session_id)
+        except Exception:
+            _session_obj = None
+
+        _agent = agent
+        if _agent is not None:
+            try:
+                _usage['input_tokens'] = getattr(_agent, 'session_prompt_tokens', 0) or 0
+                _usage['output_tokens'] = getattr(_agent, 'session_completion_tokens', 0) or 0
+                _usage['estimated_cost'] = getattr(_agent, 'session_estimated_cost_usd', 0) or 0
+            except Exception:
+                pass
+            try:
+                _cc = getattr(_agent, 'context_compressor', None)
+                if _cc:
+                    _usage['context_length'] = getattr(_cc, 'context_length', 0) or 0
+                    _usage['threshold_tokens'] = getattr(_cc, 'threshold_tokens', 0) or 0
+                    _usage['last_prompt_tokens'] = getattr(_cc, 'last_prompt_tokens', 0) or 0
+            except Exception:
+                pass
+
+        if _session_obj is not None:
+            for _field in ('input_tokens', 'output_tokens', 'estimated_cost', 'context_length', 'threshold_tokens', 'last_prompt_tokens'):
+                if not _usage.get(_field):
+                    try:
+                        _usage[_field] = getattr(_session_obj, _field, 0) or 0
+                    except Exception:
+                        pass
+
+        if _live_prompt_estimate_tokens[0] > (_usage.get('last_prompt_tokens') or 0):
+            _usage['last_prompt_tokens'] = _live_prompt_estimate_tokens[0]
+
+        return _usage
+
     # Register this stream with the global streaming meter
     meter().begin_session(stream_id)
 
@@ -1954,6 +2045,7 @@ def _run_agent_streaming(
                 break  # stream was cancelled or ended — exit
             stats = meter().get_stats()
             stats['session_id'] = stream_id
+            stats['usage'] = _live_usage_snapshot()
             put('metering', stats)
 
     _metering_thread = threading.Thread(target=_metering_ticker, daemon=True)
@@ -2200,6 +2292,35 @@ def _run_agent_streaming(
             # block is reordered later (Issue #765).
             _checkpoint_activity = [0]
 
+            def _record_live_tool_start(tool_call_id, name, args):
+                if not tool_call_id or tool_call_id in _live_prompt_estimate_seen_ids:
+                    return
+                _live_prompt_estimate_seen_ids.add(tool_call_id)
+                _tool_call = {
+                    'id': tool_call_id,
+                    'type': 'function',
+                    'function': {
+                        'name': str(name or ''),
+                        'arguments': json.dumps(args if isinstance(args, dict) else {}, ensure_ascii=False, sort_keys=True),
+                    },
+                }
+                _bump_live_prompt_estimate([{
+                    'role': 'assistant',
+                    'content': '',
+                    'tool_calls': [_tool_call],
+                }])
+
+            def _record_live_tool_complete(tool_call_id, name, function_result):
+                if not tool_call_id:
+                    return
+                _result_text = _tool_result_snippet(function_result)
+                _bump_live_prompt_estimate([{
+                    'role': 'tool',
+                    'name': str(name or ''),
+                    'tool_call_id': tool_call_id,
+                    'content': _result_text,
+                }])
+
             def on_tool(*cb_args, **cb_kwargs):
                 nonlocal _reasoning_text
                 event_type = None
@@ -2255,6 +2376,10 @@ def _run_agent_streaming(
                         'preview': preview,
                         'args': args_snap,
                     })
+                    _tool_stats = meter().get_stats()
+                    _tool_stats['session_id'] = stream_id
+                    _tool_stats['usage'] = _live_usage_snapshot()
+                    put('metering', _tool_stats)
                     # Fallback: poll for pending approval in case notify_cb wasn't
                     # registered (e.g. older approval module without gateway support).
                     try:
@@ -2298,7 +2423,31 @@ def _run_agent_streaming(
                         'duration': cb_kwargs.get('duration'),
                         'is_error': bool(cb_kwargs.get('is_error', False)),
                     })
+                    _tool_stats = meter().get_stats()
+                    _tool_stats['session_id'] = stream_id
+                    _tool_stats['usage'] = _live_usage_snapshot()
+                    put('metering', _tool_stats)
                     return
+
+            def on_tool_start(tool_call_id, name, args):
+                try:
+                    _record_live_tool_start(tool_call_id, name, args)
+                    _tool_stats = meter().get_stats()
+                    _tool_stats['session_id'] = stream_id
+                    _tool_stats['usage'] = _live_usage_snapshot()
+                    put('metering', _tool_stats)
+                except Exception:
+                    logger.debug('Failed to update live prompt estimate on tool start', exc_info=True)
+
+            def on_tool_complete(tool_call_id, name, args, function_result):
+                try:
+                    _record_live_tool_complete(tool_call_id, name, function_result)
+                    _tool_stats = meter().get_stats()
+                    _tool_stats['session_id'] = stream_id
+                    _tool_stats['usage'] = _live_usage_snapshot()
+                    put('metering', _tool_stats)
+                except Exception:
+                    logger.debug('Failed to update live prompt estimate on tool completion', exc_info=True)
 
             _AIAgent = _get_ai_agent()
             if _AIAgent is None:
@@ -2481,6 +2630,10 @@ def _run_agent_streaming(
                 _agent_kwargs['reasoning_config'] = _reasoning_config
             if 'interim_assistant_callback' in _agent_params:
                 _agent_kwargs['interim_assistant_callback'] = on_interim_assistant
+            if 'tool_start_callback' in _agent_params:
+                _agent_kwargs['tool_start_callback'] = on_tool_start
+            if 'tool_complete_callback' in _agent_params:
+                _agent_kwargs['tool_complete_callback'] = on_tool_complete
             if 'status_callback' in _agent_params:
                 _agent_kwargs['status_callback'] = _agent_status_callback
             if 'max_iterations' in _agent_params and _max_iterations_cfg is not None:

--- a/docker_init.bash
+++ b/docker_init.bash
@@ -227,9 +227,22 @@ if [ "A${whoami}" == "Aroot" ]; then
   chown hermeswebui:hermeswebui "${UV_CACHE_DIR}" || error_exit "Failed to set owner of ${UV_CACHE_DIR} to hermeswebui user"
 
   chown -R "${WANTED_UID}:${WANTED_GID}" "$itdir" || error_exit "Failed to set owner of $itdir"
-  save_env /tmp/hermeswebui_root_env.txt
-  chown "${WANTED_UID}:${WANTED_GID}" /tmp/hermeswebui_root_env.txt || error_exit "Failed to set owner of /tmp/hermeswebui_root_env.txt"
-  chmod 600 /tmp/hermeswebui_root_env.txt || error_exit "Failed to secure /tmp/hermeswebui_root_env.txt"
+  # Issue #2010 — Railway / user-namespaced runtimes: in-container UID 0 may map
+  # to a host UID outside the writable subuid range, so /tmp writes fail despite
+  # id -u == 0. Probe writability and fall back through $itdir → /app.
+  ENV_FILE="/tmp/hermeswebui_root_env.txt"
+  if ! ( : > "$ENV_FILE" ) 2>/dev/null; then
+    ENV_FILE="${itdir:-/tmp/hermeswebui_init}/hermeswebui_root_env.txt"
+    mkdir -p "$(dirname "$ENV_FILE")" 2>/dev/null
+    if ! ( : > "$ENV_FILE" ) 2>/dev/null; then
+      ENV_FILE="/app/.hermeswebui_root_env"
+    fi
+    echo "  !! /tmp not writable by root — falling back to $ENV_FILE (user-namespaced runtime?)"
+  fi
+  save_env "$ENV_FILE"
+  chown "${WANTED_UID}:${WANTED_GID}" "$ENV_FILE" || error_exit "Failed to set owner of $ENV_FILE"
+  chmod 600 "$ENV_FILE" || error_exit "Failed to secure $ENV_FILE"
+  export _HW_ROOT_ENV_PATH="$ENV_FILE"
 
   # restart the script as hermeswebui set with the correct UID/GID this time
   echo "-- Restarting as hermeswebui user with UID ${WANTED_UID} GID ${WANTED_GID}"
@@ -248,7 +261,7 @@ if [ "$WANTED_UID" != "$new_uid" ]; then error_exit "hermeswebui MUST be running
 echo ""; echo "== Running as hermeswebui"
 
 # Load environment variables one by one if they do not exist from the root init phase
-tmp_root_env=/tmp/hermeswebui_root_env.txt
+tmp_root_env="${_HW_ROOT_ENV_PATH:-/tmp/hermeswebui_root_env.txt}"
 if [ -f $tmp_root_env ]; then
   echo "-- Loading not already set environment variables from $tmp_root_env"
   load_env $tmp_root_env true

--- a/static/messages.js
+++ b/static/messages.js
@@ -1161,14 +1161,6 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         if((d.session_id||activeSid)!==activeSid) return;
         if(d.usage&&typeof _syncCtxIndicator==='function'){
           S.lastUsage={...(S.lastUsage||{}),...d.usage};
-          if(S.session&&S.session.session_id===activeSid){
-            S.session.input_tokens=d.usage.input_tokens??S.session.input_tokens;
-            S.session.output_tokens=d.usage.output_tokens??S.session.output_tokens;
-            S.session.estimated_cost=d.usage.estimated_cost??S.session.estimated_cost;
-            S.session.context_length=d.usage.context_length??S.session.context_length;
-            S.session.threshold_tokens=d.usage.threshold_tokens??S.session.threshold_tokens;
-            S.session.last_prompt_tokens=d.usage.last_prompt_tokens??S.session.last_prompt_tokens;
-          }
           _syncCtxIndicator(S.lastUsage);
         }
         if(d.estimated===true||d.tps_available!==true||typeof d.tps!=='number'||d.tps<=0){

--- a/static/messages.js
+++ b/static/messages.js
@@ -210,6 +210,7 @@ async function send(){
   startClarifyPolling(activeSid);
   _fetchYoloState(activeSid);  // sync YOLO pill with backend state
   S.activeStreamId = null;  // will be set after stream starts
+  if(typeof updateSendBtn==='function') updateSendBtn();
 
   // Set provisional title from user message immediately so session appears
   // in the sidebar right away with a meaningful name (server may refine later)
@@ -243,6 +244,7 @@ async function send(){
       profile:S.activeProfile||S.session.profile||'default',
       attachments:uploaded.length?uploaded:undefined
     })});
+
     if(startData.effective_model && S.session){
       S.session.model=startData.effective_model;
       S.session.model_provider=startData.effective_model_provider||S.session.model_provider||null;
@@ -259,6 +261,9 @@ async function send(){
     }
     streamId=startData.stream_id;
     S.activeStreamId = streamId;
+    // setBusy(true) already ran with activeStreamId=null; refresh now that we
+    // have a stream id so the primary button can switch to Stop (see getComposerPrimaryAction).
+    if(typeof updateSendBtn==='function') updateSendBtn();
     if(S.session&&typeof startData.pending_started_at==='number'){
       S.session.pending_started_at=startData.pending_started_at;
     }

--- a/static/messages.js
+++ b/static/messages.js
@@ -1159,6 +1159,18 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       try{
         const d=JSON.parse(e.data||'{}');
         if((d.session_id||activeSid)!==activeSid) return;
+        if(d.usage&&typeof _syncCtxIndicator==='function'){
+          S.lastUsage={...(S.lastUsage||{}),...d.usage};
+          if(S.session&&S.session.session_id===activeSid){
+            S.session.input_tokens=d.usage.input_tokens??S.session.input_tokens;
+            S.session.output_tokens=d.usage.output_tokens??S.session.output_tokens;
+            S.session.estimated_cost=d.usage.estimated_cost??S.session.estimated_cost;
+            S.session.context_length=d.usage.context_length??S.session.context_length;
+            S.session.threshold_tokens=d.usage.threshold_tokens??S.session.threshold_tokens;
+            S.session.last_prompt_tokens=d.usage.last_prompt_tokens??S.session.last_prompt_tokens;
+          }
+          _syncCtxIndicator(S.lastUsage);
+        }
         if(d.estimated===true||d.tps_available!==true||typeof d.tps!=='number'||d.tps<=0){
           if(typeof _setLiveAssistantTps==='function') _setLiveAssistantTps(null);
           return;

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -392,6 +392,17 @@ async function newSession(flash){
   updateSendBtn();
   setStatus('');
   setComposerStatus('');
+  if(typeof _setLiveAssistantTps==='function') _setLiveAssistantTps(null);
+  if(typeof _syncCtxIndicator==='function'){
+    _syncCtxIndicator({
+      input_tokens:data.session.input_tokens||0,
+      output_tokens:data.session.output_tokens||0,
+      estimated_cost:data.session.estimated_cost||0,
+      context_length:data.session.context_length||0,
+      last_prompt_tokens:data.session.last_prompt_tokens||0,
+      threshold_tokens:data.session.threshold_tokens||0,
+    });
+  }
   updateQueueBadge(S.session.session_id);
   syncTopbar();renderMessages();loadDir('.');
   // don't call renderSessionList here - callers do it when needed

--- a/tests/test_1062_busy_input_modes.py
+++ b/tests/test_1062_busy_input_modes.py
@@ -207,6 +207,51 @@ class TestBusySendButton:
             "boot.js should wire btnSend to handleComposerPrimaryAction(), not directly to send()"
         )
 
+    def test_send_refreshes_primary_button_after_clearing_active_stream_id(self):
+        """send() must call updateSendBtn after resetting activeStreamId for a new turn.
+
+        getComposerPrimaryAction maps to Stop only when S.activeStreamId is set; after
+        nulling the id, btnSend must refresh so a stale Stop icon cannot linger until
+        the next composer input event.
+        """
+        send_start = MESSAGES_JS.find("async function send(")
+        assert send_start >= 0, "send() not found in messages.js"
+        send_end = MESSAGES_JS.find("const LIVE_STREAMS={}", send_start)
+        assert send_end > send_start, "could not find end of send() body"
+        send_body = MESSAGES_JS[send_start:send_end]
+        marker = "S.activeStreamId = null;  // will be set after stream starts"
+        mpos = send_body.find(marker)
+        assert mpos >= 0, "send() must reset activeStreamId before chat/start"
+        window = send_body[mpos : mpos + 200]
+        assert "updateSendBtn" in window, (
+            "send() must call updateSendBtn() after clearing activeStreamId "
+            "so btnSend state matches the pending-start phase"
+        )
+
+    def test_send_refreshes_primary_button_after_chat_start_stream_id(self):
+        """send() must call updateSendBtn in the chat/start try block after assigning streamId.
+
+        setBusy(true) already ran updateSendBtn while activeStreamId was still null, so the
+        Stop affordance did not appear until something else (e.g. typing) called
+        updateSendBtn again.
+        """
+        send_start = MESSAGES_JS.find("async function send(")
+        assert send_start >= 0, "send() not found in messages.js"
+        send_end = MESSAGES_JS.find("const LIVE_STREAMS={}", send_start)
+        assert send_end > send_start, "could not find end of send() body"
+        send_body = MESSAGES_JS[send_start:send_end]
+        assign = "S.activeStreamId = streamId;"
+        apos = send_body.find(assign)
+        assert apos >= 0, "send() must assign S.activeStreamId from startData"
+        after_assign = send_body[apos:]
+        end_try = after_assign.find("  }catch(e){")
+        assert end_try > 0, "send() outer try/catch not found after stream id assign"
+        try_after_assign = after_assign[:end_try]
+        assert "updateSendBtn" in try_after_assign, (
+            "send() must call updateSendBtn() in the chat/start try block after assigning "
+            "streamId so the primary button switches to Stop without waiting for composer input"
+        )
+
 
 class TestSendBusyBranchDispatch:
     """send()'s busy block must read window._busyInputMode and branch accordingly."""

--- a/tests/test_issue1617_tps_message_header.py
+++ b/tests/test_issue1617_tps_message_header.py
@@ -46,6 +46,32 @@ def test_live_metering_updates_only_real_tps_and_never_placeholders():
     )
 
 
+def test_live_metering_usage_is_provisional_until_done():
+    listener_start = MESSAGES_JS.find("source.addEventListener('metering'")
+    assert listener_start != -1, "messages.js should listen for metering SSE events"
+    listener_end = MESSAGES_JS.find("source.addEventListener('apperror'", listener_start)
+    assert listener_end != -1, "apperror listener should follow metering listener"
+    listener = MESSAGES_JS[listener_start:listener_end]
+
+    assert "S.lastUsage={...(S.lastUsage||{}),...d.usage}" in listener, (
+        "live usage should update the transient usage cache for the indicator"
+    )
+    assert "_syncCtxIndicator(S.lastUsage)" in listener, (
+        "live usage should refresh the context indicator"
+    )
+    assert "S.session.input_tokens=d.usage.input_tokens" not in listener
+    assert "S.session.last_prompt_tokens=d.usage.last_prompt_tokens" not in listener
+
+
+def test_live_prompt_estimate_reanchors_to_fresh_exact_prompt_tokens():
+    assert "_live_prompt_exact_tokens = [0]" in STREAMING_PY, (
+        "live prompt estimates need a separate exact-token anchor"
+    )
+    assert "_real_prompt_tokens = int(_usage.get('last_prompt_tokens') or 0)" in STREAMING_PY
+    assert "_real_prompt_tokens != _live_prompt_exact_tokens[0]" in STREAMING_PY
+    assert "_live_prompt_estimate_tokens[0] = _real_prompt_tokens" in STREAMING_PY
+
+
 def test_done_payload_persists_final_tps_when_exact_usage_available():
     assert "usage['tps']" in STREAMING_PY, "done usage payload should include final exact TPS when available"
     assert "output_tokens" in STREAMING_PY and "duration_seconds" in STREAMING_PY, (

--- a/tests/test_model_resolver.py
+++ b/tests/test_model_resolver.py
@@ -179,6 +179,58 @@ def test_custom_provider_models_dict_routes_to_named_custom_provider():
     assert base_url == 'http://127.0.0.1:8080/v1'
 
 
+# ── Issue #1922: default model shadowed by overlapping custom_providers[] ──
+
+def test_default_model_not_shadowed_by_overlapping_custom_provider():
+    r'''Regression test for #1922.
+
+    When the active provider is an explicit non-custom provider (e.g. ai-gateway,
+    openrouter, xiaomi) AND the requested model_id matches the configured default
+    model, the active provider's base_url must take precedence over an overlapping
+    custom_providers[] entry. Otherwise the WebUI routes to 'custom:<name>' with
+    the wrong endpoint, causing 401 errors.
+
+    This test mirrors the reported scenario:
+      - provider: ai-gateway
+      - base_url: https://api.ai-gateway.example/v1
+      - default: gpt-5.4
+      - An overlapping custom_providers[] entry with the same default model
+
+    Expected: active provider (ai-gateway) wins over custom provider.
+    '''
+    model, provider, base_url = _resolve_with_config(
+        'gpt-5.4',
+        provider='ai-gateway',
+        base_url='https://api.ai-gateway.example/v1',
+        default='gpt-5.4',
+        custom_providers=[{
+            'name': 'My Custom Endpoint',
+            'base_url': 'http://localhost:8080/v1',
+            'model': 'gpt-5.4',
+        }],
+    )
+    assert model == 'gpt-5.4', f'Expected model=gpt-5.4, got {model!r}'
+    assert provider == 'ai-gateway', f'Expected provider=ai-gateway, got {provider!r}'
+    assert base_url == 'https://api.ai-gateway.example/v1', f'Expected base_url from active provider, got {base_url!r}'
+
+
+def test_default_model_shadowed_with_xiaomi_provider():
+    r'''Same regression test with provider=xiaomi instead of ai-gateway.'''
+    model, provider, base_url = _resolve_with_config(
+        'deepseek-v4-flash',
+        provider='xiaomi',
+        default='deepseek-v4-flash',
+        custom_providers=[{
+            'name': 'LiteLLM Proxy',
+            'base_url': 'http://127.0.0.1:8080/v1',
+            'model': 'deepseek-v4-flash',
+        }],
+    )
+    assert model == 'deepseek-v4-flash'
+    assert provider == 'xiaomi'
+    assert base_url is None  # xiaomi has no config base_url in this test
+
+
 # ── get_available_models() @provider: hint behaviour ──────────────────────
 
 


### PR DESCRIPTION
# Release O — v0.51.39 — 4-PR contributor batch

Four contributor PRs from four authors. Mix of bug fixes (Railway docker, Stop button race, model-resolver overlap) and one bounded feature (live context tracking).

## Constituent PRs

| PR | Author | Concern | LOC |
|---|---|---|---|
| #2017 | @michael-dg | `docker_init.bash` fallback when `/tmp` not root-writable on Railway (closes #2010) | +17/-4 |
| #2018 | @rhelmer | Stop button race after `/api/chat/start` returns stream_id | +50/-0 |
| #2022 | @Michaelyklam | `resolve_model_provider()` prefers active provider over overlapping `custom_providers[]` (closes #1922) | +77/-7 |
| #2009 | @dobby-d-elf | Live context-window tracking during streaming + reset on new session | +207/-2 |

## Stage merge note

`static/messages.js` touched by #2009 and #2018 with disjoint hunks (~lines 1159 vs ~210/244/261). Stage merge clean with no conflicts.

## Tests

- Pre-stage: ~5066 passing (post-N master baseline)
- Post-stage: **5082 passing**, 0 regressions, 146s
- All modified `.js` files pass `node -c`; `bash -n docker_init.bash` clean

## Especially keen for your eyes on

1. **#2009 SSE event session-id tagging** — the highest-risk item. PR description claims live metering events are tagged with the real WebUI `session_id` so the frontend session filter accepts them. Worth confirming events don't cross session boundaries when a user has multiple tabs open.
2. **#2022 resolver narrow-fix** — verify `custom:foo` still routes correctly when explicitly selected, while `claude-sonnet-4` (configured default) routes to `anthropic` even when `custom_providers: [{name:"foo", models:["claude-sonnet-4"]}]` shadows it.
3. **#2018 button refresh** — three new refresh sites in `send()`. Verify idempotent.
4. **#2017 docker fallback** — Railway-specific writability fallback chain; non-Railway runtimes preserve prior behavior.

## Closes

#1922 #2010

## Opus advisor

Running on stage diff. Will update with verdict before merge.
