### PR TITLE
fix: sanitize custom provider env hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **PR #2556** by @Michaelyklam (closes #2541) — Sanitize auto-generated custom-provider API-key environment variable names so endpoint-derived provider ids such as `custom:gpu.local-8000` use POSIX-safe names like `CUSTOM_GPU_LOCAL_8000_API_KEY`. Runtime custom-provider key resolution now checks the sanitized env var first and falls back to the legacy punctuation-preserving name with a one-shot deprecation warning.
+
 ## [v0.51.90] — 2026-05-18 — Release BN (stage-383 — 10-PR full sweep batch — empty-gateway messaging history fix + previous-messaging-sessions setting + Kanban board switcher layout + UI/UX demo theme controls + Slice 3c queue/goal RFC gate + keyless custom endpoints + custom-provider remote model catalog parity + auto-compression elapsed timer + new-conversation cold-start guard + Kanban drag-drop detail open fix)
 
 ### Fixed

--- a/api/config.py
+++ b/api/config.py
@@ -972,6 +972,49 @@ def _custom_endpoint_slugs_for_base_url(value: object) -> set[str]:
     return {f"custom:{host}:{port}", f"custom:{host}-{port}"}
 
 
+_LEGACY_CUSTOM_API_KEY_ENV_WARNED: set[str] = set()
+
+
+def _api_key_env_name(provider_id: object) -> str:
+    """Return the POSIX-safe default API-key env var for a custom provider id."""
+    sanitized = re.sub(r"[^A-Za-z0-9]", "_", str(provider_id or "")).upper().strip("_")
+    if not sanitized:
+        sanitized = "CUSTOM"
+    if not sanitized.startswith("CUSTOM_"):
+        sanitized = f"CUSTOM_{sanitized}"
+    return f"{sanitized}_API_KEY"
+
+
+def _legacy_custom_api_key_env_name(provider_id: object) -> str:
+    """Return the pre-#2541 custom-provider env hint shape, if any."""
+    raw = str(provider_id or "").strip().upper()
+    if not raw:
+        return ""
+    return f"{raw}_API_KEY"
+
+
+def _lookup_custom_api_key_env(provider_id: object) -> str | None:
+    """Look up sanitized custom-provider env first, then legacy broken shape."""
+    env_name = _api_key_env_name(provider_id)
+    api_key = os.getenv(env_name, "").strip()
+    if api_key:
+        return api_key
+
+    legacy_env_name = _legacy_custom_api_key_env_name(provider_id)
+    if legacy_env_name and legacy_env_name != env_name:
+        legacy_key = os.getenv(legacy_env_name, "").strip()
+        if legacy_key:
+            if legacy_env_name not in _LEGACY_CUSTOM_API_KEY_ENV_WARNED:
+                _LEGACY_CUSTOM_API_KEY_ENV_WARNED.add(legacy_env_name)
+                logger.warning(
+                    "Custom provider API key env var %s is deprecated; use %s instead",
+                    legacy_env_name,
+                    env_name,
+                )
+            return legacy_key
+    return None
+
+
 def _named_custom_provider_slug_for_base_url(
     base_url: object,
     config_obj: dict | None = None,
@@ -1841,7 +1884,7 @@ def resolve_custom_provider_connection(provider_id: str) -> tuple[str | None, st
     # cases after profile switches or runtime config edits.
     cfg_data = get_config()
 
-    def _resolve_key(raw_api_key, raw_key_env) -> str | None:
+    def _resolve_key(raw_api_key, raw_key_env, provider_hint=None) -> str | None:
         api_key = None
         if raw_api_key is not None:
             key_text = str(raw_api_key).strip()
@@ -1853,6 +1896,8 @@ def resolve_custom_provider_connection(provider_id: str) -> tuple[str | None, st
             key_env = str(raw_key_env or "").strip()
             if key_env:
                 api_key = os.getenv(key_env, "").strip() or None
+        if not api_key and provider_hint:
+            api_key = _lookup_custom_api_key_env(provider_hint)
         return api_key
 
     custom_providers = cfg_data.get("custom_providers", [])
@@ -1870,7 +1915,7 @@ def resolve_custom_provider_connection(provider_id: str) -> tuple[str | None, st
             continue
 
         base_url = str(entry.get("base_url") or "").strip() or None
-        api_key = _resolve_key(entry.get("api_key"), entry.get("key_env"))
+        api_key = _resolve_key(entry.get("api_key"), entry.get("key_env"), pid)
         return api_key, base_url
 
     # If exactly one custom provider is configured, use it as a pragmatic
@@ -1878,7 +1923,7 @@ def resolve_custom_provider_connection(provider_id: str) -> tuple[str | None, st
     if len(custom_providers) == 1 and isinstance(custom_providers[0], dict):
         entry = custom_providers[0]
         return (
-            _resolve_key(entry.get("api_key"), entry.get("key_env")),
+            _resolve_key(entry.get("api_key"), entry.get("key_env"), pid),
             str(entry.get("base_url") or "").strip() or None,
         )
 
@@ -1900,11 +1945,11 @@ def resolve_custom_provider_connection(provider_id: str) -> tuple[str | None, st
 
     fallback_key = None
     if isinstance(provider_specific, dict):
-        fallback_key = _resolve_key(provider_specific.get("api_key"), provider_specific.get("key_env"))
+        fallback_key = _resolve_key(provider_specific.get("api_key"), provider_specific.get("key_env"), pid)
     if not fallback_key and isinstance(provider_custom, dict):
-        fallback_key = _resolve_key(provider_custom.get("api_key"), provider_custom.get("key_env"))
+        fallback_key = _resolve_key(provider_custom.get("api_key"), provider_custom.get("key_env"), pid)
     if not fallback_key and isinstance(model_cfg, dict) and model_provider in {"custom", pid, slug}:
-        fallback_key = _resolve_key(model_cfg.get("api_key"), model_cfg.get("key_env"))
+        fallback_key = _resolve_key(model_cfg.get("api_key"), model_cfg.get("key_env"), pid)
 
     if fallback_key or fallback_base:
         return fallback_key, fallback_base or None

--- a/tests/test_issue2271_keyless_custom_provider.py
+++ b/tests/test_issue2271_keyless_custom_provider.py
@@ -73,3 +73,56 @@ def test_non_custom_provider_is_unchanged(monkeypatch):
 
     assert (provider, api_key, base_url) == ("openrouter", None, None)
     assert called is False
+
+
+def test_custom_provider_env_name_is_posix_safe():
+    import api.config as config
+
+    assert config._api_key_env_name("custom:gpu.local-8000") == "CUSTOM_GPU_LOCAL_8000_API_KEY"
+    assert config._api_key_env_name("custom:10.8.71.41:8080") == "CUSTOM_10_8_71_41_8080_API_KEY"
+    assert config._api_key_env_name("custom/foo bar") == "CUSTOM_FOO_BAR_API_KEY"
+
+
+def test_resolve_custom_provider_connection_prefers_sanitized_env(monkeypatch):
+    import api.config as config
+
+    monkeypatch.setattr(
+        config,
+        "get_config",
+        lambda: {
+            "custom_providers": [
+                {"name": "gpu.local-8000", "base_url": "http://gpu.local:8000/v1"},
+            ],
+        },
+    )
+    monkeypatch.setenv("CUSTOM_GPU_LOCAL_8000_API_KEY", "sanitized-key")
+    monkeypatch.setenv("CUSTOM:GPU.LOCAL-8000_API_KEY", "legacy-key")
+
+    api_key, base_url = config.resolve_custom_provider_connection("custom:gpu.local-8000")
+
+    assert api_key == "sanitized-key"
+    assert base_url == "http://gpu.local:8000/v1"
+
+
+def test_resolve_custom_provider_connection_falls_back_to_legacy_env(monkeypatch, caplog):
+    import logging
+    import api.config as config
+
+    config._LEGACY_CUSTOM_API_KEY_ENV_WARNED.clear()
+    monkeypatch.setattr(
+        config,
+        "get_config",
+        lambda: {
+            "custom_providers": [
+                {"name": "gpu.local-8000", "base_url": "http://gpu.local:8000/v1"},
+            ],
+        },
+    )
+    monkeypatch.delenv("CUSTOM_GPU_LOCAL_8000_API_KEY", raising=False)
+    monkeypatch.setenv("CUSTOM:GPU.LOCAL-8000_API_KEY", "legacy-key")
+
+    with caplog.at_level(logging.WARNING, logger="api.config"):
+        api_key, _base_url = config.resolve_custom_provider_connection("custom:gpu.local-8000")
+
+    assert api_key == "legacy-key"
+    assert "CUSTOM_GPU_LOCAL_8000_API_KEY" in caplog.text


### PR DESCRIPTION
## Thinking Path
- Custom OpenAI-compatible endpoints can derive provider ids from host/port strings.
- Those ids may contain punctuation that is fine for WebUI routing but invalid for POSIX environment variable names.
- The safest narrow fix is to sanitize only the generated env-var hint/resolution path while keeping legacy lookup during migration.
- This PR keeps configured literal keys and explicit `key_env` values intact, adds a sanitized default env name, and preserves a legacy fallback with a warning.

## What Changed
- Added `_api_key_env_name()` for POSIX-safe custom-provider API-key env names.
- Added sanitized-first, legacy-second lookup for custom-provider env-backed keys.
- Wired the lookup into `resolve_custom_provider_connection()` for named custom providers and fallback custom provider config shapes.
- Added regression coverage for punctuation-heavy provider ids, sanitized preference, and legacy fallback warning.
- Added an Unreleased changelog entry.

## Why It Matters
Users can now set a usable env var such as `CUSTOM_GPU_LOCAL_8000_API_KEY` for endpoint-derived providers like `custom:gpu.local-8000` instead of being shown an invalid shell/process-manager name such as `CUSTOM:GPU.LOCAL-8000_API_KEY`.

## Verification
- `env -u HERMES_CONFIG_PATH -u HERMES_WEBUI_HOST /home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_issue2271_keyless_custom_provider.py -q` — 7 passed
- `env -u HERMES_CONFIG_PATH -u HERMES_WEBUI_HOST /home/michael/.hermes/hermes-agent/venv/bin/python -m py_compile api/config.py tests/test_issue2271_keyless_custom_provider.py`
- `git diff --check`

## Risks / Follow-ups
- Legacy punctuation-preserving env-var lookup remains for a migration window and logs a one-shot deprecation warning when used.
- No UI surface changed, so screenshots are not included.

Closes #2541

## Model Used
AI-assisted change with repository inspection, targeted editing, and shell-based test verification.
