### PR TITLE
Fix profile-scoped auxiliary routing for background workers

### DIFF
--- a/api/profiles.py
+++ b/api/profiles.py
@@ -15,6 +15,7 @@ import re
 import shutil
 import sys
 import threading
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Optional
 
@@ -672,6 +673,69 @@ def get_profile_runtime_env(home: Path) -> dict[str, str]:
             logger.debug("Failed to read runtime env from %s", env_path)
 
     return env
+
+
+@contextmanager
+def profile_env_for_background_worker(
+    session,
+    purpose: str = "background worker",
+    logger_override: Optional[logging.Logger] = None,
+):
+    """Temporarily route detached worker config reads through a profile.
+
+    Background WebUI workers run outside the request/streaming thread that
+    established the profile-scoped environment.  Workers that read agent config,
+    runtime provider settings, or skill paths must temporarily apply the
+    session/request profile env or they can fall back to the server-default
+    profile. Pass either a session-like object with `.profile` or a profile name.
+    """
+    log = logger_override or logger
+    raw_profile = session if isinstance(session, str) else getattr(session, "profile", "")
+    profile = str(raw_profile or "").strip()
+    if not profile or profile == "default":
+        yield
+        return
+
+    try:
+        # Lazy import avoids a module-load cycle: streaming imports this helper.
+        from api.streaming import _ENV_LOCK
+
+        profile_home_path = Path(get_hermes_home_for_profile(profile))
+        runtime_env = get_profile_runtime_env(profile_home_path)
+    except Exception:
+        log.debug(
+            "Failed to resolve profile env for %s profile %s; falling back to current env",
+            purpose,
+            profile,
+            exc_info=True,
+        )
+        yield
+        return
+
+    env_keys = set(runtime_env.keys()) | {"HERMES_HOME"}
+    with _ENV_LOCK:
+        old_env = {key: os.environ.get(key) for key in env_keys}
+        skill_home_snapshot = snapshot_skill_home_modules()
+        try:
+            os.environ.update(runtime_env)
+            os.environ["HERMES_HOME"] = str(profile_home_path)
+            try:
+                patch_skill_home_modules(profile_home_path)
+            except Exception:
+                log.debug(
+                    "Failed to patch skill modules for %s profile %s",
+                    purpose,
+                    profile,
+                    exc_info=True,
+                )
+            yield
+        finally:
+            for key, old_value in old_env.items():
+                if old_value is None:
+                    os.environ.pop(key, None)
+                else:
+                    os.environ[key] = old_value
+            restore_skill_home_modules(skill_home_snapshot)
 
 
 def _set_hermes_home(home: Path):

--- a/api/profiles.py
+++ b/api/profiles.py
@@ -42,6 +42,24 @@ _tls = threading.local()
 _SKILL_HOME_MODULES = ("tools.skills_tool", "tools.skill_manager_tool")
 
 
+def snapshot_skill_home_modules() -> dict[str, dict[str, object]]:
+    """Snapshot imported skill-module path globals before a temporary patch."""
+    snapshot: dict[str, dict[str, object]] = {}
+    for module_name in _SKILL_HOME_MODULES:
+        module = sys.modules.get(module_name)
+        if module is None:
+            snapshot[module_name] = {"module_present": False}
+            continue
+        snapshot[module_name] = {
+            "module_present": True,
+            "has_HERMES_HOME": hasattr(module, "HERMES_HOME"),
+            "HERMES_HOME": getattr(module, "HERMES_HOME", None),
+            "has_SKILLS_DIR": hasattr(module, "SKILLS_DIR"),
+            "SKILLS_DIR": getattr(module, "SKILLS_DIR", None),
+        }
+    return snapshot
+
+
 def patch_skill_home_modules(home: Path) -> None:
     """Patch imported skill modules that cache HERMES_HOME at import time."""
     for module_name in _SKILL_HOME_MODULES:
@@ -53,6 +71,37 @@ def patch_skill_home_modules(home: Path) -> None:
             module.SKILLS_DIR = home / "skills"
         except AttributeError:
             logger.debug("Failed to patch %s module", module_name)
+
+
+def restore_skill_home_modules(snapshot: dict[str, dict[str, object]]) -> None:
+    """Restore skill-module globals captured by snapshot_skill_home_modules()."""
+    for module_name, values in snapshot.items():
+        module = sys.modules.get(module_name)
+        if not values.get("module_present"):
+            if module is not None:
+                sys.modules.pop(module_name, None)
+                parent_name, _, child_name = module_name.rpartition(".")
+                parent = sys.modules.get(parent_name)
+                if parent is not None:
+                    try:
+                        delattr(parent, child_name)
+                    except AttributeError:
+                        pass
+            continue
+        if module is None:
+            continue
+        for attr in ("HERMES_HOME", "SKILLS_DIR"):
+            has_attr = bool(values.get(f"has_{attr}"))
+            try:
+                if has_attr:
+                    setattr(module, attr, values.get(attr))
+                else:
+                    try:
+                        delattr(module, attr)
+                    except AttributeError:
+                        pass
+            except AttributeError:
+                logger.debug("Failed to restore %s.%s", module_name, attr)
 
 
 def _unwrap_profile_home_to_base(home: Path) -> Path:

--- a/api/routes.py
+++ b/api/routes.py
@@ -20,9 +20,8 @@ import threading
 import time
 import uuid
 import re
-from types import SimpleNamespace
 from pathlib import Path
