### PR TITLE
fix: drop stale cached user tail after saved assistant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Drop stale inactive cached user tails when `/api/session` reloads a conversation whose saved sidecar already ends on an assistant answer. This prevents compacted conversations from appearing to hide the final assistant response until the user forks/reloads the session.
+
 
 ## [v0.51.107] — 2026-05-21 — Release CE (stage-400 — 8-PR batch — pinned-sessions-limit getter rename + uploaded-file user-turn dedupe + active-run repair guard + incremental KaTeX streaming + profile default model on fresh boot + French locale completion + update-check error surfacing + release-update apply path)
 

--- a/api/models.py
+++ b/api/models.py
@@ -1712,6 +1712,48 @@ def _repair_stale_pending(session) -> bool:
         return False
 
 
+def _last_non_tool_role(messages) -> str:
+    if not isinstance(messages, list):
+        return ''
+    for message in reversed(messages):
+        role = _message_role(message)
+        if role and role != 'tool':
+            return role
+    return ''
+
+
+def _inactive_cache_tail_needs_disk_check(cached) -> bool:
+    if cached is None:
+        return False
+    if getattr(cached, 'active_stream_id', None) or getattr(cached, 'pending_user_message', None):
+        return False
+    return _last_non_tool_role(getattr(cached, 'messages', None) or []) == 'user'
+
+
+def _cache_has_stale_unsaved_user_tail(cached, disk_session) -> bool:
+    """Return True when an inactive cached session has an unsaved user tail.
+
+    A completed turn is saved to the sidecar before the browser reloads it.  In
+    rare compaction/reconnect paths the in-process cache can retain a recovered
+    or optimistic user row after the saved assistant tail even though the row was
+    never persisted.  If /api/session serves that cache entry, the visible
+    transcript appears to end on the old prompt and the saved assistant answer
+    looks missing until a fork/reload resets the cache.
+    """
+    if cached is None or disk_session is None:
+        return False
+    if getattr(cached, 'active_stream_id', None) or getattr(cached, 'pending_user_message', None):
+        return False
+    cached_messages = getattr(cached, 'messages', None) or []
+    disk_messages = getattr(disk_session, 'messages', None) or []
+    if len(cached_messages) <= len(disk_messages):
+        return False
+    return (
+        _last_non_tool_role(cached_messages) == 'user'
+        and _last_non_tool_role(disk_messages) == 'assistant'
+    )
+
+
 def get_session(sid, metadata_only=False):
     """Load a session, optionally with metadata only (skipping the messages array).
 
@@ -1725,6 +1767,19 @@ def get_session(sid, metadata_only=False):
         if cached is not None:
             SESSIONS.move_to_end(sid)  # LRU: mark as recently used
     if cached is not None:
+        if not metadata_only and _inactive_cache_tail_needs_disk_check(cached):
+            try:
+                disk_session = Session.load(sid)
+                if _cache_has_stale_unsaved_user_tail(cached, disk_session):
+                    with LOCK:
+                        SESSIONS[sid] = disk_session
+                        SESSIONS.move_to_end(sid)
+                    cached = disk_session
+            except Exception:
+                logger.debug(
+                    "stale cached user-tail check failed for session %s",
+                    sid, exc_info=True,
+                )
         if not metadata_only and _session_has_pending_journal_retry(cached):
             try:
                 _try_retry_journal_recovery_in_place(cached)

--- a/tests/test_webui_state_db_reconciliation.py
+++ b/tests/test_webui_state_db_reconciliation.py
@@ -467,6 +467,51 @@ def test_metadata_fast_path_excludes_state_db_rows_filtered_by_reconciliation(mo
     assert session["last_message_at"] == 1001.0
 
 
+def test_api_session_reload_drops_stale_cached_user_tail_after_saved_assistant(monkeypatch, tmp_path):
+    import api.models as models
+    import api.routes as routes
+
+    sid = "webui_reconcile_cached_user_tail"
+    _install_test_session(
+        monkeypatch,
+        tmp_path,
+        sid,
+        [
+            {"role": "user", "content": "please audit phase c", "timestamp": 1000.0},
+            {"role": "assistant", "content": "final audit complete", "timestamp": 1001.0},
+        ],
+    )
+    _make_state_db(
+        tmp_path / "state.db",
+        sid,
+        [
+            {"role": "user", "content": "please audit phase c", "timestamp": 1000.0},
+            {"role": "assistant", "content": "final audit complete", "timestamp": 1001.0},
+        ],
+    )
+
+    cached = models.Session.load(sid)
+    cached.messages.append(
+        {
+            "role": "user",
+            "content": "please audit phase c",
+            "timestamp": 1002.0,
+        }
+    )
+    cached.pending_user_message = None
+    cached.active_stream_id = None
+    models.SESSIONS[sid] = cached
+
+    handler = _GetHandler(f"/api/session?session_id={sid}&messages=1&resolve_model=0")
+    routes.handle_get(handler, urlparse(handler.path))
+
+    assert handler.status == 200
+    messages = handler.response_json["session"]["messages"]
+    assert messages[-1]["role"] == "assistant"
+    assert messages[-1]["content"] == "final audit complete"
+    assert handler.response_json["session"]["message_count"] == 2
+
+
 def test_state_db_reconciliation_preserves_tool_metadata(monkeypatch, tmp_path):
     import api.routes as routes
 


### PR DESCRIPTION
## Thinking Path

This is a follow-up to the existing state.db/sidecar reconciliation fix class. A compacted WebUI session can have the final assistant answer persisted in the sidecar, while the in-process `SESSIONS` cache still carries an inactive, unsaved user tail. When `/api/session` serves that cache entry, the visible transcript appears to end on the old user prompt and the final assistant response looks hidden until the user forks or otherwise resets the session cache.

## What Changed

- Added a narrow cache-hit guard in `api.models.get_session()`:
  - only for full message loads (`metadata_only=False`)
  - only when the cached inactive session appears to end on a user message
  - reloads the sidecar from disk and replaces the cache only if the saved sidecar ends on an assistant answer and the cached copy has extra unsaved tail rows
- Added a regression test that simulates an inactive cached user tail after a saved assistant answer.
- Added an Unreleased changelog entry.

## Why It Matters

Compacted conversations should not make a completed assistant answer look missing just because the process cache retained a stale optimistic/recovered user row. The fix keeps the sidecar assistant tail authoritative for this stale-cache shape without changing active-stream or pending-user behavior.

## Verification

- `pytest tests/test_webui_state_db_reconciliation.py::test_api_session_reload_drops_stale_cached_user_tail_after_saved_assistant -q` initially failed before the fix.
- `pytest tests/test_webui_state_db_reconciliation.py -q` → 14 passed.
- `pytest tests/test_regressions.py -q` → 52 passed, 1 skipped.

## Risks / Follow-ups

- The disk reload is gated behind an inactive cached user tail, so normal cache hits and active streams are not forced through disk.
- This does not alter state.db replay ordering; it only corrects the stale in-process cache shape where the saved sidecar already has the assistant tail.

## Model Used

AI-assisted by Hermes Agent in WebUI using OpenAI Codex `gpt-5.5`, with terminal/file tools for diagnosis, tests, and PR creation.
