### PR TITLE
fix(providers): hot-reload gateway after API-key change instead of requiring container restart

### DIFF
--- a/api/providers.py
+++ b/api/providers.py
@@ -2041,12 +2041,39 @@ def set_provider_key(provider_id: str, api_key: str | None) -> dict[str, Any]:
     # disrupting active streaming sessions that may be reading config.cfg.
     invalidate_models_cache()
 
+    # Hot-reload the gateway so the new key takes effect without a manual
+    # container restart. Several runtime_provider paths read keys via
+    # ``os.getenv`` directly (OpenRouter, OpenAI), so the gateway's process
+    # env must be refreshed — invalidate_models_cache() alone isn't enough.
+    # Best-effort: silently a no-op when supervisorctl is unavailable
+    # (upstream Hermes / dev environments without supervisord).
+    _reload_provider_runtime()
+
     return {
         "ok": True,
         "provider": provider_id,
         "display_name": _PROVIDER_DISPLAY.get(provider_id, provider_id),
         "action": "updated" if api_key else "removed",
     }
+
+
+def _reload_provider_runtime() -> None:
+    """Best-effort restart of the gateway so new env keys take effect.
+
+    Skipped silently outside supervisor-managed deployments.
+    """
+    import shutil
+
+    if not shutil.which("supervisorctl"):
+        return
+    try:
+        subprocess.run(
+            ["supervisorctl", "-c", "/etc/supervisor/supervisord.conf",
+             "restart", "hermes-gateway"],
+            capture_output=True, timeout=10, check=False,
+        )
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        logger.warning("Gateway hot-reload failed: %s", exc)
 
 
 def remove_provider_key(provider_id: str) -> dict[str, Any]:


### PR DESCRIPTION
## What

After `set_provider_key` writes a new key to `~/.hermes/.env` and
invalidates the model cache, kick off a best-effort
`supervisorctl restart hermes-gateway` so the new key actually reaches
the gateway process without requiring the user to restart the
container.

No-op outside supervisor-managed deployments (upstream Hermes / dev
environments without supervisord) — the helper bails immediately when
`supervisorctl` isn't on PATH.

## Why

Saving an API key via Settings → Providers writes to `~/.hermes/.env`,
which the *next* gateway process boot will read. But the *currently
running* gateway is holding the previous process env. Several
`runtime_provider` paths read keys via `os.getenv` directly:

- `OpenRouter`: reads `OPENROUTER_API_KEY`
- `OpenAI`: reads `OPENAI_API_KEY`

So `invalidate_models_cache()` alone isn't enough — the dropdown
refreshes, but actual API calls still use the stale key cached in
process env from when the gateway booted. Users hit "I just saved
the new key, why am I still getting 401s?" and have to manually
restart the container.

This patch fires a best-effort restart of the supervised gateway
process. In supervisor-managed deployments the wrapper script
re-sources the env file on every restart, so the new key reaches the
gateway in seconds. Outside supervisor deployments (running locally
via `python -m gateway`, dev envs, etc.) the helper is a silent no-op
and the existing behavior is preserved.

## Behavior changes

- **No supervisorctl on PATH** (the upstream-default case): no behavior
  change — `_reload_provider_runtime()` early-returns.
- **supervisorctl present + supervised**: gateway restarts in <10s
  after a key save; new key takes effect immediately.
- **supervisorctl present but config path differs from
  `/etc/supervisor/supervisord.conf`** or the program name isn't
  `hermes-gateway`: the subprocess call exits non-zero but
  `check=False` means we swallow it; user sees the original behavior
  (still need a manual restart). I'm open to making both the config
  path and program name configurable — see "On the design".

## On the design

There are at least three reasonable shapes for this. I'm shipping the
literal one Fox in the Box has been running in prod because it's the
smallest patch and it's been operational for months. Happy to refactor
toward any of these if you prefer:

1. **As shipped**: hard-coded `supervisorctl` + path + program name.
   Smallest diff. Locks the convention.
2. **Env-configurable**: read `HERMES_GATEWAY_RELOAD_CMD` and run that
   shell command if set; otherwise no-op. Most flexible, lets any
   process manager hook in.
3. **SIGHUP to a pid**: read `HERMES_GATEWAY_PID_FILE` env var, send
   SIGHUP. Doesn't restart, just asks the gateway to re-read env —
   would require gateway-side SIGHUP handler work, larger surface.

Let me know which direction you'd want and I'll iterate.

## Context

Carried in [Fox in the Box](https://github.com/fox-in-the-box-ai/fox-in-the-box)
since our v0.5.x line as a webui patch — we ship a container with
supervisord managing the gateway, and our run-with-env.sh wrapper
re-sources both env files on every restart, so the new key reaches
the gateway in seconds. Users were hitting the "saved-key-still-401"
trap regularly before this landed.

Happy to write tests — the natural home looks like
`tests/api/test_providers_hot_reload.py` covering: (1) helper
early-returns when `shutil.which` returns None; (2) subprocess is
called with the expected argv when supervisorctl is present;
(3) timeout doesn't propagate.
