### PR TITLE
fix: reset _messagesTruncated flag on new session creation

### DIFF
--- a/static/sessions.js
+++ b/static/sessions.js
@@ -455,6 +455,8 @@ async function newSession(flash, options={}){
   _newSessionInFlight=(async()=>{
     updateQueueBadge();
     S.toolCalls=[];
+    _messagesTruncated=false;
+    _oldestIdx=0;
     clearLiveToolCards();
     // One-shot profile-switch workspace: applied to the first new session after a profile
     // switch, then cleared.  Use a dedicated flag so S._profileDefaultWorkspace (the


### PR DESCRIPTION
## Thinking Path

Hermes WebUI has two session-switching paths: `loadSession()` and `newSession()`. `loadSession()` resets `_messagesTruncated = false` and `_oldestIdx = 0` at line 590, but `newSession()` missed both. When a user switches from a long session (messages > `_INITIAL_MSG_LIMIT` of 30) to a new session, the stale `_messagesTruncated = true` causes `renderMessages()` to evaluate `hasServerOlder` as true, showing the "Scroll up or click to load older messages" indicator on a fresh conversation with only 1 message. The flag only gets cleared when the assistant response completes and the done event sets it from `d.session._messages_truncated` (which is undefined). This is a one-session window of incorrect UI state.

## What Changed

- `static/sessions.js`: Added `_messagesTruncated = false` and `_oldestIdx = 0` at the top of the `newSession()` async closure, matching the reset that `loadSession()` already performs.

## Why It Matters

Users creating a new session from a long conversation see a misleading "Scroll up or click to load older messages" banner on a conversation that has no history. This is confusing and semantically wrong — there are no older messages to load. The fix ensures new sessions start with clean pagination state.

## Verification

- `pytest tests/ -v --timeout=60 --ignore=tests/test_passkey_auth.py`: **6608 passed**, 12 failed (all pre-existing, unrelated to this change)
- The change is 2 lines of state reset, no API / architecture / dependency impact
- Manual path: open WebUI → switch from a long session → create new session → send a message → confirm load-older indicator does not appear

## Risks / Follow-ups

- None. `_messagesTruncated` and `_oldestIdx` should both be `false` / `0` on a fresh session by definition. This aligns `newSession()` with `loadSession()` behavior.
- `test_passkey_auth.py` collection error (`cryptography` missing) is a pre-existing environment dependency issue, not related to this fix.

## Model Used

- Provider: xiaomi-mimo-cn
- Model: mimo-v2.5-pro