### PR TITLE
fix(terminal): prevent embedded terminal closing on Linux request thread exit

### DIFF
--- a/api/terminal.py
+++ b/api/terminal.py
@@ -70,20 +70,6 @@ _TERMINALS: dict[str, TerminalSession] = {}
 _LOCK = threading.RLock()
 
 
-def _terminal_shell_preexec_fn() -> None:
-    """Ask Linux to terminate the PTY shell when the WebUI parent dies."""
-    try:
-        import ctypes
-
-        libc = ctypes.CDLL(None)
-        libc.prctl(1, signal.SIGTERM)  # PR_SET_PDEATHSIG=1, SIGTERM=15
-    except Exception:
-        # Non-Linux platforms or restricted runtimes should still be able to
-        # open an embedded terminal; they just do not get the Linux pdeathsig
-        # hardening.
-        pass
-
-
 def _decode_terminal_output(decoder, data: bytes) -> str:
     """Decode PTY bytes without stripping terminal control sequences."""
     return decoder.decode(data)
@@ -149,7 +135,12 @@ def _set_size(term: TerminalSession, rows: int, cols: int) -> None:
 
 
 def start_terminal(session_id: str, workspace: Path, rows: int = 24, cols: int = 80, restart: bool = False) -> TerminalSession:
-    """Start or return the embedded terminal for a WebUI session."""
+    """Start or return the embedded terminal for a WebUI session.
+
+    The PTY shell intentionally avoids ``preexec_fn``/PDEATHSIG: ThreadingHTTPServer
+    request threads are short-lived, and tying the shell to that lifecycle can
+    terminate it immediately after the start request returns.
+    """
     sid = str(session_id or "").strip()
     if not sid:
         raise ValueError("session_id is required")
@@ -185,6 +176,8 @@ def start_terminal(session_id: str, workspace: Path, rows: int = 24, cols: int =
             }
         )
         shell = _shell_path()
+        # Keep the shell in its own process group for explicit cleanup via
+        # close_terminal()/close_all_terminals(); do not use PDEATHSIG here.
         proc = subprocess.Popen(
             _shell_argv(shell),
             cwd=cwd,
@@ -193,7 +186,7 @@ def start_terminal(session_id: str, workspace: Path, rows: int = 24, cols: int =
             stdout=slave_fd,
             stderr=slave_fd,
             close_fds=True,
-            preexec_fn=_terminal_shell_preexec_fn,
+            # Required so cleanup can signal the whole interactive shell tree.
             start_new_session=True,
         )
         os.close(slave_fd)
@@ -237,6 +230,7 @@ def resize_terminal(session_id: str, rows: int, cols: int) -> None:
 
 
 def close_terminal(session_id: str) -> bool:
+    """Close one embedded terminal with process-group termination."""
     sid = str(session_id or "")
     with _LOCK:
         term = _TERMINALS.pop(sid, None)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "hermes-webui",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/tergit checkout master
+++ b/tergit checkout master
@@ -1,0 +1,15 @@
+
+                   SSUUMMMMAARRYY OOFF LLEESSSS CCOOMMMMAANNDDSS
+
+      Commands marked with * may be preceded by a number, _N.
+      Notes in parentheses indicate the behavior if _N is given.
+      A key preceded by a caret indicates the Ctrl key; thus ^K is ctrl-K.
+
+  h  H                 Display this help.
+  q  :q  Q  :Q  ZZ     Exit.
+ ---------------------------------------------------------------------------
+
+                           MMOOVVIINNGG
+
+  e  ^E  j  ^N  CR  *  Forward  one line   (or _N lines).
+  y  ^Y  k  ^K  ^P  *  Backward one line   (or _N lines).

--- a/tests/test_terminal_linux_lifecycle.py
+++ b/tests/test_terminal_linux_lifecycle.py
@@ -1,0 +1,60 @@
+import queue
+import os
+import sys
+import threading
+import time
+
+import pytest
+
+
+pytestmark = pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="Linux-only terminal process lifecycle regression",
+)
+
+
+def test_terminal_survives_short_lived_request_thread(tmp_path):
+    # Mirrors ThreadingHTTPServer: the request worker exits after spawning the
+    # shell, so terminal lifetime must not be tied to that worker thread.
+    from api.terminal import close_terminal, start_terminal, write_terminal
+
+    sid = f"terminal-linux-lifecycle-{os.getpid()}-{id(tmp_path)}"
+    result = queue.Queue()
+
+    def request_thread():
+        try:
+            result.put(start_terminal(sid, tmp_path, rows=8, cols=40, restart=True))
+        except Exception as exc:
+            result.put(exc)
+
+    thread = threading.Thread(target=request_thread)
+    thread.start()
+    thread.join(timeout=1.0)
+    assert not thread.is_alive()
+
+    term = result.get(timeout=1.0)
+    if isinstance(term, Exception):
+        raise AssertionError("terminal worker thread failed") from term
+    try:
+        deadline = time.monotonic() + 0.5
+        while time.monotonic() < deadline:
+            assert term.proc.poll() is None
+            time.sleep(0.02)
+        assert term.is_alive()
+
+        marker = f"lifecycle-ok-{os.getpid()}"
+        write_terminal(sid, f"printf '{marker}\\n'\n")
+        deadline = time.monotonic() + 1.0
+        seen = ""
+        while time.monotonic() < deadline:
+            try:
+                event, payload = term.output.get(timeout=0.1)
+            except queue.Empty:
+                continue
+            if event == "output":
+                seen += payload.get("text", "")
+                if f"{marker}\r\n" in seen or f"{marker}\n" in seen:
+                    break
+        assert f"{marker}\r\n" in seen or f"{marker}\n" in seen
+    finally:
+        close_terminal(sid)

