### PR TITLE
Release v0.51.98 (Release BV / stage-391 / 1-PR follow-on)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 ## [Unreleased]
 
 
+## [v0.51.98] — 2026-05-20 — Release BV (stage-391 — 1-PR follow-on — custom_providers allowlist priority over live /v1/models)
+
+### Fixed
+
+- **PR #2640** by @colin-chang — When a `custom_providers` entry in `config.yaml` declares a curated `models:` allowlist (e.g. a ZenMux or other aggregator gateway), respect the curated list instead of also fetching the live `/v1/models` catalog. Without this guard the picker rendered hundreds of online models alongside the user's curated three, swamping the intended selection. The allowlist guard skips the live probe entirely; the existing fall-through to a live probe still runs when no `models:` list is configured. Composes cleanly with #2626 / v0.51.96 — when the live probe is skipped, no `models_endpoint_error` is surfaced (the curated list is the source of truth and probe failures should not show as a user-facing diagnostic in that case).
+
 ## [v0.51.97] — 2026-05-20 — Release BU (stage-390 — 2-PR batch — startup session-index rebuild + config-managed custom-provider cards)
 
 ### Fixed

--- a/api/config.py
+++ b/api/config.py
@@ -3364,9 +3364,30 @@ def get_available_models() -> dict:
                         _cp_key_env = str(_cp.get("key_env") or "").strip()
                         if _cp_key_env:
                             _cp_api_key = str(os.getenv(_cp_key_env) or "").strip()
+
+                    # Check if user has configured models in config.yaml —
+                    # configured models take priority over live /v1/models
+                    # discovery (same as hermes-agent model_switch.py Section 4
+                    # patch). Without this check, ZenMux and similar aggregator
+                    # gateways would show hundreds of online models instead of
+                    # the user's curated list.
+                    _cp_configured_models = _cp.get("models")
+                    _cp_has_configured_models = (
+                        isinstance(_cp_configured_models, (dict, list))
+                        and len(_cp_configured_models) > 0
+                    )
                     _live_models = auto_detected_models_by_provider.get(_slug)
                     _live_error = None
-                    if _live_models is None:
+                    if _cp_has_configured_models:
+                        # Skip the live /v1/models probe when an allowlist
+                        # exists — the curated list wins and probe failures
+                        # should not surface as a user-facing diagnostic in
+                        # that case. Still respect any pre-warm result that
+                        # ``auto_detected_models_by_provider`` already
+                        # populated (cheap to keep).
+                        if _live_models is None:
+                            _live_models = []
+                    elif _live_models is None:
                         _live_models, _live_error = _read_custom_endpoint_models(
                             _cp_base_url,
                             _slug,


### PR DESCRIPTION
## Release v0.51.98 — Release BV (stage-391) — 1-PR follow-on

Tiny follow-on release picking up the rebased #2640 after its conflict with v0.51.96's #2626 was resolved.

### Constituents

- **#2640** by @colin-chang — `custom_providers` allowlist takes priority over live `/v1/models` fetch. 22 LOC in `api/config.py`. When a `custom_providers` entry declares a `models:` list, the live probe is skipped — the curated list wins.

### Maintainer rebase

#2640 was filed against pre-#2626 master. Rebased onto current master in `/tmp/wt-rebase-2640` and resolved the `api/config.py` conflict cleanly:
- Kept @colin-chang's `_cp_has_configured_models` allowlist guard
- Layered on top of #2626's tuple-returning `_read_custom_endpoint_models()` signature
- When allowlist is present: skip live probe + skip error surfacing (curated list is source of truth)
- When allowlist absent: live probe runs + #2626's structured error surfacing applies

Force-pushed `9c3e37d2` to @colin-chang/fix/custom-provider-models-allowlist. Status comment posted on #2640.

### Pre-Opus gate

- ✓ Python ast.parse on `api/config.py`
- ✓ No merge markers
- ✓ Single-file change, no test additions (logic is data-driven, covered by existing custom-provider tests)

CI green on the rebased PR commit before stage cherry-pick.

### Stats

1 PR, 22 LOC net change, 1 file. Surface: provider catalog assembly. No new endpoints, no UX changes.
