### PR TITLE
docs: refresh CONTRIBUTORS.md and README to v0.51.58 (130→137 contributors, 568→646 PR credits)

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,12 +1,12 @@
 # Contributors
 
-Hermes WebUI is a community project. **130 people** have shipped code that landed in a release tag — including the long tail of folks whose work was salvaged into batch releases or absorbed via Co-authored-by trailers. This file is the canonical credit roll.
+Hermes WebUI is a community project. **137 people** have shipped code that landed in a release tag — including the long tail of folks whose work was salvaged into batch releases or absorbed via Co-authored-by trailers. This file is the canonical credit roll.
 
 A contributor's PR count is the number of distinct PRs they get credit for: PRs they authored that merged directly, PRs they authored that were closed-but-absorbed into a release commit (batch merges, salvage rewrites), and PRs where they were explicitly attributed in `CHANGELOG.md`. All three count the same.
 
-**Total contributors tracked:** 130  
-**Total PR credits:** 568  
-**Last refreshed:** v0.51.44, 2026-05-11
+**Total contributors tracked:** 137
+**Total PR credits:** 646
+**Last refreshed:** v0.51.58, 2026-05-13
 
 Generated from `git log` + the GitHub PR list (merged and closed) + the `CHANGELOG.md` attribution lines (`PR #N by @user`, `(credit: @user)`, `@user — PR #N`). If your name is missing or wrong, open a PR against `CONTRIBUTORS.md` — we cross-check against the changelog on each release.
 
