### PR TITLE
Recover journal output after core transcript sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Recover already-journaled visible assistant text and tool cards even when restart repair first syncs a populated Hermes core transcript into an otherwise empty WebUI sidecar. The core-sync branch now merges non-duplicate run-journal output before clearing stale stream state, closing the rare #2427 carve-out where recoverable partial output could be silently skipped. Fixes #2434.
+
 ## [v0.51.82] — 2026-05-17 — Release BF (stage-375 — 2-PR batch — table renderer pipe protection + Catppuccin appearance skin)
 
 ### Added

--- a/api/models.py
+++ b/api/models.py
@@ -718,7 +718,76 @@ def _truncate_journal_tool_args(args, limit: int = 4) -> dict:
     return out
 
 
-def _append_journaled_partial_output(session, stream_id: str | None) -> bool:
+def _normalize_journal_recovery_text(value) -> str:
+    return " ".join(str(value or "").split())
+
+
+def _find_existing_assistant_for_journal_content(session, content: str) -> int | None:
+    candidate = _normalize_journal_recovery_text(content)
+    if not candidate:
+        return None
+    for idx, message in enumerate(session.messages or []):
+        if not isinstance(message, dict) or message.get('role') != 'assistant':
+            continue
+        if message.get('_error'):
+            continue
+        existing = _normalize_journal_recovery_text(message.get('content'))
+        if not existing:
+            continue
+        if existing == candidate:
+            return idx
+        if len(candidate) >= 24 and candidate in existing:
+            return idx
+    return None
+
+
+def _journal_tool_already_present(session, name: str, preview: str) -> bool:
+    candidate_name = str(name or '')
+    candidate_preview = _normalize_journal_recovery_text(preview)
+    for tool_call in session.tool_calls or []:
+        if not isinstance(tool_call, dict):
+            continue
+        if str(tool_call.get('name') or '') != candidate_name:
+            continue
+        existing_preview = _normalize_journal_recovery_text(
+            tool_call.get('preview') or tool_call.get('snippet') or ''
+        )
+        if existing_preview == candidate_preview:
+            return True
+    return False
+
+
+def _run_journal_has_visible_output(session, stream_id: str | None) -> bool:
+    if not stream_id:
+        return False
+    try:
+        from api.run_journal import read_run_events
+        journal = read_run_events(session.session_id, stream_id)
+    except Exception:
+        return False
+    for event in journal.get('events') or []:
+        if not isinstance(event, dict):
+            continue
+        event_name = str(event.get('event') or event.get('type') or '')
+        payload = event.get('payload') if isinstance(event.get('payload'), dict) else {}
+        if event_name == 'token' and str(payload.get('text') or ''):
+            return True
+        if event_name == 'interim_assistant':
+            if payload.get('already_streamed'):
+                continue
+            if str(payload.get('text') or '').strip():
+                return True
+        if event_name == 'tool':
+            return True
+    return False
+
+
+def _append_journaled_partial_output(
+    session,
+    stream_id: str | None,
+    *,
+    dedupe_existing: bool = False,
+) -> bool:
     """Recover already-emitted visible output from a dead stream journal.
 
     This repair path is intentionally conservative: it restores user-visible
@@ -757,6 +826,12 @@ def _append_journaled_partial_output(session, stream_id: str | None) -> bool:
         assistant_parts = []
         if not content:
             return current_assistant_idx
+        if dedupe_existing:
+            existing_idx = _find_existing_assistant_for_journal_content(session, content)
+            if existing_idx is not None:
+                current_assistant_idx = existing_idx
+                assistant_started_at = None
+                return existing_idx
         timestamp = int(assistant_started_at or time.time())
         session.messages.append({
             'role': 'assistant',
@@ -821,6 +896,9 @@ def _append_journaled_partial_output(session, stream_id: str | None) -> bool:
                 anchor_idx = ensure_assistant_anchor(created_at)
             name = str(payload.get('name') or 'tool')
             preview = str(payload.get('preview') or '')
+            if dedupe_existing and _journal_tool_already_present(session, name, preview):
+                current_assistant_idx = anchor_idx
+                continue
             recovered_tool_calls.append({
                 'name': name,
                 'preview': preview,
@@ -946,19 +1024,48 @@ def _apply_core_sync_or_error_marker(
             core = json.load(f)
         core_messages = core.get('messages', [])
         if core_messages:
+            _stream_id = stream_id_for_recheck or session.active_stream_id
             session.messages = core_messages
             session.tool_calls = core.get('tool_calls', [])
             for field in ('input_tokens', 'output_tokens', 'estimated_cost'):
                 if core.get(field) is not None:
                     setattr(session, field, core[field])
+            _pending_text = _normalize_journal_recovery_text(session.pending_user_message)
+            _already_checkpointed = False
+            if _pending_text and session.messages:
+                for _last_msg in reversed(session.messages):
+                    if isinstance(_last_msg, dict) and _last_msg.get('role') == 'user':
+                        _last_text = _normalize_journal_recovery_text(_last_msg.get('content'))
+                        _already_checkpointed = _last_text == _pending_text
+                        break
+            if (
+                _pending_text
+                and not _already_checkpointed
+                and _run_journal_has_visible_output(session, _stream_id)
+            ):
+                _recovered_ts = int(time.time())
+                if isinstance(session.pending_started_at, (int, float)) and session.pending_started_at > 0:
+                    _recovered_ts = int(session.pending_started_at)
+                _append_recovered_pending_turn(session, timestamp=_recovered_ts)
+            recovered_output = _append_journaled_partial_output(
+                session,
+                _stream_id,
+                dedupe_existing=True,
+            )
             session.active_stream_id = None
             session.pending_user_message = None
             session.pending_attachments = []
             session.pending_started_at = None
+            if recovered_output:
+                session.messages.append(
+                    _interrupted_recovery_marker(recovered_output=True)
+                )
             session.save(touch_updated_at=touch_updated_at)
             logger.info(
-                "Session %s: synced %d messages from core transcript",
-                sid, len(core_messages),
+                "Session %s: synced %d messages from core transcript%s",
+                sid,
+                len(core_messages),
+                " and recovered journaled output" if recovered_output else "",
             )
             return True
 

--- a/tests/test_session_sidecar_repair.py
+++ b/tests/test_session_sidecar_repair.py
@@ -741,6 +741,134 @@ class TestNonEmptyMessagesPendingCleared:
         assert len(s.tool_calls) == 2
         assert s.tool_calls[0]["assistant_msg_idx"] == s.tool_calls[1]["assistant_msg_idx"]
 
+    def test_core_sync_branch_recovers_visible_journal_output(self, hermes_home, monkeypatch):
+        """The empty-sidecar + populated-core repair branch should still restore
+        already-journaled visible output from the interrupted stream."""
+        s = _make_session(messages=[])
+        s.pending_user_message = "Check maintainer activity"
+        s.pending_started_at = time.time() - 120
+        s.active_stream_id = "core_journal_stream"
+        s.save()
+
+        core_messages = [
+            {"role": "user", "content": "Earlier question"},
+            {"role": "assistant", "content": "Earlier answer"},
+        ]
+        core_path = _write_core_transcript(hermes_home, s.session_id, core_messages)
+
+        append_run_event(
+            s.session_id,
+            "core_journal_stream",
+            "token",
+            {"text": "I will check GitHub first."},
+        )
+        append_run_event(
+            s.session_id,
+            "core_journal_stream",
+            "tool",
+            {
+                "name": "terminal",
+                "preview": "gh pr list --repo nesquena/hermes-webui",
+                "args": {"command": "gh pr list --repo nesquena/hermes-webui"},
+            },
+        )
+        append_run_event(
+            s.session_id,
+            "core_journal_stream",
+            "tool_complete",
+            {"name": "terminal", "duration": 1.2, "is_error": False},
+        )
+        append_run_event(
+            s.session_id,
+            "core_journal_stream",
+            "token",
+            {"text": "The first check finished before the restart."},
+        )
+
+        result = _apply_core_sync_or_error_marker(
+            s,
+            core_path,
+            stream_id_for_recheck="core_journal_stream",
+        )
+
+        assert result is True
+        contents = [m.get("content", "") for m in s.messages]
+        assert contents[:2] == [m["content"] for m in core_messages]
+        recovered_users = [m for m in s.messages if m.get("_recovered")]
+        assert len(recovered_users) == 1
+        assert recovered_users[0]["role"] == "user"
+        assert recovered_users[0]["content"] == "Check maintainer activity"
+        assert any("I will check GitHub first." in c for c in contents)
+        assert any("The first check finished before the restart." in c for c in contents)
+        assert s.tool_calls, "journaled tool starts should become visible settled tool cards"
+        assert s.tool_calls[0]["name"] == "terminal"
+        error_msgs = [m for m in s.messages if m.get("_error")]
+        assert len(error_msgs) == 1
+        assert "partial output above was recovered" in error_msgs[0]["content"]
+        assert s.pending_user_message is None
+        assert s.active_stream_id is None
+
+    def test_core_sync_branch_does_not_duplicate_journal_output_already_in_core(
+        self, hermes_home, monkeypatch
+    ):
+        """If the core transcript already contains the same visible output, the
+        journal repair must not append a second copy."""
+        s = _make_session(messages=[])
+        s.pending_user_message = "Check maintainer activity"
+        s.pending_started_at = time.time() - 120
+        s.active_stream_id = "duplicate_core_journal_stream"
+        s.save()
+
+        core_messages = [
+            {"role": "user", "content": "Check maintainer activity"},
+            {"role": "assistant", "content": "I will check GitHub first."},
+        ]
+        core_tool_calls = [
+            {
+                "name": "terminal",
+                "preview": "gh pr list --repo nesquena/hermes-webui",
+                "snippet": "gh pr list --repo nesquena/hermes-webui",
+                "assistant_msg_idx": 1,
+                "done": True,
+            },
+        ]
+        core_path = _write_core_transcript(
+            hermes_home,
+            s.session_id,
+            core_messages,
+            tool_calls=core_tool_calls,
+        )
+
+        append_run_event(
+            s.session_id,
+            "duplicate_core_journal_stream",
+            "token",
+            {"text": "I will check GitHub first."},
+        )
+        append_run_event(
+            s.session_id,
+            "duplicate_core_journal_stream",
+            "tool",
+            {
+                "name": "terminal",
+                "preview": "gh pr list --repo nesquena/hermes-webui",
+                "args": {"command": "gh pr list --repo nesquena/hermes-webui"},
+            },
+        )
+
+        result = _apply_core_sync_or_error_marker(
+            s,
+            core_path,
+            stream_id_for_recheck="duplicate_core_journal_stream",
+        )
+
+        assert result is True
+        contents = [m.get("content", "") for m in s.messages]
+        assert contents.count("I will check GitHub first.") == 1
+        assert len(s.tool_calls) == 1
+        assert s.tool_calls[0]["name"] == "terminal"
+        assert not [m for m in s.messages if m.get("_error")]
+
 
 class TestLastResortSyncDelegation:
     """_last_resort_sync_from_core delegates to the shared helpers


