### PR TITLE
fix: hybridize background profile env routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Background profile workers now route broad runtime env through thread-local state while setting only `HERMES_HOME` under the narrow process-env lock, preserving `hermes_cli.config.load_config()` compatibility for non-default profiles without leaking profile-specific env keys process-wide.
+- Background profile workers now route broad runtime env through thread-local state and mirror it into process env for the worker body, preserving `hermes_cli.config.load_config()` compatibility plus provider credential readers that still call `os.getenv()` directly, then restoring prior env values after the worker exits.
 
 ## [v0.51.74] — 2026-05-16 — Release AX (stage-367 — 4-PR safe-lane batch — #2362 table-cell spacing + #2363 run-state-consistency RFC + #2365 custom_providers list-format + #2367 settings sidebar i18n)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Background profile workers now route broad runtime env through thread-local state while setting only `HERMES_HOME` under the narrow process-env lock, preserving `hermes_cli.config.load_config()` compatibility for non-default profiles without leaking profile-specific env keys process-wide.
+
 ## [v0.51.74] — 2026-05-16 — Release AX (stage-367 — 4-PR safe-lane batch — #2362 table-cell spacing + #2363 run-state-consistency RFC + #2365 custom_providers list-format + #2367 settings sidebar i18n)
 
 ### Added

