### PR TITLE
fix: handle parenthesised host:port in custom provider slug (#2047)

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -1448,11 +1448,24 @@ def _custom_slug_rest_looks_like_host_port(rest: str) -> bool:
     The #1776 peel must not treat that middle colon as part of an eaten model
     segment — otherwise ``@custom:10.8.71.41:8080:Qwen3`` wrongly becomes model
     ``8080:Qwen3``.
+
+    Also handles provider names that contain parentheses around the host:port,
+    e.g. ``Local (127.0.0.1:15721)`` → slug ``local-(127.0.0.1:15721)`` (#2047).
     """
     rest = str(rest or "").strip()
     if ":" not in rest:
         return False
     host, port_s = rest.rsplit(":", 1)
+
+    # Strip trailing ')' from port when the slug contains parenthesised host:port
+    # (e.g. 'local-(127.0.0.1:15721)' → port_s = '15721)' → '15721').
+    port_s = port_s.rstrip(")")
+
+    # Extract the host from within parentheses when present
+    # (e.g. 'local-(127.0.0.1' → '127.0.0.1').
+    if "(" in host:
+        host = host[host.rindex("(") + 1 :]
+
     if not host or ":" in host:
         return False
     if not port_s.isdigit():


### PR DESCRIPTION
## Thinking Path

- Hermes WebUI allows custom providers with user-defined names like `Local (127.0.0.1:15721)`
- The slug generation converts this to `custom:local-(127.0.0.1:15721)`
- `resolve_model_provider()` uses `rsplit(":", 1)` to separate provider from model, which correctly handles the nested colons
- However, the #1776 peel-back guard `_custom_slug_rest_looks_like_host_port()` fails to recognize the host:port pattern when parentheses are present — `port_s = '15721)'` fails `isdigit()` check
- This causes the peel-back to fire incorrectly, splitting at the port's colon and producing `15721):deepseek-v4-flash`

## What Changed

- Modified `_custom_slug_rest_looks_like_host_port()` in `api/config.py` to handle parentheses in provider slugs
- Strip trailing `)` from `port_s` before digit validation
- Extract host from within parentheses (strip prefix before `(`) before IP/hostname validation
- 13 lines added, 0 removed

## Why It Matters

- Users running local LLM servers with descriptive names (common pattern: `Local (host:port)`) get broken API calls with corrupted model strings
- The error manifests as HTTP 400 from the provider — confusing to debug

## Verification

- All 18 existing `resolve_model_provider` tests pass (including `test_custom_provider_ipv4_port_slug_no_false_peel`, `test_custom_provider_hostname_port_slug_no_false_peel`, `test_custom_provider_localhost_port_slug_no_false_peel`)
- Syntax check passes

## Risks / Follow-ups

- Minimal risk — the change only affects the pattern recognition guard, not the actual parsing logic
- The fix is additive: it extends the existing host:port detection to handle parenthesised variants

## Model Used

🤖 AI-assisted via Hermes Agent (glm-5-turbo via zai provider)

Closes #2047