### PR TITLE
fix(aux-models): validate auxiliary task slots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Auxiliary model settings now reject unknown task slots instead of allowing arbitrary keys under `config.yaml`'s `auxiliary` block. Valid slots and the `__reset__` sentinel continue to work.
+
 ## [v0.51.132] — 2026-05-24 — Release DD (stage-batch14 — 4-PR replayed-context + interrupted-response + shutdown affordance + passkey opt-in)
 
 ### Added
@@ -27,7 +31,6 @@
   - CHANGELOG entries added for PR #2685 and PR #2824 (both originally missing despite functional code changes)
 - Deferred to follow-up: per-turn cumulative live-tool-prompt token cap (#2685 only added per-call cap; aggregate across many tool calls is a separate refactor).
 - **i18n parity**: 7 new shutdown-affordance keys added across all 11 non-en locales (it, ja, ru, es, de, zh, zh-Hant, pt, ko, fr, tr) so locale parity tests pass on first run.
-
 ## [v0.51.131] — 2026-05-24 — Release DC (stage-batch13 — 6-PR notes-drawer + context-parity + PWA-swipe + locale polish)
 
 ### Added

--- a/api/config.py
+++ b/api/config.py
@@ -2248,6 +2248,10 @@ def set_auxiliary_model(task: str, provider: str, model: str) -> dict:
 
     Special case: task='__reset__' clears all auxiliary slots.
     """
+    if task != "__reset__" and task not in AUX_TASK_SLOTS:
+        raise ValueError(
+            f"Unknown auxiliary task slot: {task!r}. Valid: {list(AUX_TASK_SLOTS)}"
+        )
     config_path = _get_config_path()
     with _cfg_lock:
         config_data = _load_yaml_config_file(config_path)

--- a/tests/test_auxiliary_models_settings.py
+++ b/tests/test_auxiliary_models_settings.py
@@ -215,3 +215,44 @@ class TestAuxiliaryModelsBackend:
         assert "/api/model/options" not in body, (
             "_loadAuxiliaryModels must NOT call /api/model/options (agent-only endpoint)"
         )
+
+    def test_set_auxiliary_model_rejects_unknown_task(self, monkeypatch, tmp_path):
+        """Unknown auxiliary task names must not pollute config.yaml."""
+        from api import config
+
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text("auxiliary: {}\n", encoding="utf-8")
+        monkeypatch.setattr(config, "_get_config_path", lambda: config_path)
+
+        try:
+            config.set_auxiliary_model("arbitrary_key", "openai", "gpt-5.5")
+        except ValueError as exc:
+            assert "Unknown auxiliary task slot" in str(exc)
+            assert "vision" in str(exc)
+        else:
+            raise AssertionError("set_auxiliary_model accepted an unknown task")
+
+        assert "arbitrary_key" not in config_path.read_text(encoding="utf-8")
+
+    def test_model_set_route_returns_400_for_unknown_auxiliary_task(self, monkeypatch):
+        """The route should surface invalid auxiliary task names as a client error."""
+        from types import SimpleNamespace
+        from api import routes
+
+        monkeypatch.setattr(routes, "_check_csrf", lambda _handler: True)
+        monkeypatch.setattr(routes, "read_body", lambda _handler: {
+            "scope": "auxiliary",
+            "task": "arbitrary_key",
+            "provider": "openai",
+            "model": "gpt-5.5",
+        })
+        monkeypatch.setattr(
+            routes,
+            "bad",
+            lambda _handler, msg, status=400: {"ok": False, "error": msg, "status": status},
+        )
+
+        result = routes.handle_post(object(), SimpleNamespace(path="/api/model/set"))
+
+        assert result["status"] == 400
+        assert "Unknown auxiliary task slot" in result["error"]


### PR DESCRIPTION
## Thinking Path
- Auxiliary model settings persist task-specific model overrides in `config.yaml`.
- `set_auxiliary_model(task=...)` should only accept known task slots plus the reset sentinel.
- The old path accepted arbitrary task names, which could pollute the auxiliary config block.
- This PR adds the whitelist guard at the config layer and locks both the direct helper path and route error path.

## What Changed
- Reject unknown auxiliary task slots in `api.config.set_auxiliary_model`.
- Preserve the existing `__reset__` sentinel behavior.
- Add regression coverage for config pollution prevention and the `/api/model/set` 400 response path.
- Add a changelog entry.

## Why It Matters
This is a small defense-in-depth fix for #2871. A bad client request should not be able to write arbitrary keys into the auxiliary model config, and the UI/API should report a client error instead of treating it as a server failure.

Fixes #2871.

## Verification
- `pytest tests/test_auxiliary_models_settings.py -q` -> 25 passed
- `git diff --check` -> passed

## Risks / Follow-ups
- Low risk: the guard only rejects task names outside `AUX_TASK_SLOTS`, while valid task slots and `__reset__` remain covered by tests.

## Model Used
AI-assisted with OpenAI Codex using GPT-5. No external code generation tools beyond local repo inspection, pytest, git, and GitHub CLI.
