### PR TITLE
feat: store chat uploads outside workspace root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- **PR #TBD** (refs #2247) — Chat file uploads now land in a session-scoped attachment inbox instead of cluttering the active workspace root. By default uploads are stored under `~/.hermes/webui/attachments/<session_id>/`; operators can override the root with `HERMES_WEBUI_ATTACHMENT_DIR`, and the agent still receives the absolute uploaded file path for context.
+
 - **PR #2287** by @mslovy (refs #2284) — Upload size limit is now runtime-configurable via the `HERMES_WEBUI_MAX_UPLOAD_MB` environment variable. Previously the effective 20 MB cap was hard-coded across multiple layers. Server-side upload limit moves to runtime config; browser-side preflight check stays aligned with the effective backend limit; archive extraction guard continues to scale with the same configured cap. New `_env_mb_bytes()` helper in `api/config.py` parses `HERMES_WEBUI_MAX_UPLOAD_MB`.
 
 - **PR #2291** by @linuxid10t — New "Nous Research" skin option in the Settings → Appearance picker, inspired by [nousresearch.com](https://nousresearch.com). Monospace typography, steel blue (#4682B4) accent, cool gray text, sharp 1-2px corners, thin dashed borders, technical aesthetic.

--- a/README.md
+++ b/README.md
@@ -389,7 +389,7 @@ Production data and real cron jobs are never touched. Current snapshot:
 - Thinking/reasoning display -- collapsible gold-themed cards for Claude extended thinking and o3 reasoning blocks
 - Approval card for dangerous shell commands (allow once / session / always / deny)
 - SSE auto-reconnect on network blips (SSH tunnel resilience)
-- File attachments persist across page reloads
+- File attachments persist across page reloads and are stored outside the active workspace by default (`~/.hermes/webui/attachments/<session_id>/`, or `HERMES_WEBUI_ATTACHMENT_DIR/<session_id>/` when configured)
 - Message timestamps (HH:MM next to each message, full date on hover)
 - Code block copy button with "Copied!" feedback
 - Syntax highlighting via Prism.js (Python, JS, bash, JSON, SQL, and more)

