### PR TITLE
Release v0.51.73 (stage-366) — 1-PR compression card anchoring fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [v0.51.73] — 2026-05-16 — Release AW (stage-366 — 1-PR safe-lane batch — #2357 compression reference card anchoring fix)
+
+### Fixed
+
+- **PR #2357** by @franksong2702 (fixes #2355) — Auto-compression reference cards no longer get mixed into the final answer turn after a session rotation. Pre-fix, `_insertCompressionLikeNodeByRawIdx()` appended the compression-reference node to the future assistant anchor turn's blocks, which projected the `[CONTEXT COMPACTION — REFERENCE ONLY]` card into the live tail. The fix inserts the node *before* the anchor segment so the reference card stays a sibling, not a child of the answer turn.
+
 ## [v0.51.72] — 2026-05-16 — Release AV (stage-365 — 2-PR safe-lane batch — #2354 recovered pending turn context fix + #2348 Thinking card interim-text echo suppression)
 
 ### Fixed

--- a/static/ui.js
+++ b/static/ui.js
@@ -5562,7 +5562,7 @@ function renderMessages(options){
       const turn=anchorSeg.closest('.assistant-turn');
       const blocks=_assistantTurnBlocks(turn);
       if(blocks){
-        blocks.appendChild(node);
+        blocks.insertBefore(node, anchorSeg);
         return;
       }
       const turnParent=turn && turn.parentElement;

--- a/tests/test_auto_compression_card.py
+++ b/tests/test_auto_compression_card.py
@@ -274,6 +274,19 @@ def test_reference_message_uses_raw_transcript_position_before_anchor_fallback()
     assert "else _insertCompressionLikeNode(referenceNode);" in src
 
 
+def test_reference_message_inserted_before_future_assistant_anchor():
+    src = _read("static/ui.js")
+    start = src.find("function _insertCompressionLikeNodeByRawIdx")
+    assert start != -1, "raw-index insertion helper not found"
+    end = src.find("const preservedOnlyNode", start)
+    assert end != -1, "raw-index insertion helper end marker not found"
+    helper = src[start:end]
+
+    assert "const anchorSeg=assistantSegments.get(anchorRawIdx);" in helper
+    assert "blocks.insertBefore(node, anchorSeg);" in helper
+    assert helper.index("blocks.insertBefore(node, anchorSeg);") < helper.index("const userRow=userRows.get(anchorRawIdx);")
+
+
 def test_reference_message_selection_prefers_latest_matching_marker():
     src = _read("static/ui.js")
     start = src.find("function _latestCompressionReferenceMessage")


### PR DESCRIPTION
## Release v0.51.73 — Stage 366

**1-PR safe-lane batch**

### Included PR

- **PR #2357** by @franksong2702 (fixes #2355) — Compression reference card no longer gets appended inside the future assistant answer turn after auto-compression session rotation. One-line fix in `_insertCompressionLikeNodeByRawIdx`: `appendChild` → `insertBefore` so the `[CONTEXT COMPACTION — REFERENCE ONLY]` card lands before the answer body instead of nested inside it.

### Lane-splitting (other recent PRs deferred)

- **#2347 (live timeline restore, 380 LOC)** — Real semantic conflicts with v0.51.72's #2348 (`_stripLiveVisibleAssistantEchoFromThinking` and `visibleInterimSnippets`). Needs contributor rebase against current master to incorporate the echo-suppression helpers.
- **#2356 (mobile panel touch targets, 98 LOC)** — Incompatible architectural conflicts in `static/style.css` between PR's `.rail` layout and master's `.sidebar-nav` layout. Needs contributor redesign against the new layout.

### Gate results

- ✅ Full pytest: 5714 passed, 13 skipped, 1 xfailed, 2 xpassed, 0 failed (96s)
- ✅ PR-specific tests: 25/25 pass on `tests/test_auto_compression_card.py`
- ✅ QA harness: 20/20 pass
- ✅ Node syntax: clean
- ✅ Opus advisor: **APPROVE** — verified `anchorSeg.parentElement === blocks` invariant (line 5516 guarantees), non-rotation paths untouched, test consistent with repo style

🤖 Generated with [Claude Code](https://claude.com/claude-code)
