### PR TITLE
fix(reasoning): use agent metadata for effort support

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -2128,6 +2128,38 @@ def _heuristic_reasoning_efforts(model_id: str, provider_id: str) -> list[str]:
     return []
 
 
+def _models_dev_reasoning_efforts(model_id: str, provider_id: str) -> list[str] | None:
+    """Return reasoning efforts from Hermes Agent model metadata when known.
+
+    ``None`` means the metadata source is unavailable or has no answer, so the
+    caller should continue to compatibility fallbacks. A concrete list (including
+    ``[]``) is authoritative.
+    """
+    model = _strip_provider_hint_for_reasoning(model_id)
+    provider = str(provider_id or "").strip().lower()
+    if not model or not provider:
+        return None
+
+    try:
+        from agent.models_dev import get_model_capabilities
+    except Exception:
+        return None
+
+    try:
+        capabilities = get_model_capabilities(provider=provider, model=model)
+    except Exception:
+        return None
+    if capabilities is None:
+        return None
+
+    supports_reasoning = getattr(capabilities, "supports_reasoning", None)
+    if supports_reasoning is True:
+        return list(VALID_REASONING_EFFORTS)
+    if supports_reasoning is False:
+        return []
+    return None
+
+
 def resolve_model_reasoning_efforts(
     model_id: str | None = None,
     provider_id: str | None = None,
@@ -2150,51 +2182,42 @@ def resolve_model_reasoning_efforts(
     if provider in {"cursor-acp", "copilot-acp"}:
         return []
 
+    hinted_model = _strip_provider_hint_for_reasoning(model)
+
     try:
         from hermes_cli.models import (
             github_model_reasoning_efforts,
             lmstudio_model_reasoning_options,
         )
     except Exception:
-        return _heuristic_reasoning_efforts(model, provider)
+        if provider in {"copilot", "github-copilot"}:
+            return _heuristic_reasoning_efforts(hinted_model, provider)
+    else:
+        if provider in {"copilot", "github-copilot"}:
+            return github_model_reasoning_efforts(hinted_model)
 
-    hinted_model = _strip_provider_hint_for_reasoning(model)
-    if provider in {"copilot", "github-copilot"}:
-        return github_model_reasoning_efforts(hinted_model)
+        if provider == "openai-codex":
+            bare = hinted_model.rsplit("/", 1)[-1]
+            return github_model_reasoning_efforts(bare)
 
-    if provider == "openai-codex":
-        bare = hinted_model.rsplit("/", 1)[-1]
-        return github_model_reasoning_efforts(bare)
-
-    if provider == "lmstudio":
-        probe_base = resolved_base_url or _get_provider_base_url(provider)
-        opts = lmstudio_model_reasoning_options(model, probe_base)
-        normalized = [str(opt).strip().lower() for opt in opts if str(opt).strip()]
-        if not normalized or set(normalized).issubset({"off"}):
+        if provider == "lmstudio":
+            probe_base = resolved_base_url or _get_provider_base_url(provider)
+            opts = lmstudio_model_reasoning_options(hinted_model, probe_base)
+            normalized = [str(opt).strip().lower() for opt in opts if str(opt).strip()]
+            if not normalized or set(normalized).issubset({"off"}):
+                return []
+            level_opts = [opt for opt in normalized if opt in VALID_REASONING_EFFORTS]
+            if level_opts:
+                return list(dict.fromkeys(level_opts))
+            if set(normalized).issubset({"off", "on"}):
+                return []
             return []
-        level_opts = [opt for opt in normalized if opt in VALID_REASONING_EFFORTS]
-        if level_opts:
-            return list(dict.fromkeys(level_opts))
-        if set(normalized).issubset({"off", "on"}):
-            return []
-        return []
 
-    model_lower = model.lower()
-    prefixes = (
-        "deepseek/",
-        "anthropic/",
-        "openai/",
-        "x-ai/",
-        "google/gemini-2",
-        "google/gemma-4",
-        "qwen/qwen3",
-        "tencent/hy3-preview",
-        "xiaomi/",
-    )
-    if any(model_lower.startswith(prefix) for prefix in prefixes):
-        return list(VALID_REASONING_EFFORTS)
+    metadata_efforts = _models_dev_reasoning_efforts(hinted_model, provider)
+    if metadata_efforts is not None:
+        return metadata_efforts
 
-    return []
+    return _heuristic_reasoning_efforts(hinted_model, provider)
 
 
 def get_reasoning_status(
@@ -2215,10 +2238,23 @@ def get_reasoning_status(
     agent_cfg = config_data.get("agent") or {}
     show_raw = display_cfg.get("show_reasoning") if isinstance(display_cfg, dict) else None
     effort_raw = agent_cfg.get("reasoning_effort") if isinstance(agent_cfg, dict) else None
+
+    resolve_model = model_id
+    resolve_provider = provider_id
+    resolve_base_url = base_url
+    if not resolve_model:
+        model_cfg = config_data.get("model") or {}
+        if isinstance(model_cfg, dict):
+            resolve_model = str(model_cfg.get("default") or "").strip() or None
+            if not resolve_provider and model_cfg.get("provider"):
+                resolve_provider = str(model_cfg["provider"]).strip()
+            if not resolve_base_url and model_cfg.get("base_url"):
+                resolve_base_url = str(model_cfg["base_url"]).strip()
+
     supported_efforts = resolve_model_reasoning_efforts(
-        model_id,
-        provider_id=provider_id,
-        base_url=base_url,
+        resolve_model,
+        provider_id=resolve_provider,
+        base_url=resolve_base_url,
     )
     return {
         # Match CLI default (True if unset in config.yaml)

--- a/tests/test_models_dev_reasoning.py
+++ b/tests/test_models_dev_reasoning.py
@@ -1,0 +1,110 @@
+"""Regression coverage for Agent model-metadata reasoning capability lookup."""
+
+import sys
+import types
+from types import SimpleNamespace
+
+
+def _install_fake_models_dev(monkeypatch, fake_fn):
+    fake_agent = types.ModuleType("agent")
+    fake_models_dev = types.ModuleType("agent.models_dev")
+    setattr(fake_models_dev, "get_model_capabilities", fake_fn)
+    setattr(fake_agent, "models_dev", fake_models_dev)
+    monkeypatch.setitem(sys.modules, "agent", fake_agent)
+    monkeypatch.setitem(sys.modules, "agent.models_dev", fake_models_dev)
+
+
+def test_models_dev_true_returns_full_efforts(monkeypatch):
+    _install_fake_models_dev(
+        monkeypatch,
+        lambda provider, model: SimpleNamespace(supports_reasoning=True),
+    )
+
+    import api.config as cfg
+
+    assert cfg._models_dev_reasoning_efforts("grok-4.3", "xai-oauth") == list(
+        cfg.VALID_REASONING_EFFORTS
+    )
+
+
+def test_models_dev_false_returns_authoritative_empty(monkeypatch):
+    _install_fake_models_dev(
+        monkeypatch,
+        lambda provider, model: SimpleNamespace(supports_reasoning=False),
+    )
+
+    import api.config as cfg
+
+    assert cfg._models_dev_reasoning_efforts("grok-4.20-non-reasoning", "xai-oauth") == []
+
+
+def test_models_dev_unknown_allows_compatibility_fallback(monkeypatch):
+    _install_fake_models_dev(monkeypatch, lambda provider, model: None)
+
+    import api.config as cfg
+
+    assert cfg.resolve_model_reasoning_efforts(
+        "x-ai/grok-4", provider_id="openrouter"
+    ) == list(cfg.VALID_REASONING_EFFORTS)
+
+
+def test_xai_oauth_grok_uses_agent_metadata(monkeypatch):
+    seen = []
+
+    def fake_capabilities(provider, model):
+        seen.append((provider, model))
+        return SimpleNamespace(supports_reasoning=True)
+
+    _install_fake_models_dev(monkeypatch, fake_capabilities)
+
+    import api.config as cfg
+
+    assert cfg.resolve_model_reasoning_efforts(
+        "@xai-oauth:grok-4.3", provider_id="xai-oauth"
+    ) == list(cfg.VALID_REASONING_EFFORTS)
+    assert seen == [("xai-oauth", "grok-4.3")]
+
+
+def test_models_dev_false_suppresses_prefix_heuristic(monkeypatch):
+    _install_fake_models_dev(
+        monkeypatch,
+        lambda provider, model: SimpleNamespace(supports_reasoning=False),
+    )
+
+    import api.config as cfg
+
+    assert cfg.resolve_model_reasoning_efforts(
+        "x-ai/grok-4-non-reasoning", provider_id="openrouter"
+    ) == []
+
+
+def test_get_reasoning_status_uses_config_default_model(monkeypatch, tmp_path):
+    _install_fake_models_dev(
+        monkeypatch,
+        lambda provider, model: SimpleNamespace(supports_reasoning=True)
+        if (provider, model) == ("xai-oauth", "grok-4.3")
+        else None,
+    )
+
+    import api.config as cfg
+
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        """
+model:
+  default: grok-4.3
+  provider: xai-oauth
+agent:
+  reasoning_effort: medium
+display:
+  show_reasoning: true
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(cfg, "_get_config_path", lambda: config_path)
+
+    status = cfg.get_reasoning_status()
+
+    assert status["reasoning_effort"] == "medium"
+    assert status["supported_efforts"] == list(cfg.VALID_REASONING_EFFORTS)
+    assert status["supports_reasoning_effort"] is True


### PR DESCRIPTION
## Thinking Path

- #2792 made the reasoning-effort chip model-aware, but the resolver still depends on WebUI-local provider/model heuristics for most providers.
- That leaves native/provider-specific catalogs behind: xAI OAuth Grok models such as `grok-4.3` report no supported efforts even though Hermes Agent model metadata marks them reasoning-capable.
- The narrow fix is to keep the exact provider resolvers that need special behavior (ACP unsupported, Copilot/GitHub subsets, OpenAI Codex, LM Studio probing), then ask Hermes Agent's model metadata for the remaining providers before falling back to the existing compatibility heuristics.
- Metadata `supports_reasoning=False` is treated as authoritative so known non-reasoning variants do not get re-enabled by broad prefix heuristics.
- The no-query `/api/reasoning` boot path now resolves against the configured default model/provider so the chip can hydrate correctly before the frontend has passed explicit active-session model context.

## What Changed

- Added a small `_models_dev_reasoning_efforts()` helper that reads `agent.models_dev.get_model_capabilities()` when available.
- Updated `resolve_model_reasoning_efforts()` to use that metadata after exact provider-specific resolvers and before compatibility heuristics.
- Preserved ACP unsupported behavior, Copilot/GitHub effort subset handling, OpenAI Codex handling, LM Studio live option probing, and existing heuristic fallback behavior when metadata is unavailable or unknown.
- Updated `get_reasoning_status()` so calls without explicit `model`/`provider` fall back to `model.default`, `model.provider`, and `model.base_url` from config.
- Added regression tests for xAI OAuth Grok metadata, authoritative non-reasoning metadata, heuristic fallback preservation, provider-hint stripping, and the no-query boot/default path.

## Why It Matters

- Reasoning-capable native/provider-specific models can show the reasoning-effort chip without adding another WebUI-local prefix rule for every provider catalog shape.
- Known non-reasoning variants remain hidden when Agent metadata says they do not support reasoning.
- WebUI capability detection stays aligned with Hermes Agent's model knowledge instead of drifting into a duplicated hardcoded allowlist.
- Existing special cases that require non-boolean effort semantics remain intact.

## Verification

Targeted reasoning capability suites:

```text
python -m py_compile api/config.py tests/test_models_dev_reasoning.py
python -m pytest tests/test_models_dev_reasoning.py tests/test_reasoning_effort_model_capabilities.py tests/test_reasoning_show_hide.py -q
# 41 passed
```

Adjacent reasoning-chip suites:

```text
python -m pytest tests/test_issue1103_reasoning_chip_visibility.py tests/test_reasoning_chip_btw_fixes.py tests/test_reasoning_chip_js_behaviour.py -q
# 38 passed
```

Hygiene:

```text
git diff --check
# passed
```

Manual resolver smoke with the branch code:

```text
xai-oauth @xai-oauth:grok-4.3 => minimal, low, medium, high, xhigh
xai-oauth @xai-oauth:grok-4.20-0309-reasoning => minimal, low, medium, high, xhigh
xai-oauth @xai-oauth:grok-4.20-0309-non-reasoning => []
openrouter x-ai/grok-4 => minimal, low, medium, high, xhigh
```

## Risks / Follow-ups

- If `agent.models_dev` is unavailable in an install, WebUI keeps the existing compatibility heuristics.
- Metadata is boolean, so providers with narrower effort subsets still need exact resolvers before metadata; this PR preserves the existing exact resolver ordering for those providers.
- No frontend layout or interaction code changed; this is backend capability data feeding the existing chip visibility logic.

## Model Used

- OpenAI / GPT-5.5 High for implementation, verification, and PR preparation.
