### PR TITLE
fix: cap live chat stream transports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **PR #2393** by @Michaelyklam (refs #2313) — Chat streaming now keeps only the selected conversation's live `/api/chat/stream` EventSource open. Switching into another active session closes background chat SSE transports and relies on existing session-list status plus reattach-on-select behavior, preventing many active sessions from accumulating one long-lived browser connection each.
+
 ## [v0.51.75] — 2026-05-16 — Release AY (stage-368 — 11-PR safe-lane batch — storage + i18n + run-journal parity + attachments + compression sidebar + restart-recovery + text-mode images + tables + settings i18n + German labels)
 
 ### Test infrastructure

--- a/static/messages.js
+++ b/static/messages.js
@@ -410,6 +410,16 @@ function closeLiveStream(sessionId, streamId){
   delete LIVE_STREAMS[sessionId];
 }
 
+function closeOtherLiveStreams(activeSid){
+  // Keep the live token SSE connection scoped to the conversation pane the user
+  // is actually viewing. Background sessions still show running/finished state
+  // through the session list and can reattach when selected, but they should not
+  // keep one EventSource each and exhaust the browser connection pool (#2313).
+  for(const sid of Object.keys(LIVE_STREAMS)){
+    if(sid!==activeSid) closeLiveStream(sid);
+  }
+}
+
 function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
   if(!activeSid||!streamId) return;
   const reconnecting=!!options.reconnecting;
@@ -427,6 +437,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
   ){
     return;
   }
+  closeOtherLiveStreams(activeSid);
   closeLiveStream(activeSid);
 
   let assistantText='';

--- a/tests/test_inflight_stream_reuse.py
+++ b/tests/test_inflight_stream_reuse.py
@@ -45,6 +45,25 @@ def test_attach_live_stream_reuses_existing_same_stream_transport():
     assert "return" in body[reuse_pos:close_pos]
 
 
+def test_attach_live_stream_closes_other_session_streams_before_opening_new_one():
+    """Only the selected conversation pane should hold an open chat SSE transport."""
+    body = _function_body(MESSAGES_JS, "attachLiveStream")
+    helper = _function_body(MESSAGES_JS, "closeOtherLiveStreams")
+
+    helper_compact = helper.replace(" ", "")
+    assert "Object.keys(LIVE_STREAMS)" in helper
+    assert "if(sid!==activeSid)closeLiveStream(sid)" in helper_compact
+
+    reuse_pos = body.find("const existingLive=LIVE_STREAMS[activeSid]")
+    close_other_pos = body.find("closeOtherLiveStreams(activeSid)")
+    close_current_pos = body.find("\n  closeLiveStream(activeSid);\n")
+    assert close_other_pos != -1, "attachLiveStream() should prune background chat EventSources"
+    assert reuse_pos < close_other_pos < close_current_pos, (
+        "same-stream reuse should happen before pruning, and pruning should happen "
+        "before replacing the active session transport"
+    )
+
+
 def test_attach_live_stream_updates_uploads_before_same_stream_reuse():
     """Reusing transport must not skip per-session uploaded attachment state."""
     body = _function_body(MESSAGES_JS, "attachLiveStream")


### PR DESCRIPTION
## Thinking Path
- Issue #2313 reports that keeping many active sessions open can accumulate one long-lived chat SSE connection per session.
- The browser already has reattach-on-select behavior and session-list status for background runs.
- The safest first slice is to cap live token streaming to the selected conversation pane without changing server stream ownership or session persistence.
- This preserves same-session stream reuse while closing background chat EventSources when the user switches into another running session.

## What Changed
- Added `closeOtherLiveStreams(activeSid)` in `static/messages.js`.
- `attachLiveStream()` now reuses an existing same-session transport first, then closes other sessions' chat SSE transports before opening/replacing the selected session's stream.
- Added regression coverage to keep the ordering explicit: reuse first, prune background streams next, then replace the active session transport.
- Added an Unreleased changelog entry.

## Why It Matters
This prevents a browser tab from piling up one `/api/chat/stream` EventSource per active session while keeping the current conversation live and letting background sessions reattach when selected.

Refs #2313

## Verification
- `env -u HERMES_CONFIG_PATH -u HERMES_WEBUI_HOST /home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_inflight_stream_reuse.py tests/test_streaming_race_fix.py -q` — 17 passed
- `node --check static/messages.js`
- `git diff --check`

## Risks / Follow-ups
- This is a narrow client-side connection cap, not a full streaming architecture redesign.
- Background sessions no longer keep a live token SSE transport while not selected; they rely on existing sidebar status/reload paths and reattach when opened.
- A larger follow-up could add an explicit server/browser multiplexed stream if maintainers want true simultaneous live token feeds across multiple sessions.

## Model Used
AI-assisted change with repository inspection, targeted editing, and shell-based test verification.
