### PR TITLE
Release DL — stage-batch22 — 5-PR hold-bucket reassessment (v0.51.140)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@
 ### Fixed
 
 - Live streamed assistant Markdown now treats underscores in ordinary text and identifiers literally, matching the settled message renderer while preserving asterisk-based emphasis.
+- Models cache no longer churns every ~14 minutes when the auth.json credential pool refreshes. The auth.json fingerprint now hashes provider-identity fields (active_provider, credential_pool ids, base_url, auth_type) and excludes pure credential-rotation fields (access_token, refresh_token, expires_at, last_status, request_count, updated_at). Real provider/model-set changes still invalidate the cache. (RCA t_16551f61)
+- Paginated `/api/session?msg_limit=N` windows now anchor on the newest renderable transcript row instead of the raw message-array tail. Long sessions whose newest rows are only hidden tool-result entries no longer open to an empty visible transcript with non-empty `S.messages`.
+- `_loadOlderMessages()` now requests a larger cumulative tail window (`msg_limit=current+30`) rather than a separate `msg_before` page. Suffix-continuity check guards against races and falls back to the legacy index-page request when the loaded transcript is no longer the suffix of the new server response.
+
+### Performance
+
+- `renderMessages()` now caches `renderMd()` / `_renderUserFencedBlocks()` output keyed on message text, caches the visible-message scan across renders, scopes the question→assistant lookup to the visible window, and Prism-highlights only newly-mounted code blocks. Long sessions with many messages no longer freeze the browser tab on every render.
 
 ## [v0.51.139] — 2026-05-25 — Release DK (stage-batch21 — 5-PR tier-2 batch)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 ## [Unreleased]
 
+## [v0.51.140] — 2026-05-26 — Release DL (stage-batch22 — 5-PR hold-bucket reassessment)
+
 ### Fixed
 
 - Live streamed assistant Markdown now treats underscores in ordinary text and identifiers literally, matching the settled message renderer while preserving asterisk-based emphasis.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Live streamed assistant Markdown now treats underscores in ordinary text and identifiers literally, matching the settled message renderer while preserving asterisk-based emphasis.
+
 ## [v0.51.132] — 2026-05-24 — Release DD (stage-batch14 — 4-PR replayed-context + interrupted-response + shutdown affordance + passkey opt-in)
 
 ### Added

--- a/api/config.py
+++ b/api/config.py
@@ -2437,11 +2437,131 @@ def _models_cache_catalog_fingerprint() -> dict:
     }
 
 
+# Credential-rotation fields inside auth.json that churn on a ~14-minute
+# period (credential-pool / OAuth token refresh rewrites the whole file) but
+# DO NOT change the set of available providers or models that /api/models
+# returns. mtime/size-based fingerprinting (#1699's _models_cache_file_
+# fingerprint) treats every one of these rewrites as a cache-invalidating
+# change, so the 24h models cache is effectively dead — every few minutes a
+# tab pays a full cold get_available_models() rebuild (see RCA t_d127953d /
+# t_16551f61). We strip ONLY these known-inert fields and fingerprint the
+# rest of auth.json by content, so token rotation no longer busts the cache.
+#
+# This is a DENY-list, not an allow-list, on purpose: a field we don't know
+# about stays IN the fingerprint, so any genuine change to provider
+# enablement / endpoint / api-base / model-allow (active_provider, a NEW
+# credential_pool entry id, base_url, source, label, key_source, auth_type,
+# priority, the providers{} block, …) still correctly invalidates the cache.
+# The safety invariant is one-directional: excluding these fields can only
+# ever make the fingerprint MORE stable, never make it miss a real
+# provider/model-set change — because none of these fields feed
+# detected_providers / the catalog in _build_available_models_uncached().
+_AUTH_FINGERPRINT_VOLATILE_KEYS = frozenset({
+    # Secret material — rotates on refresh, never gates the provider/model set.
+    "access_token",
+    "refresh_token",
+    "id_token",
+    "api_key",
+    "secret",
+    "client_secret",
+    # Expiry / liveness — bumped every refresh, derived from the token above.
+    "expires_at",
+    "expires_at_ms",
+    "expires_in",
+    # Per-credential status/telemetry — churns on every request, not config.
+    "last_status",
+    "last_status_at",
+    "last_error_code",
+    "last_error_reason",
+    "last_error_message",
+    "last_error_reset_at",
+    "request_count",
+    # Whole-file save timestamp — rewritten on every _save_auth_store().
+    "updated_at",
+})
+
+
+def _strip_volatile_auth_fields(obj):
+    """Recursively drop credential-rotation-only keys from an auth.json tree.
+
+    Pure structural transform; never mutates the input. Any key NOT in the
+    deny-list is preserved verbatim so real provider/endpoint changes still
+    show through in the fingerprint.
+    """
+    if isinstance(obj, dict):
+        return {
+            k: _strip_volatile_auth_fields(v)
+            for k, v in obj.items()
+            if k not in _AUTH_FINGERPRINT_VOLATILE_KEYS
+        }
+    if isinstance(obj, list):
+        return [_strip_volatile_auth_fields(v) for v in obj]
+    return obj
+
+
+def _auth_store_semantic_fingerprint(path: Path) -> dict:
+    """Return a content fingerprint of auth.json that ignores token churn.
+
+    Unlike _models_cache_file_fingerprint() (mtime_ns + size), this hashes
+    the JSON content with the credential-rotation fields stripped, so the
+    ~14-min token-refresh rewrite of auth.json does NOT invalidate the 24h
+    /api/models cache. A change to anything that actually affects the
+    provider/model set (active_provider, a new credential_pool entry, a
+    changed base_url/source/label/auth_type, the providers{} block, …)
+    still changes the hash and correctly busts the cache.
+
+    Failure modes are deliberately conservative — if the file is missing we
+    record that, and if it can't be read/parsed we fall back to the old
+    mtime/size fingerprint so behaviour is never *less* safe than #1699.
+    """
+    p = Path(path).expanduser()
+    fp: dict = {"path": str(p)}
+    try:
+        st = p.stat()
+    except OSError:
+        fp["missing"] = True
+        return fp
+    try:
+        raw = json.loads(p.read_text(encoding="utf-8"))
+    except Exception:
+        # Unreadable / corrupt / mid-write: fall back to the stat-based
+        # fingerprint. Strictly no less safe than the pre-fix behaviour
+        # (every write still invalidates) for this rare path only.
+        fp["mtime_ns"] = st.st_mtime_ns
+        fp["size"] = st.st_size
+        fp["semantic"] = "unparsed-fallback"
+        return fp
+    stripped = _strip_volatile_auth_fields(raw)
+    try:
+        encoded = json.dumps(
+            stripped,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+            default=str,
+        ).encode("utf-8")
+        fp["semantic_sha256"] = hashlib.sha256(encoded).hexdigest()
+    except Exception:
+        fp["mtime_ns"] = st.st_mtime_ns
+        fp["size"] = st.st_size
+        fp["semantic"] = "encode-fallback"
+    return fp
+
+
 def _models_cache_source_fingerprint() -> dict:
