### PR TITLE
Fix compaction markers leaking into display transcript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Keep internal context-compaction reference rows out of the visible WebUI transcript and final SSE `done.session.messages` payload while preserving them in model-facing context for recovery. Legacy polluted sidecars are sanitized on full load so marker cards do not replace or move newly streamed replies after compaction.
+
 
 ## [v0.51.107] — 2026-05-21 — Release CE (stage-400 — 8-PR batch — pinned-sessions-limit getter rename + uploaded-file user-turn dedupe + active-run repair guard + incremental KaTeX streaming + profile default model on fresh boot + French locale completion + update-check error surfacing + release-update apply path)
 

--- a/api/display_sanitization.py
+++ b/api/display_sanitization.py
@@ -1,0 +1,52 @@
+"""Helpers for keeping internal context material out of WebUI display history."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+import copy
+
+
+def message_text(content) -> str:
+    """Return readable text from string or provider-style content parts."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for part in content:
+            if isinstance(part, str):
+                parts.append(part)
+            elif isinstance(part, dict):
+                text = part.get("text") or part.get("content")
+                if text is not None:
+                    parts.append(str(text))
+        return "\n".join(parts)
+    return str(content or "")
+
+
+def is_context_compression_marker(message) -> bool:
+    """Return true for internal context-compression handoff/reference rows."""
+    if not isinstance(message, dict):
+        return False
+    text = message_text(message.get("content", "")).lower()
+    return (
+        "context compaction" in text
+        or "context compression" in text
+        or "context was auto-compressed" in text
+        or "active task list was preserved across context compression" in text
+    )
+
+
+def sanitize_display_messages(messages: Iterable | None) -> list:
+    """Return a display transcript with internal compaction markers removed.
+
+    Context-compression handoff rows are model-facing recovery material. They may
+    exist in context_messages or provider results, but must not become normal
+    WebUI transcript rows or SSE done.session.messages entries.
+    """
+    if not messages:
+        return []
+    return [
+        copy.deepcopy(message)
+        for message in messages
+        if isinstance(message, dict) and not is_context_compression_marker(message)
+    ]

--- a/api/models.py
+++ b/api/models.py
@@ -21,6 +21,7 @@ from api.config import (
 )
 from api.workspace import get_last_workspace
 from api.usage import prompt_cache_hit_percent
+from api.display_sanitization import sanitize_display_messages
 from api.agent_sessions import (
     _is_continuation_session,
     read_importable_agent_session_rows,
@@ -419,7 +420,9 @@ class Session:
         self.workspace = str(Path(workspace).expanduser().resolve())
         self.model = model
         self.model_provider = str(model_provider).strip().lower() if model_provider else None
-        self.messages = messages or []
+        raw_messages = messages or []
+        display_messages = sanitize_display_messages(raw_messages)
+        self.messages = display_messages
         self.tool_calls = tool_calls or []
         self.created_at = created_at or time.time()
         self.updated_at = updated_at or time.time()
@@ -437,7 +440,16 @@ class Session:
         self.pending_user_message = pending_user_message
         self.pending_attachments = pending_attachments or []
         self.pending_started_at = pending_started_at
-        self.context_messages = context_messages if isinstance(context_messages, list) else []
+        raw_context_messages = context_messages if isinstance(context_messages, list) else []
+        if raw_context_messages:
+            self.context_messages = raw_context_messages
+        elif len(display_messages) < len(raw_messages):
+            # Legacy/polluted sidecars may only have the internal compaction
+            # reference in messages. Keep that recovery material model-facing
+            # while removing it from the visible transcript.
+            self.context_messages = copy.deepcopy(raw_messages)
+        else:
+            self.context_messages = []
         self.compression_anchor_visible_idx = compression_anchor_visible_idx
         self.compression_anchor_message_key = compression_anchor_message_key
         self.compression_anchor_summary = compression_anchor_summary
@@ -499,6 +511,10 @@ class Session:
             )
         if touch_updated_at:
             self.updated_at = time.time()
