### PR TITLE
fix: recover orphaned session backups on startup

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -4147,6 +4147,7 @@ def handle_post(handler, parsed) -> bool:
             return bad(handler, "Invalid session_id", 400)
         try:
             p.unlink(missing_ok=True)
+            p.with_suffix('.json.bak').unlink(missing_ok=True)
         except Exception:
             logger.debug("Failed to unlink session file %s", p)
         # Prune the per-session agent lock so deleted sessions don't leak

--- a/api/session_recovery.py
+++ b/api/session_recovery.py
@@ -5,13 +5,16 @@ data-loss bugs like #1558.
 ``Session.save()`` writes a ``<sid>.json.bak`` snapshot of the previous
 state whenever an incoming save would shrink the messages array. This
 module reads those snapshots back and restores any session whose live
-file has fewer messages than its backup.
+file has fewer messages than its backup, or whose live file is missing
+while a valid backup remains.
 
 Three integration points:
 
 1. ``recover_all_sessions_on_startup()`` — called from server.py at boot,
    scans the session dir, restores any session whose JSON has fewer
-   messages than its .bak. Idempotent: a clean run is a no-op.
+   messages than its .bak, and recreates a missing ``<sid>.json`` from an
+   orphaned ``<sid>.json.bak`` when the canonical state DB still has that
+   session. Idempotent: a clean run is a no-op.
 
 2. ``recover_session(sid)`` — single-session helper backing the
    ``POST /api/session/recover`` endpoint, so users can re-run recovery
@@ -25,6 +28,7 @@ from __future__ import annotations
 import json
 import logging
 import shutil
+import sqlite3
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -117,24 +121,81 @@ def recover_session(session_path: Path) -> dict:
     return {**status, "restored": True}
 
 
-def recover_all_sessions_on_startup(session_dir: Path) -> dict:
-    """Scan session_dir for shrunken sessions, restore each from its .bak.
+def _state_db_has_session(session_id: str, state_db_path: Path | None) -> bool:
+    """Return whether state.db still knows this session.
 
