### PR TITLE
fix: prevent state.db messages being silently dropped during sidecar merge

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -2815,21 +2815,28 @@ def _json_loads_if_string(value):
         return value
 
 
-def get_state_db_session_messages(sid, *, stitch_continuations: bool = False) -> list:
-    """Read messages for a Hermes session from the active profile's state.db.
+def get_state_db_session_messages(sid, *, stitch_continuations: bool = False, profile=None) -> list:
+    """Read messages for a Hermes session from state.db.
 
-    This generic reader intentionally works for any session source, including
-    WebUI-origin sessions that were later updated through another Hermes surface
-    such as the Gateway API Server.  When ``stitch_continuations`` is true it
-    preserves the historical CLI/external-agent behavior of walking compatible
-    compression/close parent segments before reading messages.
+    When *profile* is supplied, reads from that profile's state.db; otherwise
+    falls back to the active profile's state.db.  This generic reader works for
+    any session source, including WebUI-origin sessions that were later updated
+    through another Hermes surface such as the Gateway API Server.  When
+    ``stitch_continuations`` is true it preserves the historical CLI/external-agent
+    behavior of walking compatible compression/close parent segments before reading
+    messages.
     """
     try:
         import sqlite3
     except ImportError:
         return []
 
-    db_path = _active_state_db_path()
+    if profile:
+        db_path = _get_profile_home(profile) / 'state.db'
+        if not db_path.exists():
+            db_path = _active_state_db_path()
+    else:
+        db_path = _active_state_db_path()
     if not db_path.exists():
         return []
 
@@ -2852,7 +2859,8 @@ def get_state_db_session_messages(sid, *, stitch_continuations: bool = False) ->
                 'reasoning_content',
                 'codex_message_items',
             ]
-            selected = ['role', 'content', 'timestamp'] + [c for c in optional if c in available]
+            id_col = ['id'] if 'id' in available else []
+            selected = id_col + ['role', 'content', 'timestamp'] + [c for c in optional if c in available]
 
             session_chain = [str(sid)]
             if stitch_continuations:

--- a/api/routes.py
+++ b/api/routes.py
@@ -3752,17 +3752,18 @@ def handle_get(handler, parsed) -> bool:
             cli_messages = []
             state_db_messages = []
             sidecar_metadata_messages = None
+            _session_profile = getattr(s, 'profile', None) or None
             if is_messaging_session:
                 cli_messages = get_cli_session_messages(sid)
             elif load_messages:
-                state_db_messages = get_state_db_session_messages(sid)
+                state_db_messages = get_state_db_session_messages(sid, profile=_session_profile)
             elif not is_messaging_session:
                 # Metadata-only callers still need the same append-only
                 # reconciliation contract as full loads. A raw state.db summary
                 # can count stale rows that the merge intentionally filters out,
                 # which makes sidebar polling think the transcript is always
                 # newer than the loaded conversation.
-                state_db_messages = get_state_db_session_messages(sid)
+                state_db_messages = get_state_db_session_messages(sid, profile=_session_profile)
                 sidecar_metadata_session = Session.load(sid)
                 sidecar_metadata_messages = (
                     getattr(sidecar_metadata_session, "messages", []) or []


### PR DESCRIPTION
## Problem

Two bugs in `api/models.py` combine to silently discard historical messages when a session is loaded after being continued in a later conversation. The symptom: a session with 189 messages shows only 50 in the WebUI.

## Root Causes

### Bug 1 — `id` column missing from state.db SELECT

`get_state_db_session_messages()` selected only `role`, `content`, `timestamp` (plus optional tool/reasoning columns) — never `id`. As a result every row got a `("legacy", ...)` merge key instead of `("message_id", ...)`.

`merge_session_messages_append_only()` has a timestamp gate (line 3126–3138) that skips any state.db row whose timestamp ≤ the newest sidecar message **unless** the row carries a `message_id` key. Because no row ever had one, the entire state.db history was dropped the moment the sidecar contained any message newer than the oldest state.db row.

**Fix:** include `id` when the column is present so rows get proper `("message_id", ...)` keys and survive the timestamp filter.

### Bug 2 — always reads the *active* profile's state.db, not the session's own

`get_state_db_session_messages()` called `_active_state_db_path()` unconditionally, which returns the currently-active profile's database. Sessions belonging to a different profile (e.g. a `jump` or `aws-us` profile) were read from the wrong `state.db`, returning either zero rows or rows from unrelated sessions.

**Fix:** add an optional `profile` parameter; when supplied, resolve the path via `_get_profile_home(profile)` with a fallback to the active path if the profile-specific db is absent. The call-site in `routes.py` reads `session.profile` and passes it through.

## Changes

- **`api/models.py`** — `get_state_db_session_messages()`:
  - New `profile` parameter; reads the correct profile's `state.db`
  - Includes `id` in SELECT when the column exists

- **`api/routes.py`** — passes `session.profile` to `get_state_db_session_messages()`

## Reproduction

1. Have a session with many messages belonging to a non-default profile
2. Continue the session — the sidecar is updated with a newer timestamp
3. Reload the session in WebUI → all messages older than the newest sidecar entry disappear

## Test Plan

- [ ] Load a session belonging to a non-default profile — all historical messages appear
- [ ] Load a session that was continued after a gap — no messages missing
- [ ] New sessions with no prior sidecar still load correctly
- [ ] Sessions with `message_id`-keyed sidecar entries are not duplicated

🤖 Generated with [Claude Code](https://claude.com/claude-code)