### PR TITLE
Release BB / v0.51.78 — stage-371 (stuck-PR sweep salvage: RTL chat + ambient quota chip)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+## [v0.51.78] — 2026-05-16 — Release BB (stage-371 — stuck-PR sweep salvage — RTL chat + ambient quota chip with composer-clutter gate)
+
+### Added
+
+- **PR #2409** (maintainer follow-up from 2026-05-16 stuck-PR sweep, co-authored by @malulian and @ai-ag2026, closes #1721 and #2082) — Two stalled contributor PRs absorbed into one self-built release after Telegram UX approval across mobile/laptop/desktop/wide viewports.
+  - **Right-to-left chat layout (salvaged from #1721 by @malulian)** — New Settings → Preferences toggle, default off, flips the chat-area direction for Arabic and Hebrew users. Honors @aronprins' design review on PR #1721 (May 13 2026): drops the contributor's composer footer toggle button to keep composer real estate clean. Implementation includes a flash-prevention bootstrap `<script>` in `<head>` (applies `chat-content-rtl` class synchronously before any chat content paints), scoped CSS that only flips `.msg-row`, `.msg-body` tables, `.tool-call-group-summary`, and the composer `textarea#msg` — the sidebar, workspace panel, settings panel, and any other UI element stay left-to-right. Code blocks (`pre`, `code`, `kbd`, `samp`, `tt`, `.hljs`, `.code-block`) and tool-call group bodies force `direction:ltr; text-align:left; unicode-bidi:isolate` even under RTL, because Arabic and Hebrew developers still write English code, command lines, and JSON the same way English developers do (visually verified with embedded Python in an Arabic SSE conversation). Localized in 11 locales (en, it, ja, ru, es, de, zh-CN, zh-TW, pt, ko, fr).
+  - **Ambient provider quota chip (overridden from #2082 by @ai-ag2026)** — New green pill chip in the composer footer that surfaces the active provider's remaining quota (OpenRouter credit balance shaped as `$X.YZ`, or account-limit-shaped providers as `N%`), with click-through to Settings → Providers. Fetches `/api/provider/quota` on boot and on tab visibility return. Hidden below 1400px viewport via `@media (max-width:1400px) { display:none !important }` because the composer footer at 1280px laptop and 1440px standard desktop was already tight and the chip squeezed adjacent chips (model picker truncated from `Claude Sonnet 4 7` to `Claude Sonnet 4`, workspace dropdown lost text). Mobile users find quota through the dedicated mobile-config drawer; laptop users follow the chip's click-target into Settings → Providers anyway. The chip's value proposition (ambient quota visibility) is preserved on wide displays where there's genuine composer room without trading off existing chip readability.
+
+### Test infrastructure
+
+- New regression test `tests/test_pr1721_rtl_salvage.py` (8 cases) pins the RTL salvage invariants: Settings field + i18n keys present, no composer footer button (negative assertion encoding @aronprins' design objection), bootstrap script runs synchronously in `<head>` before paint, CSS scoped to chat only (negative tests against `.sidebar`, `.settings-panel`, `.workspace-panel`, `html`, `body` rules), code blocks force LTR under RTL, tool-call bodies force LTR under RTL, panels.js load/save round-trip, `rtl` in `api/config.py` DEFAULTS and writable-key allow-list, 11 locale strings present.
+
 ## [v0.51.77] — 2026-05-16 — Release BA (stage-370 — 1-PR follow-up — live Activity grouping boundary fix)
 
 ### Fixed

--- a/api/config.py
+++ b/api/config.py
@@ -4035,6 +4035,7 @@ _SETTINGS_DEFAULTS = {
         "HERMES_WEBUI_BOT_NAME", "Hermes"
     ),  # display name for the assistant
     "sound_enabled": False,  # play notification sound when assistant finishes
+    "rtl": False,  # right-to-left chat layout (chat messages + composer only)
     "notifications_enabled": False,  # browser notification when tab is in background
     "show_thinking": True,  # show/hide thinking/reasoning blocks in chat view
     "simplified_tool_calling": True,  # group tools/thinking into one quiet activity disclosure
@@ -4158,6 +4159,7 @@ _SETTINGS_BOOL_KEYS = {
     "check_for_updates",
     "whats_new_summary_enabled",
     "sound_enabled",
+    "rtl",
     "notifications_enabled",
     "show_thinking",
     "simplified_tool_calling",

--- a/static/boot.js
+++ b/static/boot.js
@@ -1527,6 +1527,7 @@ function applyBotName(){
   const _srch = document.getElementById('sessionSearch'); if (_srch) _srch.value = '';
   // Initialize reasoning chip on boot (fixes #1103 — chip hidden until session load)
   if(typeof fetchReasoningChip==='function') fetchReasoningChip();
+  if(typeof refreshProviderQuotaIndicator==='function') refreshProviderQuotaIndicator();
   const urlSession=(typeof _sessionIdFromLocation==='function')?_sessionIdFromLocation():null;
   const savedLocal=localStorage.getItem('hermes-webui-session');
   const saved=urlSession||savedLocal;

--- a/static/i18n.js
+++ b/static/i18n.js
@@ -736,6 +736,8 @@ const LOCALES = {
     import_session_json_tooltip: 'Import session from JSON',
     clear_conversation_btn_tooltip: 'Clear all messages in this conversation',
     // Settings detail
+    settings_label_rtl: 'Right-to-left chat layout',
+    settings_desc_rtl: 'Flips alignment of chat messages and the composer input for languages like Arabic or Hebrew. Affects only the chat area — sidebar and other panels stay left-to-right.',
     settings_label_sound: 'Notification sound',
     settings_desc_sound: 'Play a sound when the assistant finishes a response.',
     // TTS (#499)
@@ -1922,6 +1924,8 @@ const LOCALES = {
     import_session_json_tooltip: 'Importa sessione da JSON',
     clear_conversation_btn_tooltip: 'Cancella tutti i messaggi in questa conversazione',
     // Settings detail
+    settings_label_rtl: 'Layout chat da destra a sinistra',
+    settings_desc_rtl: "Inverte l'allineamento dei messaggi e dell'input del compositore per lingue come arabo o ebraico. Influisce solo sull'area chat — la barra laterale e gli altri pannelli rimangono da sinistra a destra.",
     settings_label_sound: 'Suono notifica',
     settings_desc_sound: 'Riproduci un suono quando l\'assistente termina una risposta.',
     // TTS (#499)
@@ -3113,6 +3117,8 @@ const LOCALES = {
     import_session_json_tooltip: 'JSONからセッションをインポート',
     clear_conversation_btn_tooltip: 'この会話のすべてのメッセージをクリア',
     // Settings detail
+    settings_label_rtl: 'チャットの右から左へのレイアウト',
+    settings_desc_rtl: 'アラビア語やヘブライ語のような言語向けに、チャットメッセージとコンポーザー入力の配置を反転します。チャット領域のみに影響し、サイドバーや他のパネルは左から右のままです。',
     settings_label_sound: '通知音',
     settings_desc_sound: 'アシスタントが応答を完了したときに音を鳴らします。',
     // TTS (#499)
@@ -4088,6 +4094,8 @@ const LOCALES = {
     export_session_json_tooltip: 'Экспортировать сессию как JSON',
     import_session_json_tooltip: 'Импортировать сессию из JSON',
     clear_conversation_btn_tooltip: 'Очистить все сообщения в этой беседе',
+    settings_label_rtl: 'Раскладка чата справа налево',
+    settings_desc_rtl: 'Переворачивает выравнивание сообщений чата и поля ввода для языков вроде арабского или иврита. Влияет только на область чата — боковая панель и другие панели остаются слева направо.',
     settings_label_sound: 'Звук уведомления',
     settings_desc_sound: 'Проигрывать звук, когда помощник завершает ответ.',
     settings_label_notifications: 'Уведомления браузера',
@@ -5214,6 +5222,8 @@ const LOCALES = {
     import_session_json_tooltip: 'Importar sesión desde JSON',
     clear_conversation_btn_tooltip: 'Borrar todos los mensajes de esta conversación',
     // Settings detail
+    settings_label_rtl: 'Diseño de chat de derecha a izquierda',
+    settings_desc_rtl: 'Invierte la alineación de los mensajes y la entrada del compositor para idiomas como árabe o hebreo. Afecta solo al área del chat — la barra lateral y otros paneles siguen de izquierda a derecha.',
     settings_label_sound: 'Sonido de notificación',
     settings_desc_sound: 'Reproduce un sonido cuando el asistente termina una respuesta.',
     settings_label_notifications: 'Notificaciones del navegador',
@@ -6312,6 +6322,8 @@ const LOCALES = {
     import_session_json_tooltip: 'Sitzung aus JSON importieren',
     clear_conversation_btn_tooltip: 'Alle Nachrichten in dieser Konversation löschen',
     // Settings detail
+    settings_label_rtl: 'Chat-Layout von rechts nach links',
+    settings_desc_rtl: 'Kehrt die Ausrichtung von Chat-Nachrichten und Eingabefeld für Sprachen wie Arabisch oder Hebräisch um. Betrifft nur den Chat-Bereich — Seitenleiste und andere Panels bleiben von links nach rechts.',
     settings_label_sound: 'Benachrichtigungston',
     settings_desc_sound: 'Spielt einen Ton ab, wenn der Assistent eine Antwort beendet.',
     settings_label_notifications: 'Browser-Benachrichtigungen',
@@ -7534,6 +7546,8 @@ const LOCALES = {
     password_env_var_locked: '当前已设置 HERMES_WEBUI_PASSWORD 环境变量并具有优先级。请取消该变量并重启服务器，才能在此管理密码。',
     password_env_var_locked_placeholder: '已锁定：已设置 HERMES_WEBUI_PASSWORD 环境变量',
     disable_auth: '停用认证',
+    settings_label_rtl: '从右到左聊天布局',
+    settings_desc_rtl: '为阿拉伯语或希伯来语等语言翻转聊天消息和编辑器输入的对齐方式。仅影响聊天区域 — 侧边栏和其他面板保持从左到右。',
     settings_label_sound: '通知声音',
     settings_label_notifications: '浏览器通知',
     settings_desc_sound: '助手完成回复时播放提示音。',
@@ -8591,6 +8605,8 @@ const LOCALES = {
     password_env_var_locked: '\u76ee\u524d\u5df2\u8a2d\u5b9a HERMES_WEBUI_PASSWORD \u74b0\u5883\u8b8a\u6578\u4e14\u512a\u5148\u751f\u6548\u3002\u8acb\u53d6\u6d88\u8a2d\u5b9a\u4e26\u91cd\u65b0\u555f\u52d5\u4f3a\u670d\u5668\uff0c\u624d\u80fd\u5728\u6b64\u7ba1\u7406\u5bc6\u78bc\u3002',
     password_env_var_locked_placeholder: '\u5df2\u9396\u5b9a\uff1a\u5df2\u8a2d\u5b9a HERMES_WEBUI_PASSWORD \u74b0\u5883\u8b8a\u6578',
     disable_auth: '\u505c\u7528\u9a57\u8b49',
+    settings_label_rtl: '從右到左聊天版面',
+    settings_desc_rtl: '為阿拉伯語或希伯來語等語言翻轉聊天訊息和編輯器輸入的對齊方式。僅影響聊天區域 — 側邊欄和其他面板保持從左到右。',
     settings_label_sound: '\u901a\u77e5\u8072\u97f3',
     settings_label_notifications: '\u700f\u89bd\u901a\u77e5',
     settings_desc_sound: '助手完成回答時播放聲音。',
@@ -9871,6 +9887,8 @@ const LOCALES = {
     import_session_json_tooltip: 'Importar sessão de JSON',
     clear_conversation_btn_tooltip: 'Limpar todas as mensagens nesta conversa',
     // Settings detail
+    settings_label_rtl: 'Layout de chat da direita para a esquerda',
+    settings_desc_rtl: 'Inverte o alinhamento das mensagens do chat e da entrada do compositor para idiomas como árabe ou hebraico. Afeta apenas a área do chat — a barra lateral e outros painéis permanecem da esquerda para a direita.',
     settings_label_sound: 'Som de notificação',
     settings_desc_sound: 'Tocar som quando assistente finalizar resposta.',
     settings_label_notifications: 'Notificações do navegador',
@@ -10959,6 +10977,8 @@ const LOCALES = {
     import_session_json_tooltip: 'JSON에서 세션 가져오기',
     clear_conversation_btn_tooltip: '이 대화의 모든 메시지 지우기',
     // Settings detail
+    settings_label_rtl: '오른쪽에서 왼쪽 채팅 레이아웃',
+    settings_desc_rtl: '아랍어나 히브리어 같은 언어를 위해 채팅 메시지와 작성 입력의 정렬을 뒤집습니다. 채팅 영역에만 영향을 주며, 사이드바와 다른 패널은 왼쪽에서 오른쪽으로 유지됩니다.',
     settings_label_sound: '알림음',
     settings_desc_sound: 'Assistant 응답이 끝나면 소리를 재생합니다.',
     settings_label_notifications: '브라우저 알림',
@@ -12061,6 +12081,8 @@ const LOCALES = {
     export_session_json_tooltip: 'Exporter la session complète en JSON',
     import_session_json_tooltip: 'Importer une session depuis JSON',
     clear_conversation_btn_tooltip: 'Effacer tous les messages de cette conversation',
+    settings_label_rtl: 'Mise en page du chat de droite à gauche',
+    settings_desc_rtl: "Inverse l'alignement des messages du chat et de la saisie du compositeur pour des langues comme l'arabe ou l'hébreu. N'affecte que la zone de chat — la barre latérale et les autres panneaux restent de gauche à droite.",
     settings_label_sound: 'Son de notification',
     settings_desc_sound: 'Jouez un son lorsque l\'assistant termine une réponse.',
     tts_listen: 'Écouter',

--- a/static/index.html
+++ b/static/index.html
@@ -62,6 +62,18 @@
       });
     }
   </script>
+  <script>
+    // Salvaged from PR #1721 (@malulian) — RTL bootstrap.
+    // Apply saved RTL state synchronously before any chat content paints, so
+    // RTL users don't see an LTR flash on initial load.
+    (function(){
+      try{
+        if(localStorage.getItem('hermes-rtl')==='true'){
+          document.documentElement.classList.add('chat-content-rtl');
+        }
+      }catch(_){}
+    })();
+  </script>
 </head>
 <body>
 <header class="app-titlebar" role="banner">
@@ -569,6 +581,10 @@
               </optgroup>
             </select>
             </div>
+            <button class="provider-quota-chip" id="providerQuotaChip" type="button" title="Provider quota" onclick="switchPanel('settings');switchSettingsSection('providers')" hidden>
+              <span class="provider-quota-chip-dot" aria-hidden="true"></span>
+              <span class="provider-quota-chip-label" id="providerQuotaChipLabel"></span>
+            </button>
             <div class="composer-reasoning-wrap" id="composerReasoningWrap" style="display:none">
               <button class="composer-reasoning-chip" id="composerReasoningChip" type="button" onclick="toggleReasoningDropdown()" title="Reasoning effort level">
                 <span class="composer-reasoning-icon" aria-hidden="true"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9.5 2A2.5 2.5 0 0 1 12 4.5v15a2.5 2.5 0 0 1-4.96-.46 2.5 2.5 0 0 1-2.96-3.08 3 3 0 0 1-.34-5.58 2.5 2.5 0 0 1 1.32-4.24 2.5 2.5 0 0 1 1.98-3A2.5 2.5 0 0 1 9.5 2Z"/><path d="M14.5 2A2.5 2.5 0 0 0 12 4.5v15a2.5 2.5 0 0 0 4.96-.46 2.5 2.5 0 0 0 2.96-3.08 3 3 0 0 0 .34-5.58 2.5 2.5 0 0 0-1.32-4.24 2.5 2.5 0 0 0-1.98-3A2.5 2.5 0 0 0 14.5 2Z"/></svg></span>
@@ -934,6 +950,13 @@
             <div class="settings-field">
               <label for="settingsLanguage" data-i18n="settings_label_language">Language</label>
               <select id="settingsLanguage" style="width:100%;padding:8px;background:var(--code-bg);color:var(--text);border:1px solid var(--border2);border-radius:6px"></select>
+            </div>
+            <div class="settings-field">
+              <label style="display:flex;align-items:center;gap:8px;cursor:pointer">
+                <input type="checkbox" id="settingsRtl" style="width:15px;height:15px;accent-color:var(--accent)">
+                <span data-i18n="settings_label_rtl">Right-to-left chat layout</span>
+              </label>
+              <div style="font-size:11px;color:var(--muted);margin-top:4px" data-i18n="settings_desc_rtl">Flips alignment of chat messages and the composer input for languages like Arabic or Hebrew. Affects only the chat area — sidebar and other panels stay left-to-right.</div>
             </div>
             <div class="settings-field">
               <label style="display:flex;align-items:center;gap:8px;cursor:pointer">

--- a/static/panels.js
+++ b/static/panels.js
@@ -5273,6 +5273,8 @@ function _preferencesPayloadFromUi(){
   if(whatsNewSummaryCb) payload.whats_new_summary_enabled=whatsNewSummaryCb.checked;
   const soundCb=$('settingsSoundEnabled');
   if(soundCb) payload.sound_enabled=soundCb.checked;
+  const rtlCb=$('settingsRtl');
+  if(rtlCb) payload.rtl=rtlCb.checked;
   const notifCb=$('settingsNotificationsEnabled');
   if(notifCb) payload.notifications_enabled=notifCb.checked;
   const sidebarDensitySel=$('settingsSidebarDensity');
@@ -5511,6 +5513,20 @@ async function loadSettingsPanel(){
     if(whatsNewSummaryCb){whatsNewSummaryCb.checked=!!settings.whats_new_summary_enabled;whatsNewSummaryCb.addEventListener('change',_schedulePreferencesAutosave,{once:false});}
     const soundCb=$('settingsSoundEnabled');
     if(soundCb){soundCb.checked=!!settings.sound_enabled;soundCb.addEventListener('change',_schedulePreferencesAutosave,{once:false});}
+    // Right-to-left chat layout (#1721 salvage) — Settings-only, no composer button.
+    const rtlCb=$('settingsRtl');
+    if(rtlCb){
+      const saved=!!settings.rtl || localStorage.getItem('hermes-rtl')==='true';
+      rtlCb.checked=saved;
+      try{localStorage.setItem('hermes-rtl',saved?'true':'false');}catch(_){}
+      document.documentElement.classList.toggle('chat-content-rtl',saved);
+      rtlCb.addEventListener('change',()=>{
+        const on=rtlCb.checked;
+        try{localStorage.setItem('hermes-rtl',on?'true':'false');}catch(_){}
+        document.documentElement.classList.toggle('chat-content-rtl',on);
+        _schedulePreferencesAutosave();
+      },{once:false});
+    }
     // TTS settings (localStorage-only, no server round-trip needed)
     const ttsEnabledCb=$('settingsTtsEnabled');
     if(ttsEnabledCb){ttsEnabledCb.checked=localStorage.getItem('hermes-tts-enabled')==='true';ttsEnabledCb.onchange=function(){localStorage.setItem('hermes-tts-enabled',this.checked?'true':'false');_applyTtsEnabled(this.checked);};}
@@ -6371,6 +6387,7 @@ async function saveSettings(andClose){
   body.check_for_updates=!!($('settingsCheckUpdates')||{}).checked;
   body.whats_new_summary_enabled=!!($('settingsWhatsNewSummary')||{}).checked;
   body.sound_enabled=!!($('settingsSoundEnabled')||{}).checked;
+  body.rtl=!!($('settingsRtl')||{}).checked;
   body.notifications_enabled=!!($('settingsNotificationsEnabled')||{}).checked;
   body.show_thinking=window._showThinking!==false;
   body.sidebar_density=sidebarDensity;

--- a/static/style.css
+++ b/static/style.css
@@ -1154,9 +1154,13 @@
      mobile-config drawer; laptop desktop users can find quota in
      Settings → Providers (the chip's onclick target). Show only on wide
      desktop where there's genuine room. Aron's standing position on
-     composer real estate (PR #1721, May 13 2026) reinforces this. */
-  @media (max-width:1400px){
-    .icon-btn.provider-quota-chip,
+     composer real estate (PR #1721, May 13 2026) reinforces this.
+
+     Using 1399.98px rather than 1400px to avoid the one-pixel boundary
+     overlap with the existing @media (min-width:1400px) `.messages-inner`
+     rule at line 893 — at exactly 1400px both would fire, so the chip
+     was hidden AT the wide-desktop boundary where it should first appear. */
+  @media (max-width:1399.98px){
     .provider-quota-chip{display:none!important;}
   }
   /* Increased specificity (.icon-btn.composer-mobile-config-btn) to win the cascade
@@ -4082,6 +4086,25 @@ main.main.showing-logs > #mainLogs{display:flex;}
 .chat-content-rtl .msg-body .code-block,
 .chat-content-rtl .msg-body .code-block *,
 .chat-content-rtl .msg-body pre *{
+  direction:ltr;
+  text-align:left;
+  unicode-bidi:isolate;
+}
+/* Force LTR for content classes that render English-by-design even in chat:
+   KaTeX equations (math is LTR-only in standard notation), diff hunks
+   (file paths + line numbers), CSV tables (column order must stay
+   left-to-right), and skill file paths. */
+.chat-content-rtl .msg-body .katex,
+.chat-content-rtl .msg-body .katex-block,
+.chat-content-rtl .msg-body .katex-display,
+.chat-content-rtl .msg-body .katex-html,
+.chat-content-rtl .msg-body .katex-inline,
+.chat-content-rtl .msg-body .diff-block,
+.chat-content-rtl .msg-body .diff-block *,
+.chat-content-rtl .msg-body .csv-table-wrap,
+.chat-content-rtl .msg-body .csv-table,
+.chat-content-rtl .msg-body .csv-table *,
+.chat-content-rtl .msg-body .skill-file-path{
   direction:ltr;
   text-align:left;
   unicode-bidi:isolate;

--- a/static/style.css
+++ b/static/style.css
@@ -1141,6 +1141,24 @@
   .composer-model-label{min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
   .composer-model-icon,.composer-model-chevron{display:inline-flex;align-items:center;justify-content:center;flex-shrink:0;line-height:1;}
   .composer-model-select{position:absolute!important;left:-9999px!important;width:1px!important;height:1px!important;opacity:0!important;pointer-events:none!important;}
+  .provider-quota-chip{display:inline-flex;align-items:center;gap:6px;height:34px;max-width:150px;padding:7px 10px;border:1px solid var(--border2);border-radius:999px;background:rgba(34,197,94,.10);color:var(--text);font-size:11px;font-weight:650;line-height:1;white-space:nowrap;cursor:pointer;transition:background .12s,border-color .12s,color .12s;}
+  .provider-quota-chip[hidden]{display:none!important;}
+  .provider-quota-chip:hover{background:rgba(34,197,94,.16);border-color:rgba(34,197,94,.35);}
+  .provider-quota-chip-dot{width:6px;height:6px;border-radius:999px;background:#22c55e;box-shadow:0 0 0 3px rgba(34,197,94,.12);flex:0 0 auto;}
+  .provider-quota-chip-label{min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+  /* Hide the ambient quota chip below 1400px — the composer footer already
+     has profile + workspace + model picker + reasoning + media + send and
+     was getting cramped (model picker truncating from "Claude Sonnet 4 7"
+     to "Claude Sonnet 4", workspace dropping more text) once the chip
+     squeezed in. Mobile users get provider info via the dedicated
+     mobile-config drawer; laptop desktop users can find quota in
+     Settings → Providers (the chip's onclick target). Show only on wide
+     desktop where there's genuine room. Aron's standing position on
+     composer real estate (PR #1721, May 13 2026) reinforces this. */
+  @media (max-width:1400px){
+    .icon-btn.provider-quota-chip,
+    .provider-quota-chip{display:none!important;}
+  }
   /* Increased specificity (.icon-btn.composer-mobile-config-btn) to win the cascade
      against the later-in-source `.icon-btn { display:flex }` rule that this element
      also matches. Without this, the button shows at desktop width — see #1381 review. */
@@ -4018,3 +4036,62 @@ main.main.showing-logs > #mainLogs{display:flex;}
 @media (prefers-reduced-motion: reduce){.stream-fade-word.is-new{animation:none;will-change:auto;}}
 [data-live-assistant="1"]:last-child .msg-body.stream-fade-active > :last-child::after,
 [data-live-assistant="1"]:last-child .msg-body.stream-fade-active:not(:has(> *))::after{display:none;content:none;}
+
+/* ── RTL chat layout (salvaged from PR #1721 by @malulian) ────────────────────
+ * Triggered by .chat-content-rtl on <html>. Affects ONLY the chat messages
+ * area and composer input, not the sidebar, workspace panel, settings panel,
+ * or any other UI element. Direction objection from design review (PR #1721
+ * comment by @aronprins, May 13 2026) honored: no composer button — the
+ * toggle lives in Settings → Preferences only.
+ *
+ * Code blocks, inline code, and pre-formatted blocks stay LTR even when RTL
+ * is active — Arabic/Hebrew users still write English code, command lines,
+ * URLs, and JSON the same way English users do. Flipping those would render
+ * code mirrored (e.g. `()fn()` instead of `fn()`) which is the salvage's
+ * critical bug fix vs the original PR #1721 implementation.
+ */
+.chat-content-rtl .msg-row{
+  direction:rtl;
+  text-align:right;
+  unicode-bidi:plaintext;
+}
+.chat-content-rtl .msg-body{
+  text-align:start;
+}
+.chat-content-rtl .msg-body th,
+.chat-content-rtl .csv-table th,
+.chat-content-rtl .csv-table td{
+  text-align:right;
+}
+.chat-content-rtl .tool-call-group-summary{
+  text-align:right;
+}
+.chat-content-rtl textarea#msg,
+.chat-content-rtl #msg{
+  direction:rtl;
+  text-align:right;
+  unicode-bidi:plaintext;
+}
+/* Force code/pre/tt back to LTR — Arabic users still write English code. */
+.chat-content-rtl .msg-body pre,
+.chat-content-rtl .msg-body code,
+.chat-content-rtl .msg-body kbd,
+.chat-content-rtl .msg-body samp,
+.chat-content-rtl .msg-body tt,
+.chat-content-rtl .msg-body .hljs,
+.chat-content-rtl .msg-body .code-block,
+.chat-content-rtl .msg-body .code-block *,
+.chat-content-rtl .msg-body pre *{
+  direction:ltr;
+  text-align:left;
+  unicode-bidi:isolate;
+}
+/* Tool-call content (commands, paths, JSON) stays LTR. */
+.chat-content-rtl .tool-call-group-body,
+.chat-content-rtl .tool-call-group-body *,
+.chat-content-rtl .tool-result,
+.chat-content-rtl .tool-result *{
+  direction:ltr;
+  text-align:left;
+  unicode-bidi:isolate;
+}

--- a/static/ui.js
+++ b/static/ui.js
@@ -634,6 +634,75 @@ if(document.readyState==='loading') document.addEventListener('DOMContentLoaded'
 else _initMediaPlaybackObserver();
 setTimeout(_initMediaPlaybackObserver,0);
 
+// ── Ambient provider quota indicator (#1766) ────────────────────────────────
+let _providerQuotaRefreshInFlight=false;
+
+function _formatQuotaMoneyShort(value){
+  const n=Number(value);
+  if(!Number.isFinite(n)) return '';
+  if(Math.abs(n)>=100) return '$'+n.toFixed(0);
+  if(Math.abs(n)>=10) return '$'+n.toFixed(1);
+  return '$'+n.toFixed(2);
+}
+function _formatQuotaPercentShort(value){
+  const n=Number(value);
+  if(!Number.isFinite(n)) return '';
+  return Math.max(0,Math.min(100,n)).toFixed(0)+'%';
+}
+function _providerQuotaIndicatorText(status){
+  if(!status||status.status!=='available') return null;
+  const provider=status.display_name||status.provider||'Provider';
+  const accountLimits=status.account_limits||null;
+  if(accountLimits&&Array.isArray(accountLimits.windows)&&accountLimits.windows.length){
+    const w=accountLimits.windows.find(x=>x&&Number.isFinite(Number(x.remaining_percent)))||accountLimits.windows[0];
+    const remaining=_formatQuotaPercentShort(w&&w.remaining_percent);
+    if(remaining) return {label:provider+' '+remaining, title:(status.message||'Provider usage loaded')+' — '+remaining+' remaining'};
+  }
+  const quota=status.quota||null;
+  if(quota){
+    const remaining=_formatQuotaMoneyShort(quota.limit_remaining);
+    const used=_formatQuotaMoneyShort(quota.usage);
+    const limit=_formatQuotaMoneyShort(quota.limit);
+    if(remaining){
+      const parts=[];
+      if(used) parts.push('used '+used);
+      if(limit) parts.push('limit '+limit);
+      return {label:provider+' '+remaining, title:(status.message||'Provider quota loaded')+(parts.length?' — '+parts.join(' · '):'')};
+    }
+  }
+  return null;
+}
+function renderProviderQuotaIndicator(status){
+  const chip=$('providerQuotaChip');
+  const label=$('providerQuotaChipLabel');
+  if(!chip||!label) return;
+  const text=_providerQuotaIndicatorText(status);
+  if(!text||status.status!=='available'||(!status.quota&&!status.account_limits)){
+    chip.hidden=true;
+    label.textContent='';
+    chip.removeAttribute('title');
+    return;
+  }
+  label.textContent=text.label;
+  chip.title=text.title;
+  chip.hidden=false;
+}
+async function refreshProviderQuotaIndicator(){
+  if(_providerQuotaRefreshInFlight) return;
+  _providerQuotaRefreshInFlight=true;
+  try{
+    const status=await api('/api/provider/quota');
+    renderProviderQuotaIndicator(status);
+  }catch(_e){
+    renderProviderQuotaIndicator(null);
+  }finally{
+    _providerQuotaRefreshInFlight=false;
+  }
+}
+window.addEventListener('visibilitychange',()=>{
+  if(document.visibilityState==='visible'&&typeof refreshProviderQuotaIndicator==='function') refreshProviderQuotaIndicator();
+});
+
 // Dynamic model labels -- populated by populateModelDropdown(), fallback to static map
 let _dynamicModelLabels={};
 window._configuredModelBadges=window._configuredModelBadges||{};

--- a/tests/test_issue1766_quota_topbar.py
+++ b/tests/test_issue1766_quota_topbar.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parents[1]
+INDEX = (REPO / "static" / "index.html").read_text(encoding="utf-8")
+UI_JS = (REPO / "static" / "ui.js").read_text(encoding="utf-8")
+BOOT_JS = (REPO / "static" / "boot.js").read_text(encoding="utf-8")
+CSS = (REPO / "static" / "style.css").read_text(encoding="utf-8")
+
+
+def test_quota_indicator_is_near_model_picker_in_composer_chrome():
+    model_idx = INDEX.find('id="composerModelChip"')
+    quota_idx = INDEX.find('id="providerQuotaChip"')
+
+    assert model_idx != -1, "composer model chip must exist"
+    assert quota_idx != -1, "provider quota chip must exist"
+    assert model_idx < quota_idx < INDEX.find('id="composerReasoningWrap"'), (
+        "quota chip should sit next to the model picker, before reasoning/toolset chrome"
+    )
+    assert 'class="provider-quota-chip"' in INDEX
+    assert 'hidden' in INDEX[quota_idx - 200 : quota_idx + 400]
+
+
+def test_quota_indicator_fetches_provider_quota_on_boot():
+    assert "function refreshProviderQuotaIndicator" in UI_JS
+    assert "api('/api/provider/quota')" in UI_JS
+    assert "refreshProviderQuotaIndicator" in BOOT_JS
+
+
+def test_quota_indicator_hides_unsupported_or_failed_statuses():
+    render_idx = UI_JS.find("function renderProviderQuotaIndicator")
+    assert render_idx != -1, "renderProviderQuotaIndicator helper must exist"
+    render_block = UI_JS[render_idx : UI_JS.find("function ", render_idx + 1)]
+
+    assert "providerQuotaChip" in render_block
+    assert "chip.hidden=true" in render_block
+    assert "status.status!=='available'" in render_block
+    assert "!status.quota" in render_block
+    assert "unsupported" not in render_block.lower(), "ambient chip should disappear instead of showing noisy unsupported text"
+
+
+def test_quota_indicator_formats_openrouter_and_account_limit_shapes():
+    assert "function _providerQuotaIndicatorText" in UI_JS
+    assert "limit_remaining" in UI_JS
+    assert "account_limits" in UI_JS
+    assert "remaining_percent" in UI_JS
+    assert "provider-quota-chip" in CSS

--- a/tests/test_pr1721_rtl_salvage.py
+++ b/tests/test_pr1721_rtl_salvage.py
@@ -1,0 +1,101 @@
+"""Regression tests for PR #1721 salvage — RTL chat layout (Settings-only, no composer button).
+
+Salvaged from @malulian's PR #1721 per @aronprins design review (May 13 2026):
+"Can you implement this as a global setting filed in Settings → Preferences?"
+Implementation drops the composer button and keeps only the Settings toggle + CSS.
+"""
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INDEX = REPO_ROOT / "static" / "index.html"
+STYLE = REPO_ROOT / "static" / "style.css"
+PANELS = REPO_ROOT / "static" / "panels.js"
+I18N = REPO_ROOT / "static" / "i18n.js"
+CONFIG = REPO_ROOT / "api" / "config.py"
+
+
+def test_rtl_settings_field_present_in_settings_panel():
+    html = INDEX.read_text(encoding="utf-8")
+    assert 'id="settingsRtl"' in html, "Settings checkbox for RTL not found"
+    assert 'data-i18n="settings_label_rtl"' in html
+    assert 'data-i18n="settings_desc_rtl"' in html
+
+
+def test_no_composer_rtl_button_anywhere():
+    """Honor @aronprins design review — no button in composer footer."""
+    html = INDEX.read_text(encoding="utf-8")
+    assert "btnRtlToggle" not in html, "Composer RTL button must not exist"
+    assert "rtl-toggle-btn" not in html
+    assert "rtl-toggle-label" not in html
+    css = STYLE.read_text(encoding="utf-8")
+    assert ".rtl-toggle-btn" not in css, "CSS for composer RTL button must not exist"
+
+
+def test_rtl_bootstrap_script_runs_synchronously_in_head():
+    """Saved RTL state must apply before any chat content paints — no LTR flash."""
+    html = INDEX.read_text(encoding="utf-8")
+    # The bootstrap should appear before </head>
+    head_close = html.index("</head>")
+    bootstrap_idx = html.index("localStorage.getItem('hermes-rtl')")
+    assert bootstrap_idx < head_close, "RTL bootstrap must run in <head> before paint"
+    assert "chat-content-rtl" in html
+
+
+def test_rtl_css_scoped_to_chat_only():
+    """RTL must not affect sidebar, settings panel, workspace panel — only chat area + composer."""
+    css = STYLE.read_text(encoding="utf-8")
+    assert ".chat-content-rtl .msg-row{" in css
+    assert ".chat-content-rtl textarea#msg" in css
+    # Negative: must NOT apply RTL to sidebar/panel surfaces
+    assert ".chat-content-rtl .sidebar" not in css
+    assert ".chat-content-rtl .settings-panel" not in css
+    assert ".chat-content-rtl .workspace-panel" not in css
+    assert ".chat-content-rtl body{" not in css
+    assert ".chat-content-rtl html{" not in css
+
+
+def test_rtl_code_blocks_stay_ltr():
+    """Critical: Arabic users still write English code. Code blocks must NOT flip."""
+    css = STYLE.read_text(encoding="utf-8")
+    # Must scope pre/code back to LTR
+    assert ".chat-content-rtl .msg-body pre" in css
+    assert ".chat-content-rtl .msg-body code" in css
+    # Must force direction:ltr inside code containers
+    code_block = css.split(".chat-content-rtl .msg-body pre")[1].split("}")[0]
+    # The chain ends in a single declaration block — find the closest declaration
+    # to confirm direction:ltr is present in the code-scoped rule
+    code_section_start = css.index(".chat-content-rtl .msg-body pre,")
+    code_section_end = css.index("}", code_section_start)
+    code_section = css[code_section_start:code_section_end]
+    assert "direction:ltr" in code_section
+    assert "text-align:left" in code_section
+    # Tool-call content also stays LTR (commands, paths, JSON)
+    tool_section_start = css.index(".chat-content-rtl .tool-call-group-body,")
+    tool_section_end = css.index("}", tool_section_start)
+    tool_section = css[tool_section_start:tool_section_end]
+    assert "direction:ltr" in tool_section
+
+
+def test_rtl_setting_round_trips_through_panels_js():
+    js = PANELS.read_text(encoding="utf-8")
+    # Load path: read from settings + localStorage, apply class
+    assert "const rtlCb=$('settingsRtl');" in js
+    assert "localStorage.setItem('hermes-rtl'" in js
+    assert "classList.toggle('chat-content-rtl'" in js
+    # Save path: payload + body both carry rtl
+    assert "payload.rtl=rtlCb.checked;" in js
+    assert "body.rtl=!!($('settingsRtl')||{}).checked;" in js
+
+
+def test_rtl_in_config_defaults_and_writable_keys():
+    src = CONFIG.read_text(encoding="utf-8")
+    assert '"rtl": False' in src, "rtl must be in DEFAULTS as opt-in"
+    # Must be in the writable preference key set
+    assert '"rtl",' in src
+
+
+def test_rtl_localized_in_all_locales():
+    js = I18N.read_text(encoding="utf-8")
+    # Count occurrences — should match the 11 locale blocks
+    assert js.count("settings_label_rtl:") == 11
+    assert js.count("settings_desc_rtl:") == 11

--- a/tests/test_pr1721_rtl_salvage.py
+++ b/tests/test_pr1721_rtl_salvage.py
@@ -61,9 +61,6 @@ def test_rtl_code_blocks_stay_ltr():
     assert ".chat-content-rtl .msg-body pre" in css
     assert ".chat-content-rtl .msg-body code" in css
     # Must force direction:ltr inside code containers
-    code_block = css.split(".chat-content-rtl .msg-body pre")[1].split("}")[0]
-    # The chain ends in a single declaration block — find the closest declaration
-    # to confirm direction:ltr is present in the code-scoped rule
     code_section_start = css.index(".chat-content-rtl .msg-body pre,")
     code_section_end = css.index("}", code_section_start)
     code_section = css[code_section_start:code_section_end]
@@ -74,6 +71,24 @@ def test_rtl_code_blocks_stay_ltr():
     tool_section_end = css.index("}", tool_section_start)
     tool_section = css[tool_section_start:tool_section_end]
     assert "direction:ltr" in tool_section
+
+
+def test_rtl_math_and_tables_stay_ltr():
+    """KaTeX math, diff blocks, CSV tables, and file paths stay LTR even under RTL.
+    Opus advisor catch on stage-371 (2026-05-16): math is LTR-only in standard
+    notation, CSV columns must read left-to-right regardless of locale."""
+    css = STYLE.read_text(encoding="utf-8")
+    katex_section_start = css.index(".chat-content-rtl .msg-body .katex,")
+    katex_section_end = css.index("}", katex_section_start)
+    katex_section = css[katex_section_start:katex_section_end]
+    # Must include all four key surfaces
+    assert ".katex-display" in katex_section
+    assert ".diff-block" in katex_section
+    assert ".csv-table" in katex_section
+    assert ".skill-file-path" in katex_section
+    # Must force direction:ltr
+    assert "direction:ltr" in katex_section
+    assert "text-align:left" in katex_section
 
 
 def test_rtl_setting_round_trips_through_panels_js():


### PR DESCRIPTION
## Release BB / v0.51.78 — stage-371 (stuck-PR sweep salvage)

**Review-bypass batch release**: constituent PR #2409 is already nesquena-approved. This release PR ships that approved subset plus the Opus pre-release SHOULD-FIX patch (KaTeX LTR scoping, 1px boundary fix, dead-selector removal).

### Constituent

- **PR #2409** (nesquena APPROVED 2026-05-16) — Stuck-PR sweep maintainer follow-up: salvages #1721 (RTL chat Settings-only after Aron design review) + overrides #2082 (ambient quota chip with composer-clutter @media gate). Co-authored by @malulian and @ai-ag2026.

### Stage-fix applied on top of the approved PR

Opus pre-release advisor caught three improvements which I applied directly to the stage branch:

1. **KaTeX + CSV + diff blocks force LTR under RTL** — first salvage missed math equations, file diffs, CSV tables, and skill file paths. Severity: KaTeX is the most user-visible gap (any LaTeX in a chat under RTL would flip).
2. **Quota chip `@media (max-width:1400px)` → `(max-width:1399.98px)`** to avoid the one-pixel boundary conflict with the existing `@media (min-width:1400px) .messages-inner` rule. Visually verified at 1400px: chip now correctly visible there.
3. **Dead `.icon-btn.provider-quota-chip` selector removed** (chip never has both classes).

Test `test_rtl_math_and_tables_stay_ltr` added to pin the new LTR surfaces. Removed dead-code branch in the existing code-block test.

### Pre-merge gates

- **pytest: 5784 passed, 6 skipped, 3 xpassed, 8 subtests passed** in 108s. 0 failed.
- **Pre-Opus gate**: JS + Python syntax clean, no merge markers, no CHANGELOG placeholders.
- **Opus advisor**: SHIP verdict, three SHOULD-FIX items applied.
- **Browser QA**: verified at 1280×720 (chip hidden, composer clean), 1400×900 (chip visible at boundary), 1920×1080 (chip visible, no truncation), Settings → Preferences (RTL toggle present and styled correctly), Arabic conversation (RTL flip works, code blocks stay LTR).
- **UX approved by @nesquena on Telegram** for the constituent PR #2409 before opening this release.

### What this closes

- Closes #1721 (RTL chat — Settings-only implementation as @aronprins requested)
- Closes #2082 (Ambient quota chip — composer-clutter gated to ≥1400px viewports)
- No other linked issues — the deferred follow-up #2398 will close via the next stage with PR #2406.

### Next stage queued

Stage-372 will batch #2406 + #2407 + #2408 once nesquena independent review lands on each. All three are simple, scoped fixes from @Michaelyklam and are eligible for a batch release immediately after review.
