### PR TITLE
fix: keep underscores literal while streaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Live streamed assistant Markdown now treats underscores in ordinary text and identifiers literally, matching the settled message renderer while preserving asterisk-based emphasis.
+
 ## [v0.51.132] — 2026-05-24 — Release DD (stage-batch14 — 4-PR replayed-context + interrupted-response + shutdown affordance + passkey opt-in)
 
 ### Added

--- a/static/messages.js
+++ b/static/messages.js
@@ -1002,8 +1002,35 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     _smdWrittenLen=0;
     _smdWrittenText='';
     if(!window.smd){_smdParser=null;return;}
-    const renderer=fade ? _streamFadeRenderer(el) : window.smd.default_renderer(el);
+    const baseRenderer=fade ? _streamFadeRenderer(el) : window.smd.default_renderer(el);
+    const renderer=_smdRendererWithoutUnderscoreEmphasis(baseRenderer);
     _smdParser=window.smd.parser(renderer);
+  }
+  function _smdRendererWithoutUnderscoreEmphasis(renderer){
+    if(!renderer||!window.smd) return renderer;
+    const baseAddToken=renderer.add_token;
+    const baseEndToken=renderer.end_token;
+    const baseAddText=renderer.add_text;
+    const tokenStack=[];
+    renderer.add_token=(data,token)=>{
+      if(token===window.smd.ITALIC_UND||token===window.smd.STRONG_UND){
+        const marker=token===window.smd.STRONG_UND?'__':'_';
+        tokenStack.push(marker);
+        baseAddText(data,marker);
+        return;
+      }
+      tokenStack.push(null);
+      baseAddToken(data,token);
+    };
+    renderer.end_token=(data)=>{
+      const marker=tokenStack.pop();
+      if(marker){
+        baseAddText(data,marker);
+        return;
+      }
+      baseEndToken(data);
+    };
+    return renderer;
   }
   // Helper: end the current smd parser (flushes remaining state) and null it out.
   function _smdEndParser(){

--- a/tests/test_streaming_markdown.py
+++ b/tests/test_streaming_markdown.py
@@ -21,6 +21,8 @@ Tests are static (regex / AST-level) — no browser required.
 
 import pathlib
 import re
+import json
+import subprocess
 
 REPO = pathlib.Path(__file__).parent.parent
 MESSAGES_JS = (REPO / "static" / "messages.js").read_text(encoding="utf-8")
@@ -267,6 +269,103 @@ class TestSmdHelpers:
         assert fn and "_smdParser" in fn, (
             "_smdWrite must guard on _smdParser before calling parser_write"
         )
+
+
+class TestSmdUnderscoreEmphasisParity:
+    """Live smd rendering must match renderMd()'s emphasis semantics.
+
+    The settled renderMd() path only treats asterisks as emphasis markers. The
+    smd parser also emits underscore emphasis tokens, so the live renderer wraps
+    smd's renderer and emits those tokens as literal underscores instead.
+    """
+
+    def test_smd_underscore_renderer_wrapper_exists(self):
+        fn = extract_fn(MESSAGES_JS, "_smdRendererWithoutUnderscoreEmphasis")
+        assert fn is not None, (
+            "messages.js must define _smdRendererWithoutUnderscoreEmphasis()"
+        )
+
+    def test_smd_new_parser_wraps_renderer(self):
+        fn = extract_fn(MESSAGES_JS, "_smdNewParser")
+        assert fn and "_smdRendererWithoutUnderscoreEmphasis(" in fn, (
+            "_smdNewParser must wrap the smd renderer before parser creation"
+        )
+
+    def test_smd_wrapper_targets_only_underscore_tokens(self):
+        fn = extract_fn(MESSAGES_JS, "_smdRendererWithoutUnderscoreEmphasis")
+        assert fn and "ITALIC_UND" in fn and "STRONG_UND" in fn, (
+            "The smd wrapper must neutralize underscore emphasis tokens"
+        )
+        assert fn and "ITALIC_AST" not in fn and "STRONG_AST" not in fn, (
+            "The smd wrapper must preserve asterisk emphasis tokens"
+        )
+
+    def test_smd_wrapper_keeps_nested_token_stack(self):
+        fn = extract_fn(MESSAGES_JS, "_smdRendererWithoutUnderscoreEmphasis")
+        assert fn and "tokenStack" in fn and "tokenStack.push(null)" in fn, (
+            "The wrapper must track non-suppressed tokens so nested links/code "
+            "inside underscore text still close through the base renderer"
+        )
+
+    def test_smd_wrapper_runtime_matches_render_md_emphasis_policy(self):
+        helper = extract_fn(MESSAGES_JS, "_smdRendererWithoutUnderscoreEmphasis")
+        assert helper, "_smdRendererWithoutUnderscoreEmphasis function not found"
+        script = f"""
+import * as smd from './static/vendor/smd.min.js';
+globalThis.window = {{ smd }};
+{helper}
+function render(input){{
+  const out=[];
+  const stack=[];
+  const renderer=_smdRendererWithoutUnderscoreEmphasis({{
+    data: {{}},
+    add_token(_data, token){{
+      let tag='';
+      if(token===smd.ITALIC_AST||token===smd.ITALIC_UND) tag='em';
+      if(token===smd.STRONG_AST||token===smd.STRONG_UND) tag='strong';
+      stack.push(tag);
+      if(tag) out.push('<'+tag+'>');
+    }},
+    end_token() {{
+      const tag=stack.pop();
+      if(tag) out.push('</'+tag+'>');
+    }},
+    add_text(_data, text) {{ out.push(text); }},
+    set_attr() {{}},
+  }});
+  const parser=smd.parser(renderer);
+  smd.parser_write(parser,input);
+  smd.parser_end(parser);
+  return out.join('');
+}}
+const cases = {{
+  identifiers: render('agent_response and foo_bar stay literal'),
+  singleUnderscore: render('this is _not emphasis_ now'),
+  doubleUnderscore: render('this is __not strong__ now'),
+  asteriskItalic: render('this is *emphasis* now'),
+  asteriskStrong: render('this is **strong** now'),
+  nestedLinkShape: render('keep _[label](https://example.com)_ literal'),
+}};
+console.log(JSON.stringify(cases));
+"""
+        completed = subprocess.run(
+            ["node", "--input-type=module", "-e", script],
+            cwd=REPO,
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+        cases = json.loads(completed.stdout)
+        assert "<em>" not in cases["identifiers"]
+        assert "agent_response" in cases["identifiers"]
+        assert "foo_bar" in cases["identifiers"]
+        assert cases["singleUnderscore"].count("<em>") == 0
+        assert "_not emphasis_" in cases["singleUnderscore"]
+        assert cases["doubleUnderscore"].count("<strong>") == 0
+        assert "__not strong__" in cases["doubleUnderscore"]
+        assert "<em>emphasis</em>" in cases["asteriskItalic"]
+        assert "<strong>strong</strong>" in cases["asteriskStrong"]
+        assert "_label_" in cases["nestedLinkShape"]
 
 
 # ── 4. _scheduleRender: smd path vs fallback ──────────────────────────────────


### PR DESCRIPTION
## Thinking Path

- Hermes WebUI uses `streaming-markdown` for live assistant tokens, then replaces the live DOM with the settled `renderMd()` output when the turn finishes.
- `renderMd()` only treats asterisk emphasis as Markdown emphasis, but `streaming-markdown` emits separate underscore emphasis tokens.
- That mismatch made ordinary live text containing `_` look italicized until the final settled render corrected it.
- The smallest durable fix is to keep using `smd`, but wrap its renderer so underscore emphasis tokens emit literal `_` / `__` markers while asterisk emphasis still renders normally.

## What Changed

- Wrapped the live `smd` renderer in `_smdRendererWithoutUnderscoreEmphasis()`.
- The wrapper neutralizes only `ITALIC_UND` and `STRONG_UND` tokens by writing literal underscores.
- Asterisk-based `*emphasis*` and `**strong**` still pass through the base renderer.
- Added runtime-backed regression coverage in `tests/test_streaming_markdown.py` using the vendored `smd.min.js` module.
- Added a short Unreleased changelog note.

## Why It Matters

Live streamed Markdown now matches the final settled renderer for ordinary identifiers and prose such as `agent_response`, `foo_bar`, and `_not emphasis_`. Users no longer see a paragraph temporarily turn italic during a response only to fix itself at completion.

## Verification

Passed:

```bash
/Users/georgeandraws/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_streaming_markdown.py -q
# 60 passed, 1 warning in 4.57s

/Users/georgeandraws/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_renderer_js_behaviour.py tests/test_renderer_comprehensive.py -q
# 99 passed, 1 warning in 9.31s

git diff --check
# passed
```

Additional check:

```bash
node --input-type=module -e "import * as smd from './static/vendor/smd.min.js'; console.log(JSON.stringify({ITALIC_AST:smd.ITALIC_AST,ITALIC_UND:smd.ITALIC_UND,STRONG_AST:smd.STRONG_AST,STRONG_UND:smd.STRONG_UND}))"
# {"ITALIC_AST":12,"ITALIC_UND":13,"STRONG_AST":14,"STRONG_UND":15}
```

Full-suite note:

```bash
/Users/georgeandraws/.hermes/hermes-agent/venv/bin/python -m pytest tests/ -q
# 6539 passed, 5 skipped, 3 xpassed, 8 subtests passed, 5 failed
```

The five full-suite failures appear unrelated to this diff:

- Three skills API tests build URLs with an unescaped local skill name containing a space: `Systematic Debugging`.
- Two workspace git tests assume `git init` creates `master`, but this machine creates a different default branch.
- This PR only changes `CHANGELOG.md`, `static/messages.js`, and `tests/test_streaming_markdown.py`.

## Risks / Follow-ups

- Low risk: the wrapper only intercepts `smd` underscore emphasis token IDs and forwards all other tokens to the existing renderer.
- A future `streaming-markdown` upgrade that renames token constants should keep the focused regression red.
- No new dependencies, build tools, or broader streaming lifecycle changes.

## Model Used

- OpenAI Codex CLI via `npx -y @openai/codex exec --full-auto` for investigation and implementation.
- Hermes parent verification with OpenAI Codex provider, model `gpt-5.5`.
