### PR TITLE
fix(webui): refresh active session on external sidecar updates

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -436,7 +436,14 @@ class Session:
         self.read_only = bool(kwargs.get('read_only', False))
         self.enabled_toolsets = enabled_toolsets  # List[str] or None — per-session toolset override
         self.composer_draft = composer_draft if isinstance(composer_draft, dict) else {}
-        self._metadata_message_count = None
+        raw_message_count = kwargs.get('message_count')
+        parsed_message_count = None
+        if raw_message_count is not None:
+            try:
+                parsed_message_count = int(raw_message_count)
+            except (TypeError, ValueError):
+                parsed_message_count = None
+        self._metadata_message_count = parsed_message_count if parsed_message_count is not None and parsed_message_count >= 0 else None
 
     @property
     def path(self):
@@ -590,7 +597,19 @@ class Session:
             parsed['messages'] = []
             parsed['tool_calls'] = []
             session = cls(**parsed)
-            session._metadata_message_count = _lookup_index_message_count(sid)
+            metadata_message_count = _lookup_index_message_count(sid)
+            if metadata_message_count is None:
+                raw_count = parsed.get('message_count')
+                if isinstance(raw_count, int) and raw_count >= 0:
+                    metadata_message_count = raw_count
+                else:
+                    try:
+                        parsed_count = int(raw_count)
+                    except (TypeError, ValueError):
+                        parsed_count = None
+                    if parsed_count is not None and parsed_count >= 0:
+                        metadata_message_count = parsed_count
+            session._metadata_message_count = metadata_message_count
             # Mark this session as a metadata-only stub. save() refuses to write
             # such a session because doing so would atomically replace the
             # on-disk JSON with messages=[], wiping the conversation. Any

--- a/api/routes.py
+++ b/api/routes.py
@@ -3709,9 +3709,16 @@ def handle_get(handler, parsed) -> bool:
                     _all_msgs = merge_session_messages_append_only(cli_messages, sidecar_messages)
                 else:
                     _all_msgs = merge_session_messages_append_only(getattr(s, "messages", []) or [], state_db_messages)
-            if not load_messages and state_db_summary:
+            if not load_messages:
                 sidecar_messages = getattr(s, "messages", []) or []
                 sidecar_count = len(sidecar_messages)
+                if sidecar_count == 0:
+                    try:
+                        metadata_count = getattr(s, "_metadata_message_count", None)
+                        if metadata_count is not None:
+                            sidecar_count = max(0, int(metadata_count))
+                    except (TypeError, ValueError):
+                        sidecar_count = 0
                 try:
                     sidecar_last = max(
                         float((m or {}).get("timestamp") or 0)
@@ -3720,8 +3727,8 @@ def handle_get(handler, parsed) -> bool:
                     ) if sidecar_messages else 0
                 except (TypeError, ValueError):
                     sidecar_last = 0
-                state_count = int(state_db_summary.get("message_count") or 0)
-                state_last = float(state_db_summary.get("last_message_at") or 0)
+                state_count = int(state_db_summary.get("message_count") or 0) if state_db_summary else 0
+                state_last = float(state_db_summary.get("last_message_at") or 0) if state_db_summary else 0
                 _all_msgs = sidecar_messages
                 _summary_message_count = max(sidecar_count, state_count)
                 _summary_last_message_at = max(sidecar_last, state_last)

--- a/tests/test_webui_state_db_reconciliation.py
+++ b/tests/test_webui_state_db_reconciliation.py
@@ -135,6 +135,32 @@ def test_api_session_includes_state_db_messages_newer_than_webui_sidecar(monkeyp
     assert payload["session"]["message_count"] == 4
 
 
+def test_metadata_poll_uses_sidecar_message_count_for_external_updates(monkeypatch, tmp_path):
+    """Active-session external refresh relies on metadata-only counts.
+
+    When no session index exists, metadata-only loads may fall back to
+    _metadata_message_count=None. The refresh poll must still report the real
+    sidecar message count; otherwise an external session JSON update can be
+    invisible until a full reload.
+    """
+    import api.routes as routes
+
+    sid = "webui_reconcile_metadata_sidecar"
+    sidecar_messages = [
+        {"role": "user", "content": "before external update", "timestamp": 1000.0},
+        {"role": "assistant", "content": "externally appended", "timestamp": 1001.0},
+    ]
+    _install_test_session(monkeypatch, tmp_path, sid, sidecar_messages)
+
+    handler = _GetHandler(f"/api/session?session_id={sid}&messages=0&resolve_model=0")
+    routes.handle_get(handler, urlparse(handler.path))
+
+    assert handler.status == 200
+    session = handler.response_json["session"]
+    assert session["message_count"] == 2
+    assert session["last_message_at"] == 1001.0
+
+
 def test_state_db_reconciliation_preserves_sidecar_only_messages(monkeypatch, tmp_path):
     import api.routes as routes
 


### PR DESCRIPTION
## Context

This is a follow-up to the earlier state.db/session-sidecar reconciliation work (PR #2581, from the closed broader reconciliation PR #2194). That slice made WebUI reconcile externally appended transcript content into the session response. This PR tightens the UI-facing observation layer: the active-session refresh poll must be able to notice that externally appended content exists so the already-open browser session reloads and renders it.

Active-session external refresh uses the metadata-only `/api/session?messages=0&resolve_model=0` fast path as its staleness signal. That path must reflect externally appended session-sidecar messages, not just state.db summaries or sidebar index entries, or the browser can miss an external transcript update until a full reload.

## What Changed

- Preserves a persisted `message_count` value when constructing `Session` metadata stubs.
- Falls back from the session index to a persisted sidecar `message_count` during metadata-only loads.
- Makes the metadata-only `/api/session` response compute `message_count`/`last_message_at` even when no state.db summary is present.
- Adds a regression test that confirms externally appended sidecar content is visible to the active-session refresh poll, which is the UI-layer signal that lets the browser render the new transcript content.

## Why It Matters

PR #2581 covered the backend reconciliation path: externally appended transcript content can be merged into `/api/session` responses. The remaining UI-layer gap was detection. Without an accurate metadata-only count, the frontend can compare a false local/remote zero and skip `loadSession(..., {force:true})`. The transcript file may contain a newly appended external message, but the currently open session would not update/render it until the user manually reloads or reopens it.

State layer affected: sidebar/session metadata used as the active-session external-refresh observation signal. The source of truth remains the session sidecar transcript plus state.db reconciliation; this PR fixes the metadata projection used to detect that the source changed.

## Verification

- `pytest -q tests/test_webui_state_db_reconciliation.py tests/test_webui_external_refresh_frontend.py tests/test_metadata_save_wipe_1558.py`
- `git diff --check`
- `python -m compileall -q api/models.py api/routes.py`

## Risks / Follow-ups

- Metadata-only loads still avoid materializing messages when an index or persisted count is available.
- Legacy sidecars without a persisted count still report zero unless state.db has a summary; handling that would require a heavier fallback and is intentionally not broadened here.

## Model Used

GPT-5.5 via Hermes Agent, with local git/pytest validation.