### PR TITLE
fix(server): tolerate malformed request logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Malformed HTTP request logging now falls back to `"-"` for missing method or
+  path fields instead of raising an `AttributeError` traceback while handling
+  the 400 response.
+
 ## [v0.51.124] — 2026-05-24 — Release CV (stage-batch6 — 3-PR Windows-only stack — agent paths / docs / port hardening)
 
 ### Added

--- a/server.py
+++ b/server.py
@@ -232,8 +232,8 @@ class Handler(BaseHTTPRequestHandler):
         duration_ms = round((time.time() - getattr(self, '_req_t0', time.time())) * 1000, 1)
         record = _json.dumps({
             'ts': time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime()),
-            'method': self.command or '-',
-            'path': self.path or '-',
+            'method': getattr(self, 'command', None) or '-',
+            'path': getattr(self, 'path', None) or '-',
             'status': int(code) if str(code).isdigit() else code,
             'ms': duration_ms,
         })

--- a/tests/test_issue2775_log_request.py
+++ b/tests/test_issue2775_log_request.py
@@ -1,0 +1,18 @@
+import json
+
+from server import Handler
+
+
+def test_log_request_handles_malformed_request_without_path(capsys):
+    """Malformed request lines can call log_request before path is assigned."""
+    handler = Handler.__new__(Handler)
+    handler.command = None
+
+    Handler.log_request(handler, "400")
+
+    line = capsys.readouterr().out.strip()
+    assert line.startswith("[webui] ")
+    record = json.loads(line.removeprefix("[webui] "))
+    assert record["method"] == "-"
+    assert record["path"] == "-"
+    assert record["status"] == 400


### PR DESCRIPTION
## Thinking Path

- Hermes WebUI logs each request as structured JSON from `server.py`.
- Malformed request lines can reach `log_request()` before `BaseHTTPRequestHandler` has assigned `path`.
- The existing logger accessed `self.path` directly, so the error handler produced an `AttributeError` traceback while handling the intended 400 response.
- The narrow fix is to treat missing request metadata the same way `_req_t0` is already treated: read it defensively and log `"-"` when absent.

## What Changed

- Updated `Handler.log_request()` to use `getattr(self, "command", None)` and `getattr(self, "path", None)` before falling back to `"-"`.
- Added `tests/test_issue2775_log_request.py` to lock the malformed-request shape where `path` is not assigned.
- Added an Unreleased changelog entry.

## Why It Matters

Malformed packets, port scans, and invalid HTTP request lines should produce a clean 400 access-log entry, not a noisy server traceback. This keeps the WebUI logs useful without changing normal request handling.

Closes #2775.

## Verification

- Red test before the fix: `tests/test_issue2775_log_request.py` failed with `AttributeError: 'Handler' object has no attribute 'path'`.
- `python -m pytest tests/test_issue2775_log_request.py -q` — `1 passed`
- `python -m py_compile server.py`
- `git diff --check`

## Risks / Follow-ups

- Scope is intentionally limited to `log_request()`, which is the confirmed crash path.
- `do_GET` / write error logging already reaches its error branch after parsing `self.path`; this PR does not broaden that optional defensive cleanup.

## Model Used

AI-assisted with OpenAI GPT-5 Codex in Codex Desktop. Tools used: repository inspection, pytest, py_compile, git, and GitHub CLI.
