### PR TITLE
Add Hermes Action Bus for typed WebUI/session actions

### DIFF
--- a/api/actions/__init__.py
+++ b/api/actions/__init__.py
@@ -11,6 +11,8 @@ and the ``register_builtins`` helper at the bottom of this module for
 the v1 builtin registration surface.
 """
 
+import threading
+
 from .registry import ActionNotFound, ActionRegistry, default_registry
 from .types import (
     Action,
@@ -31,6 +33,19 @@ __all__ = [
 ]
 
 
+# Module-level idempotency guard for the process-global default_registry.
+# Per-test or per-caller registries (passed explicitly) always register
+# fresh so test isolation is preserved; only the shared singleton path is
+# locked behind this flag. Earlier drafts of the route hook used a name
+# sentinel ("echo.test" in known_actions()) which silently broke whenever
+# a new builtin was added without also updating the sentinel -- the new
+# builtin would never be picked up because the sentinel check still
+# passed. The flag survives the addition of new builtins because it
+# tracks the registration call itself, not any individual action name.
+_BUILTINS_LOCK = threading.Lock()
+_BUILTINS_REGISTERED = False
+
+
 def register_builtins(registry: ActionRegistry = default_registry) -> None:
     """Register the v1 builtin actions against the given registry.
 
@@ -38,6 +53,39 @@ def register_builtins(registry: ActionRegistry = default_registry) -> None:
     so the dispatch path is testable end-to-end without touching the
     session database or the agent. Follow-up PRs add real builtins
     (``session.nudge``, ``session.refresh``) and the helpers they need.
+
+    Idempotency contract:
+
+    - When called with the module-level :data:`default_registry` (the
+      common production path), this function is idempotent. The first
+      successful call registers every v1 builtin; subsequent calls
+      return immediately under a module-level lock. Request handlers
+      can therefore call ``register_builtins(default_registry)`` on
+      every request without paying re-registration cost or risking a
+      ``ValueError`` on duplicate names. New builtins added in follow-up
+      PRs are picked up automatically the first time the process starts
+      after the upgrade.
+    - When called with an explicitly-passed registry (tests, allowlist
+      entry points), no flag is set. The registry is registered fresh
+      every call, which is what test isolation needs.
+    """
+    if registry is default_registry:
+        global _BUILTINS_REGISTERED
+        with _BUILTINS_LOCK:
+            if _BUILTINS_REGISTERED:
+                return
+            _register_all_builtins(registry)
+            _BUILTINS_REGISTERED = True
+    else:
+        _register_all_builtins(registry)
+
+
+def _register_all_builtins(registry: ActionRegistry) -> None:
+    """Register every v1 builtin against ``registry``.
+
+    Kept separate from :func:`register_builtins` so the locking and
+    idempotency policy stays a clean wrapper around the actual
+    registration list. Follow-up PRs should add their builtins here.
     """
     from .builtin.echo_test import EchoTestAction
 

--- a/api/actions/__init__.py
+++ b/api/actions/__init__.py
@@ -1,0 +1,44 @@
+"""Hermes Action Bus -- typed backend action dispatcher.
+
+The bus provides one shared primitive:
+
+    entry point  ->  dispatch_action(name, payload, context)
+                 ->  registered backend action
+                 ->  ActionResult
+
+See ``docs/rfcs/action-bus.md`` (added in this PR) for the full design
+and the ``register_builtins`` helper at the bottom of this module for
+the v1 builtin registration surface.
+"""
+
+from .registry import ActionNotFound, ActionRegistry, default_registry
+from .types import (
+    Action,
+    ActionContext,
+    ActionResult,
+    SILENT_SENTINEL,
+)
+
+__all__ = [
+    "Action",
+    "ActionContext",
+    "ActionNotFound",
+    "ActionRegistry",
+    "ActionResult",
+    "SILENT_SENTINEL",
+    "default_registry",
+    "register_builtins",
+]
+
+
+def register_builtins(registry: ActionRegistry = default_registry) -> None:
+    """Register the v1 builtin actions against the given registry.
+
+    v1 ships only :class:`~api.actions.builtin.echo_test.EchoTestAction`
+    so the dispatch path is testable end-to-end without touching the
+    session database or the agent. Follow-up PRs add real builtins
+    (``session.nudge``, ``session.refresh``) and the helpers they need.
+    """
+    from .builtin.echo_test import EchoTestAction
+
+    registry.register(EchoTestAction())

--- a/api/actions/builtin/__init__.py
+++ b/api/actions/builtin/__init__.py
@@ -1,0 +1,1 @@
+"""Builtin actions shipped with the Hermes Action Bus."""

--- a/api/actions/builtin/echo_test.py
+++ b/api/actions/builtin/echo_test.py
@@ -1,0 +1,48 @@
+"""echo.test -- trivial round-trip action for liveness and bus testing.
+
+This action does not touch the session database, the agent, or the SSE
+channel. It exists so the dispatch path can be exercised end-to-end in
+unit tests and via the manual smoke test, without requiring any of the
+helpers that later builtins (``session.nudge``) will introduce.
+
+Payload contract::
+
+    {"content": "<some short string>"}
+
+Result contract::
+
+    ok=True
+    silent=False if content is non-empty, True otherwise
+    assistant_message=content (or None if empty)
+"""
+
+from __future__ import annotations
+
+from ..types import ActionContext, ActionResult
+
+
+class EchoTestAction:
+    name = "echo.test"
+
+    def run(self, payload: dict, context: ActionContext) -> ActionResult:
+        content = payload.get("content")
+        if content is None:
+            content = ""
+        if not isinstance(content, str):
+            return ActionResult(
+                ok=False,
+                silent=True,
+                error="content must be a string",
+            )
+
+        body = content.strip()
+        if not body:
+            return ActionResult(ok=True, silent=True)
+
+        return ActionResult(
+            ok=True,
+            silent=False,
+            assistant_message=body,
+            refresh_chat=False,
+            meta={"source": context.source},
+        )

--- a/api/actions/registry.py
+++ b/api/actions/registry.py
@@ -1,0 +1,113 @@
+"""Registry and dispatcher for the Hermes Action Bus.
+
+Threaded, synchronous, no event loop. Idempotency cache is in-memory
+only; a process restart loses pending entries. That is acceptable for
+the v1 use cases (uptime >> typical TTL) and a durable cache can slot
+in behind the same ``dispatch`` signature in a later PR if needed.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import Optional
+
+from .types import Action, ActionContext, ActionResult
+
+
+class ActionNotFound(Exception):
+    """Raised when an action name is not registered."""
+
+
+class _IdempotencyCache:
+    """Thread-safe ``(action, key) -> (created_at, result)`` cache.
+
+    Entries past ``ttl_seconds`` are pruned lazily on each ``get``.
+    """
+
+    def __init__(self, ttl_seconds: int = 300):
+        self._cache: dict[tuple[str, str], tuple[float, ActionResult]] = {}
+        self._ttl = ttl_seconds
+        self._lock = threading.Lock()
+
+    def get(self, action: str, key: str) -> Optional[ActionResult]:
+        with self._lock:
+            self._prune_locked()
+            entry = self._cache.get((action, key))
+            return entry[1] if entry else None
+
+    def put(self, action: str, key: str, result: ActionResult) -> None:
+        with self._lock:
+            self._cache[(action, key)] = (time.time(), result)
+
+    def _prune_locked(self) -> None:
+        now = time.time()
+        expired = [
+            k for k, (created_at, _) in self._cache.items()
+            if now - created_at > self._ttl
+        ]
+        for key in expired:
+            self._cache.pop(key, None)
+
+
+class ActionRegistry:
+    """Named-action registry with idempotent dispatch.
+
+    The registry is intentionally a plain object so callers can hold
+    their own instance (the recommended path for tests and for entry
+    points that want to ship their own allowlist). A module-level
+    :data:`default_registry` exists for the common case.
+    """
+
+    def __init__(self, idempotency_ttl_seconds: int = 300):
+        self._actions: dict[str, Action] = {}
+        self._idempotency = _IdempotencyCache(idempotency_ttl_seconds)
+        self._register_lock = threading.Lock()
+
+    def register(self, action: Action) -> None:
+        with self._register_lock:
+            if action.name in self._actions:
+                raise ValueError(f"Action {action.name!r} already registered")
+            self._actions[action.name] = action
+
+    def known_actions(self) -> list[str]:
+        with self._register_lock:
+            return sorted(self._actions)
+
+    def dispatch(
+        self,
+        action: str,
+        payload: dict,
+        context: ActionContext,
+        idempotency_key: Optional[str] = None,
+    ) -> ActionResult:
+        if idempotency_key:
+            cached = self._idempotency.get(action, idempotency_key)
+            if cached is not None:
+                return cached
+
+        impl = self._actions.get(action)
+        if impl is None:
+            raise ActionNotFound(action)
+
+        try:
+            result = impl.run(payload, context)
+        except Exception as exc:
+            # Actions are user-defined and may raise anything. We never
+            # want a registered action to take down the request handler
+            # thread, so wrap unexpected exceptions into a structured
+            # error result. ActionNotFound is raised above this guard
+            # and continues to bubble for the HTTP adapter to map to 404.
+            result = ActionResult(
+                ok=False,
+                silent=True,
+                error=f"{type(exc).__name__}: {exc}",
+            )
+
+        if idempotency_key:
+            self._idempotency.put(action, idempotency_key, result)
+
+        return result
+
+
+default_registry = ActionRegistry()

