### PR TITLE
fix: resync virtualized sidebar after scroll clamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Resync the virtualized session sidebar when the browser rejects a restored scroll position after layout/navigation changes, preventing date-group headers from rendering without session rows until the next manual scroll.
 
 ## [v0.51.103] — 2026-05-21 — Release CA (stage-396 — 1-PR follow-on — Settings → Plugins distinguishes exclusive/provider activation)
 

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -2905,6 +2905,22 @@ function _markSessionListPointerUp(){
   if(_pendingSessionListPayload) _schedulePendingSessionListApply();
 }
 
+let _sessionVirtualResyncRaf = 0;
+function _resyncSessionVirtualWindowAfterRender(list, expectedScrollTop, virtualWindow){
+  if(!list||!virtualWindow||!virtualWindow.virtualized) return;
+  expectedScrollTop=Number(expectedScrollTop)||0;
+  if(expectedScrollTop<=0) return;
+  if(_sessionVirtualResyncRaf) cancelAnimationFrame(_sessionVirtualResyncRaf);
+  _sessionVirtualResyncRaf=requestAnimationFrame(()=>{
+    _sessionVirtualResyncRaf=0;
+    if(_renamingSid) return;
+    const actualScrollTop=Number(list.scrollTop)||0;
+    const tolerance=Math.max(2, Number(virtualWindow.itemHeight||SESSION_VIRTUAL_ROW_HEIGHT)/2);
+    if(Math.abs(actualScrollTop-expectedScrollTop)<=tolerance) return;
+    renderSessionListFromCache();
+  });
+}
+
 function renderSessionListFromCache(){
   // Don't re-render while user is actively renaming a session (would destroy the input)
   if(_renamingSid) return;
@@ -3187,6 +3203,7 @@ function renderSessionListFromCache(){
     // scrollTop drops to 0 — producing a "scroll keeps jumping back" feel
     // when the list scrolls naturally. Fixed for #1669 follow-up.
     list.scrollTop=listScrollTopBeforeRender;
+    _resyncSessionVirtualWindowAfterRender(list, listScrollTopBeforeRender, virtualWindow);
   }
   // Select mode toggle button (only when NOT in select mode)
   if(!_sessionSelectMode){

--- a/tests/test_issue500_session_list_virtualization.py
+++ b/tests/test_issue500_session_list_virtualization.py
@@ -138,3 +138,55 @@ def test_session_list_only_moves_to_active_when_active_row_is_not_visible():
     assert before_idx < visible_idx < move_idx < final_idx < anchor_idx
     assert "activeIndex:-1" in render_body[before_idx:visible_idx]
     assert "activeIndex:shouldAnchorActive?activeIndex:-1" not in render_body
+
+
+def test_session_list_resyncs_when_browser_clamps_virtual_scroll_restore():
+    """If a hidden/reflowed sidebar rejects restored scrollTop, re-render the visible window."""
+    js = SESSIONS_JS_PATH.read_text(encoding="utf-8")
+    render_start = js.index("function renderSessionListFromCache()")
+    render_end = js.index("async function _handleActiveSessionStorageEvent", render_start)
+    render_body = js[render_start:render_end]
+
+    assert "_resyncSessionVirtualWindowAfterRender(list, listScrollTopBeforeRender, virtualWindow);" in render_body
+
+    source = _extract_func_script(js) + """
+let renderCount = 0;
+let rafCount = 0;
+let _renamingSid = null;
+const SESSION_VIRTUAL_ROW_HEIGHT = 52;
+function requestAnimationFrame(cb){ rafCount += 1; cb(); return rafCount; }
+function cancelAnimationFrame(_id){}
+function renderSessionListFromCache(){ renderCount += 1; }
+const makeHelper = new Function(
+  'requestAnimationFrame',
+  'cancelAnimationFrame',
+  'renderSessionListFromCache',
+  `let _sessionVirtualResyncRaf = 0;
+   let _renamingSid = null;
+   const SESSION_VIRTUAL_ROW_HEIGHT = 52;
+   ${extractFunc('_resyncSessionVirtualWindowAfterRender')}
+   return _resyncSessionVirtualWindowAfterRender;`
+);
+const _resyncSessionVirtualWindowAfterRender = makeHelper(
+  requestAnimationFrame,
+  cancelAnimationFrame,
+  renderSessionListFromCache
+);
+
+_resyncSessionVirtualWindowAfterRender(
+  {scrollTop: 0},
+  52 * 10,
+  {virtualized: true, itemHeight: 52}
+);
+const afterClamp = renderCount;
+_resyncSessionVirtualWindowAfterRender(
+  {scrollTop: 52 * 10},
+  52 * 10,
+  {virtualized: true, itemHeight: 52}
+);
+console.log(JSON.stringify({afterClamp, final: renderCount, rafCount}));
+"""
+    metrics = json.loads(_run_node(source))
+    assert metrics["afterClamp"] == 1
+    assert metrics["final"] == 1
+    assert metrics["rafCount"] == 2


### PR DESCRIPTION
## Summary
- resyncs the virtualized session sidebar after restoring a saved scroll position if the browser clamps/rejects that scroll position
- prevents date-group headers from rendering without their session rows until the user scrolls or a later refresh recomputes the virtual window
- adds regression coverage for the clamped-scroll path

## Root cause
`renderSessionListFromCache()` computes the virtualized row window from `list.scrollTop` before rebuilding the sidebar DOM, then restores that scroll position after render. After layout/navigation changes such as Settings → Chat, browsers can clamp the restored `scrollTop` back to `0`. In that case the DOM still reflects the old lower virtual window, so the user can see only date-group headers/spacers until the next scroll event forces a recomputation.

## Related reconnaissance
- Checked open PRs touching nearby session/sidebar behavior. #2682 is chat transcript render-cache related (`static/ui.js`), not sidebar virtualization.
- Same-file open PRs #2252 and #2671 touch `static/sessions.js`, but not this virtual-scroll resync hunk.

## Test plan
- `python3 -m pytest tests/test_issue500_session_list_virtualization.py tests/test_issue1669_sidebar_scroll_jump_fix.py tests/test_firefox_sidebar_scroll_stability.py tests/test_streaming_sidebar_scroll.py -q -o addopts=`
- `node --check static/sessions.js`
- `git diff --check`
- Added-line scans for private markers, secret-like strings, and eval/exec: 0 findings
