### PR TITLE
fix(webui): keep context-engine guidance model-facing

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -69,6 +69,91 @@ _MESSAGING_SESSION_METADATA_CACHE: dict[str, object] = {
 }
 _MESSAGING_SESSION_METADATA_LOCK = threading.Lock()
 _STALE_MESSAGING_END_REASONS = {"session_reset", "session_switch"}
+
+
+def _webui_manual_compression_system_message(session) -> str:
+    workspace = getattr(session, "workspace", None) or ""
+    return (
+        f"Active workspace at session start: {workspace}\n"
+        "Every user message is prefixed with [Workspace::v1: /absolute/path] indicating the "
+        "workspace the user has selected in the web UI at the time they sent that message. "
+        "This tag is the single authoritative source of the active workspace and updates "
+        "with every message. It overrides any prior workspace mentioned in this system "
+        "prompt, memory, or conversation history. Always use the value from the most recent "
+        "[Workspace::v1: ...] tag as your default working directory for ALL file operations: "
+        "write_file, read_file, search_files, terminal workdir, and patch. "
+        "Never fall back to a hardcoded path when this tag is present."
+    )
+
+
+def _split_model_context_for_display(messages):
+    """Return (display_messages, model_context) for compressor output.
+
+    Context engines may inject model-facing guidance by returning a leading
+    system message when WebUI provides a synthetic system anchor. Keep that
+    guidance in context_messages, but do not render it as a transcript turn.
+    """
+    model_context = list(messages or [])
+    display_messages = list(model_context)
+    if display_messages and isinstance(display_messages[0], dict) and display_messages[0].get("role") == "system":
+        display_messages = display_messages[1:]
+    return display_messages, model_context
+
+
+def _message_text_for_context_policy(message):
+    if not isinstance(message, dict):
+        return ""
+    content = message.get("content", "")
+    if isinstance(content, list):
+        return "\n".join(
+            str(part.get("text") or part.get("content") or "")
+            for part in content
+            if isinstance(part, dict)
+        )
+    return str(content or "")
+
+
+def _context_has_lcm_retrieval_policy(messages):
+    return any(
+        "LCM retrieval policy" in _message_text_for_context_policy(message)
+        or "Use lcm_grep" in _message_text_for_context_policy(message)
+        for message in messages or []
+    )
+
+
+def _looks_like_lcm_model_context(messages):
+    for message in messages or []:
+        text = _message_text_for_context_policy(message)
+        if "[Recent Summary" in text or "[Session Arc Summary" in text:
+            return True
+        if "[Expand for details" in text and "node" in text:
+            return True
+    return False
+
+
+def _ensure_lcm_retrieval_policy_model_context(messages, context_engine=None):
+    """Add WebUI-only model-facing LCM retrieval guidance when absent.
+
+    WebUI keeps its system prompt outside persisted conversation history, so
+    LCM's normal system-message note can be missing even though summaries are
+    present. Keep this as model context only; callers strip it from display.
+    """
+    model_context = list(messages or [])
+    engine_name = str(context_engine or "").lower()
+    if engine_name != "lcm" and not _looks_like_lcm_model_context(model_context):
+        return model_context
+    if _context_has_lcm_retrieval_policy(model_context):
+        return model_context
+    policy = (
+        "[LCM retrieval policy: Earlier turns have been compacted into "
+        "retrieval-backed summaries. Before relying on compacted history, use "
+        "lcm_grep to search, lcm_describe to inspect candidate nodes, and "
+        "lcm_expand to recover original details. Pass exactly one identifier "
+        "to lcm_expand (node_id, store_id, or externalized_ref); do not pass "
+        "empty identifiers or store_id=0.]"
+    )
+    return [{"role": "system", "content": policy}, *model_context]
+
 _CSP_REPORT_LOGGER = logging.getLogger("csp_report")
 _CSP_REPORT_RATE_LIMIT: dict[str, list[float]] = {}
 _CSP_REPORT_RATE_LIMIT_LOCK = threading.Lock()
@@ -10550,6 +10635,7 @@ def _run_manual_compression_job(sid, body):
                 )
 
 
+
 def _handle_session_compress_start(handler, body):
     try:
         require(body, "session_id")
