### PR TITLE
docs(config): address PR #2964 review nits (client_secret comment + _write_auth docstring)

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -2603,7 +2603,7 @@ _AUTH_FINGERPRINT_VOLATILE_KEYS = frozenset({
     "id_token",
     "api_key",
     "secret",
-    "client_secret",
+    "client_secret",  # rotation-only on purpose; not a model-cache differentiator
     # Expiry / liveness — bumped every refresh, derived from the token above.
     "expires_at",
     "expires_at_ms",

--- a/tests/test_issue_t16551f61_auth_token_churn_fingerprint.py
+++ b/tests/test_issue_t16551f61_auth_token_churn_fingerprint.py
@@ -102,10 +102,11 @@ def _auth_store(*, active_provider="anthropic", extra_pool_provider=None,
 def _write_auth(tmp_path, monkeypatch, store: dict):
     """Point _get_auth_store_path() at a tmp auth.json and write `store`.
 
-    Sleeps 10ms and re-stats to guarantee mtime_ns/size would differ between
-    successive writes — proving the OLD stat-based fingerprint WOULD have
-    churned, so a stable result is attributable to the content fix, not to
-    the OS coincidentally reusing mtime/size.
+    Writes `store` as JSON to a tmp auth.json and monkeypatches
+    config._get_auth_store_path() to return that path. The mtime/size
+    sleep+restat dance lives at the call sites (the tests that actually
+    need to prove the OLD stat-based fingerprint WOULD have churned);
+    this helper itself only does the write + monkeypatch.
     """
     auth_path = tmp_path / "auth.json"
     auth_path.write_text(json.dumps(store, indent=2), encoding="utf-8")


### PR DESCRIPTION
This is a small follow-up to address two documentation nits raised by `nesquena-hermes` on the now-merged #2964 ("exclude credential-rotation fields from models-cache auth.json fingerprint"). The reviewer comments arrived after merge, so landing them in a tiny stand-alone PR rather than amending history.

Two changes:

- `api/config.py`: tighten the inline comment next to the `client_secret` deny-list entry to spell out *why* it is treated as a credential-rotation field rather than a stable provider-identity field (clearer for future readers wondering whether the entry belongs in the fingerprint set or the deny-list).
- `tests/test_issue_t16551f61_auth_token_churn_fingerprint.py`: tighten the `_write_auth` test-helper docstring so the contract it is asserting (auth.json fingerprint stability across credential rotation) is self-evident at read time.

No behavior change. No production code path touched. Total diff: 2 files, +6 / -5.

Refs #2964.
