### PR TITLE
fix: align AI-recent notes with WebUI prefill hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- The third-party notes drawer's “Recently used by AI” Joplin list now follows the WebUI-specific `webui_prefill_messages_script` hook when configured, including argv-style hooks such as `[python3, /path/to/recall.py]`, before falling back to the legacy generic `prefill_messages_script`.
+
 ## [v0.51.150] — 2026-05-28 — Release DV (stage-batch32 — single-PR reasoning-effort agent metadata)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Fixed
 
-- The third-party notes drawer's “Recently used by AI” Joplin list now follows the WebUI-specific `HERMES_WEBUI_PREFILL_MESSAGES_SCRIPT` / `webui_prefill_messages_script` hook when configured, including argv-style hooks such as `[python3, /path/to/recall.py]` and command strings such as `python3 /path/to/recall.py`, before falling back to the legacy generic `prefill_messages_script`.
+- The third-party notes drawer’s “Recently used by AI” list now follows the provider-neutral WebUI-specific `HERMES_WEBUI_PREFILL_MESSAGES_SCRIPT` / `webui_prefill_messages_script` hook when configured, including argv-style hooks such as `[python3, /path/to/recall.py]` and command strings such as `python3 /path/to/recall.py`, before falling back to the legacy generic `prefill_messages_script`. Configured third-party notes sources such as Joplin, Obsidian, Notion, and llm-wiki remain visible even before runtime tool inventory hydrates.
 
 ## [v0.51.152] — 2026-05-28 — Release DX (stage-batch34 — single-PR optional gateway-backed browser chat)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Fixed
 
-- The third-party notes drawer's “Recently used by AI” Joplin list now follows the WebUI-specific `webui_prefill_messages_script` hook when configured, including argv-style hooks such as `[python3, /path/to/recall.py]`, before falling back to the legacy generic `prefill_messages_script`.
+- The third-party notes drawer's “Recently used by AI” Joplin list now follows the WebUI-specific `HERMES_WEBUI_PREFILL_MESSAGES_SCRIPT` / `webui_prefill_messages_script` hook when configured, including argv-style hooks such as `[python3, /path/to/recall.py]` and command strings such as `python3 /path/to/recall.py`, before falling back to the legacy generic `prefill_messages_script`.
 
 ## [v0.51.152] — 2026-05-28 — Release DX (stage-batch34 — single-PR optional gateway-backed browser chat)
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -12894,7 +12894,11 @@ def _script_path_from_config_value(path_value) -> Path | None:
         if isinstance(path_value, (list, tuple)):
             candidates = [str(part).strip() for part in path_value if str(part).strip()]
         else:
-            candidates = shlex.split(str(path_value))
+            raw = str(path_value).strip()
+            raw_path = Path(raw).expanduser()
+            if raw and raw_path.exists():
+                return raw_path
+            candidates = shlex.split(raw)
         # Hooks commonly use either [python, /path/to/script.py] or the string
         # form "python /path/to/script.py". Prefer the first script-like argument
         # over the interpreter so AI-recent notes reflect the configured recall

--- a/api/routes.py
+++ b/api/routes.py
@@ -12879,15 +12879,37 @@ _JOPLIN_AI_RECALL_NOTE_PRIORITY = [
 ]
 
 
-def _joplin_prefill_script_path() -> Path | None:
-    cfg = get_config()
-    path_value = cfg.get("prefill_messages_script") if isinstance(cfg, dict) else None
+def _script_path_from_config_value(path_value) -> Path | None:
+    """Return the likely recall script path from a string or argv-style hook."""
     if not path_value:
         return None
     try:
+        if isinstance(path_value, (list, tuple)):
+            candidates = [str(part).strip() for part in path_value if str(part).strip()]
+            # Hooks commonly use [python, /path/to/script.py]. Prefer the first
+            # Python-ish script argument over the interpreter so AI-recent notes
+            # reflect the configured recall source rather than "python3".
+            for candidate in candidates:
+                if candidate.endswith((".py", ".sh", ".bash")):
+                    return Path(candidate).expanduser()
+            if candidates:
+                return Path(candidates[-1]).expanduser()
+            return None
         return Path(str(path_value)).expanduser()
     except Exception:
         return None
+
+
+def _joplin_prefill_script_path() -> Path | None:
+    cfg = get_config()
+    if not isinstance(cfg, dict):
+        return None
+    # The browser notes drawer should mirror the WebUI-specific recall hook when
+    # configured. Fall back to the legacy generic session prefill script only for
+    # deployments that have not opted into WebUI dynamic recall.
+    return _script_path_from_config_value(
+        cfg.get("webui_prefill_messages_script") or cfg.get("prefill_messages_script")
+    )
 
 
 def _joplin_recall_note_refs(script_path: Path | None = None) -> list[dict]:

--- a/api/routes.py
+++ b/api/routes.py
@@ -13,6 +13,7 @@ import os
 import queue
 import re
 import platform
+import shlex
 import shutil
 import sqlite3
 import subprocess
@@ -12892,16 +12893,18 @@ def _script_path_from_config_value(path_value) -> Path | None:
     try:
         if isinstance(path_value, (list, tuple)):
             candidates = [str(part).strip() for part in path_value if str(part).strip()]
-            # Hooks commonly use [python, /path/to/script.py]. Prefer the first
-            # Python-ish script argument over the interpreter so AI-recent notes
-            # reflect the configured recall source rather than "python3".
-            for candidate in candidates:
-                if candidate.endswith((".py", ".sh", ".bash")):
-                    return Path(candidate).expanduser()
-            if candidates:
-                return Path(candidates[-1]).expanduser()
-            return None
-        return Path(str(path_value)).expanduser()
+        else:
+            candidates = shlex.split(str(path_value))
+        # Hooks commonly use either [python, /path/to/script.py] or the string
+        # form "python /path/to/script.py". Prefer the first script-like argument
+        # over the interpreter so AI-recent notes reflect the configured recall
+        # source rather than "python3".
+        for candidate in candidates:
+            if candidate.endswith((".py", ".sh", ".bash")):
+                return Path(candidate).expanduser()
+        if candidates:
+            return Path(candidates[-1]).expanduser()
+        return None
     except Exception:
         return None
 
@@ -12914,7 +12917,9 @@ def _joplin_prefill_script_path() -> Path | None:
     # configured. Fall back to the legacy generic session prefill script only for
     # deployments that have not opted into WebUI dynamic recall.
     return _script_path_from_config_value(
-        cfg.get("webui_prefill_messages_script") or cfg.get("prefill_messages_script")
+        os.getenv("HERMES_WEBUI_PREFILL_MESSAGES_SCRIPT", "")
+        or cfg.get("webui_prefill_messages_script")
+        or cfg.get("prefill_messages_script")
     )
 
 

--- a/tests/test_webui_notes_sources.py
+++ b/tests/test_webui_notes_sources.py
@@ -260,6 +260,16 @@ def test_joplin_recent_ai_notes_mirrors_webui_prefill_env_hook(monkeypatch, tmp_
     assert [note["title"] for note in notes] == ["Current Context"]
 
 
+def test_prefill_script_path_keeps_plain_existing_paths_with_spaces(tmp_path):
+    from api import routes
+
+    script = tmp_path / "context scripts" / "recall.py"
+    script.parent.mkdir()
+    script.write_text('CURRENT_CONTEXT_ID = "5ba9ab822c344115939205ca4e8eaec0"\n', encoding="utf-8")
+
+    assert routes._script_path_from_config_value(str(script)) == script
+
+
 
 def test_external_notes_ui_uses_minimal_lucide_icons_for_ai_recent_notes():
     from pathlib import Path

--- a/tests/test_webui_notes_sources.py
+++ b/tests/test_webui_notes_sources.py
@@ -200,6 +200,39 @@ def test_joplin_recent_ai_notes_uses_configured_prefill_script(monkeypatch, tmp_
     assert all(note["used_reason"] == "automatic_recall" for note in notes)
 
 
+def test_joplin_recent_ai_notes_prefers_webui_prefill_script_hook(monkeypatch, tmp_path):
+    from api import routes
+
+    legacy_script = tmp_path / "legacy_context.py"
+    legacy_script.write_text('CURRENT_CONTEXT_ID = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"\n', encoding="utf-8")
+    webui_script = tmp_path / "webui_context.py"
+    webui_script.write_text(
+        'CURRENT_CONTEXT_ID = "5ba9ab822c344115939205ca4e8eaec0"\n'
+        'OPEN_ISSUES_ID = "623aeb6e55cb4aa39a0541f2ac09aa36"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(routes, "get_config", lambda: {
+        "prefill_messages_script": str(legacy_script),
+        "webui_prefill_messages_script": ["python3", str(webui_script)],
+    })
+
+    def fake_get(path, params=None):
+        note_id = path.rsplit("/", 1)[-1]
+        assert note_id != "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        titles = {
+            "5ba9ab822c344115939205ca4e8eaec0": "Current Context",
+            "623aeb6e55cb4aa39a0541f2ac09aa36": "Open Issues",
+        }
+        return {"id": note_id, "title": titles[note_id], "updated_time": 123, "parent_id": "folder"}
+
+    monkeypatch.setattr(routes, "_joplin_api_get", fake_get)
+
+    notes = routes._joplin_recent_ai_notes(limit=2)
+
+    assert [note["title"] for note in notes] == ["Current Context", "Open Issues"]
+
+
+
 def test_external_notes_ui_uses_minimal_lucide_icons_for_ai_recent_notes():
     from pathlib import Path
 

