### PR TITLE
test: add kanban locale parity check (refs #1973)

### DIFF
--- a/tests/test_kanban_ui_static.py
+++ b/tests/test_kanban_ui_static.py
@@ -1062,3 +1062,51 @@ console.log(JSON.stringify(results));
     # directly into the style attribute.
     assert "_kanbanSafeColor(b.color)" in PANELS
     assert "color:${esc(b.color)}" not in PANELS
+
+
+def test_kanban_locale_parity():
+    """Every kanban_* i18n key in the English locale must exist in all
+    non-English locale blocks.  The kanban panel has its own set of ~86
+    keys (kanban_board, kanban_task, …) that are rendered via t() — a
+    missing key silently falls back to English, which is acceptable for
+    content keys but confusing for UI labels the user expects to see
+    translated.
+
+    This test catches regressions where a new kanban key is added to the
+    English block but not to one or more locale blocks.  Pattern borrowed
+    from test_lineage_segment_locale_keys_are_defined_for_sidebar_locales
+    in test_session_lineage_collapse.py.
+
+    Refs: #1973
+    """
+    locale_blocks = _locale_blocks_with_body(I18N)
+    assert locale_blocks, "No locale blocks found in i18n.js"
+
+    # Collect the kanban_* keys from the English block.
+    en_name = "en"
+    en_body = None
+    for name, body in locale_blocks:
+        if name == en_name:
+            en_body = body
+            break
+    assert en_body is not None, "English locale block not found"
+
+    en_keys = set(re.findall(r"(kanban_\w+)\s*:", en_body))
+    assert en_keys, "No kanban_* keys found in English locale"
+
+    # Verify each non-English locale has the same set.
+    failures = []
+    for name, body in locale_blocks:
+        if name == en_name:
+            continue
+        loc_keys = set(re.findall(r"(kanban_\w+)\s*:", body))
+        missing = en_keys - loc_keys
+        extra = loc_keys - en_keys
+        if missing:
+            failures.append(f"{name}: missing {sorted(missing)}")
+        if extra:
+            failures.append(f"{name}: extra {sorted(extra)}")
+
+    assert not failures, (
+        "Kanban i18n key parity violations:\n" + "\n".join(failures)
+    )


### PR DESCRIPTION
## Thinking Path

- Hermes WebUI has ~86 `kanban_*` i18n keys across 9 locales (en, ja, ru, es, de, zh, zh-Hant, pt, ko)
- Issue #1973 flagged that a missing-key regression was only caught by manual review during the Opus pre-ship audit
- The existing `test_lineage_segment_locale_keys_are_defined_for_sidebar_locales` proves a count-based parity check works well
- Adding the same pattern for kanban keys prevents future regressions where a new key lands in `en` but not all locales

## What Changed

- Added `test_kanban_locale_parity` to `tests/test_kanban_ui_static.py`
- Uses the existing `_locale_blocks_with_body` helper to extract locale blocks
- Asserts every `kanban_*` key in `en` exists in all 8 non-English locales (bidirectional: also catches extra keys)

## Why It Matters

- Kanban is a frequently-updated UI panel — new keys are added regularly
- Without a test, a missing locale key silently falls back to English, which is confusing for non-English users
- This is the exact regression pattern the Opus advisor flagged in #1973

## Verification

- `pytest tests/test_kanban_ui_static.py::test_kanban_locale_parity` passes (3.4s)
- All 86 kanban keys verified present in all 9 locales

## Risks / Follow-ups

- None. Pure additive test, no production code changed.

## Model Used

🤖 AI-assisted via Hermes Agent (glm-5-turbo via zai provider)

Refs #1973