### PR TITLE
Release CG: v0.51.109 (stage-402 — 2-PR batch — sidebar action menu click stability + chat panel sidebar resync after navigation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,12 @@
 
 ## [Unreleased]
 
+## [v0.51.109] — 2026-05-22 — Release CG (stage-402 — 2-PR batch — sidebar action menu click stability + chat panel sidebar resync after navigation)
+
 ### Fixed
 
-- Keep the sidebar conversation actions menu open while session-list refreshes, stream updates, or panel-resync repairs arrive, so the three-dot menu beside chat titles remains usable while the user is interacting with it.
+- **PR #2741** by @ai-ag2026 — Keep the sidebar conversation actions menu open while session-list refreshes, stream updates, or panel-resync repairs arrive. Previously the three-dot menu beside chat titles could be torn down before the user finished clicking it because `renderSessionListFromCache()` rebuilt the row DOM (and the fixed-position menu's anchor) without checking whether the menu was open. The new early-return at the top of the refresh keeps the menu stable; destructive menu actions explicitly close the menu before they fire, so dismissal still works as expected.
+- **PR #2736** by @ai-ag2026 — Resync the chat sidebar after returning from Settings/Logs/other panels. The session list is virtualized, and the browser can clamp the preserved scrollTop during a panel transition; without a render after the chat view is visible again, stale virtual spacer/header DOM remained until the next manual scroll. The new `_resyncChatSidebarAfterPanelSwitch()` helper runs one guarded `requestAnimationFrame` after the panel becomes visible, bails if a rename input or action menu is open, and uses no polling.
 
 ## [v0.51.108] — 2026-05-22 — Release CF (stage-401 — 4-PR batch — session-index dedup + update-check diagnostic redaction + handoff-summary sqlite connection leak fix + Slice 4d runner route gate docs)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Keep the sidebar conversation actions menu open while session-list refreshes, stream updates, or panel-resync repairs arrive, so the three-dot menu beside chat titles remains usable while the user is interacting with it.
 
 ## [v0.51.107] — 2026-05-21 — Release CE (stage-400 — 8-PR batch — pinned-sessions-limit getter rename + uploaded-file user-turn dedupe + active-run repair guard + incremental KaTeX streaming + profile default model on fresh boot + French locale completion + update-check error surfacing + release-update apply path)
 
@@ -16,6 +19,7 @@
 - **PR #2722** by @victorwhale — Complete French (`fr`) locale coverage: +93 missing translation keys covering Settings, profile-ops, gateway tile, skills modal, session controls, and i18n test surfaces. Coverage 88.8% → 96.7%.
 - **PR #2717** by @ai-ag2026 — Surface update-check fetch errors in the UI instead of failing silently. The background `api/updates/check` request previously swallowed network failures, so an offline / blocked-CDN scenario showed no indication that the version banner couldn't render. Now the failure is logged and exposed to the System panel's update-status card.
 - **PR #2719** by @ai-ag2026 — Apply release-update target correctly when the user clicks "Check for updates" after a prior dismissal: clears the `sessionStorage` check-once stamp and forces banner re-evaluation. The prior path silently no-op'd because the once-per-tab guard fired before the explicit user click could re-trigger the fetch.
+
 
 ## [v0.51.106] — 2026-05-21 — Release CD (stage-399 — 3-PR batch — restamped state.db replay dedupe + context_messages dedupe so agent doesn't see duplicates + empty _partial bloat fix)
 

--- a/static/panels.js
+++ b/static/panels.js
@@ -182,6 +182,18 @@ function _consumeSettingsTargetPanel(fallback = 'chat') {
   return target;
 }
 
+function _resyncChatSidebarAfterPanelSwitch() {
+  if (_currentPanel !== 'chat') return;
+  if (typeof renderSessionListFromCache !== 'function') return;
+  const run = () => {
+    if (_currentPanel !== 'chat') return;
+    if (typeof _renamingSid !== 'undefined' && _renamingSid) return;
+    renderSessionListFromCache();
+  };
+  if (typeof requestAnimationFrame === 'function') requestAnimationFrame(run);
+  else run();
+}
+
 async function switchPanel(name, opts = {}) {
   const nextPanel = name || 'chat';
   const prevPanel = _currentPanel;
@@ -251,6 +263,7 @@ async function switchPanel(name, opts = {}) {
     if (sidebar) sidebar.classList.add('mobile-open');
     if (overlay) overlay.classList.add('visible');
   }
+  _resyncChatSidebarAfterPanelSwitch();
   syncAppTitlebar();
   return true;
 }

--- a/static/panels.js
+++ b/static/panels.js
@@ -188,6 +188,12 @@ function _resyncChatSidebarAfterPanelSwitch() {
   const run = () => {
     if (_currentPanel !== 'chat') return;
     if (typeof _renamingSid !== 'undefined' && _renamingSid) return;
+    // If the user opens the per-conversation action menu immediately after
+    // returning to Chat, do not let the deferred sidebar resync tear it down.
+    // renderSessionListFromCache() intentionally closes that menu before it
+    // rebuilds rows, which is correct for normal list refreshes but hostile to
+    // this one-shot panel-transition repair.
+    if (typeof _sessionActionMenu !== 'undefined' && _sessionActionMenu) return;
     renderSessionListFromCache();
   };
   if (typeof requestAnimationFrame === 'function') requestAnimationFrame(run);

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -2970,6 +2970,11 @@ function _resyncSessionVirtualWindowAfterRender(list, expectedScrollTop, virtual
 function renderSessionListFromCache(){
   // Don't re-render while user is actively renaming a session (would destroy the input)
   if(_renamingSid) return;
+  // Keep the per-conversation actions menu stable while the user is trying to
+  // click it. Sidebar syncs, stream/unread updates, and panel-resync repairs can
+  // all call this while the fixed-position menu is open; rebuilding the row DOM
+  // here removes the anchor and makes the menu feel unclickable.
+  if(_sessionActionMenu) return;
   closeSessionActionMenu();
   // Purge stale INFLIGHT entries for sessions the server confirms are NOT
   // streaming. This runs on every list refresh to prevent memory leaks from

--- a/tests/test_chat_panel_sidebar_resync.py
+++ b/tests/test_chat_panel_sidebar_resync.py
@@ -1,0 +1,71 @@
+"""Regression coverage for chat sidebar virtualization after panel navigation."""
+from pathlib import Path
+
+PANELS_JS = Path(__file__).parent.parent / "static" / "panels.js"
+
+
+def _read_source() -> str:
+    return PANELS_JS.read_text(encoding="utf-8")
+
+
+def _function_block(src: str, name: str) -> str:
+    marker = f"function {name}"
+    start = src.find(marker)
+    if start == -1:
+        marker = f"async function {name}"
+        start = src.find(marker)
+    assert start != -1, f"{name} not found"
+    paren = src.find("(", start)
+    assert paren != -1, f"{name} signature not found"
+    paren_depth = 1
+    j = paren + 1
+    while j < len(src) and paren_depth:
+        if src[j] == "(":
+            paren_depth += 1
+        elif src[j] == ")":
+            paren_depth -= 1
+        j += 1
+    assert paren_depth == 0, f"{name} signature did not close"
+    brace = src.find("{", j)
+    assert brace != -1, f"{name} body not found"
+    depth = 1
+    i = brace + 1
+    while i < len(src) and depth:
+        if src[i] == "{":
+            depth += 1
+        elif src[i] == "}":
+            depth -= 1
+        i += 1
+    assert depth == 0, f"{name} body did not close"
+    return src[start:i]
+
+
+def test_switching_back_to_chat_schedules_sidebar_resync_after_panel_is_visible():
+    """Chat navigation must re-render the sidebar after layout becomes visible.
+
+    The sidebar session list is virtualized. After switching away to Settings,
+    Logs, etc. and then back to Chat, the browser can clamp the preserved
+    scrollTop during the layout transition. If no render runs after the chat
+    view is visible again, stale virtual spacer/header DOM can remain until the
+    next manual scroll event.
+    """
+    src = _read_source()
+    switch_body = _function_block(src, "switchPanel")
+
+    assert "_resyncChatSidebarAfterPanelSwitch();" in switch_body
+    assert switch_body.index("if (panelEl) panelEl.classList.add('active');") < switch_body.index(
+        "_resyncChatSidebarAfterPanelSwitch();"
+    )
+
+
+def test_chat_sidebar_resync_helper_is_guarded_and_bounded_to_one_animation_frame():
+    """The resync must not poll or destroy rename state; one guarded rAF is enough."""
+    src = _read_source()
+    helper = _function_block(src, "_resyncChatSidebarAfterPanelSwitch")
+
+    assert "if (_currentPanel !== 'chat') return;" in helper
+    assert "typeof renderSessionListFromCache !== 'function'" in helper
+    assert "requestAnimationFrame" in helper
+    assert "setInterval" not in helper
+    assert "setTimeout" not in helper
+    assert "renderSessionListFromCache();" in helper

--- a/tests/test_chat_panel_sidebar_resync.py
+++ b/tests/test_chat_panel_sidebar_resync.py
@@ -68,4 +68,6 @@ def test_chat_sidebar_resync_helper_is_guarded_and_bounded_to_one_animation_fram
     assert "requestAnimationFrame" in helper
     assert "setInterval" not in helper
     assert "setTimeout" not in helper
+    assert "typeof _sessionActionMenu !== 'undefined' && _sessionActionMenu" in helper
+    assert helper.index("typeof _sessionActionMenu") < helper.index("renderSessionListFromCache();")
     assert "renderSessionListFromCache();" in helper

--- a/tests/test_configurable_pinned_sessions_limit.py
+++ b/tests/test_configurable_pinned_sessions_limit.py
@@ -53,6 +53,7 @@ def test_pin_limit_setting_is_exposed_and_wired_through_ui():
     assert "settings.pinned_sessions_limit" in PANELS_JS
     assert "window._pinnedSessionsLimit=parseInt(s.pinned_sessions_limit||3,10)||3" in BOOT_JS
     assert "function _getPinnedSessionsLimit()" in SESSIONS_JS
+    assert "function _pinnedSessionsLimit()" not in SESSIONS_JS
     assert "_pinnedSessionCount()>=_getPinnedSessionsLimit()" in SESSIONS_JS
 
 

--- a/tests/test_issue2508_session_pin_cap.py
+++ b/tests/test_issue2508_session_pin_cap.py
@@ -76,6 +76,7 @@ def test_session_pin_cap_has_backend_and_frontend_guards():
 
     assert 'function _pinnedSessionCount()' in SESSIONS_JS
     assert 'function _getPinnedSessionsLimit()' in SESSIONS_JS
+    assert 'function _pinnedSessionsLimit()' not in SESSIONS_JS
     assert 'const pinLimitReached=!session.pinned&&_pinnedSessionCount()>=_getPinnedSessionsLimit();' in SESSIONS_JS
     assert 'Only ${limit} conversations can be pinned' in SESSIONS_JS
     assert ".session-action-opt.is-disabled{opacity:.55;cursor:not-allowed;}" in STYLE_CSS

--- a/tests/test_session_action_menu_regression.py
+++ b/tests/test_session_action_menu_regression.py
@@ -1,0 +1,31 @@
+"""Regression checks for per-conversation action menu click stability."""
+from pathlib import Path
+
+SESSIONS_JS = (Path(__file__).resolve().parent.parent / "static" / "sessions.js").read_text(encoding="utf-8")
+
+
+def _function_block(src: str, name: str) -> str:
+    marker = f"function {name}"
+    start = src.find(marker)
+    assert start != -1, f"{name} not found"
+    brace = src.find("{", start)
+    assert brace != -1, f"{name} body not found"
+    depth = 1
+    i = brace + 1
+    while i < len(src) and depth:
+        if src[i] == "{":
+            depth += 1
+        elif src[i] == "}":
+            depth -= 1
+        i += 1
+    assert depth == 0, f"{name} body did not close"
+    return src[start:i]
+
+
+def test_session_list_refresh_does_not_close_open_conversation_actions():
+    """Sidebar refreshes must not eat the three-dot menu before users can click it."""
+    body = _function_block(SESSIONS_JS, "renderSessionListFromCache")
+
+    assert "if(_renamingSid) return;" in body
+    assert "if(_sessionActionMenu) return;" in body
+    assert body.index("if(_sessionActionMenu) return;") < body.index("closeSessionActionMenu();")


### PR DESCRIPTION
## v0.51.109 — Release CG (stage-402 / 2-PR batch)

Two surgical sidebar UI fixes from @ai-ag2026. Both have static-shape regression tests pinning the exact JS shape (function names, ordering of guards, rAF vs setTimeout). Pre-Opus 9-point gate clean, full pytest green (6210 passed, 7 skipped, 3 xpassed; +3 from stage-401 matching the 3 new tests), browser API sanity green, Opus Advisor GO with no blockers.

## PRs in this batch

- **#2741** by @ai-ag2026 — Keep conversation actions menu clickable. Adds `if(_sessionActionMenu) return;` at the top of `renderSessionListFromCache()` so list refreshes / stream updates / panel-resync repairs don't tear down the three-dot menu before the user can click it. Verified by Opus that every destructive menu handler explicitly calls `closeSessionActionMenu()` before acting, so dismissal still works. +42/-0, 5 files (1 behavioral + 1 new regression test + 2 existing-test assertion additions + CHANGELOG).
- **#2736** by @ai-ag2026 — Resync sidebar after panel switches. New `_resyncChatSidebarAfterPanelSwitch()` in `panels.js` runs one guarded `requestAnimationFrame` after the panel becomes visible to fix stale virtualized spacer/header DOM after returning from Settings/Logs. Bails if not on chat panel, if rename input is open, or if action menu is open. No polling, no `setTimeout`/`setInterval`. +92/-0, 2 files.

## Verification

- **Pre-Opus 9-point gate**: JS syntax ✓, Python AST ✓, no merge markers ✓, no CHANGELOG placeholders ✓, no sensitive paths ✓, no new concurrent primitives ✓, no CJK ✓, no Docker surface ✓, no string-assertion stage traps ✓
- **pytest full suite**: 6210 passed, 7 skipped, 3 xpassed, 8 subtests passed (157s) — matches stage-401 baseline + 3 new tests
- **Opus Advisor**: GO, no blockers. Verified specifically:
  - Cross-PR `_sessionActionMenu` interaction is defense-in-depth, comment in #2736 already documents the relationship
  - PR #2741 early-return is safe — destructive menu handlers explicitly close menu before acting (`sessions.js:1819-1908`), outside-click/Escape/scroll dismiss menu independently
  - Single `requestAnimationFrame` is correct (panel reveal is synchronous via `classList.add('active')` before helper runs); double-rAF only needed for transition paint, not the case here
  - Tests catch rAF→queueMicrotask, rAF→setTimeout/setInterval, function rename, guard removal
- **Browser API sanity** on port 8789: all 11 endpoints PASS

## Risk surface

- Both PRs target disjoint files in the static/ tree (one edits `sessions.js`, one adds a helper to `panels.js`)
- Both PRs INDEPENDENTLY guard against `_sessionActionMenu` being open — the redundancy reinforces, doesn't conflict
- No backend change, no API change, no streaming hot path, no concurrency primitives
- Rollback: standard `git revert` per PR (the two merge commits are independent)
