### PR TITLE
feat: add crash-safe turn journal writer

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -6675,6 +6675,22 @@ def _start_chat_stream_for_session(
             model_provider=model_provider,
             stream_id=stream_id,
         )
+        diag.stage("turn_journal_submitted") if diag else None
+        from api.turn_journal import append_turn_journal_event
+        journal_event = append_turn_journal_event(
+            s.session_id,
+            {
+                "event": "submitted",
+                "stream_id": stream_id,
+                "role": "user",
+                "content": msg,
+                "attachments": attachments,
+                "workspace": workspace,
+                "model": model,
+                "model_provider": model_provider,
+                "created_at": s.pending_started_at,
+            },
+        )
     diag.stage("set_last_workspace") if diag else None
     set_last_workspace(workspace)
     diag.stage("stream_registration") if diag else None
@@ -6696,6 +6712,7 @@ def _start_chat_stream_for_session(
         "stream_id": stream_id,
         "session_id": s.session_id,
         "pending_started_at": s.pending_started_at,
+        "turn_id": journal_event.get("turn_id"),
     }
     if normalized_model:
         response["effective_model"] = model

--- a/api/routes.py
+++ b/api/routes.py
@@ -6675,7 +6675,9 @@ def _start_chat_stream_for_session(
             model_provider=model_provider,
             stream_id=stream_id,
         )
-        diag.stage("turn_journal_submitted") if diag else None
+    diag.stage("turn_journal_submitted") if diag else None
+    journal_event = {}
+    try:
         from api.turn_journal import append_turn_journal_event
         journal_event = append_turn_journal_event(
             s.session_id,
@@ -6691,6 +6693,8 @@ def _start_chat_stream_for_session(
                 "created_at": s.pending_started_at,
             },
         )
+    except Exception:
+        logger.warning("Failed to append submitted turn journal event", exc_info=True)
     diag.stage("set_last_workspace") if diag else None
     set_last_workspace(workspace)
     diag.stage("stream_registration") if diag else None

--- a/api/session_recovery.py
+++ b/api/session_recovery.py
@@ -34,6 +34,13 @@ import sqlite3
 import threading
 from pathlib import Path
 
+from api.turn_journal import (
+    derive_turn_journal_states,
+    is_terminal_turn_event,
+    iter_turn_journal_session_ids,
+    read_turn_journal,
+)
+
 logger = logging.getLogger(__name__)
 
 
@@ -365,8 +372,9 @@ def _new_audit_item(
     recommendation: str,
     live_messages: int = -1,
     bak_messages: int = -1,
+    **extra,
 ) -> dict:
-    return {
+    item = {
         "session_id": session_id,
         "kind": kind,
         "category": category,
@@ -374,6 +382,8 @@ def _new_audit_item(
         "live_messages": live_messages,
         "bak_messages": bak_messages,
     }
+    item.update(extra)
+    return item
 
 
 def _read_index_session_ids(index_path: Path) -> set[str]:
@@ -468,6 +478,37 @@ def audit_session_recovery(session_dir: Path, state_db_path: Path | None = None)
             -1,
             -1,
         ))
+
+    for session_id in iter_turn_journal_session_ids(session_dir):
+        journal = read_turn_journal(session_id, session_dir=session_dir)
+        states = derive_turn_journal_states(journal.get('events') or [])
+        live_path = session_dir / f"{session_id}.json"
+        live_messages = _msg_count(live_path)
+        existing_user_messages: set[str] = set()
+        try:
+            payload = json.loads(live_path.read_text(encoding='utf-8'))
+            if isinstance(payload, dict):
+                for message in payload.get('messages') or []:
+                    if isinstance(message, dict) and message.get('role') == 'user':
+                        existing_user_messages.add(str(message.get('content') or '').strip())
+        except (OSError, json.JSONDecodeError, ValueError):
+            pass
+        for turn_id, event in sorted(states.items()):
+            if is_terminal_turn_event(event):
+                continue
+            content = str(event.get('content') or '').strip()
+            if not content or content in existing_user_messages:
+                continue
+            items.append(_new_audit_item(
+                session_id,
+                "turn_journal_pending_turn",
+                "repairable",
+                "audit_only_pending_turn_journal",
+                live_messages,
+                -1,
+                turn_id=turn_id,
+                event=str(event.get('event') or ''),
+            ))
 
     summary = {"ok": len(live_paths), "repairable": 0, "unsafe_to_repair": 0}
     for item in items:

