### PR TITLE
Fix session media image rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Local `MEDIA:` image tokens in chat history now include the current session id and can render exact image paths already present in that session transcript, so agent-generated artifacts outside the active workspace no longer show as broken thumbnails while arbitrary local paths remain blocked.
+
 ## [v0.51.152] — 2026-05-28 — Release DX (stage-batch34 — single-PR optional gateway-backed browser chat)
 
 ### Added

--- a/api/routes.py
+++ b/api/routes.py
@@ -7540,6 +7540,55 @@ def _serve_inline_html_preview(handler, target: Path, cache_control: str, *, csp
     return True
 
 
+_MEDIA_TOKEN_RE = re.compile(r"MEDIA:([^\s\)\]]+)")
+
+
+def _message_content_text(content) -> str:
+    if isinstance(content, list):
+        parts = []
+        for part in content:
+            if isinstance(part, dict):
+                parts.append(str(part.get("text") or ""))
+            else:
+                parts.append(str(part or ""))
+        return "\n".join(parts)
+    return str(content or "")
+
+
+def _session_media_token_allows_image_path(sid: str, target: Path, image_mimes: set[str]) -> bool:
+    """Allow exact MEDIA:image paths already present in the requested session."""
+    sid = str(sid or "").strip()
+    if not sid:
+        return False
+    mime = MIME_MAP.get(target.suffix.lower(), "application/octet-stream")
+    if mime not in image_mimes:
+        return False
+    try:
+        target_resolved = target.resolve()
+    except Exception:
+        return False
+    try:
+        session = get_session(sid)
+    except Exception:
+        return False
+
+    for message in getattr(session, "messages", []) or []:
+        if not isinstance(message, dict):
+            continue
+        text = _message_content_text(message.get("content"))
+        if "MEDIA:" not in text:
+            continue
+        for ref in _MEDIA_TOKEN_RE.findall(text):
+            if "://" in ref:
+                continue
+            try:
+                if Path(ref).expanduser().resolve() == target_resolved:
+                    return True
+            except Exception:
+                continue
+    return False
+
+
 def _handle_media(handler, parsed):
     """Serve a local file by absolute path for inline display in the chat.
 
@@ -7611,12 +7660,21 @@ def _handle_media(handler, parsed):
                 except Exception:
                     pass
 
+    _INLINE_IMAGE_TYPES = {
+        "image/png", "image/jpeg", "image/gif", "image/webp",
+        "image/x-icon", "image/bmp",
+    }
     within_allowed = any(
         _os.path.commonpath([str(target), str(root)]) == str(root)
         for root in allowed_roots
         if root.exists()
     )
-    if not within_allowed:
+    session_media_allowed = _session_media_token_allows_image_path(
+        qs.get("session_id", [""])[0],
+        target,
+        _INLINE_IMAGE_TYPES,
+    )
+    if not within_allowed and not session_media_allowed:
         return bad(handler, "Path not in allowed location", 403)
 
     if not target.exists() or not target.is_file():
@@ -7629,10 +7687,6 @@ def _handle_media(handler, parsed):
     # Only serve safe media/PDF types inline when explicitly requested. HTML is
     # allowed inline only with a CSP sandbox so "open full page" can work without
     # granting same-origin access to the WebUI. SVG is always a download (XSS risk).
-    _INLINE_IMAGE_TYPES = {
-        "image/png", "image/jpeg", "image/gif", "image/webp",
-        "image/x-icon", "image/bmp",
-    }
     _INLINE_PREVIEW_TYPES = _INLINE_IMAGE_TYPES | {
         "audio/mpeg", "audio/wav", "audio/x-wav", "audio/mp4", "audio/aac",
         "audio/ogg", "audio/opus", "audio/flac",

--- a/static/ui.js
+++ b/static/ui.js
@@ -3419,7 +3419,8 @@ function renderMd(raw){
       return `<a href="${esc(src)}" target="_blank" rel="noopener">${esc(src)}</a>`;
     }
     // Local file path
-    const apiUrl='api/media?path='+encodeURIComponent(ref);
+    const mediaSessionId=(typeof S!=='undefined'&&S&&S.session&&S.session.session_id)?String(S.session.session_id):'';
+    const apiUrl='api/media?path='+encodeURIComponent(ref)+(mediaSessionId?'&session_id='+encodeURIComponent(mediaSessionId):'');
     const localKind=mediaKindForName(ref);
     if(localKind==='image'){
       return `<img class="msg-media-img" src="${esc(apiUrl)}" alt="${esc(ref.split('/').pop())}" loading="lazy">`;

--- a/tests/test_media_inline.py
+++ b/tests/test_media_inline.py
@@ -16,6 +16,8 @@ import os
 import pathlib
 import tempfile
 import unittest
+from types import SimpleNamespace
+from unittest import mock
 import urllib.error
 import urllib.request
 
@@ -50,6 +52,10 @@ class TestMediaRenderMdStash(unittest.TestCase):
     def test_media_api_url_pattern(self):
         self.assertIn("api/media?path=", UI_JS,
                       "renderMd must build api/media?path=... URL for local files")
+
+    def test_local_media_api_url_carries_session_id_when_available(self):
+        self.assertIn("session_id='+encodeURIComponent(mediaSessionId)", UI_JS,
+                      "local MEDIA: image URLs must include session_id so the server can authorize session-referenced artifacts")
 
     def test_local_audio_video_media_tokens_request_inline_streaming(self):
         self.assertIn("apiUrl+'&inline=1'", UI_JS,
@@ -254,6 +260,48 @@ class TestMediaEndpointUnit(unittest.TestCase):
         self.assertIn("Accept-Ranges", routes_src)
         self.assertIn("Content-Range", routes_src)
         self.assertIn("206", routes_src)
+
+    def test_session_media_token_allows_exact_image_path(self):
+        from api import routes
+
+        with tempfile.TemporaryDirectory() as tmpd:
+            image = pathlib.Path(tmpd) / "card.png"
+            image.write_bytes(b"\x89PNG\r\n\x1a\n")
+            session = SimpleNamespace(messages=[{"role": "assistant", "content": f"MEDIA:{image}"}])
+            with mock.patch.object(routes, "get_session", return_value=session):
+                self.assertTrue(
+                    routes._session_media_token_allows_image_path(
+                        "s-media", image, {"image/png"}
+                    )
+                )
+
+    def test_session_media_token_rejects_unmentioned_image_path(self):
+        from api import routes
+
+        with tempfile.TemporaryDirectory() as tmpd:
+            image = pathlib.Path(tmpd) / "card.png"
+            image.write_bytes(b"\x89PNG\r\n\x1a\n")
+            session = SimpleNamespace(messages=[{"role": "assistant", "content": "MEDIA:/tmp/other.png"}])
+            with mock.patch.object(routes, "get_session", return_value=session):
+                self.assertFalse(
+                    routes._session_media_token_allows_image_path(
+                        "s-media", image, {"image/png"}
+                    )
+                )
+
+    def test_session_media_token_rejects_non_image_path(self):
+        from api import routes
+
+        with tempfile.TemporaryDirectory() as tmpd:
+            text_file = pathlib.Path(tmpd) / "notes.txt"
+            text_file.write_text("secret", encoding="utf-8")
+            session = SimpleNamespace(messages=[{"role": "assistant", "content": f"MEDIA:{text_file}"}])
+            with mock.patch.object(routes, "get_session", return_value=session):
+                self.assertFalse(
+                    routes._session_media_token_allows_image_path(
+                        "s-media", text_file, {"image/png"}
+                    )
+                )
 
 
 # ── Integration tests: live server on TEST_PORT ───────────────────────────────


### PR DESCRIPTION
## Thinking Path

- Hermes WebUI renders agent-produced artifacts in chat via `MEDIA:` tokens.
- Local `MEDIA:/absolute/path.png` tokens are rewritten to `/api/media?path=...` so the browser can show thumbnails.
- `/api/media` correctly blocks arbitrary local paths, but it had no session-scoped allowance for exact image paths already present in the transcript.
- The result was a broken-thumbnail regression for generated images saved outside the current workspace.
- This PR keeps the broad local-path block in place while allowing exact safe image paths referenced by the requested session.

## What Changed

- Adds the current `session_id` to local `MEDIA:` image URLs generated by `renderMd()`.
- Adds a server-side session transcript check for exact local `MEDIA:` image paths.
- Keeps unmentioned paths and non-image files rejected.
- Adds focused regression coverage for allowed exact image paths, rejected unmentioned paths, rejected non-image paths, and the frontend `session_id` URL parameter.
- Updates the changelog.

## Why It Matters

Agent-generated images can live in project artifact folders outside the active WebUI workspace. Those images should render when the transcript itself explicitly references them, without expanding `/api/media` into broad home-directory access.

Closes #3063.

## Verification

- `/Users/xuefusong/hermes-webui/.venv/bin/python -m pytest tests/test_media_inline.py -q`
  - `46 passed`
- `/Users/xuefusong/hermes-webui/.venv/bin/python -m pytest tests/test_renderer_js_behaviour.py::TestRendererSanitization::test_media_token_image_uses_delegated_lightbox_not_inline_js -q`
  - `1 passed`
- Manual local runtime verification on `8787`:
  - before restart, the affected `MEDIA:` image request returned `403 Forbidden`
  - after restart, the same URL returned `206 Partial Content` with `Content-Type: image/png`
  - browser image dimensions for the four affected cards were `1080 x 1440`

## Risks / Follow-ups

- This only authorizes safe image MIME types by exact transcript reference. Audio/video/PDF/HTML local paths outside existing allowed roots remain blocked.
- The check scans persisted session messages for matching `MEDIA:` tokens; very large sessions could add a small amount of work only when a media request includes a path outside the normal allowed roots.

## Model Used

OpenAI GPT-5.3 Codex, via Codex desktop. AI assisted with diagnosis, implementation, testing, live runtime verification, issue creation, and PR preparation.
