### PR TITLE
feat(model-picker): arrow-key navigation and Enter-to-select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Added
 
-- Arrow-key navigation in the model picker. Up/Down moves the highlight through the visible (and filter-narrowed) model rows, Enter selects the highlighted row, and Escape still closes the dropdown.
+- Arrow-key navigation in the model picker. Up/Down moves the highlight through the visible (and filter-narrowed) model rows, Enter selects the highlighted row, and Escape still closes the dropdown. Typing into the filter box rebuilds the row list and clears the highlight by design, so Enter after a fresh keystroke picks the first match. When the keyboard cursor lands on the currently-selected model, the `.active` accent background stays visible under the highlight outline.
 
 ## [v0.51.137] — 2026-05-25 — Release DI (stage-batch19 — 6-PR medium-risk batch)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Arrow-key navigation in the model picker. Up/Down moves the highlight through the visible (and filter-narrowed) model rows, Enter selects the highlighted row, and Escape still closes the dropdown.
+
 ## [v0.51.137] — 2026-05-25 — Release DI (stage-batch19 — 6-PR medium-risk batch)
 
 ### Added

--- a/static/style.css
+++ b/static/style.css
@@ -2038,6 +2038,7 @@
 .model-opt:hover{background:rgba(255,255,255,.07);}
 .model-opt.is-highlighted{background:rgba(255,255,255,.1);outline:1px solid var(--border2);outline-offset:-1px;}
 .model-opt.active{background:var(--accent-bg);}
+.model-opt.active.is-highlighted{background:var(--accent-bg);outline:1px solid var(--accent);outline-offset:-1px;}
 .model-opt-top{display:flex;align-items:center;gap:8px;flex-wrap:wrap;width:100%;}
 .model-opt-name{display:block;font-size:13px;color:var(--text);font-weight:500;line-height:1.25;}
 .model-opt-badge{display:inline-flex;align-items:center;justify-content:center;padding:2px 7px;border-radius:999px;font-size:10px;font-weight:700;letter-spacing:.02em;text-transform:uppercase;border:1px solid transparent;}

--- a/static/style.css
+++ b/static/style.css
@@ -2036,6 +2036,7 @@
 .model-group{padding:8px 14px 4px;font-size:10px;font-weight:700;letter-spacing:.04em;color:var(--muted);text-transform:uppercase;border-top:1px solid var(--border2);margin-top:2px;}
 .model-opt{padding:10px 14px;cursor:pointer;transition:background .12s;display:flex;flex-direction:column;gap:3px;align-items:flex-start;}
 .model-opt:hover{background:rgba(255,255,255,.07);}
+.model-opt.is-highlighted{background:rgba(255,255,255,.1);outline:1px solid var(--border2);outline-offset:-1px;}
 .model-opt.active{background:var(--accent-bg);}
 .model-opt-top{display:flex;align-items:center;gap:8px;flex-wrap:wrap;width:100%;}
 .model-opt-name{display:block;font-size:13px;color:var(--text);font-weight:500;line-height:1.25;}

--- a/static/ui.js
+++ b/static/ui.js
@@ -1535,7 +1535,31 @@ function renderModelDropdown(){
   };
   // Event handlers for search input
   _si.addEventListener('input',()=>_filterModels(_si.value));
-  _si.addEventListener('keydown',e=>{if(e.key==='Enter') {e.preventDefault();}if(e.key==='Escape') {closeModelDropdown();}});
+  // Keyboard navigation through filtered model rows (#2791).
+  const _visibleModelRows=()=>Array.from(dd.querySelectorAll('.model-opt'));
+  const _activeRowIndex=(rows)=>rows.findIndex(r=>r.classList.contains('is-highlighted'));
+  const _highlightRow=(rows,idx)=>{
+    for(const r of rows) r.classList.remove('is-highlighted');
+    if(idx<0||idx>=rows.length) return;
+    const row=rows[idx];
+    row.classList.add('is-highlighted');
+    if(typeof row.scrollIntoView==='function') row.scrollIntoView({block:'nearest'});
+  };
+  _si.addEventListener('keydown',e=>{
+    if(e.key==='Escape'){closeModelDropdown();return;}
+    if(e.key==='ArrowDown'||e.key==='ArrowUp'||e.key==='Enter'){
+      const rows=_visibleModelRows();
+      if(!rows.length){if(e.key==='Enter') e.preventDefault();return;}
+      const cur=_activeRowIndex(rows);
+      if(e.key==='ArrowDown'){e.preventDefault();_highlightRow(rows,cur<0?0:Math.min(rows.length-1,cur+1));return;}
+      if(e.key==='ArrowUp'){e.preventDefault();_highlightRow(rows,cur<=0?rows.length-1:cur-1);return;}
+      if(e.key==='Enter'){
+        e.preventDefault();
+        const pick=cur>=0?rows[cur]:rows[0];
+        if(pick) pick.click();
+      }
+    }
+  });
   _si.addEventListener('click',e=>e.stopPropagation());
   // Event handlers for clear button
   _sc.onclick=()=>{ _si.value=''; _filterModels(''); _si.focus(); };

