### PR TITLE
fix: surface fuller compression snapshots in sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **PR #2388** by @Michaelyklam (closes #2383) — The default session sidebar now surfaces a fuller pre-compression snapshot when its visible continuation has a shorter transcript for the same lineage. Ordinary archival snapshots remain hidden once the continuation is at least as complete, preventing compressed conversations from looking truncated while keeping the sidebar uncluttered.
+
 ## [v0.51.74] — 2026-05-16 — Release AX (stage-367 — 4-PR safe-lane batch — #2362 table-cell spacing + #2363 run-state-consistency RFC + #2365 custom_providers list-format + #2367 settings sidebar i18n)
 
 ### Added

--- a/api/models.py
+++ b/api/models.py
@@ -1012,7 +1012,85 @@ def _hide_from_default_sidebar(session: dict) -> bool:
     """Return True for internal/background sessions hidden from the default list."""
     sid = str(session.get('session_id') or '')
     source = session.get('source_tag') or session.get('source')
-    return bool(session.get('pre_compression_snapshot')) or source == 'cron' or sid.startswith('cron_')
+    snapshot_hidden = (
+        bool(session.get('pre_compression_snapshot'))
+        and not session.get('_show_pre_compression_snapshot_in_sidebar')
+    )
+    return (
+        snapshot_hidden
+        or bool(session.get('_hide_shorter_compression_continuation_from_sidebar'))
+        or source == 'cron'
+        or sid.startswith('cron_')
+    )
+
+
+def _sidebar_lineage_root_id(session: dict, by_id: dict[str, dict]) -> str:
+    """Return the oldest known parent id for grouping sidebar compression segments."""
+    sid = str(session.get('session_id') or '')
+    root = sid
+    seen = {sid}
+    parent = session.get('parent_session_id')
+    while parent:
+        parent_id = str(parent)
+        if parent_id in seen:
+            break
+        seen.add(parent_id)
+        root = parent_id
+        parent_session = by_id.get(parent_id)
+        if not parent_session:
+            break
+        parent = parent_session.get('parent_session_id')
+    return root
+
+
+def _surface_fuller_pre_compression_snapshots(sessions: list[dict]) -> list[dict]:
+    """Keep a fuller hidden compression snapshot visible over a shorter continuation.
+
+    Normal pre-compression snapshots are archival rows and stay hidden from the
+    default sidebar. If a continuation for the same lineage is visible but has a
+    shorter transcript than the snapshot, hiding the snapshot makes the sidebar
+    look like the user's conversation was truncated. In that narrow case, mark
+    the fuller snapshot as sidebar-visible before the generic hidden-row filter.
+    """
+    by_id = {str(s.get('session_id')): s for s in sessions if s.get('session_id')}
+    if not by_id:
+        return sessions
+
+    for session in sessions:
+        session.pop('_show_pre_compression_snapshot_in_sidebar', None)
+        session.pop('_hide_shorter_compression_continuation_from_sidebar', None)
+
+    visible_counts_by_root: dict[str, int] = {}
+    snapshot_counts_by_root: dict[str, int] = {}
+    for session in sessions:
+        if session.get('pre_compression_snapshot'):
+            root = _sidebar_lineage_root_id(session, by_id)
+            count = int(session.get('message_count') or 0)
+            snapshot_counts_by_root[root] = max(snapshot_counts_by_root.get(root, -1), count)
+            continue
+        if _hide_from_default_sidebar(session):
+            continue
+        root = _sidebar_lineage_root_id(session, by_id)
+        count = int(session.get('message_count') or 0)
+        visible_counts_by_root[root] = max(visible_counts_by_root.get(root, -1), count)
+
+    for session in sessions:
+        if not session.get('pre_compression_snapshot'):
+            if not _hide_from_default_sidebar(session):
+                root = _sidebar_lineage_root_id(session, by_id)
+                snapshot_count = snapshot_counts_by_root.get(root)
+                session_count = int(session.get('message_count') or 0)
+                if snapshot_count is not None and snapshot_count > session_count:
+                    session['_hide_shorter_compression_continuation_from_sidebar'] = True
+            continue
+        root = _sidebar_lineage_root_id(session, by_id)
+        visible_count = visible_counts_by_root.get(root)
+        if visible_count is None:
+            continue
+        snapshot_count = int(session.get('message_count') or 0)
+        if snapshot_count > visible_count:
+            session['_show_pre_compression_snapshot_in_sidebar'] = True
+    return sessions
 
 
 def _active_state_db_path() -> Path:
@@ -1131,6 +1209,7 @@ def all_sessions(diag=None):
                 and not s.get('has_pending_user_message')
                 and not s.get('worktree_path')
             )]
+            result = _surface_fuller_pre_compression_snapshots(result)
             result = [s for s in result if not _hide_from_default_sidebar(s)]
             # Backfill: sessions created before Sprint 22 have no profile tag.
             # Attribute them to 'default' so the client profile filter works correctly.
