### PR TITLE
fix: /model alias switch for cross-provider custom models

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -1772,6 +1772,19 @@ def resolve_model_provider(model_id: str) -> tuple:
             and prefix != config_provider
         ):
             return model_id, "openrouter", None
+        # Cross-provider via custom_providers: if the prefix matches a named custom
+        # provider entry (e.g. "ollama-local/glm-4.7-flash:q4_k_m"), route through it
+        # instead of falling back to the default config provider. MUST come BEFORE
+        # the config_base_url branch because many providers have a base_url set.
+        if prefix and config_provider and prefix != config_provider:
+            _custom_cfg = cfg.get("custom_providers", [])
+            if isinstance(_custom_cfg, list):
+                for _entry in _custom_cfg:
+                    if isinstance(_entry, dict) and _entry.get("name", "").strip() == prefix:
+                        _slug = _custom_provider_slug_from_name(prefix)
+                        _base = (_entry.get("base_url") or "").strip()
+                        return model_id, _slug, _base or None
+
         # If a custom endpoint base_url is configured, don't reroute through OpenRouter
         # just because the model name contains a slash (e.g. google/gemma-4-26b-a4b).
         # The user has explicitly pointed at a base_url, so trust their routing config.
@@ -3812,11 +3825,21 @@ def get_available_models() -> dict:
             or (g.get("provider_id") or "").startswith("custom:")
         ]
 
+        # 12. Include model aliases so the WebUI frontend can resolve them.
+        model_aliases: dict[str, str] = {}
+        try:
+            raw_aliases = cfg.get("model", {}).get("aliases", {})
+            if isinstance(raw_aliases, dict):
+                model_aliases = {str(k).strip(): str(v).strip() for k, v in raw_aliases.items() if k and v}
+        except Exception:
+            pass
+
         return {
             "active_provider": active_provider,
             "default_model": default_model,
             "configured_model_badges": _build_configured_model_badges(),
             "groups": groups,
+            "aliases": model_aliases,
         }
 
     # ── FAST PATH ─────────────────────────────────────────────────────────────

--- a/static/commands.js
+++ b/static/commands.js
@@ -326,12 +326,60 @@ async function cmdModel(args){
   if(!args){showToast(t('model_usage'));return;}
   const sel=$('modelSelect');
   if(!sel)return;
-  const q=args.toLowerCase();
+  let q=args.toLowerCase();
+  // Resolve alias before fuzzy matching the dropdown.
+  // Fetch /api/models which now includes an "aliases" key.
+  try {
+    const resp=await fetch('/api/models');
+    if(resp.ok){
+      const data=await resp.json();
+      const aliases=data.aliases||{};
+      for(const [alias,modelId] of Object.entries(aliases)){
+        if(alias.toLowerCase()===q){
+          q=modelId; // resolve alias to real model id e.g. "deepseek/deepseek-v4-flash"
+          break;
+        }
+      }
+    }
+  } catch(_){/* non-critical, fall through to fuzzy match */}
   // Fuzzy match: find first option whose label or value contains the query
   let match=null;
   for(const opt of sel.options){
     if(opt.value.toLowerCase().includes(q)||opt.textContent.toLowerCase().includes(q)){
       match=opt.value;break;
+    }
+  }
+  // Fallback: if q has provider/ prefix (e.g. "deepseek/deepseek-v4-flash"),
+  // try the bare model name (which is how options appear for the active provider)
+  if(!match && q.includes('/')){
+    const bare=q.slice(q.lastIndexOf('/')+1);
+    for(const opt of sel.options){
+      if(opt.value.toLowerCase().includes(bare)||opt.textContent.toLowerCase().includes(bare)){
+        match=opt.value;break;
+      }
+    }
+    // Cross-provider fallback: if still no match, the model is from a
+    // different provider not in the dropdown. Call /api/session/update directly.
+    if(!match && S&&S.session&&S.session.session_id){
+      const provider=q.slice(0,q.indexOf('/'));
+      try{
+        const resp=await fetch('/api/session/update',{
+          method:'POST',
+          headers:{'Content-Type':'application/json'},
+          body:JSON.stringify({
+            session_id:S.session.session_id,
+            model:q,
+            model_provider:provider,
+          }),
+        });
+        if(resp.ok){
+          S.session.model=q;
+          S.session.model_provider=provider;
+          if(typeof syncTopbar==='function') syncTopbar();
+          showToast(t('switched_to')+q);
+          return;
+        }
+      }catch(_){/* fall through to "no model match" */}
     }
   }
   if(!match){showToast(t('no_model_match')+`"${args}"`);return;}


### PR DESCRIPTION
## Summary

Fixes `/model <alias>` in WebUI when the alias resolves to a model on a **custom provider** that differs from the active provider (e.g. `/model glm` → `ollama-local/glm-4.7-flash:q4_k_m` while the active provider is `deepseek`).

## Problem

The WebUI `/model` command failed for cross-provider aliases because:

1. **Backend**: `resolve_model_provider()` in `api/config.py` checked custom_providers AFTER the `config_base_url` branch. Since `deepseek` has a `base_url` set, the `config_base_url` branch caught ALL slash-delimited model ids and returned `(model_id, config_provider, config_base_url)` — routing them to `deepseek` instead of the custom provider. The custom_providers check was never reached.

2. **Frontend**: `cmdModel()` in `static/commands.js` had no way to resolve aliases or handle models from providers not in the active provider dropdown.

## Changes

### Backend (`api/config.py`)

- **`resolve_model_provider()`**: Added a custom_providers prefix check **before** the `config_base_url` branch. When the model id prefix (e.g. `ollama-local`) matches a custom provider entry, it routes through that custom provider instead of falling through to the config provider.

- **`get_available_models()`**: Added `"aliases"` key to the JSON response so the frontend can resolve user-defined model aliases.

### Frontend (`static/commands.js`)

- **`cmdModel()`**: Fetches `/api/models` to resolve user-defined aliases before fuzzy-matching the dropdown.

- When the alias resolves to a slash-delimited id (e.g. `deepseek/deepseek-v4-flash`), tries the bare model name as a fallback for dropdown matching.

- If still no match (cross-provider scenario), bypasses the dropdown and calls `/api/session/update` directly with the full model id and provider override.

## Test Plan

- [x] `/model dschat` → switches to `deepseek/deepseek-v4-flash` (same provider, slash-delimited)
- [x] `/model dsv4` → switches to `deepseek/deepseek-v4-pro` (same provider, bare model)
- [x] `/model glm` → switches to `ollama-local/glm-4.7-flash:q4_k_m` (custom provider)
- [x] `/model mistral` → switches to `ollama-local/mistral-nemo:12b:q4_k_m` (custom provider)

## Affected Files

- `api/config.py` — `resolve_model_provider()`, `get_available_models()`
- `static/commands.js` — `cmdModel()`

Closes: N/A (community bug report)