### PR TITLE
fix: add WebUI memory-provider session lifecycle for batch-extraction providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- OpenViking and other batch-extraction memory providers now follow the same lifecycle split as Hermes CLI: completed WebUI turns are synced and marked as pending work, while extraction/commit runs only at session boundaries such as starting a new chat from a previous session, cache eviction, or shutdown drain. This avoids per-turn extraction while preserving reliable boundary commits for cached and reopened WebUI sessions.
+
 ## [v0.51.82] — 2026-05-17 — Release BF (stage-375 — 2-PR batch — table renderer pipe protection + Catppuccin appearance skin)
 
 ### Added

--- a/api/config.py
+++ b/api/config.py
@@ -3983,9 +3983,38 @@ SESSION_AGENT_CACHE_LOCK = threading.Lock()
 
 
 def _evict_session_agent(session_id: str) -> None:
-    """Remove a cached agent for a session (on delete, clear, or model switch)."""
+    """Remove a cached agent for a session (on delete, clear, or model switch).
+
+    Attempts a lifecycle commit before dropping the agent handle so that
+    batch-extraction memory providers can extract any pending work.  If the
+    commit fails or there is uncommitted work with no successful commit, the
+    lifecycle entry is preserved (not unregistered) so a future commit can
+    retry.
+    """
+    agent = None
     with SESSION_AGENT_CACHE_LOCK:
-        SESSION_AGENT_CACHE.pop(session_id, None)
+        entry = SESSION_AGENT_CACHE.pop(session_id, None)
+        if entry is not None:
+            agent = entry[0] if isinstance(entry, tuple) else None
+    if agent is None:
+        return
+    should_close = True
+    try:
+        from api.session_lifecycle import commit_session_memory, has_uncommitted_work, unregister_agent
+        if has_uncommitted_work(session_id):
+            commit_session_memory(session_id, agent=agent, wait=True)
+        if not has_uncommitted_work(session_id):
+            unregister_agent(session_id)
+        else:
+            should_close = False
+    except Exception:
+        should_close = False
+        logger.debug("Lifecycle commit on eviction failed for %s", session_id, exc_info=True)
+    if should_close and getattr(agent, '_session_db', None) is not None:
+        try:
+            agent._session_db.close()
+        except Exception:
+            logger.debug("Failed to close _session_db on eviction for %s", session_id, exc_info=True)
 
 # ── Thread-local env context ─────────────────────────────────────────────────
 _thread_ctx = threading.local()

--- a/api/routes.py
+++ b/api/routes.py
@@ -4765,14 +4765,17 @@ def handle_post(handler, parsed) -> bool:
             s = get_session(body["session_id"])
         except KeyError:
             return bad(handler, "Session not found", 404)
-        with _get_session_agent_lock(body["session_id"]):
+        sid = body["session_id"]
+        with _get_session_agent_lock(sid):
             s.messages = []
             s.tool_calls = []
             s.title = "Untitled"
             s.save()
-            # Evict cached agent — cleared session is a fresh conversation
-            from api.config import _evict_session_agent
-            _evict_session_agent(body["session_id"])
+        # Evict cached agent outside the per-session lock.  Eviction may run a
+        # boundary memory commit for batch-extraction providers, and provider
+        # I/O must not hold the session mutation lock.
+        from api.config import _evict_session_agent
+        _evict_session_agent(sid)
         return j(handler, {"ok": True, "session": s.compact()})
 
     if parsed.path == "/api/session/truncate":

--- a/api/routes.py
+++ b/api/routes.py
@@ -4340,6 +4340,20 @@ def handle_post(handler, parsed) -> bool:
         )
         # Use the profile sent by the client tab (if any) so that two tabs on
         # different profiles never clobber each other via the process-level global.
