### PR TITLE
fix(compression): ignore tool output for compaction cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Prevent compression-summary cards from using ordinary tool output that merely mentions context compression. The streaming path now reuses the shared strict compression-marker predicate, so only synthetic marker prefixes from non-tool messages can seed `compression_anchor_summary`; skill/tool JSON and user discussion about compaction no longer render as misleading `Context compaction` reference cards.
+
 ## [v0.51.118] — 2026-05-22 — Release CP (stage-pr2773 — 1-PR hotfix — v0.51.117 brick fix: chat input restored)
 
 ### Fixed

--- a/api/compression_anchor.py
+++ b/api/compression_anchor.py
@@ -53,7 +53,7 @@ def _content_has_part_type(content, part_types):
     )
 
 
-def _is_context_compression_marker(message):
+def is_context_compression_marker(message):
     """Return true for synthetic compression/reference cards, not user turns."""
     if not isinstance(message, dict):
         return False
@@ -69,6 +69,11 @@ def _is_context_compression_marker(message):
         or text.startswith("context compaction")
         or text.startswith("[your active task list was preserved across context compression]")
     )
+
+
+def _is_context_compression_marker(message):
+    """Backward-compatible alias for callers that have not switched yet."""
+    return is_context_compression_marker(message)
 
 
 def visible_messages_for_anchor(messages, *, auto_compression: bool = False):

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -35,7 +35,7 @@ from api.config import (
     load_settings,
 )
 from api.helpers import redact_session_data, _redact_text
-from api.compression_anchor import visible_messages_for_anchor
+from api.compression_anchor import is_context_compression_marker, visible_messages_for_anchor
 from api.metering import meter
 from api.run_journal import RunJournalWriter
 from api.turn_journal import append_turn_journal_event_for_stream
@@ -2299,15 +2299,7 @@ def _dedupe_replayed_active_context(previous_context, result_messages):
 
 
 def _is_context_compression_marker(msg):
-    if not isinstance(msg, dict):
-        return False
-    text = _message_text(msg.get('content', '')).lower()
-    return (
-        'context compaction' in text
-        or 'context compression' in text
-        or 'context was auto-compressed' in text
-        or 'active task list was preserved across context compression' in text
-    )
+    return is_context_compression_marker(msg)
 
 
 def _compact_summary_text(raw_text: str | None, limit: int = 320) -> str | None:

--- a/tests/test_issue2028_compression_anchor_helpers.py
+++ b/tests/test_issue2028_compression_anchor_helpers.py
@@ -4,7 +4,8 @@ Regression coverage for shared compression-anchor visibility helpers (#2028).
 
 from pathlib import Path
 
-from api.compression_anchor import visible_messages_for_anchor
+from api.compression_anchor import is_context_compression_marker, visible_messages_for_anchor
+from api.streaming import _compression_summary_from_messages, _is_context_compression_marker
 
 
 def test_legacy_duplicate_anchor_helpers_are_removed():
@@ -57,3 +58,42 @@ def test_visible_messages_for_anchor_keeps_manual_user_messages_simple():
         [user_tool_metadata, user_attachment, assistant_tool_metadata],
         auto_compression=True,
     ) == [user_tool_metadata, user_attachment, assistant_tool_metadata]
+
+
+def test_context_compression_marker_detection_is_prefix_and_role_scoped():
+    real_marker = {
+        "role": "assistant",
+        "content": "[CONTEXT COMPACTION — REFERENCE ONLY] Earlier turns were compacted.",
+    }
+    preserved_tasks_marker = {
+        "role": "user",
+        "content": "[Your active task list was preserved across context compression] - [ ] follow up",
+    }
+    tool_noise = {
+        "role": "tool",
+        "content": "{\"description\": \"Troubleshoot frequent context compression indicators\"}",
+    }
+    user_discussion = {
+        "role": "user",
+        "content": "Why do I see context compression after every message?",
+    }
+
+    assert is_context_compression_marker(real_marker)
+    assert is_context_compression_marker(preserved_tasks_marker)
+    assert _is_context_compression_marker(real_marker)
+    assert not is_context_compression_marker(tool_noise)
+    assert not is_context_compression_marker(user_discussion)
+
+
+def test_compression_summary_ignores_tool_output_that_mentions_compression():
+    marker = {
+        "role": "assistant",
+        "content": "[CONTEXT COMPACTION — REFERENCE ONLY] Keep this handoff as reference.",
+    }
+    skill_tool_output = {
+        "role": "tool",
+        "content": "{\"name\": \"hermes-webui-operations\", \"content\": \"Troubleshooting frequent context compression indicators...\"}",
+    }
+
+    assert _compression_summary_from_messages([marker, skill_tool_output]) == marker["content"]
+    assert _compression_summary_from_messages([skill_tool_output]) is None


### PR DESCRIPTION
## Summary

- Expose the shared strict compression-marker predicate as `is_context_compression_marker()`.
- Make the streaming auto-compression path reuse that shared predicate instead of its local broad substring matcher.
- Add regressions proving tool output and normal user discussion that merely mention context compression no longer become `compression_anchor_summary` cards.

## Root cause

The WebUI had two different compression-marker detectors:

1. `api.compression_anchor._is_context_compression_marker()` was strict: it only accepted known synthetic marker prefixes on non-tool messages.
2. `api.streaming._is_context_compression_marker()` was broad: it returned true if the message text contained phrases like `context compression` or `context compaction` anywhere.

`_compression_summary_from_messages()` scans messages in reverse to find the latest compression marker and persists that text into `compression_anchor_summary`. Because the streaming detector did not check the message role and did substring matching, an ordinary tool result, for example JSON emitted by a skill/tool whose text happened to describe "context compression", could be selected as the compression summary.

Once persisted, the frontend rendered that tool JSON as a `Context compaction` reference card. To users this looked like WebUI compacted after the current turn, even though the card was seeded from unrelated tool output that merely mentioned compression.

This patch removes that drift by routing streaming through the same strict shared marker predicate used by compression-anchor helpers. Tool messages are ignored, and user messages that discuss context compression in normal prose are not treated as synthetic compaction markers.

## Testing

- `python -m py_compile api/compression_anchor.py api/streaming.py`
- `/home/agent/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_issue2028_compression_anchor_helpers.py tests/test_auto_compression_card.py -q`
  - `47 passed`
- Full-suite local attempts were not clean in this environment:
  - one run had an order/environment-sensitive `tests/test_issue1499_keyless_onboarding.py::TestKeylessChatReady::test_lmstudio_keyless_chat_ready_via_full_status` failure; that test passed immediately when rerun alone.
  - another run hit many localhost `ConnectionRefused` failures in server-dependent tests, consistent with the local test server not being available for those cases.
