### PR TITLE
fix: avoid false response-interrupted stale repair markers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Compression parent sessions are no longer repaired as stale interrupted turns when a continuation already exists, preventing false "Response interrupted" markers and hidden continuation rows after auto-compression session rotation. (Refs #2361)
+
 ## [v0.51.152] — 2026-05-28 — Release DX (stage-batch34 — single-PR optional gateway-backed browser chat)
 
 ### Added

--- a/api/models.py
+++ b/api/models.py
@@ -1175,6 +1175,19 @@ def _run_journal_has_visible_output(session, stream_id: str | None) -> bool:
     return False
 
 
+def _run_journal_terminal_state(session, stream_id: str | None) -> str | None:
+    if not stream_id:
+        return None
+    try:
+        from api.run_journal import latest_run_summary
+        summary = latest_run_summary(session.session_id, stream_id)
+    except Exception:
+        return None
+    if not summary.get('terminal'):
+        return None
+    return str(summary.get('terminal_state') or '') or None
+
+
 def _journal_is_still_arriving(session, stream_id: str | None) -> bool:
     """Return True for journals that may become visible on a later read.
 
@@ -1689,13 +1702,35 @@ def _apply_core_sync_or_error_marker(
         _pending_text = " ".join(str(session.pending_user_message or "").split())
         _already_checkpointed = False
         if _pending_text and session.messages:
-            _last_msg = session.messages[-1]
-            if isinstance(_last_msg, dict) and _last_msg.get('role') == 'user':
-                _last_text = " ".join(str(_last_msg.get('content') or "").split())
-                _already_checkpointed = _last_text == _pending_text
+            for _last_msg in reversed(session.messages):
+                if isinstance(_last_msg, dict) and _last_msg.get('role') == 'user':
+                    _last_text = " ".join(str(_last_msg.get('content') or "").split())
+                    _already_checkpointed = _last_text == _pending_text
+                    break
         _recovered_ts = int(time.time())
         if isinstance(session.pending_started_at, (int, float)) and session.pending_started_at > 0:
             _recovered_ts = int(session.pending_started_at)
+        _stream_id = stream_id_for_recheck or session.active_stream_id
+        _pending_started_at = session.pending_started_at
+        if _run_journal_terminal_state(session, _stream_id) == 'completed':
+            if not _already_checkpointed:
+                _append_recovered_pending_turn(session, timestamp=_recovered_ts)
+            _append_journaled_partial_output(
+                session,
+                _stream_id,
+                dedupe_existing=True,
+            )
+            session.active_stream_id = None
+            session.pending_user_message = None
+            session.pending_attachments = []
+            session.pending_started_at = None
+            session.save(touch_updated_at=touch_updated_at)
+            logger.info(
+                "Session %s: cleared stale pending state for completed stream %s without error marker",
+                sid,
+                _stream_id,
+            )
+            return True
         if not _already_checkpointed:
             _append_recovered_pending_turn(session, timestamp=_recovered_ts)
         else:
@@ -1709,10 +1744,8 @@ def _apply_core_sync_or_error_marker(
             _append_recovered_turn_to_context(session, recovered)
         recovered_output = _append_journaled_partial_output(
             session,
-            stream_id_for_recheck or session.active_stream_id,
+            _stream_id,
         )
-        _stream_id = stream_id_for_recheck or session.active_stream_id
-        _pending_started_at = session.pending_started_at
         session.active_stream_id = None
         session.pending_user_message = None
         session.pending_attachments = []

--- a/api/models.py
+++ b/api/models.py
@@ -1850,6 +1850,72 @@ def _apply_core_sync_or_error_marker(
 _REPAIR_STALE_PENDING_GRACE_SECONDS = 30
 
 
+def _has_compression_continuation(session) -> bool:
+    """Return True when ``session`` is an archived compression parent.
+
+    Context compression rotates the live WebUI session id: the old sidecar is
+    preserved for lineage while the new child owns the running/completed turn.
+    Stale-pending repair must not append an interruption marker to that old
+    parent just because its stream bookkeeping disappeared after the rotation.
+    """
+    sid = getattr(session, 'session_id', None)
+    if not sid:
+        return False
+
+    def _row_is_continuation(row) -> bool:
+        if not isinstance(row, dict):
+            return False
+        child_sid = row.get('session_id')
+        if not child_sid or child_sid == sid:
+            return False
+        if row.get('parent_session_id') != sid:
+            return False
+        # Any child row is enough evidence that this pending state belongs to a
+        # compression lineage, not a dead standalone turn. The child may itself
+        # temporarily carry a bad pre_compression_snapshot flag from older code;
+        # do not filter it out here or the guard misses the exact regression.
+        return True
+
+    try:
+        with LOCK:
+            for child in SESSIONS.values():
+                if getattr(child, 'session_id', None) == sid:
+                    continue
+                if getattr(child, 'parent_session_id', None) == sid:
+                    return True
+    except Exception:
+        pass
+
+    try:
+        if SESSION_INDEX_FILE.exists():
+            entries = json.loads(SESSION_INDEX_FILE.read_text(encoding='utf-8'))
+            if isinstance(entries, list) and any(_row_is_continuation(e) for e in entries):
+                return True
+    except Exception:
+        logger.debug("Failed to inspect session index for compression continuation", exc_info=True)
+
+    # Index rows can lag behind rapid compression/save races. Fall back to a
+    # shallow JSON metadata scan; session files write parent_session_id before
+    # the messages array, so this avoids loading multi-MB transcripts.
+    try:
+        needle = f'"parent_session_id": "{sid}"'
+        for path in SESSION_DIR.glob('*.json'):
+            if path.name.startswith('_') or path.stem == sid:
+                continue
+            try:
+                head = path.read_text(encoding='utf-8', errors='ignore')[:4096]
+            except TypeError:
+                head = path.read_text(encoding='utf-8')[:4096]
+            except OSError:
+                continue
+            if needle in head:
+                return True
+    except Exception:
+        logger.debug("Failed to scan session files for compression continuation", exc_info=True)
+
+    return False
+
+
 def _repair_stale_pending(session) -> bool:
     """Recover a sidecar stuck with messages=[] and stale pending state.
 
@@ -1871,6 +1937,18 @@ def _repair_stale_pending(session) -> bool:
     if (not session.pending_user_message
             or not _seen_stream_id
             or _seen_stream_id in _active_stream_ids()):
+        return False
+    if getattr(session, 'pre_compression_snapshot', False):
+        logger.debug(
+            "_repair_stale_pending: skipping pre-compression snapshot %s",
+            getattr(session, 'session_id', '?'),
+        )
+        return False
+    if _has_compression_continuation(session):
+        logger.debug(
+            "_repair_stale_pending: skipping compression parent %s with continuation",
+            getattr(session, 'session_id', '?'),
+        )
         return False
 
     # Grace-period guard: bail if the turn is too fresh to be a real crash.

--- a/api/routes.py
+++ b/api/routes.py
@@ -1018,6 +1018,42 @@ def _clear_stale_stream_state(session) -> bool:
         stream_alive = stream_id in STREAMS
     if stream_alive:
         return False
+    try:
+        from api import config as _live_config
+        with _live_config.ACTIVE_RUNS_LOCK:
+            worker_alive = stream_id in (_live_config.ACTIVE_RUNS or {})
+    except Exception:
+        worker_alive = False
+    if worker_alive:
+        logger.debug(
+            "_clear_stale_stream_state: stream %s for session %s missing SSE channel "
+            "but worker bookkeeping is still active; deferring stale cleanup",
+            stream_id,
+            getattr(session, "session_id", "?"),
+        )
+        return False
+    grace_seconds = 30.0
+    try:
+        from api.models import _REPAIR_STALE_PENDING_GRACE_SECONDS
+        grace_seconds = float(_REPAIR_STALE_PENDING_GRACE_SECONDS)
+        pending_started_at = getattr(session, "pending_started_at", None)
+        pending_age = time.time() - float(pending_started_at) if pending_started_at else None
+    except Exception:
+        pending_age = None
+    if (
+        getattr(session, "pending_user_message", None)
+        and pending_age is not None
+        and pending_age < grace_seconds
+    ):
+        logger.debug(
+            "_clear_stale_stream_state: stream %s for session %s missing SSE channel "
+            "but pending turn is %.1fs old; waiting for %.1fs stale-repair grace",
+            stream_id,
+            getattr(session, "session_id", "?"),
+            pending_age,
+            grace_seconds,
+        )
+        return False
 
     # ── #1558 P0 safety: if we were handed a metadata-only stub, reload the
     # full session before touching persisted state. The original

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -5197,6 +5197,14 @@ def _run_agent_streaming(
                     # the write when the file already contains up-to-date data
                     # (i.e. it was just saved by a checkpoint).
                     _preserve_pre_compression_snapshot(s, old_sid)
+                    # The continuation is the live/tip session, not another archived
+                    # snapshot. If the in-memory object was itself loaded from a
+                    # pre-compression snapshot (possible on repeated compression chains
+                    # or stale-cache repair paths), _preserve_pre_compression_snapshot()
+                    # intentionally restores that old flag; clear it before saving the
+                    # new continuation so sidebar/discoverability code does not hide the
+                    # session that owns the completed turn.
+                    s.pre_compression_snapshot = False
                     # Always link the continuation session to its immediate predecessor
                     # (the preserved snapshot).  This OVERRIDES any prior
                     # parent_session_id because the new continuation IS the next link

--- a/tests/test_compression_snapshot_runtime_clear.py
+++ b/tests/test_compression_snapshot_runtime_clear.py
@@ -95,3 +95,22 @@ def test_preserve_pre_compression_snapshot_load_and_mark_branch_clears_runtime_f
     assert saved["pending_user_message"] is None
     assert saved["pending_attachments"] == []
     assert saved["pending_started_at"] is None
+
+
+def test_preserve_pre_compression_snapshot_does_not_leave_continuation_marked_as_snapshot(tmp_path, monkeypatch):
+    """A continuation loaded from an old snapshot must not remain hidden."""
+    monkeypatch.setattr(streaming, "SESSION_DIR", tmp_path)
+    (tmp_path / "old_session.json").write_text(json.dumps({"messages": []}), encoding="utf-8")
+    session = FakeSession()
+    session.pre_compression_snapshot = True
+
+    streaming._preserve_pre_compression_snapshot(session, "old_session")
+    # The helper archives the parent and restores the incoming object state.
+    # The streaming compression path must clear this before saving the child.
+    assert session.pre_compression_snapshot is True
+
+    session.pre_compression_snapshot = False
+    session.save(touch_updated_at=False)
+    continuation = json.loads((tmp_path / "new_session.json").read_text(encoding="utf-8"))
+    assert continuation["pre_compression_snapshot"] is False
+

--- a/tests/test_session_lost_response_regression.py
+++ b/tests/test_session_lost_response_regression.py
@@ -536,3 +536,43 @@ def test_marker_demotes_after_giveup_seconds(hermes_home, monkeypatch):
     assert marker["content"] == models._INTERRUPTED_NEUTRAL_WORDING
     _assert_retry_meta_removed(marker)
     assert append_calls == 0
+
+
+def test_repair_stale_pending_skips_pre_compression_snapshot_parent(hermes_home):
+    """Archived compression parents must not get synthetic interrupt markers."""
+    s = _make_dead_stream_session("compressed_parent", stream_id="dead-stream")
+    s.pre_compression_snapshot = True
+    original_messages = list(s.messages)
+
+    assert models._repair_stale_pending(s) is False
+
+    assert s.messages == original_messages
+    assert s.active_stream_id == "dead-stream"
+    assert s.pending_user_message
+
+
+def test_repair_stale_pending_skips_parent_when_continuation_exists(hermes_home):
+    """Compression old→new rotation owns the turn in the child, not the old parent."""
+    parent = _make_dead_stream_session("compression_parent", stream_id="rotated-stream")
+    child = Session(
+        session_id="compression_child",
+        title="Continuation",
+        parent_session_id="compression_parent",
+        # Pin the production regression: older code could accidentally save the
+        # child with pre_compression_snapshot=True, but its parent link still
+        # proves the parent must not be repaired as a lost standalone turn.
+        pre_compression_snapshot=True,
+        messages=[
+            {"role": "user", "content": "ok, push beide", "timestamp": 10},
+            {"role": "assistant", "content": "done", "timestamp": 11},
+        ],
+    )
+    child.save()
+    original_messages = list(parent.messages)
+
+    assert models._repair_stale_pending(parent) is False
+
+    assert parent.messages == original_messages
+    assert parent.active_stream_id == "rotated-stream"
+    assert parent.pending_user_message
+

--- a/tests/test_session_summary_redaction.py
+++ b/tests/test_session_summary_redaction.py
@@ -21,30 +21,26 @@ def _get(path):
 
 
 def _write_session_with_secret_title():
-    from tests.conftest import TEST_STATE_DIR
+    from api.models import Session
+    from tests.conftest import TEST_WORKSPACE
 
     sid = "sec_summary_" + uuid.uuid4().hex[:8]
-    sessions_dir = TEST_STATE_DIR / "sessions"
-    sessions_dir.mkdir(parents=True, exist_ok=True)
     now = time.time()
-    (sessions_dir / f"{sid}.json").write_text(json.dumps({
-        "session_id": sid,
-        "title": f"session with {_FULL_SECRET}",
-        "workspace": "/tmp",
-        "model": "test",
-        "created_at": now,
-        "updated_at": now,
-        "pinned": False,
-        "archived": False,
-        "project_id": None,
-        "profile": "default",
-        "input_tokens": 0,
-        "output_tokens": 0,
-        "estimated_cost": None,
-        "personality": None,
-        "messages": [],
-        "tool_calls": [],
-    }))
+    session = Session(
+        session_id=sid,
+        title=f"session with {_FULL_SECRET}",
+        workspace=str(TEST_WORKSPACE),
+        model="test",
+        created_at=now,
+        updated_at=now,
+        profile="default",
+        messages=[],
+        tool_calls=[],
+    )
+    # Save through the model layer so the sidebar index is updated just like a
+    # real session write. Direct sidecar writes are intentionally not visible to
+    # /api/sessions while an index exists.
+    session.save(touch_updated_at=False)
     return sid
 
 

--- a/tests/test_stale_stream_writeback.py
+++ b/tests/test_stale_stream_writeback.py
@@ -131,6 +131,45 @@ def test_stale_stream_clear_skips_fresh_pending_turn_inside_grace_window(monkeyp
     assert all(not m.get("_error") for m in s.messages)
 
 
+def test_stale_stream_clear_trusts_completed_run_journal_instead_of_adding_marker(monkeypatch):
+    import api.routes as routes
+    from api.run_journal import append_run_event
+
+    sid = "completed_journal_late_pending_clear"
+    stream_id = "completed-stream"
+    s = Session(
+        session_id=sid,
+        title="Completed journal late pending clear",
+        messages=[
+            {"role": "user", "content": "previous prompt"},
+            {"role": "assistant", "content": "previous answer"},
+            {"role": "user", "content": "new prompt"},
+            {"role": "assistant", "content": "finished answer"},
+        ],
+    )
+    s.active_stream_id = stream_id
+    s.pending_user_message = "new prompt"
+    s.pending_started_at = 1000.0
+    s.save()
+    models.SESSIONS[sid] = s
+    append_run_event(sid, stream_id, "done", {"session": {"session_id": sid}})
+    monkeypatch.setattr(routes.time, "time", lambda: 1400.0)
+
+    assert routes._clear_stale_stream_state(s) is True
+
+    assert s.active_stream_id is None
+    assert s.pending_user_message is None
+    assert s.pending_started_at is None
+    assert [m["content"] for m in s.messages] == [
+        "previous prompt",
+        "previous answer",
+        "new prompt",
+        "finished answer",
+    ]
+    assert all("Response interrupted" not in str(m.get("content") or "") for m in s.messages)
+    assert all(not m.get("_error") for m in s.messages)
+
+
 def test_success_path_checks_stream_ownership_before_persisting_result():
     src = Path("api/streaming.py").read_text(encoding="utf-8")
     guard = "if not ephemeral and not _stream_writeback_is_current(s, stream_id):"

--- a/tests/test_stale_stream_writeback.py
+++ b/tests/test_stale_stream_writeback.py
@@ -1,5 +1,6 @@
 import queue
 import threading
+import time
 from pathlib import Path
 from unittest.mock import Mock
 
@@ -24,12 +25,14 @@ def _isolate_sessions(tmp_path, monkeypatch):
     config.STREAMS.clear()
     config.CANCEL_FLAGS.clear()
     config.AGENT_INSTANCES.clear()
+    config.ACTIVE_RUNS.clear()
     config.SESSION_AGENT_LOCKS.clear()
     yield
     models.SESSIONS.clear()
     config.STREAMS.clear()
     config.CANCEL_FLAGS.clear()
     config.AGENT_INSTANCES.clear()
+    config.ACTIVE_RUNS.clear()
     config.SESSION_AGENT_LOCKS.clear()
 
 
@@ -73,6 +76,59 @@ def test_cancel_stream_does_not_append_marker_after_stream_ownership_rotated():
     assert s.pending_user_message == "newer prompt"
     assert [m["content"] for m in s.messages] == ["newer prompt"]
     assert all(m.get("content") != "*Task cancelled.*" for m in s.messages)
+
+
+def test_stale_stream_clear_skips_active_worker_when_sse_channel_is_gone():
+    import api.routes as routes
+
+    sid = "active_worker_missing_sse"
+    stream_id = "live-worker-stream"
+    s = Session(
+        session_id=sid,
+        title="Active worker missing SSE",
+        messages=[{"role": "user", "content": "previous prompt"}],
+    )
+    s.active_stream_id = stream_id
+    s.pending_user_message = "new prompt"
+    s.pending_started_at = time.time()
+    s.save()
+    models.SESSIONS[sid] = s
+
+    config.register_active_run(stream_id, session_id=sid, phase="running")
+
+    assert routes._clear_stale_stream_state(s) is False
+
+    assert s.active_stream_id == stream_id
+    assert s.pending_user_message == "new prompt"
+    assert s.pending_started_at is not None
+    assert [m["content"] for m in s.messages] == ["previous prompt"]
+    assert all(not m.get("_error") for m in s.messages)
+
+
+def test_stale_stream_clear_skips_fresh_pending_turn_inside_grace_window(monkeypatch):
+    import api.routes as routes
+
+    sid = "fresh_pending_missing_sse"
+    stream_id = "fresh-pending-stream"
+    s = Session(
+        session_id=sid,
+        title="Fresh pending missing SSE",
+        messages=[{"role": "user", "content": "previous prompt"}],
+    )
+    s.active_stream_id = stream_id
+    s.pending_user_message = "new prompt"
+    s.pending_started_at = 1000.0
+    s.save()
+    models.SESSIONS[sid] = s
+    monkeypatch.setattr(routes.time, "time", lambda: 1005.0)
+
+    assert routes._clear_stale_stream_state(s) is False
+
+    assert s.active_stream_id == stream_id
+    assert s.pending_user_message == "new prompt"
+    assert s.pending_started_at == 1000.0
+    assert [m["content"] for m in s.messages] == ["previous prompt"]
+    assert all(not m.get("_error") for m in s.messages)
 
 
 def test_success_path_checks_stream_ownership_before_persisting_result():


### PR DESCRIPTION
## Summary
- skips stale-pending repair for archived pre-compression snapshot parent sessions
- detects when a compression parent already has a continuation and avoids adding a false interrupted-turn marker
- clears the runtime-only `pre_compression_snapshot` flag on the live continuation after preserving the archived snapshot
- treats `ACTIVE_RUNS` worker bookkeeping as authoritative liveness in `_clear_stale_stream_state()` before writing an interrupted-turn marker
- honors the pending-turn stale-repair grace window in `_clear_stale_stream_state()` so fresh turns are not marked interrupted just because the SSE channel is temporarily missing
- trusts a terminal `completed` run journal before manufacturing an interrupted-turn marker, clearing stale pending runtime fields without altering a completed transcript
- compares stale pending text against the latest user message, not only the last transcript message, so completed user→assistant turns are recognized as already checkpointed
- adds regression coverage for parent/continuation repair guards, continuation runtime flag clearing, active-worker stale-stream deferral, fresh pending-turn grace deferral, and completed-journal late-pending cleanup

## Why
A live auto-compression rotation can leave the archived parent with a pending/stale-looking runtime shape while the real response continues in the child session. The recovery pass should not repair that parent as an interrupted turn. Doing so creates a false "Response interrupted" marker and can hide or confuse the visible continuation.

A second observed path produced the same user-visible false marker without compression: `_clear_stale_stream_state()` checked only whether the SSE stream id was present in `STREAMS`. If that channel was gone or not visible while the worker was still alive in `ACTIVE_RUNS`, the route-level cleanup could call the core sync/error-marker repair path immediately and append a false "Response interrupted" marker even though the worker continued running API calls and tools.

A third observed path happened after a turn had already completed: the run journal contained a terminal `completed` event and the assistant answer was already in the transcript, but the sidecar still had stale `pending_user_message` / `active_stream_id`. A later stale cleanup saw no live stream/worker and appended a false marker. This PR now treats a completed journal as authoritative and clears the stale runtime fields without adding an interruption marker.

This is a concrete run-state consistency slice under #2361. It is adjacent to, but separate from, #2980: #2980 handles reload/sidebar continuation recovery, while this PR prevents backend stale-repair paths from manufacturing the bad interrupted state in the first place.

Refs #2361

## Validation
- `python3 -m pytest tests/test_stale_stream_writeback.py::test_stale_stream_clear_trusts_completed_run_journal_instead_of_adding_marker -q` → 1 passed
- `python3 -m pytest tests/test_stale_stream_writeback.py -q` → 8 passed
- `python3 -m pytest tests/test_stale_stream_writeback.py tests/test_session_sidecar_repair.py tests/test_session_lost_response_regression.py tests/test_issue2157_sessions_list_stale_stream_state.py -q` → 91 passed
- GitHub Actions on `3469a2f`: Python 3.11, 3.12, and 3.13 passed
