### PR TITLE
Trim tool call payloads for paginated session loads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Trim session-level tool call payloads to the returned message window for paginated `/api/session` loads, so long tool-heavy sessions do not send historical tool call summaries during ordinary session switching.
+
 ## [v0.51.134] — 2026-05-25 — Release DF (stage-batch16 — single-PR Windows path defaults)
 
 ### Fixed

--- a/api/routes.py
+++ b/api/routes.py
@@ -2146,6 +2146,23 @@ def _messages_include_tool_metadata(messages) -> bool:
     return False
 
 
+def _tool_calls_for_message_window(tool_calls, start_idx: int, message_count: int) -> list:
+    """Keep session-level tool calls that point into a returned message window."""
+    if not isinstance(tool_calls, list) or message_count <= 0:
+        return []
+    end_idx = start_idx + message_count
+    filtered = []
+    for tool_call in tool_calls:
+        if not isinstance(tool_call, dict):
+            continue
+        assistant_idx = tool_call.get("assistant_msg_idx")
+        if isinstance(assistant_idx, bool) or not isinstance(assistant_idx, int):
+            continue
+        if start_idx <= assistant_idx < end_idx:
+            filtered.append(tool_call)
+    return filtered
+
+
 def _merged_session_messages_for_display(session, cli_messages=None) -> list:
     """Return the message coordinate space exposed by ``GET /api/session``.
 
@@ -4080,6 +4097,19 @@ def handle_get(handler, parsed) -> bool:
                     _truncated_msgs = _all_msgs
             else:
                 _truncated_msgs = []
+            # Index of the first returned message in the full message array.
+            # Frontend uses this as cursor for scroll-to-top paging.
+            if load_messages and msg_before is not None:
+                _messages_offset = max(0, _before_idx - len(_truncated_msgs))
+            elif load_messages:
+                _messages_offset = max(0, len(_all_msgs) - len(_truncated_msgs))
+            else:
+                _messages_offset = 0
+            _windowed_messages = (
+                load_messages
+                and msg_limit is not None
+                and (msg_before is not None or len(_truncated_msgs) < len(_all_msgs))
+            )
             # Resolve effective context_length with model-metadata fallback so
             # older sessions (pre-#1318) that have context_length=0 persisted
             # still render a meaningful indicator on load.  Mirrors the
@@ -4119,6 +4149,12 @@ def handle_get(handler, parsed) -> bool:
                 # messages already carry per-message tool metadata. Avoid sending
                 # the full historical list with a small tail window.
                 _session_tool_calls = []
+            elif _windowed_messages:
+                _session_tool_calls = _tool_calls_for_message_window(
+                    _session_tool_calls,
+                    _messages_offset,
+                    len(_truncated_msgs),
+                )
             _merged_message_count = _summary_message_count if _summary_message_count is not None else len(_all_msgs)
             _merged_last_message_at = _summary_last_message_at if _summary_last_message_at is not None else 0
             if _summary_last_message_at is None and _all_msgs:
@@ -4179,12 +4215,7 @@ def handle_get(handler, parsed) -> bool:
             else:
                 _truncated = load_messages and msg_limit is not None and len(_all_msgs) > msg_limit
             raw["_messages_truncated"] = _truncated
-            # Index of the first returned message in the full message array.
-            # Frontend uses this as cursor for scroll-to-top paging.
-            if msg_before is not None:
-                raw["_messages_offset"] = max(0, _before_idx - len(_truncated_msgs))
-            else:
-                raw["_messages_offset"] = max(0, len(_all_msgs) - len(_truncated_msgs))
+            raw["_messages_offset"] = _messages_offset
             _t4 = _time.monotonic()
             if effective_model:
                 raw["model"] = effective_model

--- a/tests/test_session_tail_payload.py
+++ b/tests/test_session_tail_payload.py
@@ -12,7 +12,8 @@ class _FakeSession:
         self.model_provider = None
         self.messages = messages
         self.tool_calls = [
-            {"name": "old-tool", "snippet": "historical snippet", "assistant_msg_idx": 0}
+            {"name": "old-tool", "snippet": "historical snippet", "assistant_msg_idx": 0},
+            {"name": "visible-tool", "snippet": "visible snippet", "assistant_msg_idx": 1},
         ]
         self.input_tokens = 0
         self.output_tokens = 0
@@ -43,7 +44,7 @@ class _FakeSession:
         }
 
 
-def _invoke(session):
+def _invoke(session, query=None):
     import api.routes as routes
 
     captured = {}
@@ -53,7 +54,9 @@ def _invoke(session):
         captured["status"] = status
         return data
 
-    parsed = urlparse("/api/session?session_id=tail_payload_001&messages=1&resolve_model=0&msg_limit=1")
+    if query is None:
+        query = "session_id=tail_payload_001&messages=1&resolve_model=0&msg_limit=1"
+    parsed = urlparse(f"/api/session?{query}")
     with patch("api.routes.get_session", return_value=session), \
          patch("api.routes._clear_stale_stream_state", return_value=False), \
          patch("api.routes._lookup_cli_session_metadata", return_value={}), \
@@ -80,7 +83,7 @@ def test_tail_window_omits_historical_tool_calls_when_messages_have_tool_metadat
     assert payload["_messages_truncated"] is True
 
 
-def test_tail_window_keeps_session_tool_calls_for_legacy_messages_without_metadata():
+def test_tail_window_keeps_only_visible_session_tool_calls_for_legacy_messages_without_metadata():
     session = _FakeSession([
         {"role": "user", "content": "older"},
         {"role": "assistant", "content": "visible legacy message"},
@@ -89,4 +92,42 @@ def test_tail_window_keeps_session_tool_calls_for_legacy_messages_without_metada
     payload = _invoke(session)
 
     assert payload["messages"] == [session.messages[-1]]
+    assert payload["tool_calls"] == [session.tool_calls[-1]]
+
+
+def test_full_load_keeps_all_session_tool_calls_for_legacy_messages_without_metadata():
+    session = _FakeSession([
+        {"role": "user", "content": "older"},
+        {"role": "assistant", "content": "visible legacy message"},
+    ])
+
+    payload = _invoke(
+        session,
+        query="session_id=tail_payload_001&messages=1&resolve_model=0",
+    )
+
+    assert payload["messages"] == session.messages
     assert payload["tool_calls"] == session.tool_calls
+
+
+def test_msg_before_window_keeps_only_that_page_session_tool_calls():
+    session = _FakeSession([
+        {"role": "user", "content": "first"},
+        {"role": "assistant", "content": "second legacy message"},
+        {"role": "user", "content": "third"},
+        {"role": "assistant", "content": "fourth legacy message"},
+    ])
+    session.tool_calls = [
+        {"name": "first-page-tool", "snippet": "kept", "assistant_msg_idx": 1},
+        {"name": "tail-tool", "snippet": "not in page", "assistant_msg_idx": 3},
+        {"name": "unindexed-tool", "snippet": "cannot place"},
+    ]
+
+    payload = _invoke(
+        session,
+        query="session_id=tail_payload_001&messages=1&resolve_model=0&msg_before=3&msg_limit=2",
+    )
+
+    assert payload["messages"] == session.messages[1:3]
+    assert payload["tool_calls"] == [session.tool_calls[0]]
+    assert payload["_messages_offset"] == 1


### PR DESCRIPTION
## Thinking Path

`/api/session?messages=1&msg_limit=N` is the fast path used when switching sessions. It already sends only a message window, but legacy sessions can still include the full session-level `tool_calls` list. For long tool-heavy conversations, that means a small message response can still carry a large amount of historical tool-call data the browser cannot render in the current window.

The response contract already exposes `_messages_offset`, so the server can use the same message coordinate space to keep only tool calls whose `assistant_msg_idx` lands inside the returned window. Full transcript loads keep the existing behavior.

## What Changed

- Filter session-level `tool_calls` to the returned message window when `/api/session` is loaded with pagination.
- Preserve full `tool_calls` behavior for non-paginated full transcript loads.
- Keep the existing behavior that omits session-level `tool_calls` when returned messages already include per-message tool metadata.
- Add regression coverage for tail-window loads, full loads, and `msg_before` pagination.
- Add an Unreleased changelog entry.

## Why It Matters

This keeps session switching payloads proportional to the visible message window. It reduces JSON serialization, transfer size, browser parse work, and render bookkeeping for long sessions with many tool calls, without changing the persisted session format.

A local synthetic benchmark with 2,000 messages, 1,000 legacy session-level tool calls, 1 KiB snippets, and `msg_limit=10` reduced the `/api/session` JSON payload from 1,111,267 bytes to 6,487 bytes. Handler + JSON serialization median time dropped from 8.599 ms to 2.436 ms across 150 runs.

## Verification

- `/tmp/hermes-webui-pr-venv/bin/python -m py_compile api/routes.py`
- `/tmp/hermes-webui-pr-venv/bin/python -m pytest tests/test_session_tail_payload.py -q --timeout=60`
- `/tmp/hermes-webui-pr-venv/bin/python -m pytest tests/test_parallel_session_switch.py -q --timeout=60`
- `/tmp/hermes-webui-pr-venv/bin/python -m pytest tests/test_webui_state_db_reconciliation.py -q --timeout=60`
- `GIT_CONFIG_GLOBAL=/tmp/hermes-webui-test-gitconfig /tmp/hermes-webui-pr-venv/bin/python -m pytest tests/ -v --timeout=60`

Full-suite result: `6430 passed, 76 skipped, 3 xpassed, 8 subtests passed in 172.26s`.

## Risks / Follow-ups

Session-level tool calls without `assistant_msg_idx` are omitted from paginated responses because they cannot be placed into a truncated message window. Full transcript loads still return them.

This does not make the frontend initial message limit configurable; that can stay separate.

## Model Used

OpenAI GPT-5.5 via Codex, with local shell-based repository inspection and test execution.
