### PR TITLE
Restore visible WebUI progress contract

### DIFF
--- a/api/streaming.py
+++ b/api/streaming.py
@@ -194,8 +194,12 @@ _CANCEL_MARKER_PATTERNS = ('task cancelled', 'task canceled', 'response interrup
 
 _WEBUI_PROGRESS_PROMPT = """
 WebUI progress guidance:
-- Match the normal Hermes messaging style; do not add extra status updates solely because this is a browser session.
-- For long multi-step work that uses tools, you may provide brief user-visible progress updates before continuing with tool calls.
+- Match the normal Hermes messaging style, but do not let long tool-running WebUI turns appear silent.
+- For long multi-step work that uses tools, emit brief user-visible progress updates as normal assistant content, not only as hidden reasoning.
+- Before the first tool batch in a long task, say what you are about to inspect.
+- After each meaningful batch of tool calls, say what you just confirmed and what you will check next before continuing with more tools.
+- Do not run many independent tool batches back-to-back without visible assistant text between them when the task is still ongoing.
+- Do not keep progress only in reasoning, thinking, or tool-result channels; those are not a substitute for visible interim updates.
 - Each update should say what you are about to check, what you just confirmed, or why the next tool call is needed.
 - Keep updates concise, factual, and in the user's language. One or two short sentences are enough.
 - Do not reveal hidden reasoning, chain-of-thought, private scratchpads, secrets, raw logs, or long tool output.

--- a/tests/test_sprint42.py
+++ b/tests/test_sprint42.py
@@ -396,7 +396,34 @@ class TestRuntimeRouteInjection(unittest.TestCase):
         self.assertTrue(callable(init_kwargs["interim_assistant_callback"]))
         self.assertIn("WebUI progress guidance", captured["agent"].ephemeral_system_prompt)
         self.assertIn("Match the normal Hermes messaging style", captured["agent"].ephemeral_system_prompt)
-        self.assertIn("user-visible progress updates", captured["agent"].ephemeral_system_prompt)
+        self.assertIn(
+            "do not let long tool-running WebUI turns appear silent",
+            captured["agent"].ephemeral_system_prompt,
+        )
+        self.assertIn(
+            "emit brief user-visible progress updates as normal assistant content",
+            captured["agent"].ephemeral_system_prompt,
+        )
+        self.assertIn(
+            "Before the first tool batch in a long task, say what you are about to inspect",
+            captured["agent"].ephemeral_system_prompt,
+        )
+        self.assertIn(
+            "After each meaningful batch of tool calls, say what you just confirmed",
+            captured["agent"].ephemeral_system_prompt,
+        )
+        self.assertIn(
+            "Do not run many independent tool batches back-to-back without visible assistant text between them",
+            captured["agent"].ephemeral_system_prompt,
+        )
+        self.assertIn(
+            "Do not keep progress only in reasoning, thinking, or tool-result channels",
+            captured["agent"].ephemeral_system_prompt,
+        )
+        self.assertNotIn(
+            "you may provide brief user-visible progress updates",
+            captured["agent"].ephemeral_system_prompt,
+        )
 
         interim_events = []
         while not fake_queue.empty():


### PR DESCRIPTION
## Thinking Path

- Refs #3014. Companion to #3005.
- Live Stream Running Session needs both a stable frontend timeline and enough visible assistant progress text for that timeline to show.
- #3005 handles the frontend/SSE/reattach/Activity placement layer. This PR intentionally handles only the WebUI prompt contract that encourages models to emit concise visible progress during long tool-running turns.
- The latest dogfood reproduced the remaining problem when the test prompt omitted explicit progress-message requirements: the model could run many tool batches with little visible assistant text, so the UI had no stable text/tool alternation to preserve.
- This PR strengthens the WebUI ephemeral guidance without changing replay, session persistence, Activity rendering, or settled transcript logic.

## What Changed

- Strengthened `_WEBUI_PROGRESS_PROMPT` so long tool-running WebUI turns should not appear silent.
- Requires visible progress updates as normal assistant content, not only hidden reasoning.
- Adds explicit guidance to speak before the first tool batch and after meaningful tool batches before continuing.
- Adds an explicit guard against many independent tool batches running back-to-back without visible assistant text.
- Keeps existing safeguards against hidden reasoning, chain-of-thought, secrets, raw logs, and long tool output.
- Updates the Sprint 42 regression test to lock the stronger wording and reject the old optional `you may provide` phrasing.

## Why It Matters

Frontend replay can preserve visible progress only after the model emits it. Without this prompt contract, some models/providers keep intermediate work in reasoning or tool channels, making the WebUI look silent or making Activity groups appear disconnected from the text.

## Contract Routing

Runtime / streaming behavior. This updates the WebUI ephemeral progress instruction only. It does not change SSE reconnect, run-journal replay, persisted session schema, Activity placement, or reasoning echo suppression; those belong to #3005.

## Contract Change

The prompt contract for long tool-running WebUI turns is strengthened from optional guidance to explicit visible-progress guidance. Direct answers and very short tasks remain exempt, and hidden reasoning / raw tool logs remain prohibited.

## Verification

- `node --check static/ui.js static/messages.js static/sessions.js`
- `pytest -q tests/test_sprint42.py::TestRuntimeRouteInjection::test_runtime_provider_forwards_interim_assistant_callback` — local clean head: 1 passed.
- GitHub Actions `test (3.11)`, `test (3.12)`, and `test (3.13)` pass on commit `fc86e278`.

## Risks / Follow-ups

- Still Draft. This needs manual 8787 dogfood together with #3005 before it should be marked ready for review.
- Prompt guidance improves model behavior but cannot guarantee every model/provider will comply perfectly.
- Watch for over-chatty behavior on short/direct answers; the prompt explicitly exempts those paths, but manual validation should confirm it.

## Model Used

OpenAI GPT-5 Codex. AI assistance was used to inspect the failure mode, split PR scope, implement the prompt/test change, and verify the clean branch.
