### PR TITLE
fix: use generic title language prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Title-generation prompts now use the same language-neutral "match the user language" instruction for every locale instead of adding German-only exemplars. (Refs #3040)
+
 ## [v0.51.152] — 2026-05-28 — Release DX (stage-batch34 — single-PR optional gateway-backed browser chat)
 
 ### Added

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -1396,13 +1396,6 @@ def _detect_title_language(text: str) -> str:
 
 
 def _title_prompt_language_rule(user_text: str) -> str:
-    lang = _detect_title_language(user_text)
-    if lang == 'de':
-        return (
-            "Match the language of the user question.\n"
-            "If the user writes German, output a German title.\n"
-            "German good: Alte Session Bilder, WebUI Attachment-Pfade, Kontextkompression Status.\n"
-        )
     return "Match the language of the user question.\n"
 
 

--- a/tests/test_title_aux_routing.py
+++ b/tests/test_title_aux_routing.py
@@ -199,7 +199,7 @@ class TestGenerateTitleRawViaAuxTimeout(unittest.TestCase):
         self.assertEqual(captured.get('api_key'), 'test-title-api-key')
 
     def test_title_prompt_requires_matching_user_language(self):
-        """German conversation starts should not invite English title output."""
+        """Conversation starts should get a language-neutral match-language instruction."""
         from api.streaming import generate_title_raw_via_aux
 
         mock_resp = types.SimpleNamespace(
@@ -227,7 +227,23 @@ class TestGenerateTitleRawViaAuxTimeout(unittest.TestCase):
         self.assertEqual(status, 'llm_aux')
         messages = captured.get('messages') or []
         self.assertIn('Match the language of the user question', messages[0]['content'])
-        self.assertIn('If the user writes German, output a German title', messages[0]['content'])
+        self.assertNotIn('If the user writes German', messages[0]['content'])
+        self.assertNotIn('German good:', messages[0]['content'])
+
+    def test_title_prompt_language_rule_is_same_for_supported_locales(self):
+        from api.streaming import _title_prompt_language_rule
+
+        expected = "Match the language of the user question.\n"
+        examples = [
+            'Warum werden hier die Bilder nicht angezeigt?',
+            'Pourquoi les images ne sont-elles pas affichées ?',
+            '¿Por qué no se muestran las imágenes?',
+            '为什么图片没有显示？',
+            'Why are the images not displayed?',
+        ]
+        for text in examples:
+            with self.subTest(text=text):
+                self.assertEqual(_title_prompt_language_rule(text), expected)
 
     def test_german_source_rejects_english_aux_title(self):
         """Regression: an English aux title must not overwrite a German conversation."""


### PR DESCRIPTION
## Thinking Path

- #3040 item 3 flags that title-generation prompts have a German-specific exemplar block while other shipped locales only get the generic match-language instruction.
- The smaller, lower-maintenance fix is to remove the German-only exemplar block and use the generic language instruction for every locale.
- Language mismatch validation remains separate and unchanged.

## What Changed

- Simplified `_title_prompt_language_rule()` to always return `Match the language of the user question.`
- Updated title prompt tests so German prompts no longer include German-only exemplar text.
- Added coverage that German, French, Spanish, Chinese, and English starts all receive the same language-neutral rule.
- Added an Unreleased changelog entry.

## Why It Matters

This removes uneven UX from the prompt path without adding a maintenance-heavy table of locale-specific examples.

## Verification

- `python3 -m pytest tests/test_title_aux_routing.py tests/test_title_sanitization.py tests/test_sprint41.py -q` → 71 passed, 5 subtests passed
- `git diff --check` → passed
- Added-line public marker scan for private/local terms → 0 hits

## Contract Routing

Task type: title-generation prompt cleanup
Touched areas: `api/streaming.py`, `tests/test_title_aux_routing.py`
Relevant public docs:
- `AGENTS.md`
- `CONTRIBUTING.md`
- `docs/CONTRACTS.md`
Scope boundaries: #3040 item 3 only; no title-language marker threshold changes from #3049 and no fallback literal changes from #3055.
Evidence needed before claiming done: title-focused tests plus locale examples showing one generic prompt rule.

## Risks / Follow-ups

- This PR touches the same file/test as #3049 and #3055, so merge order may require a trivial rebase even though the logical concern is separate.
- #3040 item 5 remains a deeper reconnect/DOM-vs-INFLIGHT contract regression candidate, not a tiny prompt cleanup.

## Model Used

AI-assisted with GPT-5.5 via Hermes/TARS.

Refs #3040
