### PR TITLE
fix: label email gateway sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **PR #2457** by @Michaelyklam (closes #2456) — Email gateway sessions imported from Hermes Agent `state.db` now normalize as messaging sessions and show an `Email` source label in the WebUI sidebar instead of falling through as unlabelled generic agent sessions. Keeps the Python source-normalization contract, gateway status platform labels, and frontend handoff/sidebar whitelist in sync.
+
 ## [v0.51.82] — 2026-05-17 — Release BF (stage-375 — 2-PR batch — table renderer pipe protection + Catppuccin appearance skin)
 
 ### Added

--- a/api/agent_sessions.py
+++ b/api/agent_sessions.py
@@ -9,6 +9,7 @@ logger = logging.getLogger(__name__)
 
 MESSAGING_SOURCES = {
     'discord',
+    'email',
     'slack',
     'telegram',
     'weixin',
@@ -22,6 +23,7 @@ SOURCE_LABELS = {
     'cli': 'CLI',
     'cron': 'Cron',
     'discord': 'Discord',
+    'email': 'Email',
     'slack': 'Slack',
     'telegram': 'Telegram',
     'tool': 'Tool',

--- a/api/routes.py
+++ b/api/routes.py
@@ -4183,6 +4183,7 @@ def handle_get(handler, parsed) -> bool:
             "telegram": "Telegram",
             "discord": "Discord",
             "slack": "Slack",
+            "email": "Email",
             "web": "Web",
             "api": "API",
         }

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -742,12 +742,13 @@ const _HANDOFF_THRESHOLD = 10;  // conversation rounds
 const _HANDOFF_STORAGE_PREFIX = 'handoff:';
 const _HANDOFF_SUFFIX_DISMISSED_AT = 'dismissed_at';
 const _HANDOFF_SUFFIX_SUMMARY_HANDLED_AT = 'summary_handled_at';
-const _MESSAGING_RAW_SOURCES = new Set(['weixin', 'telegram', 'discord', 'slack']);
+const _MESSAGING_RAW_SOURCES = new Set(['weixin', 'telegram', 'discord', 'slack', 'email']);
 const _MESSAGING_SOURCE_LABELS = {
   weixin: 'WeChat',
   telegram: 'Telegram',
   discord: 'Discord',
   slack: 'Slack',
+  email: 'Email',
 };
 
 function _isMessagingSession(session) {

--- a/tests/test_gateway_sync.py
+++ b/tests/test_gateway_sync.py
@@ -797,6 +797,7 @@ def test_agent_session_source_normalization_contract():
 
     cases = {
         'cli': ('cli', 'CLI'),
+        'email': ('messaging', 'Email'),
         'weixin': ('messaging', 'Weixin'),
         'telegram': ('messaging', 'Telegram'),
         'discord': ('messaging', 'Discord'),
@@ -816,6 +817,14 @@ def test_agent_session_source_normalization_contract():
             assert normalized['raw_source'] == raw_source
         else:
             assert normalized['raw_source'] is None
+
+
+def test_sessions_js_treats_email_as_messaging_source():
+    """Email gateway sessions should receive the same sidebar metadata as other messaging channels."""
+    src = (REPO_ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
+
+    assert "'email'" in src[src.find("_MESSAGING_RAW_SOURCES"):src.find("function _isMessagingSession")]
+    assert "email: 'Email'" in src[src.find("_MESSAGING_SOURCE_LABELS"):src.find("function _isMessagingSession")]
 
 
 def test_cross_source_parent_child_is_not_collapsed_into_root_metadata(cleanup_test_sessions):


### PR DESCRIPTION
## Thinking Path

- Hermes WebUI already treats imported Telegram/Discord/Slack/WeChat Agent sessions as messaging sessions in both backend metadata and sidebar UI.
- Hermes Agent has first-class email gateway support and writes the platform as `email`.
- Without `email` in the WebUI source allowlists, email-origin sessions fall through as generic/other rows and lose the readable channel label.
- The smallest safe fix is to add `email` to the same source-normalization surfaces used by the other messaging platforms.

## What Changed

- Added `email` to `api.agent_sessions.MESSAGING_SOURCES` and `SOURCE_LABELS`.
- Added `email: "Email"` to gateway status platform labels.
- Added `email` to the frontend messaging-source whitelist and channel-label map in `static/sessions.js`.
- Extended source-normalization and frontend source-string regression coverage.
- Added a release-note entry under `[Unreleased]`.

## Why It Matters

Email gateway conversations imported from Hermes Agent `state.db` now get the same messaging-session classification and `Email` sidebar label as other gateway platforms.

Closes #2456.

## Verification

- RED before implementation: `env -u HERMES_CONFIG_PATH -u HERMES_WEBUI_HOST /home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_gateway_sync.py::test_agent_session_source_normalization_contract tests/test_gateway_sync.py::test_sessions_js_treats_email_as_messaging_source -q` failed with `email` classified as `other` and missing from the frontend whitelist.
- `env -u HERMES_CONFIG_PATH -u HERMES_WEBUI_HOST /home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_gateway_sync.py::test_agent_session_source_normalization_contract tests/test_gateway_sync.py::test_sessions_js_treats_email_as_messaging_source -q` — 2 passed.
- `env -u HERMES_CONFIG_PATH -u HERMES_WEBUI_HOST /home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_gateway_sync.py::test_gateway_session_has_correct_metadata tests/test_gateway_sync.py::test_agent_session_source_normalization_contract tests/test_gateway_sync.py::test_sessions_js_treats_email_as_messaging_source tests/test_session_import_cli_fallback_model.py -q` — 11 passed.
- `node --check static/sessions.js`.
- `/home/michael/.hermes/hermes-agent/venv/bin/python -m py_compile api/agent_sessions.py api/routes.py`.
- `git diff --check`.

UI media: not attached. This change does not add a new layout or interaction flow; it normalizes an existing source string so the already-existing sidebar badge/label path receives `Email`. There is no configured email gateway fixture in this test environment, and the source-level regression pins the exact UI metadata contract.

## Risks / Follow-ups

- Assumes Hermes Agent stores email gateway sessions with raw source `email`; verified against the Agent `Platform.EMAIL = "email"` contract and the issue's gateway setup description.
- Other gateway platforms may need the same treatment later if they are imported through the SQLite bridge and should get first-class labels.

## Model Used

AI-assisted change with repository inspection, targeted editing, and shell-based test verification.
