### PR TITLE
feat(runtime): route cancel through RuntimeAdapter seam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- **PR #TBD** by @Michaelyklam (refs #1925) — Route Stop Generation through the default-off `RuntimeAdapter.cancel_run(...)` seam when `HERMES_WEBUI_RUNTIME_ADAPTER=legacy-journal` is enabled, while preserving the legacy `/api/chat/cancel` response shape and direct `cancel_stream(...)` fallback for the default `legacy-direct` path. This starts Slice 3a cancel-control migration without adding a new cancellation registry, runner, sidecar, approval/clarify migration, queue/goal migration, or chat-start contract changes.
+
 ## [v0.51.85] — 2026-05-17 — Release BI (stage-378 — 3-PR batch — workspace-prefix display leakage fix + release-tag update banner + Slice 3a cancel-control gate RFC)
 
 ### Fixed

--- a/api/routes.py
+++ b/api/routes.py
@@ -4035,7 +4035,13 @@ def handle_get(handler, parsed) -> bool:
         stream_id = parse_qs(parsed.query).get("stream_id", [""])[0]
         if not stream_id:
             return bad(handler, "stream_id required")
-        cancelled = cancel_stream(stream_id)
+        from api.runtime_adapter import LegacyJournalRuntimeAdapter, runtime_adapter_enabled
+
+        if runtime_adapter_enabled():
+            adapter = LegacyJournalRuntimeAdapter(cancel_delegate=cancel_stream)
+            cancelled = adapter.cancel_run(stream_id).accepted
+        else:
+            cancelled = cancel_stream(stream_id)
         return j(handler, {"ok": True, "cancelled": cancelled, "stream_id": stream_id})
 
     if parsed.path == "/api/chat/stream":

--- a/tests/test_runtime_adapter_seam.py
+++ b/tests/test_runtime_adapter_seam.py
@@ -109,6 +109,34 @@ def test_legacy_journal_adapter_controls_delegate_to_existing_handlers():
     ]
 
 
+def test_legacy_journal_adapter_cancel_returns_bounded_not_active_status():
+    runtime = importlib.import_module("api.runtime_adapter")
+    calls = []
+    adapter = runtime.LegacyJournalRuntimeAdapter(
+        cancel_delegate=lambda run_id: calls.append(run_id) or False,
+    )
+
+    result = adapter.cancel_run("already-finished-run")
+
+    assert calls == ["already-finished-run"]
+    assert result.accepted is False
+    assert result.status == "not-active"
+    assert result.safe_message == "Legacy control did not accept the request."
+
+
+def test_chat_cancel_route_uses_adapter_only_when_flag_enabled():
+    routes = importlib.import_module("api.routes")
+    src = (routes.Path(__file__).parent.parent / "api" / "routes.py").read_text(encoding="utf-8")
+    cancel_idx = src.index('if parsed.path == "/api/chat/cancel":')
+    cancel_body = src[cancel_idx:src.index('if parsed.path == "/api/chat/stream":', cancel_idx)]
+
+    assert "runtime_adapter_enabled()" in cancel_body
+    assert "LegacyJournalRuntimeAdapter(cancel_delegate=cancel_stream)" in cancel_body
+    assert "adapter.cancel_run(stream_id).accepted" in cancel_body
+    assert "else:\n            cancelled = cancel_stream(stream_id)" in cancel_body
+    assert "HERMES_WEBUI_RUNTIME_ADAPTER" not in cancel_body, "route should use runtime_adapter_enabled(), not inline env checks"
+
+
 def test_chat_start_route_selects_adapter_only_when_flag_enabled():
     routes = importlib.import_module("api.routes")
     src = (routes.Path(__file__).parent.parent / "api" / "routes.py").read_text(encoding="utf-8")
