### PR TITLE
fix: protect pipes in parentheses from table split + KaTeX dollar-sign misparse in tables

### DIFF
--- a/static/ui.js
+++ b/static/ui.js
@@ -2706,7 +2706,7 @@ function renderMd(raw){
     if(rows.length<2)return block;
     const isSep=r=>/^\|[\s|:-]+\|$/.test(r.trim());
     if(!isSep(rows[1]))return block;
-    const _protectPipes=r=>r.replace(/([([{<][^)\]}>]*)[|]([^)\]}>]*[)\]}>])/g,(_,a,b)=>a+'\x00PIPE\x00'+b);
+    const _protectPipes=r=>{let prev;do{prev=r;r=r.replace(/([([{<][^)\]}'>]*)[|]([^)\]}'>]*[)\]}>])/g,(_,a,b)=>a+'\x00PIPE\x00'+b);}while(r!==prev);return r;};
     const _restorePipes=s=>s.replace(/\x00PIPE\x00/g,'|');
     const parseRow=r=>{r=_protectPipes(r);return r.trim().replace(/^\|/,'').replace(/\|$/,'').split('|').map(c=>`<td>${inlineMd(_restorePipes(c.trim()))}</td>`).join('');};
     const parseHeader=r=>{r=_protectPipes(r);return r.trim().replace(/^\|/,'').replace(/\|$/,'').split('|').map(c=>`<th>${inlineMd(_restorePipes(c.trim()))}</th>`).join('');};

--- a/static/ui.js
+++ b/static/ui.js
@@ -2576,7 +2576,7 @@ function renderMd(raw){
   s=s.replace(/\\\[([\s\S]+?)\\\]/g,(_,m)=>{math_stash.push({type:'display',src:m});return '\x00M'+(math_stash.length-1)+'\x00';});
   // Inline math: $...$ — require non-space at boundaries to avoid false positives
   // e.g. "costs $5 and $10" should not trigger (space after opening $)
-  s=s.replace(/\$([^\s$\n][^$\n]*?[^\s$\n]|\S)\$/g,(_,m)=>{math_stash.push({type:'inline',src:m});return '\x00M'+(math_stash.length-1)+'\x00';});
+  s=s.replace(/\$([^\s$\n][^$\n]*?[^\s$\n]|\S)\$/g,(_,m)=>{if(m.includes(' | '))return '\$'+m+'\$';math_stash.push({type:'inline',src:m});return '\x00M'+(math_stash.length-1)+'\x00';});
   // Also stash \(...\) LaTeX delimiters.
   // Match a single literal backslash before the delimiter (the common LLM form).
   s=s.replace(/\\\((.+?)\\\)/g,(_,m)=>{math_stash.push({type:'inline',src:m});return '\x00M'+(math_stash.length-1)+'\x00';});
@@ -2706,8 +2706,10 @@ function renderMd(raw){
     if(rows.length<2)return block;
     const isSep=r=>/^\|[\s|:-]+\|$/.test(r.trim());
     if(!isSep(rows[1]))return block;
-    const parseRow=r=>r.trim().replace(/^\|/,'').replace(/\|$/,'').split('|').map(c=>`<td>${inlineMd(c.trim())}</td>`).join('');
-    const parseHeader=r=>r.trim().replace(/^\|/,'').replace(/\|$/,'').split('|').map(c=>`<th>${inlineMd(c.trim())}</th>`).join('');
+    const _protectPipes=r=>r.replace(/([([{<][^)\]}>]*)[|]([^)\]}>]*[)\]}>])/g,(_,a,b)=>a+'\x00PIPE\x00'+b);
+    const _restorePipes=s=>s.replace(/\x00PIPE\x00/g,'|');
+    const parseRow=r=>{r=_protectPipes(r);return r.trim().replace(/^\|/,'').replace(/\|$/,'').split('|').map(c=>`<td>${inlineMd(_restorePipes(c.trim()))}</td>`).join('');};
+    const parseHeader=r=>{r=_protectPipes(r);return r.trim().replace(/^\|/,'').replace(/\|$/,'').split('|').map(c=>`<th>${inlineMd(_restorePipes(c.trim()))}</th>`).join('');};
     const header=`<tr>${parseHeader(rows[0])}</tr>`;
     const body=rows.slice(2).map(r=>`<tr>${parseRow(r)}</tr>`).join('');
     // Surround with blank lines so the final paragraph splitter treats the


### PR DESCRIPTION
## Summary

Fixes table cell merging in `renderMd()` fallback path when cell content contains `|` inside parentheses/brackets, or when `$...$` spans across table column separators.

## Changes

### 1. Protect pipes inside brackets from `split('|')`
`parseRow` / `parseHeader` now use `_protectPipes()` to escape `|` characters that appear inside matching bracket pairs `()`, `[]`, `{}`, `<>` before splitting on column separators. Restored after split via `_restorePipes()`.

**Before:** `| (foo | bar) | baz |` would split into 4 cells instead of 3  
**After:** Correctly produces 3 cells with `(foo | bar)` intact

### 2. Prevent `$` math stashing when content contains table separators
Added guard in inline math regex: if matched `$...$` content includes ` | ` (pipe with surrounding spaces, i.e. a table column boundary), skip stashing and leave it as literal text so the table pass can split correctly.

**Before:** `$5,500/年 | 20,000/年$` could be stashed as a single math token, hiding the `|` from the table parser  
**After:** Such patterns are left for the table parser to handle

## Scope

- File: `static/ui.js`
- Affects: `renderMd()` table rendering (non-streaming / fallback path only)
- Does NOT affect the smd streaming parser (separate issue with `~` in table cells)