### PR TITLE
Fix compression reference card anchoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Context-compaction reference cards are now inserted before the future assistant anchor when rendering compressed continuation tails, so auto-compression session rotation does not place reference-only cards inside the final answer turn. Fixes #2355.
+
 ## [v0.51.71] — 2026-05-16 — Release AU (stage-364 — 3-PR batch — #2349 stale-stream cleanup non-touching + #2343 profiles vs workspaces help card + #2283 run-event journal replay [refs #1925 RFC slice 1] — with Opus-caught replay double-render fix)
 
 ### Added

--- a/static/ui.js
+++ b/static/ui.js
@@ -5549,7 +5549,7 @@ function renderMessages(options){
       const turn=anchorSeg.closest('.assistant-turn');
       const blocks=_assistantTurnBlocks(turn);
       if(blocks){
-        blocks.appendChild(node);
+        blocks.insertBefore(node, anchorSeg);
         return;
       }
       const turnParent=turn && turn.parentElement;

--- a/tests/test_auto_compression_card.py
+++ b/tests/test_auto_compression_card.py
@@ -274,6 +274,19 @@ def test_reference_message_uses_raw_transcript_position_before_anchor_fallback()
     assert "else _insertCompressionLikeNode(referenceNode);" in src
 
 
+def test_reference_message_inserted_before_future_assistant_anchor():
+    src = _read("static/ui.js")
+    start = src.find("function _insertCompressionLikeNodeByRawIdx")
+    assert start != -1, "raw-index insertion helper not found"
+    end = src.find("const preservedOnlyNode", start)
+    assert end != -1, "raw-index insertion helper end marker not found"
+    helper = src[start:end]
+
+    assert "const anchorSeg=assistantSegments.get(anchorRawIdx);" in helper
+    assert "blocks.insertBefore(node, anchorSeg);" in helper
+    assert helper.index("blocks.insertBefore(node, anchorSeg);") < helper.index("const userRow=userRows.get(anchorRawIdx);")
+
+
 def test_reference_message_selection_prefers_latest_matching_marker():
     src = _read("static/ui.js")
     start = src.find("function _latestCompressionReferenceMessage")


### PR DESCRIPTION
## Thinking Path

Fixes #2355.

This came from a real `8787` WebUI session, not a synthetic bug hunt. A long `Article-clipper` session auto-compressed while an agent run was active. The run started under the old session id, then auto-compression rotated it into a continuation session before the assistant completed. The final answer succeeded, but the rendered timeline showed a `Context compaction` / `[CONTEXT COMPACTION — REFERENCE ONLY]` reference card mixed into the active tail near the final answer.

The important distinction is that auto-compression itself is expected background context maintenance. The bug was the WebUI render placement after rotation: a compaction marker that existed earlier in raw transcript order could be projected into a later assistant turn.

Tracing `renderMessages()` showed the narrow cause. `_insertCompressionLikeNodeByRawIdx()` finds the first future visible message after a raw marker. When that future anchor was an assistant segment, the helper appended the compression node to the anchor assistant turn's blocks. For long compressed continuations whose marker is before the latest user turn, that can place the reference-only card inside the later/final assistant turn instead of before the future anchor.

## What Changed

- `static/ui.js`: insert raw-indexed compression-like nodes before the future assistant segment instead of appending them to that assistant turn.
- `tests/test_auto_compression_card.py`: add a regression test for this exact assistant-anchor insertion rule.
- `CHANGELOG.md`: add an Unreleased bugfix entry for #2355.

Diff size: 3 files, 18 insertions, 1 deletion.

## Why It Matters

Users can reasonably hit this in normal long-session work: article clipping, knowledge-base maintenance, and repeated named workflows naturally accumulate enough history to trigger auto-compression.

When auto-compression rotates a session during an active run, background reference markers should not look like part of the current answer. The final assistant answer should remain the readable tail of the run, and `CONTEXT COMPACTION` should stay anchored to the compaction boundary.

This PR keeps the fix at the rendering layer. It does not change the agent compressor, session rotation behavior, or the live-stream timeline restoration work in #2344 / #2347.

## Verification

- First ran the new regression test before the fix and confirmed it failed because `blocks.insertBefore(node, anchorSeg);` was missing.
- `python3 -m pytest -q tests/test_auto_compression_card.py::test_reference_message_inserted_before_future_assistant_anchor`
  - Before fix: failed as expected.
  - After fix: passed.
- `node --check static/ui.js`
- `python3 -m pytest -q tests/test_auto_compression_card.py`
  - `25 passed`
- `uv run --python 3.12 --with pytest --with pyyaml pytest -q tests/test_auto_compression_card.py`
  - `25 passed`
- `git diff --check`

No before/after screenshots are attached because the original reproduction was a private real `8787` transcript. The regression test pins the DOM-order invariant without exposing that session's content.

## Risks / Follow-ups

- `_insertCompressionLikeNodeByRawIdx()` is also used for other reference-like nodes, such as handoff summaries. The new behavior is still consistent with the helper's raw-index contract: place the node before the first future visible message, not at the end of that future assistant turn.
- This does not try to solve repeated auto-compression latency. The observed run took too long partly because it compacted multiple times; that is a separate product/performance concern.
- This does not replace #2344 / #2347. It covers an uncovered auto-compression rotation edge case found while using that area of the UI.

## Model Used

Codex GPT-5. AI assisted with investigation, implementation, regression test, verification, and PR text.
