### PR TITLE
fix(chat): keep one live SSE source per stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Chat streaming now keeps a single live EventSource registered per session/stream, preventing reconnect or context-compaction paths from stacking subscribers and rendering one assistant token stream multiple times.
+
 ## [v0.51.134] — 2026-05-25 — Release DF (stage-batch16 — single-PR Windows path defaults)
 
 ### Fixed

--- a/static/messages.js
+++ b/static/messages.js
@@ -609,10 +609,11 @@ async function send(){
 
 const LIVE_STREAMS={};
 
-function closeLiveStream(sessionId, streamId){
+function closeLiveStream(sessionId, streamId, source){
   const live=LIVE_STREAMS[sessionId];
   if(!live) return;
   if(streamId&&live.streamId!==streamId) return;
+  if(source&&live.source!==source) return;
   try{live.source.close();}catch(_){ }
   delete LIVE_STREAMS[sessionId];
 }
@@ -747,8 +748,8 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     if(_persistTimer) return;
     _persistTimer=setTimeout(()=>{_persistTimer=null;persistInflightState();},2000);
   }
-  function _closeSource(){
-    closeLiveStream(activeSid, streamId);
+  function _closeSource(source){
+    closeLiveStream(activeSid, streamId, source);
   }
   function _stripLiveVisibleAssistantEchoFromThinking(text, snippets){
     let out=String(text||'');
@@ -1455,6 +1456,12 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
   }
 
   function _wireSSE(source){
+    const existingLive=LIVE_STREAMS[activeSid];
+    if(existingLive&&existingLive.source&&existingLive.source!==source){
+      try{existingLive.source.close();}catch(_){ }
+    }
+    LIVE_STREAMS[activeSid]={streamId,source};
+
     // Note on #631 Bug B: the original PR description stated the server
     // "replays buffered token events" on reconnect, and proposed resetting
     // the accumulators here so the re-sent tokens wouldn't double the prefix.
@@ -2081,13 +2088,14 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
 
     source.addEventListener('error',async e=>{
       if(_terminalStateReached || _streamFinalized){
-        _closeSource();
+        _closeSource(source);
         return;
       }
       if(typeof recordClientSSEError==='function') recordClientSSEError('chat-response',{ready_state:source?source.readyState:null,session_id:activeSid,stream_id:streamId,reason:'chat EventSource.onerror'});
       source.close();
       if(_deferStreamErrorIfOffline()) return;
       if(_deferStreamErrorIfPageHidden()) return;
+      _closeSource(source);
       // Attempt one reconnect if the stream is still active server-side
       if(!_reconnectAttempted && streamId){
         _reconnectAttempted=true;

--- a/tests/test_1694_terminal_cleanup_ownership.py
+++ b/tests/test_1694_terminal_cleanup_ownership.py
@@ -121,3 +121,23 @@ def test_done_handler_is_idempotent_for_replay_or_duplicate_done_events():
     assert guard_idx != -1 and guard_idx < sound_idx, (
         "completion sound must be behind the duplicate-done finalization guard"
     )
+
+
+def test_attach_live_stream_registers_one_source_per_session_stream():
+    """Reconnect/compaction paths must not stack same-stream EventSources.
+
+    The stream channel broadcasts each token to every subscriber. If the browser
+    opens four live EventSources for the same run, one assistant paragraph is
+    appended four times even though the run journal contains it once.
+    """
+    close_body = _function_body("closeLiveStream")
+    attach_body = _function_body("attachLiveStream")
+    wire_body = _function_body("_wireSSE")
+    error_body = _event_body("error")
+
+    assert "const LIVE_STREAMS={};" in MESSAGES_JS
+    assert "LIVE_STREAMS[activeSid]={streamId,source};" in wire_body
+    assert "existingLive.source.close();" in wire_body
+    assert "if(source&&live.source!==source) return;" in close_body
+    assert "existingLive&&existingLive.streamId===streamId" in attach_body
+    assert "_closeSource(source);" in error_body


### PR DESCRIPTION
## Thinking Path

A fresh context-compaction report showed one assistant paragraph rendered four times in the browser. The persisted session and run journal did not contain four copies: the run journal had the token text once and the matching `interim_assistant` event once with `already_streamed: true`.

That points away from backend replay or transcript persistence and toward the browser owning too many live subscribers. `StreamChannel` broadcasts each event to every subscriber, so multiple browser EventSources for the same `stream_id` multiply one token stream into repeated DOM appends.

This is adjacent to the canonical-session-resolution RFC in #2922, but it is a different organ: not stale parent/tip routing, and not the visible-progress echo suppression in #2907. This PR keeps the scope to live SSE transport ownership.

## What Changed

- Registers each newly wired chat EventSource in `LIVE_STREAMS[activeSid]`.
- Closes any older live source for the same active session when a new source is wired.
- Makes `closeLiveStream()` optionally source-aware so stale handlers cannot delete a newer source registration.
- Clears the registry entry after a non-terminal SSE `error` closes its source, before reconnect/replay wiring creates a replacement.
- Adds a regression guard that pins the one-source-per-session/stream invariant.
- Adds an Unreleased changelog entry.

## Why It Matters

Reconnect and context-compaction paths can legitimately call `_wireSSE(...)` while a stream is still active. Before this patch, `_wireSSE()` attached handlers to the new EventSource but never recorded it in `LIVE_STREAMS`, so the existing same-stream reuse guard could not see it later. Repeated reattach attempts stacked subscribers; every token was then delivered once per subscriber and appended multiple times.

The fix prevents the browser from multiplying a single server-side token stream without adding content-level dedupe that could hide real repeated text.

## Verification

- `node --check static/messages.js`
- `python3 -m pytest -q tests/test_1694_terminal_cleanup_ownership.py -o addopts=''` -> `7 passed`
- `git diff --check`
- Added-line private marker scan -> `0 hits`
- Added-line secret-like scan -> `0 hits`

## Risks / Follow-ups

- Low risk: only chat live-stream EventSource bookkeeping changes.
- Existing tabs with already-open duplicate EventSources need a hard refresh/tab reload; this patch prevents new stacked sources after the fixed JS is loaded.
- This does not change transcript persistence, compression lineage routing, or backend stream emission semantics.

## Model Used

OpenAI GPT-5.5 via Hermes/TARS with terminal, file-edit, git, and GitHub CLI tooling.
