### PR TITLE
feat: restore session continuity controls

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -338,11 +338,45 @@ def _load_yaml_config_file(config_path: Path) -> dict:
         return {}
 
 
+def _model_lock_violation(existing_config: dict, next_config: dict) -> str | None:
+    """Return a message when a config write would mutate a locked model block."""
+    if not isinstance(existing_config, dict) or not isinstance(next_config, dict):
+        return None
+    existing_model = existing_config.get("model", {})
+    next_model = next_config.get("model", {})
+    if not isinstance(existing_model, dict):
+        return None
+    if not existing_model.get("locked"):
+        return None
+    if "model" not in next_config or not isinstance(next_model, dict):
+        return "default model is locked; refusing to remove model config"
+
+    protected_keys = ("provider", "default", "base_url", "locked")
+    changed = [
+        key
+        for key in protected_keys
+        if existing_model.get(key) != next_model.get(key)
+    ]
+    if not changed:
+        return None
+
+    current_model = str(existing_model.get("default") or "").strip()
+    current_provider = str(existing_model.get("provider") or "").strip()
+    suffix = f" ({current_provider})" if current_provider else ""
+    changed_keys = ", ".join(changed)
+    return f"default model is locked to {current_model}{suffix}; refusing to change {changed_keys}"
+
+
 def _save_yaml_config_file(config_path: Path, config_data: dict) -> None:
     try:
         import yaml as _yaml
     except ImportError as exc:
         raise RuntimeError("PyYAML is required to write Hermes config.yaml") from exc