+        # ── Memory lifecycle: commit the previous session before starting a new one ──
+        prev_session_id = body.get("prev_session_id")
+        if prev_session_id:
+            try:
+                from api.session_lifecycle import commit_session_memory
+                from api.config import SESSION_AGENT_CACHE, SESSION_AGENT_CACHE_LOCK
+                prev_agent = None
+                with SESSION_AGENT_CACHE_LOCK:
+                    _cached = SESSION_AGENT_CACHE.get(prev_session_id)
+                    if _cached:
+                        prev_agent = _cached[0]
+                commit_session_memory(prev_session_id, agent=prev_agent)
+            except Exception:
+                logger.debug("Lifecycle commit for prev_session %s failed", prev_session_id, exc_info=True)
         s = new_session(
             workspace=workspace,
             model=model,

--- a/api/session_lifecycle.py
+++ b/api/session_lifecycle.py
@@ -1,0 +1,193 @@
+"""
+Hermes WebUI memory-provider session lifecycle.
+
+Batch-extraction memory providers (OpenViking, Holographic) only extract memories
+when AIAgent.commit_memory_session() invokes provider on_session_end(). WebUI
+sessions can be reopened and continued many times, so the lifecycle must guarantee:
+
+1. Only completed, non-ephemeral turns are committable.
+2. A commit finishing late must not erase work completed while it was in flight.
+3. A failed commit preserves the uncommitted generation and owning agent handle.
+4. Replacement/reopened agents cannot steal older dirty generations.
+5. Overlapping commits are serialised via a per-session in-flight guard.
+
+The design uses a monotonic generation counter per session plus per-generation
+agent ownership segments. mark_turn_completed() records which agent owns the new
+generation. commit_session_memory() commits the earliest uncommitted segment and
+compare-and-clears only that captured segment after success.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+
+logger = logging.getLogger(__name__)
+
+_lock = threading.Lock()
+_condition = threading.Condition(_lock)
+
+_sessions: dict[str, dict] = {}
+
+
+def _new_entry() -> dict:
+    return {
+        "generation": 0,
+        "committed_generation": 0,
+        "agent": None,
+        "in_flight": False,
+        "segments": [],
+    }
+
+
+def _reset_for_tests() -> None:
+    with _condition:
+        _sessions.clear()
+        _condition.notify_all()
+
+
+def register_agent(session_id: str, agent) -> None:
+    """Register the current agent handle for future completed generations.
+
+    Existing dirty generations keep their original segment owner. This prevents
+    a rebuilt/reopened agent from overwriting the handle needed to retry older
+    failed memory-provider work.
+    """
+    if not session_id:
+        return
+    with _condition:
+        entry = _sessions.setdefault(session_id, _new_entry())
+        entry["agent"] = agent
+        _condition.notify_all()
+
+
+def unregister_agent(session_id: str) -> None:
+    """Clear the current future-generation agent handle.
+
+    Dirty segment owners are intentionally preserved so failed work remains
+    retryable even if the cache drops the current agent reference.
+    """
+    if not session_id:
+        return
+    with _condition:
+        entry = _sessions.get(session_id)
+        if entry is not None:
+            entry["agent"] = None
+        _condition.notify_all()
+
+
+def mark_turn_completed(session_id: str, *, agent=None) -> int:
+    if not session_id:
+        return 0
+    with _condition:
+        entry = _sessions.setdefault(session_id, _new_entry())
+        if agent is not None:
+            entry["agent"] = agent
+        owner = agent if agent is not None else entry.get("agent")
+        entry["generation"] += 1
+        generation = entry["generation"]
+        segments = entry["segments"]
+        if segments and not entry["in_flight"] and segments[-1].get("agent") is owner:
+            segments[-1]["end"] = generation
+        else:
+            segments.append({"start": generation, "end": generation, "agent": owner})
+        _condition.notify_all()
+        return generation
+
+
+def has_uncommitted_work(session_id: str) -> bool:
+    if not session_id:
+        return False
+    with _lock:
+        entry = _sessions.get(session_id)
+        if entry is None:
+            return False
+        return entry["generation"] > entry["committed_generation"]
+
+
+def _first_uncommitted_segment(entry: dict) -> dict | None:
+    committed = entry["committed_generation"]
+    for segment in entry["segments"]:
+        if segment["end"] > committed:
+            return segment
+    return None
+
+
+def commit_session_memory(session_id: str, agent=None, *, wait: bool = False, timeout: float | None = None) -> bool:
+    if not session_id:
+        return False
+    deadline = time.monotonic() + timeout if timeout is not None else None
+    with _condition:
+        entry = _sessions.get(session_id)
+        if entry is None:
+            return False
+        while entry["in_flight"]:
+            if not wait:
+                return False
+            if deadline is None:
+                _condition.wait()
+            else:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    return False
+                _condition.wait(remaining)
+            entry = _sessions.get(session_id)
+            if entry is None:
+                return False
+        if entry["generation"] <= entry["committed_generation"]:
+            return False
+        segment = _first_uncommitted_segment(entry)
+        if segment is None:
+            return False
+        effective_agent = segment.get("agent")
+        if effective_agent is None:
+            effective_agent = agent if agent is not None else entry.get("agent")
+            if effective_agent is not None:
+                segment["agent"] = effective_agent
+        if effective_agent is None:
+            return False
+        captured_generation = segment["end"]
+        entry["in_flight"] = True
+
+    try:
+        effective_agent.commit_memory_session()
+    except Exception:
+        logger.exception("commit_memory_session() failed for session %s", session_id)
+        with _condition:
+            re_entry = _sessions.get(session_id)
+            if re_entry is not None:
+                re_entry["in_flight"] = False
+            _condition.notify_all()
+        return False
+
+    with _condition:
+        re_entry = _sessions.get(session_id)
+        if re_entry is not None:
+            re_entry["in_flight"] = False
+            if captured_generation > re_entry["committed_generation"]:
+                re_entry["committed_generation"] = captured_generation
+            committed = re_entry["committed_generation"]
+            segments = re_entry["segments"]
+            while segments and segments[0]["end"] <= committed:
+                segments.pop(0)
+            if segments and segments[0]["start"] <= committed:
+                segments[0]["start"] = committed + 1
+        _condition.notify_all()
+    return True
+
+
+def drain_all_on_shutdown() -> None:
+    while True:
+        with _lock:
+            snapshot = [sid for sid, entry in _sessions.items() if entry["generation"] > entry["committed_generation"]]
+        if not snapshot:
+            return
+
+        made_progress = False
+        for sid in snapshot:
+            if commit_session_memory(sid, wait=True):
+                made_progress = True
+        if not made_progress:
+            logger.debug("drain_all_on_shutdown: stopped with uncommitted sessions: %s", sorted(snapshot))
+            return

--- a/api/session_lifecycle.py
+++ b/api/session_lifecycle.py
@@ -11,6 +11,21 @@ sessions can be reopened and continued many times, so the lifecycle must guarant
 4. Replacement/reopened agents cannot steal older dirty generations.
 5. Overlapping commits are serialised via a per-session in-flight guard.
 
+CLI-parity semantics — post-turn marking, boundary extraction/commit:
+
+- Completed turn: Hermes core still mirrors the exchange through
+  run_agent.py::_sync_external_memory_for_turn(), MemoryManager sync_all(), and
+  provider sync_turn() WITHOUT triggering extraction.  WebUI then calls
+  mark_turn_completed() after the saved/completed-turn boundary so later drains
+  know the synced session has uncommitted work and which agent owns it.
+
+- Session boundary: commit_session_memory() triggers
+  AIAgent.commit_memory_session(), which calls provider on_session_end(),
+  posting /api/v1/sessions/<sid>/commit and triggering extraction. This is
+  called only at boundaries — /api/session/new with prev_session_id, explicit
+  agent eviction, LRU cache eviction, and shutdown drain — matching the CLI's
+  AIAgent.commit_memory_session()/shutdown_memory_provider() boundary.
+
 The design uses a monotonic generation counter per session plus per-generation
 agent ownership segments. mark_turn_completed() records which agent owns the new
 generation. commit_session_memory() commits the earliest uncommitted segment and

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -3627,6 +3627,13 @@ def _run_agent_streaming(
                         agent = _cached[0]
                         SESSION_AGENT_CACHE.move_to_end(session_id)  # LRU: mark as recently used
                         logger.debug('[webui] Reusing cached agent for session %s', session_id)
+                        # Reopened/cache-hit sessions must register the agent
+                        # so later lifecycle commits can find it.
+                        try:
+                            from api.session_lifecycle import register_agent
+                            register_agent(session_id, agent)
+                        except Exception:
+                            logger.debug("Lifecycle register_agent failed for cached session %s", session_id, exc_info=True)
 
                 if agent is not None:
                     # Refresh volatile runtime credentials selected from provider
@@ -3683,24 +3690,47 @@ def _run_agent_streaming(
                         agent._interrupt_message = None
                 else:
                     agent = _AIAgent(**_agent_kwargs)
+                    # Register the new agent with the memory lifecycle so
+                    # its commit_memory_session() can be found later.
+                    try:
+                        from api.session_lifecycle import register_agent
+                        register_agent(session_id, agent)
+                    except Exception:
+                        logger.debug("Lifecycle register_agent failed for new session %s", session_id, exc_info=True)
+                    _evicted_items = []
                     with SESSION_AGENT_CACHE_LOCK:
                         SESSION_AGENT_CACHE[session_id] = (agent, _agent_sig)
                         SESSION_AGENT_CACHE.move_to_end(session_id)  # LRU: mark as recently used
                         from api.config import SESSION_AGENT_CACHE_MAX
                         while len(SESSION_AGENT_CACHE) > SESSION_AGENT_CACHE_MAX:
                             evicted_sid, evicted_entry = SESSION_AGENT_CACHE.popitem(last=False)
-                            # Same FD-leak shape as the cached-agent reuse path
-                            # in #1421: the evicted agent's _session_db won't be
-                            # released until GC finalizes the agent, which on a
-                            # long-running server may be never. Close it
-                            # explicitly so the WAL handles release immediately.
-                            try:
-                                _evicted_agent = evicted_entry[0] if isinstance(evicted_entry, tuple) else None
-                                if _evicted_agent is not None and getattr(_evicted_agent, '_session_db', None) is not None:
-                                    _evicted_agent._session_db.close()
-                            except Exception:
-                                pass
-                            logger.debug('[webui] Evicted LRU agent from cache: %s', evicted_sid)
+                            _evicted_items.append((evicted_sid, evicted_entry))
+                    # Commit and close evicted agents outside the cache lock so
+                    # concurrent cache users are not blocked by provider I/O.
+                    for _evicted_sid, _evicted_entry in _evicted_items:
+                        try:
+                            _evicted_agent = _evicted_entry[0] if isinstance(_evicted_entry, tuple) else None
+                            _should_close_evicted_agent = True
+                            if _evicted_agent is not None:
+                                try:
+                                    from api.session_lifecycle import (
+                                        commit_session_memory as _lifecycle_commit,
+                                        has_uncommitted_work as _lifecycle_has_uncommitted_work,
+                                        unregister_agent as _lifecycle_unregister_agent,
+                                    )
+                                    _lifecycle_commit(_evicted_sid, agent=_evicted_agent, wait=True)
+                                    if not _lifecycle_has_uncommitted_work(_evicted_sid):
+                                        _lifecycle_unregister_agent(_evicted_sid)
+                                    else:
+                                        _should_close_evicted_agent = False
+                                except Exception:
+                                    _should_close_evicted_agent = False
+                                    logger.debug("Lifecycle commit on eviction failed for %s", _evicted_sid, exc_info=True)
+                            if _should_close_evicted_agent and _evicted_agent is not None and getattr(_evicted_agent, '_session_db', None) is not None:
+                                _evicted_agent._session_db.close()
+                        except Exception:
+                            logger.debug("Failed to close evicted agent for session %s", _evicted_sid, exc_info=True)
+                        logger.debug('[webui] Evicted LRU agent from cache: %s', _evicted_sid)
                     logger.debug('[webui] Created new agent for session %s', session_id)
 
             # Store agent instance for cancel/interrupt propagation
@@ -3885,6 +3915,8 @@ def _run_agent_streaming(
                         logger.debug("Failed to append cancelled turn journal event", exc_info=True)
                 put('cancel', {'message': 'Cancelled by user'})
                 return
+            _memory_lifecycle_commit_sid = None
+            _memory_lifecycle_commit_agent = None
             with _agent_lock:
                 if not ephemeral and not _stream_writeback_is_current(s, stream_id):
                     logger.info(
@@ -4483,6 +4515,23 @@ def _run_agent_streaming(
                         )
                     except Exception:
                         logger.debug("Failed to append completed turn journal event", exc_info=True)
+                if not ephemeral:
+                    _memory_lifecycle_commit_sid = s.session_id
+                    _memory_lifecycle_commit_agent = agent
+            # ── Memory-provider lifecycle commit ──
+            # Mark the turn as completed and attempt a memory commit for
+            # batch-extraction providers (OpenViking, Holographic). This
+            # must happen AFTER s.save() succeeds, AFTER cancellation checks,
+            # and AFTER the completed-turn journal event so only genuinely
+            # completed, non-ephemeral turns are marked. The provider commit
+            # itself runs outside _agent_lock because it can perform I/O.
+            if _memory_lifecycle_commit_sid:
+                try:
+                    from api.session_lifecycle import mark_turn_completed, commit_session_memory
+                    mark_turn_completed(_memory_lifecycle_commit_sid, agent=_memory_lifecycle_commit_agent)
+                    commit_session_memory(_memory_lifecycle_commit_sid, agent=_memory_lifecycle_commit_agent)
+                except Exception:
+                    logger.debug("Memory lifecycle commit failed for session %s", _memory_lifecycle_commit_sid, exc_info=True)
             # Sync to state.db for /insights (opt-in setting)
             try:
                 from api.config import load_settings as _load_settings

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -4518,20 +4518,21 @@ def _run_agent_streaming(
                 if not ephemeral:
                     _memory_lifecycle_commit_sid = s.session_id
                     _memory_lifecycle_commit_agent = agent
-            # ── Memory-provider lifecycle commit ──
-            # Mark the turn as completed and attempt a memory commit for
-            # batch-extraction providers (OpenViking, Holographic). This
-            # must happen AFTER s.save() succeeds, AFTER cancellation checks,
-            # and AFTER the completed-turn journal event so only genuinely
-            # completed, non-ephemeral turns are marked. The provider commit
-            # itself runs outside _agent_lock because it can perform I/O.
+            # ── Memory-provider lifecycle: mark turn completed (CLI parity) ──
+            # Completed, non-ephemeral turns are marked dirty/uncommitted so
+            # boundary drains know there is work.  Per CLI semantics, the
+            # actual memory extraction/commit happens only at session boundaries
+            # (new session creation, LRU eviction, shutdown drain) — NOT after
+            # every completed turn.  This mirrors Hermes CLI where
+            # run_agent.py::_sync_external_memory_for_turn() records messages
+            # but only AIAgent.commit_memory_session()/shutdown_memory_provider()
+            # trigger extraction via provider on_session_end().
             if _memory_lifecycle_commit_sid:
                 try:
-                    from api.session_lifecycle import mark_turn_completed, commit_session_memory
+                    from api.session_lifecycle import mark_turn_completed
                     mark_turn_completed(_memory_lifecycle_commit_sid, agent=_memory_lifecycle_commit_agent)
-                    commit_session_memory(_memory_lifecycle_commit_sid, agent=_memory_lifecycle_commit_agent)
                 except Exception:
-                    logger.debug("Memory lifecycle commit failed for session %s", _memory_lifecycle_commit_sid, exc_info=True)
+                    logger.debug("Memory lifecycle mark failed for session %s", _memory_lifecycle_commit_sid, exc_info=True)
             # Sync to state.db for /insights (opt-in setting)
             try:
                 from api.config import load_settings as _load_settings

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -3915,8 +3915,6 @@ def _run_agent_streaming(
                         logger.debug("Failed to append cancelled turn journal event", exc_info=True)
                 put('cancel', {'message': 'Cancelled by user'})
                 return
-            _memory_lifecycle_commit_sid = None
-            _memory_lifecycle_commit_agent = None
             with _agent_lock:
                 if not ephemeral and not _stream_writeback_is_current(s, stream_id):
                     logger.info(
@@ -4516,23 +4514,22 @@ def _run_agent_streaming(
                     except Exception:
                         logger.debug("Failed to append completed turn journal event", exc_info=True)
                 if not ephemeral:
-                    _memory_lifecycle_commit_sid = s.session_id
-                    _memory_lifecycle_commit_agent = agent
-            # ── Memory-provider lifecycle: mark turn completed (CLI parity) ──
-            # Completed, non-ephemeral turns are marked dirty/uncommitted so
-            # boundary drains know there is work.  Per CLI semantics, the
-            # actual memory extraction/commit happens only at session boundaries
-            # (new session creation, LRU eviction, shutdown drain) — NOT after
-            # every completed turn.  This mirrors Hermes CLI where
-            # run_agent.py::_sync_external_memory_for_turn() records messages
-            # but only AIAgent.commit_memory_session()/shutdown_memory_provider()
-            # trigger extraction via provider on_session_end().
-            if _memory_lifecycle_commit_sid:
-                try:
-                    from api.session_lifecycle import mark_turn_completed
-                    mark_turn_completed(_memory_lifecycle_commit_sid, agent=_memory_lifecycle_commit_agent)
-                except Exception:
-                    logger.debug("Memory lifecycle mark failed for session %s", _memory_lifecycle_commit_sid, exc_info=True)
+                    # ── Memory-provider lifecycle: mark turn completed (CLI parity) ──
+                    # Completed, non-ephemeral turns are marked dirty/uncommitted so
+                    # boundary drains know there is work.  Per CLI semantics, the
+                    # actual memory extraction/commit happens only at session boundaries
+                    # (new session creation, LRU eviction, shutdown drain) — NOT after
+                    # every completed turn.  This mirrors Hermes CLI where
+                    # run_agent.py::_sync_external_memory_for_turn() records messages
+                    # but only AIAgent.commit_memory_session()/shutdown_memory_provider()
+                    # trigger extraction via provider on_session_end().  The mark is
+                    # in-memory bookkeeping, not provider I/O, so keep it inside the
+                    # per-session writeback lock to preserve completed-turn ordering.
+                    try:
+                        from api.session_lifecycle import mark_turn_completed
+                        mark_turn_completed(s.session_id, agent=agent)
+                    except Exception:
+                        logger.debug("Memory lifecycle mark failed for session %s", s.session_id, exc_info=True)
             # Sync to state.db for /insights (opt-in setting)
             try:
                 from api.config import load_settings as _load_settings

--- a/server.py
+++ b/server.py
@@ -441,6 +441,12 @@ def main() -> None:
             stop_watcher()
         except Exception:
             logger.debug("Failed to stop gateway watcher during shutdown")
+        # Drain pending memory-provider lifecycle commits before exit
+        try:
+            from api.session_lifecycle import drain_all_on_shutdown
+            drain_all_on_shutdown()
+        except Exception:
+            logger.debug("Failed to drain lifecycle on shutdown", exc_info=True)
 
 if __name__ == '__main__':
     main()

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -418,6 +418,7 @@ async function newSession(flash, options={}){
     workspace:inheritWs,
     profile:S.activeProfile||'default',
   };
+  if(S.session&&S.session.session_id) reqBody.prev_session_id=S.session.session_id;
   if(options&&options.worktree) reqBody.worktree=true;
   if(_activeProject&&_activeProject!==NO_PROJECT_FILTER) reqBody.project_id=_activeProject;
   const data=await api('/api/session/new',{method:'POST',body:JSON.stringify(reqBody)});

--- a/tests/test_memory_session_lifecycle_generation.py
+++ b/tests/test_memory_session_lifecycle_generation.py
@@ -348,7 +348,7 @@ def test_post_turn_lifecycle_marks_completion_without_commit():
     src = Path(streaming_mod.__file__).read_text(encoding="utf-8")
 
     save_pos = src.index("s.save()")
-    lifecycle_marker = src.index("_memory_lifecycle_commit_sid = s.session_id", save_pos)
+    lifecycle_marker = src.index("mark_turn_completed(s.session_id, agent=agent)", save_pos)
     cancel_check = src.index("cancel_event.is_set()", save_pos)
     completed_journal = src.index('"completed"', save_pos)
     sync_to_state_db = src.index("# Sync to state.db", save_pos)
@@ -363,11 +363,12 @@ def test_post_turn_lifecycle_marks_completion_without_commit():
 
     # The post-turn block must contain mark_turn_completed but NOT
     # commit_session_memory — extraction is a boundary concern.
-    block_start = src.index("if _memory_lifecycle_commit_sid:", save_pos)
+    block_start = src.rindex("if not ephemeral:", save_pos, lifecycle_marker)
     block_end_pos = src.index("# Sync to state.db", save_pos)
     post_turn_block = src[block_start:block_end_pos]
     assert "mark_turn_completed" in post_turn_block
     assert "commit_session_memory" not in post_turn_block
+    assert "per-session writeback lock" in post_turn_block
 
 
 def test_multiple_completed_turns_coalesce_into_single_boundary_commit():

--- a/tests/test_memory_session_lifecycle_generation.py
+++ b/tests/test_memory_session_lifecycle_generation.py
@@ -1,0 +1,388 @@
+"""Behavioral tests for WebUI memory-provider session lifecycle.
+
+Batch-extraction memory providers such as OpenViking and Holographic need a
+clear lifecycle contract: only completed turns are committable, repeated commits
+must be no-ops when nothing new happened, and a commit finishing late must not
+erase work completed while it was in flight.
+"""
+
+from __future__ import annotations
+
+import importlib
+import threading
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parents[1]
+
+
+def _fresh_lifecycle():
+    """Import/reload lifecycle module and clear process-global test state."""
+    lifecycle = importlib.import_module("api.session_lifecycle")
+    lifecycle = importlib.reload(lifecycle)
+    reset = getattr(lifecycle, "_reset_for_tests", None)
+    if callable(reset):
+        reset()
+    return lifecycle
+
+
+class RecordingAgent:
+    def __init__(self):
+        self.calls = 0
+        self.entered = threading.Event()
+        self.release = threading.Event()
+        self.failures_remaining = 0
+        self._session_db: object | None = None
+
+    def commit_memory_session(self):
+        self.calls += 1
+        self.entered.set()
+        self.release.wait(timeout=2)
+        if self.failures_remaining:
+            self.failures_remaining -= 1
+            raise RuntimeError("commit failed")
+
+
+class CloseTrackingDB:
+    def __init__(self):
+        self.close_calls = 0
+
+    def close(self):
+        self.close_calls += 1
+
+
+def test_commit_finishing_late_does_not_clear_newly_completed_turn():
+    lifecycle = _fresh_lifecycle()
+    agent = RecordingAgent()
+    sid = "rapid-reopen"
+
+    lifecycle.register_agent(sid, agent)
+    lifecycle.mark_turn_completed(sid, agent=agent)
+
+    commit_thread = threading.Thread(target=lambda: lifecycle.commit_session_memory(sid))
+    commit_thread.start()
+    assert agent.entered.wait(timeout=2)
+
+    # A later turn completes while the previous commit is still running.  The
+    # previous commit must not erase this newer generation when it finishes.
+    lifecycle.mark_turn_completed(sid, agent=agent)
+    agent.release.set()
+    commit_thread.join(timeout=2)
+
+    assert agent.calls == 1
+    assert lifecycle.has_uncommitted_work(sid) is True
+
+    assert lifecycle.commit_session_memory(sid) is True
+    assert agent.calls == 2
+    assert lifecycle.has_uncommitted_work(sid) is False
+
+
+def test_failed_commit_preserves_uncommitted_work_and_agent_handle():
+    lifecycle = _fresh_lifecycle()
+    agent = RecordingAgent()
+    agent.release.set()
+    agent.failures_remaining = 1
+    sid = "commit-failure"
+
+    lifecycle.register_agent(sid, agent)
+    lifecycle.mark_turn_completed(sid, agent=agent)
+
+    assert lifecycle.commit_session_memory(sid) is False
+    assert agent.calls == 1
+    assert lifecycle.has_uncommitted_work(sid) is True
+
+    assert lifecycle.commit_session_memory(sid) is True
+    assert agent.calls == 2
+    assert lifecycle.has_uncommitted_work(sid) is False
+
+
+def test_failed_explicit_agent_commit_preserves_agent_handle_for_retry():
+    lifecycle = _fresh_lifecycle()
+    agent = RecordingAgent()
+    agent.release.set()
+    agent.failures_remaining = 1
+    sid = "explicit-agent-failure"
+
+    lifecycle.mark_turn_completed(sid)
+
+    assert lifecycle.commit_session_memory(sid, agent=agent) is False
+    assert agent.calls == 1
+    assert lifecycle.has_uncommitted_work(sid) is True
+
+    # Retry without passing an agent must still find the explicit agent supplied
+    # to the failed commit attempt.
+    assert lifecycle.commit_session_memory(sid) is True
+    assert agent.calls == 2
+    assert lifecycle.has_uncommitted_work(sid) is False
+
+
+def test_dirty_failed_commit_handle_survives_replacement_registration():
+    lifecycle = _fresh_lifecycle()
+    old_agent = RecordingAgent()
+    old_agent.release.set()
+    old_agent.failures_remaining = 1
+    new_agent = RecordingAgent()
+    new_agent.release.set()
+    sid = "preserve-failed-handle"
+
+    lifecycle.register_agent(sid, old_agent)
+    lifecycle.mark_turn_completed(sid, agent=old_agent)
+
+    assert lifecycle.commit_session_memory(sid) is False
+    assert old_agent.calls == 1
+    assert lifecycle.has_uncommitted_work(sid) is True
+
+    lifecycle.register_agent(sid, new_agent)
+
+    assert lifecycle.commit_session_memory(sid) is True
+    assert old_agent.calls == 2
+    assert new_agent.calls == 0
+    assert lifecycle.has_uncommitted_work(sid) is False
+
+    # Once the dirty generation is clean, the pending replacement may become the
+    # active handle for future completed work.
+    lifecycle.mark_turn_completed(sid)
+    assert lifecycle.commit_session_memory(sid) is True
+    assert new_agent.calls == 1
+
+
+def test_explicit_new_agent_commit_cannot_clear_old_dirty_segment():
+    lifecycle = _fresh_lifecycle()
+    old_agent = RecordingAgent()
+    old_agent.release.set()
+    old_agent.failures_remaining = 1
+    new_agent = RecordingAgent()
+    new_agent.release.set()
+    sid = "explicit-new-cannot-steal-old"
+
+    lifecycle.register_agent(sid, old_agent)
+    lifecycle.mark_turn_completed(sid, agent=old_agent)
+    assert lifecycle.commit_session_memory(sid) is False
+
+    lifecycle.register_agent(sid, new_agent)
+    lifecycle.mark_turn_completed(sid, agent=new_agent)
+
+    # Even an explicit commit with the replacement agent must flush the oldest
+    # dirty segment with its preserved owner first.
+    assert lifecycle.commit_session_memory(sid, agent=new_agent) is True
+    assert old_agent.calls == 2
+    assert new_agent.calls == 0
+    assert lifecycle.has_uncommitted_work(sid) is True
+
+    assert lifecycle.commit_session_memory(sid) is True
+    assert new_agent.calls == 1
+    assert lifecycle.has_uncommitted_work(sid) is False
+
+
+def test_registered_session_without_completed_turn_is_not_committed():
+    lifecycle = _fresh_lifecycle()
+    agent = RecordingAgent()
+    agent.release.set()
+    sid = "registered-only"
+
+    lifecycle.register_agent(sid, agent)
+
+    assert lifecycle.commit_session_memory(sid) is False
+    assert agent.calls == 0
+    assert lifecycle.has_uncommitted_work(sid) is False
+
+
+def test_shutdown_drain_includes_dirty_sessions_even_if_pending_registry_was_cleared():
+    lifecycle = _fresh_lifecycle()
+    agent = RecordingAgent()
+    agent.release.set()
+    sid = "dirty-cached-only"
+
+    lifecycle.register_agent(sid, agent)
+    lifecycle.mark_turn_completed(sid, agent=agent)
+    lifecycle.unregister_agent(sid)
+
+    # A lifecycle registry miss should not make completed work undiscoverable if
+    # the agent is still supplied/cached by the caller.
+    assert lifecycle.commit_session_memory(sid, agent=agent) is True
+    assert agent.calls == 1
+    assert lifecycle.has_uncommitted_work(sid) is False
+
+
+def test_shutdown_drain_waits_for_inflight_commit_and_flushes_new_generation():
+    lifecycle = _fresh_lifecycle()
+    agent = RecordingAgent()
+    sid = "shutdown-waits"
+
+    lifecycle.register_agent(sid, agent)
+    lifecycle.mark_turn_completed(sid, agent=agent)
+    first_commit = threading.Thread(target=lambda: lifecycle.commit_session_memory(sid))
+    first_commit.start()
+    assert agent.entered.wait(timeout=2)
+
+    lifecycle.mark_turn_completed(sid, agent=agent)
+
+    drain_thread = threading.Thread(target=lifecycle.drain_all_on_shutdown)
+    drain_thread.start()
+    drain_thread.join(timeout=0.05)
+    assert drain_thread.is_alive()
+    assert agent.calls == 1
+
+    agent.release.set()
+    first_commit.join(timeout=2)
+    drain_thread.join(timeout=2)
+
+    assert agent.calls == 2
+    assert lifecycle.has_uncommitted_work(sid) is False
+
+
+def test_frontend_new_session_sends_previous_session_id_boundary():
+    src = (REPO / "static" / "sessions.js").read_text(encoding="utf-8")
+    start = src.index("async function newSession")
+    end = src.index("const data=await api('/api/session/new'", start)
+    body = src[start:end]
+
+    assert "prev_session_id" in body
+    assert "S.session" in body and "session_id" in body
+
+
+# ── Follow-up review fix tests ──────────────────────────────────────────────
+
+
+def test_evict_session_agent_commits_before_dropping():
+    """_evict_session_agent() must attempt a lifecycle commit before dropping
+    the cached agent handle, so batch-extraction providers can extract pending
+    work before the handle is lost."""
+    lifecycle = _fresh_lifecycle()
+    agent = RecordingAgent()
+    agent.release.set()
+    sid = "evict-commit"
+
+    lifecycle.register_agent(sid, agent)
+    lifecycle.mark_turn_completed(sid, agent=agent)
+
+    import api.config as cfg
+    import importlib as _il
+    _il.reload(cfg)
+
+    with cfg.SESSION_AGENT_CACHE_LOCK:
+        cfg.SESSION_AGENT_CACHE.clear()
+        cfg.SESSION_AGENT_CACHE[sid] = (agent, "sig")
+
+    cfg._evict_session_agent(sid)
+
+    assert agent.calls == 1, "evict should have committed before dropping"
+    assert lifecycle.has_uncommitted_work(sid) is False
+    with cfg.SESSION_AGENT_CACHE_LOCK:
+        assert sid not in cfg.SESSION_AGENT_CACHE
+
+    # Successful eviction should unregister the cached agent handle. If the
+    # handle leaked, a future mark without supplying an agent could commit.
+    lifecycle.mark_turn_completed(sid)
+    assert lifecycle.commit_session_memory(sid) is False
+
+
+def test_evict_session_agent_waits_for_inflight_commit_before_closing_db():
+    lifecycle = _fresh_lifecycle()
+    agent = RecordingAgent()
+    db = CloseTrackingDB()
+    agent._session_db = db
+    sid = "evict-waits-for-inflight"
+
+    lifecycle.register_agent(sid, agent)
+    lifecycle.mark_turn_completed(sid, agent=agent)
+    first_commit = threading.Thread(target=lambda: lifecycle.commit_session_memory(sid))
+    first_commit.start()
+    assert agent.entered.wait(timeout=2)
+
+    # A newer completed generation appears while the first commit is still in
+    # flight. Eviction must wait for the first commit and flush the newer one
+    # before closing the agent's DB resource.
+    lifecycle.mark_turn_completed(sid, agent=agent)
+
+    import api.config as cfg
+    import importlib as _il
+    _il.reload(cfg)
+    with cfg.SESSION_AGENT_CACHE_LOCK:
+        cfg.SESSION_AGENT_CACHE.clear()
+        cfg.SESSION_AGENT_CACHE[sid] = (agent, "sig")
+
+    evict_thread = threading.Thread(target=lambda: cfg._evict_session_agent(sid))
+    evict_thread.start()
+    evict_thread.join(timeout=0.05)
+    assert evict_thread.is_alive()
+    assert db.close_calls == 0
+
+    agent.release.set()
+    first_commit.join(timeout=2)
+    evict_thread.join(timeout=2)
+
+    assert agent.calls == 2
+    assert lifecycle.has_uncommitted_work(sid) is False
+    assert db.close_calls == 1
+
+
+def test_lru_eviction_commits_outside_cache_lock():
+    """LRU eviction must collect under SESSION_AGENT_CACHE_LOCK and commit only
+    after leaving that lock; provider extraction can be slow I/O."""
+    import api.streaming as streaming_mod
+
+    src = Path(streaming_mod.__file__).read_text(encoding="utf-8")
+    marker = "_evicted_items = []"
+    collect_start = src.index(marker)
+    lock_start = src.index("with SESSION_AGENT_CACHE_LOCK:", collect_start)
+    lock_end = src.index("# Commit and close evicted agents outside the cache lock", lock_start)
+    locked_section = src[lock_start:lock_end]
+    outside_section = src[lock_end:src.index("logger.debug('[webui] Created new agent", lock_end)]
+
+    assert "commit_session_memory" not in locked_section
+    assert "_lifecycle_commit" not in locked_section
+    assert "SESSION_AGENT_CACHE.popitem" in locked_section
+    assert "_lifecycle_commit" in outside_section
+    assert "wait=True" in outside_section
+    assert "outside the cache lock" in outside_section
+
+
+def test_post_turn_lifecycle_is_after_completed_journal_and_cancel_check():
+    """Source-adjacent test: verify post-turn lifecycle marking is ordered
+    after save/cancel/completed-journal and that provider commit runs outside
+    the per-session agent lock."""
+    import api.streaming as streaming_mod
+    src = Path(streaming_mod.__file__).read_text(encoding="utf-8")
+
+    save_pos = src.index("s.save()")
+    lifecycle_marker = src.index("_memory_lifecycle_commit_sid = s.session_id", save_pos)
+    lifecycle_commit = src.index("commit_session_memory", lifecycle_marker)
+    cancel_check = src.index("cancel_event.is_set()", save_pos)
+    completed_journal = src.index('"completed"', save_pos)
+    sync_to_state_db = src.index("# Sync to state.db", save_pos)
+
+    assert lifecycle_marker > cancel_check, (
+        "mark_turn_completed must appear after the cancellation check"
+    )
+    assert lifecycle_marker > completed_journal, (
+        "mark_turn_completed must appear after the completed-turn journal event"
+    )
+    assert lifecycle_marker < sync_to_state_db
+    assert lifecycle_commit < sync_to_state_db
+
+    commit_line = next(
+        line for line in src.splitlines()
+        if "commit_session_memory(_memory_lifecycle_commit_sid" in line
+    )
+    assert len(commit_line) - len(commit_line.lstrip()) == 20
+
+
+def test_empty_session_id_is_safe_noop():
+    """All lifecycle API functions must no-op safely for falsy session IDs."""
+    lifecycle = _fresh_lifecycle()
+    agent = RecordingAgent()
+    agent.release.set()
+
+    assert lifecycle.register_agent("", agent) is None
+    assert lifecycle.unregister_agent("") is None
+    assert lifecycle.mark_turn_completed("") == 0
+    assert lifecycle.has_uncommitted_work("") is False
+    assert lifecycle.commit_session_memory("") is False
+    assert lifecycle.commit_session_memory("", agent=agent) is False
+
+    assert lifecycle.register_agent(None, agent) is None
+    assert lifecycle.unregister_agent(None) is None
+    assert lifecycle.mark_turn_completed(None) == 0
+    assert lifecycle.has_uncommitted_work(None) is False
+    assert lifecycle.commit_session_memory(None) is False

--- a/tests/test_memory_session_lifecycle_generation.py
+++ b/tests/test_memory_session_lifecycle_generation.py
@@ -257,8 +257,6 @@ def test_evict_session_agent_commits_before_dropping():
     lifecycle.mark_turn_completed(sid, agent=agent)
 
     import api.config as cfg
-    import importlib as _il
-    _il.reload(cfg)
 
     with cfg.SESSION_AGENT_CACHE_LOCK:
         cfg.SESSION_AGENT_CACHE.clear()
@@ -296,8 +294,6 @@ def test_evict_session_agent_waits_for_inflight_commit_before_closing_db():
     lifecycle.mark_turn_completed(sid, agent=agent)
 
     import api.config as cfg
-    import importlib as _il
-    _il.reload(cfg)
     with cfg.SESSION_AGENT_CACHE_LOCK:
         cfg.SESSION_AGENT_CACHE.clear()
         cfg.SESSION_AGENT_CACHE[sid] = (agent, "sig")

--- a/tests/test_memory_session_lifecycle_generation.py
+++ b/tests/test_memory_session_lifecycle_generation.py
@@ -338,6 +338,27 @@ def test_lru_eviction_commits_outside_cache_lock():
     assert "outside the cache lock" in outside_section
 
 
+def test_clear_session_evicts_outside_session_lock():
+    """Clearing a session must not hold the per-session mutation lock while
+    evicting its cached agent, because eviction can run provider commit I/O."""
+    import api.routes as routes_mod
+    src = Path(routes_mod.__file__).read_text(encoding="utf-8")
+
+    route_start = src.index('if parsed.path == "/api/session/clear"')
+    route_end = src.index('if parsed.path == "/api/session/truncate"', route_start)
+    route_block = src[route_start:route_end]
+
+    lock_start = route_block.index("with _get_session_agent_lock(sid):")
+    lock_end = route_block.index("# Evict cached agent outside the per-session lock", lock_start)
+    locked_section = route_block[lock_start:lock_end]
+    outside_section = route_block[lock_end:]
+
+    assert "_evict_session_agent" not in locked_section
+    assert "s.save()" in locked_section
+    assert "_evict_session_agent(sid)" in outside_section
+    assert "provider" in outside_section and "I/O" in outside_section
+
+
 def test_post_turn_lifecycle_marks_completion_without_commit():
     """Source-adjacent test: verify post-turn lifecycle only calls
     mark_turn_completed and does NOT call commit_session_memory.  Per

--- a/tests/test_memory_session_lifecycle_generation.py
+++ b/tests/test_memory_session_lifecycle_generation.py
@@ -338,16 +338,17 @@ def test_lru_eviction_commits_outside_cache_lock():
     assert "outside the cache lock" in outside_section
 
 
-def test_post_turn_lifecycle_is_after_completed_journal_and_cancel_check():
-    """Source-adjacent test: verify post-turn lifecycle marking is ordered
-    after save/cancel/completed-journal and that provider commit runs outside
-    the per-session agent lock."""
+def test_post_turn_lifecycle_marks_completion_without_commit():
+    """Source-adjacent test: verify post-turn lifecycle only calls
+    mark_turn_completed and does NOT call commit_session_memory.  Per
+    CLI-parity semantics, completed turns are marked dirty/uncommitted;
+    actual extraction/commit happens only at session boundaries
+    (new session, LRU eviction, shutdown drain)."""
     import api.streaming as streaming_mod
     src = Path(streaming_mod.__file__).read_text(encoding="utf-8")
 
     save_pos = src.index("s.save()")
     lifecycle_marker = src.index("_memory_lifecycle_commit_sid = s.session_id", save_pos)
-    lifecycle_commit = src.index("commit_session_memory", lifecycle_marker)
     cancel_check = src.index("cancel_event.is_set()", save_pos)
     completed_journal = src.index('"completed"', save_pos)
     sync_to_state_db = src.index("# Sync to state.db", save_pos)
@@ -359,13 +360,44 @@ def test_post_turn_lifecycle_is_after_completed_journal_and_cancel_check():
         "mark_turn_completed must appear after the completed-turn journal event"
     )
     assert lifecycle_marker < sync_to_state_db
