### PR TITLE
fix(models): surface AWS Bedrock provider in WebUI model picker

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -713,6 +713,7 @@ _PROVIDER_DISPLAY = {
     "x-ai": "xAI",
     "nvidia": "NVIDIA NIM",
     "xiaomi": "Xiaomi",
+    "bedrock": "AWS Bedrock",
 }
 
 # Provider alias → canonical slug.  Users configure providers using the
@@ -1212,6 +1213,16 @@ _PROVIDER_MODELS = {
     ],
     "xai-oauth": [
         {"id": "grok-4.20", "label": "Grok 4.20"},
+    ],
+    # AWS Bedrock — static fallback list; live model list is fetched via
+    # hermes_cli.models.provider_model_ids("bedrock") when available (#2720).
+    "bedrock": [
+        {"id": "global.anthropic.claude-opus-4-7",                 "label": "Global Anthropic Claude Opus 4.7"},
+        {"id": "global.anthropic.claude-opus-4-6-v1",              "label": "Global Anthropic Claude Opus 4.6"},
+        {"id": "global.anthropic.claude-sonnet-4-6",               "label": "Global Anthropic Claude Sonnet 4.6"},
+        {"id": "global.anthropic.claude-opus-4-5-20251101-v1:0",   "label": "GLOBAL Anthropic Claude Opus 4.5"},
+        {"id": "global.anthropic.claude-sonnet-4-5-20250929-v1:0", "label": "Global Claude Sonnet 4.5"},
+        {"id": "global.anthropic.claude-haiku-4-5-20251001-v1:0",  "label": "Global Anthropic Claude Haiku 4.5"},
     ],
 }
 
@@ -3007,6 +3018,8 @@ def get_available_models() -> dict:
                 "MINIMAX_CN_API_KEY",
                 "XAI_API_KEY",
                 "MISTRAL_API_KEY",
+                "AWS_ACCESS_KEY_ID",
+                "AWS_SECRET_ACCESS_KEY",
             ):
                 val = os.getenv(k)
                 if val:
@@ -3046,6 +3059,10 @@ def get_available_models() -> dict:
                 detected_providers.add("opencode-zen")
             if all_env.get("OPENCODE_GO_API_KEY"):
                 detected_providers.add("opencode-go")
+            # AWS Bedrock uses IAM credentials rather than a single API key.
+            # Detect when both access key and secret are available (#2720).
+            if all_env.get("AWS_ACCESS_KEY_ID") and all_env.get("AWS_SECRET_ACCESS_KEY"):
+                detected_providers.add("bedrock")
             # LM Studio: detect via LM_API_KEY + LM_BASE_URL in ~/.hermes/.env
             if all_env.get("LM_API_KEY") and all_env.get("LM_BASE_URL"):
                 detected_providers.add("lmstudio")

--- a/tests/test_issue2720_bedrock_model_picker.py
+++ b/tests/test_issue2720_bedrock_model_picker.py
@@ -1,0 +1,96 @@
+"""Regression coverage for #2720: Bedrock models must appear in the WebUI model picker."""
+
+from __future__ import annotations
+
+import builtins
+
+import api.config as config
+
+
+def _force_env_fallback(monkeypatch):
+    """Force get_available_models() down its explicit env-var fallback path."""
+    real_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name in ("hermes_cli.models", "hermes_cli.auth"):
+            raise ImportError(name)
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+
+def _run_available_models_with_cfg(monkeypatch, tmp_path, cfg):
+    old_cfg = dict(config.cfg)
+    old_mtime = config._cfg_mtime
+    monkeypatch.setattr(config, "_models_cache_path", tmp_path / "models_cache.json")
+    monkeypatch.setattr(config, "_get_config_path", lambda: tmp_path / "missing-config.yaml")
+    monkeypatch.setattr("api.profiles.get_active_hermes_home", lambda: tmp_path, raising=False)
+    config.cfg.clear()
+    config.cfg.update(cfg)
+    config._cfg_mtime = 0.0
+    config.invalidate_models_cache()
+    try:
+        return config.get_available_models()
+    finally:
+        config.cfg.clear()
+        config.cfg.update(old_cfg)
+        config._cfg_mtime = old_mtime
+        config.invalidate_models_cache()
+
+
+def test_bedrock_in_provider_display():
+    """_PROVIDER_DISPLAY must have a human-readable label for 'bedrock'."""
+    assert "bedrock" in config._PROVIDER_DISPLAY, (
+        "_PROVIDER_DISPLAY is missing 'bedrock' — the group header in the model picker "
+        "will fall back to 'Bedrock' (title-cased id) instead of 'AWS Bedrock'"
+    )
+    assert config._PROVIDER_DISPLAY["bedrock"] == "AWS Bedrock"
+
+
+def test_bedrock_in_provider_models():
+    """_PROVIDER_MODELS must have a static fallback list for 'bedrock'."""
+    assert "bedrock" in config._PROVIDER_MODELS, (
+        "_PROVIDER_MODELS is missing 'bedrock' — the group builder falls to the "
+        "else/auto-detected branch where an empty model list silently drops the group"
+    )
+    assert len(config._PROVIDER_MODELS["bedrock"]) > 0, (
+        "_PROVIDER_MODELS['bedrock'] must have at least one static fallback model"
+    )
+
+
+def test_bedrock_static_models_have_required_fields():
+    """Every static bedrock model entry must have both 'id' and 'label'."""
+    for model in config._PROVIDER_MODELS["bedrock"]:
+        assert "id" in model and model["id"], f"Missing id in bedrock model entry: {model}"
+        assert "label" in model and model["label"], f"Missing label in bedrock model entry: {model}"
+
+
+def test_bedrock_aws_credentials_detected_in_env_fallback(monkeypatch, tmp_path):
+    """AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY must trigger bedrock group (no hermes_cli)."""
+    _force_env_fallback(monkeypatch)
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "AKIAIOSFODNN7EXAMPLE")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")
+
+    result = _run_available_models_with_cfg(monkeypatch, tmp_path, {"model": {}})
+    groups = {group["provider_id"]: group for group in result["groups"]}
+
+    assert "bedrock" in groups, (
+        "bedrock group missing from model picker even with AWS_ACCESS_KEY_ID and "
+        "AWS_SECRET_ACCESS_KEY set — env-var fallback path does not detect bedrock (#2720)"
+    )
+    assert groups["bedrock"]["provider"] == "AWS Bedrock"
+    assert len(groups["bedrock"]["models"]) > 0
+
+
+def test_bedrock_missing_secret_key_not_detected(monkeypatch, tmp_path):
+    """Only AWS_ACCESS_KEY_ID (without the secret) must NOT trigger bedrock group."""
+    _force_env_fallback(monkeypatch)
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "AKIAIOSFODNN7EXAMPLE")
+    monkeypatch.delenv("AWS_SECRET_ACCESS_KEY", raising=False)
+
+    result = _run_available_models_with_cfg(monkeypatch, tmp_path, {"model": {}})
+    groups = {group["provider_id"]: group for group in result["groups"]}
+
+    assert "bedrock" not in groups, (
+        "bedrock must not appear when only AWS_ACCESS_KEY_ID is set without the secret"
+    )


