### PR TITLE
fix: geist-contrast skin composer UI improvements

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -347,7 +347,7 @@
   :root[data-skin="geist-contrast"] .tool-card,
   :root[data-skin="geist-contrast"] .msg-body pre,
   :root[data-skin="geist-contrast"] .preview-md pre,
-  :root[data-skin="geist-contrast"] .composer-box{background:var(--surface)!important;border-color:var(--border)!important;box-shadow:none!important;}
+  :root[data-skin="geist-contrast"] .composer-box{background:var(--surface)!important;border:none!important;box-shadow:none!important;}
   :root[data-skin="geist-contrast"] .session-item,
   :root[data-skin="geist-contrast"] .nav-tab,
   :root[data-skin="geist-contrast"] .rail-btn,
@@ -440,10 +440,10 @@
   :root[data-skin="geist-contrast"] button.send-btn:disabled{background:var(--surface-subtle)!important;border-color:var(--border)!important;color:var(--muted)!important;opacity:1!important;}
   :root.dark[data-skin="geist-contrast"] button.send-btn:disabled svg,
   :root.dark[data-skin="geist-contrast"] button.send-btn:disabled [data-lucide]{color:var(--muted)!important;stroke:var(--muted)!important;}
+  :root[data-skin="geist-contrast"] .composer-box:focus-within{border-color:transparent!important;box-shadow:0 0 0 3px var(--focus-ring)!important;outline:none!important;}
   :root[data-skin="geist-contrast"] input:focus,
   :root[data-skin="geist-contrast"] textarea:focus,
-  :root[data-skin="geist-contrast"] select:focus,
-  :root[data-skin="geist-contrast"] .composer-box:focus-within,
+  :root[data-skin="geist-contrast"] select:focus{border-color:var(--accent)!important;box-shadow:none!important;outline:none!important;}
   :root[data-skin="geist-contrast"] .app-dialog-input:focus,
   :root[data-skin="geist-contrast"] .sidebar-search input:focus{border-color:var(--accent)!important;box-shadow:0 0 0 3px var(--focus-ring)!important;outline:none!important;}
   :root[data-skin="geist-contrast"] .logo,
@@ -463,6 +463,12 @@
   :root[data-skin="geist-contrast"] .sidebar-date-header.pinned{color:var(--accent-text)!important;}
   :root[data-skin="geist-contrast"]::-webkit-scrollbar-thumb{background:var(--border2)!important;}
   :root[data-skin="geist-contrast"] ::selection{background:var(--accent-bg-strong);color:var(--strong);}
+  /* ── Geist Contrast: composer fixes ── */
+  /* Light mode: override white user-bubble-text so textarea text is black */
+  :root[data-skin="geist-contrast"]:not(.dark){--user-bubble-text:#111111;}
+  /* Remove scrollbar from textarea */
+  :root[data-skin="geist-contrast"] textarea#msg{scrollbar-width:none;overflow-y:auto;}
+  :root[data-skin="geist-contrast"] textarea#msg::-webkit-scrollbar{display:none;}
 
   /* #594: app-dialog light mode overrides — base styles use hardcoded dark gradients */
   :root:not(.dark) .app-dialog{


### PR DESCRIPTION
## Summary

Fixes three UI issues with the `geist-contrast` skin composer:

1. **Light mode input text visibility** — Override `--user-bubble-text` to `#111` so typed text is black instead of white on light backgrounds
2. **Remove textarea scrollbar** — Hide the scrollbar on the message input (`scrollbar-width:none` + `::-webkit-scrollbar{display:none}`)
3. **Fix double border on focus** — Split `composer-box:focus-within` out of the combined `input:focus, textarea:focus` rule to prevent box-shadow stacking; remove `composer-box` border entirely

## Test Plan
- [x] Switch to geist-contrast skin, light mode → type in composer, text is black
- [x] Type enough text to fill the textarea → no scrollbar appears
- [x] Click/focus the composer → single clean focus ring, no double border
- [x] Dark mode still works correctly
- [x] Other skins unaffected (all changes scoped to `geist-contrast`)