### PR TITLE
fix: lock turn journal appends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@
 
 - **PR #2333** by @Michaelyklam (closes #2312 follow-up #1) — Removed dead production helper `_save_pre_compression_snapshot()` at `api/streaming.py:1945`. The production path now uses `_preserve_pre_compression_snapshot()` exclusively (which must index snapshots with `skip_index=False` for sidebar filtering). The dead helper was only called from `tests/test_compression_snapshot_runtime_clear.py`; the test is retargeted to exercise the actual production helper instead. Closes follow-up item #1 from the v0.51.66 review (#2312).
 
+- **PR #2334** by @Michaelyklam (refs #2097) — Turn journal appends now take an advisory `flock` around each JSONL event write and fsync when Unix file locks are available. This keeps oversized submitted-message events from interleaving at the byte level if a future deployment runs multiple WebUI worker processes against the same state directory, while preserving the previous best-effort append path on platforms without `fcntl`.
+
 ## [v0.51.68] — 2026-05-15 — Release AR (stage-361 — 4-PR follow-up batch — #2315 profile skill seeding + #2317 theme fallback + #2318 mobile stream defer + #2319 chat upload relocation — with Opus-caught vision-model regression fix)
 
 ### Added
@@ -31,7 +33,6 @@
 - **PR #2319** by @Michaelyklam — Chat file uploads now land in a session-scoped attachment inbox instead of cluttering the active workspace root. By default uploads are stored under `~/.hermes/webui/attachments/<session_id>/`; operators can override the root with `HERMES_WEBUI_ATTACHMENT_DIR`, and the agent still receives the absolute uploaded file path for context. Archive extraction stays workspace-scoped (it's an explicit workspace operation). README updated to document the new default location. **Stage-361 maintainer fix applied inline**: Opus advisor caught that `_build_native_multimodal_message` at `api/streaming.py:787` required uploads to be under `workspace_root`, which would have silently dropped every image upload for vision-capable models once the inbox moved outside the workspace. The fix adds `_attachment_root()` (from `api/upload.py`) as a second allowed location, with 3 regression tests covering the new code path AND verifying the original workspace + cross-root rejection paths still work.
 
 ### Fixed
-
 
 - **PR #2315** by @Michaelyklam (closes #2305, refs #749) — WebUI profile creation now seeds bundled profile skills for newly-created non-cloned profiles, matching the CLI's `hermes profile create` behaviour. Pre-fix, creating a profile via Settings → New Profile (without checking "Clone from active profile") left the profile's `skills/` directory empty, which was inconsistent with CLI-created profiles that get the full bundled-skills overlay. The fix calls `seed_profile_skills(profile_path, quiet=True)` after `profile_path.mkdir()` when `clone_from is None`. Cloned profiles still inherit skills from their source — they don't get a second bundled-skills overlay. Seed failures (e.g. `hermes_cli` unavailable in Docker fallback) are logged as warnings, not fatal — profile creation still succeeds.
 

--- a/api/turn_journal.py
+++ b/api/turn_journal.py
@@ -11,8 +11,14 @@ import os
 import re
 import time
 import uuid
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Iterable
+
+try:  # pragma: no cover - fcntl is unavailable on Windows.
+    import fcntl as _fcntl
+except ImportError:  # pragma: no cover
+    _fcntl = None
 
 TURN_JOURNAL_DIR_NAME = "_turn_journal"
 _TERMINAL_EVENTS = {"completed", "interrupted"}
@@ -35,6 +41,26 @@ def _journal_path(session_id: str, session_dir: Path | None = None) -> Path:
 
 def _make_turn_id() -> str:
     return f"{time.strftime('%Y%m%dT%H%M%SZ', time.gmtime())}-{uuid.uuid4().hex[:12]}"