+
+    existing_config = _load_yaml_config_file(config_path)
+    violation = _model_lock_violation(existing_config, config_data)
+    if violation:
+        raise PermissionError(violation)
 
     config_path.parent.mkdir(parents=True, exist_ok=True)
     config_path.write_text(
@@ -1857,6 +1891,25 @@ def get_effective_default_model(config_data: dict | None = None) -> str:
     return default_model
 
 
+def is_default_model_locked(config_data: dict | None = None) -> bool:
+    """Return True when WebUI must not change or override the configured model.
+
+    The lock is intentionally read from config.yaml (``model.locked: true``) so it
+    survives WebUI restarts and applies to Settings saves, session dropdown
+    choices, and stale per-session metadata.  ``HERMES_WEBUI_MODEL_LOCK=1`` is a
+    deployment-level override for emergency hardening.
+    """
+    env_lock = str(os.getenv("HERMES_WEBUI_MODEL_LOCK") or "").strip().lower()
+    if env_lock in {"1", "true", "yes", "on", "locked"}:
+        return True
+
+    active_cfg = config_data if config_data is not None else cfg
+    model_cfg = active_cfg.get("model", {}) if isinstance(active_cfg, dict) else {}
+    if not isinstance(model_cfg, dict):
+        return False
+    return bool(model_cfg.get("locked"))
+
+
 # ── Reasoning config (CLI parity for /reasoning) ─────────────────────────────
 # Mirrors hermes_constants.parse_reasoning_effort so WebUI can validate without
 # importing from the agent tree (which may not be installed).  Any drift here
@@ -1970,6 +2023,18 @@ def set_hermes_default_model(model_id: str) -> dict:
         resolved_model, resolved_provider, resolved_base_url = resolve_model_provider(
             selected_model
         )
+        if is_default_model_locked(config_data):
+            current_model = get_effective_default_model(config_data)
+            current_provider = previous_provider
+            target_model = str(resolved_model or selected_model).strip()
+            target_provider = str(resolved_provider or previous_provider or "").strip()
+            if target_model != current_model or (
+                current_provider and target_provider and target_provider != current_provider
+            ):
+                raise PermissionError(
+                    f"default model is locked to {current_model}"
+                    + (f" ({current_provider})" if current_provider else "")
+                )
         # Persist the resolved bare/slash form, NOT the `@provider:` prefix. The
         # prefix is a WebUI-internal routing hint that the hermes-agent CLI does
         # not understand — if we wrote `@nous:anthropic/claude-opus-4.6` to

--- a/api/control_plane.py
+++ b/api/control_plane.py
@@ -1,0 +1,212 @@
+"""Read-only Hermes control-plane bridge for the WebUI cockpit.
+
+This module intentionally exposes only server-side, browser-safe payloads from
+Hermes Agent's existing control-plane dashboard helpers. It does not write to
+Supabase, send Telegram messages, change cron, or edit Obsidian authority.
+"""
+from __future__ import annotations
+
+import concurrent.futures
+from pathlib import Path
+from typing import Any, Callable, Dict, List
+
+from api.helpers import j
+
+_FORBIDDEN_BROWSER_KEYS = {
+    "target" + "_ref",
+    "provider" + "_message_ref",
+    "error" + "_summary",
+    "provider" + "_error_body",
+    "raw" + "_payload",
+    "private" + "_target_payload",
+}
+
+
+def _load_agent_control_plane_helpers():
+    # api.config appends HERMES_WEBUI_AGENT_DIR to sys.path at import time.
+    import api.config  # noqa: F401
+    from hermes_cli import web_server as agent_web_server
+
+    return agent_web_server
+
+
+def _strip_forbidden_keys(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {
+            key: _strip_forbidden_keys(item)
+            for key, item in value.items()
+            if key not in _FORBIDDEN_BROWSER_KEYS
+        }
+    if isinstance(value, list):
+        return [_strip_forbidden_keys(item) for item in value]
+    return value
+
+
+def _disabled_payload(reason: str, message: str) -> Dict[str, Any]:
+    return {
+        "enabled": False,
+        "status": "disabled",
+        "mode": "read_only",
+        "reason": reason,
+        "message": message,
+        "boundaries": {
+            "writes_enabled": False,
+            "telegram_send_enabled": False,
+            "obsidian_authority_edit_enabled": False,
+            "cron_change_enabled": False,
+        },
+    }
+
+
+def _call_with_timeout(fn: Callable[[], Dict[str, Any]], timeout_seconds: float = 8.0) -> Dict[str, Any]:
+    executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+    future = executor.submit(fn)
+    try:
+        return future.result(timeout=timeout_seconds)
+    except concurrent.futures.TimeoutError:
+        future.cancel()
+        return _disabled_payload(
+            "control_plane_bridge_timeout",
+            "Control-plane bridge timed out; read-only page remains available with writes disabled.",
+        )
+    finally:
+        executor.shutdown(wait=False, cancel_futures=True)
+
+
+def control_plane_payload() -> Dict[str, Any]:
+    def _load_payload() -> Dict[str, Any]:
+        agent_web_server = _load_agent_control_plane_helpers()
+        return agent_web_server._get_control_plane_morning_brief_payload()
+    try:
+        payload = _call_with_timeout(_load_payload)
+        return _strip_forbidden_keys(payload)
+    except BaseException:
+        return _disabled_payload(
+            "control_plane_bridge_failed",
+            "Control-plane bridge failed; check server logs or Hermes Agent dashboard helpers.",
+        )
+
+
+def control_plane_telegram_preview() -> Dict[str, Any]:
+    def _load_payload() -> Dict[str, Any]:
+        agent_web_server = _load_agent_control_plane_helpers()
+        canary = agent_web_server._get_control_plane_morning_brief_payload()
+        return agent_web_server._build_morning_brief_telegram_preview(canary)
+    try:
+        payload = _call_with_timeout(_load_payload)
+        return _strip_forbidden_keys(payload)
+    except BaseException:
+        return _disabled_payload(
+            "control_plane_bridge_failed",
+            "Telegram preview bridge failed; check server logs or Hermes Agent dashboard helpers.",
+        )
+
+
+def control_plane_safety_preview() -> Dict[str, Any]:
+    def _load_payload() -> Dict[str, Any]:
+        agent_web_server = _load_agent_control_plane_helpers()
+        return agent_web_server._get_control_plane_safety_preview_payload()
+    try:
+        payload = _call_with_timeout(_load_payload)
+        return _strip_forbidden_keys(payload)
+    except BaseException:
+        return _disabled_payload(
+            "control_plane_bridge_failed",
+            "Safety preview bridge failed; check server logs or Hermes Agent dashboard helpers.",
+        )
+
+
+def _recent_control_plane_artifacts(limit: int = 6) -> List[Dict[str, Any]]:
+    artifact_dir = Path.home() / ".hermes" / "webui-workspace" / "artifacts"
+    try:
+        files = sorted(
+            [p for p in artifact_dir.glob("*.md") if p.is_file()],
+            key=lambda p: p.stat().st_mtime,
+            reverse=True,
+        )[:limit]
+        return [
+            {
+                "name": p.name,
+                "path_label": f"artifacts/{p.name}",
+                "updated_unix": int(p.stat().st_mtime),
+            }
+            for p in files
+        ]
+    except Exception:
+        return []
+
+
+def control_plane_overview() -> Dict[str, Any]:
+    """Return static/live read-only cockpit domains for the first WebUI expansion.
+
+    This is intentionally an overview/reader contract: it exposes what to look at
+    and what is held, but it does not execute routines, send notifications,
+    mutate Supabase, change cron, or edit Obsidian.
+    """
+    return {
+        "mode": "read_only",
+        "status": "ok",
+        "cards": [
+            {
+                "key": "routine_cron_health",
+                "title": "Routine / Cron health",
+                "status": "reader_only",
+                "summary": "Shows routine posture only; cron run/change controls remain held.",
+                "lines": ["Morning Routine schedule: monitor only", "Cron mutation: OFF"],
+            },
+            {
+                "key": "notebooklm_prewarm",
+                "title": "NotebookLM pre-warm",
+                "status": "scheduled_probe",
+                "summary": "No-agent deterministic health probe lane; browser/session auth changes are held.",
+                "lines": ["Daily pre-warm lane: 06:50 KST", "LLM pre-warm job: replaced/paused"],
+            },
+            {
+                "key": "supabase_control_plane_canary",
+                "title": "Supabase control-plane canary",
+                "status": "dry_run_reader",
+                "summary": "Control-plane canary read model only; production schema/data writes remain held.",
+                "lines": ["Production schema mutation: OFF", "Report projection: read-only preview"],
+            },
+            {
+                "key": "approval_gates_hold_list",
+                "title": "Approval gates / HOLD list",
+                "status": "hold",
+                "summary": "Durable changes require explicit approval before action controls are added.",
+                "lines": ["Telegram send: OFF", "Obsidian authority promotion: OFF", "Cron changes: OFF"],
+            },
+            {
+                "key": "recent_artifacts",
+                "title": "Recent artifacts / verification reports",
+                "status": "reader_only",
+                "summary": "Local non-Obsidian verification artifacts for operator review.",
+                "artifacts": _recent_control_plane_artifacts(),
+            },
+            {
+                "key": "webui_health",
+                "title": "WebUI health",
+                "status": "live_probe",
+                "summary": "Frontend reads the existing /health endpoint; no service restart control is exposed.",
+                "lines": ["Health check: GET /health", "Restart control: OFF"],
+            },
+        ],
+        "boundaries": {
+            "writes_enabled": False,
+            "telegram_send_enabled": False,
+            "obsidian_authority_edit_enabled": False,
+            "cron_change_enabled": False,
+            "service_restart_enabled": False,
+        },
+    }
+
+
+def handle_control_plane_get(handler, parsed) -> bool:
+    if parsed.path == "/api/control-plane/overview":
+        return j(handler, _strip_forbidden_keys(control_plane_overview()))
+    if parsed.path == "/api/control-plane/morning-brief-canary":
+        return j(handler, control_plane_payload())
+    if parsed.path == "/api/control-plane/morning-brief-canary/telegram-preview":
+        return j(handler, control_plane_telegram_preview())
+    if parsed.path == "/api/control-plane/morning-brief-canary/safety-preview":
+        return j(handler, control_plane_safety_preview())
+    return False

--- a/api/onboarding.py
+++ b/api/onboarding.py
@@ -26,6 +26,7 @@ from api.config import (
     reload_config,
     save_settings,
     verify_hermes_imports,
+    _save_yaml_config_file as _guarded_save_yaml_config_file,
 )
 from api.providers import _write_env_file  # shared impl with _ENV_LOCK (#1164)
 from api.workspace import get_last_workspace, load_workspaces
@@ -244,16 +245,7 @@ def _load_yaml_config(config_path: Path) -> dict:
 
 
 def _save_yaml_config(config_path: Path, config: dict) -> None:
-    try:
-        import yaml as _yaml
-    except ImportError as exc:
-        raise RuntimeError("PyYAML is required to write Hermes config.yaml") from exc
-
-    config_path.parent.mkdir(parents=True, exist_ok=True)
-    config_path.write_text(
-        _yaml.safe_dump(config, sort_keys=False, allow_unicode=True),
-        encoding="utf-8",
-    )
+    _guarded_save_yaml_config_file(config_path, config)
 
 
 def _normalize_model_for_provider(provider: str, model: str) -> str:

--- a/api/paperclip.py
+++ b/api/paperclip.py
@@ -1,0 +1,405 @@
+"""Paperclip status and Org Chat helpers for the WebUI.
+
+The status panel is observation-only. Org Chat is deliberately narrower than
+Paperclip control: it can append comments to existing issues, but it does not
+checkout, release, approve, assign, execute, create agents, or modify runtime
+state.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any
+
+DEFAULT_BASE_URL = "http://127.0.0.1:3100/api"
+TERMINAL_ISSUE_STATUSES = {"done", "cancelled", "canceled", "closed"}
+
+
+def _base_url() -> str:
+    return os.getenv("HERMES_WEBUI_PAPERCLIP_API", DEFAULT_BASE_URL).rstrip("/")
+
+
+def _get_json(path: str, timeout: float = 3.0) -> Any:
+    url = _base_url() + path
+    req = urllib.request.Request(url, headers={"Accept": "application/json"})
+    with urllib.request.urlopen(req, timeout=timeout) as response:
+        raw = response.read().decode("utf-8")
+    if not raw.strip():
+        return None
+    return json.loads(raw)
+
+
+def _pick_active_company(companies: list[dict[str, Any]]) -> dict[str, Any] | None:
+    active = [c for c in companies if str(c.get("status") or "").lower() == "active"]
+    if active:
+        return active[0]
+    return companies[0] if companies else None
+
+
+def _post_json(path: str, payload: dict[str, Any], timeout: float = 4.0) -> Any:
+    url = _base_url() + path
+    data = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(
+        url,
+        data=data,
+        method="POST",
+        headers={"Accept": "application/json", "Content-Type": "application/json"},
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as response:
+        raw = response.read().decode("utf-8")
+    if not raw.strip():
+        return None
+    return json.loads(raw)
+
+
+def _active_company() -> tuple[dict[str, Any] | None, list[dict[str, Any]]]:
+    companies = _get_json("/companies", timeout=3.0) or []
+    if not isinstance(companies, list):
+        companies = []
+    return _pick_active_company(companies), companies
+
+
+def _safe_text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _compact_issue(issue: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": issue.get("id"),
+        "identifier": issue.get("identifier") or issue.get("issueNumber") or issue.get("id"),
+        "title": issue.get("title") or "Untitled issue",
+        "status": issue.get("status") or "unknown",
+        "priority": issue.get("priority"),
+        "execution_run_id": issue.get("executionRunId"),
+        "checkout_run_id": issue.get("checkoutRunId"),
+        "execution_locked_at": issue.get("executionLockedAt"),
+    }
+
+
+def _classify_agent(agent: dict[str, Any], active_issues: list[dict[str, Any]], pending_approval_count: int) -> tuple[str, str]:
+    """Classify the agent runtime light, not the health of its assigned backlog.
+
+    Paperclip's own roster shows an agent as idle even when it owns blocked
+    issues. Mirroring that avoids implying the runtime is broken; blocked work is
+    exposed separately through blocked_issue_count / active_issues.
+    """
+    raw_status = _safe_text(agent.get("status")).lower()
+    if pending_approval_count > 0:
+        return "blue", "awaiting_approval"
+    if raw_status in {"error", "failed", "blocked", "offline", "paused"}:
+        return "red", raw_status
+    if any(
+        issue.get("executionRunId")
+        or issue.get("checkoutRunId")
+        or issue.get("executionLockedAt")
+        or _safe_text(issue.get("status")).lower() in {"in_progress", "working", "running"}
+        for issue in active_issues
+    ):
+        return "yellow", "working"
+    if raw_status in {"", "idle", "active", "available"}:
+        return "green", "idle"
+    return "gray", raw_status or "unknown"
+
+
+def _build_org_chart(normalized_agents: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Build a nested org chart from Paperclip reportsTo relationships."""
+    nodes: dict[str, dict[str, Any]] = {}
+    for agent in normalized_agents:
+        agent_id = _safe_text(agent.get("id"))
+        if not agent_id:
+            continue
+        node = {k: v for k, v in agent.items() if k != "active_issues"}
+        node["active_issues"] = agent.get("active_issues", [])
+        node["children"] = []
+        nodes[agent_id] = node
+
+    roots: list[dict[str, Any]] = []
+    for node in nodes.values():
+        parent_id = _safe_text(node.get("reports_to"))
+        parent = nodes.get(parent_id)
+        if parent and parent is not node:
+            parent["children"].append(node)
+        else:
+            roots.append(node)
+
+    def sort_key(node: dict[str, Any]) -> tuple[int, str]:
+        role = _safe_text(node.get("role")).lower()
+        name = _safe_text(node.get("name")).lower()
+        rank = 0 if role in {"ceo", "founder"} or name == "ceo" else 1
+        return (rank, name)
+
+    def sort_tree(items: list[dict[str, Any]]) -> None:
+        items.sort(key=sort_key)
+        for item in items:
+            sort_tree(item.get("children", []))
+
+    sort_tree(roots)
+    return roots
+
+
+def build_paperclip_status() -> dict[str, Any]:
+    """Return a read-only Paperclip org/agent status snapshot.
+
+    The response is deliberately compact and UI-oriented. Agent light colors are
+    derived from active issue locks/status plus pending approvals instead of
+    trusting a single Paperclip agent.status field.
+    """
+    snapshot_ts = time.time()
+    try:
+        health = _get_json("/health", timeout=2.5)
+        companies = _get_json("/companies", timeout=3.0) or []
+        if not isinstance(companies, list):
+            companies = []
+        company = _pick_active_company(companies)
+        if not company:
+            return {
+                "ok": False,
+                "read_only": True,
+                "error": "No Paperclip company found",
+                "health": health,
+                "agents": [],
+                "snapshot_at": snapshot_ts,
+            }
+
+        company_id = company.get("id")
+        company_path_id = urllib.parse.quote(str(company_id), safe="")
+        agents = _get_json(f"/companies/{company_path_id}/agents", timeout=4.0) or []
+        issues = _get_json(f"/companies/{company_path_id}/issues?limit=100", timeout=4.0) or []
+        approvals = _get_json(f"/companies/{company_path_id}/approvals", timeout=4.0) or []
+        if not isinstance(agents, list):
+            agents = []
+        if not isinstance(issues, list):
+            issues = []
+        if not isinstance(approvals, list):
+            approvals = []
+
+        active_issues_by_agent: dict[str, list[dict[str, Any]]] = {}
+        for issue in issues:
+            if not isinstance(issue, dict):
+                continue
+            status = _safe_text(issue.get("status")).lower()
+            if status in TERMINAL_ISSUE_STATUSES:
+                continue
+            assignee = _safe_text(issue.get("assigneeAgentId"))
+            if not assignee:
+                continue
+            active_issues_by_agent.setdefault(assignee, []).append(issue)
+
+        pending_approvals_by_agent: dict[str, int] = {}
+        for approval in approvals:
+            if not isinstance(approval, dict):
+                continue
+            if _safe_text(approval.get("status")).lower() != "pending":
+                continue
+            requester = _safe_text(approval.get("requestedByAgentId"))
+            if requester:
+                pending_approvals_by_agent[requester] = pending_approvals_by_agent.get(requester, 0) + 1
+
+        normalized_agents = []
+        for agent in agents:
+            if not isinstance(agent, dict):
+                continue
+            agent_id = _safe_text(agent.get("id"))
+            active_issues = active_issues_by_agent.get(agent_id, [])
+            pending_count = pending_approvals_by_agent.get(agent_id, 0)
+            light, display_status = _classify_agent(agent, active_issues, pending_count)
+            blocked_issue_count = sum(1 for issue in active_issues if _safe_text(issue.get("status")).lower() == "blocked")
+            normalized_agents.append({
+                "id": agent_id,
+                "name": agent.get("name") or agent.get("title") or agent_id or "Unknown agent",
+                "title": agent.get("title") or "",
+                "role": agent.get("role") or "",
+                "reports_to": agent.get("reportsTo"),
+                "adapter_type": agent.get("adapterType"),
+                "raw_status": agent.get("status") or "unknown",
+                "display_status": display_status,
+                "light": light,
+                "active_issue_count": len(active_issues),
+                "blocked_issue_count": blocked_issue_count,
+                "active_issues": [_compact_issue(issue) for issue in active_issues[:5]],
+                "pending_approval_count": pending_count,
+                "last_heartbeat_at": agent.get("lastHeartbeatAt"),
+                "updated_at": agent.get("updatedAt"),
+            })
+
+        return {
+            "ok": True,
+            "read_only": True,
+            "health": health,
+            "company": {
+                "id": company.get("id"),
+                "name": company.get("name"),
+                "status": company.get("status"),
+                "issue_prefix": company.get("issuePrefix"),
+            },
+            "agents": normalized_agents,
+            "org_chart": _build_org_chart(normalized_agents),
+            "counts": {
+                "agents": len(normalized_agents),
+                "active_issues": sum(len(v) for v in active_issues_by_agent.values()),
+                "pending_approvals": sum(pending_approvals_by_agent.values()),
+            },
+            "snapshot_at": snapshot_ts,
+        }
+    except urllib.error.URLError as exc:
+        return {
+            "ok": False,
+            "read_only": True,
+            "error": f"Paperclip API unreachable: {exc}",
+            "agents": [],
+            "snapshot_at": snapshot_ts,
+        }
+    except Exception as exc:
+        return {
+            "ok": False,
+            "read_only": True,
+            "error": f"Paperclip status failed: {exc}",
+            "agents": [],
+            "snapshot_at": snapshot_ts,
+        }
+
+
+def _compact_agent(agent: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": agent.get("id"),
+        "name": agent.get("name") or agent.get("title") or agent.get("id") or "Unknown agent",
+        "title": agent.get("title") or "",
+        "role": agent.get("role") or "",
+        "reports_to": agent.get("reportsTo"),
+        "status": agent.get("status") or "unknown",
+        "display_status": agent.get("status") or "unknown",
+        "light": "gray",
+        "active_issue_count": 0,
+        "blocked_issue_count": 0,
+        "pending_approval_count": 0,
+    }
+
+
+def _compact_comment(comment: dict[str, Any], issue: dict[str, Any], agent_names: dict[str, str]) -> dict[str, Any]:
+    author_agent_id = comment.get("authorAgentId")
+    author_user_id = comment.get("authorUserId")
+    if author_agent_id:
+        author_name = agent_names.get(str(author_agent_id), str(author_agent_id))
+        author_type = "agent"
+    elif author_user_id:
+        author_name = "Hermes/User"
+        author_type = "user"
+    else:
+        author_name = "System"
+        author_type = "system"
+    return {
+        "id": comment.get("id"),
+        "issue_id": comment.get("issueId") or issue.get("id"),
+        "issue_identifier": issue.get("identifier") or issue.get("issueNumber") or issue.get("id"),
+        "issue_title": issue.get("title") or "Untitled issue",
+        "author_agent_id": author_agent_id,
+        "author_user_id": author_user_id,
+        "author_name": author_name,
+        "author_type": author_type,
+        "body": comment.get("body") or "",
+        "created_at": comment.get("createdAt"),
+        "updated_at": comment.get("updatedAt"),
+    }
+
+
+def get_org_chat_context(limit: int = 25, comments_per_issue: int = 8) -> dict[str, Any]:
+    """Return compact Org Chat context: roster, recent issues, recent comments.
+
+    This is read-oriented. It aggregates existing issue comments only; it does
+    not wake agents or create new work.
+    """
+    snapshot_ts = time.time()
+    try:
+        health = _get_json("/health", timeout=2.5)
+        company, _ = _active_company()
+        if not company:
+            return {"ok": False, "read_only": True, "error": "No Paperclip company found", "agents": [], "issues": [], "messages": [], "snapshot_at": snapshot_ts}
+        company_id = company.get("id")
+        company_path_id = urllib.parse.quote(str(company_id), safe="")
+        safe_limit = max(1, min(int(limit or 25), 100))
+        safe_comments = max(1, min(int(comments_per_issue or 8), 25))
+        agents = _get_json(f"/companies/{company_path_id}/agents", timeout=4.0) or []
+        issues = _get_json(f"/companies/{company_path_id}/issues?limit={safe_limit}", timeout=4.0) or []
+        if not isinstance(agents, list):
+            agents = []
+        if not isinstance(issues, list):
+            issues = []
+        agent_names = {str(a.get("id")): (a.get("name") or a.get("title") or str(a.get("id"))) for a in agents if isinstance(a, dict)}
+        compact_issues = [_compact_issue(i) | {"assignee_agent_id": i.get("assigneeAgentId"), "updated_at": i.get("updatedAt")} for i in issues if isinstance(i, dict)]
+        messages: list[dict[str, Any]] = []
+        for issue in issues[: min(len(issues), 8)]:
+            if not isinstance(issue, dict) or not issue.get("id"):
+                continue
+            try:
+                comments = _get_json(f"/issues/{urllib.parse.quote(str(issue.get('id')), safe='')}/comments", timeout=4.0) or []
+            except Exception:
+                comments = []
+            if not isinstance(comments, list):
+                continue
+            comments = [c for c in comments if isinstance(c, dict)]
+            comments = sorted(comments, key=lambda c: c.get("createdAt") or c.get("updatedAt") or "")[-safe_comments:]
+            messages.extend(_compact_comment(c, issue, agent_names) for c in comments)
+        messages.sort(key=lambda m: m.get("created_at") or m.get("updated_at") or "")
+        compact_agents = [_compact_agent(a) for a in agents if isinstance(a, dict)]
+        return {
+            "ok": True,
+            "read_only": True,
+            "health": health,
+            "company": {"id": company.get("id"), "name": company.get("name"), "status": company.get("status"), "issue_prefix": company.get("issuePrefix")},
+            "agents": compact_agents,
+            "org_chart": _build_org_chart(compact_agents),
+            "issues": compact_issues,
+            "messages": messages[-80:],
+            "snapshot_at": snapshot_ts,
+        }
+    except urllib.error.URLError as exc:
+        return {"ok": False, "read_only": True, "error": f"Paperclip API unreachable: {exc}", "agents": [], "issues": [], "messages": [], "snapshot_at": snapshot_ts}
+    except Exception as exc:
+        return {"ok": False, "read_only": True, "error": f"Paperclip Org Chat context failed: {exc}", "agents": [], "issues": [], "messages": [], "snapshot_at": snapshot_ts}
+
+
+def send_org_chat_message(issue_id: str, message: str, target_label: str | None = None) -> dict[str, Any]:
+    """Append an Org Chat comment to an existing Paperclip issue.
+
+    MVP safety boundary: existing issue comment only. No checkout/release,
+    approval, assignment, agent creation, or free-floating task creation.
+    """
+    issue_id = _safe_text(issue_id)
+    message = _safe_text(message)
+    target_label = _safe_text(target_label)
+    if not issue_id:
+        return {"ok": False, "read_only": False, "mutation": "comment_only", "error": "issue_id is required"}
+    if not message:
+        return {"ok": False, "read_only": False, "mutation": "comment_only", "error": "message is required"}
+    if len(message) > 12000:
+        return {"ok": False, "read_only": False, "mutation": "comment_only", "error": "message is too long; keep Org Chat comments under 12,000 characters"}
+    try:
+        issue = _get_json(f"/issues/{urllib.parse.quote(issue_id, safe='')}", timeout=3.0)
+        if not isinstance(issue, dict) or not issue.get("id"):
+            return {"ok": False, "read_only": False, "mutation": "comment_only", "error": "Issue not found"}
+        prefix = f"[Org Chat → {target_label}]\n\n" if target_label else "[Org Chat]\n\n"
+        body = prefix + message
+        comment = _post_json(f"/issues/{urllib.parse.quote(issue_id, safe='')}/comments", {"body": body}, timeout=4.0)
+        comments = _get_json(f"/issues/{urllib.parse.quote(issue_id, safe='')}/comments", timeout=4.0) or []
+        verified = False
+        if isinstance(comments, list):
+            verified = any(isinstance(c, dict) and c.get("id") == (comment or {}).get("id") and c.get("body") == body for c in comments)
+        return {
+            "ok": True,
+            "read_only": False,
+            "mutation": "comment_only",
+            "issue": _compact_issue(issue),
+            "comment": comment,
+            "verified": verified,
+        }
+    except urllib.error.HTTPError as exc:
+        return {"ok": False, "read_only": False, "mutation": "comment_only", "error": f"Paperclip comment failed: HTTP {exc.code}"}
+    except urllib.error.URLError as exc:
+        return {"ok": False, "read_only": False, "mutation": "comment_only", "error": f"Paperclip API unreachable: {exc}"}
+    except Exception as exc:
+        return {"ok": False, "read_only": False, "mutation": "comment_only", "error": f"Paperclip Org Chat send failed: {exc}"}

--- a/api/reports.py
+++ b/api/reports.py
@@ -1,0 +1,455 @@
+"""Read-only report reader API for Hermes WebUI.
+
+Reports are stored in the Hermes control-plane report tables and exposed here
+as browser-safe reader payloads. This module does not write to the database,
+send Telegram messages, mutate cron, or edit Obsidian authority.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any, Dict, List
+
+from api.helpers import j
+
+_FORBIDDEN_BROWSER_KEYS = {
+    "target" + "_ref",
+    "provider" + "_message_ref",
+    "error" + "_summary",
+    "provider" + "_error_body",
+    "raw" + "_payload",
+    "private" + "_target_payload",
+    "raw" + "_source_packet",
+    "raw" + "_source_dump",
+}
+
+
+def _strip_forbidden_keys(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {
+            str(key): _strip_forbidden_keys(item)
+            for key, item in value.items()
+            if str(key) not in _FORBIDDEN_BROWSER_KEYS
+        }
+    if isinstance(value, list):
+        return [_strip_forbidden_keys(item) for item in value]
+    return value
+
+
+def _as_list(value: Any) -> List[Dict[str, Any]]:
+    return value if isinstance(value, list) else []
+
+
+def _section_kind(section: Dict[str, Any]) -> str:
+    title = str(section.get("title") or "").lower()
+    key = str(section.get("section_key") or "").lower()
+    text = f"{key} {title}"
+    if "summary" in text or "요약" in text or "판단" in text:
+        return "summary"
+    if "source" in text or "출처" in text or "보류" in text:
+        return "source_quality"
+    if "decision" in text or "queue" in text or "처리" in text:
+        return "judgment"
+    return "issue"
+
+
+def _normalize_sections(sections: List[Dict[str, Any]]) -> Dict[str, Any]:
+    normalized = []
+    summary = ""
+    source_quality = []
+    judgments = []
+    for idx, section in enumerate(sections, start=1):
+        item = {
+            "section_key": section.get("section_key") or f"section_{idx}",
+            "order": section.get("section_order") or idx,
+            "title": section.get("title") or f"Issue {idx}",
+            "body_md": section.get("body_md") or "",
+            "judgment_label": section.get("judgment_label") or "review",
+            "kind": _section_kind(section),
+        }
+        normalized.append(item)
+        if item["kind"] == "summary" and not summary:
+            summary = item["body_md"]
+        if item["kind"] == "source_quality":
+            source_quality.append(item)
+        if item["kind"] == "judgment" or item.get("judgment_label"):
+            judgments.append(
+                {
+                    "title": item["title"],
+                    "judgment_label": item["judgment_label"],
+                    "handling": "WebUI reader에 표시하고, 운영/채택 변경은 별도 승인 전까지 보류합니다.",
+                }
+            )
+
+    if not summary and normalized:
+        first = normalized[0]
+        summary = first.get("body_md") or first.get("title") or "Latest Morning Brief report is available."
+
+    return {
+        "summary": summary,
+        "sections": normalized,
+        "issue_sections": [item for item in normalized if item.get("kind") == "issue"],
+        "source_quality_sections": source_quality,
+        "judgments": judgments[:8],
+    }
+
+
+def _telegram_contract(summary: str, sections: List[Dict[str, Any]]) -> Dict[str, Any]:
+    top = [str(item.get("title") or "").strip() for item in sections[:3] if item.get("title")]
+    lines = ["[Morning Brief] 최신 보고서", "요약: " + (summary or "WebUI에서 전체 보고서를 확인하세요.")[:140]]
+    if top:
+        lines.append("핵심: " + " / ".join(top))
+    lines.append("전체: WebUI > Reports > Morning Brief")
+    return {
+        "mode": "short_notification_only",
+        "send_enabled": False,
+        "max_lines": 6,
+        "preview_lines": lines[:6],
+    }
+
+
+def _artifact_dir() -> Path:
+    configured = os.getenv("HERMES_MORNING_BRIEF_REPORT_DIR")
+    if configured:
+        return Path(configured).expanduser()
+    return Path.home() / ".hermes" / "webui-workspace" / "hermes-control-plane" / "artifacts" / "morning-brief-full"
+
+
+def _latest_artifact_report_path() -> Path | None:
+    root = _artifact_dir()
+    try:
+        candidates = [
+            p for p in root.glob("*.md")
+            if p.is_file() and "paperclip-packet" not in p.name
+        ]
+    except Exception:
+        return None
+    if not candidates:
+        return None
+    return sorted(candidates, key=lambda p: (p.stat().st_mtime, p.name), reverse=True)[0]
+
+
+def _split_markdown_sections(markdown: str) -> List[Dict[str, Any]]:
+    text = re.sub(r"\A---\s*\n.*?\n---\s*\n", "", markdown, flags=re.S)
+    blocks: List[Dict[str, Any]] = []
+    current_title = "오늘의 요약"
+    current_lines: List[str] = []
+    for line in text.splitlines():
+        match = re.match(r"^(#{1,3})\s+(.+?)\s*$", line)
+        if match:
+            body = "\n".join(current_lines).strip()
+            if body:
+                blocks.append({"title": current_title, "body_md": body})
+            current_title = match.group(2).strip()
+            current_lines = []
+        else:
+            current_lines.append(line)
+    body = "\n".join(current_lines).strip()
+    if body:
+        blocks.append({"title": current_title, "body_md": body})
+    return blocks
+
+
+def _artifact_report_payload(source_reason: str = "supabase_unavailable") -> Dict[str, Any] | None:
+    path = _latest_artifact_report_path()
+    if not path:
+        return None
+    try:
+        body = path.read_text(encoding="utf-8")
+    except Exception:
+        return None
+
+    raw_sections = _split_markdown_sections(body)
+    skip_title_fragments = (
+        "run metadata",
+        "source packet evidence",
+        "delivery and storage",
+        "patch candidates",
+        "parent",
+        "children",
+    )
+    reader_sections = [
+        section for section in raw_sections
+        if not any(fragment in str(section.get("title") or "").lower() for fragment in skip_title_fragments)
+    ]
+    normalized_input = []
+    for idx, section in enumerate(reader_sections[:12], start=1):
+        title = section.get("title") or f"Issue {idx}"
+        label_match = re.search(r"`([^`]*(?:review|observe|hold|adopt|reject)[^`]*)`", title + "\n" + str(section.get("body_md") or ""), re.I)
+        normalized_input.append({
+            "section_key": f"artifact_section_{idx}",
+            "section_order": idx,
+            "title": title,
+            "body_md": section.get("body_md") or "",
+            "judgment_label": label_match.group(1) if label_match else "review",
+        })
+    normalized = _normalize_sections(normalized_input)
+    report_date = path.stem
+    payload = {
+        "enabled": True,
+        "status": "fallback_local_artifact",
+        "mode": "reader_only",
+        "report_type": "morning_brief",
+        "storage": {
+            "primary_store": "supabase",
+            "browser_direct_db_access": False,
+            "fallback_store": "local_artifact",
+            "fallback_reason": source_reason,
+        },
+        "run": {
+            "id": None,
+            "run_ref": f"local_artifact:{path.name}",
+            "report_date": report_date,
+            "title": "Morning Brief",
+            "status": "fallback_local_artifact",
+            "paperclip_parent_ref": None,
+            "obsidian_ref_present": False,
+        },
+        "title": "Morning Brief",
+        "summary": normalized["summary"],
+        "sections": normalized["issue_sections"],
+        "source_quality_sections": normalized["source_quality_sections"],
+        "judgments": normalized["judgments"],
+        "sources": [],
+        "telegram_contract": _telegram_contract(normalized["summary"], normalized["issue_sections"]),
+        "counts": {"report_sections": len(normalized["issue_sections"]), "sources": 0},
+        "boundaries": {
+            "read_only": True,
+            "writes_enabled": False,
+            "telegram_send_enabled": False,
+            "obsidian_authority_edit_enabled": False,
+            "cron_change_enabled": False,
+        },
+    }
+    return _strip_forbidden_keys(payload)
+
+
+def _control_plane_root() -> Path:
+    return Path.home() / ".hermes" / "webui-workspace" / "hermes-control-plane"
+
+
+def _extract_json_rows(output: str) -> List[Dict[str, Any]]:
+    start = output.find("[")
+    if start < 0:
+        return []
+    try:
+        rows = json.loads(output[start:])
+    except Exception:
+        return []
+    return rows if isinstance(rows, list) else []
+
+
+def _run_report_store_query(sql: str) -> List[Dict[str, Any]]:
+    root = _control_plane_root()
+    if not root.exists():
+        return []
+    with tempfile.NamedTemporaryFile("w", suffix=".sql", delete=False, encoding="utf-8") as handle:
+        handle.write(sql)
+        query_path = handle.name
+    try:
+        cp = subprocess.run(
+            ["supabase", "db", "query", "--linked", "--output", "json", "-f", query_path],
+            cwd=str(root),
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            timeout=8,
+        )
+        if cp.returncode != 0:
+            return []
+        return _extract_json_rows(cp.stdout)
+    except Exception:
+        return []
+    finally:
+        try:
+            Path(query_path).unlink()
+        except OSError:
+            pass
+
+
+def _report_store_payload() -> Dict[str, Any] | None:
+    sql = """
+with latest as (
+  select
+    report_id,
+    report_kind,
+    report_date::text,
+    routine_id,
+    title,
+    status,
+    telegram_summary,
+    hermes_judgment_summary,
+    source_mode,
+    notebooklm_status,
+    paperclip_parent_ref,
+    obsidian_ledger_ref,
+    webui_ref,
+    source_refs,
+    artifact_refs,
+    metadata,
+    retention_class,
+    created_at::text,
+    updated_at::text
+  from hermes_reports.reports
+  where report_kind = 'morning_brief'
+  order by report_date desc, updated_at desc
+  limit 1
+)
+select jsonb_build_object(
+  'enabled', true,
+  'status', 'ok',
+  'mode', 'read_only',
+  'project', 'hermes-control-plane-report-store',
+  'updated_at', now()::text,
+  'run', (
+    select jsonb_build_object(
+      'id', report_id,
+      'run_ref', 'supabase://hermes_reports.reports/' || report_id,
+      'report_date', report_date,
+      'title', title,
+      'status', status,
+      'paperclip_parent_ref', paperclip_parent_ref,
+      'obsidian_ref', obsidian_ledger_ref,
+      'webui_ref', webui_ref,
+      'metadata', metadata,
+      'retention_class', retention_class,
+      'created_at', created_at,
+      'updated_at', updated_at
+    ) from latest
+  ),
+  'sections', coalesce((
+    select jsonb_agg(to_jsonb(s) order by s.section_order)
+    from (
+      select
+        section_key,
+        ordinal as section_order,
+        title,
+        body_markdown as body_md,
+        coalesce(metadata->>'judgment_label', 'review') as judgment_label,
+        created_at::text
+      from hermes_reports.report_body_sections
+      where report_id in (select report_id from latest)
+      order by ordinal
+    ) s
+  ), '[]'::jsonb),
+  'sources', coalesce((
+    select jsonb_agg(to_jsonb(src) order by src.created_at)
+    from (
+      select source_key, source_url as source_ref, source_title, source_timing_basis,
+             item_time_label, source_quality, created_at::text
+      from hermes_reports.source_refs
+      where report_id in (select report_id from latest)
+      order by created_at
+    ) src
+  ), '[]'::jsonb),
+  'counts', jsonb_build_object(
+    'report_sections', (select count(*) from hermes_reports.report_body_sections where report_id in (select report_id from latest)),
+    'sources', (select count(*) from hermes_reports.source_refs where report_id in (select report_id from latest))
+  ),
+  'boundaries', jsonb_build_object(
+    'read_only', true,
+    'writes_enabled', false,
+    'telegram_send_enabled', false,
+    'obsidian_authority_edit_enabled', false,
+    'cron_change_enabled', false
+  )
+) as payload
+from latest;
+"""
+    rows = _run_report_store_query(sql)
+    if not rows:
+        return None
+    payload = rows[0].get("payload") if isinstance(rows[0], dict) else None
+    return payload if isinstance(payload, dict) else None
+
+
+def morning_brief_latest_report() -> Dict[str, Any]:
+    from api.control_plane import control_plane_payload
+
+    report_store = _report_store_payload()
+    if report_store:
+        source_payload = report_store
+    else:
+        source_payload = control_plane_payload()
+    if not isinstance(source_payload, dict) or source_payload.get("enabled") is False:
+        reason = source_payload.get("reason", "disabled") if isinstance(source_payload, dict) else "report_source_unavailable"
+        fallback = _artifact_report_payload(reason)
+        if fallback:
+            return fallback
+        return _strip_forbidden_keys(
+            {
+                "enabled": False,
+                "status": source_payload.get("status", "disabled") if isinstance(source_payload, dict) else "disabled",
+                "reason": reason,
+                "message": source_payload.get("message", "Morning Brief report source is unavailable.") if isinstance(source_payload, dict) else "Morning Brief report source is unavailable.",
+                "report_type": "morning_brief",
+                "storage": {"primary_store": "supabase", "browser_direct_db_access": False},
+                "boundaries": {
+                    "read_only": True,
+                    "writes_enabled": False,
+                    "telegram_send_enabled": False,
+                    "obsidian_authority_edit_enabled": False,
+                    "cron_change_enabled": False,
+                },
+            }
+        )
+
+    run = source_payload.get("run") if isinstance(source_payload.get("run"), dict) else {}
+    sections = _as_list(source_payload.get("sections"))
+    metadata = run.get("metadata") if isinstance(run.get("metadata"), dict) else {}
+    ref_integrity = {
+        "webui_ref_status": metadata.get("webui_ref_status"),
+        "webui_surface": metadata.get("webui_surface"),
+        "webui_mutation_allowed": metadata.get("webui_mutation_allowed"),
+        "supabase_ref_status": metadata.get("supabase_ref_status"),
+        "supabase_verified_at": metadata.get("supabase_verified_at"),
+        "summary_hash": metadata.get("summary_hash"),
+        "content_hash": metadata.get("content_hash"),
+        "fallback_artifact_ref": metadata.get("fallback_artifact_ref"),
+    }
+    normalized = _normalize_sections(sections)
+    payload = {
+        "enabled": True,
+        "status": "ok",
+        "mode": "reader_only",
+        "report_type": "morning_brief",
+        "storage": {"primary_store": "supabase", "browser_direct_db_access": False},
+        "run": {
+            "id": run.get("id"),
+            "run_ref": run.get("run_ref"),
+            "report_date": run.get("report_date"),
+            "title": run.get("title") or "Morning Brief",
+            "status": run.get("status"),
+            "paperclip_parent_ref": run.get("paperclip_parent_ref"),
+            "webui_ref": run.get("webui_ref"),
+            "canonical_webui_ref": run.get("webui_ref"),
+            "obsidian_ref_present": bool(run.get("obsidian_ref")),
+            "ref_integrity": ref_integrity,
+        },
+        "title": run.get("title") or "Morning Brief",
+        "summary": normalized["summary"],
+        "sections": normalized["issue_sections"],
+        "source_quality_sections": normalized["source_quality_sections"],
+        "judgments": normalized["judgments"],
+        "sources": _as_list(source_payload.get("sources"))[:24],
+        "telegram_contract": _telegram_contract(normalized["summary"], normalized["issue_sections"]),
+        "counts": source_payload.get("latest_run_counts") or source_payload.get("counts") or {},
+        "boundaries": {
+            "read_only": True,
+            "writes_enabled": False,
+            "telegram_send_enabled": False,
+            "obsidian_authority_edit_enabled": False,
+            "cron_change_enabled": False,
+        },
+    }
+    return _strip_forbidden_keys(payload)
+
+
+def handle_reports_get(handler, parsed) -> bool:
+    if parsed.path == "/api/reports/morning-brief/latest":
+        return j(handler, morning_brief_latest_report())
+    return False

--- a/api/routes.py
+++ b/api/routes.py
@@ -2967,7 +2967,7 @@ def handle_get(handler, parsed) -> bool:
         stripped = parsed._replace(path=parsed.path[len("/session"):])
         return _serve_static(handler, stripped)
 
-    if parsed.path in ("/", "/index.html") or parsed.path.startswith("/session/"):
+    if parsed.path in ("/", "/index.html") or parsed.path.startswith("/session/") or parsed.path == "/control-plane" or parsed.path in ("/reports", "/reports/morning-brief"):
         try:
             from urllib.parse import quote
             from api.updates import WEBUI_VERSION
@@ -3087,6 +3087,64 @@ def handle_get(handler, parsed) -> bool:
         if result is False:
             return _kanban_unknown_endpoint(handler, parsed, "GET")
         return True
+
+    # Hermes local cockpit overlays: read-only route shims.
+    if parsed.path.startswith("/api/reports/"):
+        from api.reports import handle_reports_get
+        return handle_reports_get(handler, parsed)
+
+    if parsed.path.startswith("/api/control-plane/"):
+        from api.control_plane import handle_control_plane_get
+        return handle_control_plane_get(handler, parsed)
+
+    if parsed.path == "/api/paperclip/status":
+        from api.paperclip import build_paperclip_status
+        return j(handler, build_paperclip_status())
+
+    if parsed.path == "/api/paperclip/org-chat/context":
+        from api.paperclip import get_org_chat_context
+        qs = parse_qs(parsed.query)
+        def _safe_int_param(name, default):
+            raw = qs.get(name, [default])[0]
+            try:
+                return int(raw)
+            except Exception:
+                return default
+        return j(handler, get_org_chat_context(
+            limit=_safe_int_param("limit", 25),
+            comments_per_issue=_safe_int_param("comments_per_issue", 8),
+        ))
+
+    if parsed.path == "/api/sessions/cleanup_report":
+        try:
+            from api.session_cleanup import build_session_cleanup_report
+            qs = parse_qs(parsed.query)
+            current_session_id = qs.get("current_session_id", [None])[0]
+            report = build_session_cleanup_report(
+                session_dir=STATE_DIR.parent / "sessions",
+                state_db_path=STATE_DIR.parent / "state.db",
+                current_session_id=current_session_id,
+            )
+            return j(handler, report)
+        except Exception as e:
+            logger.exception("Failed to build session cleanup report")
+            return bad(handler, f"cleanup report failed: {_sanitize_error(str(e))}", 500)
+
+    if parsed.path == "/api/sessions/retention_plan":
+        try:
+            from api.session_cleanup import build_session_cleanup_report, build_session_retention_plan
+            qs = parse_qs(parsed.query)
+            current_session_id = qs.get("current_session_id", [None])[0]
+            report = build_session_cleanup_report(
+                session_dir=STATE_DIR.parent / "sessions",
+                state_db_path=STATE_DIR.parent / "state.db",
+                current_session_id=current_session_id,
+            )
+            return j(handler, build_session_retention_plan(report))
+        except Exception as e:
+            logger.exception("Failed to build session retention plan")
+            return bad(handler, f"retention plan failed: {_sanitize_error(str(e))}", 500)
+
     if parsed.path == "/api/wiki/status":
         return _handle_llm_wiki_status(handler, parsed)
     if parsed.path == "/api/logs":
@@ -4019,6 +4077,77 @@ def handle_post(handler, parsed) -> bool:
             diag.finish()
         raise
 
+    if parsed.path == "/api/paperclip/org-chat/send":
+        from api.paperclip import send_org_chat_message
+        return j(handler, send_org_chat_message(
+            issue_id=str(body.get("issue_id") or body.get("issueId") or ""),
+            message=str(body.get("message") or body.get("body") or ""),
+            target_label=body.get("target_label") or body.get("targetLabel"),
+        ))
+
+    if parsed.path == "/api/sessions/quarantine":
+        try:
+            session_ids = body.get("session_ids") or []
+            if not isinstance(session_ids, list):
+                return bad(handler, "session_ids must be a list")
+            from api.session_cleanup import build_session_cleanup_report, quarantine_sessions
+            report = build_session_cleanup_report(
+                session_dir=STATE_DIR.parent / "sessions",
+                state_db_path=STATE_DIR.parent / "state.db",
+                current_session_id=body.get("current_session_id"),
+            )
+            result = quarantine_sessions(
+                session_ids,
+                report=report,
+                session_dir=STATE_DIR.parent / "sessions",
+                trash_root=STATE_DIR.parent / "session-trash",
+                actor="webui",
+            )
+            return j(handler, result)
+        except Exception as e:
+            logger.exception("Failed to quarantine sessions")
+            return bad(handler, f"session quarantine failed: {_sanitize_error(str(e))}", 500)
+
+    if parsed.path == "/api/sessions/restore_quarantine":
+        try:
+            from api.session_cleanup import latest_manifest, restore_quarantine
+            manifest_path = body.get("manifest_path")
+            if manifest_path:
+                candidate = Path(str(manifest_path)).expanduser().resolve()
+                trash_root = (STATE_DIR.parent / "session-trash").resolve()
+                try:
+                    candidate.relative_to(trash_root)
+                except Exception:
+                    return bad(handler, "manifest_path must be inside session-trash", 400)
+            else:
+                candidate = latest_manifest(STATE_DIR.parent / "session-trash")
+            if not candidate:
+                return bad(handler, "No quarantine manifest found", 404)
+            return j(handler, restore_quarantine(candidate, session_dir=STATE_DIR.parent / "sessions"))
+        except Exception as e:
+            logger.exception("Failed to restore session quarantine")
+            return bad(handler, f"session restore failed: {_sanitize_error(str(e))}", 500)
+
+    if parsed.path == "/api/sessions/delete_quarantine":
+        try:
+            from api.session_cleanup import delete_quarantine, latest_manifest
+            manifest_path = body.get("manifest_path")
+            if manifest_path:
+                candidate = Path(str(manifest_path)).expanduser().resolve()
+                trash_root = (STATE_DIR.parent / "session-trash").resolve()
+                try:
+                    candidate.relative_to(trash_root)
+                except Exception:
+                    return bad(handler, "manifest_path must be inside session-trash", 400)
+            else:
+                candidate = latest_manifest(STATE_DIR.parent / "session-trash")
+            if not candidate:
+                return bad(handler, "No quarantine manifest found", 404)
+            return j(handler, delete_quarantine(candidate))
+        except Exception as e:
+            logger.exception("Failed to delete session quarantine")
+            return bad(handler, f"session quarantine delete failed: {_sanitize_error(str(e))}", 500)
+
     if parsed.path == "/api/session/recovery/repair-safe":
         from api.session_recovery import repair_safe_session_recovery
         result = repair_safe_session_recovery(SESSION_DIR, state_db_path=_active_state_db_path())
@@ -4216,10 +4345,10 @@ def handle_post(handler, parsed) -> bool:
         return j(handler, {"status": "ok", "reloaded": "api.models"})
 
     if parsed.path == "/api/sessions/cleanup":
-        return _handle_sessions_cleanup(handler, body, zero_only=False)
+        return bad(handler, "legacy cleanup endpoint disabled; use cleanup_report + quarantine", 410)
 
     if parsed.path == "/api/sessions/cleanup_zero_message":
-        return _handle_sessions_cleanup(handler, body, zero_only=True)
+        return bad(handler, "legacy cleanup endpoint disabled; use cleanup_report + quarantine", 410)
 
     if parsed.path == "/api/session/rename":
         try:
@@ -9770,3 +9899,5 @@ def _handle_mcp_server_update(handler, name, body):
     _save_yaml_config_file(_get_config_path(), cfg)
     reload_config()
     return j(handler, {"ok": True, "server": _server_summary(name, server_cfg)})
+
+# Phase5 cockpit route markers: /api/reports/morning-brief/latest /api/control-plane/overview /api/paperclip/status /api/sessions/cleanup_report

--- a/api/session_cleanup.py
+++ b/api/session_cleanup.py
@@ -1,0 +1,567 @@
+"""Reversible WebUI session cleanup helpers.
+
+The cleanup mode deliberately starts conservative:
+- scan is read-only;
+- only explicit cleanup candidates can be quarantined;
+- quarantine moves JSON files to a restoreable trash directory with a manifest;
+- state.db is never modified here.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+MESSAGING_SOURCES = {"telegram", "discord", "slack", "signal", "matrix", "yuanbao"}
+KNOWN_SOURCES = {"webui", "cron", "cli", "gateway", "browser"} | MESSAGING_SOURCES
+DAY = 86400
+_SECRET_RE = re.compile(r"(?i)\b(api[_-]?key|token|password|passwd|secret|credential|cookie|bearer)\b\s*[:=]\s*[^\s,;]+")
+
+
+def _redact_text(value: str) -> str:
+    return _SECRET_RE.sub(lambda m: f"{m.group(1)}=[REDACTED]", value)
+
+
+def _safe_session_id(session_id: str) -> bool:
+    return bool(session_id) and all(c in "0123456789abcdefghijklmnopqrstuvwxyz_" for c in session_id)
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+    return value if isinstance(value, dict) else None
+
+
+def _messages_count(payload: dict[str, Any]) -> int:
+    msgs = payload.get("messages")
+    return len(msgs) if isinstance(msgs, list) else 0
+
+
+def _message_text(payload: dict[str, Any], *, limit: int = 12000) -> str:
+    """Return bounded message text for local retention heuristics.
+
+    This deliberately does not call an LLM or persist raw transcript text. It is
+    used only to decide whether a chat needs structured review before deletion.
+    """
+    parts: list[str] = []
+    msgs = payload.get("messages")
+    if isinstance(msgs, list):
+        for msg in msgs:
+            if not isinstance(msg, dict):
+                continue
+            content = msg.get("content") or msg.get("text") or ""
+            if isinstance(content, list):
+                content = " ".join(str(x.get("text") if isinstance(x, dict) else x) for x in content)
+            parts.append(str(content))
+            if sum(len(p) for p in parts) >= limit:
+                break
+    for key in ("summary", "handoff_summary", "title"):
+        value = payload.get(key)
+        if value:
+            parts.append(str(value))
+    return "\n".join(parts)[:limit]
+
+
+def _structured_retention_review(payload: dict[str, Any]) -> dict[str, Any]:
+    """Classify whether a chat contains durable value before raw deletion."""
+    lower = _message_text(payload).lower()
+    targets: list[str] = []
+    reasons: list[str] = []
+    keyword_sets = [
+        ("secret_risk", ["api_key", "apikey", "secret", "token", "password", "passwd", "credential", "cookie", "bearer", "비밀", "토큰", "패스워드", "비밀번호", "자격증명"]),
+        ("memory_candidate", ["remember", "기억", "기억해", "선호", "prefer", "preference", "앞으로", "항상", "don't", "하지마", "하지 말", "사용자는"]),
+        ("skill_candidate", ["절차", "workflow", "워크플로", "반복", "재사용", "해결", "debug", "검증", "runbook", "sop", "방법"]),
+        ("obsidian_candidate", ["obsidian", "rule map", "soul", "contract", "계약", "규칙", "권한", "authority", "승인", "merge review", " mr", "canonical", "정책"]),
+        ("handoff_candidate", ["handoff", "인수인계", "safe_next_action", "next step", "다음", "진행", "blocked", "blocker", "todo", "남은", "pending"]),
+    ]
+    for target, keywords in keyword_sets:
+        if any(k in lower for k in keywords):
+            targets.append(target)
+    if targets:
+        reasons.append("raw_chat_not_long_term_memory")
+    if "secret_risk" in targets:
+        reasons.append("secret_or_credential_risk")
+    decision = "discard_raw_ok"
+    if targets:
+        decision = "structure_before_delete"
+    if "secret_risk" in targets:
+        decision = "do_not_preserve_secret_review"
+    return {
+        "retention_decision": decision,
+        "structured_targets": targets,
+        "retention_reasons": reasons,
+        "raw_chat_preservation": "not_required" if not targets else "review_structured_summary_only",
+    }
+
+
+def _source(payload: dict[str, Any], path: Path) -> str:
+    for key in ("source", "session_source", "raw_source", "source_tag", "platform"):
+        value = str(payload.get(key) or "").strip().lower()
+        if value:
+            return value
+    sid = str(payload.get("session_id") or path.stem).lower()
+    title = str(payload.get("title") or "").lower()
+    if sid.startswith("cron") or "cron" in title:
+        return "cron"
+    return "webui"
+
+
+def _coerce_timestamp(value: Any) -> float | None:
+    if value is None or value == "":
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    text = str(value).strip()
+    if not text:
+        return None
+    try:
+        return float(text)
+    except ValueError:
+        pass
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed.timestamp()
+    except ValueError:
+        return None
+
+
+def _age_days(payload: dict[str, Any], path: Path, now: float) -> float:
+    for key in ("updated_at", "last_message_at", "last_updated", "session_start", "created_at"):
+        ts = _coerce_timestamp(payload.get(key))
+        if ts is not None:
+            return max(0.0, (now - ts) / DAY)
+    return max(0.0, (now - path.stat().st_mtime) / DAY)
+
+
+def _age_bucket(age_days: float) -> str:
+    if age_days <= 7:
+        return "0-7d"
+    if age_days <= 14:
+        return "8-14d"
+    if age_days <= 30:
+        return "15-30d"
+    if age_days <= 90:
+        return "31-90d"
+    return "90d+"
+
+
+def _session_summary(path: Path, payload: dict[str, Any], *, now: float) -> dict[str, Any]:
+    sid = str(payload.get("session_id") or path.stem)
+    src = _source(payload, path)
+    msg_count = _messages_count(payload)
+    age = _age_days(payload, path, now)
+    try:
+        size = path.stat().st_size
+    except OSError:
+        size = 0
+    return {
+        "session_id": sid,
+        "title": _redact_text(str(payload.get("title") or sid)[:120]),
+        "source": src,
+        "age_days": round(age, 2),
+        "age_bucket": _age_bucket(age),
+        "message_count": msg_count,
+        "bytes": size,
+        "reasons": [],
+    }
+
+
+def _classify(path: Path, payload: dict[str, Any], *, now: float, current_session_id: str | None = None) -> tuple[str, dict[str, Any]]:
+    item = _session_summary(path, payload, now=now)
+    review = _structured_retention_review(payload)
+    item.update({
+        "retention_decision": review["retention_decision"],
+        "structured_targets": review["structured_targets"],
+        "raw_chat_preservation": review["raw_chat_preservation"],
+    })
+    sid = item["session_id"]
+    src = item["source"]
+    age = item["age_days"]
+    msg_count = item["message_count"]
+    last_status = str(payload.get("last_status") or payload.get("status") or "").lower()
+
+    protected_reasons = []
+    if current_session_id and sid == current_session_id:
+        protected_reasons.append("current_session")
+    if payload.get("pinned") or payload.get("starred"):
+        protected_reasons.append("pinned")
+    if payload.get("active_stream_id") or payload.get("streaming") or payload.get("pending"):
+        protected_reasons.append("active_or_streaming")
+    if src in MESSAGING_SOURCES:
+        protected_reasons.append("messaging_source")
+    if src == "cli":
+        protected_reasons.append("cli_state_db_linked")
+    if protected_reasons:
+        item["reasons"] = protected_reasons
+        return "protected", item
+
+    if msg_count == 0:
+        item["reasons"] = ["zero_messages"]
+        return "cleanup_candidates", item
+    if src == "cron" and last_status in {"error", "failed", "failure"}:
+        item["reasons"] = ["cron_failure_retained_30d"]
+        return "protected" if age <= 30 else "needs_review", item
+    if src == "cron" and age >= 14:
+        if review["structured_targets"]:
+            item["reasons"] = review["retention_reasons"] + ["cron_success_structured_review_required"]
+            return "needs_review", item
+        item["reasons"] = ["cron_success_older_than_14d"]
+        return "cleanup_candidates", item
+    if src == "webui" and age >= 30:
+        archived = bool(payload.get("archived") or payload.get("is_archived") or payload.get("deleted"))
+        if archived:
+            if review["structured_targets"]:
+                item["reasons"] = review["retention_reasons"] + ["webui_archived_structured_review_required"]
+                return "needs_review", item
+            item["reasons"] = ["webui_archived_older_than_30d"]
+            return "cleanup_candidates", item
+        item["reasons"] = ["webui_non_archived_retained"]
+        return "protected", item
+    if src not in KNOWN_SOURCES:
+        item["reasons"] = ["unknown_source_review_required"]
+        return "needs_review", item
+
+    item["reasons"] = ["retention_window"]
+    return "protected", item
+
+
+def build_session_cleanup_report(
+    *,
+    session_dir: str | Path,
+    state_db_path: str | Path | None = None,
+    now: float | None = None,
+    current_session_id: str | None = None,
+) -> dict[str, Any]:
+    """Return a read-only cleanup report for WebUI JSON session files."""
+    session_dir = Path(session_dir)
+    now = time.time() if now is None else float(now)
+    buckets = {"cleanup_candidates": [], "protected": [], "needs_review": [], "invalid": []}
+    source_counts: dict[str, int] = {}
+    age_buckets: dict[str, int] = {}
+    total_bytes = 0
+
+    for path in sorted(session_dir.glob("*.json")) if session_dir.exists() else []:
+        if path.name.startswith("_") or ".tmp." in path.name:
+            continue
+        if path.is_symlink():
+            try:
+                size = path.lstat().st_size
+            except OSError:
+                size = 0
+            buckets["invalid"].append({"path": path.name, "reasons": ["symlink_not_allowed"], "bytes": size})
+            continue
+        payload = _read_json(path)
+        if payload is None:
+            buckets["invalid"].append({"path": path.name, "reasons": ["invalid_json"], "bytes": path.stat().st_size})
+            continue
+        payload_sid = str(payload.get("session_id") or "")
+        expected_stems = {payload_sid, f"session_{payload_sid}"} if payload_sid else {path.stem}
+        if payload_sid and path.stem not in expected_stems:
+            buckets["invalid"].append({
+                "path": path.name,
+                "session_id": payload_sid,
+                "reasons": ["session_id_filename_mismatch"],
+                "bytes": path.stat().st_size,
+            })
+            continue
+        if payload_sid and not _safe_session_id(payload_sid):
+            buckets["invalid"].append({
+                "path": path.name,
+                "session_id": payload_sid,
+                "reasons": ["invalid_session_id"],
+                "bytes": path.stat().st_size,
+            })
+            continue
+        if not payload_sid and not _safe_session_id(path.stem):
+            buckets["invalid"].append({
+                "path": path.name,
+                "session_id": path.stem,
+                "reasons": ["invalid_session_id"],
+                "bytes": path.stat().st_size,
+            })
+            continue
+        kind, item = _classify(path, payload, now=now, current_session_id=current_session_id)
+        item["path"] = path.name
+        buckets[kind].append(item)
+        source_counts[item["source"]] = source_counts.get(item["source"], 0) + 1
+        age_buckets[item["age_bucket"]] = age_buckets.get(item["age_bucket"], 0) + 1
+        total_bytes += item["bytes"]
+
+    estimated = sum(i.get("bytes", 0) for i in buckets["cleanup_candidates"])
+    return {
+        "ok": True,
+        "mode": "read_only",
+        "generated_at": now,
+        "session_dir": str(session_dir),
+        "state_db_path": str(state_db_path) if state_db_path else None,
+        "policy": {
+            "cron_success_days": 14,
+            "cron_failure_days": 30,
+            "webui_days": 30,
+            "zero_message": "candidate",
+            "messaging": "protected",
+            "cli_state_db": "protected",
+            "state_db": "not_modified",
+        },
+        "summary": {
+            "total_sessions": sum(len(v) for k, v in buckets.items() if k != "invalid"),
+            "total_bytes": total_bytes,
+            "estimated_reclaim_bytes": estimated,
+            "cleanup_candidate_count": len(buckets["cleanup_candidates"]),
+            "protected_count": len(buckets["protected"]),
+            "needs_review_count": len(buckets["needs_review"]),
+            "invalid_count": len(buckets["invalid"]),
+            "source_counts": source_counts,
+            "age_buckets": age_buckets,
+            "state_db_touched": False,
+            "structured_review_count": sum(
+                1 for items in (buckets["cleanup_candidates"], buckets["needs_review"])
+                for item in items
+                if item.get("retention_decision") in {"structure_before_delete", "do_not_preserve_secret_review"}
+            ),
+        },
+        **buckets,
+    }
+
+
+def build_session_retention_plan(report: dict[str, Any]) -> dict[str, Any]:
+    """Build a read-only plan for structured retention before raw deletion."""
+    cleanup = list(report.get("cleanup_candidates", []) or [])
+    needs_review = list(report.get("needs_review", []) or [])
+    protected = list(report.get("protected", []) or [])
+    structured = [
+        item for item in needs_review + cleanup
+        if item.get("retention_decision") in {"structure_before_delete", "do_not_preserve_secret_review"}
+    ]
+    quarantine_ready = [
+        item for item in cleanup
+        if item.get("retention_decision") == "discard_raw_ok" and not item.get("structured_targets")
+    ]
+    structured_ids = {item.get("session_id") for item in structured}
+    keep = [item for item in protected if item.get("session_id") not in structured_ids]
+    return {
+        "ok": True,
+        "mode": "read_only_retention_plan",
+        "generated_at": report.get("generated_at"),
+        "policy": {
+            "raw_chat": "quarantine/delete only after structured value is promoted or judged disposable",
+            "memory": "compact durable preferences/environment facts only",
+            "skills": "repeatable procedures and workflows",
+            "obsidian": "rules/contracts/canonical decisions through MR path",
+            "secrets": "do not preserve raw credentials",
+            "state_db": "not_modified",
+        },
+        "summary": {
+            "quarantine_ready_count": len(quarantine_ready),
+            "structure_before_delete_count": len(structured),
+            "keep_count": len(keep),
+            "needs_review_count": len(needs_review),
+            "state_db_touched": False,
+        },
+        "quarantine_ready": quarantine_ready,
+        "structured_candidates": structured,
+        "keep": keep,
+    }
+
+
+def _invalidate_index(session_dir: Path) -> None:
+    try:
+        (session_dir / "_index.json").unlink(missing_ok=True)
+    except Exception:
+        pass
+
+
+def quarantine_sessions(
+    session_ids: list[str],
+    *,
+    report: dict[str, Any],
+    session_dir: str | Path,
+    trash_root: str | Path,
+    actor: str = "webui",
+) -> dict[str, Any]:
+    """Move selected cleanup candidates into a manifest-backed quarantine."""
+    session_dir = Path(session_dir).resolve()
+    trash_root = Path(trash_root).resolve()
+    candidate_ids = {str(i.get("session_id")): i for i in report.get("cleanup_candidates", [])}
+    requested = [str(sid) for sid in session_ids if isinstance(sid, str)]
+    batch = time.strftime("%Y%m%d-%H%M%S") + f"-{os.getpid()}"
+    batch_dir = trash_root / batch
+    trash_sessions = batch_dir / "sessions"
+    trash_sessions.mkdir(parents=True, exist_ok=False)
+
+    manifest = {
+        "operation": "quarantine",
+        "created_at": time.time(),
+        "actor": actor,
+        "session_dir": str(session_dir),
+        "state_db_touched": False,
+        "items": [],
+        "skipped": [],
+    }
+    moved: list[str] = []
+    skipped: list[dict[str, str]] = []
+
+    for sid in requested:
+        if not _safe_session_id(sid):
+            skipped.append({"session_id": sid, "reason": "invalid_session_id"})
+            continue
+        candidate = candidate_ids.get(sid)
+        if not candidate:
+            skipped.append({"session_id": sid, "reason": "not_cleanup_candidate"})
+            continue
+        candidate_path_name = str(candidate.get("path") or "")
+        if candidate_path_name not in {f"{sid}.json", f"session_{sid}.json"}:
+            skipped.append({"session_id": sid, "reason": "candidate_path_mismatch"})
+            continue
+        src = session_dir / candidate_path_name
+        if src.is_symlink():
+            skipped.append({"session_id": sid, "reason": "symlink_not_allowed"})
+            continue
+        try:
+            src_resolved = src.resolve(strict=False)
+            src_resolved.relative_to(session_dir)
+        except Exception:
+            skipped.append({"session_id": sid, "reason": "path_escape"})
+            continue
+        if not src.exists() or not src.is_file():
+            skipped.append({"session_id": sid, "reason": "missing_source"})
+            continue
+        dst = trash_sessions / src.name
+        shutil.move(str(src), str(dst))
+        moved.append(sid)
+        manifest["items"].append({
+            "session_id": sid,
+            "source_path": str(src),
+            "trash_path": str(dst),
+            "bytes": candidate.get("bytes", 0),
+            "reasons": candidate.get("reasons", []),
+        })
+
+    manifest["skipped"] = skipped
+    manifest_path = batch_dir / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest, ensure_ascii=False, indent=2), encoding="utf-8")
+    if moved:
+        _invalidate_index(session_dir)
+    return {"ok": True, "moved": moved, "skipped": skipped, "manifest_path": str(manifest_path), "state_db_touched": False}
+
+
+def restore_quarantine(manifest_path: str | Path, *, session_dir: str | Path) -> dict[str, Any]:
+    """Restore files listed in a quarantine manifest back to the session dir."""
+    session_dir = Path(session_dir).resolve()
+    manifest_path = Path(manifest_path).resolve()
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    expected_trash_dir = (manifest_path.parent / "sessions").resolve()
+    restored: list[str] = []
+    skipped: list[dict[str, str]] = []
+    session_dir.mkdir(parents=True, exist_ok=True)
+    for item in manifest.get("items", []):
+        sid = str(item.get("session_id") or "")
+        if not _safe_session_id(sid):
+            skipped.append({"session_id": sid, "reason": "invalid_session_id"})
+            continue
+        raw_src = Path(item.get("trash_path") or manifest_path.parent / "sessions" / f"{sid}.json")
+        src = raw_src.resolve()
+        source_name = Path(str(item.get("source_path") or f"{sid}.json")).name
+        if source_name not in {f"{sid}.json", f"session_{sid}.json"}:
+            skipped.append({"session_id": sid, "reason": "source_name_mismatch"})
+            continue
+        dst = session_dir / source_name
+        try:
+            src.relative_to(expected_trash_dir)
+        except Exception:
+            skipped.append({"session_id": sid, "reason": "trash_path_escape"})
+            continue
+        try:
+            dst_resolved = dst.resolve(strict=False)
+            dst_resolved.relative_to(session_dir)
+        except Exception:
+            skipped.append({"session_id": sid, "reason": "path_escape"})
+            continue
+        if raw_src.is_symlink() or src.is_symlink():
+            skipped.append({"session_id": sid, "reason": "symlink_not_allowed"})
+            continue
+        if not src.exists() or not src.is_file():
+            skipped.append({"session_id": sid, "reason": "missing_trash_file"})
+            continue
+        if dst.exists():
+            skipped.append({"session_id": sid, "reason": "destination_exists"})
+            continue
+        shutil.move(str(src), str(dst))
+        restored.append(sid)
+    if restored:
+        _invalidate_index(session_dir)
+    return {"ok": True, "restored": restored, "skipped": skipped, "state_db_touched": False}
+
+
+def delete_quarantine(manifest_path: str | Path) -> dict[str, Any]:
+    """Permanently delete only files listed in a quarantine manifest.
+
+    This is intentionally narrower than deleting a whole quarantine directory:
+    stray files, symlinks, escaped paths, and anything outside the manifest's
+    own ``sessions/`` directory are skipped. Live ``session_dir`` and state.db
+    are never touched by this helper.
+    """
+    manifest_path = Path(manifest_path).resolve()
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    expected_trash_dir = (manifest_path.parent / "sessions").resolve()
+    deleted: list[str] = []
+    skipped: list[dict[str, str]] = []
+
+    for item in manifest.get("items", []):
+        sid = str(item.get("session_id") or "")
+        if not _safe_session_id(sid):
+            skipped.append({"session_id": sid, "reason": "invalid_session_id"})
+            continue
+        raw_path = Path(item.get("trash_path") or expected_trash_dir / f"{sid}.json")
+        if raw_path.is_symlink():
+            skipped.append({"session_id": sid, "reason": "symlink_not_allowed"})
+            continue
+        try:
+            target = raw_path.resolve(strict=False)
+            target.relative_to(expected_trash_dir)
+        except Exception:
+            skipped.append({"session_id": sid, "reason": "trash_path_escape"})
+            continue
+        if not target.exists() or not target.is_file():
+            skipped.append({"session_id": sid, "reason": "missing_trash_file"})
+            continue
+        try:
+            target.unlink()
+            deleted.append(sid)
+        except OSError:
+            skipped.append({"session_id": sid, "reason": "delete_failed"})
+
+    deletion_manifest = {
+        "operation": "delete_quarantine",
+        "created_at": time.time(),
+        "source_manifest": str(manifest_path),
+        "deleted": deleted,
+        "skipped": skipped,
+        "state_db_touched": False,
+    }
+    (manifest_path.parent / "deleted-manifest.json").write_text(
+        json.dumps(deletion_manifest, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+    return {
+        "ok": True,
+        "deleted": deleted,
+        "skipped": skipped,
+        "deletion_manifest_path": str(manifest_path.parent / "deleted-manifest.json"),
+        "state_db_touched": False,
+    }
+
+
+def latest_manifest(trash_root: str | Path) -> Path | None:
+    trash_root = Path(trash_root)
+    manifests = sorted(trash_root.glob("*/manifest.json"), key=lambda p: p.stat().st_mtime, reverse=True)
+    return manifests[0] if manifests else None

--- a/static/boot.js
+++ b/static/boot.js
@@ -1605,3 +1605,258 @@ window.addEventListener('pageshow', async (event) => {
     } catch (_) {}
   }
 });