### PR DESCRIPTION
## Thinking Path

- #2427 restored already-journaled visible assistant text and tool cards when a WebUI restart interrupts an in-flight browser-originated turn.
- #2434 identified a remaining carve-out: when the WebUI sidecar has no messages but the Hermes core transcript is populated, `_apply_core_sync_or_error_marker` syncs core messages and returns before journal recovery runs.
- Owner follow-up on #2434 clarified the sharper case: core may contain only the last completed turn, while `pending_user_message` and the active stream journal belong to the interrupted next turn.
- The fix should preserve core as the source of truth, recover the pending user turn only when the active stream journal has visible output, then merge non-duplicate visible journal output without changing the already-working non-core recovery paths.

## What Changed

- In the populated-core repair branch, capture the active stream id, load core messages/tool calls, then check whether that stream's run journal has visible output.
- If the active journal has visible output and the pending user text is not already the latest user turn in the core transcript, materialize the pending user turn before replaying journal output.
- Run `_append_journaled_partial_output(...)` before clearing stale stream state.
- Add a narrow `dedupe_existing=True` mode for the core-sync branch only, so journal text/tool cards already represented in the core transcript are not appended twice.
- Append the recovered-output interrupted marker only when the journal actually contributes visible output in this branch.
- Add regression coverage for:
  - empty sidecar + populated core + pending user + run journal with visible token/tool output;
  - the negative duplicate case where core already has the same assistant text/tool card;
  - existing core-sync behavior without a visible journal, via the existing sidecar repair tests.
