### PR TITLE
test: tighten CI and console hygiene

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pyyaml>=6.0 pytest pytest-timeout pytest-asyncio
+          pip install "pyyaml>=6.0" pytest pytest-timeout pytest-asyncio
           # Install the `mcp` package so tests/test_mcp_server.py runs in CI.
           # The package is an optional runtime dep of mcp_server.py — users
           # who run the MCP integration install it themselves; CI installs

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    integration: tests that hit the live test server or external integration surface

--- a/static/ui.js
+++ b/static/ui.js
@@ -906,7 +906,7 @@ async function _fetchLiveModels(provider, sel){
     const added=_addLiveModelsToSelect(provider,data.models,sel);
     if(added>0){
       if(typeof syncModelChip==='function') syncModelChip();
-      console.log('[hermes] Live models loaded for',provider+':',added,'new models added');
+      console.debug('[hermes] Live models loaded for',provider+':',added,'new models added');
     }
   }catch(e){
     console.debug('[hermes] Live model fetch failed for',provider,e.message);

--- a/tests/test_ci_hygiene.py
+++ b/tests/test_ci_hygiene.py
@@ -1,0 +1,29 @@
+"""Small hygiene regression checks for CI and frontend console noise."""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_github_actions_quotes_pyyaml_version_specifier():
+    """Unquoted `pyyaml>=6.0` is parsed by the shell as stdout redirection."""
+    workflow = ROOT / ".github" / "workflows" / "tests.yml"
+    text = workflow.read_text(encoding="utf-8")
+
+    assert '"pyyaml>=6.0"' in text or "'pyyaml>=6.0'" in text
+    assert "pip install pyyaml>=6.0" not in text
+
+
+def test_pytest_integration_marker_is_registered():
+    config = ROOT / "pytest.ini"
+    text = config.read_text(encoding="utf-8")
+
+    assert "markers" in text
+    assert "integration:" in text
+
+
+def test_live_model_success_log_is_debug_not_default_console_log():
+    ui = (ROOT / "static" / "ui.js").read_text(encoding="utf-8")
+
+    assert "console.debug('[hermes] Live models loaded" in ui
+    assert "console.log('[hermes] Live models loaded" not in ui


### PR DESCRIPTION
## Summary
- Quote the `pyyaml>=6.0` requirement in the GitHub Actions install step so the shell cannot treat `>` as stdout redirection.
- Register the existing `integration` pytest marker to avoid collection warnings.
- Keep the live-model success diagnostic, but lower it from `console.log` to `console.debug`.
- Add small static regression tests for the CI quoting, marker registration, and log-level behavior.

## Test Plan
- `env -u HERMES_WEBUI_PASSWORD TZ=UTC LANG=C.UTF-8 LC_ALL=C.UTF-8 python3 -m pytest tests/test_ci_hygiene.py -q`
- `env -u HERMES_WEBUI_PASSWORD TZ=UTC LANG=C.UTF-8 LC_ALL=C.UTF-8 python3 -m pytest --collect-only -q tests/test_onboarding_network.py`
- `env -u HERMES_WEBUI_PASSWORD TZ=UTC LANG=C.UTF-8 LC_ALL=C.UTF-8 python3 -m pytest --collect-only -q tests/`
- `python3 - <<'PY' ... yaml.safe_load('.github/workflows/tests.yml') ... PY`
- `git diff --check`
