### PR TITLE
Fix stale session render cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Prevent stale chat HTML from being reused after session switches when the
+  message count stays the same but the visible transcript content or compression
+  anchor changes.
+
 
 ## [v0.51.103] — 2026-05-21 — Release CA (stage-396 — 1-PR follow-on — Settings → Plugins distinguishes exclusive/provider activation)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 - Prevent stale chat HTML from being reused after session switches when the
   message count stays the same but the visible transcript content or compression
   anchor changes.
+- Avoid recomputing the session HTML cache signature during in-session renders
+  where the cache cannot be used, reducing long-transcript chat UI stalls.
 
 
 ## [v0.51.103] — 2026-05-21 — Release CA (stage-396 — 1-PR follow-on — Settings → Plugins distinguishes exclusive/provider activation)

--- a/static/ui.js
+++ b/static/ui.js
@@ -5755,7 +5755,8 @@ function renderMessages(options){
     (window._compressionUi&&(!window._compressionUi.sessionId||window._compressionUi.sessionId===sid)) ||
     (window._handoffUi&&(!window._handoffUi.sessionId||window._handoffUi.sessionId===sid))
   );
-  const cacheSignature=_messageRenderCacheSignature(S.messages, renderWindowSize);
+  const cacheEligible=!!(sid&&sid!==_sessionHtmlCacheSid&&!INFLIGHT[sid]&&!hasTransientTranscriptUi);
+  const cacheSignature=cacheEligible?_messageRenderCacheSignature(S.messages, renderWindowSize):null;
 
   // Fast path: switching back to a previously rendered session with same count.
   // Guard: sid !== _sessionHtmlCacheSid ensures in-session updates (edits,
