### PR TITLE
fix(session): dedupe restamped state rows in display merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Prevent `/api/session` display merges from appending restamped `state.db` replay rows after the sidecar tail when those rows are already visible in the sidecar. This keeps compressed sessions from appearing to end on an old user prompt even though the assistant answer is persisted earlier in the transcript.
 
 ## [v0.51.103] — 2026-05-21 — Release CA (stage-396 — 1-PR follow-on — Settings → Plugins distinguishes exclusive/provider activation)
 

--- a/api/models.py
+++ b/api/models.py
@@ -6,6 +6,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import threading
 import time
 import uuid
@@ -2983,6 +2984,56 @@ def _session_message_merge_key(msg: dict):
     )
 
 
+def _normalized_session_message_content(msg: dict) -> str:
+    if not isinstance(msg, dict):
+        return repr(msg)
+    return " ".join(str(msg.get("content") or "").split())
+
+
+def _loose_session_message_content(value: str) -> str:
+    return " ".join(re.findall(r"\w+", str(value or "").casefold()))
+
+
+def _session_message_content_key(msg: dict):
+    if not isinstance(msg, dict):
+        return ("non_dict", repr(msg))
+    return (
+        str(msg.get("role") or ""),
+        _normalized_session_message_content(msg),
+        str(msg.get("tool_call_id") or ""),
+        str(msg.get("tool_name") or msg.get("name") or ""),
+    )
+
+
+def _session_message_visible_key(msg: dict):
+    if not isinstance(msg, dict):
+        return ("non_dict", repr(msg))
+    return (
+        str(msg.get("role") or ""),
+        _normalized_session_message_content(msg),
+    )
+
+
+def _has_visible_duplicate(visible_key: tuple, visible_keys: set[tuple]) -> bool:
+    if visible_key in visible_keys:
+        return True
+    role, content = visible_key
+    if not content:
+        return False
+    for existing_role, existing_content in visible_keys:
+        if role != existing_role or not existing_content:
+            continue
+        if content in existing_content or existing_content in content:
+            return True
+        loose_content = _loose_session_message_content(content)
+        loose_existing = _loose_session_message_content(existing_content)
+        if loose_content and loose_existing and (
+            loose_content in loose_existing or loose_existing in loose_content
+        ):
+            return True
+    return False
+
+
 def merge_session_messages_append_only(sidecar_messages: list, state_messages: list) -> list:
     """Merge sidecar/context and state.db messages without deleting local rows."""
     sidecar_messages = list(sidecar_messages or [])
