### PR TITLE
stage-361: 4-PR follow-up batch — profile skill seeding + theme fallback + mobile stream defer + chat upload relocation (with vision-model regression fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ### Fixed
 
+- **PR #2317** (refs #2312) — Appearance boot reconciliation now treats explicit `light`, `dark`, and `system` localStorage theme values as user selections when a prior Settings autosave failed. Previously only `system` was considered explicit, so users who picked `light` on a server defaulted to `dark` (or vice versa) could still be reverted on refresh.
+
 - **PR #2275** by @ai-ag2026 — CLI/messaging continuation sessions (sessions stitched from a `parent_session_id` chain) now return their full transcript instead of an empty list. Pre-fix, `get_cli_session_messages()` called `_is_continuation_session()` while walking the parent chain, but `api/models.py` didn't import that helper. The exception was swallowed by `except Exception: return []`, so valid external sessions could fall through silently. Adds regression coverage that a stitched continuation chain returns a non-empty transcript.
 
 - **PR #2277** by @eleboucher — Rootless container runtimes (k8s `runAsNonRoot: true`, OpenShift restricted SCC, `docker --user`, rootless Podman) no longer hit a cascade of permission errors at startup. Pre-fix, the rootless branch skipped the root init phase entirely, but root init also did rsync, `/uv_cache` permissions, `~/hermeswebui` home directory creation, and `/workspace` writability. `docker_init.bash` now distinguishes "no root init available" from "root init available but skipped", running the work that doesn't need root in the rootless branch too.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ### Fixed
 
+- Mobile/backgrounded chat streams no longer immediately insert a permanent `**Error:** Connection lost` bubble when Android/browser tab suspension drops the SSE connection. The client now defers stream-error finalization while the page is hidden/discarded, keeps the stream marked active locally, and reattaches or restores the settled session when the tab returns before showing a real failure.
+
 - **PR #2275** by @ai-ag2026 — CLI/messaging continuation sessions (sessions stitched from a `parent_session_id` chain) now return their full transcript instead of an empty list. Pre-fix, `get_cli_session_messages()` called `_is_continuation_session()` while walking the parent chain, but `api/models.py` didn't import that helper. The exception was swallowed by `except Exception: return []`, so valid external sessions could fall through silently. Adds regression coverage that a stitched continuation chain returns a non-empty transcript.
 
 - **PR #2277** by @eleboucher — Rootless container runtimes (k8s `runAsNonRoot: true`, OpenShift restricted SCC, `docker --user`, rootless Podman) no longer hit a cascade of permission errors at startup. Pre-fix, the rootless branch skipped the root init phase entirely, but root init also did rsync, `/uv_cache` permissions, `~/hermeswebui` home directory creation, and `/workspace` writability. `docker_init.bash` now distinguishes "no root init available" from "root init available but skipped", running the work that doesn't need root in the rootless branch too.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- **PR #TBD** (refs #2247) — Chat file uploads now land in a session-scoped attachment inbox instead of cluttering the active workspace root. By default uploads are stored under `~/.hermes/webui/attachments/<session_id>/`; operators can override the root with `HERMES_WEBUI_ATTACHMENT_DIR`, and the agent still receives the absolute uploaded file path for context.
+
 - **PR #2287** by @mslovy (refs #2284) — Upload size limit is now runtime-configurable via the `HERMES_WEBUI_MAX_UPLOAD_MB` environment variable. Previously the effective 20 MB cap was hard-coded across multiple layers. Server-side upload limit moves to runtime config; browser-side preflight check stays aligned with the effective backend limit; archive extraction guard continues to scale with the same configured cap. New `_env_mb_bytes()` helper in `api/config.py` parses `HERMES_WEBUI_MAX_UPLOAD_MB`.
 
 - **PR #2291** by @linuxid10t — New "Nous Research" skin option in the Settings → Appearance picker, inspired by [nousresearch.com](https://nousresearch.com). Monospace typography, steel blue (#4682B4) accent, cool gray text, sharp 1-2px corners, thin dashed borders, technical aesthetic.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## [Unreleased]
 
+### Added
+
+- **PR #2319** by @Michaelyklam — Chat file uploads now land in a session-scoped attachment inbox instead of cluttering the active workspace root. By default uploads are stored under `~/.hermes/webui/attachments/<session_id>/`; operators can override the root with `HERMES_WEBUI_ATTACHMENT_DIR`, and the agent still receives the absolute uploaded file path for context. Archive extraction stays workspace-scoped (it's an explicit workspace operation). README updated to document the new default location.
+
+### Fixed
+
+- **PR #2315** by @Michaelyklam (closes #2305, refs #749) — WebUI profile creation now seeds bundled profile skills for newly-created non-cloned profiles, matching the CLI's `hermes profile create` behaviour. Pre-fix, creating a profile via Settings → New Profile (without checking "Clone from active profile") left the profile's `skills/` directory empty, which was inconsistent with CLI-created profiles that get the full bundled-skills overlay. The fix calls `seed_profile_skills(profile_path, quiet=True)` after `profile_path.mkdir()` when `clone_from is None`. Cloned profiles still inherit skills from their source — they don't get a second bundled-skills overlay. Seed failures (e.g. `hermes_cli` unavailable in Docker fallback) are logged as warnings, not fatal — profile creation still succeeds.
+
+- **PR #2317** by @Michaelyklam (refs #2312 follow-up #2) — Appearance boot reconciliation now treats explicit `light`, `dark`, and `system` localStorage theme values as user selections when a prior Settings autosave failed. Pre-fix, the predicate `lsHasExplicitTheme = lsTheme === 'system'` only treated 'system' as explicit, so a user who picked `light` on a server defaulted to `dark` (or vice versa) with a failed autosave still reverted to the server default on refresh. Now broadened to `['system','light','dark'].includes(lsTheme)`. Skin handling was already correct (`lsSkin !== 'default'`). Closes follow-up item #2 from the v0.51.66 review (#2312).
+
+- **PR #2318** by @Michaelyklam (closes #2307) — Mobile/Android backgrounded tabs no longer show a permanent `**Error:** Connection lost` banner when the backend stream is still alive and able to replay buffered events. Pre-fix, the SSE error finalization fired regardless of page visibility state, so any tab discarded by the mobile OS (battery saver, tab compression, brief switch to another app) showed a permanent error even though the stream could be re-attached on visibility return. The fix defers inline stream error rendering while `document.visibilityState === 'hidden'` or `document.wasDiscarded === true`, then on visibility return polls `/api/chat/stream/status?stream_id=...`. If the stream is still active, reattaches with a fresh `EventSource`. If not, falls back to the settled-session restore path. If both paths fail, falls back to the original error rendering. Behaviour on desktop and on tabs that ARE visible is unchanged.
+
+## [v0.51.67] — 2026-05-15 — Release AQ (stage-360 — 3-PR streaming-lane batch — #2279 stream completion recovery + #2299 profile-scoped aux routing + #2306 workspace panel polish — with _ENV_LOCK narrow-lock architectural fix)
+
 ### Fixed
 
 - **PR #2279** by @franksong2702 (closes #2262 + refs #2168) — WebUI stream completion recovery gaps closed for both `notify_on_complete` background tasks and the preserved-task-list compression marker UI. Pre-fix, completions held in the agent process registry were never drained by the WebUI gateway session because the gateway session platform was unset. The fix routes the completion queue by process session key before injecting any notification into a WebUI turn. Separately, the preserved-task-list compression marker — an internal sentinel — was sometimes the only assistant text rendered after a context compression turn timed out, leaving a confusing "preserved tasks" message with no actual response. The frontend now suppresses the marker when it's the only assistant content and the run state is terminal.
@@ -14,7 +28,6 @@
 
 ### Added
 
-- **PR #TBD** (refs #2247) — Chat file uploads now land in a session-scoped attachment inbox instead of cluttering the active workspace root. By default uploads are stored under `~/.hermes/webui/attachments/<session_id>/`; operators can override the root with `HERMES_WEBUI_ATTACHMENT_DIR`, and the agent still receives the absolute uploaded file path for context.
 
 - **PR #2287** by @mslovy (refs #2284) — Upload size limit is now runtime-configurable via the `HERMES_WEBUI_MAX_UPLOAD_MB` environment variable. Previously the effective 20 MB cap was hard-coded across multiple layers. Server-side upload limit moves to runtime config; browser-side preflight check stays aligned with the effective backend limit; archive extraction guard continues to scale with the same configured cap. New `_env_mb_bytes()` helper in `api/config.py` parses `HERMES_WEBUI_MAX_UPLOAD_MB`.
 
@@ -26,7 +39,6 @@
 
 ### Fixed
 
-- **PR #2317** (refs #2312) — Appearance boot reconciliation now treats explicit `light`, `dark`, and `system` localStorage theme values as user selections when a prior Settings autosave failed. Previously only `system` was considered explicit, so users who picked `light` on a server defaulted to `dark` (or vice versa) could still be reverted on refresh.
 
 - **PR #2275** by @ai-ag2026 — CLI/messaging continuation sessions (sessions stitched from a `parent_session_id` chain) now return their full transcript instead of an empty list. Pre-fix, `get_cli_session_messages()` called `_is_continuation_session()` while walking the parent chain, but `api/models.py` didn't import that helper. The exception was swallowed by `except Exception: return []`, so valid external sessions could fall through silently. Adds regression coverage that a stitched continuation chain returns a non-empty transcript.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- **PR #2319** by @Michaelyklam — Chat file uploads now land in a session-scoped attachment inbox instead of cluttering the active workspace root. By default uploads are stored under `~/.hermes/webui/attachments/<session_id>/`; operators can override the root with `HERMES_WEBUI_ATTACHMENT_DIR`, and the agent still receives the absolute uploaded file path for context. Archive extraction stays workspace-scoped (it's an explicit workspace operation). README updated to document the new default location.
+- **PR #2319** by @Michaelyklam — Chat file uploads now land in a session-scoped attachment inbox instead of cluttering the active workspace root. By default uploads are stored under `~/.hermes/webui/attachments/<session_id>/`; operators can override the root with `HERMES_WEBUI_ATTACHMENT_DIR`, and the agent still receives the absolute uploaded file path for context. Archive extraction stays workspace-scoped (it's an explicit workspace operation). README updated to document the new default location. **Stage-361 maintainer fix applied inline**: Opus advisor caught that `_build_native_multimodal_message` at `api/streaming.py:787` required uploads to be under `workspace_root`, which would have silently dropped every image upload for vision-capable models once the inbox moved outside the workspace. The fix adds `_attachment_root()` (from `api/upload.py`) as a second allowed location, with 3 regression tests covering the new code path AND verifying the original workspace + cross-root rejection paths still work.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Web UI profile creation now seeds bundled profile skills for newly-created non-cloned profiles, matching CLI behavior while leaving cloned profiles unchanged. Seed failures are logged as warnings and do not prevent profile creation. (Closes #2305, refs #749)
+
 ### Added
 
 - **PR #2099** by @dobby-d-elf — Adds an opt-in `Settings → Preferences → Fade text effect` toggle (off by default). When enabled, newly streamed output tokens are revealed through an adaptive playout buffer and animated with an opacity-only fade similar to ChatGPT and other frontier LLM apps. Implementation details: fade locked per stream to avoid mid-stream toggle rewind; reduced-motion users get non-animated text; live cursor hidden while fade is active; custom renderer on `streaming-markdown` parser wraps only newly-appended words; animated spans replace themselves with plain text on `animationend` (no long-lived wrapper buildup in long responses); unsafe streamed `href`/`src` values blocked in fade renderer `set_attr` path. Performance tuning: 200ms base fade duration scaling to 350ms for fast output, 16ms word stagger, 320ms done-drain wait cap, 160 wps visual cap, max 2-3 words/frame, brief pauses after sentence punctuation. Default-off means existing users see no change. 293-line regression test pinning the contract.

--- a/README.md
+++ b/README.md
@@ -389,7 +389,7 @@ Production data and real cron jobs are never touched. Current snapshot:
 - Thinking/reasoning display -- collapsible gold-themed cards for Claude extended thinking and o3 reasoning blocks
 - Approval card for dangerous shell commands (allow once / session / always / deny)
 - SSE auto-reconnect on network blips (SSH tunnel resilience)
-- File attachments persist across page reloads
+- File attachments persist across page reloads and are stored outside the active workspace by default (`~/.hermes/webui/attachments/<session_id>/`, or `HERMES_WEBUI_ATTACHMENT_DIR/<session_id>/` when configured)
 - Message timestamps (HH:MM next to each message, full date on hover)
 - Code block copy button with "Copied!" feedback
 - Syntax highlighting via Prism.js (Python, JS, bash, JSON, SQL, and more)

--- a/api/profiles.py
+++ b/api/profiles.py
@@ -1060,6 +1060,28 @@ def create_profile_api(name: str, clone_from: str = None,
             break
 
     profile_path.mkdir(parents=True, exist_ok=True)
+
+    # Seed bundled skills for non-cloned profiles (#2305).
+    # Cloned profiles should preserve the clone-source behaviour and must not
+    # receive a second bundled-skill overlay.
+    if clone_from is None:
+        try:
+            from hermes_cli.profiles import seed_profile_skills
+            seed_profile_skills(profile_path, quiet=True)
+        except ImportError:
+            logger.debug(
+                'seed_profile_skills unavailable — bundled skills not seeded '
+                'for profile %s (hermes_cli not in path)',
+                name,
+            )
+        except Exception:
+            logger.warning(
+                'Bundled skills could not be seeded for profile %s; '
+                'profile created successfully anyway',
+                name,
+                exc_info=True,
+            )
+
     _write_endpoint_to_config(profile_path, base_url=base_url, api_key=api_key)
     _write_model_defaults_to_config(
         profile_path,

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -773,6 +773,20 @@ def _build_native_multimodal_message(workspace_ctx: str, msg_text: str, attachme
 
     parts = [{'type': 'text', 'text': workspace_ctx + msg_text}]
     workspace_root = Path(workspace).expanduser().resolve()
+    # Stage-361 maintainer fix (Opus SHOULD-FIX): chat uploads from #2319 now
+    # land in ~/.hermes/webui/attachments/<sid>/ (outside workspace_root by
+    # design). The pre-existing `path.relative_to(workspace_root)` guard would
+    # silently reject every image upload for vision-capable models. Allow the
+    # configured attachment root in addition to workspace_root so native
+    # multimodal embeds still build the base64 image_url part. The
+    # _attachment_root() helper applies expanduser+resolve and is also reused
+    # by _upload_destination — single source of truth for the inbox root.
+    try:
+        from api.upload import _attachment_root
+        attachment_root = _attachment_root()
+        _allowed_roots = (workspace_root, attachment_root)
+    except Exception:
+        _allowed_roots = (workspace_root,)
     image_count = 0
 
     for att in attachments or []:
@@ -783,9 +797,11 @@ def _build_native_multimodal_message(workspace_ctx: str, msg_text: str, attachme
             continue
         try:
             path = Path(raw_path).expanduser().resolve()
-            # Uploads should live inside the selected workspace. Do not read
-            # arbitrary paths from client-provided attachment metadata.
-            path.relative_to(workspace_root)
+            # Uploads should live inside the selected workspace OR the
+            # session attachment inbox (#2319). Do not read arbitrary paths
+            # from client-provided attachment metadata.
+            if not any(path.is_relative_to(r) for r in _allowed_roots):
+                continue
             if not path.is_file():
                 continue
             size = path.stat().st_size

--- a/api/upload.py
+++ b/api/upload.py
@@ -2,12 +2,13 @@
 Hermes Web UI -- File upload: multipart parser and upload handler.
 """
 import mimetypes
+import os
 import re as _re
 import email.parser
 import tempfile
 from pathlib import Path
 
-from api.config import MAX_UPLOAD_BYTES
+from api.config import MAX_UPLOAD_BYTES, STATE_DIR
 from api.helpers import j, bad
 from api.models import get_session
 from api.workspace import safe_resolve_ws
@@ -61,6 +62,31 @@ def _sanitize_upload_name(filename: str) -> str:
     return safe_name
 
 
+def _attachment_root() -> Path:
+    """Return the configured upload inbox root.
+
+    Plain chat attachments are transient context for the agent, not project
+    source files.  Keep them out of the active workspace by default while still
+    allowing operators to move the inbox with HERMES_WEBUI_ATTACHMENT_DIR.
+    """
+    override = os.getenv('HERMES_WEBUI_ATTACHMENT_DIR', '').strip()
+    if override:
+        return Path(override).expanduser().resolve()
+    return (STATE_DIR / 'attachments').resolve()
+
+
+def _upload_destination(session_id: str, safe_name: str) -> Path:
+    root = _attachment_root()
+    dest_dir = (root / _re.sub(r'[^\w.\-]', '_', str(session_id or 'session'))[:120]).resolve()
+    if not dest_dir.is_relative_to(root):
+        raise ValueError('Invalid attachment directory')
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    dest = (dest_dir / safe_name).resolve()
+    if not dest.is_relative_to(dest_dir):
+        raise ValueError('Invalid upload destination')
+    return dest
+
+
 def handle_upload(handler):
     import traceback as _tb
     try:
@@ -79,9 +105,8 @@ def handle_upload(handler):
             s = get_session(session_id)
         except KeyError:
             return j(handler, {'error': 'Session not found'}, status=404)
-        workspace = Path(s.workspace)
         safe_name = _sanitize_upload_name(filename)
-        dest = safe_resolve_ws(workspace, safe_name)
+        dest = _upload_destination(session_id, safe_name)
         dest.write_bytes(file_bytes)
         mime = mimetypes.guess_type(safe_name)[0] or 'application/octet-stream'
         return j(handler, {

--- a/static/boot.js
+++ b/static/boot.js
@@ -1409,15 +1409,16 @@ function applyBotName(){
     // localStorage into 'dark'/'default' BEFORE this code runs, so a truly
     // empty (new-browser) state is indistinguishable from a user who chose
     // the defaults.  To avoid blocking server→client sync on first visit we
-    // only let localStorage override the server when it carries a NON-DEFAULT
-    // skin or a non-dark/light theme value (i.e. the user explicitly picked
-    // something).  When localStorage is at the defaults, the server wins.
+    // only let localStorage override the server when it carries an explicit
+    // user-selectable theme value or a NON-DEFAULT skin.  That keeps the
+    // server in charge for empty first-visit state while preserving explicit
+    // light/dark/system choices after a failed autosave.
     const srvAppearance=_normalizeAppearance(s.theme,s.skin);
     const lsTheme=(localStorage.getItem('hermes-theme')||'').trim().toLowerCase();
     const lsSkin=(localStorage.getItem('hermes-skin')||'').trim().toLowerCase();
     const lsAppearance=_normalizeAppearance(lsTheme||null,lsSkin||null);
     const lsHasExplicitSkin=lsSkin&&lsSkin!=='default';
-    const lsHasExplicitTheme=lsTheme&&lsTheme==='system';
+    const lsHasExplicitTheme=lsTheme&&['system','light','dark'].includes(lsTheme);
     const theme=lsHasExplicitTheme?lsAppearance.theme:srvAppearance.theme;
     const skin=lsHasExplicitSkin?lsAppearance.skin:srvAppearance.skin;
     localStorage.setItem('hermes-theme',theme);

--- a/static/messages.js
+++ b/static/messages.js
@@ -578,6 +578,54 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
   // ── Shared SSE handler wiring (used for initial connection and reconnect) ──
   let _reconnectAttempted=false;
   let _terminalStateReached=false;
+  let _deferredStreamRecoveryBound=false;
+
+  function _pageHiddenForStreamError(){
+    return (typeof document!=='undefined'&&document.visibilityState==='hidden')||
+      (typeof document!=='undefined'&&document.wasDiscarded===true);
+  }
+
+  function _reattachOrRestoreAfterDeferredStreamError(){
+    if(_terminalStateReached||_streamFinalized) return;
+    (async()=>{
+      try{
+        if(streamId){
+          const st=await api(`/api/chat/stream/status?stream_id=${encodeURIComponent(streamId)}`);
+          if(st.active){
+            setComposerStatus('Reconnected');
+            _wireSSE(new EventSource(new URL(`api/chat/stream?stream_id=${encodeURIComponent(streamId)}`,document.baseURI||location.href).href,{withCredentials:true}));
+            return;
+          }
+        }
+      }catch(_){
+        if(_deferStreamErrorIfOffline()||_pageHiddenForStreamError()) return;
+      }
+      if(await _restoreSettledSession()) return;
+      if(_deferStreamErrorIfOffline()||_pageHiddenForStreamError()) return;
+      _handleStreamError();
+    })();
+  }
+
+  function _deferStreamErrorIfPageHidden(){
+    if(!_pageHiddenForStreamError()) return false;
+    setComposerStatus('Connection paused. Reconnecting when this tab returns…');
+    if(S.session&&S.session.session_id===activeSid&&streamId) S.activeStreamId=streamId;
+    if(!_deferredStreamRecoveryBound){
+      _deferredStreamRecoveryBound=true;
+      const resume=()=>{
+        if(_pageHiddenForStreamError()) return;
+        window.removeEventListener('focus',resume);
+        window.removeEventListener('pageshow',resume);
+        document.removeEventListener('visibilitychange',resume);
+        _deferredStreamRecoveryBound=false;
+        _reattachOrRestoreAfterDeferredStreamError();
+      };
+      document.addEventListener('visibilitychange',resume);
+      window.addEventListener('focus',resume);
+      window.addEventListener('pageshow',resume);
+    }
+    return true;
+  }
 
   // Bug A fix (#631): track whether the stream has been finalized so any rAF
   // scheduled by a trailing 'token'/'reasoning' event that arrives in the same
@@ -1617,6 +1665,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     source.addEventListener('error',async e=>{
       source.close();
       if(_deferStreamErrorIfOffline()) return;
+      if(_deferStreamErrorIfPageHidden()) return;
       if(_terminalStateReached || _streamFinalized){
         _closeSource();
         return;
@@ -1638,12 +1687,14 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
           }
           if(await _restoreSettledSession()) return;
           if(_deferStreamErrorIfOffline()) return;
+          if(_deferStreamErrorIfPageHidden()) return;
           _handleStreamError();
         },1500);
         return;
       }
       if(await _restoreSettledSession()) return;
       if(_deferStreamErrorIfOffline()) return;
+      if(_deferStreamErrorIfPageHidden()) return;
       _handleStreamError();
     });
 

--- a/tests/test_batch_fixes.py
+++ b/tests/test_batch_fixes.py
@@ -236,6 +236,13 @@ class TestSystemTheme:
             "_applyTheme must remove the previous OS-theme listener before adding a new one"
         )
 
+    def test_boot_reconcile_treats_light_dark_as_explicit_theme_choices(self):
+        src = read("static/boot.js")
+        assert "['system','light','dark'].includes(lsTheme)" in src, (
+            "boot appearance reconciliation must preserve explicit light/dark/system "
+            "localStorage selections when a prior autosave failed"
+        )
+
     def test_panels_hydrates_appearance_before_models_fetch(self):
         src = read("static/panels.js")
         skin_idx = src.index("const skinVal=(settings.skin||'default').toLowerCase();")

--- a/tests/test_issue2305_profile_create_seeds_skills.py
+++ b/tests/test_issue2305_profile_create_seeds_skills.py
@@ -1,0 +1,262 @@
+# coding: utf-8
+# Regression coverage for issue #2305 — seed bundled skills on profile creation.
+#
+# IMPORTANT: All filesystem operations use temporary directories only.
+# Do NOT touch real ~/.hermes, real credentials, or real profile directories.
+#
+# Test strategy:
+#   - Mock _DEFAULT_HERMES_HOME to a tmp_path so _resolve_base_hermes_home()
+#     picks up the isolated root.
+#   - Inject a mock 'hermes_cli.profiles' module directly into sys.modules so
+#     that the `from hermes_cli.profiles import seed_profile_skills` inside
+#     create_profile_api resolves to the mock (not the real module).
+#   - Stub hermes_cli.profiles.create_profile to create the profile dir.
+#   - Stub hermes_cli.profiles.seed_profile_skills to record calls.
+#   - Verify the no-clone path calls seed exactly once with the resolved path.
+#   - Verify the clone path calls seed zero times.
+#   - Verify a raising seed still returns a profile dict (best-effort).
+#
+# Acceptance criteria:
+#   1. create_profile_api(name, clone_from=None) → seed called once, path = profile_path.
+#   2. create_profile_api(name, clone_from=<str>) → seed never called.
+#   3. seed raising → profile dict returned, warning logged.
+
+import logging
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Import the module under test directly (isolated from any real HERMES_HOME env).
+import api.profiles as profiles_mod
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+def _isolated_profiles_root(fake_home: Path) -> Path:
+    return fake_home / 'profiles'
+
+
+def _make_profile_dir(base: Path, name: str) -> Path:
+    p = base / name
+    p.mkdir(parents=True, exist_ok=True)
+    return p
+
+
+# ── Fixtures ────────────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def fake_hermes_home(tmp_path, monkeypatch):
+    # Point _DEFAULT_HERMES_HOME at an isolated temp directory so that
+    # profile-path resolution does not touch the real ~/.hermes.
+    fake_home = tmp_path / '.hermes'
+    fake_home.mkdir(parents=True)
+    monkeypatch.setenv('HERMES_BASE_HOME', str(fake_home))
+    monkeypatch.setattr(profiles_mod, '_DEFAULT_HERMES_HOME', fake_home)
+    return fake_home
+
+
+def _install_hermes_cli_profiles_mock(create_impl, seed_impl):
+    # Inject a mock 'hermes_cli.profiles' module directly into sys.modules.
+    # This is the only way to intercept `from hermes_cli.profiles import X`
+    # inside create_profile_api — patch.dict(sys.modules, ...) only modifies
+    # existing keys and cannot add new ones.
+    mock = ModuleType('hermes_cli.profiles')
+    mock.create_profile = create_impl
+    mock.seed_profile_skills = seed_impl
+    sys.modules['hermes_cli'] = ModuleType('hermes_cli')
+    sys.modules['hermes_cli.profiles'] = mock
+    return mock
+
+
+def _remove_hermes_cli():
+    for key in list(sys.modules):
+        if key == 'hermes_cli' or key.startswith('hermes_cli.'):
+            del sys.modules[key]
+
+
+# Module references saved at import time so we can restore the real hermes_cli
+# after each test that overwrites sys.modules['hermes_cli.profiles'].  This
+# prevents the `FallbackDoesNotCrash` tests from finding a deleted entry and
+# incorrectly skipping.
+_real_hermes_cli = sys.modules.get('hermes_cli')
+_real_hermes_cli_profiles = sys.modules.get('hermes_cli.profiles')
+
+
+def _restore_real_hermes_cli():
+    if _real_hermes_cli is not None:
+        sys.modules['hermes_cli'] = _real_hermes_cli
+    if _real_hermes_cli_profiles is not None:
+        sys.modules['hermes_cli.profiles'] = _real_hermes_cli_profiles
+
+
+# ── Tests ──────────────────────────────────────────────────────────────────────
+
+class TestNoCloneSeedsSkills:
+    def test_seed_called_once_with_resolved_path(self, fake_hermes_home):
+        calls = []
+
+        def fake_create(name, **kw):
+            _make_profile_dir(_isolated_profiles_root(fake_hermes_home), name)
+
+        def fake_seed(profile_path, quiet=None):
+            calls.append({'profile_path': profile_path, 'quiet': quiet})
+
+        _remove_hermes_cli()
+        _install_hermes_cli_profiles_mock(fake_create, fake_seed)
+
+        try:
+            with patch.object(profiles_mod, 'list_profiles_api', return_value=[]):
+                result = profiles_mod.create_profile_api('testprofile')
+        finally:
+            _remove_hermes_cli()
+            _restore_real_hermes_cli()
+
+        # seed_profile_skills must have been called exactly once.
+        assert len(calls) == 1, f'Expected 1 seed call, got {len(calls)}: {calls}'
+        # quiet=True is required.
+        assert calls[0]['quiet'] is True
+        # Path must be the resolved profile directory under the fake hermes home.
+        expected_path = _isolated_profiles_root(fake_hermes_home) / 'testprofile'
+        assert calls[0]['profile_path'] == expected_path, (
+            f'Expected seed path {expected_path}, got {calls[0]}'
+        )
+        # Profile dict must be returned.
+        assert result['name'] == 'testprofile'
+
+
+class TestCloneSkipsSeeding:
+    def test_seed_not_called_when_clone_from_is_set(self, fake_hermes_home):
+        calls = []
+
+        def fake_create(name, clone_from=None, **kw):
+            _make_profile_dir(_isolated_profiles_root(fake_hermes_home), name)
+
+        def fake_seed(profile_path, quiet=None):
+            calls.append({'profile_path': profile_path, 'quiet': quiet})
+
+        _remove_hermes_cli()
+        _install_hermes_cli_profiles_mock(fake_create, fake_seed)
+
+        try:
+            with patch.object(profiles_mod, 'list_profiles_api', return_value=[]):
+                result = profiles_mod.create_profile_api(
+                    'clonedprofile', clone_from='sourceprofile'
+                )
+        finally:
+            _remove_hermes_cli()
+            _restore_real_hermes_cli()
+
+        # seed must not be called at all when cloning.
+        assert calls == [], f'seed_profile_skills was called during clone: {calls}'
+        # Profile dict must still be returned.
+        assert result['name'] == 'clonedprofile'
+
+
+class TestSeedFailureIsBestEffort:
+    def test_seed_raising_logs_warning_and_still_returns_profile(self, fake_hermes_home, caplog):
+        import logging as std_logging
+
+        def fake_create(name, **kw):
+            _make_profile_dir(_isolated_profiles_root(fake_hermes_home), name)
+
+        def fake_seed(profile_path, quiet=None):
+            raise RuntimeError('Bundled skill installation failed')
+
+        _remove_hermes_cli()
+        _install_hermes_cli_profiles_mock(fake_create, fake_seed)
+
+        try:
+            with caplog.at_level(std_logging.WARNING):
+                with patch.object(profiles_mod, 'list_profiles_api', return_value=[]):
+                    result = profiles_mod.create_profile_api('failprofile')
+        finally:
+            _remove_hermes_cli()
+            _restore_real_hermes_cli()
+
+        # A warning must have been logged naming the profile.
+        warning_messages = [rec.message for rec in caplog.records if rec.levelno == std_logging.WARNING]
+        assert any('failprofile' in msg for msg in warning_messages), (
+            f'No warning mentioning profile name found. Logged: {warning_messages}'
+        )
+        # Profile dict is returned (best-effort).
+        assert result['name'] == 'failprofile'
+        assert 'path' in result
+
+
+class TestHermesCliUnavailableFallbackDoesNotCrash:
+    def test_fallback_create_still_produces_profile_dict(self, fake_hermes_home):
+        # Simulate hermes_cli being present but create_profile raising ImportError
+        # (e.g. in a Docker/standalone environment where the profiles sub-module
+        # fails to load). This exercises the _create_profile_fallback path and
+        # confirms the new seed block does not interfere with it.
+        #
+        # We cannot permanently delete hermes_cli.profiles from sys.modules (it
+        # may be needed by other tests in this process), so we raise ImportError
+        # at the call site by temporarily replacing create_profile on the real
+        # module with a function that raises ImportError.
+
+        real_mod = sys.modules.get('hermes_cli.profiles')
+        if real_mod is None:
+            # hermes_cli.profiles was already cleaned up by a prior test in this
+            # process — skip rather than failing with a confusing assertion.
+            pytest.skip('hermes_cli.profiles not in sys.modules (cleaned up by prior test)')
+
+        orig_create = real_mod.create_profile
+        real_mod.create_profile = MagicMock(side_effect=ImportError('hermes_cli profiles unavailable'))
+        try:
+            with patch.object(profiles_mod, 'list_profiles_api', return_value=[]):
+                result = profiles_mod.create_profile_api('isolatedprofile')
+        finally:
+            real_mod.create_profile = orig_create
+
+        # Fallback path must have created the profile and returned a dict.
+        assert result['name'] == 'isolatedprofile'
+        expected_path = _isolated_profiles_root(fake_hermes_home) / 'isolatedprofile'
+        assert Path(result['path']) == expected_path
+
+    def test_seed_unavailable_logs_debug_without_crashing(self, fake_hermes_home, caplog):
+        import logging as std_logging
+
+        def fake_create(name, **kw):
+            _make_profile_dir(_isolated_profiles_root(fake_hermes_home), name)
+
+        # Grab references BEFORE we overwrite sys.modules — once saved here we
+        # can safely restore them in finally regardless of what happens in between.
+        real_mod = sys.modules.get('hermes_cli.profiles')
+        real_hermes_cli = sys.modules.get('hermes_cli')
+        if real_mod is None or real_hermes_cli is None:
+            pytest.skip('hermes_cli.profiles not in sys.modules (cleaned up by prior test)')
+
+        # We need hermes_cli.profiles.seed_profile_skills to not exist so that
+        # `from hermes_cli.profiles import seed_profile_skills` raises ImportError.
+        # We achieve this by putting a mock module with no seed attr in sys.modules
+        # and restoring the real module in the finally block.
+        _remove_hermes_cli()
+        mock = ModuleType('hermes_cli.profiles')
+        mock.create_profile = fake_create
+        # NO seed_profile_skills attribute — absence causes ImportError in the
+        # import statement inside create_profile_api.
+        fake_hermes_cli = ModuleType('hermes_cli')
+        sys.modules['hermes_cli'] = fake_hermes_cli
+        sys.modules['hermes_cli.profiles'] = mock
+
+        try:
+            with caplog.at_level(std_logging.DEBUG):
+                with patch.object(profiles_mod, 'list_profiles_api', return_value=[]):
+                    result = profiles_mod.create_profile_api('nohermesprofile')
+        finally:
+            # Restore the real modules so subsequent tests can use them.
+            _remove_hermes_cli()
+            sys.modules['hermes_cli'] = real_hermes_cli
+            sys.modules['hermes_cli.profiles'] = real_mod
+
+        # Profile is still created.
+        assert result['name'] == 'nohermesprofile'
+        # Debug log about unavailable seed_profile_skills.
+        debug_messages = [rec.message for rec in caplog.records if rec.levelno == std_logging.DEBUG]
+        assert any('seed_profile_skills' in msg for msg in debug_messages), (
+            f'No debug log about unavailable seed_profile_skills. Logged: {debug_messages}'
+        )

--- a/tests/test_native_image_attachments.py
+++ b/tests/test_native_image_attachments.py
@@ -378,3 +378,105 @@ class TestIsValidImage:
             p = Path(d) / 'a.png'
             _make_png(p)
             assert _is_valid_image(p, 'image/png; charset=utf-8')
+
+
+class TestAttachmentRootIntegration:
+    """Stage-361 regression: #2319 moved chat uploads to ~/.hermes/webui/attachments/<sid>/.
+
+    Pre-fix, _build_native_multimodal_message required uploads to be under
+    workspace_root, which silently rejected every image upload from the new
+    attachment inbox (vision models silently lost image context).
+
+    The fix adds the configured attachment root as a second allowed location
+    via _attachment_root() from api.upload, single source of truth.
+    """
+
+    def test_attachment_root_path_allowed_for_native_multimodal(self, tmp_path, monkeypatch):
+        """Image landing in the attachment inbox is accepted, not silently dropped."""
+        # Set up isolated attachment root
+        attachment_root = tmp_path / "attachments"
+        attachment_root.mkdir(parents=True)
+        monkeypatch.setenv("HERMES_WEBUI_ATTACHMENT_DIR", str(attachment_root))
+
+        # The image lives in the attachment inbox, NOT in the workspace
+        session_inbox = attachment_root / "sess123"
+        session_inbox.mkdir()
+        image_path = session_inbox / "photo.png"
+        _make_png(image_path)
+
+        # Workspace is a different, unrelated directory
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+
+        atts = _normalize_chat_attachments([{
+            "name": "photo.png",
+            "path": str(image_path),
+            "mime": "image/png",
+            "size": image_path.stat().st_size,
+            "is_image": True,
+        }])
+        result = _build_native_multimodal_message("", "describe this", atts, str(workspace))
+
+        # PRE-FIX: result would be a plain string (image silently rejected).
+        # POST-FIX: result is a list with the image_url part included.
+        assert isinstance(result, list), (
+            "Stage-361 regression: image in attachment inbox was silently rejected. "
+            "Expected list with image_url part, got string fallback. "
+            "The pre-fix workspace_root-only guard at api/streaming.py needs to also "
+            "allow paths under _attachment_root() (api/upload.py)."
+        )
+        assert result[1]["type"] == "image_url"
+        assert result[1]["image_url"]["url"].startswith("data:image/png;base64,")
+
+    def test_path_outside_both_workspace_and_attachment_root_still_rejected(self, tmp_path, monkeypatch):
+        """Paths outside BOTH allowed roots remain rejected — no security regression."""
+        attachment_root = tmp_path / "attachments"
+        attachment_root.mkdir()
+        monkeypatch.setenv("HERMES_WEBUI_ATTACHMENT_DIR", str(attachment_root))
+
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+
+        # Image in /tmp or wherever — neither under workspace nor attachment root
+        rogue_dir = tmp_path / "rogue"
+        rogue_dir.mkdir()
+        rogue_image = rogue_dir / "bad.png"
+        _make_png(rogue_image)
+
+        atts = _normalize_chat_attachments([{
+            "name": "bad.png",
+            "path": str(rogue_image),
+            "mime": "image/png",
+            "size": rogue_image.stat().st_size,
+            "is_image": True,
+        }])
+        result = _build_native_multimodal_message("", "hi", atts, str(workspace))
+
+        # Should fall back to string — rogue path rejected by both root checks
+        assert isinstance(result, str), (
+            "Security regression: path outside both workspace and attachment "
+            "root was accepted. The _allowed_roots check should reject."
+        )
+
+    def test_workspace_path_still_allowed(self, tmp_path, monkeypatch):
+        """Workspace-resident images still work (backward compat with pre-#2319 uploads)."""
+        attachment_root = tmp_path / "attachments"
+        attachment_root.mkdir()
+        monkeypatch.setenv("HERMES_WEBUI_ATTACHMENT_DIR", str(attachment_root))
+
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        image_path = workspace / "ws-image.png"
+        _make_png(image_path)
+
+        atts = _normalize_chat_attachments([{
+            "name": "ws-image.png",
+            "path": str(image_path),
+            "mime": "image/png",
+            "size": image_path.stat().st_size,
+            "is_image": True,
+        }])
+        result = _build_native_multimodal_message("", "describe", atts, str(workspace))
+
+        assert isinstance(result, list)
+        assert result[1]["type"] == "image_url"

--- a/tests/test_offline_banner.py
+++ b/tests/test_offline_banner.py
@@ -70,3 +70,24 @@ def test_sse_network_error_defers_to_offline_banner_instead_of_inline_error():
     assert "if(_deferStreamErrorIfOffline()) return;" in MESSAGES_JS
     error_handler = MESSAGES_JS.split("source.addEventListener('error',async e=>{", 1)[1].split("source.addEventListener('cancel'", 1)[0]
     assert error_handler.find("_deferStreamErrorIfOffline()") < error_handler.rfind("_handleStreamError()")
+
+
+def test_sse_error_defers_while_page_hidden_until_tab_returns():
+    assert "function _deferStreamErrorIfPageHidden()" in MESSAGES_JS
+    assert "document.visibilityState==='hidden'" in MESSAGES_JS
+    assert "document.wasDiscarded===true" in MESSAGES_JS
+    assert "Connection paused. Reconnecting when this tab returns…" in MESSAGES_JS
+    assert "document.addEventListener('visibilitychange',resume)" in MESSAGES_JS
+    assert "window.addEventListener('pageshow',resume)" in MESSAGES_JS
+    error_handler = MESSAGES_JS.split("source.addEventListener('error',async e=>{", 1)[1].split("source.addEventListener('cancel'", 1)[0]
+    assert "if(_deferStreamErrorIfPageHidden()) return;" in error_handler
+    assert error_handler.find("_deferStreamErrorIfPageHidden()") < error_handler.rfind("_handleStreamError()")
+
+
+def test_deferred_hidden_stream_error_reattaches_or_restores_before_inline_error():
+    recovery_block = MESSAGES_JS.split("function _reattachOrRestoreAfterDeferredStreamError(){", 1)[1].split("function _deferStreamErrorIfPageHidden()", 1)[0]
+    assert "api(`/api/chat/stream/status?stream_id=${encodeURIComponent(streamId)}`)" in recovery_block
+    assert "if(st.active)" in recovery_block
+    assert "_wireSSE(new EventSource" in recovery_block
+    assert "if(await _restoreSettledSession()) return;" in recovery_block
+    assert recovery_block.find("if(await _restoreSettledSession()) return;") < recovery_block.rfind("_handleStreamError()")

--- a/tests/test_sprint1.py
+++ b/tests/test_sprint1.py
@@ -296,7 +296,7 @@ def test_parse_multipart_binary_file():
 # ──────────────────────────────────────────────
 
 def test_upload_text_file(cleanup_test_sessions):
-    """Upload a text file to a session workspace, verify it appears in /api/list."""
+    """Upload a text file to the attachment inbox, not the workspace root."""
     sid, ws = make_session_tracked(cleanup_test_sessions)
 
     result, status = post_multipart("/api/upload", {"session_id": sid}, {
@@ -306,12 +306,30 @@ def test_upload_text_file(cleanup_test_sessions):
     assert "filename" in result
     assert result["size"] == len(b"sprint1 test content")
 
-    # Verify file appears in listing
+    uploaded_path = pathlib.Path(result["path"])
+    assert uploaded_path.exists()
+    assert uploaded_path.read_bytes() == b"sprint1 test content"
+    assert uploaded_path.parent.name == sid
+
+    # Verify ordinary chat uploads no longer clutter the workspace listing.
     listing = get(f"/api/list?session_id={sid}&path=.")
     names = [e["name"] for e in listing["entries"]]
-    assert result["filename"] in names, f"{result['filename']} not in {names}"
-    # Cleanup the uploaded file
-    post("/api/file/delete", {"session_id": sid, "path": result["filename"]})
+    assert result["filename"] not in names, f"{result['filename']} unexpectedly in {names}"
+    # Cleanup the uploaded file from the attachment inbox.
+    uploaded_path.unlink(missing_ok=True)
+
+
+def test_upload_respects_attachment_dir_env(monkeypatch, tmp_path):
+    """HERMES_WEBUI_ATTACHMENT_DIR routes chat uploads to a per-session inbox."""
+    from api.upload import _upload_destination
+
+    inbox = tmp_path / "attachment-inbox"
+    monkeypatch.setenv("HERMES_WEBUI_ATTACHMENT_DIR", str(inbox))
+
+    dest = _upload_destination("session-123", "notes.md")
+
+    assert dest == inbox.resolve() / "session-123" / "notes.md"
+    assert dest.parent.exists()
 
 
 def test_upload_too_large(cleanup_test_sessions):


### PR DESCRIPTION
# stage-361 — 4-PR follow-up batch (v0.51.68)

Ninth full PR sweep of the day. Smaller batch than usual — most of today's queue was consumed by stages 359 + 360.

+543 / -13 across 11 files.

## Composition

### Added
- **PR #2319** by @Michaelyklam — Chat file uploads now land in a session-scoped attachment inbox instead of cluttering the active workspace root. Default: `~/.hermes/webui/attachments/<session_id>/`. Operator override: `HERMES_WEBUI_ATTACHMENT_DIR`. Archive extraction stays workspace-scoped. README updated.

### Fixed
- **PR #2315** by @Michaelyklam (closes #2305, refs #749) — WebUI profile creation now seeds bundled profile skills for non-cloned profiles, matching CLI behaviour
- **PR #2317** by @Michaelyklam (refs #2312 follow-up #2) — Appearance boot reconciliation treats `light`/`dark`/`system` as explicit theme choices when autosave fails (was only `system` pre-fix)
- **PR #2318** by @Michaelyklam (closes #2307) — Defer mobile stream errors while tab is hidden; reattach or restore on visibility return

## Stage-361 maintainer fix (HIGH-SEVERITY, Opus-caught)

**#2319 would have silently broken image uploads for every vision-capable model in WebUI** without this fix.

### The bug Opus caught

Pre-#2319, `_build_native_multimodal_message` at `api/streaming.py:787` enforced:
```python
path.relative_to(workspace_root)  # ValueError if outside
```

After #2319, chat uploads land in `~/.hermes/webui/attachments/<sid>/` (outside `workspace_root` by design). The guard would have silently rejected every image upload — the base64 `image_url` part would never have been built, the `[Attached files: <name>]` text would be sent, but vision models would lose all image context.

**Opus's verdict**: *"Without the #2319 fix, this stage silently breaks image uploads for every vision-capable model in WebUI."*

### Fix applied (commit `29d13953`)

Added `_attachment_root()` (from `api/upload.py` — single source of truth) as a second allowed location:

```python
try:
    from api.upload import _attachment_root
    attachment_root = _attachment_root()
    _allowed_roots = (workspace_root, attachment_root)
except Exception:
    _allowed_roots = (workspace_root,)

# ...

if not any(path.is_relative_to(r) for r in _allowed_roots):
    continue
```

### Test augmentation (3 new regression tests)

Added `TestAttachmentRootIntegration` class to `tests/test_native_image_attachments.py`:
1. `test_attachment_root_path_allowed_for_native_multimodal` — verifies image in attachment inbox is accepted (the bug Opus found)
2. `test_path_outside_both_workspace_and_attachment_root_still_rejected` — security regression check
3. `test_workspace_path_still_allowed` — backward compat with pre-#2319 uploads

**Revert-fix verified**: temporarily reverted the fix; new test fails with the exact "silently rejected" assertion. Restored the fix; all 4 tests (3 new + existing `test_outside_workspace_path_rejected`) pass.

## #2314 closed during triage

**#2314** (by @WanderWang) and **#2315** (by @Michaelyklam) arrived for the same issue #2305 on essentially the same timeline. Both implementations were nearly identical. Picked #2315 as the overlap winner for three small tiebreakers: CHANGELOG entry included, cleaner insertion point (between `mkdir` and config writes), more thorough test coverage. Closed #2314 with a friendly comment explaining the reasoning.

## Verification

- **Targeted PR tests (4 test files + attachment regression)**: 57+4/61 pass
- **Full pytest**: **5586 passed**, 13 skipped, 1 xfailed, 2 xpassed, 8 subtests passed in **98.79s** (host slowdown earlier was a parallel cargo build pinning CPU — see `~/WebUI/docs/agent-memory/pytest-slowdown-diagnosis.md`)
- **`run-browser-tests.sh`**: **20/20 QA + 11/11 API checks PASSED** in 104s
- **QA env-lock invariants** (stage-360's narrow-lock work): 11/11 pass — no regressions
- **Python + JS syntax**: clean across all 11 modified files
- **Conflict markers**: zero
- **CI on constituent PRs (latest SHA)**: 3/3 SUCCESS on each

## Opus Advisor Review

After applying the SHOULD-FIX inline and verifying with revert-fix methodology, all 4 PRs are SHIP-cleared.

| PR | Verdict |
|---|---|
| #2315 | **SHIP** ✓ |
| #2317 | **SHIP** ✓ |
| #2318 | **SHIP** ✓ (Opus surfaced one minor follow-up: session-change listener cleanup, non-blocking) |
| #2319 | **SHIP** ✓ (with applied SHOULD-FIX + 3 regression tests + revert-fix verified) |

Opus's full quote on the resolution: *"Allow paths inside `_attachment_root()` (from `api/upload.py`) in addition to `workspace_root`. Either import the helper or accept paths under both roots."* — implemented exactly as proposed.

## Closes / refs

- `Closes #2305` (via #2315 — bundled skills for WebUI-created profiles)
- `Closes #2307` (via #2318 — mobile stream error deferral)
- Refs #2312 (via #2317 — follow-up item #2 implemented; items #1 and #3 still open)
- Refs #749 (via #2315 — profile create flow)

## Non-blocking follow-ups Opus surfaced

1. **#2318 session-change listener cleanup** — if user switches sessions in the same tab while deferred-recovery listeners are bound, they persist on the old closure. Partially guarded by `_terminalStateReached || _streamFinalized`, but not by session-change. Low impact.
2. **#2319 cleanup on session delete** — `/api/session/delete` does not remove the attachment directory. Orphaned `~/.hermes/webui/attachments/<sid>/` dirs accumulate. SHOULD-FIX follow-up.

## Stats

```
11 files changed, 543 insertions(+), 13 deletions(-) + 2 maintainer commits (CHANGELOG + Opus SHOULD-FIX with tests)
```
