### PR TITLE
fix: add Grok OAuth provider catalog support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **PR #2568** by @Michaelyklam (closes #2545) — Add the Hermes Agent `xai-oauth` provider to the WebUI's OAuth/provider catalogs so Grok OAuth accounts authenticated through the Hermes CLI appear in Settings → Providers and the model picker. The provider is treated as CLI-managed OAuth (not WebUI API-key configurable) and uses the live Hermes CLI model catalog when available with a Grok static fallback.
+
 ## [v0.51.91] — 2026-05-18 — Release BO (stage-384 — 5-PR full sweep batch — reasoning-replay history fix + archive-extract per-session inbox + fallback streaming warnings + sanitized custom-provider env hints + Slice 3c queue/goal adapter routing)
 
 ### Fixed

--- a/api/config.py
+++ b/api/config.py
@@ -692,6 +692,7 @@ _PROVIDER_DISPLAY = {
     "anthropic": "Anthropic",
     "openai": "OpenAI",
     "openai-codex": "OpenAI Codex",
+    "xai-oauth": "xAI Grok OAuth",
     "copilot": "GitHub Copilot",
     "zai": "Z.AI / GLM",
     "kimi-coding": "Kimi / Moonshot",
@@ -1207,6 +1208,9 @@ _PROVIDER_MODELS = {
     ],
     # xAI — prefix used in OpenRouter model IDs (x-ai/grok-4-20)
     "x-ai": [
+        {"id": "grok-4.20", "label": "Grok 4.20"},
+    ],
+    "xai-oauth": [
         {"id": "grok-4.20", "label": "Grok 4.20"},
     ],
 }

--- a/api/providers.py
+++ b/api/providers.py
@@ -692,6 +692,7 @@ _OAUTH_PROVIDERS = frozenset({
     "nous",
     "openai-codex",
     "qwen-oauth",
+    "xai-oauth",
 })
 
 # SECTION: Helper functions
@@ -1863,6 +1864,14 @@ def get_providers() -> dict[str, Any]:
                 if mid not in live_ids:
                     live_ids.append(mid)
             live_models = _models_from_live_provider_ids(pid, live_ids)
+            if live_models:
+                models = live_models
+                models_total = len(models)
+        if pid == "xai-oauth":
+            live_models = _models_from_live_provider_ids(
+                pid,
+                _read_live_provider_model_ids("xai-oauth"),
+            )
             if live_models:
                 models = live_models
                 models_total = len(models)

--- a/tests/test_issue2545_xai_oauth_provider.py
+++ b/tests/test_issue2545_xai_oauth_provider.py
@@ -1,0 +1,78 @@
+import copy
+
+import api.config as config
+import api.profiles as profiles
+
+
+def _with_config(monkeypatch, tmp_path, cfg):
+    old_cfg = copy.deepcopy(config.cfg)
+    old_mtime = config._cfg_mtime
+    config.cfg.clear()
+    config.cfg.update(copy.deepcopy(cfg))
+    config._cfg_mtime = 0.0
+    config.invalidate_models_cache()
+    monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: tmp_path)
+
+    def restore():
+        config.cfg.clear()
+        config.cfg.update(old_cfg)
+        config._cfg_mtime = old_mtime
+        config.invalidate_models_cache()
+
+    return restore
+
+
+def test_xai_oauth_is_known_oauth_provider():
+    from api.providers import _OAUTH_PROVIDERS
+    from api.config import _PROVIDER_DISPLAY
+
+    assert "xai-oauth" in _OAUTH_PROVIDERS
+    assert _PROVIDER_DISPLAY["xai-oauth"] == "xAI Grok OAuth"
+
+
+def test_xai_oauth_provider_card_uses_oauth_status_and_models(monkeypatch, tmp_path):
+    restore = _with_config(
+        monkeypatch,
+        tmp_path,
+        {
+            "model": {"provider": "xai-oauth", "default": "grok-4.20"},
+            "providers": {},
+        },
+    )
+    monkeypatch.setattr(config, "_read_live_provider_model_ids", lambda pid: ["grok-4.20"] if pid == "xai-oauth" else [])
+    try:
+        from api.providers import get_providers
+        import api.providers as providers
+
+        monkeypatch.setattr(providers, "_read_live_provider_model_ids", lambda pid: ["grok-4.20"] if pid == "xai-oauth" else [])
+
+        result = get_providers()
+        grok = next(p for p in result["providers"] if p["id"] == "xai-oauth")
+        assert grok["display_name"] == "xAI Grok OAuth"
+        assert grok["is_oauth"] is True
+        assert grok["configurable"] is False
+        assert grok["key_source"] == "oauth"
+        assert grok["models"] == [{"id": "grok-4.20", "label": "Grok 4.20"}]
+        assert grok["models_total"] == 1
+    finally:
+        restore()
+
+
+def test_xai_oauth_model_picker_group_uses_live_catalog(monkeypatch, tmp_path):
+    restore = _with_config(
+        monkeypatch,
+        tmp_path,
+        {
+            "model": {"provider": "xai-oauth", "default": "grok-4.20"},
+            "providers": {"xai-oauth": {}},
+        },
+    )
+    monkeypatch.setattr(config, "_read_live_provider_model_ids", lambda pid: ["grok-4.20"] if pid == "xai-oauth" else [])
+    try:
+        result = config.get_available_models()
+        group = next(g for g in result["groups"] if g["provider_id"] == "xai-oauth")
+        assert group["provider"] == "xAI Grok OAuth"
+        assert group["models"] == [{"id": "grok-4.20", "label": "Grok 4.20"}]
+        assert result["active_provider"] == "xai-oauth"
+    finally:
+        restore()


### PR DESCRIPTION
## Thinking Path
- Hermes WebUI should track Hermes Agent's provider catalog closely enough that CLI-authenticated providers are selectable in the browser.
- Hermes Agent now exposes `xai-oauth` for Grok OAuth, but WebUI only knew about older OAuth provider ids.
- The WebUI provider Settings card and `/api/models` picker both need the provider id, display name, OAuth classification, and model fallback/live catalog path.
- This keeps credentials CLI-managed and avoids adding any WebUI API-key form for Grok OAuth.

## What Changed
- Added `xai-oauth` to the WebUI's known OAuth provider set.
- Added the `xAI Grok OAuth` display name and Grok static fallback model entry.
- Taught provider cards to prefer the live Hermes CLI model catalog for `xai-oauth` when available.
- Added regression coverage for provider classification, Settings provider-card metadata, and model-picker grouping.
- Updated the changelog.

## Why It Matters
Users who authenticate Grok through the Hermes CLI can now see/select the OAuth-backed Grok provider in WebUI instead of being blocked by missing provider-picker entries.

Closes #2545

## Verification
- `env -u HERMES_CONFIG_PATH -u HERMES_WEBUI_HOST /home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_issue2545_xai_oauth_provider.py tests/test_provider_management.py tests/test_sprint34.py -q` — 50 passed
- `python3 -m py_compile api/config.py api/providers.py tests/test_issue2545_xai_oauth_provider.py`
- `git diff --check`

No screenshot is attached because this is a provider/catalog plumbing fix: the visible UI is existing Settings/model-picker rendering fed by the corrected provider metadata, and the regression tests verify that metadata without requiring a real Grok OAuth credential in the test environment.

## Risks / Follow-ups
- The static fallback currently includes `grok-4.20`; live Hermes CLI catalog discovery remains the source of truth when available.
- If Hermes Agent adds additional Grok OAuth models, WebUI should inherit them through the live model catalog path.

## Model Used
AI-assisted change with repository inspection, targeted editing, and shell-based test verification.