--- a/tests/test_webui_notes_sources.py
+++ b/tests/test_webui_notes_sources.py
@@ -41,23 +41,29 @@ def test_notes_sources_redacts_tool_descriptions_and_omits_plain_file_tools():
     assert "[REDACTED]" in source["tools"][0]["description"]
 
 
-def test_notes_sources_shows_configured_note_servers_without_tool_inventory():
+def test_notes_sources_shows_configured_third_party_note_servers_without_tool_inventory():
     from api.routes import _notes_sources_from_mcp_inventory
 
     servers = {
         "joplin": {"name": "joplin", "enabled": True, "active": False, "status": "configured"},
+        "obsidian": {"name": "obsidian", "enabled": True, "active": False, "status": "configured"},
+        "notion": {"name": "notion", "enabled": True, "active": False, "status": "configured"},
+        "llm-wiki": {"name": "llm-wiki", "enabled": True, "active": False, "status": "configured"},
         "filesystem": {"name": "filesystem", "enabled": True, "active": True, "status": "healthy"},
     }
 
     sources = _notes_sources_from_mcp_inventory(servers, [])
 
-    assert [source["name"] for source in sources] == ["joplin"]
-    assert sources[0]["label"] == "Joplin"
-    assert sources[0]["tool_count"] == 3
-    assert [tool["name"] for tool in sources[0]["tools"]] == ["search_notes", "list_notes", "get_note"]
-    assert all(tool.get("inferred") is True for tool in sources[0]["tools"])
-    assert sources[0]["tool_source"] == "configured_hint"
-    assert sources[0]["status"] == "configured"
+    assert [source["name"] for source in sources] == ["joplin", "llm-wiki", "notion", "obsidian"]
+    by_name = {source["name"]: source for source in sources}
+    assert by_name["joplin"]["label"] == "Joplin"
+    assert [tool["name"] for tool in by_name["joplin"]["tools"]] == ["search_notes", "list_notes", "get_note"]
+    assert [tool["name"] for tool in by_name["obsidian"]["tools"]] == ["search_notes", "read_note"]
+    assert [tool["name"] for tool in by_name["notion"]["tools"]] == ["search_pages", "get_page"]
+    assert [tool["name"] for tool in by_name["llm-wiki"]["tools"]] == ["query_knowledge_base", "read_page"]
+    assert all(source["tool_source"] == "configured_hint" for source in sources)
+    assert all(tool.get("inferred") is True for source in sources for tool in source["tools"])
+    assert all(source["status"] == "configured" for source in sources)
 
 
 def test_external_notes_sources_drawer_is_default_off(monkeypatch):

