### PR TITLE
docs: explain onboarding state mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 
 ## [Unreleased]
 
+### Documentation
+
+- Documented the onboarding failure mode where an already-configured Hermes
+  setup appears to need provider setup because WebUI was launched with an
+  isolated or unexpected `HERMES_HOME`; added path-check diagnostics and restart
+  guidance to the onboarding and troubleshooting docs.
+
 ## [v0.51.115] — 2026-05-22 — Release CM (stage-pr2731 — 1-PR — clarify prompt collapse/expand with chevron-icon polish)
 
 ### Added

--- a/docs/onboarding-agent-checklist.md
+++ b/docs/onboarding-agent-checklist.md
@@ -128,6 +128,21 @@ Do not paste the full payload if it contains unexpected sensitive local paths
 or values. Redact paths and provider details when the human asks for a public
 GitHub or Discord support report.
 
+## Existing-user sanity check
+
+If the human says they already use Hermes successfully, treat a new WebUI
+wizard or `setup_state=needs_provider` result as a state-selection problem until
+the paths prove otherwise. Compare `system.config_path`, `system.env_path`, and
+`system.config_exists` from `/api/onboarding/status` with the intended Hermes
+home or profile. If those fields point at an isolated trial directory, empty
+profile, Docker volume, or unexpected `.env` override, the root cause is that
+WebUI was launched against the wrong state, not that the existing provider
+credentials disappeared.
+
+Report that distinction explicitly. Only restart WebUI against real Hermes
+state after the human confirms that is what they want; otherwise keep the
+isolated trial isolated.
+
 ## Pass criteria
 
 A local onboarding trial passes when:

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -64,6 +64,13 @@ For an assistant-led trial run, follow the safety rules, evidence commands, and
 pass/fail criteria in
 [`docs/onboarding-agent-checklist.md`](onboarding-agent-checklist.md).
 
+An isolated trial intentionally cannot see your existing Hermes config,
+credentials, profiles, memory, sessions, or cron jobs. If that trial reports
+`completed=false`, `setup_state=needs_provider`, or `config_exists=false` while
+your normal Hermes install already works, do not redo provider setup in the
+trial home. Restart WebUI with the intended `HERMES_HOME` and
+`HERMES_WEBUI_STATE_DIR` instead.
+
 If your repo has a `.env` file, remember that the bootstrap loads it. Remove or
 adjust any `HERMES_HOME`, `HERMES_WEBUI_STATE_DIR`, or `HERMES_WEBUI_PORT`
 entries there before using the isolated command above.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -85,6 +85,88 @@ If after running steps 1-4 the import still fails *and* `pip install -e .` succe
 
 ---
 
