### PR TITLE
feat: add MEDIA_ALLOWED_ROOTS env var for configurable /api/media file-serving whitelist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+### Added
+
+- **MEDIA_ALLOWED_ROOTS env var** — Configurable colon-separated list of absolute
+  paths to add to the `/api/media` file-serving whitelist. The built-in allowed
+  roots (`~/.hermes`, `/tmp`, active workspace) remain the default; setting
+  `MEDIA_ALLOWED_ROOTS=/home/user/models:/home/user/Pictures` extends the
+  whitelist at runtime without code changes. Resolves the "local MEDIA: path
+  blocked outside allowed roots" usability gap for power users. Added static
+  unit test for env var presence in source. (`api/routes.py`, `tests/test_media_inline.py`)
+
 ## [v0.51.41] — 2026-05-11 — Release Q (3-PR contributor batch — session recovery audit + run-lifecycle health + transcript dedup)
 
 ### Fixed

--- a/api/routes.py
+++ b/api/routes.py
@@ -5578,6 +5578,8 @@ def _handle_media(handler, parsed):
     - Only image MIME types are served inline; all others force download
     - SVG always served as attachment (XSS risk)
     - No path traversal: resolved path must stay within an allowed root
+    - Additional roots can be added via MEDIA_ALLOWED_ROOTS env var
+      (colon-separated list of absolute paths)
     """
     import os as _os
     from api.auth import is_auth_enabled, parse_cookie, verify_session
@@ -5621,6 +5623,21 @@ def _handle_media(handler, parsed):
             allowed_roots.append(ws)
     except Exception:
         pass
+
+    # Also allow additional roots from MEDIA_ALLOWED_ROOTS env var
+    # (colon-separated list of absolute paths, e.g. /home/user/models:/home/user/Pictures)
+    extra_roots = _os.environ.get("MEDIA_ALLOWED_ROOTS", "").strip()
+    if extra_roots:
+        for root in extra_roots.split(":"):
+            root = root.strip()
+            if root:
+                try:
+                    rp = Path(root).resolve()
+                    if rp.is_dir():
+                        allowed_roots.append(rp)
+                except Exception:
+                    pass
+
     within_allowed = any(
         _os.path.commonpath([str(target), str(root)]) == str(root)
         for root in allowed_roots

--- a/tests/test_media_inline.py
+++ b/tests/test_media_inline.py
@@ -235,6 +235,12 @@ class TestMediaEndpointUnit(unittest.TestCase):
         self.assertIn("_INLINE_IMAGE_TYPES", routes_src,
                       "_INLINE_IMAGE_TYPES whitelist must exist in _handle_media")
 
+    def test_media_allowed_roots_env_var_referenced(self):
+        """Handler must reference MEDIA_ALLOWED_ROOTS for configurable roots."""
+        routes_src = (REPO_ROOT / "api" / "routes.py").read_text(encoding="utf-8")
+        self.assertIn("MEDIA_ALLOWED_ROOTS", routes_src,
+                      "MEDIA_ALLOWED_ROOTS env var must be parsed in _handle_media")
+
     def test_media_endpoints_advertise_byte_range_support(self):
         routes_src = (REPO_ROOT / "api" / "routes.py").read_text(encoding="utf-8")
         self.assertIn("Accept-Ranges", routes_src)


### PR DESCRIPTION
## Summary

The `/api/media` endpoint only serves files from `~/.hermes`, `/tmp`, and the active workspace. Power users with media in custom directories (models, Downloads, Pictures, ComfyUI outputs, etc.) have no way to serve those files inline without copying or symlinking.

This PR adds a `MEDIA_ALLOWED_ROOTS` environment variable — a colon-separated list of absolute paths — that extends the allowed roots at runtime.

## Changes

- **`api/routes.py`** — Parse `MEDIA_ALLOWED_ROOTS` in `_handle_media()`, resolve each entry, validate it's an existing directory, and append to `allowed_roots`. Non-existent or invalid paths are silently skipped.
- **`tests/test_media_inline.py`** — Static test verifying `MEDIA_ALLOWED_ROOTS` is referenced in source.
- **`CHANGELOG.md`** — Added to `[Unreleased]` section.

## Usage

```bash
MEDIA_ALLOWED_ROOTS=/home/user/models:/home/user/Pictures
```

If unset, behavior is identical to before — purely additive, no breaking changes.

## Testing

```
tests/test_media_inline.py .................... 41 passed
tests/test_profile_path_security.py ... 3 passed
tests/test_sprint28.py .......... 10 passed
```