### PR TITLE
fix: add do_OPTIONS handler for CORS preflight requests

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -110,19 +110,30 @@ def _write_session_index(updates=None):
         # Lazy full-rebuild path — used when index doesn't exist yet.
         if updates is None or not SESSION_INDEX_FILE.exists():
             _cleanup_stale_tmp_files()  # best-effort sweep on startup / first call
-            entries = []
+            entry_map: dict[str, dict] = {}
             for p in SESSION_DIR.glob('*.json'):
                 if p.name.startswith('_'):
                     continue
                 try:
-                    s = Session.load(p.stem)
+                    s = Session.load(p.stem, skip_auto_save=True)
                     if s:
-                        entries.append(s.compact())
+                        c = s.compact()
+                        sid = c.get('session_id')
+                        if sid:
+                            # Dedup by session_id: prefer entry with more messages
+                            # (handles old-format session_xxx.json files alongside
+                            #  WebUI-format xxx.json with the same session_id)
+                            existing = entry_map.get(sid)
+                            if existing is None or (
+                                c.get('message_count', 0) > existing.get('message_count', 0)
+                            ):
+                                entry_map[sid] = c
                 except Exception:
                     logger.debug("Failed to load session from %s", p)
+            entries = list(entry_map.values())
 
             with LOCK:
-                existing_ids = {e.get('session_id') for e in entries}
+                existing_ids = set(entry_map.keys())
                 for s in SESSIONS.values():
                     if s.session_id not in existing_ids:
                         entries.append(s.compact())
@@ -595,7 +606,7 @@ class Session:
             _write_session_index(updates=[self])
 
     @classmethod
-    def load(cls, sid):
+    def load(cls, sid, skip_auto_save=False):
         # Validate session ID format to prevent path traversal
         if not sid or not all(c in '0123456789abcdefghijklmnopqrstuvwxyz_' for c in sid):
             return None
@@ -604,8 +615,16 @@ class Session:
             return None
         data = json.loads(p.read_text(encoding='utf-8'))
         data['messages'], _collapsed_partials = _collapse_adjacent_duplicate_partials(data.get('messages'))
+        # Permanently strip orphaned _partial markers — they are redundant
+        # streaming artifacts. The final complete message (non-partial)
+        # already carries all content. Accumulated partials bloat the session
+        # and cause the WebUI to show empty assistant bubbles when
+        # msg_limit clips to the tail of the array.
+        _orig_msg_count = len(data.get('messages') or [])
+        data['messages'] = [m for m in (data.get('messages') or []) if not m.get('_partial')]
+        _stripped_partials = _orig_msg_count - len(data['messages'])
         session = cls(**data)
-        if _collapsed_partials:
+        if (_collapsed_partials or _stripped_partials > 0) and not skip_auto_save:
             try:
                 # Self-heal bloated sessions on first full load without touching
                 # recency/index ordering; save() creates a .bak because this

--- a/server.py
+++ b/server.py
@@ -220,6 +220,9 @@ class Handler(BaseHTTPRequestHandler):
         return cls._CSP_REPORT_ONLY
 
     def end_headers(self) -> None:
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.send_header("Access-Control-Allow-Methods", "GET, POST, PATCH, DELETE, OPTIONS")
+        self.send_header("Access-Control-Allow-Headers", "Content-Type, Authorization")
         self.send_header("Content-Security-Policy-Report-Only", self.csp_report_only_policy())
         self.send_header("Report-To", self._CSP_REPORT_TO)
         super().end_headers()
@@ -288,6 +291,12 @@ class Handler(BaseHTTPRequestHandler):
 
     def do_PATCH(self) -> None:
         self._handle_write(handle_patch)
+
+    def do_OPTIONS(self) -> None:
+        """Handle CORS preflight requests — return 200 with CORS headers."""
+        self._req_t0 = time.time()
+        self.send_response(200)
+        self.end_headers()
 
     def do_DELETE(self) -> None:
         self._handle_write(handle_delete)
@@ -434,7 +443,14 @@ def main() -> None:
     print('', flush=True)
     try:
         httpd.serve_forever()
+    except KeyboardInterrupt:
+        print('[webui] Shutdown: KeyboardInterrupt (Ctrl+C)', flush=True)
+        raise
+    except Exception:
+        print(f'[webui] Shutdown: unhandled exception in serve_forever\n{traceback.format_exc()}', flush=True)
+        raise
     finally:
+        print('[webui] Shutdown: serve_forever returned — process exiting', flush=True)
         # Stop the gateway watcher on shutdown
         try:
             from api.gateway_watcher import stop_watcher


### PR DESCRIPTION
Closing this PR — it bundled too many unrelated changes (broad CORS on all responses, session index dedup). Splitting into a minimal PR with only the do_OPTIONS() handler.