### PR TITLE
fix(routes): short-circuit resolve_model_provider when caller supplies (model, provider)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **PR (TBD)** (closes #1855) — Short-circuit the `resolve_model_provider` stage in `POST /api/chat/start` (and sibling chat-handler call sites) when the request already carries an explicit `(model, model_provider)` pair and the model isn't `@provider:model`-qualified. The new fast path in `_resolve_compatible_session_model_state()` returns the inputs verbatim without calling `get_available_models()` — that catalog rebuild can do network I/O (custom OpenAI-compat `/models`, OpenRouter `/models`, LM Studio probes, credential-pool refresh) under an RLock thundering-herd guard and was observed wedging a single request for 115 seconds in a production-grade local deployment. The recurrence captured via the PR #1911 stage diagnostics confirmed the wedge sat entirely in `resolve_model_provider` while every other stage completed in <5 ms. Users behind default-60s reverse proxies (nginx / Apache / Caddy / Cloudflare) were seeing a `502 Proxy Error` while the WebUI eventually completed the run anyway, creating a duplicate-send risk if the user retried in the browser. The slow path is preserved for the inputs that genuinely need it: bare/un-qualified models without a stored `model_provider` (cross-provider repair), `@provider:model`-qualified strings (active-provider validation per #1253), and empty models (default-model lookup). 14 new regression tests in `tests/test_issue1855_resolve_model_provider_fast_path.py` cover both directions — fast-path skips, slow-path still fires — including a static check that the short-circuit precedes the catalog call in source order.
+
 ## [v0.51.88] — 2026-05-18 — Release BL (stage-381 — 3-PR security + UX + lineage batch — session-bound CSRF tokens for unsafe browser requests + quoted-reply selected-text composer append + compression-continuation sidebar collapse)
 
 ### Security

--- a/api/routes.py
+++ b/api/routes.py
@@ -1486,11 +1486,31 @@ def _resolve_compatible_session_model_state(
     the wrong backend and fail. Normalize only obvious cross-provider mismatches.
     When a model has an explicit provider context, keep the model string itself
     in its picker/API shape and carry the provider as separate state.
+
+    Fast path (#1855): when the caller supplies both a model and an explicit
+    ``model_provider`` AND the model is not itself ``@provider:model``-qualified,
+    we can return the inputs verbatim without calling ``get_available_models()``.
+    The slow path below would arrive at the same answer via
+    ``if requested_provider and not explicit_provider: return model, requested_provider, False``
+    after paying the full catalog-build cost. Avoiding the catalog here keeps
+    ``POST /api/chat/start`` snappy even when the model catalog is cold and the
+    rebuild has to make network calls (custom OpenAI-compat endpoints,
+    OpenRouter ``/models``, LM Studio ``/models``, credential pool refresh) —
+    those used to wedge the handler for >100s and trigger 502s on default-60s
+    reverse proxies, even though the WebUI itself eventually responded.
     """
-    catalog = get_available_models()
-    default_model = str(catalog.get("default_model") or DEFAULT_MODEL or "").strip()
     model = str(model_id or "").strip()
     requested_provider = _clean_session_model_provider(model_provider)
+    if model and requested_provider:
+        # Only safe when the model itself does not carry an ``@provider:model``
+        # qualifier — qualified strings require the catalog to decide whether
+        # the qualifier matches the active provider (see slow path below).
+        bare_model, explicit_provider = _split_provider_qualified_model(model)
+        if not explicit_provider:
+            return model, requested_provider, False
+
+    catalog = get_available_models()
+    default_model = str(catalog.get("default_model") or DEFAULT_MODEL or "").strip()
     if not model:
         return default_model, requested_provider, bool(default_model)
 

--- a/tests/test_issue1855_resolve_model_provider_fast_path.py
+++ b/tests/test_issue1855_resolve_model_provider_fast_path.py
@@ -1,0 +1,274 @@
+"""Tests for issue #1855 — /api/chat/start wedge on resolve_model_provider stage.
+
+When the model catalog is cold and a rebuild has to make network calls
+(custom OpenAI-compat endpoints, OpenRouter /models, LM Studio /models, or a
+credential pool refresh), get_available_models() can take 100s+ to return.
+
+POST /api/chat/start used to call _resolve_compatible_session_model_state(),
+which unconditionally invoked get_available_models() — wedging the request
+past the typical 60s reverse-proxy timeout. Users behind nginx/Apache/Caddy
+saw 502 Proxy Error while WebUI eventually started the run anyway, creating
+a duplicate-send risk if the user retried.
+
+The fix: when the caller supplies an explicit model_provider AND the model is
+not an @provider:model-qualified string, skip the catalog build entirely and
+return (model, requested_provider, False) verbatim. The slow path would have
+reached the same answer; we just avoid paying for the cold catalog.
+
+Coverage:
+
+1. The fast path returns without calling get_available_models() when both
+   inputs are present and the model has no @-prefix.
+2. The fast path correctly preserves the model and provider unchanged.
+3. The slow path still fires for @provider:model qualified IDs (those need
+   the catalog to validate the qualifier against the active provider).
+4. The slow path still fires when no requested_provider is given (cross-
+   provider repair is the slow path's job).
+5. The slow path still fires when model is empty (default-model lookup
+   requires the catalog).
+6. The fast path returns model_was_normalized=False (no repair, just pass-
+   through).
+"""
+import pathlib
+import re
+from unittest.mock import patch
+
+
+REPO_ROOT = pathlib.Path(__file__).parent.parent.resolve()
+
+
+def _read(rel_path: str) -> str:
+    return (REPO_ROOT / rel_path).read_text(encoding="utf-8")
+
+
+class TestFastPathInvocation:
+    """The fast path must skip get_available_models() in the happy case."""
+
+    def test_fast_path_with_bare_model_and_provider_skips_catalog(self):
+        """Caller-supplied (model, model_provider) returns without catalog."""
+        from api.routes import _resolve_compatible_session_model_state
+
+        with patch("api.routes.get_available_models") as mock_catalog:
+            result = _resolve_compatible_session_model_state(
+                "gpt-5.5",
+                "openai-codex",
+            )
+
+        assert mock_catalog.call_count == 0, (
+            "get_available_models() must not be called when both model and "
+            "model_provider are supplied and the model has no @provider:model "
+            "qualifier — that's the point of the fast path."
+        )
+        assert result == ("gpt-5.5", "openai-codex", False)
+
+    def test_fast_path_with_slash_qualified_model_skips_catalog(self):
+        """Slash-qualified IDs (openrouter/...) still hit the fast path.
+
+        The fast path only excludes @provider:model strings, not slash-
+        qualified ones — those are valid model IDs that the picker emits
+        for OpenRouter and custom-provider routing, and a stored
+        model_provider is the authoritative routing decision.
+        """
+        from api.routes import _resolve_compatible_session_model_state
+
+        with patch("api.routes.get_available_models") as mock_catalog:
+            result = _resolve_compatible_session_model_state(
+                "anthropic/claude-opus-4.7",
+                "openrouter",
+            )
+
+        assert mock_catalog.call_count == 0
+        assert result == ("anthropic/claude-opus-4.7", "openrouter", False)
+
+    def test_fast_path_normalizes_provider_default_alias(self):
+        """`'default'` is treated as None by _clean_session_model_provider.
+
+        When the requested_provider cleans to None, the fast path must NOT
+        fire — the slow path needs to read the catalog to find the active
+        provider.
+        """
+        from api.routes import _resolve_compatible_session_model_state
+
+        with patch("api.routes.get_available_models") as mock_catalog:
+            mock_catalog.return_value = {
+                "active_provider": "openai-codex",
+                "default_model": "gpt-5.5",
+                "groups": [
+                    {"provider_id": "openai-codex", "models": [{"id": "gpt-5.5"}]}
+                ],
+            }
+            _resolve_compatible_session_model_state("gpt-5.5", "default")
+
+        assert mock_catalog.call_count == 1, (
+            "'default' is a sentinel meaning 'no explicit provider'; the slow "
+            "path must run so the catalog can supply the active provider."
+        )
+
+    def test_fast_path_preserves_explicit_provider_unchanged(self):
+        """Caller's explicit provider passes through verbatim, no aliasing."""
+        from api.routes import _resolve_compatible_session_model_state
+
+        with patch("api.routes.get_available_models") as mock_catalog:
+            # Even a non-canonical provider slug must pass through — this is
+            # the contract that resolve_model_provider() in config.py relies on
+            # to route through custom: providers.
+            result = _resolve_compatible_session_model_state(
+                "GLM-4.5-Air-FP8",
+                "custom:siliconflow",
+            )
+
+        assert mock_catalog.call_count == 0
+        assert result[0] == "GLM-4.5-Air-FP8"
+        assert result[1] == "custom:siliconflow"
+        assert result[2] is False  # model_was_normalized=False
+
+
+class TestSlowPathStillFires:
+    """The slow path must still fire for inputs that require catalog work."""
+
+    def test_at_provider_qualified_model_goes_to_slow_path(self):
+        """`@openrouter:foo/bar` strings need the catalog to validate the qualifier."""
+        from api.routes import _resolve_compatible_session_model_state
+
+        with patch("api.routes.get_available_models") as mock_catalog:
+            mock_catalog.return_value = {
+                "active_provider": "openrouter",
+                "default_model": "anthropic/claude-opus-4.7",
+                "groups": [
+                    {"provider_id": "openrouter", "models": [{"id": "anthropic/claude-opus-4.7"}]}
+                ],
+            }
+            _resolve_compatible_session_model_state(
+                "@openrouter:anthropic/claude-opus-4.7",
+                "openrouter",
+            )
+
+        assert mock_catalog.call_count == 1, (
+            "@provider:model qualified strings need the catalog to verify "
+            "the qualifier matches the active provider and to detect stale "
+            "cross-provider artifacts (#1253)."
+        )
+
+    def test_no_requested_provider_goes_to_slow_path(self):
+        """When provider isn't supplied, slow path must repair from catalog."""
+        from api.routes import _resolve_compatible_session_model_state
+
+        with patch("api.routes.get_available_models") as mock_catalog:
+            mock_catalog.return_value = {
+                "active_provider": "anthropic",
+                "default_model": "claude-opus-4.7",
+                "groups": [
+                    {"provider_id": "anthropic", "models": [{"id": "claude-opus-4.7"}]}
+                ],
+            }
+            _resolve_compatible_session_model_state("claude-opus-4.7", None)
+
+        assert mock_catalog.call_count == 1
+
+    def test_empty_model_goes_to_slow_path_for_default_lookup(self):
+        """Empty model means 'use the default' — needs catalog to find it."""
+        from api.routes import _resolve_compatible_session_model_state
+
+        with patch("api.routes.get_available_models") as mock_catalog:
+            mock_catalog.return_value = {
+                "default_model": "gpt-5.5",
+                "active_provider": "openai-codex",
+                "groups": [],
+            }
+            result = _resolve_compatible_session_model_state("", "openai-codex")
+
+        assert mock_catalog.call_count == 1, (
+            "Empty model must consult the catalog to find the configured "
+            "default model — the fast path can only short-circuit when a "
+            "concrete model is supplied."
+        )
+        assert result[0] == "gpt-5.5"
+
+
+class TestFastPathSourceShape:
+    """Static checks that the fast path is wired correctly in the source.
+
+    Belt-and-suspenders to ensure a future refactor can't silently remove the
+    short-circuit without flipping a test.
+    """
+
+    def test_fast_path_branch_present_in_source(self):
+        """The fast-path early-return must be in _resolve_compatible_session_model_state."""
+        src = _read("api/routes.py")
+        idx = src.find("def _resolve_compatible_session_model_state(")
+        assert idx != -1
+        # Limit search to the function body (~150 lines is enough for the
+        # whole helper; the fast path is in the first 50 lines).
+        body = src[idx:idx + 6000]
+        assert "if model and requested_provider:" in body, (
+            "Fast-path guard missing — _resolve_compatible_session_model_state "
+            "should short-circuit before get_available_models() when both "
+            "inputs are supplied."
+        )
+
+    def test_fast_path_runs_before_get_available_models_call(self):
+        """The fast-path return must come BEFORE the catalog lookup."""
+        src = _read("api/routes.py")
+        idx = src.find("def _resolve_compatible_session_model_state(")
+        body = src[idx:idx + 6000]
+        fast_path_idx = body.find("if model and requested_provider:")
+        catalog_idx = body.find("catalog = get_available_models()")
+        assert fast_path_idx != -1 and catalog_idx != -1
+        assert fast_path_idx < catalog_idx, (
+            "Fast-path guard must precede the catalog call — otherwise the "
+            "POST /api/chat/start wedge from #1855 will recur."
+        )
+
+    def test_issue_1855_referenced_in_fast_path_docstring(self):
+        """The fast-path docstring must reference #1855 for future readers."""
+        src = _read("api/routes.py")
+        idx = src.find("def _resolve_compatible_session_model_state(")
+        body = src[idx:idx + 6000]
+        # Stop at the next def to bound the search to this function's body.
+        next_def = body.find("\ndef ", 100)
+        if next_def != -1:
+            body = body[:next_def]
+        assert "#1855" in body, (
+            "Fast-path docstring should reference #1855 so future readers "
+            "understand why the short-circuit exists and what it prevents."
+        )
+
+
+class TestSplitProviderQualifiedModel:
+    """Sanity check on the helper used to detect @provider:model strings."""
+
+    def test_at_prefix_with_colon_returns_provider(self):
+        from api.routes import _split_provider_qualified_model
+        bare, provider = _split_provider_qualified_model("@openrouter:anthropic/claude-opus-4.7")
+        assert bare == "anthropic/claude-opus-4.7"
+        assert provider == "openrouter"
+
+    def test_bare_model_returns_no_provider(self):
+        from api.routes import _split_provider_qualified_model
+        bare, provider = _split_provider_qualified_model("gpt-5.5")
+        assert bare == "gpt-5.5"
+        assert provider is None
+
+    def test_slash_qualified_no_at_returns_no_provider(self):
+        """Slash-qualified IDs without @ prefix are not provider-qualified."""
+        from api.routes import _split_provider_qualified_model
+        bare, provider = _split_provider_qualified_model("anthropic/claude-opus-4.7")
+        assert bare == "anthropic/claude-opus-4.7"
+        assert provider is None
+
+
+class TestChatStartHandlerStillStagesResolveModelProvider:
+    """The diagnostic stage name must still be 'resolve_model_provider'.
+
+    Production deployments grep stage names for slow-request alerts (#1911).
+    Renaming or removing the stage would break those.
+    """
+
+    def test_chat_start_emits_resolve_model_provider_stage(self):
+        src = _read("api/routes.py")
+        # /api/chat/start handler — locate by the resolve_model_provider diag.stage call.
+        assert 'diag.stage("resolve_model_provider")' in src, (
+            "/api/chat/start handler must emit a 'resolve_model_provider' "
+            "diagnostic stage so production slow-request alerts (PR #1911) "
+            "continue to surface this stage when it's slow."
+        )


### PR DESCRIPTION
## Summary

Closes #1855 — `POST /api/chat/start` could wedge for >100 seconds on the `resolve_model_provider` stage when the model catalog rebuild had to do cold-path network I/O. The PR #1911 stage diagnostics narrowed the wedge to a single helper call; this PR adds a fast-path early return that skips the catalog when the caller already has enough information to route the run.

## What changed

`_resolve_compatible_session_model_state()` in `api/routes.py` gains a fast-path early return at the top of the function. When the caller supplies both a non-empty `model` and a non-empty `model_provider`, and the model is **not** itself an `@provider:model`-qualified string, return the inputs verbatim without calling `get_available_models()`. The slow path below would arrive at the same answer via the existing `if requested_provider and not explicit_provider: return ...` branch (line 1509 in current `master`) — but only after paying for the full catalog rebuild.

The slow path is preserved for inputs that genuinely need it:
- Bare / un-qualified models without a stored `model_provider` (cross-provider repair / Codex normalization paths)
- `@provider:model`-qualified strings (the catalog is needed to validate the qualifier against the active provider per #1253)
- Empty models (default-model lookup)

## Why this fixes #1855

`get_available_models()` is documented in its own code as the cold path that does `urlopen` calls against custom OpenAI-compat endpoints, OpenRouter `/models`, LM Studio `/models`, plus a credential-pool refresh — all serialized behind an RLock thundering-herd guard at `api/config.py:_available_models_cache_lock`.

stefanpieter's 2026-05-17 recurrence on the same `/api/chat/start` wedge class produced a slow-request record from the PR #1911 diagnostics:

```json
{
  "current_stage": "resolve_model_provider",
  "elapsed_ms": 115827.7,
  "stages": [
    {"ms": 0.0, "name": "start"},
    {"ms": 0.0, "name": "csrf"},
    {"ms": 3.2, "name": "read_body"},
    {"ms": 0.0, "name": "validate_session_id"},
    {"ms": 0.0, "name": "get_session"},
    {"ms": 0.0, "name": "validate_profile"},
    {"ms": 0.0, "name": "normalize_message"},
    {"ms": 0.0, "name": "normalize_attachments"},
    {"ms": 0.5, "name": "resolve_workspace"},
    {"ms": 115827.7, "name": "resolve_model_provider"},
    ...
  ]
}
```

Every other stage completed in <5 ms. The wedge sat entirely in this one helper, and the production deployment (`openai-codex / gpt-5.5` behind Apache with a default 60s `Timeout`) returned `502 Proxy Error` to the browser even though WebUI eventually completed the request and started the agent run — creating a duplicate-send risk if the user retried in the browser.

In the steady-state shape that the WebUI frontend actually sends (`static/messages.js:444-449` always includes both `model` and `model_provider` from `S.session`), the slow path was doing 115 seconds of work to return the inputs verbatim.

## Empirical timing

With a 500 ms stubbed catalog:

| Scenario | Time | Outcome |
|---|---|---|
| Fast path (model + provider supplied, no @-qualifier) | 0.01 ms | `('gpt-5.5', 'openai-codex', False)` |
| Slow path (no provider supplied) | 500.34 ms | catalog consulted, same answer |
| `@provider:model` qualified | 500.32 ms | catalog consulted (needs validation) |

In the production scenario where the catalog stall was 115 seconds, the wedge is eliminated entirely. The slow path still fires for the inputs that need it.

## Verification

- `api/routes.py` `ast.parse` — OK
- 14 new tests in `tests/test_issue1855_resolve_model_provider_fast_path.py` — all pass
- Full pytest suite — **5920 passed, 6 skipped, 3 xpassed, 8 subtests** in 115s on the branch (5906 prior + 14 new)
- Cross-checked related suites: `test_provider_mismatch.py`, `test_goal_command_webui.py`, `test_profile_switch_1200.py`, `test_issue646.py`, `test_issue895_894_nous_prefix.py`, `test_issue854_live_model_prefix.py`, `test_issues_907_908_909_model_dropdown.py` — 126 tests pass

## Test coverage

The new test file covers both directions:

**Fast-path fires (4 tests):**
- bare model + bare provider — `('gpt-5.5', 'openai-codex')` → catalog never called
- slash-qualified model + provider — `('anthropic/claude-opus-4.7', 'openrouter')` → catalog never called  
- explicit `custom:<slug>` provider — `('GLM-4.5-Air-FP8', 'custom:siliconflow')` → catalog never called
- `'default'` sentinel cleaning to `None` — `model_provider='default'` correctly routes to slow path (it cleans to `None`, the fast path's guard refuses to fire without a real provider)

**Slow-path still fires (3 tests):**
- `@openrouter:anthropic/claude-opus-4.7` with `model_provider='openrouter'` → catalog called (qualifier validation needed)
- `model_provider=None` → catalog called (cross-provider repair path)
- Empty model — `('', 'openai-codex')` → catalog called (default-model lookup)

**Static source-shape guards (3 tests):**
- The fast-path branch `if model and requested_provider:` is present in the helper body
- The fast-path return precedes the `catalog = get_available_models()` line in source order (a refactor can't silently reorder without flipping this test)
- `#1855` is referenced in the helper's docstring so future readers find the context

**Helper invariants (3 tests):**
- `_split_provider_qualified_model` returns the expected shape for `@-prefixed`, bare, and slash-qualified inputs (the fast-path conditional discriminates on this)

**Diagnostic stability (1 test):**
- `/api/chat/start` handler still emits `diag.stage("resolve_model_provider")` so PR #1911 slow-request alerts continue to surface this stage when something else makes it slow in the future.

## Other parts of the issue

stefanpieter's original 2026-05-07 report covered both `POST /api/chat/start` and `GET /api/sessions` wedging. The `/api/sessions` (list) handler doesn't call `_resolve_compatible_session_model_state` per row — its diagnostic stages (`all_sessions`, `load_settings`, `filter_webui_sessions`, `sort_sessions`, `active_profile`) cover filesystem + CLI-merge work, not model catalog resolution. If the `/api/sessions` wedge recurs after this fix lands, the diagnostics will narrow it to whichever stage is responsible — likely a separate slice (`all_sessions` or `get_cli_sessions`), not the catalog rebuild this PR addresses.

The current PR is scoped to the durable fix for the recurrence stefanpieter actually captured via diagnostics.

## Risks / follow-ups

- **Behavioral preservation:** the fast path returns the same `(model, requested_provider, False)` tuple the slow path produced at line 1509-1510. The test suite (5920 tests) catches any regression in the downstream consumers.
- **Sibling callers also benefit:** the three other call sites in `_handle_chat_*` (`api/routes.py:7818, 7848, 7944, 8044`), `/api/session` display path, and `_normalize_session_model_in_place` all transparently get the same speedup whenever their inputs satisfy the fast-path predicate.
- **No new state, no new lock, no new branch points downstream** — the fast path returns from inside the existing helper before the slow path's first `get_available_models()` call.
- **Belt-and-suspenders idea, not in this PR:** when the slow path itself takes >30s, return a `503 Service Unavailable` with a clear "model catalog discovery slow, retry shortly" payload instead of letting the proxy time out the connection. That's a separate slice; this PR focuses on the steady-state happy path which is where the 115s wedge actually fired.

## Files touched

- `api/routes.py` — 24 lines added (fast-path guard + extended docstring)
- `tests/test_issue1855_resolve_model_provider_fast_path.py` — new file, 274 lines, 14 tests
- `CHANGELOG.md` — Unreleased entry

Closes #1855
