### PR TITLE
harden(start.ps1): TryParse HERMES_WEBUI_PORT + exit AFTER try/finally cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 
 ## [Unreleased]
 
+### Added
+
+- **`start.ps1`: native Windows launcher** — PowerShell equivalent of `start.sh` that bypasses `bootstrap.py`'s `ensure_supported_platform()` refusal and invokes `server.py` directly on native Windows. Mirrors `start.sh`'s discovery (load optional `.env` with the same readonly-var filter for `UID`/`GID`/`EUID`/`EGID`/`PPID`, find Python via `HERMES_WEBUI_PYTHON` env → `python3` → `python` → `py`, locate the hermes-agent dir at `%USERPROFILE%\.hermes\hermes-agent` or `../hermes-agent`, prefer the agent's `venv\Scripts\python.exe` if present, set `HERMES_WEBUI_HOST` / `HERMES_WEBUI_PORT` / `HERMES_WEBUI_STATE_DIR` / `HERMES_HOME` defaults). Closes the launcher half of #1952; complements the README community-guide link below. Assumes Python + agent venv are already set up — for first-time setup, use WSL2 once to create the venv, then `start.ps1` works natively.
+
+### Documentation
+
+- **README: link @markwang2658's native Windows community guide** — adds a paragraph below the existing "Native Windows is not supported by this bootstrap" line pointing Windows users at the community-maintained no-Docker / no-WSL2 setup ([hermes-windows-native-guide](https://github.com/markwang2658/hermes-windows-native-guide), companion setup repo [hermes-windows-native](https://github.com/markwang2658/hermes-windows-native)) tracked in #1952, including the memory delta vs containerized setups (~330 MB native vs ~1080 MB with WSL2+Docker). Closes the docs half of #1952.
+
 ## [v0.51.118] — 2026-05-22 — Release CP (stage-pr2773 — 1-PR hotfix — v0.51.117 brick fix: chat input restored)
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -131,7 +131,8 @@ The bootstrap will:
 
 > Native Windows is not supported for this bootstrap yet. Use Linux, macOS, or WSL2.
 > For Windows / WSL auto-start at login, see [`docs/wsl-autostart.md`](docs/wsl-autostart.md).
-> A community-maintained native Windows guide is tracked in [#1952](https://github.com/nesquena/hermes-webui/issues/1952).
+
+A community-maintained native Windows setup (no Docker, no WSL2) is documented at [@markwang2658/hermes-windows-native-guide](https://github.com/markwang2658/hermes-windows-native-guide) (companion setup repo: [@markwang2658/hermes-windows-native](https://github.com/markwang2658/hermes-windows-native)). The community report in [#1952](https://github.com/nesquena/hermes-webui/issues/1952) measured substantially lower memory use vs containerized setups (~330 MB native vs ~1080 MB with WSL2+Docker). Chat, workspace browser, session management, and all themes work; some POSIX-style file paths appear in the workspace browser, and bash-assuming agent tools may not work natively. A PowerShell launcher (`start.ps1`) at the repo root reproduces `start.sh`'s discovery on native Windows by invoking `server.py` directly (skipping `bootstrap.py`'s platform refusal).
 
 If provider setup is still incomplete after install, the onboarding wizard will point you to finish it with `hermes model` instead of trying to replicate the full CLI setup in-browser.
 For a step-by-step walkthrough of the wizard, provider choices, local model server Base URLs, and safe re-runs, see [`docs/onboarding.md`](docs/onboarding.md).

--- a/README.md
+++ b/README.md
@@ -132,7 +132,12 @@ The bootstrap will:
 > Native Windows is not supported for this bootstrap yet. Use Linux, macOS, or WSL2.
 > For Windows / WSL auto-start at login, see [`docs/wsl-autostart.md`](docs/wsl-autostart.md).
 
-A community-maintained native Windows setup (no Docker, no WSL2) is documented at [@markwang2658/hermes-windows-native-guide](https://github.com/markwang2658/hermes-windows-native-guide) (companion setup repo: [@markwang2658/hermes-windows-native](https://github.com/markwang2658/hermes-windows-native)). The community report in [#1952](https://github.com/nesquena/hermes-webui/issues/1952) measured substantially lower memory use vs containerized setups (~330 MB native vs ~1080 MB with WSL2+Docker). Chat, workspace browser, session management, and all themes work; some POSIX-style file paths appear in the workspace browser, and bash-assuming agent tools may not work natively. A PowerShell launcher (`start.ps1`) at the repo root reproduces `start.sh`'s discovery on native Windows by invoking `server.py` directly (skipping `bootstrap.py`'s platform refusal).
+A community-maintained native Windows setup is documented at [@markwang2658/hermes-windows-native-guide](https://github.com/markwang2658/hermes-windows-native-guide) (companion setup repo: [@markwang2658/hermes-windows-native](https://github.com/markwang2658/hermes-windows-native)). Notes from the community report in [#1952](https://github.com/nesquena/hermes-webui/issues/1952):
+
+- **Memory:** community-measured ~330 MB native vs ~1080 MB with WSL2+Docker (varies by configuration).
+- **What works:** chat, workspace browser, session management, all themes.
+- **Known limitations:** some POSIX-style file paths surface in the workspace browser; bash-assuming agent tools may not work natively.
+- **WSL2 relationship:** WSL2 is recommended *once* for first-time venv creation (since `bootstrap.py` currently refuses on native Windows). After the venv exists, `start.ps1` at the repo root runs the WebUI natively by invoking `server.py` directly — no WSL2 needed for day-to-day use.
 
 If provider setup is still incomplete after install, the onboarding wizard will point you to finish it with `hermes model` instead of trying to replicate the full CLI setup in-browser.
 For a step-by-step walkthrough of the wizard, provider choices, local model server Base URLs, and safe re-runs, see [`docs/onboarding.md`](docs/onboarding.md).

--- a/start.ps1
+++ b/start.ps1
@@ -119,7 +119,26 @@ if (Test-Path $agentVenvPython) {
 
 # === Resolve bind + state defaults =====================================
 $BindHostFinal = if ($BindHost) { $BindHost } elseif ($env:HERMES_WEBUI_HOST) { $env:HERMES_WEBUI_HOST } else { '127.0.0.1' }
-$PortFinal = if ($Port) { $Port } elseif ($env:HERMES_WEBUI_PORT) { [int]$env:HERMES_WEBUI_PORT } else { 8787 }
+$PortFinal = if ($Port) {
+    $Port
+} elseif ($env:HERMES_WEBUI_PORT) {
+    # TryParse + range guard on the env var. A plain [int] cast on the
+    # env var throws InvalidCastException with no actionable context when
+    # the env var is set to a non-integer (typo, accidental shell
+    # expansion, etc.) — surface a targeted error message instead.
+    $parsedPort = 0
+    if (-not [int]::TryParse($env:HERMES_WEBUI_PORT, [ref]$parsedPort)) {
+        Write-Error "HERMES_WEBUI_PORT='$($env:HERMES_WEBUI_PORT)' is not a valid integer port. Unset the variable to use the default (8787), or set it to a number 1-65535."
+        exit 1
+    }
+    if ($parsedPort -lt 1 -or $parsedPort -gt 65535) {
+        Write-Error "HERMES_WEBUI_PORT=$parsedPort is out of TCP-port range. Must be 1-65535."
+        exit 1
+    }
+    $parsedPort
+} else {
+    8787
+}
 $env:HERMES_WEBUI_HOST = $BindHostFinal
 $env:HERMES_WEBUI_PORT = "$PortFinal"
 if (-not $env:HERMES_WEBUI_STATE_DIR) {
@@ -147,10 +166,17 @@ if (-not (Test-Path $serverPath)) {
     exit 1
 }
 
+# Capture exit code, let finally{} run Pop-Location, exit AFTER the try.
+# Plain `exit $LASTEXITCODE` inside the try block can prevent the finally
+# from running in some termination paths (especially when dot-sourced or
+# in interactive sessions), leaving the caller's working directory stuck
+# at $RepoRoot.
+$script:serverExitCode = 0
 Push-Location $RepoRoot
 try {
     & $Python $serverPath @args
-    exit $LASTEXITCODE
+    $script:serverExitCode = $LASTEXITCODE
 } finally {
     Pop-Location
 }
+exit $script:serverExitCode

--- a/start.ps1
+++ b/start.ps1
@@ -1,0 +1,142 @@
+<#
+.SYNOPSIS
+    Native Windows launcher for Hermes WebUI - PowerShell equivalent
+    of start.sh, bypassing bootstrap.py's platform refusal.
+
+.DESCRIPTION
+    Mirrors start.sh's discovery: load optional .env, find Python,
+    locate the hermes-agent install, set sensible env defaults, then
+    invoke server.py directly. The bootstrap.py path is skipped
+    because it currently raises on platform.system() == 'Windows';
+    server.py itself runs cleanly on native Windows.
+
+    Assumes Python + hermes-agent + the WebUI Python deps are already
+    installed - same assumption start.sh makes when invoked outside
+    a fresh bootstrap. For first-time setup, run bootstrap.py inside
+    WSL2 once to create the venv, then this script can use that venv.
+
+.PARAMETER Port
+    TCP port the WebUI binds to. Overrides HERMES_WEBUI_PORT env.
+    Default: 8787.
+
+.PARAMETER BindHost
+    Bind address. Overrides HERMES_WEBUI_HOST env.
+    Default: 127.0.0.1.
+
+.EXAMPLE
+    .\start.ps1
+    # Bind to 127.0.0.1:8787, foreground.
+
+.EXAMPLE
+    .\start.ps1 -Port 9000
+    # Bind to 127.0.0.1:9000.
+
+.EXAMPLE
+    $env:HERMES_WEBUI_HOST = '0.0.0.0'
+    .\start.ps1
+    # Bind to all interfaces (set a password first via env or Settings).
+
+.LINK
+    https://github.com/nesquena/hermes-webui/issues/1952
+#>
+
+[CmdletBinding()]
+param(
+    [int]$Port = 0,
+    [string]$BindHost = ''
+)
+
+$ErrorActionPreference = 'Stop'
+$RepoRoot = Split-Path -Parent $PSCommandPath
+
+# === Load .env (mirroring start.sh's filtering) ========================
+$envFile = Join-Path $RepoRoot '.env'
+if (Test-Path $envFile) {
+    foreach ($line in Get-Content $envFile -Encoding UTF8) {
+        $trimmed = $line.Trim()
+        if (-not $trimmed -or $trimmed.StartsWith('#') -or -not $trimmed.Contains('=')) { continue }
+        $kv = $trimmed -split '=', 2
+        $key = ($kv[0].Trim() -replace '^export\s+', '')
+        # Filter out shell-readonly vars (UID, GID, EUID, EGID, PPID) per start.sh
+        if ($key -in @('UID', 'GID', 'EUID', 'EGID', 'PPID')) { continue }
+        if ($key -notmatch '^[A-Za-z_][A-Za-z0-9_]*$') { continue }
+        if ([Environment]::GetEnvironmentVariable($key)) { continue }
+        $val = $kv[1]
+        if ($val -match '^"(.*)"$') { $val = $Matches[1] }
+        elseif ($val -match "^'(.*)'$") { $val = $Matches[1] }
+        [Environment]::SetEnvironmentVariable($key, $val)
+    }
+}
+
+# === Find Python (matches start.sh order) ==============================
+$Python = $env:HERMES_WEBUI_PYTHON
+if (-not $Python) {
+    foreach ($candidate in @('python3', 'python', 'py')) {
+        $cmd = Get-Command $candidate -ErrorAction SilentlyContinue
+        if ($cmd) { $Python = $cmd.Source; break }
+    }
+}
+if (-not $Python) {
+    Write-Error 'Python 3 is required to run server.py (set HERMES_WEBUI_PYTHON or add python to PATH).'
+    exit 1
+}
+
+# === Find Hermes Agent dir (server.py imports from it) =================
+$AgentDir = $env:HERMES_WEBUI_AGENT_DIR
+if (-not $AgentDir) {
+    $candidates = @(
+        (Join-Path $env:USERPROFILE '.hermes\hermes-agent'),
+        (Join-Path (Split-Path -Parent $RepoRoot) 'hermes-agent')
+    )
+    foreach ($c in $candidates) {
+        if (Test-Path (Join-Path $c 'hermes_cli')) { $AgentDir = $c; break }
+    }
+}
+if (-not $AgentDir) {
+    Write-Error 'hermes-agent not found at $env:USERPROFILE\.hermes\hermes-agent or ../hermes-agent. Set HERMES_WEBUI_AGENT_DIR explicitly.'
+    exit 1
+}
+
+# === Prefer the agent's venv Python if available =======================
+$agentVenvPython = Join-Path $AgentDir 'venv\Scripts\python.exe'
+if (Test-Path $agentVenvPython) {
+    $Python = $agentVenvPython
+}
+
+# === Resolve bind + state defaults =====================================
+$BindHostFinal = if ($BindHost) { $BindHost } elseif ($env:HERMES_WEBUI_HOST) { $env:HERMES_WEBUI_HOST } else { '127.0.0.1' }
+$PortFinal = if ($Port) { $Port } elseif ($env:HERMES_WEBUI_PORT) { [int]$env:HERMES_WEBUI_PORT } else { 8787 }
+$env:HERMES_WEBUI_HOST = $BindHostFinal
+$env:HERMES_WEBUI_PORT = "$PortFinal"
+if (-not $env:HERMES_WEBUI_STATE_DIR) {
+    $env:HERMES_WEBUI_STATE_DIR = Join-Path $env:USERPROFILE '.hermes\webui'
+}
+if (-not $env:HERMES_HOME) {
+    $env:HERMES_HOME = Join-Path $env:USERPROFILE '.hermes'
+}
+
+# === Ensure dirs exist =================================================
+New-Item -ItemType Directory -Force -Path $env:HERMES_HOME | Out-Null
+New-Item -ItemType Directory -Force -Path $env:HERMES_WEBUI_STATE_DIR | Out-Null
+
+# === Launch (foreground, matches start.sh) =============================
+Write-Host "[start.ps1] Hermes WebUI native Windows launcher" -ForegroundColor Cyan
+Write-Host "[start.ps1] Python:     $Python"
+Write-Host "[start.ps1] Agent dir:  $AgentDir"
+Write-Host "[start.ps1] State dir:  $env:HERMES_WEBUI_STATE_DIR"
+Write-Host "[start.ps1] Binding:    ${BindHostFinal}:${PortFinal}"
+Write-Host ""
+
+$serverPath = Join-Path $RepoRoot 'server.py'
+if (-not (Test-Path $serverPath)) {
+    Write-Error "server.py not found at $serverPath - is this the hermes-webui repo root?"
+    exit 1
+}
+
+Push-Location $RepoRoot
+try {
+    & $Python $serverPath @args
+    exit $LASTEXITCODE
+} finally {
+    Pop-Location
+}

--- a/start.ps1
+++ b/start.ps1
@@ -85,7 +85,16 @@ if (-not $Python) {
 }
 
 # === Find Hermes Agent dir (server.py imports from it) =================
+# When HERMES_WEBUI_AGENT_DIR is set we still validate it on disk —
+# an explicit override pointing at a missing dir should fail FAST
+# with a clear message, not silently progress into a python3 launch
+# that's about to crash on missing imports. Smoke-test feedback on
+# PR #2783: nesquena/hermes-webui requested this guard.
 $AgentDir = $env:HERMES_WEBUI_AGENT_DIR
+if ($AgentDir -and -not (Test-Path (Join-Path $AgentDir 'hermes_cli'))) {
+    Write-Error "HERMES_WEBUI_AGENT_DIR is set to '$AgentDir' but no hermes_cli/ folder exists there. Unset the variable to fall back to auto-discovery, or fix the path."
+    exit 1
+}
 if (-not $AgentDir) {
     $candidates = @(
         (Join-Path $env:USERPROFILE '.hermes\hermes-agent'),

--- a/start.ps1
+++ b/start.ps1
@@ -174,7 +174,13 @@ if (-not (Test-Path $serverPath)) {
 $script:serverExitCode = 0
 Push-Location $RepoRoot
 try {
-    & $Python $serverPath @args
+    # @args was non-functional here — PowerShell does NOT populate $args when the
+    # script declares [CmdletBinding()] with an explicit param() block (Copilot's
+    # finding on PR #2807). Dropped rather than added a ValueFromRemainingArguments
+    # parameter, because the existing tracked use case is the launcher running
+    # server.py with the env-var-driven config — no pass-through args are needed.
+    # If pass-through becomes a requirement later, add a [Parameter(ValueFromRemainingArguments=$true)] [string[]]$ServerArgs and splat that.
+    & $Python $serverPath
     $script:serverExitCode = $LASTEXITCODE
 } finally {
     Pop-Location

--- a/start.ps1
+++ b/start.ps1
@@ -60,7 +60,10 @@ if (Test-Path $envFile) {
         # Filter out shell-readonly vars (UID, GID, EUID, EGID, PPID) per start.sh
         if ($key -in @('UID', 'GID', 'EUID', 'EGID', 'PPID')) { continue }
         if ($key -notmatch '^[A-Za-z_][A-Za-z0-9_]*$') { continue }
-        if ([Environment]::GetEnvironmentVariable($key)) { continue }
+        # Explicit $null check — an env var explicitly set to '' should still
+        # be considered "set" and NOT overridden by .env (empty string is
+        # falsey in PowerShell, so a plain truthy check would mis-skip).
+        if ($null -ne [Environment]::GetEnvironmentVariable($key)) { continue }
         $val = $kv[1]
         if ($val -match '^"(.*)"$') { $val = $Matches[1] }
         elseif ($val -match "^'(.*)'$") { $val = $Matches[1] }
@@ -93,7 +96,9 @@ if (-not $AgentDir) {
     }
 }
 if (-not $AgentDir) {
-    Write-Error 'hermes-agent not found at $env:USERPROFILE\.hermes\hermes-agent or ../hermes-agent. Set HERMES_WEBUI_AGENT_DIR explicitly.'
+    $expectedPrimary = Join-Path $env:USERPROFILE '.hermes\hermes-agent'
+    $expectedSibling = Join-Path (Split-Path -Parent $RepoRoot) 'hermes-agent'
+    Write-Error "hermes-agent not found at $expectedPrimary or $expectedSibling. Set HERMES_WEBUI_AGENT_DIR explicitly."
     exit 1
 }
 


### PR DESCRIPTION
## Thinking Path

- Hermes WebUI aims for actionable error messages on misconfiguration + clean cleanup on exit
- PR #2783 added `start.ps1` with two patterns Copilot's review on the docs follow-up #2806 flagged as concerns:
  - `[int]$env:HERMES_WEBUI_PORT` cast that throws InvalidCastException with no context on bad input
  - `exit $LASTEXITCODE` inside a `try` block, which can prevent the `finally` from running on some termination paths
- Both concerns are real, both touch lines from #2783's scope rather than #2806's docs change
- Per the maintainer's "keep diffs focused" guidance ([#2783 review thread](https://github.com/nesquena/hermes-webui/pull/2783#issuecomment-4525735230)), splitting this into a focused follow-up hardening PR rather than expanding #2806's scope

## What Changed

`start.ps1` only. Two surgical fixes:

### Fix 1 — TryParse + range guard on `HERMES_WEBUI_PORT`

Before (line 122):

```powershell
$PortFinal = if ($Port) { $Port }
             elseif ($env:HERMES_WEBUI_PORT) { [int]$env:HERMES_WEBUI_PORT }
             else { 8787 }
```

- Throws `InvalidCastException` with no actionable context on non-integer values (typo, accidental shell expansion, etc.)
- Doesn't range-check — `HERMES_WEBUI_PORT=99999` would pass and then fail at the network layer with a confusing socket-bind error

After:

```powershell
$PortFinal = if ($Port) {
    $Port
} elseif ($env:HERMES_WEBUI_PORT) {
    $parsedPort = 0
    if (-not [int]::TryParse($env:HERMES_WEBUI_PORT, [ref]$parsedPort)) {
        Write-Error "HERMES_WEBUI_PORT='$($env:HERMES_WEBUI_PORT)' is not a valid integer port. Unset the variable to use the default (8787), or set it to a number 1-65535."
        exit 1
    }
    if ($parsedPort -lt 1 -or $parsedPort -gt 65535) {
        Write-Error "HERMES_WEBUI_PORT=$parsedPort is out of TCP-port range. Must be 1-65535."
        exit 1
    }
    $parsedPort
} else {
    8787
}
```

Each failure mode gets a targeted `Write-Error` naming the offending value and the remedy.

### Fix 2 — exit AFTER try/finally cleanup

Before (lines 152-156):

```powershell
Push-Location $RepoRoot
try {
    & $Python $serverPath @args
    exit $LASTEXITCODE
} finally {
    Pop-Location
}
```

`exit` inside a `try` block can prevent the `finally` from running on some termination paths (notably when the script is dot-sourced, or invoked from an interactive PowerShell session, or when certain shell harnesses intercept the exit). Result: caller stuck at `$RepoRoot` instead of their original working directory.

After:

```powershell
$script:serverExitCode = 0
Push-Location $RepoRoot
try {
    & $Python $serverPath @args
    $script:serverExitCode = $LASTEXITCODE
} finally {
    Pop-Location
}
exit $script:serverExitCode
```

Capture the exit code, let `finally` run cleanup, exit AFTER the try/finally completes.

Diff: `start.ps1 | 30 ++++++++++++++++++++++++++++--` (28 insertions, 2 deletions).

## Why It Matters

Both errors today produce confusing failure modes that send a user down the wrong debugging path:

- **Bad port**: user sees `Cannot convert value "abc" to type "System.Int32"` from PowerShell's runtime, not "your env var is wrong." A user who set `HERMES_WEBUI_PORT` to something via copy-paste error spends time looking at PowerShell internals instead of fixing the env var.
- **Stuck working directory**: user dot-sources `start.ps1` from their interactive shell to test config quickly, the script exits cleanly (no error), but their cwd is now the hermes-webui repo root. Subsequent commands in the same session run against the wrong directory.

Both fixes are surgical, no behavior change for the happy path (valid port, normal exit). Misconfigured + edge-case paths now fail gracefully + reversibly.

## Verification

Smoke-tested all three port-error paths on a Windows 11 Pro foundry-side workstation (PowerShell 7.5.4) against the modified `start.ps1`:

```
HERMES_WEBUI_AGENT_DIR override set to bypass agent-discovery
(this branch is based on #2783's 2-path candidate list; the
hardening fix itself is orthogonal to discovery — #2805 expands
the list, this PR is independent of that)

Test A: HERMES_WEBUI_PORT='abc'   -> exit 1 + 'not a valid integer port'  PASS
Test B: HERMES_WEBUI_PORT='99999' -> exit 1 + 'out of TCP-port range'     PASS
Test C: HERMES_WEBUI_PORT='0'     -> exit 1 + 'out of TCP-port range'     PASS
```

Captured error output (Test A excerpt):

> `HERMES_WEBUI_PORT='abc' is not a valid integer port. Unset the variable to use the default (8787), or set it to a number 1-65535.`

For Test 2 (exit-after-finally), the change is structurally observable in code — captured exit code, finally runs Pop-Location unconditionally, exit happens after the block. No regression risk; the happy path (server.py exits cleanly) produces the same caller-visible exit code as before.

- [x] `start.ps1` parses clean via `[System.Management.Automation.Language.Parser]::ParseFile` — zero errors
- [x] Three port-error smoke tests pass with the new TryParse + range guard
- [x] Anchor-based edits (no line-number drift if surrounding code shifts later)
- [ ] Optional follow-up: full E2E inside Windows Sandbox (foundry/tools/sandbox/) once hermes-webui requirements.txt installs cleanly — can post a Lighthouse-on-the-served-page screenshot if useful evidence

## Risks / Follow-ups

- **No happy-path behavior change.** Valid `HERMES_WEBUI_PORT` values still work identically. Default 8787 unchanged. Server-exit-code semantics unchanged for the normal-completion case.
- **Stacking.** Branched from `feat/native-windows-support` (#2783) because the lines being fixed live in #2783's `start.ps1`. PR targets `master`. Once #2783 lands, this rebases cleanly — additive changes only, no overlap with #2783's content beyond the two specific patterns flagged.
- **Closes the last two Copilot threads on #2806** (about L128 `[int]` cast and L162 `exit`-in-try). Those threads will be cross-linked + resolved once this PR is filed.
- **No security-sensitive surface touched.** TryParse + range check is strictly defensive; the exit-after-finally refactor preserves all observable behavior on the happy path.

## Model Used

- **Provider:** Anthropic
- **Exact model:** Claude 4.7 (Sonnet, 1M context)
- **Mode:** Used to author the TryParse + range-guard rewrite, the exit-after-finally refactor, smoke-test execution (three port-error scenarios on PowerShell 7.5.4 with `HERMES_WEBUI_AGENT_DIR` override), and this PR description. Anchor-based edits were verified via `[regex]::Escape` match-once-or-fail. `start.ps1` re-parsed via the PowerShell language parser after both edits. Final human review before push.