### PR TITLE
Add opt-in Cost Protection pause for suspicious long-running sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Optional cost-protection pause for chat runs can now be enabled from `config.yaml` with `cost_protection.enabled: true` or `webui.cost_protection.enabled: true`. When enabled, WebUI pauses at a safe agent step boundary if repeated compression failures, fallback churn, repeated same-pattern tool failures, or very high model-call counts match configured risk thresholds, then shows a "Run paused for review" message instead of continuing to spend tokens silently. The feature is disabled by default, and thresholds can be tuned under the same config block.
+
 ## [v0.51.141] — 2026-05-26 — Release DM (stage-batch23 — 4-PR second hold-bucket pass)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Added
 
-- Optional cost-protection pause for chat runs can now be enabled from `config.yaml` with `cost_protection.enabled: true` or `webui.cost_protection.enabled: true`. When enabled, WebUI pauses at a safe agent step boundary if repeated compression failures, fallback churn, repeated same-pattern tool failures, or very high model-call counts match configured risk thresholds, then shows a "Run paused for review" message instead of continuing to spend tokens silently. The feature is disabled by default, and thresholds can be tuned under the same config block.
+- Optional Cost Protection pause for chat runs can now be enabled with `./ctl.sh cost-protection enable`. When enabled, WebUI pauses future chat runs at a safe agent step boundary if repeated compression failures, fallback churn, repeated same-pattern tool failures, or very high model-call counts match runaway-cost signals, then shows a "Run paused for review" message instead of continuing to spend tokens silently. The feature is disabled by default, writes WebUI-owned `settings.json` state, and does not mutate Hermes Agent `config.yaml`.
 
 ## [v0.51.141] — 2026-05-26 — Release DM (stage-batch23 — 4-PR second hold-bucket pass)
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ For self-hosted VM or homelab installs, `ctl.sh` wraps the common daemon lifecyc
 ```bash
 ./ctl.sh start              # background daemon, PID at ~/.hermes/webui.pid
 ./ctl.sh status             # PID, uptime, bound host/port, log path, /health
+./ctl.sh cost-protection status
 ./ctl.sh logs --lines 100   # tail ~/.hermes/webui.log
 ./ctl.sh restart
 ./ctl.sh stop
@@ -532,6 +533,10 @@ Production data and real cron jobs are never touched. Current snapshot:
 - Unsaved changes guard -- discard/save prompt when closing with unpersisted changes
 - Cron completion alerts -- toast notifications and unread badge on Tasks tab
 - Background agent error alerts -- banner when a non-active session encounters an error
+- Optional Cost Protection pause -- disabled by default; use
+  `./ctl.sh cost-protection enable` to pause future WebUI chat runs at a safe
+  agent step boundary when runaway-cost signals are reached. The command writes
+  WebUI-owned `settings.json` state, not Hermes Agent `config.yaml`.
 
 ### Slash commands
 - Type `/` in the composer for autocomplete dropdown

--- a/api/config.py
+++ b/api/config.py
@@ -4752,6 +4752,7 @@ _SETTINGS_DEFAULTS = {
     "check_for_updates": True,  # check if webui/agent repos are behind upstream
     "ignore_agent_updates": False,  # keep WebUI update notices but suppress Agent update checks
     "whats_new_summary_enabled": False,  # show an LLM-written What's New summary before diff links
+    "cost_protection_enabled": False,  # enable WebUI-owned runaway-cost pause guards for future chat runs
     "theme": "dark",  # light | dark | system
     "skin": "default",  # accent color skin: default | ares | mono | slate | poseidon | sisyphus | charizard | sienna | catppuccin | nous
     "font_size": "default",  # small | default | large | xlarge
@@ -4912,6 +4913,7 @@ _SETTINGS_BOOL_KEYS = {
     "check_for_updates",
     "ignore_agent_updates",
     "whats_new_summary_enabled",
+    "cost_protection_enabled",
     "sound_enabled",
     "rtl",
     "notifications_enabled",

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -190,8 +190,10 @@ class CostProtectionGuard:
         self.fallback_events = 0
         self.tool_errors = 0
         self.tool_calls = 0
+        self.repeated_tool_error_count = 0
         self.paused_payload = None
         self._counted_tool_key_counts = {}
+        self._tool_error_key_counts = {}
         self._seen_prev_tool_key_counts = {}
 
     def record_status(self, kind: str, message: str) -> None:
@@ -236,12 +238,16 @@ class CostProtectionGuard:
             result=result,
         )
         self._counted_tool_key_counts[key] = self._counted_tool_key_counts.get(key, 0) + 1
-        self._record_tool_count(is_error=is_error, result=result)
+        self._record_tool_count(key=key, is_error=is_error, result=result)
 
-    def _record_tool_count(self, *, is_error: bool = False, result=None) -> None:
+    def _record_tool_count(self, *, key=None, is_error: bool = False, result=None) -> None:
         self.tool_calls += 1
         if is_error or self._result_looks_error(result):
             self.tool_errors += 1
+            if key is not None:
+                count = self._tool_error_key_counts.get(key, 0) + 1
+                self._tool_error_key_counts[key] = count
+                self.repeated_tool_error_count = max(self.repeated_tool_error_count, count)
 
     def record_step(self, api_call_count: int, prev_tools=None):
         self.api_call_count = max(self.api_call_count, int(api_call_count or 0))
@@ -266,6 +272,7 @@ class CostProtectionGuard:
                         self._counted_tool_key_counts[key] = counted - 1
                     continue
                 self._record_tool_count(
+                    key=key,
                     is_error=bool(tool.get("is_error", False)),
                     result=tool.get("result"),
                 )
@@ -285,7 +292,7 @@ class CostProtectionGuard:
             reason = "repeated_context_compression"
         elif self.fallback_events >= self.fallback_threshold:
             reason = "repeated_provider_fallbacks"
-        elif self.tool_errors >= self.tool_error_threshold:
+        elif self.repeated_tool_error_count >= self.tool_error_threshold:
             reason = "repeated_tool_errors"
         elif self.api_call_count >= self.api_call_threshold:
             reason = "high_model_call_count"
@@ -308,6 +315,7 @@ class CostProtectionGuard:
                 "fallback_events": self.fallback_events,
                 "tool_calls": self.tool_calls,
                 "tool_errors": self.tool_errors,
+                "repeated_tool_error_count": self.repeated_tool_error_count,
             },
         }
         return self.paused_payload

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -124,25 +124,20 @@ def _positive_int(value, fallback: int) -> int:
     return parsed if parsed > 0 else fallback
 
 
-def _cost_protection_config() -> dict:
+def _cost_protection_settings() -> dict:
     try:
-        cfg_data = get_config()
+        settings = load_settings()
     except Exception:
-        cfg_data = {}
-    if not isinstance(cfg_data, dict):
-        return {}
-    direct = cfg_data.get("cost_protection")
-    if isinstance(direct, dict):
-        return direct
-    webui = cfg_data.get("webui")
-    nested = webui.get("cost_protection") if isinstance(webui, dict) else None
-    return nested if isinstance(nested, dict) else {}
+        settings = {}
+    return settings if isinstance(settings, dict) else {}
 
 
-def _cost_protection_guard_from_config(*, session_id: str, stream_id: str):
-    cfg_data = _cost_protection_config()
+def _cost_protection_guard_from_settings(*, session_id: str, stream_id: str):
+    settings = _cost_protection_settings()
+    if not settings.get("cost_protection_enabled", False):
+        return None
     thresholds = {
-        key: _positive_int(cfg_data.get(key), fallback)
+        key: fallback
         for key, fallback in _DEFAULT_COST_PROTECTION_THRESHOLDS.items()
     }
     return CostProtectionGuard(session_id=session_id, stream_id=stream_id, **thresholds)
@@ -3917,7 +3912,7 @@ def _run_agent_streaming(
         except Exception:
             logger.debug("Failed to put event to queue")
 
-    _cost_guard = _cost_protection_guard_from_config(session_id=session_id, stream_id=stream_id)
+    _cost_guard = _cost_protection_guard_from_settings(session_id=session_id, stream_id=stream_id)
     _agent_ref = [None]
 
     def _agent_status_callback(kind, message):
@@ -3931,7 +3926,8 @@ def _run_agent_streaming(
         _kind = str(kind or '').strip().lower()
         if not _message:
             return
-        _cost_guard.record_status(_kind, _message)
+        if _cost_guard is not None:
+            _cost_guard.record_status(_kind, _message)
         _lower = _message.lower()
         _is_compression_start = (
             _kind == 'lifecycle'
@@ -3955,6 +3951,8 @@ def _run_agent_streaming(
             put('warning', {'type': 'fallback', 'message': _message})
 
     def _agent_step_callback(api_call_count, prev_tools=None):
+        if _cost_guard is None:
+            return
         payload = _cost_guard.record_step(api_call_count, prev_tools)
         if not payload:
             return
@@ -4387,12 +4385,13 @@ def _run_agent_streaming(
                     return
 
                 if event_type == 'tool.completed':
-                    _cost_guard.record_tool_complete(
-                        name=name,
-                        arguments=args if isinstance(args, dict) else {},
-                        is_error=bool(cb_kwargs.get('is_error', False)),
-                        result=preview,
-                    )
+                    if _cost_guard is not None:
+                        _cost_guard.record_tool_complete(
+                            name=name,
+                            arguments=args if isinstance(args, dict) else {},
+                            is_error=bool(cb_kwargs.get('is_error', False)),
+                            result=preview,
+                        )
                     for live_tc in reversed(_live_tool_calls):
                         if live_tc.get('done'):
                             continue
@@ -4462,13 +4461,14 @@ def _run_agent_streaming(
 
             def on_tool_complete(tool_call_id, name, args, function_result, **cb_kwargs):
                 try:
-                    _cost_guard.record_tool_complete(
-                        tool_call_id=tool_call_id,
-                        name=name,
-                        arguments=args,
-                        is_error=bool(cb_kwargs.get('is_error', False)),
-                        result=function_result,
-                    )
+                    if _cost_guard is not None:
+                        _cost_guard.record_tool_complete(
+                            tool_call_id=tool_call_id,
+                            name=name,
+                            arguments=args,
+                            is_error=bool(cb_kwargs.get('is_error', False)),
+                            result=function_result,
+                        )
                     _record_live_tool_complete(tool_call_id, name, function_result)
                     if tool_call_id and tool_call_id not in _live_tool_event_complete_ids:
                         _live_tool_event_complete_ids.add(tool_call_id)
@@ -5083,7 +5083,7 @@ def _run_agent_streaming(
                         logger.debug("Failed to append cancelled turn journal event", exc_info=True)
                 put('cancel', {'message': 'Cancelled by user'})
                 return
-            if _cost_guard.paused_payload is not None:
+            if _cost_guard is not None and _cost_guard.paused_payload is not None:
                 _cost_payload = _cost_guard.paused_payload
                 with _agent_lock:
                     if not ephemeral and not _stream_writeback_is_current(s, stream_id):
@@ -6109,7 +6109,7 @@ def _run_agent_streaming(
                             logger.debug("Failed to append cancelled turn journal event", exc_info=True)
             put('cancel', {'message': 'Cancelled by user'})
             return
-        if _cost_guard.paused_payload is not None:
+        if _cost_guard is not None and _cost_guard.paused_payload is not None:
             _cost_payload = _cost_guard.paused_payload
             if s is not None:
                 if _checkpoint_stop is not None:

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -107,6 +107,45 @@ def _is_fallback_lifecycle_message(kind: str, message: str) -> bool:
 
 
 COST_PROTECTION_INTERRUPT_PREFIX = "Hermes WebUI cost protection pause:"
+_DEFAULT_COST_PROTECTION_THRESHOLDS = {
+    "api_call_threshold": 36,
+    "compression_event_threshold": 8,
+    "compression_failure_threshold": 2,
+    "fallback_threshold": 3,
+    "tool_error_threshold": 3,
+}
+
+
+def _positive_int(value, fallback: int) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return fallback
+    return parsed if parsed > 0 else fallback
+
+
+def _cost_protection_config() -> dict:
+    try:
+        cfg_data = get_config()
+    except Exception:
+        cfg_data = {}
+    if not isinstance(cfg_data, dict):
+        return {}
+    direct = cfg_data.get("cost_protection")
+    if isinstance(direct, dict):
+        return direct
+    webui = cfg_data.get("webui")
+    nested = webui.get("cost_protection") if isinstance(webui, dict) else None
+    return nested if isinstance(nested, dict) else {}
+
+
+def _cost_protection_guard_from_config(*, session_id: str, stream_id: str):
+    cfg_data = _cost_protection_config()
+    thresholds = {
+        key: _positive_int(cfg_data.get(key), fallback)
+        for key, fallback in _DEFAULT_COST_PROTECTION_THRESHOLDS.items()
+    }
+    return CostProtectionGuard(session_id=session_id, stream_id=stream_id, **thresholds)
 
 
 class CostProtectionGuard:
@@ -117,19 +156,34 @@ class CostProtectionGuard:
         *,
         session_id: str,
         stream_id: str,
-        api_call_threshold: int = 12,
-        compression_event_threshold: int = 5,
-        compression_failure_threshold: int = 2,
-        fallback_threshold: int = 3,
-        tool_error_threshold: int = 3,
+        api_call_threshold: int = _DEFAULT_COST_PROTECTION_THRESHOLDS["api_call_threshold"],
+        compression_event_threshold: int = _DEFAULT_COST_PROTECTION_THRESHOLDS["compression_event_threshold"],
+        compression_failure_threshold: int = _DEFAULT_COST_PROTECTION_THRESHOLDS["compression_failure_threshold"],
+        fallback_threshold: int = _DEFAULT_COST_PROTECTION_THRESHOLDS["fallback_threshold"],
+        tool_error_threshold: int = _DEFAULT_COST_PROTECTION_THRESHOLDS["tool_error_threshold"],
     ):
         self.session_id = session_id
         self.stream_id = stream_id
-        self.api_call_threshold = max(1, int(api_call_threshold or 12))
-        self.compression_event_threshold = max(1, int(compression_event_threshold or 5))
-        self.compression_failure_threshold = max(1, int(compression_failure_threshold or 2))
-        self.fallback_threshold = max(1, int(fallback_threshold or 3))
-        self.tool_error_threshold = max(1, int(tool_error_threshold or 3))
+        self.api_call_threshold = _positive_int(
+            api_call_threshold,
+            _DEFAULT_COST_PROTECTION_THRESHOLDS["api_call_threshold"],
+        )
+        self.compression_event_threshold = _positive_int(
+            compression_event_threshold,
+            _DEFAULT_COST_PROTECTION_THRESHOLDS["compression_event_threshold"],
+        )
+        self.compression_failure_threshold = _positive_int(
+            compression_failure_threshold,
+            _DEFAULT_COST_PROTECTION_THRESHOLDS["compression_failure_threshold"],
+        )
+        self.fallback_threshold = _positive_int(
+            fallback_threshold,
+            _DEFAULT_COST_PROTECTION_THRESHOLDS["fallback_threshold"],
+        )
+        self.tool_error_threshold = _positive_int(
+            tool_error_threshold,
+            _DEFAULT_COST_PROTECTION_THRESHOLDS["tool_error_threshold"],
+        )
         self.api_call_count = 0
         self.compression_events = 0
         self.compression_failures = 0
@@ -137,7 +191,8 @@ class CostProtectionGuard:
         self.tool_errors = 0
         self.tool_calls = 0
         self.paused_payload = None
-        self._seen_prev_tool_keys = set()
+        self._counted_tool_key_counts = {}
+        self._seen_prev_tool_key_counts = {}
 
     def record_status(self, kind: str, message: str) -> None:
         message_text = str(message or "").strip()
@@ -165,24 +220,55 @@ class CostProtectionGuard:
         if _is_fallback_lifecycle_message(kind, message_text):
             self.fallback_events += 1
 
-    def record_tool_complete(self, *, is_error: bool = False, result=None) -> None:
+    def record_tool_complete(
+        self,
+        *,
+        tool_call_id=None,
+        name=None,
+        arguments=None,
+        is_error: bool = False,
+        result=None,
+    ) -> None:
+        key = self._tool_key(
+            tool_call_id=tool_call_id,
+            name=name,
+            arguments=arguments,
+            result=result,
+        )
+        self._counted_tool_key_counts[key] = self._counted_tool_key_counts.get(key, 0) + 1
+        self._record_tool_count(is_error=is_error, result=result)
+
+    def _record_tool_count(self, *, is_error: bool = False, result=None) -> None:
         self.tool_calls += 1
         if is_error or self._result_looks_error(result):
             self.tool_errors += 1
 
     def record_step(self, api_call_count: int, prev_tools=None):
         self.api_call_count = max(self.api_call_count, int(api_call_count or 0))
+        prev_seen_this_step = {}
         for tool in prev_tools or []:
             if isinstance(tool, dict):
-                key = (
-                    str(tool.get("name") or "")[:120],
-                    str(tool.get("arguments") or "")[:512],
-                    str(tool.get("result") or "")[:512],
+                key = self._tool_key(
+                    name=tool.get("name"),
+                    arguments=tool.get("arguments"),
+                    result=tool.get("result"),
                 )
-                if key in self._seen_prev_tool_keys:
+                prev_seen_this_step[key] = prev_seen_this_step.get(key, 0) + 1
+                occurrence = prev_seen_this_step[key]
+                if occurrence <= self._seen_prev_tool_key_counts.get(key, 0):
                     continue
-                self._seen_prev_tool_keys.add(key)
-                self.record_tool_complete(result=tool.get("result"))
+                self._seen_prev_tool_key_counts[key] = occurrence
+                counted = self._counted_tool_key_counts.get(key, 0)
+                if counted > 0:
+                    if counted == 1:
+                        self._counted_tool_key_counts.pop(key, None)
+                    else:
+                        self._counted_tool_key_counts[key] = counted - 1
+                    continue
+                self._record_tool_count(
+                    is_error=bool(tool.get("is_error", False)),
+                    result=tool.get("result"),
+                )
         return self._maybe_pause()
 
     def interrupt_message(self) -> str:
@@ -241,6 +327,25 @@ class CostProtectionGuard:
             or "traceback (most recent call last)" in text
             or "command not found" in text
             or "path not found" in text
+        )
+
+    @staticmethod
+    def _stable_key_part(value, limit: int) -> str:
+        try:
+            text = json.dumps(value, sort_keys=True, separators=(",", ":"), default=str)
+        except Exception:
+            text = str(value)
+        return text[:limit]
+
+    @classmethod
+    def _tool_key(cls, *, tool_call_id=None, name=None, arguments=None, result=None):
+        if tool_call_id:
+            return ("id", str(tool_call_id))
+        return (
+            "value",
+            cls._stable_key_part(name or "", 120),
+            cls._stable_key_part(arguments or {}, 512),
+            cls._stable_key_part(result or "", 512),
         )
 
 
@@ -3804,7 +3909,7 @@ def _run_agent_streaming(
         except Exception:
             logger.debug("Failed to put event to queue")
 
-    _cost_guard = CostProtectionGuard(session_id=session_id, stream_id=stream_id)
+    _cost_guard = _cost_protection_guard_from_config(session_id=session_id, stream_id=stream_id)
     _agent_ref = [None]
 
     def _agent_status_callback(kind, message):
@@ -4275,6 +4380,8 @@ def _run_agent_streaming(
 
                 if event_type == 'tool.completed':
                     _cost_guard.record_tool_complete(
+                        name=name,
+                        arguments=args if isinstance(args, dict) else {},
                         is_error=bool(cb_kwargs.get('is_error', False)),
                         result=preview,
                     )
@@ -4348,6 +4455,9 @@ def _run_agent_streaming(
             def on_tool_complete(tool_call_id, name, args, function_result, **cb_kwargs):
                 try:
                     _cost_guard.record_tool_complete(
+                        tool_call_id=tool_call_id,
+                        name=name,
+                        arguments=args,
                         is_error=bool(cb_kwargs.get('is_error', False)),
                         result=function_result,
                     )

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -106,6 +106,144 @@ def _is_fallback_lifecycle_message(kind: str, message: str) -> bool:
     )
 
 
+COST_PROTECTION_INTERRUPT_PREFIX = "Hermes WebUI cost protection pause:"
+
+
+class CostProtectionGuard:
+    """Track objective signals that a run should stop before more model calls."""
+
+    def __init__(
+        self,
+        *,
+        session_id: str,
+        stream_id: str,
+        api_call_threshold: int = 12,
+        compression_event_threshold: int = 5,
+        compression_failure_threshold: int = 2,
+        fallback_threshold: int = 3,
+        tool_error_threshold: int = 3,
+    ):
+        self.session_id = session_id
+        self.stream_id = stream_id
+        self.api_call_threshold = max(1, int(api_call_threshold or 12))
+        self.compression_event_threshold = max(1, int(compression_event_threshold or 5))
+        self.compression_failure_threshold = max(1, int(compression_failure_threshold or 2))
+        self.fallback_threshold = max(1, int(fallback_threshold or 3))
+        self.tool_error_threshold = max(1, int(tool_error_threshold or 3))
+        self.api_call_count = 0
+        self.compression_events = 0
+        self.compression_failures = 0
+        self.fallback_events = 0
+        self.tool_errors = 0
+        self.tool_calls = 0
+        self.paused_payload = None
+        self._seen_prev_tool_keys = set()
+
+    def record_status(self, kind: str, message: str) -> None:
+        message_text = str(message or "").strip()
+        if not message_text:
+            return
+        lower = message_text.lower()
+        lifecycle = str(kind or "").strip().lower() == "lifecycle"
+        compression_related = (
+            "compress" in lower
+            or "compaction" in lower
+            or "summary" in lower
+            or "summar" in lower
+            or "auxiliary responses stream" in lower
+        )
+        if lifecycle and compression_related:
+            self.compression_events += 1
+            if (
+                "timeout" in lower
+                or "timed out" in lower
+                or "exceeded" in lower
+                or "failed" in lower
+                or "error" in lower
+            ):
+                self.compression_failures += 1
+        if _is_fallback_lifecycle_message(kind, message_text):
+            self.fallback_events += 1
+
+    def record_tool_complete(self, *, is_error: bool = False, result=None) -> None:
+        self.tool_calls += 1
+        if is_error or self._result_looks_error(result):
+            self.tool_errors += 1
+
+    def record_step(self, api_call_count: int, prev_tools=None):
+        self.api_call_count = max(self.api_call_count, int(api_call_count or 0))
+        for tool in prev_tools or []:
+            if isinstance(tool, dict):
+                key = (
+                    str(tool.get("name") or "")[:120],
+                    str(tool.get("arguments") or "")[:512],
+                    str(tool.get("result") or "")[:512],
+                )
+                if key in self._seen_prev_tool_keys:
+                    continue
+                self._seen_prev_tool_keys.add(key)
+                self.record_tool_complete(result=tool.get("result"))
+        return self._maybe_pause()
+
+    def interrupt_message(self) -> str:
+        reason = (self.paused_payload or {}).get("reason") or "suspicious_long_running_session"
+        return f"{COST_PROTECTION_INTERRUPT_PREFIX} {reason}"
+
+    def _maybe_pause(self):
+        if self.paused_payload is not None:
+            return None
+        reason = None
+        if self.compression_failures >= self.compression_failure_threshold:
+            reason = "repeated_context_compression_failures"
+        elif self.compression_events >= self.compression_event_threshold:
+            reason = "repeated_context_compression"
+        elif self.fallback_events >= self.fallback_threshold:
+            reason = "repeated_provider_fallbacks"
+        elif self.tool_errors >= self.tool_error_threshold:
+            reason = "repeated_tool_errors"
+        elif self.api_call_count >= self.api_call_threshold:
+            reason = "high_model_call_count"
+        if reason is None:
+            return None
+        self.paused_payload = {
+            "type": "cost_protection_pause",
+            "session_id": self.session_id,
+            "stream_id": self.stream_id,
+            "reason": reason,
+            "message": (
+                "This run was paused before the next model call because it matched "
+                "cost-protection signals for a suspicious long-running session."
+            ),
+            "hint": "Review the run. Send a follow-up such as 'continue' if it is still on track.",
+            "stats": {
+                "api_call_count": self.api_call_count,
+                "compression_events": self.compression_events,
+                "compression_failures": self.compression_failures,
+                "fallback_events": self.fallback_events,
+                "tool_calls": self.tool_calls,
+                "tool_errors": self.tool_errors,
+            },
+        }
+        return self.paused_payload
+
+    @staticmethod
+    def _result_looks_error(result) -> bool:
+        if isinstance(result, dict):
+            if result.get("is_error") or result.get("error"):
+                return True
+            result = result.get("content") or result.get("result") or result.get("output")
+        text = str(result or "").strip().lower()
+        if not text:
+            return False
+        return (
+            text.startswith("error:")
+            or text.startswith("failed:")
+            or "traceback (most recent call last)" in text
+            or "command not found" in text
+            or "path not found" in text
+        )
+
+
 def _prewarm_skill_tool_modules():
     """Import tools.skills_tool and tools.skill_manager_tool outside any lock.
 
@@ -3666,6 +3804,9 @@ def _run_agent_streaming(
         except Exception:
             logger.debug("Failed to put event to queue")
 
+    _cost_guard = CostProtectionGuard(session_id=session_id, stream_id=stream_id)
+    _agent_ref = [None]
+
     def _agent_status_callback(kind, message):
         """Bridge Agent lifecycle status into WebUI SSE.
 
@@ -3677,6 +3818,7 @@ def _run_agent_streaming(
         _kind = str(kind or '').strip().lower()
         if not _message:
             return
+        _cost_guard.record_status(_kind, _message)
         _lower = _message.lower()
         _is_compression_start = (
             _kind == 'lifecycle'
@@ -3698,6 +3840,19 @@ def _run_agent_streaming(
         _is_fallback_notice = _is_fallback_lifecycle_message(_kind, _message)
         if _is_fallback_notice:
             put('warning', {'type': 'fallback', 'message': _message})
+
+    def _agent_step_callback(api_call_count, prev_tools=None):
+        payload = _cost_guard.record_step(api_call_count, prev_tools)
+        if not payload:
+            return
+        put('warning', {
+            'type': 'cost_protection_pause',
+            'message': payload['message'],
+            'stats': payload.get('stats') or {},
+        })
+        agent = _agent_ref[0]
+        if agent is not None and hasattr(agent, 'interrupt'):
+            agent.interrupt(_cost_guard.interrupt_message())
 
     # Initialised here (before any code that may raise) so the outer `finally`
     # block can safely check `if _checkpoint_stop is not None` even when an
@@ -4119,6 +4274,10 @@ def _run_agent_streaming(
                     return
 
                 if event_type == 'tool.completed':
+                    _cost_guard.record_tool_complete(
+                        is_error=bool(cb_kwargs.get('is_error', False)),
+                        result=preview,
+                    )
                     for live_tc in reversed(_live_tool_calls):
                         if live_tc.get('done'):
                             continue
@@ -4186,8 +4345,12 @@ def _run_agent_streaming(
                 except Exception:
                     logger.debug('Failed to update live prompt estimate on tool start', exc_info=True)
 
-            def on_tool_complete(tool_call_id, name, args, function_result):
+            def on_tool_complete(tool_call_id, name, args, function_result, **cb_kwargs):
                 try:
+                    _cost_guard.record_tool_complete(
+                        is_error=bool(cb_kwargs.get('is_error', False)),
+                        result=function_result,
+                    )
                     _record_live_tool_complete(tool_call_id, name, function_result)
                     if tool_call_id and tool_call_id not in _live_tool_event_complete_ids:
                         _live_tool_event_complete_ids.add(tool_call_id)
@@ -4214,7 +4377,7 @@ def _run_agent_streaming(
                             'preview': result_snippet,
                             'args': _tool_args_snapshot(args),
                             'tid': tool_call_id,
-                            'is_error': False,
+                            'is_error': bool(cb_kwargs.get('is_error', False)),
                         })
                     _tool_stats = meter().get_stats()
                     _tool_stats['session_id'] = session_id
@@ -4418,6 +4581,8 @@ def _run_agent_streaming(
                 _agent_kwargs['tool_complete_callback'] = on_tool_complete
             if 'status_callback' in _agent_params:
                 _agent_kwargs['status_callback'] = _agent_status_callback
+            if 'step_callback' in _agent_params:
+                _agent_kwargs['step_callback'] = _agent_step_callback
             if 'max_iterations' in _agent_params and _max_iterations_cfg is not None:
                 _agent_kwargs['max_iterations'] = _max_iterations_cfg
             if 'max_tokens' in _agent_params and _max_tokens_cfg is not None:
@@ -4517,6 +4682,8 @@ def _run_agent_streaming(
                         agent.tool_complete_callback = _agent_kwargs.get('tool_complete_callback')
                     if hasattr(agent, 'status_callback'):
                         agent.status_callback = _agent_kwargs.get('status_callback')
+                    if hasattr(agent, 'step_callback'):
+                        agent.step_callback = _agent_kwargs.get('step_callback')
                     if hasattr(agent, 'interim_assistant_callback'):
                         agent.interim_assistant_callback = _agent_kwargs.get('interim_assistant_callback')
                     if hasattr(agent, 'reasoning_callback'):
@@ -4588,6 +4755,8 @@ def _run_agent_streaming(
                             logger.debug("Failed to close evicted agent for session %s", _evicted_sid, exc_info=True)
                         logger.debug('[webui] Evicted LRU agent from cache: %s', _evicted_sid)
                     logger.debug('[webui] Created new agent for session %s', session_id)
+
+            _agent_ref[0] = agent
 
             # Store agent instance for cancel/interrupt propagation
             with STREAMS_LOCK:
@@ -4796,6 +4965,58 @@ def _run_agent_streaming(
                         logger.debug("Failed to append cancelled turn journal event", exc_info=True)
                 put('cancel', {'message': 'Cancelled by user'})
                 return
+            if _cost_guard.paused_payload is not None:
+                _cost_payload = _cost_guard.paused_payload
+                with _agent_lock:
+                    if not ephemeral and not _stream_writeback_is_current(s, stream_id):
+                        logger.info(
+                            "Skipping stale cost-protection writeback for session %s stream %s; active_stream_id=%s",
+                            getattr(s, 'session_id', session_id),
+                            stream_id,
+                            getattr(s, 'active_stream_id', None),
+                        )
+                        return
+                    _materialize_pending_user_turn_before_error(s)
+                    s.active_stream_id = None
+                    s.pending_user_message = None
+                    s.pending_attachments = []
+                    s.pending_started_at = None
+                    _stats_json = json.dumps(_cost_payload.get('stats') or {}, ensure_ascii=False, sort_keys=True)
+                    s.messages.append({
+                        'role': 'assistant',
+                        'content': (
+                            f"**Run paused for review:** {_cost_payload.get('message')}\n\n"
+                            f"*{_cost_payload.get('hint')}*"
+                        ),
+                        'timestamp': int(time.time()),
+                        '_error': True,
+                        'provider_details': _stats_json,
+                        'provider_details_label': 'Cost protection details',
+                    })
+                    try:
+                        s.save()
+                    except Exception:
+                        pass
+                    if not ephemeral:
+                        try:
+                            append_turn_journal_event_for_stream(
+                                s.session_id,
+                                stream_id,
+                                {
+                                    "event": "interrupted",
+                                    "created_at": time.time(),
+                                    "reason": "cost_protection_pause",
+                                },
+                            )
+                        except Exception:
+                            logger.debug("Failed to append cost-protection turn journal event", exc_info=True)
+                put('apperror', {
+                    'type': 'cost_protection_pause',
+                    'message': _cost_payload.get('message'),
+                    'hint': _cost_payload.get('hint'),
+                    'details': json.dumps(_cost_payload.get('stats') or {}, ensure_ascii=False, sort_keys=True),
+                })
+                return
             with _agent_lock:
                 if not ephemeral and not _stream_writeback_is_current(s, stream_id):
                     if _stream_writeback_can_supersede_recovery_marker(s, msg_text):
@@ -4938,6 +5159,7 @@ def _run_agent_streaming(
                             if 'credential_pool' in _agent_params:
                                 _agent_kwargs['credential_pool'] = _heal_rt.get('credential_pool')
                             agent = _AIAgent(**_agent_kwargs)
+                            _agent_ref[0] = agent
                             with STREAMS_LOCK:
                                 AGENT_INSTANCES[stream_id] = agent
                             from api.config import SESSION_AGENT_CACHE as _SAC, SESSION_AGENT_CACHE_LOCK as _SAC_L
@@ -5769,6 +5991,64 @@ def _run_agent_streaming(
                             logger.debug("Failed to append cancelled turn journal event", exc_info=True)
             put('cancel', {'message': 'Cancelled by user'})
             return
+        if _cost_guard.paused_payload is not None:
+            _cost_payload = _cost_guard.paused_payload
+            if s is not None:
+                if _checkpoint_stop is not None:
+                    _checkpoint_stop.set()
+                if _ckpt_thread is not None:
+                    _ckpt_thread.join(timeout=15)
+                _lock_ctx = _agent_lock if _agent_lock is not None else contextlib.nullcontext()
+                with _lock_ctx:
+                    if not ephemeral and not _stream_writeback_is_current(s, stream_id):
+                        logger.info(
+                            "Skipping stale cost-protection error writeback for session %s stream %s; active_stream_id=%s",
+                            getattr(s, 'session_id', session_id),
+                            stream_id,
+                            getattr(s, 'active_stream_id', None),
+                        )
+                        return
+                    _materialize_pending_user_turn_before_error(s)
+                    s.active_stream_id = None
+                    s.pending_user_message = None
+                    s.pending_attachments = []
+                    s.pending_started_at = None
+                    _stats_json = json.dumps(_cost_payload.get('stats') or {}, ensure_ascii=False, sort_keys=True)
+                    s.messages.append({
+                        'role': 'assistant',
+                        'content': (
+                            f"**Run paused for review:** {_cost_payload.get('message')}\n\n"
+                            f"*{_cost_payload.get('hint')}*"
+                        ),
+                        'timestamp': int(time.time()),
+                        '_error': True,
+                        'provider_details': _stats_json,
+                        'provider_details_label': 'Cost protection details',
+                    })
+                    try:
+                        s.save()
+                    except Exception:
+                        pass
+                    if not ephemeral:
+                        try:
+                            append_turn_journal_event_for_stream(
+                                s.session_id,
+                                stream_id,
+                                {
+                                    "event": "interrupted",
+                                    "created_at": time.time(),
+                                    "reason": "cost_protection_pause",
+                                },
+                            )
+                        except Exception:
+                            logger.debug("Failed to append cost-protection turn journal event", exc_info=True)
+            put('apperror', {
+                'type': 'cost_protection_pause',
+                'message': _cost_payload.get('message'),
+                'hint': _cost_payload.get('hint'),
+                'details': json.dumps(_cost_payload.get('stats') or {}, ensure_ascii=False, sort_keys=True),
+            })
+            return
         _exc_is_quota = _classification['type'] == 'quota_exhausted'
         # Exception quota text still includes: 'more credits' in _exc_lower, 'can only afford' in _exc_lower, 'fewer max_tokens' in _exc_lower.
         # Rate-limit detection remains guarded as: (not _exc_is_quota).
@@ -5815,6 +6095,7 @@ def _run_agent_streaming(
                     if 'credential_pool' in _agent_params:
                         _heal_kwargs['credential_pool'] = _heal_rt.get('credential_pool')
                     _heal_agent = _AIAgent(**_heal_kwargs)
+                    _agent_ref[0] = _heal_agent
                     with STREAMS_LOCK:
                         AGENT_INSTANCES[stream_id] = _heal_agent
                     from api.config import SESSION_AGENT_CACHE as _SAC2, SESSION_AGENT_CACHE_LOCK as _SAC2_L

--- a/ctl.sh
+++ b/ctl.sh
@@ -17,6 +17,7 @@ Commands:
   stop                        Stop the daemon started by ctl.sh
   restart [bootstrap args...] Stop, then start again
   status                      Show daemon, host/port, log, and health status
+  cost-protection <command>   Manage WebUI runaway-cost guards (status|enable|disable)
   logs [--lines N] [--follow|--no-follow]
                               Show the daemon log (defaults to tail -n 100 -f)
 EOF
@@ -357,6 +358,64 @@ logs_cmd() {
   fi
 }
 
+cost_protection_cmd() {
+  ensure_home
+  _load_repo_dotenv_preserving_env
+  local action="${1:-status}"
+  local state_dir="${HERMES_WEBUI_STATE_DIR:-${DEFAULT_STATE_DIR}}"
+  local settings_file="${state_dir}/settings.json"
+  local python_exe
+  mkdir -p "${state_dir}"
+  python_exe="$(_find_python)"
+  case "${action}" in
+    status|enable|disable)
+      SETTINGS_FILE="${settings_file}" ACTION="${action}" "${python_exe}" - <<'PY'
+import json
+import os
+from pathlib import Path
+
+settings_path = Path(os.environ["SETTINGS_FILE"]).expanduser()
+action = os.environ["ACTION"]
+settings = {}
+if settings_path.exists():
+    try:
+        loaded = json.loads(settings_path.read_text(encoding="utf-8"))
+        if isinstance(loaded, dict):
+            settings = loaded
+    except Exception:
+        settings = {}
+
+if action in {"enable", "disable"}:
+    settings["cost_protection_enabled"] = action == "enable"
+    settings_path.parent.mkdir(parents=True, exist_ok=True)
+    settings_path.write_text(json.dumps(settings, ensure_ascii=False, indent=2), encoding="utf-8")
+
+enabled = bool(settings.get("cost_protection_enabled", False))
+print(f"Cost Protection: {'enabled' if enabled else 'disabled'}")
+print(f"Settings: {settings_path}")
+if action == "enable":
+    print("Future WebUI chat runs will pause before another model call when runaway-cost signals accumulate.")
+elif action == "disable":
+    print("Future WebUI chat runs will continue without the runaway-cost pause gate.")
+else:
+    print("Coverage: WebUI chat run pause gate. Background runaway alerts are not implemented yet.")
+PY
+      ;;
+    -h|--help|help)
+      cat <<'EOF'
+Usage: ./ctl.sh cost-protection <status|enable|disable>
+
+Manage WebUI Cost Protection, an advanced runaway-cost guard for future WebUI
+chat runs. This writes WebUI-owned settings.json state, not Hermes Agent config.
+EOF
+      ;;
+    *)
+      echo "[ctl] Unknown cost-protection command: ${action}" >&2
+      return 2
+      ;;
+  esac
+}
+
 cmd="${1:-}"
 if [[ $# -gt 0 ]]; then
   shift
@@ -367,6 +426,7 @@ case "${cmd}" in
   stop) stop_cmd ;;
   restart) stop_cmd; start_cmd "$@" ;;
   status) status_cmd ;;
+  cost-protection) cost_protection_cmd "$@" ;;
   logs) logs_cmd "$@" ;;
   -h|--help|help|"") usage ;;
   *) echo "[ctl] Unknown command: ${cmd}" >&2; usage >&2; exit 2 ;;

--- a/static/messages.js
+++ b/static/messages.js
@@ -2083,11 +2083,12 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
           const isModelNotFound=d.type==='model_not_found';
           const isCancelled=d.type==='cancelled';
           const isInterrupted=d.type==='interrupted';
+          const isCostProtectionPause=d.type==='cost_protection_pause';
           const isNoResponse=d.type==='no_response'||d.type==='silent_failure';
-          const label=isCancelled?'Task cancelled':isInterrupted?'Response interrupted':isQuotaExhausted?'Out of credits':isRateLimit?'Rate limit reached':isAuthMismatch?(typeof t==='function'?t('provider_mismatch_label'):'Provider mismatch'):isModelNotFound?(typeof t==='function'?t('model_not_found_label'):'Model not found'):isNoResponse?'No response from provider':'Error';
+          const label=isCostProtectionPause?'Run paused for review':isCancelled?'Task cancelled':isInterrupted?'Response interrupted':isQuotaExhausted?'Out of credits':isRateLimit?'Rate limit reached':isAuthMismatch?(typeof t==='function'?t('provider_mismatch_label'):'Provider mismatch'):isModelNotFound?(typeof t==='function'?t('model_not_found_label'):'Model not found'):isNoResponse?'No response from provider':'Error';
           const hint=d.hint?`\n\n*${d.hint}*`:'';
           const details=d.details?String(d.details).replace(/```/g,'`\u200b``'):'';
