### PR TITLE
feat(ui): add copy button to thinking cards

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -3057,7 +3057,12 @@ main.main.showing-logs > #mainLogs{display:flex;}
    Only sub-element selectors that the consolidated block doesn't cover
    (label, toggle, rotate animation) are kept here. ── */
 .thinking-card-label{font-weight:600;letter-spacing:.02em;}
-.thinking-card-toggle{margin-left:auto;font-size:10px;display:inline-flex;align-items:center;justify-content:center;transform-origin:center;transition:transform .18s ease;will-change:transform;}
+.thinking-card-header{display:flex;align-items:center;gap:6px;padding:8px 12px;cursor:pointer;user-select:none;}
+.thinking-card-btn-row{display:inline-flex;align-items:center;gap:2px;margin-left:auto;}
+.thinking-copy-btn{display:inline-flex;align-items:center;justify-content:center;width:24px;height:24px;border:none;background:transparent;color:var(--muted);border-radius:4px;cursor:pointer;opacity:0.5;transition:opacity .15s,color .15s;}
+.thinking-card-header:hover .thinking-copy-btn{opacity:1;}
+.thinking-copy-btn:hover{opacity:1;color:var(--accent);background:rgba(128,128,128,0.1);}
+.thinking-card-toggle{margin-left:0;font-size:10px;display:inline-flex;align-items:center;justify-content:center;transform-origin:center;transition:transform .18s ease;will-change:transform;}
 .thinking-card.open .thinking-card-toggle{transform:rotate(90deg);}
 
 .bg-error-banner{background:rgba(229,62,62,.15);border:1px solid rgba(229,62,62,.3);color:#fca5a5;padding:8px 16px;font-size:12px;display:flex;align-items:center;justify-content:space-between;gap:12px;border-radius:0;}

--- a/static/ui.js
+++ b/static/ui.js
@@ -4732,9 +4732,9 @@ function _assistantTurnBlocks(turn){
 }
 function _thinkingCardHtml(text, open){
   const clean=_sanitizeThinkingDisplayText(text);
-  return open
-    ? `<div class="thinking-card open"><div class="thinking-card-header" onclick="this.parentElement.classList.toggle('open')"><span class="thinking-card-icon">${li('lightbulb',14)}</span><span class="thinking-card-label">${t('thinking')}</span><span class="thinking-card-toggle">${li('chevron-right',12)}</span></div><div class="thinking-card-body"><pre>${esc(clean)}</pre></div></div>`
-    : `<div class="thinking-card"><div class="thinking-card-header" onclick="this.parentElement.classList.toggle('open')"><span class="thinking-card-icon">${li('lightbulb',14)}</span><span class="thinking-card-label">${t('thinking')}</span><span class="thinking-card-toggle">${li('chevron-right',12)}</span></div><div class="thinking-card-body"><pre>${esc(clean)}</pre></div></div>`;
+  const copyBtn=`<button class="thinking-copy-btn" onclick="event.stopPropagation();_copyThinkingText(this)" title="${t('copy')}">${li('copy',12)}</button>`;
+  const base=`<div class="thinking-card${open?' open':''}"><div class="thinking-card-header" onclick="this.parentElement.classList.toggle('open')"><span class="thinking-card-icon">${li('lightbulb',14)}</span><span class="thinking-card-label">${t('thinking')}</span><span class="thinking-card-btn-row">${copyBtn}<span class="thinking-card-toggle">${li('chevron-right',12)}</span></span></div><div class="thinking-card-body"><pre>${esc(clean)}</pre></div></div>`;
+  return base;
 }
 function isSimplifiedToolCalling(){
   return window._simplifiedToolCalling!==false;
@@ -7906,4 +7906,16 @@ async function uploadPendingFiles(){
   const extracted=names.filter(n=>n.extracted);
   if(extracted.length)showToast(t('archive_extracted',extracted.reduce((s,n)=>s+n.extracted,0),extracted.length));
   return names;
+}
+
+// ── Thinking-card copy button ──
+function _copyThinkingText(btn){
+  const card=btn.closest('.thinking-card');
+  if(!card)return;
+  const pre=card.querySelector('.thinking-card-body pre');
+  if(!pre||!pre.textContent)return;
+  _copyText(pre.textContent).then(()=>{
+    const orig=btn.innerHTML;btn.innerHTML=li('check',12);btn.style.color='var(--accent)';
+    setTimeout(()=>{btn.innerHTML=orig;btn.style.color='';},1500);
+  }).catch(()=>showToast(t('copy_failed')));
 }


### PR DESCRIPTION
## Copy button for thinking cards

Having to manually select text from thinking cards to copy it is tedious. Especially when the model drops a long reasoning block and you just want to paste it somewhere else. A copy button in the header saves the hassle.

**Expected behavior:**

Copy button next to the chevron in the card header. Clicking it copies the `<pre>` content to clipboard. It does not collapse the card when clicked. Shows a checkmark for 1.5s as feedback, same pattern as `copyMsg`.

**Implementation:**

`static/ui.js` -- Modify `_thinkingCardHtml` (~line 4733):

```
function _thinkingCardHtml(text, open){
  const clean=_sanitizeThinkingDisplayText(text);
  const copyBtn=`<button class="thinking-copy-btn" onclick="event.stopPropagation();_copyThinkingText(this)" title="${t('copy')}">${li('copy',12)}</button>`;
  const base=`<div class="thinking-card${open?' open':''}"><div class="thinking-card-header" onclick="this.parentElement.classList.toggle('open')"><span class="thinking-card-icon">${li('lightbulb',14)}</span><span class="thinking-card-label">${t('thinking')}</span><span class="thinking-card-btn-row">${copyBtn}<span class="thinking-card-toggle">${li('chevron-right',12)}</span></span></div><div class="thinking-card-body"><pre>${esc(clean)}</pre></div></div>`;
  return base;
}
```

`static/ui.js` -- New function at end of file (uses `_copyText()` already existing ~line 3646):

```
function _copyThinkingText(btn){
  const card=btn.closest('.thinking-card');
  if(!card)return;
  const pre=card.querySelector('.thinking-card-body pre');
  if(!pre||!pre.textContent)return;
  _copyText(pre.textContent).then(()=>{
    const orig=btn.innerHTML;btn.innerHTML=li('check',12);btn.style.color='var(--accent)';
    setTimeout(()=>{btn.innerHTML=orig;btn.style.color='';},1500);
  }).catch(()=>showToast(t('copy_failed')));
}
```

`static/style.css` -- New styles at ~line 3060:

```
.thinking-card-header{display:flex;align-items:center;gap:6px;padding:8px 12px;cursor:pointer;user-select:none;}
.thinking-card-btn-row{display:inline-flex;align-items:center;gap:2px;margin-left:auto;}
.thinking-copy-btn{display:inline-flex;align-items:center;justify-content:center;width:24px;height:24px;border:none;background:transparent;color:var(--muted);border-radius:4px;cursor:pointer;opacity:0.5;transition:opacity .15s,color .15s;}
.thinking-card-header:hover .thinking-copy-btn{opacity:1;}
.thinking-copy-btn:hover{opacity:1;color:var(--accent);background:rgba(128,128,128,0.1);}
.thinking-card-toggle{margin-left:0;}
```

**Notes:**

- Inline onclick is not ideal, but the project uses them everywhere. The header toggle does the same.
- `_sanitizeThinkingDisplayText()` strips control characters. `esc()` escapes HTML. Two different things, both needed.
- The feedback pattern (innerHTML + setTimeout) is copied straight from `copyMsg()`. Keeps it consistent.
- The Sienna skin has its own `.thinking-card-header` at line 3388. Same layout, different gap/padding/color. Something to check when merging.
- Optional: adding `:focus` to `.thinking-copy-btn` would help keyboard navigation.
- Edge case: `pre.textContent` with whitespace only passes the check. Adding `.trim()` is cheap.


![Screenshot_2026-05-17-09-07-27-921_com.android.chrome.jpg](https://github.com/user-attachments/assets/89d68d8e-6983-4e8f-afac-5f2186af9a9e)







