### PR TITLE
fix: prevent replayed context in reconciliation and metering

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -3043,6 +3043,58 @@ def _has_visible_duplicate(visible_key: tuple, visible_keys: set[tuple]) -> bool
     return False
 
 
+def state_db_delta_after_context(sidecar_context: list, state_messages: list) -> list:
+    """Return only state.db rows that are newer than model-facing context.
+
+    `context_messages` is the authoritative model-facing prefix. state.db may
+    contain a mirrored copy of that prefix with fresh timestamps, especially for
+    LCM/continuation sessions. Appending the whole state transcript to a clean
+    sidecar context replays old context into the next runtime prompt.
+    """
+    sidecar_context = list(sidecar_context or [])
+    state_messages = list(state_messages or [])
+    if not sidecar_context or not state_messages:
+        return state_messages
+
+    sidecar_keys = [_session_message_content_key(m) for m in sidecar_context]
+    state_keys = [_session_message_content_key(m) for m in state_messages]
+    max_offset = min(len(sidecar_keys), len(state_keys))
+    best_len = 0
+    for offset in range(max_offset):
+        length = 0
+        while (
+            offset + length < len(sidecar_keys)
+            and length < len(state_keys)
+            and sidecar_keys[offset + length] == state_keys[length]
+        ):
+            length += 1
+        if length > best_len:
+            best_len = length
+
+    # Require at least two mirrored rows. A single repeated short user message
+    # is not enough evidence that state.db starts with a mirrored context
+    # segment, but small recovered contexts often contain only a compact summary
+    # and one follow-up row; those should still use the delta path.
+    if best_len < 2:
+        return state_messages
+
+    sidecar_key_set = set(sidecar_keys)
+    last_represented_state_index = best_len - 1
+    for idx, key in enumerate(state_keys[best_len:], start=best_len):
+        if key in sidecar_key_set:
+            last_represented_state_index = idx
+
+    delta = []
+    for msg, key in zip(
+        state_messages[last_represented_state_index + 1:],
+        state_keys[last_represented_state_index + 1:],
+    ):
+        if key in sidecar_key_set:
+            continue
+        delta.append(msg)
+    return delta
+
+
 def merge_session_messages_append_only(sidecar_messages: list, state_messages: list) -> list:
     """Merge sidecar/context and state.db messages without deleting local rows."""
     sidecar_messages = list(sidecar_messages or [])
