### PR TITLE
fix(chat): add WebUI surface context to agent turns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Add browser-surface session context to WebUI agent turns so the agent can distinguish a WebUI chat from messaging-platform transcripts while keeping the metadata ephemeral and out of saved history.
+
 ## [v0.51.89] — 2026-05-18 — Release BM (stage-382 — 6-PR full sweep batch — runtime adapter approval/clarify seam + SOUL.md memory panel + #1855 resolve_model_provider fast-path + PWA sidebar spinner fix + /model active-provider preference + contributor contract docs index)
 
 ### Changed

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -147,11 +147,47 @@ WebUI progress contract:
 """.strip()
 
 
-def _webui_ephemeral_system_prompt(personality_prompt: Optional[str]) -> str:
+def _webui_surface_context_prompt(surface_context: Optional[dict]) -> str:
+    """Return safe WebUI session metadata for the agent's ephemeral context.
+
+    Messaging gateways inject platform/channel context before each run. Browser
+    sessions do not have a chat platform wrapper, so provide an explicit, small
+    surface description here instead of relying on the model to infer where it
+    is running from the transcript alone.
+    """
+    if not isinstance(surface_context, dict):
+        return ""
+
+    lines = [
+        "WebUI session context:",
+        "- This browser session is not the same live transcript as Telegram, Discord, Slack, or other messaging surfaces.",
+        "- Use durable memory, saved sessions, and available tools for cross-surface recall instead of assuming those transcripts are in this browser chat.",
+    ]
+    fields = (
+        ("source", "Source"),
+        ("session_id", "Session ID"),
+        ("profile", "Profile"),
+        ("workspace", "Workspace"),
+    )
+    for key, label in fields:
+        raw = surface_context.get(key)
+        value = str(raw).strip() if raw is not None else ""
+        if value:
+            lines.append(f"- {label}: {value}")
+    return "\n".join(lines)
+
+
+def _webui_ephemeral_system_prompt(
+    personality_prompt: Optional[str],
+    surface_context: Optional[dict] = None,
+) -> str:
     """Build WebUI-only runtime instructions that are not persisted to history."""
     parts = []
     if personality_prompt:
         parts.append(str(personality_prompt).strip())
+    surface_prompt = _webui_surface_context_prompt(surface_context)
+    if surface_prompt:
+        parts.append(surface_prompt)
     parts.append(_WEBUI_VISIBLE_PROGRESS_PROMPT)
     return "\n\n".join(part for part in parts if part)
 
@@ -3839,7 +3875,15 @@ def _run_agent_streaming(
             # (agent's own mechanism). This preserves any selected personality
             # while making long tool runs emit real user-visible interim text
             # through interim_assistant_callback instead of frontend guesses.
-            agent.ephemeral_system_prompt = _webui_ephemeral_system_prompt(_personality_prompt)
+            agent.ephemeral_system_prompt = _webui_ephemeral_system_prompt(
+                _personality_prompt,
+                surface_context={
+                    'source': 'webui',
+                    'session_id': session_id,
+                    'profile': getattr(s, 'profile', None),
+                    'workspace': s.workspace,
+                },
+            )
             _pending_started_at = getattr(s, 'pending_started_at', None)
             # Normal chat-start sets pending_started_at before spawning this thread;
             # fallback to now only for recovered/legacy flows where that marker is absent

--- a/tests/test_webui_surface_context.py
+++ b/tests/test_webui_surface_context.py
@@ -1,0 +1,39 @@
+from api.streaming import _webui_ephemeral_system_prompt
+
+
+def test_webui_ephemeral_prompt_includes_browser_surface_context():
+    prompt = _webui_ephemeral_system_prompt(
+        "Use a concise tone.",
+        surface_context={
+            "source": "webui",
+            "session_id": "session-123",
+            "profile": "default",
+            "workspace": "/tmp/example-workspace",
+        },
+    )
+
+    assert "Use a concise tone." in prompt
+    assert "WebUI session context" in prompt
+    assert "Source: webui" in prompt
+    assert "Session ID: session-123" in prompt
+    assert "Profile: default" in prompt
+    assert "Workspace: /tmp/example-workspace" in prompt
+    assert "not the same live transcript as Telegram" in prompt
+
+
+def test_webui_ephemeral_prompt_skips_empty_surface_fields():
+    prompt = _webui_ephemeral_system_prompt(
+        None,
+        surface_context={
+            "source": "webui",
+            "session_id": "",
+            "profile": None,
+            "workspace": "   ",
+        },
+    )
+
+    assert "WebUI session context" in prompt
+    assert "Source: webui" in prompt
+    assert "Session ID:" not in prompt
+    assert "Profile:" not in prompt
+    assert "Workspace:" not in prompt


### PR DESCRIPTION
## Thinking Path
- Hermes WebUI runs browser-originated turns separately from Telegram and other messaging gateways.
- Messaging gateways can carry platform/channel context that browser sessions do not naturally expose.
- A small ephemeral WebUI surface note gives the agent the right execution context without persisting internal metadata into the visible transcript.
- This narrows the “WebUI feels like it has less context” gap while preserving current session/history storage behavior.

## What Changed
- Adds a WebUI surface-context block to the agent ephemeral system prompt.
- Includes non-secret fields: source, session id, active profile, and workspace.
- Explicitly tells the agent that the browser chat is not the same live transcript as Telegram/Discord/Slack, and to use durable memory/sessions/tools for cross-surface recall.
- Adds regression coverage for the prompt content and empty-field handling.
- Updates `CHANGELOG.md`.

## Why It Matters
WebUI chat turns now get the same kind of surface awareness that users expect from messaging-backed Hermes sessions, without assuming that Telegram transcript state is present in the browser session.

## Verification
- `python -m pytest tests/test_webui_surface_context.py -q -o 'addopts='`
- `python -m py_compile api/streaming.py`
- `git diff --check`

## Risks / Follow-ups
- This is intentionally metadata-only and ephemeral; it does not import messaging transcripts into WebUI.
- A larger follow-up could expose an explicit “search prior messaging sessions” affordance if maintainers want cross-surface recall to be user-visible.
