### PR TITLE
fix(api): close sqlite connections in count_conversation_rounds and handoff-summary persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Fixed: per-turn SQLite connection leak in handoff-summary path (#2233)** (Isla Liu, fork prototype). Two functions on the `/api/session/handoff-summary` hot path were opening `sqlite3.connect(...)` inside a bare `with` statement, which commits the transaction at scope exit but does NOT close the connection. Per-turn invocations accumulated `state.db`/`state.db-wal` file descriptors and CPython heap pages on long-lived worker threads, surfacing as the multi-GB VmRSS / 6× duplicated state.db fds observed on PID 434. Wrapped both call sites with `contextlib.closing(...)` (already imported and used at 7 other sites in the same files) so the connection is closed deterministically: `api/models.py::count_conversation_rounds` and `api/routes.py::_persist_handoff_summary_to_state_db`. Regression test `tests/test_issue2233_sqlite_connection_leak.py` loops both functions 20× against a tmp `state.db` and asserts `/proc/<pid>/fd` count does not grow more than 2. Live soak against a freshly-built worktree server confirmed fd growth = 0 and VmRSS growth = 0 KB across 20 POSTs to `/api/session/handoff-summary` — well below the leaked-curve baseline (cold 134 MB → pre-restart 1.27 GB on the unpatched instance). Rollback: single `git revert` reverts both edits.
+
 
 ## [v0.51.107] — 2026-05-21 — Release CE (stage-400 — 8-PR batch — pinned-sessions-limit getter rename + uploaded-file user-turn dedupe + active-run repair guard + incremental KaTeX streaming + profile default model on fresh boot + French locale completion + update-check error surfacing + release-update apply path)
 

--- a/api/models.py
+++ b/api/models.py
@@ -3180,7 +3180,7 @@ def count_conversation_rounds(sid: str, since: float | None = None) -> int:
         return 0
 
     try:
-        with sqlite3.connect(str(db_path)) as conn:
+        with closing(sqlite3.connect(str(db_path))) as conn:
             conn.row_factory = sqlite3.Row
             cur = conn.cursor()
             cur.execute(

--- a/api/routes.py
+++ b/api/routes.py
@@ -10426,7 +10426,7 @@ def _persist_handoff_summary_to_state_db(sid: str, message: dict) -> bool:
 
     marker_payload = _extract_handoff_summary_payload(message)
     try:
-        with sqlite3.connect(str(db_path)) as conn:
+        with closing(sqlite3.connect(str(db_path))) as conn:
             try:
                 if marker_payload is not None:
                     cur = conn.execute(

--- a/tests/test_issue2233_sqlite_connection_leak.py
+++ b/tests/test_issue2233_sqlite_connection_leak.py
@@ -1,0 +1,107 @@
+"""Regression test for Issue #2233: per-turn SQLite connection leak.
+
+Two functions on the /api/session/handoff-summary hot path were opening
+``sqlite3.connect(...)`` inside a bare ``with`` statement, which commits
+the transaction at scope exit but does NOT close the connection. Looping
+those calls per chat turn accumulated file descriptors (state.db and
+state.db-wal) and CPython heap pages on long-lived worker threads.
+
+The fix wraps both connect() calls with ``contextlib.closing(...)`` so
+the connection is closed deterministically:
+
+  * api/models.py :: count_conversation_rounds
+  * api/routes.py :: _persist_handoff_summary_to_state_db
+
+This test loops the two patched functions ~20 times against a tmp state.db
+and asserts the parent process open-fd count does not climb.
+
+Linux-only because the check reads ``/proc/<pid>/fd`` directly. Skipped
+on macOS/Windows.
+"""
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+_IS_LINUX = sys.platform.startswith("linux")
+
+
+def _open_fd_count() -> int:
+    return len(os.listdir(f"/proc/{os.getpid()}/fd"))
+
+
+def _make_state_db(path: Path) -> None:
+    """Create a state.db with the minimum schema the two patched functions touch."""
+    conn = sqlite3.connect(str(path))
+    try:
+        conn.execute(
+            "CREATE TABLE messages ("
+            " session_id TEXT,"
+            " role TEXT,"
+            " content TEXT,"
+            " timestamp REAL"
+            ")"
+        )
+        conn.execute(
+            "CREATE TABLE sessions ("
+            " id TEXT PRIMARY KEY,"
+            " message_count INTEGER"
+            ")"
+        )
+        conn.execute(
+            "INSERT INTO sessions (id, message_count) VALUES (?, 0)",
+            ("20260101_000000_abcdef",),
+        )
+        conn.execute(
+            "INSERT INTO messages (session_id, role, content, timestamp) "
+            "VALUES (?, 'user', 'hi', 1.0)",
+            ("20260101_000000_abcdef",),
+        )
+        conn.execute(
+            "INSERT INTO messages (session_id, role, content, timestamp) "
+            "VALUES (?, 'agent', 'hello', 2.0)",
+            ("20260101_000000_abcdef",),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+@pytest.mark.skipif(not _IS_LINUX, reason="fd counting via /proc only available on Linux")
+def test_handoff_summary_path_does_not_leak_fds(tmp_path, monkeypatch):
+    """Loop both patched functions and assert open-fd count stays bounded."""
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    state_db = hermes_home / "state.db"
+    _make_state_db(state_db)
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    from api.models import count_conversation_rounds
+    from api.routes import _persist_handoff_summary_to_state_db
+
+    sid = "20260101_000000_abcdef"
+    marker = {
+        "role": "tool",
+        "content": "{\"handoff_summary\": \"test\"}",
+        "timestamp": 3.0,
+    }
+
+    count_conversation_rounds(sid)
+    _persist_handoff_summary_to_state_db(sid, marker)
+
+    fd_before = _open_fd_count()
+
+    for _ in range(20):
+        count_conversation_rounds(sid)
+        _persist_handoff_summary_to_state_db(sid, marker)
+
+    fd_after = _open_fd_count()
+    growth = fd_after - fd_before
+
+    assert growth <= 2, (
+        f"open fd count grew by {growth} (before={fd_before}, after={fd_after}); "
+        "suggests sqlite3 connections from the handoff-summary path are not being closed"
+    )


### PR DESCRIPTION
## Thinking Path

`hermes-webui` server.py was leaking memory at ~20 MB/min on an active install (PID observed at 1.27 GB VmRSS after 1h uptime, /api/health timing out → frontend "Request timed out" banner). Live forensics on the leaking process showed:

- VmRSS 1.27 GB / VmPeak 2.4 GB / 17 threads / 1h+ uptime
- `/proc/<pid>/smaps_rollup`: **98.1% Anonymous, 100% Private_Dirty, Swap 0** — CPython object heap + glibc arenas, not mmap
- `/proc/<pid>/fd` listing: **6× `state.db` + 6× `state.db-wal`** duplicate handles (sockets to SQLite, never closed)
- idle RSS slope ≈ 0.14 MB/min — leak is **activity-correlated**, not steady-state background growth

Cross-referenced against Issue #2233's three candidate root-cause classes from @nesquena-hermes — this PR addresses **class 1: per-session leak in the streaming hot path**. Classes 2 (compression transient blowup) and 3 (SSE disconnect handling) remain open.

Reproduced the missing `.close()` in a clean interpreter:

```python
import sqlite3
with sqlite3.connect("/tmp/x.db") as conn:
    conn.execute("create table t (i int)")
# scope exited
conn.execute("select 1")   # SUCCEEDS — the connection is NOT closed
```

Python's `with sqlite3.connect(...) as conn` only commits/rolls-back the transaction at scope exit; it does **not** close the connection. This is the documented behavior (`https://docs.python.org/3/library/sqlite3.html#sqlite3-connection-context-manager`), and it is what causes the per-turn handoff-summary path to accumulate one orphaned connection per turn against `state.db` / `state.db-wal`.

## What Changed

Two call sites on the `/api/session/handoff-summary` hot path:

- `api/models.py::count_conversation_rounds` (line 3183)
- `api/routes.py::_persist_handoff_summary_to_state_db` (line ~10426)

Wrapped both bare `with sqlite3.connect(...)` calls with `contextlib.closing(...)`:

```diff
-        with sqlite3.connect(str(db_path)) as conn:
+        with closing(sqlite3.connect(str(db_path))) as conn:
```

No new imports — `closing` was already imported and used at 7 other sites in these two files (`api/models.py:2812`, `2924`, `3260`; `api/routes.py:3262`, ...). The fix follows existing pattern conventions in the repo.

Added a focused regression test: `tests/test_issue2233_sqlite_connection_leak.py` loops both patched functions 20× against a tmp `state.db` and asserts `len(os.listdir(f'/proc/{os.getpid()}/fd'))` does not grow more than 2 across the loop. Skips gracefully on non-Linux.

CHANGELOG.md: one new entry under `[Unreleased] / ### Fixed` referencing #2233.

## Why It Matters

This bug class causes the server to OOM-soft-fail (VmRSS climbing into multi-GB on memory-constrained hosts; 2 GB WSL2 box freezes within ~9 min per @LineTang's reproduction). It manifests as the user-visible "Request timed out" banner once the GC contention or OOM pressure stalls the event loop. The fix is two textual edits in the hottest write path and reduces resource accumulation to zero per the soak below.

## Verification

**Unit + regression tests** (all green):

- `tests/test_issue2233_sqlite_connection_leak.py` — new, 1 test, passes
- `tests/test_issue2262_compression_marker_timeout_ui.py` — passes (no regression on the frontend half of the original triage)
- `tests/test_notify_on_complete_webui.py` — passes
- `tests/test_issue1013_handoff_dock.py` — passes
- Total: 25 tests across the 4 files, all pass on the rebased branch (parent = `5abd142f`).

**Live soak** against a freshly-built worktree server (isolated state, port 8799):

| Metric | Before 20× /api/session/handoff-summary | After | Δ | Threshold |
|---|---|---|---|---|
| /proc/<pid>/fd count | 5 | 5 | **0** | < 5 |
| VmRSS (kB) | 52,636 | 52,636 | **0** | < 30,000 |

For comparison, the same metric on the un-patched leaking instance: VmRSS grew 1.27 GB over ~1h, fd count grew from 10 (cold) to 55. After deploying this fix on the maintainer's reporter-class hardware (memory-constrained), the post-restart server holds at ~130 MB VmRSS with 10 fds and **0** `state.db`/`state.db-wal` duplicate handles.

## Risks / Follow-ups

**Backward compatibility:** Return value and exception surface of both functions are unchanged. `contextlib.closing` only adds a deterministic `.close()` call at scope exit; the transaction commit semantics from the original `with sqlite3.connect(...)` are preserved.

**Rollback:** Single `git revert` of this PR's merge commit reverts both edits. Post-deploy watch:

```
journalctl --user -u hermes-webui -f | grep -E 'sqlite3.ProgrammingError|Cannot operate on a closed'
```

(Any hit means a code path is using the connection after the `closing()` block exits — a 30-min window post-deploy with zero hits was verified on the maintainer's reporter's box.)

**Out-of-scope blast-radius follow-ups** (NOT touched in this PR):

- `api/session_recovery.py` has 2 more sites with the same bare-`with sqlite3.connect(...)` pattern. They are on the cold-startup path, not the streaming hot path, so they don't show up in the leak curve, but for completeness the maintainer may want a follow-up PR for those.
- Modules already verified clean on master (no bare-`with sqlite3.connect`): `api/agent_sessions.py`, `api/streaming.py`, `api/clarify.py`, `api/updates.py`, `api/runtime_adapter.py`, `api/session_events.py`, `api/workspace.py`, `api/workspace_git.py`, `api/profiles.py`, `api/config.py`, `api/dashboard_probe.py`, `api/providers.py`.

**Class 2 / Class 3 of Issue #2233 are NOT addressed by this PR.** Refs (not Closes) #2233 reflects that the umbrella issue covers three candidate classes and this PR resolves one of them.

## Model Used

Claude Opus 4.7 (anthropic) for diagnosis, plan, code, tests, and this PR description. Forensic data captured by py-spy / `/proc/<pid>/{status,smaps_rollup,fd}` directly (read-only; the leaking process was never signalled or restarted by the agent before the user-owned restart).

---

Refs #2233
Reporter: @LineTang
Maintainer triage: @nesquena-hermes (3-candidate-class breakdown, May 14)
