### PR TITLE
fix: split live Activity groups at auto-compression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **PR #2408** by @Michaelyklam (fixes #2404) — Auto-compression cards now close the current live Activity burst before rendering, so post-compression tools start a fresh `Activity` row instead of joining the pre-compression tool group across a real timeline/context boundary.
+
 ## [v0.51.77] — 2026-05-16 — Release BA (stage-370 — 1-PR follow-up — live Activity grouping boundary fix)
 
 ### Fixed

--- a/static/ui.js
+++ b/static/ui.js
@@ -4718,6 +4718,13 @@ function ensureActivityGroup(inner, opts){
   if(live) _startActivityElapsedTimer(group);
   return group;
 }
+function closeCurrentLiveActivityGroup(){
+  const turn=$('liveAssistantTurn');
+  if(!turn) return;
+  turn.querySelectorAll('.tool-call-group[data-live-tool-call-group="1"][data-live-activity-current="1"]').forEach(group=>{
+    group.removeAttribute('data-live-activity-current');
+  });
+}
 function _compressionStateForCurrentSession(){
   const state=window._compressionUi;
   if(!state||!S.session||state.sessionId!==S.session.session_id) return null;
@@ -4845,6 +4852,7 @@ function appendLiveCompressionCard(state){
   }
   const inner=_assistantTurnBlocks(turn);
   if(!inner) return false;
+  closeCurrentLiveActivityGroup();
   const node=_compressionCardsNode(state);
   if(!node) return false;
   node.setAttribute('data-live-compression-card','1');

--- a/tests/test_ui_tool_call_cleanup.py
+++ b/tests/test_ui_tool_call_cleanup.py
@@ -327,6 +327,19 @@ class TestToolCallGroupingStatic:
             "Tool starts must not split consecutive tools into one-tool Activity rows."
         )
 
+    def test_live_compression_card_splits_current_tool_activity_burst(self):
+        compression_fn = _function_body(UI_JS, "appendLiveCompressionCard")
+        close_fn = _function_body(UI_JS, "closeCurrentLiveActivityGroup")
+        assert "closeCurrentLiveActivityGroup();" in compression_fn, (
+            "Auto-compression cards should close the current live Activity burst so later tools start a fresh group."
+        )
+        assert "data-live-activity-current" in close_fn, (
+            "The live compression boundary helper must clear the current Activity marker."
+        )
+        assert "removeAttribute('data-live-activity-current')" in close_fn, (
+            "Closing a live Activity burst should leave the row rendered but stop later tools from reusing it."
+        )
+
 
 class TestToolCardDesignTokens:
     def test_root_defines_shared_layout_design_tokens(self):


### PR DESCRIPTION
## Thinking Path
- #2404 reports a narrow live-timeline boundary bug introduced by the recent Activity grouping fixes.
- Consecutive tools should stay grouped, but auto-compression is a visible context/timeline boundary like an interim assistant progress note.
- The current live Activity group was still marked as current when the compression card rendered, so a later tool could attach to the pre-compression group.
- The safest fix is to leave the rendered group in place, clear only its current-marker, and let the next tool create a fresh Activity group.

## What Changed
- Added a `closeCurrentLiveActivityGroup()` helper in `static/ui.js` that clears `data-live-activity-current` from the current live Activity burst.
- `appendLiveCompressionCard()` now closes the current Activity burst before inserting/replacing the live compression card.
- Added source-level regression coverage ensuring compression cards split live Activity bursts while preserving the existing tool-start behavior.
- Added a release-note entry under `[Unreleased]`.

## Why It Matters
- Auto-compression changes the model context mid-turn and should be visible as a real timeline boundary.
- Post-compression tools now render under a separate `Activity` row instead of visually joining the pre-compression tool burst.
- The change stays narrow: ordinary consecutive tools still share one Activity group unless a real boundary event occurs.

## Verification
- `env -u HERMES_CONFIG_PATH -u HERMES_WEBUI_HOST /home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_ui_tool_call_cleanup.py -q` — 21 passed
- `node --check static/ui.js`
- `git diff --check`

## Risks / Follow-ups
- This is a source-level UI regression fix; no visual media is attached because the affected state is a transient mid-stream DOM boundary.
- If future compression events gain multiple simultaneous card types, they should use the same boundary helper before rendering.

Closes #2404

## Model Used
AI-assisted change with repository inspection, targeted editing, and shell-based test verification.
