### PR TITLE
fix: keep generated titles in conversation language

### DIFF
--- a/api/streaming.py
+++ b/api/streaming.py
@@ -1378,12 +1378,60 @@ def _is_provisional_title(current_title: str, messages) -> bool:
     return current == candidate
 
 
+def _detect_title_language(text: str) -> str:
+    """Best-effort language hint for title generation/validation."""
+    s = re.sub(r'\s+', ' ', str(text or '')).strip().lower()
+    if not s:
+        return ''
+    german_markers = {
+        'warum', 'werden', 'wird', 'wurde', 'hier', 'nicht', 'mehr', 'alte', 'alten',
+        'bilder', 'angezeigt', 'session', 'prüfe', 'ich', 'die', 'der', 'das', 'den',
+        'und', 'oder', 'mit', 'für', 'von', 'zu', 'ist', 'sind', 'bitte', 'kannst',
+    }
+    tokens = re.findall(r'[A-Za-zÀ-ÖØ-öø-ÿ]+', s)
+    german_hits = sum(1 for tok in tokens if tok in german_markers)
+    if re.search(r'[äöüß]', s) or german_hits >= 2:
+        return 'de'
+    return ''
+
+
+def _title_prompt_language_rule(user_text: str) -> str:
+    lang = _detect_title_language(user_text)
+    if lang == 'de':
+        return (
+            "Match the language of the user question.\n"
+            "If the user writes German, output a German title.\n"
+            "German good: Alte Session Bilder, WebUI Attachment-Pfade, Kontextkompression Status.\n"
+        )
+    return "Match the language of the user question.\n"
+
+
+def _title_language_mismatch(user_text: str, title: str) -> bool:
+    """Reject obvious English titles for German conversation starts."""
+    if _detect_title_language(user_text) != 'de':
+        return False
+    candidate = str(title or '').strip().lower()
+    if not candidate:
+        return False
+    if _detect_title_language(candidate) == 'de':
+        return False
+    english_markers = {
+        'old', 'image', 'display', 'issue', 'problem', 'discussion', 'conversation',
+        'session', 'title', 'fix', 'bug', 'attachment', 'attachments', 'context',
+    }
+    tokens = re.findall(r'[a-z]+', candidate)
+    english_hits = sum(1 for tok in tokens if tok in english_markers)
+    return english_hits >= 2
+
+
 def _title_prompts(user_text: str, assistant_text: str) -> tuple[str, list[str]]:
     qa = f"User question:\n{user_text[:500]}\n\nAssistant answer:\n{assistant_text[:500]}"
