### PR TITLE
docs(runtime): define cancel control gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Documentation
+
+- **PR #2469** by @Michaelyklam (refs #1925) — Advance the runtime-adapter RFC after the Slice 2 seam shipped by marking Slice 2 complete and defining the first Slice 3a cancel-control gate. The new gate scopes Stop Generation through `RuntimeAdapter.cancel_run(...)` only, pins behavior-preserving cancellation, journal/status coherence, idempotent duplicate cancel, and explicit non-goals for approval/clarify, queue/goal, runner/sidecar, and public chat-start response changes.
+
 ## [v0.51.84] — 2026-05-17 — Release BH (stage-377 — 1-PR Docker hygiene — agent-image upgrade docs + read-only WebUI source mount + chown prune widening)
 
 ### Changed

--- a/docs/rfcs/hermes-run-adapter-contract.md
+++ b/docs/rfcs/hermes-run-adapter-contract.md
@@ -292,9 +292,11 @@ Success criterion:
 
 ### Slice 2: Adapter interface over the journaled legacy path
 
-Status as of 2026-05-16: ready for a planning/adapter-seam PR after the active
-Slice 1 validation pass and the #2313 selected-session stream cap. Slice 2 should
-still be a reversible boundary change, not a sidecar or execution-ownership move.
+Status as of 2026-05-17: shipped. PR #2416 defined the adapter-seam contract,
+PR #2424 added the default-off `LegacyJournalRuntimeAdapter` seam, and PR #2438
+kept `/api/chat/start` response shape identical between `legacy-direct` and the
+flagged `legacy-journal` path. Slice 2 remains a reversible boundary change, not
+a sidecar or execution-ownership move.
 
 Scope:
 
@@ -405,6 +407,13 @@ execution-survives-WebUI-restart gate remains deferred to Slice 4.
 
 ### Slice 3: Control migration
 
+Status as of 2026-05-17: not started. Slice 3 should begin with cancel only.
+Cancel is the smallest control-plane migration because it already has one clear
+browser affordance, one active-run target, and an existing legacy handler to
+delegate to. Approval, clarify, queue/continue, and goal are intentionally held
+behind a successful cancel-control slice because they carry more callback and
+state-lifetime risk.
+
 Scope:
 
 - move cancel first,
@@ -415,6 +424,55 @@ Scope:
 
 Revert path: per-control feature flags or route-level fallback to legacy control
 handlers.
+
+#### Slice 3a: Cancel control gate
+
+The first control migration should route Stop Generation through the
+`RuntimeAdapter.cancel_run(...)` seam while preserving the current legacy cancel
+semantics. It should not introduce a new cancellation registry, worker-owned
+signal table, or sidecar boundary. During this slice, `cancel_run` is still a
+protocol translator over the existing cancellation path.
+
+Acceptance properties:
+
+1. **Same visible result as legacy Stop Generation.** A cancelled turn still
+   emits one terminal cancelled/interrupted state and preserves any already
+   streamed partial assistant content according to the existing cancellation
+   contract.
+2. **Adapter flag is behavior-preserving.** With
+   `HERMES_WEBUI_RUNTIME_ADAPTER=legacy-journal`, Stop Generation uses
+   `RuntimeAdapter.cancel_run(...)`; with the default `legacy-direct` path, the
+   current route remains available as fallback.
+3. **No new runtime-surrogate state.** The implementation must not add a second
+   `CANCEL_FLAGS`-like map, cached `AIAgent` table, long-lived queue, or local
+   callback registry inside the main WebUI process.
+4. **Journal/status coherence.** After cancellation, replay and session reload
+   classify the turn as cancelled/interrupted rather than stale/unknown, and the
+   terminal state is visible through the same journal/session diagnostic surface
+   used by Slice 1.
+5. **Idempotent duplicate cancel.** Repeating cancel for the same run should be
+   safe: one terminal result is recorded, later attempts return a bounded
+   `ControlResult` such as `not-active` rather than creating extra terminal
+   events or resurrecting stale stream state.
+
+Suggested regression coverage:
+
+- a route/source test proving the flagged cancel path calls the adapter seam and
+  the default path remains the legacy route;
+- an adapter unit test proving `cancel_run` delegates exactly once and returns a
+  bounded `ControlResult` for unsupported/not-active runs;
+- an existing cancellation preservation suite run (for example the partial-output
+  and cancelled-turn status tests) under the adapter flag or an equivalent
+  synthetic harness;
+- a replay/session-load assertion that a cancelled run's terminal state remains
+  classifiable from the journal/session surface after reload.
+
+Non-goals for Slice 3a:
+
+- no approval or clarify migration;
+- no queue/continue or goal migration;
+- no runner process, sidecar, or execution-survives-WebUI-restart claim;
+- no public `/api/chat/start` response-shape expansion for adapter-only fields.
 
 ### Slice 4: Runner process / sidecar boundary
 


### PR DESCRIPTION
## Thinking Path

- #1925 Slice 1 journal/replay shipped and passed active validation.
- Slice 2 has now shipped through the default-off RuntimeAdapter seam, and v0.51.83 shipped the response-shape parity follow-up (#2438).
- The next risky step is control migration; starting with all controls would blur the seam and invite a runtime-surrogate implementation.
- The safest next artifact is docs-only: mark Slice 2 shipped, then define a narrow Slice 3a gate for Stop Generation through `RuntimeAdapter.cancel_run(...)` before any code moves.

## What Changed

- Updated `docs/rfcs/hermes-run-adapter-contract.md` to record Slice 2 as shipped via #2416, #2424, and #2438.
- Added a Slice 3a cancel-control gate with acceptance properties for:
  - legacy-visible cancellation behavior;
  - adapter-flag behavior preservation;
  - no new runtime-surrogate state;
  - journal/status coherence;
  - idempotent duplicate cancel.
- Added suggested regression coverage and explicit non-goals for approval/clarify, queue/goal, runner/sidecar, and public `/api/chat/start` response changes.
- Added a release-note-ready `CHANGELOG.md` entry.

## Why It Matters

This keeps #1925 moving after the adapter seam shipped without jumping straight to sidecar or broad control-plane work. Cancel is the smallest control migration, but it still needs clear gates so the adapter remains a protocol translator rather than a renamed `CANCEL_FLAGS` / stream-state runtime.

## Verification

```bash
git diff --check
# clean

python3 - <<'PY'
from pathlib import Path
text = Path('docs/rfcs/hermes-run-adapter-contract.md').read_text()
required = [
    'Status as of 2026-05-17: shipped',
    'Slice 3a: Cancel control gate',
    'RuntimeAdapter.cancel_run',
    'No new runtime-surrogate state',
    'Idempotent duplicate cancel',
]
missing = [s for s in required if s not in text]
if missing:
    raise SystemExit(f'missing expected text: {missing}')
print('docs smoke check passed')
PY
# docs smoke check passed
```

## Risks / Follow-ups

- Docs-only; no runtime behavior changes in this PR.
- The follow-up implementation should migrate only cancel first. Approval, clarify, queue/continue, goal, and runner/sidecar remain separate gated slices.
- If reviewers want a different first control than cancel, this PR is easy to revise before any code lands.

## Model Used

OpenAI Codex GPT-5.5 via Hermes Agent, with file editing, git, and GitHub CLI tool use.

Refs #1925.
