### PR TITLE
Keep fuller compression snapshots reachable in sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Sidebar session lists now keep the fuller transcript reachable when an auto-compression snapshot has more messages than the visible continuation segment. Ordinary pre-compression snapshots remain hidden, but if hiding the snapshot would leave the user on a shorter segment, the sidebar prefers the fuller row so recent conversation content does not appear to vanish.
+
 ## [v0.51.74] — 2026-05-16 — Release AX (stage-367 — 4-PR safe-lane batch — #2362 table-cell spacing + #2363 run-state-consistency RFC + #2365 custom_providers list-format + #2367 settings sidebar i18n)
 
 ### Added

--- a/api/models.py
+++ b/api/models.py
@@ -1012,7 +1012,110 @@ def _hide_from_default_sidebar(session: dict) -> bool:
     """Return True for internal/background sessions hidden from the default list."""
     sid = str(session.get('session_id') or '')
     source = session.get('source_tag') or session.get('source')
-    return bool(session.get('pre_compression_snapshot')) or source == 'cron' or sid.startswith('cron_')
+    if source == 'cron' or sid.startswith('cron_'):
+        return True
+    if bool(session.get('pre_compression_snapshot')):
+        return not bool(session.get('_show_pre_compression_snapshot'))
+    return False
+
+
+def _sidebar_message_count(session: dict) -> int:
+    for key in ('message_count', 'actual_message_count'):
+        try:
+            value = int(session.get(key) or 0)
+        except (TypeError, ValueError):
+            value = 0
+        if value > 0:
+            return value
+    return 0
+
+
+def _sidebar_lineage_root_id(session: dict, sessions_by_id: dict[str, dict]) -> str:
+    sid = str(session.get('session_id') or '')
+    root = sid
+    parent = session.get('parent_session_id')
+    seen = {sid}
+    while parent and parent not in seen and parent in sessions_by_id:
+        root = str(parent)
+        seen.add(root)
+        parent = sessions_by_id.get(root, {}).get('parent_session_id')
+    return root
+
+
+def _has_live_sidebar_state(session: dict) -> bool:
+    return bool(
+        session.get('active_stream_id')
+        or session.get('has_pending_user_message')
+        or session.get('pending_user_message')
+    )
+
+
+def _prefer_fuller_snapshots_for_sidebar(sessions: list[dict]) -> list[dict]:
+    """Expose a hidden snapshot when it is the fuller transcript for a lineage.
+
+    Pre-compression snapshots are normally hidden so archived compression
+    segments do not duplicate the current continuation in the sidebar. If a
+    snapshot row has more messages than the visible continuation for the same
+    lineage, hiding it makes the conversation look truncated. In that case,
+    show the fuller snapshot and suppress the shorter inactive continuation.
+    """
+    sessions_by_id = {
+        str(session.get('session_id')): session
+        for session in sessions
+        if session.get('session_id')
+    }
+    groups: dict[str, list[dict]] = {}
+    for session in sessions:
+        sid = str(session.get('session_id') or '')
+        source = session.get('source_tag') or session.get('source')
+        if source == 'cron' or sid.startswith('cron_'):
+            continue
+        root = _sidebar_lineage_root_id(session, sessions_by_id)
+        groups.setdefault(root, []).append(session)
+
+    snapshot_ids_to_show: set[str] = set()
+    continuation_ids_to_hide: set[str] = set()
+    for group in groups.values():
+        visible = [session for session in group if not session.get('pre_compression_snapshot')]
+        snapshots = [session for session in group if session.get('pre_compression_snapshot')]
+        if not visible or not snapshots:
+            continue
+        if any(_has_live_sidebar_state(session) for session in visible):
+            continue
+
+        best_visible_count = max(_sidebar_message_count(session) for session in visible)
+        best_snapshot = max(
+            snapshots,
+            key=lambda session: (_sidebar_message_count(session), _session_sort_timestamp(session)),
+        )
+        if _sidebar_message_count(best_snapshot) <= best_visible_count:
+            continue
+
+        snapshot_ids_to_show.add(str(best_snapshot.get('session_id')))
+        continuation_ids_to_hide.update(
+            str(session.get('session_id'))
+            for session in visible
+            if session.get('session_id')
+        )
+
+    if not snapshot_ids_to_show and not continuation_ids_to_hide:
+        return sessions
+
+    out = []
+    for session in sessions:
+        sid = str(session.get('session_id') or '')
+        if sid in continuation_ids_to_hide:
+            continue
+        if sid in snapshot_ids_to_show:
+            session = dict(session)
+            session['_show_pre_compression_snapshot'] = True
+        out.append(session)
+    return out
+
+
+def _strip_sidebar_internal_flags(sessions: list[dict]) -> None:
+    for session in sessions:
+        session.pop('_show_pre_compression_snapshot', None)
 
 
 def _active_state_db_path() -> Path:
@@ -1131,7 +1234,9 @@ def all_sessions(diag=None):
                 and not s.get('has_pending_user_message')
                 and not s.get('worktree_path')
             )]
+            result = _prefer_fuller_snapshots_for_sidebar(result)
             result = [s for s in result if not _hide_from_default_sidebar(s)]
+            _strip_sidebar_internal_flags(result)
             # Backfill: sessions created before Sprint 22 have no profile tag.
             # Attribute them to 'default' so the client profile filter works correctly.
             for s in result:
