### PR TITLE
fix: surface custom provider model catalog warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Surface named custom-provider `/models` fetch failures in `/api/models` and the model picker instead of silently showing only configured fallback models.
+
 
 ## [v0.51.95] — 2026-05-20 — Release BS (stage-388 — 5-PR batch — live tool callback event dedup + browser-only dashboard links + messaging transcript merge alignment + Geist Contrast skin + SSE runtime diagnostics)
 

--- a/api/config.py
+++ b/api/config.py
@@ -2413,13 +2413,15 @@ def _load_models_cache_from_disk() -> dict | None:
             return None
         # Strip the disk-only metadata before returning, so the in-memory
         # cache shape stays exactly what the rest of the code expects.
-        return {
+        result = {
             "active_provider": cache["active_provider"],
             "default_model": cache["default_model"],
             "configured_model_badges": cache["configured_model_badges"],
             "groups": cache["groups"],
-            "model_warnings": cache.get("model_warnings", []),
         }
+        if "model_warnings" in cache:
+            result["model_warnings"] = cache.get("model_warnings", [])
+        return result
     except Exception:
         return None
 
@@ -2450,8 +2452,9 @@ def _save_models_cache_to_disk(cache: dict) -> None:
             "default_model": cache["default_model"],
             "configured_model_badges": cache["configured_model_badges"],
             "groups": cache["groups"],
-            "model_warnings": cache.get("model_warnings", []),
         }
+        if "model_warnings" in cache:
+            payload["model_warnings"] = cache.get("model_warnings", [])
         runtime_version = _current_webui_version()
         if runtime_version is not None:
             payload["_webui_version"] = runtime_version

--- a/api/config.py
+++ b/api/config.py
@@ -2418,6 +2418,7 @@ def _load_models_cache_from_disk() -> dict | None:
             "default_model": cache["default_model"],
             "configured_model_badges": cache["configured_model_badges"],
             "groups": cache["groups"],
+            "model_warnings": cache.get("model_warnings", []),
         }
     except Exception:
         return None
@@ -2449,6 +2450,7 @@ def _save_models_cache_to_disk(cache: dict) -> None:
             "default_model": cache["default_model"],
             "configured_model_badges": cache["configured_model_badges"],
             "groups": cache["groups"],
+            "model_warnings": cache.get("model_warnings", []),
         }
         runtime_version = _current_webui_version()
         if runtime_version is not None:
@@ -3175,6 +3177,8 @@ def get_available_models() -> dict:
             *,
             api_key: object = "",
             trusted_base_urls: tuple[object, ...] = (),
+            warning_sink: list[dict] | None = None,
+            provider_display: str | None = None,
         ) -> list[dict]:
             base = str(base_url or "").strip()
             if not base:
@@ -3229,9 +3233,20 @@ def get_available_models() -> dict:
                 return _extract_model_entries_from_payload(data, provider)
             except Exception:
                 logger.debug("Custom endpoint unreachable or misconfigured for provider: %s", provider)
+                if warning_sink is not None:
+                    warning = {
+                        "type": "custom_provider_models_unavailable",
+                        "provider_id": provider,
+                        "provider": provider_display or provider,
+                        "base_url": base,
+                        "message": "Live model catalog unavailable; showing configured models only.",
+                    }
+                    if warning not in warning_sink:
+                        warning_sink.append(warning)
                 return []
 
         # 4. Fetch models from custom endpoint if base_url is configured
+        model_warnings: list[dict] = []
         auto_detected_models = []
         auto_detected_models_by_provider: dict[str, list[dict]] = {}
         if cfg_base_url:
@@ -3335,6 +3350,8 @@ def get_available_models() -> dict:
                         _slug,
                         api_key=_cp_api_key,
                         trusted_base_urls=(_cp_base_url,),
+                        warning_sink=model_warnings,
+                        provider_display=_cp_name,
                     )
                     for _live_model in _live_models:
                         _live_id = str(_live_model.get("id") or "").strip()
@@ -3954,6 +3971,7 @@ def get_available_models() -> dict:
             "configured_model_badges": _build_configured_model_badges(),
             "groups": groups,
             "aliases": model_aliases,
+            "model_warnings": model_warnings,
         }
 
     # ── FAST PATH ─────────────────────────────────────────────────────────────

