### PR TITLE
Clarify compact activity timeline semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Clarify `Compact tool activity` semantics: the setting now describes compact inline activity that preserves the agent timeline, matching the current long-running turn behavior where thinking cards, visible progress notes, and tool Activity bursts stay in chronological order instead of being described as one top-of-turn collapsed block.
+
 ## [v0.51.82] — 2026-05-17 — Release BF (stage-375 — 2-PR batch — table renderer pipe protection + Catppuccin appearance skin)
 
 ### Added

--- a/api/config.py
+++ b/api/config.py
@@ -4057,7 +4057,7 @@ _SETTINGS_DEFAULTS = {
     "rtl": False,  # right-to-left chat layout (chat messages + composer only)
     "notifications_enabled": False,  # browser notification when tab is in background
     "show_thinking": True,  # show/hide thinking/reasoning blocks in chat view
-    "simplified_tool_calling": True,  # group tools/thinking into one quiet activity disclosure
+    "simplified_tool_calling": True,  # render tools/thinking as compact inline timeline activity
     "api_redact_enabled": True,  # redact sensitive data (API keys, secrets) from API responses
     "sidebar_density": "compact",  # compact | detailed
     "auto_title_refresh_every": "0",  # adaptive title refresh: 0=off, 5/10/20=every N exchanges

--- a/static/index.html
+++ b/static/index.html
@@ -1047,7 +1047,7 @@
                 <input type="checkbox" id="settingsSimplifiedToolCalling" style="width:15px;height:15px;accent-color:var(--accent)">
                 <span>Compact tool activity</span>
               </label>
-              <div style="font-size:11px;color:var(--muted);margin-top:4px">Group thinking and tool calls into one collapsed activity section per assistant turn.</div>
+              <div style="font-size:11px;color:var(--muted);margin-top:4px">Show thinking and tool calls as compact inline activity while preserving the agent timeline.</div>
             </div>
             <div class="settings-field">
               <label style="display:flex;align-items:center;gap:8px;cursor:pointer">

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -794,7 +794,7 @@ def test_ui_js_keeps_reasoning_only_assistant_messages_visible(cleanup_test_sess
 
 def test_ui_js_does_not_hide_anchor_segments_that_contain_thinking(cleanup_test_sessions):
     """R19c2/R19c3: reasoning-only messages must remain visible through the
-    shared collapsed activity dropdown, even when the anchor segment has no prose.
+    shared compact timeline activity UI, even when the anchor segment has no prose.
     """
     src = (REPO_ROOT / "static" / "ui.js").read_text()
     compact = src.replace(' ', '').replace('\n', '')

--- a/tests/test_ui_tool_call_cleanup.py
+++ b/tests/test_ui_tool_call_cleanup.py
@@ -100,7 +100,7 @@ class TestToolCallGroupingStatic:
         fn = _function_body(UI_JS, "renderMessages")
         helper = _function_body(UI_JS, "ensureActivityGroup")
         assert "isSimplifiedToolCalling()" in fn, (
-            "Settled tool/thinking grouping should be gated by the Compact tool activity toggle."
+            "Settled compact inline activity rendering should be gated by the Compact tool activity toggle."
         )
         assert "tool-cards-toggle" in fn, (
             "The non-simplified path should preserve the upstream loose tool-card controls."
@@ -157,7 +157,7 @@ class TestToolCallGroupingStatic:
         live_fn = _function_body(UI_JS, "appendLiveToolCard")
         settled_fn = _function_body(UI_JS, "renderMessages")
         assert "isSimplifiedToolCalling()" in live_fn, (
-            "Live streaming tool cards should branch on the Compact tool activity toggle."
+            "Live streaming tool cards should branch on the Compact tool activity timeline mode."
         )
         assert "ensureActivityGroup" in live_fn, (
             "Compact live tool rendering should use the grouped activity container."
@@ -263,7 +263,7 @@ class TestToolCallGroupingStatic:
     def test_compact_activity_keeps_thinking_cards_after_session_switch(self):
         ui_min = re.sub(r"\s+", "", UI_JS)
         assert "functionensureActivityGroup(" in ui_min, (
-            "Tool calls should still use the shared Activity disclosure helper."
+            "Tool calls should still use the shared compact Activity disclosure helper."
         )
         assert "data-agent-activity-group" in UI_JS, (
             "The Activity disclosure needs a stable data-agent-activity-group hook."


### PR DESCRIPTION
## Thinking Path

- Hermes WebUI already moved long-running agent turns toward a chronological timeline: Thinking cards, visible progress notes, compact Activity bursts, and final answer stay in run order.
- The `Compact tool activity` preference still described the older product contract: grouping thinking and tools into one collapsed section per assistant turn.
- That mismatch makes the setting look broken when it is actually being used with the newer Codex/Hermes CLI-style timeline behavior.
- This PR pays down that semantic debt without changing renderer behavior.

Closes #2465.

## What Changed

- Updated the Preferences description for `Compact tool activity` to say it preserves the agent timeline while showing compact inline activity.
- Updated the `simplified_tool_calling` default comment to match the current compact inline timeline semantics.
- Updated regression-test wording so the test contract no longer implies a single top-of-turn Activity block.
- Added an Unreleased changelog entry describing the semantics clarification.

## Why It Matters

Long-running agent work needs visible chronological progress. Codex-style agent transcripts and Hermes CLI both expose ongoing thinking/tool progress as the run unfolds instead of hiding the whole middle of the turn in one top-level block. Compact mode should reduce visual noise, not erase chronology.

This PR keeps the existing setting key and current behavior, but makes the product contract honest: compact activity means quieter inline activity cards while preserving the timeline.

## Verification

- `/Users/xuefusong/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_ui_tool_call_cleanup.py tests/test_simplified_tool_calling_setting.py tests/test_regressions.py::test_ui_js_does_not_hide_anchor_segments_that_contain_thinking -q`
  - `24 passed in 1.84s`

Note: running the same command with macOS system `python3` failed before tests completed because that interpreter is Python 3.9 and cannot import the repo's `Path | None` annotations. The verified run used Python 3.11 from the local Hermes Agent venv.

## Risks / Follow-ups

- This PR intentionally does not rename or migrate `simplified_tool_calling`; changing the stored settings key would add migration risk for no immediate UX benefit.
- This PR does not change renderer behavior. Any future refinement to card placement or collapsed details should build on the clarified contract in #2465.
- No before/after screenshot is included because the change is settings copy and test-contract wording only; no layout or interaction behavior changes.

## Model Used

AI-assisted with OpenAI GPT-5. Codex CLI was used for local code inspection, editing, tests, issue creation, branch push, and PR creation.
