### PR TITLE
feat: add slack to cron delivery options

### DIFF
--- a/static/panels.js
+++ b/static/panels.js
@@ -733,6 +733,7 @@ function _renderCronForm({ name, schedule, prompt, deliver, profile, no_agent=fa
             ${deliverOpt('local', t('cron_deliver_local') || 'Local (save output only)')}
             ${deliverOpt('discord','Discord')}
             ${deliverOpt('telegram','Telegram')}
+            ${deliverOpt('slack','Slack')}
           </select>
         </div>
         <div class="detail-form-row">


### PR DESCRIPTION
- Hermes WebUI aims for near 1:1 parity with the Hermes CLI and backend capabilities.
- The `deliver` dropdown allows users to choose the target platform for cron deliveries.
- The backend `hermes-agent` fully supports Slack delivery (`deliver: "slack"`), but it was missing from the WebUI dropdown options.
- This PR adds 'Slack' to the delivery options in the frontend `static/panels.js` script.
- The benefit is that users can easily route their automated tasks to their Slack workspace directly from the UI without falling back to the CLI.

### What Changed
Added `${deliverOpt('slack','Slack')}` to the `cronFormDeliver` select dropdown in `static/panels.js`.

### Why It Matters
Closes the gap between backend capabilities (which already supports Slack via `SLACK_HOME_CHANNEL`) and frontend UI options. 

### Verification
Local checks complete. The change only affects the HTML dropdown options and does not alter core application logic.

### Risks / Follow-ups
None. The backend already handles `deliver="slack"` natively.

### Model Used (AI-Assisted)
Gemini 3.1 Pro (High) via Antigravity
