### PR TITLE
fix: reconcile session metadata counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **PR #2604** by @Michaelyklam (refs #2594) — Make the metadata-only `/api/session?messages=0` path report the same reconciled message count and last-message timestamp as a full session load. Sidebar refresh polling no longer loops forever when `state.db` retains old rows that the append-only merge correctly filters out.
+
 
 ## [v0.51.93] — 2026-05-19 — Release BQ (stage-386 — 10-PR full sweep batch — RFC Slice 4 runner/sidecar gate + workspace tree toggle width CSS variable + settled file:// markdown link rendering + prompt-cache coverage percentage fix + terminal shell shutdown reap + configured model picker provider preservation + profile-aware assistant display names + state.db reconciliation slice 1 + queued-message cross-session drain fix + stale-stream writeback supersede)
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -2221,7 +2221,6 @@ from api.models import (
     get_cli_sessions,
     get_cli_session_messages,
     get_state_db_session_messages,
-    get_state_db_session_summary,
     merge_session_messages_append_only,
     ensure_cron_project,
     is_cron_session,
@@ -3669,16 +3668,24 @@ def handle_get(handler, parsed) -> bool:
             is_messaging_session = _is_messaging_session_record(s) or _is_messaging_session_record(cli_meta)
             cli_messages = []
             state_db_messages = []
-            state_db_summary = {}
+            sidecar_metadata_messages = None
             if is_messaging_session:
                 cli_messages = get_cli_session_messages(sid)
             elif load_messages:
                 state_db_messages = get_state_db_session_messages(sid)
             elif not is_messaging_session:
-                # Metadata-only callers (frontend refresh polling) only need a
-                # cheap staleness signal. Avoid full transcript materialization
-                # on the steady-state polling path.
-                state_db_summary = get_state_db_session_summary(sid)
+                # Metadata-only callers still need the same append-only
+                # reconciliation contract as full loads. A raw state.db summary
+                # can count stale rows that the merge intentionally filters out,
+                # which makes sidebar polling think the transcript is always
+                # newer than the loaded conversation.
+                state_db_messages = get_state_db_session_messages(sid)
+                sidecar_metadata_session = Session.load(sid)
+                sidecar_metadata_messages = (
+                    getattr(sidecar_metadata_session, "messages", []) or []
+                    if sidecar_metadata_session
+                    else []
+                )
             _t2 = _time.monotonic()
             effective_model = (
                 _resolve_effective_session_model_for_display(s)
@@ -3708,23 +3715,20 @@ def handle_get(handler, parsed) -> bool:
                     sidecar_messages = getattr(s, "messages", []) or []
                     _all_msgs = merge_session_messages_append_only(cli_messages, sidecar_messages)
                 else:
-                    _all_msgs = merge_session_messages_append_only(getattr(s, "messages", []) or [], state_db_messages)
-            if not load_messages and state_db_summary:
-                sidecar_messages = getattr(s, "messages", []) or []
-                sidecar_count = len(sidecar_messages)
+                    _metadata_sidecar = sidecar_metadata_messages
+                    if _metadata_sidecar is None:
+                        _metadata_sidecar = getattr(s, "messages", []) or []
+                    _all_msgs = merge_session_messages_append_only(_metadata_sidecar, state_db_messages)
+            if not load_messages:
+                _summary_message_count = len(_all_msgs)
                 try:
-                    sidecar_last = max(
+                    _summary_last_message_at = max(
                         float((m or {}).get("timestamp") or 0)
-                        for m in sidecar_messages
+                        for m in _all_msgs
                         if isinstance(m, dict)
-                    ) if sidecar_messages else 0
+                    ) if _all_msgs else 0
                 except (TypeError, ValueError):
-                    sidecar_last = 0
-                state_count = int(state_db_summary.get("message_count") or 0)
-                state_last = float(state_db_summary.get("last_message_at") or 0)
-                _all_msgs = sidecar_messages
-                _summary_message_count = max(sidecar_count, state_count)
-                _summary_last_message_at = max(sidecar_last, state_last)
+                    _summary_last_message_at = 0
             else:
                 _summary_message_count = None
                 _summary_last_message_at = None

--- a/tests/test_webui_state_db_reconciliation.py
+++ b/tests/test_webui_state_db_reconciliation.py
@@ -317,6 +317,43 @@ def test_metadata_fast_path_reports_reconciled_state_db_count(monkeypatch, tmp_p
     assert session["last_message_at"] == 1003.0
 
 
+def test_metadata_fast_path_excludes_state_db_rows_filtered_by_reconciliation(monkeypatch, tmp_path):
+    import api.routes as routes
+
+    sid = "webui_reconcile_metadata_filtered"
+    _install_test_session(
+        monkeypatch,
+        tmp_path,
+        sid,
+        [
+            {"role": "user", "content": "old user", "timestamp": 1000.0},
+            {"role": "assistant", "content": "old assistant", "timestamp": 1001.0},
+        ],
+    )
+    _make_state_db(
+        tmp_path / "state.db",
+        sid,
+        [
+            {"role": "user", "content": "old user", "timestamp": 1000.0},
+            {"role": "assistant", "content": "old assistant", "timestamp": 1001.0},
+            # This stale state.db-only row is older than the newest sidecar
+            # timestamp and lacks an explicit message id, so the full
+            # append-only merge filters it out. The metadata path must report
+            # the same count/last timestamp or sidebar refresh polling loops.
+            {"role": "tool", "content": "stale state row", "timestamp": 1000.5},
+        ],
+    )
+
+    handler = _GetHandler(f"/api/session?session_id={sid}&messages=0&resolve_model=0")
+    routes.handle_get(handler, urlparse(handler.path))
+
+    assert handler.status == 200
+    session = handler.response_json["session"]
+    assert session["messages"] == []
+    assert session["message_count"] == 2
+    assert session["last_message_at"] == 1001.0
+
+
 def test_state_db_reconciliation_preserves_tool_metadata(monkeypatch, tmp_path):
     import api.routes as routes
 


### PR DESCRIPTION
## Thinking Path
- Sidebar refresh polling uses `/api/session?messages=0` as a lightweight session-metadata path.
- Full session loads reconcile sidecar JSON with `state.db` through `merge_session_messages_append_only(...)`.
- The metadata path used a raw `state.db` count/max timestamp summary, which can count stale retained rows that the merge intentionally filters out.
- This PR makes metadata-only count/timestamp reporting use the same reconciled message set as full loads, preserving the sidebar metadata invariant.

## What Changed
- Load sidecar messages and state.db messages for the metadata-only non-messaging session path.
- Compute `message_count` and `last_message_at` from `merge_session_messages_append_only(...)` instead of `max(sidecar_count, state_count)`.
- Removed the now-unused `get_state_db_session_summary` route import.
- Added a regression test for a stale state.db-only row older than the newest sidecar timestamp.
- Added a release-note-ready changelog entry.

## Why It Matters
This prevents `/api/session?messages=0` from reporting a higher `message_count` than a full transcript load for the same session. The frontend's polling guard no longer sees a false `remoteCount > localCount` signal every tick when `state.db` contains rows that reconciliation correctly excludes.

State layer affected: sidebar/session metadata. The source of truth for metadata-only counts is now the same append-only reconciled transcript used by full session loads.

## Verification
- `/home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_webui_state_db_reconciliation.py -q` — 9 passed
- `/home/michael/.hermes/hermes-agent/venv/bin/python -m py_compile api/routes.py api/models.py`
- `git diff --check`

No UI media attached: this is a backend session-metadata consistency fix with no rendered interface change.

## Risks / Follow-ups
- The metadata-only path now materializes the sidecar/state.db messages needed for exact reconciliation, so the polling path does a little more work than the previous raw summary shortcut.
- The tradeoff is intentional for correctness: metadata and full-load counts must not diverge.

Refs #2594

## Model Used
AI-assisted change with repository inspection, targeted editing, and shell-based test verification.
