### PR TITLE
fix: restore sidebar session action menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **PR #2727** by @Michaelyklam (closes #2715) — Restore the sidebar chat-row action menu after v0.51.106's configurable pinned-session limit setting. The frontend helper that reads `window._pinnedSessionsLimit` no longer shares the same global name as the setting value, so clicking the three-dot menu no longer throws `_pinnedSessionsLimit is not a function` and delete/archive/rename actions are reachable again.
 
 ## [v0.51.106] — 2026-05-21 — Release CD (stage-399 — 3-PR batch — restamped state.db replay dedupe + context_messages dedupe so agent doesn't see duplicates + empty _partial bloat fix)
 

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1481,12 +1481,12 @@ function _sessionSnapshotById(sid){
 function _pinnedSessionCount(){
   return (_allSessions||[]).filter(s=>s&&s.pinned&&!s.archived).length;
 }
-function _pinnedSessionsLimit(){
+function _getPinnedSessionsLimit(){
   const limit=parseInt(window._pinnedSessionsLimit||3,10);
   return (Number.isFinite(limit)&&limit>0)?limit:3;
 }
 function _pinnedSessionsLimitMessage(){
-  const limit=_pinnedSessionsLimit();
+  const limit=_getPinnedSessionsLimit();
   return `Only ${limit} conversations can be pinned. Unpin one before pinning another.`;
 }
 function _worktreeSessionCount(ids){
@@ -1799,7 +1799,7 @@ function _openSessionActionMenu(session, anchorEl){
       }
     ));
   }
-  const pinLimitReached=!session.pinned&&_pinnedSessionCount()>=_pinnedSessionsLimit();
+  const pinLimitReached=!session.pinned&&_pinnedSessionCount()>=_getPinnedSessionsLimit();
   menu.appendChild(_buildSessionAction(
     session.pinned?t('session_unpin'):t('session_pin'),
     pinLimitReached?_pinnedSessionsLimitMessage():(session.pinned?t('session_unpin_desc'):t('session_pin_desc')),

--- a/tests/test_configurable_pinned_sessions_limit.py
+++ b/tests/test_configurable_pinned_sessions_limit.py
@@ -52,8 +52,9 @@ def test_pin_limit_setting_is_exposed_and_wired_through_ui():
     assert 'payload.pinned_sessions_limit=parseInt(pinnedLimitField.value,10)' in PANELS_JS
     assert "settings.pinned_sessions_limit" in PANELS_JS
     assert "window._pinnedSessionsLimit=parseInt(s.pinned_sessions_limit||3,10)||3" in BOOT_JS
-    assert "function _pinnedSessionsLimit()" in SESSIONS_JS
-    assert "_pinnedSessionCount()>=_pinnedSessionsLimit()" in SESSIONS_JS
+    assert "function _getPinnedSessionsLimit()" in SESSIONS_JS
+    assert "const limit=parseInt(window._pinnedSessionsLimit||3,10);" in SESSIONS_JS
+    assert "_pinnedSessionCount()>=_getPinnedSessionsLimit()" in SESSIONS_JS
 
 
 def test_settings_api_persists_integer_pin_limit_and_rejects_invalid_values():

--- a/tests/test_issue2508_session_pin_cap.py
+++ b/tests/test_issue2508_session_pin_cap.py
@@ -75,10 +75,18 @@ def test_session_pin_cap_has_backend_and_frontend_guards():
     assert 'Up to {pinned_sessions_limit} sessions can be pinned' in ROUTES_PY
 
     assert 'function _pinnedSessionCount()' in SESSIONS_JS
-    assert 'function _pinnedSessionsLimit()' in SESSIONS_JS
-    assert 'const pinLimitReached=!session.pinned&&_pinnedSessionCount()>=_pinnedSessionsLimit();' in SESSIONS_JS
+    assert 'function _getPinnedSessionsLimit()' in SESSIONS_JS
+    assert 'const limit=parseInt(window._pinnedSessionsLimit||3,10);' in SESSIONS_JS
+    assert 'const pinLimitReached=!session.pinned&&_pinnedSessionCount()>=_getPinnedSessionsLimit();' in SESSIONS_JS
     assert 'Only ${limit} conversations can be pinned' in SESSIONS_JS
     assert ".session-action-opt.is-disabled{opacity:.55;cursor:not-allowed;}" in STYLE_CSS
+
+
+def test_session_pin_limit_helper_does_not_collide_with_window_setting():
+    assert 'function _pinnedSessionsLimit()' not in SESSIONS_JS
+    assert 'window._pinnedSessionsLimit=parseInt' not in SESSIONS_JS
+    assert 'function _getPinnedSessionsLimit()' in SESSIONS_JS
+    assert '_getPinnedSessionsLimit();' in SESSIONS_JS
 
 
 def test_session_rows_open_action_menu_from_right_click():


### PR DESCRIPTION
## Thinking Path

Issue #2715 reports that v0.51.106 throws `_pinnedSessionsLimit is not a function` when the sidebar chat-row three-dot menu opens. I traced the pin-limit code added for the configurable pinned sessions preference and found a browser-global name collision: `static/boot.js`/Settings assign `window._pinnedSessionsLimit` as a numeric setting, while `static/sessions.js` declared a function with the same global name.

## What Changed

- Renamed the sidebar helper to `_getPinnedSessionsLimit()` so it no longer collides with the `window._pinnedSessionsLimit` setting value.
- Kept the setting storage name unchanged for compatibility with the existing boot/settings code.
- Added source-level regression coverage that prevents reintroducing the function/window-setting name collision.
- Added an Unreleased changelog entry.

## Why It Matters

Opening the session action menu is the path for rename, delete, archive, pin/unpin, and project actions. The exception prevented users from deleting chat items from the sidebar after the latest release.

## Verification

- `env -u HERMES_CONFIG_PATH -u HERMES_WEBUI_HOST /home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_issue2508_session_pin_cap.py tests/test_configurable_pinned_sessions_limit.py -q` → 7 passed
- `node --check static/sessions.js`
- `git diff --check`

No screenshots attached: this is a JavaScript exception fix for an existing menu with no intended visual/layout change.

## Risks / Follow-ups

Low risk. The public setting key remains `window._pinnedSessionsLimit`; only the private helper name changed. The focused tests cover the pin-limit UI wiring and the context-menu regression surface.

Closes #2715

## Model Used

AI-assisted change with repository inspection, targeted editing, and shell-based test verification.
