### PR TITLE
Release CZ — v0.51.128 (stage-batch10, 2-PR perf + correctness: #2716 perf optimizations + #2830 pin state authoritative)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,39 @@
 
 ## [Unreleased]
 
+## [v0.51.128] — 2026-05-24 — Release CZ (stage-batch10 — 2-PR perf + correctness batch)
+
+### Fixed
+
+- **PR #2830** by @franksong2702 — Pin state synchronization between persisted index and in-memory sessions (closes #2821). Three coupled bugs:
+  - **Bug A (load-bearing):** `/api/session/pin` pre-snapshot used `getattr(session, "pinned", False)` which always returned `False` for dict-backed index rows from `all_sessions()`. With ~55-session profiles and LRU eviction churn, pinned counts routinely under-counted because the persisted snapshot was effectively empty. New `_session_field(session, field, default)` helper resolves both dict-backed and Session-object snapshots correctly.
+  - **Bug B:** Removed stale client-side `pinLimitReached` short-circuit in the sidebar action menu that could block pin clicks before the server saw them, based on `_allSessions` data that was stale mid-render. Server now enforces the cap; the toast surfaces the 400 response.
+  - **Bug C recovery:** Pin/unpin failure path (4xx response from `/api/session/pin`) now triggers `renderSessionList()` to refresh `_allSessions` from the server, so the sidebar never gets stuck on stale optimistic state.
+
+  Adds `tests/test_issue2821_session_pin_state_sync.py` (70 LOC) covering the `_session_field` helper, the persisted-pinned snapshot, the removed `pinLimitReached` reference, and the failure-catch refresh path. Companion fix to #2782 (server-side 404→200 transition for missing CLI-synced sessions) which remains out of scope.
+
+### Performance
+
+- **PR #2716** by @dobby-d-elf — Six independent perf nudges plus one correctness fix. nesquena-APPROVED on 2026-05-22 after a deep-review iteration; cherry-picked onto post-v0.51.127 master via 3-way apply with sibling-PR composition resolution.
+
+  - **Metadata-only `/api/session` correctness fix.** Refactors the prior inline reconciliation into `_metadata_only_message_summary(sid, profile=None)` helper that runs the full `merge_session_messages_append_only()` path. Pre-fix shortcut could over-count stale state.db replay rows that the merge intentionally filters out, producing false "transcript newer than loaded conversation" signals (same bug class as #2705 / #2686). The new helper threads `profile=` through to `get_state_db_session_messages` to preserve #2827's TLS-vs-thread profile fix on background-thread reads.
+  - **Batched persisted-session checks in sidebar indexing.** One `SESSION_DIR.glob('*.json')` snapshot per call replaces per-row `_index_entry_exists()` filesystem lookups during `all_sessions()` pruning. Fallback to the per-row helper preserved when the glob raises.
+  - **Deferred render-cache signature.** `cachedRenderSignature` closes over the lookup-time signature so the cache STORE path reuses it without recomputing. `_messageRenderCacheSignature()` continues to include the content hash per #2692, preserving the cache-invalidation invariant.
+  - **Hoisted assistant tool-activity index.** Footer-rendering loop now uses an `O(1)` Set lookup instead of `S.toolCalls.some(...)` per message — ~30× fewer comparisons for a 100-message conversation with 30 tool calls.
+  - **Workspace stale-session guards.** `loadDir` and `_refreshGitBadge` in `static/workspace.js` capture `sessionId` at call time and check it after each `await` (including the catch path of `_refreshGitBadge` — without it, a late 404 from the previous session would hide the git badge on the current session).
+  - **Background model-catalog prime.** `_startBootModelDropdown` fires fire-and-forget on boot via `setTimeout(0)` so the live catalog hydrates without blocking. The existing `await` on the saved-session restore path is preserved (re-applies the saved session's model after hydration so the chip never shows the stale static default).
+  - **Failed hydration retryable.** `window._modelDropdownReady = null; throw e;` lets the next caller refetch instead of being stuck on a permanent failure.
+
+  Adds 76 LOC of new tests across `test_session_metadata_fast_path.py`, `test_webui_state_db_reconciliation.py`, `test_session_index.py`, `test_issue1539_provider_removal_dropdown_invalidation.py`, `test_issue1785_workspace_preview_breadcrumb.py`, `test_parallel_session_switch.py`.
+
+### Notes
+
+- PR #2716 had been pending merge since 2026-05-22 due to a rebase blocker against the rapidly-advancing master (10+ intervening releases). Cherry-picked via `git apply --3way` of the PR's net delta vs its original merge-base (`f9302601`); 12 of 14 files applied cleanly. Two files had genuine conflicts requiring resolution: `api/routes.py` (took the PR's helper extraction AND added `profile=` threading to preserve #2827's fix), and `tests/test_webui_state_db_reconciliation.py` (kept BOTH master's pre-existing `test_api_session_reload_drops_stale_cached_user_tail_after_saved_assistant` AND the PR's new `test_metadata_fast_path_matches_reconciliation_for_restamped_replays` — they pin different invariants).
+- Opus pre-release advisor reviewed all 6 risk areas (helper extraction correctness, sibling-PR composition, `Session.load` profile-safety, test coverage, deferred Bug D, stale-line-number cleanup nit). Verdict: **SHIP AS-IS** — no MUST-FIX, no inline SHOULD-FIX. Two follow-up issues to file post-tag (Bug D startup index rebuild perf; multi-profile state.db test for the `profile=` threading invariant).
+- Full pytest: **6,434 passed / 6 skipped / 3 xpassed / 8 subtests passed** in 2m43s.
+- Agent self-verified the producer→consumer channel for `_metadata_only_message_summary` with unmocked invocation against a real session-load path (per skill rule Trigger A + E for mocked-consumer test patterns).
+- Closes: #2821 (pin state sync), and `get_state_db_session_summary` dead-code removed (#2716).
+
 ## [v0.51.127] — 2026-05-24 — Release CY (stage-batch9 — 7-PR low-risk batch — brick-class Linux + brick-class update apply + composer wide-screen + Turkish locale + MCP toggle + SSE settlement + Windows CI)
 
 ### Fixed

--- a/api/models.py
+++ b/api/models.py
@@ -2153,9 +2153,27 @@ def all_sessions(diag=None):
             _diag_stage(diag, "all_sessions.prune_index")
             with LOCK:
                 in_memory_ids = set(SESSIONS.keys())
+            try:
+                persisted_ids = {
+                    p.stem
+                    for p in SESSION_DIR.glob('*.json')
+                    if not p.name.startswith('_')
+                }
+            except Exception:
+                persisted_ids = None
             index = [
                 s for s in index
-                if _index_entry_exists(s.get('session_id'), in_memory_ids=in_memory_ids)
+                if (
+                    str(s.get('session_id') or '') in in_memory_ids
+                    or (
+                        persisted_ids is not None
+                        and str(s.get('session_id') or '') in persisted_ids
+                    )
+                    or (
+                        persisted_ids is None
+                        and _index_entry_exists(s.get('session_id'), in_memory_ids=in_memory_ids)
+                    )
+                )
             ]
             backfilled = []
             for i, s in enumerate(index):
@@ -3030,55 +3048,6 @@ def get_state_db_session_messages(sid, *, stitch_continuations: bool = False, pr
     except Exception:
         return []
     return msgs
-
-
-def get_state_db_session_summary(sid) -> dict:
-    """Return cheap message count/max timestamp for one state.db session.
-
-    This is intentionally narrower than ``get_state_db_session_messages`` for
-    metadata-only WebUI polling: callers only need a staleness signal, not a
-    fully materialized transcript with tool/reasoning metadata.
-    """
-    import os
-    try:
-        import sqlite3
-    except ImportError:
-        return {}
-
-    db_path = _active_state_db_path()
-    if not sid or not db_path.exists():
-        return {}
-
-    try:
-        with closing(sqlite3.connect(str(db_path))) as conn:
-            conn.row_factory = sqlite3.Row
-            cur = conn.cursor()
-            cur.execute("PRAGMA table_info(messages)")
-            available = {str(row['name']) for row in cur.fetchall()}
-            if not {'session_id', 'timestamp'}.issubset(available):
-                return {}
-            cur.execute(
-                """
-                SELECT COUNT(*) AS message_count, MAX(timestamp) AS last_message_at
-                FROM messages
-                WHERE session_id = ?
-                """,
-                (str(sid),),
-            )
-            row = cur.fetchone()
-            if not row:
-                return {}
-            count = int(row['message_count'] or 0)
-            last_message_at = row['last_message_at']
-            result = {'message_count': count}
-            if last_message_at not in (None, ''):
-                try:
-                    result['last_message_at'] = float(last_message_at)
-                except (TypeError, ValueError):
-                    pass
-            return result
-    except Exception:
-        return {}
 
 
 def _normalized_message_timestamp_for_key(value):

--- a/api/routes.py
+++ b/api/routes.py
@@ -77,6 +77,12 @@ _CSP_REPORT_RATE_LIMIT_MAX = 100
 _CSP_REPORT_MAX_BODY_BYTES = 64 * 1024
 
 
+def _session_field(session, field, default=None):
+    if isinstance(session, dict):
+        return session.get(field, default)
+    return getattr(session, field, default)
+
+
 # ── Profile-scoped session/project filtering (#1611, #1614) ────────────────
 #
 # Sessions and projects are stored in the WebUI sidecar without per-row
@@ -5837,8 +5843,8 @@ def handle_post(handler, parsed) -> bool:
             # Pre-snapshot from persisted index (acquires LOCK internally,
             # so must run outside our own LOCK acquire below).
             persisted_pinned_ids = {
-                getattr(existing, "session_id", None) for existing in all_sessions()
-                if getattr(existing, "pinned", False) and not getattr(existing, "archived", False)
+                _session_field(existing, "session_id", None) for existing in all_sessions()
+                if _session_field(existing, "pinned", False) and not _session_field(existing, "archived", False)
             }
             with LOCK:
                 # Final authoritative count: merge persisted-pinned with the

--- a/api/routes.py
+++ b/api/routes.py
@@ -2036,6 +2036,37 @@ def _merged_session_messages_for_display(session, cli_messages=None) -> list:
     return sidecar_messages
 
 
+def _message_summary(messages) -> dict:
+    messages = list(messages or [])
+    last_message_at = 0.0
+    for msg in messages:
+        if not isinstance(msg, dict):
+            continue
+        try:
+            last_message_at = max(last_message_at, float(msg.get("timestamp") or 0))
+        except (TypeError, ValueError):
+            pass
+    return {"message_count": len(messages), "last_message_at": last_message_at}
+
+
+def _metadata_only_message_summary(sid: str, profile: str | None = None) -> dict:
+    """Return the reconciled message summary used by metadata-only session loads.
+
+    Threads ``profile=`` through to ``get_state_db_session_messages`` so
+    background-thread reads land on the correct profile's state.db (per the
+    cookie-bound profile selector — fixes the same TLS-vs-thread race the
+    #2762 fix addressed for write paths).
+    """
+    sidecar_session = Session.load(sid)
+    sidecar_messages = []
+    if sidecar_session:
+        sidecar_messages = getattr(sidecar_session, "messages", []) or []
+    state_db_messages = get_state_db_session_messages(sid, profile=profile)
+    return _message_summary(
+        merge_session_messages_append_only(sidecar_messages, state_db_messages)
+    )
+
+
 def _session_requires_cli_metadata_lookup(session) -> bool:
     """Return True when a sidecar/session row still needs CLI metadata.
 
@@ -3792,7 +3823,7 @@ def handle_get(handler, parsed) -> bool:
             is_messaging_session = _is_messaging_session_record(s) or _is_messaging_session_record(cli_meta)
             cli_messages = []
             state_db_messages = []
-            sidecar_metadata_messages = None
+            metadata_summary = None
             _session_profile = getattr(s, 'profile', None) or None
             if is_messaging_session:
                 cli_messages = get_cli_session_messages(sid)
@@ -3800,17 +3831,11 @@ def handle_get(handler, parsed) -> bool:
                 state_db_messages = get_state_db_session_messages(sid, profile=_session_profile)
             elif not is_messaging_session:
                 # Metadata-only callers still need the same append-only
-                # reconciliation contract as full loads. A raw state.db summary
-                # can count stale rows that the merge intentionally filters out,
-                # which makes sidebar polling think the transcript is always
-                # newer than the loaded conversation.
-                state_db_messages = get_state_db_session_messages(sid, profile=_session_profile)
-                sidecar_metadata_session = Session.load(sid)
-                sidecar_metadata_messages = (
-                    getattr(sidecar_metadata_session, "messages", []) or []
-                    if sidecar_metadata_session
-                    else []
-                )
+                # reconciliation contract as full loads so stale/replayed
+                # state.db rows do not make sidebar polling think the
+                # transcript is always newer. Helper threads profile= to
+                # honor #2827's TLS-vs-thread fix.
+                metadata_summary = _metadata_only_message_summary(sid, profile=_session_profile)
             _t2 = _time.monotonic()
             effective_model = (
                 _resolve_effective_session_model_for_display(s)
@@ -3840,12 +3865,16 @@ def handle_get(handler, parsed) -> bool:
                     sidecar_messages = getattr(s, "messages", []) or []
                     _all_msgs = merge_session_messages_append_only(cli_messages, sidecar_messages)
                 else:
-                    _metadata_sidecar = sidecar_metadata_messages
-                    if _metadata_sidecar is None:
-                        _metadata_sidecar = getattr(s, "messages", []) or []
-                    _all_msgs = merge_session_messages_append_only(_metadata_sidecar, state_db_messages)
+                    if metadata_summary is None:
+                        metadata_summary = _message_summary(getattr(s, "messages", []) or [])
+                    _summary_message_count = metadata_summary["message_count"]
+                    _summary_last_message_at = metadata_summary["last_message_at"]
+                    _all_msgs = []
             if not load_messages:
-                _summary_message_count = len(_all_msgs)
+                if metadata_summary is None:
+                    metadata_summary = _message_summary(_all_msgs)
+                    _summary_message_count = metadata_summary["message_count"]
+                    _summary_last_message_at = metadata_summary["last_message_at"]
                 if _summary_message_count == 0:
                     # Legacy session with no loaded sidecar and no state.db summary —
                     # fall back to the persisted metadata count from session JSON.
@@ -3858,14 +3887,6 @@ def handle_get(handler, parsed) -> bool:
                             _summary_message_count = max(0, int(metadata_count))
                     except (TypeError, ValueError):
                         pass
-                try:
-                    _summary_last_message_at = max(
-                        float((m or {}).get("timestamp") or 0)
-                        for m in _all_msgs
-                        if isinstance(m, dict)
-                    ) if _all_msgs else 0
-                except (TypeError, ValueError):
-                    _summary_last_message_at = 0
             else:
                 _summary_message_count = None
                 _summary_last_message_at = None

--- a/static/boot.js
+++ b/static/boot.js
@@ -1624,7 +1624,10 @@ function applyBotName(){
       else if(typeof syncModelChip==='function') syncModelChip();
     }
     if(S.session) syncTopbar();
-  }).catch(()=>{});
+  }).catch(e=>{
+    window._modelDropdownReady=null;
+    throw e;
+  });
   const _startBootModelDropdown=()=>{
     const ready=window._modelDropdownReady;
     if(ready&&typeof ready.then==='function') return ready;
@@ -1634,6 +1637,9 @@ function applyBotName(){
   };
   window._modelDropdownReady=null;
   window._ensureModelDropdownReady=_startBootModelDropdown;
+  setTimeout(()=>{
+    try{Promise.resolve(_startBootModelDropdown()).catch(()=>{});}catch(_){}
+  },0);
   // Start independent boot fetches without holding the conversation list behind
   // them. The sidebar can render from /api/sessions while workspace/onboarding
   // metadata settles in parallel.

--- a/static/panels.js
+++ b/static/panels.js
@@ -6736,10 +6736,13 @@ function _refreshModelDropdownsAfterProviderChange(){
     if(typeof window._invalidateSlashModelCache==='function'){
       window._invalidateSlashModelCache();
     }
-    if(typeof populateModelDropdown==='function'){
-      // Fire-and-forget: don't block the providers panel refresh on a
-      // dropdown rebuild. The composer/Settings dropdowns will catch up
-      // on the very next paint frame.
+    // Fire-and-forget: don't block the providers panel refresh on a
+    // dropdown rebuild. The composer/Settings dropdowns will catch up
+    // on the very next paint frame.
+    if(typeof window._ensureModelDropdownReady==='function'){
+      window._modelDropdownReady=null;
+      Promise.resolve(window._ensureModelDropdownReady()).catch(()=>{});
+    }else if(typeof populateModelDropdown==='function'){
       Promise.resolve(populateModelDropdown()).catch(()=>{});
     }
   }catch(_e){

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1828,26 +1828,24 @@ function _openSessionActionMenu(session, anchorEl){
       }
     ));
   }
-  const pinLimitReached=!session.pinned&&_pinnedSessionCount()>=_getPinnedSessionsLimit();
   menu.appendChild(_buildSessionAction(
     session.pinned?t('session_unpin'):t('session_pin'),
-    pinLimitReached?_pinnedSessionsLimitMessage():(session.pinned?t('session_unpin_desc'):t('session_pin_desc')),
+    session.pinned?t('session_unpin_desc'):t('session_pin_desc'),
     session.pinned?ICONS.pin:ICONS.unpin,
     async()=>{
       closeSessionActionMenu();
-      if(pinLimitReached){
-        if(typeof showToast==='function') showToast(_pinnedSessionsLimitMessage(),3000,'error');
-        return;
-      }
       const newPinned=!session.pinned;
       try{
         await api('/api/session/pin',{method:'POST',body:JSON.stringify({session_id:session.session_id,pinned:newPinned})});
         session.pinned=newPinned;
         if(S.session&&S.session.session_id===session.session_id) S.session.pinned=newPinned;
         renderSessionList();
-      }catch(err){showToast(t('session_pin_failed')+err.message);}
+      }catch(err){
+        showToast(t('session_pin_failed')+err.message);
+        await renderSessionList();
+      }
     },
-    (session.pinned?'is-active':'')+(pinLimitReached?' is-disabled':'')
+    session.pinned?'is-active':''
   ));
   menu.appendChild(_buildSessionAction(
     t('session_move_project'),

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -789,7 +789,10 @@ async function loadSession(sid){
       syncTopbar();renderMessages();
       if(typeof resumeManualCompressionForSession==='function') resumeManualCompressionForSession(sid);
       const _dirP=loadDir('.');
-      await _dirP;
+      // Workspace refresh is guarded by session id inside loadDir(); do not
+      // block session-load completion, draft restore, or model resolution on
+      // file-tree IO for users focused on the chat.
+      if(_dirP&&typeof _dirP.catch==='function') _dirP.catch(()=>{});
     }
   }
 

--- a/static/ui.js
+++ b/static/ui.js
@@ -5992,7 +5992,7 @@ function renderMessages(options){
   const msgCount=S.messages.length;
   if(sid!==_messageRenderWindowSid) _resetMessageRenderWindow(sid);
   const renderWindowSize=_currentMessageRenderWindowSize();
-  const renderSignature=_messageRenderCacheSignature();
+  let cachedRenderSignature=null;
   const hasTransientTranscriptUi=!!(
     (window._compressionUi&&(!window._compressionUi.sessionId||window._compressionUi.sessionId===sid)) ||
     (window._handoffUi&&(!window._handoffUi.sessionId||window._handoffUi.sessionId===sid))
@@ -6007,6 +6007,8 @@ function renderMessages(options){
   // cross-channel handoff summaries; otherwise the cached transcript returns
   // before those cards can be inserted.
   if(sid&&sid!==_sessionHtmlCacheSid&&!INFLIGHT[sid]&&!hasTransientTranscriptUi){
+    const renderSignature=_messageRenderCacheSignature();
+    cachedRenderSignature=renderSignature;
     const cached=_sessionHtmlCache.get(sid);
     if(cached&&cached.msgCount===msgCount&&cached.renderWindowSize===renderWindowSize&&cached.signature===renderSignature){
       inner.innerHTML=cached.html;
@@ -6128,6 +6130,13 @@ function renderMessages(options){
   const assistantSegments=new Map();
   const assistantThinking=new Map();
   const userRows=new Map();
+  const toolCallAssistantIdxs=new Set();
+  if(Array.isArray(S.toolCalls)){
+    for(const tc of S.toolCalls){
+      if(!tc) continue;
+      toolCallAssistantIdxs.add(tc.assistant_msg_idx!==undefined?tc.assistant_msg_idx:-1);
+    }
+  }
   // Windowed render loop replaces the legacy full loop:
   // for(let vi=0;vi<visWithIdx.length;vi++)
   for(let vi=0;vi<renderVisWithIdx.length;vi++){
@@ -6374,11 +6383,12 @@ function renderMessages(options){
   // a display list from per-message tool_calls (OpenAI format) stored in each
   // assistant message. This covers the reload case described in issue #140.
   if(!S.busy && (!S.toolCalls||!S.toolCalls.length)){
-    // Pass 1: index tool outputs by tool_call_id / tool_use_id so the
+    // Index tool outputs by tool_call_id / tool_use_id so the
     // fallback-built cards carry their result snippet (not just the command).
     // Without this step CLI-origin sessions reload with empty tool cards.
     const resultsByTid={};
-    S.messages.forEach(m=>{
+    const fallbackToolSources=[];
+    S.messages.forEach((m,rawIdx)=>{
       if(!m) return;
       // OpenAI / Hermes CLI format: role=tool with tool_call_id
       if(m.role==='tool'){
@@ -6398,10 +6408,14 @@ function renderMessages(options){
           resultsByTid[tid]=_cliToolResultSnippet(raw);
         });
       }
+      if(m.role==='assistant'){
+        const hasTopLevelToolCalls=Array.isArray(m.tool_calls)&&m.tool_calls.length>0;
+        const hasContentToolUse=Array.isArray(m.content)&&m.content.some(p=>p&&typeof p==='object'&&p.type==='tool_use');
+        if(hasTopLevelToolCalls||hasContentToolUse) fallbackToolSources.push({m,rawIdx});
+      }
     });
     const derived=[];
-    S.messages.forEach((m,rawIdx)=>{
-      if(m.role!=='assistant') return;
+    fallbackToolSources.forEach(({m,rawIdx})=>{
       // OpenAI format: top-level tool_calls field on the assistant message
       (m.tool_calls||[]).forEach(tc=>{
         if(!tc||typeof tc!=='object') return;
@@ -6548,7 +6562,7 @@ function renderMessages(options){
       const hasTurnUsage=!!msg._turnUsage;
       const compactActivityForMessage=isSimplifiedToolCalling()&&(
         assistantThinking.has(mi)||
-        (S.toolCalls||[]).some(tc=>tc&&(tc.assistant_msg_idx!==undefined?tc.assistant_msg_idx:-1)===mi)
+        toolCallAssistantIdxs.has(mi)
       );
       const durationText=compactActivityForMessage?'':_formatTurnDuration(msg._turnDuration);
       if(!hasTurnUsage&&!durationText&&!gatewayText&&!failoverText&&!modelWarningText) continue;
@@ -6615,10 +6629,11 @@ function renderMessages(options){
   if(typeof _applyMediaPlaybackPreferences==='function') _applyMediaPlaybackPreferences(inner);
   // Populate session cache so switching back here skips a full rebuild.
   _sessionHtmlCacheSid=sid;
-  if(sid&&!hasTransientTranscriptUi){
+  if(sid&&!INFLIGHT[sid]&&!hasTransientTranscriptUi){
     const _html=inner.innerHTML;
     // Only cache sessions with <300KB rendered HTML; evict oldest beyond 8 sessions.
     if(_html.length<300_000){
+      const renderSignature=cachedRenderSignature===null?_messageRenderCacheSignature():cachedRenderSignature;
       _sessionHtmlCache.set(sid,{html:_html,msgCount,renderWindowSize,signature:renderSignature});
       if(_sessionHtmlCache.size>8){_sessionHtmlCache.delete(_sessionHtmlCache.keys().next().value);}
     }

--- a/static/workspace.js
+++ b/static/workspace.js
@@ -105,13 +105,15 @@ function _restoreExpandedDirs(){
 
 async function loadDir(path){
   if(!S.session)return;
+  const sessionId=S.session.session_id;
   try{
     if(!path||path==='.'){
       S._dirCache={};
       _restoreExpandedDirs();  // restore per-workspace expanded state on root load
     }
     S.currentDir=path||'.';
-    const data=await api(`/api/list?session_id=${encodeURIComponent(S.session.session_id)}&path=${encodeURIComponent(path)}`);
+    const data=await api(`/api/list?session_id=${encodeURIComponent(sessionId)}&path=${encodeURIComponent(path)}`);
+    if(!S.session||S.session.session_id!==sessionId)return;
     S.entries=data.entries||[];renderBreadcrumb();renderFileTree();
     // Pre-fetch contents of restored expanded dirs so they render without a second click
     // (parallelized — avoids serial waterfall when multiple dirs are expanded)
@@ -120,10 +122,11 @@ async function loadDir(path){
       const pending=[...expanded].filter(dirPath=>!S._dirCache[dirPath]);
       if(pending.length){
         const results=await Promise.all(pending.map(dirPath=>
-          api(`/api/list?session_id=${encodeURIComponent(S.session.session_id)}&path=${encodeURIComponent(dirPath)}`)
+          api(`/api/list?session_id=${encodeURIComponent(sessionId)}&path=${encodeURIComponent(dirPath)}`)
             .then(dc=>({dirPath,entries:dc.entries||[]}))
             .catch(()=>({dirPath,entries:[]}))
         ));
+        if(!S.session||S.session.session_id!==sessionId)return;
         for(const {dirPath,entries} of results) S._dirCache[dirPath]=entries;
       }
       if(expanded.size>0)renderFileTree();
@@ -143,8 +146,10 @@ async function loadDir(path){
 async function _refreshGitBadge(){
   const badge=$('gitBadge');
   if(!badge||!S.session)return;
+  const sessionId=S.session.session_id;
   try{
-    const data=await api(`/api/git-info?session_id=${encodeURIComponent(S.session.session_id)}`);
+    const data=await api(`/api/git-info?session_id=${encodeURIComponent(sessionId)}`);
+    if(!S.session||S.session.session_id!==sessionId)return;
     if(data.git&&data.git.is_git){
       const g=data.git;
       let text=g.branch||'git';
@@ -158,7 +163,10 @@ async function _refreshGitBadge(){
       badge.style.display='none';
       badge.textContent='';
     }
-  }catch(e){badge.style.display='none';}
+  }catch(e){
+    if(!S.session||S.session.session_id!==sessionId)return;
+    badge.style.display='none';
+  }
 }
 
 function navigateUp(){

--- a/tests/test_configurable_pinned_sessions_limit.py
+++ b/tests/test_configurable_pinned_sessions_limit.py
@@ -54,7 +54,8 @@ def test_pin_limit_setting_is_exposed_and_wired_through_ui():
     assert "window._pinnedSessionsLimit=parseInt(s.pinned_sessions_limit||3,10)||3" in BOOT_JS
     assert "function _getPinnedSessionsLimit()" in SESSIONS_JS
     assert "function _pinnedSessionsLimit()" not in SESSIONS_JS
-    assert "_pinnedSessionCount()>=_getPinnedSessionsLimit()" in SESSIONS_JS
+    assert "_pinnedSessionCount()>=_getPinnedSessionsLimit()" not in SESSIONS_JS
+    assert "await api('/api/session/pin'" in SESSIONS_JS
 
 
 def test_settings_api_persists_integer_pin_limit_and_rejects_invalid_values():

--- a/tests/test_issue1539_provider_removal_dropdown_invalidation.py
+++ b/tests/test_issue1539_provider_removal_dropdown_invalidation.py
@@ -164,6 +164,15 @@ class TestProviderRemoveInvalidatesDropdowns:
             "response (covers the dropdown + badge surfaces from #1539)."
         )
 
+    def test_dropdown_flush_reuses_shared_model_ready_promise(self):
+        src = _read_static("panels.js")
+        body = _extract_function_body(src, "function _refreshModelDropdownsAfterProviderChange(")
+        ensure_pos = body.index("typeof window._ensureModelDropdownReady")
+        reset_pos = body.index("window._modelDropdownReady=null", ensure_pos)
+        call_pos = body.index("window._ensureModelDropdownReady()", reset_pos)
+
+        assert ensure_pos < reset_pos < call_pos
+
     def test_dropdown_flush_is_resilient_to_missing_modules(self):
         """If commands.js or ui.js failed to load, the providers panel must
         still update — the dropdown flush is best-effort (#1539)."""

--- a/tests/test_issue1785_workspace_preview_breadcrumb.py
+++ b/tests/test_issue1785_workspace_preview_breadcrumb.py
@@ -50,6 +50,13 @@ def test_load_dir_keeps_workspace_panel_open_when_clearing_preview():
     )
 
 
+def test_load_dir_ignores_stale_session_results():
+    block = _function_block(WORKSPACE_JS, "loadDir")
+    assert "const sessionId=S.session.session_id" in block
+    assert "encodeURIComponent(sessionId)" in block
+    assert "if(!S.session||S.session.session_id!==sessionId)return;" in block
+
+
 def test_file_preview_breadcrumb_uses_directory_navigation_for_root():
     block = _function_block(WORKSPACE_JS, "renderFileBreadcrumb")
     assert "loadDir('.')" in block, "The preview root breadcrumb should navigate to the workspace root."

--- a/tests/test_issue2508_session_pin_cap.py
+++ b/tests/test_issue2508_session_pin_cap.py
@@ -77,7 +77,9 @@ def test_session_pin_cap_has_backend_and_frontend_guards():
     assert 'function _pinnedSessionCount()' in SESSIONS_JS
     assert 'function _getPinnedSessionsLimit()' in SESSIONS_JS
     assert 'function _pinnedSessionsLimit()' not in SESSIONS_JS
-    assert 'const pinLimitReached=!session.pinned&&_pinnedSessionCount()>=_getPinnedSessionsLimit();' in SESSIONS_JS
+    assert 'const pinLimitReached=!session.pinned&&_pinnedSessionCount()>=_getPinnedSessionsLimit();' not in SESSIONS_JS
+    assert 'if(pinLimitReached)' not in SESSIONS_JS
+    assert "await api('/api/session/pin'" in SESSIONS_JS
     assert 'Only ${limit} conversations can be pinned' in SESSIONS_JS
     assert ".session-action-opt.is-disabled{opacity:.55;cursor:not-allowed;}" in STYLE_CSS
 

--- a/tests/test_issue2821_session_pin_state_sync.py
+++ b/tests/test_issue2821_session_pin_state_sync.py
@@ -1,0 +1,70 @@
+"""Regression checks for #2821 session pin/unpin state sync."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+ROUTES_PY = (ROOT / "api" / "routes.py").read_text(encoding="utf-8")
+SESSIONS_JS = (ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
+
+
+def _function_block(src: str, name: str) -> str:
+    marker = f"function {name}"
+    start = src.find(marker)
+    assert start != -1, f"{name} not found"
+    brace = src.find("{", start)
+    assert brace != -1, f"{name} body not found"
+    depth = 1
+    i = brace + 1
+    while i < len(src) and depth:
+        if src[i] == "{":
+            depth += 1
+        elif src[i] == "}":
+            depth -= 1
+        i += 1
+    assert depth == 0, f"{name} body did not close"
+    return src[start:i]
+
+
+def test_session_field_helper_reads_dicts_and_objects():
+    from api.routes import _session_field
+
+    class SessionLike:
+        session_id = "obj-1"
+        pinned = True
+        archived = False
+
+    assert _session_field({"session_id": "dict-1", "pinned": True}, "pinned", False) is True
+    assert _session_field({"session_id": "dict-1"}, "archived", False) is False
+    assert _session_field(SessionLike(), "session_id", None) == "obj-1"
+    assert _session_field(SessionLike(), "missing", "fallback") == "fallback"
+
+
+def test_pin_limit_snapshot_counts_index_dict_entries():
+    assert "_session_field(existing, \"session_id\", None)" in ROUTES_PY
+    assert "_session_field(existing, \"pinned\", False)" in ROUTES_PY
+    assert "_session_field(existing, \"archived\", False)" in ROUTES_PY
+    start = ROUTES_PY.find("persisted_pinned_ids = {")
+    assert start != -1, "persisted pin snapshot not found"
+    end = ROUTES_PY.find("with LOCK:", start)
+    assert end != -1, "persisted pin snapshot should be computed before LOCK"
+    persisted_snapshot = ROUTES_PY[start:end]
+    assert 'getattr(existing, "pinned", False)' not in persisted_snapshot
+    assert 'getattr(existing, "archived", False)' not in persisted_snapshot
+
+
+def test_pin_action_does_not_short_circuit_on_stale_client_count():
+    body = _function_block(SESSIONS_JS, "_openSessionActionMenu")
+    assert "const pinLimitReached=" not in body
+    assert "if(pinLimitReached)" not in body
+    assert "_pinnedSessionCount()>=_getPinnedSessionsLimit()" not in body
+    assert "await api('/api/session/pin'" in body
+
+
+def test_pin_action_refreshes_session_list_after_pin_failure():
+    body = _function_block(SESSIONS_JS, "_openSessionActionMenu")
+    catch_idx = body.find("}catch(err){")
+    assert catch_idx != -1, "Pin/unpin action must have an error path"
+    catch_block = body[catch_idx:body.find("}", catch_idx + len("}catch(err){")) + 1]
+    assert "showToast(t('session_pin_failed')+err.message)" in catch_block
+    assert "await renderSessionList()" in catch_block

--- a/tests/test_parallel_session_switch.py
+++ b/tests/test_parallel_session_switch.py
@@ -88,9 +88,11 @@ class TestLoadSessionIdleOverlap:
                     "The idle path should rely on renderMessages()'s consolidated "
                     "post-render pass instead of running a second highlight pass."
                 )
-                assert "await" in block and "_dirP" in block, (
-                    "loadDir() result should still be stored and awaited."
+                assert "_dirP" in block and "await _dirP" not in block, (
+                    "loadDir() should refresh the workspace without blocking "
+                    "session-load completion."
                 )
+                assert "_dirP.catch" in block
                 break
 
         assert found, (

--- a/tests/test_session_index.py
+++ b/tests/test_session_index.py
@@ -123,8 +123,8 @@ def test_all_sessions_backfills_last_message_at_for_legacy_index_rows():
     assert persisted[0].get("last_message_at") == 100.0
 
 
-def test_all_sessions_prune_reuses_in_memory_id_snapshot(monkeypatch):
-    """Index pruning should not reacquire the session lock for every row."""
+def test_all_sessions_prune_batches_persisted_id_snapshot(monkeypatch):
+    """Index pruning should not probe each backing file through the helper."""
     index_file = models.SESSION_INDEX_FILE
     entries = [
         {
@@ -152,22 +152,22 @@ def test_all_sessions_prune_reuses_in_memory_id_snapshot(monkeypatch):
             "archived": False,
         },
     ]
+    for entry in entries:
+        (models.SESSION_DIR / f"{entry['session_id']}.json").write_text(
+            "{}",
+            encoding="utf-8",
+        )
     _write_index_file(index_file, entries)
 
-    seen = []
+    def _assert_not_called(session_id, in_memory_ids=None):
+        raise AssertionError("all_sessions should batch persisted ids before pruning")
 
-    def _assert_snapshot_used(session_id, in_memory_ids=None):
-        assert in_memory_ids is not None, "all_sessions should snapshot SESSIONS once before pruning"
-        seen.append(session_id)
-        return True
-
-    monkeypatch.setattr(models, "_index_entry_exists", _assert_snapshot_used)
+    monkeypatch.setattr(models, "_index_entry_exists", _assert_not_called)
     monkeypatch.setattr(models, "_enrich_sidebar_lineage_metadata", lambda _sessions: None)
 
     rows = models.all_sessions()
 
     assert [row["session_id"] for row in rows] == ["sess_a", "sess_b"]
-    assert seen == ["sess_a", "sess_b"]
 
 
 # ── 6. test_incremental_patch_correctness ─────────────────────────────────

--- a/tests/test_session_metadata_fast_path.py
+++ b/tests/test_session_metadata_fast_path.py
@@ -68,6 +68,42 @@ def test_boot_does_not_block_session_restore_on_model_catalog():
     assert "await populateModelDropdown()" not in src
 
 
+def test_boot_primes_model_catalog_without_awaiting_it():
+    """The boot-time prime must NOT await the model-catalog hydration before
+    rendering the session list. A later awaited hydration inside the saved-
+    session restore path at ``if(S.session) await _startBootModelDropdown();``
+    is intentional — that one re-applies the saved session's model after the
+    live catalog hydrates so the chip never shows a stale static default
+    (see comment in static/boot.js next to the saved-session restore).
+    """
+    src = (ROOT / "static" / "boot.js").read_text(encoding="utf-8")
+
+    ensure_pos = src.index("window._ensureModelDropdownReady=_startBootModelDropdown;")
+    prime_pos = src.index("Promise.resolve(_startBootModelDropdown()).catch(()=>{});", ensure_pos)
+    session_restore_pos = src.index("await renderSessionList();", prime_pos)
+
+    assert ensure_pos < prime_pos < session_restore_pos
+
+    # No await on the boot-prime path itself: between ensure_pos and the first
+    # session_restore await, the dropdown is fired-and-forgotten.
+    boot_prelude = src[ensure_pos:session_restore_pos]
+    assert "await _startBootModelDropdown()" not in boot_prelude, (
+        "Boot prelude must not await _startBootModelDropdown — the prime is "
+        "fire-and-forget so the sidebar can render before /api/models returns."
+    )
+    assert "await populateModelDropdown()" not in boot_prelude
+
+
+def test_failed_boot_model_catalog_prime_is_retryable():
+    src = (ROOT / "static" / "boot.js").read_text(encoding="utf-8")
+    start = src.index("const _hydrateBootModelDropdown=()=>populateModelDropdown().then")
+    end = src.index("const _startBootModelDropdown=()=>", start)
+    block = src[start:end]
+
+    assert "window._modelDropdownReady=null;" in block
+    assert "throw e;" in block
+
+
 def test_boot_primes_visible_default_model_without_catalog_fetch():
     src = (ROOT / "static" / "boot.js").read_text(encoding="utf-8")
     default_block_start = src.index("if(s.default_model){")

--- a/tests/test_webui_state_db_reconciliation.py
+++ b/tests/test_webui_state_db_reconciliation.py
@@ -512,6 +512,40 @@ def test_api_session_reload_drops_stale_cached_user_tail_after_saved_assistant(m
     assert handler.response_json["session"]["message_count"] == 2
 
 
+def test_metadata_fast_path_matches_reconciliation_for_restamped_replays(monkeypatch, tmp_path):
+    """#2716 invariant: metadata-only /api/session uses merge_session_messages_append_only
+    (not a raw state.db COUNT) so restamped replay rows don't make sidebar polling think
+    the transcript is always newer than the loaded conversation."""
+    import api.routes as routes
+
+    sid = "webui_reconcile_metadata_replay"
+    _install_test_session(
+        monkeypatch,
+        tmp_path,
+        sid,
+        [
+            {"role": "user", "content": "old user", "timestamp": 1000.0},
+            {"role": "assistant", "content": "old assistant", "timestamp": 1001.0},
+        ],
+    )
+    _make_state_db(
+        tmp_path / "state.db",
+        sid,
+        [
+            {"role": "user", "content": "old user", "timestamp": 1002.0},
+        ],
+    )
+
+    handler = _GetHandler(f"/api/session?session_id={sid}&messages=0&resolve_model=0")
+    routes.handle_get(handler, urlparse(handler.path))
+
+    assert handler.status == 200
+    session = handler.response_json["session"]
+    assert session["messages"] == []
+    assert session["message_count"] == 2
+    assert session["last_message_at"] == 1001.0
+
+
 def test_state_db_reconciliation_preserves_tool_metadata(monkeypatch, tmp_path):
     import api.routes as routes
 


### PR DESCRIPTION
# Release CZ — v0.51.128 (stage-batch10, 2-PR perf + correctness batch)

## What's in this batch

### #2716 — Performance optimizations (@dobby-d-elf) — nesquena APPROVED

Six independent perf nudges plus one correctness fix. nesquena APPROVED on 2026-05-22; cherry-picked onto post-v0.51.127 master with sibling-PR composition resolution.

**The correctness fix**: Refactors the prior inline metadata-only reconciliation into `_metadata_only_message_summary(sid, profile=None)` helper. Pre-fix shortcut could over-count stale state.db replay rows that the merge intentionally filters out, producing false "transcript newer than loaded conversation" signals (same bug class as #2705 / #2686). Threads `profile=` through to preserve #2827's TLS-vs-thread profile fix.

**The perf nudges**:
- Batched persisted-session checks (one `glob` vs N `stat`s in `all_sessions()`)
- Deferred render-cache signature (no recomputation on store path)
- Hoisted assistant tool-activity index (`O(n)` → `O(1)` per-message lookup)
- Workspace stale-session guards (`loadDir` + `_refreshGitBadge`, including the catch-path guard for late 404s)
- Background model-catalog prime (fire-and-forget on boot)
- Retryable failed hydration

### #2830 — fix(sessions): keep pin state authoritative (@franksong2702, closes #2821)

Three coupled bugs in pin synchronization:
- **Bug A (load-bearing)**: `/api/session/pin` pre-snapshot used `getattr(dict, ...)` and silently returned `False` for dict-backed sessions. New `_session_field()` helper handles both.
- **Bug B**: Removed stale client-side `pinLimitReached` short-circuit that could block legitimate pin clicks.
- **Bug C**: Pin/unpin failures now refresh the sidebar from server state instead of leaving it on stale optimistic UI.

## Cherry-pick mechanics for #2716

This PR had been pending merge since 2026-05-22 due to a rebase blocker against the rapidly-advancing master (10+ intervening releases). Used `git apply --3way` of the PR's net delta vs its original merge-base (`f9302601`); 12 of 14 files applied cleanly. Two files needed conflict resolution:

1. **`api/routes.py`**: Master had been carrying an inline correctness fix; PR refactors into a helper. Resolution: took the PR's helper extraction AND added `profile=` threading to preserve #2827's TLS-vs-thread fix (post-PR-base master shipped #2827 which made `get_state_db_session_messages` profile-aware).
2. **`tests/test_webui_state_db_reconciliation.py`**: Kept BOTH master's pre-existing `test_api_session_reload_drops_stale_cached_user_tail_after_saved_assistant` AND the PR's new `test_metadata_fast_path_matches_reconciliation_for_restamped_replays`. They pin different invariants.

## Verification

- ✅ Full pytest: **6,434 passed / 6 skipped / 3 xpassed / 8 subtests passed** in 2m43s
- ✅ Agent self-verify (per skill rule Trigger A + E):
  - `_metadata_only_message_summary` has `profile=` kwarg
  - Production call site passes `profile=_session_profile`
  - `_session_field` handles both dict and object
  - `get_state_db_session_messages` still accepts `profile=` (preserves #2827)
  - Helper executes cleanly end-to-end with unmocked invocation against a real session-load path
- ✅ Opus pre-release advisor reviewed 6 risk areas: **SHIP AS-IS** — no MUST-FIX, no inline SHOULD-FIX
- ✅ JS syntax green on all touched static/ files
- ✅ Python syntax green on api/routes.py + api/models.py
- ✅ Merge-marker grep clean

## Follow-up issues to file (post-tag)

1. **Bug D**: Startup `_session_index.json` rebuild perf for missing-index installs (reviewer's note on PR #2830) — only hits users on first install or after manual index deletion. Functionally correct, just slow.
2. **Test gap**: Multi-profile state.db test for `_metadata_only_message_summary` profile threading — currently uncovered; the kwarg is mechanically obvious from the helper signature but no test pins it.

## Closes

- #2821 (pin state sync)
- `get_state_db_session_summary` dead-code removed (#2716)

---

🤖 Generated and reviewed end-to-end by the agent pipeline (Phase 4 stage build via 3-way apply → agent self-verify → pytest gate → Opus pre-release advisor → SHIP AS-IS).
