### PR TITLE
[security] fix(session): validate workspace on import

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -8832,7 +8832,10 @@ def _handle_session_import(handler, body):
     if not isinstance(messages, list):
         return bad(handler, 'JSON must contain a "messages" array')
     title = body.get("title", "Imported session")
-    workspace = body.get("workspace", str(DEFAULT_WORKSPACE))
+    try:
+        workspace = str(resolve_trusted_workspace(body.get("workspace", str(DEFAULT_WORKSPACE))))
+    except (TypeError, ValueError) as e:
+        return bad(handler, str(e))
     model = body.get("model", DEFAULT_MODEL)
     s = Session(
         title=title,

--- a/tests/test_session_import_workspace_validation.py
+++ b/tests/test_session_import_workspace_validation.py
@@ -1,0 +1,105 @@
+import io
+import json
+from pathlib import Path
+from urllib.parse import urlparse
+
+from api.config import DEFAULT_WORKSPACE, SESSION_DIR
+from api.models import get_session
+from api.routes import _handle_file_read, _handle_session_import
+from api.workspace import resolve_trusted_workspace
+
+
+class _DummyHandler:
+    def __init__(self):
+        self.status = None
+        self.response_headers = []
+        self.headers = {}
+        self.wfile = io.BytesIO()
+        self.command = "GET"
+        self.path = "/"
+
+    def send_response(self, status):
+        self.status = status
+
+    def send_header(self, key, value):
+        self.response_headers.append((key, value))
+
+    def end_headers(self):
+        pass
+
+    def json_body(self):
+        return json.loads(self.wfile.getvalue().decode("utf-8"))
+
+
+def test_session_import_rejects_blocked_root_workspace():
+    handler = _DummyHandler()
+
+    _handle_session_import(
+        handler,
+        {
+            "title": "blocked import",
+            "workspace": "/",
+            "model": "test",
+            "messages": [],
+        },
+    )
+
+    assert handler.status == 400
+    assert "system directory" in handler.json_body()["error"]
+
+
+def test_session_import_rejects_non_path_workspace_value():
+    handler = _DummyHandler()
+
+    _handle_session_import(
+        handler,
+        {
+            "title": "invalid import",
+            "workspace": {"not": "a path"},
+            "model": "test",
+            "messages": [],
+        },
+    )
+
+    assert handler.status == 400
+    assert handler.json_body()["error"]
+
+
+def test_imported_session_file_read_stays_under_validated_workspace():
+    SESSION_DIR.mkdir(parents=True, exist_ok=True)
+    workspace = Path(DEFAULT_WORKSPACE)
+    workspace.mkdir(parents=True, exist_ok=True)
+    (workspace / "allowed.txt").write_text("allowed", encoding="utf-8")
+
+    import_handler = _DummyHandler()
+    _handle_session_import(
+        import_handler,
+        {
+            "title": "valid import",
+            "workspace": str(workspace),
+            "model": "test",
+            "messages": [],
+        },
+    )
+
+    assert import_handler.status == 200
+    sid = import_handler.json_body()["session"]["session_id"]
+    assert get_session(sid).workspace == str(resolve_trusted_workspace(workspace))
+
+    read_handler = _DummyHandler()
+    _handle_file_read(read_handler, urlparse(f"/api/file?session_id={sid}&path=allowed.txt"))
+
+    assert read_handler.status == 200
+    assert read_handler.json_body()["content"] == "allowed"
+
+
+def test_resolver_would_reject_imported_root_before_file_read():
+    # Regression guard for the original issue shape: '/' must be rejected at
+    # import time rather than becoming a session workspace that makes
+    # Path('/')-relative reads like etc/hosts reachable through /api/file.
+    try:
+        resolve_trusted_workspace(Path("/"))
+    except ValueError as exc:
+        assert "system directory" in str(exc)
+    else:  # pragma: no cover - this would weaken the security invariant
+        raise AssertionError("root workspace unexpectedly accepted")


### PR DESCRIPTION
## Summary

This PR hardens the session import boundary so imported session JSON cannot choose an untrusted filesystem workspace.

- Validates the imported `workspace` field with the same trusted-workspace resolver used by normal session creation.
- Rejects blocked system roots such as `/` instead of persisting them into new sessions.
- Adds focused regression coverage for blocked roots, non-path workspace values, and successful imports with validated workspaces.

## Security issues covered

| Issue | Impact | Severity |
|-------|--------|----------|
| Imported session workspace validation bypass | A crafted session import could set `workspace` to a normally blocked filesystem root such as `/`, then use session file APIs to read files relative to that root. | High when WebUI is reachable by untrusted users or exposed beyond loopback; lower in strictly trusted local-only deployments. |

## Before this PR

- `POST /api/session/new` validated requested workspaces with `resolve_trusted_workspace(...)`.
- `POST /api/session/import` trusted `body["workspace"]` directly from imported JSON.
- A crafted import could persist `workspace: "/"` into a new session.
- Follow-on file routes such as `/api/file` and `/api/file/raw` resolve paths relative to the stored session workspace.
- The import path did not have regression coverage for blocked roots or invalid workspace values.

## After this PR

- Session import validates the imported workspace with `resolve_trusted_workspace(...)` before constructing the session.
- Blocked roots such as `/` are rejected with a 400 response.
- Non-path workspace values are rejected cleanly instead of becoming server errors.
- Regression tests lock the import boundary and verify valid workspace imports still work.

## Why this matters

Hermes WebUI's workspace resolver is the boundary that prevents filesystem features from operating on OS roots and other untrusted locations. Importing a session is a request-controlled state-creation path, so its serialized `workspace` value needs the same validation as interactive session creation.

Without that validation, an attacker who can reach session import could create a session rooted at `/` and then use normal session file APIs with safe-looking relative paths such as `etc/hosts`. The PoC uses only `/etc/hosts`, but the same boundary break can expose other readable host files depending on process permissions and deployment.

## Attack flow

```text
crafted session JSON with "workspace": "/"
    -> POST /api/session/import
        -> imported Session persists workspace without trusted-root validation
            -> GET /api/file?session_id=<sid>&path=etc/hosts reads from /
```

## Affected code

| Issue | Files |
|-------|-------|
| Session import workspace validation bypass | `api/routes.py`, `tests/test_session_import_workspace_validation.py` |

## Root cause

Session import workspace validation bypass:

- Direct cause: `_handle_session_import()` read `workspace = body.get("workspace", str(DEFAULT_WORKSPACE))` and passed it directly into `Session(...)`.
- Boundary failure: imported JSON is request-controlled, but it was treated as already-trusted session state. Normal session creation used `resolve_trusted_workspace(...)`; session import did not.

## CVSS assessment

| Issue | CVSS v3.1 | Vector |
|-------|-----------|--------|
| Imported session workspace validation bypass | 7.1 High | `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N` |

Rationale:

- The primary impact is confidentiality: the bug can expose readable host files through the WebUI process once the crafted session is imported.
- `PR:L` assumes password/authenticated WebUI access when auth is enabled. Deployments with auth disabled or exposed to an untrusted network increase practical risk; strictly loopback-only trusted-operator deployments reduce it.
- Scope remains unchanged because the file read occurs under the same host user/process authority as WebUI.

## Safe reproduction steps

1. On a vulnerable build, import a crafted session:

   ```http
   POST /api/session/import
   Content-Type: application/json

   {
     "title": "poc imported root workspace",
     "workspace": "/",
     "model": "test",
     "messages": []
   }
   ```

2. Capture the returned `session.session_id`.

3. Request a benign proof file through the session file API:

   ```http
   GET /api/file?session_id=<imported-session-id>&path=etc/hosts
   ```

4. Use a harmless file such as `/etc/hosts`; do not use secrets as proof material.

## Expected vulnerable behavior

- The vulnerable import succeeds and returns a session whose workspace is `/`.
- `resolve_trusted_workspace("/")` would reject `/` as a system directory in normal session creation.
- `/api/file?session_id=<sid>&path=etc/hosts` returns `/etc/hosts` contents because `etc/hosts` is resolved relative to the imported `/` workspace.

## Changes in this PR

- Routes imported session workspaces through `resolve_trusted_workspace(...)`.
- Converts invalid import workspaces into a 400 response before a `Session` is created.
- Adds tests for:
  - rejecting `/` as an imported workspace;
  - rejecting non-path workspace values;
  - preserving valid imports with canonical validated workspaces;
  - verifying the root-workspace invariant that prevented the file-read path.

## Files changed

| Category | Files | What changed |
|----------|-------|--------------|
| Security fix | `api/routes.py` | Validates imported workspaces before session creation and handles invalid path values cleanly. |
| Tests | `tests/test_session_import_workspace_validation.py` | Adds direct route-handler regression coverage for blocked roots and valid imports. |

## Maintainer impact

- The patch is narrow and limited to session import workspace handling.
- Existing valid imports with normal trusted workspaces continue to work.
- The frontend and unrelated session, workspace, and file APIs are untouched.
- The validation now matches the already-established behavior for `/api/session/new`, making the import path consistent with the rest of the workspace boundary.

## Fix rationale

The session import endpoint creates new application state from request-controlled JSON, so it must enforce the same workspace trust boundary as regular session creation. Validating at import time is the durable fix because it prevents unsafe roots from ever being persisted into session metadata. The follow-on file APIs can then continue assuming that `Session.workspace` has already passed the workspace resolver.

## Type of change

- [x] Security fix
- [x] Tests
- [ ] Documentation update
- [ ] Refactor with no behavior change

## Test plan

- [x] Focused session-import regression tests pass.
- [x] Workspace blocked-root regression tests still pass.
- [x] Touched Python files compile.
- [x] Git whitespace check passes.
- [x] Independent code-review pass completed after the initial fix; a robustness concern for non-path workspace values was addressed before commit.
- [ ] Full test suite not run locally; this PR only touches a narrow route handler and focused regression tests were run.

Executed with:

```bash
python3 -m pytest tests/test_session_import_workspace_validation.py tests/test_workspace_blocked_roots_macos.py -q
python3 -m compileall -q api/routes.py tests/test_session_import_workspace_validation.py
git diff --check
```

Result:

```text
36 passed in 1.81s
```

## Token usage

- discovery tokens: partial/unknown
- validation tokens: partial/unknown
- duplicate-check tokens: partial/unknown
- PR/writeup tokens: partial/unknown
- total tokens: partial/unknown
- notes: Discovery and validation included local review plus delegated reviewer/subagent output, but complete end-to-end token telemetry is not available in a single reliable total.

## Disclosure notes

- This PR is bounded to the session import workspace validation gap.
- The safe reproduction uses `/etc/hosts` only and does not require reading secrets.
- No unrelated files were changed.
- I did not find a `SECURITY.md` file in the repository while preparing this PR.
