### PR TITLE
fix(session): treat active runs as live during repair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Treat `ACTIVE_RUNS` as live worker state during stale-pending session repair so a detached SSE stream does not get misdiagnosed as a WebUI restart while the backend agent turn is still running.
 
 ## [v0.51.106] — 2026-05-21 — Release CD (stage-399 — 3-PR batch — restamped state.db replay dedupe + context_messages dedupe so agent doesn't see duplicates + empty _partial bloat fix)
 

--- a/api/models.py
+++ b/api/models.py
@@ -202,7 +202,16 @@ def _write_session_index(updates=None):
 
 def _active_stream_ids():
     with STREAMS_LOCK:
-        return set(STREAMS.keys())
+        active_ids = set(STREAMS.keys())
+    # STREAMS tracks the browser/SSE observation path. A worker can still be
+    # running after the SSE stream entry disappears (for example while a request
+    # is blocked in the provider, unwinding after cancel, or otherwise detached
+    # from the client). Treat ACTIVE_RUNS as authoritative for worker liveness so
+    # stale-pending repair does not append a misleading restart/interrupted
+    # marker while the agent turn is still in flight.
+    with _cfg.ACTIVE_RUNS_LOCK:
+        active_ids.update(_cfg.ACTIVE_RUNS.keys())
+    return active_ids
 
 
 def _append_recovered_turn_to_context(session, recovered: dict) -> None:

--- a/tests/test_session_sidecar_repair.py
+++ b/tests/test_session_sidecar_repair.py
@@ -48,11 +48,13 @@ def _isolate_stream_state():
     config.CANCEL_FLAGS.clear()
     config.AGENT_INSTANCES.clear()
     config.STREAM_PARTIAL_TEXT.clear()
+    config.ACTIVE_RUNS.clear()
     yield
     config.STREAMS.clear()
     config.CANCEL_FLAGS.clear()
     config.AGENT_INSTANCES.clear()
     config.STREAM_PARTIAL_TEXT.clear()
+    config.ACTIVE_RUNS.clear()
 
 
 @pytest.fixture(autouse=True)
@@ -109,6 +111,11 @@ def _register_active_stream(stream_id):
     """Register stream_id as live in the same state _run_agent_streaming uses."""
     with config.STREAMS_LOCK:
         config.STREAMS[stream_id] = queue.Queue()
+
+
+def _register_active_run(stream_id):
+    """Register stream_id as an active worker without an attached SSE stream."""
+    config.register_active_run(stream_id, session_id="stale_sid", phase="running")
 
 
 class TestRepairStalePendingNoDeadlock:
@@ -1107,6 +1114,25 @@ class TestRepairStalePendingIntegration:
         finally:
             with config.STREAMS_LOCK:
                 config.STREAMS.pop("live_stream", None)
+
+    def test_skips_when_worker_alive_without_sse_stream(self, hermes_home, monkeypatch):
+        """Pre-check: if ACTIVE_RUNS still owns the worker, repair is skipped.
+
+        STREAMS is the browser/SSE observation layer and may disappear while the
+        backend worker is still running. A detached-but-active worker must not be
+        mistaken for a WebUI restart or crashed turn.
+        """
+        s = _make_stale_session(stream_id="detached_stream")
+        s.save()
+
+        _register_active_run("detached_stream")
+
+        assert "detached_stream" in _active_stream_ids()
+        result = _repair_stale_pending(s)
+        assert result is False
+        assert s.pending_user_message == "Hello hermes"
+        assert s.active_stream_id == "detached_stream"
+        assert s.messages == []
 
     def test_skips_when_no_pending(self, hermes_home, monkeypatch):
         """Pre-check: if pending_user_message is None, repair is skipped."""


### PR DESCRIPTION
## Summary
- Treat `ACTIVE_RUNS` entries as live worker state when stale-pending session repair checks active stream ids
- Prevent detached browser/SSE streams from being misdiagnosed as crashed or restarted turns while the backend worker is still running
- Add a regression test for the detached-SSE-but-active-worker case

## Test Plan
- `python3 -m pytest tests/test_session_sidecar_repair.py::TestRepairStalePendingIntegration::test_skips_when_worker_alive_without_sse_stream -q`
- `python3 -m pytest tests/test_session_sidecar_repair.py tests/test_session_lost_response_regression.py -q`
- `git diff --check origin/master...HEAD`
- Added-line private/secret marker scan: 0 hits
