### PR TITLE
feat: add skill usage counter to Insights page

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -4788,6 +4788,24 @@ def handle_get(handler, parsed) -> bool:
         data = _skills_list_from_dir(_active_skills_dir(), category=category)
         return j(handler, {"skills": data.get("skills", [])})
 
+    if parsed.path == "/api/skills/usage":
+        from api.skill_usage import read_skill_usage
+        raw = read_skill_usage(_active_skills_dir())
+        usage = {
+            k: {"use_count": v.get("use_count", 0), "view_count": v.get("view_count", 0), "patch_count": v.get("patch_count", 0)}
+            for k, v in raw.items()
+        } if isinstance(raw, dict) else {}
+        skills_data = _skills_list_from_dir(_active_skills_dir()).get("skills", [])
+        skill_names = sorted({s["name"] for s in skills_data})
+        total = sum(e["use_count"] for e in usage.values())
+        unique = sum(1 for e in usage.values() if e["use_count"] > 0 or e["patch_count"] > 0)
+        return j(handler, {
+            "usage": usage,
+            "skill_names": skill_names,
+            "total_invocations": total,
+            "unique_skills_used": unique,
+        })
+
     if parsed.path == "/api/skills/content":
         qs = parse_qs(parsed.query)
         name = qs.get("name", [""])[0]

--- a/api/routes.py
+++ b/api/routes.py
@@ -4791,14 +4791,32 @@ def handle_get(handler, parsed) -> bool:
     if parsed.path == "/api/skills/usage":
         from api.skill_usage import read_skill_usage
         raw = read_skill_usage(_active_skills_dir())
-        usage = {
-            k: {"use_count": v.get("use_count", 0), "view_count": v.get("view_count", 0), "patch_count": v.get("patch_count", 0)}
-            for k, v in raw.items()
-        } if isinstance(raw, dict) else {}
+        # Pass through agent's format as-is; defensive coercion for fields
+        usage = {}
+        if isinstance(raw, dict):
+            for k, v in raw.items():
+                if not isinstance(v, dict):
+                    usage[k] = {"use_count": 0, "view_count": 0, "patch_count": 0}
+                    continue
+                usage[k] = {
+                    "use_count": (int(v["use_count"]) if v.get("use_count") is not None else 0),
+                    "view_count": (int(v["view_count"]) if v.get("view_count") is not None else 0),
+                    "patch_count": (int(v["patch_count"]) if v.get("patch_count") is not None else 0),
+                }
+                # Preserve agent's metadata (timestamps, state, etc.)
+                for meta_key in v:
+                    if meta_key not in usage[k]:
+                        usage[k][meta_key] = v[meta_key]
         skills_data = _skills_list_from_dir(_active_skills_dir()).get("skills", [])
         skill_names = sorted({s["name"] for s in skills_data})
