### PR TITLE
Skip CLI metadata lookup for native session loads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixed
 
+- Native WebUI session metadata loads no longer scan Agent/CLI session metadata on every `/api/session` request. Imported CLI and messaging-backed sessions still keep the Agent metadata merge path, but ordinary WebUI session switches skip the expensive state.db query.
+
 - **PR #2136** by @LumenYoung — Stale stream writebacks no longer poison the active session transcript. `cancel_stream()` intentionally clears `active_stream_id` early so the UI can accept a follow-up turn while an old worker is unwinding — but the old worker could still return later from `run_conversation()` and persist its stale result over the newer transcript, causing visible transcript / turn journal / `state.db` to disagree (especially around cancel+retry on compressed continuations). Adds a single-line ownership check `_stream_writeback_is_current(session, stream_id)` (token equality against `session.active_stream_id`) and short-circuits both finalize paths: the success path in `_run_agent_streaming` and the cancel-handler path in `cancel_stream()`. When the stream no longer owns the writeback, both paths log `Skipping stale stream/cancel writeback` and return cleanly without persisting. 89-line regression suite in `tests/test_stale_stream_writeback.py`; companion updates to `tests/test_issue1361_cancel_data_loss.py` and `tests/test_sprint42.py` for the new return-without-persist behavior.
 
 ### Added

--- a/api/routes.py
+++ b/api/routes.py
@@ -1430,6 +1430,18 @@ def _lookup_cli_session_metadata(session_id: str) -> dict:
     return {}
 
 
