### PR TITLE
Fix stale stream recovery writeback race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Allow a still-running stream that was mistakenly marked interrupted by stale-pending recovery to replace its own recovery marker when it later finishes, while continuing to block stale writeback after any newer turn appends transcript content.
 
 ## [v0.51.92] — 2026-05-19 — Release BP (stage-385 — 7-PR full sweep batch — RFC Slice 3c clarification + workspace tree icon alignment + project move cache refresh + auto-compression handoff metadata + Grok OAuth provider catalog + anonymous custom endpoint picker fallback + PWA standalone reload + pull-to-refresh)
 

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -2358,6 +2358,53 @@ def _stream_writeback_is_current(session, stream_id):
     return bool(stream_id) and getattr(session, 'active_stream_id', None) == stream_id
 
 
+def _stream_writeback_can_supersede_recovery_marker(session, msg_text):
+    """Allow a finishing worker to replace its own stale-repair marker.
+
+    The stale-pending repair path can occasionally run while the original worker
+    is still alive but temporarily missing from the in-memory stream registry. It
+    clears ``active_stream_id`` and appends a "Response interrupted" marker. If
+    the original worker later finishes, treating ``active_stream_id is None`` as
+    stale drops the real answer and leaves the misleading marker visible.
+
+    This is intentionally narrow: only a session with no active/pending turn and
+    whose last visible row is the recovery marker for this exact user prompt may
+    be superseded. If a newer turn has appended anything after the marker, the
+    normal stale-writeback guard still wins.
+    """
+    if getattr(session, 'active_stream_id', None):
+        return False
+    if getattr(session, 'pending_user_message', None):
+        return False
+    if getattr(session, 'pending_attachments', None):
+        return False
+    messages = list(getattr(session, 'messages', None) or [])
+    if len(messages) < 2:
+        return False
+    last = messages[-1]
+    if not isinstance(last, dict) or not last.get('_error'):
+        return False
+    if last.get('type') != 'interrupted':
+        return False
+    content = str(last.get('content') or '')
+    if 'Response interrupted' not in content or 'WebUI process restarted' not in content:
+        return False
+
+    expected = ' '.join(str(msg_text or '').split())
+    if not expected:
+        return False
+    for msg in reversed(messages[:-1]):
+        if not isinstance(msg, dict):
+            continue
+        if msg.get('_error'):
+            continue
+        if msg.get('role') != 'user':
+            continue
+        actual = ' '.join(str(msg.get('content') or '').split())
+        return actual == expected
+    return False
+
+
 def _merge_display_messages_after_agent_result(previous_display, previous_context, result_messages, msg_text):
     """Keep UI transcript durable while allowing model context to compact.
 
@@ -4083,13 +4130,20 @@ def _run_agent_streaming(
                 return
             with _agent_lock:
                 if not ephemeral and not _stream_writeback_is_current(s, stream_id):
-                    logger.info(
-                        "Skipping stale stream writeback for session %s stream %s; active_stream_id=%s",
-                        getattr(s, 'session_id', session_id),
-                        stream_id,
-                        getattr(s, 'active_stream_id', None),
-                    )
-                    return
+                    if _stream_writeback_can_supersede_recovery_marker(s, msg_text):
+                        logger.info(
+                            "Superseding stale recovery marker for session %s stream %s",
+                            getattr(s, 'session_id', session_id),
+                            stream_id,
+                        )
+                    else:
+                        logger.info(
+                            "Skipping stale stream writeback for session %s stream %s; active_stream_id=%s",
+                            getattr(s, 'session_id', session_id),
+                            stream_id,
+                            getattr(s, 'active_stream_id', None),
+                        )
+                        return
                 _result_messages = result.get('messages') or _previous_context_messages
                 if cancel_event.is_set():
                     _finalize_cancelled_turn(s, ephemeral=False)

--- a/tests/test_session_sidecar_repair.py
+++ b/tests/test_session_sidecar_repair.py
@@ -808,6 +808,52 @@ class TestNonEmptyMessagesPendingCleared:
         assert s.pending_user_message is None
         assert s.active_stream_id is None
 
+    def test_finished_worker_can_supersede_its_own_interrupted_marker(self):
+        """A live worker that finishes after stale repair should be allowed to
+        replace the recovery marker for the same user turn."""
+        s = _make_session(
+            messages=[
+                {"role": "user", "content": "deploy"},
+                models._interrupted_recovery_marker(),
+            ]
+        )
+        s.active_stream_id = None
+        s.pending_user_message = None
+        s.pending_attachments = []
+
+        assert streaming._stream_writeback_can_supersede_recovery_marker(s, "deploy")
+
+    def test_finished_worker_does_not_supersede_after_newer_turn_appended(self):
+        """Once a follow-up turn changes the visible tail, stale writeback stays
+        blocked so old workers cannot overwrite newer transcript state."""
+        s = _make_session(
+            messages=[
+                {"role": "user", "content": "deploy"},
+                models._interrupted_recovery_marker(),
+                {"role": "user", "content": "what happened?"},
+                {"role": "assistant", "content": "I checked the deployment status."},
+            ]
+        )
+        s.active_stream_id = None
+        s.pending_user_message = None
+        s.pending_attachments = []
+
+        assert not streaming._stream_writeback_can_supersede_recovery_marker(s, "deploy")
+
+    def test_finished_worker_does_not_supersede_different_user_turn(self):
+        """The supersede path is tied to the pending prompt that was repaired."""
+        s = _make_session(
+            messages=[
+                {"role": "user", "content": "deploy"},
+                models._interrupted_recovery_marker(),
+            ]
+        )
+        s.active_stream_id = None
+        s.pending_user_message = None
+        s.pending_attachments = []
+
+        assert not streaming._stream_writeback_can_supersede_recovery_marker(s, "ship it")
+
     def test_core_sync_branch_does_not_duplicate_journal_output_already_in_core(
         self, hermes_home, monkeypatch
     ):


### PR DESCRIPTION
## Thinking Path

A production WebUI session showed `Response interrupted` even though the WebUI process did not actually restart and the agent worker continued running. The observed log shape was the final worker writeback being skipped after stale-pending recovery had already cleared `active_stream_id` and appended the recovery marker.

## What Changed

- Adds a narrow final-writeback escape hatch for the case where a finishing worker finds its own stale recovery marker as the current transcript tail.
- Keeps the existing stale-writeback protection when a newer stream is active, a pending turn still exists, the visible tail no longer matches the recovery marker, or the marker belongs to a different prompt.
- Adds regression coverage for:
  - replacing the same turn's interrupted marker when the original worker finishes,
  - refusing to overwrite after a newer turn appends content,
  - refusing to overwrite when the prompt does not match.
- Adds an Unreleased changelog entry.

## Why It Matters

Long-running tool-heavy turns can temporarily lose WebUI stream ownership metadata and be repaired as interrupted while the underlying agent thread is still alive. Without this guard, the worker's real final response is dropped, leaving a misleading `WebUI process restarted` marker and encouraging duplicate user retries.

State layer / invariant: this touches the streaming writeback and visible transcript layers. The final answer may supersede only the recovery marker for the same current user turn; newer transcript content remains protected from stale workers.

## Verification

- `pytest tests/test_session_sidecar_repair.py -q` → `40 passed`
- `pytest tests/test_stale_stream_writeback.py tests/test_issue1624_repair_stale_pending_grace.py tests/test_metadata_save_wipe_1558.py tests/test_issue765_streaming_persistence.py -q` → `54 passed`
- `pytest tests/ -q` → `5990 passed, 4 skipped, 3 xpassed, 8 subtests passed`

Note: `pytest ... --timeout=60` was attempted first per docs, but this checkout does not have the pytest-timeout plugin installed, so verification used terminal-level timeouts instead.

## Risks / Follow-ups

- The escape hatch intentionally does not solve the upstream cause of stream metadata disappearing while a worker is active; it only prevents the completed response from being dropped when the stale repair marker is still the current tail.
- A broader fix could add a stronger active-worker heartbeat/journal check before stale-pending repair marks a turn interrupted.
