### PR TITLE
fix(chat): classify interrupted responses and log SSE diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Fixed
 
-- Clarify `Response interrupted` recovery markers so they report that the live response stream stopped instead of asserting that the WebUI process restarted. The same stale-recovery path also covers browser/SSE disconnects and lost worker bookkeeping, so the marker now matches systemd evidence instead of implying a restart that did not happen.
+- Clarify `Response interrupted` recovery markers so they report that the live response stream stopped instead of asserting that the WebUI process restarted. The recovery path now records distinct interruption causes for real process restarts, stream/run split-brain, and lost worker bookkeeping; browser-side SSE transport failures show a separate `Connection interrupted` message, and client-side `BrokenPipeError` disconnects no longer get logged as server 500s.
 
 ## [v0.51.131] — 2026-05-24 — Release DC (stage-batch13 — 6-PR notes-drawer + context-parity + PWA-swipe + locale polish)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Fixed
 
-- Clarify `Response interrupted` recovery markers so they report that the live response stream stopped instead of asserting that the WebUI process restarted. The recovery path now records distinct interruption causes for real process restarts, stream/run split-brain, and lost worker bookkeeping; browser-side SSE transport failures show a separate `Connection interrupted` message, and client-side `BrokenPipeError` disconnects no longer get logged as server 500s.
+- Clarify `Response interrupted` recovery markers so they report that the live response stream stopped instead of asserting that the WebUI process restarted. The recovery path now records distinct interruption causes for real process restarts, stream/run split-brain, and lost worker bookkeeping; browser-side SSE transport failures show a separate `Connection interrupted` message, client-side `BrokenPipeError` disconnects no longer get logged as server 500s, and chat/gateway SSE errors emit rate-limited, body-capped, sanitized client diagnostics to `/api/client-events/log` for future root-cause checks. The stream-status `terminal_state` value for lost-worker bookkeeping changes from `stale-from-restart` to `lost-worker-bookkeeping`, matching the new non-restart wording.
 
 ## [v0.51.131] — 2026-05-24 — Release DC (stage-batch13 — 6-PR notes-drawer + context-parity + PWA-swipe + locale polish)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Clarify `Response interrupted` recovery markers so they report that the live response stream stopped instead of asserting that the WebUI process restarted. The same stale-recovery path also covers browser/SSE disconnects and lost worker bookkeeping, so the marker now matches systemd evidence instead of implying a restart that did not happen.
+
 ## [v0.51.131] — 2026-05-24 — Release DC (stage-batch13 — 6-PR notes-drawer + context-parity + PWA-swipe + locale polish)
 
 ### Added
