### PR TITLE
fix: respect active provider preference in /model slash command (fixes #2488)

### DIFF
--- a/static/commands.js
+++ b/static/commands.js
@@ -336,17 +336,22 @@ async function cmdModel(args){
       const aliases=data.aliases||{};
       for(const [alias,modelId] of Object.entries(aliases)){
         if(alias.toLowerCase()===q){
-          q=modelId; // resolve alias to real model id e.g. "deepseek/deepseek-v4-flash"
+          q=modelId.toLowerCase(); // resolve alias to real model id e.g. "deepseek/deepseek-v4-flash"
           break;
         }
       }
     }
   } catch(_){/* non-critical, fall through to fuzzy match */}
-  // Fuzzy match: find first option whose label or value contains the query
-  let match=null;
-  for(const opt of sel.options){
-    if(opt.value.toLowerCase().includes(q)||opt.textContent.toLowerCase().includes(q)){
-      match=opt.value;break;
+  // First: try exact match within active provider's optgroup.
+  // Use _findModelInDropdown (ui.js) which supports preferredProviderId.
+  const preferred=(S&&S.session&&S.session.model_provider)||window._activeProvider||null;
+  let match=(typeof _findModelInDropdown==='function')?_findModelInDropdown(q,sel,preferred):null;
+  // Fallback: fuzzy match across all options
+  if(!match){
+    for(const opt of sel.options){
+      if(opt.value.toLowerCase().includes(q)||opt.textContent.toLowerCase().includes(q)){
+        match=opt.value;break;
+      }
     }
   }
   // Fallback: if q has provider/ prefix (e.g. "deepseek/deepseek-v4-flash"),


### PR DESCRIPTION
## Fix: /model slash command respects active provider

Fixes #2488

### Problem
When using `/model <name>` in WebUI where the same model ID exists across multiple providers, the command selected the first match in DOM order instead of respecting the user's configured active provider.

### Solution
Before the existing fuzzy fallback loop, delegate to `_findModelInDropdown(q, sel, preferred)` which already supports provider-preference matching (ui.js:806). The active provider is read from `S.session.model_provider` with fallback to `window._activeProvider`.

### Changes
- `static/commands.js`: Replace the blind `.includes(q)` first-hit loop with a two-pass strategy: (1) exact match within active provider's optgroup, (2) fallback to original fuzzy match
- Also fixed a latent bug: `q=modelId` after alias resolution missing `.toLowerCase()`, which could cause false negatives in the fuzzy fallback

### Testing
- Tested locally on ARM64/AVF (Android VM) with overlapping provider models
- The existing `_findModelInDropdown` helper is already tested by upstream suite
- Confirmed: /model now selects the active provider's model instead of the first DOM match

Co-authored-by: nesquena-hermes <nesquena-hermes@users.noreply.github.com>