### PR TITLE
fix: use documented aux model for update summaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
 
 - **PR #2234** by @Jordan-SkyLF (post-v0.51.61 rebase) — Update summary category handling now preserves all explicit `Notice:` and `Worth knowing:` bullets the summarizer returns instead of forcing a three-item split. Distinct categories are deduplicated against each other so the same content can't appear twice across sections. Keeps the existing fallback grouping when the model doesn't return explicit prefixes. The summary panel becomes scrollable when longer summaries need more vertical room. Caps large update-summary commit input to the latest 24 commit subjects and discloses that scope in the generated summary while keeping the full comparison link available.
 
+- **PR #2234** by @Jordan-SkyLF (follow-up to the v0.51.62 category refinement) — Update summary generation now prefers the documented `auxiliary.compression` text-model slot before falling back to the main configured model, avoiding a WebUI-only `auxiliary.update_summary` magic key that would not appear in Hermes Agent setup/config documentation.
+
 ### Added
 
 - **PR #2238** by @franksong2702 (fixes #2231) — Phone-width layouts (≤640px) keep the hamburger drawer entry pattern, but the drawer now lays out `.sidebar-nav` as a vertical 52px strip with stable 44px touch targets and a left-edge selection indicator instead of a cramped horizontal icon row. PWA chrome alignment: `theme-color` meta tag now follows the app chrome `--sidebar` color instead of the chat background `--bg`, so iOS Safari / PWA status bars visibly match the titlebar/sidebar. Phone composer also reserves the bottom safe area so it is not clipped by rounded corners or the home indicator. Before/after screenshots shipped under `docs/pr-media/2231/`.

--- a/api/routes.py
+++ b/api/routes.py
@@ -5467,8 +5467,12 @@ def handle_post(handler, parsed) -> bool:
             try:
                 from agent.auxiliary_client import get_text_auxiliary_client
 
+                # Update summaries are a short text-compression/summarization task.
+                # Reuse the documented auxiliary.compression slot instead of
+                # inventing a WebUI-only auxiliary task name that users cannot
+                # discover in the Hermes Agent setup/config UI.
                 aux_client, aux_model = get_text_auxiliary_client(
-                    "update_summary",
+                    "compression",
                     main_runtime=main_runtime,
                 )
                 if aux_client is not None and aux_model:

--- a/tests/test_update_banner_fixes.py
+++ b/tests/test_update_banner_fixes.py
@@ -419,13 +419,14 @@ class TestForceUpdateRoute:
 
 
 class TestUpdateSummaryRouteModelSelection:
-    """Update summaries should use the auxiliary update-summary model before main model fallback."""
+    """Update summaries should use a known text auxiliary model before main model fallback."""
 
-    def test_summary_route_prefers_update_summary_auxiliary_model(self):
+    def test_summary_route_prefers_documented_compression_auxiliary_model(self):
         src = read('api/routes.py')
 
         assert 'get_text_auxiliary_client' in src
-        assert '"update_summary"' in src
+        assert '"compression"' in src
+        assert '"update_summary"' not in src
         assert 'main_runtime=main_runtime' in src
         assert 'update summary auxiliary model failed; falling back to main model' in src
         assert 'from run_agent import AIAgent' in src


### PR DESCRIPTION
## Thinking Path
- The category-refinement portion of this PR shipped in v0.51.62 via stage-355.
- This branch is now rebased onto current `origin/master` so the PR carries only the remaining aux-model routing follow-up.
- The reviewer concern was that `auxiliary.update_summary` would be a WebUI-only magic key, not a documented Hermes Agent auxiliary task.

## What Changed
- Update-summary generation now asks for the documented `auxiliary.compression` text-model slot first.
- The existing main-model fallback is preserved if auxiliary resolution or generation fails.
- Added a route comment explaining why summary generation maps to compression/summarization instead of inventing a new task name.
- Updated focused regression coverage to assert the route uses `"compression"` and does not reintroduce `"update_summary"` in `api/routes.py`.
- Updated the changelog with the standalone aux-routing follow-up.

## Why It Matters
- Users can override summary generation through an existing documented auxiliary slot instead of guessing an undiscoverable WebUI-specific config key.
- The PR stays self-contained to `hermes-webui` and does not require a coordinated Hermes Agent registry/setup change.
- Existing installs without an auxiliary compression model still fall back to the configured main model.

## Before / After
- No visual before/after evidence is needed for this follow-up: the diff only changes model-routing selection and regression coverage.
- The update-summary UI/category behavior and screenshots from the earlier scope have already shipped in v0.51.62.

## Verification
- Rebased onto current `origin/master` at `18297f3aff71d11ac5951e064245ebd86e1c87aa`; latest release checked: `v0.51.62`.
- `python -m pytest tests/test_update_banner_fixes.py::TestUpdateSummaryRouteModelSelection -q` → `1 passed in 2.39s`
- `python -m pytest tests/test_update_banner_fixes.py::TestUpdateSummaryRouteModelSelection tests/test_update_banner_fixes.py::TestWhatsNewSummaryToggle -q` → `15 passed in 2.49s`
- `python -m pytest tests/test_update_banner_fixes.py -q` → `60 passed in 3.74s`
- `python -m py_compile api/routes.py api/updates.py`
- `node --check static/ui.js && node --check static/boot.js && node --check static/panels.js`
- `git diff --check origin/master...HEAD`

## Risks / Follow-ups
- Generated summary quality still depends on the configured `auxiliary.compression` model, or the main model when fallback is used.
- If maintainers later want a dedicated `update_summary` aux task, that should be registered/documented in Hermes Agent rather than introduced only in WebUI.

## Model Used
- OpenAI GPT-5.5 via Codex CLI, with local terminal/file tooling for GitHub PR refresh, rebase, tests, and verification.
