### PR TITLE
Release DJ — stage-batch20 — 7-PR ultra-safe batch (v0.51.138)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 ## [Unreleased]
 
+## [v0.51.138] — 2026-05-25 — Release DJ (stage-batch20 — 7-PR ultra-safe batch)
+
 ### Added
 
 - **PR #2972** by @Michaelyklam (refs #1925) — Advance the runtime-adapter RFC after the Slice 4e route-selection harness shipped in v0.51.129. The RFC now defines the Slice 4f supervised local runner client backend gate: replace the bounded `runner-local` 501 only when explicitly configured, prove restart/reattach from durable runner/journal state, preserve the public chat-start field whitelist, require cancel as the first live runner-owned control, and keep active-run discovery/supervision out of new WebUI process-local runtime-surrogate globals.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Removing a provider key now surfaces "Session expired. Reload the page and try again." when the underlying POST is rejected with 403, instead of the raw "Cross-origin request rejected" string that gives the user no next step. (Refs #2572)
+
 ## [v0.51.137] — 2026-05-25 — Release DI (stage-batch19 — 6-PR medium-risk batch)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Tool cards in the transcript now use a slightly stronger border and a 2px left edge so tool output stays visually distinct from final assistant prose without requiring hover. (#2867)
+
 ## [v0.51.137] — 2026-05-25 — Release DI (stage-batch19 — 6-PR medium-risk batch)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Changed
 
-- Contributor guidance now requires explicit `Contract Routing` for contract-affecting PRs and `Contract Change` when a PR intentionally changes an existing product, runtime, or review contract. Contract tests must move with the corresponding docs instead of silently redefining behavior by themselves.
+- Contributor guidance now requires explicit `Contract Routing` for contract-affecting PRs and `Contract Change` when a PR intentionally changes an existing product, runtime, or review contract. Contract tests must move with the corresponding docs instead of silently redefining behavior by themselves, with the current static coverage documented as advisory rather than a GitHub policy gate.
 
 ## [v0.51.137] — 2026-05-25 — Release DI (stage-batch19 — 6-PR medium-risk batch)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Contributor guidance now requires explicit `Contract Routing` for contract-affecting PRs and `Contract Change` when a PR intentionally changes an existing product, runtime, or review contract. Contract tests must move with the corresponding docs instead of silently redefining behavior by themselves.
+
 ## [v0.51.137] — 2026-05-25 — Release DI (stage-batch19 — 6-PR medium-risk batch)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Tasks panel "Gateway not configured" banner now includes a direct link to the new `docs/docker.md#scheduled-jobs-require-a-gateway-daemon` section that walks through running the gateway container so scheduled cron jobs actually tick. (Refs #2785)
+
 ## [v0.51.137] — 2026-05-25 — Release DI (stage-batch19 — 6-PR medium-risk batch)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- **PR #2972** by @Michaelyklam (refs #1925) — Advance the runtime-adapter RFC after the Slice 4e route-selection harness shipped in v0.51.129. The RFC now defines the Slice 4f supervised local runner client backend gate: replace the bounded `runner-local` 501 only when explicitly configured, prove restart/reattach from durable runner/journal state, preserve the public chat-start field whitelist, require cancel as the first live runner-owned control, and keep active-run discovery/supervision out of new WebUI process-local runtime-surrogate globals.
+
 ## [v0.51.137] — 2026-05-25 — Release DI (stage-batch19 — 6-PR medium-risk batch)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Changed
 
