### PR TITLE
fix: refresh context ring after compression

### DIFF
--- a/api/streaming.py
+++ b/api/streaming.py
@@ -3421,7 +3421,9 @@ def _run_agent_streaming(
                         or _compression_summary_from_messages(s.context_messages)
                     )
                     put('compressed', {
+                        'session_id': s.session_id,
                         'message': 'Context auto-compressed to continue the conversation',
+                        'usage': _live_usage_snapshot(),
                     })
 
                 # Stamp 'timestamp' on any messages that don't have one yet

--- a/static/messages.js
+++ b/static/messages.js
@@ -1175,7 +1175,12 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       if(!S.session||S.session.session_id!==activeSid) return;
       let d={};
       try{ d=JSON.parse(e.data||'{}')||{}; }catch(_){ d={}; }
+      if(d.session_id&&d.session_id!==activeSid) return;
       const message=String(d.message||'Context auto-compressed to continue the conversation').trim();
+      if(d.usage&&typeof _syncCtxIndicator==='function'){
+        S.lastUsage={...(S.lastUsage||{}),...d.usage};
+        _syncCtxIndicator(S.lastUsage);
+      }
       if(typeof setCompressionUi==='function'){
         setCompressionUi({
           sessionId:activeSid,

--- a/tests/test_auto_compression_card.py
+++ b/tests/test_auto_compression_card.py
@@ -87,6 +87,28 @@ def test_auto_compression_sse_keeps_inactive_and_malformed_paths_safe():
     assert guard in block
     assert block.index(guard) < block.index("setCompressionUi")
     assert "try{ d=JSON.parse(e.data||'{}')||{}; }catch(_){ d={}; }" in block
+    assert "if(d.session_id&&d.session_id!==activeSid) return;" in block
+
+
+def test_auto_compression_done_sse_refreshes_context_indicator_usage():
+    block = _compressed_listener_block()
+
+    assert "if(d.usage&&typeof _syncCtxIndicator==='function')" in block
+    assert "S.lastUsage={...(S.lastUsage||{}),...d.usage};" in block
+    assert "_syncCtxIndicator(S.lastUsage);" in block
+    assert block.index("_syncCtxIndicator(S.lastUsage);") < block.index("setCompressionUi")
+
+
+def test_auto_compression_done_payload_includes_live_usage_snapshot():
+    src = _read("api/streaming.py")
+    start = src.find("put('compressed'")
+    assert start != -1, "compressed SSE payload not found"
+    end = src.find("})", start)
+    assert end != -1, "compressed SSE payload end not found"
+    block = src[start:end]
+
+    assert "'session_id': s.session_id" in block
+    assert "'usage': _live_usage_snapshot()" in block
 
 
 def test_auto_compression_card_reuses_compression_card_renderer():


### PR DESCRIPTION
## Summary

Refresh the context progress indicator immediately when automatic context compression completes.

Before this change, the auto-compression `compressed` SSE event only updated the compression card/toast. The context progress ring continued to show the pre-compression token usage until a later `metering`/`done` update or the next message. This made the UI look like compression had completed but the session was still near the context limit.

## Problem

When a turn triggers automatic context compression:

1. The backend emits `compressing`.
2. The backend performs compression and emits `compressed`.
3. The UI switches the compression card to the completed state.
4. The context progress ring can still display stale pre-compression usage.

This is confusing because the compression status and the token indicator disagree immediately after compression finishes.

## Fix

The backend now includes a live usage snapshot in the `compressed` SSE payload:

- `session_id`
- `usage`

The frontend `compressed` event handler now:

- ignores events for inactive sessions
- merges `d.usage` into `S.lastUsage`
- calls `_syncCtxIndicator(S.lastUsage)` before rendering the completed compression card

This keeps the progress ring in sync as soon as compression completes, without waiting for a later event.

## Summary

Fix the context progress ring staying stale after automatic context compression completes.

Before this change, the WebUI showed the automatic compression completion card/toast when the `compressed` SSE event arrived, but the context indicator still reflected the pre-compression token usage. It only refreshed later when another usage-bearing event arrived, usually after the next assistant/model step. This made compression look incomplete even though the backend had already compacted the session.

## Problem

Automatic compression updates the persisted session state immediately, but the `compressed` SSE payload did not include the refreshed token usage snapshot.

The frontend `compressed` event handler only updated the compression UI state:

- marks the compression card as done
- clears the compression session lock
- re-renders messages
- shows a toast

It did not call `_syncCtxIndicator()`, so the context progress ring could remain at the old high-water usage until a later `metering` or `done` event.

## Fix

This PR makes the compression completion event carry enough state for the UI to refresh immediately.

Backend:

- Adds `session_id` to the `compressed` SSE payload so the frontend can ignore stale/cross-session events.
- Adds `usage: _live_usage_snapshot()` to the `compressed` SSE payload after auto-compression is detected.

Frontend:

- The `compressed` listener now ignores events whose `session_id` does not match the active session.
- When `d.usage` is present, it merges the usage into `S.lastUsage`.
- It calls `_syncCtxIndicator(S.lastUsage)` before rendering the compression completion card.

This keeps the context ring in sync as soon as compression completes, without waiting for the next model/tool/metering event.

## Testing

```bash
pytest -q tests/test_auto_compression_card.py tests/test_issue1617_tps_message_header.py tests/test_issue2028_compression_anchor_helpers.py