@@ -32,8 +36,6 @@
 - **6,503 pytest passed** (sequential mode; the test infrastructure uses a single test server that doesn't support xdist parallelism — known limitation, tracked separately).
 - **Opus Advisor verdict: SHIP-AS-IS.** Zero MUST-FIX. Three SHOULD-FIX items filed as follow-up issues (incomplete locale coverage for notes-drawer i18n keys, `_joplin_api_get` URL-token defense-in-depth, prefill `setattr` cache-reuse safety net).
 - **#2527 i18n coverage**: 10 of the 11 non-en locales currently ship the English string `'Third-party notes'` for the drawer header. Since the drawer is default-off, user impact is zero today; follow-up issue tracks proper translations before any default-on transition.
-
-
 
 ## [v0.51.130] — 2026-05-24 — Release DB (stage-batch12 — 3-PR profile-isolation + boot-precedence + workspace Artifacts tab)
 
@@ -142,6 +144,7 @@
 - Full pytest: 6,424 passed / 6 skipped / 3 xpassed / 8 subtests passed.
 - UX evidence for #2812 captured at 1280/1440/1920/mobile (iPhone 14 emulation); Telegram-approved.
 - File a follow-up issue for pdeathsig-on-supervisor-thread hardening (#2854 deferred Option B) and French-locale `open_in_vscode` parity gap (predates this batch, Opus advisor flagged).
+
 
 ## [v0.51.126] — 2026-05-24 — Release CX (stage-batch8 — 2-PR low-risk batch — kanban markdown + live activity timeline)
 
@@ -326,7 +329,6 @@
 - **PR #2738** by @weidzhou — `_write_session_index()` full-rebuild path now deduplicates entries by `session_id`. When old-format `session_*.json` files coexist with WebUI-format `xxx.json` files sharing the same `session_id`, the index produced duplicate Vue `:key` entries and crashed the frontend with a blank page. The lazy rebuild now uses `dict[session_id → compact_entry]` keyed on session_id, with the higher `message_count` entry winning on conflict.
 - **PR #2730** by @ashbuildslife — Sanitize git fetch diagnostics before returning update-check errors to the browser. New `_sanitize_git_diagnostic()` in `api/updates.py` strips credentialed URL userinfo (`user:token@host`), GitHub token shapes (`ghp_*`, `gho_*`, `github_pat_*`), and secret-looking query parameters (`?access_token=`, `?token=`, `?password=`, `?auth=`, `?key=`), then caps the message at 300 characters. Empirically verified that plain `https://github.com/owner/repo.git` URLs and SSH-style `git@host:owner/repo` remotes pass through untouched — only credentialed shapes are redacted. Update-check failure context (e.g. `Authentication failed`, network errors) is preserved.
 - **PR #2742** by @Isla-Liu — Per-turn SQLite connection leak in handoff-summary path (#2233). Two functions on the `/api/session/handoff-summary` hot path were opening `sqlite3.connect(...)` inside a bare `with` statement, which commits the transaction at scope exit but does NOT close the connection. Per-turn invocations accumulated `state.db`/`state.db-wal` file descriptors and CPython heap pages on long-lived worker threads, surfacing as multi-GB VmRSS / 6× duplicated state.db fds on long-running installs. Wrapped both call sites with `contextlib.closing(...)` (already imported and used at 7 other sites in the same files) so the connection is closed deterministically: `api/models.py::count_conversation_rounds` and `api/routes.py::_persist_handoff_summary_to_state_db`. Regression test loops both functions 20× against a tmp `state.db` and asserts `/proc/<pid>/fd` count does not grow more than 2. Live soak: fd growth = 0, VmRSS growth = 0 KB across 20 POSTs.
-
 ## [v0.51.107] — 2026-05-21 — Release CE (stage-400 — 8-PR batch — pinned-sessions-limit getter rename + uploaded-file user-turn dedupe + active-run repair guard + incremental KaTeX streaming + profile default model on fresh boot + French locale completion + update-check error surfacing + release-update apply path)
 
 ### Fixed

--- a/api/models.py
+++ b/api/models.py
@@ -787,11 +787,87 @@ _INTERRUPTED_NEUTRAL_WORDING = (
     'Partial output may have been lost.'
 )
 
+_INTERRUPTION_CAUSE_DETAILS = {
+    'process_restart': (
+        'Evidence: the WebUI process started after this turn began, so this '
+        'looks like a real process crash or restart.'
+    ),
+    'stream_run_split_brain': (
+        'Evidence: the browser response stream was gone but the worker registry '
+        'still listed the run. This is a stream/run bookkeeping split-brain.'
+    ),
+    'lost_worker_bookkeeping': (
+        'Evidence: the stream was gone and worker bookkeeping no longer had an '
+        'active run for it. This usually means the worker state was lost or '
+        'cleaned up without a terminal event.'
+    ),
+    'unknown': (
+        'Evidence: the stream stopped, but the WebUI could not classify the '
+        'interruption more precisely.'
+    ),
+}
+
+
+def _classify_interruption_cause(
+    *, stream_id: str | None = None, pending_started_at=None,
+) -> str:
+    """Classify the stale live-response state without overstating certainty."""
+    try:
+        started = float(pending_started_at) if pending_started_at else None
+    except (TypeError, ValueError):
+        started = None
+
+    if started is not None:
+        try:
+            if float(getattr(_cfg, 'SERVER_START_TIME', 0.0) or 0.0) > started:
+                return 'process_restart'
+        except (TypeError, ValueError):
+            pass
+
+    if stream_id:
+        try:
+            with _cfg.ACTIVE_RUNS_LOCK:
+                if str(stream_id) in _cfg.ACTIVE_RUNS:
+                    return 'stream_run_split_brain'
+        except Exception:
+            pass
+        return 'lost_worker_bookkeeping'
+
+    return 'unknown'
+
+
+def _interrupted_content_for(
+    *, recovered_output: bool, pending_retry: bool, interruption_cause: str,
+) -> str:
+    if recovered_output:
+        outcome = (
+            'The partial output above was recovered from the run journal, '
+            'but the interrupted agent process could not continue.'
+        )
+    elif pending_retry:
+        outcome = (
+            'Recovering the partial output from the run journal — '
+            'reload this session to retry.'
+        )
+    else:
+        outcome = 'The user message above was preserved, but no agent output was recovered.'
+    cause_detail = _INTERRUPTION_CAUSE_DETAILS.get(
+        interruption_cause,
+        _INTERRUPTION_CAUSE_DETAILS['unknown'],
+    )
+    return (
+        '**Response interrupted.**\n\n'
+        'The live response stream stopped before this turn finished. '
+        f'{cause_detail} {outcome}'
+    )
+
 
 def _interrupted_recovery_marker(
     *,
     recovered_output: bool = False,
     pending_retry: bool = False,
+    stream_id: str | None = None,
+    pending_started_at=None,
 ) -> dict:
     """Build the standard interrupted-turn marker.
 
@@ -809,18 +885,22 @@ def _interrupted_recovery_marker(
     set so the caller cannot accidentally re-arm retry on a successful
     repair.
     """
-    if recovered_output:
-        content = _INTERRUPTED_RECOVERED_WORDING
-    elif pending_retry:
-        content = _INTERRUPTED_PENDING_RETRY_WORDING
-    else:
-        content = _INTERRUPTED_NO_OUTPUT_WORDING
+    interruption_cause = _classify_interruption_cause(
+        stream_id=stream_id,
+        pending_started_at=pending_started_at,
+    )
+    content = _interrupted_content_for(
+        recovered_output=recovered_output,
+        pending_retry=pending_retry,
+        interruption_cause=interruption_cause,
+    )
     marker = {
         'role': 'assistant',
         'content': content,
         'timestamp': int(time.time()),
         '_error': True,
         'type': 'interrupted',
+        'interruption_cause': interruption_cause,
     }
     if pending_retry and not recovered_output:
         marker['_pending_journal_recovery'] = True
@@ -1218,15 +1298,26 @@ def _journal_retry_lock_for_sid(sid: str) -> threading.Lock:
 
 
 def _build_recovery_marker_with_retry_hook(
-    *, recovered_output: bool, stream_id: str | None,
+    *, recovered_output: bool, stream_id: str | None, pending_started_at=None,
 ) -> dict:
     """Build an interrupted-turn marker, arming the lazy-retry hook when
     visible output was not recovered yet but a stream id is available."""
     if recovered_output:
-        return _interrupted_recovery_marker(recovered_output=True)
+        return _interrupted_recovery_marker(
+            recovered_output=True,
+            stream_id=stream_id,
+            pending_started_at=pending_started_at,
+        )
     if not stream_id:
-        return _interrupted_recovery_marker(recovered_output=False)
-    marker = _interrupted_recovery_marker(pending_retry=True)
+        return _interrupted_recovery_marker(
+            recovered_output=False,
+            pending_started_at=pending_started_at,
+        )
+    marker = _interrupted_recovery_marker(
+        pending_retry=True,
+        stream_id=stream_id,
+        pending_started_at=pending_started_at,
+    )
     marker['_journal_retry_stream_id'] = str(stream_id)
     marker['_journal_retry_attempts'] = 0
     marker['_journal_retry_first_seen_ts'] = int(time.time())
@@ -1511,13 +1602,16 @@ def _apply_core_sync_or_error_marker(
             stream_id_for_recheck or session.active_stream_id,
         )
         _stream_id = stream_id_for_recheck or session.active_stream_id
+        _pending_started_at = session.pending_started_at
         session.active_stream_id = None
         session.pending_user_message = None
         session.pending_attachments = []
         session.pending_started_at = None
         session.messages.append(
             _build_recovery_marker_with_retry_hook(
-                recovered_output=recovered_output, stream_id=_stream_id,
+                recovered_output=recovered_output,
+                stream_id=_stream_id,
+                pending_started_at=_pending_started_at,
             )
         )
         session.save(touch_updated_at=touch_updated_at)
@@ -1562,13 +1656,18 @@ def _apply_core_sync_or_error_marker(
                 _stream_id,
                 dedupe_existing=True,
             )
+            _pending_started_at = session.pending_started_at
             session.active_stream_id = None
             session.pending_user_message = None
             session.pending_attachments = []
             session.pending_started_at = None
             if recovered_output:
                 session.messages.append(
-                    _interrupted_recovery_marker(recovered_output=True)
+                    _interrupted_recovery_marker(
+                        recovered_output=True,
+                        stream_id=_stream_id,
+                        pending_started_at=_pending_started_at,
+                    )
                 )
             # NOTE: when the core transcript was synced in but the run journal
             # is not yet visible, intentionally do NOT append a lazy-retry
@@ -1604,13 +1703,16 @@ def _apply_core_sync_or_error_marker(
         stream_id_for_recheck or session.active_stream_id,
     )
     _stream_id = stream_id_for_recheck or session.active_stream_id
+    _pending_started_at = session.pending_started_at
     session.active_stream_id = None
     session.pending_user_message = None
     session.pending_attachments = []
     session.pending_started_at = None
     session.messages.append(
         _build_recovery_marker_with_retry_hook(
-            recovered_output=recovered_output, stream_id=_stream_id,
+            recovered_output=recovered_output,
+            stream_id=_stream_id,
+            pending_started_at=_pending_started_at,
         )
     )
     session.save(touch_updated_at=touch_updated_at)

--- a/api/models.py
+++ b/api/models.py
@@ -764,18 +764,18 @@ def _get_profile_home(profile) -> Path:
 
 _INTERRUPTED_RECOVERED_WORDING = (
     '**Response interrupted.**\n\n'
-    'The WebUI process restarted before this turn finished. '
+    'The live response stream stopped before this turn finished. '
     'The partial output above was recovered from the run journal, '
     'but the interrupted agent process could not continue.'
 )
 _INTERRUPTED_NO_OUTPUT_WORDING = (
     '**Response interrupted.**\n\n'
-    'The WebUI process restarted before this turn finished. '
+    'The live response stream stopped before this turn finished. '
     'The user message above was preserved, but no agent output was recovered.'
 )
 _INTERRUPTED_PENDING_RETRY_WORDING = (
     '**Response interrupted.**\n\n'
-    'The WebUI process restarted before this turn finished. '
+    'The live response stream stopped before this turn finished. '
     'Recovering the partial output from the run journal — '
     'reload this session to retry.'
 )
@@ -783,7 +783,7 @@ _INTERRUPTED_PENDING_RETRY_WORDING = (
 # or the marker has been pending longer than _JOURNAL_RETRY_GIVEUP_SECONDS).
 _INTERRUPTED_NEUTRAL_WORDING = (
     '**Response interrupted.**\n\n'
-    'The WebUI process restarted before this turn finished. '
+    'The live response stream stopped before this turn finished. '
     'Partial output may have been lost.'
 )
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -1126,7 +1126,7 @@ def _run_journal_status_payload(summary: dict, *, active: bool = False) -> dict:
     terminal = bool(summary.get("terminal"))
     terminal_state = summary.get("terminal_state")
     if not active and not terminal:
-        terminal_state = "stale-from-restart"
+        terminal_state = "lost-worker-bookkeeping"
     return {
         "session_id": summary.get("session_id"),
         "run_id": summary.get("run_id"),

--- a/api/routes.py
+++ b/api/routes.py
@@ -23,7 +23,7 @@ import uuid
 import re
 from pathlib import Path
 from contextlib import closing
-from urllib.parse import parse_qs
+from urllib.parse import parse_qs, urlsplit
 from api.agent_sessions import (
     MESSAGING_SOURCES,
     is_cli_session_row,
@@ -75,6 +75,21 @@ _CSP_REPORT_RATE_LIMIT_LOCK = threading.Lock()
 _CSP_REPORT_RATE_LIMIT_WINDOW_SECONDS = 60
 _CSP_REPORT_RATE_LIMIT_MAX = 100
 _CSP_REPORT_MAX_BODY_BYTES = 64 * 1024
+_CLIENT_EVENT_LOGGER = logging.getLogger("client_event")
+_CLIENT_EVENT_RATE_LIMIT: dict[str, list[float]] = {}
+_CLIENT_EVENT_RATE_LIMIT_LOCK = threading.Lock()
+_CLIENT_EVENT_RATE_LIMIT_WINDOW_SECONDS = 60
+_CLIENT_EVENT_RATE_LIMIT_MAX = 30
+_CLIENT_EVENT_MAX_BODY_BYTES = 4 * 1024
+_CLIENT_EVENT_ALLOWED_FIELDS = {
+    "event": 64,
+    "source": 80,
+    "session_id": 128,
+    "stream_id": 128,
+    "visibility_state": 32,
+    "url_path": 256,
+    "reason": 160,
+}
 
 
 def _session_field(session, field, default=None):
@@ -1371,6 +1386,20 @@ def _csp_report_rate_limited(handler, *, now: float | None = None) -> bool:
     return False
 
 
+def _client_event_rate_limited(handler, *, now: float | None = None) -> bool:
+    now = time.time() if now is None else now
+    key = _client_ip_for_rate_limit(handler)
+    cutoff = now - _CLIENT_EVENT_RATE_LIMIT_WINDOW_SECONDS
+    with _CLIENT_EVENT_RATE_LIMIT_LOCK:
+        timestamps = [ts for ts in _CLIENT_EVENT_RATE_LIMIT.get(key, []) if ts >= cutoff]
+        if len(timestamps) >= _CLIENT_EVENT_RATE_LIMIT_MAX:
+            _CLIENT_EVENT_RATE_LIMIT[key] = timestamps
+            return True
+        timestamps.append(now)
+        _CLIENT_EVENT_RATE_LIMIT[key] = timestamps
+    return False
+
+
 def _send_no_content(handler, status: int = 204) -> bool:
     handler.send_response(status)
     handler.send_header("Content-Length", "0")
@@ -1408,6 +1437,105 @@ def _handle_csp_report(handler) -> bool:
     payload = _read_csp_report_payload(handler)
     _CSP_REPORT_LOGGER.info("CSP report from %s: %s", _client_ip_for_rate_limit(handler), payload)
     return _send_no_content(handler)
+
+
+def _bounded_client_event_string(value, limit: int) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    return text[:limit]
+
+
+def _sanitize_client_event_url_path(value) -> str | None:
+    text = _bounded_client_event_string(value, 1024)
+    if not text:
+        return None
+    try:
+        parsed = urlsplit(text)
+        path = parsed.path or "/"
+    except Exception:
+        path = text.split("?", 1)[0] or "/"
+    if not path.startswith("/"):
+        path = "/" + path.lstrip("/")
+    return path[: _CLIENT_EVENT_ALLOWED_FIELDS["url_path"]]
+
+
+def _sanitize_client_event_payload(payload: dict | None) -> dict:
+    """Whitelist tiny browser diagnostic events and discard sensitive content.
+
+    Client-side SSE diagnostics should explain transport failures without
+    persisting prompts, cookies, query strings, headers, or arbitrary browser
+    payloads. This helper intentionally keeps only bounded scalar metadata.
+    """
+    if not isinstance(payload, dict):
+        return {"event": "unknown"}
+    sanitized: dict[str, object] = {}
+    for field, limit in _CLIENT_EVENT_ALLOWED_FIELDS.items():
+        if field == "url_path":
+            value = _sanitize_client_event_url_path(payload.get(field))
+        else:
+            value = _bounded_client_event_string(payload.get(field), limit)
+        if value is not None:
+            sanitized[field] = value
+    ready_state = payload.get("ready_state")
+    if isinstance(ready_state, bool):
+        pass
+    elif isinstance(ready_state, int) and 0 <= ready_state <= 3:
+        sanitized["ready_state"] = ready_state
+    online = payload.get("online")
+    if isinstance(online, bool):
+        sanitized["online"] = online
+    elif isinstance(online, str):
+        lowered = online.strip().lower()
+        if lowered in {"true", "1", "yes", "on"}:
+            sanitized["online"] = True
+        elif lowered in {"false", "0", "no", "off"}:
+            sanitized["online"] = False
+    if "event" not in sanitized:
+        sanitized["event"] = "unknown"
+    return sanitized
+
+
+def _read_client_event_payload(handler) -> dict:
+    try:
+        length = int(handler.headers.get("Content-Length", 0))
+    except Exception:
+        length = 0
+    if length > _CLIENT_EVENT_MAX_BODY_BYTES:
+        try:
+            handler.rfile.read(_CLIENT_EVENT_MAX_BODY_BYTES)
+        except Exception:
+            pass
+        # Do not leave unread request-body bytes on an HTTP/1.1 keep-alive
+        # socket. Draining an arbitrary oversized body can tie up a worker;
+        # closing the connection after the bounded read preserves framing for
+        # the next request without turning diagnostics into a slow-drain sink.
+        try:
+            handler.close_connection = True
+        except Exception:
+            pass
+        return {"event": "discarded", "reason": "body_too_large"}
+    raw = handler.rfile.read(length) if length else b"{}"
+    try:
+        decoded = raw.decode("utf-8")
+        payload = json.loads(decoded)
+    except Exception:
+        return {"event": "invalid", "reason": "invalid_json"}
+    return payload if isinstance(payload, dict) else {"event": "invalid", "reason": "not_object"}
+
+
+def _handle_client_event_log(handler, body: dict) -> bool:
+    if _client_event_rate_limited(handler):
+        _CLIENT_EVENT_LOGGER.warning(
+            "Dropped client event from %s: rate limit exceeded",
+            _client_ip_for_rate_limit(handler),
+        )
+        return j(handler, {"ok": False, "error": "rate_limited"}, status=429) or True
+    payload = _sanitize_client_event_payload(body)
+    _CLIENT_EVENT_LOGGER.info("Client event from %s: %s", _client_ip_for_rate_limit(handler), payload)
+    return j(handler, {"ok": True, "event": payload.get("event")}) or True
 
 
 def _normalize_provider_id(value: str | None) -> str:
@@ -4707,6 +4835,11 @@ def handle_post(handler, parsed) -> bool:
 
     if parsed.path == "/api/transcribe":
         return handle_transcribe(handler)
+
+    if parsed.path == "/api/client-events/log":
+        if diag:
+            diag.stage("read_client_event_body")
+        return _handle_client_event_log(handler, _read_client_event_payload(handler))
 
     if diag:
         diag.stage("read_body")

--- a/api/run_journal.py
+++ b/api/run_journal.py
@@ -262,7 +262,7 @@ def stale_interrupted_event(session_id: str, run_id: str, *, after_seq: int | No
         return None
     payload = {
         "type": "interrupted",
-        "message": "WebUI restarted or lost the live worker before this run finished.",
+        "message": "The live worker stopped before this run finished.",
         "hint": "The transcript was restored to the last journaled event. Start a new turn if you still need the task to continue.",
         "session_id": session_id,
         "stream_id": run_id,

--- a/api/run_journal.py
+++ b/api/run_journal.py
@@ -278,7 +278,7 @@ def stale_interrupted_event(session_id: str, run_id: str, *, after_seq: int | No
         "type": "apperror",
         "created_at": time.time(),
         "terminal": True,
-        "terminal_state": "stale-from-restart",
+        "terminal_state": "lost-worker-bookkeeping",
         "payload": payload,
         "synthetic": True,
     }

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -2613,7 +2613,7 @@ def _stream_writeback_can_supersede_recovery_marker(session, msg_text):
     if last.get('type') != 'interrupted':
         return False
     content = str(last.get('content') or '')
-    if 'Response interrupted' not in content or 'WebUI process restarted' not in content:
+    if 'Response interrupted' not in content or 'before this turn finished' not in content:
         return False
 
     expected = ' '.join(str(msg_text or '').split())

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -87,9 +87,9 @@ If after running steps 1-4 the import still fails *and* `pip install -e .` succe
 
 ## "Response interrupted." marker keeps saying "no agent output was recovered"
 
-**Symptom.** After the WebUI process restarts mid-turn (manual restart, OOM, crash, …), the affected chat shows an `**Response interrupted.**` marker with the wording *"The user message above was preserved, but no agent output was recovered."*, even though the run-journal for that turn is present on disk and contains the partial tokens the agent had already streamed.
+**Symptom.** After a live response stream stops before a turn completes (manual restart, OOM, crash, browser/SSE disconnect, lost worker bookkeeping, …), the affected chat shows an `**Response interrupted.**` marker with the wording *"The user message above was preserved, but no agent output was recovered."*, even though the run-journal for that turn is present on disk and contains the partial tokens the agent had already streamed.
 
-**Why.** Sidecar repair re-checks the run-journal at restart and uses the result as a one-shot signal. On WSL2 (9p / DrvFs) and on some network-backed setups, the run-journal `.jsonl` is written by the dead worker but the WebUI process reads it through a page-cache state that has not yet seen those writes — recovery returns "empty" and the marker is baked permanently. The fix introduces a *lazy* retry path: when sidecar repair cannot read visible output but knows the stream id, it stores a `_pending_journal_recovery` flag on the marker and re-attempts recovery from `get_session()` until the journal becomes readable (or the retry budget is exhausted).
+**Why.** Sidecar repair re-checks the run-journal after it detects a stale stream and uses the result as a one-shot signal. On WSL2 (9p / DrvFs) and on some network-backed setups, the run-journal `.jsonl` is written by the stopped worker but the WebUI process reads it through a page-cache state that has not yet seen those writes — recovery returns "empty" and the marker is baked permanently. The fix introduces a *lazy* retry path: when sidecar repair cannot read visible output but knows the stream id, it stores a `_pending_journal_recovery` flag on the marker and re-attempts recovery from `get_session()` until the journal becomes readable (or the retry budget is exhausted).
 
 **Diagnostic.**
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -93,7 +93,7 @@ If after running steps 1-4 the import still fails *and* `pip install -e .` succe
 
 **Interruption classes.** The WebUI now keeps the user-facing cases separate instead of implying every stale stream was a restart:
 
-- **Browser/SSE connection interrupted** — the live browser `EventSource` transport dropped. The UI reports `Connection interrupted` and tries status/replay/session restore before showing the final browser-side notice.
+- **Browser/SSE connection interrupted** — the live browser `EventSource` transport dropped. The UI reports `Connection interrupted` and tries status/replay/session restore before showing the final browser-side notice. Chat and gateway SSE errors also POST a small sanitized diagnostic event to `/api/client-events/log` (source, session id, stream id, readyState, visibility, online state, path without query string) so server logs can distinguish browser transport loss from backend worker loss.
 - **Lost worker bookkeeping** — the stream id is gone and the worker registry no longer has an active run. Recovery markers carry `interruption_cause: "lost_worker_bookkeeping"` and `/api/chat/stream/status` reports `terminal_state: "lost-worker-bookkeeping"` for non-terminal journals that are no longer active.
 - **Stream/run split-brain** — the stream is gone but `ACTIVE_RUNS` still lists the worker. Recovery markers carry `interruption_cause: "stream_run_split_brain"` so the transcript says this is a bookkeeping split-brain rather than a restart.
 - **Process crash/restart** — `SERVER_START_TIME` is newer than `pending_started_at`, meaning the WebUI process started after the turn began. Recovery markers carry `interruption_cause: "process_restart"` and explicitly say the process-start evidence points to a crash or restart.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -87,9 +87,16 @@ If after running steps 1-4 the import still fails *and* `pip install -e .` succe
 
 ## "Response interrupted." marker keeps saying "no agent output was recovered"
 
-**Symptom.** After a live response stream stops before a turn completes (manual restart, OOM, crash, browser/SSE disconnect, lost worker bookkeeping, …), the affected chat shows an `**Response interrupted.**` marker with the wording *"The user message above was preserved, but no agent output was recovered."*, even though the run-journal for that turn is present on disk and contains the partial tokens the agent had already streamed.
+**Symptom.** After a live response stream stops before a turn completes (manual restart, OOM, crash, browser/SSE disconnect, lost worker bookkeeping, …), the affected chat shows an `**Response interrupted.**` marker. If the run-journal for that turn is already visible on disk, the marker says the partial output was recovered; if not, it preserves the user turn and says no agent output was recovered yet.
 
-**Why.** Sidecar repair re-checks the run-journal after it detects a stale stream and uses the result as a one-shot signal. On WSL2 (9p / DrvFs) and on some network-backed setups, the run-journal `.jsonl` is written by the stopped worker but the WebUI process reads it through a page-cache state that has not yet seen those writes — recovery returns "empty" and the marker is baked permanently. The fix introduces a *lazy* retry path: when sidecar repair cannot read visible output but knows the stream id, it stores a `_pending_journal_recovery` flag on the marker and re-attempts recovery from `get_session()` until the journal becomes readable (or the retry budget is exhausted).
+**Why.** Sidecar repair re-checks the run-journal after it detects a stale stream and uses the result as a one-shot signal. On WSL2 (9p / DrvFs) and on some network-backed setups, the run-journal `.jsonl` is written by the stopped worker but the WebUI process reads it through a page-cache state that has not yet seen those writes — recovery returns "empty" and the marker would otherwise be baked permanently. The fix introduces a *lazy* retry path: when sidecar repair cannot read visible output but knows the stream id, it stores a `_pending_journal_recovery` flag on the marker and re-attempts recovery from `get_session()` until the journal becomes readable (or the retry budget is exhausted).
+
+**Interruption classes.** The WebUI now keeps the user-facing cases separate instead of implying every stale stream was a restart:
+
+- **Browser/SSE connection interrupted** — the live browser `EventSource` transport dropped. The UI reports `Connection interrupted` and tries status/replay/session restore before showing the final browser-side notice.
+- **Lost worker bookkeeping** — the stream id is gone and the worker registry no longer has an active run. Recovery markers carry `interruption_cause: "lost_worker_bookkeeping"` and `/api/chat/stream/status` reports `terminal_state: "lost-worker-bookkeeping"` for non-terminal journals that are no longer active.
+- **Stream/run split-brain** — the stream is gone but `ACTIVE_RUNS` still lists the worker. Recovery markers carry `interruption_cause: "stream_run_split_brain"` so the transcript says this is a bookkeeping split-brain rather than a restart.
+- **Process crash/restart** — `SERVER_START_TIME` is newer than `pending_started_at`, meaning the WebUI process started after the turn began. Recovery markers carry `interruption_cause: "process_restart"` and explicitly say the process-start evidence points to a crash or restart.
 
 **Diagnostic.**
 

--- a/server.py
+++ b/server.py
@@ -258,6 +258,11 @@ class Handler(BaseHTTPRequestHandler):
             result = handle_get(self, parsed)
             if result is False:
                 return j(self, {'error': 'not found'}, status=404)
+        except (BrokenPipeError, ConnectionResetError, ConnectionAbortedError):
+            # The browser/client closed the socket while we were writing the
+            # response. This is expected for probes, tab closes, and SSE
+            # reconnect races; do not convert it into a misleading server 500.
+            return
         except Exception as e:
             print(f'[webui] ERROR {self.command} {self.path}\n' + traceback.format_exc(), flush=True)
             return j(self, {'error': 'Internal server error'}, status=500)
@@ -284,6 +289,11 @@ class Handler(BaseHTTPRequestHandler):
             result = route_func(self, parsed)
             if result is False:
                 return j(self, {'error': 'not found'}, status=404)
+        except (BrokenPipeError, ConnectionResetError, ConnectionAbortedError):
+            # The browser/client closed the socket while we were writing the
+            # response. This is expected for probes, tab closes, and SSE
+            # reconnect races; do not convert it into a misleading server 500.
+            return
         except Exception as e:
             print(f'[webui] ERROR {self.command} {self.path}\n' + traceback.format_exc(), flush=True)
             return j(self, {'error': 'Internal server error'}, status=500)

--- a/static/messages.js
+++ b/static/messages.js
@@ -2080,13 +2080,14 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     });
 
     source.addEventListener('error',async e=>{
-      source.close();
-      if(_deferStreamErrorIfOffline()) return;
-      if(_deferStreamErrorIfPageHidden()) return;
       if(_terminalStateReached || _streamFinalized){
         _closeSource();
         return;
       }
+      if(typeof recordClientSSEError==='function') recordClientSSEError('chat-response',{ready_state:source?source.readyState:null,session_id:activeSid,stream_id:streamId,reason:'chat EventSource.onerror'});
+      source.close();
+      if(_deferStreamErrorIfOffline()) return;
+      if(_deferStreamErrorIfPageHidden()) return;
       // Attempt one reconnect if the stream is still active server-side
       if(!_reconnectAttempted && streamId){
         _reconnectAttempted=true;

--- a/static/messages.js
+++ b/static/messages.js
@@ -2245,12 +2245,12 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     if(S.session&&S.session.session_id===activeSid){
       S.activeStreamId=null;
       clearLiveToolCards();if(!assistantText)removeThinking();
-      S.messages.push({role:'assistant',content:'**Error:** Connection lost'});renderMessages({preserveScroll:true});
+      S.messages.push({role:'assistant',content:'**Connection interrupted:** The browser lost the live SSE connection before the response finished. If the worker completed, reopening this session should restore the settled transcript.'});renderMessages({preserveScroll:true});
       _markSessionViewed(activeSid, S.messages.length);
     }else{
       if(typeof trackBackgroundError==='function'){
         const _errTitle=(typeof _allSessions!=='undefined'&&_allSessions.find(s=>s.session_id===activeSid)||{}).title||null;
-        trackBackgroundError(activeSid,_errTitle,'Connection lost');
+        trackBackgroundError(activeSid,_errTitle,'Connection interrupted');
       }
     }
     _setActivePaneIdleIfOwner();

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -2438,6 +2438,7 @@ function startGatewaySSE(){
       }catch(e){ /* ignore parse errors */ }
     });
     _gatewaySSE.onerror = () => {
+      if(typeof recordClientSSEError==='function') recordClientSSEError('gateway-sessions',{ready_state:_gatewaySSE?_gatewaySSE.readyState:null,reason:'gateway EventSource.onerror'});
       if(_gatewaySSE){
         _gatewaySSE.close();
         _gatewaySSE = null;

--- a/static/workspace.js
+++ b/static/workspace.js
@@ -85,6 +85,23 @@ async function api(path,opts={}){
   throw lastErr;
 }
 
+function recordClientSSEError(source, details={}){
+  try{
+    const payload={
+      event:'sse_error',
+      source:String(source||'unknown'),
+      ready_state:details.ready_state,
+      session_id:details.session_id||null,
+      stream_id:details.stream_id||null,
+      visibility_state:(typeof document!=='undefined'&&document.visibilityState)||'unknown',
+      online:(typeof navigator!=='undefined'&&typeof navigator.onLine==='boolean')?navigator.onLine:null,
+      url_path:(typeof location!=='undefined'&&location.pathname)||'/',
+      reason:details.reason||'EventSource.onerror',
+    };
+    void api('/api/client-events/log',{method:'POST',body:JSON.stringify(payload),timeoutMs:3000}).catch(()=>{});
+  }catch(_){}
+}
+
 // Persist/restore expanded directory state per workspace in localStorage
 function _wsExpandKey(){
   const ws=S.session&&S.session.workspace;

--- a/tests/test_client_event_diagnostics.py
+++ b/tests/test_client_event_diagnostics.py
@@ -1,0 +1,158 @@
+"""Regression coverage for browser-side SSE disconnect diagnostics.
+
+When an EventSource fails in the browser, the server normally only sees a dead
+socket or follow-up probe. Persisting a small, sanitized client event makes the
+next incident diagnosable without logging prompt text or credentials.
+"""
+from pathlib import Path
+from io import BytesIO
+from types import SimpleNamespace
+
+import api.routes as routes
+
+
+REPO = Path(__file__).resolve().parents[1]
+WORKSPACE_JS = (REPO / "static" / "workspace.js").read_text(encoding="utf-8")
+SESSIONS_JS = (REPO / "static" / "sessions.js").read_text(encoding="utf-8")
+MESSAGES_JS = (REPO / "static" / "messages.js").read_text(encoding="utf-8")
+
+
+def test_client_event_log_sanitizes_and_whitelists_fields():
+    payload = {
+        "event": "sse_error",
+        "source": "gateway-sessions",
+        "session_id": "abc123",
+        "stream_id": "stream456",
+        "ready_state": 2,
+        "visibility_state": "hidden",
+        "online": True,
+        "url_path": "/chat/abc123?debug=1",
+        "reason": "onerror",
+        "password": "must-not-survive",
+        "content": "prompt text must not survive",
+        "cookie": "session=secret",
+    }
+
+    sanitized = routes._sanitize_client_event_payload(payload)
+
+    assert sanitized == {
+        "event": "sse_error",
+        "source": "gateway-sessions",
+        "session_id": "abc123",
+        "stream_id": "stream456",
+        "ready_state": 2,
+        "visibility_state": "hidden",
+        "online": True,
+        "url_path": "/chat/abc123",
+        "reason": "onerror",
+    }
+    assert "secret" not in repr(sanitized)
+    assert "prompt text" not in repr(sanitized)
+
+
+def test_client_event_log_bounds_untrusted_values():
+    payload = {
+        "event": "x" * 200,
+        "source": "chat" * 100,
+        "session_id": "s" * 200,
+        "stream_id": "t" * 200,
+        "ready_state": "not-a-number",
+        "visibility_state": "visible" * 40,
+        "online": "yes",
+        "url_path": "https://example.invalid/path?debug=1",
+        "reason": "network" * 80,
+    }
+
+    sanitized = routes._sanitize_client_event_payload(payload)
+
+    assert sanitized["event"] == "x" * 64
+    assert len(sanitized["source"]) == 80
+    assert len(sanitized["session_id"]) == 128
+    assert len(sanitized["stream_id"]) == 128
+    assert "ready_state" not in sanitized
+    assert sanitized["visibility_state"] == ("visible" * 40)[:32]
+    assert sanitized["online"] is True
+    assert sanitized["url_path"] == "/path"
+    assert len(sanitized["reason"]) == 160
+
+
+def test_client_event_log_route_is_wired(monkeypatch):
+    captured = {}
+
+    body_bytes = b'{"event":"sse_error","source":"chat-response"}'
+
+    def fake_handle(handler, body):
+        captured["body"] = body
+        return True
+
+    monkeypatch.setattr(routes, "_check_csrf", lambda handler: True)
+    monkeypatch.setattr(routes, "_handle_client_event_log", fake_handle)
+
+    handler = SimpleNamespace(headers={"Content-Length": str(len(body_bytes))}, rfile=BytesIO(body_bytes))
+    handled = routes.handle_post(handler, SimpleNamespace(path="/api/client-events/log"))
+
+    assert handled is True
+    assert captured["body"] == {"event": "sse_error", "source": "chat-response"}
+
+
+def test_client_event_log_has_endpoint_specific_body_cap():
+    too_large = b"{" + b"x" * (routes._CLIENT_EVENT_MAX_BODY_BYTES + 32) + b"}"
+    handler = SimpleNamespace(
+        headers={"Content-Length": str(len(too_large))},
+        rfile=BytesIO(too_large),
+        close_connection=False,
+    )
+
+    payload = routes._read_client_event_payload(handler)
+
+    assert payload == {"event": "discarded", "reason": "body_too_large"}
+    assert handler.rfile.tell() == routes._CLIENT_EVENT_MAX_BODY_BYTES
+    assert handler.close_connection is True
+
+
+def test_client_event_log_rate_limits_per_client(monkeypatch):
+    routes._CLIENT_EVENT_RATE_LIMIT.clear()
+    monkeypatch.setattr(routes, "j", lambda handler, payload, status=200: payload.update({"status": status}) or True)
+    handler = SimpleNamespace(client_address=("203.0.113.10", 1234))
+
+    for i in range(routes._CLIENT_EVENT_RATE_LIMIT_MAX):
+        assert routes._handle_client_event_log(handler, {"event": f"sse_error_{i}"}) is True
+
+    limited = {}
+    monkeypatch.setattr(routes, "j", lambda handler, payload, status=200: limited.update(payload, status=status) or True)
+    assert routes._handle_client_event_log(handler, {"event": "sse_error_over_limit"}) is True
+
+    assert limited == {"ok": False, "error": "rate_limited", "status": 429}
+    routes._CLIENT_EVENT_RATE_LIMIT.clear()
+
+
+def test_workspace_js_defines_sanitized_client_sse_error_reporter():
+    helper_start = WORKSPACE_JS.index("function recordClientSSEError")
+    helper_block = WORKSPACE_JS[helper_start:helper_start + 900]
+    assert "api/client-events/log" in helper_block
+    assert "document.visibilityState" in helper_block
+    assert "navigator.onLine" in helper_block
+    assert "location.pathname" in helper_block
+    assert "location.search" not in helper_block
+
+
+def test_sessions_js_reports_gateway_sse_errors_with_browser_context():
+    gateway_block_start = SESSIONS_JS.index("_gatewaySSE.onerror = () =>")
+    gateway_block = SESSIONS_JS[gateway_block_start:gateway_block_start + 400]
+    assert "recordClientSSEError('gateway-sessions'" in gateway_block
+    assert "probeGatewaySSEStatus" in gateway_block
+
+
+def test_messages_js_reports_chat_sse_errors_with_stream_identity():
+    error_block_start = MESSAGES_JS.index("source.addEventListener('error',async e=>")
+    error_block = MESSAGES_JS[error_block_start:error_block_start + 900]
+    assert "recordClientSSEError('chat-response'" in error_block
+    assert "session_id:activeSid" in error_block
+    assert "stream_id:streamId" in error_block
+
+
+def test_messages_js_keeps_finalized_stream_guard_before_diagnostic_report():
+    error_block_start = MESSAGES_JS.index("source.addEventListener('error',async e=>")
+    error_block = MESSAGES_JS[error_block_start:error_block_start + 900]
+    assert "_streamFinalized" in error_block
+    assert error_block.index("_streamFinalized") < error_block.index("recordClientSSEError")

--- a/tests/test_run_journal.py
+++ b/tests/test_run_journal.py
@@ -116,7 +116,7 @@ def test_stale_interrupted_event_reports_non_terminal_journal(tmp_path, monkeypa
 
     assert event["event"] == "apperror"
     assert event["seq"] == 2
-    assert event["terminal_state"] == "stale-from-restart"
+    assert event["terminal_state"] == "lost-worker-bookkeeping"
     assert event["payload"]["type"] == "interrupted"
     assert "last journaled event" in event["payload"]["hint"]
     assert "process restarted" not in event["payload"]["message"]

--- a/tests/test_run_journal.py
+++ b/tests/test_run_journal.py
@@ -112,12 +112,16 @@ def test_stale_interrupted_event_reports_non_terminal_journal(tmp_path, monkeypa
 
     monkeypatch.setattr("api.run_journal._default_session_dir", lambda: tmp_path)
     event = stale_interrupted_event("session_1", "run_1")
+    assert event is not None
 
     assert event["event"] == "apperror"
     assert event["seq"] == 2
     assert event["terminal_state"] == "stale-from-restart"
     assert event["payload"]["type"] == "interrupted"
     assert "last journaled event" in event["payload"]["hint"]
+    assert "process restarted" not in event["payload"]["message"]
+    assert "lost the live worker" not in event["payload"]["message"]
+    assert "live worker stopped" in event["payload"]["message"]
 
 
 def test_stale_interrupted_event_skips_terminal_journal(tmp_path, monkeypatch):

--- a/tests/test_run_journal_routes.py
+++ b/tests/test_run_journal_routes.py
@@ -40,7 +40,7 @@ def test_replay_emits_event_ids_and_stale_restart_diagnostic():
 def test_session_payload_exposes_runtime_journal_for_stale_streams():
     assert "original_stream_id = getattr(s, \"active_stream_id\", None)" in ROUTES_SRC
     assert '"runtime_journal"' in ROUTES_SRC
-    assert 'terminal_state = "stale-from-restart"' in ROUTES_SRC
+    assert 'terminal_state = "lost-worker-bookkeeping"' in ROUTES_SRC
 
 
 def test_status_payload_marks_non_terminal_dead_journal_as_stale():
@@ -60,7 +60,7 @@ def test_status_payload_marks_non_terminal_dead_journal_as_stale():
     )
 
     assert payload["terminal"] is False
-    assert payload["terminal_state"] == "stale-from-restart"
+    assert payload["terminal_state"] == "lost-worker-bookkeeping"
     assert payload["last_event_id"] == "run_1:3"
 
 

--- a/tests/test_session_lost_response_regression.py
+++ b/tests/test_session_lost_response_regression.py
@@ -53,11 +53,13 @@ def _isolate_stream_state():
     config.CANCEL_FLAGS.clear()
     config.AGENT_INSTANCES.clear()
     config.STREAM_PARTIAL_TEXT.clear()
+    config.ACTIVE_RUNS.clear()
     yield
     config.STREAMS.clear()
     config.CANCEL_FLAGS.clear()
     config.AGENT_INSTANCES.clear()
     config.STREAM_PARTIAL_TEXT.clear()
+    config.ACTIVE_RUNS.clear()
 
 
 @pytest.fixture(autouse=True)
@@ -270,6 +272,62 @@ def test_interrupted_recovery_markers_do_not_claim_restart_as_fact():
         assert "Response interrupted" in text
         assert "process restarted" not in text
         assert "before this turn finished" in text
+
+
+def test_interrupted_marker_distinguishes_real_process_restart(monkeypatch):
+    monkeypatch.setattr(config, "SERVER_START_TIME", 2000.0)
+    marker = models._interrupted_recovery_marker(
+        recovered_output=False,
+        stream_id="stream_crash",
+        pending_started_at=1000.0,
+    )
+
+    assert marker["interruption_cause"] == "process_restart"
+    assert "WebUI process started after this turn began" in marker["content"]
+    assert "process restarted" not in marker["content"]
+
+
+def test_interrupted_marker_distinguishes_stream_run_split_brain(monkeypatch):
+    monkeypatch.setattr(config, "SERVER_START_TIME", 1000.0)
+    config.ACTIVE_RUNS["stream_split"] = {"session_id": "sid", "phase": "running"}
+
+    marker = models._interrupted_recovery_marker(
+        recovered_output=False,
+        stream_id="stream_split",
+        pending_started_at=2000.0,
+    )
+
+    assert marker["interruption_cause"] == "stream_run_split_brain"
+    assert "stream was gone but the worker registry still listed the run" in marker["content"]
+
+
+def test_interrupted_marker_distinguishes_lost_worker_bookkeeping(monkeypatch):
+    monkeypatch.setattr(config, "SERVER_START_TIME", 1000.0)
+
+    marker = models._interrupted_recovery_marker(
+        recovered_output=False,
+        stream_id="stream_lost",
+        pending_started_at=2000.0,
+    )
+
+    assert marker["interruption_cause"] == "lost_worker_bookkeeping"
+    assert "worker bookkeeping no longer had an active run" in marker["content"]
+
+
+def test_messages_js_names_browser_sse_disconnect_separately():
+    repo = models.Path(__file__).parent.parent
+    js = (repo / "static" / "messages.js").read_text(encoding="utf-8")
+
+    assert "Connection interrupted" in js
+    assert "browser lost the live SSE connection" in js
+    assert "Connection lost" not in js
+
+
+def test_server_treats_broken_pipe_as_client_disconnect_not_500():
+    server_py = (models.Path(__file__).parent.parent / "server.py").read_text(encoding="utf-8")
+
+    assert "except (BrokenPipeError, ConnectionResetError, ConnectionAbortedError):" in server_py
+    assert "do not convert it into a misleading server 500" in server_py
 
 
 def test_lost_response_recovered_on_second_read(hermes_home):

--- a/tests/test_session_lost_response_regression.py
+++ b/tests/test_session_lost_response_regression.py
@@ -2,8 +2,8 @@
 
 The scenario this test pins down:
 
-1. A WebUI process restarts mid-stream. On the first sidecar repair attempt
-   the run-journal for the dead stream is NOT visible yet (page-cache loss,
+1. A WebUI live response stream stops mid-turn. On the first sidecar repair
+   attempt the run-journal for the dead stream is NOT visible yet (page-cache loss,
    un-fsynced writes, slow network FS, etc.) so
    `_append_journaled_partial_output` returns False.
 2. Pre-fix the repair path baked a permanent "no agent output was recovered"
@@ -249,6 +249,27 @@ def test_state_db_middle_segment_replay_does_not_append_after_sidecar_tail():
     assert [m["content"] for m in merged] == [m["content"] for m in sidecar_messages]
     assert merged[-1]["role"] == "assistant"
     assert merged[-1]["content"] == "opened browser preview"
+
+
+def test_interrupted_recovery_markers_do_not_claim_restart_as_fact():
+    """A stale live worker is not always a WebUI process restart.
+
+    Broken SSE connections, browser disconnects, lost worker bookkeeping, and
+    real restarts all enter the same recovery marker path. User-visible wording
+    must describe the generic interruption instead of asserting a process
+    restart that systemd evidence may later disprove.
+    """
+    marker_texts = [
+        models._INTERRUPTED_RECOVERED_WORDING,
+        models._INTERRUPTED_NO_OUTPUT_WORDING,
+        models._INTERRUPTED_PENDING_RETRY_WORDING,
+        models._INTERRUPTED_NEUTRAL_WORDING,
+    ]
+
+    for text in marker_texts:
+        assert "Response interrupted" in text
+        assert "process restarted" not in text
+        assert "before this turn finished" in text
 
 
 def test_lost_response_recovered_on_second_read(hermes_home):

--- a/tests/test_session_sidecar_repair.py
+++ b/tests/test_session_sidecar_repair.py
@@ -319,7 +319,8 @@ class TestDraftRecovery:
             f"Error marker should not say 'preserved as a draft', got: {content}"
         )
         assert "Response interrupted" in content
-        assert "WebUI process restarted" in content
+        assert "live response stream stopped" in content
+        assert "WebUI process restarted" not in content
         # The marker now arms the lazy-retry hook when a stream id is known
         # ("Recovering the partial output… reload to retry."). The legacy
         # "user message above was preserved" wording is reserved for the
@@ -624,7 +625,8 @@ class TestNonEmptyMessagesPendingCleared:
         error_msgs = [m for m in s.messages if m.get("_error")]
         assert len(error_msgs) == 1
         assert "Response interrupted" in error_msgs[0]["content"]
-        assert "WebUI process restarted" in error_msgs[0]["content"]
+        assert "live response stream stopped" in error_msgs[0]["content"]
+        assert "WebUI process restarted" not in error_msgs[0]["content"]
         assert error_msgs[0].get("type") == "interrupted"
 
         # Pending fields fully cleared


### PR DESCRIPTION
## Thinking Path

- Hermes WebUI chat turns depend on live SSE streams plus recovery markers when a turn is interrupted.
- The existing recovery text could state that the WebUI process restarted even when the browser only lost the live SSE connection or the worker bookkeeping was stale.
- That wording made incident diagnosis harder because it collapsed process restarts, stream/run split-brain, lost worker bookkeeping, and browser transport failures into one apparent cause.
- This PR keeps the recovery path conservative: user-visible markers describe what is known, classify the interruption cause where the server has evidence, and record sanitized client-side SSE diagnostics for future root-cause checks.

## What Changed

- Rewords interrupted-response recovery markers so they no longer assert a WebUI process restart unless restart evidence exists.
- Adds interruption-cause classification for:
  - real process restarts,
  - stream/run split-brain,
  - lost live-worker bookkeeping,
  - unknown/uncategorized interruptions.
- Updates run-journal stale markers and streaming recovery supersede checks to use the new wording/cause semantics.
- Treats browser/client SSE disconnects as `Connection interrupted` instead of the generic `Connection lost` path.
- Suppresses noisy server stack traces for expected client-side gateway SSE disconnects (`BrokenPipeError`, reset, aborted connection).
- Adds `/api/client-events/log` for sanitized browser diagnostics and wires chat/gateway SSE error paths to it.
- Updates troubleshooting docs and the changelog.

## Why It Matters

Users and maintainers need recovery text to describe observed facts, not guess at a server restart. A browser reload or dropped EventSource should not look like a WebUI crash. The new classification keeps the UI clearer and gives future reports enough sanitized telemetry to distinguish transport failure from server/runtime recovery issues.

State layer / invariant: this touches live chat SSE transport, run-journal interruption markers, session recovery markers, and the client diagnostic event surface. The invariant is that interrupted-turn markers must not claim a process restart unless that is the classified cause, and browser-side SSE transport failures should be reported separately from server/runtime restart recovery.

## Verification

- `git diff --check origin/master...HEAD`
- Rebased onto current `origin/master` (`v0.51.131` / stage-batch13) and resolved the `CHANGELOG.md` release-block conflict.
- Added-line private marker scan: `0 hits`
- Added-line secret/private marker scan: `3 synthetic sanitizer-test fixture hits` (`password: "***"`, `cookie: "session=secret"`, assertion text), no real secrets or private markers
- `python3 -m pytest tests/test_client_event_diagnostics.py tests/test_session_lost_response_regression.py tests/test_run_journal.py tests/test_run_journal_routes.py tests/test_session_sidecar_repair.py -q` → `105 passed`
- `python3 -m compileall -q api server.py` → passed
- Current PR head: `8a2f11c`; GitHub reports `MERGEABLE` / `CLEAN`; refreshed CI is green for Python 3.11, 3.12, and 3.13.

## Risks / Follow-ups

- The new `/api/client-events/log` endpoint intentionally whitelists a very small field set and strips query strings from `url_path`; future diagnostic fields should be added only if they are non-sensitive and tested. Oversized diagnostic bodies now set `handler.close_connection = True` after a bounded read so HTTP/1.1 keep-alive sockets do not retain unread request-body bytes for the next request.
- Latest final readback after rebase: PR head matches pushed fork branch, merge state is clean, and all refreshed checks completed successfully.
- This PR does not add a browser screenshot/video because it changes diagnostic/recovery text and logging paths rather than layout or persistent interaction flow.

## Model Used

AI-assisted by TARS in Hermes WebUI.

- Provider/model: OpenAI Codex, `gpt-5.5`
- Notable tool use: git/gh CLI, pytest, compileall, static diff scans, Hermes skills for GitHub PR workflow and verification gates.



