### PR TITLE
fix(updates): pass --force to git fetch --tags to recover from remote re-tags (#2756)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **PR TBD** — fix(updates): pass `--force` to `git fetch --tags` in `api/updates.py` so the WebUI's release-tracking update check can recover from a remote re-tag (e.g. a release tag that was force-pushed to a new commit after a squash-merge). Without `--force`, plain `git fetch origin --tags` returns `! [rejected] vX.Y.Z (would clobber existing tag)` and the entire update path (check, force-apply, normal-apply) jams indefinitely — neither the periodic check nor manual "Check now" nor the Update button can recover. Three fetch call sites were patched (`_check_repo`, `apply_force_update`, `apply_update`) to use `--tags --force`; the WebUI never pushes tags, so deferring to the remote's view is the right contract. Closes #2756.
+
 ## [v0.51.110] — 2026-05-22 — Release CH (stage-403 — 2-PR batch — default personality from config + sort configured providers to top)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Fixed
 
-- **PR TBD** — fix(updates): pass `--force` to `git fetch --tags` in `api/updates.py` so the WebUI's release-tracking update check can recover from a remote re-tag (e.g. a release tag that was force-pushed to a new commit after a squash-merge). Without `--force`, plain `git fetch origin --tags` returns `! [rejected] vX.Y.Z (would clobber existing tag)` and the entire update path (check, force-apply, normal-apply) jams indefinitely — neither the periodic check nor manual "Check now" nor the Update button can recover. Three fetch call sites were patched (`_check_repo`, `apply_force_update`, `apply_update`) to use `--tags --force`; the WebUI never pushes tags, so deferring to the remote's view is the right contract. Closes #2756.
+- **PR #2758** — fix(updates): pass `--force` to `git fetch --tags` in `api/updates.py` so the WebUI's release-tracking update check can recover from a remote re-tag (e.g. a release tag that was force-pushed to a new commit after a squash-merge). Without `--force`, plain `git fetch origin --tags` returns `! [rejected] vX.Y.Z (would clobber existing tag)` and the entire update path (check, force-apply, normal-apply) jams indefinitely — neither the periodic check nor manual "Check now" nor the Update button can recover. Three fetch call sites were patched (`_check_repo`, `apply_force_update`, `apply_update`) to use `--tags --force`; the WebUI never pushes tags, so deferring to the remote's view is the right contract. Closes #2756.
 
 ## [v0.51.110] — 2026-05-22 — Release CH (stage-403 — 2-PR batch — default personality from config + sort configured providers to top)
 

--- a/api/updates.py
+++ b/api/updates.py
@@ -477,7 +477,14 @@ def _check_repo(path, name):
 
     # Fetch tags first so update prompts track published releases, not every
     # development commit that lands on master/main after the latest release.
-    fetch_out, fetch_ok = _run_git(['fetch', 'origin', '--tags'], path, timeout=15)
+    #
+    # --force is required because the WebUI is a release-tracking consumer:
+    # it never pushes tags, so it should always defer to whatever the remote
+    # says a release tag points to. Without --force, a remote re-tag (e.g.
+    # after a squash-merge that re-points a release tag at a new SHA) jams
+    # the update path indefinitely with "would clobber existing tag" errors.
+    # See #2756.
+    fetch_out, fetch_ok = _run_git(['fetch', 'origin', '--tags', '--force'], path, timeout=15)
     if not fetch_ok:
         release_info = _check_repo_release(path, name)
         message = 'fetch failed'
@@ -896,7 +903,10 @@ def apply_force_update(target: str) -> dict:
         if path is None or not (path / '.git').exists():
             return {'ok': False, 'message': 'Not a git repository'}
 
-        _, fetch_ok = _run_git(['fetch', 'origin', '--quiet', '--tags'], path, timeout=15)
+        # --force so a remote re-tag (e.g. squash-merge that re-points an
+        # existing release tag) doesn't jam the apply path with "would clobber
+        # existing tag". See #2756.
+        _, fetch_ok = _run_git(['fetch', 'origin', '--quiet', '--tags', '--force'], path, timeout=15)
         if not fetch_ok:
             return {
                 'ok': False,
@@ -953,7 +963,8 @@ def _apply_update_inner(target):
         return {'ok': False, 'message': 'Not a git repository'}
 
     # Fetch before attempting pull, so the remote ref is current.
-    _, fetch_ok = _run_git(['fetch', 'origin', '--quiet', '--tags'], path, timeout=15)
+    # --force so a remote re-tag doesn't block the update path (see #2756).
+    _, fetch_ok = _run_git(['fetch', 'origin', '--quiet', '--tags', '--force'], path, timeout=15)
     if not fetch_ok:
         return {
             'ok': False,

--- a/tests/test_update_banner_fixes.py
+++ b/tests/test_update_banner_fixes.py
@@ -487,7 +487,7 @@ class TestSuccessfulUpdateReturnsRestartScheduled:
 
         result = upd.apply_update('webui')
         assert result['ok'] is True
-        assert ['fetch', 'origin', '--quiet', '--tags'] in ran
+        assert ['fetch', 'origin', '--quiet', '--tags', '--force'] in ran
         assert ['pull', '--ff-only', 'origin', 'v0.51.106'] in ran
         assert ['rev-parse', '--abbrev-ref', '@{upstream}'] not in ran
 

--- a/tests/test_updates.py
+++ b/tests/test_updates.py
@@ -5,7 +5,7 @@ import api.updates as updates
 
 
 def _fake_git_for_release_fetch_failure(args, cwd, timeout=10):
-    if args == ['fetch', 'origin', '--tags']:
+    if args == ['fetch', 'origin', '--tags', '--force']:
         return 'would clobber existing tag v0.50.294', False
     if args == ['tag', '--list', 'v*', '--sort=-v:refname']:
         return 'v0.51.106\nv0.51.103', True
@@ -41,7 +41,7 @@ def test_check_repo_redacts_credentialed_fetch_failure(tmp_path):
     )
 
     def fake_git(args, cwd, timeout=10):
-        if args == ['fetch', 'origin', '--tags']:
+        if args == ['fetch', 'origin', '--tags', '--force']:
             return raw_error, False
         if args == ['tag', '--list', 'v*', '--sort=-v:refname']:
             return '', True
@@ -64,7 +64,7 @@ def test_check_repo_fetch_failure_without_tags_is_not_up_to_date(tmp_path):
     (tmp_path / '.git').mkdir()
 
     def fake_git(args, cwd, timeout=10):
-        if args == ['fetch', 'origin', '--tags']:
+        if args == ['fetch', 'origin', '--tags', '--force']:
             return 'network unavailable', False
         if args == ['tag', '--list', 'v*', '--sort=-v:refname']:
             return '', True
@@ -126,3 +126,137 @@ def test_split_remote_ref_splits_tracking_ref():
     assert updates._split_remote_ref('origin/master') == ('origin', 'master')
     assert updates._split_remote_ref('origin/feature/foo') == ('origin', 'feature/foo')
     assert updates._split_remote_ref('master') == (None, 'master')
+
+
+# ---------------------------------------------------------------------------
+# #2756 — Update check fails with "would clobber existing tag" when an
+# upstream release tag was moved.
+#
+# All three fetch-tag call sites in api/updates.py must use --force so the
+# WebUI (a release-tracking consumer that never pushes tags) always defers
+# to whatever the remote says a release tag points to. Without --force,
+# any remote re-tag (e.g. squash-merge that re-points a release tag at a
+# new SHA) jams the update path indefinitely.
+# ---------------------------------------------------------------------------
+
+
+def test_check_repo_fetches_tags_with_force(tmp_path):
+    """_check_repo must pass --force to git fetch --tags (regression for #2756)."""
+    (tmp_path / '.git').mkdir()
+
+    seen_args = []
+
+    def fake_git(args, cwd, timeout=10):
+        seen_args.append(args)
+        if args[:2] == ['fetch', 'origin']:
+            # Force a fetch failure path so we don't have to mock the rest of
+            # the release/branch logic; the assertion is about the args shape.
+            return '', False
+        if args == ['tag', '--list', 'v*', '--sort=-v:refname']:
+            return '', True
+        raise AssertionError(f'unexpected git args: {args!r}')
+
+    with patch.object(updates, '_run_git', side_effect=fake_git):
+        updates._check_repo(tmp_path, 'webui')
+
+    fetch_calls = [a for a in seen_args if a[:2] == ['fetch', 'origin']]
+    assert fetch_calls, 'expected at least one fetch call'
+    for call in fetch_calls:
+        assert '--tags' in call, f'fetch should include --tags: {call!r}'
+        assert '--force' in call, (
+            f'fetch should include --force to recover from remote re-tags '
+            f'(see #2756): {call!r}'
+        )
+
+
+def test_apply_force_update_fetches_tags_with_force(tmp_path):
+    """apply_force_update must pass --force to git fetch --tags (#2756)."""
+    (tmp_path / '.git').mkdir()
+
+    seen_args = []
+
+    def fake_git(args, cwd, timeout=10):
+        seen_args.append(args)
+        if args[:2] == ['fetch', 'origin']:
+            return '', False  # short-circuit; we just want the args shape.
+        raise AssertionError(f'unexpected git args: {args!r}')
+
+    with patch.object(updates, '_run_git', side_effect=fake_git), \
+         patch.object(updates, 'REPO_ROOT', tmp_path), \
+         patch.object(updates, '_active_stream_count', return_value=0):
+        updates.apply_force_update('webui')
+
+    fetch_calls = [a for a in seen_args if a[:2] == ['fetch', 'origin']]
+    assert fetch_calls, 'expected at least one fetch call'
+    for call in fetch_calls:
+        assert '--tags' in call and '--force' in call, (
+            f'apply_force_update fetch should be --tags --force (see #2756): {call!r}'
+        )
+
+
+def test_apply_update_fetches_tags_with_force(tmp_path):
+    """apply_update must pass --force to git fetch --tags (#2756)."""
+    (tmp_path / '.git').mkdir()
+
+    seen_args = []
+
+    def fake_git(args, cwd, timeout=10):
+        seen_args.append(args)
+        if args[:2] == ['fetch', 'origin']:
+            return '', False  # short-circuit on fetch failure.
+        raise AssertionError(f'unexpected git args: {args!r}')
+
+    with patch.object(updates, '_run_git', side_effect=fake_git), \
+         patch.object(updates, 'REPO_ROOT', tmp_path), \
+         patch.object(updates, '_active_stream_count', return_value=0):
+        updates.apply_update('webui')
+
+    fetch_calls = [a for a in seen_args if a[:2] == ['fetch', 'origin']]
+    assert fetch_calls, 'expected at least one fetch call'
+    for call in fetch_calls:
+        assert '--tags' in call and '--force' in call, (
+            f'apply_update fetch should be --tags --force (see #2756): {call!r}'
+        )
+
+
+def test_check_repo_recovers_from_remote_retag(tmp_path):
+    """End-to-end: a remote-retag scenario should now succeed (#2756).
+
+    Before the fix, `git fetch origin --tags` would return "would clobber
+    existing tag v0.51.5" indefinitely. With --force the fetch succeeds and
+    the regular up-to-date / behind path runs.
+    """
+    (tmp_path / '.git').mkdir()
+
+    def fake_git(args, cwd, timeout=10):
+        # The --force flag makes the fetch succeed even when local tags
+        # diverge from remote tags. Refuse to honor a plain --tags fetch
+        # (no --force) so the test fails loudly if the regression returns.
+        if args == ['fetch', 'origin', '--tags']:
+            return (
+                ' ! [rejected]        v0.51.5    -> v0.51.5    '
+                '(would clobber existing tag)'
+            ), False
+        if args == ['fetch', 'origin', '--tags', '--force']:
+            return '', True
+        if args == ['tag', '--list', 'v*', '--sort=-v:refname']:
+            return 'v0.51.110\nv0.51.109', True
+        if args == ['describe', '--tags', '--abbrev=0']:
+            return 'v0.51.110', True
+        if args == ['describe', '--tags', '--always']:
+            return 'v0.51.110', True
+        if args == ['remote', 'get-url', 'origin']:
+            return 'https://github.com/nesquena/hermes-webui.git', True
+        # Branch-check fallback is fine to no-op for this assertion.
+        return '', True
+
+    with patch.object(updates, '_run_git', side_effect=fake_git):
+        info = updates._check_repo(tmp_path, 'webui')
+
+    assert info is not None
+    assert info.get('error') is None, (
+        f'expected clean update check, got error: {info.get("error")!r}'
+    )
+    assert info.get('stale_check') is not True, (
+        'fetch with --force should have succeeded, not marked stale'
+    )


### PR DESCRIPTION
## Summary

Closes #2756 — Update check fails with "would clobber existing tag" when an upstream release tag was moved.

After v0.51.107 (#2717) made `_check_repo` surface real `git fetch` errors instead of falsely reporting "Up to date", a second class of bug became visible: **any divergence between a local release tag and the remote release tag jams the update path indefinitely**. The user can never complete an update check or pull from the WebUI.

Reported in #report-bugs by Deor:
```
Update check failed: WebUI: From https://github.com/nesquena/hermes-webui
 ! [rejected]        v0.50.126  -> v0.50.126  (would clobber existing tag)
 ! [rejected]        v0.51.5    -> v0.51.5    (would clobber existing tag)
```

Confirmed locally — `v0.51.5` has divergent SHAs (`0ea3dfbd` locally vs `0af9ca38` remote, likely re-tagged after a squash-merge). Plain `git fetch origin --tags` will never succeed once this divergence exists.

## Fix

`api/updates.py` had three `['fetch', 'origin', ..., '--tags']` call sites:

- `_check_repo` (L480) — blocks "Check now"
- `apply_force_update` (L899) — blocks the force-apply path
- `apply_update` → `_apply_update_inner` (L956) — blocks the normal Update button

All three now pass `--force`. The WebUI is a release-tracking consumer that never pushes tags, so it should always defer to whatever the remote says a release tag points to.

```diff
-fetch_out, fetch_ok = _run_git(['fetch', 'origin', '--tags'], path, timeout=15)
+fetch_out, fetch_ok = _run_git(['fetch', 'origin', '--tags', '--force'], path, timeout=15)
```

## Tests

### Updated 4 existing tests
- `test_check_repo_reports_release_gap_even_when_tag_fetch_fails` — fake_git arg shape.
- `test_check_repo_redacts_credentialed_fetch_failure` — fake_git arg shape.
- `test_check_repo_fetch_failure_without_tags_is_not_up_to_date` — fake_git arg shape.
- `test_apply_update_succeeds_with_release_tag_pull` (in `test_update_banner_fixes.py`) — `in ran` shape.

### Added 4 new regression tests in `test_updates.py`
- `test_check_repo_fetches_tags_with_force` — asserts `_check_repo` passes `--tags --force`.
- `test_apply_force_update_fetches_tags_with_force` — asserts `apply_force_update` passes `--tags --force`.
- `test_apply_update_fetches_tags_with_force` — asserts `apply_update` passes `--tags --force`.
- `test_check_repo_recovers_from_remote_retag` — **end-to-end**: makes `['fetch', 'origin', '--tags']` (no `--force`) explicitly fail with the "would clobber existing tag" error and `['fetch', 'origin', '--tags', '--force']` succeed. Asserts the update check returns a clean result with no error and `stale_check != True`. Locks in the bug-fixed behavior — if the regression returns the test fails loudly.

## Verification

Full pytest suite green:

```
6278 passed, 6 skipped, 3 xpassed, 8 subtests passed in 179.19s
```

Pre-Opus gate checks: AST clean, no merge markers, no string-assertion drift in unrelated tests.

## Scope

| File | LOC delta |
|---|---|
| `api/updates.py` | +12 / -2 (3 call sites + comments) |
| `tests/test_updates.py` | +140 / -3 (4 new tests + 3 fake_git fixes) |
| `tests/test_update_banner_fixes.py` | +1 / -1 |
| `CHANGELOG.md` | +4 / 0 |
| **Total** | **+157 / -6** |

Mechanical change (single flag added to one git command, applied uniformly across three call sites). No behavioral surface beyond what's described in the issue.
