### PR TITLE
docs(runtime): define runner client backend gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- **PR #2972** by @Michaelyklam (refs #1925) — Advance the runtime-adapter RFC after the Slice 4e route-selection harness shipped in v0.51.129. The RFC now defines the Slice 4f supervised local runner client backend gate: replace the bounded `runner-local` 501 only when explicitly configured, prove restart/reattach from durable runner/journal state, preserve the public chat-start field whitelist, require cancel as the first live runner-owned control, and keep active-run discovery/supervision out of new WebUI process-local runtime-surrogate globals.
+
 ## [v0.51.137] — 2026-05-25 — Release DI (stage-batch19 — 6-PR medium-risk batch)
 
 ### Added

--- a/docs/rfcs/hermes-run-adapter-contract.md
+++ b/docs/rfcs/hermes-run-adapter-contract.md
@@ -905,6 +905,12 @@ Non-goals for Slice 4d:
 
 #### Slice 4e: Default-off runner chat-start route-selection harness
 
+Status as of 2026-05-24: shipped in v0.51.129 via #2794. The route-selection
+harness now makes adapter mode selection explicit: `legacy-direct` remains the
+default, `legacy-journal` still delegates to the existing journaled legacy path,
+and `runner-local` returns a bounded not-configured response instead of silently
+starting an in-process legacy run.
+
 The first implementation after the Slice 4d gate should wire the
 `/api/chat/start` selection point to the existing `RuntimeAdapter` factory
 without adding a supervised runner process yet. The harness must make the
@@ -947,6 +953,65 @@ Non-goals for Slice 4e:
 - no execution-survives-WebUI-restart claim for production chat turns;
 - no removal of `legacy-direct` or `legacy-journal`;
 - no server-side queue endpoint or queue scheduler just for adapter symmetry.
+
+#### Slice 4f: Supervised local runner client backend gate
+
+After the route-selection harness ships, the next reviewable step is not to make
+`runner-local` the default. It is to define the first concrete supervised/local
+runner client backend that can replace the bounded 501 path under the existing
+feature flag and prove execution ownership has moved out of the main WebUI
+request process.
+
+This slice is a contract gate before backend code lands. The goal is to pin the
+minimum runner client behavior so the implementation cannot become a renamed
+`STREAMS` / `CANCEL_FLAGS` / cached `AIAgent` surrogate inside `api/routes.py`.
+
+Scope:
+
+- define the runner client process boundary and lifecycle: how `start_run`
+  spawns or hands off work, how the child is supervised, and how terminal state
+  is recorded without a main-process active-run dictionary;
+- require a durable runner-owned run id plus session-to-run lookup that a freshly
+  restarted WebUI process can discover without consulting old `STREAMS` entries;
+- require ordered event replay through the existing journal/cursor surface, so
+  token, reasoning, progress, tool, usage, error, and done events render through
+  the same browser path as legacy replay;
+- define cancel as the first required live control for active runner-owned runs,
+  with approval, clarify, goal, and queue either mapped to explicit runner
+  capabilities or returned as bounded unsupported/conflict `ControlResult`
+  values;
+- keep profile, workspace, attachments, provider/model, toolset, source, and
+  metadata as explicit payload fields at the runner boundary rather than
+  depending on process-global WebUI environment mutation.
+
+Acceptance tests for Slice 4f:
+
+1. **501 path replaced only when configured.** Unset adapter mode and
+   `legacy-journal` behavior stay unchanged; `runner-local` uses the supervised
+   runner client only when the backend is explicitly configured.
+2. **Restart/reattach proves ownership moved.** Start a runner-owned run,
+   discard/restart the WebUI server process, rediscover the active or terminal
+   run from durable runner/journal state, replay from cursor without duplicates,
+   and preserve cancel if the run is still active.
+3. **No runtime-surrogate globals.** The main WebUI server does not gain new
+   module-level maps for runner-owned streams, cancel flags, approval/clarify
+   callbacks, cached agents, goal state, queue schedulers, or child-process run
+   registries. Supervision state belongs to the runner client/backend boundary.
+4. **Stable browser contracts.** Successful chat-start responses remain limited
+   to the legacy-compatible field whitelist unless a later contract revision
+   explicitly exposes `run_id`, `status`, or `active_controls`.
+5. **Bounded control gaps.** Unsupported runner controls return safe
+   `unsupported`, `not-active`, or `conflict` results; they must not fall back to
+   legacy callback queues for a runner-owned run.
+
+Non-goals for Slice 4f:
+
+- no default-on runner mode;
+- no removal of the legacy in-process backends;
+- no broad WebUI product-surface migration;
+- no server-side queue scheduler just for adapter symmetry;
+- no permanent WebUI-owned active-run discovery cache that duplicates runner or
+  future Hermes Runtime API responsibility.
 
 ## First Meaningful Success Criteria
 

