### PR TITLE
Release v0.51.70 (stage-363) — 4-PR snapshot+journal+UI batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@
 
 - **PR #2333** by @Michaelyklam (closes #2312 follow-up #1) — Removed dead production helper `_save_pre_compression_snapshot()` at `api/streaming.py:1945`. The production path now uses `_preserve_pre_compression_snapshot()` exclusively (which must index snapshots with `skip_index=False` for sidebar filtering). The dead helper was only called from `tests/test_compression_snapshot_runtime_clear.py`; the test is retargeted to exercise the actual production helper instead. Closes follow-up item #1 from the v0.51.66 review (#2312).
 
+- **PR #2334** by @Michaelyklam (refs #2097) — Turn journal appends now take an advisory `flock` around each JSONL event write and fsync when Unix file locks are available. This keeps oversized submitted-message events from interleaving at the byte level if a future deployment runs multiple WebUI worker processes against the same state directory, while preserving the previous best-effort append path on platforms without `fcntl`.
+
 ## [v0.51.68] — 2026-05-15 — Release AR (stage-361 — 4-PR follow-up batch — #2315 profile skill seeding + #2317 theme fallback + #2318 mobile stream defer + #2319 chat upload relocation — with Opus-caught vision-model regression fix)
 
 ### Added
@@ -31,7 +33,6 @@
 - **PR #2319** by @Michaelyklam — Chat file uploads now land in a session-scoped attachment inbox instead of cluttering the active workspace root. By default uploads are stored under `~/.hermes/webui/attachments/<session_id>/`; operators can override the root with `HERMES_WEBUI_ATTACHMENT_DIR`, and the agent still receives the absolute uploaded file path for context. Archive extraction stays workspace-scoped (it's an explicit workspace operation). README updated to document the new default location. **Stage-361 maintainer fix applied inline**: Opus advisor caught that `_build_native_multimodal_message` at `api/streaming.py:787` required uploads to be under `workspace_root`, which would have silently dropped every image upload for vision-capable models once the inbox moved outside the workspace. The fix adds `_attachment_root()` (from `api/upload.py`) as a second allowed location, with 3 regression tests covering the new code path AND verifying the original workspace + cross-root rejection paths still work.
 
 ### Fixed
-
 
 - **PR #2315** by @Michaelyklam (closes #2305, refs #749) — WebUI profile creation now seeds bundled profile skills for newly-created non-cloned profiles, matching the CLI's `hermes profile create` behaviour. Pre-fix, creating a profile via Settings → New Profile (without checking "Clone from active profile") left the profile's `skills/` directory empty, which was inconsistent with CLI-created profiles that get the full bundled-skills overlay. The fix calls `seed_profile_skills(profile_path, quiet=True)` after `profile_path.mkdir()` when `clone_from is None`. Cloned profiles still inherit skills from their source — they don't get a second bundled-skills overlay. Seed failures (e.g. `hermes_cli` unavailable in Docker fallback) are logged as warnings, not fatal — profile creation still succeeds.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Fixed
 
+- **PR #2337** by @Michaelyklam (closes #2336) — Pre-compression snapshot preservation now also clears stale runtime stream fields when the existing on-disk snapshot is already as complete as the in-memory session. This keeps the load-and-mark branch aligned with the full-save branch and adds regression coverage so archived parent snapshots cannot retain stale `active_stream_id` / `pending_*` state.
+
 - **PR #2322** by @Michaelyklam (refs #2271) — LAN Ollama models selected from endpoint-discovered `custom:<host>-<port>` / `custom:<host>:<port>` picker entries now route through the configured `ollama` provider and base URL instead of surfacing a missing `CUSTOM_*_API_KEY` error. The picker still surfaces endpoint-discovered entries; the fix is to recognize them as UI routing hints matching the configured local-server base URL and resolve them via the actual `ollama` provider.
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ## [Unreleased]
 
+## [v0.51.70] — 2026-05-16 — Release AS (stage-363 — 4-PR snapshot+journal+UI batch — #2337 compression snapshot runtime-clear + #2334 turn-journal fcntl lock + #2342 INFLIGHT reattach pending row + #2339 workspace panel edge toggle)
+
 ### Added
 
 - **PR #2339** by @Michaelyklam (refs #2211) — The workspace panel now has a small desktop edge toggle that remains clickable after the right panel is hidden, making it possible to reopen the workspace browser without returning to Settings. The existing panel close button and composer workspace button remain unchanged; the new affordance only appears when the workspace panel is closed on desktop widths.