-    assert lifecycle_commit < sync_to_state_db
 
-    commit_line = next(
-        line for line in src.splitlines()
-        if "commit_session_memory(_memory_lifecycle_commit_sid" in line
-    )
-    assert len(commit_line) - len(commit_line.lstrip()) == 20
+    # The post-turn block must contain mark_turn_completed but NOT
+    # commit_session_memory — extraction is a boundary concern.
+    block_start = src.index("if _memory_lifecycle_commit_sid:", save_pos)
+    block_end_pos = src.index("# Sync to state.db", save_pos)
+    post_turn_block = src[block_start:block_end_pos]
+    assert "mark_turn_completed" in post_turn_block
+    assert "commit_session_memory" not in post_turn_block
+
+
+def test_multiple_completed_turns_coalesce_into_single_boundary_commit():
+    """Behavioral test: repeated completed turns accumulate without commit,
+    and a single boundary commit flushes the coalesced segment once."""
+    lifecycle = _fresh_lifecycle()
+    agent = RecordingAgent()
+    agent.release.set()
+    sid = "coalesce-boundary"
+
+    lifecycle.register_agent(sid, agent)
+
+    # Multiple turns complete — all are marked but NOT committed.
+    lifecycle.mark_turn_completed(sid, agent=agent)
+    assert lifecycle.has_uncommitted_work(sid) is True
+
+    lifecycle.mark_turn_completed(sid, agent=agent)
+    assert lifecycle.has_uncommitted_work(sid) is True
+
+    lifecycle.mark_turn_completed(sid, agent=agent)
+    assert lifecycle.has_uncommitted_work(sid) is True
+
+    # A single boundary commit flushes all accumulated work.
+    assert lifecycle.commit_session_memory(sid) is True
+    assert agent.calls == 1, "one boundary commit should coalesce all turns"
+    assert lifecycle.has_uncommitted_work(sid) is False
+
+    # A further boundary commit is a no-op when nothing new happened.
+    assert lifecycle.commit_session_memory(sid) is False
+    assert agent.calls == 1
 
 
 def test_empty_session_id_is_safe_noop():


