### PR TITLE
Release DQ — stage-batch27 — sidebar running-state preservation (v0.51.145)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 ## [Unreleased]
 
+## [v0.51.145] — 2026-05-26 — Release DQ (stage-batch27 — sidebar running-state preservation)
+
 ### Fixed
 
 - Sidebar session rows now preserve the server-reported running state when merging stale optimistic first-turn cache entries, so active background sessions keep their spinner and can later transition to unread correctly. (#2999, #3001)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Sidebar session rows now preserve the server-reported running state when merging stale optimistic first-turn cache entries, so active background sessions keep their spinner and can later transition to unread correctly.
+
 ## [v0.51.143] — 2026-05-26 — Release DO (stage-batch25 — single-PR workspace:// markdown scheme)
 
 ### Added

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -2186,7 +2186,7 @@ function _mergeOptimisticFirstTurnSessions(fetchedSessions){
         active_stream_id:fetchedIsServerIdle?null:(keepLocalOptimistic?(fetched.active_stream_id||local.active_stream_id||null):null),
         pending_user_message:fetchedIsServerIdle?null:(keepLocalOptimistic?(fetched.pending_user_message||local.pending_user_message||null):null),
         pending_started_at:fetchedIsServerIdle?null:(keepLocalOptimistic?(fetched.pending_started_at||local.pending_started_at||null):null),
-        is_streaming:fetchedIsServerIdle?false:(keepLocalOptimistic&&Boolean(fetched.is_streaming||local.is_streaming||_isSessionLocallyStreaming(local))),
+        is_streaming:fetchedIsServerIdle?false:Boolean(fetched.is_streaming||(keepLocalOptimistic&&(local.is_streaming||_isSessionLocallyStreaming(local)))),
       };
     }else{
       if(_shouldKeepLocalOnlyOptimisticSessionRow(local)){

--- a/tests/test_issue2454_active_session_spinner.py
+++ b/tests/test_issue2454_active_session_spinner.py
@@ -120,3 +120,57 @@ console.log(JSON.stringify(merged[0]));
     assert row["pending_user_message"] is None
     assert row["pending_started_at"] is None
     assert row["is_streaming"] is False
+
+
+def test_optimistic_merge_preserves_server_running_state_when_local_cache_is_stale():
+    """If the server still says running, stale local optimism must not hide the spinner."""
+    helper_body = _function_body(SESSIONS_SRC, "function _isServerIdleSessionRow(")
+    local_body = _function_body(SESSIONS_SRC, "function _isSessionLocallyStreaming(")
+    optimistic_body = _function_body(SESSIONS_SRC, "function _isOptimisticFirstTurnSessionRow(")
+    keep_body = _function_body(SESSIONS_SRC, "function _shouldKeepLocalOnlyOptimisticSessionRow(")
+    drop_body = _function_body(SESSIONS_SRC, "function _dropStaleOptimisticSessionRow(")
+    merge_body = _function_body(SESSIONS_SRC, "function _mergeOptimisticFirstTurnSessions(")
+
+    script = f"""
+let S = {{ session: null, busy: false }};
+let _sendInProgress = false;
+let _sendInProgressSid = null;
+let INFLIGHT = {{}};
+let _sessionStreamingById = new Map();
+let _allSessions = [{{
+  session_id: 'dogfood-session',
+  title: 'Local stale optimistic row',
+  message_count: 1,
+  last_message_at: 1000,
+  updated_at: 1000,
+  active_stream_id: 'stale-local-stream',
+  pending_user_message: 'stale pending text',
+  pending_started_at: 900,
+  is_streaming: true,
+}}];
+function _isServerIdleSessionRow(s) {{{helper_body}}}
+function _isSessionLocallyStreaming(s) {{{local_body}}}
+function _isOptimisticFirstTurnSessionRow(s) {{{optimistic_body}}}
+function _shouldKeepLocalOnlyOptimisticSessionRow(local) {{{keep_body}}}
+function _dropStaleOptimisticSessionRow(sid) {{{drop_body}}}
+function _mergeOptimisticFirstTurnSessions(fetchedSessions) {{{merge_body}}}
+const merged = _mergeOptimisticFirstTurnSessions([{{
+  session_id: 'dogfood-session',
+  title: 'Server running row',
+  message_count: 2,
+  last_message_at: 1100,
+  updated_at: 1100,
+  active_stream_id: null,
+  pending_user_message: null,
+  pending_started_at: null,
+  is_streaming: true,
+}}]);
+console.log(JSON.stringify(merged[0]));
+"""
+    result = subprocess.run(["node", "-e", script], check=True, capture_output=True, text=True)
+    row = json.loads(result.stdout)
+
+    assert row["session_id"] == "dogfood-session"
+    assert row["title"] == "Server running row"
+    assert row["message_count"] == 2
+    assert row["is_streaming"] is True


### PR DESCRIPTION
# Release DQ / v0.51.145 — stage-batch27 (sidebar running-state preservation)

Tier-A pickup from the canvassing pass. Fresh PR (#3001) opened minutes ago, surgical fix, no review needed beyond verification.

## PR merged

**#3001** (franksong2702) +59/-1, 3 files — Closes #2999. One-line fix in `_mergeOptimisticFirstTurnSessions()` at `static/sessions.js:2189`.

The merge expression for `is_streaming` was treating server-reported running state as conditional on `keepLocalOptimistic`. When a stale local optimistic cache entry merged with a fresh `/api/sessions` row, the sidebar's spinner could disappear even though the server still considered the session active. This also broke the downstream running→complete transition that drives unread-dot handling for background completions.

**The fix**: `(k && Boolean(f || L))` → `Boolean(f || (k && L))`. Only the `keepLocalOptimistic=false, fetched.is_streaming=true` row of the truth table changes behavior — the bug-fix path exactly.

## Verification

- ✅ Pre-merge: #3001 CI green on all 3 Python versions
- ✅ Post-merge gates: node -c on sessions.js + ast.parse on test = clean
- ✅ pytest: **6665 passed / 7 skipped / 3 xpassed / 0 failures** (175s sequential, `-p no:xdist`)
- ✅ Opus advisor: **SHIP-AS-IS** — independently constructed the full truth table and confirmed only the one bug-fix row changes behavior:

  | fetched.is_streaming | keepLocalOptimistic | local.is_streaming | OLD | NEW |
  |---|---|---|---|---|
  | T | T | * | T | T |
  | T | F | * | **F** | **T** ← only changed row |
  | F | T | T | T | T |
  | F | F | T | F | F |
  | F | T | F | F | F |
  | F | F | F | F | F |

- ✅ Row-1 ambiguity resolved: `_isServerIdleSessionRow` at sessions.js:268-270 requires `!s.is_streaming && !s.active_stream_id && !s.pending_user_message`, so `fetchedIsServerIdle===true` implies `fetched.is_streaming` is falsy. The behavior change is precisely scoped.
- ✅ Regression test `test_optimistic_merge_preserves_server_running_state_when_local_cache_is_stale` extracts the actual JS function bodies and runs them in node — asserts the merged row keeps `is_streaming: True` and that server-side title/count override local.

Sitting on top of v0.51.144 (Release DP).
