### PR TITLE
fix: stack analytics usage cards on mobile

### DIFF
--- a/static/panels.js
+++ b/static/panels.js
@@ -3023,7 +3023,7 @@ function _renderInsights(d, box, wikiStatus) {
       ${overviewCards.map(c => `<div class="insights-stat"><div class="insights-stat-icon">${c.icon}</div><div class="insights-stat-info"><div class="insights-stat-value">${c.value}</div><div class="insights-stat-label">${esc(c.label)}</div></div></div>`).join('')}
     </div>
     ${dailyHtml}
-    <div class="insights-row">
+    <div class="insights-row insights-usage-grid">
       ${tokenCards}
       ${modelsHtml}
     </div>

--- a/static/style.css
+++ b/static/style.css
@@ -3392,6 +3392,20 @@ main.main.showing-insights > #mainInsights{display:flex;overflow-y:auto;}
 .insights-token-label{color:var(--muted);}
 .insights-token-value{font-weight:600;}
 
+/* ── Mobile layout for Token Breakdown + Models (issue #2104) ───────────── */
+@media (max-width: 640px) {
+  .insights-usage-grid {
+    grid-template-columns: 1fr;
+  }
+  .insights-usage-grid .insights-card {
+    min-width: 0;
+    overflow-x: auto;
+  }
+  .insights-model-table {
+    min-width: 320px;
+  }
+}
+
 /* ── Checkpoints / Rollback UI (#466) ─────────────────────────────────────── */
 .checkpoint-list{display:flex;flex-direction:column;gap:8px;}
 .checkpoint-item{display:flex;align-items:center;justify-content:space-between;padding:8px 10px;background:var(--surface-2);border:1px solid var(--border);border-radius:6px;font-size:12px;}

--- a/tests/test_insights.py
+++ b/tests/test_insights.py
@@ -162,3 +162,27 @@ def test_insights_frontend_has_daily_chart_styles_and_range_switching_hooks():
     assert ".insights-daily-token-chart" in STYLE_CSS
     assert ".insights-daily-bar-output" in STYLE_CSS
     assert ".insights-model-cost" in STYLE_CSS
+def test_insights_mobile_layout_stacks_usage_grid():
+    # Regression test for issue #2104: Token Breakdown + Models should
+    # stack on mobile instead of being side-by-side causing horizontal overflow
+    assert 'insights-usage-grid' in PANELS_JS
+    # Scoped mobile breakpoint that forces single-column layout
+    assert '@media (max-width: 640px)' in STYLE_CSS
+    assert '.insights-usage-grid' in STYLE_CSS
+    assert 'grid-template-columns: 1fr' in STYLE_CSS
+
+
+def test_insights_mobile_models_table_has_contained_overflow():
+    # Regression test for issue #2104: Models table should have contained
+    # horizontal scrolling instead of pushing the whole page off-screen
+    assert 'insights-model-table' in PANELS_JS
+    # The mobile rule should include overflow-x handling for the models card/table
+    # Search for the specific mobile rule that contains insights-usage-grid
+    insights_mobile = '/* ── Mobile layout for Token Breakdown + Models'
+    assert insights_mobile in STYLE_CSS, 'Issue #2104 mobile rules should exist in CSS'
+    # Get the block from our specific mobile section to the next section comment
+    section_start = STYLE_CSS.find(insights_mobile)
+    section_end = STYLE_CSS.find('/* ── Checkpoints', section_start)
+    section_block = STYLE_CSS[section_start:section_end]
+    assert 'overflow-x' in section_block, 'Mobile rule should include overflow-x handling'
+    assert 'insights-model-table' in section_block or 'insights-card' in section_block


### PR DESCRIPTION
## Thinking Path
- Freebuff implemented the mobile Analytics layout slice for issue #2104.
- GPT-5.5 reviewed the resulting diff, checked that the change is scoped to the Token Breakdown + Models row, and verified the targeted tests.
- This intentionally does not duplicate the Daily Tokens long-range bucketing from #2103 / PR #2120; it fixes the mobile Token Breakdown + Models overflow portion and keeps the chart dependency separate.

## What Changed
- Adds a scoped `insights-usage-grid` class around the Token Breakdown + Models row.
- Stacks that grid to one column at mobile widths (`max-width: 640px`).
- Contains any remaining model-table overflow inside the card instead of allowing the whole page to scroll horizontally.
- Adds regression coverage for the mobile stacking and contained-overflow rules.

## Why It Matters
Mobile Analytics should not force the entire page wider than the viewport when Token Breakdown and Models render together. The Models card now gets a full-width row on phones, with any unavoidable table width handled locally.

## Verification
- `node --check static/panels.js`
- `git diff --check`
- `python3 -m pytest tests/test_insights.py -q` → 6 passed

## Evidence
- Source-level regression coverage confirms the mobile grid class, breakpoint, single-column layout, and contained overflow rule.
- Runtime screenshot evidence for the Daily Tokens chart portion is tracked separately in PR #2120.

## Risks / Follow-ups
- Refs #2104 because Daily Tokens long-range chart overflow is being handled by #2120. Once #2120 lands, the combined fixes should close the full mobile Analytics overflow report.

## Model Used
- Freebuff/Codebuff free-mode (`minimax/minimax-m2.7`) for implementation.
- OpenAI Codex / GPT-5.5 via Hermes Agent for review, verification, and publication guardrails.

Refs #2104
