### PR TITLE
Fix chat upload image attachment paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Chat uploads with the same filename in one session now keep distinct attachment
+  files instead of overwriting the earlier upload.
+
 ## [v0.51.134] — 2026-05-25 — Release DF (stage-batch16 — single-PR Windows path defaults)
 
 ### Fixed

--- a/api/upload.py
+++ b/api/upload.py
@@ -81,6 +81,16 @@ def _upload_destination(session_id: str, safe_name: str) -> Path:
     dest = (dest_dir / safe_name).resolve()
     if not dest.is_relative_to(dest_dir):
         raise ValueError('Invalid upload destination')
+    if dest.exists():
+        stem = dest.stem
+        suffix = dest.suffix
+        for idx in range(1, 1000):
+            candidate = (dest_dir / f'{stem}-{idx}{suffix}').resolve()
+            if not candidate.is_relative_to(dest_dir):
+                raise ValueError('Invalid upload destination')
+            if not candidate.exists():
+                return candidate
+        raise ValueError('Too many uploads with the same filename')
     return dest
 
 

--- a/static/messages.js
+++ b/static/messages.js
@@ -433,7 +433,7 @@ async function send(){
   setComposerStatus('');
 
   const uploadedNames=uploaded.map(u=>u.name||u);
-  const uploadedPaths=uploaded.map(u=>u&&u.is_image?(u.name||u.filename||u):(u.path||u.name||u));
+  const uploadedPaths=uploaded.map(u=>u&&u.path?u.path:(u&&u.name?u.name:(u&&u.filename?u.filename:u)));
   let msgText=text;
   if(uploaded.length&&!msgText)msgText=`I've uploaded ${uploaded.length} file(s): ${uploadedPaths.join(', ')}`;
   else if(uploaded.length)msgText=`${text}\n\n[Attached files: ${uploadedPaths.join(', ')}]`;

--- a/tests/test_chat_upload_attachment_paths.py
+++ b/tests/test_chat_upload_attachment_paths.py
@@ -1,0 +1,21 @@
+"""Regression coverage for WebUI chat upload path handoff."""
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MESSAGES_JS = ROOT / "static" / "messages.js"
+
+
+def test_image_uploads_use_server_path_in_attached_files_context():
+    """The agent text context must include real uploaded paths for images.
+
+    /api/upload returns an absolute attachment path. The browser also sends the
+    structured attachment payload to /api/chat/start, but text/tool-mode agents
+    still rely on the literal ``[Attached files: ...]`` suffix. Images must not
+    be downgraded to bare filenames there, otherwise tools like vision_analyze
+    cannot open the uploaded file immediately.
+    """
+    src = MESSAGES_JS.read_text(encoding="utf-8")
+
+    assert "uploadedPaths=uploaded.map(u=>u&&u.is_image?" not in src
+    assert "uploadedPaths=uploaded.map(u=>u&&u.path?u.path" in src

--- a/tests/test_sprint1.py
+++ b/tests/test_sprint1.py
@@ -352,6 +352,24 @@ def test_upload_respects_attachment_dir_env(monkeypatch, tmp_path):
     assert _session_attachment_dir("session-123") == inbox.resolve() / "session-123"
 
 
+def test_upload_destination_does_not_overwrite_same_filename(monkeypatch, tmp_path):
+    """Repeated uploads with the same filename in one session keep distinct paths."""
+    from api.upload import _upload_destination
+
+    inbox = tmp_path / "attachment-inbox"
+    monkeypatch.setenv("HERMES_WEBUI_ATTACHMENT_DIR", str(inbox))
+
+    first = _upload_destination("session-123", "photo.png")
+    first.write_bytes(b"first")
+    second = _upload_destination("session-123", "photo.png")
+    second.write_bytes(b"second")
+
+    assert first.name == "photo.png"
+    assert second.name == "photo-1.png"
+    assert first.read_bytes() == b"first"
+    assert second.read_bytes() == b"second"
+
+
 def test_upload_too_large(cleanup_test_sessions):
     """Uploading a file over MAX_UPLOAD_BYTES is rejected (413 or connection closed)."""
     sid, _ = make_session_tracked(cleanup_test_sessions)


### PR DESCRIPTION
## Thinking Path

- Hermes WebUI should give the agent immediate access to files uploaded in a chat turn.
- `/api/upload` already returns the absolute server-side attachment path.
- The frontend preserved that path in structured attachment metadata, but the text context sent to the agent downgraded image uploads to bare filenames.
- In text/tool-mode image handling, the agent then saw `[Attached files: Screenshot.jpg]` instead of a readable path, so tools such as `vision_analyze` could not open the upload immediately.
- Display rendering should remain friendly-name based, while agent-facing context should prefer the real server path.
- A follow-up duplicate-upload audit found that same-filename uploads in the same session could overwrite the previous attachment, which could make image behavior appear intermittent.

## What Changed

- Updated `static/messages.js` so `uploadedPaths` uses this fallback order for every uploaded item:
  - `u.path`
  - `u.name`
  - `u.filename`
  - `u`
- Left `uploadedNames` unchanged so optimistic UI, inflight state, and attachment chips still display friendly names.
- Updated `_upload_destination()` in `api/upload.py` so repeated uploads with the same sanitized filename in one session get unique paths such as `photo.png`, `photo-1.png`, instead of overwriting earlier files.
- Added regression coverage for both behaviors:
  - image upload agent context uses the server path
  - duplicate same-filename uploads preserve both files
- Added an Unreleased changelog note for duplicate upload filename handling.

## Why It Matters

When a user uploads an image and asks the agent to inspect it, the agent must be able to find the file immediately. Sending only the filename breaks that handoff because uploads live under the WebUI attachment inbox, not necessarily in the selected workspace or current working directory.

The duplicate-filename fix removes a plausible intermittent case: uploading the same image, or two files with the same name, no longer mutates the previous attachment path's contents.

## Verification

- `gh pr checks 2940 --repo nesquena/hermes-webui --watch`
  - `test (3.11)` passed in 2m03s
  - `test (3.12)` passed in 2m21s
  - `test (3.13)` passed in 2m14s
- `/Users/georgeandraws/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_sprint1.py::test_upload_destination_does_not_overwrite_same_filename tests/test_chat_upload_attachment_paths.py tests/test_native_image_attachments.py tests/test_issue1867_upload_size_preflight.py -q`
  - `46 passed`
- `/Users/georgeandraws/.hermes/hermes-agent/venv/bin/python -m pytest -q`
  - Broad local suite exposed unrelated environment-sensitive failures in this machine's test setup:
    - real local skills include `Systematic Debugging`, and older tests interpolate the name without URL encoding
    - local `git init` defaults to `main` while two tests assume `master`
    - isolated temp paths can appear as `/private/var` vs `/var` on macOS
  - Failing slices pass when rerun with isolated Hermes state and matching Git defaults where applicable.

## Risks / Follow-ups

Low risk. The path-context change only affects the agent-facing text sent to `/api/chat/start`; structured attachment metadata and UI display names remain friendly-name based.

Duplicate upload filename handling is a small behavior change: the second same-name upload now returns a suffixed filename/path instead of overwriting the first file. This should be safer for chat attachment history.

## Model Used

AI-assisted.

- Primary assistant: OpenAI GPT-5.5 via Hermes WebUI
- Coding delegate: OpenAI Codex CLI `codex-cli 0.133.0`, model `gpt-5.5`