+def _needs_cli_session_metadata(session) -> bool:
+    """Return true when /api/session should pay for Agent/CLI metadata lookup."""
+    if not session:
+        return False
+    is_cli = (
+        bool(session.get("is_cli_session"))
+        if isinstance(session, dict)
+        else bool(getattr(session, "is_cli_session", False))
+    )
+    return is_cli or _is_messaging_session_record(session)
+
+
 def _messaging_session_identity(session: dict, raw_source: str) -> str:
     metadata = _lookup_gateway_session_identity(session.get("session_id"))
     session_key = _safe_first(
@@ -3125,7 +3137,7 @@ def handle_get(handler, parsed) -> bool:
             _t1 = _time.monotonic()
             s = get_session(sid, metadata_only=(not load_messages))
             _clear_stale_stream_state(s)
-            cli_meta = _lookup_cli_session_metadata(sid)
+            cli_meta = _lookup_cli_session_metadata(sid) if _needs_cli_session_metadata(s) else {}
             is_messaging_session = _is_messaging_session_record(s) or _is_messaging_session_record(cli_meta)
             cli_messages = []
             if is_messaging_session:

--- a/tests/test_session_metadata_cli_lookup.py
+++ b/tests/test_session_metadata_cli_lookup.py
@@ -1,0 +1,104 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+from urllib.parse import urlparse
+
+
+class _FakeSession:
+    def __init__(self, *, is_cli_session=False, session_source=None, source_tag=None):
+        self.session_id = "native_webui_001"
+        self.title = "Native WebUI"
+        self.workspace = "/tmp"
+        self.model = "gpt-test"
+        self.model_provider = None
+        self.messages = []
+        self.tool_calls = []
+        self.input_tokens = 0
+        self.output_tokens = 0
+        self.estimated_cost = 0
+        self.context_length = 1
+        self.threshold_tokens = 0
+        self.last_prompt_tokens = 0
+        self.active_stream_id = None
+        self.pending_user_message = None
+        self.pending_attachments = []
+        self.pending_started_at = None
+        self.composer_draft = {}
+        self.is_cli_session = is_cli_session
+        self.session_source = session_source
+        self.source_tag = source_tag
+        self.raw_source = source_tag
+        self.source_label = source_tag
+
+    def compact(self):
+        return {
+            "session_id": self.session_id,
+            "title": self.title,
+            "workspace": self.workspace,
+            "model": self.model,
+            "model_provider": self.model_provider,
+            "message_count": 0,
+            "context_length": self.context_length,
+            "threshold_tokens": self.threshold_tokens,
+            "last_prompt_tokens": self.last_prompt_tokens,
+            "active_stream_id": self.active_stream_id,
+            "pending_user_message": self.pending_user_message,
+            "composer_draft": self.composer_draft,
+            "is_cli_session": self.is_cli_session,
+            "session_source": self.session_source,
+            "source_tag": self.source_tag,
+            "raw_source": self.raw_source,
+            "source_label": self.source_label,
+        }
+
+
+def _invoke_api_session(session_obj, *, lookup_cli):
+    import api.routes as routes
+
+    captured = {}
+
+    def fake_j(_handler, data, status=200, extra_headers=None):
+        captured["data"] = data
+        captured["status"] = status
+        return data
+
+    parsed = urlparse("/api/session?session_id=native_webui_001&messages=0&resolve_model=0")
+    with patch("api.routes.get_session", return_value=session_obj), \
+         patch("api.routes._clear_stale_stream_state", return_value=False), \
+         patch("api.routes._lookup_cli_session_metadata", side_effect=lookup_cli) as lookup, \
+         patch("api.routes.j", side_effect=fake_j):
+        routes.handle_get(SimpleNamespace(), parsed)
+    return captured, lookup
+
+
+def test_api_session_metadata_skips_cli_lookup_for_native_webui_session():
+    """Native WebUI sessions should not scan Agent state.db on every metadata load."""
+    session = _FakeSession()
+
+    def fail_lookup(_sid):
+        raise AssertionError("native WebUI metadata should not query CLI sessions")
+
+    captured, lookup = _invoke_api_session(session, lookup_cli=fail_lookup)
+
+    assert captured["status"] == 200
+    assert captured["data"]["session"]["session_id"] == "native_webui_001"
+    lookup.assert_not_called()
+
+
+def test_api_session_metadata_keeps_cli_lookup_for_imported_cli_session():
+    """Imported CLI/messaging sessions still need Agent metadata for overlap handling."""
+    session = _FakeSession(is_cli_session=True, session_source="messaging", source_tag="telegram")
+
+    captured, lookup = _invoke_api_session(
+        session,
+        lookup_cli=lambda sid: {
+            "session_id": sid,
+            "session_source": "messaging",
+            "source_tag": "telegram",
+            "raw_source": "telegram",
+            "source_label": "Telegram",
+        },
+    )
+
+    assert captured["status"] == 200
+    assert captured["data"]["session"]["source_tag"] == "telegram"
+    lookup.assert_called_once_with("native_webui_001")


### PR DESCRIPTION
## Thinking Path
- Session switching remained slow after PR #2166 removed duplicate browser post-processing work.
- Local profiling on the user's real 8787 state showed browser rendering was no longer the dominant cost: `renderMessages` was tens of milliseconds and post-processing was roughly 0-2 ms.
- The remaining hot path was `/api/session?messages=0&resolve_model=0`, where native WebUI sessions still paid `_lookup_cli_session_metadata()` on every metadata load.
- That helper scans Agent/CLI session metadata through `get_cli_sessions()`, which is needed for imported CLI and messaging-backed sessions but not for ordinary WebUI-native sessions.
- This PR keeps the Agent metadata merge path for CLI/messaging sessions and skips it for native WebUI sessions.

## What Changed
- Added `_needs_cli_session_metadata()` to identify sessions that still require the Agent/CLI metadata lookup.
- Changed `/api/session` metadata loading to call `_lookup_cli_session_metadata()` only for CLI-backed or messaging-backed sessions.
- Added regression coverage proving native WebUI sessions do not query CLI metadata while imported CLI/messaging sessions still do.
- Updated the changelog.

## Why It Matters
Native WebUI session switches should not synchronously scan Agent state just to load local WebUI session metadata. On the user's real long-session state, the old path spent hundreds of milliseconds to over a second in CLI metadata lookup before the browser could finish switching sessions.

Measured on the same real session (`20260513_112418_89ca08`, 1,793 messages) via direct `handle_get(/api/session?messages=0&resolve_model=0)` calls:

- Before: median 662.82 ms, samples `[1462.50, 487.24, 434.11, 1244.67, 1222.42, 779.24, 546.39, 391.03]`
- After: median 1.71 ms, samples `[2.17, 1.86, 1.79, 1.68, 1.74, 1.67, 1.62, 1.61]`

This is a follow-up to the measured session-switch latency tracker in #2168 and complements PR #2166.

## Verification
- `/Users/xuefusong/hermes-webui/.venv/bin/python -m pytest -q tests/test_session_metadata_cli_lookup.py tests/test_session_import_cli_fallback_model.py tests/test_gateway_sync.py::test_gateway_session_messages_readable tests/test_gateway_sync.py::test_session_prefers_state_db_messages_over_stale_local_snapshot tests/test_gateway_sync.py::test_sessions_prefers_state_db_metadata_for_messaging_overlap tests/test_metadata_save_wipe_1558.py`
- Result: `24 passed`
- `/Users/xuefusong/hermes-webui/.venv/bin/python -m py_compile api/routes.py`
- `git diff --check`
- Local real-state timing comparison listed above.

## Risks / Follow-ups
- Imported CLI and messaging-backed session paths still perform the Agent metadata lookup, because those paths need state.db metadata and transcript overlap handling.
- This does not optimize `messages=1` tail-window fetches or deferred `resolve_model=1`; those remain separate candidates under #2168 if profiling shows they matter next.

## Model Used
AI-assisted with OpenAI GPT-5 via Codex. Local profiling, tests, implementation, and PR text were produced with AI assistance and verified with the commands above.

Refs #2168. Related to #2166.
