### PR TITLE
feat(runtime): add runner adapter facade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+
+- **PR #TBD** by @Michaelyklam (refs #1925) — Add the first Slice 4b `RunnerRuntimeAdapter` facade for future runner/sidecar backends. The facade delegates `start_run`, `observe_run`, `get_run`, and control calls to an injected runner client, normalizes results into the existing RuntimeAdapter dataclasses, carries explicit profile/workspace/model payloads, and returns bounded unsupported-control results without owning `AIAgent`, stream, cancel, approval, clarify, goal, or queue state. No route wiring or default-on runner mode is introduced.
 
 ## [v0.51.93] — 2026-05-19 — Release BQ (stage-386 — 10-PR full sweep batch — RFC Slice 4 runner/sidecar gate + workspace tree toggle width CSS variable + settled file:// markdown link rendering + prompt-cache coverage percentage fix + terminal shell shutdown reap + configured model picker provider preservation + profile-aware assistant display names + state.db reconciliation slice 1 + queued-message cross-session drain fix + stale-stream writeback supersede)
 

--- a/api/runtime_adapter.py
+++ b/api/runtime_adapter.py
@@ -144,6 +144,129 @@ def _active_control_result(value: Any) -> ControlResult:
     )
 
 
+def _runner_unsupported_control(name: str) -> ControlResult:
+    return ControlResult(
+        False,
+        status="unsupported",
+        safe_message=f"{name} is not supported by this runner backend.",
+    )
+
+
+class RunnerRuntimeAdapter:
+    """Protocol-translator facade for a future runner/sidecar backend.
+
+    Slice 4 moves runtime ownership behind a runner boundary, but the WebUI
+    adapter must remain a translator.  This class deliberately delegates to an
+    injected client instead of owning process-local streams, cancellation flags,
+    approval queues, clarify queues, or cached agent instances itself.
+    """
+
+    def __init__(self, *, client: Any):
+        self._client = client
+
+    def start_run(self, request: StartRunRequest) -> RunStartResult:
+        start_run = getattr(self._client, "start_run", None)
+        if start_run is None:
+            raise NotImplementedError("RunnerRuntimeAdapter.start_run requires a runner client")
+        payload = start_run(request)
+        if isinstance(payload, RunStartResult):
+            return payload
+        payload = dict(payload or {})
+        run_id = str(payload.get("run_id") or payload.get("stream_id") or "")
+        stream_id = str(payload.get("stream_id") or run_id)
+        session_id = str(payload.get("session_id") or request.session_id)
+        active_controls = payload.get("active_controls")
+        if not isinstance(active_controls, list):
+            active_controls = []
+        return RunStartResult(
+            run_id=run_id,
+            session_id=session_id,
+            stream_id=stream_id,
+            status=str(payload.get("status") or "started"),
+            started_at=payload.get("started_at"),
+            cursor=payload.get("cursor"),
+            active_controls=active_controls,
+            payload=payload,
+        )
+
+    def observe_run(self, run_id: str, *, cursor: str | None = None) -> RunEventStream:
+        observe_run = getattr(self._client, "observe_run", None)
+        if observe_run is None:
+            return RunEventStream(run_id=run_id, events=[], cursor=cursor, last_event_id=None)
+        result = observe_run(run_id, cursor=cursor)
+        if isinstance(result, RunEventStream):
+            return result
+        payload = dict(result or {})
+        events = list(payload.get("events") or [])
+        last_event_id = payload.get("last_event_id") or (events[-1].get("event_id") if events else None)
+        next_cursor = payload.get("cursor")
+        if next_cursor is None and events:
+            next_cursor = str(events[-1].get("seq") or "")
+        return RunEventStream(
+            run_id=str(payload.get("run_id") or run_id),
+            events=events,
+            cursor=str(next_cursor) if next_cursor is not None else cursor,
+            last_event_id=last_event_id,
+        )
+
+    def get_run(self, run_id: str) -> RunStatus:
+        get_run = getattr(self._client, "get_run", None)
+        if get_run is None:
+            return RunStatus(run_id=run_id)
+        result = get_run(run_id)
+        if isinstance(result, RunStatus):
+            return result
+        payload = dict(result or {})
+        active_controls = payload.get("active_controls")
+        if not isinstance(active_controls, list):
+            active_controls = []
+        return RunStatus(
+            run_id=str(payload.get("run_id") or run_id),
+            session_id=str(payload.get("session_id") or "") or None,
+            status=str(payload.get("status") or "unknown"),
+            last_event_id=payload.get("last_event_id"),
+            terminal_state=payload.get("terminal_state"),
+            active_controls=active_controls,
+            pending_approval_id=payload.get("pending_approval_id"),
+            pending_clarify_id=payload.get("pending_clarify_id"),
+        )
+
+    def cancel_run(self, run_id: str) -> ControlResult:
+        cancel_run = getattr(self._client, "cancel_run", None)
+        if cancel_run is None:
+            return _runner_unsupported_control("Cancel")
+        return _active_control_result(cancel_run(run_id))
+
+    def respond_approval(self, run_id: str, approval_id: str, choice: str) -> ControlResult:
+        respond_approval = getattr(self._client, "respond_approval", None)
+        if respond_approval is None:
+            return _runner_unsupported_control("Approval")
+        return _active_control_result(respond_approval(run_id, approval_id, choice))
+
+    def respond_clarify(self, run_id: str, clarify_id: str, response: str) -> ControlResult:
+        respond_clarify = getattr(self._client, "respond_clarify", None)
+        if respond_clarify is None:
+            return _runner_unsupported_control("Clarify")
+        return _active_control_result(respond_clarify(run_id, clarify_id, response))
+
+    def queue_message(self, run_id: str, message: str, *, mode: str = "queue") -> ControlResult:
+        queue_message = getattr(self._client, "queue_message", None)
+        if queue_message is None:
+            return _runner_unsupported_control("Queue")
+        return _active_control_result(queue_message(run_id, message, mode=mode))
+
+    def update_goal(
+        self,
+        session_id: str,
+        action: Literal["set", "pause", "resume", "clear", "status", "edit"],
+        text: str = "",
+    ) -> ControlResult:
+        update_goal = getattr(self._client, "update_goal", None)
+        if update_goal is None:
+            return _runner_unsupported_control("Goal")
+        return _active_control_result(update_goal(session_id, action, text))
+
+
 class LegacyJournalRuntimeAdapter:
     """Protocol-translator facade over the current legacy streaming path.
 

--- a/docs/rfcs/hermes-run-adapter-contract.md
+++ b/docs/rfcs/hermes-run-adapter-contract.md
@@ -94,8 +94,13 @@ adapter-seam work:
   `queue_message(...)` as a staged protocol method only; `/queue` remains
   browser-side queue/drain behavior, and no server-side queue endpoint or queue
   scheduler should be added merely for adapter symmetry.
+- #2575 shipped the Slice 4a runner/sidecar contract gate in v0.51.93. The next
+  implementation step can add runner-backend adapter plumbing, but it must stay
+  default-off, keep legacy fallback intact, pass explicit profile/workspace/model
+  payloads instead of mutating WebUI process globals, and avoid recreating
+  `STREAMS` / `CANCEL_FLAGS` / approval queues / clarify queues under new names.
 
-The next gate is the runner/sidecar planning contract, not queue implementation
+The next gate is runner-backend plumbing, not queue implementation
 by default. Queue / continue routing should only move before Slice 4 if a future
 maintainer decision identifies an existing server-side legacy entry point and
 pins its response shape, ordering, and idempotency contract. Otherwise, keeping
@@ -745,6 +750,26 @@ Non-goals for Slice 4a:
 - no new server-side queue endpoint or scheduler just for adapter symmetry;
 - no dependency on Hermes Agent shipping `/v1/runs` before WebUI can validate the
   local runner boundary.
+
+#### Slice 4b: Runner adapter client facade
+
+The first code slice after the Slice 4a contract should be a small
+`RunnerRuntimeAdapter` facade that delegates to an injected runner client. This
+is still not the runner process itself. Its job is to pin the adapter-facing
+normalization rules before route wiring or process supervision lands:
+
+- `start_run` forwards a `StartRunRequest` carrying explicit session, profile,
+  workspace, attachments, model/provider, toolset, source, and metadata payloads;
+- `observe_run` and `get_run` normalize runner responses into `RunEventStream`
+  and `RunStatus` so a recreated WebUI server can observe the same runner-owned
+  state without relying on process-local `STREAMS`;
+- controls normalize accepted / not-active / unsupported outcomes into bounded
+  `ControlResult` values;
+- the facade itself owns no `AIAgent`, worker thread, cancellation registry,
+  approval queue, clarify queue, goal scheduler, or server-side queue.
+
+The implementation remains default-off until a later slice adds an actual runner
+client/backend and explicit route selection.
 
 ## First Meaningful Success Criteria
 

--- a/tests/test_runtime_adapter_seam.py
+++ b/tests/test_runtime_adapter_seam.py
@@ -18,6 +18,7 @@ def test_runtime_adapter_interface_and_legacy_journal_methods_exist():
     for name in required:
         assert hasattr(runtime.RuntimeAdapter, name)
         assert hasattr(runtime.LegacyJournalRuntimeAdapter, name)
+        assert hasattr(runtime.RunnerRuntimeAdapter, name)
 
     assert runtime.runtime_adapter_mode({}) == "legacy-direct"
     assert runtime.runtime_adapter_enabled({}) is False
@@ -328,3 +329,120 @@ def test_rfc_defines_slice4_runner_contract_before_runner_code():
     assert "profile,\n   workspace, attachments, model/provider, toolset, and source metadata" in rfc
     assert "no removal of the legacy in-process backend" in rfc
     assert "no default-on runner mode" in rfc
+    assert "#### Slice 4b: Runner adapter client facade" in rfc
+    assert "delegates to an injected runner client" in rfc
+    assert "without relying on process-local `STREAMS`" in rfc
+
+
+def test_runner_runtime_adapter_passes_explicit_start_payload_without_env_mutation(monkeypatch):
+    runtime = importlib.import_module("api.runtime_adapter")
+    captured = []
+
+    class FakeRunnerClient:
+        def start_run(self, request):
+            captured.append(request)
+            return {
+                "run_id": "runner-1",
+                "session_id": request.session_id,
+                "stream_id": "runner-1",
+                "status": "running",
+                "active_controls": ["cancel", "approval", "clarify", "goal"],
+            }
+
+    before_terminal_cwd = "existing-cwd"
+    monkeypatch.setenv("TERMINAL_CWD", before_terminal_cwd)
+    adapter = runtime.RunnerRuntimeAdapter(client=FakeRunnerClient())
+    request = runtime.StartRunRequest(
+        session_id="s-runner",
+        message="hello runner",
+        attachments=[{"path": "/tmp/a.png", "mime": "image/png"}],
+        workspace="/workspace/project",
+        profile="research",
+        provider="openai-codex",
+        model="gpt-5.5",
+        toolsets=["terminal", "file"],
+        source="webui",
+        metadata={"route": "/api/chat/start", "csrf_checked": True},
+    )
+
+    result = adapter.start_run(request)
+
+    assert captured == [request]
+    assert captured[0].workspace == "/workspace/project"
+    assert captured[0].profile == "research"
+    assert captured[0].attachments == [{"path": "/tmp/a.png", "mime": "image/png"}]
+    assert captured[0].provider == "openai-codex"
+    assert captured[0].model == "gpt-5.5"
+    assert captured[0].toolsets == ["terminal", "file"]
+    assert result.run_id == "runner-1"
+    assert result.active_controls == ["cancel", "approval", "clarify", "goal"]
+    assert runtime.os.environ["TERMINAL_CWD"] == before_terminal_cwd
+
+
+def test_runner_runtime_adapter_observe_and_get_survive_adapter_recreation():
+    runtime = importlib.import_module("api.runtime_adapter")
+
+    class FakeRunnerClient:
+        def __init__(self):
+            self.events = []
+            self.status = "unknown"
+
+        def start_run(self, request):
+            self.status = "running"
+            self.events.append({"event_id": "runner-1:1", "seq": 1, "type": "token", "data": {"text": "hi"}})
+            self.events.append({"event_id": "runner-1:2", "seq": 2, "type": "done", "data": {"ok": True}})
+            self.status = "completed"
+            return {"run_id": "runner-1", "session_id": request.session_id, "stream_id": "runner-1", "status": "running"}
+
+        def observe_run(self, run_id, *, cursor=None):
+            after = int(cursor or 0)
+            return {"run_id": run_id, "events": [e for e in self.events if e["seq"] > after]}
+
+        def get_run(self, run_id):
+            return {
+                "run_id": run_id,
+                "session_id": "s-runner",
+                "status": self.status,
+                "terminal_state": "completed",
+                "last_event_id": self.events[-1]["event_id"],
+                "active_controls": [],
+            }
+
+    shared_runner = FakeRunnerClient()
+    first_webui_process = runtime.RunnerRuntimeAdapter(client=shared_runner)
+    first_webui_process.start_run(runtime.StartRunRequest(session_id="s-runner", message="hello"))
+
+    restarted_webui_process = runtime.RunnerRuntimeAdapter(client=shared_runner)
+    replay = restarted_webui_process.observe_run("runner-1", cursor="1")
+    status = restarted_webui_process.get_run("runner-1")
+
+    assert [event["type"] for event in replay.events] == ["done"]
+    assert replay.cursor == "2"
+    assert replay.last_event_id == "runner-1:2"
+    assert status.status == "completed"
+    assert status.terminal_state == "completed"
+    assert status.last_event_id == "runner-1:2"
+
+
+def test_runner_runtime_adapter_controls_are_bounded_and_do_not_use_legacy_state():
+    runtime = importlib.import_module("api.runtime_adapter")
+
+    class FakeRunnerClient:
+        def cancel_run(self, run_id):
+            return {"ok": False, "status": "not-active", "message": "Run is not active."}
+
+    adapter = runtime.RunnerRuntimeAdapter(client=FakeRunnerClient())
+
+    cancel = adapter.cancel_run("finished-run")
+    approval = adapter.respond_approval("finished-run", "approval-1", "once")
+    clarify = adapter.respond_clarify("finished-run", "clarify-1", "answer")
+    queued = adapter.queue_message("finished-run", "next")
+    goal = adapter.update_goal("s-runner", "status")
+
+    assert cancel.accepted is False
+    assert cancel.status == "not-active"
+    assert cancel.safe_message == "Run is not active."
+    for result in (approval, clarify, queued, goal):
+        assert result.accepted is False
+        assert result.status == "unsupported"
+        assert "not supported by this runner backend" in (result.safe_message or "")


### PR DESCRIPTION
## Thinking Path

- #1925 has shipped the journal/replay baseline, the default-off RuntimeAdapter seam, and the control migrations through cancel, approval/clarify, and goal.
- PR #2575 / v0.51.93 accepted the Slice 4a runner/sidecar gate: before moving active execution out of the WebUI process, the runner boundary needs explicit payloads, restart/reattach observation, bounded controls, and no runtime-surrogate state in the main server.
- The safest next Slice 4b step is not route wiring or a sidecar process yet; it is a small runner-client adapter facade that pins the normalization contract behind the existing `RuntimeAdapter` dataclasses.
- This PR keeps the runner path default-off and un-routed while giving the next implementation slice a reviewed adapter shape to build against.

## What Changed

- Added `RunnerRuntimeAdapter`, a protocol-translator facade over an injected runner client.
- Normalizes runner `start_run`, `observe_run`, `get_run`, and control responses into `RunStartResult`, `RunEventStream`, `RunStatus`, and `ControlResult`.
- Returns bounded `unsupported` `ControlResult`s for controls a runner client has not implemented.
- Added regression coverage for:
  - interface parity with `RuntimeAdapter` / `LegacyJournalRuntimeAdapter`;
  - explicit profile/workspace/model/toolset/attachment payload forwarding without mutating WebUI process environment;
  - recreated-adapter observation over shared runner-owned state;
  - bounded unsupported/not-active controls with no fallback to legacy process-local state.
- Updated the #1925 RFC and changelog to mark #2575 as shipped and define this as Slice 4b runner adapter client facade plumbing.

## Why It Matters

This moves #1925 one narrow step past the docs-only runner gate without claiming execution survives WebUI restart yet. The new facade keeps the adapter as a protocol translator and prevents the next runner/sidecar slice from starting by recreating `STREAMS`, `CANCEL_FLAGS`, approval queues, clarify queues, or cached `AIAgent` state under new names.

## Verification

- `env -u HERMES_CONFIG_PATH -u HERMES_WEBUI_HOST /home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_runtime_adapter_seam.py -q` → `20 passed`
- `/home/michael/.hermes/hermes-agent/venv/bin/python -m py_compile api/runtime_adapter.py tests/test_runtime_adapter_seam.py` → passed
- `git diff --check` → clean
- `env -u HERMES_CONFIG_PATH -u HERMES_WEBUI_HOST /home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/ -q` → `6021 passed, 6 skipped, 3 xpassed, 8 subtests passed`

## Risks / Follow-ups

- No route wiring or runner process is introduced here; the default WebUI path remains unchanged.
- A later Slice 4 implementation still needs a real runner client/backend, feature-flagged selection, restart/reattach harness, and live-control verification before claiming execution survives `hermes-webui.service` restart.
- Queue/continue remains staged; this PR does not add a server-side queue endpoint or scheduler.

## Model Used

OpenAI Codex GPT-5.5 via Hermes Agent, with file, terminal, and GitHub tooling.