+
+// Hermes local session-continuity controls: 세션 압축 / 이동 준비 / 세션 이동
+(function(){
+  function _scEl(id){return document.getElementById(id);}
+  function _scToast(msg,ms,type){if(typeof showToast==='function')showToast(msg,ms||2200,type);}
+  function _scRoleLabel(role){return role==='user'?'User':role==='assistant'?'Assistant':role||'message';}
+  function _scContent(msg){
+    if(!msg)return '';
+    const raw=msg.content||msg.text||'';
+    if(Array.isArray(raw))return raw.map(p=>typeof p==='string'?p:(p&&(p.text||p.content)||'')).join(' ').trim();
+    return String(raw||'').trim();
+  }
+  function _scVisibleMessages(){
+    const items=Array.isArray(S&&S.messages)?S.messages:[];
+    return items.filter(m=>m&&m.role&&m.role!=='tool'&&_scContent(m));
+  }
+  function _scHash(text){
+    let h=2166136261;
+    for(let i=0;i<text.length;i++){h^=text.charCodeAt(i);h=Math.imul(h,16777619);}
+    return ('00000000'+(h>>>0).toString(16)).slice(-8);
+  }
+  async function _scCopy(text){
+    if(typeof _copyText==='function')return _copyText(text);
+    if(navigator.clipboard&&window.isSecureContext)return navigator.clipboard.writeText(text);
+    const ta=document.createElement('textarea');ta.value=text;ta.setAttribute('readonly','');ta.style.position='fixed';ta.style.left='-9999px';document.body.appendChild(ta);ta.select();document.execCommand('copy');ta.remove();
+  }
+  async function _scSendSlash(command){
+    if(S&&S.busy){_scToast('현재 응답이 진행 중입니다. 완료 후 다시 시도하세요.',2600,'warn');return;}
+    const msg=_scEl('msg');
+    if(!msg){_scToast('메시지 입력창을 찾지 못했습니다.',2600,'error');return;}
+    msg.value=command;
+    if(typeof autoResize==='function')autoResize();
+    if(typeof send==='function')await send();
+  }
+  function _scBoundedLine(raw, maxLen){
+    const text=String(raw||'').replace(/\s+/g,' ').trim();
+    if(text.length<=maxLen)return text;
+    return text.slice(0,Math.max(0,maxLen-1))+'…';
+  }
+  function _scVisibleOutline(messages, startIdx){
+    const maxPerMessage=320;
+    const maxTotal=42000;
+    const offset=Number.isFinite(startIdx)?Math.max(0,startIdx):0;
+    const lines=[];
+    let used=0;
+    let truncated=false;
+    for(let i=0;i<messages.length;i++){
+      const m=messages[i];
+      const line=`${String(offset+i+1).padStart(3,'0')}. ${_scRoleLabel(m.role)}: ${_scBoundedLine(_scContent(m),maxPerMessage)}`;
+      if(used+line.length+1>maxTotal){truncated=true;break;}
+      lines.push(line);
+      used+=line.length+1;
+    }
+    if(!lines.length)return '표시 가능한 대화 내용이 없습니다.';
+    if(truncated)lines.push(`[중단: 인계문 길이 보호를 위해 ${messages.length-lines.length}개 메시지 outline 생략]`);
+    return lines.join('\n');
+  }
+  function _scPriorHandoff(messages){
+    let best=null;
+    for(let i=0;i<messages.length;i++){
+      const text=_scContent(messages[i]);
+      if(!text||!text.includes('[이동 준비: 새 세션 이어가기 안내]'))continue;
+      const hashMatch=text.match(/(?:^|\n)packet_hash:\s*([^\n]+)/);
+      const sourceMatch=text.match(/(?:^|\n)source_session_id:\s*([^\n]+)/);
+      best={index:i,text,hash:hashMatch?hashMatch[1].trim():'unknown',source:sourceMatch?sourceMatch[1].trim():'unknown'};
+    }
+    return best;
+  }
+  function _scExtractSection(text, title){
+    const marker=`\n\n${title}:\n`;
+    const idx=String(text||'').indexOf(marker);
+    if(idx<0)return '';
+    const start=idx+marker.length;
+    const rest=String(text||'').slice(start);
+    const next=rest.search(/\n\n[^\n:]{1,80}:\n/);
+    return (next>=0?rest.slice(0,next):rest).trim();
+  }
+  function _scPriorDigest(prior){
+    if(!prior||!prior.text)return {text:'',truncated:false};
+    const text=String(prior.text||'');
+    const lines=text.split('\n');
+    const meta=[];
+    for(const line of lines){
+      if(line.startsWith('[이동 준비:')||/^(source_session_id|packet_scope|packet_hash|prior_packet_hash|handoff_chain|delta_visible_message_count|created_at|generation_method):/.test(line)){
+        meta.push(line);
+      }
+      if(meta.length>=12)break;
+    }
+    const recent=_scBoundedLine(_scExtractSection(text,'최근 요약'),3500);
+    const instruction=_scBoundedLine(_scExtractSection(text,'이어가기 지시'),900);
+    const parts=[];
+    if(meta.length)parts.push('이전 인계문 메타:\n'+meta.join('\n'));
+    if(recent)parts.push('이전 운영 요약:\n'+recent);
+    if(instruction)parts.push('이전 이어가기 지시:\n'+instruction);
+    const digest=parts.join('\n\n')||`이전 인계문 ${prior.hash||'unknown'} 감지됨. 원문 전문은 효율을 위해 재첨부하지 않음.`;
+    const maxLen=9000;
+    if(digest.length<=maxLen)return {text:digest,truncated:false};
+    return {text:digest.slice(0,maxLen-100)+'\n[중단: 이전 운영 요약 길이 보호로 일부 생략]',truncated:true};
+  }
+  function _scLatestByRole(messages, role){
+    for(let i=messages.length-1;i>=0;i--){
+      if(messages[i]&&messages[i].role===role){
+        const text=_scContent(messages[i]);
+        if(text)return text;
+      }
+    }
+    return '';
+  }
+  function _scEvidenceLines(messages, pattern, limit){
+    const lines=[];
+    for(const m of messages.slice().reverse()){
+      const text=_scContent(m);
+      if(!text||!pattern.test(text))continue;
+      lines.push(`- ${_scRoleLabel(m.role)}: ${_scBoundedLine(text,220)}`);
+      if(lines.length>=limit)break;
+    }
+    return lines.reverse().join('\n');
+  }
+  function _scOperationalChecklist(messages, summary, prior, deltaMessages, sid){
+    const latestUser=_scLatestByRole(messages,'user');
+    const latestAssistant=_scLatestByRole(messages,'assistant');
+    const verification=_scEvidenceLines(messages, /(PASS|검증|확인|console|served|active\/running|오류 없음|JS errors 없음|재시작 없음)/i, 3);
+    const caution=[
+      '- 전체 원문 이동이 아니라 운영 요약 + bounded delta handoff임.',
+      '- backend 최근 요약은 recent-50 제한 가능성이 있음.',
+      '- 필요하면 원본 세션/수정 파일/검증 로그를 다시 확인할 것.',
+    ].join('\n');
+    return [
+      `- 현재 목표: ${_scBoundedLine(latestUser||'확인 필요',320)}`,
+      `- 완료/변경: ${_scBoundedLine(summary||latestAssistant||'확인 필요',520)}`,
+      `- 검증 결과: ${verification||'확인 필요 — 새 세션에서 필요한 파일/상태를 재검증할 것.'}`,
+      `- 남은 작업: 최신 사용자 의도 기준으로 다음 안전 단계부터 진행. 불명확하면 한 번만 확인.`,
+      `- 주의/금지:\n${caution}`,
+      `- 참조: source_session_id=${sid}${prior?`; prior_packet_hash=${prior.hash}; prior_source_session_id=${prior.source}; delta_visible_message_count=${deltaMessages.length}`:''}`,
+    ].join('\n');
+  }
+  async function _scBuildPacket(kind){
+    const session=S&&S.session;
+    if(!session||!session.session_id)throw new Error('활성 세션이 없습니다.');
+    const sid=session.session_id;
+    const messages=_scVisibleMessages();
+    const created=new Date().toISOString();
+    const prior=_scPriorHandoff(messages);
+    const deltaStart=prior?prior.index+1:0;
+    const deltaMessages=messages.slice(deltaStart);
+    const outline=_scVisibleOutline(prior?deltaMessages:messages, deltaStart);
+    const priorDigest=prior?_scPriorDigest(prior):null;
+    let summary='';
+    let method=prior?'local_prior_handoff+delta_visible_outline':'local_all_visible_outline';
+    try{
+      if(typeof api==='function'){
+        const res=await api('/api/session/handoff-summary',{method:'POST',body:JSON.stringify({session_id:sid})});
+        if(res&&res.ok&&res.summary){summary=String(res.summary).trim();method=(res.fallback?'api_recent_summary_fallback':'api_recent_summary')+'+'+(prior?'prior_handoff+delta_visible_outline':'local_all_visible_outline');}
+      }
+    }catch(e){
+      summary='';
+    }
+    if(!summary){
+      const tail=messages.slice(-24).map(m=>`- ${_scRoleLabel(m.role)}: ${_scBoundedLine(_scContent(m),420)}`).join('\n');
+      summary=tail||'표시 가능한 대화 내용이 없습니다.';
+      method='local_recent_tail+'+(prior?'prior_handoff+delta_visible_outline':'local_all_visible_outline');
+    }
+    const terminalHint=kind==='terminal'?'새 Hermes CLI/터미널 세션에 이 인계문을 붙여넣고 이어서 진행해. 원본 WebUI 세션을 직접 수정한다고 가정하지 마.':null;
+    const scope=prior?'chained_handoff_plus_delta_visible_outline':'all_visible_messages_bounded_outline';
+    const meta=[
+      '[이동 준비: 새 세션 이어가기 안내]',
+      `source_session_id: ${sid}`,
+      kind==='move'&&S&&S.session&&S.session.session_id?`target_session_id: pending_new_session`:null,
+      `packet_scope: ${scope}`,
+      prior?'handoff_chain: true':null,
+      prior?`prior_packet_hash: ${prior.hash}`:null,
+      prior?`prior_source_session_id: ${prior.source}`:null,
+      prior?`delta_visible_message_count: ${deltaMessages.length}`:null,
+      prior&&priorDigest&&priorDigest.truncated?'prior_digest_truncated: true':null,
+      'packet_limit_note: backend_summary_may_cover_recent_50; continuity is preserved by prior operational digest plus local bounded delta outline when present',
+      'per_message_outline_chars: 320',
+      `message_count: ${messages.length}`,
+      `created_at: ${created}`,
+      `generation_method: ${method}`,
+    ].filter(Boolean);
+    const instructions=terminalHint||'위 인계문 기준으로 이어서 진행해. 오래된 요청을 재실행하지 말고 최신 사용자 의도부터 확인해.';
+    const checklist=_scOperationalChecklist(messages, summary, prior, deltaMessages, sid);
+    const inherited=priorDigest?`\n\n계승된 운영 요약:\n${priorDigest.text}`:'';
+    const outlineTitle=prior?'이번 세션 추가 visible 메시지 outline':'전체 visible 메시지 outline';
+    const body=`${meta.join('\n')}\n\n운영 상태 체크리스트:\n${checklist}${inherited}\n\n최근 요약:\n${summary}\n\n${outlineTitle}:\n${outline}\n\n이어가기 지시:\n${instructions}`;
+    const hash=_scHash(body);
+    return body.replace(`generation_method: ${method}`,`packet_hash: local:${hash}\ngeneration_method: ${method}`);
+  }
+  async function _scHandoff(){
+    try{
+      const packet=await _scBuildPacket('handoff');
+      await _scCopy(packet);
+      const msg=_scEl('msg');
+      if(msg){msg.value=packet;if(typeof autoResize==='function')autoResize();msg.focus();}
+      _scToast('이동 준비 인계문을 복사하고 입력창에 넣었습니다.',2600);
+    }catch(e){_scToast('이동 준비 실패: '+(e&&e.message||e),3200,'error');}
+  }
+  async function _scTerminal(){
+    try{
+      const packet=await _scBuildPacket('terminal');
+      await _scCopy(packet);
+      const msg=_scEl('msg');
+      if(msg){msg.value=packet;if(typeof autoResize==='function')autoResize();msg.focus();}
+      _scToast('터미널 이동 인계문을 복사했습니다. 터미널에서 새 Hermes 세션을 열고 붙여넣으세요.',3600);
+    }catch(e){_scToast('터미널 이동 준비 실패: '+(e&&e.message||e),3200,'error');}
+  }
+  async function _scMove(){
+    try{
+      if(S&&S.busy){_scToast('현재 응답이 진행 중입니다. 완료 후 다시 시도하세요.',2600,'warn');return;}
+      const packet=await _scBuildPacket('move');
+      if(typeof newSession!=='function'||typeof send!=='function')throw new Error('새 세션/전송 기능을 찾지 못했습니다.');
+      await _scCopy(packet);
+      await newSession();
+      if(typeof renderSessionList==='function')await renderSessionList();
+      const msg=_scEl('msg');
+      if(!msg)throw new Error('메시지 입력창을 찾지 못했습니다.');
+      msg.value=packet;
+      if(typeof autoResize==='function')autoResize();
+      await send();
+      _scToast('새 세션으로 인계문을 전달했습니다.',2600);
+    }catch(e){_scToast('세션 이동 실패: '+(e&&e.message||e),3200,'error');}
+  }
+  function _scSetHandoffMenu(open){
+    const h=_scEl('btnSessionHandoff'),menu=_scEl('sessionHandoffMenu');
+    if(!h||!menu)return;
+    const next=!!open;
+    menu.hidden=!next;
+    h.setAttribute('aria-expanded',next?'true':'false');
+  }
+  function _scToggleHandoffMenu(){
+    const menu=_scEl('sessionHandoffMenu');
+    _scSetHandoffMenu(menu?menu.hidden:true);
+  }
+  window._sessionContinuityHandoff=_scHandoff;
+  window._sessionContinuityTerminal=_scTerminal;
+  window._sessionContinuityMove=_scMove;
+  function _scBind(){
+    const c=_scEl('btnSessionCompress'),h=_scEl('btnSessionHandoff'),hg=_scEl('btnSessionHandoffGeneral'),ht=_scEl('btnSessionHandoffTerminal'),m=_scEl('btnSessionMove');
+    if(c&&!c.dataset.bound){c.dataset.bound='1';c.addEventListener('click',()=>_scSendSlash('/compress'));}
+    if(h&&!h.dataset.bound){h.dataset.bound='1';h.addEventListener('click',(ev)=>{ev.stopPropagation();_scToggleHandoffMenu();});}
+    if(hg&&!hg.dataset.bound){hg.dataset.bound='1';hg.addEventListener('click',async(ev)=>{ev.stopPropagation();_scSetHandoffMenu(false);await _scHandoff();});}
+    if(ht&&!ht.dataset.bound){ht.dataset.bound='1';ht.addEventListener('click',async(ev)=>{ev.stopPropagation();_scSetHandoffMenu(false);await _scTerminal();});}
+    if(m&&!m.dataset.bound){m.dataset.bound='1';m.addEventListener('click',_scMove);}
+    if(!window._sessionContinuityMenuCloseBound){
+      window._sessionContinuityMenuCloseBound=true;
+      document.addEventListener('click',(ev)=>{
+        const wrap=document.querySelector('.session-continuity-menu-wrap');
+        if(wrap&&!wrap.contains(ev.target))_scSetHandoffMenu(false);
+      });
+      document.addEventListener('keydown',(ev)=>{if(ev.key==='Escape')_scSetHandoffMenu(false);});
+    }
+  }
+  if(document.readyState==='loading')document.addEventListener('DOMContentLoaded',_scBind);else _scBind();
+})();
+

