### PR TITLE
Preserve sidebar running state during optimistic merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Sidebar session rows now preserve the server-reported running state when merging stale optimistic first-turn cache entries, so active background sessions keep their spinner and can later transition to unread correctly.
+
 ## [v0.51.143] — 2026-05-26 — Release DO (stage-batch25 — single-PR workspace:// markdown scheme)
 
 ### Added

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -2186,7 +2186,7 @@ function _mergeOptimisticFirstTurnSessions(fetchedSessions){
         active_stream_id:fetchedIsServerIdle?null:(keepLocalOptimistic?(fetched.active_stream_id||local.active_stream_id||null):null),
         pending_user_message:fetchedIsServerIdle?null:(keepLocalOptimistic?(fetched.pending_user_message||local.pending_user_message||null):null),
         pending_started_at:fetchedIsServerIdle?null:(keepLocalOptimistic?(fetched.pending_started_at||local.pending_started_at||null):null),
-        is_streaming:fetchedIsServerIdle?false:(keepLocalOptimistic&&Boolean(fetched.is_streaming||local.is_streaming||_isSessionLocallyStreaming(local))),
+        is_streaming:fetchedIsServerIdle?false:Boolean(fetched.is_streaming||(keepLocalOptimistic&&(local.is_streaming||_isSessionLocallyStreaming(local)))),
       };
     }else{
       if(_shouldKeepLocalOnlyOptimisticSessionRow(local)){

--- a/tests/test_issue2454_active_session_spinner.py
+++ b/tests/test_issue2454_active_session_spinner.py
@@ -120,3 +120,57 @@ console.log(JSON.stringify(merged[0]));
     assert row["pending_user_message"] is None
     assert row["pending_started_at"] is None
     assert row["is_streaming"] is False
+
+
+def test_optimistic_merge_preserves_server_running_state_when_local_cache_is_stale():
+    """If the server still says running, stale local optimism must not hide the spinner."""
+    helper_body = _function_body(SESSIONS_SRC, "function _isServerIdleSessionRow(")
+    local_body = _function_body(SESSIONS_SRC, "function _isSessionLocallyStreaming(")
+    optimistic_body = _function_body(SESSIONS_SRC, "function _isOptimisticFirstTurnSessionRow(")
+    keep_body = _function_body(SESSIONS_SRC, "function _shouldKeepLocalOnlyOptimisticSessionRow(")
+    drop_body = _function_body(SESSIONS_SRC, "function _dropStaleOptimisticSessionRow(")
+    merge_body = _function_body(SESSIONS_SRC, "function _mergeOptimisticFirstTurnSessions(")
+
+    script = f"""
+let S = {{ session: null, busy: false }};
+let _sendInProgress = false;
+let _sendInProgressSid = null;
+let INFLIGHT = {{}};
+let _sessionStreamingById = new Map();
+let _allSessions = [{{
+  session_id: 'dogfood-session',
+  title: 'Local stale optimistic row',
+  message_count: 1,
+  last_message_at: 1000,
+  updated_at: 1000,
+  active_stream_id: 'stale-local-stream',
+  pending_user_message: 'stale pending text',
+  pending_started_at: 900,
+  is_streaming: true,
+}}];
+function _isServerIdleSessionRow(s) {{{helper_body}}}
+function _isSessionLocallyStreaming(s) {{{local_body}}}
+function _isOptimisticFirstTurnSessionRow(s) {{{optimistic_body}}}
+function _shouldKeepLocalOnlyOptimisticSessionRow(local) {{{keep_body}}}
+function _dropStaleOptimisticSessionRow(sid) {{{drop_body}}}
+function _mergeOptimisticFirstTurnSessions(fetchedSessions) {{{merge_body}}}
+const merged = _mergeOptimisticFirstTurnSessions([{{
+  session_id: 'dogfood-session',
+  title: 'Server running row',
+  message_count: 2,
+  last_message_at: 1100,
+  updated_at: 1100,
+  active_stream_id: null,
+  pending_user_message: null,
+  pending_started_at: null,
+  is_streaming: true,
+}}]);
+console.log(JSON.stringify(merged[0]));
+"""
+    result = subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True)
+    row = json.loads(result.stdout)
+
+    assert row["session_id"] == "dogfood-session"
+    assert row["title"] == "Server running row"
+    assert row["message_count"] == 2
+    assert row["is_streaming"] is True


### PR DESCRIPTION
## Thinking Path

- Sidebar session rows are the user's quickest signal for long-running background work.
- `_mergeOptimisticFirstTurnSessions()` has to reconcile browser-local optimistic first-turn state with `/api/sessions` rows.
- The server row is the source of truth for whether a session is still running once `/api/sessions` reports `is_streaming: true`.
- The old merge expression let stale local optimistic bookkeeping mask that server-running state when `keepLocalOptimistic` was false.
- This PR keeps server-reported running state intact while still allowing confirmed server-idle rows to clear stale spinners.

## What Changed

- Preserve `fetched.is_streaming` independently of `keepLocalOptimistic` in `_mergeOptimisticFirstTurnSessions()`.
- Add a regression test where a stale local optimistic row merges with a server row that still reports `is_streaming: true`.
- Add an Unreleased changelog entry for the sidebar spinner/unread-state fix.

## Why It Matters

When the merge incorrectly forced `is_streaming` to false, the sidebar could drop the running spinner even though the server still considered the session active. That also weakened the later running-to-complete transition used by unread-dot handling for background completions.

Fixes #2999.

## Contract Routing

Task type: narrow runtime/sidebar metadata bugfix.
Touched areas: `static/sessions.js`, sidebar session-list merge state, regression tests.
Relevant public docs:
- `AGENTS.md`
- `CONTRIBUTING.md`
- `docs/CONTRACTS.md`
- `docs/rfcs/webui-run-state-consistency-contract.md`
State layer: Sidebar/session metadata.
Invariant: server-reported running state remains authoritative over stale browser-local optimistic cache; confirmed server-idle rows still clear stale spinners.
Evidence needed before claiming done: targeted regression test for server-running merge plus existing spinner/unread regression coverage.

## Verification

- `pytest tests/test_issue2454_active_session_spinner.py tests/test_issue856_background_completion_unread.py tests/test_inflight_send_start_race.py -q` (`32 passed`)
- `node --check static/sessions.js`
- `git diff --check`

## Risks / Follow-ups

- No visual layout changes; screenshots are not included because this only changes state reconciliation and regression coverage.
- This does not change backend `/api/sessions` semantics.

## Model Used

AI-assisted. Initial one-line fix was produced by Hermes Agent. Review, regression coverage, issue/PR preparation, and verification were done with OpenAI GPT-5 Codex in the Codex CLI, using local shell, GitHub CLI, and CodeGraph context for repo navigation.
