### PR TITLE
Keep unknown update summary bullets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Update summaries now keep bullets with unexpected LLM prefixes such as `Caveat:` or `Action required:` as regular notice bullets instead of silently dropping them when other categorized notice bullets are present.
+
 ### Added
 
 - **PR #2099** by @dobby-d-elf — Adds an opt-in `Settings → Preferences → Fade text effect` toggle (off by default). When enabled, newly streamed output tokens are revealed through an adaptive playout buffer and animated with an opacity-only fade similar to ChatGPT and other frontier LLM apps. Implementation details: fade locked per stream to avoid mid-stream toggle rewind; reduced-motion users get non-animated text; live cursor hidden while fade is active; custom renderer on `streaming-markdown` parser wraps only newly-appended words; animated spans replace themselves with plain text on `animationend` (no long-lived wrapper buildup in long responses); unsafe streamed `href`/`src` values blocked in fade renderer `set_attr` path. Performance tuning: 200ms base fade duration scaling to 350ms for fast output, 16ms word stagger, 320ms done-drain wait cap, 160 wps visual cap, max 2-3 words/frame, brief pauses after sentence punctuation. Default-off means existing users see no change. 293-line regression test pinning the contract.

--- a/api/updates.py
+++ b/api/updates.py
@@ -417,6 +417,8 @@ def _categorized_summary_bullets_from_text(text: str) -> tuple[list[str], list[s
             notice_items.append(body)
         elif category == 'worth':
             worth_items.append(body)
+        elif re.match(r'^\s*(?:[-*•]+|\d+[.)])?\s*[A-Za-z][A-Za-z ]{1,32}\s*:', str(line or '')):
+            notice_items.append(body)
     return _unique_summary_bullets(notice_items), _unique_summary_bullets(worth_items)
 
 

--- a/tests/test_update_banner_fixes.py
+++ b/tests/test_update_banner_fixes.py
@@ -919,6 +919,32 @@ class TestWhatsNewSummaryToggle:
             'The full diff is still available from the update banner.',
         ]
 
+    def test_update_summary_keeps_unknown_prefixed_bullets_as_notice(self):
+        from api.updates import summarize_update_payload
+
+        result = summarize_update_payload(
+            {'webui': {'behind': 3, 'current_sha': 'abc', 'latest_sha': 'def', 'compare_url': 'https://example.test/webui'}},
+            llm_callback=lambda _system, _prompt: '\n'.join(
+                [
+                    'Notice: The settings panel loads faster.',
+                    'Caveat: Restart once after applying the update.',
+                    'Action required: Reopen the update banner if the summary was already cached.',
+                    'Worth knowing: The full diff is still available from the update banner.',
+                ]
+            ),
+            use_cache=False,
+        )
+        sections = {section['title']: section['items'] for section in result['summary_sections']}
+
+        assert sections["What you'll notice"] == [
+            'The settings panel loads faster.',
+            'Caveat: Restart once after applying the update.',
+            'Action required: Reopen the update banner if the summary was already cached.',
+        ]
+        assert sections['Worth knowing'] == [
+            'The full diff is still available from the update banner.',
+        ]
+
     def test_update_summary_panel_is_scrollable_for_long_summaries(self):
         style = read('static/style.css')
 


### PR DESCRIPTION
## Thinking Path

- The v0.51.62 review follow-up in #2264 had two small concerns.
- Current `master` already has `/api/session/archive` using `_ensure_full_session_before_mutation()`, so that half is no longer open.
- The remaining issue is update-summary parsing: once an LLM returns at least one recognized `Notice:` bullet, other unknown-prefixed bullets like `Caveat:` can fall through and disappear.
- The smallest safe fix is to keep unknown prefix-shaped bullets as regular notice bullets while preserving the existing sentence-splitting fallback for plain prose.

## What Changed

- Treat unrecognized prefix-shaped summary lines as `What you'll notice` items instead of dropping them.
- Preserve existing behavior for ordinary unprefixed prose summaries, which still fall back to sentence splitting.
- Added regression coverage for mixed `Notice:`, unknown-prefixed, and `Worth knowing:` update-summary output.
- Updated `CHANGELOG.md`.

## Why It Matters

Provider drift or retrying with a different model can produce prefixes outside the exact prompt contract. Keeping those bullets visible is safer than silently omitting potentially useful user-facing update notes.

## Verification

- `pytest tests/test_update_banner_fixes.py tests/test_updates.py tests/test_update_checker.py -q` → `78 passed`
- `python3 -m py_compile api/updates.py`
- `git diff --check`

## Risks / Follow-ups

- This intentionally does not broaden `_split_summary_category()` into an ever-growing list of labels.
- Unknown prefix text is preserved as written, including the prefix itself, so the user can still see the LLM's intended framing.
- The archive-helper half of #2264 was already resolved on current `master` before this PR.

## Model Used

OpenAI GPT-5 Codex via Codex CLI.

AI assisted with code inspection, implementation, test selection, and PR description drafting.

Closes #2264.
