### PR TITLE
fix: support rootless container runtimes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,8 +46,10 @@ WORKDIR /apptoo
 # UID/GID alignment and filesystem preparation, then execs the server as this user.
 RUN groupadd -g 1024 hermeswebui \
     && useradd -u 1024 -d /home/hermeswebui -g hermeswebui -G users -s /bin/bash -m hermeswebui \
-    && mkdir -p /app /uv_cache \
-    && chown -R hermeswebui:hermeswebui /home/hermeswebui /app /uv_cache
+    && mkdir -p /app /uv_cache /workspace \
+    && chown -R hermeswebui:hermeswebui /home/hermeswebui /app /uv_cache /workspace \
+    && chmod 0755 /home/hermeswebui \
+    && chmod 1777 /app /uv_cache /workspace
 
 COPY --chmod=555 docker_init.bash /hermeswebui_init.bash
 

--- a/docker_init.bash
+++ b/docker_init.bash
@@ -269,6 +269,11 @@ if [ -f $tmp_root_env ]; then
 fi
 
 ##
+if [ ! -f /app/server.py ] && [ -d /apptoo ]; then
+  echo ""; echo "-- Seeding /app from /apptoo (rootless startup)"
+  cp -a /apptoo/. /app/ || error_exit "Failed to seed /app from /apptoo (is /app writable by the runtime user?)"
+fi
+
 echo ""; echo "-- Verifying /app is writable by the hermeswebui runtime user"
 if [ ! -d /app ]; then error_exit "/app directory does not exist"; fi
 it=/app/.testfile; touch $it || error_exit "Failed to verify /app directory"


### PR DESCRIPTION
Rootless container runtimes (k8s `runAsNonRoot: true`, OpenShift restricted SCC, `docker --user`, rootless Podman) skip the root init phase in `docker_init.bash` and hit a cascade of permission errors:

1. `error: File not found: requirements.txt` — root branch rsyncs `/apptoo` → `/app`, rootless skips it.
2. `/uv_cache is not writable by hermeswebui` — `/uv_cache` baked at UID 1024.
3. `mkdir: cannot create directory '/home/hermeswebui'` — home baked mode 700, can't traverse into the `.hermes` mount.
4. `mkdir: cannot create directory '/workspace'` — `/` not writable.

**`docker_init.bash`**: seed `/app` from `/apptoo` on the rootless path, guarded by `/app/server.py` so it's idempotent and a no-op for the root flow (rsync already populated it).

**`Dockerfile`**: `/home/hermeswebui` → `0755` (traversable, standard home-dir mode; `uv` is preinstalled at `/usr/local/bin/uv` so writing to `~/.local/bin` isn't needed). `/app`, `/uv_cache`, `/workspace` → `1777`. Pre-create `/workspace` for the default `HERMES_WEBUI_DEFAULT_WORKSPACE`.

Docker-compose flow unchanged: the root init phase still chowns these to `WANTED_UID`/`WANTED_GID`, ending with the same effective ownership.

## Test plan

- [x] k8s pod, `runAsUser: 1000`, `runAsNonRoot: true`, no init container, no added capabilities — boots through to `python server.py`.
- [x] `docker-compose.yml` (single container) — unchanged.
- [x] `docker-compose.two-container.yml` — unchanged.
- [x] Restart with persistent `/app` — seed is a no-op.