### PR TITLE
Fix HERMES_HOME skill cache patching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Harmonized profile HERMES_HOME switching so process-wide switches and per-request streaming switches patch both `tools.skills_tool` and `tools.skill_manager_tool` module-level skill paths consistently (#2023).
+
 ## [v0.51.44] — 2026-05-11 — Release T (5-PR contributor batch — security + worktree sessions + LM Studio + onboarding docs + transcript dedup, plus comprehensive test-suite network isolation)
 
 ### Added

--- a/api/profiles.py
+++ b/api/profiles.py
@@ -5,14 +5,15 @@ Wraps hermes_cli.profiles to provide profile switching for the web UI.
 The web UI maintains a process-level "active profile" that determines which
 HERMES_HOME directory is used for config, skills, memory, cron, and API keys.
 Profile switches update os.environ['HERMES_HOME'] and monkey-patch module-level
-cached paths in hermes-agent modules (skills_tool, cron/jobs) that snapshot
-HERMES_HOME at import time.
+cached paths in hermes-agent modules (skills_tool, skill_manager_tool,
+cron/jobs) that snapshot HERMES_HOME at import time.
 """
 import json
 import logging
 import os
 import re
 import shutil
+import sys
 import threading
 from pathlib import Path
 
@@ -36,6 +37,22 @@ _loaded_profile_env_keys: set[str] = set()
 # reads its own profile from the hermes_profile cookie instead of the
 # process-global _active_profile.
 _tls = threading.local()
+
+_SKILL_HOME_MODULES = ("tools.skills_tool", "tools.skill_manager_tool")
+
+
+def _patch_skill_home_modules(home: Path) -> None:
+    """Patch imported skill modules that cache HERMES_HOME at import time."""
+    for module_name in _SKILL_HOME_MODULES:
+        module = sys.modules.get(module_name)
+        if module is None:
+            continue
+        try:
+            module.HERMES_HOME = home
+            module.SKILLS_DIR = home / "skills"
+        except AttributeError:
+            logger.debug("Failed to patch %s module", module_name)
+
 
 def _unwrap_profile_home_to_base(home: Path) -> Path:
     """Return the base Hermes home when *home* is already a named profile dir."""
@@ -611,13 +628,7 @@ def _set_hermes_home(home: Path):
     """Set HERMES_HOME env var and monkey-patch cached module-level paths."""
     os.environ['HERMES_HOME'] = str(home)
 
-    # Patch skills_tool module-level cache (snapshots HERMES_HOME at import)
-    try:
-        import tools.skills_tool as _sk
-        _sk.HERMES_HOME = home
-        _sk.SKILLS_DIR = home / 'skills'
-    except (ImportError, AttributeError):
-        logger.debug("Failed to patch skills_tool module")
+    _patch_skill_home_modules(home)
 
     # Patch cron/jobs module-level cache
     try:

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -2256,13 +2256,18 @@ def _run_agent_streaming(
         # two concurrent tabs on different profiles don't clobber each other via the
         # process-level active-profile global.  Falls back gracefully.
         try:
-            from api.profiles import get_hermes_home_for_profile, get_profile_runtime_env
+            from api.profiles import (
+                _patch_skill_home_modules,
+                get_hermes_home_for_profile,
+                get_profile_runtime_env,
+            )
             _profile_home_path = get_hermes_home_for_profile(getattr(s, 'profile', None))
             _profile_home = str(_profile_home_path)
             _profile_runtime_env = get_profile_runtime_env(_profile_home_path)
         except ImportError:
             _profile_home = os.environ.get('HERMES_HOME', '')
             _profile_runtime_env = {}
+            _patch_skill_home_modules = None
         
         # Capture the resolved profile name now, while profile context is
         # reliable. Used in the compression migration block to stamp s.profile
@@ -2315,23 +2320,8 @@ def _run_agent_streaming(
                 # above, so we only do lightweight sys.modules lookups and
                 # attribute assignments here — no first-time import under
                 # the lock (#2024).
-                from pathlib import Path as _P
-                import sys as _sys
-                _ph = _P(_profile_home)
-                _sk = _sys.modules.get('tools.skills_tool')
-                if _sk is not None:
-                    try:
-                        _sk.HERMES_HOME = _ph
-                        _sk.SKILLS_DIR = _ph / 'skills'
-                    except AttributeError:
-                        pass
-                _sm = _sys.modules.get('tools.skill_manager_tool')
-                if _sm is not None:
-                    try:
-                        _sm.HERMES_HOME = _ph
-                        _sm.SKILLS_DIR = _ph / 'skills'
-                    except AttributeError:
-                        pass
+                if _patch_skill_home_modules is not None:
+                    _patch_skill_home_modules(Path(_profile_home))
         # Lock released — agent runs without holding it
         # ── MCP Server Discovery (lazy import, idempotent) ──
         # MUST run AFTER the HERMES_HOME mutation above — `discover_mcp_tools()`

--- a/tests/test_issue2023_hermes_home_skill_modules.py
+++ b/tests/test_issue2023_hermes_home_skill_modules.py
@@ -1,0 +1,35 @@
+"""Regression coverage for issue #2023.
+
+Process-wide profile switches must keep both skill tool modules pointed at the
+active profile home.  The modules live in hermes-agent and may not be importable
+in this test environment, so the test injects lightweight stand-ins into
+``sys.modules``.
+"""
+import sys
+import types
+
+
+def _skill_module(name, home):
+    module = types.ModuleType(name)
+    module.HERMES_HOME = home
+    module.SKILLS_DIR = home / "skills"
+    return module
+
+
+def test_set_hermes_home_patches_both_skill_tool_module_caches(monkeypatch, tmp_path):
+    from api.profiles import _set_hermes_home
+
+    old_home = tmp_path / "old-home"
+    new_home = tmp_path / "new-home"
+    skills_tool = _skill_module("tools.skills_tool", old_home)
+    skill_manager_tool = _skill_module("tools.skill_manager_tool", old_home)
+
+    monkeypatch.setitem(sys.modules, "tools.skills_tool", skills_tool)
+    monkeypatch.setitem(sys.modules, "tools.skill_manager_tool", skill_manager_tool)
+
+    _set_hermes_home(new_home)
+
+    assert skills_tool.HERMES_HOME == new_home
+    assert skills_tool.SKILLS_DIR == new_home / "skills"
+    assert skill_manager_tool.HERMES_HOME == new_home
+    assert skill_manager_tool.SKILLS_DIR == new_home / "skills"

--- a/tests/test_issue2024_env_lock_skill_imports.py
+++ b/tests/test_issue2024_env_lock_skill_imports.py
@@ -7,8 +7,9 @@ holding the lock during them serialises every concurrent session behind
 the slowest import.
 
 The fix introduces ``_prewarm_skill_tool_modules()`` which does the
-imports *before* the lock is acquired, and the lock body uses only
-``sys.modules.get()`` lookups (O(1) dict lookup, no import machinery).
+imports *before* the lock is acquired, and the lock body uses a shared
+helper that only performs ``sys.modules.get()`` lookups (O(1) dict lookup,
+no import machinery).
 
 These tests are AST/source-level because the actual import targets
 (``tools.skills_tool``, ``tools.skill_manager_tool``) live in the
@@ -20,6 +21,7 @@ import textwrap
 
 REPO = pathlib.Path(__file__).resolve().parent.parent
 STREAMING_PY = REPO / "api" / "streaming.py"
+PROFILES_PY = REPO / "api" / "profiles.py"
 
 
 def _read_streaming() -> str:
@@ -133,25 +135,13 @@ class TestPrewarmHelperExists:
 
 
 class TestSysModulesLookupInEnvLock:
-    """Inside the lock, the code must use ``sys.modules.get()`` instead of
-    ``import`` for the skill-tool modules."""
+    """Inside the lock, streaming must use the shared cache patch helper."""
 
-    def test_sys_modules_get_used_in_env_lock(self):
+    def test_shared_skill_home_patch_helper_used_in_env_lock(self):
         source = _read_streaming()
         bodies = _find_env_lock_with_bodies(source)
         assert bodies, "Expected at least one `with _ENV_LOCK:` block"
 
-        # Collect all string content within the lock bodies by extracting
-        # Constant/Str nodes — simpler than full AST string reconstruction.
-        lock_source_segments: list[str] = []
-        for body in bodies:
-            for node in ast.walk(ast.Module(body=body, type_ignores=[])):
-                if isinstance(node, ast.Constant) and isinstance(node.value, str):
-                    lock_source_segments.append(node.value)
-
-        # The lock body should reference sys.modules.get for both modules
-        lock_text = "\n".join(lock_source_segments)
-        # More reliable: check the raw source lines inside the lock
         lines = source.splitlines()
         in_lock = False
         lock_lines: list[str] = []
@@ -175,17 +165,38 @@ class TestSysModulesLookupInEnvLock:
                 lock_lines.append(line)
 
         lock_source = "\n".join(lock_lines)
-        assert "sys.modules.get" in lock_source, (
-            "Inside `_ENV_LOCK`, skill-tool modules must be accessed via "
-            "`sys.modules.get()` instead of `import` (#2024)"
+        assert "_patch_skill_home_modules" in lock_source, (
+            "Inside `_ENV_LOCK`, streaming must use the shared skill module "
+            "cache patch helper instead of duplicating module-specific logic "
+            "(#2023/#2024)"
         )
-        assert "tools.skills_tool" in lock_source, (
-            "tools.skills_tool must still be referenced inside `_ENV_LOCK` "
-            "for attribute patching (HERMES_HOME / SKILLS_DIR)"
+
+    def test_shared_helper_uses_sys_modules_get_for_both_skill_modules(self):
+        source = PROFILES_PY.read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        helper = next(
+            (
+                node
+                for node in ast.walk(tree)
+                if isinstance(node, ast.FunctionDef)
+                and node.name == "_patch_skill_home_modules"
+            ),
+            None,
         )
-        assert "tools.skill_manager_tool" in lock_source, (
-            "tools.skill_manager_tool must still be referenced inside `_ENV_LOCK` "
-            "for attribute patching (HERMES_HOME / SKILLS_DIR)"
+        assert helper is not None, "_patch_skill_home_modules() must be defined"
+
+        helper_source = ast.get_source_segment(source, helper) or ""
+        assert "sys.modules.get" in helper_source, (
+            "_patch_skill_home_modules() must use sys.modules.get(), not import, "
+            "so env-lock callers do not trigger first-time imports (#2024)"
+        )
+        assert "HERMES_HOME" in helper_source
+        assert "SKILLS_DIR" in helper_source
+        assert "tools.skills_tool" in source, (
+            "profiles.py must patch tools.skills_tool module-level caches"
+        )
+        assert "tools.skill_manager_tool" in source, (
+            "profiles.py must patch tools.skill_manager_tool module-level caches"
         )
 
     def test_no_import_statement_for_skill_tools_in_lock(self):


### PR DESCRIPTION
## Thinking Path

- WebUI profile switches need to keep Hermes Agent module-level path caches aligned with the active HERMES_HOME.
- The process-wide switch path patched tools.skills_tool, while the streaming per-request path patched both tools.skills_tool and tools.skill_manager_tool.
- That split left a cleanup gap from #2023 and made future fixes easy to apply to one path but not the other.
- This PR centralizes the skill-module cache patching in one helper and keeps the existing no-import-under-_ENV_LOCK invariant from #2024.

## What Changed

- Added _patch_skill_home_modules(home) in api.profiles to patch imported tools.skills_tool and tools.skill_manager_tool HERMES_HOME / SKILLS_DIR caches via sys.modules.get().
- Changed _set_hermes_home() to use that shared helper for process-wide profile switches.
- Changed streaming profile setup to call the same helper after setting per-request HERMES_HOME.
- Updated the #2024 regression test so it now verifies the shared helper still avoids first-time imports under _ENV_LOCK.
- Added #2023 regression coverage with fake skill modules injected into sys.modules.
- Added an Unreleased changelog note.

Closes #2023.

## Why It Matters

This keeps profile switching behavior consistent across process-wide and per-request WebUI paths. It also reduces duplicated runtime patching logic around Hermes Agent skill modules without reintroducing the slow import-under-lock behavior fixed by #2024.

## Verification

- /Users/xuefusong/hermes-webui/.venv_test/bin/python -m pytest -q tests/test_issue2023_hermes_home_skill_modules.py tests/test_issue2024_env_lock_skill_imports.py tests/test_issue1897_profile_switch_agent_cache.py tests/test_issue1700_parallel_profile_switch.py tests/test_issue798.py tests/test_profile_env_isolation.py tests/test_profile_terminal_env.py
- /Users/xuefusong/hermes-webui/.venv_test/bin/python -m py_compile api/profiles.py api/streaming.py tests/test_issue2023_hermes_home_skill_modules.py tests/test_issue2024_env_lock_skill_imports.py
- git diff --check

## Risks / Follow-ups

- This only patches modules already imported into sys.modules. That is intentional: modules imported later will read the already-updated HERMES_HOME from os.environ, and streaming still prewarms skill modules before taking _ENV_LOCK.
- No UI changes, so screenshots are not applicable.

## Model Used

OpenAI GPT-5 via Codex.