### PR TITLE
fix: expand legacy Hermes CLI toolset alias

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -596,6 +596,28 @@ _DEFAULT_TOOLSETS = [
     "web",
     "webhook",
 ]
+
+_LEGACY_CLI_TOOLSET_ALIASES = {
+    # Older Hermes configs used "hermes" as the CLI composite toolset. Modern
+    # Hermes Agent exposes that split as these two registered composites; keep
+    # WebUI sessions usable when pointed at an older shared config.yaml.
+    "hermes": ("hermes-cli", "hermes-api-server"),
+}
+
+
+def _normalize_cli_toolsets(toolsets):
+    """Expand legacy CLI toolset aliases while preserving order and de-duping."""
+    normalized = []
+    seen = set()
+    for name in toolsets or []:
+        replacements = _LEGACY_CLI_TOOLSET_ALIASES.get(name, (name,))
+        for replacement in replacements:
+            if replacement and replacement not in seen:
+                seen.add(replacement)
+                normalized.append(replacement)
+    return normalized
+
+
 def _resolve_cli_toolsets(cfg=None):
     """Resolve CLI toolsets using the agent's _get_platform_tools() so that
     MCP server toolsets are automatically included, matching CLI behaviour."""
@@ -603,10 +625,10 @@ def _resolve_cli_toolsets(cfg=None):
         cfg = get_config()
     try:
         from hermes_cli.tools_config import _get_platform_tools
-        return list(_get_platform_tools(cfg, "cli"))
+        return _normalize_cli_toolsets(_get_platform_tools(cfg, "cli"))
     except Exception:
         # Fallback: read raw list from config (MCP toolsets will be missing)
-        return cfg.get("platform_toolsets", {}).get("cli", _DEFAULT_TOOLSETS)
+        return _normalize_cli_toolsets(cfg.get("platform_toolsets", {}).get("cli", _DEFAULT_TOOLSETS))
 
 CLI_TOOLSETS = _resolve_cli_toolsets()
 

--- a/tests/test_issue2232_legacy_toolsets.py
+++ b/tests/test_issue2232_legacy_toolsets.py
@@ -1,0 +1,30 @@
+"""Regression coverage for issue #2232 legacy CLI toolset aliases."""
+
+from unittest import mock
+
+
+def test_normalize_cli_toolsets_expands_legacy_hermes_alias():
+    from api.config import _normalize_cli_toolsets
+
+    assert _normalize_cli_toolsets(["hermes", "web"]) == [
+        "hermes-cli",
+        "hermes-api-server",
+        "web",
+    ]
+
+
+def test_normalize_cli_toolsets_deduplicates_expanded_aliases():
+    from api.config import _normalize_cli_toolsets
+
+    assert _normalize_cli_toolsets(["hermes", "hermes-cli", "hermes-api-server"]) == [
+        "hermes-cli",
+        "hermes-api-server",
+    ]
+
+
+def test_resolve_cli_toolsets_fallback_expands_legacy_hermes_alias():
+    import api.config as config
+
+    cfg = {"platform_toolsets": {"cli": ["hermes", "web"]}}
+    with mock.patch("builtins.__import__", side_effect=ImportError("no hermes cli")):
+        assert config._resolve_cli_toolsets(cfg) == ["hermes-cli", "hermes-api-server", "web"]


### PR DESCRIPTION
## Thinking Path
- WebUI should preserve Hermes CLI tool availability when it reads shared Hermes config.
- Issue #2232 shows older configs can still contain the legacy `hermes` CLI toolset name.
- Modern Hermes Agent exposes that composite as `hermes-cli` plus `hermes-api-server`.
- The narrow fix is to normalize the legacy alias when WebUI resolves CLI toolsets, instead of letting sessions start without core tools.

## What Changed
- Added a small CLI toolset normalizer in `api/config.py`.
- Expands legacy `hermes` to `hermes-cli` and `hermes-api-server` while preserving order and de-duplicating entries.
- Applies the normalization to both the Hermes CLI resolver path and the raw config fallback path.
- Added regression tests for alias expansion, de-duplication, and fallback config handling.

## Why It Matters
Users with older shared `config.yaml` values keep the expected core tools in WebUI sessions instead of silently losing terminal, file, skills, and other core tool access.

## Verification
- `env -u HERMES_CONFIG_PATH -u HERMES_WEBUI_HOST /home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_issue2232_legacy_toolsets.py -q` — 3 passed
- `git diff --check`

## Risks / Follow-ups
- This is intentionally limited to the known legacy `hermes` alias. It does not validate every possible invalid toolset name.

## Model Used
AI-assisted change with repository inspection, targeted editing, and shell-based test verification.

Closes #2232
