### PR TITLE
fix: sanitize sync chat history with config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **PR #2406** by @Michaelyklam (fixes #2398) — The fallback synchronous `POST /api/chat` route now passes the active WebUI config into the conversation-history sanitizer, so text-mode providers do not receive historical native `image_url` content parts when direct API callers use the legacy chat endpoint. This brings the sync route in line with the streaming chat path fixed for #2297.
+
 ## [v0.51.77] — 2026-05-16 — Release BA (stage-370 — 1-PR follow-up — live Activity grouping boundary fix)
 
 ### Fixed

--- a/api/routes.py
+++ b/api/routes.py
@@ -7902,7 +7902,7 @@ def _handle_chat_sync(handler, body):
             result = agent.run_conversation(
                 user_message=workspace_ctx + msg,
                 system_message=workspace_system_msg,
-                conversation_history=_sanitize_messages_for_api(_previous_context_messages),
+                conversation_history=_sanitize_messages_for_api(_previous_context_messages, cfg=get_config()),
                 task_id=s.session_id,
                 persist_user_message=msg,
             )

--- a/tests/test_native_image_attachments.py
+++ b/tests/test_native_image_attachments.py
@@ -354,6 +354,16 @@ class TestBuildNativeMultimodalMessage:
 
         assert sanitized == [{'role': 'user', 'content': content}]
 
+    def test_sync_chat_history_sanitizer_receives_config(self):
+        """#2398: fallback POST /api/chat must use the text-mode history sanitizer too."""
+        src = Path('api/routes.py').read_text()
+        call = 'conversation_history=_sanitize_messages_for_api(_previous_context_messages, cfg=get_config())'
+        assert call in src, (
+            'The legacy synchronous /api/chat endpoint must pass current config into '
+            '_sanitize_messages_for_api so historical image_url parts are stripped '
+            'for text-mode providers just like the streaming endpoint.'
+        )
+
     def test_fake_png_rejected_by_magic_bytes(self):
         """A file named .png that is not actually an image must be rejected."""
         with TemporaryDirectory() as d:


### PR DESCRIPTION
## Thinking Path
- #2398 identifies a leftover fallback path from the #2297 text-mode image-history fix.
- The streaming chat path already passes active config into `_sanitize_messages_for_api(...)` so historical native `image_url` parts are stripped for text-mode providers.
- The legacy synchronous `POST /api/chat` path still sanitized history without config, so direct API callers could replay the same rejected image parts.
- This PR keeps the fix narrow: pass the active WebUI config into that one fallback callsite and pin it with focused regression coverage.

## What Changed
- Updated `_handle_chat_sync()` to call `_sanitize_messages_for_api(_previous_context_messages, cfg=get_config())` before `agent.run_conversation(...)`.
- Added a regression assertion in `tests/test_native_image_attachments.py` so the sync route stays aligned with the text-mode sanitizer contract.
- Added an Unreleased changelog note for #2398.

## Why It Matters
Direct users of the legacy synchronous chat endpoint now get the same text-only provider protection as the main streaming chat path: old multimodal history will not be replayed as native `image_url` parts when `agent.image_input_mode` resolves to `text`.

Closes #2398

## Verification
- `env -u HERMES_CONFIG_PATH -u HERMES_WEBUI_HOST /home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_native_image_attachments.py -q` — 39 passed
- `/home/michael/.hermes/hermes-agent/venv/bin/python -m py_compile api/routes.py api/streaming.py`
- `git diff --check`

## Risks / Follow-ups
- Low risk: this only supplies config to an existing sanitizer callsite.
- The compression precondition/idempotency sanitizer calls remain display/session comparisons rather than provider-facing history construction, matching #2398's scoped report.

## Model Used
AI-assisted change with repository inspection, targeted editing, and shell-based test verification.