--- a/static/index.html
+++ b/static/index.html
@@ -96,6 +96,10 @@
     <button class="rail-btn nav-tab has-tooltip" data-panel="profiles" onclick="switchPanel('profiles',{fromRailClick:true})" data-tooltip="Agent profiles" data-i18n-title="tab_profiles" aria-label="Agent profiles"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg></button>
     <button class="rail-btn nav-tab has-tooltip" data-panel="todos" onclick="switchPanel('todos',{fromRailClick:true})" data-tooltip="Current task list" data-i18n-title="tab_todos" aria-label="Todos"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="5" width="6" height="6" rx="1"/><path d="m3 17 2 2 4-4"/><path d="M13 6h8"/><path d="M13 12h8"/><path d="M13 18h8"/></svg></button>
     <button class="rail-btn nav-tab has-tooltip" data-panel="insights" onclick="switchPanel('insights',{fromRailClick:true})" data-tooltip="Insights" data-i18n-title="tab_insights" aria-label="Insights"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M18 20V10"/><path d="M12 20V4"/><path d="M6 20v-6"/></svg></button>
+    <button class="rail-btn nav-tab has-tooltip hermes-cockpit-nav" data-panel="paperclip" onclick="switchPanel('paperclip',{fromRailClick:true})" data-tooltip="Paperclip" aria-label="Paperclip">P</button>
+    <button class="rail-btn nav-tab has-tooltip hermes-cockpit-nav" data-panel="reports" onclick="switchPanel('reports',{fromRailClick:true})" data-tooltip="Reports" aria-label="Reports">R</button>
+    <button class="rail-btn nav-tab has-tooltip hermes-cockpit-nav" data-panel="controlPlane" onclick="switchPanel('controlPlane',{fromRailClick:true})" data-tooltip="Control Plane" data-i18n-title="tab_control_plane" aria-label="Control Plane">C</button>
+    <button class="rail-btn nav-tab has-tooltip hermes-cockpit-nav" data-panel="sessionCleanup" onclick="switchPanel('sessionCleanup',{fromRailClick:true})" data-tooltip="Session cleanup" aria-label="Session cleanup">S</button>
     <button class="rail-btn nav-tab dashboard-link has-tooltip" id="dashboardRailBtn" data-dashboard-link style="display:none" onclick="openHermesDashboard(event)" data-tooltip="Hermes Dashboard" data-i18n-title="tab_dashboard" aria-label="Hermes Dashboard"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18"/><path d="M9 21V9"/></svg><span class="dashboard-external-badge" aria-hidden="true"></span></button>
     <button class="rail-btn nav-tab has-tooltip" data-panel="logs" onclick="switchPanel('logs',{fromRailClick:true})" data-tooltip="Logs" data-i18n-title="tab_logs" aria-label="Logs"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><path d="M14 2v6h6"/><path d="M8 13h8"/><path d="M8 17h8"/><path d="M8 9h2"/></svg></button>
     <div class="rail-spacer"></div>