--- a/api/turn_journal.py
+++ b/api/turn_journal.py
@@ -63,14 +63,10 @@ def append_turn_journal_event(
     path.parent.mkdir(parents=True, exist_ok=True)
     line = json.dumps(payload, ensure_ascii=False, separators=(",", ":")) + "\n"
     fd = os.open(path, os.O_CREAT | os.O_APPEND | os.O_WRONLY, 0o600)
-    try:
-        with os.fdopen(fd, "a", encoding="utf-8") as fh:
-            fh.write(line)
-            fh.flush()
-            os.fsync(fh.fileno())
-    finally:
-        # fd ownership moves to fdopen(); this finally exists only for clarity.
-        pass
+    with os.fdopen(fd, "a", encoding="utf-8") as fh:
+        fh.write(line)
+        fh.flush()
+        os.fsync(fh.fileno())
     try:
         dir_fd = os.open(path.parent, os.O_DIRECTORY)
         try:
@@ -115,7 +111,9 @@ def derive_turn_journal_states(events: Iterable[dict]) -> dict[str, dict]:
         turn_id = str(event.get("turn_id") or "").strip()
         if not turn_id:
             continue
-        states[turn_id] = event
+        previous = states.get(turn_id)
+        if previous is None or float(event.get("created_at") or 0) >= float(previous.get("created_at") or 0):
+            states[turn_id] = event
     return states
 
 

--- a/api/turn_journal.py
+++ b/api/turn_journal.py
@@ -1,0 +1,130 @@
+"""Crash-safe WebUI turn journal helpers.
+
+The journal is deliberately tiny: one JSONL file per session, append-only events,
+and read helpers that tolerate malformed lines. Recovery and repair can then
+reason about submitted turns without depending on in-memory stream state.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import time
+import uuid
+from pathlib import Path
+from typing import Iterable
+
+TURN_JOURNAL_DIR_NAME = "_turn_journal"
+_TERMINAL_EVENTS = {"completed", "interrupted"}
+_SESSION_ID_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
+
+
+def _default_session_dir() -> Path:
+    from api.models import SESSION_DIR
+
+    return Path(SESSION_DIR)
+
+
+def _journal_path(session_id: str, session_dir: Path | None = None) -> Path:
+    sid = str(session_id or "").strip()
+    if not sid or "/" in sid or "\\" in sid or not _SESSION_ID_RE.fullmatch(sid):
+        raise ValueError("invalid session_id")
+    root = Path(session_dir) if session_dir is not None else _default_session_dir()
+    return root / TURN_JOURNAL_DIR_NAME / f"{sid}.jsonl"
+
+
+def _make_turn_id() -> str:
+    return f"{time.strftime('%Y%m%dT%H%M%SZ', time.gmtime())}-{uuid.uuid4().hex[:12]}"
+
+
+def append_turn_journal_event(
+    session_id: str,
+    event: dict,
+    *,
+    session_dir: Path | None = None,
+) -> dict:
+    """Append one turn journal event and fsync it before returning.
+
+    The returned event is the exact payload written, with default ``version``,
+    ``session_id``, ``turn_id``, and ``created_at`` fields filled in.
+    """
+    if not isinstance(event, dict):
+        raise TypeError("event must be a dict")
+    event_name = str(event.get("event") or "").strip()
+    if not event_name:
+        raise ValueError("event is required")
+    payload = dict(event)
+    payload.setdefault("version", 1)
+    payload["session_id"] = str(session_id)
+    payload.setdefault("turn_id", _make_turn_id())
+    payload.setdefault("created_at", time.time())
+
+    path = _journal_path(session_id, session_dir=session_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    line = json.dumps(payload, ensure_ascii=False, separators=(",", ":")) + "\n"
+    fd = os.open(path, os.O_CREAT | os.O_APPEND | os.O_WRONLY, 0o600)
+    try:
+        with os.fdopen(fd, "a", encoding="utf-8") as fh:
+            fh.write(line)
+            fh.flush()
+            os.fsync(fh.fileno())
+    finally:
+        # fd ownership moves to fdopen(); this finally exists only for clarity.
+        pass
+    try:
+        dir_fd = os.open(path.parent, os.O_DIRECTORY)
+        try:
+            os.fsync(dir_fd)
+        finally:
+            os.close(dir_fd)
+    except OSError:
+        pass
+    return payload
+
+
+def read_turn_journal(session_id: str, *, session_dir: Path | None = None) -> dict:
+    """Read a session journal, returning valid events plus malformed lines."""
+    path = _journal_path(session_id, session_dir=session_dir)
+    events: list[dict] = []
+    malformed: list[dict] = []
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except FileNotFoundError:
+        return {"session_id": str(session_id), "events": [], "malformed": []}
+    for line_no, raw in enumerate(lines, start=1):
+        if not raw.strip():
+            continue
+        try:
+            event = json.loads(raw)
+        except json.JSONDecodeError:
+            malformed.append({"line": line_no, "raw": raw})
+            continue
+        if isinstance(event, dict):
+            events.append(event)
+        else:
+            malformed.append({"line": line_no, "raw": raw})
+    return {"session_id": str(session_id), "events": events, "malformed": malformed}
+
+
+def derive_turn_journal_states(events: Iterable[dict]) -> dict[str, dict]:
+    """Return the latest event per ``turn_id``."""
+    states: dict[str, dict] = {}
+    for event in events:
+        if not isinstance(event, dict):
+            continue
+        turn_id = str(event.get("turn_id") or "").strip()
+        if not turn_id:
+            continue
+        states[turn_id] = event
+    return states
+
+
+def iter_turn_journal_session_ids(session_dir: Path) -> list[str]:
+    journal_dir = Path(session_dir) / TURN_JOURNAL_DIR_NAME
+    if not journal_dir.exists():
+        return []
+    return sorted(path.stem for path in journal_dir.glob("*.jsonl") if path.is_file())
+
+
+def is_terminal_turn_event(event: dict) -> bool:
+    return str((event or {}).get("event") or "") in _TERMINAL_EVENTS

--- a/tests/test_turn_journal.py
+++ b/tests/test_turn_journal.py
@@ -69,6 +69,15 @@ def test_derive_turn_journal_states_keeps_latest_event_per_turn():
     assert states["turn-2"]["event"] == "submitted"
 
 
+def test_derive_turn_journal_states_uses_created_at_not_file_order():
+    states = derive_turn_journal_states([
+        {"event": "completed", "turn_id": "turn-1", "created_at": 20},
+        {"event": "submitted", "turn_id": "turn-1", "created_at": 10},
+    ])
+
+    assert states["turn-1"]["event"] == "completed"
+
+
 def test_audit_reports_pending_turn_journal_entry_when_user_message_absent(tmp_path):
     _write_session(tmp_path, "sid-1", messages=[])
     append_turn_journal_event(

--- a/tests/test_turn_journal.py
+++ b/tests/test_turn_journal.py
@@ -1,0 +1,126 @@
+import json
+
+from api.session_recovery import audit_session_recovery
+from api.turn_journal import (
+    append_turn_journal_event,
+    derive_turn_journal_states,
+    read_turn_journal,
+)
+
+
+def _write_session(session_dir, sid, messages=None):
+    payload = {
+        "session_id": sid,
+        "title": "Turn journal test",
+        "messages": messages or [],
+    }
+    (session_dir / f"{sid}.json").write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_append_turn_journal_event_fsyncs_jsonl_and_preserves_payload(tmp_path):
+    event = append_turn_journal_event(
+        "sid-1",
+        {
+            "event": "submitted",
+            "turn_id": "turn-1",
+            "stream_id": "stream-1",
+            "role": "user",
+            "content": "hello",
+            "attachments": [{"name": "a.png", "path": "/tmp/a.png"}],
+        },
+        session_dir=tmp_path,
+    )
+
+    assert event["version"] == 1
+    assert event["session_id"] == "sid-1"
+    assert event["created_at"] > 0
+    journal_path = tmp_path / "_turn_journal" / "sid-1.jsonl"
+    assert journal_path.exists()
+    lines = journal_path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    assert json.loads(lines[0])["content"] == "hello"
+
+
+def test_read_turn_journal_tolerates_malformed_lines(tmp_path):
+    journal_dir = tmp_path / "_turn_journal"
+    journal_dir.mkdir()
+    (journal_dir / "sid-1.jsonl").write_text(
+        '{"event":"submitted","turn_id":"turn-1","session_id":"sid-1"}\n'
+        'not-json\n'
+        '{"event":"completed","turn_id":"turn-1","session_id":"sid-1"}\n',
+        encoding="utf-8",
+    )
+
+    result = read_turn_journal("sid-1", session_dir=tmp_path)
+
+    assert [event["event"] for event in result["events"]] == ["submitted", "completed"]
+    assert result["malformed"] == [{"line": 2, "raw": "not-json"}]
+
+
+def test_derive_turn_journal_states_keeps_latest_event_per_turn():
+    states = derive_turn_journal_states([
+        {"event": "submitted", "turn_id": "turn-1", "created_at": 1},
+        {"event": "worker_started", "turn_id": "turn-1", "created_at": 2},
+        {"event": "submitted", "turn_id": "turn-2", "created_at": 3},
+        {"event": "completed", "turn_id": "turn-1", "created_at": 4},
+    ])
+
+    assert states["turn-1"]["event"] == "completed"
+    assert states["turn-2"]["event"] == "submitted"
+
+
+def test_audit_reports_pending_turn_journal_entry_when_user_message_absent(tmp_path):
+    _write_session(tmp_path, "sid-1", messages=[])
+    append_turn_journal_event(
+        "sid-1",
+        {
+            "event": "submitted",
+            "turn_id": "turn-1",
+            "stream_id": "stream-1",
+            "role": "user",
+            "content": "recover me",
+            "attachments": [],
+        },
+        session_dir=tmp_path,
+    )
+
+    report = audit_session_recovery(tmp_path)
+
+    assert report["status"] == "warn"
+    assert report["summary"]["repairable"] == 1
+    assert report["items"] == [
+        {
+            "session_id": "sid-1",
+            "kind": "turn_journal_pending_turn",
+            "category": "repairable",
+            "recommendation": "audit_only_pending_turn_journal",
+            "live_messages": 0,
+            "bak_messages": -1,
+            "turn_id": "turn-1",
+            "event": "submitted",
+        }
+    ]
+
+
+def test_audit_ignores_completed_or_already_materialized_turn_journal_entry(tmp_path):
+    _write_session(tmp_path, "sid-1", messages=[{"role": "user", "content": "already there"}])
+    append_turn_journal_event(
+        "sid-1",
+        {
+            "event": "submitted",
+            "turn_id": "turn-1",
+            "role": "user",
+            "content": "already there",
+        },
+        session_dir=tmp_path,
+    )
+    append_turn_journal_event(
+        "sid-1",
+        {"event": "completed", "turn_id": "turn-1"},
+        session_dir=tmp_path,
+    )
+
+    report = audit_session_recovery(tmp_path)
+
+    assert report["status"] == "ok"
+    assert report["items"] == []

--- a/tests/test_turn_journal_callsite.py
+++ b/tests/test_turn_journal_callsite.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+
+
+def test_chat_start_appends_submitted_turn_journal_before_worker_thread_start():
+    src = Path("api/routes.py").read_text(encoding="utf-8")
+    save_idx = src.index("_prepare_chat_start_session_for_stream(")
+    append_idx = src.index("append_turn_journal_event(", save_idx)
+    thread_idx = src.index("threading.Thread(", append_idx)
+
+    assert save_idx < append_idx < thread_idx
+    assert '"event": "submitted"' in src[append_idx:thread_idx]
+    assert '"role": "user"' in src[append_idx:thread_idx]

--- a/tests/test_turn_journal_callsite.py
+++ b/tests/test_turn_journal_callsite.py
@@ -10,3 +10,16 @@ def test_chat_start_appends_submitted_turn_journal_before_worker_thread_start():
     assert save_idx < append_idx < thread_idx
     assert '"event": "submitted"' in src[append_idx:thread_idx]
     assert '"role": "user"' in src[append_idx:thread_idx]
+
+
+def test_chat_start_writes_turn_journal_after_session_lock_and_handles_failure():
+    src = Path("api/routes.py").read_text(encoding="utf-8")
+    lock_idx = src.index("with session_lock:")
+    append_idx = src.index("append_turn_journal_event(", lock_idx)
+    stream_registration_idx = src.index("STREAMS[stream_id] = stream", append_idx)
+    lock_block = src[lock_idx:append_idx]
+    append_block = src[append_idx:stream_registration_idx]
+
+    assert "append_turn_journal_event(" not in lock_block
+    assert "except Exception:" in append_block
+    assert "Failed to append submitted turn journal event" in append_block


### PR DESCRIPTION
## Summary
- Add an append-only WebUI turn journal helper that writes one JSONL file per session under `_turn_journal/` and fsyncs submitted-turn events before the worker thread starts.
- Wire `/api/chat/start` to append a `submitted` event after pending session state is saved and before `threading.Thread(...)` starts.
- Extend read-only recovery audit to report non-terminal journal turns as `turn_journal_pending_turn` when the submitted user message is not present in the sidecar.

## Context
Follow-up to the Turn Journal RFC shipped in v0.51.42: https://github.com/nesquena/hermes-webui/pull/2042#issuecomment-4417261718

This is intentionally the minimal implementation slice from `docs/rfcs/turn-journal.md`: writer + reader + state derivation + audit-only reporting. It does **not** replay or repair journal events yet. No tiny WAL goblin with write access. Yet.

## Test Plan
- RED observed first: `tests/test_turn_journal.py` initially failed with `ModuleNotFoundError: No module named 'api.turn_journal'`.
- RED observed first: `tests/test_turn_journal_callsite.py` initially failed because `append_turn_journal_event(` was absent from `api/routes.py`.
- `python -m pytest tests/test_turn_journal.py tests/test_turn_journal_callsite.py tests/test_session_recovery_audit.py tests/test_session_recovery_api.py -q -o 'addopts='`
- `python -m py_compile api/turn_journal.py api/session_recovery.py api/routes.py`
- `git diff --check`
- added-line security scan: clean
