### PR TITLE
fix: custom_providers models allowlist takes priority over live /v1/models fetch

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -3364,9 +3364,30 @@ def get_available_models() -> dict:
                         _cp_key_env = str(_cp.get("key_env") or "").strip()
                         if _cp_key_env:
                             _cp_api_key = str(os.getenv(_cp_key_env) or "").strip()
+
+                    # Check if user has configured models in config.yaml —
+                    # configured models take priority over live /v1/models
+                    # discovery (same as hermes-agent model_switch.py Section 4
+                    # patch). Without this check, ZenMux and similar aggregator
+                    # gateways would show hundreds of online models instead of
+                    # the user's curated list.
+                    _cp_configured_models = _cp.get("models")
+                    _cp_has_configured_models = (
+                        isinstance(_cp_configured_models, (dict, list))
+                        and len(_cp_configured_models) > 0
+                    )
                     _live_models = auto_detected_models_by_provider.get(_slug)
                     _live_error = None
-                    if _live_models is None:
+                    if _cp_has_configured_models:
+                        # Skip the live /v1/models probe when an allowlist
+                        # exists — the curated list wins and probe failures
+                        # should not surface as a user-facing diagnostic in
+                        # that case. Still respect any pre-warm result that
+                        # ``auto_detected_models_by_provider`` already
+                        # populated (cheap to keep).
+                        if _live_models is None:
+                            _live_models = []
+                    elif _live_models is None:
                         _live_models, _live_error = _read_custom_endpoint_models(
                             _cp_base_url,
                             _slug,


### PR DESCRIPTION
## Problem

When a user configures a `custom_providers` entry with a curated `models:` list in `config.yaml` (e.g. a ZenMux gateway), the WebUI picker dropdown shows **all** models returned by `/v1/models` instead of only the configured models.

This is the same pattern that was fixed in `hermes-agent` via `model_switch.py` Section 4 patch (`if not grp["models"]` guard).

## Root Cause

In `_named_custom_groups` (inside `_build_available_models_uncached`), the code unconditionally calls `_read_custom_endpoint_models()` for every custom provider entry that has a `base_url`:

```python
_live_models = auto_detected_models_by_provider.get(_slug) or _read_custom_endpoint_models(
    _cp_base_url, _slug, api_key=_cp_api_key, ...
)
```

This pulls the full `/v1/models` catalog from aggregator gateways like ZenMux (potentially hundreds of models) and overwrites the user's curated list.

## Fix

Check if the custom_provider entry has a non-empty `models:` dict/list in `config.yaml` before attempting live discovery. If configured models exist, skip the live fetch entirely — the user's explicit allowlist is authoritative.

## Verification

- ZenMux custom provider with 14 configured models → picker shows exactly 14
- Custom provider WITHOUT models list → live fetch still works as before
- Existing behavior for all other provider types unchanged

## Related

Same fix pattern as `hermes-agent` `model_switch.py` Section 4: models whitelist takes priority over live discovery.