### PR TITLE
Add WebUI session polish improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 
 ## [Unreleased]
 
+### Added
+
+- Add a sidebar quick profile switcher so profiles can be changed without opening an active chat or the Profiles panel.
+- Add a workspace-panel Artifacts tab that lists files mentioned, edited, or created during the active session and opens them in the existing preview flow.
+
+### Changed
+
+- Session-list SSE reconnects now use bounded jitter/backoff instead of a fixed 5-second retry, reducing reconnect bursts after restarts or network drops.
+- Expanded cron run rows now render the full output inline immediately; the truncated preview remains only for collapsed rows.
 
 ## [v0.51.103] — 2026-05-21 — Release CA (stage-396 — 1-PR follow-on — Settings → Plugins distinguishes exclusive/provider activation)
 

--- a/static/boot.js
+++ b/static/boot.js
@@ -1550,6 +1550,7 @@ function applyBotName(){
   // Update profile chip label immediately
   const profileLabel=$('profileChipLabel');
   if(profileLabel) profileLabel.textContent=S.activeProfile||'default';
+  if(typeof refreshQuickProfileSelectFromApi==='function') refreshQuickProfileSelectFromApi();
   // Fetch available models without blocking session restore. The static HTML
   // options are enough for first paint; the dynamic provider list can settle
   // after the saved session is visible.

--- a/static/index.html
+++ b/static/index.html
@@ -193,6 +193,10 @@
           </button>
         </div>
       </div>
+      <div class="sidebar-profile-quick" aria-label="Quick profile switcher">
+        <label for="sidebarProfileSelect">Profile</label>
+        <select id="sidebarProfileSelect" onchange="switchToProfile(this.value)" title="Switch agent profile"></select>
+      </div>
       <div class="session-search sidebar-search"><svg class="sidebar-search-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="8"/><path d="M21 21l-4.35-4.35"/></svg><input id="sessionSearch" placeholder="Filter conversations..." data-i18n-placeholder="filter_conversations" oninput="filterSessions()" autocomplete="off"></div>
       <div class="session-list" id="sessionList"></div>
     </div>
@@ -1287,8 +1291,13 @@
         <button class="panel-icon-btn close-preview has-tooltip has-tooltip--bottom" id="btnClearPreview" data-tooltip="Close preview"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg></button>
       </div>
     </div>
+    <div class="workspace-panel-tabs" role="tablist" aria-label="Workspace panel views">
+      <button class="workspace-panel-tab active" id="workspaceFilesTab" type="button" onclick="switchWorkspacePanelTab('files')" role="tab" aria-selected="true">Files</button>
+      <button class="workspace-panel-tab" id="workspaceArtifactsTab" type="button" onclick="switchWorkspacePanelTab('artifacts')" role="tab" aria-selected="false">Artifacts <span id="workspaceArtifactsCount" class="workspace-artifacts-count">0</span></button>
+    </div>
     <div class="breadcrumb-bar" id="breadcrumbBar" style="display:none"></div>
     <div class="file-tree" id="fileTree"></div>
+    <div class="workspace-artifacts" id="workspaceArtifacts" hidden></div>
     <div id="wsEmptyState" style="display:none;flex:1;align-items:center;justify-content:center;padding:24px 16px;text-align:center;color:var(--muted);font-size:12px;line-height:1.6"></div>
     <div class="preview-area" id="previewArea">
       <div class="preview-path" id="previewPath">

--- a/static/panels.js
+++ b/static/panels.js
@@ -658,11 +658,14 @@ async function _loadRunContent(jobId, filename, runId){
       body.textContent = data.error;
       return;
     }
+    const expanded = _cronExpansionGet(_cronRunExpandKey(jobId, filename));
+    const output = expanded ? (data.content || data.snippet || '') : (data.snippet || data.content || '');
+    body.classList.toggle('expanded', expanded);
     // Render markdown content using the same renderer as chat messages
     if (typeof renderMd === 'function') {
-      body.innerHTML = renderMd(data.snippet || data.content);
+      body.innerHTML = renderMd(output);
     } else {
-      body.textContent = data.snippet || data.content;
+      body.textContent = output;
     }
     const usageStrip = _formatCronRunUsageStrip(data.usage);
     if (usageStrip) {
@@ -671,13 +674,15 @@ async function _loadRunContent(jobId, filename, runId){
       usage.textContent = usageStrip;
       body.appendChild(usage);
     }
-    // Show "View full output" button if content was truncated
-    if (data.content && data.snippet && data.content.length > data.snippet.length) {
+    // Show "View full output" button only for collapsed previews. Expanded rows render the full body inline.
+    if (!expanded && data.content && data.snippet && data.content.length > data.snippet.length) {
       const btn = document.createElement('button');
       btn.style.cssText = 'margin-top:8px;padding:4px 12px;border-radius:var(--radius-btn);border:1px solid var(--border-subtle);background:var(--surface-subtle);color:var(--text-secondary);cursor:pointer;font-size:12px';
       btn.textContent = t('cron_view_full_output') || 'View full output';
       btn.onclick = () => {
-        body.innerHTML = renderMd ? renderMd(data.content) : '';
+        _cronExpansionSet(_cronRunExpandKey(jobId, filename), true);
+        body.classList.add('expanded');
+        body.innerHTML = renderMd ? renderMd(data.content) : data.content;
         btn.remove();
       };
       body.appendChild(btn);
@@ -4521,12 +4526,43 @@ function _refreshProfileSwitchBackground(gen){
   }).catch(function(){});
 }
 
+function refreshQuickProfileSelect(data){
+  const sel = $('sidebarProfileSelect');
+  if(!sel || !data) return;
+  const profiles = Array.isArray(data.profiles) ? data.profiles : [];
+  const active = (S.activeProfile && profiles.some(p => p.name === S.activeProfile))
+    ? S.activeProfile
+    : (data.active || 'default');
+  sel.innerHTML = '';
+  for(const p of profiles){
+    const opt = document.createElement('option');
+    opt.value = p.name;
+    opt.textContent = p.is_default ? `${p.name} (default)` : p.name;
+    sel.appendChild(opt);
+  }
+  if(!profiles.some(p => p.name === active)){
+    const opt = document.createElement('option');
+    opt.value = active;
+    opt.textContent = active;
+    sel.appendChild(opt);
+  }
+  sel.value = active;
+  sel.disabled = profiles.length <= 1;
+}
+
+function refreshQuickProfileSelectFromApi(){
+  const sel = $('sidebarProfileSelect');
+  if(!sel) return;
+  api('/api/profiles').then(refreshQuickProfileSelect).catch(()=>{});
+}
+
 async function loadProfilesPanel() {
   const panel = $('profilesPanel');
   if (!panel) return;
   try {
     const data = await api('/api/profiles');
     _profilesCache = data;
+    refreshQuickProfileSelect(data);
     panel.innerHTML = '';
     const explainer = document.createElement('div');
     explainer.className = 'profile-card profile-help-card';
@@ -4712,6 +4748,7 @@ function renderProfileDropdown(data) {
   const dd = $('profileDropdown');
   if (!dd) return;
   dd.innerHTML = '';
+  refreshQuickProfileSelect(data);
   const profiles = data.profiles || [];
   const active = (S.activeProfile && profiles.some(p => p.name === S.activeProfile))
     ? S.activeProfile
@@ -4784,6 +4821,8 @@ async function switchToProfile(name) {
   const _prevProfileName = S.activeProfile || 'default';
   const _switchGen = ++_profileSwitchGeneration;
   if (_chip) { _chip.classList.add('switching'); _chip.disabled = true; }
+  const quickSel = $('sidebarProfileSelect');
+  if(quickSel) quickSel.value = name;
   // Optimistic name update — shows the target name right away
   if (_chipLabel) _chipLabel.textContent = name;
 
@@ -4800,6 +4839,7 @@ async function switchToProfile(name) {
     const data = await api('/api/profile/switch', { method: 'POST', body: JSON.stringify({ name }) });
     if (_switchGen !== _profileSwitchGeneration) return;
     S.activeProfile = data.active || name;
+    if(quickSel) quickSel.value = S.activeProfile;
 
     // Update composer placeholder and title bar while the core profile-switch
     // state is still close to the profile API response.
@@ -4905,6 +4945,7 @@ async function switchToProfile(name) {
   } catch (e) {
     // Revert the optimistic name update on error
     if (_switchGen === _profileSwitchGeneration && _chipLabel) _chipLabel.textContent = _prevProfileName;
+    if (_switchGen === _profileSwitchGeneration && quickSel) quickSel.value = _prevProfileName;
     if (_switchGen === _profileSwitchGeneration) showToast(t('switch_failed') + e.message);
   } finally {
     // Always remove loading indicator regardless of success or failure

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -798,6 +798,7 @@ async function loadSession(sid){
   // ── Cross-channel handoff hint ──
   // After session fully loaded, check if this is a messaging session with
   // enough conversation rounds to warrant a handoff hint bar.
+  if(typeof renderSessionArtifacts==='function') renderSessionArtifacts();
   if (S.session && _isMessagingSession(S.session)) {
     _checkAndShowHandoffHint(sid);
   } else {
@@ -2112,6 +2113,16 @@ let _sessionEventsSSE = null;
 let _sessionEventsRefreshTimer = 0;
 let _sessionEventsReconnectTimer = 0;
 let _sessionEventsNeedsRefreshOnOpen = false;
+let _sessionEventsReconnectAttempt = 0;
+const _sessionEventsReconnectBaseMs = 5000;
+const _sessionEventsReconnectMaxMs = 30000;
+
+function _sessionEventsReconnectDelayMs(){
+  const attempt = Math.max(0, Number(_sessionEventsReconnectAttempt || 0));
+  const base = Math.min(_sessionEventsReconnectMaxMs, _sessionEventsReconnectBaseMs * Math.pow(2, attempt));
+  const jitter = Math.floor(Math.random() * Math.max(1, Math.floor(base * 0.35)));
+  return Math.min(_sessionEventsReconnectMaxMs, Math.floor(base * 0.75) + jitter);
+}
 let _sessionListRefreshInFlight = false;
 let _sessionListRefreshPendingReason = '';
 
@@ -2233,6 +2244,7 @@ function ensureSessionEventsSSE(){
     // Same-origin relative URL preserves subpath mounts and normal WebUI cookies.
     _sessionEventsSSE = new EventSource('api/sessions/events');
     _sessionEventsSSE.onopen = () => {
+      _sessionEventsReconnectAttempt = 0;
       if(!_sessionEventsNeedsRefreshOnOpen) return;
       _sessionEventsNeedsRefreshOnOpen = false;
       void refreshSessionList('reconnect');
@@ -2244,10 +2256,12 @@ function ensureSessionEventsSSE(){
       _sessionEventsNeedsRefreshOnOpen = true;
       _closeSessionEventsSSE();
       if(_sessionEventsReconnectTimer) return;
+      const delayMs = _sessionEventsReconnectDelayMs();
+      _sessionEventsReconnectAttempt = Math.min(_sessionEventsReconnectAttempt + 1, 6);
       _sessionEventsReconnectTimer = setTimeout(() => {
         _sessionEventsReconnectTimer = 0;
         ensureSessionEventsSSE();
-      }, 5000);
+      }, delayMs);
     };
   }catch(e){
     _closeSessionEventsSSE();

--- a/static/style.css
+++ b/static/style.css
@@ -3745,6 +3745,22 @@ main.main > .main-view:not([id="mainChat"]):not([id="mainSettings"]) .main-view-
 .detail-run-body{display:none;margin-top:6px;font-size:12px;color:var(--muted);white-space:pre-wrap;line-height:1.5;max-height:260px;overflow-y:auto;background:var(--sidebar);border:1px solid var(--border);border-radius:6px;padding:8px 10px;}
 .detail-run-item.open .detail-run-body{display:block;}
 .detail-run-body.expanded{max-height:none;overflow-y:visible;}
+.sidebar-profile-quick{display:flex;align-items:center;gap:8px;padding:8px 12px;border-bottom:1px solid var(--border);}
+.sidebar-profile-quick label{font-size:11px;color:var(--muted);text-transform:uppercase;letter-spacing:.04em;flex-shrink:0;}
+.sidebar-profile-quick select{min-width:0;flex:1;background:var(--input-bg);color:var(--text);border:1px solid var(--border);border-radius:7px;padding:5px 8px;font-size:12px;}
+.workspace-panel-tabs{display:flex;gap:4px;padding:6px 8px;border-bottom:1px solid var(--border);}
+.workspace-panel-tab{flex:1;border:1px solid transparent;background:transparent;color:var(--muted);border-radius:7px;padding:5px 8px;font-size:12px;cursor:pointer;}
+.workspace-panel-tab.active{background:var(--surface-subtle);color:var(--text);border-color:var(--border2);}
+.workspace-artifacts{flex:1;overflow:auto;padding:8px;}
+.workspace-artifact-empty{padding:16px 8px;color:var(--muted);font-size:12px;line-height:1.5;text-align:center;}
+.workspace-artifact-item{display:block;width:100%;text-align:left;background:var(--surface-subtle);color:var(--text);border:1px solid var(--border);border-radius:8px;padding:8px 10px;margin-bottom:6px;cursor:pointer;}
+.workspace-artifact-item:hover{border-color:var(--accent);}
+.workspace-artifact-path{font-family:'SF Mono',ui-monospace,monospace;font-size:12px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
+.workspace-artifact-meta{margin-top:3px;color:var(--muted);font-size:11px;}
+.workspace-artifacts-count{opacity:.65;font-size:11px;}
+.rightpanel[data-active-tab="artifacts"] .breadcrumb-bar,.rightpanel[data-active-tab="artifacts"] .file-tree,.rightpanel[data-active-tab="artifacts"] #wsEmptyState{display:none!important;}
+.rightpanel[data-active-tab="artifacts"] .workspace-artifacts{display:block;}
+.rightpanel[data-active-tab="files"] .workspace-artifacts{display:none!important;}
 .cron-run-usage-strip{display:inline-flex;align-items:center;gap:4px;margin-left:8px;color:var(--text-secondary);font-size:11px;opacity:.72;white-space:nowrap;}
 .cron-run-usage-footer{display:flex;margin:8px 0 0 0;padding-top:8px;border-top:1px solid var(--border-subtle);}
 .cron-item.active,.ws-row.active,.profile-card.active{background:var(--accent-bg);}

--- a/static/workspace.js
+++ b/static/workspace.js
@@ -103,6 +103,102 @@ function _restoreExpandedDirs(){
   }catch(e){S._expandedDirs=new Set();}
 }
 
+let _workspacePanelActiveTab = 'files';
+
+function switchWorkspacePanelTab(tab){
+  _workspacePanelActiveTab = tab === 'artifacts' ? 'artifacts' : 'files';
+  const panel = document.querySelector('.rightpanel');
+  if(panel) panel.dataset.activeTab = _workspacePanelActiveTab;
+  const filesTab = $('workspaceFilesTab');
+  const artifactsTab = $('workspaceArtifactsTab');
+  if(filesTab){
+    filesTab.classList.toggle('active', _workspacePanelActiveTab === 'files');
+    filesTab.setAttribute('aria-selected', _workspacePanelActiveTab === 'files' ? 'true' : 'false');
+  }
+  if(artifactsTab){
+    artifactsTab.classList.toggle('active', _workspacePanelActiveTab === 'artifacts');
+    artifactsTab.setAttribute('aria-selected', _workspacePanelActiveTab === 'artifacts' ? 'true' : 'false');
+  }
+  const artifacts = $('workspaceArtifacts');
+  if(artifacts) artifacts.hidden = _workspacePanelActiveTab !== 'artifacts';
+  if(_workspacePanelActiveTab === 'artifacts') renderSessionArtifacts();
+}
+
+function _artifactCandidatesFromText(text){
+  if(!text || typeof text !== 'string') return [];
+  const out = [];
+  const seen = new Set();
+  const add = (path, kind='referenced') => {
+    if(!path) return;
+    path = String(path).trim().replace(/[\`"'<>),.;:]+$/g,'').replace(/^[\`"'(<]+/g,'');
+    if(!path || path.length > 240 || path.includes('://')) return;
+    if(!/[./]/.test(path)) return;
+    if(seen.has(path)) return;
+    seen.add(path); out.push({path, kind});
+  };
+  const fenced = /```(?:diff|patch)?\n[\s\S]*?```/gi;
+  let m;
+  while((m = fenced.exec(text))){
+    const block = m[0];
+    const fm = block.match(/(?:^|\n)(?:\+\+\+|---)\s+(?:[ab]\/)?([^\n\t]+)/);
+    if(fm) add(fm[1].trim(), 'diff');
+  }
+  const patterns = [
+    /(?:created|wrote|updated|edited|saved|modified)\s+(?:file\s+)?[`"']?([^`"'\n]+?\.[A-Za-z0-9]{1,12})[`"']?(?=$|[\s),.;:])/gi,
+    /(?:MEDIA:)?((?:\/|~\/|\.\.?\/)?[A-Za-z0-9_@~.-][A-Za-z0-9_@~.\/-]*\.[A-Za-z0-9]{1,12})/g
+  ];
+  for(const re of patterns){
+    while((m = re.exec(text))) add(m[1] || m[0]);
+  }
+  return out;
+}
+
+function collectSessionArtifacts(){
+  const items = [];
+  const seen = new Set();
+  const push = (path, source) => {
+    if(!path || seen.has(path)) return;
+    seen.add(path); items.push({path, source});
+  };
+  for(const msg of (S.messages || [])){
+    const text = msg && (msg.content || msg.text || msg.message || '');
+    for(const a of _artifactCandidatesFromText(text)) push(a.path, a.kind);
+  }
+  for(const tc of (S.toolCalls || [])){
+    const args = tc && (tc.arguments || tc.args || tc.input);
+    const result = tc && (tc.result || tc.output || '');
+    for(const source of [args, result]){
+      const text = typeof source === 'string' ? source : (source ? JSON.stringify(source) : '');
+      for(const a of _artifactCandidatesFromText(text)) push(a.path, tc.name || a.kind);
+    }
+  }
+  return items.slice(0, 50);
+}
+
+function renderSessionArtifacts(){
+  const root = $('workspaceArtifacts');
+  const count = $('workspaceArtifactsCount');
+  if(!root) return;
+  const items = collectSessionArtifacts();
+  if(count) count.textContent = String(items.length);
+  if(!S.session){
+    root.innerHTML = '<div class="workspace-artifact-empty">Open a conversation to see files mentioned or changed in this session.</div>';
+    return;
+  }
+  if(!items.length){
+    root.innerHTML = '<div class="workspace-artifact-empty">No artifacts detected yet. Files created, edited, or referenced during this session will appear here.</div>';
+    return;
+  }
+  root.innerHTML = items.map(item => `<button type="button" class="workspace-artifact-item" data-artifact-path="${esc(item.path)}" onclick="openArtifactPath(this.dataset.artifactPath)"><div class="workspace-artifact-path">${esc(item.path)}</div><div class="workspace-artifact-meta">${esc(item.source || 'session')}</div></button>`).join('');
+}
+
+function openArtifactPath(path){
+  if(!path) return;
+  switchWorkspacePanelTab('files');
+  const rel = path.replace(/^~\//,'').replace(/^\.\//,'');
+  openFile(rel);
+}
+
 async function loadDir(path){
   if(!S.session)return;
   try{
@@ -112,7 +208,7 @@ async function loadDir(path){
     }
     S.currentDir=path||'.';
     const data=await api(`/api/list?session_id=${encodeURIComponent(S.session.session_id)}&path=${encodeURIComponent(path)}`);
-    S.entries=data.entries||[];renderBreadcrumb();renderFileTree();
+    S.entries=data.entries||[];renderBreadcrumb();renderFileTree();renderSessionArtifacts();
     // Pre-fetch contents of restored expanded dirs so they render without a second click
     // (parallelized — avoids serial waterfall when multiple dirs are expanded)
     if(!path||path==='.'){

--- a/tests/test_issue2661_2629_2645_2655_frontend.py
+++ b/tests/test_issue2661_2629_2645_2655_frontend.py
@@ -1,0 +1,54 @@
+from pathlib import Path
+
+
+SESSIONS_JS = Path("static/sessions.js").read_text(encoding="utf-8")
+PANELS_JS = Path("static/panels.js").read_text(encoding="utf-8")
+WORKSPACE_JS = Path("static/workspace.js").read_text(encoding="utf-8")
+INDEX_HTML = Path("static/index.html").read_text(encoding="utf-8")
+STYLE_CSS = Path("static/style.css").read_text(encoding="utf-8")
+CHANGELOG = Path("CHANGELOG.md").read_text(encoding="utf-8")
+
+
+def test_session_events_reconnect_uses_jittered_backoff_not_fixed_delay():
+    assert "function _sessionEventsReconnectDelayMs()" in SESSIONS_JS
+    assert "Math.random()" in SESSIONS_JS
+    assert "_sessionEventsReconnectMaxMs" in SESSIONS_JS
+    assert "_sessionEventsReconnectAttempt = 0" in SESSIONS_JS
+    ensure_fn = SESSIONS_JS[SESSIONS_JS.find("function ensureSessionEventsSSE()") :]
+    assert "const delayMs = _sessionEventsReconnectDelayMs();" in ensure_fn
+    assert "}, 5000);" not in ensure_fn
+
+
+def test_cron_expanded_run_renders_full_content_inline():
+    assert "const expanded = _cronExpansionGet(_cronRunExpandKey(jobId, filename));" in PANELS_JS
+    assert "const output = expanded ? (data.content || data.snippet || '') : (data.snippet || data.content || '');" in PANELS_JS
+    assert "if (!expanded && data.content && data.snippet && data.content.length > data.snippet.length)" in PANELS_JS
+    assert "_cronExpansionSet(_cronRunExpandKey(jobId, filename), true);" in PANELS_JS
+
+
+def test_sidebar_has_quick_profile_switcher_synced_to_profile_api():
+    assert "id=\"sidebarProfileSelect\"" in INDEX_HTML
+    assert "onchange=\"switchToProfile(this.value)\"" in INDEX_HTML
+    assert "function refreshQuickProfileSelect(data)" in PANELS_JS
+    assert "api('/api/profiles').then(refreshQuickProfileSelect)" in PANELS_JS
+    assert "if(quickSel) quickSel.value = S.activeProfile;" in PANELS_JS
+    assert ".sidebar-profile-quick" in STYLE_CSS
+
+
+def test_workspace_artifacts_tab_collects_session_files_and_previews_them():
+    assert "id=\"workspaceArtifactsTab\"" in INDEX_HTML
+    assert "id=\"workspaceArtifacts\"" in INDEX_HTML
+    assert "function collectSessionArtifacts()" in WORKSPACE_JS
+    assert "function renderSessionArtifacts()" in WORKSPACE_JS
+    assert "function openArtifactPath(path)" in WORKSPACE_JS
+    assert "openFile(rel);" in WORKSPACE_JS
+    assert "renderSessionArtifacts();" in SESSIONS_JS
+    assert ".workspace-artifact-item" in STYLE_CSS
+
+
+def test_changelog_mentions_the_four_webui_polish_items():
+    unreleased = CHANGELOG.split("## [v0.51.103]", 1)[0]
+    assert "sidebar quick profile switcher" in unreleased
+    assert "Artifacts tab" in unreleased
+    assert "bounded jitter/backoff" in unreleased
+    assert "Expanded cron run rows" in unreleased


### PR DESCRIPTION
## Thinking Path
- Abdiel asked to tackle the four WebUI polish candidates from the shortlist.
- #2661 is a narrow session-events SSE resiliency fix: reconnects should not herd every tab at the same fixed delay.
- #2629 is a cron UX fix: expanded run details should actually show full output inline.
- #2645 asks for quick profile access outside an active chat, so the sidebar now has a persistent compact profile selector.
- #2655 is scoped as an MVP: a workspace-panel Artifacts tab discovers likely files from session messages/tool metadata and opens them through the existing preview path.

## What Changed
- Added bounded jitter/backoff for session-events SSE reconnects and reset the attempt counter on open.
- Changed cron run rendering so expanded rows render full `content` inline; collapsed rows keep the snippet and optional “View full output” affordance.
- Added a sidebar quick profile selector synced with `/api/profiles` and existing `switchToProfile()` flow.
- Added a Files / Artifacts tab strip to the workspace panel. The Artifacts tab lists likely file paths from the active session and opens selected artifacts in the existing file preview.
- Added focused static regression coverage and changelog entries.

## Why It Matters
- Reduces reconnect bursts after WebUI restarts or transient network drops.
- Makes cron run details match the expanded-state expectation.
- Makes profile switching discoverable and reachable from the session list/sidebar context.
- Gives users a first lightweight way to review generated/edited files from a session without manually hunting paths.

## Verification
- `python3.11 -m pytest tests/test_issue2661_2629_2645_2655_frontend.py tests/test_webui_external_refresh_frontend.py -q` → 12 passed
- `python3.11 -m py_compile api/routes.py api/profiles.py`
- `node --check static/sessions.js`
- `node --check static/panels.js`
- `node --check static/workspace.js`
- `git diff --check`

## Risks / Follow-ups
- This intentionally scopes Artifacts as a frontend MVP based on discovered path mentions/tool metadata. A future backend-backed artifact index could track exact write operations with stable metadata.
- This combines four related polish items because the request was to do all of them; maintainers may prefer splitting into separate PRs.

Closes #2661
Closes #2629
Refs #2645
Refs #2655
