### PR TITLE
fix(streaming): preserve session agents for credential pools

### DIFF
--- a/api/streaming.py
+++ b/api/streaming.py
@@ -2430,6 +2430,145 @@ def _attempt_credential_self_heal(
         return None
 
 
+def _agent_cache_api_key_sig(resolved_api_key, credential_pool) -> str:
+    """Return the cache-signature component for runtime credentials.
+
+    Credential-pool providers can legitimately hand WebUI a different runtime
+    token on each request (round-robin pools, OAuth refresh, auth self-heal).
+    The AIAgent object is also where cross-turn memory-provider state lives, so
+    using the volatile token itself in the cache signature silently defeats the
+    per-session agent cache and drops warmed Hindsight prefetch results.
+    """
+    if credential_pool is not None:
+        return 'credential-pool'
+    import hashlib as _hashlib
+    return _hashlib.sha256((resolved_api_key or '').encode()).hexdigest()[:16]
+
+
+def _refresh_cached_agent_runtime(agent, agent_kwargs: dict) -> bool:
+    """Refresh volatile runtime credentials on a reused cached AIAgent.
+
+    The cache key intentionally ignores credential-pool token churn, but the
+    cached agent's LLM client still needs the latest selected/refreshed runtime
+    key. Keep long-lived provider/session state (memory prefetch, turn counters,
+    tool state) while swapping only the runtime credential/client.
+    """
+    if agent is None or not isinstance(agent_kwargs, dict):
+        return False
+
+    new_pool = agent_kwargs.get('credential_pool')
+    if new_pool is not None:
+        try:
+            agent._credential_pool = new_pool
+        except Exception:
+            pass
+
+    new_key = agent_kwargs.get('api_key') or ''
+    if not new_key:
+        return True
+
+    new_base = agent_kwargs.get('base_url') or getattr(agent, 'base_url', '') or ''
+    if getattr(agent, '_fallback_activated', False):
+        # Avoid mixing a refreshed primary credential into a live fallback
+        # runtime. Rebuilding is safer than mutating a fallback-active agent
+        # whose restore/cooldown state has not run yet for this turn.
+        return False
+
+    if new_key == (getattr(agent, 'api_key', '') or ''):
+        _refresh_cached_agent_primary_runtime_snapshot(agent)
+        return True
+
+    try:
+        if getattr(agent, 'api_mode', None) == 'anthropic_messages':
+            # Native Anthropic-style clients have their own construction path;
+            # switch_model() already handles token/client refresh there.
+            if hasattr(agent, 'switch_model'):
+                agent.switch_model(
+                    agent_kwargs.get('model') or getattr(agent, 'model', None),
+                    agent_kwargs.get('provider') or getattr(agent, 'provider', None),
+                    api_key=new_key,
+                    base_url=new_base,
+                    api_mode=agent_kwargs.get('api_mode') or getattr(agent, 'api_mode', ''),
+                )
+                return True
+            return False
+
+        if not hasattr(agent, '_client_kwargs') or not hasattr(agent, '_replace_primary_openai_client'):
+            # Test/fake-agent fallback: keep metadata accurate even if no real
+            # OpenAI client exists to rebuild.
+            agent.api_key = new_key
+            if new_base:
+                agent.base_url = new_base
+            _refresh_cached_agent_primary_runtime_snapshot(agent)
+            return True
+
+        client_kwargs = dict(getattr(agent, '_client_kwargs', {}) or {})
+        client_kwargs['api_key'] = new_key
+        if new_base:
+            client_kwargs['base_url'] = new_base
+        agent._client_kwargs = client_kwargs
+        agent.api_key = new_key
+        if new_base:
+            agent.base_url = new_base
+        if hasattr(agent, '_apply_client_headers_for_base_url'):
+            agent._apply_client_headers_for_base_url(agent.base_url)
+        rebuilt = bool(agent._replace_primary_openai_client(reason='webui_credential_refresh'))
+        if rebuilt:
+            _refresh_cached_agent_primary_runtime_snapshot(agent)
+        return rebuilt
+    except Exception:
+        logger.debug('[webui] Failed to refresh cached agent runtime credentials', exc_info=True)
+        return False
+
+
+def _refresh_cached_agent_primary_runtime_snapshot(agent) -> None:
+    """Keep AIAgent's primary-runtime snapshot aligned with refreshed creds.
+
+    Long-lived AIAgent instances use `_primary_runtime` to restore the preferred
+    provider after fallback/transport recovery. If WebUI refreshes a cached
+    agent's runtime token but leaves that snapshot stale, a later restore can
+    resurrect the old credential and undo the refresh.
+    """
+    rt = getattr(agent, '_primary_runtime', None)
+    if not isinstance(rt, dict):
+        return
+
+    base_url = getattr(agent, 'base_url', rt.get('base_url'))
+    api_key = getattr(agent, 'api_key', rt.get('api_key', ''))
+    client_kwargs = dict(getattr(agent, '_client_kwargs', None) or rt.get('client_kwargs', {}) or {})
+
+    rt['base_url'] = base_url
+    rt['api_key'] = api_key
+    rt['client_kwargs'] = client_kwargs
+
+    # The default context compressor usually tracks the primary runtime too;
+    # keep both the live compressor fields and the fallback-restoration
+    # snapshot aligned when those attributes exist.
+    cc = getattr(agent, 'context_compressor', None)
+    if cc is not None:
+        if hasattr(cc, 'base_url'):
+            cc.base_url = base_url
+        if hasattr(cc, 'api_key'):
+            cc.api_key = api_key
+        if 'compressor_base_url' in rt:
+            rt['compressor_base_url'] = getattr(cc, 'base_url', base_url)
+        if 'compressor_api_key' in rt:
+            rt['compressor_api_key'] = getattr(cc, 'api_key', api_key)
+    else:
+        if 'compressor_base_url' in rt:
+            rt['compressor_base_url'] = base_url
+        if 'compressor_api_key' in rt:
+            rt['compressor_api_key'] = api_key
+
+    if getattr(agent, 'api_mode', None) == 'anthropic_messages':
+        if hasattr(agent, '_anthropic_api_key'):
+            rt['anthropic_api_key'] = getattr(agent, '_anthropic_api_key')
+        if hasattr(agent, '_anthropic_base_url'):
+            rt['anthropic_base_url'] = getattr(agent, '_anthropic_base_url')
+        if hasattr(agent, '_is_anthropic_oauth'):
+            rt['is_anthropic_oauth'] = getattr(agent, '_is_anthropic_oauth')
+
+
 def _run_agent_streaming(
     session_id,
     msg_text,
@@ -3315,11 +3454,16 @@ def _run_agent_streaming(
                 import hashlib as _hashlib
                 import json as _json
                 from api.config import SESSION_AGENT_CACHE, SESSION_AGENT_CACHE_LOCK
+                _credential_pool = _rt.get('credential_pool')
                 _sig_blob = _json.dumps([
                     resolved_model or '',
-                    _hashlib.sha256((resolved_api_key or '').encode()).hexdigest()[:16],
+                    _agent_cache_api_key_sig(resolved_api_key, _credential_pool),
                     resolved_base_url or '',
                     resolved_provider or '',
+                    _rt.get('api_mode') or '',
+                    _rt.get('command') or '',
+                    _rt.get('args') or [],
+                    bool(_credential_pool),
                     _max_iterations_cfg or '',
                     _max_tokens_cfg or '',
                     _fallback_resolved or {},
@@ -3342,6 +3486,23 @@ def _run_agent_streaming(
                         agent = _cached[0]
                         SESSION_AGENT_CACHE.move_to_end(session_id)  # LRU: mark as recently used
                         logger.debug('[webui] Reusing cached agent for session %s', session_id)
+
+                if agent is not None:
+                    # Refresh volatile runtime credentials selected from provider
+                    # pools without discarding cross-turn agent/provider state.
+                    if not _refresh_cached_agent_runtime(agent, _agent_kwargs):
+                        logger.warning(
+                            '[webui] Cached agent runtime could not be safely refreshed; rebuilding agent for session %s',
+                            session_id,
+                        )
+                        try:
+                            if getattr(agent, '_session_db', None) is not None:
+                                agent._session_db.close()
+                        except Exception:
+                            pass
+                        with SESSION_AGENT_CACHE_LOCK:
+                            SESSION_AGENT_CACHE.pop(session_id, None)
+                        agent = None
 
                 if agent is not None:
                     # Refresh per-turn callbacks — these close over request-scoped
@@ -3392,7 +3553,6 @@ def _run_agent_streaming(
                             # released until GC finalizes the agent, which on a
                             # long-running server may be never. Close it
                             # explicitly so the WAL handles release immediately.
-                            # (Opus pre-release follow-up to #1421.)
                             try:
                                 _evicted_agent = evicted_entry[0] if isinstance(evicted_entry, tuple) else None
                                 if _evicted_agent is not None and getattr(_evicted_agent, '_session_db', None) is not None:

--- a/tests/test_sprint42.py
+++ b/tests/test_sprint42.py
@@ -874,3 +874,139 @@ class TestCredentialPoolBackwardCompat(unittest.TestCase):
         # Agent was constructed successfully
         self.assertIn("session_id", captured["init_kwargs"])
         self.assertEqual(captured["init_kwargs"]["session_id"], "sess-compat-test")
+
+
+class TestAgentCacheCredentialPoolStability(unittest.TestCase):
+    """Credential-pool token churn must not evict cached WebUI agents."""
+
+    def test_credential_pool_signature_ignores_volatile_runtime_token(self):
+        import api.streaming as streaming
+
+        pool = object()
+        self.assertEqual(
+            streaming._agent_cache_api_key_sig('token-a', pool),
+            streaming._agent_cache_api_key_sig('token-b', pool),
+        )
+        self.assertNotEqual(
+            streaming._agent_cache_api_key_sig('token-a', None),
+            streaming._agent_cache_api_key_sig('token-b', None),
+        )
+
+    def test_cached_agent_runtime_refresh_swaps_key_without_losing_agent_state(self):
+        import api.streaming as streaming
+
+        class FakeAgent:
+            def __init__(self):
+                self.api_key = 'old-token'
+                self.base_url = 'https://chatgpt.com/backend-api/codex'
+                self.api_mode = 'codex_responses'
+                self._client_kwargs = {
+                    'api_key': 'old-token',
+                    'base_url': self.base_url,
+                    'default_headers': {'old': 'header'},
+                }
+                self._credential_pool = 'old-pool'
+                self.context_compressor = type('Compressor', (), {
+                    'base_url': self.base_url,
+                    'api_key': 'old-token',
+                })()
+                self._primary_runtime = {
+                    'base_url': self.base_url,
+                    'api_key': 'old-token',
+                    'client_kwargs': dict(self._client_kwargs),
+                    'compressor_base_url': self.base_url,
+                    'compressor_api_key': 'old-token',
+                }
+                self.header_refreshes = []
+                self.replacements = []
+                self.prefetch_survives = object()
+
+            def _apply_client_headers_for_base_url(self, base_url):
+                self.header_refreshes.append((base_url, self._client_kwargs['api_key']))
+                self._client_kwargs['default_headers'] = {'refreshed-for': self._client_kwargs['api_key']}
+
+            def _replace_primary_openai_client(self, *, reason):
+                self.replacements.append(reason)
+                return True
+
+        agent = FakeAgent()
+        preserved = agent.prefetch_survives
+        changed = streaming._refresh_cached_agent_runtime(agent, {
+            'api_key': 'new-token',
+            'base_url': 'https://chatgpt.com/backend-api/codex',
+            'credential_pool': 'new-pool',
+        })
+
+        self.assertTrue(changed)
+        self.assertIs(agent.prefetch_survives, preserved)
+        self.assertEqual(agent.api_key, 'new-token')
+        self.assertEqual(agent._client_kwargs['api_key'], 'new-token')
+        self.assertEqual(agent._credential_pool, 'new-pool')
+        self.assertEqual(agent._primary_runtime['api_key'], 'new-token')
+        self.assertEqual(agent._primary_runtime['client_kwargs']['api_key'], 'new-token')
+        self.assertEqual(agent._primary_runtime['compressor_api_key'], 'new-token')
+        self.assertEqual(getattr(agent.context_compressor, 'api_key'), 'new-token')
+        self.assertEqual(agent.header_refreshes, [('https://chatgpt.com/backend-api/codex', 'new-token')])
+        self.assertEqual(agent.replacements, ['webui_credential_refresh'])
+
+    def test_same_key_refresh_repairs_stale_primary_runtime_snapshot(self):
+        import api.streaming as streaming
+
+        class FakeAgent:
+            api_key = 'current-token'
+            base_url = 'https://chatgpt.com/backend-api/codex'
+            api_mode = 'codex_responses'
+            _client_kwargs = {
+                'api_key': 'current-token',
+                'base_url': 'https://chatgpt.com/backend-api/codex',
+            }
+            _primary_runtime = {
+                'api_key': 'old-token',
+                'base_url': 'https://chatgpt.com/backend-api/codex',
+                'client_kwargs': {
+                    'api_key': 'old-token',
+                    'base_url': 'https://chatgpt.com/backend-api/codex',
+                },
+            }
+
+        agent = FakeAgent()
+        ok = streaming._refresh_cached_agent_runtime(agent, {'api_key': 'current-token'})
+
+        self.assertTrue(ok)
+        self.assertEqual(agent._primary_runtime['api_key'], 'current-token')
+        self.assertEqual(agent._primary_runtime['client_kwargs']['api_key'], 'current-token')
+
+    def test_fallback_active_refresh_requests_rebuild_without_mutating_fallback(self):
+        import api.streaming as streaming
+
+        class FakeAgent:
+            api_key = 'fallback-token'
+            base_url = 'https://fallback.example/v1'
+            api_mode = 'codex_responses'
+            _fallback_activated = True
+            _client_kwargs = {
+                'api_key': 'fallback-token',
+                'base_url': 'https://fallback.example/v1',
+            }
+            _primary_runtime = {
+                'api_key': 'old-primary-token',
+                'base_url': 'https://chatgpt.com/backend-api/codex',
+                'client_kwargs': {
+                    'api_key': 'old-primary-token',
+                    'base_url': 'https://chatgpt.com/backend-api/codex',
+                },
+                'compressor_api_key': 'old-primary-token',
+                'compressor_base_url': 'https://chatgpt.com/backend-api/codex',
+            }
+
+        agent = FakeAgent()
+        ok = streaming._refresh_cached_agent_runtime(agent, {
+            'api_key': 'new-primary-token',
+            'base_url': 'https://chatgpt.com/backend-api/codex',
+        })
+
+        self.assertFalse(ok)
+        self.assertEqual(agent.api_key, 'fallback-token')
+        self.assertEqual(agent._client_kwargs['api_key'], 'fallback-token')
+        self.assertEqual(agent._primary_runtime['api_key'], 'old-primary-token')
+        self.assertEqual(agent._primary_runtime['client_kwargs']['api_key'], 'old-primary-token')


### PR DESCRIPTION
## Thinking Path

- WebUI caches `AIAgent` per session so turn counters and memory-provider state can survive across browser messages.
- Credential-pool providers can resolve a different runtime token on each request even when the stable provider/model configuration has not changed.
- The existing cache signature mixed stable agent identity with the volatile resolved API key, so pooled providers could miss the cache every turn and recreate the agent.
- Recreating the agent loses warmed provider-instance state such as memory prefetch results for providers like Hindsight.
- The narrow fix is to keep credential-pool cache identity stable, refresh runtime credentials on cache reuse, and rebuild the cached agent only when refreshing would be unsafe.
- Static non-pool API keys still participate in the cache signature so explicit credential changes continue to invalidate the cached agent.

## What Changed

- Added a credential-aware cache-signature helper that uses a stable sentinel for credential-pool routes while preserving hashed API-key identity for non-pool routes.
- Refreshed reused cached agents with the latest runtime credential/client instead of throwing away cross-turn agent state.
- Kept `AIAgent._primary_runtime` aligned after credential refresh so fallback/transport recovery cannot resurrect an old token.
- Rebuilt the cached agent instead of mutating it when it is still fallback-active, avoiding mixed primary/fallback runtime state.
- Closed the previous cached agent's session database handle before that rebuild path creates a replacement agent.
- Added regression tests for credential-pool token churn, runtime refresh, stale primary-runtime repair, and fallback-active rebuild safety.

## Why It Matters

- Prevents credential-pool token rotation from silently defeating WebUI session-agent caching.
- Preserves cross-turn memory-provider state for integrations that prefetch context between turns.
- Keeps static-key behavior unchanged for users who are not using credential pools.
- Avoids sending requests with mismatched runtime tokens, provider-specific headers, or fallback state.

## Verification

Targeted coverage:

```text
python -m pytest tests/test_sprint42.py::TestAgentCacheCredentialPoolStability -q
# 4 passed

python -m pytest tests/test_sprint42.py -q
# 30 passed
```

Syntax / hygiene checks:

```text
python -m py_compile api/streaming.py tests/test_sprint42.py
# passed

git diff --check
# passed
```

## Risks / Follow-ups

- If a cached agent is already fallback-active, this PR rebuilds it rather than patching primary credentials into the live fallback runtime. That is the safer path, but it can discard that cached agent's in-memory state for the next turn in that rare edge case.

## Models Used

- GPT-5.5 XHIGH for implementation
- Claude Opus 4.7 Max for review
