### PR TITLE
fix: drop re.MULTILINE from 'the user is asking' strip pattern

### DIFF
--- a/api/streaming.py
+++ b/api/streaming.py
@@ -695,7 +695,7 @@ def _strip_thinking_markup(text: str) -> str:
     s = re.sub(r'^\s*<think>.*?</think>\s*', ' ', s, flags=re.IGNORECASE | re.DOTALL)
     s = re.sub(r'^\s*<\|channel\|?>thought\n?.*?<channel\|>\s*', ' ', s, flags=re.IGNORECASE | re.DOTALL)
     s = re.sub(r'^\s*<\|turn\|>thinking\n.*?<turn\|>\s*', ' ', s, flags=re.IGNORECASE | re.DOTALL)  # Gemma 4
-    s = re.sub(r'^\s*(the|ther)\s+user\s+is\s+asking.*$', ' ', s, flags=re.IGNORECASE | re.MULTILINE)
+    s = re.sub(r'^\s*(the|ther)\s+user\s+is\s+asking[^\n]*(?:\n|$)', ' ', s, flags=re.IGNORECASE)
     # Strip plain-text thinking preambles from models that don't use <think> tags (e.g. Qwen3).
     # These appear as the very first sentence of the assistant response and are not useful as titles.
     s = re.sub(

--- a/tests/test_issue607.py
+++ b/tests/test_issue607.py
@@ -88,6 +88,20 @@ class TestGemma4ThinkingTokenStrip:
         result = _strip_thinking_markup(raw)
         assert result == raw
 
+    def test_leading_the_user_is_asking_wrapper_line_is_stripped(self):
+        """A leading title-wrapper line is metadata; the visible answer should remain."""
+        raw = "The user is asking about Python imports.\nUse importlib for dynamic imports."
+        result = _strip_thinking_markup(raw)
+        assert result == "Use importlib for dynamic imports."
+
+    def test_mid_response_the_user_is_asking_line_is_preserved(self):
+        """Only the leading wrapper line is stripped; normal mid-response prose survives."""
+        raw = "First, define the context.\nThe user is asking us to be patient.\nThen answer."
+        result = _strip_thinking_markup(raw)
+        assert "First, define the context." in result
+        assert "The user is asking us to be patient." in result
+        assert "Then answer." in result
+
     def test_minimax_channel_without_second_pipe_still_stripped_at_start(self):
         """The client-facing MiniMax <|channel>thought shape is stripped when leading."""
         raw = "<|channel>thought\nSome reasoning<channel|>Answer"


### PR DESCRIPTION
Refs #2215 (Fix B).

## Thinking Path
Issue #2215 identified a pre-existing `re.MULTILINE` hazard in the "the user is asking" strip pattern. Removing `MULTILINE` alone prevents mid-response stripping, but it also stops stripping a leading wrapper line when a real answer follows on the next line. The correct narrow fix is to strip only the leading wrapper line.

## What Changed
- Updated `api/streaming.py::_strip_thinking_markup()` so the "the user is asking" cleanup consumes only the leading wrapper line:

```python
r"^\s*(the|ther)\s+user\s+is\s+asking[^\n]*(?:\n|$)"
```

- Added regression coverage proving a leading wrapper line is removed while the visible answer remains.
- Added regression coverage proving a mid-response "The user is asking..." line is preserved as normal prose.

## Why It Matters
This keeps the intended title-wrapper cleanup without deleting legitimate mid-response content. It also avoids regressing multi-line leading wrapper cases where the wrapper line should disappear but the answer should remain.

## Verification
- `pytest -q tests/test_issue607.py tests/test_issues_853_857.py tests/test_sprint38.py`
- `python -m py_compile api/streaming.py tests/test_issue607.py`
- `git diff --check`

## Risks / Follow-ups
- This is a focused regex cleanup and does not change the broader reasoning-wrapper handling from #2213.
- This is only Fix B from #2215; Fix A is tracked separately in #2216, so this PR intentionally uses `Refs` rather than auto-closing #2215.

## Model Used
OpenAI GPT-5.4 via Codex CLI.