### PR TITLE
[codex] Add PAM system-user profile auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+
+- Add optional PAM-backed system-user authentication for WebUI. PAM mode can authenticate either one configured local account or, when explicitly enabled, local login users through a username field. Multi-user PAM sessions are bound server-side to clean per-user Hermes profiles so profile cookies cannot hop across accounts, and deployments that need elevated PAM checks must configure an explicit helper command rather than relying on implicit sudo.
 
 ## [v0.51.92] — 2026-05-19 — Release BP (stage-385 — 7-PR full sweep batch — RFC Slice 3c clarification + workspace tree icon alignment + project move cache refresh + auto-compression handoff metadata + Grok OAuth provider catalog + anonymous custom endpoint picker fallback + PWA standalone reload + pull-to-refresh)
 

--- a/README.md
+++ b/README.md
@@ -272,11 +272,46 @@ Full list of environment variables:
 | `HERMES_WEBUI_DEFAULT_WORKSPACE` | `~/workspace` | Default workspace |
 | `HERMES_WEBUI_DEFAULT_MODEL` | *(provider default)* | Optional model override; leave unset to use the active Hermes provider default |
 | `HERMES_WEBUI_PASSWORD` | *(unset)* | Set to enable password authentication |
+| `HERMES_WEBUI_AUTH_MODE` | *(unset)* | Set to `pam` to authenticate with local PAM instead of a WebUI password hash |
+| `HERMES_WEBUI_PAM_USER` | current process user | Single local account for PAM auth when multi-user login is disabled |
+| `HERMES_WEBUI_PAM_ALLOW_ANY_USER` | `0` | Set to `1` to show a username field and allow real local login users |
+| `HERMES_WEBUI_PAM_MIN_UID` | `1000` | Minimum UID accepted for multi-user PAM logins |
+| `HERMES_WEBUI_PAM_SERVICE` | `login` | PAM service name used for password checks |
+| `HERMES_WEBUI_PAM_HELPER` | *(unset)* | Optional explicit helper command for deployments that need elevated PAM checks; receives password on stdin plus `--user` and `--service` args |
 | `HERMES_WEBUI_EXTENSION_DIR` | *(unset)* | Optional local directory served at `/extensions/`; must point to an existing directory before extension injection is enabled |
 | `HERMES_WEBUI_EXTENSION_SCRIPT_URLS` | *(unset)* | Optional comma-separated same-origin script URLs to inject; see [WebUI Extensions](docs/EXTENSIONS.md) |
 | `HERMES_WEBUI_EXTENSION_STYLESHEET_URLS` | *(unset)* | Optional comma-separated same-origin stylesheet URLs to inject; see [WebUI Extensions](docs/EXTENSIONS.md) |
 | `HERMES_HOME` | `~/.hermes` | Base directory for Hermes state (affects all paths) |
 | `HERMES_CONFIG_PATH` | `~/.hermes/config.yaml` | Path to Hermes config file |
+
+---
+
+### System user authentication with PAM
+
+For LAN or shared-host deployments, WebUI can authenticate against local system
+accounts instead of a shared WebUI password:
+
+```bash
+HERMES_WEBUI_AUTH_MODE=pam ./start.sh
+```
+
+By default PAM mode authenticates only the configured `HERMES_WEBUI_PAM_USER`
+(or the WebUI process user). To let any real local login user sign in with their
+own username and password:
+
+```bash
+HERMES_WEBUI_AUTH_MODE=pam HERMES_WEBUI_PAM_ALLOW_ANY_USER=1 ./start.sh
+```
+
+Multi-user PAM sessions are bound server-side to a Hermes profile derived from
+the system username. The profile is created cleanly on first login; WebUI does
+not clone the default profile's config or API keys into new login profiles.
+Service accounts are filtered out by shell and `HERMES_WEBUI_PAM_MIN_UID`.
+
+Some PAM stacks only allow password checks for the current process user unless
+the WebUI is running with additional privileges. In that case configure a
+tightly scoped helper with `HERMES_WEBUI_PAM_HELPER`; no sudo or helper command
+is assumed by default.
 
 ---
 

--- a/api/auth.py
+++ b/api/auth.py
@@ -9,6 +9,7 @@ import http.cookies
 import json
 import logging
 import os
+import re
 import secrets
 import tempfile
 import threading
@@ -57,9 +58,55 @@ COOKIE_NAME = 'hermes_session'
 CSRF_HEADER_NAME = 'X-Hermes-CSRF-Token'
 
 _SESSIONS_FILE = STATE_DIR / '.sessions.json'
