### PR TITLE
docs: require contract change routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Changed
 
-- Contributor guidance now requires explicit `Contract Routing` for contract-affecting PRs and `Contract Change` when a PR intentionally changes an existing product, runtime, or review contract. Contract tests must move with the corresponding docs instead of silently redefining behavior by themselves.
+- Contributor guidance now requires explicit `Contract Routing` for contract-affecting PRs and `Contract Change` when a PR intentionally changes an existing product, runtime, or review contract. Contract tests must move with the corresponding docs instead of silently redefining behavior by themselves, with the current static coverage documented as advisory rather than a GitHub policy gate.
 
 ## [v0.51.137] — 2026-05-25 — Release DI (stage-batch19 — 6-PR medium-risk batch)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Contributor guidance now requires explicit `Contract Routing` for contract-affecting PRs and `Contract Change` when a PR intentionally changes an existing product, runtime, or review contract. Contract tests must move with the corresponding docs instead of silently redefining behavior by themselves.
+
 ## [v0.51.137] — 2026-05-25 — Release DI (stage-batch19 — 6-PR medium-risk batch)
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,21 @@ Use those documents as review guardrails: keep the change scoped, preserve the
 no-build-step architecture, update docs/changelog when behavior changes, include
 UI evidence for UI changes, and add tests for behavior changes where practical.
 
+### Contract-affecting PRs
+
+A contract-affecting PR is any change that updates a public contract document,
+an RFC, a contributor guide, a product-semantics test, or behavior that those
+documents already describe. These PRs need an explicit `Contract Routing` section
+in the PR body that names the touched contract family and the evidence used.
+
+If the PR intentionally changes an existing contract, add a `Contract Change`
+section that states the old rule, the new rule, and why the change is justified.
+Do not silently redefine product behavior by changing tests alone; update the
+corresponding docs in the same PR.
+
+A release batch should call out included contract-affecting PRs separately
+from ordinary fixes, even when the code diff is small and CI is green.
+
 ## Two Paths to a Strong Pull Request
 
 ### Path 1: Small, Focused Changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,9 @@ A contract-affecting PR is any change that updates a public contract document,
 an RFC, a contributor guide, a product-semantics test, or behavior that those
 documents already describe. These PRs need an explicit `Contract Routing` section
 in the PR body that names the touched contract family and the evidence used.
