### PR TITLE
Soften session lineage count badge

### DIFF
--- a/static/i18n.js
+++ b/static/i18n.js
@@ -686,7 +686,10 @@ const LOCALES = {
     workspace_desc: 'Add and switch workspaces for your sessions.',
     session_meta_messages: (n) => `${n} msg${n === 1 ? '' : 's'}`,
     session_meta_children: (n) => `${n} child${n === 1 ? '' : 'ren'}`,
-    session_meta_segments: (n) => `${n} segment${n === 1 ? '' : 's'}`,
+    // Softened label: avoids exposing the technical internal term
+    // 'segment' in the default visible badge. User-facing copy remains
+    // translatable for locales that prefer a different wording. (#2155)
+    session_meta_segments: (n) => `${n} prior turn${n === 1 ? '' : 's'}`,
     session_lineage_segment_untitled: 'Untitled segment',
     session_lineage_segment_open: 'Open lineage segment',
     new_profile: 'New profile',

--- a/tests/test_session_lineage_collapse.py
+++ b/tests/test_session_lineage_collapse.py
@@ -400,3 +400,30 @@ def test_lineage_segment_locale_keys_are_defined_for_sidebar_locales():
     locale_count = i18n.count("session_meta_messages:")
     for key in required:
         assert i18n.count(key) >= locale_count, f"{key} missing from one or more locale blocks"
+
+def test_session_meta_segments_softened_label_no_literal_segment_in_english():
+    """Regression: the sidebar badge for compressed/lineage rows must not visibly
+    say 'X segments' by default — the technical internal term should be replaced
+    with softer user-facing copy (#2155).
+
+    This verifies the English base locale's session_meta_segments key so that
+    t() fallback for untranslated locales also produces softened copy.
+    """
+    import re
+    i18n_text = (REPO_ROOT / 'static' / 'i18n.js').read_text(encoding='utf-8')
+    # Locate the English base-locale block (first occurrence, before any _lang guard).
+    first_lang = i18n_text.index('_lang: \'en\'')
+    second_lang = i18n_text.index('_lang:', first_lang + 1)
+    english_slice = i18n_text[first_lang:second_lang]
+    assert 'session_meta_segments:' in english_slice, 'session_meta_segments missing from English locale'
+    # Capture only the arrow-function value (not the key name which also contains 'segment').
+    match = re.search(
+        r"session_meta_segments:\s*(\(\w+\)\s*=>\s*[^,]+)",
+        english_slice,
+    )
+    assert match, 'session_meta_segments value not found in English locale'
+    rendered = match.group(1)
+    assert 'segment' not in rendered, (
+        f"session_meta_segments English value still contains the technical word 'segment': {rendered}. "
+        "Expected softened copy like 'prior turn(s)' instead. See #2155."
+    )


### PR DESCRIPTION
## Summary
- change the session lineage count badge from `X segments` to softer `X prior turn(s)` copy in the English base locale
- keep the existing lineage expand/collapse behavior and accessibility attributes untouched
- add a focused regression test for the English badge label so the old visible `segments` wording fails

Refs #2155

## Verification
- `git diff --check`
- `python -m py_compile api/*.py server.py`
- `pytest -q tests -k "session or sidebar or lineage"`