### PR TITLE
docs(docker): give the cron 'Gateway not configured' banner a real fix link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Tasks panel "Gateway not configured" banner now includes a direct link to the new `docs/docker.md#scheduled-jobs-require-a-gateway-daemon` section that walks through running the gateway container so scheduled cron jobs actually tick. (Refs #2785)
+
 ## [v0.51.137] — 2026-05-25 — Release DI (stage-batch19 — 6-PR medium-risk batch)
 
 ### Added

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -51,16 +51,14 @@ them manually from the Tasks panel. In Docker, scheduled jobs require the Hermes
 to tick while you are away. If System Settings shows `Gateway not configured`,
 use `docker-compose.two-container.yml`,
 `docker-compose.three-container.yml`, or run `hermes gateway` separately before
-relying on offline scheduled runs. See [Scheduled jobs require a gateway daemon](#scheduled-jobs-require-a-gateway-daemon) below for the full background and verification steps.
+relying on offline scheduled runs. See [Scheduled jobs and the gateway daemon](#scheduled-jobs-and-the-gateway-daemon) below for the full background and verification steps.
 
 For troubleshooting, reinstall, or onboarding reproduction trials, do not mount
 your real `~/.hermes` unless you intentionally want to test real state. Use an
 isolated Hermes home and follow
 [`docs/onboarding-agent-checklist.md`](onboarding-agent-checklist.md) instead.
 
-## What goes wrong (and how to fix it)
-
-### Scheduled jobs require a gateway daemon
+## Scheduled jobs and the gateway daemon
 
 **Symptom**: Cron jobs created in the Tasks panel never fire. System Settings shows the orange "Gateway not configured" pill, and the Tasks panel shows the same banner above the job list.
 
@@ -75,13 +73,17 @@ docker compose -f docker-compose.two-container.yml up -d
 
 The three-container layout adds the dashboard but is otherwise the same shape. If you must stay single-container, you can run `hermes gateway` inside the container as a long-lived background process, but the compose split is sturdier.
 
-**Verify**: Once the gateway is up, the System Settings pill should turn green and the Tasks banner disappear. From inside the gateway container:
+**Verify**: Once the gateway is up, the System Settings pill should turn green and the Tasks banner disappear. From the host:
 
 ```bash
-docker exec -it <gateway-container> hermes gateway status
+docker compose -f docker-compose.two-container.yml exec hermes-agent hermes gateway status
 ```
 
+If the service name differs in your compose file, `docker compose -f docker-compose.two-container.yml ps` lists the running services.
+
 Refs #2785.
+
+## What goes wrong (and how to fix it)
 
 ### 1. "Permission denied" at startup
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -51,7 +51,7 @@ them manually from the Tasks panel. In Docker, scheduled jobs require the Hermes
 to tick while you are away. If System Settings shows `Gateway not configured`,
 use `docker-compose.two-container.yml`,
 `docker-compose.three-container.yml`, or run `hermes gateway` separately before
-relying on offline scheduled runs.
+relying on offline scheduled runs. See [Scheduled jobs require a gateway daemon](#scheduled-jobs-require-a-gateway-daemon) below for the full background and verification steps.
 
 For troubleshooting, reinstall, or onboarding reproduction trials, do not mount
 your real `~/.hermes` unless you intentionally want to test real state. Use an
@@ -59,6 +59,29 @@ isolated Hermes home and follow
 [`docs/onboarding-agent-checklist.md`](onboarding-agent-checklist.md) instead.
 
 ## What goes wrong (and how to fix it)
+
+### Scheduled jobs require a gateway daemon
+
+**Symptom**: Cron jobs created in the Tasks panel never fire. System Settings shows the orange "Gateway not configured" pill, and the Tasks panel shows the same banner above the job list.
+
+**Cause**: Scheduled cron ticks are not driven by the WebUI itself. The gateway daemon ticks the scheduler every 60 seconds; without one running, scheduled jobs sit idle. "Run now" / "Trigger" buttons still work because the WebUI handles those in-process.
+
+**Fix**: Run a gateway container alongside the WebUI. The two-container compose file is the recommended path:
+
+```bash
+cp .env.docker.example .env
+docker compose -f docker-compose.two-container.yml up -d
+```
+
+The three-container layout adds the dashboard but is otherwise the same shape. If you must stay single-container, you can run `hermes gateway` inside the container as a long-lived background process, but the compose split is sturdier.
+
+**Verify**: Once the gateway is up, the System Settings pill should turn green and the Tasks banner disappear. From inside the gateway container:
+
+```bash
+docker exec -it <gateway-container> hermes gateway status
+```
+
+Refs #2785.
 
 ### 1. "Permission denied" at startup
 

--- a/static/panels.js
+++ b/static/panels.js
@@ -437,9 +437,14 @@ function _cronGatewayNoticeHtml(status) {
   const body = notConfigured
     ? 'In Hermes WebUI, scheduled jobs require the Hermes gateway daemon. If this is a single-container Docker install, jobs can be created and run manually here, but scheduled ticks need a gateway container or `hermes gateway` running outside the WebUI.'
     : 'In Hermes WebUI, scheduled jobs require the Hermes gateway daemon to be running. Start the gateway container or `hermes gateway` before relying on offline scheduled runs.';
+  const docsHref = 'https://github.com/nesquena/hermes-webui/blob/master/docs/docker.md#scheduled-jobs-require-a-gateway-daemon';
+  const helpLink = notConfigured
+    ? `<p><a href="${docsHref}" target="_blank" rel="noopener">How to enable scheduled jobs in Docker ↗</a></p>`
+    : '';
   return `
     <div class="detail-alert-title">${esc(title)}</div>
     <p>${esc(body)}</p>
+    ${helpLink}
   `;
 }
 

--- a/static/panels.js
+++ b/static/panels.js
@@ -437,7 +437,7 @@ function _cronGatewayNoticeHtml(status) {
   const body = notConfigured
     ? 'In Hermes WebUI, scheduled jobs require the Hermes gateway daemon. If this is a single-container Docker install, jobs can be created and run manually here, but scheduled ticks need a gateway container or `hermes gateway` running outside the WebUI.'
     : 'In Hermes WebUI, scheduled jobs require the Hermes gateway daemon to be running. Start the gateway container or `hermes gateway` before relying on offline scheduled runs.';
-  const docsHref = 'https://github.com/nesquena/hermes-webui/blob/master/docs/docker.md#scheduled-jobs-require-a-gateway-daemon';
+  const docsHref = 'https://github.com/nesquena/hermes-webui/blob/master/docs/docker.md#scheduled-jobs-and-the-gateway-daemon';
   const helpLink = notConfigured
     ? `<p><a href="${docsHref}" target="_blank" rel="noopener">How to enable scheduled jobs in Docker ↗</a></p>`
     : '';


### PR DESCRIPTION
Picks up the docs-PR follow-up the maintainer suggested in #2785: single-container Docker installs surface a 'Gateway not configured' banner in the Tasks panel but don't tell the user where to go next.

Two small changes:

1. New 'Scheduled jobs require a gateway daemon' section in `docs/docker.md` under 'What goes wrong' with the two-container compose command and a verify step. The existing short blurb higher up now cross-links to it, so both entry points land on the same fix.
2. `loadCronGatewayNotice` in `static/panels.js` appends a 'How to enable scheduled jobs in Docker ↗' link to the banner when the gateway is unconfigured. Banner text itself is unchanged; the link is hidden in the 'configured but not running' branch where the message is different and the next step is just to start the daemon.

Verified locally by running the WebUI with no gateway, opening Tasks, and confirming the new link appears and lands on the new docs section. Started `hermes gateway` and confirmed the banner goes away.

Refs #2785