-    Returns {"scanned": N, "restored": M, "details": [...]}.
+    The check is deliberately fail-open: recovery must not be prevented by a
+    locked, absent, or older-schema state DB. When a DB is readable and has no
+    row, treat the orphan backup as a tombstoned/deleted session and skip it.
+    """
+    if state_db_path is None or not state_db_path.exists():
+        return True
+    try:
+        with sqlite3.connect(f"file:{state_db_path}?mode=ro", uri=True) as conn:
+            cur = conn.execute(
+                "select 1 from sqlite_master where type='table' and name='sessions'"
+            )
+            if cur.fetchone() is None:
+                return True
+            cur = conn.execute("select 1 from sessions where id = ? limit 1", (session_id,))
+            return cur.fetchone() is not None
+    except Exception as exc:
+        logger.debug("state_db session tombstone check failed for %s: %s", session_id, exc)
+        return True
+
+
+def _orphaned_backup_live_paths(
+    session_dir: Path,
+    state_db_path: Path | None = None,
+) -> list[Path]:
+    """Return live ``<sid>.json`` paths whose ``<sid>.json.bak`` exists.
+
+    ``Path.glob('*.json')`` does not see orphan backups because their suffix is
+    ``.bak``. Existing startup recovery only handled shrunken live files; this
+    helper covers the crash shape where the live sidecar is gone but the rescue
+    copy remains.
+    """
+    paths: list[Path] = []
+    for bak_path in sorted(session_dir.glob('*.json.bak')):
+        live_path = bak_path.with_suffix('')
+        if live_path.name.startswith('_') or live_path.exists():
+            continue
+        if _msg_count(bak_path) < 0:
+            continue
+        session_id = live_path.stem
+        if not _state_db_has_session(session_id, state_db_path):
+            logger.info(
+                "recover_all_sessions_on_startup: skipped orphan backup %s; "
+                "state.db has no live session row",
+                bak_path.name,
+            )
+            continue
+        paths.append(live_path)
+    return paths
+
+
+def recover_all_sessions_on_startup(
+    session_dir: Path,
+    rebuild_index: bool = False,
+    state_db_path: Path | None = None,
+) -> dict:
+    """Scan session_dir for shrunken/orphaned sessions and restore from .bak.
+
+    Returns {"scanned": N, "restored": M, "orphaned_backups": K, "details": [...]}.
     """
     if not session_dir.exists():
-        return {"scanned": 0, "restored": 0, "details": []}
+        return {"scanned": 0, "restored": 0, "orphaned_backups": 0, "details": []}
     scanned = 0
     restored = 0
     details: list[dict] = []
-    for path in session_dir.glob('*.json'):
+    live_paths = [path for path in sorted(session_dir.glob('*.json')) if not path.name.startswith('_')]
+    orphan_paths = _orphaned_backup_live_paths(session_dir, state_db_path=state_db_path)
+    for path in [*live_paths, *orphan_paths]:
         # Skip non-session JSON files in the same dir:
         # - ``_index.json`` is a top-level list of session metadata
         # - any future non-session JSON marked with the ``_`` convention is
         #   skipped automatically (project convention for system files in
         #   directories that otherwise hold user data)
-        if path.name.startswith('_'):
-            continue
         scanned += 1
         try:
             result = recover_session(path)
@@ -155,4 +216,15 @@ def recover_all_sessions_on_startup(session_dir: Path) -> dict:
             "If you weren't expecting this, check the session list for missing "
             "messages — see #1558.", restored, scanned,
         )
-    return {"scanned": scanned, "restored": restored, "details": details}
+        if rebuild_index:
+            try:
+                from api.models import _write_session_index
+                _write_session_index(updates=None)
+            except Exception as exc:
+                logger.warning("recover_all_sessions_on_startup: index rebuild failed: %s", exc)
+    return {
+        "scanned": scanned,
+        "restored": restored,
+        "orphaned_backups": len(orphan_paths),
+        "details": details,
+    }

--- a/server.py
+++ b/server.py
@@ -220,8 +220,13 @@ def main() -> None:
     # its .bak (the data-loss shape #1558 produced), restore from the .bak.
     # Safe to run unconditionally — a clean install is a no-op.
     try:
+        from api.models import _active_state_db_path
         from api.session_recovery import recover_all_sessions_on_startup
-        result = recover_all_sessions_on_startup(SESSION_DIR)
+        result = recover_all_sessions_on_startup(
+            SESSION_DIR,
+            rebuild_index=True,
+            state_db_path=_active_state_db_path(),
+        )
         if result.get("restored"):
             print(f"[recovery] Restored {result['restored']}/{result['scanned']} sessions from .bak (see #1558).", flush=True)
     except Exception as exc:

--- a/tests/test_metadata_save_wipe_1558.py
+++ b/tests/test_metadata_save_wipe_1558.py
@@ -204,6 +204,71 @@ def test_recover_all_sessions_on_startup_restores_shrunken_session(temp_session_
     assert len(restored["messages"]) == 1000
 
 
+def test_recover_all_sessions_on_startup_restores_orphan_bak(temp_session_dir):
+    """Startup self-heal: if only <sid>.json.bak survived, recreate <sid>.json."""
+    sid = _make_session_on_disk(temp_session_dir, n_msgs=293)
+    live_path = temp_session_dir / f"{sid}.json"
+    bak_path = temp_session_dir / f"{sid}.json.bak"
+    bak_path.write_text(live_path.read_text(encoding="utf-8"), encoding="utf-8")
+    live_path.unlink()
+
+    from api.session_recovery import recover_all_sessions_on_startup
+    result = recover_all_sessions_on_startup(temp_session_dir)
+
+    assert result["restored"] == 1
+    assert result["scanned"] == 1
+    assert result.get("orphaned_backups") == 1
+    restored = json.loads(live_path.read_text(encoding="utf-8"))
+    assert len(restored["messages"]) == 293
+
+
+def test_recover_all_sessions_on_startup_rebuilds_index_after_orphan_restore(temp_session_dir, monkeypatch):
+    """A restored orphan must be visible through the WebUI session index immediately."""
+    import api.models as _m
+
+    sid = _make_session_on_disk(temp_session_dir, n_msgs=42)
+    live_path = temp_session_dir / f"{sid}.json"
+    bak_path = temp_session_dir / f"{sid}.json.bak"
+    bak_path.write_text(live_path.read_text(encoding="utf-8"), encoding="utf-8")
+    live_path.unlink()
+
+    stale_index = temp_session_dir / "_index.json"
+    stale_index.write_text(json.dumps([]), encoding="utf-8")
+    monkeypatch.setattr(_m, "SESSION_INDEX_FILE", stale_index)
+
+    from api.session_recovery import recover_all_sessions_on_startup
+    result = recover_all_sessions_on_startup(temp_session_dir, rebuild_index=True)
+
+    assert result["restored"] == 1
+    index = json.loads(stale_index.read_text(encoding="utf-8"))
+    assert [entry["session_id"] for entry in index] == [sid]
+    assert index[0]["message_count"] == 42
+
+
+def test_orphan_bak_recovery_skips_sessions_absent_from_state_db(temp_session_dir):
+    """Do not resurrect an explicitly deleted session when state.db lacks the row."""
+    import sqlite3
+
+    sid = _make_session_on_disk(temp_session_dir, n_msgs=12)
+    live_path = temp_session_dir / f"{sid}.json"
+    bak_path = temp_session_dir / f"{sid}.json.bak"
+    bak_path.write_text(live_path.read_text(encoding="utf-8"), encoding="utf-8")
+    live_path.unlink()
+
+    state_db = temp_session_dir / "state.db"
+    with sqlite3.connect(state_db) as conn:
+        conn.execute("create table sessions (id text primary key)")
+        conn.execute("insert into sessions (id) values (?)", ("different_session",))
+
+    from api.session_recovery import recover_all_sessions_on_startup
+    result = recover_all_sessions_on_startup(temp_session_dir, state_db_path=state_db)
+
+    assert result["restored"] == 0
+    assert result["scanned"] == 0
+    assert result["orphaned_backups"] == 0
+    assert not live_path.exists()
+
+
 def test_recover_all_sessions_on_startup_is_idempotent_no_op_on_clean_state(temp_session_dir):
     """A clean install (no .bak files) must not modify anything."""
     sid = _make_session_on_disk(temp_session_dir, n_msgs=1000)

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -335,6 +335,19 @@ def test_server_delete_invalidates_index(cleanup_test_sessions):
             return
     assert False, "session/delete handler not found in server.py or api/routes.py"
 
+
+def test_server_delete_removes_session_bak_snapshot(cleanup_test_sessions):
+    """session/delete must remove sidecar backups so deleted sessions stay deleted."""
+    routes_src = (REPO_ROOT / "api" / "routes.py").read_text()
+    delete_idx = max(
+        routes_src.find("if parsed.path == '/api/session/delete':"),
+        routes_src.find('if parsed.path == "/api/session/delete":'),
+    )
+    assert delete_idx >= 0, "session/delete handler not found in api/routes.py"
+    delete_block = routes_src[delete_idx:delete_idx+1400]
+    assert "with_suffix('.json.bak').unlink" in delete_block or 'with_suffix(".json.bak").unlink' in delete_block, \
+        "session/delete must unlink <sid>.json.bak to avoid later orphan-backup recovery"
+
 # ── R9: Token/tool SSE events write to wrong session after switch ─────────────
 
 def test_token_handler_guards_session_id(cleanup_test_sessions):


### PR DESCRIPTION
## Summary
- Restore orphaned `<session_id>.json.bak` snapshots when the live WebUI session sidecar is missing and the canonical `state.db.sessions` row still exists.
- Rebuild the session index after startup recovery so restored sessions are visible immediately.
- Remove `<session_id>.json.bak` during explicit session delete so intentional deletes are not resurrected later.

## Why
The existing #1558 recovery handles shrunken live JSON files, but it only scans `*.json`. If a crash or recovery path leaves only `<session_id>.json.bak`, the data is still present but invisible to `/api/sessions` and the sidebar.

## Safety
- If `state.db` is available and has no row for an orphan backup, recovery skips it as a likely explicit delete/tombstone.
- If `state.db` is unavailable or unreadable, recovery remains fail-open like the existing startup recovery path.
- Index rebuild is best-effort and only runs after a successful recovery.

## Test Plan
- `python -m pytest tests/test_metadata_save_wipe_1558.py -q -o 'addopts='`
- `python -m pytest tests/test_regressions.py::test_server_delete_removes_session_bak_snapshot tests/test_regressions.py::test_server_delete_invalidates_index -q -o 'addopts='`
- `python -m py_compile api/session_recovery.py server.py api/routes.py`
- `git diff --check`

## Review note
A delegated reviewer attempt failed before tool execution with provider-side HTTP 429. I did not count it as approval; this PR has targeted regression tests plus static/security checks.