### PR TITLE
fix(streaming): finish auto-compression card after rotation

### DIFF
--- a/static/messages.js
+++ b/static/messages.js
@@ -1829,12 +1829,15 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       // Context was auto-compressed during this turn. Render it through the
       // same transient compression-card path as manual /compress, without
       // inserting a fake assistant message into history or model context.
-      if(!S.session||S.session.session_id!==activeSid) return;
+      if(!S.session) return;
+      const currentSid=S.session.session_id;
       let d={};
       try{ d=JSON.parse(e.data||'{}')||{}; }catch(_){ d={}; }
       const eventSid=d.old_session_id||d.session_id||activeSid;
-      if(eventSid!==activeSid && d.new_session_id!==activeSid && d.continuation_session_id!==activeSid) return;
       const continuationSid=d.new_session_id||d.continuation_session_id||'';
+      const eventMatchesCurrent=!!(currentSid&&(eventSid===currentSid||d.new_session_id===currentSid||d.continuation_session_id===currentSid));
+      if(!eventMatchesCurrent) return;
+      const displaySid=currentSid;
       const message=String(d.message||'Context auto-compressed to continue the conversation').trim();
       if(d.usage&&typeof _syncCtxIndicator==='function'){
         S.lastUsage={...(S.lastUsage||{}),...d.usage};
@@ -1842,7 +1845,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       }
       if(typeof setCompressionUi==='function'){
         const state={
-          sessionId:activeSid,
+          sessionId:displaySid,
           phase:'done',
           automatic:true,
           message,

--- a/tests/test_auto_compression_card.py
+++ b/tests/test_auto_compression_card.py
@@ -217,16 +217,15 @@ def test_auto_compression_sse_uses_transient_card_not_fake_message():
 def test_auto_compression_sse_keeps_inactive_and_malformed_paths_safe():
     block = _compressed_listener_block()
 
-    guard = "if(!S.session||S.session.session_id!==activeSid) return;"
+    guard = "if(!S.session) return;"
     assert guard in block
     assert block.index(guard) < block.index("setCompressionUi")
     assert "try{ d=JSON.parse(e.data||'{}')||{}; }catch(_){ d={}; }" in block
     assert "const eventSid=d.old_session_id||d.session_id||activeSid;" in block
-    # The listener also accepts a rotated continuation session id so journal-
-    # replay reconnects after compression rotate land the done card.
-    # See Opus advisor followup on stage-385 (v0.51.92).
-    event_guard = "if(eventSid!==activeSid && d.new_session_id!==activeSid && d.continuation_session_id!==activeSid) return;"
+    assert "const eventMatchesCurrent=" in block
+    event_guard = "if(!eventMatchesCurrent) return;"
     assert event_guard in block
+    assert block.index("const eventMatchesCurrent=") < block.index(event_guard)
 
 
 def test_auto_compression_done_accepts_rotated_continuation_session_event():
@@ -238,10 +237,27 @@ def test_auto_compression_done_accepts_rotated_continuation_session_event():
     # continuation id as display metadata instead of dropping the event.
     assert "const eventSid=d.old_session_id||d.session_id||activeSid;" in block
     assert "const continuationSid=d.new_session_id||d.continuation_session_id||'';" in block
-    event_guard = "if(eventSid!==activeSid && d.new_session_id!==activeSid && d.continuation_session_id!==activeSid) return;"
+    event_guard = "if(!eventMatchesCurrent) return;"
     assert event_guard in block
-    assert block.index("const eventSid=") < block.index(event_guard)
+    assert block.index("const eventSid=") < block.index("const eventMatchesCurrent=")
     assert "continuationSessionId:continuationSid" in block
+
+
+def test_auto_compression_done_accepts_event_after_current_session_rotates():
+    block = _compressed_listener_block()
+
+    # The final compressed event can arrive/replay after another event has already
+    # updated S.session to the continuation session id. Do not drop it just
+    # because the active browser session no longer equals the original activeSid.
+    strict_active_guard = "if(!S.session||S.session.session_id!==activeSid) return;"
+    assert strict_active_guard not in block
+    assert "if(!S.session) return;" in block
+    assert "const currentSid=S.session.session_id;" in block
+    assert "const eventMatchesCurrent=" in block
+    assert "const displaySid=currentSid;" in block
+    assert "sessionId:displaySid" in block
+    assert block.index("const eventSid=") < block.index("const eventMatchesCurrent=")
+    assert block.index("const displaySid=") < block.index("setCompressionUi(state)")
 
 
 def test_auto_compression_done_sse_refreshes_context_indicator_usage():


### PR DESCRIPTION
## Thinking Path

- The automatic-compression card can show a running elapsed timer even after backend compression has completed.
- The frontend already receives `old_session_id`, `new_session_id`, and `continuation_session_id` on the `compressed` SSE event, but the listener still returned early unless the currently viewed session id equaled the original stream id.
- Auto-compression may rotate the browser-visible session to the continuation before the final `compressed` event is processed or replayed, so the done event can be valid for the current session even when it no longer matches `activeSid`.
- The narrow fix is to correlate the final `compressed` event against the session currently being viewed using the known origin/continuation ids, instead of adding a timer timeout fallback or changing backend emission order.
- Events for unrelated sessions still return early because none of the event's known ids match the current session.


## Attribution / Regression Context

- #2512 by @dso2ng did the right product thing for long auto-compression runs: it gave users a visible elapsed-time heartbeat instead of a silent-looking compression card. That made the underlying missed-completion path obvious instead of invisible.
- #2567 by @dso2ng also added the right backend/frontend handoff metadata (`old_session_id`, `new_session_id`, and `continuation_session_id`) so the browser could correlate a compression completion across session rotation without writing fake transcript messages.
- The remaining gap was an older, stricter frontend guard that still returned before that richer metadata could help whenever `S.session` had already moved from the original stream id to the continuation id.
- This PR keeps the good parts from those changes and narrows the final listener check to the currently viewed session plus the known origin/continuation ids.

## What Changed

- Relaxed the `compressed` SSE listener's strict active-session guard while still requiring an active viewed session.
- Matched the event against `old_session_id` / `session_id` / `new_session_id` / `continuation_session_id` and the current viewed session id.
- Used the current viewed session id when writing the done compression UI state, so rotated continuation sessions can transition the running card to done.
- Added regression coverage that forbids reintroducing the strict `S.session.session_id !== activeSid` guard and asserts the current-session correlation path.

## Why It Matters

- Users no longer see an automatic-compression card stuck in a running elapsed-timer state after compression already completed.
- The browser handles live and replayed compression completion events consistently across session rotation.
- The fix keeps the state ownership in the existing frontend SSE/UI layer and avoids a brittle timer cleanup workaround.
- Unrelated session switches remain isolated because stale events must match the currently viewed session id before updating compression UI.

## Screenshots / UI Evidence

No static screenshot is included for this PR. The bug depends on timing between session rotation and the final `compressed` SSE event, so the durable evidence is the focused source-level regression that pins the listener's accepted/dropped paths rather than a layout comparison. No steady-state layout, styling, or responsive behavior changed.

## Verification

Targeted coverage:

```text
env -u HERMES_CONFIG_PATH -u HERMES_HOME -u HERMES_WEBUI_HOST -u HERMES_WEBUI_PORT -u HERMES_WEBUI_STATE_DIR python -m pytest tests/test_auto_compression_card.py -q
# 37 passed in 4.80s
```

Adjacent compression coverage:

```text
env -u HERMES_CONFIG_PATH -u HERMES_HOME -u HERMES_WEBUI_HOST -u HERMES_WEBUI_PORT -u HERMES_WEBUI_STATE_DIR python -m pytest tests/test_auto_compression_card.py tests/test_compression_snapshot_runtime_clear.py tests/test_issue2262_compression_marker_timeout_ui.py tests/test_issue2028_compression_anchor_helpers.py tests/test_issue2223_compression_no_rename.py tests/test_compress_status_404_fix.py -q
# 61 passed in 4.59s
```

Syntax / hygiene:

```text
node --check static/messages.js
python -m py_compile tests/test_auto_compression_card.py
git diff --check
# all passed
```

Independent review:

```text
Anthropic Claude Code `opus` with `--effort max`
# APPROVED; no blockers or should-fix items
```

## Risks / Follow-ups

- The tests follow the existing source-string assertion style in `test_auto_compression_card.py`; a future browser-level SSE simulation could cover the same state transition more directly.
- The continuation detail line may still name the currently viewed continuation session when the card completes after rotation. That is pre-existing display behavior and intentionally left outside this narrow stuck-timer fix.

## Model Used

- OpenAI / GPT-5.5 for implementation, local verification, and PR preparation.
- Anthropic Claude Code / `opus` with `--effort max` for independent review.
