### PR TITLE
Fix streaming SessionDB profile path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- WebUI streaming sessions created under a non-default profile now attach `session_search` to that profile's `state.db` instead of the server's default profile database. (#2965)
+
 ## [v0.51.141] — 2026-05-26 — Release DM (stage-batch23 — 4-PR second hold-bucket pass)
 
 ### Added

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -4231,7 +4231,8 @@ def _run_agent_streaming(
             _session_db = None
             try:
                 from hermes_state import SessionDB
-                _session_db = SessionDB()
+                _state_db_path = (Path(_profile_home) / "state.db") if _profile_home else None
+                _session_db = SessionDB(db_path=_state_db_path)
             except Exception as _db_err:
                 print(f"[webui] WARNING: SessionDB init failed — session_search will be unavailable: {_db_err}", flush=True)
             resolved_model, resolved_provider, resolved_base_url = resolve_model_provider(

--- a/tests/test_issue2965_streaming_sessiondb_profile_home.py
+++ b/tests/test_issue2965_streaming_sessiondb_profile_home.py
@@ -1,0 +1,183 @@
+"""Regression coverage for #2965 streaming SessionDB profile isolation."""
+
+from __future__ import annotations
+
+import os
+import queue
+import sys
+import types
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parent.parent
+if str(REPO) not in sys.path:
+    sys.path.insert(0, str(REPO))
+
+
+def test_streaming_sessiondb_uses_session_profile_state_db(tmp_path, monkeypatch):
+    """WebUI streaming must not rely on hermes_state.DEFAULT_DB_PATH.
+
+    ``hermes_state.DEFAULT_DB_PATH`` is frozen at import time. A non-default
+    WebUI profile therefore needs the streaming attach path to pass the already
+    resolved profile home to SessionDB explicitly.
+    """
+    from api import config as cfg
+    from api import oauth
+    from api import profiles
+    from api import streaming
+
+    profile_home = tmp_path / "hermes-home" / "profiles" / "zhangtingban"
+    profile_home.mkdir(parents=True)
+
+    class FakeSession:
+        session_id = "issue2965-session"
+        title = "Issue 2965"
+        workspace = str(tmp_path)
+        model = "test-model"
+        model_provider = None
+        profile = "zhangtingban"
+        personality = None
+        messages = []
+        context_messages = []
+        tool_calls = []
+        input_tokens = 0
+        output_tokens = 0
+        estimated_cost = None
+        context_length = 0
+        threshold_tokens = 0
+        last_prompt_tokens = 0
+        active_stream_id = "issue2965-stream"
+        pending_user_message = None
+        pending_attachments = []
+        pending_started_at = None
+        llm_title_generated = True
+
+        def save(self, *args, **kwargs):
+            return None
+
+        def compact(self):
+            return {
+                "session_id": self.session_id,
+                "title": self.title,
+                "workspace": self.workspace,
+                "model": self.model,
+                "created_at": 0,
+                "updated_at": 0,
+                "pinned": False,
+                "archived": False,
+                "project_id": None,
+                "profile": self.profile,
+                "input_tokens": self.input_tokens,
+                "output_tokens": self.output_tokens,
+                "estimated_cost": self.estimated_cost,
+                "personality": self.personality,
+            }
+
+    class FakeSessionDB:
+        def __init__(self, db_path=None):
+            self.db_path = db_path
+
+        def close(self):
+            return None
+
+    class CapturingAgent:
+        def __init__(self, **kwargs):
+            self.session_db = kwargs.get("session_db")
+            self._session_db = self.session_db
+            self.session_prompt_tokens = 0
+            self.session_completion_tokens = 0
+            self.session_estimated_cost_usd = None
+            self.context_compressor = None
+            self._last_error = None
+            self.ephemeral_system_prompt = None
+
+        def run_conversation(self, **kwargs):
+            history = list(kwargs.get("conversation_history") or [])
+            return {
+                "messages": history
+                + [
+                    {"role": "user", "content": kwargs.get("persist_user_message", "")},
+                    {"role": "assistant", "content": "ok"},
+                ]
+            }
+
+        def interrupt(self, _message):
+            return None
+
+    session_db_instances = []
+
+    def fake_session_db(db_path=None):
+        db = FakeSessionDB(db_path=db_path)
+        session_db_instances.append(db)
+        return db
+
+    fake_runtime_module = types.ModuleType("hermes_cli.runtime_provider")
+    fake_runtime_module.resolve_runtime_provider = lambda requested=None: {
+        "provider": requested or "test-provider",
+        "api_key": "synthetic-key",
+        "base_url": None,
+    }
+    fake_hermes_cli = types.ModuleType("hermes_cli")
+    fake_hermes_cli.runtime_provider = fake_runtime_module
+    fake_hermes_state = types.ModuleType("hermes_state")
+    fake_hermes_state.SessionDB = fake_session_db
+
+    fake_session = FakeSession()
+
+    monkeypatch.setattr(streaming, "get_session", lambda _sid: fake_session)
+    monkeypatch.setattr(streaming, "_get_ai_agent", lambda: CapturingAgent)
+    monkeypatch.setattr(
+        streaming,
+        "resolve_model_provider",
+        lambda _model: ("test-model", "test-provider", None),
+    )
+    monkeypatch.setattr(streaming, "_maybe_schedule_title_refresh", lambda *args, **kwargs: None)
+    monkeypatch.setattr(profiles, "get_hermes_home_for_profile", lambda _profile: profile_home)
+    monkeypatch.setattr(profiles, "get_profile_runtime_env", lambda _home: {})
+    monkeypatch.setattr(
+        oauth,
+        "resolve_runtime_provider_with_anthropic_env_lock",
+        lambda _resolver, requested=None: {
+            "provider": requested or "test-provider",
+            "api_key": "synthetic-key",
+            "base_url": None,
+        },
+    )
+    monkeypatch.setattr("api.config.get_config", lambda: {})
+    monkeypatch.setattr("api.config._resolve_cli_toolsets", lambda _cfg: [])
+    monkeypatch.setattr("api.config.load_settings", lambda: {})
+    monkeypatch.setitem(sys.modules, "hermes_cli", fake_hermes_cli)
+    monkeypatch.setitem(sys.modules, "hermes_cli.runtime_provider", fake_runtime_module)
+    monkeypatch.setitem(sys.modules, "hermes_state", fake_hermes_state)
+
+    with cfg.SESSION_AGENT_CACHE_LOCK:
+        cfg.SESSION_AGENT_CACHE.clear()
+    streaming.STREAMS.clear()
+    streaming.CANCEL_FLAGS.clear()
+    streaming.AGENT_INSTANCES.clear()
+    streaming.STREAM_PARTIAL_TEXT.clear()
+    streaming.STREAM_REASONING_TEXT.clear()
+    streaming.STREAM_LIVE_TOOL_CALLS.clear()
+
+    streaming.STREAMS[fake_session.active_stream_id] = queue.Queue()
+    old_home = os.environ.get("HERMES_HOME")
+    try:
+        streaming._run_agent_streaming(
+            session_id=fake_session.session_id,
+            msg_text="hello from zhangtingban",
+            model="test-model",
+            model_provider="test-provider",
+            workspace=str(tmp_path),
+            stream_id=fake_session.active_stream_id,
+        )
+    finally:
+        if old_home is None:
+            os.environ.pop("HERMES_HOME", None)
+        else:
+            os.environ["HERMES_HOME"] = old_home
+
+    assert session_db_instances, "streaming should construct a SessionDB for session_search"
+    assert session_db_instances[0].db_path == profile_home / "state.db"
+    with cfg.SESSION_AGENT_CACHE_LOCK:
+        agent = cfg.SESSION_AGENT_CACHE[fake_session.session_id][0]
+    assert agent._session_db.db_path == profile_home / "state.db"

--- a/tests/test_sprint42.py
+++ b/tests/test_sprint42.py
@@ -55,13 +55,18 @@ class TestSessionDBInjection(unittest.TestCase):
         )
 
     def test_sessiondb_init_in_try_except(self):
-        """SessionDB() init must be wrapped in try/except for non-fatal failure handling."""
-        # Check that the try/except pattern surrounding SessionDB() is present
-        pattern = r"try:\s*\n\s*from hermes_state import SessionDB\s*\n\s*_session_db\s*=\s*SessionDB\(\)"
+        """SessionDB init must be wrapped in try/except for non-fatal failure handling."""
+        # Check that the try/except pattern surrounding SessionDB(db_path=...) is present.
+        pattern = (
+            r"try:\s*\n"
+            r"\s*from hermes_state import SessionDB\s*\n"
+            r'\s*_state_db_path\s*=\s*\(Path\(_profile_home\)\s*/\s*"state\.db"\)\s*if\s*_profile_home\s*else\s*None\s*\n'
+            r"\s*_session_db\s*=\s*SessionDB\(db_path=_state_db_path\)"
+        )
         self.assertRegex(
             STREAMING_PY,
             pattern,
-            "SessionDB() init must be inside a try block for non-fatal error handling (PR #356)",
+            "SessionDB(db_path=...) init must be inside a try block for non-fatal error handling",
         )
 
     def test_sessiondb_failure_logs_warning(self):


### PR DESCRIPTION
## Thinking Path

- Hermes WebUI should write browser-originated session state into the same profile home the user selected in the UI.
- The streaming path already resolves `_profile_home` before constructing the WebUI agent.
- `hermes_state.DEFAULT_DB_PATH` is computed when `hermes_state` is imported, so `SessionDB()` without an explicit path can keep using the server's default profile database even after WebUI updates `HERMES_HOME`.
- The narrow fix is to give the streaming `SessionDB` the already-resolved profile `state.db` path instead of relying on the import-time default.

## What Changed

- Pass `Path(_profile_home) / "state.db"` into `SessionDB(db_path=...)` in the streaming agent attach path.
- Added a regression test for #2965 that runs `_run_agent_streaming` under a non-default profile and asserts both constructed and attached `SessionDB` instances point at that profile's `state.db`.
- Added a changelog entry for the non-default-profile `session_search` fix.

## Why It Matters

- Fixes WebUI sessions created under non-default profiles being searchable from the wrong profile database.
- Keeps this separate from #2762 / #2827, which already fixed the state_sync writer path but did not cover the streaming agent's `session_search` database attachment.

Fixes #2965.
Related #2762.
Related #2827.

## Contract Routing

Task type: runtime/state isolation bug fix.
Touched areas: `api/streaming.py`, streaming agent SessionDB attachment, profile-scoped `state.db`.
Relevant public docs:
- `AGENTS.md`
- `CONTRIBUTING.md`
- `docs/CONTRACTS.md`
Scope boundaries: no UI/profile selector changes, no session index changes, no state_sync changes.
Evidence needed before claiming done: regression test proving a non-default profile uses that profile's `state.db`, plus adjacent state_sync/profile-cache SessionDB tests.

## Verification

- `python -m pytest -q tests/test_issue2965_streaming_sessiondb_profile_home.py -o addopts=''`
- `python -m pytest -q tests/test_sprint42.py tests/test_issue2965_streaming_sessiondb_profile_home.py tests/test_issue2762_state_sync_profile_kwarg.py tests/test_issue1897_profile_switch_agent_cache.py tests/test_v050259_sessiondb_fd_leak.py -o addopts=''`
- `python -m py_compile api/streaming.py`
- `git diff --check`

## Risks / Follow-ups

- The fallback path still passes `None` if `_profile_home` cannot be resolved, preserving the legacy default behavior for that unusual failure case.
- No browser UI validation was needed because this fixes the backend database handle attached to the streaming agent.

## Model Used

OpenAI GPT-5 Codex in Codex CLI, with local shell, pytest, and GitHub CLI tool use.