### PR TITLE
fix: route openai-codex through models.dev so models expose xhigh

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -2202,10 +2202,6 @@ def resolve_model_reasoning_efforts(
         if provider in {"copilot", "github-copilot"}:
             return github_model_reasoning_efforts(hinted_model)
 
-        if provider == "openai-codex":
-            bare = hinted_model.rsplit("/", 1)[-1]
-            return github_model_reasoning_efforts(bare)
-
         if provider == "lmstudio":
             probe_base = resolved_base_url or _get_provider_base_url(provider)
             opts = lmstudio_model_reasoning_options(hinted_model, probe_base)

--- a/tests/test_models_dev_reasoning.py
+++ b/tests/test_models_dev_reasoning.py
@@ -95,6 +95,19 @@ def test_codex_gpt55_uses_models_dev_including_xhigh(monkeypatch):
     assert "xhigh" in result
 
 
+def test_codex_metadata_false_returns_empty(monkeypatch):
+    _install_fake_models_dev(
+        monkeypatch,
+        lambda provider, model: SimpleNamespace(supports_reasoning=False),
+    )
+
+    import api.config as cfg
+
+    assert cfg.resolve_model_reasoning_efforts(
+        "gpt-5.5", provider_id="openai-codex"
+    ) == []
+
+
 def test_copilot_gpt55_caps_at_high(monkeypatch):
     import api.config as cfg
 

--- a/tests/test_models_dev_reasoning.py
+++ b/tests/test_models_dev_reasoning.py
@@ -2,6 +2,8 @@
 
 import sys
 import types
+
+import pytest
 from types import SimpleNamespace
 
 
@@ -76,6 +78,35 @@ def test_models_dev_false_suppresses_prefix_heuristic(monkeypatch):
     assert cfg.resolve_model_reasoning_efforts(
         "x-ai/grok-4-non-reasoning", provider_id="openrouter"
     ) == []
+
+
+def test_codex_gpt55_uses_models_dev_including_xhigh(monkeypatch):
+    _install_fake_models_dev(
+        monkeypatch,
+        lambda provider, model: SimpleNamespace(supports_reasoning=True),
+    )
+
+    import api.config as cfg
+
+    result = cfg.resolve_model_reasoning_efforts(
+        "gpt-5.5", provider_id="openai-codex"
+    )
+    assert result == list(cfg.VALID_REASONING_EFFORTS)
+    assert "xhigh" in result
+
+
+def test_copilot_gpt55_caps_at_high(monkeypatch):
+    import api.config as cfg
+
+    try:
+        from hermes_cli.models import github_model_reasoning_efforts
+    except ImportError:
+        pytest.skip("hermes_cli not available")
+
+    result = cfg.resolve_model_reasoning_efforts(
+        "gpt-5.5", provider_id="copilot"
+    )
+    assert "xhigh" not in result
 
 
 def test_get_reasoning_status_uses_config_default_model(monkeypatch, tmp_path):


### PR DESCRIPTION
### Thinking Path
- After PR #3017 landed the models.dev reasoning metadata path, `openai-codex` was still explicitly routed through `github_model_reasoning_efforts()`.
- That helper only returns up to `high` for the GPT-5 family, so Codex users could never select `xhigh` even when the underlying Codex Responses transport supports it.
- The regression was caught during post-merge verification when `gpt-5.5` on `openai-codex` showed only four effort levels instead of five.

### What Changed
- Removed the `if provider == "openai-codex"` block in `resolve_model_reasoning_efforts()` that forced the GitHub/Copilot helper.
- Codex models now fall through to `_models_dev_reasoning_efforts()` (full effort set when metadata reports `supports_reasoning=True`), then the narrow heuristic fallback.
- GitHub/Copilot (`copilot` / `github-copilot`) continue using the existing helper and remain capped at `high`.
- Added two focused regression tests:
  - `openai-codex + gpt-5.5` returns the complete `VALID_REASONING_EFFORTS` list (including `xhigh`).
  - `copilot + gpt-5.5` still caps at `high`.

Only `api/config.py` and `tests/test_models_dev_reasoning.py` were modified.

### Why It Matters
Users running GPT-5.5 (and other reasoning-capable models) via `openai-codex` can now use Extra High reasoning effort in the WebUI, matching the capability already present in the Hermes Agent Codex transport.

### Verification
```bash
python -m py_compile api/config.py tests/test_models_dev_reasoning.py
python -m pytest tests/test_models_dev_reasoning.py -q
```

Inline smoke test:
```text
openai-codex gpt-5.5   => ['minimal', 'low', 'medium', 'high', 'xhigh']
copilot gpt-5.5        => ['minimal', 'low', 'medium', 'high']
```

All tests pass.

### Risks / Follow-ups
- No behavior change for GitHub/Copilot users.
- If upstream `github_model_reasoning_efforts()` later starts returning `xhigh` for GPT-5 models on the GitHub catalog, the WebUI path for Copilot will automatically widen (no code change needed).
- OpenCode PR review performed on the branch (structured review attached to internal session).

### Model Used
- Implementation: GLM 5.1
- Everything else (review, description, verification): Grok 4.3 Extra High