### PR TITLE
feat: add prev/next navigation to image lightbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Added
 
-- Image lightbox now supports prev/next navigation when multiple images are present in the same message. Click `‹` / `›` buttons or use `←` / `→` keyboard arrows to browse; an image counter (`1 / 5`) is shown at the bottom. (#PR)
+- Image lightbox now supports prev/next navigation when multiple images are present in the same message. Click `‹` / `›` buttons or use `←` / `→` keyboard arrows to browse; an image counter (`1 / 5`) is shown at the bottom. (#2967)
 
 ## [v0.51.137] — 2026-05-25 — Release DI (stage-batch19 — 6-PR medium-risk batch)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Image lightbox now supports prev/next navigation when multiple images are present in the same message. Click `‹` / `›` buttons or use `←` / `→` keyboard arrows to browse; an image counter (`1 / 5`) is shown at the bottom. (#PR)
+
 ## [v0.51.137] — 2026-05-25 — Release DI (stage-batch19 — 6-PR medium-risk batch)
 
 ### Added

--- a/static/style.css
+++ b/static/style.css
@@ -334,6 +334,8 @@
   /* Image lightbox close */
   :root[data-skin="nous"] .img-lightbox-close:hover{background:rgba(70,130,180,.4);}
   :root.dark[data-skin="nous"] .img-lightbox-close:hover{background:rgba(70,130,180,.4);}
+  :root[data-skin="nous"] .img-lightbox-nav:hover{background:rgba(70,130,180,.5);}
+  :root.dark[data-skin="nous"] .img-lightbox-nav:hover{background:rgba(70,130,180,.5);}
   /* Diff blocks */
   :root[data-skin="nous"] .diff-block .diff-plus{color:#4682B4;}
   :root.dark[data-skin="nous"] .diff-block .diff-plus{color:#7EB6E0;}
@@ -1323,6 +1325,11 @@
   .img-lightbox img{max-width:90vw;max-height:90vh;object-fit:contain;border-radius:8px;box-shadow:0 8px 48px rgba(0,0,0,.6);cursor:default;}
   .img-lightbox-close{position:absolute;top:16px;right:20px;width:36px;height:36px;border:none;border-radius:50%;background:rgba(255,255,255,.12);color:#fff;font-size:20px;cursor:pointer;display:flex;align-items:center;justify-content:center;transition:background .15s;}
   .img-lightbox-close:hover{background:rgba(255,255,255,.22);}
+  .img-lightbox-nav{position:absolute;top:50%;transform:translateY(-50%);width:44px;height:44px;border:none;border-radius:50%;background:rgba(255,255,255,.12);color:#fff;font-size:28px;cursor:pointer;display:flex;align-items:center;justify-content:center;transition:background .15s,opacity .15s;z-index:1;opacity:.6;}
+  .img-lightbox-nav:hover{background:rgba(255,255,255,.28);opacity:1;}
+  .img-lightbox-nav-prev{left:16px;}
+  .img-lightbox-nav-next{right:16px;}
+  .img-lightbox-counter{position:absolute;bottom:20px;left:50%;transform:translateX(-50%);background:rgba(0,0,0,.5);color:#fff;font-size:14px;padding:4px 14px;border-radius:12px;pointer-events:none;}
   .msg-media-link{display:inline-flex;align-items:center;gap:5px;background:var(--accent-bg);border:1px solid var(--accent-bg-strong);border-radius:6px;padding:4px 10px;font-size:13px;color:var(--accent-text);text-decoration:none;}
   .msg-media-link:hover{background:var(--accent-bg-strong);}
 

--- a/static/style.css
+++ b/static/style.css
@@ -331,7 +331,7 @@
   :root.dark[data-skin="nous"] .session-child-count:hover{background:rgba(99,179,237,.26);color:#7EB6E0;}
   :root.dark[data-skin="nous"] .session-tree-badge{background:rgba(99,179,237,.2);color:#4682B4;}
   :root.dark[data-skin="nous"] .session-tag{background:rgba(99,179,237,.2);color:#4682B4;}
-  /* Image lightbox close */
+  /* Image lightbox */
   :root[data-skin="nous"] .img-lightbox-close:hover{background:rgba(70,130,180,.4);}
   :root.dark[data-skin="nous"] .img-lightbox-close:hover{background:rgba(70,130,180,.4);}
   :root[data-skin="nous"] .img-lightbox-nav:hover{background:rgba(70,130,180,.5);}

--- a/static/ui.js
+++ b/static/ui.js
@@ -507,7 +507,7 @@ function _openImgLightbox(imgEl) {
   // opens a single-image lightbox (no navigation between staged uploads).
   let allImages = [];
   let startIndex = 0;
-  if(!imgEl.closest('.attach-tray, #composerAttach')){
+  if(!imgEl.closest('.attach-tray')){
     let container = imgEl.closest('.msg-row, .assistant-turn-blocks, .assistant-turn, .user-turn');
     if(!container) container = imgEl.parentElement;
     if(container){

--- a/static/ui.js
+++ b/static/ui.js
@@ -537,13 +537,11 @@ function _openImgLightboxWithNav(src, alt, images, index) {
   cls.onclick = () => _closeImgLightbox(lb);
   lb.appendChild(img);
   lb.appendChild(cls);
-  // Prev/Next navigation — store index on lb so a single set of handlers
-  // reads the live value without closure churn on every nav.
-  const hasNav = images && images.length>1;
+  // Prev/Next navigation — store index and images on lb so a single set of
+  // handlers reads live values without closure churn on every nav.
   lb._navIndex = index;
-  lb._navImages = hasNav ? images : null;
-  let counter = null;
-  if(hasNav){
+  lb._navImages = (images && images.length>1) ? images : null;
+  if(lb._navImages){
     const prevBtn = document.createElement('button');
     prevBtn.className = 'img-lightbox-nav img-lightbox-nav-prev';
     prevBtn.setAttribute('aria-label', 'Previous image');
@@ -556,22 +554,22 @@ function _openImgLightboxWithNav(src, alt, images, index) {
     nextBtn.innerHTML = '›';
     nextBtn.onclick = e => { e.stopPropagation(); _navigateLightbox(lb, 1); };
     lb.appendChild(nextBtn);
-    counter = document.createElement('div');
-    counter.className = 'img-lightbox-counter';
-    lb.appendChild(counter);
-    _updateLightboxCounter(counter, index, images.length);
+    lb._counterEl = document.createElement('div');
+    lb._counterEl.className = 'img-lightbox-counter';
+    lb.appendChild(lb._counterEl);
+    lb._counterEl.textContent = (index+1) + ' / ' + images.length;
   }
   lb.onclick = () => _closeImgLightbox(lb);
   document.body.appendChild(lb);
-  // One keyboard handler, reads lb._navIndex live — no remove/add churn.
-  lb._escHandler = e => {
+  // Single keyboard handler — reads lb._navX live, no remove/add churn.
+  lb._keyHandler = e => {
     if(e.key==='Escape'){ _closeImgLightbox(lb); return; }
-    if(hasNav){
+    if(lb._navImages){
       if(e.key==='ArrowLeft'){ e.preventDefault(); _navigateLightbox(lb, -1); }
       if(e.key==='ArrowRight'){ e.preventDefault(); _navigateLightbox(lb, 1); }
     }
   };
-  document.addEventListener('keydown', lb._escHandler);
+  document.addEventListener('keydown', lb._keyHandler);
 }
 function _navigateLightbox(lb, direction) {
   const images = lb._navImages;
@@ -581,19 +579,16 @@ function _navigateLightbox(lb, direction) {
   lb._navIndex = newIndex;
   const nextImg = images[newIndex];
   const lbImg = lb.querySelector('img');
+  if(!lbImg) return;
   lbImg.src = nextImg.src;
   lbImg.alt = nextImg.alt || '';
   lb.setAttribute('aria-label', nextImg.alt || 'Image');
-  // Update counter
-  const counter = lb.querySelector('.img-lightbox-counter');
-  if(counter) _updateLightboxCounter(counter, newIndex, images.length);
-}
-function _updateLightboxCounter(el, index, total) {
-  el.textContent = (index+1) + ' / ' + total;
+  // Update counter via stored reference — no DOM query.
+  if(lb._counterEl) lb._counterEl.textContent = (newIndex+1) + ' / ' + images.length;
 }
 function _closeImgLightbox(lb) {
   if(!lb || !lb.parentNode) return;
-  document.removeEventListener('keydown', lb._escHandler);
+  document.removeEventListener('keydown', lb._keyHandler);
   lb.style.animation = 'lb-in .12s ease reverse';
   setTimeout(() => lb.parentNode && lb.parentNode.removeChild(lb), 120);
 }

--- a/static/ui.js
+++ b/static/ui.js
@@ -498,28 +498,25 @@ if(document.readyState==='complete'){
 
 /* ── Image lightbox — click any .msg-media-img to enlarge ─────────────────── */
 function _openImgLightbox(imgEl) {
-  // Backward-compat: if called with (src, alt) from cached old code, convert.
-  if(typeof imgEl==='string'){
-    const src=imgEl, alt=arguments[1]||'';
-    const oldEl=document.querySelector(`.img-lightbox[aria-label="${esc(alt||'Image')}"]`);
-    _openImgLightboxWithNav(src, alt, [], 0);
-    return;
-  }
   if(!imgEl || !imgEl.src) return;
   const src=imgEl.src, alt=imgEl.alt||'';
   // Find sibling images in the same message for prev/next navigation.
   // Walk up from the clicked image to find the message container, then
   // collect all .msg-media-img within it.
+  // Composer attach-tray chips bypass sibling detection — each chip click
+  // opens a single-image lightbox (no navigation between staged uploads).
   let allImages = [];
   let startIndex = 0;
-  let container = imgEl.closest('.msg-row, .assistant-turn-blocks, .assistant-turn, .user-turn');
-  if(!container) container = imgEl.parentElement;
-  if(container){
-    const siblings = container.querySelectorAll('.msg-media-img');
-    if(siblings.length>1){
-      allImages = Array.from(siblings);
-      startIndex = allImages.indexOf(imgEl);
-      if(startIndex===-1) startIndex=0;
+  if(!imgEl.closest('.attach-tray, #composerAttach')){
+    let container = imgEl.closest('.msg-row, .assistant-turn-blocks, .assistant-turn, .user-turn');
+    if(!container) container = imgEl.parentElement;
+    if(container){
+      const siblings = container.querySelectorAll('.msg-media-img');
+      if(siblings.length>1){
+        allImages = Array.from(siblings);
+        startIndex = allImages.indexOf(imgEl);
+        if(startIndex===-1) startIndex=0;
+      }
     }
   }
   _openImgLightboxWithNav(src, alt, allImages, startIndex);
@@ -540,21 +537,24 @@ function _openImgLightboxWithNav(src, alt, images, index) {
   cls.onclick = () => _closeImgLightbox(lb);
   lb.appendChild(img);
   lb.appendChild(cls);
-  // Prev/Next navigation
+  // Prev/Next navigation — store index on lb so a single set of handlers
+  // reads the live value without closure churn on every nav.
   const hasNav = images && images.length>1;
+  lb._navIndex = index;
+  lb._navImages = hasNav ? images : null;
   let counter = null;
   if(hasNav){
     const prevBtn = document.createElement('button');
     prevBtn.className = 'img-lightbox-nav img-lightbox-nav-prev';
     prevBtn.setAttribute('aria-label', 'Previous image');
     prevBtn.innerHTML = '‹';
-    prevBtn.onclick = e => { e.stopPropagation(); _navigateLightbox(lb, images, index, -1); };
+    prevBtn.onclick = e => { e.stopPropagation(); _navigateLightbox(lb, -1); };
     lb.appendChild(prevBtn);
     const nextBtn = document.createElement('button');
     nextBtn.className = 'img-lightbox-nav img-lightbox-nav-next';
     nextBtn.setAttribute('aria-label', 'Next image');
     nextBtn.innerHTML = '›';
-    nextBtn.onclick = e => { e.stopPropagation(); _navigateLightbox(lb, images, index, 1); };
+    nextBtn.onclick = e => { e.stopPropagation(); _navigateLightbox(lb, 1); };
     lb.appendChild(nextBtn);
     counter = document.createElement('div');
     counter.className = 'img-lightbox-counter';
@@ -563,40 +563,30 @@ function _openImgLightboxWithNav(src, alt, images, index) {
   }
   lb.onclick = () => _closeImgLightbox(lb);
   document.body.appendChild(lb);
-  // Keyboard navigation + close
+  // One keyboard handler, reads lb._navIndex live — no remove/add churn.
   lb._escHandler = e => {
     if(e.key==='Escape'){ _closeImgLightbox(lb); return; }
     if(hasNav){
-      if(e.key==='ArrowLeft'){ e.preventDefault(); _navigateLightbox(lb, images, index, -1); }
-      if(e.key==='ArrowRight'){ e.preventDefault(); _navigateLightbox(lb, images, index, 1); }
+      if(e.key==='ArrowLeft'){ e.preventDefault(); _navigateLightbox(lb, -1); }
+      if(e.key==='ArrowRight'){ e.preventDefault(); _navigateLightbox(lb, 1); }
     }
   };
   document.addEventListener('keydown', lb._escHandler);
 }
-function _navigateLightbox(lb, images, currentIndex, direction) {
-  const newIndex = currentIndex + direction;
+function _navigateLightbox(lb, direction) {
+  const images = lb._navImages;
+  if(!images) return;
+  const newIndex = lb._navIndex + direction;
   if(newIndex<0 || newIndex>=images.length) return;
+  lb._navIndex = newIndex;
   const nextImg = images[newIndex];
   const lbImg = lb.querySelector('img');
   lbImg.src = nextImg.src;
   lbImg.alt = nextImg.alt || '';
   lb.setAttribute('aria-label', nextImg.alt || 'Image');
-  // Update navigation onclick handlers by replacing them
-  const prevBtn = lb.querySelector('.img-lightbox-nav-prev');
-  const nextBtn = lb.querySelector('.img-lightbox-nav-next');
-  if(prevBtn) prevBtn.onclick = e => { e.stopPropagation(); _navigateLightbox(lb, images, newIndex, -1); };
-  if(nextBtn) nextBtn.onclick = e => { e.stopPropagation(); _navigateLightbox(lb, images, newIndex, 1); };
   // Update counter
   const counter = lb.querySelector('.img-lightbox-counter');
   if(counter) _updateLightboxCounter(counter, newIndex, images.length);
-  // Rebind keyboard handler
-  document.removeEventListener('keydown', lb._escHandler);
-  lb._escHandler = e => {
-    if(e.key==='Escape'){ _closeImgLightbox(lb); return; }
-    if(e.key==='ArrowLeft'){ e.preventDefault(); _navigateLightbox(lb, images, newIndex, -1); }
-    if(e.key==='ArrowRight'){ e.preventDefault(); _navigateLightbox(lb, images, newIndex, 1); }
-  };
-  document.addEventListener('keydown', lb._escHandler);
 }
 function _updateLightboxCounter(el, index, total) {
   el.textContent = (index+1) + ' / ' + total;

--- a/static/ui.js
+++ b/static/ui.js
@@ -497,7 +497,34 @@ if(document.readyState==='complete'){
 }
 
 /* ── Image lightbox — click any .msg-media-img to enlarge ─────────────────── */
-function _openImgLightbox(src, alt) {
+function _openImgLightbox(imgEl) {
+  // Backward-compat: if called with (src, alt) from cached old code, convert.
+  if(typeof imgEl==='string'){
+    const src=imgEl, alt=arguments[1]||'';
+    const oldEl=document.querySelector(`.img-lightbox[aria-label="${esc(alt||'Image')}"]`);
+    _openImgLightboxWithNav(src, alt, [], 0);
+    return;
+  }
+  if(!imgEl || !imgEl.src) return;
+  const src=imgEl.src, alt=imgEl.alt||'';
+  // Find sibling images in the same message for prev/next navigation.
+  // Walk up from the clicked image to find the message container, then
+  // collect all .msg-media-img within it.
+  let allImages = [];
+  let startIndex = 0;
+  let container = imgEl.closest('.msg-row, .assistant-turn-blocks, .assistant-turn, .user-turn');
+  if(!container) container = imgEl.parentElement;
+  if(container){
+    const siblings = container.querySelectorAll('.msg-media-img');
+    if(siblings.length>1){
+      allImages = Array.from(siblings);
+      startIndex = allImages.indexOf(imgEl);
+      if(startIndex===-1) startIndex=0;
+    }
+  }
+  _openImgLightboxWithNav(src, alt, allImages, startIndex);
+}
+function _openImgLightboxWithNav(src, alt, images, index) {
   const lb = document.createElement('div');
   lb.className = 'img-lightbox';
   lb.setAttribute('role', 'dialog');
@@ -513,11 +540,66 @@ function _openImgLightbox(src, alt) {
   cls.onclick = () => _closeImgLightbox(lb);
   lb.appendChild(img);
   lb.appendChild(cls);
+  // Prev/Next navigation
+  const hasNav = images && images.length>1;
+  let counter = null;
+  if(hasNav){
+    const prevBtn = document.createElement('button');
+    prevBtn.className = 'img-lightbox-nav img-lightbox-nav-prev';
+    prevBtn.setAttribute('aria-label', 'Previous image');
+    prevBtn.innerHTML = '‹';
+    prevBtn.onclick = e => { e.stopPropagation(); _navigateLightbox(lb, images, index, -1); };
+    lb.appendChild(prevBtn);
+    const nextBtn = document.createElement('button');
+    nextBtn.className = 'img-lightbox-nav img-lightbox-nav-next';
+    nextBtn.setAttribute('aria-label', 'Next image');
+    nextBtn.innerHTML = '›';
+    nextBtn.onclick = e => { e.stopPropagation(); _navigateLightbox(lb, images, index, 1); };
+    lb.appendChild(nextBtn);
+    counter = document.createElement('div');
+    counter.className = 'img-lightbox-counter';
+    lb.appendChild(counter);
+    _updateLightboxCounter(counter, index, images.length);
+  }
   lb.onclick = () => _closeImgLightbox(lb);
   document.body.appendChild(lb);
-  // Close on Escape
-  lb._escHandler = e => { if(e.key==='Escape') _closeImgLightbox(lb); };
+  // Keyboard navigation + close
+  lb._escHandler = e => {
+    if(e.key==='Escape'){ _closeImgLightbox(lb); return; }
+    if(hasNav){
+      if(e.key==='ArrowLeft'){ e.preventDefault(); _navigateLightbox(lb, images, index, -1); }
+      if(e.key==='ArrowRight'){ e.preventDefault(); _navigateLightbox(lb, images, index, 1); }
+    }
+  };
   document.addEventListener('keydown', lb._escHandler);
+}
+function _navigateLightbox(lb, images, currentIndex, direction) {
+  const newIndex = currentIndex + direction;
+  if(newIndex<0 || newIndex>=images.length) return;
+  const nextImg = images[newIndex];
+  const lbImg = lb.querySelector('img');
+  lbImg.src = nextImg.src;
+  lbImg.alt = nextImg.alt || '';
+  lb.setAttribute('aria-label', nextImg.alt || 'Image');
+  // Update navigation onclick handlers by replacing them
+  const prevBtn = lb.querySelector('.img-lightbox-nav-prev');
+  const nextBtn = lb.querySelector('.img-lightbox-nav-next');
+  if(prevBtn) prevBtn.onclick = e => { e.stopPropagation(); _navigateLightbox(lb, images, newIndex, -1); };
+  if(nextBtn) nextBtn.onclick = e => { e.stopPropagation(); _navigateLightbox(lb, images, newIndex, 1); };
+  // Update counter
+  const counter = lb.querySelector('.img-lightbox-counter');
+  if(counter) _updateLightboxCounter(counter, newIndex, images.length);
+  // Rebind keyboard handler
+  document.removeEventListener('keydown', lb._escHandler);
+  lb._escHandler = e => {
+    if(e.key==='Escape'){ _closeImgLightbox(lb); return; }
+    if(e.key==='ArrowLeft'){ e.preventDefault(); _navigateLightbox(lb, images, newIndex, -1); }
+    if(e.key==='ArrowRight'){ e.preventDefault(); _navigateLightbox(lb, images, newIndex, 1); }
+  };
+  document.addEventListener('keydown', lb._escHandler);
+}
+function _updateLightboxCounter(el, index, total) {
+  el.textContent = (index+1) + ' / ' + total;
 }
 function _closeImgLightbox(lb) {
   if(!lb || !lb.parentNode) return;
@@ -530,14 +612,14 @@ document.addEventListener('click', e => {
   if(!e.target || !e.target.closest) return;
   // Message-attached images (already wired since v0.50.x).
   let img = e.target.closest('.msg-media-img');
-  if(img){ _openImgLightbox(img.src, img.alt); return; }
+  if(img){ _openImgLightbox(img); return; }
   // Composer attach-tray image thumbnails — click any pasted/dropped image
   // chip to lightbox-zoom it before sending. Excludes audio/video chips,
   // which keep their inline media controls. SVG thumbnails (.attach-thumb--svg)
   // are still images visually, so they qualify.
   img = e.target.closest('.attach-thumb');
   if(img && img.tagName === 'IMG'){
-    _openImgLightbox(img.src, img.alt || img.title || 'Attached image');
+    _openImgLightbox(img);
     return;
   }
 });

--- a/tests/test_composer_chip_lightbox.py
+++ b/tests/test_composer_chip_lightbox.py
@@ -46,7 +46,7 @@ class TestComposerChipLightboxDelegate:
         src = UI.read_text(encoding="utf-8")
         # The message-image branch must come first (so _openImgLightbox
         # fires for them without falling through to the .attach-thumb check).
-        msg_branch = "let img = e.target.closest('.msg-media-img');\n  if(img){ _openImgLightbox(img.src, img.alt); return; }"
+        msg_branch = "let img = e.target.closest('.msg-media-img');\n  if(img){ _openImgLightbox(img); return; }"
         assert msg_branch in src
 
     def test_delegate_excludes_audio_video_chips(self):


### PR DESCRIPTION
### Summary

When multiple images are present in the same message, the image lightbox now supports browsing through them with prev/next buttons and keyboard shortcuts.

### Changes

- **`_openImgLightbox`**: now accepts the clicked `<img>` element directly to find sibling images within the same message container
- **`_openImgLightboxWithNav`**: new function that builds the lightbox with optional navigation
- **`_navigateLightbox`**: new function for switching images
- **`_updateLightboxCounter`**: new function to display counter
- **CSS**: added `.img-lightbox-nav`, `.img-lightbox-counter` with `nous` skin adaptation
- **Test**: updated assertion for new function signature

### UX

| Interaction | Behavior |
|-------------|----------|
| Click prev/next buttons | Navigate to previous / next image |
| Keyboard arrow keys | Navigate while lightbox is open |
| Esc / click outside / close button | Close lightbox (unchanged) |
| Single image message | No nav buttons (unchanged) |