### PR TITLE
fix: show pending assistant state on chat submit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **PR #2431** by @Michaelyklam (fixes #2429) — Chat sends now render the assistant-side pending `Thinking…` placeholder immediately after the user turn is echoed, before `/api/chat/start` returns a stream id or the first SSE event arrives. The existing stale-stream guard remains in place for ordinary reasoning updates.
+
 ### Documentation
 
 - **PR #2416** by @Michaelyklam (refs #1925) — Expand the runtime-adapter RFC with the concrete Slice 2 adapter-seam contract: minimal `RuntimeAdapter` methods, payload fields, `legacy-direct` / `legacy-journal` feature-flag rollback path, legacy-backend mapping, explicit non-goals, and adapter-seam acceptance tests. Keeps the next step scoped to a reversible protocol-translator boundary over the journaled legacy path, not a runner/sidecar or execution-ownership move.

--- a/static/messages.js
+++ b/static/messages.js
@@ -273,7 +273,7 @@ async function send(){
   const userMsg={role:'user',content:displayText,attachments:uploaded.length?uploadedNames:undefined,_ts:Date.now()/1000};
   S.toolCalls=[];  // clear tool calls from previous turn
   clearLiveToolCards();  // clear any leftover live cards from last turn
-  S.messages.push(userMsg);renderMessages();appendThinking();setBusy(true);
+  S.messages.push(userMsg);renderMessages();appendThinking('',{pending:true});setBusy(true);
   // First optimistic pass: make the local user turn visible before /api/chat/start
   // can save pending state on the server.
   if(typeof upsertActiveSessionForLocalTurn==='function'){

--- a/static/ui.js
+++ b/static/ui.js
@@ -7018,11 +7018,12 @@ function finalizeThinkingCard(){
     _syncToolCallGroupSummary(group);
   }
 }
-function appendThinking(text=''){
+function appendThinking(text='', options){
   // Guard: ignore if session was switched during an async SSE stream.
   // The old stream's reasoning events can still fire after switch;
   // without this check they would pollute the new session's DOM.
-  if(!S.session||!S.activeStreamId) return;
+  const allowPendingPlaceholder=!!(options&&options.pending===true);
+  if(!S.session||(!S.activeStreamId&&!allowPendingPlaceholder)) return;
   $('emptyState').style.display='none';
   let turn=$('liveAssistantTurn');
   if(!turn){

--- a/tests/test_sidebar_first_turn_visibility.py
+++ b/tests/test_sidebar_first_turn_visibility.py
@@ -16,7 +16,7 @@ class TestSidebarFirstTurnVisibility:
             "send() must optimistically upsert the active session into the sidebar "
             "as soon as the local user message is pushed."
         )
-        push_idx = src.index("S.messages.push(userMsg);renderMessages();appendThinking();setBusy(true);")
+        push_idx = src.index("S.messages.push(userMsg);renderMessages();appendThinking('',{pending:true});setBusy(true);")
         helper_idx = src.index("upsertActiveSessionForLocalTurn", push_idx)
         start_idx = src.index("api('/api/chat/start'", push_idx)
         assert helper_idx < start_idx, (
@@ -28,6 +28,26 @@ class TestSidebarFirstTurnVisibility:
             "Do not re-fetch /api/sessions before /api/chat/start saves pending state; "
             "that race can overwrite the optimistic first-turn row with an empty list."
         )
+
+    def test_messages_send_renders_pending_assistant_placeholder_before_chat_start(self):
+        messages = read("static/messages.js")
+        ui = read("static/ui.js")
+        send_start = messages.index("async function send()")
+        push_idx = messages.index("appendThinking('',{pending:true})", send_start)
+        start_idx = messages.index("api('/api/chat/start'", send_start)
+        assert push_idx < start_idx, (
+            "send() should render an assistant-side pending placeholder before "
+            "/api/chat/start or the first SSE event returns."
+        )
+        append_start = ui.index("function appendThinking(text='', options)")
+        append_end = ui.index("function updateThinking", append_start)
+        append_body = ui[append_start:append_end]
+        assert "allowPendingPlaceholder" in append_body
+        assert "options.pending===true" in append_body.replace(" ", ""), (
+            "appendThinking() must allow the explicit pre-stream placeholder path "
+            "without weakening the stale-stream guard for ordinary SSE updates."
+        )
+        assert "(!S.activeStreamId&&!allowPendingPlaceholder)" in append_body.replace(" ", "")
 
     def test_sessions_js_has_local_turn_upsert_helper(self):
         src = read("static/sessions.js")


### PR DESCRIPTION
## Thinking Path
- Issue #2429 reports that the main transcript can look idle after submit while the backend is already starting the turn.
- The send path already tried to call `appendThinking()` before `/api/chat/start`, but `appendThinking()` rejected that call because no `S.activeStreamId` existed yet.
- The narrow fix is to allow only this explicit pre-stream placeholder path while keeping the existing stale-stream guard for ordinary SSE reasoning updates.

## What Changed
- Changed the chat send path to call `appendThinking('', { pending: true })` immediately after echoing the user message.
- Updated `appendThinking()` to permit that explicit pending placeholder before a stream id exists.
- Added source-level regression coverage that the pending assistant placeholder is rendered before `/api/chat/start` and that the guard remains strict unless the pending option is used.
- Added an Unreleased changelog entry.

## Why It Matters
- Users get immediate transcript feedback in the primary chat pane during slow first model calls.
- Sidebar/composer running indicators are now matched by an assistant-side pending state.
- The change avoids broad streaming rewrites and does not loosen stale event handling for normal stream updates.

## Verification
- `env -u HERMES_CONFIG_PATH -u HERMES_WEBUI_HOST /home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_sidebar_first_turn_visibility.py tests/test_ui_tool_call_cleanup.py tests/test_issue677.py -q` — 38 passed
- `env -u HERMES_CONFIG_PATH -u HERMES_WEBUI_HOST /home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_regressions.py tests/test_streaming_race_fix.py tests/test_run_journal_frontend_static.py -q` — 69 passed
- `node --check static/messages.js`
- `node --check static/ui.js`
- `git diff --check`

## Risks / Follow-ups
- This is source-verified rather than screenshot-attached; the visual delta is the existing `Thinking…` placeholder appearing earlier.
- If maintainers want a distinct pending copy or styling separate from Thinking, that should be a small follow-up UX decision.

## Model Used
AI-assisted change with repository inspection, targeted editing, and shell-based test verification.

Closes #2429
