### PR TITLE
fix: apply release update target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Self-update now applies the same release target that the update check reports. Release-based update prompts previously could pull the current branch's tracking ref instead; checkouts tracking a fork or local rescue branch would restart successfully without advancing to the newer published release.
 
 ## [v0.51.106] — 2026-05-21 — Release CD (stage-399 — 3-PR batch — restamped state.db replay dedupe + context_messages dedupe so agent doesn't see duplicates + empty _partial bloat fix)
 

--- a/api/updates.py
+++ b/api/updates.py
@@ -329,6 +329,26 @@ def _release_gap(tags, current, latest):
     return 1
 
 
+def _select_apply_compare_ref(path):
+    """Return the same remote ref family that the update check reports.
+
+    The update banner prefers published release tags when they exist. Applying
+    an update must therefore advance to the latest release tag too; otherwise a
+    checkout on a local/fork tracking branch can report release updates, pull a
+    different branch that is already current, restart, and still remain behind.
+    """
+    tags = _release_tags(path)
+    if tags:
+        return tags[0]
+
+    upstream, ok = _run_git(['rev-parse', '--abbrev-ref', '@{upstream}'], path)
+    if ok and upstream:
+        return upstream
+
+    branch = _detect_default_branch(path)
+    return f'origin/{branch}'
+
+
 def _check_repo_release(path, name):
     """Check if a git repo is behind its latest published release tag."""
     tags = _release_tags(path)
@@ -840,19 +860,14 @@ def apply_force_update(target: str) -> dict:
         if path is None or not (path / '.git').exists():
             return {'ok': False, 'message': 'Not a git repository'}
 
-        _, fetch_ok = _run_git(['fetch', 'origin', '--quiet'], path, timeout=15)
+        _, fetch_ok = _run_git(['fetch', 'origin', '--quiet', '--tags'], path, timeout=15)
         if not fetch_ok:
             return {
                 'ok': False,
                 'message': 'Could not reach the remote repository. Check your connection.',
             }
 
-        upstream, ok = _run_git(['rev-parse', '--abbrev-ref', '@{upstream}'], path)
-        if ok and upstream:
-            compare_ref = upstream
-        else:
-            branch = _detect_default_branch(path)
-            compare_ref = f'origin/{branch}'
+        compare_ref = _select_apply_compare_ref(path)
 
         # Discard local modifications then reset to remote HEAD
         _run_git(['checkout', '.'], path)
@@ -901,17 +916,8 @@ def _apply_update_inner(target):
     if path is None or not (path / '.git').exists():
         return {'ok': False, 'message': 'Not a git repository'}
 
-    # Use the current branch's upstream for pull, matching the behaviour
-    # of _check_repo. Falls back to default branch if no upstream is set.
-    upstream, ok = _run_git(['rev-parse', '--abbrev-ref', '@{upstream}'], path)
-    if ok and upstream:
-        compare_ref = upstream
-    else:
-        branch = _detect_default_branch(path)
-        compare_ref = f'origin/{branch}'
-
     # Fetch before attempting pull, so the remote ref is current.
-    _, fetch_ok = _run_git(['fetch', 'origin', '--quiet'], path, timeout=15)
+    _, fetch_ok = _run_git(['fetch', 'origin', '--quiet', '--tags'], path, timeout=15)
     if not fetch_ok:
         return {
             'ok': False,
@@ -920,6 +926,8 @@ def _apply_update_inner(target):
                 'Check your internet connection and try again.'
             ),
         }
+
+    compare_ref = _select_apply_compare_ref(path)
 
     # Check for dirty working tree (ignore untracked files — git stash
     # doesn't include them, so stashing on '??' alone leaves nothing to pop)
@@ -956,7 +964,7 @@ def _apply_update_inner(target):
     if remote:
         pull_args.extend([remote, branch])
     else:
-        pull_args.append(compare_ref)
+        pull_args.extend(['origin', compare_ref])
     pull_out, pull_ok = _run_git(pull_args, path, timeout=30)
     if not pull_ok:
         if stashed:

--- a/tests/test_update_banner_fixes.py
+++ b/tests/test_update_banner_fixes.py
@@ -438,6 +438,8 @@ class TestSuccessfulUpdateReturnsRestartScheduled:
         def fake_run(args, cwd, timeout=10):
             if args[0] == 'fetch':
                 return '', True
+            if args[0] == 'tag':
+                return '', True
             if args[:2] == ['status', '--porcelain']:
                 return '', True   # clean tree
             if args[:2] == ['rev-parse', '--abbrev-ref']:
@@ -457,6 +459,68 @@ class TestSuccessfulUpdateReturnsRestartScheduled:
         assert result.get('restart_scheduled') is True, (
             "successful update must set restart_scheduled: True"
         )
