### PR TITLE
Feat/insights global toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## [Unreleased]
 
+### Added
+
+- Insights panel now has a **WebUI / Global** scope toggle. WebUI (default) keeps the historical view of sessions persisted by this WebUI's `_index.json`. Global aggregates every Hermes session — CLI, Discord, Telegram, cron, kanban worker, `delegate_task`, plus WebUI — by reading `~/.hermes/state.db` (the hermes-agent gateway's session store) in SQLite read-only URI mode. All tokens, costs, models, and daily/activity charts switch atomically with the toggle. The toggle persists across reloads via `localStorage`. When `state.db` is unreachable (fresh install, missing gateway, locked) the Global button auto-disables with a tooltip and the panel transparently falls back to WebUI data — `/api/insights` advertises this via `scope`, `scope_requested`, and `scope_available` so the UI never silently lies about what it's showing.
+- Global-scope token semantics match the WebUI scope: state.db's cache-subtracted `input_tokens` is summed back with `cache_read_tokens` and `cache_write_tokens` so the displayed "input" column equals provider `prompt_tokens`. This keeps the toggle's two views directly comparable and aligns with what providers actually bill.
+- New i18n keys `insights_scope_label`, `insights_scope_webui`, `insights_scope_global`, `insights_scope_global_unavailable`, and `insights_scope_note` shipped in all 11 locales.
+
 ## [v0.51.171] — 2026-05-30 — Release EQ (stage-batch53 — tool-output card badge + Neon opt-in skin)
 
 ### Added

--- a/api/routes.py
+++ b/api/routes.py
@@ -3398,8 +3398,142 @@ def _handle_llm_wiki_status(handler, parsed) -> bool:
     return True
 
 
+def _load_webui_index_entries(cutoff: float) -> list[dict]:
+    """Load WebUI-scoped session entries from _index.json.
+
+    Filters to entries created or updated within the calendar window.
+    Each entry follows the _index.json convention where ``input_tokens`` is
+    the full prompt total (cache reads + writes + new input) — i.e. it
+    already matches what providers bill as ``prompt_tokens``.
+    """
+    sessions_data: list[dict] = []
+    idx_path = SESSION_DIR / "_index.json"
+    if not idx_path.exists():
+        return sessions_data
+    try:
+        idx = json.loads(idx_path.read_text(encoding="utf-8"))
+    except Exception:
+        return sessions_data
+    for entry in idx:
+        created = entry.get("created_at", 0) or 0
+        updated = entry.get("updated_at", 0) or 0
+        if max(created, updated) < cutoff:
+            continue
+        sessions_data.append(entry)
+    return sessions_data
+
+
+def _hermes_state_db_path() -> "Path | None":
+    """Return path to the hermes-agent global state.db if discoverable."""
+    import os
+
+    home = os.environ.get("HERMES_HOME") or os.path.expanduser("~/.hermes")
+    if not home:
+        return None
+    return Path(home) / "state.db"
+
+
+def _load_global_state_db_entries(cutoff: float) -> "list[dict] | None":
+    """Load Hermes-global session entries from ``state.db`` for the
+    ``scope=global`` Insights view.
+
+    Returns ``None`` when the database is missing or unreadable, signalling
+    the caller to fall back to the WebUI-only path. Returns an empty list
+    when the database exists but has no qualifying rows (legitimate empty
+    result, not a fallback signal).
+
+    Each row is reshaped to match the ``_index.json`` convention so the
+    downstream aggregation needs no source-specific branching:
+
+    - ``input_tokens`` becomes the **full prompt total** (state.db stores
+      it as cache-subtracted "new only"; we add ``cache_read_tokens`` and
+      ``cache_write_tokens`` back so the value equals the provider's
+      ``prompt_tokens``).
+    - ``estimated_cost`` prefers ``actual_cost_usd`` and falls back to
+      ``estimated_cost_usd``.
+    - ``created_at`` / ``updated_at`` come from ``started_at`` /
+      ``ended_at`` (with ``started_at`` as updated fallback).
+    - window filtering uses the same "active in window" rule as WebUI
+      scope: started or ended/updated within the requested calendar range.
+
+    Connection is opened in SQLite read-only URI mode so we cannot
+    accidentally mutate the gateway's state store, with a short timeout
+    so a writer-locked db never stalls the dashboard request.
+    """
+    import sqlite3
+
+    db_path = _hermes_state_db_path()
+    if db_path is None or not db_path.exists():
+        return None
+
+    try:
+        uri = f"file:{db_path.as_posix()}?mode=ro"
+        conn = sqlite3.connect(uri, uri=True, timeout=2.0, isolation_level=None)
+        conn.row_factory = sqlite3.Row
+        try:
+            cur = conn.execute(
+                """SELECT id, source, model, started_at, ended_at,
+                          message_count, input_tokens, output_tokens,
+                          cache_read_tokens, cache_write_tokens,
+                          estimated_cost_usd, actual_cost_usd
+                     FROM sessions
+                    WHERE MAX(started_at, COALESCE(ended_at, started_at)) >= ?""",
+                (cutoff,),
+            )
+            rows = cur.fetchall()
+        finally:
+            conn.close()
+    except sqlite3.Error:
+        return None
+
+    entries: list[dict] = []
+    for row in rows:
+        new_input = int(row["input_tokens"] or 0)
+        cache_read = int(row["cache_read_tokens"] or 0)
+        cache_write = int(row["cache_write_tokens"] or 0)
+        full_prompt = new_input + cache_read + cache_write
+
+        actual = row["actual_cost_usd"]
+        if actual is not None:
+            cost = actual
+        else:
+            cost = row["estimated_cost_usd"] or 0.0
+
+        started = float(row["started_at"] or 0.0)
+        ended = row["ended_at"]
+        updated = float(ended) if ended is not None else started
+
+        entries.append({
+            "session_id": row["id"],
+            "source": row["source"] or "unknown",
+            "model": row["model"] or "unknown",
+            "created_at": started,
+            "updated_at": updated,
+            "message_count": int(row["message_count"] or 0),
+            "input_tokens": full_prompt,
+            "output_tokens": int(row["output_tokens"] or 0),
+            # Keep cache buckets as informational sub-components of the
+            # prompt/input total. They are NOT added again to total_tokens.
+            "cache_read_tokens": cache_read,
+            "cache_write_tokens": cache_write,
+            "estimated_cost": cost,
+        })
+    return entries
+
+
 def _handle_insights(handler, parsed) -> bool:
-    """Return usage analytics from local WebUI session data."""
+    """Return usage analytics with selectable scope.
+
+    Scopes:
+    - ``webui`` (default): only sessions started via the WebUI, sourced
+      from ``_index.json``. This is the historical behaviour and what
+      8787 users have been seeing.
+    - ``global``: every Hermes session (CLI, Discord, Telegram, cron,
+      kanban worker, delegate_task, WebUI, …) sourced from the
+      hermes-agent ``state.db``. Falls back to ``webui`` data when the
+      database is missing or unreadable; the response carries
+      ``scope_available=false`` so the UI can surface the fallback.
+    """
     import collections
     import time as _time
 
@@ -3408,6 +3542,10 @@ def _handle_insights(handler, parsed) -> bool:
         days = min(max(int(query.get("days", ["30"])[0]), 1), 365)
     except (ValueError, TypeError):
         days = 30
+
+    requested_scope = (query.get("scope", ["webui"])[0] or "webui").strip().lower()
+    if requested_scope not in ("webui", "global"):
+        requested_scope = "webui"
 
     now = _time.time()
     today = _time.localtime(now)
@@ -3437,30 +3575,25 @@ def _handle_insights(handler, parsed) -> bool:
     def _session_usage_ts(session: dict) -> float:
         return session.get("updated_at", session.get("created_at", 0)) or session.get("created_at", 0) or 0
 
-    # Walk session index (fast, no full JSON parse)
-    sessions_data = []
-    idx_path = SESSION_DIR / "_index.json"
-    if idx_path.exists():
-        try:
-            idx = json.loads(idx_path.read_text(encoding="utf-8"))
-        except Exception:
-            idx = []
+    # Resolve effective scope + load matching session entries.
+    effective_scope = requested_scope
+    scope_available = True
+    if requested_scope == "global":
+        sessions_data = _load_global_state_db_entries(cutoff)
+        if sessions_data is None:
+            sessions_data = _load_webui_index_entries(cutoff)
+            effective_scope = "webui"
+            scope_available = False
     else:
-        idx = []
-
-    for entry in idx:
-        created = entry.get("created_at", 0) or 0
-        updated = entry.get("updated_at", 0) or 0
-        # Session is relevant if it was created or updated within the calendar window.
-        if max(created, updated) < cutoff:
-            continue
-        sessions_data.append(entry)
+        sessions_data = _load_webui_index_entries(cutoff)
 
     # Aggregate
     total_sessions = len(sessions_data)
     total_messages = 0
     total_input_tokens = 0
     total_output_tokens = 0
+    total_cache_read_tokens = 0
+    total_cache_write_tokens = 0
     total_cost = 0.0
     model_stats: dict[str, dict] = {}
     daily_tokens: dict[str, dict] = {}
@@ -3472,10 +3605,14 @@ def _handle_insights(handler, parsed) -> bool:
     for s in sessions_data:
         input_tokens = _safe_usage_int(s.get("input_tokens"))
         output_tokens = _safe_usage_int(s.get("output_tokens"))
+        cache_read_tokens = _safe_usage_int(s.get("cache_read_tokens"))
+        cache_write_tokens = _safe_usage_int(s.get("cache_write_tokens"))
         cost_value = _safe_cost_float(s.get("estimated_cost"))
         total_messages += _safe_usage_int(s.get("message_count"))
         total_input_tokens += input_tokens
         total_output_tokens += output_tokens
+        total_cache_read_tokens += cache_read_tokens
+        total_cache_write_tokens += cache_write_tokens
         total_cost += cost_value
 
         model = s.get("model") or "unknown"
@@ -3483,11 +3620,15 @@ def _handle_insights(handler, parsed) -> bool:
             "sessions": 0,
             "input_tokens": 0,
             "output_tokens": 0,
+            "cache_read_tokens": 0,
+            "cache_write_tokens": 0,
             "cost": 0.0,
         })
         bucket["sessions"] += 1
         bucket["input_tokens"] += input_tokens
         bucket["output_tokens"] += output_tokens
+        bucket["cache_read_tokens"] += cache_read_tokens
+        bucket["cache_write_tokens"] += cache_write_tokens
         bucket["cost"] += cost_value
 
         # Activity patterns
@@ -3499,11 +3640,15 @@ def _handle_insights(handler, parsed) -> bool:
                 daily_bucket = daily_tokens.setdefault(day_key, {
                     "input_tokens": 0,
                     "output_tokens": 0,
+                    "cache_read_tokens": 0,
+                    "cache_write_tokens": 0,
                     "sessions": 0,
                     "cost": 0.0,
                 })
                 daily_bucket["input_tokens"] += input_tokens
                 daily_bucket["output_tokens"] += output_tokens
+                daily_bucket["cache_read_tokens"] += cache_read_tokens
+                daily_bucket["cache_write_tokens"] += cache_write_tokens
                 daily_bucket["sessions"] += 1
                 daily_bucket["cost"] += cost_value
                 dow_activity[dt.tm_wday] += 1
@@ -3522,12 +3667,42 @@ def _handle_insights(handler, parsed) -> bool:
             "sessions": stats["sessions"],
             "input_tokens": stats["input_tokens"],
             "output_tokens": stats["output_tokens"],
+            "cache_read_tokens": stats["cache_read_tokens"],
+            "cache_write_tokens": stats["cache_write_tokens"],
             "total_tokens": row_total_tokens,
             "cost": row_cost,
-            "session_share": int(round((stats["sessions"] / total_sessions) * 100)) if total_sessions else 0,
-            "token_share": int(round((row_total_tokens / total_tokens) * 100)) if total_tokens else 0,
-            "cost_share": int(round((row_cost / total_cost) * 100)) if total_cost else 0,
+            "session_share": 0,
+            "token_share": 0,
+            "cost_share": 0,
         })
+
+    def _assign_integer_percent_share(rows: list[dict], value_key: str, share_key: str, total_value: float) -> None:
+        """Assign integer percentage shares that sum to exactly 100.
+
+        Plain round(row / total * 100) is easy but per-row rounding can sum to
+        99/101. Use largest-remainder allocation so the displayed model share
+        column has a coherent denominator.
+        """
+        if not rows or total_value <= 0:
+            for row in rows:
+                row[share_key] = 0
+            return
+        allocations = []
+        floor_sum = 0
+        for idx, row in enumerate(rows):
+            value = max(float(row.get(value_key) or 0), 0.0)
+            raw = (value / total_value) * 100
+            floor = int(raw)
+            floor_sum += floor
+            allocations.append((raw - floor, value, idx, floor))
+        remainder = max(0, 100 - floor_sum)
+        winners = {idx for _frac, _value, idx, _floor in sorted(allocations, key=lambda item: (-item[0], -item[1], item[2]))[:remainder]}
+        for _frac, _value, idx, floor in allocations:
+            rows[idx][share_key] = floor + (1 if idx in winners else 0)
+
+    _assign_integer_percent_share(models_breakdown, "sessions", "session_share", total_sessions)
+    _assign_integer_percent_share(models_breakdown, "total_tokens", "token_share", total_tokens)
+    _assign_integer_percent_share(models_breakdown, "cost", "cost_share", total_cost)
     models_breakdown.sort(key=lambda r: (-r["cost"], -r["sessions"], r["model"]))
 
     daily_series = []
@@ -3537,6 +3712,8 @@ def _handle_insights(handler, parsed) -> bool:
         bucket = daily_tokens.get(day_key, {
             "input_tokens": 0,
             "output_tokens": 0,
+            "cache_read_tokens": 0,
+            "cache_write_tokens": 0,
             "sessions": 0,
             "cost": 0.0,
         })
@@ -3544,6 +3721,8 @@ def _handle_insights(handler, parsed) -> bool:
             "date": day_key,
             "input_tokens": bucket["input_tokens"],
             "output_tokens": bucket["output_tokens"],
+            "cache_read_tokens": bucket["cache_read_tokens"],
+            "cache_write_tokens": bucket["cache_write_tokens"],
             "sessions": bucket["sessions"],
             "cost": round(bucket["cost"], 6),
         })
