### PR TITLE
fix: preserve reasoning_content in API message whitelist

### DIFF
--- a/api/streaming.py
+++ b/api/streaming.py
@@ -266,7 +266,7 @@ from api.workspace import set_last_workspace
 # Fields that are safe to send to LLM provider APIs.
 # Everything else (attachments, timestamp, _ts, etc.) is display-only
 # metadata added by the webui and must be stripped before the API call.
-_API_SAFE_MSG_KEYS = {'role', 'content', 'tool_calls', 'tool_call_id', 'name', 'refusal'}
+_API_SAFE_MSG_KEYS = {'role', 'content', 'tool_calls', 'tool_call_id', 'name', 'refusal', 'reasoning_content'}
 
 _NATIVE_IMAGE_MAX_BYTES = 20 * 1024 * 1024
 


### PR DESCRIPTION
## Problem

Using MiMo (Xiaomi) models in WebUI causes HTTP 400 on any multi-turn conversation that involves tool calls:

```
HTTP 400: {'error': {'code': '400', 'message': 'Param Incorrect',
  'param': 'The reasoning_content in the thinking mode must be passed back to the API.'}}
```

The same session works fine from CLI. DeepSeek and Kimi/Moonshot are also affected through WebUI.

## Root Cause

WebUI's `_sanitize_messages_for_api()` strips all fields not in `_API_SAFE_MSG_KEYS` before sending conversation history to the LLM API. `reasoning_content` was not in this whitelist.

When conversation history is replayed on the second turn, the assistant message (with `tool_calls`) arrives **without** `reasoning_content`. Providers enforcing thinking-mode echo-back reject this with HTTP 400.

CLI is unaffected because `run_agent.py` has its own `_copy_reasoning_content_for_api()` that operates on raw message dicts without going through this filter.

## Fix

Added `'reasoning_content'` to `_API_SAFE_MSG_KEYS`:

```python
# Before
_API_SAFE_MSG_KEYS = {'role', 'content', 'tool_calls', 'tool_call_id', 'name', 'refusal'}

# After
_API_SAFE_MSG_KEYS = {'role', 'content', 'tool_calls', 'tool_call_id', 'name', 'refusal', 'reasoning_content'}
```