### PR TITLE
fix: preserve settled tool cards after done render

### DIFF
--- a/static/messages.js
+++ b/static/messages.js
@@ -1707,10 +1707,17 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
               }
             }
           }
-          if(d.session.tool_calls&&d.session.tool_calls.length){
+          const hasMessageToolMetadata=S.messages.some(m=>{
+            if(!m||m.role!=='assistant') return false;
+            const hasTc=Array.isArray(m.tool_calls)&&m.tool_calls.length>0;
+            const hasPartialTc=Array.isArray(m._partial_tool_calls)&&m._partial_tool_calls.length>0;
+            const hasTu=Array.isArray(m.content)&&m.content.some(p=>p&&p.type==='tool_use');
+            return hasTc||hasPartialTc||hasTu;
+          });
+          if(!hasMessageToolMetadata&&d.session.tool_calls&&d.session.tool_calls.length){
             S.toolCalls=d.session.tool_calls.map(tc=>({...tc,done:true}));
           } else {
-            S.toolCalls=S.toolCalls.map(tc=>({...tc,done:true}));
+            S.toolCalls=hasMessageToolMetadata?[]:S.toolCalls.map(tc=>({...tc,done:true}));
           }
           if(typeof _copyActivityDisclosureState==='function'&&lastAsst){
             const assistantIdx=S.messages.indexOf(lastAsst);

--- a/tests/test_streaming_markdown.py
+++ b/tests/test_streaming_markdown.py
@@ -450,6 +450,21 @@ class TestDoneEventSmd:
             "the possibly-stale _scrollPinned flag."
         )
 
+    def test_done_handler_prefers_message_tool_metadata_for_settled_render(self):
+        """If final messages already contain tool metadata, renderMessages()
+        should derive anchored settled cards from those messages.
+
+        Falling back to session-level tool_calls unconditionally can hide cards
+        after pagination/windowing because those anchors may not line up with
+        the active message array.
+        """
+        fn = self.get_fn()
+        assert fn, "'done' handler not found"
+        done_before_render = fn[:fn.index("renderMessages({preserveScroll:true})")]
+        assert "const hasMessageToolMetadata=S.messages.some" in done_before_render
+        assert "!hasMessageToolMetadata&&d.session.tool_calls&&d.session.tool_calls.length" in done_before_render
+        assert "S.toolCalls=hasMessageToolMetadata?[]:S.toolCalls.map" in done_before_render
+
 
 # ── 7. apperror event: smd parser ends cleanly ───────────────────────────────
 


### PR DESCRIPTION
## Summary
- Preserve message-level settled tool metadata when the streaming done payload also carries a stale/empty session-level `tool_calls` field.
- Keep settled tool cards visible after stream completion instead of letting the final done render erase them.
- Add a regression assertion for the done-event helper path.

Fixes #2613.
Complements #2777; this covers final done-event metadata precedence, while #2777 covers pending segment flushes at tool/interim boundaries.

## Test plan
- `node --check static/messages.js`
- `python3 -m pytest tests/test_streaming_markdown.py::TestDoneEventSmd::test_done_handler_prefers_message_tool_metadata_for_settled_render -q -o addopts=`
- `python3 -m pytest tests/test_streaming_markdown.py tests/test_turn_duration_display.py tests/test_issue2028_compression_anchor_helpers.py -q -o addopts=`
- added-line hygiene scans: private/local markers 0, secret-like 0, risky JS sinks 0
