### PR TITLE
docs(runtime): define runner route gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 ## [Unreleased]
 
+### Added
+
+- **PR #2744** by @Michaelyklam — #1925 RuntimeAdapter RFC follow-up: marks the `runner-local` selection seam shipped in v0.51.105 and defines the next Slice 4d supervised runner route gate before live chat can move onto a runner backend. The gate keeps runner routing default-off, preserves legacy fallback and public response shapes, and carries the Runtime API gap matrix forward so active-run discovery, session→run lookup, command metadata, artifacts, and provider/tool routing do not become private WebUI runtime replicas.
 
 ## [v0.51.107] — 2026-05-21 — Release CE (stage-400 — 8-PR batch — pinned-sessions-limit getter rename + uploaded-file user-turn dedupe + active-run repair guard + incremental KaTeX streaming + profile default model on fresh boot + French locale completion + update-check error surfacing + release-update apply path)
 

--- a/docs/rfcs/hermes-run-adapter-contract.md
+++ b/docs/rfcs/hermes-run-adapter-contract.md
@@ -4,7 +4,7 @@
 - **Author:** @Michaelyklam
 - **Updated by:** @franksong2702
 - **Created:** 2026-05-11
-- **Revised:** 2026-05-17
+- **Revised:** 2026-05-21
 - **Tracking issue:** [#1925](https://github.com/nesquena/hermes-webui/issues/1925)
 
 ## Credit and Scope
@@ -52,7 +52,7 @@ The immediate goal is not to build a sidecar. The immediate goal is to define th
 browser contract, classify current runtime state, and gate the first reversible
 journal slice.
 
-## Current Gate State — 2026-05-19
+## Current Gate State — 2026-05-21
 
 Slice 1 is now past the first active validation gate:
 
@@ -99,11 +99,16 @@ adapter-seam work:
   facade normalizes an injected runner client's start / observe / status /
   control responses without owning `AIAgent`, streams, cancellation flags,
   approval queues, clarify queues, goal state, or cached-agent tables.
-- The next implementation gate is a feature-flagged runner backend plus
-  restart/reattach harness. It must stay default-off, keep legacy fallback
-  intact, pass explicit profile/workspace/model payloads instead of mutating
-  WebUI process globals, and avoid recreating `STREAMS` / `CANCEL_FLAGS` /
-  approval queues / clarify queues under new names.
+- #2627 shipped the Slice 4c runner-backend harness gate in v0.51.96.
+- #2696 shipped the first Slice 4c implementation in v0.51.105: the default-off
+  `runner-local` adapter selection point and `build_runtime_adapter(...)`
+  factory wiring around an injected runner client. Live browser chat routes still
+  stay on the legacy backend, and no supervised runner process exists yet.
+- The next implementation gate is a supervised/local runner backend proposal and
+  route-selection harness. It must stay default-off, keep legacy fallback intact,
+  pass explicit profile/workspace/model payloads instead of mutating WebUI
+  process globals, and avoid recreating `STREAMS` / `CANCEL_FLAGS` / approval
+  queues / clarify queues under new names.
 
 The next gate is runner-backend plumbing, not queue implementation
 by default. Queue / continue routing should only move before Slice 4 if a future
@@ -780,11 +785,11 @@ client/backend and explicit route selection.
 
 #### Slice 4c: Feature-flagged runner backend and restart/reattach harness
 
-Status as of PR #2696: implementation proposed. The code adds a default-off
-`runner-local` adapter selection point plus factory wiring for an injected runner
-client, while keeping live browser chat routes on the legacy backend. The
-restart/reattach harness remains synthetic/fake-runner based until a later slice
-introduces a supervised runner process.
+Status as of 2026-05-21: shipped in v0.51.105 via #2696. The code adds a
+default-off `runner-local` adapter selection point plus factory wiring for an
+injected runner client, while keeping live browser chat routes on the legacy
+backend. The restart/reattach harness remains synthetic/fake-runner based until a
+later slice introduces a supervised runner process.
 
 After the facade exists, the next narrow implementation slice should add a real
 runner-client/backend selection point and a synthetic restart/reattach harness,
@@ -835,6 +840,61 @@ Non-goals for Slice 4c:
 - no live chat route switch to the runner backend before the restart/reattach
   harness is reviewed;
 - no server-side queue endpoint or queue scheduler just for adapter symmetry.
+
+#### Slice 4d: Supervised runner backend route gate
+
+After `runner-local` selection exists, the next reviewable gate should define the
+first supervised/local runner backend and the route-selection harness before live
+browser chat can use it. This is still a contract/test slice first: no default-on
+runner mode, no removal of `legacy-direct` or `legacy-journal`, and no claim that
+production WebUI turns survive restart until the harness demonstrates it.
+
+Scope:
+
+- define the runner process/client lifecycle: how a run is spawned, supervised,
+  observed, and terminated without placing new active-run maps in the main WebUI
+  request process;
+- define the route-selection point for `/api/chat/start` without changing the
+  public response shape while the default remains legacy-backed;
+- specify how runner-owned events become WebUI journal events with stable
+  cursors, terminal state, and replay ordering;
+- specify cancellation, approval, clarify, goal, and staged queue behavior as
+  runner-client `ControlResult` responses, with unsupported controls bounded and
+  visible rather than silently falling back to legacy process-local callbacks;
+- carry the runtime API gap matrix forward: missing Hermes-owned capabilities
+  such as active-run discovery, session-to-run lookup, command capability
+  metadata, artifact events, and provider/tool routing should remain explicit
+  gaps or temporary adapter state, not private WebUI runtime replicas.
+
+Acceptance tests for Slice 4d:
+
+1. **Route remains default-off.** Unset `HERMES_WEBUI_RUNTIME_ADAPTER` and
+   `legacy-direct` keep `/api/chat/start` on the existing path; `runner-local`
+   is the only mode allowed to select the runner route.
+2. **Restart/reattach harness proves ownership moved.** A fake or local runner
+   starts a run, the first WebUI server/adapter instance is discarded, a new
+   adapter instance discovers the same active or terminal run, replay catches up
+   from cursor, and cancel remains available if the run is still active.
+3. **No public response-shape drift.** Chat start and control responses remain
+   stable while adapter-only fields stay internal or explicitly documented as a
+   new contract revision.
+4. **No runtime-surrogate globals.** The main WebUI server does not gain new
+   module-level maps for runner-owned streams, cancel flags, approval/clarify
+   callbacks, cached agents, goal state, or queue schedulers.
+5. **Explicit context payloads.** Runner startup carries session, profile,
+   workspace, attachments, provider/model, toolsets, source, and metadata as
+   payload fields rather than depending on process-global environment mutation in
+   the WebUI server.
+
+Non-goals for Slice 4d:
+
+- no default-on runner backend;
+- no removal of the legacy in-process backends;
+- no server-side queue endpoint or scheduler just for adapter symmetry;
+- no permanent WebUI-owned active-run discovery cache when the missing capability
+  belongs in a runner or future Hermes Runtime API;
+- no broad UI/product surface migration; WebUI remains the rich workbench while
+  only execution ownership moves.
 
 ## First Meaningful Success Criteria
 

--- a/tests/test_runtime_adapter_seam.py
+++ b/tests/test_runtime_adapter_seam.py
@@ -470,6 +470,7 @@ def test_rfc_defines_slice4c_runner_backend_harness_gate():
     rfc = (routes.Path(__file__).parent.parent / "docs" / "rfcs" / "hermes-run-adapter-contract.md").read_text(encoding="utf-8")
 
     assert "#### Slice 4c: Feature-flagged runner backend and restart/reattach harness" in rfc
+    assert "Status as of 2026-05-21: shipped in v0.51.105 via #2696" in rfc
     assert "`HERMES_WEBUI_RUNTIME_ADAPTER=runner-local`" in rfc
     assert "`legacy-direct` remains the default" in rfc
     assert "No route-shape drift" in rfc
@@ -477,6 +478,22 @@ def test_rfc_defines_slice4c_runner_backend_harness_gate():
     assert "discard the first WebUI adapter instance" in rfc
     assert "No runtime-surrogate globals" in rfc
     assert "no live chat route switch to the runner backend before the restart/reattach" in rfc
+
+
+def test_rfc_defines_slice4d_supervised_runner_route_gate():
+    routes = importlib.import_module("api.routes")
+    rfc = (routes.Path(__file__).parent.parent / "docs" / "rfcs" / "hermes-run-adapter-contract.md").read_text(encoding="utf-8")
+
+    assert "#### Slice 4d: Supervised runner backend route gate" in rfc
+    assert "After `runner-local` selection exists" in rfc
+    assert "route-selection harness before live\nbrowser chat can use it" in rfc
+    assert "Route remains default-off" in rfc
+    assert "Restart/reattach harness proves ownership moved" in rfc
+    assert "No public response-shape drift" in rfc
+    assert "No runtime-surrogate globals" in rfc
+    assert "Explicit context payloads" in rfc
+    assert "active-run discovery, session-to-run lookup, command capability\n  metadata, artifact events, and provider/tool routing" in rfc
+    assert "WebUI remains the rich workbench while\n  only execution ownership moves" in rfc
 
 
 def test_runner_runtime_adapter_passes_explicit_start_payload_without_env_mutation(monkeypatch):


### PR DESCRIPTION
## Thinking Path

- #1925 has already shipped the journal/replay baseline, RuntimeAdapter seam, control routing, RunnerRuntimeAdapter facade, and default-off `runner-local` selection seam.
- PR #2696 shipped in v0.51.105 via #2708, so the RFC should no longer describe Slice 4c as merely proposed.
- The next risky step is live route wiring to a supervised/local runner backend, which should get a docs/test gate before code touches `/api/chat/start`.
- This PR keeps the same guardrail: WebUI stays thin in execution ownership, not thin in product scope, and the adapter must not become a private runtime surrogate.

## What Changed

- Updates `docs/rfcs/hermes-run-adapter-contract.md` to mark #2627 / #2696 as shipped.
- Adds a Slice 4d supervised runner backend route gate covering route selection, restart/reattach, response-shape preservation, context payloads, and Runtime API gap handling.
- Adds source-level regression coverage in `tests/test_runtime_adapter_seam.py` so the new Slice 4d gate and #2696 shipped status do not drift.
- Adds a release-note-ready changelog entry.

## Why It Matters

This keeps #1925 moving after #2696 without jumping straight into route wiring. The next implementation slice needs to prove restart/reattach and runner-owned execution without recreating `STREAMS`, `CANCEL_FLAGS`, cached agents, approval/clarify queues, or active-run discovery caches inside the main WebUI server.

## Verification

- `env -u HERMES_CONFIG_PATH -u HERMES_WEBUI_HOST /home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_runtime_adapter_seam.py -q` → `26 passed`
- `git diff --check` → clean

## Risks / Follow-ups

- Docs/test only; no runtime behavior changes.
- A later implementation PR still needs to define the supervised runner/client lifecycle and route-selection harness before live browser chat can run through `runner-local`.
- If Hermes Agent later ships a durable Runtime API, the gap matrix should map active-run discovery, session→run lookup, command metadata, artifacts, and provider/tool routing to that API instead of adding private WebUI state.

## Model Used

OpenAI Codex / `gpt-5.5` via Hermes Agent, with terminal/file/GitHub tooling.

Refs #1925