--- a/api/profiles.py
+++ b/api/profiles.py
@@ -697,7 +697,8 @@ def profile_env_for_background_worker(
         return
 
     try:
-        # Lazy import avoids a module-load cycle: streaming imports this helper.
+        # Lazy imports avoid a module-load cycle: streaming imports this helper.
+        from api.config import _clear_thread_env, _set_thread_env, _thread_ctx
         from api.streaming import _ENV_LOCK
 
         profile_home_path = Path(get_hermes_home_for_profile(profile))
@@ -712,23 +713,23 @@ def profile_env_for_background_worker(
         yield
         return
 
-    env_keys = set(runtime_env.keys()) | {"HERMES_HOME"}
-    # Stage-360 maintainer fix: narrow the _ENV_LOCK critical section to just
-    # the env mutation (and the env restoration). Pre-fix, this held _ENV_LOCK
-    # for the entire `yield` duration — i.e. the whole background worker's
-    # runtime (title generation, compression, update summary). That caused
-    # _ENV_LOCK to be held for many seconds, blocking ALL other sessions and
-    # surfacing as the QA `test_third_message_completes` timeout. The fix
-    # mirrors the narrow-lock pattern in _run_agent_streaming: acquire briefly
-    # to set env, run worker without holding the lock, reacquire to restore.
-    # See also QA `test_finally_restores_env_with_lock`.
+    thread_env = dict(runtime_env)
+    thread_env["HERMES_HOME"] = str(profile_home_path)
+    # Hybrid profile routing: keep the broad runtime env in WebUI's thread-local
+    # channel so provider/API-key overrides do not leak through process-global
+    # os.environ, but still set HERMES_HOME under the narrow _ENV_LOCK because
+    # hermes_cli.config.load_config() currently resolves homes from os.environ.
+    # Do not hold _ENV_LOCK across the worker body.
     skill_home_snapshot = None
-    old_env = {}
+    old_hermes_home = None
+    had_hermes_home = False
+    previous_thread_env = getattr(_thread_ctx, "env", {}).copy()
     try:
+        _set_thread_env(**thread_env)
         with _ENV_LOCK:
-            old_env = {key: os.environ.get(key) for key in env_keys}
+            had_hermes_home = "HERMES_HOME" in os.environ
+            old_hermes_home = os.environ.get("HERMES_HOME")
             skill_home_snapshot = snapshot_skill_home_modules()
-            os.environ.update(runtime_env)
             os.environ["HERMES_HOME"] = str(profile_home_path)
             try:
                 patch_skill_home_modules(profile_home_path)
@@ -741,12 +742,15 @@ def profile_env_for_background_worker(
                 )
         yield
     finally:
+        if previous_thread_env:
+            _set_thread_env(**previous_thread_env)
+        else:
+            _clear_thread_env()
         with _ENV_LOCK:
-            for key, old_value in old_env.items():
-                if old_value is None:
-                    os.environ.pop(key, None)
-                else:
-                    os.environ[key] = old_value
+            if had_hermes_home:
+                os.environ["HERMES_HOME"] = old_hermes_home or ""
+            else:
+                os.environ.pop("HERMES_HOME", None)
             if skill_home_snapshot is not None:
                 restore_skill_home_modules(skill_home_snapshot)
 

--- a/api/profiles.py
+++ b/api/profiles.py
@@ -716,20 +716,23 @@ def profile_env_for_background_worker(
     thread_env = dict(runtime_env)
     thread_env["HERMES_HOME"] = str(profile_home_path)
     # Hybrid profile routing: keep the broad runtime env in WebUI's thread-local
-    # channel so provider/API-key overrides do not leak through process-global
-    # os.environ, but still set HERMES_HOME under the narrow _ENV_LOCK because
-    # hermes_cli.config.load_config() currently resolves homes from os.environ.
-    # Do not hold _ENV_LOCK across the worker body.
+    # channel for WebUI helpers, and also mirror it into process env for the
+    # worker body because several production Hermes readers still call
+    # os.getenv() directly for provider credentials.  Keep the _ENV_LOCK scope
+    # narrow: serialize only setup/restore, not the whole worker body.
     skill_home_snapshot = None
+    old_runtime_env: dict[str, Optional[str]] = {}
     old_hermes_home = None
     had_hermes_home = False
     previous_thread_env = getattr(_thread_ctx, "env", {}).copy()
     try:
         _set_thread_env(**thread_env)
         with _ENV_LOCK:
+            old_runtime_env = {key: os.environ.get(key) for key in runtime_env}
             had_hermes_home = "HERMES_HOME" in os.environ
             old_hermes_home = os.environ.get("HERMES_HOME")
             skill_home_snapshot = snapshot_skill_home_modules()
+            os.environ.update(runtime_env)
             os.environ["HERMES_HOME"] = str(profile_home_path)
             try:
                 patch_skill_home_modules(profile_home_path)
@@ -747,6 +750,11 @@ def profile_env_for_background_worker(
         else:
             _clear_thread_env()
         with _ENV_LOCK:
+            for key, old_value in old_runtime_env.items():
+                if old_value is None:
+                    os.environ.pop(key, None)
+                else:
+                    os.environ[key] = old_value
             if had_hermes_home:
                 os.environ["HERMES_HOME"] = old_hermes_home or ""
             else:

--- a/tests/test_sprint46.py
+++ b/tests/test_sprint46.py
@@ -415,10 +415,15 @@ def test_manual_compress_worker_uses_session_profile_env(monkeypatch, tmp_path, 
         seen_env = None
 
         def __init__(self, **kwargs):
+            from api.config import _thread_ctx
+
             skill_module = sys.modules.get("tools.skills_tool")
+            thread_env = getattr(_thread_ctx, "env", {})
             EnvAssertingAgent.seen_env = {
                 "HERMES_HOME": os.environ.get("HERMES_HOME"),
                 "HERMES_TEST_PROFILE_ENV": os.environ.get("HERMES_TEST_PROFILE_ENV"),
+                "THREAD_HERMES_HOME": thread_env.get("HERMES_HOME"),
+                "THREAD_HERMES_TEST_PROFILE_ENV": thread_env.get("HERMES_TEST_PROFILE_ENV"),
                 "SKILL_MODULE_HOME": getattr(skill_module, "HERMES_HOME", None),
                 "SKILL_MODULE_DIR": getattr(skill_module, "SKILLS_DIR", None),
             }
@@ -460,7 +465,9 @@ def test_manual_compress_worker_uses_session_profile_env(monkeypatch, tmp_path, 
 
     assert EnvAssertingAgent.seen_env == {
         "HERMES_HOME": str(profile_home),
-        "HERMES_TEST_PROFILE_ENV": "work-runtime",
+        "HERMES_TEST_PROFILE_ENV": None,
+        "THREAD_HERMES_HOME": str(profile_home),
+        "THREAD_HERMES_TEST_PROFILE_ENV": "work-runtime",
         "SKILL_MODULE_HOME": profile_home,
         "SKILL_MODULE_DIR": profile_home / "skills",
     }

--- a/tests/test_sprint46.py
+++ b/tests/test_sprint46.py
@@ -465,7 +465,7 @@ def test_manual_compress_worker_uses_session_profile_env(monkeypatch, tmp_path, 
 
     assert EnvAssertingAgent.seen_env == {
         "HERMES_HOME": str(profile_home),
-        "HERMES_TEST_PROFILE_ENV": None,
+        "HERMES_TEST_PROFILE_ENV": "work-runtime",
         "THREAD_HERMES_HOME": str(profile_home),
         "THREAD_HERMES_TEST_PROFILE_ENV": "work-runtime",
         "SKILL_MODULE_HOME": profile_home,

--- a/tests/test_title_aux_routing.py
+++ b/tests/test_title_aux_routing.py
@@ -502,8 +502,8 @@ class TestBackgroundTitleProfileRouting(unittest.TestCase):
         self.assertEqual(getattr(fake_skill_module, 'SKILLS_DIR'), 'default-home/skills')
         self.assertEqual(mock_session.title, 'Profile Routed Title')
 
-    def test_background_profile_env_routes_load_config_without_process_env_leak(self):
-        """Hybrid worker env must satisfy hermes_cli.load_config without leaking profile env keys."""
+    def test_background_profile_env_routes_load_config_and_provider_credentials(self):
+        """Hybrid worker env must satisfy config and os.getenv provider-key readers."""
         import tempfile
 
         import pytest
@@ -529,8 +529,12 @@ class TestBackgroundTitleProfileRouting(unittest.TestCase):
                 f.write('model:\n  provider: profile-provider\n  default: profile-model\n')
 
             with patch('api.profiles.get_hermes_home_for_profile', return_value=profile_home):
-                with patch('api.profiles.get_profile_runtime_env', return_value={'PROFILE_ONLY_KEY': 'profile-only'}):
-                    with patch.dict(os.environ, {'HERMES_HOME': default_home}, clear=False):
+                runtime_env = {
+                    'PROFILE_ONLY_KEY': 'profile-only',
+                    'OPENROUTER_API_KEY': 'profile-openrouter-key',
+                }
+                with patch('api.profiles.get_profile_runtime_env', return_value=runtime_env):
+                    with patch.dict(os.environ, {'HERMES_HOME': default_home, 'OPENROUTER_API_KEY': 'default-openrouter-key'}, clear=False):
                         os.environ.pop('PROFILE_ONLY_KEY', None)
                         hermes_config._LOAD_CONFIG_CACHE.clear()
                         with profiles.profile_env_for_background_worker(session, 'background title'):
@@ -538,19 +542,23 @@ class TestBackgroundTitleProfileRouting(unittest.TestCase):
                             captured['loaded_provider'] = loaded.get('model', {}).get('provider')
                             captured['process_home'] = os.environ.get('HERMES_HOME')
                             captured['process_runtime_key'] = os.environ.get('PROFILE_ONLY_KEY')
+                            captured['provider_credential'] = os.getenv('OPENROUTER_API_KEY')
                             captured['thread_home'] = getattr(_thread_ctx, 'env', {}).get('HERMES_HOME')
                             captured['thread_runtime_key'] = getattr(_thread_ctx, 'env', {}).get('PROFILE_ONLY_KEY')
                         captured['restored_home'] = os.environ.get('HERMES_HOME')
                         captured['restored_runtime_key'] = os.environ.get('PROFILE_ONLY_KEY')
+                        captured['restored_provider_credential'] = os.environ.get('OPENROUTER_API_KEY')
                         hermes_config._LOAD_CONFIG_CACHE.clear()
 
         self.assertEqual(captured['loaded_provider'], 'profile-provider')
         self.assertEqual(captured['process_home'], profile_home)
-        self.assertIsNone(captured['process_runtime_key'])
+        self.assertEqual(captured['process_runtime_key'], 'profile-only')
+        self.assertEqual(captured['provider_credential'], 'profile-openrouter-key')
         self.assertEqual(captured['thread_home'], profile_home)
         self.assertEqual(captured['thread_runtime_key'], 'profile-only')
         self.assertEqual(captured['restored_home'], default_home)
         self.assertIsNone(captured['restored_runtime_key'])
+        self.assertEqual(captured['restored_provider_credential'], 'default-openrouter-key')
 
 
 class TestAuxTitleTimeoutEdgeCases(unittest.TestCase):

--- a/tests/test_title_aux_routing.py
+++ b/tests/test_title_aux_routing.py
@@ -502,6 +502,56 @@ class TestBackgroundTitleProfileRouting(unittest.TestCase):
         self.assertEqual(getattr(fake_skill_module, 'SKILLS_DIR'), 'default-home/skills')
         self.assertEqual(mock_session.title, 'Profile Routed Title')
 
+    def test_background_profile_env_routes_load_config_without_process_env_leak(self):
+        """Hybrid worker env must satisfy hermes_cli.load_config without leaking profile env keys."""
+        import tempfile
+
+        import pytest
+
+        import api.profiles as profiles
+        from api.config import _thread_ctx
+        try:
+            from hermes_cli import config as hermes_config
+        except ModuleNotFoundError:
+            pytest.skip('hermes_cli is not installed in this CI environment')
+
+        session = types.SimpleNamespace(profile='work')
+        captured = {}
+
+        with tempfile.TemporaryDirectory() as tmp:
+            default_home = os.path.join(tmp, 'default-home')
+            profile_home = os.path.join(tmp, 'profile-home')
+            os.makedirs(default_home, exist_ok=True)
+            os.makedirs(profile_home, exist_ok=True)
+            with open(os.path.join(default_home, 'config.yaml'), 'w', encoding='utf-8') as f:
+                f.write('model:\n  provider: default-provider\n  default: default-model\n')
+            with open(os.path.join(profile_home, 'config.yaml'), 'w', encoding='utf-8') as f:
+                f.write('model:\n  provider: profile-provider\n  default: profile-model\n')
+
+            with patch('api.profiles.get_hermes_home_for_profile', return_value=profile_home):
+                with patch('api.profiles.get_profile_runtime_env', return_value={'PROFILE_ONLY_KEY': 'profile-only'}):
+                    with patch.dict(os.environ, {'HERMES_HOME': default_home}, clear=False):
+                        os.environ.pop('PROFILE_ONLY_KEY', None)
+                        hermes_config._LOAD_CONFIG_CACHE.clear()
+                        with profiles.profile_env_for_background_worker(session, 'background title'):
+                            loaded = hermes_config.load_config()
+                            captured['loaded_provider'] = loaded.get('model', {}).get('provider')
+                            captured['process_home'] = os.environ.get('HERMES_HOME')
+                            captured['process_runtime_key'] = os.environ.get('PROFILE_ONLY_KEY')
+                            captured['thread_home'] = getattr(_thread_ctx, 'env', {}).get('HERMES_HOME')
+                            captured['thread_runtime_key'] = getattr(_thread_ctx, 'env', {}).get('PROFILE_ONLY_KEY')
+                        captured['restored_home'] = os.environ.get('HERMES_HOME')
+                        captured['restored_runtime_key'] = os.environ.get('PROFILE_ONLY_KEY')
+                        hermes_config._LOAD_CONFIG_CACHE.clear()
+
+        self.assertEqual(captured['loaded_provider'], 'profile-provider')
+        self.assertEqual(captured['process_home'], profile_home)
+        self.assertIsNone(captured['process_runtime_key'])
+        self.assertEqual(captured['thread_home'], profile_home)
+        self.assertEqual(captured['thread_runtime_key'], 'profile-only')
+        self.assertEqual(captured['restored_home'], default_home)
+        self.assertIsNone(captured['restored_runtime_key'])
+
 
 class TestAuxTitleTimeoutEdgeCases(unittest.TestCase):
     """_aux_title_timeout must reject zero, negative, and non-numeric values."""

--- a/tests/test_update_banner_fixes.py
+++ b/tests/test_update_banner_fixes.py
@@ -569,13 +569,13 @@ class TestUpdateSummaryRouteModelSelection:
         assert captured['aux_task'] == 'compression'
         assert captured['model_resolution_env'] == {
             'HERMES_HOME': str(profile_home),
-            'HERMES_TEST_PROFILE_ENV': 'default-runtime',
+            'HERMES_TEST_PROFILE_ENV': 'work-runtime',
             'THREAD_HERMES_HOME': str(profile_home),
             'THREAD_HERMES_TEST_PROFILE_ENV': 'work-runtime',
         }
         assert captured['aux_env'] == {
             'HERMES_HOME': str(profile_home),
-            'HERMES_TEST_PROFILE_ENV': 'default-runtime',
+            'HERMES_TEST_PROFILE_ENV': 'work-runtime',
             'THREAD_HERMES_HOME': str(profile_home),
             'THREAD_HERMES_TEST_PROFILE_ENV': 'work-runtime',
             'SKILL_MODULE_HOME': profile_home,

--- a/tests/test_update_banner_fixes.py
+++ b/tests/test_update_banner_fixes.py
@@ -476,9 +476,12 @@ class TestUpdateSummaryRouteModelSelection:
         monkeypatch.setattr(cfg, 'get_effective_default_model', lambda: 'openai/test-main')
 
         def fake_resolve_model_provider(model):
+            thread_env = getattr(cfg._thread_ctx, 'env', {})
             captured['model_resolution_env'] = {
                 'HERMES_HOME': os.environ.get('HERMES_HOME'),
                 'HERMES_TEST_PROFILE_ENV': os.environ.get('HERMES_TEST_PROFILE_ENV'),
+                'THREAD_HERMES_HOME': thread_env.get('HERMES_HOME'),
+                'THREAD_HERMES_TEST_PROFILE_ENV': thread_env.get('HERMES_TEST_PROFILE_ENV'),
             }
             return model, 'openai', 'https://example.test/v1'
 
@@ -514,9 +517,12 @@ class TestUpdateSummaryRouteModelSelection:
                         )
 
         def fake_get_text_auxiliary_client(task, main_runtime=None):
+            thread_env = getattr(cfg._thread_ctx, 'env', {})
             captured['aux_env'] = {
                 'HERMES_HOME': os.environ.get('HERMES_HOME'),
                 'HERMES_TEST_PROFILE_ENV': os.environ.get('HERMES_TEST_PROFILE_ENV'),
+                'THREAD_HERMES_HOME': thread_env.get('HERMES_HOME'),
+                'THREAD_HERMES_TEST_PROFILE_ENV': thread_env.get('HERMES_TEST_PROFILE_ENV'),
                 'SKILL_MODULE_HOME': getattr(fake_skill_module, 'HERMES_HOME'),
                 'SKILL_MODULE_DIR': getattr(fake_skill_module, 'SKILLS_DIR'),
             }
@@ -563,11 +569,15 @@ class TestUpdateSummaryRouteModelSelection:
         assert captured['aux_task'] == 'compression'
         assert captured['model_resolution_env'] == {
             'HERMES_HOME': str(profile_home),
-            'HERMES_TEST_PROFILE_ENV': 'work-runtime',
+            'HERMES_TEST_PROFILE_ENV': 'default-runtime',
+            'THREAD_HERMES_HOME': str(profile_home),
+            'THREAD_HERMES_TEST_PROFILE_ENV': 'work-runtime',
         }
         assert captured['aux_env'] == {
             'HERMES_HOME': str(profile_home),
-            'HERMES_TEST_PROFILE_ENV': 'work-runtime',
+            'HERMES_TEST_PROFILE_ENV': 'default-runtime',
+            'THREAD_HERMES_HOME': str(profile_home),
+            'THREAD_HERMES_TEST_PROFILE_ENV': 'work-runtime',
             'SKILL_MODULE_HOME': profile_home,
             'SKILL_MODULE_DIR': profile_home / 'skills',
         }


### PR DESCRIPTION
## Thinking Path

- Background title generation, manual compression, and update-summary workers need to honor a session's non-default profile.
- The pure thread-local refactor for #2321 was reverted because `hermes_cli.config.load_config()` still reads `HERMES_HOME` from process env.
- The first hybrid pass proved that config loading worked, but review caught that provider credential readers still call `os.getenv()` directly.
- The follow-up keeps WebUI thread-local state for WebUI helpers and mirrors the profile runtime env into process env during the worker body so existing Hermes provider/auth readers see the correct profile credentials.
- The `_ENV_LOCK` critical section remains short: it serializes setup/restore of env and skill-home module caches, but does not wrap the whole worker body.

## What Changed

- Updated `profile_env_for_background_worker()` to set thread-local profile runtime env and mirror runtime env into `os.environ` for the worker body.
- Restores prior runtime env values after the worker exits, including preserving default-profile credentials when they existed before the worker.
- Preserved skill-home module snapshot/patch/restore behavior for profile-scoped skill imports.
- Added regression coverage proving both `hermes_cli.config.load_config()` and `os.getenv()`-style provider credential readers see the session profile.
- Updated manual-compression and update-summary tests to assert the revised hybrid contract.

## Why It Matters

Non-default profile background workers previously had two bad choices: broad process-env mutation with race risk, or thread-local-only env that production Hermes readers did not actually consult. This PR takes the current compatibility path: the worker sees the profile config and provider credentials used by existing Hermes Agent code, while setup/restore is bounded and covered by regressions.

Closes #2321.

## Verification

```bash
env -u HERMES_CONFIG_PATH -u HERMES_WEBUI_HOST /home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_profile_terminal_env.py tests/test_sprint29.py tests/test_issue2024_env_lock_skill_imports.py tests/test_sprint46.py::test_manual_compress_worker_uses_session_profile_env tests/test_title_aux_routing.py::TestBackgroundTitleProfileRouting tests/test_update_banner_fixes.py::TestUpdateSummaryRouteModelSelection::test_summary_route_auxiliary_model_uses_active_profile_env -q
/home/michael/.hermes/hermes-agent/venv/bin/python -m py_compile api/profiles.py
git diff --check origin/master...HEAD
git merge-tree --write-tree origin/master HEAD
```

Result on follow-up head `5bd1f14`:

```text
81 passed in 2.56s
py_compile api/profiles.py passed
git diff --check origin/master...HEAD passed
git merge-tree --write-tree origin/master HEAD passed
```

CI is running on the new head.

UI media: not applicable; backend/profile-env behavior only.

## Risks / Follow-ups

- This is still a compatibility compromise: profile runtime env keys are process-global during the worker body because current Hermes provider/auth readers still use `os.getenv()`.
- The long-term clean fix is for Hermes Agent config/auth resolution to consult an opt-in thread-local/profile context before falling back to `os.environ`.
- Any future background worker tests should exercise production config and credential readers, not only mocks that read `_thread_ctx.env`.

## Model Used

AI-assisted change with repository inspection, targeted editing, GitHub issue/PR review, and shell-based test verification.
