### PR TITLE
fix(chat): dedupe uploaded-file pending turns

### DIFF
--- a/static/sessions.js
+++ b/static/sessions.js
@@ -647,6 +647,7 @@ async function loadSession(sid){
     if(!Array.isArray(messages)) return false;
     const pendingMsg=typeof getPendingSessionMessage==='function'?getPendingSessionMessage(session,messages):null;
     if(!pendingMsg) return false;
+    if(messages.some(existing=>_sameTranscriptMessage(existing,pendingMsg))) return false;
     const liveAssistantIdx=messages.findIndex(m=>m&&m.role==='assistant'&&m._live);
     if(liveAssistantIdx>=0) messages.splice(liveAssistantIdx,0,pendingMsg);
     else messages.push(pendingMsg);

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -665,6 +665,12 @@ def test_inflight_merge_dedupes_uploaded_user_message(cleanup_test_sessions):
     assert "role==='user'" in src, (
         "attached-files normalization should be limited to user turns"
     )
+    pending_idx = src.find("function _mergePendingSessionMessage")
+    assert pending_idx >= 0, "pending session merge helper not found"
+    pending_block = src[pending_idx:pending_idx+500]
+    assert "_sameTranscriptMessage(existing,pendingMsg)" in pending_block, (
+        "pending-user merge should reuse transcript identity dedupe before inserting the server pending message"
+    )
 
 
 def test_loadSession_inflight_sets_active_stream_before_replaying_live_tool_cards(cleanup_test_sessions):


### PR DESCRIPTION
## Thinking Path
- Hermes WebUI keeps active chat turns coherent across the persisted transcript, pending turn metadata, and browser-side optimistic state.
- Uploaded-file turns can render an optimistic user bubble before the server returns the pending message text with an `[Attached files: ...]` suffix.
- #2723 already normalized that suffix for the INFLIGHT tail merge path.
- The pending-session merge helper used during active-session restore still inserted the server pending message without checking transcript identity first.
- This PR applies the same `_sameTranscriptMessage` identity check to that pending merge path so the same uploaded-file user turn is rendered once.

## What Changed
- Reuses `_sameTranscriptMessage(existing, pendingMsg)` in `_mergePendingSessionMessage()` before inserting a server pending user message.
- Extends the existing uploaded-file dedupe regression to pin the pending-session merge path, not only the INFLIGHT tail merge.

## Why It Matters
- Prevents duplicate user bubbles when an uploaded-file prompt is already visible optimistically and the server-side pending text includes the attached-files marker.
- Keeps the fix narrowly inside the existing session reconciliation logic without adding a DOM-level dedupe pass.
- Follow-up to #2723 / #2725; refs #2361.

## Verification
- `python3 -m pytest -q tests/test_regressions.py::test_inflight_merge_dedupes_uploaded_user_message tests/test_issue2341_pending_user_reattach.py -o addopts=''` -> 3 passed
- `node --check static/sessions.js`
- `git diff --check origin/master...HEAD`
- Added-line public hygiene/secret scan -> 0 hits

## Risks / Follow-ups
- Low risk: one guard in the pending merge helper, using the same transcript identity helper already used by the adjacent INFLIGHT merge logic.
- This does not attempt a broader session-state cleanup; it only closes the missing pending-merge dedupe seam.

## Model Used
- AI-assisted via OpenAI GPT-5.5 in Hermes/TARS with terminal, file-edit, git, and GitHub CLI tooling.