--- a/api/upload.py
+++ b/api/upload.py
@@ -2,12 +2,13 @@
 Hermes Web UI -- File upload: multipart parser and upload handler.
 """
 import mimetypes
+import os
 import re as _re
 import email.parser
 import tempfile
 from pathlib import Path
 
-from api.config import MAX_UPLOAD_BYTES
+from api.config import MAX_UPLOAD_BYTES, STATE_DIR
 from api.helpers import j, bad
 from api.models import get_session
 from api.workspace import safe_resolve_ws
@@ -61,6 +62,31 @@ def _sanitize_upload_name(filename: str) -> str:
     return safe_name
 
 
+def _attachment_root() -> Path:
+    """Return the configured upload inbox root.
+
+    Plain chat attachments are transient context for the agent, not project
+    source files.  Keep them out of the active workspace by default while still
+    allowing operators to move the inbox with HERMES_WEBUI_ATTACHMENT_DIR.
+    """
+    override = os.getenv('HERMES_WEBUI_ATTACHMENT_DIR', '').strip()
+    if override:
+        return Path(override).expanduser().resolve()
+    return (STATE_DIR / 'attachments').resolve()
+
+
+def _upload_destination(session_id: str, safe_name: str) -> Path:
+    root = _attachment_root()
+    dest_dir = (root / _re.sub(r'[^\w.\-]', '_', str(session_id or 'session'))[:120]).resolve()
+    if not dest_dir.is_relative_to(root):
+        raise ValueError('Invalid attachment directory')
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    dest = (dest_dir / safe_name).resolve()
+    if not dest.is_relative_to(dest_dir):
+        raise ValueError('Invalid upload destination')
+    return dest
+
+
 def handle_upload(handler):
     import traceback as _tb
     try:
@@ -79,9 +105,8 @@ def handle_upload(handler):
             s = get_session(session_id)
         except KeyError:
             return j(handler, {'error': 'Session not found'}, status=404)
-        workspace = Path(s.workspace)
         safe_name = _sanitize_upload_name(filename)
-        dest = safe_resolve_ws(workspace, safe_name)
+        dest = _upload_destination(session_id, safe_name)
         dest.write_bytes(file_bytes)
         mime = mimetypes.guess_type(safe_name)[0] or 'application/octet-stream'
         return j(handler, {

--- a/tests/test_sprint1.py
+++ b/tests/test_sprint1.py
@@ -296,7 +296,7 @@ def test_parse_multipart_binary_file():
 # ──────────────────────────────────────────────
 
 def test_upload_text_file(cleanup_test_sessions):
-    """Upload a text file to a session workspace, verify it appears in /api/list."""
+    """Upload a text file to the attachment inbox, not the workspace root."""
     sid, ws = make_session_tracked(cleanup_test_sessions)
 
     result, status = post_multipart("/api/upload", {"session_id": sid}, {
@@ -306,12 +306,30 @@ def test_upload_text_file(cleanup_test_sessions):
     assert "filename" in result
     assert result["size"] == len(b"sprint1 test content")
 
-    # Verify file appears in listing
+    uploaded_path = pathlib.Path(result["path"])
+    assert uploaded_path.exists()
+    assert uploaded_path.read_bytes() == b"sprint1 test content"
+    assert uploaded_path.parent.name == sid
+
+    # Verify ordinary chat uploads no longer clutter the workspace listing.
     listing = get(f"/api/list?session_id={sid}&path=.")
     names = [e["name"] for e in listing["entries"]]
-    assert result["filename"] in names, f"{result['filename']} not in {names}"
-    # Cleanup the uploaded file
-    post("/api/file/delete", {"session_id": sid, "path": result["filename"]})
+    assert result["filename"] not in names, f"{result['filename']} unexpectedly in {names}"
+    # Cleanup the uploaded file from the attachment inbox.
+    uploaded_path.unlink(missing_ok=True)
+
+
+def test_upload_respects_attachment_dir_env(monkeypatch, tmp_path):
+    """HERMES_WEBUI_ATTACHMENT_DIR routes chat uploads to a per-session inbox."""
+    from api.upload import _upload_destination
+
+    inbox = tmp_path / "attachment-inbox"
+    monkeypatch.setenv("HERMES_WEBUI_ATTACHMENT_DIR", str(inbox))
+
+    dest = _upload_destination("session-123", "notes.md")
+
+    assert dest == inbox.resolve() / "session-123" / "notes.md"
+    assert dest.parent.exists()
 
 
 def test_upload_too_large(cleanup_test_sessions):


### PR DESCRIPTION
## Thinking Path
- Uploaded chat files are context for the agent, but the current upload route writes them directly into the active workspace root.
- In project workspaces that makes reference PDFs, screenshots, and temporary logs look like project files.
- The narrowest safe first slice is to move ordinary chat uploads into a session-scoped attachment inbox while preserving the absolute path returned to the agent.
- Archive extraction remains workspace-scoped because extracting an archive is an explicit workspace operation.

## What Changed
- Added a chat-upload destination helper that stores uploads under `~/.hermes/webui/attachments/<session_id>/` by default.
- Added `HERMES_WEBUI_ATTACHMENT_DIR` so operators can move the attachment inbox elsewhere; uploads still use a per-session subdirectory.
- Kept `/api/upload` returning the absolute file path, MIME type, size, and image flag so the existing chat/agent attachment flow continues to work.
- Updated upload regression coverage and README/changelog notes for the new storage behavior.

## Why It Matters
- Keeps attached context files out of real project/workspace roots.
- Preserves agent readability because uploaded files are still passed by absolute path.
- Gives self-hosted operators a simple deployment-level storage knob before a future Settings UI layer.

## Verification
- `/home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_sprint1.py::test_upload_text_file tests/test_sprint1.py::test_upload_respects_attachment_dir_env -q` → 2 passed
- `/home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_sprint1.py::test_upload_text_file tests/test_sprint1.py::test_upload_respects_attachment_dir_env tests/test_sprint1.py::test_upload_too_large tests/test_sprint1.py::test_upload_no_file_field tests/test_sprint1.py::test_upload_bad_session tests/test_native_image_attachments.py -q` → 38 passed
- `git diff --check` → passed

## Risks / Follow-ups
- This is the server-side storage slice and refs #2247 rather than fully closing it.
- A follow-up can expose the attachment directory in Settings → Storage if maintainers want browser-level configuration in addition to the environment variable.
- Existing scripts that expected uploads to appear in the workspace root should use the returned absolute upload path instead.

## Model Used
AI-assisted change with repository inspection, targeted editing, and shell-based test verification.

Refs #2247