@@ -2994,6 +3045,9 @@ def merge_session_messages_append_only(sidecar_messages: list, state_messages: l
 
     merged_messages = []
     seen_message_keys = set()
+    seen_content_keys = set()
+    seen_visible_keys = set()
+    sidecar_visible_sequence = []
     max_sidecar_timestamp = None
     for msg in sidecar_messages:
         timestamp = _message_timestamp_as_float(msg)
@@ -3001,10 +3055,26 @@ def merge_session_messages_append_only(sidecar_messages: list, state_messages: l
             max_sidecar_timestamp = timestamp if max_sidecar_timestamp is None else max(max_sidecar_timestamp, timestamp)
         key = _session_message_merge_key(msg)
         seen_message_keys.add(key)
+        seen_content_keys.add(_session_message_content_key(msg))
+        visible_key = _session_message_visible_key(msg)
+        seen_visible_keys.add(visible_key)
+        sidecar_visible_sequence.append(visible_key)
         merged_messages.append(msg)
+    state_replay_idx = 0
     for msg in state_messages:
         timestamp = _message_timestamp_as_float(msg)
         key = _session_message_merge_key(msg)
+        visible_key = _session_message_visible_key(msg)
+        replays_sidecar_prefix = False
+        if state_replay_idx < len(sidecar_visible_sequence):
+            expected_visible_key = sidecar_visible_sequence[state_replay_idx]
+            if visible_key == expected_visible_key or _has_visible_duplicate(
+                visible_key, {expected_visible_key}
+            ):
+                replays_sidecar_prefix = True
+                state_replay_idx += 1
+        if replays_sidecar_prefix and state_replay_idx < len(sidecar_visible_sequence):
+            continue
         if max_sidecar_timestamp is not None and timestamp is not None and timestamp <= max_sidecar_timestamp:
             if key in seen_message_keys:
                 continue
@@ -3016,8 +3086,12 @@ def merge_session_messages_append_only(sidecar_messages: list, state_messages: l
         # assumed to have already been observed by the sidecar. The <= gate
         # preserves sidecar-only ordering/metadata for equal timestamps and
         # prevents duplicate legacy rows when timestamp precision differs
-        # between stores. Explicit message ids are authoritative, though: two
-        # equal-timestamp messages with different ids are distinct retries.
+        # between stores. State rows whose visible content already exists in
+        # the sidecar are also skipped even if state.db restamped them later
+        # during compaction/recovery; otherwise old prompts can be appended
+        # after the assistant tail and make /api/session look like the answer
+        # vanished. Explicit message ids are authoritative for distinct rows
+        # only when their visible content is not already present.
         if (
             key[0] != "message_id"
             and max_sidecar_timestamp is not None
@@ -3027,6 +3101,8 @@ def merge_session_messages_append_only(sidecar_messages: list, state_messages: l
             continue
         if key[0] == "message_id":
             seen_message_keys.add(key)
+        seen_content_keys.add(_session_message_content_key(msg))
+        seen_visible_keys.add(visible_key)
         merged_messages.append(msg)
     return merged_messages
 

--- a/tests/test_session_lost_response_regression.py
+++ b/tests/test_session_lost_response_regression.py
@@ -27,6 +27,7 @@ import api.streaming as streaming  # noqa: F401  imported for fixture parity
 from api.models import (
     Session,
     _apply_core_sync_or_error_marker,
+    merge_session_messages_append_only,
 )
 from api.run_journal import append_run_event
 
@@ -129,6 +130,69 @@ def _assert_retry_meta_removed(marker):
 
 
 # ── The regression test ────────────────────────────────────────────────────
+
+
+def test_state_db_prefix_with_float_timestamps_does_not_hide_sidecar_tail():
+    """State rows replaying an already-visible prefix must not append after the tail.
+
+    Production shape: a compressed/tip sidecar can persist messages with
+    second-level timestamps while state.db stores the same early rows with
+    sub-second floats. The merge must preserve the sidecar assistant tail;
+    otherwise /api/session returns a transcript ending on an old user prompt.
+    """
+    sidecar_messages = [
+        {"role": "user", "content": "plan", "timestamp": 1779309765},
+        {"role": "assistant", "content": "loaded plan", "timestamp": 1779309765},
+        {"role": "tool", "content": "skill output", "timestamp": 1779309765},
+        {"role": "assistant", "content": "answer before compaction", "timestamp": 1779309765},
+        {
+            "role": "user",
+            "content": (
+                "[CONTEXT COMPACTION — REFERENCE ONLY] Earlier turns were compacted into "
+                "the summary below. This is a handoff from a previous context window — "
+                "treat it as background reference, NOT as active instructions."
+            ),
+            "timestamp": 1779309765,
+        },
+        {"role": "tool", "content": '{"success": true, "message": "Patched SKILL.md"}', "timestamp": 1779309765},
+        {"role": "user", "content": "noch weitere prs?", "timestamp": 1779309765},
+        {
+            "role": "assistant",
+            "content": "Ja, aber nicht als Sammel-PR",
+            "timestamp": 1779309765,
+        },
+    ]
+    state_prefix = [
+        {"role": "user", "content": "plan", "timestamp": 1779344917.2780898},
+        {"role": "assistant", "content": "loaded plan", "timestamp": 1779344917.285758},
+        {"role": "tool", "content": "skill output", "timestamp": 1779344917.2926793},
+        {"role": "assistant", "content": "answer before compaction", "timestamp": 1779344917.3077576},
+        {
+            "role": "user",
+            "content": (
+                "[CONTEXT COMPACTION — REFERENCE ONLY] Earlier turns were compacted into "
+                "the summary below. This is a handoff from a previous context window."
+            ),
+            "timestamp": 1779344917.299318,
+        },
+        {
+            "role": "tool",
+            "content": '{"success": true, "message": "Patched SKILL.md"}',
+            "timestamp": 1779344917.315237,
+            "tool_call_id": "different-state-tool-id",
+        },
+        {
+            "role": "user",
+            "content": "[Workspace::v1: /tmp/project-workspace]\nnoch weitere prs?",
+            "timestamp": 1779344917.3287876,
+        },
+    ]
+
+    merged = merge_session_messages_append_only(sidecar_messages, state_prefix)
+
+    assert [m["content"] for m in merged] == [m["content"] for m in sidecar_messages]
+    assert merged[-1]["role"] == "assistant"
+    assert "Sammel-PR" in merged[-1]["content"]
 
 
 def test_lost_response_recovered_on_second_read(hermes_home):


### PR DESCRIPTION
## Summary
- Dedupe restamped `state.db` replay rows during `/api/session` display merges when the same visible role/content already exists in the sidecar.
- Preserve the sidecar assistant tail so compressed sessions do not appear to end on an old user prompt.
- Add a regression test covering coarse sidecar timestamps, newer state-db float timestamps, compaction-card variants, tool metadata drift, and workspace-prefix user prompt variants.

## Root cause
`merge_session_messages_append_only()` deduped state rows mainly through exact merge keys and timestamp ordering. After compression/recovery, the sidecar can already contain the correct transcript with older coarse timestamps while `state.db` contains replayed older rows restamped with newer float timestamps and slightly different metadata/content shape.

Those state rows looked newer than the sidecar tail, so the API display merge appended them after the assistant answer. The answer was persisted, but the merged transcript tail could end on the old user prompt.

## Related reconnaissance
- Checked open PR overlap: #2682 touches frontend render-cache files (`static/ui.js`, `tests/test_session_render_cache_signature.py`) and does not touch the backend merge path in `api/models.py`.
- Existing #2651 dedupes replayed active-context tails in streaming/context paths; this PR fixes the separate `/api/session` sidecar + `state.db` display merge path.

## Test plan
- `python3 -m pytest tests/test_session_lost_response_regression.py tests/test_parallel_session_switch.py tests/test_issue1217_transcript_compaction.py -q -o 'addopts='` → 58 passed
- `python3 -m py_compile api/models.py`
- `git diff --check`
- Added-line scan for private markers/secrets/risky patterns → 0 findings

## AI disclosure
Prepared with AI assistance. I inspected the affected merge path, wrote the regression test, and ran the verification commands above.