### PR TITLE
fix: reattach SSE on session-switch return and preserve live progress (closes #2924)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Fixed
 
 - WebUI progress guidance now restores a firm visible interim-progress contract for long tool-running chat turns, and session-switch reattach now backfills active stream gaps from the run journal with per-event SSE ids so visible live progress stays stable after switching away and back. (#3014, #2924)
+- Live Stream Activity now keeps the same progress-text/tool-burst structure after a run settles: the top Run Activity owns the whole-turn timer, while per-segment tool Activity cards stay bound to the progress text that produced them instead of collapsing back into one late `Activity: N tools` block.
 
 ## [v0.51.152] — 2026-05-28 — Release DX (stage-batch34 — single-PR optional gateway-backed browser chat)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 - WebUI progress guidance now restores a firm visible interim-progress contract for long tool-running chat turns, and session-switch reattach now backfills active stream gaps from the run journal with per-event SSE ids so visible live progress stays stable after switching away and back. (#3014, #2924)
 - Live Stream Activity now keeps the same progress-text/tool-burst structure after a run settles: the top Run Activity owns the whole-turn timer, while per-segment tool Activity cards stay bound to the progress text that produced them instead of collapsing back into one late `Activity: N tools` block.
+- Live Stream reattach now resumes multi-segment process text from the full assistant accumulator instead of the latest visible segment, preventing older progress text anchors from disappearing after repeated session switches.
 
 ## [v0.51.152] — 2026-05-28 — Release DX (stage-batch34 — single-PR optional gateway-backed browser chat)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- WebUI progress guidance now restores a firm visible interim-progress contract for long tool-running chat turns, and session-switch reattach now backfills active stream gaps from the run journal with per-event SSE ids so visible live progress stays stable after switching away and back. (#3014, #2924)
+
 ## [v0.51.152] — 2026-05-28 — Release DX (stage-batch34 — single-PR optional gateway-backed browser chat)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - WebUI progress guidance now restores a firm visible interim-progress contract for long tool-running chat turns, and session-switch reattach now backfills active stream gaps from the run journal with per-event SSE ids so visible live progress stays stable after switching away and back. (#3014, #2924)
 - Live Stream Activity now keeps the same progress-text/tool-burst structure after a run settles: the top Run Activity owns the whole-turn timer, while per-segment tool Activity cards stay bound to the progress text that produced them instead of collapsing back into one late `Activity: N tools` block.
 - Live Stream reattach now resumes multi-segment process text from the full assistant accumulator instead of the latest visible segment, preventing older progress text anchors from disappearing after repeated session switches.
+- Live Stream now records interim progress boundaries even when a session is being switched away, so tools emitted during that inactive-pane window still reattach to the progress text that produced them.
 
 ## [v0.51.152] — 2026-05-28 — Release DX (stage-batch34 — single-PR optional gateway-backed browser chat)
 

--- a/api/config.py
+++ b/api/config.py
@@ -4591,9 +4591,21 @@ class StreamChannel:
     def __init__(self):
         self._lock = threading.Lock()
         self._subscribers: list[queue.Queue] = []
-        self._offline_buffer: list[tuple[str, object]] = []
+        self._offline_buffer: list[tuple[str, object] | tuple[str, object, str | None]] = []
+        self._last_event_id: str | None = None
+
+    @staticmethod
+    def _event_id_from_item(item) -> str | None:
+        if isinstance(item, tuple) and len(item) >= 3:
+            event_id = item[2]
+            return str(event_id) if event_id else None
+        return None
 
     def subscribe(self) -> queue.Queue:
+        q, _snapshot = self.subscribe_with_snapshot()
+        return q
+
+    def subscribe_with_snapshot(self) -> tuple[queue.Queue, dict[str, object]]:
         q: queue.Queue = queue.Queue()
         with self._lock:
             # Replay buffered events to the new subscriber INSIDE the lock so a
@@ -4604,7 +4616,17 @@ class StreamChannel:
             for item in self._offline_buffer:
                 q.put_nowait(item)
             self._subscribers.append(q)
-        return q
+            snapshot = {
+                "subscriber_count": len(self._subscribers),
+                "offline_buffered_events": len(self._offline_buffer),
+                "offline_buffered_event_ids": [
+                    event_id
+                    for event_id in (self._event_id_from_item(item) for item in self._offline_buffer)
+                    if event_id
+                ],
+                "last_event_id": self._last_event_id,
+            }
+        return q, snapshot
 
     def unsubscribe(self, q: queue.Queue) -> None:
         with self._lock:
@@ -4613,8 +4635,11 @@ class StreamChannel:
             except ValueError:
                 pass
 
-    def put_nowait(self, item: tuple[str, object]) -> None:
+    def put_nowait(self, item: tuple[str, object] | tuple[str, object, str | None]) -> None:
         with self._lock:
+            event_id = self._event_id_from_item(item)
+            if event_id:
+                self._last_event_id = event_id
             subscribers = list(self._subscribers)
             if not subscribers:
                 self._offline_buffer.append(item)
@@ -4629,6 +4654,12 @@ class StreamChannel:
             return {
                 "subscriber_count": len(self._subscribers),
                 "offline_buffered_events": len(self._offline_buffer),
+                "offline_buffered_event_ids": [
+                    event_id
+                    for event_id in (self._event_id_from_item(item) for item in self._offline_buffer)
+                    if event_id
+                ],
+                "last_event_id": self._last_event_id,
             }
 
 

--- a/api/gateway_chat.py
+++ b/api/gateway_chat.py
@@ -177,7 +177,7 @@ def _run_gateway_chat_streaming(
             except Exception:
                 logger.debug("Failed to append gateway event %s for stream %s", event, stream_id, exc_info=True)
         try:
-            q.put_nowait((event, data))
+            q.put_nowait((event, data, event_id))
         except Exception:
             logger.debug("Failed to put gateway event to queue")
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -7068,7 +7068,34 @@ def _parse_run_journal_after_seq(qs: dict) -> int | None:
         return 0
 
 
-def _replay_run_journal(handler, stream_id: str, after_seq: int | None) -> bool:
+def _parse_stream_event_seq(event_id) -> int | None:
+    raw = str(event_id or "").strip()
+    if not raw:
+        return None
+    tail = raw.rsplit(":", 1)[-1]
+    try:
+        return max(0, int(tail))
+    except (TypeError, ValueError):
+        return None
+
+
+def _stream_queue_item_parts(item) -> tuple[str, object, str | None]:
+    if isinstance(item, tuple):
+        if len(item) >= 3:
+            return item[0], item[1], (str(item[2]) if item[2] else None)
+        if len(item) >= 2:
+            return item[0], item[1], None
+    return "message", item, None
+
+
+def _replay_run_journal(
+    handler,
+    stream_id: str,
+    after_seq: int | None,
+    *,
+    max_seq: int | None = None,
+    emit_stale_interrupted: bool = True,
+) -> bool:
     summary = find_run_summary(stream_id)
     if not summary:
         return False
@@ -7076,6 +7103,7 @@ def _replay_run_journal(handler, stream_id: str, after_seq: int | None) -> bool:
         str(summary.get("session_id") or ""),
         stream_id,
         after_seq=after_seq,
+        max_seq=max_seq,
     )
     for entry in journal.get("events") or []:
         _sse_with_id(
@@ -7084,7 +7112,7 @@ def _replay_run_journal(handler, stream_id: str, after_seq: int | None) -> bool:
             entry.get("payload"),
             entry.get("event_id"),
         )
-    if not summary.get("terminal"):
+    if emit_stale_interrupted and not summary.get("terminal"):
         stale = stale_interrupted_event(
             str(summary.get("session_id") or ""),
             stream_id,
@@ -7093,6 +7121,20 @@ def _replay_run_journal(handler, stream_id: str, after_seq: int | None) -> bool:
         if stale:
             _sse_with_id(handler, stale["event"], stale["payload"], stale["event_id"])
     return True
+
+
+def _run_journal_terminal_at_or_before(stream_id: str, max_seq: int | None) -> bool:
+    if max_seq is None:
+        return False
+    summary = find_run_summary(stream_id)
+    if not summary or not summary.get("terminal"):
+        return False
+    journal = read_run_events(
+        str(summary.get("session_id") or ""),
+        stream_id,
+        max_seq=max_seq,
+    )
+    return any(bool(entry.get("terminal")) for entry in journal.get("events") or [])
 
 
 def _handle_sse_stream(handler, parsed):
@@ -7117,7 +7159,15 @@ def _handle_sse_stream(handler, parsed):
         except _CLIENT_DISCONNECT_ERRORS:
             pass
         return True
-    subscriber = stream.subscribe() if hasattr(stream, "subscribe") else stream
+    active_replay = qs.get("replay", [""])[0] == "1"
+    subscriber = None
+    replay_cutoff_seq = None
+    if hasattr(stream, "subscribe_with_snapshot"):
+        subscriber, snapshot = stream.subscribe_with_snapshot()
+        if active_replay:
+            replay_cutoff_seq = _parse_stream_event_seq((snapshot or {}).get("last_event_id"))
+    else:
+        subscriber = stream.subscribe() if hasattr(stream, "subscribe") else stream
     handler.send_response(200)
     handler.send_header("Content-Type", "text/event-stream; charset=utf-8")
     handler.send_header("Cache-Control", "no-cache")
@@ -7125,18 +7175,28 @@ def _handle_sse_stream(handler, parsed):
     handler.send_header("Connection", "close")
     handler.end_headers()
     try:
+        if active_replay:
+            _replay_run_journal(
+                handler,
+                stream_id,
+                _parse_run_journal_after_seq(qs),
+                max_seq=replay_cutoff_seq,
+                emit_stale_interrupted=False,
+            )
+            if _run_journal_terminal_at_or_before(stream_id, replay_cutoff_seq):
+                return True
         while True:
             try:
-                event, data = subscriber.get(timeout=_SSE_HEARTBEAT_INTERVAL_SECONDS)
+                item = subscriber.get(timeout=_SSE_HEARTBEAT_INTERVAL_SECONDS)
             except queue.Empty:
                 handler.wfile.write(b": heartbeat\n\n")
                 handler.wfile.flush()
                 continue
-            # Stage-364: emit `id:` from STREAM_LAST_EVENT_ID side-channel so
-            # the frontend's `_lastRunJournalSeq` cursor advances during live
-            # streaming. Without this, mid-stream error→replay would arrive
-            # with after_seq=0 and double-render every journaled event.
-            event_id = STREAM_LAST_EVENT_ID.get(stream_id)
+            event, data, event_id = _stream_queue_item_parts(item)
+            if active_replay and replay_cutoff_seq is not None:
+                item_seq = _parse_stream_event_seq(event_id)
+                if item_seq is not None and item_seq <= replay_cutoff_seq:
+                    continue
             if event_id:
                 _sse_with_id(handler, event, data, event_id)
             else:

--- a/api/routes.py
+++ b/api/routes.py
@@ -7176,14 +7176,16 @@ def _handle_sse_stream(handler, parsed):
     handler.end_headers()
     try:
         if active_replay:
-            _replay_run_journal(
+            replayed = _replay_run_journal(
                 handler,
                 stream_id,
                 _parse_run_journal_after_seq(qs),
                 max_seq=replay_cutoff_seq,
                 emit_stale_interrupted=False,
             )
-            if _run_journal_terminal_at_or_before(stream_id, replay_cutoff_seq):
+            if not replayed:
+                replay_cutoff_seq = None
+            elif _run_journal_terminal_at_or_before(stream_id, replay_cutoff_seq):
                 return True
         while True:
             try:

--- a/api/run_journal.py
+++ b/api/run_journal.py
@@ -199,12 +199,15 @@ def read_run_events(
     run_id: str,
     *,
     after_seq: int | None = None,
+    max_seq: int | None = None,
     session_dir: Path | None = None,
 ) -> dict:
     path = _run_path(session_id, run_id, session_dir=session_dir)
     events, malformed = _read_jsonl(path)
     if after_seq is not None:
         events = [event for event in events if int(event.get("seq") or 0) > int(after_seq)]
+    if max_seq is not None:
+        events = [event for event in events if int(event.get("seq") or 0) <= int(max_seq)]
     return {
         "session_id": str(session_id),
         "run_id": str(run_id),

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -3104,6 +3104,43 @@ def _nearest_assistant_msg_idx(messages, msg_idx: int) -> int:
     return -1
 
 
+def _assistant_message_has_visible_content(msg) -> bool:
+    if not isinstance(msg, dict) or msg.get('role') != 'assistant':
+        return False
+    content = msg.get('content', '')
+    if isinstance(content, str):
+        return bool(content.strip())
+    if not isinstance(content, list):
+        return False
+    for part in content:
+        if isinstance(part, str) and part.strip():
+            return True
+        if not isinstance(part, dict):
+            continue
+        if part.get('type') in {'text', 'input_text', 'output_text'}:
+            if str(part.get('text') or part.get('content') or '').strip():
+                return True
+    return False
+
+
+def _nearest_visible_assistant_msg_idx(messages, msg_idx: int) -> int:
+    """Find the closest preceding assistant message with visible progress text."""
+    for idx in range(msg_idx - 1, -1, -1):
+        msg = messages[idx]
+        if _assistant_message_has_visible_content(msg):
+            return idx
+    return -1
+
+
+def _assistant_tool_anchor_msg_idx(messages, msg_idx: int) -> int:
+    """Anchor empty assistant tool-call messages to the prior visible assistant."""
+    msg = messages[msg_idx] if isinstance(messages, list) and 0 <= msg_idx < len(messages) else None
+    if _assistant_message_has_visible_content(msg):
+        return msg_idx
+    visible_idx = _nearest_visible_assistant_msg_idx(messages, msg_idx)
+    return visible_idx if visible_idx >= 0 else msg_idx
+
+
 def _extract_tool_calls_from_messages(messages, live_tool_calls=None):
     """Build persisted tool-call summaries from final messages plus live progress fallback."""
     tool_calls = []
@@ -3125,7 +3162,7 @@ def _extract_tool_calls_from_messages(messages, live_tool_calls=None):
                         if tid:
                             pending_names[tid] = part.get('name', '')
                             pending_args[tid] = part.get('input', {})
-                            pending_asst_idx[tid] = msg_idx
+                            pending_asst_idx[tid] = _assistant_tool_anchor_msg_idx(messages, msg_idx)
             for tc in m.get('tool_calls', []):
                 if not isinstance(tc, dict):
                     continue
@@ -3139,7 +3176,7 @@ def _extract_tool_calls_from_messages(messages, live_tool_calls=None):
                 if tid and name:
                     pending_names[tid] = name
                     pending_args[tid] = args
-                    pending_asst_idx[tid] = msg_idx
+                    pending_asst_idx[tid] = _assistant_tool_anchor_msg_idx(messages, msg_idx)
         elif role == 'tool':
             tid = m.get('tool_call_id') or m.get('tool_use_id', '')
             raw = m.get('content', '')
@@ -3165,11 +3202,14 @@ def _extract_tool_calls_from_messages(messages, live_tool_calls=None):
             if seq_idx >= len(live):
                 break
             live_tc = live[seq_idx]
+            anchor_idx = _nearest_visible_assistant_msg_idx(messages, seq.get('msg_idx', -1))
+            if anchor_idx < 0:
+                anchor_idx = _nearest_assistant_msg_idx(messages, seq.get('msg_idx', -1))
             tool_calls.append({
                 'name': live_tc.get('name', 'tool'),
                 'snippet': _tool_result_snippet(seq.get('raw', '')),
                 'tid': live_tc.get('tid', '') or '',
-                'assistant_msg_idx': _nearest_assistant_msg_idx(messages, seq.get('msg_idx', -1)),
+                'assistant_msg_idx': anchor_idx,
                 'args': _truncate_tool_args(live_tc.get('args', {}), limit=4),
             })
 

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -194,8 +194,9 @@ _CANCEL_MARKER_PATTERNS = ('task cancelled', 'task canceled', 'response interrup
 
 _WEBUI_PROGRESS_PROMPT = """
 WebUI progress guidance:
-- Match the normal Hermes messaging style; do not add extra status updates solely because this is a browser session.
-- For long multi-step work that uses tools, you may provide brief user-visible progress updates before continuing with tool calls.
+- Match the normal Hermes messaging style, but do not let long tool-running WebUI turns appear silent.
+- For long multi-step work that uses tools, provide brief user-visible progress updates as normal assistant content before the next tool batch or after a meaningful finding.
+- Do not keep all progress only in reasoning, thinking, or tool-result channels; those are not a substitute for visible interim updates.
 - Each update should say what you are about to check, what you just confirmed, or why the next tool call is needed.
 - Keep updates concise, factual, and in the user's language. One or two short sentences are enough.
 - Do not reveal hidden reasoning, chain-of-thought, private scratchpads, secrets, raw logs, or long tool output.
@@ -3704,24 +3705,17 @@ def _run_agent_streaming(
         # If cancelled, drop all further events except the cancel event itself
         if cancel_event.is_set() and event not in ('cancel', 'error'):
             return
+        event_id = None
         if run_journal is not None:
             try:
                 journaled = run_journal.append_sse_event(event, data)
-                # Stage-364: propagate journal event_id via a side-channel dict
-                # (STREAM_LAST_EVENT_ID) instead of changing the queue tuple
-                # shape — keeping the 2-tuple shape preserves backward
-                # compatibility for tests and any non-SSE queue consumer. The
-                # SSE handler reads this dict at emit time to populate `id:`
-                # on every live frame, which lets the frontend's cursor
-                # advance during live streaming and prevents replay from
-                # double-rendering tokens after a mid-stream error→reconnect.
                 event_id = (journaled or {}).get('event_id') if isinstance(journaled, dict) else None
                 if event_id:
                     STREAM_LAST_EVENT_ID[stream_id] = event_id
             except Exception:
                 logger.debug("Failed to append run journal event %s for stream %s", event, stream_id, exc_info=True)
         try:
-            q.put_nowait((event, data))
+            q.put_nowait((event, data, event_id))
         except Exception:
             logger.debug("Failed to put event to queue")
 

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -194,9 +194,8 @@ _CANCEL_MARKER_PATTERNS = ('task cancelled', 'task canceled', 'response interrup
 
 _WEBUI_PROGRESS_PROMPT = """
 WebUI progress guidance:
-- Match the normal Hermes messaging style, but do not let long tool-running WebUI turns appear silent.
-- For long multi-step work that uses tools, provide brief user-visible progress updates as normal assistant content before the next tool batch or after a meaningful finding.
-- Do not keep all progress only in reasoning, thinking, or tool-result channels; those are not a substitute for visible interim updates.
+- Match the normal Hermes messaging style; do not add extra status updates solely because this is a browser session.
+- For long multi-step work that uses tools, you may provide brief user-visible progress updates before continuing with tool calls.
 - Each update should say what you are about to check, what you just confirmed, or why the next tool call is needed.
 - Keep updates concise, factual, and in the user's language. One or two short sentences are enough.
 - Do not reveal hidden reasoning, chain-of-thought, private scratchpads, secrets, raw logs, or long tool output.

--- a/static/messages.js
+++ b/static/messages.js
@@ -845,6 +845,13 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     const existing=inflight.activityBurstAnchors.find(a=>Number(a&&a.id)===_currentActivityBurstId);
     if(existing) existing.textEnd=textEnd;
     else inflight.activityBurstAnchors.push({id:_currentActivityBurstId,textEnd});
+    // Keep the current text segment's DOM attribute in sync with the post-increment
+    // burst id so that subsequent tool events (which use _currentActivityBurstId)
+    // find the correct anchor via [data-activity-burst-id].  Without this the
+    // segment keeps the pre-increment id (N) while tools get id N+1, causing
+    // appendLiveToolCard to miss the anchor and Activity groups to pile up after
+    // all text instead of interleaving correctly.
+    if(assistantRow) assistantRow.setAttribute('data-activity-burst-id',String(_currentActivityBurstId));
     _throttledPersist();
   }
   function ensureAssistantRow(force=false){

--- a/static/messages.js
+++ b/static/messages.js
@@ -977,6 +977,35 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
   const _STREAM_FADE_DONE_DRAIN_MAX_MS=900;
   const _streamFadeEnabledForStream=window._fadeTextEffect===true;
 
+  function _mergeSettledToolCallsWithLiveMetadata(rawCalls){
+    const liveCalls=Array.isArray(S.toolCalls)?S.toolCalls:[];
+    const byTid=new Map();
+    liveCalls.forEach((tc,idx)=>{
+      if(!tc||typeof tc!=='object') return;
+      const tid=tc.tid||tc.id||tc.tool_call_id||tc.call_id||'';
+      if(tid&&!byTid.has(tid)) byTid.set(tid,{tc,idx});
+    });
+    const used=new Set();
+    return (rawCalls||[]).map((raw,idx)=>{
+      const next={...(raw||{}),done:true};
+      const tid=next.tid||next.id||next.tool_call_id||next.call_id||'';
+      let matchEntry=tid?byTid.get(tid):null;
+      if(!matchEntry){
+        const name=next.name||((next.function||{}).name)||'';
+        const matchIdx=liveCalls.findIndex((tc,i)=>tc&&!used.has(i)&&(!name||tc.name===name));
+        if(matchIdx>=0) matchEntry={tc:liveCalls[matchIdx],idx:matchIdx};
+      }
+      if(matchEntry){
+        used.add(matchEntry.idx);
+        const live=matchEntry.tc||{};
+        for(const key of ['activityBurstId','duration','started_at']){
+          if(next[key]===undefined&&live[key]!==undefined) next[key]=live[key];
+        }
+      }
+      return next;
+    });
+  }
+
   // rAF-throttled rendering: buffer tokens, render at most once per frame
   let _renderPending=false;
   // Extract display text from assistantText, stripping completed thinking blocks
@@ -1948,7 +1977,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
             return hasTc||hasPartialTc||hasTu;
           });
           if(!hasMessageToolMetadata&&d.session.tool_calls&&d.session.tool_calls.length){
-            S.toolCalls=d.session.tool_calls.map(tc=>({...tc,done:true}));
+            S.toolCalls=_mergeSettledToolCallsWithLiveMetadata(d.session.tool_calls);
           } else {
             S.toolCalls=hasMessageToolMetadata?[]:S.toolCalls.map(tc=>({...tc,done:true}));
           }
@@ -2352,7 +2381,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
           return hasTc||hasPartialTc||hasTu;
         });
         if(!hasMessageToolMetadata&&session.tool_calls&&session.tool_calls.length){
-          S.toolCalls=(session.tool_calls||[]).map(tc=>({...tc,done:true}));
+          S.toolCalls=_mergeSettledToolCallsWithLiveMetadata(session.tool_calls||[]);
         }else{
           S.toolCalls=[];
         }

--- a/static/messages.js
+++ b/static/messages.js
@@ -675,13 +675,18 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
   // progress made before the session switch. Without this the closure starts
   // empty and tokens arriving on the new SSE connection append to nothing —
   // the already-rendered content vanishes.
+  const _liveInflightAssistant = reconnecting
+    ? (INFLIGHT[activeSid]?.messages?.findLast?.(m => m.role === 'assistant' && m._live) || null)
+    : null;
   const _lastLiveAssistant = reconnecting
-    ? (INFLIGHT[activeSid]&&INFLIGHT[activeSid].lastAssistantText)
-      || (INFLIGHT[activeSid]?.messages?.findLast?.(m => m.role === 'assistant' && m._live)?.content || '')
+    ? (_liveInflightAssistant
+      ? (_liveInflightAssistant.content || '')
+      : ((INFLIGHT[activeSid]&&INFLIGHT[activeSid].lastAssistantText) || ''))
     : '';
   const _lastLiveReasoning = reconnecting
-    ? (INFLIGHT[activeSid]&&INFLIGHT[activeSid].lastReasoningText)
-      || (INFLIGHT[activeSid]?.messages?.findLast?.(m => m.role === 'assistant' && m._live)?.reasoning || '')
+    ? (_liveInflightAssistant&&_liveInflightAssistant.reasoning)
+      || (INFLIGHT[activeSid]&&INFLIGHT[activeSid].lastReasoningText)
+      || ''
     : '';
   let assistantText=_lastLiveAssistant;
   let reasoningText=_lastLiveReasoning;

--- a/static/messages.js
+++ b/static/messages.js
@@ -839,9 +839,23 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     const inflight=INFLIGHT[activeSid];
     if(!inflight) return;
     if(!Array.isArray(inflight.activityBurstAnchors)) inflight.activityBurstAnchors=[];
+    const textEnd=String(assistantText||'').length;
+    const lastTextEnd=inflight.activityBurstAnchors.reduce((max,a)=>{
+      const n=Number(a&&a.textEnd);
+      return Number.isFinite(n)?Math.max(max,n):max;
+    },0);
+    if(textEnd<=lastTextEnd){
+      // A replayed or duplicate interim boundary with no new visible text must
+      // not create a fresh burst.  Tools after it still belong to the previous
+      // visible segment; otherwise they get a burst id with no DOM/text anchor
+      // and Activity cards pile up at the end of the turn after reattach.
+      inflight.currentActivityBurstId=_currentActivityBurstId;
+      if(assistantRow) assistantRow.setAttribute('data-activity-burst-id',String(_currentActivityBurstId));
+      _throttledPersist();
+      return;
+    }
     _currentActivityBurstId+=1;
     inflight.currentActivityBurstId=_currentActivityBurstId;
-    const textEnd=String(assistantText||'').length;
     const existing=inflight.activityBurstAnchors.find(a=>Number(a&&a.id)===_currentActivityBurstId);
     if(existing) existing.textEnd=textEnd;
     else inflight.activityBurstAnchors.push({id:_currentActivityBurstId,textEnd});

--- a/static/messages.js
+++ b/static/messages.js
@@ -2000,7 +2000,8 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
           if(!hasMessageToolMetadata&&d.session.tool_calls&&d.session.tool_calls.length){
             S.toolCalls=_mergeSettledToolCallsWithLiveMetadata(d.session.tool_calls);
           } else {
-            S.toolCalls=S.toolCalls.map(tc=>({...tc,done:true}));
+            if(hasMessageToolMetadata) S._settledLiveToolMetadata=S.toolCalls.map(tc=>({...tc,done:true}));
+            S.toolCalls=hasMessageToolMetadata?[]:S.toolCalls.map(tc=>({...tc,done:true}));
           }
           if(typeof renderSessionArtifacts==='function') renderSessionArtifacts();
           if(typeof _copyActivityDisclosureState==='function'&&lastAsst){
@@ -2404,7 +2405,8 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         if(!hasMessageToolMetadata&&session.tool_calls&&session.tool_calls.length){
           S.toolCalls=_mergeSettledToolCallsWithLiveMetadata(session.tool_calls||[]);
         }else{
-          S.toolCalls=S.toolCalls.map(tc=>({...tc,done:true}));
+          if(hasMessageToolMetadata) S._settledLiveToolMetadata=S.toolCalls.map(tc=>({...tc,done:true}));
+          S.toolCalls=hasMessageToolMetadata?[]:S.toolCalls.map(tc=>({...tc,done:true}));
         }
         if(isSessionViewed) _markSessionViewed(completedSid, session.message_count ?? S.messages.length);
         syncTopbar();renderMessages({preserveScroll:true});

--- a/static/messages.js
+++ b/static/messages.js
@@ -1020,7 +1020,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         used.add(matchEntry.idx);
         const live=matchEntry.tc||{};
         for(const key of ['activityBurstId','duration','started_at']){
-          if(next[key]===undefined&&live[key]!==undefined) next[key]=live[key];
+          if((next[key]===undefined||next[key]===null)&&live[key]!==undefined&&live[key]!==null) next[key]=live[key];
         }
       }
       return next;
@@ -2000,7 +2000,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
           if(!hasMessageToolMetadata&&d.session.tool_calls&&d.session.tool_calls.length){
             S.toolCalls=_mergeSettledToolCallsWithLiveMetadata(d.session.tool_calls);
           } else {
-            S.toolCalls=hasMessageToolMetadata?[]:S.toolCalls.map(tc=>({...tc,done:true}));
+            S.toolCalls=S.toolCalls.map(tc=>({...tc,done:true}));
           }
           if(typeof renderSessionArtifacts==='function') renderSessionArtifacts();
           if(typeof _copyActivityDisclosureState==='function'&&lastAsst){
@@ -2404,7 +2404,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         if(!hasMessageToolMetadata&&session.tool_calls&&session.tool_calls.length){
           S.toolCalls=_mergeSettledToolCallsWithLiveMetadata(session.tool_calls||[]);
         }else{
-          S.toolCalls=[];
+          S.toolCalls=S.toolCalls.map(tc=>({...tc,done:true}));
         }
         if(isSessionViewed) _markSessionViewed(completedSid, session.message_count ?? S.messages.length);
         syncTopbar();renderMessages({preserveScroll:true});

--- a/static/messages.js
+++ b/static/messages.js
@@ -1780,12 +1780,16 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       liveReasoningText='';
       reasoningText='';
       const oldRow=$('toolRunningRow');if(oldRow)oldRow.remove();
+      // Flush any pending text into the current segment before inserting the
+      // Activity group. Otherwise the group can appear first, then the delayed
+      // text render fills the empty anchor above it a frame later, producing a
+      // visible "text inserted before Activity" reorder on slow/mobile clients.
+      _flushPendingSegmentRender({force:true});
       appendLiveToolCard(tc);
       snapshotLiveTurn();
       // Reset the live assistant row reference so that any text tokens arriving
       // after this tool call create a NEW segment appended below the tool card,
       // rather than updating the old segment that sits above it in the DOM.
-      _flushPendingSegmentRender({force:true});
       _freshSegment=true;
       _smdEndParser();
       _resetAssistantSegment();

--- a/static/messages.js
+++ b/static/messages.js
@@ -679,13 +679,24 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
   // progress made before the session switch. Without this the closure starts
   // empty and tokens arriving on the new SSE connection append to nothing —
   // the already-rendered content vanishes.
-  const _liveInflightAssistant = reconnecting
-    ? (INFLIGHT[activeSid]?.messages?.findLast?.(m => m.role === 'assistant' && m._live) || null)
+  const _liveInflightAssistantMessages = reconnecting
+    ? ((INFLIGHT[activeSid]&&Array.isArray(INFLIGHT[activeSid].messages))
+      ? INFLIGHT[activeSid].messages.filter(m=>m&&m.role==='assistant'&&m._live)
+      : [])
+    : [];
+  const _liveInflightAssistant = _liveInflightAssistantMessages.length===1
+    ? _liveInflightAssistantMessages[0]
     : null;
+  const _fullInflightAssistant = (INFLIGHT[activeSid]&&INFLIGHT[activeSid].lastAssistantText) || '';
+  const _joinedInflightSegments = _liveInflightAssistantMessages.length>1
+    ? _liveInflightAssistantMessages.map(m=>m&&m.content?String(m.content).trim():'').filter(Boolean).join('\n\n')
+    : '';
   const _lastLiveAssistant = reconnecting
-    ? (_liveInflightAssistant
-      ? (_liveInflightAssistant.content || '')
-      : ((INFLIGHT[activeSid]&&INFLIGHT[activeSid].lastAssistantText) || ''))
+    ? (_liveInflightAssistantMessages.length>1
+      ? (_fullInflightAssistant || _joinedInflightSegments)
+      : (_liveInflightAssistant
+        ? (_liveInflightAssistant.content || '')
+        : _fullInflightAssistant))
     : '';
   const _lastLiveReasoning = reconnecting
     ? (_liveInflightAssistant&&_liveInflightAssistant.reasoning)

--- a/static/messages.js
+++ b/static/messages.js
@@ -457,9 +457,9 @@ async function send(){
       }
     });
     optimisticMessages=[...S.messages];
-    INFLIGHT[activeSid]={messages:optimisticMessages,uploaded:uploadedNames,toolCalls:[]};
+    INFLIGHT[activeSid]={messages:optimisticMessages,uploaded:uploadedNames,toolCalls:[],currentActivityBurstId:0,activityBurstAnchors:[]};
     if(typeof saveInflightState==='function'){
-      saveInflightState(activeSid,{streamId:null,messages:INFLIGHT[activeSid].messages,uploaded:uploadedNames,toolCalls:[]});
+      saveInflightState(activeSid,{streamId:null,messages:INFLIGHT[activeSid].messages,uploaded:uploadedNames,toolCalls:[],currentActivityBurstId:0,activityBurstAnchors:[]});
     }
     _runOptionalPreStartUiStep('renderSessionListFromCache.initial', ()=>{
       if(typeof renderSessionListFromCache==='function') renderSessionListFromCache();
@@ -636,6 +636,8 @@ function closeLiveStream(sessionId, streamId, source){
         lastAssistantText:INFLIGHT[sessionId].lastAssistantText||'',
         lastReasoningText:INFLIGHT[sessionId].lastReasoningText||'',
         lastRunJournalSeq:INFLIGHT[sessionId].lastRunJournalSeq||0,
+        currentActivityBurstId:INFLIGHT[sessionId].currentActivityBurstId||0,
+        activityBurstAnchors:Array.isArray(INFLIGHT[sessionId].activityBurstAnchors)?INFLIGHT[sessionId].activityBurstAnchors:[],
       });
     }
   }
