### PR TITLE
fix(webui): preserve composer during external refresh

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -4852,7 +4852,7 @@ def handle_post(handler, parsed) -> bool:
             if files is not None:
                 draft["files"] = files
             s.composer_draft = draft
-            s.save()
+            s.save(touch_updated_at=False)
         return j(handler, {"ok": True, "draft": s.composer_draft})
 
     if parsed.path == "/api/session/update":

--- a/static/boot.js
+++ b/static/boot.js
@@ -957,6 +957,7 @@ $('modelSelect').onchange=async()=>{
   }
 };
 $('msg').addEventListener('input',()=>{
+  if(typeof markComposerEditedNow==='function') markComposerEditedNow();
   autoResize();
   updateSendBtn();
   // Persist composer draft to server (debounced in _saveComposerDraft).

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -22,6 +22,15 @@ let _loadingSessionId = null;
 // Debounced save — prevents hammering the server on every keystroke.
 let _draftSaveTimer = null;
 const _DRAFT_SAVE_DELAY_MS = 400;
+let _composerLastInputAt = 0;
+
+function markComposerEditedNow() {
+  _composerLastInputAt = Date.now();
+}
+
+function _composerHasRecentLocalEdit(windowMs=3000) {
+  return !!(_composerLastInputAt && (Date.now() - _composerLastInputAt < windowMs));
+}
 
 function _saveComposerDraft(sid, text, files) {
   if (!sid) return;
@@ -790,7 +799,15 @@ async function loadSession(sid){
   // against stale writes from slow responses racing to restore the previous draft).
   const _draft = S.session && S.session.composer_draft;
   if (_draft && (typeof _restoreComposerDraft === 'function')) {
-    _restoreComposerDraft(_draft, sid);
+    const ta=$('msg');
+    const sameSessionForceReload=currentSid===sid&&forceReload;
+    const composerFocused=!!(ta&&document.activeElement===ta);
+    const hasLocalComposerText=!!(ta&&ta.value);
+    const recentLocalEdit=(typeof _composerHasRecentLocalEdit==='function')&&_composerHasRecentLocalEdit();
+    const shouldSkipDraftRestore=sameSessionForceReload&&(
+      composerFocused||recentLocalEdit||hasLocalComposerText
+    );
+    if(!shouldSkipDraftRestore) _restoreComposerDraft(_draft, sid);
   }
 
   _resolveSessionModelForDisplaySoon(sid);

--- a/tests/test_stage326_composer_draft_validation.py
+++ b/tests/test_stage326_composer_draft_validation.py
@@ -81,8 +81,9 @@ def test_draft_validation_appears_before_persist():
     src = Path(__file__).parents[1].joinpath("api", "routes.py").read_text(encoding="utf-8")
     # Anchor on the unique POST-validation comment marker.
     marker_idx = src.find("Stage-326 hardening (per Opus advisor)")
-    persist_idx = src.find("s.composer_draft = draft\n            s.save()")
-    assert marker_idx != -1 and persist_idx != -1, (
+    persist_idx = src.find("s.composer_draft = draft")
+    save_idx = src.find("s.save(touch_updated_at=False)", persist_idx)
+    assert marker_idx != -1 and persist_idx != -1 and save_idx != -1, (
         "could not locate validation marker or persist site"
     )
     assert marker_idx < persist_idx, (

--- a/tests/test_webui_external_refresh_frontend.py
+++ b/tests/test_webui_external_refresh_frontend.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 
 SESSIONS_JS = Path("static/sessions.js").read_text(encoding="utf-8")
+ROUTES_PY = Path("api/routes.py").read_text(encoding="utf-8")
 
 
 def test_load_session_supports_force_reload_for_external_refresh():
@@ -37,3 +38,42 @@ def test_force_reload_clears_stale_blocking_prompts_immediately():
     """
     assert "hideApprovalCard(forceReload)" in SESSIONS_JS
     assert "hideClarifyCard(forceReload, forceReload?'external-refresh':'dismissed')" in SESSIONS_JS
+
+
+def test_same_session_external_refresh_preserves_active_composer_draft():
+    """Same-session forced reload must not overwrite text the user is typing.
+
+    Active-session external refresh calls loadSession(currentSid, {force:true}) after
+    a metadata poll sees state.db advance. That should refresh the transcript, but
+    it must not restore a stale server composer_draft over a focused/dirty textarea.
+    """
+    assert "function markComposerEditedNow()" in SESSIONS_JS
+    assert "function _composerHasRecentLocalEdit" in SESSIONS_JS
+    assert "const sameSessionForceReload=currentSid===sid&&forceReload;" in SESSIONS_JS
+    assert "const shouldSkipDraftRestore=sameSessionForceReload&&" in SESSIONS_JS
+    assert "composerFocused" in SESSIONS_JS
+    assert "recentLocalEdit" in SESSIONS_JS
+    assert "hasLocalComposerText" in SESSIONS_JS
+    assert "if(!shouldSkipDraftRestore) _restoreComposerDraft(_draft, sid);" in SESSIONS_JS
+
+
+def test_composer_input_marks_local_edit_before_debounced_draft_save():
+    """The dirty guard needs to be updated synchronously on every textarea input."""
+    assert "if(typeof markComposerEditedNow==='function') markComposerEditedNow();" in Path(
+        "static/boot.js"
+    ).read_text(encoding="utf-8")
+
+
+def test_draft_save_does_not_touch_session_updated_at():
+    """Draft autosave is UI state and must not look like a transcript update.
+
+    If /api/session/draft bumps updated_at, the active-session metadata poll can
+    treat normal typing as an external session update and force-reload the current
+    session, reopening the stale-draft overwrite race.
+    """
+    draft_block = ROUTES_PY[
+        ROUTES_PY.index('if parsed.path == "/api/session/draft":') : ROUTES_PY.index(
+            'if parsed.path == "/api/session/update":'
+        )
+    ]
+    assert "s.save(touch_updated_at=False)" in draft_block


### PR DESCRIPTION
## Context

Follow-up to the merged state.db/session reconciliation work in #2581.

#2581 made active WebUI sessions notice external state.db appends and force-reload the current session when another surface advances the transcript. That is the right behavior for transcript consistency, but there is a narrow UX race: if the user is typing in the composer while the current session is force-reloaded, restoring the server-side `composer_draft` can overwrite newer local textarea text.

## What Changed

- Track local composer edits synchronously on textarea input.
- During same-session forced reloads (`loadSession(currentSid, {force:true})`), skip restoring server `composer_draft` when the composer is focused, recently edited, or currently non-empty.
- Save `/api/session/draft` with `touch_updated_at=False` so normal draft autosave does not look like a transcript/session update to metadata polling.
- Update frontend/source-shape regression tests for the external-refresh + composer-draft race.

## Why It Matters

External refresh should update the transcript without clobbering text the user is actively typing. Draft autosave is UI state, not a conversation turn; it should not bump `updated_at` and trigger the same metadata path used for external transcript changes.

## Verification

```text
python -m compileall -q api/routes.py
git diff --check
pytest -q tests/test_webui_external_refresh_frontend.py \
  tests/test_stage326_composer_draft_validation.py \
  tests/test_issue856_background_completion_unread.py \
  tests/test_tars_scroll_reset_regressions.py
# 39 passed
```

## Model Used

AI-assisted with Hermes Agent using GPT-5.5