### PR TITLE
fix: prevent concurrent send() from losing messages or swallowing stream output

### DIFF
--- a/static/messages.js
+++ b/static/messages.js
@@ -52,7 +52,28 @@ const _msgEl=document.getElementById('msg');
 if(_msgEl) _msgEl.addEventListener('focus', ()=>{ if('speechSynthesis' in window && speechSynthesis.speaking) speechSynthesis.pause(); });
 if(_msgEl) _msgEl.addEventListener('blur', ()=>{ if('speechSynthesis' in window && speechSynthesis.paused) speechSynthesis.resume(); });
 
+// Guard against concurrent send() calls.  Without this, two rapid sends
+// (e.g. queue drain + user click) can both pass the S.busy check because
+// setBusy(true) is only called after the first await inside send().
+let _sendInProgress = false;
+
 async function send(){
+  // Reject concurrent invocations early — before any await yields control.
+  // If a send is already in-flight (e.g. queue drain), re-queue the message
+  // instead of silently dropping it.
+  if (_sendInProgress) {
+    const _text=$('msg').value.trim();
+    if(_text && S.session && S.session.session_id){
+      queueSessionMessage(S.session.session_id,{text:_text,files:[...S.pendingFiles],model:S.session&&S.session.model||($('modelSelect')&&$('modelSelect').value)||'',model_provider:S.session&&S.session.model_provider||null,profile:S.activeProfile||'default'});
+      $('msg').value='';autoResize();
+      S.pendingFiles=[];renderTray();
+      updateQueueBadge(S.session.session_id);
+      showToast(`Queued: "${_text.slice(0,40)}${_text.length>40?'…':''}"`,2000);
+    }
+    return;
+  }
+  _sendInProgress = true;
+  try{
   const text=$('msg').value.trim();
   if(!text&&!S.pendingFiles.length)return;
   // Don't send while an inline message edit is active
@@ -337,6 +358,7 @@ async function send(){
   // Open SSE stream and render tokens live
   attachLiveStream(activeSid, streamId, uploadedNames);
 
+  }finally{ _sendInProgress=false; }
 }
 
 const LIVE_STREAMS={};

--- a/tests/test_1062_busy_input_modes.py
+++ b/tests/test_1062_busy_input_modes.py
@@ -268,7 +268,7 @@ class TestSendBusyBranchDispatch:
 
     def test_send_calls_cancel_stream_on_interrupt(self):
         send_idx = MESSAGES_JS.find("async function send(")
-        send_body = MESSAGES_JS[send_idx:send_idx + 3000]
+        send_body = MESSAGES_JS[send_idx:send_idx + 5000]
         # The interrupt branch must call cancelStream
         assert "cancelStream" in send_body
         # And queue before cancel (otherwise the drain has nothing to pick up)


### PR DESCRIPTION
## Problem

When two messages are sent in rapid succession (e.g. queue drain + user click), the second `send()` can pass the `S.busy` check because `setBusy(true)` only runs **after** the first `await` inside `send()`. This creates a window where two async `send()` calls run concurrently, leading to:

- **Streaming output swallowed** — Stream A's `done` event fires → `S.messages = d.session.messages` overwrites everything, including Stream B's partial output
- **User messages lost** — Server returns 409 for the duplicate `/api/chat/start`, and the error path can't recover the local message state

## Root Cause

```js
async function send(){
  // S.busy is still false here ← GAP
  ...uploaded = await uploadPendingFiles(); // ← yields, S.busy still false
  ...setBusy(true); // ← too late, second send() already entered
  ...await api("/api/chat/start"); // ← another yield point
```

Two `send()` calls can both pass the `if(S.busy)` check during these await windows.

## Fix

Add a **synchronous** `_sendInProgress` flag at the very top of `send()` (before any `await`). Concurrent calls **re-queue** the message instead of silently dropping it. `try/finally` ensures the flag resets on all exit paths (returns, errors, normal completion).

## Testing

- All existing tests pass
- `test_1062_busy_input_modes.py` window widened from 3000→5000 chars to accommodate the new guard block

> Split from #2164 per review feedback. This PR contains only the concurrent-send guard. The steer visual badge change will be submitted separately.