--- a/api/actions/types.py
+++ b/api/actions/types.py
@@ -1,0 +1,107 @@
+"""Typed action contracts for the Hermes Action Bus.
+
+The bus is intentionally synchronous: Hermes WebUI runs on
+``ThreadingHTTPServer`` and the rest of ``api/*`` is plain ``def``. Actions
+follow the same style so dispatch can happen inside any POST handler
+thread without spinning an event loop.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Optional, Protocol
+
+
+SILENT_SENTINEL = "[SILENT]"
+
+
+def _noop_emit(event_type: str, payload: dict) -> None:
+    """Default ``emit_event`` that drops the event on the floor.
+
+    Real entry points (the ``/api/actions`` HTTP adapter, cron, webhooks)
+    pass a real publisher backed by ``api/session_events.py``. Unit tests
+    pass their own capturing closure.
+    """
+
+
+def _no_dispatch(*args, **kwargs):  # pragma: no cover - guard against accidental nested dispatch
+    raise RuntimeError(
+        "ActionContext.dispatch was not wired by the caller. "
+        "Pass registry.dispatch (or a bound equivalent) when constructing "
+        "the context if your action needs to chain into another action."
+    )
+
+
+@dataclass
+class ActionContext:
+    """Runtime context handed to an action at dispatch time.
+
+    *session_id* and *user_id* are optional; some actions (e.g. webhook
+    health pings) have no session. *source* is a short string identifying
+    the entry point: ``"webui_api"``, ``"cron"``, ``"webhook"``,
+    ``"gateway"``, ``"internal"``. *emit_event* is a synchronous callable
+    that publishes a typed event onto the WebUI SSE channel (see
+    ``api/session_events.py``); the default is a no-op so unit tests do
+    not need a real publisher. *dispatch* lets an action chain into the
+    bus; the default raises so that an unwired context fails loudly the
+    first time an action tries to nest.
+    """
+
+    session_id: Optional[str] = None
+    user_id: Optional[str] = None
+    source: str = "unknown"
+    emit_event: Callable[[str, dict], None] = field(default=_noop_emit)
+    dispatch: Callable[..., "ActionResult"] = field(default=_no_dispatch)
+    request_meta: dict = field(default_factory=dict)
+    # Open slot for adapter-specific injections (db handles, agent runners,
+    # session stores) without committing to a typed shape in v1. Follow-up
+    # PRs that add real session-touching actions will use this and we will
+    # tighten the type then.
+    extras: dict = field(default_factory=dict)
+
+
+@dataclass
+class ActionResult:
+    """Normalized return shape for every action.
+
+    The three concerns are kept separate on purpose:
+
+    - ``ok``: did the action complete without an unrecoverable error
+    - ``silent`` / ``assistant_message``: should anything surface to chat
+    - ``refresh_chat``: should open WebUI clients refresh session state
+
+    ``error`` is set when ``ok=False`` so callers can surface a short
+    string to the user or to logs without parsing exceptions.
+    """
+
+    ok: bool = True
+    silent: bool = True
+    assistant_message: Optional[str] = None
+    refresh_chat: bool = False
+    error: Optional[str] = None
+    meta: dict = field(default_factory=dict)
+
+    def to_dict(self) -> dict:
+        return {
+            "ok": self.ok,
+            "silent": self.silent,
+            "assistant_message": self.assistant_message,
+            "refresh_chat": self.refresh_chat,
+            "error": self.error,
+            "meta": self.meta,
+        }
+
+
+class Action(Protocol):
+    """Every registered action implements this protocol.
+
+    ``name`` is the dotted identifier used at the dispatch site
+    (``"echo.test"``, ``"session.nudge"``, etc). ``run`` is synchronous;
+    long-running work belongs in a worker thread spawned by the action,
+    not in an event loop.
+    """
+
+    name: str
+
+    def run(self, payload: dict, context: ActionContext) -> ActionResult:
+        ...

--- a/api/actions_http.py
+++ b/api/actions_http.py
@@ -1,0 +1,115 @@
+"""POST /api/actions -- HTTP adapter for the Hermes Action Bus.
+
+Kept deliberately thin: validate the request body, build an
+:class:`~api.actions.ActionContext`, dispatch, and return a normalized
+``(body_dict, status_int)`` pair. CSRF and authentication run in
+``api/routes.py::handle_post`` before this is called, matching the
+pattern of every other POST handler in the WebUI.
+
+The registry is injected so unit tests can supply a clean instance
+without leaking module-level state between tests. Production callers
+pass ``default_registry`` (also the default value here).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Optional
+
+from api.actions import (
+    ActionContext,
+    ActionNotFound,
+    ActionRegistry,
+    default_registry,
+)
+
+
+def _resolve_emit_event() -> Callable[[str, dict], None]:
+    """Return the production SSE publisher, or a no-op if it is absent.
+
+    The publisher is resolved lazily on each request so test runs that
+    monkey-patch ``api.session_events`` (or do not import it at all)
+    still get a working bus. When ``publish_session_event`` lands in a
+    follow-up PR this will pick it up automatically; until then we drop
+    events on the floor, which matches the v1 surface where no builtin
+    emits events.
+    """
+    try:
+        from api.session_events import publish_session_event  # type: ignore[attr-defined]
+    except ImportError:
+        return lambda _name, _payload: None
+    return publish_session_event
+
+
+def handle_actions_post(
+    handler: Any,
+    body: dict,
+    registry: ActionRegistry = default_registry,
+    *,
+    emit_event: Optional[Callable[[str, dict], None]] = None,
+) -> tuple[dict, int]:
+    """Validate, dispatch, and serialize.
+
+    Returns ``(response_body_dict, http_status_int)``. The caller in
+    ``api/routes.py`` is responsible for the actual ``j(handler, ...)``
+    write so all routes share one response helper.
+
+    *handler* is the ``BaseHTTPRequestHandler`` instance and is used
+    only to read non-required request metadata (remote address, user
+    id) into ``ActionContext.request_meta``. It is fine for *handler*
+    to be ``None`` in tests; this function does not write to it.
+    """
+    if not isinstance(body, dict):
+        return {"ok": False, "error": "request body must be a JSON object"}, 400
+
+    action = body.get("action")
+    if not isinstance(action, str) or not action.strip():
+        return {"ok": False, "error": "action required"}, 400
+
+    payload = body.get("payload")
+    if payload is None:
+        payload = {}
+    if not isinstance(payload, dict):
+        return {"ok": False, "error": "payload must be an object"}, 400
+
+    session_id = body.get("session_id")
+    if session_id is not None and not isinstance(session_id, str):
+        return {"ok": False, "error": "session_id must be a string"}, 400
+
+    idempotency_key = body.get("idempotency_key")
+    if idempotency_key is not None and not isinstance(idempotency_key, str):
+        return {"ok": False, "error": "idempotency_key must be a string"}, 400
+
+    resolved_emit = emit_event if emit_event is not None else _resolve_emit_event()
+
+    context = ActionContext(
+        session_id=session_id,
+        user_id=getattr(handler, "user_id", None),
+        source="webui_api",
+        emit_event=resolved_emit,
+        dispatch=registry.dispatch,
+        request_meta={
+            "remote": _safe_remote(handler),
+        },
+    )
+
+    try:
+        result = registry.dispatch(
+            action=action,
+            payload=payload,
+            context=context,
+            idempotency_key=idempotency_key,
+        )
+    except ActionNotFound:
+        return {"ok": False, "error": f"unknown action: {action}"}, 404
+
+    return result.to_dict(), 200
+
+
+def _safe_remote(handler: Any) -> Optional[str]:
+    if handler is None:
+        return None
+    addr = getattr(handler, "client_address", None)
+    if isinstance(addr, tuple) and addr:
+        return str(addr[0])
+    remote = getattr(handler, "remote", None)
+    return str(remote) if remote is not None else None