+_SESSION_PROFILE_RE = re.compile(r'^(default|[a-z0-9][a-z0-9_-]{0,63})$')
 
 
-def _load_sessions() -> dict[str, float]:
+def _session_expiry(record) -> float | None:
+    """Return the expiry timestamp from a legacy or metadata session record."""
+    if isinstance(record, (int, float)):
+        return float(record)
+    if isinstance(record, dict) and isinstance(record.get('exp'), (int, float)):
+        return float(record['exp'])
+    return None
+
+
+def _safe_session_value(value, *, max_len: int = 128) -> str | None:
+    if not isinstance(value, str) or not value or len(value) > max_len:
+        return None
+    if any(ord(ch) < 32 or ord(ch) == 127 for ch in value):
+        return None
+    return value
+
+
+def _session_metadata(record) -> dict:
+    """Return safe identity metadata from a session record."""
+    if not isinstance(record, dict):
+        return {}
+    result = {}
+    user = _safe_session_value(record.get('user'))
+    if user:
+        result['user'] = user
+    profile = _safe_session_value(record.get('profile'), max_len=64)
+    if profile and _SESSION_PROFILE_RE.fullmatch(profile):
+        result['profile'] = profile
+    return result
+
+
+def _session_record(expiry: float, *, username: str | None = None, profile: str | None = None):
+    """Build a persisted session record, preserving legacy float records when empty."""
+    metadata = {}
+    user = _safe_session_value(username)
+    if user:
+        metadata['user'] = user
+    prof = _safe_session_value(profile, max_len=64)
+    if prof and _SESSION_PROFILE_RE.fullmatch(prof):
+        metadata['profile'] = prof
+    if not metadata:
+        return expiry
+    return {'exp': expiry, **metadata}
+
+
+def _load_sessions() -> dict[str, object]:
     """Load persisted sessions from STATE_DIR, pruning expired entries.
 
     Returns an empty dict on any read or parse error so startup is never
@@ -71,14 +118,22 @@ def _load_sessions() -> dict[str, float]:
             if not isinstance(data, dict):
                 raise ValueError('malformed sessions file — expected dict')
             now = time.time()
-            return {t: exp for t, exp in data.items()
-                    if isinstance(t, str) and isinstance(exp, (int, float)) and exp > now}
+            sessions: dict[str, object] = {}
+            for token, record in data.items():
+                exp = _session_expiry(record)
+                if not isinstance(token, str) or exp is None or exp <= now:
+                    continue
+                if isinstance(record, dict):
+                    sessions[token] = {'exp': exp, **_session_metadata(record)}
+                else:
+                    sessions[token] = exp
+            return sessions
     except Exception as e:
         logger.debug("Failed to load sessions file, starting fresh: %s", e)
     return {}
 
 
-def _save_sessions(sessions: dict[str, float]) -> None:
+def _save_sessions(sessions: dict[str, object]) -> None:
     """Atomically persist sessions to STATE_DIR/.sessions.json (0600).
 
     Uses a temp file + os.replace() so a crash mid-write never leaves a
@@ -243,6 +298,7 @@ def _hash_password(password, *, salt: bytes | None = None) -> str:
 _AUTH_HASH_LOCK = threading.Lock()
 _AUTH_HASH_COMPUTED: bool = False
 _AUTH_HASH_CACHE: str | None = None
+_PAM_SENTINEL = "__pam_auth_enabled__"
 
 
 def _invalidate_password_hash_cache() -> None:
@@ -279,11 +335,16 @@ def get_password_hash() -> str | None:
         if _AUTH_HASH_COMPUTED:
             return _AUTH_HASH_CACHE
 
-        env_pw = os.getenv('HERMES_WEBUI_PASSWORD', '').strip()
-        if env_pw:
-            result = _hash_password(env_pw)
+        from api import auth_pam
+
+        if auth_pam.enabled():
+            result = _PAM_SENTINEL
         else:
-            result = load_settings().get('password_hash') or None
+            env_pw = os.getenv('HERMES_WEBUI_PASSWORD', '').strip()
+            if env_pw:
+                result = _hash_password(env_pw)
+            else:
+                result = load_settings().get('password_hash') or None
 
         _AUTH_HASH_CACHE = result
         _AUTH_HASH_COMPUTED = True
@@ -306,6 +367,10 @@ def verify_password(plain: str) -> bool:
     expected = get_password_hash()
     if not expected:
         return False
+    if expected == _PAM_SENTINEL:
+        from api import auth_pam
+
+        return auth_pam.authenticate(None, plain) is not None
     # Fast path: current PBKDF2 key
     if hmac.compare_digest(_hash_password(plain), expected):
         return True
@@ -326,10 +391,33 @@ def verify_password(plain: str) -> bool:
     return False
 
 
-def create_session() -> str:
+def verify_login(username: str | None, plain: str) -> dict | None:
+    """Verify a login request and return optional session identity metadata."""
+    expected = get_password_hash()
+    if not expected:
+        return None
+    if expected == _PAM_SENTINEL:
+        from api import auth_pam
+
+        return auth_pam.authenticate(username, plain)
+    return {} if verify_password(plain) else None
+
+
+def login_uses_username() -> bool:
+    """Return True when the login page should ask for a username."""
+    from api import auth_pam
+
+    return auth_pam.login_uses_username()
+
+
+def create_session(username: str | None = None, profile: str | None = None) -> str:
     """Create a new auth session. Returns signed cookie value."""
     token = secrets.token_hex(32)
-    _sessions[token] = time.time() + _resolve_session_ttl()
+    _sessions[token] = _session_record(
+        time.time() + _resolve_session_ttl(),
+        username=username,
+        profile=profile,
+    )
     _save_sessions(_sessions)
     sig = hmac.new(_signing_key(), token.encode(), hashlib.sha256).hexdigest()
     return f"{token}.{sig}"
@@ -338,7 +426,10 @@ def create_session() -> str:
 def _prune_expired_sessions():
     """Remove all expired session entries to prevent unbounded memory growth."""
     now = time.time()
-    expired = [t for t, exp in _sessions.items() if now > exp]
+    expired = [
+        token for token, record in _sessions.items()
+        if (exp := _session_expiry(record)) is None or now > exp
+    ]
     if expired:
         for token in expired:
             _sessions.pop(token, None)
@@ -360,7 +451,7 @@ def verify_session(cookie_value: str) -> bool:
     )
     if not valid:
         return False
-    expiry = _sessions.get(token)
+    expiry = _session_expiry(_sessions.get(token))
     if not expiry or time.time() > expiry:
         _sessions.pop(token, None)
         return False
@@ -373,6 +464,22 @@ def _session_token_from_cookie_value(cookie_value: str) -> str | None:
         return None
     token, _sig = cookie_value.rsplit('.', 1)
     return token or None
