### PR TITLE
fix: rename _pinnedSessionsLimit() to _getPinnedSessionsLimit() to avoid naming collision with config var

### DIFF
--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1481,12 +1481,12 @@ function _sessionSnapshotById(sid){
 function _pinnedSessionCount(){
   return (_allSessions||[]).filter(s=>s&&s.pinned&&!s.archived).length;
 }
-function _pinnedSessionsLimit(){
+function _getPinnedSessionsLimit(){
   const limit=parseInt(window._pinnedSessionsLimit||3,10);
   return (Number.isFinite(limit)&&limit>0)?limit:3;
 }
 function _pinnedSessionsLimitMessage(){
-  const limit=_pinnedSessionsLimit();
+  const limit=_getPinnedSessionsLimit();
   return `Only ${limit} conversations can be pinned. Unpin one before pinning another.`;
 }
 function _worktreeSessionCount(ids){
@@ -1799,7 +1799,7 @@ function _openSessionActionMenu(session, anchorEl){
       }
     ));
   }
-  const pinLimitReached=!session.pinned&&_pinnedSessionCount()>=_pinnedSessionsLimit();
+  const pinLimitReached=!session.pinned&&_pinnedSessionCount()>=_getPinnedSessionsLimit();
   menu.appendChild(_buildSessionAction(
     session.pinned?t('session_unpin'):t('session_pin'),
     pinLimitReached?_pinnedSessionsLimitMessage():(session.pinned?t('session_unpin_desc'):t('session_pin_desc')),


### PR DESCRIPTION
## Bug
The Conversation Actions menu does not open when clicked.

## Root cause
Naming collision between function _pinnedSessionsLimit() in sessions.js and window._pinnedSessionsLimit = number in boot.js/panels.js. Since boot.js loads after sessions.js, the number overwrites the function.

## Fix
Renamed to _getPinnedSessionsLimit() to avoid the collision.

Introduced by Stage 398 (PR #2700).