### PR TITLE
fix: reuse compact live thinking card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Compact live Thinking cards now reuse the same timeline card across sequential tool calls, preventing repeated Thinking cards from stacking during one multi-tool turn.
+
 ## [v0.51.82] — 2026-05-17 — Release BF (stage-375 — 2-PR batch — table renderer pipe protection + Catppuccin appearance skin)
 
 ### Added

--- a/static/ui.js
+++ b/static/ui.js
@@ -7040,7 +7040,7 @@ function finalizeThinkingCard(){
       const summary=group.querySelector('.tool-call-group-summary');
       if(summary) summary.setAttribute('aria-expanded','false');
     }
-    const active=group.querySelector('.agent-activity-thinking[data-thinking-active="1"]');
+    const active=turn.querySelector('.agent-activity-thinking[data-thinking-active="1"]');
     if(active) active.removeAttribute('data-thinking-active');
     _syncToolCallGroupSummary(group);
   }
@@ -7095,6 +7095,11 @@ function appendThinking(text='', options){
   }
   const thinkingText=String(text||'').trim()||'Thinking…';
   let row=blocks.querySelector('.agent-activity-thinking[data-thinking-active="1"]');
+  if(!row){
+    const thinkingCards=Array.from(blocks.querySelectorAll('.agent-activity-thinking'));
+    row=thinkingCards.filter(el=>el.closest('.assistant-turn-blocks')===blocks).pop()||null;
+    if(row) row.setAttribute('data-thinking-active','1');
+  }
   if(!row){
     row=_thinkingActivityNode(thinkingText, false);
     row.setAttribute('data-thinking-active','1');

--- a/tests/test_ui_tool_call_cleanup.py
+++ b/tests/test_ui_tool_call_cleanup.py
@@ -307,6 +307,13 @@ class TestToolCallGroupingStatic:
         assert "body.querySelector" in live_tool_fn and "data-live-tid" in live_tool_fn, (
             "tool_complete must still update its current live Activity burst by tool id."
         )
+        finalize_fn = _function_body(UI_JS, "finalizeThinkingCard")
+        assert "turn.querySelector('.agent-activity-thinking[data-thinking-active=\"1\"]')" in finalize_fn, (
+            "Compact Thinking cards live directly in assistant-turn blocks, so finalization must clear the active marker from the whole turn, not only the tool group."
+        )
+        assert "thinkingCards.filter" in live_thinking_fn and "setAttribute('data-thinking-active','1')" in live_thinking_fn, (
+            "Compact live thinking should reactivate the latest existing Thinking card instead of stacking a new card after every tool boundary."
+        )
         close_activity_fn = _function_body(MESSAGES_JS, "_closeCurrentLiveActivityGroup")
         assert "data-live-activity-current" in close_activity_fn, (
             "Visible interim assistant boundaries should close the previous live Activity burst."


### PR DESCRIPTION
## Thinking Path
Issue #2440 points to a compact-tooling live-stream DOM mismatch: compact Thinking cards are rendered directly under the assistant turn blocks, while finalization only cleared the active marker from inside the live tool group. That lets later reasoning/tool boundaries create or preserve extra Thinking cards during one turn.

## What Changed
- Clear the compact Thinking `data-thinking-active` marker by searching the whole live assistant turn instead of only the tool group.
- When a compact Thinking update resumes without an active marker, reactivate and reuse the latest existing Thinking card in the current assistant turn blocks before creating a new card.
- Added source-level regression coverage for both invariants.
- Added an Unreleased changelog note.

## Why It Matters
A single multi-tool assistant turn should keep one live Thinking card updated instead of stacking repeated Thinking cards as reasoning resumes between tool calls.

## Verification
- `env -u HERMES_CONFIG_PATH -u HERMES_WEBUI_HOST /home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_ui_tool_call_cleanup.py -q` — 21 passed
- `env -u HERMES_CONFIG_PATH -u HERMES_WEBUI_HOST /home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_ui_tool_call_cleanup.py tests/test_streaming_race_fix.py tests/test_issue1298_cancel_and_activity.py -q` — 43 passed
- `node --check static/ui.js`
- `node --check static/messages.js`
- `git diff --check`

## Risks / Follow-ups
- This keeps the existing compact Thinking placement unchanged; it only makes active-marker cleanup and reuse match that placement.
- No browser screenshot attached because this is a streaming-state DOM lifecycle fix and is covered with source-level regression checks.

Closes #2440

## Model Used
AI-assisted change with repository inspection, targeted editing, and shell-based test verification.
