### PR TITLE
fix: allow current-pane SSE reconnect when unfocused

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Visible but unfocused chat windows now still attempt the immediate SSE reconnect for the current session; only a real session switch skips the reconnect path. (Refs #3040)
+
 ## [v0.51.152] — 2026-05-28 — Release DX (stage-batch34 — single-PR optional gateway-backed browser chat)
 
 ### Added

--- a/static/messages.js
+++ b/static/messages.js
@@ -2155,7 +2155,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       // If the user has switched to a different session, don't attempt to
       // reconnect — the old stream's EventSource was closed intentionally
       // during session switch and reconnecting would leak a background stream.
-      if(!_isSessionActivelyViewed(activeSid)) return;
+      if(!_isSessionCurrentPane(activeSid)) return;
       if(_terminalStateReached || _streamFinalized){
         return;
       }

--- a/tests/test_issue3040_reattach_focus_gate.py
+++ b/tests/test_issue3040_reattach_focus_gate.py
@@ -1,0 +1,37 @@
+"""Regression coverage for #3040 item 4: visible-but-unfocused stream reattach."""
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MESSAGES_JS = (REPO_ROOT / "static" / "messages.js").read_text(encoding="utf-8")
+
+
+def _chat_error_handler() -> str:
+    return MESSAGES_JS.split("source.addEventListener('error',async e=>{", 1)[1].split(
+        "source.addEventListener('cancel'", 1
+    )[0]
+
+
+def test_visible_unfocused_current_session_still_attempts_sse_reconnect():
+    """The immediate chat SSE error path should only require current-pane ownership.
+
+    `_isSessionActivelyViewed()` also gates on document focus/visibility. Hidden tabs
+    are already deferred by `_deferStreamErrorIfPageHidden(source)`, so the direct
+    reconnect branch must not skip a visible-but-unfocused current session.
+    """
+    handler = _chat_error_handler()
+    assert "if(!_isSessionCurrentPane(activeSid)) return;" in handler
+    assert "if(!_isSessionActivelyViewed(activeSid)) return;" not in handler
+    assert handler.index("if(!_isSessionCurrentPane(activeSid)) return;") < handler.index(
+        "if(!_reconnectAttempted && streamId)"
+    )
+
+
+def test_reconnect_gate_comment_matches_current_pane_contract():
+    handler = _chat_error_handler()
+    guard_idx = handler.index("if(!_isSessionCurrentPane(activeSid)) return;")
+    comment_window = handler[max(0, guard_idx - 260):guard_idx]
+    assert "different session" in comment_window
+    assert "visible" not in comment_window.lower()
+    assert "focused" not in comment_window.lower()


### PR DESCRIPTION
## Thinking Path

- #3040 item 4 notes that the chat SSE `error` path already defers hidden tabs via `_deferStreamErrorIfPageHidden(source)`.
- After that hidden-tab deferral, the immediate reconnect gate used `_isSessionActivelyViewed(activeSid)`.
- `_isSessionActivelyViewed()` also checks focus, so a visible but unfocused current session skipped reconnect even though it had not switched sessions.
- The comment describes a session-switch guard, so the code should use `_isSessionCurrentPane(activeSid)`.

## What Changed

- Changed the immediate chat SSE reconnect gate from `_isSessionActivelyViewed(activeSid)` to `_isSessionCurrentPane(activeSid)`.
- Added regression tests pinning that visible-but-unfocused current sessions still attempt reconnect, while the guard remains before the reconnect attempt.
- Added an Unreleased changelog entry.

## Why It Matters

Current-pane ownership and document focus are different contracts. Hidden tabs are already deferred; visible but unfocused windows should still reconnect instead of falling through to an inline stream error.

## Verification

- `python3 -m pytest tests/test_issue3040_reattach_focus_gate.py tests/test_offline_banner.py tests/test_streaming_race_fix.py tests/test_inflight_stream_reuse.py -q` → 29 passed
- `git diff --check` → passed
- Added-line public marker scan for private/local terms → 0 hits

## Contract Routing

Task type: frontend SSE reconnect regression fix
Touched areas: `static/messages.js`, `tests/test_issue3040_reattach_focus_gate.py`
Relevant public docs:
- `AGENTS.md`
- `CONTRIBUTING.md`
- `docs/CONTRACTS.md`
Scope boundaries: item 4 from #3040 only; no title-language changes and no backend changes.
Evidence needed before claiming done: focused regression tests plus existing offline/streaming/reattach tests.

## Risks / Follow-ups

- This intentionally leaves background/different-session streams protected: `_isSessionCurrentPane(activeSid)` still prevents reconnect after session switch.
- #3040 title-language item 1 is covered separately by #3049. Items 2/3 should not be stacked until that title PR lands. Item 5 remains a deeper reconnect-contract regression test candidate.

## Model Used

AI-assisted with GPT-5.5 via Hermes/TARS.

Refs #3040
