### PR TITLE
fix: update opencode-go base_url + clean up test_issue1894 provider overlap tests

### DIFF
--- a/tests/test_issue1894_provider_overlap.py
+++ b/tests/test_issue1894_provider_overlap.py
@@ -1,8 +1,6 @@
 # Copyright 2025 the Hermes WebUI contributors
 # SPDX-License-Identifier: MIT
 
-# noqa: N801
-
 # Regression tests for GitHub issue #1894.
 #
 # Symptom: when the WebUI's configured provider (e.g. `opencode-go`) and a
@@ -44,15 +42,14 @@ def _restore_config(cfg_module, old_model, old_custom):
         cfg_module.cfg['custom_providers'] = old_custom
 
 
-# ---------------------------------------------------------------------------
-# Case 1 — overlap: selected non-custom provider should win
-# ---------------------------------------------------------------------------
-
 def test_selected_opencode_go_wins_over_custom_provider_overlap():
-    # opencode-go and a custom DeepSeek-compatible endpoint both serve
-    # deepseek-v4-pro.  With opencode-go configured as the active provider,
-    # selection of deepseek-v4-pro must route to opencode-go, not to the
-    # custom endpoint.
+    """Case 1 — overlap: selected non-custom provider should win.
+
+    OpenCode Go and a custom DeepSeek-compatible endpoint both serve
+    deepseek-v4-pro. With opencode-go configured as the active provider,
+    selection of deepseek-v4-pro must route to opencode-go, not to the
+    custom endpoint.
+    """
     import api.config as cfg_mod
     old_model, old_custom = _apply_config_overrides(cfg_mod, {
         'base_url': 'https://opencode.ai/zen/go/v1',
@@ -80,8 +77,11 @@ def test_selected_opencode_go_wins_over_custom_provider_overlap():
 
 
 def test_selected_opencode_go_wins_direct_resolve():
-    # Same scenario but bypassing model_with_provider_context to test the
-    # resolver path directly with a bare model id.
+    """Case 1 variant — same overlap scenario via direct resolve path.
+
+    Bypasses model_with_provider_context to test the resolver path directly
+    with a bare model id.
+    """
     import api.config as cfg_mod
     old_model, old_custom = _apply_config_overrides(cfg_mod, {
         'base_url': 'https://opencode.ai/zen/go/v1',
@@ -106,8 +106,11 @@ def test_selected_opencode_go_wins_direct_resolve():
 # ---------------------------------------------------------------------------
 
 def test_custom_only_model_still_routes_to_custom_provider():
-    # A model that exists only in a custom provider must still be routed
-    # correctly when no explicit provider prefix is given.
+    """Case 2 — custom-only model routing must stay intact.
+
+    A model that exists only in a custom provider must still be routed
+    correctly when no explicit provider prefix is given.
+    """
     import api.config as cfg_mod
     old_model, old_custom = _apply_config_overrides(cfg_mod, {
         'base_url': 'https://opencode.ai/zen/go/v1',
@@ -132,7 +135,10 @@ def test_custom_only_model_still_routes_to_custom_provider():
 # ---------------------------------------------------------------------------
 
 def test_explicit_custom_provider_selection_intact():
-    # @custom:<name>:<model> syntax must not be swallowed by the new guard.
+    """Case 3 — explicit custom provider selection still works.
+
+    The @custom:<name>:<model> syntax must not be swallowed by the new guard.
+    """
     model, provider, base_url = resolve_model_provider('@custom:ds2api:deepseek-v4-pro')
     assert provider == 'custom:ds2api', f'Expected provider=custom:ds2api, got {provider!r}'
     assert model == 'deepseek-v4-pro'
@@ -143,6 +149,11 @@ def test_explicit_custom_provider_selection_intact():
 # ---------------------------------------------------------------------------
 
 def test_openrouter_suffix_still_works():
+    """Case 4 — existing suffix syntax is preserved.
+
+    Ensures the openrouter suffix syntax (e.g. model_name:free) still routes
+    correctly through model_with_provider_context.
+    """
     import api.config as cfg_mod
     old_model, old_custom = _apply_config_overrides(cfg_mod, {
         'provider': 'anthropic',          # non-openrouter so prefix is needed

--- a/tests/test_issue1894_provider_overlap.py
+++ b/tests/test_issue1894_provider_overlap.py
@@ -1,21 +1,22 @@
 # Copyright 2025 the Hermes WebUI contributors
 # SPDX-License-Identifier: MIT
 
-# Regression tests for GitHub issue #1894.
-#
-# Symptom: when the WebUI's configured provider (e.g. `opencode-go`) and a
-# `custom_providers[]` entry both expose the same bare model id (e.g.
-# `deepseek-v4-pro`), the resolver was routing to `custom:<name>` instead of
-# the configured `opencode-go` endpoint.
-#
-# Root cause: `resolve_model_provider()` in `api/config.py` guarded the custom-
-# provider skip only when `model_id == model.default`.  If `model.default`
-# was a different model (e.g. `glm-5.1`), the overlap was not detected and
-# `deepseek-v4-pro` was matched against `custom_providers[]` first, routing
-# the WebUI to the wrong endpoint.
-#
-# Fix: widen the guard so an explicit non-custom provider wins for any model
-# it owns in `_PROVIDER_MODELS[config_provider]`.
+"""Regression tests for GitHub issue #1894.
+
+Symptom: when the WebUI's configured provider (e.g. ``opencode-go``) and a
+``custom_providers[]`` entry both expose the same bare model id (e.g.
+``deepseek-v4-pro``), the resolver was routing to ``custom:<name>`` instead of
+the configured ``opencode-go`` endpoint.
+
+Root cause: ``resolve_model_provider()`` in ``api/config.py`` guarded the
+custom-provider skip only when ``model_id == model.default``. If
+``model.default`` was a different model (e.g. ``glm-5.1``), the overlap was
+not detected and ``deepseek-v4-pro`` was matched against
+``custom_providers[]`` first, routing the WebUI to the wrong endpoint.
+
+Fix: widen the guard so an explicit non-custom provider wins for any model
+it owns in ``_PROVIDER_MODELS[config_provider]``.
+"""
 
 from api.config import resolve_model_provider, model_with_provider_context
 
@@ -101,10 +102,6 @@ def test_selected_opencode_go_wins_direct_resolve():
         _restore_config(cfg_mod, old_model, old_custom)
 
 
-# ---------------------------------------------------------------------------
-# Case 2 — custom-only model: custom provider routing must stay intact
-# ---------------------------------------------------------------------------
-
 def test_custom_only_model_still_routes_to_custom_provider():
     """Case 2 — custom-only model routing must stay intact.
 
@@ -130,10 +127,6 @@ def test_custom_only_model_still_routes_to_custom_provider():
         _restore_config(cfg_mod, old_model, old_custom)
 
 
-# ---------------------------------------------------------------------------
-# Case 3 — explicit custom provider selection still works
-# ---------------------------------------------------------------------------
-
 def test_explicit_custom_provider_selection_intact():
     """Case 3 — explicit custom provider selection still works.
 
@@ -143,10 +136,6 @@ def test_explicit_custom_provider_selection_intact():
     assert provider == 'custom:ds2api', f'Expected provider=custom:ds2api, got {provider!r}'
     assert model == 'deepseek-v4-pro'
 
-
-# ---------------------------------------------------------------------------
-# Case 4 — existing suffix syntax is preserved
-# ---------------------------------------------------------------------------
 
 def test_openrouter_suffix_still_works():
     """Case 4 — existing suffix syntax is preserved.

--- a/tests/test_issue1894_provider_overlap.py
+++ b/tests/test_issue1894_provider_overlap.py
@@ -55,7 +55,7 @@ def test_selected_opencode_go_wins_over_custom_provider_overlap():
     # custom endpoint.
     import api.config as cfg_mod
     old_model, old_custom = _apply_config_overrides(cfg_mod, {
-        'base_url': 'https://api.opencode.ai/go/v1',
+        'base_url': 'https://opencode.ai/zen/go/v1',
     })
     cfg_mod.cfg['custom_providers'] = [{
         'name': 'ds2api',
@@ -71,7 +71,7 @@ def test_selected_opencode_go_wins_over_custom_provider_overlap():
             f'Expected provider=opencode-go, got provider={provider!r}. '
             f'WebUI was routed to custom provider instead.'
         )
-        assert base_url == 'https://api.opencode.ai/go/v1', (
+        assert base_url == 'https://opencode.ai/zen/go/v1', (
             f'Expected base_url from opencode-go config, got {base_url!r}'
         )
         assert model == 'deepseek-v4-pro'
@@ -84,7 +84,7 @@ def test_selected_opencode_go_wins_direct_resolve():
     # resolver path directly with a bare model id.
     import api.config as cfg_mod
     old_model, old_custom = _apply_config_overrides(cfg_mod, {
-        'base_url': 'https://api.opencode.ai/go/v1',
+        'base_url': 'https://opencode.ai/zen/go/v1',
     })
     cfg_mod.cfg['custom_providers'] = [{
         'name': 'ds2api',
@@ -96,7 +96,7 @@ def test_selected_opencode_go_wins_direct_resolve():
         assert provider == 'opencode-go', (
             f'Expected provider=opencode-go, got provider={provider!r}'
         )
-        assert base_url == 'https://api.opencode.ai/go/v1'
+        assert base_url == 'https://opencode.ai/zen/go/v1'
     finally:
         _restore_config(cfg_mod, old_model, old_custom)
 
@@ -110,7 +110,7 @@ def test_custom_only_model_still_routes_to_custom_provider():
     # correctly when no explicit provider prefix is given.
     import api.config as cfg_mod
     old_model, old_custom = _apply_config_overrides(cfg_mod, {
-        'base_url': 'https://api.opencode.ai/go/v1',
+        'base_url': 'https://opencode.ai/zen/go/v1',
     })
     cfg_mod.cfg['custom_providers'] = [{
         'name': 'ds2api',


### PR DESCRIPTION
## Summary

Three commits cleaning up `tests/test_issue1894_provider_overlap.py`:

### 1. Canonicalize opencode-go base_url in tests
`api.opencode.ai/go/v1` → `opencode.ai/zen/go/v1` — the canonical URL per `hermes_cli/auth.py:406`. The upstream source code (`api/config.py`) already uses the correct URL; this synchronizes the test assertions to match.

### 2. Remove vestigial `# noqa: N801` + add docstrings
- File has zero classes — the `noqa: N801` suppression was leftover cruft with no purpose
- Converted inline `# comments` above each of the 5 test functions into proper `"""docstrings"""` for discoverability via `pytest --doc` and standard tooling
- Converted the module-level `# description` block into a `"""module docstring"""`

### 3. Consistent section separators
Remaining `# ---` section separators that were left behind during the docstring conversion are now removed — all 4 test groups are uniformly formatted.

## Verification

```
5 passed, 1 warning in 2.78s
```

- `pytest tests/test_issue1894_provider_overlap.py` — all 5 pass
- `ruff check` — clean, no violations
- `python3 -m py_compile` — syntax OK