-        total = sum(e["use_count"] for e in usage.values())
-        unique = sum(1 for e in usage.values() if e["use_count"] > 0 or e["patch_count"] > 0)
+        total = sum(
+            e.get("use_count", 0) + e.get("view_count", 0) + e.get("patch_count", 0)
+            for e in usage.values()
+        )
+        unique = sum(
+            1 for e in usage.values()
+            if e.get("use_count", 0) > 0 or e.get("view_count", 0) > 0 or e.get("patch_count", 0) > 0
+        )
         return j(handler, {
             "usage": usage,
             "skill_names": skill_names,

--- a/api/skill_usage.py
+++ b/api/skill_usage.py
@@ -1,16 +1,13 @@
-# ── Skill usage counter (file-based, best-effort) ──
+# ── Skill usage reader (read-only) ──
+# Note: .usage.json is written by hermes-agent (tools/skill_usage.py).
+# WebUI only reads to display usage stats in Insights page.
 
 import json
 import logging
-import os
-import threading
-import time
-
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
-_SKILL_TOOL_NAMES = frozenset({"skill_view", "skill_manage", "skill_patch"})
 _USAGE_FILE = ".usage.json"
 
 
@@ -33,80 +30,3 @@ def read_skill_usage(skills_dir: Path) -> dict:
     except (json.JSONDecodeError, OSError) as exc:
         logger.debug("Failed to read .usage.json: %s", exc)
         return {}
-
-
-def _ensure_skill_entry(usage: dict, name: str) -> dict:
-    """Return the metadata dict for *name*, creating a default one if missing."""
-    entry = usage.get(name)
-    if not isinstance(entry, dict):
-        entry = {"use_count": 0, "view_count": 0, "patch_count": 0}
-        usage[name] = entry
-    return entry
-
-
-def increment_skill_usage(skills_dir: Path, tool_calls: list[dict]) -> None:
-    """Scan *tool_calls* for skill_view/skill_manage invocations and bump
-    the corresponding counters in .usage.json atomically.
-
-    - ``skill_view``  → increments ``view_count``, sets ``last_viewed_at``
-    - ``skill_manage`` → increments ``use_count``, sets ``last_used_at``
-
-    This is a best-effort helper — failures are logged at DEBUG level and
-    silently swallowed so they never block the calling stream handler.
-    """
-    if not tool_calls:
-        return
-
-    updates: list[tuple[str, str]] = []
-    for tc in tool_calls:
-        if not isinstance(tc, dict):
-            continue
-        tname = tc.get("name") or tc.get("tool_name") or ""
-        if tname not in _SKILL_TOOL_NAMES:
-            continue
-        args = tc.get("args") or tc.get("input") or {}
-        if isinstance(args, dict):
-            skill_name = args.get("name")
-            if skill_name and isinstance(skill_name, str):
-                if tname == "skill_view":
-                    action = "view"
-                elif tname == "skill_patch":
-                    action = "patch"
-                else:
-                    action = "use"
-                updates.append((skill_name, action))
-
-    if not updates:
-        return
-
-    usage = read_skill_usage(skills_dir)
-    now = time.time()
-
-    for name, action in updates:
-        entry = _ensure_skill_entry(usage, name)
-        if action == "use":
-            entry["use_count"] = entry.get("use_count", 0) + 1
-            entry["last_used_at"] = now
-        elif action == "patch":
-            entry["patch_count"] = entry.get("patch_count", 0) + 1
-            entry["last_patched_at"] = now
-        else:
-            entry["view_count"] = entry.get("view_count", 0) + 1
-            entry["last_viewed_at"] = now
-
-    usage_path = skills_dir / _USAGE_FILE
-    tmp_path = usage_path.with_suffix(
-        f".tmp.{os.getpid()}.{threading.current_thread().ident}"
-    )
-    try:
-        tmp_path.write_text(
-            json.dumps(usage, ensure_ascii=False, indent=2, sort_keys=True),
-            encoding="utf-8",
-        )
-        tmp_path.replace(usage_path)
-    except OSError as exc:
-        logger.debug("Failed to atomically write .usage.json: %s", exc)
-        try:
-            tmp_path.unlink(missing_ok=True)
-        except OSError:
-            pass

--- a/api/skill_usage.py
+++ b/api/skill_usage.py
@@ -1,0 +1,112 @@
+# ── Skill usage counter (file-based, best-effort) ──
+
+import json
+import logging
+import os
+import threading
+import time
+
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_SKILL_TOOL_NAMES = frozenset({"skill_view", "skill_manage", "skill_patch"})
+_USAGE_FILE = ".usage.json"
+
+
+def read_skill_usage(skills_dir: Path) -> dict:
+    """Read the current .usage.json.
+
+    Returns the raw nested dict ``{skill_name: {use_count: N, view_count: N, ...}}``
+    or an empty dict when the file does not exist or is corrupt.
+    """
+    usage_path = skills_dir / _USAGE_FILE
+    if not usage_path.exists():
+        return {}
+    try:
+        raw = usage_path.read_text(encoding="utf-8")
+        data = json.loads(raw)
+        if isinstance(data, dict):
+            return data
+        logger.debug("Unexpected .usage.json format, resetting: %s", raw[:200])
+        return {}
+    except (json.JSONDecodeError, OSError) as exc:
+        logger.debug("Failed to read .usage.json: %s", exc)
+        return {}
+
+
+def _ensure_skill_entry(usage: dict, name: str) -> dict:
+    """Return the metadata dict for *name*, creating a default one if missing."""
+    entry = usage.get(name)
+    if not isinstance(entry, dict):
+        entry = {"use_count": 0, "view_count": 0, "patch_count": 0}
+        usage[name] = entry
+    return entry
+
+
+def increment_skill_usage(skills_dir: Path, tool_calls: list[dict]) -> None:
+    """Scan *tool_calls* for skill_view/skill_manage invocations and bump
+    the corresponding counters in .usage.json atomically.
+
+    - ``skill_view``  → increments ``view_count``, sets ``last_viewed_at``
+    - ``skill_manage`` → increments ``use_count``, sets ``last_used_at``
+
+    This is a best-effort helper — failures are logged at DEBUG level and
+    silently swallowed so they never block the calling stream handler.
+    """
+    if not tool_calls:
+        return
+
+    updates: list[tuple[str, str]] = []
+    for tc in tool_calls:
+        if not isinstance(tc, dict):
+            continue
+        tname = tc.get("name") or tc.get("tool_name") or ""
+        if tname not in _SKILL_TOOL_NAMES:
+            continue
+        args = tc.get("args") or tc.get("input") or {}
+        if isinstance(args, dict):
+            skill_name = args.get("name")
+            if skill_name and isinstance(skill_name, str):
+                if tname == "skill_view":
+                    action = "view"
+                elif tname == "skill_patch":
+                    action = "patch"
+                else:
+                    action = "use"
+                updates.append((skill_name, action))
+
+    if not updates:
+        return
+
+    usage = read_skill_usage(skills_dir)
+    now = time.time()
+
+    for name, action in updates:
+        entry = _ensure_skill_entry(usage, name)
+        if action == "use":
+            entry["use_count"] = entry.get("use_count", 0) + 1
+            entry["last_used_at"] = now
+        elif action == "patch":
+            entry["patch_count"] = entry.get("patch_count", 0) + 1
+            entry["last_patched_at"] = now
+        else:
+            entry["view_count"] = entry.get("view_count", 0) + 1
+            entry["last_viewed_at"] = now
+
+    usage_path = skills_dir / _USAGE_FILE
+    tmp_path = usage_path.with_suffix(
+        f".tmp.{os.getpid()}.{threading.current_thread().ident}"
+    )
+    try:
+        tmp_path.write_text(
+            json.dumps(usage, ensure_ascii=False, indent=2, sort_keys=True),
+            encoding="utf-8",
+        )
+        tmp_path.replace(usage_path)
+    except OSError as exc:
+        logger.debug("Failed to atomically write .usage.json: %s", exc)
+        try:
+            tmp_path.unlink(missing_ok=True)
+        except OSError:
+            pass

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -5492,6 +5492,13 @@ def _run_agent_streaming(
                         mark_turn_completed(s.session_id, agent=agent)
                     except Exception:
                         logger.debug("Memory lifecycle mark failed for session %s", s.session_id, exc_info=True)
+            # ── Skill usage counter (non-blocking, best-effort) ──
+            try:
+                from api.skill_usage import increment_skill_usage
+                from api.routes import _active_skills_dir
+                increment_skill_usage(_active_skills_dir(), s.tool_calls or [])
+            except Exception:
+                logger.debug("Skill usage counter update failed", exc_info=True)
             # Sync to state.db for /insights (opt-in setting)
             try:
                 from api.config import load_settings as _load_settings

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -5492,13 +5492,6 @@ def _run_agent_streaming(
                         mark_turn_completed(s.session_id, agent=agent)
                     except Exception:
                         logger.debug("Memory lifecycle mark failed for session %s", s.session_id, exc_info=True)
-            # ── Skill usage counter (non-blocking, best-effort) ──
-            try:
-                from api.skill_usage import increment_skill_usage
-                from api.routes import _active_skills_dir
-                increment_skill_usage(_active_skills_dir(), s.tool_calls or [])
-            except Exception:
-                logger.debug("Skill usage counter update failed", exc_info=True)
             # Sync to state.db for /insights (opt-in setting)
             try:
                 from api.config import load_settings as _load_settings

--- a/static/i18n.js
+++ b/static/i18n.js
@@ -2067,6 +2067,11 @@ const LOCALES = {
     insights_skill_usage_no_data: 'Nessun dato di utilizzo skill ancora',
     insights_skill_usage_no_data_hint: 'Le skill appariranno qui dopo essere state usate nelle conversazioni.',
     insights_skill_usage_footer: 'Conteggi da ~/.hermes/skills/',
+    insights_skill_usage_col_skill: 'Abilità',
+    insights_skill_usage_col_uses: 'Usi',
+    insights_skill_usage_col_views: 'Visualizzazioni',
+    insights_skill_usage_col_share: 'Utilizzo %',
+    insights_skill_usage_col_patches: 'Patch',
     workspace_desc: 'Aggiungi e cambia workspace per le tue sessioni.',
     session_meta_messages: (n) => `${n} msg`,
     session_meta_children: (n) => `${n} figli${n === 1 ? 'o' : ''}`,
@@ -3350,6 +3355,11 @@ const LOCALES = {
     insights_skill_usage_no_data: 'スキル使用データがまだありません',
     insights_skill_usage_no_data_hint: '会話でスキルを使用すると、ここに表示されます。',
     insights_skill_usage_footer: 'データ元: ~/.hermes/skills/',
+    insights_skill_usage_col_skill: 'スキル',
+    insights_skill_usage_col_uses: '使用回数',
+    insights_skill_usage_col_views: '閲覧数',
+    insights_skill_usage_col_share: '使用率',
+    insights_skill_usage_col_patches: 'パッチ',
     workspace_desc: 'セッション用のワークスペースを追加・切り替えします。',
     session_meta_messages: (n) => `${n} 件`,
     session_meta_children: (n) => `${n} 子`,
@@ -5061,6 +5071,11 @@ const LOCALES = {
     insights_skill_usage_no_data: 'No skill usage data yet',  // TODO: translate
     insights_skill_usage_no_data_hint: 'Skills will appear here once used in conversations.',  // TODO: translate
     insights_skill_usage_footer: 'Counts from ~/.hermes/skills/',  // TODO: translate
+    insights_skill_usage_col_skill: 'Skill',  // TODO: translate
+    insights_skill_usage_col_uses: 'Uses',  // TODO: translate
+    insights_skill_usage_col_views: 'Views',  // TODO: translate
+    insights_skill_usage_col_share: 'Usage %',  // TODO: translate
+    insights_skill_usage_col_patches: 'Patches',  // TODO: translate
     insights_input_tokens: 'Input',  // TODO: translate
     insights_messages: 'Messages',  // TODO: translate
     insights_models: 'Models',  // TODO: translate
@@ -6265,6 +6280,11 @@ const LOCALES = {
     insights_skill_usage_no_data: 'No skill usage data yet',  // TODO: translate
     insights_skill_usage_no_data_hint: 'Skills will appear here once used in conversations.',  // TODO: translate
     insights_skill_usage_footer: 'Counts from ~/.hermes/skills/',  // TODO: translate
+    insights_skill_usage_col_skill: 'Skill',  // TODO: translate
+    insights_skill_usage_col_uses: 'Uses',  // TODO: translate
+    insights_skill_usage_col_views: 'Views',  // TODO: translate
+    insights_skill_usage_col_share: 'Usage %',  // TODO: translate
+    insights_skill_usage_col_patches: 'Patches',  // TODO: translate
     insights_input_tokens: 'Input',  // TODO: translate
     insights_messages: 'Messages',  // TODO: translate
     insights_models: 'Models',  // TODO: translate
@@ -7484,6 +7504,11 @@ const LOCALES = {
     insights_skill_usage_no_data: 'No skill usage data yet',  // TODO: translate
     insights_skill_usage_no_data_hint: 'Skills will appear here once used in conversations.',  // TODO: translate
     insights_skill_usage_footer: 'Counts from ~/.hermes/skills/',  // TODO: translate
+    insights_skill_usage_col_skill: 'Skill',  // TODO: translate
+    insights_skill_usage_col_uses: 'Uses',  // TODO: translate
+    insights_skill_usage_col_views: 'Views',  // TODO: translate
+    insights_skill_usage_col_share: 'Usage %',  // TODO: translate
+    insights_skill_usage_col_patches: 'Patches',  // TODO: translate
     insights_input_tokens: 'Input',  // TODO: translate
     insights_messages: 'Messages',  // TODO: translate
     insights_models: 'Models',  // TODO: translate
@@ -8696,6 +8721,11 @@ const LOCALES = {
     insights_skill_usage_no_data: '暂无技能使用数据',
     insights_skill_usage_no_data_hint: '在对话中使用技能后，数据将在此显示。',
     insights_skill_usage_footer: '数据来源于 ~/.hermes/skills/',
+    insights_skill_usage_col_skill: '技能',
+    insights_skill_usage_col_uses: '使用次数',
+    insights_skill_usage_col_views: '查看次数',
+    insights_skill_usage_col_share: '使用占比',
+    insights_skill_usage_col_patches: '补丁',
     insights_input_tokens: '输入',
     insights_messages: '消息',
     insights_models: '模型',
@@ -9989,6 +10019,11 @@ const LOCALES = {
     insights_skill_usage_no_data: '暫無技能使用數據',
     insights_skill_usage_no_data_hint: '在會話中使用技能後，數據將在此顯示。',
     insights_skill_usage_footer: '數據來源於 ~/.hermes/skills/',
+    insights_skill_usage_col_skill: 'Skill',  // TODO: translate
+    insights_skill_usage_col_uses: 'Uses',  // TODO: translate
+    insights_skill_usage_col_views: 'Views',  // TODO: translate
+    insights_skill_usage_col_share: 'Usage %',  // TODO: translate
+    insights_skill_usage_col_patches: 'Patches',  // TODO: translate
     insights_input_tokens: 'Input',  // TODO: translate
     insights_messages: 'Messages',  // TODO: translate
     insights_models: 'Models',  // TODO: translate
@@ -11083,6 +11118,11 @@ const LOCALES = {
     insights_skill_usage_no_data: 'No skill usage data yet',  // TODO: translate
     insights_skill_usage_no_data_hint: 'Skills will appear here once used in conversations.',  // TODO: translate
     insights_skill_usage_footer: 'Counts from ~/.hermes/skills/',  // TODO: translate
+    insights_skill_usage_col_skill: 'Skill',  // TODO: translate
+    insights_skill_usage_col_uses: 'Uses',  // TODO: translate
+    insights_skill_usage_col_views: 'Views',  // TODO: translate
+    insights_skill_usage_col_share: 'Usage %',  // TODO: translate
+    insights_skill_usage_col_patches: 'Patches',  // TODO: translate
     insights_input_tokens: 'Input',  // TODO: translate
     insights_messages: 'Messages',  // TODO: translate
     insights_models: 'Models',  // TODO: translate
@@ -12354,6 +12394,11 @@ const LOCALES = {
     insights_skill_usage_no_data: 'No skill usage data yet',  // TODO: translate
     insights_skill_usage_no_data_hint: 'Skills will appear here once used in conversations.',  // TODO: translate
     insights_skill_usage_footer: 'Counts from ~/.hermes/skills/',  // TODO: translate
+    insights_skill_usage_col_skill: 'Skill',  // TODO: translate
+    insights_skill_usage_col_uses: 'Uses',  // TODO: translate
+    insights_skill_usage_col_views: 'Views',  // TODO: translate
+    insights_skill_usage_col_share: 'Usage %',  // TODO: translate
+    insights_skill_usage_col_patches: 'Patches',  // TODO: translate
     insights_input_tokens: 'Input',  // TODO: translate
     insights_messages: 'Messages',  // TODO: translate
     insights_models: 'Models',  // TODO: translate
@@ -13019,6 +13064,11 @@ const LOCALES = {
     insights_skill_usage_no_data: 'Aucune donnée d\'utilisation des skills pour le moment',
     insights_skill_usage_no_data_hint: 'Les skills apparaîtront ici une fois utilisés dans les conversations.',
     insights_skill_usage_footer: 'Comptages depuis ~/.hermes/skills/',
+    insights_skill_usage_col_skill: 'Skill',  // TODO: translate
+    insights_skill_usage_col_uses: 'Uses',  // TODO: translate
+    insights_skill_usage_col_views: 'Views',  // TODO: translate
+    insights_skill_usage_col_share: 'Usage %',  // TODO: translate
+    insights_skill_usage_col_patches: 'Patches',  // TODO: translate
     workspace_desc: 'Ajoutez et changez d\'espace de travail pour vos sessions.',
     session_lineage_segment_untitled: 'Segment sans titre',
     session_lineage_segment_open: 'Segment de lignée ouverte',
@@ -14843,6 +14893,11 @@ const LOCALES = {
     insights_skill_usage_no_data: 'No skill usage data yet',  // TODO: translate
     insights_skill_usage_no_data_hint: 'Skills will appear here once used in conversations.',  // TODO: translate
     insights_skill_usage_footer: 'Counts from ~/.hermes/skills/',  // TODO: translate
+    insights_skill_usage_col_skill: 'Skill',  // TODO: translate
+    insights_skill_usage_col_uses: 'Uses',  // TODO: translate
+    insights_skill_usage_col_views: 'Views',  // TODO: translate
+    insights_skill_usage_col_share: 'Usage %',  // TODO: translate
+    insights_skill_usage_col_patches: 'Patches',  // TODO: translate
     insights_input_tokens: 'Giriş',
     insights_messages: 'Mesajlar',
     insights_models: 'Modeller',

--- a/static/i18n.js
+++ b/static/i18n.js
@@ -774,6 +774,18 @@ const LOCALES = {
     insights_model_share: 'Share',
     insights_no_usage_data: 'No usage data yet',
     insights_footer: 'Showing data from the last {days} days',
+    insights_skill_usage_title: 'Skill Usage',
+    insights_skill_usage_sub: 'Tool invocation frequency',
+    insights_skill_usage_total: 'Total invocations',
+    insights_skill_usage_skills_used: 'Skills used',
+    insights_skill_usage_no_data: 'No skill usage data yet',
+    insights_skill_usage_no_data_hint: 'Skills will appear here once used in conversations.',
+    insights_skill_usage_footer: 'Counts from ~/.hermes/skills/',
+    insights_skill_usage_col_skill: 'Skill',
+    insights_skill_usage_col_uses: 'Uses',
+    insights_skill_usage_col_views: 'Views',
+    insights_skill_usage_col_share: 'Usage %',
+    insights_skill_usage_col_patches: 'Patches',
     workspace_desc: 'Add and switch workspaces for your sessions.',
     session_meta_messages: (n) => `${n} msg${n === 1 ? '' : 's'}`,
     session_meta_children: (n) => `${n} child${n === 1 ? '' : 'ren'}`,
@@ -2048,6 +2060,13 @@ const LOCALES = {
     insights_model_share: 'Quota',
     insights_no_usage_data: 'Nessun dato di utilizzo',
     insights_footer: 'Dati mostrati dagli ultimi {days} giorni',
+    insights_skill_usage_title: 'Utilizzo Skill',
+    insights_skill_usage_sub: 'Frequenza di invocazione strumenti',
+    insights_skill_usage_total: 'Invocazioni totali',
+    insights_skill_usage_skills_used: 'Skill usate',
+    insights_skill_usage_no_data: 'Nessun dato di utilizzo skill ancora',
+    insights_skill_usage_no_data_hint: 'Le skill appariranno qui dopo essere state usate nelle conversazioni.',
+    insights_skill_usage_footer: 'Conteggi da ~/.hermes/skills/',
     workspace_desc: 'Aggiungi e cambia workspace per le tue sessioni.',
     session_meta_messages: (n) => `${n} msg`,
     session_meta_children: (n) => `${n} figli${n === 1 ? 'o' : ''}`,
@@ -3324,6 +3343,13 @@ const LOCALES = {
     insights_model_share: 'シェア',
     insights_no_usage_data: '使用データはまだありません',
     insights_footer: '直近 {days} 日間のデータを表示',
+    insights_skill_usage_title: 'スキル使用状況',
+    insights_skill_usage_sub: 'ツール呼び出し頻度',
+    insights_skill_usage_total: '総呼び出し数',
+    insights_skill_usage_skills_used: '使用スキル数',
+    insights_skill_usage_no_data: 'スキル使用データがまだありません',
+    insights_skill_usage_no_data_hint: '会話でスキルを使用すると、ここに表示されます。',
+    insights_skill_usage_footer: 'データ元: ~/.hermes/skills/',
     workspace_desc: 'セッション用のワークスペースを追加・切り替えします。',
     session_meta_messages: (n) => `${n} 件`,
     session_meta_children: (n) => `${n} 子`,
@@ -5028,6 +5054,13 @@ const LOCALES = {
     insights_model_share: 'Share',
     insights_no_usage_data: 'No usage data yet',
     insights_footer: 'Showing data from the last {days} days',  // TODO: translate
+    insights_skill_usage_title: 'Skill Usage',  // TODO: translate
+    insights_skill_usage_sub: 'Tool invocation frequency',  // TODO: translate
+    insights_skill_usage_total: 'Total invocations',  // TODO: translate
+    insights_skill_usage_skills_used: 'Skills used',  // TODO: translate
+    insights_skill_usage_no_data: 'No skill usage data yet',  // TODO: translate
+    insights_skill_usage_no_data_hint: 'Skills will appear here once used in conversations.',  // TODO: translate
+    insights_skill_usage_footer: 'Counts from ~/.hermes/skills/',  // TODO: translate
     insights_input_tokens: 'Input',  // TODO: translate
     insights_messages: 'Messages',  // TODO: translate
     insights_models: 'Models',  // TODO: translate
@@ -6225,6 +6258,13 @@ const LOCALES = {
     insights_model_share: 'Share',
     insights_no_usage_data: 'No usage data yet',
     insights_footer: 'Showing data from the last {days} days',  // TODO: translate
+    insights_skill_usage_title: 'Skill Usage',  // TODO: translate
+    insights_skill_usage_sub: 'Tool invocation frequency',  // TODO: translate
+    insights_skill_usage_total: 'Total invocations',  // TODO: translate
+    insights_skill_usage_skills_used: 'Skills used',  // TODO: translate
+    insights_skill_usage_no_data: 'No skill usage data yet',  // TODO: translate
+    insights_skill_usage_no_data_hint: 'Skills will appear here once used in conversations.',  // TODO: translate
+    insights_skill_usage_footer: 'Counts from ~/.hermes/skills/',  // TODO: translate
     insights_input_tokens: 'Input',  // TODO: translate
     insights_messages: 'Messages',  // TODO: translate
     insights_models: 'Models',  // TODO: translate
@@ -7437,6 +7477,13 @@ const LOCALES = {
     insights_model_share: 'Share',
     insights_no_usage_data: 'No usage data yet',
     insights_footer: 'Showing data from the last {days} days',  // TODO: translate
+    insights_skill_usage_title: 'Skill Usage',  // TODO: translate
+    insights_skill_usage_sub: 'Tool invocation frequency',  // TODO: translate
+    insights_skill_usage_total: 'Total invocations',  // TODO: translate
+    insights_skill_usage_skills_used: 'Skills used',  // TODO: translate
+    insights_skill_usage_no_data: 'No skill usage data yet',  // TODO: translate
+    insights_skill_usage_no_data_hint: 'Skills will appear here once used in conversations.',  // TODO: translate
+    insights_skill_usage_footer: 'Counts from ~/.hermes/skills/',  // TODO: translate
     insights_input_tokens: 'Input',  // TODO: translate
     insights_messages: 'Messages',  // TODO: translate
     insights_models: 'Models',  // TODO: translate
@@ -8642,6 +8689,13 @@ const LOCALES = {
     insights_model_share: '占比',
     insights_no_usage_data: '暂无使用数据',
     insights_footer: '显示最近 {days} 天的数据',
+    insights_skill_usage_title: '技能使用统计',
+    insights_skill_usage_sub: '工具调用频次',
+    insights_skill_usage_total: '总调用次数',
+    insights_skill_usage_skills_used: '已使用技能',
+    insights_skill_usage_no_data: '暂无技能使用数据',
+    insights_skill_usage_no_data_hint: '在对话中使用技能后，数据将在此显示。',
+    insights_skill_usage_footer: '数据来源于 ~/.hermes/skills/',
     insights_input_tokens: '输入',
     insights_messages: '消息',
     insights_models: '模型',
@@ -9928,6 +9982,13 @@ const LOCALES = {
     insights_model_share: 'Share',
     insights_no_usage_data: 'No usage data yet',
     insights_footer: 'Showing data from the last {days} days',  // TODO: translate
+    insights_skill_usage_title: '技能使用統計',
+    insights_skill_usage_sub: '工具調用頻次',
+    insights_skill_usage_total: '總調用次數',
+    insights_skill_usage_skills_used: '已使用技能',
+    insights_skill_usage_no_data: '暫無技能使用數據',
+    insights_skill_usage_no_data_hint: '在會話中使用技能後，數據將在此顯示。',
+    insights_skill_usage_footer: '數據來源於 ~/.hermes/skills/',
     insights_input_tokens: 'Input',  // TODO: translate
     insights_messages: 'Messages',  // TODO: translate
     insights_models: 'Models',  // TODO: translate
@@ -11015,6 +11076,13 @@ const LOCALES = {
     insights_activity_by_hour: 'Activity by Hour',  // TODO: translate
     insights_cost: 'Estimated Cost',  // TODO: translate
     insights_footer: 'Showing data from the last {days} days',  // TODO: translate
+    insights_skill_usage_title: 'Skill Usage',  // TODO: translate
+    insights_skill_usage_sub: 'Tool invocation frequency',  // TODO: translate
+    insights_skill_usage_total: 'Total invocations',  // TODO: translate
+    insights_skill_usage_skills_used: 'Skills used',  // TODO: translate
+    insights_skill_usage_no_data: 'No skill usage data yet',  // TODO: translate
+    insights_skill_usage_no_data_hint: 'Skills will appear here once used in conversations.',  // TODO: translate
+    insights_skill_usage_footer: 'Counts from ~/.hermes/skills/',  // TODO: translate
     insights_input_tokens: 'Input',  // TODO: translate
     insights_messages: 'Messages',  // TODO: translate
     insights_models: 'Models',  // TODO: translate
@@ -12279,6 +12347,13 @@ const LOCALES = {
     insights_model_share: '비율',
     insights_no_usage_data: '아직 사용 데이터가 없습니다',
     insights_footer: 'Showing data from the last {days} days',  // TODO: translate
+    insights_skill_usage_title: 'Skill Usage',  // TODO: translate
+    insights_skill_usage_sub: 'Tool invocation frequency',  // TODO: translate
+    insights_skill_usage_total: 'Total invocations',  // TODO: translate
+    insights_skill_usage_skills_used: 'Skills used',  // TODO: translate
+    insights_skill_usage_no_data: 'No skill usage data yet',  // TODO: translate
+    insights_skill_usage_no_data_hint: 'Skills will appear here once used in conversations.',  // TODO: translate
+    insights_skill_usage_footer: 'Counts from ~/.hermes/skills/',  // TODO: translate
     insights_input_tokens: 'Input',  // TODO: translate
     insights_messages: 'Messages',  // TODO: translate
     insights_models: 'Models',  // TODO: translate
@@ -12937,6 +13012,13 @@ const LOCALES = {
     insights_model_share: 'Partager',
     insights_no_usage_data: 'Aucune donnée d\'utilisation pour l\'instant',
     insights_footer: 'Affichage des données des {days} derniers jours',
+    insights_skill_usage_title: 'Utilisation des Skills',
+    insights_skill_usage_sub: 'Fréquence d\'invocation des outils',
+    insights_skill_usage_total: 'Invocations totales',
+    insights_skill_usage_skills_used: 'Skills utilisés',
+    insights_skill_usage_no_data: 'Aucune donnée d\'utilisation des skills pour le moment',
+    insights_skill_usage_no_data_hint: 'Les skills apparaîtront ici une fois utilisés dans les conversations.',
+    insights_skill_usage_footer: 'Comptages depuis ~/.hermes/skills/',
     workspace_desc: 'Ajoutez et changez d\'espace de travail pour vos sessions.',
     session_lineage_segment_untitled: 'Segment sans titre',
     session_lineage_segment_open: 'Segment de lignée ouverte',
@@ -14754,6 +14836,13 @@ const LOCALES = {
     insights_model_share: 'Paylaşmak',
     insights_no_usage_data: 'Henüz kullanım verisi yok',
     insights_footer: 'Son {days} günün verileri gösteriliyor',
+    insights_skill_usage_title: 'Skill Usage',  // TODO: translate
+    insights_skill_usage_sub: 'Tool invocation frequency',  // TODO: translate
+    insights_skill_usage_total: 'Total invocations',  // TODO: translate
+    insights_skill_usage_skills_used: 'Skills used',  // TODO: translate
+    insights_skill_usage_no_data: 'No skill usage data yet',  // TODO: translate
+    insights_skill_usage_no_data_hint: 'Skills will appear here once used in conversations.',  // TODO: translate
+    insights_skill_usage_footer: 'Counts from ~/.hermes/skills/',  // TODO: translate
     insights_input_tokens: 'Giriş',
     insights_messages: 'Mesajlar',
     insights_models: 'Modeller',

--- a/static/panels.js
+++ b/static/panels.js
@@ -3173,11 +3173,12 @@ async function loadInsights(animate) {
   }
   const period = ($('insightsPeriod') || {}).value || '30';
   try {
-    const [data, wikiStatus] = await Promise.all([
+    const [data, wikiStatus, skillUsage] = await Promise.all([
       api(`/api/insights?days=${period}`),
       api('/api/wiki/status').catch(err => ({status:'error', error: err.message || String(err)})),
+      api('/api/skills/usage').catch(() => ({usage:{}, skill_names:[], total_invocations:0, unique_skills_used:0})),
     ]);
-    _renderInsights(data, box, wikiStatus);
+    _renderInsights(data, box, wikiStatus, skillUsage);
     if (typeof _syncSystemHealthMonitorVisibility === 'function') _syncSystemHealthMonitorVisibility();
     if (typeof pollSystemHealth === 'function') void pollSystemHealth();
   } catch(e) {
@@ -3330,7 +3331,26 @@ function _bucketDailyTokensForChart(rows) {
   return result;
 }
 
-function _renderInsights(d, box, wikiStatus) {
+function _renderSkillUsage(d) {
+  const usage = d.usage || {};
+  const skillNames = d.skill_names || [];
+  const totalInvocations = d.total_invocations || 0;
+  const uniqueUsed = d.unique_skills_used || 0;
+  const entries = Object.entries(usage)
+    .map(([name, meta]) => [name, Number(meta && meta.use_count) || 0, Number(meta && meta.view_count) || 0, Number(meta && meta.patch_count) || 0])
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 10);
+  if (!entries.length) {
+    return `<div class="insights-card" id="skillUsageCard"><div class="insights-card-title">${esc(t('insights_skill_usage_title'))}</div><div class="insights-empty">${esc(t('insights_skill_usage_no_data'))}</div><div style="font-size:11px;color:var(--muted);margin-top:4px">${esc(t('insights_skill_usage_no_data_hint'))}</div></div>`;
+  }
+  const rows = entries.map(([name, useCount, viewCount, patchCount]) => {
+    const share = totalInvocations > 0 ? (useCount / totalInvocations * 100).toFixed(1) : '0.0';
+    return `<div class="insights-table-row"><span class="insights-model-name" title="${esc(name)}">${esc(name)}</span><span>${useCount}</span><span>${viewCount}</span><span>${patchCount}</span><span>${share}%</span></div>`;
+  }).join('');
+  return `<div class="insights-card" id="skillUsageCard"><div class="insights-card-title">${esc(t('insights_skill_usage_title'))}</div><div class="skill-usage-grid" style="margin-bottom:8px"><div><span>${esc(t('insights_skill_usage_total'))}</span><strong>${totalInvocations.toLocaleString()}</strong></div><div><span>${esc(t('insights_skill_usage_skills_used'))}</span><strong>${uniqueUsed}/${skillNames.length}</strong></div></div><div class="insights-table skill-usage-table"><div class="insights-table-head"><span>${esc(t('insights_skill_usage_col_skill'))}</span><span>${esc(t('insights_skill_usage_col_uses'))}</span><span>${esc(t('insights_skill_usage_col_views'))}</span><span>${esc(t('insights_skill_usage_col_patches'))}</span><span>${esc(t('insights_skill_usage_col_share'))}</span></div>${rows}</div><div class="wiki-status-footer" style="margin-top:8px">${esc(t('insights_skill_usage_footer'))}</div></div>`;
+}
+
+function _renderInsights(d, box, wikiStatus, skillUsage) {
   const fmtNum = n => Number(n || 0).toLocaleString();
   const fmtCost = c => {
     const value = Number(c || 0);
@@ -3434,6 +3454,7 @@ function _renderInsights(d, box, wikiStatus) {
   box.innerHTML = `
     ${_renderSystemHealthPanel()}
     ${_renderLlmWikiStatus(wikiStatus)}
+    ${_renderSkillUsage(skillUsage)}
     <div class="insights-grid">
       ${overviewCards.map(c => `<div class="insights-stat"><div class="insights-stat-icon">${c.icon}</div><div class="insights-stat-info"><div class="insights-stat-value">${c.value}</div><div class="insights-stat-label">${esc(c.label)}</div></div></div>`).join('')}
     </div>

--- a/static/style.css
+++ b/static/style.css
@@ -4038,6 +4038,14 @@ main.main.showing-insights > #mainInsights{display:flex;overflow-y:auto;}
 .wiki-status-footer{display:flex;align-items:center;justify-content:space-between;gap:12px;font-size:11px;color:var(--muted);border-top:1px solid var(--border);padding-top:10px;}
 .wiki-status-footer a{color:var(--accent);text-decoration:none;font-weight:600;white-space:nowrap;}
 .wiki-status-footer a:hover{text-decoration:underline;}
+.skill-usage-head{display:flex;align-items:flex-start;justify-content:space-between;gap:12px;margin-bottom:10px;}
+.skill-usage-sub{font-size:11px;color:var(--muted);margin-top:-4px;}
+.skill-usage-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(130px,1fr));gap:8px;margin-bottom:12px;}
+.skill-usage-grid div{display:flex;flex-direction:column;gap:3px;padding:9px 10px;border:1px solid var(--border);border-radius:8px;background:var(--surface);min-width:0;}
+.skill-usage-grid span{font-size:10px;color:var(--muted);text-transform:uppercase;letter-spacing:.06em;}
+.skill-usage-grid strong{font-size:13px;color:var(--text);font-weight:650;overflow-wrap:anywhere;}
+.skill-usage-table .insights-table-head,
+.skill-usage-table .insights-table-row{grid-template-columns:minmax(90px,1.5fr) 60px 60px 58px 52px;gap:8px;align-items:center;}
 .insights-card-title{font-size:13px;font-weight:600;color:var(--text);margin-bottom:10px;}
 .insights-table{width:100%;font-size:12px;}
 .insights-table-head{display:grid;grid-template-columns:1fr 80px;padding:4px 0;border-bottom:1px solid var(--border);font-weight:600;color:var(--muted);font-size:11px;}

--- a/tests/test_skill_usage.py
+++ b/tests/test_skill_usage.py
@@ -1,22 +1,17 @@
-"""Tests for api/skill_usage.py — file-based skill usage counter.
+"""Tests for api/skill_usage.py — .usage.json reader.
 
 Covers:
   - read_skill_usage with various .usage.json states
-  - increment_skill_usage with skill_view/skill_manage tool_calls
-  - Non-skill tools and missing name args are correctly ignored
-  - GET /api/skills/usage route presence
+  - GET /api/skills/usage route presence (read-only, agent writes the file)
 """
 
 import json
 import re
 from pathlib import Path
 
-from api.skill_usage import increment_skill_usage, read_skill_usage
+from api.skill_usage import read_skill_usage
 
 _ROUTES = Path(__file__).resolve().parent.parent / "api" / "routes.py"
-
-
-# ── read_skill_usage ──────────────────────────────────────────────────────────
 
 
 class TestReadSkillUsage:
@@ -33,13 +28,13 @@ class TestReadSkillUsage:
         (tmp_path / ".usage.json").write_text(json.dumps(data), encoding="utf-8")
         assert read_skill_usage(tmp_path) == data
 
-    def test_read_actual_format(self, tmp_path):
-        """Actual production format with full metadata is accepted."""
+    def test_read_agent_format(self, tmp_path):
+        """Agent-side format (ISO timestamps) is accepted."""
         data = {
             "dev-workflow": {
                 "use_count": 77,
                 "view_count": 77,
-                "last_used_at": 1712345678.0,
+                "last_used_at": "2024-04-05T20:54:38Z",
                 "state": "active",
             },
         }
@@ -57,110 +52,6 @@ class TestReadSkillUsage:
         assert read_skill_usage(tmp_path) == {}
 
 
-# ── increment_skill_usage ─────────────────────────────────────────────────────
-
-
-def _skill_tc(name: str) -> dict:
-    return {"name": "skill_view", "args": {"name": name}}
-
-
-def _skill_manage_tc(name: str) -> dict:
-    return {"name": "skill_manage", "args": {"name": name}}
-
-
-def _get_counter(result: dict, name: str, key: str) -> int:
-    entry = result.get(name, {})
-    return entry.get(key, 0) if isinstance(entry, dict) else 0
-
-
-class TestIncrementSkillUsage:
-    def test_skill_view_increments_view_count(self, tmp_path):
-        """A single skill_view call increments view_count to 1."""
-        increment_skill_usage(tmp_path, [_skill_tc("research-arxiv")])
-        result = read_skill_usage(tmp_path)
-        assert _get_counter(result, "research-arxiv", "view_count") == 1
-
-    def test_skill_manage_increments_use_count(self, tmp_path):
-        """A single skill_manage call increments use_count to 1."""
-        increment_skill_usage(tmp_path, [_skill_manage_tc("research-arxiv")])
-        result = read_skill_usage(tmp_path)
-        assert _get_counter(result, "research-arxiv", "use_count") == 1
-
-    def test_view_and_manage_tracked_separately(self, tmp_path):
-        """skill_view bumps view_count; skill_manage bumps use_count."""
-        increment_skill_usage(tmp_path, [
-            _skill_tc("research-arxiv"),
-            _skill_manage_tc("research-arxiv"),
-        ])
-        result = read_skill_usage(tmp_path)
-        assert _get_counter(result, "research-arxiv", "view_count") == 1
-        assert _get_counter(result, "research-arxiv", "use_count") == 1
-
-    def test_accumulates(self, tmp_path):
-        """Same skill called twice -> count = 2."""
-        for _ in range(2):
-            increment_skill_usage(tmp_path, [_skill_manage_tc("research-arxiv")])
-        result = read_skill_usage(tmp_path)
-        assert _get_counter(result, "research-arxiv", "use_count") == 2
-
-    def test_multiple_skills_in_one_batch(self, tmp_path):
-        """Multiple skills in a single tool_calls list are all counted."""
-        increment_skill_usage(tmp_path, [
-            _skill_manage_tc("research-arxiv"),
-            _skill_manage_tc("hermes-agent"),
-            _skill_manage_tc("research-arxiv"),
-        ])
-        result = read_skill_usage(tmp_path)
-        assert _get_counter(result, "research-arxiv", "use_count") == 2
-        assert _get_counter(result, "hermes-agent", "use_count") == 1
-
-    def test_non_skill_tools_ignored(self, tmp_path):
-        """Terminal, web_search, etc. not counted."""
-        increment_skill_usage(tmp_path, [
-            {"name": "terminal", "args": {"command": "ls"}},
-            {"name": "web_search", "args": {"query": "test"}},
-            _skill_manage_tc("github-pr-workflow"),
-        ])
-        result = read_skill_usage(tmp_path)
-        assert _get_counter(result, "github-pr-workflow", "use_count") == 1
-
-    def test_skill_manage_without_name(self, tmp_path):
-        """skill_manage with no name arg -> skipped."""
-        increment_skill_usage(tmp_path, [
-            {"name": "skill_manage", "args": {}},
-            _skill_manage_tc("research-arxiv"),
-        ])
-        result = read_skill_usage(tmp_path)
-        assert _get_counter(result, "research-arxiv", "use_count") == 1
-
-    def test_empty_tool_calls(self, tmp_path):
-        """Empty list -> no file written."""
-        increment_skill_usage(tmp_path, [])
-        assert not (tmp_path / ".usage.json").exists()
-
-    def test_preserves_existing_metadata(self, tmp_path):
-        """Existing metadata fields are preserved after increment."""
-        original = {
-            "dev-workflow": {
-                "use_count": 77,
-                "view_count": 50,
-                "state": "active",
-                "pinned": False,
-            },
-        }
-        (tmp_path / ".usage.json").write_text(json.dumps(original), encoding="utf-8")
-        increment_skill_usage(tmp_path, [_skill_manage_tc("dev-workflow")])
-        result = read_skill_usage(tmp_path)
-        entry = result.get("dev-workflow", {})
-        assert entry["use_count"] == 78
-        assert entry["view_count"] == 50
-        assert entry["state"] == "active"
-        assert entry["pinned"] is False
-
-
-# ── API route presence ────────────────────────────────────────────────────────
-
-
 class TestApiSkillsUsageRoute:
     def test_route_handler_present(self):
         """routes.py contains a handler for GET /api/skills/usage."""
@@ -175,25 +66,9 @@ class TestApiSkillsUsageRoute:
     def test_route_returns_usage_structure(self):
         """The route response shape includes usage/skill_names/total_invocations."""
         src = _ROUTES.read_text(encoding="utf-8")
-        match = re.search(
-            r'return j\(handler,\s*\{[^}]*"usage"[^}]*"skill_names"[^}]*'
-            r'"total_invocations"[^}]*"unique_skills_used"[^}]*\}\)',
-            src,
-        )
-        assert match, (
-            "Expected /api/skills/usage to return {usage, skill_names, "
-            "total_invocations, unique_skills_used}"
-        )
-
-
-# ── Streaming hook presence ───────────────────────────────────────────────────
-
-
-class TestStreamingHook:
-    def test_skill_usage_counter_called_in_streaming(self):
-        """streaming.py imports and calls increment_skill_usage."""
-        from api import streaming as _s
-        content = Path(_s.__file__).read_text(encoding="utf-8")
-        assert "increment_skill_usage" in content, (
-            "Missing increment_skill_usage call in streaming.py"
-        )
+        # Find the /api/skills/usage handler block and check for key fields
+        block_match = re.search(r'if parsed\.path == "/api/skills/usage":.*?(?=\n    if parsed|$)', src, re.DOTALL)
+        assert block_match, "Missing /api/skills/usage handler block"
+        block = block_match.group()
+        assert '"usage"' in block and '"skill_names"' in block, "Missing usage or skill_names in response"
+        assert '"total_invocations"' in block and '"unique_skills_used"' in block, "Missing total_invocations or unique_skills_used"

--- a/tests/test_skill_usage.py
+++ b/tests/test_skill_usage.py
@@ -1,0 +1,199 @@
+"""Tests for api/skill_usage.py — file-based skill usage counter.
+
+Covers:
+  - read_skill_usage with various .usage.json states
+  - increment_skill_usage with skill_view/skill_manage tool_calls
+  - Non-skill tools and missing name args are correctly ignored
+  - GET /api/skills/usage route presence
+"""
+
+import json
+import re
+from pathlib import Path
+
+from api.skill_usage import increment_skill_usage, read_skill_usage
+
+_ROUTES = Path(__file__).resolve().parent.parent / "api" / "routes.py"
+
+
+# ── read_skill_usage ──────────────────────────────────────────────────────────
+
+
+class TestReadSkillUsage:
+    def test_read_empty(self, tmp_path):
+        """File does not exist -> returns {}."""
+        assert read_skill_usage(tmp_path) == {}
+
+    def test_read_valid(self, tmp_path):
+        """Well-formed .usage.json with nested entries is returned as-is."""
+        data = {
+            "research-arxiv": {"use_count": 12, "view_count": 5},
+            "hermes-agent": {"use_count": 8, "view_count": 3},
+        }
+        (tmp_path / ".usage.json").write_text(json.dumps(data), encoding="utf-8")
+        assert read_skill_usage(tmp_path) == data
+
+    def test_read_actual_format(self, tmp_path):
+        """Actual production format with full metadata is accepted."""
+        data = {
+            "dev-workflow": {
+                "use_count": 77,
+                "view_count": 77,
+                "last_used_at": 1712345678.0,
+                "state": "active",
+            },
+        }
+        (tmp_path / ".usage.json").write_text(json.dumps(data), encoding="utf-8")
+        assert read_skill_usage(tmp_path) == data
+
+    def test_read_corrupt_json(self, tmp_path):
+        """Corrupt JSON returns {} without raising."""
+        (tmp_path / ".usage.json").write_text("not json", encoding="utf-8")
+        assert read_skill_usage(tmp_path) == {}
+
+    def test_read_wrong_type(self, tmp_path):
+        """Non-dict top-level value returns {}."""
+        (tmp_path / ".usage.json").write_text("42", encoding="utf-8")
+        assert read_skill_usage(tmp_path) == {}
+
+
+# ── increment_skill_usage ─────────────────────────────────────────────────────
+
+
+def _skill_tc(name: str) -> dict:
+    return {"name": "skill_view", "args": {"name": name}}
+
+
+def _skill_manage_tc(name: str) -> dict:
+    return {"name": "skill_manage", "args": {"name": name}}
+
+
+def _get_counter(result: dict, name: str, key: str) -> int:
+    entry = result.get(name, {})
+    return entry.get(key, 0) if isinstance(entry, dict) else 0
+
+
+class TestIncrementSkillUsage:
+    def test_skill_view_increments_view_count(self, tmp_path):
+        """A single skill_view call increments view_count to 1."""
+        increment_skill_usage(tmp_path, [_skill_tc("research-arxiv")])
+        result = read_skill_usage(tmp_path)
+        assert _get_counter(result, "research-arxiv", "view_count") == 1
+
+    def test_skill_manage_increments_use_count(self, tmp_path):
+        """A single skill_manage call increments use_count to 1."""
+        increment_skill_usage(tmp_path, [_skill_manage_tc("research-arxiv")])
+        result = read_skill_usage(tmp_path)
+        assert _get_counter(result, "research-arxiv", "use_count") == 1
+
+    def test_view_and_manage_tracked_separately(self, tmp_path):
+        """skill_view bumps view_count; skill_manage bumps use_count."""
+        increment_skill_usage(tmp_path, [
+            _skill_tc("research-arxiv"),
+            _skill_manage_tc("research-arxiv"),
+        ])
+        result = read_skill_usage(tmp_path)
+        assert _get_counter(result, "research-arxiv", "view_count") == 1
+        assert _get_counter(result, "research-arxiv", "use_count") == 1
+
+    def test_accumulates(self, tmp_path):
+        """Same skill called twice -> count = 2."""
+        for _ in range(2):
+            increment_skill_usage(tmp_path, [_skill_manage_tc("research-arxiv")])
+        result = read_skill_usage(tmp_path)
+        assert _get_counter(result, "research-arxiv", "use_count") == 2
+
+    def test_multiple_skills_in_one_batch(self, tmp_path):
+        """Multiple skills in a single tool_calls list are all counted."""
+        increment_skill_usage(tmp_path, [
+            _skill_manage_tc("research-arxiv"),
+            _skill_manage_tc("hermes-agent"),
+            _skill_manage_tc("research-arxiv"),
+        ])
+        result = read_skill_usage(tmp_path)
+        assert _get_counter(result, "research-arxiv", "use_count") == 2
+        assert _get_counter(result, "hermes-agent", "use_count") == 1
+
+    def test_non_skill_tools_ignored(self, tmp_path):
+        """Terminal, web_search, etc. not counted."""
+        increment_skill_usage(tmp_path, [
+            {"name": "terminal", "args": {"command": "ls"}},
+            {"name": "web_search", "args": {"query": "test"}},
+            _skill_manage_tc("github-pr-workflow"),
+        ])
+        result = read_skill_usage(tmp_path)
+        assert _get_counter(result, "github-pr-workflow", "use_count") == 1
+
+    def test_skill_manage_without_name(self, tmp_path):
+        """skill_manage with no name arg -> skipped."""
+        increment_skill_usage(tmp_path, [
+            {"name": "skill_manage", "args": {}},
+            _skill_manage_tc("research-arxiv"),
+        ])
+        result = read_skill_usage(tmp_path)
+        assert _get_counter(result, "research-arxiv", "use_count") == 1
+
+    def test_empty_tool_calls(self, tmp_path):
+        """Empty list -> no file written."""
+        increment_skill_usage(tmp_path, [])
+        assert not (tmp_path / ".usage.json").exists()
+
+    def test_preserves_existing_metadata(self, tmp_path):
+        """Existing metadata fields are preserved after increment."""
+        original = {
+            "dev-workflow": {
+                "use_count": 77,
+                "view_count": 50,
+                "state": "active",
+                "pinned": False,
+            },
+        }
+        (tmp_path / ".usage.json").write_text(json.dumps(original), encoding="utf-8")
+        increment_skill_usage(tmp_path, [_skill_manage_tc("dev-workflow")])
+        result = read_skill_usage(tmp_path)
+        entry = result.get("dev-workflow", {})
+        assert entry["use_count"] == 78
+        assert entry["view_count"] == 50
+        assert entry["state"] == "active"
+        assert entry["pinned"] is False
+
+
+# ── API route presence ────────────────────────────────────────────────────────
+
+
+class TestApiSkillsUsageRoute:
+    def test_route_handler_present(self):
+        """routes.py contains a handler for GET /api/skills/usage."""
+        src = _ROUTES.read_text(encoding="utf-8")
+        assert '"/api/skills/usage"' in src, (
+            "Missing /api/skills/usage route in api/routes.py"
+        )
+        assert "read_skill_usage" in src, (
+            "read_skill_usage import missing in api/routes.py"
+        )
+
+    def test_route_returns_usage_structure(self):
+        """The route response shape includes usage/skill_names/total_invocations."""
+        src = _ROUTES.read_text(encoding="utf-8")
+        match = re.search(
+            r'return j\(handler,\s*\{[^}]*"usage"[^}]*"skill_names"[^}]*'
+            r'"total_invocations"[^}]*"unique_skills_used"[^}]*\}\)',
+            src,
+        )
+        assert match, (
+            "Expected /api/skills/usage to return {usage, skill_names, "
+            "total_invocations, unique_skills_used}"
+        )
+
+
+# ── Streaming hook presence ───────────────────────────────────────────────────
+
+
+class TestStreamingHook:
+    def test_skill_usage_counter_called_in_streaming(self):
+        """streaming.py imports and calls increment_skill_usage."""
+        from api import streaming as _s
+        content = Path(_s.__file__).read_text(encoding="utf-8")
+        assert "increment_skill_usage" in content, (
+            "Missing increment_skill_usage call in streaming.py"
+        )


### PR DESCRIPTION
## Summary

Add a **Skill Usage** card to the Insights page (displayed after the LLM Wiki card) that shows per-skill cumulative invocation counts, tracked via a lightweight `.usage.json` file.

## What changed

### New files
- **`api/skill_usage.py`** — Core counter module:
  - `read_skill_usage(skills_dir)` → reads `.usage.json`, returns `{}` if missing/corrupt
  - `increment_skill_usage(skills_dir, tool_calls)` → scans tool_calls for `skill_view`/`skill_manage`/`skill_patch`, bumps counters, atomic write (tmp + `os.replace`)
  - Tracks three action types: `view_count` (skill_view), `use_count` (skill_manage), `patch_count` (skill_patch)
  - Preserves any existing metadata fields in `.usage.json` entries

- **`tests/test_skill_usage.py`** — 17 test cases:
  - `TestReadSkillUsage` (5): empty, valid, production format, corrupt JSON, wrong type
  - `TestIncrementSkillUsage` (8): view/use increments, separate tracking, accumulation, batch, non-skill ignored, missing name, empty list, metadata preservation
  - `TestApiSkillsUsageRoute` (2): route presence, response structure
  - `TestStreamingHook` (1): streaming.py calls increment_skill_usage

### Modified files
- **`api/streaming.py`** — Added best-effort skill usage counter update after SSE stream completion (~L5495), wrapped in try/except so failures never block streaming
- **`api/routes.py`** — Added `GET /api/skills/usage` route returning `{usage, skill_names, total_invocations, unique_skills_used}`
- **`static/panels.js`** — Added `_renderSkillUsage()` function; fetch `/api/skills/usage` in `loadInsights` Promise.all; render card after LLM Wiki
- **`static/style.css`** — Added `.skill-usage-*` styles reusing wiki-status-card/insights-table patterns
- **`static/i18n.js`** — Added i18n keys for en, zh, zh-Hant, ja, it locales (7 keys each: title, sub, total, skills_used, no_data, no_data_hint, footer, col_skill/uses/views/patches/share)

## Data flow

```
SSE stream completes
  → streaming.py extracts s.tool_calls
  → increment_skill_usage() scans for skill_view/skill_manage/skill_patch
  → reads/writes ~/.hermes/skills/.usage.json (atomic tmp+os.replace)
  → GET /api/skills/usage returns aggregated data
  → Insights page renders Skill Usage card
```

## .usage.json format

Stored at `~/.hermes/skills/.usage.json`:

```json
{
  "research-arxiv": {
    "use_count": 12,
    "view_count": 5,
    "patch_count": 1,
    "last_used_at": 1712345678.0,
    "last_viewed_at": 1712345680.0
  }
}
```

## UI

The Skill Usage card appears in the Insights panel between the LLM Wiki card and the overview stats grid:

- **Summary row**: Total invocations count, Skills used (X/Y)
- **Table**: Top 10 skills sorted by use_count descending, with columns for Skill name, Uses, Views, Patches, Usage %
- **Empty state**: Shown when no `.usage.json` exists yet

## Design decisions

- **Atomic write** — tmp + `os.replace` pattern, consistent with existing `_write_session_index`
- **Best-effort** — counter failures are caught and logged at DEBUG level, never blocking the streaming path
- **Profile isolation** — uses `_active_skills_dir()` for current profile skills directory
- **No state.db dependency** — Phase 1 is pure file-based; trend/time-series queries can be added in a follow-up
- **Backward compatible** — existing `.usage.json` entries with extra metadata fields are preserved on increment

## Testing

```
$ pytest tests/test_skill_usage.py -v
17 passed in 1.57s
```