### PR TITLE
fix(terminal): drop PR_SET_PDEATHSIG preexec_fn that killed every Linux shell (#2853)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Embedded terminal closes immediately on Linux** (regression from #2363) — fixes #2853. The `_terminal_shell_preexec_fn` introduced in commit `71d8a8fb` set `PR_SET_PDEATHSIG=SIGTERM` to reap orphaned PTY shells when the WebUI process crashed, but that signal is *per-thread*. WebUI runs `ThreadingHTTPServer`, so `subprocess.Popen` ran on a short-lived per-request thread; the PTY shell registered the request thread as its parent and was killed within ~10 ms of the response being sent. The frontend correctly surfaced this as `[terminal closed]`. Fix: drop the `preexec_fn` entirely — `atexit.register(close_all_terminals)` plus the explicit `close_terminal` paths already cover graceful shutdown, and orphaned shells after a hard server crash are rare for self-hosted single-user installs (the tradeoff the original PR was navigating). Empirically reproduced and verified: with `preexec_fn` the shell exits with code `-15` (SIGTERM) right after the spawning thread joins; without it, the shell stays alive indefinitely. macOS users were unaffected because `libc.prctl` doesn't exist and the `except Exception: pass` swallowed the `AttributeError` silently. Adds `test_pty_shell_survives_when_spawning_thread_exits` (real PTY + worker thread, asserts shell is still alive after the worker joins), inverts the existing `test_terminal_shell_uses_parent_death_signal_preexec` to lock in the no-preexec contract, and updates the module-source guard to refuse re-introduction.
+
 ## [v0.51.126] — 2026-05-24 — Release CX (stage-batch8 — 2-PR low-risk batch — kanban markdown + live activity timeline)
 
 ### Added

--- a/api/terminal.py
+++ b/api/terminal.py
@@ -70,18 +70,17 @@ _TERMINALS: dict[str, TerminalSession] = {}
 _LOCK = threading.RLock()
 
 
-def _terminal_shell_preexec_fn() -> None:
-    """Ask Linux to terminate the PTY shell when the WebUI parent dies."""
-    try:
-        import ctypes
-
-        libc = ctypes.CDLL(None)
-        libc.prctl(1, signal.SIGTERM)  # PR_SET_PDEATHSIG=1, SIGTERM=15
-    except Exception:
-        # Non-Linux platforms or restricted runtimes should still be able to
-        # open an embedded terminal; they just do not get the Linux pdeathsig
-        # hardening.
-        pass
+# NOTE on parent-death-signal: a previous version of this module set
+# PR_SET_PDEATHSIG via a preexec_fn to terminate orphaned PTY shells when the
+# WebUI process crashed.  That broke every Linux user (#2853): WebUI runs a
+# ThreadingHTTPServer, so the Popen call happens on a short-lived per-request
+# thread, and PR_SET_PDEATHSIG is per-thread.  The PTY shell registered the
+# spawning thread as its "parent" and was killed with SIGTERM the instant that
+# thread joined — within ~10 ms of opening the terminal — surfacing as the
+# `[terminal closed]` banner.  The graceful path is covered by
+# `atexit.register(close_all_terminals)` and the explicit `close_terminal`
+# call sites; hard kills of the WebUI process leak the shell, which is the
+# tradeoff for working on Linux at all.
 
 
 def _decode_terminal_output(decoder, data: bytes) -> str:
@@ -193,7 +192,6 @@ def start_terminal(session_id: str, workspace: Path, rows: int = 24, cols: int =
             stdout=slave_fd,
             stderr=slave_fd,
             close_fds=True,
-            preexec_fn=_terminal_shell_preexec_fn,
             start_new_session=True,
         )
         os.close(slave_fd)

--- a/tests/test_terminal_process_cleanup.py
+++ b/tests/test_terminal_process_cleanup.py
@@ -1,4 +1,9 @@
+import os
 import subprocess
+import threading
+import time
+
+import pytest
 
 import api.terminal as terminal
 
@@ -27,7 +32,19 @@ class _FakeProc:
         return 0
 
 
-def test_terminal_shell_uses_parent_death_signal_preexec(monkeypatch, tmp_path):
+def test_terminal_shell_does_not_use_pdeathsig_preexec(monkeypatch, tmp_path):
+    """Regression for #2853.
+
+    The previous implementation passed a ``preexec_fn`` that called
+    ``prctl(PR_SET_PDEATHSIG, SIGTERM)``.  Because that signal is *per-thread*
+    and WebUI's ``ThreadingHTTPServer`` spawns a new thread for every HTTP
+    request, the PTY shell registered the request-handler thread as its
+    parent and was killed within ~10 ms of being created on Linux.
+
+    The fix is to spawn the shell without ``preexec_fn`` at all.  Graceful
+    shutdown remains covered by ``atexit.register(close_all_terminals)`` and
+    the explicit ``close_terminal`` paths.
+    """
     captured = {}
     proc = _FakeProc()
 
@@ -40,15 +57,59 @@ def test_terminal_shell_uses_parent_death_signal_preexec(monkeypatch, tmp_path):
     monkeypatch.setattr(terminal.threading, "Thread", _DummyThread)
     monkeypatch.setattr(terminal, "_set_size", lambda *args, **kwargs: None)
 
-    term = terminal.start_terminal("term-preexec", tmp_path)
+    term = terminal.start_terminal("term-no-preexec", tmp_path)
 
     try:
         assert term.proc is proc
-        assert captured["kwargs"]["preexec_fn"] is terminal._terminal_shell_preexec_fn
+        assert "preexec_fn" not in captured["kwargs"], (
+            "preexec_fn must not be set — the PR_SET_PDEATHSIG implementation "
+            "killed every Linux user's terminal (#2853). See module-level note."
+        )
         assert captured["kwargs"]["start_new_session"] is True
         assert captured["kwargs"]["stdin"] == captured["kwargs"]["stdout"] == captured["kwargs"]["stderr"]
     finally:
-        terminal.close_terminal("term-preexec")
+        terminal.close_terminal("term-no-preexec")
+
+
+@pytest.mark.skipif(
+    not hasattr(os, "openpty") or os.name != "posix",
+    reason="PTY-spawn test requires a POSIX host",
+)
+def test_pty_shell_survives_when_spawning_thread_exits(tmp_path):
+    """End-to-end regression for #2853.
+
+    Spawn a real PTY shell via ``start_terminal`` from inside a worker thread
+    that then exits.  The shell must remain alive after the spawning thread
+    joins, otherwise we've regressed back to the PR_SET_PDEATHSIG behaviour
+    that killed every Linux user's embedded terminal.
+    """
+    sid = "term-thread-survival"
+    holder: dict = {}
+
+    def worker():
+        try:
+            holder["term"] = terminal.start_terminal(sid, tmp_path)
+        except Exception as exc:  # pragma: no cover - surface in assertion
+            holder["error"] = exc
+
+    t = threading.Thread(target=worker)
+    t.start()
+    t.join(timeout=5)
+    assert not t.is_alive(), "spawn worker thread should have exited"
+    assert "error" not in holder, holder.get("error")
+    term = holder["term"]
+
+    try:
+        # Give the kernel a beat — if PR_SET_PDEATHSIG were re-introduced the
+        # shell would receive SIGTERM right about now.
+        time.sleep(0.5)
+        assert term.proc.poll() is None, (
+            "PTY shell exited after the spawning thread joined — likely a "
+            "PR_SET_PDEATHSIG regression (#2853). "
+            f"exit_code={term.proc.poll()!r}"
+        )
+    finally:
+        terminal.close_terminal(sid)
 
 
 def test_close_terminal_waits_again_after_sigkill(monkeypatch):
@@ -96,8 +157,11 @@ def test_close_all_terminals_closes_snapshot(monkeypatch):
 
 
 def test_terminal_module_registers_graceful_shutdown_reaper():
+    """atexit is still the reap path; pdeathsig must NOT be re-introduced."""
     src = terminal.Path(terminal.__file__).read_text()
 
     assert "atexit.register(close_all_terminals)" in src
-    assert "preexec_fn=_terminal_shell_preexec_fn" in src
-    assert "libc.prctl(1, signal.SIGTERM)" in src
+    # The PR_SET_PDEATHSIG implementation broke every Linux user (#2853);
+    # guard against accidentally bringing it back.
+    assert "preexec_fn=_terminal_shell_preexec_fn" not in src
+    assert "libc.prctl(1, signal.SIGTERM)" not in src


### PR DESCRIPTION
## Fixes #2853 — embedded terminal opens then immediately shows `[terminal closed]` on Linux

The `_terminal_shell_preexec_fn` added in `71d8a8fb` ("fix: reap terminal shells on shutdown") set `PR_SET_PDEATHSIG=SIGTERM` on the PTY shell so orphans would die when the WebUI process crashed. But that signal is **per-thread**, not per-process — and WebUI runs `ThreadingHTTPServer`, so every HTTP request is handled in its own short-lived worker thread.

Flow that broke every Linux user past `71d8a8fb`:

1. User clicks the terminal toggle → frontend hits `POST /api/terminal/start`.
2. `ThreadingHTTPServer` spins up a worker thread to handle that one request.
3. The worker thread calls `subprocess.Popen(..., preexec_fn=_terminal_shell_preexec_fn)`.
4. The shell calls `prctl(PR_SET_PDEATHSIG, SIGTERM)` in its preexec_fn. Its registered "parent" is now the **worker thread** that called Popen.
5. The handler returns its JSON response and the worker thread exits.
6. The kernel sees the pdeathsig-parent thread has died and sends `SIGTERM` to the PTY shell. The shell dies within ~10 ms of being created.
7. The reader loop sees `EIO` on the master FD, emits `terminal_closed`, and the frontend writes `[terminal closed]`.

macOS users were unaffected because `libc.prctl` doesn't exist there — `ctypes.CDLL(None).prctl` raises `AttributeError`, the bare `except` swallows it, and the shell starts normally.

## Empirical verification

Same threading topology as WebUI: a worker thread calls `subprocess.Popen` (PTY, `start_new_session=True`) then joins immediately. Main thread then polls the shell after a 500 ms grace window.

```
with    preexec_fn (PR_SET_PDEATHSIG, SIGTERM) → proc.poll() == -15 (SIGTERM)
                                                  master FD read → EIO
without preexec_fn                              → proc.poll() == None (alive)
                                                  master FD read → b'HELLO\r\n'
```

## Fix — option A from the issue

Drop the `preexec_fn` entirely.

The orphan-shell-on-crash case the original PR was navigating is rare for self-hosted single-user installs, and:

- `atexit.register(close_all_terminals)` already reaps shells on graceful shutdown.
- Explicit `close_terminal` calls cover the user-driven close path.

A future fix (option B in the issue — pdeathsig pinned to a long-lived supervisor thread) can re-add the hardening, but that's a follow-up. This PR is the smallest unbricks-Linux-today change.

## Tests

- **Invert** `test_terminal_shell_uses_parent_death_signal_preexec` → `test_terminal_shell_does_not_use_pdeathsig_preexec`: asserts `preexec_fn` is **not** in the `Popen` kwargs.
- **Add** `test_pty_shell_survives_when_spawning_thread_exits` — spawns a real PTY shell via `start_terminal` from inside a worker thread, waits for the worker to join, asserts the shell is still alive after a 500 ms grace window. This is the contract the previous test suite never exercised, and is the empirical regression check.
- **Update** `test_terminal_module_registers_graceful_shutdown_reaper` to refuse re-introduction of the preexec_fn or the `libc.prctl(1, signal.SIGTERM)` call (treats either as a regression).

All 27 terminal-related tests pass locally:

```
tests/test_terminal_process_cleanup.py
tests/test_profile_terminal_env.py
tests/test_embedded_workspace_terminal.py
tests/test_1694_terminal_cleanup_ownership.py
27 passed in 3.61s
```

## CHANGELOG

Entry under `[Unreleased] → Fixed`.

Refs #2853.
