### PR TITLE
fix: lock cost history snapshot updates across workers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **PR #2418** by @Michaelyklam (fixes #2402) — OpenRouter cost-history snapshot updates now take a provider-specific POSIX file lock around the read-modify-write cycle, preserving the existing process-local lock while preventing lost snapshot updates if WebUI is deployed with multiple worker processes sharing one Hermes home/state directory.
+
 ### Documentation
 
 - **PR #2416** by @Michaelyklam (refs #1925) — Expand the runtime-adapter RFC with the concrete Slice 2 adapter-seam contract: minimal `RuntimeAdapter` methods, payload fields, `legacy-direct` / `legacy-journal` feature-flag rollback path, legacy-backend mapping, explicit non-goals, and adapter-seam acceptance tests. Keeps the next step scoped to a reversible protocol-translator boundary over the journaled legacy path, not a runner/sidecar or execution-ownership move.

--- a/api/providers.py
+++ b/api/providers.py
@@ -19,10 +19,16 @@ import threading
 import time
 import urllib.error
 import urllib.request
+from contextlib import contextmanager, nullcontext
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
+
+try:  # POSIX-only; Windows-style environments fall back to process-local locking.
+    import fcntl
+except ImportError:  # pragma: no cover - exercised only where fcntl is unavailable
+    fcntl = None  # type: ignore[assignment]
 
 from api.config import (
     _PROVIDER_DISPLAY,
@@ -1457,6 +1463,22 @@ def _cost_snapshots_dir() -> Path:
     return _get_hermes_home() / _COST_SNAPSHOTS_DIR_NAME
 
 
+@contextmanager
+def _cost_snapshot_file_lock(provider: str):
+    """Serialize cost snapshot read-modify-write across worker processes."""
+    if fcntl is None:
+        with nullcontext():
+            yield
+        return
+
+    snap_dir = _cost_snapshots_dir()
+    snap_dir.mkdir(parents=True, exist_ok=True)
+    lock_path = snap_dir / f"{provider}.lock"
+    with lock_path.open("a", encoding="utf-8") as lock_file:
+        fcntl.flock(lock_file, fcntl.LOCK_EX)
+        yield
+
+
 def _fetch_openrouter_key_usage(api_key: str) -> dict[str, Any] | None:
     """Fetch current usage/limit from the OpenRouter ``/auth/key`` endpoint.
 
@@ -1560,27 +1582,30 @@ def _append_cost_snapshot(provider: str, usage: int | float | None, limit: int |
     """
     today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
     # Serialize the read-modify-write cycle.  The atomic os.replace in
-    # _write_cost_snapshots protects the file write itself, but without this
-    # lock two concurrent requests can both read the same old snapshot list and
-    # race to replace it with stale data.
+    # _write_cost_snapshots protects the file write itself, but without these
+    # locks two concurrent requests can both read the same old snapshot list and
+    # race to replace it with stale data.  The threading lock covers current
+    # single-process deployments; the file lock covers future multi-worker
+    # deployments that share one Hermes home/state directory.
     with _COST_SNAPSHOT_LOCK:
-        snapshots = _read_cost_snapshots(provider)
-        # Update or append today's entry
-        updated = False
-        for entry in snapshots:
-            if entry["date"] == today:
-                entry["used"] = usage
-                entry["limit"] = limit
-                updated = True
-                break
-        if not updated:
-            snapshots.append({"date": today, "used": usage, "limit": limit})
-        snapshots.sort(key=lambda e: e["date"])
-        # Cap to _COST_SNAPSHOT_MAX_DAYS entries (keep most recent)
-        if len(snapshots) > _COST_SNAPSHOT_MAX_DAYS:
-            snapshots = snapshots[-_COST_SNAPSHOT_MAX_DAYS:]
-        _write_cost_snapshots(provider, snapshots)
-        return snapshots
+        with _cost_snapshot_file_lock(provider):
+            snapshots = _read_cost_snapshots(provider)
+            # Update or append today's entry
+            updated = False
+            for entry in snapshots:
+                if entry["date"] == today:
+                    entry["used"] = usage
+                    entry["limit"] = limit
+                    updated = True
+                    break
+            if not updated:
+                snapshots.append({"date": today, "used": usage, "limit": limit})
+            snapshots.sort(key=lambda e: e["date"])
+            # Cap to _COST_SNAPSHOT_MAX_DAYS entries (keep most recent)
+            if len(snapshots) > _COST_SNAPSHOT_MAX_DAYS:
+                snapshots = snapshots[-_COST_SNAPSHOT_MAX_DAYS:]
+            _write_cost_snapshots(provider, snapshots)
+            return snapshots
 
 
 def _compute_deltas(snapshots: list[dict[str, Any]], window_days: int) -> list[dict[str, Any]]:

--- a/tests/test_provider_cost_history.py
+++ b/tests/test_provider_cost_history.py
@@ -260,6 +260,34 @@ def test_cost_snapshot_append_uses_lock(monkeypatch, tmp_path):
     assert snapshots == [{"date": "2030-04-15", "used": 4.0, "limit": 20.0}]
 
 
+def test_cost_snapshot_append_uses_file_lock(monkeypatch, tmp_path):
+    """Snapshot append takes a provider-specific file lock for multi-process workers."""
+    monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
+
+    import api.providers as providers
+
+    calls = []
+
+    class RecordingFcntl:
+        LOCK_EX = 2
+
+        @staticmethod
+        def flock(file_obj, operation):
+            calls.append((Path(file_obj.name).name, operation))
+
+    monkeypatch.setattr(providers, "fcntl", RecordingFcntl, raising=False)
+    monkeypatch.setattr(providers, "datetime", type("DT", (), {
+        "now": staticmethod(lambda tz=None: datetime(2030, 4, 15, 12, 0, 0, tzinfo=tz or timezone.utc)),
+        "strftime": datetime.strftime,
+    }))
+
+    snapshots = providers._append_cost_snapshot("openrouter", 4.0, 20.0)
+
+    assert calls == [("openrouter.lock", RecordingFcntl.LOCK_EX)]
+    assert (tmp_path / "cost-snapshots" / "openrouter.lock").exists()
+    assert snapshots == [{"date": "2030-04-15", "used": 4.0, "limit": 20.0}]
+
+
 # ── Missing credentials ───────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Thinking Path
- Hermes WebUI's OpenRouter cost history persists cumulative quota snapshots in a shared Hermes home/state directory.
- The existing `threading.Lock()` protects the read-modify-write cycle for the current single-process deployment.
- Issue #2402 calls out the multi-worker deployment gap: separate worker processes can still read the same old snapshot list and overwrite each other.
- The smallest safe fix is to keep the process-local lock and add a provider-specific POSIX file lock around the same critical section.

## What Changed
- Added `_cost_snapshot_file_lock(provider)` using `fcntl.flock(LOCK_EX)` on `cost-snapshots/<provider>.lock`.
- Wrapped `_append_cost_snapshot()`'s read-modify-write section in that file lock while preserving `_COST_SNAPSHOT_LOCK`.
- Kept a no-`fcntl` fallback for non-POSIX environments, where the existing process-local lock remains the available guard.
- Added regression coverage proving snapshot append takes the provider-specific file lock.
- Added an Unreleased changelog entry.

## Why It Matters
- Prevents lost OpenRouter cost-history snapshot updates when WebUI is run with multiple worker processes sharing one state directory.
- Keeps the current single-process behavior unchanged.
- Uses only Python stdlib and avoids a broader persistence rewrite.

## Verification
- `env -u HERMES_CONFIG_PATH -u HERMES_WEBUI_HOST /home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_provider_cost_history.py -q` → 14 passed
- `/home/michael/.hermes/hermes-agent/venv/bin/python -m py_compile api/providers.py`
- `git diff --check`

## Risks / Follow-ups
- The fallback path without `fcntl` cannot provide cross-process locking; it intentionally preserves the previous process-local protection rather than adding a non-stdlib dependency.
- This does not change the snapshot file schema or the OpenRouter fetch behavior.

## Model Used
AI-assisted change with repository inspection, targeted editing, and shell-based test verification.

Closes #2402
