### PR TITLE
fix: guard concurrent New Conversation creates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Prevent repeated New Conversation clicks from queuing multiple session creates while `/api/session/new` is still in flight, and mark the sidebar `+` button busy until the create request settles.
+
 ## [v0.51.89] — 2026-05-18 — Release BM (stage-382 — 6-PR full sweep batch — runtime adapter approval/clarify seam + SOUL.md memory panel + #1855 resolve_model_provider fast-path + PWA sidebar spinner fix + /model active-provider preference + contributor contract docs index)
 
 ### Changed

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -17,6 +17,20 @@ const ICONS={
 // before the first request completes (#1060).
 let _loadingSessionId = null;
 
+// Coalesce concurrent New Conversation requests. Cold provider/model catalog
+// resolution can make /api/session/new take several seconds; without this guard,
+// repeated clicks enqueue multiple empty conversations before the first response
+// comes back (#2518).
+let _newSessionPromise = null;
+
+function _setNewSessionCreating(active){
+  const btn=(typeof $==='function')?$('btnNewChat'):null;
+  if(!btn)return;
+  btn.disabled=!!active;
+  btn.setAttribute('aria-busy',active?'true':'false');
+  btn.classList.toggle('is-loading',!!active);
+}
+
 // ── Composer draft persistence ────────────────────────────────────────────────
 
 // Debounced save — prevents hammering the server on every keystroke.
@@ -418,73 +432,83 @@ function _markPollingCompletionUnreadTransitions(sessions) {
 }
 
 async function newSession(flash, options={}){
-  updateQueueBadge();
-  S.toolCalls=[];
-  clearLiveToolCards();
-  // One-shot profile-switch workspace: applied to the first new session after a profile
-  // switch, then cleared.  Use a dedicated flag so S._profileDefaultWorkspace (the
-  // persistent boot/settings default) is not consumed and remains available for the
-  // blank-page display on all subsequent returns to the empty state (#823).
-  const switchWs=S._profileSwitchWorkspace;
-  S._profileSwitchWorkspace=null;
-  const inheritWs=switchWs||(S.session?S.session.workspace:null)||(S._profileDefaultWorkspace||null);
-  // Use the saved default model for new sessions (#872). The user's saved
-  // default_model (from Settings) takes priority over the chat-header dropdown
-  // value, which reflects the *previous* session's model. Fall back to the
-  // dropdown value only when no default_model is configured.
-  const modelSel=$('modelSelect');
-  const selectedDefaultModel=window._defaultModel||(modelSel&&modelSel.value)||'';
-  let defaultApplied=false;
-  if(window._defaultModel&&modelSel&&typeof _applyModelToDropdown==='function'){
-    defaultApplied=!!_applyModelToDropdown(window._defaultModel,modelSel,window._activeProvider||null);
-  }
-  const canQualify=!window._defaultModel||defaultApplied||(modelSel&&modelSel.value===selectedDefaultModel);
-  const newModelState=(canQualify&&typeof _modelStateForSelect==='function')
-    ? _modelStateForSelect(modelSel,selectedDefaultModel)
-    : {model:selectedDefaultModel,model_provider:null};
-  const reqBody={
-    model:newModelState.model,
-    model_provider:newModelState.model_provider||null,
-    workspace:inheritWs,
-    profile:S.activeProfile||'default',
-  };
-  if(S.session&&S.session.session_id) reqBody.prev_session_id=S.session.session_id;
-  if(options&&options.worktree) reqBody.worktree=true;
-  if(_activeProject&&_activeProject!==NO_PROJECT_FILTER) reqBody.project_id=_activeProject;
-  const data=await api('/api/session/new',{method:'POST',body:JSON.stringify(reqBody)});
-  S.session=data.session;S.messages=data.session.messages||[];
-  S.lastUsage={...(data.session.last_usage||{})};
-  if(flash)S.session._flash=true;
-  try{localStorage.setItem('hermes-webui-session',S.session.session_id);}catch(_){}
-  _setActiveSessionUrl(S.session.session_id);
-  _setSessionViewedCount(S.session.session_id, S.session.message_count || 0);
-  // Sync chat-header dropdown to the session's model so the UI reflects
-  // the default model the server actually used (#872).
-  if(S.session.model && S.session.model!==$('modelSelect').value && typeof _applyModelToDropdown==='function'){
-    _applyModelToDropdown(S.session.model,$('modelSelect'),S.session.model_provider||null);
-    if(typeof syncModelChip==='function') syncModelChip();
-  }
-  // Reset per-session visual state: a fresh chat is idle even if another
-  // conversation is still streaming in the background.
-  S.busy=false;
-  S.activeStreamId=null;
-  updateSendBtn();
-  setStatus('');
-  setComposerStatus('');
-  if(typeof _setLiveAssistantTps==='function') _setLiveAssistantTps(null);
-  if(typeof _syncCtxIndicator==='function'){
-    _syncCtxIndicator({
-      input_tokens:data.session.input_tokens||0,
-      output_tokens:data.session.output_tokens||0,
-      estimated_cost:data.session.estimated_cost||0,
-      context_length:data.session.context_length||0,
-      last_prompt_tokens:data.session.last_prompt_tokens||0,
-      threshold_tokens:data.session.threshold_tokens||0,
-    });
-  }
-  updateQueueBadge(S.session.session_id);
-  syncTopbar();renderMessages();loadDir('.');
-  // don't call renderSessionList here - callers do it when needed
+  if(_newSessionPromise) return _newSessionPromise;
+  _setNewSessionCreating(true);
+  _newSessionPromise=(async()=>{
+    try{
+      updateQueueBadge();
+      S.toolCalls=[];
+      clearLiveToolCards();
+      // One-shot profile-switch workspace: applied to the first new session after a profile
+      // switch, then cleared.  Use a dedicated flag so S._profileDefaultWorkspace (the
+      // persistent boot/settings default) is not consumed and remains available for the
+      // blank-page display on all subsequent returns to the empty state (#823).
+      const switchWs=S._profileSwitchWorkspace;
+      S._profileSwitchWorkspace=null;
+      const inheritWs=switchWs||(S.session?S.session.workspace:null)||(S._profileDefaultWorkspace||null);
+      // Use the saved default model for new sessions (#872). The user's saved
+      // default_model (from Settings) takes priority over the chat-header dropdown
+      // value, which reflects the *previous* session's model. Fall back to the
+      // dropdown value only when no default_model is configured.
+      const modelSel=$('modelSelect');
+      const selectedDefaultModel=window._defaultModel||(modelSel&&modelSel.value)||'';
+      let defaultApplied=false;
+      if(window._defaultModel&&modelSel&&typeof _applyModelToDropdown==='function'){
+        defaultApplied=!!_applyModelToDropdown(window._defaultModel,modelSel,window._activeProvider||null);
+      }
+      const canQualify=!window._defaultModel||defaultApplied||(modelSel&&modelSel.value===selectedDefaultModel);
+      const newModelState=(canQualify&&typeof _modelStateForSelect==='function')
+        ? _modelStateForSelect(modelSel,selectedDefaultModel)
+        : {model:selectedDefaultModel,model_provider:null};
+      const reqBody={
+        model:newModelState.model,
+        model_provider:newModelState.model_provider||null,
+        workspace:inheritWs,
+        profile:S.activeProfile||'default',
+      };
+      if(S.session&&S.session.session_id) reqBody.prev_session_id=S.session.session_id;
+      if(options&&options.worktree) reqBody.worktree=true;
+      if(_activeProject&&_activeProject!==NO_PROJECT_FILTER) reqBody.project_id=_activeProject;
+      const data=await api('/api/session/new',{method:'POST',body:JSON.stringify(reqBody)});
+      S.session=data.session;S.messages=data.session.messages||[];
+      S.lastUsage={...(data.session.last_usage||{})};
+      if(flash)S.session._flash=true;
+      try{localStorage.setItem('hermes-webui-session',S.session.session_id);}catch(_){}
+      _setActiveSessionUrl(S.session.session_id);
+      _setSessionViewedCount(S.session.session_id, S.session.message_count || 0);
+      // Sync chat-header dropdown to the session's model so the UI reflects
+      // the default model the server actually used (#872).
+      if(S.session.model && S.session.model!==$('modelSelect').value && typeof _applyModelToDropdown==='function'){
+        _applyModelToDropdown(S.session.model,$('modelSelect'),S.session.model_provider||null);
+        if(typeof syncModelChip==='function') syncModelChip();
+      }
+      // Reset per-session visual state: a fresh chat is idle even if another
+      // conversation is still streaming in the background.
+      S.busy=false;
+      S.activeStreamId=null;
+      updateSendBtn();
+      setStatus('');
+      setComposerStatus('');
+      if(typeof _setLiveAssistantTps==='function') _setLiveAssistantTps(null);
+      if(typeof _syncCtxIndicator==='function'){
+        _syncCtxIndicator({
+          input_tokens:data.session.input_tokens||0,
+          output_tokens:data.session.output_tokens||0,
+          estimated_cost:data.session.estimated_cost||0,
+          context_length:data.session.context_length||0,
+          last_prompt_tokens:data.session.last_prompt_tokens||0,
+          threshold_tokens:data.session.threshold_tokens||0,
+        });
+      }
+      updateQueueBadge(S.session.session_id);
+      syncTopbar();renderMessages();loadDir('.');
+      // don't call renderSessionList here - callers do it when needed
+    }finally{
+      _newSessionPromise=null;
+      _setNewSessionCreating(false);
+    }
+  })();
+  return _newSessionPromise;
 }
 
 async function loadSession(sid){

--- a/static/style.css
+++ b/static/style.css
@@ -2545,6 +2545,8 @@ main.main.showing-logs > #mainLogs{display:flex;}
 .panel-head-actions{display:flex;align-items:center;gap:4px;text-transform:none;letter-spacing:normal;}
 .panel-head-btn{width:24px;height:24px;padding:0;display:inline-flex;align-items:center;justify-content:center;border:none;background:transparent;border-radius:6px;color:var(--muted);cursor:pointer;transition:background .15s,color .15s;flex-shrink:0;}
 .panel-head-btn:hover{background:var(--accent-bg);color:var(--accent-text);}
+.panel-head-btn:disabled{opacity:.45;cursor:wait;}
+.panel-head-btn:disabled:hover{background:transparent;color:var(--muted);}
 .panel-head-btn svg{width:14px;height:14px;display:block;}
 .panel-head-sub{padding:6px 12px 8px;font-size:11px;color:var(--muted);flex-shrink:0;}
 .side-menu{display:flex;flex-direction:column;gap:2px;padding:8px;overflow-y:auto;}

--- a/tests/test_issue2518_new_session_guard.py
+++ b/tests/test_issue2518_new_session_guard.py
@@ -1,0 +1,158 @@
+import json
+import shutil
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SESSIONS_JS = (ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
+STYLE_CSS = (ROOT / "static" / "style.css").read_text(encoding="utf-8")
+NODE = shutil.which("node")
+
+
+def test_new_session_coalesces_concurrent_create_requests_static_guard():
+    """Regression for #2518: repeated clicks must not enqueue duplicate creates."""
+    guard_pos = SESSIONS_JS.index("if(_newSessionPromise) return _newSessionPromise;")
+    assign_pos = SESSIONS_JS.index("_newSessionPromise=(async()=>", guard_pos)
+    api_pos = SESSIONS_JS.index("api('/api/session/new'", assign_pos)
+
+    assert guard_pos < assign_pos < api_pos
+    assert SESSIONS_JS.count("api('/api/session/new'") == 1
+    assert "return _newSessionPromise;" in SESSIONS_JS[assign_pos:SESSIONS_JS.index("async function loadSession", assign_pos)]
+
+
+@pytest.mark.skipif(NODE is None, reason="node not on PATH")
+def test_new_session_coalesces_concurrent_create_requests_in_runtime():
+    """Execute sessions.js and verify two overlapping calls send one request."""
+    script = textwrap.dedent(
+        f"""
+        const fs = require('fs');
+        const vm = require('vm');
+        const source = fs.readFileSync({json.dumps(str(ROOT / 'static' / 'sessions.js'))}, 'utf8');
+
+        const calls = [];
+        let resolveApi;
+        const btn = {{
+          disabled: false,
+          attributes: {{}},
+          classList: {{
+            tokens: new Set(),
+            toggle(name, active) {{
+              if (active) this.tokens.add(name);
+              else this.tokens.delete(name);
+            }},
+          }},
+          setAttribute(name, value) {{ this.attributes[name] = value; }},
+        }};
+        const modelSelect = {{ value: 'gpt-test' }};
+        const context = {{
+          console,
+          window: {{}},
+          document: {{
+            addEventListener() {{}},
+            visibilityState: 'visible',
+            hasFocus() {{ return true; }},
+          }},
+          localStorage: {{
+            getItem() {{ return null; }},
+            setItem() {{}},
+            removeItem() {{}},
+          }},
+          S: {{
+            activeProfile: 'default',
+            activeStreamId: 'stream-1',
+            busy: true,
+            lastUsage: {{}},
+            messages: [],
+            session: null,
+            toolCalls: [],
+            _profileDefaultWorkspace: null,
+            _profileSwitchWorkspace: null,
+          }},
+          $(id) {{
+            if (id === 'btnNewChat') return btn;
+            if (id === 'modelSelect') return modelSelect;
+            return null;
+          }},
+          _applyModelToDropdown(model, select) {{ select.value = model; return true; }},
+          _modelStateForSelect(_select, model) {{ return {{ model, model_provider: 'test-provider' }}; }},
+          _setActiveSessionUrl() {{}},
+          _syncCtxIndicator() {{}},
+          clearLiveToolCards() {{}},
+          loadDir() {{}},
+          renderMessages() {{}},
+          setComposerStatus() {{}},
+          setStatus() {{}},
+          syncModelChip() {{}},
+          syncTopbar() {{}},
+          updateQueueBadge() {{}},
+          updateSendBtn() {{}},
+          addEventListener() {{}},
+          api(path, opts) {{
+            if (path !== '/api/session/new') return Promise.resolve({{ ok: true }});
+            calls.push({{ path, opts }});
+            return new Promise((resolve) => {{
+              resolveApi = () => resolve({{
+                session: {{
+                  session_id: 'sid-1',
+                  messages: [],
+                  last_usage: {{}},
+                  model: 'gpt-test',
+                  model_provider: 'test-provider',
+                  message_count: 0,
+                }},
+              }});
+            }});
+          }},
+        }};
+        context.window = context;
+        vm.createContext(context);
+        vm.runInContext(source + '\\nglobalThis.__newSession = newSession;', context);
+
+        const p1 = context.__newSession(true);
+        const p2 = context.__newSession(true);
+        if (calls.length !== 1) throw new Error(`expected one request while pending, got ${{calls.length}}`);
+        if (!btn.disabled) throw new Error('new conversation button was not disabled while pending');
+        if (btn.attributes['aria-busy'] !== 'true') throw new Error('aria-busy was not set while pending');
+        if (!btn.classList.tokens.has('is-loading')) throw new Error('loading class was not set while pending');
+
+        resolveApi();
+        Promise.all([p1, p2]).then(() => {{
+          if (calls.length !== 1) throw new Error(`expected one total request, got ${{calls.length}}`);
+          if (btn.disabled) throw new Error('new conversation button stayed disabled after settle');
+          if (btn.attributes['aria-busy'] !== 'false') throw new Error('aria-busy was not cleared after settle');
+          if (btn.classList.tokens.has('is-loading')) throw new Error('loading class was not cleared after settle');
+          process.stdout.write(JSON.stringify({{ calls: calls.length, disabled: btn.disabled }}));
+        }}).catch((err) => {{
+          console.error(err && err.stack || err);
+          process.exit(1);
+        }});
+        """
+    )
+    assert NODE is not None
+    proc = subprocess.run([NODE, "-e", script], text=True, capture_output=True, check=True)
+    assert json.loads(proc.stdout) == {"calls": 1, "disabled": False}
+
+
+def test_new_session_busy_state_clears_after_success_or_failure():
+    """The sidebar + button should show busy while the create request is in flight."""
+    helper_pos = SESSIONS_JS.index("function _setNewSessionCreating(active)")
+    fn_pos = SESSIONS_JS.index("async function newSession")
+    finally_pos = SESSIONS_JS.index("finally{", fn_pos)
+    clear_pos = SESSIONS_JS.index("_newSessionPromise=null;", finally_pos)
+    idle_pos = SESSIONS_JS.index("_setNewSessionCreating(false);", clear_pos)
+
+    assert helper_pos < fn_pos
+    assert "_setNewSessionCreating(true);" in SESSIONS_JS[fn_pos:finally_pos]
+    assert finally_pos < clear_pos < idle_pos
+    assert "btn.disabled=!!active" in SESSIONS_JS
+    assert "btn.setAttribute('aria-busy',active?'true':'false')" in SESSIONS_JS
+
+
+def test_new_session_button_has_disabled_feedback_style():
+    assert ".panel-head-btn:disabled" in STYLE_CSS
+    assert "cursor:wait" in STYLE_CSS
+    assert ".panel-head-btn:disabled:hover" in STYLE_CSS


### PR DESCRIPTION
## Thinking Path

- Hermes WebUI should keep the sidebar New Conversation control feeling immediate even when backend startup paths are cold.
- Issue #2518 showed the click reached `/api/session/new`, but cold model/provider catalog resolution could leave the request in flight for several seconds.
- During that window, repeated clicks could enqueue multiple empty session creates, making the UI look unresponsive and then suddenly create several sessions once the cache warmed.
- A narrow frontend guard is the lowest-risk first slice: coalesce overlapping `newSession()` calls and make the sidebar `+` visibly busy until the pending create settles.
- This does not change the backend model/provider resolution path; deeper cold-start decoupling can remain a follow-up if needed.

## What Changed

- Added a module-level in-flight promise around `newSession()` in `static/sessions.js` so concurrent calls share the same pending create request.
- Marked the sidebar New Conversation button disabled / `aria-busy` / `is-loading` while the create request is pending, and always clear that state in `finally`.
- Added disabled-state styling for panel header buttons so the busy state is visible and non-clickable.
- Added regression coverage for the #2518 behavior, including a Node runtime test that executes `sessions.js` and proves two overlapping `newSession()` calls send only one `/api/session/new` request.
- Added a release-note-ready `CHANGELOG.md` entry.

## Why It Matters

- Users no longer get a silent multi-click trap when `/api/session/new` is slow during cold model/provider catalog resolution.
- The UI now gives immediate feedback that a New Conversation create is already in progress.
- The fix prevents duplicate empty conversations without changing session creation semantics after the pending request settles.

Closes #2518.

## Verification

- `/Users/xuefusong/hermes-webui/.venv/bin/python -m pytest tests/test_issue2518_new_session_guard.py -q` → `4 passed`
- `/Users/xuefusong/hermes-webui/.venv/bin/python -m pytest tests/test_issue2518_new_session_guard.py tests/test_stale_empty_session_restore.py tests/test_session_static_assets.py -q` → `13 passed`
- Contract/docs checked before opening: `AGENTS.md`, `CONTRIBUTING.md`, `docs/CONTRACTS.md`, `docs/UIUX-GUIDE.md`, `DESIGN.md`, `CHANGELOG.md`.
- UI evidence: the user-visible state is the transient disabled/busy New Conversation control; the runtime regression test asserts the exact DOM state while the request is unresolved (`disabled`, `aria-busy="true"`, and `is-loading`) and asserts it clears after settle.

## Risks / Follow-ups

- This PR intentionally does not remove the backend cold model/provider catalog work from the session-create path; it prevents duplicate creates and provides immediate feedback while that request is pending.
- If users can trigger New Conversation from another future control, it should call the same `newSession()` path so the coalescing guard still applies.
- The guard coalesces overlapping new-session calls; once the pending create settles, normal subsequent new-session behavior resumes.

## Model Used

AI-assisted with Hermes Agent in WebUI using OpenAI Codex `gpt-5.5`. Tooling included repository inspection, GitHub issue/PR workflow, git worktree usage, and local pytest verification.