@@ -3557,10 +3736,19 @@ def _handle_insights(handler, parsed) -> bool:
 
     return j(handler, {
         "period_days": days,
+        # Effective scope reflects what was actually returned. When the user
+        # asked for ``global`` but state.db was unreachable, this stays
+        # ``webui`` and ``scope_available=false`` lets the UI surface the
+        # fallback (e.g. disable the Global toggle with an explanation).
+        "scope": effective_scope,
+        "scope_requested": requested_scope,
+        "scope_available": scope_available,
         "total_sessions": total_sessions,
         "total_messages": total_messages,
         "total_input_tokens": total_input_tokens,
         "total_output_tokens": total_output_tokens,
+        "total_cache_read_tokens": total_cache_read_tokens,
+        "total_cache_write_tokens": total_cache_write_tokens,
         "total_tokens": total_tokens,
         "total_cost": round(total_cost, 6),
         "models": models_breakdown,

--- a/static/i18n.js
+++ b/static/i18n.js
@@ -768,6 +768,8 @@ const LOCALES = {
     insights_token_breakdown: 'Token Breakdown',
     insights_input_tokens: 'Input',
     insights_output_tokens: 'Output',
+    insights_cache_read_tokens: 'Cache Read',
+    insights_cache_write_tokens: 'Cache Write',
     insights_total: 'Total',
     insights_daily_tokens: 'Daily Tokens',
     insights_model_name: 'Model',
@@ -789,6 +791,12 @@ const LOCALES = {
     insights_skill_usage_col_views: 'Views',
     insights_skill_usage_col_share: 'Usage %',
     insights_skill_usage_col_patches: 'Patches',
+    insights_period_label: 'Period',
+    insights_scope_label: 'View',
+    insights_scope_webui: 'WebUI',
+    insights_scope_global: 'Global',
+    insights_scope_global_unavailable: 'Hermes global usage data is unavailable',
+    insights_scope_note: 'WebUI shows local session-index usage; Global shows cumulative Hermes usage for provider billing comparison.',
     workspace_desc: 'Add and switch workspaces for your sessions.',
     session_meta_messages: (n) => `${n} msg${n === 1 ? '' : 's'}`,
     session_meta_children: (n) => `${n} child${n === 1 ? '' : 'ren'}`,
@@ -2064,6 +2072,8 @@ const LOCALES = {
     insights_token_breakdown: 'Ripartizione Token',
     insights_input_tokens: 'Input',
     insights_output_tokens: 'Output',
+    insights_cache_read_tokens: 'Cache letto',
+    insights_cache_write_tokens: 'Cache scritto',
     insights_total: 'Totale',
     insights_daily_tokens: 'Token Giornalieri',
     insights_model_name: 'Modello',
@@ -2085,6 +2095,12 @@ const LOCALES = {
     insights_skill_usage_col_views: 'Visualizzazioni',
     insights_skill_usage_col_share: 'Utilizzo %',
     insights_skill_usage_col_patches: 'Patch',
+    insights_period_label: 'Periodo',
+    insights_scope_label: 'Vista',
+    insights_scope_webui: 'WebUI',
+    insights_scope_global: 'Globale',
+    insights_scope_global_unavailable: 'Dati globali Hermes non disponibili',
+    insights_scope_note: 'WebUI mostra l\'uso dell\'indice sessioni locale; Globale mostra l\'uso Hermes cumulativo per il confronto con la fatturazione del provider.',
     workspace_desc: 'Aggiungi e cambia workspace per le tue sessioni.',
     session_meta_messages: (n) => `${n} msg`,
     session_meta_children: (n) => `${n} figli${n === 1 ? 'o' : ''}`,
@@ -3362,6 +3378,8 @@ const LOCALES = {
     insights_token_breakdown: 'トークン内訳',
     insights_input_tokens: '入力',
     insights_output_tokens: '出力',
+    insights_cache_read_tokens: 'キャッシュ読込',
+    insights_cache_write_tokens: 'キャッシュ書込',
     insights_total: '合計',
     insights_daily_tokens: '日別トークン',
     insights_model_name: 'モデル',
@@ -3383,6 +3401,12 @@ const LOCALES = {
     insights_skill_usage_col_views: '閲覧数',
     insights_skill_usage_col_share: '使用率',
     insights_skill_usage_col_patches: 'パッチ',
+    insights_period_label: '期間',
+    insights_scope_label: '表示',
+    insights_scope_webui: 'WebUI',
+    insights_scope_global: '全体',
+    insights_scope_global_unavailable: 'Hermes 全体の利用データは利用できません',
+    insights_scope_note: 'WebUI はローカルのセッション索引用量を表示し、全体はプロバイダー請求との比較向けに Hermes の累積用量を表示します。',
     workspace_desc: 'セッション用のワークスペースを追加・切り替えします。',
     session_meta_messages: (n) => `${n} 件`,
     session_meta_children: (n) => `${n} 子`,
@@ -5115,11 +5139,19 @@ const LOCALES = {
     insights_skill_usage_col_views: 'Views',  // TODO: translate
     insights_skill_usage_col_share: 'Usage %',  // TODO: translate
     insights_skill_usage_col_patches: 'Patches',  // TODO: translate
+    insights_period_label: 'Период',
+    insights_scope_label: 'Вид',
+    insights_scope_webui: 'WebUI',
+    insights_scope_global: 'Глобально',
+    insights_scope_global_unavailable: 'Глобальные данные Hermes недоступны',
+    insights_scope_note: 'WebUI показывает локальное использование индекса сессий; Глобально показывает накопленное использование Hermes для сравнения с биллингом провайдера.',
     insights_input_tokens: 'Input',  // TODO: translate
     insights_messages: 'Messages',  // TODO: translate
     insights_models: 'Models',  // TODO: translate
     insights_no_cost: 'N/A',  // TODO: translate
     insights_output_tokens: 'Output',  // TODO: translate
+    insights_cache_read_tokens: 'Чтение кэша',
+    insights_cache_write_tokens: 'Запись кэша',
     insights_peak_hour: 'Peak: {hour}',  // TODO: translate
     insights_sessions: 'Sessions',  // TODO: translate
     insights_title: 'Usage Analytics',  // TODO: translate
@@ -6333,11 +6365,19 @@ const LOCALES = {
     insights_skill_usage_col_views: 'Views',  // TODO: translate
     insights_skill_usage_col_share: 'Usage %',  // TODO: translate
     insights_skill_usage_col_patches: 'Patches',  // TODO: translate
+    insights_period_label: 'Período',
+    insights_scope_label: 'Vista',
+    insights_scope_webui: 'WebUI',
+    insights_scope_global: 'Global',
+    insights_scope_global_unavailable: 'Datos globales de Hermes no disponibles',
+    insights_scope_note: 'WebUI muestra el uso del índice local de sesiones; Global muestra el uso acumulado de Hermes para compararlo con la facturación del proveedor.',
     insights_input_tokens: 'Input',  // TODO: translate
     insights_messages: 'Messages',  // TODO: translate
     insights_models: 'Models',  // TODO: translate
     insights_no_cost: 'N/A',  // TODO: translate
     insights_output_tokens: 'Output',  // TODO: translate
+    insights_cache_read_tokens: 'Lectura caché',
+    insights_cache_write_tokens: 'Escritura caché',
     insights_peak_hour: 'Peak: {hour}',  // TODO: translate
     insights_sessions: 'Sessions',  // TODO: translate
     insights_title: 'Usage Analytics',  // TODO: translate
@@ -7566,11 +7606,19 @@ const LOCALES = {
     insights_skill_usage_col_views: 'Views',  // TODO: translate
     insights_skill_usage_col_share: 'Usage %',  // TODO: translate
     insights_skill_usage_col_patches: 'Patches',  // TODO: translate
+    insights_period_label: 'Zeitraum',
+    insights_scope_label: 'Ansicht',
+    insights_scope_webui: 'WebUI',
+    insights_scope_global: 'Global',
+    insights_scope_global_unavailable: 'Hermes-Gesamtnutzungsdaten nicht verfügbar',
+    insights_scope_note: 'WebUI zeigt die lokale Sitzungsindex-Nutzung; Global zeigt die kumulierte Hermes-Nutzung zum Abgleich mit der Provider-Abrechnung.',
     insights_input_tokens: 'Input',  // TODO: translate
     insights_messages: 'Messages',  // TODO: translate
     insights_models: 'Models',  // TODO: translate
     insights_no_cost: 'N/A',  // TODO: translate
     insights_output_tokens: 'Output',  // TODO: translate
+    insights_cache_read_tokens: 'Cache gelesen',
+    insights_cache_write_tokens: 'Cache geschrieben',
     insights_peak_hour: 'Peak: {hour}',  // TODO: translate
     insights_sessions: 'Sessions',  // TODO: translate
     insights_title: 'Usage Analytics',  // TODO: translate
@@ -8792,11 +8840,19 @@ const LOCALES = {
     insights_skill_usage_col_views: '查看次数',
     insights_skill_usage_col_share: '使用占比',
     insights_skill_usage_col_patches: '补丁',
+    insights_period_label: '周期',
+    insights_scope_label: '视角',
+    insights_scope_webui: 'WebUI',
+    insights_scope_global: '全局',
+    insights_scope_global_unavailable: 'Hermes 全局用量数据不可用',
+    insights_scope_note: 'WebUI 显示本地会话索引用量；全局显示 Hermes 累计用量，更适合与 provider 后台对账。',
     insights_input_tokens: '输入',
     insights_messages: '消息',
     insights_models: '模型',
     insights_no_cost: 'N/A',
     insights_output_tokens: '输出',
+    insights_cache_read_tokens: '读取缓存',
+    insights_cache_write_tokens: '写入缓存',
     insights_peak_hour: '高峰：{hour}时',
     insights_sessions: '会话',
     insights_title: '使用分析',
@@ -10104,6 +10160,8 @@ const LOCALES = {
     insights_models: 'Models',  // TODO: translate
     insights_no_cost: 'N/A',  // TODO: translate
     insights_output_tokens: 'Output',  // TODO: translate
+    insights_cache_read_tokens: '读取缓存',
+    insights_cache_write_tokens: '写入缓存',
     insights_peak_hour: 'Peak: {hour}',  // TODO: translate
     insights_sessions: 'Sessions',  // TODO: translate
     insights_title: 'Usage Analytics',  // TODO: translate
@@ -11208,11 +11266,19 @@ const LOCALES = {
     insights_skill_usage_col_views: 'Views',  // TODO: translate
     insights_skill_usage_col_share: 'Usage %',  // TODO: translate
     insights_skill_usage_col_patches: 'Patches',  // TODO: translate
+    insights_period_label: 'Período',
+    insights_scope_label: 'Visão',
+    insights_scope_webui: 'WebUI',
+    insights_scope_global: 'Global',
+    insights_scope_global_unavailable: 'Dados globais Hermes indisponíveis',
+    insights_scope_note: 'WebUI mostra o uso do índice local de sessões; Global mostra o uso acumulado do Hermes para comparar com a cobrança do provedor.',
     insights_input_tokens: 'Input',  // TODO: translate
     insights_messages: 'Messages',  // TODO: translate
     insights_models: 'Models',  // TODO: translate
     insights_no_cost: 'N/A',  // TODO: translate
     insights_output_tokens: 'Output',  // TODO: translate
+    insights_cache_read_tokens: 'Cache lido',
+    insights_cache_write_tokens: 'Cache escrito',
     insights_peak_hour: 'Peak: {hour}',  // TODO: translate
     insights_sessions: 'Sessions',  // TODO: translate
     insights_title: 'Usage Analytics',  // TODO: translate
@@ -12494,11 +12560,19 @@ const LOCALES = {
     insights_skill_usage_col_views: 'Views',  // TODO: translate
     insights_skill_usage_col_share: 'Usage %',  // TODO: translate
     insights_skill_usage_col_patches: 'Patches',  // TODO: translate
+    insights_period_label: '기간',
+    insights_scope_label: '보기',
+    insights_scope_webui: 'WebUI',
+    insights_scope_global: '전체',
+    insights_scope_global_unavailable: 'Hermes 전체 사용 데이터를 사용할 수 없습니다',
+    insights_scope_note: 'WebUI는 로컬 세션 인덱스 사용량을 표시하고, 전체는 제공자 과금과 비교하기 위한 Hermes 누적 사용량을 표시합니다.',
     insights_input_tokens: 'Input',  // TODO: translate
     insights_messages: 'Messages',  // TODO: translate
     insights_models: 'Models',  // TODO: translate
     insights_no_cost: 'N/A',  // TODO: translate
     insights_output_tokens: 'Output',  // TODO: translate
+    insights_cache_read_tokens: '캐시 읽기',
+    insights_cache_write_tokens: '캐시 쓰기',
     insights_peak_hour: 'Peak: {hour}',  // TODO: translate
     insights_sessions: 'Sessions',  // TODO: translate
     insights_title: 'Usage Analytics',  // TODO: translate
@@ -13146,6 +13220,8 @@ const LOCALES = {
     insights_token_breakdown: 'Répartition des jetons',
     insights_input_tokens: 'Saisir',
     insights_output_tokens: 'Sortir',
+    insights_cache_read_tokens: 'Cache lu',
+    insights_cache_write_tokens: 'Cache écrit',
     insights_total: 'Total',
     insights_daily_tokens: 'Jetons quotidiens',
     insights_model_name: 'Modèle',
@@ -13167,6 +13243,12 @@ const LOCALES = {
     insights_skill_usage_col_views: 'Views',  // TODO: translate
     insights_skill_usage_col_share: 'Usage %',  // TODO: translate
     insights_skill_usage_col_patches: 'Patches',  // TODO: translate
+    insights_period_label: 'Période',
+    insights_scope_label: 'Vue',
+    insights_scope_webui: 'WebUI',
+    insights_scope_global: 'Global',
+    insights_scope_global_unavailable: 'Données globales Hermes indisponibles',
+    insights_scope_note: 'WebUI affiche l\'usage de l\'index local des sessions ; Global affiche l\'usage cumulé de Hermes pour le comparer à la facturation du fournisseur.',
     workspace_desc: 'Ajoutez et changez d\'espace de travail pour vos sessions.',
     session_lineage_segment_untitled: 'Segment sans titre',
     session_lineage_segment_open: 'Segment de lignée ouverte',
@@ -15013,11 +15095,19 @@ const LOCALES = {
     insights_skill_usage_col_views: 'Views',  // TODO: translate
     insights_skill_usage_col_share: 'Usage %',  // TODO: translate
     insights_skill_usage_col_patches: 'Patches',  // TODO: translate
+    insights_period_label: 'Dönem',
+    insights_scope_label: 'Görünüm',
+    insights_scope_webui: 'WebUI',
+    insights_scope_global: 'Genel',
+    insights_scope_global_unavailable: 'Hermes genel kullanım verisi mevcut değil',
+    insights_scope_note: 'WebUI yerel oturum dizini kullanımını gösterir; Genel, sağlayıcı faturalamasıyla karşılaştırmak için kümülatif Hermes kullanımını gösterir.',
     insights_input_tokens: 'Giriş',
     insights_messages: 'Mesajlar',
     insights_models: 'Modeller',
     insights_no_cost: 'Yok',
     insights_output_tokens: 'Çıkış',
+    insights_cache_read_tokens: 'Önbellek okuma',
+    insights_cache_write_tokens: 'Önbellek yazma',
     insights_peak_hour: 'Zirve: {hour}',
     insights_sessions: 'Oturumlar',
     insights_title: 'Kullanım analitiği',

--- a/static/index.html
+++ b/static/index.html
@@ -273,13 +273,19 @@
           <button class="panel-head-btn has-tooltip has-tooltip--bottom" id="insightsRefreshBtn" onclick="loadInsights(true)" data-tooltip="Refresh" aria-label="Refresh"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="23 4 23 10 17 10"/><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/></svg></button>
         </div>
       </div>
-      <div class="panel-head-sub" style="padding:0 12px 8px">
-        <select id="insightsPeriod" onchange="loadInsights()" style="width:100%;background:var(--input-bg);color:var(--text);border:1px solid var(--border);border-radius:6px;padding:4px 8px;font-size:12px">
+      <div class="insights-control-panel">
+        <label class="insights-control-label" for="insightsPeriod" data-i18n="insights_period_label">Period</label>
+        <select id="insightsPeriod" onchange="loadInsights()">
           <option value="7">7 days</option>
           <option value="30" selected>30 days</option>
           <option value="90">90 days</option>
           <option value="365">365 days</option>
         </select>
+        <span class="insights-control-label" id="insightsScopeLabel" data-i18n="insights_scope_label">View</span>
+        <div class="insights-scope-segmented" id="insightsScopeToggle" role="group" aria-labelledby="insightsScopeLabel">
+          <button type="button" class="insights-scope-btn is-active" data-scope="webui" aria-pressed="true" onclick="setInsightsScope('webui')" data-i18n="insights_scope_webui">WebUI</button>
+          <button type="button" class="insights-scope-btn" data-scope="global" aria-pressed="false" onclick="setInsightsScope('global')" data-i18n="insights_scope_global">Global</button>
+        </div>
       </div>
     </div>
     <!-- Workspaces panel -->

--- a/static/panels.js
+++ b/static/panels.js
@@ -3193,6 +3193,32 @@ async function copyLogsAll() {
 }
 
 // ── Insights panel ──
+// Scope state for the WebUI/Global toggle. Persisted in localStorage so the
+// user's last choice survives a reload. Default 'webui' matches historical
+// behavior — anyone not actively running hermes-agent gateway elsewhere
+// should never see a regression.
+let _insightsScope = 'webui';
+let _insightsRequestSeq = 0;
+try {
+  const stored = localStorage.getItem('insightsScope');
+  if (stored === 'webui' || stored === 'global') _insightsScope = stored;
+} catch (_) { /* localStorage may be unavailable in private mode */ }
+
+function setInsightsScope(scope) {
+  if (scope !== 'webui' && scope !== 'global') return;
+  if (scope === _insightsScope) return;
+  _insightsScope = scope;
+  try { localStorage.setItem('insightsScope', scope); } catch (_) {}
+  // Visual sync of the toggle buttons before fetch so the click feels instant.
+  const buttons = document.querySelectorAll('#insightsScopeToggle .insights-scope-btn');
+  buttons.forEach(btn => {
+    const active = btn.dataset.scope === scope;
+    btn.classList.toggle('is-active', active);
+    btn.setAttribute('aria-pressed', active ? 'true' : 'false');
+  });
+  void loadInsights();
+}
+
 async function loadInsights(animate) {
   const box = $('insightsContent');
   const refreshBtn = $('insightsRefreshBtn');
@@ -3202,22 +3228,71 @@ async function loadInsights(animate) {
     refreshBtn.disabled = true;
   }
   const period = ($('insightsPeriod') || {}).value || '30';
+  const scope = _insightsScope;
+  const requestSeq = ++_insightsRequestSeq;
   try {
     const [data, wikiStatus, skillUsage] = await Promise.all([
-      api(`/api/insights?days=${period}`),
+      api(`/api/insights?days=${period}&scope=${scope}`),
       api('/api/wiki/status').catch(err => ({status:'error', error: err.message || String(err)})),
       api('/api/skills/usage').catch(() => ({usage:{}, skill_names:[], total_invocations:0, unique_skills_used:0})),
     ]);
+    // If the user flipped the scope/period again while this request was in
+    // flight, ignore the stale response. This keeps every card/chart on the
+    // page synchronized to the most recent toggle state.
+    if (requestSeq !== _insightsRequestSeq) return;
+    _syncInsightsScopeUI(data);
     _renderInsights(data, box, wikiStatus, skillUsage);
     if (typeof _syncSystemHealthMonitorVisibility === 'function') _syncSystemHealthMonitorVisibility();
     if (typeof pollSystemHealth === 'function') void pollSystemHealth();
   } catch(e) {
+    // Mirror the success-path stale guard: an older failed request must not
+    // replace newer scope/period data with an error banner after the user has
+    // already toggled again.
+    if (requestSeq !== _insightsRequestSeq) return;
     box.innerHTML = `<div style="color:var(--accent);font-size:12px">${esc(t('error_prefix') + e.message)}</div>`;
   } finally {
     if (animate && refreshBtn) {
       refreshBtn.style.opacity = '';
       refreshBtn.disabled = false;
     }
+  }
+}
+
+// Reflect the *effective* scope returned by the server in the toggle UI.
+// When the user asked for 'global' but state.db was unreachable, the server
+// falls back to webui data and sets scope_available=false; we surface that
+// by disabling the Global button with an explanatory tooltip and snapping
+// the active state back to webui so the next refresh doesn't keep retrying.
+function _syncInsightsScopeUI(data) {
+  if (!data) return;
+  const effective = data.scope || 'webui';
+  const requested = data.scope_requested || effective;
+  const available = data.scope_available !== false;
+
+  if (effective !== _insightsScope) {
+    _insightsScope = effective;
+    try { localStorage.setItem('insightsScope', effective); } catch (_) {}
+  }
+
+  const buttons = document.querySelectorAll('#insightsScopeToggle .insights-scope-btn');
+  buttons.forEach(btn => {
+    const isGlobal = btn.dataset.scope === 'global';
+    const isActive = btn.dataset.scope === effective;
+    btn.classList.toggle('is-active', isActive);
+    btn.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+    // Disable the Global button when state.db is unreachable so the user
+    // gets an honest signal rather than a silently-falling-back toggle.
+    if (isGlobal && !available) {
+      btn.disabled = true;
+      btn.title = t('insights_scope_global_unavailable');
+    } else {
+      btn.disabled = false;
+      btn.removeAttribute('title');
+    }
+  });
+  // Keep the underlying state.scope honest after a fallback.
+  if (requested === 'global' && !available && effective === 'webui') {
+    _insightsScope = 'webui';
   }
 }
 
@@ -3428,8 +3503,8 @@ function _renderInsights(d, box, wikiStatus, skillUsage) {
   if (d.models && d.models.length) {
     modelsHtml = `<div class="insights-card"><div class="insights-card-title">${esc(t('insights_models'))}</div><div class="insights-table insights-model-table"><div class="insights-table-head"><span>${esc(t('insights_model_name'))}</span><span>${esc(t('insights_model_sessions'))}</span><span>${esc(t('insights_model_tokens'))}</span><span>${esc(t('insights_model_cost'))}</span><span>${esc(t('insights_model_share'))}</span></div>` +
       d.models.map(m => {
-        const share = Number(m.cost_share || m.token_share || m.session_share || 0);
-        const title = `${m.model} · ${fmtTokens(m.input_tokens)} ${t('insights_input_tokens')} · ${fmtTokens(m.output_tokens)} ${t('insights_output_tokens')}`;
+        const share = Number(m.token_share || 0);
+        const title = `${m.model} · ${fmtTokens(m.input_tokens)} ${t('insights_input_tokens')} · ${fmtTokens(m.cache_read_tokens || 0)} ${t('insights_cache_read_tokens')} · ${fmtTokens(m.cache_write_tokens || 0)} ${t('insights_cache_write_tokens')} · ${fmtTokens(m.output_tokens)} ${t('insights_output_tokens')}`;
         return `<div class="insights-table-row"><span class="insights-model-name" title="${esc(m.model)}">${esc(m.model)}</span><span>${fmtNum(m.sessions)}</span><span class="insights-model-tokens" title="${esc(title)}">${fmtTokens(m.total_tokens || 0)}</span><span class="insights-model-cost">${fmtCost(m.cost)}</span><span>${share}%</span></div>`;
       }).join('') +
       `</div></div>`;
@@ -3464,12 +3539,22 @@ function _renderInsights(d, box, wikiStatus, skillUsage) {
   }
 
   // Token breakdown
+  const cacheReadTokens = Number(d.total_cache_read_tokens || 0);
+  const cacheWriteTokens = Number(d.total_cache_write_tokens || 0);
   const tokenCards = `
     <div class="insights-card">
       <div class="insights-card-title">${esc(t('insights_token_breakdown'))}</div>
       <div class="insights-token-row">
         <span class="insights-token-label">${esc(t('insights_input_tokens'))}</span>
         <span class="insights-token-value">${fmtTokens(d.total_input_tokens)}</span>
+      </div>
+      <div class="insights-token-row insights-token-subrow">
+        <span class="insights-token-label">${esc(t('insights_cache_read_tokens'))}</span>
+        <span class="insights-token-value">${fmtTokens(cacheReadTokens)}</span>
+      </div>
+      <div class="insights-token-row insights-token-subrow">
+        <span class="insights-token-label">${esc(t('insights_cache_write_tokens'))}</span>
+        <span class="insights-token-value">${fmtTokens(cacheWriteTokens)}</span>
       </div>
       <div class="insights-token-row">
         <span class="insights-token-label">${esc(t('insights_output_tokens'))}</span>
@@ -3488,6 +3573,7 @@ function _renderInsights(d, box, wikiStatus, skillUsage) {
     <div class="insights-grid">
       ${overviewCards.map(c => `<div class="insights-stat"><div class="insights-stat-icon">${c.icon}</div><div class="insights-stat-info"><div class="insights-stat-value">${c.value}</div><div class="insights-stat-label">${esc(c.label)}</div></div></div>`).join('')}
     </div>
+    <div class="insights-scope-note">${esc(t('insights_scope_note'))}</div>
     ${dailyHtml}
     <div class="insights-row insights-usage-grid">
       ${tokenCards}

--- a/static/style.css
+++ b/static/style.css
@@ -4263,6 +4263,18 @@ main.main.showing-insights > #mainInsights{display:flex;overflow-y:auto;}
 .insights-model-cost,.insights-model-tokens{font-variant-numeric:tabular-nums;}
 .insights-model-name{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
 .insights-empty{font-size:12px;color:var(--muted);padding:12px 0;}
+/* ── Insights control panel (mirrors logs-control-panel for visual parity) ─ */
+.insights-control-panel{display:flex;flex-direction:column;gap:8px;padding:12px;flex-shrink:0;}
+.insights-control-label{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--muted);}
+.insights-control-panel select{width:100%;background:var(--input-bg);color:var(--text);border:1px solid var(--border);border-radius:8px;padding:7px 9px;font-size:12px;}
+/* ── Insights scope toggle (WebUI vs Hermes Global) ───────────────── */
+.insights-scope-segmented{display:flex;width:100%;background:var(--input-bg);border:1px solid var(--border);border-radius:8px;padding:2px;}
+.insights-scope-btn{flex:1;padding:5px 10px;font-size:12px;font-weight:500;background:transparent;color:var(--muted);border:none;border-radius:6px;cursor:pointer;transition:background .12s,color .12s;}
+.insights-scope-btn:hover:not(:disabled){color:var(--text);}
+.insights-scope-btn.is-active{background:var(--accent-bg);color:var(--accent-text);}
+.insights-scope-btn:disabled{opacity:.45;cursor:not-allowed;}
+.insights-scope-note{font-size:11px;color:var(--muted);line-height:1.45;margin:-2px 0 6px;text-align:left;opacity:.78;}
+.insights-token-subrow{padding-left:12px;opacity:.72;font-size:11px;}
 .insights-daily-token-chart{height:180px;display:grid;grid-auto-flow:column;grid-auto-columns:minmax(0,1fr);gap:4px;align-items:end;padding:6px 0 2px;border-bottom:1px solid var(--border);overflow:hidden;max-width:100%;}
 .insights-daily-bar{min-width:0;height:100%;display:flex;flex-direction:column;justify-content:flex-end;gap:4px;}
 .insights-daily-stack{height:150px;display:flex;flex-direction:column;justify-content:flex-end;background:var(--border,.15);border-radius:4px;overflow:hidden;}

--- a/tests/test_insights.py
+++ b/tests/test_insights.py
@@ -39,7 +39,7 @@ class _FakeHandler:
         return json.loads(bytes(self.body).decode("utf-8"))
 
 
-def _call_insights(monkeypatch, tmp_path, entries, days="7", now=None):
+def _call_insights(monkeypatch, tmp_path, entries, days="7", now=None, scope=None):
     import api.routes as routes
 
     session_dir = tmp_path / "sessions"
@@ -50,10 +50,247 @@ def _call_insights(monkeypatch, tmp_path, entries, days="7", now=None):
         monkeypatch.setattr(time, "time", lambda: now)
 
     handler = _FakeHandler()
-    parsed = SimpleNamespace(query=f"days={days}")
+    qs = f"days={days}"
+    if scope is not None:
+        qs += f"&scope={scope}"
+    parsed = SimpleNamespace(query=qs)
     routes._handle_insights(handler, parsed)
     assert handler.status == 200
     return handler.json_body()
+
+
+def _seed_state_db(db_path, rows):
+    """Build a minimal hermes-agent state.db with the schema columns
+    _load_global_state_db_entries reads. Returns the path written."""
+    import sqlite3
+
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute("""
+            CREATE TABLE sessions (
+                id TEXT PRIMARY KEY,
+                source TEXT NOT NULL,
+                model TEXT,
+                started_at REAL NOT NULL,
+                ended_at REAL,
+                message_count INTEGER DEFAULT 0,
+                input_tokens INTEGER DEFAULT 0,
+                output_tokens INTEGER DEFAULT 0,
+                cache_read_tokens INTEGER DEFAULT 0,
+                cache_write_tokens INTEGER DEFAULT 0,
+                estimated_cost_usd REAL,
+                actual_cost_usd REAL
+            )
+        """)
+        for r in rows:
+            conn.execute("""
+                INSERT INTO sessions (
+                    id, source, model, started_at, ended_at, message_count,
+                    input_tokens, output_tokens, cache_read_tokens,
+                    cache_write_tokens, estimated_cost_usd, actual_cost_usd
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """, (
+                r["id"], r["source"], r.get("model", "test"),
+                r["started_at"], r.get("ended_at"), r.get("message_count", 1),
+                r.get("input_tokens", 0), r.get("output_tokens", 0),
+                r.get("cache_read_tokens", 0), r.get("cache_write_tokens", 0),
+                r.get("estimated_cost_usd"), r.get("actual_cost_usd"),
+            ))
+        conn.commit()
+    finally:
+        conn.close()
+    return db_path
+
+
+def test_insights_default_scope_is_webui_and_response_advertises_scope(monkeypatch, tmp_path):
+    """Without ``?scope=`` the endpoint serves the historical webui-only
+    payload, and the response declares the effective scope so the UI can
+    label what's being shown."""
+    now = time.mktime((2026, 5, 4, 12, 0, 0, 0, 0, -1))
+    entries = [{
+        "session_id": "webui-only",
+        "updated_at": now,
+        "created_at": now,
+        "message_count": 3,
+        "input_tokens": 9000,
+        "output_tokens": 100,
+        "estimated_cost": 0.05,
+        "model": "gpt-5.5",
+    }]
+
+    data = _call_insights(monkeypatch, tmp_path, entries, days="7", now=now)
+    assert data["scope"] == "webui"
+    assert data["scope_requested"] == "webui"
+    assert data["scope_available"] is True
+    assert data["total_input_tokens"] == 9000
+    assert data["total_output_tokens"] == 100
+    assert data["total_tokens"] == 9100
+
+
+def test_insights_global_scope_reads_state_db_with_full_prompt_semantics(monkeypatch, tmp_path):
+    """scope=global must aggregate every Hermes session source from state.db
+    and reshape ``input_tokens`` to the *full prompt total* (new + cache_read
+    + cache_write) so it lines up with what providers bill — and with what
+    the WebUI scope already shows."""
+    import api.routes as routes
+
+    now = time.mktime((2026, 5, 4, 12, 0, 0, 0, 0, -1))
+    one_hour_ago = now - 3600
+
+    home_dir = tmp_path / "hermes_home"
+    home_dir.mkdir()
+    state_db = home_dir / "state.db"
+    _seed_state_db(state_db, [
+        # WebUI session — also exists in _index.json conceptually; here we
+        # just verify it is summed in the global view.
+        {
+            "id": "webui-1", "source": "webui", "model": "claude-opus-4.7",
+            "started_at": one_hour_ago, "ended_at": one_hour_ago + 60,
+            "message_count": 4,
+            "input_tokens": 1_000_000,    # new prompt only (cache subtracted)
+            "output_tokens": 50_000,
+            "cache_read_tokens": 7_700_000,
+            "cache_write_tokens": 400_000,
+            "estimated_cost_usd": 5.0,
+        },
+        # Discord session — completely invisible in the WebUI scope.
+        {
+            "id": "discord-1", "source": "discord", "model": "claude-sonnet-4",
+            "started_at": one_hour_ago, "ended_at": one_hour_ago + 30,
+            "message_count": 2,
+            "input_tokens": 500_000,
+            "output_tokens": 20_000,
+            "cache_read_tokens": 3_000_000,
+            "cache_write_tokens": 100_000,
+            "actual_cost_usd": 1.25,
+        },
+        # CLI session — cost only via actual_cost_usd; estimated is null.
+        {
+            "id": "cli-1", "source": "cli", "model": "gpt-5.5",
+            "started_at": one_hour_ago, "ended_at": None,
+            "message_count": 1,
+            "input_tokens": 100_000, "output_tokens": 10_000,
+            "cache_read_tokens": 0, "cache_write_tokens": 0,
+            "actual_cost_usd": 0.42,
+        },
+    ])
+    monkeypatch.setenv("HERMES_HOME", str(home_dir))
+    # SESSION_DIR is still patched by _call_insights but should not be read
+    # for scope=global; pass an empty index just in case.
+    data = _call_insights(monkeypatch, tmp_path, [], days="7", now=now, scope="global")
+
+    assert data["scope"] == "global"
+    assert data["scope_requested"] == "global"
+    assert data["scope_available"] is True
+    assert data["total_sessions"] == 3
+
+    # Full-prompt semantics: state.db's three buckets must be summed back
+    # together so the WebUI's "input" column equals provider prompt_tokens.
+    expected_input = (
+        (1_000_000 + 7_700_000 + 400_000) +
+        (500_000 + 3_000_000 + 100_000) +
+        (100_000 + 0 + 0)
+    )
+    expected_output = 50_000 + 20_000 + 10_000
+    assert data["total_input_tokens"] == expected_input
+    assert data["total_output_tokens"] == expected_output
+    assert data["total_tokens"] == expected_input + expected_output
+
+    # Cost: actual_cost_usd preferred when present; otherwise estimated.
+    # Here: webui-1 → 5.0 (estimated, no actual), discord-1 → 1.25 (actual),
+    # cli-1 → 0.42 (actual). Total = 6.67.
+    assert abs(data["total_cost"] - 6.67) < 1e-6
+
+    # Per-model breakdown must include both webui and discord models.
+    model_names = {m["model"] for m in data["models"]}
+    assert {"claude-opus-4.7", "claude-sonnet-4", "gpt-5.5"}.issubset(model_names)
+
+
+def test_insights_global_scope_includes_sessions_active_inside_window(monkeypatch, tmp_path):
+    """Global scope should use the same active-in-window semantics as the
+    historical WebUI scope: a long-running session that started before the
+    selected range but ended/updated inside it is still relevant."""
+    now = time.mktime((2026, 5, 25, 12, 0, 0, 0, 0, -1))
+    today = time.localtime(now)
+    today_midnight = time.mktime((
+        today.tm_year, today.tm_mon, today.tm_mday, 0, 0, 0,
+        today.tm_wday, today.tm_yday, today.tm_isdst,
+    ))
+    cutoff = today_midnight - (6 * 86400)  # days=7 calendar window
+
+    home_dir = tmp_path / "hermes_home_active_window"
+    home_dir.mkdir()
+    _seed_state_db(home_dir / "state.db", [{
+        "id": "long-session",
+        "source": "webui",
+        "model": "claude-opus-4.7",
+        "started_at": cutoff - 3600,
+        "ended_at": cutoff + 3600,
+        "message_count": 2,
+        "input_tokens": 10,
+        "cache_read_tokens": 20,
+        "cache_write_tokens": 30,
+        "output_tokens": 5,
+        "estimated_cost_usd": 0.1,
+    }])
+    monkeypatch.setenv("HERMES_HOME", str(home_dir))
+
+    data = _call_insights(monkeypatch, tmp_path, [], days="7", now=now, scope="global")
+    assert data["scope"] == "global"
+    assert data["total_sessions"] == 1
+    assert data["total_messages"] == 2
+    assert data["total_input_tokens"] == 60
+    assert data["total_output_tokens"] == 5
+    assert data["total_tokens"] == 65
+
+
+def test_insights_global_scope_falls_back_when_state_db_missing(monkeypatch, tmp_path):
+    """Asking for scope=global when state.db isn't reachable must return
+    the WebUI payload with scope_available=false so the UI can disable the
+    Global toggle and explain why."""
+    home_dir = tmp_path / "hermes_home_no_db"
+    home_dir.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home_dir))
+
+    now = time.mktime((2026, 5, 4, 12, 0, 0, 0, 0, -1))
+    entries = [{
+        "session_id": "webui-only",
+        "updated_at": now,
+        "created_at": now,
+        "message_count": 1,
+        "input_tokens": 200,
+        "output_tokens": 50,
+        "estimated_cost": 0.0,
+        "model": "gpt-5.5",
+    }]
+
+    data = _call_insights(monkeypatch, tmp_path, entries, days="7", now=now, scope="global")
+    assert data["scope"] == "webui"               # effective fell back
+    assert data["scope_requested"] == "global"     # but UI knows the user asked for global
+    assert data["scope_available"] is False        # so the toggle can disable
+    assert data["total_input_tokens"] == 200
+    assert data["total_output_tokens"] == 50
+
+
+def test_insights_unknown_scope_param_is_treated_as_webui(monkeypatch, tmp_path):
+    """Defensive: any garbage value in ?scope= must collapse to the safe
+    WebUI default rather than 500-ing or leaking implementation details."""
+    now = time.mktime((2026, 5, 4, 12, 0, 0, 0, 0, -1))
+    entries = [{
+        "session_id": "webui-only",
+        "updated_at": now,
+        "created_at": now,
+        "message_count": 1,
+        "input_tokens": 10,
+        "output_tokens": 5,
+        "estimated_cost": 0.0,
+        "model": "x",
+    }]
+
+    data = _call_insights(monkeypatch, tmp_path, entries, days="7", now=now, scope="bogus-scope-name")
+    assert data["scope"] == "webui"
+    assert data["scope_requested"] == "webui"
+    assert data["total_tokens"] == 15
 
 
 def _day(ts):
@@ -96,6 +333,8 @@ def test_insights_daily_tokens_zero_fills_selected_range_and_parses_cost(monkeyp
         "date": _day(now),
         "input_tokens": 1200,
         "output_tokens": 300,
+        "cache_read_tokens": 0,
+        "cache_write_tokens": 0,
         "sessions": 1,
         "cost": 0.0123,
     }
@@ -103,6 +342,8 @@ def test_insights_daily_tokens_zero_fills_selected_range_and_parses_cost(monkeyp
         "date": _day(now - 86400),
         "input_tokens": 0,
         "output_tokens": 0,
+        "cache_read_tokens": 0,
+        "cache_write_tokens": 0,
         "sessions": 0,
         "cost": 0.0,
     }
@@ -158,10 +399,85 @@ def test_insights_frontend_has_daily_chart_styles_and_range_switching_hooks():
     assert 'option value="30"' in INDEX_HTML
     assert 'option value="90"' in INDEX_HTML
     assert "loadInsights()" in INDEX_HTML
-    assert "/api/insights?days=${period}" in PANELS_JS
+    # Scope param now part of the insights URL contract.
+    assert "/api/insights?days=${period}&scope=${scope}" in PANELS_JS
     assert ".insights-daily-token-chart" in STYLE_CSS
     assert ".insights-daily-bar-output" in STYLE_CSS
     assert ".insights-model-cost" in STYLE_CSS
+
+
+def test_insights_frontend_exposes_webui_global_scope_toggle():
+    """The toggle must exist in both the markup and the panel script,
+    and CSS must style the segmented control. This is the visual contract
+    that lets a user flip between WebUI-only and Hermes-global token
+    views without any other page state changing."""
+    # HTML: toggle DOM
+    assert 'id="insightsScopeToggle"' in INDEX_HTML
+    assert 'data-scope="webui"' in INDEX_HTML
+    assert 'data-scope="global"' in INDEX_HTML
+    scope_start = INDEX_HTML.index('id="insightsScopeToggle"')
+    scope_end = INDEX_HTML.index('</div>\n        </div>', scope_start)
+    scope_markup = INDEX_HTML[scope_start:scope_end]
+    assert 'aria-pressed="true"' in scope_markup
+    assert 'role="tab"' not in scope_markup
+    assert 'role="tablist"' not in scope_markup
+    assert "insights_scope_label" in INDEX_HTML
+    assert "insights_scope_webui" in INDEX_HTML
+    assert "insights_scope_global" in INDEX_HTML
+    assert "setInsightsScope" in INDEX_HTML
+
+    # JS: state, setter, fetch param, fallback sync
+    assert "let _insightsScope" in PANELS_JS
+    assert "function setInsightsScope" in PANELS_JS
+    assert "_syncInsightsScopeUI" in PANELS_JS
+    assert "let _insightsRequestSeq" in PANELS_JS
+    assert "requestSeq !== _insightsRequestSeq" in PANELS_JS
+    assert "aria-pressed" in PANELS_JS
+    assert "scope_available" in PANELS_JS  # frontend reads the fallback flag
+    assert "insights_scope_note" in PANELS_JS
+    assert "insights-scope-note" in PANELS_JS
+    assert "localStorage.setItem('insightsScope'" in PANELS_JS  # persisted preference
+
+    # CSS: segmented control styling
+    assert ".insights-scope-toggle" in STYLE_CSS
+    assert ".insights-scope-segmented" in STYLE_CSS
+    assert ".insights-scope-btn" in STYLE_CSS
+    assert ".insights-scope-btn.is-active" in STYLE_CSS
+    assert ".insights-scope-note" in STYLE_CSS
+
+
+def test_insights_i18n_scope_keys_present_in_every_locale():
+    """Every locale must carry the four scope-toggle keys so the toggle
+    label and the unavailable-tooltip work in every language. Missing a
+    locale would surface as 'undefined' text in the UI."""
+    import re as _re
+
+    i18n_path = REPO_ROOT / "static" / "i18n.js"
+    text = i18n_path.read_text(encoding="utf-8")
+
+    locales: list[tuple[str, int, int]] = []
+    for m in _re.finditer(r"^  ([a-z]{2}(?:-[a-z]+)?):\s*\{", text, _re.MULTILINE):
+        locales.append((m.group(1), m.start(), -1))
+    # Compute end-offsets
+    finalized = []
+    for i, (name, start, _end) in enumerate(locales):
+        end = locales[i + 1][1] if i + 1 < len(locales) else len(text)
+        finalized.append((name, start, end))
+
+    # Sanity: project ships at least 11 locales today.
+    assert len(finalized) >= 11, f"expected >=11 locales, found {len(finalized)}"
+
+    required_keys = (
+        "insights_scope_label",
+        "insights_scope_webui",
+        "insights_scope_global:",          # trailing colon disambiguates from _global_unavailable
+        "insights_scope_global_unavailable",
+        "insights_scope_note",
+    )
+    for name, start, end in finalized:
+        block = text[start:end]
+        for key in required_keys:
+            assert key in block, f"locale '{name}' missing i18n key: {key.rstrip(':')}"
 
 
 def _make_daily_rows(n):

--- a/tests/test_insights.py
+++ b/tests/test_insights.py
@@ -415,8 +415,14 @@ def test_insights_frontend_exposes_webui_global_scope_toggle():
     assert 'id="insightsScopeToggle"' in INDEX_HTML
     assert 'data-scope="webui"' in INDEX_HTML
     assert 'data-scope="global"' in INDEX_HTML
+    # Locate the segmented control's body and assert pressed-state semantics
+    # without pinning the assertion to a specific surrounding indent so the
+    # sidebar layout can evolve without breaking the contract.
     scope_start = INDEX_HTML.index('id="insightsScopeToggle"')
-    scope_end = INDEX_HTML.index('</div>\n        </div>', scope_start)
+    # The segmented control's own </div> closes the toggle; everything between
+    # the opening tag and that close is the scope toggle body (label + buttons).
+    after_open = INDEX_HTML.index('>', scope_start) + 1
+    scope_end = INDEX_HTML.index('</div>', after_open)
     scope_markup = INDEX_HTML[scope_start:scope_end]
     assert 'aria-pressed="true"' in scope_markup
     assert 'role="tab"' not in scope_markup
@@ -425,25 +431,41 @@ def test_insights_frontend_exposes_webui_global_scope_toggle():
     assert "insights_scope_webui" in INDEX_HTML
     assert "insights_scope_global" in INDEX_HTML
     assert "setInsightsScope" in INDEX_HTML
+    # Sidebar control panel layout: Period select sits above the scope toggle
+    # in a stacked label+control rhythm that mirrors the Logs control panel,
+    # so both controls share the same starting x and the period select is no
+    # longer floating tight against the panel header. (#2943)
+    assert 'class="insights-control-panel"' in INDEX_HTML
+    assert 'insights_period_label' in INDEX_HTML
+    assert 'for="insightsPeriod"' in INDEX_HTML
 
     # JS: state, setter, fetch param, fallback sync
     assert "let _insightsScope" in PANELS_JS
     assert "function setInsightsScope" in PANELS_JS
     assert "_syncInsightsScopeUI" in PANELS_JS
     assert "let _insightsRequestSeq" in PANELS_JS
-    assert "requestSeq !== _insightsRequestSeq" in PANELS_JS
+    # Both success and error paths must drop stale responses after a newer
+    # period/scope request starts; otherwise an old failure can overwrite
+    # fresh data with an error banner.
+    assert PANELS_JS.count("requestSeq !== _insightsRequestSeq") >= 2
     assert "aria-pressed" in PANELS_JS
     assert "scope_available" in PANELS_JS  # frontend reads the fallback flag
     assert "insights_scope_note" in PANELS_JS
     assert "insights-scope-note" in PANELS_JS
+    assert "insights_cache_read_tokens" in PANELS_JS
+    assert "insights_cache_write_tokens" in PANELS_JS
+    assert "insights_cache_tokens_note" not in PANELS_JS
     assert "localStorage.setItem('insightsScope'" in PANELS_JS  # persisted preference
 
-    # CSS: segmented control styling
-    assert ".insights-scope-toggle" in STYLE_CSS
+    # CSS: segmented control + sidebar control panel styling
+    assert ".insights-control-panel" in STYLE_CSS
+    assert ".insights-control-label" in STYLE_CSS
     assert ".insights-scope-segmented" in STYLE_CSS
     assert ".insights-scope-btn" in STYLE_CSS
     assert ".insights-scope-btn.is-active" in STYLE_CSS
     assert ".insights-scope-note" in STYLE_CSS
+    assert ".insights-token-subrow" in STYLE_CSS
+    assert ".insights-cache-note" not in STYLE_CSS
 
 
 def test_insights_i18n_scope_keys_present_in_every_locale():
@@ -473,6 +495,8 @@ def test_insights_i18n_scope_keys_present_in_every_locale():
         "insights_scope_global:",          # trailing colon disambiguates from _global_unavailable
         "insights_scope_global_unavailable",
         "insights_scope_note",
+        "insights_cache_read_tokens",
+        "insights_cache_write_tokens",
     )
     for name, start, end in finalized:
         block = text[start:end]


### PR DESCRIPTION
# PR Description

## Summary

Add a WebUI / Global scope toggle to the Insights panel so users can distinguish local WebUI session-index usage from cumulative Hermes usage across all entry points.

The original Insights panel only read WebUI's local `_index.json`, so token totals could be much lower than provider billing dashboards when usage came from Discord, CLI, cron, kanban workers, `delegate_task`, or other Hermes surfaces.

## What changed

### Backend

- Add `scope=webui|global` to `/api/insights`.
- `scope=webui` preserves historical behavior:
  - reads `~/.hermes/webui/sessions/_index.json`
  - keeps existing WebUI session/message semantics
- `scope=global` reads Hermes Agent's `~/.hermes/state.db` in SQLite read-only URI mode.
- Global token accounting normalizes `state.db` token buckets into provider-comparable prompt totals:

  ```text
  input = input_tokens + cache_read_tokens + cache_write_tokens
  total = input + output_tokens
  ```

- Adds `scope`, `scope_requested`, and `scope_available` response fields so the UI can reflect fallbacks honestly.
- Uses active-in-window filtering for both scopes.
- Adds Cache Read / Cache Write fields to the response as informational prompt subcomponents.
- Fixes model share calculation using largest-remainder allocation so displayed percentages sum to 100.

### Frontend

- Adds a WebUI / Global segmented toggle under the Insights period selector.
- Persists selected scope in `localStorage`.
- Guards against stale responses when toggling quickly.
- Shows a short left-aligned scope note explaining:
  - WebUI = local session-index usage
  - Global = cumulative Hermes usage for provider billing comparison
- Token Breakdown now shows:
  - Input
  - Cache Read
  - Cache Write
  - Output
  - Total
- Models table Share now uses `token_share` consistently instead of mixing `cost_share || token_share || session_share`.
- Uses `aria-pressed` button semantics instead of an incomplete tablist pattern.
- Adds i18n coverage for all new labels across supported locales.

## Testing

- `python -m py_compile api/routes.py`
- `node --check static/panels.js`
- `node --check static/i18n.js`
- `pytest tests/test_insights.py`

Result:

```text
18 passed
```

## Notes

Cost display still depends on whether `state.db` has populated cost fields. This PR fixes token accounting and scope visibility; it does not attempt to backfill or recalculate missing cost data.
