### PR TITLE
test: allow top-level markdown docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,15 +36,14 @@ api/_version.py
 .DS_Store
 Thumbs.db
 
-# Local reference clones — never committed (except tracked design/UI-UX reference pages)
+# Local reference clones/artifacts — never committed by default.
+# Markdown docs at docs/*.md are intentionally trackable for contributor docs.
 docs/*
+!docs/*.md
 !docs/ui-ux/
 !docs/ui-ux/**
 !docs/rfcs/
 !docs/rfcs/**
-!docs/docker.md
-!docs/supervisor.md
-!docs/troubleshooting.md
 
 # Local-only PR review harness: rendering drivers, sample bank, fixtures.
 # Used by Claude during deep reviews; never shared in the repo.

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,12 @@ docs/*
 !docs/rfcs/
 !docs/rfcs/**
 
+# Local-only AI assistant context — never committed even under docs/.
+docs/AGENTS.md
+docs/CLAUDE.md
+docs/.cursorrules
+docs/.windsurfrules
+
 # Local-only PR review harness: rendering drivers, sample bank, fixtures.
 # Used by Claude during deep reviews; never shared in the repo.
 .local-review/

--- a/tests/test_docs_gitignore_policy.py
+++ b/tests/test_docs_gitignore_policy.py
@@ -1,0 +1,25 @@
+"""Regression tests for docs/ ignore policy."""
+
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _git_check_ignore(path: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "check-ignore", "-q", path],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_new_top_level_markdown_docs_are_trackable():
+    """New docs/*.md files should be visible to Git, not silently ignored."""
+    assert _git_check_ignore("docs/example-new-guide.md").returncode == 1
+
+
+def test_docs_scratch_files_remain_ignored():
+    """The broad docs/* ignore rule should still keep arbitrary scratch files out."""
+    assert _git_check_ignore("docs/local-scratch.tmp").returncode == 0

--- a/tests/test_docs_gitignore_policy.py
+++ b/tests/test_docs_gitignore_policy.py
@@ -23,3 +23,11 @@ def test_new_top_level_markdown_docs_are_trackable():
 def test_docs_scratch_files_remain_ignored():
     """The broad docs/* ignore rule should still keep arbitrary scratch files out."""
     assert _git_check_ignore("docs/local-scratch.tmp").returncode == 0
+
+
+def test_local_only_ai_context_files_remain_ignored_under_docs():
+    """Local AI assistant context files must stay out of commits under docs/."""
+    assert _git_check_ignore("docs/AGENTS.md").returncode == 0
+    assert _git_check_ignore("docs/CLAUDE.md").returncode == 0
+    assert _git_check_ignore("docs/.cursorrules").returncode == 0
+    assert _git_check_ignore("docs/.windsurfrules").returncode == 0


### PR DESCRIPTION
## Summary
- Allow new top-level Markdown docs under `docs/*.md` to be tracked instead of silently ignored by the broad `docs/*` rule.
- Keep arbitrary scratch/reference files under `docs/` ignored by default.
- Add regression tests around the intended `git check-ignore` behavior.

## Test Plan
- `env -u HERMES_WEBUI_PASSWORD TZ=UTC LANG=C.UTF-8 LC_ALL=C.UTF-8 python3 -m pytest tests/test_docs_gitignore_policy.py -q`
- `git check-ignore -v docs/example-new-guide.md || true`
- `git check-ignore -v docs/local-scratch.tmp`
- `git diff --check`

## Notes
- No open PRs currently touch `.gitignore`.
- A reviewer subagent timed out before returning a verdict, so this PR was finalized with manual blocker review plus deterministic tests.
