### PR TITLE
fix: use assistant name in cancel copy

### DIFF
--- a/api/streaming.py
+++ b/api/streaming.py
@@ -31,6 +31,7 @@ from api.config import (
     resolve_model_provider,
     resolve_custom_provider_connection,
     model_with_provider_context,
+    load_settings,
 )
 from api.helpers import redact_session_data, _redact_text
 from api.compression_anchor import visible_messages_for_anchor
@@ -165,6 +166,21 @@ def _has_new_assistant_reply(all_messages: list, prev_count: int) -> bool:
     )
 
 
+def _preferred_agent_display_name() -> str:
+    """Return the configured assistant display name for user-facing copy."""
+    try:
+        name = str((load_settings() or {}).get('bot_name') or '').strip()
+    except Exception:
+        logger.debug("Failed to load bot_name for cancellation copy", exc_info=True)
+        name = ''
+    return name or 'Hermes'
+
+
+def _cancelled_turn_hint(agent_name: str | None = None) -> str:
+    name = str(agent_name or _preferred_agent_display_name()).strip() or 'Hermes'
+    return f'The run was cancelled by the user before {name} finished. No provider failure occurred.'
+
+
 def _classify_provider_error(err_str: str, exc=None, *, silent_failure: bool = False) -> dict:
     """Classify provider/agent failure text for WebUI apperror UX.
 
@@ -201,7 +217,7 @@ def _classify_provider_error(err_str: str, exc=None, *, silent_failure: bool = F
         return {
             'label': 'Task cancelled',
             'type': 'cancelled',
-            'hint': 'The run was cancelled by the user before Skyly finished. No provider failure occurred.',
+            'hint': _cancelled_turn_hint(),
         }
     if _is_interrupted:
         return {
@@ -318,7 +334,7 @@ def _cancelled_turn_content(message: str = 'Task cancelled.') -> str:
         _message += '.'
     return (
         f"**Task cancelled:** {_message}\n\n"
-        "*The run was cancelled by the user before Skyly finished. No provider failure occurred.*"
+        f"*{_cancelled_turn_hint()}*"
     )
 
 

--- a/static/messages.js
+++ b/static/messages.js
@@ -1695,7 +1695,8 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
           // Fallback to local cancel message if API fails
           if(S.session&&S.session.session_id===activeSid){
             clearLiveToolCards();if(!assistantText)removeThinking();
-            S.messages.push({role:'assistant',content:'**Task cancelled:** Task cancelled.\n\n*The run was cancelled by the user before Skyly finished. No provider failure occurred.*',provider_details:'Task cancelled.',provider_details_label:'Cancellation details',_error:true});renderMessages({preserveScroll:true});
+            const cancelAgentName=((window._botName||'Hermes')+'').trim()||'Hermes';
+            S.messages.push({role:'assistant',content:`**Task cancelled:** Task cancelled.\n\n*The run was cancelled by the user before ${cancelAgentName} finished. No provider failure occurred.*`,provider_details:'Task cancelled.',provider_details_label:'Cancellation details',_error:true});renderMessages({preserveScroll:true});
             _markSessionViewed(activeSid, S.messages.length);
           }
         }

--- a/tests/test_issue1361_cancel_data_loss.py
+++ b/tests/test_issue1361_cancel_data_loss.py
@@ -445,6 +445,35 @@ def test_materialize_helper_called_immediately_before_error_path_clears():
 
 
 
+def test_cancel_copy_uses_configured_bot_name(monkeypatch):
+    """Cancellation copy should use the configured assistant display name."""
+    import api.streaming as streaming
+
+    monkeypatch.setattr(streaming, 'load_settings', lambda: {'bot_name': 'Obryn'})
+
+    assert streaming._cancelled_turn_hint() == (
+        'The run was cancelled by the user before Obryn finished. '
+        'No provider failure occurred.'
+    )
+    assert 'before Obryn finished' in streaming._cancelled_turn_content()
+    assert streaming._classify_provider_error('Task cancelled by user')['hint'] == (
+        'The run was cancelled by the user before Obryn finished. '
+        'No provider failure occurred.'
+    )
+
+
+def test_cancel_copy_falls_back_to_hermes_for_blank_bot_name(monkeypatch):
+    """Blank or missing bot_name should not leak old persona copy."""
+    import api.streaming as streaming
+
+    monkeypatch.setattr(streaming, 'load_settings', lambda: {'bot_name': '   '})
+
+    assert streaming._cancelled_turn_hint() == (
+        'The run was cancelled by the user before Hermes finished. '
+        'No provider failure occurred.'
+    )
+
+
 class TestCancelStreamIdempotentWithWorkerFinalizer:
     """The worker and explicit cancel endpoint can both finalize the same turn."""
 
@@ -455,7 +484,7 @@ class TestCancelStreamIdempotentWithWorkerFinalizer:
             session_id=sid,
             messages=[
                 {'role': 'user', 'content': 'Help me debug this', 'timestamp': 100},
-                {'role': 'assistant', 'content': '**Task cancelled:** Task cancelled.\n\n*The run was cancelled by the user before Skyly finished. No provider failure occurred.*', '_error': True, 'timestamp': 101},
+                {'role': 'assistant', 'content': '**Task cancelled:** Task cancelled.\n\n*The run was cancelled by the user before Hermes finished. No provider failure occurred.*', '_error': True, 'timestamp': 101},
             ],
         )
         _setup_cancel_state(sid, stream_id)


### PR DESCRIPTION
**Thought process:**

Preferences allows defining an Assistant Name which says that it persists throughout the UI

Cancelling a message results in the response that the run was cancelled before Skyly finished.

Fix for this issue is to replace the hardcoded Skyly (likely an agent persona name or other artifact that leaked into a pull, does not seem to be a lib reference) with bot_name

**This fix:**

Replaces the hardcoded Skyly cancellation wording with the configured bot_name from settings, falling back to Hermes when unset.

Keeps the client-side fallback in sync by using window._botName if the session refresh after cancellation fails.

**Testing:**

Includes unit tests for set name and fallback (used my agent persona's name, sorry Skyly)

Manually verified setting and unsetting name and cancelling tasks in new sessions and in the same session, worked as expected, existing messages unchanged, new task cancellation messages used the correct name.

**Risks:** 

Low future risk, PR is a fix to better align actual and advertised state and improves testing posture for bot_name actually being used.

**AI Disclosure:**

Guided and reviewed by myself, coded by Obryn 🐉 (hermes-agent, gpt-5.5)