### PR TITLE
perf(session): cumulative tail-window load for older history

### DIFF
--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1356,7 +1356,15 @@ async function _loadOlderMessages() {
   // rebuilt transcript (#1937).
   const startGeneration = _messagesGeneration;
   try {
-    const data = await api(`/api/session?session_id=${encodeURIComponent(sid)}&messages=1&resolve_model=0&msg_before=${_oldestIdx}&msg_limit=${_INITIAL_MSG_LIMIT}`);
+    // Ask the server for a larger authoritative tail window instead of a
+    // separate msg_before page. The same /api/session contract handles both —
+    // post-#2716 the backend always runs the full append-only merge, so a
+    // larger msg_limit on the same call produces the same merged transcript
+    // we'd get by stitching pages, but without client-side index bookkeeping.
+    // Cumulative growth: each "load more" asks for currentLoaded + 30, and the
+    // newly exposed head is what we expose to the user.
+    const requestedLimit = Math.max(_INITIAL_MSG_LIMIT, (S.messages || []).length + _INITIAL_MSG_LIMIT);
+    const data = await api(`/api/session?session_id=${encodeURIComponent(sid)}&messages=1&resolve_model=0&msg_limit=${requestedLimit}`);
     // Guard: api() may have redirected (401) and returned undefined.
     if (!data || !data.session) { _loadingOlder = false; return; }
     //  - response shape sane
@@ -1374,13 +1382,50 @@ async function _loadOlderMessages() {
     // counter and abort cleanly. _oldestIdx and _messagesTruncated were
     // already reset by the wholesale-replace path, so no rollback needed.
     if (_messagesGeneration !== startGeneration) return;
-    const olderMsgs = (data.session.messages || []).filter(m => m && m.role);
-    if (!olderMsgs.length) { _messagesTruncated = false; return; }
-    // Prepend older messages
+    let responseSession = data.session;
+    let expandedMsgs = (responseSession.messages || []).filter(m => m && m.role);
+    const currentMsgs = (S.messages || []).filter(m => m && m.role);
+    const currentLen = currentMsgs.length;
+    // Suffix-continuity check: the cumulative tail is only safe to wholesale-
+    // replace when our currently-displayed messages are still its suffix. If
+    // the server appended new messages (or merge filtered something) while we
+    // were awaiting, the suffix won't line up — fall back to the legacy
+    // msg_before page so we never drop visible older messages on the floor.
+    let tailMatches = expandedMsgs.length >= currentLen;
+    if (tailMatches && currentLen > 0) {
+      const start = expandedMsgs.length - currentLen;
+      for (let i = 0; i < currentLen; i++) {
+        if (!_sameTranscriptMessage(expandedMsgs[start + i], currentMsgs[i])) {
+          tailMatches = false;
+          break;
+        }
+      }
+    }
+    let olderCount = Math.max(0, expandedMsgs.length - currentLen);
+    let olderMsgs = expandedMsgs.slice(0, olderCount);
+    let nextMessages = expandedMsgs;
+    if (!tailMatches) {
+      // Race fallback: keep the legacy index-page request as the
+      // correctness-preserving alternative. Same guards reapplied because
+      // we just awaited again.
+      const fallback = await api(`/api/session?session_id=${encodeURIComponent(sid)}&messages=1&resolve_model=0&msg_before=${_oldestIdx}&msg_limit=${_INITIAL_MSG_LIMIT}`);
+      if (!fallback || !fallback.session) { _loadingOlder = false; return; }
+      if (!S.session || S.session.session_id !== sid) return;
+      if (_loadingSessionId !== null && _loadingSessionId !== sid) return;
+      if (_messagesGeneration !== startGeneration) return;
+      responseSession = fallback.session;
+      olderMsgs = (responseSession.messages || []).filter(m => m && m.role);
+      nextMessages = [...olderMsgs, ...S.messages];
+    }
+    if (!olderMsgs.length) { _messagesTruncated = !!responseSession._messages_truncated; return; }
+    // Replace with the larger tail window and preserve scroll as if older
+    // messages were prepended. When the suffix check fails, nextMessages
+    // already encodes the legacy prepend fallback so the visible behavior
+    // matches the old msg_before page path exactly.
     // Use $('messages') — the scrollable container (#msgInner is not scrollable).
     const container = $('messages');
     const prevScrollH = container ? container.scrollHeight : 0;
-    S.messages = [...olderMsgs, ...S.messages];
+    S.messages = nextMessages;
     // renderMessages() windows long transcripts from the end. If we do not
     // expand that window before rendering, the newly prepended page stays
     // hidden and the "hidden" counter rises while the viewport appears stuck.
@@ -1394,8 +1439,8 @@ async function _loadOlderMessages() {
       return !!(msgContent(m)||m._statusCard||m.attachments?.length||(m.role==='assistant'&&(hasTc||hasTu||(typeof _messageHasReasoningPayload==='function'&&_messageHasReasoningPayload(m)))));
     }).length;
     _messageRenderWindowSize=_currentMessageRenderWindowSize()+Math.max(addedRenderable, MESSAGE_RENDER_WINDOW_DEFAULT);
-    _messagesTruncated = !!data.session._messages_truncated;
-    _oldestIdx = data.session._messages_offset || 0;
+    _messagesTruncated = !!responseSession._messages_truncated;
+    _oldestIdx = responseSession._messages_offset || 0;
     renderMessages({ preserveScroll: true });
     if (container) {
       // Prepending older messages must not teleport the reader. Preserve the

--- a/tests/test_issue1937_endless_scroll_jumpstart_race.py
+++ b/tests/test_issue1937_endless_scroll_jumpstart_race.py
@@ -106,13 +106,13 @@ def test_load_older_aborts_when_generation_changed():
     )
 
 
-def test_load_older_generation_check_runs_before_prepend():
-    """Generation check must come BEFORE the `S.messages = [...older, ...]` mutation."""
+def test_load_older_generation_check_runs_before_replace():
+    """Generation check must come BEFORE the `S.messages = nextMessages` mutation."""
     body = _function_body(SESSIONS_JS, "_loadOlderMessages")
     guard_idx = body.index("if (_messagesGeneration !== startGeneration) return;")
-    prepend_idx = body.index("S.messages = [...olderMsgs, ...S.messages];")
-    assert guard_idx < prepend_idx, (
-        "Generation guard must short-circuit BEFORE the prepend. "
+    replace_idx = body.index("S.messages = nextMessages;")
+    assert guard_idx < replace_idx, (
+        "Generation guard must short-circuit BEFORE the message-array mutation. "
         "Otherwise duplicate messages can still slip through. See #1937."
     )
 

--- a/tests/test_older_history_viewport_preservation.py
+++ b/tests/test_older_history_viewport_preservation.py
@@ -21,11 +21,11 @@ def _function_body(src: str, signature: str) -> str:
 def test_loading_older_messages_expands_render_window_before_rendering():
     body = _function_body(SESSIONS_JS, "async function _loadOlderMessages")
 
-    prepend_idx = body.index("S.messages = [...olderMsgs, ...S.messages]")
+    replace_idx = body.index("S.messages = nextMessages")
     expand_idx = body.index("_messageRenderWindowSize=_currentMessageRenderWindowSize()")
     render_idx = body.index("renderMessages({ preserveScroll: true });")
 
-    assert prepend_idx < expand_idx < render_idx, (
+    assert replace_idx < expand_idx < render_idx, (
         "scroll-to-top paging must expand the DOM render window before renderMessages(); "
         "otherwise fetched older messages stay hidden and only the hidden counter changes"
     )

--- a/tests/test_parallel_session_switch.py
+++ b/tests/test_parallel_session_switch.py
@@ -410,15 +410,23 @@ class TestMessagePaginationFrontend:
         """_loadOlderMessages must be defined for scroll-to-top loading."""
         assert "async function _loadOlderMessages" in SESSIONS_JS
 
-    def test_load_older_uses_index_cursor(self):
-        """_loadOlderMessages must pass msg_before as integer index, not timestamp."""
+    def test_load_older_uses_cumulative_tail_limit(self):
+        """_loadOlderMessages requests a larger authoritative tail window via msg_limit.
+
+        The cumulative tail path is the default. msg_before remains in the
+        body as the race-fallback request when the suffix-continuity check
+        fails.
+        """
         fn_start = SESSIONS_JS.find("async function _loadOlderMessages")
         fn_end = SESSIONS_JS.find("\n}", fn_start) + 2
         fn_body = SESSIONS_JS[fn_start:fn_end]
 
-        assert "msg_before=${_oldestIdx}" in fn_body, (
-            "_loadOlderMessages should use _oldestIdx (integer) as msg_before cursor"
-        )
+        assert "requestedLimit" in fn_body
+        assert "S.messages || []" in fn_body
+        assert "msg_limit=${requestedLimit}" in fn_body
+        assert "tailMatches" in fn_body
+        # Race fallback still issues the legacy msg_before page request.
+        assert "msg_before=${_oldestIdx}" in fn_body
 
     def test_ensure_all_messages_function_exists(self):
         """_ensureAllMessagesLoaded must exist for operations needing full history."""
@@ -492,7 +500,7 @@ class TestSessionSwitchCancellation:
         """Verify the guard prevents S.messages mutation.
 
         The guard `if (_loadingSessionId !== null && _loadingSessionId !== sid) return`
-        runs BEFORE `S.messages = [...olderMsgs, ...S.messages]`.
+        runs BEFORE `S.messages = nextMessages`.
         If the session changed, we return early — no mutation.
         """
         fn_start = SESSIONS_JS.find("async function _loadOlderMessages")
@@ -501,7 +509,7 @@ class TestSessionSwitchCancellation:
 
         # Guard must appear before S.messages mutation
         guard_idx = fn_body.find("_loadingSessionId")
-        mutation_idx = fn_body.find("S.messages = [...olderMsgs")
+        mutation_idx = fn_body.find("S.messages = nextMessages")
         assert guard_idx >= 0 and mutation_idx >= 0 and guard_idx < mutation_idx, (
             "The _loadingSessionId guard must appear BEFORE the S.messages "
             "mutation to prevent stale data from landing on the wrong session."
@@ -552,7 +560,7 @@ class TestSessionSwitchCancellation:
         )
         # The S.session check must appear BEFORE the S.messages mutation.
         active_check_idx = fn_body.find("S.session.session_id !== sid")
-        mutation_idx = fn_body.find("S.messages = [...olderMsgs")
+        mutation_idx = fn_body.find("S.messages = nextMessages")
         assert active_check_idx >= 0 and mutation_idx >= 0 and active_check_idx < mutation_idx, (
             "Active-session guard must run before S.messages mutation."
         )


### PR DESCRIPTION
# perf(session): cumulative tail-window load for older history

## Context

Follow-up to #2835 (closed) per the maintainer's split recommendation:

> Split B — Cumulative-tail "Load older history" in `static/sessions.js`
> ... a completely different file from the contested metadata path.
> The cumulative `msg_limit=currentLoaded+30` with suffix-continuity
> guard is cleaner than the page-stitching approach and the legacy
> fallback handles the race correctly. ... Please re-file as a separate
> PR against post-#2716 master — this can land immediately, no rebase
> considerations because it's untouched by #2716.

This branch is exactly that. Independent of `perf/merge-cache`, applies
cleanly on `origin/master = 4132085e`.

## What changes

`_loadOlderMessages()` previously fetched older messages with a legacy
index-cursor page (`msg_before=_oldestIdx&msg_limit=30`) and prepended
the page to `S.messages`. After #2716 the backend always runs the full
append-only merge for `/api/session?messages=1` — and the same merge
runs for a larger `msg_limit` on the same call — so we can ask for a
larger authoritative tail window directly instead of stitching pages
on the client.

### Default path

```text
msg_limit = currentLoaded + 30
```

The newly exposed head of the response is what the user sees as
"older messages". No new query parameters, no contract changes, the
same `/api/session` endpoint as before.

### Suffix-continuity check

The cumulative tail is only safe to wholesale-replace when the
currently-displayed messages are still its suffix. The client checks
this with the existing `_sameTranscriptMessage` helper (which already
tolerates timestamp drift and content-array reshapes — same comparator
used elsewhere in `sessions.js`).

### Race fallback

If the suffix check fails (because the session appended new messages
mid-flight, or merge filtered something), the client issues the legacy
`msg_before=_oldestIdx&msg_limit=30` request and prepends that page
instead. So the cumulative path is the default fast path, and the
legacy index page remains as a correctness-preserving fallback.

`msg_before` remains supported by the backend for compatibility.

### Race guards reapplied

After the fallback `await`, the existing race guards are reapplied:

- `S.session.session_id` (#1060)
- `_loadingSessionId` (#1060)
- `_messagesGeneration` snapshot (#1937)

So a session switch or wholesale-replace mid-fallback still bails out
before mutating `S.messages`.

## Test plan

```text
node --check static/sessions.js -> ok

pytest -q \
  tests/test_older_history_viewport_preservation.py \
  tests/test_parallel_session_switch.py \
  tests/test_issue1937_endless_scroll_jumpstart_race.py \
  tests/test_session_tail_payload.py
# 52 passed
```

The four touched test files have static-string assertions that pinned
the old `S.messages = [...olderMsgs, ...S.messages]` mutation site.
Updated to track the new `S.messages = nextMessages` site and the new
`msg_limit=requestedLimit` request shape, while still asserting that
`msg_before` remains in the body for the race-fallback path.

## Diff scope

```text
static/sessions.js                                   | +50 / -9
tests/test_issue1937_endless_scroll_jumpstart_race.py| +5 / -5
tests/test_older_history_viewport_preservation.py    | +2 / -2
tests/test_parallel_session_switch.py                | +18 / -6
4 files changed, 75 insertions(+), 22 deletions(-)
```

## Notes

- This branch does not depend on `perf/merge-cache`. They touch
  different files and either can land first.
- The PR #2835 review noted that cumulative tail growth implicitly
  grows `_messageRenderWindowSize` with `currentLoaded + 30` instead
  of `+30`. That's the correct behavior for "show more old context"
  here, and the existing `MESSAGE_RENDER_WINDOW_DEFAULT` clamp on the
  same line partly bounds memory on long sessions. A hard upper bound
  is a reasonable separate change if the project wants it tracked.
