### PR TITLE
Fix Markdown table cell paragraph spacing

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -906,6 +906,7 @@
   .role-icon.assistant{background:var(--accent-bg-strong);color:var(--accent-text);border:1px solid var(--accent-bg-strong);}
   .msg-body{font-size:14px;line-height:1.75;color:var(--text);padding-left:30px;max-width:680px;overflow-wrap:anywhere;}
   .msg-body p{margin-bottom:10px;}.msg-body p:last-child{margin-bottom:0;}
+  .msg-body td p,.msg-body th p{margin:0;}
   .msg-body ul,.msg-body ol{margin:6px 0 10px 20px;}.msg-body li{margin-bottom:3px;}
   .msg-body h1,.msg-body h2,.msg-body h3,.msg-body h4,.msg-body h5,.msg-body h6{font-weight:700;color:var(--strong,var(--text));line-height:1.3;}
   .msg-body h1{font-size:24px;margin:24px 0 12px;border-bottom:1px solid var(--border);padding-bottom:6px;}

--- a/tests/test_markdown_table_cell_spacing.py
+++ b/tests/test_markdown_table_cell_spacing.py
@@ -1,0 +1,20 @@
+"""Regression tests for Markdown table cell spacing."""
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+STYLE_CSS = (REPO_ROOT / "static" / "style.css").read_text(encoding="utf-8")
+
+
+def test_table_cell_paragraph_margins_are_reset():
+    """Paragraphs inserted inside Markdown table cells should not add extra row height."""
+    assert ".msg-body td p,.msg-body th p{margin:0;}" in STYLE_CSS
+
+
+def test_table_cell_paragraph_reset_follows_global_message_paragraph_rule():
+    """The table-specific reset must override the generic message paragraph spacing rule."""
+    generic_rule = ".msg-body p{margin-bottom:10px;}"
+    table_reset = ".msg-body td p,.msg-body th p{margin:0;}"
+
+    assert generic_rule in STYLE_CSS
+    assert STYLE_CSS.index(generic_rule) < STYLE_CSS.index(table_reset)


### PR DESCRIPTION
## Summary

Fixes Markdown table rows becoming too tall when cell text is wrapped in paragraph tags by the Markdown renderer.

## Linked issue

Fixes #2360.

## Problem / why

The global message paragraph rule applies `margin-bottom: 10px` to `.msg-body p`. When Markdown table cell content is emitted as `<td><p>...</p></td>` or `<th><p>...</p></th>`, that paragraph margin adds unwanted vertical space inside each cell. The issue is especially visible in narrow browser layouts such as iPad Safari/Chrome.

## What changed

- Added a table-specific CSS reset for paragraphs inside `.msg-body td` and `.msg-body th`.
- Added regression tests that assert the table-cell paragraph reset exists and is ordered after the generic message paragraph rule.

## Testing

- `git diff --check`
- `/Users/xuefusong/hermes-webui/.venv/bin/python -m pytest tests/test_markdown_table_cell_spacing.py -v`
- `/Users/xuefusong/hermes-webui/.venv/bin/python -m pytest tests/test_markdown_table_cell_spacing.py tests/test_csv_table_rendering.py -v`

## Risk / rollback

Low risk: the CSS selector is scoped to paragraphs inside assistant/user message table cells only. Rollback is a one-line CSS removal plus deleting the dedicated regression test file.
