### PR TITLE
fix: defer mobile stream errors while tab is hidden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ### Fixed
 
+- Mobile/backgrounded chat streams no longer immediately insert a permanent `**Error:** Connection lost` bubble when Android/browser tab suspension drops the SSE connection. The client now defers stream-error finalization while the page is hidden/discarded, keeps the stream marked active locally, and reattaches or restores the settled session when the tab returns before showing a real failure.
+
 - **PR #2275** by @ai-ag2026 — CLI/messaging continuation sessions (sessions stitched from a `parent_session_id` chain) now return their full transcript instead of an empty list. Pre-fix, `get_cli_session_messages()` called `_is_continuation_session()` while walking the parent chain, but `api/models.py` didn't import that helper. The exception was swallowed by `except Exception: return []`, so valid external sessions could fall through silently. Adds regression coverage that a stitched continuation chain returns a non-empty transcript.
 
 - **PR #2277** by @eleboucher — Rootless container runtimes (k8s `runAsNonRoot: true`, OpenShift restricted SCC, `docker --user`, rootless Podman) no longer hit a cascade of permission errors at startup. Pre-fix, the rootless branch skipped the root init phase entirely, but root init also did rsync, `/uv_cache` permissions, `~/hermeswebui` home directory creation, and `/workspace` writability. `docker_init.bash` now distinguishes "no root init available" from "root init available but skipped", running the work that doesn't need root in the rootless branch too.

--- a/static/messages.js
+++ b/static/messages.js
@@ -578,6 +578,54 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
   // ── Shared SSE handler wiring (used for initial connection and reconnect) ──
   let _reconnectAttempted=false;
   let _terminalStateReached=false;
+  let _deferredStreamRecoveryBound=false;
+
+  function _pageHiddenForStreamError(){
+    return (typeof document!=='undefined'&&document.visibilityState==='hidden')||
+      (typeof document!=='undefined'&&document.wasDiscarded===true);
+  }
+
+  function _reattachOrRestoreAfterDeferredStreamError(){
+    if(_terminalStateReached||_streamFinalized) return;
+    (async()=>{
+      try{
+        if(streamId){
+          const st=await api(`/api/chat/stream/status?stream_id=${encodeURIComponent(streamId)}`);
+          if(st.active){
+            setComposerStatus('Reconnected');
+            _wireSSE(new EventSource(new URL(`api/chat/stream?stream_id=${encodeURIComponent(streamId)}`,document.baseURI||location.href).href,{withCredentials:true}));
+            return;
+          }
+        }
+      }catch(_){
+        if(_deferStreamErrorIfOffline()||_pageHiddenForStreamError()) return;
+      }
+      if(await _restoreSettledSession()) return;
+      if(_deferStreamErrorIfOffline()||_pageHiddenForStreamError()) return;
+      _handleStreamError();
+    })();
+  }
+
+  function _deferStreamErrorIfPageHidden(){
+    if(!_pageHiddenForStreamError()) return false;
+    setComposerStatus('Connection paused. Reconnecting when this tab returns…');
+    if(S.session&&S.session.session_id===activeSid&&streamId) S.activeStreamId=streamId;
+    if(!_deferredStreamRecoveryBound){
+      _deferredStreamRecoveryBound=true;
+      const resume=()=>{
+        if(_pageHiddenForStreamError()) return;
+        window.removeEventListener('focus',resume);
+        window.removeEventListener('pageshow',resume);
+        document.removeEventListener('visibilitychange',resume);
+        _deferredStreamRecoveryBound=false;
+        _reattachOrRestoreAfterDeferredStreamError();
+      };
+      document.addEventListener('visibilitychange',resume);
+      window.addEventListener('focus',resume);
+      window.addEventListener('pageshow',resume);
+    }
+    return true;
+  }
 
   // Bug A fix (#631): track whether the stream has been finalized so any rAF
   // scheduled by a trailing 'token'/'reasoning' event that arrives in the same
@@ -1617,6 +1665,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     source.addEventListener('error',async e=>{
       source.close();
       if(_deferStreamErrorIfOffline()) return;
+      if(_deferStreamErrorIfPageHidden()) return;
       if(_terminalStateReached || _streamFinalized){
         _closeSource();
         return;
@@ -1638,12 +1687,14 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
           }
           if(await _restoreSettledSession()) return;
           if(_deferStreamErrorIfOffline()) return;
+          if(_deferStreamErrorIfPageHidden()) return;
           _handleStreamError();
         },1500);
         return;
       }
       if(await _restoreSettledSession()) return;
       if(_deferStreamErrorIfOffline()) return;
