### PR TITLE
Fix session recovery polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Session recovery polish for #2050: audit now reports WebUI `state.db` rows with missing sidecars and no readable messages as `state_db_orphan_webui_row` / `unsafe_to_repair` instead of silently dropping them, `repair_safe_session_recovery()` exposes an explicit `clean` flag while preserving `ok` for compatibility, `/api/session/recovery/repair-safe` keys its 200/409 status off `clean`, and `MEDIA_ALLOWED_ROOTS` now splits on `os.pathsep` instead of a hard-coded colon.
+
 ## [v0.51.44] — 2026-05-11 — Release T (5-PR contributor batch — security + worktree sessions + LM Studio + onboarding docs + transcript dedup, plus comprehensive test-suite network isolation)
 
 ### Added

--- a/api/routes.py
+++ b/api/routes.py
@@ -3823,7 +3823,7 @@ def handle_post(handler, parsed) -> bool:
     if parsed.path == "/api/session/recovery/repair-safe":
         from api.session_recovery import repair_safe_session_recovery
         result = repair_safe_session_recovery(SESSION_DIR, state_db_path=_active_state_db_path())
-        return j(handler, result, status=200 if result.get("ok") else 409)
+        return j(handler, result, status=200 if result.get("clean") else 409)
 
     if parsed.path.startswith("/api/kanban/"):
         from api.kanban_bridge import handle_kanban_post
@@ -5607,7 +5607,7 @@ def _handle_media(handler, parsed):
     - SVG always served as attachment (XSS risk)
     - No path traversal: resolved path must stay within an allowed root
     - Additional roots can be added via MEDIA_ALLOWED_ROOTS env var
