### PR TITLE
fix: handle dict model entries in provider models list

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -3500,7 +3500,9 @@ def get_available_models() -> dict:
                         if isinstance(cfg_models, dict):
                             raw_models = [{"id": k, "label": k} for k in cfg_models.keys()]
                         elif isinstance(cfg_models, list):
-                            raw_models = [{"id": k, "label": k} for k in cfg_models]
+                            raw_models = [{"id": k["id"] if isinstance(k, dict) else k,
+                                            "label": k.get("label", k["id"]) if isinstance(k, dict) else k}
+                                           for k in cfg_models]
 
                     if not raw_models:
                         raw_models = _models_from_live_provider_ids(


### PR DESCRIPTION
When a provider's 'models' config contains dicts (e.g. {"id": "x", "label": "y"}) instead of plain strings, _apply_provider_prefix() crashes with:
  AttributeError: 'dict' object has no attribute 'startswith'

This happens because the list comprehension at line 3505 passes the raw dict as the model ID. The fix extracts 'id' and 'label' from dict entries while keeping string entries as-is.

Fixes the /api/models and /api/onboarding/status 500 errors.