+See [`docs/CONTRACTS.md#contract-routing`](docs/CONTRACTS.md#contract-routing)
+for the short routing shape and [`docs/CONTRACTS.md#contract-changes`](docs/CONTRACTS.md#contract-changes)
+for intentional contract changes.
 
 If the PR intentionally changes an existing contract, add a `Contract Change`
 section that states the old rule, the new rule, and why the change is justified.

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -102,6 +102,26 @@ Evidence needed before claiming done:
 For small, obvious fixes, keep this short. The goal is to avoid routing mistakes,
 not to create process overhead.
 
+## Contract changes
+
+Changing contract documents, RFC guidance, or contract tests changes review
+expectations for future contributors. A PR that intentionally changes an
+existing contract should include a `Contract Change` section in its PR body with:
+
+- the previous contract,
+- the new contract,
+- the affected docs and tests,
+- the compatibility or migration reason.
+
+Contract tests and corresponding docs must move together. Tests that encode
+product semantics must not silently redefine the contract by asserting the
+opposite behavior without updating the public docs and naming the change in the
+PR body.
+
+Release batches should list included contract-affecting PRs explicitly so
+reviewers can distinguish ordinary green-CI fixes from changes that update the
+project's product or runtime guardrails.
+
 ## PR preparation checklist
 
 Before opening or updating a PR, verify `CONTRIBUTING.md` against the actual PR
@@ -118,6 +138,8 @@ Required checks:
 - UI/UX changes include before/after evidence and responsive-state coverage.
 - Runtime/streaming changes name the state layer or invariant being changed and
   list the regression or manual invariant check.
+- Contract-affecting PRs include `Contract Routing`; intentional contract
+  changes also include `Contract Change`.
 - Onboarding/setup validation used isolated `HERMES_HOME` and
   `HERMES_WEBUI_STATE_DIR`, unless the human operator explicitly requested real
   state.

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -118,6 +118,13 @@ product semantics must not silently redefine the contract by asserting the
 opposite behavior without updating the public docs and naming the change in the
 PR body.
 
+The static tests for this guidance are advisory coverage. They pin contributor
+wording so the rule stays visible. This advisory coverage is not an automated
+policy gate; static coverage is not an automated policy gate and does not enforce
+PR-body content on GitHub. A future release-time or CI check could
+surface contract-affecting diffs whose PR body lacks `Contract Routing`, but this
+document only defines the review expectation.
+
 Release batches should list included contract-affecting PRs explicitly so
 reviewers can distinguish ordinary green-CI fixes from changes that update the
 project's product or runtime guardrails.

--- a/tests/test_contract_review_gate.py
+++ b/tests/test_contract_review_gate.py
@@ -32,3 +32,18 @@ def test_contracts_requires_docs_tests_and_pr_body_to_move_together():
 
     missing = [term for term in required_terms if term not in text]
     assert missing == []
+
+
+def test_contract_guidance_names_static_coverage_as_advisory_not_enforcement():
+    text = CONTRACTS.read_text(encoding="utf-8")
+
+    required_terms = [
+        "advisory",
+        "not an automated policy gate",
+        "does not enforce",
+        "PR-body content",
+        "release-time",
+    ]
+
+    missing = [term for term in required_terms if term not in text]
+    assert missing == []

--- a/tests/test_contract_review_gate.py
+++ b/tests/test_contract_review_gate.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CONTRIBUTING = ROOT / "CONTRIBUTING.md"
+CONTRACTS = ROOT / "docs" / "CONTRACTS.md"
+
+
+def test_contributing_requires_contract_routing_for_contract_affecting_prs():
+    text = CONTRIBUTING.read_text(encoding="utf-8")
+
+    required_terms = [
+        "contract-affecting PR",
+        "Contract Routing",
+        "Contract Change",
+        "release batch",
+    ]
+
+    missing = [term for term in required_terms if term not in text]
+    assert missing == []
+
+
+def test_contracts_requires_docs_tests_and_pr_body_to_move_together():
+    text = CONTRACTS.read_text(encoding="utf-8")
+
+    required_terms = [
+        "Contract Change",
+        "contract tests",
+        "corresponding docs",
+        "must not silently redefine",
+    ]
+
+    missing = [term for term in required_terms if term not in text]
+    assert missing == []


### PR DESCRIPTION
## Thinking Path

- Hermes WebUI uses contributor-facing contracts to keep product, runtime, and review expectations stable across many small PRs.
- A PR can still change product semantics by editing behavior or contract tests without explicitly saying it is changing a contract.
- Green CI is not enough when a PR changes the rule that future CI will enforce.
- This PR makes contract-affecting changes explicit in contributor guidance and pins the new process rule with a small static test.

Fixes #2959.

## Contract Routing

Task type: contributor-process guardrail
Touched areas:
- `CONTRIBUTING.md`
- `docs/CONTRACTS.md`
- `tests/test_contract_review_gate.py`
- `CHANGELOG.md`
Relevant public docs:
- `AGENTS.md`
- `CONTRIBUTING.md`
- `docs/CONTRACTS.md`
Scope boundaries:
- Adds review guidance and static coverage only.
- Does not add a GitHub Actions policy engine or PR template.
Evidence needed before claiming done:
- Static regression test proves the guidance names `Contract Routing`, `Contract Change`, contract tests, corresponding docs, and release-batch callouts.

## What Changed

- Added a `Contract-affecting PRs` section to `CONTRIBUTING.md`.
- Added a `Contract changes` section to `docs/CONTRACTS.md`.
- Updated the PR preparation checklist so contract-affecting PRs require `Contract Routing`, and intentional contract changes require `Contract Change`.
- Added `tests/test_contract_review_gate.py` to pin the process terms.
- Added an Unreleased changelog entry.

## Why It Matters

Contracts should prevent accidental product-direction changes, not just document them after the fact. When a PR changes product semantics or the tests that encode them, reviewers need an explicit signal that the PR is changing a contract rather than merely fixing a local bug.

## Verification

- RED before docs update:
  - `python3 -m pytest tests/test_contract_review_gate.py -q` -> failed on missing `Contract Routing`, `Contract Change`, `contract tests`, corresponding-docs language, and release-batch callout.
- GREEN after docs update:
  - `python3 -m pytest tests/test_contract_review_gate.py tests/test_canonical_session_resolution_rfc.py -q` -> `4 passed`
  - `git diff --check`

## Risks / Follow-ups

- This is guidance plus static coverage, not an automated GitHub policy gate. A stricter follow-up could add a PR-template or CI check if maintainers want enforcement beyond docs/tests.
- The rule is intentionally narrow: it targets contract-affecting PRs, not every small bugfix.

## Model Used

OpenAI GPT-5 via Codex app agent. Tool use: local repo inspection, GitHub CLI, pytest, git worktree, and git push/PR creation.
