### PR TITLE
Improve sidebar chat search result highlighting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Sidebar chat search now highlights matching title text and shows a subtle content preview for body-only matches.
+
 ## [v0.51.137] — 2026-05-25 — Release DI (stage-batch19 — 6-PR medium-risk batch)
 
 ### Added

--- a/api/routes.py
+++ b/api/routes.py
@@ -6787,6 +6787,51 @@ def _handle_session_export(handler, parsed):
     return True
 
 
+def _session_search_message_text(message):
+    content = message.get("content") if isinstance(message, dict) else ""
+    if isinstance(content, list):
+        return " ".join(
+            str(part.get("text", ""))
+            for part in content
+            if isinstance(part, dict) and part.get("type") == "text"
+        )
+    return str(content or "")
+
+
+def _session_search_preview(text, query, max_len=124):
+    normalized = re.sub(r"\s+", " ", str(text or "")).strip()
+    q = re.sub(r"\s+", " ", str(query or "")).strip()
+    if not normalized or not q:
+        return ""
+    idx = normalized.lower().find(q.lower())
+    if idx < 0:
+        return ""
+
+    max_len = max(32, int(max_len or 124))
+    if len(normalized) <= max_len:
+        return normalized
+
+    context = max(12, (max_len - len(q)) // 2)
+    start = max(0, idx - context)
+    end = min(len(normalized), idx + len(q) + context)
+    if start > 0:
+        while start < idx and normalized[start] != " ":
+            start += 1
+        if start >= idx:
+            start = max(0, idx - context)
+    if end < len(normalized):
+        while end > idx + len(q) and normalized[end - 1] != " ":
+            end -= 1
+        if end <= idx + len(q):
+            end = min(len(normalized), idx + len(q) + context)
+    excerpt = normalized[start:end].strip()
+    if start > 0:
+        excerpt = "..." + excerpt
+    if end < len(normalized):
+        excerpt = excerpt + "..."
+    return excerpt
+
+
 def _handle_sessions_search(handler, parsed):
     qs = parse_qs(parsed.query)
     q = qs.get("q", [""])[0].lower().strip()
@@ -6814,15 +6859,12 @@ def _handle_sessions_search(handler, parsed):
                 sess = get_session(s["session_id"])
                 msgs = sess.messages[:depth] if depth else sess.messages
                 for m in msgs:
-                    c = m.get("content") or ""
-                    if isinstance(c, list):
-                        c = " ".join(
-                            p.get("text", "")
-                            for p in c
-                            if isinstance(p, dict) and p.get("type") == "text"
-                        )
+                    c = _session_search_message_text(m)
                     if q in str(c).lower():
                         item = dict(s, match_type="content")
+                        preview = _session_search_preview(c, q)
+                        if preview:
+                            item["match_preview"] = _redact_text(preview)
                         if isinstance(item.get("title"), str):
                             item["title"] = _redact_text(item["title"])
                         results.append(item)

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -2487,19 +2487,85 @@ function stopGatewaySSE(){
 
 let _searchDebounceTimer = null;
 let _contentSearchResults = [];  // results from /api/sessions/search content scan
+let _lastSessionSearchQuery = '';
+let _hideSearchPreviewsAfterSelect = false;
 let _serverTimeDelta = 0;       // ms offset: client clock - server clock (for clock-skew compensation)
 let _serverTz = '';              // server timezone offset string (e.g. "+0800", "+0000", "-0500")
 
+function _sessionSearchRanges(text, query){
+  const source=String(text||'');
+  const q=String(query||'').trim();
+  if(!source||!q) return [];
+  const lower=source.toLowerCase();
+  const full=q.toLowerCase();
+  const ranges=[];
+  const collect=(needle)=>{
+    if(!needle) return;
+    let from=0;
+    while(from<lower.length){
+      const idx=lower.indexOf(needle,from);
+      if(idx<0) break;
+      const end=idx+needle.length;
+      if(!ranges.some(r=>idx<r.end&&end>r.start)) ranges.push({start:idx,end});
+      from=Math.max(end,idx+1);
+    }
+  };
+  collect(full);
+  if(!ranges.length&&/\s/.test(full)){
+    const seen=new Set();
+    full.split(/\s+/).filter(Boolean).sort((a,b)=>b.length-a.length).forEach(token=>{
+      if(seen.has(token)) return;
+      seen.add(token);
+      collect(token);
+    });
+  }
+  return ranges.sort((a,b)=>a.start-b.start);
+}
+
+function _appendHighlightedText(parent, text, query, highlightClass){
+  const source=String(text||'');
+  const ranges=_sessionSearchRanges(source,query);
+  if(!ranges.length){
+    parent.appendChild(document.createTextNode(source));
+    return ranges;
+  }
+  let pos=0;
+  for(const r of ranges){
+    if(r.start>pos) parent.appendChild(document.createTextNode(source.slice(pos,r.start)));
+    const mark=document.createElement('span');
+    mark.className=highlightClass||'session-search-hit';
+    mark.textContent=source.slice(r.start,r.end);
+    parent.appendChild(mark);
+    pos=r.end;
+  }
+  if(pos<source.length) parent.appendChild(document.createTextNode(source.slice(pos)));
+  return ranges;
+}
+
+function _sessionSearchContentPreview(session, query){
+  if(!session||!query||_hideSearchPreviewsAfterSelect) return '';
+  if(session.match_type!=='content') return '';
+  const preview=String(session.match_preview||'').replace(/\s+/g,' ').trim();
+  return preview||'';
+}
+
 function filterSessions(){
   // Immediate client-side title filter (no flicker)
-  renderSessionListFromCache();
   // Debounced content search via API for message text
   const q = ($('sessionSearch').value || '').trim();
+  if(q!==_lastSessionSearchQuery){
+    _lastSessionSearchQuery=q;
+    _hideSearchPreviewsAfterSelect=false;
+  }
+  renderSessionListFromCache();
   clearTimeout(_searchDebounceTimer);
   if (!q) { _contentSearchResults = []; return; }
   _searchDebounceTimer = setTimeout(async () => {
+    const requestedQ = q;
     try {
-      const data = await api(`/api/sessions/search?q=${encodeURIComponent(q)}&content=1&depth=5`);
+      const data = await api(`/api/sessions/search?q=${encodeURIComponent(requestedQ)}&content=1&depth=5`);
+      const currentQ = ($('sessionSearch').value || '').trim();
+      if(currentQ!==requestedQ) return;
       const titleIds = new Set(_allSessions.filter(s => _sessionDisplayTitle(s).toLowerCase().includes(q.toLowerCase())).map(s=>s.session_id));
       _contentSearchResults = (data.sessions||[]).filter(s => s.match_type === 'content' && !titleIds.has(s.session_id));
       renderSessionListFromCache();
@@ -3096,7 +3162,8 @@ function renderSessionListFromCache(){
   // streaming. This runs on every list refresh to prevent memory leaks from
   // interrupted streams. (#2066)
   _purgeStaleInflightEntries();
-  const q=($('sessionSearch').value||'').toLowerCase();
+  const searchQueryRaw=($('sessionSearch').value||'').trim();
+  const q=searchQueryRaw.toLowerCase();
   const activeSidForSidebar=_activeSessionIdForSidebar();
   const titleMatches=q?_allSessions.filter(s=>_sessionDisplayTitle(s).toLowerCase().includes(q)):_allSessions;
   // Merge content matches (deduped): content matches appended after title matches
@@ -3452,7 +3519,10 @@ function renderSessionListFromCache(){
     }
     const title=document.createElement('span');
     title.className='session-title';
-    title.textContent=cleanTitle||'Untitled';
+    const displayTitle=cleanTitle||'Untitled';
+    const titleMatched=Boolean(searchQueryRaw&&displayTitle.toLowerCase().includes(searchQueryRaw.toLowerCase()));
+    if(titleMatched) _appendHighlightedText(title,displayTitle,searchQueryRaw,'session-search-hit');
+    else title.textContent=displayTitle;
     title.title=readOnly?'Read-only imported session':'Double-click to rename';
     const tsMs=_sessionTimestampMs(s);
     const ts=document.createElement('span');
@@ -3549,6 +3619,14 @@ function renderSessionListFromCache(){
       meta.className='session-meta';
       meta.textContent=metaBits.join(' · ');
       sessionText.appendChild(meta);
+    }
+    const contentPreview=titleMatched?'':_sessionSearchContentPreview(s,searchQueryRaw);
+    if(contentPreview){
+      const preview=document.createElement('div');
+      preview.className='session-search-preview';
+      preview.title=contentPreview;
+      _appendHighlightedText(preview,contentPreview,searchQueryRaw,'session-search-hit session-search-hit-preview');
+      sessionText.appendChild(preview);
     }
     if(lineageSegmentsExpanded){
       const lineageList=document.createElement('div');
@@ -3811,6 +3889,7 @@ function renderSessionListFromCache(){
             await api('/api/session/import_cli',{method:'POST',body:JSON.stringify({session_id:s.session_id})});
           }catch(e){ /* import failed -- fall through to read-only view */ }
         }
+        if(($('sessionSearch').value||'').trim()) _hideSearchPreviewsAfterSelect=true;
         await loadSession(s.session_id);renderSessionListFromCache();
         if(typeof closeMobileSidebar==='function')closeMobileSidebar();
       }, delay);

--- a/static/style.css
+++ b/static/style.css
@@ -730,8 +730,13 @@
   .session-text{flex:1;min-width:0;display:flex;flex-direction:column;gap:2px;overflow:hidden;}
   .session-title-row{display:flex;align-items:center;gap:6px;min-width:0;}
   .session-title{flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:var(--text);user-select:none;}
+  .session-search-hit{border-radius:4px;background:var(--accent-bg);color:var(--accent-text);box-decoration-break:clone;-webkit-box-decoration-break:clone;padding:0 .08em;}
+  .session-search-preview{font-size:11px;line-height:1.35;color:var(--muted);overflow:hidden;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow-wrap:anywhere;opacity:.9;}
+  .session-search-hit-preview{background:var(--accent-bg);color:var(--accent-text);}
   .session-item.active .session-title{color:var(--accent-text);}
   .session-meta{font-size:11px;color:var(--muted);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+  .session-item.active .session-search-preview{color:var(--accent-text);opacity:.72;}
+  .session-item.active .session-search-hit{background:var(--accent-bg-strong);color:var(--accent-text);}
   .session-item.active .session-meta{color:var(--accent-text);opacity:.8;}
   .session-state-indicator{display:inline-flex;align-items:center;justify-content:center;flex-shrink:0;width:10px;height:10px;color:var(--accent);visibility:hidden;}
   .session-attention-indicator{position:absolute;right:6px;top:50%;transform:translateY(-50%);width:26px;height:26px;z-index:1;pointer-events:none;transition:opacity .15s ease,visibility .15s ease;}

--- a/tests/test_sidebar_search_highlights.py
+++ b/tests/test_sidebar_search_highlights.py
@@ -1,0 +1,87 @@
+import json
+import re
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+SESSIONS_JS = ROOT / "static" / "sessions.js"
+STYLE_CSS = ROOT / "static" / "style.css"
+
+
+def _run_js_ranges(cases):
+    src = SESSIONS_JS.read_text(encoding="utf-8")
+    start = src.index("function _sessionSearchRanges")
+    end = src.index("function _appendHighlightedText", start)
+    helper = src[start:end]
+    script = helper + "\nconsole.log(JSON.stringify(cases.map(c => _sessionSearchRanges(c.text, c.query))));"
+    completed = subprocess.run(
+        ["node", "-e", "const cases = " + json.dumps(cases) + ";\n" + script],
+        check=True,
+        text=True,
+        capture_output=True,
+        cwd=ROOT,
+    )
+    return json.loads(completed.stdout)
+
+
+def test_sidebar_search_ranges_are_case_insensitive_and_repeated():
+    ranges = _run_js_ranges([
+        {"text": "Psalm notes and psalm outline", "query": "PSALM"},
+    ])[0]
+    assert ranges == [{"start": 0, "end": 5}, {"start": 16, "end": 21}]
+
+
+def test_sidebar_search_ranges_handle_regex_special_characters():
+    ranges = _run_js_ranges([
+        {"text": "Can we search for foo(bar)+baz? safely", "query": "foo(bar)+baz?"},
+    ])[0]
+    assert ranges == [{"start": 18, "end": 31}]
+
+
+def test_sidebar_search_ranges_support_multi_word_exact_then_tokens():
+    exact, tokenized = _run_js_ranges([
+        {"text": "Parallel TTS Audio Generation Strategy", "query": "tts audio"},
+        {"text": "Parallel TTS and Audio Strategy", "query": "tts audio"},
+    ])
+    assert exact == [{"start": 9, "end": 18}]
+    assert tokenized == [{"start": 9, "end": 12}, {"start": 17, "end": 22}]
+
+
+def test_sidebar_search_ranges_empty_query_returns_no_ranges():
+    assert _run_js_ranges([{"text": "Psalm", "query": ""}])[0] == []
+
+
+def test_session_search_preview_trims_long_body_with_ellipses():
+    from api.routes import _session_search_preview
+
+    body = "Intro " + ("before " * 20) + "generated audio for the Psalm study" + (" after" * 20)
+    preview = _session_search_preview(body, "Psalm", max_len=92)
+    assert preview.startswith("...")
+    assert preview.endswith("...")
+    assert "Psalm" in preview
+    assert len(preview) <= 98
+
+
+def test_session_search_preview_handles_empty_or_unavailable_body():
+    from api.routes import _session_search_message_text, _session_search_preview
+
+    assert _session_search_preview("", "psalm") == ""
+    assert _session_search_preview(None, "psalm") == ""
+    assert _session_search_preview("No matching body", "psalm") == ""
+    assert _session_search_preview("Some body", "") == ""
+    assert _session_search_message_text({}) == ""
+    assert _session_search_message_text({"content": [{"type": "text", "text": "Psalm body"}]}) == "Psalm body"
+
+
+def test_sidebar_search_rendering_uses_safe_dom_helpers():
+    src = SESSIONS_JS.read_text(encoding="utf-8")
+    css = STYLE_CSS.read_text(encoding="utf-8")
+    assert "function _appendHighlightedText" in src
+    assert ".textContent=source.slice(r.start,r.end)" in src
+    assert "dangerouslySetInnerHTML" not in src
+    assert "displayTitle.toLowerCase().includes(searchQueryRaw.toLowerCase())" in src
+    assert "contentPreview=titleMatched?'':_sessionSearchContentPreview" in src
+    assert "if(($('sessionSearch').value||'').trim()) _hideSearchPreviewsAfterSelect=true;" in src
+    assert ".session-search-preview" in css
+    assert "-webkit-line-clamp:2" in css


### PR DESCRIPTION
**Thinking Path**

The left sidebar chat search already filtered conversations by title and message content, but the result rows did not explain why a conversation matched. This PR keeps the existing search behavior intact and adds a focused presentation layer so users can quickly understand each result.

**What Changed**

- Highlighted matching query text directly inside chat titles.
- Added compact, muted content snippets for content-only matches.
- Highlighted matched text inside snippets using safe DOM rendering.
- Extended `/api/sessions/search` to return a short redacted `match_preview` for content matches rather than sending full message bodies to the sidebar.
- Added helper logic for match ranges, snippet extraction, repeated matches, punctuation-heavy queries, multi-word queries, and empty query handling.
- Hid content snippets after selecting a search result so the sidebar returns to a cleaner state.
- Preserved existing filtering, sorting, metadata, selected/hover states, unread markers, source labels, date grouping, and row layout behavior.
- Updated `CHANGELOG.md`.
- Added focused tests in `tests/test_sidebar_search_highlights.py`.

**Customer Experience Improvement**

Search now feels explainable instead of mysterious. If a user searches for a term like `psalm`, they can immediately see whether the match came from the title or from conversation content. Title matches are subtly emphasized without disrupting the dark Hermes theme, and body-only matches show a small preview such as:

`...generated audio for the Psalm study...`

This makes it easier to find the right conversation quickly while keeping the sidebar quiet and uncluttered.

**Validation**

Automated validation:

- Installed local test dependencies in `.venv` using:
  `pip install -U pip pytest pytest-timeout -r requirements.txt`

- Focused validation:
  `HERMES_WEBUI_PYTHON=/Users/georgeandraws/hermes-webui/.venv/bin/python HERMES_HOME=/private/tmp/hermes-pytest-home HERMES_BASE_HOME=/private/tmp/hermes-pytest-home HERMES_WEBUI_TEST_STATE_DIR=/private/tmp/hermes-pytest-state HERMES_WEBUI_STATE_DIR=/private/tmp/hermes-pytest-state HERMES_WEBUI_DEFAULT_WORKSPACE=/private/tmp/hermes-pytest-workspace HERMES_CONFIG_PATH=/private/tmp/hermes-pytest-home/config.yaml .venv/bin/python -m pytest tests/test_sidebar_search_highlights.py tests/test_session_lineage_collapse.py::test_sidebar_search_and_rows_use_read_only_display_title tests/test_sprint3.py::test_session_search_returns_matches tests/test_sprint4.py::test_session_search_returns_matches tests/test_sprint7.py::test_session_search_returns_count -v --timeout=60`

  Result: 11 passed.

- Full suite on the rebased PR branch:
  `GIT_CONFIG_GLOBAL=/private/tmp/hermes-pytest-gitconfig HERMES_WEBUI_PYTHON=/Users/georgeandraws/hermes-webui/.venv/bin/python HERMES_HOME=/private/tmp/hermes-pytest-home HERMES_BASE_HOME=/private/tmp/hermes-pytest-home HERMES_WEBUI_TEST_STATE_DIR=/private/tmp/hermes-pytest-state HERMES_WEBUI_STATE_DIR=/private/tmp/hermes-pytest-state HERMES_WEBUI_DEFAULT_WORKSPACE=/private/tmp/hermes-pytest-workspace HERMES_CONFIG_PATH=/private/tmp/hermes-pytest-home/config.yaml .venv/bin/python -m pytest tests/ -v --timeout=60`

  Result: 6500 passed, 50 skipped, 1 xfailed, 2 xpassed, 8 subtests passed.

Manual validation:

- Ran Hermes WebUI locally with isolated state.
- Seeded throwaway sessions for:
  - title match: `Psalm Study Notes`
  - content-only match: `Parallel TTS Audio Generation Strategy`
  - unrelated/title search match: `TTS Playback Polish`
- Searched for `psalm`.
- Confirmed title matches are highlighted.
- Confirmed content-only matches show a clean muted snippet.
- Confirmed selecting a result hides the snippet preview.
- Confirmed clearing search restores the normal sidebar.
- Confirmed narrow/mobile sidebar layout has no clipping or overlap.

Screenshot evidence captured locally:

- Before: `/Users/georgeandraws/hermes-webui/.local-review/sidebar-search-highlights/before-psalm.png`
- After: `/Users/georgeandraws/hermes-webui/.local-review/sidebar-search-highlights/after-psalm.png`

**Risks / Follow-ups**

- Content snippets depend on content already available through the search endpoint and are capped/redacted before being sent to the sidebar.
- Screenshots are local ignored validation artifacts and are not committed.
- Full-suite git tests required `GIT_CONFIG_GLOBAL=/private/tmp/hermes-pytest-gitconfig` to pin `init.defaultBranch=master`, because some temporary-repo tests assume `master`.

**Model Used**

OpenAI GPT-5 Codex
