### PR TITLE
fix: dedupe replayed context tail after compression

### DIFF
--- a/api/streaming.py
+++ b/api/streaming.py
@@ -2199,6 +2199,52 @@ def _messages_have_prefix(messages, prefix):
     return True
 
 
+def _message_replay_key(msg):
+    """Return a stable comparison key for replay/overlap de-duplication."""
+    identity = _message_identity(msg)
+    if identity is not None:
+        return identity
+    if not isinstance(msg, dict):
+        return None
+    return (
+        str(msg.get('role') or ''),
+        _message_text(msg.get('content', '')),
+        str(msg.get('tool_call_id') or ''),
+        json.dumps(msg.get('tool_calls') or [], sort_keys=True, ensure_ascii=False),
+    )
+
+
+def _strip_replayed_prefix(existing_messages, candidates):
+    """Drop a candidate prefix that is already the suffix of existing_messages.
+
+    Compression/continuation can replay the active tail from state.db after the
+    previous WebUI context/display already contains it. Prefix-only merge logic
+    then treats that replayed tail as a fresh delta and duplicates a whole turn.
+    Strip the largest exact suffix/prefix overlap before appending.
+    """
+    existing_messages = list(existing_messages or [])
+    candidates = list(candidates or [])
+    max_overlap = min(len(existing_messages), len(candidates))
+    for overlap in range(max_overlap, 0, -1):
+        left = [_message_replay_key(m) for m in existing_messages[-overlap:]]
+        right = [_message_replay_key(m) for m in candidates[:overlap]]
+        if left == right:
+            return candidates[overlap:]
+    return candidates
+
+
+def _dedupe_replayed_active_context(previous_context, result_messages):
+    """Keep model context append-only without re-appending a replayed tail."""
+    previous_context = list(previous_context or [])
+    result_messages = list(result_messages or [])
+    if not previous_context or not result_messages:
+        return result_messages
+    if not _messages_have_prefix(result_messages, previous_context):
+        return result_messages
+    candidates = result_messages[len(previous_context):]
+    return previous_context + _strip_replayed_prefix(previous_context, candidates)
+
+
 def _is_context_compression_marker(msg):
     if not isinstance(msg, dict):
         return False
