### PR TITLE
fix: clear stale INFLIGHT cache when non-active session stream completes (#2066)

### DIFF
--- a/static/sessions.js
+++ b/static/sessions.js
@@ -283,10 +283,20 @@ function _markSessionCompletedInList(session, previousSid = null) {
   };
   _sessionStreamingById.set(finalSid, false);
   _forgetObservedStreamingSession(finalSid);
+  // Clear stale INFLIGHT cache for completed sessions that were not the
+  // active pane when the stream ended — otherwise _isSessionLocallyStreaming
+  // keeps returning true and the sidebar spinner sticks forever (#2066).
+  if (typeof INFLIGHT === 'object' && INFLIGHT && INFLIGHT[finalSid]) {
+    delete INFLIGHT[finalSid];
+    if (typeof clearInflightState === 'function') clearInflightState(finalSid);
+  }
   if (previousSid && previousSid !== finalSid) {
     _sessionStreamingById.delete(previousSid);
     _forgetObservedStreamingSession(previousSid);
     _sessionListSnapshotById.delete(previousSid);
+    if (typeof INFLIGHT === 'object' && INFLIGHT && INFLIGHT[previousSid]) {
+      delete INFLIGHT[previousSid];
+    }
   }
   _sessionListSnapshotById.set(finalSid, {
     message_count: messageCount,


### PR DESCRIPTION
## Thinking Path

- The sidebar spinner uses `_isSessionEffectivelyStreaming(s)` which checks `s.is_streaming` and `_isSessionLocallyStreaming(s)`
- `_isSessionLocallyStreaming` checks `S.busy` (active session only) and `INFLIGHT[sid]`
- When a stream completes, `_clearOwnerInflightState()` clears `INFLIGHT` for the **active pane** — but this only runs if the completed session is the one the user is currently viewing
- When the user navigated away during streaming, `_markSessionCompletedInList()` updates `_allSessions` with `is_streaming: false` but never cleans `INFLIGHT[sid]`
- Result: `_isSessionLocallyStreaming` keeps returning true → spinner sticks forever

## What Changed

- Added `INFLIGHT` cleanup in `_markSessionCompletedInList()` in `static/sessions.js`
- Clears `INFLIGHT[finalSid]` + calls `clearInflightState(finalSid)` when the completed session has a stale INFLIGHT entry
- Also clears `INFLIGHT[previousSid]` in the session-ID-rename path
- 10 lines added, 0 removed

## Why It Matters

- Users who switch sessions during streaming see permanent stuck spinners in the sidebar
- The only recovery is a full page reload — confusing and looks broken
- This is a UX regression that directly impacts perceived reliability

## Verification

- `node --check static/sessions.js` passes
- 757 session-related tests pass (1 pre-existing failure in `test_v050259_sessiondb_fd_leak` — unrelated, agent module import issue)

## Risks / Follow-ups

- Low risk — the change is defensive cleanup, only fires when `INFLIGHT[sid]` exists
- The `typeof INFLIGHT === 'object'` guard ensures safety even if INFLIGHT is undefined

## Model Used

🤖 AI-assisted via Hermes Agent (glm-5-turbo via zai provider)

Closes #2066