### PR TITLE
fix: tighten title language detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Title-language detection no longer treats common English tech/jargon text such as "session die" or DAS/DER references as German just because of shared tokens. (Refs #3040)
+
 ## [v0.51.152] — 2026-05-28 — Release DX (stage-batch34 — single-PR optional gateway-backed browser chat)
 
 ### Added

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -1385,12 +1385,12 @@ def _detect_title_language(text: str) -> str:
         return ''
     german_markers = {
         'warum', 'werden', 'wird', 'wurde', 'hier', 'nicht', 'mehr', 'alte', 'alten',
-        'bilder', 'angezeigt', 'session', 'prüfe', 'ich', 'die', 'der', 'das', 'den',
-        'und', 'oder', 'mit', 'für', 'von', 'zu', 'ist', 'sind', 'bitte', 'kannst',
+        'bilder', 'angezeigt', 'prüfe', 'ich', 'und', 'oder', 'mit', 'für', 'von',
+        'zu', 'ist', 'sind', 'bitte', 'kannst',
     }
     tokens = re.findall(r'[A-Za-zÀ-ÖØ-öø-ÿ]+', s)
     german_hits = sum(1 for tok in tokens if tok in german_markers)
-    if re.search(r'[äöüß]', s) or german_hits >= 2:
+    if re.search(r'[äöüß]', s) or german_hits >= 3:
         return 'de'
     return ''
 

--- a/tests/test_title_aux_routing.py
+++ b/tests/test_title_aux_routing.py
@@ -229,6 +229,28 @@ class TestGenerateTitleRawViaAuxTimeout(unittest.TestCase):
         self.assertIn('Match the language of the user question', messages[0]['content'])
         self.assertIn('If the user writes German, output a German title', messages[0]['content'])
 
+    def test_title_language_detection_avoids_english_tech_false_positives(self):
+        """English tech/jargon text must not be classified as German by shared tokens."""
+        from api.streaming import _detect_title_language
+
+        examples = [
+            'Why did the session die after the DAS storage failover?',
+            'The session can die when DAS storage disconnects.',
+            'Debug the session and DER certificate import failure.',
+        ]
+        for text in examples:
+            with self.subTest(text=text):
+                self.assertEqual(_detect_title_language(text), '')
+
+    def test_title_language_detection_keeps_german_without_umlaut(self):
+        """German without umlauts still needs a language hint when evidence is specific."""
+        from api.streaming import _detect_title_language
+
+        self.assertEqual(
+            _detect_title_language('Warum werden hier die Bilder der alten Session nicht angezeigt?'),
+            'de',
+        )
+
     def test_german_source_rejects_english_aux_title(self):
         """Regression: an English aux title must not overwrite a German conversation."""
         from api.streaming import _generate_llm_session_title_via_aux


### PR DESCRIPTION
## Summary
- removes ambiguous shared tokens (`session`, `die`, `der`, `das`, `den`) from German title-language detection
- requires at least three non-umlaut German marker hits before classifying text as German
- keeps the umlaut/ß fast path and preserves German detection for specific German prompts without umlauts
- adds regression coverage for English tech/jargon false positives like "session die", DAS, and DER

## Why
Issue #3040 flagged that the follow-up title-language detection from #2984 can classify English tech text as German when two shared tokens appear together. That can make English conversations receive German title prompt/validation behavior.

This PR addresses item 1 from #3040. The other items in #3040 are separate cleanup/streaming-reconnect concerns and should stay separate to avoid mixing title-generation heuristics with SSE reattach behavior.

Refs #3040
Follow-up to #2984

## Validation
- `python3 -m py_compile api/streaming.py`
- `python3 -m pytest tests/test_title_aux_routing.py tests/test_sprint41.py -q`
- `LC_ALL=C.UTF-8 LANG=C.UTF-8 python3 -m pytest`
