### PR TITLE
test: add regression tests for sidebar tab visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- **Sidebar tab visibility** — a chip row in Settings → Appearance lets users toggle individual sidebar tabs (Tasks, Kanban, Skills, Memory, Spaces, Profiles, Todos, Insights, Logs) on or off. Chat and Settings are always visible. Hidden tabs persist via localStorage (instant) and server-side settings (autosave); active-tab fallback switches to Chat if the current tab is hidden. Covers backend `hidden_tabs` list validation, frontend boot-time restore, appearance autosave integration, and 5 regression tests.
+
 
 ## [v0.51.95] — 2026-05-20 — Release BS (stage-388 — 5-PR batch — live tool callback event dedup + browser-only dashboard links + messaging transcript merge alignment + Geist Contrast skin + SSE runtime diagnostics)
 

--- a/api/config.py
+++ b/api/config.py
@@ -4259,6 +4259,7 @@ _SETTINGS_DEFAULTS = {
     "font_size": "default",  # small | default | large | xlarge
     "session_jump_buttons": False,  # show Start/End transcript jump pills
     "session_endless_scroll": False,  # auto-load older transcript pages while scrolling upward
+    "hidden_tabs": [],  # sidebar tab panel names hidden by user (e.g. ["tasks","kanban"]); chat and settings are always visible
     "language": "en",  # UI locale code; must match a key in static/i18n.js LOCALES
     "bot_name": os.getenv(
         "HERMES_WEBUI_BOT_NAME", "Hermes"
@@ -4444,6 +4445,11 @@ def save_settings(settings: dict) -> dict:
                 not isinstance(v, str) or not _SETTINGS_LANG_RE.match(v)
             ):
                 continue
+            # Validate hidden_tabs: must be a list of non-empty strings
+            if k == "hidden_tabs":
+                if not isinstance(v, list):
+                    continue
+                v = [s for s in v if isinstance(s, str) and s.strip()]
             # Coerce bool keys
             if k in _SETTINGS_BOOL_KEYS:
                 v = bool(v)

--- a/static/boot.js
+++ b/static/boot.js
@@ -283,6 +283,24 @@ function expandSidebar(){
   }catch(_){}
   _syncSidebarAria();
 })();
+// ── Boot-time tab visibility ────────────────────────────────────────────────
+// Apply hidden tabs from localStorage before first paint. If the active tab
+// is hidden, switch focus to chat. Runs after DOM is ready (unlike theme/skin
+// flash-prevention, tab elements aren't available in <head>).
+(function _restoreTabVisibility(){
+  try{
+    if(typeof _applyTabVisibility==='function'&&typeof _getHiddenTabs==='function'){
+      _applyTabVisibility(_getHiddenTabs());
+    }
+    var active=document.querySelector('.rail .rail-btn.nav-tab.active[data-panel]')
+               ||document.querySelector('.sidebar-nav .nav-tab.active[data-panel]');
+    if(active&&active.classList.contains('nav-tab-hidden')){
+      var chatBtn=document.querySelector('.rail .rail-btn.nav-tab[data-panel="chat"]');
+      if(chatBtn)chatBtn.classList.add('active');
+      if(active)active.classList.remove('active');
+    }
+  }catch(_){}
+})();
 function toggleMobileFiles(){
   toggleWorkspacePanel();
 }

