### PR TITLE
fix(chat): dedupe uploaded-file optimistic user turns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Deduplicate uploaded-file user turns when the optimistic browser bubble uses plain text but the server-persisted pending turn includes the `[Attached files: ...]` suffix.
 
 ## [v0.51.106] — 2026-05-21 — Release CD (stage-399 — 3-PR batch — restamped state.db replay dedupe + context_messages dedupe so agent doesn't see duplicates + empty _partial bloat fix)
 

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1267,10 +1267,21 @@ function _messageComparableText(m){
   return String(m.content||'').trim();
 }
 
+function _stripAttachedFilesMarker(text){
+  return String(text||'').replace(/\n\n\[Attached files: [^\]]+\]$/,'').trim();
+}
+
 function _sameTranscriptMessage(a,b){
-  return !!(a&&b) &&
-    String(a.role||'')===String(b.role||'') &&
-    _messageComparableText(a)===_messageComparableText(b);
+  if(!(a&&b)) return false;
+  const role=String(a.role||'');
+  if(role!==String(b.role||'')) return false;
+  const aText=_messageComparableText(a);
+  const bText=_messageComparableText(b);
+  if(aText===bText) return true;
+  if(role==='user'){
+    return _stripAttachedFilesMarker(aText)===_stripAttachedFilesMarker(bText);
+  }
+  return false;
 }
 
 function _mergeInflightTailMessages(baseMessages, inflightMessages){

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -650,6 +650,23 @@ def test_loadSession_inflight_merges_tail_with_persisted_transcript(cleanup_test
     )
 
 
+def test_inflight_merge_dedupes_uploaded_user_message(cleanup_test_sessions):
+    """Uploaded-file turns render optimistically before the server stores the
+    final pending text with an `[Attached files: ...]` suffix.  The INFLIGHT
+    merge must treat those as the same user turn instead of rendering both.
+    """
+    src = (REPO_ROOT / "static/sessions.js").read_text()
+    assert "function _stripAttachedFilesMarker" in src, (
+        "sessions.js must normalize the server-side attached-files suffix before deduping user turns"
+    )
+    assert "_stripAttachedFilesMarker(aText)===_stripAttachedFilesMarker(bText)" in src, (
+        "INFLIGHT user-message comparison should dedupe optimistic upload text against final pending text"
+    )
+    assert "role==='user'" in src, (
+        "attached-files normalization should be limited to user turns"
+    )
+
+
 def test_loadSession_inflight_sets_active_stream_before_replaying_live_tool_cards(cleanup_test_sessions):
     """#1715: returning to an active chat must replay persisted tool cards.
 


### PR DESCRIPTION
## Summary
- normalize the server-side `[Attached files: ...]` suffix when comparing optimistic uploaded-file user turns against persisted pending turns
- keep the normalization limited to user messages so assistant/tool transcript comparisons remain exact
- add a regression guard for the upload optimistic-vs-pending dedupe path

## Test Plan
- `python -m pytest tests/test_regressions.py::test_inflight_merge_dedupes_uploaded_user_message tests/test_regressions.py::test_loadSession_inflight_merges_tail_with_persisted_transcript -q -o 'addopts='`