+
+
+def session_identity(cookie_value: str) -> dict:
+    """Return server-side identity metadata for a valid signed session cookie."""
+    if not cookie_value or not verify_session(cookie_value):
+        return {}
+    token = _session_token_from_cookie_value(cookie_value)
+    if not token:
+        return {}
+    return _session_metadata(_sessions.get(token))
+
+
+def session_profile(cookie_value: str) -> str | None:
+    """Return the Hermes profile bound to a valid signed session cookie."""
+    profile = session_identity(cookie_value).get('profile')
+    return profile if isinstance(profile, str) and profile else None
 
 
 def csrf_token_for_session(cookie_value: str) -> str | None:

--- a/api/auth_pam.py
+++ b/api/auth_pam.py
@@ -1,0 +1,190 @@
+"""PAM-backed login provider for Hermes WebUI.
+
+This module is intentionally separate from api.auth so the optional PAM path
+does not make the default shared-password auth flow harder to reason about.
+"""
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+import re
+import shlex
+import subprocess
+
+try:  # pragma: no cover - only absent on non-Unix platforms
+    import pwd
+except ImportError:  # pragma: no cover
+    pwd = None
+
+logger = logging.getLogger(__name__)
+
+_TRUTHY = {'1', 'true', 'yes', 'on'}
+_PROFILE_NAME_RE = re.compile(r'^[a-z0-9][a-z0-9_-]{0,63}$')
+_PROFILE_CLEAN_RE = re.compile(r'[^a-z0-9_-]+')
+_UNSAFE_ACCOUNT_CHARS = {'\x00', '\r', '\n', ':', '/'}
+
+
+def enabled() -> bool:
+    """Return True when WebUI should use PAM instead of a stored password hash."""
+    return os.getenv('HERMES_WEBUI_AUTH_MODE', '').strip().lower() == 'pam'
+
+
+def fixed_user() -> str:
+    """Return the single PAM account used when multi-user login is disabled."""
+    return (
+        os.getenv('HERMES_WEBUI_PAM_USER', '').strip()
+        or os.getenv('USER', '').strip()
+        or ''
+    )
+
+
+def allow_any_user() -> bool:
+    """Return True when the login form should accept a local system username."""
+    return os.getenv('HERMES_WEBUI_PAM_ALLOW_ANY_USER', '').strip().lower() in _TRUTHY
+
+
+def login_uses_username() -> bool:
+    """Return True when the login UI should ask for a username."""
+    return enabled() and allow_any_user()
+
+
+def service() -> str:
+    """Return the PAM service name to use for WebUI login checks."""
+    return os.getenv('HERMES_WEBUI_PAM_SERVICE', '').strip() or 'login'
+
+
+def min_uid() -> int:
+    """Minimum UID accepted for multi-user login, defaulting to human users."""
+    raw = os.getenv('HERMES_WEBUI_PAM_MIN_UID', '1000').strip()
+    try:
+        return max(0, int(raw))
+    except ValueError:
+        return 1000
+
+
+def helper_command() -> list[str]:
+    """Return an optional admin-configured helper command.
+
+    The helper receives the password on stdin and is invoked with
+    ``--user <name> --service <pam-service>``. No helper is used by default:
+    deployments that need elevated PAM checks should configure a tightly
+    scoped wrapper or sudoers rule explicitly.
+    """
+    raw = os.getenv('HERMES_WEBUI_PAM_HELPER', '').strip()
+    return shlex.split(raw) if raw else []
+
+
+def _safe_account_name(name: str) -> bool:
+    return bool(name) and not any(ch in name for ch in _UNSAFE_ACCOUNT_CHARS)
+
+
+def _account_for_name(name: str):
+    if pwd is None:
+        return None
+    try:
+        return pwd.getpwnam(name)
+    except KeyError:
+        return None
+
+
+def _is_login_account(account, *, fixed_name: str) -> bool:
+    if account is None:
+        return False
+    shell = (getattr(account, 'pw_shell', '') or '').lower()
+    if shell.endswith('/nologin') or shell.endswith('/false'):
+        return False
+    uid = int(getattr(account, 'pw_uid', -1))
+    if uid < min_uid() and getattr(account, 'pw_name', '') != fixed_name:
+        return False
+    return True
+
+
+def resolve_login_user(username: str | None, *, allow_default: bool = False) -> str | None:
+    """Resolve a submitted username to an allowed local login account."""
+    requested = (username or '').strip()
+    configured_user = fixed_user()
+    if not requested and allow_default:
+        requested = configured_user
+    if not _safe_account_name(requested):
+        return None
+
+    account = _account_for_name(requested)
+    if account is None:
+        return None
+
+    account_name = getattr(account, 'pw_name', requested)
+    if not allow_any_user():
+        return account_name if account_name == configured_user else None
+    if not _is_login_account(account, fixed_name=configured_user):
+        return None
+    return account_name
+
+
+def profile_name_for_user(username: str) -> str:
+    """Map a system username to a deterministic Hermes profile identifier."""
+    raw = (username or '').strip()
+    lowered = raw.lower()
+    base = _PROFILE_CLEAN_RE.sub('-', lowered).strip('-_') or 'user'
+    needs_suffix = base != lowered or len(base) > 64 or base == 'default'
+    if needs_suffix:
+        suffix = '-' + hashlib.sha256(raw.encode('utf-8')).hexdigest()[:8]
+        base = base[:64 - len(suffix)].rstrip('-_') or 'user'
+        base = base + suffix
+    name = base[:64].rstrip('-_') or 'user'
+    if not _PROFILE_NAME_RE.fullmatch(name) or name == 'default':
+        suffix = hashlib.sha256(raw.encode('utf-8')).hexdigest()[:12]
+        name = f'user-{suffix}'
+    return name
+
+
+def _authenticate_with_python_pam(username: str, password: str) -> bool:
+    try:
+        import pam
+    except Exception as exc:
+        logger.error("PAM auth is enabled but python-pam is unavailable: %s", exc)
+        return False
+
+    try:
+        return bool(pam.pam().authenticate(username, password, service=service()))
+    except Exception as exc:
+        logger.warning("PAM authentication failed unexpectedly: %s", exc)
+        return False
+
+
+def _authenticate_with_helper(username: str, password: str) -> bool:
+    cmd = helper_command()
+    if not cmd:
+        return False
+    try:
+        result = subprocess.run(
+            cmd + ['--user', username, '--service', service()],
+            input=password,
+            text=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=10,
+            check=False,
+        )
+    except Exception as exc:
+        logger.warning("PAM helper failed unexpectedly: %s", exc)
+        return False
+    return result.returncode == 0
+
+
+def authenticate(username: str | None, password: str) -> dict | None:
+    """Return login identity metadata when a PAM login succeeds."""
+    if not password:
+        return None
+    account = resolve_login_user(username, allow_default=not allow_any_user())
+    if not account:
+        return None
+    if not (
+        _authenticate_with_python_pam(account, password)
+        or _authenticate_with_helper(account, password)
+    ):
+        return None
+    return {
+        'user': account,
+        'profile': profile_name_for_user(account),
+    }

