### PR TITLE
feat: record turn journal lifecycle events

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -6675,6 +6675,22 @@ def _start_chat_stream_for_session(
             model_provider=model_provider,
             stream_id=stream_id,
         )
+        diag.stage("turn_journal_submitted") if diag else None
+        from api.turn_journal import append_turn_journal_event
+        journal_event = append_turn_journal_event(
+            s.session_id,
+            {
+                "event": "submitted",
+                "stream_id": stream_id,
+                "role": "user",
+                "content": msg,
+                "attachments": attachments,
+                "workspace": workspace,
+                "model": model,
+                "model_provider": model_provider,
+                "created_at": s.pending_started_at,
+            },
+        )
     diag.stage("set_last_workspace") if diag else None
     set_last_workspace(workspace)
     diag.stage("stream_registration") if diag else None
@@ -6696,6 +6712,7 @@ def _start_chat_stream_for_session(
         "stream_id": stream_id,
         "session_id": s.session_id,
         "pending_started_at": s.pending_started_at,
+        "turn_id": journal_event.get("turn_id"),
     }
     if normalized_model:
         response["effective_model"] = model

--- a/api/routes.py
+++ b/api/routes.py
@@ -6675,7 +6675,9 @@ def _start_chat_stream_for_session(
             model_provider=model_provider,
             stream_id=stream_id,
         )
-        diag.stage("turn_journal_submitted") if diag else None
+    diag.stage("turn_journal_submitted") if diag else None
+    journal_event = {}
+    try:
         from api.turn_journal import append_turn_journal_event
         journal_event = append_turn_journal_event(
             s.session_id,
@@ -6691,6 +6693,8 @@ def _start_chat_stream_for_session(
                 "created_at": s.pending_started_at,
             },
         )
+    except Exception:
+        logger.warning("Failed to append submitted turn journal event", exc_info=True)
     diag.stage("set_last_workspace") if diag else None
     set_last_workspace(workspace)
     diag.stage("stream_registration") if diag else None

--- a/api/session_recovery.py
+++ b/api/session_recovery.py
@@ -34,6 +34,13 @@ import sqlite3
 import threading
 from pathlib import Path
 
+from api.turn_journal import (
+    derive_turn_journal_states,
+    is_terminal_turn_event,
+    iter_turn_journal_session_ids,
+    read_turn_journal,
+)
+
 logger = logging.getLogger(__name__)
 
 
@@ -365,8 +372,9 @@ def _new_audit_item(
     recommendation: str,
     live_messages: int = -1,
     bak_messages: int = -1,
+    **extra,
 ) -> dict:
-    return {
+    item = {
         "session_id": session_id,
         "kind": kind,
         "category": category,
@@ -374,6 +382,8 @@ def _new_audit_item(
         "live_messages": live_messages,
         "bak_messages": bak_messages,
     }
+    item.update(extra)
+    return item
 
 
 def _read_index_session_ids(index_path: Path) -> set[str]:
@@ -468,6 +478,37 @@ def audit_session_recovery(session_dir: Path, state_db_path: Path | None = None)
             -1,
             -1,
         ))