--- a/static/ui.js
+++ b/static/ui.js
@@ -955,14 +955,6 @@ async function populateModelDropdown(){
     const groups=(Array.isArray(data.groups)&&data.groups.length)
       ? data.groups
       : _synthGroupsFromConfigured();
-    const modelWarnings=Array.isArray(data.model_warnings)?data.model_warnings:[];
-    const warningsByProvider=new Map();
-    for(const w of modelWarnings){
-      const pid=String((w&&w.provider_id)||'').trim();
-      if(!pid) continue;
-      if(!warningsByProvider.has(pid)) warningsByProvider.set(pid,[]);
-      warningsByProvider.get(pid).push(w);
-    }
 
     if(!groups.length) return; // no server groups and no configured fallback
     // Clear existing options
@@ -979,13 +971,6 @@ async function populateModelDropdown(){
         og.appendChild(opt);
         _dynamicModelLabels[m.id]=m.id;
       }
-      for(const w of (warningsByProvider.get(String(g.provider_id||''))||[])){
-        const opt=document.createElement('option');
-        opt.disabled=true;
-        opt.value='';
-        opt.textContent='⚠ '+(w.message||'Live model catalog unavailable');
-        og.appendChild(opt);
-      }
       // Hydrate the label map from extra_models too (the catalog tail that
       // doesn't render as <option> entries when the picker is capped — see
       // _build_nous_featured_set in api/config.py for the rationale). This
@@ -996,6 +981,13 @@ async function populateModelDropdown(){
         for(const m of g.extra_models){
           if(m && m.id) _dynamicModelLabels[m.id]=m.id;
         }
+      }
+      for(const w of ((Array.isArray(data.model_warnings)?data.model_warnings:[]).filter(w=>String((w&&w.provider_id)||'')===String(g.provider_id||'')))){
+        const opt=document.createElement('option');
+        opt.disabled=true;
+        opt.value='';
+        opt.textContent='⚠ '+(w.message||'Live model catalog unavailable');
+        og.appendChild(opt);
       }
       sel.appendChild(og);
     }

--- a/static/ui.js
+++ b/static/ui.js
@@ -955,6 +955,14 @@ async function populateModelDropdown(){
     const groups=(Array.isArray(data.groups)&&data.groups.length)
       ? data.groups
       : _synthGroupsFromConfigured();
+    const modelWarnings=Array.isArray(data.model_warnings)?data.model_warnings:[];
+    const warningsByProvider=new Map();
+    for(const w of modelWarnings){
+      const pid=String((w&&w.provider_id)||'').trim();
+      if(!pid) continue;
+      if(!warningsByProvider.has(pid)) warningsByProvider.set(pid,[]);
+      warningsByProvider.get(pid).push(w);
+    }
 
     if(!groups.length) return; // no server groups and no configured fallback
     // Clear existing options
@@ -970,6 +978,13 @@ async function populateModelDropdown(){
         opt.textContent=m.label;
         og.appendChild(opt);
         _dynamicModelLabels[m.id]=m.id;
+      }
+      for(const w of (warningsByProvider.get(String(g.provider_id||''))||[])){
+        const opt=document.createElement('option');
+        opt.disabled=true;
+        opt.value='';
+        opt.textContent='⚠ '+(w.message||'Live model catalog unavailable');
+        og.appendChild(opt);
       }
       // Hydrate the label map from extra_models too (the catalog tail that
       // doesn't render as <option> entries when the picker is capped — see

--- a/tests/test_custom_provider_display_name.py
+++ b/tests/test_custom_provider_display_name.py
@@ -116,6 +116,39 @@ class TestNamedCustomProviderGroup:
             f"Expected 'my-llm' in Agent37 group models, got {model_ids}"
         )
 
+    def test_named_provider_reports_live_catalog_fetch_failure(self, monkeypatch):
+        """A failing /models fetch should return a structured picker warning."""
+        import urllib.error
+        from email.message import Message
+
+        def fail_urlopen(*args, **kwargs):
+            raise urllib.error.HTTPError(
+                "http://127.0.0.1:9999/v1/models",
+                401,
+                "Unauthorized",
+                hdrs=Message(),
+                fp=None,
+            )
+
+        monkeypatch.setattr("urllib.request.urlopen", fail_urlopen)
+        result = _models_with_cfg(
+            model_cfg={"provider": "custom"},
+            custom_providers=[
+                {"name": "BrokenProxy", "model": "fallback-model", "base_url": "http://127.0.0.1:9999/v1"}
+            ],
+        )
+
+        warnings = result.get("model_warnings") or []
+        assert warnings == [
+            {
+                "type": "custom_provider_models_unavailable",
+                "provider_id": "custom:brokenproxy",
+                "provider": "BrokenProxy",
+                "base_url": "http://127.0.0.1:9999/v1",
+                "message": "Live model catalog unavailable; showing configured models only.",
+            }
+        ]
+
     def test_multiple_named_providers_each_get_their_own_group(self):
         """Two named custom providers should produce two distinct groups."""
         result = _models_with_cfg(


### PR DESCRIPTION
## Summary
- Return structured `model_warnings` when a named custom provider's live `/models` endpoint fails
- Render the warning as a disabled hint in the composer model picker while preserving configured fallback models
- Add regression coverage for a failing named custom-provider catalog fetch

Closes #2540

## Test Plan
- [x] `/tmp/hermes-webui-py311-venv/bin/python -m pytest tests/test_custom_provider_display_name.py::TestNamedCustomProviderGroup::test_named_provider_reports_live_catalog_fetch_failure -q` (failed before the fix, passed after)
- [x] `/tmp/hermes-webui-py311-venv/bin/python -m pytest tests/test_custom_provider_display_name.py -q`
- [x] `python3.11 -m py_compile api/config.py`
- [x] `node -c static/ui.js`
- [x] `git diff --check`
