### PR TITLE
feat(ui): keyboard navigation (arrows + enter) in model picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Model picker dropdown now supports ArrowDown / ArrowUp / Enter for keyboard navigation through the filtered results. Escape still closes the dropdown. The currently navigated row receives a subtle highlight and is scrolled into view as it moves. (#2791)
+
 ## [v0.51.137] — 2026-05-25 — Release DI (stage-batch19 — 6-PR medium-risk batch)
 
 ### Added

--- a/static/style.css
+++ b/static/style.css
@@ -2036,6 +2036,7 @@
 .model-group{padding:8px 14px 4px;font-size:10px;font-weight:700;letter-spacing:.04em;color:var(--muted);text-transform:uppercase;border-top:1px solid var(--border2);margin-top:2px;}
 .model-opt{padding:10px 14px;cursor:pointer;transition:background .12s;display:flex;flex-direction:column;gap:3px;align-items:flex-start;}
 .model-opt:hover{background:rgba(255,255,255,.07);}
+.model-opt.is-highlighted{background:rgba(255,255,255,.10);outline:1px solid var(--border2);outline-offset:-1px;}
 .model-opt.active{background:var(--accent-bg);}
 .model-opt-top{display:flex;align-items:center;gap:8px;flex-wrap:wrap;width:100%;}
 .model-opt-name{display:block;font-size:13px;color:var(--text);font-weight:500;line-height:1.25;}

--- a/static/ui.js
+++ b/static/ui.js
@@ -1535,7 +1535,32 @@ function renderModelDropdown(){
   };
   // Event handlers for search input
   _si.addEventListener('input',()=>_filterModels(_si.value));
-  _si.addEventListener('keydown',e=>{if(e.key==='Enter') {e.preventDefault();}if(e.key==='Escape') {closeModelDropdown();}});
+  // ArrowDown / ArrowUp / Enter keyboard navigation through the filtered options (#2791).
+  // Walks the actual rendered `.model-opt` rows so it works for both the Configured
+  // section and the provider-grouped list, and stays correct as the user types.
+  _si.addEventListener('keydown',e=>{
+    if(e.key==='Escape'){closeModelDropdown();return;}
+    if(e.key!=='ArrowDown'&&e.key!=='ArrowUp'&&e.key!=='Enter') return;
+    const rows=Array.from(dd.querySelectorAll('.model-opt'));
+    if(!rows.length) return;
+    let idx=rows.findIndex(r=>r.classList.contains('is-highlighted'));
+    if(e.key==='Enter'){
+      e.preventDefault();
+      if(idx<0) idx=0;
+      const row=rows[idx];
+      if(row&&typeof row.onclick==='function') row.onclick();
+      return;
+    }
+    e.preventDefault();
+    if(e.key==='ArrowDown') idx=idx<0?0:Math.min(rows.length-1,idx+1);
+    else /* ArrowUp */      idx=idx<=0?rows.length-1:idx-1;
+    rows.forEach(r=>r.classList.remove('is-highlighted'));
+    const target=rows[idx];
+    if(target){
+      target.classList.add('is-highlighted');
+      if(typeof target.scrollIntoView==='function') target.scrollIntoView({block:'nearest'});
+    }
+  });
   _si.addEventListener('click',e=>e.stopPropagation());
   // Event handlers for clear button
   _sc.onclick=()=>{ _si.value=''; _filterModels(''); _si.focus(); };

--- a/tests/test_issue2791_model_picker_keyboard.py
+++ b/tests/test_issue2791_model_picker_keyboard.py
@@ -1,0 +1,28 @@
+"""Regression tests for issue #2791: keyboard navigation in the model picker."""
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+
+def test_model_picker_has_arrow_and_enter_handlers():
+    src = (REPO / "static/ui.js").read_text(encoding="utf-8")
+    # The keydown handler must cover ArrowDown, ArrowUp, Enter, and Escape.
+    # Locate the search-input handler block by anchor and assert each branch lives there.
+    anchor = src.index("_si.addEventListener('input',()=>_filterModels(_si.value));")
+    block = src[anchor:anchor + 2200]
+    assert "'ArrowDown'" in block, "missing ArrowDown branch"
+    assert "'ArrowUp'" in block, "missing ArrowUp branch"
+    assert "'Enter'" in block, "missing Enter branch"
+    assert "'Escape'" in block, "missing Escape branch"
+    assert "is-highlighted" in block
+    # Enter should invoke the highlighted row's onclick.
+    assert "row.onclick" in block
+    # And the handler must scroll the highlighted row into view.
+    assert "scrollIntoView" in block
+
+
+def test_highlighted_style_present():
+    src = (REPO / "static/style.css").read_text(encoding="utf-8")
+    assert ".model-opt.is-highlighted" in src, (
+        "expected a CSS rule for the keyboard-highlighted model row"
+    )


### PR DESCRIPTION
As @nesquena-hermes pointed out in #2791, substring search and `?prefix/` filtering already exist, but three things from the request are genuinely missing: keyboard navigation, fuzzy matching, and match highlighting. This PR ships the smallest one — keyboard navigation — so it can land without coupling to the fuzzy-scorer / highlight work.

## What this does

In `static/ui.js`, the search input's `keydown` handler used to swallow Enter and close on Escape. It now also handles:

- **ArrowDown / ArrowUp** — moves a `.is-highlighted` class through the rendered `.model-opt` rows with wrap-around, and calls `scrollIntoView({block:'nearest'})` so the focused row stays visible.
- **Enter** — invokes the highlighted row's existing `onclick`. If nothing is highlighted yet, Enter picks the first row, which matches the "type-a-substring-then-hit-enter" muscle memory people expect from VS Code's command palette.
- **Escape** — unchanged, closes the dropdown.

It walks the live `.model-opt` rows (not a separate cached array), so it stays correct across the Configured section and the provider-grouped list, and re-renders as the user types.

`static/style.css` gets a subtle `.model-opt.is-highlighted` rule (a slightly stronger background than `:hover` plus a 1px inset outline) that doesn't collide with the existing `.active` selected-row style.

## Verification

- `pytest tests/test_issue2791_model_picker_keyboard.py` — 2 passed (asserts all four key branches exist in the handler and that the CSS rule is defined).
- `node --check static/ui.js`.
- Manually walking the dropdown with arrows reaches both the Configured section and provider-grouped rows; Enter activates the highlighted model.

The remaining two pieces from the maintainer's suggested PR scope (fuzzy scorer + matched-character highlighting) are independent and can land separately.

Closes #2791