--- a/api/actions_http.py
+++ b/api/actions_http.py
@@ -34,6 +34,13 @@ def _resolve_emit_event() -> Callable[[str, dict], None]:
     emits events.
     """
     try:
+        # publish_session_event intentionally does not yet exist on this
+        # PR's branch -- it lands in the session.nudge follow-up. Grepping
+        # for the symbol on master today will only return this import; the
+        # ImportError fallback below resolves to a no-op for every request
+        # until then, which matches the v1 surface where no builtin emits
+        # SSE events. Function-level docstring above documents the same
+        # behavior at the API level.
         from api.session_events import publish_session_event  # type: ignore[attr-defined]
     except ImportError:
         return lambda _name, _payload: None

--- a/api/routes.py
+++ b/api/routes.py
@@ -5023,16 +5023,13 @@ def handle_post(handler, parsed) -> bool:
         from api.actions import register_builtins, default_registry
         from api.actions_http import handle_actions_post
 
-        # Register v1 builtins exactly once against the module-level
-        # default_registry. ValueError on re-register is swallowed because
-        # the registry is process-global and idempotent registration is
-        # the right behavior for repeated POST requests in the same
-        # process. Per-test isolation uses an injected registry instead.
-        if "echo.test" not in default_registry.known_actions():
-            try:
-                register_builtins(default_registry)
-            except ValueError:
-                pass
+        # Idempotent on the default_registry singleton (see
+        # register_builtins docstring). First request in the process
+        # pays for registration; later calls return immediately under
+        # the module-level lock. Tracking the call rather than any
+        # individual action name means new builtins added in follow-up
+        # PRs are picked up automatically.
+        register_builtins(default_registry)
 
         body_dict, status = handle_actions_post(handler, body)
         return j(handler, body_dict, status=status)

--- a/api/routes.py
+++ b/api/routes.py
@@ -5019,6 +5019,24 @@ def handle_post(handler, parsed) -> bool:
         result = repair_safe_session_recovery(SESSION_DIR, state_db_path=_active_state_db_path())
         return j(handler, result, status=200 if result.get("clean") else 409)
 
+    if parsed.path == "/api/actions":
+        from api.actions import register_builtins, default_registry
+        from api.actions_http import handle_actions_post
+
+        # Register v1 builtins exactly once against the module-level
+        # default_registry. ValueError on re-register is swallowed because
+        # the registry is process-global and idempotent registration is
+        # the right behavior for repeated POST requests in the same
+        # process. Per-test isolation uses an injected registry instead.
+        if "echo.test" not in default_registry.known_actions():
+            try:
+                register_builtins(default_registry)
+            except ValueError:
+                pass
+
+        body_dict, status = handle_actions_post(handler, body)
+        return j(handler, body_dict, status=status)
+
     if parsed.path.startswith("/api/kanban/"):
         from api.kanban_bridge import handle_kanban_post
 

--- a/docs/rfcs/action-bus.md
+++ b/docs/rfcs/action-bus.md
@@ -1,0 +1,291 @@
+# RFC: Hermes Action Bus
+
+- **Status:** Proposed (v1)
+- **Author:** @webflow-pt
+- **Created:** 2026-05-28
+
+## Problem
+
+Hermes WebUI exposes a small number of entry points that need to make
+the same kind of side-effecting backend call: a cron job wakes a
+session, a webhook delivers a third-party event, a future MCP tool
+asks Hermes to do something on behalf of a remote caller, the in-UI
+slash-command surface fires a one-shot operation. Today each of those
+entry points reaches into `api/routes.py` (or `api/background.py`,
+or the gateway adapter, or `api/cron.py`) and assembles its own ad-hoc
+path: parse a payload, look up a session, decide whether to run the
+agent, decide whether to persist anything, decide whether to notify
+open WebUI tabs.
+
+The lack of a shared primitive means:
+
+- Each entry point reimplements the same validation and error
+  contract slightly differently.
+- Idempotency (repeated cron/webhook deliveries should not double up)
+  has to be solved per-caller.
+- The wire shape of "what happened on the server" is not normalized,
+  so client code has to special-case every channel.
+- Adding a new operation means touching the dispatch code in every
+  entry point, which discourages experiments.
+
+## Goals
+
+- One typed, synchronous dispatcher that any entry point (HTTP,
+  cron, webhook, gateway, MCP, slash-command) can call to invoke a
+  registered backend action.
+- A normalized result shape that decouples "did it succeed?" from
+  "should the UI render anything?".
+- In-process idempotency so the same `(action, idempotency_key)`
+  pair returns the same `ActionResult` within a TTL window.
+- An emit-event seam so actions can broadcast typed SSE events on
+  the existing session-events channel without taking a direct
+  dependency on the SSE module.
+- A registration model that survives the addition of new builtins
+  in follow-up PRs without anyone editing the route hook.
+
+## Non-goals
+
+- Replacing `api/background.py` slash-commands or `api/cron.py` job
+  delivery. Those can be re-expressed on top of the bus later; v1
+  ships alongside them.
+- Asynchronous dispatch. The WebUI is a `ThreadingHTTPServer` and
+  every existing handler is synchronous; an `asyncio` runtime is
+  out of scope for this RFC.
+- Durable idempotency. v1 caches in-process for a configurable
+  TTL; a durable backend (sqlite, Redis) can slot in behind the
+  same `dispatch` signature later.
+- A general-purpose plugin loader. Builtins are explicitly
+  registered in `api/actions/__init__.py::_register_all_builtins`.
+- A per-action access-control model. v1 piggybacks on the existing
+  `_check_csrf` path on `/api/actions`; a future PR can add a
+  per-action `allowed_sources` allowlist when the action surface
+  grows beyond browser-driven calls.
+
+## The contract
+
+### `Action`
+
+A registered backend action is anything that implements
+`api.actions.types.Action`:
+
+```python
+class Action(Protocol):
+    name: str
+    def run(self, payload: dict, context: ActionContext) -> ActionResult: ...
+```
+
+Actions are synchronous, side-effecting, and free to raise. The
+registry catches any non-`BaseException` and converts it into an
+error `ActionResult`; `BaseException` (`KeyboardInterrupt`,
+`SystemExit`) propagates so process shutdown is never blocked.
+
+### `ActionContext`
+
+Every dispatch carries an `ActionContext` describing the caller:
+
+```python
+@dataclass
+class ActionContext:
+    session_id: str | None
+    user_id: str | None
+    source: str                      # "webui_api", "cron", "webhook", "gateway", ...
+    emit_event: Callable[[str, dict], None]
+    dispatch: Callable[[str, dict, "ActionContext", str | None], "ActionResult"]
+    request_meta: dict
+```
+
+- `session_id` is the WebUI session the action targets, when one
+  exists. Actions that operate on a session validate this field
+  themselves; the bus does not enforce it.
+- `source` is a free-form tag the caller sets so actions and logs
+  can distinguish a browser POST from a cron firing.
+- `emit_event(event_type, payload)` lets the action broadcast a
+  typed SSE event on the shared session-events channel. The
+  default (when no production publisher is available) is a no-op.
+- `dispatch(name, payload, context, idempotency_key=None)` lets
+  an action chain to another registered action. See **Chaining**
+  below.
+- `request_meta` is a free-form bag for caller-specific context
+  (remote address, gateway request id, etc.) without bloating the
+  context type.
+
+### `ActionResult`
+
+Every dispatch returns:
+
+```python
+@dataclass
+class ActionResult:
+    ok: bool
+    silent: bool
+    assistant_message: str | None = None
+    refresh_chat: bool = False
+    error: str | None = None
+    meta: dict | None = None
+```
+
+The three orthogonal flags matter:
+
+- `ok` — did the action complete successfully? Used by the HTTP
+  adapter to map to 2xx vs. 5xx.
+- `silent` — should the UI surface anything? An action can succeed
+  silently (a cron that decided not to wake the session) or fail
+  silently (a no-op duplicate delivery).
+- `refresh_chat` — should open WebUI tabs reload the active
+  session's messages? Set by actions that wrote to the session.
+
+`assistant_message` carries the rendered text when the action
+emitted one. Decoupling it from `ok`/`silent` means UI code never
+has to infer intent from content.
+
+## Idempotency
+
+The registry holds an in-memory `_IdempotencyCache`:
+
+```text
+(action_name, idempotency_key) -> (created_at, ActionResult)
+```
+
+`dispatch(action, payload, context, idempotency_key=...)` checks
+the cache before running. A hit returns the previously stored
+result and never re-invokes the action. On a miss the action runs,
+its result is cached, and the cache prunes entries older than
+`ttl_seconds` (default 300) on the next `get`.
+
+Trade-offs:
+
+- The cache is in-process. A process restart loses pending entries.
+  Cron/webhook callers should treat this as "best-effort within
+  the TTL window" rather than "exactly-once forever".
+- Pruning is lazy and O(n) on the cache size. v1 expects very few
+  in-flight keys at any time; a future tightening can swap to a
+  sorted-by-insertion-time pop if hot-path metrics warrant it.
+- The lock is per-cache, not per-action. Two threads dispatching
+  the same `(action, key)` may both run the action if they race
+  past the `get` before either `put`. v1 accepts this — the
+  guarantee is "the cached result wins for the rest of the TTL",
+  not "the action runs at most once during the race window".
+
+## Error handling
+
+```text
+dispatch(name=...)
+  -> ActionNotFound          (raised by registry, caught by HTTP -> 404)
+  -> ActionResult(ok=False, error=...) for any other Exception
+  -> ActionResult(ok=True, ...)        for success
+```
+
+The HTTP adapter (`api/actions_http.py`) maps:
+
+- `ActionNotFound` -> 404 with `{"error": "...", "known_actions": [...]}`
+- Validation failures (missing/invalid `action`, non-dict body,
+  bad `session_id`/`idempotency_key` types) -> 400 with a
+  descriptive error.
+- Successful dispatch -> 200 with the serialized `ActionResult`.
+
+Validation lives in the HTTP adapter, not the registry, so callers
+that bypass HTTP (in-process cron, MCP) can pass already-validated
+input without paying twice.
+
+## Chaining
+
+`ActionContext.dispatch` lets a registered action invoke another
+registered action without taking a direct dependency on the
+registry. This is the right primitive when an action wants to
+trigger a follow-on operation as part of its own response (for
+example, a `session.nudge` that, on success, dispatches a small
+`session.refresh` to materialize updated sidebar metadata on
+non-active tabs).
+
+Chaining preserves the `source` tag of the outer caller by
+default, but actions are free to construct a fresh `ActionContext`
+when they want the inner dispatch to look like a different
+originator. Idempotency keys propagate independently — chained
+calls do not share a key with the outer dispatch unless the
+action explicitly forwards one.
+
+Tests cover this via the `_ctx(dispatch=registry.dispatch)`
+pattern; see `tests/test_action_bus.py::test_action_can_chain_via_context_dispatch`.
+
+## Registration
+
+Production callers use the module-level singleton:
+
+```python
+from api.actions import default_registry, register_builtins
+register_builtins(default_registry)   # idempotent
+default_registry.dispatch("echo.test", {"content": "ping"}, ctx)
+```
+
+`register_builtins(default_registry)` is guarded by
+`_BUILTINS_LOCK` + `_BUILTINS_REGISTERED` so it is safe to call on
+every request — the first call registers the v1 builtins, every
+subsequent call returns immediately under the lock. New builtins
+added in follow-up PRs are picked up automatically the first time
+the process starts after the upgrade; the route hook does not
+need to be touched.
+
+Test code constructs its own `ActionRegistry()` and passes it
+explicitly, which bypasses the singleton flag and gives every
+test a fresh registry. `register_builtins(reg)` against a
+non-default registry always registers fresh, which is what test
+isolation needs.
+
+## HTTP entry point
+
+```text
+POST /api/actions
+Content-Type: application/json
+
+{
+  "action": "echo.test",
+  "payload": {"content": "ping"},
+  "session_id": "...",        // optional
+  "idempotency_key": "..."    // optional
+}
+
+200 OK
+{
+  "ok": true,
+  "silent": false,
+  "assistant_message": "ping",
+  "refresh_chat": false,
+  "error": null,
+  "meta": {}
+}
+```
+
+CSRF is enforced via the existing `_check_csrf` path in
+`api/routes.py`; `/api/actions` is intentionally not on the
+exempt list. Curl callers without an `Origin` header pass the
+`_is_browser_unsafe_request` gate; browser callers go through the
+same-origin path.
+
+## What's out of scope for v1
+
+- Per-action `allowed_sources` allowlist (e.g. `session.nudge`
+  restricted to non-browser entry points). Defer until the action
+  surface grows beyond browser-driven smoke tests.
+- Durable idempotency cache (sqlite or Redis backend).
+- Async actions / async dispatch. Synchronous matches the WebUI's
+  threading model and the rest of `api/*`.
+- A plugin loader / dynamic action registration from disk.
+- Inline batch dispatch (`POST /api/actions` with a list of
+  actions). Each call is one action; chaining within actions
+  covers the small set of cases where one call should fan out.
+
+## Follow-ups planned
+
+- **`session.nudge`** (separate PR, gated on this one landing).
+  First session-touching builtin. Runs an inference-only synthetic
+  user turn against an existing session, persists only a
+  non-silent assistant response, and emits
+  `session.message_appended` on the WebUI SSE channel so open
+  tabs refresh.
+- **`session.refresh`** (further follow-up). Recomputes sidebar
+  metadata without invoking the agent. Useful as a chain target
+  for `session.nudge` and for cron-driven housekeeping.
+- **Refactor** of agent construction. `session.nudge` currently
+  inlines the model/provider/api_key resolution that
+  `/api/chat` does. A small extraction (`build_session_agent(session)`)
+  can land later and be called from both sites.

--- a/tests/test_action_bus.py
+++ b/tests/test_action_bus.py
@@ -291,12 +291,28 @@ class TestEchoTest(unittest.TestCase):
         registration pass.
         """
         from api.actions import default_registry, register_builtins
