### PR TITLE
fix(plugins): distinguish exclusive/provider activation in Settings panel

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -3299,6 +3299,13 @@ def _plugin_visibility_payload(manager=None) -> dict:
     four lifecycle hook names called out by the Settings visibility MVP. It
     never includes plugin source paths, callback names, callback reprs, or raw
     load errors because those can contain private filesystem details.
+
+    Exclusive plugins (e.g. memory providers) are activated through their
+    category's ``<category>.provider`` config, not through ``plugins.enabled``.
+    Their ``loaded.enabled`` stays False by design and they register hooks
+    outside the four visibility hooks below. The payload surfaces ``kind``
+    and ``activation`` so the panel can render them distinctly instead of
+    mislabeling them as "Disabled" with no hooks (issue #2659).
     """
     manager = manager or _get_plugin_manager_for_visibility()
     manager.discover_and_load(force=False)
@@ -3316,6 +3323,14 @@ def _plugin_visibility_payload(manager=None) -> dict:
         name = _clean_plugin_visibility_text(getattr(manifest, "name", "") or plugin_key, limit=120)
         version = _clean_plugin_visibility_text(getattr(manifest, "version", ""), limit=80)
         description = _clean_plugin_visibility_text(getattr(manifest, "description", ""), limit=280)
+        kind = _clean_plugin_visibility_text(getattr(manifest, "kind", "") or "standalone", limit=40)
+        enabled_flag = bool(getattr(loaded, "enabled", False))
+        if kind == "exclusive":
+            activation = "exclusive"
+        elif kind == "model-provider" and enabled_flag:
+            activation = "provider"
+        else:
+            activation = "enabled" if enabled_flag else "disabled"
         registered = []
         for hook in list(getattr(manifest, "provides_hooks", []) or []) + list(getattr(loaded, "hooks_registered", []) or []):
             hook_name = str(hook or "").strip()
@@ -3327,7 +3342,11 @@ def _plugin_visibility_payload(manager=None) -> dict:
             "key": plugin_key or name,
             "version": version,
             "description": description,
-            "enabled": bool(getattr(loaded, "enabled", False)),
+            # `enabled` is preserved for back-compat with older WebUI clients
+            # that key off it directly. New clients should prefer `activation`.
+            "enabled": enabled_flag,
+            "kind": kind,
+            "activation": activation,
             "hooks": registered,
         })
 

--- a/static/i18n.js
+++ b/static/i18n.js
@@ -530,6 +530,8 @@ const LOCALES = {
     plugins_registered_hooks: 'Registered hooks',
     plugins_enabled: 'Enabled',
     plugins_disabled: 'Disabled',
+    plugins_active_provider: 'Active (provider)',
+    plugins_provider_no_hooks: 'Provider plugin — no agent-visibility hooks',
     plugins_load_failed: 'Failed to load plugins: ',
     settings_tab_system: 'System',
     settings_title: 'Settings',

--- a/static/panels.js
+++ b/static/panels.js
@@ -5757,20 +5757,42 @@ function _buildPluginCard(plugin){
   const card=document.createElement('div');
   card.className='provider-card plugin-card';
   card.dataset.plugin=(plugin&&plugin.key)||'';
+  // `activation` is the canonical state from /api/plugins (added in #2659).
+  // Fall back to the older `enabled` boolean when the field is missing so
+  // the panel still works against older backends.
+  const activation=(plugin&&typeof plugin.activation==='string')
+    ? plugin.activation
+    : (plugin&&plugin.enabled===false ? 'disabled' : 'enabled');
+  const isProvider=activation==='exclusive'||activation==='provider';
   const hooks=Array.isArray(plugin&&plugin.hooks)?plugin.hooks:[];
+  // Provider plugins (memory/web/browser/etc.) register hooks on their
+  // category's dispatcher, not the four agent-wide visibility hooks the
+  // payload filters to. Show an explanatory line instead of the generic
+  // "No registered lifecycle hooks" when the visibility-hook list is empty.
   const hookHtml=hooks.length
     ? hooks.map(h=>`<span class="plugin-hook-badge">${esc(h)}</span>`).join('')
-    : '<span class="plugin-hook-empty">'+t('plugins_no_hooks')+'</span>';
+    : '<span class="plugin-hook-empty">'+t(isProvider?'plugins_provider_no_hooks':'plugins_no_hooks')+'</span>';
   const version=(plugin&&plugin.version)?' · v'+esc(plugin.version):'';
   const desc=(plugin&&plugin.description)?esc(plugin.description):t('plugins_no_description');
-  const enabled=plugin&&plugin.enabled!==false;
+  let badgeText;
+  let badgeClass;
+  if(isProvider){
+    badgeText=t('plugins_active_provider');
+    badgeClass='plugin-card-badge-provider';
+  }else if(activation==='enabled'){
+    badgeText=t('plugins_enabled');
+    badgeClass='';
+  }else{
+    badgeText=t('plugins_disabled');
+    badgeClass='plugin-card-badge-disabled';
+  }
   card.innerHTML=`
     <div class="provider-card-header plugin-card-header">
       <div class="provider-card-info">
         <div class="provider-card-name">${esc((plugin&&plugin.name)||t('plugins_unnamed'))}</div>
         <div class="provider-card-meta">${esc((plugin&&plugin.key)||'plugin')}${version}</div>
       </div>
-      <span class="provider-card-badge ${enabled?'':'plugin-card-badge-disabled'}">${enabled?t('plugins_enabled'):t('plugins_disabled')}</span>
+      <span class="provider-card-badge ${badgeClass}">${badgeText}</span>
     </div>
     <div class="provider-card-body plugin-card-body">
       <div class="provider-card-hint">${desc}</div>

--- a/tests/test_plugins_panel.py
+++ b/tests/test_plugins_panel.py
@@ -10,7 +10,7 @@ def read(path: str) -> str:
 
 
 class _FakeManifest:
-    def __init__(self, *, name, key, version="", description="", provides_hooks=None, path=None):
+    def __init__(self, *, name, key, version="", description="", provides_hooks=None, path=None, kind="standalone"):
         self.name = name
         self.key = key
         self.version = version
@@ -18,7 +18,7 @@ class _FakeManifest:
         self.provides_hooks = provides_hooks or []
         self.path = path
         self.source = "user"
-        self.kind = "standalone"
+        self.kind = kind
 
 
 class _FakeLoadedPlugin:
@@ -86,6 +86,8 @@ class TestPluginsApi:
             "version": "1.2.3",
             "description": "Blocks unsafe tool calls",
             "enabled": True,
+            "kind": "standalone",
+            "activation": "enabled",
             "hooks": ["pre_tool_call", "post_tool_call"],
         }]
         serialized = repr(payload)
@@ -128,8 +130,69 @@ class TestPluginsApi:
         plugin = payload["plugins"][0]
         assert plugin["hooks"] == ["pre_llm_call", "post_llm_call"]
         assert plugin["enabled"] is False
+        assert plugin["kind"] == "standalone"
+        assert plugin["activation"] == "disabled"
         assert "/tmp/not-a-hook" not in repr(payload)
         assert "/secret" not in repr(payload)
+
+    def test_api_plugins_marks_exclusive_plugins_as_active_provider(self):
+        # Exclusive plugins (e.g. memory.provider: noema) leave loaded.enabled
+        # False by design — the bundled discovery scanner records the manifest
+        # but defers loading to the category's own activation path. Without
+        # the `activation`/`kind` fields, the panel rendered them as
+        # "Disabled + no hooks" indistinguishable from broken plugins (#2659).
+        manager = _FakePluginManager({
+            "noema": _FakeLoadedPlugin(
+                _FakeManifest(
+                    name="noema",
+                    key="noema",
+                    version="0.1.0",
+                    description="Structured memory backed by a Noema Cortex",
+                    kind="exclusive",
+                ),
+                enabled=False,
+                hooks_registered=[],
+                error="exclusive plugin — activate via <category>.provider config",
+            )
+        })
+
+        payload = self._capture_plugins_response(manager)
+
+        plugin = payload["plugins"][0]
+        assert plugin["kind"] == "exclusive"
+        assert plugin["activation"] == "exclusive"
+        # `enabled` stays False for back-compat with older WebUI clients that
+        # key off it directly; new clients must read `activation`.
+        assert plugin["enabled"] is False
+        assert plugin["hooks"] == []
+        # The raw error string is intentionally NOT surfaced — it can contain
+        # filesystem paths or other internals on other plugin kinds.
+        assert "exclusive plugin" not in repr(payload)
+
+    def test_api_plugins_marks_active_model_provider(self):
+        # model-provider plugins that loaded successfully (loaded.enabled True)
+        # get the "provider" activation badge so the panel can distinguish
+        # them from standalone hook plugins.
+        manager = _FakePluginManager({
+            "openrouter": _FakeLoadedPlugin(
+                _FakeManifest(
+                    name="openrouter",
+                    key="openrouter",
+                    version="1.0.0",
+                    description="OpenRouter model provider",
+                    kind="model-provider",
+                ),
+                enabled=True,
+                hooks_registered=[],
+            )
+        })
+
+        payload = self._capture_plugins_response(manager)
+
+        plugin = payload["plugins"][0]
+        assert plugin["kind"] == "model-provider"
+        assert plugin["activation"] == "provider"
+        assert plugin["enabled"] is True
 
 
 class TestPluginsSettingsUi:
@@ -159,3 +222,25 @@ class TestPluginsSettingsUi:
         segment = js[js.find("function _buildPluginCard"):js.find("// ── Providers panel")]
         assert ".path" not in segment
         assert ".callback" not in segment
+
+    def test_plugins_panel_renders_active_provider_badge(self):
+        # The card must distinguish exclusive/provider activation from a plain
+        # "Enabled" state and use the dedicated empty-hooks message for
+        # provider plugins instead of "No registered lifecycle hooks" (#2659).
+        js = read("static/panels.js")
+        segment = js[js.find("function _buildPluginCard"):js.find("// ── Providers panel")]
+
+        assert "plugin.activation" in segment
+        assert "'exclusive'" in segment
+        assert "'provider'" in segment
+        assert "plugins_active_provider" in segment
+        assert "plugins_provider_no_hooks" in segment
+        # Graceful fallback when the older payload shape (no `activation` field)
+        # is returned — the card should still resolve a badge from `enabled`.
+        assert "plugin.enabled===false" in segment
+
+    def test_plugins_panel_i18n_strings_present(self):
+        i18n = read("static/i18n.js")
+
+        assert "plugins_active_provider:" in i18n
+        assert "plugins_provider_no_hooks:" in i18n


### PR DESCRIPTION
## Summary

Closes #2659. Exclusive plugins (memory providers, model providers, etc.) were rendered as "Disabled" with "No registered lifecycle hooks" in Settings → Plugins, indistinguishable from broken plugins. This PR surfaces `manifest.kind` + a derived `activation` field through `/api/plugins` and teaches the card render to render a distinct "Active (provider)" badge for them.

Direction follows your sketch in the issue comment (keying off `manifest.kind`, not `loaded.error`).

## Changes

- `api/routes.py`: `_plugin_visibility_payload` reads `manifest.kind`, computes `activation`, surfaces both. `enabled` preserved for back-compat.
- `static/panels.js`: `_buildPluginCard` picks one of three badge states from `activation`, with a graceful fallback to `enabled` for older backends. Empty-hook rows on provider plugins use `plugins_provider_no_hooks` instead of the generic message.
- `static/i18n.js`: Two new English strings (`plugins_active_provider`, `plugins_provider_no_hooks`). Other locales auto-fall-back via `t()`'s existing `_locale[key] ?? LOCALES.en[key]`.
- `tests/test_plugins_panel.py`: extended existing tests for the new payload fields; two new API tests (exclusive + model-provider activation); two new frontend tests asserting the new badge logic and i18n keys.

## Test plan

- [x] `pytest tests/test_plugins_panel.py -v` → 10/10 pass
- [x] Visual check: the noema memory plugin (`memory.provider: noema`) now renders "Active (provider)" instead of "Disabled" on my own cluster, with "Provider plugin — no agent-visibility hooks" replacing the generic empty-hooks message
- [ ] Reviewer: cross-check that older webui clients (pre-`activation`) still get a sensible badge from the back-compat fallback path

## Evidence

<img width="944" height="371" alt="image" src="https://github.com/user-attachments/assets/999ab372-7946-494b-904e-d5417343655f" />

## Notes

- No CSS added for `plugin-card-badge-provider`. The badge renders with the default `provider-card-badge` styling (green); happy to add a distinct color if you have a preference — left out so this PR stays scoped.
- No upstream `hermes-cli` change required. `PluginManifest.kind` already exists in the upstream dataclass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)