### PR TITLE
fix(session): keep truncated sidecars authoritative

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Undo, retry, and explicit session truncation now persist a sidecar truncation watermark, preventing older `state.db` rows from reappearing after the WebUI transcript was intentionally shortened.
+
 ## [v0.51.134] — 2026-05-25 — Release DF (stage-batch16 — single-PR Windows path defaults)
 
 ### Fixed

--- a/api/models.py
+++ b/api/models.py
@@ -415,6 +415,7 @@ class Session:
                  context_engine_state=None,
                  context_length=None, threshold_tokens=None,
                  last_prompt_tokens=None,
+                 truncation_watermark=None,
                  gateway_routing=None, gateway_routing_history=None,
                  llm_title_generated: bool=False,
                 parent_session_id: str=None,
@@ -461,6 +462,7 @@ class Session:
         self.context_length = context_length
         self.threshold_tokens = threshold_tokens
         self.last_prompt_tokens = last_prompt_tokens
+        self.truncation_watermark = truncation_watermark
         self.gateway_routing = gateway_routing if isinstance(gateway_routing, dict) else None
         self.gateway_routing_history = gateway_routing_history if isinstance(gateway_routing_history, list) else []
         self.llm_title_generated = bool(llm_title_generated)
@@ -490,6 +492,18 @@ class Session:
     def path(self):
         return SESSION_DIR / f'{self.session_id}.json'
 
+    def _maybe_clear_truncation_watermark(self) -> None:
+        watermark = _message_timestamp_as_float({"timestamp": self.truncation_watermark})
+        if watermark is None:
+            return
+        max_message_timestamp = None
+        for msg in self.messages or []:
+            timestamp = _message_timestamp_as_float(msg)
+            if timestamp is not None:
+                max_message_timestamp = timestamp if max_message_timestamp is None else max(max_message_timestamp, timestamp)
+        if max_message_timestamp is not None and max_message_timestamp > watermark:
+            self.truncation_watermark = None
+
     def save(self, touch_updated_at: bool = True, skip_index: bool = False) -> None:
         # ── #1558 P0 guard ──────────────────────────────────────────────
         # Refuse to save a session that was loaded with metadata_only=True.
@@ -510,6 +524,7 @@ class Session:
             )
         if touch_updated_at:
             self.updated_at = time.time()
+        self._maybe_clear_truncation_watermark()
         # Write metadata fields first so load_metadata_only() can read them
         # without parsing the full messages array (which may be 400KB+).
         # Fields are listed in the order they should appear in the JSON file.
@@ -525,6 +540,7 @@ class Session:
             'context_engine', 'compression_anchor_engine', 'compression_anchor_mode',
             'compression_anchor_details', 'context_engine_state',
             'context_length', 'threshold_tokens', 'last_prompt_tokens',
+            'truncation_watermark',
             'gateway_routing', 'gateway_routing_history', 'llm_title_generated',
             'parent_session_id',
             'worktree_path', 'worktree_branch', 'worktree_repo_root', 'worktree_created_at',
@@ -3285,13 +3301,27 @@ def state_db_delta_after_context(sidecar_context: list, state_messages: list) ->
     return state_messages[best_len:]
 
 
-def merge_session_messages_append_only(sidecar_messages: list, state_messages: list) -> list:
+def merge_session_messages_append_only(
+    sidecar_messages: list,
+    state_messages: list,
+    *,
+    truncation_watermark=None,
+) -> list:
     """Merge sidecar/context and state.db messages without deleting local rows."""
     sidecar_messages = list(sidecar_messages or [])
     state_messages = list(state_messages or [])
+    watermark_timestamp = _message_timestamp_as_float({"timestamp": truncation_watermark})
     if not state_messages:
         return sidecar_messages
     if not sidecar_messages:
+        if watermark_timestamp is not None:
+            return [
+                msg for msg in state_messages
+                if (
+                    (timestamp := _message_timestamp_as_float(msg)) is not None
+                    and timestamp <= watermark_timestamp
+                )
+            ]
         return state_messages
 
     merged_messages = []