-    """Return the current config/auth/catalog fingerprint for /api/models cache."""
+    """Return the current config/auth/catalog fingerprint for /api/models cache.
+
+    The auth.json axis uses a *content* fingerprint that excludes pure
+    credential-rotation fields (see _auth_store_semantic_fingerprint): the
+    auth store is rewritten roughly every 14 minutes by token refresh, and
+    a stat-based (mtime/size) fingerprint made the 24h cache churn on every
+    one of those rewrites (RCA t_16551f61). config.yaml keeps the cheap
+    mtime/size fingerprint because it is only rewritten on deliberate user
+    edits (which can change anything) and does not churn on a timer.
+    """
     return {
         "config_yaml": _models_cache_file_fingerprint(_get_config_path()),
-        "auth_json": _models_cache_file_fingerprint(_get_auth_store_path()),
+        "auth_json": _auth_store_semantic_fingerprint(_get_auth_store_path()),
         "catalog": _models_cache_catalog_fingerprint(),
     }
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -2163,6 +2163,54 @@ def _tool_calls_for_message_window(tool_calls, start_idx: int, message_count: in
     return filtered
 
 
+def _message_counts_as_renderable_for_window(message) -> bool:
+    """Return true when a paginated window should include this transcript row.
+
+    Tool result rows are rendered through their assistant anchor or hidden as raw
+    tool output. A tail page containing only tool rows makes the frontend set
+    ``S.messages`` to a non-empty array while the visible transcript and topbar
+    count stay empty. Anchor small tail windows on the newest non-tool row so
+    long sessions do not open to a blank chat with only transient metadata.
+    """
+    if not isinstance(message, dict):
+        return False
+    role = str(message.get("role") or "").strip().lower()
+    return bool(role and role != "tool")
+
+
+def _message_window_for_display(messages, msg_limit=None, msg_before=None) -> tuple[list, int]:
+    """Return a paginated message window plus its offset in ``messages``.
+
+    The normal fast path is a raw tail window. If that window contains no
+    renderable transcript rows because state.db appended hidden tool rows after
+    the visible assistant tail, shift the window end back to the newest
+    renderable row. This preserves the raw index cursor while avoiding the
+    WebUI blank-transcript trap.
+    """
+    messages = list(messages or [])
+    if msg_before is not None:
+        before_idx = max(0, min(int(msg_before), len(messages)))
+    else:
+        before_idx = len(messages)
+    source = messages[:before_idx]
+    if not source:
+        return [], 0
+    if not msg_limit:
+        return source, 0
+    limit = max(1, int(msg_limit))
+    end_idx = len(source)
+    start_idx = max(0, end_idx - limit)
+    window = source[start_idx:end_idx]
+    if window and not any(_message_counts_as_renderable_for_window(msg) for msg in window):
+        for idx in range(end_idx - 1, -1, -1):
+            if _message_counts_as_renderable_for_window(source[idx]):
+                end_idx = idx + 1
+                start_idx = max(0, end_idx - limit)
+                window = source[start_idx:end_idx]
+                break
+    return window, start_idx
+
+
 def _merged_session_messages_for_display(session, cli_messages=None) -> list:
     """Return the message coordinate space exposed by ``GET /api/session``.
 
@@ -4090,29 +4138,19 @@ def handle_get(handler, parsed) -> bool:
                 _summary_message_count = None
                 _summary_last_message_at = None
             if load_messages:
+                _truncated_msgs, _messages_offset = _message_window_for_display(
+                    _all_msgs,
+                    msg_limit=msg_limit,
+                    msg_before=msg_before,
+                )
                 if msg_before is not None:
-                    # Scroll-to-top paging: msg_before is a 0-based index into
-                    # the full message list. Return the msg_limit messages that
-                    # appear *before* this index (i.e. older messages).
-                    # Using index instead of timestamp avoids issues with
-                    # duplicate/missing timestamps.
                     _before_idx = max(0, min(int(msg_before), len(_all_msgs)))
                     _slice = _all_msgs[:_before_idx]
-                    _truncated_msgs = _slice[-msg_limit:] if msg_limit else _slice
-                elif msg_limit and len(_all_msgs) > msg_limit:
-                    _truncated_msgs = _all_msgs[-msg_limit:]
-                else:
-                    _truncated_msgs = _all_msgs
             else:
                 _truncated_msgs = []
+                _messages_offset = 0
             # Index of the first returned message in the full message array.
             # Frontend uses this as cursor for scroll-to-top paging.
-            if load_messages and msg_before is not None:
-                _messages_offset = max(0, _before_idx - len(_truncated_msgs))
-            elif load_messages:
-                _messages_offset = max(0, len(_all_msgs) - len(_truncated_msgs))
-            else:
-                _messages_offset = 0
             _windowed_messages = (
                 load_messages
                 and msg_limit is not None

--- a/static/messages.js
+++ b/static/messages.js
@@ -1002,8 +1002,35 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     _smdWrittenLen=0;
     _smdWrittenText='';
     if(!window.smd){_smdParser=null;return;}
-    const renderer=fade ? _streamFadeRenderer(el) : window.smd.default_renderer(el);
+    const baseRenderer=fade ? _streamFadeRenderer(el) : window.smd.default_renderer(el);
+    const renderer=_smdRendererWithoutUnderscoreEmphasis(baseRenderer);
     _smdParser=window.smd.parser(renderer);
+  }
+  function _smdRendererWithoutUnderscoreEmphasis(renderer){
+    if(!renderer||!window.smd) return renderer;
+    const baseAddToken=renderer.add_token;
+    const baseEndToken=renderer.end_token;
+    const baseAddText=renderer.add_text;
+    const tokenStack=[];
+    renderer.add_token=(data,token)=>{
+      if(token===window.smd.ITALIC_UND||token===window.smd.STRONG_UND){
+        const marker=token===window.smd.STRONG_UND?'__':'_';
+        tokenStack.push(marker);
+        baseAddText(data,marker);
+        return;
+      }
+      tokenStack.push(null);
+      baseAddToken(data,token);
+    };
+    renderer.end_token=(data)=>{
+      const marker=tokenStack.pop();
+      if(marker){
+        baseAddText(data,marker);
+        return;
+      }
+      baseEndToken(data);
+    };
+    return renderer;
   }
   // Helper: end the current smd parser (flushes remaining state) and null it out.
   function _smdEndParser(){

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1356,7 +1356,15 @@ async function _loadOlderMessages() {
   // rebuilt transcript (#1937).
   const startGeneration = _messagesGeneration;
   try {
-    const data = await api(`/api/session?session_id=${encodeURIComponent(sid)}&messages=1&resolve_model=0&msg_before=${_oldestIdx}&msg_limit=${_INITIAL_MSG_LIMIT}`);
+    // Ask the server for a larger authoritative tail window instead of a
+    // separate msg_before page. The same /api/session contract handles both —
+    // post-#2716 the backend always runs the full append-only merge, so a
+    // larger msg_limit on the same call produces the same merged transcript
+    // we'd get by stitching pages, but without client-side index bookkeeping.
+    // Cumulative growth: each "load more" asks for currentLoaded + 30, and the
+    // newly exposed head is what we expose to the user.
+    const requestedLimit = Math.max(_INITIAL_MSG_LIMIT, (S.messages || []).length + _INITIAL_MSG_LIMIT);
+    const data = await api(`/api/session?session_id=${encodeURIComponent(sid)}&messages=1&resolve_model=0&msg_limit=${requestedLimit}`);
     // Guard: api() may have redirected (401) and returned undefined.
     if (!data || !data.session) { _loadingOlder = false; return; }
     //  - response shape sane
@@ -1374,13 +1382,50 @@ async function _loadOlderMessages() {
     // counter and abort cleanly. _oldestIdx and _messagesTruncated were
     // already reset by the wholesale-replace path, so no rollback needed.
     if (_messagesGeneration !== startGeneration) return;
-    const olderMsgs = (data.session.messages || []).filter(m => m && m.role);
-    if (!olderMsgs.length) { _messagesTruncated = false; return; }
-    // Prepend older messages
+    let responseSession = data.session;
+    let expandedMsgs = (responseSession.messages || []).filter(m => m && m.role);
+    const currentMsgs = (S.messages || []).filter(m => m && m.role);
+    const currentLen = currentMsgs.length;
+    // Suffix-continuity check: the cumulative tail is only safe to wholesale-
+    // replace when our currently-displayed messages are still its suffix. If
+    // the server appended new messages (or merge filtered something) while we
+    // were awaiting, the suffix won't line up — fall back to the legacy
+    // msg_before page so we never drop visible older messages on the floor.
+    let tailMatches = expandedMsgs.length >= currentLen;
+    if (tailMatches && currentLen > 0) {
+      const start = expandedMsgs.length - currentLen;
+      for (let i = 0; i < currentLen; i++) {
+        if (!_sameTranscriptMessage(expandedMsgs[start + i], currentMsgs[i])) {
+          tailMatches = false;
+          break;
+        }
+      }
+    }
+    let olderCount = Math.max(0, expandedMsgs.length - currentLen);
+    let olderMsgs = expandedMsgs.slice(0, olderCount);
+    let nextMessages = expandedMsgs;
+    if (!tailMatches) {
+      // Race fallback: keep the legacy index-page request as the
+      // correctness-preserving alternative. Same guards reapplied because
+      // we just awaited again.
+      const fallback = await api(`/api/session?session_id=${encodeURIComponent(sid)}&messages=1&resolve_model=0&msg_before=${_oldestIdx}&msg_limit=${_INITIAL_MSG_LIMIT}`);
+      if (!fallback || !fallback.session) { _loadingOlder = false; return; }
+      if (!S.session || S.session.session_id !== sid) return;
+      if (_loadingSessionId !== null && _loadingSessionId !== sid) return;
+      if (_messagesGeneration !== startGeneration) return;
+      responseSession = fallback.session;
+      olderMsgs = (responseSession.messages || []).filter(m => m && m.role);
+      nextMessages = [...olderMsgs, ...S.messages];
+    }
+    if (!olderMsgs.length) { _messagesTruncated = !!responseSession._messages_truncated; return; }
+    // Replace with the larger tail window and preserve scroll as if older
+    // messages were prepended. When the suffix check fails, nextMessages
+    // already encodes the legacy prepend fallback so the visible behavior
+    // matches the old msg_before page path exactly.
     // Use $('messages') — the scrollable container (#msgInner is not scrollable).
     const container = $('messages');
     const prevScrollH = container ? container.scrollHeight : 0;
-    S.messages = [...olderMsgs, ...S.messages];
+    S.messages = nextMessages;
     // renderMessages() windows long transcripts from the end. If we do not
     // expand that window before rendering, the newly prepended page stays
     // hidden and the "hidden" counter rises while the viewport appears stuck.
@@ -1394,8 +1439,8 @@ async function _loadOlderMessages() {
       return !!(msgContent(m)||m._statusCard||m.attachments?.length||(m.role==='assistant'&&(hasTc||hasTu||(typeof _messageHasReasoningPayload==='function'&&_messageHasReasoningPayload(m)))));
     }).length;
     _messageRenderWindowSize=_currentMessageRenderWindowSize()+Math.max(addedRenderable, MESSAGE_RENDER_WINDOW_DEFAULT);
-    _messagesTruncated = !!data.session._messages_truncated;
-    _oldestIdx = data.session._messages_offset || 0;
+    _messagesTruncated = !!responseSession._messages_truncated;
+    _oldestIdx = responseSession._messages_offset || 0;
     renderMessages({ preserveScroll: true });
     if (container) {
       // Prepending older messages must not teleport the reader. Preserve the

--- a/static/ui.js
+++ b/static/ui.js
@@ -6178,9 +6178,19 @@ function renderMessages(options){
   }
   let _prevSepKey=null;
   let currentAssistantTurn=null;
+  // Only build question→assistant mapping for the visible window, not the
+  // full visWithIdx.  The jump-to-question button is only rendered for
+  // assistant messages that appear in the current render window anyway.
   const questionRawIdxByAssistantRawIdx=new Map();
+  // Seed lastQuestionRawIdx from hidden messages so the first visible
+  // assistant message still gets a valid jump target even when its
+  // corresponding user message sits just before the render window.
   let lastQuestionRawIdx=-1;
-  for(const entry of visWithIdx){
+  for(let i=0;i<windowStart;i++){
+    const role=visWithIdx[i]?.m?.role;
+    if(role==='user') lastQuestionRawIdx=visWithIdx[i].rawIdx;
+  }
+  for(const entry of renderVisWithIdx){
     const role=entry&&entry.m&&entry.m.role;
     if(role==='user') lastQuestionRawIdx=entry.rawIdx;
     else if(role==='assistant') questionRawIdxByAssistantRawIdx.set(entry.rawIdx,lastQuestionRawIdx);
@@ -6188,11 +6198,19 @@ function renderMessages(options){
   const assistantSegments=new Map();
   const assistantThinking=new Map();
   const userRows=new Map();
+  // Only collect tool-call assistant indices for messages that are actually
+  // rendered in the current window.  S.toolCalls can grow large in long turns,
+  // but we only need the ones whose assistant_msg_idx falls inside the visible
+  // range.
   const toolCallAssistantIdxs=new Set();
   if(Array.isArray(S.toolCalls)){
+    const renderedRawIdxs=new Set(renderVisWithIdx.map(e=>e.rawIdx));
     for(const tc of S.toolCalls){
       if(!tc) continue;
-      toolCallAssistantIdxs.add(tc.assistant_msg_idx!==undefined?tc.assistant_msg_idx:-1);
+      const idx=tc.assistant_msg_idx;
+      if(idx!==undefined && renderedRawIdxs.has(idx)){
+        toolCallAssistantIdxs.add(idx);
+      }
     }
   }
   // Windowed render loop replaces the legacy full loop:

--- a/static/ui.js
+++ b/static/ui.js
@@ -265,10 +265,15 @@ function _statusCardHtml(card){
 const MESSAGE_RENDER_WINDOW_DEFAULT=50;
 let _messageRenderWindowSid=null;
 let _messageRenderWindowSize=MESSAGE_RENDER_WINDOW_DEFAULT;
+// Cached visWithIdx array — invalidated when S.messages.length changes.
+let _visWithIdxCache=null;
+let _visWithIdxCacheLen=0;
 function _resetMessageRenderWindow(sid){
   _messageRenderWindowSid=sid||null;
   _messageRenderWindowSize=MESSAGE_RENDER_WINDOW_DEFAULT;
   _clearRenderCache();
+  _visWithIdxCache=null;
+  _visWithIdxCacheLen=0;
 }
 
 // ── renderMd / _renderUserFencedBlocks cache ──────────────────────────────
@@ -6120,15 +6125,29 @@ function renderMessages(options){
     ? (()=>{const row=document.createElement('div');row.innerHTML=`<div class="compression-turn"><div class="compression-turn-blocks">${_compressionReferenceCardHtml(referenceText,false)}${_preservedCompressionTaskListCardsHtml(preservedCompressionTaskMessages)}</div></div>`;return row.firstElementChild;})()
     : null;
   let preservedCompressionTaskCardsAttached=!!referenceNode;
-  const visWithIdx=[];
+  // Cache visWithIdx so expanding the render window (Load earlier) doesn't
+  // re-scan S.messages from scratch.  Invalidate only when the message array
+  // length changes — i.e. new messages arrived or session was truncated.
+  if(!_visWithIdxCache || _visWithIdxCacheLen !== S.messages.length){
+    const rebuilt=[];
+    let ri=0;
+    for(const m of S.messages){
+      if(!m||!m.role||m.role==='tool'){ri++;continue;}
+      if(_isPreservedCompressionTaskListMessage(m)){ri++;continue;}
+      const hasTc=Array.isArray(m.tool_calls)&&m.tool_calls.length>0;
+      const hasTu=Array.isArray(m.content)&&m.content.some(p=>p&&p.type==='tool_use');
+      if(msgContent(m)||m._statusCard||m.attachments?.length||(m.role==='assistant'&&(hasTc||hasTu||_messageHasReasoningPayload(m)))) rebuilt.push({m,rawIdx:ri});
+      ri++;
+    }
+    _visWithIdxCache=rebuilt;
+    _visWithIdxCacheLen=S.messages.length;
+  }
+  const visWithIdx=_visWithIdxCache;
   const preservedCompressionRawIdxs=[];
   let rawIdx=0;
   for(const m of S.messages){
     if(!m||!m.role||m.role==='tool'){rawIdx++;continue;}
     if(_isPreservedCompressionTaskListMessage(m)){preservedCompressionRawIdxs.push(rawIdx);rawIdx++;continue;}
-    const hasTc=Array.isArray(m.tool_calls)&&m.tool_calls.length>0;
-    const hasTu=Array.isArray(m.content)&&m.content.some(p=>p&&p.type==='tool_use');
-    if(msgContent(m)||m._statusCard||m.attachments?.length||(m.role==='assistant'&&(hasTc||hasTu||_messageHasReasoningPayload(m)))) visWithIdx.push({m,rawIdx});
     rawIdx++;
   }
   // Show a top affordance when earlier transcript content exists either in

--- a/static/ui.js
+++ b/static/ui.js
@@ -268,6 +268,34 @@ let _messageRenderWindowSize=MESSAGE_RENDER_WINDOW_DEFAULT;
 function _resetMessageRenderWindow(sid){
   _messageRenderWindowSid=sid||null;
   _messageRenderWindowSize=MESSAGE_RENDER_WINDOW_DEFAULT;
+  _clearRenderCache();
+}
+
+// ── renderMd / _renderUserFencedBlocks cache ──────────────────────────────
+// Long sessions re-render the same messages on every renderMessages() call.
+// Cache the rendered HTML so unchanged messages skip the expensive regex
+// pipeline entirely.  ~95% of messages are identical between renders.
+const _renderCache = new Map();
+const _renderCacheMax = 300;
+function _clearRenderCache(){ _renderCache.clear(); }
+function _renderCacheKey(text, isUser){
+  const p = isUser ? 'u' : 'a';
+  // Short content: use the full string as key (cheap Map lookup).
+  // Long content: length + prefix + suffix is good enough — collisions on
+  // 20-char prefix+suffix are vanishingly rare for chat messages.
+  if(text.length <= 500) return p + ':' + text;
+  return p + ':' + text.length + ':' + text.slice(0,20) + ':' + text.slice(-20);
+}
+function _getCachedRender(text, isUser){
+  const key = _renderCacheKey(text, isUser);
+  const hit = _renderCache.get(key);
+  if(hit !== undefined) return hit;
+  const rendered = isUser
+    ? _renderUserFencedBlocks(text)
+    : renderMd(_stripXmlToolCallsDisplay(String(text)));
+  if(_renderCache.size > _renderCacheMax) _renderCache.clear();
+  _renderCache.set(key, rendered);
+  return rendered;
 }
 function _currentMessageRenderWindowSize(){
   return Math.max(
@@ -6236,7 +6264,7 @@ function renderMessages(options){
         return _renderAttachmentHtml(fname,fileUrl);
       }).join('')}</div>`;
     }
-    let bodyHtml = isUser ? _renderUserFencedBlocks(displayContent) : renderMd(_stripXmlToolCallsDisplay(String(displayContent)));
+    let bodyHtml = _getCachedRender(displayContent, isUser);
     if(!isUser&&m.provider_details){
       const summary=m.provider_details_label||'Provider details';
       bodyHtml += `<details class="provider-error-details"><summary>${esc(String(summary))}</summary><pre><code>${esc(String(m.provider_details))}</code></pre></details>`;
@@ -7017,11 +7045,22 @@ function postProcessRenderedMessages(container) {
 }
 
 function highlightCode(container) {
-  // Apply Prism.js syntax highlighting to all code blocks in container (or whole messages area)
-  if(typeof Prism === 'undefined' || !Prism.highlightAllUnder) return;
+  // Apply Prism.js syntax highlighting only to *new* code blocks.
+  // Previously every renderMessages() called Prism.highlightAllUnder() which
+  // re-scanned and re-highlighted every <pre> in the container — expensive in
+  // long sessions with dozens of code blocks.  Now we only touch blocks that
+  // don't already have the data-highlighted marker.
+  if(typeof Prism === 'undefined') return;
   const el = container || $('msgInner');
   if(!el) return;
-  Prism.highlightAllUnder(el);
+  // Prefer per-element highlight (avoids the full DOM walk of highlightAllUnder)
+  const blocks = el.querySelectorAll('pre code:not([data-highlighted])');
+  if(blocks.length === 0) return;
+  for(let i = 0; i < blocks.length; i++){
+    const block = blocks[i];
+    if(typeof Prism.highlightElement === 'function') Prism.highlightElement(block);
+    block.dataset.highlighted = '1';
+  }
 }
 
 // Lazy load js-yaml for YAML tree view support

--- a/tests/test_issue1937_endless_scroll_jumpstart_race.py
+++ b/tests/test_issue1937_endless_scroll_jumpstart_race.py
@@ -106,13 +106,13 @@ def test_load_older_aborts_when_generation_changed():
     )
 
 
-def test_load_older_generation_check_runs_before_prepend():
-    """Generation check must come BEFORE the `S.messages = [...older, ...]` mutation."""
+def test_load_older_generation_check_runs_before_replace():
+    """Generation check must come BEFORE the `S.messages = nextMessages` mutation."""
     body = _function_body(SESSIONS_JS, "_loadOlderMessages")
     guard_idx = body.index("if (_messagesGeneration !== startGeneration) return;")
-    prepend_idx = body.index("S.messages = [...olderMsgs, ...S.messages];")
-    assert guard_idx < prepend_idx, (
-        "Generation guard must short-circuit BEFORE the prepend. "
+    replace_idx = body.index("S.messages = nextMessages;")
+    assert guard_idx < replace_idx, (
+        "Generation guard must short-circuit BEFORE the message-array mutation. "
         "Otherwise duplicate messages can still slip through. See #1937."
     )
 

--- a/tests/test_issue_t16551f61_auth_token_churn_fingerprint.py
+++ b/tests/test_issue_t16551f61_auth_token_churn_fingerprint.py
@@ -1,0 +1,295 @@
+"""Regression tests for RCA t_16551f61: auth.json ~14-min token churn must
+NOT bust the 24h /api/models cache, but a real provider/model-set change
+still must.
+
+Bug shape (chained from RCA t_d127953d residual #2): the models cache has a
+24h TTL, but its _source_fingerprint hashed auth.json via mtime/size
+(#1699's _models_cache_file_fingerprint). credential-pool / OAuth token
+refresh rewrites the WHOLE auth.json roughly every 14 minutes (RCA observed
+17:12:51 -> 17:26:31), bumping mtime+size every time. So the fingerprint
+mismatched every ~14 min, the 24h cache was effectively dead, and the hot
+GET /api/session?resolve_model=1 path paid a cold ~11.5s rebuild over and
+over.
+
+Fix: fingerprint auth.json by *content* with the credential-rotation fields
+deny-listed (_auth_store_semantic_fingerprint). Token rotation is invisible
+to the fingerprint; anything that changes the available provider/model set
+still changes it.
+
+These tests are INVARIANTS, not change-detectors:
+  * churn-immune  — rewriting only volatile token fields keeps the
+                     fingerprint byte-identical AND keeps a valid disk cache
+                     loadable.
+  * real-change-invalidates — active_provider change, a NEW credential_pool
+                     entry, and a changed base_url each flip the fingerprint
+                     AND reject the previously-valid disk cache.
+
+A test that only asserted "fingerprint stable on churn" would pass even if
+the function hard-coded `return {}` — hence the paired real-change half and
+the explicit assertion that the two fingerprints actually differ on a real
+change. Verified non-tautological by reverting the fix (see report.md): the
+churn-immune half then fails.
+"""
+
+import json
+import time
+
+import api.config as config
+
+
+# ── auth.json builders ────────────────────────────────────────────────────
+
+
+def _auth_store(*, active_provider="anthropic", extra_pool_provider=None,
+                anthropic_base_url="https://api.anthropic.com",
+                access_token="tok-AAAA", request_count=1):
+    """A realistic auth.json shaped like the production researcher profile
+    (version / providers / active_provider / credential_pool / updated_at)."""
+    pool = {
+        "anthropic": [
+            {
+                "id": "anthropic-oauth-1",
+                "label": "Claude Max",
+                "auth_type": "oauth",
+                "priority": 0,
+                "source": "claude-oauth",
+                "access_token": access_token,
+                "refresh_token": "refresh-" + access_token,
+                "last_status": "ok",
+                "last_status_at": None,
+                "last_error_code": None,
+                "expires_at_ms": 1779152637000,
+                "base_url": anthropic_base_url,
+                "request_count": request_count,
+            }
+        ],
+        "openrouter": [
+            {
+                "id": "openrouter-key-1",
+                "label": "OpenRouter",
+                "auth_type": "api_key",
+                "priority": 1,
+                "source": "env",
+                "access_token": "or-" + access_token,
+                "last_status": "ok",
+                "base_url": "https://openrouter.ai/api/v1",
+                "request_count": request_count,
+            }
+        ],
+    }
+    if extra_pool_provider:
+        pool[extra_pool_provider] = [
+            {
+                "id": f"{extra_pool_provider}-key-1",
+                "label": extra_pool_provider.title(),
+                "auth_type": "api_key",
+                "priority": 2,
+                "source": "manual",
+                "access_token": "new-provider-token",
+                "base_url": f"https://api.{extra_pool_provider}.test/v1",
+                "request_count": 0,
+            }
+        ]
+    return {
+        "version": 2,
+        "providers": {},
+        "active_provider": active_provider,
+        "credential_pool": pool,
+        "updated_at": "2026-05-19T01:00:00+00:00",
+    }
+
+
+def _write_auth(tmp_path, monkeypatch, store: dict):
+    """Point _get_auth_store_path() at a tmp auth.json and write `store`.
+
+    Sleeps 10ms and re-stats to guarantee mtime_ns/size would differ between
+    successive writes — proving the OLD stat-based fingerprint WOULD have
+    churned, so a stable result is attributable to the content fix, not to
+    the OS coincidentally reusing mtime/size.
+    """
+    auth_path = tmp_path / "auth.json"
+    auth_path.write_text(json.dumps(store, indent=2), encoding="utf-8")
+    monkeypatch.setattr(config, "_get_auth_store_path", lambda: auth_path)
+    return auth_path
+
+
+# ── churn-immune invariant ─────────────────────────────────────────────────
+
+
+def test_token_only_churn_keeps_auth_fingerprint_identical(tmp_path, monkeypatch):
+    """Rotating ONLY the volatile credential fields (access/refresh token,
+    expiry, status, request_count, updated_at) must not change the auth.json
+    fingerprint at all — even though mtime_ns and size both change."""
+    p = _write_auth(tmp_path, monkeypatch, _auth_store(access_token="tok-AAAA",
+                                                       request_count=1))
+    st1 = p.stat()
+    fp1 = config._auth_store_semantic_fingerprint(p)
+
+    time.sleep(0.01)
+    # Same logical config, fresh tokens + bumped counters + new save ts.
+    bigger = _auth_store(access_token="tok-BBBBBBBBBBBBBBBBBBBB",
+                          request_count=999)
+    bigger["updated_at"] = "2026-05-19T01:14:00+00:00"
+    p.write_text(json.dumps(bigger, indent=2), encoding="utf-8")
+    st2 = p.stat()
+    fp2 = config._auth_store_semantic_fingerprint(p)
+
+    # Precondition: the OLD stat-based fingerprint WOULD have churned.
+    assert (st1.st_mtime_ns, st1.st_size) != (st2.st_mtime_ns, st2.st_size)
+    # Invariant: the content fingerprint does NOT churn.
+    assert fp1 == fp2
+    assert "semantic_sha256" in fp1
+
+
+def test_token_churn_does_not_reject_valid_disk_models_cache(tmp_path, monkeypatch):
+    """End-to-end: a disk models cache saved before a token refresh stays
+    loadable after the refresh (the actual user-visible bug — cold rebuild
+    every ~14 min)."""
+    _write_auth(tmp_path, monkeypatch, _auth_store(access_token="tok-1"))
+    monkeypatch.setattr(config, "_models_cache_path",
+                        tmp_path / "models_cache.json")
+
+    shape = {
+        "active_provider": "anthropic",
+        "default_model": "claude-opus-4-7",
+        "configured_model_badges": {"claude-opus-4-7": "Anthropic"},
+        "groups": [{"name": "Anthropic", "models": ["claude-opus-4-7"]}],
+    }
+    config._save_models_cache_to_disk(shape)
+    assert config._load_models_cache_from_disk() is not None
+
+    # ~14 minutes later: credential-pool refresh rewrites auth.json.
+    time.sleep(0.01)
+    churned = _auth_store(access_token="tok-2-rotated", request_count=42)
+    churned["updated_at"] = "2026-05-19T01:14:00+00:00"
+    config._get_auth_store_path().write_text(
+        json.dumps(churned, indent=2), encoding="utf-8")
+
+    assert config._load_models_cache_from_disk() is not None, (
+        "Pure token-refresh churn of auth.json must NOT invalidate the 24h "
+        "models cache (RCA t_16551f61)"
+    )
+
+
+# ── real-change-invalidates invariant ──────────────────────────────────────
+
+
+def test_active_provider_change_changes_auth_fingerprint(tmp_path, monkeypatch):
+    p = _write_auth(tmp_path, monkeypatch, _auth_store(active_provider="anthropic"))
+    fp_before = config._auth_store_semantic_fingerprint(p)
+
+    p.write_text(json.dumps(_auth_store(active_provider="openrouter"), indent=2),
+                 encoding="utf-8")
+    fp_after = config._auth_store_semantic_fingerprint(p)
+
+    assert fp_before != fp_after, (
+        "Changing active_provider changes the available-provider set and MUST "
+        "bust the cache"
+    )
+
+
+def test_new_credential_pool_entry_changes_auth_fingerprint(tmp_path, monkeypatch):
+    """The explicit edge from the task body: adding a credential_pool entry
+    that enables a NEW provider MUST still invalidate the cache."""
+    p = _write_auth(tmp_path, monkeypatch, _auth_store())
+    fp_before = config._auth_store_semantic_fingerprint(p)
+
+    p.write_text(json.dumps(_auth_store(extra_pool_provider="deepseek"),
+                            indent=2), encoding="utf-8")
+    fp_after = config._auth_store_semantic_fingerprint(p)
+
+    assert fp_before != fp_after, (
+        "A new credential_pool provider entry expands the model set and MUST "
+        "bust the cache (task t_16551f61 boundary case)"
+    )
+
+
+def test_changed_base_url_changes_auth_fingerprint(tmp_path, monkeypatch):
+    """Endpoint / api-base is a non-volatile field — it stays in the
+    fingerprint, so pointing a provider at a different endpoint invalidates."""
+    p = _write_auth(tmp_path, monkeypatch, _auth_store())
+    fp_before = config._auth_store_semantic_fingerprint(p)
+
+    p.write_text(
+        json.dumps(_auth_store(anthropic_base_url="https://proxy.internal/v1"),
+                   indent=2),
+        encoding="utf-8")
+    fp_after = config._auth_store_semantic_fingerprint(p)
+
+    assert fp_before != fp_after, "A changed provider base_url MUST bust the cache"
+
+
+def test_real_change_rejects_previously_valid_disk_cache(tmp_path, monkeypatch):
+    """End-to-end mirror of the churn test: a disk cache that was valid must
+    be REJECTED once a genuine provider-set change lands in auth.json."""
+    _write_auth(tmp_path, monkeypatch, _auth_store(active_provider="anthropic"))
+    monkeypatch.setattr(config, "_models_cache_path",
+                        tmp_path / "models_cache.json")
+    config._save_models_cache_to_disk({
+        "active_provider": "anthropic",
+        "default_model": "claude-opus-4-7",
+        "configured_model_badges": {"claude-opus-4-7": "Anthropic"},
+        "groups": [{"name": "Anthropic", "models": ["claude-opus-4-7"]}],
+    })
+    assert config._load_models_cache_from_disk() is not None
+
+    config._get_auth_store_path().write_text(
+        json.dumps(_auth_store(active_provider="openrouter"), indent=2),
+        encoding="utf-8")
+
+    assert config._load_models_cache_from_disk() is None, (
+        "A real active_provider change MUST reject the stale disk cache — the "
+        "fix must not over-stabilise into serving wrong data"
+    )
+
+
+# ── deny-list helper unit guards ───────────────────────────────────────────
+
+
+def test_strip_volatile_is_pure_and_recurses():
+    src = {
+        "active_provider": "anthropic",
+        "credential_pool": {
+            "anthropic": [
+                {"id": "x", "base_url": "u", "access_token": "S",
+                 "request_count": 7, "last_status": "ok"}
+            ]
+        },
+        "updated_at": "ts",
+    }
+    import copy as _copy
+    snapshot = _copy.deepcopy(src)
+    out = config._strip_volatile_auth_fields(src)
+
+    assert src == snapshot  # input untouched (pure)
+    entry = out["credential_pool"]["anthropic"][0]
+    assert entry == {"id": "x", "base_url": "u"}  # volatile keys gone, rest kept
+    assert "updated_at" not in out
+    assert out["active_provider"] == "anthropic"  # non-volatile preserved
+
+
+def test_unknown_field_stays_in_fingerprint(tmp_path, monkeypatch):
+    """Deny-list (not allow-list) safety: a field we don't know about is NOT
+    stripped, so a hypothetical future provider-gating field still busts the
+    cache."""
+    base = _auth_store()
+    base["some_future_provider_gate"] = "v1"
+    p = _write_auth(tmp_path, monkeypatch, base)
+    fp1 = config._auth_store_semantic_fingerprint(p)
+
+    base["some_future_provider_gate"] = "v2"
+    p.write_text(json.dumps(base, indent=2), encoding="utf-8")
+    fp2 = config._auth_store_semantic_fingerprint(p)
+
+    assert fp1 != fp2, (
+        "An unknown (non-deny-listed) field must remain in the fingerprint — "
+        "the deny-list must fail safe toward over-invalidation"
+    )
+
+
+def test_missing_auth_file_fingerprint_is_stable_and_marked(tmp_path, monkeypatch):
+    missing = tmp_path / "nope" / "auth.json"
+    monkeypatch.setattr(config, "_get_auth_store_path", lambda: missing)
+    fp = config._auth_store_semantic_fingerprint(missing)
+    assert fp.get("missing") is True
+    assert config._auth_store_semantic_fingerprint(missing) == fp

--- a/tests/test_older_history_viewport_preservation.py
+++ b/tests/test_older_history_viewport_preservation.py
@@ -21,11 +21,11 @@ def _function_body(src: str, signature: str) -> str:
 def test_loading_older_messages_expands_render_window_before_rendering():
     body = _function_body(SESSIONS_JS, "async function _loadOlderMessages")
 
-    prepend_idx = body.index("S.messages = [...olderMsgs, ...S.messages]")
+    replace_idx = body.index("S.messages = nextMessages")
     expand_idx = body.index("_messageRenderWindowSize=_currentMessageRenderWindowSize()")
     render_idx = body.index("renderMessages({ preserveScroll: true });")
 
-    assert prepend_idx < expand_idx < render_idx, (
+    assert replace_idx < expand_idx < render_idx, (
         "scroll-to-top paging must expand the DOM render window before renderMessages(); "
         "otherwise fetched older messages stay hidden and only the hidden counter changes"
     )

--- a/tests/test_parallel_session_switch.py
+++ b/tests/test_parallel_session_switch.py
@@ -410,15 +410,23 @@ class TestMessagePaginationFrontend:
         """_loadOlderMessages must be defined for scroll-to-top loading."""
         assert "async function _loadOlderMessages" in SESSIONS_JS
 
-    def test_load_older_uses_index_cursor(self):
-        """_loadOlderMessages must pass msg_before as integer index, not timestamp."""
+    def test_load_older_uses_cumulative_tail_limit(self):
+        """_loadOlderMessages requests a larger authoritative tail window via msg_limit.
+
+        The cumulative tail path is the default. msg_before remains in the
+        body as the race-fallback request when the suffix-continuity check
+        fails.
+        """
         fn_start = SESSIONS_JS.find("async function _loadOlderMessages")
         fn_end = SESSIONS_JS.find("\n}", fn_start) + 2
         fn_body = SESSIONS_JS[fn_start:fn_end]
 
-        assert "msg_before=${_oldestIdx}" in fn_body, (
-            "_loadOlderMessages should use _oldestIdx (integer) as msg_before cursor"
-        )
+        assert "requestedLimit" in fn_body
+        assert "S.messages || []" in fn_body
+        assert "msg_limit=${requestedLimit}" in fn_body
+        assert "tailMatches" in fn_body
+        # Race fallback still issues the legacy msg_before page request.
+        assert "msg_before=${_oldestIdx}" in fn_body
 
     def test_ensure_all_messages_function_exists(self):
         """_ensureAllMessagesLoaded must exist for operations needing full history."""
@@ -492,7 +500,7 @@ class TestSessionSwitchCancellation:
         """Verify the guard prevents S.messages mutation.
 
         The guard `if (_loadingSessionId !== null && _loadingSessionId !== sid) return`
-        runs BEFORE `S.messages = [...olderMsgs, ...S.messages]`.
+        runs BEFORE `S.messages = nextMessages`.
         If the session changed, we return early — no mutation.
         """
         fn_start = SESSIONS_JS.find("async function _loadOlderMessages")
@@ -501,7 +509,7 @@ class TestSessionSwitchCancellation:
 
         # Guard must appear before S.messages mutation
         guard_idx = fn_body.find("_loadingSessionId")
-        mutation_idx = fn_body.find("S.messages = [...olderMsgs")
+        mutation_idx = fn_body.find("S.messages = nextMessages")
         assert guard_idx >= 0 and mutation_idx >= 0 and guard_idx < mutation_idx, (
             "The _loadingSessionId guard must appear BEFORE the S.messages "
             "mutation to prevent stale data from landing on the wrong session."
@@ -552,7 +560,7 @@ class TestSessionSwitchCancellation:
         )
         # The S.session check must appear BEFORE the S.messages mutation.
         active_check_idx = fn_body.find("S.session.session_id !== sid")
-        mutation_idx = fn_body.find("S.messages = [...olderMsgs")
+        mutation_idx = fn_body.find("S.messages = nextMessages")
         assert active_check_idx >= 0 and mutation_idx >= 0 and active_check_idx < mutation_idx, (
             "Active-session guard must run before S.messages mutation."
         )

--- a/tests/test_session_message_window_renderable_tail.py
+++ b/tests/test_session_message_window_renderable_tail.py
@@ -1,0 +1,58 @@
+from api.routes import _message_window_for_display
+
+
+def test_initial_msg_limit_skips_trailing_tool_only_rows():
+    messages = [
+        {"role": "user", "content": "question"},
+        {"role": "assistant", "content": "answer"},
+    ] + [
+        {"role": "tool", "content": f"tool result {idx}"}
+        for idx in range(40)
+    ]
+
+    window, offset = _message_window_for_display(messages, msg_limit=5)
+
+    assert [m["role"] for m in window] == ["user", "assistant"]
+    assert offset == 0
+
+
+def test_msg_limit_keeps_raw_tail_when_it_has_renderable_rows():
+    messages = [
+        {"role": "user", "content": f"u{idx}"} if idx % 2 == 0 else {"role": "assistant", "content": f"a{idx}"}
+        for idx in range(10)
+    ]
+
+    window, offset = _message_window_for_display(messages, msg_limit=4)
+
+    assert [m["content"] for m in window] == ["u6", "a7", "u8", "a9"]
+    assert offset == 6
+
+
+def test_msg_before_anchors_page_before_trailing_tool_rows():
+    messages = [
+        {"role": "user", "content": "older"},
+        {"role": "assistant", "content": "visible before tools"},
+    ] + [
+        {"role": "tool", "content": f"hidden {idx}"}
+        for idx in range(12)
+    ] + [
+        {"role": "assistant", "content": "newer visible"},
+    ]
+
+    window, offset = _message_window_for_display(messages, msg_limit=3, msg_before=14)
+
+    assert [m["role"] for m in window] == ["user", "assistant"]
+    assert [m["content"] for m in window] == ["older", "visible before tools"]
+    assert offset == 0
+
+
+def test_all_tool_session_keeps_tail_fallback():
+    messages = [
+        {"role": "tool", "content": f"tool {idx}"}
+        for idx in range(6)
+    ]
+
+    window, offset = _message_window_for_display(messages, msg_limit=3)
+
+    assert [m["content"] for m in window] == ["tool 3", "tool 4", "tool 5"]
+    assert offset == 3

--- a/tests/test_streaming_markdown.py
+++ b/tests/test_streaming_markdown.py
@@ -21,6 +21,8 @@ Tests are static (regex / AST-level) — no browser required.
 
 import pathlib
 import re
+import json
+import subprocess
 
 REPO = pathlib.Path(__file__).parent.parent
 MESSAGES_JS = (REPO / "static" / "messages.js").read_text(encoding="utf-8")
@@ -267,6 +269,103 @@ class TestSmdHelpers:
         assert fn and "_smdParser" in fn, (
             "_smdWrite must guard on _smdParser before calling parser_write"
         )
+
+
+class TestSmdUnderscoreEmphasisParity:
+    """Live smd rendering must match renderMd()'s emphasis semantics.
+
+    The settled renderMd() path only treats asterisks as emphasis markers. The
+    smd parser also emits underscore emphasis tokens, so the live renderer wraps
+    smd's renderer and emits those tokens as literal underscores instead.
+    """
+
+    def test_smd_underscore_renderer_wrapper_exists(self):
+        fn = extract_fn(MESSAGES_JS, "_smdRendererWithoutUnderscoreEmphasis")
+        assert fn is not None, (
+            "messages.js must define _smdRendererWithoutUnderscoreEmphasis()"
+        )
+
+    def test_smd_new_parser_wraps_renderer(self):
+        fn = extract_fn(MESSAGES_JS, "_smdNewParser")
+        assert fn and "_smdRendererWithoutUnderscoreEmphasis(" in fn, (
+            "_smdNewParser must wrap the smd renderer before parser creation"
+        )
+
+    def test_smd_wrapper_targets_only_underscore_tokens(self):
+        fn = extract_fn(MESSAGES_JS, "_smdRendererWithoutUnderscoreEmphasis")
+        assert fn and "ITALIC_UND" in fn and "STRONG_UND" in fn, (
+            "The smd wrapper must neutralize underscore emphasis tokens"
+        )
+        assert fn and "ITALIC_AST" not in fn and "STRONG_AST" not in fn, (
+            "The smd wrapper must preserve asterisk emphasis tokens"
+        )
+
+    def test_smd_wrapper_keeps_nested_token_stack(self):
+        fn = extract_fn(MESSAGES_JS, "_smdRendererWithoutUnderscoreEmphasis")
+        assert fn and "tokenStack" in fn and "tokenStack.push(null)" in fn, (
+            "The wrapper must track non-suppressed tokens so nested links/code "
+            "inside underscore text still close through the base renderer"
+        )
+
+    def test_smd_wrapper_runtime_matches_render_md_emphasis_policy(self):
+        helper = extract_fn(MESSAGES_JS, "_smdRendererWithoutUnderscoreEmphasis")
+        assert helper, "_smdRendererWithoutUnderscoreEmphasis function not found"
+        script = f"""
+import * as smd from './static/vendor/smd.min.js';
+globalThis.window = {{ smd }};
+{helper}
+function render(input){{
+  const out=[];
+  const stack=[];
+  const renderer=_smdRendererWithoutUnderscoreEmphasis({{
+    data: {{}},
+    add_token(_data, token){{
+      let tag='';
+      if(token===smd.ITALIC_AST||token===smd.ITALIC_UND) tag='em';
+      if(token===smd.STRONG_AST||token===smd.STRONG_UND) tag='strong';
+      stack.push(tag);
+      if(tag) out.push('<'+tag+'>');
+    }},
+    end_token() {{
+      const tag=stack.pop();
+      if(tag) out.push('</'+tag+'>');
+    }},
+    add_text(_data, text) {{ out.push(text); }},
+    set_attr() {{}},
+  }});
+  const parser=smd.parser(renderer);
+  smd.parser_write(parser,input);
+  smd.parser_end(parser);
+  return out.join('');
+}}
+const cases = {{
+  identifiers: render('agent_response and foo_bar stay literal'),
+  singleUnderscore: render('this is _not emphasis_ now'),
+  doubleUnderscore: render('this is __not strong__ now'),
+  asteriskItalic: render('this is *emphasis* now'),
+  asteriskStrong: render('this is **strong** now'),
+  nestedLinkShape: render('keep _[label](https://example.com)_ literal'),
+}};
+console.log(JSON.stringify(cases));
+"""
+        completed = subprocess.run(
+            ["node", "--input-type=module", "-e", script],
+            cwd=REPO,
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+        cases = json.loads(completed.stdout)
+        assert "<em>" not in cases["identifiers"]
+        assert "agent_response" in cases["identifiers"]
+        assert "foo_bar" in cases["identifiers"]
+        assert cases["singleUnderscore"].count("<em>") == 0
+        assert "_not emphasis_" in cases["singleUnderscore"]
+        assert cases["doubleUnderscore"].count("<strong>") == 0
+        assert "__not strong__" in cases["doubleUnderscore"]
+        assert "<em>emphasis</em>" in cases["asteriskItalic"]
+        assert "<strong>strong</strong>" in cases["asteriskStrong"]
+        assert "_label_" in cases["nestedLinkShape"]
 
 
 # ── 4. _scheduleRender: smd path vs fallback ──────────────────────────────────

--- a/tests/test_workspace_display_prefix.py
+++ b/tests/test_workspace_display_prefix.py
@@ -42,5 +42,9 @@ def test_user_render_uses_stripped_display_content_without_preempting_context_ca
     assert context_idx != -1, "context compaction branch not found"
     assert user_idx != -1, "user render branch not found"
     assert display_idx < context_idx < user_idx
-    assert "_renderUserFencedBlocks(displayContent)" in render_prefix
+    # The render call may be a direct _renderUserFencedBlocks call or go
+    # through the cached wrapper _getCachedRender.  Both paths accept the
+    # already-stripped displayContent, so the invariant holds either way.
+    assert ("_renderUserFencedBlocks(displayContent)" in render_prefix or
+            "_getCachedRender(displayContent, isUser)" in render_prefix)
     assert "row.dataset.rawText=String(displayContent).trim();" in render_prefix


### PR DESCRIPTION
# Release DL / v0.51.140 — stage-batch22 (5 PRs from re-examined hold bucket)

**This is a deliberate "actually-reviewable" pass through the hold bucket.** All 5 PRs were previously labeled `hold` but on second read are bounded enough to ship without architectural input.

## PRs merged

| PR | Author | Net LOC | What it does |
|----|--------|---------|--------------|
| #2964 | Isla-Liu | +417/-2 | Models cache fingerprint excludes credential-rotation fields (deny-list of 14 keys). Fixes the 14-min churn that effectively killed the 24h cache. RCA t_16551f61. |
| #2986 | ai-ag2026 | +112/-16 | `_message_window_for_display()` anchors paginated window on newest renderable row (skips tool-only tail). |
| #2902 | george-andraws | +131/-1 | `_smdRendererWithoutUnderscoreEmphasis()` wraps smd renderer so `agent_response` and `foo_bar` stay literal while streaming (matches settled renderer). |
| #2899 | v2psv | +75/-22 | `_loadOlderMessages()` switches to cumulative `msg_limit=current+30` tail load with suffix-continuity guard + legacy-page fallback. |
| #2970 | AlexeyDsov | +91/-11 | `renderMessages()` perf: caches `renderMd`/`_renderUserFencedBlocks` output, caches visible-message scan, scopes question→assistant lookup to render window, lazy Prism highlight. |

## Verification

- ✅ Pre-merge: all 5 CI-green, no stale-base traps
- ✅ Post-merge gates: no merge markers, `ast.parse` clean on 9 changed .py, `node -c` clean on messages/sessions/ui.js
- ✅ pytest: **6623 passed / 6 skipped / 3 xpassed / 0 failures** (178s sequential, `-p no:xdist`)
- ✅ Opus advisor: **SHIP-AS-IS** — verified all 7 concerns line-by-line:
  - #2964 deny-list is fail-safe (unknown keys stay in fingerprint, invalidate on real changes — confirmed by `test_unknown_field_stays_in_fingerprint`)
  - #2986 composes correctly with #2915 (already shipped) — they touch different state fields, no overlap
  - #2902 token-stack push/pop balanced; stack underflow falls through to base renderer (graceful, not crash)
  - #2899 suffix-continuity check uses `_sameTranscriptMessage` (role + content, not reference); fallback reapplies session/generation guards after second await
  - #2970 visWithIdx cache holds `m` by reference — in-place mutations of `tool_calls`/`content` are visible on read; cache key collision rare-but-bounded for >500 char messages
  - Cross-PR: #2986 + #2899 touch `_messages_offset` contract from opposite sides, frontend just consumes the field
- ✅ CHANGELOG entries explicit for all 5 PRs (4 backfilled — only #2902 had its own)

## Hold-bucket re-classification rationale

Each of these was previously hold-labeled with a different actual blocker than "needs deep review":
- **#2964**: I'd grouped it with the Isla-Liu bg_task_complete cluster — actually independent, 6 standalone tests, clean deny-list with explicit rationale.
- **#2986**: I'd flagged it as conflicting with already-shipped #2915 — they're complementary (anchor for compression vs window selector).
- **#2902**: Sat in `hold` from before today's sweeps; the actual conflict was CHANGELOG-only.
- **#2899**: Had `hold` from the cumulative-tail discussion in #2835. The suffix-continuity guard is exactly the safety mechanism a reviewer would request — it's already there.
- **#2970**: Held without specific reason; on read it's surgical and the cache invalidation invariants hold up.

This batch sits on top of v0.51.139 (Release DK).