-      (colon-separated list of absolute paths)
+      (os.pathsep-separated list of absolute paths; ":" on POSIX, ";" on Windows)
     """
     import os as _os
     from api.auth import is_auth_enabled, parse_cookie, verify_session
@@ -5653,10 +5653,10 @@ def _handle_media(handler, parsed):
         pass
 
     # Also allow additional roots from MEDIA_ALLOWED_ROOTS env var
-    # (colon-separated list of absolute paths, e.g. /home/user/models:/home/user/Pictures)
+    # (os.pathsep-separated list; ":" on POSIX, ";" on Windows).
     extra_roots = _os.environ.get("MEDIA_ALLOWED_ROOTS", "").strip()
     if extra_roots:
-        for root in extra_roots.split(":"):
+        for root in extra_roots.split(_os.pathsep):
             root = root.strip()
             if root:
                 try:

--- a/api/session_recovery.py
+++ b/api/session_recovery.py
@@ -177,7 +177,12 @@ def _orphaned_backup_live_paths(
     return paths
 
 
-def _read_state_db_missing_sidecar_rows(session_dir: Path, state_db_path: Path | None) -> list[dict]:
+def _read_state_db_missing_sidecar_rows(
+    session_dir: Path,
+    state_db_path: Path | None,
+    *,
+    include_empty: bool = False,
+) -> list[dict]:
     """Return WebUI-origin state.db rows whose JSON sidecar is missing."""
     if state_db_path is None or not state_db_path.exists():
         return []
@@ -229,9 +234,10 @@ def _read_state_db_missing_sidecar_rows(session_dir: Path, state_db_path: Path |
                         if msg['timestamp'] is not None:
                             message['timestamp'] = msg['timestamp']
                         message_rows.append(message)
-                if not message_rows:
+                if not message_rows and not include_empty:
                     continue
                 data['messages'] = message_rows
+                data['_state_db_empty_messages'] = not message_rows
                 rows.append(data)
             return rows
     except Exception as exc:
@@ -323,6 +329,7 @@ def recover_missing_sidecars_from_state_db(session_dir: Path, state_db_path: Pat
         # Session.save() convention).
         tmp_suffix = f".json.reconcile.tmp.{os.getpid()}.{threading.current_thread().ident}"
         tmp = target.with_suffix(tmp_suffix)
+        detail_recorded = False
         try:
             tmp.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding='utf-8')
         except OSError as exc:
@@ -345,6 +352,7 @@ def recover_missing_sidecars_from_state_db(session_dir: Path, state_db_path: Pat
             pass
         except OSError as exc:
             details.append({'session_id': sid, 'materialized': False, 'error': str(exc)})
+            detail_recorded = True
         finally:
             try:
                 tmp.unlink(missing_ok=True)
@@ -353,7 +361,7 @@ def recover_missing_sidecars_from_state_db(session_dir: Path, state_db_path: Pat
         if materialized_now:
             materialized += 1
             details.append({'session_id': sid, 'materialized': True, 'messages': len(payload.get('messages') or [])})
-        elif not any(d.get('session_id') == sid for d in details[-1:]):
+        elif not detail_recorded:
             details.append({'session_id': sid, 'materialized': False, 'skipped': 'sidecar_appeared_during_reconcile'})
     return {'scanned': len(rows), 'materialized': materialized, 'details': details}
 
@@ -458,8 +466,18 @@ def audit_session_recovery(session_dir: Path, state_db_path: Path | None = None)
                 _msg_count(session_dir / f"{session_id}.json"), -1,
             ))
 
-    for row in _read_state_db_missing_sidecar_rows(session_dir, state_db_path):
+    for row in _read_state_db_missing_sidecar_rows(session_dir, state_db_path, include_empty=True):
         sid = str(row.get('id') or '')
+        if row.get('_state_db_empty_messages'):
+            items.append(_new_audit_item(
+                sid,
+                "state_db_orphan_webui_row",
+                "unsafe_to_repair",
+                "manual_review",
+                -1,
+                -1,
+            ))
+            continue
         items.append(_new_audit_item(
             sid,
             "state_db_missing_sidecar",
@@ -506,8 +524,10 @@ def repair_safe_session_recovery(session_dir: Path, state_db_path: Path | None =
     after = audit_session_recovery(session_dir, state_db_path=state_db_path)
     unsafe_remaining = int((after.get("summary") or {}).get("unsafe_to_repair") or 0)
     repairable_remaining = int((after.get("summary") or {}).get("repairable") or 0)
+    clean = unsafe_remaining == 0 and repairable_remaining == 0
     return {
-        "ok": unsafe_remaining == 0 and repairable_remaining == 0,
+        "clean": clean,
+        "ok": clean,
         "repaired": int(backup_repair.get("restored") or 0) + int(sidecar_repair.get("materialized") or 0),
         "before": before,
         "backup_repair": backup_repair,

--- a/tests/test_media_inline.py
+++ b/tests/test_media_inline.py
@@ -241,6 +241,14 @@ class TestMediaEndpointUnit(unittest.TestCase):
         self.assertIn("MEDIA_ALLOWED_ROOTS", routes_src,
                       "MEDIA_ALLOWED_ROOTS env var must be parsed in _handle_media")
 
+    def test_media_allowed_roots_uses_os_pathsep(self):
+        """MEDIA_ALLOWED_ROOTS must use the platform path separator."""
+        routes_src = (REPO_ROOT / "api" / "routes.py").read_text(encoding="utf-8")
+        start = routes_src.index("extra_roots =")
+        block = routes_src[start:start + 900]
+        self.assertIn(".split(_os.pathsep)", block)
+        self.assertNotIn('.split(":")', block)
+
     def test_media_endpoints_advertise_byte_range_support(self):
         routes_src = (REPO_ROOT / "api" / "routes.py").read_text(encoding="utf-8")
         self.assertIn("Accept-Ranges", routes_src)

--- a/tests/test_session_db_sidecar_reconciliation.py
+++ b/tests/test_session_db_sidecar_reconciliation.py
@@ -69,6 +69,29 @@ def test_audit_reports_state_db_row_missing_sidecar(tmp_path):
     )
 
 
+def test_empty_state_db_webui_row_is_unsafe_not_materialized(tmp_path):
+    sid = _make_state_db(tmp_path / "state.db", sid="empty_state_row", messages=0)
+
+    audit = audit_session_recovery(tmp_path, state_db_path=tmp_path / "state.db")
+
+    assert any(
+        item["session_id"] == sid
+        and item["kind"] == "state_db_orphan_webui_row"
+        and item["category"] == "unsafe_to_repair"
+        and item["recommendation"] == "manual_review"
+        for item in audit["items"]
+    )
+    assert not any(
+        item["session_id"] == sid and item["kind"] == "state_db_missing_sidecar"
+        for item in audit["items"]
+    )
+
+    result = recover_missing_sidecars_from_state_db(tmp_path, tmp_path / "state.db")
+
+    assert result["materialized"] == 0
+    assert not (tmp_path / f"{sid}.json").exists()
+
+
 def test_materialized_sidecar_round_trips_through_session_load(tmp_path, monkeypatch):
     """Schema parity guard: a materialized sidecar must be readable by Session.load
     and the resulting Session must have the same messages we put in state.db.