### PR DESCRIPTION
## Thinking Path

- Hermes CLI splits memory-provider work into two phases: each completed turn syncs into the provider session, while batch extraction/commit runs only at session boundaries (new session, compression rotation, shutdown).
- The WebUI has no equivalent lifecycle layer. An agent's `commit_memory_session()` is never called from WebUI code at any boundary, so batch-extraction memory providers like OpenViking have no reliable commit signal.
- Adding a shared lifecycle module lets the WebUI mark completed turns as dirty/uncommitted and drive boundary commits from the same kind of events CLI uses, without adding per-turn extraction.
- The lifecycle tracks generation and segment ownership so that a late-finishing commit can't clear newer completed work, and a replacement agent can't steal older dirty segments — both needed because WebUI sessions can be reopened many times under cached or rebuilt agents.
- The module is narrow: `mark_turn_completed` is called post-turn after save/cancel/completed-journal guards; `commit_session_memory` only at boundaries (new session, eviction, shutdown).
- Provider commit I/O is kept outside cache locks and per-session mutation locks at every boundary site.

## What Changed

- Added `api/session_lifecycle.py` with per-session lifecycle state, generation/segment ownership tracking, `mark_turn_completed`, `commit_session_memory`, `register_agent`/`unregister_agent`, `has_uncommitted_work`, and `drain_all_on_shutdown`.
- Streaming path: new and cached/reopened agents are registered with the lifecycle; completed non-ephemeral turns call `mark_turn_completed` after save/cancel/completed-journal guards.
- LRU agent eviction now commits pending memory work and closes the agent's `_session_db` outside the cache lock, rather than closing the DB immediately without committing.
- `_evict_session_agent` (delete, clear, model switch) commits memory and waits for in-flight work before closing the agent's DB.
- `/api/session/new` accepts and commits a `prev_session_id` so starting a new chat from an existing session triggers a boundary commit.
- `/api/session/clear` evicts the cached agent outside the per-session mutation lock, since eviction can run provider commit I/O.
- Server shutdown drains all pending lifecycle commits before exit.
- Frontend `newSession()` sends the current `session_id` as `prev_session_id`.
- Added regression tests covering: post-turn mark-without-commit, coalesced boundary commits, late-commit safety, failed-commit retry, replacement-agent ownership, LRU eviction outside cache lock, clear-session eviction outside session lock, shutdown drain behavior, and empty-session-id safety.

