### PR TITLE
fix(update): reject apply with no selected target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Update Now no longer reports success or enters the restart wait flow when no WebUI or Agent update target is selected.
+
 ## [v0.51.132] — 2026-05-24 — Release DD (stage-batch14 — 4-PR replayed-context + interrupted-response + shutdown affordance + passkey opt-in)
 
 ### Added
@@ -27,7 +31,6 @@
   - CHANGELOG entries added for PR #2685 and PR #2824 (both originally missing despite functional code changes)
 - Deferred to follow-up: per-turn cumulative live-tool-prompt token cap (#2685 only added per-call cap; aggregate across many tool calls is a separate refactor).
 - **i18n parity**: 7 new shutdown-affordance keys added across all 11 non-en locales (it, ja, ru, es, de, zh, zh-Hant, pt, ko, fr, tr) so locale parity tests pass on first run.
-
 ## [v0.51.131] — 2026-05-24 — Release DC (stage-batch13 — 6-PR notes-drawer + context-parity + PWA-swipe + locale polish)
 
 ### Added

--- a/static/ui.js
+++ b/static/ui.js
@@ -4838,6 +4838,13 @@ async function applyUpdates(){
   const targets=[];
   if(window._updateData?.webui?.behind>0) targets.push('webui');
   if(window._updateData?.agent?.behind>0) targets.push('agent');
+  if(!targets.length){
+    const msg='No update target selected. Refresh update status and retry.';
+    if(errEl){errEl.textContent=msg;errEl.style.display='block';}
+    else showToast(msg,5000,'error');
+    resetApplyButton(0);
+    return;
+  }
   try{
     for(const target of targets){
       const res=await api('/api/updates/apply',{method:'POST',body:JSON.stringify({target}),timeoutMs:120000});

--- a/tests/test_update_apply_ui.py
+++ b/tests/test_update_apply_ui.py
@@ -53,3 +53,16 @@ def test_update_apply_prevents_duplicate_apply_requests_while_in_flight():
     assert "if(window._updateApplyInFlight) return;" in body
     assert "window._updateApplyInFlight=true;" in body
     assert "window._updateApplyInFlight=false;" in body
+
+
+def test_update_apply_rejects_zero_target_success_path():
+    """Update Now must not claim success when no webui/agent target is selected."""
+    src = _ui_js()
+    apply_start = src.index("async function applyUpdates()")
+    target_agent = src.index("if(window._updateData?.agent?.behind>0) targets.push('agent');", apply_start)
+    try_start = src.index("try{", target_agent)
+    zero_target_guard = src.find("if(!targets.length)", target_agent, try_start)
+
+    assert zero_target_guard >= 0, (
+        "applyUpdates must return before the success/restart flow when targets is empty"
+    )


### PR DESCRIPTION
## Thinking Path
- `Update Now` builds an apply target list from the current update status payload.
- If the list is empty, no backend apply request is sent.
- The old frontend path still showed the success/restarting toast and entered the reload wait flow.
- A zero-target update should instead be treated as an actionable client-side error.

## What Changed
- Add an early `!targets.length` guard in `applyUpdates()`.
- Show a clear error message and reset the update button instead of claiming success.
- Add a regression test for the zero-target path.
- Add a changelog entry.

## Why It Matters
This prevents a misleading self-update success state where the UI reports a restart even though no update was applied.

Fixes #2879.

## Verification
- `pytest tests/test_update_apply_ui.py -q` -> 5 passed
- `node --check static/ui.js` -> passed
- `git diff --check` -> passed

## Risks / Follow-ups
- Low risk: the new path only runs when no update target is selected.
- No screenshot included because the failure is a guarded edge path covered by regression tests, not a layout change.

## Model Used
AI-assisted with OpenAI Codex using GPT-5. No external code generation tools beyond local repo inspection, pytest, node syntax checks, git, and GitHub CLI.