-
-        # Force a clean registration pass for this test by resetting the
-        # module-level flag. The default_registry is process-global so
-        # we cannot easily isolate state otherwise; this matches what a
-        # fresh process startup would observe.
         import api.actions as actions_pkg
+
+        # The default_registry is process-global; this test has to mutate
+        # both the registration flag and the registry's action map to
+        # observe a fresh registration pass. Snapshot the pre-test state
+        # and register an addCleanup() that restores it so the test stays
+        # order-independent: any later test in the same process sees the
+        # exact registry state it would have seen if this test had never
+        # run.
+        saved_registered = actions_pkg._BUILTINS_REGISTERED
+        saved_actions = dict(default_registry._actions)
+
+        def _restore_default_registry_state() -> None:
+            with actions_pkg._BUILTINS_LOCK:
+                actions_pkg._BUILTINS_REGISTERED = saved_registered
+                default_registry._actions.clear()
+                default_registry._actions.update(saved_actions)
+
+        self.addCleanup(_restore_default_registry_state)
+
+        # Force a clean registration pass for this test. Mirrors what a
+        # fresh process startup would observe.
         with actions_pkg._BUILTINS_LOCK:
             actions_pkg._BUILTINS_REGISTERED = False
             default_registry._actions.clear()

--- a/tests/test_action_bus.py
+++ b/tests/test_action_bus.py
@@ -200,6 +200,85 @@ class TestEchoTest(unittest.TestCase):
         register_builtins(reg)
         self.assertEqual(reg.known_actions(), ["echo.test"])
 
