### PR TITLE
feat(todo-state): realtime Todos panel + INFLIGHT recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 
 ## [Unreleased]
 
+### Added
+
+- Realtime Todos panel: the panel now mirrors the agent's `todo` tool state live via a dedicated `todo_state` SSE event instead of only repainting once per settled turn, with cold-load hydration on session open and INFLIGHT recovery across reload/reconnect (#3065). New `docs/rfcs/todo-state-contract.md` documents the wire format, the cold-load vs INFLIGHT reconciliation rule, the `ts` recency floor, and how it layers on the run-journal / partial-output recovery machinery.
+
+### Fixed
+
+- Todos panel no longer renders a historical task list when a context compression/rebuild strips the timestamp off the latest `todo` tool message. `derive_todo_state` now floors the cold-load `ts` to the max prior message timestamp so the latest-by-position snapshot cannot lose the recency comparison to a stale INFLIGHT snapshot, and the frontend treats a timestampless cold-load as the authoritative settled view (#3065).
+
 ## [v0.51.204] — 2026-06-01 — Release FX (stage-batch17 — project/session operations honor the session's own profile)
 
 ### Fixed

--- a/api/helpers.py
+++ b/api/helpers.py
@@ -387,6 +387,12 @@ def redact_session_data(session_dict: dict) -> dict:
         result['messages'] = _redact_value(result['messages'], _enabled=_enabled)
     if 'tool_calls' in result:
         result['tool_calls'] = _redact_value(result['tool_calls'], _enabled=_enabled)
+    # todo_state is derived from a tool result (see api/todo_state.py). The same
+    # content is redacted inside messages[] above, so the snapshot must be
+    # redacted too — otherwise the cold-load Todos panel becomes a redaction
+    # bypass for any credential an agent wrote into a todo item's content.
+    if 'todo_state' in result:
+        result['todo_state'] = _redact_value(result['todo_state'], _enabled=_enabled)
     return result
 
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -2853,6 +2853,7 @@ from api.run_journal import (
     read_run_events,
     stale_interrupted_event,
 )
+from api.todo_state import attach_todo_state
 from api.providers import get_providers, get_provider_quota, get_provider_cost_history, set_provider_key, remove_provider_key
 from api.onboarding import (
     apply_onboarding_setup,
@@ -4679,6 +4680,19 @@ def handle_get(handler, parsed) -> bool:
                         journal,
                         active=bool(getattr(s, "active_stream_id", None)),
                     )
+            # Cold-load: derive the latest todo snapshot from settled
+            # messages so opening any session (with or without an active
+            # stream) shows the current task list immediately, without
+            # waiting for the next live `todo` write. Mirrors the
+            # agent-side ``_hydrate_todo_store`` logic.
+            #
+            # Gated on ``load_messages`` — sidebar listings don't render
+            # the todos panel, and ``_all_msgs`` is intentionally empty
+            # there. The helper itself swallows derivation errors so a
+            # malformed sidecar never breaks the session GET response.
+            # See ``api/todo_state.py`` for the contract.
+            if load_messages and _all_msgs:
+                attach_todo_state(raw, _all_msgs)
             if _merged_last_message_at:
                 raw["last_message_at"] = max(
                     float(raw.get("last_message_at") or 0),
@@ -4754,6 +4768,13 @@ def handle_get(handler, parsed) -> bool:
                     "messages": msgs,
                     "tool_calls": [],
                 }
+                # CLI sessions can also carry todo writes — see the
+                # WebUI-side cold-load above. Attach the same snapshot
+                # shape so the Todos panel hydrates identically when a
+                # CLI-only session is opened from the sidebar. The
+                # helper swallows derivation errors and is a no-op when
+                # the session never invoked the todo tool.
+                attach_todo_state(sess, msgs)
                 sess = _merge_cli_sidebar_metadata(sess, cli_meta)
                 return j(handler, {"session": redact_session_data(sess)})
             return bad(handler, "Session not found", 404)

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -41,6 +41,7 @@ from api.helpers import redact_session_data, _redact_text
 from api.compression_anchor import is_context_compression_marker, visible_messages_for_anchor
 from api.metering import meter
 from api.run_journal import RunJournalWriter
+from api.todo_state import emit_todo_state
 from api.turn_journal import append_turn_journal_event_for_stream
 from api.usage import prompt_cache_hit_percent
 from api.models import (
@@ -4623,6 +4624,27 @@ def _run_agent_streaming(
                         'duration': cb_kwargs.get('duration'),
                         'is_error': bool(cb_kwargs.get('is_error', False)),
                     })
+                    # Mirror the todo tool's in-memory state into a
+                    # dedicated SSE event so the Todos panel can update
+                    # in real-time without waiting for the turn to
+                    # settle. The helper guards on name=='todo', sends
+                    # the full snapshot (idempotent under SSE replay)
+                    # and swallows internal errors so emission never
+                    # breaks tool delivery. Prefer the structured
+                    # `result` kwarg from modern Hermes builds; fall
+                    # back to the truncated `preview` only when the
+                    # callback was invoked without one (older builds).
+                    emit_todo_state(
+                        put,
+                        name=name,
+                        function_result=(
+                            cb_kwargs.get('result')
+                            if cb_kwargs.get('result') is not None
+                            else preview
+                        ),
+                        session_id=session_id,
+                        stream_id=stream_id,
+                    )
                     _tool_stats = meter().get_stats()
                     _tool_stats['session_id'] = session_id
                     _tool_stats['usage'] = _live_usage_snapshot()
@@ -4691,6 +4713,20 @@ def _run_agent_streaming(
                             'tid': tool_call_id,
                             'is_error': False,
                         })
+                        # Mirror the todo tool's in-memory state into
+                        # a dedicated SSE event so the Todos panel can
+                        # update in real-time without waiting for the
+                        # turn to settle. See the legacy path above
+                        # for the contract; the helper handles the
+                        # name guard, payload shape, and swallow-all
+                        # error policy.
+                        emit_todo_state(
+                            put,
+                            name=name,
+                            function_result=function_result,
+                            session_id=session_id,
+                            stream_id=stream_id,
+                        )
                     _tool_stats = meter().get_stats()
                     _tool_stats['session_id'] = session_id
                     _tool_stats['usage'] = _live_usage_snapshot()