## Why It Matters

- Gives batch-extraction memory providers like OpenViking a reliable commit signal from WebUI, matching CLI semantics.
- Prevents per-turn extraction while still ensuring uncommitted work is preserved across cached/reopened sessions and drained at boundaries.
- Keeps provider I/O out of cache and session mutation locks, reducing contention risk.
- All lifecycle behavior is tested: not just the happy path, but in-flight commits, failed commits, replacement agents, eviction ordering, and shutdown drain.

## Verification

```text
python -m pytest tests/test_memory_session_lifecycle_generation.py tests/test_run_journal_routes.py tests/test_sidebar_first_turn_visibility.py -q
# 32 passed

python -m py_compile api/session_lifecycle.py api/streaming.py api/routes.py api/config.py
# passed

git diff --check
# passed
```

Live smoke with OpenViking: two turns synced to current session, no archive created until `/api/session/new` with `prev_session_id`, archive then contained both turns.

## Risks / Follow-ups

- Browser/tab close is not a commit boundary; extraction remains server-lifecycle-driven (new chat, eviction, shutdown). A hard kill before any boundary leaves synced-but-unextracted current session messages — this is the same trade-off as CLI.
- `/api/session/new` does not wait for an already-in-flight commit; preserved work rolls forward to the next boundary or shutdown drain. Bounded waiting could be added as a future polish.
- Eviction paths commit one dirty segment per call; shutdown drain loops until no progress remains. Fully draining all segments during eviction could be added later if needed.

## Models Used

- GLM-5.1 for implementation
- GPT-5.5 for planning and orchestration
- Claude Opus 4.7 for independent review