+    def test_action_can_chain_via_context_dispatch(self):
+        """A registered action can dispatch a sibling via ``context.dispatch``.
+
+        v1 ships no chaining actions, but the bus contract supports the
+        pattern (see docs/rfcs/action-bus.md ``Chaining`` section). This
+        test locks the contract in so follow-up actions
+        (``session.nudge -> session.refresh``, etc) can rely on it and
+        their PR diffs do not have to also grow the test surface.
+
+        Exercises the ``_ctx(dispatch=...)`` extensibility too: the
+        chaining action only works when its ``context.dispatch`` is
+        wired to the registry's own dispatch method.
+        """
+        reg = ActionRegistry()
+        reg.register(EchoTestAction())
+
+        class _ChainEchoAction:
+            name = "chain.echo"
+
+            def run(self, payload, context):
+                inner_payload = {"content": payload.get("forward", "")}
+                inner = context.dispatch("echo.test", inner_payload, context)
+                if not inner.ok:
+                    return ActionResult(
+                        ok=False, silent=True, error=f"inner: {inner.error}"
+                    )
+                return ActionResult(
+                    ok=True,
+                    silent=False,
+                    assistant_message=f"chain -> {inner.assistant_message}",
+                    refresh_chat=False,
+                )
+
+        reg.register(_ChainEchoAction())
+
+        # _ctx already accepts arbitrary overrides; passing dispatch=
+        # wires the chain through the same registry the outer dispatch
+        # uses. Without this wiring, the default _no_dispatch raises
+        # RuntimeError -- which is the right failure mode for callers
+        # that did not opt in to chaining.
+        result = reg.dispatch(
+            "chain.echo",
+            {"forward": "ping"},
+            _ctx(dispatch=reg.dispatch),
+        )
+
+        self.assertTrue(result.ok)
+        self.assertFalse(result.silent)
+        self.assertEqual(result.assistant_message, "chain -> ping")
+
+    def test_chaining_without_dispatch_raises(self):
+        """If the test surface forgets to wire dispatch, chaining fails loud.
+
+        The bus default for ``ActionContext.dispatch`` is ``_no_dispatch``
+        which raises ``RuntimeError``. The registry's outer ``dispatch``
+        catches the resulting ``Exception`` and wraps it in an error
+        ``ActionResult`` -- which is the right behavior, but means the
+        test surface must explicitly opt in to chaining via
+        ``_ctx(dispatch=...)``. This test asserts that omission is
+        observable rather than silently producing wrong results.
+        """
+        reg = ActionRegistry()
+        reg.register(EchoTestAction())
+
+        class _ChainEchoAction:
+            name = "chain.echo"
+
+            def run(self, payload, context):
+                context.dispatch("echo.test", {"content": "x"}, context)
+                return ActionResult(ok=True, silent=False, assistant_message="ok")
+
+        reg.register(_ChainEchoAction())
+
+        result = reg.dispatch("chain.echo", {}, _ctx())
+
+        self.assertFalse(result.ok)
+        self.assertTrue(result.silent)
+        self.assertIn("RuntimeError", result.error or "")
+
     def test_register_builtins_default_registry_is_idempotent(self):
         """Repeated calls against default_registry must not raise.
 

--- a/tests/test_action_bus.py
+++ b/tests/test_action_bus.py
@@ -1,0 +1,374 @@
+"""Unit tests for the Hermes Action Bus.
+
+Covers:
+    1. ActionRegistry dispatch + ActionNotFound
+    2. Exception inside an action becomes ActionResult(ok=False, error=...)
+    3. Idempotency cache (same key returns cached result; different keys
+       run the action again; no key always runs)
+    4. The trivial ``echo.test`` builtin behavior
+    5. The HTTP adapter ``handle_actions_post``: 400 on missing/invalid
+       fields, 404 on unknown action, 200 on a valid dispatch
+
+These are pure in-process tests; they do not start the test server.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+import unittest
+
+# Ensure the repo root is importable without relying on CWD. Mirrors the
+# bootstrap in tests/test_background_tasks.py.
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from api.actions import (  # noqa: E402  (after sys.path bootstrap)
+    ActionContext,
+    ActionNotFound,
+    ActionRegistry,
+    ActionResult,
+    register_builtins,
+)
+from api.actions.builtin.echo_test import EchoTestAction  # noqa: E402
+from api.actions_http import handle_actions_post  # noqa: E402
+
+
+# ── Helpers ────────────────────────────────────────────────────────────
+
+
+def _capture_emit():
+    calls: list[tuple[str, dict]] = []
+
+    def _emit(event_type: str, payload: dict) -> None:
+        calls.append((event_type, payload))
+
+    return _emit, calls
+
+
+def _ctx(**overrides) -> ActionContext:
+    emit, _calls = _capture_emit()
+    defaults = dict(
+        session_id=overrides.pop("session_id", "sess-1"),
+        user_id=overrides.pop("user_id", None),
+        source=overrides.pop("source", "test"),
+        emit_event=overrides.pop("emit_event", emit),
+        request_meta=overrides.pop("request_meta", {}),
+    )
+    return ActionContext(**defaults, **overrides)
+
+
+# ── Registry behavior ──────────────────────────────────────────────────
+
+
+class TestRegistryDispatch(unittest.TestCase):
+    def test_unknown_action_raises_action_not_found(self):
+        reg = ActionRegistry()
+        with self.assertRaises(ActionNotFound):
+            reg.dispatch("missing.action", {}, _ctx())
+
+    def test_register_duplicate_name_raises(self):
+        reg = ActionRegistry()
+        reg.register(EchoTestAction())
+        with self.assertRaises(ValueError):
+            reg.register(EchoTestAction())
+
+    def test_known_actions_is_sorted(self):
+        reg = ActionRegistry()
+
+        class A:
+            name = "zeta.thing"
+            def run(self, payload, context):  # pragma: no cover
+                return ActionResult()
+
+        class B:
+            name = "alpha.thing"
+            def run(self, payload, context):  # pragma: no cover
+                return ActionResult()
+
+        reg.register(A())
+        reg.register(B())
+        self.assertEqual(reg.known_actions(), ["alpha.thing", "zeta.thing"])
+
+    def test_exception_in_action_becomes_error_result(self):
+        reg = ActionRegistry()
+
+        class Boom:
+            name = "x.boom"
+            def run(self, payload, context):
+                raise RuntimeError("kaboom")
+
+        reg.register(Boom())
+        result = reg.dispatch("x.boom", {}, _ctx())
+        self.assertFalse(result.ok)
+        self.assertTrue(result.silent)
+        self.assertIsNotNone(result.error)
+        self.assertIn("RuntimeError", result.error)
+        self.assertIn("kaboom", result.error)
+
+
+class TestIdempotency(unittest.TestCase):
+    def _counting_action(self):
+        class Counter:
+            name = "x.count"
+            calls = 0
+
+            def run(self, payload, context):
+                type(self).calls += 1
+                return ActionResult(
+                    ok=True,
+                    silent=False,
+                    assistant_message=f"run #{type(self).calls}",
+                )
+
+        return Counter
+
+    def test_same_key_returns_cached_result(self):
+        reg = ActionRegistry()
+        Counter = self._counting_action()
+        reg.register(Counter())
+
+        r1 = reg.dispatch("x.count", {}, _ctx(), idempotency_key="k1")
+        r2 = reg.dispatch("x.count", {}, _ctx(), idempotency_key="k1")
+
+        self.assertEqual(r1.assistant_message, "run #1")
+        self.assertEqual(r2.assistant_message, "run #1")
+        self.assertEqual(Counter.calls, 1)
+
+    def test_different_keys_run_action_again(self):
+        reg = ActionRegistry()
+        Counter = self._counting_action()
+        reg.register(Counter())
+
+        r1 = reg.dispatch("x.count", {}, _ctx(), idempotency_key="k1")
+        r2 = reg.dispatch("x.count", {}, _ctx(), idempotency_key="k2")
+
+        self.assertEqual(r1.assistant_message, "run #1")
+        self.assertEqual(r2.assistant_message, "run #2")
+        self.assertEqual(Counter.calls, 2)
+
+    def test_no_key_always_runs(self):
+        reg = ActionRegistry()
+        Counter = self._counting_action()
+        reg.register(Counter())
+
+        reg.dispatch("x.count", {}, _ctx())
+        reg.dispatch("x.count", {}, _ctx())
+        self.assertEqual(Counter.calls, 2)
+
+
+# ── echo.test builtin ──────────────────────────────────────────────────
+
+
+class TestEchoTest(unittest.TestCase):
+    def test_echo_returns_visible_assistant_message(self):
+        reg = ActionRegistry()
+        reg.register(EchoTestAction())
+
+        result = reg.dispatch(
+            "echo.test",
+            {"content": "hello bus"},
+            _ctx(source="unit"),
+        )
+        self.assertTrue(result.ok)
+        self.assertFalse(result.silent)
+        self.assertEqual(result.assistant_message, "hello bus")
+        self.assertFalse(result.refresh_chat)
+        self.assertEqual(result.meta.get("source"), "unit")
+
+    def test_echo_empty_content_is_silent_ok(self):
+        reg = ActionRegistry()
+        reg.register(EchoTestAction())
+
+        result = reg.dispatch("echo.test", {"content": "   "}, _ctx())
+        self.assertTrue(result.ok)
+        self.assertTrue(result.silent)
+        self.assertIsNone(result.assistant_message)
+
+    def test_echo_non_string_content_is_error(self):
+        reg = ActionRegistry()
+        reg.register(EchoTestAction())
+
+        result = reg.dispatch("echo.test", {"content": 42}, _ctx())
+        self.assertFalse(result.ok)
+        self.assertTrue(result.silent)
+        self.assertEqual(result.error, "content must be a string")
+
+    def test_register_builtins_registers_echo_only(self):
+        reg = ActionRegistry()
+        register_builtins(reg)
+        self.assertEqual(reg.known_actions(), ["echo.test"])
+
+
+# ── HTTP adapter handle_actions_post ───────────────────────────────────
+
+
+class _MockHandler:
+    """Stand-in for BaseHTTPRequestHandler -- only the fields the adapter reads."""
+
+    def __init__(self, remote: str = "127.0.0.1", user_id=None):
+        self.client_address = (remote, 0)
+        self.user_id = user_id
+
+
+class TestHandleActionsPostValidation(unittest.TestCase):
+    def setUp(self):
+        self.reg = ActionRegistry()
+        self.reg.register(EchoTestAction())
+        self.handler = _MockHandler()
+
+    def test_missing_action_returns_400(self):
+        body, status = handle_actions_post(self.handler, {}, registry=self.reg)
+        self.assertEqual(status, 400)
+        self.assertFalse(body["ok"])
+        self.assertEqual(body["error"], "action required")
+
+    def test_non_string_action_returns_400(self):
+        body, status = handle_actions_post(
+            self.handler, {"action": 42}, registry=self.reg
+        )
+        self.assertEqual(status, 400)
+        self.assertFalse(body["ok"])
+
+    def test_blank_string_action_returns_400(self):
+        body, status = handle_actions_post(
+            self.handler, {"action": "   "}, registry=self.reg
+        )
+        self.assertEqual(status, 400)
+
+    def test_invalid_payload_type_returns_400(self):
+        body, status = handle_actions_post(
+            self.handler,
+            {"action": "echo.test", "payload": "not-an-object"},
+            registry=self.reg,
+        )
+        self.assertEqual(status, 400)
+        self.assertEqual(body["error"], "payload must be an object")
+
+    def test_invalid_session_id_type_returns_400(self):
+        body, status = handle_actions_post(
+            self.handler,
+            {"action": "echo.test", "session_id": 123},
+            registry=self.reg,
+        )
+        self.assertEqual(status, 400)
+        self.assertIn("session_id", body["error"])
+
+    def test_invalid_idempotency_key_type_returns_400(self):
+        body, status = handle_actions_post(
+            self.handler,
+            {"action": "echo.test", "idempotency_key": ["nope"]},
+            registry=self.reg,
+        )
+        self.assertEqual(status, 400)
+        self.assertIn("idempotency_key", body["error"])
+
+    def test_non_dict_body_returns_400(self):
+        body, status = handle_actions_post(
+            self.handler, "not a dict", registry=self.reg  # type: ignore[arg-type]
+        )
+        self.assertEqual(status, 400)
+
+
+class TestHandleActionsPostDispatch(unittest.TestCase):
+    def setUp(self):
+        self.reg = ActionRegistry()
+        self.reg.register(EchoTestAction())
+        self.handler = _MockHandler()
+
+    def test_unknown_action_returns_404(self):
+        body, status = handle_actions_post(
+            self.handler,
+            {"action": "does.not.exist.anywhere", "payload": {}},
+            registry=self.reg,
+        )
+        self.assertEqual(status, 404)
+        self.assertFalse(body["ok"])
+        self.assertIn("unknown action", body["error"])
+
+    def test_echo_returns_200_with_normalized_result(self):
+        body, status = handle_actions_post(
+            self.handler,
+            {"action": "echo.test", "payload": {"content": "ping"}},
+            registry=self.reg,
+        )
+        self.assertEqual(status, 200)
+        self.assertTrue(body["ok"])
+        self.assertFalse(body["silent"])
+        self.assertEqual(body["assistant_message"], "ping")
+        self.assertFalse(body["refresh_chat"])
+        self.assertIsNone(body["error"])
+
+    def test_missing_payload_defaults_to_empty_object(self):
+        body, status = handle_actions_post(
+            self.handler,
+            {"action": "echo.test"},  # no payload key at all
+            registry=self.reg,
+        )
+        # Empty payload -> echo.test returns silent ok.
+        self.assertEqual(status, 200)
+        self.assertTrue(body["ok"])
+        self.assertTrue(body["silent"])
+
+    def test_idempotency_via_http_adapter(self):
+        # Same idempotency_key should return the cached result, even
+        # though we wrap the registry in two separate dispatches.
+        class Counter:
+            name = "x.count"
+            calls = 0
+
+            def run(self, payload, context):
+                type(self).calls += 1
+                return ActionResult(
+                    ok=True,
+                    silent=False,
+                    assistant_message=f"run #{type(self).calls}",
+                )
+
+        self.reg.register(Counter())
+
+        b1, s1 = handle_actions_post(
+            self.handler,
+            {"action": "x.count", "payload": {}, "idempotency_key": "abc"},
+            registry=self.reg,
+        )
+        b2, s2 = handle_actions_post(
+            self.handler,
+            {"action": "x.count", "payload": {}, "idempotency_key": "abc"},
+            registry=self.reg,
+        )
+        self.assertEqual(s1, 200)
+        self.assertEqual(s2, 200)
+        self.assertEqual(b1["assistant_message"], "run #1")
+        self.assertEqual(b2["assistant_message"], "run #1")
+        self.assertEqual(Counter.calls, 1)
+
+    def test_emit_event_is_passed_through_context(self):
+        # An action that fires an event should reach the emit_event
+        # closure handed to handle_actions_post.
+        calls: list[tuple[str, dict]] = []
+
+        def _emit(event_type: str, payload: dict) -> None:
+            calls.append((event_type, payload))
+
+        class Emitter:
+            name = "x.emit"
+            def run(self, payload, context):
+                context.emit_event("x.fired", {"echo": payload.get("note")})
+                return ActionResult(ok=True, silent=True)
+
+        self.reg.register(Emitter())
+
+        body, status = handle_actions_post(
+            self.handler,
+            {"action": "x.emit", "payload": {"note": "hi"}},
+            registry=self.reg,
+            emit_event=_emit,
+        )
+        self.assertEqual(status, 200)
+        self.assertEqual(calls, [("x.fired", {"echo": "hi"})])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_action_bus.py
+++ b/tests/test_action_bus.py
@@ -200,6 +200,38 @@ class TestEchoTest(unittest.TestCase):
         register_builtins(reg)
         self.assertEqual(reg.known_actions(), ["echo.test"])
 
