### PR TITLE
fix(agent_health): detect profile-scoped gateway.pid to fix false "Gateway not configured"

### DIFF
--- a/api/agent_health.py
+++ b/api/agent_health.py
@@ -174,10 +174,24 @@ def _gateway_root_pid_path() -> Path | None:
     Gateway runtime files are root-level singletons.  A profile-scoped WebUI
     process may have HERMES_HOME=<root>/profiles/<name>, but gateway.pid,
     gateway.lock, and gateway_state.json still live under <root>.
+
+    When the root-level gateway.pid is absent (profile-scoped gateway
+    deployments write it under <root>/profiles/<name>/), fall back to the
+    active profile's directory so the gateway is detected correctly.
     """
     try:
         from hermes_constants import get_default_hermes_root
-        return get_default_hermes_root() / _GATEWAY_PID_FILE
+        root_pid = get_default_hermes_root() / _GATEWAY_PID_FILE
+        if root_pid.exists():
+            return root_pid
+        try:
+            from api.profiles import get_active_hermes_home
+            profile_pid = Path(get_active_hermes_home()) / _GATEWAY_PID_FILE
+            if profile_pid.exists():
+                return profile_pid
+        except Exception:
+            pass
+        return root_pid
     except Exception:
         return None
 

--- a/tests/test_agent_health_pid_path_fallback.py
+++ b/tests/test_agent_health_pid_path_fallback.py
@@ -1,0 +1,108 @@
+"""Regression coverage for _gateway_root_pid_path() profile-scoped fallback.
+
+Before the fix, _gateway_root_pid_path() unconditionally returned
+<hermes_root>/gateway.pid.  Profile-scoped gateways (running via
+``gateway run --profile <name>`` or with ``active_profile`` set) write
+their PID file under <hermes_root>/profiles/<name>/gateway.pid instead of
+the root, so the root-level file never existed.  The WebUI's
+build_agent_health_payload() therefore always received a non-existent
+pid_path, fell through to the stale root-level gateway_state.json, and
+returned alive=None — causing the cron page to display "Gateway not
+configured" even though the gateway was running.
+
+Fix: when the root-level gateway.pid is absent, _gateway_root_pid_path()
+now falls back to the active profile's directory.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _call(monkeypatch, root: Path, profile_dir: Path | None = None) -> Path | None:
+    """Call _gateway_root_pid_path() with mocked filesystem roots."""
+    import hermes_constants
+    import api.profiles as profiles
+
+    monkeypatch.setattr(hermes_constants, "get_default_hermes_root", lambda: root)
+    if profile_dir is not None:
+        monkeypatch.setattr(profiles, "get_active_hermes_home", lambda: str(profile_dir))
+
+    from api.agent_health import _gateway_root_pid_path
+    return _gateway_root_pid_path()
+
+
+# ── core behaviour ────────────────────────────────────────────────────────────
+
+def test_returns_root_pid_when_root_level_file_exists(tmp_path, monkeypatch):
+    """Root-level gateway.pid present → return it (original behaviour unchanged)."""
+    root = tmp_path / "hermes"
+    root.mkdir()
+    root_pid = root / "gateway.pid"
+    root_pid.write_text("1234")
+    profile_dir = root / "profiles" / "other"
+    profile_dir.mkdir(parents=True)
+    (profile_dir / "gateway.pid").write_text("9999")
+
+    result = _call(monkeypatch, root=root, profile_dir=profile_dir)
+    assert result == root_pid
+
+
+def test_falls_back_to_profile_pid_when_root_absent(tmp_path, monkeypatch):
+    """Root gateway.pid absent + profile-level exists → return profile path."""
+    root = tmp_path / "hermes"
+    root.mkdir()
+    # root-level gateway.pid intentionally not created
+    profile_dir = root / "profiles" / "safeline"
+    profile_dir.mkdir(parents=True)
+    profile_pid = profile_dir / "gateway.pid"
+    profile_pid.write_text("5678")
+
+    result = _call(monkeypatch, root=root, profile_dir=profile_dir)
+    assert result == profile_pid
+
+
+def test_returns_root_path_when_neither_pid_exists(tmp_path, monkeypatch):
+    """Neither root nor profile gateway.pid exists → return root path (graceful)."""
+    root = tmp_path / "hermes"
+    root.mkdir()
+    profile_dir = root / "profiles" / "empty"
+    profile_dir.mkdir(parents=True)
+    # no gateway.pid created anywhere
+
+    result = _call(monkeypatch, root=root, profile_dir=profile_dir)
+    assert result == root / "gateway.pid"
+
+
+def test_returns_root_path_when_profile_lookup_raises(tmp_path, monkeypatch):
+    """get_active_hermes_home() raising must be caught; root path returned."""
+    root = tmp_path / "hermes"
+    root.mkdir()
+
+    import hermes_constants
+    import api.profiles as profiles
+
+    monkeypatch.setattr(hermes_constants, "get_default_hermes_root", lambda: root)
+
+    def _raise():
+        raise RuntimeError("profile resolution failed")
+
+    monkeypatch.setattr(profiles, "get_active_hermes_home", _raise)
+
+    from api.agent_health import _gateway_root_pid_path
+    result = _gateway_root_pid_path()
+    assert result == root / "gateway.pid"
+
+
+def test_root_takes_priority_over_profile_when_both_exist(tmp_path, monkeypatch):
+    """Root gateway.pid present even when profile pid also exists → root wins."""
+    root = tmp_path / "hermes"
+    root.mkdir()
+    root_pid = root / "gateway.pid"
+    root_pid.write_text("1111")
+    profile_dir = root / "profiles" / "safeline"
+    profile_dir.mkdir(parents=True)
+    (profile_dir / "gateway.pid").write_text("2222")
+
+    result = _call(monkeypatch, root=root, profile_dir=profile_dir)
+    assert result == root_pid


