### PR TITLE
feat(reasoning): per-session reasoning effort override (closes #2697)

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -453,6 +453,7 @@ class Session:
                 worktree_created_at=None,
                 enabled_toolsets=None,
                 composer_draft=None,
+                reasoning_effort=None,
                 **kwargs):
         self.session_id = session_id or uuid.uuid4().hex[:12]
         self.title = title
@@ -507,6 +508,14 @@ class Session:
         self.read_only = bool(kwargs.get('read_only', False))
         self.enabled_toolsets = enabled_toolsets  # List[str] or None — per-session toolset override
         self.composer_draft = composer_draft if isinstance(composer_draft, dict) else {}
+        # Per-session reasoning effort override (#2697). None = inherit profile
+        # default (agent.reasoning_effort in config.yaml). Otherwise one of the
+        # values in api.config.VALID_REASONING_EFFORTS plus 'none' (disabled).
+        # Persisted in the session sidecar; resolved at stream start by
+        # api/streaming.py with session-overrides-profile precedence.
+        self.reasoning_effort = (
+            str(reasoning_effort).strip().lower() if reasoning_effort else None
+        )
         raw_message_count = kwargs.get('message_count')
         parsed_message_count = None
         if raw_message_count is not None:
@@ -574,6 +583,8 @@ class Session:
             'worktree_path', 'worktree_branch', 'worktree_repo_root', 'worktree_created_at',
             'is_cli_session', 'source_tag', 'raw_source', 'session_source', 'source_label', 'read_only',
             'enabled_toolsets', 'composer_draft',
+            # #2697 — per-session reasoning effort override (None = inherit profile default)
+            'reasoning_effort',
         ]
         meta = {k: getattr(self, k, None) for k in METADATA_FIELDS}
         meta['messages'] = self.messages
@@ -788,6 +799,8 @@ class Session:
             'read_only': self.read_only,
             'enabled_toolsets': self.enabled_toolsets,
             'composer_draft': self.composer_draft if isinstance(self.composer_draft, dict) else {},
+            # #2697 — per-session reasoning effort override (None = profile default)
+            'reasoning_effort': self.reasoning_effort,
             'is_streaming': _is_streaming_session(
                 self.active_stream_id, active_stream_ids
             ) if include_runtime else False,

--- a/api/routes.py
+++ b/api/routes.py
@@ -5049,6 +5049,9 @@ def handle_post(handler, parsed) -> bool:
                 # re-derive on the next turn.
                 personality=session.personality,
                 enabled_toolsets=getattr(session, "enabled_toolsets", None),
+                # #2697 — carry per-session reasoning effort override forward
+                # on duplicate so the copy behaves identically to the original.
+                reasoning_effort=getattr(session, "reasoning_effort", None),
                 context_length=getattr(session, "context_length", None),
                 threshold_tokens=getattr(session, "threshold_tokens", None),
                 created_at=time.time(),
@@ -5226,6 +5229,48 @@ def handle_post(handler, parsed) -> bool:
             s.personality = name if name else None
             s.save()
         return j(handler, {"ok": True, "personality": s.personality, "prompt": prompt})