+    def test_register_builtins_default_registry_is_idempotent(self):
+        """Repeated calls against default_registry must not raise.
+
+        The route hook in api/routes.py calls register_builtins on every
+        request. The first call registers; later calls must be no-ops
+        rather than raising ValueError on duplicate names. Adding new
+        builtins in follow-up PRs must not change this contract --
+        whatever set _register_all_builtins() installs is what the
+        registry must end up with after exactly one observable
+        registration pass.
+        """
+        from api.actions import default_registry, register_builtins
+
+        # Force a clean registration pass for this test by resetting the
+        # module-level flag. The default_registry is process-global so
+        # we cannot easily isolate state otherwise; this matches what a
+        # fresh process startup would observe.
+        import api.actions as actions_pkg
+        with actions_pkg._BUILTINS_LOCK:
+            actions_pkg._BUILTINS_REGISTERED = False
+            default_registry._actions.clear()
+
+        register_builtins(default_registry)
+        after_first = sorted(default_registry.known_actions())
+
+        # Must not raise on the second call.
+        register_builtins(default_registry)
+        after_second = sorted(default_registry.known_actions())
+
+        self.assertEqual(after_first, after_second)
+        self.assertIn("echo.test", after_second)
+
 
 # ── HTTP adapter handle_actions_post ───────────────────────────────────
 


