### PR TITLE
Release BE: stage-374 (v0.51.81) — 6-PR batch — cost-history POSIX lock + prompt-cache tokens + Plugins panel i18n + pending placeholder + journal partial recovery + RuntimeAdapter Slice 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **PR #2418** by @Michaelyklam (fixes #2402) — OpenRouter cost-history snapshot updates now take a provider-specific POSIX file lock around the read-modify-write cycle, preserving the existing process-local lock while preventing lost snapshot updates if WebUI is deployed with multiple worker processes sharing one Hermes home/state directory.
+
 ### Documentation
 
 - **PR #2416** by @Michaelyklam (refs #1925) — Expand the runtime-adapter RFC with the concrete Slice 2 adapter-seam contract: minimal `RuntimeAdapter` methods, payload fields, `legacy-direct` / `legacy-journal` feature-flag rollback path, legacy-backend mapping, explicit non-goals, and adapter-seam acceptance tests. Keeps the next step scoped to a reversible protocol-translator boundary over the journaled legacy path, not a runner/sidecar or execution-ownership move.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [v0.51.81] — 2026-05-17 — Release BE (stage-374 — 6-PR batch — cost-history POSIX lock + prompt-cache tokens + Plugins panel i18n + pending-placeholder chat + journal-replay partial recovery + default-off RuntimeAdapter Slice 2 seam)
+
 ### Added
 
 - **PR #2424** by @Michaelyklam (refs #1925) — Add the default-off `RuntimeAdapter` Slice 2 seam. `HERMES_WEBUI_RUNTIME_ADAPTER=legacy-journal` now routes chat start through a `LegacyJournalRuntimeAdapter` facade over the existing legacy streaming path, while the default remains `legacy-direct`. The new adapter interface/payload classes expose start/observe/status/cancel/approval/clarify methods and delegate controls to existing handlers without introducing a runner, sidecar, new process-local queues, cached agents, cancellation registries, or callback registries.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,17 @@
 
 ## [Unreleased]
 
+### Added
+
+- **PR #2424** by @Michaelyklam (refs #1925) — Add the default-off `RuntimeAdapter` Slice 2 seam. `HERMES_WEBUI_RUNTIME_ADAPTER=legacy-journal` now routes chat start through a `LegacyJournalRuntimeAdapter` facade over the existing legacy streaming path, while the default remains `legacy-direct`. The new adapter interface/payload classes expose start/observe/status/cancel/approval/clarify methods and delegate controls to existing handlers without introducing a runner, sidecar, new process-local queues, cached agents, cancellation registries, or callback registries.
+- **PR #2421** by @Michaelyklam (fixes #2419) — Surface provider prompt-cache read/write tokens in WebUI usage displays. Cache-miss cost issues are now visible in the context tooltip and per-turn usage footer; counters carry through session persistence, SSE usage payloads, and live snapshots so deltas remain accurate across the active turn.
+- **PR #2425** by @mccxj — Wire Settings → Plugins panel into the existing i18n system. Panel title, description, empty state, and per-plugin labels (hooks, enabled/disabled, load failures) now respect the user's language preference; 10 new keys ship in English with `TODO: translate` placeholders in 9 additional locales.
+
 ### Fixed
 
 - **PR #2418** by @Michaelyklam (fixes #2402) — OpenRouter cost-history snapshot updates now take a provider-specific POSIX file lock around the read-modify-write cycle, preserving the existing process-local lock while preventing lost snapshot updates if WebUI is deployed with multiple worker processes sharing one Hermes home/state directory.
+- **PR #2431** by @Michaelyklam (fixes #2429) — Chat sends now render the assistant-side pending `Thinking…` placeholder immediately after the user turn is echoed, before `/api/chat/start` returns a stream id or the first SSE event arrives. The existing stale-stream guard remains in place for ordinary reasoning updates — only the explicit pre-stream placeholder path is allowed through.
+- **PR #2427** by @franksong2702 (fixes #2423) — Recover already-journaled visible assistant text and tool cards when a WebUI process restart interrupts an in-flight browser-originated turn. The stale-stream repair path now materializes run-journal output before the explicit interrupted marker instead of collapsing the turn to "no agent output was recovered."
 
 ### Documentation
 

--- a/api/models.py
+++ b/api/models.py
@@ -365,6 +365,7 @@ class Session:
                  tool_calls=None, pinned: bool=False, archived: bool=False,
                  project_id: str=None, profile=None,
                  input_tokens: int=0, output_tokens: int=0, estimated_cost=None,
+                 cache_read_tokens: int=0, cache_write_tokens: int=0,
                  personality=None,
                  active_stream_id: str=None,
                  pending_user_message: str=None,
@@ -403,6 +404,8 @@ class Session:
         self.input_tokens = input_tokens or 0
         self.output_tokens = output_tokens or 0
         self.estimated_cost = estimated_cost
+        self.cache_read_tokens = cache_read_tokens or 0
+        self.cache_write_tokens = cache_write_tokens or 0
         self.personality = personality
         self.active_stream_id = active_stream_id
         self.pending_user_message = pending_user_message
@@ -465,6 +468,7 @@ class Session:
             'session_id', 'title', 'workspace', 'model', 'model_provider', 'created_at', 'updated_at',
             'pinned', 'archived', 'project_id', 'profile',
             'input_tokens', 'output_tokens', 'estimated_cost',
+            'cache_read_tokens', 'cache_write_tokens',
             'personality', 'active_stream_id',
             'pending_user_message', 'pending_attachments', 'pending_started_at',
             'compression_anchor_visible_idx', 'compression_anchor_message_key',
@@ -628,6 +632,8 @@ class Session:
             'input_tokens': self.input_tokens,
             'output_tokens': self.output_tokens,
             'estimated_cost': self.estimated_cost,
+            'cache_read_tokens': self.cache_read_tokens,
+            'cache_write_tokens': self.cache_write_tokens,
             'personality': self.personality,
             'compression_anchor_visible_idx': self.compression_anchor_visible_idx,
             'compression_anchor_message_key': self.compression_anchor_message_key,

--- a/api/models.py
+++ b/api/models.py
@@ -685,18 +685,179 @@ def _get_profile_home(profile) -> Path:
         return Path(os.environ.get('HERMES_HOME') or '~/.hermes').expanduser()
 
 
