### PR TITLE
fix(auth) 1/3: thread-safe login rate limiter + PBKDF2 key separation + transparent migration

### DIFF
--- a/api/auth.py
+++ b/api/auth.py
@@ -317,8 +317,9 @@ def verify_password(plain: str) -> bool:
             from api.config import save_settings
 
             save_settings({'_set_password': plain})
-            # Cache invalidated inside save_settings(); the next call to
-            # get_password_hash() will re-read and warm the cache automatically.
+            # Password re-hashed and persisted to disk using the current salt.
+            # Cache invalidation is handled by fix 2/3 (#2192) which adds the
+            # _invalidate_password_hash_cache() call inside save_settings().
             return True
     return False
 

--- a/api/auth.py
+++ b/api/auth.py
@@ -203,17 +203,22 @@ def _load_key(filename: str) -> bytes:
     return key
 
 
+_PBKDF2_KEY_CACHE: bytes | None = None
+_SIGNING_KEY_CACHE: bytes | None = None
+
+
 def _pbkdf2_key() -> bytes:
-    """Salt for password hashing (PBKDF2). Persisted so password hashes remain
-    valid across restarts. Separate from _signing_key to avoid key reuse across
-    different cryptographic primitives."""
-    return _load_key('.pbkdf2_key')
+    global _PBKDF2_KEY_CACHE
+    if _PBKDF2_KEY_CACHE is None:
+        _PBKDF2_KEY_CACHE = _load_key('.pbkdf2_key')
+    return _PBKDF2_KEY_CACHE
 
 
 def _signing_key() -> bytes:
-    """HMAC key for session signing. Persisted so signed cookies remain
-    valid across restarts."""
-    return _load_key('.signing_key')
+    global _SIGNING_KEY_CACHE
+    if _SIGNING_KEY_CACHE is None:
+        _SIGNING_KEY_CACHE = _load_key('.signing_key')
+    return _SIGNING_KEY_CACHE
 
 
 def _hash_password(password, *, salt: bytes | None = None) -> str:
@@ -312,8 +317,8 @@ def verify_password(plain) -> bool:
             from api.config import save_settings
 
             save_settings({'_set_password': plain})
-            _invalidate_password_hash_cache()
-            get_password_hash()
+            # Cache invalidated inside save_settings(); the next call to
+            # get_password_hash() will re-read and warm the cache automatically.
             return True
     return False
 

--- a/api/auth.py
+++ b/api/auth.py
@@ -191,14 +191,14 @@ def _load_key(filename: str) -> bytes:
             raw = key_file.read_bytes()
             if len(raw) >= 32:
                 return raw[:32]
-    except Exception:
+    except OSError:
         logger.debug("Failed to read key %s", filename)
     key = secrets.token_bytes(32)
     try:
         STATE_DIR.mkdir(parents=True, exist_ok=True)
         key_file.write_bytes(key)
         key_file.chmod(0o600)
-    except Exception:
+    except OSError:
         logger.debug("Failed to persist key %s", filename)
     return key
 
@@ -293,7 +293,7 @@ def is_auth_enabled() -> bool:
     return get_password_hash() is not None
 
 