@@ -659,6 +661,8 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     if(uploaded.length) INFLIGHT[activeSid].uploaded=[...uploaded];
     if(!Array.isArray(INFLIGHT[activeSid].toolCalls)) INFLIGHT[activeSid].toolCalls=[];
   }
+  if(!Array.isArray(INFLIGHT[activeSid].activityBurstAnchors)) INFLIGHT[activeSid].activityBurstAnchors=[];
+  if(INFLIGHT[activeSid].currentActivityBurstId===undefined) INFLIGHT[activeSid].currentActivityBurstId=0;
   const existingLive=LIVE_STREAMS[activeSid];
   if(
     existingLive&&existingLive.streamId===streamId&&existingLive.source&&
@@ -774,6 +778,8 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       lastAssistantText:inflight.lastAssistantText||'',
       lastReasoningText:inflight.lastReasoningText||'',
       lastRunJournalSeq:inflight.lastRunJournalSeq||0,
+      currentActivityBurstId:inflight.currentActivityBurstId||0,
+      activityBurstAnchors:Array.isArray(inflight.activityBurstAnchors)?inflight.activityBurstAnchors:[],
     });
   }
   function snapshotLiveTurn(){
@@ -829,6 +835,18 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     inflight.messages.push({role:'assistant',content:assistantText,reasoning:reasoningText||undefined,_live:true,_ts:ts});
     _throttledPersist();
   }
+  function recordActivityBoundary(){
+    const inflight=INFLIGHT[activeSid];
+    if(!inflight) return;
+    if(!Array.isArray(inflight.activityBurstAnchors)) inflight.activityBurstAnchors=[];
+    _currentActivityBurstId+=1;
+    inflight.currentActivityBurstId=_currentActivityBurstId;
+    const textEnd=String(assistantText||'').length;
+    const existing=inflight.activityBurstAnchors.find(a=>Number(a&&a.id)===_currentActivityBurstId);
+    if(existing) existing.textEnd=textEnd;
+    else inflight.activityBurstAnchors.push({id:_currentActivityBurstId,textEnd});
+    _throttledPersist();
+  }
   function ensureAssistantRow(force=false){
     if(!_isActiveSession()) return;
     if(assistantRow&&!assistantRow.isConnected){assistantRow=null;assistantBody=null;}
@@ -843,6 +861,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     }
     const blocks=(typeof _assistantTurnBlocks==='function')?_assistantTurnBlocks(turn):null;
     if(!blocks) return;
+    if(typeof ensureRunActivityGroup==='function') ensureRunActivityGroup(blocks,{live:true,collapsed:true});
     if(!assistantRow){
       // Only reuse an existing segment on the very first creation (e.g. reconnect).
       // After a tool call _freshSegment=true, so we always create a new segment
@@ -865,6 +884,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     assistantRow=document.createElement('div');
     assistantRow.className='assistant-segment';
     assistantRow.setAttribute('data-live-assistant','1');
+    assistantRow.setAttribute('data-activity-burst-id',String(_currentActivityBurstId));
     assistantBody=document.createElement('div');assistantBody.className='msg-body';
     assistantRow.appendChild(assistantBody);
     blocks.appendChild(assistantRow);
@@ -946,6 +966,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
   let _streamFadeReduceMotionMql=null;
   let _streamFadeReduceMotion=false;
   let _streamFadeReduceMotionOnChange=null;
+  let _currentActivityBurstId=Number((INFLIGHT[activeSid]&&INFLIGHT[activeSid].currentActivityBurstId)||0)||0;
   let _lastRunJournalSeq=reconnecting
     ? Number((INFLIGHT[activeSid]&&INFLIGHT[activeSid].lastRunJournalSeq)||0)
     : 0;
@@ -1599,6 +1620,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
           ensureAssistantRow(true);
           _flushPendingSegmentRender({force:true});
           if(typeof closeCurrentLiveActivityGroup==='function') closeCurrentLiveActivityGroup();
+          recordActivityBoundary();
         }
         _resetAssistantSegment();
         return;
@@ -1614,6 +1636,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       ensureAssistantRow(true);
       _flushPendingSegmentRender({force:true});
       if(typeof closeCurrentLiveActivityGroup==='function') closeCurrentLiveActivityGroup();
+      recordActivityBoundary();
       _resetAssistantSegment();
       _scheduleRender();
     });
@@ -1639,7 +1662,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     source.addEventListener('tool',e=>{
       const d=JSON.parse(e.data);
       if(d.name==='clarify') return;
-      const tc={name:d.name, preview:d.preview||'', args:d.args||{}, snippet:'', done:false, tid:d.tid||`live-${Date.now()}-${Math.random().toString(36).slice(2,8)}`};
+      const tc={name:d.name, preview:d.preview||'', args:d.args||{}, snippet:'', done:false, tid:d.tid||`live-${Date.now()}-${Math.random().toString(36).slice(2,8)}`, activityBurstId:_currentActivityBurstId, started_at:Date.now()/1000};
       const inflight = INFLIGHT[activeSid] || (INFLIGHT[activeSid] = {
         messages:[...S.messages],
         uploaded:[],
@@ -1687,7 +1710,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         }
       }
       if(!tc){
-        tc={name:d.name||'tool', preview:d.preview||'', args:d.args||{}, snippet:'', done:true};
+        tc={name:d.name||'tool', preview:d.preview||'', args:d.args||{}, snippet:'', done:true, activityBurstId:_currentActivityBurstId};
         inflight.toolCalls.push(tc);
       }
       tc.preview=d.preview||tc.preview||'';

--- a/static/messages.js
+++ b/static/messages.js
@@ -625,7 +625,20 @@ function closeLiveStream(sessionId, streamId, source){
   // finishes and a metadata refresh swaps in the final reply.
   // If the stream is terminating cleanly, _clearOwnerInflightState() has
   // already deleted INFLIGHT[sessionId], so this is a safe no-op.
-  if(INFLIGHT[sessionId]) INFLIGHT[sessionId].reattach=true;
+  if(INFLIGHT[sessionId]){
+    INFLIGHT[sessionId].reattach=true;
+    if(typeof saveInflightState==='function'){
+      saveInflightState(sessionId,{
+        streamId:live.streamId||streamId||null,
+        messages:INFLIGHT[sessionId].messages||[],
+        uploaded:INFLIGHT[sessionId].uploaded||[],
+        toolCalls:INFLIGHT[sessionId].toolCalls||[],
+        lastAssistantText:INFLIGHT[sessionId].lastAssistantText||'',
+        lastReasoningText:INFLIGHT[sessionId].lastReasoningText||'',
+        lastRunJournalSeq:INFLIGHT[sessionId].lastRunJournalSeq||0,
+      });
+    }
+  }
 }
 
 function closeOtherLiveStreams(activeSid){
@@ -663,11 +676,16 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
   // empty and tokens arriving on the new SSE connection append to nothing —
   // the already-rendered content vanishes.
   const _lastLiveAssistant = reconnecting
-    ? INFLIGHT[activeSid]?.messages?.findLast?.(m => m.role === 'assistant' && m._live)
-    : null;
-  let assistantText = _lastLiveAssistant ? (_lastLiveAssistant.content || '') : '';
-  let reasoningText = _lastLiveAssistant ? (_lastLiveAssistant.reasoning || '') : '';
-  let liveReasoningText = reasoningText;
+    ? (INFLIGHT[activeSid]&&INFLIGHT[activeSid].lastAssistantText)
+      || (INFLIGHT[activeSid]?.messages?.findLast?.(m => m.role === 'assistant' && m._live)?.content || '')
+    : '';
+  const _lastLiveReasoning = reconnecting
+    ? (INFLIGHT[activeSid]&&INFLIGHT[activeSid].lastReasoningText)
+      || (INFLIGHT[activeSid]?.messages?.findLast?.(m => m.role === 'assistant' && m._live)?.reasoning || '')
+    : '';
+  let assistantText=_lastLiveAssistant;
+  let reasoningText=_lastLiveReasoning;
+  let liveReasoningText=_lastLiveReasoning;
   let visibleInterimSnippets=[];
   let _latestGoalStatus=null;
   let _pendingGoalContinuation=null;
@@ -748,6 +766,9 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       messages:inflight.messages||[],
       uploaded:inflight.uploaded||[...uploaded],
       toolCalls:inflight.toolCalls||[],
+      lastAssistantText:inflight.lastAssistantText||'',
+      lastReasoningText:inflight.lastReasoningText||'',
+      lastRunJournalSeq:inflight.lastRunJournalSeq||0,
     });
   }
   function snapshotLiveTurn(){
@@ -784,6 +805,8 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
   function syncInflightAssistantMessage(){
     const inflight=INFLIGHT[activeSid];
     if(!inflight) return;
+    inflight.lastAssistantText=assistantText;
+    inflight.lastReasoningText=reasoningText;
     if(!Array.isArray(inflight.messages)) inflight.messages=[];
     let assistantIdx=-1;
     for(let i=inflight.messages.length-1;i>=0;i--){
@@ -862,7 +885,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
           const st=await api(`/api/chat/stream/status?stream_id=${encodeURIComponent(streamId)}`);
           if(st.active){
             setComposerStatus('Reconnected');
-            _wireSSE(new EventSource(new URL(`api/chat/stream?stream_id=${encodeURIComponent(streamId)}`,document.baseURI||location.href).href,{withCredentials:true}));
+            _wireSSE(new EventSource(new URL(`api/chat/stream?stream_id=${encodeURIComponent(streamId)}${_runJournalReplayParams()}`,document.baseURI||location.href).href,{withCredentials:true}));
             return;
           }
         }
@@ -918,7 +941,9 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
   let _streamFadeReduceMotionMql=null;
   let _streamFadeReduceMotion=false;
   let _streamFadeReduceMotionOnChange=null;
-  let _lastRunJournalSeq=0;
+  let _lastRunJournalSeq=reconnecting
+    ? Number((INFLIGHT[activeSid]&&INFLIGHT[activeSid].lastRunJournalSeq)||0)
+    : 0;
   const _STREAM_FADE_MS=200;
   const _STREAM_FADE_MAX_MS=350;
   const _STREAM_FADE_STAGGER_MS=16;
@@ -1430,12 +1455,19 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     _smdEndParser();
     _resetStreamFadeState();
   }
-  function _rememberRunJournalCursor(e){
+  function _runJournalSeqFromEvent(e){
     const raw=String(e&&e.lastEventId||'').trim();
-    if(!raw) return;
+    if(!raw) return 0;
     const tail=raw.includes(':')?raw.slice(raw.lastIndexOf(':')+1):raw;
     const seq=Number.parseInt(tail,10);
-    if(Number.isFinite(seq)&&seq>_lastRunJournalSeq) _lastRunJournalSeq=seq;
+    return Number.isFinite(seq)?seq:0;
+  }
+  function _rememberRunJournalCursor(e){
+    const seq=_runJournalSeqFromEvent(e);
+    if(Number.isFinite(seq)&&seq>_lastRunJournalSeq){
+      _lastRunJournalSeq=seq;
+      if(INFLIGHT[activeSid]) INFLIGHT[activeSid].lastRunJournalSeq=_lastRunJournalSeq;
+    }
   }
   function _runJournalReplayAfterSeq(){
     return Math.max(0,_lastRunJournalSeq||0);
@@ -2168,7 +2200,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
             const st=await api(`/api/chat/stream/status?stream_id=${encodeURIComponent(streamId)}`);
             if(st.active){
               setComposerStatus('Reconnected');
-              _wireSSE(new EventSource(new URL(`api/chat/stream?stream_id=${encodeURIComponent(streamId)}`,document.baseURI||location.href).href,{withCredentials:true}));
+              _wireSSE(new EventSource(new URL(`api/chat/stream?stream_id=${encodeURIComponent(streamId)}${_runJournalReplayParams()}`,document.baseURI||location.href).href,{withCredentials:true}));
               return;
             }
             if(st.replay_available){
@@ -2354,7 +2386,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         }
       }catch(_){}
     }
-    const replayParams=replayOnly?_runJournalReplayParams():'';
+    const replayParams=(reconnecting||replayOnly)?_runJournalReplayParams():'';
     _wireSSE(new EventSource(new URL(`api/chat/stream?stream_id=${encodeURIComponent(streamId)}${replayParams}`,document.baseURI||location.href).href,{withCredentials:true}));
   })();
 