--- a/tests/test_session_recovery_api.py
+++ b/tests/test_session_recovery_api.py
@@ -27,6 +27,7 @@ def test_repair_safe_session_recovery_restores_backup_and_rebuilds_index(tmp_pat
 
     result = repair_safe_session_recovery(tmp_path)
 
+    assert result["clean"] is True
     assert result["ok"] is True
     assert result["repaired"] == 1
     assert live.exists()
@@ -50,10 +51,19 @@ def test_repair_safe_session_recovery_leaves_unsafe_orphan_for_manual_review(tmp
 
     result = repair_safe_session_recovery(tmp_path, state_db_path=db)
 
+    assert result["clean"] is False
     assert result["ok"] is False
     assert result["repaired"] == 0
     assert not live.exists()
     assert result["after"]["status"] == "needs_manual_review"
+
+
+def test_repair_safe_route_uses_clean_flag_for_status_code():
+    from pathlib import Path
+
+    src = Path("api/routes.py").read_text(encoding="utf-8")
+
+    assert 'status=200 if result.get("clean") else 409' in src
 
 
 def test_recovery_audit_routes_are_registered():


### PR DESCRIPTION
## Thinking Path

Issue #2050 collects four low-severity follow-ups from the v0.51.42 Opus review. The important boundary is to keep the existing safe-repair behavior: materialize only state.db rows with readable messages, but make unrecoverable rows visible to operators instead of silently dropping them.

## What Changed

- Audit now reports missing-sidecar WebUI state.db rows with no readable messages as `state_db_orphan_webui_row` / `unsafe_to_repair` / `manual_review`.
- State.db sidecar materialization still skips those empty rows, so no blank shell sidecars are created.
- `repair_safe_session_recovery()` now returns an explicit `clean` flag while preserving `ok` for compatibility.
- `/api/session/recovery/repair-safe` keys its 200/409 response status off `clean`, making 409 mean “the audit still has findings,” not “the repair code failed.”
- `MEDIA_ALLOWED_ROOTS` now splits on `os.pathsep` instead of a hard-coded colon, so POSIX keeps `:` and Windows gets `;`.
- Replaced the one-element `details[-1:]` guard with an explicit local detail-recorded flag.
- Added regression coverage and an Unreleased changelog entry.

## Verification

- `python3 -m pytest -q ...` first failed with the new red tests before the implementation.
- `/Users/xuefusong/hermes-webui/.venv_test/bin/python -m pytest -q tests/test_session_db_sidecar_reconciliation.py tests/test_session_recovery_api.py tests/test_session_recovery_audit.py tests/test_state_db_worktree_recovery.py tests/test_media_inline.py::TestMediaEndpointUnit tests/test_issue1800_file_html_interactions.py`
- `/Users/xuefusong/hermes-webui/.venv_test/bin/python -m py_compile api/session_recovery.py api/routes.py`
- `git diff --check`

## Risks

Low. The repair behavior stays conservative: empty-message state.db rows are surfaced for manual review but are not materialized. The existing `ok` response key remains present for compatibility; `clean` is the clearer status key for new callers. No UI behavior changes.

## Model Used

OpenAI GPT-5 Codex assisted with the implementation and tests.

Closes #2050