+## Existing Hermes setup opens onboarding or reports `needs_provider`
+
+**Symptom.** You already use Hermes from the CLI or another running profile,
+but WebUI opens the first-run wizard. `/api/onboarding/status` may report
+`completed=false`, `system.setup_state=needs_provider`,
+`system.provider_configured=false`, or `system.config_exists=false`.
+
+**Why.** WebUI reads Hermes config and credentials from the `HERMES_HOME` of
+the running WebUI process. If WebUI was launched for an isolated support trial
+such as `HERMES_HOME=~/hermes-onboarding-test/.hermes`, or a repo `.env` points
+`HERMES_HOME` / `HERMES_WEBUI_STATE_DIR` somewhere unexpected, the existing
+Hermes setup is invisible. In that case the wizard is accurately reporting the
+empty trial home; it does not mean the real Hermes install lost its provider
+setup.
+
+**Diagnostic.**
+
+1. Check only the non-secret onboarding fields:
+   ```bash
+   python3 - <<'PY'
+   import json, urllib.request
+
+   status = json.load(urllib.request.urlopen(
+       "http://127.0.0.1:8789/api/onboarding/status",
+       timeout=10,
+   ))
+   system = status.get("system", {})
+   print("completed=", status.get("completed"))
+   for key in (
+       "config_path",
+       "config_exists",
+       "setup_state",
+       "provider_configured",
+       "provider_ready",
+       "chat_ready",
+       "current_provider",
+       "current_model",
+       "env_path",
+   ):
+       print(f"{key}={system.get(key)}")
+   PY
+   ```
+2. Check whether repo-local `.env` overrides are changing the active state. Do
+   not print the whole file:
+   ```bash
+   test -f .env && grep -nE '^(HERMES_HOME|HERMES_WEBUI_STATE_DIR|HERMES_WEBUI_PORT|HERMES_WEBUI_HOST)=' .env || true
+   ```
+3. Compare those paths with the Hermes home or profile you meant to run. For a
+   named profile, the home usually looks like `~/.hermes/profiles/<profile>` and
+   WebUI state usually belongs under that profile, for example
+   `~/.hermes/profiles/<profile>/webui`.
+
+**Fix.** Stop the WebUI process that is using the wrong state, then restart it
+with the intended Hermes home and WebUI state directory:
+
+```bash
+HERMES_HOME="$HOME/.hermes" \
+HERMES_WEBUI_STATE_DIR="$HOME/.hermes/webui" \
+HERMES_WEBUI_PORT=8789 \
+python3 bootstrap.py --no-browser
+```
+
+For a named Hermes profile, point both variables at that profile instead:
+
+```bash
+HERMES_HOME="$HOME/.hermes/profiles/<profile>" \
+HERMES_WEBUI_STATE_DIR="$HOME/.hermes/profiles/<profile>/webui" \
+HERMES_WEBUI_PORT=8789 \
+python3 bootstrap.py --no-browser
+```
+
+If you use `ctl.sh`, put the intended values in the repo `.env` or pass them
+inline to `./ctl.sh restart` so future daemon restarts keep the same state.
+
+**When to file a bug.** If `system.config_path` points at the intended Hermes
+home, `system.config_exists=true`, and WebUI still reports `needs_provider` for
+a provider that works from the same environment in `hermes`, collect the
+diagnostic output above plus the provider name/model with secrets redacted and
+file an issue.
+
+---
+
 ## "Response interrupted." marker keeps saying "no agent output was recovered"
 
 **Symptom.** After the WebUI process restarts mid-turn (manual restart, OOM, crash, …), the affected chat shows an `**Response interrupted.**` marker with the wording *"The user message above was preserved, but no agent output was recovered."*, even though the run-journal for that turn is present on disk and contains the partial tokens the agent had already streamed.


### PR DESCRIPTION
## Thinking Path
- Hermes WebUI should use an existing Hermes Agent setup when launched against the correct state directories.
- Safe assistant-led onboarding trials intentionally use isolated `HERMES_HOME` / `HERMES_WEBUI_STATE_DIR`.
- That isolation can look like a provider failure when the human expected WebUI to read an already-configured profile.
- The docs should distinguish wrong active state from missing provider credentials before asking the user to redo setup.

## What Changed
- Added an existing-user sanity check to `docs/onboarding-agent-checklist.md`.
- Added a warning in `docs/onboarding.md` that isolated trials cannot see existing Hermes state.
- Added a troubleshooting entry for WebUI opening onboarding or reporting `needs_provider` despite an existing setup.
- Added an Unreleased changelog note.

## Why It Matters
This prevents operators and AI assistants from misdiagnosing an isolated or wrong `HERMES_HOME` launch as lost provider setup, and gives a safe restart path for the intended Hermes home/profile.

## Verification
- `git diff --check`
- Manual docs review of the changed sections.

## Risks / Follow-ups
- Docs-only change; no runtime behavior changed.
- Commands are intentionally non-secret and avoid printing full `.env` contents.

## Model Used
OpenAI Codex / `gpt-5.5` via Hermes Agent, with file, terminal, session-search, and GitHub CLI tool use.
