### PR TITLE
fix: load CLI continuation session transcripts

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -19,7 +19,11 @@ from api.config import (
     get_effective_default_model, _get_session_agent_lock,
 )
 from api.workspace import get_last_workspace
-from api.agent_sessions import read_importable_agent_session_rows, read_session_lineage_metadata
+from api.agent_sessions import (
+    _is_continuation_session,
+    read_importable_agent_session_rows,
+    read_session_lineage_metadata,
+)
 
 logger = logging.getLogger(__name__)
 CLI_VISIBLE_SESSION_LIMIT = 20
@@ -1805,7 +1809,6 @@ def get_cli_session_messages(sid) -> list:
     continuation chain, return the stitched full transcript across all segments
     in chronological order. Returns empty list on any error.
     """
-    import os
     if str(sid or '').startswith(f'{CLAUDE_CODE_SOURCE}_'):
         return get_claude_code_session_messages(sid)
     try:
@@ -1813,12 +1816,7 @@ def get_cli_session_messages(sid) -> list:
     except ImportError:
         return []
 
-    try:
-        from api.profiles import get_active_hermes_home
-        hermes_home = Path(get_active_hermes_home()).expanduser().resolve()
-    except Exception:
-        hermes_home = Path(os.getenv('HERMES_HOME', str(HOME / '.hermes'))).expanduser().resolve()
-    db_path = hermes_home / 'state.db'
+    db_path = _active_state_db_path()
     if not db_path.exists():
         return []
 

--- a/tests/test_session_lineage_full_transcript.py
+++ b/tests/test_session_lineage_full_transcript.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import sqlite3
+
+import api.models as models
 import api.routes as routes
 
 
@@ -123,3 +126,61 @@ def test_session_endpoint_preserves_distinct_messages_with_different_ids(monkeyp
     session = captured["payload"]["session"]
     retry_messages = [m for m in session["messages"] if m.get("content") == "retry the same request"]
     assert [m.get("id") for m in retry_messages] == ["cli-retry", "sidecar-retry"]
+
+
+
+def test_cli_continuation_session_opens_nonempty(monkeypatch, tmp_path):
+    db_path = tmp_path / "state.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """
+        CREATE TABLE sessions (
+            id TEXT PRIMARY KEY,
+            source TEXT,
+            parent_session_id TEXT,
+            started_at REAL,
+            ended_at REAL,
+            end_reason TEXT
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE messages (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT NOT NULL,
+            role TEXT NOT NULL,
+            content TEXT,
+            tool_calls TEXT,
+            tool_call_id TEXT,
+            name TEXT,
+            reasoning TEXT,
+            timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            metadata TEXT
+        )
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO sessions (id, source, parent_session_id, started_at, ended_at, end_reason)
+        VALUES
+            ('parent-session', 'telegram', NULL, 100.0, 200.0, 'cli_close'),
+            ('child-session', 'telegram', 'parent-session', 201.0, NULL, NULL)
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO messages (session_id, role, content, timestamp)
+        VALUES
+            ('parent-session', 'user', 'parent turn', '2026-05-14 10:00:01'),
+            ('child-session', 'assistant', 'child reply', '2026-05-14 10:01:01')
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    monkeypatch.setattr(models, '_active_state_db_path', lambda: db_path)
+
+    messages = models.get_cli_session_messages('child-session')
+
+    assert [message['content'] for message in messages] == ['parent turn', 'child reply']


### PR DESCRIPTION
## Summary
- import `_is_continuation_session` where `get_cli_session_messages()` stitches continuation chains
- reuse the existing active-profile state.db helper for easier focused coverage
- add regression coverage that a CLI/messaging continuation session returns a stitched, non-empty transcript

## Root cause
`get_cli_session_messages()` calls `_is_continuation_session()` while walking `parent_session_id` links, but `api/models.py` did not import that helper. The exception was swallowed by the defensive `except Exception: return []`, so valid external sessions could fall through to an empty transcript and the WebUI returned "Session not available in web UI."

## Test plan
- `python3 -m pytest tests/test_session_lineage_full_transcript.py -q -o 'addopts='`

## Related context
I checked current open PRs for overlapping session/lineage work. #2194 touches external session reconciliation, but current `origin/master` still has this missing import and no focused regression for this failure mode.
