### PR TITLE
fix(session-recovery): 4 polish items from Opus review (#2050)

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -5653,10 +5653,10 @@ def _handle_media(handler, parsed):
         pass
 
     # Also allow additional roots from MEDIA_ALLOWED_ROOTS env var
-    # (colon-separated list of absolute paths, e.g. /home/user/models:/home/user/Pictures)
+    # (pathsep-separated list of absolute paths, e.g. /home/user/models:/home/user/Pictures on Unix)
     extra_roots = _os.environ.get("MEDIA_ALLOWED_ROOTS", "").strip()
     if extra_roots:
-        for root in extra_roots.split(":"):
+        for root in extra_roots.split(_os.pathsep):
             root = root.strip()
             if root:
                 try:

--- a/api/session_recovery.py
+++ b/api/session_recovery.py
@@ -230,6 +230,8 @@ def _read_state_db_missing_sidecar_rows(session_dir: Path, state_db_path: Path |
                             message['timestamp'] = msg['timestamp']
                         message_rows.append(message)
                 if not message_rows:
+                    row['messages'] = []
+                    rows.append(row)
                     continue
                 data['messages'] = message_rows
                 rows.append(data)
@@ -314,6 +316,10 @@ def recover_missing_sidecars_from_state_db(session_dir: Path, state_db_path: Pat
         sid = str(row.get('id') or '').strip()
         if not sid:
             continue
+        msg = row.get('messages')
+        if isinstance(msg, list) and not msg:
+            details.append({'session_id': sid, 'materialized': False, 'skipped': 'empty_messages'})
+            continue
         target = session_dir / f"{sid}.json"
         if target.exists():
             continue
@@ -353,7 +359,7 @@ def recover_missing_sidecars_from_state_db(session_dir: Path, state_db_path: Pat
         if materialized_now:
             materialized += 1
             details.append({'session_id': sid, 'materialized': True, 'messages': len(payload.get('messages') or [])})
-        elif not any(d.get('session_id') == sid for d in details[-1:]):
+        elif not (details and details[-1].get('session_id') == sid):
             details.append({'session_id': sid, 'materialized': False, 'skipped': 'sidecar_appeared_during_reconcile'})
     return {'scanned': len(rows), 'materialized': materialized, 'details': details}
 
@@ -460,14 +466,25 @@ def audit_session_recovery(session_dir: Path, state_db_path: Path | None = None)
 
     for row in _read_state_db_missing_sidecar_rows(session_dir, state_db_path):
         sid = str(row.get('id') or '')
-        items.append(_new_audit_item(
-            sid,
-            "state_db_missing_sidecar",
-            "repairable",
-            "materialize_from_state_db",
-            -1,
-            -1,
-        ))
+        messages = row.get('messages')
+        if isinstance(messages, list) and not messages:
+            items.append(_new_audit_item(
+                sid,
+                "state_db_orphan_webui_row",
+                "unsafe_to_repair",
+                "manual_review",
+                -1,
+                -1,
+            ))
+        else:
+            items.append(_new_audit_item(
+                sid,
+                "state_db_missing_sidecar",
+                "repairable",
+                "materialize_from_state_db",
+                -1,
+                -1,
+            ))
 
     summary = {"ok": len(live_paths), "repairable": 0, "unsafe_to_repair": 0}
     for item in items:
@@ -507,7 +524,7 @@ def repair_safe_session_recovery(session_dir: Path, state_db_path: Path | None =
     unsafe_remaining = int((after.get("summary") or {}).get("unsafe_to_repair") or 0)
     repairable_remaining = int((after.get("summary") or {}).get("repairable") or 0)
     return {
-        "ok": unsafe_remaining == 0 and repairable_remaining == 0,
+        "clean": unsafe_remaining == 0 and repairable_remaining == 0,
         "repaired": int(backup_repair.get("restored") or 0) + int(sidecar_repair.get("materialized") or 0),
         "before": before,
         "backup_repair": backup_repair,

--- a/tests/test_session_recovery_api.py
+++ b/tests/test_session_recovery_api.py
@@ -27,7 +27,7 @@ def test_repair_safe_session_recovery_restores_backup_and_rebuilds_index(tmp_pat
 
     result = repair_safe_session_recovery(tmp_path)
 
-    assert result["ok"] is True
+    assert result["clean"] is True
     assert result["repaired"] == 1
     assert live.exists()
     assert audit_session_recovery(tmp_path)["status"] == "ok"
@@ -50,7 +50,7 @@ def test_repair_safe_session_recovery_leaves_unsafe_orphan_for_manual_review(tmp
 
     result = repair_safe_session_recovery(tmp_path, state_db_path=db)
 
-    assert result["ok"] is False
+    assert result["clean"] is False
     assert result["repaired"] == 0
     assert not live.exists()
     assert result["after"]["status"] == "needs_manual_review"


### PR DESCRIPTION
## Thinking Path

Four low-severity polish items from the v0.51.42 Opus pre-release review, grouped because they touch `api/session_recovery.py` and `api/routes.py`.

### 1. Empty-message rows silently dropped
A `state.db` row with `source='webui'` but zero readable messages was invisible to operators — no audit item, no repair attempt, no log line. Now emits `state_db_orphan_webui_row` → `unsafe_to_repair` in the audit, and `recover_missing_sidecars_from_state_db` skips them with a `skipped: 'empty_messages'` detail entry.

### 2. `ok` flag permanently false after successful repair
When a second repair pass finds `repairable` items (e.g., the `index_missing_entry` created by the first pass), the `ok` flag stays false forever even though all scope-appropriate fixes succeeded. Renamed to `clean` — a 409 still means "audit has findings," not "repair failed."

### 3. Windows pathcompat for MEDIA_ALLOWED_ROOTS
Used hardcoded `:` separator. Switched to `os.pathsep` (`;` on Windows, `:` elsewhere).

### 4. Readability: `details[-1:]` slice
One-element slice via `any()` over one-element list was correct but confusing. Replaced with explicit `details and details[-1].get(...)` check.

## What Changed

### `api/session_recovery.py`
- Empty-message rows from `_read_state_db_missing_sidecar_rows` now included with `messages: []`
- Audit function distinguishes empty → `state_db_orphan_webui_row` / `unsafe_to_repair`
- Materialize function skips empty rows with `skipped: 'empty_messages'`
- `repair_safe_session_recovery` returns `"clean"` instead of `"ok"` (2 call sites updated)
- Readability: `details[-1:]` → `details and details[-1].get(...)`

### `api/routes.py`
- `MEDIA_ALLOWED_ROOTS` split uses `os.pathsep` instead of hardcoded `:`

### `tests/test_session_recovery_api.py`
- Updated assertions from `"ok"` to `"clean"`

## Why It Matters

- Operators can now discover empty-message rows in the audit instead of them being invisible
- The repair endpoint no longer falsely reports a problem after success
- Windows users can use semicolon-separated env vars consistently
- Code is easier to read on first glance

## Verification

- All 3 session recovery API tests pass
- All 60+ sprint regression tests pass
- All 12 log tests pass
- `node --check` passes on JS files
- Python syntax valid on all changed modules

Closes #2050