+      if(_deferStreamErrorIfPageHidden()) return;
       _handleStreamError();
     });
 

--- a/tests/test_offline_banner.py
+++ b/tests/test_offline_banner.py
@@ -70,3 +70,24 @@ def test_sse_network_error_defers_to_offline_banner_instead_of_inline_error():
     assert "if(_deferStreamErrorIfOffline()) return;" in MESSAGES_JS
     error_handler = MESSAGES_JS.split("source.addEventListener('error',async e=>{", 1)[1].split("source.addEventListener('cancel'", 1)[0]
     assert error_handler.find("_deferStreamErrorIfOffline()") < error_handler.rfind("_handleStreamError()")
+
+
+def test_sse_error_defers_while_page_hidden_until_tab_returns():
+    assert "function _deferStreamErrorIfPageHidden()" in MESSAGES_JS
+    assert "document.visibilityState==='hidden'" in MESSAGES_JS
+    assert "document.wasDiscarded===true" in MESSAGES_JS
+    assert "Connection paused. Reconnecting when this tab returns…" in MESSAGES_JS
+    assert "document.addEventListener('visibilitychange',resume)" in MESSAGES_JS
+    assert "window.addEventListener('pageshow',resume)" in MESSAGES_JS
+    error_handler = MESSAGES_JS.split("source.addEventListener('error',async e=>{", 1)[1].split("source.addEventListener('cancel'", 1)[0]
+    assert "if(_deferStreamErrorIfPageHidden()) return;" in error_handler
+    assert error_handler.find("_deferStreamErrorIfPageHidden()") < error_handler.rfind("_handleStreamError()")
+
+
+def test_deferred_hidden_stream_error_reattaches_or_restores_before_inline_error():
+    recovery_block = MESSAGES_JS.split("function _reattachOrRestoreAfterDeferredStreamError(){", 1)[1].split("function _deferStreamErrorIfPageHidden()", 1)[0]
+    assert "api(`/api/chat/stream/status?stream_id=${encodeURIComponent(streamId)}`)" in recovery_block
+    assert "if(st.active)" in recovery_block
+    assert "_wireSSE(new EventSource" in recovery_block
+    assert "if(await _restoreSettledSession()) return;" in recovery_block
+    assert recovery_block.find("if(await _restoreSettledSession()) return;") < recovery_block.rfind("_handleStreamError()")


### PR DESCRIPTION
## Thinking Path
- Issue #2307 reports Android/backgrounded tabs showing a permanent `**Error:** Connection lost` even though the backend stream can keep running and replay buffered events.
- The risky part is not backend cancellation; it is client-side SSE error finalization while the page is hidden or discarded.
- Keep the fix narrow: defer the inline error only while the page is hidden/discarded, then reattach to the active stream or restore the settled session when the tab returns.

## What Changed
- Added hidden/discarded-page stream-error deferral in `static/messages.js`.
- Preserves the active stream id locally instead of clearing inflight state when Android/browser suspension drops the EventSource.
- On `visibilitychange`, `focus`, or `pageshow`, checks stream status, reattaches if active, restores the settled session if complete, and only then falls back to the existing connection-lost error path.
- Added source-level regression coverage for hidden-page deferral and deferred reattach/restore ordering.
- Added an Unreleased changelog note.

## Why It Matters
- Mobile users can background WebUI during long responses without immediately seeing a fake cancellation/error bubble when they return.
- The backend's existing StreamChannel/offline-buffer behavior is now reachable from the common Android tab-suspension path.

## Verification
- `node --check static/messages.js`
- `python -m pytest tests/test_offline_banner.py tests/test_streaming_race_fix.py -q` → 18 passed
- `python -m pytest tests/test_issue856_active_session_read_state.py tests/test_issue856_background_completion_unread.py tests/test_1694_terminal_cleanup_ownership.py -q` → 29 passed
- `git diff --check`

## Risks / Follow-ups
- This is the minimum safe fix for the fake-error path. A fuller follow-up could add visible-state exponential reconnect backoff for flaky cellular networks.
- No screenshot included because this changes stream error-state behavior rather than a stable visual layout; the behavior is covered by source-level regressions.

## Model Used
AI-assisted change with repository inspection, targeted editing, and shell-based test verification.

Closes #2307
