### PR TITLE
fix(chat): accept session_id URL parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Browser session links that use the API-style `?session_id=<id>` query parameter now open the requested conversation instead of falling back to the last locally stored session.
+
 ## [v0.51.134] — 2026-05-25 — Release DF (stage-batch16 — single-PR Windows path defaults)
 
 ### Fixed

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1556,7 +1556,7 @@ function _sessionIdFromLocation(){
   }
   try{
     const qs=new URLSearchParams(window.location.search||'');
-    return qs.get('session')||null;
+    return qs.get('session')||qs.get('session_id')||null;
   }catch(_e){return null;}
 }
 function _sessionUrlForSid(sid){

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -650,6 +650,25 @@ def test_loadSession_inflight_merges_tail_with_persisted_transcript(cleanup_test
     )
 
 
+
+def test_browser_session_url_accepts_api_session_id_param(cleanup_test_sessions):
+    """External links using ?session_id=... should open that session in the browser.
+
+    The API endpoint uses `session_id`, while the browser URL historically used
+    `session`/`/session/<id>`. Auth/cookie bridges and external callers can
+    legitimately produce `/?session_id=<sid>`; ignoring it falls back to stale
+    localStorage and renders the wrong or empty conversation.
+    """
+    src = (REPO_ROOT / "static/sessions.js").read_text()
+    start = src.find("function _sessionIdFromLocation")
+    assert start >= 0, "session URL parser not found"
+    end = src.find("function _sessionUrlForSid", start)
+    assert end > start, "session URL parser block end not found"
+    block = src[start:end]
+    assert "qs.get('session')" in block or 'qs.get("session")' in block
+    assert "qs.get('session_id')" in block or 'qs.get("session_id")' in block
+
+
 def test_inflight_merge_dedupes_uploaded_user_message(cleanup_test_sessions):
     """Uploaded-file turns render optimistically before the server stores the
     final pending text with an `[Attached files: ...]` suffix.  The INFLIGHT


### PR DESCRIPTION
## Thinking Path
A browser-auth redirect and external callers can land on WebUI with `/?session_id=<id>` because the backend/API parameter is named `session_id`. The client URL parser only accepted `/session/<id>` and `?session=<id>`, so it ignored the explicit target and fell back to the last locally stored session.

## What Changed
- Teach `_sessionIdFromLocation()` to also accept `session_id` from `window.location.search`.
- Add a focused regression assertion for the browser URL parser.
- Add an Unreleased changelog entry.

## Why It Matters
External links, auth bridges, or bookmarked URLs using the API-style parameter now open the requested conversation instead of rendering a stale/empty previous session. Tiny bug. Annoying blast radius. The usual.

## Verification
- `python3 -m pytest -q tests/test_regressions.py::test_browser_session_url_accepts_api_session_id_param tests/test_regressions.py::test_inflight_merge_dedupes_uploaded_user_message -o addopts=''` -> 2 passed
- `node --check static/sessions.js`
- `git diff --check`
- Added-line public/secret marker scan -> 0 hits

## Risks / Follow-ups
Low risk. Existing `/session/<id>` and `?session=<id>` behavior is unchanged; `session_id` is only an additional accepted alias.

## Model Used
OpenAI GPT-5.5 via Hermes/TARS, with terminal/file tooling for tests, git, and PR prep.
