### PR TITLE
fix(gateway): treat active sessions as configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Gateway status now treats existing messaging-session metadata as configured when `gateway.status` is unavailable, avoiding a misleading "Gateway not configured" warning for multi-container deployments with active gateway sessions.
+
 ## [v0.51.134] — 2026-05-25 — Release DF (stage-batch16 — single-PR Windows path defaults)
 
 ### Fixed

--- a/api/routes.py
+++ b/api/routes.py
@@ -4754,7 +4754,7 @@ def handle_get(handler, parsed) -> bool:
             configured = True
         else:  # alive is None → gateway not configured / unavailable
             running = bool(identity_map)
-            configured = False
+            configured = bool(identity_map)
 
         platforms_set: set[str] = set()
         for meta in identity_map.values():

--- a/tests/test_gateway_status_agent_health.py
+++ b/tests/test_gateway_status_agent_health.py
@@ -124,7 +124,8 @@ def test_gateway_status_running_true_and_platforms_when_agent_health_alive_and_s
 
 def test_gateway_status_alive_none_falls_back_to_identity_map_heuristic(monkeypatch):
     """When alive=None (not configured) but sessions exist, running reflects identity_map.
-    configured=false tells the frontend to show 'not configured' state."""
+    configured=true because sessions metadata proves a gateway is configured
+    even if gateway.status cannot be imported in this WebUI process."""
     from api import routes
 
     monkeypatch.setattr(
@@ -144,8 +145,8 @@ def test_gateway_status_alive_none_falls_back_to_identity_map_heuristic(monkeypa
     result = handler.get_json()
     # Fallback to identity_map: sessions exist → running=true
     assert result["running"] is True
-    # But configured=false because alive was None (no gateway metadata)
-    assert result["configured"] is False
+    # Existing gateway sessions prove the gateway has been configured.
+    assert result["configured"] is True
 
 
 def test_gateway_status_handles_corrupted_sessions_json(monkeypatch):


### PR DESCRIPTION
## Thinking Path

- `/api/gateway/status` uses `build_agent_health_payload()` as the process-health source of truth.
- In multi-container deployments, `gateway.status` can be unavailable to the WebUI process even while gateway session metadata exists.
- Existing messaging-session metadata proves the gateway has been configured, but the `alive is None` branch still returned `configured: false`.
- This PR keeps `running` tied to the existing identity-map fallback and aligns `configured` with that same evidence.

## What Changed

- Changed the `alive is None` fallback in `/api/gateway/status` so non-empty gateway session metadata returns `configured: true`.
- Updated the gateway status regression test to lock the `alive=None + sessions` case.
- Added an Unreleased changelog entry.

## Why It Matters

This fixes the concrete false-warning path in #2935: active gateway sessions no longer produce a contradictory `running: true, configured: false` response when `gateway.status` cannot be imported from the WebUI process.

Closes #2935.

## Verification

- `pytest tests/test_gateway_status_agent_health.py::test_gateway_status_alive_none_falls_back_to_identity_map_heuristic -q` — failed before the route change with `configured` still false
- `pytest tests/test_gateway_status_agent_health.py tests/test_issue1879_cross_container_gateway_liveness.py tests/test_issue2785_gateway_cron_guidance.py -q` — 30 passed
- `python -m py_compile api/routes.py tests/test_gateway_status_agent_health.py`
- `git diff --check`

## Risks / Follow-ups

- This does not change the `alive=false` branch; explicit gateway-down metadata still returns `running: false, configured: true`.
- Empty or corrupted `sessions.json` still reports `configured: false` when `alive is None`.

## Model Used

OpenAI GPT-5 via Codex desktop, with local shell/git/pytest tooling and Hermes WebUI project skills. AI assisted with implementation, tests, and PR preparation.