--- a/tests/test_runtime_adapter_seam.py
+++ b/tests/test_runtime_adapter_seam.py
@@ -558,6 +558,7 @@ def test_rfc_defines_slice4e_runner_chat_start_route_selection_harness():
     rfc = (routes.Path(__file__).parent.parent / "docs" / "rfcs" / "hermes-run-adapter-contract.md").read_text(encoding="utf-8")
 
     assert "#### Slice 4e: Default-off runner chat-start route-selection harness" in rfc
+    assert "Status as of 2026-05-24: shipped in v0.51.129 via #2794" in rfc
     assert "route `/api/chat/start` through `build_runtime_adapter(...)`" in rfc
     assert "`legacy-direct` stays default" in rfc
     assert "`legacy-journal`\ncontinues to delegate to the legacy in-process stream path" in rfc
@@ -565,6 +566,22 @@ def test_rfc_defines_slice4e_runner_chat_start_route_selection_harness():
     assert "return a bounded not-configured error for `runner-local`" in rfc
     assert "`run_id`, `status`, and\n   `active_controls` remain internal" in rfc
     assert "no supervised runner process yet" in rfc
+
+
+def test_rfc_defines_slice4f_supervised_local_runner_client_gate():
+    routes = importlib.import_module("api.routes")
+    rfc = (routes.Path(__file__).parent.parent / "docs" / "rfcs" / "hermes-run-adapter-contract.md").read_text(encoding="utf-8")
+
+    assert "#### Slice 4f: Supervised local runner client backend gate" in rfc
+    assert "replace the bounded 501 path under the existing\nfeature flag" in rfc
+    assert "durable runner-owned run id plus session-to-run lookup" in rfc
+    assert "cancel as the first required live control" in rfc
+    assert "501 path replaced only when configured" in rfc
+    assert "Restart/reattach proves ownership moved" in rfc
+    assert "No runtime-surrogate globals" in rfc
+    assert "Successful chat-start responses remain limited\n   to the legacy-compatible field whitelist" in rfc
+    assert "Unsupported runner controls return safe\n   `unsupported`, `not-active`, or `conflict` results" in rfc
+    assert "no permanent WebUI-owned active-run discovery cache" in rfc
 
 def test_runner_runtime_adapter_passes_explicit_start_payload_without_env_mutation(monkeypatch):
     runtime = importlib.import_module("api.runtime_adapter")


### PR DESCRIPTION
## Thinking Path

- #1925 has already shipped the journal/replay baseline, RuntimeAdapter seam, control routing, RunnerRuntimeAdapter facade, `runner-local` selection, and the default-off `/api/chat/start` route-selection harness.
- PR #2794 shipped in v0.51.129, so `runner-local` now fails closed with a bounded not-configured response rather than silently falling back to WebUI-owned execution.
- The next risky step is replacing that bounded 501 with a supervised/local runner client backend.
- Before code lands, the RFC should pin the gate: how the runner owns execution/lifecycle, how restart/reattach proves ownership moved, which controls are required, and which WebUI-owned runtime-surrogate state remains prohibited.

## What Changed

- Marked Slice 4e as shipped in the runtime-adapter RFC.
- Added a new Slice 4f gate for the supervised local runner client backend.
- Scoped Slice 4f around explicit runner configuration, durable runner-owned run/session lookup, journal/cursor replay, cancel as the first required live control, stable browser response contracts, and bounded unsupported-control behavior.
- Added a source-level regression test that keeps the Slice 4f gate text present in `docs/rfcs/hermes-run-adapter-contract.md`.
- Added an Unreleased changelog entry.

## Why It Matters

This keeps the #1925 ladder moving without jumping straight from route-selection plumbing to a runner implementation. The key guardrail stays intact: WebUI should be thin in execution ownership, not thin in product scope, and the runner boundary should not recreate `STREAMS`, `CANCEL_FLAGS`, cached `AIAgent`, approval/clarify callback queues, or active-run discovery caches under new names.

Refs #1925.

## Verification

- `env -u HERMES_CONFIG_PATH -u HERMES_WEBUI_HOST /home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_runtime_adapter_seam.py -q` → `30 passed`
- `env -u HERMES_CONFIG_PATH -u HERMES_WEBUI_HOST /home/michael/.hermes/hermes-agent/venv/bin/python -m pytest tests/ -q` → `6587 passed, 6 skipped, 3 xpassed, 8 subtests passed`
- `git diff --check` → clean

## Risks / Follow-ups

- Docs/test-only; no runtime behavior changes.
- This does not add the supervised runner client/backend yet, does not enable runner mode by default, and does not claim production execution survives WebUI restart.
- If accepted, the next implementation slice can replace the current `runner-local` bounded 501 path only when a supervised runner client is explicitly configured.

## Model Used

OpenAI Codex / GPT-5.5 via Hermes Agent, with terminal/file tools and repository tests.