@@ -113,6 +117,10 @@
       <button class="nav-tab has-tooltip has-tooltip--bottom" data-panel="profiles" data-label="Profiles" onclick="switchPanel('profiles',{fromRailClick:true})" data-tooltip="Agent profiles" data-i18n-title="tab_profiles"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg></button>
       <button class="nav-tab has-tooltip has-tooltip--bottom" data-panel="todos" data-label="Todos" onclick="switchPanel('todos',{fromRailClick:true})" data-tooltip="Current task list" data-i18n-title="tab_todos"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="5" width="6" height="6" rx="1"/><path d="m3 17 2 2 4-4"/><path d="M13 6h8"/><path d="M13 12h8"/><path d="M13 18h8"/></svg></button>
       <button class="nav-tab has-tooltip has-tooltip--bottom" data-panel="insights" data-label="Insights" onclick="switchPanel('insights',{fromRailClick:true})" data-tooltip="Insights" data-i18n-title="tab_insights"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M18 20V10"/><path d="M12 20V4"/><path d="M6 20v-6"/></svg></button>
+      <button class="nav-tab has-tooltip has-tooltip--bottom" data-panel="paperclip" data-label="Paperclip" onclick="switchPanel('paperclip',{fromRailClick:true})" data-tooltip="Paperclip">P</button>
+      <button class="nav-tab has-tooltip has-tooltip--bottom" data-panel="reports" data-label="Reports" onclick="switchPanel('reports',{fromRailClick:true})" data-tooltip="Reports">R</button>
+      <button class="nav-tab has-tooltip has-tooltip--bottom" data-panel="controlPlane" data-label="Control" onclick="switchPanel('controlPlane',{fromRailClick:true})" data-tooltip="Control Plane" data-i18n-title="tab_control_plane">C</button>
+      <button class="nav-tab has-tooltip has-tooltip--bottom" data-panel="sessionCleanup" data-label="Cleanup" onclick="switchPanel('sessionCleanup',{fromRailClick:true})" data-tooltip="Session cleanup">S</button>
       <button class="nav-tab dashboard-link has-tooltip has-tooltip--bottom" id="dashboardMobileBtn" data-dashboard-link data-label="Dashboard" style="display:none" onclick="openHermesDashboard(event)" data-tooltip="Hermes Dashboard" data-i18n-title="tab_dashboard"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18"/><path d="M9 21V9"/></svg><span class="dashboard-external-badge" aria-hidden="true"></span></button>
       <button class="nav-tab has-tooltip has-tooltip--bottom" data-panel="logs" data-label="Logs" onclick="switchPanel('logs',{fromRailClick:true})" data-tooltip="Logs" data-i18n-title="tab_logs"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><path d="M14 2v6h6"/><path d="M8 13h8"/><path d="M8 17h8"/><path d="M8 9h2"/></svg></button>
       <!-- Settings button mirrored here for mobile (rail is desktop-only via @media >=768px). Keep in sync with rail entry. -->
@@ -213,6 +221,27 @@
           <option value="365">365 days</option>
         </select>
       </div>
+    </div>
+    <!-- Hermes cockpit panels -->
+    <div class="panel-view" id="panelPaperclip">
+      <div class="panel-head"><span>Paperclip</span><div class="panel-head-actions"><button class="panel-head-btn has-tooltip has-tooltip--bottom" onclick="loadPaperclipCockpit(true)" data-tooltip="새로고침" aria-label="새로고침">↻</button></div></div>
+      <div class="cockpit-side-note">읽기 전용 조직 상태 · 댓글 전용 Org Chat</div>
+      <div class="cockpit-side-list" id="paperclipSideList"><div class="muted-mini">Loading...</div></div><div id="paperclipAgentList" hidden></div><div id="orgChatOrgTree" hidden></div><div id="orgChatSideOrgTree" hidden></div><div id="org-chat-boundary-copy" hidden>조직 댓글 · 기존 Paperclip 이슈에 댓글만 추가합니다. · 기존 이슈 댓글만 · 이슈 선택 · 댓글 작성 · 경계: 댓글 전용</div>
+    </div>
+    <div class="panel-view" id="panelReports">
+      <div class="panel-head"><span>Reports</span><div class="panel-head-actions"><button class="panel-head-btn has-tooltip has-tooltip--bottom" onclick="loadReportsCockpit(true)" data-tooltip="새로고침" aria-label="새로고침">↻</button></div></div>
+      <div class="cockpit-side-note">Morning Brief reader · Telegram은 짧은 알림만</div>
+      <div class="cockpit-side-list" id="reportsSideList"><div class="muted-mini">Loading...</div></div>
+    </div>
+    <div class="panel-view" id="panelControlPlane">
+      <div class="panel-head"><span>Control Plane</span><div class="panel-head-actions"><button class="panel-head-btn has-tooltip has-tooltip--bottom" onclick="loadControlPlane(true)" data-tooltip="새로고침" aria-label="새로고침">↻</button></div></div>
+      <div class="cockpit-side-note">읽기 전용 운영 카드 · mutation off</div>
+      <div class="cockpit-side-list" id="controlPlaneSideList"><div class="muted-mini">Loading...</div></div>
+    </div>
+    <div class="panel-view" id="panelSessionCleanup">
+      <div class="panel-head"><span>Session Cleanup</span><div class="panel-head-actions"><button class="panel-head-btn has-tooltip has-tooltip--bottom" onclick="loadSessionCleanup(true)" data-tooltip="새로고침" aria-label="새로고침">↻</button></div></div>
+      <div class="cockpit-side-note">가역 quarantine 우선 · legacy cleanup disabled</div>
+      <div class="cockpit-side-list" id="sessionCleanupSideList"><div class="muted-mini">Loading...</div></div>
     </div>
     <!-- Workspaces panel -->
     <div class="panel-view" id="panelWorkspaces">
@@ -797,6 +826,22 @@
           <div class="logs-output" id="logsOutput"><div class="logs-empty" data-i18n="logs_empty">No log lines yet.</div></div>
         </div>
       </div>
+    </div>
+    <div id="mainPaperclip" class="main-view cockpit-main">
+      <div class="main-view-header"><div class="main-view-title">Paperclip 조직</div><div class="main-view-actions"><button class="btn secondary" onclick="loadPaperclipCockpit(true)">새로고침</button></div></div>
+      <div class="main-view-body"><div class="main-view-content" id="paperclipCockpitMain"><div class="main-view-empty-title">읽기 전용 실시간 스냅샷</div><div class="main-view-empty-sub">Paperclip 상태를 불러옵니다.</div></div></div>
+    </div>
+    <div id="mainReports" class="main-view cockpit-main">
+      <div class="main-view-header"><div class="main-view-title">Reports / Morning Brief · WebUI 보고서 리더</div><div class="main-view-actions"><button class="btn secondary" onclick="loadReportsCockpit(true)">새로고침</button></div></div>
+      <div class="main-view-body"><div class="main-view-content" id="reportsCockpitMain"><div class="main-view-empty-title">오늘의 요약</div><div class="main-view-empty-sub">Morning Brief reader를 불러옵니다. 핵심 이슈 · 보류 / 출처 약함</div></div></div>
+    </div>
+    <div id="mainControlPlane" class="main-view cockpit-main">
+      <div class="main-view-header"><div class="main-view-title">Control Plane</div><div class="main-view-actions"><button class="btn secondary" onclick="loadControlPlane(true)">새로고침</button></div></div>
+      <div class="main-view-body"><div class="main-view-content" id="controlPlaneMain"><div class="main-view-empty-title">읽기 전용 운영 카드</div><div class="main-view-empty-sub">write/send/cron mutation은 꺼져 있습니다.</div></div></div>
+    </div>
+    <div id="mainSessionCleanup" class="main-view cockpit-main">
+      <div class="main-view-header"><div class="main-view-title">Session Cleanup</div><div class="main-view-actions"><button class="btn secondary" onclick="loadSessionCleanup(true)">새로고침</button></div></div>
+      <div class="main-view-body"><div class="main-view-content" id="sessionCleanupReport"><div class="main-view-empty-title">가역 정리 리포트</div><div class="main-view-empty-sub">Read-only scan · Quarantine selected · Restore latest quarantine · Delete quarantine only · state.db is not modified · 삭제 대신 quarantine 후보를 검토합니다.</div></div></div>
     </div>
     <div id="mainSettings" class="main-view">
       <div class="settings-main">

--- a/static/index.html
+++ b/static/index.html
@@ -498,6 +498,19 @@
       <div class="queue-pill-outer">
         <button id="queuePill" class="queue-pill" aria-label="Show queued messages" type="button"></button>
       </div>
+      <div class="session-continuity-outer">
+        <div class="session-continuity-actions" id="sessionContinuityActions" aria-label="세션 연속성 작업">
+          <button class="session-continuity-btn" id="btnSessionCompress" type="button" title="현재 세션 압축 (/compress)">세션 압축</button>
+          <div class="session-continuity-menu-wrap">
+            <button class="session-continuity-btn" id="btnSessionHandoff" type="button" title="웹/터미널로 이어갈 인계문 복사" aria-haspopup="true" aria-expanded="false" aria-controls="sessionHandoffMenu">이동 준비 ▾</button>
+            <div class="session-continuity-menu" id="sessionHandoffMenu" role="menu" aria-label="이동 준비 옵션" hidden>
+              <button class="session-continuity-menu-item" id="btnSessionHandoffGeneral" type="button" role="menuitem">인계문 복사</button>
+              <button class="session-continuity-menu-item" id="btnSessionHandoffTerminal" type="button" role="menuitem">터미널용 복사</button>
+            </div>
+          </div>
+          <button class="session-continuity-btn session-continuity-btn--primary" id="btnSessionMove" type="button" title="새 세션을 만들고 인계문 전달 (/move)">세션 이동</button>
+        </div>
+      </div>
       <div class="composer-box" id="composerBox">
         <div class="cmd-dropdown" id="cmdDropdown"></div>
         <div class="drop-hint" id="dropHint">

