### PR TITLE
Fix new chat default model provider sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- New conversations now resync the model picker when the default model provider changes but the model id matches a stale previous selection, so fresh chats visibly use the configured default model provider.
+
 
 ## [v0.51.103] — 2026-05-21 — Release CA (stage-396 — 1-PR follow-on — Settings → Plugins distinguishes exclusive/provider activation)
 

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -474,11 +474,22 @@ async function newSession(flash, options={}){
     try{localStorage.setItem('hermes-webui-session',S.session.session_id);}catch(_){}
     _setActiveSessionUrl(S.session.session_id);
     _setSessionViewedCount(S.session.session_id, S.session.message_count || 0);
-    // Sync chat-header dropdown to the session's model so the UI reflects
-    // the default model the server actually used (#872).
-    if(S.session.model && S.session.model!==$('modelSelect').value && typeof _applyModelToDropdown==='function'){
-      _applyModelToDropdown(S.session.model,$('modelSelect'),S.session.model_provider||null);
-      if(typeof syncModelChip==='function') syncModelChip();
+    // Sync chat-header dropdown to the session's model/provider so the UI reflects
+    // the default route the server actually used (#872). Compare provider state too:
+    // duplicate model ids can exist under several providers, and a stale persisted
+    // picker selection with the same model id should not mask the new session's
+    // configured default provider.
+    const modelSel=$('modelSelect');
+    if(S.session.model && modelSel && typeof _applyModelToDropdown==='function'){
+      const currentModelState=(typeof _modelStateForSelect==='function')
+        ? _modelStateForSelect(modelSel,modelSel.value)
+        : {model:modelSel.value,model_provider:null};
+      const sessionProvider=S.session.model_provider||null;
+      const currentProvider=currentModelState.model_provider||null;
+      if(S.session.model!==modelSel.value || sessionProvider !== currentProvider){
+        _applyModelToDropdown(S.session.model,modelSel,sessionProvider);
+        if(typeof syncModelChip==='function') syncModelChip();
+      }
     }
     // Reset per-session visual state: a fresh chat is idle even if another
     // conversation is still streaming in the background.

--- a/tests/test_new_chat_default_model_frontend.py
+++ b/tests/test_new_chat_default_model_frontend.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+
+SESSIONS_JS = Path("static/sessions.js").read_text(encoding="utf-8")
+MESSAGES_JS = Path("static/messages.js").read_text(encoding="utf-8")
+CHANGELOG = Path("CHANGELOG.md").read_text(encoding="utf-8")
+
+
+def _new_session_function() -> str:
+    start = SESSIONS_JS.index("async function newSession")
+    end = SESSIONS_JS.index("async function loadSession", start)
+    return SESSIONS_JS[start:end]
+
+
+def test_new_chat_syncs_model_picker_when_default_provider_changes_but_model_id_matches():
+    fn = _new_session_function()
+    assert "currentModelState" in fn
+    assert "currentProvider" in fn
+    assert "sessionProvider" in fn
+    assert "sessionProvider !== currentProvider" in fn
+    assert "_applyModelToDropdown(S.session.model,modelSel,sessionProvider)" in fn
+
+
+def test_new_chat_does_not_send_stale_dropdown_model_when_session_has_default_model():
+    assert "model:S.session.model||$('modelSelect').value" in MESSAGES_JS
+    assert "model_provider:S.session.model_provider||null" in MESSAGES_JS
+
+
+def test_changelog_mentions_new_chat_default_model_provider_sync():
+    unreleased = CHANGELOG.split("## [v0.51.103]", 1)[0]
+    assert "New conversations now resync" in unreleased
+    assert "default model provider" in unreleased

--- a/tests/test_new_chat_default_model_frontend.py
+++ b/tests/test_new_chat_default_model_frontend.py
@@ -5,10 +5,25 @@ MESSAGES_JS = Path("static/messages.js").read_text(encoding="utf-8")
 CHANGELOG = Path("CHANGELOG.md").read_text(encoding="utf-8")
 
 
+def _extract_function(source: str, signature: str) -> str:
+    start = source.index(signature)
+    # Look for the function body's opening brace, not an object literal inside
+    # a default argument such as `options={}`.
+    brace = source.index("{\n", start)
+    depth = 0
+    for idx in range(brace, len(source)):
+        ch = source[idx]
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return source[start : idx + 1]
+    raise AssertionError(f"Function body not closed for {signature}")
+
+
 def _new_session_function() -> str:
-    start = SESSIONS_JS.index("async function newSession")
-    end = SESSIONS_JS.index("async function loadSession", start)
-    return SESSIONS_JS[start:end]
+    return _extract_function(SESSIONS_JS, "async function newSession")
 
 
 def test_new_chat_syncs_model_picker_when_default_provider_changes_but_model_id_matches():


### PR DESCRIPTION
## Summary
- Resyncs the new-chat model picker when the server-created session has the same model id as the current dropdown selection but a different provider.
- Prevents a stale persisted picker/provider selection from making a fresh conversation appear to ignore the configured default model provider.
- Adds a focused frontend regression test for the provider-comparison path.

## Test plan
- `python3.11 -m pytest tests/test_new_chat_default_model_frontend.py tests/test_issue1855_resolve_model_provider_fast_path.py -q`
- `node --check static/sessions.js`
- `git diff --check`
