### PR TITLE
Fix workspace save icon contrast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Dark-mode panel header save buttons now use a theme-aware foreground token, keeping workspace and other detail-pane check icons visible on the default gold accent. (#2998)
+
 ## [v0.51.145] — 2026-05-26 — Release DQ (stage-batch27 — sidebar running-state preservation)
 
 ### Fixed

--- a/static/style.css
+++ b/static/style.css
@@ -3922,9 +3922,10 @@ main.main > .main-view:not([id="mainChat"]):not([id="mainSettings"]) .main-view-
 .detail-form-row label.detail-form-check{display:flex;align-items:center;gap:8px;font-size:13px;color:var(--text);cursor:pointer;font-weight:400;}
 .detail-form-row label.detail-form-check input{accent-color:var(--accent,var(--link));}
 .detail-form-error{font-size:12px;color:var(--error,#e05);padding:8px 10px;border:1px solid color-mix(in srgb,var(--error,#e05) 35%,transparent);background:color-mix(in srgb,var(--error,#e05) 8%,transparent);border-radius:8px;line-height:1.5;}
-.panel-head-btn.primary{background:var(--accent,var(--link));color:#fff;border:none;}
-.panel-head-btn.primary:hover{background:var(--accent-hover,var(--accent,var(--link)));color:#fff;}
-.panel-head-btn.primary svg{color:#fff;}
+:root.dark{--panel-head-primary-fg:var(--bg);}
+.panel-head-btn.primary{background:var(--accent,var(--link));color:var(--panel-head-primary-fg,#fff);border:none;}
+.panel-head-btn.primary:hover{background:var(--accent-hover,var(--accent,var(--link)));color:var(--panel-head-primary-fg,#fff);}
+.panel-head-btn.primary svg{color:var(--panel-head-primary-fg,#fff);}
 /* Skill-picker inside in-main forms reuses the sidebar styles but needs light tweaks */
 .detail-form-row .skill-picker-wrap{position:relative;}
 .detail-form-row .skill-picker-tags{margin-top:6px;display:flex;flex-wrap:wrap;gap:4px;}

--- a/tests/test_issue2998_panel_primary_contrast.py
+++ b/tests/test_issue2998_panel_primary_contrast.py
@@ -1,0 +1,17 @@
+"""Regression coverage for #2998: gold panel save buttons need visible icons."""
+
+from pathlib import Path
+
+
+CSS = (Path(__file__).resolve().parent.parent / "static" / "style.css").read_text(encoding="utf-8")
+
+
+def test_panel_primary_buttons_use_foreground_token_for_icon_contrast():
+    assert "--panel-head-primary-fg" in CSS
+    assert ".panel-head-btn.primary{background:var(--accent,var(--link));color:var(--panel-head-primary-fg,#fff);border:none;}" in CSS
+    assert ".panel-head-btn.primary:hover{background:var(--accent-hover,var(--accent,var(--link)));color:var(--panel-head-primary-fg,#fff);}" in CSS
+    assert ".panel-head-btn.primary svg{color:var(--panel-head-primary-fg,#fff);}" in CSS
+
+
+def test_dark_theme_panel_primary_buttons_use_dark_foreground_on_bright_accents():
+    assert ":root.dark{--panel-head-primary-fg:var(--bg);}" in CSS


### PR DESCRIPTION
## Thinking Path
- Issue #2998 reports that the workspace save/OK control is hard to see on the default dark theme because white icons sit on the bright gold primary button.
- The button is still functional, so this keeps behavior unchanged and fixes the theme token used for panel-header primary button foregrounds.

## What Changed
- Added `--panel-head-primary-fg` for dark theme panel-header primary buttons.
- Updated primary panel-header buttons and their SVG icons to use that foreground token.
- Added regression coverage for the CSS contract.
- Added an Unreleased changelog entry.

## Why It Matters
- The workspace detail save/check icon remains visible on the default dark/gold palette.
- The same panel-header primary control pattern is safer for other detail panes that reuse it.

## Verification
- `HERMES_HOME=C:\Users\pchin\AppData\Local\Temp\hermes-webui-pytest-home HERMES_WEBUI_AGENT_DIR=C:\Users\pchin\AppData\Local\hermes\hermes-agent HERMES_WEBUI_PYTHON=C:\Users\pchin\AppData\Local\hermes\hermes-agent\venv\Scripts\python.exe python -m pytest tests/test_issue2998_panel_primary_contrast.py tests/test_sprint5.py::test_workspace_rename -q` -> 3 passed.
- `python -m py_compile server.py api/*.py` -> passed.
- Local WebUI smoke on Windows 11 at `http://127.0.0.1:8787`: `/health` ok, onboarding ready, default model `qwen3.5:4b`, workspace save icon computed as dark text/icon on gold background.

## Risks / Follow-ups
- This is a CSS-only visible-state change and should not affect workspace persistence behavior.
- Screenshot evidence was captured locally during verification; no binary artifacts are included in the PR.

## Model Used
OpenAI Codex / GPT-5