@@ -16,26 +16,27 @@ Generated from `git log` + the GitHub PR list (merged and closed) + the `CHANGEL
 
 | # | Contributor | PRs | First release | Latest release |
 |---|---|---:|---|---|
-| 1 | [@franksong2702](https://github.com/franksong2702) | 92 | `v0.49.3` | `v0.51.44` |
-| 2 | [@Michaelyklam](https://github.com/Michaelyklam) | 81 | `v0.50.240` | `v0.51.40` |
-| 3 | [@bergeouss](https://github.com/bergeouss) | 61 | `v0.48.0` | `v0.51.18` |
-| 4 | [@ai-ag2026](https://github.com/ai-ag2026) | 49 | `v0.50.279` | `v0.51.44` |
-| 5 | [@dso2ng](https://github.com/dso2ng) | 21 | `v0.50.227` | `v0.51.37` |
-| 6 | [@jasonjcwu](https://github.com/jasonjcwu) | 13 | `v0.50.227` | `v0.51.43` |
-| 7 | [@aronprins](https://github.com/aronprins) | 10 | `v0.44.0` | `v0.50.233` |
-| 8 | [@JKJameson](https://github.com/JKJameson) | 10 | `v0.50.233` | `v0.51.31` |
-| 9 | [@ccqqlo](https://github.com/ccqqlo) | 9 | `v0.44.0` | `v0.50.270` |
-| 10 | [@24601](https://github.com/24601) | 8 | `v0.50.233` | `v0.51.5` |
-| 11 | [@starship-s](https://github.com/starship-s) | 8 | `v0.50.128` | `v0.51.8` |
-| 12 | [@armorbreak001](https://github.com/armorbreak001) | 7 | `v0.50.47` | `v0.50.50` |
-| 13 | [@NocGeek](https://github.com/NocGeek) | 7 | `v0.50.251` | `v0.50.252` |
-| 14 | [@Hinotoi-agent](https://github.com/Hinotoi-agent) | 6 | `v0.50.12` | `v0.51.44` |
-| 15 | [@iRonin](https://github.com/iRonin) | 6 | `v0.41.0` | `v0.41.0` |
-| 16 | [@Jordan-SkyLF](https://github.com/Jordan-SkyLF) | 6 | `v0.50.18` | `v0.50.27` |
-| 17 | [@Sanjays2402](https://github.com/Sanjays2402) | 6 | `v0.50.292` | `v0.51.31` |
-| 18 | [@cloudyun888](https://github.com/cloudyun888) | 5 | `v0.50.47` | `v0.50.140` |
-| 19 | [@fxd-jason](https://github.com/fxd-jason) | 5 | `v0.50.245` | `v0.50.249` |
-| 20 | [@happy5318](https://github.com/happy5318) | 5 | `v0.50.238` | `v0.51.31` |
+| 1 | [@franksong2702](https://github.com/franksong2702) | 117 | `v0.49.3` | `v0.51.58` |
+| 2 | [@Michaelyklam](https://github.com/Michaelyklam) | 92 | `v0.50.240` | `v0.51.57` |
+| 3 | [@bergeouss](https://github.com/bergeouss) | 62 | `v0.48.0` | `v0.51.46` |
+| 4 | [@ai-ag2026](https://github.com/ai-ag2026) | 55 | `v0.50.279` | `v0.51.47` |
+| 5 | [@dso2ng](https://github.com/dso2ng) | 23 | `v0.50.227` | `v0.51.51` |
+| 6 | [@jasonjcwu](https://github.com/jasonjcwu) | 16 | `v0.50.227` | `v0.51.55` |
+| 7 | [@Jordan-SkyLF](https://github.com/Jordan-SkyLF) | 12 | `v0.50.18` | `v0.51.58` |
+| 8 | [@aronprins](https://github.com/aronprins) | 10 | `v0.44.0` | `v0.50.233` |
+| 9 | [@JKJameson](https://github.com/JKJameson) | 10 | `v0.50.233` | `v0.51.31` |
+| 10 | [@starship-s](https://github.com/starship-s) | 10 | `v0.50.128` | `v0.51.58` |
+| 11 | [@ccqqlo](https://github.com/ccqqlo) | 9 | `v0.44.0` | `v0.50.270` |
+| 12 | [@24601](https://github.com/24601) | 8 | `v0.50.233` | `v0.51.5` |
+| 13 | [@armorbreak001](https://github.com/armorbreak001) | 7 | `v0.50.47` | `v0.50.50` |
+| 14 | [@NocGeek](https://github.com/NocGeek) | 7 | `v0.50.251` | `v0.50.252` |
+| 15 | [@dobby-d-elf](https://github.com/dobby-d-elf) | 6 | `v0.51.38` | `v0.51.58` |
+| 16 | [@Hinotoi-agent](https://github.com/Hinotoi-agent) | 6 | `v0.50.12` | `v0.51.44` |
+| 17 | [@iRonin](https://github.com/iRonin) | 6 | `v0.41.0` | `v0.41.0` |
+| 18 | [@Sanjays2402](https://github.com/Sanjays2402) | 6 | `v0.50.292` | `v0.51.31` |
+| 19 | [@cloudyun888](https://github.com/cloudyun888) | 5 | `v0.50.47` | `v0.50.140` |
+| 20 | [@fxd-jason](https://github.com/fxd-jason) | 5 | `v0.50.245` | `v0.50.249` |
+| 21 | [@happy5318](https://github.com/happy5318) | 5 | `v0.50.238` | `v0.51.31` |
 
 ## Sustained contributors (3–4 PRs landed)
 
@@ -45,23 +46,25 @@ Generated from `git log` + the GitHub PR list (merged and closed) + the `CHANGEL
 | [@fecolinhares](https://github.com/fecolinhares) | 4 | `v0.50.238` | `v0.50.250` |
 | [@frap129](https://github.com/frap129) | 4 | `v0.50.140` | `v0.50.233` |
 | [@KingBoyAndGirl](https://github.com/KingBoyAndGirl) | 4 | `v0.50.238` | `v0.50.240` |
+| [@LumenYoung](https://github.com/LumenYoung) | 4 | `v0.51.47` | `v0.51.55` |
 | [@qxxaa](https://github.com/qxxaa) | 4 | `v0.50.233` | `v0.51.37` |
 | [@renheqiang](https://github.com/renheqiang) | 4 | `v0.50.61` | `v0.50.95` |
 | [@Thanatos-Z](https://github.com/Thanatos-Z) | 4 | `v0.50.257` | `v0.50.278` |
 | [@AlexeyDsov](https://github.com/AlexeyDsov) | 3 | `v0.50.267` | `v0.50.278` |
 | [@deboste](https://github.com/deboste) | 3 | `v0.50.269` | `v0.50.297` |
 | [@dutchaiagency](https://github.com/dutchaiagency) | 3 | `v0.50.281` | `v0.50.286` |
+| [@lucasrc](https://github.com/lucasrc) | 3 | `v0.51.57` | `v0.51.57` |
 | [@pavolbiely](https://github.com/pavolbiely) | 3 | `v0.50.159` | `v0.50.233` |
 
-## Two-PR contributors (14)
+## Two-PR contributors (19)
 
-[@ChaseFlorell](https://github.com/ChaseFlorell), [@dobby-d-elf](https://github.com/dobby-d-elf), [@gabogabucho](https://github.com/gabogabucho), [@hacker1e7](https://github.com/hacker1e7), [@lost9999](https://github.com/lost9999), [@mmartial](https://github.com/mmartial), [@nickgiulioni1](https://github.com/nickgiulioni1), [@renatomott](https://github.com/renatomott), [@ruxme](https://github.com/ruxme), [@Saik0s](https://github.com/Saik0s), [@shruggr](https://github.com/shruggr), [@TaraTheStar](https://github.com/TaraTheStar), [@vansour](https://github.com/vansour), [@zichen0116](https://github.com/zichen0116).
+[@ChaseFlorell](https://github.com/ChaseFlorell), [@gabogabucho](https://github.com/gabogabucho), [@hacker1e7](https://github.com/hacker1e7), [@hualong1009](https://github.com/hualong1009), [@lost9999](https://github.com/lost9999), [@michael-dg](https://github.com/michael-dg), [@mmartial](https://github.com/mmartial), [@MrFant](https://github.com/MrFant), [@nickgiulioni1](https://github.com/nickgiulioni1), [@renatomott](https://github.com/renatomott), [@ruxme](https://github.com/ruxme), [@Saik0s](https://github.com/Saik0s), [@samuelgudi](https://github.com/samuelgudi), [@shruggr](https://github.com/shruggr), [@TaraTheStar](https://github.com/TaraTheStar), [@vansour](https://github.com/vansour), [@vcavichini](https://github.com/vcavichini), [@xz-dev](https://github.com/xz-dev), [@zichen0116](https://github.com/zichen0116).
 
-## Single-PR contributors (85)
+## Single-PR contributors (84)
 
 Each of these folks landed exactly one PR that shipped — a bug fix, a locale, a security hardening, a doc improvement, an infrastructure tweak. Every one moved the project forward.
 
-[@29n](https://github.com/29n), [@amlyczz](https://github.com/amlyczz), [@andrewy-wizard](https://github.com/andrewy-wizard), [@Argonaut790](https://github.com/Argonaut790), [@Asunfly](https://github.com/Asunfly), [@betamod](https://github.com/betamod), [@Bobby9228](https://github.com/Bobby9228), [@bschmidy10](https://github.com/bschmidy10), [@carlytwozero](https://github.com/carlytwozero), [@davidsben](https://github.com/davidsben), [@DavidSchuchert](https://github.com/DavidSchuchert), [@DelightRun](https://github.com/DelightRun), [@DrMaks22](https://github.com/DrMaks22), [@eba8](https://github.com/eba8), [@eov128](https://github.com/eov128), [@galvani](https://github.com/galvani), [@GeoffBao](https://github.com/GeoffBao), [@georgebdavis](https://github.com/georgebdavis), [@GiggleSamurai](https://github.com/GiggleSamurai), [@hacker2005](https://github.com/hacker2005), [@halmisen](https://github.com/halmisen), [@hermes-gimmethebeans](https://github.com/hermes-gimmethebeans), [@hi-friday](https://github.com/hi-friday), [@hualong1009](https://github.com/hualong1009), [@huangzt](https://github.com/huangzt), [@indigokarasu](https://github.com/indigokarasu), [@insecurejezza](https://github.com/insecurejezza), [@jeffscottward](https://github.com/jeffscottward), [@Jellypowered](https://github.com/Jellypowered), [@jimdawdy-hub](https://github.com/jimdawdy-hub), [@JinYue-GitHub](https://github.com/JinYue-GitHub), [@joaompfp](https://github.com/joaompfp), [@jundev0001](https://github.com/jundev0001), [@KayZz69](https://github.com/KayZz69), [@kcclaw001](https://github.com/kcclaw001), [@kevin-ho](https://github.com/kevin-ho), [@koshikai](https://github.com/koshikai), [@kowenhaoai](https://github.com/kowenhaoai), [@lawrencel1ng](https://github.com/lawrencel1ng), [@likawa3b](https://github.com/likawa3b), [@lucky-yonug](https://github.com/lucky-yonug), [@lx3133584](https://github.com/lx3133584), [@MacLeodMike](https://github.com/MacLeodMike), [@mangodxd](https://github.com/mangodxd), [@mariosam95](https://github.com/mariosam95), [@MatzAgent](https://github.com/MatzAgent), [@mbac](https://github.com/mbac), [@michael-dg](https://github.com/michael-dg), [@migueltavares](https://github.com/migueltavares), [@mittyok](https://github.com/mittyok), [@ng-technology-llc](https://github.com/ng-technology-llc), [@octo-patch](https://github.com/octo-patch), [@rhelmer](https://github.com/rhelmer), [@rickchew](https://github.com/rickchew), [@ryan-remeo](https://github.com/ryan-remeo), [@ryansombraio](https://github.com/ryansombraio), [@s905060](https://github.com/s905060), [@samuelgudi](https://github.com/samuelgudi), [@SaulgoodMan-C](https://github.com/SaulgoodMan-C), [@sbe27](https://github.com/sbe27), [@shaoxianbilly](https://github.com/shaoxianbilly), [@sheng-di](https://github.com/sheng-di), [@sixianli](https://github.com/sixianli), [@skspade](https://github.com/skspade), [@smurmann](https://github.com/smurmann), [@snuffxxx](https://github.com/snuffxxx), [@spektro33](https://github.com/spektro33), [@Stampede](https://github.com/Stampede), [@suinia](https://github.com/suinia), [@sunnysktsang](https://github.com/sunnysktsang), [@tgaalman](https://github.com/tgaalman), [@thadreber-web](https://github.com/thadreber-web), [@the-own-lab](https://github.com/the-own-lab), [@tomaioo](https://github.com/tomaioo), [@trucuit](https://github.com/trucuit), [@vcavichini](https://github.com/vcavichini), [@vCillusion](https://github.com/vCillusion), [@vikarag](https://github.com/vikarag), [@wali-reheman](https://github.com/wali-reheman), [@watzon](https://github.com/watzon), [@woaijiadanoo](https://github.com/woaijiadanoo), [@xingyue52077](https://github.com/xingyue52077), [@yunyunyunyun-yun](https://github.com/yunyunyunyun-yun), [@yzp12138](https://github.com/yzp12138), [@zenc-cp](https://github.com/zenc-cp).
+[@29n](https://github.com/29n), [@amlyczz](https://github.com/amlyczz), [@andrewy-wizard](https://github.com/andrewy-wizard), [@Argonaut790](https://github.com/Argonaut790), [@Asunfly](https://github.com/Asunfly), [@ayushere](https://github.com/ayushere), [@betamod](https://github.com/betamod), [@Bobby9228](https://github.com/Bobby9228), [@bschmidy10](https://github.com/bschmidy10), [@carlytwozero](https://github.com/carlytwozero), [@davidsben](https://github.com/davidsben), [@DavidSchuchert](https://github.com/DavidSchuchert), [@DelightRun](https://github.com/DelightRun), [@DrMaks22](https://github.com/DrMaks22), [@eba8](https://github.com/eba8), [@eov128](https://github.com/eov128), [@galvani](https://github.com/galvani), [@GeoffBao](https://github.com/GeoffBao), [@georgebdavis](https://github.com/georgebdavis), [@GiggleSamurai](https://github.com/GiggleSamurai), [@hacker2005](https://github.com/hacker2005), [@halmisen](https://github.com/halmisen), [@hermes-gimmethebeans](https://github.com/hermes-gimmethebeans), [@hi-friday](https://github.com/hi-friday), [@huangzt](https://github.com/huangzt), [@indigokarasu](https://github.com/indigokarasu), [@insecurejezza](https://github.com/insecurejezza), [@jeffscottward](https://github.com/jeffscottward), [@Jellypowered](https://github.com/Jellypowered), [@jimdawdy-hub](https://github.com/jimdawdy-hub), [@JinYue-GitHub](https://github.com/JinYue-GitHub), [@joaompfp](https://github.com/joaompfp), [@jundev0001](https://github.com/jundev0001), [@KayZz69](https://github.com/KayZz69), [@kcclaw001](https://github.com/kcclaw001), [@kevin-ho](https://github.com/kevin-ho), [@koshikai](https://github.com/koshikai), [@kowenhaoai](https://github.com/kowenhaoai), [@lawrencel1ng](https://github.com/lawrencel1ng), [@legeantbleu](https://github.com/legeantbleu), [@likawa3b](https://github.com/likawa3b), [@lucky-yonug](https://github.com/lucky-yonug), [@lx3133584](https://github.com/lx3133584), [@MacLeodMike](https://github.com/MacLeodMike), [@mangodxd](https://github.com/mangodxd), [@mariosam95](https://github.com/mariosam95), [@MatzAgent](https://github.com/MatzAgent), [@mbac](https://github.com/mbac), [@migueltavares](https://github.com/migueltavares), [@mittyok](https://github.com/mittyok), [@ng-technology-llc](https://github.com/ng-technology-llc), [@octo-patch](https://github.com/octo-patch), [@plerohellec](https://github.com/plerohellec), [@rhelmer](https://github.com/rhelmer), [@rickchew](https://github.com/rickchew), [@ryan-remeo](https://github.com/ryan-remeo), [@ryansombraio](https://github.com/ryansombraio), [@s905060](https://github.com/s905060), [@SaulgoodMan-C](https://github.com/SaulgoodMan-C), [@sbe27](https://github.com/sbe27), [@shaoxianbilly](https://github.com/shaoxianbilly), [@sheng-di](https://github.com/sheng-di), [@sixianli](https://github.com/sixianli), [@skspade](https://github.com/skspade), [@smurmann](https://github.com/smurmann), [@snuffxxx](https://github.com/snuffxxx), [@spektro33](https://github.com/spektro33), [@Stampede](https://github.com/Stampede), [@suinia](https://github.com/suinia), [@sunnysktsang](https://github.com/sunnysktsang), [@tgaalman](https://github.com/tgaalman), [@thadreber-web](https://github.com/thadreber-web), [@the-own-lab](https://github.com/the-own-lab), [@tomaioo](https://github.com/tomaioo), [@trucuit](https://github.com/trucuit), [@vCillusion](https://github.com/vCillusion), [@vikarag](https://github.com/vikarag), [@wali-reheman](https://github.com/wali-reheman), [@watzon](https://github.com/watzon), [@woaijiadanoo](https://github.com/woaijiadanoo), [@xingyue52077](https://github.com/xingyue52077), [@yunyunyunyun-yun](https://github.com/yunyunyunyun-yun), [@yzp12138](https://github.com/yzp12138), [@zenc-cp](https://github.com/zenc-cp).
 
 ---
 
@@ -70,7 +73,7 @@ Each of these folks landed exactly one PR that shipped — a bug fix, a locale, 
 Most PRs in this repo land via one of four paths:
 
 1. **Direct merge** — your PR is reviewed and merged on its own. Author shows up directly in `git log` and on the PR's `merged_at` timestamp.
-2. **Squash into a batch release** — your PR is merged together with several other contributor PRs into a single release commit (e.g. `release: v0.51.44 — 5-PR contributor batch`). The original PR closes (not merges) on GitHub but the squashed release commit carries a `Co-authored-by: <you>` trailer plus an entry in `CHANGELOG.md` crediting you by username and PR number.
+2. **Squash into a batch release** — your PR is merged together with several other contributor PRs into a single release commit (e.g. `release: v0.51.55 — 9-PR contributor batch`). The original PR closes (not merges) on GitHub but the squashed release commit carries a `Co-authored-by: <you>` trailer plus an entry in `CHANGELOG.md` crediting you by username and PR number.
 3. **Salvaged from a larger PR** — when a PR mixes one good change with several unrelated or risky ones, we split it: the good parts ship in a clean follow-up PR, you get credit in the CHANGELOG entry, and the original PR is closed with a salvage map showing what went where.
 4. **Auto-rebase + auto-fix** — for merge-ready contributor PRs with mechanical blockers (CHANGELOG conflicts, lint, drifted tests), a maintainer rebases the contributor's branch, fixes the blockers, and force-pushes back. The `Co-authored-by` trailer preserves your authorship.
 
@@ -79,15 +82,19 @@ All four paths count as a contribution. GitHub's `merged_at` field only catches 
 ## Special thanks
 
 - **[@aronprins](https://github.com/aronprins)** — `v0.50.0` UI overhaul (PR #242). The CSS-only redesign that defined the design tokens, theme architecture, and three-panel layout that the rest of the app builds on. PR #242 didn't merge as-is, but it is the design language of the app.
-- **[@franksong2702](https://github.com/franksong2702)** — most prolific external contributor across the project's history. 92 PRs spanning the session sidebar, mobile/responsive layout, workspace state machine, profile context, slash autocomplete, breadcrumb navigation, streaming-session exemption, cron output preservation, embedded terminal, and a long tail of polish.
-- **[@Michaelyklam](https://github.com/Michaelyklam)** — most prolific contributor of late-2025/early-2026. 81 PRs covering Docker hardening, profile-scoped skills, KaTeX delimiter parsing, Codex quota surfacing, Goal command, Kanban polish, auto-compression toast lifetime, and the localization parity backfills.
-- **[@bergeouss](https://github.com/bergeouss)** — provider-management UI, OAuth status, two-container Docker docs, profile isolation hardening, Reveal-in-Finder, the OpenRouter free-tier live fetch, and most of Settings → Providers. 61 PRs.
-- **[@ai-ag2026](https://github.com/ai-ag2026)** — autonomous-AI contributor (Hermes Agent-driven). 49 PRs focused on session recovery (state.db sidecar reconciliation, orphan `.bak` recovery, audit + safe-repair endpoints), workspace/run lifecycle health, and the crash-safe turn-journal RFC.
+- **[@franksong2702](https://github.com/franksong2702)** — most prolific external contributor across the project's history. 117 PRs spanning the session sidebar, mobile/responsive layout, workspace state machine, profile context, slash autocomplete, breadcrumb navigation, streaming-session exemption, cron output preservation, embedded terminal, the manual-compress async start/status endpoint pair, the worktree status surface (PR #2109) + guarded remove (PR #2156) for the lifecycle umbrella #2057, session post-render dedup (PR #2166), the `/api/session` native-WebUI fast path (PR #2170), tail-window response trim (PR #2171), the second-wave stale-stream guard extension (PR #2158), CSP report collector (PR #2160), and the long tail of polish.
+- **[@Michaelyklam](https://github.com/Michaelyklam)** — most prolific contributor of late-2025/early-2026. 92 PRs covering Docker hardening, profile-scoped skills, KaTeX delimiter parsing, Codex quota surfacing, Goal command, Kanban polish, auto-compression toast lifetime, the localization parity backfills, the v0.51.51 mobile Insights bucketing/layout pair (PRs #2120/#2121), the Hermes run adapter RFC (PR #2105 for #1925), the fork-from-here absolute-index fix (PR #2198 for #2184), and the opencode-go custom-provider overlap routing fix (PR #2204 for #1894).
+- **[@bergeouss](https://github.com/bergeouss)** — provider-management UI, OAuth status, two-container Docker docs, profile isolation hardening, Reveal-in-Finder, the OpenRouter free-tier live fetch, and most of Settings → Providers. 62 PRs.
+- **[@ai-ag2026](https://github.com/ai-ag2026)** — autonomous-AI contributor (Hermes Agent-driven). 55 PRs focused on session recovery (state.db sidecar reconciliation, orphan `.bak` recovery, audit + safe-repair endpoints), workspace/run lifecycle health, the crash-safe turn-journal RFC, the append-only turn-journal helper (PR #2059), the matching lifecycle-events layer (PR #2062), the `Content-Security-Policy-Report-Only` header (PR #2084), and the per-cron toast notification toggle (PR #2100).
+- **[@Jordan-SkyLF](https://github.com/Jordan-SkyLF)** — Live streaming, session recovery, workspace fallback, and a recent burst of presentation polish: the manual "Refresh usage" button on the Provider quota card (PR #2150), cancelled-turn status classification (PR #2151), Firefox sidebar scroll stabilization (PR #2200), early provisional session titles (PR #2202), target-aware "What's new?" links (PR #2207), and MCP tools overflow fix in Settings (PR #2210). 12 PRs total.
+- **[@LumenYoung](https://github.com/LumenYoung)** — newer contributor focused on the streaming hot path's correctness. 4 PRs including the original stale-stream writeback guard (PR #2136 — the bug class the next two releases extended), gateway-state alive-null classification (PR #2075), compression-banner anchor alignment (PR #2182), and context-progress ring auto-refresh on compression complete (PR #2188).
 - **[@iRonin](https://github.com/iRonin)** — security hardening sprint (PRs #196–#204): session memory leak fix, CSP + Permissions-Policy headers, slow-client connection timeout, optional HTTPS/TLS, upstream branch tracking, CLI session file-browser support. Six consecutive, focused, high-quality security PRs.
 - **[@indigokarasu](https://github.com/indigokarasu)** — visual redesign proposal (PR #213). Icon rail sidebar, design token system, 7 themes. Didn't merge as-is but shaped the design language that landed in v0.50.0.
 - **[@zenc-cp](https://github.com/zenc-cp)** — anti-hallucination guard for the ReAct loop (PR #133). Three-layer approach (ephemeral prompt, live token filtering, session-history cleanup) that the streaming pipeline still uses.
-- **[@Jordan-SkyLF](https://github.com/Jordan-SkyLF)** — live streaming, session recovery, workspace fallback (PRs #366, #367, #394–#397). Six interlocking improvements that landed across v0.50.18–v0.50.27.
 - **[@deboste](https://github.com/deboste)** — reverse-proxy auth, mobile responsive layout, model routing (PRs #3, #4, #5). Three of the very first community PRs. Early foundation work.
 - **[@Hinotoi-agent](https://github.com/Hinotoi-agent)** — security fixes spanning profile `.env` isolation (PR #351), session-import workspace validation (PR #2048), and bandit B105 hardening. Subtle, high-leverage credential and path-traversal fixes.
+- **[@lucasrc](https://github.com/lucasrc)** — auth-hardening trilogy in v0.51.57 (PRs #2191/#2192/#2193): thread-safe login rate limiter with PBKDF2 key separation, password-hash cache invalidation on settings change, and the full 64-char HMAC-SHA256 session signature with backwards-compatible migration bridge. Three coordinated security PRs that landed together.
+- **[@jasonjcwu](https://github.com/jasonjcwu)** — composer and transcript polish, 16 PRs. Recent: silent compress-status during session switch (PR #2185), concurrent-send loss fix (PR #2186), in-transcript steer message badge (PR #2187), plus sidebar collapse via active-rail click (PR #2054).
+- **[@dobby-d-elf](https://github.com/dobby-d-elf)** — frontend reliability and motion polish: workspace fallback on deleted directories (PR #2138), iPhone PWA bottom-scroll fix (PR #2143), the new "Activity: X tools" composer footer animation (PR #2203) and its follow-up tuning (PR #2212).
 
 If you've contributed and aren't here, **open a PR**. We cross-check the CHANGELOG on every release, but if a credit fell through (a Co-authored-by trailer that didn't make it into the changelog entry, an attribution in a PR comment that should be in the release notes), this list is the right place to fix it.

--- a/README.md
+++ b/README.md
@@ -551,44 +551,47 @@ State lives outside the repo at `~/.hermes/webui/` by default
 
 Hermes WebUI is built with help from the open-source community. Every PR — whether merged directly, absorbed into a batch release, or salvaged from a larger proposal — shapes the project, and we're grateful to everyone who has taken the time to contribute.
 
-**130 contributors have shipped code that landed in a release tag** as of v0.51.44. The full credit roll lives in [`CONTRIBUTORS.md`](CONTRIBUTORS.md). The highlights:
+**137 contributors have shipped code that landed in a release tag** as of v0.51.58. The full credit roll lives in [`CONTRIBUTORS.md`](CONTRIBUTORS.md). The highlights:
 
 ### Top contributors (by PR count, including absorbed/batch-released work)
 
 | # | Contributor | PRs | First → latest release |
 |---|---|---:|---|
-| 1 | [@franksong2702](https://github.com/franksong2702) | 92 | `v0.49.3` → `v0.51.44` |
-| 2 | [@Michaelyklam](https://github.com/Michaelyklam) | 81 | `v0.50.240` → `v0.51.40` |
-| 3 | [@bergeouss](https://github.com/bergeouss) | 61 | `v0.48.0` → `v0.51.18` |
-| 4 | [@ai-ag2026](https://github.com/ai-ag2026) | 49 | `v0.50.279` → `v0.51.44` |
-| 5 | [@dso2ng](https://github.com/dso2ng) | 21 | `v0.50.227` → `v0.51.37` |
-| 6 | [@jasonjcwu](https://github.com/jasonjcwu) | 13 | `v0.50.227` → `v0.51.43` |
-| 7 | [@aronprins](https://github.com/aronprins) | 10 | `v0.44.0` → `v0.50.233` |
-| 8 | [@JKJameson](https://github.com/JKJameson) | 10 | `v0.50.233` → `v0.51.31` |
-| 9 | [@ccqqlo](https://github.com/ccqqlo) | 9 | `v0.44.0` → `v0.50.270` |
-| 10 | [@24601](https://github.com/24601) | 8 | `v0.50.233` → `v0.51.5` |
+| 1 | [@franksong2702](https://github.com/franksong2702) | 117 | `v0.49.3` → `v0.51.58` |
+| 2 | [@Michaelyklam](https://github.com/Michaelyklam) | 92 | `v0.50.240` → `v0.51.57` |
+| 3 | [@bergeouss](https://github.com/bergeouss) | 62 | `v0.48.0` → `v0.51.46` |
+| 4 | [@ai-ag2026](https://github.com/ai-ag2026) | 55 | `v0.50.279` → `v0.51.47` |
+| 5 | [@dso2ng](https://github.com/dso2ng) | 23 | `v0.50.227` → `v0.51.51` |
+| 6 | [@jasonjcwu](https://github.com/jasonjcwu) | 16 | `v0.50.227` → `v0.51.55` |
+| 7 | [@Jordan-SkyLF](https://github.com/Jordan-SkyLF) | 12 | `v0.50.18` → `v0.51.58` |
+| 8 | [@aronprins](https://github.com/aronprins) | 10 | `v0.44.0` → `v0.50.233` |
+| 9 | [@JKJameson](https://github.com/JKJameson) | 10 | `v0.50.233` → `v0.51.31` |
+| 10 | [@starship-s](https://github.com/starship-s) | 10 | `v0.50.128` → `v0.51.58` |
 
-See [`CONTRIBUTORS.md`](CONTRIBUTORS.md) for the full ranked list of all 130 contributors, including everyone with one or two PRs and the special-thanks roll for design and architectural contributions.
+See [`CONTRIBUTORS.md`](CONTRIBUTORS.md) for the full ranked list of all 137 contributors, including everyone with one or two PRs and the special-thanks roll for design and architectural contributions.
 
 ### Notable contributions
 
-**[@franksong2702](https://github.com/franksong2702)** — Most prolific external contributor (92 PRs, `v0.49.3` → `v0.51.44`)
-Across the longest tenure of any external contributor: the session title guard (#301), breadcrumb workspace navigation (#302), embedded workspace terminal (#1099), worktree-backed session creation (#2053), onboarding documentation (#2052), composer footer container queries, streaming-session sidebar exemption (#1327), session sidecar repair, cron output preservation (#1295), profile default workspace persistence, and a long tail of polish across mobile/responsive, the session sidebar, and the workspace state machine.
+**[@franksong2702](https://github.com/franksong2702)** — Most prolific external contributor (117 PRs, `v0.49.3` → `v0.51.58`)
+Across the longest tenure of any external contributor: the session title guard (#301), breadcrumb workspace navigation (#302), embedded workspace terminal (#1099), worktree-backed session creation (#2053), onboarding documentation (#2052), composer footer container queries, streaming-session sidebar exemption (#1327), session sidecar repair, cron output preservation (#1295), profile default workspace persistence, manual `/compress` async start/status endpoints (#2128), worktree status surface (#2109) + guarded remove (#2156) for the lifecycle umbrella #2057, session post-render dedup (#2166), native-WebUI fast path (#2170), tail-window response trim (#2171), stale-stream guard extension (#2158), CSP report collector (#2160), and a long tail of polish across mobile/responsive, the session sidebar, and the workspace state machine.
 
-**[@Michaelyklam](https://github.com/Michaelyklam)** — Most prolific contributor of recent releases (81 PRs, `v0.50.240` → `v0.51.40`)
-Production Docker hardening (#1921, drops sudo-capable staging user), profile-scoped skills endpoints (#1903), gateway PID resolution under profile-scoped HERMES_HOME (#1901), profile-aware AIAgent cache (#1898/#1904), backslash LaTeX delimiters (#1848), Codex quota error surfacing (#1770), shell-route HTML 503 (#1836), stale Kanban client recovery (#1828), context auto-compression toast lifetime (#1988), `/goal` command (#1866), Kanban detail-view scrolling (#1916), CLI session tool metadata preservation (#1778), Traditional Chinese kanban locale backfill (#1979).
+**[@Michaelyklam](https://github.com/Michaelyklam)** — Most prolific contributor of recent releases (92 PRs, `v0.50.240` → `v0.51.57`)
+Production Docker hardening (#1921, drops sudo-capable staging user), profile-scoped skills endpoints (#1903), gateway PID resolution under profile-scoped HERMES_HOME (#1901), profile-aware AIAgent cache (#1898/#1904), backslash LaTeX delimiters (#1848), Codex quota error surfacing (#1770), shell-route HTML 503 (#1836), stale Kanban client recovery (#1828), context auto-compression toast lifetime (#1988), `/goal` command (#1866), Kanban detail-view scrolling (#1916), CLI session tool metadata preservation (#1778), Traditional Chinese kanban locale backfill (#1979), v0.51.51 mobile Insights bucketing/layout (#2120/#2121), Hermes run adapter RFC (#2105 for #1925), fork-from-here absolute index (#2198 for #2184), opencode-go custom-provider overlap routing (#2204 for #1894).
 
-**[@bergeouss](https://github.com/bergeouss)** — Provider management UI + Docker hardening (61 PRs, `v0.48.0` → `v0.51.18`)
+**[@bergeouss](https://github.com/bergeouss)** — Provider management UI + Docker hardening (62 PRs, `v0.48.0` → `v0.51.46`)
 Provider management UI for adding/editing custom providers from Settings, OAuth provider status detection (#1552), two-container Docker setup, profile isolation hardening (per-profile `.env` secrets), the bulk of what users see when they touch Settings → Providers, Reveal-in-Finder context menu (#1551), gateway status card (#1552), auto-assign session to active project filter (#1550), "What's new?" link in update banner (#1549), OpenRouter free-tier live fetch (#1548), credential pool 401 self-heal (#1553), inline provider chip + group model count in model picker (#1644).
 
-**[@ai-ag2026](https://github.com/ai-ag2026)** — Session recovery + audit infrastructure (49 PRs, `v0.50.279` → `v0.51.44`)
-Autonomous-AI contributor (Hermes Agent-driven) focused on durability: `state.db`-backed sidecar reconciliation (#2041), orphan `.json.bak` recovery on startup (#2035), read-only session recovery audit endpoints (#2036, #2040), active run lifecycle in `/health` (#2039), crash-safe turn-journal RFC at `docs/rfcs/turn-journal.md` (#2042), fork-session compression lineage isolation (#2014).
+**[@ai-ag2026](https://github.com/ai-ag2026)** — Session recovery + audit infrastructure (55 PRs, `v0.50.279` → `v0.51.47`)
+Autonomous-AI contributor (Hermes Agent-driven) focused on durability: `state.db`-backed sidecar reconciliation (#2041), orphan `.json.bak` recovery on startup (#2035), read-only session recovery audit endpoints (#2036, #2040), active run lifecycle in `/health` (#2039), crash-safe turn-journal RFC at `docs/rfcs/turn-journal.md` (#2042), append-only turn-journal helper (#2059), lifecycle events layer (#2062), `Content-Security-Policy-Report-Only` header (#2084), per-cron toast toggle (#2100), fork-session compression lineage isolation (#2014).
 
-**[@dso2ng](https://github.com/dso2ng)** — Session lineage + diagnostics (21 PRs, `v0.50.227` → `v0.51.37`)
-`/api/session/lineage-report/<sid>` endpoint for bounded session graph diagnostics (#2012), stale Mermaid render error cleanup (#1337), and a long tail of frontend reliability fixes around session loading.
+**[@dso2ng](https://github.com/dso2ng)** — Session lineage + diagnostics (23 PRs, `v0.50.227` → `v0.51.51`)
+`/api/session/lineage-report/<sid>` endpoint for bounded session graph diagnostics (#2012), stale Mermaid render error cleanup (#1337), `session_source="fork"` continuation-chain isolation (#2063), lazy lineage-report fetch on sidebar badge expand (#2130), and a long tail of frontend reliability fixes around session loading.
 
-**[@jasonjcwu](https://github.com/jasonjcwu)** — Composer + transcript polish (13 PRs, `v0.50.227` → `v0.51.43`)
-Sidebar collapse via active-rail click (#2054, fuses #1884 + #1924), composer chip lightbox (#1758), title fixes for tool-heavy first turns, and a string of frontend polish fixes.
+**[@jasonjcwu](https://github.com/jasonjcwu)** — Composer + transcript polish (16 PRs, `v0.50.227` → `v0.51.55`)
+Sidebar collapse via active-rail click (#2054, fuses #1884 + #1924), composer chip lightbox (#1758), title fixes for tool-heavy first turns, silent compress-status during session switch (#2185), concurrent-send loss fix (#2186), in-transcript steer message badges (#2187), and a string of frontend polish fixes.
+
+**[@Jordan-SkyLF](https://github.com/Jordan-SkyLF)** — Live streaming + UX polish (12 PRs, `v0.50.18` → `v0.51.58`)
+Original sprint of workspace fallback resolution, live reasoning cards (#366, #367, #394–#397), then a recent burst: manual "Refresh usage" button on the Provider quota card (#2150), cancelled-turn status classification (#2151), Firefox sidebar scroll stabilization (#2200), early provisional session titles (#2202), target-aware "What's new?" update-banner links (#2207), and MCP tools overflow fix in Settings (#2210).
 
 **[@aronprins](https://github.com/aronprins)** — `v0.50.0` UI overhaul (PR #242, plus 9 follow-ups)
 The biggest single contribution to the project: a complete UI redesign that moved model/profile/workspace controls into the composer footer, replaced the gear-icon settings panel with the Hermes Control Center (tabbed modal), removed the activity bar in favor of inline composer status, redesigned the session list with a `⋯` action dropdown, and added the workspace panel state machine. Plus chat transcript redesign (#587), sidebar declutter (#584), three-column layout refactor (#899), light/dark theme + accent skins (#627), and shared `confirm()`/`prompt()` dialog replacement (PR #251 extracted from #242).
@@ -596,8 +599,14 @@ The biggest single contribution to the project: a complete UI redesign that move
 **[@iRonin](https://github.com/iRonin)** — Security hardening sprint (PRs #196–#204)
 Six consecutive, focused security PRs: session memory leak fix (expired token pruning), CSP + Permissions-Policy headers, 30-second slow-client connection timeout, optional HTTPS/TLS support via environment variables, upstream branch tracking fix for self-update, and CLI session support in the file-browser API. The kind of focused, high-quality security work that makes a self-hosted tool trustworthy.
 
-**[@Jordan-SkyLF](https://github.com/Jordan-SkyLF)** — Live streaming + session recovery (PRs #366, #367, #394–#397)
-Six interlocking improvements: workspace fallback resolution, live reasoning cards that upgrade the generic thinking spinner to a real-time reasoning display, durable session state recovery via `localStorage` so in-flight tool cards survive a page reload, plus relative time labels and imported-session timestamp preservation.
+**[@lucasrc](https://github.com/lucasrc)** — Auth-hardening trilogy (PRs #2191, #2192, #2193)
+Three coordinated security PRs that all landed in v0.51.57: thread-safe login rate limiter with PBKDF2 key separation, password-hash cache invalidation on Settings save, and the full 64-char HMAC-SHA256 session signature with a backwards-compatible migration bridge. The kind of cleanly-decomposed security work that's reviewable as three independent pieces.
+
+**[@LumenYoung](https://github.com/LumenYoung)** — Streaming hot-path correctness (4 PRs, `v0.51.47` → `v0.51.55`)
+The original stale-stream writeback guard (#2136 — the bug class the next two releases extended), gateway-state alive-null classification (#2075), compression-banner anchor alignment (#2182), and context-progress ring auto-refresh on compression complete (#2188). Each PR opened a small surgical fix in one of the most fragile subsystems in the codebase.
+
+**[@dobby-d-elf](https://github.com/dobby-d-elf)** — Frontend reliability + motion polish (6 PRs, `v0.51.38` → `v0.51.58`)
+Workspace fallback on deleted directories (#2138), iPhone PWA bottom-scroll fix (#2143), the new "Activity: X tools" composer footer shimmer animation (#2203), and follow-up animation tuning (#2212).
 
 **[@JKJameson](https://github.com/JKJameson)** — Composer + session polish (10 PRs)
 Persistent composer draft per session (#1956), and a long tail of polish across the composer and session sidebar.


### PR DESCRIPTION
## Summary

Refresh `CONTRIBUTORS.md` and the README contributor section to reflect the 14 releases shipped between v0.51.44 (last refresh) and v0.51.58 (today). Source of truth: `CHANGELOG.md` attribution lines (`**PR #N** by @user`).

Header bumps:
- **130 → 137** total contributors
- **568 → 646** PR credits
- **Last refreshed: v0.51.44 → v0.51.58**

## What changed since v0.51.44

20 distinct contributors got new attribution; 78 PRs total attributed in v0.51.45–Unreleased.

**7 first-time contributors:**

| Handle | New PRs | Bucket | Notable |
|---|---|---|---|
| [@lucasrc](https://github.com/lucasrc) | 3 | sustained | Auth-hardening trilogy in v0.51.57 (#2191/#2192/#2193) |
| [@LumenYoung](https://github.com/LumenYoung) | 4 | sustained | Stale-stream writeback guard (#2136) + 3 streaming correctness fixes |
| [@MrFant](https://github.com/MrFant) | 2 | two-PR | reasoning_content whitelist (#2201), message preservation (#2176) |
| [@xz-dev](https://github.com/xz-dev) | 2 | two-PR | Thinking-card state (#2190), session-scoped metering (#2189) |
| [@legeantbleu](https://github.com/legeantbleu) | 1 | single-PR | French (`fr`) locale (#2142) |
| [@ayushere](https://github.com/ayushere) | 1 | single-PR | ctl.sh bash 3.2 macOS compat (#2117) |
| [@plerohellec](https://github.com/plerohellec) | 1 | single-PR | (#2089) |

**Bucket promotions** (existing contributors who moved up):
- [@dobby-d-elf](https://github.com/dobby-d-elf): 2 → 6 PRs (two-PR → top contributors)
- [@samuelgudi](https://github.com/samuelgudi), [@michael-dg](https://github.com/michael-dg), [@vcavichini](https://github.com/vcavichini), [@hualong1009](https://github.com/hualong1009): single-PR → two-PR

**Top contributor count updates** (only contributors with new PRs since v0.51.44 shown):

| Contributor | Before | After | Δ | Latest release |
|---|---:|---:|---:|---|
| @franksong2702 | 92 | **117** | +25 | Unreleased |
| @Michaelyklam | 81 | **92** | +11 | v0.51.57 |
| @bergeouss | 61 | **62** | +1 | v0.51.46 |
| @ai-ag2026 | 49 | **55** | +6 | v0.51.47 |
| @dso2ng | 21 | **23** | +2 | v0.51.51 |
| @jasonjcwu | 13 | **16** | +3 | v0.51.55 |
| @Jordan-SkyLF | 6 | **12** | +6 | Unreleased |
| @starship-s | 8 | **10** | +2 | Unreleased |
| @dobby-d-elf | 2 | **6** | +4 | Unreleased |

## Notable contributions paragraphs updated

The README's "Notable contributions" section has been refreshed for every contributor with new shipped work. Major additions:

- **@franksong2702**: manual `/compress` async start/status pair (#2128), worktree status surface (#2109) + guarded remove (#2156) for the #2057 lifecycle umbrella, session post-render dedup (#2166), `/api/session` native-WebUI fast path (#2170), tail-window response trim (#2171), stale-stream guard extension (#2158), CSP report collector (#2160).
- **@Michaelyklam**: v0.51.51 mobile Insights bucketing/layout (#2120/#2121), Hermes run adapter RFC (#2105 for #1925), fork-from-here absolute index fix (#2198 for #2184), opencode-go custom-provider overlap routing (#2204 for #1894).
- **@ai-ag2026**: append-only turn-journal helper (#2059), lifecycle events layer (#2062), `Content-Security-Policy-Report-Only` header (#2084), per-cron toast toggle (#2100).
- **@dso2ng**: `session_source="fork"` continuation-chain isolation (#2063), lazy lineage-report fetch on sidebar badge expand (#2130).
- **@jasonjcwu**: silent compress-status during session switch (#2185), concurrent-send loss fix (#2186), in-transcript steer message badges (#2187).
- **@Jordan-SkyLF**: "Refresh usage" button (#2150), cancelled-turn status (#2151), Firefox sidebar scroll (#2200), early provisional titles (#2202), target-aware "What's new?" links (#2207), MCP tools overflow fix (#2210).
- **@LumenYoung** (new entry): stale-stream guard (#2136), gateway alive-null (#2075), compression banner anchor (#2182), context ring auto-refresh (#2188).
- **@lucasrc** (new entry): auth-hardening trilogy (#2191/#2192/#2193).
- **@dobby-d-elf** (new entry in top contributors): workspace fallback (#2138), iPhone PWA scroll (#2143), Activity sweep animation (#2203) + tuning (#2212).

## Verification

Cross-bucket sanity check passes: 21 top + 13 sustained + 19 two-PR + 84 single-PR = **137 unique handles**, no handle appears in multiple buckets.

Existing CONTRIBUTORS.md / README parity tests pass:

```
pytest tests/ -k "contributors or readme or attribution"
# 2 passed
```

## How the refresh was generated

1. Parsed CHANGELOG.md between v0.51.44 header and Unreleased to extract all `**PR #N** by @user` attribution lines.
2. Built `(user → set of new PRs)` delta map.
3. Applied to baseline counts parsed from existing CONTRIBUTORS.md.
4. Re-bucketed (5+, 3-4, 2, 1) and updated all four bucket lists.
5. For each top contributor with new PRs, rewrote their "Notable contributions" paragraph to include the new work, using the changelog entries as the source for one-line PR descriptions.
6. Verified cross-bucket disjointness + header totals before commit.

This is purely a docs refresh — no source code or test changes.