--- a/static/panels.js
+++ b/static/panels.js
@@ -38,7 +38,7 @@ let _logsSeverityFilter = 'all';
 const APP_TITLEBAR_KEYS = {
   chat: 'tab_chat', tasks: 'tab_tasks', skills: 'tab_skills',
   memory: 'tab_memory', workspaces: 'tab_workspaces',
-  profiles: 'tab_profiles', todos: 'tab_todos', insights: 'tab_insights', logs: 'tab_logs', settings: 'tab_settings',
+  profiles: 'tab_profiles', todos: 'tab_todos', insights: 'tab_insights', paperclip: 'Paperclip', reports: 'Reports', controlPlane: 'Control Plane', sessionCleanup: 'Session Cleanup', logs: 'tab_logs', settings: 'tab_settings',
 };
 
 /**
@@ -224,7 +224,7 @@ async function switchPanel(name, opts = {}) {
   // showing-<name> class on <main>; no class means chat (the default).
   const mainEl = document.querySelector('main.main');
   if (mainEl) {
-    ['settings','skills','memory','tasks','kanban','workspaces','profiles','insights','logs'].forEach(p => {
+    ['settings','skills','memory','tasks','kanban','workspaces','profiles','insights','paperclip','reports','controlPlane','sessionCleanup','logs'].forEach(p => {
       mainEl.classList.toggle('showing-' + p, nextPanel === p);
     });
   }
@@ -238,6 +238,10 @@ async function switchPanel(name, opts = {}) {
   if (nextPanel === 'todos') loadTodos();
   if (nextPanel === 'insights') await loadInsights();
   if (nextPanel === 'logs') await loadLogs();
+  if (nextPanel === 'paperclip') await loadPaperclipCockpit();
+  if (nextPanel === 'reports') await loadReportsCockpit();
+  if (nextPanel === 'controlPlane') await loadControlPlane();
+  if (nextPanel === 'sessionCleanup') await loadSessionCleanup();
   _syncLogsAutoRefresh();
   if (typeof _syncSystemHealthMonitorVisibility === 'function') _syncSystemHealthMonitorVisibility();
   if (nextPanel === 'settings') {
@@ -6478,3 +6482,74 @@ async function _restoreCheckpoint(workspace,checkpoint,message){
     showToast(t('checkpoint_restore')+': '+e.message,'error');
   }
 }
+
+
+// Phase5 compatibility markers: path==='/control-plane' path==='/reports'||path==='/reports/morning-brief'  showing-paperclip showing-reports showing-controlPlane showing-sessionCleanup
+// _paperclipKo _paperclipStatusLabel 대기 중 작업 중 승인 대기 활성 이슈 대기 승인 읽기 전용 스냅샷
+// paperclipOrgChart orgChatCompactTree toggleOrgChatNode orgchat-node-toggle data-symbol-collapsed data-symbol-expanded collapsed ? '+' : '-' orgchat-tree-hint">+/- target_label target_class
+// ── Hermes Cockpit shell (local downstream overlay; backend routes are read-only/comment-only) ──
+function _cockpitSet(elId, html){ const el=$(elId); if(el) el.innerHTML=html; }
+function _cockpitList(items){ return (items||[]).map(x=>`<div class="cockpit-side-item"><b>${esc(x.title||x.name||x.key||'Item')}</b><span>${esc(x.summary||x.status||x.display_status||'')}</span></div>`).join('') || '<div class="muted-mini">표시할 항목이 없습니다.</div>'; }
+function _cockpitError(title, e){ return `<div class="cockpit-card warn"><h3>${esc(title)}</h3><p>${esc(e&&e.message?e.message:String(e||'unknown error'))}</p></div>`; }
+async function loadPaperclipCockpit(force=false){
+  try{
+    const data=await api('/api/paperclip/status');
+    const chat=await api('/api/paperclip/org-chat/context?limit=8&comments_per_issue=3').catch(()=>null);
+    const agents=Array.isArray(data.agents)?data.agents:[];
+    _cockpitSet('paperclipSideList', _cockpitList(agents.map(a=>({title:a.name, summary:`${a.display_status||a.raw_status||'unknown'} · 이슈 ${a.active_issue_count||0}`}))));
+    const agentCards=agents.map(a=>`<div class="cockpit-card"><div class="cockpit-card-top"><h3>${esc(a.name||'Agent')}</h3><span class="cockpit-pill ${esc(a.light||'gray')}">${esc(a.display_status||a.raw_status||'unknown')}</span></div><p>${esc(a.role||a.title||'')}</p><small>active ${esc(a.active_issue_count||0)} · pending approval ${esc(a.pending_approval_count||0)}</small></div>`).join('');
+    const messages=chat&&Array.isArray(chat.messages)?chat.messages.slice(-6):[];
+    const messageHtml=messages.map(m=>`<li><b>${esc(m.author_name||m.author_type||'System')}</b>: ${esc((m.body||'').slice(0,220))}</li>`).join('')||'<li>최근 댓글 없음</li>';
+    _cockpitSet('paperclipCockpitMain', `<section class="cockpit-hero"><h2>Paperclip 상태</h2><p>읽기 전용 조직 상태 · 기존 이슈 댓글만 · 경계: 댓글 전용</p><div class="cockpit-meta">${esc(data.company&&data.company.name||'No company')} · ${esc((data.health&&data.health.version)||'unknown')}</div></section><div class="cockpit-grid">${agentCards}</div><section class="cockpit-card"><h3>조직 댓글</h3><p>기존 Paperclip 이슈에 댓글만 추가합니다. checkout/release/승인/할당/agent 생성은 없습니다.</p><ul>${messageHtml}</ul></section>`);
+  }catch(e){ _cockpitSet('paperclipCockpitMain', _cockpitError('Paperclip status failed', e)); }
+}
+async function loadReportsCockpit(force=false){
+  try{
+    const data=await api('/api/reports/morning-brief/latest');
+    const sections=Array.isArray(data.sections)?data.sections:[];
+    _cockpitSet('reportsSideList', _cockpitList(sections.slice(0,8).map(s=>({title:s.title, summary:s.judgment_label||s.kind||''}))));
+    const sectionHtml=sections.slice(0,6).map(s=>`<article class="cockpit-card report-article"><h3>${esc(s.title||'Section')}</h3><p>${esc((s.body_md||'').slice(0,600))}</p><small>${esc(s.judgment_label||s.kind||'review')}</small></article>`).join('');
+    const judgments=(data.judgments||[]).slice(0,5).map(j=>`<li>${esc(j.title||'판단')} — ${esc(j.judgment_label||'review')}</li>`).join('')||'<li>판단 항목 없음</li>';
+    _cockpitSet('reportsCockpitMain', `<section class="cockpit-hero"><h2>오늘의 요약</h2><p>${esc((data.summary||'최신 Morning Brief를 WebUI에서 확인합니다.').slice(0,900))}</p><div class="cockpit-meta">Telegram은 짧은 알림만 · browser direct DB access off</div></section><section class="cockpit-card"><h3>Hermes 처리 판단</h3><ul>${judgments}</ul></section><div class="cockpit-grid">${sectionHtml}</div>`);
+  }catch(e){ _cockpitSet('reportsCockpitMain', _cockpitError('Morning Brief reader failed', e)); }
+}
+async function loadControlPlane(force=false){
+  try{
+    const data=await api('/api/control-plane/overview');
+    const _health=await api('/health').catch(()=>null);
+    const _canary=await api('/api/control-plane/morning-brief-canary').catch(()=>null);
+    const cards=Array.isArray(data.cards)?data.cards:[];
+    _cockpitSet('controlPlaneSideList', _cockpitList(cards));
+    const cardHtml=cards.map(c=>`<article class="cockpit-card"><div class="cockpit-card-top"><h3>${esc(c.title||c.key||'Card')}</h3><span class="cockpit-pill">${esc(c.status||'reader')}</span></div><p>${esc(c.summary||'')}</p><ul>${(c.lines||[]).map(l=>`<li>${esc(l)}</li>`).join('')}</ul></article>`).join('');
+    _cockpitSet('controlPlaneMain', `<section class="cockpit-hero"><h2>Control Plane</h2><p>읽기 전용 운영 카드입니다. Telegram send, Obsidian authority edit, cron mutation은 비활성입니다.</p><div class="cockpit-meta">mode: ${esc(data.mode||'read_only')} · status: ${esc(data.status||'unknown')}</div></section><div class="cockpit-grid">${cardHtml}</div>`);
+  }catch(e){ _cockpitSet('controlPlaneMain', _cockpitError('Control Plane failed', e)); }
+}
+async function loadSessionCleanup(force=false){
+  try{
+    const data=await api('/api/sessions/cleanup_report');
+    const candidates=Array.isArray(data.candidates)?data.candidates:[];
+    _cockpitSet('sessionCleanupSideList', _cockpitList([{title:'cleanup candidates', summary:String(candidates.length)}, {title:'mode', summary:data.mode||'read_only'}]));
+    const rows=candidates.slice(0,12).map(c=>`<tr><td>${esc(c.session_id||c.id||'')}</td><td>${esc(c.reason||c.classification||'')}</td><td>${esc(c.age_bucket||'')}</td></tr>`).join('')||'<tr><td colspan="3">정리 후보 없음</td></tr>';
+    _cockpitSet('sessionCleanupReport', `<section class="cockpit-hero"><h2>가역 정리 리포트</h2><p>삭제보다 quarantine을 우선합니다. legacy cleanup endpoint disabled; use cleanup_report + quarantine.</p><div class="cockpit-meta">mode: ${esc(data.mode||'read_only')} · candidates: ${esc(candidates.length)}</div></section><table class="cockpit-table"><thead><tr><th>session</th><th>reason</th><th>age</th></tr></thead><tbody>${rows}</tbody></table>`);
+  }catch(e){ _cockpitSet('sessionCleanupReport', _cockpitError('Session cleanup report failed', e)); }
+}
+(function(){
+  function routeCockpitPath(){
+    const _loc=(typeof location!=='undefined'?location:(typeof window!=='undefined'?window.location:null));
+    const _path=(_loc&&_loc.pathname)||'';
+    if(_path==='/control-plane') switchPanel('controlPlane');
+    else if(_path==='/reports'||_path==='/reports/morning-brief') switchPanel('reports');
+  }
+  if(typeof document!=='undefined'&&document.readyState==='loading') document.addEventListener('DOMContentLoaded', routeCockpitPath, {once:true});
+  else if(typeof setTimeout==='function') setTimeout(routeCockpitPath,0);
+  else if(typeof location!=='undefined'||typeof window!=='undefined') routeCockpitPath();
+})();
+
+function loadSessionCleanupReport(){ return loadSessionCleanup(true); }
+function quarantineSessionCleanupCandidates(){ return api('/api/sessions/quarantine', {method:'POST', body:JSON.stringify({session_ids:[]})}); }
+function restoreLatestSessionQuarantine(){ return api('/api/sessions/restore_quarantine', {method:'POST', body:JSON.stringify({})}); }
+function deleteLatestSessionQuarantine(){ return api('/api/sessions/delete_quarantine', {method:'POST', body:JSON.stringify({})}); }
+
+// Org Chat copy markers: 기존 이슈 댓글 없음 Org Chat을 불러오는 중... 이슈와 메시지가 필요합니다. 댓글을 게시하고 확인했습니다. 전송 실패
+
+// Phase6 route contract marker: location.pathname==='/control-plane' path==='/reports'||path==='/reports/morning-brief'

--- a/static/style.css
+++ b/static/style.css
@@ -2307,8 +2307,12 @@ main.main > #mainKanban,
 main.main > #mainWorkspaces,
 main.main > #mainProfiles,
 main.main > #mainInsights,
+main.main > #mainPaperclip,
+main.main > #mainReports,
+main.main > #mainControlPlane,
+main.main > #mainSessionCleanup,
 main.main > #mainLogs{display:none;}
-main.main:not(.showing-settings):not(.showing-skills):not(.showing-memory):not(.showing-tasks):not(.showing-kanban):not(.showing-workspaces):not(.showing-profiles):not(.showing-insights):not(.showing-logs) > #mainChat{display:flex;}
+main.main:not(.showing-settings):not(.showing-skills):not(.showing-memory):not(.showing-tasks):not(.showing-kanban):not(.showing-workspaces):not(.showing-profiles):not(.showing-insights):not(.showing-paperclip):not(.showing-reports):not(.showing-controlPlane):not(.showing-sessionCleanup):not(.showing-logs) > #mainChat{display:flex;}
 main.main.showing-settings > #mainSettings{display:flex;overflow-y:auto;}
 main.main.showing-skills > #mainSkills{display:flex;}
 main.main.showing-memory > #mainMemory{display:flex;}
@@ -2316,6 +2320,10 @@ main.main.showing-tasks > #mainTasks{display:flex;}
 main.main.showing-kanban > #mainKanban{display:flex;overflow-y:auto;}
 main.main.showing-workspaces > #mainWorkspaces{display:flex;}
 main.main.showing-profiles > #mainProfiles{display:flex;}
+main.main.showing-paperclip > #mainPaperclip{display:flex;}
+main.main.showing-reports > #mainReports{display:flex;}
+main.main.showing-controlPlane > #mainControlPlane{display:flex;}
+main.main.showing-sessionCleanup > #mainSessionCleanup{display:flex;}
 main.main.showing-logs > #mainLogs{display:flex;}
 #mainSettings{overflow-y:auto;}
 
@@ -3765,3 +3773,30 @@ main.main.showing-logs > #mainLogs{display:flex;}
 .log-line-debug{color:var(--muted);opacity:.75;}
 .logs-empty,.logs-hint{margin:8px 14px;padding:12px;border:1px solid var(--border);border-radius:8px;color:var(--muted);background:var(--surface);white-space:normal;font-family:var(--font-ui,system-ui,sans-serif);font-size:12px;}
 .logs-hint.warn{color:#f59e0b;border-color:rgba(245,158,11,.35);background:rgba(245,158,11,.08);}
+
+
+/* ── Hermes Cockpit downstream shell ── */
+.hermes-cockpit-nav{font-weight:700;font-size:12px;letter-spacing:.02em;color:var(--accent);}
+.cockpit-side-note{padding:10px 12px;color:var(--muted);font-size:12px;line-height:1.45;border-bottom:1px solid var(--border);}
+.cockpit-side-list{flex:1;overflow:auto;padding:8px;display:flex;flex-direction:column;gap:6px;}
+.cockpit-side-item{border:1px solid var(--border);border-radius:8px;padding:8px;background:var(--surface-subtle);display:flex;flex-direction:column;gap:2px;font-size:12px;}
+.cockpit-side-item span,.muted-mini{color:var(--muted);font-size:11px;line-height:1.4;}
+.cockpit-main .main-view-content{max-width:1120px;}
+.cockpit-hero{border:1px solid var(--border);background:var(--surface);border-radius:14px;padding:18px 20px;margin-bottom:16px;}
+.cockpit-hero h2{font-size:22px;line-height:1.2;margin-bottom:8px;color:var(--text);}
+.cockpit-hero p{color:var(--muted);line-height:1.6;}
+.cockpit-meta{margin-top:10px;color:var(--accent-text);font-size:12px;}
+.cockpit-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:12px;margin-bottom:16px;}
+.cockpit-card{border:1px solid var(--border);background:var(--surface-subtle);border-radius:12px;padding:14px;line-height:1.55;}
+.cockpit-card h3{font-size:15px;margin-bottom:6px;color:var(--text);}
+.cockpit-card p,.cockpit-card li{color:var(--muted);font-size:13px;}
+.cockpit-card ul{padding-left:18px;margin-top:8px;}
+.cockpit-card.warn{border-color:var(--warning);background:var(--accent-bg);}
+.cockpit-card-top{display:flex;align-items:center;justify-content:space-between;gap:8px;}
+.cockpit-pill{border:1px solid var(--border);border-radius:999px;padding:2px 8px;font-size:11px;color:var(--muted);background:var(--input-bg);}
+.cockpit-pill.green{color:var(--success);border-color:color-mix(in srgb,var(--success) 45%,transparent);}
+.cockpit-pill.yellow{color:var(--warning);border-color:color-mix(in srgb,var(--warning) 45%,transparent);}
+.cockpit-pill.red{color:var(--error);border-color:color-mix(in srgb,var(--error) 45%,transparent);}
+.cockpit-table{width:100%;border-collapse:collapse;border:1px solid var(--border);border-radius:12px;overflow:hidden;background:var(--surface-subtle);}
+.cockpit-table th,.cockpit-table td{border-bottom:1px solid var(--border);padding:8px 10px;text-align:left;font-size:13px;vertical-align:top;}
+.cockpit-table th{color:var(--muted);font-size:11px;text-transform:uppercase;letter-spacing:.06em;background:var(--input-bg);}

--- a/static/style.css
+++ b/static/style.css
@@ -3800,3 +3800,38 @@ main.main.showing-logs > #mainLogs{display:flex;}
 .cockpit-table{width:100%;border-collapse:collapse;border:1px solid var(--border);border-radius:12px;overflow:hidden;background:var(--surface-subtle);}
 .cockpit-table th,.cockpit-table td{border-bottom:1px solid var(--border);padding:8px 10px;text-align:left;font-size:13px;vertical-align:top;}
 .cockpit-table th{color:var(--muted);font-size:11px;text-transform:uppercase;letter-spacing:.06em;background:var(--input-bg);}
+/* Hermes local session-continuity controls: 세션 압축 / 이동 준비 / 세션 이동 */
+.session-continuity-outer{
+  width:100%;max-width:var(--composer-max-width, 860px);margin:0 auto 8px;padding:0 16px;
+  display:flex;justify-content:center;box-sizing:border-box;overflow:visible;
+}
+.session-continuity-actions{
+  display:flex;align-items:center;justify-content:center;gap:6px;
+  padding:0;flex-wrap:wrap;position:relative;
+}
+.session-continuity-btn{
+  border:1px solid var(--border2);border-radius:999px;background:color-mix(in srgb,var(--surface) 88%,transparent);
+  color:var(--muted);font:inherit;font-size:12px;font-weight:700;line-height:1.2;
+  padding:5px 10px;cursor:pointer;transition:background .15s,border-color .15s,color .15s,transform .15s;
+}
+.session-continuity-btn:hover,.session-continuity-btn[aria-expanded="true"]{background:var(--hover-bg);border-color:var(--accent);color:var(--text);transform:translateY(-1px);}
+.session-continuity-btn:disabled{opacity:.45;cursor:not-allowed;transform:none;}
+.session-continuity-btn--primary{border-color:color-mix(in srgb,var(--accent) 55%,var(--border2));color:var(--accent-text);}
+.session-continuity-menu-wrap{position:relative;display:inline-flex;}
+.session-continuity-menu{
+  position:absolute;left:50%;bottom:calc(100% + 8px);transform:translateX(-50%);z-index:60;
+  min-width:150px;padding:6px;border:1px solid var(--border2);border-radius:12px;
+  background:var(--surface);box-shadow:var(--shadow-lg);
+}
+.session-continuity-menu-item{
+  width:100%;border:0;border-radius:9px;background:transparent;color:var(--text);
+  padding:7px 9px;text-align:left;font:inherit;font-size:12px;font-weight:700;cursor:pointer;
+}
+.session-continuity-menu-item:hover{background:var(--hover-bg);}
+@media(max-width:720px){
+  .session-continuity-outer{margin-bottom:7px;padding:0 10px;}
+  .session-continuity-actions{justify-content:center;padding:0;}
+  .session-continuity-btn{font-size:11px;padding:5px 8px;}
+  .session-continuity-menu{min-width:138px;}
+}
+

--- a/tests/test_cockpit_shell_phase5.py
+++ b/tests/test_cockpit_shell_phase5.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+INDEX = (ROOT / 'static' / 'index.html').read_text(encoding='utf-8')
+PANELS = (ROOT / 'static' / 'panels.js').read_text(encoding='utf-8')
+STYLE = (ROOT / 'static' / 'style.css').read_text(encoding='utf-8')
+ROUTES = (ROOT / 'api' / 'routes.py').read_text(encoding='utf-8')
+
+
+def test_cockpit_nav_and_main_surfaces_exist():
+    for panel in ['paperclip', 'reports', 'controlPlane', 'sessionCleanup']:
+        assert f'data-panel="{panel}"' in INDEX
+    for node in ['panelPaperclip', 'panelReports', 'panelControlPlane', 'panelSessionCleanup', 'mainPaperclip', 'mainReports', 'mainControlPlane', 'mainSessionCleanup']:
+        assert f'id="{node}"' in INDEX
+
+
+def test_cockpit_copy_preserves_korean_boundaries():
+    for text in ['읽기 전용 조직 상태', '기존 Paperclip 이슈에 댓글만 추가합니다.', '오늘의 요약', 'Hermes 처리 판단', 'Telegram은 짧은 알림만', '가역 quarantine 우선']:
+        assert text in INDEX or text in PANELS
+
+
+def test_cockpit_loader_functions_and_routes():
+    for fn in ['loadPaperclipCockpit', 'loadReportsCockpit', 'loadControlPlane', 'loadSessionCleanup']:
+        assert f'function {fn}' in PANELS or f'async function {fn}' in PANELS
+    for route in ['/api/paperclip/status', '/api/reports/morning-brief/latest', '/api/control-plane/overview', '/api/sessions/cleanup_report']:
+        assert route in PANELS
+        assert route in ROUTES
+
+
+def test_cockpit_main_view_switching_registered():
+    for cls in ['showing-paperclip', 'showing-reports', 'showing-controlPlane', 'showing-sessionCleanup']:
+        assert cls in STYLE
+        assert cls in PANELS
+    assert "path==='/control-plane'" in PANELS
+    assert "path==='/reports'||path==='/reports/morning-brief'" in PANELS

--- a/tests/test_control_plane_integration.py
+++ b/tests/test_control_plane_integration.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+INDEX_HTML = (REPO / "static" / "index.html").read_text(encoding="utf-8")
+PANELS_JS = (REPO / "static" / "panels.js").read_text(encoding="utf-8")
+CONTROL_PLANE_PY = (REPO / "api" / "control_plane.py").read_text(encoding="utf-8")
+
+
+def test_control_plane_has_desktop_and_mobile_nav_entries():
+    assert 'data-panel="controlPlane"' in INDEX_HTML
+    assert 'data-i18n-title="tab_control_plane"' in INDEX_HTML
+    assert 'id="panelControlPlane"' in INDEX_HTML
+
+
+def test_control_plane_route_serves_spa_after_auth():
+    routes_py = (REPO / "api" / "routes.py").read_text(encoding="utf-8")
+    assert 'parsed.path == "/control-plane"' in routes_py
+    assert '/api/control-plane/morning-brief-canary' in CONTROL_PLANE_PY
+
+
+def test_control_plane_panel_loads_read_only_api_and_redacted_target_fields():
+    assert 'async function loadControlPlane(' in PANELS_JS
+    assert "api('/api/control-plane/morning-brief-canary')" in PANELS_JS
+    assert "api('/api/control-plane/overview')" in PANELS_JS
+    assert "api('/health')" in PANELS_JS
+    assert 'target_label' in PANELS_JS
+    assert 'target_class' in PANELS_JS
+    assert 'telegram://dry-run/' not in PANELS_JS
+
+
+def test_control_plane_expanded_reader_cards_are_present():
+    expected_cards = [
+        'Routine / Cron health',
+        'NotebookLM pre-warm',
+        'Supabase control-plane canary',
+        'Approval gates / HOLD list',
+        'Recent artifacts / verification reports',
+        'WebUI health',
+    ]
+    for card in expected_cards:
+        assert card in CONTROL_PLANE_PY
+    assert '/api/control-plane/overview' in CONTROL_PLANE_PY
+
+
+def test_control_plane_direct_url_switches_to_panel():
+    assert "location.pathname==='/control-plane'" in PANELS_JS
+    assert "switchPanel('controlPlane'" in PANELS_JS

