### PR TITLE
fix: guard empty array iteration for bash 3.2 compatibility

### DIFF
--- a/ctl.sh
+++ b/ctl.sh
@@ -51,9 +51,11 @@ _load_repo_dotenv_preserving_env() {
   set +a
 
   local assignment
-  for assignment in "${preserved[@]}"; do
-    export "${assignment}"
-  done
+  if [[ ${#preserved[@]} -gt 0 ]]; then
+    for assignment in "${preserved[@]}"; do
+      export "${assignment}"
+    done
+  fi
 }
 
 _find_python() {


### PR DESCRIPTION
## Bug

`ctl.sh start` crashes on macOS (bash 3.2) with:
```
ctl.sh: line 29: preserved[@]: unbound variable
```

## Root Cause

The `_load_repo_dotenv_preserving_env()` function uses `set -euo pipefail` and iterates over `${preserved[@]}`. On bash 3.2 (the default on macOS), an empty array triggers "unbound variable" under `set -u`. Bash 4+ handles this correctly, but macOS still ships bash 3.2.

## Fix

Wraps the `for` loop in an array-length guard:
```bash
if [[ ${#preserved[@]} -gt 0 ]]; then
  for assignment in "${preserved[@]}"; do
    export "${assignment}"
  done
fi
```

## Test

Reproduced on macOS with bash 3.2.57 — `ctl.sh start` fails before fix, succeeds after.