@@ -3131,6 +3183,8 @@ def reconciled_state_db_messages_for_session(
         local_messages = getattr(session, 'messages', None) or []
     if state_messages is None:
         state_messages = get_state_db_session_messages(getattr(session, 'session_id', None))
+    if prefer_context and local_messages:
+        state_messages = state_db_delta_after_context(local_messages, state_messages)
     return merge_session_messages_append_only(local_messages, state_messages)
 
 

--- a/api/models.py
+++ b/api/models.py
@@ -3078,21 +3078,19 @@ def state_db_delta_after_context(sidecar_context: list, state_messages: list) ->
     if best_len < 2:
         return state_messages
 
-    sidecar_key_set = set(sidecar_keys)
-    last_represented_state_index = best_len - 1
-    for idx, key in enumerate(state_keys[best_len:], start=best_len):
-        if key in sidecar_key_set:
-            last_represented_state_index = idx
-
-    delta = []
-    for msg, key in zip(
-        state_messages[last_represented_state_index + 1:],
-        state_keys[last_represented_state_index + 1:],
-    ):
-        if key in sidecar_key_set:
-            continue
-        delta.append(msg)
-    return delta
+    # Drop only rows that can be aligned with the remaining sidecar context in
+    # order. This still tolerates stale state-only rows between mirrored context
+    # rows, but once the sidecar context is exhausted every later state row is a
+    # real delta, even if it repeats a short earlier message.
+    sidecar_index = best_len
+    state_index = best_len
+    while sidecar_index < len(sidecar_keys) and state_index < len(state_keys):
+        if state_keys[state_index] == sidecar_keys[sidecar_index]:
+            sidecar_index += 1
+        state_index += 1
+    if sidecar_index == len(sidecar_keys):
+        return state_messages[state_index:]
+    return state_messages[best_len:]
 
 
 def merge_session_messages_append_only(sidecar_messages: list, state_messages: list) -> list:

--- a/api/routes.py
+++ b/api/routes.py
@@ -8634,6 +8634,7 @@ def _handle_chat_sync(handler, body):
                 session_id=s.session_id,
             )
             from api.streaming import (
+                _dedupe_replayed_context_messages,
                 _merge_display_messages_after_agent_result,
                 _restore_display_reasoning_metadata,
                 _restore_reasoning_metadata,
@@ -8683,6 +8684,10 @@ def _handle_chat_sync(handler, body):
         _next_context_messages = _restore_reasoning_metadata(
             _previous_context_messages,
             _result_messages,
+        )
+        _next_context_messages = _dedupe_replayed_context_messages(
+            _previous_context_messages,
+            _next_context_messages,
         )
         s.context_messages = _next_context_messages
         s.messages = _merge_display_messages_after_agent_result(

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -2286,8 +2286,68 @@ def _strip_replayed_prefix(existing_messages, candidates):
     return candidates
 
 
-def _dedupe_replayed_active_context(previous_context, result_messages):
-    """Keep model context append-only without re-appending a replayed tail."""
+def _looks_like_replayed_session_arc_summary(previous_msg, candidate_msg):
+    """Return True for repeated LCM/session summaries with refreshed hints.
+
+    LCM summary cards can be re-injected with the same long recovered context
+    and a different tail such as an expand hint. Exact identity misses those,
+    but appending both copies bloats every later model prompt.
+    """
+    if not isinstance(previous_msg, dict) or not isinstance(candidate_msg, dict):
+        return False
+    if previous_msg.get('role') != candidate_msg.get('role'):
+        return False
+    previous_text = " ".join(_message_text(previous_msg.get('content', '')).split())
+    candidate_text = " ".join(_message_text(candidate_msg.get('content', '')).split())
+    if len(previous_text) < 2000 or len(candidate_text) < 2000:
+        return False
+    marker = '[Session Arc Summary'
+    if not previous_text.startswith(marker) or not candidate_text.startswith(marker):
+        return False
+    return previous_text[:1500] == candidate_text[:1500]
+
+
+def _strip_replayed_context_items(existing_messages, candidates):
+    """Drop replayed non-adjacent context blocks before persisting context."""
+    existing_messages = list(existing_messages or [])
+    candidates = list(candidates or [])
+    if not existing_messages or not candidates:
+        return candidates
+
+    existing_keys = [_message_replay_key(m) for m in existing_messages]
+    candidate_keys = [_message_replay_key(m) for m in candidates]
+    existing_large = [m for m in existing_messages if isinstance(m, dict)]
+    cleaned = []
+    idx = 0
+    min_block = 3
+    while idx < len(candidates):
+        msg = candidates[idx]
+        if any(_looks_like_replayed_session_arc_summary(prev, msg) for prev in existing_large):
+            idx += 1
+            continue
+
+        best = 0
+        for start in range(len(existing_keys)):
+            length = 0
+            while (
+                idx + length < len(candidate_keys)
+                and start + length < len(existing_keys)
+                and candidate_keys[idx + length] == existing_keys[start + length]
+            ):
+                length += 1
+            if length > best:
+                best = length
+        if best >= min_block:
+            idx += best
+            continue
+
+        cleaned.append(msg)
+        idx += 1
+    return cleaned
+
+
+def _dedupe_replayed_context_messages(previous_context, result_messages):
+    """Keep model context append-only without replayed blocks/summaries."""
     previous_context = list(previous_context or [])
     result_messages = list(result_messages or [])
     if not previous_context or not result_messages:
@@ -2295,7 +2355,14 @@ def _dedupe_replayed_active_context(previous_context, result_messages):
     if not _messages_have_prefix(result_messages, previous_context):
         return result_messages
     candidates = result_messages[len(previous_context):]
-    return previous_context + _strip_replayed_prefix(previous_context, candidates)
+    candidates = _strip_replayed_prefix(previous_context, candidates)
+    candidates = _strip_replayed_context_items(previous_context, candidates)
+    return previous_context + candidates
+
+
+def _dedupe_replayed_active_context(previous_context, result_messages):
+    """Keep model context append-only without re-appending a replayed tail."""
+    return _dedupe_replayed_context_messages(previous_context, result_messages)
 
 
 def _is_context_compression_marker(msg):
@@ -4451,7 +4518,7 @@ def _run_agent_streaming(
                     _previous_context_messages,
                     _result_messages,
                 )
-                _next_context_messages = _dedupe_replayed_active_context(
+                _next_context_messages = _dedupe_replayed_context_messages(
                     _previous_context_messages,
                     _next_context_messages,
                 )
@@ -4598,7 +4665,7 @@ def _run_agent_streaming(
                                     _previous_context_messages,
                                     _result_messages,
                                 )
-                                _next_context_messages = _dedupe_replayed_active_context(
+                                _next_context_messages = _dedupe_replayed_context_messages(
                                     _previous_context_messages,
                                     _next_context_messages,
                                 )
@@ -5418,7 +5485,7 @@ def _run_agent_streaming(
                                 _next_context_messages = _restore_reasoning_metadata(
                                     _previous_context_messages, _result_messages,
                                 )
-                                _next_context_messages = _dedupe_replayed_active_context(
+                                _next_context_messages = _dedupe_replayed_context_messages(
                                     _previous_context_messages,
                                     _next_context_messages,
                                 )

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -2356,7 +2356,8 @@ def _dedupe_replayed_context_messages(previous_context, result_messages):
         return result_messages
     candidates = result_messages[len(previous_context):]
     candidates = _strip_replayed_prefix(previous_context, candidates)
-    candidates = _strip_replayed_context_items(previous_context, candidates)
+    if candidates:
+        candidates = _strip_replayed_context_items(previous_context, candidates)
     return previous_context + candidates
 
 

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -2744,6 +2744,50 @@ def _assistant_reply_added_after_current_turn(result_messages, previous_context,
 _TOOL_RESULT_SNIPPET_MAX = 4000
 
 
+_LIVE_TOOL_PROMPT_DELTA_MAX = 12_000
+
+
+def _bounded_live_tool_prompt_delta(messages, *, cap: int = _LIVE_TOOL_PROMPT_DELTA_MAX) -> int:
+    """Return a bounded rough token delta for live tool metering.
+
+    Tool-result callbacks can fire before the agent's next exact prompt accounting
+    is available. The live usage ring should show a conservative in-flight hint,
+    not replay a full large tool payload into `last_prompt_tokens`.
+    """
+    if not messages:
+        return 0
+    try:
+        from agent.model_metadata import estimate_messages_tokens_rough
+        delta = int(estimate_messages_tokens_rough(messages) or 0)
+    except Exception:
+        delta = 0
+    if delta <= 0:
+        return 0
+    return min(delta, int(cap or 0))
+
+
+def live_usage_prompt_estimate_after_tool_delta(
+    *,
+    base_prompt_tokens: int,
+    exact_prompt_tokens: int = 0,
+    messages=None,
+    cap: int = _LIVE_TOOL_PROMPT_DELTA_MAX,
+) -> dict:
+    """Compute the live `last_prompt_tokens` estimate after a tool update.
+
+    Exact compressor/provider prompt accounting wins. When no newer exact prompt
+    is available, add only a bounded live tool delta to the persisted base.
+    """
+    base = int(base_prompt_tokens or 0)
+    exact = int(exact_prompt_tokens or 0)
+    if exact and exact != base:
+        return {'last_prompt_tokens': exact, 'estimated': False}
+    return {
+        'last_prompt_tokens': base + _bounded_live_tool_prompt_delta(messages, cap=cap),
+        'estimated': True,
+    }
+
+
 def _tool_result_snippet(raw, limit: int = _TOOL_RESULT_SNIPPET_MAX) -> str:
     """Extract a bounded result preview from a stored tool message payload."""
     if limit <= 0:
@@ -3275,11 +3319,7 @@ def _run_agent_streaming(
         """Increment a rough next-prompt estimate from live tool activity."""
         if not messages:
             return _live_prompt_estimate_tokens[0]
-        try:
-            from agent.model_metadata import estimate_messages_tokens_rough
-            _delta = int(estimate_messages_tokens_rough(messages) or 0)
-        except Exception:
-            _delta = 0
+        _delta = _bounded_live_tool_prompt_delta(messages)
         if _delta > 0:
             _seed_live_prompt_estimate()
             _live_prompt_estimate_tokens[0] += _delta

--- a/pr-artifacts/context-replay-failure-cases.md
+++ b/pr-artifacts/context-replay-failure-cases.md
@@ -141,3 +141,20 @@ Key invariant for upstream:
 If context_messages exists, it is the authoritative model-facing prefix.
 State/db/display histories may be fuller/noisier and should only contribute messages that are demonstrably newer than that prefix.
 ```
+
+
+## F. Live metering over-counts large in-flight tool results after cancel/retry
+
+Observed after deploying the reconciliation fix and retrying `continue` in session `20260521_060755_294aed`:
+
+```text
+persisted sidecar context: 69 messages, ~49,993 rough content tokens
+state.db messages: 90 messages
+state delta after context: 21 messages, ~21,226 rough content tokens
+turn-start context after fix: 90 messages, ~71,219 rough content tokens
+last_prompt_tokens persisted: 86,723 (~33.9%)
+```
+
+The previous full-transcript turn-start replay was gone, but the ring still jumped during the run. The new jump came from live metering, not persisted context reconciliation. The run executed several large `read_file` tool calls (5k / 17k / 13k chars). `_record_live_tool_complete()` fed each bounded preview into `_bump_live_prompt_estimate()`, which added the full rough tool-result tokens to `last_prompt_tokens` before any exact next-prompt accounting was available. Repeated cancel/retry makes this look like context replay even when final sidecar context remains clean.
+
+Regression target: live tool metering should be a conservative UI hint and must not inflate `last_prompt_tokens` by the full content of large in-flight tool results. Exact provider/compressor prompt accounting should still win when available.

--- a/pr-artifacts/context-replay-failure-cases.md
+++ b/pr-artifacts/context-replay-failure-cases.md
@@ -1,0 +1,143 @@
+# Context replay / progress-ring failure cases
+
+This artifact records concrete failure cases observed while debugging WebUI + LCM context replay. It is intended to support an upstream PR with reproducible rationale.
+
+## A. Compression continuation replays active tail into display/context
+
+Observed shape after compression/continuation:
+
+```text
+previous_context = [summary, A, B, C]
+result_messages = previous_context + [A, B, C, D]
+old saved context/display = [summary, A, B, C, A, B, C, D]
+expected = [summary, A, B, C, D]
+```
+
+Code-level cause: writeback assumed `result_messages[len(previous_context):]` was all new delta. After LCM/session rollover, the agent may replay the active tail after the compacted prefix, so this assumption is false.
+
+Regression target: strip candidate prefixes that are already suffixes of existing context/display.
+
+## B. Near-duplicate large Session Arc Summary cards
+
+Observed in WebUI sidecar display transcript for sessions in the `20260520_200424_a43cef` / `20260520_201320_a95eac` lineage:
+
+```text
+[Session Arc Summary (d1, node 39)] ... 62k chars
+[Session Arc Summary (d1, node 39)] ... 62k chars
+[Session Arc Summary (d1, node 39)] ... 74k chars
+```
+
+These summaries shared thousands of identical prefix characters but differed in tails/expand hints. Exact identity checks missed them. One duplicated ~80k char summary explains a ~20k-token jump.
+
+Regression target: treat large `[Session Arc Summary ...]` messages with the same long prefix as replayed summary artifacts.
+
+## C. Non-adjacent replay blocks separated by markers/summaries
+
+Observed display transcript contained repeated blocks that were not immediately adjacent, e.g. best block lengths around 171 messages in historical `messages`:
+
+```text
+A B C ... [compression marker / summary / unrelated rows] ... A B C
+```
+
+Adjacent-only dedupe falsely reported clean. This matters because LCM/continuation can insert compression cards, cron banners, or summary messages between original block and replayed tail.
+
+Regression target: detect and strip replayed non-adjacent blocks when appending model context candidates.
+
+## D. Non-streaming `/api/chat` writeback missed dedupe
+
+Observed session: `20260521_060755_294aed`.
+
+User asked a short question with no meaningful new tool usage:
+
+```text
+这是一个内部服务对么？简答
+```
+
+Before cleanup:
+
+```text
+context_messages: 136
+best replay: 67 messages repeated from index 0 at index 67
+last_prompt_tokens: 136668 (~53.4% of 256k)
+```
+
+Expected shape was:
+
+```text
+previous_context(67) + new_user + new_assistant = 69 messages
+```
+
+Actual cause: streaming writeback used `_dedupe_replayed_context_messages`, but synchronous `/api/chat` wrote `_restore_reasoning_metadata(previous_context, result_messages)` directly to `s.context_messages`.
+
+Regression target: both streaming and non-streaming writeback paths must use the same replay-dedupe guard.
+
+## E. Runtime/progress-ring jump: clean persisted context, polluted turn-start reconciliation
+
+Observed session: `20260521_060755_294aed` after cleanup and deployment.
+
+Persisted sidecar after pause/cancel:
+
+```text
+context_messages: 69
+context chars: 199,972
+rough content tokens: ~49,993
+last_prompt_tokens: 86,723 (~33.9%)
+```
+
+But starting/continuing a streaming turn made the progress ring jump to ~55%. Simulating the turn-start code path showed:
+
+```text
+ctx_before_agent: 154 messages
+chars: 448,438
+rough content tokens: ~112,109
+```
+
+After applying existing final-writeback dedupe to that runtime prompt:
+
+```text
+after_current_dedupe: 85 messages
+chars: 248,466
+rough content tokens: ~62,116
+```
+
+So the ring was not randomly wrong: it reflected a polluted runtime prompt estimate. The persisted sidecar stayed clean because final writeback/cancel did not save the runtime replay.
+
+Code-level cause: streaming turn start does:
+
+```python
+_previous_context_messages = _new_turn_context_from_messages(
+    reconciled_state_db_messages_for_session(
+        s,
+        prefer_context=True,
+        state_messages=_external_state_messages,
+    ),
+    msg_text,
+)
+```
+
+When `prefer_context=True`, sidecar `context_messages` are clean, but `state.db` still contains mirrored/replayed transcript rows. `reconciled_state_db_messages_for_session` append-only merges `context_messages + whole state transcript`, so the agent/runtime prompt temporarily receives old transcript rows again.
+
+Regression target: when `prefer_context=True` and sidecar `context_messages` exists, reconciliation must return:
+
+```text
+clean sidecar context + truly newer state.db delta
+```
+
+not:
+
+```text
+clean sidecar context + full state.db transcript
+```
+
+## PR thesis
+
+The bug family is not a model behavior issue. It is a WebUI persistence/reconciliation invariant violation:
+
+> Model-facing context is append-only, but append candidates may contain replayed context due to LCM/session continuation/state-db mirroring. Every boundary that merges result/state messages into model context must strip replayed prefixes/blocks and must distinguish clean sidecar context from full display/state transcripts.
+
+Key invariant for upstream:
+
+```text
+If context_messages exists, it is the authoritative model-facing prefix.
+State/db/display histories may be fuller/noisier and should only contribute messages that are demonstrably newer than that prefix.
+```

--- a/pr-artifacts/pr-body-summary-replay-dedupe.md
+++ b/pr-artifacts/pr-body-summary-replay-dedupe.md
@@ -79,5 +79,5 @@ python -m compileall -q api/models.py api/streaming.py api/routes.py
 Current local result:
 
 ```text
-43 passed
+45 passed
 ```

--- a/pr-artifacts/pr-body-summary-replay-dedupe.md
+++ b/pr-artifacts/pr-body-summary-replay-dedupe.md
@@ -1,0 +1,83 @@
+## Summary
+
+Follow-up to #2651. That PR fixed one replay boundary, but continued testing exposed the same context-invariant violation at additional WebUI merge/metering boundaries.
+
+This PR makes the replay protection context-engine agnostic:
+
+- strips replayed non-adjacent context blocks and near-duplicate large Session Arc Summary cards before writing model context
+- applies the same replay guard to the non-streaming `/api/chat` writeback path
+- treats `context_messages` as the authoritative model-facing prefix when reconciling sidecar state with `state.db`, appending only demonstrably new state rows
+- caps live tool-result prompt estimates so the context ring does not treat large in-flight tool outputs as exact prompt growth
+
+LCM/continuation made these failures easy to reproduce, but the invariant is broader than LCM:
+
+> If `context_messages` exists, it is the authoritative model-facing prefix. `messages`/`state.db` may be fuller or noisier histories and should only contribute true deltas. Live usage estimates must not override exact prompt accounting.
+
+## Why this happens
+
+WebUI currently merges several histories that have different meanings:
+
+- `context_messages`: compact model-facing context for the next call
+- `messages`: visible display transcript
+- `state.db`: append-only runtime/session journal, including tool rows
+
+After compression/continuation, those sources can overlap. The old code sometimes treated append candidates as wholly new:
+
+```text
+clean context_messages + whole state.db transcript
+```
+
+or:
+
+```text
+previous_context + replayed_tail + new_delta
+```
+
+That reintroduced old summaries, tool rows, or active-tail messages into the next model context or into the live usage estimate.
+
+## Failure cases covered
+
+The detailed debugging artifact is in `pr-artifacts/context-replay-failure-cases.md`. The key cases are:
+
+1. **Compression continuation replays the active tail**
+   - `result_messages` can contain `previous_context + replayed_tail + new_delta`.
+   - Prefix slicing alone saves the replayed tail again.
+
+2. **Near-duplicate large Session Arc Summary cards**
+   - Large `[Session Arc Summary ...]` messages can share a huge prefix while differing in refreshed tails/hints.
+   - Exact-match dedupe misses them.
+
+3. **Non-adjacent replay blocks**
+   - Replayed blocks can be separated by compression markers/summaries/tool rows, so adjacent-only dedupe is insufficient.
+
+4. **Non-streaming `/api/chat` writeback missed the replay guard**
+   - The streaming path deduped context writeback; synchronous chat restored reasoning metadata and saved directly.
+
+5. **Turn-start state reconciliation polluted a clean sidecar context**
+   - With `prefer_context=True`, a clean sidecar context could still be followed by mirrored `state.db` transcript rows.
+   - The next runtime prompt grew even though persisted `context_messages` stayed compact.
+
+6. **Live metering over-counted large in-flight tool results**
+   - Tool callbacks can arrive before exact next-prompt accounting.
+   - The old live estimate added full rough tool-result tokens to `last_prompt_tokens`, causing context-ring jumps that disappeared after cancel/persisted refresh.
+
+## Implementation notes
+
+- `_dedupe_replayed_context_messages(...)` now handles non-adjacent replay blocks and large near-duplicate summary cards.
+- `/api/chat` writeback calls the same context replay guard as streaming writeback.
+- `state_db_delta_after_context(...)` uses `context_messages` as the authoritative prefix and only returns state rows after the last state row already represented by sidecar context.
+- `_bounded_live_tool_prompt_delta(...)` bounds live-only tool estimate growth while preserving exact compressor/provider prompt accounting when available.
+
+## Test plan
+
+```bash
+python -m pytest -q tests/test_streaming_live_usage_estimate.py tests/test_issue1217_transcript_compaction.py tests/test_session_save_mode.py
+git diff --check
+python -m compileall -q api/models.py api/streaming.py api/routes.py
+```
+
+Current local result:
+
+```text
+43 passed
+```

--- a/tests/test_issue1217_transcript_compaction.py
+++ b/tests/test_issue1217_transcript_compaction.py
@@ -4,7 +4,7 @@ import json
 import sys
 from types import SimpleNamespace
 
-from api.models import Session, reconciled_state_db_messages_for_session
+from api.models import Session, reconciled_state_db_messages_for_session, state_db_delta_after_context
 
 from api.streaming import (
     _assistant_reply_added_after_current_turn,
@@ -512,6 +512,26 @@ def test_prefer_context_reconcile_starts_after_last_state_row_seen_in_context():
     assert reconciled == sidecar_context + [
         {"role": "user", "content": "new after represented boundary", "timestamp": 200.0},
     ]
+
+
+
+def test_state_db_delta_preserves_fresh_rows_before_repeated_context_message():
+    sidecar_context = [
+        {"role": "user", "content": "ok"},
+        {"role": "assistant", "content": "ready"},
+    ]
+    state_messages = [
+        {"role": "user", "content": "ok", "timestamp": 1.0},
+        {"role": "assistant", "content": "ready", "timestamp": 2.0},
+        {"role": "user", "content": "fresh question", "timestamp": 3.0},
+        {"role": "user", "content": "ok", "timestamp": 4.0},
+        {"role": "assistant", "content": "after repeat", "timestamp": 5.0},
+    ]
+
+    delta = state_db_delta_after_context(sidecar_context, state_messages)
+
+    assert [m["content"] for m in delta] == ["fresh question", "ok", "after repeat"]
+
 
 def test_non_streaming_chat_writeback_dedupes_full_context_replay():
     previous_context = [

--- a/tests/test_issue1217_transcript_compaction.py
+++ b/tests/test_issue1217_transcript_compaction.py
@@ -1,6 +1,10 @@
-from api.models import Session, reconciled_state_db_messages_for_session
 import contextlib
+import io
+import json
+import sys
 from types import SimpleNamespace
+
+from api.models import Session, reconciled_state_db_messages_for_session
 
 from api.streaming import (
     _assistant_reply_added_after_current_turn,
@@ -426,6 +430,31 @@ def test_prefer_context_reconcile_keeps_state_delta_when_no_mirrored_prefix():
     assert reconciled == sidecar_context + state_messages
 
 
+def test_prefer_context_reconcile_strips_small_mirrored_context_prefix():
+    sidecar_context = [
+        {"role": "user", "content": "[Session Arc Summary] compacted"},
+        {"role": "assistant", "content": "last compacted answer"},
+    ]
+    state_messages = [
+        {"role": "user", "content": "[Session Arc Summary] compacted", "timestamp": 100.0},
+        {"role": "assistant", "content": "last compacted answer", "timestamp": 101.0},
+        {"role": "user", "content": "fresh follow-up", "timestamp": 200.0},
+    ]
+    session = SimpleNamespace(
+        session_id="small-context-prefix",
+        context_messages=sidecar_context,
+        messages=[],
+    )
+
+    reconciled = reconciled_state_db_messages_for_session(
+        session, prefer_context=True, state_messages=state_messages
+    )
+
+    assert reconciled == sidecar_context + [
+        {"role": "user", "content": "fresh follow-up", "timestamp": 200.0},
+    ]
+
+
 def test_prefer_context_reconcile_strips_mirrored_rows_without_sidecar_timestamps():
     sidecar_context = [
         {"role": "assistant", "content": "cron banner"},
@@ -501,6 +530,96 @@ def test_non_streaming_chat_writeback_dedupes_full_context_replay():
         {"role": "user", "content": "simple follow-up"},
         {"role": "assistant", "content": "short answer"},
     ]
+
+class _FakePostHandler:
+    def __init__(self):
+        self.status = None
+        self.headers = {}
+        self.body = bytearray()
+        self.wfile = self
+
+    def send_response(self, status):
+        self.status = status
+
+    def send_header(self, name, value):
+        self.headers[name] = value
+
+    def end_headers(self):
+        pass
+
+    def write(self, data):
+        self.body.extend(data)
+
+    def json_body(self):
+        return json.loads(bytes(self.body).decode("utf-8"))
+
+
+def test_handle_chat_sync_writeback_dedupes_full_context_replay(tmp_path, monkeypatch):
+    import api.config as config
+    import api.models as models
+    import api.routes as routes
+
+    state_dir = tmp_path / "state"
+    session_dir = state_dir / "sessions"
+    session_dir.mkdir(parents=True)
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", state_dir / "session_index.json")
+    monkeypatch.setattr(routes, "SESSION_INDEX_FILE", state_dir / "session_index.json")
+    monkeypatch.setattr(routes, "get_session", models.get_session)
+    monkeypatch.setattr(routes, "title_from", models.title_from)
+    monkeypatch.setattr(config, "get_config", lambda: {"model": "test-model", "provider": "test-provider"})
+    monkeypatch.setattr(routes, "get_config", lambda: {"model": "test-model", "provider": "test-provider"})
+    monkeypatch.setattr(routes, "resolve_trusted_workspace", lambda value: tmp_path)
+    monkeypatch.setattr(routes, "load_settings", lambda: {})
+    monkeypatch.setattr(routes, "_resolve_cli_toolsets", lambda: [])
+
+    previous_context = [
+        {"role": "assistant", "content": "cron banner"},
+        {"role": "user", "content": "[Session Arc Summary (d1, node 39)]\n" + "old context\n" * 400},
+        {"role": "assistant", "content": "previous answer"},
+    ]
+    session = Session(
+        session_id="sync_chat_replay",
+        workspace=str(tmp_path),
+        messages=list(previous_context),
+        context_messages=list(previous_context),
+        model="test-model",
+        model_provider="test-provider",
+    )
+    session.save(touch_updated_at=False)
+
+    replayed_result = previous_context + previous_context + [
+        {"role": "user", "content": "simple follow-up"},
+        {"role": "assistant", "content": "short answer"},
+    ]
+
+    class FakeAgent:
+        def __init__(self, **_kwargs):
+            pass
+
+        def run_conversation(self, **_kwargs):
+            return {
+                "messages": replayed_result,
+                "final_response": "short answer",
+                "completed": True,
+            }
+
+    monkeypatch.setitem(sys.modules, "run_agent", SimpleNamespace(AIAgent=FakeAgent))
+
+    handler = _FakePostHandler()
+    routes._handle_chat_sync(
+        handler,
+        {"session_id": session.session_id, "message": "simple follow-up", "workspace": str(tmp_path)},
+    )
+
+    assert handler.status == 200
+    reloaded = Session.load(session.session_id)
+    assert reloaded.context_messages == previous_context + [
+        {"role": "user", "content": "simple follow-up"},
+        {"role": "assistant", "content": "short answer"},
+    ]
+    assert reloaded.context_messages.count(previous_context[0]) == 1
+
 
 def test_session_context_falls_back_to_display_messages_for_legacy_sessions(tmp_path):
     messages = [

--- a/tests/test_issue1217_transcript_compaction.py
+++ b/tests/test_issue1217_transcript_compaction.py
@@ -371,6 +371,137 @@ def test_non_adjacent_replayed_context_block_is_not_appended_again():
     ]
 
 
+
+
+def test_prefer_context_reconcile_strips_state_db_mirrored_prefix():
+    sidecar_context = [
+        {"role": "assistant", "content": "cron banner"},
+        {"role": "user", "content": "[Session Arc Summary]"},
+        {"role": "assistant", "content": "old answer"},
+        {"role": "user", "content": "latest saved question", "timestamp": 200.0},
+        {"role": "assistant", "content": "latest saved answer", "timestamp": 201.0},
+    ]
+    state_messages = [
+        {"role": "assistant", "content": "cron banner", "timestamp": 100.0},
+        {"role": "user", "content": "[Session Arc Summary]", "timestamp": 101.0},
+        {"role": "assistant", "content": "old answer", "timestamp": 102.0},
+        {"role": "user", "content": "latest saved question", "timestamp": 200.0},
+        {"role": "assistant", "content": "latest saved answer", "timestamp": 201.0},
+        {"role": "user", "content": "continue", "timestamp": 300.0},
+    ]
+    session = SimpleNamespace(
+        session_id="prefix-replay",
+        context_messages=sidecar_context,
+        messages=[],
+    )
+
+    reconciled = reconciled_state_db_messages_for_session(
+        session, prefer_context=True, state_messages=state_messages
+    )
+
+    assert reconciled == sidecar_context + [
+        {"role": "user", "content": "continue", "timestamp": 300.0},
+    ]
+
+
+def test_prefer_context_reconcile_keeps_state_delta_when_no_mirrored_prefix():
+    sidecar_context = [
+        {"role": "user", "content": "summary"},
+        {"role": "assistant", "content": "saved answer"},
+    ]
+    state_messages = [
+        {"role": "user", "content": "fresh question", "timestamp": 300.0},
+        {"role": "assistant", "content": "fresh answer", "timestamp": 301.0},
+    ]
+    session = SimpleNamespace(
+        session_id="fresh-delta",
+        context_messages=sidecar_context,
+        messages=[],
+    )
+
+    reconciled = reconciled_state_db_messages_for_session(
+        session, prefer_context=True, state_messages=state_messages
+    )
+
+    assert reconciled == sidecar_context + state_messages
+
+
+def test_prefer_context_reconcile_strips_mirrored_rows_without_sidecar_timestamps():
+    sidecar_context = [
+        {"role": "assistant", "content": "cron banner"},
+        {"role": "user", "content": "summary"},
+        {"role": "assistant", "content": "older answer"},
+        {"role": "user", "content": "already saved"},
+    ]
+    state_messages = [
+        {"role": "assistant", "content": "cron banner", "timestamp": 100.0},
+        {"role": "user", "content": "summary", "timestamp": 101.0},
+        {"role": "assistant", "content": "older answer", "timestamp": 102.0},
+        {"role": "user", "content": "already saved", "timestamp": 500.0},
+        {"role": "user", "content": "new after sidecar", "timestamp": 600.0},
+    ]
+    session = SimpleNamespace(
+        session_id="untimestamped-context",
+        context_messages=sidecar_context,
+        messages=[],
+    )
+
+    reconciled = reconciled_state_db_messages_for_session(
+        session, prefer_context=True, state_messages=state_messages
+    )
+
+    assert reconciled == sidecar_context + [
+        {"role": "user", "content": "new after sidecar", "timestamp": 600.0},
+    ]
+
+
+def test_prefer_context_reconcile_starts_after_last_state_row_seen_in_context():
+    sidecar_context = [
+        {"role": "assistant", "content": "cron banner"},
+        {"role": "user", "content": "summary"},
+        {"role": "assistant", "content": "old answer"},
+        {"role": "assistant", "content": "later represented row"},
+    ]
+    state_messages = [
+        {"role": "assistant", "content": "cron banner", "timestamp": 100.0},
+        {"role": "user", "content": "summary", "timestamp": 101.0},
+        {"role": "assistant", "content": "old answer", "timestamp": 102.0},
+        {"role": "tool", "content": "state-only stale tool", "timestamp": 103.0},
+        {"role": "assistant", "content": "later represented row", "timestamp": 104.0},
+        {"role": "user", "content": "new after represented boundary", "timestamp": 200.0},
+    ]
+    session = SimpleNamespace(
+        session_id="represented-boundary",
+        context_messages=sidecar_context,
+        messages=[],
+    )
+
+    reconciled = reconciled_state_db_messages_for_session(
+        session, prefer_context=True, state_messages=state_messages
+    )
+
+    assert reconciled == sidecar_context + [
+        {"role": "user", "content": "new after represented boundary", "timestamp": 200.0},
+    ]
+
+def test_non_streaming_chat_writeback_dedupes_full_context_replay():
+    previous_context = [
+        {"role": "assistant", "content": "cron banner"},
+        {"role": "user", "content": "[Session Arc Summary (d1, node 39)]\n" + "old context\n" * 400},
+        {"role": "assistant", "content": "previous answer"},
+    ]
+    result_messages = previous_context + previous_context + [
+        {"role": "user", "content": "simple follow-up"},
+        {"role": "assistant", "content": "short answer"},
+    ]
+
+    next_context = _dedupe_replayed_context_messages(previous_context, result_messages)
+
+    assert next_context == previous_context + [
+        {"role": "user", "content": "simple follow-up"},
+        {"role": "assistant", "content": "short answer"},
+    ]
+
 def test_session_context_falls_back_to_display_messages_for_legacy_sessions(tmp_path):
     messages = [
         {"role": "user", "content": "legacy prompt"},

--- a/tests/test_issue1217_transcript_compaction.py
+++ b/tests/test_issue1217_transcript_compaction.py
@@ -6,6 +6,7 @@ from api.streaming import (
     _assistant_reply_added_after_current_turn,
     _context_messages_for_new_turn,
     _dedupe_replayed_active_context,
+    _dedupe_replayed_context_messages,
     _merge_display_messages_after_agent_result,
     _new_turn_context_from_messages,
     _sanitize_messages_for_api,
@@ -307,6 +308,66 @@ def test_repeated_user_text_after_compaction_is_not_dropped():
         "[CONTEXT COMPACTION — REFERENCE ONLY] summary",
         "continue",
         "new answer",
+    ]
+
+
+def test_near_duplicate_session_arc_summary_is_not_replayed_in_context():
+    summary_a = {
+        "role": "user",
+        "content": "[Session Arc Summary (d1, node 39)]\n"
+        + "same recovered LCM context\n" * 260
+        + "expand hint: old node",
+    }
+    summary_b = {
+        "role": "user",
+        "content": "[Session Arc Summary (d1, node 39)]\n"
+        + "same recovered LCM context\n" * 260
+        + "expand hint: refreshed node",
+    }
+    previous_context = [summary_a, {"role": "user", "content": "choose agent"}]
+    result_messages = previous_context + [
+        {"role": "assistant", "content": "agent answer"},
+        summary_b,
+        {"role": "user", "content": "next question"},
+    ]
+
+    next_context = _dedupe_replayed_context_messages(previous_context, result_messages)
+
+    assert [m["content"] for m in next_context] == [
+        summary_a["content"],
+        "choose agent",
+        "agent answer",
+        "next question",
+    ]
+
+
+def test_non_adjacent_replayed_context_block_is_not_appended_again():
+    previous_context = [
+        {"role": "user", "content": "older setup"},
+        {"role": "user", "content": "choose agent"},
+        {"role": "assistant", "content": "checking agents"},
+        {"role": "tool", "content": "agent list"},
+        {"role": "assistant", "content": "agent answer"},
+    ]
+    result_messages = previous_context + [
+        {"role": "assistant", "content": "[CONTEXT COMPACTION — REFERENCE ONLY] compacted"},
+        {"role": "user", "content": "choose agent"},
+        {"role": "assistant", "content": "checking agents"},
+        {"role": "tool", "content": "agent list"},
+        {"role": "assistant", "content": "agent answer"},
+        {"role": "user", "content": "next question"},
+    ]
+
+    next_context = _dedupe_replayed_context_messages(previous_context, result_messages)
+
+    assert [m["content"] for m in next_context] == [
+        "older setup",
+        "choose agent",
+        "checking agents",
+        "agent list",
+        "agent answer",
+        "[CONTEXT COMPACTION — REFERENCE ONLY] compacted",
+        "next question",
     ]
 
 

--- a/tests/test_streaming_live_usage_estimate.py
+++ b/tests/test_streaming_live_usage_estimate.py
@@ -1,0 +1,22 @@
+from api.streaming import live_usage_prompt_estimate_after_tool_delta
+
+
+def test_live_usage_estimate_caps_tool_delta_against_previous_prompt():
+    usage = live_usage_prompt_estimate_after_tool_delta(
+        base_prompt_tokens=86_723,
+        exact_prompt_tokens=86_723,
+        messages=[{"role": "tool", "content": "x" * 80_000}],
+    )
+
+    assert usage["last_prompt_tokens"] <= 86_723 + 12_000
+    assert usage["last_prompt_tokens"] < 120_000
+
+
+def test_live_usage_estimate_preserves_real_prompt_when_exact_prompt_advances():
+    usage = live_usage_prompt_estimate_after_tool_delta(
+        base_prompt_tokens=86_723,
+        exact_prompt_tokens=136_000,
+        messages=[{"role": "tool", "content": "x" * 80_000}],
+    )
+
+    assert usage["last_prompt_tokens"] == 136_000


### PR DESCRIPTION
## Summary

Follow-up to #2651. That PR fixed one replay boundary, but continued testing exposed the same context-invariant violation at additional WebUI merge/metering boundaries.

This PR makes the replay protection context-engine agnostic:

- strips replayed non-adjacent context blocks and near-duplicate large Session Arc Summary cards before writing model context
- applies the same replay guard to the non-streaming `/api/chat` writeback path
- treats `context_messages` as the authoritative model-facing prefix when reconciling sidecar state with `state.db`, appending only demonstrably new state rows
- caps live tool-result prompt estimates so the context ring does not treat large in-flight tool outputs as exact prompt growth

LCM/continuation made these failures easy to reproduce, but the invariant is broader than LCM:

> If `context_messages` exists, it is the authoritative model-facing prefix. `messages`/`state.db` may be fuller or noisier histories and should only contribute true deltas. Live usage estimates must not override exact prompt accounting.

## Why this happens

WebUI currently merges several histories that have different meanings:

- `context_messages`: compact model-facing context for the next call
- `messages`: visible display transcript
- `state.db`: append-only runtime/session journal, including tool rows

After compression/continuation, those sources can overlap. The old code sometimes treated append candidates as wholly new:

```text
clean context_messages + whole state.db transcript
```

or:

```text
previous_context + replayed_tail + new_delta
```

That reintroduced old summaries, tool rows, or active-tail messages into the next model context or into the live usage estimate.

## Failure cases covered

The detailed debugging artifact is in `pr-artifacts/context-replay-failure-cases.md`. The key cases are:

1. **Compression continuation replays the active tail**
   - `result_messages` can contain `previous_context + replayed_tail + new_delta`.
   - Prefix slicing alone saves the replayed tail again.

2. **Near-duplicate large Session Arc Summary cards**
   - Large `[Session Arc Summary ...]` messages can share a huge prefix while differing in refreshed tails/hints.
   - Exact-match dedupe misses them.

3. **Non-adjacent replay blocks**
   - Replayed blocks can be separated by compression markers/summaries/tool rows, so adjacent-only dedupe is insufficient.

4. **Non-streaming `/api/chat` writeback missed the replay guard**
   - The streaming path deduped context writeback; synchronous chat restored reasoning metadata and saved directly.

5. **Turn-start state reconciliation polluted a clean sidecar context**
   - With `prefer_context=True`, a clean sidecar context could still be followed by mirrored `state.db` transcript rows.
   - The next runtime prompt grew even though persisted `context_messages` stayed compact.

6. **Live metering over-counted large in-flight tool results**
   - Tool callbacks can arrive before exact next-prompt accounting.
   - The old live estimate added full rough tool-result tokens to `last_prompt_tokens`, causing context-ring jumps that disappeared after cancel/persisted refresh.

## Implementation notes

- `_dedupe_replayed_context_messages(...)` now handles non-adjacent replay blocks and large near-duplicate summary cards.
- `/api/chat` writeback calls the same context replay guard as streaming writeback.
- `state_db_delta_after_context(...)` uses `context_messages` as the authoritative prefix and only returns state rows after the last state row already represented by sidecar context.
- `_bounded_live_tool_prompt_delta(...)` bounds live-only tool estimate growth while preserving exact compressor/provider prompt accounting when available.

## Test plan

```bash
python -m pytest -q tests/test_streaming_live_usage_estimate.py tests/test_issue1217_transcript_compaction.py tests/test_session_save_mode.py
git diff --check
python -m compileall -q api/models.py api/streaming.py api/routes.py
```

Current local result:

```text
45 passed
```
