### PR TITLE
Clarify interrupted turn recovery after WebUI restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **PR TBD** by @franksong2702 (fixes #2370) — Recovered interrupted turns now explain that the WebUI process restarted before the agent finished, that the user message above was preserved, and that no agent output was recovered. Pre-fix, stale pending-turn repair appended the vague `Previous turn did not complete` marker, which looked like an unexplained assistant response after a WebUI restart killed the in-process worker.
+
 ## [v0.51.74] — 2026-05-16 — Release AX (stage-367 — 4-PR safe-lane batch — #2362 table-cell spacing + #2363 run-state-consistency RFC + #2365 custom_providers list-format + #2367 settings sidebar i18n)
 
 ### Added

--- a/api/models.py
+++ b/api/models.py
@@ -679,6 +679,20 @@ def _get_profile_home(profile) -> Path:
         return Path(os.environ.get('HERMES_HOME') or '~/.hermes').expanduser()
 
 
+def _interrupted_recovery_marker() -> dict:
+    return {
+        'role': 'assistant',
+        'content': (
+            '**Response interrupted.**\n\n'
+            'The WebUI process restarted before this turn finished. '
+            'The user message above was preserved, but no agent output was recovered.'
+        ),
+        'timestamp': int(time.time()),
+        '_error': True,
+        'type': 'interrupted',
+    }
+
+
 def _apply_core_sync_or_error_marker(
     session,
     core_path,
@@ -745,12 +759,7 @@ def _apply_core_sync_or_error_marker(
         session.pending_user_message = None
         session.pending_attachments = []
         session.pending_started_at = None
-        session.messages.append({
-            'role': 'assistant',
-            'content': '**Previous turn did not complete.**',
-            'timestamp': int(time.time()),
-            '_error': True,
-        })
+        session.messages.append(_interrupted_recovery_marker())
         session.save()
         logger.info(
             "Session %s: recovered pending user turn (messages non-empty), added error marker",
@@ -794,12 +803,7 @@ def _apply_core_sync_or_error_marker(
     session.pending_user_message = None
     session.pending_attachments = []
     session.pending_started_at = None
-    session.messages.append({
-        'role': 'assistant',
-        'content': '**Previous turn did not complete.**',
-        'timestamp': int(time.time()),
-        '_error': True,
-    })
+    session.messages.append(_interrupted_recovery_marker())
     session.save()
     logger.info("Session %s: no core transcript found, added error marker", sid)
     return True

--- a/api/models.py
+++ b/api/models.py
@@ -815,7 +815,7 @@ def _apply_core_sync_or_error_marker(
 # pending_user_message and STREAMS.pop(stream_id). Without this guard, any
 # fast turn (e.g. command approval) that exits the thread before the on-disk
 # pending clear has flushed gets misdiagnosed as a crashed turn, producing a
-# spurious "Previous turn did not complete." marker.
+# spurious "Response interrupted." marker.
 #
 # 30s covers the worst-case post-loop persistence window: LLM finishing a tool
 # batch + lock contention with the checkpoint thread + a multi-MB session.save.

--- a/tests/test_session_sidecar_repair.py
+++ b/tests/test_session_sidecar_repair.py
@@ -231,7 +231,7 @@ class TestRepairStalePendingNoDeadlock:
 class TestDraftRecovery:
     """When no core transcript exists, the pending user message is restored as
     a recovered user turn (_recovered=True) and the error marker says
-    'Previous turn did not complete.' — NOT 'preserved as a draft'."""
+    a clear restart interruption marker — NOT 'preserved as a draft'."""
 
     def test_pending_message_recovered_as_user_turn(self, hermes_home, monkeypatch):
         """When core transcript is missing, the pending_user_message is appended
@@ -310,7 +310,10 @@ class TestDraftRecovery:
         assert "preserved as a draft" not in content, (
             f"Error marker should not say 'preserved as a draft', got: {content}"
         )
-        assert "Previous turn did not complete" in content
+        assert "Response interrupted" in content
+        assert "WebUI process restarted" in content
+        assert "user message above was preserved" in content
+        assert error_msgs[0].get("type") == "interrupted"
 
     def test_pending_attachments_recovered(self, hermes_home, monkeypatch):
         """Attachments on the pending message are carried over to the recovered turn."""
@@ -604,7 +607,9 @@ class TestNonEmptyMessagesPendingCleared:
         # Exactly one error marker
         error_msgs = [m for m in s.messages if m.get("_error")]
         assert len(error_msgs) == 1
-        assert "Previous turn did not complete" in error_msgs[0]["content"]
+        assert "Response interrupted" in error_msgs[0]["content"]
+        assert "WebUI process restarted" in error_msgs[0]["content"]
+        assert error_msgs[0].get("type") == "interrupted"
 
         # Pending fields fully cleared
         assert s.pending_user_message is None


### PR DESCRIPTION
## Thinking Path

- WebUI currently executes browser-originated agent turns inside the WebUI process.
- If that process restarts while a turn is running, the worker dies with it.
- Run journal replay can only replay events that were already emitted; in the observed case the journal had `submitted` and `worker_started`, but no assistant/tool/terminal output.
- The existing stale-pending repair correctly preserves the user's submitted message and clears stale runtime state, but the assistant marker says only `Previous turn did not complete.`
- That wording is too vague: users cannot tell whether the model failed, the task is still running, the prompt was lost, or WebUI restarted.
- This PR keeps the recovery behavior the same while making the recovered interruption explicit.

Fixes #2370.
Related to #1925, #2283, and #2361.

## What Changed

- Replaced the generic `Previous turn did not complete` marker with a shared `_interrupted_recovery_marker()` helper.
- The marker now says:

  ```text
  Response interrupted.

  The WebUI process restarted before this turn finished. The user message above was preserved, but no agent output was recovered.
  ```

- Preserves `_error: true` and adds `type: "interrupted"` to the recovered assistant marker.
- Uses the same marker for both stale-pending repair paths:
  - sessions that already have messages;
  - sessions whose core transcript is missing or empty.
- Updates regression tests to verify the clearer wording and interrupted type.
- Adds a CHANGELOG entry.

## Why It Matters

Before:

```text
User: <preserved recovered prompt>
Assistant: Previous turn did not complete.
```

That looked like an unexplained assistant response after a restart.

After:

```text
User: <preserved recovered prompt>
Assistant: Response interrupted.

The WebUI process restarted before this turn finished. The user message above was preserved, but no agent output was recovered.
```

This does not make dead in-process worker execution survive a WebUI restart. It does make the fallback state understandable: the user's prompt is safe, the task was interrupted, and there is no recovered agent output to replay.

## Verification

- `python -m pytest tests/test_session_sidecar_repair.py tests/test_stale_stream_pending_recovery.py tests/test_issue1361_cancel_data_loss.py tests/test_cancelled_turn_status.py`
- Result: `61 passed`
- `git diff --check`

## Risks / Follow-ups

- This changes the persisted assistant marker text for future recovered stale-pending turns.
- It intentionally does not auto-resume interrupted work.
- True restart-surviving execution still belongs to the larger runtime ownership direction in #1925.
- No screenshots are included because this is a persisted backend recovery marker; the PR includes before/after transcript text instead.

## Model Used

OpenAI GPT-5.5 via Codex. AI assisted with investigation, implementation, tests, and PR preparation.
