### PR TITLE
docs: advance runtime adapter gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Documentation
+
+- Document the #1925 runtime-adapter gate update: Slice 1 run-journal replay has now passed a 100-trial synthetic replay/restart validation pass on current `origin/master`, #2313's selected-session chat SSE cap is shipped, and Slice 2 is ready for a reversible adapter-seam planning PR without moving execution ownership yet.
+
 ## [v0.51.78] — 2026-05-16 — Release BB (stage-371 — stuck-PR sweep salvage — RTL chat + ambient quota chip with composer-clutter gate)
 
 ### Added

--- a/docs/rfcs/hermes-run-adapter-contract.md
+++ b/docs/rfcs/hermes-run-adapter-contract.md
@@ -4,7 +4,7 @@
 - **Author:** @Michaelyklam
 - **Updated by:** @franksong2702
 - **Created:** 2026-05-11
-- **Revised:** 2026-05-14
+- **Revised:** 2026-05-16
 - **Tracking issue:** [#1925](https://github.com/nesquena/hermes-webui/issues/1925)
 
 ## Credit and Scope
@@ -48,6 +48,29 @@ truth. Consequences include:
 The immediate goal is not to build a sidecar. The immediate goal is to define the
 browser contract, classify current runtime state, and gate the first reversible
 journal slice.
+
+## Current Gate State — 2026-05-16
+
+Slice 1 is now past the first active validation gate:
+
+- #2283 shipped the run-journal replay layer in v0.51.71.
+- A 100-trial synthetic replay/restart validation pass against current
+  `origin/master` passed on 2026-05-16. The matrix covered completed-run replay,
+  interrupted stale-pending recovery, fresh-pending grace handling, StreamChannel
+  reconnect ordering, duplicate-prevention merge behavior, many-session recovery,
+  large-journal derivation, and stream-to-turn-id lifecycle linking.
+- The focused regression set
+  `tests/test_turn_journal.py tests/test_turn_journal_lifecycle.py tests/test_stale_stream_pending_recovery.py`
+  also passed on the same worktree.
+- #2393, shipped through v0.51.76, capped live chat token SSE transports to the
+  selected conversation pane. Background sessions now rely on existing
+  status/replay/reattach behavior instead of keeping one live `/api/chat/stream`
+  EventSource per active session.
+
+This evidence does not prove the future runner/sidecar path. It does mean the
+project should stop treating Slice 1 as purely passive observation and can move to
+Slice 2 planning: introduce the adapter seam over the still-legacy journaled path
+without moving execution ownership yet.
 
 ## Goals
 
@@ -268,6 +291,10 @@ Success criterion:
    kept executing.
 
 ### Slice 2: Adapter interface over the journaled legacy path
+
+Status as of 2026-05-16: ready for a planning/adapter-seam PR after the active
+Slice 1 validation pass and the #2313 selected-session stream cap. Slice 2 should
+still be a reversible boundary change, not a sidecar or execution-ownership move.
 
 Scope:
 


### PR DESCRIPTION
## Thinking Path
- #1925 previously held Slice 2 behind passive observation of the Slice 1 run-journal replay layer.
- We now have an active validation datapoint: 100 synthetic replay/restart trials passed against current `origin/master`, and the focused run-journal/stale-recovery regression set passed on the same worktree.
- #2313's first streaming-topology slice is also already shipped via #2393/#2400, so background sessions no longer need one live chat SSE transport each as the default observation model.
- This PR updates the RFC to make that gate state explicit and to mark Slice 2 as ready for a reversible adapter-seam planning PR, while still keeping runner/sidecar execution ownership changes deferred.

## What Changed
- Updated `docs/rfcs/hermes-run-adapter-contract.md` with a 2026-05-16 gate-state section.
- Recorded the #2283 Slice 1 replay baseline, the 100-trial validation pass, the focused regression command, and the #2393 selected-session stream cap as the current baseline.
- Clarified that Slice 2 is ready for planning/adapter-seam work only; it must not introduce sidecar/runtime ownership changes.
- Added an Unreleased changelog entry.

Refs #1925
Refs #2313

## Verification
- `git diff --check`
- `python3 - <<'PY'
from pathlib import Path
for p in ['docs/rfcs/hermes-run-adapter-contract.md','CHANGELOG.md']:
    assert Path(p).read_text(encoding='utf-8').strip()
print('docs present')
PY`

## Risks / Follow-ups
- Docs-only; no runtime behavior changes.
- The validation evidence supports moving to Slice 2 planning, not jumping directly to runner/sidecar execution ownership.
- The next implementation PR should introduce only a reversible adapter seam over the still-legacy journaled path.

## Model Used
AI-assisted change with repository inspection, targeted editing, and shell-based verification.