-
-- **PR #2332** by @Michaelyklam (refs #2290) — Cron run history/output cards now surface token/cost metadata when the underlying cron output markdown includes it. The backend parses optional model/token/cost/duration frontmatter from cron output files and returns it from `/api/crons/history` and `/api/crons/run`; the Tasks panel renders a compact usage strip beside run rows and below expanded output without affecting older outputs that lack usage metadata.
 
 ### Fixed
 
@@ -14,8 +14,17 @@
 
 - **PR #2342** by @franksong2702 (fixes #2341) — Reattaching to an active streaming session now keeps the user prompt that started the running turn visible. Pre-fix, reload/session-switch restore could hydrate from the browser's INFLIGHT stream cache while the backend still held the initiating prompt only as `pending_user_message`, so the transcript showed assistant Thinking/Tool activity without the user's just-submitted message. The restore path now merges that pending user row into the live transcript before rendering and updates the INFLIGHT cache, while duplicate suppression checks the current message array so final session payloads do not show the prompt twice.
 
-- **PR #2322** by @Michaelyklam (refs #2271) — LAN Ollama models selected from endpoint-discovered `custom:<host>-<port>` / `custom:<host>:<port>` picker entries now route through the configured `ollama` provider and base URL instead of surfacing a missing `CUSTOM_*_API_KEY` error. The picker still surfaces endpoint-discovered entries; the fix is to recognize them as UI routing hints matching the configured local-server base URL and resolve them via the actual `ollama` provider.
+- **PR #2334** by @Michaelyklam (refs #2097) — Turn journal appends now take an advisory `flock` around each JSONL event write and fsync when Unix file locks are available. This keeps oversized submitted-message events from interleaving at the byte level if a future deployment runs multiple WebUI worker processes against the same state directory, while preserving the previous best-effort append path on platforms without `fcntl`.
 
+## [v0.51.69] — 2026-05-15 — Release AT (stage-362 — 8-PR follow-up batch — Ollama routing + legacy toolset + cancel copy + cleanup + custom provider mismatch + cron metadata + dead-code removal; #2323 reverted after Opus-caught silent regression, refiled as #2321 reopen)
+
+### Added
+
+- **PR #2332** by @Michaelyklam (refs #2290) — Cron run history/output cards now surface token/cost metadata when the underlying cron output markdown includes it. The backend parses optional model/token/cost/duration frontmatter from cron output files and returns it from `/api/crons/history` and `/api/crons/run`; the Tasks panel renders a compact usage strip beside run rows and below expanded output without affecting older outputs that lack usage metadata.
+
+### Fixed
+
+- **PR #2322** by @Michaelyklam (refs #2271) — LAN Ollama models selected from endpoint-discovered `custom:<host>-<port>` / `custom:<host>:<port>` picker entries now route through the configured `ollama` provider and base URL instead of surfacing a missing `CUSTOM_*_API_KEY` error. The picker still surfaces endpoint-discovered entries; the fix is to recognize them as UI routing hints matching the configured local-server base URL and resolve them via the actual `ollama` provider.
 
 - **PR #2326** by @Michaelyklam (closes #2232) — Legacy `hermes` CLI toolset alias is now normalized to `hermes-cli` + `hermes-api-server` when WebUI resolves CLI toolsets from shared Hermes config. Modern Hermes Agent exposes the composite under those two names; older configs that still contain the legacy `hermes` toolset name no longer surface as "unknown toolset" warnings.
 
@@ -28,8 +37,6 @@
 - **PR #2331** by @Michaelyklam — Live activity row now shows a transient human-readable progress phrase derived from the current tool category (e.g. "Reading file…", "Searching files…", "Running command…") instead of only the elapsed-time counter `Working 1m 23s`. Compact transcript view unchanged.
 
 - **PR #2333** by @Michaelyklam (closes #2312 follow-up #1) — Removed dead production helper `_save_pre_compression_snapshot()` at `api/streaming.py:1945`. The production path now uses `_preserve_pre_compression_snapshot()` exclusively (which must index snapshots with `skip_index=False` for sidebar filtering). The dead helper was only called from `tests/test_compression_snapshot_runtime_clear.py`; the test is retargeted to exercise the actual production helper instead. Closes follow-up item #1 from the v0.51.66 review (#2312).