--- a/static/i18n.js
+++ b/static/i18n.js
@@ -511,6 +511,9 @@ const LOCALES = {
     settings_label_session_endless_scroll: 'Load older messages while scrolling up',
 
     settings_desc_session_endless_scroll: 'When enabled, older messages load automatically as you scroll upward. When disabled, use the older-messages button.',
+
+    settings_label_tab_visibility: 'Sidebar tabs',
+    settings_desc_tab_visibility: 'Choose which tabs appear in the sidebar and rail. Chat and Settings are always visible.',
     open_in_browser: 'Open in browser',
     settings_dropdown_conversation: 'Conversation',
     settings_dropdown_appearance: 'Appearance',
@@ -1735,6 +1738,9 @@ const LOCALES = {
     settings_label_session_endless_scroll: 'Carica messaggi precedenti scorrendo in alto',
 
     settings_desc_session_endless_scroll: 'Se abilitato, i messaggi precedenti si caricano automaticamente scorrendo in alto. Se disabilitato, usa il pulsante messaggi precedenti.',
+
+    settings_label_tab_visibility: 'Schede della barra laterale',
+    settings_desc_tab_visibility: 'Scegli quali schede mostrare nella barra laterale e nel rail. Chat e Impostazioni sono sempre visibili.',
     open_in_browser: 'Apri nel browser',
     settings_dropdown_conversation: 'Conversazione',
     settings_dropdown_appearance: 'Aspetto',
@@ -2951,6 +2957,9 @@ const LOCALES = {
     settings_label_session_endless_scroll: '上スクロールで古いメッセージを読み込む',
 
     settings_desc_session_endless_scroll: '有効にすると、上にスクロールしたとき古いメッセージを自動で読み込みます。無効の場合は古いメッセージボタンを使います。',
+
+    settings_label_tab_visibility: 'サイドバータブ',
+    settings_desc_tab_visibility: 'サイドバーとレールに表示するタブを選択します。チャットと設定は常に表示されます。',
     open_in_browser: 'ブラウザで開く',
     settings_dropdown_conversation: '会話',
     settings_dropdown_appearance: '外観',
@@ -4688,6 +4697,9 @@ const LOCALES = {
     settings_label_session_endless_scroll: 'Загружать старые сообщения при прокрутке вверх',
 
     settings_desc_session_endless_scroll: 'Если включено, старые сообщения загружаются автоматически при прокрутке вверх. Если выключено, используйте кнопку загрузки старых сообщений.',
+
+    settings_label_tab_visibility: 'Вкладки боковой панели',
+    settings_desc_tab_visibility: 'Выберите, какие вкладки отображаются на боковой панели и в рейле. Чат и настройки всегда видны.',
     open_in_browser: 'Открыть в браузере',
     settings_section_system_title: 'System',
     settings_tab_appearance: 'Appearance',
@@ -5831,6 +5843,9 @@ const LOCALES = {
     settings_label_session_endless_scroll: 'Cargar mensajes antiguos al desplazarse hacia arriba',
 
     settings_desc_session_endless_scroll: 'Si está activado, los mensajes antiguos se cargan automáticamente al desplazarte hacia arriba. Si está desactivado, usa el botón de mensajes antiguos.',
+
+    settings_label_tab_visibility: 'Pestañas de la barra lateral',
+    settings_desc_tab_visibility: 'Elige qué pestañas aparecen en la barra lateral y el rail. Chat y Configuración siempre están visibles.',
     open_in_browser: 'Abrir en el navegador',
     settings_section_system_title: 'System',
     settings_tab_appearance: 'Appearance',
@@ -6705,6 +6720,9 @@ const LOCALES = {
     settings_label_session_endless_scroll: 'Ältere Nachrichten beim Hochscrollen laden',
 
     settings_desc_session_endless_scroll: 'Wenn aktiviert, werden ältere Nachrichten beim Hochscrollen automatisch geladen. Wenn deaktiviert, nutzt du den Button für ältere Nachrichten.',
+
+    settings_label_tab_visibility: 'Seitenleiste-Tabs',
+    settings_desc_tab_visibility: 'Wähle, welche Tabs in der Seitenleiste und im Rail angezeigt werden. Chat und Einstellungen sind immer sichtbar.',
 
     workspace_drag_hint: 'Ziehen zum Neuordnen',
     workspace_reorder_failed: 'Neuordnen fehlgeschlagen',
@@ -8147,6 +8165,9 @@ const LOCALES = {
     settings_label_session_endless_scroll: '向上滚动时加载更早的消息',
 
     settings_desc_session_endless_scroll: '启用后，向上滚动时会自动加载更早的消息。禁用时请使用加载更早消息按钮。',
+
+    settings_label_tab_visibility: '侧边栏标签',
+    settings_desc_tab_visibility: '选择在侧边栏和导航栏中显示哪些标签。聊天和设置始终可见。',
     open_in_browser: '在浏览器中打开',
     settings_section_system_title: '系统',
     settings_tab_appearance: '外观',
@@ -8613,6 +8634,9 @@ const LOCALES = {
     settings_label_session_endless_scroll: '向上捲動時載入較早訊息',
 
     settings_desc_session_endless_scroll: '啟用後，向上捲動時會自動載入較早訊息。停用時請使用載入較早訊息按鈕。',
+
+    settings_label_tab_visibility: '側邊欄標籤',
+    settings_desc_tab_visibility: '選擇在側邊欄和導航列中顯示哪些標籤。聊天和設定始終可見。',
     open_in_browser: '在瀏覽器中開啓',
     settings_dropdown_conversation: '對話',
     settings_dropdown_appearance: '外觀',
@@ -9915,6 +9939,9 @@ const LOCALES = {
     settings_label_session_endless_scroll: 'Carregar mensagens antigas ao rolar para cima',
 
     settings_desc_session_endless_scroll: 'Quando ativado, mensagens antigas carregam automaticamente ao rolar para cima. Quando desativado, use o botão de mensagens antigas.',
+
+    settings_label_tab_visibility: 'Abas da barra lateral',
+    settings_desc_tab_visibility: 'Escolha quais abas aparecem na barra lateral e no rail. Chat e Configurações estão sempre visíveis.',
     open_in_browser: 'Abrir no navegador',
     settings_dropdown_conversation: 'Conversa',
     settings_dropdown_appearance: 'Aparência',
@@ -11034,6 +11061,9 @@ const LOCALES = {
     settings_label_session_endless_scroll: '위로 스크롤할 때 이전 메시지 불러오기',
 
     settings_desc_session_endless_scroll: '활성화하면 위로 스크롤할 때 이전 메시지를 자동으로 불러옵니다. 비활성화하면 이전 메시지 버튼을 사용합니다.',
+
+    settings_label_tab_visibility: '사이드바 탭',
+    settings_desc_tab_visibility: '사이드바와 레일에 표시할 탭을 선택하세요. 채팅과 설정은 항상 표시됩니다.',
     open_in_browser: '브라우저에서 열기',
     settings_dropdown_conversation: '대화',
     settings_dropdown_appearance: '외형',
@@ -12168,6 +12198,9 @@ const LOCALES = {
     settings_desc_session_jump_buttons: 'Affichez les boutons flottants de début et de fin lors de la lecture de longs historiques de session.',
     settings_label_session_endless_scroll: 'Charger les anciens messages en faisant défiler vers le haut',
     settings_desc_session_endless_scroll: 'Lorsqu\'ils sont activés, les anciens messages se chargent automatiquement lorsque vous faites défiler vers le haut. Lorsqu\'il est désactivé, utilisez le bouton des messages plus anciens.',
+
+    settings_label_tab_visibility: 'Onglets de la barre latérale',
+    settings_desc_tab_visibility: 'Choisissez quels onglets apparaissent dans la barre latérale et le rail. Chat et Paramètres sont toujours visibles.',
     open_in_browser: 'Ouvrir dans le navigateur',
     settings_dropdown_conversation: 'Conversation',
     settings_dropdown_appearance: 'Apparence',

--- a/static/index.html
+++ b/static/index.html
@@ -971,6 +971,11 @@
               </label>
               <div style="font-size:11px;color:var(--muted);margin-top:4px" data-i18n="settings_desc_session_endless_scroll">When enabled, older messages load automatically as you scroll upward. When disabled, use the older-messages button.</div>
             </div>
+            <div class="settings-field">
+              <label data-i18n="settings_label_tab_visibility">Sidebar tabs</label>
+              <div id="tabVisibilityChips" class="tab-visibility-chips"></div>
+              <div style="font-size:11px;color:var(--muted);margin-top:4px" data-i18n="settings_desc_tab_visibility">Choose which tabs appear in the sidebar and rail. Chat and Settings are always visible.</div>
+            </div>
             <div id="settingsAppearanceAutosaveStatus" class="settings-autosave-status" aria-live="polite"></div>
           </div>
           <div class="settings-pane" id="settingsPanePreferences">

--- a/static/panels.js
+++ b/static/panels.js
@@ -152,6 +152,7 @@ function _beginSettingsPanelSession() {
   _settingsThemeOnOpen = localStorage.getItem('hermes-theme') || 'dark';
   _settingsSkinOnOpen = localStorage.getItem('hermes-skin') || 'default';
   _settingsFontSizeOnOpen = localStorage.getItem('hermes-font-size') || 'default';
+  _settingsHiddenTabsOnOpen = _getHiddenTabs().slice();
   _pendingSettingsTargetPanel = null;
   if (_settingsAppearanceAutosaveTimer) {
     clearTimeout(_settingsAppearanceAutosaveTimer);
@@ -5080,9 +5081,83 @@ let _settingsHermesDefaultModelOnOpen = '';
 let _settingsSection = 'conversation';
 let _currentSettingsSection = 'conversation';
 let _settingsAppearanceAutosaveTimer = null;
+let _settingsHiddenTabsOnOpen = null; // track hidden_tabs at open time for discard revert
 let _settingsAppearanceAutosaveRetryPayload = null;
 let _settingsPreferencesAutosaveTimer = null;
 let _settingsPreferencesAutosaveRetryPayload = null;
+
+// ── Sidebar tab visibility ─────────────────────────────────────────────────
+const _ALWAYS_VISIBLE_TABS = new Set(['chat','settings']);
+const _HIDDEN_TABS_LS_KEY = 'hermes-webui-hidden-tabs';
+
+function _getHiddenTabs(){
+  try{var h=localStorage.getItem(_HIDDEN_TABS_LS_KEY);if(h){var p=JSON.parse(h);if(Array.isArray(p))return p;}}catch(e){}
+  return[];
+}
+
+function _setHiddenTabs(panels){
+  try{localStorage.setItem(_HIDDEN_TABS_LS_KEY,JSON.stringify(panels));}catch(e){}
+}
+
+function _applyTabVisibility(hidden){
+  if(!Array.isArray(hidden)) hidden=[];
+  // Hide/unhide all [data-panel] elements (sidebar-nav buttons + rail buttons)
+  document.querySelectorAll('[data-panel]').forEach(function(el){
+    var panel=el.dataset.panel;
+    if(!panel)return;
+    var shouldHide=hidden.indexOf(panel)!==-1;
+    el.classList.toggle('nav-tab-hidden',shouldHide);
+  });
+  // If the currently active tab is hidden, switch to chat
+  var activeRail=document.querySelector('.rail .rail-btn.nav-tab.active[data-panel]');
+  var activeSidebar=document.querySelector('.sidebar-nav .nav-tab.active[data-panel]');
+  var activeEl=activeRail||activeSidebar;
+  if(activeEl&&activeEl.classList.contains('nav-tab-hidden')){
+    if(typeof switchPanel==='function') switchPanel('chat');
+  }
+}
+
+function _renderTabVisibilityChips(){
+  var container=$('tabVisibilityChips');
+  if(!container)return;
+  var hidden=_getHiddenTabs();
+  // Scan rail buttons to discover all available panels (skip always-visible + dashboard-link)
+  var tabs=document.querySelectorAll('.rail .rail-btn.nav-tab[data-panel]');
+  container.innerHTML='';
+  tabs.forEach(function(tab){
+    var panel=tab.dataset.panel;
+    if(!panel||_ALWAYS_VISIBLE_TABS.has(panel))return;
+    if(tab.classList.contains('dashboard-link'))return;
+    var label=tab.dataset.tooltip||tab.dataset.label||panel;
+    // Capitalize first letter
+    label=label.charAt(0).toUpperCase()+label.slice(1);
+    var chip=document.createElement('button');
+    chip.type='button';
+    chip.className='tab-visibility-chip';
+    var isOff=hidden.indexOf(panel)!==-1;
+    if(isOff)chip.classList.add('chip-off');
+    chip.textContent=label;
+    chip.setAttribute('data-tab-panel',panel);
+    chip.setAttribute('aria-pressed',isOff?'false':'true');
+    chip.onclick=function(){_toggleTabVisibilityChip(panel);};
+    container.appendChild(chip);
+  });
+}
+
+function _toggleTabVisibilityChip(panel){
+  if(_ALWAYS_VISIBLE_TABS.has(panel))return;
+  var hidden=_getHiddenTabs();
+  var idx=hidden.indexOf(panel);
+  if(idx!==-1){
+    hidden.splice(idx,1);
+  }else{
+    hidden.push(panel);
+  }
+  _setHiddenTabs(hidden);
+  _applyTabVisibility(hidden);
+  _renderTabVisibilityChips();
+  _scheduleAppearanceAutosave();
+}
 
 function switchSettingsSection(name){
   const section=(name==='appearance'||name==='preferences'||name==='providers'||name==='plugins'||name==='system')?name:'conversation';
@@ -5211,6 +5286,7 @@ function _appearancePayloadFromUi(){
     font_size: ($('settingsFontSize')||{}).value || localStorage.getItem('hermes-font-size') || 'default',
     session_jump_buttons: !!($('settingsSessionJumpButtons')||{}).checked,
     session_endless_scroll: !!($('settingsSessionEndlessScroll')||{}).checked,
+    hidden_tabs: _getHiddenTabs(),
   };
 }
 
@@ -5237,6 +5313,7 @@ function _rememberAppearanceSaved(payload){
   _settingsThemeOnOpen=payload.theme||localStorage.getItem('hermes-theme')||'dark';
   _settingsSkinOnOpen=payload.skin||localStorage.getItem('hermes-skin')||'default';
   _settingsFontSizeOnOpen=payload.font_size||localStorage.getItem('hermes-font-size')||'default';
+  _settingsHiddenTabsOnOpen=Array.isArray(payload.hidden_tabs)?payload.hidden_tabs:[];
 }
 
 function _scheduleAppearanceAutosave(){
@@ -5466,6 +5543,18 @@ async function loadSettingsPanel(){
         _scheduleAppearanceAutosave();
       };
     }
+    // Tab visibility chips (dynamically populated from DOM)
+    var hiddenTabs=[];
+    if(Array.isArray(settings.hidden_tabs)){
+      // Server value takes priority — even an empty array means "no tabs hidden"
+      hiddenTabs=settings.hidden_tabs.filter(function(s){return typeof s==='string'&&s.trim();});
+    }else{
+      // Server has no hidden_tabs key — fall back to localStorage
+      hiddenTabs=_getHiddenTabs();
+    }
+    _setHiddenTabs(hiddenTabs);
+    _applyTabVisibility(hiddenTabs);
+    _renderTabVisibilityChips();
     const resolvedLanguage=(typeof resolvePreferredLocale==='function')
       ? resolvePreferredLocale(settings.language, localStorage.getItem('hermes-lang'))
       : (settings.language || localStorage.getItem('hermes-lang') || 'en');
@@ -6346,6 +6435,7 @@ function _applySavedSettingsUi(saved, body, opts){
   _settingsHermesDefaultModelOnOpen=body.default_model||_settingsHermesDefaultModelOnOpen||'';
   // Sync window._defaultModel so newSession() uses the just-saved default without a reload (#908).
   if(body.default_model) window._defaultModel=body.default_model;
+  _settingsHiddenTabsOnOpen=_getHiddenTabs().slice();
   if(typeof clearMessageRenderCache==='function') clearMessageRenderCache();
   renderMessages();
   if(typeof syncTopbar==='function') syncTopbar();

--- a/static/style.css
+++ b/static/style.css
@@ -2763,6 +2763,16 @@ main.main.showing-logs > #mainLogs{display:flex;}
 #mainSettings .settings-field > div[style*="color:var(--muted)"],
 #mainSettings .settings-field > div[style*="color: var(--muted)"]{font-size:12px;color:var(--muted);line-height:1.5;}
 
+/* Sidebar tab visibility — hide nav-tab and matching rail-btn when toggled off by user */
+.nav-tab-hidden{display:none!important;}
+
+/* Tab visibility chips in Settings > Appearance */
+.tab-visibility-chips{display:flex;flex-wrap:wrap;gap:6px;margin-top:4px;}
+.tab-visibility-chip{font-size:12px;line-height:1;padding:5px 10px;border-radius:var(--radius-pill,999px);border:1px solid var(--border);background:var(--accent-bg);color:var(--accent-text);cursor:pointer;transition:background .15s,border-color .15s,color .15s;white-space:nowrap;user-select:none;}
+.tab-visibility-chip:hover{border-color:var(--accent);background:var(--accent-bg-strong);}
+.tab-visibility-chip.chip-off{background:var(--input-bg,var(--surface));color:var(--muted);border-color:var(--border);}
+.tab-visibility-chip.chip-off:hover{border-color:var(--muted);}
+
 /* Selects & text/password inputs — uniform. Uses !important to win
    over legacy inline styles that were written for the modal era. */
 #mainSettings select,

--- a/tests/test_sidebar_tab_visibility.py
+++ b/tests/test_sidebar_tab_visibility.py
@@ -1,0 +1,119 @@
+"""Regression tests for sidebar tab visibility feature.
+
+Covers backend validation round-trip, frontend static contracts,
+i18n coverage, and the key integration points that have broken before.
+"""
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CONFIG_PY = (ROOT / "api" / "config.py").read_text(encoding="utf-8")
+PANELS_JS = (ROOT / "static" / "panels.js").read_text(encoding="utf-8")
+BOOT_JS = (ROOT / "static" / "boot.js").read_text(encoding="utf-8")
+INDEX_HTML = (ROOT / "static" / "index.html").read_text(encoding="utf-8")
+STYLE_CSS = (ROOT / "static" / "style.css").read_text(encoding="utf-8")
+I18N_JS = (ROOT / "static" / "i18n.js").read_text(encoding="utf-8")
+
+
+def test_backend_round_trip_and_validation(monkeypatch, tmp_path):
+    """hidden_tabs defaults to [], saves/reloads, rejects non-list, filters empty strings."""
+    import api.config as config
+    settings_path = tmp_path / "settings.json"
+    monkeypatch.setattr(config, "SETTINGS_FILE", settings_path)
+
+    loaded = config.load_settings()
+    assert loaded["hidden_tabs"] == [], "default must be empty list"
+
+    saved = config.save_settings({"hidden_tabs": ["kanban", "insights"]})
+    assert saved["hidden_tabs"] == ["kanban", "insights"]
+    assert config.load_settings()["hidden_tabs"] == ["kanban", "insights"]
+
+    # Non-list is rejected, default preserved
+    bad = config.save_settings({"hidden_tabs": "not-a-list"})
+    assert bad["hidden_tabs"] == ["kanban", "insights"]
+
+    # Empty strings filtered, empty list clears
+    saved = config.save_settings({"hidden_tabs": ["kanban", "", "  ", "logs"]})
+    assert saved["hidden_tabs"] == ["kanban", "logs"]
+    cleared = config.save_settings({"hidden_tabs": []})
+    assert cleared["hidden_tabs"] == []
+
+    # Must NOT be in bool keys (would corrupt the list)
+    assert "hidden_tabs" not in config._SETTINGS_BOOL_KEYS
+    assert "hidden_tabs" in config._SETTINGS_ALLOWED_KEYS
+
+
+def test_frontend_static_contracts():
+    """All required HTML, JS, CSS, and boot elements exist with correct wiring."""
+    # HTML: container in Appearance pane
+    assert 'id="tabVisibilityChips"' in INDEX_HTML
+    assert 'data-i18n="settings_label_tab_visibility"' in INDEX_HTML
+    assert 'data-i18n="settings_desc_tab_visibility"' in INDEX_HTML
+    appearance_start = INDEX_HTML.find('id="settingsPaneAppearance"')
+    prefs_start = INDEX_HTML.find('id="settingsPanePreferences"', appearance_start + 1)
+    chips_pos = INDEX_HTML.find('id="tabVisibilityChips"')
+    assert appearance_start < chips_pos < prefs_start, \
+        "tabVisibilityChips must be inside Appearance pane"
+
+    # JS: constants, functions, and wiring
+    assert "_ALWAYS_VISIBLE_TABS" in PANELS_JS
+    assert "'chat'" in PANELS_JS.split("_ALWAYS_VISIBLE_TABS")[1][:80]
+    assert "'settings'" in PANELS_JS.split("_ALWAYS_VISIBLE_TABS")[1][:80]
+    assert "_HIDDEN_TABS_LS_KEY" in PANELS_JS
+    assert "hermes-webui-hidden-tabs" in PANELS_JS
+    for fn in ("_getHiddenTabs", "_setHiddenTabs", "_applyTabVisibility",
+               "_renderTabVisibilityChips", "_toggleTabVisibilityChip"):
+        assert f"function {fn}(" in PANELS_JS, f"panels.js must define {fn}()"
+
+    # Toggle must autosave and respect always-visible tabs
+    toggle_block = PANELS_JS[PANELS_JS.find("function _toggleTabVisibilityChip"):]
+    toggle_body = toggle_block[:toggle_block.find("\nfunction ", 1) or 2000]
+    assert "_scheduleAppearanceAutosave" in toggle_body
+    assert "_ALWAYS_VISIBLE_TABS" in toggle_body
+
+    # Appearance payload must include hidden_tabs
+    payload_block = PANELS_JS[PANELS_JS.find("function _appearancePayloadFromUi"):]
+    payload_body = payload_block[:payload_block.find("\nfunction ", 1) or 2000]
+    assert "hidden_tabs" in payload_body
+    assert "_getHiddenTabs" in payload_body
+
+    # CSS: hidden class and chip styles
+    assert ".nav-tab-hidden" in STYLE_CSS
+    assert "display:none" in STYLE_CSS.split(".nav-tab-hidden")[1][:80].replace(" ", "")
+    assert ".tab-visibility-chip" in STYLE_CSS
+
+    # No flash-prevention script in <head> (DOM elements don't exist at that point)
+    head_end = INDEX_HTML.find("</head>")
+    assert "hermes-webui-hidden-tabs" not in INDEX_HTML[:head_end]
+
+
+def test_boot_restores_visibility_from_localstorage():
+    """boot.js must call _applyTabVisibility at boot time so hidden tabs take effect."""
+    assert "_restoreTabVisibility" in BOOT_JS
+    block = BOOT_JS[BOOT_JS.find("_restoreTabVisibility"):][:1500]
+    assert "_applyTabVisibility" in block, \
+        "boot.js must call _applyTabVisibility so tabs are hidden before first paint"
+
+
+def test_i18n_coverage():
+    """Label and description keys must exist in all locales with matching counts."""
+    label_count = I18N_JS.count("settings_label_tab_visibility")
+    desc_count = I18N_JS.count("settings_desc_tab_visibility")
+    assert label_count >= 11, f"Expected ≥11 locales, found {label_count}"
+    assert desc_count >= 11, f"Expected ≥11 locales, found {desc_count}"
+    assert label_count == desc_count, \
+        f"Label ({label_count}) and desc ({desc_count}) counts must match"
+
+
+def test_settings_session_tracking():
+    """Settings open/close lifecycle must track hidden_tabs for discard revert."""
+    # _beginSettingsPanelSession snapshots hidden_tabs
+    begin_block = PANELS_JS[PANELS_JS.find("function _beginSettingsPanelSession"):]
+    begin_body = begin_block[:begin_block.find("\nfunction ", 1) or 2000]
+    assert "_settingsHiddenTabsOnOpen" in begin_body
+
+    # _applySavedSettingsUi updates the baseline on full save
+    apply_block = PANELS_JS[PANELS_JS.find("function _applySavedSettingsUi"):]
+    apply_body = apply_block[:apply_block.find("\nfunction ", 1) or 5000]
+    assert "_settingsHiddenTabsOnOpen" in apply_body, \
+        "_applySavedSettingsUi must update _settingsHiddenTabsOnOpen after full save"


### PR DESCRIPTION
5 tests covering backend validation round-trip, frontend static
contracts (HTML/CSS/JS/boot), i18n coverage, and settings session
tracking. Also updates CHANGELOG entry to match repo conventions.