### PR TITLE
Release v0.51.97 (Release BU / stage-390 / 3-PR batch)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Rebuild the WebUI session index during startup recovery when `_index.json` is missing, even when no `.bak` session restore occurs, so large state directories avoid repeated full-scan `/api/sessions` fallback after an index loss.
+
 
 ## [v0.51.95] — 2026-05-20 — Release BS (stage-388 — 5-PR batch — live tool callback event dedup + browser-only dashboard links + messaging transcript merge alignment + Geist Contrast skin + SSE runtime diagnostics)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,16 @@
 
 ## [Unreleased]
 
+
+## [v0.51.97] — 2026-05-20 — Release BU (stage-390 — 2-PR batch — startup session-index rebuild + config-managed custom-provider cards)
+
 ### Fixed
 
-- Rebuild the WebUI session index during startup recovery when `_index.json` is missing, even when no `.bak` session restore occurs, so large state directories avoid repeated full-scan `/api/sessions` fallback after an index loss.
+- **PR #2642** by @dso2ng — Rebuild the WebUI session index during startup recovery when `_index.json` is missing, even when no `.bak` session restore occurs. Previously the rebuild only ran after a `.bak` restore path, leaving large state directories on a repeated full-scan `/api/sessions` fallback after an index loss. Startup recovery now unconditionally calls `_write_session_index()` when no `_index.json` is present on disk, restoring the O(1) sidebar read path.
 
+### Added
+
+- **PR #2634** by @Michaelyklam (closes #2632) — Show `custom_providers` entries created by `hermes model` (CLI) in Settings → Providers as read-only config-managed provider cards, including their configured models and key status, instead of filtering them out because they are not WebUI-editable API-key providers. The new card variant displays configured models, key-env status (set/unset), and a "config-managed" badge that links to the CLI as the canonical edit surface.
 
 ## [v0.51.96] — 2026-05-20 — Release BT (stage-389 — 8-PR batch — IPv6 dashboard link normalization + configured title-generation provider routing + sidebar pinned-session 3-cap + external-refresh sidecar count preference + Hermes overview docs relocation + legacy dedup timestamp granularity + custom provider /models endpoint error surfacing + RuntimeAdapter Slice 4c harness gate RFC)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- **PR #2634** by @Michaelyklam (closes #2632) — Show `custom_providers` entries created by `hermes model` in Settings → Providers as read-only config-managed provider cards, including their configured models and key status, instead of filtering them out because they are not WebUI-editable API-key providers.
+
 
 ## [v0.51.95] — 2026-05-20 — Release BS (stage-388 — 5-PR batch — live tool callback event dedup + browser-only dashboard links + messaging transcript merge alignment + Geist Contrast skin + SSE runtime diagnostics)
 

--- a/api/providers.py
+++ b/api/providers.py
@@ -1984,8 +1984,10 @@ def get_providers() -> dict[str, Any]:
                 "display_name": cp_name,
                 "has_key": cp_has_key,
                 "configurable": False,  # custom providers managed via config.yaml
+                "is_custom": True,
                 "key_source": "config_yaml" if cp_has_key else "none",
                 "models": cp_models,
+                "models_total": len(cp_models),
             })
 
     # Determine active provider

--- a/api/session_recovery.py
+++ b/api/session_recovery.py
@@ -619,12 +619,13 @@ def recover_all_sessions_on_startup(
             "If you weren't expecting this, check the session list for missing "
             "messages — see #1558.", restored, scanned,
         )
-        if rebuild_index:
-            try:
-                from api.models import _write_session_index
+    if rebuild_index:
+        try:
+            from api.models import SESSION_INDEX_FILE, _write_session_index
+            if restored or not SESSION_INDEX_FILE.exists():
                 _write_session_index(updates=None)
