### PR TITLE
fix: add Portuguese session management i18n

### DIFF
--- a/static/i18n.js
+++ b/static/i18n.js
@@ -8947,6 +8947,13 @@ const LOCALES = {
     session_deleted_worktree: 'Conversa excluída. O worktree permanece no disco.',
     session_batch_delete_worktree_confirm: 'Excluir {0} conversas? {1} conversa(s) com worktree manterão seus diretórios de worktree no disco.',
     session_batch_archive_worktree_confirm: 'Arquivar {0} conversas? {1} conversa(s) com worktree manterão seus diretórios de worktree no disco.',
+    session_batch_delete_confirm: 'Excluir {0} conversas?',
+    session_batch_archive_confirm: 'Arquivar {0} conversas?',
+    session_select_mode: 'Selecionar',
+    session_select_mode_desc: 'Selecionar conversas para gerenciamento em lote',
+    session_select_all: 'Selecionar todas',
+    session_selected_count: '{0} selecionadas',
+    session_no_selection: 'Nenhuma conversa selecionada',
     // settings panel
     settings_heading_title: 'Control Center',
     settings_heading_subtitle: 'Preferências, ferramentas de conversa e controles do sistema.',

--- a/tests/test_login_locale_parity.py
+++ b/tests/test_login_locale_parity.py
@@ -328,3 +328,33 @@ def test_login_flow_keys_are_translated(loc_key: str):
         f"Locale {loc_key!r} leaks English for login-flow keys: {leaks}. "
         f"Translate these in static/i18n.js (issue #1442)."
     )
+
+
+# ── Session-management key parity ─────────────────────────────────────────────
+#
+# Keys added for session batch operations and multi-select (#2112).
+# Every locale block must have these keys; missing them falls back to English
+# which is a regression for non-English users.
+
+SESSION_MANAGEMENT_KEYS = (
+    "session_batch_delete_confirm",
+    "session_batch_archive_confirm",
+    "session_batch_delete_worktree_confirm",
+    "session_batch_archive_worktree_confirm",
+    "session_select_mode",
+    "session_select_mode_desc",
+    "session_select_all",
+    "session_selected_count",
+    "session_no_selection",
+)
+
+
+@pytest.mark.parametrize("loc_key", ["en", "es", "de", "ru", "zh", "zh-Hant", "ja", "pt", "ko"])
+def test_session_management_keys_present(loc_key: str):
+    """Every locale block must define all session-management keys (no fallback to English)."""
+    seg = _i18n_locale_block(loc_key)
+    missing = [k for k in SESSION_MANAGEMENT_KEYS if _value_of(seg, k) is None]
+    assert not missing, (
+        f"Locale {loc_key!r} is missing session-management keys: {missing}. "
+        f"Add translations in static/i18n.js (issue #2112)."
+    )


### PR DESCRIPTION
## Thinking Path
- Hermes WebUI keeps locale strings in a single vanilla JS i18n table.
- Issue #2112 identified that Portuguese silently fell back to English for bulk session-management actions.
- The safest fix is a narrow locale-parity patch: fill the missing `pt` keys and add a regression test so the gap cannot reappear unnoticed.
- This PR avoids changing locale loading or UI behavior beyond the missing Portuguese strings.

## What Changed
- Added the missing Portuguese session-management keys in `static/i18n.js` for bulk delete/archive, select mode, select all, selected count, and no-selection text.
- Extended `tests/test_login_locale_parity.py` with a session-management key parity check across all supported locale blocks.

## Why It Matters
Portuguese users no longer see English fallback text in bulk-select/session-management flows, and future session-management i18n keys now have regression coverage.

## Verification
- `git diff --check`
- `/home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_login_locale_parity.py -q` — 29 passed

## Risks / Follow-ups
- Low risk: this only adds missing locale entries and a parity test.
- Translation nuance may still benefit from a Portuguese-fluent reviewer, but the phrasing follows the issue's suggested copy and neighboring Romance-language patterns.

## Model Used
- OpenAI GPT-5.5 via Hermes Agent for queue stewardship and review.
- Freebuff/Codebuff free mode with `minimax/minimax-m2.7` for implementation/repair using local file and command tools.

Closes #2112