@@ -5765,7 +5766,7 @@ function renderMessages(options){
   // Also skip cache for transient transcript cards such as /compress and
   // cross-channel handoff summaries; otherwise the cached transcript returns
   // before those cards can be inserted.
-  if(sid&&sid!==_sessionHtmlCacheSid&&!INFLIGHT[sid]&&!hasTransientTranscriptUi){
+  if(cacheEligible){
     const cached=_sessionHtmlCache.get(sid);
     if(cached&&cached.msgCount===msgCount&&cached.renderWindowSize===renderWindowSize&&cached.signature===cacheSignature){
       inner.innerHTML=cached.html;
@@ -6374,7 +6375,7 @@ function renderMessages(options){
   if(typeof _applyMediaPlaybackPreferences==='function') _applyMediaPlaybackPreferences(inner);
   // Populate session cache so switching back here skips a full rebuild.
   _sessionHtmlCacheSid=sid;
-  if(sid&&!hasTransientTranscriptUi){
+  if(sid&&!hasTransientTranscriptUi&&cacheSignature){
     const _html=inner.innerHTML;
     // Only cache sessions with <300KB rendered HTML; evict oldest beyond 8 sessions.
     if(_html.length<300_000){

--- a/static/ui.js
+++ b/static/ui.js
@@ -5537,19 +5537,72 @@ function renderCompressionUi(){
   el.style.display='none';
 }
 // Session render cache: avoids full markdown+DOM rebuild when switching back
-// to a session that was already rendered with the same message count.
+// to a session that was already rendered with the same visible transcript.
 // Keyed by session_id. Only used on cross-session navigation, never for
 // in-session updates (new messages, edits, stream events).
-//
-// Known limitation: cache key is session_id + message count. Edits and retries
-// that mutate message content without changing the count will serve stale HTML
-// on back-navigation until the user triggers an in-session update. Acceptable
-// for the common read-only back-navigation case; not suitable as a general cache.
 const _sessionHtmlCache=new Map();
 let _sessionHtmlCacheSid=null; // session_id currently rendered in the DOM
 function clearMessageRenderCache(){
   _sessionHtmlCache.clear();
   _sessionHtmlCacheSid=null;
+}
+
+function _messageRenderHash(value){
+  const s=String(value||'');
+  let h=2166136261;
+  for(let i=0;i<s.length;i++){
+    h^=s.charCodeAt(i);
+    h=Math.imul(h,16777619);
+  }
+  return `${s.length}:${h>>>0}`;
+}
+function _messageRenderCachePart(m){
+  if(!m||typeof m!=='object') return 'null';
+  let text='';
+  try{text=msgContent(m);}
+  catch(_){text=typeof m.content==='string'?m.content:JSON.stringify(m.content||'');}
+  const attachments=Array.isArray(m.attachments)?m.attachments.map(a=>typeof a==='string'?a:(a&&(a.name||a.filename||a.path))||'').join(','):'';
+  const toolCalls=Array.isArray(m.tool_calls)
+    ? m.tool_calls.map(tc=>{
+        const fn=tc&&(tc.function||tc);
+        return `${tc&&(tc.id||tc.call_id)||''}:${fn&&(fn.name||'')}:${_messageRenderHash(fn&&(fn.arguments||fn.input||''))}`;
+      }).join(',')
+    : '';
+  const contentShape=Array.isArray(m.content)
+    ? m.content.map(p=>p&&p.type||'').join(',')
+    : typeof m.content;
+  const rawContentHash=_messageRenderHash(
+    typeof m.content==='string' ? m.content : JSON.stringify(m.content||'')
+  );
+  return [
+    m.id||m.message_id||'',
+    m.role||'',
+    m.timestamp||m._ts||'',
+    m.tool_call_id||m.tool_use_id||'',
+    m.tool_name||m.name||'',
+    _messageRenderHash(text),
+    rawContentHash,
+    contentShape,
+    attachments,
+    toolCalls,
+    m._live?'live':'',
+    m._pending?'pending':'',
+    m._statusCard?_messageRenderHash(JSON.stringify(m._statusCard)):'',
+    m.reasoning?_messageRenderHash(m.reasoning):'',
+  ].join('\x1f');
+}
+function _messageRenderCacheSignature(messages, renderWindowSize){
+  const session=S.session||{};
+  const anchor={
+    truncated:!!(typeof _messagesTruncated!=='undefined'&&_messagesTruncated),
+    oldestIdx:typeof _oldestIdx!=='undefined'?_oldestIdx:0,
+    renderWindowSize,
+    compressionAnchorVisibleIdx:session.compression_anchor_visible_idx,
+    compressionAnchorMessageKey:session.compression_anchor_message_key||null,
+    compressionAnchorSummary:session.compression_anchor_summary||'',
+  };
+  const rows=(Array.isArray(messages)?messages:[]).map(_messageRenderCachePart).join('\x1e');
+  return `${_messageRenderHash(JSON.stringify(anchor))}:${_messageRenderHash(rows)}`;
 }
 
 function _clipCliToolSnippet(text, maxLen=20000){
@@ -5702,6 +5755,7 @@ function renderMessages(options){
     (window._compressionUi&&(!window._compressionUi.sessionId||window._compressionUi.sessionId===sid)) ||
     (window._handoffUi&&(!window._handoffUi.sessionId||window._handoffUi.sessionId===sid))
   );
+  const cacheSignature=_messageRenderCacheSignature(S.messages, renderWindowSize);
 
   // Fast path: switching back to a previously rendered session with same count.
   // Guard: sid !== _sessionHtmlCacheSid ensures in-session updates (edits,
@@ -5713,7 +5767,7 @@ function renderMessages(options){
   // before those cards can be inserted.
   if(sid&&sid!==_sessionHtmlCacheSid&&!INFLIGHT[sid]&&!hasTransientTranscriptUi){
     const cached=_sessionHtmlCache.get(sid);
-    if(cached&&cached.msgCount===msgCount&&cached.renderWindowSize===renderWindowSize){
+    if(cached&&cached.msgCount===msgCount&&cached.renderWindowSize===renderWindowSize&&cached.signature===cacheSignature){
       inner.innerHTML=cached.html;
       _sessionHtmlCacheSid=sid;
       _wireMessageWindowLoadEarlierButton();
@@ -6324,7 +6378,7 @@ function renderMessages(options){
     const _html=inner.innerHTML;
     // Only cache sessions with <300KB rendered HTML; evict oldest beyond 8 sessions.
     if(_html.length<300_000){
-      _sessionHtmlCache.set(sid,{html:_html,msgCount,renderWindowSize});
+      _sessionHtmlCache.set(sid,{html:_html,msgCount,renderWindowSize,signature:cacheSignature});
       if(_sessionHtmlCache.size>8){_sessionHtmlCache.delete(_sessionHtmlCache.keys().next().value);}
     }
   }

--- a/tests/test_session_render_cache_signature.py
+++ b/tests/test_session_render_cache_signature.py
@@ -1,0 +1,48 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+UI_JS = (ROOT / "static" / "ui.js").read_text(encoding="utf-8")
+
+
+def _function_body(src: str, name: str) -> str:
+    start = src.find(f"function {name}(")
+    assert start != -1, f"{name} not found"
+    brace = src.find("{", start)
+    depth = 0
+    for idx in range(brace, len(src)):
+        ch = src[idx]
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return src[brace + 1:idx]
+    raise AssertionError(f"{name} body did not close")
+
+
+def test_session_html_cache_uses_message_signature_not_count_only():
+    render = _function_body(UI_JS, "renderMessages")
+    assert "const cacheSignature=_messageRenderCacheSignature(S.messages, renderWindowSize);" in render
+    assert "cached.signature===cacheSignature" in render
+    assert "signature:cacheSignature" in render
+    assert "cached.msgCount===msgCount&&cached.renderWindowSize===renderWindowSize)" not in render
+
+
+def test_message_render_cache_signature_covers_content_and_compression_anchor():
+    helper = _function_body(UI_JS, "_messageRenderCacheSignature")
+    part = _function_body(UI_JS, "_messageRenderCachePart")
+    assert "compression_anchor_visible_idx" in helper
+    assert "compression_anchor_message_key" in helper
+    assert "compression_anchor_summary" in helper
+    assert ".map(_messageRenderCachePart)" in helper
+    assert "msgContent(m)" in part
+    assert "rawContentHash" in part
+    assert "JSON.stringify(m.content||'')" in part
+    assert "m._pending?'pending'" in part
+    assert "m._live?'live'" in part
+
+
+def test_old_count_only_cache_limitation_comment_removed():
+    assert "cache key is session_id + message count" not in UI_JS
+    assert "serve stale HTML" not in UI_JS

--- a/tests/test_session_render_cache_signature.py
+++ b/tests/test_session_render_cache_signature.py
@@ -23,9 +23,12 @@ def _function_body(src: str, name: str) -> str:
 
 def test_session_html_cache_uses_message_signature_not_count_only():
     render = _function_body(UI_JS, "renderMessages")
-    assert "const cacheSignature=_messageRenderCacheSignature(S.messages, renderWindowSize);" in render
+    assert "const cacheEligible=!!(sid&&sid!==_sessionHtmlCacheSid&&!INFLIGHT[sid]&&!hasTransientTranscriptUi);" in render
+    assert "const cacheSignature=cacheEligible?_messageRenderCacheSignature(S.messages, renderWindowSize):null;" in render
+    assert "if(cacheEligible)" in render
     assert "cached.signature===cacheSignature" in render
     assert "signature:cacheSignature" in render
+    assert "if(sid&&!hasTransientTranscriptUi&&cacheSignature)" in render
     assert "cached.msgCount===msgCount&&cached.renderWindowSize===renderWindowSize)" not in render
 
 


### PR DESCRIPTION
  ## Summary

  Fixes a WebUI transcript rendering cache issue where session HTML could be reused after switching sessions when only
  the message count and render window size matched. This could make the visible transcript stale, including recently
  sent messages disappearing or old messages appearing in the wrong position after navigation or context compaction.

  This is a follow-up to #963 and fixes the known limitation where the session render cache was keyed only by session
  id, message count, and render window size.

  ## Root Cause

  `renderMessages()` in `static/ui.js` used a count-based cache guard. When two render states had the same message
  count and render window size, cached `innerHTML` could be reused even if the message content, live/pending state,
  tool metadata, or compression anchor had changed.

  ## Changes

  - Added a deterministic render-cache signature for session messages.
  - Included message identity/content, live and pending flags, status cards, tool calls, attachments, reasoning,
  truncation/window state, and compression anchor metadata in the cache key.
  - Required the cached signature to match before reusing session HTML.
  - Added regression coverage for same-count transcript changes and compression-anchor changes.
  - Updated the changelog.

  ## Validation

  ```bash
  pytest tests/test_session_render_cache_signature.py \
    tests/test_auto_compression_card.py \
    tests/test_regressions.py \
    -q

  pytest tests/test_session_runtime_ownership_invariants.py \
    tests/test_streaming_markdown.py \
    tests/test_stale_stream_cleanup.py \
    tests/test_session_metadata_fast_path.py \
    -q
  ```

  Combined result: `170 passed, 1 skipped` locally. The skipped test was environment-gated, not a failure.