### PR TITLE
stage-batch28: v0.51.146 / Release DR — 6-PR low-risk safety+contrast batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Custom provider `/v1/models` discovery now uses a short per-endpoint timeout and gracefully skips slow or unreachable providers, reducing cold `/api/models` cache rebuild latency. (#3024)
+
 ## [v0.51.145] — 2026-05-26 — Release DQ (stage-batch27 — sidebar running-state preservation)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,19 @@
 
 ## [Unreleased]
 
+## [v0.51.146] — 2026-05-28 — Release DR (stage-batch28 — 6-PR low-risk safety+contrast batch)
+
 ### Fixed
 
-- Dark-mode panel header save buttons now use a theme-aware foreground token, keeping workspace and other detail-pane check icons visible on the default gold accent. (#2998)
-- Custom provider `/v1/models` discovery now uses a short per-endpoint timeout and gracefully skips slow or unreachable providers, reducing cold `/api/models` cache rebuild latency. (#3024)
+- Dark-mode panel header save buttons now use a theme-aware foreground token, keeping workspace and other detail-pane check icons visible on the default gold accent. (#2998, #3022)
+- Custom provider `/v1/models` discovery now uses a short per-endpoint timeout and gracefully skips slow or unreachable providers, reducing cold `/api/models` cache rebuild latency. (#3024, #3025)
+- Messaging (Telegram-resumed) sessions: the `?messages=0` metadata fast path now routes through the same display merge as the full-message path, so `message_count` and `last_message_at` match the rendered transcript and stop triggering refresh-loops that reset scroll and close open dropdowns. (#3003)
+- WebUI sessions mirrored into `state.db` for long-history retention now stay in the WebUI sidebar tab instead of being misclassified as CLI rows. Adds regression coverage for both directions of the WebUI vs CLI source-tab invariant. (#3027)
+- Sidebar projection now keeps at least one messageful representative visible per non-background conversation when normal filters would otherwise hide every row, rescuing discoverability for sessions with stale snapshot/lineage metadata. Rescued rows are marked `discoverability_warning: rescued_messageful_hidden_session` for auditability; intentional background/cron sessions stay hidden. (#3028)
+
+### Added
+
+- New read-only `api.session_discoverability` audit module cross-checks JSON sidecars, `_index.json`, `state.db`, and the live sidebar response to classify messageful sessions without a visible representative, stale WebUI-as-CLI source flags, missing sidecars, and lineage segments without a visible tip. Diagnostic surface only; does not repair, restart, or mutate any state. (#3029)
 
 ## [v0.51.145] — 2026-05-26 — Release DQ (stage-batch27 — sidebar running-state preservation)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Dark-mode panel header save buttons now use a theme-aware foreground token, keeping workspace and other detail-pane check icons visible on the default gold accent. (#2998)
+
 ## [v0.51.145] — 2026-05-26 — Release DQ (stage-batch27 — sidebar running-state preservation)
 
 ### Fixed

--- a/api/agent_sessions.py
+++ b/api/agent_sessions.py
@@ -142,14 +142,16 @@ def is_cli_session_row(row: dict) -> bool:
     if not isinstance(row, dict):
         return False
     source = _safe_lower(row.get("session_source"))
-    if source == "messaging":
-        return False
-    if source == "cli":
-        return True
     source_tag = _safe_lower(row.get("source_tag"))
     raw_source = _safe_lower(row.get("raw_source"))
     source_name = _safe_lower(row.get("source"))
     source_label = _safe_lower(row.get("source_label"))
+    if "webui" in {source, source_tag, raw_source, source_name, source_label}:
+        return False
+    if source == "messaging":
+        return False
+    if source == "cli":
+        return True
     if source_tag == "cli" or raw_source == "cli" or source_name == "cli" or source_label == "cli":
         return True
 
@@ -727,6 +729,15 @@ def read_session_lineage_metadata(db_path: Path, session_ids: list[str] | set[st
         state_title = str(row.get('title') or '').strip()
         if state_title:
             metadata.setdefault(sid, {})['_state_db_title'] = state_title
+        state_source = str(row.get('source') or '').strip().lower()
+        if state_source:
+            entry = metadata.setdefault(sid, {})
+            entry['_state_db_source'] = state_source
+            source_meta = normalize_agent_session_source(state_source)
+            entry['_state_db_source_tag'] = state_source
+            entry['_state_db_raw_source'] = source_meta.get('raw_source')
+            entry['_state_db_session_source'] = source_meta.get('session_source')
+            entry['_state_db_source_label'] = source_meta.get('source_label')
 
         parent_id = row.get('parent_session_id')
         parent_row = rows.get(parent_id) if parent_id else None

--- a/api/config.py
+++ b/api/config.py
@@ -70,6 +70,12 @@ PROJECTS_FILE = STATE_DIR / "projects.json"
 
 logger = logging.getLogger(__name__)
 
+# Keep custom provider /v1/models probes below the frontend's generic request
+# timeout even when one upstream is slow or unreachable. The models cache rebuild
+# path probes configured custom endpoints serially, so each provider needs a
+# short hard cap and graceful degradation.
+CUSTOM_MODELS_ENDPOINT_TIMEOUT_SECONDS = 5.0
+
 
 def _env_mb_bytes(name: str, default_mb: int) -> int:
     """Parse an optional megabyte environment variable into bytes.
@@ -3653,7 +3659,7 @@ def get_available_models() -> dict:
                 req.add_header("User-Agent", "OpenAI/Python 1.0")
                 for k, v in headers.items():
                     req.add_header(k, v)
-                with urllib.request.urlopen(req, timeout=10) as response:  # nosec B310
+                with urllib.request.urlopen(req, timeout=CUSTOM_MODELS_ENDPOINT_TIMEOUT_SECONDS) as response:  # nosec B310
                     data = json.loads(response.read().decode("utf-8"))
                 return _extract_model_entries_from_payload(data, provider), None
             except urllib.error.HTTPError as exc:

--- a/api/models.py
+++ b/api/models.py
@@ -2295,7 +2295,18 @@ def _enrich_sidebar_lineage_metadata(sessions: list[dict]) -> None:
         if sid in metadata:
             entry = dict(metadata[sid])
             state_db_title = entry.pop('_state_db_title', None)
+            state_db_source = entry.pop('_state_db_source', None)
+            state_db_source_tag = entry.pop('_state_db_source_tag', None)
+            state_db_raw_source = entry.pop('_state_db_raw_source', None)
+            state_db_session_source = entry.pop('_state_db_session_source', None)
+            state_db_source_label = entry.pop('_state_db_source_label', None)
             session.update(entry)
+            if state_db_source == 'webui':
+                session['source_tag'] = state_db_source_tag
+                session['raw_source'] = state_db_raw_source
+                session['session_source'] = state_db_session_source
+                session['source_label'] = state_db_source_label
+                session['is_cli_session'] = False
             title = session.get('title')
             if (
                 state_db_title

--- a/api/models.py
+++ b/api/models.py
@@ -2195,6 +2195,70 @@ def _has_live_sidebar_state(session: dict) -> bool:
     )
 
 
+def _is_intentionally_background_sidebar_session(session: dict) -> bool:
+    sid = str(session.get('session_id') or '')
+    source = session.get('source_tag') or session.get('source')
+    return source == 'cron' or sid.startswith('cron_')
+
+
+def _preserve_messageful_sidebar_discoverability(
+    candidates: list[dict],
+    visible: list[dict],
+) -> list[dict]:
+    """Keep at least one messageful row per non-background conversation visible.
+
+    The normal sidebar filters intentionally hide empty drafts, cron/background
+    rows, and duplicate pre-compression snapshots. They must not make the only
+    messageful representative of a conversation disappear. If every visible row
+    for a lineage was filtered out, rescue the best hidden messageful row and
+    mark it so callers can surface or audit the degraded state.
+    """
+    sessions_by_id = {
+        str(session.get('session_id')): session
+        for session in candidates
+        if session.get('session_id')
+    }
+    covered_roots = {
+        _sidebar_lineage_root_id(session, sessions_by_id)
+        for session in visible
+        if _sidebar_message_count(session) > 0
+    }
+    visible_ids = {
+        str(session.get('session_id'))
+        for session in visible
+        if session.get('session_id')
+    }
+    rescue_by_root: dict[str, dict] = {}
+    for session in candidates:
+        sid = str(session.get('session_id') or '')
+        if not sid or sid in visible_ids:
+            continue
+        if _sidebar_message_count(session) <= 0:
+            continue
+        if _is_intentionally_background_sidebar_session(session):
+            continue
+        root = _sidebar_lineage_root_id(session, sessions_by_id)
+        if root in covered_roots:
+            continue
+        current = rescue_by_root.get(root)
+        if current is None or (
+            _sidebar_message_count(session), _session_sort_timestamp(session)
+        ) > (
+            _sidebar_message_count(current), _session_sort_timestamp(current)
+        ):
+            rescued = dict(session)
+            rescued['discoverability_warning'] = 'rescued_messageful_hidden_session'
+            rescue_by_root[root] = rescued
+    if not rescue_by_root:
+        return visible
+    rescued_rows = sorted(
+        rescue_by_root.values(),
+        key=lambda session: (session.get('pinned', False), _session_sort_timestamp(session)),
+        reverse=True,
+    )
+    return visible + rescued_rows
+
+
 def _prefer_fuller_snapshots_for_sidebar(sessions: list[dict]) -> list[dict]:
     """Expose a hidden snapshot when it is the fuller transcript for a lineage.
 
@@ -2401,7 +2465,8 @@ def all_sessions(diag=None):
                 and not s.get('worktree_path')
             )]
             result = _prefer_fuller_snapshots_for_sidebar(result)
-            result = [s for s in result if not _hide_from_default_sidebar(s)]
+            visible_result = [s for s in result if not _hide_from_default_sidebar(s)]
+            result = _preserve_messageful_sidebar_discoverability(result, visible_result)
             _strip_sidebar_internal_flags(result)
             # Backfill: sessions created before Sprint 22 have no profile tag.
             # Attribute them to 'default' so the client profile filter works correctly.
@@ -2439,7 +2504,8 @@ def all_sessions(diag=None):
         and not getattr(s, 'worktree_path', None)
     )]
     result = _prefer_fuller_snapshots_for_sidebar(result)
-    result = [s for s in result if not _hide_from_default_sidebar(s)]
+    visible_result = [s for s in result if not _hide_from_default_sidebar(s)]
+    result = _preserve_messageful_sidebar_discoverability(result, visible_result)
     _strip_sidebar_internal_flags(result)
     for s in result:
         if not s.get('profile'):

--- a/api/routes.py
+++ b/api/routes.py
@@ -2385,6 +2385,15 @@ def _is_cli_session_for_settings(session: dict) -> bool:
     )
 
 
+def _normalize_sidebar_source_flags(session: dict) -> dict:
+    """Return a sidebar row with the frontend CLI flag matching source metadata."""
+    if not isinstance(session, dict):
+        return session
+    normalized = dict(session)
+    normalized["is_cli_session"] = is_cli_session_row(normalized)
+    return normalized
+
+
 CLI_VISIBLE_SESSION_CAP = 20
 
 
@@ -2414,7 +2423,11 @@ def _merge_cli_sidebar_metadata(ui_session: dict, cli_meta: dict) -> dict:
     if not cli_meta:
         return dict(ui_session)
     merged = dict(ui_session)
-    merged["is_cli_session"] = True
+    # Only preserve the CLI flag when the imported metadata is actually a CLI
+    # row. WebUI sessions are also mirrored into state.db; treating every
+    # matching state row as CLI hides long WebUI continuations from the default
+    # sidebar source tab.
+    merged["is_cli_session"] = is_cli_session_row(cli_meta)
     for key in (
         "source_tag",
         "raw_source",
@@ -4415,6 +4428,7 @@ def handle_get(handler, parsed) -> bool:
             diag.stage("load_settings")
             settings = load_settings()
             show_cli_sessions = bool(settings.get("show_cli_sessions"))
+            webui_sessions = [_normalize_sidebar_source_flags(s) for s in webui_sessions]
             if show_cli_sessions:
                 diag.stage("get_cli_sessions")
                 cli = get_cli_sessions()
@@ -4432,6 +4446,7 @@ def handle_get(handler, parsed) -> bool:
                         for key in ("source_tag", "raw_source", "session_source", "source_label"):
                             if not s.get(key) and meta.get(key):
                                 s[key] = meta[key]
+                webui_sessions = [_normalize_sidebar_source_flags(s) for s in webui_sessions]
                 # Apply the same CLI visibility semantics to imported local copies so
                 # low-value imported artifacts do not leak into the sidebar.
                 webui_sessions = [s for s in webui_sessions if is_cli_session_row_visible(s)]

--- a/api/routes.py
+++ b/api/routes.py
@@ -4152,8 +4152,7 @@ def handle_get(handler, parsed) -> bool:
                     )
             else:
                 if is_messaging_session and cli_messages:
-                    sidecar_messages = getattr(s, "messages", []) or []
-                    _all_msgs = merge_session_messages_append_only(cli_messages, sidecar_messages)
+                    _all_msgs = _merged_session_messages_for_display(s, cli_messages)
                 else:
                     if metadata_summary is None:
                         metadata_summary = _message_summary(getattr(s, "messages", []) or [])

--- a/api/session_discoverability.py
+++ b/api/session_discoverability.py
@@ -1,0 +1,433 @@
+"""Read-only sidebar discoverability audit for Hermes WebUI sessions.
+
+This module does not repair or mutate session state. It cross-checks the four
+places that decide whether a session can be found from the WebUI sidebar:
+
+- JSON sidecars under the WebUI session directory
+- ``_index.json`` sidebar metadata
+- canonical ``state.db`` rows/messages
+- the live ``api.models.all_sessions()`` sidebar response, when available
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+from collections import Counter
+from pathlib import Path
+from typing import Iterable
+
+
+def _safe_int(value, default: int = 0) -> int:
+    try:
+        if value is None:
+            return default
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _read_json(path: Path):
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, ValueError):
+        return None
+
+
+def _message_count_from_payload(payload: dict) -> int:
+    messages = payload.get("messages")
+    if isinstance(messages, list):
+        return len(messages)
+    return _safe_int(payload.get("message_count"), 0)
+
+
+def _record_from_mapping(mapping: dict, source_name: str) -> dict:
+    sid = str(mapping.get("session_id") or mapping.get("id") or "").strip()
+    if not sid:
+        return {}
+    return {
+        "session_id": sid,
+        "title": mapping.get("title"),
+        "message_count": _message_count_from_payload(mapping),
+        "source_tag": mapping.get("source_tag"),
+        "session_source": mapping.get("session_source"),
+        "source": mapping.get("source"),
+        "is_cli_session": mapping.get("is_cli_session"),
+        "parent_session_id": mapping.get("parent_session_id"),
+        "pre_compression_snapshot": bool(mapping.get("pre_compression_snapshot")),
+        "_lineage_root_id": mapping.get("_lineage_root_id"),
+        "archived": bool(mapping.get("archived")),
+        "project_id": mapping.get("project_id"),
+        "workspace": mapping.get("workspace"),
+        "_source_name": source_name,
+    }
+
+
+def _read_sidecars(session_dir: Path) -> dict[str, dict]:
+    records: dict[str, dict] = {}
+    if not session_dir.exists():
+        return records
+    for path in sorted(p for p in session_dir.glob("*.json") if not p.name.startswith("_")):
+        payload = _read_json(path)
+        if not isinstance(payload, dict):
+            continue
+        record = _record_from_mapping(payload, "sidecar")
+        if record:
+            records[record["session_id"]] = record
+    return records
+
+
+def _read_index(session_dir: Path) -> dict[str, dict]:
+    payload = _read_json(session_dir / "_index.json")
+    records: dict[str, dict] = {}
+    if not isinstance(payload, list):
+        return records
+    for entry in payload:
+        if not isinstance(entry, dict):
+            continue
+        record = _record_from_mapping(entry, "index")
+        if record:
+            records[record["session_id"]] = record
+    return records
+
+
+def _optional_expr(name: str, columns: set[str], fallback: str = "NULL") -> str:
+    return name if name in columns else f"{fallback} AS {name}"
+
+
+def _read_state_db(state_db_path: Path | None) -> dict[str, dict]:
+    if state_db_path is None or not state_db_path.exists():
+        return {}
+    try:
+        with sqlite3.connect(f"file:{state_db_path}?mode=ro", uri=True) as conn:
+            conn.row_factory = sqlite3.Row
+            tables = {row[0] for row in conn.execute("select name from sqlite_master where type='table'")}
+            if "sessions" not in tables:
+                return {}
+            session_cols = {row[1] for row in conn.execute("pragma table_info(sessions)")}
+            if "id" not in session_cols:
+                return {}
+            message_cols: set[str] = set()
+            if "messages" in tables:
+                message_cols = {row[1] for row in conn.execute("pragma table_info(messages)")}
+            title_expr = _optional_expr("title", session_cols)
+            source_expr = _optional_expr("source", session_cols)
+            parent_expr = _optional_expr("parent_session_id", session_cols)
+            msg_expr = _optional_expr("message_count", session_cols, "0")
+            workspace_expr = _optional_expr("workspace", session_cols)
+            rows = conn.execute(
+                f"""
+                SELECT id, {title_expr}, {source_expr}, {parent_expr}, {msg_expr}, {workspace_expr}
+                FROM sessions
+                """
+            ).fetchall()
+            message_counts: dict[str, int] = {}
+            if {"session_id"}.issubset(message_cols):
+                for row in conn.execute("SELECT session_id, COUNT(*) AS count FROM messages GROUP BY session_id"):
+                    message_counts[str(row["session_id"])] = _safe_int(row["count"], 0)
+            records: dict[str, dict] = {}
+            for row in rows:
+                sid = str(row["id"] or "").strip()
+                if not sid:
+                    continue
+                count = message_counts.get(sid, _safe_int(row["message_count"], 0))
+                records[sid] = {
+                    "session_id": sid,
+                    "title": row["title"],
+                    "message_count": count,
+                    "source": row["source"],
+                    "source_tag": row["source"],
+                    "session_source": row["source"],
+                    "parent_session_id": row["parent_session_id"],
+                    "workspace": row["workspace"],
+                    "_source_name": "state_db",
+                }
+            return records
+    except Exception:
+        return {}
+
+
+def _normalize_api_sessions(api_sessions: Iterable[dict] | None) -> dict[str, dict]:
+    records: dict[str, dict] = {}
+    if api_sessions is None:
+        try:
+            from api.models import all_sessions
+
+            api_sessions = all_sessions()
+        except Exception:
+            api_sessions = []
+    for entry in api_sessions or []:
+        if not isinstance(entry, dict):
+            continue
+        record = _record_from_mapping(entry, "api")
+        if record:
+            records[record["session_id"]] = record
+    return records
+
+
+def _merged_field(sid: str, stores: list[dict[str, dict]], field: str):
+    for store in stores:
+        value = store.get(sid, {}).get(field)
+        if value not in (None, ""):
+            return value
+    return None
+
+
+def _max_message_count(sid: str, stores: list[dict[str, dict]]) -> int:
+    return max((_safe_int(store.get(sid, {}).get("message_count"), 0) for store in stores), default=0)
+
+
+def _lineage_root(sid: str, parent_by_id: dict[str, str | None]) -> str:
+    seen: set[str] = set()
+    current = sid
+    while current and current not in seen:
+        seen.add(current)
+        parent = parent_by_id.get(current)
+        if not parent:
+            return current
+        current = parent
+    return sid
+
+
+def _webui_origin(*records: dict) -> bool:
+    values: list[str] = []
+    for record in records:
+        for key in ("source", "source_tag", "session_source"):
+            value = record.get(key)
+            if value is not None:
+                values.append(str(value).strip().lower())
+    return "webui" in values
+
+
+def _computed_is_cli_session(row: dict) -> bool:
+    sources = {
+        str(row.get(key) or "").strip().lower()
+        for key in ("session_source", "source_tag", "raw_source", "source", "source_label")
+    }
+    if "webui" in sources:
+        return False
+    try:
+        from api.agent_sessions import is_cli_session_row
+
+        return is_cli_session_row(row)
+    except Exception:
+        source = str(row.get("session_source") or row.get("source_tag") or row.get("raw_source") or row.get("source") or "").strip().lower()
+        return source == "cli"
+
+
+def _new_item(session_id: str, kind: str, category: str, recommendation: str, **extra) -> dict:
+    item = {
+        "session_id": session_id,
+        "kind": kind,
+        "category": category,
+        "recommendation": recommendation,
+    }
+    item.update(extra)
+    return item
+
+
+def audit_session_discoverability(
+    session_dir: Path,
+    state_db_path: Path | None = None,
+    *,
+    api_sessions: Iterable[dict] | None = None,
+) -> dict:
+    """Return a read-only cross-store discoverability report.
+
+    The audit is intentionally diagnostic only. It reports cases where
+    messageful sessions have no visible API/sidebar representative, stale source
+    flags can put WebUI sessions into the CLI tab, and index/sidecar/state-db
+    drift can make a session harder to resolve.
+    """
+    session_dir = Path(session_dir)
+    sidecars = _read_sidecars(session_dir)
+    index = _read_index(session_dir)
+    state = _read_state_db(state_db_path)
+    api = _normalize_api_sessions(api_sessions)
+    stores = [sidecars, index, state, api]
+    all_ids = set().union(*(store.keys() for store in stores))
+
+    parent_by_id: dict[str, str | None] = {}
+    for sid in all_ids:
+        parent = _merged_field(sid, stores, "parent_session_id")
+        parent_by_id[sid] = str(parent) if parent else None
+    api_lineage_ids: set[str] = set()
+    for sid, row in api.items():
+        explicit_root = row.get("_lineage_root_id")
+        if explicit_root:
+            api_lineage_ids.add(str(explicit_root))
+        current = sid
+        seen: set[str] = set()
+        while current and current not in seen:
+            seen.add(current)
+            api_lineage_ids.add(current)
+            current = parent_by_id.get(current) or ""
+
+    items: list[dict] = []
+    for sid in sorted(all_ids):
+        message_count = _max_message_count(sid, stores)
+        present_in = {
+            "sidecar": sid in sidecars,
+            "index": sid in index,
+            "state_db": sid in state,
+            "api": sid in api,
+        }
+        sidecar = sidecars.get(sid, {})
+        index_row = index.get(sid, {})
+        state_row = state.get(sid, {})
+        api_row = api.get(sid, {})
+        webui_origin = _webui_origin(sidecar, index_row, state_row, api_row)
+
+        api_is_cli = api_row.get("is_cli_session") is True
+        api_computed_is_cli = _computed_is_cli_session(api_row) if api_row else False
+        index_is_cli = index_row.get("is_cli_session") is True
+        sidecar_is_cli = sidecar.get("is_cli_session") is True
+        if webui_origin and api_is_cli and api_computed_is_cli:
+            items.append(_new_item(
+                sid,
+                "source_misclassified",
+                "warning",
+                "normalize_api_source_flags",
+                message_count=message_count,
+                state_source=state_row.get("source"),
+                api_is_cli_session=api_row.get("is_cli_session"),
+                api_computed_is_cli_session=api_computed_is_cli,
+                index_is_cli_session=index_row.get("is_cli_session"),
+                sidecar_is_cli_session=sidecar.get("is_cli_session"),
+                present_in=present_in,
+            ))
+        elif webui_origin and (api_is_cli or index_is_cli or sidecar_is_cli):
+            items.append(_new_item(
+                sid,
+                "persisted_source_flag_stale",
+                "warning",
+                "rewrite_persisted_sidebar_source_flags_or_ignore_route_normalizes",
+                message_count=message_count,
+                state_source=state_row.get("source"),
+                api_is_cli_session=api_row.get("is_cli_session"),
+                api_computed_is_cli_session=api_computed_is_cli,
+                index_is_cli_session=index_row.get("is_cli_session"),
+                sidecar_is_cli_session=sidecar.get("is_cli_session"),
+                present_in=present_in,
+            ))
+
+        if message_count <= 0 or sid in api:
+            continue
+
+        lineage_root = _lineage_root(sid, parent_by_id)
+        is_hidden_snapshot = bool(sidecar.get("pre_compression_snapshot") or index_row.get("pre_compression_snapshot"))
+        if sid in api_lineage_ids or lineage_root in api_lineage_ids:
+            continue
+
+        if is_hidden_snapshot:
+            items.append(_new_item(
+                sid,
+                "lineage_missing_visible_representative",
+                "warning",
+                "repair_lineage_or_expose_tip",
+                message_count=message_count,
+                lineage_root=lineage_root,
+                present_in=present_in,
+            ))
+            continue
+
+        if not present_in["sidecar"] and not present_in["index"] and present_in["state_db"]:
+            items.append(_new_item(
+                sid,
+                "state_db_messageful_missing_sidecar",
+                "warning",
+                "materialize_sidecar_or_archive_state_row",
+                message_count=message_count,
+                lineage_root=lineage_root,
+                present_in=present_in,
+            ))
+            continue
+
+        items.append(_new_item(
+            sid,
+            "api_missing_messageful",
+            "warning",
+            "investigate_sidebar_filters_or_api_merge",
+            message_count=message_count,
+            lineage_root=lineage_root,
+            present_in=present_in,
+        ))
+
+    summary = {
+        "sessions_seen": len(all_ids),
+        "messageful": sum(1 for sid in all_ids if _max_message_count(sid, stores) > 0),
+        "visible_api": len(api),
+        "warnings": sum(1 for item in items if item.get("category") == "warning"),
+    }
+    status = "warn" if summary["warnings"] else "ok"
+    return {
+        "status": status,
+        "summary": summary,
+        "stores": {
+            "sidecar": len(sidecars),
+            "index": len(index),
+            "state_db": len(state),
+            "api": len(api),
+        },
+        "items": items,
+    }
+
+
+def render_discoverability_markdown(report: dict) -> str:
+    lines = [
+        "# WebUI Session Discoverability Audit",
+        "",
+        f"Status: `{report.get('status')}`",
+        "",
+        "## Summary",
+        "",
+    ]
+    for key, value in (report.get("summary") or {}).items():
+        lines.append(f"- `{key}`: {value}")
+    lines.extend(["", "## Stores", ""])
+    for key, value in (report.get("stores") or {}).items():
+        lines.append(f"- `{key}`: {value}")
+    lines.extend(["", "## Findings", ""])
+    items = report.get("items") or []
+    if items:
+        lines.extend(["### By kind", ""])
+        for kind, count in sorted(Counter(str(item.get("kind")) for item in items).items()):
+            lines.append(f"- `{kind}`: {count}")
+        lines.extend(["", "### Details", ""])
+    if not items:
+        lines.append("No discoverability findings.")
+    else:
+        for item in items:
+            lines.append(
+                f"- `{item.get('kind')}` `{item.get('session_id')}` "
+                f"messages={item.get('message_count', 'n/a')} recommendation=`{item.get('recommendation')}`"
+            )
+            present = item.get("present_in")
+            if isinstance(present, dict):
+                lines.append(
+                    "  - present_in: " + ", ".join(f"{k}={v}" for k, v in sorted(present.items()))
+                )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _main() -> int:
+    parser = argparse.ArgumentParser(description="Read-only Hermes WebUI session discoverability audit")
+    parser.add_argument("--session-dir", type=Path, required=True)
+    parser.add_argument("--state-db", type=Path, default=None)
+    parser.add_argument("--format", choices=("json", "markdown"), default="json")
+    parser.add_argument("--out", type=Path, default=None)
+    args = parser.parse_args()
+
+    report = audit_session_discoverability(args.session_dir, state_db_path=args.state_db)
+    text = render_discoverability_markdown(report) if args.format == "markdown" else json.dumps(report, sort_keys=True)
+    if args.out:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(text, encoding="utf-8")
+    else:
+        print(text)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/static/style.css
+++ b/static/style.css
@@ -3922,9 +3922,10 @@ main.main > .main-view:not([id="mainChat"]):not([id="mainSettings"]) .main-view-
 .detail-form-row label.detail-form-check{display:flex;align-items:center;gap:8px;font-size:13px;color:var(--text);cursor:pointer;font-weight:400;}
 .detail-form-row label.detail-form-check input{accent-color:var(--accent,var(--link));}
 .detail-form-error{font-size:12px;color:var(--error,#e05);padding:8px 10px;border:1px solid color-mix(in srgb,var(--error,#e05) 35%,transparent);background:color-mix(in srgb,var(--error,#e05) 8%,transparent);border-radius:8px;line-height:1.5;}
-.panel-head-btn.primary{background:var(--accent,var(--link));color:#fff;border:none;}
-.panel-head-btn.primary:hover{background:var(--accent-hover,var(--accent,var(--link)));color:#fff;}
-.panel-head-btn.primary svg{color:#fff;}
+:root.dark{--panel-head-primary-fg:var(--bg);}
+.panel-head-btn.primary{background:var(--accent,var(--link));color:var(--panel-head-primary-fg,#fff);border:none;}
+.panel-head-btn.primary:hover{background:var(--accent-hover,var(--accent,var(--link)));color:var(--panel-head-primary-fg,#fff);}
+.panel-head-btn.primary svg{color:var(--panel-head-primary-fg,#fff);}
 /* Skill-picker inside in-main forms reuses the sidebar styles but needs light tweaks */
 .detail-form-row .skill-picker-wrap{position:relative;}
 .detail-form-row .skill-picker-tags{margin-top:6px;display:flex;flex-wrap:wrap;gap:4px;}

--- a/tests/test_issue2351_cli_session_source_filter.py
+++ b/tests/test_issue2351_cli_session_source_filter.py
@@ -29,3 +29,94 @@ def test_session_source_tabs_have_dedicated_sidebar_styles():
     assert ".session-source-tabs" in css
     assert ".session-source-tab.active" in css
     assert ".session-empty-note" in css
+
+
+def test_webui_state_db_mirror_does_not_become_cli_sidebar_row():
+    from api.routes import _merge_cli_sidebar_metadata
+
+    merged = _merge_cli_sidebar_metadata(
+        {"session_id": "webui-tip", "title": "Long WebUI session", "source_tag": "webui"},
+        {
+            "session_id": "webui-tip",
+            "source_tag": "webui",
+            "session_source": "webui",
+            "message_count": 1740,
+        },
+    )
+
+    assert merged["is_cli_session"] is False
+    assert merged["source_tag"] == "webui"
+    assert merged["session_source"] == "webui"
+    assert merged["message_count"] == 1740
+
+
+def test_real_cli_state_db_mirror_stays_cli_sidebar_row():
+    from api.routes import _merge_cli_sidebar_metadata
+
+    merged = _merge_cli_sidebar_metadata(
+        {"session_id": "cli-tip", "title": "CLI session", "source_tag": "cli"},
+        {
+            "session_id": "cli-tip",
+            "source_tag": "cli",
+            "session_source": "cli",
+            "message_count": 12,
+        },
+    )
+
+    assert merged["is_cli_session"] is True
+    assert merged["session_source"] == "cli"
+
+
+def test_stale_webui_sidebar_cli_flag_is_cleared_before_frontend_response():
+    from api.routes import _normalize_sidebar_source_flags
+
+    normalized = _normalize_sidebar_source_flags(
+        {
+            "session_id": "webui-tip",
+            "title": "Long WebUI session",
+            "source_tag": "webui",
+            "session_source": "webui",
+            "is_cli_session": True,
+            "message_count": 1740,
+        }
+    )
+
+    assert normalized["is_cli_session"] is False
+    assert normalized["source_tag"] == "webui"
+    assert normalized["session_source"] == "webui"
+
+
+
+def test_webui_source_overrides_stale_cli_flag_even_with_default_title():
+    from api.agent_sessions import is_cli_session_row
+    from api.routes import _normalize_sidebar_source_flags
+
+    stale_webui = {
+        "session_id": "webui-default-title",
+        "title": "CLI Session",
+        "source_tag": "webui",
+        "session_source": "webui",
+        "source_label": "WebUI",
+        "is_cli_session": True,
+        "message_count": 23,
+    }
+
+    assert is_cli_session_row(stale_webui) is False
+    assert _normalize_sidebar_source_flags(stale_webui)["is_cli_session"] is False
+
+
+def test_real_cli_sidebar_cli_flag_is_preserved_before_frontend_response():
+    from api.routes import _normalize_sidebar_source_flags
+
+    normalized = _normalize_sidebar_source_flags(
+        {
+            "session_id": "cli-tip",
+            "title": "CLI session",
+            "source_tag": "cli",
+            "session_source": "cli",
+            "is_cli_session": True,
+            "message_count": 12,
+        }
+    )
+
+    assert normalized["is_cli_session"] is True

--- a/tests/test_issue2540_models_endpoint_error.py
+++ b/tests/test_issue2540_models_endpoint_error.py
@@ -112,6 +112,25 @@ def test_named_custom_provider_models_endpoint_5xx_preserves_status(monkeypatch,
     assert error["code"] == 502
     assert "returned 502" in error["message"]
 
+def test_named_custom_provider_models_endpoint_network_error_uses_short_timeout(monkeypatch, tmp_path):
+    observed_timeouts = []
+
+    def fake_urlopen(req, timeout=10):
+        observed_timeouts.append(timeout)
+        raise urllib.error.URLError("timed out")
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+    with _ConfigState():
+        _configure_named_custom_provider(tmp_path, monkeypatch)
+        data = config.get_available_models()
+
+    group = _groups_by_provider(data)["custom:broken-proxy"]
+    assert group["models"] == []
+    assert group["models_endpoint_error"]["kind"] == "network"
+    assert observed_timeouts == [config.CUSTOM_MODELS_ENDPOINT_TIMEOUT_SECONDS]
+    assert max(observed_timeouts) <= 5.0
+
 
 def test_frontend_model_picker_renders_provider_endpoint_hint():
     ui = open("static/ui.js", encoding="utf-8").read()

--- a/tests/test_issue2998_panel_primary_contrast.py
+++ b/tests/test_issue2998_panel_primary_contrast.py
@@ -1,0 +1,17 @@
+"""Regression coverage for #2998: gold panel save buttons need visible icons."""
+
+from pathlib import Path
+
+
+CSS = (Path(__file__).resolve().parent.parent / "static" / "style.css").read_text(encoding="utf-8")
+
+
+def test_panel_primary_buttons_use_foreground_token_for_icon_contrast():
+    assert "--panel-head-primary-fg" in CSS
+    assert ".panel-head-btn.primary{background:var(--accent,var(--link));color:var(--panel-head-primary-fg,#fff);border:none;}" in CSS
+    assert ".panel-head-btn.primary:hover{background:var(--accent-hover,var(--accent,var(--link)));color:var(--panel-head-primary-fg,#fff);}" in CSS
+    assert ".panel-head-btn.primary svg{color:var(--panel-head-primary-fg,#fff);}" in CSS
+
+
+def test_dark_theme_panel_primary_buttons_use_dark_foreground_on_bright_accents():
+    assert ":root.dark{--panel-head-primary-fg:var(--bg);}" in CSS

--- a/tests/test_session_cli_scan_fast_path.py
+++ b/tests/test_session_cli_scan_fast_path.py
@@ -107,3 +107,20 @@ def test_messaging_session_metadata_load_preserves_cli_metadata_lookup(monkeypat
 
     assert looked_up == ["messaging_sidecar"]
     assert response["session"]["source_label"] == "Telegram"
+
+
+def test_messaging_session_metadata_matches_full_display_merge(monkeypatch):
+    import api.routes as routes
+    from api.models import Session
+    sidecar = [{"role": "user", "content": "hi", "timestamp": 1000}, {"role": "assistant", "content": "ok", "timestamp": 1001}]
+    cli = sidecar + [{"role": "assistant", "content": "ok", "timestamp": 1001.7}]
+    session = Session(session_id="telegram_resume", title="Telegram", messages=sidecar, session_source="messaging", raw_source="telegram")
+    monkeypatch.setattr(routes, "get_session", lambda sid, metadata_only=False: session)
+    monkeypatch.setattr(routes, "_clear_stale_stream_state", lambda _session: None)
+    monkeypatch.setattr(routes, "_lookup_cli_session_metadata", lambda sid: {"session_id": sid, "session_source": "messaging", "raw_source": "telegram"})
+    monkeypatch.setattr(routes, "get_cli_session_messages", lambda _sid: cli)
+    monkeypatch.setattr(routes, "redact_session_data", lambda payload: payload)
+    monkeypatch.setattr(routes, "j", lambda _handler, payload, status=200, extra_headers=None: payload)
+    full = routes.handle_get(object(), urlparse("/api/session?session_id=telegram_resume&messages=1&resolve_model=0"))["session"]
+    meta = routes.handle_get(object(), urlparse("/api/session?session_id=telegram_resume&messages=0&resolve_model=0"))["session"]
+    assert (meta["message_count"], meta["last_message_at"]) == (full["message_count"], full["last_message_at"])

--- a/tests/test_session_discoverability_audit.py
+++ b/tests/test_session_discoverability_audit.py
@@ -1,0 +1,213 @@
+import json
+import sqlite3
+from pathlib import Path
+
+from api.session_discoverability import audit_session_discoverability
+
+
+def _write_sidecar(session_dir: Path, sid: str, *, messages=1, **metadata):
+    payload = {
+        "session_id": sid,
+        "id": sid,
+        "title": metadata.pop("title", sid),
+        "messages": [{"role": "user", "content": f"message {i}"} for i in range(messages)],
+        **metadata,
+    }
+    path = session_dir / f"{sid}.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def _write_index(session_dir: Path, *entries):
+    (session_dir / "_index.json").write_text(json.dumps(list(entries)), encoding="utf-8")
+
+
+def _state_db(session_dir: Path, rows, message_counts=None):
+    db = session_dir / "state.db"
+    message_counts = message_counts or {}
+    with sqlite3.connect(db) as conn:
+        conn.execute(
+            """
+            create table sessions (
+                id text primary key,
+                source text,
+                title text,
+                parent_session_id text,
+                message_count integer
+            )
+            """
+        )
+        conn.execute("create table messages (session_id text, role text, content text)")
+        for row in rows:
+            conn.execute(
+                "insert into sessions (id, source, title, parent_session_id, message_count) values (?, ?, ?, ?, ?)",
+                (
+                    row["id"],
+                    row.get("source"),
+                    row.get("title"),
+                    row.get("parent_session_id"),
+                    row.get("message_count", message_counts.get(row["id"], 0)),
+                ),
+            )
+            for i in range(message_counts.get(row["id"], 0)):
+                conn.execute(
+                    "insert into messages (session_id, role, content) values (?, 'user', ?)",
+                    (row["id"], f"message {i}"),
+                )
+    return db
+
+
+def test_audit_reports_messageful_sidecar_missing_from_api_visible_sessions(tmp_path):
+    sid = "20260526_234828_b8393a"
+    _write_sidecar(tmp_path, sid, messages=12, source_tag="webui", session_source="webui")
+    _write_index(tmp_path, {"session_id": sid, "message_count": 12, "source_tag": "webui"})
+    db = _state_db(tmp_path, [{"id": sid, "source": "webui", "message_count": 12}], {sid: 12})
+
+    report = audit_session_discoverability(tmp_path, state_db_path=db, api_sessions=[])
+
+    assert report["status"] == "warn"
+    item = report["items"][0]
+    assert item["kind"] == "api_missing_messageful"
+    assert item["category"] == "warning"
+    assert item["session_id"] == sid
+    assert item["message_count"] == 12
+    assert item["present_in"] == {"sidecar": True, "index": True, "state_db": True, "api": False}
+
+
+def test_audit_reports_stale_cli_flag_on_webui_session(tmp_path):
+    sid = "webui-marked-cli"
+    _write_sidecar(tmp_path, sid, messages=3, source_tag="webui", session_source="webui", is_cli_session=True)
+    _write_index(tmp_path, {"session_id": sid, "message_count": 3, "source_tag": "webui", "is_cli_session": True})
+    db = _state_db(tmp_path, [{"id": sid, "source": "webui", "message_count": 3}], {sid: 3})
+
+    report = audit_session_discoverability(
+        tmp_path,
+        state_db_path=db,
+        api_sessions=[{"session_id": sid, "title": "WebUI Project Work", "message_count": 3, "source_tag": "webui", "session_source": "webui", "is_cli_session": True}],
+    )
+
+    kinds = {item["kind"] for item in report["items"]}
+    assert "persisted_source_flag_stale" in kinds
+    assert "source_misclassified" not in kinds
+    item = next(item for item in report["items"] if item["kind"] == "persisted_source_flag_stale")
+    assert item["session_id"] == sid
+    assert item["state_source"] == "webui"
+    assert item["api_is_cli_session"] is True
+    assert item["api_computed_is_cli_session"] is False
+    assert item["index_is_cli_session"] is True
+    assert item["sidecar_is_cli_session"] is True
+
+
+def test_audit_classifies_state_db_only_messageful_rows_as_missing_sidecar(tmp_path):
+    sid = "state-only-session"
+    db = _state_db(tmp_path, [{"id": sid, "source": "webui", "message_count": 5}], {sid: 5})
+
+    report = audit_session_discoverability(tmp_path, state_db_path=db, api_sessions=[])
+
+    assert report["items"][0]["kind"] == "state_db_messageful_missing_sidecar"
+    assert report["items"][0]["recommendation"] == "materialize_sidecar_or_archive_state_row"
+    assert report["items"][0]["present_in"] == {"sidecar": False, "index": False, "state_db": True, "api": False}
+
+
+def test_audit_treats_hidden_snapshot_as_represented_when_visible_lineage_tip_exists(tmp_path):
+    root = "root-session"
+    child = "child-session"
+    _write_sidecar(
+        tmp_path,
+        root,
+        messages=8,
+        source_tag="webui",
+        session_source="webui",
+        pre_compression_snapshot=True,
+    )
+    _write_sidecar(
+        tmp_path,
+        child,
+        messages=2,
+        source_tag="webui",
+        session_source="webui",
+        parent_session_id=root,
+    )
+    _write_index(tmp_path, {"session_id": root, "message_count": 8}, {"session_id": child, "message_count": 2})
+    db = _state_db(
+        tmp_path,
+        [
+            {"id": root, "source": "webui", "message_count": 8},
+            {"id": child, "source": "webui", "parent_session_id": root, "message_count": 2},
+        ],
+        {root: 8, child: 2},
+    )
+
+    report = audit_session_discoverability(
+        tmp_path,
+        state_db_path=db,
+        api_sessions=[{"session_id": child, "message_count": 2, "parent_session_id": root}],
+    )
+
+    assert report["status"] == "ok"
+    assert report["items"] == []
+
+
+def test_audit_treats_siblings_as_represented_when_visible_tip_points_at_lineage_root(tmp_path):
+    root = "root-session"
+    hidden_sibling = "hidden-sibling"
+    visible_tip = "visible-tip"
+    _write_sidecar(
+        tmp_path,
+        root,
+        messages=8,
+        source_tag="webui",
+        session_source="webui",
+        pre_compression_snapshot=True,
+    )
+    _write_sidecar(
+        tmp_path,
+        hidden_sibling,
+        messages=5,
+        source_tag="webui",
+        session_source="webui",
+        parent_session_id=root,
+    )
+    _write_index(
+        tmp_path,
+        {"session_id": root, "message_count": 8, "pre_compression_snapshot": True},
+        {"session_id": hidden_sibling, "message_count": 5, "parent_session_id": root},
+    )
+    db = _state_db(
+        tmp_path,
+        [
+            {"id": root, "source": "webui", "message_count": 8},
+            {"id": hidden_sibling, "source": "webui", "parent_session_id": root, "message_count": 5},
+            {"id": visible_tip, "source": "webui", "parent_session_id": root, "message_count": 9},
+        ],
+        {root: 8, hidden_sibling: 5, visible_tip: 9},
+    )
+
+    report = audit_session_discoverability(
+        tmp_path,
+        state_db_path=db,
+        api_sessions=[{"session_id": visible_tip, "message_count": 9, "_lineage_root_id": root}],
+    )
+
+    assert report["status"] == "ok"
+    assert report["items"] == []
+
+
+def test_audit_reports_lineage_without_visible_representative(tmp_path):
+    root = "root-session"
+    _write_sidecar(
+        tmp_path,
+        root,
+        messages=8,
+        source_tag="webui",
+        session_source="webui",
+        pre_compression_snapshot=True,
+    )
+    _write_index(tmp_path, {"session_id": root, "message_count": 8})
+    db = _state_db(tmp_path, [{"id": root, "source": "webui", "message_count": 8}], {root: 8})
+
+    report = audit_session_discoverability(tmp_path, state_db_path=db, api_sessions=[])
+
+    assert report["status"] == "warn"
+    assert [item["kind"] for item in report["items"]] == ["lineage_missing_visible_representative"]
+    assert report["items"][0]["session_id"] == root

--- a/tests/test_session_discoverability_invariants.py
+++ b/tests/test_session_discoverability_invariants.py
@@ -1,0 +1,62 @@
+"""Regression coverage for session sidebar discoverability invariants."""
+
+
+def test_messageful_hidden_snapshot_is_preserved_when_no_visible_representative():
+    from api.models import _preserve_messageful_sidebar_discoverability
+
+    hidden_snapshot = {
+        "session_id": "root_snapshot",
+        "title": "Long conversation snapshot",
+        "message_count": 42,
+        "pre_compression_snapshot": True,
+    }
+
+    result = _preserve_messageful_sidebar_discoverability(
+        candidates=[hidden_snapshot],
+        visible=[],
+    )
+
+    assert [row["session_id"] for row in result] == ["root_snapshot"]
+    assert result[0]["discoverability_warning"] == "rescued_messageful_hidden_session"
+
+
+def test_messageful_hidden_snapshot_stays_hidden_when_continuation_is_visible():
+    from api.models import _preserve_messageful_sidebar_discoverability
+
+    hidden_snapshot = {
+        "session_id": "root_snapshot",
+        "title": "Archived snapshot",
+        "message_count": 42,
+        "pre_compression_snapshot": True,
+    }
+    visible_tip = {
+        "session_id": "tip_session",
+        "parent_session_id": "root_snapshot",
+        "title": "Visible continuation",
+        "message_count": 50,
+    }
+
+    result = _preserve_messageful_sidebar_discoverability(
+        candidates=[hidden_snapshot, visible_tip],
+        visible=[visible_tip],
+    )
+
+    assert [row["session_id"] for row in result] == ["tip_session"]
+
+
+def test_intentional_background_sessions_are_not_rescued_into_sidebar():
+    from api.models import _preserve_messageful_sidebar_discoverability
+
+    cron_row = {
+        "session_id": "cron_digest_001",
+        "title": "Digest",
+        "source_tag": "cron",
+        "message_count": 12,
+    }
+
+    result = _preserve_messageful_sidebar_discoverability(
+        candidates=[cron_row],
+        visible=[],
+    )
+
+    assert result == []

--- a/tests/test_session_lineage_metadata_api.py
+++ b/tests/test_session_lineage_metadata_api.py
@@ -271,6 +271,41 @@ def test_cross_surface_child_session_metadata_marks_orphan_top_level_candidate(_
         conn.close()
 
 
+def test_state_db_webui_source_overrides_stale_cli_json_metadata(_isolate):
+    """State-db WebUI mirrors should clear stale CLI source fields in sidebar rows."""
+    conn = _ensure_state_db(_isolate)
+    t0 = time.time() - 100
+    try:
+        session = Session(
+            session_id="lineage_api_stale_cli_source",
+            title="WebUI Chatnachrichten verschwinden nach Neustart #9",
+            messages=[{"role": "user", "content": "hello"}, {"role": "assistant", "content": "hi"}],
+            updated_at=t0,
+            is_cli_session=True,
+            source_tag="cli",
+            raw_source="cli",
+            session_source="cli",
+            source_label="CLI",
+        )
+        session.save(touch_updated_at=False)
+        _insert_state_row(
+            conn,
+            "lineage_api_stale_cli_source",
+            source="webui",
+            started_at=t0,
+        )
+
+        row = {row["session_id"]: row for row in all_sessions()}["lineage_api_stale_cli_source"]
+
+        assert row["source_tag"] == "webui"
+        assert row["raw_source"] == "webui"
+        assert row["session_source"] == "webui"
+        assert row["source_label"] == "WebUI"
+        assert row["is_cli_session"] is False
+    finally:
+        conn.close()
+
+
 def test_generic_webui_title_gets_read_only_state_db_display_title(_isolate):
     """Sidebar rows can display the fresher state.db title without mutating JSON."""
     conn = _ensure_state_db(_isolate)


### PR DESCRIPTION
## stage-batch28 — v0.51.146 (Release DR)

6-PR low-risk safety + contrast batch.

### PRs

- **#3022** Dark-mode panel-head save button contrast (`--panel-head-primary-fg` token) — sunilkumarvalmiki (fork) — closes #2998
- **#3025** Cap custom `/v1/models` discovery probes at 5s — AJV20 — closes #3024
- **#3003** Messaging session metadata fast-path parity (Telegram-resumed refresh-loop fix) — george-andraws
- **#3027** WebUI mirrored sessions stay in WebUI sidebar tab — ai-ag2026
- **#3028** Messageful sidebar discoverability invariant (rescued_messageful_hidden_session) — ai-ag2026
- **#3029** New read-only `api.session_discoverability` audit module — ai-ag2026

### Pre-merge gate

- Targeted-test sweep on merged stage branch: **58/58 passed**
- Full sequential suite (`pytest -p no:xdist`): **6630 passed, 0 failures**, 12 skipped, 1 xfailed, 2 xpassed
- Opus advisor (claude-opus-4-7): **SHIP-AS-BATCH**, no cross-PR semantic conflict, no brick-class risk, CHANGELOG clean
- Each PR had CI green across 3.11/3.12/3.13 on its branch
- nesquena-hermes parallel-reviewer-agent verdicts on file for #3022/#3025/#3003/#3027 (#3028/#3029 cleared via Opus deep review here)

### Files touched

- `static/style.css` (#3022) — CSS-only
- `api/config.py` (#3025) — single constant + one urllib timeout swap
- `api/routes.py` (#3003, #3027) — 1-line metadata-merge swap + sidebar metadata classification
- `api/agent_sessions.py` (#3027) — `is_cli_session_row()` derive
- `api/models.py` (#3027, #3028) — sidebar projection rescue + WebUI source preservation
- `api/session_discoverability.py` (#3029) — NEW read-only module, not wired into any route
- 7 new/updated test files
- `CHANGELOG.md` — release entry under v0.51.146 / Release DR

### Follow-up (non-blocking)

Opus flagged that #3027's `_enrich_sidebar_lineage_metadata` does an unconditional sidebar source-flag overwrite when state.db.source == 'webui'. A future batch could add a unit test asserting that a state.db row with `source='webui'` does NOT clobber a JSON sidecar with `session_source='messaging'`. Today the test `test_state_db_webui_source_overrides_stale_cli_json_metadata` only covers the CLI→WebUI direction. Not a ship-blocker.