@@ -10825,6 +10911,10 @@ def _handle_session_compress(handler, body):
         # Lock contract: hold for the in-memory mutation only, never across
         # network I/O.
         original_messages = list(messages)
+        compression_input_messages = [
+            {"role": "system", "content": _webui_manual_compression_system_message(s)},
+            *original_messages,
+        ]
         original_stream_state = (
             getattr(s, "active_stream_id", None),
             getattr(s, "pending_user_message", None),
@@ -10845,12 +10935,18 @@ def _handle_session_compress(handler, body):
             enabled_toolsets=_resolve_cli_toolsets(),
             session_id=sid,
         )
-        compressed = agent.context_compressor.compress(
-            original_messages,
+        compressed_context = agent.context_compressor.compress(
+            compression_input_messages,
             current_tokens=approx_tokens,
             focus_topic=focus_topic,
         )
-        new_tokens = _estimate_messages_tokens_rough(compressed)
+        compressor_name = getattr(agent.context_compressor, "name", None)
+        compressed_context = _ensure_lcm_retrieval_policy_model_context(
+            compressed_context,
+            compressor_name or getattr(s, "context_engine", None),
+        )
+        compressed, compressed_context = _split_model_context_for_display(compressed_context)
+        new_tokens = _estimate_messages_tokens_rough(compressed_context)
         summary = _summarize_manual_compression(
             original_messages,
             compressed,
@@ -10874,7 +10970,7 @@ def _handle_session_compress(handler, body):
                 return bad(handler, "Session was modified during compression; please retry.", 409)
 
             s.messages = compressed
-            s.context_messages = compressed
+            s.context_messages = compressed_context
             s.tool_calls = []
             s.active_stream_id = None
             s.pending_user_message = None

--- a/tests/test_sprint46.py
+++ b/tests/test_sprint46.py
@@ -48,9 +48,12 @@ class _FakeCompressor:
                 "focus_topic": focus_topic,
             }
         )
-        if len(messages) >= 2:
-            return [messages[0], messages[-1]]
-        return list(messages)
+        display_messages = list(messages)
+        if display_messages and display_messages[0].get("role") == "system":
+            display_messages = display_messages[1:]
+        if len(display_messages) >= 2:
+            return [display_messages[0], display_messages[-1]]
+        return display_messages
 
 
 class _FakeAgent:
@@ -160,6 +163,76 @@ def test_session_compress_roundtrip(monkeypatch, cleanup_test_sessions):
     assert _FakeAgent.last_instance.context_compressor.calls[0]["focus_topic"] == "database schema"
 
 
+
+def test_lcm_policy_helper_injects_model_facing_policy_for_summary_context():
+    import api.routes as routes
+
+    context = [
+        {"role": "assistant", "content": "[Recent Summary (d0, node 7)] compacted history"},
+        {"role": "user", "content": "latest"},
+    ]
+
+    out = routes._ensure_lcm_retrieval_policy_model_context(context, "lcm")
+
+    assert out[0]["role"] == "system"
+    assert "LCM retrieval policy" in out[0]["content"]
+    assert "lcm_grep" in out[0]["content"]
+    assert "store_id=0" in out[0]["content"]
+    assert out[1:] == context
+
+
+def test_lcm_policy_helper_is_idempotent_and_avoids_non_lcm_context():
+    import api.routes as routes
+
+    non_lcm = [{"role": "user", "content": "plain history"}]
+    assert routes._ensure_lcm_retrieval_policy_model_context(non_lcm, "builtin") == non_lcm
+
+    existing = [
+        {"role": "system", "content": "[LCM retrieval policy: Use lcm_grep.]"},
+        {"role": "assistant", "content": "[Recent Summary (d0, node 7)] compacted history"},
+    ]
+    assert routes._ensure_lcm_retrieval_policy_model_context(existing, "lcm") == existing
+
+
+def test_session_compress_keeps_engine_system_guidance_model_facing_only(monkeypatch, cleanup_test_sessions):
+    class GuidanceCompressor:
+        def compress(self, messages, current_tokens=None, focus_topic=None):
+            assert messages and messages[0]["role"] == "system"
+            assert "Active workspace at session start" in messages[0]["content"]
+            return [
+                {
+                    "role": "system",
+                    "content": messages[0]["content"]
+                    + "\n\n[LCM retrieval policy: Use lcm_grep before relying on compacted summaries.]",
+                },
+                {"role": "assistant", "content": "[Recent Summary (d0, node 7)] old context"},
+                messages[-1],
+            ]
+
+    class GuidanceAgent:
+        def __init__(self, **kwargs):
+            self.context_compressor = GuidanceCompressor()
+
+    created = cleanup_test_sessions
+    sid = _make_session()
+    created.append(sid)
+    _install_fake_compression_runtime(monkeypatch, GuidanceAgent)
+
+    handler = _FakeHandler()
+    _handle_session_compress(handler, {"session_id": sid})
+
+    assert handler.status == 200
+    loaded = get_session(sid)
+    assert loaded.messages == [
+        {"role": "assistant", "content": "[Recent Summary (d0, node 7)] old context"},
+        {"role": "assistant", "content": "four"},
+    ]
+    assert loaded.context_messages[0]["role"] == "system"
+    assert "LCM retrieval policy" in loaded.context_messages[0]["content"]
+    payload = handler.payload()
+    assert all(m.get("role") != "system" for m in payload["session"]["messages"])
+
+
 def test_session_compress_start_is_async_and_reuses_running_job(monkeypatch, cleanup_test_sessions):
     import api.routes as routes
 