+        raw_messages = list(self.messages or [])
+        self.messages = sanitize_display_messages(raw_messages)
+        if len(self.messages) < len(raw_messages) and not self.context_messages:
+            self.context_messages = copy.deepcopy(raw_messages)
         # Write metadata fields first so load_metadata_only() can read them
         # without parsing the full messages array (which may be 400KB+).
         # Fields are listed in the order they should appear in the JSON file.
@@ -604,15 +620,17 @@ class Session:
             return None
         data = json.loads(p.read_text(encoding='utf-8'))
         data['messages'], _collapsed_partials = _collapse_adjacent_duplicate_partials(data.get('messages'))
+        _raw_message_count = len(data.get('messages') or [])
         session = cls(**data)
-        if _collapsed_partials:
+        _display_markers_removed = len(session.messages or []) < _raw_message_count
+        if _collapsed_partials or _display_markers_removed:
             try:
-                # Self-heal bloated sessions on first full load without touching
-                # recency/index ordering; save() creates a .bak because this
-                # intentionally shrinks the transcript (#2592).
+                # Self-heal bloated or marker-polluted sessions on first full load
+                # without touching recency/index ordering; save() creates a .bak
+                # because this intentionally shrinks the display transcript.
                 session.save(touch_updated_at=False, skip_index=True)
             except Exception:
-                logger.debug("Failed to persist collapsed duplicate partials for %s", sid, exc_info=True)
+                logger.debug("Failed to persist sanitized display messages for %s", sid, exc_info=True)
         return session
 
     @classmethod

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -36,6 +36,7 @@ from api.config import (
 )
 from api.helpers import redact_session_data, _redact_text
 from api.compression_anchor import visible_messages_for_anchor
+from api.display_sanitization import is_context_compression_marker, sanitize_display_messages
 from api.metering import meter
 from api.run_journal import RunJournalWriter
 from api.turn_journal import append_turn_journal_event_for_stream
@@ -2299,15 +2300,7 @@ def _dedupe_replayed_active_context(previous_context, result_messages):
 
 
 def _is_context_compression_marker(msg):
-    if not isinstance(msg, dict):
-        return False
-    text = _message_text(msg.get('content', '')).lower()
-    return (
-        'context compaction' in text
-        or 'context compression' in text
-        or 'context was auto-compressed' in text
-        or 'active task list was preserved across context compression' in text
-    )
+    return is_context_compression_marker(msg)
 
 
 def _compact_summary_text(raw_text: str | None, limit: int = 320) -> str | None:
@@ -2532,9 +2525,10 @@ def _merge_display_messages_after_agent_result(previous_display, previous_contex
     If Hermes Agent returns a normal append-only history, append that delta to
     the UI transcript. If the model/context history was compacted and no longer
     has the prior context as a prefix, keep the previous UI transcript and append
-    only compaction marker messages plus the current user turn onward.
+    only the current visible turn onward. Context-compression markers remain
+    model-facing recovery material and are never persisted into display history.
     """
-    previous_display = list(previous_display or [])
+    previous_display = list(sanitize_display_messages(previous_display))
     # Deduplicate stale _partial messages that accumulated in previous_display.
     # A bug in cancel_stream() could insert multiple identical _partial messages
     # when _stripped was empty but _has_reasoning/_has_tools was True. The
@@ -2570,12 +2564,10 @@ def _merge_display_messages_after_agent_result(previous_display, previous_contex
         candidates = _strip_replayed_prefix(previous_context, candidates)
     else:
         current_user_idx = _find_current_user_turn(result_messages, msg_text)
-        marker_candidates = [
-            m for m in result_messages[:current_user_idx if current_user_idx is not None else len(result_messages)]
-            if _is_context_compression_marker(m)
-        ]
         turn_candidates = result_messages[current_user_idx:] if current_user_idx is not None else []
-        candidates = marker_candidates + turn_candidates
+        candidates = turn_candidates
+
+    candidates = sanitize_display_messages(candidates)
 
     merged = previous_display[:]
     seen = {_message_identity(m) for m in merged}
@@ -5245,7 +5237,7 @@ def _run_agent_streaming(
                         })
             except Exception as _goal_exc:
                 logger.debug("Goal continuation hook failed for session %s: %s", session_id, _goal_exc)
-            raw_session = s.compact() | {'messages': s.messages, 'tool_calls': tool_calls}
+            raw_session = s.compact() | {'messages': sanitize_display_messages(s.messages), 'tool_calls': tool_calls}
             put('done', {'session': redact_session_data(raw_session), 'usage': usage})
             # Emit one last metering packet for the live message-header TPS label.
             meter_stats = meter().get_stats()

--- a/tests/test_issue1217_transcript_compaction.py
+++ b/tests/test_issue1217_transcript_compaction.py
@@ -1,5 +1,8 @@
 from api.models import Session, reconciled_state_db_messages_for_session
+from api.display_sanitization import sanitize_display_messages
 import contextlib
+import json
+from pathlib import Path
 from types import SimpleNamespace
 
 from api.streaming import (
@@ -52,6 +55,68 @@ def test_session_persists_model_context_separately_from_display_transcript(tmp_p
     assert _sanitize_messages_for_api(_session_context_messages(reloaded)) == compacted_context
 
 
+def test_legacy_compaction_marker_sidecar_loads_context_but_sanitizes_display(tmp_path, monkeypatch):
+    """Polluted sidecar messages are repaired on full load without losing model context."""
+    state_dir = tmp_path / "state"
+    session_dir = state_dir / "sessions"
+    session_dir.mkdir(parents=True)
+
+    import api.models as models
+
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", state_dir / "session_index.json")
+
+    payload = {
+        "session_id": "legacy1217polluted",
+        "title": "Polluted compaction marker",
+        "workspace": str(tmp_path),
+        "model": "test-model",
+        "created_at": 1.0,
+        "updated_at": 2.0,
+        "messages": [
+            {"role": "user", "content": "visible prompt"},
+            {"role": "assistant", "content": "visible answer"},
+            {"role": "assistant", "content": "[CONTEXT COMPACTION — REFERENCE ONLY] summary"},
+            {"role": "user", "content": "latest prompt"},
+        ],
+    }
+    (session_dir / "legacy1217polluted.json").write_text(
+        json.dumps(payload, ensure_ascii=False),
+        encoding="utf-8",
+    )
+
+    reloaded = Session.load("legacy1217polluted")
+    assert reloaded is not None
+
+    assert [m["content"] for m in reloaded.messages] == [
+        "visible prompt",
+        "visible answer",
+        "latest prompt",
+    ]
+    assert [m["content"] for m in reloaded.context_messages] == [
+        "visible prompt",
+        "visible answer",
+        "[CONTEXT COMPACTION — REFERENCE ONLY] summary",
+        "latest prompt",
+    ]
+
+
+def test_done_payload_messages_are_sanitized_before_client_assignment():
+    raw_messages = [
+        {"role": "user", "content": "visible prompt"},
+        {"role": "assistant", "content": "[CONTEXT COMPACTION — REFERENCE ONLY] summary"},
+        {"role": "assistant", "content": "visible answer"},
+    ]
+
+    assert sanitize_display_messages(raw_messages) == [
+        {"role": "user", "content": "visible prompt"},
+        {"role": "assistant", "content": "visible answer"},
+    ]
+
+    src = Path("api/streaming.py").read_text(encoding="utf-8")
+    assert "'messages': sanitize_display_messages(s.messages)" in src
+
+
 def test_workspace_prefixed_current_user_after_compaction_is_not_duplicated():
     previous_display = [
         {"role": "user", "content": "older prompt"},
@@ -74,7 +139,7 @@ def test_workspace_prefixed_current_user_after_compaction_is_not_duplicated():
         "Ok, mache weiter",
     )
 
-    assert [m["role"] for m in merged] == ["user", "assistant", "assistant", "user", "assistant"]
+    assert [m["role"] for m in merged] == ["user", "assistant", "user", "assistant"]
     assert [m["content"] for m in merged[-2:]] == [
         "Ok, mache weiter",
         "continuing",
@@ -201,10 +266,10 @@ def test_compacted_agent_result_keeps_old_prompts_and_appends_current_turn():
         "first answer",
         "second prompt that must remain visible",
         "second answer",
-        "[CONTEXT COMPACTION — REFERENCE ONLY] Earlier turns were compacted.",
         "new question after compaction",
         "new answer after compaction",
     ]
+    assert all("CONTEXT COMPACTION" not in m["content"] for m in merged)
 
 
 def test_append_only_agent_result_preserves_normal_delta_behavior():
@@ -304,10 +369,10 @@ def test_repeated_user_text_after_compaction_is_not_dropped():
     assert [m["content"] for m in merged] == [
         "continue",
         "old answer",
-        "[CONTEXT COMPACTION — REFERENCE ONLY] summary",
         "continue",
         "new answer",
     ]
+    assert all("CONTEXT COMPACTION" not in m["content"] for m in merged)
 
 
 def test_session_context_falls_back_to_display_messages_for_legacy_sessions(tmp_path):


### PR DESCRIPTION
## Thinking Path

The bug path is a state-layer mismatch: context-compression handoff rows are valid model-facing recovery material, but they were leaking into the display transcript. When the stream finished, the frontend accepted `done.session.messages` as authoritative, so leaked `[CONTEXT COMPACTION ... REFERENCE ONLY]` rows could replace, move, or wrap the just-streamed answer.

State layer changed: visible transcript and SSE `done.session.messages`. Model-facing `context_messages` still preserves compaction handoff rows for recovery.

## What Changed

- Added a shared backend display sanitizer for context-compression marker rows.
- Updated streaming display merge so compacted agent results append the current visible turn without inserting compaction markers.
- Sanitized final SSE `done.session.messages` before the browser assigns it to client state.
- Sanitized `Session.messages` on load/save, while preserving legacy marker-polluted sidecars in `context_messages` when needed.
- Updated issue 1217 regression tests and added coverage for legacy sidecar repair and final done-payload sanitation.
- Added a changelog entry.

## Why It Matters

This preserves the invariant from the run-state contract: automatic compression summaries are recovery material, not current visible conversation content. It should stop the post-compaction symptom where a streamed answer appears normally, then vanishes or is replaced by a "Context Compaction, reference only" card after the final rerender.

## Verification

- `/usr/local/lib/hermes-agent/venv/bin/python -m pytest tests/test_issue1217_transcript_compaction.py tests/test_session_save_mode.py tests/test_partial_bloat_fix.py tests/test_session_lost_response_regression.py -q`
  - `58 passed in 2.00s`
- `/usr/local/lib/hermes-agent/venv/bin/python -m compileall -q api/display_sanitization.py api/models.py api/streaming.py`
- Direct repro against `_merge_display_messages_after_agent_result` now returns `contains_marker=False` and the sequence `older prompt`, `older answer`, `latest prompt`, `latest answer`.

## Risks / Follow-ups

- This intentionally repairs marker-polluted display sidecars on full load and writes a backup when the display transcript shrinks.
- Existing frontend compression-card anchoring may still need hardening, but this PR removes the backend marker leak that makes the final rerender authoritative and polluted.
- Full suite was not run locally.

## Model Used

OpenAI Codex provider, gpt-5.5. Tool-assisted repository inspection, patching, and test execution.
