### PR TITLE
Invalidate model cache when catalog sources change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Invalidate the persisted `/api/models` cache when the bundled provider/model catalog changes, so same-version local builds or hotfix deployments do not keep serving stale model-picker options until the 24-hour cache TTL expires.
+
 ## [v0.51.82] — 2026-05-17 — Release BF (stage-375 — 2-PR batch — table renderer pipe protection + Catppuccin appearance skin)
 
 ### Added

--- a/api/config.py
+++ b/api/config.py
@@ -2205,11 +2205,55 @@ def _models_cache_file_fingerprint(path: Path) -> dict:
     return fingerprint
 
 
+def _models_cache_static_catalog_fingerprint() -> dict:
+    """Return non-secret static catalog metadata that shapes /api/models.
+
+    The disk cache already follows external inputs such as config.yaml and
+    auth.json.  Same-version development builds and hotfix deployments can also
+    change the bundled provider catalog in this module; include only public
+    model ids, labels, provider display names, and aliases so those source
+    changes invalidate persisted picker data without exposing credentials.
+    """
+
+    def _model_entry_fingerprint(entry: object) -> dict:
+        if isinstance(entry, dict):
+            payload = {
+                "id": str(entry.get("id") or ""),
+                "label": str(entry.get("label") or ""),
+            }
+            provider = entry.get("provider")
+            if provider:
+                payload["provider"] = str(provider)
+            return payload
+        return {"id": str(entry), "label": str(entry)}
+
+    provider_models: dict[str, list[dict]] = {}
+    for provider_id, models in sorted(_PROVIDER_MODELS.items()):
+        entries = models if isinstance(models, list) else []
+        provider_models[str(provider_id)] = [
+            _model_entry_fingerprint(entry)
+            for entry in entries
+        ]
+
+    return {
+        "provider_aliases": {
+            str(key): str(value)
+            for key, value in sorted(_PROVIDER_ALIASES.items())
+        },
+        "provider_display": {
+            str(key): str(value)
+            for key, value in sorted(_PROVIDER_DISPLAY.items())
+        },
+        "provider_models": provider_models,
+    }
+
+
 def _models_cache_source_fingerprint() -> dict:
-    """Return the current config/auth-store fingerprint for /api/models cache."""
+    """Return current inputs that determine the persisted /api/models cache."""
     return {
         "config_yaml": _models_cache_file_fingerprint(_get_config_path()),
         "auth_json": _models_cache_file_fingerprint(_get_auth_store_path()),
+        "static_catalog": _models_cache_static_catalog_fingerprint(),
     }
 
 

--- a/tests/test_issue1699_model_cache_source_fingerprint.py
+++ b/tests/test_issue1699_model_cache_source_fingerprint.py
@@ -6,6 +6,7 @@ provider outside WebUI, the browser can keep seeing the previous provider's
 PRIMARY badge until the cache is manually cleared or expires.
 """
 
+import copy
 import json
 import sys
 import time
@@ -142,3 +143,43 @@ def test_disk_models_cache_still_loads_when_auth_and_config_sources_are_unchange
     result = config.get_available_models()
 
     assert result == fresh_opencode
+
+
+def test_disk_models_cache_invalidates_when_static_model_catalog_changes(
+    tmp_path, monkeypatch
+):
+    _configure_isolated_sources(tmp_path, monkeypatch, "opencode-go")
+    fresh_opencode = _valid_models_cache("opencode-go", "glm-5.1")
+    config._save_models_cache_to_disk(fresh_opencode)
+
+    assert config._load_models_cache_from_disk() == fresh_opencode
+
+    updated_catalog = copy.deepcopy(config._PROVIDER_MODELS)
+    updated_catalog.setdefault("opencode-go", []).append(
+        {"id": "glm-5.1-new", "label": "GLM-5.1 New"}
+    )
+    monkeypatch.setattr(config, "_PROVIDER_MODELS", updated_catalog)
+
+    assert config._load_models_cache_from_disk() is None
+
+
+def test_memory_models_cache_invalidates_when_static_model_catalog_changes(
+    tmp_path, monkeypatch
+):
+    _configure_isolated_sources(tmp_path, monkeypatch, "opencode-go")
+    fresh_opencode = _valid_models_cache("opencode-go", "glm-5.1")
+
+    with config._available_models_cache_lock:
+        config._available_models_cache = fresh_opencode
+        config._available_models_cache_ts = time.monotonic()
+        config._available_models_cache_source_fingerprint = (
+            config._models_cache_source_fingerprint()
+        )
+
+    updated_catalog = copy.deepcopy(config._PROVIDER_MODELS)
+    updated_catalog.setdefault("opencode-go", []).append(
+        {"id": "glm-5.1-new", "label": "GLM-5.1 New"}
+    )
+    monkeypatch.setattr(config, "_PROVIDER_MODELS", updated_catalog)
+
+    assert config._get_fresh_memory_models_cache(time.monotonic()) is None


### PR DESCRIPTION
## Thinking Path

- #2443 tracks a concrete state-divergence case from #2361: `/api/models` can keep using a persisted `models_cache.json` after the bundled provider/model catalog changes.
- Existing cache metadata already follows external user inputs (`config.yaml`, `auth.json`) and the WebUI release version.
- That is enough for ordinary versioned releases, but not for same-version local builds, hotfix deployments, or development branches where `api/config.py` changes without a version bump.
- The correct layer is the server-side `/api/models` cache fingerprint, not the frontend selector and not the runtime-adapter execution layer.

## What Changed

- Added a non-secret static catalog fingerprint to the model-cache source metadata.
- The fingerprint includes public provider aliases, provider display names, and bundled provider/model ids and labels.
- Persisted and in-memory `/api/models` caches now invalidate when that static catalog changes.
- Added regression coverage for both disk-cache and memory-cache invalidation when `_PROVIDER_MODELS` changes.
- Added a changelog entry.

## Why It Matters

Users should not have to delete `~/.hermes/webui/models_cache.json` or wait up to 24 hours after a catalog update before a new bundled model appears in the picker.

This is a narrow sibling to #2444: #2444 refreshes selected-session context metadata after session/model changes; this PR refreshes model-picker cache data after catalog/source changes. They address different cache-coherence paths under the broader #2361 consistency theme.

Fixes #2443.
Refs #2361.

## Verification

- `pytest tests/test_issue1699_model_cache_source_fingerprint.py -q`
  - `5 passed`
- `pytest tests/test_issue1699_model_cache_source_fingerprint.py tests/test_ttl_cache.py tests/test_issue1680_codex_spark.py -q`
  - `11 passed, 1 skipped`
- `python -m py_compile api/config.py`
- `git diff --check`

## Risks / Follow-ups

- This intentionally invalidates cache only when public catalog-shaped inputs change. It does not change live provider fetching, model routing, or frontend rendering.
- The fingerprint is larger than before, but it is computed in-process from small static tables and compared as metadata during cache validation.
- It does not expose secrets: config/auth files are still represented only by path/mtime/size, and the new static catalog fields are public model/provider metadata already shipped in source.

## Model Used

OpenAI GPT-5 via Codex.