+
+    def test_apply_update_pulls_latest_release_tag_when_updates_are_release_based(
+        self, tmp_path, monkeypatch
+    ):
+        import api.updates as upd
+
+        (tmp_path / '.git').mkdir()
+        ran = []
+
+        def fake_run(args, cwd, timeout=10):
+            ran.append(args)
+            if args[0] == 'fetch':
+                return '', True
+            if args[0] == 'tag':
+                return 'v0.51.106\nv0.51.105\nv0.51.104', True
+            if args[:2] == ['status', '--porcelain']:
+                return '', True
+            if args[0] == 'pull':
+                return 'Updating release tag', True
+            return '', True
+
+        monkeypatch.setattr(upd, '_run_git', fake_run)
+        monkeypatch.setattr(upd, 'REPO_ROOT', tmp_path)
+        monkeypatch.setattr(upd, '_AGENT_DIR', tmp_path)
+        monkeypatch.setattr(upd, '_schedule_restart', lambda delay=2.0: None)
+
+        result = upd.apply_update('webui')
+        assert result['ok'] is True
+        assert ['fetch', 'origin', '--quiet', '--tags'] in ran
+        assert ['pull', '--ff-only', 'origin', 'v0.51.106'] in ran
+        assert ['rev-parse', '--abbrev-ref', '@{upstream}'] not in ran
+
+    def test_apply_update_falls_back_to_tracking_branch_without_release_tags(
+        self, tmp_path, monkeypatch
+    ):
+        import api.updates as upd
+
+        (tmp_path / '.git').mkdir()
+        ran = []
+
+        def fake_run(args, cwd, timeout=10):
+            ran.append(args)
+            if args[0] == 'fetch':
+                return '', True
+            if args[0] == 'tag':
+                return '', True
+            if args[:2] == ['rev-parse', '--abbrev-ref']:
+                return 'fork/feature-branch', True
+            if args[:2] == ['status', '--porcelain']:
+                return '', True
+            if args[0] == 'pull':
+                return 'Already up to date.', True
+            return '', True
+
+        monkeypatch.setattr(upd, '_run_git', fake_run)
+        monkeypatch.setattr(upd, 'REPO_ROOT', tmp_path)
+        monkeypatch.setattr(upd, '_AGENT_DIR', tmp_path)
+        monkeypatch.setattr(upd, '_schedule_restart', lambda delay=2.0: None)
+
+        result = upd.apply_update('agent')
+        assert result['ok'] is True
+        assert ['pull', '--ff-only', 'fork', 'feature-branch'] in ran
 
 
 class TestApplyForceUpdate:

--- a/tests/test_update_checker.py
+++ b/tests/test_update_checker.py
@@ -61,9 +61,8 @@ class TestApplyUpdateDiagnostics:
         from api import updates
         with patch(f'{_MODULE}.REPO_ROOT', tmp_path), \
              patch(f'{_MODULE}._run_git') as mock_run_git:
-            # Call sequence: upstream query, fetch
+            # Call sequence: fetch
             mock_run_git.side_effect = [
-                ('origin/master', True),   # rev-parse @{upstream}
                 ('', False),               # fetch fails
             ]
             result = updates._apply_update_inner('webui')
@@ -80,12 +79,11 @@ class TestApplyUpdateDiagnostics:
         with patch(f'{_MODULE}.REPO_ROOT', tmp_path), \
              patch(f'{_MODULE}._run_git') as mock_run_git:
             mock_run_git.side_effect = [
-                ('origin/master', True),   # upstream query
                 ('', False),               # fetch fails
             ]
             updates._apply_update_inner('webui')
-            # Only 2 calls: upstream query + fetch. No pull call.
-            assert mock_run_git.call_count == 2
+            # Only fetch is called. No target selection or pull call.
+            assert mock_run_git.call_count == 1
 
     # ------------------------------------------------------------------
     # Path 2: pull fails + diverged history
@@ -99,8 +97,9 @@ class TestApplyUpdateDiagnostics:
         with patch(f'{_MODULE}.REPO_ROOT', tmp_path), \
              patch(f'{_MODULE}._run_git') as mock_run_git:
             mock_run_git.side_effect = [
-                ('origin/master', True),                          # upstream query
                 ('', True),                                       # fetch succeeds
+                ('', True),                                       # no release tags
+                ('origin/master', True),                          # upstream query
                 ('', True),                                       # status --porcelain (clean)
                 ('Not possible to fast-forward, aborting.', False),  # pull fails
             ]
@@ -119,8 +118,9 @@ class TestApplyUpdateDiagnostics:
         with patch(f'{_MODULE}.REPO_ROOT', tmp_path), \
              patch(f'{_MODULE}._run_git') as mock_run_git:
             mock_run_git.side_effect = [
-                ('origin/feat/my-feature', True),   # upstream query
                 ('', True),                         # fetch
+                ('', True),                         # no release tags
+                ('origin/feat/my-feature', True),   # upstream query
                 ('', True),                         # status (clean)
                 ('Your branch and origin have diverged.', False),  # pull
             ]
@@ -137,8 +137,9 @@ class TestApplyUpdateDiagnostics:
         with patch(f'{_MODULE}.REPO_ROOT', tmp_path), \
              patch(f'{_MODULE}._run_git') as mock_run_git:
             mock_run_git.side_effect = [
-                ('origin/master', True),
                 ('', True),
+                ('', True),
+                ('origin/master', True),
                 ('', True),
                 ('DIVERGED from upstream', False),
             ]
