### PR TITLE
[codex] Fix empty gateway session hiding messaging history

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -2162,10 +2162,16 @@ def _keep_latest_messaging_session_per_source(sessions: list[dict]) -> list[dict
     """Keep only the newest sidebar row per messaging session identity."""
     gateway_metadata = _load_gateway_session_identity_map()
     active_gateway_session_ids = {str(sid) for sid in gateway_metadata.keys() if sid}
+    session_ids = {
+        _safe_first(session.get("session_id"))
+        for session in sessions
+        if isinstance(session, dict)
+    }
+    visible_active_gateway_session_ids = active_gateway_session_ids & session_ids
     active_gateway_sources = {
         _normalize_messaging_source(_safe_first(meta.get("raw_source"), meta.get("platform")))
-        for meta in gateway_metadata.values()
-        if isinstance(meta, dict)
+        for sid, meta in gateway_metadata.items()
+        if sid in visible_active_gateway_session_ids and isinstance(meta, dict)
     }
     active_gateway_sources = {source for source in active_gateway_sources if _is_known_messaging_source(source)}
 
@@ -2177,7 +2183,7 @@ def _keep_latest_messaging_session_per_source(sessions: list[dict]) -> list[dict
         if not key:
             kept.append(session)
             continue
-        if _should_hide_stale_messaging_session(session, active_gateway_session_ids, active_gateway_sources):
+        if _should_hide_stale_messaging_session(session, visible_active_gateway_session_ids, active_gateway_sources):
             continue
         if key in kept_sources:
             kept_sources.add(key)

--- a/tests/test_gateway_sync.py
+++ b/tests/test_gateway_sync.py
@@ -827,6 +827,42 @@ def test_sessions_js_treats_email_as_messaging_source():
     assert "email: 'Email'" in src[src.find("_MESSAGING_SOURCE_LABELS"):src.find("function _isMessagingSession")]
 
 
+def test_empty_active_gateway_session_does_not_hide_messaging_history(monkeypatch):
+    """A zero-message active Gateway row must not hide older Discord history."""
+    import api.routes as routes
+
+    monkeypatch.setattr(
+        routes,
+        "_load_gateway_session_identity_map",
+        lambda: {
+            "discord_empty_active": {
+                "raw_source": "discord",
+                "platform": "discord",
+                "user_id": "user-1",
+            }
+        },
+    )
+
+    rows = [
+        {
+            "session_id": "discord_previous_history",
+            "title": "Previous Discord chat",
+            "source_tag": "discord",
+            "raw_source": "discord",
+            "session_source": "messaging",
+            "source_label": "Discord",
+            "user_id": "user-1",
+            "message_count": 7,
+            "updated_at": 100.0,
+            "end_reason": "session_reset",
+        }
+    ]
+
+    kept = routes._keep_latest_messaging_session_per_source(rows)
+
+    assert [row["session_id"] for row in kept] == ["discord_previous_history"]
+
+
 def test_cross_source_parent_child_is_not_collapsed_into_root_metadata(cleanup_test_sessions):
     """A WebUI continuation from a messaging parent must keep WebUI metadata.
 


### PR DESCRIPTION
## Summary
- Narrow messaging stale-session filtering to active gateway sessions that are present in the current sidebar candidate set.
- Preserve older messaging history when the gateway advertises a fresh zero-message session that is not visible yet.
- Add a regression test for an empty active Discord gateway row.

## Root cause
When the gateway advertised a fresh Discord session in sessions.json, the sidebar treated that source as active and hid older Discord rows as stale. If the fresh session had zero messages, it was omitted from the visible session projection, leaving no Discord rows visible.

## Validation
- /Users/junwon/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_gateway_sync.py