### PR TITLE
Fix login health probe credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixed
 
+- **PR #2137** by @franksong2702 — The login page `/health` connectivity probe now sends same-origin credentials instead of forcing `credentials: "omit"`, so deployments protected by Cloudflare Access or another same-origin access proxy can pass their access cookie through before WebUI decides the service is reachable. This keeps the probe mount-relative and does not change WebUI password auth.
+
 - **PR #2117** by @ayushere — `ctl.sh start` no longer crashes on macOS (bash 3.2) with `preserved[@]: unbound variable`. The dotenv-preserve loop in `_load_repo_dotenv_preserving_env()` iterated `"${preserved[@]}"` under `set -euo pipefail`, which bash 4+ silently allows on empty arrays but bash 3.2 (still the default `/usr/bin/bash` on macOS) treats as an unbound-variable error. Guards the iteration with `if [[ ${#preserved[@]} -gt 0 ]]; then ... fi` — matches the canonical bash 3.2 strict-mode pattern. This is the third bash 3.2 compat fix to land in `ctl.sh` (prior: `025f137f` guarded `CTL_BOOTSTRAP_ARGS[@]` with the `${arr[@]+...}` pass-through pattern, `630981a0` replaced `[[ -v ${key} ]]` with `[[ -n "${!key+x}" ]]`). Defense-in-depth: added `tests/test_ctl_bash32_compat.py` (5 static-pattern regressions) pinning both empty-array guards plus a denylist for bash 4+ syntax (`declare -A`, `mapfile`, `[[ -v ]]`, `${var^^}`, `${var,,}`) so the next regression surfaces in CI instead of a macOS user's terminal. Stage-343 reviewer added the regression-test file alongside the contributor's 5-LOC fix to ctl.sh.
 
 ## [v0.51.49] — 2026-05-12 — Release Y (stage-342 — 3-PR contributor batch — read-only worktree status endpoint + worktree-retained response preference + Codex quota credential-pool fallback)

--- a/static/login.js
+++ b/static/login.js
@@ -69,7 +69,8 @@ document.addEventListener('DOMContentLoaded', function () {
 
   // On page load, probe the server so we can distinguish "can't reach server"
   // (Tailscale off, wrong network) from "session expired / need to log in".
-  // Uses /health — a public endpoint, no auth required.
+  // Uses /health — public for WebUI auth, but deployment access proxies may
+  // require same-origin cookies before the request reaches WebUI.
   // If unreachable, retries every 3 s and auto-reloads once the server is back.
   (function checkConnectivity() {
     var retryTimer = null;
@@ -81,7 +82,7 @@ document.addEventListener('DOMContentLoaded', function () {
     }
 
     function probe() {
-      fetch('health', { method: 'GET', credentials: 'omit' })
+      fetch('health', { method: 'GET', credentials: 'same-origin' })
         .then(function (r) {
           if (r.ok) {
             // Server is reachable — if we were in retry mode, reload so the

--- a/tests/test_1038_pwa_auth_redirect.py
+++ b/tests/test_1038_pwa_auth_redirect.py
@@ -112,3 +112,12 @@ class TestLoginJsSafeNextPath:
         assert "charAt(0) !== '/'" in src or "startsWith('/')" in src, (
             "_safeNextPath must reject non-path-absolute inputs (e.g. 'http://...')"
         )
+
+    def test_health_probe_sends_same_origin_credentials(self):
+        """Cloudflare Access protects /health with same-origin cookies before WebUI sees it."""
+        src = self._login_js()
+        assert "fetch('health', { method: 'GET', credentials: 'omit' })" not in src, (
+            "login.js must not omit credentials for the health probe because "
+            "deployment-level access proxies may require same-origin cookies"
+        )
+        assert "fetch('health', { method: 'GET', credentials: 'same-origin' })" in src


### PR DESCRIPTION
## Thinking Path

Issue #2122 reports that the login page health probe fails behind Cloudflare Access because it forces `credentials: 'omit'`. That prevents same-origin access cookies from reaching the proxy, so WebUI can incorrectly disable login before the request reaches `/health`.

## What Changed

- Changed the login page `/health` probe from `credentials: 'omit'` to `credentials: 'same-origin'`.
- Kept the health URL mount-relative (`health`) so subpath deployments continue to work.
- Added a static regression test that forbids the omitted-credentials probe and pins same-origin credentials.
- Added a changelog entry.

## Why It Matters

Deployments behind Cloudflare Access or similar same-origin access proxies can now pass the proxy cookie during the pre-login health check. This fixes the false "connection failed" state without changing WebUI password authentication.

## Verification

- `/Users/xuefusong/hermes-webui/.venv_test/bin/python -m pytest -q tests/test_1038_pwa_auth_redirect.py::TestLoginJsSafeNextPath::test_health_probe_sends_same_origin_credentials`
- `/Users/xuefusong/hermes-webui/.venv_test/bin/python -m pytest -q tests/test_1038_pwa_auth_redirect.py tests/test_sprint19.py tests/test_subpath_frontend_routes.py tests/test_service_worker_api_cache.py`
- `node --check static/login.js`
- `git diff --check`

## Risks

Low. Browser `same-origin` credentials are scoped to the WebUI origin and do not send cross-origin cookies. `/health` remains public from WebUI's auth perspective; this only allows deployment-level same-origin access controls to see their own cookies.

## Model Used

GPT-5.5 via Codex.

Closes #2122