### PR TITLE
Prefer credential pool base_url over config.yaml model.base_url

### DIFF
--- a/api/streaming.py
+++ b/api/streaming.py
@@ -44,6 +44,26 @@ from api.turn_journal import append_turn_journal_event_for_stream
 _ENV_LOCK = threading.Lock()
 
 
+def _prefer_pool_base_url(resolved_base_url, runtime, resolved_provider):
+    """Prefer the credential pool's base_url over config.yaml's model.base_url.
+
+    config.yaml can hold a stale path suffix (e.g. ``api.kimi.com/coding/v1``
+    instead of ``api.kimi.com/coding``) that doubles up when the SDK appends
+    ``/v1/messages`` to the Anthropic-wire endpoint, yielding a 404. The
+    credential pool's base_url is the source of truth, written by
+    ``hermes model`` and used by the CLI and gateway. Custom providers
+    (``custom`` / ``custom:<slug>``) keep their config.yaml URL because
+    ``custom_providers[]`` is where their base_url legitimately lives.
+    """
+    pool_base = runtime.get("base_url") if runtime else None
+    is_custom = isinstance(resolved_provider, str) and (
+        resolved_provider == "custom" or resolved_provider.startswith("custom:")
+    )
+    if pool_base and not is_custom:
+        return pool_base
+    return resolved_base_url or pool_base
+
+
 def _prewarm_skill_tool_modules():
     """Import tools.skills_tool and tools.skill_manager_tool outside any lock.
 
@@ -2708,8 +2728,9 @@ def _run_agent_streaming(
                 resolved_api_key = _rt.get("api_key")
                 if not resolved_provider:
                     resolved_provider = _rt.get("provider")
-                if not resolved_base_url:
-                    resolved_base_url = _rt.get("base_url")
+                resolved_base_url = _prefer_pool_base_url(
+                    resolved_base_url, _rt, resolved_provider
+                )
             except Exception as _e:
                 print(f"[webui] WARNING: resolve_runtime_provider failed: {_e}", flush=True)
 
@@ -3188,8 +3209,9 @@ def _run_agent_streaming(
                             resolved_api_key = _heal_rt.get('api_key')
                             if not resolved_provider:
                                 resolved_provider = _heal_rt.get('provider')
-                            if not resolved_base_url:
-                                resolved_base_url = _heal_rt.get('base_url')
+                            resolved_base_url = _prefer_pool_base_url(
+                                resolved_base_url, _heal_rt, resolved_provider
+                            )
                             if isinstance(resolved_provider, str) and resolved_provider.startswith('custom:'):
                                 _cp_key, _cp_base = resolve_custom_provider_connection(resolved_provider)
                                 if not resolved_api_key and _cp_key:
@@ -3885,8 +3907,9 @@ def _run_agent_streaming(
                     resolved_api_key = _heal_rt.get('api_key')
                     if not resolved_provider:
                         resolved_provider = _heal_rt.get('provider')
-                    if not resolved_base_url:
-                        resolved_base_url = _heal_rt.get('base_url')
+                    resolved_base_url = _prefer_pool_base_url(
+                        resolved_base_url, _heal_rt, resolved_provider
+                    )
                     if isinstance(resolved_provider, str) and resolved_provider.startswith('custom:'):
                         _cp_key, _cp_base = resolve_custom_provider_connection(resolved_provider)
                         if not resolved_api_key and _cp_key:


### PR DESCRIPTION
## Summary

When a chat is started, `_run_agent_streaming` resolves the model's `base_url` first from `config.yaml`'s `model.base_url` (via `resolve_model_provider`), then falls back to the credential pool (via `resolve_runtime_provider`) only if the first value is empty:

```python
resolved_model, resolved_provider, resolved_base_url = resolve_model_provider(...)
...
if not resolved_base_url:
    resolved_base_url = _rt.get("base_url")
```

This is the wrong precedence for non-custom providers. The credential pool entry is what `hermes model` writes and what the CLI / gateway use as the source of truth. `config.yaml`'s `model.base_url` is a convenience hint that can be stale — particularly for providers where the agent SDK appends a wire-specific path suffix.

## Concrete repro: Kimi Coding Plan

The Kimi Coding Plan endpoint (`https://api.kimi.com/coding`) speaks the Anthropic Messages wire — the Anthropic SDK appends `/v1/messages` to whatever base_url it's given. The agent's own `_to_openai_base_url` helper documents this in `agent/auxiliary_client.py`:

> Kimi Code uses `/coding/v1/messages` for Anthropic SDK (appends `/v1/messages`) but `/coding/v1/chat/completions` for OpenAI SDK (appends `/chat/completions`). Without `/v1` here, OpenAI SDK hits `/coding/chat/completions` — a 404.

The credential pool stores `base_url: https://api.kimi.com/coding` (no trailing `/v1`). The CLI uses that and produces the correct URL `/coding/v1/messages`.

But `hermes model` (or an older WebUI build) can persist `model.base_url: https://api.kimi.com/coding/v1` into `config.yaml`. The WebUI then prefers that value, the Anthropic SDK appends `/v1/messages`, and the final URL becomes `/coding/v1/v1/messages` — `HTTP 404: The requested resource was not found`. CLI and Telegram work; only the WebUI 404s.

Surfaces as the standard apperror in the chat panel:

> **Model not found: HTTP 404: The requested resource was not found**
> The selected model was not found by the provider. Check the model ID in Settings or run `hermes model` to verify it exists for your provider.

…but the model and credentials are fine — only the base_url path is wrong.

## Fix

Introduce a small helper `_prefer_pool_base_url(resolved_base_url, runtime, resolved_provider)` and use it at all three sites in `_run_agent_streaming` that previously did the `if not resolved_base_url: resolved_base_url = _rt.get(\"base_url\")` fallback:

1. Initial agent build (line ~2731)
2. Self-heal happy path after credential refresh (line ~3212)
3. Self-heal except path (line ~3910)

For non-custom providers, when the runtime resolve returns a non-empty `base_url`, prefer it over the config.yaml value. Custom providers (`custom` and `custom:<slug>`) keep the existing behavior — `custom_providers[]` in config.yaml is the legitimate source of their base_url, and `resolve_custom_provider_connection` is already used to fill that in further down.

This matches the precedence the CLI already uses and resolves the kimi-coding 404 without any agent-side changes.

## Test plan

- [x] Reproduce the 404 on a Kimi Coding Plan account with `config.yaml`'s `model.base_url: https://api.kimi.com/coding/v1` and `auth.json`'s pool entry `base_url: https://api.kimi.com/coding`. WebUI returns "Model not found"; CLI works.
- [x] Apply patch, verify `POST /api/chat/start` returns 200 and the model responds normally.
- [x] Verify CLI behavior unchanged (it doesn't go through `_run_agent_streaming`).
- [ ] Sanity-check a custom provider (`provider: custom` with explicit `base_url`) — confirm it still uses the config.yaml URL, since the helper falls through when `is_custom`.
- [ ] Sanity-check named-custom (`custom:<slug>`) routing path — same expectation.