### PR TITLE
fix(streaming): preserve cached agent prefill context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Cached WebUI agents no longer overwrite `prefill_messages` with an empty list when a later request does not include explicit prefill context.
+
 ## [v0.51.132] — 2026-05-24 — Release DD (stage-batch14 — 4-PR replayed-context + interrupted-response + shutdown affordance + passkey opt-in)
 
 ### Added
@@ -27,7 +31,6 @@
   - CHANGELOG entries added for PR #2685 and PR #2824 (both originally missing despite functional code changes)
 - Deferred to follow-up: per-turn cumulative live-tool-prompt token cap (#2685 only added per-call cap; aggregate across many tool calls is a separate refactor).
 - **i18n parity**: 7 new shutdown-affordance keys added across all 11 non-en locales (it, ja, ru, es, de, zh, zh-Hant, pt, ko, fr, tr) so locale parity tests pass on first run.
-
 ## [v0.51.131] — 2026-05-24 — Release DC (stage-batch13 — 6-PR notes-drawer + context-parity + PWA-swipe + locale polish)
 
 ### Added

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -4374,7 +4374,7 @@ def _run_agent_streaming(
                         agent.reasoning_callback = _agent_kwargs.get('reasoning_callback')
                     if hasattr(agent, 'clarify_callback'):
                         agent.clarify_callback = _agent_kwargs.get('clarify_callback')
-                    if hasattr(agent, 'prefill_messages'):
+                    if 'prefill_messages' in _agent_kwargs and hasattr(agent, 'prefill_messages'):
                         agent.prefill_messages = list(_agent_kwargs.get('prefill_messages') or [])
                     if _session_db is not None:
                         # Close any previously held SessionDB connection before

--- a/tests/test_webui_prefill_context.py
+++ b/tests/test_webui_prefill_context.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 
 def test_prefill_json_file_keeps_valid_roles_and_drops_invalid_items(tmp_path):
@@ -78,3 +79,14 @@ def test_prefill_status_redactor_handles_secret_shaped_text():
 
     assert "redaction-test-placeholder" not in redacted
     assert "[REDACTED]" in redacted
+
+
+def test_cached_agent_prefill_refresh_requires_explicit_kwargs():
+    """Cached agents should not get an empty prefill list when kwargs omitted it."""
+    src = Path("api/streaming.py").read_text(encoding="utf-8")
+    callback_refresh = src.index("# Refresh per-turn callbacks")
+    session_db_refresh = src.index("if _session_db is not None:", callback_refresh)
+    body = src[callback_refresh:session_db_refresh]
+
+    assert "'prefill_messages' in _agent_kwargs" in body
+    assert "hasattr(agent, 'prefill_messages')" in body


### PR DESCRIPTION
## Thinking Path
- Cached WebUI agent instances may be reused across requests.
- `prefill_messages` should only be refreshed when the caller explicitly provides prefill context.
- The old cache-refresh path materialized an empty list even when `_agent_kwargs` did not include `prefill_messages`.
- The correct guard is membership in `_agent_kwargs`, not just `hasattr(agent, 'prefill_messages')`.

## What Changed
- Tighten the cached-agent `prefill_messages` assignment to require an explicit `_agent_kwargs` key.
- Preserve the existing list coercion when prefill context is provided.
- Add a defensive regression test for the no-prefill cache-refresh path.
- Add a changelog entry.

## Why It Matters
This prevents an accidental cache-refresh path from clearing or overwriting prefill context when no new prefill was supplied.

Fixes #2887.

## Verification
- `pytest tests/test_webui_prefill_context.py -q` -> 5 passed
- `git diff --check` -> passed

## Risks / Follow-ups
- Low risk: the change only narrows when WebUI mutates `agent.prefill_messages`; explicit prefill still follows the existing path.

## Model Used
AI-assisted with OpenAI Codex using GPT-5. No external code generation tools beyond local repo inspection, pytest, git, and GitHub CLI.
