### PR TITLE
fix: clean session attachment and stream recovery leftovers

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -4628,6 +4628,12 @@ def handle_post(handler, parsed) -> bool:
             p.with_suffix('.json.bak').unlink(missing_ok=True)
         except Exception:
             logger.debug("Failed to unlink session file %s", p)
+        try:
+            from api.upload import _session_attachment_dir
+
+            shutil.rmtree(_session_attachment_dir(sid), ignore_errors=True)
+        except Exception:
+            logger.debug("Failed to clean attachment dir for deleted session %s", sid)
         # Prune the per-session agent lock so deleted sessions don't leak
         # Lock entries in SESSION_AGENT_LOCKS forever.
         with SESSION_AGENT_LOCKS_LOCK:

--- a/api/upload.py
+++ b/api/upload.py
@@ -76,15 +76,20 @@ def _attachment_root() -> Path:
 
 
 def _upload_destination(session_id: str, safe_name: str) -> Path:
-    root = _attachment_root()
-    dest_dir = (root / _re.sub(r'[^\w.\-]', '_', str(session_id or 'session'))[:120]).resolve()
-    if not dest_dir.is_relative_to(root):
-        raise ValueError('Invalid attachment directory')
+    dest_dir = _session_attachment_dir(session_id)
     dest_dir.mkdir(parents=True, exist_ok=True)
     dest = (dest_dir / safe_name).resolve()
     if not dest.is_relative_to(dest_dir):
         raise ValueError('Invalid upload destination')
     return dest
+
+
+def _session_attachment_dir(session_id: str, *, root: Path | None = None) -> Path:
+    root = (root or _attachment_root()).resolve()
+    dest_dir = (root / _re.sub(r'[^\w.\-]', '_', str(session_id or 'session'))[:120]).resolve()
+    if not dest_dir.is_relative_to(root):
+        raise ValueError('Invalid attachment directory')
+    return dest_dir
 
 
 def handle_upload(handler):

--- a/static/messages.js
+++ b/static/messages.js
@@ -601,6 +601,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
 
   function _reattachOrRestoreAfterDeferredStreamError(){
     if(_terminalStateReached||_streamFinalized) return;
+    if((S.session&&S.session.session_id)!==activeSid) return;
     (async()=>{
       try{
         if(streamId){

--- a/tests/test_sprint1.py
+++ b/tests/test_sprint1.py
@@ -179,6 +179,25 @@ def test_session_delete():
         assert e.code in (404, 500), f"Expected 404 or 500, got {e.code}"
 
 
+def test_session_delete_removes_attachment_inbox(cleanup_test_sessions):
+    """Deleting a session also removes its chat attachment inbox directory."""
+    sid, _ = make_session_tracked(cleanup_test_sessions)
+
+    result, status = post_multipart("/api/upload", {"session_id": sid}, {
+        "file": ("delete-me.txt", b"temporary attachment")
+    })
+    assert status == 200, f"Upload failed {status}: {result}"
+    attachment_dir = pathlib.Path(result["path"]).parent
+    assert attachment_dir.name == sid
+    assert attachment_dir.exists()
+
+    delete_result, delete_status = post("/api/session/delete", {"session_id": sid})
+
+    assert delete_status == 200
+    assert delete_result.get("ok") is True
+    assert not attachment_dir.exists()
+
+
 def test_session_delete_nonexistent():
     """Deleting a nonexistent session should return ok:True (idempotent)."""
     result, status = post("/api/session/delete", {"session_id": "doesnotexist"})
@@ -321,7 +340,7 @@ def test_upload_text_file(cleanup_test_sessions):
 
 def test_upload_respects_attachment_dir_env(monkeypatch, tmp_path):
     """HERMES_WEBUI_ATTACHMENT_DIR routes chat uploads to a per-session inbox."""
-    from api.upload import _upload_destination
+    from api.upload import _session_attachment_dir, _upload_destination
 
     inbox = tmp_path / "attachment-inbox"
     monkeypatch.setenv("HERMES_WEBUI_ATTACHMENT_DIR", str(inbox))
@@ -330,6 +349,7 @@ def test_upload_respects_attachment_dir_env(monkeypatch, tmp_path):
 
     assert dest == inbox.resolve() / "session-123" / "notes.md"
     assert dest.parent.exists()
+    assert _session_attachment_dir("session-123") == inbox.resolve() / "session-123"
 
 
 def test_upload_too_large(cleanup_test_sessions):

--- a/tests/test_streaming_race_fix.py
+++ b/tests/test_streaming_race_fix.py
@@ -173,3 +173,14 @@ class TestReconnectAccumulatorPreservation:
         assert 'cancelAnimationFrame' in fn, (
             "_handleStreamError must cancel any pending rAF before renderMessages() runs"
         )
+
+    def test_deferred_stream_recovery_bails_after_session_switch(self):
+        """Deferred hidden-tab recovery must not reattach an old stream after
+        the user has switched to a different session in the same tab."""
+        src = read('static/messages.js')
+        m = re.search(r'function _reattachOrRestoreAfterDeferredStreamError\(\)\{.*?\n  \}', src, re.DOTALL)
+        assert m, "_reattachOrRestoreAfterDeferredStreamError not found"
+        fn = m.group(0)
+        assert 'S.session&&S.session.session_id' in fn
+        assert '!==activeSid' in fn
+        assert fn.index('!==activeSid') < fn.index('api(`/api/chat/stream/status?stream_id=')


### PR DESCRIPTION
## Thinking Path
- Issue #2325 captured two small follow-ups from the v0.51.68 review.
- Chat uploads now live in a per-session attachment inbox, so session deletion should clean that inbox too.
- Hidden-tab stream recovery is closure-bound to the original live stream, so it should not reattach after the user switches to another session in the same tab.
- Both fixes are narrow cleanup changes with regression coverage.

## What Changed
- Added `_session_attachment_dir()` so upload storage and cleanup share the same sanitized per-session attachment directory calculation.
- Removed a deleted session's attachment inbox during `/api/session/delete`, while keeping cleanup best-effort and non-fatal.
- Guarded deferred stream recovery so it bails if the active browser session no longer matches the stream's original `activeSid`.
- Added regression tests for attachment inbox cleanup and stale deferred stream reattachment.

## Why It Matters
- Deleted sessions no longer leave orphaned chat upload directories behind.
- A tab returning from the background won't reconnect or update composer status for a stream from a session the user already moved away from.

## Verification
- `node --check static/messages.js`
- `/home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_sprint1.py::test_session_delete_removes_attachment_inbox tests/test_sprint1.py::test_upload_text_file tests/test_sprint1.py::test_upload_respects_attachment_dir_env tests/test_streaming_race_fix.py::TestReconnectAccumulatorPreservation::test_deferred_stream_recovery_bails_after_session_switch -q`
- `/home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_sprint1.py::test_session_delete tests/test_sprint1.py::test_session_delete_removes_attachment_inbox tests/test_sprint1.py::test_session_delete_nonexistent tests/test_sprint1.py::test_upload_text_file tests/test_sprint1.py::test_upload_respects_attachment_dir_env tests/test_streaming_race_fix.py -q`
- `git diff --check`

## Risks / Follow-ups
- Attachment cleanup is intentionally best-effort; failures are logged at debug level and do not block session deletion.
- No screenshots included because this is storage/session cleanup and stale-stream recovery behavior, not a visual UI change.

## Model Used
AI-assisted change with repository inspection, targeted editing, and shell-based test verification.

Closes #2325
