### PR TITLE
fix: collapse WebUI compression continuations in sidebar

### DIFF
--- a/static/sessions.js
+++ b/static/sessions.js
@@ -2246,17 +2246,31 @@ function _isChildSession(s){
   return !!(s&&s.parent_session_id&&s.relationship_type==='child_session');
 }
 
-function _sessionLineageKey(s, sessionIdsInList){
+function _sessionLineageKey(s, sessionIdsInList, sessionsById){
   if(!s||!s.session_id) return null;
   if(_isChildSession(s)) return null;
   if(s.session_source==='fork') return null;
   const lineageKey=s._lineage_root_id||s.lineage_root_id||null;
   if(lineageKey) return lineageKey;
+  // WebUI-native context compression may only persist parent_session_id:
+  // the preserved parent snapshot is marked pre_compression_snapshot while
+  // the new continuation points at it.  When both rows are in the sidebar
+  // payload, still collapse them into one conversation (#2489).
+  const parent=s.parent_session_id&&sessionsById?sessionsById.get(s.parent_session_id):null;
+  if(s.pre_compression_snapshot||parent&&parent.pre_compression_snapshot){
+    let root=s;
+    const seen=new Set();
+    while(root&&root.parent_session_id&&sessionsById&&sessionsById.has(root.parent_session_id)&&!seen.has(root.parent_session_id)){
+      const next=sessionsById.get(root.parent_session_id);
+      if(!next||_isChildSession(next)||next.session_source==='fork'||!(root.pre_compression_snapshot||next.pre_compression_snapshot)) break;
+      seen.add(root.session_id);
+      root=next;
+    }
+    return root&&root.session_id||s.parent_session_id||s.session_id;
+  }
   // If parent_session_id points to another session in the current list,
   // this is a subagent/fork child without compression metadata — don't
-  // collapse it into lineage (#494). Compression continuations carry an
-  // explicit lineage root, even when stale optimistic rows leave parent
-  // segments in the browser cache during active compression.
+  // collapse it into lineage (#494).
   if(s.parent_session_id && sessionIdsInList && sessionIdsInList.has(s.parent_session_id)){
     return null;
   }
@@ -2432,9 +2446,10 @@ function _syncSidebarExpansionForActiveSession(rows, activeSid){
 function _collapseSessionLineageForSidebar(sessions){
   const result=[];
   const sessionIdsInList=new Set((sessions||[]).map(s=>s.session_id));
+  const sessionsById=new Map((sessions||[]).filter(s=>s&&s.session_id).map(s=>[s.session_id,s]));
   const groups=new Map();
   for(const s of sessions||[]){
-    const key=_sessionLineageKey(s, sessionIdsInList);
+    const key=_sessionLineageKey(s, sessionIdsInList, sessionsById);
     if(!key){result.push(s);continue;}
     if(!groups.has(key)) groups.set(key,[]);
     groups.get(key).push(s);

--- a/tests/test_session_lineage_collapse.py
+++ b/tests/test_session_lineage_collapse.py
@@ -126,6 +126,47 @@ console.log(JSON.stringify({{sid: collapsed[0].session_id, containsRoot: _sessio
     assert '"containsRoot":true' in result
 
 
+def test_parent_present_webui_compression_child_without_lineage_metadata_collapses():
+    """WebUI-native compression continuations may only carry parent_session_id.
+
+    When both the preserved parent snapshot and the new continuation are present
+    in the sidebar payload, the continuation should still collapse with its
+    parent instead of appearing as a separate branch-like conversation (#2489).
+    """
+    js = SESSIONS_JS_PATH.read_text(encoding="utf-8")
+    source = f"""
+const src = {js!r};
+function extractFunc(name) {{
+  const re = new RegExp('function\\\\s+' + name + '\\\\s*\\\\(');
+  const start = src.search(re);
+  if (start < 0) throw new Error(name + ' not found');
+  let i = src.indexOf('{{', start);
+  let depth = 1; i++;
+  while (depth > 0 && i < src.length) {{
+    if (src[i] === '{{') depth++;
+    else if (src[i] === '}}') depth--;
+    i++;
+  }}
+  return src.slice(start, i);
+}}
+eval(extractFunc('_sessionTimestampMs'));
+eval(extractFunc('_isChildSession'));
+eval(extractFunc('_sessionLineageKey'));
+eval(extractFunc('_collapseSessionLineageForSidebar'));
+const sessions = [
+  {{session_id:'parent', title:'Long WebUI conversation', message_count:50, updated_at:10, last_message_at:10, pre_compression_snapshot:true}},
+  {{session_id:'child', title:'Long WebUI conversation', parent_session_id:'parent', message_count:12, updated_at:20, last_message_at:20}},
+];
+const collapsed = _collapseSessionLineageForSidebar(sessions);
+console.log(JSON.stringify(collapsed));
+"""
+    collapsed = json.loads(_run_node(source))
+    assert [row["session_id"] for row in collapsed] == ["child"]
+    assert collapsed[0]["_lineage_key"] == "parent"
+    assert collapsed[0]["_lineage_collapsed_count"] == 2
+    assert [seg["session_id"] for seg in collapsed[0]["_lineage_segments"]] == ["child", "parent"]
+
+
 def test_stale_optimistic_compression_tips_collapse_even_when_parents_are_visible():
     """Active compression can leave old streaming tips in browser memory.
 


### PR DESCRIPTION
## Thinking Path

- Hermes WebUI should keep long-running WebUI conversations visually continuous in the sidebar.
- Auto-compression preserves the previous session as a `pre_compression_snapshot` and starts a continuation that may only carry `parent_session_id`.
- When both rows are present in the sidebar payload and the continuation has no explicit lineage metadata yet, `_sessionLineageKey()` treated the parent-present link as a non-compression child/fork guard case and returned `null`.
- That made the preserved snapshot and continuation render as separate branch-like sidebar rows.
- This PR keeps the existing child/fork guard, but recognizes the `pre_compression_snapshot` parent-chain shape as compression lineage and collapses it into one sidebar row.

## What Changed

- Pass a `sessionsById` map into `_sessionLineageKey()` from `_collapseSessionLineageForSidebar()`.
- Collapse WebUI-native compression continuations when the row or its visible parent is marked `pre_compression_snapshot`.
- Walk compatible preserved-snapshot parents so the lineage key stays stable across materialized compression chains.
- Add a regression test for the #2489 case where a parent snapshot and its continuation are both visible but the continuation lacks `_lineage_root_id` / `lineage_root_id`.

## Why It Matters

Fixes #2489. Long WebUI conversations should stay as one sidebar conversation while context compression happens in the background, instead of appearing to spawn branch-like sessions.

## Verification

Passed:

```bash
node --check static/sessions.js
python -m py_compile api/routes.py api/models.py
python -m pytest \
  tests/test_session_lineage_collapse.py \
  tests/test_session_lineage_metadata_api.py \
  tests/test_session_index.py \
  tests/test_compression_snapshot_runtime_clear.py \
  -q
```

Result: `50 passed`.

Also ran:

```bash
python -m pytest tests/ -q
```

Result on this checkout: `5886 passed, 6 skipped, 3 xpassed, 8 subtests passed, 4 failed`.

The 4 failures are unrelated existing model-provider expectations in `tests/test_issue1527_lmstudio_base_url_classification.py`; this PR only changes `static/sessions.js` and `tests/test_session_lineage_collapse.py`.

## Risks / Follow-ups

- The new collapse path is intentionally limited to `pre_compression_snapshot` lineage shapes so ordinary child sessions and fork sessions continue to render separately.
- This does not introduce broader same-title grouping; it only fixes compression continuation collapse.
- No styling or interaction changes are included.

## Model Used

OpenAI GPT-5.5 via Hermes Agent / Codex tool workflow.