### PR TITLE
stage-batch32: v0.51.150 / Release DV — single-PR reasoning-effort agent metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## [Unreleased]
 
+## [v0.51.150] — 2026-05-28 — Release DV (stage-batch32 — single-PR reasoning-effort agent metadata)
+
+### Fixed
+
+- Reasoning-effort capability detection now consults Hermes Agent's `models.dev` metadata before falling back to WebUI-local provider/model prefix heuristics. xAI OAuth Grok models (e.g. `grok-4.3`) and other native/provider-specific catalogs that Hermes Agent already knows about now show the reasoning-effort chip without requiring a per-provider WebUI allowlist update. Existing exact-resolver paths (ACP unsupported, Copilot/GitHub effort subsets, OpenAI Codex, LM Studio live probing) keep their authoritative behavior — the new metadata lookup sits between those resolvers and the broad heuristic fallback. Metadata `supports_reasoning=False` is treated as authoritative so known non-reasoning variants stay hidden. Also: the no-query boot path of `/api/reasoning` now hydrates against the configured default model so the chip can populate before the front-end has session model context. (#3017)
+
 ## [v0.51.149] — 2026-05-28 — Release DU (stage-batch31 — hyphenated session ids + prefill role consistency)
 
 ### Fixed

--- a/api/config.py
+++ b/api/config.py
@@ -2128,6 +2128,38 @@ def _heuristic_reasoning_efforts(model_id: str, provider_id: str) -> list[str]:
     return []
 
 