--- a/tests/test_2791_model_picker_keyboard_nav.py
+++ b/tests/test_2791_model_picker_keyboard_nav.py
@@ -1,0 +1,33 @@
+"""Regression check for #2791 — keyboard navigation in the model picker.
+
+The picker is a click-driven dropdown; users asked for arrow-key navigation
+and Enter-to-select on the existing search input. Verified at the source
+level so this stays fast.
+"""
+from pathlib import Path
+
+REPO = Path(__file__).parent.parent
+UI_JS = (REPO / "static" / "ui.js").read_text(encoding="utf-8")
+STYLE_CSS = (REPO / "static" / "style.css").read_text(encoding="utf-8")
+
+
+def test_arrow_keys_wired_on_search_input():
+    # ArrowDown / ArrowUp / Enter all handled in one keydown listener on _si.
+    assert "ArrowDown" in UI_JS
+    assert "ArrowUp" in UI_JS
+    assert "is-highlighted" in UI_JS
+
+
+def test_highlight_class_has_style():
+    assert ".model-opt.is-highlighted" in STYLE_CSS
+
+
+def test_escape_still_closes_dropdown():
+    # Existing Escape-to-close behavior must not regress.
+    assert "if(e.key==='Escape'){closeModelDropdown();return;}" in UI_JS
+
+
+def test_enter_picks_highlighted_row():
+    # Enter should call .click() on the highlighted (or first) row.
+    snippet = UI_JS[UI_JS.index("ArrowDown"):]
+    assert "pick.click()" in snippet


### PR DESCRIPTION
The model picker has a working search input but no keyboard navigation. After you type a filter you still have to take your hand off the keyboard to click the row you want, which is the part of #2791 that bites the most in day-to-day use.

This wires three handlers onto the existing search input:

- `ArrowDown` / `ArrowUp` move a `.is-highlighted` class through the visible (and filter-narrowed) `.model-opt` rows, with wraparound at the ends.
- `Enter` clicks the highlighted row (or the first row if nothing is highlighted yet, so typing a filter and immediately hitting Enter just picks the top match).
- `Escape` keeps its existing close-dropdown behavior.

Highlight gets a small CSS rule that reuses the existing border-color and brightens the row a bit more than `:hover` so the selection is obvious without redoing the dropdown styling.

The maintainer's review on #2791 already broke the issue into three slices (fuzzy scorer, match highlighting, keyboard nav) and called this one out as the clean keyboard-only change. Fuzzy matching and `<mark>` highlighting are intentionally left for follow-ups — this PR is just the nav.

## Verified

- `python -m pytest tests/test_2791_model_picker_keyboard_nav.py` — 4 passed.
- `node --check static/ui.js` — clean.
- Manual: opened picker, typed "son", arrowed down/up through filtered rows, Enter selected. Escape still closes.

Closes #2791


## Sanity check: not inside a `<form>`

Confirmed in source: `static/index.html` contains no `<form>` element at all (grep returns no matches). `#composerModelDropdown` lives under `#composer` as a plain `<div>` with no form ancestor, so the `preventDefault()` on empty-list Enter is defensive only and won't be exercised in practice.

## Review-feedback fixes (7bb7e30d)

- `.model-opt.active.is-highlighted` rule added so the selection accent (`--accent-bg`) survives when the keyboard cursor lands on the currently-selected row, with `outline: 1px solid var(--accent)` doing the cursor indication on its own.
- CHANGELOG entry now calls out that typing into the filter resets the highlight by design (DOM is rebuilt, retyping is a fresh choice).