--- a/api/profile_policy.py
+++ b/api/profile_policy.py
@@ -1,0 +1,63 @@
+"""Profile access policy helpers for authenticated WebUI sessions."""
+from __future__ import annotations
+
+from api.helpers import get_profile_cookie
+
+
+class ProfileBoundError(PermissionError):
+    """Raised when a login-bound session tries to access another profile."""
+
+    def __init__(self, message: str = "Profile is managed by your login session"):
+        super().__init__(message)
+        self.status = 403
+
+
+def session_bound_profile(handler) -> str | None:
+    """Return the server-bound profile for the request's auth session, if any."""
+    if not getattr(handler, 'headers', None):
+        return None
+    from api.auth import parse_cookie, session_profile
+
+    cookie_val = parse_cookie(handler)
+    return session_profile(cookie_val) if cookie_val else None
+
+
+def request_profile(handler) -> str | None:
+    """Return the effective request profile.
+
+    A profile bound into the signed auth session takes priority over the
+    client-controlled profile cookie. This preserves existing per-client
+    profile switching while preventing username-bound sessions from hopping
+    profiles by editing a cookie.
+    """
+    if not getattr(handler, 'headers', None):
+        return None
+    return session_bound_profile(handler) or get_profile_cookie(handler)
+
+
+def require_unbound_or_profile(handler, requested_name: str, *, action: str) -> None:
+    """Reject profile mutations that escape a login-bound profile."""
+    bound = session_bound_profile(handler)
+    if not bound:
+        return
+    if action in {'switch', 'create'} and requested_name == bound:
+        return
+    if action == 'delete' and requested_name == bound:
+        raise ProfileBoundError("Cannot delete your login profile while signed in")
+    raise ProfileBoundError()
+
+
+def ensure_profile_exists(name: str) -> dict | None:
+    """Create a clean named profile if it does not already exist."""
+    from api.profiles import create_profile_api, list_profiles_api
+
+    for profile in list_profiles_api():
+        if profile.get('name') == name:
+            return profile
+    try:
+        return create_profile_api(name)
+    except FileExistsError:
+        for profile in list_profiles_api():
+            if profile.get('name') == name:
+                return profile
+        return None

--- a/api/routes.py
+++ b/api/routes.py
@@ -2572,7 +2572,8 @@ button:hover{background:rgba(124,185,255,.25)}
   <h1>{{BOT_NAME}}</h1>
   <p class="sub">{{LOGIN_SUBTITLE}}</p>
   <form id="login-form" data-invalid-pw="{{LOGIN_INVALID_PW}}" data-conn-failed="{{LOGIN_CONN_FAILED}}">
-    <input type="password" id="pw" placeholder="{{LOGIN_PLACEHOLDER}}" autofocus>
+    {{LOGIN_USERNAME_INPUT}}
+    <input type="password" id="pw" placeholder="{{LOGIN_PLACEHOLDER}}" autocomplete="current-password" {{LOGIN_PASSWORD_AUTOFOCUS}}>
     <button type="submit">{{LOGIN_BTN}}</button>
   </form>
   <div class="err" id="err"></div>
@@ -3418,12 +3419,23 @@ def handle_get(handler, parsed) -> bool:
             _resolve_login_locale_key(_lang)
         ]
         from urllib.parse import quote
+        from api.auth import login_uses_username
         from api.updates import WEBUI_VERSION
         version_token = quote(WEBUI_VERSION, safe="")