@@ -129,9 +157,11 @@ def test_chat_start_adapter_path_preserves_legacy_response_shape():
     """
     routes = importlib.import_module("api.routes")
     src = (routes.Path(__file__).parent.parent / "api" / "routes.py").read_text(encoding="utf-8")
-    branch_start = src.index("if runtime_adapter_enabled():")
-    branch_end = src.index("else:", branch_start)
-    adapter_branch = src[branch_start:branch_end]
+    start_idx = src.index("def _handle_chat_start")
+    start_body = src[start_idx:src.index("def _resolve_chat_workspace_with_recovery", start_idx)]
+    branch_start = start_body.index("if runtime_adapter_enabled():")
+    branch_end = start_body.index("else:", branch_start)
+    adapter_branch = start_body[branch_start:branch_end]
 
     assert 'response.setdefault("stream_id", result.stream_id)' in adapter_branch
     assert 'response.setdefault("session_id", result.session_id)' in adapter_branch


### PR DESCRIPTION
## Thinking Path

- #1925 has shipped Slice 1 journal/replay and Slice 2's default-off RuntimeAdapter seam.
- PR #2469 / v0.51.85 accepted the Slice 3a gate: move **Stop Generation only** through `RuntimeAdapter.cancel_run(...)` before touching approval, clarify, queue/goal, or runner/sidecar work.
- The safe first implementation is a protocol-translator route change: when `HERMES_WEBUI_RUNTIME_ADAPTER=legacy-journal` is enabled, `/api/chat/cancel` delegates through `LegacyJournalRuntimeAdapter.cancel_run(...)`; the default `legacy-direct` path still calls `cancel_stream(...)` directly.
- This keeps the browser response shape stable and avoids creating any new cancellation registry or runtime-surrogate state.

## What Changed

- Updated `/api/chat/cancel` to route through `LegacyJournalRuntimeAdapter(cancel_delegate=cancel_stream).cancel_run(stream_id)` only when the runtime adapter flag is enabled.
- Preserved the existing `/api/chat/cancel` JSON contract: `{ ok, cancelled, stream_id }`.
- Preserved the default direct legacy fallback when the adapter flag is not enabled.
- Added regression coverage for:
  - bounded `not-active` `ControlResult` behavior when the legacy cancel delegate does not accept a run;
  - the cancel route using the adapter seam only behind `runtime_adapter_enabled()`;
  - the chat-start response-shape source test staying scoped to `_handle_chat_start` after the cancel route gained its own adapter branch.
- Added an Unreleased changelog entry for the Slice 3a implementation step.

## Why It Matters

This is the first narrow control-plane migration slice for #1925. It proves Stop Generation can be expressed through the RuntimeAdapter seam without changing visible behavior or inventing a second runtime inside the WebUI process.

## Verification

```bash
env -u HERMES_CONFIG_PATH -u HERMES_WEBUI_HOST /home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_runtime_adapter_seam.py tests/test_sprint10.py tests/test_issue893_cancel_preserves_partial.py tests/test_issue1361_cancel_data_loss.py tests/test_cancelled_turn_status.py tests/test_run_journal.py tests/test_run_journal_routes.py -q
# 86 passed in 2.54s

/home/michael/.hermes/hermes-agent/venv/bin/python -m py_compile api/runtime_adapter.py api/routes.py

git diff --check
# clean

env -u HERMES_CONFIG_PATH -u HERMES_WEBUI_HOST /home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/ -q
# 5868 passed, 6 skipped, 3 xpassed, 8 subtests passed in 90.60s
```

## Risks / Follow-ups

- The adapter path still delegates to the existing `cancel_stream(...)`; this PR intentionally does **not** move execution ownership, cancellation flags, agent instances, or callback lifetime out of the WebUI process.
- Approval, clarify, queue/continue, goal, and runner/sidecar work remain explicitly out of scope.
- The implementation keeps adapter-internal control status out of the public cancel response; if maintainers want control-result details surfaced later, that should be a separate contract change applying consistently across paths.

## Model Used

OpenAI Codex `gpt-5.5` via Hermes Agent, with filesystem, terminal, and GitHub CLI tool use.