@@ -2443,6 +2489,8 @@ def _merge_display_messages_after_agent_result(previous_display, previous_contex
 
     if _messages_have_prefix(result_messages, previous_context):
         candidates = result_messages[len(previous_context):]
+        candidates = _strip_replayed_prefix(previous_display, candidates)
+        candidates = _strip_replayed_prefix(previous_context, candidates)
     else:
         current_user_idx = _find_current_user_turn(result_messages, msg_text)
         marker_candidates = [
@@ -4322,6 +4370,10 @@ def _run_agent_streaming(
                     _previous_context_messages,
                     _result_messages,
                 )
+                _next_context_messages = _dedupe_replayed_active_context(
+                    _previous_context_messages,
+                    _next_context_messages,
+                )
                 s.context_messages = _next_context_messages
                 s.messages = _merge_display_messages_after_agent_result(
                     _previous_messages,
@@ -4464,6 +4516,10 @@ def _run_agent_streaming(
                                 _next_context_messages = _restore_reasoning_metadata(
                                     _previous_context_messages,
                                     _result_messages,
+                                )
+                                _next_context_messages = _dedupe_replayed_active_context(
+                                    _previous_context_messages,
+                                    _next_context_messages,
                                 )
                                 s.context_messages = _next_context_messages
                                 s.messages = _merge_display_messages_after_agent_result(
@@ -5280,6 +5336,10 @@ def _run_agent_streaming(
                                 _result_messages = _heal_result.get('messages') or _previous_context_messages
                                 _next_context_messages = _restore_reasoning_metadata(
                                     _previous_context_messages, _result_messages,
+                                )
+                                _next_context_messages = _dedupe_replayed_active_context(
+                                    _previous_context_messages,
+                                    _next_context_messages,
                                 )
                                 s.context_messages = _next_context_messages
                                 s.messages = _merge_display_messages_after_agent_result(

--- a/tests/test_issue1217_transcript_compaction.py
+++ b/tests/test_issue1217_transcript_compaction.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 from api.streaming import (
     _assistant_reply_added_after_current_turn,
     _context_messages_for_new_turn,
+    _dedupe_replayed_active_context,
     _merge_display_messages_after_agent_result,
     _new_turn_context_from_messages,
     _sanitize_messages_for_api,
@@ -225,6 +226,60 @@ def test_append_only_agent_result_preserves_normal_delta_behavior():
     )
 
     assert merged == result_messages
+
+
+def test_replayed_active_tail_after_compression_is_not_duplicated():
+    previous_display = [
+        {"role": "assistant", "content": "old visible transcript"},
+        {"role": "user", "content": "choose agent"},
+        {"role": "assistant", "content": "checking agents"},
+        {"role": "tool", "content": "agent list"},
+        {"role": "assistant", "content": "agent answer"},
+    ]
+    previous_context = [
+        {"role": "assistant", "content": "[Session Arc Summary] compacted history"},
+        {"role": "user", "content": "choose agent"},
+        {"role": "assistant", "content": "checking agents"},
+        {"role": "tool", "content": "agent list"},
+        {"role": "assistant", "content": "agent answer"},
+    ]
+    result_messages = previous_context + [
+        # The new compressed state.db segment can replay the already-visible
+        # active tail before adding the next turn.
+        {"role": "user", "content": "choose agent"},
+        {"role": "assistant", "content": "checking agents"},
+        {"role": "tool", "content": "agent list"},
+        {"role": "assistant", "content": "agent answer"},
+        {"role": "user", "content": "choose B"},
+        {"role": "assistant", "content": "using B"},
+    ]
+
+    merged = _merge_display_messages_after_agent_result(
+        previous_display,
+        previous_context,
+        result_messages,
+        "choose B",
+    )
+    next_context = _dedupe_replayed_active_context(previous_context, result_messages)
+
+    assert [m["content"] for m in merged] == [
+        "old visible transcript",
+        "choose agent",
+        "checking agents",
+        "agent list",
+        "agent answer",
+        "choose B",
+        "using B",
+    ]
+    assert [m["content"] for m in next_context] == [
+        "[Session Arc Summary] compacted history",
+        "choose agent",
+        "checking agents",
+        "agent list",
+        "agent answer",
+        "choose B",
+        "using B",
+    ]
 
 
 def test_repeated_user_text_after_compaction_is_not_dropped():


### PR DESCRIPTION
## Summary
- Dedupe replayed active-context tails before appending agent result deltas to the WebUI display transcript.
- Apply the same replay protection to persisted `context_messages`, so compression/continuation does not re-feed an already-present tail into the next model turn.
- Add a regression covering state.db/compression replay of an already-visible active tail while preserving normal append-only deltas.

## Why this happens
WebUI intentionally keeps two related but different histories:

- `messages`: the visible transcript shown in the UI.
- `context_messages`: the model-facing context used to start the next turn.

Normally, when the agent returns `result.messages`, WebUI can treat it as:

```text
previous_context + new_turn_delta
```

and append only `new_turn_delta` to the visible transcript/context.

During compression or session continuation, however, Hermes rotates/continues the underlying agent session and the state-db-backed result may include the previous model context *plus a replay of the active tail* before the newly generated turn:

```text
previous_context + replayed_active_tail + new_turn_delta
```

That replayed active tail is not a new user/assistant/tool exchange. It is the same suffix that WebUI already has in `messages` and/or `context_messages`, reconstructed after the compression/continuation boundary.

The existing prefix-only merge logic only checked whether `result.messages` started with `previous_context`. Once that was true, it blindly appended everything after that prefix. In the replay case, that means WebUI appends `replayed_active_tail` as if it were fresh output, duplicating a whole contiguous block of user/assistant/tool messages.

Once duplicated in `context_messages`, the duplicated block is sent into the next turn as model context. That makes token usage jump unexpectedly after what appears to be a small/simple exchange, and can cause repeated compaction on subsequent turns.

## When this happens
This is most likely to occur when all of the following are true:

1. A WebUI session is near the compression threshold or otherwise crosses a compression/continuation boundary.
2. The agent/session layer returns a state-db-reconciled `result.messages` sequence that contains the previous context prefix.
3. That returned sequence also replays the already-active tail before the new turn, for example:

```text
summary/context marker
A: user asks something
A: assistant/tool work
A: assistant answer
A: user asks something        <-- replayed
A: assistant/tool work        <-- replayed
A: assistant answer           <-- replayed
B: new user/assistant turn
```

Before this fix, WebUI saw the whole suffix after `previous_context` as new, so it persisted the replayed A block again. The bug is not normal conversation growth; it is a merge/reconciliation artifact at compression/continuation boundaries.

## State invariant repaired
After compression or session continuation, WebUI may receive a result whose prefix is the previous model context followed by a replay of the active tail from state.db. That replay is not a new turn.

Both histories should remain append-only with respect to genuinely new turns:

- visible transcript (`messages`) should not duplicate an already-visible suffix.
- model-facing context (`context_messages`) should not re-append an already-present suffix and feed it back into the next model call.

This PR strips the largest exact suffix/prefix overlap before appending result deltas. It applies the same protection to the display transcript merge and to persisted `context_messages`.

## Test plan
- `python -m pytest -q tests/test_issue1217_transcript_compaction.py`
- `python -m pytest -q tests/test_session_save_mode.py tests/test_issue1217_transcript_compaction.py`
- `git diff --check`
- `git merge-tree --write-tree origin/master HEAD`
