### PR TITLE
fix: remove German-only fallback title override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Local fallback title generation no longer has a German-only `Session Bilder` special case; it now uses the same generic topic extraction path as other fallback titles. (Refs #3040)
+
 ## [v0.51.152] — 2026-05-28 — Release DX (stage-batch34 — single-PR optional gateway-backed browser chat)
 
 ### Added

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -1869,13 +1869,6 @@ def _fallback_title_from_exchange(user_text: str, assistant_text: str) -> Option
     assistant_text = re.sub(r'\s+', ' ', assistant_text).strip()
     combined = f"{user_text} {assistant_text}".strip().lower()
     combined_raw = f"{user_text} {assistant_text}".strip()
-    source_lang = _detect_title_language(user_text)
-
-    if source_lang == 'de' and 'bilder' in combined and 'session' in combined:
-        if 'alt' in combined or 'alte' in combined or 'alten' in combined:
-            return 'Alte Session Bilder'
-        return 'Session Bilder'
-
     def _contains_latin(text: str) -> bool:
         return bool(re.search(r'[A-Za-z]', text or ''))
 

--- a/tests/test_title_aux_routing.py
+++ b/tests/test_title_aux_routing.py
@@ -253,7 +253,7 @@ class TestGenerateTitleRawViaAuxTimeout(unittest.TestCase):
         self.assertEqual(status, 'llm_language_mismatch_aux')
         self.assertEqual(raw_preview, 'Old Session Image Display Issue')
 
-    def test_german_fallback_keeps_german_topic_words(self):
+    def test_german_fallback_uses_generic_topic_extraction_without_literal_override(self):
         from api.streaming import _fallback_title_from_exchange
 
         title = _fallback_title_from_exchange(
@@ -261,7 +261,11 @@ class TestGenerateTitleRawViaAuxTimeout(unittest.TestCase):
             'Ich prüfe die Rendering- und Attachment-Pfade im WebUI.',
         )
 
-        self.assertEqual(title, 'Alte Session Bilder')
+        self.assertIsNotNone(title)
+        self.assertIsInstance(title, str)
+        self.assertNotEqual(title, 'Alte Session Bilder')
+        self.assertNotEqual(title, 'Session Bilder')
+        self.assertIn('Warum', title)
 
     def test_configured_api_key_is_not_sent_to_caller_supplied_route(self):
         """Regression: title task keys must not leak to explicit fallback routes.


### PR DESCRIPTION
## Thinking Path

- #3040 item 2 flags the `Alte Session Bilder` / `Session Bilder` local fallback as a branch-specific German one-off.
- The LLM-side title-language prompt/validation path remains intact.
- The local fallback should not special-case one user's bug-report wording; it should use the same generic topic extraction path as other local fallback titles.

## What Changed

- Removed the German-only `bilder` + `session` fallback override from `_fallback_title_from_exchange()`.
- Updated the regression test so German fallback still returns a title but no longer returns either hardcoded literal.
- Added an Unreleased changelog entry.

## Why It Matters

This removes a user/scenario-shaped literal from a generic fallback path. The fallback remains deterministic and language-preserving enough for a local backup path, while the higher-quality LLM title path still handles matching the user's language.

## Verification

- `python3 -m pytest tests/test_title_aux_routing.py tests/test_title_sanitization.py tests/test_sprint41.py -q` → 70 passed
- `git diff --check` → passed
- Added-line public marker scan for private/local terms → 0 hits

## Contract Routing

Task type: title-generation fallback cleanup
Touched areas: `api/streaming.py`, `tests/test_title_aux_routing.py`
Relevant public docs:
- `AGENTS.md`
- `CONTRIBUTING.md`
- `docs/CONTRACTS.md`
Scope boundaries: #3040 item 2 only; no title-language marker threshold changes from #3049 and no frontend reconnect changes from #3054.
Evidence needed before claiming done: title-focused tests plus public-marker scan.

## Risks / Follow-ups

- This PR may conflict textually with #3049 because both touch `api/streaming.py` and `tests/test_title_aux_routing.py`, but the logical concern is separate: #3049 handles language detection false positives; this PR removes a fallback literal override.
- #3040 item 3 remains a policy choice: either remove the German exemplar block entirely or add examples for other shipped locales. That should wait until #3049 lands to avoid stacking prompt changes.
- #3040 item 5 is a deeper reconnect/DOM-vs-INFLIGHT contract regression candidate, not a tiny cleanup.

## Model Used

AI-assisted with GPT-5.5 via Hermes/TARS.

Refs #3040
