### PR TITLE
stage-batch31: v0.51.149 / Release DU — hyphenated session ids + prefill role consistency

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -123,7 +123,7 @@ Environment variables controlling behavior:
     HERMES_WEBUI_PASSWORD          Optional: enable password auth (off by default)
     HERMES_WEBUI_SKIP_ONBOARDING   Optional: bypass the first-run onboarding wizard
     HERMES_PREFILL_MESSAGES_FILE   Optional JSON message list for browser-turn prefill context
-    HERMES_WEBUI_PREFILL_MESSAGES_SCRIPT Optional command that prints JSON messages or text prefill context
+    HERMES_WEBUI_PREFILL_MESSAGES_SCRIPT Optional command that prints JSON messages or plain-text user prefill context
     HERMES_WEBUI_PREFILL_MESSAGES_SCRIPT_TIMEOUT Optional script timeout in seconds (default 5, max 30)
     HERMES_HOME                    Base directory for Hermes state (~/.hermes by default)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 
 ## [Unreleased]
 
+## [v0.51.149] — 2026-05-28 — Release DU (stage-batch31 — hyphenated session ids + prefill role consistency)
+
+### Fixed
+
+- Session IDs containing hyphens (e.g. API-issued `api-*` and gateway-issued `reachy-voice-*`) are now accepted by every filesystem-touching session validator: `Session.load`, `Session.load_metadata_only`, `_repair_stale_pending`, `/api/session/delete`, and `/api/session/worktree/remove`. Previously the load path accepted hyphens but the delete and worktree-remove routes rejected them with HTTP 400, producing a confusing "visible in sidebar but undeletable" UX. Refactors the duplicated character-class check into a shared `api.models.is_safe_session_id` helper with regression coverage at every call site. (#3023, #3024)
+- Plain-text `webui_prefill_messages_script` output is now wrapped as a `user` prefill message instead of a `system` message, so dynamic recall context from notes/Obsidian/Joplin scripts becomes ordinary turn context rather than an extra system instruction. The JSON message-list escape hatch is unchanged: scripts that emit explicit `[{"role": "system", "content": "..."}]` still produce a system message. Avoids provider-specific multi-system-message footguns (Anthropic concatenation, OpenAI Responses-API divergence). (#3009)
+
 ## [v0.51.148] — 2026-05-28 — Release DT (stage-batch30 — single-PR Insights skill-usage reader)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Plain-text `webui_prefill_messages_script` output is now wrapped as a `user` prefill message instead of an extra `system` message, keeping dynamic recall context provider-safe while preserving explicit JSON message roles.
+
 ## [v0.51.145] — 2026-05-26 — Release DQ (stage-batch27 — sidebar running-state preservation)
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -154,10 +154,11 @@ HERMES_WEBUI_PREFILL_MESSAGES_SCRIPT_TIMEOUT=5 \
 ```
 
 The script may print either an OpenAI-style JSON message list, a JSON object with
-a `messages` list, or plain text; plain text is wrapped as one `system` prefill
-message. Script output is capped at 256 KiB before parsing. The browser only
-receives a compact status event (`source`, `label`, message count, and redacted
-errors), never the prefill message bodies.
+a `messages` list, or plain text; plain text is wrapped as one `user` prefill
+message so dynamic recall text becomes ordinary context instead of an extra
+system instruction. Script output is capped at 256 KiB before parsing. The
+browser only receives a compact status event (`source`, `label`, message count,
+and redacted errors), never the prefill message bodies.
 
 The bootstrap will:
 

--- a/api/models.py
+++ b/api/models.py
@@ -690,8 +690,10 @@ class Session:
 
     @classmethod
     def load(cls, sid):
-        # Validate session ID format to prevent path traversal
-        if not sid or not all(c in '0123456789abcdefghijklmnopqrstuvwxyz_' for c in sid):
+        # Validate session ID format to prevent path traversal.  API/gateway
+        # session ids may contain hyphens (for example ``api-*`` and
+        # ``reachy-voice-*``); allow those but still reject dots/slashes.
+        if not sid or not all(c in '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_-' for c in sid):
             return None
         p = SESSION_DIR / f'{sid}.json'
         if not p.exists():
@@ -718,7 +720,9 @@ class Session:
         top-level "messages" field and synthesize a small metadata-only object.
         Falls back to load() for legacy or unexpected file layouts.
         """
-        if not sid or not all(c in '0123456789abcdefghijklmnopqrstuvwxyz_' for c in sid):
+        # Same path-safety contract as load(): hyphens are valid session ids,
+        # path separators and traversal dots are not.
+        if not sid or not all(c in '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_-' for c in sid):
             return None
         p = SESSION_DIR / f'{sid}.json'
         if not p.exists():

--- a/api/models.py
+++ b/api/models.py
@@ -54,6 +54,29 @@ _INDEX_WRITE_LOCK = threading.RLock()
 _SESSION_INDEX_REBUILD_LOCK = threading.Lock()
 _SESSION_INDEX_REBUILD_THREAD = None
 
+# Path-safety contract for session IDs.  Accept alphanumerics, underscore, and
+# hyphen so API/gateway-issued ids (``api-*``, ``reachy-voice-*``) round-trip
+# through filesystem load/save/delete/worktree paths without traversal risk.
+# Dots and slashes are rejected so the id can never name a parent directory
+# or hide an unexpected extension.
+_SAFE_SID_CHARS = frozenset(
+    '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_-'
+)
+
+
+def is_safe_session_id(sid) -> bool:
+    """Return True iff ``sid`` is a non-empty path-safe session id.
+
+    Centralizes the validation previously duplicated across
+    ``Session.load``, ``Session.load_metadata_only``,
+    ``_repair_stale_pending``, ``/api/session/worktree/remove``, and
+    ``/api/session/delete`` so every call site agrees on what characters
+    are allowed.  See #3023.
+    """
+    if not sid or not isinstance(sid, str):
+        return False
+    return all(c in _SAFE_SID_CHARS for c in sid)
+
 
 def _cleanup_stale_tmp_files() -> None:
     """Best-effort removal of stale ``*.tmp.*`` files from SESSION_DIR.
@@ -693,7 +716,7 @@ class Session:
         # Validate session ID format to prevent path traversal.  API/gateway
         # session ids may contain hyphens (for example ``api-*`` and
         # ``reachy-voice-*``); allow those but still reject dots/slashes.
-        if not sid or not all(c in '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_-' for c in sid):
+        if not is_safe_session_id(sid):
             return None
         p = SESSION_DIR / f'{sid}.json'
         if not p.exists():
@@ -722,7 +745,7 @@ class Session:
         """
         # Same path-safety contract as load(): hyphens are valid session ids,
         # path separators and traversal dots are not.
-        if not sid or not all(c in '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_-' for c in sid):
+        if not is_safe_session_id(sid):
             return None
         p = SESSION_DIR / f'{sid}.json'
         if not p.exists():
@@ -1871,7 +1894,7 @@ def _repair_stale_pending(session) -> bool:
         _age = float('inf')
 
     sid = session.session_id
-    if not sid or not all(c in '0123456789abcdefghijklmnopqrstuvwxyz_' for c in sid):
+    if not is_safe_session_id(sid):
         return False
 
     try:

--- a/api/routes.py
+++ b/api/routes.py
@@ -2554,6 +2554,7 @@ from api.models import (
     prune_session_from_index,
     ensure_cron_project,
     is_cron_session,
+    is_safe_session_id,
 )
 from api.workspace import (
     load_workspaces,
@@ -5500,7 +5501,7 @@ def handle_post(handler, parsed) -> bool:
         if not sid or not isinstance(sid, str) or not sid.strip():
             return bad(handler, "session_id must be a non-empty string", status=400)
         sid = sid.strip()
-        if not all(c in '0123456789abcdefghijklmnopqrstuvwxyz_' for c in sid):
+        if not is_safe_session_id(sid):
             return bad(handler, "Invalid session_id", 400)
         try:
             s = get_session(sid, metadata_only=True)
@@ -5522,7 +5523,7 @@ def handle_post(handler, parsed) -> bool:
         sid = body.get("session_id", "")
         if not sid:
             return bad(handler, "session_id is required")
-        if not all(c in '0123456789abcdefghijklmnopqrstuvwxyz_' for c in sid):
+        if not is_safe_session_id(sid):
             return bad(handler, "Invalid session_id", 400)
         cli_meta_for_delete = _lookup_cli_session_metadata(sid)
         if cli_meta_for_delete.get("read_only"):

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -340,7 +340,7 @@ def _messages_from_prefill_script_output(text: str) -> list[dict]:
     messages = _valid_prefill_messages(payload)
     if messages:
         return messages
-    return [{"role": "system", "content": stripped}]
+    return [{"role": "user", "content": stripped}]
 
 
 def _load_prefill_messages_script(config_data: dict) -> dict:

--- a/tests/test_issue3023_safe_session_id_validators.py
+++ b/tests/test_issue3023_safe_session_id_validators.py
@@ -1,0 +1,91 @@
+"""Regression coverage for #3023: hyphenated session ids must be safe at every
+filesystem-touching call site, not just Session.load() / load_metadata_only().
+
+Before this fix, ``api-*`` and ``reachy-voice-*`` sessions could be loaded
+into the sidebar but rejected with HTTP 400 by ``/api/session/delete`` and
+``/api/session/worktree/remove``, producing a confusing "visible but
+undeletable" UX.  The fix factored validation into ``is_safe_session_id``
+and applied it consistently across the five known call sites.
+"""
+
+from api.models import is_safe_session_id
+
+
+def test_is_safe_session_id_accepts_hyphenated_gateway_ids():
+    assert is_safe_session_id("api-182894de593468b6") is True
+    assert is_safe_session_id("reachy-voice-20260513-1131-d5542adf") is True
+
+
+def test_is_safe_session_id_accepts_classic_lowercase_ids():
+    assert is_safe_session_id("sess_a") is True
+    assert is_safe_session_id("20260528_010551_b8e14a") is True
+
+
+def test_is_safe_session_id_accepts_uppercase_and_mixed_case():
+    # Some API/gateway producers emit mixed case; the helper allows it.
+    # Filesystem case-folding on macOS/Windows is the caller's contract.
+    assert is_safe_session_id("API-CAFEBABE") is True
+    assert is_safe_session_id("Foo") is True
+
+
+def test_is_safe_session_id_rejects_path_traversal():
+    assert is_safe_session_id("bad/../id") is False
+    assert is_safe_session_id("../etc/passwd") is False
+    assert is_safe_session_id("a/b") is False
+
+
+def test_is_safe_session_id_rejects_dots_and_extensions():
+    assert is_safe_session_id("bad.id") is False
+    assert is_safe_session_id("session.json") is False
+
+
+def test_is_safe_session_id_rejects_empty_and_non_string():
+    assert is_safe_session_id("") is False
+    assert is_safe_session_id(None) is False
+    assert is_safe_session_id(123) is False
+    assert is_safe_session_id([]) is False
+
+
+def test_is_safe_session_id_rejects_whitespace_and_control_chars():
+    assert is_safe_session_id("api 1234") is False
+    assert is_safe_session_id("api\n1234") is False
+    assert is_safe_session_id("api\t1234") is False
+
+
+def test_session_delete_validator_accepts_hyphenated_ids():
+    """``/api/session/delete`` validator path must accept hyphens (#3023)."""
+    import inspect
+    import api.routes as routes
+    src = inspect.getsource(routes.handle_post if hasattr(routes, "handle_post") else routes)
+    # Should call the shared helper, not the old magic-string check
+    assert "is_safe_session_id" in src
+    assert "'0123456789abcdefghijklmnopqrstuvwxyz_'" not in src
+
+
+def test_session_worktree_remove_validator_accepts_hyphenated_ids():
+    """``/api/session/worktree/remove`` validator path must accept hyphens (#3023)."""
+    routes_src = open("api/routes.py", encoding="utf-8").read()
+    # The worktree-remove block must use the shared helper
+    block_start = routes_src.find('/api/session/worktree/remove')
+    block_end = routes_src.find('/api/session/delete', block_start)
+    assert block_start != -1 and block_end != -1
+    block = routes_src[block_start:block_end]
+    assert "is_safe_session_id" in block
+    assert "'0123456789abcdefghijklmnopqrstuvwxyz_'" not in block
+
+
+def test_repair_stale_pending_validator_accepts_hyphenated_ids():
+    """``_repair_stale_pending`` in models.py must accept hyphens (#3023)."""
+    models_src = open("api/models.py", encoding="utf-8").read()
+    assert "is_safe_session_id" in models_src
+    # No magic-string validator should survive anywhere in models.py
+    assert "'0123456789abcdefghijklmnopqrstuvwxyz_'" not in models_src
+
+
+def test_no_lowercase_only_magic_string_remains_in_session_validators():
+    """Repo-wide guarantee: no validator falls back to the old lowercase-only set."""
+    for path in ("api/models.py", "api/routes.py"):
+        src = open(path, encoding="utf-8").read()
+        # The old narrow class is gone everywhere; only the helper's frozenset remains.
+        narrow = "'0123456789abcdefghijklmnopqrstuvwxyz_'"
+        assert narrow not in src, f"{path} still uses the narrow lowercase-only validator"

--- a/tests/test_session_index.py
+++ b/tests/test_session_index.py
@@ -83,6 +83,28 @@ def test_compact_exposes_last_message_at_from_message_timestamp():
     assert compact["last_message_at"] == 200.0
 
 
+def test_session_load_allows_hyphenated_safe_ids_but_rejects_traversal():
+    sid = "api-182894de593468b6"
+    s = _make_session(sid, "API session", updated_at=100)
+    s.path.write_text(json.dumps(s.__dict__, ensure_ascii=False, indent=2), encoding="utf-8")
+
+    assert Session.load(sid) is not None
+    assert Session.load_metadata_only(sid) is not None
+    assert Session.load("bad/../id") is None
+    assert Session.load_metadata_only("bad.id") is None
+
+
+def test_full_index_rebuild_includes_hyphenated_sessions():
+    sid = "reachy-voice-20260513-1131-d5542adf"
+    s = _make_session(sid, "Reachy voice", updated_at=100)
+    s.path.write_text(json.dumps(s.__dict__, ensure_ascii=False, indent=2), encoding="utf-8")
+
+    _write_session_index(updates=None)
+
+    ids = [entry["session_id"] for entry in _read_index(models.SESSION_INDEX_FILE)]
+    assert sid in ids
+
+
 def test_prune_session_from_index_removes_requested_row_only():
     index_file = models.SESSION_INDEX_FILE
     s_a = _make_session("sess_a", "A", updated_at=100)

--- a/tests/test_webui_prefill_context.py
+++ b/tests/test_webui_prefill_context.py
@@ -70,7 +70,7 @@ def test_webui_prefill_script_loads_json_messages(tmp_path):
     assert result["messages"] == [{"role": "system", "content": "Joplin has durable context; use notes/search tools for details."}]
 
 
-def test_webui_prefill_script_wraps_plain_text_for_any_notes_source(tmp_path):
+def test_webui_prefill_script_wraps_plain_text_as_user_context(tmp_path):
     from api.streaming import _load_webui_prefill_context
 
     script = tmp_path / "obsidian_recall.py"
@@ -80,7 +80,7 @@ def test_webui_prefill_script_wraps_plain_text_for_any_notes_source(tmp_path):
 
     assert result["status"] == "loaded"
     assert result["source"] == "script"
-    assert result["messages"] == [{"role": "system", "content": "Obsidian project note context"}]
+    assert result["messages"] == [{"role": "user", "content": "Obsidian project note context"}]
 
 
 def test_webui_prefill_script_errors_are_redacted(tmp_path):
@@ -111,7 +111,7 @@ def test_webui_prefill_script_takes_precedence_over_static_file(tmp_path):
     })
 
     assert result["source"] == "script"
-    assert result["messages"] == [{"role": "system", "content": "dynamic"}]
+    assert result["messages"] == [{"role": "user", "content": "dynamic"}]
 
 
 def test_webui_prefill_script_timeout_returns_redacted_error(tmp_path):


### PR DESCRIPTION
## stage-batch31 — v0.51.149 (Release DU)

Hyphenated session-id validators (widened from #3023) + plain-text prefill role consistency.

### PRs

- **#3023** Allow hyphenated session ids — ai-ag2026 (widened in-batch)
- **#3009** Wrap plain-text prefill script output as user context — AJV20

### #3023 widening

The submitted PR only updated `Session.load()` and `Session.load_metadata_only()`. The parallel reviewer agent flagged that three sibling validators (`_repair_stale_pending` in models.py, and the `/api/session/delete` + `/api/session/worktree/remove` route handlers in routes.py) still rejected hyphens with HTTP 400. Shipping as-is would have produced a confusing UX: `api-*` and `reachy-voice-*` sessions visible in the sidebar but undeletable.

Widened in-batch by factoring the duplicated character-class check into a shared `api.models.is_safe_session_id()` helper and applying it at all five call sites:

```
api/models.py:716    Session.load
api/models.py:746    Session.load_metadata_only
api/models.py:1894   _repair_stale_pending
api/routes.py:5504   /api/session/worktree/remove
api/routes.py:5526   /api/session/delete
```

Adds `tests/test_issue3023_safe_session_id_validators.py` with 11 tests covering the helper itself plus a repo-wide assertion that no narrow lowercase-only magic string survives anywhere in models.py or routes.py.

### #3009 prefill role flip

One-line change in `_messages_from_prefill_script_output()`: plain-text fallback now returns `[{"role": "user", "content": stripped}]` instead of `[{"role": "system", ...}]`. The JSON message-list path is unchanged so explicit `system` role assignments still work. README + ARCHITECTURE + CHANGELOG already document the semantic shift; the existing JSON test locks the escape hatch.

### Pre-merge gate

- Targeted-test sweep (44 tests): **44/44 passed**
- Full sequential pytest: **6651 passed, 0 failures**, 12 skipped (150s)
- `python3 -c "import api.models"` + `import api.routes`: OK
- Both upstream PRs had CI green on their branches
- nesquena-hermes parallel reviewer LGTM on both PRs (with the widening note that we just absorbed for #3023)

### Files

- `api/models.py`: new `is_safe_session_id()` helper + 3 call-site updates
- `api/routes.py`: import the helper + 2 call-site updates
- `api/streaming.py`: `system` → `user` literal swap (#3009)
- `tests/test_issue3023_safe_session_id_validators.py`: NEW, 11 tests
- `tests/test_session_index.py`: hyphenated-id positive tests (from #3023)
- `tests/test_webui_prefill_context.py`: updated assertions for #3009
- README.md, ARCHITECTURE.md, CHANGELOG.md: doc updates

### Migration note

Anyone who deliberately used a plain-text `webui_prefill_messages_script` to inject system-level instruction text will see a semantic shift to `user` context. The README explicitly documents the JSON escape hatch for power users who need exact role control.
