### PR TITLE
fix: interpolate German session time labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **PR #2381** by @Michaelyklam (fixes #2379) — German relative session-time labels now interpolate the elapsed value instead of rendering the literal `{n}` placeholder in the sidebar/header. The German locale now uses function-valued translations for minutes, hours, and days, matching the other locale bundles.
+
 ## [v0.51.74] — 2026-05-16 — Release AX (stage-367 — 4-PR safe-lane batch — #2362 table-cell spacing + #2363 run-state-consistency RFC + #2365 custom_providers list-format + #2367 settings sidebar i18n)
 
 ### Added

--- a/static/i18n.js
+++ b/static/i18n.js
@@ -6581,9 +6581,9 @@ const LOCALES = {
     session_toolsets_cleared: 'Toolsets cleared — using global config', // TODO: translate
     session_toolsets_failed: 'Failed to update toolsets: ', // TODO: translate
     session_time_unknown: 'Unbekannt',
-    session_time_minutes_ago: 'Vor {n} Minuten',
-    session_time_hours_ago: 'Vor {n} Stunden',
-    session_time_days_ago: 'Vor {n} Tagen',
+    session_time_minutes_ago: (n) => `Vor ${n} Minuten`,
+    session_time_hours_ago: (n) => `Vor ${n} Stunden`,
+    session_time_days_ago: (n) => `Vor ${n} Tagen`,
     session_time_last_week: 'Letzte Woche',
     session_time_bucket_today: 'Heute',
     session_time_bucket_yesterday: 'Gestern',

--- a/tests/test_session_sidebar_relative_time.py
+++ b/tests/test_session_sidebar_relative_time.py
@@ -169,3 +169,12 @@ def test_relative_time_strings_are_localized_in_english_and_spanish_bundles():
         "session_time_bucket_older",
     ):
         assert key in I18N_JS
+
+
+def test_german_relative_time_translations_interpolate_numbers():
+    assert "session_time_minutes_ago: (n) => `Vor ${n} Minuten`" in I18N_JS
+    assert "session_time_hours_ago: (n) => `Vor ${n} Stunden`" in I18N_JS
+    assert "session_time_days_ago: (n) => `Vor ${n} Tagen`" in I18N_JS
+    assert "session_time_minutes_ago: 'Vor {n} Minuten'" not in I18N_JS
+    assert "session_time_hours_ago: 'Vor {n} Stunden'" not in I18N_JS
+    assert "session_time_days_ago: 'Vor {n} Tagen'" not in I18N_JS


### PR DESCRIPTION
## Thinking Path
- The German locale currently defines relative session-time labels as strings containing `{n}`.
- The shared `t()` helper only interpolates numbered placeholders like `{0}` for string-valued translations.
- Other locale bundles use function-valued translations for these session-time labels, which is the safer existing pattern.
- This PR keeps the change narrow: convert only the German minutes/hours/days labels to functions and add regression coverage.

## What Changed
- Updated German `session_time_minutes_ago`, `session_time_hours_ago`, and `session_time_days_ago` entries to function-valued translations.
- Added a source-level regression test asserting the German labels interpolate numbers and no longer use literal `{n}` strings.
- Added an Unreleased changelog entry.

## Why It Matters
German users should see labels like `Vor 5 Minuten` instead of the literal placeholder `Vor {n} Minuten` in session-time surfaces.

## Verification
- `/home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_session_sidebar_relative_time.py -q` — 8 passed
- `node --check static/i18n.js` — passed
- `git diff --check` — passed

## Risks / Follow-ups
- Low risk: this changes only three German locale values and matches the existing function-valued translation pattern used by other locales.
- No screenshots attached because this is a locale interpolation bug fix with targeted source/test coverage.

Closes #2379

## Model Used
AI-assisted change with repository inspection, targeted editing, and shell-based test verification.
