### PR TITLE
fix: preserve provider for configured model picker selections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Preserve the configured provider when choosing a configured model from the composer picker, so selecting a model owned by another provider does not send it through the previous provider. (PR #2588)
+
 
 ## [v0.51.92] — 2026-05-19 — Release BP (stage-385 — 7-PR full sweep batch — RFC Slice 3c clarification + workspace tree icon alignment + project move cache refresh + auto-compression handoff metadata + Grok OAuth provider catalog + anonymous custom endpoint picker fallback + PWA standalone reload + pull-to-refresh)
 

--- a/static/ui.js
+++ b/static/ui.js
@@ -732,6 +732,7 @@ const MODEL_STATE_KEY='hermes-webui-model-state';
 // first colliding entry.
 function _getOptionProviderId(opt){
   if(!opt) return '';
+  if(opt.dataset && opt.dataset.provider) return opt.dataset.provider;
   const group=opt.parentElement;
   if(group && group.tagName==='OPTGROUP' && group.dataset && group.dataset.provider){
     return group.dataset.provider;
@@ -1416,6 +1417,8 @@ async function selectModelFromDropdown(value){
     opt.value=value;
     opt.textContent=getModelLabel(value);
     opt.dataset.custom='1';
+    const badge=(window._configuredModelBadges||{})[value];
+    if(badge&&badge.provider) opt.dataset.provider=badge.provider;
     // Remove any previous custom option before adding new one
     sel.querySelectorAll('option[data-custom]').forEach(o=>o.remove());
     sel.appendChild(opt);

--- a/tests/test_issue2569_model_provider_picker.py
+++ b/tests/test_issue2569_model_provider_picker.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+UI_JS = (ROOT / "static" / "ui.js").read_text()
+
+
+def test_temporary_configured_model_option_carries_provider_badge():
+    """Configured picker rows that are not already <option>s must keep provider."""
+
+    assert "const badge=(window._configuredModelBadges||{})[value];" in UI_JS
+    assert "if(badge&&badge.provider) opt.dataset.provider=badge.provider;" in UI_JS
+
+
+def test_model_state_reads_provider_from_option_dataset_before_optgroup():
+    """selectModelFromDropdown() adds temporary options outside optgroups."""
+
+    start = UI_JS.index("function _getOptionProviderId(opt)")
+    body = UI_JS[start : UI_JS.index("function _providerFromModelValue", start)]
+    assert "if(opt.dataset && opt.dataset.provider) return opt.dataset.provider;" in body
+    assert body.index("opt.dataset && opt.dataset.provider") < body.index("const group=opt.parentElement")


### PR DESCRIPTION
## Thinking Path
- The issue reports that selecting a model from another provider can leave the session routed through the previous provider.
- The composer picker already knows provider ownership for normal optgroup-backed options.
- The missing case is configured-model rows that are rendered from `window._configuredModelBadges` but are not present as native `<option>` entries.
- When selected, those rows become temporary custom options outside any optgroup, so `_modelStateForSelect()` lost the provider.
- This PR carries the configured provider onto the temporary option and teaches the shared option-provider helper to read it.

## What Changed
- `_getOptionProviderId()` now checks `option.dataset.provider` before falling back to the parent optgroup.
- `selectModelFromDropdown()` stamps a temporary option with the provider from `window._configuredModelBadges[value]` when available.
- Added source-level regression coverage for configured picker rows preserving provider context.
- Added a changelog entry.

## Why It Matters
Selecting a configured model owned by another provider now persists both `model` and `model_provider` for the session, so the next message routes to the intended provider instead of sending the model slug to the previously active provider.

## Verification
- `env -u HERMES_CONFIG_PATH -u HERMES_WEBUI_HOST /home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_issue2569_model_provider_picker.py -q`
- `node --check static/ui.js`
- `node --check static/boot.js`
- `git diff --check`

## Risks / Follow-ups
- Low risk: the change only affects temporary picker options created for configured model rows outside the native catalog.
- Manual free-form custom model IDs still behave as before unless they carry an explicit `@provider:` prefix.
- No UI screenshots attached because this is a routing/state fix with no intended visual delta.

Closes #2569

## Model Used
AI-assisted change with repository inspection, targeted editing, and shell-based test verification.
