### PR TITLE
Avoid touching updated_at during stale stream cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Fixed
 
+- **PR TBD** by @franksong2702 — Clearing stale stream runtime flags no longer refreshes a session's `updated_at`, so old compressed continuations should not jump back to the top of the sidebar just because WebUI repaired a dead `active_stream_id` during a read/list request.
+
 - **PR #2322** by @Michaelyklam (refs #2271) — LAN Ollama models selected from endpoint-discovered `custom:<host>-<port>` / `custom:<host>:<port>` picker entries now route through the configured `ollama` provider and base URL instead of surfacing a missing `CUSTOM_*_API_KEY` error. The picker still surfaces endpoint-discovered entries; the fix is to recognize them as UI routing hints matching the configured local-server base URL and resolve them via the actual `ollama` provider.
 
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -1012,7 +1012,10 @@ def _clear_stale_stream_state(session) -> bool:
         if hasattr(session, "pending_started_at"):
             session.pending_started_at = None
         try:
-            session.save()
+            # Runtime cleanup is not user activity; do not bubble old sessions
+            # to the top of the sidebar just because a stale stream flag was
+            # repaired during a read/list path.
+            session.save(touch_updated_at=False)
         except Exception:
             logger.exception(
                 "_clear_stale_stream_state: save() failed for session %s",

--- a/tests/test_stale_stream_cleanup.py
+++ b/tests/test_stale_stream_cleanup.py
@@ -37,10 +37,13 @@ class _FakeSession:
         self.pending_user_message = "old prompt"
         self.pending_attachments = ["old.txt"]
         self.pending_started_at = 123
+        self.messages = []
         self.saved_stream_ids = []
+        self.saved_touch_updated_at = []
 
-    def save(self):
+    def save(self, *, touch_updated_at=True):
         self.saved_stream_ids.append(self.active_stream_id)
+        self.saved_touch_updated_at.append(touch_updated_at)
 
 
 def test_stale_stream_cleanup_helper_exists():
@@ -50,7 +53,18 @@ def test_stale_stream_cleanup_helper_exists():
     assert "session.pending_user_message = None" in ROUTES_SRC
     assert "session.pending_attachments = []" in ROUTES_SRC
     assert "session.pending_started_at = None" in ROUTES_SRC
-    assert "session.save()" in ROUTES_SRC
+    assert "session.save(touch_updated_at=False)" in ROUTES_SRC
+
+
+def test_stale_stream_cleanup_does_not_refresh_sidebar_timestamp():
+    config.STREAMS.clear()
+    config.SESSION_AGENT_LOCKS.clear()
+    session = _FakeSession()
+
+    assert routes._clear_stale_stream_state(session) is True
+
+    assert session.active_stream_id is None
+    assert session.saved_touch_updated_at == [False]
 
 
 def test_session_load_clears_stale_stream_before_response():


### PR DESCRIPTION
## Thinking Path

Fixes #2345.

The bug is a source-of-truth problem: stale stream cleanup is runtime metadata cleanup, not user-visible session activity. Calling `session.save()` with the default behavior refreshes `updated_at`, which can make an old session look newly active in the sidebar.

The right layer for the fix is the cleanup path itself. It should persist the cleared stale stream metadata without touching the session's activity timestamp.

## What Changed

- Update `_clear_stale_stream_state()` to save with `touch_updated_at=False`.
- Add a regression test that records the save call and proves stale cleanup does not refresh the sidebar timestamp.
- Keep the existing stale stream cleanup behavior otherwise unchanged.

## Why It Matters

Users should not see old sessions bubble back up just because the server cleaned stale runtime fields. Sidebar ordering should reflect real conversation/session activity, not maintenance work.

## Verification

- `uv run --python 3.12 --with pytest --with pyyaml pytest tests/test_stale_stream_cleanup.py tests/test_metadata_save_wipe_1558.py tests/test_issue2157_sessions_list_stale_stream_state.py`
  - Result: `24 passed`

## Risks / Follow-ups

- This is intentionally narrow: it does not clean existing local data or archive duplicate-looking historical sessions.
- Other metadata-only save paths should continue to use `touch_updated_at=False` when they are not user-visible activity.

## Model Used

Codex GPT-5. AI assisted with investigation, implementation, tests, and PR text.