@@ -1167,7 +1272,9 @@ def all_sessions(diag=None):
         and not s.pending_user_message
         and not getattr(s, 'worktree_path', None)
     )]
+    result = _prefer_fuller_snapshots_for_sidebar(result)
     result = [s for s in result if not _hide_from_default_sidebar(s)]
+    _strip_sidebar_internal_flags(result)
     for s in result:
         if not s.get('profile'):
             s['profile'] = 'default'

--- a/tests/test_session_index.py
+++ b/tests/test_session_index.py
@@ -369,6 +369,44 @@ def test_pre_compression_snapshot_hidden_from_active_sidebar_but_file_remains(mo
     assert [row["session_id"] for row in rows] == ["new_sid"]
 
 
+def test_fuller_pre_compression_snapshot_replaces_shorter_visible_segment(monkeypatch):
+    """If the hidden snapshot has the fuller transcript, keep it reachable.
+
+    Auto-compression can leave a visible continuation segment in the sidebar
+    while the fuller transcript remains on disk marked as a pre-compression
+    snapshot. In that case the default session list should prefer the fuller
+    transcript so the conversation does not look like recent messages vanished.
+    """
+    snapshot = Session(
+        session_id="full_parent",
+        title="Long Conversation",
+        messages=[
+            {"role": "user", "content": "first"},
+            {"role": "assistant", "content": "second"},
+            {"role": "user", "content": "latest user"},
+            {"role": "assistant", "content": "latest answer"},
+        ],
+        pre_compression_snapshot=True,
+        updated_at=300.0,
+    )
+    continuation = Session(
+        session_id="short_child",
+        title="Long Conversation",
+        messages=[{"role": "user", "content": "first"}],
+        parent_session_id="full_parent",
+        updated_at=400.0,
+    )
+    snapshot.save()
+    continuation.save()
+    monkeypatch.setattr(models, "_enrich_sidebar_lineage_metadata", lambda _sessions: None)
+
+    rows = models.all_sessions()
+
+    assert [row["session_id"] for row in rows] == ["full_parent"]
+    assert rows[0]["message_count"] == 4
+    assert rows[0]["pre_compression_snapshot"] is True
+
+
 def test_session_save_does_not_persist_metadata_message_count_hint():
     s = Session(
         session_id="sess_private_hint",


### PR DESCRIPTION
## Thinking Path

- Hermes WebUI normally hides `pre_compression_snapshot` rows so archived compression segments do not duplicate the active continuation in the sidebar.
- A real long Kanban session exposed a narrower failure mode: the fuller transcript was still present on disk, but it remained marked as `pre_compression_snapshot: true`.
- The default sidebar hid that fuller row and showed a shorter continuation segment instead, which looked like recent conversation content disappeared.
- The right fix is not to show every snapshot. Ordinary compression snapshots should stay hidden.
- The sidebar should only surface a snapshot when it is clearly the fuller transcript for the same lineage and the visible continuation is inactive and shorter.

Fixes #2383.

## What Changed

- Added sidebar selection logic that groups sessions by compression lineage.
- Keeps ordinary pre-compression snapshots hidden.
- If a hidden snapshot has more messages than the visible inactive continuation for that lineage, the sidebar shows the fuller snapshot row and suppresses the shorter continuation row.
- Keeps live/pending continuations visible instead of replacing active work.
- Added a regression test beside the existing snapshot-hiding test.
- Updated the changelog.

## Why It Matters

This avoids a data-loss-looking UX after auto-compression. The transcript was still recoverable by direct session id, but users normally reopen work from the sidebar. Showing a shorter segment makes the latest conversation appear to vanish.

## Before / After Evidence

Before this fix, the observed local session list exposed only the shorter row:

```text
20260516_175601_9c1c7c  51 messages  parent=f49759236f5a  pre_compression_snapshot=false
```

The fuller transcript was still on disk but hidden from `/api/sessions`:

```text
f49759236f5a  129 messages  pre_compression_snapshot=true
```

After this fix, the regression test pins the intended behavior:

```text
hidden snapshot: 4 messages, pre_compression_snapshot=true
visible child:   1 message,  parent=hidden snapshot
/api/sessions:   returns the hidden snapshot row because it is the fuller transcript
```

The existing test still verifies the normal case:

```text
hidden snapshot: 1 message
visible child:   1 message
/api/sessions:   returns only the visible child
```

## Verification

```text
uv run --python 3.12 --with pytest pytest -q tests/test_session_index.py -k 'pre_compression_snapshot'
# 3 passed, 17 deselected

uv run --python 3.12 --with pytest pytest -q tests/test_session_index.py tests/test_compression_snapshot_runtime_clear.py tests/test_issue2223_compression_no_rename.py
# 31 passed

git diff --check
# clean
```

## Risks / Follow-ups

- The change is intentionally limited to sidebar listing behavior. It does not rewrite compression, session persistence, direct session loading, or lineage traversal.
- If a visible continuation is actively streaming or has a pending user message, it is not replaced by the snapshot.
- The API row can still carry `pre_compression_snapshot: true`; this PR only keeps the fuller transcript reachable from the default list when hiding it would show a shorter conversation.

## Model Used

AI-assisted with OpenAI Codex / GPT-5.5 in a local Hermes WebUI worktree. Human-directed investigation, issue creation, implementation, verification, and PR preparation.
