### PR TITLE
fix(profile): seed bundled skills for fresh WebUI-created profiles (#2305)

### DIFF
--- a/api/profiles.py
+++ b/api/profiles.py
@@ -1067,6 +1067,22 @@ def create_profile_api(name: str, clone_from: str = None,
         model_provider=model_provider,
     )
 
+    # Seed bundled skills for fresh (non-cloned) profiles so WebUI-created
+    # profiles match CLI behaviour (#2305).  Cloned profiles already inherit
+    # skills from the source.  Wrapped in try/except so a seed failure is
+    # non-fatal — an empty skills/ directory is recoverable, a missing profile
+    # is not.
+    if clone_from is None:
+        try:
+            from hermes_cli.profiles import seed_profile_skills
+            seed_profile_skills(profile_path, quiet=True)
+        except ImportError:
+            # hermes_cli unavailable in Docker/standalone fallback — skills/
+            # remains empty, which is the pre-existing behaviour for that path.
+            logger.debug("hermes_cli unavailable; skipping skill seed for %s", name)
+        except Exception as e:
+            logger.warning("seed_profile_skills failed for new profile %s: %s", name, e)
+
     # Invalidate cached root-profile-name lookup; create_profile may have added
     # a new profile that flips is_default semantics on the agent side (#1612).
     _invalidate_root_profile_cache()

--- a/tests/test_issue2305_seed_profile_skills.py
+++ b/tests/test_issue2305_seed_profile_skills.py
@@ -1,0 +1,163 @@
+"""Regression coverage for #2305 — new profiles created without clone get bundled skills."""
+
+import json
+import os
+import pathlib
+import shutil
+import urllib.error
+import urllib.request
+
+import pytest
+
+import api.profiles as profiles
+
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+
+
+class TestProfileCreateSkillSeeding:
+    """Verify that create_profile_api seeds bundled skills for fresh profiles."""
+
+    def test_create_profile_api_seeds_skills_when_clone_from_none(self, monkeypatch, tmp_path):
+        """Fresh profile (clone_from=None) should call seed_profile_skills."""
+        base = tmp_path / ".hermes"
+        monkeypatch.setenv("HERMES_BASE_HOME", str(base))
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+
+        # Ensure hermes_cli is not importable so we hit the fallback path,
+        # then simulate seed_profile_skills being available by monkeypatching
+        # the import in create_profile_api.
+        seed_calls = []
+
+        def fake_seed(profile_dir, quiet=False):
+            seed_calls.append((str(profile_dir), quiet))
+            # Create a dummy skill file so the profile looks seeded
+            skills_dir = pathlib.Path(profile_dir) / "skills"
+            skills_dir.mkdir(parents=True, exist_ok=True)
+            (skills_dir / "test-skill-2305").mkdir(parents=True, exist_ok=True)
+            (skills_dir / "test-skill-2305" / "SKILL.md").write_text(
+                "---\nname: test-skill-2305\n---\n", encoding="utf-8"
+            )
+
+        # Patch the hermes_cli.profiles module in sys.modules
+        import sys
+        fake_module = type(sys)("hermes_cli.profiles")
+        fake_module.seed_profile_skills = fake_seed
+        fake_module.create_profile = lambda *args, **kwargs: None
+        monkeypatch.setitem(sys.modules, "hermes_cli.profiles", fake_module)
+
+        # Also need hermes_cli itself
+        if "hermes_cli" not in sys.modules:
+            monkeypatch.setitem(sys.modules, "hermes_cli", type(sys)("hermes_cli"))
+
+        # Re-import api.profiles to pick up the patched environment
+        monkeypatch.delitem(sys.modules, "api.profiles", raising=False)
+        import importlib
+        profiles_mod = importlib.import_module("api.profiles")
+
+        result = profiles_mod.create_profile_api("test-seed-2305", clone_from=None)
+
+        assert len(seed_calls) == 1, f"Expected 1 seed call, got {len(seed_calls)}"
+        assert "test-seed-2305" in seed_calls[0][0]
+        assert seed_calls[0][1] is True  # quiet=True
+
+    def test_create_profile_api_skips_seed_when_clone_from_set(self, monkeypatch, tmp_path):
+        """Cloned profile should NOT call seed_profile_skills (skills copied from source)."""
+        base = tmp_path / ".hermes"
+        (base / "profiles" / "source" / "skills" / "existing-skill").mkdir(parents=True)
+        (base / "profiles" / "source" / "skills" / "existing-skill" / "SKILL.md").write_text(
+            "---\nname: existing-skill\n---\n", encoding="utf-8"
+        )
+        monkeypatch.setenv("HERMES_BASE_HOME", str(base))
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+
+        seed_calls = []
+
+        def fake_seed(profile_dir, quiet=False):
+            seed_calls.append((str(profile_dir), quiet))
+
+        import sys
+        fake_module = type(sys)("hermes_cli.profiles")
+        fake_module.seed_profile_skills = fake_seed
+        fake_module.create_profile = lambda *args, **kwargs: None
+        monkeypatch.setitem(sys.modules, "hermes_cli.profiles", fake_module)
+
+        if "hermes_cli" not in sys.modules:
+            monkeypatch.setitem(sys.modules, "hermes_cli", type(sys)("hermes_cli"))
+
+        monkeypatch.delitem(sys.modules, "api.profiles", raising=False)
+        import importlib
+        profiles_mod = importlib.import_module("api.profiles")
+
+        result = profiles_mod.create_profile_api("test-clone-2305", clone_from="source", clone_config=True)
+
+        assert len(seed_calls) == 0, f"Expected 0 seed calls for cloned profile, got {len(seed_calls)}"
+
+    def test_seed_failure_is_non_fatal(self, monkeypatch, tmp_path):
+        """If seed_profile_skills raises, profile creation should still succeed."""
+        base = tmp_path / ".hermes"
+        monkeypatch.setenv("HERMES_BASE_HOME", str(base))
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+
+        def failing_seed(profile_dir, quiet=False):
+            raise RuntimeError("Simulated seed failure")
+
+        import sys
+        fake_module = type(sys)("hermes_cli.profiles")
+        fake_module.seed_profile_skills = failing_seed
+        fake_module.create_profile = lambda *args, **kwargs: None
+        monkeypatch.setitem(sys.modules, "hermes_cli.profiles", fake_module)
+
+        if "hermes_cli" not in sys.modules:
+            monkeypatch.setitem(sys.modules, "hermes_cli", type(sys)("hermes_cli"))
+
+        monkeypatch.delitem(sys.modules, "api.profiles", raising=False)
+        import importlib
+        profiles_mod = importlib.import_module("api.profiles")
+
+        # Should not raise
+        result = profiles_mod.create_profile_api("test-fail-2305", clone_from=None)
+
+        assert result["name"] == "test-fail-2305"
+        assert result["skill_count"] == 0  # Empty because seed failed
+
+
+class TestProfileCreateSkillSeedingStatic:
+    """Static analysis — verify the seed call exists in the source."""
+
+    def test_create_profile_api_contains_seed_call(self):
+        src = (REPO / "api" / "profiles.py").read_text(encoding="utf-8")
+        assert "seed_profile_skills" in src, (
+            "api/profiles.py must call seed_profile_skills for #2305"
+        )
+
+    def test_seed_is_conditional_on_clone_from_none(self):
+        src = (REPO / "api" / "profiles.py").read_text(encoding="utf-8")
+        # Find the create_profile_api function
+        fn_start = src.find("def create_profile_api(")
+        assert fn_start != -1
+        fn_end = src.find("\ndef ", fn_start + 1)
+        if fn_end == -1:
+            fn_end = len(src)
+        fn_body = src[fn_start:fn_end]
+
+        assert "if clone_from is None:" in fn_body, (
+            "seed_profile_skills must be gated on clone_from is None"
+        )
+        assert "seed_profile_skills" in fn_body
+
+    def test_seed_failure_wrapped_in_try_except(self):
+        src = (REPO / "api" / "profiles.py").read_text(encoding="utf-8")
+        fn_start = src.find("def create_profile_api(")
+        assert fn_start != -1
+        fn_end = src.find("\ndef ", fn_start + 1)
+        if fn_end == -1:
+            fn_end = len(src)
+        fn_body = src[fn_start:fn_end]
+
+        assert "except ImportError:" in fn_body, (
+            "seed call must handle hermes_cli being unavailable"
+        )
+        assert "except Exception" in fn_body, (
+            "seed call must handle general failures non-fatally"
+        )


### PR DESCRIPTION
## Problem

When creating a new profile via the Web UI **without** checking "Clone from active profile", the resulting profile has **0 skills** (empty `skills/` directory). This is inconsistent with the CLI behavior where `hermes profile create foo` automatically seeds bundled skills.

## Root Cause

`api/profiles.py::create_profile_api()` never called `seed_profile_skills()`. The CLI entrypoint (`hermes_cli/main.py`) and the web server route (`hermes_cli/web_server.py`) both call it, but the WebUI's `create_profile_api()` bypassed this.

## Fix

- Add `seed_profile_skills()` call in `create_profile_api()` when `clone_from is None` (fresh profile).
- Skip seeding for cloned profiles since `create_profile()` already copies skills from the source.
- Wrap in `try/except` so a seed failure is non-fatal — an empty `skills/` directory is recoverable, a missing profile is not.
- Handle `ImportError` for Docker/standalone fallback paths where `hermes_cli` is unavailable.

## Tests

Added `tests/test_issue2305_seed_profile_skills.py` with 6 tests:
1. Fresh profile (`clone_from=None`) calls `seed_profile_skills`
2. Cloned profile does NOT call `seed_profile_skills`
3. Seed failure is non-fatal
4-6. Static analysis verifying the seed call exists, is conditional on `clone_from is None`, and has proper exception handling

## Verification

```bash
python -m pytest tests/test_issue2305_seed_profile_skills.py -q
```

All 6 tests pass.

Refs #2305, #749