### PR TITLE
Add run-journal replay timeline parity checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- **PR TBD** by @franksong2702 (refs #2376, refs #1925, refs #2283, refs #2361, refs #2363) — Adds a focused run-journal replay parity check for long tool-heavy turns. The frontend regression coverage now pins that replayed `reasoning`, `interim_assistant`, `tool`, `tool_complete`, `compressing`, `compressed`, `metering`, and terminal events enter the same EventSource timeline handlers as live streaming, and that each user-visible long-task event advances the replay cursor to avoid duplicate replay. The run-state consistency RFC now calls out live/replay timeline parity explicitly.
+
 ## [v0.51.74] — 2026-05-16 — Release AX (stage-367 — 4-PR safe-lane batch — #2362 table-cell spacing + #2363 run-state-consistency RFC + #2365 custom_providers list-format + #2367 settings sidebar i18n)
 
 ### Added

--- a/docs/rfcs/webui-run-state-consistency-contract.md
+++ b/docs/rfcs/webui-run-state-consistency-contract.md
@@ -78,7 +78,10 @@ while WebUI still has multiple overlapping state stores.
    assistant just acted.
 5. **Replay is idempotent.** Replaying a run from a cursor must not duplicate
    transcript rows, thinking content, interim assistant text, tool cards, or
-   compression cards.
+   compression cards. Replayed long-task events should enter the same
+   browser-facing timeline renderer as live SSE events so recovery does not
+   downgrade a structured Thinking / progress / tool / compression turn into a
+   separate flattened presentation.
 6. **Compression is not current intent.** Automatic compression summaries and
    reference cards are recovery/handoff material. They must not be treated as a
    new user request, active-turn content, or the default visible explanation for
@@ -102,6 +105,8 @@ context reconstruction, or session metadata:
 - What happens after browser refresh, session switch, SSE reconnect, and WebUI
   restart?
 - Does replay rebuild the same scene without duplicates?
+- Does replay use the same timeline-rendering path as live SSE for thinking,
+  interim assistant text, tool cards, compression cards, and terminal states?
 - Can this change move a session in the sidebar without meaningful user or
   assistant activity?
 - Can automatic compression or recovery text become visible active-turn content?
@@ -147,4 +152,3 @@ The two documents should be read together:
 4. If #1925 introduces a new adapter-backed runtime layer, update this RFC or
    replace it with the accepted implementation contract so these invariants do
    not live only in historical discussion.
-

--- a/tests/test_run_journal_frontend_static.py
+++ b/tests/test_run_journal_frontend_static.py
@@ -73,7 +73,7 @@ def test_replayed_long_task_events_enter_the_same_live_timeline_handlers():
 def test_run_journal_cursor_tracks_every_long_task_timeline_event():
     """Every user-visible long-task event needs cursor tracking for parity replay."""
     cursor_loop_pos = MESSAGES_SRC.index("for(const _runJournalEventName of [")
-    cursor_loop = MESSAGES_SRC[cursor_loop_pos : cursor_loop_pos + 700]
+    cursor_loop = MESSAGES_SRC[cursor_loop_pos : MESSAGES_SRC.index("]", cursor_loop_pos)]
     timeline_events = [
         "token",
         "interim_assistant",

--- a/tests/test_run_journal_frontend_static.py
+++ b/tests/test_run_journal_frontend_static.py
@@ -35,3 +35,60 @@ def test_frontend_replay_cursor_uses_eventsource_last_event_id():
     assert "source.addEventListener(_runJournalEventName,_rememberRunJournalCursor)" in MESSAGES_SRC
     assert "after_seq=${encodeURIComponent(String(_runJournalReplayAfterSeq()))}" in MESSAGES_SRC
     assert "after_seq=0" not in MESSAGES_SRC
+
+
+def test_replayed_long_task_events_enter_the_same_live_timeline_handlers():
+    """Run-journal replay must not grow a parallel long-task renderer.
+
+    The run-state consistency contract depends on replayed journal events
+    flowing through the same EventSource handlers as live streams.  Otherwise a
+    live long task can render as Thinking -> progress text -> tool cards, while
+    the same journaled event sequence replays as a flattened or reordered scene.
+    """
+    wire_pos = MESSAGES_SRC.index("function _wireSSE(source)")
+    wire_block = MESSAGES_SRC[wire_pos : MESSAGES_SRC.index("async function _restoreSettledSession", wire_pos)]
+    replay_events = [
+        "reasoning",
+        "interim_assistant",
+        "tool",
+        "tool_complete",
+        "compressing",
+        "compressed",
+        "metering",
+        "done",
+        "apperror",
+    ]
+
+    for event_name in replay_events:
+        assert f"source.addEventListener('{event_name}'" in wire_block, (
+            f"{event_name} must be handled by the shared live/replay SSE pipeline"
+        )
+
+    assert "updateThinking(" in wire_block, "reasoning replay should use the live Thinking card path"
+    assert "appendLiveToolCard(tc)" in wire_block, "tool replay should use live tool-card rendering"
+    assert "setCompressionUi({" in wire_block, "compression replay should use the compression card path"
+    assert "_runJournalReplayParams()" in MESSAGES_SRC, "replay attachments should enter _wireSSE via EventSource"
+
+
+def test_run_journal_cursor_tracks_every_long_task_timeline_event():
+    """Every user-visible long-task event needs cursor tracking for parity replay."""
+    cursor_loop_pos = MESSAGES_SRC.index("for(const _runJournalEventName of [")
+    cursor_loop = MESSAGES_SRC[cursor_loop_pos : cursor_loop_pos + 700]
+    timeline_events = [
+        "token",
+        "interim_assistant",
+        "reasoning",
+        "tool",
+        "tool_complete",
+        "compressing",
+        "compressed",
+        "metering",
+        "done",
+        "apperror",
+        "cancel",
+    ]
+
+    for event_name in timeline_events:
+        assert f"'{event_name}'" in cursor_loop, (
+            f"{event_name} must advance the replay cursor to avoid duplicate timeline replay"
+        )


### PR DESCRIPTION
## Thinking Path

- #2283 shipped the first #1925 run-journal replay slice: already-emitted SSE events can be replayed after reconnect or a dead WebUI stream.
- #2363 then documented the run-state consistency contract across transcript, context, streams, journal replay, compression, and the browser timeline.
- Long tool-heavy turns now depend on a structured browser timeline: Thinking, visible progress text, tool cards, compression cards, and terminal states.
- The replay layer should not grow a second renderer or replay those events as a flattened/reordered scene.
- This PR makes that contract explicit and pins it with focused frontend regression coverage.

## What Changed

- Added frontend static regression coverage that verifies replay-relevant long-task events enter the same `_wireSSE()` EventSource handler pipeline as live streaming:
  - `reasoning`
  - `interim_assistant`
  - `tool`
  - `tool_complete`
  - `compressing`
  - `compressed`
  - `metering`
  - terminal events such as `done`, `apperror`, and `cancel`
- Added coverage that those user-visible long-task events are included in the run-journal cursor tracking loop so replay starts after the latest rendered event instead of duplicating timeline content.
- Clarified the #2363 run-state consistency RFC: replayed long-task events should use the same browser-facing timeline renderer as live SSE events.
- Added a changelog entry for the contract/test hardening.

## Why It Matters

This is the concrete follow-up that connects the shipped run-journal replay slice (#2283) to the run-state consistency contract (#2363) without expanding #2347 or starting the RuntimeAdapter/sidecar work.

The intended architecture is:

```text
live SSE events      ┐
                     ├─ shared EventSource handlers / timeline renderer ─ user-visible timeline
journal replay events┘
```

Not:

```text
live stream renderer
journal replay renderer
```

That keeps WebUI thin in execution ownership without making replay a separate presentation/runtime truth.

## Verification

- `node --check static/messages.js`
- `git diff --check`
- `uv run --python 3.12 --with pytest pytest -q tests/test_run_journal_frontend_static.py`
  - `5 passed`
- `uv run --python 3.12 --with pytest pytest -q tests/test_run_journal.py tests/test_run_journal_routes.py tests/test_run_journal_frontend_static.py tests/test_run_journal_streaming_static.py`
  - `24 passed`

Note: `python3 -m pytest ...` on this Mac's system Python 3.9 fails while importing current master because the repo uses Python 3.10+ union syntax (`str | None`). CI targets Python 3.11/3.12/3.13, so verification used Python 3.12 via `uv`.

## Risks / Follow-ups

- This is intentionally a contract/test/doc PR. It does not change runtime behavior.
- It does not make WebUI-owned execution survive a WebUI process restart.
- It does not change #2347's live timeline/session-switch behavior.
- If future SSE event names are added, the cursor-tracking event list still needs to be updated. This PR makes that drift visible.
- No before/after screenshots are included because there is no user-visible UI change in this PR.

Refs #2376.
Refs #1925, #2283, #2361, #2363, #2347.

## Model Used

OpenAI Codex (GPT-5) assisted with the analysis, implementation, tests, and PR preparation.
