### PR TITLE
fix(runtime): preserve adapter chat-start response shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Tighten `HERMES_WEBUI_RUNTIME_ADAPTER=legacy-journal` `/api/chat/start` response shape parity so the adapter seam does not add `run_id`, unconditional `status`, or `active_controls` fields beyond the legacy response contract. Fixes #2435.
+
 ## [v0.51.81] — 2026-05-17 — Release BE (stage-374 — 6-PR batch — cost-history POSIX lock + prompt-cache tokens + Plugins panel i18n + pending-placeholder chat + journal-replay partial recovery + default-off RuntimeAdapter Slice 2 seam)
 
 ### Added

--- a/api/routes.py
+++ b/api/routes.py
@@ -7800,9 +7800,6 @@ def _handle_chat_start(handler, body, diag=None):
             response = dict(result.payload)
             response.setdefault("stream_id", result.stream_id)
             response.setdefault("session_id", result.session_id)
-            response.setdefault("run_id", result.run_id)
-            response.setdefault("status", result.status)
-            response.setdefault("active_controls", result.active_controls)
         else:
             response = _start_chat_stream_for_session(
                 s,

--- a/tests/test_runtime_adapter_seam.py
+++ b/tests/test_runtime_adapter_seam.py
@@ -119,3 +119,17 @@ def test_chat_start_route_selects_adapter_only_when_flag_enabled():
     assert "LegacyJournalRuntimeAdapter" in start_body
     assert "_start_chat_stream_for_session(" in start_body
     assert "HERMES_WEBUI_RUNTIME_ADAPTER" not in start_body, "route should use runtime_adapter_enabled(), not inline env checks"
+
+
+def test_chat_start_adapter_response_shape_stays_legacy_compatible():
+    routes = importlib.import_module("api.routes")
+    src = (routes.Path(__file__).parent.parent / "api" / "routes.py").read_text(encoding="utf-8")
+    start_idx = src.index("def _handle_chat_start")
+    start_body = src[start_idx:src.index("def _resolve_chat_workspace_with_recovery", start_idx)]
+
+    assert "response = dict(result.payload)" in start_body
+    assert 'response.setdefault("stream_id", result.stream_id)' in start_body
+    assert 'response.setdefault("session_id", result.session_id)' in start_body
+    assert 'response.setdefault("run_id", result.run_id)' not in start_body
+    assert 'response.setdefault("status", result.status)' not in start_body
+    assert 'response.setdefault("active_controls", result.active_controls)' not in start_body


### PR DESCRIPTION
## Thinking Path

- #1925 Slice 2 is supposed to introduce a reversible RuntimeAdapter seam without changing caller-visible behavior unless a later slice explicitly expands the contract.
- v0.51.81 shipped the default-off `legacy-journal` route, and Opus flagged that enabling the flag adds `run_id`, unconditional `status`, and `active_controls` to `/api/chat/start` responses.
- The frontend currently ignores those fields, but third-party callers and future snapshot tests would see the adapter flag as an HTTP contract change.
- The smallest safe fix is to keep the adapter path returning the legacy delegate payload, only retaining the existing `stream_id` / `session_id` safety fallbacks.
- This keeps the seam honest as a protocol translator rather than a behavior-changing runtime surface.

## What Changed

- Removed adapter-path fallback injection of `run_id`, unconditional `status`, and `active_controls` in `api/routes.py`.
- Added a regression assertion in `tests/test_runtime_adapter_seam.py` that the adapter branch preserves the legacy-compatible response shape.
- Added an Unreleased changelog entry for #2435.

## Why It Matters

The RuntimeAdapter seam needs to be safe to enable for validation without surprising HTTP consumers. This preserves the #1925 invariant that the current `legacy-journal` adapter is a drop-in seam over the legacy path, not a new public response contract.

Fixes #2435. Refs #1925.

## Verification

```bash
env -u HERMES_CONFIG_PATH -u HERMES_WEBUI_HOST /home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_runtime_adapter_seam.py::test_chat_start_adapter_response_shape_stays_legacy_compatible -q
# RED before implementation: 1 failed

env -u HERMES_CONFIG_PATH -u HERMES_WEBUI_HOST /home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_runtime_adapter_seam.py -q
# 6 passed

env -u HERMES_CONFIG_PATH -u HERMES_WEBUI_HOST /home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_runtime_adapter_seam.py tests/test_run_journal.py tests/test_run_journal_routes.py -q
# 23 passed

env -u HERMES_CONFIG_PATH -u HERMES_WEBUI_HOST /home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/ -q
# 5815 passed, 6 skipped, 3 xpassed, 8 subtests passed in 91.25s

git diff --check
# clean
```

UI media: not applicable — backend API response-shape parity only.

## Risks / Follow-ups

- If maintainers decide `run_id` / `active_controls` should become part of the stable `/api/chat/start` contract, that should be added intentionally to both paths in a later PR rather than leaking only through the adapter flag.
- #2434 remains a separate journal-recovery SHOULD-FIX and is intentionally not bundled into this response-parity PR.

## Model Used

AI assisted.

- Provider: OpenAI Codex
- Model: `gpt-5.5`
- Notable tool use: `gh`, `git`, focused/full pytest, Hermes file patching tools.
