### PR TITLE
fix: recover mobile reloads after compression rotation

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -2000,6 +2000,10 @@ def _lookup_cli_session_metadata(session_id: str) -> dict:
 
 
 def _messaging_session_identity(session: dict, raw_source: str) -> str:
+    sid = _safe_first(session.get("session_id"))
+    if sid and _is_pre_compression_continuation_row(session):
+        return f"{raw_source}|session_id:{sid}"
+
     metadata = _lookup_gateway_session_identity(session.get("session_id"))
     session_key = _safe_first(
         metadata.get("session_key"),
@@ -2034,7 +2038,27 @@ def _messaging_session_identity(session: dict, raw_source: str) -> str:
 
     if identity_parts:
         return f"{raw_source}|" + "|".join(identity_parts)
+
     return raw_source
+
+
+def _is_pre_compression_snapshot_id(session_id: str) -> bool:
+    sid = _safe_first(session_id)
+    if not sid or not all(c in "0123456789abcdefghijklmnopqrstuvwxyz_" for c in sid):
+        return False
+    try:
+        path = SESSION_DIR / f"{sid}.json"
+        if not path.exists():
+            return False
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return bool(data.get("pre_compression_snapshot"))
+    except Exception:
+        return False
+
+
+def _is_pre_compression_continuation_row(session: dict) -> bool:
+    parent_sid = _safe_first(session.get("parent_session_id"))
+    return bool(parent_sid and _is_pre_compression_snapshot_id(parent_sid))
 
 
 def _session_messaging_raw_source(session: dict) -> str:
@@ -2098,9 +2122,14 @@ def _should_hide_stale_messaging_session(
         return True
 
     if not _has_durable_messaging_identity(session):
+        if _is_pre_compression_continuation_row(session):
+            return False
+        parent_sid = _safe_first(session.get("parent_session_id"))
+        if parent_sid and parent_sid in active_gateway_session_ids:
+            return True
         return True
 
-    if session.get("parent_session_id"):
+    if session.get("parent_session_id") and not _is_pre_compression_continuation_row(session):
         return True
 
     message_count = _numeric_count(session.get("message_count"))
@@ -2462,6 +2491,91 @@ from api.models import (
     ensure_cron_project,
     is_cron_session,
 )
+
+
+def _pre_compression_continuation_session_id(session) -> str | None:
+    """Return the newest visible descendant for a hidden compression snapshot.
+
+    Mobile browsers can miss the final SSE `done` handoff while backgrounded.
+    On reload they may request the archived pre-compression session id from the
+    stale URL/localStorage. The old snapshot is intentionally hidden from the
+    sidebar, so expose a lightweight recovery hint when a child continuation
+    exists either in memory or on disk. Follow bounded snapshot-to-snapshot hops
+    so repeated compression still lands on the latest visible continuation.
+    """
+    if not getattr(session, "pre_compression_snapshot", False):
+        return None
+    sid = _safe_first(getattr(session, "session_id", None))
+    if not sid:
+        return None
+
+    def _child_rows() -> list:
+        rows = []
+        seen_ids = set()
+        try:
+            with LOCK:
+                memory_sessions = list(SESSIONS.values())
+            for child in memory_sessions:
+                child_sid = _safe_first(getattr(child, "session_id", None))
+                if not child_sid or child_sid in seen_ids:
+                    continue
+                seen_ids.add(child_sid)
+                rows.append(child)
+        except Exception:
+            pass
+        try:
+            for path in SESSION_DIR.glob("*.json"):
+                if path.name.startswith("_"):
+                    continue
+                child_sid = path.stem
+                if not child_sid or child_sid in seen_ids:
+                    continue
+                child = Session.load_metadata_only(child_sid)
+                if child:
+                    seen_ids.add(child_sid)
+                    rows.append(child)
+        except Exception:
+            pass
+        return rows
+
+    children_by_parent: dict[str, list] = {}
+    for child in _child_rows():
+        parent_sid = _safe_first(getattr(child, "parent_session_id", None))
+        child_sid = _safe_first(getattr(child, "session_id", None))
+        if not parent_sid or not child_sid or child_sid == sid:
+            continue
+        children_by_parent.setdefault(parent_sid, []).append(child)
+
+    candidates = []
+    frontier = [sid]
+    seen = {sid}
+    for _ in range(20):
+        if not frontier:
+            break
+        parent_sid = frontier.pop(0)
+        for child in children_by_parent.get(parent_sid, []):
+            child_sid = _safe_first(getattr(child, "session_id", None))
+            if not child_sid or child_sid in seen:
+                continue
+            seen.add(child_sid)
+            if getattr(child, "pre_compression_snapshot", False):
+                frontier.append(child_sid)
+            else:
+                candidates.append(child)
+
+    if not candidates:
+        return None
+    latest = max(
+        candidates,
+        key=lambda child: float(
+            _safe_first(
+                getattr(child, "updated_at", None),
+                getattr(child, "created_at", None),
+                0,
+            ) or 0
+        ),
+    )
+    return getattr(latest, "session_id", None) or None
 from api.workspace import (
     load_workspaces,
     save_workspaces,
@@ -4205,6 +4319,9 @@ def handle_get(handler, parsed) -> bool:
                     float(raw.get("updated_at") or 0),
                     _merged_last_message_at,
                 )
+            continuation_sid = _pre_compression_continuation_session_id(s)
+            if continuation_sid:
+                raw["continuation_session_id"] = continuation_sid
             if cli_meta and _is_messaging_session_record(cli_meta):
                 raw = _merge_cli_sidebar_metadata(raw, cli_meta)
                 # ``message_count`` in /api/session is the display coordinate

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -618,6 +618,13 @@ async function loadSession(sid){
   }
   // Stale response? A newer loadSession() call has already started (#1060).
   if (_loadingSessionId !== sid) return;
+  const continuationSid=(data.session&&data.session.continuation_session_id)||'';
+  if(continuationSid&&continuationSid!==sid&&!opts.skipContinuationResolve){
+    try{localStorage.setItem('hermes-webui-session',continuationSid);}catch(_){}
+    _setActiveSessionUrl(continuationSid);
+    _loadingSessionId=null;
+    return loadSession(continuationSid,{...opts,skipLineageResolve:true,skipContinuationResolve:true,force:true});
+  }
   S.session=data.session;
   S.session._modelResolutionDeferred=true;
   S.lastUsage={...(data.session.last_usage||{})};

--- a/tests/test_gateway_sync.py
+++ b/tests/test_gateway_sync.py
@@ -1214,6 +1214,159 @@ def test_sessions_response_distinguishes_same_user_different_chat_identity_from_
             pass
 
 
+def test_messaging_projection_keeps_no_identity_continuation_when_gateway_source_active(monkeypatch, cleanup_test_sessions):
+    """A WebUI/mobile recovery continuation must not disappear behind source-wide Gateway hiding.
+
+    Long WebUI turns can rotate to a child session during compression. If the
+    browser is backgrounded before the final SSE handoff, recovery depends on
+    the continuation still being visible in the sidebar. This is source-generic:
+    Telegram, Discord, Slack, and Weixin all use the same messaging projection.
+    """
+    from api import routes
+    from api.models import Session
+
+    parent_sid = "webui_pre_compression_snapshot"
+    cleanup_test_sessions.append(parent_sid)
+    Session(
+        session_id=parent_sid,
+        title="Archived pre-compression snapshot",
+        model="openai/gpt-5",
+        messages=[{"role": "user", "content": "before compression", "timestamp": time.time() - 10}],
+        pre_compression_snapshot=True,
+    ).save(touch_updated_at=False)
+
+    for source in ("telegram", "discord", "slack", "weixin"):
+        active_sid = f"{source}_active_sid"
+        continuation_sid = f"webui_{source}_continuation_no_identity"
+        cleanup_test_sessions.append(continuation_sid)
+        monkeypatch.setattr(
+            routes,
+            "_load_gateway_session_identity_map",
+            lambda source=source, active_sid=active_sid: {
+                active_sid: {
+                    "session_key": f"agent:main:{source}:dm:user_1",
+                    "raw_source": source,
+                    "platform": source,
+                    "chat_type": "dm",
+                    "chat_id": "user_1",
+                    "user_id": "user_1",
+                },
+            },
+        )
+        sessions = [
+            {
+                "session_id": active_sid,
+                "raw_source": source,
+                "session_source": "messaging",
+                "title": f"Current {source} DM",
+                "updated_at": 100,
+                "message_count": 3,
+            },
+            {
+                "session_id": continuation_sid,
+                "raw_source": source,
+                "session_source": "messaging",
+                "chat_id": "webui_recovery_chat",
+                "chat_type": "dm",
+                "title": f"Recovered {source} WebUI continuation",
+                "parent_session_id": parent_sid,
+                "updated_at": 200,
+                "message_count": 1003,
+            },
+        ]
+
+        kept = routes._keep_latest_messaging_session_per_source(sessions)
+        ids = {session.get("session_id") for session in kept}
+
+        assert ids == {active_sid, continuation_sid}
+
+
+def test_session_load_exposes_continuation_for_pre_compression_snapshot(cleanup_test_sessions):
+    """Reloading an old hidden compression snapshot should give the browser a recovery target."""
+    from api.models import Session
+
+    parent_sid = "webui_mobile_snapshot_parent"
+    child_sid = "webui_mobile_snapshot_child"
+    now = time.time()
+    cleanup_test_sessions.extend([parent_sid, child_sid])
+
+    parent = Session(
+        session_id=parent_sid,
+        title="Mobile reload parent",
+        model="openai/gpt-5",
+        messages=[{"role": "user", "content": "before compression", "timestamp": now - 10}],
+        created_at=now - 20,
+        updated_at=now - 10,
+        pre_compression_snapshot=True,
+    )
+    child = Session(
+        session_id=child_sid,
+        title="Mobile reload child",
+        model="openai/gpt-5",
+        parent_session_id=parent_sid,
+        messages=[{"role": "assistant", "content": "finished after reload", "timestamp": now}],
+        created_at=now - 5,
+        updated_at=now,
+    )
+    parent.save(touch_updated_at=False)
+    child.save(touch_updated_at=False)
+
+    data, status = get(f"/api/session?session_id={parent_sid}&messages=0&resolve_model=0")
+
+    assert status == 200
+    assert data["session"].get("session_id") == parent_sid
+    assert data["session"].get("continuation_session_id") == child_sid
+
+
+def test_session_load_exposes_multihop_continuation_for_repeated_compression(cleanup_test_sessions):
+    """A stale older snapshot should recover to the newest visible descendant."""
+    from api.models import Session
+
+    root_sid = "webui_mobile_snapshot_root"
+    middle_sid = "webui_mobile_snapshot_middle"
+    child_sid = "webui_mobile_snapshot_grandchild"
+    now = time.time()
+    cleanup_test_sessions.extend([root_sid, middle_sid, child_sid])
+
+    root = Session(
+        session_id=root_sid,
+        title="Mobile reload root snapshot",
+        model="openai/gpt-5",
+        messages=[{"role": "user", "content": "before first compression", "timestamp": now - 30}],
+        created_at=now - 40,
+        updated_at=now - 30,
+        pre_compression_snapshot=True,
+    )
+    middle = Session(
+        session_id=middle_sid,
+        title="Mobile reload middle snapshot",
+        model="openai/gpt-5",
+        parent_session_id=root_sid,
+        messages=[{"role": "assistant", "content": "before second compression", "timestamp": now - 20}],
+        created_at=now - 25,
+        updated_at=now - 20,
+        pre_compression_snapshot=True,
+    )
+    child = Session(
+        session_id=child_sid,
+        title="Mobile reload final child",
+        model="openai/gpt-5",
+        parent_session_id=middle_sid,
+        messages=[{"role": "assistant", "content": "finished after repeated compression", "timestamp": now}],
+        created_at=now - 5,
+        updated_at=now,
+    )
+    root.save(touch_updated_at=False)
+    middle.save(touch_updated_at=False)
+    child.save(touch_updated_at=False)
+
+    data, status = get(f"/api/session?session_id={root_sid}&messages=0&resolve_model=0")
+
+    assert status == 200
+    assert data["session"].get("session_id") == root_sid
+    assert data["session"].get("continuation_session_id") == child_sid
+
+
 def test_messaging_projection_hides_stale_gateway_internal_segments(monkeypatch):
     """Active Gateway identity should hide old reset rows and internal child segments."""
     from api import routes

--- a/tests/test_mobile_reload_compression_recovery.py
+++ b/tests/test_mobile_reload_compression_recovery.py
@@ -1,0 +1,33 @@
+"""Regression coverage for mobile reload recovery after compression session rotation."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SESSIONS_JS = ROOT / "static" / "sessions.js"
+
+
+def _function_block(source: str, marker: str) -> str:
+    start = source.index(marker)
+    brace = source.index("{", start)
+    depth = 1
+    i = brace + 1
+    while i < len(source) and depth:
+        if source[i] == "{":
+            depth += 1
+        elif source[i] == "}":
+            depth -= 1
+        i += 1
+    return source[start:i]
+
+
+def test_load_session_follows_backend_continuation_hint():
+    """Reloading a stale pre-compression URL should update URL/localStorage to the continuation."""
+    src = SESSIONS_JS.read_text(encoding="utf-8")
+    load_session = _function_block(src, "async function loadSession")
+
+    assert "continuation_session_id" in load_session
+    assert "loadSession(continuationSid" in load_session
+    assert "skipContinuationResolve" in load_session
+    assert "localStorage.setItem('hermes-webui-session',continuationSid)" in load_session
+    assert "_setActiveSessionUrl(continuationSid)" in load_session


### PR DESCRIPTION
## Thinking Path
- Mobile Safari/WebUI can reload while a long-running turn is still rotating through context compression.
- The browser can come back with a stale `/session/<pre-compression-snapshot>` URL or `localStorage` session id.
- That parent snapshot is intentionally hidden from the sidebar, so reopening it can make the current conversation look like it disappeared.
- The safe fix is to resolve only hidden pre-compression snapshots to their visible continuation, without broadening normal Gateway stale-row visibility.

## What Changed
- `GET /api/session` now includes `continuation_session_id` when the requested session is a hidden pre-compression snapshot with a visible descendant continuation.
- The continuation lookup follows bounded repeated-compression hops and checks both in-memory sessions and persisted sidecars.
- `loadSession()` now follows the backend continuation hint, updates URL/localStorage to the continuation id, and guards against recursion.
- Sidebar messaging-session dedupe now treats pre-compression continuations as recoverable rows, while preserving existing stale Gateway hiding behavior.
- Added regression coverage for:
  - mobile reload continuation hint
  - repeated compression hop recovery
  - frontend continuation follow-up behavior
  - messaging-source generic recovery across Telegram, Discord, Slack, and Weixin
  - existing Gateway stale-row hiding behavior

## Why It Matters
A user who backgrounds WebUI on mobile during a long response should not lose the visible route back to that conversation. This restores the active continuation instead of reopening or hiding the archived pre-compression snapshot.

For messaging surfaces like Discord/Slack/Telegram/Weixin: the exact stale-browser-URL symptom is WebUI-specific, but the sidebar projection path is shared for messaging-looking rows. The regression test now validates the exemption is source-generic and not Telegram-only.

## Verification
- `python -m pytest tests/test_gateway_sync.py tests/test_mobile_reload_compression_recovery.py -q` → 59 passed
- `python -m pytest tests/test_session_lineage_collapse.py tests/test_canonical_session_resolution_rfc.py tests/test_auto_compression_card.py -q` → 65 passed
- `python -m py_compile api/routes.py`
- `git diff --check`
- Codex read-only review: no blocking correctness issues found after the multi-hop and messaging-source fixes.

## Risks / Follow-ups
- The frontend behavior test is static because this codebase has no JS test harness for `loadSession()`. Backend behavior and sidebar projection are covered with executable tests.
- The continuation lookup is intentionally bounded to avoid cycles or runaway scans.

## Model Used
AI-assisted by Hermes WebUI using OpenAI Codex GPT-5.5, plus Codex CLI read-only review.