### PR TITLE
feat: echo clarify user choice as visible message in conversation

### DIFF
--- a/static/messages.js
+++ b/static/messages.js
@@ -2804,6 +2804,16 @@ async function respondClarify(response) {
         _clarifyId = null;
         _clearClarifyPendingForSession(sid);
         hideClarifyCard(true, 'sent');
+        // Echo the user's clarify choice as a visible message in the conversation
+        if (S.session && S.session.session_id === sid) {
+          S.messages.push({
+            role: 'user',
+            content: value,
+            _clarify_response: true,
+            _ts: Date.now() / 1000,
+          });
+          if (typeof renderMessages === 'function') renderMessages({preserveScroll: true});
+        }
       }
     } else {
       // Stale / expired / wrong session — keep the card and draft visible.


### PR DESCRIPTION
After the user responds to a clarify prompt, insert a synthetic user message into the conversation showing their choice. This makes the clarify interaction visible in the chat history, which was previously only shown in the transient clarify dialog card.

The message is marked with _clarify_response: true so downstream consumers can distinguish it from regular user messages if needed.