-
-- **PR #2334** by @Michaelyklam (refs #2097) — Turn journal appends now take an advisory `flock` around each JSONL event write and fsync when Unix file locks are available. This keeps oversized submitted-message events from interleaving at the byte level if a future deployment runs multiple WebUI worker processes against the same state directory, while preserving the previous best-effort append path on platforms without `fcntl`.
 
 ## [v0.51.68] — 2026-05-15 — Release AR (stage-361 — 4-PR follow-up batch — #2315 profile skill seeding + #2317 theme fallback + #2318 mobile stream defer + #2319 chat upload relocation — with Opus-caught vision-model regression fix)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Fixed
 
+- **Issue #2341** by @franksong2702 — Reattaching to an active streaming session now keeps the user prompt that started the running turn visible. Pre-fix, reload/session-switch restore could hydrate from the browser's INFLIGHT stream cache while the backend still held the initiating prompt only as `pending_user_message`, so the transcript showed assistant Thinking/Tool activity without the user's just-submitted message. The restore path now merges that pending user row into the live transcript before rendering and updates the INFLIGHT cache, while duplicate suppression checks the current message array so final session payloads do not show the prompt twice.
+
 - **PR #2322** by @Michaelyklam (refs #2271) — LAN Ollama models selected from endpoint-discovered `custom:<host>-<port>` / `custom:<host>:<port>` picker entries now route through the configured `ollama` provider and base URL instead of surfacing a missing `CUSTOM_*_API_KEY` error. The picker still surfaces endpoint-discovered entries; the fix is to recognize them as UI routing hints matching the configured local-server base URL and resolve them via the actual `ollama` provider.
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- **PR #2339** by @Michaelyklam (refs #2211) — The workspace panel now has a small desktop edge toggle that remains clickable after the right panel is hidden, making it possible to reopen the workspace browser without returning to Settings. The existing panel close button and composer workspace button remain unchanged; the new affordance only appears when the workspace panel is closed on desktop widths.
+
 - **PR #2332** by @Michaelyklam (refs #2290) — Cron run history/output cards now surface token/cost metadata when the underlying cron output markdown includes it. The backend parses optional model/token/cost/duration frontmatter from cron output files and returns it from `/api/crons/history` and `/api/crons/run`; the Tasks panel renders a compact usage strip beside run rows and below expanded output without affecting older outputs that lack usage metadata.
 
 ### Fixed

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -1738,8 +1738,6 @@ def _preserve_pre_compression_snapshot(s, old_sid: str) -> None:
             # than leaving an unreadable recovery snapshot behind.
             existing_msgs = -1
             existing_snapshot = False
-        if len(s.messages) <= existing_msgs and existing_snapshot:
-            return
         if len(s.messages) > existing_msgs:
             # In-memory messages are newer than the file; save the full old
             # snapshot from the current session object while preserving its

--- a/api/turn_journal.py
+++ b/api/turn_journal.py
@@ -11,8 +11,14 @@ import os
 import re
 import time
 import uuid
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Iterable
+
+try:  # pragma: no cover - fcntl is unavailable on Windows.
+    import fcntl as _fcntl
+except ImportError:  # pragma: no cover
+    _fcntl = None
 
 TURN_JOURNAL_DIR_NAME = "_turn_journal"
 _TERMINAL_EVENTS = {"completed", "interrupted"}
@@ -35,6 +41,26 @@ def _journal_path(session_id: str, session_dir: Path | None = None) -> Path:
 
 def _make_turn_id() -> str:
     return f"{time.strftime('%Y%m%dT%H%M%SZ', time.gmtime())}-{uuid.uuid4().hex[:12]}"
