### PR TITLE
Fix duplicate assistant transcript merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fixed duplicate assistant messages in browser chat transcripts by ignoring adjacent assistant replay duplicates during server-side result merge while preserving identical assistant text across separate user turns (#2051).
+
 ## [v0.51.43] — 2026-05-11 — Release S (fused community PR — desktop sidebar collapse)
 
 ### Added

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -1753,6 +1753,18 @@ def _merge_display_messages_after_agent_result(previous_display, previous_contex
             # in result_messages, keep the durable checkpoint and append only
             # the assistant/tool delta.
             continue
+        if (
+            key is not None
+            and isinstance(msg, dict)
+            and msg.get('role') == 'assistant'
+            and merged
+            and _message_identity(merged[-1]) == key
+        ):
+            # Some provider/result replay paths can include the same assistant
+            # message twice in the current delta. Treat only adjacent identity
+            # matches as replay duplicates so identical answers in separate
+            # user turns remain visible.
+            continue
         if _is_context_compression_marker(msg) and key is not None and key in seen:
             continue
         display_msg = msg

--- a/tests/test_session_save_mode.py
+++ b/tests/test_session_save_mode.py
@@ -159,6 +159,69 @@ def test_deferred_turn_is_materialized_when_agent_returns_assistant_only_delta()
     assert [m["content"] for m in merged[-2:]] == ["latest prompt", "current answer"]
 
 
+def test_duplicate_assistant_delta_is_not_persisted_twice():
+    """Provider/result merge replay must not duplicate the same assistant bubble."""
+    previous_display = [
+        {"role": "user", "content": "older prompt"},
+        {"role": "assistant", "content": "older answer"},
+    ]
+    previous_context = list(previous_display)
+    result_messages = previous_context + [
+        {"role": "user", "content": "latest prompt"},
+        {"role": "assistant", "content": "current answer"},
+        {"role": "assistant", "content": "current answer"},
+    ]
+
+    merged = streaming._merge_display_messages_after_agent_result(
+        previous_display=previous_display,
+        previous_context=previous_context,
+        result_messages=result_messages,
+        msg_text="latest prompt",
+    )
+
+    assert [m["role"] for m in merged] == [
+        "user",
+        "assistant",
+        "user",
+        "assistant",
+    ]
+    assert [m["content"] for m in merged[-2:]] == ["latest prompt", "current answer"]
+    assert (
+        sum(
+            1
+            for m in merged
+            if m.get("role") == "assistant" and m.get("content") == "current answer"
+        )
+        == 1
+    )
+
+
+def test_same_assistant_text_across_different_turns_is_preserved():
+    previous_display = [
+        {"role": "user", "content": "first prompt"},
+        {"role": "assistant", "content": "same answer"},
+    ]
+    previous_context = list(previous_display)
+    result_messages = previous_context + [
+        {"role": "user", "content": "second prompt"},
+        {"role": "assistant", "content": "same answer"},
+    ]
+
+    merged = streaming._merge_display_messages_after_agent_result(
+        previous_display=previous_display,
+        previous_context=previous_context,
+        result_messages=result_messages,
+        msg_text="second prompt",
+    )
+
+    assert [m["content"] for m in merged] == [
+        "first prompt",
+        "same answer",
+        "second prompt",
+        "same answer",
+    ]
+
+
 def test_llm_title_generated_survives_save_and_load(_isolate_state):
     s = Session(
         session_id="generated_title",


### PR DESCRIPTION
## Thinking Path

- Issue #2051 reports duplicate assistant responses in the browser.
- The frontend `done` handler replaces local state with the server session payload, so if the browser renders two assistant bubbles, the first layer to check is the server-side transcript merge.
- `_merge_display_messages_after_agent_result()` already avoids duplicating an eager-checkpointed current user turn, but it did not guard against the same assistant message being replayed twice in the current result delta.
- The safe fix is narrow: skip only adjacent assistant messages with the same merge identity. This treats provider/result replay as duplicate, while preserving identical assistant text in separate user turns.

## What Changed

- Added a merge guard in `api/streaming.py` for adjacent duplicate assistant messages.
- Added a regression test that reproduces the #2051 failure: a result delta containing the same assistant bubble twice now persists only one copy.
- Added a negative-path test proving identical assistant text across different user turns is still preserved.
- Added a changelog entry.

## Why It Matters

This prevents duplicate assistant bubbles from being persisted into `s.messages` and then sent back to the browser in the `done` SSE payload. Keeping the guard adjacent-only avoids silently rewriting legitimate history where two separate turns happen to produce the same visible assistant text.

Closes #2051.

## Verification

- RED: `pytest -q tests/test_session_save_mode.py::test_duplicate_assistant_delta_is_not_persisted_twice tests/test_session_save_mode.py::test_same_assistant_text_across_different_turns_is_preserved`
  - failed before the fix with the duplicate assistant message still present
- `pytest -q tests/test_session_save_mode.py::test_duplicate_assistant_delta_is_not_persisted_twice tests/test_session_save_mode.py::test_same_assistant_text_across_different_turns_is_preserved`
  - `2 passed`
- `pytest -q tests/test_session_save_mode.py tests/test_issue1217_transcript_compaction.py tests/test_session_lineage_full_transcript.py tests/test_issue1361_cancel_data_loss.py`
  - `40 passed`
- `python -m py_compile api/streaming.py`
- `git diff --check`

## Risks / Follow-ups

- This intentionally does not global-deduplicate all assistant content. Global content dedup could drop legitimate repeated answers across different user turns.
- If a future report involves duplicate tool-result rows, that should be handled with its own regression case rather than broadened here without evidence.

## Model Used

AI-assisted with OpenAI Codex in Codex desktop. Model: GPT-5.3 Codex.