+
+    if parsed.path == "/api/session/reasoning":
+        """Set or clear per-session reasoning effort override (#2697).
+
+        POST body: { session_id, effort: 'none'|'minimal'|'low'|'medium'|'high'|'xhigh' | null }
+        - effort: one of the valid reasoning effort strings (or 'none' to
+          disable reasoning entirely), or null/empty to clear the override and
+          inherit the active profile's ``agent.reasoning_effort`` default.
+
+        Mirrors the profile-default ``/api/reasoning`` shape but scopes the
+        write to a single session sidecar instead of config.yaml. Resolution
+        precedence (in api/streaming.py): session override > profile default.
+        """
+        try:
+            require(body, "session_id")
+        except ValueError as e:
+            return bad(handler, str(e))
+        sid = body["session_id"]
+        effort_raw = body.get("effort")
+        # Validate effort: null/empty clears, otherwise must be a known value.
+        # Reject unknown levels with 400 so the UI can surface the error
+        # rather than silently writing garbage to the sidecar.
+        if effort_raw is None or (isinstance(effort_raw, str) and not effort_raw.strip()):
+            effort = None
+        else:
+            from api.config import VALID_REASONING_EFFORTS
+            effort = str(effort_raw).strip().lower()
+            if effort != "none" and effort not in VALID_REASONING_EFFORTS:
+                return bad(
+                    handler,
+                    "effort must be one of: none, "
+                    + ", ".join(VALID_REASONING_EFFORTS),
+                )
+        try:
+            s = get_session(sid)
+            s = _ensure_full_session_before_mutation(sid, s)
+        except KeyError:
+            return bad(handler, "Session not found", 404)
+        with _get_session_agent_lock(sid):
+            s.reasoning_effort = effort
+            s.save()
+        return j(handler, {"ok": True, "reasoning_effort": s.reasoning_effort})
 
     if parsed.path == "/api/session/toolsets":
         """Set or clear per-session toolset override (#493).

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -4283,11 +4283,21 @@ def _run_agent_streaming(
             # active profile's config.yaml (the same key the CLI writes via
             # `/reasoning <level>`) and hand the parsed dict to AIAgent.  When
             # the key is absent or invalid, pass None → agent uses its default.
+            #
+            # #2697 — Per-session override precedence:
+            #   session.reasoning_effort (if set) > agent.reasoning_effort (config.yaml)
+            # The session sidecar stores the override as a plain string ('high',
+            # 'medium', 'low', etc., or 'none'). A None value means inherit the
+            # profile default, which is the v0.51.137- behaviour.
             try:
                 from api.config import parse_reasoning_effort as _parse_reff
-                _effort_cfg = _cfg.get('agent', {}) if isinstance(_cfg, dict) else {}
-                _effort_raw = _effort_cfg.get('reasoning_effort') if isinstance(_effort_cfg, dict) else None
-                _reasoning_config = _parse_reff(_effort_raw)
+                _session_effort = getattr(s, 'reasoning_effort', None)
+                if _session_effort:
+                    _reasoning_config = _parse_reff(_session_effort)
+                else:
+                    _effort_cfg = _cfg.get('agent', {}) if isinstance(_cfg, dict) else {}
+                    _effort_raw = _effort_cfg.get('reasoning_effort') if isinstance(_effort_cfg, dict) else None
+                    _reasoning_config = _parse_reff(_effort_raw)
             except Exception:
                 _reasoning_config = None
 

--- a/static/commands.js
+++ b/static/commands.js
@@ -29,7 +29,7 @@ const COMMANDS=[
   {name:'background',desc:t('cmd_background'),fn:cmdBackground,arg:'prompt',  noEcho:true},
   {name:'status',    desc:t('cmd_status'),   fn:cmdStatus},
   {name:'voice',     desc:t('cmd_voice'),    fn:cmdVoice,     noEcho:true},
-  {name:'reasoning', desc:t('cmd_reasoning'), fn:cmdReasoning, arg:'show|hide|none|minimal|low|medium|high|xhigh', subArgs:['show','hide','none','minimal','low','medium','high','xhigh'], noEcho:true},
+  {name:'reasoning', desc:t('cmd_reasoning'), fn:cmdReasoning, arg:'show|hide|none|minimal|low|medium|high|xhigh [session]', subArgs:['show','hide','none','minimal','low','medium','high','xhigh'], noEcho:true},
   {name:'yolo', desc:t('cmd_yolo'), fn:cmdYolo, noEcho:true},
   {name:'branch', desc:t('cmd_branch'), fn:cmdBranch, arg:'[name]', noEcho:true},
 ];
@@ -1128,16 +1128,24 @@ function cmdStatus(){
   renderMessages();
 }
 function cmdReasoning(args){
-  const arg=(args||'').trim().toLowerCase();
+  const raw=(args||'').trim();
   const BRAIN='\uD83E\uDDE0';
   // Matches hermes_constants.VALID_REASONING_EFFORTS + 'none' (CLI parity).
   const EFFORTS=['none','minimal','low','medium','high','xhigh'];
+  // #2697 \u2014 accept an optional 'session' qualifier as a second token:
+  //   /reasoning <effort>          --> profile default (writes config.yaml)
+  //   /reasoning <effort> session  --> session override (writes session sidecar)
+  // The arg parse keeps the no-token and show/hide branches unchanged.
+  const tokens=raw.toLowerCase().split(/\s+/).filter(Boolean);
+  const arg=tokens[0]||'';
+  const scopeToken=tokens[1]||'';
+  const wantSession=(scopeToken==='session');
   // Shared status renderer used by the no-args branch and as a fallback.
   function _fmtStatus(st){
     const vis=(st && st.show_reasoning===false)?'off':'on';
     const eff=(st && st.reasoning_effort)||'default';
     return BRAIN+' Reasoning effort: '+eff+' \u00B7 display: '+vis
-      +'  |  /reasoning show|hide|none|minimal|low|medium|high|xhigh';
+      +'  |  /reasoning show|hide|none|minimal|low|medium|high|xhigh [session]';
   }
   if(!arg){
     // Status — read from the same config.yaml keys the CLI uses.
@@ -1175,7 +1183,28 @@ function cmdReasoning(args){
       });
     return true;
   }
-  showToast('Unknown argument: '+arg+' \u2014 use show|hide|'+EFFORTS.join('|'));
+  if(scopeToken&&!wantSession){
+    showToast('Unknown scope: '+scopeToken+' \u2014 use "session" or omit for profile default');
+    return true;
+  }
+  if(wantSession&&EFFORTS.includes(arg)){
+    // #2697 \u2014 per-session override: writes the session sidecar, NOT
+    // config.yaml, so the profile default and CLI are unaffected.
+    const sid=S.session&&S.session.session_id;
+    if(!sid){showToast(t('no_active_session'));return true;}
+    api('/api/session/reasoning',{method:'POST',body:JSON.stringify({session_id:sid,effort:arg})})
+      .then(function(st){
+        const eff=(st && st.reasoning_effort)||arg;
+        if(S.session) S.session.reasoning_effort=eff;
+        showToast(BRAIN+' Reasoning effort: '+eff+' (session only)');
+        if(typeof _applyReasoningChip==='function') _applyReasoningChip(eff,eff);
+      })
+      .catch(function(e){
+        showToast(BRAIN+' Failed to set session effort: '+(e && e.message ? e.message : arg));
+      });
+    return true;
+  }
+  showToast('Unknown argument: '+arg+' \u2014 use show|hide|'+EFFORTS.join('|')+' [session]');
   return true;
 }
 function cmdVoice(){

--- a/static/index.html
+++ b/static/index.html
@@ -709,12 +709,22 @@
           <div class="profile-dropdown" id="profileDropdown"></div>
           <div class="ws-dropdown ws-dropdown-footer" id="composerWsDropdown"></div>
           <div class="composer-reasoning-dropdown" id="composerReasoningDropdown">
+            <!-- #2697 — scope picker: write target for the effort options below.
+                 'session' writes /api/session/reasoning (no profile change);
+                 'profile' writes /api/reasoning (config.yaml, CLI parity). -->
+            <div class="reasoning-scope-group" role="group" aria-label="Apply effort to">
+              <div class="reasoning-scope-option" data-scope="session">Set for this session only</div>
+              <div class="reasoning-scope-option" data-scope="profile">Set as profile default</div>
+            </div>
+            <div class="reasoning-scope-divider" aria-hidden="true"></div>
             <div class="reasoning-option" data-effort="none">None</div>
             <div class="reasoning-option" data-effort="minimal">Minimal</div>
             <div class="reasoning-option" data-effort="low">Low</div>
             <div class="reasoning-option" data-effort="medium">Medium</div>
             <div class="reasoning-option" data-effort="high">High</div>
             <div class="reasoning-option" data-effort="xhigh">Extra High</div>
+            <!-- Visible only when the current session has an override active. -->
+            <div class="reasoning-clear-override" id="reasoningClearOverride" style="display:none">Clear session override</div>
           </div>
           <div class="composer-toolsets-dropdown" id="composerToolsetsDropdown">
             <div class="toolsets-dropdown-desc" id="toolsetsDropdownDesc"></div>

--- a/static/style.css
+++ b/static/style.css
@@ -1449,6 +1449,21 @@
   .reasoning-option{padding:8px 14px;border-radius:6px;cursor:pointer;font-size:13px;color:var(--text);white-space:nowrap;transition:background-color .12s;}
   .reasoning-option:hover{background:rgba(255,255,255,.07);}
   .reasoning-option.selected{background:var(--accent-bg);}
+  /* #2697 — scope picker at the top of the reasoning dropdown. Two pill-styled
+     options ("Set for this session only" / "Set as profile default") that
+     toggle where the next effort click writes. */
+  .reasoning-scope-group{display:flex;gap:4px;padding:2px 2px 4px;}
+  .reasoning-scope-option{flex:1 1 0;padding:6px 8px;border-radius:6px;cursor:pointer;font-size:11px;color:var(--muted);white-space:nowrap;text-align:center;transition:background-color .12s,color .12s;}
+  .reasoning-scope-option:hover{background:rgba(255,255,255,.05);color:var(--text);}
+  .reasoning-scope-option.selected{background:var(--accent-bg);color:var(--text);}
+  .reasoning-scope-divider{height:1px;background:var(--border2);margin:2px 4px 4px;}
+  /* Subtle visual indicator that the chip is showing a session-scoped override
+     rather than the profile default — italic label + small leading dot. */
+  .composer-reasoning-chip.session-override .composer-reasoning-label{font-style:italic;}
+  .composer-reasoning-chip.session-override::before{content:"";display:inline-block;width:6px;height:6px;border-radius:50%;background:var(--accent);margin-right:2px;flex-shrink:0;}
+  .composer-mobile-config-action.session-override .composer-mobile-config-value{font-style:italic;}
+  .reasoning-clear-override{padding:8px 14px;margin-top:4px;border-top:1px solid var(--border2);border-radius:0 0 6px 6px;cursor:pointer;font-size:12px;color:var(--muted);white-space:nowrap;transition:background-color .12s,color .12s;}
+  .reasoning-clear-override:hover{background:rgba(255,255,255,.07);color:var(--text);}
   /* Toolsets chip — session-level toolset override (#493) */
   .composer-toolsets-wrap{display:none;}
   .composer-toolsets-chip{display:inline-flex;align-items:center;gap:8px;max-width:180px;padding:8px 10px 8px 12px;border-radius:999px;border:1px solid transparent;background-color:transparent;color:var(--muted);font-weight:500;cursor:pointer;transition:color .15s,background-color .15s,border-color .15s;}

--- a/static/ui.js
+++ b/static/ui.js
@@ -1629,6 +1629,13 @@ window.addEventListener('resize',()=>{
 
 // ── Reasoning effort chip ────────────────────────────────────────────────────
 let _currentReasoningEffort=null;
+// #2697 — when a session has its own override the chip shows that value AND
+// flags it visually (italic + dot). Null means "no override / inherit profile".
+let _currentReasoningSessionOverride=null;
+// Where the next effort click writes: 'session' (default when a session is
+// active) or 'profile' (writes config.yaml for CLI parity). Picked via the
+// scope buttons at the top of the dropdown.
+let _reasoningWriteScope='session';
 
 function _normalizeReasoningEffort(eff){
   return String(eff||'').trim().toLowerCase();
@@ -1640,9 +1647,16 @@ function _formatReasoningEffortLabel(effort){
   return effort;
 }
 
-function _applyReasoningChip(eff){
+function _applyReasoningChip(eff,sessionOverride){
   const effort=_normalizeReasoningEffort(eff);
-  _currentReasoningEffort=effort;
+  // The two module-scoped trackers are defensively assigned via typeof so that
+  // unit-test drivers which `eval` this function in isolation (extracting it
+  // from ui.js without the surrounding `let` declarations) don't ReferenceError
+  // on the outer-scope read. See tests/test_reasoning_chip_js_behaviour.py.
+  if(typeof _currentReasoningEffort!=='undefined') _currentReasoningEffort=effort;
+  if(sessionOverride!==undefined&&typeof _currentReasoningSessionOverride!=='undefined'){
+    _currentReasoningSessionOverride=sessionOverride?_normalizeReasoningEffort(sessionOverride):null;
+  }
   const wrap=$('composerReasoningWrap');
   const label=$('composerReasoningLabel');
   const chip=$('composerReasoningChip');
@@ -1654,24 +1668,55 @@ function _applyReasoningChip(eff){
   const text=_formatReasoningEffortLabel(effort);
   label.textContent=text;
   if(mobileLabel) mobileLabel.textContent=text;
+  const hasOverride=(typeof _currentReasoningSessionOverride!=='undefined')
+    ?!!_currentReasoningSessionOverride
+    :!!sessionOverride;
   if(chip){
     const inactive=!effort||effort==='none';
     chip.classList.toggle('inactive',inactive);
-    chip.title='Reasoning effort: '+text;
+    // session-override class drives the italic + dot indicator (style.css).
+    chip.classList.toggle('session-override',hasOverride);
+    chip.title=hasOverride
+      ?'Reasoning effort: '+text+' (session override; profile default unchanged)'
+      :'Reasoning effort: '+text;
   }
-  if(mobileAction) mobileAction.classList.toggle('inactive',!effort||effort==='none');
+  if(mobileAction){
+    mobileAction.classList.toggle('inactive',!effort||effort==='none');
+    mobileAction.classList.toggle('session-override',hasOverride);
+  }
   _highlightReasoningOption(effort);
+  if(typeof _syncReasoningScopeUI==='function') _syncReasoningScopeUI();
+}
+
+function _syncReasoningScopeUI(){
+  // Highlight the active scope button and toggle the "Clear session override"
+  // row's visibility based on whether the current session actually has one.
+  const dd=$('composerReasoningDropdown');
+  if(!dd) return;
+  dd.querySelectorAll('.reasoning-scope-option').forEach(function(opt){
+    opt.classList.toggle('selected',opt.dataset.scope===_reasoningWriteScope);
+  });
+  const clearRow=$('reasoningClearOverride');
+  if(clearRow){
+    clearRow.style.display=_currentReasoningSessionOverride?'':'none';
+  }
 }
 
 function fetchReasoningChip(){
+  // #2697 — prefer the session-scoped value when a session is loaded. The
+  // profile default is the fallback (matches streaming.py resolution order).
+  const sid=(typeof S!=='undefined'&&S&&S.session&&S.session.session_id)||null;
+  const sessionOverride=sid&&S.session?_normalizeReasoningEffort(S.session.reasoning_effort||''):'';
   api('/api/reasoning').then(function(st){
-    _applyReasoningChip((st&&st.reasoning_effort)||'');
-  }).catch(function(){_applyReasoningChip('');});
+    const profileEffort=(st&&st.reasoning_effort)||'';
+    const effective=sessionOverride||profileEffort;
+    _applyReasoningChip(effective,sessionOverride||null);
+  }).catch(function(){_applyReasoningChip(sessionOverride||'',sessionOverride||null);});
 }
 
 function syncReasoningChip(){
   if(_currentReasoningEffort===null){fetchReasoningChip();return;}
-  _applyReasoningChip(_currentReasoningEffort);
+  _applyReasoningChip(_currentReasoningEffort,_currentReasoningSessionOverride);
 }
 
 function _highlightReasoningOption(effort){
@@ -1731,18 +1776,60 @@ document.addEventListener('click',function(e){
     !e.target.closest('#composerMobileReasoningAction') &&
     !e.target.closest('#composerReasoningDropdown')
   ) closeReasoningDropdown();
+  // #2697 — scope picker (session-only vs profile-default). Clicking a scope
+  // option does NOT write yet; it just sets where the NEXT effort click goes.
+  const scopeOpt=e.target.closest('.reasoning-scope-option');
+  if(scopeOpt){
+    const scope=scopeOpt.dataset.scope;
+    if(scope==='session'||scope==='profile'){
+      _reasoningWriteScope=scope;
+      _syncReasoningScopeUI();
+    }
+    return;
+  }
+  // #2697 — clear session override row (only visible when one is set).
+  if(e.target.closest('#reasoningClearOverride')){
+    const sid=(typeof S!=='undefined'&&S&&S.session&&S.session.session_id)||null;
+    if(!sid){showToast(t('no_active_session'));closeReasoningDropdown();return;}
+    api('/api/session/reasoning',{method:'POST',body:JSON.stringify({session_id:sid,effort:null})})
+      .then(function(){
+        if(S.session) S.session.reasoning_effort=null;
+        fetchReasoningChip();
+        showToast('🧠 Session reasoning override cleared');
+      })
+      .catch(function(){showToast('🧠 Failed to clear session override');});
+    closeReasoningDropdown();
+    return;
+  }
   if(e.target.closest('.reasoning-option')){
     const opt=e.target.closest('.reasoning-option');
     const effort=opt&&opt.dataset.effort;
-    if(effort){
+    if(!effort){closeReasoningDropdown();return;}
+    const sid=(typeof S!=='undefined'&&S&&S.session&&S.session.session_id)||null;
+    // Session scope requires an active session — fall back to profile-default
+    // write rather than silently failing when none is loaded.
+    if(_reasoningWriteScope==='session'&&sid){
+      api('/api/session/reasoning',{method:'POST',body:JSON.stringify({session_id:sid,effort:effort})})
+        .then(function(st){
+          const override=(st&&st.reasoning_effort)||effort;
+          if(S.session) S.session.reasoning_effort=override;
+          _applyReasoningChip(override,override);
+          showToast('🧠 Reasoning effort set to '+override+' (session only)');
+        })
+        .catch(function(){showToast('🧠 Failed to set session effort');});
+    }else{
       api('/api/reasoning',{method:'POST',body:JSON.stringify({effort:effort})})
         .then(function(st){
-          _applyReasoningChip((st&&st.reasoning_effort)||effort);
-          showToast('🧠 Reasoning effort set to '+((st&&st.reasoning_effort)||effort));
+          const profileEffort=(st&&st.reasoning_effort)||effort;
+          // Profile write does not change the session override; keep showing
+          // it if one is set, otherwise the new profile default takes over.
+          const effective=_currentReasoningSessionOverride||profileEffort;
+          _applyReasoningChip(effective,_currentReasoningSessionOverride);
+          showToast('🧠 Reasoning effort set to '+profileEffort+' (profile default)');
         })
         .catch(function(){showToast('🧠 Failed to set effort');});
-      closeReasoningDropdown();
     }
+    closeReasoningDropdown();
   }
 });
 

--- a/tests/test_2697_per_session_reasoning_effort.py
+++ b/tests/test_2697_per_session_reasoning_effort.py
@@ -1,0 +1,250 @@
+"""Regression coverage for #2697 — per-session reasoning effort override.
+
+Three layers under test (matching the issue's spec):
+
+1. **Session storage** — `Session.reasoning_effort` round-trips through the
+   sidecar JSON. None means "inherit profile default" (the pre-PR behaviour).
+
+2. **Resolve-at-stream-start precedence** — `api/streaming.py` honours
+   `session.reasoning_effort` over the profile's
+   `agent.reasoning_effort` from `config.yaml`. Static assertion on the
+   resolve block in `streaming.py` so the precedence cannot silently regress.
+
+3. **Slash command + UI** — `cmdReasoning()` accepts an optional `session`
+   qualifier and posts to `/api/session/reasoning`; the chip dropdown has
+   two scope options and a clear-override row; the chip carries a
+   `session-override` class for the visual indicator (italic + dot).
+
+Run only the model-level test cleanly without the live test server; the
+text-based tests just grep the source for the invariants we want locked in
+(same pattern as `test_reasoning_show_hide.py` and `test_reasoning_chip_btw_fixes.py`).
+"""
+from __future__ import annotations
+
+import pathlib
+
+from api.models import SESSION_DIR, Session
+
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+
+# Ensure the sessions directory exists for the model round-trip tests. The
+# webui server normally creates this on startup; running tests as a plain
+# pytest invocation may race or skip the creation.
+SESSION_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def _read(rel: str) -> str:
+    return (REPO / rel).read_text(encoding="utf-8")
+
+
+# ── Layer 1: session storage round-trip ─────────────────────────────────────
+
+
+class TestSessionReasoningEffortRoundTrip:
+    """Session.reasoning_effort persists across save/load."""
+
+    def test_default_is_none(self):
+        s = Session(session_id="r2697aa")
+        assert s.reasoning_effort is None, (
+            "default reasoning_effort must be None so profile default applies"
+        )
+
+    def test_explicit_value_is_normalised(self):
+        s = Session(session_id="r2697ab", reasoning_effort="HIGH")
+        assert s.reasoning_effort == "high", (
+            "reasoning_effort should be lowercased on construction"
+        )
+
+    def test_empty_string_is_treated_as_none(self):
+        s = Session(session_id="r2697ac", reasoning_effort="")
+        assert s.reasoning_effort is None, (
+            "empty/whitespace reasoning_effort must coerce to None (inherit)"
+        )
+
+    def test_save_and_reload_preserves_override(self):
+        sid = "r2697ad"
+        s = Session(session_id=sid, reasoning_effort="medium")
+        s.save()
+        try:
+            reloaded = Session.load(sid)
+            assert reloaded is not None
+            assert reloaded.reasoning_effort == "medium", (
+                "session sidecar must round-trip reasoning_effort"
+            )
+        finally:
+            # Clean up the temp file the test wrote.
+            try:
+                s.path.unlink()
+            except FileNotFoundError:
+                pass
+
+    def test_clear_override_persists_as_none(self):
+        sid = "r2697ae"
+        s = Session(session_id=sid, reasoning_effort="high")
+        s.save()
+        try:
+            reloaded = Session.load(sid)
+            assert reloaded.reasoning_effort == "high"
+            reloaded.reasoning_effort = None
+            reloaded.save()
+            reloaded2 = Session.load(sid)
+            assert reloaded2.reasoning_effort is None, (
+                "clearing the override must persist as None so the next stream "
+                "falls back to the profile default"
+            )
+        finally:
+            try:
+                s.path.unlink()
+            except FileNotFoundError:
+                pass
+
+    def test_compact_payload_emits_reasoning_effort(self):
+        """The UI reads `session.reasoning_effort` via the compact payload."""
+        s = Session(session_id="r2697af", reasoning_effort="low")
+        payload = s.compact()
+        assert "reasoning_effort" in payload, (
+            "compact() must include reasoning_effort so the UI can sync the chip"
+        )
+        assert payload["reasoning_effort"] == "low"
+
+
+# ── Layer 2: streaming.py honours session-overrides-profile precedence ──────
+
+
+class TestStreamingResolvesSessionOverFirst:
+    """The reasoning_config build in api/streaming.py must prefer
+    session.reasoning_effort when set, falling back to the profile's
+    agent.reasoning_effort only when the session has none.
+    """
+
+    SRC = _read("api/streaming.py")
+
+    def test_session_override_branch_exists(self):
+        assert "_session_effort = getattr(s, 'reasoning_effort', None)" in self.SRC, (
+            "streaming.py must read the session-level override before the "
+            "profile default — see #2697"
+        )
+
+    def test_session_override_takes_precedence_over_profile_default(self):
+        # The branch order matters: session-effort first, profile second.
+        idx_session = self.SRC.find("_session_effort")
+        idx_profile = self.SRC.find(
+            "_effort_cfg.get('reasoning_effort')"
+        )
+        assert 0 < idx_session < idx_profile, (
+            "session-override read must appear BEFORE the profile-default read "
+            "so the override wins when both are present"
+        )
+
+    def test_parse_reasoning_effort_handles_session_value(self):
+        # The session value is parsed via the same parse_reasoning_effort
+        # helper as the profile value, so 'none' / valid efforts route the
+        # same way and unknown values silently become None.
+        assert "_reasoning_config = _parse_reff(_session_effort)" in self.SRC
+
+
+# ── Layer 3a: routes.py exposes /api/session/reasoning ──────────────────────
+
+
+class TestSessionReasoningRoute:
+    SRC = _read("api/routes.py")
+
+    def test_endpoint_registered(self):
+        assert 'parsed.path == "/api/session/reasoning"' in self.SRC, (
+            "routes.py must expose /api/session/reasoning for the UI to write"
+        )
+
+    def test_endpoint_validates_effort(self):
+        # Unknown effort levels must 400 rather than silently writing garbage
+        # to the sidecar (matches the profile-default route's behaviour).
+        assert "VALID_REASONING_EFFORTS" in self.SRC, (
+            "/api/session/reasoning must validate effort against the canonical "
+            "set, same as /api/reasoning"
+        )
+
+    def test_endpoint_accepts_null_to_clear_override(self):
+        # The endpoint must accept a null/empty effort and write None so the
+        # session falls back to the profile default on the next stream.
+        block_start = self.SRC.find('parsed.path == "/api/session/reasoning"')
+        assert block_start != -1
+        block = self.SRC[block_start:block_start + 2500]
+        assert "effort = None" in block, (
+            "/api/session/reasoning must accept null/empty effort to clear "
+            "the override and inherit the profile default"
+        )
+
+    def test_duplicate_session_carries_reasoning_effort_forward(self):
+        # Per maintainer Q2 — duplicate session should carry the override.
+        block_start = self.SRC.find('parsed.path == "/api/session/duplicate"')
+        assert block_start != -1
+        block = self.SRC[block_start:block_start + 4000]
+        assert 'reasoning_effort=getattr(session, "reasoning_effort", None)' in block, (
+            "/api/session/duplicate must carry the per-session override "
+            "forward (maintainer's Q2 on #2697)"
+        )
+
+
+# ── Layer 3b: slash command + dropdown UI ───────────────────────────────────
+
+
+class TestSlashCommandSessionVariant:
+    COMMANDS_JS = _read("static/commands.js")
+
+    def test_session_token_parsed(self):
+        assert "const wantSession=(scopeToken==='session');" in self.COMMANDS_JS, (
+            "cmdReasoning must parse a 'session' second token to scope the write"
+        )
+
+    def test_session_branch_posts_to_session_endpoint(self):
+        assert "'/api/session/reasoning'" in self.COMMANDS_JS, (
+            "the session-scoped branch must post to /api/session/reasoning"
+        )
+
+    def test_unknown_scope_token_is_rejected(self):
+        assert "Unknown scope: " in self.COMMANDS_JS, (
+            "an unrecognised second token (e.g. /reasoning high foo) must surface "
+            "an error rather than silently treating it as a profile write"
+        )
+
+    def test_command_arg_string_mentions_session(self):
+        # Autocomplete should hint at the new qualifier without breaking the
+        # existing subArgs list (which still surfaces the effort levels).
+        assert "[session]" in self.COMMANDS_JS, (
+            "COMMANDS entry for /reasoning must hint at the optional [session] qualifier"
+        )
+
+
+class TestDropdownScopePicker:
+    INDEX = _read("static/index.html")
+    UI_JS = _read("static/ui.js")
+    STYLE_CSS = _read("static/style.css")
+
+    def test_dropdown_has_two_scope_options(self):
+        assert 'data-scope="session"' in self.INDEX
+        assert 'data-scope="profile"' in self.INDEX
+        assert "Set for this session only" in self.INDEX
+        assert "Set as profile default" in self.INDEX
+
+    def test_dropdown_has_clear_override_row(self):
+        assert 'id="reasoningClearOverride"' in self.INDEX
+        assert "Clear session override" in self.INDEX
+
+    def test_ui_js_tracks_write_scope_state(self):
+        assert "_reasoningWriteScope='session'" in self.UI_JS, (
+            "ui.js must default the write scope to 'session' so a click on an "
+            "effort writes the override (not the profile default) when a session "
+            "is active"
+        )
+
+    def test_chip_carries_session_override_class(self):
+        assert "session-override" in self.UI_JS, (
+            "the chip must toggle a session-override CSS class so the indicator "
+            "(italic + dot) reflects an active override"
+        )
+
+    def test_css_indicator_styles_present(self):
+        assert ".composer-reasoning-chip.session-override" in self.STYLE_CSS, (
+            "CSS must define a session-override style (italic + leading dot) "
+            "for the indicator"
+        )

--- a/tests/test_mobile_layout.py
+++ b/tests/test_mobile_layout.py
@@ -1049,7 +1049,11 @@ def test_mobile_config_panel_escape_closes_panel_and_dropdowns():
 def test_reasoning_chip_updates_desktop_and_mobile_controls():
     """Reasoning chip sync should keep both footer and mobile overflow labels current."""
     ui_js = (REPO / "static" / "ui.js").read_text(encoding="utf-8")
-    chip_start = ui_js.index("function _applyReasoningChip(eff)")
+    # #2697 added a second `sessionOverride` argument; the slice marker uses a
+    # signature-agnostic prefix so future signature changes don't break the test
+    # without removing the invariants it actually asserts on (mobile + desktop
+    # label sync via `label.textContent=text` and `mobileLabel.textContent=text`).
+    chip_start = ui_js.index("function _applyReasoningChip(")
     chip_end = ui_js.index("function fetchReasoningChip()", chip_start)
     chip_body = ui_js[chip_start:chip_end]
     for expected in (

--- a/tests/test_reasoning_chip_btw_fixes.py
+++ b/tests/test_reasoning_chip_btw_fixes.py
@@ -72,9 +72,12 @@ class TestReasoningDropdownEscapesComposerLeft:
         ]
         for name, pos in positions:
             assert pos > -1, f"{name} not found in index.html"
-        # They should all be in the same area of the document — within ~1.5 KB
+        # They should all be in the same area of the document — within ~3 KB
+        # (the reasoning dropdown grew when the per-session scope picker landed
+        # in #2697; the structural invariant — siblings, not nested inside
+        # composer-left's overflow-hidden — is still enforced by the test above).
         window = [p for _, p in positions]
-        assert max(window) - min(window) < 2000, (
+        assert max(window) - min(window) < 3000, (
             "composer dropdowns are no longer grouped — reasoning dropdown may "
             "have drifted back inside a nested container"
         )


### PR DESCRIPTION
## Thinking Path

The CLI's `/reasoning <level>` writes to `agent.reasoning_effort` in the active profile's `config.yaml`. The WebUI followed the same shape: the chip and the slash command both mutated the profile default. That's the right primitive for "set my baseline" but the wrong one for "this one session needs deeper thinking, the rest don't" — switching profile-wide for a single conversation forces the user to remember to switch back.

Followed the 3-layer split from the issue thread:

1. **Storage** — add `reasoning_effort` to the `Session` dataclass and to `METADATA_FIELDS` so it round-trips through the sidecar JSON. `None` means "inherit profile default" (the pre-PR behaviour, preserved end-to-end).
2. **Resolution** — at stream construction in `api/streaming.py`, prefer `session.reasoning_effort` over `agent.reasoning_effort`. The same `parse_reasoning_effort()` helper parses both, so 'none'/'minimal'/.../'xhigh' route identically and unknown values silently become `None` (no behavioural drift between the two layers).
3. **Surfaces** — chip dropdown gets a two-button scope picker ("Set for this session only" / "Set as profile default") at the top, the `/reasoning` slash command accepts an optional `session` qualifier, and the chip carries a `.session-override` class for the visual indicator (italic label + small leading accent dot). Maintainer's Q2 answered by carrying the override forward on `/api/session/duplicate`; Q3 by writing to the session sidecar (not a memory cache).

The existing `/api/reasoning` endpoint is untouched — it still writes `config.yaml` for CLI parity. The new `/api/session/reasoning` endpoint writes only the session sidecar and validates effort against `api.config.VALID_REASONING_EFFORTS`. Null/empty effort clears the override and lets the next stream fall back to the profile default.

## What Changed

**Backend (Python)**

- `api/models.py` — `Session.reasoning_effort: Optional[str]` (None = inherit profile default). Added to `METADATA_FIELDS` for sidecar persistence and to `compact()` so the UI can sync the chip from session state.
- `api/streaming.py` — resolve block now reads `s.reasoning_effort` first and falls back to `_cfg['agent']['reasoning_effort']` when the session has no override. Same `parse_reasoning_effort()` helper for both branches; same `_reasoning_config = None` fallback when neither is set.
- `api/routes.py` — new `POST /api/session/reasoning` endpoint, validates effort against the canonical set, accepts `null`/empty to clear the override. `/api/session/duplicate` carries `reasoning_effort` forward so the copy behaves identically.

**Frontend (JS/HTML/CSS)**

- `static/index.html` — dropdown gains a `.reasoning-scope-group` (two buttons), a divider, and a `#reasoningClearOverride` row that is display-toggled by JS based on whether the current session has an override.
- `static/ui.js` — `_currentReasoningSessionOverride` + `_reasoningWriteScope` trackers, `_applyReasoningChip(eff, sessionOverride)` extended to set the `.session-override` class, `_syncReasoningScopeUI()` reflects active scope + clear-override row visibility, click handler routes to `/api/session/reasoning` or `/api/reasoning` based on scope.
- `static/commands.js` — `cmdReasoning` parses an optional `session` second token and routes the request through the session endpoint when present. Existing `/reasoning <effort>` and `/reasoning show|hide` calls are unchanged.
- `static/style.css` — `.reasoning-scope-option` (+ `.selected`), divider, clear-override row, and `.composer-reasoning-chip.session-override` (italic label + leading accent dot). Indicator is also applied to the mobile-config action so the override is visible from the mobile composer.

**Tests** — new `tests/test_2697_per_session_reasoning_effort.py` with 22 tests covering all three layers (storage round-trip, streaming precedence, route validation, duplicate-session carry-forward, slash-command parse, dropdown markup, CSS indicator, clear-override flow).

The existing `test_reasoning_chip_btw_fixes.py` "dropdowns grouped within 2 KB" check was bumped to 3 KB because the new scope picker + clear-override rows added ~380 bytes to the same dropdown container; the structural invariant the test really enforces (sibling of `composer-footer`, not nested inside `composer-left`'s overflow-hidden) is unchanged and still asserted by the sibling test above it.

## Why It Matters

Two concrete pain points the issue captures:

- Bumping reasoning depth for one tricky session without polluting the profile default (or forgetting to switch it back).
- Keeping the CLI surface unchanged — a user who lives in `hermes` at the terminal still gets the same `agent.reasoning_effort` they always had.

The override is per-session, so duplicating a session keeps the override (maintainer's Q2) and clearing it via the dropdown's clear-override row returns the session to the profile default with no `config.yaml` write at all.

## Verification

`pytest tests/test_2697_per_session_reasoning_effort.py` on Windows 11 against Python 3.11. `--noconftest` is used because the repo's session conftest tries to create a Windows symlink that requires `SeCreateSymbolicLinkPrivilege` (pre-existing Windows-only issue, also affects the existing `test_reasoning_show_hide.py` and similar; unrelated to this PR).

```
collected 22 items

tests/test_2697_per_session_reasoning_effort.py::TestSessionReasoningEffortRoundTrip::test_default_is_none PASSED [  4%]
tests/test_2697_per_session_reasoning_effort.py::TestSessionReasoningEffortRoundTrip::test_explicit_value_is_normalised PASSED [  9%]
tests/test_2697_per_session_reasoning_effort.py::TestSessionReasoningEffortRoundTrip::test_empty_string_is_treated_as_none PASSED [ 13%]
tests/test_2697_per_session_reasoning_effort.py::TestSessionReasoningEffortRoundTrip::test_save_and_reload_preserves_override PASSED [ 18%]
tests/test_2697_per_session_reasoning_effort.py::TestSessionReasoningEffortRoundTrip::test_clear_override_persists_as_none PASSED [ 22%]
tests/test_2697_per_session_reasoning_effort.py::TestSessionReasoningEffortRoundTrip::test_compact_payload_emits_reasoning_effort PASSED [ 27%]
tests/test_2697_per_session_reasoning_effort.py::TestStreamingResolvesSessionOverFirst::test_session_override_branch_exists PASSED [ 31%]
tests/test_2697_per_session_reasoning_effort.py::TestStreamingResolvesSessionOverFirst::test_session_override_takes_precedence_over_profile_default PASSED [ 36%]
tests/test_2697_per_session_reasoning_effort.py::TestStreamingResolvesSessionOverFirst::test_parse_reasoning_effort_handles_session_value PASSED [ 40%]
tests/test_2697_per_session_reasoning_effort.py::TestSessionReasoningRoute::test_endpoint_registered PASSED [ 45%]
tests/test_2697_per_session_reasoning_effort.py::TestSessionReasoningRoute::test_endpoint_validates_effort PASSED [ 50%]
tests/test_2697_per_session_reasoning_effort.py::TestSessionReasoningRoute::test_endpoint_accepts_null_to_clear_override PASSED [ 54%]
tests/test_2697_per_session_reasoning_effort.py::TestSessionReasoningRoute::test_duplicate_session_carries_reasoning_effort_forward PASSED [ 59%]
tests/test_2697_per_session_reasoning_effort.py::TestSlashCommandSessionVariant::test_session_token_parsed PASSED [ 63%]
tests/test_2697_per_session_reasoning_effort.py::TestSlashCommandSessionVariant::test_session_branch_posts_to_session_endpoint PASSED [ 68%]
tests/test_2697_per_session_reasoning_effort.py::TestSlashCommandSessionVariant::test_unknown_scope_token_is_rejected PASSED [ 72%]
tests/test_2697_per_session_reasoning_effort.py::TestSlashCommandSessionVariant::test_command_arg_string_mentions_session PASSED [ 77%]
tests/test_2697_per_session_reasoning_effort.py::TestDropdownScopePicker::test_dropdown_has_two_scope_options PASSED [ 81%]
tests/test_2697_per_session_reasoning_effort.py::TestDropdownScopePicker::test_dropdown_has_clear_override_row PASSED [ 86%]
tests/test_2697_per_session_reasoning_effort.py::TestDropdownScopePicker::test_ui_js_tracks_write_scope_state PASSED [ 90%]
tests/test_2697_per_session_reasoning_effort.py::TestDropdownScopePicker::test_chip_carries_session_override_class PASSED [ 95%]
tests/test_2697_per_session_reasoning_effort.py::TestDropdownScopePicker::test_css_indicator_styles_present PASSED [100%]

======================== 22 passed, 1 warning in 1.51s ========================
```

Adjacent suites re-run to confirm no regressions:

- `tests/test_reasoning_show_hide.py` — 28 passed
- `tests/test_reasoning_chip_btw_fixes.py` — 17 passed (1 threshold bumped 2 KB -> 3 KB; same invariant)
- `tests/test_reasoning_chip_js_behaviour.py` — 11 passed
- `tests/test_issue1103_reasoning_chip_visibility.py` — 4 passed, 3 pre-existing Windows-cp1252 (master too)
- `tests/test_465_session_branching.py`, `tests/test_session_duplicate.py`, `tests/test_issue1431_toolsets_chip_responsive.py` — identical pass/fail counts on master and this branch (Windows-only env failures, unrelated).

`node --check` clean on `static/commands.js` and `static/ui.js`. `ruff check` on the four touched Python files: zero new findings (the 77 pre-existing issues in `api/streaming.py` are master-side).

What is verified vs. what is NOT:

- VERIFIED on Windows 11 + Python 3.11: storage round-trip, streaming precedence block presence + ordering, route handler shape, slash-command parse, dropdown markup, CSS rules.
- NOT verified end-to-end against a live broker: I did not boot the WebUI server and click through the dropdown. The static + harness tests pin the invariants the issue's spec calls out, but a real-browser screenshot pass on a Linux/macOS dev machine would be a useful follow-up if you want it.

## Risks

- **Storage migration.** Pre-existing session sidecars don't have `reasoning_effort` in their JSON. `Session.__init__` accepts the kwarg with a `None` default and the load path passes `**data` through, so old sidecars load with `reasoning_effort=None` (= inherit profile default, i.e. exactly the v0.51.137- behaviour). Once a session has been saved under this PR the field appears in the JSON; rolling back would simply see an unknown kwarg on `Session.__init__` (which `**kwargs` absorbs today, but worth noting).
- **Scope picker UX.** The default scope when the dropdown opens is `session` so a single-click on an effort writes the override (not the profile default). For a user who only ever wants the profile-write path this is one extra click. The slash command keeps the old default (`/reasoning high` -> profile) and the chip's behaviour is discoverable via the visible scope buttons, so the discoverability cost is low.
- **No new auth surface.** The endpoint trusts the session-id lookup; per-session authorisation is the same as the existing `/api/session/toolsets` and `/api/session/draft` shapes.
- **Dropdown markup grew ~380 bytes.** The grouped-dropdowns test was bumped from `<2000` to `<3000` bytes for the spread. The structural guarantee (dropdown is a sibling of `composer-footer`, not nested in `composer-left`) is still enforced by the test above it.

## Model Used

claude-opus-4-7 (1M context) via Claude Code, directed by a human contributor. Final review + adversarial pass + commit message + PR body authored on the contributor's machine; all `gh search prs`/`gh search issues` pre-flight dup-checks performed before filing.

### AI Usage Disclosure

This PR's code, tests, and PR body were drafted with substantial AI assistance (Claude Opus 4.7, via Claude Code). A human contributor read, ran, and reviewed the diff before commit and is responsible for the contents. Three pre-flight items per the contributor's checklist:

- `gh search prs --repo nesquena/hermes-webui "per-session reasoning effort" --state all` — no canonical fix in flight.
- `gh search issues --repo nesquena/hermes-webui "session reasoning_effort"` — #2697 is the live issue this PR closes.