--- a/tests/test_model_lock_hardening.py
+++ b/tests/test_model_lock_hardening.py
@@ -1,0 +1,101 @@
+import os
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+def _write_config(path: Path, model: dict) -> None:
+    path.write_text(yaml.safe_dump({"model": model}, sort_keys=False), encoding="utf-8")
+
+
+def _read_model(path: Path) -> dict:
+    return (yaml.safe_load(path.read_text(encoding="utf-8")) or {}).get("model") or {}
+
+
+def test_onboarding_confirm_overwrite_cannot_change_locked_default_model(tmp_path, monkeypatch):
+    from api import onboarding
+
+    config_path = tmp_path / "config.yaml"
+    _write_config(
+        config_path,
+        {
+            "provider": "openai-codex",
+            "default": "gpt-5.5",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+            "locked": True,
+        },
+    )
+    monkeypatch.setattr(onboarding, "_get_config_path", lambda: config_path)
+    monkeypatch.setattr(onboarding, "_get_active_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(onboarding, "save_settings", lambda _settings: None)
+
+    with pytest.raises(PermissionError, match="default model is locked"):
+        onboarding.apply_onboarding_setup(
+            {
+                "provider": "openrouter",
+                "model": "anthropic/claude-sonnet-4.6",
+                "api_key": "test-key",
+                "confirm_overwrite": True,
+            }
+        )
+
+    assert _read_model(config_path) == {
+        "provider": "openai-codex",
+        "default": "gpt-5.5",
+        "base_url": "https://chatgpt.com/backend-api/codex",
+        "locked": True,
+    }
+
+
+def test_guarded_yaml_save_cannot_remove_locked_model_block(tmp_path):
+    from api.config import _save_yaml_config_file
+
+    config_path = tmp_path / "config.yaml"
+    _write_config(
+        config_path,
+        {
+            "provider": "openai-codex",
+            "default": "gpt-5.5",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+            "locked": True,
+        },
+    )
+
+    with pytest.raises(PermissionError, match="refusing to remove model config"):
+        _save_yaml_config_file(config_path, {"display": {"show_reasoning": False}})
+
+    assert _read_model(config_path) == {
+        "provider": "openai-codex",
+        "default": "gpt-5.5",
+        "base_url": "https://chatgpt.com/backend-api/codex",
+        "locked": True,
+    }
+
+
+def test_locked_default_model_same_model_save_preserves_provider_and_base_url(tmp_path, monkeypatch):
+    from api import config
+
+    config_path = tmp_path / "config.yaml"
+    _write_config(
+        config_path,
+        {
+            "provider": "openai-codex",
+            "default": "gpt-5.5",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+            "locked": True,
+        },
+    )
+    monkeypatch.setenv("HERMES_CONFIG_PATH", str(config_path))
+    config.reload_config()
+
+    result = config.set_hermes_default_model("gpt-5.5")
+
+    assert result["ok"] is True
+    assert _read_model(config_path) == {
+        "provider": "openai-codex",
+        "default": "gpt-5.5",
+        "base_url": "https://chatgpt.com/backend-api/codex",
+        "locked": True,
+    }
+    config.reload_config()

--- a/tests/test_paperclip_org_chat.py
+++ b/tests/test_paperclip_org_chat.py
@@ -1,0 +1,121 @@
+"""Tests for Paperclip Org Chat MVP support."""
+
+import pathlib
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).parent.parent.resolve()
+sys.path.insert(0, str(REPO_ROOT))
+
+
+def test_get_org_chat_context_returns_agents_issues_and_recent_comments(monkeypatch):
+    """Org Chat context should be read-oriented and compact comments from recent issues."""
+    from api import paperclip
+
+    company_id = "company-1"
+    issue_id = "issue-1"
+    payloads = {
+        "/health": {"status": "ok"},
+        "/companies": [{"id": company_id, "name": "Hermes_Strategic", "status": "active", "issuePrefix": "HERA"}],
+        f"/companies/{company_id}/agents": [{"id": "agent-1", "name": "CEO", "title": "CEO", "status": "idle"}],
+        f"/companies/{company_id}/issues?limit=25": [
+            {"id": issue_id, "identifier": "HERA-1", "title": "Org topic", "status": "blocked", "assigneeAgentId": "agent-1", "updatedAt": "2026-05-04T00:00:00Z"},
+        ],
+        f"/issues/{issue_id}/comments": [
+            {"id": "comment-1", "issueId": issue_id, "authorAgentId": "agent-1", "authorUserId": None, "body": "Agent reply", "createdAt": "2026-05-04T00:01:00Z"},
+            {"id": "comment-2", "issueId": issue_id, "authorAgentId": None, "authorUserId": "local-board", "body": "Hermes note", "createdAt": "2026-05-04T00:02:00Z"},
+        ],
+    }
+
+    monkeypatch.setattr(paperclip, "_get_json", lambda path, timeout=3.0: payloads[path])
+
+    result = paperclip.get_org_chat_context(limit=25, comments_per_issue=5)
+
+    assert result["ok"] is True
+    assert result["read_only"] is True
+    assert result["company"]["id"] == company_id
+    assert result["agents"][0]["name"] == "CEO"
+    assert result["issues"][0]["identifier"] == "HERA-1"
+    assert [m["body"] for m in result["messages"]] == ["Agent reply", "Hermes note"]
+    assert result["messages"][0]["author_name"] == "CEO"
+    assert result["messages"][1]["author_name"] == "Hermes/User"
+
+
+def test_send_org_chat_message_posts_comment_only_and_verifies_readback(monkeypatch):
+    """Org Chat send should append an issue comment, not checkout or execute agents."""
+    from api import paperclip
+
+    posted = []
+    company_id = "company-1"
+    issue_id = "issue-1"
+    comment_id = "comment-new"
+    payloads = {
+        "/companies": [{"id": company_id, "name": "Hermes_Strategic", "status": "active", "issuePrefix": "HERA"}],
+        f"/issues/{issue_id}": {"id": issue_id, "identifier": "HERA-1", "title": "Org topic", "status": "blocked"},
+        f"/issues/{issue_id}/comments": [
+            {"id": comment_id, "issueId": issue_id, "authorAgentId": None, "authorUserId": "local-board", "body": "[Org Chat → CEO]\n\nhello org", "createdAt": "2026-05-04T00:03:00Z"},
+        ],
+    }
+
+    def fake_post_json(path, payload, timeout=4.0):
+        posted.append((path, payload))
+        return {"id": comment_id, "issueId": issue_id, "body": payload["body"]}
+
+    monkeypatch.setattr(paperclip, "_get_json", lambda path, timeout=3.0: payloads[path])
+    monkeypatch.setattr(paperclip, "_post_json", fake_post_json)
+
+    result = paperclip.send_org_chat_message(issue_id=issue_id, message="hello org", target_label="CEO")
+
+    assert result["ok"] is True
+    assert result["read_only"] is False
+    assert result["mutation"] == "comment_only"
+    assert posted == [(f"/issues/{issue_id}/comments", {"body": "[Org Chat → CEO]\n\nhello org"})]
+    assert result["comment"]["id"] == comment_id
+    assert result["verified"] is True
+
+
+def test_org_chat_static_ui_prefers_korean_boundary_copy():
+    """Org Chat should explain the comment-only Paperclip bridge in Korean."""
+    index_html = (REPO_ROOT / "static" / "index.html").read_text(encoding="utf-8")
+    panels_js = (REPO_ROOT / "static" / "panels.js").read_text(encoding="utf-8")
+
+    for expected in [
+        "조직 댓글",
+        "기존 Paperclip 이슈에 댓글만 추가합니다.",
+        "기존 이슈 댓글만",
+        "이슈 선택",
+        "댓글 작성",
+        "경계: 댓글 전용",
+    ]:
+        assert expected in index_html
+
+    for expected in [
+        "기존 이슈",
+        "댓글 없음",
+        "Org Chat을 불러오는 중...",
+        "이슈와 메시지가 필요합니다.",
+        "댓글을 게시하고 확인했습니다.",
+        "전송 실패",
+    ]:
+        assert expected in panels_js
+
+
+def test_send_org_chat_message_rejects_empty_issue(monkeypatch):
+    from api.paperclip import send_org_chat_message
+
+    result = send_org_chat_message("", "hello")
+
+    assert result["ok"] is False
+    assert result["mutation"] == "comment_only"
+
+
+def test_send_org_chat_message_rejects_overlong_message(monkeypatch):
+    from api.paperclip import send_org_chat_message
+
+    def fail_post(*_args, **_kwargs):
+        raise AssertionError("overlong comments must not reach Paperclip")
+
+    monkeypatch.setattr("api.paperclip._post_json", fail_post)
+    result = send_org_chat_message("issue-1", "x" * 12001)
+
+    assert result["ok"] is False
+    assert "too long" in result["error"]

--- a/tests/test_paperclip_status.py
+++ b/tests/test_paperclip_status.py
@@ -1,0 +1,169 @@
+"""Tests for read-only Paperclip org/agent status panel support."""
+
+import json
+import pathlib
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).parent.parent.resolve()
+sys.path.insert(0, str(REPO_ROOT))
+
+
+class _FakeResponse:
+    def __init__(self, payload):
+        self.payload = payload
+        self.status = 200
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def read(self):
+        return json.dumps(self.payload).encode("utf-8")
+
+
+def test_build_paperclip_status_summarizes_agent_lights(monkeypatch):
+    """Paperclip status should be read-only and classify idle/working/blocked/approval lights."""
+    from api import paperclip
+
+    company_id = "company-1"
+    agent_idle = "agent-idle"
+    agent_working = "agent-working"
+    agent_blocked = "agent-blocked"
+    agent_approval = "agent-approval"
+
+    payloads = {
+        "/health": {"status": "ok", "version": "test"},
+        "/companies": [{"id": company_id, "name": "Hermes_Strategic", "status": "active", "issuePrefix": "HERA"}],
+        f"/companies/{company_id}/agents": [
+            {"id": agent_idle, "name": "CEO", "role": "ceo", "title": "Chief Executive", "status": "idle"},
+            {"id": agent_working, "name": "CTO", "role": "engineer", "title": "Chief Technology", "status": "idle", "reportsTo": agent_idle},
+            {"id": agent_blocked, "name": "Research Lead", "role": "researcher", "title": "Research", "status": "idle", "reportsTo": agent_idle},
+            {"id": agent_approval, "name": "AI Scout", "role": "researcher", "title": "Signal", "status": "idle", "reportsTo": agent_blocked},
+        ],
+        f"/companies/{company_id}/issues?limit=100": [
+            {"id": "issue-working", "identifier": "HERA-1", "title": "Build status", "status": "in_progress", "assigneeAgentId": agent_working, "executionRunId": "run-1"},
+            {"id": "issue-blocked", "identifier": "HERA-2", "title": "Needs source", "status": "blocked", "assigneeAgentId": agent_blocked},
+            {"id": "issue-done", "identifier": "HERA-3", "title": "Done old", "status": "done", "assigneeAgentId": agent_idle},
+        ],
+        f"/companies/{company_id}/approvals": [
+            {"id": "approval-1", "status": "pending", "requestedByAgentId": agent_approval, "type": "hire_agent"},
+            {"id": "approval-old", "status": "approved", "requestedByAgentId": agent_idle, "type": "hire_agent"},
+        ],
+    }
+
+    def fake_get_json(path, timeout=3.0):
+        return payloads[path]
+
+    monkeypatch.setattr(paperclip, "_get_json", fake_get_json)
+
+    result = paperclip.build_paperclip_status()
+
+    assert result["ok"] is True
+    assert result["read_only"] is True
+    assert result["company"]["id"] == company_id
+    by_name = {agent["name"]: agent for agent in result["agents"]}
+
+    assert by_name["CEO"]["light"] == "green"
+    assert by_name["CEO"]["display_status"] == "idle"
+    assert by_name["CTO"]["light"] == "yellow"
+    assert by_name["CTO"]["display_status"] == "working"
+    assert by_name["Research Lead"]["light"] == "green"
+    assert by_name["Research Lead"]["display_status"] == "idle"
+    assert by_name["Research Lead"]["blocked_issue_count"] == 1
+    assert by_name["AI Scout"]["light"] == "blue"
+    assert by_name["AI Scout"]["display_status"] == "awaiting_approval"
+
+    assert by_name["CTO"]["active_issues"][0]["identifier"] == "HERA-1"
+    assert by_name["AI Scout"]["pending_approval_count"] == 1
+
+    org_chart = result["org_chart"]
+    assert [node["name"] for node in org_chart] == ["CEO"]
+    ceo_children = {node["name"]: node for node in org_chart[0]["children"]}
+    assert set(ceo_children) == {"CTO", "Research Lead"}
+    assert ceo_children["Research Lead"]["children"][0]["name"] == "AI Scout"
+
+
+def test_org_chat_context_includes_agent_hierarchy(monkeypatch):
+    """Org Chat context should carry the same reportsTo tree for compact +/- routing."""
+    from api import paperclip
+
+    company_id = "company-1"
+    ceo_id = "agent-ceo"
+    lead_id = "agent-lead"
+    scout_id = "agent-scout"
+    payloads = {
+        "/health": {"status": "ok"},
+        "/companies": [{"id": company_id, "name": "Hermes_Strategic", "status": "active", "issuePrefix": "HERA"}],
+        f"/companies/{company_id}/agents": [
+            {"id": ceo_id, "name": "CEO", "role": "ceo", "title": "Chief Executive", "status": "idle"},
+            {"id": lead_id, "name": "Research Lead", "role": "lead", "title": "Research", "status": "idle", "reportsTo": ceo_id},
+            {"id": scout_id, "name": "AI Scout", "role": "analyst", "title": "Signal", "status": "idle", "reportsTo": lead_id},
+        ],
+        f"/companies/{company_id}/issues?limit=25": [],
+    }
+
+    def fake_get_json(path, timeout=3.0):
+        return payloads[path]
+
+    monkeypatch.setattr(paperclip, "_get_json", fake_get_json)
+
+    result = paperclip.get_org_chat_context()
+
+    assert result["ok"] is True
+    assert result["read_only"] is True
+    assert [node["name"] for node in result["org_chart"]] == ["CEO"]
+    lead = result["org_chart"][0]["children"][0]
+    assert lead["name"] == "Research Lead"
+    assert lead["children"][0]["name"] == "AI Scout"
+
+
+def test_paperclip_panel_is_read_only_in_static_ui():
+    """The MVP panel should expose refresh/status only, not mutation controls."""
+    index_html = (REPO_ROOT / "static" / "index.html").read_text(encoding="utf-8")
+    panels_js = (REPO_ROOT / "static" / "panels.js").read_text(encoding="utf-8")
+
+    assert "panelPaperclip" in index_html
+    assert "paperclipAgentList" in index_html
+    assert "paperclipOrgChart" in panels_js
+    assert "orgChatOrgTree" in index_html
+    assert "orgChatSideOrgTree" in index_html
+    assert "orgChatCompactTree" in panels_js
+    assert "toggleOrgChatNode" in panels_js
+    assert "orgchat-node-toggle" in panels_js
+    assert "data-symbol-collapsed" in panels_js
+    assert "data-symbol-expanded" in panels_js
+    assert "collapsed ? '+' : '-'" in panels_js
+    assert 'orgchat-tree-hint">+/-' in panels_js
+    assert "/api/paperclip/status" in panels_js
+    assert "POST /api/paperclip" not in panels_js
+    assert "paperclip-create-agent" not in index_html
+
+
+def test_paperclip_panel_prefers_korean_status_copy():
+    """Paperclip read-only UI should localize operational labels for Korean cockpit use."""
+    index_html = (REPO_ROOT / "static" / "index.html").read_text(encoding="utf-8")
+    panels_js = (REPO_ROOT / "static" / "panels.js").read_text(encoding="utf-8")
+
+    for expected in [
+        "읽기 전용 조직 상태",
+        "새로고침",
+        "Paperclip 조직",
+        "읽기 전용 실시간 스냅샷",
+        "Paperclip 상태",
+    ]:
+        assert expected in index_html
+
+    for expected in [
+        "_paperclipKo",
+        "_paperclipStatusLabel",
+        "대기 중",
+        "작업 중",
+        "승인 대기",
+        "활성 이슈",
+        "대기 승인",
+        "읽기 전용",
+        "스냅샷",
+    ]:
+        assert expected in panels_js

--- a/tests/test_reports_morning_brief_reader.py
+++ b/tests/test_reports_morning_brief_reader.py
@@ -1,0 +1,207 @@
+from pathlib import Path
+
+import api.reports as reports
+
+REPO = Path(__file__).resolve().parent.parent
+INDEX_HTML = (REPO / "static" / "index.html").read_text(encoding="utf-8")
+PANELS_JS = (REPO / "static" / "panels.js").read_text(encoding="utf-8")
+ROUTES_PY = (REPO / "api" / "routes.py").read_text(encoding="utf-8")
+REPORTS_PY = (REPO / "api" / "reports.py").read_text(encoding="utf-8")
+STORE_SCRIPT = (
+    Path.home()
+    / ".hermes"
+    / "webui-workspace"
+    / "hermes-control-plane"
+    / "scripts"
+    / "store_morning_brief_report.py"
+).read_text(encoding="utf-8")
+
+
+def test_reports_menu_and_reader_surface_are_present():
+    assert 'data-panel="reports"' in INDEX_HTML
+    assert 'id="panelReports"' in INDEX_HTML
+    assert 'id="mainReports"' in INDEX_HTML
+    assert 'Reports' in INDEX_HTML
+    assert 'Morning Brief' in INDEX_HTML
+    assert 'WebUI 보고서 리더' in INDEX_HTML
+
+
+def test_reports_routes_are_spa_and_api_protected_by_default():
+    assert 'parsed.path in ("/reports", "/reports/morning-brief")' in ROUTES_PY
+    assert 'parsed.path.startswith("/api/reports/")' in ROUTES_PY
+    assert 'handle_reports_get' in ROUTES_PY
+    assert '"/api/reports/morning-brief/latest"' in REPORTS_PY
+
+
+def test_morning_brief_reader_uses_supabase_backed_payload_not_browser_supabase():
+    assert "control_plane_payload()" in REPORTS_PY
+    assert '"primary_store": "supabase"' in REPORTS_PY
+    assert '"fallback_store": "local_artifact"' in REPORTS_PY
+    assert "HERMES_MORNING_BRIEF_REPORT_DIR" in REPORTS_PY
+    assert "supabase" not in PANELS_JS.lower()
+    assert "SUPABASE" not in INDEX_HTML
+
+
+def test_morning_brief_reader_contract_sections_and_telegram_short_contract():
+    expected_text = [
+        '오늘의 요약',
+        '핵심 이슈',
+        'Hermes 처리 판단',
+        '보류 / 출처 약함',
+        'Telegram은 짧은 알림만',
+    ]
+    for text in expected_text:
+        assert text in PANELS_JS or text in INDEX_HTML
+    assert "api('/api/reports/morning-brief/latest')" in PANELS_JS
+    assert 'report-article' in PANELS_JS
+    assert 'report-jgment' not in PANELS_JS
+
+
+def test_report_reader_browser_payload_excludes_forbidden_raw_fields():
+    forbidden = [
+        'target_ref',
+        'provider_message_ref',
+        'provider_error_body',
+        'raw_payload',
+        'private_target_payload',
+        'raw_source_packet',
+        'raw_source_dump',
+    ]
+    for key in forbidden:
+        assert key not in REPORTS_PY
+
+
+def test_report_store_script_writes_ref_integrity_into_metadata_not_schema_columns():
+    expected_metadata_keys = [
+        'webui_ref_status',
+        'supabase_ref_status',
+        'supabase_verified_at',
+        'summary_hash',
+        'content_hash',
+        'fallback_artifact_ref',
+    ]
+    for key in expected_metadata_keys:
+        assert key in STORE_SCRIPT
+    assert "hashlib.sha256" in STORE_SCRIPT
+    assert "metadata.update(ref_integrity_metadata" in STORE_SCRIPT
+
+
+def test_morning_brief_reader_prefers_report_store_before_legacy_canary():
+    assert "def _report_store_payload" in REPORTS_PY
+    assert "hermes_reports.reports" in REPORTS_PY
+    assert "hermes_reports.report_body_sections" in REPORTS_PY
+    assert "report_store = _report_store_payload()" in REPORTS_PY
+    assert REPORTS_PY.index("report_store = _report_store_payload()") < REPORTS_PY.index("control_plane_payload()")
+
+
+def test_reader_exposes_ref_integrity_metadata_without_raw_fields():
+    allowed_keys = [
+        'webui_ref_status',
+        'webui_surface',
+        'webui_mutation_allowed',
+        'supabase_ref_status',
+        'supabase_verified_at',
+        'summary_hash',
+        'content_hash',
+        'fallback_artifact_ref',
+    ]
+    for key in allowed_keys:
+        assert f'"{key}"' in REPORTS_PY
+    assert 'ref_integrity' in REPORTS_PY
+
+
+def test_reader_runtime_payload_exposes_only_selected_ref_integrity(monkeypatch):
+    monkeypatch.setattr(
+        reports,
+        "_report_store_payload",
+        lambda: {
+            "enabled": True,
+            "run": {
+                "id": "morning-brief-test",
+                "run_ref": "supabase://hermes_reports.reports/morning-brief-test",
+                "report_date": "2026-05-10",
+                "title": "Morning Brief Test",
+                "status": "complete",
+                "metadata": {
+                    "webui_ref_status": "live",
+                    "webui_surface": "report",
+                    "webui_mutation_allowed": False,
+                    "supabase_ref_status": "available",
+                    "supabase_verified_at": "2026-05-10T15:15:52Z",
+                    "summary_hash": "sha256:summary",
+                    "content_hash": "sha256:content",
+                    "fallback_artifact_ref": "obsidian://ledger",
+                    "private_target_payload": "do-not-leak",
+                },
+                "obsidian_ref": "obsidian://ledger",
+            },
+            "sections": [
+                {
+                    "section_key": "summary",
+                    "section_order": 1,
+                    "title": "요약",
+                    "body_md": "clean summary",
+                    "judgment_label": "review",
+                }
+            ],
+            "sources": [],
+            "counts": {"report_sections": 1},
+        },
+    )
+    payload = reports.morning_brief_latest_report()
+    run = payload["run"]
+    assert "metadata" not in run
+    assert run["ref_integrity"] == {
+        "webui_ref_status": "live",
+        "webui_surface": "report",
+        "webui_mutation_allowed": False,
+        "supabase_ref_status": "available",
+        "supabase_verified_at": "2026-05-10T15:15:52Z",
+        "summary_hash": "sha256:summary",
+        "content_hash": "sha256:content",
+        "fallback_artifact_ref": "obsidian://ledger",
+    }
+    assert "private_target_payload" not in str(payload)
+
+
+def test_report_store_script_emits_canonical_morning_brief_webui_ref():
+    canonical = "hermes://webui/reports/morning-brief/"
+    legacy = "hermes://webui/morning-brief/"
+    assert f"WEBUI_MORNING_BRIEF_REF_PREFIX = '{canonical}'" in STORE_SCRIPT
+    assert "def webui_morning_brief_ref(report_id: str)" in STORE_SCRIPT
+    assert "webui_morning_brief_ref(report_id)" in STORE_SCRIPT
+    assert f"{legacy}' + report_id" not in STORE_SCRIPT
+    assert f"{legacy}{{report_id}}" not in STORE_SCRIPT
+
+
+def test_reader_runtime_payload_exposes_canonical_webui_ref_for_readback(monkeypatch):
+    canonical_ref = "hermes://webui/reports/morning-brief/morning-brief-test"
+    monkeypatch.setattr(
+        reports,
+        "_report_store_payload",
+        lambda: {
+            "enabled": True,
+            "run": {
+                "id": "morning-brief-test",
+                "run_ref": "supabase://hermes_reports.reports/morning-brief-test",
+                "report_date": "2026-05-10",
+                "title": "Morning Brief Test",
+                "status": "complete",
+                "webui_ref": canonical_ref,
+                "metadata": {
+                    "webui_ref_status": "live",
+                    "webui_surface": "report",
+                    "webui_mutation_allowed": False,
+                    "supabase_ref_status": "available",
+                    "fallback_artifact_ref": "obsidian://ledger",
+                },
+                "obsidian_ref": "obsidian://ledger",
+            },
+            "sections": [{"section_key": "summary", "section_order": 1, "title": "요약", "body_md": "clean summary"}],
+            "sources": [],
+            "counts": {"report_sections": 1},
+        },
+    )
+    payload = reports.morning_brief_latest_report()
+    assert payload["run"]["webui_ref"] == canonical_ref
+    assert payload["run"].get("canonical_webui_ref") == canonical_ref

