### PR TITLE
fix: prevent queued follow-up message from draining into wrong chat

### DIFF
--- a/static/messages.js
+++ b/static/messages.js
@@ -187,6 +187,7 @@ if(typeof document!=='undefined'){
 // (e.g. queue drain + user click) can both pass the S.busy check because
 // setBusy(true) is only called after the first await inside send().
 let _sendInProgress = false;
+let _sendInProgressSid = null;  // session_id of the in-flight send
 const _sessionTitleProvisionalBySid = new Map();
 
 function _sessionTitleLooksDefaultOrProvisional(titleText, provisionalText){
@@ -236,11 +237,14 @@ async function send(){
   // instead of silently dropping it.
   if (_sendInProgress) {
     const _text=$('msg').value.trim();
-    if(_text && S.session && S.session.session_id){
-      queueSessionMessage(S.session.session_id,{text:_text,files:[...S.pendingFiles],model:S.session&&S.session.model||($('modelSelect')&&$('modelSelect').value)||'',model_provider:S.session&&S.session.model_provider||null,profile:S.activeProfile||'default'});
+    // Use the in-flight session's sid, not the currently viewed session,
+    // so the queued message goes to the chat that owns the active stream.
+    const _targetSid=_sendInProgressSid||(S.session&&S.session.session_id);
+    if(_text && _targetSid){
+      queueSessionMessage(_targetSid,{text:_text,files:[...S.pendingFiles],model:S.session&&S.session.model||($('modelSelect')&&$('modelSelect').value)||'',model_provider:S.session&&S.session.model_provider||null,profile:S.activeProfile||'default'});
       $('msg').value='';autoResize();
       S.pendingFiles=[];renderTray();
-      updateQueueBadge(S.session.session_id);
+      updateQueueBadge(_targetSid);
       showToast(`Queued: "${_text.slice(0,40)}${_text.length>40?'…':''}"`,2000);
     }
     return;
@@ -248,9 +252,9 @@ async function send(){
   _sendInProgress = true;
   try{
   const text=$('msg').value.trim();
-  if(!text&&!S.pendingFiles.length)return;
+  if(!text&&!S.pendingFiles.length){_sendInProgress=false;_sendInProgressSid=null;return;}
   // Don't send while an inline message edit is active
-  if(document.querySelector('.msg-edit-area'))return;
+  if(document.querySelector('.msg-edit-area')){_sendInProgress=false;_sendInProgressSid=null;return;}
 
   // Dismiss handoff hint when user sends a message (resets seen_at).
   if(S.session&&S.session.session_id&&typeof _dismissHandoffHint==='function'){
@@ -380,6 +384,7 @@ async function send(){
   if(!S.session){await newSession();await renderSessionList();}
 
   const activeSid=S.session.session_id;
+  _sendInProgressSid=activeSid;
 
   setComposerStatus(S.pendingFiles&&S.pendingFiles.length?'Uploading…':'');
   let uploaded=[];
@@ -528,7 +533,7 @@ async function send(){
   // Open SSE stream and render tokens live
   attachLiveStream(activeSid, streamId, uploadedNames);
 
-  }finally{ _sendInProgress=false; }
+  }finally{ _sendInProgress=false; _sendInProgressSid=null; }
 }
 
 const LIVE_STREAMS={};

--- a/static/ui.js
+++ b/static/ui.js
@@ -3266,6 +3266,16 @@ function setBusy(v){
     if(next){
       updateQueueBadge(sid);
       setTimeout(()=>{
+        // Guard: if the user switched away from the drain session during
+        // the 120ms settle window, the queued message must NOT go to the
+        // wrong chat.  Put it back into the original session's queue and
+        // skip sending — it will drain when the user returns to that session
+        // or when its next stream completes while it is the active view.
+        if(S.session&&S.session.session_id!==sid){
+          queueSessionMessage(sid,next);
+          updateQueueBadge(sid);
+          return;
+        }
         $('msg').value=next.text||'';
         S.pendingFiles=Array.isArray(next.files)?[...next.files]:[];
         // Restore model from queued item (sent in /api/chat/start payload)


### PR DESCRIPTION
## Bug

When a follow-up message is queued (sent while a stream is active) and the user switches to a different chat, the queued message can be sent to the wrong session.

### Root cause

`setBusy(false)` drains queued messages via a 120ms `setTimeout` that writes the queued text to the shared `#msg` composer and calls `send()`. But `send()` reads `S.session.session_id` at call time, not when the message was queued. If the user switches sessions during the 120ms window, the message goes to the wrong chat.

A secondary issue: the `_sendInProgress` re-queue guard uses `S.session.session_id` (the currently viewed session) instead of the session that owns the in-flight stream.

### Fix

1. **`setBusy(false)` drain (ui.js)**: Guard the `setTimeout` callback — if `S.session.session_id` no longer matches the drain session `sid`, put the message back into the original session's queue instead of sending it to the wrong chat.

2. **`_sendInProgress` re-queue (messages.js)**: Track `_sendInProgressSid` alongside `_sendInProgress` so the re-queued message targets the in-flight session, not the currently viewed one.

### Reproduction

1. Start a conversation in chat A (stream begins)
2. Type a follow-up message and hit send → gets queued for A
3. Switch to chat B before the stream in A finishes
4. When stream A completes, the queued message is sent to B instead of A

### Test plan
- [x] Reproduced the bug before the fix
- [x] Verified the queued message stays in the original chat after the fix
- [ ] Queued message drains correctly when user stays in the same chat (no regression)
- [ ] Queued message re-queues when user switches away, then drains when returning

Closes #2585