### PR TITLE
fix: keep compression banner attached to the compaction marker

### DIFF
--- a/static/ui.js
+++ b/static/ui.js
@@ -4890,6 +4890,7 @@ function renderMessages(options){
   inner.innerHTML='';
   const compressionNode=compressionState?_compressionCardsNode(compressionState):null;
   const referenceMessage=S.messages.find(m=>_isContextCompactionMessage(m));
+  const referenceMessageRawIdx=referenceMessage?S.messages.findIndex(m=>m===referenceMessage):-1;
   const referenceText=referenceMessage
     ? msgContent(referenceMessage)||String(referenceMessage.content||'')
     : sessionCompressionSummary;
@@ -5171,7 +5172,8 @@ function renderMessages(options){
   const handoffSummaryStates=_collectHandoffSummaryStates(S.messages);
 
   _insertCompressionLikeNode(compressionNode);
-  _insertCompressionLikeNode(referenceNode);
+  if(referenceNode&&referenceMessageRawIdx>=0) _insertCompressionLikeNodeByRawIdx(referenceNode, referenceMessageRawIdx);
+  else _insertCompressionLikeNode(referenceNode);
   _insertCompressionLikeNode(preservedOnlyNode, preservedOnlyAnchor);
   _insertCompressionLikeNode(handoffState?_handoffCardsNode(handoffState):null, renderVisWithIdx.length?renderVisWithIdx.length-1:null);
   for(const entry of handoffSummaryStates){

--- a/static/ui.js
+++ b/static/ui.js
@@ -4472,9 +4472,11 @@ function _compressionAnchorIndex(visWithIdx, anchorKey, fallbackIdx=null){
     for(let i=visWithIdx.length-1;i>=0;i--){
       const candidate=_compressionMessageAnchorKey(visWithIdx[i].m);
       if(!candidate) continue;
+      const anchorTs=String(anchorKey.ts??'');
+      const candidateTs=String(candidate.ts??'');
       if(
         candidate.role===String(anchorKey.role||'') &&
-        String(candidate.ts??'')===String(anchorKey.ts??'') &&
+        (!anchorTs||!candidateTs||candidateTs===anchorTs) &&
         String(candidate.text||'')===String(anchorKey.text||'') &&
         Number(candidate.attachments||0)===Number(anchorKey.attachments||0)
       ){
@@ -4938,13 +4940,19 @@ function renderMessages(options){
       break;
     }
   }
-  const insertionAnchor=_compressionAnchorIndex(
-    renderVisWithIdx,
+  const insertionAnchorFull=_compressionAnchorIndex(
+    visWithIdx,
     compressionState ? compressionState.anchorMessageKey : sessionCompressionAnchorKey,
     compressionState
       ? (typeof compressionState.anchorVisibleIdx==='number' ? compressionState.anchorVisibleIdx : compressionState.anchorRawIdx)
       : sessionCompressionAnchor
   );
+  let insertionAnchor=null;
+  if(typeof insertionAnchorFull==='number'){
+    if(insertionAnchorFull<windowStart) insertionAnchor=renderVisWithIdx.length?0:null;
+    else if(insertionAnchorFull<windowStart+renderVisWithIdx.length) insertionAnchor=insertionAnchorFull-windowStart;
+    else insertionAnchor=renderVisWithIdx.length?renderVisWithIdx.length-1:null;
+  }
   let _prevSepKey=null;
   let currentAssistantTurn=null;
   const assistantSegments=new Map();

--- a/static/ui.js
+++ b/static/ui.js
@@ -4486,6 +4486,24 @@ function _compressionAnchorIndex(visWithIdx, anchorKey, fallbackIdx=null){
   }
   return typeof fallbackIdx==='number' ? fallbackIdx : null;
 }
+function _latestCompressionReferenceMessage(messages, summaryText=''){
+  if(!Array.isArray(messages)||!messages.length) return {message:null, rawIdx:-1};
+  const summaryNorm=String(summaryText||'').replace(/\s+/g,' ').trim();
+  for(let i=messages.length-1;i>=0;i--){
+    const m=messages[i];
+    if(!_isContextCompactionMessage(m)) continue;
+    if(!summaryNorm) return {message:m, rawIdx:i};
+    let content='';
+    try{
+      content=String(msgContent(m)||'');
+    }catch(_){
+      content=String((m&&m.content)||'');
+    }
+    const contentNorm=content.replace(/\s+/g,' ').trim();
+    if(contentNorm.includes(summaryNorm)) return {message:m, rawIdx:i};
+  }
+  return {message:null, rawIdx:-1};
+}
 function _compressionReferenceCardHtml(text, open=false){
   const preview=text.split(/\n+/).filter(Boolean).slice(0,2).join(' ');
   return `
@@ -4889,8 +4907,10 @@ function renderMessages(options){
   $('emptyState').style.display=(vis.length||preservedCompressionTaskMessages.length)?'none':'';
   inner.innerHTML='';
   const compressionNode=compressionState?_compressionCardsNode(compressionState):null;
-  const referenceMessage=S.messages.find(m=>_isContextCompactionMessage(m));
-  const referenceMessageRawIdx=referenceMessage?S.messages.findIndex(m=>m===referenceMessage):-1;
+  const {message:referenceMessage, rawIdx:referenceMessageRawIdx}=_latestCompressionReferenceMessage(
+    S.messages,
+    sessionCompressionSummary
+  );
   const referenceText=referenceMessage
     ? msgContent(referenceMessage)||String(referenceMessage.content||'')
     : sessionCompressionSummary;

--- a/tests/test_auto_compression_card.py
+++ b/tests/test_auto_compression_card.py
@@ -244,6 +244,14 @@ def test_compression_anchor_index_is_translated_into_render_window():
     assert "windowStart+renderVisWithIdx.length" in block
 
 
+def test_reference_message_uses_raw_transcript_position_before_anchor_fallback():
+    src = _read("static/ui.js")
+
+    assert "const referenceMessageRawIdx=referenceMessage?S.messages.findIndex(m=>m===referenceMessage):-1;" in src
+    assert "if(referenceNode&&referenceMessageRawIdx>=0) _insertCompressionLikeNodeByRawIdx(referenceNode, referenceMessageRawIdx);" in src
+    assert "else _insertCompressionLikeNode(referenceNode);" in src
+
+
 def test_preserved_task_list_attaches_once_per_render():
     src = _read("static/ui.js")
 

--- a/tests/test_auto_compression_card.py
+++ b/tests/test_auto_compression_card.py
@@ -217,6 +217,33 @@ def test_context_anchor_reference_uses_session_summary_fallback():
     assert "!!referenceText && (sessionCompressionAnchor!==null || sessionCompressionAnchorKey || sessionCompressionSummary)" in src
 
 
+def test_compression_anchor_matching_tolerates_legacy_missing_timestamp():
+    src = _read("static/ui.js")
+    start = src.find("function _compressionAnchorIndex")
+    assert start != -1, "compression anchor matcher not found"
+    end = src.find("function _compressionReferenceCardHtml", start)
+    assert end != -1, "compression reference renderer not found after anchor matcher"
+    helper = src[start:end]
+
+    assert "const anchorTs=String(anchorKey.ts??'');" in helper
+    assert "const candidateTs=String(candidate.ts??'');" in helper
+    assert "(!anchorTs||!candidateTs||candidateTs===anchorTs)" in helper
+
+
+def test_compression_anchor_index_is_translated_into_render_window():
+    src = _read("static/ui.js")
+    start = src.find("const insertionAnchorFull=_compressionAnchorIndex")
+    assert start != -1, "full compression anchor lookup not found"
+    end = src.find("let _prevSepKey=null", start)
+    assert end != -1, "message render loop marker not found after anchor lookup"
+    block = src[start:end]
+
+    assert "_compressionAnchorIndex(\n    visWithIdx," in block
+    assert "insertionAnchorFull<windowStart" in block
+    assert "insertionAnchorFull-windowStart" in block
+    assert "windowStart+renderVisWithIdx.length" in block
+
+
 def test_preserved_task_list_attaches_once_per_render():
     src = _read("static/ui.js")
 

--- a/tests/test_auto_compression_card.py
+++ b/tests/test_auto_compression_card.py
@@ -247,9 +247,34 @@ def test_compression_anchor_index_is_translated_into_render_window():
 def test_reference_message_uses_raw_transcript_position_before_anchor_fallback():
     src = _read("static/ui.js")
 
-    assert "const referenceMessageRawIdx=referenceMessage?S.messages.findIndex(m=>m===referenceMessage):-1;" in src
+    assert "const {message:referenceMessage, rawIdx:referenceMessageRawIdx}=_latestCompressionReferenceMessage(" in src
     assert "if(referenceNode&&referenceMessageRawIdx>=0) _insertCompressionLikeNodeByRawIdx(referenceNode, referenceMessageRawIdx);" in src
     assert "else _insertCompressionLikeNode(referenceNode);" in src
+
+
+def test_reference_message_selection_prefers_latest_matching_marker():
+    src = _read("static/ui.js")
+    start = src.find("function _latestCompressionReferenceMessage")
+    assert start != -1, "compression reference selection helper not found"
+    end = src.find("function _compressionReferenceCardHtml", start)
+    assert end != -1, "compression reference renderer not found after selection helper"
+    helper = src[start:end]
+
+    assert "for(let i=messages.length-1;i>=0;i--)" in helper
+    assert "if(!summaryNorm) return {message:m, rawIdx:i};" in helper
+    assert "if(contentNorm.includes(summaryNorm)) return {message:m, rawIdx:i};" in helper
+
+
+def test_reference_message_falls_back_to_current_summary_when_only_stale_markers_exist():
+    src = _read("static/ui.js")
+    start = src.find("function _latestCompressionReferenceMessage")
+    assert start != -1, "compression reference selection helper not found"
+    end = src.find("function _compressionReferenceCardHtml", start)
+    assert end != -1, "compression reference renderer not found after selection helper"
+    helper = src[start:end]
+
+    assert "const summaryNorm=String(summaryText||'').replace(/\\s+/g,' ').trim();" in helper
+    assert "return {message:null, rawIdx:-1};" in helper
 
 
 def test_preserved_task_list_attaches_once_per_render():


### PR DESCRIPTION
## Summary

Fixes several related cases where the context compression banner can appear to drift away from the actual compaction boundary in long WebUI conversations.

### Case 1: windowed transcript rendering

The compression anchor is stored as an index into the full visible transcript, but `renderMessages()` renders only a sliced `renderVisWithIdx` window. When the anchor key cannot be matched, the previous code passed the full visible index directly into the rendered-window array. For long sessions this index is usually outside the current render window, so the compression card falls back to `inner.appendChild(node)` and appears near the newest messages instead of near the compression boundary.

### Case 2: persisted compaction reference messages

Some sessions already contain a persisted `[CONTEXT COMPACTION — REFERENCE ONLY]` message in the transcript. That message can be a stronger placement signal than anchor metadata, because it preserves the raw transcript position where compaction happened.

### Case 3: stale / multiple compaction markers

Long sessions can contain multiple older persisted compaction reference messages. The banner should not blindly attach to the first or latest marker. A persisted marker is only authoritative when its content matches the current `compression_anchor_summary`; otherwise placement falls back to the current anchor metadata.

This prevents a new compression banner from attaching to an older compaction marker in the same transcript.

This change also keeps anchor matching tolerant of older persisted anchor keys that do not include a timestamp. Some existing sessions have `compression_anchor_message_key.ts = null`, while the corresponding message later has `_ts`/`timestamp` stamped. Strict timestamp comparison makes those anchors fail to match.

## Fix

- Match compression anchors by role/text/attachments even when either side is missing a timestamp.
- Resolve the anchor against the full `visWithIdx` list, not the sliced render window.
- Translate the full visible index into the current `renderVisWithIdx` window before inserting the compression card.
- Clamp off-window anchors to the nearest rendered boundary instead of appending to the bottom.
- If the current transcript contains a persisted compaction reference message matching the current `compression_anchor_summary`, insert the banner relative to that message's raw transcript position.
- Ignore stale persisted compaction markers whose content does not match the current compression summary.

## Why this is correct

There are now three levels of placement fidelity, in descending priority:

1. A persisted compaction reference message that matches the current compression summary
2. A matched saved anchor key
3. A saved anchor index fallback

This keeps the banner stable across normal long-session windowing, partially damaged sidecars, and transcripts that contain multiple older compaction markers.

## Tests

Added / updated coverage for:

- legacy missing-timestamp anchor keys still matching
- full visible anchor indexes being translated into render-window indexes
- persisted compaction reference messages being positioned by their raw transcript location before anchor fallback
- stale persisted compaction markers being ignored when they do not match the current compression summary

Tested with:

```bash
pytest -q tests/test_auto_compression_card.py tests/test_issue2028_compression_anchor_helpers.py