@@ -3335,6 +3365,13 @@ def merge_session_messages_append_only(sidecar_messages: list, state_messages: l
                 skipped_state_visible_counts[matched_visible_key] = (
                     skipped_state_visible_counts.get(matched_visible_key, 0) + 1
                 )
+            continue
+        if (
+            watermark_timestamp is not None
+            and timestamp is not None
+            and timestamp > watermark_timestamp
+            and key not in seen_message_keys
+        ):
             continue
         if max_sidecar_timestamp is not None and timestamp is not None and timestamp <= max_sidecar_timestamp:
             if key in seen_message_keys:
@@ -3392,7 +3429,11 @@ def reconciled_state_db_messages_for_session(
         state_messages = get_state_db_session_messages(getattr(session, 'session_id', None))
     if prefer_context and local_messages:
         state_messages = state_db_delta_after_context(local_messages, state_messages)
-    return merge_session_messages_append_only(local_messages, state_messages)
+    return merge_session_messages_append_only(
+        local_messages,
+        state_messages,
+        truncation_watermark=getattr(session, "truncation_watermark", None),
+    )
 
 
 def get_cli_session_messages(sid) -> list:

--- a/api/routes.py
+++ b/api/routes.py
@@ -2202,7 +2202,11 @@ def _metadata_only_message_summary(sid: str, profile: str | None = None) -> dict
         sidecar_messages = getattr(sidecar_session, "messages", []) or []
     state_db_messages = get_state_db_session_messages(sid, profile=profile)
     return _message_summary(
-        merge_session_messages_append_only(sidecar_messages, state_db_messages)
+        merge_session_messages_append_only(
+            sidecar_messages,
+            state_db_messages,
+            truncation_watermark=getattr(sidecar_session, "truncation_watermark", None),
+        )
     )
 
 
@@ -4033,7 +4037,11 @@ def handle_get(handler, parsed) -> bool:
                     # them chronologically and dedupe exact repeats.
                     _all_msgs = _merged_session_messages_for_display(s, cli_messages)
                 else:
-                    _all_msgs = merge_session_messages_append_only(s.messages, state_db_messages)
+                    _all_msgs = merge_session_messages_append_only(
+                        s.messages,
+                        state_db_messages,
+                        truncation_watermark=getattr(s, "truncation_watermark", None),
+                    )
             else:
                 if is_messaging_session and cli_messages:
                     sidecar_messages = getattr(s, "messages", []) or []
@@ -5433,6 +5441,11 @@ def handle_post(handler, parsed) -> bool:
         keep = int(body["keep_count"])
         with _get_session_agent_lock(body["session_id"]):
             s.messages = s.messages[:keep]
+            try:
+                from api.session_ops import _truncation_watermark_for
+                s.truncation_watermark = _truncation_watermark_for(s.messages)
+            except Exception:
+                s.truncation_watermark = 0.0
             s.save()
         return j(
             handler, {"ok": True, "session": s.compact() | {"messages": s.messages}}

--- a/api/session_ops.py
+++ b/api/session_ops.py
@@ -27,6 +27,16 @@ def _truncate_at_last_user(messages):
     return history[:last_user_idx]
 
 
+def _truncation_watermark_for(messages):
+    history = list(messages or [])
+    if not history:
+        return 0.0
+    try:
+        return float(history[-1].get('timestamp') or 0)
+    except (AttributeError, TypeError, ValueError):
+        return 0.0
+
+
 def retry_last(session_id: str) -> dict[str, Any]:
     """Truncate the session to before the last user message, return its text.
 
@@ -75,6 +85,7 @@ def retry_last(session_id: str) -> dict[str, Any]:
             last_user_text = _extract_text(history[last_user_idx].get('content', ''))
             removed_count = len(history) - last_user_idx
             s.messages = history[:last_user_idx]
+            s.truncation_watermark = _truncation_watermark_for(s.messages)
             if isinstance(getattr(s, 'context_messages', None), list) and s.context_messages:
                 truncated_context = _truncate_at_last_user(s.context_messages)
                 if truncated_context is not None:
@@ -114,6 +125,7 @@ def undo_last(session_id: str) -> dict[str, Any]:
             removed_text = _extract_text(history[last_user_idx].get('content', ''))
             removed_count = len(history) - last_user_idx
             s.messages = history[:last_user_idx]
+            s.truncation_watermark = _truncation_watermark_for(s.messages)
             if isinstance(getattr(s, 'context_messages', None), list) and s.context_messages:
                 truncated_context = _truncate_at_last_user(s.context_messages)
                 if truncated_context is not None:

--- a/tests/test_issue2914_truncation_watermark.py
+++ b/tests/test_issue2914_truncation_watermark.py
@@ -1,0 +1,76 @@
+"""Regression tests for #2914 state.db tail replay after undo/retry/edit."""
+from __future__ import annotations
+
+
+def _msg(role: str, content: str, ts: float, mid: str) -> dict:
+    return {"id": mid, "role": role, "content": content, "timestamp": ts}
+
+
+def test_reconciled_messages_skip_state_tail_after_sidecar_truncation():
+    from api.models import Session, reconciled_state_db_messages_for_session
+
+    sidecar = [
+        _msg("user", "first", 1.0, "sidecar-u1"),
+        _msg("assistant", "reply first", 2.0, "sidecar-a1"),
+    ]
+    state_db = [
+        _msg("user", "first", 1.0, "state-u1"),
+        _msg("assistant", "reply first", 2.0, "state-a1"),
+        _msg("user", "second", 3.0, "state-u2"),
+        _msg("assistant", "reply second", 4.0, "state-a2"),
+    ]
+    session = Session(
+        session_id="issue2914",
+        messages=sidecar,
+        truncation_watermark=2.0,
+    )
+
+    merged = reconciled_state_db_messages_for_session(session, state_messages=state_db)
+
+    assert [m["content"] for m in merged] == ["first", "reply first"]
+
+
+def test_empty_sidecar_truncation_watermark_blocks_state_replay():
+    from api.models import Session, reconciled_state_db_messages_for_session
+
+    state_db = [
+        _msg("user", "only prompt", 1.0, "state-u1"),
+        _msg("assistant", "only reply", 2.0, "state-a1"),
+    ]
+    session = Session(
+        session_id="issue2914empty",
+        messages=[],
+        truncation_watermark=0.0,
+    )
+
+    assert reconciled_state_db_messages_for_session(session, state_messages=state_db) == []
+
+
+def test_undo_persists_truncation_watermark_at_new_tail(monkeypatch, tmp_path):
+    import api.models as models
+    from api.models import Session
+    from api.session_ops import undo_last
+
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir(parents=True)
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    models.SESSIONS.clear()
+
+    session = Session(
+        session_id="issue2914undo",
+        messages=[
+            _msg("user", "first", 1.0, "u1"),
+            _msg("assistant", "reply first", 2.0, "a1"),
+            _msg("user", "second", 3.0, "u2"),
+            _msg("assistant", "reply second", 4.0, "a2"),
+        ],
+    )
+    session.save()
+
+    undo_last("issue2914undo")
+
+    loaded = Session.load("issue2914undo")
+    assert loaded is not None
+    assert [m["content"] for m in loaded.messages] == ["first", "reply first"]
+    assert loaded.truncation_watermark == 2.0


### PR DESCRIPTION
## Thinking Path

- WebUI `/undo`, `/retry`, and message-edit truncation mutate the WebUI sidecar transcript, not Hermes Agent `state.db`.
- After the state.db reconciliation change, reading a shortened sidecar could append newer state.db rows back into the visible transcript.
- That made destructive session operations look successful in the toast but ineffective after reload or session switch.
- The least-invasive fix is to persist the sidecar's truncation boundary and teach reconciliation to respect it.

## What Changed

- Added `Session.truncation_watermark` as sidecar metadata.
- Set the watermark when `/undo`, `/retry`, or `/api/session/truncate` shortens a transcript.
- Updated state.db reconciliation and metadata-only summaries to skip state rows newer than the sidecar truncation boundary.
- Clear the watermark automatically once the sidecar grows past it again.
- Added regression coverage for normal truncation and empty-transcript truncation.
- Added an Unreleased changelog entry.

## Why It Matters

The mutated state layer is the WebUI sidecar/state.db transcript reconciliation boundary. The WebUI can now shorten the sidecar transcript without state.db tail rows being replayed into the visible chat, while avoiding direct deletion from Hermes Agent's authoritative replay log.

Fixes #2914.

## Verification

- `pytest tests/test_issue2914_truncation_watermark.py tests/test_session_ops.py tests/test_session_lost_response_regression.py -q` — 34 passed
- `python -m py_compile api/models.py api/routes.py api/session_ops.py tests/test_issue2914_truncation_watermark.py`
- `git diff --check`

## Risks / Follow-ups

- This does not delete any rows from `state.db`; it only changes WebUI reconciliation for sidecar-authoritative truncation.
- Existing sessions without a watermark continue to use the current append-only reconciliation behavior.
- No UI surface changed, so screenshots are not applicable.

## Model Used

OpenAI GPT-5 via Codex desktop, with local shell/git/pytest tooling and Hermes WebUI project skills. AI assisted with implementation, tests, and PR preparation.
