### PR TITLE
Fix cron run output truncation in task detail

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -569,8 +569,6 @@ def _cron_output_content_window(text: str, limit: int = _CRON_OUTPUT_CONTENT_LIM
     return text[-limit:]
 
 
-
-
 def _cron_job_for_api(job: dict) -> dict:
     """Return a cron job payload with optional UI settings normalized.
 
@@ -744,6 +742,24 @@ def _run_cron_job_in_profile_subprocess(job, execution_profile_home):
     if traceback_text:
         logger.error("Manual cron subprocess failed:\n%s", traceback_text)
     raise RuntimeError(message)
+
+
+def _resolve_cron_output_file(job_id: str, filename: str) -> Path:
+    """Resolve one cron output markdown file under the per-job output dir."""
+    if not job_id:
+        raise ValueError("job_id required")
+    if not filename:
+        raise ValueError("file required")
+    safe_name = Path(filename).name
+    if safe_name != filename or Path(safe_name).suffix.lower() != ".md":
+        raise ValueError("invalid file")
+    hermes_home = Path(os.getenv("HERMES_HOME", str(Path.home() / ".hermes"))).expanduser()
+    out_root = hermes_home / "cron" / "output"
+    out_dir = (out_root / job_id).resolve()
+    target = (out_dir / safe_name).resolve()
+    if os.path.commonpath([str(target), str(out_dir)]) != str(out_dir):
+        raise ValueError("invalid file")
+    return target
 
 
 def _run_cron_tracked(job, profile_home=None, execution_profile_home=None):
@@ -4332,6 +4348,9 @@ def handle_get(handler, parsed) -> bool:
         with cron_profile_context():
             return _handle_cron_run_detail(handler, parsed)
 
+    if parsed.path == "/api/crons/output/raw":
+        return _handle_cron_output_raw(handler, parsed)
+
     if parsed.path == "/api/crons/recent":
         from api.profiles import cron_profile_context
 
@@ -7600,6 +7619,32 @@ def _handle_cron_output(handler, parsed):
             except Exception:
                 logger.debug("Failed to read cron output file %s", f)
     return j(handler, {"job_id": job_id, "outputs": outputs})
+
+
+def _handle_cron_output_raw(handler, parsed):
+    qs = parse_qs(parsed.query)
+    job_id = qs.get("job_id", [""])[0]
+    filename = qs.get("file", [""])[0]
+    force_download = qs.get("download", [""])[0] == "1"
+    try:
+        target = _resolve_cron_output_file(job_id, filename)
+    except ValueError as e:
+        return bad(handler, str(e), 400)
+    if not target.exists() or not target.is_file():
+        return j(handler, {"error": "not found"}, status=404)
+    if force_download:
+        return _serve_file_bytes(
+            handler,
+            target,
+            "text/markdown; charset=utf-8",
+            "attachment",
+            "no-store",
+        )
+    try:
+        content = target.read_text(encoding="utf-8", errors="replace")
+    except Exception:
+        return bad(handler, "Could not read file", 500)
+    return j(handler, {"job_id": job_id, "filename": target.name, "content": content})
 
 
 def _handle_cron_status(handler, parsed):

--- a/static/panels.js
+++ b/static/panels.js
@@ -658,29 +658,25 @@ async function _loadRunContent(jobId, filename, runId){
       body.textContent = data.error;
       return;
     }
-    // Render markdown content using the same renderer as chat messages
+    const rawUrl = `/api/crons/output/raw?job_id=${encodeURIComponent(jobId)}&file=${encodeURIComponent(filename)}&download=1`;
+    const actions = document.createElement('div');
+    actions.className = 'detail-run-body-actions';
+    actions.innerHTML = `<a class="detail-run-download" href="${rawUrl}" download="${esc(filename)}">Download raw</a>`;
+    const content = document.createElement('div');
     if (typeof renderMd === 'function') {
-      body.innerHTML = renderMd(data.snippet || data.content);
+      content.innerHTML = renderMd(data.content || data.snippet);
     } else {
-      body.textContent = data.snippet || data.content;
+      content.textContent = data.content || data.snippet;
     }
+    body.innerHTML = '';
+    body.appendChild(actions);
+    body.appendChild(content);
     const usageStrip = _formatCronRunUsageStrip(data.usage);
     if (usageStrip) {
       const usage = document.createElement('div');
       usage.className = 'cron-run-usage-strip cron-run-usage-footer';
       usage.textContent = usageStrip;
       body.appendChild(usage);
-    }
-    // Show "View full output" button if content was truncated
-    if (data.content && data.snippet && data.content.length > data.snippet.length) {
-      const btn = document.createElement('button');
-      btn.style.cssText = 'margin-top:8px;padding:4px 12px;border-radius:var(--radius-btn);border:1px solid var(--border-subtle);background:var(--surface-subtle);color:var(--text-secondary);cursor:pointer;font-size:12px';
-      btn.textContent = t('cron_view_full_output') || 'View full output';
-      btn.onclick = () => {
-        body.innerHTML = renderMd ? renderMd(data.content) : '';
-        btn.remove();
-      };
-      body.appendChild(btn);
     }
   } catch(e) {
     body.textContent = 'Error: ' + e.message;

--- a/static/style.css
+++ b/static/style.css
@@ -3721,6 +3721,9 @@ main.main > .main-view:not([id="mainChat"]):not([id="mainSettings"]) .main-view-
 .detail-run-head{display:flex;align-items:center;justify-content:space-between;cursor:pointer;font-size:12px;color:var(--muted);}
 .detail-run-actions{display:flex;align-items:center;gap:8px;flex-shrink:0;}
 .detail-run-body{display:none;margin-top:6px;font-size:12px;color:var(--muted);white-space:pre-wrap;line-height:1.5;max-height:260px;overflow-y:auto;background:var(--sidebar);border:1px solid var(--border);border-radius:6px;padding:8px 10px;}
+.detail-run-body-actions{display:flex;justify-content:flex-end;margin-bottom:8px;}
+.detail-run-download{font-size:12px;color:var(--accent-text);text-decoration:none;}
+.detail-run-download:hover{text-decoration:underline;}
 .detail-run-item.open .detail-run-body{display:block;}
 .detail-run-body.expanded{max-height:none;overflow-y:visible;}
 .cron-run-usage-strip{display:inline-flex;align-items:center;gap:4px;margin-left:8px;color:var(--text-secondary);font-size:11px;opacity:.72;white-space:nowrap;}

--- a/tests/test_sprint10.py
+++ b/tests/test_sprint10.py
@@ -104,12 +104,23 @@ def test_crons_output_limit_param(cleanup_test_sessions):
     # 404 or 200 with empty -- both acceptable for nonexistent job
     assert status in (200, 404)
 
+def test_cron_output_raw_requires_file(cleanup_test_sessions):
+    try:
+        data, status = get("/api/crons/output/raw?job_id=nonexistent")
+        assert status == 400
+        assert "file required" in data["error"]
+    except urllib.error.HTTPError as e:
+        assert e.code == 400
+        body = json.loads(e.read())
+        assert "file required" in body["error"]
+
 def test_cron_history_button_in_panels_js(cleanup_test_sessions):
     src, _ = get_text("/static/panels.js")
     # After the main-view refactor, cron runs load inline into the detail card
     # via _loadCronDetailRuns() instead of a separate "All runs" button.
     assert "_loadCronDetailRuns" in src
     assert "cron_last_output" in src  # i18n key used by the runs card
+    assert "/api/crons/output/raw" in src
 
 def test_cron_output_snippet_helper(cleanup_test_sessions):
     src, _ = get_text("/static/panels.js")
@@ -182,6 +193,31 @@ def test_cron_output_window_without_response_uses_tail(cleanup_test_sessions):
     assert len(window) == 8000
     assert window.endswith("tail result")
     assert "old prompt" not in window
+
+
+def test_resolve_cron_output_file_rejects_traversal(cleanup_test_sessions):
+    from api.routes import _resolve_cron_output_file
+    import pytest
+
+    with pytest.raises(ValueError):
+        _resolve_cron_output_file("job123", "../secret.txt")
+
+
+def test_cron_output_raw_reads_full_file(cleanup_test_sessions):
+    from pathlib import Path
+    import os
+
+    job_id = "test-raw-job"
+    out_dir = Path(os.environ["HERMES_HOME"]) / "cron" / "output" / job_id
+    out_dir.mkdir(parents=True, exist_ok=True)
+    target = out_dir / "2026-05-20_19-42-00.md"
+    content = "# Cron Job\n\n## Response\n" + ("line\n" * 400)
+    target.write_text(content, encoding="utf-8")
+
+    data, status = get(f"/api/crons/output/raw?job_id={urllib.parse.quote(job_id)}&file={urllib.parse.quote(target.name)}")
+    assert status == 200
+    assert data["filename"] == target.name
+    assert data["content"] == content
 
 # ── Tool card polish ───────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary\n\n- show the full saved cron run output as soon as a run row is expanded\n- add a raw download link for the underlying cron output markdown file\n- add a dedicated `/api/crons/output/raw` endpoint with traversal protection\n- add regression coverage for the new endpoint and path validation\n\nCloses #2629.\n\n## Testing\n\n- `/home/hacker2005/miniconda3/envs/hermes-agent/bin/python3 -m pytest tests/test_sprint10.py -q`\n\n## Notes\n\nThis keeps the existing run history list and usage strip intact. The only UX change is that expanding a run now shows the full content immediately instead of making the user click an extra "View full output" button.\n
