### PR TITLE
fix: redact update-check git diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Sanitize git fetch diagnostics before returning update-check errors to the browser, preserving useful failure context while redacting credentialed remote URLs, GitHub token shapes, and secret-looking query parameters.
+
 
 ## [v0.51.107] — 2026-05-21 — Release CE (stage-400 — 8-PR batch — pinned-sessions-limit getter rename + uploaded-file user-turn dedupe + active-run repair guard + incremental KaTeX streaming + profile default model on fresh boot + French locale completion + update-check error surfacing + release-update apply path)
 

--- a/api/updates.py
+++ b/api/updates.py
@@ -36,6 +36,28 @@ _cache_lock = threading.Lock()
 _check_in_progress = False
 _apply_lock = threading.Lock()   # prevents concurrent stash/pull/pop on same repo
 CACHE_TTL = 1800  # 30 minutes
+_GIT_DIAGNOSTIC_MAX_CHARS = 300
+_CREDENTIAL_IN_URL_RE = re.compile(r"([a-zA-Z][a-zA-Z0-9+.-]*://)([^/@\s'\"]+)@")
+_GITHUB_TOKEN_RE = re.compile(r"\b(?:gh[pousr]_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9_]{20,})\b")
+_QUERY_SECRET_RE = re.compile(r"([?&](?:access_token|token|password|auth|key)=)[^&\s'\"]+", re.IGNORECASE)
+
+
+def _sanitize_git_diagnostic(output: str, *, limit: int = _GIT_DIAGNOSTIC_MAX_CHARS) -> str:
+    """Return a user-facing git diagnostic with credentials removed.
+
+    Git can echo remote URLs in failure output.  Keep the actionable error text,
+    but strip URL userinfo, common GitHub token shapes, and secret-looking query
+    parameter values before any message reaches the update-check API/UI.
+    """
+    if not output:
+        return ""
+    sanitized = _CREDENTIAL_IN_URL_RE.sub(r"\1<redacted>@", str(output))
+    sanitized = _GITHUB_TOKEN_RE.sub("<redacted>", sanitized)
+    sanitized = _QUERY_SECRET_RE.sub(r"\1<redacted>", sanitized)
+    sanitized = sanitized.strip()
+    if len(sanitized) > limit:
+        sanitized = sanitized[:limit].rstrip() + "…"
+    return sanitized
 
 
 def _active_stream_count() -> int:
@@ -460,7 +482,7 @@ def _check_repo(path, name):
         release_info = _check_repo_release(path, name)
         message = 'fetch failed'
         if fetch_out:
-            message = f'{message}: {fetch_out}'
+            message = f'{message}: {_sanitize_git_diagnostic(fetch_out)}'
         if release_info is not None:
             release_info = dict(release_info)
             release_info['error'] = message

--- a/tests/test_updates.py
+++ b/tests/test_updates.py
@@ -30,6 +30,35 @@ def test_check_repo_reports_release_gap_even_when_tag_fetch_fails(tmp_path):
     assert 'would clobber existing tag' in info['error']
 
 
+def test_check_repo_redacts_credentialed_fetch_failure(tmp_path):
+    """Update-check errors must not expose credentials from git remotes."""
+    (tmp_path / '.git').mkdir()
+    secret = 'ghp_' + 'A' * 36
+    raw_error = (
+        "fatal: unable to access "
+        f"'https://ash:{secret}@github.com/private/repo.git/': "
+        "Authentication failed"
+    )
+
+    def fake_git(args, cwd, timeout=10):
+        if args == ['fetch', 'origin', '--tags']:
+            return raw_error, False
+        if args == ['tag', '--list', 'v*', '--sort=-v:refname']:
+            return '', True
+        raise AssertionError(f'unexpected git args: {args!r}')
+
+    with patch.object(updates, '_run_git', side_effect=fake_git):
+        info = updates._check_repo(tmp_path, 'webui')
+
+    assert info is not None
+    assert info['behind'] is None
+    assert info['stale_check'] is True
+    assert secret not in info['error']
+    assert 'ash:' not in info['error']
+    assert '<redacted>' in info['error']
+    assert 'Authentication failed' in info['error']
+
+
 def test_check_repo_fetch_failure_without_tags_is_not_up_to_date(tmp_path):
     """If release tags cannot be read, behind is unknown rather than zero."""
     (tmp_path / '.git').mkdir()


### PR DESCRIPTION
## Thinking Path
- WebUI update checks now surface fetch failures, which is useful for operators.
- Git fetch diagnostics can include credentialed remote URLs or token-like strings depending on local git/credential configuration.
- Those diagnostics are returned through the update-check API and displayed in the browser.
- The fix keeps actionable fetch-error context but sanitizes sensitive shapes before the message leaves the server.

## What Changed
- Added `_sanitize_git_diagnostic()` in `api/updates.py`.
- Redacts credentialed URL userinfo, common GitHub token shapes, and secret-looking query parameter values.
- Caps update-check git diagnostic length at 300 chars.
- Routes `_check_repo()` fetch-failure error messages through the sanitizer.
- Added a regression test for credentialed fetch failures.
- Updated `CHANGELOG.md`.

## Why It Matters
- Update-check failures stay visible and useful.
- Browser/API responses no longer risk exposing credentials or private remote details echoed by git.
- This keeps the v0.51.107 update-check diagnostics safer for self-hosted installs with varied git credential setups.

## Verification
- `uv run --with pytest --with pyyaml pytest tests/test_updates.py::test_check_repo_redacts_credentialed_fetch_failure -q`
- `uv run --with pytest --with pyyaml pytest tests/test_updates.py tests/test_update_checker.py tests/test_update_banner_fixes.py tests/test_update_check_ui.py -q`
- Result: `90 passed`

## Risks / Follow-ups
- This intentionally preserves non-sensitive diagnostic text, so unusual secret formats outside the known patterns could still require future redaction coverage.
- The sanitizer is scoped to update-check fetch diagnostics in this PR; other update/apply diagnostic paths can be reviewed separately if maintainers want the same treatment everywhere.

## Model Used
- OpenAI Codex / `gpt-5.5` via Hermes Agent WebUI with terminal and file tools.
