### PR TITLE
fix: keep background metering from overwriting visible session usage

### DIFF
--- a/static/messages.js
+++ b/static/messages.js
@@ -1195,8 +1195,10 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         const d=JSON.parse(e.data||'{}');
         if((d.session_id||activeSid)!==activeSid) return;
         if(d.usage&&typeof _syncCtxIndicator==='function'){
-          S.lastUsage={...(S.lastUsage||{}),...d.usage};
-          _syncCtxIndicator(S.lastUsage);
+          if(S.session&&S.session.session_id===activeSid){
+            S.lastUsage={...(S.lastUsage||{}),...d.usage};
+            _syncCtxIndicator(S.lastUsage);
+          }
         }
         if(d.estimated===true||d.tps_available!==true||typeof d.tps!=='number'||d.tps<=0){
           if(typeof _setLiveAssistantTps==='function') _setLiveAssistantTps(null);


### PR DESCRIPTION
## Summary
- scope live metering usage updates to the session currently visible in the chat pane
- prevent background streams from overwriting `S.lastUsage` and the composer context indicator for the active session

## Testing
- not run (UI state fix)