### PR TITLE
fix(approval): route agent_session_key through SSE→frontend→respond for correct session matching

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -2367,6 +2367,10 @@ def submit_pending(session_key: str, approval: dict) -> None:
     """
     entry = dict(approval)
     entry.setdefault("approval_id", uuid.uuid4().hex)
+    # Stash the agent's session_key so it survives the SSE→frontend→respond
+    # round-trip. The frontend uses the WebUI session_id for SSE routing, but
+    # approve_session needs the agent's session_key to match is_approved().
+    entry["agent_session_key"] = session_key
     with _lock:
         queue_list = _pending.setdefault(session_key, [])
         # Replace a legacy non-list value if the agent version uses the old pattern.
@@ -8748,14 +8752,20 @@ def _handle_approval_respond(handler, body):
     if choice not in ("once", "session", "always", "deny"):
         return bad(handler, f"Invalid choice: {choice}")
     approval_id = body.get("approval_id", "")
+    # Use the agent's real session_key for approve_session matching.
+    # The frontend sends the WebUI session_id for SSE routing, but the
+    # agent stores approvals under its own session_key.  When the agent
+    # session_key is available (from submit_pending -> SSE -> frontend ->
+    # respond round-trip), use it instead of the WebUI sid.
+    agent_session_key = body.get("agent_session_key", "") or sid
 
     from api.runtime_adapter import LegacyJournalRuntimeAdapter, runtime_adapter_enabled
 
     if runtime_adapter_enabled():
         adapter = LegacyJournalRuntimeAdapter(approval_delegate=_resolve_approval_legacy)
-        ok = adapter.respond_approval(sid, approval_id, choice).accepted
+        ok = adapter.respond_approval(agent_session_key, approval_id, choice).accepted
     else:
-        ok = _resolve_approval_legacy(sid, approval_id, choice)
+        ok = _resolve_approval_legacy(agent_session_key, approval_id, choice)
     return j(handler, {"ok": ok, "choice": choice})
 
 

--- a/static/messages.js
+++ b/static/messages.js
@@ -2218,6 +2218,7 @@ function hideApprovalCard(force=false) {
     }
   }
   _approvalSessionId = null;
+  _approvalAgentSessionKey = null;
   _resetApprovalCardState();
   card.classList.remove("visible");
   $("approvalCmd").textContent = "";
@@ -2226,6 +2227,7 @@ function hideApprovalCard(force=false) {
 
 // Track session_id of the active approval so respond goes to the right session
 let _approvalSessionId = null;
+let _approvalAgentSessionKey = null;  // agent's session_key for approve_session matching
 let _approvalCurrentId = null;  // approval_id of the card currently shown
 let _approvalPendingBySession = new Map();
 
@@ -2265,6 +2267,12 @@ function _renderPendingApprovalForActiveSession() {
 function showApprovalForSession(sid, pending, pendingCount) {
   if (!pending) return;
   pending._session_id = sid;
+  // Preserve the agent's session_key from the backend through the
+  // SSE→frontend→respond round-trip. The backend stashed it at
+  // submit_pending time; don't overwrite it with the WebUI sid.
+  if (pending.agent_session_key) {
+    _approvalAgentSessionKey = pending.agent_session_key;
+  }
   showApprovalCard(pending, pendingCount);
 }
 
@@ -2320,9 +2328,16 @@ async function respondApproval(choice) {
   _clearApprovalPendingForSession(sid);
   hideApprovalCard(true);
   try {
+    // Include the agent's session_key so the backend can call
+    // approve_session against the correct key for is_approved() matching.
+    const body = { session_id: sid, choice, approval_id: approvalId };
+    if (_approvalAgentSessionKey) {
+      body.agent_session_key = _approvalAgentSessionKey;
+    }
+    _approvalAgentSessionKey = null;
     await api("/api/approval/respond", {
       method: "POST",
-      body: JSON.stringify({ session_id: sid, choice, approval_id: approvalId })
+      body: JSON.stringify(body)
     });
   } catch(e) { setStatus(t("approval_responding") + " " + e.message); }
 }

--- a/tests/test_runtime_adapter_seam.py
+++ b/tests/test_runtime_adapter_seam.py
@@ -218,8 +218,8 @@ def test_approval_and_clarify_routes_use_adapter_only_when_flag_enabled():
 
     assert "runtime_adapter_enabled()" in approval_body
     assert "LegacyJournalRuntimeAdapter(approval_delegate=_resolve_approval_legacy)" in approval_body
-    assert "adapter.respond_approval(sid, approval_id, choice).accepted" in approval_body
-    assert "else:\n        ok = _resolve_approval_legacy(sid, approval_id, choice)" in approval_body
+    assert 'adapter.respond_approval(agent_session_key, approval_id, choice).accepted' in approval_body
+    assert 'else:\n        ok = _resolve_approval_legacy(agent_session_key, approval_id, choice)' in approval_body
     assert "HERMES_WEBUI_RUNTIME_ADAPTER" not in approval_body
 
     assert "runtime_adapter_enabled()" in clarify_body


### PR DESCRIPTION
## Problem

When the user clicks "Allow for this session" on a dangerous-command approval, the approval is stored against the **WebUI session_id** (e.g. `0659c8c61e3e`). But when the agent checks `is_approved()` on the next tool call, it uses `get_current_session_key()` which resolves to the **agent's session_key** — a different value. The approval is never found, so the next dangerous command asks again.

## Root cause

The frontend sends the WebUI `session_id` for SSE routing, but the agent stores approvals under its own `session_key` (HERMES_SESSION_KEY / contextvar). The `_handle_approval_respond` handler passed the WebUI `sid` directly to `_resolve_approval_legacy`, which then called `approve_session()` against the wrong key.

## Fix

Three changes, one per layer:

**Backend — `api/routes.py` `submit_pending()`:** Stash the agent's real `session_key` in the approval entry as `agent_session_key` so it survives the SSE round-trip.

**Frontend — `static/messages.js`:**
- `showApprovalForSession()` preserves `pending.agent_session_key` in a new `_approvalAgentSessionKey` variable (instead of overwriting it with the WebUI sid)
- `respondApproval()` includes `agent_session_key` in the POST body when available
- `hideApprovalCard()` clears it on card dismiss

**Backend — `api/routes.py` `_handle_approval_respond()`:** When `agent_session_key` is present in the request body, use it instead of the WebUI `sid` for `_resolve_approval_legacy`. Falls back to `sid` when absent for backwards compatibility.

## Testing

- Updated source-contract test to match the new `agent_session_key` parameter name
- Existing functional tests (PR A, gated with `@requires_agent_modules`) continue to pass

## Scope

This is the companion to PR #2573 (the `_gateway_queues` peek fix). Together they ensure session-level approvals persist across streaming turns: PR A finds the approval in the right queue, PR B stores it against the right key.