### PR TITLE
feat: add shutdown button to WebUI title bar

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -3426,12 +3426,13 @@ def _serve_shell_unavailable(handler, exc: Exception) -> bool:
 def _handle_shutdown(handler) -> bool:
     """Shut down the WebUI server process."""
     j(handler, {"status": "shutting_down"})
+    import signal
     import threading
 
     def _do_shutdown():
         import time
         time.sleep(0.3)
-        os._exit(0)
+        os.kill(os.getpid(), signal.SIGINT)
 
     threading.Thread(target=_do_shutdown, daemon=True).start()
     return True
@@ -4621,8 +4622,6 @@ def handle_post(handler, parsed) -> bool:
         finally:
             if diag:
                 diag.finish()
-    if parsed.path == "/api/shutdown":
-        return _handle_shutdown(handler)
     # CSRF: reject cross-origin or tokenless authenticated browser requests.
     # /api/auth/login has no authenticated session token yet, and /api/csp-report
     # is intentionally unauthenticated for browser-generated violation reports.
@@ -4634,6 +4633,9 @@ def handle_post(handler, parsed) -> bool:
         finally:
             if diag:
                 diag.finish()
+
+    if parsed.path == "/api/shutdown":
+        return _handle_shutdown(handler)
 
     if parsed.path == "/api/upload":
         return handle_upload(handler)

--- a/api/routes.py
+++ b/api/routes.py
@@ -3423,6 +3423,20 @@ def _serve_shell_unavailable(handler, exc: Exception) -> bool:
     return True
 
 
