### PR TITLE
ux(composer): cap composer-box max-width at 1600px on ultrawide viewports (#2856)

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -4509,3 +4509,8 @@ main.main.showing-logs > #mainLogs{display:flex;}
   text-align:left;
   unicode-bidi:isolate;
 }
+
+/* Cap composer width on very wide displays so the chip-cluster gap stays bounded */
+@media (min-width:1600px) {
+  .composer-box{max-width:1600px;margin:0 auto;}
+}


### PR DESCRIPTION
## Thinking Path

Issue #2856 surfaced the intra-`.composer-left` gap at ultrawide viewports
(3440px+). The maintainer confirmed Position A in the same thread: chips stay
content-sized and left-anchored, and the trailing space is unused width rather
than a layout bug. As a separate, page-level proportionality concern the
maintainer offered this exact `@media (min-width:1600px) { .composer-box { max-width:1600px; margin:0 auto; } }`
rule as a "lowest-risk first slice" -- not a fix for Position A, but an
adjacent improvement so the composer claims more of the viewport on very wide
displays.

This PR implements exactly that offer. One rule, no redesign, no chip
redistribution. Position A on the chip-cluster gap is unchanged.

## What Changed

Appended a single `@media (min-width:1600px)` block at the end of
`static/style.css`:

```css
@media (min-width:1600px) {
  .composer-box{max-width:1600px;margin:0 auto;}
}
```

The base rule on master is
`.composer-box{max-width:clamp(780px,60vw,1100px);margin:0 auto;...}`
(shipped in v0.51.127 via #2812). At viewports >=1600px the new `@media` rule's
`max-width:1600px` wins by source order over the clamp's 1100px ceiling, so
`.composer-box` is allowed to grow up to 1600px and stays centered via
`margin:0 auto` (which the base rule already sets -- the @media `margin:0 auto`
is a no-op for the margin and present only for self-containment).

Below 1600px nothing changes: the clamp behavior holds and the composer-box
ceiling is 1100px as on master.

## Why It Matters

At a 3440px viewport the current `.composer-box` tops out at 1100px (the
clamp's ceiling), which leaves the composer feeling small relative to the
viewport. The 1600px allowance raises that ceiling on very wide displays so
the composer claims proportionally more horizontal space, centered.

Note on the Position A interaction: the intra-`.composer-left` gap (rightmost
left-cluster chip to right-cluster) is unchanged in behavior -- chips remain
content-sized, the gap is still unused width. The gap's absolute pixel width
does grow because `.composer-left` now has more space to absorb when
`.composer-box` is wider. That growth is intentional under Position A; the
chips don't redistribute. This PR widens the box, not the chips.

## Verification

Verified by reasoning from the CSS cascade:

- Below 1600px the new rule does not match, the base clamp rule applies,
  and `.composer-box` ceiling is `clamp(780px,60vw,1100px)` exactly as
  on master.
- At >=1600px the new rule matches. By source order it appears after the
  base rule, so `max-width:1600px` wins the cascade for `.composer-box`.
  No `!important` is used; specificity is identical to the base rule
  (single class selector), and source-order tie-breaking applies.
- `margin:0 auto` keeps centering consistent with the base rule.

No browser-resize screenshots were captured this session. The rule is small
and deterministic enough that a maintainer can verify with the #2856
reproducer plus the one-line addition.

What was NOT verified:

- macOS / iOS / Android -- no test surfaces available
- Firefox / Safari -- not tested (the rule is standard CSS, no vendor prefix
  needed)
- Upstream CI matrix -- not accessible from a contributor environment
- Mobile (<780px) -- the rule activates only at >=1600px so there is no
  mobile interaction by construction

## Risks

Purely additive: a new `@media` block at EOF. No existing rule is modified.
No `!important`. Cascade wins via source order at viewports >=1600px only.
Below 1600px the existing clamp behavior holds unchanged. No flex layout or
chip sizing is altered.

## Model Used

Claude Opus 4.7 (claude-opus-4-7). PR body, diff, and verification reasoning
drafted with AI assistance; reviewed by a human on the contributor side
before filing.