-def verify_password(plain) -> bool:
+def verify_password(plain: str) -> bool:
     """Verify a plaintext password against the stored hash.
 
     Supports transparent migration of password hashes that were computed

--- a/api/auth.py
+++ b/api/auth.py
@@ -155,58 +155,80 @@ def _save_login_attempts(attempts: dict[str, list[float]]) -> None:
 
 
 _login_attempts = _load_login_attempts()  # ip -> [timestamp, ...]
+_LOGIN_ATTEMPTS_LOCK = threading.Lock()
 
 
 def _check_login_rate(ip: str) -> bool:
-    """Return True if the IP is allowed to attempt login."""
-    now = time.time()
-    attempts = _login_attempts.get(ip, [])
-    # Prune old attempts
-    attempts = [t for t in attempts if now - t < _LOGIN_WINDOW]
-    if attempts:
-        _login_attempts[ip] = attempts
-    else:
-        _login_attempts.pop(ip, None)
-    _save_login_attempts(_login_attempts)
-    return len(attempts) < _LOGIN_MAX_ATTEMPTS
+    """Return True if the IP is allowed to attempt login (thread-safe)."""
+    with _LOGIN_ATTEMPTS_LOCK:
+        now = time.time()
+        attempts = _login_attempts.get(ip, [])
+        # Prune old attempts
+        attempts = [t for t in attempts if now - t < _LOGIN_WINDOW]
+        if attempts:
+            _login_attempts[ip] = attempts
+        else:
+            _login_attempts.pop(ip, None)
+        _save_login_attempts(_login_attempts)
+        return len(attempts) < _LOGIN_MAX_ATTEMPTS
 
 
 def _record_login_attempt(ip: str) -> None:
-    now = time.time()
-    attempts = _login_attempts.get(ip, [])
-    attempts.append(now)
-    _login_attempts[ip] = attempts
-    _save_login_attempts(_login_attempts)
+    """Record a login attempt for rate limiting (thread-safe)."""
+    with _LOGIN_ATTEMPTS_LOCK:
+        now = time.time()
+        attempts = _login_attempts.get(ip, [])
+        attempts.append(now)
+        _login_attempts[ip] = attempts
+        _save_login_attempts(_login_attempts)
 
 
-def _signing_key():
-    """Return a random signing key, generating and persisting one on first call."""
-    key_file = STATE_DIR / '.signing_key'
+def _load_key(filename: str) -> bytes:
+    """Load a 32-byte key from STATE_DIR, generating and persisting one if missing."""
+    key_file = STATE_DIR / filename
     try:
         if key_file.exists():
             raw = key_file.read_bytes()
             if len(raw) >= 32:
                 return raw[:32]
     except Exception:
-        logger.debug("Failed to read or access signing key file, using in-memory key")
-    # Generate a new random key
+        logger.debug("Failed to read key %s", filename)
     key = secrets.token_bytes(32)
     try:
         STATE_DIR.mkdir(parents=True, exist_ok=True)
         key_file.write_bytes(key)
         key_file.chmod(0o600)
     except Exception:
-        logger.debug("Failed to persist signing key, using in-memory key only")
+        logger.debug("Failed to persist key %s", filename)
     return key
 
 
-def _hash_password(password):
+def _pbkdf2_key() -> bytes:
+    """Salt for password hashing (PBKDF2). Persisted so password hashes remain
+    valid across restarts. Separate from _signing_key to avoid key reuse across
+    different cryptographic primitives."""
+    return _load_key('.pbkdf2_key')
+
+
+def _signing_key() -> bytes:
+    """HMAC key for session signing. Persisted so signed cookies remain
+    valid across restarts."""
+    return _load_key('.signing_key')
+
+
+def _hash_password(password, *, salt: bytes | None = None) -> str:
     """PBKDF2-SHA256 with 600k iterations (OWASP recommendation).
-    Salt is the persisted random signing key, which is secret and unique per
+    Salt is the persisted PBKDF2 key, which is secret and unique per
     installation. This keeps the stored hash format a plain hex string
     (no format change to settings.json) while replacing the predictable
-    STATE_DIR-derived salt from the original implementation."""
-    salt = _signing_key()
+    STATE_DIR-derived salt from the original implementation.
+
+    The *salt* parameter exists solely to support transparent migration
+    of password hashes that were computed with a different key (e.g. the
+    old `.signing_key`). Normal callers should never pass it.
+    """
+    if salt is None:
+        salt = _pbkdf2_key()
     dk = hashlib.pbkdf2_hmac('sha256', password.encode(), salt, 600_000)
     return dk.hex()
 
@@ -214,6 +236,15 @@ def _hash_password(password):
 _AUTH_HASH_LOCK = threading.Lock()
 _AUTH_HASH_COMPUTED: bool = False
 _AUTH_HASH_CACHE: str | None = None
+
+
+def _invalidate_password_hash_cache() -> None:
+    """Invalidate the in-process password hash cache so the next call to
+    get_password_hash() re-reads from settings.json or the env var."""
+    global _AUTH_HASH_COMPUTED, _AUTH_HASH_CACHE
+    with _AUTH_HASH_LOCK:
+        _AUTH_HASH_COMPUTED = False
+        _AUTH_HASH_CACHE = None
 
 
 def get_password_hash() -> str | None:
@@ -258,11 +289,33 @@ def is_auth_enabled() -> bool:
 
 
 def verify_password(plain) -> bool:
-    """Verify a plaintext password against the stored hash."""
+    """Verify a plaintext password against the stored hash.
+
+    Supports transparent migration of password hashes that were computed
+    with the old `.signing_key` salt.  When the two keys differ and the
+    legacy-salted hash matches, the password is transparently re-hashed
+    with the current `.pbkdf2_key` and persisted to settings.json.
+    """
     expected = get_password_hash()
     if not expected:
         return False
