### PR TITLE
fix: allow keyless named custom endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Treat named custom OpenAI-compatible endpoints with a configured `base_url` as key-optional at WebUI agent startup, so local keyless servers do not fail early with a synthetic `CUSTOM:<slug>_API_KEY` prompt before the request reaches the endpoint.
+
 ## [v0.51.89] — 2026-05-18 — Release BM (stage-382 — 6-PR full sweep batch — runtime adapter approval/clarify seam + SOUL.md memory panel + #1855 resolve_model_provider fast-path + PWA sidebar spinner fix + /model active-provider preference + contributor contract docs index)
 
 ### Changed

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -50,6 +50,40 @@ from api.turn_journal import append_turn_journal_event_for_stream
 # (api/profiles.py:715).
 _ENV_LOCK = threading.Lock()
 
+_KEYLESS_CUSTOM_API_KEY = "dummy-key"
+
+
+def _resolve_custom_provider_runtime_overrides(
+    resolved_provider: str | None,
+    resolved_api_key: str | None,
+    resolved_base_url: str | None,
+) -> tuple[str | None, str | None, str | None]:
+    """Return provider/key/base_url overrides for ``custom:*`` endpoints.
+
+    Hermes Agent treats named custom providers as routing hints around an
+    OpenAI-compatible base URL.  Local OpenAI-compatible servers often run
+    without authentication, so a missing key should not fail before the first
+    request; pass a harmless placeholder to the SDK and let the endpoint accept
+    it or return its own auth error.
+    """
+    if not (isinstance(resolved_provider, str) and resolved_provider.startswith("custom:")):
+        return resolved_provider, resolved_api_key, resolved_base_url
+
+    _cp_key, _cp_base = resolve_custom_provider_connection(resolved_provider)
+    if not resolved_api_key and _cp_key:
+        resolved_api_key = _cp_key
+    if not resolved_base_url and _cp_base:
+        resolved_base_url = _cp_base
+    if resolved_base_url:
+        # Route through the generic custom OpenAI-compatible client once the
+        # named provider has supplied the concrete endpoint. Keeping the
+        # provider as custom:<slug> would make Agent init synthesize invalid
+        # env-var hints like CUSTOM:SOMETHING-8000_API_KEY on keyless setups.
+        resolved_provider = "custom"
+        if not resolved_api_key:
+            resolved_api_key = _KEYLESS_CUSTOM_API_KEY
+    return resolved_provider, resolved_api_key, resolved_base_url
+
 
 def _prewarm_skill_tool_modules():
     """Import tools.skills_tool and tools.skill_manager_tool outside any lock.
@@ -3467,12 +3501,9 @@ def _run_agent_streaming(
             # Named custom providers (custom:slug) may not be resolvable by
             # hermes_cli.runtime_provider directly. Fall back to config.yaml
             # custom_providers[] so WebUI can pass explicit creds/base_url.
-            if isinstance(resolved_provider, str) and resolved_provider.startswith("custom:"):
-                _cp_key, _cp_base = resolve_custom_provider_connection(resolved_provider)
-                if not resolved_api_key and _cp_key:
-                    resolved_api_key = _cp_key
-                if not resolved_base_url and _cp_base:
-                    resolved_base_url = _cp_base
+            resolved_provider, resolved_api_key, resolved_base_url = _resolve_custom_provider_runtime_overrides(
+                resolved_provider, resolved_api_key, resolved_base_url
+            )
 
             # Read per-profile config at call time (not module-level snapshot)
             from api.config import get_config as _get_config
@@ -4090,12 +4121,9 @@ def _run_agent_streaming(
                                 resolved_provider = _heal_rt.get('provider')
                             if not resolved_base_url:
                                 resolved_base_url = _heal_rt.get('base_url')
-                            if isinstance(resolved_provider, str) and resolved_provider.startswith('custom:'):
-                                _cp_key, _cp_base = resolve_custom_provider_connection(resolved_provider)
-                                if not resolved_api_key and _cp_key:
-                                    resolved_api_key = _cp_key
-                                if not resolved_base_url and _cp_base:
-                                    resolved_base_url = _cp_base
+                            resolved_provider, resolved_api_key, resolved_base_url = _resolve_custom_provider_runtime_overrides(
+                                resolved_provider, resolved_api_key, resolved_base_url
+                            )
                             # Rebuild agent kwargs and create a fresh agent
                             _agent_kwargs['api_key'] = resolved_api_key
                             _agent_kwargs['base_url'] = resolved_base_url
@@ -4894,12 +4922,9 @@ def _run_agent_streaming(
                         resolved_provider = _heal_rt.get('provider')
                     if not resolved_base_url:
                         resolved_base_url = _heal_rt.get('base_url')
-                    if isinstance(resolved_provider, str) and resolved_provider.startswith('custom:'):
-                        _cp_key, _cp_base = resolve_custom_provider_connection(resolved_provider)
-                        if not resolved_api_key and _cp_key:
-                            resolved_api_key = _cp_key
-                        if not resolved_base_url and _cp_base:
-                            resolved_base_url = _cp_base
+                    resolved_provider, resolved_api_key, resolved_base_url = _resolve_custom_provider_runtime_overrides(
+                        resolved_provider, resolved_api_key, resolved_base_url
+                    )
                     # Build a fresh agent with the new credentials
                     _heal_kwargs = dict(_agent_kwargs) if '_agent_kwargs' in dir() else {}
                     _heal_kwargs['api_key'] = resolved_api_key

--- a/tests/test_issue2271_keyless_custom_provider.py
+++ b/tests/test_issue2271_keyless_custom_provider.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+
+def test_keyless_named_custom_provider_uses_placeholder_and_generic_custom(monkeypatch):
+    import api.streaming as streaming
+
+    monkeypatch.setattr(
+        streaming,
+        "resolve_custom_provider_connection",
+        lambda provider: (None, "http://gpu.local:8000/v1"),
+    )
+
+    provider, api_key, base_url = streaming._resolve_custom_provider_runtime_overrides(
+        "custom:gpu-local-8000", None, None
+    )
+
+    assert provider == "custom"
+    assert api_key == "dummy-key"
+    assert base_url == "http://gpu.local:8000/v1"
+
+
+def test_named_custom_provider_preserves_configured_key(monkeypatch):
+    import api.streaming as streaming
+
+    monkeypatch.setattr(
+        streaming,
+        "resolve_custom_provider_connection",
+        lambda provider: ("real-key", "http://gpu.local:8000/v1"),
+    )
+
+    provider, api_key, base_url = streaming._resolve_custom_provider_runtime_overrides(
+        "custom:gpu-local-8000", None, None
+    )
+
+    assert provider == "custom"
+    assert api_key == "real-key"
+    assert base_url == "http://gpu.local:8000/v1"
+
+
+def test_named_custom_provider_keeps_existing_runtime_base_url(monkeypatch):
+    import api.streaming as streaming
+
+    monkeypatch.setattr(
+        streaming,
+        "resolve_custom_provider_connection",
+        lambda provider: (None, "http://config.example/v1"),
+    )
+
+    provider, api_key, base_url = streaming._resolve_custom_provider_runtime_overrides(
+        "custom:runtime-local", None, "http://runtime.example/v1"
+    )
+
+    assert provider == "custom"
+    assert api_key == "dummy-key"
+    assert base_url == "http://runtime.example/v1"
+
+
+def test_non_custom_provider_is_unchanged(monkeypatch):
+    import api.streaming as streaming
+
+    called = False
+
+    def _unexpected(provider):
+        nonlocal called
+        called = True
+        return (None, None)
+
+    monkeypatch.setattr(streaming, "resolve_custom_provider_connection", _unexpected)
+
+    provider, api_key, base_url = streaming._resolve_custom_provider_runtime_overrides(
+        "openrouter", None, None
+    )
+
+    assert (provider, api_key, base_url) == ("openrouter", None, None)
+    assert called is False


### PR DESCRIPTION
## Thinking Path

- Issue #2271 has a renewed report that local OpenAI-compatible custom endpoints can be keyless, especially llama-server/vLLM-style LAN deployments.
- WebUI already resolves named `custom:*` providers to their configured `base_url`, but when no API key is configured it can still hand Agent a named provider with no key.
- Agent then fails before reaching the endpoint and can synthesize an invalid env-var hint such as `CUSTOM:<slug>_API_KEY`.
- The narrow fix is to treat a configured custom `base_url` as enough to initialize the OpenAI-compatible client with a harmless placeholder key, while preserving real configured keys when present.
- This keeps auth failures endpoint-owned: keyless servers can proceed, and authenticated servers can return their actual auth error if the placeholder is rejected.

## What Changed

- Added a shared WebUI streaming helper that resolves `custom:*` providers to concrete custom-provider runtime overrides.
- When a named custom provider has a `base_url` but no configured key, normalize the provider to generic `custom` and pass a harmless placeholder API key so Agent initialization does not fail early.
- Preserved configured `custom_providers[].api_key` / `key_env` behavior when a key exists.
- Reused the helper in the initial agent setup path and the two retry/healing rebuild paths.
- Added focused regression coverage for keyless named custom endpoints, configured-key preservation, existing runtime base URLs, and non-custom no-op behavior.
- Added a release-note-ready changelog entry.

## Why It Matters

- LAN/self-hosted OpenAI-compatible endpoints that do not require auth can now be reached instead of failing before the first request.
- Users no longer see invalid `CUSTOM:<slug>_API_KEY` guidance for named custom endpoints whose slug contains punctuation or ports.
- Auth-required custom endpoints still behave honestly: if no key is configured, the endpoint can reject the request with its own auth error.

Refs #2271.

## Verification

- `env -u HERMES_CONFIG_PATH -u HERMES_WEBUI_HOST /home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_issue2271_keyless_custom_provider.py -q` — 4 passed
- `env -u HERMES_CONFIG_PATH -u HERMES_WEBUI_HOST /home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_issue2271_keyless_custom_provider.py tests/test_update_banner_fixes.py::TestUpdateSummaryRouteModelSelection -q` — 6 passed
- `/home/michael/.hermes/hermes-agent/venv/bin/python -m py_compile api/streaming.py tests/test_issue2271_keyless_custom_provider.py`
- `git diff --check`

No screenshots included: this is a backend/runtime provider-resolution fix with source-level regression coverage, not a visible UI/layout change.

## Risks / Follow-ups

- Keyless endpoints receive an `Authorization: Bearer dummy-key` header from the OpenAI SDK path. Common local OpenAI-compatible servers ignore it, but a stricter server may reject it; that is still a real endpoint auth failure instead of WebUI failing before request dispatch.
- This does not redesign custom-provider setup or provider-management UI.
- Broader custom relay CRUD work remains separate from this narrow runtime fix.

## Model Used

AI-assisted change with repository inspection, targeted editing, and shell-based test verification.
