### PR TITLE
fix(session): use second-level timestamp granularity in legacy dedup key

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -2495,9 +2495,10 @@ def _normalized_message_timestamp_for_key(value):
         timestamp = float(value)
     except (TypeError, ValueError):
         return str(value)
-    if timestamp.is_integer():
-        return str(int(timestamp))
-    return ("%.6f" % timestamp).rstrip("0").rstrip(".")
+    # Truncate to second-level granularity so that sub-second drift between
+    # the sidecar JSON write and the state.db created_at write does not cause
+    # the legacy dedup key to differ for the same logical message.
+    return str(int(timestamp))
 
 
 def _message_timestamp_as_float(msg):


### PR DESCRIPTION
## Summary

Fix duplicate messages in chat (closes #2616).

`_normalized_message_timestamp_for_key` was preserving microsecond precision (`%.6f`). When the same message is persisted by both the WebUI sidecar JSON writer and the Hermes agent `state.db` writer, their timestamps can differ by a few microseconds. This caused `_session_message_merge_key` to produce different keys for the same logical message, letting both copies survive the dedup pass in `merge_session_messages_append_only` — resulting in every user message and AI response appearing twice in the UI.

## Fix

Truncate to second-level granularity (`int(timestamp)`) so sub-second drift between the two writers collapses to the same key.

## Reproduction

1. Run WebUI v0.51.95
2. Send any message
3. Both the user message and AI response appear twice

v0.51.90 is not affected.

Closes #2616

@nesquena Could you review and merge? One-line fix for the regression introduced in stage-387/388.