### PR TITLE
docs: note Android AVF ARM64 field report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Documentation
+
+- Refs #2364 — Add a narrow README note for the community ARM64 Android AVF field report: Hermes Agent + WebUI running inside a Debian 12 VM on a mid-range Android phone with cloud-hosted inference. The note frames the report as a compatibility signal rather than an official support baseline or provider/model benchmark, and records practical mobile caveats around first-install compile time, Android tab reloads, and battery optimization.
+
 ## [v0.51.85] — 2026-05-17 — Release BI (stage-378 — 3-PR batch — workspace-prefix display leakage fix + release-tag update banner + Slice 3a cancel-control gate RFC)
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -328,6 +328,22 @@ That's it. Traffic is encrypted end-to-end by WireGuard, and password auth
 protects the UI at the application level. You can add it to your home screen
 for an app-like experience.
 
+### Community field report: ARM64 Android via AVF
+
+A community report in [#2364](https://github.com/nesquena/hermes-webui/issues/2364)
+documents Hermes Agent + WebUI running on a mid-range ARM64 Android phone inside
+a Debian 12 VM via Android Virtualization Framework (AVF). The reported setup
+used a Xiaomi Redmi Note 13 Pro 4G, 3.8 GiB RAM allocated to the VM, 8 visible
+CPU cores, Chrome on Android at `localhost:8787`, and cloud-hosted inference.
+
+This is not an official support baseline or provider/model benchmark, but it is
+a useful compatibility signal for mobile ARM64 experiments: the WebUI rendered
+smoothly in Chrome, ARM64 Debian worked for the agent stack, and the total local
+footprint was about 1.7 GB. Practical caveats from the report: first install can
+take longer when dependencies compile from source, Android browser tabs may
+reload when switching apps, and disabling battery optimization for the terminal
+or VM host may be needed for longer-running sessions.
+
 > **Tip:** If using Docker, set `HERMES_WEBUI_HOST=0.0.0.0` in your
 > `docker-compose.yml` environment (already the default) and set
 > `HERMES_WEBUI_PASSWORD`.


### PR DESCRIPTION
## Thinking Path
Issue #2364 is a real upstream documentation/data-point issue, not a code bug. The maintainer response frames the Android AVF report as an informational compatibility signal that should remain a reference, so the safest contribution is a small documentation note rather than a runtime or provider/model change.

## What Changed
- Added a README note under the mobile/Tailscale guidance for the community ARM64 Android AVF field report.
- Added an Unreleased changelog documentation entry.
- Used `Refs #2364` instead of a closing keyword because the issue is being kept open as a reference/data point.

## Why It Matters
Users experimenting with mobile or constrained ARM64 environments now have a concrete, caveated compatibility signal: Hermes WebUI can run on an Android phone via AVF + Debian VM with cloud inference, while still noting the setup is experimental and not an official Android support baseline.

## Verification
- `git diff --check`
- `python -m pytest tests/test_docs_gitignore_policy.py -q` → `4 passed`
- Reviewer gate: verified no duplicate open PR, docs-only scope, accurate issue framing, and no closing keyword for #2364.

## Risks / Follow-ups
- This intentionally does not document local mobile inference, provider/model benchmarks, or official native Android support.
- #2364 should remain open unless maintainers decide the field report no longer needs to be tracked as a reference.

## Model Used
OpenAI GPT-5.5 via Hermes Agent. Workflow used researcher/implementer/reviewer subagents, live GitHub duplicate checks, and local docs/test verification.

Refs #2364
