### PR TITLE
fix(model): prefer profile default on fresh boot

### DIFF
--- a/static/boot.js
+++ b/static/boot.js
@@ -1459,10 +1459,15 @@ function applyBotName(){
     if(s.default_model){
       window._defaultModel=s.default_model;
       const sel=$('modelSelect');
-      const savedState=(typeof _readPersistedModelState==='function')
-        ? _readPersistedModelState()
-        : (localStorage.getItem('hermes-webui-model')?{model:localStorage.getItem('hermes-webui-model'),model_provider:null}:null);
-      if(sel&&!savedState&&typeof _applyModelToDropdown==='function'){
+      if(sel&&typeof _applyModelToDropdown==='function'){
+        // Fresh page boot must prefer the profile/server default over stale
+        // browser-persisted model state. A restored session can still apply its
+        // own persisted model later through loadSession().
+        if(typeof _clearPersistedModelState==='function') _clearPersistedModelState();
+        else {
+          localStorage.removeItem('hermes-webui-model');
+          localStorage.removeItem('hermes-webui-model-state');
+        }
         const existingDefaultOpt=Array.from(sel.options).find(o=>o.value===s.default_model);
         if(existingDefaultOpt&&window._activeProvider&&!existingDefaultOpt.dataset.provider){
           existingDefaultOpt.dataset.provider=window._activeProvider;
@@ -1575,7 +1580,10 @@ function applyBotName(){
       ? _readPersistedModelState()
       : (localStorage.getItem('hermes-webui-model')?{model:localStorage.getItem('hermes-webui-model'),model_provider:null}:null);
     const savedModel=savedState&&savedState.model;
-    if(savedModel && $('modelSelect')){
+    // Guardrail: prefer profile/server default on boot when available.
+    // Persisted browser model state should not override a valid default model.
+    const allowBootSavedModelOverride=!window._defaultModel;
+    if(savedModel && $('modelSelect') && allowBootSavedModelOverride){
       const applied=(typeof _applyModelToDropdown==='function')
         ? _applyModelToDropdown(savedModel,$('modelSelect'),savedState.model_provider||null)
         : null;
@@ -1583,7 +1591,10 @@ function applyBotName(){
       // If the value didn't take (model not in list), clear the bad pref
       if(!applied&&$('modelSelect').value!==savedModel){
         if(typeof _clearPersistedModelState==='function') _clearPersistedModelState();
-        else localStorage.removeItem('hermes-webui-model');
+        else {
+          localStorage.removeItem('hermes-webui-model');
+          localStorage.removeItem('hermes-webui-model-state');
+        }
       }
       else if(typeof syncModelChip==='function') syncModelChip();
     }

--- a/static/ui.js
+++ b/static/ui.js
@@ -992,8 +992,10 @@ async function populateModelDropdown(){
       }
       sel.appendChild(og);
     }
-    // Set default model from server if no localStorage preference
-    if(data.default_model && !(typeof _readPersistedModelState==='function'&&_readPersistedModelState()) && !localStorage.getItem('hermes-webui-model')){
+    // Set default model from server on fresh/blank boot. Loaded sessions keep
+    // their own persisted model and apply it via loadSession(). Do not let stale
+    // browser localStorage suppress the profile default.
+    if(data.default_model && !(S.session&&S.session.model)){
       _applyModelToDropdown(data.default_model, sel, data.active_provider||null);
     }
     if(typeof syncModelChip==='function') syncModelChip();

--- a/tests/test_model_default_boot_precedence.py
+++ b/tests/test_model_default_boot_precedence.py
@@ -1,0 +1,34 @@
+"""
+Regression coverage for model selector drift on fresh browser boot.
+
+A stale browser-persisted model (localStorage) must not suppress the configured
+profile/server default on page load. Restored sessions may still apply their own
+session model later through loadSession().
+"""
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parents[1]
+BOOT_JS = (REPO / "static" / "boot.js").read_text(encoding="utf-8")
+UI_JS = (REPO / "static" / "ui.js").read_text(encoding="utf-8")
+
+
+def test_boot_settings_applies_default_even_when_browser_model_state_exists():
+    assert "Fresh page boot must prefer the profile/server default" in BOOT_JS
+    assert "_clearPersistedModelState" in BOOT_JS
+    assert "localStorage.removeItem('hermes-webui-model-state')" in BOOT_JS
+    assert "if(sel&&typeof _applyModelToDropdown==='function')" in BOOT_JS
+    assert "if(sel&&!savedState&&typeof _applyModelToDropdown==='function')" not in BOOT_JS
+
+
+def test_populate_model_dropdown_default_not_blocked_by_localstorage():
+    assert "Do not let stale\n    // browser localStorage suppress the profile default" in UI_JS
+    assert "if(data.default_model && !(S.session&&S.session.model))" in UI_JS
+    assert "_readPersistedModelState()" not in _populate_default_guard_snippet()
+    assert "localStorage.getItem('hermes-webui-model')" not in _populate_default_guard_snippet()
+
+
+def _populate_default_guard_snippet() -> str:
+    marker = "// Set default model from server on fresh/blank boot."
+    start = UI_JS.index(marker)
+    return UI_JS[start : start + 500]


### PR DESCRIPTION
## Thinking Path

- WebUI now has an explicit contract that composer model changes are session-scoped, while new chats inherit the configured profile default model.
- Recent fixes (#2674, #2684) hardened new-chat/provider synchronization and stale Codex slash-model repair, but a separate fresh-browser-boot path still let browser-persisted model state suppress the server/profile default before any session restore finished.
- The visible failure was a reload/reopen letting a stale browser-persisted picker value win over the configured profile default before any restored session had a chance to apply its own saved model.
- This PR fixes the boot/default-hydration layer rather than normalizing session files, so restored sessions can still apply their own session model through `loadSession()` and session-local manual choices remain preserved.
- This builds on the #2633 / `19ad20a` contract that new chats use the profile default; it does not change composer model scope or make manual picks global.

## What Changed

- Boot settings hydration now applies the server/profile `default_model` even when stale browser model state exists, and clears persisted model state before doing so.
- The later boot-time saved-model reapply path now only runs when no server/profile default is available.
- `populateModelDropdown()` now applies the server default on fresh/blank boot unless a loaded session already has its own model.
- Added regression coverage for fresh-boot default precedence and for clearing both legacy and structured persisted model-state keys.

## Why It Matters

- Reloading or reopening WebUI should not make stale browser-local state override the configured profile default model.
- The fix preserves the current source-of-truth split: Settings/default model for new conversations, composer picker for the current conversation, restored sessions for their saved model.
- This avoids a confusing reload state where the visible picker can disagree with the configured profile default before session restore has established a session-specific model.
- Refs #2678, which is tracked under Milestone 1 (Core quality & parity), as one concrete fresh-boot stale-state slice; it does not implement global model locking across all conversations, which is currently outside the WebUI session-scoped model contract.

## Screenshots / UI Evidence

No layout or visual component changed in this PR. The behavior is a boot-time state-precedence fix covered by source-level regression tests plus existing session/model synchronization tests.

## Verification

Targeted coverage:

```text
python -m pytest -q tests/test_model_default_boot_precedence.py tests/test_issue1771_session_model_switch_sync.py tests/test_issue1855_resolve_model_provider_fast_path.py tests/test_issue798.py tests/test_provider_mismatch.py
# 97 passed in 5.39s
```

Syntax / hygiene checks:

```text
node --check static/boot.js
node --check static/ui.js
python -m py_compile api/routes.py
git diff --check
# all passed
```

## Risks / Follow-ups

- The new regression is source-level because the existing WebUI boot path is vanilla JS without a dedicated DOM/unit harness for this exact state transition. A future browser-level harness could cover the same behavior more directly.
- This PR intentionally does not bulk-normalize old session sidecars; existing session-specific model state remains owned by session restore/resolution paths.

## Model Used

- OpenAI / GPT-5.5 via Hermes Agent for implementation, verification, and PR preparation.
- OpenAI / GPT-5.5 via independent Hermes delegated review for the pre-PR code review.