--- a/tests/test_terminal_process_cleanup.py
+++ b/tests/test_terminal_process_cleanup.py
@@ -27,7 +27,7 @@ class _FakeProc:
         return 0
 
 
-def test_terminal_shell_uses_parent_death_signal_preexec(monkeypatch, tmp_path):
+def test_terminal_shell_starts_new_session_without_preexec(monkeypatch, tmp_path):
     captured = {}
     proc = _FakeProc()
 
@@ -44,7 +44,7 @@ def test_terminal_shell_uses_parent_death_signal_preexec(monkeypatch, tmp_path):
 
     try:
         assert term.proc is proc
-        assert captured["kwargs"]["preexec_fn"] is terminal._terminal_shell_preexec_fn
+        assert "preexec_fn" not in captured["kwargs"]
         assert captured["kwargs"]["start_new_session"] is True
         assert captured["kwargs"]["stdin"] == captured["kwargs"]["stdout"] == captured["kwargs"]["stderr"]
     finally:
@@ -99,5 +99,5 @@ def test_terminal_module_registers_graceful_shutdown_reaper():
     src = terminal.Path(terminal.__file__).read_text()
 
     assert "atexit.register(close_all_terminals)" in src
-    assert "preexec_fn=_terminal_shell_preexec_fn" in src
-    assert "libc.prctl(1, signal.SIGTERM)" in src
+    assert "preexec_fn=" not in src
+    assert "PR_SET_PDEATHSIG" not in src


### PR DESCRIPTION
## Problem

On Linux, the embedded terminal would close immediately after being started from a request thread.

This was caused by `preexec_fn` in `subprocess.Popen`, which enabled `PR_SET_PDEATHSIG` and tied the terminal process to the lifecycle of the HTTP request worker thread.

When the request thread exited, the shell process received a termination signal and shut down immediately.

## Fix

Removed `preexec_fn` from the terminal process creation.

The terminal is now started with `start_new_session=True`, and lifecycle management is handled explicitly by the application.

Existing cleanup mechanisms remain unchanged:
- close_terminal()
- close_all_terminals()
- atexit cleanup

## Behavior Change

Before:
- Terminal process exited when request thread ended

After:
- Terminal process persists independently of request thread lifecycle
- Terminal is only closed via explicit cleanup paths

## Tests

Added Linux-only regression test to verify:

- Terminal survives after request thread exits
- Process remains alive after thread termination
- Basic terminal output still works after thread lifecycle ends

Existing tests ensure:
- No reintroduction of preexec_fn
- Proper cleanup behavior on shutdown

## Notes

- No changes to Windows or macOS behavior
- No changes to frontend or API structure
- No architectural changes introduced