### PR TITLE
fix(session): rebuild missing startup index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Rebuild the WebUI session index during startup recovery when `_index.json` is missing, even when no `.bak` session restore occurs, so large state directories avoid repeated full-scan `/api/sessions` fallback after an index loss.
+
 
 ## [v0.51.95] — 2026-05-20 — Release BS (stage-388 — 5-PR batch — live tool callback event dedup + browser-only dashboard links + messaging transcript merge alignment + Geist Contrast skin + SSE runtime diagnostics)
 

--- a/api/session_recovery.py
+++ b/api/session_recovery.py
@@ -619,12 +619,13 @@ def recover_all_sessions_on_startup(
             "If you weren't expecting this, check the session list for missing "
             "messages — see #1558.", restored, scanned,
         )
-        if rebuild_index:
-            try:
-                from api.models import _write_session_index
+    if rebuild_index:
+        try:
+            from api.models import SESSION_INDEX_FILE, _write_session_index
+            if restored or not SESSION_INDEX_FILE.exists():
                 _write_session_index(updates=None)
-            except Exception as exc:
-                logger.warning("recover_all_sessions_on_startup: index rebuild failed: %s", exc)
+        except Exception as exc:
+            logger.warning("recover_all_sessions_on_startup: index rebuild failed: %s", exc)
     return {
         "scanned": scanned,
         "restored": restored,

--- a/tests/test_metadata_save_wipe_1558.py
+++ b/tests/test_metadata_save_wipe_1558.py
@@ -270,6 +270,24 @@ def test_recover_all_sessions_on_startup_restores_orphan_bak(temp_session_dir):
     assert len(restored["messages"]) == 293
 
 
+def test_recover_all_sessions_on_startup_rebuilds_missing_index_without_restores(temp_session_dir, monkeypatch):
+    """Startup recovery must rebuild a missing index even when no .bak restore runs."""
+    import api.models as _m
+
+    sid = _make_session_on_disk(temp_session_dir, n_msgs=42)
+    missing_index = temp_session_dir / "_index.json"
+    monkeypatch.setattr(_m, "SESSION_INDEX_FILE", missing_index)
+    assert not missing_index.exists()
+
+    from api.session_recovery import recover_all_sessions_on_startup
+    result = recover_all_sessions_on_startup(temp_session_dir, rebuild_index=True)
+
+    assert result["restored"] == 0
+    index = json.loads(missing_index.read_text(encoding="utf-8"))
+    assert [entry["session_id"] for entry in index] == [sid]
+    assert index[0]["message_count"] == 42
+
+
 def test_recover_all_sessions_on_startup_rebuilds_index_after_orphan_restore(temp_session_dir, monkeypatch):
     """A restored orphan must be visible through the WebUI session index immediately."""
     import api.models as _m


### PR DESCRIPTION
## Thinking Path

- Hermes WebUI keeps sidebar/session-list reads fast by maintaining `sessions/_index.json`.
- Startup recovery already accepts `rebuild_index=True`, but the rebuild only ran after a `.bak` restore.
- If `_index.json` is lost without any `.bak` restoration, the server can keep serving `/api/sessions` through the full sidecar scan fallback.
- On large state directories, repeated full scans can make the WebUI appear disconnected or unavailable even though session sidecars are intact.
- This PR keeps the recovery path narrow: rebuild the missing index at startup without changing session storage or UI behavior.

## What Changed

- Move the startup recovery index-rebuild check outside the `restored > 0` branch.
- Rebuild `_index.json` when `rebuild_index=True` and either:
  - recovery restored one or more sessions, or
  - the session index file is missing.
- Add a regression test covering the missing-index/no-restore startup path.
- Add a release-note-ready changelog entry under `Unreleased`.

## Why It Matters

A missing index should be self-healing at startup. Without this guard, large installations can fall back to expensive `/api/sessions` sidecar scans after an index loss, causing slow session-list requests and poor reconnect/reload behavior.

State layer touched: WebUI session metadata index (`sessions/_index.json`). The session JSON sidecars remain the source of truth for rebuilding the index; this PR does not mutate `state.db` or change transcript contents.

## Verification

Local targeted verification:

- `python -m pytest tests/test_metadata_save_wipe_1558.py::test_recover_all_sessions_on_startup_rebuilds_missing_index_without_restores -q`
  - RED before the fix: failed with `FileNotFoundError` because `_index.json` was not rebuilt.
  - GREEN after the fix: passed.
- `python -m py_compile api/session_recovery.py tests/test_metadata_save_wipe_1558.py`
- `python -m pytest tests/test_metadata_save_wipe_1558.py tests/test_turn_journal.py -q` -> `26 passed`
- `git diff --check`
- non-ASCII added-lines guard -> `non_ascii_added_lines=0`

Full local suite attempt:

- `python -m pytest tests/ -q --timeout=60` -> local long-suite run failed after the shared test server stopped responding (`433 failed, 5633 passed, 6 skipped, 3 xfailed`; representative failures were `urllib.error.URLError: [Errno 111] Connection refused` against the isolated pytest server port).
- To isolate that failure shape, reran representative server-backed tests fresh: `python -m pytest tests/test_sprint8.py::test_index_html_contains_prism tests/test_sprint9.py::test_ui_js_served -q --timeout=60` -> `2 passed`.
- GitHub Actions full-suite signal: `test (3.11)`, `test (3.12)`, and `test (3.13)` all passed.

## Risks / Follow-ups

Low risk. The change only adds a missing-index rebuild to an existing best-effort startup recovery hook, and preserves the existing `.bak` restore rebuild behavior. The rebuild remains guarded by `rebuild_index=True`, and recovery failures still log warnings instead of blocking startup.

This does not redesign `/api/sessions` fallback behavior or address corrupt-but-present index files; those can be separate follow-ups if needed.

## Model Used

OpenAI GPT-5.5 via Hermes Agent CLI, with repository file/terminal tools for inspection, test execution, commit, and PR creation.