-            except Exception as exc:
-                logger.warning("recover_all_sessions_on_startup: index rebuild failed: %s", exc)
+        except Exception as exc:
+            logger.warning("recover_all_sessions_on_startup: index rebuild failed: %s", exc)
     return {
         "scanned": scanned,
         "restored": restored,

--- a/static/panels.js
+++ b/static/panels.js
@@ -5770,7 +5770,7 @@ async function loadProvidersPanel(){
   try{
     const data=await api('/api/providers');
     const quota=await _fetchProviderQuotaStatus(false).catch(e=>({ok:false,status:'unavailable',quota:null,message:e.message||t('provider_quota_unavailable'),client_fetched_at:new Date().toISOString()}));
-    const providers=(data.providers||[]).filter(p=>p.configurable||p.is_oauth);
+    const providers=(data.providers||[]).filter(p=>p.configurable||p.is_oauth||p.is_custom);
     list.innerHTML='';
     _providerCardEls.clear();
     const quotaCard=_buildProviderQuotaCard(quota);
@@ -6097,48 +6097,59 @@ function _buildProviderCard(p){
     return card;
   }
 
-  const field=document.createElement('div');
-  field.className='provider-card-field';
-  const label=document.createElement('label');
-  label.className='provider-card-label';
-  label.textContent=t('providers_status_api_key');
-  field.appendChild(label);
+  let input=null;
+  let saveBtn=null;
+  if(p.configurable){
+    const field=document.createElement('div');
+    field.className='provider-card-field';
+    const label=document.createElement('label');
+    label.className='provider-card-label';
+    label.textContent=t('providers_status_api_key');
+    field.appendChild(label);
 
-  const row=document.createElement('div');
-  row.className='provider-card-row';
-  const input=document.createElement('input');
-  input.type='password';
-  input.className='provider-card-input';
-  input.placeholder=p.has_key?t('providers_key_placeholder_replace'):t('providers_key_placeholder_new');
-  input.autocomplete='off';
-  const toggleBtn=document.createElement('button');
-  toggleBtn.type='button';
-  toggleBtn.className='provider-card-btn provider-card-btn-ghost';
-  toggleBtn.textContent='Show';
-  toggleBtn.onclick=()=>{
-    const revealed=input.type==='text';
-    input.type=revealed?'password':'text';
-    toggleBtn.textContent=revealed?'Show':'Hide';
-  };
-  const saveBtn=document.createElement('button');
-  saveBtn.type='button';
-  saveBtn.className='provider-card-btn provider-card-btn-primary';
-  saveBtn.textContent=t('providers_save');
-  saveBtn.onclick=()=>_saveProviderKey(p.id);
-  saveBtn.disabled=true;
-  row.appendChild(input);
-  row.appendChild(toggleBtn);
-  row.appendChild(saveBtn);
-  if(p.has_key){
-    const removeBtn=document.createElement('button');
-    removeBtn.type='button';
-    removeBtn.className='provider-card-btn provider-card-btn-danger';
-    removeBtn.textContent=t('providers_remove');
-    removeBtn.onclick=()=>_removeProviderKey(p.id);
-    row.appendChild(removeBtn);
+    const row=document.createElement('div');
+    row.className='provider-card-row';
+    input=document.createElement('input');
+    input.type='password';
+    input.className='provider-card-input';
+    input.placeholder=p.has_key?t('providers_key_placeholder_replace'):t('providers_key_placeholder_new');
+    input.autocomplete='off';
+    const toggleBtn=document.createElement('button');
+    toggleBtn.type='button';
+    toggleBtn.className='provider-card-btn provider-card-btn-ghost';
+    toggleBtn.textContent='Show';
+    toggleBtn.onclick=()=>{
+      const revealed=input.type==='text';
+      input.type=revealed?'password':'text';
+      toggleBtn.textContent=revealed?'Show':'Hide';
+    };
+    saveBtn=document.createElement('button');
+    saveBtn.type='button';
+    saveBtn.className='provider-card-btn provider-card-btn-primary';
+    saveBtn.textContent=t('providers_save');
+    saveBtn.onclick=()=>_saveProviderKey(p.id);
+    saveBtn.disabled=true;
+    row.appendChild(input);
+    row.appendChild(toggleBtn);
+    row.appendChild(saveBtn);
+    if(p.has_key){
+      const removeBtn=document.createElement('button');
+      removeBtn.type='button';
+      removeBtn.className='provider-card-btn provider-card-btn-danger';
+      removeBtn.textContent=t('providers_remove');
+      removeBtn.onclick=()=>_removeProviderKey(p.id);
+      row.appendChild(removeBtn);
+    }
+    field.appendChild(row);
+    body.appendChild(field);
+  }else{
+    const hint=document.createElement('div');
+    hint.className='provider-card-hint';
+    hint.textContent=p.is_custom
+      ? 'Custom provider loaded from config.yaml / hermes model. Edit it from the CLI or config file.'
+      : 'Provider is managed outside the WebUI.';
+    body.appendChild(hint);
   }
-  field.appendChild(row);
-  body.appendChild(field);
 
   // Model list — show when provider has known models
   if(modelCount>0){
@@ -6192,8 +6203,10 @@ function _buildProviderCard(p){
   body.appendChild(refreshRow);
   card.appendChild(body);
 
-  _providerCardEls.set(p.id,{card,input,saveBtn,hasKey:p.has_key});
-  input.addEventListener('input',()=>{saveBtn.disabled=!input.value.trim();});
+  if(input&&saveBtn){
+    _providerCardEls.set(p.id,{card,input,saveBtn,hasKey:p.has_key});
+    input.addEventListener('input',()=>{saveBtn.disabled=!input.value.trim();});
+  }
   header.addEventListener('click',e=>{
     // Don't toggle when clicking inside body (defensive; body isn't inside header)
     if(e.target.closest('.provider-card-body')) return;

--- a/tests/test_custom_providers_in_panel.py
+++ b/tests/test_custom_providers_in_panel.py
@@ -91,6 +91,7 @@ class TestCustomProvidersInGetProviders:
             assert glmcode["configurable"] is False, (
                 "custom providers should not be configurable via WebUI"
             )
+            assert glmcode["is_custom"] is True
             assert glmcode["key_source"] == "config_yaml"
             assert glmcode["display_name"] == "glmcode"
 
@@ -99,8 +100,16 @@ class TestCustomProvidersInGetProviders:
             assert "glm-5.1" in model_ids, (
                 f"Expected glm-5.1 in models, got: {model_ids}"
             )
+            assert glmcode["models_total"] == 1
         finally:
             self._restore_cfg(old_cfg, old_mtime)
+
+    def test_providers_panel_renders_config_yaml_custom_providers(self):
+        """Settings → Providers must not filter out read-only custom providers."""
+        src = open("static/panels.js", encoding="utf-8").read()
+        assert "filter(p=>p.configurable||p.is_oauth||p.is_custom)" in src
+        assert "Custom provider loaded from config.yaml / hermes model" in src
+        assert "if(p.configurable){" in src
 
     def test_custom_provider_with_multi_models(self, monkeypatch, tmp_path):
         """Custom provider with `models` list should expose all entries."""

--- a/tests/test_issue1202_oauth_provider_status.py
+++ b/tests/test_issue1202_oauth_provider_status.py
@@ -291,7 +291,8 @@ class TestProviderListFilter:
             "Settings → Providers panel. The filter must be 'filter(p=>p.configurable||p.is_oauth)'."
         )
         fixed_filter_idx = self.JS.find("filter(p=>p.configurable||p.is_oauth)")
-        assert fixed_filter_idx != -1, (
-            "The provider filter 'filter(p=>p.configurable||p.is_oauth)' is missing from panels.js. "
+        extended_filter_idx = self.JS.find("filter(p=>p.configurable||p.is_oauth||p.is_custom)")
+        assert fixed_filter_idx != -1 or extended_filter_idx != -1, (
+            "The provider filter must include p.is_oauth in panels.js. "
             "OAuth providers will not appear in Settings → Providers."
         )

--- a/tests/test_metadata_save_wipe_1558.py
+++ b/tests/test_metadata_save_wipe_1558.py
@@ -270,6 +270,24 @@ def test_recover_all_sessions_on_startup_restores_orphan_bak(temp_session_dir):
     assert len(restored["messages"]) == 293
 
 
+def test_recover_all_sessions_on_startup_rebuilds_missing_index_without_restores(temp_session_dir, monkeypatch):
+    """Startup recovery must rebuild a missing index even when no .bak restore runs."""
+    import api.models as _m
+
+    sid = _make_session_on_disk(temp_session_dir, n_msgs=42)
+    missing_index = temp_session_dir / "_index.json"
+    monkeypatch.setattr(_m, "SESSION_INDEX_FILE", missing_index)
+    assert not missing_index.exists()
+
+    from api.session_recovery import recover_all_sessions_on_startup
+    result = recover_all_sessions_on_startup(temp_session_dir, rebuild_index=True)
+
+    assert result["restored"] == 0
+    index = json.loads(missing_index.read_text(encoding="utf-8"))
+    assert [entry["session_id"] for entry in index] == [sid]
+    assert index[0]["message_count"] == 42
+
+
 def test_recover_all_sessions_on_startup_rebuilds_index_after_orphan_restore(temp_session_dir, monkeypatch):
     """A restored orphan must be visible through the WebUI session index immediately."""
     import api.models as _m


### PR DESCRIPTION
## Release v0.51.97 — Release BU (stage-390) — 2-PR contributor batch

Conservative follow-on batch from v0.51.96. Originally three PRs; dropped #2638 mid-stage after pytest revealed a semantic conflict with v0.51.96's #2620 (see below).

### Constituents (parallel-agent reviewed via comments, CI green pre-stage)

- **#2642** by @dso2ng — Rebuild missing startup session index. 28 LOC, `api/session_recovery.py` + test. Fast-path restoration when `_index.json` is missing without a `.bak` restore.
- **#2634** by @Michaelyklam (closes #2632) — Show CLI-managed `custom_providers` as read-only cards in Settings → Providers. 75 LOC, `api/providers.py` + `static/panels.js` + 2 tests. Read-only card variant only — no new editable surface, no composer changes.

### Dropped mid-stage

- **#2638** (@dobby-d-elf) — Compact tool activity grouping + transcript dedup. The PR was filed against pre-#2620 master where `_normalized_message_timestamp_for_key` preserved sub-second precision. v0.51.96 shipped #2620 which truncates to second-level. When merged onto current master, #2638's new `_session_message_same_second_key` dedup blocks a case (`test_state_db_reconciliation_preserves_same_second_state_repeats`) that the v0.51.96 invariant expects preserved. Needs rebase onto the truncated key + dedup logic re-thought; posted a comment on #2638 with the failing test and the conflict signature.

### Held from this batch

- #2640 (@colin-chang, 20 LOC) — conflicts on `api/config.py` against #2626. Needs rebase.
- #2633 (@dobby-d-elf, 381 LOC) — substantial profile-switch perf rework. Own release.
- #2636 (@FrancescoFarinola, 281 LOC) — new sidebar tab visibility toggle UI. Held for maintainer UX call.
- #2637 (@dobby-d-elf, 262 LOC) — new in-process session-events bus + SSE endpoint. Own release.

### Pre-Opus gate

- ✓ JS node -c (panels.js)
- ✓ Python ast.parse (api/providers.py, api/session_recovery.py, 2 tests)
- ✓ No merge markers
- ✓ No `**PR TBD**` placeholders

### Stats

2 PRs, ~103 LOC net change, 5 files. Surfaces: settings panel read-only card + session-recovery startup path. No overlap, no shared lock structure, no UX surface change.