@@ -1167,6 +1246,7 @@ def all_sessions(diag=None):
         and not s.pending_user_message
         and not getattr(s, 'worktree_path', None)
     )]
+    result = _surface_fuller_pre_compression_snapshots(result)
     result = [s for s in result if not _hide_from_default_sidebar(s)]
     for s in result:
         if not s.get('profile'):

--- a/tests/test_session_index.py
+++ b/tests/test_session_index.py
@@ -369,6 +369,65 @@ def test_pre_compression_snapshot_hidden_from_active_sidebar_but_file_remains(mo
     assert [row["session_id"] for row in rows] == ["new_sid"]
 
 
+def test_fuller_pre_compression_snapshot_replaces_shorter_sidebar_continuation(monkeypatch):
+    """A fuller compression snapshot should stay reachable from the default sidebar."""
+    snapshot = Session(
+        session_id="full_sid",
+        title="Long Conversation",
+        messages=[
+            {"role": "user", "content": "first"},
+            {"role": "assistant", "content": "second"},
+            {"role": "user", "content": "latest full transcript turn"},
+        ],
+        pre_compression_snapshot=True,
+        updated_at=100.0,
+    )
+    continuation = Session(
+        session_id="continuation_sid",
+        title="Long Conversation",
+        messages=[{"role": "assistant", "content": "compressed continuation"}],
+        parent_session_id="full_sid",
+        updated_at=200.0,
+    )
+    snapshot.save()
+    continuation.save()
+    monkeypatch.setattr(models, "_enrich_sidebar_lineage_metadata", lambda _sessions: None)
+
+    rows = models.all_sessions()
+
+    assert [row["session_id"] for row in rows] == ["full_sid"]
+    assert rows[0]["pre_compression_snapshot"] is True
+    assert rows[0]["message_count"] == 3
+
+
+def test_equal_or_fuller_continuation_keeps_snapshot_hidden(monkeypatch):
+    """Ordinary archival snapshots stay hidden once the continuation is complete enough."""
+    snapshot = Session(
+        session_id="archive_sid",
+        title="Long Conversation",
+        messages=[{"role": "user", "content": "pre-compression history"}],
+        pre_compression_snapshot=True,
+        updated_at=100.0,
+    )
+    continuation = Session(
+        session_id="complete_continuation_sid",
+        title="Long Conversation",
+        messages=[
+            {"role": "user", "content": "pre-compression history"},
+            {"role": "assistant", "content": "compressed continuation"},
+        ],
+        parent_session_id="archive_sid",
+        updated_at=200.0,
+    )
+    snapshot.save()
+    continuation.save()
+    monkeypatch.setattr(models, "_enrich_sidebar_lineage_metadata", lambda _sessions: None)
+
+    rows = models.all_sessions()
+
+    assert [row["session_id"] for row in rows] == ["complete_continuation_sid"]
+
+
 def test_session_save_does_not_persist_metadata_message_count_hint():
     s = Session(
         session_id="sess_private_hint",


### PR DESCRIPTION
## Thinking Path
Issue #2383 identified a trust problem after auto-compression: the default sidebar hid every `pre_compression_snapshot` row even when that hidden row had more transcript messages than the visible continuation in the same lineage. The safest slice is to keep ordinary archival snapshots hidden, but let the fuller snapshot replace a shorter continuation when that is the only way to keep the complete transcript reachable from the default list.

## What Changed
- Added sidebar lineage comparison in `api/models.py` before the default hidden-session filter runs.
- Surfaces a pre-compression snapshot only when it has more messages than the visible continuation for the same parent lineage.
- Hides the shorter continuation in that narrow case so the default sidebar points at the fuller transcript instead of showing both rows.
- Added regressions for both the fuller-snapshot case and the ordinary snapshot-hidden case.
- Added a release-note entry under `CHANGELOG.md`.

## Why It Matters
Long compressed conversations should not look like data disappeared. This keeps the fuller transcript reachable from the normal session list without changing compression storage, direct session loading, or the normal hidden-snapshot behavior.

## Verification
- `env -u HERMES_CONFIG_PATH -u HERMES_WEBUI_HOST /home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_session_index.py -q` → 21 passed
- `env -u HERMES_CONFIG_PATH -u HERMES_WEBUI_HOST /home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_session_index.py tests/test_issue2223_compression_no_rename.py tests/test_compression_snapshot_runtime_clear.py tests/test_session_lineage_metadata_api.py -q` → 40 passed
- `python -m py_compile api/models.py`
- `git diff --check`

## Risks / Follow-ups
- This uses `message_count` as the completeness heuristic because that is already available in compact session rows. If future compression metadata exposes a stronger lineage completeness signal, this helper can use it without changing the sidebar contract.
- No screenshots attached: this is a server-side session-list selection fix with regression coverage rather than a visual layout change.

Closes #2383

## Model Used
AI-assisted change with repository inspection, targeted editing, and shell-based test verification.