### PR DESCRIPTION
## Thinking Path

- Hermes WebUI aims for near 1:1 parity with the Hermes CLI in a browser
- The CLI correctly discovers and lists 49 Bedrock models via `hermes_cli`
- The WebUI model picker builds groups from `detected_providers`, then dispatches per-provider
- `bedrock` was absent from both `_PROVIDER_DISPLAY` and `_PROVIDER_MODELS`
- This caused `bedrock` to fall through to the `else` branch of the group builder, which requires `auto_detected_models` (a base-URL probe) — Bedrock has no base URL, so the group was silently dropped
- Additionally, the hermes_cli-unavailable fallback path never checked AWS credentials
- This PR registers `bedrock` in both registries and adds AWS credential detection

## What Changed

**`api/config.py`**

- `_PROVIDER_DISPLAY`: added `"bedrock": "AWS Bedrock"`
- `_PROVIDER_MODELS`: added `"bedrock"` with 6 static fallback model entries using global Anthropic cross-region inference profile IDs (Claude 4.5 / 4.6 / 4.7 family); live discovery via `hermes_cli.models.provider_model_ids("bedrock")` takes precedence through the existing `_read_live_provider_model_ids` machinery
- Fallback env detection: added `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` to the env-var fetch list; detects `bedrock` when both are present (mirrors how other providers detect their API keys when hermes_cli is unavailable)

**`tests/test_issue2720_bedrock_model_picker.py`** — 5 new regression tests:
- `test_bedrock_in_provider_display` — display label registered
- `test_bedrock_in_provider_models` — static fallback list present
- `test_bedrock_static_models_have_required_fields` — every entry has id + label
- `test_bedrock_aws_credentials_detected_in_env_fallback` — group appears with both AWS env vars set (hermes_cli blocked)
- `test_bedrock_missing_secret_key_not_detected` — partial credentials do not trigger the group

## Why It Matters

Users with properly configured AWS credentials see zero Bedrock models in the picker despite the CLI working fine. The fix is purely additive — no existing provider logic is touched.

## Verification

```
pytest tests/test_issue2720_bedrock_model_picker.py -v
# 5 passed

pytest tests/ -v
# 6271 passed, 2 pre-existing failures (git default-branch master→main, unrelated)
```

## Risks / Follow-ups

- The 6 static fallback model IDs are global cross-region inference profile IDs supplied in the issue. Users with live hermes_cli will get the full 49-model list automatically via `_read_live_provider_model_ids("bedrock")`.
- `_PROVIDER_ENV_VAR` and the Settings → Providers card for Bedrock are not updated here (Bedrock uses IAM, not a single API key — that deserves its own issue/PR).

## Model Used

Provider: Anthropic via GitHub Copilot  
Model: `github-copilot/claude-sonnet-4.6`  
Mode: OpenCode agent with Karpathy guidelines skill

Closes #2720