-from contextlib import closing, contextmanager
+from contextlib import closing
 from urllib.parse import parse_qs
 from api.agent_sessions import (
     MESSAGING_SOURCES,
@@ -31,6 +30,7 @@ from api.agent_sessions import (
     read_session_lineage_report,
 )
 from api.compression_anchor import visible_messages_for_anchor
+from api.profiles import get_active_profile_name as _get_active_profile_name, profile_env_for_background_worker
 
 logger = logging.getLogger(__name__)
 
@@ -70,57 +70,6 @@ _CSP_REPORT_RATE_LIMIT_LOCK = threading.Lock()
 _CSP_REPORT_RATE_LIMIT_WINDOW_SECONDS = 60
 _CSP_REPORT_RATE_LIMIT_MAX = 100
 _CSP_REPORT_MAX_BODY_BYTES = 64 * 1024
-
-
-@contextmanager
-def _profile_env_for_background_worker(session, purpose: str = "background worker"):
-    """Temporarily route agent/config reads through a session's profile.
-
-    Detached WebUI workers run in their own threads, so they do not inherit the
-    streaming thread's profile-scoped HERMES_HOME/runtime environment.  Any
-    worker that calls hermes-agent config/runtime helpers must set the session
-    profile explicitly or it may read the default profile instead.
-    """
-    profile = str(getattr(session, "profile", "") or "").strip()
-    if not profile or profile == "default":
-        yield
-        return
-
-    try:
-        from api.profiles import (
-            get_hermes_home_for_profile,
-            get_profile_runtime_env,
-            patch_skill_home_modules,
-            restore_skill_home_modules,
-            snapshot_skill_home_modules,
-        )
-        from api.streaming import _ENV_LOCK
-
-        profile_home_path = Path(get_hermes_home_for_profile(profile))
-        runtime_env = get_profile_runtime_env(profile_home_path)
-    except Exception:
-        yield
-        return
-
-    env_keys = set(runtime_env.keys()) | {"HERMES_HOME"}
-    with _ENV_LOCK:
-        old_env = {key: os.environ.get(key) for key in env_keys}
-        skill_home_snapshot = snapshot_skill_home_modules()
-        try:
-            os.environ.update(runtime_env)
-            os.environ["HERMES_HOME"] = str(profile_home_path)
-            try:
-                patch_skill_home_modules(profile_home_path)
-            except Exception:
-                logger.debug("Failed to patch skill modules for %s profile %s", purpose, profile)
-            yield
-        finally:
-            for key, old_value in old_env.items():
-                if old_value is None:
-                    os.environ.pop(key, None)
-                else:
-                    os.environ[key] = old_value
-            restore_skill_home_modules(skill_home_snapshot)
 
 
 # ── Profile-scoped session/project filtering (#1611, #1614) ────────────────
@@ -5495,100 +5444,94 @@ def handle_post(handler, parsed) -> bool:
         target = body.get("target") if isinstance(body, dict) else None
 
         def _llm_update_summary(system_prompt: str, user_prompt: str) -> str:
-            try:
-                from api.profiles import get_active_profile_name
-                active_profile = get_active_profile_name() or "default"
-            except Exception:
-                active_profile = "default"
+            active_profile = _get_active_profile_name() or "default"
 
-            with _profile_env_for_background_worker(
-                SimpleNamespace(profile=active_profile),
+            with profile_env_for_background_worker(
+                active_profile,
                 "update summary",
+                logger_override=logger,
             ):
-                return _llm_update_summary_with_profile_env(system_prompt, user_prompt)
-
-        def _llm_update_summary_with_profile_env(system_prompt: str, user_prompt: str) -> str:
-            from api.config import (
-                get_effective_default_model,
-                resolve_model_provider,
-                resolve_custom_provider_connection,
-            )
-
-            messages = [
-                {"role": "system", "content": system_prompt},
-                {"role": "user", "content": user_prompt},
-            ]
-
-            _main_model, _main_provider, _main_base_url = resolve_model_provider(get_effective_default_model())
-            _main_api_key = None
-            try:
-                from api.oauth import resolve_runtime_provider_with_anthropic_env_lock
-                from hermes_cli.runtime_provider import resolve_runtime_provider
-
-                _rt = resolve_runtime_provider_with_anthropic_env_lock(
-                    resolve_runtime_provider,
-                    requested=_main_provider,
+                from api.config import (
+                    get_effective_default_model,
+                    resolve_model_provider,
+                    resolve_custom_provider_connection,
                 )
-                _main_api_key = _rt.get("api_key")
-                if not _main_provider:
-                    _main_provider = _rt.get("provider")
-                if not _main_base_url:
-                    _main_base_url = _rt.get("base_url")
-            except Exception as _e:
-                logger.debug("update summary runtime provider resolution failed: %s", _e)
-            if isinstance(_main_provider, str) and _main_provider.startswith("custom:"):
-                _cp_key, _cp_base = resolve_custom_provider_connection(_main_provider)
-                if not _main_api_key and _cp_key:
-                    _main_api_key = _cp_key
-                if not _main_base_url and _cp_base:
-                    _main_base_url = _cp_base
 
-            main_runtime = {
-                "provider": _main_provider,
-                "model": _main_model,
-                "base_url": _main_base_url,
-                "api_key": _main_api_key,
-            }
+                messages = [
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": user_prompt},
+                ]
 
-            try:
-                from agent.auxiliary_client import get_text_auxiliary_client
+                _main_model, _main_provider, _main_base_url = resolve_model_provider(get_effective_default_model())
+                _main_api_key = None
+                try:
+                    from api.oauth import resolve_runtime_provider_with_anthropic_env_lock
+                    from hermes_cli.runtime_provider import resolve_runtime_provider
 
-                # Update summaries are a short text-compression/summarization task.
-                # Reuse the documented auxiliary.compression slot instead of
-                # inventing a WebUI-only auxiliary task name that users cannot
-                # discover in the Hermes Agent setup/config UI.
-                aux_client, aux_model = get_text_auxiliary_client(
-                    "compression",
-                    main_runtime=main_runtime,
-                )
-                if aux_client is not None and aux_model:
-                    response = aux_client.chat.completions.create(
-                        model=aux_model,
-                        messages=messages,
+                    _rt = resolve_runtime_provider_with_anthropic_env_lock(
+                        resolve_runtime_provider,
+                        requested=_main_provider,
                     )
-                    return str(response.choices[0].message.content or "").strip()
-            except Exception as _e:
-                logger.debug("update summary auxiliary model failed; falling back to main model: %s", _e)
+                    _main_api_key = _rt.get("api_key")
+                    if not _main_provider:
+                        _main_provider = _rt.get("provider")
+                    if not _main_base_url:
+                        _main_base_url = _rt.get("base_url")
+                except Exception as _e:
+                    logger.debug("update summary runtime provider resolution failed: %s", _e)
+                if isinstance(_main_provider, str) and _main_provider.startswith("custom:"):
+                    _cp_key, _cp_base = resolve_custom_provider_connection(_main_provider)
+                    if not _main_api_key and _cp_key:
+                        _main_api_key = _cp_key
+                    if not _main_base_url and _cp_base:
+                        _main_base_url = _cp_base
 
-            from run_agent import AIAgent
+                main_runtime = {
+                    "provider": _main_provider,
+                    "model": _main_model,
+                    "base_url": _main_base_url,
+                    "api_key": _main_api_key,
+                }
 
-            agent = AIAgent(
-                model=_main_model,
-                provider=_main_provider,
-                base_url=_main_base_url,
-                api_key=_main_api_key,
-                platform="webui",
-                quiet_mode=True,
-                enabled_toolsets=[],
-                session_id=f"updates-summary-{uuid.uuid4().hex[:8]}",
-            )
-            result = agent.run_conversation(
-                user_message=user_prompt,
-                system_message=system_prompt,
-                conversation_history=[],
-                task_id=f"updates-summary-{uuid.uuid4().hex[:8]}",
-            )
-            return str(result.get("final_response") or "").strip()
+                try:
+                    from agent.auxiliary_client import get_text_auxiliary_client
+
+                    # Update summaries are a short text-compression/summarization task.
+                    # Reuse the documented auxiliary.compression slot instead of
+                    # inventing a WebUI-only auxiliary task name that users cannot
+                    # discover in the Hermes Agent setup/config UI.
+                    aux_client, aux_model = get_text_auxiliary_client(
+                        "compression",
+                        main_runtime=main_runtime,
+                    )
+                    if aux_client is not None and aux_model:
+                        response = aux_client.chat.completions.create(
+                            model=aux_model,
+                            messages=messages,
+                        )
+                        return str(response.choices[0].message.content or "").strip()
+                except Exception as _e:
+                    logger.debug("update summary auxiliary model failed; falling back to main model: %s", _e)
+
+                from run_agent import AIAgent
+
+                agent = AIAgent(
+                    model=_main_model,
+                    provider=_main_provider,
+                    base_url=_main_base_url,
+                    api_key=_main_api_key,
+                    platform="webui",
+                    quiet_mode=True,
+                    enabled_toolsets=[],
+                    session_id=f"updates-summary-{uuid.uuid4().hex[:8]}",
+                )
+                result = agent.run_conversation(
+                    user_message=user_prompt,
+                    system_message=system_prompt,
+                    conversation_history=[],
+                    task_id=f"updates-summary-{uuid.uuid4().hex[:8]}",
+                )
+                return str(result.get("final_response") or "").strip()
 
         return j(handler, summarize_update_payload(updates, llm_callback=_llm_update_summary, target=target))
 
@@ -8338,7 +8281,7 @@ def _run_manual_compression_job(sid, body):
         except KeyError:
             session = None
         if session is not None:
-            with _profile_env_for_background_worker(session, "manual compression"):
+            with profile_env_for_background_worker(session, "manual compression", logger_override=logger):
                 _handle_session_compress(memory_handler, body)
         else:
             _handle_session_compress(memory_handler, body)

--- a/api/routes.py
+++ b/api/routes.py
@@ -30,7 +30,6 @@ from api.agent_sessions import (
     read_session_lineage_report,
 )
 from api.compression_anchor import visible_messages_for_anchor
-from api.profiles import get_active_profile_name as _get_active_profile_name, profile_env_for_background_worker
 
 logger = logging.getLogger(__name__)
 
@@ -5444,9 +5443,11 @@ def handle_post(handler, parsed) -> bool:
         target = body.get("target") if isinstance(body, dict) else None
 
         def _llm_update_summary(system_prompt: str, user_prompt: str) -> str:
-            active_profile = _get_active_profile_name() or "default"
+            from api import profiles as profiles_api
 
-            with profile_env_for_background_worker(
+            active_profile = profiles_api.get_active_profile_name() or "default"
+
+            with profiles_api.profile_env_for_background_worker(
                 active_profile,
                 "update summary",
                 logger_override=logger,
@@ -8281,7 +8282,9 @@ def _run_manual_compression_job(sid, body):
         except KeyError:
             session = None
         if session is not None:
-            with profile_env_for_background_worker(session, "manual compression", logger_override=logger):
+            from api import profiles as profiles_api
+
+            with profiles_api.profile_env_for_background_worker(session, "manual compression", logger_override=logger):
                 _handle_session_compress(memory_handler, body)
         else:
             _handle_session_compress(memory_handler, body)

--- a/api/routes.py
+++ b/api/routes.py
@@ -20,8 +20,9 @@ import threading
 import time
 import uuid
 import re
+from types import SimpleNamespace
 from pathlib import Path
-from contextlib import closing
+from contextlib import closing, contextmanager
 from urllib.parse import parse_qs
 from api.agent_sessions import (
     MESSAGING_SOURCES,
@@ -69,6 +70,57 @@ _CSP_REPORT_RATE_LIMIT_LOCK = threading.Lock()
 _CSP_REPORT_RATE_LIMIT_WINDOW_SECONDS = 60
 _CSP_REPORT_RATE_LIMIT_MAX = 100
 _CSP_REPORT_MAX_BODY_BYTES = 64 * 1024
+
+
+@contextmanager
+def _profile_env_for_background_worker(session, purpose: str = "background worker"):
+    """Temporarily route agent/config reads through a session's profile.
+
+    Detached WebUI workers run in their own threads, so they do not inherit the
+    streaming thread's profile-scoped HERMES_HOME/runtime environment.  Any
+    worker that calls hermes-agent config/runtime helpers must set the session
+    profile explicitly or it may read the default profile instead.
+    """
+    profile = str(getattr(session, "profile", "") or "").strip()
+    if not profile or profile == "default":
+        yield
+        return
+
+    try:
+        from api.profiles import (
+            get_hermes_home_for_profile,
+            get_profile_runtime_env,
+            patch_skill_home_modules,
+            restore_skill_home_modules,
+            snapshot_skill_home_modules,
+        )
+        from api.streaming import _ENV_LOCK
+
+        profile_home_path = Path(get_hermes_home_for_profile(profile))
+        runtime_env = get_profile_runtime_env(profile_home_path)
+    except Exception:
+        yield
+        return
+
+    env_keys = set(runtime_env.keys()) | {"HERMES_HOME"}
+    with _ENV_LOCK:
+        old_env = {key: os.environ.get(key) for key in env_keys}
+        skill_home_snapshot = snapshot_skill_home_modules()
+        try:
+            os.environ.update(runtime_env)
+            os.environ["HERMES_HOME"] = str(profile_home_path)
+            try:
+                patch_skill_home_modules(profile_home_path)
+            except Exception:
+                logger.debug("Failed to patch skill modules for %s profile %s", purpose, profile)
+            yield
+        finally:
+            for key, old_value in old_env.items():
+                if old_value is None:
+                    os.environ.pop(key, None)
+                else:
+                    os.environ[key] = old_value
+            restore_skill_home_modules(skill_home_snapshot)
 
 
 # ── Profile-scoped session/project filtering (#1611, #1614) ────────────────
@@ -5443,6 +5495,19 @@ def handle_post(handler, parsed) -> bool:
         target = body.get("target") if isinstance(body, dict) else None
 
         def _llm_update_summary(system_prompt: str, user_prompt: str) -> str:
+            try:
+                from api.profiles import get_active_profile_name
+                active_profile = get_active_profile_name() or "default"
+            except Exception:
+                active_profile = "default"
+
+            with _profile_env_for_background_worker(
+                SimpleNamespace(profile=active_profile),
+                "update summary",
+            ):
+                return _llm_update_summary_with_profile_env(system_prompt, user_prompt)
+
+        def _llm_update_summary_with_profile_env(system_prompt: str, user_prompt: str) -> str:
             from api.config import (
                 get_effective_default_model,
                 resolve_model_provider,
@@ -8268,7 +8333,15 @@ def _manual_compression_status_payload(job):
 def _run_manual_compression_job(sid, body):
     memory_handler = _ManualCompressionMemoryHandler()
     try:
-        _handle_session_compress(memory_handler, body)
+        try:
+            session = get_session(sid)
+        except KeyError:
+            session = None
+        if session is not None:
+            with _profile_env_for_background_worker(session, "manual compression"):
+                _handle_session_compress(memory_handler, body)
+        else:
+            _handle_session_compress(memory_handler, body)
         status = int(memory_handler.status or 500)
         payload = memory_handler.payload()
         with _MANUAL_COMPRESSION_JOBS_LOCK:

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -34,7 +34,6 @@ from api.config import (
 )
 from api.helpers import redact_session_data, _redact_text
 from api.compression_anchor import visible_messages_for_anchor
-from api.profiles import profile_env_for_background_worker
 from api.metering import meter
 from api.turn_journal import append_turn_journal_event_for_stream
 
@@ -1469,7 +1468,9 @@ def _run_background_title_update(session_id: str, user_text: str, assistant_text
         if not still_auto:
             _put_title_status(put_event, session_id, 'skipped', 'manual_title', current)
             return
-        with profile_env_for_background_worker(s, "background title", logger_override=logger):
+        from api import profiles as profiles_api
+
+        with profiles_api.profile_env_for_background_worker(s, "background title", logger_override=logger):
             aux_title_configured = _aux_title_configured()
             if agent and not aux_title_configured:
                 next_title, llm_status, raw_preview = _generate_llm_session_title_for_agent(agent, user_text, assistant_text)
@@ -1550,7 +1551,9 @@ def _run_background_title_refresh(session_id: str, user_text: str, assistant_tex
             return
         if not effective or effective in ('Untitled', 'New Chat'):
             return
-        with profile_env_for_background_worker(s, "background title", logger_override=logger):
+        from api import profiles as profiles_api
+
+        with profiles_api.profile_env_for_background_worker(s, "background title", logger_override=logger):
             aux_title_configured = _aux_title_configured()
             if agent and not aux_title_configured:
                 next_title, llm_status, raw_preview = _generate_llm_session_title_for_agent(agent, user_text, assistant_text)

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -34,6 +34,7 @@ from api.config import (
 )
 from api.helpers import redact_session_data, _redact_text
 from api.compression_anchor import visible_messages_for_anchor
+from api.profiles import profile_env_for_background_worker
 from api.metering import meter
 from api.turn_journal import append_turn_journal_event_for_stream
 
@@ -1445,54 +1446,6 @@ def _is_generic_fallback_title(title: str) -> bool:
     return str(title or '').strip().lower() in {'conversation topic'}
 
 
-@contextlib.contextmanager
-def _profile_env_for_title_worker(session):
-    """Temporarily route auxiliary title-generation config through the session profile.
-
-    Background title workers run in their own thread and do not inherit the
-    streaming thread's thread-local/profile context.  Without setting
-    HERMES_HOME here, hermes-agent's auxiliary_client.load_config() can read
-    the default profile and use the wrong title_generation model.
-    """
-    profile = str(getattr(session, 'profile', '') or '').strip()
-    if not profile or profile == 'default':
-        yield
-        return
-    try:
-        from api.profiles import (
-            get_hermes_home_for_profile,
-            get_profile_runtime_env,
-            patch_skill_home_modules,
-            restore_skill_home_modules,
-            snapshot_skill_home_modules,
-        )
-        profile_home_path = Path(get_hermes_home_for_profile(profile))
-        runtime_env = get_profile_runtime_env(profile_home_path)
-    except Exception:
-        yield
-        return
-
-    env_keys = set(runtime_env.keys()) | {'HERMES_HOME'}
-    with _ENV_LOCK:
-        old_env = {key: os.environ.get(key) for key in env_keys}
-        skill_home_snapshot = snapshot_skill_home_modules()
-        try:
-            os.environ.update(runtime_env)
-            os.environ['HERMES_HOME'] = str(profile_home_path)
-            try:
-                patch_skill_home_modules(profile_home_path)
-            except Exception:
-                logger.debug("Failed to patch skill modules for background title profile %s", profile)
-            yield
-        finally:
-            for key, old_value in old_env.items():
-                if old_value is None:
-                    os.environ.pop(key, None)
-                else:
-                    os.environ[key] = old_value
-            restore_skill_home_modules(skill_home_snapshot)
-
-
 def _run_background_title_update(session_id: str, user_text: str, assistant_text: str, placeholder_title: str, put_event, agent=None):
     """Generate and publish a better title after `done`, then end the stream."""
     try:
@@ -1516,7 +1469,7 @@ def _run_background_title_update(session_id: str, user_text: str, assistant_text
         if not still_auto:
             _put_title_status(put_event, session_id, 'skipped', 'manual_title', current)
             return
-        with _profile_env_for_title_worker(s):
+        with profile_env_for_background_worker(s, "background title", logger_override=logger):
             aux_title_configured = _aux_title_configured()
             if agent and not aux_title_configured:
                 next_title, llm_status, raw_preview = _generate_llm_session_title_for_agent(agent, user_text, assistant_text)
@@ -1597,7 +1550,7 @@ def _run_background_title_refresh(session_id: str, user_text: str, assistant_tex
             return
         if not effective or effective in ('Untitled', 'New Chat'):
             return
-        with _profile_env_for_title_worker(s):
+        with profile_env_for_background_worker(s, "background title", logger_override=logger):
             aux_title_configured = _aux_title_configured()
             if agent and not aux_title_configured:
                 next_title, llm_status, raw_preview = _generate_llm_session_title_for_agent(agent, user_text, assistant_text)

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -41,7 +41,7 @@ from api.turn_journal import append_turn_journal_event_for_stream
 # concurrent runs of the SAME session, but two DIFFERENT sessions can still
 # interleave their os.environ writes. This global lock serializes the env
 # save/restore around the entire agent run.
-_ENV_LOCK = threading.Lock()
+_ENV_LOCK = threading.RLock()
 
 
 def _prewarm_skill_tool_modules():
@@ -1445,6 +1445,54 @@ def _is_generic_fallback_title(title: str) -> bool:
     return str(title or '').strip().lower() in {'conversation topic'}
 
 
+@contextlib.contextmanager
+def _profile_env_for_title_worker(session):
+    """Temporarily route auxiliary title-generation config through the session profile.
+
+    Background title workers run in their own thread and do not inherit the
+    streaming thread's thread-local/profile context.  Without setting
+    HERMES_HOME here, hermes-agent's auxiliary_client.load_config() can read
+    the default profile and use the wrong title_generation model.
+    """
+    profile = str(getattr(session, 'profile', '') or '').strip()
+    if not profile or profile == 'default':
+        yield
+        return
+    try:
+        from api.profiles import (
+            get_hermes_home_for_profile,
+            get_profile_runtime_env,
+            patch_skill_home_modules,
+            restore_skill_home_modules,
+            snapshot_skill_home_modules,
+        )
+        profile_home_path = Path(get_hermes_home_for_profile(profile))
+        runtime_env = get_profile_runtime_env(profile_home_path)
+    except Exception:
+        yield
+        return
+
+    env_keys = set(runtime_env.keys()) | {'HERMES_HOME'}
+    with _ENV_LOCK:
+        old_env = {key: os.environ.get(key) for key in env_keys}
+        skill_home_snapshot = snapshot_skill_home_modules()
+        try:
+            os.environ.update(runtime_env)
+            os.environ['HERMES_HOME'] = str(profile_home_path)
+            try:
+                patch_skill_home_modules(profile_home_path)
+            except Exception:
+                logger.debug("Failed to patch skill modules for background title profile %s", profile)
+            yield
+        finally:
+            for key, old_value in old_env.items():
+                if old_value is None:
+                    os.environ.pop(key, None)
+                else:
+                    os.environ[key] = old_value
+            restore_skill_home_modules(skill_home_snapshot)
+
+
 def _run_background_title_update(session_id: str, user_text: str, assistant_text: str, placeholder_title: str, put_event, agent=None):
     """Generate and publish a better title after `done`, then end the stream."""
     try:
@@ -1468,24 +1516,25 @@ def _run_background_title_update(session_id: str, user_text: str, assistant_text
         if not still_auto:
             _put_title_status(put_event, session_id, 'skipped', 'manual_title', current)
             return
-        aux_title_configured = _aux_title_configured()
-        if agent and not aux_title_configured:
-            next_title, llm_status, raw_preview = _generate_llm_session_title_for_agent(agent, user_text, assistant_text)
-            if not next_title and llm_status in ('llm_error', 'llm_invalid'):
-                next_title, llm_status, raw_preview = _generate_llm_session_title_via_aux(user_text, assistant_text, agent=agent, use_agent_model=True)
-        else:
-            next_title, llm_status, raw_preview = _generate_llm_session_title_via_aux(user_text, assistant_text)
-            if not next_title and agent and llm_status in ('llm_error_aux', 'llm_invalid_aux'):
+        with _profile_env_for_title_worker(s):
+            aux_title_configured = _aux_title_configured()
+            if agent and not aux_title_configured:
                 next_title, llm_status, raw_preview = _generate_llm_session_title_for_agent(agent, user_text, assistant_text)
-        source = llm_status
-        if not next_title:
-            fallback_title = _fallback_title_from_exchange(user_text, assistant_text)
-            if fallback_title and not _is_generic_fallback_title(fallback_title):
-                logger.debug("Using local fallback for session title generation")
-                next_title = fallback_title
-                source = 'fallback'
-            elif fallback_title:
-                logger.debug("Skipping generic local fallback for session title generation: %r", fallback_title)
+                if not next_title and llm_status in ('llm_error', 'llm_invalid'):
+                    next_title, llm_status, raw_preview = _generate_llm_session_title_via_aux(user_text, assistant_text, agent=agent, use_agent_model=True)
+            else:
+                next_title, llm_status, raw_preview = _generate_llm_session_title_via_aux(user_text, assistant_text)
+                if not next_title and agent and llm_status in ('llm_error_aux', 'llm_invalid_aux'):
+                    next_title, llm_status, raw_preview = _generate_llm_session_title_for_agent(agent, user_text, assistant_text)
+            source = llm_status
+            if not next_title:
+                fallback_title = _fallback_title_from_exchange(user_text, assistant_text)
+                if fallback_title and not _is_generic_fallback_title(fallback_title):
+                    logger.debug("Using local fallback for session title generation")
+                    next_title = fallback_title
+                    source = 'fallback'
+                elif fallback_title:
+                    logger.debug("Skipping generic local fallback for session title generation: %r", fallback_title)
         fallback_reason = (
             f'local_summary:{llm_status}'
             if source == 'fallback' and llm_status
@@ -1548,15 +1597,16 @@ def _run_background_title_refresh(session_id: str, user_text: str, assistant_tex
             return
         if not effective or effective in ('Untitled', 'New Chat'):
             return
-        aux_title_configured = _aux_title_configured()
-        if agent and not aux_title_configured:
-            next_title, llm_status, raw_preview = _generate_llm_session_title_for_agent(agent, user_text, assistant_text)
-            if not next_title and llm_status in ('llm_error', 'llm_invalid'):
-                next_title, llm_status, raw_preview = _generate_llm_session_title_via_aux(user_text, assistant_text, agent=agent, use_agent_model=True)
-        else:
-            next_title, llm_status, raw_preview = _generate_llm_session_title_via_aux(user_text, assistant_text)
-            if not next_title and agent and llm_status in ('llm_error_aux', 'llm_invalid_aux'):
+        with _profile_env_for_title_worker(s):
+            aux_title_configured = _aux_title_configured()
+            if agent and not aux_title_configured:
                 next_title, llm_status, raw_preview = _generate_llm_session_title_for_agent(agent, user_text, assistant_text)
+                if not next_title and llm_status in ('llm_error', 'llm_invalid'):
+                    next_title, llm_status, raw_preview = _generate_llm_session_title_via_aux(user_text, assistant_text, agent=agent, use_agent_model=True)
+            else:
+                next_title, llm_status, raw_preview = _generate_llm_session_title_via_aux(user_text, assistant_text)
+                if not next_title and agent and llm_status in ('llm_error_aux', 'llm_invalid_aux'):
+                    next_title, llm_status, raw_preview = _generate_llm_session_title_for_agent(agent, user_text, assistant_text)
         if not next_title:
             _put_title_status(put_event, session_id, 'refresh_skipped', llm_status or 'empty', effective, raw_preview)
             return

--- a/tests/test_profile_path_security.py
+++ b/tests/test_profile_path_security.py
@@ -27,8 +27,13 @@ def _reload_profiles_module(base_home: Path):
 
     profiles = importlib.import_module("api.profiles")
 
-    # Restore original modules so the cache stays consistent for the rest of the suite.
+    # Restore original modules and package attributes so the cache stays
+    # consistent for the rest of the suite.
     sys.modules.update(_saved)
+    api_pkg = sys.modules.get("api")
+    if api_pkg is not None:
+        for name, module in _saved.items():
+            setattr(api_pkg, name.rsplit(".", 1)[-1], module)
 
     return profiles
 

--- a/tests/test_sprint29.py
+++ b/tests/test_sprint29.py
@@ -712,11 +712,18 @@ class TestSSRFCheck:
 
 class TestENVLock:
     def test_env_lock_importable_from_streaming(self):
-        """_ENV_LOCK must be importable from api.streaming."""
+        """_ENV_LOCK must be an importable threading-style reentrant lock."""
         from api.streaming import _ENV_LOCK
-        import threading
-        assert isinstance(_ENV_LOCK, type(threading.Lock())), \
-            "_ENV_LOCK must be a threading.Lock"
+
+        assert hasattr(_ENV_LOCK, "acquire"), "_ENV_LOCK must expose acquire()"
+        assert hasattr(_ENV_LOCK, "release"), "_ENV_LOCK must expose release()"
+        assert hasattr(_ENV_LOCK, "__enter__"), "_ENV_LOCK must support context manager use"
+        assert hasattr(_ENV_LOCK, "__exit__"), "_ENV_LOCK must support context manager use"
+
+        with _ENV_LOCK:
+            acquired = _ENV_LOCK.acquire(False)
+            assert acquired, "_ENV_LOCK must allow reentrant acquisition"
+            _ENV_LOCK.release()
 
     def test_env_lock_importable_in_routes(self):
         """api.routes must be able to import _ENV_LOCK from api.streaming."""

--- a/tests/test_sprint46.py
+++ b/tests/test_sprint46.py
@@ -5,6 +5,7 @@ Sprint 46 Tests: manual session compression with optional focus topic.
 import contextlib
 import io
 import json
+import os
 import sys
 import threading
 import time
@@ -404,6 +405,71 @@ def test_session_compress_async_reports_stream_state_guard(monkeypatch, cleanup_
     assert error_payload["error_status"] == 409
     assert "stream state changed" in error_payload["error"]
     assert get_session(sid).active_stream_id == "stream-concurrent"
+
+
+def test_manual_compress_worker_uses_session_profile_env(monkeypatch, tmp_path, cleanup_test_sessions):
+    import api.profiles as profiles
+    import api.routes as routes
+
+    class EnvAssertingAgent:
+        seen_env = None
+
+        def __init__(self, **kwargs):
+            skill_module = sys.modules.get("tools.skills_tool")
+            EnvAssertingAgent.seen_env = {
+                "HERMES_HOME": os.environ.get("HERMES_HOME"),
+                "HERMES_TEST_PROFILE_ENV": os.environ.get("HERMES_TEST_PROFILE_ENV"),
+                "SKILL_MODULE_HOME": getattr(skill_module, "HERMES_HOME", None),
+                "SKILL_MODULE_DIR": getattr(skill_module, "SKILLS_DIR", None),
+            }
+            self.context_compressor = _FakeCompressor()
+
+    created = cleanup_test_sessions
+    sid = _make_session()
+    created.append(sid)
+    session = get_session(sid)
+    session.profile = "work"
+    session.model_provider = "profile-provider"
+    session.save(touch_updated_at=False)
+
+    profile_home = tmp_path / "work-profile-home"
+    fake_skill_module = types.ModuleType("tools.skills_tool")
+    setattr(fake_skill_module, "HERMES_HOME", "default-home")
+    setattr(fake_skill_module, "SKILLS_DIR", "default-home/skills")
+    monkeypatch.setitem(sys.modules, "tools.skills_tool", fake_skill_module)
+    monkeypatch.setattr(profiles, "get_hermes_home_for_profile", lambda profile: profile_home)
+    monkeypatch.setattr(
+        profiles,
+        "get_profile_runtime_env",
+        lambda home: {"HERMES_TEST_PROFILE_ENV": "work-runtime"},
+    )
+    monkeypatch.setenv("HERMES_HOME", "default-home")
+    monkeypatch.delenv("HERMES_TEST_PROFILE_ENV", raising=False)
+    _install_fake_compression_runtime(monkeypatch, EnvAssertingAgent)
+
+    with routes._MANUAL_COMPRESSION_JOBS_LOCK:
+        routes._MANUAL_COMPRESSION_JOBS[sid] = {
+            "session_id": sid,
+            "focus_topic": None,
+            "status": "running",
+            "started_at": time.time(),
+            "updated_at": time.time(),
+        }
+
+    routes._run_manual_compression_job(sid, {"session_id": sid})
+
+    assert EnvAssertingAgent.seen_env == {
+        "HERMES_HOME": str(profile_home),
+        "HERMES_TEST_PROFILE_ENV": "work-runtime",
+        "SKILL_MODULE_HOME": profile_home,
+        "SKILL_MODULE_DIR": profile_home / "skills",
+    }
+    assert str(getattr(fake_skill_module, "HERMES_HOME")) == "default-home"
+    assert str(getattr(fake_skill_module, "SKILLS_DIR")) == "default-home/skills"
+    assert os.environ.get("HERMES_HOME") == "default-home"
+    assert os.environ.get("HERMES_TEST_PROFILE_ENV") is None
+    with routes._MANUAL_COMPRESSION_JOBS_LOCK:
+        assert routes._MANUAL_COMPRESSION_JOBS[sid]["status"] == "done"
 
 
 def test_static_commands_js_registers_compress_alias(cleanup_test_sessions):

--- a/tests/test_title_aux_routing.py
+++ b/tests/test_title_aux_routing.py
@@ -380,6 +380,30 @@ class TestReasoningModelTitleGeneration(unittest.TestCase):
 
 
 class TestBackgroundTitleProfileRouting(unittest.TestCase):
+    def test_profile_env_context_logs_fail_open_resolution_errors(self):
+        """Profile env setup failures should be diagnosable without breaking workers."""
+        import api.profiles as profiles
+
+        session = types.SimpleNamespace(profile='work')
+        captured = {}
+
+        with patch(
+            'api.profiles.get_hermes_home_for_profile',
+            side_effect=RuntimeError('profile lookup failed'),
+        ):
+            with patch.dict(os.environ, {'HERMES_HOME': 'default-home'}, clear=False):
+                with self.assertLogs('api.profiles', level='DEBUG') as logs:
+                    with profiles.profile_env_for_background_worker(session, 'background title'):
+                        captured['HERMES_HOME'] = os.environ.get('HERMES_HOME')
+
+        message_found = any(
+            'Failed to resolve profile env for background title profile work' in record.getMessage()
+            for record in logs.records
+        )
+        self.assertEqual(captured['HERMES_HOME'], 'default-home')
+        self.assertTrue(message_found)
+        self.assertTrue(any(record.exc_info for record in logs.records))
+
     def test_skill_home_snapshot_removes_modules_imported_during_context(self):
         """Modules first imported inside a temporary profile context must not leak."""
         import api.profiles as profiles

--- a/tests/test_title_aux_routing.py
+++ b/tests/test_title_aux_routing.py
@@ -387,8 +387,9 @@ class TestBackgroundTitleProfileRouting(unittest.TestCase):
         session = types.SimpleNamespace(profile='work')
         captured = {}
 
-        with patch(
-            'api.profiles.get_hermes_home_for_profile',
+        with patch.object(
+            profiles,
+            'get_hermes_home_for_profile',
             side_effect=RuntimeError('profile lookup failed'),
         ):
             with patch.dict(os.environ, {'HERMES_HOME': 'default-home'}, clear=False):

--- a/tests/test_title_aux_routing.py
+++ b/tests/test_title_aux_routing.py
@@ -6,6 +6,7 @@ Covers:
   - aux→agent fallback triggers on 'llm_invalid_aux' status
   - _aux_title_timeout rejects zero, negative, and non-numeric values
 """
+import os
 import sys
 import types
 import unittest
@@ -376,6 +377,105 @@ class TestReasoningModelTitleGeneration(unittest.TestCase):
         self.assertEqual(mock_session.title, provisional_title)
         self.assertFalse(mock_session.llm_title_generated)
         mock_session.save.assert_not_called()
+
+
+class TestBackgroundTitleProfileRouting(unittest.TestCase):
+    def test_skill_home_snapshot_removes_modules_imported_during_context(self):
+        """Modules first imported inside a temporary profile context must not leak."""
+        import api.profiles as profiles
+
+        original_parent = sys.modules.get('tools')
+        original_skill_module = sys.modules.get('tools.skills_tool')
+        original_manager_module = sys.modules.get('tools.skill_manager_tool')
+
+        sys.modules.pop('tools.skills_tool', None)
+        sys.modules.pop('tools.skill_manager_tool', None)
+        tools_parent = types.ModuleType('tools')
+        sys.modules['tools'] = tools_parent
+        try:
+            snapshot = profiles.snapshot_skill_home_modules()
+
+            imported_during_context = types.ModuleType('tools.skills_tool')
+            setattr(imported_during_context, 'HERMES_HOME', 'profile-home')
+            setattr(imported_during_context, 'SKILLS_DIR', 'profile-home/skills')
+            sys.modules['tools.skills_tool'] = imported_during_context
+            setattr(tools_parent, 'skills_tool', imported_during_context)
+
+            profiles.restore_skill_home_modules(snapshot)
+
+            self.assertNotIn('tools.skills_tool', sys.modules)
+            self.assertFalse(hasattr(tools_parent, 'skills_tool'))
+        finally:
+            sys.modules.pop('tools.skills_tool', None)
+            sys.modules.pop('tools.skill_manager_tool', None)
+            if original_parent is None:
+                sys.modules.pop('tools', None)
+            else:
+                sys.modules['tools'] = original_parent
+            if original_skill_module is not None:
+                sys.modules['tools.skills_tool'] = original_skill_module
+            if original_manager_module is not None:
+                sys.modules['tools.skill_manager_tool'] = original_manager_module
+
+    @patch('api.streaming._aux_title_configured', return_value=True)
+    @patch('api.streaming.get_session')
+    def test_background_title_generation_uses_session_profile_home(
+        self, mock_get_session, mock_configured,
+    ):
+        """A background title worker for a non-default profile must resolve aux config from that profile."""
+        from api.streaming import _run_background_title_update
+
+        mock_session = MagicMock()
+        mock_session.title = 'Untitled'
+        mock_session.profile = 'work'
+        mock_session.llm_title_generated = False
+        mock_session.messages = [
+            {'role': 'user', 'content': 'This is a test message'},
+            {'role': 'assistant', 'content': 'Received.'},
+        ]
+        mock_get_session.return_value = mock_session
+
+        captured = {}
+
+        original_skill_module = sys.modules.get('tools.skills_tool')
+        fake_skill_module = types.ModuleType('tools.skills_tool')
+        setattr(fake_skill_module, 'HERMES_HOME', 'default-home')
+        setattr(fake_skill_module, 'SKILLS_DIR', 'default-home/skills')
+        sys.modules['tools.skills_tool'] = fake_skill_module
+
+        def fake_aux_title(*args, **kwargs):
+            captured['hermes_home'] = os.environ.get('HERMES_HOME')
+            captured['skill_module_home'] = getattr(fake_skill_module, 'HERMES_HOME')
+            captured['skill_module_dir'] = getattr(fake_skill_module, 'SKILLS_DIR')
+            return ('Profile Routed Title', 'llm_aux', '')
+
+        events = []
+        try:
+            with patch('api.profiles.get_hermes_home_for_profile', return_value='profile-home'):
+                with patch('api.streaming._generate_llm_session_title_via_aux', side_effect=fake_aux_title):
+                    with patch.dict(os.environ, {'HERMES_HOME': 'default-home'}, clear=False):
+                        _run_background_title_update(
+                            session_id='profile-title-session',
+                            user_text='This is a test message',
+                            assistant_text='Received.',
+                            placeholder_title='Untitled',
+                            put_event=lambda event_type, data: events.append((event_type, data)),
+                            agent=None,
+                        )
+                        captured['restored_hermes_home'] = os.environ.get('HERMES_HOME')
+        finally:
+            if original_skill_module is None:
+                sys.modules.pop('tools.skills_tool', None)
+            else:
+                sys.modules['tools.skills_tool'] = original_skill_module
+
+        self.assertEqual(captured.get('hermes_home'), 'profile-home')
+        self.assertEqual(str(captured.get('skill_module_home')), 'profile-home')
+        self.assertEqual(str(captured.get('skill_module_dir')), 'profile-home/skills')
+        self.assertEqual(captured.get('restored_hermes_home'), 'default-home')
+        self.assertEqual(getattr(fake_skill_module, 'HERMES_HOME'), 'default-home')
+        self.assertEqual(getattr(fake_skill_module, 'SKILLS_DIR'), 'default-home/skills')
+        self.assertEqual(mock_session.title, 'Profile Routed Title')
 
 
 class TestAuxTitleTimeoutEdgeCases(unittest.TestCase):

--- a/tests/test_update_banner_fixes.py
+++ b/tests/test_update_banner_fixes.py
@@ -431,8 +431,6 @@ class TestUpdateSummaryRouteModelSelection:
         assert '"compression"' in src
         assert '"update_summary"' not in src
         assert 'main_runtime=main_runtime' in src
-        assert '_profile_env_for_background_worker' in src
-        assert 'get_active_profile_name' in src
         assert 'update summary auxiliary model failed; falling back to main model' in src
         assert 'from run_agent import AIAgent' in src
 

--- a/tests/test_update_banner_fixes.py
+++ b/tests/test_update_banner_fixes.py
@@ -18,6 +18,9 @@ import threading
 import time
 import sys
 import os
+import io
+import json
+import types
 
 REPO = pathlib.Path(__file__).parent.parent
 
@@ -428,8 +431,153 @@ class TestUpdateSummaryRouteModelSelection:
         assert '"compression"' in src
         assert '"update_summary"' not in src
         assert 'main_runtime=main_runtime' in src
+        assert '_profile_env_for_background_worker' in src
+        assert 'get_active_profile_name' in src
         assert 'update summary auxiliary model failed; falling back to main model' in src
         assert 'from run_agent import AIAgent' in src
+
+    def test_summary_route_auxiliary_model_uses_active_profile_env(self, monkeypatch, tmp_path):
+        import api.config as cfg
+        import api.profiles as profiles
+        import api.routes as routes
+        import api.updates as updates
+
+        class FakeHandler:
+            def __init__(self, payload):
+                raw = json.dumps(payload).encode('utf-8')
+                self.headers = {'Content-Length': str(len(raw))}
+                self.rfile = io.BytesIO(raw)
+                self.wfile = io.BytesIO()
+                self.status = None
+
+            def send_response(self, status):
+                self.status = status
+
+            def send_header(self, _key, _value):
+                pass
+
+            def end_headers(self):
+                pass
+
+            def response_payload(self):
+                return json.loads(self.wfile.getvalue().decode('utf-8'))
+
+        captured = {}
+        profile_home = tmp_path / 'profiles' / 'work'
+        fake_skill_module = types.ModuleType('tools.skills_tool')
+        setattr(fake_skill_module, 'HERMES_HOME', 'default-home')
+        setattr(fake_skill_module, 'SKILLS_DIR', 'default-home/skills')
+        monkeypatch.setitem(sys.modules, 'tools.skills_tool', fake_skill_module)
+
+        monkeypatch.setattr(profiles, 'get_hermes_home_for_profile', lambda profile: profile_home)
+        monkeypatch.setattr(
+            profiles,
+            'get_profile_runtime_env',
+            lambda home: {'HERMES_TEST_PROFILE_ENV': 'work-runtime'},
+        )
+        monkeypatch.setattr(cfg, 'get_effective_default_model', lambda: 'openai/test-main')
+
+        def fake_resolve_model_provider(model):
+            captured['model_resolution_env'] = {
+                'HERMES_HOME': os.environ.get('HERMES_HOME'),
+                'HERMES_TEST_PROFILE_ENV': os.environ.get('HERMES_TEST_PROFILE_ENV'),
+            }
+            return model, 'openai', 'https://example.test/v1'
+
+        monkeypatch.setattr(cfg, 'resolve_model_provider', fake_resolve_model_provider)
+        monkeypatch.setattr(cfg, 'resolve_custom_provider_connection', lambda provider: (None, None))
+
+        fake_runtime_provider = types.ModuleType('hermes_cli.runtime_provider')
+        fake_runtime_provider.resolve_runtime_provider = lambda requested=None: {
+            'api_key': 'fake-key',
+            'provider': requested or 'openai',
+            'base_url': 'https://example.test/v1',
+        }
+        fake_hermes_cli = types.ModuleType('hermes_cli')
+        fake_hermes_cli.__path__ = []
+        fake_hermes_cli.runtime_provider = fake_runtime_provider
+        monkeypatch.setitem(sys.modules, 'hermes_cli', fake_hermes_cli)
+        monkeypatch.setitem(sys.modules, 'hermes_cli.runtime_provider', fake_runtime_provider)
+
+        class FakeAuxClient:
+            class chat:
+                class completions:
+                    @staticmethod
+                    def create(model, messages):
+                        captured['aux_create'] = {'model': model, 'messages': messages}
+                        return types.SimpleNamespace(
+                            choices=[
+                                types.SimpleNamespace(
+                                    message=types.SimpleNamespace(
+                                        content='Notice: Profile-routed update summaries work.'
+                                    )
+                                )
+                            ]
+                        )
+
+        def fake_get_text_auxiliary_client(task, main_runtime=None):
+            captured['aux_env'] = {
+                'HERMES_HOME': os.environ.get('HERMES_HOME'),
+                'HERMES_TEST_PROFILE_ENV': os.environ.get('HERMES_TEST_PROFILE_ENV'),
+                'SKILL_MODULE_HOME': getattr(fake_skill_module, 'HERMES_HOME'),
+                'SKILL_MODULE_DIR': getattr(fake_skill_module, 'SKILLS_DIR'),
+            }
+            captured['aux_task'] = task
+            captured['main_runtime'] = dict(main_runtime or {})
+            return FakeAuxClient(), 'profile-compression-model'
+
+        fake_auxiliary_client = types.ModuleType('agent.auxiliary_client')
+        fake_auxiliary_client.get_text_auxiliary_client = fake_get_text_auxiliary_client
+        fake_agent = types.ModuleType('agent')
+        fake_agent.__path__ = []
+        fake_agent.auxiliary_client = fake_auxiliary_client
+        monkeypatch.setitem(sys.modules, 'agent', fake_agent)
+        monkeypatch.setitem(sys.modules, 'agent.auxiliary_client', fake_auxiliary_client)
+
+        with updates._cache_lock:
+            updates._summary_cache.clear()
+
+        monkeypatch.setenv('HERMES_HOME', 'default-home')
+        monkeypatch.setenv('HERMES_TEST_PROFILE_ENV', 'default-runtime')
+
+        body = {
+            'target': 'webui',
+            'updates': {
+                'webui': {
+                    'behind': 1,
+                    'current_sha': 'profile-env-before',
+                    'latest_sha': f'profile-env-after-{time.time_ns()}',
+                    'compare_url': 'https://example.test/compare',
+                },
+            },
+        }
+        handler = FakeHandler(body)
+
+        profiles.set_request_profile('work')
+        try:
+            routes.handle_post(handler, types.SimpleNamespace(path='/api/updates/summary'))
+        finally:
+            profiles.clear_request_profile()
+
+        assert handler.status == 200
+        payload = handler.response_payload()
+        assert payload['generated_by'] == 'llm'
+        assert captured['aux_task'] == 'compression'
+        assert captured['model_resolution_env'] == {
+            'HERMES_HOME': str(profile_home),
+            'HERMES_TEST_PROFILE_ENV': 'work-runtime',
+        }
+        assert captured['aux_env'] == {
+            'HERMES_HOME': str(profile_home),
+            'HERMES_TEST_PROFILE_ENV': 'work-runtime',
+            'SKILL_MODULE_HOME': profile_home,
+            'SKILL_MODULE_DIR': profile_home / 'skills',
+        }
+        assert captured['aux_create']['model'] == 'profile-compression-model'
+        assert getattr(fake_skill_module, 'HERMES_HOME') == 'default-home'
+        assert getattr(fake_skill_module, 'SKILLS_DIR') == 'default-home/skills'
+        assert os.environ.get('HERMES_HOME') == 'default-home'
+        assert os.environ.get('HERMES_TEST_PROFILE_ENV') == 'default-runtime'
 
 
 class TestUiJsUpdateBanner:


### PR DESCRIPTION
## Thinking Path

- Profile-scoped chats already run the main streaming turn with a session-specific Hermes home/runtime environment, but detached follow-up work does not automatically inherit that thread context.
- Background title generation, manual session compression, and update-summary generation can all call Hermes Agent auxiliary/config/runtime helpers after the main profiled stream has moved on.
- When those workers read default-profile configuration instead of the session/request profile, auxiliary model routing can silently use the wrong configured model or fail provider resolution for profile-only custom providers.
- The narrow fix is to wrap only those detached auxiliary/config-resolution call sites in a temporary profile environment derived from the session or active request profile, then restore process state afterward.
- Because these helpers still depend on process-level environment and imported module globals, the temporary context also preserves and restores the skill-module home globals, including modules imported for the first time while the profile context is active.
- The env lock is intentionally reentrant now: manual compression and update-summary can enter profile-scoped worker setup and then re-enter runtime-provider resolution that also takes the same shared env lock.

## What Changed

- Added shared profile-scoped environment handling for detached background workers that need Hermes Agent config/runtime reads.
- Routed background title generation through the session profile before checking/generating auxiliary titles.
- Routed manual `/compress` jobs through the session profile before compression model/provider resolution.
- Routed WebUI update-summary auxiliary compression through the active request profile.
- Added snapshot/restore helpers for Hermes Agent skill modules that cache `HERMES_HOME` / `SKILLS_DIR`, so temporary profile routing does not leak into later work.
- Changed the shared env lock to a reentrant lock to support nested provider-resolution paths without self-deadlock.
- Added debug logging for fail-open profile-env setup paths so fallback behavior remains resilient but diagnosable.
- Kept profile-module reload tests isolated so full-suite ordering cannot leave stale `api.profiles` package bindings behind.
- Added regression coverage for title generation, manual compression, update-summary compression, skill-module restoration, fail-open logging, module-reload isolation, and the reentrant env-lock contract.

## Why It Matters

- Keeps non-default-profile chats from accidentally using the default profile's auxiliary model settings for title generation or compression-style tasks.
- Prevents profile-only custom providers from failing in detached workers simply because the worker resolved config from the wrong profile.
- Preserves the existing process-wide environment model while making the temporary profile switch bounded and restored after each worker call.
- Avoids a deadlock path introduced by wrapping manual compression/update-summary around code that can re-enter provider-resolution lock handling.
- Improves regression coverage around the specific background-worker surfaces most likely to drift from the main profiled streaming path.

## Verification

Targeted profile-routing coverage:

```text
python -m pytest tests/test_sprint29.py::TestENVLock tests/test_sprint46.py tests/test_title_aux_routing.py tests/test_update_banner_fixes.py::TestUpdateSummaryRouteModelSelection -q --timeout=60
```

Result: `49 passed`

Full-suite ordering check for profile module reload isolation:

```text
python -m pytest tests/test_profile_path_security.py tests/test_sprint46.py::test_manual_compress_worker_uses_session_profile_env tests/test_title_aux_routing.py::TestBackgroundTitleProfileRouting::test_profile_env_context_logs_fail_open_resolution_errors tests/test_title_aux_routing.py::TestBackgroundTitleProfileRouting::test_background_title_generation_uses_session_profile_home tests/test_update_banner_fixes.py::TestUpdateSummaryRouteModelSelection::test_summary_route_auxiliary_model_uses_active_profile_env -q --timeout=60
```

Result: `7 passed`

Adjacent env-lock/runtime coverage:

```text
python -m pytest tests/test_issue2024_env_lock_skill_imports.py tests/test_sprint42.py tests/test_issue1164_env_file_corruption.py tests/test_issue1362_codex_oauth_onboarding.py -q --timeout=60
```

Result: `66 passed`

Syntax / hygiene checks:

```text
python -m py_compile api/profiles.py api/routes.py api/streaming.py tests/test_profile_path_security.py tests/test_sprint29.py tests/test_sprint46.py tests/test_title_aux_routing.py tests/test_update_banner_fixes.py

git diff --check
```

Result: passed

## Risks / Follow-ups

- The title/compression/update-summary profile contexts hold the shared env lock across the auxiliary/config call to keep process-global environment and module globals stable. That is the safe option with the current architecture, but it can serialize concurrent env-touching work while a slow auxiliary call is in flight.
- Existing source-string assertions remain in some pre-existing update-summary tests; this PR removes the new brittle assertions added during the fix and keeps the new profile-routing coverage behavioral.

## Models Used

- GPT-5.5 XHIGH (implementation) 
- Claude Opus 4.7 (independent review) 