@@ -159,8 +160,9 @@ class TestApplyUpdateDiagnostics:
         with patch(f'{_MODULE}.REPO_ROOT', tmp_path), \
              patch(f'{_MODULE}._run_git') as mock_run_git:
             mock_run_git.side_effect = [
-                ('origin/master', True),                               # upstream query
                 ('', True),                                            # fetch
+                ('', True),                                            # no release tags
+                ('origin/master', True),                               # upstream query
                 ('', True),                                            # status (clean)
                 ('There is no tracking information for the current branch.', False),  # pull
             ]
@@ -178,8 +180,9 @@ class TestApplyUpdateDiagnostics:
         with patch(f'{_MODULE}.REPO_ROOT', tmp_path), \
              patch(f'{_MODULE}._run_git') as mock_run_git:
             mock_run_git.side_effect = [
-                ('origin/master', True),
                 ('', True),
+                ('', True),
+                ('origin/master', True),
                 ('', True),
                 ('fatal: The current branch local does not track a remote branch.', False),
             ]
@@ -196,8 +199,9 @@ class TestApplyUpdateDiagnostics:
         with patch(f'{_MODULE}.REPO_ROOT', tmp_path), \
              patch(f'{_MODULE}._run_git') as mock_run_git:
             mock_run_git.side_effect = [
-                ('origin/main', True),
                 ('', True),
+                ('', True),
+                ('origin/main', True),
                 ('', True),
                 ('no tracking information', False),
             ]
@@ -219,8 +223,9 @@ class TestApplyUpdateDiagnostics:
         with patch(f'{_MODULE}.REPO_ROOT', tmp_path), \
              patch(f'{_MODULE}._run_git') as mock_run_git:
             mock_run_git.side_effect = [
-                ('origin/master', True),
                 ('', True),
+                ('', True),
+                ('origin/master', True),
                 ('', True),
                 (long_error, False),
             ]
@@ -240,8 +245,9 @@ class TestApplyUpdateDiagnostics:
         with patch(f'{_MODULE}.REPO_ROOT', tmp_path), \
              patch(f'{_MODULE}._run_git') as mock_run_git:
             mock_run_git.side_effect = [
-                ('origin/master', True),
                 ('', True),
+                ('', True),
+                ('origin/master', True),
                 ('', True),
                 ('', False),   # pull fails with empty output
             ]
@@ -258,8 +264,9 @@ class TestApplyUpdateDiagnostics:
         with patch(f'{_MODULE}.REPO_ROOT', tmp_path), \
              patch(f'{_MODULE}._run_git') as mock_run_git:
             mock_run_git.side_effect = [
-                ('origin/master', True),
                 ('', True),
+                ('', True),
+                ('origin/master', True),
                 ('', True),
                 ('Some unrecognized git error', False),
             ]
@@ -285,8 +292,9 @@ class TestApplyUpdateDiagnostics:
              patch(f'{_MODULE}._update_cache', fake_cache), \
              patch(f'{_MODULE}._cache_lock'):
             mock_run_git.side_effect = [
-                ('origin/master', True),          # upstream query
                 ('', True),                       # fetch succeeds
+                ('', True),                       # no release tags
+                ('origin/master', True),          # upstream query
                 ('', True),                       # status (clean working tree)
                 ('Already up to date.', True),    # pull succeeds
             ]
@@ -306,7 +314,6 @@ class TestApplyUpdateDiagnostics:
         with patch(f'{_MODULE}._AGENT_DIR', tmp_path), \
              patch(f'{_MODULE}._run_git') as mock_run_git:
             mock_run_git.side_effect = [
-                ('origin/master', True),
                 ('', False),   # fetch fails
             ]
             result = updates._apply_update_inner('agent')


### PR DESCRIPTION
## Summary
- Make self-update apply the same release target that `/api/updates/check` reports.
- Fetch tags before apply/force-apply target selection so the latest published release tag is available.
- Keep the existing tracking-branch fallback for repositories that do not have release tags.

## Root cause
The update check prefers published release tags when tags exist, but `/api/updates/apply` and `/api/updates/force` selected the current branch's upstream tracking ref. If a checkout tracked a fork/local rescue branch that was already current while `origin` had newer release tags, the apply call could return success and schedule a restart without advancing to the reported release. The user then reopened the app and still saw the same release gap.

## Related reconnaissance
- Searched open PRs for `apply_update`, `Self-update`, `release tag`, and `updates/apply`; no matching open fix found.
- Verified with a temporary real Git repository that `git pull --ff-only origin <tag>` fast-forwards an older release checkout to a newer release tag.

## Test plan
- `python3 -m pytest tests/test_update_banner_fixes.py::TestSuccessfulUpdateReturnsRestartScheduled tests/test_update_banner_fixes.py::TestApplyForceUpdate -q -o addopts=`
- `python3 -m pytest tests/test_update_banner_fixes.py tests/test_updates.py tests/test_api_timeout.py -q -o addopts=`
- `python3 -m py_compile api/updates.py`
- Added-line hygiene scan: 0 findings
