### PR TITLE
fix(profiles): patch skill_manager_tool HERMES_HOME in _set_hermes_home (#2023)

### DIFF
--- a/api/profiles.py
+++ b/api/profiles.py
@@ -619,6 +619,14 @@ def _set_hermes_home(home: Path):
     except (ImportError, AttributeError):
         logger.debug("Failed to patch skills_tool module")
 
+    # Patch skill_manager_tool module-level cache (same constants as skills_tool)
+    try:
+        import tools.skill_manager_tool as _sm
+        _sm.HERMES_HOME = home
+        _sm.SKILLS_DIR = home / 'skills'
+    except (ImportError, AttributeError):
+        logger.debug("Failed to patch skill_manager_tool module")
+
     # Patch cron/jobs module-level cache
     try:
         import cron.jobs as _cj


### PR DESCRIPTION
## Thinking Path

PR #2000 added per-request `HERMES_HOME` switching for the skill manager, patching both `tools.skills_tool` and `tools.skill_manager_tool` under `_ENV_LOCK` in `api/streaming.py`. But the pre-existing `_set_hermes_home()` helper in `api/profiles.py` only patched `skills_tool` — missing `skill_manager_tool`.

If a profile switch happens via `_set_hermes_home()` without the streaming path running, `skill_manager_tool.HERMES_HOME` stays at its import-time value and skill discovery reads from the wrong directory.

## What Changed

### `api/profiles.py`
- Added `skill_manager_tool` patching in `_set_hermes_home()` — sets `HERMES_HOME` and `SKILLS_DIR` to match the profile home
- Uses the same try/except pattern as the existing `skills_tool` and `cron.jobs` patches
- 8 lines added, 0 removed

## Why It Matters

- Prevents stale `HERMES_HOME` in `skill_manager_tool` when profiles are switched via the profile helper
- Eliminates the asymmetry between the streaming path and the profile path — both now patch the same modules
- No current callers hit the bad state, but the drift would bite a future contributor

## Verification

- All 6 env-lock skill import tests pass
- All 178 profile-related tests pass
- Python syntax valid on `api/profiles.py`

Closes #2023