### PR TITLE
fix: cap stream fade done drain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **PR #2450** by @Michaelyklam (fixes #2447) — Cap the optional streaming word-fade drain after the final `done` SSE event so very large or bursty completed responses are rendered from the canonical session promptly instead of keeping the chat in a live/working state until Stop is pressed.
+
 ## [v0.51.82] — 2026-05-17 — Release BF (stage-375 — 2-PR batch — table renderer pipe protection + Catppuccin appearance skin)
 
 ### Added

--- a/static/messages.js
+++ b/static/messages.js
@@ -697,6 +697,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
   const _STREAM_FADE_MAX_MS=350;
   const _STREAM_FADE_STAGGER_MS=16;
   const _STREAM_FADE_DONE_MAX_MS=320;
+  const _STREAM_FADE_DONE_DRAIN_MAX_MS=900;
   const _streamFadeEnabledForStream=window._fadeTextEffect===true;
 
   // rAF-throttled rendering: buffer tokens, render at most once per frame
@@ -1086,6 +1087,8 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       : _stripXmlToolCalls(assistantText.slice(segmentStart));
   }
   function _drainStreamFadeBeforeDone(onDone){
+    const drainStartedAt=performance.now();
+    let forcedDone=false;
     const step=()=>{
       if(!assistantBody){onDone();return;}
       const target=_streamFadeCurrentDisplayText();
@@ -1099,6 +1102,15 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         // the final renderMessages() DOM replacement removes the live spans.
         const remainingAnimationMs=Math.max(_STREAM_FADE_MS, _streamFadeLatestAnimationEndAt-performance.now());
         setTimeout(onDone, Math.min(remainingAnimationMs, _STREAM_FADE_DONE_MAX_MS));
+        return;
+      }
+      // Final SSE `done` means the canonical completed session is available.
+      // The optional word-fade playout must not keep that completed answer
+      // hidden behind the live Thinking state for large/bursty responses.
+      if(!forcedDone&&performance.now()-drainStartedAt>=_STREAM_FADE_DONE_DRAIN_MAX_MS){
+        forcedDone=true;
+        if(_smdParser) _smdEndParser();
+        onDone();
         return;
       }
       setTimeout(()=>requestAnimationFrame(step), 33);

--- a/tests/test_smooth_text_fade.py
+++ b/tests/test_smooth_text_fade.py
@@ -82,6 +82,7 @@ const _STREAM_FADE_MS=200;
 const _STREAM_FADE_MAX_MS=350;
 const _STREAM_FADE_STAGGER_MS=16;
 const _STREAM_FADE_DONE_MAX_MS=320;
+const _STREAM_FADE_DONE_DRAIN_MAX_MS=900;
 const performance={performance_stub};
 {helpers}
 """
@@ -176,6 +177,20 @@ def test_stream_fade_uses_incremental_renderer_without_changing_default_path():
         ["animationend", "span.replaceWith(document.createTextNode"],
     )
     assert "_wrapStreamingFadeWords" not in MESSAGES_JS
+
+
+def test_stream_fade_done_drain_has_hard_cap_for_large_buffered_responses():
+    drain_block = function_block(MESSAGES_JS, "_drainStreamFadeBeforeDone")
+    assert "const _STREAM_FADE_DONE_DRAIN_MAX_MS=900" in MESSAGES_JS
+    assert_contains_all(
+        drain_block,
+        [
+            "const drainStartedAt=performance.now();",
+            "performance.now()-drainStartedAt>=_STREAM_FADE_DONE_DRAIN_MAX_MS",
+            "if(_smdParser) _smdEndParser();",
+            "onDone();",
+        ],
+    )
 
 
 def test_stream_fade_css_is_opacity_only_and_hides_live_cursor():


### PR DESCRIPTION
## Thinking Path
- Hermes WebUI streams live chat turns through SSE and then settles the transcript on the final `done` event.
- The optional smooth text fade intentionally buffers live token display for readability.
- For large or bursty responses, the final response should not remain hidden behind that optional playout after the canonical completed session is already available.
- This keeps the visual polish but caps the terminal drain so completed answers render promptly.

## What Changed
- Added a hard cap to `_drainStreamFadeBeforeDone()` so the optional word-fade playout yields to the final `done` handler after a bounded delay.
- Preserved the existing caught-up path and final animation wait for normal responses.
- Added a regression test asserting the terminal fade-drain cap remains wired.
- Added an Unreleased changelog entry.

## Why It Matters
- Fixes a failure mode where a completed response can appear stuck in the WebUI until the user presses Stop.
- Keeps the transport/session source of truth authoritative once `done` arrives, instead of letting optional animation state block the completed transcript.

## Verification
- `env -u HERMES_CONFIG_PATH -u HERMES_WEBUI_HOST /home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_smooth_text_fade.py -q` — 9 passed
- `node --check static/messages.js`
- `git diff --check`

## Risks / Follow-ups
- This is a narrow frontend terminal-state fix for the smooth fade path. If reporters can reproduce the same Stop-to-flush symptom with smooth fade disabled, the SSE/proxy path should be investigated separately.
- No visual media attached because this changes the timing of final transcript settlement rather than static layout or appearance.

Closes #2447

## Model Used
AI-assisted change with repository inspection, targeted editing, and shell-based test verification.
