### PR TITLE
fix: align messaging session display counts

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -3926,6 +3926,13 @@ def handle_get(handler, parsed) -> bool:
                 )
             if cli_meta and _is_messaging_session_record(cli_meta):
                 raw = _merge_cli_sidebar_metadata(raw, cli_meta)
+                # ``message_count`` in /api/session is the display coordinate
+                # space used for pagination and the header badge. Messaging
+                # state.db metadata can include raw duplicate transport rows that
+                # _merged_session_messages_for_display() intentionally dedupes;
+                # keep the raw count available as ``actual_message_count`` but
+                # do not let it make the frontend expect phantom messages.
+                raw["message_count"] = _merged_message_count
             # Signal to the frontend that older messages were omitted.
             # For msg_before paging, compare against the filtered set,
             # not the full list — otherwise we signal truncation even when

--- a/tests/test_gateway_sync.py
+++ b/tests/test_gateway_sync.py
@@ -1708,6 +1708,77 @@ def test_session_prefers_state_db_messages_over_stale_local_snapshot(cleanup_tes
             pass
 
 
+def test_messaging_session_message_count_matches_deduped_display_messages(cleanup_test_sessions):
+    """Thread sessions must not advertise raw DB rows that display merge dedupes away."""
+    from api.models import Session
+
+    conn = _ensure_state_db()
+    sid = 'gw_display_count_regression_001'
+    cleanup_test_sessions.append(sid)
+    base_ts = time.time() - 60
+    rows = [
+        ("user", "Thread question", base_ts + 1),
+        ("assistant", "", base_ts + 2),
+        ("assistant", "", base_ts + 2),
+        ("tool", '{"ok": true}', base_ts + 3),
+        ("assistant", "Thread answer", base_ts + 4),
+    ]
+    raw_db_count = len(rows)
+    try:
+        _insert_gateway_session(
+            conn,
+            session_id=sid,
+            source='discord',
+            title='Discord Thread Count Regression',
+            message_count=raw_db_count,
+            started_at=base_ts,
+        )
+        conn.execute("DELETE FROM messages WHERE session_id = ?", (sid,))
+        for role, content, ts in rows:
+            _insert_message(conn, sid, role, content, ts)
+        conn.execute(
+            "UPDATE sessions SET message_count = ? WHERE id = ?",
+            (raw_db_count, sid),
+        )
+        conn.commit()
+
+        # A stale WebUI sidecar can exist for the same messaging thread. The API
+        # display merge dedupes repeated blank assistant separators, so the
+        # advertised count must match the returned display coordinate space, not
+        # the raw state.db row count.
+        s = Session(
+            session_id=sid,
+            title='Legacy Discord Snapshot',
+            workspace='/tmp/hermes-webui-test',
+            model='openai/gpt-5',
+            messages=[{"role": "user", "content": "Thread question", "timestamp": base_ts + 1}],
+            session_source='messaging',
+            raw_source='discord',
+            source_tag='discord',
+            source_label='Discord',
+        )
+        s.save(touch_updated_at=False)
+
+        post('/api/settings', {'show_cli_sessions': True})
+        data, status = get(f'/api/session?session_id={sid}&messages=1&resolve_model=0&msg_limit=100')
+        assert status == 200, data
+        session = data.get('session', {})
+        msgs = session.get('messages', [])
+        assert msgs[-1].get('content') == 'Thread answer'
+        assert len(msgs) < raw_db_count, "fixture must exercise display dedupe"
+        assert session.get('message_count') == len(msgs)
+    finally:
+        try:
+            _remove_test_sessions(conn, sid)
+            conn.close()
+        except Exception:
+            pass
+        try:
+            post('/api/settings', {'show_cli_sessions': False})
+        except Exception:
+            pass
+
+
 def test_sessions_prefers_state_db_metadata_for_messaging_overlap(cleanup_test_sessions):
     """Sidebar metadata for messaging sessions should come from state.db, not local JSON snapshots."""
     conn = _ensure_state_db()


### PR DESCRIPTION
## Summary
- Aligns messaging session message counts with the deduplicated display messages returned to the UI.
- Preserves the existing payload shape while filling the count field from the display-message layer.
- Adds regression coverage for deduped display-message counts in gateway sync responses.

## Test Plan
- `git diff --check origin/master...HEAD`
- `python3 -m pytest tests/test_gateway_sync.py -q` -> 55 passed
- `python3 -m py_compile api/routes.py`
- Added-line public hygiene scan -> 0 marker hits

## Notes
Prepared from fresh `nesquena/hermes-webui:master` at `e091e65d56fba42f350a95f3308d6d43b3627a87`.
