### PR TITLE
fix(workspace): prefer last workspace for new chats

### DIFF
--- a/static/panels.js
+++ b/static/panels.js
@@ -3818,8 +3818,8 @@ function getWorkspaceFriendlyName(path){
 
 function syncWorkspaceDisplays(){
   const hasSession=!!(S.session&&S.session.workspace);
-  // Fall back to the profile default workspace when no session is active yet.
-  // S._profileDefaultWorkspace is set during boot and profile switches from /api/settings.
+  // Fall back to the profile workspace when no session is active yet. Boot seeds this
+  // from settings; loadWorkspaceList() refreshes it from /api/workspaces.last.
   const defaultWs=(typeof S._profileDefaultWorkspace==='string'&&S._profileDefaultWorkspace)||'';
   const ws=hasSession?S.session.workspace:(defaultWs||'');
   const hasWorkspace=!!(ws);
@@ -3855,6 +3855,7 @@ async function loadWorkspaceList(){
   try{
     const data = await api('/api/workspaces');
     _workspaceList = data.workspaces || [];
+    if(data.last) S._profileDefaultWorkspace=data.last;
     syncWorkspaceDisplays();
     return data;
   }catch(e){ return {workspaces:[], last:''}; }
@@ -3966,7 +3967,8 @@ function renderWorkspaceDropdownInto(dd, workspaces, currentWs){
     async()=>{
       closeWsDropdown();
       try{
-        await newSession(false,{worktree:true});
+        const worktreeBase=currentWs||((typeof S._profileDefaultWorkspace==='string'&&S._profileDefaultWorkspace)||'');
+        await newSession(false,{worktree:true,workspace:worktreeBase});
         await renderSessionList();
         const msg=$('msg');
         if(msg)msg.focus();
@@ -4000,7 +4002,7 @@ function toggleWsDropdown(){
   else{
     closeProfileDropdown(); // close profile dropdown if open
     loadWorkspaceList().then(data=>{
-      renderWorkspaceDropdownInto(dd, data.workspaces, S.session?S.session.workspace:'');
+      renderWorkspaceDropdownInto(dd, data.workspaces, S.session?S.session.workspace:(data.last||''));
       dd.classList.add('open');
     });
   }
@@ -4020,7 +4022,7 @@ function toggleComposerWsDropdown(){
     if(typeof closeModelDropdown==='function') closeModelDropdown();
     if(typeof closeReasoningDropdown==='function') closeReasoningDropdown();
     loadWorkspaceList().then(data=>{
-      renderWorkspaceDropdownInto(dd, data.workspaces, S.session?S.session.workspace:'');
+      renderWorkspaceDropdownInto(dd, data.workspaces, S.session?S.session.workspace:(data.last||''));
       dd.classList.add('open');
       _positionComposerWsDropdown();
       if(chip) chip.classList.add('active');

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -457,16 +457,15 @@ async function newSession(flash, options={}){
     S.toolCalls=[];
     clearLiveToolCards();
     // One-shot profile-switch workspace: applied to the first new session after a profile
-    // switch, then cleared.  Use a dedicated flag so S._profileDefaultWorkspace (the
-    // persistent boot/settings default) is not consumed and remains available for the
-    // blank-page display on all subsequent returns to the empty state (#823).
+    // switch, then cleared. Normal new conversations omit workspace so the backend
+    // resolves the active last workspace.
     const switchWs=S._profileSwitchWorkspace;
     S._profileSwitchWorkspace=null;
-    const inheritWs=switchWs||(S.session?S.session.workspace:null)||(S._profileDefaultWorkspace||null);
+    const explicitWs=(options&&options.workspace)||switchWs||null;
     const reqBody={
-      workspace:inheritWs,
       profile:S.activeProfile||'default',
     };
+    if(explicitWs) reqBody.workspace=explicitWs;
     if(S.session&&S.session.session_id) reqBody.prev_session_id=S.session.session_id;
     if(options&&options.worktree) reqBody.worktree=true;
     if(_activeProject&&_activeProject!==NO_PROJECT_FILTER) reqBody.project_id=_activeProject;

--- a/tests/test_issue1955_worktree_ui_static.py
+++ b/tests/test_issue1955_worktree_ui_static.py
@@ -25,7 +25,7 @@ def test_workspace_dropdown_exposes_new_worktree_conversation_action():
     src = read("static/panels.js")
     assert "workspace_new_worktree_conversation" in src
     assert "workspace_new_worktree_conversation_meta" in src
-    assert "newSession(false,{worktree:true})" in src
+    assert "newSession(false,{worktree:true,workspace:worktreeBase})" in src
     assert "li('git-branch',12)" in src
 
 

--- a/tests/test_profile_default_workspace_823.py
+++ b/tests/test_profile_default_workspace_823.py
@@ -47,19 +47,19 @@ class TestProfileDefaultWorkspacePersistence:
             "newSession must null S._profileSwitchWorkspace after consuming it"
         )
 
-    def test_new_session_still_inherits_default_workspace(self):
-        """newSession must still pass a workspace to /api/session/new —
-        now via the _profileSwitchWorkspace → current session → _profileDefaultWorkspace chain."""
+    def test_new_session_does_not_inherit_persistent_default_workspace(self):
+        """Normal newSession must not post stale restored/settings workspace state."""
         src = read('static/sessions.js')
         m = re.search(r'async function newSession\(.*?\n\}', src, re.DOTALL)
         assert m
         fn = m.group(0)
-        # inheritWs must be computed and passed to /api/session/new
-        assert 'inheritWs' in fn or 'inherit' in fn.lower(), (
-            "newSession must compute an inheritWs from switch/current/default workspace"
+        compact = ''.join(fn.split())
+        assert '_profileDefaultWorkspace' not in fn, (
+            "normal newSession must not read the persistent settings default; "
+            "omitting workspace lets the backend use get_last_workspace()"
         )
-        assert '_profileDefaultWorkspace' in fn, (
-            "newSession must fall through to S._profileDefaultWorkspace as last resort"
+        assert 'S.session?S.session.workspace' not in compact, (
+            "normal newSession must not inherit a restored session workspace implicitly"
         )
 
 
@@ -95,16 +95,16 @@ class TestProfileSwitchWorkspaceSetter:
 
 
     def test_switch_to_workspace_clears_profile_switch_workspace(self):
-        """Opus Q4: when the user manually changes workspace, the pending one-shot
-        switch flag should be cleared so a subsequent newSession() inherits the
-        user's explicit choice rather than the stale profile-switch default."""
+        """When the user manually changes workspace, the pending one-shot switch
+        flag should be cleared so a subsequent newSession() can use backend last
+        workspace state rather than a stale profile-switch default."""
         src = read('static/panels.js')
         m = re.search(r'async function switchToWorkspace\(.*?\n\}', src, re.DOTALL)
         assert m, "switchToWorkspace not found"
         fn = m.group(0)
         assert '_profileSwitchWorkspace=null' in fn or '_profileSwitchWorkspace = null' in fn, (
             "switchToWorkspace must null S._profileSwitchWorkspace after a manual switch "
-            "so the next newSession() inherits the user's explicit workspace choice"
+            "so the next newSession() uses backend last-workspace resolution"
         )
 
 

--- a/tests/test_workspace_default_fresh_boot.py
+++ b/tests/test_workspace_default_fresh_boot.py
@@ -1,0 +1,85 @@
+from pathlib import Path
+import re
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _read(path: str) -> str:
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+def _extract_function(source: str, signature: str) -> str:
+    start = source.index(signature)
+    brace = source.index("{\n", start)
+    depth = 0
+    for idx in range(brace, len(source)):
+        char = source[idx]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return source[start : idx + 1]
+    raise AssertionError(f"Function body not closed for {signature}")
+
+
+def test_new_session_omits_implicit_restored_or_settings_workspace():
+    fn = _extract_function(_read("static/sessions.js"), "async function newSession")
+    compact = "".join(fn.split())
+
+    assert "S.session?S.session.workspace" not in compact
+    assert "S._profileDefaultWorkspace" not in fn
+
+    req_start = fn.index("const reqBody={")
+    req_end = fn.index("};", req_start)
+    req_literal = fn[req_start:req_end]
+    assert "workspace" not in req_literal
+
+    assert re.search(r"if\s*\(\s*explicitWs\s*\)\s*reqBody\.workspace\s*=\s*explicitWs\s*;", fn)
+    assert "S._profileSwitchWorkspace=null" in compact
+
+
+def test_load_workspace_list_promotes_api_last_before_syncing_blank_display():
+    fn = _extract_function(_read("static/panels.js"), "async function loadWorkspaceList")
+    compact = "".join(fn.split())
+
+    update = "if(data.last)S._profileDefaultWorkspace=data.last;"
+    assert update in compact
+    assert compact.index(update) < compact.index("syncWorkspaceDisplays();")
+
+
+def test_worktree_action_passes_explicit_base_but_empty_base_still_omits_workspace():
+    panels = _read("static/panels.js")
+    assert "const worktreeBase=currentWs||((typeof S._profileDefaultWorkspace==='string'&&S._profileDefaultWorkspace)||'');" in panels
+    assert "newSession(false,{worktree:true,workspace:worktreeBase})" in panels
+
+    fn = _extract_function(_read("static/sessions.js"), "async function newSession")
+    compact = "".join(fn.split())
+    assert "constexplicitWs=(options&&options.workspace)||switchWs||null;" in compact
+    assert "if(explicitWs)reqBody.workspace=explicitWs;" in compact
+
+
+def test_models_new_session_without_workspace_uses_get_last_workspace(tmp_path, monkeypatch):
+    import api.models as models
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    last_workspace = tmp_path / "last-workspace"
+    last_workspace.mkdir()
+
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    monkeypatch.setattr(models, "get_last_workspace", lambda: str(last_workspace))
+    monkeypatch.setattr(
+        models,
+        "_profile_default_model_state",
+        lambda profile=None: ("test/default-model", None),
+    )
+    models.SESSIONS.clear()
+
+    try:
+        session = models.new_session(workspace=None, profile="default")
+        assert session.workspace == str(last_workspace)
+    finally:
+        models.SESSIONS.clear()


### PR DESCRIPTION
## Thinking Path

- A refreshed browser can restore an older session whose workspace no longer matches the user's current WebUI workspace.
- The backend already has the right fallback: when `/api/session/new` receives no workspace, it resolves through the profile's `last_workspace` state.
- The frontend was overriding that fallback by always posting either the restored session workspace or the boot/settings default workspace.
- The narrow fix is to make normal new chats omit implicit workspace state and reserve `workspace` in the request for explicit choices such as profile-switch one-shots, selected workspaces, and worktree bases.
- Blank-page workspace chrome still needs a display value, so workspace-list hydration now refreshes that value from `/api/workspaces.last` before syncing controls, preserving the earlier blank-page workspace behavior from #821/#824 without reusing that display state as new-chat routing state.
- This keeps backend state ownership for new-chat workspace selection without changing saved session workspaces or workspace path validation.

## What Changed

- Changed `newSession()` so normal new conversations no longer inherit a restored session workspace or persistent settings default workspace.
- Kept explicit workspace paths working by conditionally sending `workspace` only for explicit `options.workspace` or the profile-switch one-shot workspace.
- Refreshed no-session workspace display state from `/api/workspaces.last` when workspace metadata loads.
- Preserved worktree conversation creation by passing an explicit base workspace when the user chooses the worktree action.
- Added regression coverage for the new request-shaping contract, `/api/workspaces.last` display hydration, worktree-base fallback, and backend `get_last_workspace()` fallback.

## Why It Matters

- Prevents a stale but valid workspace path from quietly becoming the working directory for fresh chats after reload.
- Makes the server's current last-workspace state authoritative for normal new chats.
- Preserves explicit user actions and profile-switch behavior while avoiding hidden restored-session contamination.
- Avoids local cleanup or path-specific special cases; old session metadata stays intact, and future new chats route through the correct state owner.

## Verification

Targeted coverage:

```text
python -m pytest -q tests/test_workspace_default_fresh_boot.py tests/test_profile_default_workspace_823.py tests/test_issue1955_worktree_ui_static.py
# 18 passed in 2.75s
```

Adjacent workspace/session coverage:

```text
python -m pytest -q tests/test_sprint13.py tests/test_default_workspace_fallback.py tests/test_workspace_default_fresh_boot.py tests/test_profile_default_workspace_823.py tests/test_issue1955_worktree_ui_static.py
# 33 passed in 3.29s
```

Syntax / hygiene checks:

```text
node --check static/sessions.js
node --check static/panels.js
node --check static/boot.js
git diff --check
# all passed
```

## Risks / Follow-ups

- This is a request-shaping fix, not a migration of older session JSON files that already point at stale workspaces.
- The existing `S._profileDefaultWorkspace` variable now acts as blank-page/display workspace state after `/api/workspaces` hydration; a future cleanup could rename it for clarity.
- No visual layout changes; no screenshots included.

## Model Used

- OpenAI / GPT-5.5 via Codex CLI for implementation.
- OpenAI / GPT-5.5 for independent diff review and verification guidance.