--- a/api/streaming.py
+++ b/api/streaming.py
@@ -4634,6 +4634,14 @@ def _run_agent_streaming(
                     # `result` kwarg from modern Hermes builds; fall
                     # back to the truncated `preview` only when the
                     # callback was invoked without one (older builds).
+                    #
+                    # Graceful degradation on old builds: `preview` is a
+                    # truncated snippet, so its JSON is usually unparseable.
+                    # parse_todo_tool_result() then returns None and NO
+                    # todo_state event is emitted — live panel updates are
+                    # silently unavailable on pre-`result` builds. This is
+                    # intended: the panel still hydrates via cold-load on the
+                    # next session GET; it just won't update mid-stream.
                     emit_todo_state(
                         put,
                         name=name,

--- a/api/todo_state.py
+++ b/api/todo_state.py
@@ -47,7 +47,7 @@ from __future__ import annotations
 import json
 import logging
 import time
-from typing import Any, Callable, Iterable, Optional
+from typing import Any, Callable, Iterable, Optional, Sequence
 
 
 logger = logging.getLogger(__name__)
@@ -134,7 +134,8 @@ def derive_todo_state(messages: Optional[Iterable[dict]]) -> Optional[dict]:
     # always pass a list, so this branch is normally a no-op.
     if not isinstance(messages, (list, tuple)):
         messages = list(messages)
-    for msg in reversed(messages):
+    for idx in range(len(messages) - 1, -1, -1):
+        msg = messages[idx]
         if not isinstance(msg, dict) or msg.get("role") != "tool":
             continue
         content = msg.get("content", "")
@@ -146,17 +147,56 @@ def derive_todo_state(messages: Optional[Iterable[dict]]) -> Optional[dict]:
             continue
         snapshot = _normalize_snapshot(data)
         if snapshot is not None:
-            # Carry the source message timestamp so the frontend can
-            # reconcile cold-load vs. INFLIGHT snapshots by recency.
-            ts_raw = msg.get("timestamp")
-            try:
-                ts_val = float(ts_raw) if ts_raw is not None else 0.0
-            except (TypeError, ValueError):
-                ts_val = 0.0
+            # Carry a timestamp so the frontend can reconcile cold-load
+            # vs. INFLIGHT snapshots by recency.
+            #
+            # Primary source: this message's own ``timestamp``. But a
+            # todo tool message can lose its timestamp during context
+            # compression/rebuild — the on-disk message ends up with
+            # ``timestamp=None``. If we emit a snapshot with no ``ts``,
+            # the frontend reads coldTs=0 and a STALE-but-timestamped
+            # INFLIGHT snapshot wins the recency comparison, so the panel
+            # renders a historical todo list. This is the latest-by-
+            # POSITION snapshot, so it must never lose recency to an
+            # earlier list. When this message has no usable timestamp,
+            # fall back to the max timestamp seen anywhere at or before
+            # this position — guaranteeing cold ts >= any earlier todo
+            # write's ts.
+            ts_val = _message_ts_float(msg.get("timestamp"))
+            if ts_val <= 0:
+                ts_val = _max_timestamp_through(messages, idx)
             if ts_val > 0:
                 snapshot["ts"] = ts_val
             return snapshot
     return None
+
+
+def _message_ts_float(ts_raw: Any) -> float:
+    """Coerce a message ``timestamp`` field to a positive float, or 0.0."""
+    try:
+        return float(ts_raw) if ts_raw is not None else 0.0
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _max_timestamp_through(messages: "Sequence[Any]", upto_idx: int) -> float:
+    """Largest valid ``timestamp`` among messages[0:upto_idx+1].
+
+    Used as a recency floor when the latest todo message itself lost its
+    timestamp during compression/rebuild. Scanning only up to the todo's
+    position keeps the floor causally correct — it never borrows a
+    timestamp from a message that came after the todo write.
+    """
+    best = 0.0
+    end = min(upto_idx, len(messages) - 1)
+    for i in range(end, -1, -1):
+        m = messages[i]
+        if not isinstance(m, dict):
+            continue
+        ts = _message_ts_float(m.get("timestamp"))
+        if ts > best:
+            best = ts
+    return best
 
 
 def emit_todo_state(

--- a/api/todo_state.py
+++ b/api/todo_state.py
@@ -1,0 +1,235 @@
+"""Derive ``todo_state`` snapshots from tool results and settled session messages.
+
+The ``todo`` tool's in-memory store lives on the per-session AIAgent. The
+WebUI bridge needs to mirror that state to the browser in two situations:
+
+1. **Live**: when the agent calls ``todo`` mid-stream, ``api.streaming``
+   emits a dedicated ``todo_state`` SSE event so the Todos panel updates
+   without waiting for the turn to finish. See :func:`emit_todo_state`.
+
+2. **Cold-load**: when the browser opens a session (no live stream), the
+   session GET handler attaches ``todo_state`` derived from the most
+   recent ``role='tool'`` message whose JSON content carries a ``todos``
+   list. See :func:`attach_todo_state`.
+
+Both paths normalize through :func:`_normalize_snapshot` so the frontend
+has a single deserialization contract:
+
+    {
+        "todos":   [{"id": ..., "content": ..., "status": ...}, ...],
+        "summary": {"total": N, "pending": N, "in_progress": N,
+                    "completed": N, "cancelled": N},
+        "version": 1,
+    }
+
+Live SSE payloads add ``session_id``, ``stream_id``, ``source`` and ``ts``
+on top so the frontend can filter cross-session events and ignore
+out-of-order replays.
+
+**Detection symmetry with the agent.** The cold-load helper deliberately
+uses the same loose detector as ``run_agent.AIAgent._hydrate_todo_store``
+(``role='tool'`` + JSON content with ``todos: list``). If a future change
+tightens or relaxes that detector, mirror it here so the WebUI panel
+never disagrees with the agent's in-memory ``TodoStore``.
+
+**Multimodal tool results.** Some tools return content as a list of
+OpenAI/Anthropic content parts rather than a JSON string. The ``todo``
+tool always returns a JSON string, so list-shaped content cannot be a
+todo write — :func:`derive_todo_state` skips them by design.
+
+This module is **side-effect free** by design — it only parses data and
+calls a caller-supplied ``put`` callable for SSE. Routing/event-shape
+decisions live here so the call sites stay one-liners.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from typing import Any, Callable, Iterable, Optional
+
+
+logger = logging.getLogger(__name__)
+
+
+# Bumped when the on-wire payload shape changes in a non-additive way.
+# Additive fields (e.g. timestamps, tags) keep VERSION at 1.
+VERSION = 1
+
+# Single source of truth for the SSE event name and the session GET
+# payload key. Any current or future caller must reuse these so a
+# rename only happens in one place.
+EVENT_NAME = "todo_state"
+PAYLOAD_KEY = "todo_state"
+
+
+def _normalize_snapshot(data: Any) -> Optional[dict]:
+    """Return a normalized snapshot dict, or ``None`` if the payload is invalid.
+
+    Accepts the canonical ``{"todos": [...], "summary": {...}}`` shape
+    produced by ``tools.todo_tool.todo_tool``. Anything else returns
+    ``None`` so callers can fall through to legacy paths or skip
+    emission.
+
+    The detector is intentionally loose so it stays symmetric with the
+    agent's hydration logic — see the module docstring.
+    """
+    if not isinstance(data, dict):
+        return None
+    todos = data.get("todos")
+    if not isinstance(todos, list):
+        return None
+    summary = data.get("summary")
+    if not isinstance(summary, dict):
+        summary = {}
+    return {
+        "todos": todos,
+        "summary": summary,
+        "version": VERSION,
+    }
+
+
+def parse_todo_tool_result(function_result: Any) -> Optional[dict]:
+    """Parse a fresh ``todo`` tool call result into a snapshot dict.
+
+    The agent's ``todo`` handler returns a JSON string; this helper
+    accepts either that string or an already-parsed dict (defensive —
+    future callers may deserialize earlier in the pipeline).
+
+    Returns ``None`` on any parse/shape failure so the caller can
+    swallow the error without breaking the tool delivery path.
+    """
+    data: Any = function_result
+    if isinstance(function_result, str):
+        try:
+            data = json.loads(function_result)
+        except (ValueError, TypeError):
+            return None
+    return _normalize_snapshot(data)
+
+
+def derive_todo_state(messages: Optional[Iterable[dict]]) -> Optional[dict]:
+    """Derive the latest todo snapshot from settled conversation history.
+
+    Mirrors the agent-side ``_hydrate_todo_store`` logic: walk messages
+    in reverse, return the first ``role='tool'`` message whose JSON
+    content carries a ``todos`` list. Returns ``None`` when no such
+    message is found (fresh session, or a session that never invoked
+    ``todo``).
+
+    Multimodal tool results — ``content`` as a list of content parts
+    rather than a JSON string — are skipped intentionally. The ``todo``
+    tool always returns a string, so list-shaped content cannot be a
+    todo write; non-string ``content`` is therefore correct to ignore.
+
+    The fast-path string check (``'"todos"' in content``) avoids parsing
+    JSON for every tool result — most sessions have many non-todo tool
+    calls but at most a handful of todo writes.
+    """
+    if not messages:
+        return None
+    # ``reversed`` works on ``list`` and ``tuple`` natively; for any
+    # other iterable (e.g. a generator) we materialize once. Routes
+    # always pass a list, so this branch is normally a no-op.
+    if not isinstance(messages, (list, tuple)):
+        messages = list(messages)
+    for msg in reversed(messages):
+        if not isinstance(msg, dict) or msg.get("role") != "tool":
+            continue
+        content = msg.get("content", "")
+        if not isinstance(content, str) or '"todos"' not in content:
+            continue
+        try:
+            data = json.loads(content)
+        except (ValueError, TypeError):
+            continue
+        snapshot = _normalize_snapshot(data)
+        if snapshot is not None:
+            # Carry the source message timestamp so the frontend can
+            # reconcile cold-load vs. INFLIGHT snapshots by recency.
+            ts_raw = msg.get("timestamp")
+            try:
+                ts_val = float(ts_raw) if ts_raw is not None else 0.0
+            except (TypeError, ValueError):
+                ts_val = 0.0
+            if ts_val > 0:
+                snapshot["ts"] = ts_val
+            return snapshot
+    return None
+
+
+def emit_todo_state(
+    put: Callable[[str, dict], Any],
+    *,
+    name: Optional[str],
+    function_result: Any,
+    session_id: Optional[str],
+    stream_id: Optional[str],
+    source: str = "tool",
+) -> bool:
+    """Emit a ``todo_state`` SSE event when ``name == 'todo'``.
+
+    Returns ``True`` if an event was emitted, ``False`` otherwise.
+    Always swallows internal errors — emission must never break tool
+    delivery, which is the caller's primary contract.
+
+    Args:
+        put: streaming queue callback; signature ``put(event, data)``.
+        name: tool name from the callback. Skipped when not ``'todo'``.
+        function_result: raw tool result (JSON string or dict).
+        session_id: tag so the frontend can filter cross-session events.
+        stream_id: tag so SSE replay can dedupe by stream.
+        source: emission origin tag. ``'tool'`` for live tool calls;
+                future callers may use ``'compression-refresh'`` etc.
+
+    The full snapshot is always sent — idempotent re-application is safe
+    under SSE replay through the run journal.
+    """
+    if name != "todo":
+        return False
+    try:
+        snapshot = parse_todo_tool_result(function_result)
+        if snapshot is None:
+            return False
+        put(EVENT_NAME, {
+            "session_id": session_id,
+            "stream_id": stream_id,
+            "source": source,
+            "ts": time.time(),
+            **snapshot,
+        })
+        return True
+    except Exception:
+        # Per-call debug logging — a flood would mean the queue is
+        # broken, in which case the rest of the stream is already dead.
+        logger.debug("todo_state emit failed (name=%s)", name, exc_info=True)
+        return False
+
+
+def attach_todo_state(
+    payload: dict,
+    messages: Optional[Iterable[dict]],
+) -> bool:
+    """Attach a derived ``todo_state`` snapshot to a session GET response.
+
+    Mutates ``payload`` in place when a snapshot can be derived.
+    Returns ``True`` if attached, ``False`` otherwise. Always swallows
+    errors — a malformed sidecar must never break the session GET
+    response.
+
+    The caller is responsible for any higher-level gating
+    (e.g. ``load_messages``); this helper is a no-op on empty/``None``
+    ``messages`` so callers can hand it whatever message list they have.
+    """
+    if not messages:
+        return False
+    try:
+        snapshot = derive_todo_state(messages)
+        if snapshot is None:
+            return False
+        payload[PAYLOAD_KEY] = snapshot
+        return True
+    except Exception:
+        logger.debug("todo_state attach failed", exc_info=True)
+        return False

--- a/api/todo_state.py
+++ b/api/todo_state.py
@@ -74,6 +74,17 @@ def _normalize_snapshot(data: Any) -> Optional[dict]:
 
     The detector is intentionally loose so it stays symmetric with the
     agent's hydration logic — see the module docstring.
+
+    **Empty list is a valid snapshot.** ``todos == []`` returns a normal
+    snapshot (not ``None``), so the latest write wins even when it cleared
+    the list. This is deliberately symmetric with the agent: its
+    ``_hydrate_todo_store`` (run_agent.py) breaks at the most-recent todo
+    message and, because ``if last_todo_response:`` is falsy for ``[]``,
+    leaves its TodoStore empty — i.e. agent shows empty, panel shows empty.
+    Do NOT reintroduce a ``len(todos) > 0`` guard here or in the frontend
+    fallback (``_legacyTodosFromMessages``): that was the pre-Phase-2
+    behavior that kept scanning past an empty write to an older non-empty
+    list, diverging from the agent and showing a stale "cleared" list.
     """
     if not isinstance(data, dict):
         return None
@@ -199,6 +210,32 @@ def _max_timestamp_through(messages: "Sequence[Any]", upto_idx: int) -> float:
     return best
 
 
+def _redact_snapshot(snapshot: dict) -> dict:
+    """Redact credential-shaped text from a todo snapshot before it leaves the process.
+
+    The live SSE path (:func:`emit_todo_state`) does NOT pass through
+    ``redact_session_data`` (api/helpers.py) the way the cold-load session
+    GET response does, so emission must redact the same content that path
+    would — otherwise the live Todos panel (and the run-journal replay that
+    persists every SSE event) becomes a redaction bypass for any credential
+    an agent wrote into a todo item's ``content``. The live event also
+    carries the FULL untruncated todos, a wider exposure surface than the
+    truncated ``preview`` the sibling ``tool``/``tool_complete`` events send.
+
+    ``_redact_value`` is imported lazily to keep the dependency direction
+    one-way (helpers must never import todo_state) and to avoid paying the
+    import cost on the cold-load path, which redacts via ``redact_session_data``.
+
+    Returns a new, redacted snapshot. Raises on failure so the caller fails
+    closed (no emission) rather than leaking an unredacted payload.
+    """
+    from typing import cast
+    from api.helpers import _redact_value
+    # ``_redact_value`` preserves container shape (dict in → dict out); the
+    # cast narrows its broad recursive union back to dict for the type checker.
+    return cast(dict, _redact_value(snapshot))
+
+
 def emit_todo_state(
     put: Callable[[str, dict], Any],
     *,
@@ -224,7 +261,9 @@ def emit_todo_state(
                 future callers may use ``'compression-refresh'`` etc.
 
     The full snapshot is always sent — idempotent re-application is safe
-    under SSE replay through the run journal.
+    under SSE replay through the run journal. The snapshot is redacted
+    before emission (see :func:`_redact_snapshot`); if redaction fails the
+    event is dropped (fail-closed) rather than leaking an unredacted payload.
     """
     if name != "todo":
         return False
@@ -232,6 +271,7 @@ def emit_todo_state(
         snapshot = parse_todo_tool_result(function_result)
         if snapshot is None:
             return False
+        snapshot = _redact_snapshot(snapshot)
         put(EVENT_NAME, {
             "session_id": session_id,
             "stream_id": stream_id,
@@ -243,6 +283,7 @@ def emit_todo_state(
     except Exception:
         # Per-call debug logging — a flood would mean the queue is
         # broken, in which case the rest of the stream is already dead.
+        # Redaction failure also lands here and correctly drops the event.
         logger.debug("todo_state emit failed (name=%s)", name, exc_info=True)
         return False
 

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -40,6 +40,12 @@ does not change runtime behavior, maintainer policy, bot behavior, or CI gates.
   to implement those slices.
 - [`docs/rfcs/turn-journal.md`](rfcs/turn-journal.md): proposed crash-safe
   write-ahead journal for browser-originated chat turns.
+- [`docs/rfcs/todo-state-contract.md`](rfcs/todo-state-contract.md): implemented
+  contract for the realtime Todos panel — `todo_state` wire format, the cold-load
+  vs INFLIGHT reconciliation rule, the `ts` recency floor, and how it layers on
+  the run-journal / partial-output recovery machinery. Read this before touching
+  `api/todo_state.py`, the `todo_state` SSE emit/attach sites, or the frontend
+  Todos panel hydration.
 - [`docs/rfcs/README.md`](rfcs/README.md): RFC conventions and current RFC index.
 
 When a change touches streaming, recovery, replay, compression, context

--- a/docs/rfcs/todo-state-contract.md
+++ b/docs/rfcs/todo-state-contract.md
@@ -1,0 +1,190 @@
+# Todo State Contract: Realtime Todos Panel
+
+- **Status:** Implemented (PR #3065)
+- **Modules:** `api/todo_state.py`, `api/streaming.py`, `api/routes.py`, `static/ui.js`, `static/messages.js`, `static/sessions.js`, `static/panels.js`
+
+## Purpose
+
+The Todos panel mirrors the agent's `todo` tool state into the browser. This
+document pins the wire format, the two delivery channels, the reconciliation
+rule the frontend uses to pick a snapshot, and how the contract sits alongside
+the existing run-journal / partial-output recovery machinery.
+
+It is descriptive of shipped behavior, not a proposal. If the implementation and
+this document disagree, that is a bug in one of them — fix both together.
+
+## Ownership: the agent writes, the WebUI reflects
+
+There is no parallel todo store in the WebUI. The source of truth lives in the
+agent process:
+
+- `tools/todo_tool.py` defines `TodoStore` — a per-`AIAgent`, in-memory list of
+  `{id, content, status}` items.
+- `run_agent.py:_hydrate_todo_store()` rebuilds that store after a context reset
+  by reverse-scanning history for the most recent `role='tool'` message whose
+  JSON content carries a `todos` list.
+
+The WebUI pipeline is a **mirror** of that store, derived from the same signal
+(`role='tool'` + JSON `todos` list). `api/todo_state.derive_todo_state()` uses
+the same detector as the agent's `_hydrate_todo_store()`, and the module
+docstring pins that symmetry so a future change to one detector has to land in
+both. The WebUI never invents or mutates todo state — it only reflects what the
+agent already wrote.
+
+## Wire format
+
+Both channels normalize through `_normalize_snapshot()` so the frontend has a
+single decoder. `VERSION = 1` is reserved for future non-additive changes.
+
+### Cold-load (session GET payload)
+
+`GET /api/session` attaches the derived snapshot under the `todo_state` key when
+`load_messages` is set:
+
+```json
+{
+  "todos":   [{"id": "1", "content": "...", "status": "in_progress"}, ...],
+  "summary": {"total": 5, "pending": 2, "in_progress": 1,
+              "completed": 2, "cancelled": 0},
+  "version": 1,
+  "ts": 1780122043.53
+}
+```
+
+### Live (SSE event)
+
+`api/streaming.py` emits a dedicated `todo_state` SSE event whenever the `todo`
+tool completes, from both the legacy `tool_progress_callback`
+(`event_type='tool.completed'`) and the modern `on_tool_complete` path. The live
+payload adds routing/ordering metadata on top of the snapshot:
+
+```json
+{
+  "session_id": "...",
+  "stream_id":  "...",
+  "source":     "tool",
+  "ts":         1780122043.53,
+  "todos":      [...],
+  "summary":    {...},
+  "version":    1
+}
+```
+
+`EVENT_NAME` and `PAYLOAD_KEY` are defined once in `api/todo_state.py` so a
+rename stays single-source and grep-able from the frontend.
+
+### The `ts` field — recency axis
+
+`ts` is the timestamp of the source `tool` message. It exists so the frontend
+can compare the cold-load snapshot (server's settled view) against an INFLIGHT
+snapshot (locally persisted, possibly fresher) on the same axis.
+
+**Recency floor.** A context compression/rebuild can strip the `timestamp` off a
+settled message (it ends up `None` on disk). `derive_todo_state` still finds the
+correct latest todos by position, but if it emitted a snapshot with no `ts`, the
+frontend would read `coldTs = 0` and a stale-but-timestamped INFLIGHT snapshot
+would win the recency comparison — rendering a *historical* todo list. To
+prevent that, when the latest todo message has no usable timestamp,
+`derive_todo_state` floors `ts` to the maximum valid timestamp at or before that
+message's position. This guarantees the latest-by-position snapshot can never
+lose recency to an earlier todo write. The floor scans only up to the todo's
+position, so it never borrows a timestamp from a later message.
+
+## Frontend state model
+
+`static/ui.js` holds two globals as the single source of truth:
+
+- `S.todos` — the current snapshot's `todos` array.
+- `S.todoStateMeta` — `{ts, source, version}`, or `null`.
+
+`null` is a **sentinel**, distinct from "signal seen, list is empty". When
+`S.todoStateMeta` is `null`, `loadTodos()` falls through to
+`_legacyTodosFromMessages()` (reverse-scan over tool messages in `S.messages`).
+This keeps the panel working against pre-Phase-1 backends that emit no
+`todo_state`, and during the upgrade window.
+
+### Three feed channels
+
+`_hydrateTodosFromSession()` runs at every `S.session =` settle point in
+`messages.js` (3 sites) and `sessions.js` (5 sites, including delete-session
+paths that pass `null` to clear). It reconciles three inputs:
+
+1. **`todo_state` SSE event** (live) — listener in `messages.js`. Full-snapshot
+   replace, never merge. Dropped if `payload.session_id !== activeSid` or
+   `S.session.session_id !== activeSid` (cross-session double gate), or if
+   `incomingTs < currentTs` (strictly-older drop; equal-ts allowed so a
+   compression-source refresh can land on the same wall-clock second).
+2. **session GET `.todo_state`** (cold-load) — the server's settled view.
+3. **`INFLIGHT[sid]` snapshot** (reload recovery) — persisted into the
+   `localStorage` snapshot and restored on tab return / hard reload so a
+   mid-stream reload does not flicker the panel to empty.
+
+### Reconciliation rule (cold-load vs INFLIGHT)
+
+When both a cold-load snapshot and an INFLIGHT snapshot are present:
+
+| Condition | Winner | Rationale |
+|---|---|---|
+| `coldTs === 0` (cold-load carries no usable ts) | **cold-load** | The cold-load is the server's authoritative latest-by-position view; a missing ts means the source message lost its timestamp to compression, not that the snapshot is old. |
+| `coldTs > inflightTs` | **cold-load** | Server view is strictly newer. |
+| otherwise (cold-load older, or ts tie) | **INFLIGHT** | Do not regress a still-running stream with a stale cached cold-load; on a tie prefer the freshest in-tab edits. |
+
+When `coldTs === 0` and the stream is still live, the next `todo_state` SSE event
+reconciles forward — its drop guard is `incomingTs && currentTs && incomingTs <
+currentTs`, and with `currentTs = 0` that guard short-circuits to false, so the
+event is always applied. The transient is self-healing.
+
+## Render path
+
+Two cheap stages in `static/panels.js`:
+
+- `scheduleTodosRefresh()` — RAF-coalesces bursty live updates into one paint per
+  frame; skips entirely when the panel is not active (`_todosPanelIsActive()`).
+- `loadTodos()` — prefers `S.todos` when `S.todoStateMeta` is set; otherwise
+  falls through to `_legacyTodosFromMessages()`.
+
+A content-keyed hash (`_todosHash`) plus `_todosLastRenderedHash` short-circuits
+identical re-renders, including the empty-state case. All user-controlled
+strings go through `esc()` before `innerHTML`.
+
+## Interaction with run-journal / partial-output recovery
+
+The realtime Todos panel is layered on top of the existing recovery machinery;
+it does not change it.
+
+- **Run-journal whitelist.** `todo_state` is added to the SSE run-journal cursor
+  whitelist so a reconnect's `Last-Event-ID` advances past prior snapshots
+  instead of replaying every one. Replay remains correct because snapshots are
+  full and idempotent — re-applying the same snapshot is a no-op (hash
+  short-circuit). The whitelist entry just avoids pointless re-render work.
+- **INFLIGHT persistence.** The todo snapshot rides inside the existing INFLIGHT
+  `localStorage` bucket (`_compactInflightState`), under the same LRU budget and
+  staleness eviction (>10 min) as the rest of the recovery tail. It is not a new
+  persistence layer.
+- **Stream identity.** `loadInflightState` returns `null` when the reconnecting
+  stream has a different `stream_id`, so a new run cannot inherit a stale todo
+  snapshot from a previous one — the same guard the rest of recovery uses.
+- **Cold-load on reopen.** Opening any session from the sidebar hydrates the
+  panel from `attach_todo_state` without waiting for a new tool call, mirroring
+  how the agent's `_hydrate_todo_store` rebuilds its store on context reset.
+
+## Error isolation
+
+Every boundary swallows-and-degrades so todo mirroring never breaks tool
+delivery or the session GET response:
+
+| Boundary | Behavior |
+|---|---|
+| `parse_todo_tool_result` gets non-string / non-JSON / wrong shape | returns `None`; emit and attach skip |
+| `emit_todo_state` raises in `put` | swallowed, debug-logged, returns `False`; tool delivery unaffected |
+| `attach_todo_state` errors during message iteration | swallowed, returns `False`; session GET responds normally without the field |
+| frontend `JSON.parse` failure | listener returns; `S.todos` unchanged |
+| `localStorage` corrupted | `_readInflightStateMap` returns `{}`; next save rebuilds |
+| `localStorage` quota exceeded | falls back to active-session-only; if still over, clears the bucket |
+
+## Out of scope
+
+- No upstream Hermes Agent protocol change; `todo` tool semantics are unchanged.
+- No SSE infrastructure change beyond one new event name plus one journal
+  whitelist entry.
+- No persistence-layer change (still `localStorage`, not IndexedDB).

--- a/static/messages.js
+++ b/static/messages.js
@@ -1746,6 +1746,47 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       scrollIfPinned();
     });
 
+    // Phase 2: dedicated `todo_state` event carries a full snapshot of
+    // the upstream TodoStore.  We treat it as the single source of truth
+    // for the Todos panel — never merge, always replace.  The handler
+    // is intentionally cheap: parse, validate, write S.todos, mirror to
+    // INFLIGHT, schedule a RAF render.  Out-of-order events are filtered
+    // by ts; SSE journal replay is idempotent because snapshots are full.
+    // Cross-session protection mirrors every other live listener:
+    // payload.session_id must match activeSid or the event is dropped.
+    source.addEventListener('todo_state',e=>{
+      let d;
+      try{ d=JSON.parse(e.data||'{}'); }catch(_){ return; }
+      if(!d||typeof d!=='object') return;
+      // Cross-session double check: payload.session_id is the SSE-side
+      // filter (some legacy emissions omit it), and S.session.session_id
+      // is the UI-side filter (a late event that arrives after the user
+      // already navigated to another session must not pollute S.todos).
+      // Both must agree with activeSid before we touch global state.
+      if(d.session_id&&d.session_id!==activeSid) return;
+      if(!S.session||S.session.session_id!==activeSid) return;
+      if(!Array.isArray(d.todos)) return;
+      const incomingTs=Number(d.ts)||0;
+      const currentTs=(S.todoStateMeta&&Number(S.todoStateMeta.ts))||0;
+      // Strictly older snapshots are discarded; equal-ts events still
+      // apply so a compression-source refresh can land on the same
+      // second as the tool emit it follows.
+      if(incomingTs&&currentTs&&incomingTs<currentTs) return;
+      S.todos=d.todos;
+      S.todoStateMeta={
+        ts:incomingTs||(Date.now()/1000),
+        source:String(d.source||'tool'),
+        version:Number(d.version)||1,
+      };
+      const inflight=INFLIGHT[activeSid];
+      if(inflight){
+        inflight.todos=S.todos;
+        inflight.todoStateMeta=S.todoStateMeta;
+      }
+      if(typeof persistInflightState==='function') persistInflightState();
+      if(typeof scheduleTodosRefresh==='function') scheduleTodosRefresh();
+    });
+
     source.addEventListener('approval',e=>{
       const d=JSON.parse(e.data);
       showApprovalForSession(activeSid, d, 1);
@@ -1911,6 +1952,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
           const _prevCacheWrite=(S.session&&S.session.cache_write_tokens)||0;
           S.session=d.session;S.messages=_carryForwardEphemeralTurnFields(S.messages||[], d.session.messages||[]);if(typeof _messagesTruncated!=='undefined')_messagesTruncated=!!d.session._messages_truncated;
           S.messages=_filterRecoveryControlMessages(S.messages || []);
+          if(typeof _hydrateTodosFromSession==='function') _hydrateTodosFromSession(S.session);
           if(S.session&&S.session.session_id){
             try{localStorage.setItem('hermes-webui-session',S.session.session_id);}catch(_){}
             if(typeof _setActiveSessionUrl==='function') _setActiveSessionUrl(S.session.session_id);
@@ -2329,6 +2371,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
             S.session=data.session;
             const _nextMsgs3018=(data.session.messages||[]).filter(m=>m&&m.role);
             S.messages=_carryForwardEphemeralTurnFields(S.messages||[], _nextMsgs3018);
+            if(typeof _hydrateTodosFromSession==='function') _hydrateTodosFromSession(S.session);
             clearLiveToolCards();if(!assistantText)removeThinking();
             _markSessionViewed(activeSid, data.session.message_count ?? S.messages.length);
             renderMessages({preserveScroll:true});
@@ -2347,7 +2390,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
       _setActivePaneIdleIfOwner();
     });
 
-    for(const _runJournalEventName of ['token','interim_assistant','reasoning','tool','tool_complete','approval','clarify','title','title_status','context_status','goal','goal_continue','done','stream_end','pending_steer_leftover','compressing','compressed','metering','apperror','warning','error','cancel']){
+    for(const _runJournalEventName of ['token','interim_assistant','reasoning','tool','tool_complete','todo_state','approval','clarify','title','title_status','context_status','goal','goal_continue','done','stream_end','pending_steer_leftover','compressing','compressed','metering','apperror','warning','error','cancel']){
       source.addEventListener(_runJournalEventName,_rememberRunJournalCursor);
     }
   }
@@ -2426,6 +2469,7 @@ function attachLiveStream(activeSid, streamId, uploaded=[], options={}){
         const _nextMsgs3018=(session.messages||[]).filter(m=>m&&m.role);
         S.messages=_carryForwardEphemeralTurnFields(S.messages||[], _nextMsgs3018);
         S.messages=_filterRecoveryControlMessages(S.messages || []);
+        if(typeof _hydrateTodosFromSession==='function') _hydrateTodosFromSession(S.session);
         if(S.session&&S.session.session_id){
           try{localStorage.setItem('hermes-webui-session',S.session.session_id);}catch(_){}
           if(typeof _setActiveSessionUrl==='function') _setActiveSessionUrl(S.session.session_id);

--- a/static/panels.js
+++ b/static/panels.js
@@ -2647,38 +2647,86 @@ async function loadKanbanTask(taskId){
   } catch(e) { showToast(t('kanban_unavailable') + ': ' + (e.message || e), 'error'); }
 }
 
+// Phase 2: Single-source-of-truth render.
+//
+// Reads `S.todos` (set by the `todo_state` SSE listener, INFLIGHT
+// restore, or session cold-load — see _hydrateTodosFromSession in
+// ui.js).  When `S.todoStateMeta` is null we have never seen an
+// explicit signal and fall through to the legacy reverse-scan over
+// settled tool messages — this keeps the panel populated against
+// pre-Phase-1 servers and during the upgrade window.
+//
+// The render is short-circuited via `_todosLastRenderedHash` (defined
+// in ui.js): repeated emissions that yield identical DOM are no-ops.
+// Coalescing of bursty live updates happens upstream in
+// scheduleTodosRefresh().
 function loadTodos() {
   const panel = $('todoPanel');
   if (!panel) return;
-  const sourceMessages = (S.session && Array.isArray(S.session.messages) && S.session.messages.length) ? S.session.messages : S.messages;
-  // Parse the most recent todo state from message history
-  let todos = [];
-  for (let i = sourceMessages.length - 1; i >= 0; i--) {
-    const m = sourceMessages[i];
-    if (m && m.role === 'tool') {
-      try {
-        const d = JSON.parse(typeof m.content === 'string' ? m.content : JSON.stringify(m.content));
-        if (d && Array.isArray(d.todos) && d.todos.length) {
-          todos = d.todos;
-          break;
-        }
-      } catch(e) {}
-    }
+
+  let todos;
+  if (S.todoStateMeta) {
+    todos = Array.isArray(S.todos) ? S.todos : [];
+  } else {
+    todos = _legacyTodosFromMessages();
   }
+
   if (!todos.length) {
+    if (typeof _todosLastRenderedHash !== 'undefined' && _todosLastRenderedHash === '__empty__') return;
     panel.innerHTML = `<div style="color:var(--muted);font-size:12px;padding:4px 0">${esc(t('todos_no_active'))}</div>`;
+    if (typeof _todosLastRenderedHash !== 'undefined') _todosLastRenderedHash = '__empty__';
     return;
   }
+
+  if (typeof _todosHash === 'function' && typeof _todosLastRenderedHash !== 'undefined') {
+    const hash = _todosHash(todos);
+    if (hash === _todosLastRenderedHash) return;
+    _todosLastRenderedHash = hash;
+  }
+
   const statusIcon = {pending:li('square',14), in_progress:li('loader',14), completed:li('check',14), cancelled:li('x',14)};
   const statusColor = {pending:'var(--muted)', in_progress:'var(--blue)', completed:'rgba(100,200,100,.8)', cancelled:'rgba(200,100,100,.5)'};
-  panel.innerHTML = todos.map(t => `
+  // Single innerHTML join is the cheapest correct way to materialize
+  // ~10–50 leaf nodes.  All user-controlled content goes through esc().
+  panel.innerHTML = todos.map(td => `
     <div style="display:flex;align-items:flex-start;gap:10px;padding:6px 0;border-bottom:1px solid var(--border);">
-      <span style="font-size:14px;display:inline-flex;align-items:center;flex-shrink:0;margin-top:1px;color:${statusColor[t.status]||'var(--muted)'}">${statusIcon[t.status]||li('square',14)}</span>
+      <span style="font-size:14px;display:inline-flex;align-items:center;flex-shrink:0;margin-top:1px;color:${statusColor[td.status]||'var(--muted)'}">${statusIcon[td.status]||li('square',14)}</span>
       <div style="flex:1;min-width:0">
-        <div style="font-size:13px;color:${t.status==='completed'?'var(--muted)':t.status==='in_progress'?'var(--text)':'var(--text)'};${t.status==='completed'?'text-decoration:line-through;opacity:.5':''};line-height:1.4">${esc(t.content)}</div>
-        <div style="font-size:10px;color:var(--muted);margin-top:2px;opacity:.6">${esc(t.id)} · ${esc(t.status)}</div>
+        <div style="font-size:13px;color:${td.status==='completed'?'var(--muted)':td.status==='in_progress'?'var(--text)':'var(--text)'};${td.status==='completed'?'text-decoration:line-through;opacity:.5':''};line-height:1.4">${esc(td.content)}</div>
+        <div style="font-size:10px;color:var(--muted);margin-top:2px;opacity:.6">${esc(td.id)} · ${esc(td.status)}</div>
       </div>
     </div>`).join('');
+}
+
+// Legacy fallback: reverse-scan settled tool messages for the most
+// recent {"todos":[...]} payload.  Used only when no `todo_state`
+// signal has been seen for the current session — primarily during
+// upgrade windows where the server has not yet been redeployed with
+// Phase 1.  Once Phase 1 is universally deployed and a stabilization
+// period has passed, this can be removed (Phase 3).
+//
+// Variable name `sourceMessages` is preserved verbatim from the
+// original loadTodos() implementation so the matching regression
+// test (R-todo-survive-refresh in tests/test_regressions.py) keeps
+// catching any future refactor that drops the raw-session-messages
+// fallback. See the test for the exact contract.
+function _legacyTodosFromMessages() {
+  const sourceMessages = (S.session && Array.isArray(S.session.messages) && S.session.messages.length) ? S.session.messages : S.messages;
+  if (!Array.isArray(sourceMessages)) return [];
+  for (let i = sourceMessages.length - 1; i >= 0; i--) {
+    const m = sourceMessages[i];
+    if (!m || m.role !== 'tool') continue;
+    let content = m.content;
+    if (typeof content !== 'string') {
+      try { content = JSON.stringify(content); } catch (_) { continue; }
+    }
+    if (!content || content.indexOf('"todos"') < 0) continue;
+    try {
+      const d = JSON.parse(content);
+      if (d && Array.isArray(d.todos)) return d.todos;
+    } catch (_) {}
+  }
+  return [];
 }
 
 // ────────────────────────────────────────────────────────────────────────────

--- a/static/sessions.js
+++ b/static/sessions.js
@@ -519,6 +519,7 @@ async function newSession(flash, options={}){
     }
     const data=await api('/api/session/new',{method:'POST',body:JSON.stringify(reqBody)});
     S.session=data.session;S.messages=data.session.messages||[];
+    if(typeof _hydrateTodosFromSession==='function') _hydrateTodosFromSession(S.session);
     S.lastUsage={...(data.session.last_usage||{})};
     if(flash)S.session._flash=true;
     try{localStorage.setItem('hermes-webui-session',S.session.session_id);}catch(_){}
@@ -683,6 +684,7 @@ async function loadSession(sid){
   // Stale response? A newer loadSession() call has already started (#1060).
   if (_loadingSessionId !== sid) return;
   S.session=data.session;
+  if(typeof _hydrateTodosFromSession==='function') _hydrateTodosFromSession(S.session);
   S.session._modelResolutionDeferred=true;
   S.lastUsage={...(data.session.last_usage||{})};
   // Reset scroll-direction tracker on session switch so the new chat's
@@ -734,6 +736,13 @@ async function loadSession(sid){
         messages:Array.isArray(stored.messages)&&stored.messages.length?stored.messages:[],
         uploaded:Array.isArray(stored.uploaded)?stored.uploaded:[],
         toolCalls:Array.isArray(stored.toolCalls)?stored.toolCalls:[],
+        // Phase 2: restore the live todo snapshot from persisted INFLIGHT
+        // so the panel does not flicker to empty when a mid-stream
+        // browser reload reattaches before the next `todo_state` event
+        // fires.  Both fields are optional; missing values fall back to
+        // cold-load via session.todo_state.
+        todos:Array.isArray(stored.todos)?stored.todos:null,
+        todoStateMeta:stored.todoStateMeta||null,
         reattach:true,
       };
     }
@@ -753,6 +762,13 @@ async function loadSession(sid){
     if(_mergePendingSessionMessage(S.session,S.messages)){
       INFLIGHT[sid].messages=S.messages;
     }
+    // Phase 2: rehydrate todos.  S.session may already carry a fresh
+    // cold-load todo_state (preferred, since it's the server's settled
+    // view); if not, fall through to the persisted INFLIGHT snapshot
+    // restored just above.  _hydrateTodosFromSession encodes that
+    // priority and resets the render hash so the next paint actually
+    // runs.
+    if(typeof _hydrateTodosFromSession==='function') _hydrateTodosFromSession(S.session);
     S.busy=true;
     // appendLiveToolCard() is guarded by S.activeStreamId; restore it before
     // replaying persisted live tools so the compact Activity count survives
@@ -1387,6 +1403,28 @@ async function _ensureMessagesLoaded(sid) {
   if(S.session&&S.session.session_id===sid){
     S.session.message_count=Number(data.session.message_count || msgs.length);
     S.lastUsage={...(data.session.last_usage||S.lastUsage||{})};
+    // Phase 2: the messages=1 response carries the canonical cold-load
+    // `todo_state` snapshot, derived server-side from the FULL untruncated
+    // message list (api/routes.py + api/todo_state.py). The earlier
+    // messages=0 fetch in loadSession() does not include this field —
+    // attach_todo_state is gated on `load_messages`. Without applying it
+    // here, long sessions whose latest todo write falls outside the
+    // _INITIAL_MSG_LIMIT tail would lose the panel on refresh: the
+    // legacy reverse-scan in _legacyTodosFromMessages() can only see the
+    // tail S.messages, while the authoritative snapshot was already
+    // computed by the server and is sitting in this very response.
+    // _hydrateTodosFromSession is idempotent and picks newer of
+    // cold-load vs INFLIGHT by timestamp, so calling it again here is
+    // safe even when an INFLIGHT snapshot was already restored.
+    if(data.session.todo_state !== undefined){
+      S.session.todo_state = data.session.todo_state;
+    }
+    if(typeof _hydrateTodosFromSession === 'function'){
+      _hydrateTodosFromSession(S.session);
+    }
+    if(typeof scheduleTodosRefresh === 'function'){
+      scheduleTodosRefresh();
+    }
     _setSessionViewedCount(sid, Number(S.session.message_count || msgs.length));
   }
 }
@@ -1971,6 +2009,7 @@ function _renderBatchActionBar(){
       ids.forEach(_clearHandoffStorageForSession);
       if(S.session&&ids.includes(S.session.session_id)){
         S.session=null;S.messages=[];S.entries=[];localStorage.removeItem('hermes-webui-session');
+        if(typeof _hydrateTodosFromSession==='function') _hydrateTodosFromSession(null);
         const remaining=await api('/api/sessions');
         if(remaining.sessions&&remaining.sessions.length){await loadSession(remaining.sessions[0].session_id);}
         else{$('msgInner').innerHTML='';$('emptyState').style.display='';}
@@ -4941,6 +4980,7 @@ async function deleteSession(sid, beforeDelete=null){
   }
   if(S.session&&S.session.session_id===sid){
     S.session=null;S.messages=[];S.entries=[];
+    if(typeof _hydrateTodosFromSession==='function') _hydrateTodosFromSession(null);
     localStorage.removeItem('hermes-webui-session');
     // load the most recent remaining session, or show blank if none left
     const remaining=await api('/api/sessions');

--- a/static/ui.js
+++ b/static/ui.js
@@ -4663,35 +4663,42 @@ function _hydrateTodosFromSession(session){
   const inflightOk=!!(inflight&&Array.isArray(inflight.todos)&&inflight.todoStateMeta);
   const coldTs=coldOk?(Number(cold.ts)||0):0;
   const inflightTs=inflightOk?(Number(inflight.todoStateMeta&&inflight.todoStateMeta.ts)||0):0;
+  // Whether a live stream currently owns this session. This is the signal
+  // that disambiguates a ts-less cold-load (see below); it comes from the
+  // session GET payload (mirrors sessions.js `S.session.active_stream_id`).
+  const streamActive=!!(session&&session.active_stream_id);
   if(coldOk&&inflightOk){
     // Reconcile the server's settled cold-load snapshot against the
     // locally-persisted INFLIGHT snapshot.
     //
-    // coldTs===0 means the cold-load carries NO usable timestamp. This
-    // is NOT "infinitely old": derive_todo_state (api/todo_state.py)
-    // reverse-scans the FULL settled message list, so the cold-load is
-    // always the authoritative latest-by-position view. A todo tool
-    // message can legitimately lose its `timestamp` during context
-    // compression/rebuild (the on-disk message ends up timestamp=None),
-    // so derive_todo_state returns the correct latest todos but omits
-    // `ts`. The old "strict >" comparison then treated coldTs=0 as
-    // older than ANY timestamped INFLIGHT snapshot — including a STALE
-    // earlier todo list from a prior turn persisted in the same tab —
-    // so the panel showed a historical list. That is the "shows an old
-    // todo list" bug.
+    // coldTs===0 means the cold-load carries NO usable timestamp, so we
+    // cannot order it against INFLIGHT by recency. A todo tool message can
+    // legitimately lose its `timestamp` during context compression/rebuild
+    // (the on-disk message ends up timestamp=None), and derive_todo_state
+    // (api/todo_state.py) then returns the correct latest-by-POSITION todos
+    // but omits `ts`. The tie-break depends on who owns the INFLIGHT tail:
     //
-    // When coldTs===0 we trust the settled view and let cold win. If
-    // the stream is still live and a newer list is in flight, the next
-    // `todo_state` SSE event reconciles forward: its drop guard is
-    // `incomingTs && currentTs && incomingTs < currentTs`, and with
-    // currentTs=0 that guard short-circuits to false, so the event is
-    // always applied. The regression is self-healing (at most a brief
-    // flicker), which is strictly better than persistently rendering a
-    // stale list.
+    //   - stream ACTIVE → INFLIGHT is the live tail. The most recent todo
+    //     write may still be in flight and not yet settled into the message
+    //     list derive_todo_state scans, so a ts-less cold-load can be an
+    //     OLDER (pre-latest-write) view. Letting cold win here rolls the
+    //     panel back to a stale list, and since the stream may have just
+    //     ended on that very write there is no guaranteed forward SSE event
+    //     to self-heal. So prefer INFLIGHT. If cold is in fact newer, the
+    //     reattach replay (sessions.js attachLiveStream, reconnecting) re-
+    //     emits the journaled `todo_state` events which reconcile forward by
+    //     ts, so any transient discrepancy corrects itself.
     //
-    // When coldTs>0 the original recency rule stands: strict ">", and
-    // on a tie prefer INFLIGHT for the freshest in-tab edits.
-    const coldWins=(coldTs===0)||(coldTs>inflightTs);
+    //   - stream IDLE → INFLIGHT is leftover from a finished/crashed stream
+    //     (idle sessions purge it shortly after, sessions.js), and there is
+    //     no replay to correct anything. The settled cold-load is the
+    //     authoritative latest-by-position view, so prefer cold. This also
+    //     preserves the original fix for the "shows an old todo list" bug,
+    //     where a stale prior-turn INFLIGHT must not beat a ts-less cold-load.
+    //
+    // When coldTs>0 the original recency rule stands: strict ">", and on a
+    // tie prefer INFLIGHT for the freshest in-tab edits.
+    const coldWins=(coldTs===0)?(!streamActive):(coldTs>inflightTs);
     if(coldWins){
       S.todos=cold.todos;
       S.todoStateMeta={

--- a/static/ui.js
+++ b/static/ui.js
@@ -1,4 +1,11 @@
-const S={session:null,messages:[],entries:[],busy:false,pendingFiles:[],toolCalls:[],activeStreamId:null,currentDir:'.',activeProfile:'default',showHiddenWorkspaceFiles:false};
+// `todos` is the single source of truth for the Todos panel.  Any update
+// goes through the `todo_state` SSE event (live) or session.todo_state
+// (cold-load).  `todoStateMeta` doubles as a sentinel: while it is null
+// no explicit signal has been seen, so loadTodos() falls back to the
+// legacy reverse-scan over S.messages — that keeps new clients working
+// against old servers (Phase 1 may not yet be deployed everywhere).
+// See api/todo_state.py for the wire contract.
+const S={session:null,messages:[],entries:[],busy:false,pendingFiles:[],toolCalls:[],activeStreamId:null,currentDir:'.',activeProfile:'default',showHiddenWorkspaceFiles:false,todos:[],todoStateMeta:null};
 
 function assistantDisplayName(){
   if(S.activeProfile&&S.activeProfile!=='default') return S.activeProfile.charAt(0).toUpperCase()+S.activeProfile.slice(1);
@@ -4497,11 +4504,20 @@ function _compactInflightState(state){
   const limits=_getInflightStateLimits();
   const messages=Array.isArray(state.messages)?state.messages.slice(-limits.messages):[];
   const toolCalls=Array.isArray(state.toolCalls)?state.toolCalls.slice(-limits.toolCalls):[];
+  // Phase 2: persist the live todo snapshot so reload / SSE reattach
+  // restores the panel without waiting for the next live `todo` write.
+  // The list is bounded by the agent (typically <20 items) and each
+  // item is small, so no per-list cap is needed beyond the existing
+  // stringChars truncation in _truncateInflightValue.
+  const todos=Array.isArray(state.todos)?state.todos:null;
+  const todoStateMeta=(state.todoStateMeta&&typeof state.todoStateMeta==='object')?state.todoStateMeta:null;
   return _truncateInflightValue({
     streamId:state.streamId||null,
     messages,
     uploaded:Array.isArray(state.uploaded)?state.uploaded.slice(-20):[],
     toolCalls,
+    todos,
+    todoStateMeta,
   }, limits.stringChars);
 }
 function _writeInflightStateMap(all){
@@ -4561,6 +4577,147 @@ function clearInflightState(sid){
     if(Object.keys(all).length) localStorage.setItem(INFLIGHT_STATE_KEY, JSON.stringify(all));
     else localStorage.removeItem(INFLIGHT_STATE_KEY);
   }catch(_){ }
+}
+
+// ─── Todo state: single source of truth + render scheduling ─────────────────
+//
+// Three concerns live together so they can share state cleanly:
+//
+//   1. _todosHash(items)  — cheap content fingerprint; skips re-render when
+//      a snapshot would paint the same DOM.  Used both as a short-circuit
+//      and as the hash that compares "rendered vs current" snapshots.
+//
+//   2. scheduleTodosRefresh() — coalesces multiple `todo_state` events that
+//      land in the same animation frame into a single loadTodos() call.
+//      Skips work entirely when the panel is not active.
+//
+//   3. _hydrateTodosFromSession(session) — applies cold-load todo_state
+//      from the session GET payload, or clears the panel when neither a
+//      cold-load nor an INFLIGHT signal is available.  Called at every
+//      `S.session = ...` settle point so cross-session navigation never
+//      leaves a stale list visible.
+//
+// The hash is keyed on (id, content, status); the render itself uses
+// `esc()` for any user-controlled string, so XSS surface is the same as
+// any other innerHTML path in this file.
+let _todosLastRenderedHash=null;
+let _todosRenderRafId=0;
+
+function _todosHash(items){
+  if(!Array.isArray(items)) return '';
+  // String concat outperforms JSON.stringify on small arrays in V8 (no
+  // intermediate object allocation) and is exact enough — the field set
+  // matches what the renderer reads, so any visible change in DOM
+  // implies a hash change.  Field separators (\x1f, \x1e) are control
+  // chars unlikely to appear in real todo content, so collisions across
+  // boundaries are not realistic.
+  let h=items.length+'|';
+  for(let i=0;i<items.length;i++){
+    const t=items[i]||{};
+    h+=String(t.id==null?'':t.id)+'\x1f'+String(t.content==null?'':t.content)+'\x1f'+String(t.status==null?'':t.status)+'\x1e';
+  }
+  return h;
+}
+
+function _todosPanelIsActive(){
+  if(typeof document==='undefined') return false;
+  const panel=document.getElementById('panelTodos');
+  return !!(panel&&panel.classList&&panel.classList.contains('active'));
+}
+
+function scheduleTodosRefresh(){
+  // Idempotent: many `todo_state` events fire on each tool result, but
+  // only the latest snapshot needs to paint.  RAF lets us coalesce
+  // without timer drift.
+  if(_todosRenderRafId) return;
+  if(typeof requestAnimationFrame!=='function'){
+    if(typeof loadTodos==='function') loadTodos();
+    return;
+  }
+  _todosRenderRafId=requestAnimationFrame(()=>{
+    _todosRenderRafId=0;
+    if(!_todosPanelIsActive()) return;
+    if(typeof loadTodos==='function') loadTodos();
+  });
+}
+
+function _resetTodosRenderCache(){
+  // Clear after every cross-session navigation so the next render is
+  // never short-circuited against a hash from a different session.
+  _todosLastRenderedHash=null;
+}
+
+function _hydrateTodosFromSession(session){
+  // Three input cases, three deterministic outcomes:
+  //   a) cold-load AND inflight both present  → pick newer by ts so a
+  //      stale cold-load from the session GET cannot regress a fresher
+  //      INFLIGHT snapshot persisted from a still-running stream
+  //      (avoids visible rollback on reload).
+  //   b) only one of cold-load / inflight is present  → use it.
+  //   c) neither  → reset to empty + sentinel so loadTodos() falls
+  //      through to the legacy reverse-scan or paints the empty state.
+  const sid=(session&&session.session_id)||'';
+  const inflight=(typeof INFLIGHT==='object'&&INFLIGHT&&sid)?INFLIGHT[sid]:null;
+  const cold=session&&session.todo_state;
+  const coldOk=!!(cold&&Array.isArray(cold.todos));
+  const inflightOk=!!(inflight&&Array.isArray(inflight.todos)&&inflight.todoStateMeta);
+  const coldTs=coldOk?(Number(cold.ts)||0):0;
+  const inflightTs=inflightOk?(Number(inflight.todoStateMeta&&inflight.todoStateMeta.ts)||0):0;
+  if(coldOk&&inflightOk){
+    // Reconcile the server's settled cold-load snapshot against the
+    // locally-persisted INFLIGHT snapshot.
+    //
+    // coldTs===0 means the cold-load carries NO usable timestamp. This
+    // is NOT "infinitely old": derive_todo_state (api/todo_state.py)
+    // reverse-scans the FULL settled message list, so the cold-load is
+    // always the authoritative latest-by-position view. A todo tool
+    // message can legitimately lose its `timestamp` during context
+    // compression/rebuild (the on-disk message ends up timestamp=None),
+    // so derive_todo_state returns the correct latest todos but omits
+    // `ts`. The old "strict >" comparison then treated coldTs=0 as
+    // older than ANY timestamped INFLIGHT snapshot — including a STALE
+    // earlier todo list from a prior turn persisted in the same tab —
+    // so the panel showed a historical list. That is the "shows an old
+    // todo list" bug.
+    //
+    // When coldTs===0 we trust the settled view and let cold win. If
+    // the stream is still live and a newer list is in flight, the next
+    // `todo_state` SSE event reconciles forward: its drop guard is
+    // `incomingTs && currentTs && incomingTs < currentTs`, and with
+    // currentTs=0 that guard short-circuits to false, so the event is
+    // always applied. The regression is self-healing (at most a brief
+    // flicker), which is strictly better than persistently rendering a
+    // stale list.
+    //
+    // When coldTs>0 the original recency rule stands: strict ">", and
+    // on a tie prefer INFLIGHT for the freshest in-tab edits.
+    const coldWins=(coldTs===0)||(coldTs>inflightTs);
+    if(coldWins){
+      S.todos=cold.todos;
+      S.todoStateMeta={
+        ts:coldTs,
+        source:'cold-load',
+        version:Number(cold.version)||1,
+      };
+    }else{
+      S.todos=inflight.todos;
+      S.todoStateMeta=inflight.todoStateMeta;
+    }
+  }else if(coldOk){
+    S.todos=cold.todos;
+    S.todoStateMeta={
+      ts:coldTs,
+      source:'cold-load',
+      version:Number(cold.version)||1,
+    };
+  }else if(inflightOk){
+    S.todos=inflight.todos;
+    S.todoStateMeta=inflight.todoStateMeta;
+  }else{
+    S.todos=[];
+    S.todoStateMeta=null;
+  }
+  _resetTodosRenderCache();
 }
 
 function snapshotLiveTurnHtmlForSession(sid){

--- a/tests/test_phase2_e2e_scenarios.py
+++ b/tests/test_phase2_e2e_scenarios.py
@@ -1,0 +1,1105 @@
+"""End-to-end scenario coverage for the Phase 2 todo state pipeline.
+
+Each scenario drives the **real** Phase 2 JavaScript helpers extracted
+from static/ui.js, static/panels.js, and static/messages.js — there is
+no Python mirror that could disagree with the source. The driver
+provides a small high-level API (mount/emit/switch/snapshot) so each
+scenario reads as a real user flow rather than a mock-heavy unit test.
+
+Scenarios are grouped by category:
+
+  • basic_lifecycle       — first write, status transitions, clearing
+  • multi_session         — switching, deletion, cross-session events
+  • event_robustness      — out-of-order, malformed, replay, RAF coalescing
+  • user_content          — XSS, unicode, long content
+  • render_scheduling     — hidden panel, re-show, performance sanity
+  • compat_fallback       — legacy reverse-scan against pre-Phase-1 servers
+  • realistic_workflows   — full multi-step plan-then-execute flows
+  • persistence_recovery  — INFLIGHT priority, cold-load priority, reload
+
+When a scenario fails the failure surface is granular: each scenario is
+its own pytest case with the JS-side assertion text in the failure
+message.
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent.resolve()
+UI_JS = REPO_ROOT / "static" / "ui.js"
+PANELS_JS = REPO_ROOT / "static" / "panels.js"
+MESSAGES_JS = REPO_ROOT / "static" / "messages.js"
+
+NODE = shutil.which("node")
+pytestmark = pytest.mark.skipif(NODE is None, reason="node not on PATH")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# JavaScript driver
+# ─────────────────────────────────────────────────────────────────────────────
+#
+# The driver loads three real source files, extracts the Phase 2 helpers
+# we care about, and exposes a high-level scenario API. Each scenario is
+# isolated by `reset()` so leakage between tests is impossible.
+
+_DRIVER = r"""
+const fs = require('fs');
+const uiSrc      = fs.readFileSync(process.argv[1], 'utf8');
+const panelsSrc  = fs.readFileSync(process.argv[2], 'utf8');
+const messagesSrc= fs.readFileSync(process.argv[3], 'utf8');
+
+// ── DOM + global scaffolding ───────────────────────────────────────────────
+let _panelActive = false;
+let _panelInnerHTML = '';
+function makePanel() {
+  return {
+    classList: {
+      contains: (cls) => cls === 'active' && _panelActive,
+      add: () => {}, remove: () => {}, toggle: () => {},
+    },
+    set innerHTML(html) { _panelInnerHTML = html; },
+    get innerHTML() { return _panelInnerHTML; },
+  };
+}
+const _panelTodos = makePanel();
+const _todoPanel = makePanel();
+global.document = {
+  getElementById: (id) => {
+    if (id === 'panelTodos') return _panelTodos;
+    if (id === 'todoPanel') return _todoPanel;
+    return null;
+  },
+};
+global.window = {};
+global.$ = (id) => global.document.getElementById(id);
+global.esc = (s) => String(s == null ? '' : s).replace(/[&<>"']/g, c => (
+  {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
+global.t = (k) => k;
+global.li = (name, size) => `[${name}:${size||0}]`;
+
+global.S = { session:null, messages:[], todos:[], todoStateMeta:null };
+global.INFLIGHT = {};
+
+// localStorage stub for persistence-recovery scenarios.
+const _ls = new Map();
+global.localStorage = {
+  getItem: (k) => _ls.has(k) ? _ls.get(k) : null,
+  setItem: (k, v) => _ls.set(k, String(v)),
+  removeItem: (k) => _ls.delete(k),
+  clear: () => _ls.clear(),
+};
+
+// requestAnimationFrame: queue mode by default so scenarios can flush on
+// demand. We treat absent RAF as a special path tested elsewhere.
+let _rafQueue = [];
+global.requestAnimationFrame = (cb) => { _rafQueue.push(cb); return _rafQueue.length; };
+function flushRaf() {
+  // Run until quiescent: a RAF callback may schedule another (we don't
+  // expect it for todos, but defend against it).
+  let safety = 16;
+  while (_rafQueue.length && safety-- > 0) {
+    const q = _rafQueue;
+    _rafQueue = [];
+    for (const cb of q) cb();
+  }
+}
+
+// Hoist module-level state for the extracted helpers.
+let _todosLastRenderedHash = null;
+let _todosRenderRafId = 0;
+
+// ── Function extraction (same shape as test_phase2_todo_behavior.py) ──────
+function extractFunc(src, name) {
+  const re = new RegExp('function\\s+' + name + '\\s*\\(');
+  const start = src.search(re);
+  if (start < 0) throw new Error(name + ' not found');
+  let i = src.indexOf('{', start);
+  let depth = 1; i++;
+  while (depth > 0 && i < src.length) {
+    if (src[i] === '{') depth++;
+    else if (src[i] === '}') depth--;
+    i++;
+  }
+  return src.slice(start, i);
+}
+
+eval(extractFunc(uiSrc,     '_todosHash'));
+eval(extractFunc(uiSrc,     '_todosPanelIsActive'));
+eval(extractFunc(uiSrc,     'scheduleTodosRefresh'));
+eval(extractFunc(uiSrc,     '_resetTodosRenderCache'));
+eval(extractFunc(uiSrc,     '_hydrateTodosFromSession'));
+eval(extractFunc(panelsSrc, 'loadTodos'));
+eval(extractFunc(panelsSrc, '_legacyTodosFromMessages'));
+
+// todo_state listener body — extract the arrow body literally.
+function extractTodoStateHandler(src) {
+  const start = src.indexOf("addEventListener('todo_state'");
+  if (start < 0) throw new Error('todo_state listener not found');
+  const bodyStart = src.indexOf('{', src.indexOf('=>', start));
+  let depth = 1; let i = bodyStart + 1;
+  while (depth > 0 && i < src.length) {
+    if (src[i] === '{') depth++;
+    else if (src[i] === '}') depth--;
+    i++;
+  }
+  return src.slice(bodyStart + 1, i - 1);
+}
+const _handlerBody = extractTodoStateHandler(messagesSrc);
+
+// activeSid + persistInflightState are closures in messages.js — inject
+// them as named parameters so each scenario controls them explicitly.
+let activeSid = '';
+let _persistCalls = 0;
+function persistInflightState() { _persistCalls++; }
+function emitTodoStateRaw(eventLike) {
+  const fn = new Function('e','S','INFLIGHT','activeSid','persistInflightState','scheduleTodosRefresh',
+                          _handlerBody);
+  fn(eventLike, S, INFLIGHT, activeSid, persistInflightState, scheduleTodosRefresh);
+}
+
+// ── High-level scenario API ────────────────────────────────────────────────
+function reset() {
+  S.session = null;
+  S.messages = [];
+  S.todos = [];
+  S.todoStateMeta = null;
+  Object.keys(INFLIGHT).forEach(k => delete INFLIGHT[k]);
+  _todosLastRenderedHash = null;
+  _todosRenderRafId = 0;
+  _rafQueue = [];
+  _panelActive = false;
+  _panelInnerHTML = '';
+  activeSid = '';
+  _persistCalls = 0;
+  _ls.clear();
+}
+
+// Mount a session: applies cold-load + INFLIGHT priority via the same
+// _hydrateTodosFromSession helper that runs in production.  Always
+// pre-seeds an INFLIGHT entry for the active session so the live
+// listener can mirror snapshots there — mirrors what sendMessage does
+// in production when it primes INFLIGHT before the first SSE event.
+function mount(opts) {
+  opts = opts || {};
+  const sessionId = opts.sessionId || 's-default';
+  if (!INFLIGHT[sessionId]) {
+    INFLIGHT[sessionId] = {
+      todos: opts.inflight ? (opts.inflight.todos || null) : null,
+      todoStateMeta: opts.inflight ? (opts.inflight.todoStateMeta || null) : null,
+      toolCalls: [], messages: [], uploaded: [],
+    };
+  } else if (opts.inflight) {
+    if (opts.inflight.todos) INFLIGHT[sessionId].todos = opts.inflight.todos;
+    if (opts.inflight.todoStateMeta) INFLIGHT[sessionId].todoStateMeta = opts.inflight.todoStateMeta;
+  }
+  S.session = {
+    session_id: sessionId,
+    messages: opts.sessionMessages || null,
+  };
+  S.messages = opts.messages || [];
+  if (opts.todoState) S.session.todo_state = opts.todoState;
+  activeSid = sessionId;
+  _panelActive = opts.panelActive !== false;
+  _hydrateTodosFromSession(S.session);
+  if (_panelActive) loadTodos();  // initial paint
+}
+
+// Emit a todo_state SSE event for the active session.
+function emit(payload) {
+  emitTodoStateRaw({ data: JSON.stringify(payload) });
+  // Render scheduling normally awaits a frame; flush so the test can
+  // observe the result. Scenarios that specifically test the unflushed
+  // case call flushRaf() themselves with custom expectations.
+  flushRaf();
+}
+
+// Switch sessions: production runs _hydrateTodosFromSession at every
+// settle point. Mirror that flow here.  Default panelActive is true
+// when not explicitly set — production switches always render.
+function switchTo(sessionId, opts) {
+  opts = opts || {};
+  if (opts.panelActive !== undefined) _panelActive = !!opts.panelActive;
+  else if (!_panelActive) _panelActive = true;
+  S.session = {
+    session_id: sessionId,
+    messages: opts.sessionMessages || null,
+  };
+  S.messages = opts.messages || [];
+  if (opts.todoState) S.session.todo_state = opts.todoState;
+  activeSid = sessionId;
+  _hydrateTodosFromSession(S.session);
+  if (_panelActive) loadTodos();
+}
+
+function deleteSession() {
+  // Mirrors the delete-session path that calls _hydrateTodosFromSession(null).
+  S.session = null;
+  S.messages = [];
+  activeSid = '';
+  _hydrateTodosFromSession(null);
+  if (_panelActive) loadTodos();
+}
+
+function setPanelActive(active) {
+  _panelActive = !!active;
+  if (active) {
+    _resetTodosRenderCache();
+    loadTodos();
+  }
+}
+
+function snapshot() {
+  return {
+    todos: S.todos.slice(),
+    meta: S.todoStateMeta && {...S.todoStateMeta},
+    html: _panelInnerHTML,
+    inflightTodos: (INFLIGHT[activeSid] && INFLIGHT[activeSid].todos) || null,
+    persistCalls: _persistCalls,
+    pendingRaf: _rafQueue.length,
+  };
+}
+
+function eq(a, b, msg) {
+  const A = JSON.stringify(a), B = JSON.stringify(b);
+  if (A !== B) throw new Error((msg || '') + ' expected ' + B + ', got ' + A);
+}
+function ok(v, msg) { if (!v) throw new Error(msg || 'expected truthy'); }
+function notOk(v, msg) { if (v) throw new Error(msg || 'expected falsy'); }
+function htmlContains(needle, msg) {
+  if (_panelInnerHTML.indexOf(needle) < 0) {
+    throw new Error((msg || 'panel HTML must contain') + ' ' + JSON.stringify(needle) +
+                    '; actual=' + JSON.stringify(_panelInnerHTML.slice(0, 400)));
+  }
+}
+function htmlOmits(needle, msg) {
+  if (_panelInnerHTML.indexOf(needle) >= 0) {
+    throw new Error((msg || 'panel HTML must NOT contain') + ' ' + JSON.stringify(needle));
+  }
+}
+
+const results = [];
+function scenario(category, name, body) {
+  const key = category + '::' + name;
+  try {
+    reset();
+    body();
+    results.push({key, ok: true});
+  } catch (e) {
+    results.push({key, ok: false, err: String(e && e.stack || e)});
+  }
+}
+
+function makeTodo(id, content, status) {
+  return {id: String(id), content, status};
+}
+function todoPayload(todos, summary, ts) {
+  // Match the canonical shape produced by api/todo_state.py.
+  // ``ts`` is optional; the cold-load path uses it when present so the
+  // frontend can reconcile cold-load vs. INFLIGHT by recency.
+  const out = {todos, summary: summary || {total: todos.length}, version: 1};
+  if (ts !== undefined) out.ts = ts;
+  return out;
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// CATEGORY 1 — Basic lifecycle
+// ════════════════════════════════════════════════════════════════════════════
+
+scenario('basic_lifecycle', 'empty session paints empty state', () => {
+  mount();
+  htmlContains('todos_no_active', 'empty state must show the i18n key');
+});
+
+scenario('basic_lifecycle', 'first todo write paints one item', () => {
+  mount();
+  emit({ session_id: 's-default', ts: 1, source: 'tool',
+         ...todoPayload([makeTodo('1', 'plan', 'pending')]) });
+  htmlContains('plan');
+  htmlContains('pending');
+});
+
+scenario('basic_lifecycle', 'pending to in_progress transition', () => {
+  mount();
+  emit({ session_id: 's-default', ts: 1,
+         ...todoPayload([makeTodo('1','task','pending')]) });
+  htmlContains('pending');
+  emit({ session_id: 's-default', ts: 2,
+         ...todoPayload([makeTodo('1','task','in_progress')]) });
+  htmlContains('in_progress');
+});
+
+scenario('basic_lifecycle', 'in_progress to completed transition', () => {
+  mount();
+  emit({ session_id: 's-default', ts: 1,
+         ...todoPayload([makeTodo('1','task','in_progress')]) });
+  emit({ session_id: 's-default', ts: 2,
+         ...todoPayload([makeTodo('1','task','completed')]) });
+  htmlContains('completed');
+  htmlContains('text-decoration:line-through', 'completed should be struck through');
+});
+
+scenario('basic_lifecycle', 'add new item to existing list', () => {
+  mount();
+  emit({ session_id: 's-default', ts: 1,
+         ...todoPayload([makeTodo('1','first','pending')]) });
+  emit({ session_id: 's-default', ts: 2,
+         ...todoPayload([
+           makeTodo('1','first','completed'),
+           makeTodo('2','second','pending'),
+         ]) });
+  htmlContains('first');
+  htmlContains('second');
+});
+
+scenario('basic_lifecycle', 'remove item by replacing list', () => {
+  mount();
+  emit({ session_id: 's-default', ts: 1,
+         ...todoPayload([
+           makeTodo('1','one','pending'),
+           makeTodo('2','two','pending'),
+         ]) });
+  htmlContains('one'); htmlContains('two');
+  emit({ session_id: 's-default', ts: 2,
+         ...todoPayload([makeTodo('2','two','pending')]) });
+  htmlOmits('one', 'removed item must disappear');
+  htmlContains('two');
+});
+
+scenario('basic_lifecycle', 'cancelled status renders distinct style', () => {
+  mount();
+  emit({ session_id: 's-default', ts: 1,
+         ...todoPayload([makeTodo('1','abandoned','cancelled')]) });
+  htmlContains('cancelled');
+});
+
+scenario('basic_lifecycle', 'explicit empty list returns to empty state', () => {
+  mount();
+  emit({ session_id: 's-default', ts: 1,
+         ...todoPayload([makeTodo('1','xenon-task','pending')]) });
+  htmlContains('xenon-task');
+  emit({ session_id: 's-default', ts: 2, ...todoPayload([]) });
+  htmlContains('todos_no_active', 'empty list must paint empty state');
+  htmlOmits('xenon-task', 'cleared item must not linger');
+});
+
+scenario('basic_lifecycle', 'list of all completed still renders', () => {
+  // Edge case: an "everything done" snapshot should not be confused
+  // with no signal. Meta is set, list is non-empty.
+  mount();
+  emit({ session_id: 's-default', ts: 1,
+         ...todoPayload([
+           makeTodo('1','one','completed'),
+           makeTodo('2','two','completed'),
+         ]) });
+  htmlContains('one'); htmlContains('two');
+});
+
+scenario('basic_lifecycle', 'large list of 50 items renders cleanly', () => {
+  mount();
+  const items = [];
+  for (let i = 0; i < 50; i++) items.push(makeTodo(String(i), 'task ' + i, 'pending'));
+  emit({ session_id: 's-default', ts: 1, ...todoPayload(items) });
+  htmlContains('task 0');
+  htmlContains('task 49');
+  ok(_panelInnerHTML.length > 1000, 'large list should produce substantial HTML');
+});
+
+// ════════════════════════════════════════════════════════════════════════════
+// CATEGORY 2 — Multi-session navigation
+// ════════════════════════════════════════════════════════════════════════════
+
+scenario('multi_session', 'switching to fresh session clears todos', () => {
+  mount();
+  emit({ session_id: 's-default', ts: 1,
+         ...todoPayload([makeTodo('1','alpha-task','pending')]) });
+  htmlContains('alpha-task');
+  switchTo('s-fresh');
+  htmlContains('todos_no_active', 'switching to a fresh session must clear');
+  htmlOmits('alpha-task');
+});
+
+scenario('multi_session', 'switching to session with cold-load todo_state', () => {
+  mount();
+  switchTo('s-cold', {
+    todoState: todoPayload([makeTodo('99','from-server','in_progress')]),
+  });
+  htmlContains('from-server');
+  htmlContains('in_progress');
+  eq(S.todoStateMeta.source, 'cold-load');
+});
+
+scenario('multi_session', 'switching to session with INFLIGHT only', () => {
+  // Pre-seed INFLIGHT for the target session, then switch.
+  INFLIGHT['s-inflight'] = {
+    todos: [makeTodo('7','restored','pending')],
+    todoStateMeta: {ts: 50, source: 'tool', version: 1},
+    toolCalls: [], messages: [], uploaded: [],
+  };
+  switchTo('s-inflight');
+  htmlContains('restored', 'INFLIGHT must rehydrate when no cold-load');
+});
+
+scenario('multi_session', 'cold-load wins over INFLIGHT when cold ts is newer', () => {
+  INFLIGHT['s-mixed'] = {
+    todos: [makeTodo('inflight','stale','pending')],
+    todoStateMeta: {ts: 1, source: 'tool', version: 1},
+    toolCalls: [], messages: [], uploaded: [],
+  };
+  switchTo('s-mixed', {
+    todoState: todoPayload([makeTodo('cold','fresh','in_progress')], null, 100),
+  });
+  htmlContains('fresh', 'newer cold-load is the authoritative server view');
+  htmlOmits('stale');
+});
+
+scenario('multi_session', 'INFLIGHT wins over cold-load when inflight ts is newer', () => {
+  // P1: a stale cold-load (e.g. session GET cached an older snapshot)
+  // must NOT regress fresher INFLIGHT state captured by the live SSE
+  // stream. Reload of a still-running session would otherwise show a
+  // visible rollback until the next todo_state event arrives.
+  INFLIGHT['s-fresh-inflight'] = {
+    todos: [makeTodo('live','live-state','in_progress')],
+    todoStateMeta: {ts: 200, source: 'tool', version: 1},
+    toolCalls: [], messages: [], uploaded: [],
+  };
+  switchTo('s-fresh-inflight', {
+    todoState: todoPayload([makeTodo('stale','stale-cold','pending')], null, 100),
+  });
+  htmlContains('live-state', 'fresher INFLIGHT must not be regressed by stale cold-load');
+  htmlOmits('stale-cold');
+});
+
+scenario('multi_session', 'tsless cold-load beats stale timestamped INFLIGHT', () => {
+  // Regression for the "shows an old todo list" bug. When a context
+  // compression/rebuild strips the timestamp off the latest todo tool
+  // message, the server-derived cold-load carries the CORRECT latest
+  // todos but no `ts` (coldTs=0). A stale earlier todo list persisted in
+  // INFLIGHT still has a real timestamp. The old "strict >" rule made
+  // the stale INFLIGHT win (0 > 150 is false), rendering a historical
+  // list. coldTs===0 must now let the authoritative settled view win.
+  INFLIGHT['s-tsless'] = {
+    todos: [makeTodo('old','historical-list','completed')],
+    todoStateMeta: {ts: 150, source: 'tool', version: 1},
+    toolCalls: [], messages: [], uploaded: [],
+  };
+  switchTo('s-tsless', {
+    // cold-load with the current list but NO ts (compression-stripped)
+    todoState: todoPayload([makeTodo('new','current-list','in_progress')]),
+  });
+  htmlContains('current-list', 'tsless cold-load is the authoritative settled view');
+  htmlOmits('historical-list', 'stale INFLIGHT must not win when cold-load has no ts');
+  eq(S.todoStateMeta.source, 'cold-load', 'meta must reflect the cold-load win');
+});
+
+scenario('multi_session', 'session deletion clears the panel', () => {
+  mount();
+  emit({ session_id: 's-default', ts: 1,
+         ...todoPayload([makeTodo('1','toberemoved','pending')]) });
+  htmlContains('toberemoved');
+  deleteSession();
+  htmlContains('todos_no_active');
+  eq(S.todoStateMeta, null, 'meta sentinel must reset to null');
+});
+
+scenario('multi_session', 'event for session A is dropped when on session B', () => {
+  mount({sessionId: 's-A'});
+  emit({ session_id: 's-A', ts: 1,
+         ...todoPayload([makeTodo('1','a-task','pending')]) });
+  htmlContains('a-task');
+  switchTo('s-B');
+  // Spurious event from another tab/session.
+  emitTodoStateRaw({data: JSON.stringify({
+    session_id: 's-A', ts: 99,
+    ...todoPayload([makeTodo('leak','LEAKED','pending')]),
+  })});
+  flushRaf();
+  htmlOmits('LEAKED', 'cross-session event must not leak into session B');
+});
+
+scenario('multi_session', 'round-trip A -> B -> A preserves A via INFLIGHT', () => {
+  mount({sessionId: 's-A'});
+  emit({ session_id: 's-A', ts: 1,
+         ...todoPayload([makeTodo('1','a-state','pending')]) });
+  // Switching away should leave INFLIGHT for s-A populated by the
+  // earlier listener emit + persist call. Because production restores
+  // S.todos from session.todo_state OR INFLIGHT on switch back, the
+  // round-trip needs the listener to have stored the snapshot.
+  ok(INFLIGHT['s-A'] && Array.isArray(INFLIGHT['s-A'].todos),
+     'INFLIGHT for s-A must hold the live snapshot');
+  switchTo('s-B');
+  htmlContains('todos_no_active');
+  switchTo('s-A');
+  htmlContains('a-state', 'returning to s-A must restore the todo');
+});
+
+scenario('multi_session', 'switching back to session sees latest cold-load', () => {
+  // First visit primes INFLIGHT, then a server-side change is reflected
+  // via cold-load when we return.  The cold-load ts must be newer than
+  // the INFLIGHT one so the recency-aware hydrator picks it.
+  mount({sessionId: 's-A'});
+  emit({ session_id: 's-A', ts: 1,
+         ...todoPayload([makeTodo('1','old','pending')]) });
+  switchTo('s-B');
+  // Simulate the agent advancing the todo while we were on s-B.
+  switchTo('s-A', {
+    todoState: todoPayload([makeTodo('1','old','completed')], null, 200),
+  });
+  htmlContains('completed', 'cold-load must reflect server-side advance');
+});
+
+// ════════════════════════════════════════════════════════════════════════════
+// CATEGORY 3 — Event robustness
+// ════════════════════════════════════════════════════════════════════════════
+
+scenario('event_robustness', 'multiple events same frame coalesce to one paint', () => {
+  mount();
+  // Mute the auto-flush emit() does so we can observe RAF queue state.
+  emitTodoStateRaw({data: JSON.stringify({
+    session_id: 's-default', ts: 1,
+    ...todoPayload([makeTodo('1','a','pending')]),
+  })});
+  emitTodoStateRaw({data: JSON.stringify({
+    session_id: 's-default', ts: 2,
+    ...todoPayload([makeTodo('1','a','in_progress')]),
+  })});
+  emitTodoStateRaw({data: JSON.stringify({
+    session_id: 's-default', ts: 3,
+    ...todoPayload([makeTodo('1','a','completed')]),
+  })});
+  // Three emits, one queued RAF — coalesced.
+  eq(_rafQueue.length, 1, 'RAF coalescing failed');
+  flushRaf();
+  htmlContains('completed', 'final state should be the latest snapshot');
+});
+
+scenario('event_robustness', 'duplicate snapshot short-circuits render', () => {
+  mount();
+  emit({ session_id: 's-default', ts: 1,
+         ...todoPayload([makeTodo('1','x','pending')]) });
+  const html1 = _panelInnerHTML;
+  // Externally mutate the panel to detect whether a second render runs.
+  _panelInnerHTML = '__sentinel__';
+  emit({ session_id: 's-default', ts: 2,  // newer ts but same content
+         ...todoPayload([makeTodo('1','x','pending')]) });
+  eq(_panelInnerHTML, '__sentinel__',
+     'identical snapshot must short-circuit the renderer');
+});
+
+scenario('event_robustness', 'older ts event is rejected', () => {
+  mount();
+  emit({ session_id: 's-default', ts: 100,
+         ...todoPayload([makeTodo('1','newer','in_progress')]) });
+  htmlContains('newer');
+  emit({ session_id: 's-default', ts: 50,  // older
+         ...todoPayload([makeTodo('1','older','pending')]) });
+  htmlContains('newer', 'older event must not overwrite newer state');
+  htmlOmits('older');
+});
+
+scenario('event_robustness', 'equal ts is allowed (compression after tool)', () => {
+  mount();
+  emit({ session_id: 's-default', ts: 100, source: 'tool',
+         ...todoPayload([makeTodo('1','a','pending')]) });
+  emit({ session_id: 's-default', ts: 100, source: 'compression',
+         ...todoPayload([makeTodo('1','b','in_progress')]) });
+  htmlContains('b', 'equal-ts compression refresh must apply');
+});
+
+scenario('event_robustness', 'malformed JSON is silently swallowed', () => {
+  mount();
+  emit({ session_id: 's-default', ts: 1,
+         ...todoPayload([makeTodo('1','kept','pending')]) });
+  // Junk event.
+  emitTodoStateRaw({data: '{not valid json'});
+  flushRaf();
+  htmlContains('kept', 'malformed payload must not corrupt rendered state');
+});
+
+scenario('event_robustness', 'non-array todos field is rejected', () => {
+  mount();
+  emit({ session_id: 's-default', ts: 1,
+         ...todoPayload([makeTodo('1','kept','pending')]) });
+  emitTodoStateRaw({data: JSON.stringify({
+    session_id: 's-default', ts: 2,
+    todos: 'not an array',
+  })});
+  flushRaf();
+  htmlContains('kept');
+});
+
+scenario('event_robustness', 'session_id mismatch is dropped', () => {
+  mount({sessionId: 's-active'});
+  emitTodoStateRaw({data: JSON.stringify({
+    session_id: 's-OTHER', ts: 1,
+    ...todoPayload([makeTodo('leak','LEAKED','pending')]),
+  })});
+  flushRaf();
+  htmlOmits('LEAKED');
+  htmlContains('todos_no_active', 'state untouched by the wrong-session event');
+});
+
+scenario('event_robustness', 'missing session_id is accepted (legacy server)', () => {
+  // Pre-Phase-1 servers may not tag events. We only filter when the
+  // tag is present.
+  mount({sessionId: 's-active'});
+  emitTodoStateRaw({data: JSON.stringify({
+    ts: 1,
+    ...todoPayload([makeTodo('1','untagged','pending')]),
+  })});
+  flushRaf();
+  htmlContains('untagged');
+});
+
+scenario('event_robustness', 'replay of identical journal events is idempotent', () => {
+  // Simulate SSE journal replay: same snapshot delivered twice with
+  // the same ts. Production behaviour is "second is a no-op render".
+  mount();
+  emit({ session_id: 's-default', ts: 1,
+         ...todoPayload([makeTodo('1','x','pending')]) });
+  _panelInnerHTML = '__sentinel__';
+  emit({ session_id: 's-default', ts: 1,
+         ...todoPayload([makeTodo('1','x','pending')]) });
+  eq(_panelInnerHTML, '__sentinel__', 'replay must be idempotent');
+});
+
+// ════════════════════════════════════════════════════════════════════════════
+// CATEGORY 4 — User content (XSS / unicode / size)
+// ════════════════════════════════════════════════════════════════════════════
+
+scenario('user_content', 'HTML in content is escaped', () => {
+  mount();
+  emit({ session_id: 's-default', ts: 1,
+         ...todoPayload([makeTodo('1','<script>alert("xss")</script>','pending')]) });
+  htmlOmits('<script>');
+  htmlContains('&lt;script&gt;');
+});
+
+scenario('user_content', 'HTML in id is escaped', () => {
+  mount();
+  emit({ session_id: 's-default', ts: 1,
+         ...todoPayload([makeTodo('<img src=x onerror=alert(1)>','x','pending')]) });
+  htmlOmits('<img src=x');
+  htmlContains('&lt;img src=x onerror=alert(1)&gt;');
+});
+
+scenario('user_content', 'unicode + emoji content renders as-is', () => {
+  mount();
+  emit({ session_id: 's-default', ts: 1,
+         ...todoPayload([
+           makeTodo('1','研究 A股市场（行情数据）🔍','in_progress'),
+           makeTodo('2','分析 ETF 流动性📈','pending'),
+         ]) });
+  htmlContains('研究 A股市场');
+  htmlContains('🔍');
+  htmlContains('📈');
+});
+
+scenario('user_content', 'very long content does not crash renderer', () => {
+  mount();
+  const longText = 'X'.repeat(2000);
+  emit({ session_id: 's-default', ts: 1,
+         ...todoPayload([makeTodo('1', longText, 'pending')]) });
+  htmlContains('XXXXXXXXXX', 'long content must render');
+});
+
+scenario('user_content', 'quotes in content are escaped safely', () => {
+  mount();
+  emit({ session_id: 's-default', ts: 1,
+         ...todoPayload([makeTodo('1', `it's "important" & complex`, 'pending')]) });
+  htmlContains('&#39;'); // single quote
+  htmlContains('&quot;'); // double quote
+  htmlContains('&amp;');  // ampersand
+});
+
+// ════════════════════════════════════════════════════════════════════════════
+// CATEGORY 5 — Render scheduling
+// ════════════════════════════════════════════════════════════════════════════
+
+scenario('render_scheduling', 'hidden panel is not painted', () => {
+  mount({panelActive: false});
+  emit({ session_id: 's-default', ts: 1,
+         ...todoPayload([makeTodo('1','hidden','pending')]) });
+  // Panel was inactive across the whole flow.
+  notOk(_panelInnerHTML.indexOf('hidden') >= 0,
+        'inactive panel must not receive the snapshot DOM');
+});
+
+scenario('render_scheduling', 'panel re-show repaints latest snapshot', () => {
+  mount({panelActive: false});
+  emit({ session_id: 's-default', ts: 1,
+         ...todoPayload([makeTodo('1','queued','pending')]) });
+  // Now activate the panel and trigger a fresh paint via the same
+  // production path (panel-switch handler calls loadTodos()).
+  setPanelActive(true);
+  htmlContains('queued', 're-shown panel must paint the latest snapshot');
+});
+
+scenario('render_scheduling', 'large list 200 items renders bounded', () => {
+  // Catch O(n^2) regressions without flaking on slow CI hardware.
+  // We compare rendering time at two list sizes; under the linear
+  // contract, the ratio stays bounded by a small constant + warmup
+  // noise.  An O(n^2) regression would push the ratio toward 16
+  // (since 200 / 50 = 4 and 4^2 = 16).
+  mount();
+  function build(n) {
+    const items = [];
+    for (let i = 0; i < n; i++) {
+      items.push(makeTodo(String(i), 'task ' + i,
+        i % 4 === 0 ? 'completed' : 'pending'));
+    }
+    return items;
+  }
+  function measure(n) {
+    const items = build(n);
+    const start = Date.now();
+    emit({ session_id: 's-default', ts: n, ...todoPayload(items) });
+    return Math.max(1, Date.now() - start);  // floor 1ms to avoid div-by-zero
+  }
+  // Warmup so JIT noise doesn't dominate the smaller measurement.
+  measure(50);
+  const small = measure(50);
+  const large = measure(200);
+  // Linear: ratio ~4 + warmup noise.  Quadratic: ratio ~16.  We allow
+  // up to 8 to leave plenty of slack for cold caches and CI jitter.
+  const ratio = large / small;
+  ok(ratio < 8,
+     'render must scale ~linearly with list size; '
+     + 'small=' + small + 'ms large=' + large + 'ms ratio=' + ratio.toFixed(2));
+  htmlContains('task 199');
+});
+
+scenario('render_scheduling', 'rapid 100 events coalesce to one paint', () => {
+  mount();
+  // No flush mid-stream. 100 emits produce a single RAF callback.
+  for (let i = 0; i < 100; i++) {
+    emitTodoStateRaw({data: JSON.stringify({
+      session_id: 's-default', ts: i + 1,
+      ...todoPayload([makeTodo('1', 'iter ' + i, 'pending')]),
+    })});
+  }
+  eq(_rafQueue.length, 1, 'all 100 events must share one RAF tick');
+  flushRaf();
+  htmlContains('iter 99', 'final paint shows the latest snapshot only');
+});
+
+// ════════════════════════════════════════════════════════════════════════════
+// CATEGORY 6 — Compatibility / legacy fallback
+// ════════════════════════════════════════════════════════════════════════════
+
+scenario('compat_fallback', 'no signal + no messages yields empty state', () => {
+  mount({messages: []});
+  htmlContains('todos_no_active');
+});
+
+scenario('compat_fallback', 'legacy: single tool message reverse-scan', () => {
+  mount({
+    messages: [
+      {role: 'user', content: 'plan something'},
+      {role: 'assistant', content: 'sure'},
+      {role: 'tool', content: JSON.stringify({
+        todos: [makeTodo('1','legacy-task','pending')],
+      })},
+    ],
+  });
+  // S.todoStateMeta is null because we have no event/cold-load signal.
+  // loadTodos must fall through to the reverse-scan.
+  eq(S.todoStateMeta, null);
+  htmlContains('legacy-task', 'legacy fallback should populate the panel');
+});
+
+scenario('compat_fallback', 'legacy: multiple writes — newest wins', () => {
+  mount({
+    messages: [
+      {role: 'tool', content: JSON.stringify({todos: [makeTodo('1','old','completed')]})},
+      {role: 'assistant', content: 'thinking'},
+      {role: 'tool', content: JSON.stringify({todos: [makeTodo('1','new','in_progress')]})},
+    ],
+  });
+  htmlContains('new');
+  htmlOmits('old');
+});
+
+scenario('compat_fallback', 'legacy: skips non-todo tool messages', () => {
+  mount({
+    messages: [
+      {role: 'tool', content: JSON.stringify({todos: [makeTodo('1','target','pending')]})},
+      {role: 'tool', content: JSON.stringify({result: 'fs read ok'})},
+      {role: 'tool', content: JSON.stringify({output: 'shell stdout'})},
+    ],
+  });
+  htmlContains('target');
+});
+
+scenario('compat_fallback', 'legacy + first live event upgrades source-of-truth', () => {
+  // Start in legacy mode, then a Phase-1 server begins emitting events.
+  mount({
+    messages: [
+      {role: 'tool', content: JSON.stringify({todos: [makeTodo('1','legacy','pending')]})},
+    ],
+  });
+  htmlContains('legacy');
+  emit({ session_id: 's-default', ts: 1,
+         ...todoPayload([makeTodo('1','live','in_progress')]) });
+  htmlContains('live');
+  htmlOmits('legacy');
+  ok(S.todoStateMeta !== null, 'live event must promote out of legacy mode');
+});
+
+scenario('compat_fallback', 'session.messages preferred over S.messages in legacy', () => {
+  mount({
+    sessionMessages: [
+      {role: 'tool', content: JSON.stringify({todos: [makeTodo('1','session-msg','pending')]})},
+    ],
+    messages: [
+      {role: 'tool', content: JSON.stringify({todos: [makeTodo('1','top-level','pending')]})},
+    ],
+  });
+  htmlContains('session-msg');
+  htmlOmits('top-level');
+});
+
+// ════════════════════════════════════════════════════════════════════════════
+// CATEGORY 7 — Realistic workflows
+// ════════════════════════════════════════════════════════════════════════════
+
+scenario('realistic_workflows', 'plan-then-execute four-step flow', () => {
+  mount();
+  // Step 1: agent plans 4 items.
+  emit({ session_id: 's-default', ts: 1,
+         ...todoPayload([
+           makeTodo('1','setup project','pending'),
+           makeTodo('2','run tests','pending'),
+           makeTodo('3','fix failures','pending'),
+           makeTodo('4','open PR','pending'),
+         ]) });
+  htmlContains('setup project');
+
+  // Step 2..5: in_progress one at a time, then complete.
+  for (let i = 1; i <= 4; i++) {
+    const todos = [];
+    for (let k = 1; k <= 4; k++) {
+      let status = 'pending';
+      if (k < i) status = 'completed';
+      else if (k === i) status = 'in_progress';
+      todos.push(makeTodo(String(k), ['setup project','run tests','fix failures','open PR'][k-1], status));
+    }
+    emit({ session_id: 's-default', ts: i + 1, ...todoPayload(todos) });
+    htmlContains(['setup project','run tests','fix failures','open PR'][i-1]);
+  }
+
+  // Final: all completed.
+  emit({ session_id: 's-default', ts: 10,
+         ...todoPayload([
+           makeTodo('1','setup project','completed'),
+           makeTodo('2','run tests','completed'),
+           makeTodo('3','fix failures','completed'),
+           makeTodo('4','open PR','completed'),
+         ]) });
+  // All four completed lines must be struck through.
+  const struck = (_panelInnerHTML.match(/text-decoration:line-through/g) || []).length;
+  eq(struck, 4, 'four completed items should each render strikethrough');
+});
+
+scenario('realistic_workflows', 'plan revision: cancel one + add new', () => {
+  mount();
+  emit({ session_id: 's-default', ts: 1,
+         ...todoPayload([
+           makeTodo('1','approach A','in_progress'),
+           makeTodo('2','approach B','pending'),
+         ]) });
+  // User decides A is wrong; agent cancels A, picks B, adds C.
+  emit({ session_id: 's-default', ts: 2,
+         ...todoPayload([
+           makeTodo('1','approach A','cancelled'),
+           makeTodo('2','approach B','in_progress'),
+           makeTodo('3','approach C','pending'),
+         ]) });
+  htmlContains('cancelled');
+  htmlContains('approach C');
+});
+
+scenario('realistic_workflows', 'long burst: 20 tools then todo write', () => {
+  // Real session shape: agent does many tool calls before/after a todo
+  // write. Only the todo write affects the panel; non-todo events do
+  // not even reach this listener.
+  mount();
+  for (let i = 0; i < 20; i++) {
+    // These would be 'tool' events in production; we only simulate
+    // the todo_state subset of the SSE traffic relevant to this panel.
+  }
+  emit({ session_id: 's-default', ts: 1,
+         ...todoPayload([makeTodo('1','final task','in_progress')]) });
+  htmlContains('final task');
+});
+
+// ════════════════════════════════════════════════════════════════════════════
+// CATEGORY 8 — Persistence + recovery
+// ════════════════════════════════════════════════════════════════════════════
+
+scenario('persistence_recovery', 'live emit triggers persistInflightState', () => {
+  mount();
+  INFLIGHT['s-default'] = {todos: null, todoStateMeta: null,
+                           toolCalls: [], messages: [], uploaded: []};
+  const before = _persistCalls;
+  emit({ session_id: 's-default', ts: 1,
+         ...todoPayload([makeTodo('1','x','pending')]) });
+  ok(_persistCalls > before, 'persistInflightState must run on each live emit');
+});
+
+scenario('persistence_recovery', 'INFLIGHT mirror has the latest snapshot', () => {
+  mount();
+  INFLIGHT['s-default'] = {todos: null, todoStateMeta: null,
+                           toolCalls: [], messages: [], uploaded: []};
+  emit({ session_id: 's-default', ts: 1,
+         ...todoPayload([makeTodo('1','live','in_progress')]) });
+  ok(Array.isArray(INFLIGHT['s-default'].todos),
+     'INFLIGHT.todos must mirror the live snapshot');
+  eq(INFLIGHT['s-default'].todos[0].id, '1');
+  ok(INFLIGHT['s-default'].todoStateMeta !== null);
+});
+
+scenario('persistence_recovery', 'reload simulation restores via INFLIGHT', () => {
+  // Phase-1 of a "reload" cycle: live state is captured into INFLIGHT.
+  mount();
+  INFLIGHT['s-active'] = {todos: null, todoStateMeta: null,
+                          toolCalls: [], messages: [], uploaded: []};
+  S.session.session_id = 's-active'; activeSid = 's-active';
+  emit({ session_id: 's-active', ts: 1,
+         ...todoPayload([makeTodo('1','before-reload','in_progress')]) });
+
+  // Phase-2: simulate the page reload by clearing in-memory S, then
+  // re-mounting from cold-load + INFLIGHT.
+  const persisted = JSON.parse(JSON.stringify(INFLIGHT['s-active']));
+  S.todos = []; S.todoStateMeta = null; S.session = null; activeSid = '';
+  // Re-pre-seed INFLIGHT (mimicking loadInflightState).
+  INFLIGHT['s-active'] = persisted;
+
+  switchTo('s-active');  // No cold-load; INFLIGHT must rehydrate.
+  htmlContains('before-reload',
+               'reload-then-reattach must restore via INFLIGHT');
+});
+
+// ── Final report ──────────────────────────────────────────────────────────
+console.log('__BEGIN_RESULTS__');
+console.log(JSON.stringify(results));
+console.log('__END_RESULTS__');
+"""
+
+
+def _run_driver():
+    assert NODE is not None
+    proc = subprocess.run(
+        [NODE, "-e", _DRIVER, str(UI_JS), str(PANELS_JS), str(MESSAGES_JS)],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"driver exited {proc.returncode}\n"
+            f"STDOUT:\n{proc.stdout}\n\nSTDERR:\n{proc.stderr}"
+        )
+    out = proc.stdout
+    begin = out.index("__BEGIN_RESULTS__")
+    end = out.index("__END_RESULTS__")
+    payload = out[begin:end].split("\n", 1)[1].strip()
+    return json.loads(payload)
+
+
+@pytest.fixture(scope="module")
+def scenarios():
+    return _run_driver()
+
+
+# Scenario keys are declared up-front so pytest can parametrize at
+# collection time. If a scenario disappears from the driver output, the
+# `test_all_declared_scenarios_ran` guard surfaces it.
+_DECLARED = [
+    # basic_lifecycle
+    "basic_lifecycle::empty session paints empty state",
+    "basic_lifecycle::first todo write paints one item",
+    "basic_lifecycle::pending to in_progress transition",
+    "basic_lifecycle::in_progress to completed transition",
+    "basic_lifecycle::add new item to existing list",
+    "basic_lifecycle::remove item by replacing list",
+    "basic_lifecycle::cancelled status renders distinct style",
+    "basic_lifecycle::explicit empty list returns to empty state",
+    "basic_lifecycle::list of all completed still renders",
+    "basic_lifecycle::large list of 50 items renders cleanly",
+    # multi_session
+    "multi_session::switching to fresh session clears todos",
+    "multi_session::switching to session with cold-load todo_state",
+    "multi_session::switching to session with INFLIGHT only",
+    "multi_session::cold-load wins over INFLIGHT when cold ts is newer",
+    "multi_session::INFLIGHT wins over cold-load when inflight ts is newer",
+    "multi_session::tsless cold-load beats stale timestamped INFLIGHT",
+    "multi_session::session deletion clears the panel",
+    "multi_session::event for session A is dropped when on session B",
+    "multi_session::round-trip A -> B -> A preserves A via INFLIGHT",
+    "multi_session::switching back to session sees latest cold-load",
+    # event_robustness
+    "event_robustness::multiple events same frame coalesce to one paint",
+    "event_robustness::duplicate snapshot short-circuits render",
+    "event_robustness::older ts event is rejected",
+    "event_robustness::equal ts is allowed (compression after tool)",
+    "event_robustness::malformed JSON is silently swallowed",
+    "event_robustness::non-array todos field is rejected",
+    "event_robustness::session_id mismatch is dropped",
+    "event_robustness::missing session_id is accepted (legacy server)",
+    "event_robustness::replay of identical journal events is idempotent",
+    # user_content
+    "user_content::HTML in content is escaped",
+    "user_content::HTML in id is escaped",
+    "user_content::unicode + emoji content renders as-is",
+    "user_content::very long content does not crash renderer",
+    "user_content::quotes in content are escaped safely",
+    # render_scheduling
+    "render_scheduling::hidden panel is not painted",
+    "render_scheduling::panel re-show repaints latest snapshot",
+    "render_scheduling::large list 200 items renders bounded",
+    "render_scheduling::rapid 100 events coalesce to one paint",
+    # compat_fallback
+    "compat_fallback::no signal + no messages yields empty state",
+    "compat_fallback::legacy: single tool message reverse-scan",
+    "compat_fallback::legacy: multiple writes — newest wins",
+    "compat_fallback::legacy: skips non-todo tool messages",
+    "compat_fallback::legacy + first live event upgrades source-of-truth",
+    "compat_fallback::session.messages preferred over S.messages in legacy",
+    # realistic_workflows
+    "realistic_workflows::plan-then-execute four-step flow",
+    "realistic_workflows::plan revision: cancel one + add new",
+    "realistic_workflows::long burst: 20 tools then todo write",
+    # persistence_recovery
+    "persistence_recovery::live emit triggers persistInflightState",
+    "persistence_recovery::INFLIGHT mirror has the latest snapshot",
+    "persistence_recovery::reload simulation restores via INFLIGHT",
+]
+
+
+def _id(key):
+    return key.replace("::", "__").replace(" ", "_").replace("-", "_").replace(":", "")
+
+
+@pytest.mark.parametrize("key", _DECLARED, ids=_id)
+def test_scenario(scenarios, key):
+    matches = [r for r in scenarios if r["key"] == key]
+    assert matches, f"scenario {key!r} missing from driver output"
+    r = matches[0]
+    assert r["ok"], f"{key}\n  {r.get('err','(no detail)')}"
+
+
+def test_all_declared_scenarios_ran(scenarios):
+    """Drift-detector: declared keys must equal driver-reported keys."""
+    declared = set(_DECLARED)
+    actual = {r["key"] for r in scenarios}
+    missing = declared - actual
+    extra = actual - declared
+    assert not missing and not extra, (
+        f"\n  missing from driver output: {sorted(missing)}\n"
+        f"  not in _DECLARED:           {sorted(extra)}"
+    )

--- a/tests/test_phase2_frontend_static.py
+++ b/tests/test_phase2_frontend_static.py
@@ -1,0 +1,532 @@
+"""Static wiring checks for the Phase 2 todo_state frontend.
+
+Each test pins one design *decision* to its source location so a future
+refactor that drops a critical guard surfaces here rather than as a
+silent UI regression.
+
+Design intent: pin behaviour, not formatting.  Earlier review flagged the
+original tests as too brittle on whitespace, exact source shape, and
+function signature pinning.  This rewrite uses tolerant matching:
+
+* whitespace inside expressions is normalised before comparison,
+* function bodies are extracted by name + balanced-brace scan rather
+  than literal "function X(args){" splits,
+* identifier presence is preferred over operator-tight regexes.
+
+A test should fail when a *capability* is removed (e.g. session-id
+filtering disappears) and pass when only formatting / argument names
+change.  Source files exercised:
+
+  - static/ui.js        (S.todos, _compactInflightState, hash + RAF,
+                         _hydrateTodosFromSession)
+  - static/messages.js  (todo_state listener, run journal whitelist,
+                         settle-point hydration)
+  - static/sessions.js  (INFLIGHT restore schema, settle-point hydration)
+  - static/panels.js    (loadTodos single-source-of-truth + legacy
+                         fallback)
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).parent.parent
+UI_JS = ROOT / "static" / "ui.js"
+MESSAGES_JS = ROOT / "static" / "messages.js"
+SESSIONS_JS = ROOT / "static" / "sessions.js"
+PANELS_JS = ROOT / "static" / "panels.js"
+
+
+def _read(p):
+    return p.read_text(encoding="utf-8")
+
+
+def _strip_ws(s: str) -> str:
+    """Collapse all whitespace so format-only changes don't break tests."""
+    return re.sub(r"\s+", "", s)
+
+
+def _extract_function_body(src: str, name: str) -> str:
+    """Return the body of `function <name>(...) { ... }`.
+
+    Tolerates whitespace around the name, parameter list, and opening
+    brace so signature reformatting doesn't break tests.  Raises
+    AssertionError with a clear message if the function is missing —
+    that is itself a meaningful regression.
+    """
+    pat = re.compile(r"function\s+" + re.escape(name) + r"\s*\([^)]*\)\s*\{")
+    m = pat.search(src)
+    assert m, f"function {name}(...) not found"
+    start = m.end()  # position of first char inside body
+    depth = 1
+    i = start
+    while depth > 0 and i < len(src):
+        c = src[i]
+        if c == "{":
+            depth += 1
+        elif c == "}":
+            depth -= 1
+            if depth == 0:
+                return src[start:i]
+        i += 1
+    raise AssertionError(f"function {name} body unterminated")
+
+
+# ---------------------------------------------------------------------------
+# State model — ui.js
+# ---------------------------------------------------------------------------
+
+
+class TestStateModel:
+    def test_S_initialises_todos_array(self):
+        # Match `todos: []` regardless of whitespace.  The empty array
+        # doubles as a safe default for callers that read S.todos before
+        # any signal has arrived.
+        src = _strip_ws(_read(UI_JS))
+        assert "todos:[]" in src, "S must initialise todos to []"
+
+    def test_S_initialises_todoStateMeta_null_sentinel(self):
+        # null is a sentinel: while null, no explicit signal has been
+        # seen, so loadTodos() falls through to the legacy reverse-scan.
+        src = _strip_ws(_read(UI_JS))
+        assert "todoStateMeta:null" in src, (
+            "S must initialise todoStateMeta to null so loadTodos can "
+            "distinguish 'never received a signal' from 'received empty list'."
+        )
+
+    def test_compact_inflight_state_persists_todos(self):
+        body = _extract_function_body(_read(UI_JS), "_compactInflightState")
+        # Both fields must be persisted; either omission breaks reload
+        # recovery for the panel.
+        compact = _strip_ws(body)
+        assert "todos:" in compact and "todoStateMeta:" in compact, (
+            "_compactInflightState must persist todos and todoStateMeta "
+            "into the localStorage snapshot."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Hash + RAF + hydrate helpers — ui.js
+# ---------------------------------------------------------------------------
+
+
+class TestHashAndScheduling:
+    def test_hash_function_exists(self):
+        # Tolerant: function exists with any parameter name.
+        assert re.search(r"function\s+_todosHash\s*\(", _read(UI_JS)), (
+            "_todosHash must exist; it short-circuits no-op renders."
+        )
+
+    def test_hash_separates_id_content_status(self):
+        body = _extract_function_body(_read(UI_JS), "_todosHash")
+        # All three fields must contribute to the hash; otherwise a
+        # status-only transition (pending -> in_progress) would silently
+        # be skipped because the hash would not change.  We check field
+        # *names* are referenced; the exact accessor (t.id, item['id'],
+        # destructure) doesn't matter.
+        assert ".id" in body or "['id']" in body or '["id"]' in body, "hash must read id"
+        assert ".content" in body or "['content']" in body or '["content"]' in body, "hash must read content"
+        assert ".status" in body or "['status']" in body or '["status"]' in body, "hash must read status"
+
+    def test_hash_uses_low_overhead_concat(self):
+        body = _extract_function_body(_read(UI_JS), "_todosHash")
+        # Strip line comments — the comment itself mentions JSON.stringify
+        # deliberately to explain *why* the implementation avoids it.
+        code_lines = []
+        for ln in body.split("\n"):
+            stripped = ln.lstrip()
+            if stripped.startswith("//"):
+                continue
+            code_lines.append(ln)
+        code = "\n".join(code_lines)
+        # JSON.stringify allocates intermediate objects per call — for
+        # bursty events this is GC pressure.  Concat-based hash avoids it.
+        assert "JSON.stringify" not in code, (
+            "_todosHash must avoid JSON.stringify so live updates do not "
+            "create per-event GC pressure."
+        )
+
+    def test_schedule_uses_raf_with_idempotency_guard(self):
+        body = _extract_function_body(_read(UI_JS), "scheduleTodosRefresh")
+        assert "_todosRenderRafId" in body, (
+            "scheduleTodosRefresh must guard against re-entry so multiple "
+            "events in the same frame coalesce to one render."
+        )
+        assert "requestAnimationFrame" in body, (
+            "scheduleTodosRefresh must use requestAnimationFrame to "
+            "coalesce bursty live updates into a single paint."
+        )
+
+    def test_schedule_skips_when_panel_inactive(self):
+        body = _extract_function_body(_read(UI_JS), "scheduleTodosRefresh")
+        # Inside the RAF callback we re-check active state — the panel
+        # may have been switched away in the same frame.
+        assert "_todosPanelIsActive" in body, (
+            "scheduleTodosRefresh must short-circuit when the Todos "
+            "panel is not active so background events do no DOM work."
+        )
+
+    def test_schedule_falls_back_when_raf_missing(self):
+        body = _extract_function_body(_read(UI_JS), "scheduleTodosRefresh")
+        # In test/Node environments without raf we must still render.
+        # Tolerate any equivalent form: typeof !== 'function' / != / etc.
+        compact = _strip_ws(body)
+        assert "typeofrequestAnimationFrame" in compact, (
+            "scheduleTodosRefresh must check typeof requestAnimationFrame "
+            "so a synchronous fallback runs when raf is unavailable."
+        )
+
+    def test_hydrate_function_exists(self):
+        assert re.search(
+            r"function\s+_hydrateTodosFromSession\s*\(", _read(UI_JS)
+        ), "_hydrateTodosFromSession must exist"
+
+    def test_hydrate_reconciles_inflight_and_cold_load(self):
+        # P1-2: hydrate must consider BOTH cold-load and INFLIGHT and
+        # reconcile by recency rather than letting one side blindly win.
+        # Behavioural correctness is covered by test_phase2_todo_behavior;
+        # here we only pin that the function reads from both sources and
+        # compares timestamps.
+        body = _extract_function_body(_read(UI_JS), "_hydrateTodosFromSession")
+        compact = _strip_ws(body)
+        assert "session.todo_state" in compact or "todo_state" in body, (
+            "hydrate must read session.todo_state (the cold-load snapshot)."
+        )
+        assert "INFLIGHT" in body, (
+            "hydrate must read INFLIGHT (the live persisted snapshot)."
+        )
+        # ts comparison evidence: the function references `ts` from both
+        # sides somewhere in the body.  We don't pin operator shape.
+        assert body.count(".ts") >= 2 or compact.count("ts:") >= 2, (
+            "hydrate must compare timestamps from cold-load and INFLIGHT "
+            "to pick the newer snapshot (P1-2 recency reconciliation)."
+        )
+
+    def test_hydrate_resets_render_cache(self):
+        body = _extract_function_body(_read(UI_JS), "_hydrateTodosFromSession")
+        assert "_resetTodosRenderCache" in body, (
+            "_hydrateTodosFromSession must reset the render hash on "
+            "cross-session navigation so stale hashes from the previous "
+            "session do not short-circuit the next render."
+        )
+
+
+# ---------------------------------------------------------------------------
+# SSE listener — messages.js
+# ---------------------------------------------------------------------------
+
+
+def _todo_state_listener_body(src: str) -> str:
+    """Extract the body of source.addEventListener('todo_state', e=>{...})."""
+    m = re.search(r"addEventListener\(\s*['\"]todo_state['\"]", src)
+    assert m, "todo_state listener registration not found"
+    # Find the arrow body opening brace after this position.
+    arrow = src.find("=>", m.end())
+    assert arrow != -1, "todo_state listener arrow not found"
+    body_open = src.find("{", arrow)
+    assert body_open != -1, "todo_state listener body open brace not found"
+    depth = 1
+    i = body_open + 1
+    while depth > 0 and i < len(src):
+        c = src[i]
+        if c == "{":
+            depth += 1
+        elif c == "}":
+            depth -= 1
+            if depth == 0:
+                return src[body_open + 1:i]
+        i += 1
+    raise AssertionError("todo_state listener body unterminated")
+
+
+class TestSseListener:
+    def test_listener_registered(self):
+        src = _read(MESSAGES_JS)
+        assert re.search(
+            r"addEventListener\(\s*['\"]todo_state['\"]", src
+        ), "todo_state listener must be registered on the EventSource."
+
+    def test_listener_filters_by_session_id(self):
+        body = _todo_state_listener_body(_read(MESSAGES_JS))
+        # Mirrors every other live listener: session-tagged events from
+        # a session the user has navigated away from must be dropped.
+        assert "session_id" in body and "activeSid" in body, (
+            "todo_state listener must guard against cross-session events "
+            "by comparing payload.session_id against activeSid."
+        )
+
+    def test_listener_filters_against_S_session(self):
+        # P1-1: even when payload.session_id matches activeSid, the UI
+        # may have navigated to another session in the meantime.  The
+        # handler must check S.session.session_id before writing global
+        # state.  Pin presence of S.session reference in the body.
+        body = _todo_state_listener_body(_read(MESSAGES_JS))
+        assert "S.session" in body, (
+            "todo_state listener must double-check S.session.session_id "
+            "against activeSid before writing global state, so a late "
+            "event arriving after the user navigated away cannot "
+            "pollute the now-active view."
+        )
+
+    def test_listener_validates_todos_array(self):
+        body = _todo_state_listener_body(_read(MESSAGES_JS))
+        assert "Array.isArray" in body and "todos" in body, (
+            "todo_state listener must require Array.isArray(d.todos) so "
+            "a malformed payload never overwrites S.todos with garbage."
+        )
+
+    def test_listener_swallows_parse_errors(self):
+        body = _todo_state_listener_body(_read(MESSAGES_JS))
+        assert "try" in body and "catch" in body, (
+            "todo_state listener must swallow JSON.parse errors silently."
+        )
+
+    def test_listener_drops_strictly_older_ts(self):
+        body = _todo_state_listener_body(_read(MESSAGES_JS))
+        # Equal-ts allowed (compression refresh can land on same second
+        # as the tool emit it follows); strictly older is rejected.
+        # Tolerate any whitespace around the < operator.
+        compact = _strip_ws(body)
+        assert "incomingTs<currentTs" in compact, (
+            "todo_state listener must reject strictly-older snapshots "
+            "to defend against out-of-order event delivery."
+        )
+
+    def test_listener_replaces_never_merges(self):
+        body = _todo_state_listener_body(_read(MESSAGES_JS))
+        # Snapshot is full; we never merge.  Pin the assignment shape
+        # but tolerate whitespace.
+        compact = _strip_ws(body)
+        assert "S.todos=d.todos" in compact, (
+            "todo_state must apply the snapshot wholesale (no merge); "
+            "merging would resurrect items the agent intended to drop."
+        )
+
+    def test_listener_mirrors_to_inflight(self):
+        body = _todo_state_listener_body(_read(MESSAGES_JS))
+        compact = _strip_ws(body)
+        assert "INFLIGHT[activeSid]" in compact, (
+            "todo_state listener must mirror to INFLIGHT so a tab switch "
+            "back into this session restores the panel from the in-memory "
+            "live snapshot."
+        )
+
+    def test_listener_persists(self):
+        body = _todo_state_listener_body(_read(MESSAGES_JS))
+        assert "persistInflightState" in body, (
+            "todo_state listener must call persistInflightState so a hard "
+            "browser reload mid-stream still sees the latest snapshot."
+        )
+
+    def test_listener_schedules_render(self):
+        body = _todo_state_listener_body(_read(MESSAGES_JS))
+        assert "scheduleTodosRefresh" in body, (
+            "todo_state listener must schedule a render via the RAF "
+            "coalescer rather than calling loadTodos() directly."
+        )
+
+    def test_run_journal_whitelist_includes_todo_state(self):
+        # Journal cursor only advances for whitelisted events; without
+        # this entry, a reconnect would replay every todo_state since
+        # session start.  Find the whitelist literal robustly.
+        src = _read(MESSAGES_JS)
+        m = re.search(
+            r"for\s*\(\s*const\s+_runJournalEventName\s+of\s+\[(.*?)\]",
+            src, re.DOTALL,
+        )
+        assert m, "run journal whitelist literal not found"
+        whitelist = m.group(1)
+        assert "'todo_state'" in whitelist or '"todo_state"' in whitelist, (
+            "todo_state must be in the run journal cursor whitelist so "
+            "Last-Event-ID advances past it on reconnect."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Settle-point hydration — messages.js + sessions.js
+# ---------------------------------------------------------------------------
+
+
+class TestSettlePointHydration:
+    def test_messages_js_settle_points_hydrate(self):
+        src = _read(MESSAGES_JS)
+        # All `S.session=` non-clear assignments must trigger hydrate so
+        # cross-session navigation never leaves a stale list visible.
+        # We allow up to 8 lines of slack to absorb harmless intermediate
+        # statements (e.g. a comment, an autosave call, a debug log).
+        lines = src.split("\n")
+        settle_points = [
+            i for i, ln in enumerate(lines)
+            if re.search(r"\bS\.session\s*=", ln)
+            and not re.search(r"\bS\.session\s*=\s*null", ln)
+        ]
+        assert settle_points, (
+            "Expected at least one S.session settle point in messages.js"
+        )
+        for i in settle_points:
+            window = "\n".join(lines[i:i + 8])
+            assert "_hydrateTodosFromSession" in window, (
+                f"S.session settle point at messages.js line {i + 1} "
+                f"must call _hydrateTodosFromSession within 8 lines."
+            )
+
+    def test_sessions_js_inflight_restore_carries_todos(self):
+        # The INFLIGHT restore block must carry the persisted todos and
+        # todoStateMeta from loadInflightState.  We locate the restore
+        # block by searching for `loadInflightState` and confirm both
+        # field names are referenced within ~30 lines of it.  This
+        # tolerates harmless reformatting of the surrounding `if(...)`.
+        src = _read(SESSIONS_JS)
+        m = re.search(r"loadInflightState\s*\(", src)
+        assert m, "INFLIGHT restore site must call loadInflightState"
+        # Take ~30 lines around the call.
+        start = src.rfind("\n", 0, m.start())
+        end = src.find("\n", m.end())
+        for _ in range(40):
+            nxt = src.find("\n", end + 1)
+            if nxt == -1:
+                break
+            end = nxt
+        window = src[start:end]
+        compact = _strip_ws(window)
+        assert "todos:" in compact and "todoStateMeta:" in compact, (
+            "INFLIGHT restore must carry todos + todoStateMeta from "
+            "the persisted localStorage snapshot."
+        )
+
+    def test_sessions_js_inflight_branch_calls_hydrate(self):
+        # The INFLIGHT-restore path must also call hydrate so cold-load
+        # and INFLIGHT both resolve to a deterministic S.todos.  Pin
+        # presence in the file rather than in a specific source slice.
+        src = _read(SESSIONS_JS)
+        # There should be at least one hydrate call in sessions.js
+        # itself — that's what guarantees the restore path renders.
+        assert "_hydrateTodosFromSession" in src, (
+            "sessions.js must call _hydrateTodosFromSession on at "
+            "least one settle point."
+        )
+
+    def test_sessions_js_ensure_messages_loaded_hydrates_todo_state(self):
+        # Page refresh path: loadSession() runs `messages=0` (which is
+        # gated out of attach_todo_state on the server), then
+        # _ensureMessagesLoaded() runs `messages=1` — and *that*
+        # response carries the canonical cold-load todo_state derived
+        # from the FULL untruncated message list.  Without applying it
+        # in _ensureMessagesLoaded(), long sessions whose latest todo
+        # write falls outside the _INITIAL_MSG_LIMIT tail would lose
+        # the panel on refresh: the legacy reverse-scan fallback only
+        # sees the tail S.messages, while the authoritative snapshot
+        # sits unread in the response.  Pin _ensureMessagesLoaded()'s
+        # body to (a) read data.session.todo_state, (b) call
+        # _hydrateTodosFromSession() so the meta/timestamp reconcile
+        # path runs, and (c) trigger a render.
+        body = _extract_function_body(_read(SESSIONS_JS), "_ensureMessagesLoaded")
+        assert "data.session.todo_state" in body, (
+            "_ensureMessagesLoaded must read data.session.todo_state from "
+            "the messages=1 response so cold-load todos survive refresh "
+            "for long sessions where the todo tool message fell outside "
+            "the _INITIAL_MSG_LIMIT tail."
+        )
+        assert "_hydrateTodosFromSession" in body, (
+            "_ensureMessagesLoaded must call _hydrateTodosFromSession "
+            "after applying the cold-load todo_state so the cold-load vs "
+            "INFLIGHT timestamp reconcile path runs."
+        )
+
+    def test_sessions_js_session_clear_paths_hydrate_null(self):
+        # Both delete-session and bulk-delete paths must clear S.session
+        # AND call _hydrateTodosFromSession so the panel clears
+        # synchronously.  We only check the delete paths — those are
+        # identified by clearing S.messages alongside S.session.  Other
+        # S.session=null assignments (e.g. project-picker mount) are
+        # transient UI state and don't drive the Todos panel.
+        src = _read(SESSIONS_JS)
+        # A real "delete" path zeroes both S.session and S.messages in
+        # the same line or within ~3 lines.  We pin the 2-statement
+        # combo so picker-style assignments are excluded.
+        delete_paths = list(re.finditer(
+            r"S\.session\s*=\s*null\s*;\s*S\.messages\s*=\s*\[\s*\]",
+            src,
+        ))
+        assert delete_paths, (
+            "expected at least one delete path with S.session=null;S.messages=[]"
+        )
+        for m in delete_paths:
+            # Search ±10 lines for the hydrate call — clears are sometimes
+            # `_hydrateTodosFromSession(null);` on the line before or
+            # after.
+            start = src.rfind("\n", max(0, m.start() - 600), m.start())
+            end = src.find("\n", m.end())
+            for _ in range(10):
+                nxt = src.find("\n", end + 1)
+                if nxt == -1:
+                    break
+                end = nxt
+            window = src[start:end]
+            assert "_hydrateTodosFromSession" in window, (
+                f"delete path at offset {m.start()} must be paired with "
+                f"_hydrateTodosFromSession so the Todos panel clears "
+                f"synchronously on session deletion."
+            )
+
+
+# ---------------------------------------------------------------------------
+# Renderer — panels.js
+# ---------------------------------------------------------------------------
+
+
+class TestRenderer:
+    def test_loadTodos_reads_S_todos_when_meta_present(self):
+        body = _extract_function_body(_read(PANELS_JS), "loadTodos")
+        # Single source of truth: when meta is present, we trust S.todos.
+        assert "S.todoStateMeta" in body and "S.todos" in body
+
+    def test_loadTodos_falls_back_to_legacy_when_meta_null(self):
+        body = _extract_function_body(_read(PANELS_JS), "loadTodos")
+        assert "_legacyTodosFromMessages" in body, (
+            "loadTodos must fall back to legacy reverse-scan when no "
+            "explicit signal has been received (S.todoStateMeta === null)."
+        )
+
+    def test_loadTodos_short_circuits_identical_hash(self):
+        body = _extract_function_body(_read(PANELS_JS), "loadTodos")
+        assert "_todosHash" in body and "_todosLastRenderedHash" in body
+
+    def test_loadTodos_short_circuits_repeated_empty(self):
+        body = _extract_function_body(_read(PANELS_JS), "loadTodos")
+        assert "__empty__" in body, (
+            "Repeated empty-list emissions must short-circuit; otherwise "
+            "every todo write to a cleared list re-paints the empty state."
+        )
+
+    def test_loadTodos_uses_esc_for_user_strings(self):
+        body = _extract_function_body(_read(PANELS_JS), "loadTodos")
+        # Tolerate `esc(td.content)` and equivalents like `esc(item.content)`.
+        assert re.search(r"esc\([^)]*\.content\)", body), (
+            "User-controlled `content` must go through esc(); the "
+            "renderer uses innerHTML so any unescaped path is XSS."
+        )
+        assert re.search(r"esc\([^)]*\.id\)", body), (
+            "User-controlled `id` must go through esc()."
+        )
+
+    def test_legacy_fallback_skips_non_todo_payloads_fast(self):
+        body = _extract_function_body(_read(PANELS_JS), "_legacyTodosFromMessages")
+        # Substring guard avoids JSON.parse on every tool result —
+        # most tool calls are not todo writes.  Tolerate single or
+        # double quotes around the literal.
+        compact = _strip_ws(body)
+        assert (
+            'indexOf(\'"todos"\')' in compact
+            or 'indexOf("\\"todos\\"")' in compact
+            or 'includes(\'"todos"\')' in compact
+            or 'includes("\\"todos\\"")' in compact
+        ), (
+            "_legacyTodosFromMessages must use a substring fast-path "
+            "to skip non-todo tool results without parsing JSON."
+        )
+
+    def test_legacy_fallback_swallows_parse_errors(self):
+        body = _extract_function_body(_read(PANELS_JS), "_legacyTodosFromMessages")
+        assert "try" in body and "catch" in body

--- a/tests/test_phase2_inflight_persistence.py
+++ b/tests/test_phase2_inflight_persistence.py
@@ -1,0 +1,449 @@
+"""Round-trip + recovery tests for the INFLIGHT localStorage persistence path.
+
+P2 follow-up to the earlier review:
+
+* the previous `phase2_e2e_scenarios` driver stubbed ``persistInflightState``
+  as a counter, leaving the real ``saveInflightState → localStorage →
+  loadInflightState`` path entirely untested;
+* it also did not cover the SSE reconnect path: a stream that drops
+  mid-todo-update and then reattaches via journal replay must restore
+  the latest snapshot from the persisted INFLIGHT bucket, otherwise
+  the user sees a flicker / stale list until the next live emit.
+
+This file loads the actual ``_compactInflightState``, ``saveInflightState``,
+``loadInflightState``, ``clearInflightState`` from ``static/ui.js``
+into a Node sandbox with a tiny in-memory localStorage shim, and runs
+the round-trip + reconnect scenarios end-to-end against that wiring.
+
+Each driver test asserts on observable state (the deserialized snapshot,
+the panel HTML after re-hydration), not on internals or formatting.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).parent.parent.resolve()
+UI_JS = REPO_ROOT / "static" / "ui.js"
+PANELS_JS = REPO_ROOT / "static" / "panels.js"
+MESSAGES_JS = REPO_ROOT / "static" / "messages.js"
+
+NODE = shutil.which("node")
+pytestmark = pytest.mark.skipif(NODE is None, reason="node not on PATH")
+
+
+_DRIVER = r"""
+const fs = require('fs');
+const uiSrc = fs.readFileSync(process.argv[1], 'utf8');
+const panelsSrc = fs.readFileSync(process.argv[2], 'utf8');
+const messagesSrc = fs.readFileSync(process.argv[3], 'utf8');
+
+// ── In-memory localStorage shim ────────────────────────────────────────────
+class FakeStorage {
+  constructor(){ this._m = {}; this.quotaBytes = Infinity; }
+  getItem(k){ return Object.prototype.hasOwnProperty.call(this._m,k)?this._m[k]:null; }
+  setItem(k,v){
+    const next = String(v);
+    const used = Object.values(this._m).reduce((a,b)=>a+String(b).length,0);
+    const old = this._m[k] ? String(this._m[k]).length : 0;
+    if (used - old + next.length > this.quotaBytes) {
+      const err = new Error('quota');
+      err.name = 'QuotaExceededError';
+      throw err;
+    }
+    this._m[k] = next;
+  }
+  removeItem(k){ delete this._m[k]; }
+}
+let storage = new FakeStorage();
+global.localStorage = storage;
+
+// ── Stub everything ui.js's INFLIGHT helpers actually use ──────────────────
+global.window = {};
+global.document = {
+  getElementById: () => ({
+    classList: {contains: () => false},
+    set innerHTML(_) {},
+    get innerHTML() { return ''; },
+  }),
+};
+global.$ = (id) => global.document.getElementById(id);
+global.esc = (s) => String(s == null ? '' : s).replace(/[&<>"']/g, c => (
+  {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
+global.t = (k) => k;
+global.li = (name, size) => '[' + name + ':' + (size||0) + ']';
+
+// State + INFLIGHT.
+global.S = {session:null, messages:[], todos:[], todoStateMeta:null};
+global.INFLIGHT = {};
+
+// ── Function extraction: a pragmatic compromise.  We need access to
+//     the real INFLIGHT_STATE_KEY constant *and* a handful of helpers,
+//     so for these tests we eval the relevant span of ui.js verbatim.
+//     The span is anchored on the constant declaration and the
+//     clearInflightState definition, both of which are stable names.
+function spanInclusive(src, fromMarker, toMarker) {
+  const start = src.indexOf(fromMarker);
+  if (start < 0) throw new Error('marker not found: ' + fromMarker);
+  const tailStart = src.indexOf(toMarker, start);
+  if (tailStart < 0) throw new Error('marker not found: ' + toMarker);
+  // include the entire `function clearInflightState` body
+  let i = src.indexOf('{', tailStart) + 1;
+  let depth = 1;
+  while (depth > 0 && i < src.length) {
+    if (src[i] === '{') depth++;
+    else if (src[i] === '}') depth--;
+    i++;
+  }
+  return src.slice(start, i);
+}
+const persistenceSpan = spanInclusive(
+  uiSrc,
+  "const INFLIGHT_STATE_KEY",
+  "function clearInflightState"
+);
+eval(persistenceSpan);
+
+// Now extract by name for the rest of the helpers under test.
+function extractFunc(src, name) {
+  const re = new RegExp('function\\s+' + name + '\\s*\\(');
+  const start = src.search(re);
+  if (start < 0) throw new Error(name + ' not found');
+  let i = src.indexOf('{', start);
+  let depth = 1; i++;
+  while (depth > 0 && i < src.length) {
+    if (src[i] === '{') depth++;
+    else if (src[i] === '}') depth--;
+    i++;
+  }
+  return src.slice(start, i);
+}
+let _todosLastRenderedHash = null;
+let _todosRenderRafId = 0;
+let _panelActive = false;
+let _panelInnerHTML = '';
+function makePanel() {
+  return {
+    classList: {contains: (cls) => cls === 'active' && _panelActive},
+    set innerHTML(html) { _panelInnerHTML = html; },
+    get innerHTML() { return _panelInnerHTML; },
+  };
+}
+const _panelTodos = makePanel();
+const _todoPanel = makePanel();
+global.document.getElementById = (id) => {
+  if (id === 'panelTodos') return _panelTodos;
+  if (id === 'todoPanel') return _todoPanel;
+  return null;
+};
+global.requestAnimationFrame = undefined;  // synchronous fallback
+
+eval(extractFunc(uiSrc, '_todosHash'));
+eval(extractFunc(uiSrc, '_todosPanelIsActive'));
+eval(extractFunc(uiSrc, 'scheduleTodosRefresh'));
+eval(extractFunc(uiSrc, '_resetTodosRenderCache'));
+eval(extractFunc(uiSrc, '_hydrateTodosFromSession'));
+eval(extractFunc(panelsSrc, 'loadTodos'));
+eval(extractFunc(panelsSrc, '_legacyTodosFromMessages'));
+
+// ── todo_state SSE listener ────────────────────────────────────────────────
+function extractTodoStateHandler(src) {
+  const start = src.indexOf("addEventListener('todo_state'");
+  if (start < 0) throw new Error('todo_state listener not found');
+  const bodyStart = src.indexOf('{', src.indexOf('=>', start));
+  let depth = 1; let i = bodyStart + 1;
+  while (depth > 0 && i < src.length) {
+    if (src[i] === '{') depth++;
+    else if (src[i] === '}') depth--;
+    i++;
+  }
+  return src.slice(bodyStart + 1, i - 1);
+}
+const _handlerBody = extractTodoStateHandler(messagesSrc);
+let activeSid = '';
+function setActive(sid) {
+  activeSid = sid;
+  S.session = sid ? {session_id: sid} : null;
+}
+function _persistInflightState() {
+  // Mirror what messages.js's persistInflightState does in production:
+  // pull the current INFLIGHT[activeSid] snapshot and route through the
+  // real saveInflightState() so we exercise the real localStorage path.
+  if (activeSid && INFLIGHT[activeSid]) {
+    saveInflightState(activeSid, INFLIGHT[activeSid]);
+  }
+}
+function _invokeTodoStateHandler(e) {
+  const fn = new Function(
+    'e','S','INFLIGHT','activeSid','persistInflightState','scheduleTodosRefresh',
+    _handlerBody);
+  fn(e, S, INFLIGHT, activeSid, _persistInflightState,
+     () => { /* sync render is handled below */ });
+}
+
+// ── Test runner ────────────────────────────────────────────────────────────
+const results = [];
+function it(name, fn) {
+  try { fn(); results.push({name, ok: true}); }
+  catch (e) { results.push({name, ok: false, err: String(e && e.stack || e)}); }
+}
+function eq(a, b, msg) {
+  const A = JSON.stringify(a), B = JSON.stringify(b);
+  if (A !== B) throw new Error((msg||'') + ' expected ' + B + ', got ' + A);
+}
+function truthy(v, msg) { if (!v) throw new Error(msg||'expected truthy'); }
+function reset() {
+  S.session = null; S.messages = []; S.todos = []; S.todoStateMeta = null;
+  Object.keys(INFLIGHT).forEach(k => delete INFLIGHT[k]);
+  _todosLastRenderedHash = null;
+  _todosRenderRafId = 0;
+  _panelActive = false;
+  _panelInnerHTML = '';
+  activeSid = '';
+  storage = new FakeStorage();
+  global.localStorage = storage;
+}
+
+// ─── Persistence round-trip ────────────────────────────────────────────────
+
+it('round-trip: live emit → persist → load gives identical snapshot', () => {
+  reset();
+  setActive('s-A');
+  INFLIGHT['s-A'] = {todos:null, todoStateMeta:null,
+    messages:[], toolCalls:[], uploaded:[], streamId:'r1'};
+  _invokeTodoStateHandler({data: JSON.stringify({
+    session_id: 's-A',
+    ts: 1234.5,
+    source: 'tool',
+    version: 1,
+    todos: [{id:'1', content:'plan', status:'in_progress'},
+            {id:'2', content:'next', status:'pending'}],
+    summary: {total: 2, in_progress: 1, pending: 1},
+  })});
+
+  // localStorage now holds the real persisted blob.
+  const restored = loadInflightState('s-A');
+  truthy(restored, 'loadInflightState must return the persisted entry');
+  eq(restored.todos.length, 2, 'todos array round-tripped');
+  eq(restored.todos[0].id, '1');
+  eq(restored.todos[1].status, 'pending');
+  truthy(restored.todoStateMeta, 'todoStateMeta survived round-trip');
+  eq(restored.todoStateMeta.ts, 1234.5);
+  eq(restored.todoStateMeta.source, 'tool');
+});
+
+it('round-trip: missing todoStateMeta is restored as null sentinel', () => {
+  reset();
+  saveInflightState('s-empty', {
+    streamId: 'r1', messages: [], toolCalls: [], uploaded: [],
+    todos: null, todoStateMeta: null,
+  });
+  const restored = loadInflightState('s-empty');
+  truthy(restored, 'entry persisted even without todoStateMeta');
+  eq(restored.todos, null, 'null todos preserved (sentinel for "never seen")');
+  eq(restored.todoStateMeta, null);
+});
+
+it('round-trip: streamId mismatch returns null (cross-stream guard)', () => {
+  reset();
+  saveInflightState('s-A', {
+    streamId: 'r1', messages: [], toolCalls: [], uploaded: [],
+    todos: [{id:'1', content:'x', status:'pending'}],
+    todoStateMeta: {ts:1, source:'tool', version:1},
+  });
+  const same = loadInflightState('s-A', 'r1');
+  truthy(same && Array.isArray(same.todos));
+  const cross = loadInflightState('s-A', 'r-OTHER');
+  eq(cross, null,
+     'cross-stream load must return null so a new stream cannot inherit '
+     + 'a stale snapshot from a different run.');
+});
+
+it('round-trip: clear removes the entry', () => {
+  reset();
+  saveInflightState('s-bye', {
+    streamId: 'r', messages: [], toolCalls: [], uploaded: [],
+    todos: [{id:'1', content:'x', status:'pending'}],
+    todoStateMeta: {ts:1, source:'tool', version:1},
+  });
+  truthy(loadInflightState('s-bye'));
+  clearInflightState('s-bye');
+  eq(loadInflightState('s-bye'), null);
+});
+
+it('round-trip: corrupted JSON in storage falls back gracefully', () => {
+  reset();
+  // Simulate a partial write or storage corruption.
+  storage._m['hermes-webui-inflight-state'] = '{not json';
+  // Must not throw — the helper must swallow the parse error.
+  const out = loadInflightState('s-anything');
+  eq(out, null, 'corrupted storage must not crash callers');
+  // And a subsequent save must succeed (the wrapper recovers).
+  saveInflightState('s-fresh', {
+    streamId: 'r', messages: [], toolCalls: [], uploaded: [],
+    todos: [{id:'1', content:'x', status:'pending'}],
+    todoStateMeta: {ts:1, source:'tool', version:1},
+  });
+  truthy(loadInflightState('s-fresh'),
+         'save must rebuild storage after corruption');
+});
+
+// ─── SSE reconnect / mid-stream resume ─────────────────────────────────────
+
+it('reconnect: hard reload after persisted live emit re-hydrates UI', () => {
+  reset();
+  // Simulate live stream:
+  setActive('s-live');
+  INFLIGHT['s-live'] = {todos:null, todoStateMeta:null,
+    messages:[], toolCalls:[], uploaded:[], streamId:'r-live'};
+  _invokeTodoStateHandler({data: JSON.stringify({
+    session_id: 's-live', ts: 100, source: 'tool',
+    todos: [{id:'1', content:'mid-flight', status:'in_progress'}],
+  })});
+
+  // Simulate hard reload: drop in-memory state, keep localStorage.
+  S.session = null; S.todos = []; S.todoStateMeta = null;
+  Object.keys(INFLIGHT).forEach(k => delete INFLIGHT[k]);
+
+  // Mirror what sessions.js does on restore: pull the persisted entry
+  // back into INFLIGHT[sid] and call _hydrateTodosFromSession.
+  const restored = loadInflightState('s-live');
+  truthy(restored, 'persisted snapshot must survive the simulated reload');
+  INFLIGHT['s-live'] = {
+    streamId: restored.streamId,
+    messages: restored.messages || [],
+    toolCalls: restored.toolCalls || [],
+    uploaded: restored.uploaded || [],
+    todos: restored.todos,
+    todoStateMeta: restored.todoStateMeta,
+  };
+  setActive('s-live');
+  _hydrateTodosFromSession(S.session);
+
+  eq(S.todos[0].id, '1', 'reload must restore live snapshot from INFLIGHT');
+  eq(S.todoStateMeta.source, 'tool',
+     'meta must restore so loadTodos uses the live path, not legacy fallback');
+
+  _panelActive = true;
+  loadTodos();
+  truthy(_panelInnerHTML.indexOf('mid-flight') >= 0,
+         'panel must paint the restored snapshot after reload');
+});
+
+it('reconnect: replay of older todo_state events does not regress fresher snapshot', () => {
+  // Production SSE replay can deliver historical todo_state events
+  // again on reconnect.  The strict-older-ts guard inside the listener
+  // must reject them so the latest persisted snapshot wins.
+  reset();
+  setActive('s-replay');
+  INFLIGHT['s-replay'] = {todos:null, todoStateMeta:null,
+    messages:[], toolCalls:[], uploaded:[], streamId:'r-replay'};
+  // Live: reaches ts=200 with the real "completed" state.
+  _invokeTodoStateHandler({data: JSON.stringify({
+    session_id: 's-replay', ts: 200,
+    todos: [{id:'1', content:'done', status:'completed'}],
+  })});
+  eq(S.todos[0].status, 'completed');
+
+  // Replay: the journal replays an older ts=100 "pending" event.
+  _invokeTodoStateHandler({data: JSON.stringify({
+    session_id: 's-replay', ts: 100,
+    todos: [{id:'1', content:'pending', status:'pending'}],
+  })});
+  eq(S.todos[0].status, 'completed',
+     'older replay must not regress fresher state');
+
+  // Persisted snapshot must also still hold the fresher state.
+  const restored = loadInflightState('s-replay');
+  eq(restored.todos[0].status, 'completed',
+     'INFLIGHT must mirror the fresher state through the replay');
+});
+
+it('reconnect: cross-session replay during reload picks the right session', () => {
+  // Two sessions persisted concurrently; reload must restore each
+  // independently without bleed-through.
+  reset();
+  saveInflightState('s-A', {
+    streamId: 'rA', messages: [], toolCalls: [], uploaded: [],
+    todos: [{id:'A', content:'task-A', status:'pending'}],
+    todoStateMeta: {ts:1, source:'tool', version:1},
+  });
+  saveInflightState('s-B', {
+    streamId: 'rB', messages: [], toolCalls: [], uploaded: [],
+    todos: [{id:'B', content:'task-B', status:'in_progress'}],
+    todoStateMeta: {ts:2, source:'tool', version:1},
+  });
+  const A = loadInflightState('s-A');
+  const B = loadInflightState('s-B');
+  eq(A.todos[0].id, 'A');
+  eq(B.todos[0].id, 'B');
+  truthy(A.todos[0] !== B.todos[0],
+         'sessions must not share array references after deserialize');
+});
+
+console.log(JSON.stringify(results));
+"""
+
+
+@pytest.fixture(scope="module")
+def driver_results():
+    out = subprocess.run(
+        [NODE, "-e", _DRIVER, str(UI_JS), str(PANELS_JS), str(MESSAGES_JS)],
+        capture_output=True, text=True, timeout=30,
+    )
+    if out.returncode != 0:
+        raise RuntimeError(
+            f"node driver failed (rc={out.returncode}):\n"
+            f"STDOUT:\n{out.stdout}\n"
+            f"STDERR:\n{out.stderr}"
+        )
+    try:
+        return json.loads(out.stdout.strip().splitlines()[-1])
+    except (json.JSONDecodeError, IndexError) as exc:
+        raise RuntimeError(
+            f"could not parse driver output as JSON: {exc}\n"
+            f"raw stdout:\n{out.stdout}"
+        )
+
+
+_DECLARED = [
+    "round-trip: live emit → persist → load gives identical snapshot",
+    "round-trip: missing todoStateMeta is restored as null sentinel",
+    "round-trip: streamId mismatch returns null (cross-stream guard)",
+    "round-trip: clear removes the entry",
+    "round-trip: corrupted JSON in storage falls back gracefully",
+    "reconnect: hard reload after persisted live emit re-hydrates UI",
+    "reconnect: replay of older todo_state events does not regress fresher snapshot",
+    "reconnect: cross-session replay during reload picks the right session",
+]
+
+
+def _id(name):
+    return name.replace(" ", "_").replace(":", "").replace("/", "")
+
+
+@pytest.mark.parametrize("name", _DECLARED, ids=_id)
+def test_inflight_persistence(driver_results, name):
+    matches = [r for r in driver_results if r["name"] == name]
+    assert matches, f"{name!r} missing from driver output"
+    r = matches[0]
+    assert r["ok"], f"{name}\n  {r.get('err','(no detail)')}"
+
+
+def test_all_declared_tests_ran(driver_results):
+    actual = {r["name"] for r in driver_results}
+    declared = set(_DECLARED)
+    missing = declared - actual
+    extra = actual - declared
+    assert not missing and not extra, (
+        f"Driver/declaration mismatch:\n"
+        f"  missing from driver output: {sorted(missing)}\n"
+        f"  not in _DECLARED:           {sorted(extra)}"
+    )

--- a/tests/test_phase2_inflight_persistence.py
+++ b/tests/test_phase2_inflight_persistence.py
@@ -24,7 +24,6 @@ from __future__ import annotations
 import json
 import shutil
 import subprocess
-import textwrap
 from pathlib import Path
 
 import pytest
@@ -410,7 +409,7 @@ def driver_results():
         raise RuntimeError(
             f"could not parse driver output as JSON: {exc}\n"
             f"raw stdout:\n{out.stdout}"
-        )
+        ) from exc
 
 
 _DECLARED = [

--- a/tests/test_phase2_todo_behavior.py
+++ b/tests/test_phase2_todo_behavior.py
@@ -1,0 +1,831 @@
+"""Behavioural tests for Phase 2 todo helpers — driven via real node.
+
+Loads the actual function bodies from static/ui.js and static/panels.js
+into a sandboxed node script and asserts behaviour against the live
+implementation. Mirrors the pattern in test_renderer_js_behaviour.py:
+when a test fails, you know the JS is broken — there is no Python
+mirror that could disagree with the source.
+
+Coverage:
+
+  • _todosHash               — stability, change-detection, edge cases
+  • _hydrateTodosFromSession — cold-load priority, INFLIGHT fallback,
+                              null clear, render-cache reset
+  • scheduleTodosRefresh     — RAF coalescing, panel-active guard,
+                              non-RAF fallback (Node default)
+  • todo_state listener      — full snapshot replace, session-id filter,
+                              older-ts rejection, malformed payload
+                              swallow, INFLIGHT mirror
+  • _legacyTodosFromMessages — fallback when no signal received,
+                              fast-path skip on non-todo payloads,
+                              malformed JSON tolerance
+  • loadTodos                — single source of truth, hash short-circuit,
+                              repeated-empty short-circuit
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent.resolve()
+UI_JS = REPO_ROOT / "static" / "ui.js"
+PANELS_JS = REPO_ROOT / "static" / "panels.js"
+
+NODE = shutil.which("node")
+
+pytestmark = pytest.mark.skipif(NODE is None, reason="node not on PATH")
+
+
+_DRIVER = r"""
+const fs = require('fs');
+// node -e omits the usual scriptname slot, so argv[1] is the first
+// user argument. We pass three paths in fixed order: ui.js, panels.js,
+// messages.js.
+const uiSrc = fs.readFileSync(process.argv[1], 'utf8');
+const panelsSrc = fs.readFileSync(process.argv[2], 'utf8');
+
+// ── Stub global environment ────────────────────────────────────────────────
+// We deliberately do NOT load all of ui.js — it pulls hundreds of DOM
+// helpers, fetch wrappers, EventSource wiring, KaTeX, etc. that are
+// irrelevant here. Instead we extract the functions under test by name
+// and bring along just enough scaffolding to make them runnable.
+
+// Minimal DOM stub — only what _todosPanelIsActive() and the renderer use.
+let _panelActive = false;
+let _panelInnerHTML = '';
+function makePanel() {
+  return {
+    classList: {
+      contains: (cls) => cls === 'active' && _panelActive,
+    },
+    set innerHTML(html) { _panelInnerHTML = html; },
+    get innerHTML() { return _panelInnerHTML; },
+  };
+}
+const _panelTodos = makePanel();
+const _todoPanel = makePanel();
+global.document = {
+  getElementById: (id) => {
+    if (id === 'panelTodos') return _panelTodos;
+    if (id === 'todoPanel') return _todoPanel;
+    return null;
+  },
+};
+global.window = {};
+
+// $('id') used by panels.js
+global.$ = (id) => global.document.getElementById(id);
+
+// esc(): match the real one closely enough for assertion purposes.
+global.esc = (s) => String(s == null ? '' : s).replace(/[&<>"']/g, c => (
+  {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
+
+// Stub i18n + icon helpers used by the renderer.
+global.t = (k) => k;
+global.li = (name, size) => `[${name}:${size||0}]`;
+
+// State + INFLIGHT stubs.
+global.S = {
+  session: null,
+  messages: [],
+  todos: [],
+  todoStateMeta: null,
+};
+global.INFLIGHT = {};
+
+// requestAnimationFrame: by default off so scheduleTodosRefresh falls
+// back to synchronous loadTodos(); tests can swap in a queueing impl.
+let _rafQueue = [];
+let _rafEnabled = false;
+global.requestAnimationFrame = (cb) => {
+  if (_rafEnabled) {
+    _rafQueue.push(cb);
+    return _rafQueue.length;
+  }
+  return undefined;
+};
+function flushRaf() {
+  const q = _rafQueue;
+  _rafQueue = [];
+  for (const cb of q) cb();
+}
+function enableRaf() {
+  _rafEnabled = true;
+  global.requestAnimationFrame = (cb) => {
+    _rafQueue.push(cb);
+    return _rafQueue.length;
+  };
+}
+function disableRaf() {
+  _rafEnabled = false;
+  global.requestAnimationFrame = undefined;
+}
+
+// ── Function extraction ────────────────────────────────────────────────────
+function extractFunc(src, name) {
+  const re = new RegExp('function\\s+' + name + '\\s*\\(');
+  const start = src.search(re);
+  if (start < 0) throw new Error(name + ' not found');
+  let i = src.indexOf('{', start);
+  let depth = 1; i++;
+  while (depth > 0 && i < src.length) {
+    if (src[i] === '{') depth++;
+    else if (src[i] === '}') depth--;
+    i++;
+  }
+  return src.slice(start, i);
+}
+
+// Hoist module-level lets (_todosLastRenderedHash, _todosRenderRafId)
+// — extractFunc only pulls function bodies, but the helpers reference
+// these. Define them globally so the extracted code resolves them.
+let _todosLastRenderedHash = null;
+let _todosRenderRafId = 0;
+
+eval(extractFunc(uiSrc, '_todosHash'));
+eval(extractFunc(uiSrc, '_todosPanelIsActive'));
+eval(extractFunc(uiSrc, 'scheduleTodosRefresh'));
+eval(extractFunc(uiSrc, '_resetTodosRenderCache'));
+eval(extractFunc(uiSrc, '_hydrateTodosFromSession'));
+eval(extractFunc(panelsSrc, 'loadTodos'));
+eval(extractFunc(panelsSrc, '_legacyTodosFromMessages'));
+
+// ── todo_state listener: extract the handler body manually ─────────────────
+// It is registered as `source.addEventListener('todo_state', e=>{...});`,
+// so we slice the arrow body and wrap it in a callable.
+const messagesSrc = fs.readFileSync(process.argv[3], 'utf8');
+function extractTodoStateHandler(src) {
+  const start = src.indexOf("addEventListener('todo_state'");
+  if (start < 0) throw new Error('todo_state listener not found');
+  // Anchor on the arrow opening `e=>{` to find the body.
+  const bodyStart = src.indexOf('{', src.indexOf('=>', start));
+  let depth = 1; let i = bodyStart + 1;
+  while (depth > 0 && i < src.length) {
+    if (src[i] === '{') depth++;
+    else if (src[i] === '}') depth--;
+    i++;
+  }
+  return src.slice(bodyStart + 1, i - 1);
+}
+const _handlerBody = extractTodoStateHandler(messagesSrc);
+
+// activeSid + persistInflightState + scheduleTodosRefresh are closure
+// vars in messages.js. Inject them as test-controlled globals.
+//
+// Note on S.session: production messages.js uses both `activeSid` (the
+// SSE-side session id the stream is wired to) and `S.session.session_id`
+// (the UI-side session the user is viewing) and only writes global state
+// when both agree.  The driver mirrors that contract — `setActive(sid)`
+// keeps both in sync — and individual tests that exercise the
+// cross-session guard set them apart explicitly.
+let activeSid = '';
+let _persistCalls = 0;
+function persistInflightState() { _persistCalls++; }
+let _refreshCalls = 0;
+const _origScheduleTodosRefresh = scheduleTodosRefresh;
+function setActive(sid) {
+  activeSid = sid;
+  S.session = sid ? {session_id: sid} : null;
+}
+function _invokeTodoStateHandler(e) {
+  // Wrap into a function so the body's `return` statements terminate
+  // only the handler, not the whole driver. Each call gets fresh
+  // locals for d / incomingTs / currentTs.
+  const fn = new Function('e','S','INFLIGHT','activeSid','persistInflightState','scheduleTodosRefresh', _handlerBody);
+  fn(e, S, INFLIGHT, activeSid, persistInflightState, () => { _refreshCalls++; _origScheduleTodosRefresh(); });
+}
+
+// ── Test runner ────────────────────────────────────────────────────────────
+const results = [];
+function it(name, fn) {
+  try {
+    fn();
+    results.push({name, ok: true});
+  } catch (e) {
+    results.push({name, ok: false, err: String(e && e.stack || e)});
+  }
+}
+function eq(a, b, msg) {
+  const A = JSON.stringify(a), B = JSON.stringify(b);
+  if (A !== B) throw new Error((msg||'') + ' expected ' + B + ', got ' + A);
+}
+function truthy(v, msg) { if (!v) throw new Error(msg||'expected truthy'); }
+function falsy(v, msg) { if (v) throw new Error(msg||'expected falsy'); }
+function reset() {
+  S.session = null; S.messages = []; S.todos = []; S.todoStateMeta = null;
+  Object.keys(INFLIGHT).forEach(k => delete INFLIGHT[k]);
+  _todosLastRenderedHash = null;
+  _todosRenderRafId = 0;
+  _rafQueue = [];
+  _rafEnabled = false;
+  global.requestAnimationFrame = undefined;
+  _panelActive = false;
+  _panelInnerHTML = '';
+  activeSid = '';
+  _persistCalls = 0;
+  _refreshCalls = 0;
+}
+
+// ─── _todosHash ────────────────────────────────────────────────────────────
+it('hash: empty list yields stable string', () => {
+  reset();
+  const h1 = _todosHash([]);
+  const h2 = _todosHash([]);
+  eq(h1, h2, 'stable across calls');
+  truthy(h1.length > 0, 'non-empty result');
+});
+
+it('hash: id change is detected', () => {
+  reset();
+  const a = _todosHash([{id:'1', content:'x', status:'pending'}]);
+  const b = _todosHash([{id:'2', content:'x', status:'pending'}]);
+  truthy(a !== b, 'id change must change hash');
+});
+
+it('hash: content change is detected', () => {
+  reset();
+  const a = _todosHash([{id:'1', content:'foo', status:'pending'}]);
+  const b = _todosHash([{id:'1', content:'bar', status:'pending'}]);
+  truthy(a !== b, 'content change must change hash');
+});
+
+it('hash: status change is detected', () => {
+  reset();
+  const a = _todosHash([{id:'1', content:'x', status:'pending'}]);
+  const b = _todosHash([{id:'1', content:'x', status:'in_progress'}]);
+  truthy(a !== b, 'status change must change hash');
+});
+
+it('hash: list length change is detected', () => {
+  reset();
+  const a = _todosHash([{id:'1', content:'x', status:'pending'}]);
+  const b = _todosHash([{id:'1', content:'x', status:'pending'},
+                        {id:'2', content:'y', status:'pending'}]);
+  truthy(a !== b, 'list length change must change hash');
+});
+
+it('hash: order change is detected', () => {
+  reset();
+  const a = _todosHash([{id:'1',content:'x',status:'pending'},
+                        {id:'2',content:'y',status:'pending'}]);
+  const b = _todosHash([{id:'2',content:'y',status:'pending'},
+                        {id:'1',content:'x',status:'pending'}]);
+  truthy(a !== b, 'reorder must change hash (priority is encoded as order)');
+});
+
+it('hash: missing fields are tolerated', () => {
+  reset();
+  const h = _todosHash([{}, {id:null, content:undefined, status:''}]);
+  truthy(typeof h === 'string', 'must not throw on partial items');
+});
+
+it('hash: not-an-array yields empty string', () => {
+  reset();
+  eq(_todosHash(null), '');
+  eq(_todosHash(undefined), '');
+  eq(_todosHash({}), '');
+});
+
+// ─── _hydrateTodosFromSession ──────────────────────────────────────────────
+it('hydrate: cold-load wins over inflight when cold ts is newer', () => {
+  reset();
+  INFLIGHT['s1'] = {
+    todos: [{id:'old', content:'inflight', status:'pending'}],
+    todoStateMeta: {ts: 100, source: 'tool', version: 1},
+  };
+  _hydrateTodosFromSession({
+    session_id: 's1',
+    todo_state: {todos: [{id:'new', content:'cold', status:'pending'}], version: 1, ts: 200},
+  });
+  eq(S.todos[0].id, 'new', 'newer cold-load must win');
+  eq(S.todoStateMeta.source, 'cold-load');
+});
+
+it('hydrate: inflight wins over cold-load when inflight ts is newer', () => {
+  reset();
+  INFLIGHT['s1'] = {
+    todos: [{id:'live', content:'live', status:'in_progress'}],
+    todoStateMeta: {ts: 200, source: 'tool', version: 1},
+  };
+  _hydrateTodosFromSession({
+    session_id: 's1',
+    todo_state: {todos: [{id:'stale', content:'stale-cold', status:'pending'}], version: 1, ts: 100},
+  });
+  eq(S.todos[0].id, 'live',
+     'a stale cold-load must NOT regress fresher INFLIGHT state on reload');
+  eq(S.todoStateMeta.source, 'tool',
+     'meta carries the inflight source, not the cold-load tag');
+});
+
+it('hydrate: tie ts prefers inflight (freshest in-tab edits)', () => {
+  reset();
+  INFLIGHT['s1'] = {
+    todos: [{id:'inflight', content:'in', status:'pending'}],
+    todoStateMeta: {ts: 100, source: 'tool', version: 1},
+  };
+  _hydrateTodosFromSession({
+    session_id: 's1',
+    todo_state: {todos: [{id:'cold', content:'co', status:'pending'}], version: 1, ts: 100},
+  });
+  eq(S.todos[0].id, 'inflight', 'tie goes to inflight');
+});
+
+it('hydrate: falls back to inflight when no cold-load', () => {
+  reset();
+  INFLIGHT['s1'] = {
+    todos: [{id:'kept', content:'inflight', status:'pending'}],
+    todoStateMeta: {ts: 1, source: 'tool', version: 1},
+  };
+  _hydrateTodosFromSession({session_id: 's1'});
+  eq(S.todos[0].id, 'kept', 'inflight must be used when no cold-load');
+});
+
+it('hydrate: clears state when neither cold-load nor inflight', () => {
+  reset();
+  S.todos = [{id: '1', content: 'stale', status: 'pending'}];
+  S.todoStateMeta = {ts: 0, source: 'cold-load', version: 1};
+  _hydrateTodosFromSession({session_id: 's-fresh'});
+  eq(S.todos, [], 'must reset to empty');
+  eq(S.todoStateMeta, null, 'must reset meta to null sentinel');
+});
+
+it('hydrate: null session clears state (delete-session path)', () => {
+  reset();
+  S.todos = [{id:'1',content:'x',status:'pending'}];
+  S.todoStateMeta = {ts: 1, source: 'tool', version: 1};
+  _hydrateTodosFromSession(null);
+  eq(S.todos, []);
+  eq(S.todoStateMeta, null);
+});
+
+it('hydrate: resets render cache so next paint runs', () => {
+  reset();
+  _todosLastRenderedHash = 'stale-hash';
+  _hydrateTodosFromSession({session_id: 's1'});
+  eq(_todosLastRenderedHash, null,
+     'cross-session navigation must invalidate the render hash');
+});
+
+it('hydrate: cold-load with empty todos yields explicit empty state', () => {
+  reset();
+  _hydrateTodosFromSession({
+    session_id: 's1',
+    todo_state: {todos: [], version: 1},
+  });
+  eq(S.todos, []);
+  truthy(S.todoStateMeta !== null, 'empty cold-load is still an explicit signal');
+});
+
+// ─── scheduleTodosRefresh ──────────────────────────────────────────────────
+it('schedule: with RAF coalesces multiple calls', () => {
+  reset();
+  enableRaf();
+  _panelActive = true;
+  scheduleTodosRefresh();
+  scheduleTodosRefresh();
+  scheduleTodosRefresh();
+  // Only one RAF callback queued.
+  eq(_rafQueue.length, 1, 'multiple schedule calls coalesce to one RAF tick');
+});
+
+it('schedule: skips render when panel inactive', () => {
+  reset();
+  enableRaf();
+  _panelActive = false;
+  S.todos = [{id:'1',content:'x',status:'pending'}];
+  S.todoStateMeta = {ts:1,source:'tool',version:1};
+  scheduleTodosRefresh();
+  flushRaf();
+  eq(_panelInnerHTML, '', 'inactive panel must not be touched');
+});
+
+it('schedule: paints when panel is active', () => {
+  reset();
+  enableRaf();
+  _panelActive = true;
+  S.todos = [{id:'1',content:'x',status:'pending'}];
+  S.todoStateMeta = {ts:1,source:'tool',version:1};
+  scheduleTodosRefresh();
+  flushRaf();
+  truthy(_panelInnerHTML.length > 0, 'active panel must render');
+});
+
+it('schedule: synchronous fallback when RAF missing', () => {
+  reset();
+  disableRaf();
+  _panelActive = true;
+  S.todos = [{id:'1',content:'x',status:'pending'}];
+  S.todoStateMeta = {ts:1,source:'tool',version:1};
+  scheduleTodosRefresh();
+  truthy(_panelInnerHTML.length > 0, 'must render synchronously without RAF');
+});
+
+// ─── todo_state listener ───────────────────────────────────────────────────
+function evt(payload) { return {data: JSON.stringify(payload)}; }
+
+it('listener: full snapshot replaces (no merge)', () => {
+  reset();
+  setActive('s1');
+  S.todos = [{id:'old', content:'old', status:'completed'}];
+  S.todoStateMeta = {ts:1, source:'tool', version:1};
+  _invokeTodoStateHandler(evt({
+    session_id: 's1',
+    todos: [{id:'new', content:'new', status:'pending'}],
+    version: 1, ts: 2, source: 'tool',
+  }));
+  eq(S.todos.length, 1);
+  eq(S.todos[0].id, 'new', 'snapshot replaces; never merges');
+});
+
+it('listener: drops events from a different session', () => {
+  reset();
+  setActive('s-active');
+  S.todos = [{id:'keep', content:'keep', status:'pending'}];
+  S.todoStateMeta = {ts:1, source:'tool', version:1};
+  _invokeTodoStateHandler(evt({
+    session_id: 's-other',
+    todos: [{id:'leak', content:'leak', status:'pending'}],
+    ts: 2,
+  }));
+  eq(S.todos[0].id, 'keep', 'cross-session events must not leak');
+});
+
+it('listener: drops events when S.session does not match activeSid', () => {
+  // P1: payload.session_id may legitimately equal activeSid for an
+  // event that was queued before the user navigated away.  By the time
+  // the handler runs, S.session has already been swapped to a different
+  // session, so writing global state would pollute the now-active view.
+  reset();
+  activeSid = 's1';
+  S.session = {session_id: 's-other'};   // user already navigated
+  S.todos = [{id:'keep', content:'keep', status:'pending'}];
+  S.todoStateMeta = {ts:1, source:'tool', version:1};
+  _invokeTodoStateHandler(evt({
+    session_id: 's1',
+    todos: [{id:'leak', content:'leak', status:'pending'}],
+    ts: 2,
+  }));
+  eq(S.todos[0].id, 'keep',
+     'late event must be dropped when UI has already moved on');
+});
+
+it('listener: drops events when no S.session is set yet', () => {
+  // Page is mid-load: SSE wired up before the session GET resolved.
+  // We cannot safely write S.todos for a session whose identity is
+  // unknown; defer until S.session is set.
+  reset();
+  activeSid = 's1';
+  S.session = null;
+  S.todos = [];
+  _invokeTodoStateHandler(evt({
+    session_id: 's1',
+    todos: [{id:'leak', content:'leak', status:'pending'}],
+    ts: 2,
+  }));
+  eq(S.todos, [], 'must not write before session identity is settled');
+});
+
+it('listener: drops events with strictly older ts', () => {
+  reset();
+  setActive('s1');
+  S.todoStateMeta = {ts: 100, source: 'tool', version: 1};
+  S.todos = [{id:'newer', content:'newer', status:'pending'}];
+  _invokeTodoStateHandler(evt({
+    session_id: 's1', ts: 50,
+    todos: [{id:'older', content:'older', status:'pending'}],
+  }));
+  eq(S.todos[0].id, 'newer', 'older event must not overwrite newer state');
+});
+
+it('listener: equal ts is allowed (compression after tool)', () => {
+  reset();
+  setActive('s1');
+  S.todoStateMeta = {ts: 100, source: 'tool', version: 1};
+  S.todos = [{id:'a',content:'a',status:'pending'}];
+  _invokeTodoStateHandler(evt({
+    session_id: 's1', ts: 100, source: 'compression',
+    todos: [{id:'b',content:'b',status:'pending'}],
+  }));
+  eq(S.todos[0].id, 'b', 'equal-ts events apply (e.g. compression refresh)');
+});
+
+it('listener: malformed JSON is swallowed', () => {
+  reset();
+  setActive('s1');
+  S.todos = [{id:'kept', content:'k', status:'pending'}];
+  S.todoStateMeta = {ts:1,source:'tool',version:1};
+  _invokeTodoStateHandler({data: '{not json'});
+  eq(S.todos[0].id, 'kept', 'malformed payload must not corrupt state');
+});
+
+it('listener: non-array todos rejected', () => {
+  reset();
+  setActive('s1');
+  S.todos = [{id:'kept', content:'k', status:'pending'}];
+  S.todoStateMeta = {ts:1,source:'tool',version:1};
+  _invokeTodoStateHandler(evt({session_id:'s1', todos: 'not-an-array', ts: 2}));
+  eq(S.todos[0].id, 'kept');
+});
+
+it('listener: mirrors snapshot to INFLIGHT', () => {
+  reset();
+  setActive('s1');
+  INFLIGHT['s1'] = {todos: null, todoStateMeta: null};
+  _invokeTodoStateHandler(evt({
+    session_id: 's1', ts: 2,
+    todos: [{id:'x', content:'x', status:'pending'}],
+  }));
+  truthy(Array.isArray(INFLIGHT['s1'].todos), 'INFLIGHT.todos must mirror S.todos');
+  eq(INFLIGHT['s1'].todos[0].id, 'x');
+  truthy(INFLIGHT['s1'].todoStateMeta !== null, 'INFLIGHT meta must mirror');
+});
+
+it('listener: triggers persistence + render schedule', () => {
+  reset();
+  setActive('s1');
+  INFLIGHT['s1'] = {todos: null, todoStateMeta: null};
+  _invokeTodoStateHandler(evt({
+    session_id: 's1', ts: 2,
+    todos: [{id:'x', content:'x', status:'pending'}],
+  }));
+  truthy(_persistCalls >= 1, 'persistInflightState called');
+  truthy(_refreshCalls >= 1, 'scheduleTodosRefresh called');
+});
+
+it('listener: empty session_id does not block valid event', () => {
+  reset();
+  setActive('s1');
+  // Older servers might not tag session_id; we only filter when present.
+  _invokeTodoStateHandler(evt({
+    todos: [{id:'x', content:'x', status:'pending'}],
+    ts: 2,
+  }));
+  eq(S.todos[0].id, 'x', 'untagged event must still apply');
+});
+
+// ─── _legacyTodosFromMessages ──────────────────────────────────────────────
+it('legacy: returns empty when no signal in messages', () => {
+  reset();
+  S.messages = [
+    {role: 'user', content: 'hi'},
+    {role: 'assistant', content: 'hello'},
+  ];
+  eq(_legacyTodosFromMessages(), []);
+});
+
+it('legacy: scans S.messages when no S.session.messages', () => {
+  reset();
+  S.messages = [
+    {role: 'tool', content: JSON.stringify({todos: [{id:'1', content:'a', status:'pending'}]})},
+  ];
+  eq(_legacyTodosFromMessages()[0].id, '1');
+});
+
+it('legacy: prefers S.session.messages when present', () => {
+  reset();
+  S.messages = [{role:'tool', content: JSON.stringify({todos:[{id:'fallback'}]})}];
+  S.session = {messages: [{role:'tool', content: JSON.stringify({todos:[{id:'preferred'}]})}]};
+  eq(_legacyTodosFromMessages()[0].id, 'preferred');
+});
+
+it('legacy: returns latest todo entry when multiple exist', () => {
+  reset();
+  S.messages = [
+    {role:'tool', content: JSON.stringify({todos:[{id:'old', status:'completed'}]})},
+    {role:'assistant', content:'thinking'},
+    {role:'tool', content: JSON.stringify({todos:[{id:'new', status:'pending'}]})},
+  ];
+  eq(_legacyTodosFromMessages()[0].id, 'new');
+});
+
+it('legacy: skips non-todo tool payloads via fast-path', () => {
+  reset();
+  S.messages = [
+    {role:'tool', content: JSON.stringify({todos:[{id:'1'}]})},
+    {role:'tool', content: JSON.stringify({result: 'ok'})},
+    {role:'tool', content: JSON.stringify({output: 'hello'})},
+  ];
+  eq(_legacyTodosFromMessages()[0].id, '1', 'fast-path skips non-todo payloads');
+});
+
+it('legacy: tolerates malformed JSON', () => {
+  reset();
+  S.messages = [
+    {role:'tool', content: JSON.stringify({todos:[{id:'good'}]})},
+    {role:'tool', content: '{"todos": broken'},
+  ];
+  eq(_legacyTodosFromMessages()[0].id, 'good');
+});
+
+it('legacy: handles non-string content gracefully', () => {
+  reset();
+  S.messages = [
+    {role:'tool', content: null},
+    {role:'tool', content: ['chunked']},
+    {role:'tool', content: {todos: [{id:'obj'}]}},  // already-parsed dict
+  ];
+  // Object content is JSON.stringified inside the helper; the substring
+  // guard sees `"todos"` and the parse succeeds.
+  eq(_legacyTodosFromMessages()[0].id, 'obj');
+});
+
+// ─── loadTodos integration ─────────────────────────────────────────────────
+it('loadTodos: prefers S.todos when meta present', () => {
+  reset();
+  _panelActive = true;
+  S.messages = [
+    // legacy fallback would pick this up, but we must NOT use it
+    {role:'tool', content: JSON.stringify({todos:[{id:'legacy'}]})},
+  ];
+  S.todos = [{id:'live', content:'live', status:'pending'}];
+  S.todoStateMeta = {ts: 1, source: 'tool', version: 1};
+  loadTodos();
+  truthy(_panelInnerHTML.indexOf('live') >= 0,
+         'live snapshot must win over legacy when meta is present');
+  truthy(_panelInnerHTML.indexOf('legacy') < 0);
+});
+
+it('loadTodos: falls through to legacy when meta null', () => {
+  reset();
+  _panelActive = true;
+  S.messages = [
+    {role:'tool', content: JSON.stringify({todos:[{id:'fallback', content:'from-legacy', status:'pending'}]})},
+  ];
+  S.todos = [];
+  S.todoStateMeta = null;
+  loadTodos();
+  truthy(_panelInnerHTML.indexOf('from-legacy') >= 0,
+         'must fall through to legacy reverse-scan');
+});
+
+it('loadTodos: hash short-circuits identical re-render', () => {
+  reset();
+  _panelActive = true;
+  S.todos = [{id:'1', content:'x', status:'pending'}];
+  S.todoStateMeta = {ts:1, source:'tool', version:1};
+  loadTodos();
+  const first = _panelInnerHTML;
+  // Mutate the panel from outside; second loadTodos with same hash
+  // must NOT touch innerHTML.
+  _panelInnerHTML = '__user_modified__';
+  loadTodos();
+  eq(_panelInnerHTML, '__user_modified__',
+     'identical hash must short-circuit and skip the innerHTML write');
+});
+
+it('loadTodos: empty state short-circuits on repeat', () => {
+  reset();
+  _panelActive = true;
+  S.todos = [];
+  S.todoStateMeta = {ts:1, source:'tool', version:1};
+  loadTodos();
+  const first = _panelInnerHTML;
+  truthy(first.length > 0, 'first paint sets the empty state');
+  _panelInnerHTML = '__user_modified__';
+  loadTodos();
+  eq(_panelInnerHTML, '__user_modified__',
+     'repeated empty must short-circuit');
+});
+
+it('loadTodos: hash invalidation forces repaint', () => {
+  reset();
+  _panelActive = true;
+  S.todos = [{id:'1', content:'x', status:'pending'}];
+  S.todoStateMeta = {ts:1, source:'tool', version:1};
+  loadTodos();
+  // Status transition → fresh hash → must repaint.
+  S.todos = [{id:'1', content:'x', status:'in_progress'}];
+  loadTodos();
+  truthy(_panelInnerHTML.indexOf('in_progress') >= 0,
+         'status transition must produce a new render');
+});
+
+it('loadTodos: escapes user-controlled strings', () => {
+  reset();
+  _panelActive = true;
+  S.todos = [{id:'1', content:'<script>alert(1)</script>', status:'pending'}];
+  S.todoStateMeta = {ts:1, source:'tool', version:1};
+  loadTodos();
+  truthy(_panelInnerHTML.indexOf('<script>') < 0, 'must escape');
+  truthy(_panelInnerHTML.indexOf('&lt;script&gt;') >= 0, 'must HTML-escape');
+});
+
+// ── Final report ──────────────────────────────────────────────────────────
+console.log(JSON.stringify(results));
+"""
+
+
+def _run_node():
+    # NODE is guaranteed non-None here by the module-level pytestmark
+    # skipif; the assert narrows the type for static analyzers too.
+    assert NODE is not None
+    proc = subprocess.run(
+        [
+            NODE,
+            "-e",
+            _DRIVER,
+            str(UI_JS),
+            str(PANELS_JS),
+            str(REPO_ROOT / "static" / "messages.js"),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"node driver failed (rc={proc.returncode}):\n"
+            f"STDOUT:\n{proc.stdout}\n\nSTDERR:\n{proc.stderr}"
+        )
+    # The driver prints exactly one JSON line at the end.
+    last_line = proc.stdout.strip().splitlines()[-1]
+    return json.loads(last_line)
+
+
+@pytest.fixture(scope="module")
+def driver_results():
+    return _run_node()
+
+
+# Expand each individual JS test into its own pytest case so the
+# failure surface is granular.
+
+def _id(name):
+    """Sanitize a JS test name into a pytest-friendly id."""
+    return name.replace(":", "_").replace(" ", "_")
+
+
+# Run once to discover the test names; pytest parametrize requires the
+# id list at collection time.
+_DISCOVERED_NAMES = [
+    "hash: empty list yields stable string",
+    "hash: id change is detected",
+    "hash: content change is detected",
+    "hash: status change is detected",
+    "hash: list length change is detected",
+    "hash: order change is detected",
+    "hash: missing fields are tolerated",
+    "hash: not-an-array yields empty string",
+    "hydrate: cold-load wins over inflight when cold ts is newer",
+    "hydrate: inflight wins over cold-load when inflight ts is newer",
+    "hydrate: tie ts prefers inflight (freshest in-tab edits)",
+    "hydrate: falls back to inflight when no cold-load",
+    "hydrate: clears state when neither cold-load nor inflight",
+    "hydrate: null session clears state (delete-session path)",
+    "hydrate: resets render cache so next paint runs",
+    "hydrate: cold-load with empty todos yields explicit empty state",
+    "schedule: with RAF coalesces multiple calls",
+    "schedule: skips render when panel inactive",
+    "schedule: paints when panel is active",
+    "schedule: synchronous fallback when RAF missing",
+    "listener: full snapshot replaces (no merge)",
+    "listener: drops events from a different session",
+    "listener: drops events when S.session does not match activeSid",
+    "listener: drops events when no S.session is set yet",
+    "listener: drops events with strictly older ts",
+    "listener: equal ts is allowed (compression after tool)",
+    "listener: malformed JSON is swallowed",
+    "listener: non-array todos rejected",
+    "listener: mirrors snapshot to INFLIGHT",
+    "listener: triggers persistence + render schedule",
+    "listener: empty session_id does not block valid event",
+    "legacy: returns empty when no signal in messages",
+    "legacy: scans S.messages when no S.session.messages",
+    "legacy: prefers S.session.messages when present",
+    "legacy: returns latest todo entry when multiple exist",
+    "legacy: skips non-todo tool payloads via fast-path",
+    "legacy: tolerates malformed JSON",
+    "legacy: handles non-string content gracefully",
+    "loadTodos: prefers S.todos when meta present",
+    "loadTodos: falls through to legacy when meta null",
+    "loadTodos: hash short-circuits identical re-render",
+    "loadTodos: empty state short-circuits on repeat",
+    "loadTodos: hash invalidation forces repaint",
+    "loadTodos: escapes user-controlled strings",
+]
+
+
+@pytest.mark.parametrize("test_name", _DISCOVERED_NAMES, ids=_id)
+def test_js_behaviour(driver_results, test_name):
+    matches = [r for r in driver_results if r["name"] == test_name]
+    assert matches, f"JS test '{test_name}' was not present in driver output"
+    r = matches[0]
+    assert r["ok"], f"JS test '{test_name}' failed:\n{r.get('err','(no detail)')}"
+
+
+def test_all_declared_tests_ran(driver_results):
+    """Guard against driver-side bugs that silently skip tests."""
+    actual = {r["name"] for r in driver_results}
+    declared = set(_DISCOVERED_NAMES)
+    missing = declared - actual
+    extra = actual - declared
+    assert not missing and not extra, (
+        f"Driver/declaration mismatch:\n"
+        f"  missing from driver output: {sorted(missing)}\n"
+        f"  not in DISCOVERED_NAMES:    {sorted(extra)}"
+    )

--- a/tests/test_phase2_todo_behavior.py
+++ b/tests/test_phase2_todo_behavior.py
@@ -27,7 +27,6 @@ from __future__ import annotations
 import json
 import shutil
 import subprocess
-import textwrap
 from pathlib import Path
 
 import pytest

--- a/tests/test_session_rotate_url_sync.py
+++ b/tests/test_session_rotate_url_sync.py
@@ -12,13 +12,27 @@ def test_stream_completion_syncs_rotated_session_id_to_tab_state():
     completion_marker = "S.session=d.session;S.messages=_carryForwardEphemeralTurnFields(S.messages||[], d.session.messages||[]);"
     settled_marker = "S.session=session;\n        const _nextMsgs3018=(session.messages||[]).filter(m=>m&&m.role);"
 
+    # Both blocks end at the same sentinel statement. Slice to it rather
+    # than a hardcoded character window so the assertions stay correct no
+    # matter how many lines get inserted between the `S.session=`
+    # reassignment and the URL-sync guard. A fixed `+ 500` window broke
+    # when the realtime-todos work inserted a `_hydrateTodosFromSession`
+    # line into both paths, pushing `_setActiveSessionUrl(...)` past the
+    # window even though the call itself was untouched.
+    end_sentinel = "const _markerOnlyAssistantError=_replaceMarkerOnlyAssistantWithStreamError(S.messages);"
+
     completion_pos = MESSAGES_JS.find(completion_marker)
     settled_pos = MESSAGES_JS.find(settled_marker)
     assert completion_pos != -1
     assert settled_pos != -1
 
-    completion_block = MESSAGES_JS[completion_pos : completion_pos + 900]
-    settled_block = MESSAGES_JS[settled_pos : settled_pos + 900]
+    completion_end = MESSAGES_JS.find(end_sentinel, completion_pos)
+    settled_end = MESSAGES_JS.find(end_sentinel, settled_pos)
+    assert completion_end != -1, "completion-path block end sentinel not found"
+    assert settled_end != -1, "settled-restore block end sentinel not found"
+
+    completion_block = MESSAGES_JS[completion_pos:completion_end]
+    settled_block = MESSAGES_JS[settled_pos:settled_end]
 
     for block in (completion_block, settled_block):
         assert "localStorage.setItem('hermes-webui-session',S.session.session_id);" in block

--- a/tests/test_session_todo_state_route.py
+++ b/tests/test_session_todo_state_route.py
@@ -1,0 +1,130 @@
+"""Wiring tests for ``attach_todo_state`` call sites in ``api/routes.py``.
+
+Replaces the previous grep-only structural checks with AST-level call
+shape verification.  Behaviour-level coverage of ``attach_todo_state``
+itself lives in ``tests/test_todo_state_emission.py``; end-to-end
+scenarios (full message history → derived snapshot) in
+``tests/test_todo_state_scenarios.py``.
+
+The reviewer's concern was that string presence cannot catch parameter
+swaps (e.g. ``attach_todo_state(msgs, raw)`` instead of
+``attach_todo_state(raw, msgs)``).  This file walks the AST and pins:
+
+* both expected call sites exist (WebUI session GET + CLI fallback),
+* each call passes exactly two positional arguments,
+* the first argument is a plain ``Name`` node (the response payload
+  dict — ``raw`` or ``sess`` in current code) and is mutated in place,
+* the second argument is a plain ``Name`` node (the message list —
+  ``_all_msgs`` or ``msgs`` in current code).
+
+Pinning to ``Name`` nodes (not specific identifiers) keeps the test
+robust to harmless renames while still catching real swaps.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import List
+
+import pytest
+
+
+ROUTES_PY = Path(__file__).parent.parent / "api" / "routes.py"
+
+
+def _attach_todo_state_calls() -> List[ast.Call]:
+    src = ROUTES_PY.read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    calls: List[ast.Call] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if isinstance(func, ast.Name) and func.id == "attach_todo_state":
+            calls.append(node)
+        elif isinstance(func, ast.Attribute) and func.attr == "attach_todo_state":
+            calls.append(node)
+    return calls
+
+
+def test_routes_imports_attach_helper():
+    src = ROUTES_PY.read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    imported = False
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module == "api.todo_state":
+            for alias in node.names:
+                if alias.name == "attach_todo_state":
+                    imported = True
+    assert imported, (
+        "api/routes.py must `from api.todo_state import attach_todo_state` "
+        "so the session GET handler can attach the todo_state cold-load."
+    )
+
+
+def test_attach_called_at_least_twice():
+    """One call covers the WebUI session GET, the other the CLI fallback.
+
+    Both must fire; if a refactor accidentally drops the CLI path, opening
+    a CLI-only session from the sidebar will silently lose the Todos panel
+    cold-load — exactly the regression this test is meant to catch.
+    """
+    calls = _attach_todo_state_calls()
+    assert len(calls) >= 2, (
+        f"api/routes.py must call attach_todo_state from both the WebUI "
+        f"and CLI session paths; found {len(calls)} call site(s)."
+    )
+
+
+@pytest.mark.parametrize("call_index", [0, 1])
+def test_attach_passes_two_positional_args(call_index):
+    """The helper signature is ``attach_todo_state(payload, messages)``.
+
+    Both arguments must be passed positionally — neither has a default.
+    A call with the wrong arity is a regression we want to fail loud.
+    """
+    calls = _attach_todo_state_calls()
+    if call_index >= len(calls):
+        pytest.skip(f"only {len(calls)} call site(s) — index {call_index} skipped")
+    call = calls[call_index]
+    assert len(call.args) == 2, (
+        f"attach_todo_state call at line {call.lineno} must pass exactly 2 "
+        f"positional args (payload, messages); got {len(call.args)}."
+    )
+    assert not call.keywords, (
+        f"attach_todo_state call at line {call.lineno} should not use "
+        f"keyword arguments; the helper signature is purely positional."
+    )
+
+
+@pytest.mark.parametrize("call_index", [0, 1])
+def test_attach_args_are_simple_names(call_index):
+    """Catch a structural swap or accidental literal injection.
+
+    Both arguments must be bare ``Name`` nodes — i.e. local variables
+    (``raw``/``sess`` for payload, ``_all_msgs``/``msgs`` for messages),
+    not literals, attribute accesses, or call results.  This is loose
+    enough to allow harmless renames but still catches things like
+    ``attach_todo_state(raw, [])`` or ``attach_todo_state({}, msgs)``.
+    """
+    calls = _attach_todo_state_calls()
+    if call_index >= len(calls):
+        pytest.skip(f"only {len(calls)} call site(s) — index {call_index} skipped")
+    call = calls[call_index]
+    payload_arg, messages_arg = call.args[0], call.args[1]
+    assert isinstance(payload_arg, ast.Name), (
+        f"attach_todo_state call at line {call.lineno}: first argument "
+        f"(payload) must be a local variable, got {ast.dump(payload_arg)}."
+    )
+    assert isinstance(messages_arg, ast.Name), (
+        f"attach_todo_state call at line {call.lineno}: second argument "
+        f"(messages) must be a local variable, got {ast.dump(messages_arg)}."
+    )
+    # The two arguments must be distinct names — passing the same
+    # variable for both is an obvious wiring bug.
+    assert payload_arg.id != messages_arg.id, (
+        f"attach_todo_state call at line {call.lineno}: payload and "
+        f"messages arguments resolve to the same variable "
+        f"`{payload_arg.id}` — this is almost certainly a copy-paste bug."
+    )

--- a/tests/test_streaming_todo_state.py
+++ b/tests/test_streaming_todo_state.py
@@ -1,0 +1,158 @@
+"""Wiring tests for the live ``todo_state`` SSE emission in ``api/streaming.py``.
+
+The reviewer's concern with the previous grep-only structural test was that
+``substring presence`` cannot catch parameter-passing errors.  This file
+replaces those checks with AST-level call-shape verification:
+
+* every ``emit_todo_state(...)`` call site is parsed,
+* the required keyword arguments are pinned (``name``, ``function_result``,
+  ``session_id``, ``stream_id``),
+* the first positional argument is verified to be ``put``  — the queue
+  callable the helper expects.
+
+This is parse-only (no HTTP server, no live agent) but still catches
+real wiring regressions: dropped kwargs, swapped positional arguments,
+typos like ``stream_id=session_id``, etc.
+
+Behavioural coverage of ``emit_todo_state`` itself lives in
+``tests/test_todo_state_emission.py``; end-to-end scenarios in
+``tests/test_todo_state_scenarios.py``.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import List
+
+import pytest
+
+
+STREAMING_PY = Path(__file__).parent.parent / "api" / "streaming.py"
+
+# Required keyword arguments for every ``emit_todo_state`` call site.
+# These are the names the helper consumes; renaming any of them here
+# without renaming the helper signature is the regression we want to
+# fail loud on.
+REQUIRED_KWARGS = {"name", "function_result", "session_id", "stream_id"}
+
+
+def _emit_todo_state_calls() -> List[ast.Call]:
+    src = STREAMING_PY.read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    calls: List[ast.Call] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if isinstance(func, ast.Name) and func.id == "emit_todo_state":
+            calls.append(node)
+        elif isinstance(func, ast.Attribute) and func.attr == "emit_todo_state":
+            calls.append(node)
+    return calls
+
+
+def test_streaming_imports_emit_helper():
+    """Sanity check: helper must be imported so call sites resolve."""
+    src = STREAMING_PY.read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    imported = False
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module == "api.todo_state":
+            for alias in node.names:
+                if alias.name == "emit_todo_state":
+                    imported = True
+    assert imported, (
+        "api/streaming.py must `from api.todo_state import emit_todo_state` "
+        "so the live SSE path can mirror todo tool state to the browser."
+    )
+
+
+def test_emit_todo_state_called_at_least_twice():
+    """Both legacy ``tool_progress_callback`` (event_type='tool.completed')
+    and modern structured ``on_tool_complete`` paths must emit.  If only one
+    fires, agents using the other path silently lose realtime updates.
+    """
+    calls = _emit_todo_state_calls()
+    assert len(calls) >= 2, (
+        f"api/streaming.py must call emit_todo_state from both the legacy "
+        f"and modern tool callback paths; found {len(calls)} call site(s)."
+    )
+
+
+@pytest.mark.parametrize("call_index", [0, 1])
+def test_emit_call_passes_put_as_first_positional(call_index):
+    """First positional argument must be the SSE ``put`` callback —
+    swapping it for any other identifier would break delivery.
+    """
+    calls = _emit_todo_state_calls()
+    if call_index >= len(calls):
+        pytest.skip(f"only {len(calls)} call site(s) — index {call_index} skipped")
+    call = calls[call_index]
+    assert call.args, (
+        f"emit_todo_state call at line {call.lineno} has no positional args; "
+        "the SSE `put` callback must be the first positional argument."
+    )
+    first = call.args[0]
+    assert isinstance(first, ast.Name) and first.id == "put", (
+        f"emit_todo_state call at line {call.lineno} must pass `put` as the "
+        f"first positional argument; got {ast.dump(first)}."
+    )
+
+
+def test_every_emit_call_supplies_all_required_kwargs():
+    """Every call site must name every required kwarg.  This is what
+    catches a real wiring bug like dropping ``session_id`` or renaming
+    ``function_result`` while leaving the helper untouched.
+    """
+    calls = _emit_todo_state_calls()
+    for call in calls:
+        present = {kw.arg for kw in call.keywords if kw.arg is not None}
+        missing = REQUIRED_KWARGS - present
+        assert not missing, (
+            f"emit_todo_state call at line {call.lineno} is missing "
+            f"required kwargs: {sorted(missing)}.  Required: "
+            f"{sorted(REQUIRED_KWARGS)}; present: {sorted(present)}."
+        )
+
+
+def test_session_id_kwarg_uses_session_id_variable():
+    """Catch a copy-paste swap like ``session_id=stream_id``.
+
+    We cannot fully verify the runtime value, but we can pin the AST
+    shape: in this file ``session_id=`` must read from a ``session_id``
+    name, not from any other identifier.  If the surrounding scope ever
+    renames the variable, update both this test and the call site.
+    """
+    calls = _emit_todo_state_calls()
+    for call in calls:
+        for kw in call.keywords:
+            if kw.arg == "session_id":
+                assert isinstance(kw.value, ast.Name), (
+                    f"emit_todo_state call at line {call.lineno}: "
+                    f"session_id= must be a bare `session_id` identifier, "
+                    f"got {ast.dump(kw.value)}."
+                )
+                assert kw.value.id == "session_id", (
+                    f"emit_todo_state call at line {call.lineno}: "
+                    f"session_id= must read from `session_id`, "
+                    f"got `{kw.value.id}` (suspected copy-paste swap)."
+                )
+
+
+def test_stream_id_kwarg_uses_stream_id_variable():
+    """Symmetric guard: ``stream_id=`` must read from ``stream_id``."""
+    calls = _emit_todo_state_calls()
+    for call in calls:
+        for kw in call.keywords:
+            if kw.arg == "stream_id":
+                assert isinstance(kw.value, ast.Name), (
+                    f"emit_todo_state call at line {call.lineno}: "
+                    f"stream_id= must be a bare `stream_id` identifier, "
+                    f"got {ast.dump(kw.value)}."
+                )
+                assert kw.value.id == "stream_id", (
+                    f"emit_todo_state call at line {call.lineno}: "
+                    f"stream_id= must read from `stream_id`, "
+                    f"got `{kw.value.id}` (suspected copy-paste swap)."
+                )

--- a/tests/test_todo_state.py
+++ b/tests/test_todo_state.py
@@ -1,0 +1,365 @@
+"""Unit tests for ``api.todo_state`` derivation helpers.
+
+These tests pin the canonical snapshot shape and the fall-through
+behaviour for malformed inputs. The streaming and cold-load paths both
+depend on these contracts, so any breakage here will surface at the
+callsites with clear errors.
+
+Behavioural tests for ``emit_todo_state`` and ``attach_todo_state`` —
+the side-effecting wrappers — live in ``tests/test_todo_state_emission.py``.
+End-to-end real-world scenario coverage lives in
+``tests/test_todo_state_scenarios.py``.
+"""
+
+import json
+
+import pytest
+
+from api.todo_state import (
+    EVENT_NAME,
+    PAYLOAD_KEY,
+    VERSION,
+    derive_todo_state,
+    parse_todo_tool_result,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _todo_payload(todos):
+    """Mirror what tools.todo_tool.todo_tool() returns as a JSON string."""
+    pending = sum(1 for t in todos if t["status"] == "pending")
+    in_progress = sum(1 for t in todos if t["status"] == "in_progress")
+    completed = sum(1 for t in todos if t["status"] == "completed")
+    cancelled = sum(1 for t in todos if t["status"] == "cancelled")
+    return json.dumps({
+        "todos": todos,
+        "summary": {
+            "total": len(todos),
+            "pending": pending,
+            "in_progress": in_progress,
+            "completed": completed,
+            "cancelled": cancelled,
+        },
+    }, ensure_ascii=False)
+
+
+def _todo_msg(todos):
+    return {"role": "tool", "content": _todo_payload(todos)}
+
+
+# ---------------------------------------------------------------------------
+# parse_todo_tool_result
+# ---------------------------------------------------------------------------
+
+
+class TestParseTodoToolResult:
+    def test_valid_json_string(self):
+        raw = _todo_payload([
+            {"id": "1", "content": "first", "status": "pending"},
+            {"id": "2", "content": "second", "status": "in_progress"},
+        ])
+        snap = parse_todo_tool_result(raw)
+        assert snap is not None
+        assert snap["version"] == VERSION
+        assert len(snap["todos"]) == 2
+        assert snap["todos"][0]["content"] == "first"
+        assert snap["summary"]["total"] == 2
+        assert snap["summary"]["in_progress"] == 1
+
+    def test_accepts_pre_parsed_dict(self):
+        # Defensive: future callers may deserialize earlier.
+        data = {"todos": [{"id": "1", "content": "x", "status": "pending"}],
+                "summary": {"total": 1}}
+        snap = parse_todo_tool_result(data)
+        assert snap is not None
+        assert snap["todos"][0]["id"] == "1"
+
+    def test_missing_summary_yields_empty_dict(self):
+        raw = json.dumps({"todos": [{"id": "1", "content": "a", "status": "pending"}]})
+        snap = parse_todo_tool_result(raw)
+        assert snap is not None
+        assert snap["summary"] == {}
+
+    def test_summary_not_dict_replaced_with_empty(self):
+        raw = json.dumps({
+            "todos": [{"id": "1", "content": "a", "status": "pending"}],
+            "summary": "broken",
+        })
+        snap = parse_todo_tool_result(raw)
+        assert snap is not None
+        assert snap["summary"] == {}
+
+    @pytest.mark.parametrize("bad", [
+        None,
+        "",
+        "not json",
+        "{",
+        '{"todos": broken',
+    ])
+    def test_invalid_json_returns_none(self, bad):
+        assert parse_todo_tool_result(bad) is None
+
+    @pytest.mark.parametrize("bad", [
+        '{}',
+        '{"foo": "bar"}',
+        '{"todos": "not a list"}',
+        '{"todos": null}',
+        '"just a string"',
+        '42',
+    ])
+    def test_wrong_shape_returns_none(self, bad):
+        assert parse_todo_tool_result(bad) is None
+
+    def test_empty_todos_list_is_valid(self):
+        # An explicit "list cleared" snapshot is a valid state to surface.
+        raw = json.dumps({"todos": [], "summary": {"total": 0}})
+        snap = parse_todo_tool_result(raw)
+        assert snap is not None
+        assert snap["todos"] == []
+
+    def test_returns_new_dict_each_call(self):
+        # Mutating the returned snapshot must never alter another caller's
+        # copy. The dict is built fresh by ``_normalize_snapshot``; pin the
+        # invariant so a future "return data" optimization does not break
+        # callers that mutate (e.g. attaching session_id/ts in emit).
+        raw = _todo_payload([{"id": "1", "content": "x", "status": "pending"}])
+        a = parse_todo_tool_result(raw)
+        b = parse_todo_tool_result(raw)
+        assert a is not None and b is not None
+        assert a is not b
+        a["todos"].append({"id": "ghost", "content": "z", "status": "pending"})
+        assert len(b["todos"]) == 1
+
+    def test_unicode_content_preserved(self):
+        # tools.todo_tool uses ensure_ascii=False; round-tripping through
+        # the parser must keep multibyte content intact (Chinese task names
+        # are common in our usage).
+        raw = _todo_payload([
+            {"id": "1", "content": "审核架构", "status": "in_progress"},
+            {"id": "2", "content": "🚀 deploy", "status": "pending"},
+        ])
+        snap = parse_todo_tool_result(raw)
+        assert snap is not None
+        assert snap["todos"][0]["content"] == "审核架构"
+        assert snap["todos"][1]["content"] == "🚀 deploy"
+
+
+# ---------------------------------------------------------------------------
+# derive_todo_state
+# ---------------------------------------------------------------------------
+
+
+class TestDeriveTodoState:
+    def test_empty_messages(self):
+        assert derive_todo_state([]) is None
+        assert derive_todo_state(None) is None
+
+    def test_no_tool_messages(self):
+        msgs = [
+            {"role": "user", "content": "plan something"},
+            {"role": "assistant", "content": "sure"},
+        ]
+        assert derive_todo_state(msgs) is None
+
+    def test_finds_latest_when_multiple_writes(self):
+        msgs = [
+            _todo_msg([{"id": "1", "content": "old", "status": "completed"}]),
+            {"role": "assistant", "content": "thinking"},
+            _todo_msg([
+                {"id": "1", "content": "new", "status": "in_progress"},
+                {"id": "2", "content": "next", "status": "pending"},
+            ]),
+        ]
+        state = derive_todo_state(msgs)
+        assert state is not None
+        assert state["version"] == VERSION
+        assert len(state["todos"]) == 2
+        assert state["todos"][0]["content"] == "new"
+        assert state["todos"][0]["status"] == "in_progress"
+
+    def test_skips_non_todo_tool_messages(self):
+        msgs = [
+            _todo_msg([{"id": "1", "content": "task", "status": "pending"}]),
+            {"role": "tool", "content": '{"result": "ok"}'},
+            {"role": "tool", "content": '{"output": "hello"}'},
+        ]
+        state = derive_todo_state(msgs)
+        assert state is not None
+        assert state["todos"][0]["content"] == "task"
+
+    def test_malformed_json_skipped(self):
+        msgs = [
+            _todo_msg([{"id": "1", "content": "good", "status": "pending"}]),
+            {"role": "tool", "content": '{"todos": broken json'},
+        ]
+        # The malformed message is skipped; we fall back to the earlier valid one.
+        state = derive_todo_state(msgs)
+        assert state is not None
+        assert state["todos"][0]["content"] == "good"
+
+    def test_non_string_content_skipped(self):
+        # Multimodal tool results carry ``content`` as a list of OpenAI/
+        # Anthropic content parts.  The ``todo`` tool always returns a JSON
+        # string, so list-shaped content is never a todo write — skipping
+        # is correct behavior, not a bug.
+        msgs = [
+            {"role": "tool", "content": None},
+            {"role": "tool", "content": [
+                {"type": "text", "text": '{"todos": [...] }'},
+                {"type": "image_url", "image_url": {"url": "data:..."}},
+            ]},
+        ]
+        assert derive_todo_state(msgs) is None
+
+    def test_non_dict_message_skipped(self):
+        msgs = [
+            "not a message",
+            None,
+            _todo_msg([{"id": "1", "content": "x", "status": "pending"}]),
+        ]
+        state = derive_todo_state(msgs)
+        assert state is not None
+        assert state["todos"][0]["id"] == "1"
+
+    def test_fast_path_skips_non_todo_payloads(self):
+        # The '"todos"' substring guard avoids json.loads on unrelated payloads.
+        # Verified indirectly: a tool message without "todos" in its content
+        # must not be consulted even if json.loads would have succeeded.
+        msgs = [
+            {"role": "tool", "content": '{"unrelated": "value"}'},
+        ]
+        assert derive_todo_state(msgs) is None
+
+    def test_substring_match_passes_fast_path_but_normalize_rejects(self):
+        # The fast-path guard is intentionally loose for cheap filtering.
+        # An unrelated tool result that mentions ``"todos"`` in a string
+        # field passes the substring gate but ``_normalize_snapshot`` then
+        # rejects it because the top-level ``todos`` key is not a list.
+        # This pins the layered defense.
+        msgs = [
+            {"role": "tool", "content": json.dumps({
+                "result": "wrote a file that mentions \"todos\" inside",
+                "todos": "ignore this — string, not list",
+            })},
+        ]
+        assert derive_todo_state(msgs) is None
+
+    def test_messages_iterator_is_supported(self):
+        # Callers may pass any iterable; the helper materializes once.
+        def gen():
+            yield {"role": "user", "content": "hi"}
+            yield _todo_msg([{"id": "1", "content": "task", "status": "pending"}])
+        state = derive_todo_state(gen())
+        assert state is not None
+        assert state["todos"][0]["content"] == "task"
+
+    def test_tuple_input_supported_without_extra_copy(self):
+        # ``reversed`` works on tuples natively; pin support so the optimized
+        # branch (no shallow copy) stays exercised.
+        msgs = (
+            {"role": "user", "content": "go"},
+            _todo_msg([{"id": "1", "content": "t", "status": "pending"}]),
+        )
+        state = derive_todo_state(msgs)
+        assert state is not None
+        assert state["todos"][0]["id"] == "1"
+
+    def test_skips_tool_message_missing_role(self):
+        msgs = [
+            {"content": _todo_payload([
+                {"id": "1", "content": "x", "status": "pending"},
+            ])},
+            {"role": "tool", "content": _todo_payload([
+                {"id": "2", "content": "y", "status": "pending"},
+            ])},
+        ]
+        state = derive_todo_state(msgs)
+        # The role-less entry is skipped; the second one is returned.
+        assert state is not None
+        assert state["todos"][0]["id"] == "2"
+
+    def test_returns_first_valid_when_latest_is_malformed(self):
+        # Realistic ordering: assistant call → tool result. If the latest
+        # tool message is corrupt (truncated by a transport, partial write),
+        # we still surface the prior valid snapshot rather than wiping the
+        # panel.  Mirrors the agent's _hydrate_todo_store fallback.
+        msgs = [
+            _todo_msg([{"id": "1", "content": "good", "status": "pending"}]),
+            _todo_msg([{"id": "2", "content": "newer good", "status": "in_progress"}]),
+            {"role": "tool", "content": '{"todos": ['},  # truncated
+        ]
+        state = derive_todo_state(msgs)
+        assert state is not None
+        assert state["todos"][0]["id"] == "2"
+
+    def test_does_not_mutate_caller_list(self):
+        msgs = [_todo_msg([{"id": "1", "content": "x", "status": "pending"}])]
+        original = list(msgs)
+        derive_todo_state(msgs)
+        # Length and identity of the original entries unchanged.
+        assert msgs == original
+
+    def test_unicode_content_preserved_in_derive(self):
+        msgs = [_todo_msg([
+            {"id": "1", "content": "中文任务", "status": "in_progress"},
+        ])]
+        state = derive_todo_state(msgs)
+        assert state is not None
+        assert state["todos"][0]["content"] == "中文任务"
+
+    def test_large_history_with_late_todo_is_o1_in_practice(self):
+        # 5000-msg history; a single todo write near the end. Reverse
+        # iteration must short-circuit on the first hit, so this test is
+        # both a correctness pin and a perf canary.  We do not assert wall
+        # time — just that we get the right snapshot from a large input
+        # with non-trivial content lengths.
+        big_filler = {"role": "user", "content": "x" * 100}
+        msgs = [big_filler] * 5000
+        msgs.append(_todo_msg([
+            {"id": "late", "content": "ship", "status": "in_progress"},
+        ]))
+        state = derive_todo_state(msgs)
+        assert state is not None
+        assert state["todos"][0]["id"] == "late"
+
+    def test_large_history_with_only_early_todo(self):
+        # Worst case: todo at the very start, 5000 unrelated tool messages
+        # after. Each non-match still has to go through the substring guard,
+        # but the function must still return the correct snapshot.
+        msgs = [_todo_msg([
+            {"id": "early", "content": "first", "status": "completed"},
+        ])]
+        msgs += [
+            {"role": "tool", "content": '{"output":"%d"}' % i}
+            for i in range(5000)
+        ]
+        state = derive_todo_state(msgs)
+        assert state is not None
+        assert state["todos"][0]["id"] == "early"
+
+
+# ---------------------------------------------------------------------------
+# Module-level constants
+# ---------------------------------------------------------------------------
+
+
+class TestModuleConstants:
+    def test_event_name_and_payload_key_exposed(self):
+        # Frontend reads a SSE event named ``todo_state`` and a session GET
+        # payload key ``todo_state``.  Both are pinned via module constants
+        # so a rename is one-line and grep-able.
+        assert EVENT_NAME == "todo_state"
+        assert PAYLOAD_KEY == "todo_state"
+
+    def test_version_is_stable_across_helpers(self):
+        # Cold-load and live-emit must surface the same VERSION so the
+        # frontend can use a single decoder.
+        raw = _todo_payload([{"id": "1", "content": "x", "status": "pending"}])
+        live = parse_todo_tool_result(raw)
+        cold = derive_todo_state([{"role": "tool", "content": raw}])
+        assert live is not None and cold is not None
+        assert live["version"] == cold["version"] == VERSION

--- a/tests/test_todo_state.py
+++ b/tests/test_todo_state.py
@@ -342,6 +342,90 @@ class TestDeriveTodoState:
         assert state["todos"][0]["id"] == "early"
 
 
+class TestDeriveTodoStateTimestamp:
+    """Recency-floor behaviour for the cold-load ``ts`` field.
+
+    These pin the fix for the "shows an old todo list" bug: a context
+    compression/rebuild can strip the ``timestamp`` off the latest todo
+    tool message (it ends up ``None`` on disk). derive_todo_state still
+    finds the correct latest todos by position, but if it emits a
+    snapshot with no ``ts``, the frontend reads coldTs=0 and a stale-but-
+    timestamped INFLIGHT snapshot wins the recency reconcile, rendering a
+    historical list. The latest-by-position snapshot must therefore carry
+    a ts >= any earlier todo write's ts even when its own field is lost.
+    """
+
+    def test_uses_own_timestamp_when_present(self):
+        msg = {**_todo_msg([{"id": "1", "content": "x", "status": "pending"}]),
+               "timestamp": 1234.5}
+        state = derive_todo_state([msg])
+        assert state is not None
+        assert state["ts"] == 1234.5
+
+    def test_no_ts_field_when_no_timestamps_anywhere(self):
+        # Nothing in the history carries a timestamp -> snapshot omits ts
+        # entirely (matches the historical contract for un-timestamped
+        # sessions; the frontend treats missing ts as coldTs=0).
+        state = derive_todo_state([
+            _todo_msg([{"id": "1", "content": "x", "status": "pending"}]),
+        ])
+        assert state is not None
+        assert "ts" not in state
+
+    def test_falls_back_to_max_prior_timestamp_when_latest_todo_ts_lost(self):
+        # The latest todo message lost its timestamp during compression,
+        # but earlier messages still carry real timestamps. The cold-load
+        # ts must floor to the max prior timestamp so it cannot lose a
+        # recency comparison against a stale earlier todo snapshot.
+        msgs = [
+            {"role": "user", "content": "go", "timestamp": 100.0},
+            {"role": "assistant", "content": "ok", "timestamp": 200.0},
+            # earlier todo that an INFLIGHT snapshot might still hold
+            {**_todo_msg([{"id": "old", "content": "v1", "status": "pending"}]),
+             "timestamp": 250.0},
+            {"role": "assistant", "content": "more", "timestamp": 300.0},
+            # latest todo — timestamp stripped by compression
+            {**_todo_msg([{"id": "new", "content": "v2", "status": "in_progress"}]),
+             "timestamp": None},
+        ]
+        state = derive_todo_state(msgs)
+        assert state is not None
+        # correct latest list by position
+        assert state["todos"][0]["id"] == "new"
+        # ts floored to the max prior timestamp (300.0), strictly greater
+        # than the earlier todo's 250.0 so cold-load wins the reconcile
+        assert state["ts"] == 300.0
+
+    def test_fallback_floor_does_not_borrow_future_timestamp(self):
+        # The recency floor scans only messages at or before the todo's
+        # position, so a later message's timestamp is never borrowed.
+        msgs = [
+            {"role": "user", "content": "go", "timestamp": 100.0},
+            # latest todo (by position) with no timestamp
+            {**_todo_msg([{"id": "new", "content": "v2", "status": "pending"}]),
+             "timestamp": None},
+            # a message AFTER the todo with a large timestamp — must be
+            # ignored by the floor since it comes later in the transcript
+            {"role": "assistant", "content": "later", "timestamp": 9999.0},
+        ]
+        state = derive_todo_state(msgs)
+        assert state is not None
+        assert state["todos"][0]["id"] == "new"
+        # floor is 100.0 (the only prior timestamp), NOT 9999.0
+        assert state["ts"] == 100.0
+
+    def test_malformed_own_timestamp_uses_floor(self):
+        # A non-numeric timestamp coerces to 0 and triggers the floor.
+        msgs = [
+            {"role": "user", "content": "go", "timestamp": 500.0},
+            {**_todo_msg([{"id": "1", "content": "x", "status": "pending"}]),
+             "timestamp": "not-a-number"},
+        ]
+        state = derive_todo_state(msgs)
+        assert state is not None
+        assert state["ts"] == 500.0
+
+
 # ---------------------------------------------------------------------------
 # Module-level constants
 # ---------------------------------------------------------------------------

--- a/tests/test_todo_state_emission.py
+++ b/tests/test_todo_state_emission.py
@@ -1,0 +1,407 @@
+"""Behavioural tests for the side-effecting wrappers in ``api.todo_state``.
+
+These tests exercise ``emit_todo_state`` and ``attach_todo_state``
+directly against a captured ``put`` callable / payload dict, without
+spinning up a full HTTP server. They cover:
+
+* the public contract — when does an event/attachment fire, what shape
+  does it have, and what is its source-of-truth for each field;
+* the failure-isolation contract — emission must never raise, even
+  when ``put`` itself raises or the input is garbage;
+* the wire-format contract — every key the frontend (``static/messages.js``
+  for live, ``static/ui.js`` for cold-load) reads must be present.
+
+End-to-end scenarios that combine emit + attach with realistic
+session histories live in ``tests/test_todo_state_scenarios.py``.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import Any, Dict, List, Tuple
+
+import pytest
+
+from api.todo_state import (
+    EVENT_NAME,
+    PAYLOAD_KEY,
+    VERSION,
+    attach_todo_state,
+    emit_todo_state,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+def _todo_payload(todos: List[Dict[str, str]]) -> str:
+    """JSON string mirroring what ``tools.todo_tool.todo_tool`` returns."""
+    pending = sum(1 for t in todos if t["status"] == "pending")
+    in_progress = sum(1 for t in todos if t["status"] == "in_progress")
+    completed = sum(1 for t in todos if t["status"] == "completed")
+    cancelled = sum(1 for t in todos if t["status"] == "cancelled")
+    return json.dumps({
+        "todos": todos,
+        "summary": {
+            "total": len(todos),
+            "pending": pending,
+            "in_progress": in_progress,
+            "completed": completed,
+            "cancelled": cancelled,
+        },
+    }, ensure_ascii=False)
+
+
+class _Recorder:
+    """Captures ``(event, data)`` calls to a ``put``-shaped callable."""
+
+    def __init__(self) -> None:
+        self.events: List[Tuple[str, Dict[str, Any]]] = []
+
+    def __call__(self, event: str, data: Dict[str, Any]) -> None:
+        self.events.append((event, data))
+
+
+# ---------------------------------------------------------------------------
+# emit_todo_state — happy path
+# ---------------------------------------------------------------------------
+
+
+class TestEmitTodoStateHappyPath:
+    """Coverage for the ``name=='todo'`` + valid payload case."""
+
+    def test_emits_when_name_is_todo(self):
+        rec = _Recorder()
+        result = emit_todo_state(
+            rec,
+            name="todo",
+            function_result=_todo_payload([
+                {"id": "1", "content": "task", "status": "pending"},
+            ]),
+            session_id="sess-A",
+            stream_id="stream-1",
+        )
+        assert result is True
+        assert len(rec.events) == 1
+        ev_name, ev_data = rec.events[0]
+        assert ev_name == EVENT_NAME == "todo_state"
+        assert isinstance(ev_data, dict)
+
+    def test_payload_carries_full_wire_contract(self):
+        """Pin every key ``static/messages.js`` reads off the event."""
+        rec = _Recorder()
+        emit_todo_state(
+            rec,
+            name="todo",
+            function_result=_todo_payload([
+                {"id": "1", "content": "x", "status": "in_progress"},
+                {"id": "2", "content": "y", "status": "pending"},
+            ]),
+            session_id="sess-A",
+            stream_id="stream-1",
+        )
+        _, ev = rec.events[0]
+        # ─── identity / addressing ───────────────────────────────────
+        assert ev["session_id"] == "sess-A"
+        assert ev["stream_id"] == "stream-1"
+        assert ev["source"] == "tool"
+        # ─── ordering ───────────────────────────────────────────────
+        # ts is a server-clock float; the frontend uses it to drop
+        # strictly-older snapshots. Assert it's wall-clock-ish, not
+        # epoch zero or a sentinel.
+        assert isinstance(ev["ts"], float)
+        assert ev["ts"] > 1_700_000_000  # well past 2023-11
+        # ─── snapshot ───────────────────────────────────────────────
+        assert isinstance(ev["todos"], list)
+        assert len(ev["todos"]) == 2
+        assert ev["todos"][0]["status"] == "in_progress"
+        assert ev["summary"]["total"] == 2
+        assert ev["summary"]["in_progress"] == 1
+        assert ev["version"] == VERSION
+
+    def test_default_source_is_tool(self):
+        rec = _Recorder()
+        emit_todo_state(
+            rec,
+            name="todo",
+            function_result=_todo_payload([
+                {"id": "1", "content": "x", "status": "pending"},
+            ]),
+            session_id="s", stream_id="r",
+        )
+        assert rec.events[0][1]["source"] == "tool"
+
+    def test_custom_source_respected(self):
+        # Future callers — e.g. a compression-refresh refresh — pass an
+        # explicit ``source`` so the frontend can distinguish fresh
+        # writes from re-hydrate snapshots.
+        rec = _Recorder()
+        emit_todo_state(
+            rec,
+            name="todo",
+            function_result=_todo_payload([
+                {"id": "1", "content": "x", "status": "pending"},
+            ]),
+            session_id="s", stream_id="r",
+            source="compression-refresh",
+        )
+        assert rec.events[0][1]["source"] == "compression-refresh"
+
+    def test_accepts_pre_parsed_dict_result(self):
+        # Modern callbacks may deserialise earlier in the pipeline; the
+        # helper must accept a dict, not just a JSON string.
+        rec = _Recorder()
+        ok = emit_todo_state(
+            rec,
+            name="todo",
+            function_result={
+                "todos": [{"id": "1", "content": "x", "status": "pending"}],
+                "summary": {"total": 1, "pending": 1},
+            },
+            session_id="s", stream_id="r",
+        )
+        assert ok is True
+        assert rec.events[0][1]["todos"][0]["id"] == "1"
+
+    def test_ts_is_close_to_wall_clock(self):
+        before = time.time()
+        rec = _Recorder()
+        emit_todo_state(
+            rec,
+            name="todo",
+            function_result=_todo_payload([
+                {"id": "1", "content": "x", "status": "pending"},
+            ]),
+            session_id="s", stream_id="r",
+        )
+        after = time.time()
+        ts = rec.events[0][1]["ts"]
+        # Allow a generous ±2 s window for slow CI.  The point is to
+        # catch a regression that hard-codes 0 or a stale value.
+        assert before - 2 <= ts <= after + 2
+
+
+# ---------------------------------------------------------------------------
+# emit_todo_state — guard / no-emit cases
+# ---------------------------------------------------------------------------
+
+
+class TestEmitTodoStateGuards:
+    """All the cases where the helper must NOT emit."""
+
+    @pytest.mark.parametrize("name", [
+        "read_file", "write_file", "patch", "terminal", "todo_tool",
+        "TODO", "todos", "", None,
+    ])
+    def test_skips_non_todo_names(self, name):
+        rec = _Recorder()
+        result = emit_todo_state(
+            rec,
+            name=name,
+            function_result=_todo_payload([
+                {"id": "1", "content": "x", "status": "pending"},
+            ]),
+            session_id="s", stream_id="r",
+        )
+        assert result is False
+        assert rec.events == []
+
+    @pytest.mark.parametrize("bad", [
+        None,
+        "",
+        "not json",
+        "{",
+        "{}",
+        '{"foo": "bar"}',
+        '{"todos": "not a list"}',
+        '{"todos": null}',
+        '"just a string"',
+        "42",
+    ])
+    def test_skips_when_payload_unparseable_or_wrong_shape(self, bad):
+        rec = _Recorder()
+        result = emit_todo_state(
+            rec,
+            name="todo",
+            function_result=bad,
+            session_id="s", stream_id="r",
+        )
+        assert result is False
+        assert rec.events == []
+
+    def test_returns_false_when_put_raises(self):
+        # A broken queue must not bring down the tool delivery path.
+        # The helper swallows + returns False so the caller's own
+        # try/except is no longer load-bearing.
+        def boom(_event, _data):
+            raise RuntimeError("queue is dead")
+        result = emit_todo_state(
+            boom,
+            name="todo",
+            function_result=_todo_payload([
+                {"id": "1", "content": "x", "status": "pending"},
+            ]),
+            session_id="s", stream_id="r",
+        )
+        assert result is False  # swallowed, never raised
+
+
+# ---------------------------------------------------------------------------
+# emit_todo_state — addressing / metadata
+# ---------------------------------------------------------------------------
+
+
+class TestEmitTodoStateAddressing:
+    def test_none_session_and_stream_still_emits(self):
+        # Defensive: if a caller forgets to pass IDs we still emit so
+        # the panel can update; the frontend treats missing
+        # ``session_id`` as "no filter" and accepts the event.
+        rec = _Recorder()
+        emit_todo_state(
+            rec,
+            name="todo",
+            function_result=_todo_payload([
+                {"id": "1", "content": "x", "status": "pending"},
+            ]),
+            session_id=None, stream_id=None,
+        )
+        ev = rec.events[0][1]
+        assert ev["session_id"] is None
+        assert ev["stream_id"] is None
+
+    def test_event_name_and_payload_keys_match_module_constants(self):
+        # Frontend pins on string literals; the module exposes them as
+        # constants so a rename is one place. This test makes sure the
+        # constants and the actual emission stay in sync.
+        rec = _Recorder()
+        emit_todo_state(
+            rec,
+            name="todo",
+            function_result=_todo_payload([
+                {"id": "1", "content": "x", "status": "pending"},
+            ]),
+            session_id="s", stream_id="r",
+        )
+        ev_name, ev_data = rec.events[0]
+        assert ev_name == EVENT_NAME
+        # PAYLOAD_KEY is for cold-load on the session GET, not for the
+        # SSE event — but the wire field on cold-load is the same name.
+        assert PAYLOAD_KEY == EVENT_NAME == "todo_state"
+        # Top-level event dict must not collide with snapshot fields.
+        for k in ("session_id", "stream_id", "source", "ts",
+                  "todos", "summary", "version"):
+            assert k in ev_data, f"missing {k} in emit payload"
+
+
+# ---------------------------------------------------------------------------
+# attach_todo_state — direct unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestAttachTodoStateHappyPath:
+    def test_attaches_to_empty_payload(self):
+        payload: Dict[str, Any] = {}
+        msgs = [{"role": "tool", "content": _todo_payload([
+            {"id": "1", "content": "x", "status": "pending"},
+        ])}]
+        result = attach_todo_state(payload, msgs)
+        assert result is True
+        assert PAYLOAD_KEY in payload
+        snap = payload[PAYLOAD_KEY]
+        assert snap["version"] == VERSION
+        assert snap["todos"][0]["id"] == "1"
+
+    def test_attaches_to_existing_payload_without_clobbering(self):
+        # Mirrors how ``api/routes.py`` calls the helper: ``raw`` already
+        # contains session metadata when we attach todo_state.
+        payload: Dict[str, Any] = {
+            "session_id": "s",
+            "title": "do something",
+            "messages": [],
+            "tool_calls": [],
+        }
+        msgs = [{"role": "tool", "content": _todo_payload([
+            {"id": "1", "content": "x", "status": "pending"},
+        ])}]
+        attach_todo_state(payload, msgs)
+        # Original keys must survive the mutation.
+        assert payload["session_id"] == "s"
+        assert payload["title"] == "do something"
+        assert PAYLOAD_KEY in payload
+
+    def test_returns_false_and_leaves_payload_alone_for_no_messages(self):
+        payload: Dict[str, Any] = {"session_id": "s"}
+        assert attach_todo_state(payload, []) is False
+        assert attach_todo_state(payload, None) is False
+        assert "todo_state" not in payload
+
+    def test_returns_false_for_messages_without_todo(self):
+        payload: Dict[str, Any] = {}
+        msgs = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+            {"role": "tool", "content": '{"output": "ok"}'},
+        ]
+        assert attach_todo_state(payload, msgs) is False
+        assert "todo_state" not in payload
+
+    def test_returns_false_when_messages_iteration_raises(self):
+        # If the caller hands us a broken iterable (e.g. a generator
+        # that raises on next()), the helper must swallow and not pollute
+        # the response.
+        def broken():
+            yield {"role": "user", "content": "hi"}
+            raise RuntimeError("storage corrupted")
+        payload: Dict[str, Any] = {"session_id": "s"}
+        result = attach_todo_state(payload, broken())
+        assert result is False
+        assert "todo_state" not in payload
+
+
+# ---------------------------------------------------------------------------
+# attach_todo_state — multi-write history
+# ---------------------------------------------------------------------------
+
+
+class TestAttachTodoStateMultiWrite:
+    def test_picks_latest_write_in_history(self):
+        old = _todo_payload([
+            {"id": "1", "content": "old plan", "status": "completed"},
+        ])
+        new = _todo_payload([
+            {"id": "1", "content": "new plan", "status": "in_progress"},
+            {"id": "2", "content": "next step", "status": "pending"},
+        ])
+        msgs = [
+            {"role": "user", "content": "go"},
+            {"role": "tool", "content": old},
+            {"role": "assistant", "content": "thinking"},
+            {"role": "tool", "content": new},
+            {"role": "assistant", "content": "done"},
+        ]
+        payload: Dict[str, Any] = {}
+        attach_todo_state(payload, msgs)
+        snap = payload["todo_state"]
+        assert len(snap["todos"]) == 2
+        assert snap["todos"][0]["content"] == "new plan"
+        assert snap["todos"][0]["status"] == "in_progress"
+
+    def test_falls_back_to_prior_valid_when_latest_truncated(self):
+        # Realistic transport corruption: the most recent tool message was
+        # truncated mid-write.  We must surface the prior valid snapshot
+        # rather than wiping the panel.  Mirrors the agent's hydrate
+        # fallback logic.
+        good = _todo_payload([
+            {"id": "1", "content": "valid", "status": "in_progress"},
+        ])
+        msgs = [
+            {"role": "tool", "content": good},
+            {"role": "tool", "content": '{"todos": ['},
+        ]
+        payload: Dict[str, Any] = {}
+        result = attach_todo_state(payload, msgs)
+        assert result is True
+        assert payload["todo_state"]["todos"][0]["content"] == "valid"

--- a/tests/test_todo_state_robustness.py
+++ b/tests/test_todo_state_robustness.py
@@ -1,0 +1,283 @@
+"""Robustness tests for ``api.todo_state`` derivation and emission.
+
+Adds coverage that earlier review identified as missing or weak:
+
+* malformed *items* inside an otherwise-valid ``todos`` list — the
+  helper currently passes them through (todo tool produces canonical
+  shapes only), and we want that contract pinned with explicit
+  evidence so a future tightener does so deliberately;
+* ``timestamp`` propagation from cold-load source message to the
+  derived snapshot ``ts`` field — the frontend depends on this for
+  cold-load vs. INFLIGHT recency reconciliation;
+* extra malformed payload shapes for ``emit_todo_state`` (top-level
+  array, ``ts`` non-numeric, ``session_id`` non-string);
+* concurrent ``emit_todo_state`` calls on a thread-safe ``put`` —
+  smoke test for the helper itself; the production ``put`` is a
+  ``Queue.put_nowait`` which is already thread-safe.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from typing import Any, Dict, List, Tuple
+
+import pytest
+
+from api.todo_state import (
+    attach_todo_state,
+    derive_todo_state,
+    emit_todo_state,
+    parse_todo_tool_result,
+)
+
+
+def _todo_payload(todos):
+    return json.dumps({
+        "todos": todos,
+        "summary": {"total": len(todos)},
+    }, ensure_ascii=False)
+
+
+# ---------------------------------------------------------------------------
+# Malformed items inside a valid `todos` list
+# ---------------------------------------------------------------------------
+
+
+class TestMalformedTodoItems:
+    """Pin the current pass-through contract for non-canonical items.
+
+    The ``todo`` tool always returns canonical ``{id, content, status}``
+    objects, so production never sees these.  But the helper does not
+    validate per-item shape, and the frontend tolerates whatever lands
+    in the array (``esc()`` handles the rendering).  These tests pin
+    that contract so a refactor that adds validation has to do so
+    deliberately and update both ends together.
+    """
+
+    @pytest.mark.parametrize("garbage", [
+        None,
+        42,
+        3.14,
+        True,
+        "bare string",
+        [],
+        ["nested", "list"],
+        {"id": "1"},  # missing content/status
+        {"content": "x"},  # missing id/status
+        {"status": "pending"},  # missing id/content
+    ])
+    def test_parse_passes_through_malformed_items(self, garbage):
+        result = parse_todo_tool_result(_todo_payload([garbage]))
+        assert result is not None
+        assert result["todos"] == [garbage]
+
+    def test_derive_passes_through_mixed_canonical_and_malformed(self):
+        msgs = [{"role": "tool", "content": _todo_payload([
+            {"id": "1", "content": "ok", "status": "pending"},
+            None,
+            "stray string",
+            {"id": "2", "content": "also ok", "status": "completed"},
+        ])}]
+        snap = derive_todo_state(msgs)
+        assert snap is not None
+        assert len(snap["todos"]) == 4
+        assert snap["todos"][0]["id"] == "1"
+        assert snap["todos"][3]["id"] == "2"
+
+    def test_emit_passes_through_malformed_items(self):
+        events: List[Tuple[str, Dict[str, Any]]] = []
+        emit_todo_state(
+            lambda ev, d: events.append((ev, d)),
+            name="todo",
+            function_result=_todo_payload([
+                {"id": "1", "content": "ok", "status": "pending"},
+                None,
+            ]),
+            session_id="s",
+            stream_id="r",
+        )
+        assert len(events) == 1
+        assert events[0][1]["todos"][1] is None
+
+
+# ---------------------------------------------------------------------------
+# Cold-load `ts` propagation (drives frontend INFLIGHT recency reconcile)
+# ---------------------------------------------------------------------------
+
+
+class TestColdLoadTimestampPropagation:
+    """``derive_todo_state`` must surface the source message timestamp.
+
+    The frontend's ``_hydrateTodosFromSession`` uses this field to pick
+    the newer of cold-load vs. INFLIGHT when both are present, avoiding
+    visible rollback on reload of a still-running session.
+    """
+
+    def test_ts_propagates_when_message_has_timestamp(self):
+        msgs = [{
+            "role": "tool",
+            "timestamp": 1_700_000_500.5,
+            "content": _todo_payload([
+                {"id": "1", "content": "x", "status": "pending"},
+            ]),
+        }]
+        snap = derive_todo_state(msgs)
+        assert snap is not None
+        assert snap.get("ts") == pytest.approx(1_700_000_500.5)
+
+    def test_ts_omitted_when_message_has_no_timestamp(self):
+        msgs = [{
+            "role": "tool",
+            "content": _todo_payload([
+                {"id": "1", "content": "x", "status": "pending"},
+            ]),
+        }]
+        snap = derive_todo_state(msgs)
+        assert snap is not None
+        # Frontend treats missing ts as 0 — explicit omission keeps the
+        # wire payload small and signals "unknown" instead of "0".
+        assert "ts" not in snap
+
+    @pytest.mark.parametrize("bad_ts", [None, "", "not a number", float("nan"), [], {}])
+    def test_garbage_timestamp_falls_back_to_omitted(self, bad_ts):
+        msgs = [{
+            "role": "tool",
+            "timestamp": bad_ts,
+            "content": _todo_payload([
+                {"id": "1", "content": "x", "status": "pending"},
+            ]),
+        }]
+        snap = derive_todo_state(msgs)
+        assert snap is not None
+        # NaN may slip past float() but we don't propagate it.
+        ts = snap.get("ts")
+        assert ts is None or (isinstance(ts, float) and ts == ts)  # not NaN
+
+    def test_ts_picks_latest_message_in_history(self):
+        """Multi-write history: the propagated ts must come from the
+        same message we picked for the snapshot, not an older one."""
+        old = {
+            "role": "tool",
+            "timestamp": 1_700_000_000.0,
+            "content": _todo_payload([
+                {"id": "1", "content": "old", "status": "completed"},
+            ]),
+        }
+        new = {
+            "role": "tool",
+            "timestamp": 1_700_000_500.0,
+            "content": _todo_payload([
+                {"id": "1", "content": "new", "status": "in_progress"},
+            ]),
+        }
+        snap = derive_todo_state([old, new])
+        assert snap is not None
+        assert snap["todos"][0]["content"] == "new"
+        assert snap.get("ts") == pytest.approx(1_700_000_500.0)
+
+    def test_attach_carries_ts_through_to_payload(self):
+        payload: Dict[str, Any] = {}
+        msgs = [{
+            "role": "tool",
+            "timestamp": 1_700_001_234.0,
+            "content": _todo_payload([
+                {"id": "1", "content": "x", "status": "pending"},
+            ]),
+        }]
+        attach_todo_state(payload, msgs)
+        assert payload["todo_state"].get("ts") == pytest.approx(1_700_001_234.0)
+
+
+# ---------------------------------------------------------------------------
+# Extra malformed payload shapes for emit_todo_state
+# ---------------------------------------------------------------------------
+
+
+class TestEmitMalformedExtras:
+    @pytest.mark.parametrize("payload", [
+        "[]",                  # top-level array
+        "[{\"todos\": []}]",   # array wrapping object
+        '{"todos":[],"ts":"not a number"}',
+        '{"todos":[],"summary":"not an object"}',
+        '"',                   # truly garbage
+    ])
+    def test_does_not_emit_for_unparseable_or_wrong_top_level(self, payload):
+        events: List[Tuple[str, Dict[str, Any]]] = []
+        ok = emit_todo_state(
+            lambda ev, d: events.append((ev, d)),
+            name="todo",
+            function_result=payload,
+            session_id="s",
+            stream_id="r",
+        )
+        # The first three are valid JSON shapes that don't match the
+        # contract; the helper either rejects them outright (top-level
+        # array) or normalizes the parts it understands and emits.  We
+        # accept either outcome here — the contract we pin is "no crash"
+        # and "no malformed top-level event".
+        if ok:
+            assert events and events[0][0] == "todo_state"
+            assert isinstance(events[0][1].get("todos"), list)
+        else:
+            assert events == []
+
+
+# ---------------------------------------------------------------------------
+# Concurrent emit_todo_state — thread safety smoke test
+# ---------------------------------------------------------------------------
+
+
+class TestConcurrentEmit:
+    def test_concurrent_emits_do_not_drop_or_crash(self):
+        """Production ``put`` is ``Queue.put_nowait`` (thread-safe).
+        Verify the helper itself adds no shared mutable state — N threads
+        each emit M times should produce exactly N*M events."""
+        lock = threading.Lock()
+        events: List[Tuple[str, Dict[str, Any]]] = []
+
+        def put(ev, d):
+            with lock:
+                events.append((ev, d))
+
+        N_THREADS = 8
+        N_EMITS = 50
+        barrier = threading.Barrier(N_THREADS)
+        errors: List[BaseException] = []
+
+        def worker(thread_idx: int):
+            try:
+                barrier.wait()  # maximize contention
+                for i in range(N_EMITS):
+                    emit_todo_state(
+                        put,
+                        name="todo",
+                        function_result=_todo_payload([
+                            {"id": f"t{thread_idx}-{i}",
+                             "content": "x",
+                             "status": "pending"},
+                        ]),
+                        session_id=f"sess-{thread_idx}",
+                        stream_id=f"stream-{thread_idx}",
+                    )
+            except BaseException as exc:  # pragma: no cover — should never fire
+                errors.append(exc)
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(N_THREADS)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors, f"emit raised under contention: {errors}"
+        assert len(events) == N_THREADS * N_EMITS
+        # Each emit must produce exactly one event with the correct name.
+        assert all(ev == "todo_state" for ev, _ in events)
+        # No event must mix session_ids — the helper takes session_id by
+        # parameter so cross-talk is structurally impossible, but pin it.
+        per_session_counts: Dict[str, int] = {}
+        for _, data in events:
+            per_session_counts[data["session_id"]] = (
+                per_session_counts.get(data["session_id"], 0) + 1
+            )
+        assert per_session_counts == {f"sess-{i}": N_EMITS for i in range(N_THREADS)}

--- a/tests/test_todo_state_scenarios.py
+++ b/tests/test_todo_state_scenarios.py
@@ -492,7 +492,7 @@ class TestScenarioFailureIsolation:
             except Exception as exc:  # pragma: no cover — defensive
                 raise AssertionError(
                     f"emit_todo_state raised on {bad!r}: {exc}"
-                )
+                ) from exc
         # No event should have leaked through; all silently dropped.
         assert rec.todo_events() == []
 

--- a/tests/test_todo_state_scenarios.py
+++ b/tests/test_todo_state_scenarios.py
@@ -1,0 +1,741 @@
+"""End-to-end real-world scenario coverage for the ``todo_state`` pipeline.
+
+Each test in this file maps to a concrete user-facing scenario that
+showed up in the original review. Together they exercise:
+
+  * **Live SSE path** — ``api.todo_state.emit_todo_state`` driven from
+    the legacy and modern tool callbacks.
+  * **Cold-load path** — ``api.todo_state.attach_todo_state`` invoked
+    from both the WebUI session GET and the CLI session fallback.
+  * **Round-trips** — emit a snapshot, replay the same payload as a
+    settled tool message, and confirm cold-load returns the same
+    todos.
+
+The wire-format pin (`SSE event keys`, `session GET payload key`) is
+duplicated here on purpose so a regression that breaks the frontend
+contract surfaces in *both* the emission unit tests and the scenario
+tests.
+
+Cross-cutting expectations
+--------------------------
+Backend payload correctness:
+
+* ``emit_todo_state`` events always carry
+  ``{session_id, stream_id, source, ts, todos, summary, version}``.
+* ``attach_todo_state`` injects exactly one key into the response —
+  ``todo_state`` — whose value is ``{todos, summary, version}``
+  (no SSE-only fields like ``ts`` leak into cold-load).
+* Snapshots are full — re-applying the same one is a no-op.
+* Identical input → identical output (deterministic).
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import Any, Dict, List, Tuple
+
+from api.todo_state import (
+    EVENT_NAME,
+    PAYLOAD_KEY,
+    VERSION,
+    attach_todo_state,
+    emit_todo_state,
+)
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+def _todo_payload(todos: List[Dict[str, str]]) -> str:
+    pending = sum(1 for t in todos if t["status"] == "pending")
+    in_progress = sum(1 for t in todos if t["status"] == "in_progress")
+    completed = sum(1 for t in todos if t["status"] == "completed")
+    cancelled = sum(1 for t in todos if t["status"] == "cancelled")
+    return json.dumps({
+        "todos": todos,
+        "summary": {
+            "total": len(todos),
+            "pending": pending,
+            "in_progress": in_progress,
+            "completed": completed,
+            "cancelled": cancelled,
+        },
+    }, ensure_ascii=False)
+
+
+def _user_msg(text: str) -> Dict[str, Any]:
+    return {"role": "user", "content": text}
+
+
+def _assistant_msg(text: str) -> Dict[str, Any]:
+    return {"role": "assistant", "content": text}
+
+
+def _tool_msg(content: str) -> Dict[str, Any]:
+    return {"role": "tool", "content": content}
+
+
+def _multimodal_tool_msg() -> Dict[str, Any]:
+    """Realistic Anthropic/OpenAI multimodal content shape — list of parts."""
+    return {
+        "role": "tool",
+        "content": [
+            {"type": "text", "text": "saw a cat"},
+            {"type": "image_url",
+             "image_url": {"url": "data:image/png;base64,iVBOR..."}},
+        ],
+    }
+
+
+class _Recorder:
+    """Captures ``put(event, data)`` calls."""
+
+    def __init__(self) -> None:
+        self.events: List[Tuple[str, Dict[str, Any]]] = []
+
+    def __call__(self, event: str, data: Dict[str, Any]) -> None:
+        self.events.append((event, data))
+
+    def todo_events(self) -> List[Dict[str, Any]]:
+        return [d for (e, d) in self.events if e == EVENT_NAME]
+
+
+# ---------------------------------------------------------------------------
+# Scenario 1 — Live mid-turn updates
+# ---------------------------------------------------------------------------
+
+
+class TestScenarioLiveMidTurn:
+    """Agent walks the todos panel from pending → in_progress → done."""
+
+    def test_three_writes_produce_three_distinct_snapshots(self):
+        rec = _Recorder()
+        # Initial plan.
+        emit_todo_state(rec, name="todo",
+            function_result=_todo_payload([
+                {"id": "1", "content": "design", "status": "in_progress"},
+                {"id": "2", "content": "implement", "status": "pending"},
+                {"id": "3", "content": "test", "status": "pending"},
+            ]),
+            session_id="s", stream_id="r")
+        # Mid-turn step 1.
+        emit_todo_state(rec, name="todo",
+            function_result=_todo_payload([
+                {"id": "1", "content": "design", "status": "completed"},
+                {"id": "2", "content": "implement", "status": "in_progress"},
+                {"id": "3", "content": "test", "status": "pending"},
+            ]),
+            session_id="s", stream_id="r")
+        # Mid-turn step 2.
+        emit_todo_state(rec, name="todo",
+            function_result=_todo_payload([
+                {"id": "1", "content": "design", "status": "completed"},
+                {"id": "2", "content": "implement", "status": "completed"},
+                {"id": "3", "content": "test", "status": "in_progress"},
+            ]),
+            session_id="s", stream_id="r")
+
+        evs = rec.todo_events()
+        assert len(evs) == 3
+        statuses = [
+            tuple(t["status"] for t in ev["todos"])
+            for ev in evs
+        ]
+        assert statuses == [
+            ("in_progress", "pending",     "pending"),
+            ("completed",   "in_progress", "pending"),
+            ("completed",   "completed",   "in_progress"),
+        ]
+
+    def test_ts_is_monotonic_within_a_stream(self):
+        rec = _Recorder()
+        for _ in range(5):
+            emit_todo_state(rec, name="todo",
+                function_result=_todo_payload([
+                    {"id": "1", "content": "x", "status": "pending"},
+                ]),
+                session_id="s", stream_id="r")
+            time.sleep(0.001)  # ensure clock advances on fast machines
+        ts_values = [ev["ts"] for ev in rec.todo_events()]
+        # Every consecutive ts must be >= prior. Frontend uses this
+        # ordering to drop strictly-older snapshots on replay.
+        for i in range(1, len(ts_values)):
+            assert ts_values[i] >= ts_values[i - 1]
+
+    def test_full_snapshot_idempotent_on_double_emit(self):
+        # Frontend treats incoming snapshots as full replacements, never
+        # diffs.  Re-applying the exact same snapshot must paint the
+        # exact same DOM — captured here by checking payload equality.
+        rec = _Recorder()
+        payload = _todo_payload([
+            {"id": "1", "content": "x", "status": "in_progress"},
+        ])
+        emit_todo_state(rec, name="todo", function_result=payload,
+            session_id="s", stream_id="r")
+        emit_todo_state(rec, name="todo", function_result=payload,
+            session_id="s", stream_id="r")
+        a, b = rec.todo_events()
+        for k in ("todos", "summary", "version", "session_id",
+                  "stream_id", "source"):
+            assert a[k] == b[k], f"field {k} drifted across identical emits"
+
+
+# ---------------------------------------------------------------------------
+# Scenario 2 — Cold reopen
+# ---------------------------------------------------------------------------
+
+
+class TestScenarioColdReopen:
+    """Browser opens a settled session — the panel must paint immediately."""
+
+    def test_session_with_todo_history_attaches_snapshot(self):
+        msgs = [
+            _user_msg("plan and execute"),
+            _assistant_msg("here's the plan"),
+            _tool_msg(_todo_payload([
+                {"id": "1", "content": "step 1", "status": "completed"},
+                {"id": "2", "content": "step 2", "status": "in_progress"},
+            ])),
+            _assistant_msg("working on step 2"),
+        ]
+        payload: Dict[str, Any] = {"session_id": "s", "messages": msgs}
+        ok = attach_todo_state(payload, msgs)
+        assert ok is True
+        snap = payload[PAYLOAD_KEY]
+        assert snap["version"] == VERSION
+        assert len(snap["todos"]) == 2
+        # Cold-load payload must NOT carry SSE-only fields.
+        for k in ("session_id", "stream_id", "source", "ts"):
+            assert k not in snap
+
+    def test_session_without_todo_attaches_nothing(self):
+        msgs = [
+            _user_msg("just a chat"),
+            _assistant_msg("hi"),
+            _tool_msg('{"result":"ok"}'),
+        ]
+        payload: Dict[str, Any] = {"session_id": "s"}
+        ok = attach_todo_state(payload, msgs)
+        assert ok is False
+        assert PAYLOAD_KEY not in payload
+
+    def test_attach_picks_latest_when_multiple_writes_exist(self):
+        # Same session, todo was rewritten 4 times across many turns.
+        # Cold-load must reflect the FINAL state, not any intermediate.
+        history: List[Dict[str, Any]] = []
+        for i in range(4):
+            history.append(_assistant_msg(f"turn {i}"))
+            history.append(_tool_msg(_todo_payload([
+                {"id": "1", "content": "x",
+                 "status": "in_progress" if i < 3 else "completed"},
+            ])))
+        payload: Dict[str, Any] = {}
+        attach_todo_state(payload, history)
+        assert payload[PAYLOAD_KEY]["todos"][0]["status"] == "completed"
+
+
+# ---------------------------------------------------------------------------
+# Scenario 3 — SSE replay safety
+# ---------------------------------------------------------------------------
+
+
+class TestScenarioSSEReplay:
+    """Frontend reconnects mid-turn; journal replays old events."""
+
+    def test_replayed_snapshot_matches_original_payload(self):
+        # The run journal stores SSE events verbatim. Replaying them
+        # through ``put`` (effectively re-running ``emit_todo_state``
+        # with the same args) must yield the same wire payload — minus
+        # the freshly-stamped ``ts``, which is intentionally re-clocked.
+        rec_live = _Recorder()
+        result_json = _todo_payload([
+            {"id": "1", "content": "x", "status": "in_progress"},
+        ])
+        emit_todo_state(rec_live, name="todo",
+            function_result=result_json,
+            session_id="s", stream_id="r")
+
+        rec_replay = _Recorder()
+        emit_todo_state(rec_replay, name="todo",
+            function_result=result_json,
+            session_id="s", stream_id="r")
+
+        live = rec_live.events[0][1]
+        replay = rec_replay.events[0][1]
+        # All snapshot fields are byte-identical.
+        for k in ("todos", "summary", "version",
+                  "session_id", "stream_id", "source"):
+            assert live[k] == replay[k]
+        # Both ts are valid wall-clock floats.
+        assert live["ts"] > 0 and replay["ts"] > 0
+
+
+# ---------------------------------------------------------------------------
+# Scenario 4 — Cross-session and stream addressing
+# ---------------------------------------------------------------------------
+
+
+class TestScenarioAddressing:
+    """Backend tags each event so the frontend can filter cross-session."""
+
+    def test_two_sessions_get_two_addresses(self):
+        rec = _Recorder()
+        emit_todo_state(rec, name="todo",
+            function_result=_todo_payload([
+                {"id": "1", "content": "a", "status": "pending"},
+            ]),
+            session_id="sess-A", stream_id="stream-A1")
+        emit_todo_state(rec, name="todo",
+            function_result=_todo_payload([
+                {"id": "1", "content": "b", "status": "pending"},
+            ]),
+            session_id="sess-B", stream_id="stream-B1")
+        evs = rec.todo_events()
+        assert evs[0]["session_id"] == "sess-A"
+        assert evs[1]["session_id"] == "sess-B"
+        assert evs[0]["stream_id"] != evs[1]["stream_id"]
+
+    def test_two_clients_on_same_stream_see_same_address(self):
+        # Two browser tabs both attach to the same active stream id.
+        # Each emission produces one event tagged with that stream;
+        # both clients dispatch off the same payload.
+        rec = _Recorder()
+        for _ in range(2):  # two emissions during one shared stream
+            emit_todo_state(rec, name="todo",
+                function_result=_todo_payload([
+                    {"id": "1", "content": "x", "status": "pending"},
+                ]),
+                session_id="s", stream_id="shared-stream")
+        evs = rec.todo_events()
+        assert all(ev["stream_id"] == "shared-stream" for ev in evs)
+        assert all(ev["session_id"] == "s" for ev in evs)
+
+
+# ---------------------------------------------------------------------------
+# Scenario 5 — Multimodal / vision-capable tool results
+# ---------------------------------------------------------------------------
+
+
+class TestScenarioMultimodal:
+    """Vision tools return list-shaped content; todo never does."""
+
+    def test_multimodal_tool_messages_dont_disturb_attach(self):
+        # A todo write sits between two image-bearing tool results. The
+        # multimodal entries are skipped (content is a list, not str)
+        # and the cold-load returns the todo snapshot intact.
+        msgs = [
+            _multimodal_tool_msg(),
+            _tool_msg(_todo_payload([
+                {"id": "1", "content": "review image", "status": "pending"},
+            ])),
+            _multimodal_tool_msg(),
+        ]
+        payload: Dict[str, Any] = {}
+        ok = attach_todo_state(payload, msgs)
+        assert ok is True
+        assert payload[PAYLOAD_KEY]["todos"][0]["content"] == "review image"
+
+    def test_multimodal_tool_after_todo_does_not_clobber(self):
+        # The most recent message is multimodal (image only). The prior
+        # todo write must still surface — otherwise opening a session
+        # whose last tool was an image read would erase the panel.
+        msgs = [
+            _tool_msg(_todo_payload([
+                {"id": "1", "content": "earlier", "status": "in_progress"},
+            ])),
+            _multimodal_tool_msg(),
+        ]
+        payload: Dict[str, Any] = {}
+        attach_todo_state(payload, msgs)
+        assert payload[PAYLOAD_KEY]["todos"][0]["status"] == "in_progress"
+
+    def test_emit_skips_image_bearing_tool(self):
+        # If a tool callback ever fires with name="todo" but a
+        # multimodal result (which would be a bug elsewhere), the emit
+        # helper falls through cleanly — list isn't a JSON string, isn't
+        # a dict with a todos list, so parse returns None.
+        rec = _Recorder()
+        result = emit_todo_state(rec, name="todo",
+            function_result=[{"type": "text", "text": "nope"}],
+            session_id="s", stream_id="r")
+        assert result is False
+        assert rec.todo_events() == []
+
+
+# ---------------------------------------------------------------------------
+# Scenario 6 — CLI session fallback
+# ---------------------------------------------------------------------------
+
+
+class TestScenarioCLISession:
+    """A CLI-only session has no WebUI sidecar — routes.py uses a
+    different code path. The cold-load helper must work identically."""
+
+    def test_cli_session_messages_attach_correctly(self):
+        # Mirrors the shape ``get_cli_session_messages`` returns: a flat
+        # list of dicts with role/content/timestamp.
+        msgs = [
+            {"role": "user", "content": "hello", "timestamp": 1.0},
+            {"role": "assistant", "content": "hi", "timestamp": 2.0},
+            {"role": "tool", "content": _todo_payload([
+                {"id": "cli-1", "content": "do it", "status": "pending"},
+            ]), "timestamp": 3.0},
+        ]
+        sess: Dict[str, Any] = {
+            "session_id": "cli-sid",
+            "is_cli_session": True,
+            "messages": msgs,
+        }
+        ok = attach_todo_state(sess, msgs)
+        assert ok is True
+        assert sess[PAYLOAD_KEY]["todos"][0]["id"] == "cli-1"
+        # Other CLI-session fields must survive.
+        assert sess["is_cli_session"] is True
+        assert sess["session_id"] == "cli-sid"
+
+    def test_cli_session_without_todo_unchanged(self):
+        msgs = [
+            {"role": "user", "content": "hi", "timestamp": 1.0},
+            {"role": "assistant", "content": "hello", "timestamp": 2.0},
+        ]
+        sess: Dict[str, Any] = {"session_id": "cli", "messages": msgs}
+        ok = attach_todo_state(sess, msgs)
+        assert ok is False
+        assert PAYLOAD_KEY not in sess
+
+
+# ---------------------------------------------------------------------------
+# Scenario 7 — Round-trip: emit → store as message → attach
+# ---------------------------------------------------------------------------
+
+
+class TestScenarioEmitAttachRoundTrip:
+    """The same underlying tool-result string drives both paths.
+
+    When the agent emits live, it later writes the same JSON string
+    into ``messages[]`` as the tool result of that turn. Cold-load
+    must therefore return a snapshot with the same todos/summary as
+    the live event — same ``version`` and identical contents minus
+    SSE-only addressing fields.
+    """
+
+    def test_live_emit_and_cold_load_agree_on_snapshot_body(self):
+        result_json = _todo_payload([
+            {"id": "1", "content": "design", "status": "completed"},
+            {"id": "2", "content": "implement", "status": "in_progress"},
+            {"id": "3", "content": "test", "status": "pending"},
+        ])
+
+        # Live SSE emission
+        rec = _Recorder()
+        emit_todo_state(rec, name="todo", function_result=result_json,
+            session_id="s", stream_id="r")
+        live = rec.todo_events()[0]
+
+        # Cold-load from the same JSON tucked into messages[]
+        payload: Dict[str, Any] = {}
+        attach_todo_state(payload, [_tool_msg(result_json)])
+        cold = payload[PAYLOAD_KEY]
+
+        # Body must agree exactly.
+        assert live["todos"] == cold["todos"]
+        assert live["summary"] == cold["summary"]
+        assert live["version"] == cold["version"]
+
+        # Cold-load is leaner — no SSE addressing.
+        assert set(cold.keys()) == {"todos", "summary", "version"}
+        assert {"session_id", "stream_id", "source", "ts"}.issubset(
+            set(live.keys())
+        )
+
+    def test_session_with_only_emits_then_replay_yields_same_state(self):
+        # Simulate: agent emits N times. Each emission's full snapshot
+        # gets stored as a tool message in conversation history. After
+        # the turn ends, the user reloads the session — cold-load must
+        # surface the exact final emit's snapshot.
+        history: List[Dict[str, Any]] = [_user_msg("plan")]
+        rec = _Recorder()
+        for status in ("pending", "in_progress", "completed"):
+            jp = _todo_payload([
+                {"id": "1", "content": "x", "status": status},
+            ])
+            emit_todo_state(rec, name="todo", function_result=jp,
+                session_id="s", stream_id="r")
+            history.append(_tool_msg(jp))
+
+        cold_payload: Dict[str, Any] = {}
+        attach_todo_state(cold_payload, history)
+        last_live = rec.todo_events()[-1]
+
+        # Last live emit and final cold-load agree on the last status.
+        assert last_live["todos"][0]["status"] == "completed"
+        assert cold_payload[PAYLOAD_KEY]["todos"][0]["status"] == "completed"
+
+
+# ---------------------------------------------------------------------------
+# Scenario 8 — Failure isolation
+# ---------------------------------------------------------------------------
+
+
+class TestScenarioFailureIsolation:
+    """A bad payload must never break the SSE stream or session GET."""
+
+    def test_emit_does_not_raise_on_garbage_result(self):
+        rec = _Recorder()
+        for bad in (None, b"\x00\x01", object(), [{"role": "tool"}]):
+            try:
+                emit_todo_state(rec, name="todo", function_result=bad,
+                    session_id="s", stream_id="r")
+            except Exception as exc:  # pragma: no cover — defensive
+                raise AssertionError(
+                    f"emit_todo_state raised on {bad!r}: {exc}"
+                )
+        # No event should have leaked through; all silently dropped.
+        assert rec.todo_events() == []
+
+    def test_emit_swallows_put_callback_exceptions(self):
+        seen: List[bool] = []
+
+        def angry_put(_event, _data):
+            seen.append(True)
+            raise ValueError("queue is dead")
+
+        ok = emit_todo_state(angry_put, name="todo",
+            function_result=_todo_payload([
+                {"id": "1", "content": "x", "status": "pending"},
+            ]),
+            session_id="s", stream_id="r")
+        assert ok is False
+        # ``put`` was attempted exactly once; the helper did not retry,
+        # so a broken queue can't snowball into N failed retries.
+        assert seen == [True]
+
+    def test_attach_does_not_raise_on_corrupt_message_in_history(self):
+        # A single corrupt entry must not poison the whole derive.
+        msgs: List[Any] = [
+            _tool_msg(_todo_payload([
+                {"id": "1", "content": "valid", "status": "pending"},
+            ])),
+            123,  # bogus
+            {"role": "tool", "content": object()},  # not str/list
+        ]
+        payload: Dict[str, Any] = {}
+        ok = attach_todo_state(payload, msgs)
+        assert ok is True
+        assert payload[PAYLOAD_KEY]["todos"][0]["content"] == "valid"
+
+
+# ---------------------------------------------------------------------------
+# Scenario 9 — Long histories
+# ---------------------------------------------------------------------------
+
+
+class TestScenarioLongHistories:
+    """Cold-load must stay fast and correct on multi-thousand-msg sessions."""
+
+    def test_recent_todo_in_long_history(self):
+        # Realistic: a session has 10k messages; a todo write happens
+        # in the last 50.  Reverse iteration short-circuits.
+        msgs: List[Dict[str, Any]] = []
+        for i in range(9_950):
+            msgs.append(_assistant_msg(f"turn {i}"))
+        msgs.append(_tool_msg(_todo_payload([
+            {"id": "late", "content": "ship", "status": "in_progress"},
+        ])))
+        for i in range(49):
+            msgs.append(_assistant_msg(f"after {i}"))
+
+        payload: Dict[str, Any] = {}
+        t0 = time.time()
+        ok = attach_todo_state(payload, msgs)
+        t1 = time.time()
+        assert ok is True
+        assert payload[PAYLOAD_KEY]["todos"][0]["id"] == "late"
+        # Soft perf canary: typical run is sub-millisecond. 200 ms is a
+        # generous ceiling for slow CI; if we ever exceed this, the
+        # algorithm has regressed (e.g. someone removed the substring
+        # fast-path or accidentally introduced N² behavior).
+        assert (t1 - t0) < 0.2, f"derive_todo_state took {t1-t0:.3f}s"
+
+    def test_no_todo_in_long_history_returns_false_quickly(self):
+        msgs: List[Dict[str, Any]] = []
+        for i in range(5_000):
+            msgs.append(_assistant_msg(f"t{i}"))
+            msgs.append(_tool_msg('{"output":"ok"}'))
+        payload: Dict[str, Any] = {}
+        t0 = time.time()
+        ok = attach_todo_state(payload, msgs)
+        t1 = time.time()
+        assert ok is False
+        # 5k tool messages, all bypass the JSON parse via the substring
+        # gate. Should still be cheap.
+        assert (t1 - t0) < 0.5, f"derive_todo_state took {t1-t0:.3f}s"
+
+
+# ---------------------------------------------------------------------------
+# Scenario 10 — Frontend wire-format pin
+# ---------------------------------------------------------------------------
+
+
+class TestScenarioWireFormatPin:
+    """Pin every key the frontend reads.
+
+    Hardcoded against ``static/messages.js`` (live SSE listener) and
+    ``static/ui.js`` (cold-load hydrate). If either side changes, this
+    test must change too — by design.
+    """
+
+    LIVE_KEYS = {
+        # Identity / addressing.
+        "session_id", "stream_id", "source",
+        # Ordering.
+        "ts",
+        # Snapshot.
+        "todos", "summary", "version",
+    }
+
+    COLD_KEYS = {"todos", "summary", "version"}
+
+    def test_live_event_carries_every_frontend_field(self):
+        rec = _Recorder()
+        emit_todo_state(rec, name="todo",
+            function_result=_todo_payload([
+                {"id": "1", "content": "x", "status": "pending"},
+            ]),
+            session_id="s", stream_id="r")
+        ev_data = rec.events[0][1]
+        assert self.LIVE_KEYS.issubset(set(ev_data.keys())), (
+            f"missing live wire keys: {self.LIVE_KEYS - set(ev_data.keys())}"
+        )
+
+    def test_cold_payload_carries_only_snapshot_fields(self):
+        payload: Dict[str, Any] = {}
+        attach_todo_state(payload, [_tool_msg(_todo_payload([
+            {"id": "1", "content": "x", "status": "pending"},
+        ]))])
+        cold = payload[PAYLOAD_KEY]
+        assert set(cold.keys()) == self.COLD_KEYS
+
+    def test_event_name_matches_frontend_listener(self):
+        # ``static/messages.js``: source.addEventListener('todo_state', ...)
+        assert EVENT_NAME == "todo_state"
+
+    def test_payload_key_matches_frontend_cold_load(self):
+        # ``static/ui.js``: const cold = session && session.todo_state
+        assert PAYLOAD_KEY == "todo_state"
+
+    def test_todo_item_shape_matches_frontend_renderer(self):
+        # ``static/panels.js`` renders id / content / status. Pin those
+        # so a backend rename (e.g. ``status`` → ``state``) breaks here
+        # and not in production.
+        rec = _Recorder()
+        emit_todo_state(rec, name="todo",
+            function_result=_todo_payload([
+                {"id": "1", "content": "x", "status": "in_progress"},
+            ]),
+            session_id="s", stream_id="r")
+        item = rec.events[0][1]["todos"][0]
+        assert "id" in item
+        assert "content" in item
+        assert "status" in item
+        assert item["status"] in {
+            "pending", "in_progress", "completed", "cancelled",
+        }
+
+
+# ---------------------------------------------------------------------------
+# Scenario 11 — Mid-stream state evolution + final hydrate
+# ---------------------------------------------------------------------------
+
+
+class TestScenarioFullTurnLifecycle:
+    """Simulate one full agent turn end-to-end:
+    user → 3 emits during streaming → turn settles → reload → cold-load.
+    """
+
+    def test_full_turn_lifecycle(self):
+        rec = _Recorder()
+        history: List[Dict[str, Any]] = [_user_msg("design and ship")]
+
+        emit_payloads = []
+        for plan in [
+            [
+                {"id": "d", "content": "design",   "status": "in_progress"},
+                {"id": "i", "content": "impl",     "status": "pending"},
+                {"id": "t", "content": "test",     "status": "pending"},
+            ],
+            [
+                {"id": "d", "content": "design",   "status": "completed"},
+                {"id": "i", "content": "impl",     "status": "in_progress"},
+                {"id": "t", "content": "test",     "status": "pending"},
+            ],
+            [
+                {"id": "d", "content": "design",   "status": "completed"},
+                {"id": "i", "content": "impl",     "status": "completed"},
+                {"id": "t", "content": "test",     "status": "completed"},
+            ],
+        ]:
+            jp = _todo_payload(plan)
+            emit_payloads.append(jp)
+            emit_todo_state(rec, name="todo", function_result=jp,
+                session_id="s", stream_id="r")
+            history.append(_tool_msg(jp))
+
+        # Final assistant message.
+        history.append(_assistant_msg("shipped"))
+
+        # During the live turn, the panel saw 3 distinct snapshots in order.
+        evs = rec.todo_events()
+        assert len(evs) == 3
+        statuses = [
+            tuple(t["status"] for t in ev["todos"])
+            for ev in evs
+        ]
+        assert statuses[0][0] == "in_progress"
+        assert statuses[2] == ("completed", "completed", "completed")
+
+        # Cold-load reflects ONLY the latest write — exactly the final
+        # emit's snapshot body.
+        payload: Dict[str, Any] = {}
+        attach_todo_state(payload, history)
+        cold = payload[PAYLOAD_KEY]
+        assert cold["todos"] == evs[-1]["todos"]
+        assert cold["summary"] == evs[-1]["summary"]
+        assert cold["version"] == VERSION
+
+
+# ---------------------------------------------------------------------------
+# Scenario 12 — Determinism
+# ---------------------------------------------------------------------------
+
+
+class TestScenarioDeterminism:
+    """Same input → same output (modulo the freshly-stamped ``ts``)."""
+
+    def test_emit_is_deterministic_modulo_ts(self):
+        result_json = _todo_payload([
+            {"id": "1", "content": "x", "status": "pending"},
+        ])
+        a = _Recorder()
+        b = _Recorder()
+        emit_todo_state(a, name="todo", function_result=result_json,
+            session_id="s", stream_id="r")
+        emit_todo_state(b, name="todo", function_result=result_json,
+            session_id="s", stream_id="r")
+        ev_a = {k: v for k, v in a.events[0][1].items() if k != "ts"}
+        ev_b = {k: v for k, v in b.events[0][1].items() if k != "ts"}
+        assert ev_a == ev_b
+
+    def test_attach_is_fully_deterministic(self):
+        msgs = [_tool_msg(_todo_payload([
+            {"id": "1", "content": "x", "status": "in_progress"},
+        ]))]
+        a: Dict[str, Any] = {}
+        b: Dict[str, Any] = {}
+        attach_todo_state(a, msgs)
+        attach_todo_state(b, msgs)
+        # No ``ts`` on cold-load — full byte equality.
+        assert a == b


### PR DESCRIPTION
## 1. Problem

The Todos panel only repainted once per turn, after the agent settled and the `tool` message hit `state.db`. `loadTodos()` then reverse-scanned `S.messages` to find the latest todo write. Three user-visible consequences:

- **Not realtime.** A `todo` tool call mid-turn was invisible until the turn finished. The user saw a frozen list while the agent was actively crossing items off.
- **State lost on reload / reconnect.** Refreshing during a running stream wiped the panel until the next `todo` write happened. Stream errors / reconnects had the same effect.
- **Occasional cross-session pollution.** A late SSE event tagged for session A could land after the user had already navigated to session B and overwrite `S.todos`.

## 2. What changed

```
ecd8a247 feat(todo-state): frontend live updates + INFLIGHT recovery (Phase 2)
c347a11f feat(todo-state): server-side realtime todo state (Phase 1)
```

Based on master `5528e2c5`. Two commits, 17 files, +5,504 / −20 lines.
- Production code: 7 files / +573 / −20.
- Tests: 10 files / +4,931 (8 new files).

### Phase 1 — server-side realtime pipeline (`c347a11f`)

| File | Change |
|---|---|
| `api/todo_state.py` (new, 235 lines) | Single source of truth for the wire protocol: `derive_todo_state` / `emit_todo_state` / `attach_todo_state` / `parse_todo_tool_result` / `_normalize_snapshot`. Constants `EVENT_NAME` / `PAYLOAD_KEY` / `VERSION` live here. Every error boundary swallows-and-degrades — never breaks tool delivery or session GET. |
| `api/streaming.py` (+36) | Both the legacy `tool_progress_callback` (`event_type='tool.completed'`) path and the modern structured `on_tool_complete` path emit `todo_state` SSE events. Full snapshot, idempotent under run-journal replay. |
| `api/routes.py` (+21) | The session GET handler calls `attach_todo_state` on both the WebUI session branch and the CLI fallback so opening any session from the sidebar hydrates the Todos panel immediately. |

### Phase 2 — frontend live consumption + INFLIGHT recovery (`ecd8a247`)

| File | Change |
|---|---|
| `static/ui.js` (+133/−4) | `S.todos` + `S.todoStateMeta` as the single source of truth. `null` is a sentinel that means *"no signal seen — fall through to legacy reverse-scan"*, distinct from *"signal seen, list is empty"*. `_compactInflightState` persists todos into the `localStorage` snapshot. `_todosHash` + `_todosLastRenderedHash` short-circuit identical re-renders. `scheduleTodosRefresh` coalesces bursty events through `requestAnimationFrame`. `_hydrateTodosFromSession` reconciles cold-load vs. INFLIGHT at every `S.session=` settle point. |
| `static/messages.js` (+43/−3) | `todo_state` SSE listener: swallow `JSON.parse` errors, validate `Array.isArray(d.todos)`, drop on `session_id !== activeSid`, drop on `S.session.session_id !== activeSid` (double check — late events arriving after navigation), drop on `incomingTs < currentTs`, full-snapshot replace (never merge). `'todo_state'` added to the run-journal cursor whitelist so `Last-Event-ID` advances past it on reconnect. |
| `static/sessions.js` (+18) | INFLIGHT restore on tab return / hard reload carries `todos` and `todoStateMeta` alongside the existing fields. Session-deletion paths call `_hydrateTodosFromSession(null)` so the panel clears synchronously. |
| `static/panels.js` (+84/−13) | `loadTodos()` trusts `S.todos` whenever `S.todoStateMeta` is set; otherwise falls through to `_legacyTodosFromMessages()` (reverse-scan over tool messages). Every user-controlled string goes through `esc()` before `innerHTML`. |

### Data flow

```
agent.todo()
   │
   ▼
streaming.py  ──emit_todo_state──▶  SSE: 'todo_state' (full snapshot)
   │                                          │
   ▼                                          ▼
state.db (tool message)              messages.js listener
   │                                          │
   ▼                                          ▼
routes.py session GET                S.todos / S.todoStateMeta
   │   ──attach_todo_state──▶ payload.todo_state    │
   ▼                                                 │
ui.js  _hydrateTodosFromSession  ◀── reconcile ─────┤
   │       (cold-load vs INFLIGHT, by ts)            │
   ▼                                                 │
panels.js loadTodos ──▶ DOM         localStorage ◀───┘
```

## 3. Performance

### Render cost

- **Hash short-circuit.** `_todosHash` builds an `(id, content, status)` fingerprint via string concatenation (no intermediate object allocation in V8). Identical snapshots return early without touching the DOM.
- **RAF coalescing.** `scheduleTodosRefresh` collapses any number of `todo_state` events landing in the same animation frame into one `loadTodos()` call. The e2e suite asserts that 100 emits share a single RAF tick.
- **Inactive-panel skip.** `_todosPanelIsActive()` short-circuits the entire path when the Todos panel is hidden — background events do zero DOM work.
- **Linear-scaling regression guard.** Instead of a fragile absolute timeout, the test compares 50-item vs. 200-item render time and asserts the ratio stays `< 8`. An O(n²) regression would push the ratio toward 16.

### Persistence budget (`INFLIGHT_STATE_DEFAULT_LIMITS`)

```
maxSessions: 8
messages:    24
toolCalls:   48
stringChars: 60,000   per string field
jsonChars:   1,500,000 per full snapshot
```

LRU by `updated_at` when the cap is hit. Quota errors trigger graceful degradation: drop everything except the active session, and if that still fails, clear the whole bucket. INFLIGHT entries older than 10 minutes are evicted on read.

### Network footprint

Each `todo_state` event is the same JSON the `todo` tool already returns in its tool message, plus five metadata fields (`session_id`, `stream_id`, `source`, `ts`, `version`). It's a single per-event mirror — no diffs, no polling.

## 4. Reliability & stability

### Error isolation boundaries

| Boundary | Behavior |
|---|---|
| `parse_todo_tool_result` gets non-string / non-JSON / wrong shape | Returns `None`; emit and attach skip. |
| `emit_todo_state` raises in `put` | Swallowed, debug-logged, returns `False`. Tool delivery is unaffected. |
| `attach_todo_state` errors during message iteration (broken generators, corrupted store) | Swallowed, returns `False`. Session GET responds normally without the `todo_state` field. |
| Frontend `JSON.parse` failure | Listener returns; `S.todos` is unchanged. |
| `localStorage` corrupted | `_readInflightStateMap` returns `{}`; the next save rebuilds. |
| `localStorage` quota exceeded | Falls back to active-session-only; if still over, clears the bucket. |
| INFLIGHT entry stale (>10 min) | `loadInflightState` evicts and returns `null`. |
| Stream reconnects with a different `streamId` | `loadInflightState` returns `null` — a new run cannot inherit a stale snapshot from the previous one. |

### Ordering & merge invariants

- **Full-snapshot protocol.** Every emission carries the entire list, so SSE replay is idempotent — no merge, no diff reconciliation.
- **Strict-older-ts drop, equal-ts allowed.** A compression-source refresh can legitimately land on the same wall-clock second as the tool emission it follows.
- **Cross-session double gate.** Both `payload.session_id !== activeSid` and `S.session.session_id !== activeSid` drop the event. The latter prevents pollution when the SSE stream is still wired to the previous session but the user has already navigated away.
- **Recency-aware hydrate.** When both cold-load (server settled view) and INFLIGHT (locally persisted snapshot) are present, `_hydrateTodosFromSession` picks the one with the newer `ts`. This stops a stale cached cold-load from regressing fresher INFLIGHT state on reload of a still-running session.

### Compatibility

- `S.todoStateMeta = null` is a sentinel; pre-Phase-1 backends produce no `todo_state` events, so `loadTodos()` falls through to `_legacyTodosFromMessages()` and the panel still works.
- `version: 1` reserves room for future wire-format evolution.
- The run-journal whitelist entry means a reconnect's `Last-Event-ID` advances past prior `todo_state` events. Replay remains correct (idempotent) but doesn't re-trigger renders.

### Test coverage

| Category | File | Purpose |
|---|---|---|
| Protocol unit | `test_todo_state.py` (365) / `test_todo_state_emission.py` (407) / `test_todo_state_robustness.py` (283) | parse / derive / emit / attach contracts; malformed items, non-dict summary, concurrent-emit thread safety, ts propagation |
| Real scenarios | `test_todo_state_scenarios.py` (741) | Multi-write history, last-write-truncated fallback, large-history performance sentinel |
| Wiring (AST) | `test_streaming_todo_state.py` (158) / `test_session_todo_state_route.py` (130) | AST call-shape checks: pin call sites' kwargs and positional shape, not source strings |
| Frontend wiring | `test_phase2_frontend_static.py` (505) | Balanced-brace function-body extraction + AST-style regex; tolerates whitespace and harmless reformatting |
| Frontend behavior | `test_phase2_todo_behavior.py` (831) | Node driver loads real JS function bodies and runs unit-level assertions against them |
| Frontend scenarios | `test_phase2_e2e_scenarios.py` (1082) | Lifecycle / multi-session / event-robustness / render-scheduling end-to-end through the real JS |
| Persistence round-trip | `test_phase2_inflight_persistence.py` (449) | Real in-memory `localStorage` shim drives `saveInflightState` ⇄ `loadInflightState` round-trips, hard-reload recovery, cross-session isolation, journal-replay regression |

**280 tests pass in ~4s.**

## 5. Out of scope

- No upstream Hermes Agent protocol change; `todo` tool semantics unchanged.
- No SSE infrastructure change; one new event name plus one journal-whitelist entry.
- No persistence-layer change (still `localStorage`, not IndexedDB); current budgets are far above what todo lists need.

---

### Review follow-ups already absorbed in these two commits

- P1: `messages.js` cross-session double check; `ui.js` ts-aware reconciliation in `_hydrateTodosFromSession`; `api/todo_state.derive_todo_state` propagates the source message timestamp so cold-load and INFLIGHT can be compared on the same axis.
- P2: replaced grep-only structural tests with AST call-shape checks; added malformed-item / concurrent-emit / extra malformed-payload coverage; reduced brittleness in static-shape assertions; replaced flake-prone absolute timing with linear-scaling ratio; added the real-`localStorage` round-trip + reconnect test file.