+
+
+@contextmanager
+def _journal_file_lock(file_obj):
+    """Serialize multi-process journal writes when advisory locks exist.
+
+    ``O_APPEND`` keeps normal same-process appends simple, but a long JSONL event
+    can exceed POSIX's small atomic-write boundary.  On Unix, take an advisory
+    lock around the single event write+fsync so two WebUI worker processes cannot
+    interleave large submitted-message payloads into corrupted JSONL.  Platforms
+    without ``fcntl`` keep the previous best-effort append behavior.
+    """
+    if _fcntl is None:
+        yield
+        return
+    _fcntl.flock(file_obj.fileno(), _fcntl.LOCK_EX)
+    try:
+        yield
+    finally:
+        _fcntl.flock(file_obj.fileno(), _fcntl.LOCK_UN)
 
 
 def append_turn_journal_event(
@@ -64,9 +90,10 @@ def append_turn_journal_event(
     line = json.dumps(payload, ensure_ascii=False, separators=(",", ":")) + "\n"
     fd = os.open(path, os.O_CREAT | os.O_APPEND | os.O_WRONLY, 0o600)
     with os.fdopen(fd, "a", encoding="utf-8") as fh:
-        fh.write(line)
-        fh.flush()
-        os.fsync(fh.fileno())
+        with _journal_file_lock(fh):
+            fh.write(line)
+            fh.flush()
+            os.fsync(fh.fileno())
     try:
         dir_fd = os.open(path.parent, os.O_DIRECTORY)
         try:

--- a/tests/test_turn_journal.py
+++ b/tests/test_turn_journal.py
@@ -1,5 +1,6 @@
 import json
 
+import api.turn_journal as turn_journal
 from api.session_recovery import audit_session_recovery
 from api.turn_journal import (
     append_turn_journal_event,
@@ -55,6 +56,41 @@ def test_read_turn_journal_tolerates_malformed_lines(tmp_path):
 
     assert [event["event"] for event in result["events"]] == ["submitted", "completed"]
     assert result["malformed"] == [{"line": 2, "raw": "not-json"}]
+
+
+def test_append_turn_journal_event_locks_around_write_and_fsync(tmp_path, monkeypatch):
+    calls = []
+
+    class FakeFcntl:
+        LOCK_EX = 1
+        LOCK_UN = 2
+
+        @staticmethod
+        def flock(fd, flag):
+            calls.append((fd, flag))
+
+    monkeypatch.setattr(turn_journal, "_fcntl", FakeFcntl)
+
+    append_turn_journal_event(
+        "sid-1",
+        {"event": "submitted", "turn_id": "turn-locked", "content": "x" * 5000},
+        session_dir=tmp_path,
+    )
+
+    assert [flag for _, flag in calls] == [FakeFcntl.LOCK_EX, FakeFcntl.LOCK_UN]
+
+
+def test_append_turn_journal_event_still_writes_when_fcntl_unavailable(tmp_path, monkeypatch):
+    monkeypatch.setattr(turn_journal, "_fcntl", None)
+
+    append_turn_journal_event(
+        "sid-1",
+        {"event": "submitted", "turn_id": "turn-no-fcntl", "content": "hello"},
+        session_dir=tmp_path,
+    )
+
+    result = read_turn_journal("sid-1", session_dir=tmp_path)
+    assert result["events"][0]["turn_id"] == "turn-no-fcntl"
 
 
 def test_derive_turn_journal_states_keeps_latest_event_per_turn():


### PR DESCRIPTION
## Thinking Path
Issue #2097's double-terminal audit slice is already present on current `master`, but the multi-process append-safety follow-up was still open. The narrowest safe slice is to keep the current one-file JSONL journal format and serialize each event append with a Unix advisory file lock when available.

## What Changed
- Added a small `_journal_file_lock()` context manager around turn-journal event write + flush + fsync.
- Uses `fcntl.flock(LOCK_EX)` on Unix and preserves the previous best-effort append behavior when `fcntl` is unavailable.
- Added regression coverage for both the locked Unix path and the no-`fcntl` fallback path.
- Added a release-note-ready changelog entry.

## Why It Matters
Large `submitted` events can exceed the small POSIX atomic-write boundary. If a future deployment runs multiple WebUI worker processes against the same state directory, two large event writes could otherwise interleave and corrupt the JSONL journal. Locking the write+fsync section keeps the existing format while making that deployment shape safer.

Refs #2097

## Verification
- `/home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_turn_journal.py tests/test_turn_journal_lifecycle.py tests/test_turn_journal_callsite.py -q` — 14 passed
- `git diff --check` — passed

## Risks / Follow-ups
- Advisory locks require cooperating writers. This covers WebUI's turn-journal writer; external tools manually editing the JSONL file can still bypass the lock.
- The broader async/fsync latency tradeoff is tracked separately by #2096.

## Model Used
AI-assisted change with repository inspection, targeted editing, and shell-based test verification.
