### PR TITLE
fix(providers): clearer toast on 403 when removing a provider key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Removing a provider key now surfaces "Session expired. Reload the page and try again." when the underlying POST is rejected with 403, instead of the raw "Cross-origin request rejected" string that gives the user no next step. (Refs #2572)
+
 ## [v0.51.137] — 2026-05-25 — Release DI (stage-batch19 — 6-PR medium-risk batch)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Changed
 
-- Removing a provider key now surfaces "Session expired. Reload the page and try again." when the underlying POST is rejected with 403, instead of the raw "Cross-origin request rejected" string that gives the user no next step. (Refs #2572)
+- Removing a provider key now surfaces the server's specific CSRF rejection reason ("Session expired - reload the page", "Cross-origin mismatch - check reverse proxy headers", or the fallback "Cross-origin request rejected") when the underlying POST is rejected with 403, instead of swallowing all three into one generic toast. (Refs #2572)
 
 ## [v0.51.137] — 2026-05-25 — Release DI (stage-batch19 — 6-PR medium-risk batch)
 

--- a/static/panels.js
+++ b/static/panels.js
@@ -6875,13 +6875,15 @@ async function _removeProviderKey(providerId){
     }
   }catch(e){
     // A 403 from /api/providers/delete fires when the CSRF cookie/header
-    // pair has drifted (typically a tab opened before the most recent
-    // login or cookie rotation). The raw server string is
-    // "Cross-origin request rejected" which reads like a deployment-shape
-    // problem and gives the user no next step (#2572). Surface a clearer
-    // recovery hint instead so reloading the page is an obvious fix.
+    // pair has drifted. The server distinguishes three reasons in
+    // api/routes.py:_csrf_rejection_error ("Session expired - reload the
+    // page", "Cross-origin mismatch - check reverse proxy headers", and
+    // the fallback "Cross-origin request rejected"); api()'s catch lifts
+    // that string onto e.message. Pass it through verbatim so the
+    // deployment-shape failure #2572 calls out keeps its actionable hint
+    // instead of being flattened to a single generic toast.
     if(e&&e.status===403){
-      showToast('Session expired. Reload the page and try again.',6000,'error');
+      showToast(e.message||'Session expired. Reload the page and try again.',6000,'error');
     }else{
       showToast('Error: '+e.message);
     }

--- a/static/panels.js
+++ b/static/panels.js
@@ -6874,7 +6874,17 @@ async function _removeProviderKey(providerId){
       if(els.saveBtn){els.saveBtn.disabled=false;els.saveBtn.textContent=t('providers_save');}
     }
   }catch(e){
-    showToast('Error: '+e.message);
+    // A 403 from /api/providers/delete fires when the CSRF cookie/header
+    // pair has drifted (typically a tab opened before the most recent
+    // login or cookie rotation). The raw server string is
+    // "Cross-origin request rejected" which reads like a deployment-shape
+    // problem and gives the user no next step (#2572). Surface a clearer
+    // recovery hint instead so reloading the page is an obvious fix.
+    if(e&&e.status===403){
+      showToast('Session expired. Reload the page and try again.',6000,'error');
+    }else{
+      showToast('Error: '+e.message);
+    }
     if(els.saveBtn){els.saveBtn.disabled=false;els.saveBtn.textContent=t('providers_save');}
   }
 }


### PR DESCRIPTION
Picks up one of the small fix candidates from #2572: when the Remove click in Settings → Providers hits a 403 (CSRF cookie/header drift, classic stale-tab signature), show a recovery-shaped toast instead of the raw 'Cross-origin request rejected' string. The raw string reads like a reverse-proxy deployment bug and leaves the user nowhere to go.

This is the JS-only sub-fix the issue calls out as not needing to be combined with the deeper investigation; it doesn't change the server response, doesn't paper over the origin-mismatch deployment case (any non-403 error still falls through to the existing 'Error: …' toast carrying the server message), and doesn't touch the CSRF code itself.

Verified locally by patching `_check_csrf` to return False, clicking Remove on a provider card, and confirming the toast now reads 'Session expired. Reload the page and try again.' Reverted the patch and confirmed the success path still removes the key and refreshes the dropdown caches.

Refs #2572