+        username_input = ""
+        password_autofocus = "autofocus"
+        if login_uses_username():
+            username_input = (
+                '<input type="text" id="username" placeholder="Username" '
+                'autocomplete="username" autocapitalize="none" spellcheck="false" autofocus>'
+            )
+            password_autofocus = ""
         _page = (
             _LOGIN_PAGE_HTML.replace("{{BOT_NAME}}", _bn)
             .replace("{{BOT_NAME_INITIAL}}", _bn[0].upper())
             .replace("{{WEBUI_VERSION}}", version_token)
+            .replace("{{LOGIN_USERNAME_INPUT}}", username_input)
+            .replace("{{LOGIN_PASSWORD_AUTOFOCUS}}", password_autofocus)
             .replace("{{LANG}}", _html.escape(_login_strings["lang"]))
             .replace("{{LOGIN_TITLE}}", _html.escape(_login_strings["title"]))
             .replace("{{LOGIN_SUBTITLE}}", _html.escape(_login_strings["subtitle"]))
@@ -3439,13 +3451,31 @@ def handle_get(handler, parsed) -> bool:
         return t(handler, _page, content_type="text/html; charset=utf-8")
 
     if parsed.path == "/api/auth/status":
-        from api.auth import is_auth_enabled, parse_cookie, verify_session
+        from api.auth import (
+            is_auth_enabled,
+            login_uses_username,
+            parse_cookie,
+            session_identity,
+            verify_session,
+        )
 
         logged_in = False
+        identity = {}
         if is_auth_enabled():
             cv = parse_cookie(handler)
             logged_in = bool(cv and verify_session(cv))
-        return j(handler, {"auth_enabled": is_auth_enabled(), "logged_in": logged_in})
+            if logged_in:
+                identity = session_identity(cv)
+        return j(
+            handler,
+            {
+                "auth_enabled": is_auth_enabled(),
+                "logged_in": logged_in,
+                "login_uses_username": login_uses_username(),
+                "user": identity.get("user"),
+                "profile": identity.get("profile"),
+            },
+        )
 
     if parsed.path in ("/manifest.json", "/manifest.webmanifest"):
         return _serve_manifest(handler)
@@ -5271,8 +5301,10 @@ def handle_post(handler, parsed) -> bool:
         if not name:
             return bad(handler, "name is required")
         try:
+            from api.profile_policy import ProfileBoundError, require_unbound_or_profile
             from api.profiles import switch_profile, _validate_profile_name
             from api.helpers import build_profile_cookie
+            require_unbound_or_profile(handler, name, action="switch")
             if name != 'default':
                 _validate_profile_name(name)
             # process_wide=False: don't mutate the process-global _active_profile.
@@ -5286,6 +5318,8 @@ def handle_post(handler, parsed) -> bool:
             return j(handler, result, extra_headers={
                 'Set-Cookie': build_profile_cookie(name),
             })
+        except ProfileBoundError as e:
+            return bad(handler, str(e), e.status)
         except (ValueError, FileNotFoundError) as e:
             return bad(handler, _sanitize_error(e), 404)
         except RuntimeError as e:
@@ -5295,6 +5329,11 @@ def handle_post(handler, parsed) -> bool:
         name = body.get("name", "").strip()
         if not name:
             return bad(handler, "name is required")
+        try:
+            from api.profile_policy import ProfileBoundError, require_unbound_or_profile
+            require_unbound_or_profile(handler, name, action="create")
+        except ProfileBoundError as e:
+            return bad(handler, str(e), e.status)
         import re as _re
 
         if not _re.match(r"^[a-z0-9][a-z0-9_-]{0,63}$", name):
@@ -5334,11 +5373,15 @@ def handle_post(handler, parsed) -> bool:
         if not name:
             return bad(handler, "name is required")
         try:
+            from api.profile_policy import ProfileBoundError, require_unbound_or_profile
             from api.profiles import delete_profile_api, _validate_profile_name
 
+            require_unbound_or_profile(handler, name, action="delete")
             _validate_profile_name(name)
             result = delete_profile_api(name)
             return j(handler, result)
+        except ProfileBoundError as e:
+            return bad(handler, str(e), e.status)
         except (ValueError, FileNotFoundError) as e:
             return bad(handler, _sanitize_error(e))
         except RuntimeError as e:
@@ -5840,12 +5883,13 @@ def handle_post(handler, parsed) -> bool:
     # ── Auth endpoints (POST) ──
     if parsed.path == "/api/auth/login":
         from api.auth import (
-            verify_password,
+            verify_login,
             create_session,
             set_auth_cookie,
             is_auth_enabled,
         )
         from api.auth import _check_login_rate, _record_login_attempt
+        from api.helpers import build_profile_cookie
 
         if not is_auth_enabled():
             return j(handler, {"ok": True, "message": "Auth not enabled"})
@@ -5856,18 +5900,41 @@ def handle_post(handler, parsed) -> bool:
                 {"error": "Too many attempts. Try again in a minute."},
                 status=429,
             )
+        username = body.get("username", "")
         password = body.get("password", "")
-        if not verify_password(password):
+        identity = verify_login(username, password)
+        if identity is None:
             _record_login_attempt(client_ip)
             return bad(handler, "Invalid password", 401)
-        cookie_val = create_session()
+        profile = identity.get("profile") if isinstance(identity, dict) else None
+        if profile:
+            try:
+                from api.profile_policy import ensure_profile_exists
+
+                ensure_profile_exists(profile)
+            except Exception as e:
+                return bad(handler, f"Could not prepare profile: {_sanitize_error(e)}", 500)
+        cookie_val = create_session(
+            username=identity.get("user") if isinstance(identity, dict) else None,
+            profile=profile,
+        )
         handler.send_response(200)
         handler.send_header("Content-Type", "application/json")
         handler.send_header("Cache-Control", "no-store")
         _security_headers(handler)
         set_auth_cookie(handler, cookie_val)
+        if profile:
+            handler.send_header("Set-Cookie", build_profile_cookie(profile))
         handler.end_headers()
-        handler.wfile.write(json.dumps({"ok": True}).encode())
+        handler.wfile.write(
+            json.dumps(
+                {
+                    "ok": True,
+                    "user": identity.get("user") if isinstance(identity, dict) else None,
+                    "profile": profile,
+                }
+            ).encode()
+        )
         return True
 
     if parsed.path == "/api/auth/logout":

--- a/server.py
+++ b/server.py
@@ -114,6 +114,7 @@ logger = logging.getLogger(__name__)
 from api.auth import check_auth
 from api.config import HOST, PORT, STATE_DIR, SESSION_DIR, DEFAULT_WORKSPACE
 from api.helpers import j, get_profile_cookie
+from api.profile_policy import request_profile
 from api.profiles import set_request_profile, clear_request_profile
 from api.routes import handle_delete, handle_get, handle_patch, handle_post
 from api.startup import auto_install_agent_deps, fix_credential_permissions
@@ -241,8 +242,8 @@ class Handler(BaseHTTPRequestHandler):
 
     def do_GET(self) -> None:
         self._req_t0 = time.time()