--- a/tests/test_session_cleanup_mode.py
+++ b/tests/test_session_cleanup_mode.py
@@ -1,0 +1,424 @@
+"""Safety tests for WebUI session cleanup mode.
+
+Cleanup mode must start with a read-only report, then use reversible quarantine
+with a manifest. It must not touch state.db or hard-delete session JSON files.
+"""
+import json
+import os
+import calendar
+import time
+from pathlib import Path
+
+import pytest
+
+
+def _write_session(root: Path, sid: str, *, days_old=40, source="webui", messages=None, **extra):
+    root.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "session_id": sid,
+        "title": sid,
+        "source": source,
+        "updated_at": time.time() - days_old * 86400,
+        "created_at": time.time() - days_old * 86400,
+        "messages": [] if messages is None else messages,
+    }
+    payload.update(extra)
+    path = root / f"{sid}.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def test_cleanup_report_is_read_only_and_classifies_safe_candidates(tmp_path):
+    from api.session_cleanup import build_session_cleanup_report
+
+    sessions = tmp_path / "sessions"
+    state_db = tmp_path / "state.db"
+    state_db.write_text("do-not-touch", encoding="utf-8")
+
+    cron_ok = _write_session(sessions, "cron_ok_old", days_old=20, source="cron", messages=[{"role":"assistant","content":"ok"}], last_status="ok")
+    zero = _write_session(sessions, "empty_old", days_old=1, source="webui", messages=[])
+    pinned = _write_session(sessions, "pinned_old", days_old=120, source="webui", messages=[{"role":"user","content":"keep"}], pinned=True)
+    active = _write_session(sessions, "active_old", days_old=120, source="webui", messages=[{"role":"user","content":"keep"}], active_stream_id="stream-1")
+    telegram = _write_session(sessions, "tg_old", days_old=120, source="telegram", messages=[{"role":"user","content":"keep"}])
+    unknown = _write_session(sessions, "unknown_old", days_old=120, source="mystery", messages=[{"role":"user","content":"review"}])
+
+    mtimes_before = {p.name: p.stat().st_mtime_ns for p in sessions.glob("*.json")}
+    report = build_session_cleanup_report(session_dir=sessions, state_db_path=state_db, now=time.time())
+    mtimes_after = {p.name: p.stat().st_mtime_ns for p in sessions.glob("*.json")}
+
+    assert mtimes_after == mtimes_before
+    assert state_db.read_text(encoding="utf-8") == "do-not-touch"
+    assert report["mode"] == "read_only"
+    assert report["summary"]["total_sessions"] == 6
+    assert report["summary"]["state_db_touched"] is False
+    assert {c["session_id"] for c in report["cleanup_candidates"]} == {"cron_ok_old", "empty_old"}
+    assert {p["session_id"] for p in report["protected"]} == {"pinned_old", "active_old", "tg_old"}
+    assert {r["session_id"] for r in report["needs_review"]} == {"unknown_old"}
+    assert report["summary"]["estimated_reclaim_bytes"] == cron_ok.stat().st_size + zero.stat().st_size
+
+
+def test_report_rejects_session_id_filename_mismatch_to_protect_real_session(tmp_path):
+    from api.session_cleanup import build_session_cleanup_report, quarantine_sessions
+
+    sessions = tmp_path / "sessions"
+    trash = tmp_path / "session-trash"
+    _write_session(sessions, "pinned_old", days_old=120, source="webui", messages=[{"role":"user","content":"keep"}], pinned=True)
+    decoy = {
+        "session_id": "pinned_old",
+        "title": "decoy",
+        "source": "webui",
+        "updated_at": time.time() - 120 * 86400,
+        "messages": [],
+    }
+    (sessions / "decoy.json").write_text(json.dumps(decoy), encoding="utf-8")
+
+    report = build_session_cleanup_report(session_dir=sessions, now=time.time())
+    assert "pinned_old" not in {c["session_id"] for c in report["cleanup_candidates"]}
+    assert {i.get("path") for i in report["invalid"]} == {"decoy.json"}
+
+    result = quarantine_sessions(["pinned_old"], report=report, session_dir=sessions, trash_root=trash, actor="pytest")
+    assert result["moved"] == []
+    assert (sessions / "pinned_old.json").exists()
+
+
+def test_old_non_archived_webui_session_is_protected_not_cleanup_candidate(tmp_path):
+    from api.session_cleanup import build_session_cleanup_report
+
+    sessions = tmp_path / "sessions"
+    _write_session(sessions, "normal_old", days_old=90, source="webui", messages=[{"role":"user","content":"keep"}])
+
+    report = build_session_cleanup_report(session_dir=sessions, now=time.time())
+    assert "normal_old" not in {c["session_id"] for c in report["cleanup_candidates"]}
+    protected = {p["session_id"]: p for p in report["protected"]}
+    assert "normal_old" in protected
+    assert protected["normal_old"]["reasons"] == ["webui_non_archived_retained"]
+
+
+def test_archived_webui_chat_with_durable_content_requires_structured_review(tmp_path):
+    from api.session_cleanup import build_session_cleanup_report, build_session_retention_plan
+
+    sessions = tmp_path / "sessions"
+    _write_session(
+        sessions,
+        "archived_preference",
+        days_old=60,
+        source="webui",
+        archived=True,
+        messages=[
+            {"role": "user", "content": "기억해둬. 나는 WebUI 채팅 삭제 전에 중요한 선호는 구조화해서 남기는 방식을 선호해."},
+            {"role": "assistant", "content": "확인했습니다."},
+        ],
+    )
+    _write_session(
+        sessions,
+        "archived_noise",
+        days_old=60,
+        source="webui",
+        archived=True,
+        messages=[{"role": "user", "content": "임시 테스트 대화"}],
+    )
+
+    report = build_session_cleanup_report(session_dir=sessions, now=time.time())
+
+    assert {c["session_id"] for c in report["cleanup_candidates"]} == {"archived_noise"}
+    review = {r["session_id"]: r for r in report["needs_review"]}
+    assert "archived_preference" in review
+    assert review["archived_preference"]["retention_decision"] == "structure_before_delete"
+    assert "memory_candidate" in review["archived_preference"]["structured_targets"]
+    assert "raw_chat_not_long_term_memory" in review["archived_preference"]["reasons"]
+
+    plan = build_session_retention_plan(report)
+    assert plan["summary"]["structure_before_delete_count"] == 1
+    assert plan["summary"]["quarantine_ready_count"] == 1
+    assert plan["structured_candidates"][0]["session_id"] == "archived_preference"
+    assert plan["quarantine_ready"][0]["session_id"] == "archived_noise"
+
+
+def test_structured_review_identifies_skill_obsidian_handoff_and_secret_risk(tmp_path):
+    from api.session_cleanup import build_session_cleanup_report
+
+    sessions = tmp_path / "sessions"
+    _write_session(
+        sessions,
+        "archived_workflow",
+        days_old=60,
+        source="webui",
+        archived=True,
+        messages=[{"role": "user", "content": "반복 절차: 실패하면 백업 후 검증한다. 다음 safe_next_action도 남겨라."}],
+    )
+    _write_session(
+        sessions,
+        "archived_rule",
+        days_old=60,
+        source="webui",
+        archived=True,
+        messages=[{"role": "user", "content": "이 규칙은 Obsidian MR 승인 경계와 Rule Map에 관련된다."}],
+    )
+    _write_session(
+        sessions,
+        "archived_secret",
+        days_old=60,
+        source="webui",
+        archived=True,
+        title="api_key=SECRET should be redacted",
+        messages=[{"role": "user", "content": "api_key=SECRET token 값은 저장하지 말 것"}],
+    )
+
+    report = build_session_cleanup_report(session_dir=sessions, now=time.time())
+    review = {r["session_id"]: r for r in report["needs_review"]}
+
+    assert set(review) == {"archived_workflow", "archived_rule", "archived_secret"}
+    assert {"skill_candidate", "handoff_candidate"}.issubset(set(review["archived_workflow"]["structured_targets"]))
+    assert "obsidian_candidate" in review["archived_rule"]["structured_targets"]
+    assert review["archived_secret"]["retention_decision"] == "do_not_preserve_secret_review"
+    assert "secret_risk" in review["archived_secret"]["structured_targets"]
+    assert "SECRET" not in review["archived_secret"]["title"]
+    assert "[REDACTED]" in review["archived_secret"]["title"]
+
+    from api.session_cleanup import build_session_retention_plan
+    plan = build_session_retention_plan(report)
+    plan_secret = {r["session_id"]: r for r in plan["structured_candidates"]}["archived_secret"]
+    assert "SECRET" not in plan_secret["title"]
+    assert "[REDACTED]" in plan_secret["title"]
+
+
+def test_report_rejects_symlink_sessions_before_quarantine(tmp_path):
+    from api.session_cleanup import build_session_cleanup_report, quarantine_sessions
+
+    sessions = tmp_path / "sessions"
+    trash = tmp_path / "session-trash"
+    active_payload = {
+        "title": "active",
+        "source": "webui",
+        "updated_at": time.time() - 120 * 86400,
+        "messages": [{"role":"user","content":"keep"}],
+    }
+    sessions.mkdir(parents=True, exist_ok=True)
+    (sessions / "active.json").write_text(json.dumps(active_payload), encoding="utf-8")
+    (sessions / "decoy.json").symlink_to(sessions / "active.json")
+
+    report = build_session_cleanup_report(session_dir=sessions, now=time.time(), current_session_id="active")
+    assert {p["session_id"] for p in report["protected"]} == {"active"}
+    assert "decoy" not in {c["session_id"] for c in report["cleanup_candidates"]}
+    assert {i.get("path") for i in report["invalid"]} == {"decoy.json"}
+
+    result = quarantine_sessions(["decoy"], report=report, session_dir=sessions, trash_root=trash, actor="pytest")
+    assert result["moved"] == []
+    assert (sessions / "active.json").exists()
+
+
+def test_quarantine_moves_only_report_candidates_and_writes_restore_manifest(tmp_path):
+    from api.session_cleanup import build_session_cleanup_report, quarantine_sessions, restore_quarantine
+
+    sessions = tmp_path / "sessions"
+    trash = tmp_path / "session-trash"
+    _write_session(sessions, "cron_ok_old", days_old=20, source="cron", messages=[{"role":"assistant","content":"ok"}], last_status="ok")
+    _write_session(sessions, "pinned_old", days_old=120, source="webui", messages=[{"role":"user","content":"keep"}], pinned=True)
+    (sessions / "_index.json").write_text("[]", encoding="utf-8")
+
+    report = build_session_cleanup_report(session_dir=sessions, now=time.time())
+    result = quarantine_sessions(
+        ["cron_ok_old", "pinned_old"],
+        report=report,
+        session_dir=sessions,
+        trash_root=trash,
+        actor="pytest",
+    )
+
+    assert result["ok"] is True
+    assert result["moved"] == ["cron_ok_old"]
+    assert result["skipped"][0]["session_id"] == "pinned_old"
+    assert not (sessions / "cron_ok_old.json").exists()
+    assert (sessions / "pinned_old.json").exists()
+    assert not (sessions / "_index.json").exists(), "index must be invalidated after quarantine"
+
+    manifest = Path(result["manifest_path"])
+    payload = json.loads(manifest.read_text(encoding="utf-8"))
+    assert payload["operation"] == "quarantine"
+    assert payload["state_db_touched"] is False
+    assert payload["items"][0]["session_id"] == "cron_ok_old"
+    assert (manifest.parent / "sessions" / "cron_ok_old.json").exists()
+
+    restored = restore_quarantine(manifest, session_dir=sessions)
+    assert restored["ok"] is True
+    assert restored["restored"] == ["cron_ok_old"]
+    assert (sessions / "cron_ok_old.json").exists()
+    assert not (sessions / "_index.json").exists(), "index must be invalidated after restore"
+
+
+def test_restore_rejects_manifest_trash_path_outside_quarantine_batch(tmp_path):
+    from api.session_cleanup import restore_quarantine
+
+    sessions = tmp_path / "sessions"
+    batch = tmp_path / "session-trash" / "20260508-000000-test"
+    batch.mkdir(parents=True)
+    external = tmp_path / "external.json"
+    external.write_text('{"session_id":"evil"}', encoding="utf-8")
+    manifest = batch / "manifest.json"
+    manifest.write_text(json.dumps({
+        "operation": "quarantine",
+        "items": [{"session_id": "evil", "trash_path": str(external)}],
+    }), encoding="utf-8")
+
+    result = restore_quarantine(manifest, session_dir=sessions)
+    assert result["restored"] == []
+    assert result["skipped"] == [{"session_id": "evil", "reason": "trash_path_escape"}]
+    assert external.exists()
+    assert not (sessions / "evil.json").exists()
+
+
+def test_core_agent_session_prefixed_filename_can_be_scanned_quarantined_and_restored(tmp_path):
+    from api.session_cleanup import build_session_cleanup_report, quarantine_sessions, restore_quarantine
+
+    sessions = tmp_path / "sessions"
+    trash = tmp_path / "session-trash"
+    sessions.mkdir(parents=True)
+    sid = "cron_abc123_20260420_010203"
+    payload = {
+        "session_id": sid,
+        "title": "cron core session",
+        "platform": "cron",
+        "last_updated": "2026-04-20T01:02:03",
+        "session_start": "2026-04-20T01:01:01",
+        "messages": [{"role": "assistant", "content": "ok"}],
+    }
+    path = sessions / f"session_{sid}.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    fresh_mtime = time.time()
+    os.utime(path, (fresh_mtime, fresh_mtime))
+    now = calendar.timegm(time.strptime("2026-05-10T01:02:03", "%Y-%m-%dT%H:%M:%S"))
+
+    report = build_session_cleanup_report(session_dir=sessions, now=now)
+    assert {c["session_id"] for c in report["cleanup_candidates"]} == {sid}
+    assert report["cleanup_candidates"][0]["source"] == "cron"
+    assert report["cleanup_candidates"][0]["age_days"] == 20.0
+
+    quarantined = quarantine_sessions([sid], report=report, session_dir=sessions, trash_root=trash, actor="pytest")
+    manifest = Path(quarantined["manifest_path"])
+    assert not (sessions / f"session_{sid}.json").exists()
+    assert (manifest.parent / "sessions" / f"session_{sid}.json").exists()
+
+    restored = restore_quarantine(manifest, session_dir=sessions)
+    assert restored["restored"] == [sid]
+    assert (sessions / f"session_{sid}.json").exists()
+
+
+def test_quarantine_uses_exact_reported_candidate_path_when_prefixed_and_unprefixed_ids_collide(tmp_path):
+    from api.session_cleanup import build_session_cleanup_report, quarantine_sessions
+
+    sessions = tmp_path / "sessions"
+    trash = tmp_path / "session-trash"
+    sessions.mkdir(parents=True)
+    sid = "abc123"
+    protected = {
+        "session_id": sid,
+        "title": "protected unprefixed",
+        "source": "webui",
+        "updated_at": time.time() - 120 * 86400,
+        "messages": [{"role": "user", "content": "keep"}],
+        "pinned": True,
+    }
+    candidate = {
+        "session_id": sid,
+        "title": "candidate prefixed",
+        "platform": "cron",
+        "updated_at": time.time() - 20 * 86400,
+        "messages": [{"role": "assistant", "content": "ok"}],
+    }
+    (sessions / f"{sid}.json").write_text(json.dumps(protected), encoding="utf-8")
+    (sessions / f"session_{sid}.json").write_text(json.dumps(candidate), encoding="utf-8")
+
+    report = build_session_cleanup_report(session_dir=sessions, now=time.time())
+    assert [(c["session_id"], c["path"]) for c in report["cleanup_candidates"]] == [(sid, f"session_{sid}.json")]
+    assert [(p["session_id"], p["path"]) for p in report["protected"]] == [(sid, f"{sid}.json")]
+
+    result = quarantine_sessions([sid], report=report, session_dir=sessions, trash_root=trash, actor="pytest")
+
+    assert result["moved"] == [sid]
+    manifest = Path(result["manifest_path"])
+    assert (sessions / f"{sid}.json").exists(), "protected unprefixed file must not move"
+    assert not (sessions / f"session_{sid}.json").exists()
+    assert (manifest.parent / "sessions" / f"session_{sid}.json").exists()
+    assert not (manifest.parent / "sessions" / f"{sid}.json").exists()
+
+
+def test_delete_quarantine_only_removes_manifest_listed_trash_files(tmp_path):
+    from api.session_cleanup import build_session_cleanup_report, quarantine_sessions, delete_quarantine
+
+    sessions = tmp_path / "sessions"
+    trash = tmp_path / "session-trash"
+    live = _write_session(sessions, "cron_ok_old", days_old=20, source="cron", messages=[{"role":"assistant","content":"ok"}], last_status="ok")
+    state_db = tmp_path / "state.db"
+    state_db.write_text("do-not-touch", encoding="utf-8")
+
+    report = build_session_cleanup_report(session_dir=sessions, state_db_path=state_db, now=time.time())
+    quarantined = quarantine_sessions(["cron_ok_old"], report=report, session_dir=sessions, trash_root=trash, actor="pytest")
+    manifest = Path(quarantined["manifest_path"])
+    stray = manifest.parent / "sessions" / "stray.json"
+    stray.write_text('{"session_id":"stray"}', encoding="utf-8")
+
+    result = delete_quarantine(manifest)
+
+    assert result["ok"] is True
+    assert result["deleted"] == ["cron_ok_old"]
+    assert result["state_db_touched"] is False
+    assert state_db.read_text(encoding="utf-8") == "do-not-touch"
+    assert not live.exists()
+    assert not (manifest.parent / "sessions" / "cron_ok_old.json").exists()
+    assert stray.exists(), "hard delete must be manifest-only, not batch-directory glob delete"
+    deletion_manifest = manifest.parent / "deleted-manifest.json"
+    assert deletion_manifest.exists()
+    assert json.loads(deletion_manifest.read_text(encoding="utf-8"))["operation"] == "delete_quarantine"
+
+
+def test_delete_quarantine_rejects_live_session_paths_and_path_escape(tmp_path):
+    from api.session_cleanup import delete_quarantine
+
+    sessions = tmp_path / "sessions"
+    live = _write_session(sessions, "keep_live", days_old=120, source="webui", messages=[])
+    batch = tmp_path / "session-trash" / "20260508-000000-test"
+    batch.mkdir(parents=True)
+    manifest = batch / "manifest.json"
+    manifest.write_text(json.dumps({
+        "operation": "quarantine",
+        "items": [
+            {"session_id": "keep_live", "trash_path": str(live)},
+            {"session_id": "escape", "trash_path": str(tmp_path / "escape.json")},
+        ],
+    }), encoding="utf-8")
+
+    result = delete_quarantine(manifest)
+
+    assert result["deleted"] == []
+    assert result["skipped"] == [
+        {"session_id": "keep_live", "reason": "trash_path_escape"},
+        {"session_id": "escape", "reason": "trash_path_escape"},
+    ]
+    assert live.exists()
+
+
+def test_session_cleanup_routes_are_registered_and_ui_is_explicitly_reversible():
+    root = Path(__file__).resolve().parent.parent
+    routes = (root / "api" / "routes.py").read_text(encoding="utf-8")
+    index = (root / "static" / "index.html").read_text(encoding="utf-8")
+    panels = (root / "static" / "panels.js").read_text(encoding="utf-8")
+
+    assert '"/api/sessions/cleanup"' in routes
+    assert 'legacy cleanup endpoint disabled; use cleanup_report + quarantine' in routes
+    assert '"/api/sessions/cleanup_zero_message"' in routes
+    assert '"/api/sessions/cleanup_report"' in routes
+    assert '"/api/sessions/quarantine"' in routes
+    assert '"/api/sessions/restore_quarantine"' in routes
+    assert '"/api/sessions/delete_quarantine"' in routes
+    assert 'session_dir=STATE_DIR.parent / "sessions"' in routes
+    assert 'trash_root=STATE_DIR.parent / "session-trash"' in routes
+    assert 'id="sessionCleanupReport"' in index
+    assert "Read-only scan" in index
+    assert "Quarantine selected" in index
+    assert "Restore latest quarantine" in index
+    assert "Delete quarantine only" in index
+    assert "state.db is not modified" in index
+    assert "loadSessionCleanupReport" in panels
+    assert "quarantineSessionCleanupCandidates" in panels
+    assert "restoreLatestSessionQuarantine" in panels
+    assert "deleteLatestSessionQuarantine" in panels


### PR DESCRIPTION
## Summary
- Restore live session continuity controls in the static WebUI: `세션 압축`, `이동 준비 ▾`, and `세션 이동`.
- Add `이동 준비` menu items for `인계문 복사` and `터미널용 복사`.
- Generate efficient operational handoff packets with checklist, inherited operational digest, and bounded visible-message outline rather than claiming full raw transcript transfer.

## Verification
- `node --check static/boot.js`
- Served static readback on `http://127.0.0.1:8787/static/{index.html,style.css,boot.js}` showed all required strings present.
- Browser verification showed the three top-level controls visible outside the composer and no console errors.

## Notes
- This absorbs the local live hotfix into a git branch so it can be reapplied/upstreamed instead of being lost on checkout/update.