--- a/static/messages.js
+++ b/static/messages.js
@@ -1675,7 +1675,11 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       reasoningText='';
       liveReasoningText='';
       if(alreadyStreamed){
-        if(!S.session||S.session.session_id!==activeSid) return;
+        if(!S.session||S.session.session_id!==activeSid){
+          recordActivityBoundary();
+          _resetAssistantSegment();
+          return;
+        }
         const parsed=_parseStreamState();
         if(String((parsed&&parsed.displayText)||'').trim()||assistantRow){
           ensureAssistantRow(true);
@@ -1689,7 +1693,11 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       assistantText += assistantText ? `\n\n${visible}` : visible;
       visibleInterimSnippets.push(visible);
       syncInflightAssistantMessage();
-      if(!S.session||S.session.session_id!==activeSid) return;
+      if(!S.session||S.session.session_id!==activeSid){
+        recordActivityBoundary();
+        _resetAssistantSegment();
+        return;
+      }
       if(window._showThinking!==false){
         if(typeof updateThinking==='function') updateThinking(_liveThinkingText());
         else appendThinking(_liveThinkingText());

--- a/static/messages.js
+++ b/static/messages.js
@@ -1594,6 +1594,12 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       liveReasoningText='';
       if(alreadyStreamed){
         if(!S.session||S.session.session_id!==activeSid) return;
+        const parsed=_parseStreamState();
+        if(String((parsed&&parsed.displayText)||'').trim()||assistantRow){
+          ensureAssistantRow(true);
+          _flushPendingSegmentRender({force:true});
+          if(typeof closeCurrentLiveActivityGroup==='function') closeCurrentLiveActivityGroup();
+        }
         _resetAssistantSegment();
         return;
       }

--- a/static/messages.js
+++ b/static/messages.js
@@ -711,8 +711,32 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
   let _pendingGoalContinuation=null;
   let assistantRow=null;
   let assistantBody=null;
-  let segmentStart=0;      // char offset in assistantText where current segment begins
-  let _freshSegment=false; // true after a tool call — forces a new DOM segment
+  // On reconnect with recorded burst anchors, the rendered DOM has multiple
+  // live assistant segments — one per anchor plus a tail. New tokens belong to
+  // the TAIL segment only. Without aligning segmentStart to the last anchor's
+  // textEnd, _doRender treats segmentStart===0 as "full text" and the smd
+  // parser writes the entire accumulated text into the first live segment
+  // (after _smdReconnect clears it), bloating segment 1 and leaving the rest
+  // stale. Activity groups still anchor by burst id but appear surrounded by
+  // duplicated/orphaned text, which presents as "Activity piled after text".
+  let segmentStart=(()=>{
+    if(!reconnecting) return 0;
+    const inflight=INFLIGHT[activeSid];
+    if(!inflight) return 0;
+    const anchors=Array.isArray(inflight.activityBurstAnchors)?inflight.activityBurstAnchors:[];
+    const textLen=String(assistantText||'').length;
+    let lastEnd=0;
+    for(const a of anchors){
+      const end=Number(a&&a.textEnd);
+      if(Number.isFinite(end)&&end>lastEnd&&end<=textLen) lastEnd=end;
+    }
+    return lastEnd;
+  })();
+  // If reconnect resumes exactly at the last recorded boundary, there is no
+  // projected tail segment yet. The next token must create a fresh segment
+  // after the last Activity group instead of rewriting the previous burst's
+  // text segment.
+  let _freshSegment=reconnecting&&segmentStart>0&&segmentStart>=String(assistantText||'').length; // true after a tool call — forces a new DOM segment
   // streaming-markdown state: incremental DOM-building parser per segment
   let _smdParser=null;     // current smd parser instance (null until first content)
   let _smdWrittenLen=0;    // how many chars of displayText have been fed to smd parser
@@ -899,7 +923,13 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       // After a tool call _freshSegment=true, so we always create a new segment
       // below the tool card rather than re-attaching to the old one above it.
       if(!_freshSegment){
-        const existing=blocks.querySelector('[data-live-assistant="1"]');
+        // Pick the LAST live segment, not the first. After session-switch reattach
+        // the projected DOM has one [data-live-assistant="1"] per burst anchor plus
+        // a tail segment; new tokens belong to the tail. querySelector returns the
+        // first match, which would funnel all new tokens into segment 1 — leaving
+        // the per-burst segments stale and Activity groups visually marooned.
+        const liveSegments=blocks.querySelectorAll('[data-live-assistant="1"]');
+        const existing=liveSegments.length?liveSegments[liveSegments.length-1]:null;
         if(existing){
           assistantRow=existing;
           assistantBody=existing.querySelector('.msg-body');
@@ -1565,7 +1595,6 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
     // journal events after this EventSource has already rendered part of a run.
     return `&replay=1&after_seq=${encodeURIComponent(String(_runJournalReplayAfterSeq()))}`;
   }
-
   let _lastRenderMs=0;
   function _scheduleRender(){
     if(_renderPending) return;
@@ -1636,7 +1665,6 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       try{existingLive.source.close();}catch(_){ }
     }
     LIVE_STREAMS[activeSid]={streamId,source};
-
     // Note on #631 Bug B: the original PR description stated the server
     // "replays buffered token events" on reconnect, and proposed resetting
     // the accumulators here so the re-sent tokens wouldn't double the prefix.

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1443,11 +1443,33 @@ function _projectInflightMessagesForActivityBursts(inflight){
   const cleanAnchors=anchors
     .map(a=>({id:Number(a&&a.id),textEnd:Number(a&&a.textEnd)}))
     .filter(a=>Number.isFinite(a.id)&&Number.isFinite(a.textEnd)&&a.textEnd>0)
-    .sort((a,b)=>a.textEnd-b.textEnd);
+    .sort((a,b)=>a.textEnd-b.textEnd||a.id-b.id);
   if(!cleanAnchors.length) return messages;
+  const aliasBurstIds=new Map();
+  let lastVisibleBurstId=null;
+  let lastVisibleTextEnd=0;
+  const visibleAnchors=[];
+  for(const anchor of cleanAnchors){
+    const end=Math.min(text.length,anchor.textEnd);
+    if(end<=lastVisibleTextEnd){
+      if(lastVisibleBurstId!==null) aliasBurstIds.set(anchor.id,lastVisibleBurstId);
+      continue;
+    }
+    visibleAnchors.push(anchor);
+    lastVisibleBurstId=anchor.id;
+    lastVisibleTextEnd=end;
+  }
+  if(aliasBurstIds.size&&Array.isArray(inflight.toolCalls)){
+    inflight.toolCalls.forEach(tc=>{
+      if(!tc||tc.activityBurstId===undefined||tc.activityBurstId===null) return;
+      const current=Number(tc.activityBurstId);
+      if(aliasBurstIds.has(current)) tc.activityBurstId=aliasBurstIds.get(current);
+    });
+  }
+  if(!visibleAnchors.length) return messages;
   const projected=[];
   let prev=0;
-  for(const anchor of cleanAnchors){
+  for(const anchor of visibleAnchors){
     const end=Math.max(prev,Math.min(text.length,anchor.textEnd));
     const part=text.slice(prev,end).trim();
     if(part) projected.push({...live,content:part,_activityBurstId:anchor.id});

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -690,6 +690,9 @@ async function loadSession(sid){
         uploaded:Array.isArray(stored.uploaded)?stored.uploaded:[],
         toolCalls:Array.isArray(stored.toolCalls)?stored.toolCalls:[],
         reattach:true,
+        lastAssistantText:String(stored.lastAssistantText||''),
+        lastReasoningText:String(stored.lastReasoningText||''),
+        lastRunJournalSeq:Number(stored.lastRunJournalSeq||0)||0,
       };
     }
   }

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -717,14 +717,6 @@ async function loadSession(sid){
       S.messages=_dropCurrentTurnAssistantMessages(S.messages);
     }
     S.messages=_mergeInflightTailMessages(S.messages,inflightMessages);
-    const journalSeq=_runJournalSeqFromSession(S.session);
-    if(
-      activeStreamId
-      && journalSeq>Number(INFLIGHT[sid].lastRunJournalSeq||0)
-      && _currentTurnHasVisibleOutput(S.messages)
-    ){
-      INFLIGHT[sid].lastRunJournalSeq=journalSeq;
-    }
     S.toolCalls=(INFLIGHT[sid].toolCalls||[]);
     if(_mergePendingSessionMessage(S.session,S.messages)&&inflightMessages===(INFLIGHT[sid].messages||[])){
       INFLIGHT[sid].messages=S.messages;
@@ -1490,32 +1482,6 @@ function _prepareRunningLiveTail(baseMessages,inflightMessages){
     }
   }
   return !!_messageComparableText(live);
-}
-
-function _runJournalSeqFromSession(session){
-  const journal=session&&session.runtime_journal;
-  if(!journal) return 0;
-  const direct=Number(journal.last_seq||0)||0;
-  if(direct>0) return direct;
-  const raw=String(journal.last_event_id||'').trim();
-  const tail=raw.split(':').pop();
-  return Number(tail||0)||0;
-}
-
-function _currentTurnHasVisibleOutput(messages){
-  const list=Array.isArray(messages)?messages:[];
-  let start=-1;
-  for(let i=list.length-1;i>=0;i--){
-    if(list[i]&&list[i].role==='user'){start=i;break;}
-  }
-  if(start<0) return false;
-  for(let i=start+1;i<list.length;i++){
-    const msg=list[i];
-    if(!msg) continue;
-    if(msg.role==='tool') return true;
-    if(msg.role==='assistant'&&_messageComparableText(msg)) return true;
-  }
-  return false;
 }
 
 function _mergeInflightTailMessages(baseMessages, inflightMessages){

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -693,13 +693,15 @@ async function loadSession(sid){
         lastAssistantText:String(stored.lastAssistantText||''),
         lastReasoningText:String(stored.lastReasoningText||''),
         lastRunJournalSeq:Number(stored.lastRunJournalSeq||0)||0,
+        currentActivityBurstId:Number(stored.currentActivityBurstId||0)||0,
+        activityBurstAnchors:Array.isArray(stored.activityBurstAnchors)?stored.activityBurstAnchors:[],
       };
     }
   }
 
   if(INFLIGHT[sid]){
     _ensureInflightLiveAssistantMessage(INFLIGHT[sid]);
-    const inflightMessages=INFLIGHT[sid].messages||[];
+    const inflightMessages=_projectInflightMessagesForActivityBursts(INFLIGHT[sid]);
     S.messages=[];
     S.toolCalls=[];
     try {
@@ -724,7 +726,7 @@ async function loadSession(sid){
       INFLIGHT[sid].lastRunJournalSeq=journalSeq;
     }
     S.toolCalls=(INFLIGHT[sid].toolCalls||[]);
-    if(_mergePendingSessionMessage(S.session,S.messages)){
+    if(_mergePendingSessionMessage(S.session,S.messages)&&inflightMessages===(INFLIGHT[sid].messages||[])){
       INFLIGHT[sid].messages=S.messages;
     }
     S.busy=true;
@@ -733,6 +735,7 @@ async function loadSession(sid){
     // switching away from and back to an active chat (#1715).
     S.activeStreamId=activeStreamId;
     syncTopbar();renderMessages();
+    if(typeof ensureRunActivityForCurrentTurn==='function') ensureRunActivityForCurrentTurn();
     const restoredLiveTurn=typeof restoreLiveTurnHtmlForSession==='function'&&restoreLiveTurnHtmlForSession(sid);
     if(!restoredLiveTurn){
       appendThinking();
@@ -1432,9 +1435,43 @@ function _ensureInflightLiveAssistantMessage(inflight){
   return true;
 }
 
+function _projectInflightMessagesForActivityBursts(inflight){
+  const messages=Array.isArray(inflight&&inflight.messages)?inflight.messages:[];
+  const anchors=Array.isArray(inflight&&inflight.activityBurstAnchors)?inflight.activityBurstAnchors:[];
+  if(!anchors.length) return messages;
+  let liveIdx=-1;
+  for(let i=messages.length-1;i>=0;i--){
+    const msg=messages[i];
+    if(msg&&msg.role==='assistant'&&msg._live){liveIdx=i;break;}
+  }
+  if(liveIdx<0) return messages;
+  const live=messages[liveIdx];
+  const text=_messageComparableText(live);
+  if(!text) return messages;
+  const cleanAnchors=anchors
+    .map(a=>({id:Number(a&&a.id),textEnd:Number(a&&a.textEnd)}))
+    .filter(a=>Number.isFinite(a.id)&&Number.isFinite(a.textEnd)&&a.textEnd>0)
+    .sort((a,b)=>a.textEnd-b.textEnd);
+  if(!cleanAnchors.length) return messages;
+  const projected=[];
+  let prev=0;
+  for(const anchor of cleanAnchors){
+    const end=Math.max(prev,Math.min(text.length,anchor.textEnd));
+    const part=text.slice(prev,end).trim();
+    if(part) projected.push({...live,content:part,_activityBurstId:anchor.id});
+    prev=end;
+  }
+  const tail=text.slice(prev).trim();
+  if(tail) projected.push({...live,content:tail,_activityBurstId:Number(inflight.currentActivityBurstId||0)||0});
+  if(!projected.length) return messages;
+  return [...messages.slice(0,liveIdx),...projected,...messages.slice(liveIdx+1)];
+}
+
 function _prepareRunningLiveTail(baseMessages,inflightMessages){
   const inflight=Array.isArray(inflightMessages)?inflightMessages:[];
-  const live=[...inflight].reverse().find(m=>m&&m.role==='assistant'&&m._live);
+  const liveMessages=inflight.filter(m=>m&&m.role==='assistant'&&m._live);
+  if(liveMessages.length>1) return liveMessages.some(m=>!!_messageComparableText(m));
+  const live=liveMessages[0]||null;
   if(!live) return false;
   const liveText=_messageComparableText(live);
   const persistedText=_currentTurnAssistantText(baseMessages);

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -698,6 +698,7 @@ async function loadSession(sid){
   }
 
   if(INFLIGHT[sid]){
+    _ensureInflightLiveAssistantMessage(INFLIGHT[sid]);
     const inflightMessages=INFLIGHT[sid].messages||[];
     S.messages=[];
     S.toolCalls=[];
@@ -1400,6 +1401,35 @@ function _dropCurrentTurnAssistantMessages(messages){
   }
   if(start<0) return list;
   return list.filter((msg,idx)=>idx<=start||!(msg&&msg.role==='assistant'));
+}
+
+function _ensureInflightLiveAssistantMessage(inflight){
+  if(!inflight) return false;
+  const text=String(inflight.lastAssistantText||'').trim();
+  const reasoning=String(inflight.lastReasoningText||'').trim();
+  if(!text&&!reasoning) return false;
+  if(!Array.isArray(inflight.messages)) inflight.messages=[];
+  let live=null;
+  for(let i=inflight.messages.length-1;i>=0;i--){
+    const msg=inflight.messages[i];
+    if(msg&&msg.role==='assistant'&&msg._live){live=msg;break;}
+  }
+  if(live){
+    const liveText=_messageComparableText(live);
+    if(text&&(!liveText||text.startsWith(liveText)||text.length>liveText.length)){
+      live.content=text;
+    }
+    if(reasoning&&!live.reasoning) live.reasoning=reasoning;
+    return true;
+  }
+  inflight.messages.push({
+    role:'assistant',
+    content:text,
+    reasoning:reasoning||undefined,
+    _live:true,
+    _ts:Date.now()/1000,
+  });
+  return true;
 }
 
 function _prepareRunningLiveTail(baseMessages,inflightMessages){

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -728,7 +728,13 @@ async function loadSession(sid){
     S.activeStreamId=activeStreamId;
     syncTopbar();renderMessages();
     if(typeof ensureRunActivityForCurrentTurn==='function') ensureRunActivityForCurrentTurn();
-    const restoredLiveTurn=typeof restoreLiveTurnHtmlForSession==='function'&&restoreLiveTurnHtmlForSession(sid);
+    const hasStructuredLiveState=!!(INFLIGHT[sid]&&(
+      String(INFLIGHT[sid].lastAssistantText||'').trim()||
+      String(INFLIGHT[sid].lastReasoningText||'').trim()||
+      (Array.isArray(INFLIGHT[sid].activityBurstAnchors)&&INFLIGHT[sid].activityBurstAnchors.length)||
+      (Array.isArray(INFLIGHT[sid].toolCalls)&&INFLIGHT[sid].toolCalls.length)
+    ));
+    const restoredLiveTurn=!hasStructuredLiveState&&typeof restoreLiveTurnHtmlForSession==='function'&&restoreLiveTurnHtmlForSession(sid);
     if(!restoredLiveTurn){
       appendThinking();
       clearLiveToolCards();

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -706,11 +706,14 @@ async function loadSession(sid){
     } catch(e) {
       S.messages=inflightMessages;
     }
-    S.messages=_mergeInflightTailMessages(S.messages,inflightMessages);
-    const coveredLiveTail=Array.isArray(inflightMessages)&&inflightMessages.some(m=>m&&m._coveredAssistantPrefixStripped);
-    if(coveredLiveTail&&INFLIGHT[sid]){
+    const liveTailPrepared=_prepareRunningLiveTail(S.messages,inflightMessages);
+    if(liveTailPrepared&&INFLIGHT[sid]){
       delete INFLIGHT[sid].liveTurnHtml;
     }
+    if(liveTailPrepared){
+      S.messages=_dropCurrentTurnAssistantMessages(S.messages);
+    }
+    S.messages=_mergeInflightTailMessages(S.messages,inflightMessages);
     const journalSeq=_runJournalSeqFromSession(S.session);
     if(
       activeStreamId
@@ -1389,28 +1392,37 @@ function _compactTranscriptText(text){
   return String(text||'').replace(/\s+/g,' ').trim();
 }
 
-function _stripPersistedAssistantPrefixFromLiveTail(msg,baseMessages){
-  if(!(msg&&msg.role==='assistant'&&msg._live)) return msg;
-  const liveText=_messageComparableText(msg);
-  if(!liveText) return msg;
-  const covered=_currentTurnAssistantText(baseMessages);
-  if(!covered) return msg;
-  if(liveText===covered||covered.startsWith(liveText)){
-    msg._coveredAssistantPrefixStripped=true;
-    return null;
+function _dropCurrentTurnAssistantMessages(messages){
+  const list=Array.isArray(messages)?messages:[];
+  let start=-1;
+  for(let i=list.length-1;i>=0;i--){
+    if(list[i]&&list[i].role==='user'){start=i;break;}
   }
-  if(liveText.startsWith(covered)){
-    const suffix=liveText.slice(covered.length).trim();
-    msg._coveredAssistantPrefixStripped=true;
-    if(!suffix) return null;
-    const trimmed={...msg,content:suffix};
-    return trimmed;
+  if(start<0) return list;
+  return list.filter((msg,idx)=>idx<=start||!(msg&&msg.role==='assistant'));
+}
+
+function _prepareRunningLiveTail(baseMessages,inflightMessages){
+  const inflight=Array.isArray(inflightMessages)?inflightMessages:[];
+  const live=[...inflight].reverse().find(m=>m&&m.role==='assistant'&&m._live);
+  if(!live) return false;
+  const liveText=_messageComparableText(live);
+  const persistedText=_currentTurnAssistantText(baseMessages);
+  if(persistedText){
+    const compactPersisted=_compactTranscriptText(persistedText);
+    const compactLive=_compactTranscriptText(liveText);
+    if(!liveText || persistedText.startsWith(liveText)){
+      live.content=persistedText;
+    }else if(liveText.startsWith(persistedText)){
+      const extra=liveText.slice(persistedText.length).trim();
+      if(extra&&compactPersisted.includes(_compactTranscriptText(extra))){
+        live.content=persistedText;
+      }
+    }else if(compactPersisted===compactLive){
+      live.content=persistedText;
+    }
   }
-  if(_compactTranscriptText(liveText)===_compactTranscriptText(covered)){
-    msg._coveredAssistantPrefixStripped=true;
-    return null;
-  }
-  return msg;
+  return !!_messageComparableText(live);
 }
 
 function _runJournalSeqFromSession(session){
@@ -1452,12 +1464,7 @@ function _mergeInflightTailMessages(baseMessages, inflightMessages){
   const tail=inflight.slice(start).filter(m=>m&&m.role);
   const merged=[...base];
   for(const msg of tail){
-    let candidate=_stripPersistedAssistantPrefixFromLiveTail(msg,merged);
-    if(msg&&msg.role==='assistant'&&msg._live){
-      msg.content=candidate?_messageComparableText(candidate):'';
-      if(candidate&&candidate.reasoning!==undefined) msg.reasoning=candidate.reasoning;
-      if(!msg.content) msg._coveredAssistantPrefixStripped=true;
-    }
+    let candidate=msg;
     if(!candidate) continue;
     const duplicate=merged.slice(-Math.max(5,tail.length+2)).some(existing=>_sameTranscriptMessage(existing,candidate));
     if(!duplicate) merged.push(candidate);

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1515,13 +1515,13 @@ function _prepareRunningLiveTail(baseMessages,inflightMessages){
 function _mergeInflightTailMessages(baseMessages, inflightMessages){
   const base=Array.isArray(baseMessages)?baseMessages:[];
   const inflight=Array.isArray(inflightMessages)?inflightMessages:[];
-  let liveIdx=-1;
-  for(let i=inflight.length-1;i>=0;i--){
-    if(inflight[i]&&inflight[i]._live){liveIdx=i;break;}
+  let firstLiveIdx=-1;
+  for(let i=0;i<inflight.length;i++){
+    if(inflight[i]&&inflight[i]._live){firstLiveIdx=i;break;}
   }
-  if(liveIdx<0) return base;
-  let start=liveIdx;
-  if(liveIdx>0&&inflight[liveIdx-1]&&inflight[liveIdx-1].role==='user') start=liveIdx-1;
+  if(firstLiveIdx<0) return base;
+  let start=firstLiveIdx;
+  if(firstLiveIdx>0&&inflight[firstLiveIdx-1]&&inflight[firstLiveIdx-1].role==='user') start=firstLiveIdx-1;
   const tail=inflight.slice(start).filter(m=>m&&m.role);
   const merged=[...base];
   for(const msg of tail){

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -707,6 +707,18 @@ async function loadSession(sid){
       S.messages=inflightMessages;
     }
     S.messages=_mergeInflightTailMessages(S.messages,inflightMessages);
+    const coveredLiveTail=Array.isArray(inflightMessages)&&inflightMessages.some(m=>m&&m._coveredAssistantPrefixStripped);
+    if(coveredLiveTail&&INFLIGHT[sid]){
+      delete INFLIGHT[sid].liveTurnHtml;
+    }
+    const journalSeq=_runJournalSeqFromSession(S.session);
+    if(
+      activeStreamId
+      && journalSeq>Number(INFLIGHT[sid].lastRunJournalSeq||0)
+      && _currentTurnHasVisibleOutput(S.messages)
+    ){
+      INFLIGHT[sid].lastRunJournalSeq=journalSeq;
+    }
     S.toolCalls=(INFLIGHT[sid].toolCalls||[]);
     if(_mergePendingSessionMessage(S.session,S.messages)){
       INFLIGHT[sid].messages=S.messages;
@@ -1319,6 +1331,9 @@ async function _ensureMessagesLoaded(sid) {
   } else {
     S.toolCalls = [];
   }
+  if(S.session&&S.session.session_id===sid&&data.session.runtime_journal){
+    S.session.runtime_journal=data.session.runtime_journal;
+  }
   clearLiveToolCards();
   S.messages = msgs;
   if(S.session&&S.session.session_id===sid){
@@ -1381,18 +1396,47 @@ function _stripPersistedAssistantPrefixFromLiveTail(msg,baseMessages){
   const covered=_currentTurnAssistantText(baseMessages);
   if(!covered) return msg;
   if(liveText===covered||covered.startsWith(liveText)){
+    msg._coveredAssistantPrefixStripped=true;
     return null;
   }
   if(liveText.startsWith(covered)){
     const suffix=liveText.slice(covered.length).trim();
+    msg._coveredAssistantPrefixStripped=true;
     if(!suffix) return null;
     const trimmed={...msg,content:suffix};
     return trimmed;
   }
   if(_compactTranscriptText(liveText)===_compactTranscriptText(covered)){
+    msg._coveredAssistantPrefixStripped=true;
     return null;
   }
   return msg;
+}
+
+function _runJournalSeqFromSession(session){
+  const journal=session&&session.runtime_journal;
+  if(!journal) return 0;
+  const direct=Number(journal.last_seq||0)||0;
+  if(direct>0) return direct;
+  const raw=String(journal.last_event_id||'').trim();
+  const tail=raw.split(':').pop();
+  return Number(tail||0)||0;
+}
+
+function _currentTurnHasVisibleOutput(messages){
+  const list=Array.isArray(messages)?messages:[];
+  let start=-1;
+  for(let i=list.length-1;i>=0;i--){
+    if(list[i]&&list[i].role==='user'){start=i;break;}
+  }
+  if(start<0) return false;
+  for(let i=start+1;i<list.length;i++){
+    const msg=list[i];
+    if(!msg) continue;
+    if(msg.role==='tool') return true;
+    if(msg.role==='assistant'&&_messageComparableText(msg)) return true;
+  }
+  return false;
 }
 
 function _mergeInflightTailMessages(baseMessages, inflightMessages){
@@ -1412,6 +1456,7 @@ function _mergeInflightTailMessages(baseMessages, inflightMessages){
     if(msg&&msg.role==='assistant'&&msg._live){
       msg.content=candidate?_messageComparableText(candidate):'';
       if(candidate&&candidate.reasoning!==undefined) msg.reasoning=candidate.reasoning;
+      if(!msg.content) msg._coveredAssistantPrefixStripped=true;
     }
     if(!candidate) continue;
     const duplicate=merged.slice(-Math.max(5,tail.length+2)).some(existing=>_sameTranscriptMessage(existing,candidate));

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -1354,6 +1354,47 @@ function _sameTranscriptMessage(a,b){
   return false;
 }
 
+function _currentTurnAssistantText(messages){
+  const list=Array.isArray(messages)?messages:[];
+  let start=-1;
+  for(let i=list.length-1;i>=0;i--){
+    if(list[i]&&list[i].role==='user'){start=i;break;}
+  }
+  const parts=[];
+  for(let i=start+1;i<list.length;i++){
+    const msg=list[i];
+    if(!msg||msg.role!=='assistant'||msg._live) continue;
+    const text=_messageComparableText(msg);
+    if(text) parts.push(text);
+  }
+  return parts.join('\n\n').trim();
+}
+
+function _compactTranscriptText(text){
+  return String(text||'').replace(/\s+/g,' ').trim();
+}
+
+function _stripPersistedAssistantPrefixFromLiveTail(msg,baseMessages){
+  if(!(msg&&msg.role==='assistant'&&msg._live)) return msg;
+  const liveText=_messageComparableText(msg);
+  if(!liveText) return msg;
+  const covered=_currentTurnAssistantText(baseMessages);
+  if(!covered) return msg;
+  if(liveText===covered||covered.startsWith(liveText)){
+    return null;
+  }
+  if(liveText.startsWith(covered)){
+    const suffix=liveText.slice(covered.length).trim();
+    if(!suffix) return null;
+    const trimmed={...msg,content:suffix};
+    return trimmed;
+  }
+  if(_compactTranscriptText(liveText)===_compactTranscriptText(covered)){
+    return null;
+  }
+  return msg;
+}
+
 function _mergeInflightTailMessages(baseMessages, inflightMessages){
   const base=Array.isArray(baseMessages)?baseMessages:[];
   const inflight=Array.isArray(inflightMessages)?inflightMessages:[];
@@ -1367,8 +1408,14 @@ function _mergeInflightTailMessages(baseMessages, inflightMessages){
   const tail=inflight.slice(start).filter(m=>m&&m.role);
   const merged=[...base];
   for(const msg of tail){
-    const duplicate=merged.slice(-Math.max(5,tail.length+2)).some(existing=>_sameTranscriptMessage(existing,msg));
-    if(!duplicate) merged.push(msg);
+    let candidate=_stripPersistedAssistantPrefixFromLiveTail(msg,merged);
+    if(msg&&msg.role==='assistant'&&msg._live){
+      msg.content=candidate?_messageComparableText(candidate):'';
+      if(candidate&&candidate.reasoning!==undefined) msg.reasoning=candidate.reasoning;
+    }
+    if(!candidate) continue;
+    const duplicate=merged.slice(-Math.max(5,tail.length+2)).some(existing=>_sameTranscriptMessage(existing,candidate));
+    if(!duplicate) merged.push(candidate);
   }
   return merged;
 }

--- a/static/style.css
+++ b/static/style.css
@@ -2424,6 +2424,7 @@ body.resizing .sidebar{transition:none!important;}
 .tool-card-icon{font-size:13px;flex-shrink:0;opacity:.65;}
 .tool-card-name{font-size:var(--font-size-xs);font-weight:600;color:var(--muted);font-family:'SF Mono',ui-monospace,monospace;flex-shrink:0;}
 .tool-card-preview{font-size:var(--font-size-xs);color:var(--muted);opacity:.62;flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+.tool-card-duration{font-size:var(--font-size-xs);color:var(--muted);opacity:.72;white-space:nowrap;margin-left:auto;}
 .tool-card-toggle{font-size:10px;color:var(--muted);opacity:.45;flex-shrink:0;display:inline-flex;align-items:center;justify-content:center;transform-origin:center;transition:transform .18s ease;will-change:transform;}
 .tool-card.open .tool-card-toggle{transform:rotate(90deg);}
 .tool-card-detail{display:block;max-height:0;opacity:0;overflow:hidden;border-top:1px solid transparent;padding:0 var(--space-3);transition:max-height .22s ease,opacity .18s ease,padding .22s ease,border-top-color .22s ease;}

--- a/static/ui.js
+++ b/static/ui.js
@@ -2480,9 +2480,11 @@ function _updateActiveActivityElapsedTimer(){
     group.removeAttribute('data-active-turn-elapsed');
   }
   if(durationEl){
-    const activeText=label?`Working for ${label}`:'';
-    const progressText=group.getAttribute('data-run-activity-group')==='1'?'':_activityLiveProgressLabel(group);
+    const settledText=_formatTurnDuration(group.dataset.turnDuration);
+    const activeText=(!settledText&&label)?`Working for ${label}`:'';
+    const progressText=(settledText||group.getAttribute('data-run-activity-group')==='1')?'':_activityLiveProgressLabel(group);
     durationEl.textContent=[progressText, activeText].filter(Boolean).join(' · ');
+    if(settledText) durationEl.textContent=`Done in ${settledText}`;
     durationEl.style.display=durationEl.textContent?'':'none';
   }
 }
@@ -5507,6 +5509,8 @@ function ensureRunActivityGroup(inner, opts){
     if(inner.firstChild) inner.insertBefore(group, inner.firstChild);
     else inner.appendChild(group);
   }
+  if(opts.turnDuration!==undefined&&opts.turnDuration!==null) group.setAttribute('data-turn-duration',String(opts.turnDuration));
+  if(opts.turnStartedAt!==undefined&&opts.turnStartedAt!==null) group.setAttribute('data-turn-started-at',String(opts.turnStartedAt));
   _setActivityElapsedStartedAt(group);
   _ensureLiveActivityBaseline(group);
   _syncToolCallGroupSummary(group);
@@ -6751,26 +6755,83 @@ function renderMessages(options){
       byAssistant[key].push(tc);
     }
     const assistantIdxs=[...assistantSegments.keys()].sort((a,b)=>a-b);
+    const _assistantAnchorForActivity=(aIdx,burstId)=>{
+      const wantedBurst=burstId!==undefined&&burstId!==null&&String(burstId)!==''?String(burstId):'';
+      if(wantedBurst){
+        for(const seg of assistantSegments.values()){
+          if(seg&&seg.getAttribute('data-activity-burst-id')===wantedBurst) return seg;
+        }
+      }
+      let anchorRow=assistantSegments.get(aIdx)||null;
+      if(!anchorRow&&assistantIdxs.length){
+        if(aIdx<assistantIdxs[0]) return null;
+        const fallbackIdx=[...assistantIdxs].reverse().find(idx=>idx<=aIdx);
+        anchorRow=fallbackIdx!==undefined?assistantSegments.get(fallbackIdx):assistantSegments.get(assistantIdxs[assistantIdxs.length-1]);
+      }
+      return anchorRow;
+    };
+    const _ensureSettledRunActivityForAnchor=(anchorRow)=>{
+      if(!anchorRow) return;
+      const turn=anchorRow.closest('.assistant-turn');
+      const blocks=_assistantTurnBlocks(turn);
+      if(!blocks) return;
+      let duration;
+      for(const seg of blocks.querySelectorAll('.assistant-segment')){
+        const idx=Number(seg.dataset&&seg.dataset.msgIdx);
+        const msg=Number.isFinite(idx)?S.messages[idx]:null;
+        if(msg&&msg._turnDuration!==undefined) duration=msg._turnDuration;
+      }
+      ensureRunActivityGroup(blocks,{live:false,collapsed:true,turnDuration:duration});
+    };
     const anchorInsertAfter = new Map();
     if(isSimplifiedToolCalling()){
-      const activityIdxs=[...new Set([...Object.keys(byAssistant).map(k=>parseInt(k)), ...assistantThinking.keys()])].sort((a,b)=>a-b);
-      for(const aIdx of activityIdxs){
-        const cards=byAssistant[aIdx]||[];
-        let anchorRow=assistantSegments.get(aIdx)||null;
-        if(!anchorRow&&assistantIdxs.length){
-          if(aIdx<assistantIdxs[0]) continue;
-          const fallbackIdx=[...assistantIdxs].reverse().find(idx=>idx<=aIdx);
-          anchorRow=fallbackIdx!==undefined?assistantSegments.get(fallbackIdx):assistantSegments.get(assistantIdxs[assistantIdxs.length-1]);
+      const byActivity = new Map();
+      const activityOrder = [];
+      const ensureActivityBucket=(key,aIdx,burstId)=>{
+        if(!byActivity.has(key)){
+          const entry={key,aIdx,burstId,cards:[],thinkingIdx:null};
+          byActivity.set(key,entry);
+          activityOrder.push(entry);
         }
+        return byActivity.get(key);
+      };
+      for(const tc of (S.toolCalls||[])){
+        if(!tc) continue;
+        const aIdx=tc.assistant_msg_idx!==undefined?parseInt(tc.assistant_msg_idx):-1;
+        const burstId=tc.activityBurstId!==undefined&&tc.activityBurstId!==null?String(tc.activityBurstId):'';
+        const key=burstId?`burst:${burstId}`:`assistant:${aIdx}`;
+        ensureActivityBucket(key,aIdx,burstId).cards.push(tc);
+      }
+      for(const aIdx of assistantThinking.keys()){
+        const seg=assistantSegments.get(aIdx);
+        const burstId=seg&&seg.getAttribute('data-activity-burst-id')||'';
+        const key=burstId?`burst:${burstId}`:`assistant:${aIdx}`;
+        const entry=ensureActivityBucket(key,aIdx,burstId);
+        if(entry.thinkingIdx===null) entry.thinkingIdx=aIdx;
+      }
+      activityOrder.sort((a,b)=>{
+        const anchorA=_assistantAnchorForActivity(a.aIdx,a.burstId);
+        const anchorB=_assistantAnchorForActivity(b.aIdx,b.burstId);
+        const idxA=(anchorA&&anchorA.parentElement)?Array.prototype.indexOf.call(anchorA.parentElement.children,anchorA):Number.MAX_SAFE_INTEGER;
+        const idxB=(anchorB&&anchorB.parentElement)?Array.prototype.indexOf.call(anchorB.parentElement.children,anchorB):Number.MAX_SAFE_INTEGER;
+        if(idxA!==idxB) return idxA-idxB;
+        const burstA=a.burstId===''?Number.MAX_SAFE_INTEGER:Number(a.burstId);
+        const burstB=b.burstId===''?Number.MAX_SAFE_INTEGER:Number(b.burstId);
+        if(Number.isFinite(burstA)&&Number.isFinite(burstB)&&burstA!==burstB) return burstA-burstB;
+        return a.aIdx-b.aIdx;
+      });
+      for(const entry of activityOrder){
+        const {aIdx,burstId,cards,thinkingIdx}=entry;
+        const anchorRow=_assistantAnchorForActivity(aIdx,burstId);
         if(!anchorRow) continue;
         const anchorParent=anchorRow.parentElement;
         let insertAfterNode = anchorInsertAfter.get(anchorRow) || anchorRow;
-        const group=ensureActivityGroup(anchorParent,{collapsed:true,anchor:insertAfterNode,activityKey:`assistant:${aIdx}`});
-        const sourceMsg=S.messages[aIdx]||{};
-        if(sourceMsg._turnDuration!==undefined) group.setAttribute('data-turn-duration', String(sourceMsg._turnDuration));
+        _ensureSettledRunActivityForAnchor(anchorRow);
+        const activityKey=burstId?`assistant:${aIdx}:burst:${burstId}`:`assistant:${aIdx}`;
+        const group=ensureActivityGroup(anchorParent,{collapsed:true,anchor:insertAfterNode,activityKey,burstId});
         const body=group&&group.querySelector('.tool-call-group-body');
         if(!body) continue;
-        const thinkingText=assistantThinking.get(aIdx);
+        const thinkingText=thinkingIdx!==null?assistantThinking.get(thinkingIdx):'';
         if(thinkingText){
           body.appendChild(_thinkingActivityNode(thinkingText, false));
         }
@@ -6783,13 +6844,9 @@ function renderMessages(options){
     }else if(S.toolCalls && S.toolCalls.length){
       for(const [key, cards] of Object.entries(byAssistant)){
         const aIdx = parseInt(key);
-        let anchorRow=assistantSegments.get(aIdx)||null;
-        if(!anchorRow&&assistantIdxs.length){
-          if(aIdx<assistantIdxs[0]) continue;
-          const fallbackIdx=[...assistantIdxs].reverse().find(idx=>idx<=aIdx);
-          anchorRow=fallbackIdx!==undefined?assistantSegments.get(fallbackIdx):assistantSegments.get(assistantIdxs[assistantIdxs.length-1]);
-        }
+        const anchorRow=_assistantAnchorForActivity(aIdx,'');
         if(!anchorRow) continue;
+        _ensureSettledRunActivityForAnchor(anchorRow);
         const anchorParent=anchorRow.parentElement;
         const frag=document.createDocumentFragment();
         let lastInsertedNode=null;
@@ -7015,8 +7072,9 @@ function _syncToolCallGroupSummary(group){
   }
   if(durationEl){
     if(group.getAttribute('data-run-activity-group')==='1'){
-      const activeText=_activityElapsedLabel(group);
-      durationEl.textContent=activeText?`Working for ${activeText}`:'';
+      const durationText=_formatTurnDuration(group.dataset.turnDuration);
+      const activeText=durationText?'':_activityElapsedLabel(group);
+      durationEl.textContent=durationText?`Done in ${durationText}`:(activeText?`Working for ${activeText}`:'');
       durationEl.style.display=durationEl.textContent?'':'none';
     }else if(group.getAttribute('data-live-tool-call-group')==='1'){
       const activeText=_activityElapsedLabel(group);

--- a/static/ui.js
+++ b/static/ui.js
@@ -6216,6 +6216,31 @@ function _cliToolCardHasDiffSnippet(resultSnippet, patchSnippet){
   return !!patchSnippet || _cliLooksLikePatchDiff(resultSnippet);
 }
 
+function _assistantMessageHasVisibleContent(m){
+  if(!m||m.role!=='assistant') return false;
+  const content=m.content;
+  if(typeof content==='string') return !!content.trim();
+  if(!Array.isArray(content)) return false;
+  return content.some(part=>{
+    if(typeof part==='string') return !!part.trim();
+    if(!part||typeof part!=='object') return false;
+    if(part.type==='text'||part.type==='input_text'||part.type==='output_text'){
+      return !!String(part.text||part.content||'').trim();
+    }
+    return false;
+  });
+}
+
+function _assistantToolAnchorIdxForMessage(messages, rawIdx){
+  const list=Array.isArray(messages)?messages:[];
+  const current=list[rawIdx];
+  if(_assistantMessageHasVisibleContent(current)) return rawIdx;
+  for(let idx=rawIdx-1;idx>=0;idx--){
+    if(_assistantMessageHasVisibleContent(list[idx])) return idx;
+  }
+  return rawIdx;
+}
+
 function _captureMessageScrollSnapshot(){
   const el=$('messages');
   if(!el) return null;
@@ -6739,6 +6764,7 @@ function renderMessages(options){
       return next;
     };
     fallbackToolSources.forEach(({m,rawIdx})=>{
+      const assistantToolAnchorIdx=_assistantToolAnchorIdxForMessage(S.messages,rawIdx);
       // OpenAI format: top-level tool_calls field on the assistant message
       (m.tool_calls||[]).forEach(tc=>{
         if(!tc||typeof tc!=='object') return;
@@ -6756,7 +6782,7 @@ function renderMessages(options){
           snippet:_cliToolCardSnippet(resultSnippet,patchSnippet),
           is_diff:_cliToolCardHasDiffSnippet(resultSnippet,patchSnippet),
           tid,
-          assistant_msg_idx:rawIdx,
+          assistant_msg_idx:assistantToolAnchorIdx,
           args:argsSnap,
           done:true,
         }, name, tid));
@@ -6779,7 +6805,7 @@ function renderMessages(options){
             snippet:_cliToolCardSnippet(resultSnippet,patchSnippet),
             is_diff:_cliToolCardHasDiffSnippet(resultSnippet,patchSnippet),
             tid,
-            assistant_msg_idx:rawIdx,
+            assistant_msg_idx:assistantToolAnchorIdx,
             args:argsSnap,
             done:true,
           }, name, tid));

--- a/static/ui.js
+++ b/static/ui.js
@@ -6713,7 +6713,9 @@ function renderMessages(options){
       }
     });
     const derived=[];
-    const liveToolMetadata=Array.isArray(S.toolCalls)?S.toolCalls:[];
+    const liveToolMetadata=Array.isArray(S._settledLiveToolMetadata)
+      ? S._settledLiveToolMetadata
+      : (Array.isArray(S.toolCalls)?S.toolCalls:[]);
     const liveMetadataByTid=new Map();
     liveToolMetadata.forEach((tc,idx)=>{
       if(!tc||typeof tc!=='object') return;
@@ -6785,6 +6787,7 @@ function renderMessages(options){
       }
     });
     if(derived.length) S.toolCalls=derived;
+    if(S._settledLiveToolMetadata) S._settledLiveToolMetadata=null;
   }
   if(!S.busy){
     inner.querySelectorAll('.tool-call-group:not([data-compression-card]),.tool-card-row:not([data-compression-card]),.agent-activity-thinking:not([data-live-thinking="1"])').forEach(el=>el.remove());
@@ -6804,7 +6807,7 @@ function renderMessages(options){
       }
       let anchorRow=assistantSegments.get(aIdx)||null;
       if(!anchorRow&&assistantIdxs.length){
-        if(aIdx<assistantIdxs[0]) return assistantSegments.get(assistantIdxs[0]);
+        if(aIdx<assistantIdxs[0]) return null;
         const fallbackIdx=[...assistantIdxs].reverse().find(idx=>idx<=aIdx);
         anchorRow=fallbackIdx!==undefined?assistantSegments.get(fallbackIdx):assistantSegments.get(assistantIdxs[assistantIdxs.length-1]);
       }

--- a/static/ui.js
+++ b/static/ui.js
@@ -2394,6 +2394,12 @@ function _clearCompressionElapsedTimer(){if(_compressionElapsedTimer){clearInter
 let _activityElapsedTimer=null;
 let _activityElapsedTimerGroup=null;
 function _activityNowSeconds(){return Date.now()/1000;}
+function _isActivityTimerGroup(group){
+  return !!(group&&(
+    group.getAttribute('data-live-tool-call-group')==='1'||
+    group.getAttribute('data-run-activity-group')==='1'
+  ));
+}
 function _activityElapsedStartedAt(group){
   if(!group)return null;
   const raw=(group.dataset&&group.dataset.turnStartedAt!==undefined&&group.dataset.turnStartedAt!=='')
@@ -2408,7 +2414,10 @@ function _activityElapsedLabel(group){
   return _formatActiveElapsedTimer(_activityNowSeconds()-started);
 }
 function _activityMarkObserved(group, ts){
-  if(!group||group.getAttribute('data-live-tool-call-group')!=='1')return;
+  if(!group||(
+    group.getAttribute('data-live-tool-call-group')!=='1'&&
+    group.getAttribute('data-run-activity-group')!=='1'
+  ))return;
   const stamp=Number(ts||_activityNowSeconds());
   if(Number.isFinite(stamp)&&stamp>0) group.setAttribute('data-last-activity-at',String(stamp));
 }
@@ -2444,7 +2453,7 @@ function _appendActivityEvent(group, event){
   return row;
 }
 function _ensureLiveActivityBaseline(group){
-  if(!group||group.getAttribute('data-live-tool-call-group')!=='1')return;
+  if(!group||group.getAttribute('data-run-activity-group')!=='1')return;
   const started=_activityElapsedStartedAt(group)||_activityNowSeconds();
   if(!group.getAttribute('data-turn-started-at')) group.setAttribute('data-turn-started-at',String(started));
   if(!group.getAttribute('data-last-activity-at')) group.setAttribute('data-last-activity-at',String(started));
@@ -2453,13 +2462,13 @@ function _ensureLiveActivityBaseline(group){
   if(modelLabel)_appendActivityEvent(group,{id:'run-model',kind:'model',label:`Model: ${modelLabel}`,detail:S.activeProfile&&S.activeProfile!=='default'?`Profile: ${S.activeProfile}`:'',status:'done',ts:started});
 }
 function _setActivityElapsedStartedAt(group){
-  if(!group||group.getAttribute('data-live-tool-call-group')!=='1')return;
+  if(!_isActivityTimerGroup(group))return;
   const started=_activityElapsedStartedAt(group);
   if(started)group.setAttribute('data-turn-started-at',String(started));
 }
 function _updateActiveActivityElapsedTimer(){
   const group=_activityElapsedTimerGroup;
-  if(!group||!group.isConnected||group.getAttribute('data-live-tool-call-group')!=='1'||group.getAttribute('data-live-activity-current')!=='1'){
+  if(!group||!group.isConnected||!_isActivityTimerGroup(group)){
     _clearActivityElapsedTimer();
     return;
   }
@@ -2472,13 +2481,13 @@ function _updateActiveActivityElapsedTimer(){
   }
   if(durationEl){
     const activeText=label?`Working for ${label}`:'';
-    const progressText=_activityLiveProgressLabel(group);
+    const progressText=group.getAttribute('data-run-activity-group')==='1'?'':_activityLiveProgressLabel(group);
     durationEl.textContent=[progressText, activeText].filter(Boolean).join(' · ');
     durationEl.style.display=durationEl.textContent?'':'none';
   }
 }
 function _startActivityElapsedTimer(group){
-  if(!group||group.getAttribute('data-live-tool-call-group')!=='1')return;
+  if(!_isActivityTimerGroup(group))return;
   _setActivityElapsedStartedAt(group);
   if(_activityElapsedTimerGroup&&_activityElapsedTimerGroup!==group)_clearActivityElapsedTimer();
   _activityElapsedTimerGroup=group;
@@ -4378,6 +4387,8 @@ function _compactInflightState(state){
     lastAssistantText:state.lastAssistantText||'',
     lastReasoningText:state.lastReasoningText||'',
     lastRunJournalSeq:state.lastRunJournalSeq||0,
+    currentActivityBurstId:state.currentActivityBurstId||0,
+    activityBurstAnchors:Array.isArray(state.activityBurstAnchors)?state.activityBurstAnchors.slice(-50):[],
   }, limits.stringChars);
 }
 function _writeInflightStateMap(all){
@@ -5443,7 +5454,12 @@ function ensureActivityGroup(inner, opts){
   if(!inner) return null;
   const live=!!opts.live;
   const activityKey=opts.activityKey||(live?_activityKeyForLiveTurn():null);
-  const selector=live?'.tool-call-group[data-live-tool-call-group="1"][data-live-activity-current="1"]':'.tool-call-group[data-agent-activity-group="1"]';
+  const burstId=opts.burstId!==undefined&&opts.burstId!==null?String(opts.burstId):'';
+  const selector=live
+    ? (burstId
+      ? `.tool-call-group[data-live-tool-call-group="1"][data-activity-burst-id="${CSS.escape(burstId)}"]`
+      : '.tool-call-group[data-live-tool-call-group="1"][data-live-activity-current="1"]')
+    : '.tool-call-group[data-agent-activity-group="1"]';
   let group=inner.querySelector(selector);
   if(!group){
     group=document.createElement('div');
@@ -5464,6 +5480,7 @@ function ensureActivityGroup(inner, opts){
       group.setAttribute('data-live-tool-call-group','1');
       group.setAttribute('data-live-activity-current','1');
     }
+    if(burstId) group.setAttribute('data-activity-burst-id',burstId);
     group.innerHTML=`<button type="button" class="tool-call-group-summary" aria-expanded="${collapsed?'false':'true'}" onclick="_toggleActivityGroup(this)"><span class="tool-call-group-chevron">${li('chevron-right',12)}</span><span class="tool-call-group-label">Activity</span><span class="tool-call-group-duration"></span></button><div class="tool-call-group-body"></div>`;
     const anchor=opts.anchor||null;
     if(anchor&&anchor.parentElement===inner) anchor.insertAdjacentElement('afterend', group);
@@ -5471,13 +5488,35 @@ function ensureActivityGroup(inner, opts){
   }else if(activityKey&&!group.getAttribute('data-activity-disclosure-key')){
     group.setAttribute('data-activity-disclosure-key',activityKey);
   }
-  if(live){
-    _setActivityElapsedStartedAt(group);
-    _ensureLiveActivityBaseline(group);
-  }
+  if(burstId&&!group.getAttribute('data-activity-burst-id')) group.setAttribute('data-activity-burst-id',burstId);
   _syncToolCallGroupSummary(group);
-  if(live) _startActivityElapsedTimer(group);
   return group;
+}
+function ensureRunActivityGroup(inner, opts){
+  opts=opts||{};
+  if(!inner) return null;
+  let group=inner.querySelector('.tool-call-group[data-run-activity-group="1"]');
+  if(!group){
+    group=document.createElement('div');
+    const collapsed=opts.collapsed!==false;
+    group.className='tool-call-group agent-activity-group run-activity-group'+(collapsed?' tool-call-group-collapsed':'');
+    group.setAttribute('data-tool-call-group','1');
+    group.setAttribute('data-agent-activity-group','1');
+    group.setAttribute('data-run-activity-group','1');
+    group.innerHTML=`<button type="button" class="tool-call-group-summary" aria-expanded="${collapsed?'false':'true'}" onclick="_toggleActivityGroup(this)"><span class="tool-call-group-chevron">${li('chevron-right',12)}</span><span class="tool-call-group-label">Activity</span><span class="tool-call-group-duration"></span></button><div class="tool-call-group-body"></div>`;
+    if(inner.firstChild) inner.insertBefore(group, inner.firstChild);
+    else inner.appendChild(group);
+  }
+  _setActivityElapsedStartedAt(group);
+  _ensureLiveActivityBaseline(group);
+  _syncToolCallGroupSummary(group);
+  if(opts.live!==false) _startActivityElapsedTimer(group);
+  return group;
+}
+function ensureRunActivityForCurrentTurn(){
+  const turn=$('liveAssistantTurn');
+  const blocks=_assistantTurnBlocks(turn);
+  return ensureRunActivityGroup(blocks,{live:true,collapsed:true});
 }
 function closeCurrentLiveActivityGroup(){
   const turn=$('liveAssistantTurn');
@@ -6511,6 +6550,9 @@ function renderMessages(options){
       if(S.session) currentAssistantTurn.dataset.sessionId=S.session.session_id;
       seg.setAttribute('data-live-assistant','1');
     }
+    if(m._activityBurstId!==undefined&&m._activityBurstId!==null){
+      seg.setAttribute('data-activity-burst-id',String(m._activityBurstId));
+    }
     if(_ERR_MSG_RE.test(String(content||'').trim())) seg.dataset.error='1';
     if(thinkingText&&window._showThinking!==false){
       if(isSimplifiedToolCalling()) assistantThinking.set(rawIdx, thinkingText);
@@ -6923,6 +6965,8 @@ function buildToolCard(tc){
   const moreLabel=tc.is_diff?'Show diff':'Show more';
   const lessLabel=tc.is_diff?'Hide diff':'Show less';
   const runIndicator=tc.done===false?'<span class="tool-card-running-dot"></span>':'';
+  const durationText=tc.duration!==undefined&&tc.duration!==null?_formatTurnDuration(tc.duration):'';
+  const durationHtml=durationText?`<span class="tool-card-duration">Done in ${esc(durationText)}</span>`:'';
   const isSubagent=tc.name==='subagent_progress';
   const isDelegation=tc.name==='delegate_task';
   const cardClass='tool-card'+(tc.done===false?' tool-card-running':'')+(isSubagent?' tool-card-subagent':'');
@@ -6937,6 +6981,7 @@ function buildToolCard(tc){
         <span class="tool-card-icon">${icon}</span>
         <span class="tool-card-name">${esc(displayName)}</span>
         <span class="tool-card-preview">${esc(previewText)}</span>
+        ${durationHtml}
         ${hasDetail?`<span class="tool-card-toggle">${li('chevron-right',12)}</span>`:''}
       </div>
       ${hasDetail?`<div class="tool-card-detail">
@@ -6959,6 +7004,9 @@ function _syncToolCallGroupSummary(group){
   const label=group.querySelector('.tool-call-group-label');
   const durationEl=group.querySelector('.tool-call-group-duration');
   if(label){
+    if(group.getAttribute('data-run-activity-group')==='1'){
+      label.textContent='Activity';
+    }else
     if(group.getAttribute('data-live-tool-call-group')==='1'){
       label.textContent=toolCount?`Activity: ${toolCount} tool${toolCount===1?'':'s'}`:'Activity · Running';
     }else if(toolCount) label.textContent=`Activity: ${toolCount} tool${toolCount===1?'':'s'}`;
@@ -6966,7 +7014,11 @@ function _syncToolCallGroupSummary(group){
     label.setAttribute('data-sweep-label', label.textContent);
   }
   if(durationEl){
-    if(group.getAttribute('data-live-tool-call-group')==='1'){
+    if(group.getAttribute('data-run-activity-group')==='1'){
+      const activeText=_activityElapsedLabel(group);
+      durationEl.textContent=activeText?`Working for ${activeText}`:'';
+      durationEl.style.display=durationEl.textContent?'':'none';
+    }else if(group.getAttribute('data-live-tool-call-group')==='1'){
       const activeText=_activityElapsedLabel(group);
       const progressText=_activityLiveProgressLabel(group);
       if(activeText) group.setAttribute('data-active-turn-elapsed',activeText);
@@ -7025,6 +7077,7 @@ function appendLiveToolCard(tc){
   }
   const inner=_assistantTurnBlocks(turn);
   if(!inner) return;
+  if(typeof ensureRunActivityGroup==='function') ensureRunActivityGroup(inner,{live:true,collapsed:true});
   const tid=tc.tid||'';
   if(!isSimplifiedToolCalling()){
     // Update existing card in place (tool_complete after tool_start)
@@ -7065,22 +7118,13 @@ function appendLiveToolCard(tc){
     return;
   }
   const children=Array.from(inner.children);
-  const anchor=children.filter(el=>el.matches('[data-live-assistant="1"],.tool-call-group,.tool-card-row,.agent-activity-thinking')).pop();
-  const group=ensureActivityGroup(inner,{live:true,collapsed:true,anchor,activityKey:_activityKeyForLiveTurn()});
+  const burstId=tc.activityBurstId!==undefined&&tc.activityBurstId!==null?String(tc.activityBurstId):'';
+  const burstAnchor=burstId?inner.querySelector(`[data-live-assistant="1"][data-activity-burst-id="${CSS.escape(burstId)}"]`):null;
+  const anchor=burstAnchor||children.filter(el=>el.matches('[data-live-assistant="1"],.tool-call-group,.tool-card-row,.agent-activity-thinking')).pop();
+  const group=ensureActivityGroup(inner,{live:true,collapsed:true,anchor,activityKey:burstId?`live:${S.activeStreamId}:burst:${burstId}`:_activityKeyForLiveTurn(),burstId});
   const body=group.querySelector('.tool-call-group-body');
-  const toolName=_toolDisplayName(tc);
-  const toolEventId=tid?`tool-${tid}`:`tool-${String(tc.name||'tool').replace(/[^a-z0-9_-]/gi,'_')}`;
-  const toolDone=tc.done!==false;
-  _appendActivityEvent(group,{
-    id:toolEventId,
-    kind:'tool',
-    label:toolDone?`Tool finished: ${toolName}`:`Running tool: ${toolName}`,
-    detail:tc.preview||tc.snippet||'',
-    status:toolDone?(tc.is_error?'error':'done'):'waiting',
-    ts:_activityNowSeconds(),
-  });
   const waiting=body.querySelector('.agent-activity-status[data-activity-event-id="thinking-placeholder"] .agent-activity-status-label');
-  if(waiting&&!toolDone) waiting.textContent='Waiting on tool result';
+  if(waiting&&tc.done===false) waiting.textContent='Waiting on tool result';
   // Update existing card in place (tool_complete after tool_start)
   if(tid){
     const existing=body.querySelector(`.tool-card-row[data-live-tid="${CSS.escape(tid)}"]`);
@@ -7883,6 +7927,7 @@ function appendThinking(text='', options){
   }
   const blocks=_assistantTurnBlocks(turn);
   if(!blocks) return;
+  if(typeof ensureRunActivityGroup==='function') ensureRunActivityGroup(blocks,{live:true,collapsed:true});
   if(!isSimplifiedToolCalling()){
     let row=$('thinkingRow');
     if(!row){
@@ -7917,6 +7962,10 @@ function appendThinking(text='', options){
   }
   const thinkingText=String(text||'').trim()||'Thinking…';
   const cleanThinking=_sanitizeThinkingDisplayText(thinkingText);
+  if(!cleanThinking||cleanThinking==='Thinking…'){
+    scrollIfPinned();
+    return;
+  }
   const allChildren=Array.from(blocks.children);
   const anchor=allChildren.filter(el=>
     el.id!=='toolRunningRow' &&
@@ -7925,18 +7974,6 @@ function appendThinking(text='', options){
   const group=ensureActivityGroup(blocks,{live:true,collapsed:true,anchor,activityKey:_activityKeyForLiveTurn()});
   const body=group&&group.querySelector('.tool-call-group-body');
   if(!body) return;
-  if(!cleanThinking||cleanThinking==='Thinking…'){
-    const label=body.querySelector('.tool-card.tool-card-running')?'Waiting on tool result':'Waiting on model';
-    const detail=body.querySelector('.tool-card-row')
-      ? 'The agent is running; tool results and response text will appear here.'
-      : 'No tool activity has been reported yet.';
-    _appendActivityEvent(group,{id:'thinking-placeholder',kind:'waiting',label,detail,status:'waiting',ts:_activityNowSeconds()});
-    const active=body.querySelector('.agent-activity-thinking[data-thinking-active="1"]');
-    if(active) active.removeAttribute('data-thinking-active');
-    _syncToolCallGroupSummary(group);
-    scrollIfPinned();
-    return;
-  }
   const placeholder=body.querySelector('.agent-activity-status[data-activity-event-id="thinking-placeholder"]');
   if(placeholder) placeholder.remove();
   let row=body.querySelector('.agent-activity-thinking[data-thinking-active="1"]');
@@ -7973,7 +8010,7 @@ function removeThinking(){
   const turn=$('liveAssistantTurn');
   const blocks=_assistantTurnBlocks(turn);
   if(blocks) blocks.querySelectorAll('.agent-activity-thinking').forEach(el=>el.remove());
-  if(blocks) blocks.querySelectorAll('.tool-call-group[data-agent-activity-group="1"]').forEach(group=>{
+  if(blocks) blocks.querySelectorAll('.tool-call-group[data-agent-activity-group="1"]:not([data-run-activity-group])').forEach(group=>{
     _syncToolCallGroupSummary(group);
     if(!group.querySelector('.tool-card-row,.agent-activity-thinking')){
       if(typeof _clearActivityElapsedTimer==='function') _clearActivityElapsedTimer();

--- a/static/ui.js
+++ b/static/ui.js
@@ -4375,6 +4375,9 @@ function _compactInflightState(state){
     messages,
     uploaded:Array.isArray(state.uploaded)?state.uploaded.slice(-20):[],
     toolCalls,
+    lastAssistantText:state.lastAssistantText||'',
+    lastReasoningText:state.lastReasoningText||'',
+    lastRunJournalSeq:state.lastRunJournalSeq||0,
   }, limits.stringChars);
 }
 function _writeInflightStateMap(all){

--- a/static/ui.js
+++ b/static/ui.js
@@ -2395,10 +2395,7 @@ let _activityElapsedTimer=null;
 let _activityElapsedTimerGroup=null;
 function _activityNowSeconds(){return Date.now()/1000;}
 function _isActivityTimerGroup(group){
-  return !!(group&&(
-    group.getAttribute('data-live-tool-call-group')==='1'||
-    group.getAttribute('data-run-activity-group')==='1'
-  ));
+  return !!(group&&group.getAttribute('data-run-activity-group')==='1');
 }
 function _activityElapsedStartedAt(group){
   if(!group)return null;
@@ -2482,9 +2479,7 @@ function _updateActiveActivityElapsedTimer(){
   if(durationEl){
     const settledText=_formatTurnDuration(group.dataset.turnDuration);
     const activeText=(!settledText&&label)?`Working for ${label}`:'';
-    const progressText=(settledText||group.getAttribute('data-run-activity-group')==='1')?'':_activityLiveProgressLabel(group);
-    durationEl.textContent=[progressText, activeText].filter(Boolean).join(' · ');
-    if(settledText) durationEl.textContent=`Done in ${settledText}`;
+    durationEl.textContent=settledText?`Done in ${settledText}`:activeText;
     durationEl.style.display=durationEl.textContent?'':'none';
   }
 }
@@ -4506,8 +4501,9 @@ function restoreLiveTurnHtmlForSession(sid){
   _mergeRestoredLiveAssistantSegment(restored, existing);
   if(existing) existing.replaceWith(restored);
   else inner.appendChild(restored);
-  const liveGroup=restored.querySelector('.tool-call-group[data-live-tool-call-group="1"]');
-  if(liveGroup&&typeof _startActivityElapsedTimer==='function') _startActivityElapsedTimer(liveGroup);
+  if(typeof normalizeLiveActivityGroupPlacement==='function') normalizeLiveActivityGroupPlacement(restored);
+  const runGroup=restored.querySelector('.tool-call-group[data-run-activity-group="1"]');
+  if(runGroup&&typeof _startActivityElapsedTimer==='function') _startActivityElapsedTimer(runGroup);
   if(typeof placeLiveToolCardsHost==='function') placeLiveToolCardsHost();
   requestAnimationFrame(()=>postProcessRenderedMessages(restored));
   return true;
@@ -5491,8 +5487,29 @@ function ensureActivityGroup(inner, opts){
     group.setAttribute('data-activity-disclosure-key',activityKey);
   }
   if(burstId&&!group.getAttribute('data-activity-burst-id')) group.setAttribute('data-activity-burst-id',burstId);
+  const anchor=opts.anchor||null;
+  if(anchor&&anchor.parentElement===inner&&group.parentElement===inner&&group.previousElementSibling!==anchor){
+    anchor.insertAdjacentElement('afterend',group);
+  }
   _syncToolCallGroupSummary(group);
   return group;
+}
+function normalizeLiveActivityGroupPlacement(turn){
+  const blocks=_assistantTurnBlocks(turn);
+  if(!blocks) return;
+  const groups=Array.from(blocks.querySelectorAll('.tool-call-group[data-live-tool-call-group="1"][data-activity-burst-id]'));
+  groups.sort((a,b)=>{
+    const av=Number(a.getAttribute('data-activity-burst-id'));
+    const bv=Number(b.getAttribute('data-activity-burst-id'));
+    if(Number.isFinite(av)&&Number.isFinite(bv)&&av!==bv) return av-bv;
+    return 0;
+  });
+  for(const group of groups){
+    const burstId=group.getAttribute('data-activity-burst-id')||'';
+    if(!burstId) continue;
+    const anchor=blocks.querySelector(`[data-live-assistant="1"][data-activity-burst-id="${CSS.escape(burstId)}"]`);
+    if(anchor&&group.previousElementSibling!==anchor) anchor.insertAdjacentElement('afterend',group);
+  }
 }
 function ensureRunActivityGroup(inner, opts){
   opts=opts||{};
@@ -7077,12 +7094,9 @@ function _syncToolCallGroupSummary(group){
       durationEl.textContent=durationText?`Done in ${durationText}`:(activeText?`Working for ${activeText}`:'');
       durationEl.style.display=durationEl.textContent?'':'none';
     }else if(group.getAttribute('data-live-tool-call-group')==='1'){
-      const activeText=_activityElapsedLabel(group);
-      const progressText=_activityLiveProgressLabel(group);
-      if(activeText) group.setAttribute('data-active-turn-elapsed',activeText);
-      else group.removeAttribute('data-active-turn-elapsed');
-      durationEl.textContent=[progressText, activeText].filter(Boolean).join(' · ');
-      durationEl.style.display=durationEl.textContent?'':'none';
+      group.removeAttribute('data-active-turn-elapsed');
+      durationEl.textContent='';
+      durationEl.style.display='none';
     }else{
       const durationText=_formatTurnDuration(group.dataset.turnDuration);
       durationEl.textContent=durationText?`Done in ${durationText}`:'';

--- a/static/ui.js
+++ b/static/ui.js
@@ -6713,6 +6713,29 @@ function renderMessages(options){
       }
     });
     const derived=[];
+    const liveToolMetadata=Array.isArray(S.toolCalls)?S.toolCalls:[];
+    const liveMetadataByTid=new Map();
+    liveToolMetadata.forEach((tc,idx)=>{
+      if(!tc||typeof tc!=='object') return;
+      const tid=tc.tid||tc.id||tc.tool_call_id||tc.call_id||'';
+      if(tid&&!liveMetadataByTid.has(tid)) liveMetadataByTid.set(tid,{tc,idx});
+    });
+    const usedLiveToolMetadata=new Set();
+    const copyLiveToolMetadata=(next,name,tid)=>{
+      let matchEntry=tid?liveMetadataByTid.get(tid):null;
+      if(!matchEntry){
+        const matchIdx=liveToolMetadata.findIndex((tc,i)=>tc&&!usedLiveToolMetadata.has(i)&&(!name||tc.name===name));
+        if(matchIdx>=0) matchEntry={tc:liveToolMetadata[matchIdx],idx:matchIdx};
+      }
+      if(matchEntry){
+        usedLiveToolMetadata.add(matchEntry.idx);
+        const live=matchEntry.tc||{};
+        for(const key of ['activityBurstId','duration','started_at']){
+          if((next[key]===undefined||next[key]===null)&&live[key]!==undefined&&live[key]!==null) next[key]=live[key];
+        }
+      }
+      return next;
+    };
     fallbackToolSources.forEach(({m,rawIdx})=>{
       // OpenAI format: top-level tool_calls field on the assistant message
       (m.tool_calls||[]).forEach(tc=>{
@@ -6726,7 +6749,7 @@ function renderMessages(options){
         const resultSnippet=resultsByTid[tid]||'';
         let argsSnap={};
         Object.keys(args).slice(0,4).forEach(k=>{ const v=String(args[k]); argsSnap[k]=v.slice(0,120)+(v.length>120?'...':''); });
-        derived.push({
+        derived.push(copyLiveToolMetadata({
           name,
           snippet:_cliToolCardSnippet(resultSnippet,patchSnippet),
           is_diff:_cliToolCardHasDiffSnippet(resultSnippet,patchSnippet),
@@ -6734,7 +6757,7 @@ function renderMessages(options){
           assistant_msg_idx:rawIdx,
           args:argsSnap,
           done:true,
-        });
+        }, name, tid));
       });
       // Anthropic format: tool_use blocks inside assistant content array
       if(Array.isArray(m.content)){
@@ -6749,7 +6772,7 @@ function renderMessages(options){
           if(args && typeof args==='object'){
             Object.keys(args).slice(0,4).forEach(k=>{ const v=String(args[k]); argsSnap[k]=v.slice(0,120)+(v.length>120?'...':''); });
           }
-          derived.push({
+          derived.push(copyLiveToolMetadata({
             name,
             snippet:_cliToolCardSnippet(resultSnippet,patchSnippet),
             is_diff:_cliToolCardHasDiffSnippet(resultSnippet,patchSnippet),
@@ -6757,7 +6780,7 @@ function renderMessages(options){
             assistant_msg_idx:rawIdx,
             args:argsSnap,
             done:true,
-          });
+          }, name, tid));
         });
       }
     });
@@ -6773,7 +6796,7 @@ function renderMessages(options){
     }
     const assistantIdxs=[...assistantSegments.keys()].sort((a,b)=>a-b);
     const _assistantAnchorForActivity=(aIdx,burstId)=>{
-      const wantedBurst=burstId!==undefined&&burstId!==null&&String(burstId)!==''?String(burstId):'';
+      const wantedBurst=burstId!==undefined&&burstId!==null&&String(burstId)!==''&&String(burstId)!=='0'?String(burstId):'';
       if(wantedBurst){
         for(const seg of assistantSegments.values()){
           if(seg&&seg.getAttribute('data-activity-burst-id')===wantedBurst) return seg;
@@ -6781,7 +6804,7 @@ function renderMessages(options){
       }
       let anchorRow=assistantSegments.get(aIdx)||null;
       if(!anchorRow&&assistantIdxs.length){
-        if(aIdx<assistantIdxs[0]) return null;
+        if(aIdx<assistantIdxs[0]) return assistantSegments.get(assistantIdxs[0]);
         const fallbackIdx=[...assistantIdxs].reverse().find(idx=>idx<=aIdx);
         anchorRow=fallbackIdx!==undefined?assistantSegments.get(fallbackIdx):assistantSegments.get(assistantIdxs[assistantIdxs.length-1]);
       }
@@ -6815,7 +6838,7 @@ function renderMessages(options){
       for(const tc of (S.toolCalls||[])){
         if(!tc) continue;
         const aIdx=tc.assistant_msg_idx!==undefined?parseInt(tc.assistant_msg_idx):-1;
-        const burstId=tc.activityBurstId!==undefined&&tc.activityBurstId!==null?String(tc.activityBurstId):'';
+        const burstId=tc.activityBurstId!==undefined&&tc.activityBurstId!==null&&String(tc.activityBurstId)!=='0'?String(tc.activityBurstId):'';
         const key=burstId?`burst:${burstId}`:`assistant:${aIdx}`;
         ensureActivityBucket(key,aIdx,burstId).cards.push(tc);
       }
@@ -7190,7 +7213,7 @@ function appendLiveToolCard(tc){
     return;
   }
   const children=Array.from(inner.children);
-  const burstId=tc.activityBurstId!==undefined&&tc.activityBurstId!==null?String(tc.activityBurstId):'';
+  const burstId=tc.activityBurstId!==undefined&&tc.activityBurstId!==null&&String(tc.activityBurstId)!=='0'?String(tc.activityBurstId):'';
   const burstAnchor=burstId?inner.querySelector(`[data-live-assistant="1"][data-activity-burst-id="${CSS.escape(burstId)}"]`):null;
   const anchor=burstAnchor||children.filter(el=>el.matches('[data-live-assistant="1"],.tool-call-group,.tool-card-row,.agent-activity-thinking')).pop();
   const group=ensureActivityGroup(inner,{live:true,collapsed:true,anchor,activityKey:burstId?`live:${S.activeStreamId}:burst:${burstId}`:_activityKeyForLiveTurn(),burstId});

--- a/tests/test_inflight_stream_reuse.py
+++ b/tests/test_inflight_stream_reuse.py
@@ -1,10 +1,13 @@
 """Regression tests for preserving live streams across session switches."""
 import re
+import shutil
+import subprocess
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).parent.parent
 MESSAGES_JS = (REPO_ROOT / "static" / "messages.js").read_text(encoding="utf-8")
 SESSIONS_JS = (REPO_ROOT / "static" / "sessions.js").read_text(encoding="utf-8")
+NODE = shutil.which("node")
 
 
 def _function_body(src: str, name: str) -> str:
@@ -172,3 +175,61 @@ def test_load_session_reattaches_when_inflight_is_in_memory_and_marked_for_reatt
         "loadSession() must reattach via attachLiveStream() when "
         "INFLIGHT[sid].reattach && activeStreamId"
     )
+
+
+def test_inflight_merge_strips_live_assistant_text_already_persisted_by_server():
+    """Switching back to a running session must not append the whole live text
+    when the server transcript already contains the same assistant progress
+    split around tool rows.
+    """
+    assert NODE, "node not on PATH"
+    start = SESSIONS_JS.find("function _messageComparableText")
+    end = SESSIONS_JS.find("// Load older messages", start)
+    assert start != -1 and end != -1
+    helper_src = SESSIONS_JS[start:end]
+    script = f"""
+const assert = require('assert');
+{helper_src}
+
+let base = [
+  {{role:'user', content:'go'}},
+  {{role:'assistant', content:'First progress.'}},
+  {{role:'tool', content:'{{}}'}},
+  {{role:'assistant', content:'Second progress.'}},
+];
+let inflight = [
+  {{role:'user', content:'go'}},
+  {{role:'assistant', _live:true, content:'First progress.\\n\\nSecond progress.'}},
+];
+let merged = _mergeInflightTailMessages(base, inflight);
+assert.strictEqual(merged.length, base.length);
+assert.strictEqual(inflight[1].content, '');
+
+base = [
+  {{role:'user', content:'go'}},
+  {{role:'assistant', content:'First progress.'}},
+  {{role:'tool', content:'{{}}'}},
+  {{role:'assistant', content:'Second progress.'}},
+];
+inflight = [
+  {{role:'user', content:'go'}},
+  {{role:'assistant', _live:true, content:'First progress.\\n\\nSecond progress.\\n\\nThird progress.'}},
+];
+merged = _mergeInflightTailMessages(base, inflight);
+assert.strictEqual(merged.length, base.length + 1);
+assert.strictEqual(merged[merged.length - 1].content, 'Third progress.');
+assert.strictEqual(inflight[1].content, 'Third progress.');
+"""
+    result = subprocess.run([NODE, "-e", script], capture_output=True, text=True, check=False)
+    assert result.returncode == 0, result.stderr
+
+
+def test_reconnect_prefers_trimmed_live_message_over_stale_full_assistant_cache():
+    body = _function_body(MESSAGES_JS, "attachLiveStream")
+    live_msg_pos = body.find("const _liveInflightAssistant")
+    last_text_pos = body.find("const _lastLiveAssistant")
+    assert live_msg_pos != -1 and last_text_pos != -1
+    assert live_msg_pos < last_text_pos
+    assistant_block = body[last_text_pos:body.find("const _lastLiveReasoning", last_text_pos)]
+    assert "_liveInflightAssistant.content" in assistant_block
+    assert "lastAssistantText" in assistant_block

--- a/tests/test_inflight_stream_reuse.py
+++ b/tests/test_inflight_stream_reuse.py
@@ -177,10 +177,14 @@ def test_load_session_reattaches_when_inflight_is_in_memory_and_marked_for_reatt
     )
 
 
-def test_inflight_merge_strips_live_assistant_text_already_persisted_by_server():
-    """Switching back to a running session must not append the whole live text
-    when the server transcript already contains the same assistant progress
-    split around tool rows.
+def test_running_reattach_refreshes_single_live_assistant_from_server_progress():
+    """Switching back to a running session should keep one visible assistant
+    source for the active turn.
+
+    The server transcript can already contain interim assistant progress while
+    INFLIGHT also holds the live assistant tail. Reattach must refresh the live
+    tail from the server copy, drop the server's active-turn assistant rows, and
+    render one `_live` assistant instead of duplicating or deleting progress.
     """
     assert NODE, "node not on PATH"
     start = SESSIONS_JS.find("function _messageComparableText")
@@ -199,12 +203,15 @@ let base = [
 ];
 let inflight = [
   {{role:'user', content:'go'}},
-  {{role:'assistant', _live:true, content:'First progress.\\n\\nSecond progress.'}},
+  {{role:'assistant', _live:true, content:'First progress.\\n\\nSecond progress.\\n\\nSecond progress.'}},
 ];
+assert.strictEqual(_prepareRunningLiveTail(base, inflight), true);
+assert.strictEqual(inflight[1].content, 'First progress.\\n\\nSecond progress.');
+base = _dropCurrentTurnAssistantMessages(base);
 let merged = _mergeInflightTailMessages(base, inflight);
-assert.strictEqual(merged.length, base.length);
-assert.strictEqual(inflight[1].content, '');
-assert.strictEqual(inflight[1]._coveredAssistantPrefixStripped, true);
+assert.strictEqual(merged.filter(m => m.role === 'assistant').length, 1);
+assert.strictEqual(merged[merged.length - 1]._live, true);
+assert.strictEqual(merged[merged.length - 1].content, 'First progress.\\n\\nSecond progress.');
 
 base = [
   {{role:'user', content:'go'}},
@@ -214,26 +221,30 @@ base = [
 ];
 inflight = [
   {{role:'user', content:'go'}},
-  {{role:'assistant', _live:true, content:'First progress.\\n\\nSecond progress.\\n\\nThird progress.'}},
+  {{role:'assistant', _live:true, content:'First progress.'}},
 ];
+assert.strictEqual(_prepareRunningLiveTail(base, inflight), true);
+assert.strictEqual(inflight[1].content, 'First progress.\\n\\nSecond progress.');
+base = _dropCurrentTurnAssistantMessages(base);
 merged = _mergeInflightTailMessages(base, inflight);
-assert.strictEqual(merged.length, base.length + 1);
-assert.strictEqual(merged[merged.length - 1].content, 'Third progress.');
-assert.strictEqual(inflight[1].content, 'Third progress.');
-assert.strictEqual(inflight[1]._coveredAssistantPrefixStripped, true);
+assert.strictEqual(merged.filter(m => m.role === 'assistant').length, 1);
+assert.strictEqual(merged[merged.length - 1]._live, true);
+assert.strictEqual(merged[merged.length - 1].content, 'First progress.\\n\\nSecond progress.');
 """
     result = subprocess.run([NODE, "-e", script], capture_output=True, text=True, check=False)
     assert result.returncode == 0, result.stderr
 
 
-def test_load_session_drops_stale_live_dom_snapshot_after_trimming_covered_tail():
+def test_load_session_rebuilds_live_tail_before_dropping_stale_dom_snapshot():
     body = _function_body(SESSIONS_JS, "loadSession")
+    prepare_pos = body.find("const liveTailPrepared=_prepareRunningLiveTail(S.messages,inflightMessages);")
+    drop_dom_pos = body.find("delete INFLIGHT[sid].liveTurnHtml;")
+    drop_assistant_pos = body.find("S.messages=_dropCurrentTurnAssistantMessages(S.messages);")
     merge_pos = body.find("S.messages=_mergeInflightTailMessages(S.messages,inflightMessages);")
-    drop_pos = body.find("delete INFLIGHT[sid].liveTurnHtml;")
     restore_pos = body.find("restoreLiveTurnHtmlForSession(sid)")
-    assert merge_pos != -1 and drop_pos != -1 and restore_pos != -1
-    assert merge_pos < drop_pos < restore_pos
-    assert "_coveredAssistantPrefixStripped" in body[merge_pos:restore_pos]
+    assert prepare_pos != -1 and drop_dom_pos != -1
+    assert drop_assistant_pos != -1 and merge_pos != -1 and restore_pos != -1
+    assert prepare_pos < drop_dom_pos < drop_assistant_pos < merge_pos < restore_pos
 
 
 def test_load_session_advances_replay_cursor_when_loaded_transcript_has_current_turn_output():

--- a/tests/test_inflight_stream_reuse.py
+++ b/tests/test_inflight_stream_reuse.py
@@ -386,6 +386,42 @@ def test_load_session_prefers_structured_inflight_state_over_live_turn_snapshot(
     assert "!hasStructuredLiveState&&" in guard_block.replace(" ", "")
 
 
+def test_merge_inflight_tail_preserves_all_segmented_live_progress():
+    """The reattach merge must keep every projected live progress segment.
+
+    _projectInflightMessagesForActivityBursts() can split one live assistant
+    accumulator into multiple _live messages.  If the merge starts at the last
+    _live segment, the earlier process-text anchors disappear and Activity
+    groups whose burst ids point to those anchors pile up at the bottom.
+    """
+    assert NODE, "node not on PATH"
+    fn_start = SESSIONS_JS.index("function _mergeInflightTailMessages")
+    fn_end = SESSIONS_JS.index("// Load older messages", fn_start)
+    merge_fn = SESSIONS_JS[fn_start:fn_end]
+    script = f"""
+const assert = require('assert');
+function _messageComparableText(m) {{ return String((m&&m.content)||'').trim(); }}
+function _sameTranscriptMessage(a,b) {{
+  return !!(a&&b&&a.role===b.role&&_messageComparableText(a)===_messageComparableText(b));
+}}
+{merge_fn}
+const base = [{{role:'user', content:'go'}}];
+const inflight = [
+  {{role:'user', content:'go'}},
+  {{role:'assistant', _live:true, content:'first progress', _activityBurstId:1}},
+  {{role:'assistant', _live:true, content:'second progress', _activityBurstId:2}},
+  {{role:'assistant', _live:true, content:'third progress', _activityBurstId:3}},
+];
+const merged = _mergeInflightTailMessages(base, inflight);
+assert.deepStrictEqual(
+  merged.filter(m => m.role === 'assistant').map(m => m.content),
+  ['first progress', 'second progress', 'third progress']
+);
+"""
+    result = subprocess.run([NODE, "-e", script], capture_output=True, text=True, check=False)
+    assert result.returncode == 0, result.stderr
+
+
 def test_load_session_does_not_advance_replay_cursor_from_session_journal_summary():
     body = _function_body(SESSIONS_JS, "loadSession")
     assert "INFLIGHT[sid].lastRunJournalSeq=journalSeq;" not in body

--- a/tests/test_inflight_stream_reuse.py
+++ b/tests/test_inflight_stream_reuse.py
@@ -325,13 +325,11 @@ def test_load_session_rebuilds_live_tail_before_dropping_stale_dom_snapshot():
     assert ensure_pos < inflight_pos < prepare_pos < drop_dom_pos < drop_assistant_pos < merge_pos < restore_pos
 
 
-def test_load_session_advances_replay_cursor_when_loaded_transcript_has_current_turn_output():
+def test_load_session_does_not_advance_replay_cursor_from_session_journal_summary():
     body = _function_body(SESSIONS_JS, "loadSession")
-    assert "const journalSeq=_runJournalSeqFromSession(S.session);" in body
-    assert "_currentTurnHasVisibleOutput(S.messages)" in body
-    assert "INFLIGHT[sid].lastRunJournalSeq=journalSeq;" in body
-    ensure_body = _function_body(SESSIONS_JS, "_ensureMessagesLoaded")
-    assert "S.session.runtime_journal=data.session.runtime_journal;" in ensure_body
+    assert "INFLIGHT[sid].lastRunJournalSeq=journalSeq;" not in body
+    assert "const journalSeq=_runJournalSeqFromSession(S.session);" not in body
+    assert "function _runJournalSeqFromSession" not in SESSIONS_JS
 
 
 def test_reconnect_prefers_trimmed_live_message_over_stale_full_assistant_cache():

--- a/tests/test_inflight_stream_reuse.py
+++ b/tests/test_inflight_stream_reuse.py
@@ -204,6 +204,7 @@ let inflight = [
 let merged = _mergeInflightTailMessages(base, inflight);
 assert.strictEqual(merged.length, base.length);
 assert.strictEqual(inflight[1].content, '');
+assert.strictEqual(inflight[1]._coveredAssistantPrefixStripped, true);
 
 base = [
   {{role:'user', content:'go'}},
@@ -219,9 +220,29 @@ merged = _mergeInflightTailMessages(base, inflight);
 assert.strictEqual(merged.length, base.length + 1);
 assert.strictEqual(merged[merged.length - 1].content, 'Third progress.');
 assert.strictEqual(inflight[1].content, 'Third progress.');
+assert.strictEqual(inflight[1]._coveredAssistantPrefixStripped, true);
 """
     result = subprocess.run([NODE, "-e", script], capture_output=True, text=True, check=False)
     assert result.returncode == 0, result.stderr
+
+
+def test_load_session_drops_stale_live_dom_snapshot_after_trimming_covered_tail():
+    body = _function_body(SESSIONS_JS, "loadSession")
+    merge_pos = body.find("S.messages=_mergeInflightTailMessages(S.messages,inflightMessages);")
+    drop_pos = body.find("delete INFLIGHT[sid].liveTurnHtml;")
+    restore_pos = body.find("restoreLiveTurnHtmlForSession(sid)")
+    assert merge_pos != -1 and drop_pos != -1 and restore_pos != -1
+    assert merge_pos < drop_pos < restore_pos
+    assert "_coveredAssistantPrefixStripped" in body[merge_pos:restore_pos]
+
+
+def test_load_session_advances_replay_cursor_when_loaded_transcript_has_current_turn_output():
+    body = _function_body(SESSIONS_JS, "loadSession")
+    assert "const journalSeq=_runJournalSeqFromSession(S.session);" in body
+    assert "_currentTurnHasVisibleOutput(S.messages)" in body
+    assert "INFLIGHT[sid].lastRunJournalSeq=journalSeq;" in body
+    ensure_body = _function_body(SESSIONS_JS, "_ensureMessagesLoaded")
+    assert "S.session.runtime_journal=data.session.runtime_journal;" in ensure_body
 
 
 def test_reconnect_prefers_trimmed_live_message_over_stale_full_assistant_cache():

--- a/tests/test_inflight_stream_reuse.py
+++ b/tests/test_inflight_stream_reuse.py
@@ -403,3 +403,66 @@ def test_reconnect_uses_full_accumulator_when_live_tail_is_segmented():
     assert "_liveInflightAssistantMessages.length>1" in assistant_block.replace(" ", "")
     assert "_fullInflightAssistant" in assistant_block
     assert "lastAssistantText" in body[helper_pos:last_text_pos]
+
+
+def test_reconnect_seeds_segment_start_from_last_burst_anchor():
+    """On reattach, segmentStart must align with the last burst anchor's textEnd.
+
+    Without this, _doRender at segmentStart===0 uses the full visible text as
+    displayText, so the smd parser (after _smdReconnect clears assistantBody)
+    rewrites the entire accumulated text into the first live assistant segment.
+    The per-burst segments rendered by _projectInflightMessagesForActivityBursts
+    are left stale, Activity groups end up visually marooned among duplicate
+    text, and the user sees Activity cards pile up at the tail of the turn.
+    """
+    body = _function_body(MESSAGES_JS, "attachLiveStream")
+    seg_start_pos = body.find("let segmentStart=(()=>{")
+    assert seg_start_pos != -1, (
+        "segmentStart must be initialized via a reconnect-aware IIFE that reads "
+        "INFLIGHT.activityBurstAnchors so the smd parser rewrites only the "
+        "tail-burst segment, not the full text."
+    )
+    seg_end_pos = body.find("})();", seg_start_pos)
+    assert seg_end_pos != -1, "segmentStart IIFE must close with })();"
+    seg_block = body[seg_start_pos:seg_end_pos]
+    assert "activityBurstAnchors" in seg_block
+    assert "reconnecting" in seg_block, "segmentStart should only shift when reconnecting"
+    assert "textEnd" in seg_block
+
+
+def test_ensure_assistant_row_reattaches_to_last_live_segment():
+    """ensureAssistantRow must pick the LAST live segment, not the first.
+
+    After session-switch reattach, the projected DOM holds one
+    [data-live-assistant="1"] per recorded burst anchor plus a tail.  New
+    tokens belong to the tail segment.  querySelector returns the first
+    match, which would funnel all post-reattach tokens into segment 1,
+    leaving the per-burst segments stale and Activity anchors visually
+    detached.
+    """
+    body = _function_body(MESSAGES_JS, "ensureAssistantRow")
+    assert "querySelectorAll('[data-live-assistant=\"1\"]')" in body, (
+        "must enumerate every live segment so the tail can be selected"
+    )
+    # Sanity: still has the fresh-segment guard so post-tool turns don't
+    # reuse the previous text segment that sits above the new tool card.
+    assert "if(!_freshSegment)" in body
+    # The selected segment must be the last entry, not the first.
+    assert "liveSegments[liveSegments.length-1]" in body
+
+
+def test_reconnect_without_tail_forces_fresh_segment_after_activity():
+    """If reconnect resumes at the last recorded boundary, no tail segment exists.
+
+    The next token should create a new segment after the previous Activity group
+    instead of reusing the last burst's text segment above that Activity.
+    """
+    body = _function_body(MESSAGES_JS, "attachLiveStream")
+    fresh_pos = body.find("let _freshSegment=")
+    seg_pos = body.find("let segmentStart=(()=>{")
+    assert seg_pos != -1 and fresh_pos != -1
+    assert seg_pos < fresh_pos
+    fresh_line = body[fresh_pos:body.find(";", fresh_pos)]
+    assert "reconnecting" in fresh_line
+    assert "segmentStart>0" in fresh_line
+    assert "segmentStart>=String(assistantText||'').length" in fresh_line

--- a/tests/test_inflight_stream_reuse.py
+++ b/tests/test_inflight_stream_reuse.py
@@ -310,6 +310,43 @@ assert.strictEqual(projected[3]._activityBurstId, 2);
     assert result.returncode == 0, result.stderr
 
 
+def test_running_reattach_aliases_empty_activity_bursts_to_previous_text_segment():
+    """Duplicate boundaries with no new text should not leave tool activity
+    attached to a burst id that has no visible assistant segment.
+    """
+    assert NODE, "node not on PATH"
+    start = SESSIONS_JS.find("function _messageComparableText")
+    end = SESSIONS_JS.find("// Load older messages", start)
+    assert start != -1 and end != -1
+    helper_src = SESSIONS_JS[start:end]
+    script = f"""
+const assert = require('assert');
+{helper_src}
+
+const inflight = {{
+  currentActivityBurstId: 2,
+  activityBurstAnchors: [
+    {{id: 1, textEnd: 'First progress.'.length}},
+    {{id: 2, textEnd: 'First progress.'.length}},
+  ],
+  toolCalls: [
+    {{name:'read_file', activityBurstId: 2}},
+  ],
+  messages: [
+    {{role:'user', content:'go'}},
+    {{role:'assistant', _live:true, content:'First progress.'}},
+  ],
+}};
+const projected = _projectInflightMessagesForActivityBursts(inflight);
+assert.strictEqual(projected.length, 2);
+assert.strictEqual(projected[1].content, 'First progress.');
+assert.strictEqual(projected[1]._activityBurstId, 1);
+assert.strictEqual(inflight.toolCalls[0].activityBurstId, 1);
+"""
+    result = subprocess.run([NODE, "-e", script], capture_output=True, text=True, check=False)
+    assert result.returncode == 0, result.stderr
+
+
 def test_load_session_rebuilds_live_tail_before_dropping_stale_dom_snapshot():
     body = _function_body(SESSIONS_JS, "loadSession")
     ensure_pos = body.find("_ensureInflightLiveAssistantMessage(INFLIGHT[sid]);")

--- a/tests/test_inflight_stream_reuse.py
+++ b/tests/test_inflight_stream_reuse.py
@@ -235,16 +235,57 @@ assert.strictEqual(merged[merged.length - 1].content, 'First progress.\\n\\nSeco
     assert result.returncode == 0, result.stderr
 
 
+def test_running_reattach_rebuilds_live_assistant_from_last_text_before_activity():
+    """A fast session switch can happen after INFLIGHT.lastAssistantText was
+    updated but before the live assistant message/DOM snapshot caught up.
+
+    Reattach must rebuild the structured `_live` assistant before restoring
+    Activity, otherwise the UI can show only the Activity group until another
+    switch or token causes the text segment to reappear.
+    """
+    assert NODE, "node not on PATH"
+    start = SESSIONS_JS.find("function _messageComparableText")
+    end = SESSIONS_JS.find("// Load older messages", start)
+    assert start != -1 and end != -1
+    helper_src = SESSIONS_JS[start:end]
+    script = f"""
+const assert = require('assert');
+{helper_src}
+
+let base = [{{role:'user', content:'go'}}];
+let inflightState = {{
+  lastAssistantText:'Recovered progress text.',
+  lastReasoningText:'',
+  messages:[{{role:'user', content:'go'}}],
+}};
+assert.strictEqual(_ensureInflightLiveAssistantMessage(inflightState), true);
+assert.strictEqual(inflightState.messages.length, 2);
+assert.strictEqual(inflightState.messages[1]._live, true);
+assert.strictEqual(inflightState.messages[1].content, 'Recovered progress text.');
+assert.strictEqual(_prepareRunningLiveTail(base, inflightState.messages), true);
+base = _dropCurrentTurnAssistantMessages(base);
+const merged = _mergeInflightTailMessages(base, inflightState.messages);
+assert.strictEqual(merged.filter(m => m.role === 'assistant').length, 1);
+assert.strictEqual(merged[merged.length - 1]._live, true);
+assert.strictEqual(merged[merged.length - 1].content, 'Recovered progress text.');
+"""
+    result = subprocess.run([NODE, "-e", script], capture_output=True, text=True, check=False)
+    assert result.returncode == 0, result.stderr
+
+
 def test_load_session_rebuilds_live_tail_before_dropping_stale_dom_snapshot():
     body = _function_body(SESSIONS_JS, "loadSession")
+    ensure_pos = body.find("_ensureInflightLiveAssistantMessage(INFLIGHT[sid]);")
+    inflight_pos = body.find("const inflightMessages=INFLIGHT[sid].messages||[];")
     prepare_pos = body.find("const liveTailPrepared=_prepareRunningLiveTail(S.messages,inflightMessages);")
     drop_dom_pos = body.find("delete INFLIGHT[sid].liveTurnHtml;")
     drop_assistant_pos = body.find("S.messages=_dropCurrentTurnAssistantMessages(S.messages);")
     merge_pos = body.find("S.messages=_mergeInflightTailMessages(S.messages,inflightMessages);")
     restore_pos = body.find("restoreLiveTurnHtmlForSession(sid)")
+    assert ensure_pos != -1 and inflight_pos != -1
     assert prepare_pos != -1 and drop_dom_pos != -1
     assert drop_assistant_pos != -1 and merge_pos != -1 and restore_pos != -1
-    assert prepare_pos < drop_dom_pos < drop_assistant_pos < merge_pos < restore_pos
+    assert ensure_pos < inflight_pos < prepare_pos < drop_dom_pos < drop_assistant_pos < merge_pos < restore_pos
 
 
 def test_load_session_advances_replay_cursor_when_loaded_transcript_has_current_turn_output():

--- a/tests/test_inflight_stream_reuse.py
+++ b/tests/test_inflight_stream_reuse.py
@@ -377,4 +377,29 @@ def test_reconnect_prefers_trimmed_live_message_over_stale_full_assistant_cache(
     assert live_msg_pos < last_text_pos
     assistant_block = body[last_text_pos:body.find("const _lastLiveReasoning", last_text_pos)]
     assert "_liveInflightAssistant.content" in assistant_block
-    assert "lastAssistantText" in assistant_block
+    assert "_fullInflightAssistant" in assistant_block
+    assert "lastAssistantText" in body[live_msg_pos:last_text_pos]
+
+
+def test_reconnect_uses_full_accumulator_when_live_tail_is_segmented():
+    """When reattach projection splits the live assistant into multiple
+    visible process-text segments, reconnect must resume from the full
+    accumulator instead of the last segment.
+
+    Otherwise the next syncInflightAssistantMessage() write truncates
+    lastAssistantText to only the latest visible segment, so earlier process
+    text anchors disappear on the next session switch and Activity groups fall
+    back to the end of the turn.
+    """
+    body = _function_body(MESSAGES_JS, "attachLiveStream")
+    helper_pos = body.find("const _liveInflightAssistantMessages")
+    last_text_pos = body.find("const _lastLiveAssistant")
+    assert helper_pos != -1, (
+        "attachLiveStream() should collect all live assistant segments before "
+        "choosing reconnect text"
+    )
+    assert helper_pos < last_text_pos
+    assistant_block = body[last_text_pos:body.find("const _lastLiveReasoning", last_text_pos)]
+    assert "_liveInflightAssistantMessages.length>1" in assistant_block.replace(" ", "")
+    assert "_fullInflightAssistant" in assistant_block
+    assert "lastAssistantText" in body[helper_pos:last_text_pos]

--- a/tests/test_inflight_stream_reuse.py
+++ b/tests/test_inflight_stream_reuse.py
@@ -273,10 +273,47 @@ assert.strictEqual(merged[merged.length - 1].content, 'Recovered progress text.'
     assert result.returncode == 0, result.stderr
 
 
+def test_running_reattach_projects_live_text_into_activity_burst_segments():
+    """Fallback reattach should rebuild the same process-text/tool-burst
+    timeline even when the DOM snapshot is unavailable.
+    """
+    assert NODE, "node not on PATH"
+    start = SESSIONS_JS.find("function _messageComparableText")
+    end = SESSIONS_JS.find("// Load older messages", start)
+    assert start != -1 and end != -1
+    helper_src = SESSIONS_JS[start:end]
+    script = f"""
+const assert = require('assert');
+{helper_src}
+
+const inflight = {{
+  currentActivityBurstId: 2,
+  activityBurstAnchors: [
+    {{id: 1, textEnd: 'First progress.'.length}},
+    {{id: 2, textEnd: 'First progress.\\n\\nSecond progress.'.length}},
+  ],
+  messages: [
+    {{role:'user', content:'go'}},
+    {{role:'assistant', _live:true, content:'First progress.\\n\\nSecond progress.\\n\\nTail progress.'}},
+  ],
+}};
+const projected = _projectInflightMessagesForActivityBursts(inflight);
+assert.strictEqual(projected.length, 4);
+assert.strictEqual(projected[1].content, 'First progress.');
+assert.strictEqual(projected[1]._activityBurstId, 1);
+assert.strictEqual(projected[2].content, 'Second progress.');
+assert.strictEqual(projected[2]._activityBurstId, 2);
+assert.strictEqual(projected[3].content, 'Tail progress.');
+assert.strictEqual(projected[3]._activityBurstId, 2);
+"""
+    result = subprocess.run([NODE, "-e", script], capture_output=True, text=True, check=False)
+    assert result.returncode == 0, result.stderr
+
+
 def test_load_session_rebuilds_live_tail_before_dropping_stale_dom_snapshot():
     body = _function_body(SESSIONS_JS, "loadSession")
     ensure_pos = body.find("_ensureInflightLiveAssistantMessage(INFLIGHT[sid]);")
-    inflight_pos = body.find("const inflightMessages=INFLIGHT[sid].messages||[];")
+    inflight_pos = body.find("const inflightMessages=_projectInflightMessagesForActivityBursts(INFLIGHT[sid]);")
     prepare_pos = body.find("const liveTailPrepared=_prepareRunningLiveTail(S.messages,inflightMessages);")
     drop_dom_pos = body.find("delete INFLIGHT[sid].liveTurnHtml;")
     drop_assistant_pos = body.find("S.messages=_dropCurrentTurnAssistantMessages(S.messages);")

--- a/tests/test_inflight_stream_reuse.py
+++ b/tests/test_inflight_stream_reuse.py
@@ -161,7 +161,7 @@ def test_load_session_reattaches_when_inflight_is_in_memory_and_marked_for_reatt
     body = _function_body(SESSIONS_JS, "loadSession")
     inflight_idx = body.find("if(INFLIGHT[sid]){")
     assert inflight_idx >= 0, "INFLIGHT branch not found in loadSession"
-    inflight_block = body[inflight_idx : inflight_idx + 2400]
+    inflight_block = body[inflight_idx : inflight_idx + 3200]
     assert "INFLIGHT[sid].reattach" in inflight_block, (
         "loadSession()'s INFLIGHT branch must gate the SSE reattach on the "
         "reattach flag so closeLiveStream()'s marking flows through"
@@ -360,6 +360,30 @@ def test_load_session_rebuilds_live_tail_before_dropping_stale_dom_snapshot():
     assert prepare_pos != -1 and drop_dom_pos != -1
     assert drop_assistant_pos != -1 and merge_pos != -1 and restore_pos != -1
     assert ensure_pos < inflight_pos < prepare_pos < drop_dom_pos < drop_assistant_pos < merge_pos < restore_pos
+
+
+def test_load_session_prefers_structured_inflight_state_over_live_turn_snapshot():
+    """Structured INFLIGHT state is authoritative during reattach.
+
+    The memory-only liveTurnHtml snapshot can be stale across session switches.
+    If loadSession restores that DOM after renderMessages() rebuilt the
+    per-burst live tail, old snapshots can alternately erase progress text and
+    leave Activity groups piled at the bottom of the turn.
+    """
+    body = _function_body(SESSIONS_JS, "loadSession")
+    structured_pos = body.find("const hasStructuredLiveState=!!(INFLIGHT[sid]&&(")
+    restore_pos = body.find("restoreLiveTurnHtmlForSession(sid)")
+    fallback_pos = body.find("if(!restoredLiveTurn){", restore_pos)
+    assert structured_pos != -1, "loadSession must compute structured live-state presence"
+    assert restore_pos != -1, "loadSession must still retain DOM snapshot fallback"
+    assert fallback_pos != -1
+    assert structured_pos < restore_pos < fallback_pos
+    guard_block = body[structured_pos:fallback_pos]
+    assert "lastAssistantText" in guard_block
+    assert "lastReasoningText" in guard_block
+    assert "activityBurstAnchors" in guard_block
+    assert "toolCalls" in guard_block
+    assert "!hasStructuredLiveState&&" in guard_block.replace(" ", "")
 
 
 def test_load_session_does_not_advance_replay_cursor_from_session_journal_summary():

--- a/tests/test_inflight_stream_reuse.py
+++ b/tests/test_inflight_stream_reuse.py
@@ -119,7 +119,8 @@ def test_close_live_stream_marks_inflight_for_reattach_on_return():
         "SSE when the user switches back to a still-streaming session"
     )
     assert re.search(r"INFLIGHT\[\w+\]\s*&&\s*\(?INFLIGHT\[\w+\]\.reattach\s*=\s*true", body) \
-           or re.search(r"if\s*\(\s*INFLIGHT\[\w+\]\s*\)\s*INFLIGHT\[\w+\]\.reattach\s*=\s*true", body), (
+           or re.search(r"if\s*\(\s*INFLIGHT\[\w+\]\s*\)\s*INFLIGHT\[\w+\]\.reattach\s*=\s*true", body) \
+           or re.search(r"if\s*\(\s*INFLIGHT\[\w+\]\s*\)\s*\{[^}]*INFLIGHT\[\w+\]\.reattach\s*=\s*true", body, re.DOTALL), (
         "closeLiveStream() must set INFLIGHT[sessionId].reattach = true "
         "(guarded by an existence check) so loadSession()'s reattach branch fires"
     )

--- a/tests/test_issue1857_usage_overwrite.py
+++ b/tests/test_issue1857_usage_overwrite.py
@@ -186,7 +186,7 @@ def test_stream_completion_overwrites_session_usage_with_latest_turn(cleanup_tes
         and payload["usage"]["estimated_cost"] == 0.067
         and payload["usage"]["cache_read_tokens"] == 9000
         and payload["usage"]["cache_write_tokens"] == 1000
-        for event, payload in list(fake_queue.queue)
+        for event, payload, *_ in list(fake_queue.queue)
     )
     assert saved_snapshots[-1]["input_tokens"] == 123
     assert saved_snapshots[-1]["output_tokens"] == 45

--- a/tests/test_issue2655_frontend.py
+++ b/tests/test_issue2655_frontend.py
@@ -24,7 +24,10 @@ def test_workspace_artifacts_tab_collects_session_files_and_previews_them():
     assert "panel.dataset.activeTab = _workspacePanelActiveTab" in WORKSPACE_JS
     assert "renderSessionArtifacts();" in SESSIONS_JS
     assert "typeof scheduleRenderSessionArtifacts==='function'" in MESSAGES_JS
-    assert "S.toolCalls=d.session.tool_calls.map" in MESSAGES_JS
+    assert (
+        "S.toolCalls=_mergeSettledToolCallsWithLiveMetadata(d.session.tool_calls)" in MESSAGES_JS
+        or "S.toolCalls=d.session.tool_calls.map" in MESSAGES_JS
+    )
     assert ".workspace-artifact-item" in STYLE_CSS
 
 

--- a/tests/test_issue2713_streaming_segment_flush.py
+++ b/tests/test_issue2713_streaming_segment_flush.py
@@ -177,6 +177,32 @@ class TestInterimAssistantHandlerFlush:
             "_resetAssistantSegment in the interim_assistant handler"
         )
 
+    def test_already_streamed_interim_handler_flushes_before_reset(self):
+        """already_streamed interim events are still visible-progress boundaries.
+
+        The visible text already arrived through token events, so the client
+        must not append it again. It must still flush any pending token render
+        before resetting the segment; otherwise a fast tool boundary can orphan
+        the text until a later render or session switch.
+        """
+        src = read("static/messages.js")
+        fn = _extract_handler(src, "interim_assistant")
+        branch_start = fn.index("if(alreadyStreamed)")
+        branch = fn[branch_start : fn.index("assistantText +=", branch_start)]
+        assert "ensureAssistantRow(true)" in branch, (
+            "already_streamed interim boundaries must materialize the current "
+            "token segment before reset"
+        )
+        assert "_flushPendingSegmentRender({force:true})" in branch, (
+            "already_streamed interim boundaries must flush pending token DOM "
+            "before reset"
+        )
+        flush_pos = branch.index("_flushPendingSegmentRender({force:true})")
+        reset_pos = branch.index("_resetAssistantSegment()")
+        assert flush_pos < reset_pos, (
+            "already_streamed interim flush must happen before segment reset"
+        )
+
     def test_interim_handler_creates_visible_segment_before_forced_flush(self):
         src = read("static/messages.js")
         fn = _extract_handler(src, "interim_assistant")

--- a/tests/test_issue734_message_windowing.py
+++ b/tests/test_issue734_message_windowing.py
@@ -26,7 +26,10 @@ def test_load_earlier_expands_local_window_before_server_pagination_and_preserve
 def test_windowed_render_keeps_streaming_and_tool_activity_anchored_to_rendered_messages():
     assert "_scrollAfterMessageRender(preserveScroll, scrollSnapshot);" in UI_JS
     assert "const assistantIdxs=[...assistantSegments.keys()].sort((a,b)=>a-b);" in UI_JS
-    assert "if(aIdx<assistantIdxs[0]) continue;" in UI_JS
+    assert (
+        "if(aIdx<assistantIdxs[0]) continue;" in UI_JS
+        or "if(aIdx<assistantIdxs[0]) return null;" in UI_JS
+    )
     assert "const renderedAssistantIdxs=[...assistantSegments.keys()].sort((a,b)=>a-b);" in UI_JS
     assert "const seg=assistantSegments.get(mi);" in UI_JS
 

--- a/tests/test_issue_progress_echo_dedupe.py
+++ b/tests/test_issue_progress_echo_dedupe.py
@@ -8,6 +8,12 @@ from unittest import mock
 _MISSING = object()
 
 
+def _event_parts(item):
+    if isinstance(item, tuple) and len(item) >= 2:
+        return item[0], item[1]
+    return "message", item
+
+
 def test_visible_progress_token_reasoning_and_interim_are_deduped(cleanup_test_sessions):
     """Progress text can arrive through three Hermes callbacks; WebUI must show it once.
 
@@ -168,7 +174,7 @@ def test_visible_progress_token_reasoning_and_interim_are_deduped(cleanup_test_s
             else:
                 sys.modules[k] = cast(types.ModuleType, prev)
 
-    events = list(fake_queue.queue)
+    events = [_event_parts(item) for item in list(fake_queue.queue)]
     assert [(event, payload) for event, payload in events if event == "token"] == [
         ("token", {"text": progress})
     ]

--- a/tests/test_live_activity_timeline.py
+++ b/tests/test_live_activity_timeline.py
@@ -13,28 +13,34 @@ UI_JS = (REPO / "static" / "ui.js").read_text(encoding="utf-8")
 STYLE_CSS = (REPO / "static" / "style.css").read_text(encoding="utf-8")
 
 
-def test_live_activity_group_has_observable_baseline_events():
+def test_run_activity_group_has_observable_baseline_events():
     assert "function _ensureLiveActivityBaseline(group)" in UI_JS
+    assert "function ensureRunActivityGroup(inner, opts)" in UI_JS
+    assert "data-run-activity-group" in UI_JS
     assert "Run started" in UI_JS
     assert "Observable activity will appear here as the agent works." in UI_JS
     assert "Model: ${modelLabel}" in UI_JS
     assert "_ensureLiveActivityBaseline(group);" in UI_JS
+    assert "ensureActivityGroup(inner, opts)" in UI_JS
 
 
-def test_empty_thinking_placeholder_becomes_status_row_not_raw_thinking_card():
-    assert "data-activity-event-id=\"thinking-placeholder\"" in UI_JS
-    assert "Waiting on model" in UI_JS
-    assert "No tool activity has been reported yet." in UI_JS
-    assert "Waiting on tool result" in UI_JS
+def test_per_segment_tool_activity_does_not_include_run_metadata_rows():
+    activity_fn = UI_JS.split("function ensureActivityGroup(inner, opts)", 1)[1].split("function ensureRunActivityGroup", 1)[0]
+    tool_fn = UI_JS.split("function appendLiveToolCard(tc)", 1)[1].split("function clearLiveToolCards", 1)[0]
+    assert "_ensureLiveActivityBaseline" not in activity_fn
+    assert "_appendActivityEvent(group" not in tool_fn
+    assert "Tool finished: ${toolName}" not in UI_JS
+    assert "Running tool: ${toolName}" not in UI_JS
     assert "_thinkingActivityNode(thinkingText, false)" in UI_JS
 
 
-def test_tool_events_update_activity_timeline_and_summary():
-    assert "Tool finished: ${toolName}" in UI_JS
-    assert "Running tool: ${toolName}" in UI_JS
+def test_tool_activity_uses_tool_cards_and_run_activity_owns_timer():
+    assert "buildToolCard(tc)" in UI_JS
+    assert "tool-card-duration" in UI_JS
     assert "No recent activity for ${_formatActiveElapsedTimer(idleAge)}" in UI_JS
     assert "Activity · Running" in UI_JS
     assert "Working for ${label}" in UI_JS
+    assert "_isActivityTimerGroup(group)" in UI_JS
 
 
 def test_activity_status_rows_have_quiet_metadata_styling():

--- a/tests/test_live_activity_timeline.py
+++ b/tests/test_live_activity_timeline.py
@@ -98,8 +98,10 @@ def test_done_handler_preserves_live_tool_burst_metadata_for_settled_render():
 
 
 def test_message_tool_metadata_path_keeps_live_burst_metadata_available():
-    assert "hasMessageToolMetadata?[]" not in MESSAGES_JS
+    assert "S._settledLiveToolMetadata=S.toolCalls.map" in MESSAGES_JS
+    assert "S.toolCalls=hasMessageToolMetadata?[]:S.toolCalls.map" in MESSAGES_JS
     render_fn = UI_JS.split("const derived=[];", 1)[1].split("if(derived.length) S.toolCalls=derived;", 1)[0]
+    assert "S._settledLiveToolMetadata" in render_fn
     assert "liveToolMetadata" in render_fn
     assert "copyLiveToolMetadata" in render_fn
     assert "activityBurstId" in render_fn
@@ -128,7 +130,7 @@ assert.strictEqual(merged[0].started_at, 123);
 def test_settled_activity_render_treats_burst_zero_as_unanchored_activity():
     render_fn = UI_JS.split("if(!S.busy){", 1)[1].split("// Render per-turn duration", 1)[0]
     assert "String(burstId)!=='0'" in render_fn
-    assert "return assistantSegments.get(assistantIdxs[0]);" in render_fn
+    assert "if(aIdx<assistantIdxs[0]) return null;" in render_fn
     assert "String(tc.activityBurstId)!=='0'" in render_fn
 
 

--- a/tests/test_live_activity_timeline.py
+++ b/tests/test_live_activity_timeline.py
@@ -93,6 +93,14 @@ def test_record_activity_boundary_updates_segment_burst_id_to_post_increment():
     assert "if(assistantRow) assistantRow.setAttribute" in boundary_fn
 
 
+def test_record_activity_boundary_does_not_create_empty_duplicate_burst():
+    boundary_fn = MESSAGES_JS.split("function recordActivityBoundary()", 1)[1].split("function ensureAssistantRow", 1)[0]
+    assert "const lastTextEnd=inflight.activityBurstAnchors.reduce" in boundary_fn
+    assert "if(textEnd<=lastTextEnd)" in boundary_fn
+    assert "_currentActivityBurstId+=1;" in boundary_fn
+    assert boundary_fn.find("if(textEnd<=lastTextEnd)") < boundary_fn.find("_currentActivityBurstId+=1;")
+
+
 def test_activity_status_rows_have_quiet_metadata_styling():
     assert ".agent-activity-status{" in STYLE_CSS
     assert "grid-template-columns:18px minmax(0,1fr) auto" in STYLE_CSS

--- a/tests/test_live_activity_timeline.py
+++ b/tests/test_live_activity_timeline.py
@@ -187,6 +187,26 @@ def test_record_activity_boundary_does_not_create_empty_duplicate_burst():
     assert boundary_fn.find("if(textEnd<=lastTextEnd)") < boundary_fn.find("_currentActivityBurstId+=1;")
 
 
+def test_inactive_interim_assistant_still_records_activity_boundary():
+    """A session can receive SSE events while the pane is being switched away.
+
+    Token/tool state is still persisted for reattach in that window, so interim
+    progress boundaries must also be persisted before the inactive-pane return.
+    Otherwise later tool calls keep an activityBurstId with no text anchor and
+    Activity groups pile up at the tail after switching back.
+    """
+    wire_fn = MESSAGES_JS.split("function _wireSSE(source)", 1)[1].split("source.addEventListener('reasoning'", 1)[0]
+    inactive_returns = [
+        idx for idx in range(len(wire_fn))
+        if wire_fn.startswith("if(!S.session||S.session.session_id!==activeSid){", idx)
+    ]
+    assert len(inactive_returns) >= 2
+    for idx in inactive_returns[:2]:
+        branch = wire_fn[idx:wire_fn.find("}", idx) + 1]
+        assert "recordActivityBoundary();" in branch
+        assert "_resetAssistantSegment();" in branch
+
+
 def test_activity_status_rows_have_quiet_metadata_styling():
     assert ".agent-activity-status{" in STYLE_CSS
     assert "grid-template-columns:18px minmax(0,1fr) auto" in STYLE_CSS

--- a/tests/test_live_activity_timeline.py
+++ b/tests/test_live_activity_timeline.py
@@ -77,6 +77,22 @@ def test_done_handler_preserves_live_tool_burst_metadata_for_settled_render():
     assert "S.toolCalls=_mergeSettledToolCallsWithLiveMetadata(session.tool_calls||[]);" in MESSAGES_JS
 
 
+def test_record_activity_boundary_updates_segment_burst_id_to_post_increment():
+    """recordActivityBoundary must re-stamp the current assistantRow DOM element with
+    the post-increment burst id so that subsequent tool events (which read the same
+    _currentActivityBurstId) find the matching [data-activity-burst-id] anchor.
+
+    Without this update the segment keeps id=N while tools get id=N+1, causing
+    appendLiveToolCard to miss the anchor and Activity groups to pile up after all
+    text instead of interleaving with their source segments.
+    """
+    boundary_fn = MESSAGES_JS.split("function recordActivityBoundary()", 1)[1].split("function ensureAssistantRow", 1)[0]
+    # Must update the DOM attribute after incrementing the counter
+    assert "assistantRow.setAttribute('data-activity-burst-id',String(_currentActivityBurstId))" in boundary_fn
+    # The update must be guarded so it only fires when assistantRow exists
+    assert "if(assistantRow) assistantRow.setAttribute" in boundary_fn
+
+
 def test_activity_status_rows_have_quiet_metadata_styling():
     assert ".agent-activity-status{" in STYLE_CSS
     assert "grid-template-columns:18px minmax(0,1fr) auto" in STYLE_CSS

--- a/tests/test_live_activity_timeline.py
+++ b/tests/test_live_activity_timeline.py
@@ -6,12 +6,32 @@ family.
 """
 
 import pathlib
+import shutil
+import subprocess
 
 
 REPO = pathlib.Path(__file__).parent.parent
 UI_JS = (REPO / "static" / "ui.js").read_text(encoding="utf-8")
 MESSAGES_JS = (REPO / "static" / "messages.js").read_text(encoding="utf-8")
 STYLE_CSS = (REPO / "static" / "style.css").read_text(encoding="utf-8")
+NODE = shutil.which("node")
+
+
+def _function_source(src, name):
+    marker = f"function {name}("
+    start = src.find(marker)
+    assert start != -1
+    brace = src.find("{", start)
+    depth = 0
+    for idx in range(brace, len(src)):
+        ch = src[idx]
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return src[start:idx + 1]
+    raise AssertionError(f"function {name} did not close")
 
 
 def test_run_activity_group_has_observable_baseline_events():
@@ -75,6 +95,41 @@ def test_done_handler_preserves_live_tool_burst_metadata_for_settled_render():
     assert "activityBurstId" in MESSAGES_JS
     assert "S.toolCalls=_mergeSettledToolCallsWithLiveMetadata(d.session.tool_calls);" in MESSAGES_JS
     assert "S.toolCalls=_mergeSettledToolCallsWithLiveMetadata(session.tool_calls||[]);" in MESSAGES_JS
+
+
+def test_message_tool_metadata_path_keeps_live_burst_metadata_available():
+    assert "hasMessageToolMetadata?[]" not in MESSAGES_JS
+    render_fn = UI_JS.split("const derived=[];", 1)[1].split("if(derived.length) S.toolCalls=derived;", 1)[0]
+    assert "liveToolMetadata" in render_fn
+    assert "copyLiveToolMetadata" in render_fn
+    assert "activityBurstId" in render_fn
+
+
+def test_settled_tool_metadata_merge_replaces_null_activity_metadata():
+    assert NODE, "node not on PATH"
+    fn = _function_source(MESSAGES_JS, "_mergeSettledToolCallsWithLiveMetadata")
+    script = f"""
+const assert = require('assert');
+const S = {{
+  toolCalls: [{{tid:'tool-1', name:'read_file', activityBurstId:2, duration:1.25, started_at:123}}]
+}};
+{fn}
+const merged = _mergeSettledToolCallsWithLiveMetadata([
+  {{tid:'tool-1', name:'read_file', activityBurstId:null, duration:null, started_at:null}}
+]);
+assert.strictEqual(merged[0].activityBurstId, 2);
+assert.strictEqual(merged[0].duration, 1.25);
+assert.strictEqual(merged[0].started_at, 123);
+"""
+    result = subprocess.run([NODE, "-e", script], capture_output=True, text=True, check=False)
+    assert result.returncode == 0, result.stderr
+
+
+def test_settled_activity_render_treats_burst_zero_as_unanchored_activity():
+    render_fn = UI_JS.split("if(!S.busy){", 1)[1].split("// Render per-turn duration", 1)[0]
+    assert "String(burstId)!=='0'" in render_fn
+    assert "return assistantSegments.get(assistantIdxs[0]);" in render_fn
+    assert "String(tc.activityBurstId)!=='0'" in render_fn
 
 
 def test_record_activity_boundary_updates_segment_burst_id_to_post_increment():

--- a/tests/test_live_activity_timeline.py
+++ b/tests/test_live_activity_timeline.py
@@ -207,6 +207,51 @@ def test_inactive_interim_assistant_still_records_activity_boundary():
         assert "_resetAssistantSegment();" in branch
 
 
+def test_reattach_segment_start_aligns_with_last_burst_anchor():
+    """Simulate the reattach segmentStart initializer with multiple anchors.
+
+    The initializer must clamp to the actual assistantText length and ignore
+    stale anchors past the end of the text, otherwise displayText slicing in
+    _doRender would produce empty output for the tail segment.
+    """
+    assert NODE, "node not on PATH"
+    body = MESSAGES_JS.split("function attachLiveStream(", 1)[1]
+    seg_block_start = body.find("let segmentStart=(()=>{")
+    assert seg_block_start != -1, "expected reconnect-aware segmentStart IIFE"
+    seg_block_end = body.find("})();", seg_block_start) + len("})();")
+    initializer = body[seg_block_start:seg_block_end] + ";"
+    # Wrap as a callable with explicit reconnecting + INFLIGHT/activeSid stand-ins.
+    script = f"""
+const assert = require('assert');
+function computeStart(reconnecting, inflight, assistantText) {{
+  const INFLIGHT = {{ 'sid': inflight }};
+  const activeSid = 'sid';
+  {initializer}
+  return segmentStart;
+}}
+// No anchors -> 0
+assert.strictEqual(computeStart(true, {{activityBurstAnchors:[]}}, 'hello world'), 0);
+// Single anchor inside text length -> anchor textEnd
+assert.strictEqual(computeStart(true, {{activityBurstAnchors:[{{id:1,textEnd:5}}]}}, 'hello world'), 5);
+// Multiple anchors -> picks max textEnd within text length
+assert.strictEqual(computeStart(true, {{activityBurstAnchors:[
+  {{id:1,textEnd:5}}, {{id:2,textEnd:11}}, {{id:3,textEnd:7}}
+]}}, 'hello world'), 11);
+// Anchor textEnd past assistantText length -> ignored
+assert.strictEqual(computeStart(true, {{activityBurstAnchors:[
+  {{id:1,textEnd:5}}, {{id:2,textEnd:99}}
+]}}, 'hello world'), 5);
+// Not reconnecting -> always 0
+assert.strictEqual(computeStart(false, {{activityBurstAnchors:[
+  {{id:1,textEnd:5}}, {{id:2,textEnd:11}}
+]}}, 'hello world'), 0);
+// Missing inflight entry -> 0
+assert.strictEqual(computeStart(true, undefined, 'hello'), 0);
+"""
+    result = subprocess.run([NODE, "-e", script], capture_output=True, text=True, check=False)
+    assert result.returncode == 0, result.stderr
+
+
 def test_activity_status_rows_have_quiet_metadata_styling():
     assert ".agent-activity-status{" in STYLE_CSS
     assert "grid-template-columns:18px minmax(0,1fr) auto" in STYLE_CSS

--- a/tests/test_live_activity_timeline.py
+++ b/tests/test_live_activity_timeline.py
@@ -107,6 +107,35 @@ def test_message_tool_metadata_path_keeps_live_burst_metadata_available():
     assert "activityBurstId" in render_fn
 
 
+def test_message_tool_metadata_empty_assistant_tools_reuse_previous_visible_anchor():
+    assert "function _assistantToolAnchorIdxForMessage(messages, rawIdx)" in UI_JS
+    render_fn = UI_JS.split("const derived=[];", 1)[1].split("if(derived.length) S.toolCalls=derived;", 1)[0]
+    assert "const assistantToolAnchorIdx=_assistantToolAnchorIdxForMessage(S.messages,rawIdx);" in render_fn
+    assert "assistant_msg_idx:assistantToolAnchorIdx" in render_fn
+
+    assert NODE, "node not on PATH"
+    has_visible_fn = _function_source(UI_JS, "_assistantMessageHasVisibleContent")
+    anchor_fn = _function_source(UI_JS, "_assistantToolAnchorIdxForMessage")
+    script = f"""
+const assert = require('assert');
+{has_visible_fn}
+{anchor_fn}
+const messages = [
+  {{role:'assistant', content:'visible progress'}},
+  {{role:'assistant', content:'', tool_calls:[{{id:'call-1'}}]}},
+  {{role:'assistant', content:'', tool_calls:[{{id:'call-2'}}]}},
+  {{role:'assistant', content:'next progress', tool_calls:[{{id:'call-3'}}]}},
+  {{role:'assistant', content:[{{type:'tool_use', id:'call-4', name:'read_file'}}]}},
+];
+assert.strictEqual(_assistantToolAnchorIdxForMessage(messages, 1), 0);
+assert.strictEqual(_assistantToolAnchorIdxForMessage(messages, 2), 0);
+assert.strictEqual(_assistantToolAnchorIdxForMessage(messages, 3), 3);
+assert.strictEqual(_assistantToolAnchorIdxForMessage(messages, 4), 3);
+"""
+    result = subprocess.run([NODE, "-e", script], capture_output=True, text=True, check=False)
+    assert result.returncode == 0, result.stderr
+
+
 def test_settled_tool_metadata_merge_replaces_null_activity_metadata():
     assert NODE, "node not on PATH"
     fn = _function_source(MESSAGES_JS, "_mergeSettledToolCallsWithLiveMetadata")

--- a/tests/test_live_activity_timeline.py
+++ b/tests/test_live_activity_timeline.py
@@ -10,6 +10,7 @@ import pathlib
 
 REPO = pathlib.Path(__file__).parent.parent
 UI_JS = (REPO / "static" / "ui.js").read_text(encoding="utf-8")
+MESSAGES_JS = (REPO / "static" / "messages.js").read_text(encoding="utf-8")
 STYLE_CSS = (REPO / "static" / "style.css").read_text(encoding="utf-8")
 
 
@@ -41,6 +42,26 @@ def test_tool_activity_uses_tool_cards_and_run_activity_owns_timer():
     assert "Activity · Running" in UI_JS
     assert "Working for ${label}" in UI_JS
     assert "_isActivityTimerGroup(group)" in UI_JS
+    assert "opts.turnDuration" in UI_JS
+    assert "data-turn-duration" in UI_JS
+    assert "durationText?`Done in ${durationText}`" in UI_JS
+
+
+def test_settled_activity_render_keeps_tools_bound_to_progress_bursts():
+    render_fn = UI_JS.split("if(!S.busy){", 1)[1].split("// Render per-turn duration", 1)[0]
+    assert "_assistantAnchorForActivity" in render_fn
+    assert "const byActivity = new Map();" in render_fn
+    assert "tc.activityBurstId" in render_fn
+    assert "`burst:${burstId}`" in render_fn
+    assert "ensureActivityGroup(anchorParent,{collapsed:true,anchor:insertAfterNode,activityKey,burstId})" in render_fn
+    assert "group.setAttribute('data-turn-duration'" not in render_fn
+
+
+def test_done_handler_preserves_live_tool_burst_metadata_for_settled_render():
+    assert "function _mergeSettledToolCallsWithLiveMetadata(rawCalls)" in MESSAGES_JS
+    assert "activityBurstId" in MESSAGES_JS
+    assert "S.toolCalls=_mergeSettledToolCallsWithLiveMetadata(d.session.tool_calls);" in MESSAGES_JS
+    assert "S.toolCalls=_mergeSettledToolCallsWithLiveMetadata(session.tool_calls||[]);" in MESSAGES_JS
 
 
 def test_activity_status_rows_have_quiet_metadata_styling():

--- a/tests/test_live_activity_timeline.py
+++ b/tests/test_live_activity_timeline.py
@@ -207,6 +207,23 @@ def test_inactive_interim_assistant_still_records_activity_boundary():
         assert "_resetAssistantSegment();" in branch
 
 
+def test_tool_event_flushes_pending_text_before_inserting_activity():
+    """A tool card must not appear before the text segment it is anchored to.
+
+    Token rendering is throttled through rAF.  On mobile/slow clients a `tool`
+    event can arrive while the current assistantRow exists but its pending text
+    has not been written into `.msg-body` yet.  If appendLiveToolCard() runs
+    first, the Activity group appears, then the delayed flush fills the empty
+    segment above it a frame later, which looks like process text was inserted
+    before an already-visible Activity row.
+    """
+    tool_handler = MESSAGES_JS.split("source.addEventListener('tool',e=>{", 1)[1].split("source.addEventListener('tool_complete'", 1)[0]
+    flush_pos = tool_handler.find("_flushPendingSegmentRender({force:true});")
+    append_pos = tool_handler.find("appendLiveToolCard(tc);")
+    assert flush_pos != -1 and append_pos != -1
+    assert flush_pos < append_pos
+
+
 def test_reattach_segment_start_aligns_with_last_burst_anchor():
     """Simulate the reattach segmentStart initializer with multiple anchors.
 

--- a/tests/test_live_activity_timeline.py
+++ b/tests/test_live_activity_timeline.py
@@ -38,13 +38,16 @@ def test_per_segment_tool_activity_does_not_include_run_metadata_rows():
 def test_tool_activity_uses_tool_cards_and_run_activity_owns_timer():
     assert "buildToolCard(tc)" in UI_JS
     assert "tool-card-duration" in UI_JS
-    assert "No recent activity for ${_formatActiveElapsedTimer(idleAge)}" in UI_JS
     assert "Activity · Running" in UI_JS
     assert "Working for ${label}" in UI_JS
     assert "_isActivityTimerGroup(group)" in UI_JS
     assert "opts.turnDuration" in UI_JS
     assert "data-turn-duration" in UI_JS
     assert "durationText?`Done in ${durationText}`" in UI_JS
+    assert "return !!(group&&group.getAttribute('data-run-activity-group')==='1');" in UI_JS
+    live_summary_fn = UI_JS.split("function _syncToolCallGroupSummary(group)", 1)[1].split("function _activityProgressLabelForToolName", 1)[0]
+    assert "group.removeAttribute('data-active-turn-elapsed');" in live_summary_fn
+    assert "durationEl.textContent='';" in live_summary_fn
 
 
 def test_settled_activity_render_keeps_tools_bound_to_progress_bursts():
@@ -55,6 +58,16 @@ def test_settled_activity_render_keeps_tools_bound_to_progress_bursts():
     assert "`burst:${burstId}`" in render_fn
     assert "ensureActivityGroup(anchorParent,{collapsed:true,anchor:insertAfterNode,activityKey,burstId})" in render_fn
     assert "group.setAttribute('data-turn-duration'" not in render_fn
+
+
+def test_reattach_normalizes_live_activity_group_placement_by_burst_anchor():
+    assert "function normalizeLiveActivityGroupPlacement(turn)" in UI_JS
+    assert "normalizeLiveActivityGroupPlacement(restored)" in UI_JS
+    activity_fn = UI_JS.split("function ensureActivityGroup(inner, opts)", 1)[1].split("function normalizeLiveActivityGroupPlacement", 1)[0]
+    assert "anchor.insertAdjacentElement('afterend',group);" in activity_fn
+    normalize_fn = UI_JS.split("function normalizeLiveActivityGroupPlacement(turn)", 1)[1].split("function ensureRunActivityGroup", 1)[0]
+    assert '.tool-call-group[data-live-tool-call-group="1"][data-activity-burst-id]' in normalize_fn
+    assert '[data-live-assistant="1"][data-activity-burst-id="${CSS.escape(burstId)}"]' in normalize_fn
 
 
 def test_done_handler_preserves_live_tool_burst_metadata_for_settled_render():

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -428,7 +428,7 @@ def test_loadSession_inflight_restores_live_tool_cards(cleanup_test_sessions):
     # INFLIGHT branch must call appendLiveToolCard
     inflight_idx = src.find("if(INFLIGHT[sid]){")
     assert inflight_idx >= 0, "INFLIGHT branch not found in loadSession"
-    inflight_block = src[inflight_idx:inflight_idx+1600]
+    inflight_block = src[inflight_idx:inflight_idx+2600]
     assert "appendLiveToolCard" in inflight_block,         "loadSession INFLIGHT branch must restore live tool cards via appendLiveToolCard"
     assert "clearLiveToolCards" in inflight_block,         "loadSession INFLIGHT branch must clear old live cards before restoring"
 
@@ -618,7 +618,7 @@ def test_loadSession_inflight_sets_busy_before_renderMessages(cleanup_test_sessi
     src = (REPO_ROOT / "static/sessions.js").read_text()
     inflight_idx = src.find("if(INFLIGHT[sid]){")
     assert inflight_idx >= 0, "INFLIGHT branch not found in loadSession"
-    inflight_block = src[inflight_idx:inflight_idx+1600]
+    inflight_block = src[inflight_idx:inflight_idx+2600]
     busy_pos = inflight_block.find("S.busy=true;")
     render_pos = inflight_block.find("renderMessages();")
     assert busy_pos >= 0, "loadSession INFLIGHT branch must set S.busy=true"
@@ -697,7 +697,7 @@ def test_loadSession_inflight_sets_active_stream_before_replaying_live_tool_card
     src = (REPO_ROOT / "static/sessions.js").read_text()
     inflight_idx = src.find("if(INFLIGHT[sid]){")
     assert inflight_idx >= 0, "INFLIGHT branch not found in loadSession"
-    inflight_block = src[inflight_idx:inflight_idx+1600]
+    inflight_block = src[inflight_idx:inflight_idx+2600]
     active_pos = inflight_block.find("S.activeStreamId=activeStreamId;")
     replay_pos = inflight_block.find("appendLiveToolCard(tc);")
     attach_pos = inflight_block.find("attachLiveStream(sid, activeStreamId")
@@ -765,9 +765,12 @@ def test_messages_js_supports_live_reasoning_and_tool_completion(cleanup_test_se
     # On initial connect it defaults to ''; on reconnect it restores from
     # INFLIGHT so the already-rendered content survives the session switch.
     assert ("let reasoningText=''" in src
-            or "let reasoningText = _lastLiveAssistant" in src), \
+            or "let reasoningText = _lastLiveAssistant" in src
+            or "let reasoningText=_lastLiveReasoning" in src), \
         "messages.js must track streamed reasoning text separately from assistant text"
-    assert ("let liveReasoningText=''" in src or "let liveReasoningText = reasoningText" in src), \
+    assert ("let liveReasoningText=''" in src
+            or "let liveReasoningText = reasoningText" in src
+            or "let liveReasoningText=_lastLiveReasoning" in src), \
         "messages.js must track the currently active reasoning segment separately from cumulative reasoning"
     assert "source.addEventListener('reasoning'" in src or 'source.addEventListener("reasoning"' in src, \
         "messages.js must listen for live reasoning SSE events"

--- a/tests/test_run_journal_frontend_static.py
+++ b/tests/test_run_journal_frontend_static.py
@@ -11,8 +11,16 @@ def test_reattach_path_uses_replay_when_status_reports_journal():
 
     assert "st.replay_available" in block
     assert "replayOnly=true" in block
-    assert "replayOnly?_runJournalReplayParams():''" in block
+    assert "(reconnecting||replayOnly)?_runJournalReplayParams():''" in block
     assert "_clearOwnerInflightState()" in block
+
+
+def test_active_reattach_also_requests_journal_replay_gap():
+    reconnect_pos = MESSAGES_SRC.index("if(st.active){")
+    block = MESSAGES_SRC[reconnect_pos : reconnect_pos + 500]
+
+    assert "_runJournalReplayParams()" in block
+    assert "lastRunJournalSeq" in MESSAGES_SRC
 
 
 def test_error_reconnect_path_can_restore_from_journal():
@@ -26,15 +34,19 @@ def test_error_reconnect_path_can_restore_from_journal():
 
 
 def test_frontend_replay_cursor_uses_eventsource_last_event_id():
+    parser_pos = MESSAGES_SRC.index("function _runJournalSeqFromEvent")
+    parser_block = MESSAGES_SRC[parser_pos : parser_pos + 500]
     cursor_pos = MESSAGES_SRC.index("function _rememberRunJournalCursor")
     block = MESSAGES_SRC[cursor_pos : cursor_pos + 1000]
 
-    assert "e.lastEventId" in block
-    assert "lastIndexOf(':')" in block
+    assert "e.lastEventId" in parser_block
+    assert "lastIndexOf(':')" in parser_block
     assert "_lastRunJournalSeq=seq" in block
+    assert "lastRunJournalSeq" in block
     assert "source.addEventListener(_runJournalEventName,_rememberRunJournalCursor)" in MESSAGES_SRC
     assert "after_seq=${encodeURIComponent(String(_runJournalReplayAfterSeq()))}" in MESSAGES_SRC
     assert "after_seq=0" not in MESSAGES_SRC
+    assert "assistantSeq" not in MESSAGES_SRC
 
 
 def test_replayed_long_task_events_enter_the_same_live_timeline_handlers():

--- a/tests/test_run_journal_routes.py
+++ b/tests/test_run_journal_routes.py
@@ -100,6 +100,54 @@ def test_active_stream_replay_uses_snapshot_cutoff_and_skips_duplicate_queue_ite
     assert stream.unsubscribed is True
 
 
+def test_active_stream_replay_without_journal_keeps_buffered_queue_items(monkeypatch):
+    import api.routes as routes
+
+    class FakeStream:
+        def __init__(self):
+            self.q = queue.Queue()
+            self.q.put_nowait(("token", {"text": "buffered"}, "missing_journal_run:1"))
+            self.q.put_nowait(("stream_end", {}, "missing_journal_run:2"))
+
+        def subscribe_with_snapshot(self):
+            return self.q, {"last_event_id": "missing_journal_run:1", "offline_buffered_events": 1}
+
+        def unsubscribe(self, _q):
+            pass
+
+    class Handler:
+        def __init__(self):
+            self.wfile = io.BytesIO()
+
+        def send_response(self, _code):
+            pass
+
+        def send_header(self, _name, _value):
+            pass
+
+        def end_headers(self):
+            pass
+
+    monkeypatch.setattr(routes, "find_run_summary", lambda _stream_id: None)
+    handler = Handler()
+    previous_streams = dict(routes.STREAMS)
+    routes.STREAMS.clear()
+    routes.STREAMS["missing_journal_run"] = FakeStream()
+    try:
+        routes._handle_sse_stream(
+            handler,
+            urlparse("/api/chat/stream?stream_id=missing_journal_run&replay=1&after_seq=0"),
+        )
+    finally:
+        routes.STREAMS.clear()
+        routes.STREAMS.update(previous_streams)
+
+    body = handler.wfile.getvalue().decode("utf-8")
+    assert "id: missing_journal_run:1\n" in body
+    assert "event: token\n" in body
+    assert "buffered" in body
+
+
 def test_live_sse_uses_each_queue_items_own_event_id():
     import api.routes as routes
     from api.config import create_stream_channel

--- a/tests/test_run_journal_routes.py
+++ b/tests/test_run_journal_routes.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 from types import SimpleNamespace
+from urllib.parse import urlparse
 import io
+import queue
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -26,6 +28,112 @@ def test_dead_stream_sse_replays_journal_before_404_fallback():
     assert "_replay_run_journal" in block
     assert "_parse_run_journal_after_seq" in block
     assert 'Content-Type", "text/event-stream; charset=utf-8"' in block
+
+
+def test_active_stream_replay_uses_snapshot_cutoff_and_skips_duplicate_queue_items(monkeypatch):
+    import api.routes as routes
+
+    class FakeStream:
+        def __init__(self):
+            self.q = queue.Queue()
+            self.q.put_nowait(("token", {"text": "replayed"}, "run_1:1"))
+            self.q.put_nowait(("stream_end", {}, "run_1:2"))
+            self.unsubscribed = False
+
+        def subscribe_with_snapshot(self):
+            return self.q, {"last_event_id": "run_1:1", "offline_buffered_events": 1}
+
+        def unsubscribe(self, q):
+            self.unsubscribed = q is self.q
+
+    class Handler:
+        def __init__(self):
+            self.wfile = io.BytesIO()
+
+        def send_response(self, _code):
+            pass
+
+        def send_header(self, _name, _value):
+            pass
+
+        def end_headers(self):
+            pass
+
+    handler = Handler()
+    stream = FakeStream()
+    monkeypatch.setattr(
+        routes,
+        "find_run_summary",
+        lambda stream_id: {
+            "session_id": "session_1",
+            "run_id": stream_id,
+            "terminal": False,
+        },
+    )
+    monkeypatch.setattr(
+        routes,
+        "read_run_events",
+        lambda session_id, run_id, after_seq=None, max_seq=None: {
+            "events": [
+                {
+                    "event": "token",
+                    "payload": {"text": "replayed"},
+                    "event_id": f"{run_id}:1",
+                }
+            ]
+        },
+    )
+    monkeypatch.setattr(routes, "stale_interrupted_event", lambda *_args, **_kwargs: None)
+    previous_streams = dict(routes.STREAMS)
+    routes.STREAMS.clear()
+    routes.STREAMS["run_1"] = stream
+    try:
+        routes._handle_sse_stream(handler, urlparse("/api/chat/stream?stream_id=run_1&replay=1&after_seq=0"))
+    finally:
+        routes.STREAMS.clear()
+        routes.STREAMS.update(previous_streams)
+
+    body = handler.wfile.getvalue().decode("utf-8")
+    assert body.count("event: token\n") == 1
+    assert "id: run_1:1\n" in body
+    assert "id: run_1:2\n" in body
+    assert stream.unsubscribed is True
+
+
+def test_live_sse_uses_each_queue_items_own_event_id():
+    import api.routes as routes
+    from api.config import create_stream_channel
+
+    class Handler:
+        def __init__(self):
+            self.wfile = io.BytesIO()
+
+        def send_response(self, _code):
+            pass
+
+        def send_header(self, _name, _value):
+            pass
+
+        def end_headers(self):
+            pass
+
+    stream = create_stream_channel()
+    stream.put_nowait(("token", {"text": "A"}, "run_own_id:1"))
+    stream.put_nowait(("stream_end", {"ok": True}, "run_own_id:2"))
+    handler = Handler()
+    previous_streams = dict(routes.STREAMS)
+    routes.STREAMS.clear()
+    routes.STREAMS["run_own_id"] = stream
+    try:
+        routes._handle_sse_stream(handler, urlparse("/api/chat/stream?stream_id=run_own_id"))
+    finally:
+        routes.STREAMS.clear()
+        routes.STREAMS.update(previous_streams)
+
+    body = handler.wfile.getvalue().decode("utf-8")
+    assert "id: run_own_id:1\nevent: token\n" in body
+    assert "id: run_own_id:2\nevent: stream_end\n" in body
+    assert body.count("id: run_own_id:2\n") == 1
 
 
 def test_replay_emits_event_ids_and_stale_restart_diagnostic():
@@ -98,7 +206,7 @@ def test_replay_run_journal_writes_replayed_events_and_synthetic_terminal(monkey
     monkeypatch.setattr(
         routes,
         "read_run_events",
-        lambda session_id, run_id, after_seq=None: {
+        lambda session_id, run_id, after_seq=None, max_seq=None: {
             "events": [
                 {
                     "event": "token",
@@ -111,7 +219,7 @@ def test_replay_run_journal_writes_replayed_events_and_synthetic_terminal(monkey
     monkeypatch.setattr(
         routes,
         "stale_interrupted_event",
-        lambda session_id, run_id, after_seq=None: {
+        lambda session_id, run_id, after_seq=None, max_seq=None: {
             "event": "apperror",
             "payload": {"type": "interrupted"},
             "event_id": f"{run_id}:2",
@@ -141,8 +249,9 @@ def test_replay_run_journal_honors_after_seq_cursor(monkeypatch):
         },
     )
 
-    def fake_read_run_events(session_id, run_id, after_seq=None):
+    def fake_read_run_events(session_id, run_id, after_seq=None, max_seq=None):
         captured["after_seq"] = after_seq
+        captured["max_seq"] = max_seq
         return {
             "events": [
                 {
@@ -157,6 +266,7 @@ def test_replay_run_journal_honors_after_seq_cursor(monkeypatch):
 
     assert routes._replay_run_journal(handler, "run_1", 3) is True
     assert captured["after_seq"] == 3
+    assert captured["max_seq"] is None
     body = handler.wfile.getvalue().decode("utf-8")
     assert "id: run_1:4\n" in body
     assert "event: done\n" in body

--- a/tests/test_sprint42.py
+++ b/tests/test_sprint42.py
@@ -396,7 +396,22 @@ class TestRuntimeRouteInjection(unittest.TestCase):
         self.assertTrue(callable(init_kwargs["interim_assistant_callback"]))
         self.assertIn("WebUI progress guidance", captured["agent"].ephemeral_system_prompt)
         self.assertIn("Match the normal Hermes messaging style", captured["agent"].ephemeral_system_prompt)
-        self.assertIn("user-visible progress updates", captured["agent"].ephemeral_system_prompt)
+        self.assertIn(
+            "do not let long tool-running WebUI turns appear silent",
+            captured["agent"].ephemeral_system_prompt,
+        )
+        self.assertIn(
+            "provide brief user-visible progress updates as normal assistant content",
+            captured["agent"].ephemeral_system_prompt,
+        )
+        self.assertIn(
+            "Do not keep all progress only in reasoning, thinking, or tool-result channels",
+            captured["agent"].ephemeral_system_prompt,
+        )
+        self.assertNotIn(
+            "you may provide brief user-visible progress updates",
+            captured["agent"].ephemeral_system_prompt,
+        )
 
         interim_events = []
         while not fake_queue.empty():
@@ -405,13 +420,13 @@ class TestRuntimeRouteInjection(unittest.TestCase):
             except queue.Empty:
                 break
         self.assertTrue(
-            any(event == "interim_assistant" for event, _ in interim_events),
+            any(event == "interim_assistant" for event, *_ in interim_events),
             "interim_assistant callback should emit interim_assistant SSE events",
         )
         self.assertTrue(
             any(
                 event == "interim_assistant" and event_data.get("text") == "Inspecting repo structure."
-                for event, event_data in interim_events
+                for event, event_data, *_ in interim_events
             ),
             "interim_assistant event should carry the assistant commentary text"
         )

--- a/tests/test_sprint42.py
+++ b/tests/test_sprint42.py
@@ -396,22 +396,7 @@ class TestRuntimeRouteInjection(unittest.TestCase):
         self.assertTrue(callable(init_kwargs["interim_assistant_callback"]))
         self.assertIn("WebUI progress guidance", captured["agent"].ephemeral_system_prompt)
         self.assertIn("Match the normal Hermes messaging style", captured["agent"].ephemeral_system_prompt)
-        self.assertIn(
-            "do not let long tool-running WebUI turns appear silent",
-            captured["agent"].ephemeral_system_prompt,
-        )
-        self.assertIn(
-            "provide brief user-visible progress updates as normal assistant content",
-            captured["agent"].ephemeral_system_prompt,
-        )
-        self.assertIn(
-            "Do not keep all progress only in reasoning, thinking, or tool-result channels",
-            captured["agent"].ephemeral_system_prompt,
-        )
-        self.assertNotIn(
-            "you may provide brief user-visible progress updates",
-            captured["agent"].ephemeral_system_prompt,
-        )
+        self.assertIn("user-visible progress updates", captured["agent"].ephemeral_system_prompt)
 
         interim_events = []
         while not fake_queue.empty():

--- a/tests/test_stage364_opus_live_sse_event_id.py
+++ b/tests/test_stage364_opus_live_sse_event_id.py
@@ -1,4 +1,4 @@
-"""Regression test for stage-364 Opus-caught SHOULD-FIX (side-channel approach):
+"""Regression test for live SSE event ids:
 
 When the live SSE stream errors mid-stream and the frontend falls back to
 journal replay, live frames must carry an `id:` field so the frontend's
@@ -7,19 +7,15 @@ arrives with `after_seq=0` and the server replays every journaled event from
 seq 1, double-rendering tokens against the live-phase `assistantText`
 accumulator.
 
-Implementation (stage-364 — side-channel approach to avoid breaking the
-queue tuple contract used by 4 existing tests):
+Implementation:
 
-  - api/config.py adds `STREAM_LAST_EVENT_ID: dict = {}` module-level dict.
   - api/streaming.py `put()` captures `journaled["event_id"]` from
-    `RunJournalWriter.append_sse_event()` return and writes it to
-    `STREAM_LAST_EVENT_ID[stream_id]`.
-  - api/routes.py `_handle_sse_stream` reads `STREAM_LAST_EVENT_ID[stream_id]`
-    at SSE emit time and uses `_sse_with_id` when set.
-  - api/streaming.py finally-block cleanup pops STREAM_LAST_EVENT_ID.
-
-The queue tuple shape is preserved as (event, data), so existing tests like
-test_cancel_puts_sentinel_in_queue still work.
+    `RunJournalWriter.append_sse_event()`.
+  - The queue item carries that event id with the event payload, so replay
+    cursors track the event that was actually emitted rather than a side-channel
+    "latest" value that can mis-stamp buffered backlog events.
+  - api/routes.py `_handle_sse_stream` unpacks the per-item id and uses
+    `_sse_with_id` when set.
 """
 
 from pathlib import Path
@@ -30,16 +26,13 @@ ROUTES_PY = (REPO_ROOT / "api" / "routes.py").read_text(encoding="utf-8")
 CONFIG_PY = (REPO_ROOT / "api" / "config.py").read_text(encoding="utf-8")
 
 
-def test_stream_last_event_id_dict_exists_in_config():
-    """`STREAM_LAST_EVENT_ID` must be declared as a module-level dict in
-    api/config.py alongside the other STREAM_* registries."""
-    assert "STREAM_LAST_EVENT_ID: dict = {}" in CONFIG_PY, (
-        "STREAM_LAST_EVENT_ID dict missing from api/config.py — needed as "
-        "the side-channel that lets SSE consumers emit `id:` on live frames"
-    )
+def test_stream_channel_tracks_per_item_event_ids():
+    assert "subscribe_with_snapshot" in CONFIG_PY
+    assert "_event_id_from_item" in CONFIG_PY
+    assert "_last_event_id" in CONFIG_PY
 
 
-def test_put_writes_event_id_to_side_channel_dict():
+def test_put_writes_event_id_into_queue_item():
     """The `put()` helper must capture the event_id from the journal and
     write it to STREAM_LAST_EVENT_ID[stream_id]."""
     put_def_idx = STREAMING_PY.find("def put(event, data):")
@@ -48,34 +41,25 @@ def test_put_writes_event_id_to_side_channel_dict():
     assert "journaled = run_journal.append_sse_event(event, data)" in put_body, (
         "put() must capture append_sse_event return value"
     )
-    assert "STREAM_LAST_EVENT_ID[stream_id]" in put_body, (
-        "put() must write event_id to STREAM_LAST_EVENT_ID[stream_id] — "
-        "this is the side-channel the SSE consumer reads at emit time"
+    assert "q.put_nowait((event, data, event_id))" in put_body, (
+        "put() must queue event_id with its own SSE event so buffered backlog "
+        "frames cannot inherit a later event's id"
     )
 
 
-def test_queue_tuple_shape_preserved_as_two_tuple():
-    """The queue still uses 2-tuples (event, data) so existing consumers
-    that unpack `event, data = q.get()` are not broken."""
+def test_queue_tuple_shape_is_three_tuple_for_journaled_events():
+    """Journaled live events must carry their own event id in the queue item."""
     put_def_idx = STREAMING_PY.find("def put(event, data):")
     put_body = STREAMING_PY[put_def_idx:put_def_idx + 2500]
-    assert "q.put_nowait((event, data))" in put_body, (
-        "Queue tuple shape must remain (event, data) — changing to 3-tuple "
-        "breaks 4 existing tests in test_cancel_interrupt, test_sprint42, "
-        "test_sprint51, test_issue1857_usage_overwrite"
-    )
+    assert "q.put_nowait((event, data, event_id))" in put_body
 
 
-def test_sse_handler_reads_event_id_from_side_channel():
-    """The SSE consumer in _handle_sse_stream must read STREAM_LAST_EVENT_ID
-    and pass it to _sse_with_id when present."""
+def test_sse_handler_reads_event_id_from_queue_item():
+    """The SSE consumer must use the event id attached to the queue item."""
     handler_idx = ROUTES_PY.find("def _handle_sse_stream(handler, parsed):")
     assert handler_idx != -1, "_handle_sse_stream not found"
     handler_body = ROUTES_PY[handler_idx:handler_idx + 4000]
-    assert "STREAM_LAST_EVENT_ID.get(stream_id)" in handler_body, (
-        "_handle_sse_stream must read STREAM_LAST_EVENT_ID[stream_id] to "
-        "get the event_id for emit"
-    )
+    assert "_stream_queue_item_parts(item)" in handler_body
     assert "_sse_with_id(handler, event, data, event_id)" in handler_body, (
         "_handle_sse_stream must call _sse_with_id when event_id is set"
     )
@@ -95,7 +79,5 @@ def test_cleanup_pops_stream_last_event_id():
 
 
 def test_imports_present():
-    """STREAM_LAST_EVENT_ID must be imported in both streaming.py (writer)
-    and routes.py (reader)."""
+    """STREAM_LAST_EVENT_ID remains available for cleanup/backcompat."""
     assert "STREAM_LAST_EVENT_ID," in STREAMING_PY, "streaming.py must import"
-    assert "STREAM_LAST_EVENT_ID," in ROUTES_PY, "routes.py must import"

--- a/tests/test_streaming_race_fix.py
+++ b/tests/test_streaming_race_fix.py
@@ -160,6 +160,7 @@ class TestReconnectAccumulatorPreservation:
         # from INFLIGHT so the already-rendered content survives the session switch.
         assert ("let assistantText=''" in prelude
                 or 'let assistantText = _lastLiveAssistant' in prelude
+                or 'let assistantText=_lastLiveAssistant' in prelude
                 or 'let assistantText = ""' in prelude), (
             "assistantText must be initialised at closure scope — "
             "this is the only legitimate reset; _wireSSE must not re-reset"

--- a/tests/test_tool_call_persistence.py
+++ b/tests/test_tool_call_persistence.py
@@ -33,6 +33,41 @@ def test_extract_tool_calls_from_openai_message_linkage():
     assert result[0]["snippet"] == "file.txt"
 
 
+def test_extract_tool_calls_from_empty_assistant_reuses_previous_visible_anchor():
+    messages = [
+        {"role": "user", "content": "inspect code"},
+        {"role": "assistant", "content": "Checking the frontend reattach path."},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{
+                "id": "call-1",
+                "function": {"name": "read_file", "arguments": '{"path":"static/ui.js"}'},
+            }],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call-1",
+            "content": '{"content":"function renderMessages() {}"}',
+        },
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{
+                "id": "call-2",
+                "function": {"name": "terminal", "arguments": '{"command":"rg attachLiveStream"}'},
+            }],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call-2",
+            "content": '{"output":"static/messages.js"}',
+        },
+    ]
+    result = _extract_tool_calls_from_messages(messages)
+    assert [tc["assistant_msg_idx"] for tc in result] == [1, 1]
+
+
 def test_tool_result_snippet_allows_frontend_show_more_threshold_but_stays_bounded():
     """Persisted snippets should be long enough for frontend Show more but capped."""
     medium_output = "m" * 1200

--- a/tests/test_turn_duration_display.py
+++ b/tests/test_turn_duration_display.py
@@ -53,7 +53,11 @@ def test_ui_formats_and_renders_turn_duration_in_footer_and_activity_summary():
         "Compact tool activity summary should have a dedicated duration span at the end of the line."
     )
     assert "data-turn-duration" in UI_JS, (
-        "Activity groups need a stable data-turn-duration hook so settled duration can update the summary."
+        "The top run Activity needs a stable data-turn-duration hook so settled duration can update its summary."
+    )
+    assert "ensureRunActivityGroup(blocks,{live:false,collapsed:true,turnDuration:duration})" in UI_JS, (
+        "Settled compact activity should put turn duration on the top Run Activity, "
+        "not on each tool Activity group."
     )
     assert "compactActivityForMessage" in UI_JS, (
         "When compact activity is present, duration should live on the Activity row "

--- a/tests/test_ui_tool_call_cleanup.py
+++ b/tests/test_ui_tool_call_cleanup.py
@@ -340,8 +340,9 @@ class TestToolCallGroupingStatic:
             "Already-streamed progress boundaries must flush token-rendered text before splitting Activity."
         )
         timer_fn = _function_body(UI_JS, "_updateActiveActivityElapsedTimer")
-        assert "data-live-activity-current" in timer_fn, (
-            "Elapsed timers should clear once an Activity group is no longer current."
+        assert "_isActivityTimerGroup(group)" in timer_fn, (
+            "Elapsed timers should now be owned by the run-level Activity timer group, "
+            "not by each per-segment tool Activity burst."
         )
         tool_start_segment = MESSAGES_JS.split("source.addEventListener('tool',e=>{", 1)[1].split("source.addEventListener('tool_complete'", 1)[0]
         assert "_resetAssistantSegment();" in tool_start_segment, (

--- a/tests/test_ui_tool_call_cleanup.py
+++ b/tests/test_ui_tool_call_cleanup.py
@@ -331,6 +331,14 @@ class TestToolCallGroupingStatic:
         assert interim_match and "_flushPendingSegmentRender({force:true})" in interim_match.group(1), (
             "Visible interim assistant progress must be synchronously rendered before the segment reset."
         )
+        already_streamed_branch = interim_match.group(1).split("if(alreadyStreamed){", 1)[1].split("assistantText +=", 1)[0]
+        assert "closeCurrentLiveActivityGroup()" in already_streamed_branch, (
+            "An already-streamed interim event is still a visible-progress boundary; "
+            "it must split the current Activity burst without appending duplicate text."
+        )
+        assert "_flushPendingSegmentRender({force:true})" in already_streamed_branch, (
+            "Already-streamed progress boundaries must flush token-rendered text before splitting Activity."
+        )
         timer_fn = _function_body(UI_JS, "_updateActiveActivityElapsedTimer")
         assert "data-live-activity-current" in timer_fn, (
             "Elapsed timers should clear once an Activity group is no longer current."

--- a/tests/test_ui_tool_call_cleanup.py
+++ b/tests/test_ui_tool_call_cleanup.py
@@ -219,11 +219,13 @@ class TestToolCallGroupingStatic:
         sync_fn = _function_body(UI_JS, "_syncToolCallGroupSummary")
         progress_fn = _function_body(UI_JS, "_activityProgressLabelForToolName")
         live_progress_fn = _function_body(UI_JS, "_activityLiveProgressLabel")
-        assert "_activityLiveProgressLabel" in sync_fn, (
-            "Live compact Activity rows should expose a readable transient progress label."
+        assert "_activityLiveProgressLabel" not in sync_fn, (
+            "Per-segment Activity rows should not show a group-level live timer/progress label; "
+            "only the top Run Activity owns the running timer."
         )
-        assert "durationEl.textContent" in sync_fn and "filter(Boolean).join(' · ')" in sync_fn, (
-            "Progress should share the existing non-persistent summary/duration slot, not become transcript text."
+        assert "durationEl.textContent='';" in sync_fn and "durationEl.style.display='none';" in sync_fn, (
+            "Per-segment Activity rows should keep the summary duration slot empty; "
+            "individual tool durations belong on tool cards."
         )
         for label in ("Searching workspace", "Reading files", "Updating files", "Running command"):
             assert label in progress_fn

--- a/tests/test_webui_gateway_chat_backend.py
+++ b/tests/test_webui_gateway_chat_backend.py
@@ -117,3 +117,55 @@ def test_gateway_chat_worker_translates_sse_and_persists_session(tmp_path, monke
     assert captured["headers"]["X-hermes-session-id"] == s.session_id
     assert captured["headers"]["X-hermes-session-key"] == f"webui:{s.session_id}"
     assert '"stream": true' in captured["body"]
+
+
+def test_gateway_chat_worker_queues_journal_event_ids(tmp_path, monkeypatch):
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    monkeypatch.setattr(models, "SESSION_DIR", session_dir)
+    monkeypatch.setattr(models, "SESSION_INDEX_FILE", session_dir / "_index.json")
+    monkeypatch.setattr(models, "SESSIONS", OrderedDict())
+
+    class FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def __iter__(self):
+            yield b'data: {"choices":[{"delta":{"content":"hi"}}]}\n\n'
+            yield b'data: [DONE]\n\n'
+
+    monkeypatch.setenv("HERMES_WEBUI_GATEWAY_BASE_URL", "http://gateway.local")
+    monkeypatch.setattr(gateway_chat.urllib.request, "urlopen", lambda *_args, **_kwargs: FakeResponse())
+
+    s = new_session()
+    stream_id = "stream-gateway-event-id"
+    s.active_stream_id = stream_id
+    s.pending_user_message = "Say hi"
+    s.pending_attachments = []
+    s.pending_started_at = 123
+    s.save()
+    stream = create_stream_channel()
+    subscriber = stream.subscribe()
+    STREAMS[stream_id] = stream
+
+    gateway_chat._run_gateway_chat_streaming(
+        s.session_id,
+        "Say hi",
+        "test-model",
+        str(tmp_path),
+        stream_id,
+        [],
+    )
+
+    items = []
+    while not subscriber.empty():
+        items.append(subscriber.get_nowait())
+
+    assert items, "gateway worker should publish live SSE queue items"
+    assert all(len(item) >= 3 for item in items), items
+    assert items[0][0] == "token"
+    assert items[0][2] == f"{stream_id}:1"
+    assert any(item[0] == "stream_end" and item[2] for item in items)

--- a/tests/test_webui_runtime_diagnostics.py
+++ b/tests/test_webui_runtime_diagnostics.py
@@ -6,10 +6,11 @@ def test_stream_channel_exposes_buffer_and_subscriber_counts():
     channel = create_stream_channel()
     channel.put_nowait(("token", {"text": "offline"}))
 
-    assert channel.diagnostic_snapshot() == {
-        "subscriber_count": 0,
-        "offline_buffered_events": 1,
-    }
+    snapshot = channel.diagnostic_snapshot()
+    assert snapshot["subscriber_count"] == 0
+    assert snapshot["offline_buffered_events"] == 1
+    assert snapshot["offline_buffered_event_ids"] == []
+    assert snapshot["last_event_id"] is None
 
     subscriber = channel.subscribe()
     try:


### PR DESCRIPTION
## Thinking Path

- Refs #2924. Related: #2925 and #3015.
- Live Stream Running Session needs two separate guarantees: the UI must preserve and replay the visible timeline correctly, and the model must emit visible progress text often enough for that timeline to be useful.
- This PR is the UI / replay half. It does not strengthen the model prompt; that belongs in #3015.
- The old failure was not a single bug. Session switching could lose the live text buffers, replay could start from the wrong cursor, active replay could duplicate events, and tool Activity groups could lose their anchor to the progress text that triggered them.
- Follow-up review found several remaining blockers: the frontend was fast-forwarding replay from `/api/session.runtime_journal` even though that is not an applied-SSE cursor; the backend could skip buffered queue items when `replay=1` was requested but no journal replay was available; duplicate interim boundaries with no new visible text could create Activity burst ids that had no text anchor; and final settled rendering could drop live burst metadata when final messages carried their own tool metadata.
- The current fix keeps live assistant text, reasoning text, journal cursors, and Activity burst ids aligned across stream close, reattach, active replay, message-windowed rendering, and final settled rendering.

## Contract Routing

Task type: runtime / streaming / recovery fix with chat-rendering UI behavior.

Touched areas:
- Browser INFLIGHT recovery state in `static/sessions.js` and `static/messages.js`.
- SSE replay / run journal fallback behavior in `api/routes.py`.
- Live and settled Activity placement in `static/ui.js`.
- Runtime diagnostics, config prompt, and regression coverage for replay / Activity invariants.

Relevant public docs:
- `AGENTS.md`
- `CONTRIBUTING.md`
- `docs/CONTRACTS.md`
- `docs/rfcs/README.md`
- `docs/rfcs/webui-run-state-consistency-contract.md`
- `docs/rfcs/turn-journal.md`
- `docs/UIUX-GUIDE.md`
- `DESIGN.md`

Contract families exercised:
- Runtime / streaming / state: active SSE reattach, run-journal cursoring, replay idempotence, structured degradation when replay is unavailable.
- UI/UX: visible progress remains prose-first timeline content; Activity stays quiet metadata bound to the progress segment that produced it.
- General PR body / verification: single logical problem, explicit state layers, tests and CI listed below.

Scope boundaries:
- Does not change the model prompt; #3015 is the prompt-side companion.
- Does not implement a new runtime adapter or a new turn-journal design slice.
- Does not claim final UI readiness without manual 8787 dogfood and before/after visual evidence.

Evidence needed before Ready for review:
- Green CI on the current head.
- Manual long-running 8787 session-switch dogfood showing progress text and Activity remain interleaved.
- Screenshot or short video evidence for the live Activity timeline after manual validation.

## What Changed

- Persist and restore running-stream state across session switches:
  - live assistant text
  - live reasoning text
  - applied run-journal replay cursor
  - Activity burst id and text anchors
- Reattach active streams with run-journal replay parameters so reconnects can request only the missing event gap.
- Make active SSE replay replay the journal snapshot before subscribing to new live events, then skip events already covered by the replay cutoff.
- Only apply that replay cutoff when journal replay actually succeeded; if no journal is available, buffered live queue items remain deliverable.
- Keep stale `Response interrupted` diagnostics out of active stream replay while preserving dead-stream behavior.
- Bind live tool Activity groups to the progress segment that ended immediately before the tool burst.
- Normalize live and settled Activity placement so text and Activity remain interleaved instead of collapsing all Activity at the top or bottom.
- Fix the burst-id anchor mismatch where `recordActivityBoundary()` incremented the next tool burst id but left the current text DOM stamped with the old id.
- Prevent duplicate or replayed interim boundaries with no new visible text from creating empty Activity bursts.
- During reattach projection, alias any persisted empty Activity burst back to the previous visible text segment so existing localStorage state can recover instead of leaving tool groups anchorless.
- Preserve live `activityBurstId`, `duration`, and `started_at` as auxiliary metadata when the final message owns the settled tool metadata, without violating message-windowing ownership.
- Fold empty assistant messages that contain only `tool_calls` back to the previous visible assistant progress segment, so final settled rendering and session-switch reattach do not split one tool burst into multiple orphaned Activity groups.
- Resume reconnecting multi-segment live turns from the full assistant accumulator, not the latest projected segment, so repeated session switches do not truncate older process-text anchors and push earlier Activity groups to the tail.
- Persist interim progress boundaries even when the stream event arrives during an inactive-pane session switch, so tools produced in that window keep a valid progress-text burst anchor on reattach.
- Keep reconnect rendering scoped to the live tail segment: seed `segmentStart` from the last recorded burst anchor, select the last projected live segment, and force a fresh segment when reconnect resumes exactly at a boundary with no tail yet.
- Do not advance `INFLIGHT.lastRunJournalSeq` from `/api/session.runtime_journal`; that summary is diagnostic state, not proof that the frontend applied every SSE event through that seq.
- Update static/regression tests to lock the new replay queue shape, anchored Activity restore invariants, empty-burst normalization, message-windowing compatibility, final settled metadata merge, and replay-cursor/cutoff boundaries.

## Why It Matters

A long-running WebUI turn should keep the same visible timeline while the user switches sessions: progress text, the tools that followed that text, more progress text, then later tools. Reattaching should not blank the interim text, duplicate it, skip not-yet-consumed journal events, or pile all Activity groups into one unrelated block.

## Verification

- `node --check static/ui.js static/messages.js static/sessions.js`
- `pytest -q tests/test_live_activity_timeline.py tests/test_tool_call_persistence.py tests/test_streaming_markdown.py tests/test_inflight_stream_reuse.py tests/test_run_journal_routes.py tests/test_ui_tool_call_cleanup.py tests/test_issue734_message_windowing.py` — local clean head `e15f8270`: 131 passed.
- `python3 -m pytest tests/test_live_activity_timeline.py tests/test_inflight_stream_reuse.py tests/test_streaming_race_fix.py -q` — local clean head `1a8379d9`: 41 passed.
- `python3 -m pytest tests/test_live_activity_timeline.py tests/test_inflight_stream_reuse.py tests/test_streaming_race_fix.py -q` — local clean head `5c2c83a2`: 42 passed.
- `python3 -m pytest tests/test_inflight_stream_reuse.py tests/test_live_activity_timeline.py tests/test_streaming_race_fix.py -q` — local clean head `886e7548`: 46 passed.
- `node --check static/messages.js static/ui.js static/sessions.js` — local clean head `886e7548`: passed.
- `pytest -q --ignore=tests/test_passkey_auth.py` — local machine before the final cursor/empty-burst/final-metadata follow-up patches: 6624 passed, 62 skipped, 3 xpassed; 2 unrelated `tests/test_workspace_git.py` failures caused by local git default branch not being `master`.
- GitHub Actions `test (3.11)`, `test (3.12)`, and `test (3.13)` pass on commit `e15f8270`.
- GitHub Actions for `886e7548` are pending after the latest follow-up push.

## Risks / Follow-ups

- Still Draft. This needs manual 8787 dogfood before it should be marked ready for review.
- This PR cannot make a model emit visible progress text; if the model runs many tool batches without ordinary assistant text, the UI can only anchor Activity to the latest available visible segment. #3015 is the prompt-side companion.
- Manual validation should stress rapid session switching during long, tool-heavy runs before publishing.
- UI/UX publication evidence is still pending: before/after screenshot or short video after 8787 dogfood.

## Model Used

OpenAI GPT-5 Codex. AI assistance was used to inspect runtime evidence, split PR scope, implement the focused fixes, run contract verification, and verify the clean branch.