-        # Per-request profile context from cookie (issue #798)
-        cookie_profile = get_profile_cookie(self)
+        # Per-request profile context; auth-bound profiles win over cookies.
+        cookie_profile = request_profile(self)
         if cookie_profile:
             set_request_profile(cookie_profile)
         try:
@@ -259,8 +260,8 @@ class Handler(BaseHTTPRequestHandler):
 
     def _handle_write(self, route_func) -> None:
         self._req_t0 = time.time()
-        # Per-request profile context from cookie (issue #798)
-        cookie_profile = get_profile_cookie(self)
+        # Per-request profile context; auth-bound profiles win over cookies.
+        cookie_profile = request_profile(self)
         if cookie_profile:
             set_request_profile(cookie_profile)
         try:

--- a/static/login.js
+++ b/static/login.js
@@ -4,6 +4,7 @@
  */
 document.addEventListener('DOMContentLoaded', function () {
   var form = document.getElementById('login-form');
+  var userInput = document.getElementById('username');
   var input = document.getElementById('pw');
 
   if (!form || !input) return;
@@ -37,13 +38,14 @@ document.addEventListener('DOMContentLoaded', function () {
 
   async function doLogin(e) {
     e.preventDefault();
+    var username = userInput ? userInput.value.trim() : '';
     var pw = input.value;
     hideErr();
     try {
       var res = await fetch('api/auth/login', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ password: pw }),
+        body: JSON.stringify({ username: username, password: pw }),
         credentials: 'include',
       });
       var data = {};
@@ -59,6 +61,15 @@ document.addEventListener('DOMContentLoaded', function () {
   }
 
   form.addEventListener('submit', doLogin);
+
+  if (userInput) {
+    userInput.addEventListener('keydown', function (e) {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        input.focus();
+      }
+    });
+  }
 
   input.addEventListener('keydown', function (e) {
     if (e.key === 'Enter') {
@@ -76,6 +87,7 @@ document.addEventListener('DOMContentLoaded', function () {
     var retryTimer = null;
 
     function setFormDisabled(disabled) {
+      if (userInput) userInput.disabled = disabled;
       if (input) input.disabled = disabled;
       var btn = form.querySelector('button');
       if (btn) btn.disabled = disabled;

--- a/tests/test_auth_pam.py
+++ b/tests/test_auth_pam.py
@@ -1,0 +1,102 @@
+from types import SimpleNamespace
+
+from api import auth_pam
+
+
+def _pwd(users):
+    def getpwnam(name):
+        if name not in users:
+            raise KeyError(name)
+        return users[name]
+
+    return SimpleNamespace(getpwnam=getpwnam)
+
+
+def _account(name, uid=1000, shell="/bin/bash"):
+    return SimpleNamespace(pw_name=name, pw_uid=uid, pw_shell=shell)
+
+
+def test_pam_username_ui_only_for_multi_user_pam(monkeypatch):
+    monkeypatch.delenv("HERMES_WEBUI_AUTH_MODE", raising=False)
+    monkeypatch.delenv("HERMES_WEBUI_PAM_ALLOW_ANY_USER", raising=False)
+    assert auth_pam.login_uses_username() is False
+
+    monkeypatch.setenv("HERMES_WEBUI_AUTH_MODE", "pam")
+    assert auth_pam.login_uses_username() is False
+
+    monkeypatch.setenv("HERMES_WEBUI_PAM_ALLOW_ANY_USER", "1")
+    assert auth_pam.login_uses_username() is True
+
+
+def test_profile_name_for_user_is_safe_and_deterministic():
+    assert auth_pam.profile_name_for_user("dbyte") == "dbyte"
+
+    dotted = auth_pam.profile_name_for_user("Jane.Doe")
+    assert dotted.startswith("jane-doe-")
+    assert dotted == auth_pam.profile_name_for_user("Jane.Doe")
+    assert "." not in dotted
+
+    default = auth_pam.profile_name_for_user("default")
+    assert default != "default"
+    assert default.startswith("default-")
+
+
+def test_resolve_login_user_uses_fixed_user_when_multi_user_disabled(monkeypatch):
+    monkeypatch.setenv("HERMES_WEBUI_PAM_USER", "alice")
+    monkeypatch.delenv("HERMES_WEBUI_PAM_ALLOW_ANY_USER", raising=False)
+    monkeypatch.setattr(auth_pam, "pwd", _pwd({
+        "alice": _account("alice"),
+        "bob": _account("bob"),
+    }))
+
+    assert auth_pam.resolve_login_user(None, allow_default=True) == "alice"
+    assert auth_pam.resolve_login_user("alice") == "alice"
+    assert auth_pam.resolve_login_user("bob") is None
+
+
+def test_resolve_login_user_filters_service_accounts(monkeypatch):
+    monkeypatch.setenv("HERMES_WEBUI_PAM_ALLOW_ANY_USER", "1")
+    monkeypatch.setenv("HERMES_WEBUI_PAM_MIN_UID", "1000")
+    monkeypatch.setattr(auth_pam, "pwd", _pwd({
+        "alice": _account("alice", uid=1000),
+        "daemon": _account("daemon", uid=1),
+        "disabled": _account("disabled", uid=1001, shell="/usr/sbin/nologin"),
+    }))
+
+    assert auth_pam.resolve_login_user("alice") == "alice"
+    assert auth_pam.resolve_login_user("daemon") is None
+    assert auth_pam.resolve_login_user("disabled") is None
+
+
+def test_authenticate_does_not_assume_helper_without_configuration(monkeypatch):
+    monkeypatch.setenv("HERMES_WEBUI_PAM_ALLOW_ANY_USER", "1")
+    monkeypatch.delenv("HERMES_WEBUI_PAM_HELPER", raising=False)
+    monkeypatch.setattr(auth_pam, "pwd", _pwd({"alice": _account("alice")}))
+    monkeypatch.setattr(auth_pam, "_authenticate_with_python_pam", lambda _u, _p: False)
+
+    def fail_run(*_args, **_kwargs):
+        raise AssertionError("subprocess helper should not run without HERMES_WEBUI_PAM_HELPER")
+
+    monkeypatch.setattr(auth_pam.subprocess, "run", fail_run)
+    assert auth_pam.authenticate("alice", "pw") is None
+
+
+def test_authenticate_uses_explicit_helper_as_fallback(monkeypatch):
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["input"] = kwargs.get("input")
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setenv("HERMES_WEBUI_PAM_ALLOW_ANY_USER", "1")
+    monkeypatch.setenv("HERMES_WEBUI_PAM_HELPER", "/opt/hermes/pam-helper")
+    monkeypatch.setattr(auth_pam, "pwd", _pwd({"alice": _account("alice")}))
+    monkeypatch.setattr(auth_pam, "_authenticate_with_python_pam", lambda _u, _p: False)
+    monkeypatch.setattr(auth_pam.subprocess, "run", fake_run)
+
+    identity = auth_pam.authenticate("alice", "pw")
+
+    assert identity == {"user": "alice", "profile": "alice"}
+    assert captured["cmd"] == ["/opt/hermes/pam-helper", "--user", "alice", "--service", "login"]
+    assert captured["input"] == "pw"

--- a/tests/test_auth_session_persistence.py
+++ b/tests/test_auth_session_persistence.py
@@ -57,6 +57,14 @@ class TestSessionPersistence(unittest.TestCase):
         self.assertTrue(auth.verify_session(cookie),
                         "Session must survive process restart via persisted .sessions.json")
 
+    def test_session_identity_survives_restart(self) -> None:
+        """Bound user/profile metadata must survive module reload."""
+        cookie = auth.create_session(username="alice", profile="alice")
+        self._simulate_restart()
+        self.assertTrue(auth.verify_session(cookie))
+        self.assertEqual(auth.session_identity(cookie), {"user": "alice", "profile": "alice"})
+        self.assertEqual(auth.session_profile(cookie), "alice")
+
     def test_invalidated_session_does_not_survive_restart(self) -> None:
         """Invalidating a session must be reflected after reload."""
         cookie = auth.create_session()
@@ -73,10 +81,25 @@ class TestSessionPersistence(unittest.TestCase):
         sessions_file.write_text(json.dumps({
             "expired_token": now - 10,
             "valid_token": now + 3600,
+            "valid_bound_token": {"exp": now + 3600, "user": "alice", "profile": "alice"},
         }))
         self._simulate_restart()
         self.assertNotIn("expired_token", auth._sessions)
         self.assertIn("valid_token", auth._sessions)
+        self.assertIn("valid_bound_token", auth._sessions)
+
+    def test_invalid_session_metadata_is_sanitized_on_load(self) -> None:
+        """Invalid persisted identity metadata must not become trusted."""
+        sessions_file = _TEST_STATE / '.sessions.json'
+        sessions_file.write_text(json.dumps({
+            "token": {
+                "exp": time.time() + 3600,
+                "user": "bad\nuser",
+                "profile": "../default",
+            },
+        }))
+        self._simulate_restart()
+        self.assertEqual(set(auth._sessions["token"].keys()), {"exp"})
 
     def test_sessions_file_permissions(self) -> None:
         """Sessions file must be owner-read-only (0600)."""

--- a/tests/test_auth_sessions.py
+++ b/tests/test_auth_sessions.py
@@ -33,16 +33,36 @@ class TestSessionPruning(unittest.TestCase):
         token = auth.create_session()
         self.assertTrue(auth.verify_session(token))
 
+    def test_session_identity_metadata_roundtrip(self):
+        """A session can carry server-side user/profile metadata."""
+        cookie = auth.create_session(username="alice", profile="alice")
+
+        self.assertTrue(auth.verify_session(cookie))
+        self.assertEqual(
+            auth.session_identity(cookie),
+            {"user": "alice", "profile": "alice"},
+        )
+        self.assertEqual(auth.session_profile(cookie), "alice")
+
+    def test_session_identity_ignores_legacy_float_records(self):
+        """Legacy token -> expiry records remain valid but unbound."""
+        cookie = auth.create_session()
+
+        self.assertTrue(auth.verify_session(cookie))
+        self.assertEqual(auth.session_identity(cookie), {})
+        self.assertIsNone(auth.session_profile(cookie))
+
     def test_expired_session_pruned(self):
         """Manually inserting an expired entry should be pruned on next verify_session call."""
         # Insert sessions that have already expired
         auth._sessions["fake_token"] = time.time() - 100
         auth._sessions["another_fake"] = time.time() - 50
+        auth._sessions["expired_metadata"] = {"exp": time.time() - 10, "profile": "alice"}
         # Insert one valid session (far future)
-        auth._sessions["good_token"] = time.time() + 3600
+        auth._sessions["good_token"] = {"exp": time.time() + 3600, "profile": "alice"}
 
-        # _sessions has 3 entries, 2 expired
-        self.assertEqual(len(auth._sessions), 3)
+        # _sessions has 4 entries, 3 expired
+        self.assertEqual(len(auth._sessions), 4)
 
         # Call verify_session — this triggers _prune_expired_sessions()
         # Cookie format is token.signature, so we need a dot to pass the early check
@@ -53,6 +73,7 @@ class TestSessionPruning(unittest.TestCase):
         self.assertIn("good_token", auth._sessions)
         self.assertNotIn("fake_token", auth._sessions)
         self.assertNotIn("another_fake", auth._sessions)
+        self.assertNotIn("expired_metadata", auth._sessions)
 
     def test_prune_does_not_remove_valid_sessions(self):
         """_prune_expired_sessions should never remove sessions that are still active."""

--- a/tests/test_profile_policy.py
+++ b/tests/test_profile_policy.py
@@ -1,0 +1,67 @@
+from types import SimpleNamespace
+
+import pytest
+
+from api import auth
+from api import profile_policy
+
+
+def _handler(cookie_header: str = ""):
+    return SimpleNamespace(headers=SimpleNamespace(get=lambda key, default="": cookie_header if key == "Cookie" else default))
+
+
+def setup_function():
+    auth._sessions.clear()
+
+
+def test_request_profile_prefers_session_bound_profile_over_cookie():
+    cookie = auth.create_session(username="alice", profile="alice")
+    handler = _handler(f"hermes_profile=bob; hermes_session={cookie}")
+
+    assert profile_policy.request_profile(handler) == "alice"
+
+
+def test_request_profile_falls_back_to_profile_cookie_for_unbound_sessions():
+    cookie = auth.create_session()
+    handler = _handler(f"hermes_profile=bob; hermes_session={cookie}")
+
+    assert profile_policy.request_profile(handler) == "bob"
+
+
+def test_bound_session_cannot_switch_to_another_profile():
+    cookie = auth.create_session(username="alice", profile="alice")
+    handler = _handler(f"hermes_session={cookie}")
+
+    with pytest.raises(profile_policy.ProfileBoundError):
+        profile_policy.require_unbound_or_profile(handler, "bob", action="switch")
+
+
+def test_bound_session_can_switch_to_its_own_profile():
+    cookie = auth.create_session(username="alice", profile="alice")
+    handler = _handler(f"hermes_session={cookie}")
+
+    profile_policy.require_unbound_or_profile(handler, "alice", action="switch")
+
+
+def test_bound_session_cannot_delete_its_login_profile():
+    cookie = auth.create_session(username="alice", profile="alice")
+    handler = _handler(f"hermes_session={cookie}")
+
+    with pytest.raises(profile_policy.ProfileBoundError) as exc:
+        profile_policy.require_unbound_or_profile(handler, "alice", action="delete")
+    assert "Cannot delete" in str(exc.value)
+
+
+def test_ensure_profile_exists_creates_clean_profile_without_cloning(monkeypatch):
+    calls = []
+
+    monkeypatch.setattr("api.profiles.list_profiles_api", lambda: [])
+
+    def fake_create(name, **kwargs):
+        calls.append((name, kwargs))
+        return {"name": name}
+
+    monkeypatch.setattr("api.profiles.create_profile_api", fake_create)
+
+    assert profile_policy.ensure_profile_exists("alice") == {"name": "alice"}
+    assert calls == [("alice", {})]


### PR DESCRIPTION
Closes #2590

## Thinking Path

- Hermes WebUI is intentionally a simple Python plus vanilla JavaScript browser front end for Hermes Agent.
- The existing shared-password auth mode is a good default for single-user setups, but it is awkward for shared local-network hosts where users already have OS accounts.
- Adding username-based login safely requires more than a password check because profile choice was previously driven by client cookies.
- This change keeps the default password mode untouched, adds PAM as an opt-in auth provider, and binds PAM multi-user sessions to server-authoritative per-user profiles.
- The implementation stays inside the current server/API/static JS shape without adding frameworks, build steps, or runtime dependencies.

## What Changed

- Added optional `HERMES_WEBUI_AUTH_MODE=pam` support with a dedicated PAM auth module.
- Added fixed-user PAM login and explicit multi-user login through `HERMES_WEBUI_PAM_ALLOW_ANY_USER=1`.
- Added optional `HERMES_WEBUI_PAM_HELPER` support for deployments where PAM validation needs to happen in a configured privileged helper rather than in process.
- Added server-side profile policy for auth-bound sessions so PAM users are routed to their own clean profile and cannot switch, create, or delete profiles outside that binding.
- Preserved the existing password auth path and legacy session-file compatibility.
- Updated README and CHANGELOG coverage for the new mode.
- Added focused PAM/profile/session tests.

## Why It Matters

This makes it possible to run Hermes WebUI on a shared workstation or LAN-facing host without issuing a single shared WebUI password to every browser user. It also prevents a PAM-authenticated browser session from selecting a different profile through cookies or profile-management routes.

This PR touches security-sensitive auth and profile-isolation behavior, so it is opened as a draft for review alignment.

## Verification

- Targeted auth/profile/login suites: `126 passed`.
- Full suite with Node available on `PATH`: `6001 passed, 6 skipped, 3 xpassed, 8 subtests passed`.
- Checked fixed-user PAM, multi-user PAM, auth-bound profile routing, legacy session parsing, and blocked cross-profile operations in automated tests.

UI evidence: this PR adds a conditional username field to the login form only when PAM multi-user mode is enabled. Before/after screenshots are still pending before marking the draft ready for full UI/UX review.

## Risks / Follow-ups

- PAM behavior varies by distribution and PAM service configuration, so maintainers may want the README wording tuned for their supported deployment targets.
- Multi-user login currently derives profile names from local usernames after service-account filtering; reviewers should confirm that this is the desired long-term profile naming policy.
- The helper command path intentionally requires explicit operator configuration and does not assume sudo or any default privilege escalation.
- Before ready-for-review, add UI evidence for the login-form username field in password mode versus PAM multi-user mode if maintainers want strict UI/UX evidence even for this conditional auth screen change.

## Model Used

- Provider: OpenAI
- Model: Codex based on GPT-5
- Notable tool use: SSH to a local development host, Git, GitHub CLI, pytest, and local code inspection.
- AI usage: AI-assisted implementation, testing, documentation updates, issue text, and PR text under human direction.