+def _handle_shutdown(handler) -> bool:
+    """Shut down the WebUI server process."""
+    j(handler, {"status": "shutting_down"})
+    import threading
+
+    def _do_shutdown():
+        import time
+        time.sleep(0.3)
+        os._exit(0)
+
+    threading.Thread(target=_do_shutdown, daemon=True).start()
+    return True
+
+
 def _serve_manifest(handler) -> bool:
     """Serve static/manifest.json with the correct PWA Content-Type.
 
@@ -4607,6 +4621,8 @@ def handle_post(handler, parsed) -> bool:
         finally:
             if diag:
                 diag.finish()
+    if parsed.path == "/api/shutdown":
+        return _handle_shutdown(handler)
     # CSRF: reject cross-origin or tokenless authenticated browser requests.
     # /api/auth/login has no authenticated session token yet, and /api/csp-report
     # is intentionally unauthenticated for browser-generated violation reports.

--- a/static/boot.js
+++ b/static/boot.js
@@ -1,3 +1,13 @@
+(function(){
+  // Clear stale stop-server flag on successful page load (server is reachable)
+  localStorage.removeItem('hermes-webui-server-stopped');
+  // Listen for shutdown broadcast from other tabs
+  try {
+    var _stopChan = new BroadcastChannel('hermes-webui-shutdown');
+    _stopChan.onmessage = function() { _showServerStopped(); };
+  } catch(_) {}
+})();
+
 async function cancelStream(){
   const streamId = S.activeStreamId;
   if(!streamId) return;
@@ -1782,3 +1792,15 @@ window.addEventListener('pageshow', async (event) => {
     } catch (_) {}
   }
 });
+
+async function shutdownServer() {
+  if (!confirm('Stop the Hermes WebUI server?')) return;
+  localStorage.setItem('hermes-webui-server-stopped', '1');
+  try { var bc = new BroadcastChannel('hermes-webui-shutdown'); bc.postMessage('stop'); bc.close(); } catch(_) {}
+  _showServerStopped();
+  try { await fetch('/api/shutdown', { method: 'POST' }); } catch (_) {}
+}
+
+function _showServerStopped() {
+  document.body.innerHTML = '<div style="display:flex;align-items:center;justify-content:center;height:100vh;color:var(--muted);font-family:system-ui,ui-sans-serif;font-size:14px"><p>Server stopped. You can close this tab.</p></div>';
+}

--- a/static/boot.js
+++ b/static/boot.js
@@ -1794,11 +1794,17 @@ window.addEventListener('pageshow', async (event) => {
 });
 
 async function shutdownServer() {
-  if (!confirm('Stop the Hermes WebUI server?')) return;
+  const ok = await showConfirmDialog({
+    title: 'Stop Hermes WebUI',
+    message: 'Stop the Hermes WebUI server?',
+    confirmLabel: 'Stop',
+    danger: true,
+  });
+  if (!ok) return;
   localStorage.setItem('hermes-webui-server-stopped', '1');
   try { var bc = new BroadcastChannel('hermes-webui-shutdown'); bc.postMessage('stop'); bc.close(); } catch(_) {}
   _showServerStopped();
-  try { await fetch('/api/shutdown', { method: 'POST' }); } catch (_) {}
+  try { await api('/api/shutdown', { method: 'POST' }); } catch (_) {}
 }
 
 function _showServerStopped() {

--- a/static/index.html
+++ b/static/index.html
@@ -144,6 +144,12 @@
       <path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/>
     </svg>
   </button>
+  <button class="app-titlebar-shutdown has-tooltip has-tooltip--left" id="btnShutdown" onclick="shutdownServer()" type="button" data-tooltip="Stop server" aria-label="Stop Hermes WebUI">
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <path d="M18.36 6.64a9 9 0 1 1-12.73 0"/>
+      <line x1="12" y1="2" x2="12" y2="12"/>
+    </svg>
+  </button>
 </header>
 <div class="layout">
   <nav class="rail" aria-label="Primary navigation">

--- a/static/style.css
+++ b/static/style.css
@@ -653,6 +653,8 @@
     /* Reload button — visible only in PWA standalone / fullscreen */
     .app-titlebar-reload{display:none;align-items:center;justify-content:center;width:32px;height:32px;flex-shrink:0;background:none;border:none;color:var(--muted);border-radius:8px;cursor:pointer;padding:0;-webkit-tap-highlight-color:transparent;transition:background-color .15s,color .15s;}
     .app-titlebar-reload:hover{background:var(--hover-bg);color:var(--text);}
+    .app-titlebar-shutdown{display:inline-flex;align-items:center;justify-content:center;width:32px;height:32px;flex-shrink:0;background:transparent;border:none;color:var(--muted);border-radius:8px;cursor:pointer;padding:0;margin-left:auto;-webkit-tap-highlight-color:transparent;-webkit-app-region:no-drag;transition:background-color .15s,color .15s;}
+    .app-titlebar-shutdown:hover{background:var(--hover-bg);color:var(--danger,#e74c3c);}
     @media (display-mode: standalone), (display-mode: fullscreen){
       :root{--app-titlebar-safe-top:env(safe-area-inset-top,0px);}
       .app-titlebar-reload{display:inline-flex;}


### PR DESCRIPTION
## Thinking Path
- Hermes WebUI currently has no way to stop the server from the browser UI
- Users must switch to terminal and run ctl.sh stop or kill the process
- A title-bar button would make local dev / restart workflows smoother
→ Add a shutdown button with confirm prompt and cross-tab notification

## What Changed
- `api/routes.py`: +16 lines, `POST /api/shutdown` endpoint with threaded
  `os._exit(0)` after a 0.3s delay for response delivery
- `static/boot.js`: +22 lines, `shutdownServer()` with `confirm()` prompt,
  `BroadcastChannel` cross-tab notification, and `_showServerStopped()`
  placeholder page
- `static/index.html`: +6 lines, ⏻ SVG button in title bar (after reload
  button), with tooltip and aria-label
- `static/style.css`: +2 lines, `.app-titlebar-shutdown` styles matching
  the reload button pattern, hover turns red via `var(--danger)`

## Verification
- Shutdown button appears in title bar on desktop layout
- Click → confirm dialog → server stops gracefully
- Other open tabs receive BroadcastChannel message and show
  "Server stopped" placeholder instead of error spinner
- Page reload after restart clears the stopped flag and returns to normal
- Tested on macOS Chrome

  ### Screen Shot
  **click here**
  <img width="3840" height="2100" alt="image" src="https://github.com/user-attachments/assets/9dca7ebc-3e62-47ea-b116-c5023a1084e0" />
  **done**
  <img width="3840" height="2100" alt="image" src="https://github.com/user-attachments/assets/6d3a3452-da0b-4cfd-9c1d-ae4a99e0da38" />


## Model Used
DeepSeek V4 Pro (via Hermes Agent) — AI-assisted development