### PR TITLE
fix: show auto-compression elapsed time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Show an elapsed timer on the running automatic-compression card so long WebUI context-compression pauses no longer look frozen while the browser waits for the `compressed` event.
+
 ## [v0.51.89] — 2026-05-18 — Release BM (stage-382 — 6-PR full sweep batch — runtime adapter approval/clarify seam + SOUL.md memory panel + #1855 resolve_model_provider fast-path + PWA sidebar spinner fix + /model active-provider preference + contributor contract docs index)
 
 ### Changed

--- a/static/messages.js
+++ b/static/messages.js
@@ -1785,6 +1785,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
           phase:'running',
           automatic:true,
           message:d.message||'Auto-compressing context...',
+          startedAt:Date.now()/1000,
         };
         setCompressionUi(state);
         const liveAnswerStarted=!!(assistantRow||String(((_parseStreamState&&_parseStreamState())||{}).displayText||'').trim());

--- a/static/ui.js
+++ b/static/ui.js
@@ -1970,6 +1970,45 @@ function _formatActiveElapsedTimer(seconds){
   const s=total%60;
   return`${String(m).padStart(2,'0')}:${String(s).padStart(2,'0')}`;
 }
+const _COMPRESSION_ELAPSED_MAX_SECONDS=5*60;
+let _compressionElapsedTimer=null;
+function _compressionElapsedStartedAt(state){const n=Number(state&&state.startedAt);return Number.isFinite(n)&&n>0?n:null;}
+function _compressionElapsedLabel(state){
+  const started=_compressionElapsedStartedAt(state);
+  if(!started)return'';
+  const elapsed=Math.min(Math.max(0,(Date.now()/1000)-started),_COMPRESSION_ELAPSED_MAX_SECONDS);
+  return _formatActiveElapsedTimer(elapsed);
+}
+function _compressionElapsedExpired(state){const started=_compressionElapsedStartedAt(state);return !!(started&&((Date.now()/1000)-started)>=_COMPRESSION_ELAPSED_MAX_SECONDS);}
+function _compressionLiveCardNode(){return document.querySelector('[data-live-compression-card="1"][data-compression-started-at]');}
+function _compressionLiveCardState(){
+  const node=_compressionLiveCardNode();
+  const started=Number(node&&node.getAttribute('data-compression-started-at'));
+  if(!node||!S.session||!Number.isFinite(started)||started<=0)return null;
+  return {sessionId:S.session.session_id,phase:'running',automatic:true,message:node.getAttribute('data-compression-message')||'Auto-compressing context...',startedAt:started};
+}
+function _updateCompressionElapsedCards(state){
+  if(!state)return false;
+  const preview=_autoCompressionPreviewText(state), detail=_autoCompressionDetailText(state);
+  let updated=false;
+  document.querySelectorAll('.tool-card-compress-auto.tool-card-compress-running').forEach(card=>{
+    const previewEl=card.querySelector('.tool-card-preview');
+    const detailEl=card.querySelector('.tool-card-result pre');
+    if(previewEl) previewEl.textContent=preview;
+    if(detailEl) detailEl.textContent=detail;
+    updated=true;
+  });
+  return updated;
+}
+function _updateCompressionElapsedTimer(){
+  const state=_compressionStateForCurrentSession()||_compressionLiveCardState();
+  if(state&&state.automatic&&state.phase==='running'){
+    _updateCompressionElapsedCards(state);
+    if(_compressionElapsedExpired(state)) _clearCompressionElapsedTimer();
+  }else _clearCompressionElapsedTimer();
+}
+function _startCompressionElapsedTimer(){if(!_compressionElapsedTimer)_compressionElapsedTimer=setInterval(_updateCompressionElapsedTimer,1000);}
+function _clearCompressionElapsedTimer(){if(_compressionElapsedTimer){clearInterval(_compressionElapsedTimer);_compressionElapsedTimer=null;}}
 let _activityElapsedTimer=null;
 let _activityElapsedTimerGroup=null;
 function _activityElapsedStartedAt(group){
@@ -4875,6 +4914,7 @@ function isCompressionUiRunning(){
 }
 function clearCompressionUi(){
   window._compressionUi=null;
+  _clearCompressionElapsedTimer();
   _setCompressionSessionLock(null);
   renderCompressionUi();
 }
@@ -4883,8 +4923,14 @@ function setCompressionUi(state){
     clearCompressionUi();
     return;
   }
-  window._compressionUi={...state};
-  if(state.sessionId) _setCompressionSessionLock(state.sessionId);
+  const nextState={...state};
+  if(nextState.automatic&&nextState.phase==='running'&&!_compressionElapsedStartedAt(nextState)){
+    nextState.startedAt=Date.now()/1000;
+  }
+  window._compressionUi=nextState;
+  if(nextState.sessionId) _setCompressionSessionLock(nextState.sessionId);
+  if(nextState.automatic&&nextState.phase==='running') _startCompressionElapsedTimer();
+  else _clearCompressionElapsedTimer();
   renderCompressionUi();
 }
 function _compressionCardsHtml(state){
@@ -4950,21 +4996,38 @@ function _compressionCardsHtml(state){
     </div>
     ${referenceHtml}`;
 }
-function _autoCompressionCardsHtml(state){
+function _autoCompressionBaseDetail(state){
   const fallback='Context auto-compressed to continue the conversation';
   const running=state&&state.phase==='running';
-  const detail=running
+  return running
     ? (String(state.message||'Auto-compressing context...').trim()||'Auto-compressing context...')
-    : (String(state.message||fallback).trim()||fallback);
-  const preview=running
-    ? detail
-    : (String(state.summary?.headline||detail).trim()||detail);
+    : (String(state&&state.message||fallback).trim()||fallback);
+}
+function _autoCompressionPreviewText(state){
+  const running=state&&state.phase==='running';
+  const detail=_autoCompressionBaseDetail(state);
+  if(!running) return (String(state&&state.summary?.headline||detail).trim()||detail);
+  const elapsedLabel=_compressionElapsedLabel(state);
+  return [detail, elapsedLabel].filter(Boolean).join(' · ');
+}
+function _autoCompressionDetailText(state){
+  const running=state&&state.phase==='running';
+  const detail=_autoCompressionBaseDetail(state);
+  const elapsedLabel=running?_compressionElapsedLabel(state):'';
+  return running&&elapsedLabel
+    ? `${detail}\nElapsed: ${elapsedLabel}`
+    : detail;
+}
+function _autoCompressionCardsHtml(state){
+  const running=state&&state.phase==='running';
+  const preview=_autoCompressionPreviewText(state);
+  const cardDetail=_autoCompressionDetailText(state);
   return `
     <div class="tool-card-row compression-card-row" data-compression-card="1">
       ${_compressionStatusCardHtml({
         statusLabel: t('auto_compress_label'),
         previewText: preview,
-        detail,
+        detail: cardDetail,
         icon: running ? '<span class="tool-card-running-dot"></span>' : li('check',13),
         open: running,
         variantClass: running
@@ -4994,6 +5057,12 @@ function appendLiveCompressionCard(state){
   const node=_compressionCardsNode(state);
   if(!node) return false;
   node.setAttribute('data-live-compression-card','1');
+  if(state.automatic&&state.phase==='running'){
+    const started=_compressionElapsedStartedAt(state)||Date.now()/1000;
+    node.setAttribute('data-compression-started-at',String(started));
+    node.setAttribute('data-compression-message',String(state.message||'Auto-compressing context...'));
+    _startCompressionElapsedTimer();
+  }
   const existing=inner.querySelector('[data-live-compression-card="1"]');
   if(existing) existing.replaceWith(node);
   else inner.appendChild(node);

--- a/static/ui.js
+++ b/static/ui.js
@@ -1976,7 +1976,8 @@ function _compressionElapsedStartedAt(state){const n=Number(state&&state.started
 function _compressionElapsedLabel(state){
   const started=_compressionElapsedStartedAt(state);
   if(!started)return'';
-  const elapsed=Math.min(Math.max(0,(Date.now()/1000)-started),_COMPRESSION_ELAPSED_MAX_SECONDS);
+  const elapsed=Math.max(0,(Date.now()/1000)-started);
+  if(elapsed>=_COMPRESSION_ELAPSED_MAX_SECONDS)return '5+ min';
   return _formatActiveElapsedTimer(elapsed);
 }
 function _compressionElapsedExpired(state){const started=_compressionElapsedStartedAt(state);return !!(started&&((Date.now()/1000)-started)>=_COMPRESSION_ELAPSED_MAX_SECONDS);}
@@ -5012,11 +5013,9 @@ function _autoCompressionPreviewText(state){
 }
 function _autoCompressionDetailText(state){
   const running=state&&state.phase==='running';
-  const detail=_autoCompressionBaseDetail(state);
+  const base=_autoCompressionBaseDetail(state);
   const elapsedLabel=running?_compressionElapsedLabel(state):'';
-  return running&&elapsedLabel
-    ? `${detail}\nElapsed: ${elapsedLabel}`
-    : detail;
+  return elapsedLabel?`Elapsed: ${elapsedLabel}`:base;
 }
 function _autoCompressionCardsHtml(state){
   const running=state&&state.phase==='running';

--- a/tests/test_auto_compression_card.py
+++ b/tests/test_auto_compression_card.py
@@ -96,6 +96,31 @@ def test_auto_compression_running_card_renders_elapsed_timer_and_caps_updates():
     assert "_clearCompressionElapsedTimer();" in src
 
 
+def test_auto_compression_elapsed_cap_uses_non_frozen_label():
+    src = _read("static/ui.js")
+    start = src.find("function _compressionElapsedLabel")
+    assert start != -1, "elapsed label helper not found"
+    end = src.find("function _compressionElapsedExpired", start)
+    assert end != -1, "elapsed expiry helper not found after label helper"
+    helper = src[start:end]
+
+    assert "'5+ min'" in helper
+    assert "elapsed>=_COMPRESSION_ELAPSED_MAX_SECONDS" in helper
+    assert "return '05:00'" not in helper
+
+
+def test_auto_compression_running_detail_avoids_duplicate_message_text():
+    src = _read("static/ui.js")
+    start = src.find("function _autoCompressionDetailText")
+    assert start != -1, "auto compression detail helper not found"
+    end = src.find("function _autoCompressionCardsHtml", start)
+    assert end != -1, "auto compression card helper not found after detail helper"
+    helper = src[start:end]
+
+    assert "return elapsedLabel?`Elapsed: ${elapsedLabel}`:base;" in helper
+    assert "${base}\\nElapsed:" not in helper
+
+
 def test_auto_compression_live_card_keeps_elapsed_state_for_timer_refresh():
     src = _read("static/ui.js")
     start = src.find("function appendLiveCompressionCard")

--- a/tests/test_auto_compression_card.py
+++ b/tests/test_auto_compression_card.py
@@ -67,6 +67,48 @@ def test_auto_compression_completion_transition_is_preserved_after_running_liste
     assert "phase:'done'" in _compressed_listener_block()
 
 
+def test_auto_compression_running_sse_stamps_elapsed_timer_start():
+    block = _compressing_listener_block()
+
+    assert "startedAt:Date.now()/1000" in block
+    assert block.index("startedAt:Date.now()/1000") < block.index("setCompressionUi(state)")
+
+
+def test_auto_compression_running_card_renders_elapsed_timer_and_caps_updates():
+    src = _read("static/ui.js")
+    start = src.find("function _autoCompressionPreviewText")
+    assert start != -1, "auto compression preview helper not found"
+    end = src.find("function _compressionCardsNode", start)
+    assert end != -1, "compression cards node helper not found after auto helper"
+    helper = src[start:end]
+
+    assert "const _COMPRESSION_ELAPSED_MAX_SECONDS=5*60;" in src
+    assert "function _compressionElapsedLabel(state)" in src
+    assert "_formatActiveElapsedTimer" in src
+    assert "_compressionElapsedLabel(state)" in helper
+    assert "elapsedLabel" in helper
+    assert "_autoCompressionPreviewText(state)" in helper
+    assert "_autoCompressionDetailText(state)" in helper
+    assert "function _startCompressionElapsedTimer()" in src
+    assert "function _clearCompressionElapsedTimer()" in src
+    assert "function _updateCompressionElapsedCards(state)" in src
+    assert "_startCompressionElapsedTimer();" in src
+    assert "_clearCompressionElapsedTimer();" in src
+
+
+def test_auto_compression_live_card_keeps_elapsed_state_for_timer_refresh():
+    src = _read("static/ui.js")
+    start = src.find("function appendLiveCompressionCard")
+    assert start != -1, "live compression card append helper not found"
+    end = src.find("function _isHandoffSummaryToolPayload", start)
+    assert end != -1, "handoff helper not found after live compression helper"
+    helper = src[start:end]
+
+    assert "data-compression-started-at" in helper
+    assert "data-compression-message" in helper
+    assert "_compressionLiveCardState" in src
+
+
 def test_auto_compression_does_not_rerender_over_live_answer_text():
     block = _compressing_listener_block()
     src = _read("static/ui.js")


### PR DESCRIPTION
## Thinking Path

- #2477 identifies that long WebUI auto-compression can look frozen between the `compressing` SSE event and the later `compressed` event.
- The issue's maintainer guidance splits this into independently mergeable slices; this PR implements **Slice A only**: a persistent running indicator with elapsed time.
- The existing automatic-compression card already provides the right calm UI surface, so this keeps that card and adds a small elapsed timer instead of introducing a new backend event contract or sidebar behavior.
- The state layer changed here is browser transient compression UI (`window._compressionUi` plus the live compression card DOM), not durable transcript history or model context.

## What Changed

- Stamp the automatic-compression `running` state with `startedAt` when the `compressing` SSE event arrives.
- Render running automatic-compression cards as:
  - preview/header: `Auto-compressing context... · 00:23`
  - expanded body: `Elapsed: 00:23`
- Once the 5-minute Slice A cap is reached, show `5+ min` instead of freezing at `05:00`.
- Start a lightweight 1s timer while the running card is visible.
- Update the existing card's preview/detail text in place; the timer does **not** call `renderMessages()` each tick, so it avoids disrupting live stream DOM.
- Stop the timer when compression completes/clears, when the session no longer has a matching compression state, or after the 5-minute Slice A cap.
- Preserve the existing live-card path by carrying `data-compression-started-at` / `data-compression-message` on anchored live compression cards.
- Add regression coverage in `tests/test_auto_compression_card.py`.
- Add an Unreleased changelog entry.

## Why It Matters

Long compression can take minutes. Before this PR, the user saw the same generic running card the entire time, which made the browser feel stalled. The elapsed label gives a visible heartbeat while preserving the existing quiet compression-card design.

This intentionally does **not** implement #2477 Slice B/C:

- no compressed-session handoff link,
- no provider fallback/warning contract changes,
- no backend SSE payload change,
- no sidebar/session-list behavior change.

## Visual Evidence

![Before/after auto-compression elapsed indicator](https://raw.githubusercontent.com/dso2ng/hermes-webui/f3a3e994ddf17db03299ada0dd20e45ad9ad5a9d/pr-assets/2477-auto-compression-elapsed-v2.png)

## Verification

Targeted local verification on the updated head:

```bash
node --check static/ui.js
node --check static/messages.js
python -m pytest \
  tests/test_auto_compression_card.py \
  tests/test_compression_snapshot_runtime_clear.py \
  tests/test_session_lineage_collapse.py \
  tests/test_streaming_session_sidebar.py \
  tests/test_issue734_message_windowing.py \
  tests/test_issue1617_tps_message_header.py \
  -q
```

Result:

```text
74 passed
```

Hygiene:

```text
git diff --check -> clean
non_ascii_added_lines=1
```

The one intentional non-ASCII added line is the existing public UI separator `·` in the elapsed preview.

Full local suite was also run on the updated head:

```bash
python -m pytest tests/ -q
```

Result:

```text
5934 passed, 6 skipped, 3 xpassed, 8 subtests passed, 4 failed
```

The 4 failures are existing base failures in `tests/test_issue1527_lmstudio_base_url_classification.py` about prefixed model ids. I confirmed the same file fails the same way on clean `origin/master@e6be01c4`:

```bash
python -m pytest tests/test_issue1527_lmstudio_base_url_classification.py -q
# 4 failed, 1 passed
```

## Risks / Follow-ups

- Page reloads during an in-flight compression are not resume-on-reload. The timer state is browser-transient; after a reload the UI waits for any new `compressing` SSE state rather than reconstructing elapsed time from server history.
- The timer is intentionally presentation-only and capped at 5 minutes per the Slice A guidance; it does not infer provider progress or compression phases.
- If #2505 lands first, this may need a small rebase because both PRs touch `tests/test_auto_compression_card.py`, but the implementation layers are separate.
- Slice B/C from #2477 remain open follow-ups for compressed-session handoff surfacing and fallback transparency.

## Model Used

AI-assisted with Hermes Agent using OpenAI Codex provider, model `gpt-5.5`, with terminal/file/browser tooling for implementation, tests, and visual evidence capture.