### PR DESCRIPTION
## Problem

When a Hermes gateway runs under a named profile — either via `gateway run --profile <name>` or because `active_profile` is set — it writes its runtime files under:

```
<hermes_root>/profiles/<name>/gateway.pid
<hermes_root>/profiles/<name>/gateway_state.json
```

`_gateway_root_pid_path()` in `api/agent_health.py` unconditionally returned `<hermes_root>/gateway.pid` (the root-level path), which is never created in profile-scoped deployments. As a result, `build_agent_health_payload()` always received a non-existent `pid_path`, fell through to reading the stale root-level `gateway_state.json` (which retains the last recorded state, often `"stopped"` from a previous default-profile run), and returned `alive=None`.

The `/api/gateway/status` route maps `alive=None` to `configured=false`, so the cron/scheduled-jobs page permanently displayed:

> **Gateway not configured** — *scheduled ticks need a gateway container or `hermes gateway` running outside the WebUI.*

…even when a profile-scoped gateway was actively running.

## Root cause

```python
# Before
def _gateway_root_pid_path() -> Path | None:
    try:
        from hermes_constants import get_default_hermes_root
        return get_default_hermes_root() / _GATEWAY_PID_FILE  # always root-level
    except Exception:
        return None
```

The root-level `gateway.pid` is only written when the gateway runs without a named profile. Profile-scoped gateways skip it.

## Fix

After failing to find a root-level `gateway.pid`, fall back to the active profile's directory via `get_active_hermes_home()`:

```python
root_pid = get_default_hermes_root() / _GATEWAY_PID_FILE
if root_pid.exists():
    return root_pid          # root-level wins when present (no behaviour change)
# Fall back to the active profile's directory
profile_pid = Path(get_active_hermes_home()) / _GATEWAY_PID_FILE
if profile_pid.exists():
    return profile_pid
return root_pid              # neither exists — return root path as before
```

Errors from `get_active_hermes_home()` are caught and silently ignored so the function retains its previous safe default.

## Tests

Five new unit tests in `tests/test_agent_health_pid_path_fallback.py`:

| Test | Scenario |
|------|----------|
| `test_returns_root_pid_when_root_level_file_exists` | Root pid present → root path returned (no regression) |
| `test_falls_back_to_profile_pid_when_root_absent` | Root absent, profile pid present → profile path returned |
| `test_returns_root_path_when_neither_pid_exists` | Neither exists → root path returned (graceful) |
| `test_returns_root_path_when_profile_lookup_raises` | `get_active_hermes_home()` raises → root path returned silently |
| `test_root_takes_priority_over_profile_when_both_exist` | Both present → root wins |

All 15 tests in `test_gateway_status_agent_health.py` and `test_agent_health_pid_path_fallback.py` pass.