### PR DESCRIPTION
## Summary

Adds a small typed backend Action Bus for Hermes WebUI session events.

The new dispatcher provides one shared primitive:

    entry point  →  dispatch_action(name, payload, context)
                 →  registered backend action
                 →  ActionResult

This PR ships the primitive plus one trivial builtin, `echo.test`,
which round-trips the dispatch path without touching the session DB,
the agent, or the SSE channel. It exists so the bus can be exercised
end-to-end in unit tests and via the manual smoke test before any
session-touching action lands.

A follow-up PR adds `session.nudge` — the inference-only synthetic
user turn that wakes a session from a background trigger — together
with the `load_visible_messages` / `append_assistant_message` helpers
and the `publish_session_message_appended` SSE event that surfaces the
appended assistant message in open WebUI tabs.

Splitting the work this way keeps this PR mechanically tiny and lets
the session/agent integration land in its own focused review.

## Motivation

Hermes WebUI already has several ways for non-typed-user events to
reach the system: WebUI interactions, cron jobs, webhooks, gateway
messages, and internal background jobs. Today, each entry point that
needs to trigger session-related work invents its own delivery and
execution flow (`api/background.py`, `/background`, `/btw`, ad-hoc
cron callbacks). Those entry points benefit from a shared typed
dispatcher that can:

