### PR TITLE
fix(notes): send Joplin token in Authorization header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Joplin notes drawer API calls now send the Web Clipper token in an `Authorization` header instead of placing it in the request URL query string.
+
 ## [v0.51.132] — 2026-05-24 — Release DD (stage-batch14 — 4-PR replayed-context + interrupted-response + shutdown affordance + passkey opt-in)
 
 ### Added
@@ -27,7 +31,6 @@
   - CHANGELOG entries added for PR #2685 and PR #2824 (both originally missing despite functional code changes)
 - Deferred to follow-up: per-turn cumulative live-tool-prompt token cap (#2685 only added per-call cap; aggregate across many tool calls is a separate refactor).
 - **i18n parity**: 7 new shutdown-affordance keys added across all 11 non-en locales (it, ja, ru, es, de, zh, zh-Hant, pt, ko, fr, tr) so locale parity tests pass on first run.
-
 ## [v0.51.131] — 2026-05-24 — Release DC (stage-batch13 — 6-PR notes-drawer + context-parity + PWA-swipe + locale polish)
 
 ### Added

--- a/api/routes.py
+++ b/api/routes.py
@@ -12534,7 +12534,7 @@ def _joplin_connection_from_config() -> tuple[str, str]:
 def _joplin_api_get(path: str, params: dict | None = None) -> dict:
     """Call the local Joplin Web Clipper API without logging credentials."""
     from urllib.parse import urlencode
-    from urllib.request import urlopen
+    from urllib.request import Request, urlopen
     from urllib.error import HTTPError, URLError
 
     base_url, token = _joplin_connection_from_config()
@@ -12542,10 +12542,10 @@ def _joplin_api_get(path: str, params: dict | None = None) -> dict:
         raise ValueError("Joplin token is not configured")
     safe_path = "/" + str(path or "").lstrip("/")
     query = dict(params or {})
-    query["token"] = token
     url = f"{base_url}{safe_path}?{urlencode(query)}"
+    request = Request(url, headers={"Authorization": f"token {token}"})
     try:
-        with urlopen(url, timeout=8) as response:
+        with urlopen(request, timeout=8) as response:
             raw = response.read(2_000_000).decode("utf-8", errors="replace")
     except HTTPError as exc:
         raise ValueError(f"Joplin API returned HTTP {exc.code}") from None

--- a/tests/test_webui_notes_sources.py
+++ b/tests/test_webui_notes_sources.py
@@ -132,6 +132,39 @@ def test_joplin_get_note_validates_id_and_truncates_body(monkeypatch):
     assert "Preview truncated" in note["body"]
 
 
+def test_joplin_api_get_uses_authorization_header(monkeypatch):
+    from api import routes
+
+    captured = {}
+
+    class FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_exc):
+            return False
+
+        def read(self, _limit):
+            return b'{"ok": true}'
+
+    def fake_urlopen(request, timeout):
+        captured["url"] = request.full_url
+        captured["authorization"] = request.get_header("Authorization")
+        captured["timeout"] = timeout
+        return FakeResponse()
+
+    monkeypatch.setattr(routes, "_joplin_connection_from_config", lambda: ("http://127.0.0.1:41184", "secret-token"))
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+    data = routes._joplin_api_get("/notes", {"query": "hello world"})
+
+    assert data == {"ok": True}
+    assert captured["timeout"] == 8
+    assert "token=" not in captured["url"]
+    assert "query=hello+world" in captured["url"]
+    assert captured["authorization"] == "token secret-token"
+
+
 def test_joplin_recent_ai_notes_uses_configured_prefill_script(monkeypatch, tmp_path):
     from api import routes
 


### PR DESCRIPTION
## Thinking Path
- The notes drawer Joplin helper needs to authenticate to the local Joplin API.
- Putting the token in the URL works, but URLs are easy to leak through future logging or diagnostics.
- A request header is the narrower place for the token and keeps it out of the generated URL string.
- The fix belongs in `_joplin_api_get`, where the request is built.

## What Changed
- Build Joplin request URLs without a `token=` query parameter.
- Send `Authorization: token <token>` through `urllib.request.Request` headers.
- Add regression coverage that verifies the token is in the header and not in the URL.
- Add a changelog entry.

## Why It Matters
This is a defense-in-depth safety fix for the notes drawer. It reduces the chance that a future URL log leaks a Joplin token.

Fixes #2886.

## Verification
- `pytest tests/test_webui_notes_sources.py -q` -> 12 passed
- `git diff --check` -> passed

## Risks / Follow-ups
- Low risk: Joplin supports token auth through the `Authorization` header, and the test locks the request shape.

## Model Used
AI-assisted with OpenAI Codex using GPT-5. No external code generation tools beyond local repo inspection, pytest, git, and GitHub CLI.
