### PR TITLE
fix(chat): prevent duplicate streamed output after compaction

### DIFF
--- a/api/streaming.py
+++ b/api/streaming.py
@@ -3696,6 +3696,18 @@ def _run_agent_streaming(
                 stats.setdefault('estimated', False)
                 put('metering', stats)
 
+            def _compact_for_echo_compare(value: str) -> str:
+                return re.sub(r'\s+', ' ', str(value or '')).strip()
+
+            def _is_visible_output_echo(text: str) -> bool:
+                candidate = _compact_for_echo_compare(text)
+                if not candidate:
+                    return False
+                visible_tail = _compact_for_echo_compare(
+                    STREAM_PARTIAL_TEXT.get(stream_id, '')[-max(len(str(text)) * 2, 512):]
+                )
+                return bool(visible_tail and visible_tail.endswith(candidate))
+
             def on_token(text):
                 nonlocal _token_sent
                 if text is None:
@@ -3716,11 +3728,18 @@ def _run_agent_streaming(
                 nonlocal _reasoning_text
                 if text is None:
                     return
-                _reasoning_text += str(text)
+                reasoning_delta = str(text)
+                # Some runtimes mirror user-visible progress text through the
+                # reasoning channel after it already streamed as normal assistant
+                # output. Treat that as an echo, otherwise the UI renders the
+                # same sentence again inside a Thinking card.
+                if _is_visible_output_echo(reasoning_delta):
+                    return
+                _reasoning_text += reasoning_delta
                 # Mirror to shared dict so cancel_stream() can persist it (#1361 §A)
                 if stream_id in STREAM_REASONING_TEXT:
-                    STREAM_REASONING_TEXT[stream_id] += str(text)
-                put('reasoning', {'text': str(text)})
+                    STREAM_REASONING_TEXT[stream_id] += reasoning_delta
+                put('reasoning', {'text': reasoning_delta})
                 # Track reasoning deltas in the meter so live TPS reflects all AI output.
                 _metering_reasoning_deltas[0] += 1
                 meter().record_reasoning(stream_id, _metering_reasoning_deltas[0])
@@ -3732,9 +3751,10 @@ def _run_agent_streaming(
                 visible = str(text).strip()
                 if not visible:
                     return
+                already_streamed = bool(cb_kwargs.get('already_streamed', False)) or _is_visible_output_echo(visible)
                 put('interim_assistant', {
                     'text': visible,
-                    'already_streamed': bool(cb_kwargs.get('already_streamed', False)),
+                    'already_streamed': already_streamed,
                 })
 
             # Pre-initialise the activity counter here so on_tool (which
@@ -3804,11 +3824,17 @@ def _run_agent_streaming(
                 if event_type in ('reasoning.available', '_thinking'):
                     reason_text = preview if event_type == 'reasoning.available' else name
                     if reason_text:
-                        _reasoning_text += str(reason_text)
+                        reason_delta = str(reason_text)
+                        # Older tool-progress paths can mirror the same visible
+                        # progress text already emitted through stream_delta_callback.
+                        # Suppress those echoes like the dedicated reasoning callback.
+                        if _is_visible_output_echo(reason_delta):
+                            return
+                        _reasoning_text += reason_delta
                         # Mirror to shared dict so cancel_stream() can persist it (#1361 §A)
                         if stream_id in STREAM_REASONING_TEXT:
-                            STREAM_REASONING_TEXT[stream_id] += str(reason_text)
-                        put('reasoning', {'text': str(reason_text)})
+                            STREAM_REASONING_TEXT[stream_id] += reason_delta
+                        put('reasoning', {'text': reason_delta})
                         _metering_reasoning_deltas[0] += 1
                         meter().record_reasoning(stream_id, _metering_reasoning_deltas[0])
                         _emit_metering()

--- a/static/messages.js
+++ b/static/messages.js
@@ -609,10 +609,11 @@ async function send(){
 
 const LIVE_STREAMS={};
 
-function closeLiveStream(sessionId, streamId){
+function closeLiveStream(sessionId, streamId, source){
   const live=LIVE_STREAMS[sessionId];
   if(!live) return;
   if(streamId&&live.streamId!==streamId) return;
+  if(source&&live.source!==source) return;
   try{live.source.close();}catch(_){ }
   delete LIVE_STREAMS[sessionId];
 }
@@ -747,8 +748,8 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     if(_persistTimer) return;
     _persistTimer=setTimeout(()=>{_persistTimer=null;persistInflightState();},2000);
   }
-  function _closeSource(){
-    closeLiveStream(activeSid, streamId);
+  function _closeSource(source){
+    closeLiveStream(activeSid, streamId, source);
   }
   function _stripLiveVisibleAssistantEchoFromThinking(text, snippets){
     let out=String(text||'');
@@ -1455,6 +1456,12 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
   }
 
   function _wireSSE(source){
+    const existingLive=LIVE_STREAMS[activeSid];
+    if(existingLive&&existingLive.source&&existingLive.source!==source){
+      try{existingLive.source.close();}catch(_){ }
+    }
+    LIVE_STREAMS[activeSid]={streamId,source};
+
     // Note on #631 Bug B: the original PR description stated the server
     // "replays buffered token events" on reconnect, and proposed resetting
     // the accumulators here so the re-sent tokens wouldn't double the prefix.
@@ -1880,7 +1887,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
 
     source.addEventListener('stream_end',async e=>{
       if(_streamFinalized){
-        source.close();
+        _closeSource(source);
         return;
       }
       _terminalStateReached=true;
@@ -1893,8 +1900,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       // live DOM/inflight state remains projected and can duplicate Thinking or
       // assistant content until a later session switch. Settle from the persisted
       // session before closing so the pane converges on canonical state.
-      if(await _restoreSettledSession()){
-        source.close();
+      if(await _restoreSettledSession(source)){
         return;
       }
       if(_persistTimer){clearTimeout(_persistTimer);_persistTimer=null;}
@@ -1903,7 +1909,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       _streamFadeCleanupReduceMotionListener();
       _smdEndParser();
       if(typeof finalizeThinkingCard==='function') finalizeThinkingCard();
-      source.close();
+      _closeSource(source);
     });
 
     source.addEventListener('pending_steer_leftover',e=>{
@@ -2032,7 +2038,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       if(typeof finalizeThinkingCard==='function') finalizeThinkingCard();
       // Application-level error sent explicitly by the server (rate limit, crash, etc.)
       // This is distinct from the SSE network 'error' event below.
-      source.close();
+      _closeSource(source);
       _clearOwnerInflightState();
       _clearApprovalForOwner();
       _clearClarifyForOwner('terminal');
@@ -2081,13 +2087,14 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
 
     source.addEventListener('error',async e=>{
       if(_terminalStateReached || _streamFinalized){
-        _closeSource();
+        _closeSource(source);
         return;
       }
       if(typeof recordClientSSEError==='function') recordClientSSEError('chat-response',{ready_state:source?source.readyState:null,session_id:activeSid,stream_id:streamId,reason:'chat EventSource.onerror'});
       source.close();
       if(_deferStreamErrorIfOffline()) return;
       if(_deferStreamErrorIfPageHidden()) return;
+      _closeSource(source);
       // Attempt one reconnect if the stream is still active server-side
       if(!_reconnectAttempted && streamId){
         _reconnectAttempted=true;
@@ -2108,17 +2115,17 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
           }catch(_){
             if(_deferStreamErrorIfOffline()) return;
           }
-          if(await _restoreSettledSession()) return;
+          if(await _restoreSettledSession(source)) return;
           if(_deferStreamErrorIfOffline()) return;
           if(_deferStreamErrorIfPageHidden()) return;
-          _handleStreamError();
+          _handleStreamError(source);
         },1500);
         return;
       }
-      if(await _restoreSettledSession()) return;
+      if(await _restoreSettledSession(source)) return;
       if(_deferStreamErrorIfOffline()) return;
       if(_deferStreamErrorIfPageHidden()) return;
-      _handleStreamError();
+      _handleStreamError(source);
     });
 
     source.addEventListener('cancel',e=>{
@@ -2129,7 +2136,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       _streamFadeCleanupReduceMotionListener();
       _smdEndParser();
       if(typeof finalizeThinkingCard==='function') finalizeThinkingCard();
-      source.close();
+      _closeSource(source);
       _clearOwnerInflightState();
       _clearApprovalForOwner();
       _clearClarifyForOwner('cancelled');
@@ -2168,7 +2175,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     }
   }
 
-  async function _restoreSettledSession(){
+  async function _restoreSettledSession(source){
     try{
       const data=await api(`/api/session?session_id=${encodeURIComponent(activeSid)}`);
       // Opus #2852 race-fix: if a late `done` event ran the finalize path while
@@ -2184,7 +2191,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       _smdEndParser();
       if(typeof finalizeThinkingCard==='function') finalizeThinkingCard();
       _clearOwnerInflightState();
-      _closeSource();
+      _closeSource(source);
       _clearApprovalForOwner();
       _clearClarifyForOwner('terminal');
       const isSessionViewed=_isSessionActivelyViewed(activeSid);
@@ -2231,7 +2238,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     }
   }
 
-  function _handleStreamError(){
+  function _handleStreamError(source){
     // Opus review Q1: mirror done/apperror/cancel finalization so any pending rAF
     // cannot fire after renderMessages() has settled the DOM with the error message.
     if(_persistTimer){clearTimeout(_persistTimer);_persistTimer=null;}
@@ -2240,7 +2247,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     _streamFadeCleanupReduceMotionListener();
     if(typeof finalizeThinkingCard==='function') finalizeThinkingCard();
     _clearOwnerInflightState();
-    _closeSource();
+    _closeSource(source);
     _clearApprovalForOwner();
     _clearClarifyForOwner('terminal');
     if(S.session&&S.session.session_id===activeSid){

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -543,6 +543,10 @@ async function newSession(flash, options={}){
 
 async function loadSession(sid){
   const opts = arguments[1] || {};
+  if(!opts.skipLineageResolve && typeof _resolveSessionIdFromSidebarLineage==='function'){
+    const resolvedSid=_resolveSessionIdFromSidebarLineage(sid);
+    if(resolvedSid&&resolvedSid!==sid) sid=resolvedSid;
+  }
   const forceReload = !!opts.force;
   const currentSid = S.session ? S.session.session_id : null;
   // Clicking the already-open session in the sidebar is a no-op. Reloading it
@@ -647,6 +651,7 @@ async function loadSession(sid){
     if(!Array.isArray(messages)) return false;
     const pendingMsg=typeof getPendingSessionMessage==='function'?getPendingSessionMessage(session,messages):null;
     if(!pendingMsg) return false;
+    if(messages.some(existing=>_sameTranscriptMessage(existing,pendingMsg))) return false;
     const liveAssistantIdx=messages.findIndex(m=>m&&m.role==='assistant'&&m._live);
     if(liveAssistantIdx>=0) messages.splice(liveAssistantIdx,0,pendingMsg);
     else messages.push(pendingMsg);
@@ -1556,7 +1561,7 @@ function _sessionIdFromLocation(){
   }
   try{
     const qs=new URLSearchParams(window.location.search||'');
-    return qs.get('session')||null;
+    return qs.get('session')||qs.get('session_id')||null;
   }catch(_e){return null;}
 }
 function _sessionUrlForSid(sid){
@@ -2640,6 +2645,39 @@ function _sessionLineageContainsSession(s, sid){
   return false;
 }
 
+function _resolveSessionIdFromSidebarLineage(sid){
+  sid=String(sid||'').trim();
+  if(!sid||!Array.isArray(_allSessions)||!_allSessions.length) return sid||null;
+  const visibleRows=_collapseSessionLineageForSidebar(_allSessions).filter(row=>row&&!_isChildSession(row));
+  if(visibleRows.some(row=>row&&row.session_id===sid)) return sid;
+  const candidates=[];
+  for(const row of visibleRows){
+    if(!row||!row.session_id) continue;
+    if(row.session_source==='fork'||row.relationship_type==='child_session') continue;
+    const lineageLike=!!(
+      row._lineage_key||row._lineage_root_id||row.lineage_root_id||
+      row._compression_segment_count||row.pre_compression_snapshot||
+      (Array.isArray(row._lineage_segments)&&row._lineage_segments.length>1)
+    );
+    if(!lineageLike) continue;
+    const key=_sidebarLineageKeyForRow(row);
+    if(key===sid||row.parent_session_id===sid||row._lineage_root_id===sid||row.lineage_root_id===sid||_sessionLineageContainsSession(row,sid)){
+      candidates.push(row);
+    }
+  }
+  if(!candidates.length) return sid;
+  candidates.sort((a,b)=>{
+    const bSeg=Number(b&&b._compression_segment_count||b&&b._lineage_collapsed_count||0);
+    const aSeg=Number(a&&a._compression_segment_count||a&&a._lineage_collapsed_count||0);
+    if(bSeg!==aSeg) return bSeg-aSeg;
+    const bSnapshot=!!(b&&b.pre_compression_snapshot);
+    const aSnapshot=!!(a&&a.pre_compression_snapshot);
+    if(bSnapshot!==aSnapshot) return aSnapshot-bSnapshot;
+    return _sessionTimestampMs(b)-_sessionTimestampMs(a);
+  });
+  return candidates[0].session_id||sid;
+}
+
 function _sessionSegmentCount(s){
   if(!s) return 0;
   const counts=[];
@@ -2817,6 +2855,13 @@ function _collapseSessionLineageForSidebar(sessions){
       if(bSeg||aSeg){
         if(bSeg!==aSeg) return bSeg-aSeg;
       }
+      // Preserved pre-compression parents can share the same backend segment
+      // count as the continuation. Prefer the non-snapshot tip before falling
+      // back to timestamps, otherwise a recently-polled parent reopens the
+      // older transcript and makes the active continuation look lost.
+      const bSnapshot=!!(b&&b.pre_compression_snapshot);
+      const aSnapshot=!!(a&&a.pre_compression_snapshot);
+      if(bSnapshot!==aSnapshot) return aSnapshot-bSnapshot;
       return _sessionTimestampMs(b)-_sessionTimestampMs(a);
     });
     const chosen=sorted[0];

--- a/tests/test_1694_terminal_cleanup_ownership.py
+++ b/tests/test_1694_terminal_cleanup_ownership.py
@@ -99,8 +99,8 @@ def test_stream_end_without_done_restores_settled_session_before_closing():
     never replaces the pane with the persisted transcript when done is missing.
     """
     body = _event_body("stream_end")
-    restore_idx = body.find("_restoreSettledSession()")
-    close_idx = body.rfind("source.close()")
+    restore_idx = body.find("_restoreSettledSession(source)")
+    close_idx = body.rfind("_closeSource(source)")
     finalized_idx = body.find("_streamFinalized=true")
     assert restore_idx != -1, "stream_end handler must restore settled session when done is absent"
     assert close_idx != -1, "stream_end handler must still close the EventSource"
@@ -121,3 +121,29 @@ def test_done_handler_is_idempotent_for_replay_or_duplicate_done_events():
     assert guard_idx != -1 and guard_idx < sound_idx, (
         "completion sound must be behind the duplicate-done finalization guard"
     )
+
+
+def test_attach_live_stream_registers_one_source_per_session_stream():
+    """Reconnect/compaction paths must not stack same-stream EventSources.
+
+    The stream channel broadcasts each token to every subscriber. If the browser
+    opens four live EventSources for the same run, one assistant paragraph is
+    appended four times even though the run journal contains it once.
+    """
+    close_body = _function_body("closeLiveStream")
+    attach_body = _function_body("attachLiveStream")
+    wire_body = _function_body("_wireSSE")
+    error_body = _event_body("error")
+
+    assert "const LIVE_STREAMS={};" in MESSAGES_JS
+    assert "LIVE_STREAMS[activeSid]={streamId,source};" in wire_body
+    assert "existingLive.source.close();" in wire_body
+    assert "if(source&&live.source!==source) return;" in close_body
+    assert "existingLive&&existingLive.streamId===streamId" in attach_body
+    assert "_restoreSettledSession(source)" in error_body
+    assert "_handleStreamError(source)" in error_body
+    assert "_closeSource(source);" in error_body
+    assert "function _restoreSettledSession(source)" in attach_body
+    assert "function _handleStreamError(source)" in attach_body
+    for event_name in ("stream_end", "apperror", "cancel"):
+        assert "_closeSource(source);" in _event_body(event_name), event_name

--- a/tests/test_issue856_active_session_read_state.py
+++ b/tests/test_issue856_active_session_read_state.py
@@ -29,24 +29,24 @@ def test_done_path_marks_active_session_as_viewed():
 def test_cancel_path_marks_active_session_as_viewed():
     cancel_idx = MESSAGES_JS.find("source.addEventListener('cancel'")
     assert cancel_idx != -1, "cancel handler not found in messages.js"
-    cancel_block = MESSAGES_JS[cancel_idx:MESSAGES_JS.find("async function _restoreSettledSession()", cancel_idx)]
+    cancel_block = MESSAGES_JS[cancel_idx:MESSAGES_JS.find("async function _restoreSettledSession", cancel_idx)]
     assert "_markSessionViewed(activeSid" in cancel_block, (
         "cancel handler must mark the active session as viewed after settling messages"
     )
 
 
 def test_restore_and_error_paths_mark_active_session_as_viewed():
-    restore_idx = MESSAGES_JS.find("async function _restoreSettledSession()")
-    assert restore_idx != -1, "_restoreSettledSession() not found in messages.js"
-    restore_block = MESSAGES_JS[restore_idx:MESSAGES_JS.find("function _handleStreamError()", restore_idx)]
+    restore_idx = MESSAGES_JS.find("async function _restoreSettledSession")
+    assert restore_idx != -1, "_restoreSettledSession not found in messages.js"
+    restore_block = MESSAGES_JS[restore_idx:MESSAGES_JS.find("function _handleStreamError", restore_idx)]
     assert "const completedSid=session.session_id||activeSid;" in restore_block
     assert "_markSessionViewed(completedSid" in restore_block, (
-        "_restoreSettledSession() must mark the final session id as viewed"
+        "_restoreSettledSession must mark the final session id as viewed"
     )
 
-    error_idx = MESSAGES_JS.find("function _handleStreamError()")
-    assert error_idx != -1, "_handleStreamError() not found in messages.js"
+    error_idx = MESSAGES_JS.find("function _handleStreamError")
+    assert error_idx != -1, "_handleStreamError not found in messages.js"
     error_block = MESSAGES_JS[error_idx:]
     assert "_markSessionViewed(activeSid" in error_block, (
-        "_handleStreamError() must mark the active session as viewed"
+        "_handleStreamError must mark the active session as viewed"
     )

--- a/tests/test_issue856_background_completion_unread.py
+++ b/tests/test_issue856_background_completion_unread.py
@@ -359,7 +359,7 @@ def test_switching_away_counts_as_background_completion():
 
 
 def test_restore_settled_background_stream_marks_completion_unread():
-    restore_idx = MESSAGES_JS.find("async function _restoreSettledSession()")
+    restore_idx = MESSAGES_JS.find("async function _restoreSettledSession")
     assert restore_idx != -1, "_restoreSettledSession not found"
     restore_block = MESSAGES_JS[restore_idx:MESSAGES_JS.find("function _handleStreamError", restore_idx)]
 

--- a/tests/test_issue_progress_echo_dedupe.py
+++ b/tests/test_issue_progress_echo_dedupe.py
@@ -1,0 +1,176 @@
+import queue
+import sys
+import types
+from typing import Callable, cast
+from unittest import mock
+
+
+_MISSING = object()
+
+
+def test_visible_progress_token_reasoning_and_interim_are_deduped(cleanup_test_sessions):
+    """Progress text can arrive through three Hermes callbacks; WebUI must show it once.
+
+    Some runtimes emit a user-visible progress sentence as a normal token, mirror the
+    same text through reasoning, and then report it through interim_assistant before
+    a tool call. The SSE bridge should keep the visible token, suppress the hidden
+    reasoning echo, and mark interim_assistant as already_streamed so the client and
+    journal recovery do not append the same paragraph again.
+    """
+    import api.streaming as streaming
+
+    progress = "Gefunden: der Skill-Tab lädt `/api/skill-html?slug=...`."
+
+    class FakeSession:
+        def __init__(self):
+            self.session_id = "issue_progress_echo_dedupe"
+            self.title = "Progress echo"
+            self.workspace = "/tmp"
+            self.model = "gpt-test"
+            self.model_provider = None
+            self.profile = None
+            self.personality = None
+            self.messages = []
+            self.context_messages = []
+            self.input_tokens = 0
+            self.output_tokens = 0
+            self.estimated_cost = 0
+            self.cache_read_tokens = 0
+            self.cache_write_tokens = 0
+            self.tool_calls = []
+            self.gateway_routing = None
+            self.gateway_routing_history = []
+            self.active_stream_id = ""
+            self.pending_user_message = None
+            self.pending_attachments = []
+            self.pending_started_at = None
+            self.context_length = 0
+            self.threshold_tokens = 0
+            self.last_prompt_tokens = 0
+            self.llm_title_generated = True
+
+        def save(self, *args, **kwargs):
+            pass
+
+        def compact(self):
+            return {
+                "session_id": self.session_id,
+                "title": self.title,
+                "workspace": self.workspace,
+                "model": self.model,
+                "created_at": 0,
+                "updated_at": 0,
+                "pinned": False,
+                "archived": False,
+                "project_id": None,
+                "profile": self.profile,
+                "input_tokens": self.input_tokens,
+                "output_tokens": self.output_tokens,
+                "estimated_cost": self.estimated_cost,
+                "cache_read_tokens": self.cache_read_tokens,
+                "cache_write_tokens": self.cache_write_tokens,
+                "personality": self.personality,
+            }
+
+    class EchoAgent:
+        def __init__(
+            self,
+            model=None,
+            provider=None,
+            base_url=None,
+            api_key=None,
+            platform=None,
+            quiet_mode=False,
+            enabled_toolsets=None,
+            fallback_model=None,
+            session_id=None,
+            session_db=None,
+            prefill_messages=None,
+            stream_delta_callback=None,
+            reasoning_callback=None,
+            tool_progress_callback=None,
+            clarify_callback=None,
+            interim_assistant_callback=None,
+        ):
+            self.stream_delta_callback = cast(Callable[[str], None], stream_delta_callback)
+            self.reasoning_callback = cast(Callable[[str], None], reasoning_callback)
+            self.tool_progress_callback = cast(Callable[..., None], tool_progress_callback)
+            self.interim_assistant_callback = cast(Callable[[str], None], interim_assistant_callback)
+            self.context_compressor = None
+            self.session_prompt_tokens = 0
+            self.session_completion_tokens = 0
+            self.session_estimated_cost_usd = 0
+            self.session_cache_read_tokens = 0
+            self.session_cache_write_tokens = 0
+            self.reasoning_config = None
+            self.ephemeral_system_prompt = None
+            self._last_error = None
+
+        def run_conversation(self, **kwargs):
+            self.stream_delta_callback(progress)
+            self.reasoning_callback(progress)
+            self.tool_progress_callback("reasoning.available", "progress", progress, {})
+            self.interim_assistant_callback(progress)
+            history = kwargs.get("conversation_history", [])
+            return {"messages": history + [
+                {"role": "user", "content": kwargs["persist_user_message"]},
+                {"role": "assistant", "content": progress},
+            ]}
+
+        def interrupt(self, _message):
+            pass
+
+    fake_session = FakeSession()
+    fake_stream_id = "stream_issue_progress_echo_dedupe"
+    fake_session.active_stream_id = fake_stream_id
+    fake_queue = queue.Queue()
+    fake_runtime_module = types.ModuleType("hermes_cli.runtime_provider")
+    setattr(fake_runtime_module, "resolve_runtime_provider", mock.Mock(return_value={
+        "provider": "openai",
+        "base_url": None,
+        "api_key": "***",
+        "api_mode": "chat_completions",
+        "command": None,
+        "args": [],
+        "credential_pool": None,
+    }))
+    fake_hermes_cli = types.ModuleType("hermes_cli")
+    setattr(fake_hermes_cli, "runtime_provider", fake_runtime_module)
+    fake_hermes_state = types.ModuleType("hermes_state")
+    setattr(fake_hermes_state, "SessionDB", mock.Mock(return_value=None))
+    injected = {
+        "hermes_cli": fake_hermes_cli,
+        "hermes_cli.runtime_provider": fake_runtime_module,
+        "hermes_state": fake_hermes_state,
+    }
+    saved = {k: sys.modules.get(k, _MISSING) for k in injected}
+    sys.modules.update(injected)
+    try:
+        with mock.patch.object(streaming, "get_session", return_value=fake_session), \
+             mock.patch.object(streaming, "_get_ai_agent", return_value=EchoAgent), \
+             mock.patch.object(streaming, "resolve_model_provider", return_value=("gpt-test", "openai", None)), \
+             mock.patch("api.config.get_config", return_value={}), \
+             mock.patch("api.config._resolve_cli_toolsets", return_value=[]):
+            streaming.STREAMS[fake_stream_id] = fake_queue
+            streaming._run_agent_streaming(
+                session_id=fake_session.session_id,
+                msg_text="scan",
+                model="gpt-test",
+                workspace="/tmp",
+                stream_id=fake_stream_id,
+            )
+    finally:
+        streaming.STREAMS.pop(fake_stream_id, None)
+        for k, prev in saved.items():
+            if prev is _MISSING:
+                sys.modules.pop(k, None)
+            else:
+                sys.modules[k] = cast(types.ModuleType, prev)
+
+    events = list(fake_queue.queue)
+    assert [(event, payload) for event, payload in events if event == "token"] == [
+        ("token", {"text": progress})
+    ]
+    assert not [payload for event, payload in events if event == "reasoning" and payload.get("text") == progress]
+    interim = [payload for event, payload in events if event == "interim_assistant"]
+    assert interim == [{"text": progress, "already_streamed": True}]

--- a/tests/test_offline_banner.py
+++ b/tests/test_offline_banner.py
@@ -69,7 +69,7 @@ def test_sse_network_error_defers_to_offline_banner_instead_of_inline_error():
     assert "t('offline_stream_waiting')" in MESSAGES_JS
     assert "if(_deferStreamErrorIfOffline()) return;" in MESSAGES_JS
     error_handler = MESSAGES_JS.split("source.addEventListener('error',async e=>{", 1)[1].split("source.addEventListener('cancel'", 1)[0]
-    assert error_handler.find("_deferStreamErrorIfOffline()") < error_handler.rfind("_handleStreamError()")
+    assert error_handler.find("_deferStreamErrorIfOffline()") < error_handler.rfind("_handleStreamError(")
 
 
 def test_sse_error_defers_while_page_hidden_until_tab_returns():
@@ -81,7 +81,7 @@ def test_sse_error_defers_while_page_hidden_until_tab_returns():
     assert "window.addEventListener('pageshow',resume)" in MESSAGES_JS
     error_handler = MESSAGES_JS.split("source.addEventListener('error',async e=>{", 1)[1].split("source.addEventListener('cancel'", 1)[0]
     assert "if(_deferStreamErrorIfPageHidden()) return;" in error_handler
-    assert error_handler.find("_deferStreamErrorIfPageHidden()") < error_handler.rfind("_handleStreamError()")
+    assert error_handler.find("_deferStreamErrorIfPageHidden()") < error_handler.rfind("_handleStreamError(")
 
 
 def test_deferred_hidden_stream_error_reattaches_or_restores_before_inline_error():
@@ -89,5 +89,5 @@ def test_deferred_hidden_stream_error_reattaches_or_restores_before_inline_error
     assert "api(`/api/chat/stream/status?stream_id=${encodeURIComponent(streamId)}`)" in recovery_block
     assert "if(st.active)" in recovery_block
     assert "_wireSSE(new EventSource" in recovery_block
-    assert "if(await _restoreSettledSession()) return;" in recovery_block
-    assert recovery_block.find("if(await _restoreSettledSession()) return;") < recovery_block.rfind("_handleStreamError()")
+    assert "if(await _restoreSettledSession(" in recovery_block
+    assert recovery_block.find("if(await _restoreSettledSession(") < recovery_block.rfind("_handleStreamError(")

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -653,7 +653,8 @@ def test_loadSession_inflight_merges_tail_with_persisted_transcript(cleanup_test
 def test_inflight_merge_dedupes_uploaded_user_message(cleanup_test_sessions):
     """Uploaded-file turns render optimistically before the server stores the
     final pending text with an `[Attached files: ...]` suffix.  The INFLIGHT
-    merge must treat those as the same user turn instead of rendering both.
+    merge and pending-message merge must treat those as the same user turn
+    instead of rendering both.
     """
     src = (REPO_ROOT / "static/sessions.js").read_text()
     assert "function _stripAttachedFilesMarker" in src, (
@@ -665,6 +666,31 @@ def test_inflight_merge_dedupes_uploaded_user_message(cleanup_test_sessions):
     assert "role==='user'" in src, (
         "attached-files normalization should be limited to user turns"
     )
+    pending_idx = src.find("function _mergePendingSessionMessage")
+    assert pending_idx >= 0, "pending-session merge helper not found"
+    pending_block = src[pending_idx:pending_idx+700]
+    assert "_sameTranscriptMessage(existing,pendingMsg)" in pending_block, (
+        "pending-session merge must also dedupe an optimistic uploaded user turn "
+        "against the server pending text with the attached-files marker"
+    )
+
+
+def test_browser_session_url_accepts_api_session_id_param(cleanup_test_sessions):
+    """External links using ?session_id=... should open that session in the browser.
+
+    The API endpoint uses `session_id`, while the browser URL historically used
+    `session`/`/session/<id>`. Auth/cookie bridges and external callers can
+    legitimately produce `/?session_id=<sid>`; ignoring it falls back to stale
+    localStorage and renders the wrong or empty conversation.
+    """
+    src = (REPO_ROOT / "static/sessions.js").read_text()
+    start = src.find("function _sessionIdFromLocation")
+    assert start >= 0, "session URL parser not found"
+    end = src.find("function _sessionUrlForSid", start)
+    assert end > start, "session URL parser block end not found"
+    block = src[start:end]
+    assert "qs.get('session')" in block or 'qs.get("session")' in block
+    assert "qs.get('session_id')" in block or 'qs.get("session_id")' in block
 
 
 def test_loadSession_inflight_sets_active_stream_before_replaying_live_tool_cards(cleanup_test_sessions):

--- a/tests/test_sprint42.py
+++ b/tests/test_sprint42.py
@@ -681,7 +681,7 @@ def test_streaming_persists_reasoning_in_session():
         "_reasoning_text variable not initialised in streaming.py"
 
     # on_reasoning must accumulate into _reasoning_text
-    assert '_reasoning_text += str(text)' in src, \
+    assert '_reasoning_text += reasoning_delta' in src, \
         "on_reasoning callback does not accumulate into _reasoning_text"
 
     # Persistence block must exist before raw_session is built

--- a/tests/test_streaming_race_fix.py
+++ b/tests/test_streaming_race_fix.py
@@ -176,7 +176,7 @@ class TestReconnectAccumulatorPreservation:
         It calls renderMessages() which settles the DOM. Any pending rAF must be
         cancelled before that renderMessages call — same as done/apperror/cancel."""
         src = read('static/messages.js')
-        m = re.search(r'function _handleStreamError\(\)\{.*?\n  \}', src, re.DOTALL)
+        m = re.search(r'function _handleStreamError\([^)]*\)\{.*?\n  \}', src, re.DOTALL)
         assert m, "_handleStreamError not found"
         fn = m.group(0)
         assert '_streamFinalized=true' in fn or '_streamFinalized = true' in fn, (


### PR DESCRIPTION
## Summary

- Ensures the chat UI keeps a single live SSE source per active stream after context compaction/session restore.
- Marks interim assistant echoes as already streamed when identical text was already emitted visibly.
- Hardens session lineage/url-param/pending-message restoration so restored compacted sessions do not duplicate the same assistant text.

## Why

After context compaction, the browser could have more than one live/recovered path appending the same streamed assistant output. The visible symptom was the same assistant paragraph repeated multiple times after the compaction banner.

## Changes

- Make the live stream registry source-aware and close only the specific stale EventSource being retired.
- Pass the concrete EventSource through restore/error handlers so older async handlers cannot close or overwrite newer live streams.
- Deduplicate visible progress/reasoning/interim assistant echo text on the streaming backend path.
- Accept `?session_id=` in session navigation and avoid merging pending/user messages already present in restored history.
- Add regression coverage for streaming echo dedupe, extend existing ownership/pending-message tests, and update brittle static regression checks for the new source-aware handler signatures.

## Test Plan

- `node --check static/messages.js`
- `node --check static/sessions.js`
- `pytest tests/test_issue856_active_session_read_state.py tests/test_issue856_background_completion_unread.py tests/test_offline_banner.py tests/test_sprint42.py::test_streaming_persists_reasoning_in_session tests/test_streaming_race_fix.py::TestReconnectAccumulatorPreservation::test_handle_stream_error_sets_stream_finalized tests/test_issue_progress_echo_dedupe.py -q -o addopts=`
- `pytest tests/test_1694_terminal_cleanup_ownership.py tests/test_issue_progress_echo_dedupe.py tests/test_auto_compression_card.py tests/test_regressions.py tests/test_session_runtime_ownership_invariants.py -q -o addopts=`

Result: focused CI-failure mirror `35 passed`; original targeted regression set `107 passed, 1 skipped`.

## Evidence

The reported screenshot shows a `Context compaction` marker followed by the same assistant answer repeated four times in the chat body. This PR targets that exact post-compaction duplicate append path.

## Model Used

AI-assisted by TARS in Hermes WebUI.

- Provider/model: OpenAI Codex, `gpt-5.5`
- Notable tool use: git/gh CLI, pytest, node syntax checks, added-line public hygiene scan, screenshot inspection.
