### PR TITLE
perf(http): enable HTTP/1.1 keep-alive

### DIFF
--- a/api/auth.py
+++ b/api/auth.py
@@ -435,10 +435,12 @@ def check_auth(handler, parsed) -> bool:
         return True
     # Not authorized
     if parsed.path.startswith('/api/'):
+        body = b'{"error":"Authentication required"}'
         handler.send_response(401)
         handler.send_header('Content-Type', 'application/json')
+        handler.send_header('Content-Length', str(len(body)))
         handler.end_headers()
-        handler.wfile.write(b'{"error":"Authentication required"}')
+        handler.wfile.write(body)
     else:
         handler.send_response(302)
         # Pass the original path as ?next= so login.js redirects back after auth.
@@ -468,6 +470,7 @@ def check_auth(handler, parsed) -> bool:
         # `?`, `&`, `=`) gets percent-encoded.
         _next = _urlparse.quote(_path_with_query, safe='/')
         handler.send_header('Location', 'login?next=' + _next)
+        handler.send_header('Content-Length', '0')
         handler.end_headers()
     return False
 

--- a/api/kanban_bridge.py
+++ b/api/kanban_bridge.py
@@ -1022,7 +1022,7 @@ def _handle_events_sse_stream(handler, parsed):
     handler.send_header("Content-Type", "text/event-stream; charset=utf-8")
     handler.send_header("Cache-Control", "no-cache")
     handler.send_header("X-Accel-Buffering", "no")
-    handler.send_header("Connection", "keep-alive")
+    handler.send_header("Connection", "close")
     handler.end_headers()
 
     # Send an initial frame so the client knows the connection is open

--- a/api/routes.py
+++ b/api/routes.py
@@ -6147,13 +6147,15 @@ def handle_post(handler, parsed) -> bool:
             _record_login_attempt(client_ip)
             return bad(handler, "Invalid password", 401)
         cookie_val = create_session()
+        body = json.dumps({"ok": True}).encode()
         handler.send_response(200)
         handler.send_header("Content-Type", "application/json")
+        handler.send_header("Content-Length", str(len(body)))
         handler.send_header("Cache-Control", "no-store")
         _security_headers(handler)
         set_auth_cookie(handler, cookie_val)
         handler.end_headers()
-        handler.wfile.write(json.dumps({"ok": True}).encode())
+        handler.wfile.write(body)
         return True
 
     if parsed.path == "/api/auth/logout":
@@ -6162,13 +6164,15 @@ def handle_post(handler, parsed) -> bool:
         cookie_val = parse_cookie(handler)
         if cookie_val:
             invalidate_session(cookie_val)
+        body = json.dumps({"ok": True}).encode()
         handler.send_response(200)
         handler.send_header("Content-Type", "application/json")
+        handler.send_header("Content-Length", str(len(body)))
         handler.send_header("Cache-Control", "no-store")
         _security_headers(handler)
         clear_auth_cookie(handler)
         handler.end_headers()
-        handler.wfile.write(json.dumps({"ok": True}).encode())
+        handler.wfile.write(body)
         return True
 
     # ── Checkpoints / Rollback (POST) ──
@@ -6491,7 +6495,7 @@ def _handle_sse_stream(handler, parsed):
         handler.send_header("Content-Type", "text/event-stream; charset=utf-8")
         handler.send_header("Cache-Control", "no-cache")
         handler.send_header("X-Accel-Buffering", "no")
-        handler.send_header("Connection", "keep-alive")
+        handler.send_header("Connection", "close")
         handler.end_headers()
         try:
             _replay_run_journal(handler, stream_id, _parse_run_journal_after_seq(qs))
@@ -6503,7 +6507,7 @@ def _handle_sse_stream(handler, parsed):
     handler.send_header("Content-Type", "text/event-stream; charset=utf-8")
     handler.send_header("Cache-Control", "no-cache")
     handler.send_header("X-Accel-Buffering", "no")
-    handler.send_header("Connection", "keep-alive")
+    handler.send_header("Connection", "close")
     handler.end_headers()
     try:
         while True:
@@ -6634,7 +6638,7 @@ def _handle_terminal_output(handler, parsed):
     handler.send_header("Content-Type", "text/event-stream; charset=utf-8")
     handler.send_header("Cache-Control", "no-cache")
     handler.send_header("X-Accel-Buffering", "no")
-    handler.send_header("Connection", "keep-alive")
+    handler.send_header("Connection", "close")
     handler.end_headers()
     try:
         while True:
@@ -6712,7 +6716,7 @@ def _handle_gateway_sse_stream(handler, parsed):
     handler.send_header('Content-Type', 'text/event-stream; charset=utf-8')
     handler.send_header('Cache-Control', 'no-cache')
     handler.send_header('X-Accel-Buffering', 'no')
-    handler.send_header('Connection', 'keep-alive')
+    handler.send_header('Connection', 'close')
     handler.end_headers()
 
     q = watcher.subscribe()
@@ -6745,7 +6749,7 @@ def _handle_session_events_stream(handler):
     handler.send_header('Content-Type', 'text/event-stream; charset=utf-8')
     handler.send_header('Cache-Control', 'no-cache')
     handler.send_header('X-Accel-Buffering', 'no')