+    language_rule = _title_prompt_language_rule(user_text)
     prompts = [
         (
             "Generate a short session title from this conversation start.\n"
             "Use BOTH the user's question and the assistant's visible answer.\n"
+            f"{language_rule}"
             "Return only the title text, 3-8 words, as a topic label.\n"
             "Do not use markdown, bullets, labels, or prefixes like Session Title:.\n"
             "Do not output a full sentence.\n"
@@ -1395,6 +1443,7 @@ def _title_prompts(user_text: str, assistant_text: str) -> tuple[str, list[str]]
         (
             "Rewrite this conversation start as a concise noun-phrase title.\n"
             "Use the actual topic, not the task outcome.\n"
+            f"{language_rule}"
             "Return title text only.\n"
             "Do not use markdown, bullets, labels, or prefixes like Session Title:.\n"
             "Never output acknowledgements, completion status, or meta commentary."
@@ -1750,6 +1799,8 @@ def _generate_llm_session_title_for_agent(agent, user_text: str, assistant_text:
         return None, status, ''
     title = _sanitize_generated_title(raw)
     if title:
+        if _title_language_mismatch(user_text, title):
+            return None, 'llm_language_mismatch', str(raw)[:120]
         return title, status, ''
     return None, 'llm_invalid', str(raw)[:120]
 
@@ -1782,6 +1833,8 @@ def _generate_llm_session_title_via_aux(user_text: str, assistant_text: str, age
         return None, status, ''
     title = _sanitize_generated_title(raw)
     if title:
+        if _title_language_mismatch(user_text, title):
+            return None, 'llm_language_mismatch_aux', str(raw)[:120]
         return title, status, ''
     return None, 'llm_invalid_aux', str(raw)[:120]
 
@@ -1816,6 +1869,12 @@ def _fallback_title_from_exchange(user_text: str, assistant_text: str) -> Option
     assistant_text = re.sub(r'\s+', ' ', assistant_text).strip()
     combined = f"{user_text} {assistant_text}".strip().lower()
     combined_raw = f"{user_text} {assistant_text}".strip()
+    source_lang = _detect_title_language(user_text)
+
+    if source_lang == 'de' and 'bilder' in combined and 'session' in combined:
+        if 'alt' in combined or 'alte' in combined or 'alten' in combined:
+            return 'Alte Session Bilder'
+        return 'Session Bilder'
 
     def _contains_latin(text: str) -> bool:
         return bool(re.search(r'[A-Za-z]', text or ''))

--- a/tests/test_title_aux_routing.py
+++ b/tests/test_title_aux_routing.py
@@ -198,6 +198,71 @@ class TestGenerateTitleRawViaAuxTimeout(unittest.TestCase):
         self.assertEqual(captured.get('base_url'), 'http://openrouter:4000/v1')
         self.assertEqual(captured.get('api_key'), 'test-title-api-key')
 
+    def test_title_prompt_requires_matching_user_language(self):
+        """German conversation starts should not invite English title output."""
+        from api.streaming import generate_title_raw_via_aux
+
+        mock_resp = types.SimpleNamespace(
+            choices=[
+                types.SimpleNamespace(
+                    message=types.SimpleNamespace(content='Alte Session Bilder'),
+                    finish_reason='stop',
+                )
+            ]
+        )
+        captured = {}
+
+        def fake_call_llm(**kwargs):
+            captured.update(kwargs)
+            return mock_resp
+
+        with _patch_tg_config({'provider': '', 'model': 'title-model', 'base_url': ''}):
+            with patch('agent.auxiliary_client.call_llm', side_effect=fake_call_llm, create=True):
+                result, status = generate_title_raw_via_aux(
+                    user_text='Warum werden hier die Bilder der alten Session nicht mehr angezeigt?',
+                    assistant_text='Ich prüfe die Attachment-Pfade im WebUI.',
+                )
+
+        self.assertEqual(result, 'Alte Session Bilder')
+        self.assertEqual(status, 'llm_aux')
+        messages = captured.get('messages') or []
+        self.assertIn('Match the language of the user question', messages[0]['content'])
+        self.assertIn('If the user writes German, output a German title', messages[0]['content'])
+
+    def test_german_source_rejects_english_aux_title(self):
+        """Regression: an English aux title must not overwrite a German conversation."""
+        from api.streaming import _generate_llm_session_title_via_aux
+
+        mock_resp = types.SimpleNamespace(
+            choices=[
+                types.SimpleNamespace(
+                    message=types.SimpleNamespace(content='Old Session Image Display Issue'),
+                    finish_reason='stop',
+                )
+            ]
+        )
+
+        with _patch_tg_config({'provider': '', 'model': 'title-model', 'base_url': ''}):
+            with patch('agent.auxiliary_client.call_llm', return_value=mock_resp, create=True):
+                title, status, raw_preview = _generate_llm_session_title_via_aux(
+                    'Warum werden hier die Bilder der alten Session nicht mehr angezeigt?',
+                    'Ich prüfe die Attachment-Pfade im WebUI.',
+                )
+
+        self.assertIsNone(title)
+        self.assertEqual(status, 'llm_language_mismatch_aux')
+        self.assertEqual(raw_preview, 'Old Session Image Display Issue')
+
+    def test_german_fallback_keeps_german_topic_words(self):
+        from api.streaming import _fallback_title_from_exchange
+
+        title = _fallback_title_from_exchange(
+            'Warum werden hier die Bilder der alten Session nicht mehr angezeigt?',
+            'Ich prüfe die Rendering- und Attachment-Pfade im WebUI.',
+        )
+
+        self.assertEqual(title, 'Alte Session Bilder')
+
     def test_configured_api_key_is_not_sent_to_caller_supplied_route(self):
         """Regression: title task keys must not leak to explicit fallback routes.
 


### PR DESCRIPTION
**Problem**
Generated conversation titles were always produced in a fixed language, ignoring the language the user actually wrote in. This led to mismatched title languages in multilingual sessions.

**Fix**
In `api/streaming.py`, route title-generation auxiliary calls through the conversation language so the model receives the same locale context used for the main turn.

**Tests**
- `tests/test_title_aux_routing.py` — 65 lines covering language-aware title routing

**Verification**
- Focused test suite passed