### PR TITLE
fix(scroll): preserve user position during live stream reattach on session return

### DIFF
--- a/static/sessions.js
+++ b/static/sessions.js
@@ -713,7 +713,7 @@ async function loadSession(sid){
     // replaying persisted live tools so the compact Activity count survives
     // switching away from and back to an active chat (#1715).
     S.activeStreamId=activeStreamId;
-    syncTopbar();renderMessages();
+    syncTopbar();renderMessages({preserveScroll:true});
     const restoredLiveTurn=typeof restoreLiveTurnHtmlForSession==='function'&&restoreLiveTurnHtmlForSession(sid);
     if(!restoredLiveTurn){
       appendThinking();
@@ -797,7 +797,7 @@ async function loadSession(sid){
       updateSendBtn();
       setStatus('');
       setComposerStatus('');
-      syncTopbar();renderMessages();appendThinking();loadDir('.');
+      syncTopbar();renderMessages({preserveScroll:true});appendThinking();loadDir('.');
       updateQueueBadge(sid);
       startApprovalPolling(sid);
       if(typeof startClarifyPolling==='function') startClarifyPolling(sid);
@@ -811,7 +811,7 @@ async function loadSession(sid){
       setStatus('');
       setComposerStatus('');
       updateQueueBadge(sid);
-      syncTopbar();renderMessages();
+      syncTopbar();renderMessages({preserveScroll:true});
       if(typeof resumeManualCompressionForSession==='function') resumeManualCompressionForSession(sid);
       const _dirP=loadDir('.');
       // Workspace refresh is guarded by session id inside loadDir(); do not

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -811,7 +811,7 @@ async function loadSession(sid){
       setStatus('');
       setComposerStatus('');
       updateQueueBadge(sid);
-      syncTopbar();renderMessages({preserveScroll:true});
+      syncTopbar();renderMessages();
       if(typeof resumeManualCompressionForSession==='function') resumeManualCompressionForSession(sid);
       const _dirP=loadDir('.');
       // Workspace refresh is guarded by session id inside loadDir(); do not

--- a/static/ui.js
+++ b/static/ui.js
@@ -2748,6 +2748,7 @@ function _settleMessageScrollToBottom(force){
 function scrollIfPinned(){
   if(!_scrollPinned) return;
   if(_recentNonMessageScrollIntent()) return;
+  if(_recentMessageUpwardIntent()) return;  // strengthen for live reattach / token renders (post-8408a3dd scroll-jump regression per skill reference)
   _settleMessageScrollToBottom(false);
 }
 function scrollToBottom(){

--- a/static/ui.js
+++ b/static/ui.js
@@ -2748,7 +2748,7 @@ function _settleMessageScrollToBottom(force){
 function scrollIfPinned(){
   if(!_scrollPinned) return;
   if(_recentNonMessageScrollIntent()) return;
-  if(_recentMessageUpwardIntent()) return;  // strengthen for live reattach / token renders (post-8408a3dd scroll-jump regression per skill reference)
+  if(_recentMessageUpwardIntent()) return;  // respect user upward scroll intent during live token delivery (post-8408a3dd)
   _settleMessageScrollToBottom(false);
 }
 function scrollToBottom(){

--- a/tests/test_issue2341_pending_user_reattach.py
+++ b/tests/test_issue2341_pending_user_reattach.py
@@ -25,7 +25,7 @@ def test_load_session_inflight_reattach_merges_pending_user_message_before_rende
     block = _load_session_inflight_branch()
 
     merge_pos = block.find("_mergePendingSessionMessage")
-    render_pos = block.find("renderMessages();")
+    render_pos = block.find("renderMessages({preserveScroll:true});")
 
     assert merge_pos != -1, (
         "loadSession's INFLIGHT reattach branch must merge pending_user_message "

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -620,7 +620,7 @@ def test_loadSession_inflight_sets_busy_before_renderMessages(cleanup_test_sessi
     assert inflight_idx >= 0, "INFLIGHT branch not found in loadSession"
     inflight_block = src[inflight_idx:inflight_idx+1600]
     busy_pos = inflight_block.find("S.busy=true;")
-    render_pos = inflight_block.find("renderMessages();")
+    render_pos = inflight_block.find("renderMessages({preserveScroll:true});")
     assert busy_pos >= 0, "loadSession INFLIGHT branch must set S.busy=true"
     assert render_pos >= 0, "loadSession INFLIGHT branch must call renderMessages()"
     assert busy_pos < render_pos, \


### PR DESCRIPTION
**Thinking Path**

- Hermes WebUI needs to support scrolling up to read history while a response is still generating, including after the user switches away from and back to the conversation.
- The recent SSE reattach and stream ownership work (8408a3dd + ffd9f337) correctly increased the frequency of `loadSession` → `renderMessages()` + `attachLiveStream({reconnecting:true})` when returning to sessions that still have an active generation.
- Two active-stream paths in `loadSession` were still calling `renderMessages()` without the existing `preserveScroll` contract.
- Live token rendering paths continued to call `scrollIfPinned()` without consulting the upward scroll intent window that the scroll listener was already tracking.
- **Result: users who scrolled up after switching back to an in-progress chat were repeatedly yanked to the bottom on the next token batch.**

**What Changed**

- In `static/sessions.js`, the two live/reattach render sites inside `loadSession` now pass `{preserveScroll:true}` so the established snapshot/restore logic in `_scrollAfterMessageRender` can preserve the user’s position.
- In `static/ui.js`, `scrollIfPinned()` now also short-circuits when `_recentMessageUpwardIntent()` is true. This makes the intent tracking (already computed by the wheel/scroll listener) authoritative for live token delivery.

Net change: 3 lines. No new state, no timeouts, no reattach-specific branches.

**Why It Matters**

Users can scroll up to review earlier turns while a response is generating, even after switching sessions. The previous behavior made this unreliable when returning to an in-progress chat.

**Verification**

- Branch created directly from latest `origin/master` and pushed for review.
- The two live/reattach `renderMessages({preserveScroll:true})` call sites and the strengthened `scrollIfPinned()` guard were confirmed present.
- Manual reproduction: long chat with active generation → switch away → return → immediately scroll up (wheel and trackpad momentum) while tokens continue to arrive.

**Risks / Follow-ups**

- Low risk. All changes reuse long-standing scroll-pinning machinery (`preserveScroll`, `_recentMessageUpwardIntent`, `_scrollAfterMessageRender`).
- No behavior change for users already pinned at the bottom or for historical (non-live) session loads.
- Future live DOM mutation sources (compression cards, handoff summaries, etc.) should continue to be checked against the same user scroll intent rules.

**Model Used**

xAI / Grok Build 0.1