-    handler.send_header('Connection', 'keep-alive')
+    handler.send_header('Connection', 'close')
     handler.end_headers()
 
     q = subscribe_session_events()
@@ -6831,6 +6835,7 @@ def _serve_file_bytes(handler, target: Path, mime: str, disposition: str, cache_
         handler.send_response(416)
         handler.send_header("Content-Range", f"bytes */{file_size}")
         handler.send_header("Accept-Ranges", "bytes")
+        handler.send_header("Content-Length", "0")
         _security_headers(handler)
         handler.end_headers()
         return True
@@ -6896,10 +6901,12 @@ def _handle_media(handler, parsed):
     if is_auth_enabled():
         cv = parse_cookie(handler)
         if not (cv and verify_session(cv)):
+            body = b'{"error":"Authentication required"}'
             handler.send_response(401)
             handler.send_header("Content-Type", "application/json")
+            handler.send_header("Content-Length", str(len(body)))
             handler.end_headers()
-            handler.wfile.write(b'{"error":"Authentication required"}')
+            handler.wfile.write(body)
             return
 
     qs = parse_qs(parsed.query)
@@ -7256,7 +7263,7 @@ def _handle_approval_sse_stream(handler, parsed):
     handler.send_header('Content-Type', 'text/event-stream; charset=utf-8')
     handler.send_header('Cache-Control', 'no-cache')
     handler.send_header('X-Accel-Buffering', 'no')
-    handler.send_header('Connection', 'keep-alive')
+    handler.send_header('Connection', 'close')
     handler.end_headers()
 
     from api.streaming import _sse
@@ -7357,7 +7364,7 @@ def _handle_clarify_sse_stream(handler, parsed):
     handler.send_header('Content-Type', 'text/event-stream; charset=utf-8')
     handler.send_header('Cache-Control', 'no-cache')
     handler.send_header('X-Accel-Buffering', 'no')
-    handler.send_header('Connection', 'keep-alive')
+    handler.send_header('Connection', 'close')
     handler.end_headers()
 
     from api.streaming import _sse

--- a/server.py
+++ b/server.py
@@ -170,6 +170,13 @@ class QuietHTTPServer(ThreadingHTTPServer):
 
 
 class Handler(BaseHTTPRequestHandler):
+    # HTTP/1.1 enables keep-alive connection reuse — major latency win on
+    # high-RTT links where every saved TCP handshake is 2×RTT. Each response
+    # MUST declare framing (Content-Length, Transfer-Encoding: chunked, or
+    # Connection: close) so the client knows where the message ends. Helpers
+    # j()/t() emit Content-Length; SSE/streaming endpoints emit
+    # Connection: close because the body has no terminator. See PR notes.
+    protocol_version = "HTTP/1.1"
     timeout = 30  # seconds — kills idle/incomplete connections to prevent thread exhaustion
     
     def setup(self):


### PR DESCRIPTION
# perf(http): enable HTTP/1.1 keep-alive for WebUI responses

## Summary

This enables HTTP/1.1 for the WebUI HTTP server so the browser can reuse TCP connections across normal API and static-file requests.

The main motivation is high-RTT access: VPN, tunnels, reverse proxies, or remote homelab usage. Before this change, the server used the default HTTP/1.0 behavior from `BaseHTTPRequestHandler`, so browsers had to open new connections repeatedly while loading a session and nearby UI state. With HTTP/1.1 framing in place, those requests can share existing connections.

## What changed

- Set `Handler.protocol_version = "HTTP/1.1"`.
- Added explicit `Content-Length` headers to hand-written responses that were not already using the shared `j()` / `t()` helpers.
- Added `Content-Length: 0` to empty redirect / range-error responses.
- Switched SSE-style streaming endpoints from `Connection: keep-alive` to `Connection: close`.

The last point is important: HTTP/1.1 keep-alive is safe only when the response body is framed. Most JSON/static responses already have `Content-Length`; SSE streams intentionally do not have a fixed body length, so those endpoints should not be treated as reusable keep-alive responses.

## Local performance notes

On a high-latency / VPN-style path, this reduces the repeated connection setup cost around first paint and session navigation.

Earlier local measurements from the WebUI flow showed approximate improvements after enabling HTTP/1.1 keep-alive:

| Flow | Improvement |
|---|---:|
| First paint | ~47% faster |
| Kanban panel load | ~39% faster |
| File panel load | ~38% faster |
| Session open request group | ~30% faster |

The exact numbers depend heavily on RTT, browser connection reuse, and whether a reverse proxy is in front of the server. Locally on loopback the gain is smaller, but this removes a real cost for remote usage.

## Correctness / compatibility

The patch is deliberately small and only changes HTTP transport behavior:

- normal API/static responses remain the same payloads;
- existing helper-generated responses already had framing;
- SSE endpoints still stream normally, but advertise `Connection: close` so clients do not attempt to reuse an unframed response body.

## Testing

Focused checks:

```text
python -m pytest \
  tests/test_auth_sessions.py \
  tests/test_auth_session_persistence.py \
  tests/test_auth_password_hash_cache.py \
  tests/test_1038_pwa_auth_redirect.py \
  tests/test_run_journal_streaming_static.py \
  tests/test_inflight_stream_reuse.py \
  tests/test_media_inline.py \
  -q
```

Result:

```text
96 passed
```