-- Removing a provider key now surfaces "Session expired. Reload the page and try again." when the underlying POST is rejected with 403, instead of the raw "Cross-origin request rejected" string that gives the user no next step. (Refs #2572)
+- Removing a provider key now surfaces the server's specific CSRF rejection reason ("Session expired - reload the page", "Cross-origin mismatch - check reverse proxy headers", or the fallback "Cross-origin request rejected") when the underlying POST is rejected with 403, instead of swallowing all three into one generic toast. (Refs #2572)
 
 ## [v0.51.137] — 2026-05-25 — Release DI (stage-batch19 — 6-PR medium-risk batch)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@
 - Removing a provider key now surfaces the server's specific CSRF rejection reason ("Session expired - reload the page", "Cross-origin mismatch - check reverse proxy headers", or the fallback "Cross-origin request rejected") when the underlying POST is rejected with 403, instead of swallowing all three into one generic toast. (Refs #2572)
 - Tool cards in the transcript now use a slightly stronger border and a 2px left edge so tool output stays visually distinct from final assistant prose without requiring hover. (#2867)
 - Tasks panel "Gateway not configured" banner now includes a direct link to the new `docs/docker.md#scheduled-jobs-and-the-gateway-daemon` section that walks through running the gateway container so scheduled cron jobs actually tick. (Refs #2785)
+- WebUI structured request logs now include `remote` (client IP) and an optional `forwarded_for` field when an `X-Forwarded-For` header is present, making failed-login and unauthorized-access logs usable by downstream security tooling like fail2ban behind a reverse proxy.
+
+### Internal
+
+- Test cleanup in `tests/test_issue1894_provider_overlap.py`: canonicalize the `opencode-go` base URL to `opencode.ai/zen/go/v1` (matching `hermes_cli/auth.py` and `api/config.py`), drop a vestigial `# noqa: N801`, and convert section banner comments to per-test docstrings.
 
 ## [v0.51.137] — 2026-05-25 — Release DI (stage-batch19 — 6-PR medium-risk batch)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,21 @@ Use those documents as review guardrails: keep the change scoped, preserve the
 no-build-step architecture, update docs/changelog when behavior changes, include
 UI evidence for UI changes, and add tests for behavior changes where practical.
 
+### Contract-affecting PRs
+
+A contract-affecting PR is any change that updates a public contract document,
+an RFC, a contributor guide, a product-semantics test, or behavior that those
+documents already describe. These PRs need an explicit `Contract Routing` section
+in the PR body that names the touched contract family and the evidence used.
+
+If the PR intentionally changes an existing contract, add a `Contract Change`
+section that states the old rule, the new rule, and why the change is justified.
+Do not silently redefine product behavior by changing tests alone; update the
+corresponding docs in the same PR.
+
+A release batch should call out included contract-affecting PRs separately
+from ordinary fixes, even when the code diff is small and CI is green.
+
 ## Two Paths to a Strong Pull Request
 
 ### Path 1: Small, Focused Changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,9 @@ A contract-affecting PR is any change that updates a public contract document,
 an RFC, a contributor guide, a product-semantics test, or behavior that those
 documents already describe. These PRs need an explicit `Contract Routing` section
 in the PR body that names the touched contract family and the evidence used.
+See [`docs/CONTRACTS.md#contract-routing`](docs/CONTRACTS.md#contract-routing)
+for the short routing shape and [`docs/CONTRACTS.md#contract-changes`](docs/CONTRACTS.md#contract-changes)
+for intentional contract changes.
 
 If the PR intentionally changes an existing contract, add a `Contract Change`
 section that states the old rule, the new rule, and why the change is justified.

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -102,6 +102,26 @@ Evidence needed before claiming done:
 For small, obvious fixes, keep this short. The goal is to avoid routing mistakes,
 not to create process overhead.
 
+## Contract changes
+
+Changing contract documents, RFC guidance, or contract tests changes review
+expectations for future contributors. A PR that intentionally changes an
+existing contract should include a `Contract Change` section in its PR body with:
+
+- the previous contract,
+- the new contract,
+- the affected docs and tests,
+- the compatibility or migration reason.
+
+Contract tests and corresponding docs must move together. Tests that encode
+product semantics must not silently redefine the contract by asserting the
+opposite behavior without updating the public docs and naming the change in the
+PR body.
+
+Release batches should list included contract-affecting PRs explicitly so
+reviewers can distinguish ordinary green-CI fixes from changes that update the
+project's product or runtime guardrails.
+
 ## PR preparation checklist
 
 Before opening or updating a PR, verify `CONTRIBUTING.md` against the actual PR
@@ -118,6 +138,8 @@ Required checks:
 - UI/UX changes include before/after evidence and responsive-state coverage.
 - Runtime/streaming changes name the state layer or invariant being changed and
   list the regression or manual invariant check.
+- Contract-affecting PRs include `Contract Routing`; intentional contract
+  changes also include `Contract Change`.
 - Onboarding/setup validation used isolated `HERMES_HOME` and
   `HERMES_WEBUI_STATE_DIR`, unless the human operator explicitly requested real
   state.

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -118,6 +118,13 @@ product semantics must not silently redefine the contract by asserting the
 opposite behavior without updating the public docs and naming the change in the
 PR body.
 
+The static tests for this guidance are advisory coverage. They pin contributor
+wording so the rule stays visible. This advisory coverage is not an automated
+policy gate; static coverage is not an automated policy gate and does not enforce
+PR-body content on GitHub. A future release-time or CI check could
+surface contract-affecting diffs whose PR body lacks `Contract Routing`, but this
+document only defines the review expectation.
+
 Release batches should list included contract-affecting PRs explicitly so
 reviewers can distinguish ordinary green-CI fixes from changes that update the
 project's product or runtime guardrails.

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -51,16 +51,14 @@ them manually from the Tasks panel. In Docker, scheduled jobs require the Hermes
 to tick while you are away. If System Settings shows `Gateway not configured`,
 use `docker-compose.two-container.yml`,
 `docker-compose.three-container.yml`, or run `hermes gateway` separately before
-relying on offline scheduled runs. See [Scheduled jobs require a gateway daemon](#scheduled-jobs-require-a-gateway-daemon) below for the full background and verification steps.
+relying on offline scheduled runs. See [Scheduled jobs and the gateway daemon](#scheduled-jobs-and-the-gateway-daemon) below for the full background and verification steps.
 
 For troubleshooting, reinstall, or onboarding reproduction trials, do not mount
 your real `~/.hermes` unless you intentionally want to test real state. Use an
 isolated Hermes home and follow
 [`docs/onboarding-agent-checklist.md`](onboarding-agent-checklist.md) instead.
 
-## What goes wrong (and how to fix it)
-
-### Scheduled jobs require a gateway daemon
+## Scheduled jobs and the gateway daemon
 
 **Symptom**: Cron jobs created in the Tasks panel never fire. System Settings shows the orange "Gateway not configured" pill, and the Tasks panel shows the same banner above the job list.
 
@@ -75,13 +73,17 @@ docker compose -f docker-compose.two-container.yml up -d
 
 The three-container layout adds the dashboard but is otherwise the same shape. If you must stay single-container, you can run `hermes gateway` inside the container as a long-lived background process, but the compose split is sturdier.
 
-**Verify**: Once the gateway is up, the System Settings pill should turn green and the Tasks banner disappear. From inside the gateway container:
+**Verify**: Once the gateway is up, the System Settings pill should turn green and the Tasks banner disappear. From the host:
 
 ```bash
-docker exec -it <gateway-container> hermes gateway status
+docker compose -f docker-compose.two-container.yml exec hermes-agent hermes gateway status
 ```
 
+If the service name differs in your compose file, `docker compose -f docker-compose.two-container.yml ps` lists the running services.
+
 Refs #2785.
+
+## What goes wrong (and how to fix it)
 
 ### 1. "Permission denied" at startup
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -51,7 +51,7 @@ them manually from the Tasks panel. In Docker, scheduled jobs require the Hermes
 to tick while you are away. If System Settings shows `Gateway not configured`,
 use `docker-compose.two-container.yml`,
 `docker-compose.three-container.yml`, or run `hermes gateway` separately before
-relying on offline scheduled runs.
+relying on offline scheduled runs. See [Scheduled jobs require a gateway daemon](#scheduled-jobs-require-a-gateway-daemon) below for the full background and verification steps.
 
 For troubleshooting, reinstall, or onboarding reproduction trials, do not mount
 your real `~/.hermes` unless you intentionally want to test real state. Use an
@@ -59,6 +59,29 @@ isolated Hermes home and follow
 [`docs/onboarding-agent-checklist.md`](onboarding-agent-checklist.md) instead.
 
 ## What goes wrong (and how to fix it)
+
+### Scheduled jobs require a gateway daemon
+
+**Symptom**: Cron jobs created in the Tasks panel never fire. System Settings shows the orange "Gateway not configured" pill, and the Tasks panel shows the same banner above the job list.
+
+**Cause**: Scheduled cron ticks are not driven by the WebUI itself. The gateway daemon ticks the scheduler every 60 seconds; without one running, scheduled jobs sit idle. "Run now" / "Trigger" buttons still work because the WebUI handles those in-process.
+
+**Fix**: Run a gateway container alongside the WebUI. The two-container compose file is the recommended path:
+
+```bash
+cp .env.docker.example .env
+docker compose -f docker-compose.two-container.yml up -d
+```
+
+The three-container layout adds the dashboard but is otherwise the same shape. If you must stay single-container, you can run `hermes gateway` inside the container as a long-lived background process, but the compose split is sturdier.
+
+**Verify**: Once the gateway is up, the System Settings pill should turn green and the Tasks banner disappear. From inside the gateway container:
+
+```bash
+docker exec -it <gateway-container> hermes gateway status
+```
+
+Refs #2785.
 
 ### 1. "Permission denied" at startup
 

--- a/docs/rfcs/hermes-run-adapter-contract.md
+++ b/docs/rfcs/hermes-run-adapter-contract.md
@@ -905,6 +905,12 @@ Non-goals for Slice 4d:
 
 #### Slice 4e: Default-off runner chat-start route-selection harness
 
+Status as of 2026-05-24: shipped in v0.51.129 via #2794. The route-selection
+harness now makes adapter mode selection explicit: `legacy-direct` remains the
+default, `legacy-journal` still delegates to the existing journaled legacy path,
+and `runner-local` returns a bounded not-configured response instead of silently
+starting an in-process legacy run.
+
 The first implementation after the Slice 4d gate should wire the
 `/api/chat/start` selection point to the existing `RuntimeAdapter` factory
 without adding a supervised runner process yet. The harness must make the
@@ -947,6 +953,65 @@ Non-goals for Slice 4e:
 - no execution-survives-WebUI-restart claim for production chat turns;
 - no removal of `legacy-direct` or `legacy-journal`;
 - no server-side queue endpoint or queue scheduler just for adapter symmetry.
+
+#### Slice 4f: Supervised local runner client backend gate
+
+After the route-selection harness ships, the next reviewable step is not to make
+`runner-local` the default. It is to define the first concrete supervised/local
+runner client backend that can replace the bounded 501 path under the existing
+feature flag and prove execution ownership has moved out of the main WebUI
+request process.
+
+This slice is a contract gate before backend code lands. The goal is to pin the
+minimum runner client behavior so the implementation cannot become a renamed
+`STREAMS` / `CANCEL_FLAGS` / cached `AIAgent` surrogate inside `api/routes.py`.
+
+Scope:
+
+- define the runner client process boundary and lifecycle: how `start_run`
+  spawns or hands off work, how the child is supervised, and how terminal state
+  is recorded without a main-process active-run dictionary;
+- require a durable runner-owned run id plus session-to-run lookup that a freshly
+  restarted WebUI process can discover without consulting old `STREAMS` entries;
+- require ordered event replay through the existing journal/cursor surface, so
+  token, reasoning, progress, tool, usage, error, and done events render through
+  the same browser path as legacy replay;
+- define cancel as the first required live control for active runner-owned runs,
+  with approval, clarify, goal, and queue either mapped to explicit runner
+  capabilities or returned as bounded unsupported/conflict `ControlResult`
+  values;
+- keep profile, workspace, attachments, provider/model, toolset, source, and
+  metadata as explicit payload fields at the runner boundary rather than
+  depending on process-global WebUI environment mutation.
+
+Acceptance tests for Slice 4f:
+
+1. **501 path replaced only when configured.** Unset adapter mode and
+   `legacy-journal` behavior stay unchanged; `runner-local` uses the supervised
+   runner client only when the backend is explicitly configured.
+2. **Restart/reattach proves ownership moved.** Start a runner-owned run,
+   discard/restart the WebUI server process, rediscover the active or terminal
+   run from durable runner/journal state, replay from cursor without duplicates,
+   and preserve cancel if the run is still active.
+3. **No runtime-surrogate globals.** The main WebUI server does not gain new
+   module-level maps for runner-owned streams, cancel flags, approval/clarify
+   callbacks, cached agents, goal state, queue schedulers, or child-process run
+   registries. Supervision state belongs to the runner client/backend boundary.
+4. **Stable browser contracts.** Successful chat-start responses remain limited
+   to the legacy-compatible field whitelist unless a later contract revision
+   explicitly exposes `run_id`, `status`, or `active_controls`.
+5. **Bounded control gaps.** Unsupported runner controls return safe
+   `unsupported`, `not-active`, or `conflict` results; they must not fall back to
+   legacy callback queues for a runner-owned run.
+
+Non-goals for Slice 4f:
+
+- no default-on runner mode;
+- no removal of the legacy in-process backends;
+- no broad WebUI product-surface migration;
+- no server-side queue scheduler just for adapter symmetry;
+- no permanent WebUI-owned active-run discovery cache that duplicates runner or
+  future Hermes Runtime API responsibility.
 
 ## First Meaningful Success Criteria
 

--- a/server.py
+++ b/server.py
@@ -274,13 +274,28 @@ class Handler(BaseHTTPRequestHandler):
         """Structured JSON logs for each request."""
         import json as _json
         duration_ms = round((time.time() - getattr(self, '_req_t0', time.time())) * 1000, 1)
-        record = _json.dumps({
+        remote = '-'
+        try:
+            if getattr(self, 'client_address', None):
+                remote = str(self.client_address[0])
+        except Exception:
+            remote = '-'
+        forwarded_for = None
+        try:
+            forwarded_for = (self.headers.get('X-Forwarded-For') or '').split(',')[0].strip() or None
+        except Exception:
+            forwarded_for = None
+        record_data = {
             'ts': time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime()),
+            'remote': remote,
             'method': getattr(self, 'command', None) or '-',
             'path': getattr(self, 'path', None) or '-',
             'status': int(code) if str(code).isdigit() else code,
             'ms': duration_ms,
-        })
+        }
+        if forwarded_for:
+            record_data['forwarded_for'] = forwarded_for
+        record = _json.dumps(record_data)
         print(f'[webui] {record}', flush=True)
 
     def do_GET(self) -> None:

--- a/static/panels.js
+++ b/static/panels.js
@@ -6875,13 +6875,15 @@ async function _removeProviderKey(providerId){
     }
   }catch(e){
     // A 403 from /api/providers/delete fires when the CSRF cookie/header
-    // pair has drifted (typically a tab opened before the most recent
-    // login or cookie rotation). The raw server string is
-    // "Cross-origin request rejected" which reads like a deployment-shape
-    // problem and gives the user no next step (#2572). Surface a clearer
-    // recovery hint instead so reloading the page is an obvious fix.
+    // pair has drifted. The server distinguishes three reasons in
+    // api/routes.py:_csrf_rejection_error ("Session expired - reload the
+    // page", "Cross-origin mismatch - check reverse proxy headers", and
+    // the fallback "Cross-origin request rejected"); api()'s catch lifts
+    // that string onto e.message. Pass it through verbatim so the
+    // deployment-shape failure #2572 calls out keeps its actionable hint
+    // instead of being flattened to a single generic toast.
     if(e&&e.status===403){
-      showToast('Session expired. Reload the page and try again.',6000,'error');
+      showToast(e.message||'Session expired. Reload the page and try again.',6000,'error');
     }else{
       showToast('Error: '+e.message);
     }

--- a/static/panels.js
+++ b/static/panels.js
@@ -6874,7 +6874,17 @@ async function _removeProviderKey(providerId){
       if(els.saveBtn){els.saveBtn.disabled=false;els.saveBtn.textContent=t('providers_save');}
     }
   }catch(e){
-    showToast('Error: '+e.message);
+    // A 403 from /api/providers/delete fires when the CSRF cookie/header
+    // pair has drifted (typically a tab opened before the most recent
+    // login or cookie rotation). The raw server string is
+    // "Cross-origin request rejected" which reads like a deployment-shape
+    // problem and gives the user no next step (#2572). Surface a clearer
+    // recovery hint instead so reloading the page is an obvious fix.
+    if(e&&e.status===403){
+      showToast('Session expired. Reload the page and try again.',6000,'error');
+    }else{
+      showToast('Error: '+e.message);
+    }
     if(els.saveBtn){els.saveBtn.disabled=false;els.saveBtn.textContent=t('providers_save');}
   }
 }

--- a/static/panels.js
+++ b/static/panels.js
@@ -437,9 +437,14 @@ function _cronGatewayNoticeHtml(status) {
   const body = notConfigured
     ? 'In Hermes WebUI, scheduled jobs require the Hermes gateway daemon. If this is a single-container Docker install, jobs can be created and run manually here, but scheduled ticks need a gateway container or `hermes gateway` running outside the WebUI.'
     : 'In Hermes WebUI, scheduled jobs require the Hermes gateway daemon to be running. Start the gateway container or `hermes gateway` before relying on offline scheduled runs.';
+  const docsHref = 'https://github.com/nesquena/hermes-webui/blob/master/docs/docker.md#scheduled-jobs-require-a-gateway-daemon';
+  const helpLink = notConfigured
+    ? `<p><a href="${docsHref}" target="_blank" rel="noopener">How to enable scheduled jobs in Docker ↗</a></p>`
+    : '';
   return `
     <div class="detail-alert-title">${esc(title)}</div>
     <p>${esc(body)}</p>
+    ${helpLink}
   `;
 }
 

--- a/static/panels.js
+++ b/static/panels.js
@@ -437,7 +437,7 @@ function _cronGatewayNoticeHtml(status) {
   const body = notConfigured
     ? 'In Hermes WebUI, scheduled jobs require the Hermes gateway daemon. If this is a single-container Docker install, jobs can be created and run manually here, but scheduled ticks need a gateway container or `hermes gateway` running outside the WebUI.'
     : 'In Hermes WebUI, scheduled jobs require the Hermes gateway daemon to be running. Start the gateway container or `hermes gateway` before relying on offline scheduled runs.';
-  const docsHref = 'https://github.com/nesquena/hermes-webui/blob/master/docs/docker.md#scheduled-jobs-require-a-gateway-daemon';
+  const docsHref = 'https://github.com/nesquena/hermes-webui/blob/master/docs/docker.md#scheduled-jobs-and-the-gateway-daemon';
   const helpLink = notConfigured
     ? `<p><a href="${docsHref}" target="_blank" rel="noopener">How to enable scheduled jobs in Docker ↗</a></p>`
     : '';

--- a/static/style.css
+++ b/static/style.css
@@ -2322,7 +2322,7 @@ body.resizing .sidebar{transition:none!important;}
 .tool-card-more{background:none;border:none;color:var(--blue);font-size:10px;cursor:pointer;padding:3px 0 0;opacity:.7;display:block;}
 .tool-card-more:hover{opacity:1;}
 /* Subagent cards: indented with accent border */
-.tool-card-subagent{border-left:2px solid var(--accent-bg);margin-left:8px;}
+.tool-card.tool-card-subagent{border-left:2px solid var(--accent-bg);margin-left:8px;}
 /* Token usage badge below assistant messages */
 .msg-usage{font-size:11px;color:var(--muted);opacity:.6;margin-top:2px;padding-left:42px;}
 .msg-usage:hover{opacity:1;}

--- a/static/style.css
+++ b/static/style.css
@@ -2405,8 +2405,8 @@ body.resizing .sidebar{transition:none!important;}
     display:none;
   }
 }
-.tool-card{background:var(--surface-subtle);border:1px solid var(--border-subtle);border-radius:var(--radius-card);margin:2px 0;overflow:hidden;transition:border-color .15s,background-color .15s;}
-.tool-card:hover{border-color:var(--border-muted);background:var(--surface-subtle-hover);}
+.tool-card{background:var(--surface-subtle);border:1px solid var(--border-muted);border-left:2px solid var(--border-muted);border-radius:var(--radius-card);margin:2px 0;overflow:hidden;transition:border-color .15s,background-color .15s;}
+.tool-card:hover{border-color:var(--border2);background:var(--surface-subtle-hover);}
 .tool-card-running{border-color:var(--accent-bg-strong);background:var(--accent-bg);}
 .tool-card-header{display:flex;align-items:center;gap:var(--space-2);padding:var(--space-1) var(--space-3);cursor:pointer;user-select:none;}
 .tool-card-icon{font-size:13px;flex-shrink:0;opacity:.65;}

--- a/tests/test_contract_review_gate.py
+++ b/tests/test_contract_review_gate.py
@@ -32,3 +32,18 @@ def test_contracts_requires_docs_tests_and_pr_body_to_move_together():
 
     missing = [term for term in required_terms if term not in text]
     assert missing == []
+
+
+def test_contract_guidance_names_static_coverage_as_advisory_not_enforcement():
+    text = CONTRACTS.read_text(encoding="utf-8")
+
+    required_terms = [
+        "advisory",
+        "not an automated policy gate",
+        "does not enforce",
+        "PR-body content",
+        "release-time",
+    ]
+
+    missing = [term for term in required_terms if term not in text]
+    assert missing == []

--- a/tests/test_contract_review_gate.py
+++ b/tests/test_contract_review_gate.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CONTRIBUTING = ROOT / "CONTRIBUTING.md"
+CONTRACTS = ROOT / "docs" / "CONTRACTS.md"
+
+
+def test_contributing_requires_contract_routing_for_contract_affecting_prs():
+    text = CONTRIBUTING.read_text(encoding="utf-8")
+
+    required_terms = [
+        "contract-affecting PR",
+        "Contract Routing",
+        "Contract Change",
+        "release batch",
+    ]
+
+    missing = [term for term in required_terms if term not in text]
+    assert missing == []
+
+
+def test_contracts_requires_docs_tests_and_pr_body_to_move_together():
+    text = CONTRACTS.read_text(encoding="utf-8")
+
+    required_terms = [
+        "Contract Change",
+        "contract tests",
+        "corresponding docs",
+        "must not silently redefine",
+    ]
+
+    missing = [term for term in required_terms if term not in text]
+    assert missing == []

--- a/tests/test_issue1894_provider_overlap.py
+++ b/tests/test_issue1894_provider_overlap.py
@@ -1,8 +1,6 @@
 # Copyright 2025 the Hermes WebUI contributors
 # SPDX-License-Identifier: MIT
 
-# noqa: N801
-
 # Regression tests for GitHub issue #1894.
 #
 # Symptom: when the WebUI's configured provider (e.g. `opencode-go`) and a
@@ -44,15 +42,14 @@ def _restore_config(cfg_module, old_model, old_custom):
         cfg_module.cfg['custom_providers'] = old_custom
 
 
-# ---------------------------------------------------------------------------
-# Case 1 — overlap: selected non-custom provider should win
-# ---------------------------------------------------------------------------
-
 def test_selected_opencode_go_wins_over_custom_provider_overlap():
-    # opencode-go and a custom DeepSeek-compatible endpoint both serve
-    # deepseek-v4-pro.  With opencode-go configured as the active provider,
-    # selection of deepseek-v4-pro must route to opencode-go, not to the
-    # custom endpoint.
+    """Case 1 — overlap: selected non-custom provider should win.
+
+    OpenCode Go and a custom DeepSeek-compatible endpoint both serve
+    deepseek-v4-pro. With opencode-go configured as the active provider,
+    selection of deepseek-v4-pro must route to opencode-go, not to the
+    custom endpoint.
+    """
     import api.config as cfg_mod
     old_model, old_custom = _apply_config_overrides(cfg_mod, {
         'base_url': 'https://opencode.ai/zen/go/v1',
@@ -80,8 +77,11 @@ def test_selected_opencode_go_wins_over_custom_provider_overlap():
 
 
 def test_selected_opencode_go_wins_direct_resolve():
-    # Same scenario but bypassing model_with_provider_context to test the
-    # resolver path directly with a bare model id.
+    """Case 1 variant — same overlap scenario via direct resolve path.
+
+    Bypasses model_with_provider_context to test the resolver path directly
+    with a bare model id.
+    """
     import api.config as cfg_mod
     old_model, old_custom = _apply_config_overrides(cfg_mod, {
         'base_url': 'https://opencode.ai/zen/go/v1',
@@ -106,8 +106,11 @@ def test_selected_opencode_go_wins_direct_resolve():
 # ---------------------------------------------------------------------------
 
 def test_custom_only_model_still_routes_to_custom_provider():
-    # A model that exists only in a custom provider must still be routed
-    # correctly when no explicit provider prefix is given.
+    """Case 2 — custom-only model routing must stay intact.
+
+    A model that exists only in a custom provider must still be routed
+    correctly when no explicit provider prefix is given.
+    """
     import api.config as cfg_mod
     old_model, old_custom = _apply_config_overrides(cfg_mod, {
         'base_url': 'https://opencode.ai/zen/go/v1',
@@ -132,7 +135,10 @@ def test_custom_only_model_still_routes_to_custom_provider():
 # ---------------------------------------------------------------------------
 
 def test_explicit_custom_provider_selection_intact():
-    # @custom:<name>:<model> syntax must not be swallowed by the new guard.
+    """Case 3 — explicit custom provider selection still works.
+
+    The @custom:<name>:<model> syntax must not be swallowed by the new guard.
+    """
     model, provider, base_url = resolve_model_provider('@custom:ds2api:deepseek-v4-pro')
     assert provider == 'custom:ds2api', f'Expected provider=custom:ds2api, got {provider!r}'
     assert model == 'deepseek-v4-pro'
@@ -143,6 +149,11 @@ def test_explicit_custom_provider_selection_intact():
 # ---------------------------------------------------------------------------
 
 def test_openrouter_suffix_still_works():
+    """Case 4 — existing suffix syntax is preserved.
+
+    Ensures the openrouter suffix syntax (e.g. model_name:free) still routes
+    correctly through model_with_provider_context.
+    """
     import api.config as cfg_mod
     old_model, old_custom = _apply_config_overrides(cfg_mod, {
         'provider': 'anthropic',          # non-openrouter so prefix is needed

--- a/tests/test_issue1894_provider_overlap.py
+++ b/tests/test_issue1894_provider_overlap.py
@@ -1,21 +1,22 @@
 # Copyright 2025 the Hermes WebUI contributors
 # SPDX-License-Identifier: MIT
 
-# Regression tests for GitHub issue #1894.
-#
-# Symptom: when the WebUI's configured provider (e.g. `opencode-go`) and a
-# `custom_providers[]` entry both expose the same bare model id (e.g.
-# `deepseek-v4-pro`), the resolver was routing to `custom:<name>` instead of
-# the configured `opencode-go` endpoint.
-#
-# Root cause: `resolve_model_provider()` in `api/config.py` guarded the custom-
-# provider skip only when `model_id == model.default`.  If `model.default`
-# was a different model (e.g. `glm-5.1`), the overlap was not detected and
-# `deepseek-v4-pro` was matched against `custom_providers[]` first, routing
-# the WebUI to the wrong endpoint.
-#
-# Fix: widen the guard so an explicit non-custom provider wins for any model
-# it owns in `_PROVIDER_MODELS[config_provider]`.
+"""Regression tests for GitHub issue #1894.
+
+Symptom: when the WebUI's configured provider (e.g. ``opencode-go``) and a
+``custom_providers[]`` entry both expose the same bare model id (e.g.
+``deepseek-v4-pro``), the resolver was routing to ``custom:<name>`` instead of
+the configured ``opencode-go`` endpoint.
+
+Root cause: ``resolve_model_provider()`` in ``api/config.py`` guarded the
+custom-provider skip only when ``model_id == model.default``. If
+``model.default`` was a different model (e.g. ``glm-5.1``), the overlap was
+not detected and ``deepseek-v4-pro`` was matched against
+``custom_providers[]`` first, routing the WebUI to the wrong endpoint.
+
+Fix: widen the guard so an explicit non-custom provider wins for any model
+it owns in ``_PROVIDER_MODELS[config_provider]``.
+"""
 
 from api.config import resolve_model_provider, model_with_provider_context
 
@@ -101,10 +102,6 @@ def test_selected_opencode_go_wins_direct_resolve():
         _restore_config(cfg_mod, old_model, old_custom)
 
 
-# ---------------------------------------------------------------------------
-# Case 2 — custom-only model: custom provider routing must stay intact
-# ---------------------------------------------------------------------------
-
 def test_custom_only_model_still_routes_to_custom_provider():
     """Case 2 — custom-only model routing must stay intact.
 
@@ -130,10 +127,6 @@ def test_custom_only_model_still_routes_to_custom_provider():
         _restore_config(cfg_mod, old_model, old_custom)
 
 
-# ---------------------------------------------------------------------------
-# Case 3 — explicit custom provider selection still works
-# ---------------------------------------------------------------------------
-
 def test_explicit_custom_provider_selection_intact():
     """Case 3 — explicit custom provider selection still works.
 
@@ -143,10 +136,6 @@ def test_explicit_custom_provider_selection_intact():
     assert provider == 'custom:ds2api', f'Expected provider=custom:ds2api, got {provider!r}'
     assert model == 'deepseek-v4-pro'
 
-
-# ---------------------------------------------------------------------------
-# Case 4 — existing suffix syntax is preserved
-# ---------------------------------------------------------------------------
 
 def test_openrouter_suffix_still_works():
     """Case 4 — existing suffix syntax is preserved.

--- a/tests/test_issue1894_provider_overlap.py
+++ b/tests/test_issue1894_provider_overlap.py
@@ -55,7 +55,7 @@ def test_selected_opencode_go_wins_over_custom_provider_overlap():
     # custom endpoint.
     import api.config as cfg_mod
     old_model, old_custom = _apply_config_overrides(cfg_mod, {
-        'base_url': 'https://api.opencode.ai/go/v1',
+        'base_url': 'https://opencode.ai/zen/go/v1',
     })
     cfg_mod.cfg['custom_providers'] = [{
         'name': 'ds2api',
@@ -71,7 +71,7 @@ def test_selected_opencode_go_wins_over_custom_provider_overlap():
             f'Expected provider=opencode-go, got provider={provider!r}. '
             f'WebUI was routed to custom provider instead.'
         )
-        assert base_url == 'https://api.opencode.ai/go/v1', (
+        assert base_url == 'https://opencode.ai/zen/go/v1', (
             f'Expected base_url from opencode-go config, got {base_url!r}'
         )
         assert model == 'deepseek-v4-pro'
@@ -84,7 +84,7 @@ def test_selected_opencode_go_wins_direct_resolve():
     # resolver path directly with a bare model id.
     import api.config as cfg_mod
     old_model, old_custom = _apply_config_overrides(cfg_mod, {
-        'base_url': 'https://api.opencode.ai/go/v1',
+        'base_url': 'https://opencode.ai/zen/go/v1',
     })
     cfg_mod.cfg['custom_providers'] = [{
         'name': 'ds2api',
@@ -96,7 +96,7 @@ def test_selected_opencode_go_wins_direct_resolve():
         assert provider == 'opencode-go', (
             f'Expected provider=opencode-go, got provider={provider!r}'
         )
-        assert base_url == 'https://api.opencode.ai/go/v1'
+        assert base_url == 'https://opencode.ai/zen/go/v1'
     finally:
         _restore_config(cfg_mod, old_model, old_custom)
 
@@ -110,7 +110,7 @@ def test_custom_only_model_still_routes_to_custom_provider():
     # correctly when no explicit provider prefix is given.
     import api.config as cfg_mod
     old_model, old_custom = _apply_config_overrides(cfg_mod, {
-        'base_url': 'https://api.opencode.ai/go/v1',
+        'base_url': 'https://opencode.ai/zen/go/v1',
     })
     cfg_mod.cfg['custom_providers'] = [{
         'name': 'ds2api',

--- a/tests/test_issue2775_log_request.py
+++ b/tests/test_issue2775_log_request.py
@@ -16,3 +16,39 @@ def test_log_request_handles_malformed_request_without_path(capsys):
     assert record["method"] == "-"
     assert record["path"] == "-"
     assert record["status"] == 400
+    assert record["remote"] == "-"
+
+
+def test_log_request_includes_remote_address(capsys):
+    handler = Handler.__new__(Handler)
+    handler.command = "POST"
+    handler.path = "/api/auth/login"
+    handler.client_address = ("192.0.2.10", 54321)
+    handler.headers = {}
+
+    Handler.log_request(handler, "401")
+
+    line = capsys.readouterr().out.strip()
+    record = json.loads(line.removeprefix("[webui] "))
+    assert record["remote"] == "192.0.2.10"
+    assert "forwarded_for" not in record
+
+
+def test_log_request_includes_first_forwarded_for_address(capsys):
+    class Headers:
+        def get(self, key):
+            assert key == "X-Forwarded-For"
+            return "203.0.113.7, 198.51.100.9"
+
+    handler = Handler.__new__(Handler)
+    handler.command = "POST"
+    handler.path = "/api/auth/login"
+    handler.client_address = ("192.0.2.10", 54321)
+    handler.headers = Headers()
+
+    Handler.log_request(handler, "401")
+
+    line = capsys.readouterr().out.strip()
+    record = json.loads(line.removeprefix("[webui] "))
+    assert record["remote"] == "192.0.2.10"
+    assert record["forwarded_for"] == "203.0.113.7"

--- a/tests/test_runtime_adapter_seam.py
+++ b/tests/test_runtime_adapter_seam.py
@@ -558,6 +558,7 @@ def test_rfc_defines_slice4e_runner_chat_start_route_selection_harness():
     rfc = (routes.Path(__file__).parent.parent / "docs" / "rfcs" / "hermes-run-adapter-contract.md").read_text(encoding="utf-8")
 
     assert "#### Slice 4e: Default-off runner chat-start route-selection harness" in rfc
+    assert "Status as of 2026-05-24: shipped in v0.51.129 via #2794" in rfc
     assert "route `/api/chat/start` through `build_runtime_adapter(...)`" in rfc
     assert "`legacy-direct` stays default" in rfc
     assert "`legacy-journal`\ncontinues to delegate to the legacy in-process stream path" in rfc
@@ -565,6 +566,22 @@ def test_rfc_defines_slice4e_runner_chat_start_route_selection_harness():
     assert "return a bounded not-configured error for `runner-local`" in rfc
     assert "`run_id`, `status`, and\n   `active_controls` remain internal" in rfc
     assert "no supervised runner process yet" in rfc
+
+
+def test_rfc_defines_slice4f_supervised_local_runner_client_gate():
+    routes = importlib.import_module("api.routes")
+    rfc = (routes.Path(__file__).parent.parent / "docs" / "rfcs" / "hermes-run-adapter-contract.md").read_text(encoding="utf-8")
+
+    assert "#### Slice 4f: Supervised local runner client backend gate" in rfc
+    assert "replace the bounded 501 path under the existing\nfeature flag" in rfc
+    assert "durable runner-owned run id plus session-to-run lookup" in rfc
+    assert "cancel as the first required live control" in rfc
+    assert "501 path replaced only when configured" in rfc
+    assert "Restart/reattach proves ownership moved" in rfc
+    assert "No runtime-surrogate globals" in rfc
+    assert "Successful chat-start responses remain limited\n   to the legacy-compatible field whitelist" in rfc
+    assert "Unsupported runner controls return safe\n   `unsupported`, `not-active`, or `conflict` results" in rfc
+    assert "no permanent WebUI-owned active-run discovery cache" in rfc
 
 def test_runner_runtime_adapter_passes_explicit_start_payload_without_env_mutation(monkeypatch):
     runtime = importlib.import_module("api.runtime_adapter")


### PR DESCRIPTION
# Release DJ / v0.51.138 — stage-batch20 (7 PRs)

Tier-1 ultra-safe batch — docs, tests cleanup, single-file behavioral fixes ≤53 LOC.

## PRs merged

| PR | Author | Net LOC | Surface |
|----|--------|---------|---------|
| #2960 | franksong2702 | +100 | docs — Contract Routing requirement in CONTRIBUTING.md + CONTRACTS.md |
| #2972 | Michaelyklam | +86 | docs — RFC Slice 4f supervised local runner client gate |
| #2975 | someaka | +48/-48 | tests cleanup — canonicalize opencode-go base_url, drop vestigial noqa, docstrings |
| #2949 | Sanjays2402 | +17/-1 | static/panels.js — surface CSRF rejection reason on 403 when removing provider key |
| #2982 | xolom | +53/-2 | server.py — add `remote` + `forwarded_for` to structured request logs (fail2ban-friendly) |
| #2948 | Sanjays2402 | +7/-3 | static/style.css — tool cards visually distinct at rest (border + 2px left edge) |
| #2950 | Sanjays2402 | +35/-1 | docs/docker.md + static/panels.js — gateway-banner deep link to docker docs |

## Verification

- ✅ Pre-merge: all 7 CI-green, no stale-base traps
- ✅ Post-merge gates: no merge markers, `ast.parse` clean on all changed .py, `node -c` clean on `static/panels.js`
- ✅ pytest: **6592 passed / 6 skipped / 3 xpassed / 0 failures** (190s sequential, `-p no:xdist`)
- ✅ Opus advisor: **SHIP-AS-IS** — verified all 6 listed concerns line-by-line:
  - #2982: `_json.dumps()` escapes `\n`/`\r` in X-Forwarded-For — log injection safe
  - #2949: `api()` wrapper in static/workspace.js:44 sets `err.status` on non-ok responses; 403 branch will fire correctly
  - #2948: `tool-card-subagent` always emitted alongside `tool-card` in static/ui.js:6723 — specificity bump is correct everywhere
  - #2950: GitHub slug `#scheduled-jobs-require-a-gateway-daemon` matches actual heading in docs/docker.md:63
  - #2960 + #2972: pure docs, no new code paths beyond static-text assertions
  - #2975: round-trip self-consistent test; production code wasn't affected (no behavior change)
- ✅ CHANGELOG entries explicit for all 7 PRs (including backfills for #2975 and #2982)

## Notes for reviewers

This batch picks up smaller-than-typical fixes from `Sanjays2402` (3 PRs, all surgical: toast text, CSS resting state, docker docs link), plus one tests-only cleanup, two docs PRs (one RFC slice, one contract-routing process), and one production-affecting fix (#2982 adds client IP to logs for fail2ban-style downstream tooling).

Sitting on top of v0.51.137 (Release DI).