--- a/tests/test_webui_notes_sources.py
+++ b/tests/test_webui_notes_sources.py
@@ -232,6 +232,28 @@ def test_joplin_recent_ai_notes_prefers_webui_prefill_script_hook(monkeypatch, t
     assert [note["title"] for note in notes] == ["Current Context", "Open Issues"]
 
 
+def test_joplin_recent_ai_notes_mirrors_webui_prefill_env_hook(monkeypatch, tmp_path):
+    from api import routes
+
+    legacy_script = tmp_path / "legacy_context.py"
+    legacy_script.write_text('CURRENT_CONTEXT_ID = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"\n', encoding="utf-8")
+    env_script = tmp_path / "env context.py"
+    env_script.write_text('CURRENT_CONTEXT_ID = "5ba9ab822c344115939205ca4e8eaec0"\n', encoding="utf-8")
+    monkeypatch.setattr(routes, "get_config", lambda: {"prefill_messages_script": str(legacy_script)})
+    monkeypatch.setenv("HERMES_WEBUI_PREFILL_MESSAGES_SCRIPT", f'python3 "{env_script}"')
+
+    def fake_get(path, params=None):
+        note_id = path.rsplit("/", 1)[-1]
+        assert note_id != "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        return {"id": note_id, "title": "Current Context", "updated_time": 123, "parent_id": "folder"}
+
+    monkeypatch.setattr(routes, "_joplin_api_get", fake_get)
+
+    notes = routes._joplin_recent_ai_notes(limit=1)
+
+    assert [note["title"] for note in notes] == ["Current Context"]
+
+
 
 def test_external_notes_ui_uses_minimal_lucide_icons_for_ai_recent_notes():
     from pathlib import Path

--- a/tests/test_workspace_git.py
+++ b/tests/test_workspace_git.py
@@ -47,6 +47,20 @@ def _init_repo(path):
     return path
 
 
+def _init_bare_repo(path):
+    init = subprocess.run(
+        ["git", "init", "--bare", "-b", "master", str(path)],
+        shell=False,
+        text=True,
+        capture_output=True,
+        timeout=20,
+    )
+    if init.returncode != 0:
+        _git(path.parent, "init", "--bare", str(path))
+        _git(path, "symbolic-ref", "HEAD", "refs/heads/master")
+    return path
+
+
 def _commit_all(path, message="initial"):
     _git(path, "add", ".")
     _git(path, "commit", "-m", message)
@@ -513,8 +527,7 @@ def test_staged_commit_message_prompt_uses_only_staged_diff(tmp_path):
 def test_git_fetch_pull_and_push_with_upstream(tmp_path):
     from api.workspace_git import git_fetch, git_pull, git_push, git_status
 
-    remote = tmp_path / "remote.git"
-    _git(tmp_path, "init", "--bare", str(remote))
+    remote = _init_bare_repo(tmp_path / "remote.git")
 
     origin = _init_repo(tmp_path / "origin")
     (origin / "tracked.txt").write_text("one\n", encoding="utf-8")
@@ -550,8 +563,7 @@ def test_git_fetch_pull_and_push_with_upstream(tmp_path):
 def test_git_branches_lists_local_remote_and_upstream(tmp_path):
     from api.workspace_git import git_branches
 
-    remote = tmp_path / "remote.git"
-    _git(tmp_path, "init", "--bare", str(remote))
+    remote = _init_bare_repo(tmp_path / "remote.git")
     origin = _init_repo(tmp_path / "origin")
     (origin / "tracked.txt").write_text("one\n", encoding="utf-8")
     _commit_all(origin)
@@ -575,8 +587,7 @@ def test_git_branches_lists_local_remote_and_upstream(tmp_path):
 def test_git_checkout_local_new_remote_dirty_and_invalid_refs(tmp_path):
     from api.workspace_git import GitWorkspaceError, git_branches, git_checkout
 
-    remote = tmp_path / "remote.git"
-    _git(tmp_path, "init", "--bare", str(remote))
+    remote = _init_bare_repo(tmp_path / "remote.git")
     origin = _init_repo(tmp_path / "origin")
     (origin / "tracked.txt").write_text("one\n", encoding="utf-8")
     _commit_all(origin)

--- a/tests/test_workspace_git.py
+++ b/tests/test_workspace_git.py
@@ -31,7 +31,17 @@ def _git(cwd, *args):
 
 def _init_repo(path):
     path.mkdir(parents=True, exist_ok=True)
-    _git(path, "init")
+    init = subprocess.run(
+        ["git", "init", "-b", "master"],
+        cwd=str(path),
+        shell=False,
+        text=True,
+        capture_output=True,
+        timeout=20,
+    )
+    if init.returncode != 0:
+        _git(path, "init")
+        _git(path, "checkout", "-B", "master")
     _git(path, "config", "user.email", "hermes-tests@example.invalid")
     _git(path, "config", "user.name", "Hermes Tests")
     return path


### PR DESCRIPTION
## Thinking Path

The WebUI-specific prefill hook is now the explicit browser-chat context path, but the third-party notes drawer's AI-recent Joplin helper still inspected only the legacy generic `prefill_messages_script`. That can make the drawer point at stale or no recall notes even when browser chat is correctly using `webui_prefill_messages_script`.

## What Changed

- Prefer `webui_prefill_messages_script` when deriving Joplin notes that are recently used by AI recall.
- Fall back to the legacy `prefill_messages_script` for deployments that have not opted into the WebUI hook.
- Support argv-style hooks such as `["python3", "/path/to/recall.py"]` by selecting the script argument instead of the interpreter.
- Added a regression test covering WebUI-hook precedence over the legacy hook.
- Added a changelog entry.

## Why It Matters

This keeps the notes drawer aligned with the same recall path browser-originated WebUI turns use, which makes WebUI context/notes behavior closer to the Telegram/CLI runtime expectation without hard-coding any note provider or local path.

## Contract Routing

Task type: context / notes metadata parity.
Touched areas:
- `api/routes.py` Joplin AI-recent note discovery
- `tests/test_webui_notes_sources.py`
- `CHANGELOG.md`
Relevant public docs:
- `AGENTS.md`
- `CONTRIBUTING.md`
- `docs/CONTRACTS.md`
Scope boundaries:
- Does not execute recall scripts.
- Does not expose prefill message bodies.
- Does not change chat streaming or the WebUI prefill loader.
Evidence needed before claiming done:
- Focused notes-source regression passes.
- Existing WebUI prefill-context regression remains green.

## Verification

- `python3.11 -m py_compile api/routes.py`
- `python3.11 -m pytest tests/test_webui_notes_sources.py tests/test_webui_prefill_context.py -q -o addopts=` (`24 passed`)
- `git diff --check`

## Risks / Follow-ups

- Low risk: the change only selects which configured script file is inspected for existing Joplin note ID constants.
- If a hook is a complex shell command without a script-like argument, the helper falls back to the last argv element rather than executing anything.
