### PR TITLE
feat: add manual provider usage refresh

### DIFF
--- a/static/panels.js
+++ b/static/panels.js
@@ -5545,7 +5545,7 @@ async function _refreshProviderQuota(card,button){
   }catch(e){
     failed=true;
   }
-  if(button){
+  if(card.isConnected&&button){
     button.disabled=false;
     button.textContent='Refresh usage';
     button.removeAttribute('aria-busy');

--- a/static/panels.js
+++ b/static/panels.js
@@ -5485,13 +5485,20 @@ function _buildPluginCard(plugin){
 
 const _providerCardEls = new Map(); // providerId → {card, statusDot, input, saveBtn, removeBtn}
 
+async function _fetchProviderQuotaStatus(force=false){
+  const endpoint=force?`/api/provider/quota?refresh=1&ts=${Date.now()}`:'/api/provider/quota';
+  const status=await api(endpoint,{cache:'no-store'});
+  if(status&&typeof status==='object') status.client_fetched_at=new Date().toISOString();
+  return status;
+}
+
 async function loadProvidersPanel(){
   const list=$('providersList');
   const empty=$('providersEmpty');
   if(!list) return;
   try{
     const data=await api('/api/providers');
-    const quota=await api('/api/provider/quota').catch(e=>({ok:false,status:'unavailable',quota:null,message:e.message||'Quota status unavailable'}));
+    const quota=await _fetchProviderQuotaStatus(false).catch(e=>({ok:false,status:'unavailable',quota:null,message:e.message||'Quota status unavailable',client_fetched_at:new Date().toISOString()}));
     const providers=(data.providers||[]).filter(p=>p.configurable||p.is_oauth);
     list.innerHTML='';
     _providerCardEls.clear();
@@ -5510,6 +5517,40 @@ async function loadProvidersPanel(){
   }catch(e){
     list.innerHTML='<div style="color:var(--error);padding:12px;font-size:13px">Failed to load providers: '+e.message+'</div>';
   }
+}
+
+async function _refreshProviderQuota(card,button){
+  if(!card) return;
+  if(button){
+    button.disabled=true;
+    button.textContent='Refreshing…';
+    button.setAttribute('aria-busy','true');
+  }
+  let failed=false;
+  let next;
+  try{
+    next=await _fetchProviderQuotaStatus(true);
+    failed=next&&next.ok===false;
+  }catch(e){
+    failed=true;
+    next={ok:false,status:'unavailable',quota:null,message:e.message||'Quota status unavailable',client_fetched_at:new Date().toISOString()};
+  }
+  try{
+    const fresh=_buildProviderQuotaCard(next);
+    if(fresh){
+      card.replaceWith(fresh);
+      if(typeof showToast==='function') showToast(failed?'Provider usage refresh failed':'Provider usage refreshed');
+      return;
+    }
+  }catch(e){
+    failed=true;
+  }
+  if(button){
+    button.disabled=false;
+    button.textContent='Refresh usage';
+    button.removeAttribute('aria-busy');
+  }
+  if(typeof showToast==='function') showToast('Provider usage refresh failed');
 }
 
 function _formatProviderQuotaMoney(value){
@@ -5541,6 +5582,15 @@ function _formatProviderQuotaWindowLabel(accountLimits,w){
     if(raw.toLowerCase()==='weekly') return 'Weekly limit';
   }
   return raw||'Window';
+}
+
+function _formatProviderQuotaLastChecked(status){
+  const accountLimits=status&&status.account_limits;
+  const value=(accountLimits&&accountLimits.fetched_at)||status&&status.client_fetched_at;
+  if(!value) return 'Last checked after refresh';
+  const d=new Date(value);
+  if(Number.isNaN(d.getTime())) return 'Last checked after refresh';
+  try{return 'Last checked '+d.toLocaleString();}catch(e){return 'Last checked '+value;}
 }
 
 function _buildProviderQuotaCard(status){
@@ -5590,11 +5640,17 @@ function _buildProviderQuotaCard(status){
       <div>
         <div class="provider-quota-title">Active provider quota</div>
         <div class="provider-quota-subtitle">${esc(provider)}</div>
+        <div class="provider-quota-checked">${esc(_formatProviderQuotaLastChecked(status))}</div>
       </div>
-      <span class="provider-quota-badge">${esc(state.replace(/_/g,' '))}</span>
+      <div class="provider-quota-actions">
+        <span class="provider-quota-badge">${esc(state.replace(/_/g,' '))}</span>
+        <button class="provider-quota-refresh" type="button" data-provider-quota-refresh title="Refresh provider usage limits now">Refresh usage</button>
+      </div>
     </div>
     <div class="provider-quota-body">${body}</div>
   `;
+  const refreshBtn=card.querySelector('[data-provider-quota-refresh]');
+  if(refreshBtn) refreshBtn.addEventListener('click',()=>_refreshProviderQuota(card,refreshBtn));
   return card;
 }
 

--- a/static/style.css
+++ b/static/style.css
@@ -2494,7 +2494,12 @@ main.main.showing-logs > #mainLogs{display:flex;}
 .provider-quota-header{display:flex;align-items:flex-start;justify-content:space-between;gap:12px;margin-bottom:10px;}
 .provider-quota-title{font-size:13px;font-weight:650;color:var(--text);line-height:1.2;}
 .provider-quota-subtitle{font-size:11px;color:var(--muted);line-height:1.3;margin-top:2px;}
+.provider-quota-checked{font-size:10.5px;color:var(--muted);line-height:1.3;margin-top:2px;}
+.provider-quota-actions{display:flex;align-items:center;gap:8px;flex-wrap:wrap;justify-content:flex-end;}
 .provider-quota-badge{font-size:10.5px;font-weight:650;text-transform:capitalize;padding:2px 8px;border-radius:999px;background:var(--accent-bg);color:var(--accent-text);white-space:nowrap;}
+.provider-quota-refresh{appearance:none;border:1px solid var(--border);border-radius:999px;background:var(--sidebar);color:var(--text);font-size:11px;font-weight:650;line-height:1;padding:5px 9px;cursor:pointer;white-space:nowrap;}
+.provider-quota-refresh:hover:not(:disabled){border-color:var(--accent);color:var(--accent);}
+.provider-quota-refresh:disabled{opacity:.65;cursor:wait;}
 .provider-quota-body{display:flex;flex-wrap:wrap;gap:8px;}
 .provider-quota-metric{flex:1;min-width:88px;border:1px solid var(--border);border-radius:8px;background:var(--sidebar);padding:8px 10px;}
 .provider-quota-metric span{display:block;font-size:10.5px;color:var(--muted);margin-bottom:2px;}

--- a/tests/test_provider_quota_status.py
+++ b/tests/test_provider_quota_status.py
@@ -563,6 +563,7 @@ def test_provider_quota_card_has_manual_refresh_control():
     assert "Refresh usage" in panels
     assert "Provider usage refreshed" in panels
     assert "Provider usage refresh failed" in panels
+    assert "card.isConnected&&button" in panels
     assert "Last checked" in panels
 
 

--- a/tests/test_provider_quota_status.py
+++ b/tests/test_provider_quota_status.py
@@ -541,7 +541,8 @@ def test_provider_quota_route_is_registered():
 def test_provider_quota_card_is_rendered_in_providers_panel():
     """The Providers panel should show active provider quota/status before cards."""
     panels = (ROOT / "static" / "panels.js").read_text(encoding="utf-8")
-    assert "api('/api/provider/quota')" in panels
+    assert "_fetchProviderQuotaStatus(false)" in panels
+    assert "'/api/provider/quota'" in panels
     assert "function _buildProviderQuotaCard" in panels
     assert "Active provider quota" in panels
     assert "provider-quota-card" in panels
@@ -549,6 +550,20 @@ def test_provider_quota_card_is_rendered_in_providers_panel():
     assert "remaining_percent" in panels
     assert "provider-quota-details" in panels
     assert "5-hour limit" in panels
+
+
+def test_provider_quota_card_has_manual_refresh_control():
+    """The quota card should let users force an immediate fresh usage lookup."""
+    panels = (ROOT / "static" / "panels.js").read_text(encoding="utf-8")
+    assert "function _refreshProviderQuota" in panels
+    assert "function _fetchProviderQuotaStatus" in panels
+    assert "refresh=1" in panels
+    assert "cache:'no-store'" in panels
+    assert "data-provider-quota-refresh" in panels
+    assert "Refresh usage" in panels
+    assert "Provider usage refreshed" in panels
+    assert "Provider usage refresh failed" in panels
+    assert "Last checked" in panels
 
 
 def test_provider_quota_styles_exist():
@@ -562,6 +577,9 @@ def test_provider_quota_styles_exist():
         ".provider-quota-card-invalid_key",
         ".provider-quota-details",
         ".provider-quota-window",
+        ".provider-quota-actions",
+        ".provider-quota-refresh",
+        ".provider-quota-checked",
     ):
         assert token in css
 


### PR DESCRIPTION
## Thinking Path

- Hermes WebUI surfaces provider account limits in Settings → Providers so users can decide whether their active provider is safe to use.
- Those limits can change outside the WebUI, especially for OAuth-backed OpenAI Codex usage windows.
- Reloading the whole Providers panel is a heavier interaction than needed when a user just wants fresh usage data.
- This PR keeps the existing sanitized `/api/provider/quota` surface and adds a narrow manual refresh control to that quota card.

## What Changed

- Adds a `Refresh usage` button to the Active provider quota card in Settings → Providers.
- Forced refresh calls `/api/provider/quota?refresh=1&ts=...` with `cache: 'no-store'` to avoid stale browser/proxy responses.
- Shows a disabled `Refreshing…` state while the request is in flight.
- Re-renders the quota card from the fresh response and shows a `Last checked ...` timestamp.
- Shows a success toast on successful refresh and a failure toast if the refresh request fails.
- Adds focused regression coverage for the refresh control, cache-busting request, no-store fetch option, and new CSS hooks.

## Why It Matters

Users with Codex/OpenAI-style usage windows can force a fresh account-limits lookup and get immediate feedback without guessing whether the displayed quota data is stale.

## Before / After

Before: quota card had no manual refresh control.

![Before: quota card without refresh button](https://gist.githubusercontent.com/Jordan-SkyLF/7fbd88fb1684cb85d5b943a8e06148f5/raw/e828142a9a2e2f2a0372a95d958c0318f2210c86/before-provider-quota-card.svg)

After: quota card shows `Refresh usage` and a `Last checked` timestamp.

![After: quota card with Refresh usage button](https://gist.githubusercontent.com/Jordan-SkyLF/7fbd88fb1684cb85d5b943a8e06148f5/raw/95a5bece90aa3313f12241057780b618ac8b9a08/after-provider-quota-refresh-button.svg)

## Verification

- [x] `python -m pytest tests/test_provider_quota_status.py -q`
  - result: `20 passed in 7.43s`
- [x] `python -m pytest tests/ -v`
  - result: `5304 passed, 11 skipped, 1 xfailed, 2 xpassed, 8 subtests passed in 149.70s`
- [x] `python -m py_compile api/providers.py api/routes.py`
  - result: passed
- [x] `node --check static/panels.js`
  - result: passed
- [x] `git diff --check origin/master...HEAD`
  - result: passed
- [x] Manual browser check on a branch instance
  - Settings → Providers showed the active OpenAI Codex quota card.
  - `Refresh usage` updated the Last checked timestamp and displayed `Provider usage refreshed`.
  - Browser resource entries included `/api/provider/quota?refresh=1&ts=...`.
  - Browser console had no JavaScript errors.

Note: `pytest tests/ -v --timeout=60` was attempted per `CONTRIBUTING.md`, but this local environment does not have the `pytest-timeout` plugin installed, so pytest rejected the `--timeout` option. I reran the full suite without that local-only option and it passed.

## Risks / Follow-ups

- Scope is intentionally limited to the Settings → Providers quota card.
- Backend quota/account-limit fetching and credential handling are unchanged.
- The refresh button still uses the existing server-side sanitized quota response; provider credentials are not exposed to the browser.

## Model Used

- OpenAI Codex, `gpt-5.5`, via Hermes WebUI/browser and terminal tooling.
