### PR TITLE
fix(session): dedupe messaging transcript timestamp variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+### Fixed
+- Deduplicate messaging/CLI session transcript rows when the sidecar and state store encode the same no-id message with equivalent timestamps in different formats, preventing repeated visible chat messages after session reconstruction.
 
 ## [v0.51.94] — 2026-05-19 — Release BR (stage-387 — 10-PR full sweep batch — Slice 4b runner adapter facade + folder zip download + partial recovery marker dedupe + browser api() client-side timeout + auto-compression card rotation finish + composer draft rollback fix + metadata count reconciliation + active-session refresh on external sidecar updates + indexed context metadata + gateway-queues approval peek)
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -1970,18 +1970,7 @@ def _merged_session_messages_for_display(session, cli_messages=None) -> list:
                 str(m.get("role") or ""),
                 str(m.get("content") or ""),
             )):
-                message_identity = msg.get("id") or msg.get("message_id")
-                if message_identity:
-                    key = ("message_id", str(message_identity))
-                else:
-                    key = (
-                        "legacy",
-                        str(msg.get("role") or ""),
-                        str(msg.get("content") or ""),
-                        str(msg.get("timestamp") or ""),
-                        str(msg.get("tool_call_id") or ""),
-                        str(msg.get("tool_name") or msg.get("name") or ""),
-                    )
+                key = _session_message_merge_key(msg)
                 if key in seen_message_keys:
                     continue
                 seen_message_keys.add(key)
@@ -2222,6 +2211,7 @@ from api.models import (
     get_cli_session_messages,
     get_state_db_session_messages,
     merge_session_messages_append_only,
+    _session_message_merge_key,
     ensure_cron_project,
     is_cron_session,
 )

--- a/tests/test_issue2472_fork_from_here_messaging.py
+++ b/tests/test_issue2472_fork_from_here_messaging.py
@@ -49,6 +49,23 @@ def test_messaging_merge_helper_matches_session_get_coordinate_space():
     ]
 
 
+def test_messaging_merge_helper_dedupes_equivalent_timestamp_formats():
+    session = SimpleNamespace(
+        messages=[
+            {"role": "user", "content": "hi", "timestamp": "10.0"},
+            {"role": "assistant", "content": "same answer", "timestamp": "11.000000"},
+        ]
+    )
+    cli_messages = [
+        {"role": "user", "content": "hi", "timestamp": 10},
+        {"role": "assistant", "content": "same answer", "timestamp": 11},
+    ]
+
+    merged = routes._merged_session_messages_for_display(session, cli_messages)
+
+    assert [m["content"] for m in merged] == ["hi", "same answer"]
+
+
 def test_branch_handler_uses_merged_messaging_messages_for_keep_count():
     branch_idx = ROUTES_PY.index('parsed.path == "/api/session/branch":')
     block = ROUTES_PY[branch_idx : branch_idx + 2600]


### PR DESCRIPTION
## Thinking Path
- Repeated visible chat rows can come from backend reconstruction when WebUI combines sidecar/session messages with Agent/CLI state messages.
- Messaging/CLI display merge had its own legacy dedupe key using raw `str(timestamp)`, while the state-db append-only merge already normalizes timestamp values for no-id messages.
- The fix aligns the messaging display merge with the existing normalized merge key instead of hiding duplicates in the DOM.

## What Changed
- Reuse `api.models._session_message_merge_key(...)` inside `api.routes._merged_session_messages_for_display(...)`.
- Add a regression where sidecar and CLI carry the same no-id user/assistant rows with equivalent timestamps encoded as `"10.0"` / `10` and `"11.000000"` / `11`.
- Add a changelog entry for the user-visible repeated-message fix.

## Why It Matters
- Prevents WebUI conversations from rendering the same logical message twice after session reconstruction for messaging/CLI-backed sessions.
- Keeps the fix in the backend transcript reconciliation layer, so sidebar/session reloads and frontend renders receive one canonical display transcript.
- Preserves explicit `message_id` semantics from the existing helper, so distinct retries with stable ids remain distinct.

## Verification
- `python3 -m py_compile api/routes.py api/models.py`
- `/Users/abdiel/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_issue2472_fork_from_here_messaging.py tests/test_session_import_cli_fallback_model.py tests/test_session_sidecar_repair.py -q -o addopts=`
- `git diff --check`

## Risks / Follow-ups
- Scope is limited to messaging/CLI display reconstruction. If a future report shows duplicates only while an active stream is reconnecting and `/api/session?messages=1` is clean, that should be handled separately in the frontend inflight/optimistic-tail merge path.
