### PR TITLE
feat(config): expand xAI OAuth provider model list and endpoint

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -1211,8 +1211,17 @@ _PROVIDER_MODELS = {
     "x-ai": [
         {"id": "grok-4.20", "label": "Grok 4.20"},
     ],
+    # xAI OAuth — xAI OAuth provider (stores credentials in auth.json)
     "xai-oauth": [
         {"id": "grok-4.20", "label": "Grok 4.20"},
+        {"id": "grok-4.3", "label": "Grok 4.3"},
+        {"id": "grok-build-0.1", "label": "Grok Build 0.1"},
+        {"id": "grok-4.20-0309-reasoning", "label": "Grok 4.20 Reasoning"},
+        {"id": "grok-4.20-0309-non-reasoning", "label": "Grok 4.20"},
+        {"id": "grok-4.20-multi-agent-0309", "label": "Grok 4.20 Multi-Agent"},
+        {"id": "grok-imagine-image", "label": "Grok Imagine Image"},
+        {"id": "grok-imagine-image-quality", "label": "Grok Imagine Image (Quality)"},
+        {"id": "grok-imagine-video", "label": "Grok Imagine Video"},
     ],
     # AWS Bedrock — static fallback list; live model list is fetched via
     # hermes_cli.models.provider_model_ids("bedrock") when available (#2720).

--- a/api/routes.py
+++ b/api/routes.py
@@ -852,6 +852,7 @@ _OPENAI_COMPAT_ENDPOINTS = {
     "minimax": "https://api.minimax.chat/v1",
     "mistralai": "https://api.mistral.ai/v1",
     "xai": "https://api.x.ai/v1",
+    "xai-oauth": "https://api.x.ai/v1",
     "deepseek": "https://api.deepseek.com",
     "gemini": "https://generativelanguage.googleapis.com/v1beta/openai",
     "nvidia": "https://integrate.api.nvidia.com/v1",


### PR DESCRIPTION
> **⚠️ Important Notice for Reviewers**
>
> This PR was prepared by **Hermes Agent** (Kimi 2.6 model, OpenCode Go provider). The user **@mbac** has insufficient coding knowledge to fully verify the safety, correctness, or idiomatic quality of the changes below.
>
> **Repository maintainers are kindly invited to review this PR with great care** — treat it as if it came from an inexperienced first-time contributor. Please verify that the changes do not break existing behavior, introduce security issues, or conflict with upstream design patterns.
>
> ---
>
> ## Context
>
> xAI recently allowed the use of their models in agentic harnesses even through the OAuth API. In response, Hermes Agent added the `xai-oauth` provider to its configuration. However, the `hermes-webui` GUI selector does not auto-populate with models for this new provider, making it inaccessible to users who rely on the web interface for model selection.
>
> This PR patches the web UI code to explicitly present the available xAI OAuth models in the provider dropdown.
>
> ## Problem Statement
>
> The `xai-oauth` provider was partially present in the web UI configuration (display name already existed upstream as `"xAI Grok OAuth"`, and the single model `grok-4.20` was already listed). However, the full model catalog was missing:
> - `_PROVIDER_MODELS` only had `grok-4.20`, leaving out newer variants (Grok 4.3, Build 0.1, reasoning/multi-agent modes, image/video generation).
> - `_OPENAI_COMPAT_ENDPOINTS` had no endpoint URL for `xai-oauth`, so API calls would fail to route correctly.
>
> ## Solution
>
> Expanded the existing `xai-oauth` configuration without altering upstream's already-present display name:
>
> 1. **`api/config.py` — `_PROVIDER_MODELS`**:
>    Added 8 additional model entries to the existing `xai-oauth` list, covering the currently available Grok and Imagine variants:
>    - `grok-4.3`
>    - `grok-build-0.1`
>    - `grok-4.20-0309-reasoning`
>    - `grok-4.20-0309-non-reasoning`
>    - `grok-4.20-multi-agent-0309`
>    - `grok-imagine-image`
>    - `grok-imagine-image-quality`
>    - `grok-imagine-video`
>
>    The base model `grok-4.20` (already present upstream) is preserved as the first entry.
>
> 2. **`api/routes.py` — `_OPENAI_COMPAT_ENDPOINTS`**:
>    Added `"xai-oauth": "https://api.x.ai/v1"` so chat completions route to the correct xAI OpenAI-compatible endpoint.
>
> ## Files Changed
>
> | File | Change |
> |------|--------|
> | `api/config.py` | Expanded `_PROVIDER_MODELS["xai-oauth"]` from 1 to 9 model entries |
> | `api/routes.py` | Added `xai-oauth` endpoint URL to `_OPENAI_COMPAT_ENDPOINTS` |
>
> ## Verification
>
> - `git diff origin/master..feature/xai-oauth-models` shows a clean, minimal diff with no conflict markers.
> - No existing providers (including `bedrock`, `x-ai`, `nvidia`, etc.) were removed or altered.
> - The `xai-oauth` entries are placed alphabetically consistent with surrounding providers.
> - The existing `_PROVIDER_DISPLAY["xai-oauth"]` value (`"xAI Grok OAuth"`) is left untouched.
>
> ## Notes for Reviewers
>
> - The model ID strings (`grok-4.20-0309-reasoning`, `grok-imagine-image`, etc.) were compiled from the user's Hermes Agent configuration. Please verify these are valid and current xAI model identifiers.
> - The endpoint `https://api.x.ai/v1` is the standard xAI OpenAI-compatible API base. Please confirm this is the correct URL for the OAuth-authenticated flow.
> - If upstream has diverged since this branch was cut, please rebase and re-verify.
