### PR TITLE
fix: invalidate model cache on catalog changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **PR #2445** by @Michaelyklam (fixes #2443) — `/api/models` now fingerprints model-catalog inputs as part of its persisted cache metadata, so server-side catalog additions and Codex local catalog changes invalidate `models_cache.json` immediately instead of waiting for the 24-hour TTL or manual cache deletion.
+
 ## [v0.51.82] — 2026-05-17 — Release BF (stage-375 — 2-PR batch — table renderer pipe protection + Catppuccin appearance skin)
 
 ### Added

--- a/api/config.py
+++ b/api/config.py
@@ -11,6 +11,7 @@ Discovery order for all paths:
 
 import collections
 import copy
+import hashlib
 import json
 import logging
 import os
@@ -2205,11 +2206,45 @@ def _models_cache_file_fingerprint(path: Path) -> dict:
     return fingerprint
 
 
+def _models_cache_catalog_fingerprint() -> dict:
+    """Return non-secret model-catalog identity metadata for cache invalidation.
+
+    The /api/models payload is not only a function of user config/auth files.
+    It also depends on the provider/model catalog baked into this module and on
+    small local catalogs such as Codex's models_cache.json. Keep this cheap and
+    deterministic so a server restart after catalog changes does not keep
+    serving an otherwise-valid persisted models_cache.json until the 24h TTL
+    expires (#2443).
+    """
+    catalog_payload = {
+        "provider_models": _PROVIDER_MODELS,
+        "provider_display": _PROVIDER_DISPLAY,
+    }
+    try:
+        encoded = json.dumps(
+            catalog_payload,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+            default=str,
+        ).encode("utf-8")
+        provider_catalog_sha = hashlib.sha256(encoded).hexdigest()
+    except Exception:
+        provider_catalog_sha = "unavailable"
+
+    codex_home = Path(os.getenv("CODEX_HOME", "").strip() or (HOME / ".codex")).expanduser()
+    return {
+        "provider_catalog_sha256": provider_catalog_sha,
+        "codex_models_cache": _models_cache_file_fingerprint(codex_home / "models_cache.json"),
+    }
+
+
 def _models_cache_source_fingerprint() -> dict:
-    """Return the current config/auth-store fingerprint for /api/models cache."""
+    """Return the current config/auth/catalog fingerprint for /api/models cache."""
     return {
         "config_yaml": _models_cache_file_fingerprint(_get_config_path()),
         "auth_json": _models_cache_file_fingerprint(_get_auth_store_path()),
+        "catalog": _models_cache_catalog_fingerprint(),
     }
 
 

--- a/tests/test_issue1699_model_cache_source_fingerprint.py
+++ b/tests/test_issue1699_model_cache_source_fingerprint.py
@@ -142,3 +142,39 @@ def test_disk_models_cache_still_loads_when_auth_and_config_sources_are_unchange
     result = config.get_available_models()
 
     assert result == fresh_opencode
+
+
+def test_memory_models_cache_invalidates_when_static_catalog_changes(tmp_path, monkeypatch):
+    _configure_isolated_sources(tmp_path, monkeypatch, "opencode-go")
+    stale_opencode = _valid_models_cache("opencode-go", "glm-5.1")
+    with config._available_models_cache_lock:
+        config._available_models_cache = stale_opencode
+        config._available_models_cache_ts = time.monotonic()
+        config._available_models_cache_source_fingerprint = config._models_cache_source_fingerprint()
+
+    updated_models = list(config._PROVIDER_MODELS["opencode-go"])
+    updated_models.append({"id": "new-catalog-model", "label": "New Catalog Model"})
+    monkeypatch.setitem(config._PROVIDER_MODELS, "opencode-go", updated_models)
+
+    result = config.get_available_models()
+
+    opencode_group = next(g for g in result["groups"] if g.get("provider_id") == "opencode-go")
+    assert any(m.get("id") == "new-catalog-model" for m in opencode_group["models"])
+
+
+def test_disk_models_cache_invalidates_when_static_catalog_changes(tmp_path, monkeypatch):
+    _configure_isolated_sources(tmp_path, monkeypatch, "opencode-go")
+    stale_opencode = _valid_models_cache("opencode-go", "glm-5.1")
+    config._save_models_cache_to_disk(stale_opencode)
+    assert config._models_cache_path.exists()
+
+    updated_models = list(config._PROVIDER_MODELS["opencode-go"])
+    updated_models.append({"id": "new-disk-catalog-model", "label": "New Disk Catalog Model"})
+    monkeypatch.setitem(config._PROVIDER_MODELS, "opencode-go", updated_models)
+    _reset_memory_cache()
+
+    result = config.get_available_models()
+
+    assert result != stale_opencode
+    opencode_group = next(g for g in result["groups"] if g.get("provider_id") == "opencode-go")
+    assert any(m.get("id") == "new-disk-catalog-model" for m in opencode_group["models"])


### PR DESCRIPTION
## Thinking Path

- #2443 reports a concrete `/api/models` freshness bug: after model-catalog inputs change and the server restarts, the persisted `models_cache.json` can still look valid until the 24-hour TTL expires.
- The existing cache fingerprint covered config/auth source files, but not the catalog data that also shapes the model picker response.
- The narrow fix is to add a non-secret catalog fingerprint to the existing source fingerprint, so both in-memory and disk caches reject stale catalog-shaped payloads before serving them.

## What Changed

- Added `_models_cache_catalog_fingerprint()` to hash the static provider/model catalog and provider display metadata.
- Included Codex's local `models_cache.json` file identity in the catalog fingerprint, matching the existing file-metadata-only approach used for config/auth sources.
- Added the catalog fingerprint to `_models_cache_source_fingerprint()` so memory and disk cache validation share the same invalidation signal.
- Added regression coverage for both in-memory and persisted disk cache invalidation when the static catalog changes.
- Added an Unreleased changelog entry.

## Why It Matters

Model-picker cache freshness should follow the server's current source of truth. After a catalog update or Codex local catalog refresh, users should see the new model list on the next `/api/models` response instead of deleting cache files manually or waiting for the TTL.

Fixes #2443.
Refs #2361.

## Verification

- `env -u HERMES_CONFIG_PATH -u HERMES_WEBUI_HOST /home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_issue1699_model_cache_source_fingerprint.py -q` -> 5 passed
- `env -u HERMES_CONFIG_PATH -u HERMES_WEBUI_HOST /home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_model_cache_metadata.py tests/test_issue1699_model_cache_source_fingerprint.py -q` -> 11 passed
- `env -u HERMES_CONFIG_PATH -u HERMES_WEBUI_HOST /home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_ttl_cache.py tests/test_model_cache_metadata.py tests/test_issue1699_model_cache_source_fingerprint.py -q` -> 16 passed
- `/home/michael/.hermes/hermes-agent/venv/bin/python -m py_compile api/config.py` -> passed
- `git diff --check` -> passed

## Risks / Follow-ups

- The fingerprint stores only non-secret identity/hash metadata, not catalog contents from user secrets.
- This does not shorten the normal provider live-fetch TTL by itself; it only rejects stale caches when source inputs change.
- #2361 remains the broader run-state consistency tracker.

## Model Used

AI-assisted change with repository inspection, targeted editing, and shell-based test verification.