-          const detailsLabel=isCancelled?'Cancellation details':isInterrupted?'Interruption details':undefined;
+          const detailsLabel=isCostProtectionPause?'Cost protection details':isCancelled?'Cancellation details':isInterrupted?'Interruption details':undefined;
           S.messages.push({role:'assistant',content:`**${label}:** ${d.message}${hint}`,provider_details:details,provider_details_label:detailsLabel});
         }catch(_){
           S.messages.push({role:'assistant',content:'**Error:** An error occurred. Check server logs.'});

--- a/tests/test_cost_protection_pause.py
+++ b/tests/test_cost_protection_pause.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from api.streaming import CostProtectionGuard
+from api.streaming import CostProtectionGuard, _cost_protection_guard_from_config
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -49,6 +49,64 @@ def test_cost_protection_guard_triggers_before_runaway_api_calls():
     assert payload is not None
     assert payload["reason"] == "high_model_call_count"
     assert payload["stats"]["api_call_count"] == 3
+
+
+def test_cost_protection_dedupes_completed_tools_seen_again_on_next_step():
+    guard = CostProtectionGuard(
+        session_id="sid",
+        stream_id="stream",
+        tool_error_threshold=2,
+    )
+    tool = {
+        "name": "shell",
+        "arguments": {"cmd": "pytest"},
+        "result": {"is_error": True, "output": "failed"},
+    }
+
+    guard.record_tool_complete(
+        name=tool["name"],
+        arguments=tool["arguments"],
+        result=tool["result"],
+    )
+    payload = guard.record_step(1, prev_tools=[tool])
+
+    assert payload is None
+    assert guard.tool_calls == 1
+    assert guard.tool_errors == 1
+
+
+def test_cost_protection_counts_distinct_identical_prev_tools():
+    guard = CostProtectionGuard(
+        session_id="sid",
+        stream_id="stream",
+        tool_error_threshold=3,
+    )
+    tool = {
+        "name": "shell",
+        "arguments": {"cmd": "pytest"},
+        "result": {"is_error": True, "output": "failed"},
+    }
+
+    payload = guard.record_step(1, prev_tools=[tool, dict(tool)])
+
+    assert payload is None
+    assert guard.tool_calls == 2
+    assert guard.tool_errors == 2
+
+
+def test_cost_protection_thresholds_can_be_configured(monkeypatch):
+    import api.config as config
+
+    monkeypatch.setattr(
+        config,
+        "cfg",
+        {"cost_protection": {"api_call_threshold": 7, "tool_error_threshold": 4}},
+    )
+
+    guard = _cost_protection_guard_from_config(session_id="sid", stream_id="stream")
+
+    assert guard.api_call_threshold == 7
+    assert guard.tool_error_threshold == 4
 
 
 def test_streaming_wires_cost_protection_to_agent_step_callback():

--- a/tests/test_cost_protection_pause.py
+++ b/tests/test_cost_protection_pause.py
@@ -94,6 +94,63 @@ def test_cost_protection_counts_distinct_identical_prev_tools():
     assert guard.tool_errors == 2
 
 
+def test_default_cost_protection_tolerates_routine_diagnostic_tool_errors():
+    guard = CostProtectionGuard(session_id="sid", stream_id="stream")
+
+    for index in range(3):
+        guard.record_tool_complete(
+            name="terminal",
+            arguments={"command": f"probe-{index}"},
+            result={"is_error": True, "output": "Traceback (most recent call last)"},
+        )
+        payload = guard.record_step(index + 1)
+
+    assert payload is None
+    assert guard.tool_errors == 3
+
+
+def test_default_cost_protection_pauses_on_repeated_tool_error_pattern():
+    guard = CostProtectionGuard(session_id="sid", stream_id="stream")
+    tool = {
+        "name": "terminal",
+        "arguments": {"command": "retry-the-same-failing-probe"},
+        "result": {"is_error": True, "output": "same failure"},
+    }
+
+    assert guard.record_step(1, prev_tools=[dict(tool)]) is None
+    assert guard.record_step(2, prev_tools=[dict(tool), dict(tool)]) is None
+    payload = guard.record_step(3, prev_tools=[dict(tool), dict(tool), dict(tool)])
+
+    assert payload is not None
+    assert payload["reason"] == "repeated_tool_errors"
+    assert payload["stats"]["repeated_tool_error_count"] == 3
+
+
+def test_cost_protection_can_still_pause_on_configured_tool_errors():
+    guard = CostProtectionGuard(
+        session_id="sid",
+        stream_id="stream",
+        tool_error_threshold=2,
+    )
+
+    guard.record_tool_complete(
+        name="terminal",
+        arguments={"command": "same-failing-probe"},
+        result={"is_error": True, "output": "failed"},
+    )
+    assert guard.record_step(1) is None
+
+    guard.record_tool_complete(
+        name="terminal",
+        arguments={"command": "same-failing-probe"},
+        result={"is_error": True, "output": "failed"},
+    )
+    payload = guard.record_step(2)
+
+    assert payload is not None
+    assert payload["reason"] == "repeated_tool_errors"
+
+
 def test_cost_protection_thresholds_can_be_configured(monkeypatch):
     import api.config as config
 

--- a/tests/test_cost_protection_pause.py
+++ b/tests/test_cost_protection_pause.py
@@ -1,0 +1,64 @@
+from pathlib import Path
+
+from api.streaming import CostProtectionGuard
+
+
+ROOT = Path(__file__).resolve().parents[1]
+STREAMING_SRC = (ROOT / "api" / "streaming.py").read_text()
+MESSAGES_SRC = (ROOT / "static" / "messages.js").read_text()
+
+
+def test_cost_protection_guard_triggers_on_repeated_compression_timeouts():
+    guard = CostProtectionGuard(
+        session_id="sid",
+        stream_id="stream",
+        compression_failure_threshold=2,
+    )
+
+    assert guard.record_step(1) is None
+
+    guard.record_status(
+        "lifecycle",
+        "Codex auxiliary Responses stream exceeded 120.0s total timeout during compression",
+    )
+    assert guard.record_step(2) is None
+
+    guard.record_status(
+        "lifecycle",
+        "Codex auxiliary Responses stream exceeded 120.0s total timeout during compression",
+    )
+    payload = guard.record_step(3)
+
+    assert payload is not None
+    assert payload["type"] == "cost_protection_pause"
+    assert payload["session_id"] == "sid"
+    assert payload["stream_id"] == "stream"
+    assert payload["reason"] == "repeated_context_compression_failures"
+
+
+def test_cost_protection_guard_triggers_before_runaway_api_calls():
+    guard = CostProtectionGuard(
+        session_id="sid",
+        stream_id="stream",
+        api_call_threshold=3,
+    )
+
+    assert guard.record_step(2) is None
+    payload = guard.record_step(3)
+
+    assert payload is not None
+    assert payload["reason"] == "high_model_call_count"
+    assert payload["stats"]["api_call_count"] == 3
+
+
+def test_streaming_wires_cost_protection_to_agent_step_callback():
+    assert "_agent_step_callback" in STREAMING_SRC
+    assert "_agent_kwargs['step_callback'] = _agent_step_callback" in STREAMING_SRC
+    assert "agent.step_callback = _agent_kwargs.get('step_callback')" in STREAMING_SRC
+    assert "agent.interrupt(_cost_guard.interrupt_message())" in STREAMING_SRC
+
+
+def test_cost_protection_pause_is_not_rendered_as_generic_error():
+    assert "isCostProtectionPause=d.type==='cost_protection_pause'" in MESSAGES_SRC
+    assert "Run paused for review" in MESSAGES_SRC
+    assert "cost_protection_pause" in MESSAGES_SRC

--- a/tests/test_cost_protection_pause.py
+++ b/tests/test_cost_protection_pause.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from api.streaming import CostProtectionGuard, _cost_protection_guard_from_config
+from api.streaming import CostProtectionGuard, _cost_protection_guard_from_settings
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -151,19 +151,42 @@ def test_cost_protection_can_still_pause_on_configured_tool_errors():
     assert payload["reason"] == "repeated_tool_errors"
 
 
-def test_cost_protection_thresholds_can_be_configured(monkeypatch):
-    import api.config as config
+def test_cost_protection_is_disabled_by_default(monkeypatch):
+    import api.streaming as streaming
+
+    monkeypatch.setattr(streaming, "load_settings", lambda: {})
+
+    guard = _cost_protection_guard_from_settings(session_id="sid", stream_id="stream")
+
+    assert guard is None
+
+
+def test_cost_protection_can_be_enabled_from_webui_settings(monkeypatch):
+    import api.streaming as streaming
 
     monkeypatch.setattr(
-        config,
-        "cfg",
-        {"cost_protection": {"api_call_threshold": 7, "tool_error_threshold": 4}},
+        streaming,
+        "load_settings",
+        lambda: {"cost_protection_enabled": True},
     )
 
-    guard = _cost_protection_guard_from_config(session_id="sid", stream_id="stream")
+    guard = _cost_protection_guard_from_settings(session_id="sid", stream_id="stream")
 
-    assert guard.api_call_threshold == 7
-    assert guard.tool_error_threshold == 4
+    assert guard is not None
+    assert guard.api_call_threshold == 36
+    assert guard.tool_error_threshold == 3
+
+
+def test_cost_protection_setting_persists_as_webui_owned_bool(tmp_path, monkeypatch):
+    import api.config as config
+
+    settings_file = tmp_path / "settings.json"
+    monkeypatch.setattr(config, "SETTINGS_FILE", settings_file)
+
+    saved = config.save_settings({"cost_protection_enabled": True})
+
+    assert saved["cost_protection_enabled"] is True
+    assert config.load_settings()["cost_protection_enabled"] is True
 
 
 def test_streaming_wires_cost_protection_to_agent_step_callback():
@@ -171,6 +194,7 @@ def test_streaming_wires_cost_protection_to_agent_step_callback():
     assert "_agent_kwargs['step_callback'] = _agent_step_callback" in STREAMING_SRC
     assert "agent.step_callback = _agent_kwargs.get('step_callback')" in STREAMING_SRC
     assert "agent.interrupt(_cost_guard.interrupt_message())" in STREAMING_SRC
+    assert "if _cost_guard is None:" in STREAMING_SRC
 
 
 def test_cost_protection_pause_is_not_rendered_as_generic_error():

--- a/tests/test_ctl_cost_protection.py
+++ b/tests/test_ctl_cost_protection.py
@@ -1,0 +1,53 @@
+import json
+import os
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _run_ctl_cost_protection(tmp_path, action):
+    env = os.environ.copy()
+    env["HERMES_HOME"] = str(tmp_path / "home")
+    env["HERMES_WEBUI_STATE_DIR"] = str(tmp_path / "state")
+    return subprocess.run(
+        ["bash", str(ROOT / "ctl.sh"), "cost-protection", action],
+        cwd=ROOT,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=True,
+    )
+
+
+def test_ctl_cost_protection_enable_disable_status_uses_webui_settings(tmp_path):
+    enabled = _run_ctl_cost_protection(tmp_path, "enable")
+    settings_file = tmp_path / "state" / "settings.json"
+
+    assert "Cost Protection: enabled" in enabled.stdout
+    assert settings_file.exists()
+    assert json.loads(settings_file.read_text())["cost_protection_enabled"] is True
+
+    status = _run_ctl_cost_protection(tmp_path, "status")
+    assert "Cost Protection: enabled" in status.stdout
+    assert "Background runaway alerts are not implemented yet" in status.stdout
+
+    disabled = _run_ctl_cost_protection(tmp_path, "disable")
+    assert "Cost Protection: disabled" in disabled.stdout
+    assert json.loads(settings_file.read_text())["cost_protection_enabled"] is False
+
+
+def test_ctl_help_lists_cost_protection_command():
+    result = subprocess.run(
+        ["bash", str(ROOT / "ctl.sh"), "--help"],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=True,
+    )
+
+    assert "cost-protection <command>" in result.stdout
+    assert "runaway-cost guards" in result.stdout


### PR DESCRIPTION
## Thinking Path

Issue #2957 came from a real WebUI run that kept spending time and tokens through repeated compression/retry/tool-error recovery without producing a durable result. The incident is real, but this is a heuristic safety feature, so the PR now treats Cost Protection as an opt-in operator guard rather than a default product behavior.

The narrow slice here is WebUI-owned chat-run protection: when enabled, WebUI uses Hermes Agent's per-step hook to pause before the next expensive model call if runaway-cost signals accumulate. It does not mutate Hermes Agent `config.yaml`, does not add a Settings UI switch, and does not claim to cover background dispatch/cron/kanban loops yet.

## What Changed

- Added `CostProtectionGuard` to track repeated context compression failures, repeated compression, fallback churn, repeated same-pattern tool errors, and high model-call counts.
- Wired the guard into Hermes Agent `status_callback`, tool-completion callbacks, and `step_callback`.
- Made Cost Protection disabled by default and enabled only via the WebUI-owned command:
  - `./ctl.sh cost-protection status`
  - `./ctl.sh cost-protection enable`
  - `./ctl.sh cost-protection disable`
- Persisted the opt-in flag in WebUI `settings.json` as `cost_protection_enabled`, not in Hermes Agent `config.yaml`.
- When triggered, WebUI interrupts the agent before the next model call, persists a `Run paused for review` marker, emits a `cost_protection_pause` app-error payload, and clears active run state.
- Updated the frontend app-error renderer so cost-protection pauses are shown as `Run paused for review` instead of a generic error.
- Added regression coverage for default-off behavior, WebUI-owned settings persistence, `ctl.sh cost-protection` enable/disable/status, guard logic, callback dedupe, same-pattern tool-error detection, step-callback wiring, and frontend labeling.
- Updated `README.md` and `CHANGELOG.md` with the opt-in command and scope boundary.

## Why It Matters

A suspicious long-running run should not continue burning tokens indefinitely just because it is still technically making internal progress. This gives operators an explicit opt-in guard and a clear review point, while avoiding surprise interruptions for normal long agentic/debugging sessions.

## Contract Routing

Task type: runtime / streaming / operator safety UX

Touched areas:

- WebUI streaming step-boundary control
- WebUI-owned `settings.json` preference
- `ctl.sh` operator command surface
- chat app-error rendering for the pause marker

Scope boundaries:

- Does not write or read Hermes Agent `config.yaml` for this feature.
- Does not add a Settings UI toggle.
- Does not implement background runaway alerts for cron, kanban, or dispatch loops yet.
- Does not implement an in-place suspended worker resume; continuing is a normal follow-up user turn.
- Does not close the broader Cost Protection design space in #2957.

## Verification

- `pytest tests/test_cost_protection_pause.py tests/test_ctl_cost_protection.py tests/test_run_journal_frontend_static.py tests/test_regressions.py::test_streaming_bridge_accepts_current_tool_progress_callback_signature -q` -> 20 passed
- `python -m py_compile api/streaming.py api/config.py`
- `git diff --check`
- Manual `ctl.sh cost-protection enable/status/disable` against an isolated `HERMES_WEBUI_STATE_DIR`, confirming it writes WebUI `settings.json` and reports background runaway alerts as not implemented yet.

## Risks / Follow-ups

- Heuristic false positives remain possible, which is why the feature is default-off and operator-enabled.
- Thresholds are internal defaults in this slice; exposing threshold tuning should wait until the behavior model is accepted.
- A future iteration should add a richer inline action card for `Continue` / `Stop` / `Summarize and stop`.
- A separate follow-up should extend Cost Protection into a Logs-backed alert/evidence center for background runaway patterns such as cron, kanban dispatch, and other long-running Hermes activity. That should be alert-first unless the runtime can safely pause the work.

## Model Used

Implemented with GPT-5 Codex in Hermes WebUI. AI-generated code was reviewed and verified with the tests above.

Refs #2957