- Add a release-note-ready changelog entry.

## Why It Matters

This closes the #2427 recovery gap called out in #2434. After a WebUI process restart, users should not lose visible progress that had already been journaled just because the repair path first found a populated Hermes core transcript.

The implementation is intentionally conservative: it does not recover hidden reasoning, does not attempt to continue the dead worker process, and keeps dedupe limited to the core-sync branch so existing #2427 behavior is not broadened unnecessarily.

Fixes #2434.
Refs #2427 and #2423.

## Verification

- RED first: `test_core_sync_branch_recovers_visible_journal_output` failed on current `origin/master` because the core-sync branch returned before journal recovery.
- After owner follow-up, tightened the same regression so the core transcript does not already contain `pending_user_message`; it failed until the pending-user recovery condition was added.
- `uv run --python /opt/homebrew/bin/python3.12 --with-requirements requirements.txt --with pytest --with pytest-timeout pytest tests/test_session_sidecar_repair.py tests/test_run_journal.py tests/test_runtime_adapter_seam.py tests/test_regressions.py::test_chat_start_persists_pending_turn_metadata_for_reload_recovery -q` -> 52 passed.
- `uv run --python /opt/homebrew/bin/python3.12 --with-requirements requirements.txt --with pytest --with pytest-timeout python -m py_compile api/models.py` -> passed.
- `git diff --check` -> passed.

## Risks / Follow-ups

- The dedupe check is content/preview based, not a durable journal cursor. That is enough for this narrow repair branch, but a future RuntimeAdapter/run-journal owner model should prefer an explicit persisted cursor such as `last_persisted_event_id`.
- This PR does not change execution ownership and does not attempt to resume a killed WebUI worker process.

## Model Used

AI-assisted with OpenAI GPT-5 in Codex, using local shell/git/pytest workflows.