+
+    for session_id in iter_turn_journal_session_ids(session_dir):
+        journal = read_turn_journal(session_id, session_dir=session_dir)
+        states = derive_turn_journal_states(journal.get('events') or [])
+        live_path = session_dir / f"{session_id}.json"
+        live_messages = _msg_count(live_path)
+        existing_user_messages: set[str] = set()
+        try:
+            payload = json.loads(live_path.read_text(encoding='utf-8'))
+            if isinstance(payload, dict):
+                for message in payload.get('messages') or []:
+                    if isinstance(message, dict) and message.get('role') == 'user':
+                        existing_user_messages.add(str(message.get('content') or '').strip())
+        except (OSError, json.JSONDecodeError, ValueError):
+            pass
+        for turn_id, event in sorted(states.items()):
+            if is_terminal_turn_event(event):
+                continue
+            content = str(event.get('content') or '').strip()
+            if not content or content in existing_user_messages:
+                continue
+            items.append(_new_audit_item(
+                session_id,
+                "turn_journal_pending_turn",
+                "repairable",
+                "audit_only_pending_turn_journal",
+                live_messages,
+                -1,
+                turn_id=turn_id,
+                event=str(event.get('event') or ''),
+            ))
 
     summary = {"ok": len(live_paths), "repairable": 0, "unsafe_to_repair": 0}
     for item in items:

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -3570,21 +3570,25 @@ def _run_agent_streaming(
                         # Better to leave context_length=0 than crash the save.
                         pass
                 if not ephemeral and s.messages:
-                    for _idx, _msg in enumerate(s.messages):
-                        if isinstance(_msg, dict) and _msg.get('role') == 'assistant':
-                            try:
-                                append_turn_journal_event_for_stream(
-                                    s.session_id,
-                                    stream_id,
-                                    {
-                                        "event": "assistant_started",
-                                        "created_at": float(_msg.get('timestamp') or time.time()),
-                                        "assistant_message_index": _idx,
-                                    },
-                                )
-                            except Exception:
-                                logger.debug("Failed to append assistant_started turn journal event", exc_info=True)
-                            break
+                    _latest_assistant_idx = next(
+                        (idx for idx in range(len(s.messages) - 1, -1, -1)
+                         if isinstance(s.messages[idx], dict) and s.messages[idx].get('role') == 'assistant'),
+                        None,
+                    )
+                    if _latest_assistant_idx is not None:
+                        _latest_assistant = s.messages[_latest_assistant_idx]
+                        try:
+                            append_turn_journal_event_for_stream(
+                                s.session_id,
+                                stream_id,
+                                {
+                                    "event": "assistant_started",
+                                    "created_at": float(_latest_assistant.get('timestamp') or time.time()),
+                                    "assistant_message_index": _latest_assistant_idx,
+                                },
+                            )
+                        except Exception:
+                            logger.debug("Failed to append assistant_started turn journal event", exc_info=True)
                 s.save()
                 if not ephemeral:
                     try:

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -34,6 +34,7 @@ from api.config import (
 )
 from api.helpers import redact_session_data, _redact_text
 from api.metering import meter
+from api.turn_journal import append_turn_journal_event_for_stream
 
 # Global lock for os.environ writes. Per-session locks (_agent_lock) prevent
 # concurrent runs of the SAME session, but two DIFFERENT sessions can still
@@ -2053,6 +2054,15 @@ def _run_agent_streaming(
         provider=model_provider,
         ephemeral=bool(ephemeral),
     )
+    if not ephemeral:
+        try:
+            append_turn_journal_event_for_stream(
+                session_id,
+                stream_id,
+                {"event": "worker_started", "created_at": time.time()},
+            )
+        except Exception:
+            logger.debug("Failed to append worker_started turn journal event", exc_info=True)
     s = None
     _rt = {}
     old_cwd = None
@@ -3559,7 +3569,40 @@ def _run_agent_streaming(
                         # Older hermes-agent builds may not expose this helper.
                         # Better to leave context_length=0 than crash the save.
                         pass
+                if not ephemeral and s.messages:
+                    for _idx, _msg in enumerate(s.messages):
+                        if isinstance(_msg, dict) and _msg.get('role') == 'assistant':
+                            try:
+                                append_turn_journal_event_for_stream(
+                                    s.session_id,
+                                    stream_id,
+                                    {
+                                        "event": "assistant_started",
+                                        "created_at": float(_msg.get('timestamp') or time.time()),
+                                        "assistant_message_index": _idx,
+                                    },
+                                )
+                            except Exception:
+                                logger.debug("Failed to append assistant_started turn journal event", exc_info=True)
+                            break
                 s.save()
+                if not ephemeral:
+                    try:
+                        append_turn_journal_event_for_stream(
+                            s.session_id,
+                            stream_id,
+                            {
+                                "event": "completed",
+                                "created_at": time.time(),
+                                "assistant_message_index": next(
+                                    (idx for idx in range(len(s.messages) - 1, -1, -1)
+                                     if isinstance(s.messages[idx], dict) and s.messages[idx].get('role') == 'assistant'),
+                                    None,
+                                ),
+                            },
+                        )
+                    except Exception:
+                        logger.debug("Failed to append completed turn journal event", exc_info=True)
             # Sync to state.db for /insights (opt-in setting)
             try:
                 from api.config import load_settings as _load_settings
@@ -3929,6 +3972,19 @@ def _run_agent_streaming(
                     s.save()
                 except Exception:
                     pass
+                if not ephemeral:
+                    try:
+                        append_turn_journal_event_for_stream(
+                            s.session_id,
+                            stream_id,
+                            {
+                                "event": "interrupted",
+                                "created_at": time.time(),
+                                "reason": _exc_type,
+                            },
+                        )
+                    except Exception:
+                        logger.debug("Failed to append interrupted turn journal event", exc_info=True)
         put('apperror', _error_payload)
     finally:
         # Stop the periodic checkpoint thread before the final recovery path.

--- a/api/turn_journal.py
+++ b/api/turn_journal.py
@@ -119,6 +119,40 @@ def derive_turn_journal_states(events: Iterable[dict]) -> dict[str, dict]:
     return states
 
 
+def _latest_turn_id_for_stream(events: Iterable[dict], stream_id: str) -> str | None:
+    stream = str(stream_id or "").strip()
+    if not stream:
+        return None
+    latest: str | None = None
+    for event in events:
+        if not isinstance(event, dict):
+            continue
+        if str(event.get("stream_id") or "") != stream:
+            continue
+        turn_id = str(event.get("turn_id") or "").strip()
+        if turn_id:
+            latest = turn_id
+    return latest
+
+
+def append_turn_journal_event_for_stream(
+    session_id: str,
+    stream_id: str,
+    event: dict,
+    *,
+    session_dir: Path | None = None,
+) -> dict:
+    """Append a lifecycle event for the turn associated with ``stream_id``."""
+    payload = dict(event)
+    payload["stream_id"] = str(stream_id)
+    if not payload.get("turn_id"):
+        journal = read_turn_journal(session_id, session_dir=session_dir)
+        turn_id = _latest_turn_id_for_stream(journal.get("events") or [], stream_id)
+        if turn_id:
+            payload["turn_id"] = turn_id
+    return append_turn_journal_event(session_id, payload, session_dir=session_dir)
+
+
 def iter_turn_journal_session_ids(session_dir: Path) -> list[str]:
     journal_dir = Path(session_dir) / TURN_JOURNAL_DIR_NAME
     if not journal_dir.exists():

--- a/api/turn_journal.py
+++ b/api/turn_journal.py
@@ -63,14 +63,10 @@ def append_turn_journal_event(
     path.parent.mkdir(parents=True, exist_ok=True)
     line = json.dumps(payload, ensure_ascii=False, separators=(",", ":")) + "\n"
     fd = os.open(path, os.O_CREAT | os.O_APPEND | os.O_WRONLY, 0o600)
-    try:
-        with os.fdopen(fd, "a", encoding="utf-8") as fh:
-            fh.write(line)
-            fh.flush()
-            os.fsync(fh.fileno())
-    finally:
-        # fd ownership moves to fdopen(); this finally exists only for clarity.
-        pass
+    with os.fdopen(fd, "a", encoding="utf-8") as fh:
+        fh.write(line)
+        fh.flush()
+        os.fsync(fh.fileno())
     try:
         dir_fd = os.open(path.parent, os.O_DIRECTORY)
         try:
@@ -115,7 +111,9 @@ def derive_turn_journal_states(events: Iterable[dict]) -> dict[str, dict]:
         turn_id = str(event.get("turn_id") or "").strip()
         if not turn_id:
             continue
-        states[turn_id] = event
+        previous = states.get(turn_id)
+        if previous is None or float(event.get("created_at") or 0) >= float(previous.get("created_at") or 0):
+            states[turn_id] = event
     return states
 
 

--- a/api/turn_journal.py
+++ b/api/turn_journal.py
@@ -1,0 +1,130 @@
+"""Crash-safe WebUI turn journal helpers.
+
+The journal is deliberately tiny: one JSONL file per session, append-only events,
+and read helpers that tolerate malformed lines. Recovery and repair can then
+reason about submitted turns without depending on in-memory stream state.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import time
+import uuid
+from pathlib import Path
+from typing import Iterable
+
+TURN_JOURNAL_DIR_NAME = "_turn_journal"
+_TERMINAL_EVENTS = {"completed", "interrupted"}
+_SESSION_ID_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
+
+
+def _default_session_dir() -> Path:
+    from api.models import SESSION_DIR
+
+    return Path(SESSION_DIR)
+
+
+def _journal_path(session_id: str, session_dir: Path | None = None) -> Path:
+    sid = str(session_id or "").strip()
+    if not sid or "/" in sid or "\\" in sid or not _SESSION_ID_RE.fullmatch(sid):
+        raise ValueError("invalid session_id")
+    root = Path(session_dir) if session_dir is not None else _default_session_dir()
+    return root / TURN_JOURNAL_DIR_NAME / f"{sid}.jsonl"
+
+
+def _make_turn_id() -> str:
+    return f"{time.strftime('%Y%m%dT%H%M%SZ', time.gmtime())}-{uuid.uuid4().hex[:12]}"
+
+
+def append_turn_journal_event(
+    session_id: str,
+    event: dict,
+    *,
+    session_dir: Path | None = None,
+) -> dict:
+    """Append one turn journal event and fsync it before returning.
+
+    The returned event is the exact payload written, with default ``version``,
+    ``session_id``, ``turn_id``, and ``created_at`` fields filled in.
+    """
+    if not isinstance(event, dict):
+        raise TypeError("event must be a dict")
+    event_name = str(event.get("event") or "").strip()
+    if not event_name:
+        raise ValueError("event is required")
+    payload = dict(event)
+    payload.setdefault("version", 1)
+    payload["session_id"] = str(session_id)
+    payload.setdefault("turn_id", _make_turn_id())
+    payload.setdefault("created_at", time.time())
+
+    path = _journal_path(session_id, session_dir=session_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    line = json.dumps(payload, ensure_ascii=False, separators=(",", ":")) + "\n"
+    fd = os.open(path, os.O_CREAT | os.O_APPEND | os.O_WRONLY, 0o600)
+    try:
+        with os.fdopen(fd, "a", encoding="utf-8") as fh:
+            fh.write(line)
+            fh.flush()
+            os.fsync(fh.fileno())
+    finally:
+        # fd ownership moves to fdopen(); this finally exists only for clarity.
+        pass
+    try:
+        dir_fd = os.open(path.parent, os.O_DIRECTORY)
+        try:
+            os.fsync(dir_fd)
+        finally:
+            os.close(dir_fd)
+    except OSError:
+        pass
+    return payload
+
+
+def read_turn_journal(session_id: str, *, session_dir: Path | None = None) -> dict:
+    """Read a session journal, returning valid events plus malformed lines."""
+    path = _journal_path(session_id, session_dir=session_dir)
+    events: list[dict] = []
+    malformed: list[dict] = []
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except FileNotFoundError:
+        return {"session_id": str(session_id), "events": [], "malformed": []}
+    for line_no, raw in enumerate(lines, start=1):
+        if not raw.strip():
+            continue
+        try:
+            event = json.loads(raw)
+        except json.JSONDecodeError:
+            malformed.append({"line": line_no, "raw": raw})
+            continue
+        if isinstance(event, dict):
+            events.append(event)
+        else:
+            malformed.append({"line": line_no, "raw": raw})
+    return {"session_id": str(session_id), "events": events, "malformed": malformed}
+
+
+def derive_turn_journal_states(events: Iterable[dict]) -> dict[str, dict]:
+    """Return the latest event per ``turn_id``."""
+    states: dict[str, dict] = {}
+    for event in events:
+        if not isinstance(event, dict):
+            continue
+        turn_id = str(event.get("turn_id") or "").strip()
+        if not turn_id:
+            continue
+        states[turn_id] = event
+    return states
+
+
+def iter_turn_journal_session_ids(session_dir: Path) -> list[str]:
+    journal_dir = Path(session_dir) / TURN_JOURNAL_DIR_NAME
+    if not journal_dir.exists():
+        return []
+    return sorted(path.stem for path in journal_dir.glob("*.jsonl") if path.is_file())
+
+
+def is_terminal_turn_event(event: dict) -> bool:
+    return str((event or {}).get("event") or "") in _TERMINAL_EVENTS

--- a/tests/test_pr1341_context_window_persistence.py
+++ b/tests/test_pr1341_context_window_persistence.py
@@ -38,12 +38,11 @@ def test_streaming_persists_context_fields_on_session_before_save():
     # Save call follows shortly after
     save_call = src.find("\n                s.save()", block_start)
     assert save_call != -1, "s.save() not found after the post-merge marker"
-    # Limit bumped to 7000 in #1896 fix — the context_length fallback grew to
-    # accept config_context_length / provider / custom_providers kwargs and a
-    # legacy 2-arg fallback for older hermes-agent builds. The block is still
-    # focused: it's a single fallback resolver call with arg-prep scaffold and
-    # commentary explaining the failure mode it prevents.
-    assert save_call - block_start < 7000, (
+    # Limit bumped to 8200 by turn-journal lifecycle events: the block now also
+    # records `assistant_started` immediately before the durable final save.
+    # The context_length fallback is still a single focused resolver call with
+    # arg-prep scaffold and commentary explaining the failure mode it prevents.
+    assert save_call - block_start < 8200, (
         "s.save() should be close to the post-merge marker — block expanded unexpectedly. "
         "If you've added a new pre-save mutation block here, bump this limit."
     )

--- a/tests/test_turn_journal.py
+++ b/tests/test_turn_journal.py
@@ -69,6 +69,15 @@ def test_derive_turn_journal_states_keeps_latest_event_per_turn():
     assert states["turn-2"]["event"] == "submitted"
 
 
+def test_derive_turn_journal_states_uses_created_at_not_file_order():
+    states = derive_turn_journal_states([
+        {"event": "completed", "turn_id": "turn-1", "created_at": 20},
+        {"event": "submitted", "turn_id": "turn-1", "created_at": 10},
+    ])
+
+    assert states["turn-1"]["event"] == "completed"
+
+
 def test_audit_reports_pending_turn_journal_entry_when_user_message_absent(tmp_path):
     _write_session(tmp_path, "sid-1", messages=[])
     append_turn_journal_event(

--- a/tests/test_turn_journal.py
+++ b/tests/test_turn_journal.py
@@ -1,0 +1,126 @@
+import json
+
+from api.session_recovery import audit_session_recovery
+from api.turn_journal import (
+    append_turn_journal_event,
+    derive_turn_journal_states,
+    read_turn_journal,
+)
+
+
+def _write_session(session_dir, sid, messages=None):
+    payload = {
+        "session_id": sid,
+        "title": "Turn journal test",
+        "messages": messages or [],
+    }
+    (session_dir / f"{sid}.json").write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_append_turn_journal_event_fsyncs_jsonl_and_preserves_payload(tmp_path):
+    event = append_turn_journal_event(
+        "sid-1",
+        {
+            "event": "submitted",
+            "turn_id": "turn-1",
+            "stream_id": "stream-1",
+            "role": "user",
+            "content": "hello",
+            "attachments": [{"name": "a.png", "path": "/tmp/a.png"}],
+        },
+        session_dir=tmp_path,
+    )
+
+    assert event["version"] == 1
+    assert event["session_id"] == "sid-1"
+    assert event["created_at"] > 0
+    journal_path = tmp_path / "_turn_journal" / "sid-1.jsonl"
+    assert journal_path.exists()
+    lines = journal_path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    assert json.loads(lines[0])["content"] == "hello"
+
+
+def test_read_turn_journal_tolerates_malformed_lines(tmp_path):
+    journal_dir = tmp_path / "_turn_journal"
+    journal_dir.mkdir()
+    (journal_dir / "sid-1.jsonl").write_text(
+        '{"event":"submitted","turn_id":"turn-1","session_id":"sid-1"}\n'
+        'not-json\n'
+        '{"event":"completed","turn_id":"turn-1","session_id":"sid-1"}\n',
+        encoding="utf-8",
+    )
+
+    result = read_turn_journal("sid-1", session_dir=tmp_path)
+
+    assert [event["event"] for event in result["events"]] == ["submitted", "completed"]
+    assert result["malformed"] == [{"line": 2, "raw": "not-json"}]
+
+
+def test_derive_turn_journal_states_keeps_latest_event_per_turn():
+    states = derive_turn_journal_states([
+        {"event": "submitted", "turn_id": "turn-1", "created_at": 1},
+        {"event": "worker_started", "turn_id": "turn-1", "created_at": 2},
+        {"event": "submitted", "turn_id": "turn-2", "created_at": 3},
+        {"event": "completed", "turn_id": "turn-1", "created_at": 4},
+    ])
+
+    assert states["turn-1"]["event"] == "completed"
+    assert states["turn-2"]["event"] == "submitted"
+
+
+def test_audit_reports_pending_turn_journal_entry_when_user_message_absent(tmp_path):
+    _write_session(tmp_path, "sid-1", messages=[])
+    append_turn_journal_event(
+        "sid-1",
+        {
+            "event": "submitted",
+            "turn_id": "turn-1",
+            "stream_id": "stream-1",
+            "role": "user",
+            "content": "recover me",
+            "attachments": [],
+        },
+        session_dir=tmp_path,
+    )
+
+    report = audit_session_recovery(tmp_path)
+
+    assert report["status"] == "warn"
+    assert report["summary"]["repairable"] == 1
+    assert report["items"] == [
+        {
+            "session_id": "sid-1",
+            "kind": "turn_journal_pending_turn",
+            "category": "repairable",
+            "recommendation": "audit_only_pending_turn_journal",
+            "live_messages": 0,
+            "bak_messages": -1,
+            "turn_id": "turn-1",
+            "event": "submitted",
+        }
+    ]
+
+
+def test_audit_ignores_completed_or_already_materialized_turn_journal_entry(tmp_path):
+    _write_session(tmp_path, "sid-1", messages=[{"role": "user", "content": "already there"}])
+    append_turn_journal_event(
+        "sid-1",
+        {
+            "event": "submitted",
+            "turn_id": "turn-1",
+            "role": "user",
+            "content": "already there",
+        },
+        session_dir=tmp_path,
+    )
+    append_turn_journal_event(
+        "sid-1",
+        {"event": "completed", "turn_id": "turn-1"},
+        session_dir=tmp_path,
+    )
+
+    report = audit_session_recovery(tmp_path)
+
+    assert report["status"] == "ok"
+    assert report["items"] == []

--- a/tests/test_turn_journal_callsite.py
+++ b/tests/test_turn_journal_callsite.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+
+
+def test_chat_start_appends_submitted_turn_journal_before_worker_thread_start():
+    src = Path("api/routes.py").read_text(encoding="utf-8")
+    save_idx = src.index("_prepare_chat_start_session_for_stream(")
+    append_idx = src.index("append_turn_journal_event(", save_idx)
+    thread_idx = src.index("threading.Thread(", append_idx)
+
+    assert save_idx < append_idx < thread_idx
+    assert '"event": "submitted"' in src[append_idx:thread_idx]
+    assert '"role": "user"' in src[append_idx:thread_idx]

--- a/tests/test_turn_journal_callsite.py
+++ b/tests/test_turn_journal_callsite.py
@@ -10,3 +10,16 @@ def test_chat_start_appends_submitted_turn_journal_before_worker_thread_start():
     assert save_idx < append_idx < thread_idx
     assert '"event": "submitted"' in src[append_idx:thread_idx]
     assert '"role": "user"' in src[append_idx:thread_idx]
+
+
+def test_chat_start_writes_turn_journal_after_session_lock_and_handles_failure():
+    src = Path("api/routes.py").read_text(encoding="utf-8")
+    lock_idx = src.index("with session_lock:")
+    append_idx = src.index("append_turn_journal_event(", lock_idx)
+    stream_registration_idx = src.index("STREAMS[stream_id] = stream", append_idx)
+    lock_block = src[lock_idx:append_idx]
+    append_block = src[append_idx:stream_registration_idx]
+
+    assert "append_turn_journal_event(" not in lock_block
+    assert "except Exception:" in append_block
+    assert "Failed to append submitted turn journal event" in append_block

--- a/tests/test_turn_journal_lifecycle.py
+++ b/tests/test_turn_journal_lifecycle.py
@@ -1,0 +1,38 @@
+from api.turn_journal import (
+    append_turn_journal_event,
+    append_turn_journal_event_for_stream,
+    derive_turn_journal_states,
+)
+
+
+def test_append_turn_journal_event_for_stream_reuses_submitted_turn_id(tmp_path):
+    submitted = append_turn_journal_event(
+        "sid-1",
+        {"event": "submitted", "turn_id": "turn-1", "stream_id": "stream-1", "content": "hello"},
+        session_dir=tmp_path,
+    )
+
+    worker = append_turn_journal_event_for_stream(
+        "sid-1",
+        "stream-1",
+        {"event": "worker_started"},
+        session_dir=tmp_path,
+    )
+
+    assert submitted["turn_id"] == "turn-1"
+    assert worker["turn_id"] == "turn-1"
+    states = derive_turn_journal_states([submitted, worker])
+    assert states["turn-1"]["event"] == "worker_started"
+
+
+def test_append_turn_journal_event_for_stream_falls_back_to_new_turn_for_missing_stream(tmp_path):
+    event = append_turn_journal_event_for_stream(
+        "sid-1",
+        "stream-missing",
+        {"event": "interrupted", "reason": "no submitted event found"},
+        session_dir=tmp_path,
+    )
+
+    assert event["stream_id"] == "stream-missing"
+    assert event["turn_id"]
+    assert event["event"] == "interrupted"

--- a/tests/test_turn_journal_lifecycle_callsite.py
+++ b/tests/test_turn_journal_lifecycle_callsite.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+
+def test_streaming_appends_worker_started_before_running_phase():
+    src = Path("api/streaming.py").read_text(encoding="utf-8")
+    run_idx = src.index("def _run_agent_streaming(")
+    worker_idx = src.index('"event": "worker_started"', run_idx)
+    running_idx = src.index('update_active_run(stream_id, phase="running"', run_idx)
+
+    assert worker_idx < running_idx
+
+
+def test_streaming_appends_assistant_started_before_final_save():
+    src = Path("api/streaming.py").read_text(encoding="utf-8")
+    block_idx = src.index("if not ephemeral and s.messages:")
+    assistant_idx = src.index('"event": "assistant_started"', block_idx)
+    save_idx = src.index("s.save()", assistant_idx)
+
+    assert block_idx < assistant_idx < save_idx
+
+
+def test_streaming_appends_completed_after_final_save():
+    src = Path("api/streaming.py").read_text(encoding="utf-8")
+    assistant_idx = src.index('"event": "assistant_started"')
+    save_idx = src.index("s.save()", assistant_idx)
+    completed_idx = src.index('"event": "completed"', save_idx)
+
+    assert save_idx < completed_idx
+
+
+def test_streaming_appends_interrupted_on_provider_error_path():
+    src = Path("api/streaming.py").read_text(encoding="utf-8")
+    err_idx = src.index("err_str = str(e)")
+    interrupted_idx = src.index('"event": "interrupted"', err_idx)
+    apperror_idx = src.index("put('apperror'", interrupted_idx)
+
+    assert err_idx < interrupted_idx < apperror_idx

--- a/tests/test_turn_journal_lifecycle_callsite.py
+++ b/tests/test_turn_journal_lifecycle_callsite.py
@@ -19,6 +19,16 @@ def test_streaming_appends_assistant_started_before_final_save():
     assert block_idx < assistant_idx < save_idx
 
 
+def test_streaming_assistant_started_uses_latest_assistant_message():
+    src = Path("api/streaming.py").read_text(encoding="utf-8")
+    block_idx = src.index("if not ephemeral and s.messages:")
+    assistant_idx = src.index('"event": "assistant_started"', block_idx)
+    block = src[block_idx:assistant_idx]
+
+    assert "range(len(s.messages) - 1, -1, -1)" in block
+    assert '"assistant_message_index": _latest_assistant_idx' in src[assistant_idx:src.index("s.save()", assistant_idx)]
+
+
 def test_streaming_appends_completed_after_final_save():
     src = Path("api/streaming.py").read_text(encoding="utf-8")
     assistant_idx = src.index('"event": "assistant_started"')


### PR DESCRIPTION
## Summary
- Add turn-journal lifecycle events on top of #2059's submitted-event writer.
- Record `worker_started` when the streaming worker begins, `assistant_started` before the final session save once an assistant message exists, `completed` after the final save, and `interrupted` on the provider-error path.
- Add `append_turn_journal_event_for_stream(...)` so lifecycle events reuse the `turn_id` associated with the stream's submitted event.

## Stack
Builds on #2059. Until #2059 lands, GitHub will show the writer commit in this PR diff too; the new commit is `feat: record turn journal lifecycle events`.

## Scope
Still audit-only / journaling-only. This does not replay turns, repair assistant output, or invent missing model responses. The little WAL goblin remains on a leash.

## Test Plan
- RED observed first: lifecycle helper import failed before `append_turn_journal_event_for_stream` existed.
- RED observed first: streaming callsite tests failed until lifecycle events were placed in `api/streaming.py`.
- `python -m pytest tests/test_turn_journal.py tests/test_turn_journal_callsite.py tests/test_turn_journal_lifecycle.py tests/test_turn_journal_lifecycle_callsite.py tests/test_session_recovery_audit.py tests/test_session_recovery_api.py -q -o 'addopts='`
- `python -m py_compile api/turn_journal.py api/session_recovery.py api/routes.py api/streaming.py`
- `git diff --check`
- added-line security scan: clean