-def _interrupted_recovery_marker() -> dict:
-    return {
-        'role': 'assistant',
-        'content': (
+def _interrupted_recovery_marker(*, recovered_output: bool = False) -> dict:
+    if recovered_output:
+        content = (
+            '**Response interrupted.**\n\n'
+            'The WebUI process restarted before this turn finished. '
+            'The partial output above was recovered from the run journal, '
+            'but the interrupted agent process could not continue.'
+        )
+    else:
+        content = (
             '**Response interrupted.**\n\n'
             'The WebUI process restarted before this turn finished. '
             'The user message above was preserved, but no agent output was recovered.'
-        ),
+        )
+    return {
+        'role': 'assistant',
+        'content': content,
         'timestamp': int(time.time()),
         '_error': True,
         'type': 'interrupted',
     }
+
+
+def _truncate_journal_tool_args(args, limit: int = 4) -> dict:
+    if not isinstance(args, dict):
+        return {}
+    out = {}
+    for key, value in list(args.items())[:limit]:
+        text = str(value)
+        out[str(key)] = text[:120] + ('...' if len(text) > 120 else '')
+    return out
+
+
+def _append_journaled_partial_output(session, stream_id: str | None) -> bool:
+    """Recover already-emitted visible output from a dead stream journal.
+
+    This repair path is intentionally conservative: it restores user-visible
+    assistant text and tool-card metadata that had already been emitted over
+    SSE before the WebUI process died. It does not restore hidden reasoning and
+    it does not try to continue execution.
+    """
+    if not stream_id:
+        return False
+
+    try:
+        from api.run_journal import read_run_events
+        journal = read_run_events(session.session_id, stream_id)
+    except Exception:
+        logger.debug(
+            "Session %s: failed to read run journal for stream %s",
+            getattr(session, 'session_id', '?'),
+            stream_id,
+            exc_info=True,
+        )
+        return False
+
+    events = [event for event in journal.get('events') or [] if isinstance(event, dict)]
+    if not events:
+        return False
+
+    appended_any = False
+    assistant_parts: list[str] = []
+    assistant_started_at: float | None = None
+    current_assistant_idx: int | None = None
+    recovered_tool_calls: list[dict] = []
+
+    def flush_assistant() -> int | None:
+        nonlocal appended_any, assistant_parts, assistant_started_at, current_assistant_idx
+        content = ''.join(assistant_parts).strip()
+        assistant_parts = []
+        if not content:
+            return current_assistant_idx
+        timestamp = int(assistant_started_at or time.time())
+        session.messages.append({
+            'role': 'assistant',
+            'content': content,
+            'timestamp': timestamp,
+            '_recovered_from_run_journal': True,
+            '_recovered_stream_id': stream_id,
+        })
+        current_assistant_idx = len(session.messages) - 1
+        assistant_started_at = None
+        appended_any = True
+        return current_assistant_idx
+
+    def ensure_assistant_anchor(created_at: float | None = None) -> int:
+        nonlocal appended_any, current_assistant_idx
+        idx = flush_assistant()
+        if idx is not None:
+            return idx
+        # A stream can start with tools before any text. Keep those tools
+        # visible after restart with an empty recovered assistant anchor instead
+        # of inventing synthetic progress prose.
+        session.messages.append({
+            'role': 'assistant',
+            'content': '',
+            'timestamp': int(created_at or time.time()),
+            '_recovered_from_run_journal': True,
+            '_recovered_stream_id': stream_id,
+        })
+        current_assistant_idx = len(session.messages) - 1
+        appended_any = True
+        return current_assistant_idx
+
+    for event in events:
+        event_name = str(event.get('event') or event.get('type') or '')
+        payload = event.get('payload') if isinstance(event.get('payload'), dict) else {}
+        created_at = event.get('created_at') if isinstance(event.get('created_at'), (int, float)) else None
+        if event_name == 'token':
+            text = str(payload.get('text') or '')
+            if not text:
+                continue
+            if not assistant_parts and assistant_started_at is None:
+                assistant_started_at = created_at or time.time()
+            assistant_parts.append(text)
+            continue
+        if event_name == 'interim_assistant':
+            if payload.get('already_streamed'):
+                flush_assistant()
+                continue
+            text = str(payload.get('text') or '').strip()
+            if not text:
+                continue
+            if not assistant_parts and assistant_started_at is None:
+                assistant_started_at = created_at or time.time()
+            if assistant_parts and not ''.join(assistant_parts).endswith(('\n', ' ')):
+                assistant_parts.append('\n\n')
+            assistant_parts.append(text)
+            flush_assistant()
+            continue
+        if event_name == 'tool':
+            anchor_idx = flush_assistant()
+            if anchor_idx is None:
+                anchor_idx = ensure_assistant_anchor(created_at)
+            name = str(payload.get('name') or 'tool')
+            preview = str(payload.get('preview') or '')
+            recovered_tool_calls.append({
+                'name': name,
+                'preview': preview,
+                'snippet': preview,
+                'tid': f"journal-{event.get('seq') or len(recovered_tool_calls) + 1}",
+                'assistant_msg_idx': anchor_idx,
+                'args': _truncate_journal_tool_args(payload.get('args') or {}),
+                'done': False,
+                '_recovered_from_run_journal': True,
+                '_recovered_stream_id': stream_id,
+            })
+            appended_any = True
+            current_assistant_idx = anchor_idx
+            continue
+        if event_name == 'tool_complete':
+            name = str(payload.get('name') or '')
+            for tool_call in reversed(recovered_tool_calls):
+                if tool_call.get('done'):
+                    continue
+                if not name or tool_call.get('name') == name:
+                    tool_call['done'] = True
+                    if payload.get('preview'):
+                        tool_call['preview'] = str(payload.get('preview') or '')
+                        tool_call['snippet'] = str(payload.get('preview') or '')
+                    if payload.get('duration') is not None:
+                        tool_call['duration'] = payload.get('duration')
+                    tool_call['is_error'] = bool(payload.get('is_error', False))
+                    break
+            continue
+        if event_name in {'done', 'stream_end', 'cancel', 'apperror', 'error'}:
+            flush_assistant()
+
+    flush_assistant()
+    if recovered_tool_calls:
+        session.tool_calls = list(session.tool_calls or []) + recovered_tool_calls
+        appended_any = True
+    return appended_any
 
 
 def _apply_core_sync_or_error_marker(
@@ -705,6 +866,7 @@ def _apply_core_sync_or_error_marker(
     stream_id_for_recheck=None,
     *,
     require_stream_dead=True,
+    touch_updated_at=True,
 ) -> bool:
     """Inner repair logic. Must be called with the per-session lock already held.
 
@@ -761,12 +923,16 @@ def _apply_core_sync_or_error_marker(
             if session.pending_attachments:
                 recovered['attachments'] = list(session.pending_attachments)
             _append_recovered_turn_to_context(session, recovered)
+        recovered_output = _append_journaled_partial_output(
+            session,
+            stream_id_for_recheck or session.active_stream_id,
+        )
         session.active_stream_id = None
         session.pending_user_message = None
         session.pending_attachments = []
         session.pending_started_at = None
-        session.messages.append(_interrupted_recovery_marker())
-        session.save()
+        session.messages.append(_interrupted_recovery_marker(recovered_output=recovered_output))
+        session.save(touch_updated_at=touch_updated_at)
         logger.info(
             "Session %s: recovered pending user turn (messages non-empty), added error marker",
             sid,
@@ -789,7 +955,7 @@ def _apply_core_sync_or_error_marker(
             session.pending_user_message = None
             session.pending_attachments = []
             session.pending_started_at = None
-            session.save()
+            session.save(touch_updated_at=touch_updated_at)
             logger.info(
                 "Session %s: synced %d messages from core transcript",
                 sid, len(core_messages),
@@ -805,12 +971,16 @@ def _apply_core_sync_or_error_marker(
         if isinstance(session.pending_started_at, (int, float)) and session.pending_started_at > 0:
             _recovered_ts = int(session.pending_started_at)
         _append_recovered_pending_turn(session, timestamp=_recovered_ts)
+    recovered_output = _append_journaled_partial_output(
+        session,
+        stream_id_for_recheck or session.active_stream_id,
+    )
     session.active_stream_id = None
     session.pending_user_message = None
     session.pending_attachments = []
     session.pending_started_at = None
-    session.messages.append(_interrupted_recovery_marker())
-    session.save()
+    session.messages.append(_interrupted_recovery_marker(recovered_output=recovered_output))
+    session.save(touch_updated_at=touch_updated_at)
     logger.info("Session %s: no core transcript found, added error marker", sid)
     return True
 

--- a/api/providers.py
+++ b/api/providers.py
@@ -19,10 +19,16 @@ import threading
 import time
 import urllib.error
 import urllib.request
+from contextlib import contextmanager, nullcontext
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
+
+try:  # POSIX-only; Windows-style environments fall back to process-local locking.
+    import fcntl
+except ImportError:  # pragma: no cover - exercised only where fcntl is unavailable
+    fcntl = None  # type: ignore[assignment]
 
 from api.config import (
     _PROVIDER_DISPLAY,
@@ -1457,6 +1463,22 @@ def _cost_snapshots_dir() -> Path:
     return _get_hermes_home() / _COST_SNAPSHOTS_DIR_NAME
 
 
+@contextmanager
+def _cost_snapshot_file_lock(provider: str):
+    """Serialize cost snapshot read-modify-write across worker processes."""
+    if fcntl is None:
+        with nullcontext():
+            yield
+        return
+
+    snap_dir = _cost_snapshots_dir()
+    snap_dir.mkdir(parents=True, exist_ok=True)
+    lock_path = snap_dir / f"{provider}.lock"
+    with lock_path.open("a", encoding="utf-8") as lock_file:
+        fcntl.flock(lock_file, fcntl.LOCK_EX)
+        yield
+
+
 def _fetch_openrouter_key_usage(api_key: str) -> dict[str, Any] | None:
     """Fetch current usage/limit from the OpenRouter ``/auth/key`` endpoint.
 
@@ -1560,27 +1582,30 @@ def _append_cost_snapshot(provider: str, usage: int | float | None, limit: int |
     """
     today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
     # Serialize the read-modify-write cycle.  The atomic os.replace in
-    # _write_cost_snapshots protects the file write itself, but without this
-    # lock two concurrent requests can both read the same old snapshot list and
-    # race to replace it with stale data.
+    # _write_cost_snapshots protects the file write itself, but without these
+    # locks two concurrent requests can both read the same old snapshot list and
+    # race to replace it with stale data.  The threading lock covers current
+    # single-process deployments; the file lock covers future multi-worker
+    # deployments that share one Hermes home/state directory.
     with _COST_SNAPSHOT_LOCK:
-        snapshots = _read_cost_snapshots(provider)
-        # Update or append today's entry
-        updated = False
-        for entry in snapshots:
-            if entry["date"] == today:
-                entry["used"] = usage
-                entry["limit"] = limit
-                updated = True
-                break
-        if not updated:
-            snapshots.append({"date": today, "used": usage, "limit": limit})
-        snapshots.sort(key=lambda e: e["date"])
-        # Cap to _COST_SNAPSHOT_MAX_DAYS entries (keep most recent)
-        if len(snapshots) > _COST_SNAPSHOT_MAX_DAYS:
-            snapshots = snapshots[-_COST_SNAPSHOT_MAX_DAYS:]
-        _write_cost_snapshots(provider, snapshots)
-        return snapshots
+        with _cost_snapshot_file_lock(provider):
+            snapshots = _read_cost_snapshots(provider)
+            # Update or append today's entry
+            updated = False
+            for entry in snapshots:
+                if entry["date"] == today:
+                    entry["used"] = usage
+                    entry["limit"] = limit
+                    updated = True
+                    break
+            if not updated:
+                snapshots.append({"date": today, "used": usage, "limit": limit})
+            snapshots.sort(key=lambda e: e["date"])
+            # Cap to _COST_SNAPSHOT_MAX_DAYS entries (keep most recent)
+            if len(snapshots) > _COST_SNAPSHOT_MAX_DAYS:
+                snapshots = snapshots[-_COST_SNAPSHOT_MAX_DAYS:]
+            _write_cost_snapshots(provider, snapshots)
+            return snapshots
 
 
 def _compute_deltas(snapshots: list[dict[str, Any]], window_days: int) -> list[dict[str, Any]]:

--- a/api/routes.py
+++ b/api/routes.py
@@ -1004,6 +1004,39 @@ def _clear_stale_stream_state(session) -> bool:
     with _get_session_agent_lock(session.session_id):
         if getattr(session, "active_stream_id", None) != stream_id:
             return False
+        if getattr(session, "pending_user_message", None):
+            try:
+                from api.models import _apply_core_sync_or_error_marker, _get_profile_home
+                profile_home = _get_profile_home(getattr(session, "profile", None))
+                core_path = profile_home / "sessions" / f"session_{session.session_id}.json"
+                repaired = _apply_core_sync_or_error_marker(
+                    session,
+                    core_path,
+                    stream_id_for_recheck=stream_id,
+                    touch_updated_at=False,
+                )
+            except Exception:
+                logger.exception(
+                    "_clear_stale_stream_state: failed to repair stale pending stream %s "
+                    "for session %s",
+                    stream_id, getattr(session, "session_id", "?"),
+                )
+                repaired = False
+            if repaired:
+                if original_stub is not session:
+                    try:
+                        original_stub.active_stream_id = None
+                        if hasattr(original_stub, "pending_user_message"):
+                            original_stub.pending_user_message = None
+                        if hasattr(original_stub, "pending_attachments"):
+                            original_stub.pending_attachments = []
+                        if hasattr(original_stub, "pending_started_at"):
+                            original_stub.pending_started_at = None
+                    except Exception:
+                        pass
+                return True
+            if getattr(session, "active_stream_id", None) != stream_id:
+                return False
         _materialize_pending_user_turn_before_error(session)
         session.active_stream_id = None
         if hasattr(session, "pending_user_message"):

--- a/api/routes.py
+++ b/api/routes.py
@@ -7764,16 +7764,56 @@ def _handle_chat_start(handler, body, diag=None):
             requested_model,
             requested_provider,
         )
-        response = _start_chat_stream_for_session(
-            s,
-            msg=msg,
-            attachments=attachments,
-            workspace=workspace,
-            model=model,
-            model_provider=model_provider,
-            normalized_model=normalized_model,
-            diag=diag,
+        from api.runtime_adapter import (
+            LegacyJournalRuntimeAdapter,
+            StartRunRequest,
+            runtime_adapter_enabled,
         )
+
+        if runtime_adapter_enabled():
+            def _legacy_start_run(request: StartRunRequest) -> dict:
+                return _start_chat_stream_for_session(
+                    s,
+                    msg=request.message,
+                    attachments=request.attachments,
+                    workspace=request.workspace or workspace,
+                    model=request.model or model,
+                    model_provider=request.provider or model_provider,
+                    normalized_model=normalized_model,
+                    diag=diag,
+                )
+
+            adapter = LegacyJournalRuntimeAdapter(start_run_delegate=_legacy_start_run)
+            result = adapter.start_run(
+                StartRunRequest(
+                    session_id=s.session_id,
+                    message=msg,
+                    attachments=attachments,
+                    workspace=workspace,
+                    profile=getattr(s, "profile", None),
+                    provider=model_provider,
+                    model=model,
+                    source="webui",
+                    metadata={"route": "/api/chat/start"},
+                )
+            )
+            response = dict(result.payload)
+            response.setdefault("stream_id", result.stream_id)
+            response.setdefault("session_id", result.session_id)
+            response.setdefault("run_id", result.run_id)
+            response.setdefault("status", result.status)
+            response.setdefault("active_controls", result.active_controls)
+        else:
+            response = _start_chat_stream_for_session(
+                s,
+                msg=msg,
+                attachments=attachments,
+                workspace=workspace,
+                model=model,
+                model_provider=model_provider,
+                normalized_model=normalized_model,
+                diag=diag,
+            )
         status = int(response.pop("_status", 200) or 200)
         diag.stage("response_write") if diag else None
         return j(handler, response, status=status)

--- a/api/runtime_adapter.py
+++ b/api/runtime_adapter.py
@@ -1,0 +1,223 @@
+"""RuntimeAdapter seam for WebUI-owned run execution.
+
+This is the #1925 Slice 2 seam only.  The default WebUI chat path remains the
+legacy direct route; enabling ``HERMES_WEBUI_RUNTIME_ADAPTER=legacy-journal``
+routes through this protocol-translator facade over the same legacy execution
+path plus the Slice 1 run journal.  This module intentionally does not own
+AIAgent instances, cancellation flags, approval callbacks, clarify callbacks, or
+new long-lived queues.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import os
+from pathlib import Path
+from typing import Any, Callable, Iterable, Protocol
+
+_RUNTIME_ADAPTER_ENV = "HERMES_WEBUI_RUNTIME_ADAPTER"
+_RUNTIME_ADAPTER_DIRECT = "legacy-direct"
+_RUNTIME_ADAPTER_JOURNAL = "legacy-journal"
+_VALID_RUNTIME_ADAPTER_MODES = {_RUNTIME_ADAPTER_DIRECT, _RUNTIME_ADAPTER_JOURNAL}
+
+
+@dataclass(frozen=True)
+class StartRunRequest:
+    session_id: str
+    message: str
+    attachments: list[dict[str, Any]] = field(default_factory=list)
+    workspace: str | None = None
+    profile: str | None = None
+    provider: str | None = None
+    model: str | None = None
+    toolsets: list[str] = field(default_factory=list)
+    source: str = "webui"
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class RunStartResult:
+    run_id: str
+    session_id: str
+    stream_id: str
+    status: str = "started"
+    started_at: float | None = None
+    cursor: str | None = None
+    active_controls: list[str] = field(default_factory=list)
+    payload: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class RunEventStream:
+    run_id: str
+    events: list[dict[str, Any]] = field(default_factory=list)
+    cursor: str | None = None
+    last_event_id: str | None = None
+
+
+@dataclass(frozen=True)
+class RunStatus:
+    run_id: str
+    session_id: str | None = None
+    status: str = "unknown"
+    last_event_id: str | None = None
+    terminal_state: str | None = None
+    active_controls: list[str] = field(default_factory=list)
+    pending_approval_id: str | None = None
+    pending_clarify_id: str | None = None
+
+
+@dataclass(frozen=True)
+class ControlResult:
+    accepted: bool
+    status: str = "accepted"
+    event_id: str | None = None
+    safe_message: str | None = None
+
+
+class RuntimeAdapter(Protocol):
+    def start_run(self, request: StartRunRequest) -> RunStartResult: ...
+    def observe_run(self, run_id: str, *, cursor: str | None = None) -> RunEventStream: ...
+    def get_run(self, run_id: str) -> RunStatus: ...
+    def cancel_run(self, run_id: str) -> ControlResult: ...
+    def respond_approval(self, run_id: str, approval_id: str, choice: str) -> ControlResult: ...
+    def respond_clarify(self, run_id: str, clarify_id: str, response: str) -> ControlResult: ...
+
+
+def runtime_adapter_mode(environ: dict[str, str] | None = None) -> str:
+    """Return the configured adapter mode, defaulting safely to legacy-direct."""
+    source = os.environ if environ is None else environ
+    raw = str(source.get(_RUNTIME_ADAPTER_ENV, _RUNTIME_ADAPTER_DIRECT) or "").strip().lower()
+    return raw if raw in _VALID_RUNTIME_ADAPTER_MODES else _RUNTIME_ADAPTER_DIRECT
+
+
+def runtime_adapter_enabled(environ: dict[str, str] | None = None) -> bool:
+    return runtime_adapter_mode(environ) == _RUNTIME_ADAPTER_JOURNAL
+
+
+def _cursor_to_after_seq(cursor: str | None) -> int | None:
+    if cursor in (None, ""):
+        return None
+    try:
+        text = str(cursor)
+        if ":" in text:
+            text = text.rsplit(":", 1)[-1]
+        return max(0, int(text))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _active_control_result(value: Any) -> ControlResult:
+    accepted = bool(value)
+    return ControlResult(
+        accepted=accepted,
+        status="accepted" if accepted else "not-active",
+        safe_message=None if accepted else "Legacy control did not accept the request.",
+    )
+
+
+class LegacyJournalRuntimeAdapter:
+    """Protocol-translator facade over the current legacy streaming path.
+
+    Delegates keep Slice 2 honest: this adapter has no worker thread, AIAgent
+    cache, cancellation registry, approval queue, or clarify queue of its own.
+    """
+
+    def __init__(
+        self,
+        *,
+        start_run_delegate: Callable[[StartRunRequest], dict[str, Any]] | None = None,
+        cancel_delegate: Callable[[str], Any] | None = None,
+        approval_delegate: Callable[[str, str, str], Any] | None = None,
+        clarify_delegate: Callable[[str, str, str], Any] | None = None,
+        live_stream_lookup: Callable[[str], bool] | None = None,
+        session_dir: Path | None = None,
+    ):
+        self._start_run_delegate = start_run_delegate
+        self._cancel_delegate = cancel_delegate
+        self._approval_delegate = approval_delegate
+        self._clarify_delegate = clarify_delegate
+        self._live_stream_lookup = live_stream_lookup or (lambda _run_id: False)
+        self._session_dir = Path(session_dir) if session_dir is not None else None
+
+    def start_run(self, request: StartRunRequest) -> RunStartResult:
+        if self._start_run_delegate is None:
+            raise NotImplementedError("LegacyJournalRuntimeAdapter.start_run requires a legacy delegate")
+        payload = dict(self._start_run_delegate(request) or {})
+        stream_id = str(payload.get("stream_id") or payload.get("run_id") or "")
+        run_id = str(payload.get("run_id") or stream_id)
+        session_id = str(payload.get("session_id") or request.session_id)
+        active_controls = payload.get("active_controls")
+        if not isinstance(active_controls, list):
+            active_controls = ["cancel"] if stream_id else []
+        return RunStartResult(
+            run_id=run_id,
+            session_id=session_id,
+            stream_id=stream_id,
+            status=str(payload.get("status") or "started"),
+            started_at=payload.get("started_at"),
+            cursor=payload.get("cursor"),
+            active_controls=active_controls,
+            payload=payload,
+        )
+
+    def observe_run(self, run_id: str, *, cursor: str | None = None) -> RunEventStream:
+        from api.run_journal import find_run_summary, read_run_events
+
+        summary = find_run_summary(run_id, session_dir=self._session_dir)
+        if not summary:
+            return RunEventStream(run_id=run_id, events=[], cursor=cursor, last_event_id=None)
+        journal = read_run_events(
+            str(summary.get("session_id") or ""),
+            run_id,
+            after_seq=_cursor_to_after_seq(cursor),
+            session_dir=self._session_dir,
+        )
+        events = list(journal.get("events") or [])
+        last_event_id = events[-1].get("event_id") if events else summary.get("last_event_id")
+        return RunEventStream(
+            run_id=run_id,
+            events=events,
+            cursor=str(events[-1].get("seq")) if events else cursor,
+            last_event_id=last_event_id,
+        )
+
+    def get_run(self, run_id: str) -> RunStatus:
+        from api.run_journal import find_run_summary
+
+        live = bool(self._live_stream_lookup(run_id))
+        summary = find_run_summary(run_id, session_dir=self._session_dir)
+        if live:
+            return RunStatus(
+                run_id=run_id,
+                session_id=str((summary or {}).get("session_id") or "") or None,
+                status="running",
+                last_event_id=(summary or {}).get("last_event_id"),
+                terminal_state=None,
+                active_controls=["cancel"],
+            )
+        if summary:
+            terminal_state = summary.get("terminal_state")
+            return RunStatus(
+                run_id=run_id,
+                session_id=str(summary.get("session_id") or "") or None,
+                status=str(terminal_state or "unknown"),
+                last_event_id=summary.get("last_event_id"),
+                terminal_state=terminal_state,
+                active_controls=[],
+            )
+        return RunStatus(run_id=run_id)
+
+    def cancel_run(self, run_id: str) -> ControlResult:
+        if self._cancel_delegate is None:
+            return ControlResult(False, status="unsupported", safe_message="Cancel is not wired for this adapter.")
+        return _active_control_result(self._cancel_delegate(run_id))
+
+    def respond_approval(self, run_id: str, approval_id: str, choice: str) -> ControlResult:
+        if self._approval_delegate is None:
+            return ControlResult(False, status="unsupported", safe_message="Approval is delegated to the legacy path.")
+        return _active_control_result(self._approval_delegate(run_id, approval_id, choice))
+
+    def respond_clarify(self, run_id: str, clarify_id: str, response: str) -> ControlResult:
+        if self._clarify_delegate is None:
+            return ControlResult(False, status="unsupported", safe_message="Clarify is delegated to the legacy path.")
+        return _active_control_result(self._clarify_delegate(run_id, clarify_id, response))

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -2827,6 +2827,8 @@ def _run_agent_streaming(
             'input_tokens': 0,
             'output_tokens': 0,
             'estimated_cost': 0,
+            'cache_read_tokens': 0,
+            'cache_write_tokens': 0,
             'context_length': 0,
             'threshold_tokens': 0,
             'last_prompt_tokens': 0,
@@ -2842,6 +2844,8 @@ def _run_agent_streaming(
                 _usage['input_tokens'] = getattr(_agent, 'session_prompt_tokens', 0) or 0
                 _usage['output_tokens'] = getattr(_agent, 'session_completion_tokens', 0) or 0
                 _usage['estimated_cost'] = getattr(_agent, 'session_estimated_cost_usd', 0) or 0
+                _usage['cache_read_tokens'] = getattr(_agent, 'session_cache_read_tokens', 0) or 0
+                _usage['cache_write_tokens'] = getattr(_agent, 'session_cache_write_tokens', 0) or 0
             except Exception:
                 pass
             try:
@@ -2854,7 +2858,7 @@ def _run_agent_streaming(
                 pass
 
         if _session_obj is not None:
-            for _field in ('input_tokens', 'output_tokens', 'estimated_cost', 'context_length', 'threshold_tokens', 'last_prompt_tokens'):
+            for _field in ('input_tokens', 'output_tokens', 'estimated_cost', 'cache_read_tokens', 'cache_write_tokens', 'context_length', 'threshold_tokens', 'last_prompt_tokens'):
                 if not _usage.get(_field):
                     try:
                         _usage[_field] = getattr(_session_obj, _field, 0) or 0
@@ -4260,12 +4264,18 @@ def _run_agent_streaming(
                 input_tokens = getattr(agent, 'session_prompt_tokens', 0) or 0
                 output_tokens = getattr(agent, 'session_completion_tokens', 0) or 0
                 estimated_cost = getattr(agent, 'session_estimated_cost_usd', None)
+                cache_read_tokens = getattr(agent, 'session_cache_read_tokens', 0) or 0
+                cache_write_tokens = getattr(agent, 'session_cache_write_tokens', 0) or 0
                 if input_tokens > 0:
                     s.input_tokens = input_tokens
                 if output_tokens > 0:
                     s.output_tokens = output_tokens
                 if estimated_cost is not None:
                     s.estimated_cost = estimated_cost
+                if cache_read_tokens > 0:
+                    s.cache_read_tokens = cache_read_tokens
+                if cache_write_tokens > 0:
+                    s.cache_write_tokens = cache_write_tokens
                 # Persist tool-call summaries even when the final message history only
                 # kept bare tool rows and omitted explicit assistant tool_call IDs.
                 tool_calls = _extract_tool_calls_from_messages(
@@ -4493,6 +4503,8 @@ def _run_agent_streaming(
                 'input_tokens': input_tokens,
                 'output_tokens': output_tokens,
                 'estimated_cost': estimated_cost,
+                'cache_read_tokens': cache_read_tokens,
+                'cache_write_tokens': cache_write_tokens,
                 'duration_seconds': round(_turn_duration_seconds, 3),
             }
             if _turn_tps is not None:

--- a/static/i18n.js
+++ b/static/i18n.js
@@ -509,6 +509,16 @@ const LOCALES = {
     settings_tab_appearance: 'Appearance',
     settings_tab_preferences: 'Preferences',
     settings_tab_plugins: 'Plugins',
+    settings_plugins_title: 'Plugins',
+    settings_plugins_meta: 'View installed Hermes plugins and the lifecycle hooks they register. This panel is read-only.',
+    settings_plugins_empty: 'No Hermes plugins are currently visible. Install or enable plugins from the Hermes CLI/config to see them here.',
+    plugins_unnamed: 'Unnamed plugin',
+    plugins_no_description: 'No description provided.',
+    plugins_no_hooks: 'No registered lifecycle hooks',
+    plugins_registered_hooks: 'Registered hooks',
+    plugins_enabled: 'Enabled',
+    plugins_disabled: 'Disabled',
+    plugins_load_failed: 'Failed to load plugins: ',
     settings_tab_system: 'System',
     settings_title: 'Settings',
     settings_save_btn: 'Save Settings',
@@ -1707,6 +1717,16 @@ const LOCALES = {
     settings_tab_appearance: 'Aspetto',
     settings_tab_preferences: 'Preferenze',
     settings_tab_plugins: 'Plugin',
+    settings_plugins_title: 'Plugins',  // TODO: translate
+    settings_plugins_meta: 'View installed Hermes plugins and the lifecycle hooks they register. This panel is read-only.',  // TODO: translate
+    settings_plugins_empty: 'No Hermes plugins are currently visible. Install or enable plugins from the Hermes CLI/config to see them here.',  // TODO: translate
+    plugins_unnamed: 'Unnamed plugin',  // TODO: translate
+    plugins_no_description: 'No description provided.',  // TODO: translate
+    plugins_no_hooks: 'No registered lifecycle hooks',  // TODO: translate
+    plugins_registered_hooks: 'Registered hooks',  // TODO: translate
+    plugins_enabled: 'Enabled',  // TODO: translate
+    plugins_disabled: 'Disabled',  // TODO: translate
+    plugins_load_failed: 'Failed to load plugins: ',  // TODO: translate
     settings_tab_system: 'Sistema',
     settings_title: 'Impostazioni',
     settings_save_btn: 'Salva Impostazioni',
@@ -2897,6 +2917,16 @@ const LOCALES = {
     settings_tab_appearance: '外観',
     settings_tab_preferences: '環境設定',
     settings_tab_plugins: 'プラグイン',
+    settings_plugins_title: 'Plugins',  // TODO: translate
+    settings_plugins_meta: 'View installed Hermes plugins and the lifecycle hooks they register. This panel is read-only.',  // TODO: translate
+    settings_plugins_empty: 'No Hermes plugins are currently visible. Install or enable plugins from the Hermes CLI/config to see them here.',  // TODO: translate
+    plugins_unnamed: 'Unnamed plugin',  // TODO: translate
+    plugins_no_description: 'No description provided.',  // TODO: translate
+    plugins_no_hooks: 'No registered lifecycle hooks',  // TODO: translate
+    plugins_registered_hooks: 'Registered hooks',  // TODO: translate
+    plugins_enabled: 'Enabled',  // TODO: translate
+    plugins_disabled: 'Disabled',  // TODO: translate
+    plugins_load_failed: 'Failed to load plugins: ',  // TODO: translate
     settings_tab_system: 'システム',
     settings_title: '設定',
     settings_save_btn: '設定を保存',
@@ -4600,6 +4630,16 @@ const LOCALES = {
     settings_tab_conversation: 'Conversation',
     settings_tab_preferences: 'Preferences',
     settings_tab_plugins: 'Плагины',
+    settings_plugins_title: 'Plugins',  // TODO: translate
+    settings_plugins_meta: 'View installed Hermes plugins and the lifecycle hooks they register. This panel is read-only.',  // TODO: translate
+    settings_plugins_empty: 'No Hermes plugins are currently visible. Install or enable plugins from the Hermes CLI/config to see them here.',  // TODO: translate
+    plugins_unnamed: 'Unnamed plugin',  // TODO: translate
+    plugins_no_description: 'No description provided.',  // TODO: translate
+    plugins_no_hooks: 'No registered lifecycle hooks',  // TODO: translate
+    plugins_registered_hooks: 'Registered hooks',  // TODO: translate
+    plugins_enabled: 'Enabled',  // TODO: translate
+    plugins_disabled: 'Disabled',  // TODO: translate
+    plugins_load_failed: 'Failed to load plugins: ',  // TODO: translate
     settings_tab_system: 'System',
     status_updated: 'Updated',
     status_ephemeral: 'Ephemeral snapshot — not saved to transcript history.',
@@ -5717,6 +5757,16 @@ const LOCALES = {
     settings_tab_conversation: 'Conversation',
     settings_tab_preferences: 'Preferences',
     settings_tab_plugins: 'Plugins',
+    settings_plugins_title: 'Plugins',  // TODO: translate
+    settings_plugins_meta: 'View installed Hermes plugins and the lifecycle hooks they register. This panel is read-only.',  // TODO: translate
+    settings_plugins_empty: 'No Hermes plugins are currently visible. Install or enable plugins from the Hermes CLI/config to see them here.',  // TODO: translate
+    plugins_unnamed: 'Unnamed plugin',  // TODO: translate
+    plugins_no_description: 'No description provided.',  // TODO: translate
+    plugins_no_hooks: 'No registered lifecycle hooks',  // TODO: translate
+    plugins_registered_hooks: 'Registered hooks',  // TODO: translate
+    plugins_enabled: 'Enabled',  // TODO: translate
+    plugins_disabled: 'Disabled',  // TODO: translate
+    plugins_load_failed: 'Failed to load plugins: ',  // TODO: translate
     settings_tab_system: 'System',
     status_updated: 'Updated',
     status_ephemeral: 'Ephemeral snapshot — not saved to transcript history.',
@@ -6570,6 +6620,16 @@ const LOCALES = {
     settings_tab_conversation: 'Conversation',
     settings_tab_preferences: 'Preferences',
     settings_tab_plugins: 'Plugins',
+    settings_plugins_title: 'Plugins',  // TODO: translate
+    settings_plugins_meta: 'View installed Hermes plugins and the lifecycle hooks they register. This panel is read-only.',  // TODO: translate
+    settings_plugins_empty: 'No Hermes plugins are currently visible. Install or enable plugins from the Hermes CLI/config to see them here.',  // TODO: translate
+    plugins_unnamed: 'Unnamed plugin',  // TODO: translate
+    plugins_no_description: 'No description provided.',  // TODO: translate
+    plugins_no_hooks: 'No registered lifecycle hooks',  // TODO: translate
+    plugins_registered_hooks: 'Registered hooks',  // TODO: translate
+    plugins_enabled: 'Enabled',  // TODO: translate
+    plugins_disabled: 'Disabled',  // TODO: translate
+    plugins_load_failed: 'Failed to load plugins: ',  // TODO: translate
     settings_tab_system: 'System',
     status_updated: 'Updated',
     status_ephemeral: 'Ephemeral snapshot — not saved to transcript history.',
@@ -7207,13 +7267,22 @@ const LOCALES = {
     busy_steer_fallback: 'Steer 不可用 — 已中断',
     busy_interrupt_confirm: '已中断 — 正在发送新消息',
     settings_label_busy_input_mode: '忙碌输入模式',
-    settings_desc_busy_input_mode: '控制在代理运行时发送消息的行为。队列等待；中断取消并重新开始；Steer中途注入纠正，不中断。',
-    settings_label_fade_text_effect: '文本淡入效果',
-    settings_desc_fade_text_effect: '在助手回复时让新流式输出的词语淡入显示。类似 OpenWebUI；为获得最佳性能默认关闭。',
-    settings_busy_input_mode_queue: '加入队列',
-    settings_busy_input_mode_interrupt: '中断当前回合',
-    settings_busy_input_mode_steer: 'Steer（中断 + 发送）',
-
+    settings_desc_busy_input_mode: '控制当代理正在运行时你发送消息会发生什么。队列会等待；中断会取消并重新开始；引导会在不中断的情况下注入中间修正（当流不可用时回退到队列）。',
+    settings_label_fade_text_effect: '淡入文字效果',
+    settings_desc_fade_text_effect: '在助手回复时淡入新流式单词。类似于 OpenWebUI；默认关闭以获得最佳性能。',
+    settings_busy_input_mode_queue: '队列后续消息',
+    settings_busy_input_mode_interrupt: '中断当前轮次',
+    settings_busy_input_mode_steer: '引导（中间修正）',
+    settings_plugins_title: '插件',
+    settings_plugins_meta: '查看已安装的 Hermes 插件及其注册的生命周期挂钩。此面板为只读。',
+    settings_plugins_empty: '当前没有可见的 Hermes 插件。通过 Hermes CLI/配置文件安装或启用插件后即可在此查看。',
+    plugins_unnamed: '未命名插件',
+    plugins_no_description: '未提供描述信息。',
+    plugins_no_hooks: '未注册生命周期挂钩',
+    plugins_registered_hooks: '已注册的挂钩',
+    plugins_enabled: '已启用',
+    plugins_disabled: '已禁用',
+    plugins_load_failed: '加载插件失败：',
     workspace_empty_no_path: '未选择工作区。请在 设置 → 工作区 中设置工作区以浏览文件。',
     workspace_empty_dir: '此工作区为空。',
     workspace_show_hidden_files: '显示隐藏文件',
@@ -8432,6 +8501,16 @@ const LOCALES = {
     settings_tab_appearance: '外觀',
     settings_tab_preferences: '偏好設定',
     settings_tab_plugins: '外掛',
+    settings_plugins_title: '外掛',
+    settings_plugins_meta: '檢視已安裝的 Hermes 外掛及其註冊的生命週期鉤子。此面板為唯讀。',
+    settings_plugins_empty: '目前沒有可見的 Hermes 外掛。透過 Hermes CLI/設定檔安裝或啟用外掛後即可在此檢視。',
+    plugins_unnamed: '未命名外掛',
+    plugins_no_description: '未提供描述。',
+    plugins_no_hooks: '未註冊生命週期鉤子',
+    plugins_registered_hooks: '已註冊的鉤子',
+    plugins_enabled: '已啟用',
+    plugins_disabled: '已停用',
+    plugins_load_failed: '載入外掛失敗：',
     settings_tab_system: '系統',
     settings_title: '\u8a2d\u5b9a',
     settings_save_btn: '\u5132\u5b58\u8a2d\u5b9a',
@@ -9710,6 +9789,16 @@ const LOCALES = {
     settings_tab_appearance: 'Aparência',
     settings_tab_preferences: 'Preferências',
     settings_tab_plugins: 'Plugins',
+    settings_plugins_title: 'Plugins',  // TODO: translate
+    settings_plugins_meta: 'View installed Hermes plugins and the lifecycle hooks they register. This panel is read-only.',  // TODO: translate
+    settings_plugins_empty: 'No Hermes plugins are currently visible. Install or enable plugins from the Hermes CLI/config to see them here.',  // TODO: translate
+    plugins_unnamed: 'Unnamed plugin',  // TODO: translate
+    plugins_no_description: 'No description provided.',  // TODO: translate
+    plugins_no_hooks: 'No registered lifecycle hooks',  // TODO: translate
+    plugins_registered_hooks: 'Registered hooks',  // TODO: translate
+    plugins_enabled: 'Enabled',  // TODO: translate
+    plugins_disabled: 'Disabled',  // TODO: translate
+    plugins_load_failed: 'Failed to load plugins: ',  // TODO: translate
     settings_tab_system: 'Sistema',
     settings_title: 'Configurações',
     settings_save_btn: 'Salvar Configurações',
@@ -10803,6 +10892,16 @@ const LOCALES = {
     settings_tab_appearance: '외형',
     settings_tab_preferences: '환경설정',
     settings_tab_plugins: '플러그인',
+    settings_plugins_title: 'Plugins',  // TODO: translate
+    settings_plugins_meta: 'View installed Hermes plugins and the lifecycle hooks they register. This panel is read-only.',  // TODO: translate
+    settings_plugins_empty: 'No Hermes plugins are currently visible. Install or enable plugins from the Hermes CLI/config to see them here.',  // TODO: translate
+    plugins_unnamed: 'Unnamed plugin',  // TODO: translate
+    plugins_no_description: 'No description provided.',  // TODO: translate
+    plugins_no_hooks: 'No registered lifecycle hooks',  // TODO: translate
+    plugins_registered_hooks: 'Registered hooks',  // TODO: translate
+    plugins_enabled: 'Enabled',  // TODO: translate
+    plugins_disabled: 'Disabled',  // TODO: translate
+    plugins_load_failed: 'Failed to load plugins: ',  // TODO: translate
     settings_tab_system: '시스템',
     settings_title: '설정',
     settings_save_btn: '설정 저장',
@@ -11913,6 +12012,16 @@ const LOCALES = {
     settings_tab_appearance: 'Apparence',
     settings_tab_preferences: 'Préférences',
     settings_tab_plugins: 'Plugins',
+    settings_plugins_title: 'Plugins',  // TODO: translate
+    settings_plugins_meta: 'View installed Hermes plugins and the lifecycle hooks they register. This panel is read-only.',  // TODO: translate
+    settings_plugins_empty: 'No Hermes plugins are currently visible. Install or enable plugins from the Hermes CLI/config to see them here.',  // TODO: translate
+    plugins_unnamed: 'Unnamed plugin',  // TODO: translate
+    plugins_no_description: 'No description provided.',  // TODO: translate
+    plugins_no_hooks: 'No registered lifecycle hooks',  // TODO: translate
+    plugins_registered_hooks: 'Registered hooks',  // TODO: translate
+    plugins_enabled: 'Enabled',  // TODO: translate
+    plugins_disabled: 'Disabled',  // TODO: translate
+    plugins_load_failed: 'Failed to load plugins: ',  // TODO: translate
     settings_tab_system: 'Système',
     settings_title: 'Paramètres',
     settings_save_btn: 'Enregistrer les paramètres',

--- a/static/index.html
+++ b/static/index.html
@@ -1136,14 +1136,14 @@
           <div class="settings-pane" id="settingsPanePlugins">
             <div class="settings-section-head">
               <div>
-                <div class="settings-section-title">Plugins</div>
-                <div class="settings-section-meta">View installed Hermes plugins and the lifecycle hooks they register. This panel is read-only.</div>
+                <div class="settings-section-title" data-i18n="settings_plugins_title">Plugins</div>
+                <div class="settings-section-meta" data-i18n="settings_plugins_meta">View installed Hermes plugins and the lifecycle hooks they register. This panel is read-only.</div>
               </div>
             </div>
             <div id="pluginsList" style="display:flex;flex-direction:column;margin-top:4px">
               <!-- Populated dynamically by loadPluginsPanel() -->
             </div>
-            <div id="pluginsEmpty" style="display:none;text-align:center;padding:32px 0;color:var(--muted);font-size:13px">
+            <div id="pluginsEmpty" style="display:none;text-align:center;padding:32px 0;color:var(--muted);font-size:13px" data-i18n="settings_plugins_empty">
               No Hermes plugins are currently visible. Install or enable plugins from the Hermes CLI/config to see them here.
             </div>
           </div>

--- a/static/messages.js
+++ b/static/messages.js
@@ -1480,6 +1480,8 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
           const _prevIn=(S.session&&S.session.input_tokens)||0;
           const _prevOut=(S.session&&S.session.output_tokens)||0;
           const _prevCost=(S.session&&S.session.estimated_cost)||0;
+          const _prevCacheRead=(S.session&&S.session.cache_read_tokens)||0;
+          const _prevCacheWrite=(S.session&&S.session.cache_write_tokens)||0;
           S.session=d.session;S.messages=d.session.messages||[];if(typeof _messagesTruncated!=='undefined')_messagesTruncated=!!d.session._messages_truncated;
           if(S.session&&S.session.session_id){
             try{localStorage.setItem('hermes-webui-session',S.session.session_id);}catch(_){}
@@ -1509,12 +1511,16 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
               const curIn=d.usage.input_tokens||0;
               const curOut=d.usage.output_tokens||0;
               const curCost=d.usage.estimated_cost||0;
+              const curCacheRead=d.usage.cache_read_tokens||0;
+              const curCacheWrite=d.usage.cache_write_tokens||0;
               // Only set delta if values actually increased (skip no-op turns)
-              if(curIn>prevIn||curOut>prevOut){
+              if(curIn>prevIn||curOut>prevOut||curCacheRead>_prevCacheRead||curCacheWrite>_prevCacheWrite){
                 lastAsst._turnUsage={
                   input_tokens:Math.max(0,curIn-prevIn),
                   output_tokens:Math.max(0,curOut-prevOut),
                   estimated_cost:Math.max(0,curCost-prevCost),
+                  cache_read_tokens:Math.max(0,curCacheRead-_prevCacheRead),
+                  cache_write_tokens:Math.max(0,curCacheWrite-_prevCacheWrite),
                 };
               }
               if(typeof d.usage.duration_seconds==='number'){

--- a/static/messages.js
+++ b/static/messages.js
@@ -273,7 +273,7 @@ async function send(){
   const userMsg={role:'user',content:displayText,attachments:uploaded.length?uploadedNames:undefined,_ts:Date.now()/1000};
   S.toolCalls=[];  // clear tool calls from previous turn
   clearLiveToolCards();  // clear any leftover live cards from last turn
-  S.messages.push(userMsg);renderMessages();appendThinking();setBusy(true);
+  S.messages.push(userMsg);renderMessages();appendThinking('',{pending:true});setBusy(true);
   // First optimistic pass: make the local user turn visible before /api/chat/start
   // can save pending state on the server.
   if(typeof upsertActiveSessionForLocalTurn==='function'){

--- a/static/panels.js
+++ b/static/panels.js
@@ -5685,7 +5685,7 @@ async function loadPluginsPanel(){
       list.appendChild(_buildPluginCard(plugin));
     }
   }catch(e){
-    list.innerHTML='<div style="color:var(--error);padding:12px;font-size:13px">Failed to load plugins: '+esc(e.message||String(e))+'</div>';
+    list.innerHTML='<div style="color:var(--error);padding:12px;font-size:13px">'+t('plugins_load_failed')+esc(e.message||String(e))+'</div>';
   }
 }
 
@@ -5696,21 +5696,21 @@ function _buildPluginCard(plugin){
   const hooks=Array.isArray(plugin&&plugin.hooks)?plugin.hooks:[];
   const hookHtml=hooks.length
     ? hooks.map(h=>`<span class="plugin-hook-badge">${esc(h)}</span>`).join('')
-    : '<span class="plugin-hook-empty">No registered lifecycle hooks</span>';
-  const version=(plugin&&plugin.version)?` · v${esc(plugin.version)}`:'';
-  const desc=(plugin&&plugin.description)?esc(plugin.description):'No description provided.';
+    : '<span class="plugin-hook-empty">'+t('plugins_no_hooks')+'</span>';
+  const version=(plugin&&plugin.version)?' · v'+esc(plugin.version):'';
+  const desc=(plugin&&plugin.description)?esc(plugin.description):t('plugins_no_description');
   const enabled=plugin&&plugin.enabled!==false;
   card.innerHTML=`
     <div class="provider-card-header plugin-card-header">
       <div class="provider-card-info">
-        <div class="provider-card-name">${esc((plugin&&plugin.name)||'Unnamed plugin')}</div>
+        <div class="provider-card-name">${esc((plugin&&plugin.name)||t('plugins_unnamed'))}</div>
         <div class="provider-card-meta">${esc((plugin&&plugin.key)||'plugin')}${version}</div>
       </div>
-      <span class="provider-card-badge ${enabled?'':'plugin-card-badge-disabled'}">${enabled?'Enabled':'Disabled'}</span>
+      <span class="provider-card-badge ${enabled?'':'plugin-card-badge-disabled'}">${enabled?t('plugins_enabled'):t('plugins_disabled')}</span>
     </div>
     <div class="provider-card-body plugin-card-body">
       <div class="provider-card-hint">${desc}</div>
-      <div class="provider-card-label">Registered hooks</div>
+      <div class="provider-card-label">${t('plugins_registered_hooks')}</div>
       <div class="plugin-hook-list">${hookHtml}</div>
     </div>
   `;

--- a/static/ui.js
+++ b/static/ui.js
@@ -2120,12 +2120,14 @@ function _syncCtxIndicator(usage){
   // branch below — honest "no data" instead of misleading "890% used".
   const promptTok=usage.last_prompt_tokens||0;
   const totalTok=(usage.input_tokens||0)+(usage.output_tokens||0);
+  const cacheReadTok=usage.cache_read_tokens||0;
+  const cacheWriteTok=usage.cache_write_tokens||0;
   // Default context window to 128K when not provided by backend
   const DEFAULT_CTX=128*1024;
   const ctxWindow=usage.context_length||DEFAULT_CTX;
   const cost=usage.estimated_cost;
   // Show indicator whenever we have any usage data (tokens or cost)
-  if(!promptTok&&!totalTok&&!cost){
+  if(!promptTok&&!totalTok&&!cost&&!cacheReadTok&&!cacheWriteTok){
     if(wrap) wrap.style.display='none';
     _syncMobileCtxDisplay({visible:false});
     return;
@@ -2158,9 +2160,13 @@ function _syncCtxIndicator(usage){
   const compressText=pct>=75?t('ctx_compress_action'):(pct>=50?t('ctx_compress_hint'):'');
   if(compressWrap) compressWrap.style.display=compressText?'':'none';
   _setCtxCompressButton(compressBtn,compressText);
+  const cacheTotalTok=cacheReadTok+cacheWriteTok;
+  const cacheHitPct=cacheTotalTok?Math.round((cacheReadTok/cacheTotalTok)*100):null;
+  const cacheText=cacheTotalTok?`cache: ${cacheHitPct}% hit (${_fmtTokens(cacheReadTok)} read / ${_fmtTokens(cacheWriteTok)} write)`:'';
   let label=hasPromptTok?`Context window ${pct}% used`:`${_fmtTokens(totalTok)} tokens used`;
   if(!hasExplicitCtx&&hasPromptTok) label+=' (est. 128K)';
   if(cost) label+=` \u00b7 $${cost<0.01?cost.toFixed(4):cost.toFixed(2)}`;
+  if(cacheText) label+=` \u00b7 ${cacheText}`;
   el.setAttribute('aria-label',label);
   const usageText=hasPromptTok?(overflowed?`${rawPct}% used (context exceeded)`:`${pct}% used (${100-pct}% left)`):`${_fmtTokens(totalTok)} tokens used`;
   const tokensText=hasPromptTok?`${_fmtTokens(promptTok)} / ${_fmtTokens(ctxWindow)} tokens used`:`In: ${_fmtTokens(usage.input_tokens||0)} \u00b7 Out: ${_fmtTokens(usage.output_tokens||0)}`;
@@ -2182,6 +2188,11 @@ function _syncCtxIndicator(usage){
   if(costLine){
     if(cost){
       costText=`Estimated cost: $${cost<0.01?cost.toFixed(4):cost.toFixed(2)}`;
+      if(cacheText) costText+=` \u00b7 ${cacheText}`;
+      costLine.style.display='';
+      costLine.textContent=costText;
+    }else if(cacheText){
+      costText=cacheText;
       costLine.style.display='';
       costLine.textContent=costText;
     }else{
@@ -6026,8 +6037,12 @@ function renderMessages(options){
         const inTok=msg._turnUsage.input_tokens||0;
         const outTok=msg._turnUsage.output_tokens||0;
         const cost=msg._turnUsage.estimated_cost;
+        const cacheRead=msg._turnUsage.cache_read_tokens||0;
+        const cacheWrite=msg._turnUsage.cache_write_tokens||0;
         let text=`${_fmtTokens(inTok)} in · ${_fmtTokens(outTok)} out`;
         if(cost) text+=` · ~$${cost<0.01?cost.toFixed(4):cost.toFixed(2)}`;
+        const cacheTotal=cacheRead+cacheWrite;
+        if(cacheTotal) text+=` · cache ${Math.round((cacheRead/cacheTotal)*100)}% hit`;
         usage.textContent=text;
         fragments.push(usage);
       }

--- a/static/ui.js
+++ b/static/ui.js
@@ -7033,11 +7033,12 @@ function finalizeThinkingCard(){
     _syncToolCallGroupSummary(group);
   }
 }
-function appendThinking(text=''){
+function appendThinking(text='', options){
   // Guard: ignore if session was switched during an async SSE stream.
   // The old stream's reasoning events can still fire after switch;
   // without this check they would pollute the new session's DOM.
-  if(!S.session||!S.activeStreamId) return;
+  const allowPendingPlaceholder=!!(options&&options.pending===true);
+  if(!S.session||(!S.activeStreamId&&!allowPendingPlaceholder)) return;
   $('emptyState').style.display='none';
   let turn=$('liveAssistantTurn');
   if(!turn){

--- a/tests/test_issue1361_cancel_data_loss.py
+++ b/tests/test_issue1361_cancel_data_loss.py
@@ -25,6 +25,7 @@ import api.config as config
 import api.models as models
 import api.streaming as streaming
 from api.models import Session
+from api.run_journal import append_run_event
 from api.streaming import cancel_stream
 
 REPO_ROOT = pathlib.Path(__file__).parent.parent.resolve()
@@ -391,14 +392,60 @@ def test_stale_stream_cleanup_materializes_pending_turn_before_clearing_state():
     assert cleared is True
     assert s.active_stream_id is None
     assert s.pending_user_message is None
-    assert s.messages[-1]["role"] == "user"
-    assert s.messages[-1]["content"] == "please make the GUI fully usable"
-    assert s.messages[-1]["timestamp"] == 1778187755
-    assert s.messages[-1]["attachments"] == [{"name": "visible-state.png"}]
+    assert s.messages[-2]["role"] == "user"
+    assert s.messages[-2]["content"] == "please make the GUI fully usable"
+    assert s.messages[-2]["timestamp"] == 1778187755
+    assert s.messages[-2]["attachments"] == [{"name": "visible-state.png"}]
+    assert s.messages[-1]["role"] == "assistant"
+    assert s.messages[-1].get("_error") is True
+    assert s.messages[-1].get("type") == "interrupted"
 
     reloaded = models.get_session(sid, metadata_only=False)
-    assert reloaded.messages[-1]["role"] == "user"
-    assert reloaded.messages[-1]["content"] == "please make the GUI fully usable"
+    assert reloaded.messages[-2]["role"] == "user"
+    assert reloaded.messages[-2]["content"] == "please make the GUI fully usable"
+    assert reloaded.messages[-1]["role"] == "assistant"
+    assert reloaded.messages[-1].get("type") == "interrupted"
+
+
+def test_stale_stream_cleanup_recovers_journaled_visible_output():
+    """The /api/session stale cleanup path can run before a full chat reload;
+    it must preserve journaled partial output instead of only clearing runtime
+    flags."""
+    from api.routes import _clear_stale_stream_state
+
+    sid = "test_pending_error_d4_journal"
+    s = _make_session(
+        session_id=sid,
+        pending_msg="please check maintainer activity",
+        messages=[{"role": "assistant", "content": "previous answer"}],
+    )
+    append_run_event(
+        sid,
+        "stream_1361",
+        "token",
+        {"text": "I will check GitHub first."},
+    )
+    append_run_event(
+        sid,
+        "stream_1361",
+        "tool",
+        {"name": "terminal", "preview": "gh issue view 2423", "args": {"command": "gh issue view 2423"}},
+    )
+    append_run_event(
+        sid,
+        "stream_1361",
+        "tool_complete",
+        {"name": "terminal", "duration": 0.4, "is_error": False},
+    )
+
+    cleared = _clear_stale_stream_state(s)
+
+    assert cleared is True
+    assert any("I will check GitHub first." in (m.get("content") or "") for m in s.messages)
+    assert s.tool_calls
+    assert s.tool_calls[0]["name"] == "terminal"
+    assert s.messages[-1].get("type") == "interrupted"
+    assert "partial output above was recovered" in s.messages[-1]["content"]
 
 
 # ── Structural guard: pin call sites of the materialize helper at error branches ──

--- a/tests/test_issue1857_usage_overwrite.py
+++ b/tests/test_issue1857_usage_overwrite.py
@@ -30,6 +30,8 @@ def test_stream_completion_overwrites_session_usage_with_latest_turn(cleanup_tes
             self.input_tokens = 9000
             self.output_tokens = 800
             self.estimated_cost = 12.34
+            self.cache_read_tokens = 1000
+            self.cache_write_tokens = 200
             self.tool_calls = []
             self.gateway_routing = None
             self.gateway_routing_history = []
@@ -48,6 +50,8 @@ def test_stream_completion_overwrites_session_usage_with_latest_turn(cleanup_tes
                     "input_tokens": self.input_tokens,
                     "output_tokens": self.output_tokens,
                     "estimated_cost": self.estimated_cost,
+                    "cache_read_tokens": self.cache_read_tokens,
+                    "cache_write_tokens": self.cache_write_tokens,
                     "kwargs": kwargs,
                 }
             )
@@ -67,6 +71,8 @@ def test_stream_completion_overwrites_session_usage_with_latest_turn(cleanup_tes
                 "input_tokens": self.input_tokens,
                 "output_tokens": self.output_tokens,
                 "estimated_cost": self.estimated_cost,
+                "cache_read_tokens": self.cache_read_tokens,
+                "cache_write_tokens": self.cache_write_tokens,
                 "personality": self.personality,
             }
 
@@ -93,6 +99,8 @@ def test_stream_completion_overwrites_session_usage_with_latest_turn(cleanup_tes
             self.session_prompt_tokens = 123
             self.session_completion_tokens = 45
             self.session_estimated_cost_usd = 0.067
+            self.session_cache_read_tokens = 9000
+            self.session_cache_write_tokens = 1000
             self.reasoning_config = None
             self.ephemeral_system_prompt = None
             self._last_error = None
@@ -169,13 +177,19 @@ def test_stream_completion_overwrites_session_usage_with_latest_turn(cleanup_tes
     assert fake_session.input_tokens == 123
     assert fake_session.output_tokens == 45
     assert fake_session.estimated_cost == 0.067
+    assert fake_session.cache_read_tokens == 9000
+    assert fake_session.cache_write_tokens == 1000
     assert any(
         event == "done"
         and payload["usage"]["input_tokens"] == 123
         and payload["usage"]["output_tokens"] == 45
         and payload["usage"]["estimated_cost"] == 0.067
+        and payload["usage"]["cache_read_tokens"] == 9000
+        and payload["usage"]["cache_write_tokens"] == 1000
         for event, payload in list(fake_queue.queue)
     )
     assert saved_snapshots[-1]["input_tokens"] == 123
     assert saved_snapshots[-1]["output_tokens"] == 45
     assert saved_snapshots[-1]["estimated_cost"] == 0.067
+    assert saved_snapshots[-1]["cache_read_tokens"] == 9000
+    assert saved_snapshots[-1]["cache_write_tokens"] == 1000

--- a/tests/test_issue2419_cache_usage_display.py
+++ b/tests/test_issue2419_cache_usage_display.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_session_compact_exposes_prompt_cache_counters():
+    from api.models import Session
+
+    session = Session(
+        session_id="issue2419_cache_usage",
+        workspace="/tmp",
+        input_tokens=120_000,
+        output_tokens=5_000,
+        estimated_cost=0.44,
+        cache_read_tokens=100_000,
+        cache_write_tokens=20_000,
+    )
+
+    compact = session.compact()
+
+    assert compact["cache_read_tokens"] == 100_000
+    assert compact["cache_write_tokens"] == 20_000
+
+
+def test_streaming_usage_payload_includes_prompt_cache_counters():
+    src = (ROOT / "api" / "streaming.py").read_text()
+
+    assert "session_cache_read_tokens" in src
+    assert "session_cache_write_tokens" in src
+    assert "'cache_read_tokens': cache_read_tokens" in src
+    assert "'cache_write_tokens': cache_write_tokens" in src
+
+
+def test_context_indicator_surfaces_cache_hit_rate():
+    src = (ROOT / "static" / "ui.js").read_text()
+
+    assert "cacheReadTok=usage.cache_read_tokens||0" in src
+    assert "cacheWriteTok=usage.cache_write_tokens||0" in src
+    assert "cache: ${cacheHitPct}% hit" in src
+    assert "Estimated cost: $${cost<0.01?cost.toFixed(4):cost.toFixed(2)}" in src
+    assert "cache ${Math.round((cacheRead/cacheTotal)*100)}% hit" in src
+
+
+def test_done_handler_preserves_per_turn_cache_deltas():
+    src = (ROOT / "static" / "messages.js").read_text()
+
+    assert "_prevCacheRead=(S.session&&S.session.cache_read_tokens)||0" in src
+    assert "curCacheRead=d.usage.cache_read_tokens||0" in src
+    assert "cache_read_tokens:Math.max(0,curCacheRead-_prevCacheRead)" in src
+    assert "cache_write_tokens:Math.max(0,curCacheWrite-_prevCacheWrite)" in src

--- a/tests/test_provider_cost_history.py
+++ b/tests/test_provider_cost_history.py
@@ -260,6 +260,34 @@ def test_cost_snapshot_append_uses_lock(monkeypatch, tmp_path):
     assert snapshots == [{"date": "2030-04-15", "used": 4.0, "limit": 20.0}]
 
 
+def test_cost_snapshot_append_uses_file_lock(monkeypatch, tmp_path):
+    """Snapshot append takes a provider-specific file lock for multi-process workers."""
+    monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
+
+    import api.providers as providers
+
+    calls = []
+
+    class RecordingFcntl:
+        LOCK_EX = 2
+
+        @staticmethod
+        def flock(file_obj, operation):
+            calls.append((Path(file_obj.name).name, operation))
+
+    monkeypatch.setattr(providers, "fcntl", RecordingFcntl, raising=False)
+    monkeypatch.setattr(providers, "datetime", type("DT", (), {
+        "now": staticmethod(lambda tz=None: datetime(2030, 4, 15, 12, 0, 0, tzinfo=tz or timezone.utc)),
+        "strftime": datetime.strftime,
+    }))
+
+    snapshots = providers._append_cost_snapshot("openrouter", 4.0, 20.0)
+
+    assert calls == [("openrouter.lock", RecordingFcntl.LOCK_EX)]
+    assert (tmp_path / "cost-snapshots" / "openrouter.lock").exists()
+    assert snapshots == [{"date": "2030-04-15", "used": 4.0, "limit": 20.0}]
+
+
 # ── Missing credentials ───────────────────────────────────────────────────────
 
 

--- a/tests/test_runtime_adapter_seam.py
+++ b/tests/test_runtime_adapter_seam.py
@@ -1,0 +1,121 @@
+import importlib
+import queue
+
+
+def test_runtime_adapter_interface_and_legacy_journal_methods_exist():
+    runtime = importlib.import_module("api.runtime_adapter")
+
+    required = (
+        "start_run",
+        "observe_run",
+        "get_run",
+        "cancel_run",
+        "respond_approval",
+        "respond_clarify",
+    )
+    for name in required:
+        assert hasattr(runtime.RuntimeAdapter, name)
+        assert hasattr(runtime.LegacyJournalRuntimeAdapter, name)
+
+    assert runtime.runtime_adapter_mode({}) == "legacy-direct"
+    assert runtime.runtime_adapter_enabled({}) is False
+    assert runtime.runtime_adapter_mode({"HERMES_WEBUI_RUNTIME_ADAPTER": "legacy-journal"}) == "legacy-journal"
+    assert runtime.runtime_adapter_enabled({"HERMES_WEBUI_RUNTIME_ADAPTER": "legacy-journal"}) is True
+    assert runtime.runtime_adapter_mode({"HERMES_WEBUI_RUNTIME_ADAPTER": "sidecar"}) == "legacy-direct"
+
+
+def test_legacy_journal_adapter_start_run_delegates_without_owning_runtime_state():
+    runtime = importlib.import_module("api.runtime_adapter")
+    calls = []
+
+    def start_delegate(request):
+        calls.append(request)
+        return {
+            "stream_id": "stream-123",
+            "session_id": request.session_id,
+            "status": "started",
+            "active_controls": ["cancel"],
+        }
+
+    adapter = runtime.LegacyJournalRuntimeAdapter(start_run_delegate=start_delegate)
+    request = runtime.StartRunRequest(
+        session_id="s1",
+        message="hello",
+        attachments=[{"name": "a.txt"}],
+        workspace="/tmp/work",
+        profile="default",
+        provider="openai-codex",
+        model="gpt-5.5",
+        toolsets=["terminal"],
+        source="webui",
+        metadata={"k": "v"},
+    )
+
+    result = adapter.start_run(request)
+
+    assert calls == [request]
+    assert result.session_id == "s1"
+    assert result.stream_id == "stream-123"
+    assert result.run_id == "stream-123"
+    assert result.status == "started"
+    assert result.active_controls == ["cancel"]
+
+
+def test_legacy_journal_adapter_observe_and_get_run_use_journal_and_live_state(tmp_path):
+    runtime = importlib.import_module("api.runtime_adapter")
+    run_journal = importlib.import_module("api.run_journal")
+
+    run_journal.append_run_event("s1", "r1", "token", {"text": "a"}, session_dir=tmp_path)
+    run_journal.append_run_event("s1", "r1", "done", {"ok": True}, session_dir=tmp_path)
+
+    adapter = runtime.LegacyJournalRuntimeAdapter(
+        session_dir=tmp_path,
+        live_stream_lookup=lambda run_id: run_id == "live-run",
+    )
+
+    replay = adapter.observe_run("r1", cursor="0")
+    assert [event["type"] for event in replay.events] == ["token", "done"]
+    assert replay.last_event_id == "r1:2"
+
+    completed = adapter.get_run("r1")
+    assert completed.run_id == "r1"
+    assert completed.session_id == "s1"
+    assert completed.status == "completed"
+    assert completed.terminal_state == "completed"
+    assert completed.last_event_id == "r1:2"
+
+    live = adapter.get_run("live-run")
+    assert live.run_id == "live-run"
+    assert live.status == "running"
+    assert live.active_controls == ["cancel"]
+
+
+def test_legacy_journal_adapter_controls_delegate_to_existing_handlers():
+    runtime = importlib.import_module("api.runtime_adapter")
+    calls = []
+    adapter = runtime.LegacyJournalRuntimeAdapter(
+        cancel_delegate=lambda run_id: calls.append(("cancel", run_id)) or True,
+        approval_delegate=lambda run_id, approval_id, choice: calls.append(("approval", run_id, approval_id, choice)) or True,
+        clarify_delegate=lambda run_id, clarify_id, response: calls.append(("clarify", run_id, clarify_id, response)) or True,
+    )
+
+    assert adapter.cancel_run("r1").accepted is True
+    assert adapter.respond_approval("r1", "a1", "once").accepted is True
+    assert adapter.respond_clarify("r1", "c1", "answer").accepted is True
+    assert calls == [
+        ("cancel", "r1"),
+        ("approval", "r1", "a1", "once"),
+        ("clarify", "r1", "c1", "answer"),
+    ]
+
+
+def test_chat_start_route_selects_adapter_only_when_flag_enabled():
+    routes = importlib.import_module("api.routes")
+    src = (routes.Path(__file__).parent.parent / "api" / "routes.py").read_text(encoding="utf-8")
+    start_idx = src.index("def _handle_chat_start")
+    start_body = src[start_idx:src.index("def _resolve_chat_workspace_with_recovery", start_idx)]
+
+    assert "runtime_adapter_enabled()" in start_body
+    assert "LegacyJournalRuntimeAdapter" in start_body
+    assert "_start_chat_stream_for_session(" in start_body
+    assert "HERMES_WEBUI_RUNTIME_ADAPTER" not in start_body, "route should use runtime_adapter_enabled(), not inline env checks"

--- a/tests/test_session_sidecar_repair.py
+++ b/tests/test_session_sidecar_repair.py
@@ -21,6 +21,7 @@ from api.models import (
 import api.config as config
 import api.streaming as streaming
 import api.profiles as profiles
+from api.run_journal import append_run_event
 
 
 # ── Fixtures ────────────────────────────────────────────────────────────────
@@ -616,6 +617,129 @@ class TestNonEmptyMessagesPendingCleared:
         assert s.pending_attachments == []
         assert s.pending_started_at is None
         assert s.active_stream_id is None
+
+    def test_journaled_partial_output_is_recovered_before_interrupted_marker(self, hermes_home, monkeypatch):
+        """When a WebUI restart leaves a dead stream with journaled partial
+        output, repair should not collapse the user-visible transcript to only
+        a generic interrupted marker."""
+        s = _make_session(messages=[{"role": "user", "content": "existing turn"}])
+        s.pending_user_message = "Check maintainer activity"
+        s.pending_started_at = time.time() - 120
+        s.active_stream_id = "journaled_stream"
+        s.save()
+
+        append_run_event(
+            s.session_id,
+            "journaled_stream",
+            "token",
+            {"text": "I will check GitHub first."},
+        )
+        append_run_event(
+            s.session_id,
+            "journaled_stream",
+            "tool",
+            {
+                "name": "terminal",
+                "preview": "gh pr list --repo nesquena/hermes-webui",
+                "args": {"command": "gh pr list --repo nesquena/hermes-webui"},
+            },
+        )
+        append_run_event(
+            s.session_id,
+            "journaled_stream",
+            "tool_complete",
+            {"name": "terminal", "duration": 1.2, "is_error": False},
+        )
+        append_run_event(
+            s.session_id,
+            "journaled_stream",
+            "token",
+            {"text": "The first check finished before the restart."},
+        )
+
+        core_path = hermes_home / "sessions" / f"session_{s.session_id}.json"
+        result = _apply_core_sync_or_error_marker(
+            s,
+            core_path,
+            stream_id_for_recheck="journaled_stream",
+        )
+
+        assert result is True
+        contents = [m.get("content", "") for m in s.messages]
+        assert any("I will check GitHub first." in c for c in contents)
+        assert any("The first check finished before the restart." in c for c in contents)
+        assert s.tool_calls, "journaled tool starts should become visible settled tool cards"
+        assert s.tool_calls[0]["name"] == "terminal"
+        assert s.tool_calls[0]["done"] is True
+        assert s.tool_calls[0]["assistant_msg_idx"] < len(s.messages)
+        error_msgs = [m for m in s.messages if m.get("_error")]
+        assert len(error_msgs) == 1
+        assert "partial output above was recovered" in error_msgs[0]["content"]
+        assert "no agent output was recovered" not in error_msgs[0]["content"]
+
+    def test_journal_recovery_does_not_materialize_reasoning_only_events(self, hermes_home, monkeypatch):
+        """Run-journal repair must not turn hidden reasoning into visible chat
+        transcript content."""
+        s = _make_session(messages=[{"role": "user", "content": "existing turn"}])
+        s.pending_user_message = "Keep going"
+        s.pending_started_at = time.time() - 120
+        s.active_stream_id = "reasoning_only_stream"
+        s.save()
+
+        append_run_event(
+            s.session_id,
+            "reasoning_only_stream",
+            "reasoning",
+            {"text": "private scratchpad text"},
+        )
+
+        core_path = hermes_home / "sessions" / f"session_{s.session_id}.json"
+        result = _apply_core_sync_or_error_marker(
+            s,
+            core_path,
+            stream_id_for_recheck="reasoning_only_stream",
+        )
+
+        assert result is True
+        contents = [m.get("content", "") for m in s.messages]
+        assert not any("private scratchpad text" in c for c in contents)
+        error_msgs = [m for m in s.messages if m.get("_error")]
+        assert len(error_msgs) == 1
+        assert "no agent output was recovered" in error_msgs[0]["content"]
+
+    def test_journal_recovery_keeps_consecutive_tools_on_one_anchor(self, hermes_home, monkeypatch):
+        """Consecutive journaled tools without an intervening visible update
+        should recover as one activity group instead of repeated empty anchors."""
+        s = _make_session(messages=[{"role": "user", "content": "existing turn"}])
+        s.pending_user_message = "Inspect files"
+        s.pending_started_at = time.time() - 120
+        s.active_stream_id = "tool_burst_stream"
+        s.save()
+
+        append_run_event(
+            s.session_id,
+            "tool_burst_stream",
+            "token",
+            {"text": "I will inspect the relevant files first."},
+        )
+        for name in ("search_files", "read_file"):
+            append_run_event(
+                s.session_id,
+                "tool_burst_stream",
+                "tool",
+                {"name": name, "preview": name, "args": {"query": "stream recovery"}},
+            )
+
+        core_path = hermes_home / "sessions" / f"session_{s.session_id}.json"
+        result = _apply_core_sync_or_error_marker(
+            s,
+            core_path,
+            stream_id_for_recheck="tool_burst_stream",
+        )
+
+        assert result is True
+        assert len(s.tool_calls) == 2
+        assert s.tool_calls[0]["assistant_msg_idx"] == s.tool_calls[1]["assistant_msg_idx"]
 
 
 class TestLastResortSyncDelegation:

--- a/tests/test_sidebar_first_turn_visibility.py
+++ b/tests/test_sidebar_first_turn_visibility.py
@@ -16,7 +16,7 @@ class TestSidebarFirstTurnVisibility:
             "send() must optimistically upsert the active session into the sidebar "
             "as soon as the local user message is pushed."
         )
-        push_idx = src.index("S.messages.push(userMsg);renderMessages();appendThinking();setBusy(true);")
+        push_idx = src.index("S.messages.push(userMsg);renderMessages();appendThinking('',{pending:true});setBusy(true);")
         helper_idx = src.index("upsertActiveSessionForLocalTurn", push_idx)
         start_idx = src.index("api('/api/chat/start'", push_idx)
         assert helper_idx < start_idx, (
@@ -28,6 +28,26 @@ class TestSidebarFirstTurnVisibility:
             "Do not re-fetch /api/sessions before /api/chat/start saves pending state; "
             "that race can overwrite the optimistic first-turn row with an empty list."
         )
+
+    def test_messages_send_renders_pending_assistant_placeholder_before_chat_start(self):
+        messages = read("static/messages.js")
+        ui = read("static/ui.js")
+        send_start = messages.index("async function send()")
+        push_idx = messages.index("appendThinking('',{pending:true})", send_start)
+        start_idx = messages.index("api('/api/chat/start'", send_start)
+        assert push_idx < start_idx, (
+            "send() should render an assistant-side pending placeholder before "
+            "/api/chat/start or the first SSE event returns."
+        )
+        append_start = ui.index("function appendThinking(text='', options)")
+        append_end = ui.index("function updateThinking", append_start)
+        append_body = ui[append_start:append_end]
+        assert "allowPendingPlaceholder" in append_body
+        assert "options.pending===true" in append_body.replace(" ", ""), (
+            "appendThinking() must allow the explicit pre-stream placeholder path "
+            "without weakening the stale-stream guard for ordinary SSE updates."
+        )
+        assert "(!S.activeStreamId&&!allowPendingPlaceholder)" in append_body.replace(" ", "")
 
     def test_sessions_js_has_local_turn_upsert_helper(self):
         src = read("static/sessions.js")


### PR DESCRIPTION
# v0.51.81 — Release BE (stage-374)

6-PR contributor batch. All authored by contributors, agent-assembled and tested.

## Contents

### Added
- **#2424** @Michaelyklam — default-off RuntimeAdapter Slice 2 seam (`HERMES_WEBUI_RUNTIME_ADAPTER=legacy-journal`)
- **#2421** @Michaelyklam — surface prompt-cache read/write tokens in WebUI usage (fixes #2419)
- **#2425** @mccxj — i18n for Settings Plugins panel

### Fixed
- **#2418** @Michaelyklam — provider-specific POSIX file lock for cost-history snapshot updates (fixes #2402)
- **#2431** @Michaelyklam — render assistant-side pending placeholder before /api/chat/start returns (fixes #2429)
- **#2427** @franksong2702 — recover journaled partial output after WebUI restart (fixes #2423)

## Pre-merge gate

- Pre-Opus checks: JS `node -c`, Python `ast.parse`, merge-marker scan (tightened), CHANGELOG placeholder scan, agent self-verify on #2418/#2421/#2424/#2427 — all clean
- pytest: **5814 passed, 6 skipped, 3 xpassed** in 115s
- Opus advisor (claude-opus-4-7 with --thinking): **VERDICT: ship as-is**. No BLOCKER. Two SHOULD-FIX items deferred to v0.51.82 follow-up issues (S1: response-shape contract drift when `legacy-journal` flag on; S2: narrow journal recovery gap when in-memory messages empty but core transcript populated).

## Held this round

- **#2428** (@bengdan, table renderer pipe-protect) — multi-pipe inside a single bracket pair still mis-splits. Detailed regression note + suggested iterative-fix posted; `hold` applied.

## Approval

Contributor PRs — no nesquena-self-built work in this stage, so independent-review gate doesn't apply. #2418 already had a nesquena APPROVED review; the other five passed agent review + the full automated gate above.
