### PR TITLE
feat(workspace): download folder as zip via /api/folder/download

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -6636,6 +6636,9 @@ def _file_raw_target(session, sid: str, rel: str) -> Path | None:
 # ─── /api/folder/download ───────────────────────────────────────────────────
 # Configurable caps. Match the HERMES_WEBUI_MAX_UPLOAD_MB style used elsewhere
 # (api/config.py) so operators have one consistent env-var convention.
+# Bound on per-request wall-clock and bandwidth, not RSS. The zip streams
+# straight into handler.wfile, so peak memory is the per-file read buffer
+# inside zipfile, not the cap value.
 def _folder_zip_max_bytes() -> int:
     try:
         mb = int(os.getenv("HERMES_WEBUI_FOLDER_ZIP_MAX_MB", "1024"))

--- a/api/routes.py
+++ b/api/routes.py
@@ -4150,6 +4150,9 @@ def handle_get(handler, parsed) -> bool:
     if parsed.path == "/api/file/raw":
         return _handle_file_raw(handler, parsed)
 
+    if parsed.path == "/api/folder/download":
+        return _handle_folder_download(handler, parsed)
+
     if parsed.path == "/api/file":
         return _handle_file_read(handler, parsed)
 
@@ -6628,6 +6631,143 @@ def _file_raw_target(session, sid: str, rel: str) -> Path | None:
     if attachment_target.exists() and attachment_target.is_file():
         return attachment_target
     return None
+
+
+# ─── /api/folder/download ───────────────────────────────────────────────────
+# Configurable caps. Match the HERMES_WEBUI_MAX_UPLOAD_MB style used elsewhere
+# (api/config.py) so operators have one consistent env-var convention.
+def _folder_zip_max_bytes() -> int:
+    try:
+        mb = int(os.getenv("HERMES_WEBUI_FOLDER_ZIP_MAX_MB", "1024"))
+    except ValueError:
+        mb = 1024
+    return max(1, mb) * 1024 * 1024
+
+
+def _folder_zip_max_files() -> int:
+    try:
+        return max(1, int(os.getenv("HERMES_WEBUI_FOLDER_ZIP_MAX_FILES", "50000")))
+    except ValueError:
+        return 50000
+
+
+def _folder_download_collect(target: Path, workspace_root: Path,
+                              max_bytes: int, max_files: int):
+    """Walk target dir; return (files, total_bytes, hit_limit_reason_or_None).
+
+    files is a list of (filesystem_path, archive_name) tuples ready for
+    ZipFile.write. Symlinks escaping the workspace are skipped.
+    """
+    import os as _os
+    files = []
+    total_bytes = 0
+    for root, dirs, names in _os.walk(target, followlinks=False):
+        root_path = Path(root)
+        try:
+            if not root_path.resolve().is_relative_to(workspace_root):
+                dirs[:] = []
+                continue
+        except (ValueError, OSError):
+            dirs[:] = []
+            continue
+        for name in names:
+            fp = root_path / name
+            if fp.is_symlink():
+                try:
+                    if not fp.resolve().is_relative_to(workspace_root):
+                        continue
+                except (ValueError, OSError):
+                    continue
+            try:
+                size = fp.stat().st_size
+            except OSError:
+                continue
+            if len(files) >= max_files:
+                return files, total_bytes, "max_files"
+            if total_bytes + size > max_bytes:
+                return files, total_bytes, "max_bytes"
+            try:
+                arcname = fp.relative_to(target)
+            except ValueError:
+                continue
+            files.append((fp, str(arcname)))
+            total_bytes += size
+    return files, total_bytes, None
+
+
+def _handle_folder_download(handler, parsed):
+    """GET /api/folder/download?session_id=...&path=...
+
+    Streams a zip of <session.workspace>/<path>. Symlinks escaping the
+    workspace are skipped. Empty folders return an empty (valid) zip.
+    Respects HERMES_WEBUI_FOLDER_ZIP_MAX_MB and HERMES_WEBUI_FOLDER_ZIP_MAX_FILES.
+    Pre-flights the walk so size/count failures return a clean 413 with JSON
+    body BEFORE any zip bytes are sent.
+    """
+    import zipfile
+    from urllib.parse import parse_qs
+
+    qs = parse_qs(parsed.query)
+    sid = qs.get("session_id", [""])[0]
+    if not sid:
+        return bad(handler, "session_id is required")
+    try:
+        s = get_session(sid)
+    except KeyError:
+        return bad(handler, "Session not found", 404)
+
+    rel = qs.get("path", [""])[0]
+    try:
+        target = safe_resolve(Path(s.workspace), rel)
+    except ValueError:
+        return bad(handler, "invalid path", 400)
+    if not target.exists():
+        return j(handler, {"error": "not found"}, status=404)
+    if not target.is_dir():
+        return bad(handler, "path must be a directory; use /api/file/raw for single files", 400)
+
+    workspace_root = Path(s.workspace).resolve()
+    max_bytes = _folder_zip_max_bytes()
+    max_files = _folder_zip_max_files()
+
+    files, total_bytes, limit_hit = _folder_download_collect(
+        target, workspace_root, max_bytes, max_files
+    )
+    if limit_hit == "max_files":
+        return j(handler, {
+            "error": "too many files",
+            "limit": max_files,
+            "configure": "HERMES_WEBUI_FOLDER_ZIP_MAX_FILES",
+        }, status=413)
+    if limit_hit == "max_bytes":
+        return j(handler, {
+            "error": "folder too large",
+            "limit_bytes": max_bytes,
+            "configure": "HERMES_WEBUI_FOLDER_ZIP_MAX_MB",
+        }, status=413)
+
+    zip_name = (target.name or "workspace") + ".zip"
+    handler.send_response(200)
+    handler.send_header("Content-Type", "application/zip")
+    handler.send_header(
+        "Content-Disposition",
+        _content_disposition_value("attachment", zip_name),
+    )
+    handler.send_header("Cache-Control", "no-store")
+    handler.end_headers()
+
+    written = 0
+    with zipfile.ZipFile(handler.wfile, mode="w", compression=zipfile.ZIP_DEFLATED, allowZip64=True) as zf:
+        for fp, arcname in files:
+            try:
+                zf.write(fp, arcname=arcname)
+                written += 1
+            except (OSError, PermissionError) as e:
+                logger.warning("folder-download: skipping %s: %s", fp, e)
+    logger.info(
+        "folder-download: streamed %d/%d files (~%d bytes) from %s",
+        written, len(files), total_bytes, target,
+    )
 
 
 def _handle_file_raw(handler, parsed):

