### PR TITLE
test: retarget compression snapshot runtime regression

### DIFF
--- a/api/streaming.py
+++ b/api/streaming.py
@@ -2066,37 +2066,6 @@ def _drop_checkpointed_current_user_from_context(messages, msg_text):
     return history
 
 
-def _save_pre_compression_snapshot(session, old_session_id):
-    """Persist the archived pre-compression session without live turn state.
-
-    During context compression the same ``Session`` object is reused for the new
-    continuation id.  Before the final continuation save clears
-    ``active_stream_id`` and ``pending_*``, we also preserve an old-id snapshot so
-    the full pre-compression transcript remains recoverable.  That archived
-    parent must not keep the current stream bookkeeping, otherwise the sidebar can
-    reopen the parent as a permanently running session while the child already
-    contains the completed answer.
-    """
-    saved_sid = session.session_id
-    saved_active_stream_id = getattr(session, 'active_stream_id', None)
-    saved_pending_user_message = getattr(session, 'pending_user_message', None)
-    saved_pending_attachments = list(getattr(session, 'pending_attachments', []) or [])
-    saved_pending_started_at = getattr(session, 'pending_started_at', None)
-    session.session_id = old_session_id
-    session.active_stream_id = None
-    session.pending_user_message = None
-    session.pending_attachments = []
-    session.pending_started_at = None
-    try:
-        session.save(touch_updated_at=False, skip_index=True)
-    finally:
-        session.session_id = saved_sid
-        session.active_stream_id = saved_active_stream_id
-        session.pending_user_message = saved_pending_user_message
-        session.pending_attachments = saved_pending_attachments
-        session.pending_started_at = saved_pending_started_at
-
-
 def _stream_writeback_is_current(session, stream_id):
     """Return True only while a worker still owns the session writeback.
 

--- a/tests/test_compression_snapshot_runtime_clear.py
+++ b/tests/test_compression_snapshot_runtime_clear.py
@@ -1,3 +1,5 @@
+import json
+
 from api import streaming
 
 
@@ -5,6 +7,7 @@ class FakeSession:
     def __init__(self):
         self.session_id = "new_session"
         self.parent_session_id = "original_parent"
+        self.pre_compression_snapshot = False
         self.active_stream_id = "live-stream"
         self.pending_user_message = "current prompt"
         self.pending_attachments = [{"name": "file.txt"}]
@@ -16,6 +19,7 @@ class FakeSession:
         self.saved_payload = {
             "session_id": self.session_id,
             "parent_session_id": self.parent_session_id,
+            "pre_compression_snapshot": self.pre_compression_snapshot,
             "active_stream_id": self.active_stream_id,
             "pending_user_message": self.pending_user_message,
             "pending_attachments": list(self.pending_attachments),
@@ -23,25 +27,38 @@ class FakeSession:
             "touch_updated_at": touch_updated_at,
             "skip_index": skip_index,
         }
+        path = streaming.SESSION_DIR / f"{self.session_id}.json"
+        path.write_text(json.dumps(self.saved_payload), encoding="utf-8")
 
 
-def test_pre_compression_snapshot_clears_runtime_fields_while_restoring_continuation_state():
+def test_preserve_pre_compression_snapshot_clears_runtime_fields_while_restoring_continuation_state(tmp_path, monkeypatch):
+    monkeypatch.setattr(streaming, "SESSION_DIR", tmp_path)
+    (tmp_path / "old_session.json").write_text(json.dumps({"messages": []}), encoding="utf-8")
     session = FakeSession()
 
-    streaming._save_pre_compression_snapshot(session, "old_session")
+    streaming._preserve_pre_compression_snapshot(session, "old_session")
 
     assert session.saved_payload == {
         "session_id": "old_session",
         "parent_session_id": "original_parent",
+        "pre_compression_snapshot": True,
         "active_stream_id": None,
         "pending_user_message": None,
         "pending_attachments": [],
         "pending_started_at": None,
         "touch_updated_at": False,
-        "skip_index": True,
+        "skip_index": False,
     }
     assert session.session_id == "new_session"
+    assert session.pre_compression_snapshot is False
     assert session.active_stream_id == "live-stream"
     assert session.pending_user_message == "current prompt"
     assert session.pending_attachments == [{"name": "file.txt"}]
     assert session.pending_started_at == 123.0
+
+    saved = json.loads((tmp_path / "old_session.json").read_text(encoding="utf-8"))
+    assert saved["pre_compression_snapshot"] is True
+    assert saved["active_stream_id"] is None
+    assert saved["pending_user_message"] is None
+    assert saved["pending_attachments"] == []
+    assert saved["pending_started_at"] is None


### PR DESCRIPTION
## Thinking Path
- Issue #2312 tracks a few non-blocking follow-ups from the compression/theme/Docker review.
- The theme fallback slice is already covered, but `_save_pre_compression_snapshot()` remained as a dead production helper.
- The production path now uses `_preserve_pre_compression_snapshot()`, because it must index snapshots with `skip_index=False` for sidebar filtering.
- Keeping an unused helper with the old `skip_index=True` contract makes the compression snapshot behavior harder to reason about.
- This PR deletes the dead helper and points the runtime-field regression at the actual production helper.

## What Changed
- Removed unused `api.streaming._save_pre_compression_snapshot()`.
- Retargeted `tests/test_compression_snapshot_runtime_clear.py` to exercise `_preserve_pre_compression_snapshot()`.
- Updated the regression to assert that the production helper:
  - marks the old session as `pre_compression_snapshot`;
  - clears stale runtime stream/pending fields on the archived snapshot;
  - restores the continuation session's live state after saving;
  - uses the production `skip_index=False` path.

## Why It Matters
- Future maintainers now see one compression snapshot preservation path instead of a stale parallel helper.
- The test documents the current production contract directly, including the indexed snapshot marker used by the sidebar projection.

## Verification
- `/home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_compression_snapshot_runtime_clear.py tests/test_issue2223_compression_no_rename.py -q` — 10 passed
- `git diff --check` — passed

## Risks / Follow-ups
- Low risk: code deletion is limited to an unused helper, and the related compression snapshot tests still pass.
- Issue #2312 still has the Dockerfile `chmod 1777 /app` release-notes follow-up remaining.

## Model Used
AI-assisted change with repository inspection, targeted editing, and shell-based test verification.

Refs #2312
