### PR TITLE
fix: preserve IPv6 dashboard link brackets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Preserve square brackets around IPv6 hosts when normalizing browser-only dashboard URLs, so links like `http://[::1]:9119` remain valid after saving.
+
 
 ## [v0.51.95] — 2026-05-20 — Release BS (stage-388 — 5-PR batch — live tool callback event dedup + browser-only dashboard links + messaging transcript merge alignment + Geist Contrast skin + SSE runtime diagnostics)
 

--- a/api/dashboard_probe.py
+++ b/api/dashboard_probe.py
@@ -88,7 +88,10 @@ def normalize_dashboard_browser_url(raw_url: str | None) -> str:
         port = parsed.port
     except ValueError as exc:
         raise ValueError("invalid dashboard URL port") from exc
-    netloc = parsed.hostname.lower()
+    host = parsed.hostname.lower()
+    if ":" in host and not host.startswith("["):
+        host = f"[{host}]"
+    netloc = host
     if port is not None:
         if not (1 <= port <= 65535):
             raise ValueError("invalid dashboard URL port")

--- a/tests/test_dashboard_probe.py
+++ b/tests/test_dashboard_probe.py
@@ -132,6 +132,13 @@ def test_status_tries_default_loopback_targets_until_dashboard_found(monkeypatch
     assert attempts == [("127.0.0.1", 9119, 0.5, "http"), ("localhost", 9119, 0.5, "http")]
 
 
+def test_dashboard_browser_url_preserves_ipv6_host_brackets():
+    from api.dashboard_probe import normalize_dashboard_browser_url
+
+    assert normalize_dashboard_browser_url("http://[::1]:9119") == "http://[::1]:9119"
+    assert normalize_dashboard_browser_url("https://[2001:db8::1]") == "https://[2001:db8::1]"
+
+
 def test_status_honors_never_and_external_browser_link_without_probe(monkeypatch):
     from api import dashboard_probe
 


### PR DESCRIPTION
## Summary
- Preserve IPv6 host brackets when normalizing browser-only dashboard URLs
- Add regression coverage for bracketed IPv6 dashboard links
- Update the unreleased changelog

Closes #2609

## Test Plan
- [x] `python3.11 -m venv /tmp/hermes-webui-py311-venv && /tmp/hermes-webui-py311-venv/bin/python -m pip install -q --upgrade pip pytest pytest-timeout pyyaml`
- [x] `/tmp/hermes-webui-py311-venv/bin/python -m pytest tests/test_dashboard_probe.py::test_dashboard_browser_url_preserves_ipv6_host_brackets -q` (failed before the fix, passed after)
- [x] `/tmp/hermes-webui-py311-venv/bin/python -m pytest tests/test_dashboard_probe.py -q`
- [x] `python3.11 -m py_compile api/dashboard_probe.py`
- [x] `git diff --check`