+
+
+@contextmanager
+def _journal_file_lock(file_obj):
+    """Serialize multi-process journal writes when advisory locks exist.
+
+    ``O_APPEND`` keeps normal same-process appends simple, but a long JSONL event
+    can exceed POSIX's small atomic-write boundary.  On Unix, take an advisory
+    lock around the single event write+fsync so two WebUI worker processes cannot
+    interleave large submitted-message payloads into corrupted JSONL.  Platforms
+    without ``fcntl`` keep the previous best-effort append behavior.
+    """
+    if _fcntl is None:
+        yield
+        return
+    _fcntl.flock(file_obj.fileno(), _fcntl.LOCK_EX)
+    try:
+        yield
+    finally:
+        _fcntl.flock(file_obj.fileno(), _fcntl.LOCK_UN)
 
 
 def append_turn_journal_event(
@@ -64,9 +90,10 @@ def append_turn_journal_event(
     line = json.dumps(payload, ensure_ascii=False, separators=(",", ":")) + "\n"
     fd = os.open(path, os.O_CREAT | os.O_APPEND | os.O_WRONLY, 0o600)
     with os.fdopen(fd, "a", encoding="utf-8") as fh:
-        fh.write(line)
-        fh.flush()
-        os.fsync(fh.fileno())
+        with _journal_file_lock(fh):
+            fh.write(line)
+            fh.flush()
+            os.fsync(fh.fileno())
     try:
         dir_fd = os.open(path.parent, os.O_DIRECTORY)
         try:

--- a/static/boot.js
+++ b/static/boot.js
@@ -82,6 +82,7 @@ function _workspacePanelEls(){
     layout: document.querySelector('.layout'),
     panel: document.querySelector('.rightpanel'),
     toggleBtn: $('btnWorkspacePanelToggle'),
+    edgeToggleBtn: $('btnWorkspacePanelEdgeToggle'),
     collapseBtn: $('btnCollapseWorkspacePanel'),
   };
 }
@@ -176,7 +177,7 @@ function _setButtonTooltip(btn, text){
 }
 
 function syncWorkspacePanelUI(){
-  const {layout,panel,toggleBtn,collapseBtn}= _workspacePanelEls();
+  const {layout,panel,toggleBtn,edgeToggleBtn,collapseBtn}= _workspacePanelEls();
   if(!layout||!panel)return;
   const desktopOpen=_workspacePanelMode!=='closed';
   const mobileOpen=panel.classList.contains('mobile-open');
@@ -189,6 +190,12 @@ function syncWorkspacePanelUI(){
     toggleBtn.setAttribute('aria-pressed',isOpen?'true':'false');
     _setButtonTooltip(toggleBtn, isOpen?'Hide workspace panel':'Show workspace panel');
     toggleBtn.disabled=!canBrowse;
+  }
+  if(edgeToggleBtn){
+    edgeToggleBtn.classList.toggle('active',isOpen);
+    edgeToggleBtn.setAttribute('aria-expanded',isOpen?'true':'false');
+    _setButtonTooltip(edgeToggleBtn, isOpen?'Hide workspace panel':'Show workspace panel');
+    edgeToggleBtn.disabled=!canBrowse;
   }
   if(collapseBtn){
     _setButtonTooltip(collapseBtn, isCompact?'Close workspace panel':'Hide workspace panel');

--- a/static/index.html
+++ b/static/index.html
@@ -1178,6 +1178,9 @@
       </div>
     </div>
   </main>
+  <button class="workspace-panel-edge-toggle has-tooltip has-tooltip--left" id="btnWorkspacePanelEdgeToggle" type="button" onclick="toggleWorkspacePanel(true)" data-tooltip="Show workspace panel" aria-label="Show workspace panel" aria-expanded="false">
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="9 18 15 12 9 6"/></svg>
+  </button>
   <aside class="rightpanel">
     <div class="resize-handle" id="rightpanelResize"></div>
     <div class="panel-header">

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -540,6 +540,16 @@ async function loadSession(sid){
     S.busy=false;
   }
 
+  function _mergePendingSessionMessage(session,messages){
+    if(!Array.isArray(messages)) return false;
+    const pendingMsg=typeof getPendingSessionMessage==='function'?getPendingSessionMessage(session,messages):null;
+    if(!pendingMsg) return false;
+    const liveAssistantIdx=messages.findIndex(m=>m&&m.role==='assistant'&&m._live);
+    if(liveAssistantIdx>=0) messages.splice(liveAssistantIdx,0,pendingMsg);
+    else messages.push(pendingMsg);
+    return true;
+  }
+
   // Phase 2a: If session is streaming, restore from INFLIGHT cache before
   // loading full messages (INFLIGHT state is self-contained and sufficient).
   if(!INFLIGHT[sid]&&activeStreamId&&typeof loadInflightState==='function'){
@@ -558,6 +568,9 @@ async function loadSession(sid){
     // Streaming session: use cached INFLIGHT messages (already has pending assistant output).
     S.messages=INFLIGHT[sid].messages;
     S.toolCalls=(INFLIGHT[sid].toolCalls||[]);
+    if(_mergePendingSessionMessage(S.session,S.messages)){
+      INFLIGHT[sid].messages=S.messages;
+    }
     S.busy=true;
     // appendLiveToolCard() is guarded by S.activeStreamId; restore it before
     // replaying persisted live tools so the compact Activity count survives
@@ -634,8 +647,7 @@ async function loadSession(sid){
     updateQueueBadge(sid);
 
     // Attach pending user message if one is queued.
-    const pendingMsg=typeof getPendingSessionMessage==='function'?getPendingSessionMessage(S.session):null;
-    if(pendingMsg) S.messages.push(pendingMsg);
+    _mergePendingSessionMessage(S.session,S.messages);
 
     if(activeStreamId){
       S.busy=true;

--- a/static/style.css
+++ b/static/style.css
@@ -1329,6 +1329,9 @@
   @container rightpanel (max-width: 420px){
     .workspace-hidden-indicator{display:none!important;}
   }
+  .workspace-panel-edge-toggle{position:fixed;right:10px;top:50%;transform:translateY(-50%) translateX(12px);z-index:120;width:34px;height:44px;border:1px solid var(--border2);border-radius:999px;background:var(--surface);color:var(--muted);box-shadow:0 10px 28px rgba(0,0,0,.22);display:none;align-items:center;justify-content:center;cursor:pointer;opacity:0;pointer-events:none;transition:opacity .18s ease,transform .18s ease,color .15s ease,background .15s ease,border-color .15s ease;}
+  .workspace-panel-edge-toggle:hover{color:var(--text);background:var(--hover-bg);border-color:var(--accent);}
+  .workspace-panel-edge-toggle:disabled{opacity:.3;cursor:not-allowed;transform:translateY(-50%);}
   /* Small accent dot on the kebab button when a non-default pref is on */
   #btnWorkspacePrefs{position:relative;}
   #btnWorkspacePrefs .workspace-prefs-dot{position:absolute;top:3px;right:3px;width:6px;height:6px;border-radius:50%;background:var(--accent-text);box-shadow:0 0 0 1.5px var(--surface);pointer-events:none;}
@@ -1413,6 +1416,8 @@
   @media(min-width:901px){
     html[data-workspace-panel="closed"] .rightpanel{width:0 !important;opacity:0;transform:translateX(14px);border-left-color:transparent;pointer-events:none;}
     .layout.workspace-panel-collapsed .rightpanel{width:0 !important;opacity:0;transform:translateX(14px);border-left-color:transparent;pointer-events:none;}
+    html[data-workspace-panel="closed"] .workspace-panel-edge-toggle{display:inline-flex;opacity:1;pointer-events:auto;transform:translateY(-50%);}
+    html[data-workspace-panel="open"] .workspace-panel-edge-toggle{display:none;}
   }
 
   /* Sidebar collapse breakpoint matches `_isDesktopWidth()` (min-width:641px) so
@@ -1431,6 +1436,7 @@
   }
 
   @media(max-width:900px){
+    .workspace-panel-edge-toggle{display:none!important;}
     .rightpanel{display:none}
     .workspace-toggle-btn,.mobile-files-btn{display:inline-flex!important;}
   }

--- a/static/ui.js
+++ b/static/ui.js
@@ -3902,7 +3902,7 @@ async function refreshSession() {
     const data = await api(`/api/session?session_id=${encodeURIComponent(S.session.session_id)}`);
     S.session = data.session;
     S.messages = data.session.messages || [];
-    const pendingMsg=getPendingSessionMessage(data.session);
+    const pendingMsg=getPendingSessionMessage(data.session,S.messages);
     if(pendingMsg) S.messages.push(pendingMsg);
     S.activeStreamId=data.session.active_stream_id||null;
 
@@ -4302,11 +4302,12 @@ async function _waitForServerThenReload(opts){
   if(msgEl) msgEl.textContent='⚠️ Server is taking longer than expected — click Reload when ready';
 }
 
-function getPendingSessionMessage(session){
+function getPendingSessionMessage(session, messagesOverride=null){
   const text=String(session?.pending_user_message||'').trim();
   if(!text) return null;
   const attachments=Array.isArray(session?.pending_attachments)?session.pending_attachments.filter(Boolean):[];
-  const messages=Array.isArray(session?.messages)?session.messages:[];
+  const sourceMessages=Array.isArray(messagesOverride)?messagesOverride:session?.messages;
+  const messages=Array.isArray(sourceMessages)?sourceMessages:[];
   const lastUser=[...messages].reverse().find(m=>m&&m.role==='user');
   if(lastUser){
     const lastText=String(msgContent(lastUser)||'').trim();

--- a/tests/test_compression_snapshot_runtime_clear.py
+++ b/tests/test_compression_snapshot_runtime_clear.py
@@ -1,5 +1,6 @@
 import json
 
+from api import models
 from api import streaming
 
 
@@ -57,6 +58,38 @@ def test_preserve_pre_compression_snapshot_clears_runtime_fields_while_restoring
     assert session.pending_started_at == 123.0
 
     saved = json.loads((tmp_path / "old_session.json").read_text(encoding="utf-8"))
+    assert saved["pre_compression_snapshot"] is True
+    assert saved["active_stream_id"] is None
+    assert saved["pending_user_message"] is None
+    assert saved["pending_attachments"] == []
+    assert saved["pending_started_at"] is None
+
+
+def test_preserve_pre_compression_snapshot_load_and_mark_branch_clears_runtime_fields(tmp_path, monkeypatch):
+    monkeypatch.setattr(streaming, "SESSION_DIR", tmp_path)
+    monkeypatch.setattr(models, "SESSION_DIR", tmp_path)
+    old_payload = {
+        "session_id": "old_session",
+        "title": "Archived parent",
+        "messages": [
+            {"role": "user", "content": "older prompt"},
+            {"role": "assistant", "content": "older answer"},
+            {"role": "user", "content": "newer prompt already on disk"},
+        ],
+        "pre_compression_snapshot": True,
+        "active_stream_id": "stale-stream",
+        "pending_user_message": "stale prompt",
+        "pending_attachments": [{"name": "stale.txt"}],
+        "pending_started_at": 12345,
+    }
+    (tmp_path / "old_session.json").write_text(json.dumps(old_payload), encoding="utf-8")
+    session = FakeSession()
+    session.messages = [{"role": "user", "content": "current prompt"}]
+
+    streaming._preserve_pre_compression_snapshot(session, "old_session")
+
+    saved = json.loads((tmp_path / "old_session.json").read_text(encoding="utf-8"))
+    assert saved["messages"] == old_payload["messages"]
     assert saved["pre_compression_snapshot"] is True
     assert saved["active_stream_id"] is None
     assert saved["pending_user_message"] is None

--- a/tests/test_issue2211_workspace_panel_reopen.py
+++ b/tests/test_issue2211_workspace_panel_reopen.py
@@ -1,0 +1,37 @@
+"""Regression coverage for issue #2211 workspace panel reopen affordance."""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+HTML = (ROOT / "static" / "index.html").read_text(encoding="utf-8")
+CSS = (ROOT / "static" / "style.css").read_text(encoding="utf-8")
+BOOT_JS = (ROOT / "static" / "boot.js").read_text(encoding="utf-8")
+CHANGELOG = (ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+
+
+def test_workspace_panel_has_edge_reopen_toggle_outside_hidden_panel():
+    assert 'id="btnWorkspacePanelEdgeToggle"' in HTML
+    assert 'class="workspace-panel-edge-toggle' in HTML
+    assert 'onclick="toggleWorkspacePanel(true)"' in HTML
+    edge_idx = HTML.index('id="btnWorkspacePanelEdgeToggle"')
+    aside_idx = HTML.index('<aside class="rightpanel">')
+    assert edge_idx < aside_idx, "reopen control must remain clickable when .rightpanel is collapsed"
+
+
+def test_workspace_panel_edge_toggle_only_shows_when_panel_closed_on_desktop():
+    assert 'html[data-workspace-panel="closed"] .workspace-panel-edge-toggle' in CSS
+    assert 'html[data-workspace-panel="open"] .workspace-panel-edge-toggle' in CSS
+    assert '@media(max-width:900px)' in CSS and '.workspace-panel-edge-toggle{display:none!important;}' in CSS
+
+
+def test_workspace_panel_sync_updates_edge_toggle_state_and_accessibility():
+    assert "edgeToggleBtn: $('btnWorkspacePanelEdgeToggle')" in BOOT_JS
+    assert "edgeToggleBtn.classList.toggle('active',isOpen)" in BOOT_JS
+    assert "edgeToggleBtn.setAttribute('aria-expanded',isOpen?'true':'false')" in BOOT_JS
+    assert "edgeToggleBtn.disabled=!canBrowse" in BOOT_JS
+
+
+def test_changelog_mentions_workspace_panel_reopen_affordance():
+    assert "#2211" in CHANGELOG
+    assert "workspace panel" in CHANGELOG.lower()
+    assert "reopen" in CHANGELOG.lower()

--- a/tests/test_issue2341_pending_user_reattach.py
+++ b/tests/test_issue2341_pending_user_reattach.py
@@ -1,0 +1,64 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SESSIONS_JS = (ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
+UI_JS = (ROOT / "static" / "ui.js").read_text(encoding="utf-8")
+
+
+def _load_session_inflight_branch() -> str:
+    start = SESSIONS_JS.find("if(INFLIGHT[sid]){")
+    assert start != -1, "loadSession INFLIGHT branch not found"
+    end = SESSIONS_JS.find("}else{", start)
+    assert end != -1, "loadSession INFLIGHT branch end not found"
+    return SESSIONS_JS[start:end]
+
+
+def test_load_session_inflight_reattach_merges_pending_user_message_before_render():
+    """#2341: Reattaching to an active stream must show the initiating user turn.
+
+    A reload or session switch can hydrate a running turn from INFLIGHT while the
+    backend still carries the user prompt only as pending_user_message. Without
+    merging that pending row before renderMessages(), the user sees assistant
+    thinking/tool activity without the prompt that started it.
+    """
+    block = _load_session_inflight_branch()
+
+    merge_pos = block.find("_mergePendingSessionMessage")
+    render_pos = block.find("renderMessages();appendThinking();")
+
+    assert merge_pos != -1, (
+        "loadSession's INFLIGHT reattach branch must merge pending_user_message "
+        "into S.messages before rendering the running turn"
+    )
+    assert render_pos != -1, "INFLIGHT branch render call not found"
+    assert merge_pos < render_pos, (
+        "The pending user row must be present before renderMessages() rebuilds "
+        "the active transcript"
+    )
+    assert "INFLIGHT[sid].messages=S.messages;" in block, (
+        "After merging the pending user row, the INFLIGHT cache should be updated "
+        "so later session switches keep the same visible turn"
+    )
+    assert "messages.findIndex(m=>m&&m.role==='assistant'&&m._live)" in SESSIONS_JS
+    assert "messages.splice(liveAssistantIdx,0,pendingMsg)" in SESSIONS_JS
+
+
+def test_pending_user_message_dedup_checks_current_message_array():
+    """#2341: Pending merge must not duplicate an already-visible user row."""
+    assert "function getPendingSessionMessage(session, messagesOverride=null)" in UI_JS
+    helper_start = UI_JS.find("function getPendingSessionMessage(session, messagesOverride=null)")
+    assert helper_start != -1, "getPendingSessionMessage helper not found"
+    helper_end = UI_JS.find("async function checkInflightOnBoot", helper_start)
+    assert helper_end != -1, "getPendingSessionMessage helper end not found"
+    helper = UI_JS[helper_start:helper_end]
+
+    assert "messagesOverride" in helper
+    assert "Array.isArray(messagesOverride)?messagesOverride" in helper.replace(" ", ""), (
+        "Pending-message dedup must inspect the current S.messages/INFLIGHT "
+        "array, not only session.messages from the metadata response"
+    )
+    assert "lastText===text" in helper, (
+        "Pending-message merge must suppress duplicates when the last user row "
+        "already matches pending_user_message"
+    )

--- a/tests/test_turn_journal.py
+++ b/tests/test_turn_journal.py
@@ -1,5 +1,6 @@
 import json
 
+import api.turn_journal as turn_journal
 from api.session_recovery import audit_session_recovery
 from api.turn_journal import (
     append_turn_journal_event,
@@ -55,6 +56,41 @@ def test_read_turn_journal_tolerates_malformed_lines(tmp_path):
 
     assert [event["event"] for event in result["events"]] == ["submitted", "completed"]
     assert result["malformed"] == [{"line": 2, "raw": "not-json"}]
+
+
+def test_append_turn_journal_event_locks_around_write_and_fsync(tmp_path, monkeypatch):
+    calls = []
+
+    class FakeFcntl:
+        LOCK_EX = 1
+        LOCK_UN = 2
+
+        @staticmethod
+        def flock(fd, flag):
+            calls.append((fd, flag))
+
+    monkeypatch.setattr(turn_journal, "_fcntl", FakeFcntl)
+
+    append_turn_journal_event(
+        "sid-1",
+        {"event": "submitted", "turn_id": "turn-locked", "content": "x" * 5000},
+        session_dir=tmp_path,
+    )
+
+    assert [flag for _, flag in calls] == [FakeFcntl.LOCK_EX, FakeFcntl.LOCK_UN]
+
+
+def test_append_turn_journal_event_still_writes_when_fcntl_unavailable(tmp_path, monkeypatch):
+    monkeypatch.setattr(turn_journal, "_fcntl", None)
+
+    append_turn_journal_event(
+        "sid-1",
+        {"event": "submitted", "turn_id": "turn-no-fcntl", "content": "hello"},
+        session_dir=tmp_path,
+    )
+
+    result = read_turn_journal("sid-1", session_dir=tmp_path)
+    assert result["events"][0]["turn_id"] == "turn-no-fcntl"
 
 
 def test_derive_turn_journal_states_keeps_latest_event_per_turn():


### PR DESCRIPTION
## Release v0.51.70 — Stage 363

**4-PR snapshot+journal+UI batch**

### Included PRs

- **PR #2337** by @Michaelyklam (closes #2336) — Pre-compression snapshot runtime-clear branch 2. Opus follow-up from v0.51.69 stage-362.
- **PR #2334** by @Michaelyklam (refs #2097) — fcntl.flock around turn-journal appends for multi-process append safety.
- **PR #2342** by @franksong2702 (fixes #2341) — INFLIGHT reattach now keeps the user prompt visible on the active streaming session.
- **PR #2339** by @Michaelyklam (refs #2211) — Workspace panel edge reopen toggle (desktop, when panel is closed).

### Gate results

- ✅ Full pytest: 5681 passed, 10 skipped, 1 xfailed, 2 xpassed, 0 failed (111s)
- ✅ PR-specific tests: 18/18 pass
- ✅ QA harness (~/WebUI/qa/): 20/20 pass (with 60s timeout)
- ✅ Node syntax check: 3/3 JS files clean
- ✅ Merge-conflict marker sweep: clean
- ✅ Opus advisor: **APPROVE** — independently verified each PR against source

### Agent self-verification (TWO-LAYER catch, first time live)

Per the new agent-side empirical verification procedure codified earlier today:
- #2334 triggered class D (concurrency primitive) → verified `_journal_file_lock` cleanly wraps `write + flush + fsync` with `fcntl.LOCK_EX`. QA harness has no contradicting invariant. Both fcntl-available and fcntl-None paths have tests.
- Other 3 PRs below trigger thresholds (no producer→consumer channel, no path refactor, no native-replace, no mocked-consumer pattern).

### Bonus: CHANGELOG drift fix

While stamping, detected that v0.51.69 (tagged yesterday) shipped without moving 8 orphan PRs out of `## [Unreleased]`. Retroactively spliced a v0.51.69 section to give those PRs proper attribution. v0.51.70 contains ONLY this batch's 4 PRs.

### Next batch

- **PR #2283** (run-event journal replay, 787 LOC, refs #1925 RFC slice 1) deferred to dedicated stage-364 — runs through full agent self-verify procedure first.
- **PR #2340** ([WIP] custom provider CRUD) deferred until author marks ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
