### PR TITLE
fix(webui): prefer sidecar counts during external refresh

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -358,6 +358,16 @@ def _lookup_index_message_count(session_id):
     return None
 
 
+def _parse_nonnegative_int(value):
+    if isinstance(value, int) and value >= 0:
+        return value
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed >= 0 else None
+
+
 class Session:
     def __init__(self, session_id: str=None, title: str='Untitled',
                  workspace=str(DEFAULT_WORKSPACE), model=DEFAULT_MODEL,
@@ -620,19 +630,16 @@ class Session:
             parsed['messages'] = []
             parsed['tool_calls'] = []
             session = cls(**parsed)
-            metadata_message_count = _lookup_index_message_count(sid)
-            if metadata_message_count is None:
-                raw_count = parsed.get('message_count')
-                if isinstance(raw_count, int) and raw_count >= 0:
-                    metadata_message_count = raw_count
-                else:
-                    try:
-                        parsed_count = int(raw_count)
-                    except (TypeError, ValueError):
-                        parsed_count = None
-                    if parsed_count is not None and parsed_count >= 0:
-                        metadata_message_count = parsed_count
-            session._metadata_message_count = metadata_message_count
+            index_message_count = _lookup_index_message_count(sid)
+            sidecar_message_count = _parse_nonnegative_int(parsed.get('message_count'))
+            # The sidebar index is a cache and can lag behind external sidecar
+            # appends/backfills. Prefer the largest known count so metadata-only
+            # active-session polls do not miss real remote updates.
+            known_counts = [
+                count for count in (index_message_count, sidecar_message_count)
+                if count is not None
+            ]
+            session._metadata_message_count = max(known_counts) if known_counts else None
             # Mark this session as a metadata-only stub. save() refuses to write
             # such a session because doing so would atomically replace the
             # on-disk JSON with messages=[], wiping the conversation. Any

--- a/tests/test_webui_state_db_reconciliation.py
+++ b/tests/test_webui_state_db_reconciliation.py
@@ -161,6 +161,31 @@ def test_metadata_poll_uses_sidecar_message_count_for_external_updates(monkeypat
     assert session["last_message_at"] == 1001.0
 
 
+def test_metadata_poll_prefers_sidecar_count_when_index_is_stale(monkeypatch, tmp_path):
+    """A stale sidebar index must not hide externally appended sidecar turns."""
+    import api.config as config
+    import api.routes as routes
+
+    sid = "webui_reconcile_metadata_stale_index"
+    sidecar_messages = [
+        {"role": "user", "content": "before stale index", "timestamp": 1000.0},
+        {"role": "assistant", "content": "new sidecar turn", "timestamp": 1001.0},
+    ]
+    _install_test_session(monkeypatch, tmp_path, sid, sidecar_messages)
+    config.SESSION_INDEX_FILE.write_text(
+        json.dumps([{"session_id": sid, "message_count": 1}]),
+        encoding="utf-8",
+    )
+
+    handler = _GetHandler(f"/api/session?session_id={sid}&messages=0&resolve_model=0")
+    routes.handle_get(handler, urlparse(handler.path))
+
+    assert handler.status == 200
+    session = handler.response_json["session"]
+    assert session["message_count"] == 2
+    assert session["last_message_at"] == 1001.0
+
+
 def test_state_db_reconciliation_preserves_sidecar_only_messages(monkeypatch, tmp_path):
     import api.routes as routes
 


### PR DESCRIPTION
## Thinking Path

This is a narrow follow-up to the state.db/session-sidecar reconciliation work from #2581 and the active-session external update fix from #2605.

#2605 made active sessions notice externally appended sidecar content through the metadata-only `/api/session?messages=0&resolve_model=0` polling path. This PR covers the remaining stale-index case: the full session sidecar can already contain the appended message, while the sidebar/session index still reports an older `message_count`. If metadata-only polling trusts that stale index count, the currently open browser session may skip its forced reload and hide a real external update until a later refresh or manual reload.

## What Changed

- Prefer the current session sidecar JSON `message_count` over stale sidebar/index counts in metadata-only session responses.
- Keep `last_message_at`/count projection aligned with the sidecar source of truth for active-session polling.
- Add regression coverage for a deliberately stale sidebar index so metadata-only polling still reports the current sidecar count.

## Why It Matters

The active WebUI refresh contract has two halves:

1. Backend reconciliation must make externally appended transcript content available in `/api/session`.
2. The frontend metadata poll must detect that content changed and trigger a full reload.

#2581/#2605 covered the broader reconciliation and active refresh path. This PR fixes a smaller but important observation-layer gap: stale index metadata must not mask a sidecar append that is already present in the transcript source of truth.

State layer affected: session metadata projection used by active-session external refresh. The source of truth remains the session sidecar transcript plus state.db reconciliation; this PR only fixes the fast metadata signal used to detect changes.

## Verification

- `pytest -q tests/test_webui_state_db_reconciliation.py tests/test_webui_external_refresh_frontend.py tests/test_metadata_save_wipe_1558.py`
- `git diff --check`
- `python -m compileall -q api/models.py api/routes.py`

Composed deploy verification also passed after replaying #2618 onto latest `origin/master`:

- `72 passed`
- `git diff --check` clean
- `compileall` clean

## Risks / Follow-ups

- This does not broaden the feature beyond generic external sidecar/session updates.
- Metadata-only loads still avoid materializing full messages when accurate sidecar/index metadata is available.
- If a legacy sidecar lacks persisted count/timestamp metadata, heavier fallback behavior should be considered separately rather than folded into this small stale-index fix.

## Model Used

GPT-5.5 via Hermes Agent, with local git/pytest validation.