@@ -175,7 +248,10 @@ def test_session_compress_start_is_async_and_reuses_running_job(monkeypatch, cle
             self.calls.append({"messages": list(messages), "focus_topic": focus_topic})
             self.entered.set()
             assert self.release.wait(timeout=5), "test timed out waiting to release compression"
-            return [messages[0], messages[-1]]
+            display_messages = list(messages)
+            if display_messages and display_messages[0].get("role") == "system":
+                display_messages = display_messages[1:]
+            return [display_messages[0], display_messages[-1]]
 
     class BlockingAgent:
         instances = []


### PR DESCRIPTION
## Summary

This PR makes WebUI preserve context-engine guidance as model-facing context after manual compression, without rendering that guidance in the visible transcript.

The motivating case is LCM/retrieval-backed compression: WebUI can successfully persist compacted summaries such as `[Recent Summary ...]`, but because WebUI keeps its system prompt separate from `conversation_history`, context engines that attach guidance to a leading system message may not have a stable model-facing place to put retrieval instructions. The next model turn can then see compacted summaries without the policy that tells it to recover exact details through retrieval tools.

## Why this happens

WebUI has a split that the CLI/core path does not expose in the same way:

- `messages`: user-visible transcript
- `context_messages`: model-facing active context
- `system_message`: passed separately to `run_conversation(...)`

The manual compression path previously compressed only the transcript messages and then wrote the returned list to both display and model context. That works for plain summarization, but it loses the context-engine contract for engines that need to return model-facing guidance, especially when the guidance is attached to a leading system message.

For retrieval-backed summaries, this is risky: summaries are useful routing/index hints, not a complete source of exact historical facts. The model should be reminded to use retrieval before relying on compacted history.

## Fix

- Add a synthetic WebUI system anchor before manual compression so context engines have a stable place for model-facing guidance.
- Treat compressor output as the canonical model-facing context.
- Split compressor output into:
  - `context_messages`: preserves leading system guidance for the model
  - `messages`: strips leading system guidance so it is not rendered as a visible transcript turn
- Add a minimal LCM fallback policy when the returned model context is LCM-like but lacks retrieval guidance.
  - The fallback is model-facing only.
  - It is idempotent.
  - It avoids non-LCM/plain contexts.

## Tests

- `tests/test_sprint46.py::test_lcm_policy_helper_injects_model_facing_policy_for_summary_context`
- `tests/test_sprint46.py::test_lcm_policy_helper_is_idempotent_and_avoids_non_lcm_context`
- `tests/test_sprint46.py::test_session_compress_keeps_engine_system_guidance_model_facing_only`
- `tests/test_sprint46.py::test_session_compress_roundtrip`

Local focused run:

```text
4 passed
```
