### PR TITLE
fix: add do_OPTIONS handler for CORS preflight requests

### DIFF
--- a/server.py
+++ b/server.py
@@ -289,6 +289,15 @@ class Handler(BaseHTTPRequestHandler):
     def do_PATCH(self) -> None:
         self._handle_write(handle_patch)
 
+    def do_OPTIONS(self) -> None:
+        """Handle CORS preflight requests."""
+        self._req_t0 = time.time()
+        self.send_response(200)
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.send_header("Access-Control-Allow-Methods", "GET, POST, PATCH, DELETE, OPTIONS")
+        self.send_header("Access-Control-Allow-Headers", "Content-Type, Authorization")
+        self.end_headers()
+
     def do_DELETE(self) -> None:
         self._handle_write(handle_delete)
 


### PR DESCRIPTION
## Summary

Add `do_OPTIONS()` handler to respond to CORS preflight requests with 200 OK and appropriate headers.

Without this handler, browsers sending a preflight OPTIONS request receive 501 Not Implemented, blocking cross-origin API calls.

## Changes

**`server.py`** — Added `do_OPTIONS()` method. No changes to `end_headers()` — CORS headers are only set on the preflight response, not broadened to all endpoints.