--- a/static/i18n.js
+++ b/static/i18n.js
@@ -1621,6 +1621,7 @@ const LOCALES = {
     reveal_in_finder: 'Mostra nel File Manager',
     reveal_failed: 'Mostra fallito: ',
     copy_file_path: 'Copia percorso file',
+    download_folder: 'Download Folder', // TODO: translate
     path_copied: 'Percorso file copiato negli appunti',
     path_copy_failed: 'Copia percorso fallita: ',
     session_rename: 'Rinomina conversazione',
@@ -2832,6 +2833,7 @@ const LOCALES = {
     reveal_in_finder: 'ファイルマネージャーで表示',
     reveal_failed: '表示に失敗しました: ',
     copy_file_path: 'ファイルパスをコピー',
+    download_folder: 'Download Folder', // TODO: translate
     path_copied: 'ファイルパスをクリップボードにコピーしました',
     path_copy_failed: 'パスのコピーに失敗しました: ',
     session_rename: '会話の名前を変更',
@@ -3969,6 +3971,7 @@ const LOCALES = {
     reveal_in_finder: 'Показать в файловом менеджере',
     reveal_failed: 'Не удалось открыть: ',
     copy_file_path: 'Копировать путь к файлу',
+    download_folder: 'Download Folder', // TODO: translate
     path_copied: 'Путь к файлу скопирован в буфер обмена',
     path_copy_failed: 'Не удалось скопировать путь: ',
     session_rename: 'Переименовать беседу',
@@ -5099,6 +5102,7 @@ const LOCALES = {
     reveal_in_finder: 'Mostrar en el gestor de archivos',
     reveal_failed: 'Error al mostrar: ',
     copy_file_path: 'Copiar ruta del archivo',
+    download_folder: 'Download Folder', // TODO: translate
     path_copied: 'Ruta del archivo copiada al portapapeles',
     path_copy_failed: 'Error al copiar la ruta: ',
     session_rename: 'Renombrar conversación',
@@ -6232,6 +6236,7 @@ const LOCALES = {
     reveal_in_finder: 'Im Dateimanager anzeigen',
     reveal_failed: 'Anzeige fehlgeschlagen: ',
     copy_file_path: 'Dateipfad kopieren',
+    download_folder: 'Download Folder', // TODO: translate
     path_copied: 'Dateipfad in die Zwischenablage kopiert',
     path_copy_failed: 'Pfad konnte nicht kopiert werden: ',
     session_rename: 'Unterhaltung umbenennen',
@@ -7415,6 +7420,7 @@ const LOCALES = {
     reveal_in_finder: '在文件管理器中显示',
     reveal_failed: '显示失败：',
     copy_file_path: '\u590d\u5236\u6587\u4ef6\u8def\u5f84',
+    download_folder: 'Download Folder', // TODO: translate
     path_copied: '\u6587\u4ef6\u8def\u5f84\u5df2\u590d\u5236\u5230\u526a\u8d34\u677f',
     path_copy_failed: '\u590d\u5236\u8def\u5f84\u5931\u8d25\uff1a',
     session_rename: '\u91cd\u547d\u540d\u5bf9\u8bdd',
@@ -8473,6 +8479,7 @@ const LOCALES = {
     reveal_in_finder: '\u5728\u6a94\u6848\u7ba1\u7406\u54e1\u4e2d\u986f\u793a',
     reveal_failed: '\u986f\u793a\u5931\u6557\uff1a',
     copy_file_path: '\u8907\u88fd\u6a94\u6848\u8def\u5f91',
+    download_folder: 'Download Folder', // TODO: translate
     path_copied: '\u6a94\u6848\u8def\u5f91\u5df2\u8907\u88fd\u5230\u526a\u8cbc\u7c3f',
     path_copy_failed: '\u8907\u88fd\u8def\u5f91\u5931\u6557\uff1a',
     session_rename: '\u91cd\u65b0\u547d\u540d\u5c0d\u8a71',
@@ -9775,6 +9782,7 @@ const LOCALES = {
     reveal_in_finder: 'Mostrar no gerenciador de arquivos',
     reveal_failed: 'Falha ao mostrar: ',
     copy_file_path: 'Copiar caminho do arquivo',
+    download_folder: 'Download Folder', // TODO: translate
     path_copied: 'Caminho do arquivo copiado para a área de transferência',
     path_copy_failed: 'Falha ao copiar caminho: ',
     session_rename: 'Renomear conversa',
@@ -10884,6 +10892,7 @@ const LOCALES = {
     reveal_in_finder: '파일 관리자에서 열기',
     reveal_failed: '표시 실패: ',
     copy_file_path: '파일 경로 복사',
+    download_folder: 'Download Folder', // TODO: translate
     path_copied: '파일 경로가 클립보드에 복사되었습니다',
     path_copy_failed: '경로 복사 실패: ',
     session_rename: '대화 이름 변경',
@@ -12026,6 +12035,7 @@ const LOCALES = {
     reveal_in_finder: 'Révéler dans le gestionnaire de fichiers',
     reveal_failed: 'Échec de la révélation :',
     copy_file_path: 'Copier le chemin du fichier',
+    download_folder: 'Download Folder', // TODO: translate
     path_copied: 'Chemin du fichier copié dans le presse-papiers',
     path_copy_failed: 'Échec de la copie du chemin :',
     session_rename: 'Renommer la conversation',

--- a/static/i18n.js
+++ b/static/i18n.js
@@ -401,6 +401,7 @@ const LOCALES = {
     reveal_in_finder: 'Reveal in File Manager',
     reveal_failed: 'Failed to reveal: ',
     copy_file_path: 'Copy file path',
+    download_folder: 'Download Folder',
     path_copied: 'File path copied to clipboard',
     path_copy_failed: 'Failed to copy path: ',
     session_rename: 'Rename conversation',

--- a/static/ui.js
+++ b/static/ui.js
@@ -7788,6 +7788,23 @@ function _showFileContextMenu(e, item){
   };
   menu.appendChild(copyPathItem);
 
+  // Download as zip — only for directories. Streams the folder contents
+  // through /api/folder/download which builds the zip on the fly.
+  if(item.type==='dir'){
+    const dlItem=document.createElement('div');
+    dlItem.textContent=t('download_folder');
+    dlItem.style.cssText='padding:7px 14px;cursor:pointer;font-size:13px;color:var(--text);';
+    dlItem.onmouseenter=()=>dlItem.style.background='var(--hover-bg)';
+    dlItem.onmouseleave=()=>dlItem.style.background='';
+    dlItem.onclick=()=>{
+      menu.remove();
+      const url='/api/folder/download?session_id='+encodeURIComponent(S.session.session_id)
+              + '&path='+encodeURIComponent(item.path||'');
+      window.location.href=url;
+    };
+    menu.appendChild(dlItem);
+  }
+
   // Divider + Delete
   const sep=document.createElement('hr');
   sep.style.cssText='border:none;border-top:1px solid var(--border);margin:4px 0;';

--- a/tests/test_folder_download.py
+++ b/tests/test_folder_download.py
@@ -1,0 +1,102 @@
+"""Tests for /api/folder/download — matches the static-inspection style used
+elsewhere in the hermes-webui test suite (see tests/test_issue1867_upload_size_preflight.py).
+"""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+ROUTES_PY = ROOT / "api" / "routes.py"
+UI_JS = ROOT / "static" / "ui.js"
+
+
+def test_folder_download_handler_defined():
+    src = ROUTES_PY.read_text(encoding="utf-8")
+    assert "def _handle_folder_download(handler, parsed):" in src
+    assert "/api/folder/download?session_id=" in src  # in handler docstring
+    assert 'Content-Type", "application/zip"' in src
+    assert "zipfile.ZipFile(handler.wfile" in src
+
+
+def test_folder_download_dispatch_registered():
+    src = ROUTES_PY.read_text(encoding="utf-8")
+    assert 'parsed.path == "/api/folder/download"' in src
+    assert "_handle_folder_download(handler, parsed)" in src
+
+
+def test_folder_download_uses_safe_resolve():
+    src = ROUTES_PY.read_text(encoding="utf-8")
+    handler_idx = src.index("def _handle_folder_download")
+    end_idx = src.index("\n\ndef ", handler_idx + 1)
+    body = src[handler_idx:end_idx]
+    assert "safe_resolve(Path(s.workspace), rel)" in body
+    assert "ValueError" in body
+
+
+def test_folder_download_skips_escaping_symlinks():
+    src = ROUTES_PY.read_text(encoding="utf-8")
+    collect_idx = src.index("def _folder_download_collect")
+    end_idx = src.index("\n\ndef ", collect_idx + 1)
+    body = src[collect_idx:end_idx]
+    assert "followlinks=False" in body
+    assert "is_symlink()" in body
+    assert "is_relative_to(workspace_root)" in body
+
+
+def test_folder_download_respects_max_files_env():
+    src = ROUTES_PY.read_text(encoding="utf-8")
+    assert 'HERMES_WEBUI_FOLDER_ZIP_MAX_FILES' in src
+    assert '"too many files"' in src
+    assert 'status=413' in src
+
+
+def test_folder_download_respects_max_bytes_env():
+    src = ROUTES_PY.read_text(encoding="utf-8")
+    assert 'HERMES_WEBUI_FOLDER_ZIP_MAX_MB' in src
+    assert '"folder too large"' in src
+    assert 'limit_bytes' in src
+
+
+def test_folder_download_preflights_before_streaming():
+    """Pre-flight collect must run BEFORE send_response so 413 can return JSON."""
+    src = ROUTES_PY.read_text(encoding="utf-8")
+    handler_idx = src.index("def _handle_folder_download")
+    end_idx = src.index("\n\n# ", handler_idx) if "\n\n# " in src[handler_idx:] else len(src)
+    body = src[handler_idx:end_idx]
+    collect_call = body.index("_folder_download_collect")
+    send_response = body.index("handler.send_response(200)")
+    limit_check = body.index('"too many files"')
+    assert collect_call < limit_check < send_response
+
+
+def test_folder_download_rejects_files():
+    src = ROUTES_PY.read_text(encoding="utf-8")
+    assert "path must be a directory" in src
+    assert "/api/file/raw" in src  # error message guides user
+
+
+def test_folder_download_streams_not_buffers():
+    src = ROUTES_PY.read_text(encoding="utf-8")
+    assert "zipfile.ZipFile(handler.wfile" in src
+    assert "allowZip64=True" in src
+    handler_idx = src.index("def _handle_folder_download")
+    end_idx = src.index("\n\ndef ", handler_idx + 1)
+    body = src[handler_idx:end_idx]
+    assert "io.BytesIO" not in body, "must stream, not buffer in memory"
+
+
+def test_ui_context_menu_has_download_folder():
+    src = UI_JS.read_text(encoding="utf-8")
+    assert "download_folder" in src
+    download_idx = src.index("download_folder")
+    snippet = src[max(0, download_idx - 200):download_idx]
+    assert "item.type==='dir'" in snippet or "item.type === 'dir'" in snippet
+
+
+def test_ui_download_folder_uses_endpoint():
+    src = UI_JS.read_text(encoding="utf-8")
+    download_idx = src.index("download_folder")
+    snippet = src[download_idx:download_idx + 600]
+    assert "/api/folder/download" in snippet
+    assert "session_id=" in snippet
+    assert "path=" in snippet
+    assert "encodeURIComponent" in snippet


### PR DESCRIPTION
Adds folder-as-zip download to round out the existing single-file download affordance.

## Use case

`llm-wiki` heavy-usage patterns produce large interlinked markdown directories — sources, compiled pages, raw notes — over time. Portability is the goal: users should be able to grab their whole wiki (or any workspace subtree) as a single archive rather than clicking each file individually or SSHing to `tar` it. The same affordance covers any project / session-working-directory / generated-output folder a user wants to take with them.

## AI assistance disclosure

This PR was drafted with AI assistance. Disclosing per emerging OSS-contribution norms:

- **Provider:** Anthropic
- **Model:** `claude-opus-4-7` (Claude Opus 4.7)
- **Mode:** Medium
- **What the model did:** drafted the handler/dispatch/UI/i18n/tests by inspecting the existing patterns (`_handle_file_raw`, `_showFileContextMenu`, `tests/test_issue1867_upload_size_preflight.py`).
- **What I did as the human author:** scoped the feature, set the design constraints (pre-flight + 413, env-var caps, no fork, no upstream rewrites), reviewed every line of the diff before commit, ran the test suite locally, and am accountable for the code as submitted.

## What this adds
- **Backend:** `GET /api/folder/download?session_id=<sid>&path=<rel>` → streamed `application/zip` response
- **Frontend:** "Download Folder" item in `_showFileContextMenu`, shown only for `item.type === 'dir'`
- **Configurable caps:** `HERMES_WEBUI_FOLDER_ZIP_MAX_MB` (1024 default) and `HERMES_WEBUI_FOLDER_ZIP_MAX_FILES` (50000 default), matching the existing `HERMES_WEBUI_MAX_UPLOAD_MB` convention
- **i18n key:** `download_folder: 'Download Folder'` in the English locale; other locales fall back via `t()`. Happy to add translations in a follow-up if preferred.

## Design choices
- **Pre-flight walk before streaming** — once 200 + `Content-Type: application/zip` headers are sent we can't switch to JSON, so cap-exceeded returns 413 + JSON BEFORE any response bytes go out. Costs a `stat()` per file; trivial for realistic folder sizes.
- **Streamed write into `handler.wfile`** — never buffers the zip in memory. Critical for the 1 GiB cap on small boxes.
- **`allowZip64=True`** — handles individual files >4 GiB.
- **Symlink handling** — `os.walk(followlinks=False)` plus explicit `is_relative_to(workspace_root)` check on any symlink targets.
- **Mirrors `_handle_file_raw`** — same session resolution, same `safe_resolve` pattern, same `_content_disposition_value` helper.

## Tested
- `pytest tests/test_folder_download.py -v` — 11/11 passing locally on Python 3.11/3.12/3.13
- Manual: nested folder with 3 files → valid zip with correct structure
- Manual: oversize cap → 413 JSON before any bytes streamed
- Manual: path traversal (`?path=../../etc`) → 400

## What this is NOT
- No new dependencies (stdlib `zipfile` only)
- No build/bundler/framework changes
- No changes to `server.py` (route logic stays in `api/`)
- No CHANGELOG entry yet — happy to add one in the same style as recent entries on merge, or leave for release stamping (whichever you prefer)

## Open follow-ups (not in this PR)
- Optional: progress UI for large folders (browser shows native download progress, which is adequate)