### PR TITLE
fix: keep kanban drag drop from opening detail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Keep Kanban drag/drop status updates from also opening the task detail pane via a trailing card click or the generic task-update helper (refs #2529).
+
 ## [v0.51.89] — 2026-05-18 — Release BM (stage-382 — 6-PR full sweep batch — runtime adapter approval/clarify seam + SOUL.md memory panel + #1855 resolve_model_provider fast-path + PWA sidebar spinner fix + /model active-provider preference + contributor contract docs index)
 
 ### Changed

--- a/static/panels.js
+++ b/static/panels.js
@@ -13,6 +13,7 @@ let _kanbanCurrentBoard = null;
 let _kanbanBoardsList = null;
 let _kanbanBoardMenuOpen = false;
 let _kanbanIsDispatching = false;
+let _kanbanSuppressCardClickUntil = 0;
 // SSE event stream — replaces the 30s polling cadence with a long-lived
 // /api/kanban/events/stream connection. Falls back to polling when the
 // EventSource fails to connect (proxy that strips text/event-stream, etc).
@@ -1264,10 +1265,31 @@ async function quickKanbanCardAction(event, taskId, status){
   return updateKanbanTask(taskId, {status});
 }
 
+function _kanbanSuppressNextCardClick(){
+  _kanbanSuppressCardClickUntil = Date.now() + 700;
+}
+
 function dragKanbanTask(event, taskId){
+  _kanbanSuppressNextCardClick();
   if (!event.dataTransfer) return;
   event.dataTransfer.effectAllowed = 'move';
   event.dataTransfer.setData('text/plain', taskId);
+}
+
+function finishKanbanDrag(event){
+  if (event) _kanbanSuppressNextCardClick();
+}
+
+function openKanbanCard(event, taskId){
+  if (Date.now() < _kanbanSuppressCardClickUntil) {
+    if (event) {
+      event.preventDefault();
+      event.stopPropagation();
+    }
+    return false;
+  }
+  loadKanbanTask(taskId);
+  return false;
 }
 
 function allowKanbanDrop(event){
@@ -1290,10 +1312,13 @@ function clearKanbanDrop(event){
 }
 
 async function dropKanbanTask(event, status){
+  _kanbanSuppressNextCardClick();
   event.preventDefault();
+  event.stopPropagation();
   clearKanbanDrop(event);
   const taskId = event.dataTransfer ? event.dataTransfer.getData('text/plain') : '';
-  if (taskId && status) await updateKanbanTask(taskId, {status});
+  if (taskId && status) await updateKanbanTask(taskId, {status}, {openDetail: false});
+  _kanbanSuppressNextCardClick();
 }
 
 function _kanbanLaneNames(columns){
@@ -1356,7 +1381,7 @@ function _kanbanCard(task, status){
   const stale = _kanbanCardStalenessClass(task);
   const body = _kanbanTaskBody(task);
   const assignee = task.assignee ? `<span class="kanban-card-assignee">@${esc(task.assignee)}</span>` : `<span class="kanban-card-unassigned">${esc(t('kanban_unassigned'))}</span>`;
-  return `<article class="kanban-card ${esc(stale)}" data-kanban-task-id="${esc(task.id)}" draggable="true" ondragstart="dragKanbanTask(event, '${esc(task.id)}')" onclick="loadKanbanTask('${esc(task.id)}')" tabindex="0" role="button" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();loadKanbanTask('${esc(task.id)}')}">
+  return `<article class="kanban-card ${esc(stale)}" data-kanban-task-id="${esc(task.id)}" draggable="true" ondragstart="dragKanbanTask(event, '${esc(task.id)}')" ondragend="finishKanbanDrag(event)" onclick="return openKanbanCard(event, '${esc(task.id)}')" tabindex="0" role="button" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();loadKanbanTask('${esc(task.id)}')}">
     <div class="kanban-card-topline"><span class="kanban-card-id">${esc(task.id || '')}</span>${priority ? `<span class="kanban-badge priority">P${priority}</span>` : ''}${task.tenant ? `<span class="kanban-badge tenant">${esc(task.tenant)}</span>` : ''}</div>
     <div class="kanban-card-title">${esc(_kanbanTaskTitle(task))}</div>
     ${body ? `<div class="kanban-card-body">${_kanbanRenderMarkdown(body)}</div>` : ''}
@@ -2269,15 +2294,16 @@ async function submitKanbanTaskModal(){
   }
 }
 
-async function updateKanbanTask(taskId, patch){
+async function updateKanbanTask(taskId, patch, opts){
   if (!taskId || !patch) return;
   try {
+    const openDetail = !opts || opts.openDetail !== false;
     const updated = await api('/api/kanban/tasks/' + encodeURIComponent(taskId) + _kanbanBoardQuery(), {
       method: 'PATCH',
       body: JSON.stringify(patch),
     });
     await loadKanban(true);
-    await loadKanbanTask((updated && updated.task && updated.task.id) || taskId);
+    if (openDetail) await loadKanbanTask((updated && updated.task && updated.task.id) || taskId);
   } catch(e) { showToast(t('kanban_unavailable') + ': ' + (e.message || e), 'error'); }
 }
 

--- a/tests/test_kanban_ui_static.py
+++ b/tests/test_kanban_ui_static.py
@@ -692,6 +692,65 @@ def test_kanban_ui_parity_polish_adds_card_metadata_quick_actions_and_swimlanes(
     assert "javascript:" not in PANELS.lower()
 
 
+def test_kanban_dragging_card_does_not_open_detail_on_drop_click():
+    """Regression: drag/drop should move a card without opening task detail."""
+    assert "function _kanbanSuppressNextCardClick" in PANELS
+    assert "let _kanbanSuppressCardClickUntil" in PANELS
+    assert "function openKanbanCard" in PANELS
+    assert "function finishKanbanDrag" in PANELS
+
+    drag_fn = re.search(r"function dragKanbanTask\([^)]*\)\{(.*?)\n\}", PANELS, re.DOTALL)
+    assert drag_fn, "dragKanbanTask() not found"
+    assert "_kanbanSuppressNextCardClick" in drag_fn.group(1), (
+        "drag start must arm the click suppressor so the trailing click after "
+        "drop cannot open the task detail pane"
+    )
+
+    finish_fn = re.search(r"function finishKanbanDrag\([^)]*\)\{(.*?)\n\}", PANELS, re.DOTALL)
+    assert finish_fn, "finishKanbanDrag() not found"
+    assert "_kanbanSuppressNextCardClick" in finish_fn.group(1), (
+        "drag end must refresh the suppressor window before browsers emit a "
+        "trailing synthetic click"
+    )
+
+    drop_fn = re.search(r"async function dropKanbanTask\([^)]*\)\{(.*?)\n\}", PANELS, re.DOTALL)
+    assert drop_fn, "dropKanbanTask() not found"
+    drop_body = drop_fn.group(1)
+    assert "_kanbanSuppressNextCardClick" in drop_body
+    assert "event.stopPropagation()" in drop_body
+    assert "updateKanbanTask(taskId, {status}, {openDetail: false})" in drop_body, (
+        "drag/drop status updates must refresh the board without opening the task detail"
+    )
+
+    update_fn = re.search(r"async function updateKanbanTask\([^)]*\)\{(.*?)\n\}", PANELS, re.DOTALL)
+    assert update_fn, "updateKanbanTask() not found"
+    update_body = update_fn.group(1)
+    assert "const openDetail = !opts || opts.openDetail !== false;" in update_body
+    assert "if (openDetail) await loadKanbanTask" in update_body
+
+    card_template = re.search(r"return `<article class=\"kanban-card.*?</article>`;", PANELS, re.DOTALL)
+    assert card_template, "Kanban card template not found"
+    card_html = card_template.group(0)
+    assert "ondragend=\"finishKanbanDrag(event)\"" in card_html
+    assert "onclick=\"return openKanbanCard(event," in card_html
+    assert "onclick=\"loadKanbanTask" not in card_html, (
+        "Kanban cards must not call loadKanbanTask directly from onclick; "
+        "drag/drop needs a guarded click path"
+    )
+
+    open_fn = re.search(r"function openKanbanCard\([^)]*\)\{(.*?)\n\}", PANELS, re.DOTALL)
+    assert open_fn, "openKanbanCard() not found"
+    open_body = open_fn.group(1)
+    for token in (
+        "Date.now()",
+        "_kanbanSuppressCardClickUntil",
+        "preventDefault",
+        "stopPropagation",
+        "loadKanbanTask",
+    ):
+        assert token in open_body
+
+
 def test_kanban_lifecycle_controls_do_not_offer_manual_running_start():
     assert "quickKanbanCardAction(event,'${id}','running')" not in PANELS
     assert "kanban_card_start" not in PANELS


### PR DESCRIPTION
## Thinking Path

- Kanban cards are draggable and clickable, and both interactions currently share the same card surface.
- Drag/drop status changes should update the board in place, not imply that the user explicitly selected the moved task.
- The old path could open the detail pane in two ways: a trailing synthetic click after drag/drop, and the generic task-update helper opening detail after every PATCH.
- This PR keeps explicit card click and keyboard activation unchanged while making drag/drop a board-only status update.

## What Changed

- Added a short click-suppression window around Kanban drag start/end/drop so browser-emitted trailing clicks do not open task detail.
- Routed drag/drop PATCHes through `updateKanbanTask(..., {openDetail: false})` so board refreshes do not programmatically select the moved task.
- Left normal card click, keyboard activation, and quick-action status buttons on their existing detail-opening path.
- Added a static regression test that pins both failure paths.
- Added an Unreleased changelog entry.

## Why It Matters

Dragging a Kanban card is a status update, not a task-selection action. Keeping drag/drop from opening the detail pane makes the board behave predictably and avoids surprising context switches while users reorganize work.

Closes #2529.

## Verification

- `node --check static/panels.js`
- `python3 -m pytest tests/test_kanban_ui_static.py::test_kanban_dragging_card_does_not_open_detail_on_drop_click tests/test_kanban_ui_static.py::test_kanban_ui_parity_polish_adds_card_metadata_quick_actions_and_swimlanes -q`
- `python3 -m pytest tests/test_kanban_ui_static.py -q`
- `git diff --check`

Screenshots are not included because this is an interaction-state fix with no visual layout change; the regression is whether drag/drop opens the detail pane.

## Risks / Follow-ups

- The click suppressor is intentionally short-lived and scoped to card opening only; keyboard activation still opens task detail.
- This does not change Kanban backend status semantics, dispatcher rules, board selection, or task detail rendering.

## Model Used

OpenAI Codex (GPT-5). AI assisted with code review, implementation, and verification.