+def _models_dev_reasoning_efforts(model_id: str, provider_id: str) -> list[str] | None:
+    """Return reasoning efforts from Hermes Agent model metadata when known.
+
+    ``None`` means the metadata source is unavailable or has no answer, so the
+    caller should continue to compatibility fallbacks. A concrete list (including
+    ``[]``) is authoritative.
+    """
+    model = _strip_provider_hint_for_reasoning(model_id)
+    provider = str(provider_id or "").strip().lower()
+    if not model or not provider:
+        return None
+
+    try:
+        from agent.models_dev import get_model_capabilities
+    except Exception:
+        return None
+
+    try:
+        capabilities = get_model_capabilities(provider=provider, model=model)
+    except Exception:
+        return None
+    if capabilities is None:
+        return None
+
+    supports_reasoning = getattr(capabilities, "supports_reasoning", None)
+    if supports_reasoning is True:
+        return list(VALID_REASONING_EFFORTS)
+    if supports_reasoning is False:
+        return []
+    return None
+
+
 def resolve_model_reasoning_efforts(
     model_id: str | None = None,
     provider_id: str | None = None,
@@ -2150,51 +2182,42 @@ def resolve_model_reasoning_efforts(
     if provider in {"cursor-acp", "copilot-acp"}:
         return []
 
+    hinted_model = _strip_provider_hint_for_reasoning(model)
+
     try:
         from hermes_cli.models import (
             github_model_reasoning_efforts,
             lmstudio_model_reasoning_options,
         )
     except Exception:
-        return _heuristic_reasoning_efforts(model, provider)
+        if provider in {"copilot", "github-copilot"}:
+            return _heuristic_reasoning_efforts(hinted_model, provider)
+    else:
+        if provider in {"copilot", "github-copilot"}:
+            return github_model_reasoning_efforts(hinted_model)
 
-    hinted_model = _strip_provider_hint_for_reasoning(model)
-    if provider in {"copilot", "github-copilot"}:
-        return github_model_reasoning_efforts(hinted_model)
+        if provider == "openai-codex":
+            bare = hinted_model.rsplit("/", 1)[-1]
+            return github_model_reasoning_efforts(bare)
 
-    if provider == "openai-codex":
-        bare = hinted_model.rsplit("/", 1)[-1]
-        return github_model_reasoning_efforts(bare)
-
-    if provider == "lmstudio":
-        probe_base = resolved_base_url or _get_provider_base_url(provider)
-        opts = lmstudio_model_reasoning_options(model, probe_base)
-        normalized = [str(opt).strip().lower() for opt in opts if str(opt).strip()]
-        if not normalized or set(normalized).issubset({"off"}):
+        if provider == "lmstudio":
+            probe_base = resolved_base_url or _get_provider_base_url(provider)
+            opts = lmstudio_model_reasoning_options(hinted_model, probe_base)
+            normalized = [str(opt).strip().lower() for opt in opts if str(opt).strip()]
+            if not normalized or set(normalized).issubset({"off"}):
+                return []
+            level_opts = [opt for opt in normalized if opt in VALID_REASONING_EFFORTS]
+            if level_opts:
+                return list(dict.fromkeys(level_opts))
+            if set(normalized).issubset({"off", "on"}):
+                return []
             return []
-        level_opts = [opt for opt in normalized if opt in VALID_REASONING_EFFORTS]
-        if level_opts:
-            return list(dict.fromkeys(level_opts))
-        if set(normalized).issubset({"off", "on"}):
-            return []
-        return []
 
-    model_lower = model.lower()
-    prefixes = (
-        "deepseek/",
-        "anthropic/",
-        "openai/",
-        "x-ai/",
-        "google/gemini-2",
-        "google/gemma-4",
-        "qwen/qwen3",
-        "tencent/hy3-preview",
-        "xiaomi/",
-    )
-    if any(model_lower.startswith(prefix) for prefix in prefixes):
-        return list(VALID_REASONING_EFFORTS)
+    metadata_efforts = _models_dev_reasoning_efforts(hinted_model, provider)
+    if metadata_efforts is not None:
+        return metadata_efforts
 
-    return []
+    return _heuristic_reasoning_efforts(hinted_model, provider)
 
 
 def get_reasoning_status(
@@ -2215,10 +2238,23 @@ def get_reasoning_status(
     agent_cfg = config_data.get("agent") or {}
     show_raw = display_cfg.get("show_reasoning") if isinstance(display_cfg, dict) else None
     effort_raw = agent_cfg.get("reasoning_effort") if isinstance(agent_cfg, dict) else None
+
+    resolve_model = model_id
+    resolve_provider = provider_id
+    resolve_base_url = base_url
+    if not resolve_model:
+        model_cfg = config_data.get("model") or {}
+        if isinstance(model_cfg, dict):
+            resolve_model = str(model_cfg.get("default") or "").strip() or None
+            if not resolve_provider and model_cfg.get("provider"):
+                resolve_provider = str(model_cfg["provider"]).strip()
+            if not resolve_base_url and model_cfg.get("base_url"):
+                resolve_base_url = str(model_cfg["base_url"]).strip()
+
     supported_efforts = resolve_model_reasoning_efforts(
-        model_id,
-        provider_id=provider_id,
-        base_url=base_url,
+        resolve_model,
+        provider_id=resolve_provider,
+        base_url=resolve_base_url,
     )
     return {
         # Match CLI default (True if unset in config.yaml)

--- a/tests/test_models_dev_reasoning.py
+++ b/tests/test_models_dev_reasoning.py
@@ -1,0 +1,110 @@
+"""Regression coverage for Agent model-metadata reasoning capability lookup."""
+
+import sys
+import types
+from types import SimpleNamespace
+
+
+def _install_fake_models_dev(monkeypatch, fake_fn):
+    fake_agent = types.ModuleType("agent")
+    fake_models_dev = types.ModuleType("agent.models_dev")
+    setattr(fake_models_dev, "get_model_capabilities", fake_fn)
+    setattr(fake_agent, "models_dev", fake_models_dev)
+    monkeypatch.setitem(sys.modules, "agent", fake_agent)
+    monkeypatch.setitem(sys.modules, "agent.models_dev", fake_models_dev)
+
+
+def test_models_dev_true_returns_full_efforts(monkeypatch):
+    _install_fake_models_dev(
+        monkeypatch,
+        lambda provider, model: SimpleNamespace(supports_reasoning=True),
+    )
+
+    import api.config as cfg
+
+    assert cfg._models_dev_reasoning_efforts("grok-4.3", "xai-oauth") == list(
+        cfg.VALID_REASONING_EFFORTS
+    )
+
+
+def test_models_dev_false_returns_authoritative_empty(monkeypatch):
+    _install_fake_models_dev(
+        monkeypatch,
+        lambda provider, model: SimpleNamespace(supports_reasoning=False),
+    )
+
+    import api.config as cfg
+
+    assert cfg._models_dev_reasoning_efforts("grok-4.20-non-reasoning", "xai-oauth") == []
+
+
+def test_models_dev_unknown_allows_compatibility_fallback(monkeypatch):
+    _install_fake_models_dev(monkeypatch, lambda provider, model: None)
+
+    import api.config as cfg
+
+    assert cfg.resolve_model_reasoning_efforts(
+        "x-ai/grok-4", provider_id="openrouter"
+    ) == list(cfg.VALID_REASONING_EFFORTS)
+
+
+def test_xai_oauth_grok_uses_agent_metadata(monkeypatch):
+    seen = []
+
+    def fake_capabilities(provider, model):
+        seen.append((provider, model))
+        return SimpleNamespace(supports_reasoning=True)
+
+    _install_fake_models_dev(monkeypatch, fake_capabilities)
+
+    import api.config as cfg
+
+    assert cfg.resolve_model_reasoning_efforts(
+        "@xai-oauth:grok-4.3", provider_id="xai-oauth"
+    ) == list(cfg.VALID_REASONING_EFFORTS)
+    assert seen == [("xai-oauth", "grok-4.3")]
+
+
+def test_models_dev_false_suppresses_prefix_heuristic(monkeypatch):
+    _install_fake_models_dev(
+        monkeypatch,
+        lambda provider, model: SimpleNamespace(supports_reasoning=False),
+    )
+
+    import api.config as cfg
+
+    assert cfg.resolve_model_reasoning_efforts(
+        "x-ai/grok-4-non-reasoning", provider_id="openrouter"
+    ) == []
+
+
+def test_get_reasoning_status_uses_config_default_model(monkeypatch, tmp_path):
+    _install_fake_models_dev(
+        monkeypatch,
+        lambda provider, model: SimpleNamespace(supports_reasoning=True)
+        if (provider, model) == ("xai-oauth", "grok-4.3")
+        else None,
+    )
+
+    import api.config as cfg
+
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        """
+model:
+  default: grok-4.3
+  provider: xai-oauth
+agent:
+  reasoning_effort: medium
+display:
+  show_reasoning: true
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(cfg, "_get_config_path", lambda: config_path)
+
+    status = cfg.get_reasoning_status()
+
+    assert status["reasoning_effort"] == "medium"
+    assert status["supported_efforts"] == list(cfg.VALID_REASONING_EFFORTS)
+    assert status["supports_reasoning_effort"] is True


### PR DESCRIPTION
## stage-batch32 — v0.51.150 (Release DV)

Single-PR reasoning-effort agent metadata integration.

### PR

- **#3017** Use agent metadata for reasoning-effort support — starship-s

Changes `resolve_model_reasoning_efforts()` in `api/config.py` to consult Hermes Agent's `models.dev` metadata (`agent.models_dev.get_model_capabilities()`) between the exact provider-specific resolvers and the broad heuristic fallback. Closes the gap where native/provider-specific catalogs (e.g. xAI OAuth `grok-4.3`) were reasoning-capable per agent metadata but reported no efforts by WebUI because no local prefix heuristic matched.

### Order of precedence (verified by Opus)

```
ACP / Copilot subset / OpenAI Codex / LM Studio probe  →  (authoritative)
NEW: models.dev metadata
  • supports_reasoning=True  → full effort list
  • supports_reasoning=False → [] (authoritative — known non-reasoning variants stay hidden)
  • Unknown / None          → fall through
Prefix-based heuristic fallback                        →  (unchanged)
```

The new metadata layer sits exactly where the old prefix heuristic was the only answer for non-special-cased providers. Existing exact resolvers return BEFORE the metadata lookup, so they cannot be overridden by stale agent metadata.

### Pre-merge gate

- Targeted-test sweep (41 reasoning-adjacent tests): **41/41 passed**
- Full sequential pytest: **6657 passed, 0 failures**, 12 skipped (156s)
- CI green on PR branch: test 3.11/3.12/3.13 SUCCESS
- Opus advisor deep review (claude-opus-4-7): **SHIP-IN-NEXT-LOW-RISK-BATCH**
  - Brick-class assessment: **~2/10 — additive + fallthrough-safe**
  - Import is bare-`except Exception`-guarded (older hermes-agent without models_dev module = identical behavior to current master)
  - `supports_reasoning=False` authoritative path is bounded: a single model becomes unaccessible-for-reasoning at worst, not a global brick
  - The `models.dev` call is wrapped in a second `try/except Exception`; no raise can escape

### Drive-by fix called out by Opus

The LMStudio branch now passes `hinted_model` (the provider-stripped value) to `lmstudio_model_reasoning_options()` instead of the raw `model` arg. Previously the unstripped `@xai-oauth:...` style hint was passed through to LMStudio's probe — that was a real bug that this PR incidentally fixes.

### Test coverage

`tests/test_models_dev_reasoning.py` (110 LOC, 6 tests) covers:
- `supports_reasoning=True` → full effort list
- `supports_reasoning=False` → authoritative empty
- Unknown / None → falls through to prefix heuristic
- `@xai-oauth:` hint stripping before lookup
- False overrides a prior known prefix heuristic
- `get_reasoning_status()` hydrates from config defaults

### Files

- `api/config.py`: +114/-39 (new `_models_dev_reasoning_efforts()` helper, resolver call-chain update, no-query path hydration)
- `tests/test_models_dev_reasoning.py`: NEW, 6 tests
- `CHANGELOG.md`: v0.51.150 / Release DV entry

### Non-blocking follow-ups (Opus suggestions)

1. Add a `model.reasoning_efforts_force_supported: true` config knob so a user can override an authoritative-False signal when models.dev cache is stale. File as sprint-candidate.
2. Add a direct test for the `ImportError` branch (mock `sys.modules["agent.models_dev"] = None`) — the existing "metadata returns None" tests cover the same downstream behavior via a different upstream path.

Both can land in a subsequent PR.