- run named backend actions consistently;
- keep action handlers small and testable;
- deduplicate repeated triggers with idempotency keys;
- normalize success / error / silent-vs-visible into one result shape;
- be wired into existing transports (HTTP, cron, gateway) without each
  caller reinventing the validation/auth/result layer.

This PR does not replace `api/background.py`. `/background` and
`/btw` remain the user-facing slash commands for "fork a
sub-conversation". A later PR can re-express those on top of the bus,
but that migration is out of scope here.

## Design

### Action Bus

The Action Bus is a registry plus dispatcher:

    result = default_registry.dispatch(
        action="echo.test",
        payload={"content": "ping"},
        context=context,
        idempotency_key="smoke-2026-05-27T17-00",
    )

Actions are registered by name and implement one method:

    def run(self, payload: dict, context: ActionContext) -> ActionResult:
        ...

The bus is intentionally synchronous: Hermes WebUI runs on
`ThreadingHTTPServer` and the rest of `api/*` is plain `def`. Actions
follow the same style so dispatch can happen inside any POST handler
thread without spinning an event loop.

### ActionResult

Every action returns the same shape:

    ActionResult(
        ok=True,
        silent=False,
        assistant_message="ping",
        refresh_chat=False,
        meta={"source": "webui_api"},
    )

The result separates three concerns:

- `ok`: whether the action completed without unrecoverable error;
- `silent` / `assistant_message`: whether anything should surface to chat;
- `refresh_chat`: whether open clients should refresh session state.

### Idempotency

`ActionRegistry.dispatch` accepts an optional `idempotency_key`. For a
given `(action, idempotency_key)` pair, the first successful (or
errored) result is cached for a TTL (default 300s) and returned for
repeat dispatches. The cache is in-memory only, guarded by a
`threading.Lock` to match the WebUI's threaded request model. A
process restart loses pending entries — acceptable for the v1 use
cases (uptime >> typical TTL) and a durable cache can slot in behind
the same `dispatch` signature in a later PR if needed.

### `echo.test` (the only v1 builtin)

`echo.test` is the smallest possible action: it reads
`payload["content"]`, returns it as `assistant_message` when
non-empty, and returns a silent ok otherwise. It does not touch the
session database, the agent, or the SSE channel. It exists so the
dispatch path can be exercised end-to-end in unit tests and via the
manual smoke test.

### HTTP entry point

`POST /api/actions` accepts:

    {
        "action": "echo.test",
        "payload": {"content": "ping"},
        "session_id": "...",         // optional
        "idempotency_key": "..."     // optional
    }

and returns the dispatched `ActionResult.to_dict()` with HTTP status
200 on dispatch (regardless of `ok`), 400 on a malformed request, and
404 on an unknown action name. CSRF is enforced by the existing
`api/routes.py::_check_csrf` path; `/api/actions` is intentionally
NOT added to the CSRF-exempt allowlist — same-origin browser callers
work through the existing Origin/Host check, and non-browser callers
(curl, MCP, agent) pass through because they have no Origin header.

## What lands in this PR

1. `api/actions/types.py` — `ActionContext`, `ActionResult`, `Action`
   protocol, `SILENT_SENTINEL`.
2. `api/actions/registry.py` — `ActionRegistry`, `ActionNotFound`,
   `_IdempotencyCache`, module-level `default_registry`.
3. `api/actions/__init__.py` — package exports and `register_builtins`.
4. `api/actions/builtin/__init__.py`
5. `api/actions/builtin/echo_test.py` — the v1 builtin.
6. `api/actions_http.py` — `handle_actions_post(handler, body, registry, *, emit_event)`.
7. `api/routes.py` — six-line route block routing `/api/actions` to
   the adapter, with lazy idempotent `register_builtins` against the
   process-global registry.
8. `tests/test_action_bus.py` — 23 unit tests, no test-server fixture.

No new dependencies. No async runtime. No frontend changes (the SSE
event and frontend handler land in the follow-up PR alongside the
first real consumer).

## Follow-up PRs

- `session.nudge` builtin + the inference-only agent invocation helper
  + `publish_session_message_appended` SSE event + frontend handler
  (drafted alongside this PR).
- Cron integration calling `dispatch_action("session.nudge", ...)`.
- Webhook integration calling `dispatch_action(...)`.
- Re-express `/background` and `/btw` on top of the bus.
- Persistent audit table for action invocations.

## Testing

- 23 unit tests covering registry dispatch, idempotency (same key /
  different keys / no key), exception handling, the `echo.test`
  builtin (visible, silent, error), and the HTTP adapter (six 400
  cases, 404, 200, idempotency through the adapter, and `emit_event`
  pass-through). No test-server fixture required.
- Manual smoke test against a running WebUI:

  ```bash
  curl -X POST http://127.0.0.1:8787/api/actions \
    -H "Content-Type: application/json" \
    -H "Cookie: <your hermes session cookie>" \
    -d '{
      "action": "echo.test",
      "idempotency_key": "smoke-test-1",
      "payload": {"content": "hello bus"}
    }'
  ```

  Expected: `200` with `{"ok": true, "silent": false, "assistant_message": "hello bus", ...}`. Repeat with the same `idempotency_key` → same body (cached). POST without `action` → `400`. POST with an unregistered name → `404`. Curl is a non-browser caller (no `Origin` header) so it passes CSRF naturally; browser callers go through the existing same-origin check.
```
