### PR TITLE
Preserve chat-start response shape for RuntimeAdapter path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Keep the default-off `HERMES_WEBUI_RUNTIME_ADAPTER=legacy-journal` chat-start path response-compatible with the legacy-direct path by not adding adapter-internal `run_id`, `status`, or `active_controls` fields to `/api/chat/start` responses. Fixes #2435.
+
 ## [v0.51.82] — 2026-05-17 — Release BF (stage-375 — 2-PR batch — table renderer pipe protection + Catppuccin appearance skin)
 
 ### Added

--- a/api/routes.py
+++ b/api/routes.py
@@ -7800,9 +7800,6 @@ def _handle_chat_start(handler, body, diag=None):
             response = dict(result.payload)
             response.setdefault("stream_id", result.stream_id)
             response.setdefault("session_id", result.session_id)
-            response.setdefault("run_id", result.run_id)
-            response.setdefault("status", result.status)
-            response.setdefault("active_controls", result.active_controls)
         else:
             response = _start_chat_stream_for_session(
                 s,

--- a/tests/test_runtime_adapter_seam.py
+++ b/tests/test_runtime_adapter_seam.py
@@ -119,3 +119,22 @@ def test_chat_start_route_selects_adapter_only_when_flag_enabled():
     assert "LegacyJournalRuntimeAdapter" in start_body
     assert "_start_chat_stream_for_session(" in start_body
     assert "HERMES_WEBUI_RUNTIME_ADAPTER" not in start_body, "route should use runtime_adapter_enabled(), not inline env checks"
+
+
+def test_chat_start_adapter_path_preserves_legacy_response_shape():
+    """The RuntimeAdapter seam must be invisible to /api/chat/start callers.
+
+    The adapter can use run_id/status/controls internally, but the flagged
+    route must not add fields that the legacy-direct response does not expose.
+    """
+    routes = importlib.import_module("api.routes")
+    src = (routes.Path(__file__).parent.parent / "api" / "routes.py").read_text(encoding="utf-8")
+    branch_start = src.index("if runtime_adapter_enabled():")
+    branch_end = src.index("else:", branch_start)
+    adapter_branch = src[branch_start:branch_end]
+
+    assert 'response.setdefault("stream_id", result.stream_id)' in adapter_branch
+    assert 'response.setdefault("session_id", result.session_id)' in adapter_branch
+    assert 'response.setdefault("run_id", result.run_id)' not in adapter_branch
+    assert 'response.setdefault("status", result.status)' not in adapter_branch
+    assert 'response.setdefault("active_controls", result.active_controls)' not in adapter_branch


### PR DESCRIPTION
## Thinking Path

- #2424 added a default-off RuntimeAdapter seam for the future #1925 runtime split.
- That seam should be behavior-preserving for existing `/api/chat/start` callers when `HERMES_WEBUI_RUNTIME_ADAPTER=legacy-journal` is enabled.
- The adapter path currently wraps the legacy start result, then adds adapter-internal fields (`run_id`, `status`, `active_controls`) to the HTTP response when the legacy-direct path would not expose them.
- The frontend currently ignores those fields, so this is not a user-visible regression, but it weakens the seam invariant and creates a future contract trap.
- The narrow fix is to keep those fields inside `RunStartResult` while not adding them to the public chat-start response unless the legacy payload already contains them.

## What Changed

- Removed the adapter-path `response.setdefault(...)` calls for:
  - `run_id`
  - `status`
  - `active_controls`
- Kept the existing `stream_id` and `session_id` fallback fields so the adapter path still returns the same required fields as legacy-direct.
- Added a regression test that pins the adapter branch response-shape contract.
- Added an Unreleased changelog entry.

## Why It Matters

This keeps the default-off RuntimeAdapter seam invisible to `/api/chat/start` callers. Turning on `HERMES_WEBUI_RUNTIME_ADAPTER=legacy-journal` should not expose extra response fields just because the route used the adapter facade internally.

Fixes #2435. Refs #2424, #1925, #2416, and #2407.

## Verification

- First added failing regression:
  - `/Users/xuefusong/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_runtime_adapter_seam.py::test_chat_start_adapter_path_preserves_legacy_response_shape -q`
  - failed on the existing `run_id/status/active_controls` setdefault calls, as expected
- After the fix:
  - `/Users/xuefusong/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_runtime_adapter_seam.py -q` -> 6 passed
  - `/Users/xuefusong/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_turn_duration_display.py tests/test_empty_session_no_disk_write.py tests/test_sprint3.py -q` -> 42 passed
  - `/Users/xuefusong/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_regressions.py::test_chat_start_returns_stream_id tests/test_regressions.py::test_chat_start_persists_pending_turn_metadata_for_reload_recovery -q` -> 2 passed
  - `/Users/xuefusong/.hermes/hermes-agent/venv/bin/python -m py_compile api/routes.py api/runtime_adapter.py`
  - `git diff --check`

## Risks / Follow-ups

- This PR does not remove `run_id`, `status`, or `active_controls` from the adapter's internal `RunStartResult`; it only avoids adding them to the public HTTP response.
- If we later want these fields to become part of the stable `/api/chat/start` contract, that should be a separate explicit API change applied consistently to both legacy-direct and adapter paths.
- Does not address #2434, which is a separate journal-recovery ordering edge case.

## Model Used

AI-assisted using OpenAI GPT-5. Codex CLI was used for code editing, local tests, and GitHub workflow.