-    return hmac.compare_digest(_hash_password(plain), expected)
+    # Fast path: current PBKDF2 key
+    if hmac.compare_digest(_hash_password(plain), expected):
+        return True
+    # Migration: some hashes were computed with `.signing_key` before the
+    # PBKDF2 key was separated.  Try the legacy salt; if it matches,
+    # transparently upgrade so the next login uses the fast path.
+    legacy_salt = _signing_key()
+    current_salt = _pbkdf2_key()
+    if legacy_salt != current_salt:
+        if hmac.compare_digest(_hash_password(plain, salt=legacy_salt), expected):
+            from api.config import save_settings
+
+            save_settings({'_set_password': plain})
+            _invalidate_password_hash_cache()
+            get_password_hash()
+            return True
+    return False
 
 
 def create_session() -> str:

--- a/api/auth.py
+++ b/api/auth.py
@@ -11,6 +11,7 @@ import logging
 import os
 import secrets
 import tempfile
+import threading
 import time
 
 from api.config import STATE_DIR, load_settings
@@ -210,14 +211,45 @@ def _hash_password(password):
     return dk.hex()
 
 
+_AUTH_HASH_LOCK = threading.Lock()
+_AUTH_HASH_COMPUTED: bool = False
+_AUTH_HASH_CACHE: str | None = None
+
+
 def get_password_hash() -> str | None:
     """Return the active password hash, or None if auth is disabled.
-    Priority: env var > settings.json."""
-    env_pw = os.getenv('HERMES_WEBUI_PASSWORD', '').strip()
-    if env_pw:
-        return _hash_password(env_pw)
-    settings = load_settings()
-    return settings.get('password_hash') or None
+    Priority: env var > settings.json.
+
+    The hash is computed once and cached for the lifetime of the process.
+    PBKDF2-600k takes ~1 s and is called on nearly every HTTP request via
+    check_auth → is_auth_enabled, so caching avoids wasting a full second
+    of CPU per request after the first one.
+
+    Thread-safe: double-checked locking ensures that under a burst of
+    concurrent requests only one thread computes PBKDF2, while the fast
+    path (after initialisation) requires zero locks.
+    """
+    global _AUTH_HASH_COMPUTED, _AUTH_HASH_CACHE
+
+    # Fast path — no lock needed once cache is populated.
+    if _AUTH_HASH_COMPUTED:
+        return _AUTH_HASH_CACHE
+
+    with _AUTH_HASH_LOCK:
+        # Re-check inside lock — another thread may have populated while
+        # we were waiting to acquire.
+        if _AUTH_HASH_COMPUTED:
+            return _AUTH_HASH_CACHE
+
+        env_pw = os.getenv('HERMES_WEBUI_PASSWORD', '').strip()
+        if env_pw:
+            result = _hash_password(env_pw)
+        else:
+            result = load_settings().get('password_hash') or None
+
+        _AUTH_HASH_CACHE = result
+        _AUTH_HASH_COMPUTED = True
+        return result
 
 
 def is_auth_enabled() -> bool:

--- a/api/config.py
+++ b/api/config.py
@@ -4039,15 +4039,18 @@ def save_settings(settings: dict) -> dict:
     theme_was_explicit = False
     skin_was_explicit = False
     # Handle _set_password: hash and store as password_hash
+    _password_changed = False
     raw_pw = settings.pop("_set_password", None)
     if raw_pw and isinstance(raw_pw, str) and raw_pw.strip():
         # Use PBKDF2 from auth module (600k iterations) -- never raw SHA-256
         from api.auth import _hash_password
 
         current["password_hash"] = _hash_password(raw_pw.strip())
+        _password_changed = True
     # Handle _clear_password: explicitly disable auth
     if settings.pop("_clear_password", False):
         current["password_hash"] = None
+        _password_changed = True
     for k, v in settings.items():
         if k in _SETTINGS_ALLOWED_KEYS:
             if k == "theme":
@@ -4089,6 +4092,12 @@ def save_settings(settings: dict) -> dict:
         json.dumps(persisted, ensure_ascii=False, indent=2),
         encoding="utf-8",
     )
+    # Invalidate the in-memory password hash cache so the next call to
+    # get_password_hash() picks up the new value from disk immediately.
+    if _password_changed:
+        from api.auth import _invalidate_password_hash_cache
+
+        _invalidate_password_hash_cache()
     # Update runtime defaults so new sessions use them immediately
     global DEFAULT_WORKSPACE
     if "default_workspace" in current:

--- a/tests/test_auth_password_hash_cache.py
+++ b/tests/test_auth_password_hash_cache.py
@@ -17,6 +17,7 @@ the cached result.
 import importlib
 import os
 import sys
+import tempfile
 import threading
 import time
 import unittest
@@ -27,7 +28,6 @@ from pathlib import Path
 # sibling test files that need a fresh config import).  Deleting api.config
 # would change its module-level STATE_DIR global and leak into all
 # subsequently collected tests (breaking test_pytest_state_isolation.py).
-import tempfile
 _TEST_STATE = Path(tempfile.mkdtemp())
 os.environ["HERMES_WEBUI_STATE_DIR"] = str(_TEST_STATE)
 
@@ -64,7 +64,6 @@ class TestPasswordHashCache(unittest.TestCase):
         h = auth.get_password_hash()
         self.assertIsNotNone(h)
         self.assertIsInstance(h, str)
-        assert h is not None  # narrow type for type checker
         self.assertGreater(len(h), 10)
 
     def test_cache_flag_set_after_first_call(self):

--- a/tests/test_auth_password_hash_cache.py
+++ b/tests/test_auth_password_hash_cache.py
@@ -1,0 +1,236 @@
+"""
+Tests for get_password_hash() caching (env-var path).
+
+get_password_hash() calls PBKDF2-SHA256 with 600k iterations, which takes
+~1 second per invocation.  When HERMES_WEBUI_PASSWORD is set via env var,
+the hash never changes during the process lifetime, so the result should
+be computed once and cached.
+
+Performance regression: without caching, every HTTP request pays ~1s for
+PBKDF2 (check_auth -> is_auth_enabled -> get_password_hash), causing
+multi-second API response times.
+
+Thread-safety: under a burst of concurrent requests, only one thread must
+compute PBKDF2.  Double-checked locking ensures the others wait and receive
+the cached result.
+"""
+import importlib
+import os
+import sys
+import threading
+import time
+import unittest
+from pathlib import Path
+
+# Isolate state dir from production
+import tempfile
+_TEST_STATE = Path(tempfile.mkdtemp())
+os.environ["HERMES_WEBUI_STATE_DIR"] = str(_TEST_STATE)
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+# Ensure a clean module state
+for mod in list(sys.modules.keys()):
+    if 'api.auth' in mod or 'api.config' in mod:
+        del sys.modules[mod]
+
+import api.auth as auth
+
+
+class TestPasswordHashCache(unittest.TestCase):
+    """Verify that get_password_hash() caches after first computation."""
+
+    def setUp(self):
+        # Reset the module-level cache state
+        auth._AUTH_HASH_LOCK = threading.Lock()
+        auth._AUTH_HASH_COMPUTED = False
+        auth._AUTH_HASH_CACHE = None
+        # Clear the env var before each test so a dirty environment
+        # doesn't cascade across test boundaries
+        os.environ.pop('HERMES_WEBUI_PASSWORD', None)
+
+    def _set_env_pw(self, pw: str) -> None:
+        os.environ['HERMES_WEBUI_PASSWORD'] = pw
+
+    def test_first_call_returns_hash(self):
+        """First call with env var set should return a hex hash string."""
+        self._set_env_pw("hunter2")
+        h = auth.get_password_hash()
+        self.assertIsNotNone(h)
+        self.assertIsInstance(h, str)
+        assert h is not None  # narrow type for type checker
+        self.assertGreater(len(h), 10)
+
+    def test_cache_flag_set_after_first_call(self):
+        """_AUTH_HASH_COMPUTED should be True after first call."""
+        self._set_env_pw("test-password")
+        self.assertFalse(auth._AUTH_HASH_COMPUTED)
+        auth.get_password_hash()
+        self.assertTrue(auth._AUTH_HASH_COMPUTED)
+
+    def test_cache_hit_is_order_of_magnitude_faster(self):
+        """Second invocation must be >>10x faster than the first (sub-millisecond vs ~1s)."""
+        self._set_env_pw("a-fairly-long-password-for-benchmarking")
+        t0 = time.perf_counter()
+        first = auth.get_password_hash()
+        t_first = time.perf_counter() - t0
+        t0 = time.perf_counter()
+        second = auth.get_password_hash()
+        t_second = time.perf_counter() - t0
+        self.assertEqual(first, second,
+                         "Cached hash must match the original")
+        self.assertLess(t_second, t_first / 10,
+                        f"Cache hit ({t_second*1000:.1f}ms) should be "
+                        f">10x faster than first call ({t_first*1000:.1f}ms)")
+
+    def test_subsequent_calls_return_same_hash(self):
+        """Multiple calls after caching should all return the identical hash."""
+        self._set_env_pw("consistent-password")
+        hashes = [auth.get_password_hash() for _ in range(10)]
+        self.assertTrue(all(h == hashes[0] for h in hashes),
+                        "All cached calls must return the same hash")
+
+    def test_cache_lifetime_is_process_lifetime(self):
+        """Cached value persists for the lifetime of the process."""
+        self._set_env_pw("persistent-password")
+        first = auth.get_password_hash()
+        # The env var could change between calls — cache must still
+        # return the original value.
+        os.environ['HERMES_WEBUI_PASSWORD'] = 'different-password'
+        second = auth.get_password_hash()
+        self.assertEqual(first, second,
+                         "Cache must return the original hash even if "
+                         "the env var changes (process-lifetime semantics)")
+
+    def test_multiple_calls_no_env_var(self):
+        """When env var is unset, get_password_hash must still work.
+
+        This exercises the settings.json fallback path. The test state
+        dir is fresh, so no settings file exists — the result should
+        be None (auth disabled).
+        """
+        # Ensure no env var
+        os.environ.pop('HERMES_WEBUI_PASSWORD', None)
+        h = auth.get_password_hash()
+        self.assertIsNone(h, "With no env var and no settings file, "
+                             "hash should be None")
+        self.assertTrue(auth._AUTH_HASH_COMPUTED)
+
+    def test_cache_returns_none_when_disabled(self):
+        """Once computed as None (no password), cache must keep returning None."""
+        os.environ.pop('HERMES_WEBUI_PASSWORD', None)
+        h1 = auth.get_password_hash()
+        h2 = auth.get_password_hash()
+        self.assertIsNone(h1)
+        self.assertIsNone(h2)
+
+    def test_cache_independent_of_settings_file(self):
+        """Env-var path must not read or depend on settings.json.
+
+        The query count on settings.json before caching is acceptable;
+        after caching it must not touch settings at all.
+        """
+        # Force a hash via env var, then cache it
+        self._set_env_pw("env-only")
+        auth.get_password_hash()
+
+        # Tamper with the settings load — after caching this should not
+        # matter because settings.json is only read inside
+        # get_password_hash when COMPUTED is False.
+        _original_load = auth.load_settings
+        try:
+            auth.load_settings = lambda: {"password_hash": "evil"}
+            cached = auth.get_password_hash()
+            self.assertIsNotNone(cached)
+            # The hash should NOT come from the tampered settings
+            self.assertNotEqual(cached, "evil",
+                                "Cached env-var hash must not be replaced "
+                                "by a settings.json value")
+        finally:
+            auth.load_settings = _original_load
+
+
+class TestPasswordHashCacheConcurrency(unittest.TestCase):
+    """Verify thread-safety: concurrent burst must not duplicate PBKDF2."""
+
+    def setUp(self):
+        auth._AUTH_HASH_LOCK = threading.Lock()
+        auth._AUTH_HASH_COMPUTED = False
+        auth._AUTH_HASH_CACHE = None
+        os.environ.pop('HERMES_WEBUI_PASSWORD', None)
+
+    def _set_env_pw(self, pw: str) -> None:
+        os.environ['HERMES_WEBUI_PASSWORD'] = pw
+
+    def test_concurrent_burst_only_computes_once(self):
+        """Under a burst of N concurrent requests, PBKDF2 runs exactly once.
+
+        Each thread records how many times _hash_password was invoked
+        (via a monkey-patched wrapper).  After all threads finish, the
+        counter must be exactly 1 and all results identical.
+        """
+        self._set_env_pw("burst-test-password")
+
+        call_count = 0
+        count_lock = threading.Lock()
+
+        original_hash = auth._hash_password
+        def counting_hash(pw):
+            nonlocal call_count
+            with count_lock:
+                call_count += 1
+            return original_hash(pw)
+        auth._hash_password = counting_hash
+        try:
+            results: list = []
+            results_lock = threading.Lock()
+
+            def worker():
+                r = auth.get_password_hash()
+                with results_lock:
+                    results.append(r)
+
+            threads = [threading.Thread(target=worker) for _ in range(8)]
+            t0 = time.perf_counter()
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+            elapsed = time.perf_counter() - t0
+
+            self.assertEqual(call_count, 1,
+                             f"Expected 1 PBKDF2 call, got {call_count}. "
+                             "Threads are racing on cache population.")
+            self.assertEqual(len(set(results)), 1,
+                             "All threads must see the same hash")
+            # Elapsed time should be ~1s (one PBKDF2), not ~8s (serial).
+            # Use a generous 3× bound for slow machines.
+            self.assertLess(elapsed, 3.0,
+                            f"Burst took {elapsed:.1f}s — threads are likely "
+                            f"running PBKDF2 serially under the lock.")
+        finally:
+            auth._hash_password = original_hash
+
+    def test_concurrent_burst_with_no_env_var(self):
+        """Concurrent calls with no env var must all return None."""
+        os.environ.pop('HERMES_WEBUI_PASSWORD', None)
+        results: list = []
+        results_lock = threading.Lock()
+
+        def worker():
+            r = auth.get_password_hash()
+            with results_lock:
+                results.append(r)
+
+        threads = [threading.Thread(target=worker) for _ in range(5)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        self.assertTrue(all(r is None for r in results),
+                        "All threads must see None when auth is disabled")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_auth_password_hash_cache.py
+++ b/tests/test_auth_password_hash_cache.py
@@ -22,19 +22,25 @@ import time
 import unittest
 from pathlib import Path
 
-# Isolate state dir from production
+# Isolate state dir from production — only affects the auth module reload.
+# We deliberately do NOT delete api.config from sys.modules (unlike some
+# sibling test files that need a fresh config import).  Deleting api.config
+# would change its module-level STATE_DIR global and leak into all
+# subsequently collected tests (breaking test_pytest_state_isolation.py).
 import tempfile
 _TEST_STATE = Path(tempfile.mkdtemp())
 os.environ["HERMES_WEBUI_STATE_DIR"] = str(_TEST_STATE)
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-# Ensure a clean module state
-for mod in list(sys.modules.keys()):
-    if 'api.auth' in mod or 'api.config' in mod:
-        del sys.modules[mod]
-
-import api.auth as auth
+# Force a fresh import of the auth module so it picks up the isolated env var.
+# The auth module re-executes `from api.config import STATE_DIR, load_settings`
+# at import time, but api.config is already in sys.modules — Python just
+# rebinds the names from the existing module, keeping the conftest STATE_DIR
+# untouched.
+import api.auth
+importlib.reload(api.auth)
+auth = api.auth
 
 
 class TestPasswordHashCache(unittest.TestCase):


### PR DESCRIPTION
## Part 1 of 3 — merge first

> **Series**: split from `cache-pbkdf2-hash`. #2192 depends on this one. #2193 is independent and can be reviewed/merged in any order.

## Summary

- Add `_LOGIN_ATTEMPTS_LOCK` — concurrent failed logins raced on `_login_attempts` dict without a lock
- Extract `_load_key(filename)` + introduce `_pbkdf2_key()` (`.pbkdf2_key`) separate from `_signing_key()` (`.signing_key`) — key reuse across PBKDF2 and HMAC is unsafe
- `_hash_password()` uses `_pbkdf2_key()` by default; optional `salt` kwarg for migration only
- Add `_invalidate_password_hash_cache()` as the single cache invalidation primitive, wired into `save_settings()` so password changes via the Settings panel take effect immediately — no restart required
- `verify_password()` transparently re-hashes passwords stored with the old `.signing_key` salt

## Problem

`_check_login_rate()` and `_record_login_attempt()` mutated `_login_attempts` without a lock. Under a concurrent brute-force burst, two threads could both read a stale count, both pass the rate-limit check, and both allow the attempt.

PBKDF2 and HMAC signing shared `.signing_key`. Key reuse across cryptographic primitives is unnecessary risk.

`get_password_hash()` caches its result with no invalidation path — changing the password via the Settings panel is invisible until restart. This PR introduces the cache invalidation primitive and wires it into `save_settings()` so password changes take effect immediately.

## Testing

```
python3 -m pytest tests/test_auth_sessions.py tests/test_issue1560_password_env_var_lock.py -q
# 25 passed
```