### PR TITLE
fix: cap _summary_cache with LRU (max 16 entries)

### DIFF
--- a/api/updates.py
+++ b/api/updates.py
@@ -14,6 +14,7 @@ import re
 import subprocess
 import threading
 import time
+from collections import OrderedDict
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -26,7 +27,8 @@ except ImportError:
     _AGENT_DIR = None
 
 _update_cache = {'webui': None, 'agent': None, 'checked_at': 0}
-_summary_cache = {}
+_SUMMARY_CACHE_MAX = 16
+_summary_cache: OrderedDict = OrderedDict()
 _cache_lock = threading.Lock()
 _check_in_progress = False
 _apply_lock = threading.Lock()   # prevents concurrent stash/pull/pop on same repo
@@ -498,6 +500,8 @@ def summarize_update_payload(updates: dict, llm_callback=None, *, target: str | 
     if use_cache:
         with _cache_lock:
             cached = _summary_cache.get(cache_key)
+            if cached:
+                _summary_cache.move_to_end(cache_key)
         if cached:
             result = dict(cached)
             result['cached'] = True
@@ -526,6 +530,8 @@ def summarize_update_payload(updates: dict, llm_callback=None, *, target: str | 
     }
     if use_cache:
         with _cache_lock:
+            if len(_summary_cache) >= _SUMMARY_CACHE_MAX and cache_key not in _summary_cache:
+                _summary_cache.popitem(last=False)
             _summary_cache[cache_key] = dict(result)
     return result
 

--- a/tests/test_update_banner_fixes.py
+++ b/tests/test_update_banner_fixes.py
@@ -839,6 +839,51 @@ class TestWhatsNewSummaryToggle:
         assert second['summary'] == first['summary']
         assert second['cached'] is True
         assert changed['summary'] != first['summary']
+
+    def test_update_summary_cache_is_bounded_lru(self):
+        import api.updates as upd
+
+        upd._summary_cache.clear()
+        calls = []
+
+        def payload(n):
+            return {
+                'webui': {
+                    'behind': n + 1,
+                    'current_sha': f'old-{n}',
+                    'latest_sha': f'new-{n}',
+                    'compare_url': f'https://example.test/webui/{n}',
+                },
+            }
+
+        def fake_llm(_system, prompt):
+            calls.append(prompt)
+            return f'- Generated summary #{len(calls)}'
+
+        try:
+            for i in range(upd._SUMMARY_CACHE_MAX):
+                upd.summarize_update_payload(payload(i), llm_callback=fake_llm)
+
+            assert len(upd._summary_cache) == upd._SUMMARY_CACHE_MAX
+            assert len(calls) == upd._SUMMARY_CACHE_MAX
+
+            first_again = upd.summarize_update_payload(payload(0), llm_callback=fake_llm)
+            assert first_again['cached'] is True
+            assert len(calls) == upd._SUMMARY_CACHE_MAX
+
+            upd.summarize_update_payload(payload(upd._SUMMARY_CACHE_MAX), llm_callback=fake_llm)
+            assert len(upd._summary_cache) == upd._SUMMARY_CACHE_MAX
+
+            still_cached = upd.summarize_update_payload(payload(0), llm_callback=fake_llm)
+            assert still_cached['cached'] is True
+            assert len(calls) == upd._SUMMARY_CACHE_MAX + 1
+
+            evicted = upd.summarize_update_payload(payload(1), llm_callback=fake_llm)
+            assert evicted['cached'] is False
+            assert len(calls) == upd._SUMMARY_CACHE_MAX + 2
+        finally:
+            upd._summary_cache.clear()
+
     def test_update_summary_can_be_generated_per_target_and_cached_separately(self):
         import api.updates as upd
 
@@ -932,4 +977,3 @@ class TestCheckForUpdatesButton:
         assert count >= 5, (
             f"settings_check_now found in only {count} locale blocks (expected ≥5: en, ru, es, zh, zh-Hant)"
         )
-


### PR DESCRIPTION
Refs #2215 (Fix A).

## Thinking Path
Issue #2215 flagged `_summary_cache` as an unbounded plain dict. The current single-user cardinality is small, but a bounded cache is the right low-risk cleanup for long-running servers and future higher-cardinality update targets.

## What Changed
- Kept the existing update summary cache behavior.
- Changed `_summary_cache` to an `OrderedDict` with `_SUMMARY_CACHE_MAX = 16`.
- Refresh recency on cache hits with `move_to_end()`.
- Evict the least-recently used entry with `popitem(last=False)` when adding a new key at capacity.
- Added regression coverage for cache reuse, bounded size, hit recency refresh, and least-recently used eviction.

## Why It Matters
The summary cache should not grow without bound across a long-running WebUI process. The LRU cap preserves the fast path for recent update ranges while giving the cache an explicit memory ceiling.

## Verification
- `pytest -q tests/test_update_banner_fixes.py::TestWhatsNewSummaryToggle::test_update_summary_cache_reuses_same_update_summary tests/test_update_banner_fixes.py::TestWhatsNewSummaryToggle::test_update_summary_cache_is_bounded_lru tests/test_update_banner_fixes.py::TestWhatsNewSummaryToggle::test_update_summary_can_be_generated_per_target_and_cached_separately tests/test_updates.py`
- `python -m py_compile api/updates.py tests/test_update_banner_fixes.py tests/test_updates.py`
- `git diff --check`

## Risks / Follow-ups
- Cache miss rate can increase after eviction, but update summaries are generated infrequently and the cap is intentionally conservative.
- This is only Fix A from #2215; Fix B is tracked separately in #2217, so this PR intentionally uses `Refs` rather than auto-closing #2215.

## Model Used
OpenAI GPT-5.4 via Codex CLI.