### PR TITLE
feat: new_session() reads display.personality from config as default

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -1837,6 +1837,19 @@ def new_session(workspace=None, model=None, profile=None, model_provider=None, p
         effective_model, effective_model_provider = _profile_default_model_state(profile)
         if model_provider:
             effective_model_provider = model_provider
+
+    # Read default personality from config display.personality
+    _default_personality = None
+    try:
+        from api.config import get_config as _get_cfg_for_personality
+        _cfg_personality = (_get_cfg_for_personality().get('display') or {}).get('personality')
+        if _cfg_personality and isinstance(_cfg_personality, str):
+            _cfg_personality = _cfg_personality.strip().lower()
+            if _cfg_personality and _cfg_personality not in ('default', 'none', 'neutral'):
+                _default_personality = _cfg_personality
+    except Exception:
+        pass
+
     wt = worktree_info if isinstance(worktree_info, dict) else None
     workspace_path = (wt.get('path') if wt and wt.get('path') else workspace) if wt else workspace
     s = Session(
@@ -1845,6 +1858,7 @@ def new_session(workspace=None, model=None, profile=None, model_provider=None, p
         model_provider=effective_model_provider,
         profile=profile,
         project_id=project_id,
+        personality=_default_personality,
         worktree_path=wt.get('path') if wt else None,
         worktree_branch=wt.get('branch') if wt else None,
         worktree_repo_root=wt.get('repo_root') if wt else None,

--- a/tests/test_default_personality.py
+++ b/tests/test_default_personality.py
@@ -1,0 +1,123 @@
+"""Test that new_session() reads display.personality from config and uses it as default.
+
+Regression test for the feature that makes /personality taleb sticky across
+new sessions — when display.personality is set in config.yaml, every new
+session should inherit it without requiring an explicit /personality command.
+"""
+
+import pytest
+from unittest.mock import patch
+
+
+# ---------------------------------------------------------------------------
+# R1: new_session() inherits display.personality from config
+# ---------------------------------------------------------------------------
+
+def test_new_session_reads_default_personality_from_config():
+    """When display.personality is set to 'taleb', new_session() should
+    create a Session with personality='taleb'."""
+    import api.models as m
+    import api.config as cfg_mod
+
+    _cfg = {
+        "display": {"personality": "taleb"},
+        "agent": {"personalities": {"taleb": {"system_prompt": "Be like Taleb", "tone": "blunt"}}},
+    }
+
+    with patch.object(cfg_mod, "get_config", return_value=_cfg), \
+         patch.object(m.Session, "save", return_value=None):
+        s = m.new_session(workspace="/tmp/test-personality")
+
+    assert s.personality == "taleb", (
+        f"Expected personality='taleb', got {s.personality!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# R2: 'none', 'default', 'neutral' are treated as no personality
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("personality_value", ["none", "default", "neutral", ""])
+def test_new_session_ignores_neutral_personality_values(personality_value):
+    """Values like 'none', 'default', 'neutral', and '' should NOT be set as
+    the session personality — they mean 'no personality overlay'."""
+
+    import api.models as m
+    import api.config as cfg_mod
+
+    _cfg = {
+        "display": {"personality": personality_value},
+        "agent": {"personalities": {}},
+    }
+
+    with patch.object(cfg_mod, "get_config", return_value=_cfg), \
+         patch.object(m.Session, "save", return_value=None):
+        s = m.new_session(workspace="/tmp/test-personality-neutral")
+
+    assert s.personality is None, (
+        f"Expected None for display.personality={personality_value!r}, "
+        f"got {s.personality!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# R3: Missing display.personality → personality=None
+# ---------------------------------------------------------------------------
+
+def test_new_session_no_personality_when_config_missing():
+    """When config has no display.personality (or display section is absent),
+    new_session() should set personality=None."""
+
+    import api.models as m
+    import api.config as cfg_mod
+
+    _cfg = {"agent": {"personalities": {}}}  # No display section at all
+
+    with patch.object(cfg_mod, "get_config", return_value=_cfg), \
+         patch.object(m.Session, "save", return_value=None):
+        s = m.new_session(workspace="/tmp/test-personality-missing")
+
+    assert s.personality is None
+
+
+# ---------------------------------------------------------------------------
+# R4: Config exception is handled gracefully → personality=None
+# ---------------------------------------------------------------------------
+
+def test_new_session_handles_config_exception_gracefully():
+    """If get_config() raises, we should still get a valid session with
+    personality=None (the try/except should swallow the error)."""
+
+    import api.models as m
+    import api.config as cfg_mod
+
+    def _boom():
+        raise RuntimeError("config exploded")
+
+    with patch.object(cfg_mod, "get_config", side_effect=_boom), \
+         patch.object(m.Session, "save", return_value=None):
+        s = m.new_session(workspace="/tmp/test-personality-boom")
+
+    assert s.personality is None
+
+
+# ---------------------------------------------------------------------------
+# R5: display.personality is case-insensitive
+# ---------------------------------------------------------------------------
+
+def test_new_session_personality_is_case_insensitive():
+    """display.personality='Taleb' should be normalized to 'taleb'."""
+
+    import api.models as m
+    import api.config as cfg_mod
+
+    _cfg = {
+        "display": {"personality": "Taleb"},
+        "agent": {"personalities": {"taleb": {"system_prompt": "Be like Taleb"}}},
+    }
+
+    with patch.object(cfg_mod, "get_config", return_value=_cfg), \
+         patch.object(m.Session, "save", return_value=None):
+        s = m.new_session(workspace="/tmp/test-personality-case")
+
+    assert s.personality == "taleb"


### PR DESCRIPTION
## Problem

When `display.personality` is set in `config.yaml` (e.g. `personality: taleb`), new WebUI sessions start with `personality=None` instead of inheriting the configured default. Users must manually run `/personality taleb` in every new conversation to activate their preferred personality.

## What changed

**`api/models.py`** — `new_session()` now reads `display.personality` from config and passes it as the default `personality` kwarg to `Session()`:

```python
# Read default personality from config display.personality
_default_personality = None
try:
    from api.config import get_config as _get_cfg_for_personality
    _cfg_personality = (_get_cfg_for_personality().get("display") or {}).get("personality")
    if _cfg_personality and isinstance(_cfg_personality, str):
        _cfg_personality = _cfg_personality.strip().lower()
        if _cfg_personality and _cfg_personality not in ("default", "none", "neutral"):
            _default_personality = _cfg_personality
except Exception:
    pass
```

**`tests/test_default_personality.py`** — 8 new tests covering:
- R1: `display.personality: taleb` → session gets `personality="taleb"`
- R2: Values `"none"`, `"default"`, `"neutral"`, `""` → `None` (no overlay)
- R3: Missing `display` section → `None`
- R4: Config read exception → graceful fallback to `None`
- R5: Case normalization: `"Taleb"` → `"taleb"`

## Why this is safe

- Config read is wrapped in `try/except` — any failure falls back to `None` (no personality), which is the current behavior. Zero regression risk.
- The `("default", "none", "neutral")` exclusion set matches the same semantics used in the TUI gateway personality handler (`tui_gateway/server.py` line 1402).
- Case normalization (`.strip().lower()`) matches how personality names are resolved elsewhere in the codebase.
- Existing `/personality` slash command still works for per-session overrides — this only sets the initial default.

## Test results

```
tests/test_default_personality.py::8 passed in 2.45s
tests/test_issue798.py::13 passed
tests/test_streaming_session_sidebar.py::7 passed
tests/test_sprint42.py::30 passed
```

## Contracts touched

- `new_session()` signature: unchanged (new param `personality=_default_personality` fills the previously-defaulted `None`)
- Session state layer: `personality` field already exists and is saved/loaded; this just populates it at creation time