### PR TITLE
fix(workspace): fallback for large markdown previews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Workspace Markdown previews now fall back to the plain-text viewer for large `.md` files (>64 KB or >1500 lines) instead of synchronously running the full Markdown renderer on the browser main thread. The raw content remains available for Edit mode, while smaller Markdown files still render richly as before.
+
 ## [v0.51.124] — 2026-05-24 — Release CV (stage-batch6 — 3-PR Windows-only stack — agent paths / docs / port hardening)
 
 ### Added

--- a/static/workspace.js
+++ b/static/workspace.js
@@ -189,6 +189,8 @@ function fileExt(p){ const i=p.lastIndexOf('.'); return i>=0?p.slice(i).toLowerC
 let _previewCurrentPath = '';  // relative path of currently previewed file
 let _previewCurrentMode = '';  // 'code' | 'md' | 'image' | 'html' | 'pdf' | 'audio' | 'video'
 let _previewDirty = false;     // true when edits are unsaved
+const LARGE_MARKDOWN_PREVIEW_BYTES = 64 * 1024;
+const LARGE_MARKDOWN_PREVIEW_LINES = 1500;
 
 function showPreview(mode){
   // mode: 'code' | 'image' | 'md' | 'html' | 'pdf' | 'audio' | 'video'
@@ -314,12 +316,23 @@ async function openFile(path){
       frame.title=`PDF preview: ${path.split('/').pop()||path}`;
     }
   } else if(MD_EXTS.has(ext)){
-    // Markdown: fetch text, render with renderMd, display as formatted HTML
+    // Markdown: fetch text, render with renderMd, display as formatted HTML.
+    // Large markdown files can make renderMd() block the main thread, so fall
+    // back to the plain text preview while keeping raw content available for Edit.
     try{
       const data=await api(`/api/file?session_id=${encodeURIComponent(S.session.session_id)}&path=${encodeURIComponent(path)}`);
+      const content = data.content || '';
+      _previewRawContent = content;
+      const sizeBytes = new Blob([content]).size;
+      const lineCount = content.split('\n').length;
+      if(sizeBytes > LARGE_MARKDOWN_PREVIEW_BYTES || lineCount > LARGE_MARKDOWN_PREVIEW_LINES){
+        showPreview('code');
+        $('previewCode').textContent = content;
+        setStatus(`Large markdown file (${Math.round(sizeBytes/1024)} KB, ${lineCount} lines) — showing as plain text to keep the preview responsive.`);
+        return;
+      }
       showPreview('md');
-      _previewRawContent = data.content;
-      $('previewMd').innerHTML=renderMd(data.content);
+      $('previewMd').innerHTML=renderMd(content);
       requestAnimationFrame(()=>{if(typeof renderKatexBlocks==='function')renderKatexBlocks();});
     }catch(e){setStatus(t('file_open_failed'));}
   } else if(HTML_EXTS.has(ext)){

--- a/tests/test_issue347.py
+++ b/tests/test_issue347.py
@@ -360,21 +360,41 @@ def test_workspace_calls_render_katex_after_preview():
 
 
 def test_workspace_renders_katex_after_file_open():
-    """workspace.js renderKatexBlocks call must come after the renderMd(data.content) assignment."""
-    preview_md_pos = WORKSPACE_JS.find("renderMd(data.content)")
+    """workspace.js renderKatexBlocks call must come after the rich markdown render."""
+    preview_md_pos = WORKSPACE_JS.find("renderMd(content)")
     # Use the actual call string (not a stray regex match on 'M' characters)
     katex_call_str = "renderKatexBlocks==='function'"
     katex_call_pos = WORKSPACE_JS.find(katex_call_str)
-    assert preview_md_pos != -1, "renderMd(data.content) not found in workspace.js"
+    assert preview_md_pos != -1, "renderMd(content) not found in workspace.js"
     assert katex_call_pos != -1, (
         "renderKatexBlocks guard (typeof renderKatexBlocks==='function') not found in workspace.js"
     )
-    # The call after 'renderMd(data.content)' — find the LAST occurrence
+    # The call after 'renderMd(content)' — find the LAST occurrence
     # (there may be an earlier one in the save path at line ~153)
     last_katex_pos = WORKSPACE_JS.rfind(katex_call_str)
     assert last_katex_pos > preview_md_pos, (
-        "renderKatexBlocks must be called AFTER renderMd(data.content) in workspace.js "
+        "renderKatexBlocks must be called AFTER renderMd(content) in workspace.js "
         f"(renderMd at {preview_md_pos}, last renderKatexBlocks at {last_katex_pos})"
+    )
+
+
+def test_workspace_large_markdown_falls_back_to_plain_text_before_rendering():
+    """Large markdown files should use the plain text preview before renderMd()/KaTeX."""
+    assert "LARGE_MARKDOWN_PREVIEW_BYTES = 64 * 1024" in WORKSPACE_JS
+    assert "LARGE_MARKDOWN_PREVIEW_LINES = 1500" in WORKSPACE_JS
+    fallback_pos = WORKSPACE_JS.find("sizeBytes > LARGE_MARKDOWN_PREVIEW_BYTES")
+    code_preview_pos = WORKSPACE_JS.find("showPreview('code')", fallback_pos)
+    render_md_pos = WORKSPACE_JS.find("renderMd(content)", fallback_pos)
+    katex_call_pos = WORKSPACE_JS.find("renderKatexBlocks==='function'", fallback_pos)
+    assert fallback_pos != -1, "large markdown size guard not found"
+    assert code_preview_pos != -1, "large markdown fallback must show code/plain text preview"
+    assert render_md_pos != -1, "small markdown path must still rich-render markdown"
+    assert katex_call_pos != -1, "small markdown path must still render KaTeX"
+    assert code_preview_pos < render_md_pos < katex_call_pos, (
+        "large markdown fallback must return before rich render and KaTeX pass"
+    )
+    assert "return;" in WORKSPACE_JS[code_preview_pos:render_md_pos], (
+        "large markdown fallback must return before renderMd(content)"
     )
 
 


### PR DESCRIPTION
## Thinking Path

- Hermes WebUI is a browser workbench with a workspace file browser and inline previews.
- Markdown previews currently fetch the full file and synchronously run `renderMd()` on the browser main thread.
- Large Markdown files with many headings/tables can make that rich-render path appear frozen.
- The safest narrow fix is to keep small Markdown files rendering richly, but fall back to the existing plain-text preview for large Markdown files.
- This preserves editability and avoids adding dependencies, workers, or virtualized rendering in a small bug-fix PR.

## What Changed

- Added large Markdown preview thresholds in `static/workspace.js`:
  - `> 64 KB`, or
  - `> 1500 lines`.
- When a Markdown file exceeds either threshold:
  - populate `_previewRawContent` before the check so Edit mode still has the source content;
  - switch to `showPreview('code')`;
  - set `previewCode.textContent` to the raw Markdown;
  - show a status message explaining that the file is shown as plain text to keep preview responsive;
  - return before `renderMd()` and `renderKatexBlocks()` run.
- Small Markdown files still use the existing rich Markdown preview and KaTeX post-pass.
- Updated the workspace/KaTeX structural test to match the `renderMd(content)` path.
- Added a regression test asserting the large Markdown fallback exists and returns before rich rendering.
- Added an Unreleased changelog entry.

## Why It Matters

Large document workflows can otherwise look like file corruption or a broken workspace preview even when the file is valid and local editors can open it. Falling back to plain text gives users a responsive preview and lets them use Edit mode without freezing the UI.

Closes #2823.

## Verification

- `node --check static/workspace.js`
- `git diff --check`
- `python -m pytest tests/test_issue347.py -q`
  - `35 passed, 1 warning in 2.46s`

Manual reasoning checks:

- Large Markdown path sets `_previewRawContent` before the threshold check.
- Large Markdown path returns before `renderMd(content)` and `renderKatexBlocks()`.
- Small Markdown path still calls `renderMd(content)` and schedules `renderKatexBlocks()`.
- Fallback uses the existing `code` preview mode, so the existing Edit button remains available.

## Risks / Follow-ups

- The 64 KB / 1500 line thresholds are intentionally conservative and can be tuned later.
- This PR does not add a “Render anyway” button; that could be a follow-up if users want to opt into slow rich rendering.
- This PR does not implement virtualized Markdown rendering or a Web Worker; those are larger architectural changes.

## Model Used

AI-assisted with Hermes Agent using GPT-5.5 via a custom provider. Tools used: terminal, file reads, patch/write operations, and GitHub CLI.
